### PR TITLE
Fix sscanf white space bug

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2456,19 +2456,22 @@ LibraryManager.library = {
     var fields = 0;
     var argIndex = 0;
     var next;
-    // remove initial whitespace
-    while (1) {
-      next = get();
-      if (next == 0) return 0;
-      if (!(next in __scanString.whiteSpace)) break;
-    } 
-    unget(next);
+
     next = 1;
     mainLoop:
     for (var formatIndex = 0; formatIndex < format.length; formatIndex++) {
+      // remove whitespace
+      while (1) {
+        next = get();
+        if (next == 0) return fields;
+        if (!(next in __scanString.whiteSpace)) break;
+      } 
+      unget(next);
+      
       if (next <= 0) return fields;
       var next = get();
       if (next <= 0) return fields;  // End of input.
+
       if (format[formatIndex] === '%') {
         formatIndex++;
         var maxSpecifierStart = formatIndex;

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -4378,6 +4378,32 @@ Pass: 0.000012 0.000012''')
       '''
       self.do_run(src, '''[DEBUG] word 1: version, l: 7\n1,one,4''')
 
+    def test_sscanf_whitespace(self):
+      src = r'''
+        #include<stdio.h>
+
+        int main() {
+          short int x;
+          short int y;
+
+          const char* buffer[] = {
+            "173,16",
+            "    16,173",
+            "183,   173",
+            "  17,   287",
+            " 98,  123,   "
+          };
+
+          for (int i=0; i<5; ++i) {
+            sscanf(buffer[i], "%hd,%hd", &x, &y);
+            printf("%d:%d,%d ", i, x, y);
+          }
+
+          return 0;
+        }
+      '''
+      self.do_run(src, '''0:173,16 1:16,173 2:183,173 3:17,287 4:98,123''')      
+
     def test_langinfo(self):
       src = open(path_from_root('tests', 'langinfo', 'test.c'), 'r').read()
       expected = open(path_from_root('tests', 'langinfo', 'output.txt'), 'r').read()


### PR DESCRIPTION
As i think sscanf should ignore all white spaces in string not only at the beginning. For example code:

```
int main() {
    int16 x;
    int16 y;
    const char* buffer = "  173,    16 ";

    sscanf(buffer, "%hd,%hd", &x, &y);
    printf("%d,%d\n", x, y);

    return 0;
}
```

Should print:

```
173,16
```

But prints:

```
173,0
```

I suppose i fix this problem, but i'm not sure that I did it right, please take a look.
