### PR TITLE
Fix crash when using optimization to build libmp3lame.

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1697,8 +1697,10 @@ function getGetElementPtrIndexes(item) {
       // We have a *variable* to index with, or a negative number. In both
       // cases, in theory we might need to do something dynamic here. FIXME?
       // But, most likely all the possible types are the same, so do that case here now...
-      for (var i = 1; i < typeData.fields.length; i++) {
-        assert(typeData.fields[0] === typeData.fields[i]);
+      if (typeData) {
+        for (var i = 1; i < typeData.fields.length; i++) {
+          assert(typeData.fields[0] === typeData.fields[i]);
+        }
       }
       curr = 0;
     }


### PR DESCRIPTION
Hi,

I discovered that building libmp3lame using emscripten would crash if I use any optimization flags. That's how I build libmp3lame with emscripten: https://github.com/akrennmair/libmp3lame-js

I dug a little deeper, and found out that the problem lies in src/parseTools.js:1700. That's where the whole thing crashes because typeData is null, but fields are referenced without any further checks. When I surrounded the whole thing by an additional check on the validity of typeData. With this change, the issue goes away and I can build libmp3lame with -O2.

Best regards,
Andreas Krennmair
