### PR TITLE
llvm_uadd_with_overflow_i8

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4771,6 +4771,15 @@ LibraryManager.library = {
   // type_info for void*.
   _ZTIPv: [0],
 
+  llvm_uadd_with_overflow_i8: function(x, y) {
+    x = (x>>>0) & 0xff;
+    y = (y>>>0) & 0xff;
+    return {
+      f0: (x+y) & 0xff,
+      f1: x+y > 255
+    };
+  },
+
   llvm_uadd_with_overflow_i16: function(x, y) {
     x = (x>>>0) & 0xffff;
     y = (y>>>0) & 0xffff;


### PR DESCRIPTION
When i compile project with optimization flags --llvm-opts 1 --llvm-lto 1, i have error:

<pre>
Uncaught TypeError: Property '_llvm_uadd_with_overflow_i8' of object [object DOMWindow] is not a function
</pre>


Surrounding code:

<pre>
      var $22=(($v+188)|0);
      var $23=HEAP8[($22)];
      var $uadd=_llvm_uadd_with_overflow_i8($23, $6);
      var $24=$uadd.f0;
      HEAP8[($22)]=$24;
      var $25=$_12 & 1;
      var $26=(($25 << 24) >> 24)==0;
      var $27=(($v+186)|0);
--
      }
    }
var _llvm_uadd_with_overflow_i8; // stub for _llvm_uadd_with_overflow_i8
</pre>


I add implementation for llvm_uadd_with_overflow_i8, but i dont clearly understand why we should do x>>>0, y>>>0 (may be it is for get values unsigned)?
