### PR TITLE
Add Runtime.removeFunction()

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -365,7 +365,7 @@ var Runtime = {
     return ret;
   },
 
-  removeFunction: function(index, func) {
+  removeFunction: function(index) {
     var table = FUNCTION_TABLE; // TODO: support asm
     table[index] = null;
   },


### PR DESCRIPTION
I'm using `Runtime.addFunction()` to register some callbacks that in turn hold reference to large objects. When I have no use for these functions (and their referenced objects), it would be nice if these functions could be unregistered so that my large objects could be garbage collected.
