### PR TITLE
Add a -U__GXX_EXPERIMENTAL_CXX0X__ to command line parameters when emscr...

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -346,7 +346,8 @@ except:
 # Force a simple, standard target as much as possible: target 32-bit linux, and disable various flags that hint at other platforms
 COMPILER_OPTS = COMPILER_OPTS + ['-m32', '-U__i386__', '-U__x86_64__', '-U__i386', '-U__x86_64', '-Ui386', '-Ux86_64', '-U__SSE__', '-U__SSE2__', '-U__MMX__',
                                  '-UX87_DOUBLE_ROUNDING', '-UHAVE_GCC_ASM_FOR_X87', '-DEMSCRIPTEN', '-U__STRICT_ANSI__', '-U__CYGWIN__',
-                                 '-D__STDC__', '-Xclang', '-triple=i386-pc-linux-gnu', '-D__IEEE_LITTLE_ENDIAN', '-fno-math-errno']
+                                 '-U__GXX_EXPERIMENTAL_CXX0X__', '-D__STDC__', '-Xclang', '-triple=i386-pc-linux-gnu', 
+                                 '-D__IEEE_LITTLE_ENDIAN', '-fno-math-errno']
 
 
 USE_EMSDK = not os.environ.get('EMMAKEN_NO_SDK')


### PR DESCRIPTION
...ipten invokes the clang compiler. The new LLVM3.2 libcxx libraries will otherwise give an error about char16_t and char32_t being undeclared on Windows. (This did not occur on LLVM 3.1). See https://github.com/kripken/emscripten/issues/762 for a discussion. After this fix, I can successfully compile applications on Windows with LLVM3.2.
