### PR TITLE
Statically allocate the strtok state block so it doesn't trip up our leak detection

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4619,10 +4619,8 @@ LibraryManager.library = {
 
   __strtok_state: 0,
   strtok__deps: ['__strtok_state', 'strtok_r'],
+  strtok__postset: '___strtok_state = Runtime.staticAlloc(4);',
   strtok: function(s, delim) {
-    if (!___strtok_state) {
-      ___strtok_state = _malloc(4);
-    }
     return _strtok_r(s, delim, ___strtok_state);
   },
 


### PR DESCRIPTION
This is upstreaming a change from @chadaustin at IMVU.
