### PR TITLE
Fix '-1' problem in recv

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -7023,7 +7023,7 @@ LibraryManager.library = {
     if (!info) return -1;
     if (info.inQueue.length == 0) {
       ___setErrNo(ERRNO_CODES.EAGAIN); // no data, and all sockets are nonblocking, so this is the right behavior
-      return 0; // should this be -1 like the spec says?
+      return -1;
     }
     var buffer = info.inQueue.shift();
 #if SOCKET_DEBUG

--- a/tests/websockets.c
+++ b/tests/websockets.c
@@ -50,7 +50,7 @@ unsigned int get_all_buf(int sock, char* output, unsigned int maxsize)
     }
   }
 
-  if(n < 0) {
+  if(n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
     fprintf(stderr, "error in get_all_buf!");
     exit(EXIT_FAILURE);
   }

--- a/tests/websockets_bi.c
+++ b/tests/websockets_bi.c
@@ -35,7 +35,7 @@ unsigned int get_all_buf(int sock, char* output, unsigned int maxsize)
     }
   }
 
-  if(n < 0) {
+  if(n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
     fprintf(stderr, "error in get_all_buf!");
     exit(EXIT_FAILURE);
   }

--- a/tests/websockets_bi_bigdata.c
+++ b/tests/websockets_bi_bigdata.c
@@ -37,7 +37,7 @@ unsigned int get_all_buf(int sock, char* output, unsigned int maxsize)
     }
   }
 
-  if(n < 0) {
+  if(n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
     fprintf(stderr, "error in get_all_buf!");
     exit(EXIT_FAILURE);
   }

--- a/tests/websockets_bi_listener.c
+++ b/tests/websockets_bi_listener.c
@@ -35,7 +35,7 @@ unsigned int get_all_buf(int sock, char* output, unsigned int maxsize)
     }
   }
 
-  if(n < 0) {
+  if(n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
     fprintf(stderr, "error in get_all_buf!");
     exit(EXIT_FAILURE);
   }

--- a/tests/websockets_gethostbyname.c
+++ b/tests/websockets_gethostbyname.c
@@ -35,7 +35,7 @@ unsigned int get_all_buf(int sock, char* output, unsigned int maxsize)
     }
   }
 
-  if(n < 0) {
+  if(n < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
     fprintf(stderr, "error in get_all_buf!");
     exit(EXIT_FAILURE);
   }


### PR DESCRIPTION
Related with https://groups.google.com/forum/?fromgroups=#!topic/emscripten-discuss/0G8yA33ETos.

Websocket tests

```
test_websockets
test_websockets_bi
test_websockets_bi_listen
test_websockets_gethostbyname
test_websockets_bi_bigdata
test_enet
```

passed. 

But i make changes in it. I think '-1' should be tested on real projects?
