### PR TITLE
Partial recive of package in recv (websockets)

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -7029,15 +7029,20 @@ LibraryManager.library = {
       ___setErrNo(ERRNO_CODES.EAGAIN); // no data, and all sockets are nonblocking, so this is the right behavior
       return -1;
     }
-    var buffer = info.inQueue.shift();
+    
+    var readed = info.inQueue[0].subarray(0, len);
+    info.inQueue[0] = info.inQueue[0].subarray(readed.length);
+    
+    if (info.inQueue[0].length == 0) {
+      info.inQueue.shift();
+    } 
+
 #if SOCKET_DEBUG
-    Module.print('recv: ' + [Array.prototype.slice.call(buffer)]);
+    Module.print('recv: ' + [Array.prototype.slice.call(readed)]);
 #endif
-    if (len < buffer.length) {
-      buffer = buffer.subarray(0, len);
-    }
-    HEAPU8.set(buffer, buf);
-    return buffer.length;
+    
+    HEAPU8.set(readed, buf);
+    return readed.length;
   },
 
   send__deps: ['$Sockets'],


### PR DESCRIPTION
Found problem with recv implementation. If length of buffer is more than parameter len then rest of packet is discarded.

For example OpenTTD read length of packet with recv (len = 2 bytes) after that it read rest of  packet with readed length. So in current implementation actual packet data is lost. 

I try to implement right behavior. All websockets test passed.
