### PR TITLE
Prevent SDL events from having their default behavior

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -271,7 +271,11 @@ mergeInto(LibraryManager.library, {
       switch(event.type) {
         case 'keydown': case 'keyup': case 'mousedown': case 'mouseup': case 'mousemove':
           SDL.events.push(event);
-          event.preventDefault();
+          if ((event.keyCode >= 37 && event.keyCode <= 40) || // arrow keys
+              event.keyCode == 32 || // space
+              event.keyCode == 33 || event.keyCode == 34) { // page up/down
+            event.preventDefault();
+          }
           break;
       }
       //event.preventDefault();


### PR DESCRIPTION
This prevents doing things like scrolling the page down when receiving an
SDL event.
