### PR TITLE
std::endl was missing. We just need to comment extern to make std::cout w

### DIFF
--- a/system/include/libcxx/ostream
+++ b/system/include/libcxx/ostream
@@ -204,7 +204,6 @@ protected:
     basic_ostream() {}  // extension, intentially does not initialize
 };
 
-/*
 template <class _CharT, class _Traits>
 class _LIBCPP_VISIBLE basic_ostream<_CharT, _Traits>::sentry
 {
@@ -1286,9 +1285,8 @@ operator<<(basic_ostream<_CharT, _Traits>& __os, const bitset<_Size>& __x)
                          use_facet<ctype<_CharT> >(__os.getloc()).widen('1'));
 }
 
-extern template class basic_ostream<char>;
-extern template class basic_ostream<wchar_t>;
-*/
+//extern template class basic_ostream<char>; /* XXX EMScripten */
+//extern template class basic_ostream<wchar_t>; /* XXX EMScripten */
 
 _LIBCPP_END_NAMESPACE_STD
 


### PR DESCRIPTION
std::endl was missing. We just need to comment extern to make std::cout works
