### PR TITLE
Clang++ reports warning "argument unused during compilation '-nostdinc++'.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -197,7 +197,7 @@ USE_EMSDK = not os.environ.get('EMMAKEN_NO_SDK')
 if USE_EMSDK:
   # Disable system C and C++ include directories, and add our own (using -idirafter so they are last, like system dirs, which
   # allows projects to override them)
-  EMSDK_OPTS = ['-nostdinc', '-nostdinc++', '-Xclang', '-nobuiltininc', '-Xclang', '-nostdinc++', '-Xclang', '-nostdsysteminc',
+  EMSDK_OPTS = ['-nostdinc', '-Xclang', '-nobuiltininc', '-Xclang', '-nostdinc++', '-Xclang', '-nostdsysteminc',
     '-Xclang', '-isystem' + path_from_root('system', 'include'),
     '-Xclang', '-isystem' + path_from_root('system', 'include', 'emscripten'),
     '-Xclang', '-isystem' + path_from_root('system', 'include', 'bsd'), # posix stuff


### PR DESCRIPTION
I'm getting the following warning spammed to console when I build with emcc:

https://dl.dropbox.com/u/40949268/emcc/nostdinc.png

so I removed that command line option from the submitted parameters.

Is this safe thing to do? Is that always a redundant parameter?
