### PR TITLE
Added IE7 fix script

### DIFF
--- a/tools/ie7_fix.py
+++ b/tools/ie7_fix.py
@@ -9,6 +9,6 @@ outputFilename = sys.argv[2];
 inputFiledata = open(inputFilename).read()
 outputFile = open(outputFilename, "w")
 
-outputFile.write(re.sub('type\[type.length - 1\] == "\*"', 'type.charAt(type.length - 1) == "*"', inputFiledata))
+outputFile.write(re.sub('type\[type.length - 1\] ===? "\*"', 'type.charAt(type.length - 1) == "*"', inputFiledata))
 
 outputFile.close()


### PR DESCRIPTION
Here is the script to replace `type[type.length - 1] == "*"` with `type.charAt(type.length - 1)`.

Purpose is for IE7 compatibility. When code is compiled with USE_TYPED_ARRAYS = 0 this is required.

`python tools/ie7_fix.py input output`
