### PR TITLE
don't pass EMCC specific flags on when configuring using clang

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -36,3 +36,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Mokhtar Naamani <mokhtar.naamani@gmail.com>
 * Benjamin Stover <benjamin.stover@gmail.com>
 * Riccardo Magliocchetti <riccardo.magliocchetti@gmail.com>
+* Janus Troelsen <janus.troelsen@stud.tu-darmstadt.de>

--- a/emcc
+++ b/emcc
@@ -322,12 +322,12 @@ elif len(sys.argv) == 2 and sys.argv[1] == '-v': # -v with no inputs
   exit(subprocess.call([shared.CLANG, '-v']))
 
 def is_minus_s_for_emcc(newargs,i):
-      assert newargs[i] == '-s'
-      if i+1 < len(newargs) and '=' in newargs[i+1]: # -s OPT=VALUE is for us, -s by itself is a linker option
-        return True
-      else:
-        print >> sys.stderr, 'emcc: warning: treating -s as linker option and not as -s OPT=VALUE for js compilation'
-        return False
+  assert newargs[i] == '-s'
+  if i+1 < len(newargs) and '=' in newargs[i+1]: # -s OPT=VALUE is for us, -s by itself is a linker option
+    return True
+  else:
+    print >> sys.stderr, 'emcc: warning: treating -s as linker option and not as -s OPT=VALUE for js compilation'
+    return False
 
 # If this is a configure-type thing, do not compile to JavaScript, instead use clang
 # to compile to a native binary (using our headers, so things make sense later)
@@ -339,14 +339,14 @@ if CONFIGURE_CONFIG or CMAKE_CONFIG:
     compiler = shared.to_cc(compiler)
   def filter_emscripten_options(argv):
     idx = 0
-    skipNext = False
+    skip_next = False
     for el in argv:
-      if skipNext:
-        skipNext = False
+      if skip_next:
+        skip_next = False
         idx += 1
         continue
-      if el=='-s' and is_minus_s_for_emcc(argv,idx):
-        skipNext = True
+      if el == '-s' and is_minus_s_for_emcc(argv, idx):
+        skip_next = True
       else:
         yield el
       idx += 1

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -7674,6 +7674,19 @@ fscanfed: 10 - hello
       code = open('a.out.js').read()
       assert 'SAFE_HEAP' in code, 'valid -s option had an effect'
 
+    def test_conftest_s_flag_passing(self):
+      open(os.path.join(self.get_dir(), 'conftest.c'), 'w').write(r'''
+        int main() {
+          return 0;
+        }
+      ''')
+      os.environ["EMMAKEN_JUST_CONFIGURE"] = "1"
+      cmd = ['python', EMCC, '-s', 'ASSERTIONS=1', os.path.join(self.get_dir(), 'conftest.c'), '-o', 'conftest']
+      output = Popen(cmd, stderr=PIPE).communicate()
+      self.assertNotContained('emcc: warning: treating -s as linker option', output[1])
+      assert os.path.exists('conftest')
+      del os.environ["EMMAKEN_JUST_CONFIGURE"]
+
     def test_crunch(self):
       # crunch should not be run if a .crn exists that is more recent than the .dds
       shutil.copyfile(path_from_root('tests', 'ship.dds'), 'ship.dds')


### PR DESCRIPTION
Clang doesn't understand flags such as "-s ASSERTIONS=1" so it makes no sense to pass them on. This patch pulls the heuristics to determine if a parameter is a emcc flags out into a function and calls it from the place of the original check and during EMCC_JUST_CONFIGURE too.
