### PR TITLE
Implement Firefox workaround for "TypeError: anonymous method called on incompatible string"

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -350,6 +350,12 @@ function ccallFunc(func, returnType, argTypes, args) {
   function toC(value, type) {
     if (type == 'string') {
       if (value === null || value === undefined || value === 0) return 0; // null string
+      // START Firefox workaround
+      // It seems that Firefox optimizes sometimes too hard and therefore 'value' is some kind of unassigned.
+      // Then calling 'value.length' (see below) throws an exception. With the concat of an empty string we can 
+      // workaround that problem.
+      value += ""; // Hope browsers can optimize that call to a no-op
+      // END Firefox workaround
       if (!stack) stack = Runtime.stackSave();
       var ret = Runtime.stackAlloc(value.length+1);
       writeStringToMemory(value, ret);


### PR DESCRIPTION
My theory: It seems that Firefox optimizes sometimes too hard and therefore 'value' in 'ccallFunc/toC' is some kind of unassigned. Then calling 'value.length' in the 'toC' throws an exception. When an empty string is concatenated to 'value' check we can workaround that problem, probably because Firefox JavaScript compiler needs to load a pointer into a register or something like that.
