### PR TITLE
Added support in glGetBooleanv GL_VERTEX_ARRAY.

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -1058,12 +1058,20 @@ var LibraryGL = {
 
       var glGetBooleanv = _glGetBooleanv;
       _glGetBooleanv = function(pname, p) {
-      var result = null;
+        var attrib = null;
         switch (pname) {
+          case 0x8078: // GL_TEXTURE_COORD_ARRAY
+          case 0x0de1: // GL_TEXTURE_2D - XXX not according to spec, and not in desktop GL, but works in some GLES1.x apparently, so support it
+            attrib = GL.immediate.TEXTURE0 + GL.immediate.clientActiveTexture; break;
           case 0x8074: // GL_VERTEX_ARRAY
-            result = GL.immediate.enabledClientAttributes[GL.immediate.VERTEX];
-            {{{ makeSetValue('p', '0', 'result === true ? 1 : 0', 'i8') }}};
-            return;
+            attrib = GL.immediate.VERTEX; break;
+          case 0x8076: // GL_COLOR_ARRAY
+            attrib = GL.immediate.COLOR; break;
+        }
+        if (attrib != null) {
+          var result = GL.immediate.enabledClientAttributes[attrib];
+          {{{ makeSetValue('p', '0', 'result === true ? 1 : 0', 'i8') }}};
+          return;
         }
         glGetBooleanv(pname, p);
       };


### PR DESCRIPTION
`glGetBooleanv` now supports the enum `GL_VERTEX_ARRAY` (implemented in emulation mode)
