### PR TITLE
Improve default options to allow script to be run "out of the box" by more users

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -2,14 +2,15 @@
 # IMPORTANT: Edit the *copy* with the right paths!
 # Note: If you put paths relative to the home directory, do not forget os.path.expanduser
 
-EMSCRIPTEN_ROOT = os.path.expanduser('~/Dev/emscripten') # this helps projects using emscripten find it
-
-LLVM_ROOT = os.path.expanduser('~/Dev/llvm/cbuild/bin')
+# this helps projects using emscripten find it
+EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN') or '/usr/bin')
+LLVM_ROOT = os.path.expanduser(os.getenv('LLVM') or '/usr/bin')
 
 # See below for notes on which JS engine(s) you need
 NODE_JS = 'node'
-SPIDERMONKEY_ENGINE = [os.path.expanduser('~/Dev/mozilla-central/js/src/js'), '-m', '-n']
-V8_ENGINE = os.path.expanduser('~/Dev/v8/d8')
+SPIDERMONKEY_ENGINE = [
+  os.path.expanduser(os.getenv('SPIDERMONKEY') or 'js'), '-m', '-n']
+V8_ENGINE = os.path.expanduser(os.getenv('V8') or 'd8')
 
 JAVA = 'java'
 


### PR DESCRIPTION
I think this change is particularly useful in that it allows most default settings to be set from the environment.

This allows build systems that use emscripten to configure paths without always forcing the user to first edit ~/.emscripten
