### PR TITLE
In allocate() only query native type size when needed

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,4 +49,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Manuel Schölling <manuel.schoelling@gmx.de>
 * Bruce Mitchener, Jr. <bruce.mitchener@gmail.com>
 * Michael Bishop <mbtyke@gmail.com>
+* Lorant Pinter <lorant.pinter@prezi.com>
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -470,6 +470,7 @@ function allocate(slab, types, allocator, ptr) {
 
     setValue(ret+i, curr, type);
 
+    // no need to look up size unless type changes, so cache it
     if (previousType !== type) {
       typeSize = Runtime.getNativeTypeSize(type);
       previousType = type;


### PR DESCRIPTION
I'm trying to get an application work with IE8 (yeah, I know), and it works okay-ish, but the load time is very long, so I started investigating. And it appears that inside the code generated for allocate() there's a call to getNativeTypeSize() for each setValue() call. Apparently getNativeTypeSize() is really slow on IE8, so it adds a hefty amount to load time.

Original Layout JS with IE8:

```
                       COUNT   INC.TIME  EXCL.TIME
getNativeTypeSize    123,433   2,453.53   2,453.53
unserialize              124     891.28     490.71
setValue             123,869     320.46     260.37
_memset                   19     260.37     260.37
Array.push           571,398     200.29     200.29
Array.splice               2     200.29     200.29
JScript - window           1   3,064.41     160.23
```

However, getNativeTypeSize() does not need calling for every single value. In fact, in most cases it will be the same for all of them. With a trivial caching trick I could get the number of calls to getNativeTypeSize() down from 123869 to 2059, and essentially saving more than two seconds on the load time:

With type size caching:

```
                       COUNT   INC.TIME  EXCL.TIME
unserialize              124     821.18     470.68
setValue             123,869     300.43     300.43
_memset                   19     300.43     300.43
Array.splice               2     200.29     200.29
allocate                 608     761.09     150.22
alloc                      2     250.36     140.20
Array.push           571,398     110.16     110.16
String.charCodeAt    755,890     100.14     100.14
```

The change in the pull request fixes this.
