### PR TITLE
Added %lld support to __scanString

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -39,3 +39,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Janus Troelsen <janus.troelsen@stud.tu-darmstadt.de>
 * Lars Schneider <lars.schneider@autodesk.com> (copyright owned by Autodesk, Inc.)
 * Joel Martin <github@martintribe.org>
+* Manuel Wellmann <manuel.wellmann@autodesk.com> (copyright owned by Autodesk, Inc.)

--- a/src/library.js
+++ b/src/library.js
@@ -2434,7 +2434,7 @@ LibraryManager.library = {
       __scanString.whiteSpace['\t'] = 1;
       __scanString.whiteSpace['\n'] = 1;
     }
-    // Supports %x, %4x, %d.%d, %s, %f, %lf.
+    // Supports %x, %4x, %d.%d, %lld, %s, %f, %lf.
     // TODO: Support all format specifiers.
     format = Pointer_stringify(format);
     var soFar = 0;
@@ -2485,9 +2485,14 @@ LibraryManager.library = {
         }
         var long_ = false;
         var half = false;
+        var longLong = false;
         if (format[formatIndex] == 'l') {
           long_ = true;
           formatIndex++;
+          if(format[formatIndex] == 'l') {
+            longLong = true;
+            formatIndex++;
+          }
         } else if (format[formatIndex] == 'h') {
           half = true;
           formatIndex++;
@@ -2498,7 +2503,7 @@ LibraryManager.library = {
         var buffer = [];
         // Read characters according to the format. floats are trickier, they may be in an unfloat state in the middle, then be a valid float later
         if (type == 'f') {
-          var last = -1;
+          var last = 0;
           while (next > 0) {
             buffer.push(String.fromCharCode(next));
             if (__isFloat(buffer.join(''))) {
@@ -2539,6 +2544,8 @@ LibraryManager.library = {
           case 'd': case 'u': case 'i':
             if (half) {
               {{{ makeSetValue('argPtr', 0, 'parseInt(text, 10)', 'i16') }}};
+            } else if(longLong) {
+              {{{ makeSetValue('argPtr', 0, 'parseInt(text, 10)', 'i64') }}};
             } else {
               {{{ makeSetValue('argPtr', 0, 'parseInt(text, 10)', 'i32') }}};
             }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1005,6 +1005,10 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
     return '(tempDoubleF64[0]=' + value + ',' +
             makeSetValue(ptr, pos, 'tempDoubleI32[0]', 'i32', noNeedFirst, ignore, align, noSafe, ',') + ',' +
             makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'tempDoubleI32[1]', 'i32', noNeedFirst, ignore, align, noSafe, ',') + ')';
+  } else if (USE_TYPED_ARRAYS == 2 && type == 'i64') {
+    return '(tempI64 = [' + splitI64(value) + '],' +
+            makeSetValue(ptr, pos, 'tempI64[0]', 'i32', noNeedFirst, ignore, align, noSafe, ',') + ',' +
+            makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'tempI64[1]', 'i32', noNeedFirst, ignore, align, noSafe, ',') + ')';
   }
 
   var bits = getBits(type);

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -4407,6 +4407,29 @@ Pass: 0.000012 0.000012''')
       '''
       self.do_run(src, '''0:173,16 1:16,173 2:183,173 3:17,287 4:98,123''')      
 
+    def test_sscanf_3(self):
+      # i64
+      if not Settings.USE_TYPED_ARRAYS == 2: return self.skip('64-bit sscanf only supported in ta2')
+      src = r'''
+        #include <stdio.h>
+
+        int main(){
+            
+            int64_t s, m, l;
+            printf("%d\n", sscanf("123 1073741823 1125899906842620", "%lld %lld %lld", &s, &m, &l));
+            printf("%lld,%lld,%lld\n", s, m, l);
+   
+            int64_t negS, negM, negL;
+            printf("%d\n", sscanf("-123 -1073741823 -1125899906842620", "%lld %lld %lld", &negS, &negM, &negL));
+            printf("%lld,%lld,%lld\n", negS, negM, negL);
+
+            return 0;
+        }
+      '''
+      
+      self.do_run(src, '3\n123,1073741823,1125899906842620\n' + 
+                     '3\n-123,-1073741823,-1125899906842620\n')
+        
     def test_langinfo(self):
       src = open(path_from_root('tests', 'langinfo', 'test.c'), 'r').read()
       expected = open(path_from_root('tests', 'langinfo', 'output.txt'), 'r').read()


### PR DESCRIPTION
Also extended makeSetValue for the i64/typed_array=2 case.

Please note that the change in 2402/2407 (old/new) is not strictly required as there is a next <= 0 check further up in the for-loop. As I had created an issue unrelated to this pull request, I triggered this minor glitch and changed it to be on the safe side.
