### PR TITLE
Use strto{l,l,ll,d} for ato{i,l,ll,f} repectively, as does glibc.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3479,16 +3479,6 @@ LibraryManager.library = {
   abs: 'Math.abs',
   labs: 'Math.abs',
 
-  atoi__deps: ['isspace', 'isdigit'],
-  atoi: function(s) {
-    var c;
-    while ((c = {{{ makeGetValue('s', 0, 'i8') }}}) && _isspace(c)) s++;
-    if (!c || !_isdigit(c)) return 0;
-    var e = s;
-    while ((c = {{{ makeGetValue('e', 0, 'i8') }}}) && _isdigit(c)) e++;
-    return Math.floor(Number(Pointer_stringify(s).substr(0, e-s)));
-  },
-
   exit__deps: ['_exit'],
   exit: function(status) {
     __exit(status);
@@ -3723,10 +3713,28 @@ LibraryManager.library = {
   },
   strtoull_l: 'strtoull', // no locale support yet
 
+  atof__deps: ['strtod'],
   atof: function(ptr) {
     var str = Pointer_stringify(ptr);
-    var ret = parseFloat(str);
-    return isNaN(ret) ? 0 : ret;
+    var ret = _strtod(ptr, null);
+  },
+
+  atoi__deps: ['strtol'],
+  atoi: function(ptr) {
+    var str = Pointer_stringify(ptr);
+    return _strtol(ptr, null, 10);
+  },
+
+  atol__deps: ['strtol'],
+  atol: function(ptr) {
+    var str = Pointer_stringify(ptr);
+    return _strtol(ptr, null, 10);
+  },
+
+  atoll__deps: ['strtoll'],
+  atoll: function(ptr) {
+    var str = Pointer_stringify(ptr);
+    return _strtoll(ptr, null, 10);
   },
 
   qsort__deps: ['memcpy'],


### PR DESCRIPTION
Hi there,

My patch redefines atof and atoi in terms of the existing implementation of strtod and strtol, as glibc seems to do. I also add similar definition of atol and atoll. The patch passes test_atoi.

This possibly addresses the remark in 8b14e998c1f2a27dcd1d0b67af85f1637612aa5b and the issue gh-141.
