### PR TITLE
One more linker stub fix for Windows.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -499,7 +499,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)''' % { 'winfix': '' if not WINDOWS e
   @staticmethod
   def link(files, target):
     try_delete(target)
-    stub = os.path.join(EMSCRIPTEN_TEMP_DIR, 'stub_deleteme')
+    stub = os.path.join(EMSCRIPTEN_TEMP_DIR, 'stub_deleteme') + ('.exe' if WINDOWS else '')
     output = Popen([LLVM_LD, '-disable-opt'] + files + ['-b', target, '-o', stub], stdout=PIPE).communicate()[0]
     try_delete(stub) # clean up stub left by the linker
     assert os.path.exists(target) and (output is None or 'Could not open input file' not in output), 'Linking error: ' + output


### PR DESCRIPTION
There is still an issue with read-only linker stubs, but hopefully that will be fixed in llvm:
http://llvm.org/bugs/show_bug.cgi?id=12560
