### PR TITLE
Ensure that a failing compilation results in a nonzero return code.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -7331,9 +7331,11 @@ Options that are modified or new in %s include:
         # properly report source code errors, and stop there
         self.clear()
         assert not os.path.exists('a.out.js')
-        output = Popen(['python', compiler, path_from_root('tests', 'hello_world_error' + suffix)], stdout=PIPE, stderr=PIPE).communicate()
+        process = Popen(['python', compiler, path_from_root('tests', 'hello_world_error' + suffix)], stdout=PIPE, stderr=PIPE)
+        output = process.communicate()
         assert not os.path.exists('a.out.js'), 'compilation failed, so no output file is expected'
         assert len(output[0]) == 0, output[0]
+        assert process.returncode is not 0, 'Failed compilation must return a nonzero error code!'
         self.assertNotContained('IOError', output[1]) # no python stack
         self.assertNotContained('Traceback', output[1]) # no python stack
         self.assertContained('error: invalid preprocessing directive', output[1])


### PR DESCRIPTION
Tests that if a file is compiled with errors, the return code of the process is nonzero.

This test was detected to succeed on Windows. (most likely will also on Ubuntu and OSX, but haven't run on them) Adding this test, since didn't see that kind of check present already.
