### PR TITLE
Don't explode in emconfigure if no args are passed

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -533,6 +533,8 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)''' % { 'winfix': '' if not WINDOWS e
 
   @staticmethod
   def configure(args, stdout=None, stderr=None, env=None):
+    if not args:
+      return
     if env is None:
       env = Building.get_building_env()
     env['EMMAKEN_JUST_CONFIGURE'] = '1'


### PR DESCRIPTION
$ ~/src/emscripten/emconfigure 
Traceback (most recent call last):
  File "/home/rm/src/emscripten/emconfigure", line 22, in <module>
    shared.Building.configure(sys.argv[1:])
  File "/home/rm/src/emscripten/tools/shared.py", line 539, in configure
    if 'cmake' in args[0]:
IndexError: list index out of range
