### PR TITLE
Added support for querying client attribute state through `glGet*`.

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -118,6 +118,16 @@ var LibraryGL = {
                ((height - 1) * alignedRowSize + plainRowSize);
     },
 
+    getAttribute: function(cap) {
+      var result;
+      var attrib = GL.immediate.clientAttributeIndexForGLEnum(cap);
+      if ( attrib === null )
+        result = Module.ctx.getParameter(cap);
+      else
+        result = GL.immediate.enabledClientAttributes[attrib];
+      return result;
+    },
+
     getTexPixelData: function(type, format, width, height, pixels, internalFormat) {
       var sizePerPixel;
       switch (type) {
@@ -227,7 +237,7 @@ var LibraryGL = {
         {{{ makeSetValue('p', '0', '0', 'i32') }}};
         return;
     }
-    var result = Module.ctx.getParameter(name_);
+    var result = GL.getAttribute(name_);
     switch (typeof(result)) {
       case "number":
         {{{ makeSetValue('p', '0', 'result', 'i32') }}};
@@ -269,7 +279,7 @@ var LibraryGL = {
   },
 
   glGetFloatv: function(name_, p) {
-    var result = Module.ctx.getParameter(name_);
+    var result = GL.getAttribute(name_);
     switch (typeof(result)) {
       case "number":
         {{{ makeSetValue('p', '0', 'result', 'float') }}};
@@ -311,7 +321,8 @@ var LibraryGL = {
   },
 
   glGetBooleanv: function(name_, p) {
-    var result = Module.ctx.getParameter(name_);
+    var result = GL.getAttribute(name_);
+
     switch (typeof(result)) {
       case "number":
         {{{ makeSetValue('p', '0', 'result != 0', 'i8') }}};
@@ -1608,6 +1619,22 @@ var LibraryGL = {
       this.modifiedClientAttributes = true;
     },
 
+    clientAttributeIndexForGLEnum: function(cap) {
+      switch(cap) {
+        case 0x8078: // GL_TEXTURE_COORD_ARRAY
+        case 0x0de1: // GL_TEXTURE_2D - XXX not according to spec, and not in desktop GL, but works in some GLES1.x apparently, so support it
+          return GL.immediate.TEXTURE0 + GL.immediate.clientActiveTexture; break;
+        case 0x8074: // GL_VERTEX_ARRAY
+          return GL.immediate.VERTEX; break;
+        case 0x8075: // GL_NORMAL_ARRAY
+          return GL.immediate.NORMAL; break;
+        case 0x8076: // GL_COLOR_ARRAY
+          return GL.immediate.COLOR; break;
+        default:
+          return null;
+        }
+    },
+
     // Temporary buffers
     MAX_TEMP_BUFFER_SIZE: {{{ GL_MAX_TEMP_BUFFER_SIZE }}},
     tempBufferIndexLookup: null,
@@ -2449,18 +2476,9 @@ var LibraryGL = {
   // ClientState/gl*Pointer
 
   glEnableClientState: function(cap, disable) {
-    var attrib;
-    switch(cap) {
-      case 0x8078: // GL_TEXTURE_COORD_ARRAY
-      case 0x0de1: // GL_TEXTURE_2D - XXX not according to spec, and not in desktop GL, but works in some GLES1.x apparently, so support it
-        attrib = GL.immediate.TEXTURE0 + GL.immediate.clientActiveTexture; break;
-      case 0x8074: // GL_VERTEX_ARRAY
-        attrib = GL.immediate.VERTEX; break;
-      case 0x8075: // GL_NORMAL_ARRAY
-        attrib = GL.immediate.NORMAL; break;
-      case 0x8076: // GL_COLOR_ARRAY
-        attrib = GL.immediate.COLOR; break;
-      default:
+    var attrib = GL.immediate.clientAttributeIndexForGLEnum( cap );
+    if (attrib === null)
+    {
 #if ASSERTIONS
         Module.printErr('WARNING: unhandled clientstate: ' + cap);
 #endif

--- a/tests/sdl_ogl_p.c
+++ b/tests/sdl_ogl_p.c
@@ -28,6 +28,7 @@ REDISTRIBUTION OF THIS SOFTWARE.
 
 #include <stdio.h>
 #include <string.h>
+#include <assert.h>
 
 int main(int argc, char *argv[])
 {
@@ -135,6 +136,14 @@ int main(int argc, char *argv[])
     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
     glTexCoordPointer(2, GL_FLOAT, 4*4, &vertexData[0]);
     glEnableClientState(GL_VERTEX_ARRAY);
+    // test to see that the state was set
+	GLboolean b = GL_FALSE;
+	glGetBooleanv(GL_VERTEX_ARRAY, &b);
+	if (b != GL_TRUE)
+	{
+		fprintf(stderr, "glGetBooleanv(GL_VERTEX_ARRAY) should return true!");
+	}
+	assert(b == GL_TRUE);
     glVertexPointer(2, GL_FLOAT, 4*4, &vertexData[2]);
 
     glDrawArrays(GL_QUADS, 0, 8);


### PR DESCRIPTION
All the `glGet*` calls will first see if the attribute passed in is an attribute recognized by `glEnableClientState`
and if so, will retrieve that from `GL.immediate.enabledClientAttributes`.
Otherwise, it will call into WebGL for the value of the attribute.
Modified test included.
