### PR TITLE
don't die on "closure does not exist", since naive `make` can trigger it

### DIFF
--- a/emcc
+++ b/emcc
@@ -286,10 +286,11 @@ try:
   newargs = [ arg for arg in newargs if arg is not '' ]
 
   if llvm_opt_level is None: llvm_opt_level = 1 if opt_level >= 1 else 0
-  if closure is None: closure = 1 if opt_level >= 2 else 0
 
-  if closure:
-    assert os.path.exists(shared.CLOSURE_COMPILER), 'emcc: fatal: Closure compiler (%s) does not exist' % shared.CLOSURE_COMPILER
+  if closure is None: closure = 1 if opt_level >= 2 else 0
+  if closure and not os.path.exists(shared.CLOSURE_COMPILER):
+    print >> sys.stderr, 'emcc: warning: not running Closure compiler, it does not exist at %s' % shared.CLOSURE_COMPILER
+    closure = 0
 
   settings_changes = []
   for i in range(len(newargs)):


### PR DESCRIPTION
Hey there,

As I reported in "should emconfigure adjust CXXFLAGS?" in the Google group, a naive `emconfigure ./configure` can fail because it leaves CXXFLAGS unchanged and if the project default includes -O2, any compile will fail until you set up Closure.  (emscripten's tools/shared.py currently overrides project's CFLAGS so this assert doesn't affect projects using CFLAGS.)

This simple change turns the assert into warn and disable closure.

(n00b alert! This is my first attempt to use this github machinery, thanks in advance for your patience.)
