### PR TITLE
Adding intrinsic llvm_uadd_with_overflow_i16.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4732,6 +4732,15 @@ LibraryManager.library = {
   // type_info for void*.
   _ZTIPv: [0],
 
+  llvm_uadd_with_overflow_i16: function(x, y) {
+    x = (x>>>0) & 0xffff;
+    y = (y>>>0) & 0xffff;
+    return {
+      f0: (x+y) & 0xffff,
+      f1: x+y > 65535
+    };
+  },
+
   llvm_uadd_with_overflow_i32: function(x, y) {
     x = x>>>0;
     y = y>>>0;

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -950,6 +950,30 @@ m_divisor is 1091269979
       '''
       self.do_run(src, 'zero 2, 104', ['hallo'])
 
+    def test_i16_emcc_intrinsic(self):
+
+      src = r'''
+        #include <stdio.h>
+
+        int test(unsigned short a, unsigned short b) {
+            unsigned short result = a;
+            result += b;
+            if (result < b) printf("C!");
+            return result;
+        }
+
+        int main(void) {
+            printf(",%d,", test(0, 0));
+            printf(",%d,", test(1, 1));
+            printf(",%d,", test(65535, 1));
+            printf(",%d,", test(1, 65535));
+            printf(",%d,", test(32768, 32767));
+            printf(",%d,", test(32768, 32768));
+            return 0;
+        }
+      '''
+      self.do_run(src, ',0,,2,C!,0,C!,0,,65535,C!,0,')
+
     def test_sha1(self):
       if self.emcc_args == None: return self.skip('needs ta2')
 


### PR DESCRIPTION
With -O1, sometimes LLVM generates code which calls its intrinsic llvm_uadd_with_overflow_i16, which was previously missing in emscripten's library.

This commit adds that intrinsic, and also adds a test which causes LLVM to call that intrinsic (only in 'o1'). This new test previously failed in 'o1' without the addition of the intrinsic; it now passes.

Because this is the simple addition of an extra function to the library, I have not run the whole test suite.
