### PR TITLE
Missign extern "C"

### DIFF
--- a/system/include/sys/select.h
+++ b/system/include/sys/select.h
@@ -1,6 +1,14 @@
 #ifndef _SELECT_H
 #define _SELECT_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
function 

```
int select(int nfds, fd_set *readfds, fd_set *writefds, fd_set *exceptfds, struct timeval *timeout);
```

should be declared as extern "C", cause in library.js it is defined as simpe C function:

```
  select: function(nfds, readfds, writefds, exceptfds, timeout) {
    // only readfds are supported, not writefds or exceptfds
    // timeout is always 0 - fully async
    assert(!writefds && !exceptfds);
    var ret = 0;
    var l = {{{ makeGetValue('readfds', 0, 'i32') }}};
    var h = {{{ makeGetValue('readfds', 4, 'i32') }}};
    nfds = Math.min(64, nfds); // fd sets have 64 bits
    for (var fd = 0; fd < nfds; fd++) {
      var bit = fd % 32, int = fd < 32 ? l : h;
      if (int & (1 << bit)) {
        // index is in the set, check if it is ready for read
        var info = Sockets.fds[fd];
        if (!info) continue;
        if (info.inQueue.length > 0) ret++;
      }
    }
    return ret;
  },
```

So when i use it from C++ code i have undefined reference to

```
__Z6selectiP13_types_fd_setS0_S0_P7timeval
```
