### PR TITLE
Fix C++11 support in libcxx

### DIFF
--- a/system/lib/libcxx/locale.cpp
+++ b/system/lib/libcxx/locale.cpp
@@ -1418,10 +1418,10 @@ codecvt<wchar_t, char, mbstate_t>::do_in(state_type& st,
                 case 0:
                     ++frm;
                     break;
-                case -1:
+                case static_cast<size_t>(-1):
                     frm_nxt = frm;
                     return error;
-                case -2:
+                case static_cast<size_t>(-2):
                     frm_nxt = frm;
                     return partial;
                 default:
@@ -1524,8 +1524,8 @@ codecvt<wchar_t, char, mbstate_t>::do_length(state_type& st,
             ++nbytes;
             ++frm;
             break;
-        case -1:
-        case -2:
+        case static_cast<size_t>(-1):
+        case static_cast<size_t>(-2):
             return nbytes;
         default:
             nbytes += n;


### PR DESCRIPTION
Parts of libcxx weren't compiling with -std=c++11
