### PR TITLE
Add CHECK_HEAP_ALIGN to perform runtime alignment checks

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -345,6 +345,7 @@ def emscript(infile, settings, outfile, libraries=[]):
     asm_setup += '\n'.join(['var %s = %s;' % (f.replace('.', '_'), f) for f in math_envs])
     basic_funcs = ['abort', 'assert', 'asmPrintInt', 'asmPrintFloat', 'copyTempDouble', 'copyTempFloat'] + [m.replace('.', '_') for m in math_envs]
     if settings['SAFE_HEAP']: basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_STORE', 'SAFE_HEAP_CLEAR']
+    if settings['CHECK_HEAP_ALIGN']: basic_funcs += ['CHECK_ALIGN_2', 'CHECK_ALIGN_4', 'CHECK_ALIGN_8']
     basic_vars = ['STACKTOP', 'STACK_MAX', 'tempDoublePtr', 'ABORT']
     basic_float_vars = ['NaN', 'Infinity']
     if forwarded_json['Types']['preciseI64MathUsed']:

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -185,7 +185,7 @@ if (phase == 'pre') {
     print('// Note: For maximum-speed code, see "Optimizing Code" on the Emscripten wiki, https://github.com/kripken/emscripten/wiki/Optimizing-Code');
   }
 
-  if (DOUBLE_MODE || CORRECT_SIGNS || CORRECT_OVERFLOWS || CORRECT_ROUNDINGS) {
+  if (DOUBLE_MODE || CORRECT_SIGNS || CORRECT_OVERFLOWS || CORRECT_ROUNDINGS || CHECK_HEAP_ALIGN) {
     print('// Note: Some Emscripten settings may limit the speed of the generated code.');
   }
 }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -984,18 +984,24 @@ function checkSafeHeap() {
 function getHeapOffset(offset, type, forceAsm) {
   if (USE_TYPED_ARRAYS !== 2) {
     return offset;
-  } else {
-    if (Runtime.getNativeFieldSize(type) > 4) {
-      type = 'i32'; // XXX we emulate 64-bit values as 32
-    }
-    var shifts = Math.log(Runtime.getNativeTypeSize(type))/Math.LN2;
-    offset = '(' + offset + ')';
-    if (shifts != 0) {
-      return '(' + offset + '>>' + shifts + ')';
+  }
+
+  if (Runtime.getNativeFieldSize(type) > 4) {
+    type = 'i32'; // XXX we emulate 64-bit values as 32
+  }
+
+  var sz = Runtime.getNativeTypeSize(type);
+  var shifts = Math.log(sz)/Math.LN2;
+  offset = '(' + offset + ')';
+  if (shifts != 0) {
+    if (CHECK_HEAP_ALIGN) {
+      return '(CHECK_ALIGN_' + sz + '(' + offset + ')>>' + shifts + ')';
     } else {
-      // we need to guard against overflows here, HEAP[U]8 expects a guaranteed int
-      return isJSVar(offset) ? offset : '(' + offset + '|0)';
+      return '(' + offset + '>>' + shifts + ')';
     }
+  } else {
+    // we need to guard against overflows here, HEAP[U]8 expects a guaranteed int
+    return isJSVar(offset) ? offset : '(' + offset + '|0)';
   }
 }
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -150,6 +150,25 @@ function SAFE_HEAP_COPY_HISTORY(dest, src) {
 //==========================================
 #endif
 
+#if CHECK_HEAP_ALIGN
+//========================================
+// Debugging tools - alignment check
+//========================================
+function CHECK_ALIGN_8(addr) {
+  assert((addr & 7) == 0, "address must be 8-byte aligned, is " + addr + "!");
+  return addr;
+}
+function CHECK_ALIGN_4(addr) {
+  assert((addr & 3) == 0, "address must be 4-byte aligned, is " + addr + "!");
+  return addr;
+}
+function CHECK_ALIGN_2(addr) {
+  assert((addr & 1) == 0, "address must be 2-byte aligned!");
+  return addr;
+}
+#endif
+
+
 #if CHECK_OVERFLOWS
 //========================================
 // Debugging tools - Mathop overflows

--- a/src/settings.js
+++ b/src/settings.js
@@ -128,6 +128,9 @@ var SAFE_HEAP = 0; // Check each write to the heap, for example, this will give 
                    // that 3 is the option you usually want here.
 var SAFE_HEAP_LOG = 0; // Log out all SAFE_HEAP operations
 
+var CHECK_HEAP_ALIGN = 0; // Check heap accesses for alignment, but don't do as
+                          // near extensive (or slow) checks as SAFE_HEAP.
+
 var SAFE_DYNCALLS = 0; // Show stack traces on missing function pointer/virtual method calls
 
 var ASM_HEAP_LOG = 0; // Simple heap logging, like SAFE_HEAP_LOG but cheaper, and in asm.js


### PR DESCRIPTION
Adds a much cheaper CHECK_HEAP_ALIGN option to do heap access
alignment checks.  Less extensive than SAFE_HEAP, but also much
cheaper.
