### PR TITLE
Always pick the JS implementation of uncaught_exception

### DIFF
--- a/system/lib/libcxx/exception.cpp
+++ b/system/lib/libcxx/exception.cpp
@@ -86,6 +86,7 @@ std::terminate() _NOEXCEPT
 }
 #endif // LIBCXXRT
 
+#ifndef EMSCRIPTEN // This is implemented in Javascript for Emscripten
 bool std::uncaught_exception() _NOEXCEPT
 {
 #if __APPLE__
@@ -99,6 +100,7 @@ bool std::uncaught_exception() _NOEXCEPT
     ::abort();
 #endif  // __APPLE__
 }
+#endif  // EMSCRIPTEN
 
 namespace std
 {

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1428,6 +1428,18 @@ if 'benchmark' not in str(sys.argv) and 'sanity' not in str(sys.argv):
         '''
         self.do_run(src, 'exception? no\nexception? yes\nexception? no\nexception? no\n')
 
+        src = r'''
+          #include <fstream>
+          #include <iostream>
+          int main() {
+            std::ofstream os("test");
+            os << std::unitbuf << "foo"; // trigger a call to std::uncaught_exception from
+                                         // std::basic_ostream::sentry::~sentry
+            std::cout << "success";
+          }
+        '''
+        self.do_run(src, 'success')
+
     def test_typed_exceptions(self):
         return self.skip('TODO: fix this for llvm 3.0')
 


### PR DESCRIPTION
This test case triggers a call to uncaught_exception from the operator<<, which would abort if the libcxx version of the function is picked up.
