### PR TITLE
Fixes to emcc to make autoconf enable shared objs

### DIFF
--- a/emcc
+++ b/emcc
@@ -374,10 +374,12 @@ or LLVM assembly files in human-readable form.
 emcc is affected by several environment variables. For details, view
 the source of emcc (search for 'os.environ').
 
+emcc: supported targets: llvm bitcode, javascript, NOT elf
+(autoconf likes to see elf above to enable shared object support)
 ''' % (this, this, this)
   exit(0)
 elif len(sys.argv) == 2 and sys.argv[1] == '-v': # -v with no inputs
-  print 'emcc (Emscripten GCC-like replacement) 2.0'
+  print 'emcc (Emscripten GCC-like replacement + linker emulating GNU ld ) 2.0'
   exit(subprocess.call([shared.CLANG, '-v']))
 
 def is_minus_s_for_emcc(newargs,i):


### PR DESCRIPTION
When using emcc as a linker, autoconf disables
shared object support.  This is because it expects
the text returned by the -v and --help options to
match certain things that GNU ld prints.

Specifically it expects the output of emcc -v to include
the word 'GNU' and the output of emcc --help to match the
regexp ': supported targets.\* elf'

Modified the messages returned by emcc for these options
to make autoconf happy.
