### PR TITLE
Fix keyCodes for ctrl, alt, shift

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -26,4 +26,5 @@ under the licensing terms detailed in LICENSE.
 * Chad Austin <chad@chadaustin.me>
 * nandhp <nandhp@gmail.com>
 * YeZhongWen <linghuye2.0@gmail.com>
+* Xingxing Pan <forandom@gmail.com>
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -50,10 +50,10 @@ var LibrarySDL = {
       33: 1099, // pagedup
       34: 1102, // pagedown
 
-      17:  305, // control (right, or left)
-      18:  308, // alt
+      17:  1248, // control (right, or left)
+      18:  1250, // alt
       173: 45, // minus
-      16:  304, // shift
+      16:  1249, // shift
       
       96: 88 | 1<<10, // keypad 0
       97: 89 | 1<<10, // keypad 1


### PR DESCRIPTION
Key codes of ctrl, alt and shift have different values in SDL headers and library_sdl.js, which will cause incorrect mapping from DOM key to SDL key.

This patch fix this problem by conform key codes in library_sdl.js to the ones in SDL headers.
