### PR TITLE
CMake toolchain

### DIFF
--- a/cmake/Platform/Emscripten.cmake
+++ b/cmake/Platform/Emscripten.cmake
@@ -1,0 +1,46 @@
+# This file is a 'toolchain description file' for CMake.
+# It teaches CMake about the Emscripten compiler, so that CMake can generate Unix Makefiles
+# from CMakeLists.txt that invoke emcc.
+
+# To use this toolchain file with CMake, invoke CMake with the following command line parameters
+# cmake -DEMSCRIPTEN=1 
+#       -DCMAKE_TOOLCHAIN_FILE=<EmscriptenRoot>/cmake/Platform/Emscripten.cmake
+#       -DCMAKE_MODULE_PATH=<EmscriptenRoot>/cmake
+#       -DCMAKE_BUILD_TYPE=<Debug|RelWithDebInfo|Release|MinSizeRel>
+#       -G "Unix Makefiles"
+#       <path/to/CMakeLists.txt> # Note, pass in here ONLY the path to the file, not the filename 'CMakeLists.txt' itself.
+
+# After that, build the generated Makefile with the command 'make'. On Windows, you may download and use 'mingw32-make' instead.
+
+# the name of the target operating system
+SET(CMAKE_SYSTEM_NAME Emscripten)
+SET(CMAKE_SYSTEM_VERSION 1)
+
+if ("$ENV{EMCC_BIN}" STREQUAL "")
+	message(ERROR "Environment variable EMCC_BIN has not been set! Please point it to Emscripten root directory!")
+endif()
+
+#message(STATUS "CMake is using Emscripten toolchain file, Emscripten root path '$ENV{EMCC_BIN}'.")
+
+SET(CMAKE_FIND_ROOT_PATH $ENV{EMCC_BIN})
+
+FILE(TO_CMAKE_PATH "$ENV{EMCC_BIN}" EMCC_PATH)
+
+# Specify the compilers to use for C and C++
+SET(CMAKE_C_COMPILER ${EMCC_PATH}/emcc)
+SET(CMAKE_CXX_COMPILER ${EMCC_PATH}/em++)
+SET(CMAKE_AR ${EMCC_PATH}/emar)
+SET(CMAKE_RANLIB ${EMCC_PATH}/emranlib)
+
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE BOTH)
+set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+
+# Specify the program to use when building static libraries. Force Emscripten-related command line options to clang.
+SET(CMAKE_CXX_ARCHIVE_CREATE "${CMAKE_CXX_COMPILER} -o <TARGET> -emit-llvm <LINK_FLAGS> <OBJECTS>")
+SET(CMAKE_C_ARCHIVE_CREATE "${CMAKE_C_COMPILER} -o <TARGET> -emit-llvm <LINK_FLAGS> <OBJECTS>")
+
+# Set a global EMSCRIPTEN variable that can be used in client CMakeLists.txt to detect when building using Emscripten.
+# There seems to be some kind of bug with CMake, so you might need to define this manually on the command line with "-DEMSCRIPTEN=1".
+SET(EMSCRIPTEN 1)

--- a/tests/cmake/target_html/CMakeLists.txt
+++ b/tests/cmake/target_html/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(hello_world_gles.html)
+
+file(GLOB sourceFiles ../../hello_world_gles.c)
+
+if (CMAKE_BUILD_TYPE STREQUAL Debug)
+	SET(linkFlags "")
+else() # Either MinSizeRel, RelWithDebInfo or Release, all which run with optimizations enabled.
+	SET(linkFlags "-O2")
+endif()
+
+add_executable(hello_world_gles.html ${sourceFiles})
+set_target_properties(hello_world_gles.html PROPERTIES LINK_FLAGS "${linkFlags}")

--- a/tests/cmake/target_js/CMakeLists.txt
+++ b/tests/cmake/target_js/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(hello_world.js)
+
+file(GLOB sourceFiles ../../hello_world.cpp)
+
+if (CMAKE_BUILD_TYPE STREQUAL Debug)
+	SET(linkFlags "")
+else() # Either MinSizeRel, RelWithDebInfo or Release, all which run with optimizations enabled.
+	SET(linkFlags "-O2")
+endif()
+
+add_executable(hello_world.js ${sourceFiles})
+set_target_properties(hello_world.js PROPERTIES LINK_FLAGS "${linkFlags}")

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -7432,6 +7432,54 @@ f.close()
       # TODO: test normal project linking, static and dynamic: get_library should not need to be told what to link!
       # TODO: deprecate llvm optimizations, dlmalloc, etc. in emscripten.py.
 
+    def test_cmake(self):
+      emscriptencmaketoolchain = path_from_root('cmake', 'Platform', 'Emscripten.cmake')
+
+      # On Windows, we want to build cmake-generated Makefiles with mingw32-make instead of e.g. cygwin make, since mingw32-make
+      # understands Windows paths, and cygwin make additionally produces a cryptic 'not valid bitcode file' errors on files that
+      # *are* valid bitcode files.
+      if os.name == 'nt':
+        make_command = 'mingw32-make'
+      else:
+        make_command = 'make'
+
+      cmake_cases = ['target_js', 'target_html']
+      cmake_outputs = ['hello_world.js', 'hello_world_gles.html']
+      for i in range(0, 2):
+        for configuration in ['Debug', 'Release']:
+        
+          # Create a temp workspace folder
+          cmakelistsdir = path_from_root('tests', 'cmake', cmake_cases[i])
+          tempdirname = tempfile.mkdtemp(prefix='emscripten_test_' + self.__class__.__name__ + '_', dir=TEMP_DIR)
+          try:
+            os.chdir(tempdirname)
+            
+            # Run Cmake
+            cmd = ['cmake', '-DCMAKE_TOOLCHAIN_FILE='+emscriptencmaketoolchain, '-DCMAKE_BUILD_TYPE=' + configuration, '-G' 'Unix Makefiles', cmakelistsdir]
+            ret = Popen(cmd, stdout=PIPE, stderr=PIPE).communicate()
+            if 'error' in ret[1].lower():
+              print >> sys.stderr, 'Failed command: ' + ' '.join(cmd)
+              print >> sys.stderr, 'Result:\n' + ret[1]
+              raise Exception('cmake call failed!') # cmake spams this silly message to stderr, so hide it: "Platform/Emscripten to use this system, please send your config file to cmake@www.cmake.org so it can be added to cmake"
+            assert os.path.exists(tempdirname + '/Makefile'), 'CMake call did not produce a Makefile!'
+            
+            # Build
+            cmd = [make_command]
+            ret = Popen(cmd, stdout=PIPE).communicate()
+            if 'error' in ret[0].lower() and not '0 error(s)' in ret[0].lower():
+              print >> sys.stderr, 'Failed command: ' + ' '.join(cmd)
+              print >> sys.stderr, 'Result:\n' + ret[0]
+              raise Exception('make failed!')
+            assert os.path.exists(tempdirname + '/' + cmake_outputs[i]), 'Building a cmake-generated Makefile failed to produce an output file!'
+            
+            # Run through node, if CMake produced a .js file.
+            if cmake_outputs[i].endswith('.js'):
+              ret = Popen([NODE_JS, tempdirname + '/' + cmake_outputs[i]], stdout=PIPE).communicate()[0]
+              assert 'hello, world!' in ret, 'Running cmake-based .js application failed!'
+          finally:
+            os.chdir(path_from_root('tests')) # Move away from the directory we are about to remove.
+            shutil.rmtree(tempdirname)
+      
     def test_Os(self):
       for opt in ['s', '0']:
         output = Popen(['python', EMCC, path_from_root('tests', 'hello_world.c'), '-O' + opt], stdout=PIPE, stderr=PIPE).communicate()


### PR DESCRIPTION
Adds a cmake toolchain file for targeting Emscripten from cmake.

A new test other.test_cmake tests .js and .html output in both debug and release configurations.
