### PR TITLE
Add strtof function(use strtod instead)

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3738,6 +3738,7 @@ LibraryManager.library = {
   strtod_l: 'strtod', // no locale support yet
   strtold: 'strtod', // XXX add real support for long double
   strtold_l: 'strtold', // no locale support yet
+  strtof: 'strtod', // use stdtod to handle strtof
 
   _parseInt__deps: ['isspace', '__setErrNo', '$ERRNO_CODES'],
   _parseInt: function(str, endptr, base, min, max, bits, unsign) {


### PR DESCRIPTION
strtof function is missing in library.js. This commit uses strtod function to handle strtof. Just like the other math functions
