### PR TITLE
malloc and mmap fixes

### DIFF
--- a/src/dlmalloc.c
+++ b/src/dlmalloc.c
@@ -588,7 +588,10 @@ MAX_RELEASE_CHECK_RATE   default: 4095 unless not HAVE_MMAP
 #define INSECURE 0
 #endif  /* INSECURE */
 #ifndef HAVE_MMAP
-#define HAVE_MMAP 1
+/* XXX Emscripten
+ * mmap uses malloc, so malloc can't use mmap
+ */
+#define HAVE_MMAP 0
 #endif  /* HAVE_MMAP */
 #ifndef MMAP_CLEARS
 #define MMAP_CLEARS 1


### PR DESCRIPTION
- Update stub malloc to byte-align by 8. Even though it leaks memory, it shouldn't be an issue because it gets replaced by dlmalloc when using optimizations
- Change dlmalloc not to use mmap by setting HAVE_MMAP to 0
- Update mmap to use work when fstream is -1 (MAP_ANONYMOUS). mmap is implemented using malloc, which is not how it normally is done, but it seems to be the best choice in this case

Tested these:
- test_dlmalloc
- test_memorygrowth
- test_mallocstruct
