### PR TITLE
Fix locale tests for special character

### DIFF
--- a/system/include/libcxx/__locale
+++ b/system/include/libcxx/__locale
@@ -471,7 +471,20 @@ public:
     _LIBCPP_ALWAYS_INLINE
     bool is(mask __m, char_type __c) const
     {
-        return isascii(__c) ? __tab_[__c] & __m : false;
+        // XXX EMSCRIPTEN __tab is always null 
+        if( !isascii(__c) ) return false;
+        if (__m & space && !isspace(__c)) return false;
+        if (__m & print && !isprint(__c)) return false;
+        if (__m & cntrl && !iscntrl(__c)) return false;
+        if (__m & upper && !isupper(__c)) return false;
+        if (__m & lower && !islower(__c)) return false;
+        if (__m & alpha && !isalpha(__c)) return false;
+        if (__m & digit && !isdigit(__c)) return false;
+        if (__m & punct && !ispunct(__c)) return false;
+        if (__m & xdigit && !isxdigit(__c)) return false;
+        if (__m & blank && !isblank(__c)) return false;
+        return true;
+        //return isascii(__c) ? __tab_[__c] & __m : false;
     }
 
     _LIBCPP_ALWAYS_INLINE

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -3739,6 +3739,27 @@ def process(filename):
       '''
       self.do_run(src, "some string constant")
 
+    def test_istream(self):
+      if self.emcc_args is None: return self.skip('requires libcxx')
+
+      src = '''
+        #include <string>
+        #include <sstream>
+        #include <iostream>
+        
+        int main()
+        {
+            std::string mystring("1 2 3");
+            std::istringstream is(mystring);
+            int one, two, three;
+            
+            is >> one >> two >> three;
+            
+            printf( " %i %i %i", one, two, three );
+        }
+      '''
+      self.do_run(src, "1 2 3")
+
     def test_fs_base(self):
       Settings.INCLUDE_FULL_LIBRARY = 1
       try:


### PR DESCRIPTION
This commit solves #202. istream uses locale to skip whitespace characters.

Emscripten has no implementation for locale in libc and use javascript stub. This patch uses those versions s well in libcxx.
