### PR TITLE
Added gluOrtho2D

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -44,4 +44,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dominic Wong <dom@slowbunyip.org>
 * Alan Kligman <alan.kligman@gmail.com> (copyright owned by Mozilla Foundation)
 * Anthony Liot <wolfviking0@yahoo.com>
-* Michael Riß <Michael.Riss@gmx.de>
+* Michael Riss <Michael.Riss@gmx.de>

--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -2466,7 +2466,7 @@ var LibraryGL = {
   
   gluOrtho2D: function(left, right, bottom, top) {
     _glOrtho(left, right, bottom, top, -1, 1);
-  },
+  }
 };
 
 // Simple pass-through functions. Starred ones have return values. [X] ones have X in the C name but not in the JS name


### PR DESCRIPTION
Hi kripken,

I missed the gluOrtho2D function and therefore added it.

The test suite shows no regressions, before and after the change of 2171 tests
1 test fails and 19 have errors.
The benchmarks are a mixed bag (see below), some became a bit faster, 
some a bit slower. But the deviations are small, so I assume it's just noise.

Please consider the inclusion of this function.

cu
Michi

Benchmarks:

Before
  JavaScript: mean: 0.096 (+-0.001) secs  median: 0.096  range: 0.095-0.100  (noise: 1.449%)  (10 runs)
   Native    : mean: 0.032 (+-0.000) secs  median: 0.032  range: 0.032-0.033  (noise: 0.538%)  JS is 3.00 X slower

   JavaScript: mean: 0.454 (+-0.003) secs  median: 0.455  range: 0.446-0.458  (noise: 0.676%)  (10 runs)
   Native    : mean: 0.155 (+-0.000) secs  median: 0.155  range: 0.155-0.156  (noise: 0.102%)  JS is 2.92 X slower

   JavaScript: mean: 3.035 (+-0.006) secs  median: 3.034  range: 3.024-3.045  (noise: 0.211%)  (10 runs)
   Native    : mean: 0.178 (+-0.000) secs  median: 0.178  range: 0.178-0.179  (noise: 0.243%)  JS is 17.04 X slower

   JavaScript: mean: 4.241 (+-0.325) secs  median: 4.125  range: 4.093-5.210  (noise: 7.654%)  (10 runs)
   Native    : mean: 0.222 (+-0.001) secs  median: 0.222  range: 0.221-0.224  (noise: 0.317%)  JS is 19.12 X slower

   JavaScript: mean: 0.910 (+-0.004) secs  median: 0.911  range: 0.903-0.915  (noise: 0.429%)  (10 runs)
   Native    : mean: 0.146 (+-0.001) secs  median: 0.146  range: 0.145-0.148  (noise: 0.511%)  JS is 6.24 X slower

   JavaScript: mean: 7.312 (+-0.834) secs  median: 6.925  range: 6.731-9.148  (noise: 11.408%)  (10 runs)
   Native    : mean: 0.291 (+-0.000) secs  median: 0.291  range: 0.291-0.291  (noise: 0.039%)  JS is 25.12 X slower

   JavaScript: mean: 0.794 (+-0.015) secs  median: 0.804  range: 0.773-0.807  (noise: 1.871%)  (10 runs)
   Native    : mean: 0.365 (+-0.000) secs  median: 0.365  range: 0.365-0.366  (noise: 0.053%)  JS is 2.18 X slower

   JavaScript: mean: 16.732 (+-0.224) secs  median: 16.689  range: 16.405-17.115  (noise: 1.336%)  (10 runs)
   Native    : mean: 0.392 (+-0.002) secs  median: 0.392  range: 0.391-0.398  (noise: 0.500%)  JS is 42.68 X slower

After
   JavaScript: mean: 0.097 (+-0.001) secs  median: 0.096  range: 0.095-0.100  (noise: 1.386%)  (10 runs)
   Native    : mean: 0.034 (+-0.002) secs  median: 0.032  range: 0.032-0.037  (noise: 6.383%)  JS is 2.87 X slower

   JavaScript: mean: 0.455 (+-0.002) secs  median: 0.455  range: 0.453-0.461  (noise: 0.503%)  (10 runs)
   Native    : mean: 0.163 (+-0.019) secs  median: 0.156  range: 0.155-0.220  (noise: 11.764%)  JS is 2.79 X slower

   JavaScript: mean: 3.031 (+-0.006) secs  median: 3.029  range: 3.024-3.040  (noise: 0.198%)  (10 runs)
   Native    : mean: 0.178 (+-0.000) secs  median: 0.178  range: 0.177-0.178  (noise: 0.111%)  JS is 17.06 X slower

   JavaScript: mean: 4.130 (+-0.035) secs  median: 4.125  range: 4.082-4.191  (noise: 0.849%)  (10 runs)
   Native    : mean: 0.222 (+-0.001) secs  median: 0.222  range: 0.221-0.225  (noise: 0.454%)  JS is 18.60 X slower

   JavaScript: mean: 0.920 (+-0.027) secs  median: 0.911  range: 0.904-0.999  (noise: 2.901%)  (10 runs)
   Native    : mean: 0.147 (+-0.002) secs  median: 0.146  range: 0.145-0.152  (noise: 1.616%)  JS is 6.25 X slower

   JavaScript: mean: 7.027 (+-0.435) secs  median: 6.848  range: 6.721-8.081  (noise: 6.194%)  (10 runs)
   Native    : mean: 0.291 (+-0.000) secs  median: 0.291  range: 0.291-0.292  (noise: 0.068%)  JS is 24.14 X slower

   JavaScript: mean: 0.829 (+-0.105) secs  median: 0.807  range: 0.773-1.141  (noise: 12.698%)  (10 runs)
   Native    : mean: 0.375 (+-0.026) secs  median: 0.366  range: 0.365-0.453  (noise: 6.901%)  JS is 2.21 X slower

   JavaScript: mean: 17.816 (+-2.026) secs  median: 16.793  range: 16.567-23.227  (noise: 11.373%)  (10 runs)
   Native    : mean: 0.391 (+-0.000) secs  median: 0.391  range: 0.391-0.392  (noise: 0.103%)  JS is 45.51 X slower
