### PR TITLE
Don't run Clang in MS compatibility mode on Windows (-fno-ms-compatibility).

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -344,10 +344,12 @@ try:
 except:
   COMPILER_OPTS = []
 # Force a simple, standard target as much as possible: target 32-bit linux, and disable various flags that hint at other platforms
+# -fno-ms-compatibility is passed, since on Windows, Clang enables a 'MS compatibility mode' by default, that disables char16_t and char32_t 
+#                       to be MSVC header -compatible. This would cause build errors in libcxx file __config.
 COMPILER_OPTS = COMPILER_OPTS + ['-m32', '-U__i386__', '-U__x86_64__', '-U__i386', '-U__x86_64', '-Ui386', '-Ux86_64', '-U__SSE__', '-U__SSE2__', '-U__MMX__',
                                  '-UX87_DOUBLE_ROUNDING', '-UHAVE_GCC_ASM_FOR_X87', '-DEMSCRIPTEN', '-U__STRICT_ANSI__', '-U__CYGWIN__',
-                                 '-D__STDC__', '-Xclang', '-triple=i386-pc-linux-gnu', '-D__IEEE_LITTLE_ENDIAN', '-fno-math-errno']
-
+                                 '-D__STDC__', '-Xclang', '-triple=i386-pc-linux-gnu', '-D__IEEE_LITTLE_ENDIAN', '-fno-math-errno', 
+                                 '-fno-ms-compatibility']
 
 USE_EMSDK = not os.environ.get('EMMAKEN_NO_SDK')
 


### PR DESCRIPTION
Fixes #762. Thanks to d0k in #llvm for the helpful insight!

Finally found the cause to the mysterious issues on Windows. It turns out that Clang enables Microsoft-friendly emulation mode by default, and that's the reason why it fails to parse libcxx properly. This commit removes that, and fixes the Clang 3.2 libcxx problem.

(There are still other build errors found after that, reported in #779)
