### PR TITLE
Reverse the order of function lookup in getCFunc() to avoid eval()

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -251,9 +251,7 @@ Module["ccall"] = ccall;
 // Returns the C function with a specified identifier (for C++, you need to do manual name mangling)
 function getCFunc(ident) {
   try {
-    try {
-      var func = globalScope['Module']['_' + ident]; // closure exported function
-    } catch(e) {}
+    var func = globalScope['Module']['_' + ident]; // closure exported function
     if (!func) func = eval('_' + ident); // explicit lookup
   } catch(e) {
   }


### PR DESCRIPTION
Is there a particular reason why `getCFunc()` looks up functions via `eval()` first, and only if that fails does it look in `Module[]`? If this could be reversed, `eval()` would not have to be called to look up functions that are already exported through closure.
