### PR TITLE
Add glVertex3i and glVertex2i calls

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -2332,8 +2332,10 @@ var LibraryGL = {
   glVertex2fv: function(p) {
     _glVertex3f({{{ makeGetValue('p', '0', 'float') }}}, {{{ makeGetValue('p', '4', 'float') }}}, 0);
   },
+  
+  glVertex3i: 'glVertex3f',
 
-  glVertex2i: function() { throw 'glVertex2i: TODO' },
+  glVertex2i: 'glVertex3f',
 
   glTexCoord2i: function(u, v) {
 #if ASSERTIONS


### PR DESCRIPTION
These are basically just aliases for the glVertex3f function.
Javascript seems to convert the integers to float values correctly.
However, I did not follow the code path through the immediate mode
emulation to know for sure. In my applications it works for "normal", small
values (e.g. 1, 500, 1000, ...).
