### PR TITLE
Fix sdl_getmod

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -45,6 +45,7 @@ var LibrarySDL = {
     DOMEventToSDLEvent: {},
 
     keyCodes: { // DOM code ==> SDL code. See https://developer.mozilla.org/en/Document_Object_Model_%28DOM%29/KeyboardEvent and SDL_keycode.h
+      46: 127, // SDLK_DEL == '\177'
       38:  1106, // up arrow
       40:  1105, // down arrow
       37:  1104, // left arrow


### PR DESCRIPTION
Add into makeCEvent check for key pressing of shit, alt, ctrl keys. SDL_GetModState should return right status if user press shift, alt, or ctrl key (OpenTTD expect this).

Replace & with |, i think it is been typo.
