### PR TITLE
Use the copy composite operation when calling drawImage

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1079,7 +1079,9 @@ var LibrarySDL = {
     }
     var surf = SDL.makeSurface(raw.width, raw.height, 0, false, 'load:' + filename);
     var surfData = SDL.surfaces[surf];
+    surfData.ctx.globalCompositeOperation = "copy";
     surfData.ctx.drawImage(raw, 0, 0, raw.width, raw.height, 0, 0, raw.width, raw.height);
+    surfData.ctx.globalCompositeOperation = "source-over";
     // XXX SDL does not specify that loaded images must have available pixel data, in fact
     //     there are cases where you just want to blit them, so you just need the hardware
     //     accelerated version. However, code everywhere seems to assume that the pixels


### PR DESCRIPTION
This optimizes IMG_Load so that it just does a memcpy as opposed to try
to composite.  The resulting buffer will be the same, it just happens
that we don't need to do all of the work involved in compositing in the
first place.
