### PR TITLE
Try to locate emcc in cmake based on the cmake toolchain directory struc...

### DIFF
--- a/cmake/Platform/Emscripten.cmake
+++ b/cmake/Platform/Emscripten.cmake
@@ -16,11 +16,11 @@
 set(CMAKE_SYSTEM_NAME Emscripten)
 set(CMAKE_SYSTEM_VERSION 1)
 
-if ("$ENV{EMSCRIPTEN}" STREQUAL "")
-	message(ERROR "Environment variable EMSCRIPTEN has not been set! Please point it to Emscripten root directory!")
+if ("${EMSCRIPTEN_ROOT_PATH}" STREQUAL "")
+	set(CMAKE_FIND_ROOT_PATH "$ENV{EMSCRIPTEN}")
+else()
+	set(CMAKE_FIND_ROOT_PATH "${EMSCRIPTEN_ROOT_PATH}")
 endif()
-
-set(CMAKE_FIND_ROOT_PATH $ENV{EMSCRIPTEN})
 
 # Specify the compilers to use for C and C++
 if ("${CMAKE_C_COMPILER}" STREQUAL "")

--- a/cmake/Platform/Emscripten_unix.cmake
+++ b/cmake/Platform/Emscripten_unix.cmake
@@ -1,13 +1,24 @@
 # On Unix platforms, we must specify the absolute path to emcc for cmake, having emcc in PATH will cause cmake to fail finding it.
 # The user must set the EMSCRIPTEN variable to point to the Emscripten root folder.
 
-if ("$ENV{EMSCRIPTEN}" STREQUAL "")
-	message(ERROR "Environment variable EMSCRIPTEN has not been set! Please point it to Emscripten root directory!")
+# Try locating Emscripten root directory based on the location of this toolchain file.
+get_filename_component(GUESS_EMSCRIPTEN_ROOT_PATH "${CMAKE_CURRENT_LIST_FILE}/../../.." ABSOLUTE)
+if (EXISTS "${GUESS_EMSCRIPTEN_ROOT_PATH}/emcc")
+	set(EMSCRIPTEN_ROOT_PATH "${GUESS_EMSCRIPTEN_ROOT_PATH}")
 endif()
 
-set(CMAKE_C_COMPILER "$ENV{EMSCRIPTEN}/emcc")
-set(CMAKE_CXX_COMPILER "$ENV{EMSCRIPTEN}/em++")
-set(CMAKE_AR "$ENV{EMSCRIPTEN}/emar")
-set(CMAKE_RANLIB "$ENV{EMSCRIPTEN}/emranlib")
+# If not found, try if the environment variable Emscripten was set.
+if ("${EMSCRIPTEN_ROOT_PATH}" STREQUAL "")
+	if ("$ENV{EMSCRIPTEN}" STREQUAL "")
+		message(ERROR "Could not locate emcc and the environment variable EMSCRIPTEN has not been set! Please point it to Emscripten root directory!")
+	else()
+		set(EMSCRIPTEN_ROOT_PATH "$ENV{EMSCRIPTEN}")
+	endif()
+endif()
 
-include($ENV{EMSCRIPTEN}/cmake/Platform/Emscripten.cmake)
+set(CMAKE_C_COMPILER "${EMSCRIPTEN_ROOT_PATH}/emcc")
+set(CMAKE_CXX_COMPILER "${EMSCRIPTEN_ROOT_PATH}/em++")
+set(CMAKE_AR "${EMSCRIPTEN_ROOT_PATH}/emar")
+set(CMAKE_RANLIB "${EMSCRIPTEN_ROOT_PATH}/emranlib")
+
+include(${EMSCRIPTEN_ROOT_PATH}/cmake/Platform/Emscripten.cmake)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -7530,8 +7530,6 @@ f.close()
       # understands Windows paths, and cygwin make additionally produces a cryptic 'not valid bitcode file' errors on files that
       # *are* valid bitcode files.
 
-      os.environ['EMSCRIPTEN'] = path_from_root('') # XXX FIXME this should be done in emconfigure
-
       if os.name == 'nt':
         make_command = 'mingw32-make'
         emscriptencmaketoolchain = path_from_root('cmake', 'Platform', 'Emscripten.cmake')


### PR DESCRIPTION
...ture to avoid having to set EMSCRIPTEN environment variable on unix. Remove the temporary workaround for other.test_cmake, which shouldn't now be needed.
