### PR TITLE
Move some definitions to sys/features.

### DIFF
--- a/system/include/libc/sys/features.h
+++ b/system/include/libc/sys/features.h
@@ -26,7 +26,10 @@ extern "C" {
 #endif
 
 #if EMSCRIPTEN
-#define _POSIX_REALTIME_SIGNALS 1
+#define _POSIX_REALTIME_SIGNALS          1
+#define _POSIX_THREADS                   200112L
+#define _UNIX98_THREAD_MUTEX_ATTRIBUTES  1
+#define _POSIX_READER_WRITER_LOCKS       200112L
 #endif
 
 /* RTEMS adheres to POSIX -- 1003.1b with some features from annexes.  */

--- a/system/include/libc/sys/types.h
+++ b/system/include/libc/sys/types.h
@@ -24,12 +24,6 @@
 
 #include <machine/_types.h>
 
-#if EMSCRIPTEN
-  #define _POSIX_THREADS
-  #define _UNIX98_THREAD_MUTEX_ATTRIBUTES
-  #define _POSIX_READER_WRITER_LOCKS
-#endif
-
 #if defined(__rtems__) || defined(__XMK__) || defined(EMSCRIPTEN)
 /*
  *  The following section is RTEMS specific and is needed to more


### PR DESCRIPTION
This moves some feature flags to sys/features.h where they belong
and gives them the same values that are established in the settings
file.

Fixes #812.
