### PR TITLE
When I64_MODE==1, split each global constant int64 at compile time.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -8,3 +8,4 @@ under the licensing terms detailed in LICENSE.
 * Jeff Terrace <jterrace@gmail.com>
 * Benoit Tremblay <benoit.tremblay@frimastudio.com>
 * Andreas Bergmeier <andreas.bergmeier@gmx.net>
+* Ben Schwartz <bens@alum.mit.edu>

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -147,11 +147,11 @@ function JSify(data, functionsOnly, givenFunctions, givenGlobalVariables) {
       var currValue = flatten(values[i]);
       if (I64_MODE == 1 && typeData.fields[i] == 'i64') {
         // 'flatten' out the 64-bit value into two 32-bit halves
-        ret[index++] = currValue + '>>>0';
+        ret[index++] = currValue>>>0;
         ret[index++] = 0;
         ret[index++] = 0;
         ret[index++] = 0;
-        ret[index++] = 'Math.floor(' + currValue + '/4294967296)';
+        ret[index++] = Math.floor(currValue/4294967296);
         ret[index++] = 0;
         ret[index++] = 0;
         ret[index++] = 0;


### PR DESCRIPTION
This change allows the generated code to be processed by the
closure compiler.  Without this change, commit
81f82a6a0dd932344027a408ff7bf905de1d2e52
prevents the closure compiler from running
(see http://code.google.com/closure/compiler/docs/error-ref.html#error).

This change should also slightly improve startup speed and reduce code
size.

(I expect there's a good reason you didn't do it this way in the first place, but I don't know what the reason is.)
