### PR TITLE
Error codes and messages

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2233,20 +2233,16 @@ var Library = {
     11: 'Resource temporarily unavailable',
     18: 'Invalid cross-device link'
   },
-  errno: 0,
-  __setErrNo__deps: ['errno'],
   __setErrNo: function(value) {
-    // NOTE: This still doesn't fix the case where errno is updated from user
-    // code, but it works for errno being set from our library.
+    // For convenient setting and returning of errno.
     var me = ___setErrNo;
     if (!me.ptr) me.ptr = Pointer_make([0], 0, ALLOC_STATIC, 'i32');
     {{{ makeSetValue('me.ptr', '0', 'value', 'i32') }}}
-    _errno = value;
-    return value;  // For convenient setting and returning of errno.
+    return value;
   },
   __errno_location__deps: ['__setErrNo'],
-  __errno_location: function() { 
-    if (___setErrNo.ptr === undefined) ___setErrNo(0);
+  __errno_location: function() {
+    if (!___setErrNo.ptr) ___setErrNo(0);
     return ___setErrNo.ptr;
   },
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -693,6 +693,8 @@ if 'benchmark' not in sys.argv:
             printf("<%s>\n", buffer);
 
             printf("<%d>\n", strerror_r(EWOULDBLOCK, buffer, 0));
+            errno = 123;
+            printf("<%d>\n", errno);
 
             return 0;
           }
@@ -701,6 +703,7 @@ if 'benchmark' not in sys.argv:
           <Numerical argument out of domain>
           <Resource temporarily unavailable>
           <34>
+          <123>
           '''
         self.do_test(src, re.sub('(^|\n)\s+', '\\1', expected))
 


### PR DESCRIPTION
This pull adds glibc-compatible error code and message constants and implements `strerror()`. All llvm-gcc tests except poppler pass and the new `test_error` also passes under clang.
