### PR TITLE
Add function name filter for LABEL_DEBUG

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -486,25 +486,17 @@ function JSify(data, functionsOnly, givenFunctions) {
     }
   });
 
-  function functionNameFilterTest(ident) {
-    if (LABEL_FUNCTION_FILTERS.length == 0) {
-      // empty array means filter is disabled
+  // function for filtering functions for label debugging
+  if (LABEL_FUNCTION_FILTERS.length > 0) {
+    var LABEL_FUNCTION_FILTER_SET = set(LABEL_FUNCTION_FILTERS);
+    var functionNameFilterTest = function(ident) {
+      return (ident in LABEL_FUNCTION_FILTER_SET);
+    };
+  } else {
+    // no filters are specified, all function names are printed
+    var functionNameFilterTest = function(ident) {
       return true;
     }
-
-    for (var i = 0; i < LABEL_FUNCTION_FILTERS.length; i++) {
-      var filter = LABEL_FUNCTION_FILTERS[i];
-      var match = false;
-
-      if (typeof filter == 'string') {
-        match = (filter == ident);
-      } else if (filter instanceof RegExp) { // typeof would return 'object' for RegExp
-        match = filter.test(ident);
-      }
-
-      if (match) return true;
-    }
-    return false;
   }
 
   // function reconstructor & post-JS optimizer

--- a/src/settings.js
+++ b/src/settings.js
@@ -135,11 +135,8 @@ var LABEL_DEBUG = 0; // 1: Print out functions as we enter them
 var LABEL_FUNCTION_FILTERS = []; // Filters for function label debug.
                                  // The items for this array will be used
                                  // as filters for function names. Only the
-                                 // labels of functions that match one particular
-                                 // filter are printed out.
-                                 // The filters can be specified in both string
-                                 // type (use equality test) and regular expression
-                                 // (use match test).
+                                 // labels of functions that is equaled to
+                                 // one of the filters are printed out
                                  // When the array is empty, the filter is disabled.
 var EXCEPTION_DEBUG = 1; // Print out exceptions in emscriptened code
 


### PR DESCRIPTION
This commit adds a filter for function name when using with LABEL_DEBUG.

Currently, if we enable LABEL_DEBUG, the output simply contains all functions, twhich can result in a very large log file(running the mruby tests with LABEL_DEBUG enabled generates a ~181MB file). This commit adds a filter for function names so we can control what names to print.
