### PR TITLE
select function: return error condition when network connection fails

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -7306,6 +7306,10 @@ LibraryManager.library = {
       // make sure socket exists. 
       // we do create it when the socket is connected, 
       // but other implementations may create it lazily
+      if ((info.socket.readyState == WebSocket.CLOSING || info.socket.readyState == WebSocket.CLOSED)) {
+        errorCondition = -1;
+        return false;
+      }
       return info.socket && (info.socket.readyState == info.socket.OPEN);
     }
 

--- a/tests/websockets_select.c
+++ b/tests/websockets_select.c
@@ -1,0 +1,95 @@
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <assert.h>
+#if EMSCRIPTEN
+#include <emscripten.h>
+#endif
+
+#define EXPECTED_BYTES 5
+
+int SocketFD;
+
+int done = 0;
+
+void iter(void *arg) {  
+  fd_set sett;
+  FD_ZERO(&sett);
+  FD_SET(SocketFD, &sett);
+  
+  // The error should happen here
+  int select_says_yes = select(64, &sett, NULL, NULL, NULL);
+  if( select_says_yes == -1 ){
+    printf( "Connection to websocket server failed as expected." );
+    perror( "Error message" );
+    int result = 266;
+    REPORT_RESULT();
+    done = 1;
+  }
+
+  assert(!select_says_yes);
+  done = 1;
+}
+
+// This is for testing a websocket connection to a closed server port.
+// The connect call will succeed (due to the asynchronous websocket
+// behavior) but once the underlying websocket system realized that 
+// the connection cannot be established, the next select call will fail.
+int main(void)
+{
+  struct sockaddr_in stSockAddr;
+  int Res;
+  SocketFD = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+  if (-1 == SocketFD)
+  {
+    perror("cannot create socket");
+    exit(EXIT_FAILURE);
+  }
+
+  memset(&stSockAddr, 0, sizeof(stSockAddr));
+
+  stSockAddr.sin_family = AF_INET;
+  stSockAddr.sin_port = htons(
+#if EMSCRIPTEN
+    8995
+#else
+    8994
+#endif
+  );
+  Res = inet_pton(AF_INET, "127.0.0.1", &stSockAddr.sin_addr);
+
+  if (0 > Res) {
+    perror("error: first parameter is not a valid address family");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+  } else if (0 == Res) {
+    perror("char string (second parameter does not contain valid ipaddress)");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+  }
+
+  // This call should succeed (even if the server port is closed)
+  if (-1 == connect(SocketFD, (struct sockaddr *)&stSockAddr, sizeof(stSockAddr))) {
+    perror("connect failed");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+
+  }
+
+#if EMSCRIPTEN
+  emscripten_set_main_loop(iter, 0, 0);
+#else
+  while (!done) iter(NULL);
+#endif
+
+  return EXIT_SUCCESS;
+}
+

--- a/tests/websockets_select_server_closes_connection.c
+++ b/tests/websockets_select_server_closes_connection.c
@@ -1,0 +1,126 @@
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <assert.h>
+#if EMSCRIPTEN
+#include <emscripten.h>
+#endif
+
+#define EXPECTED_BYTES 5
+
+int SocketFD;
+
+int done = 0;
+
+void iter(void *arg) {  
+  static char readbuf[1024];
+  static int readPos = 0;
+  
+  fd_set sett;
+  FD_ZERO(&sett);
+  FD_SET(SocketFD, &sett);
+  
+  if( readPos < 7 ){
+    // still reading
+    int selectRes = select(64, &sett, NULL, NULL, NULL);
+    
+    if( selectRes == 0 )
+      return;
+    
+    if( selectRes == -1 ){
+      perror( "Connection to websocket server failed" );
+      exit(EXIT_FAILURE);
+    }
+    if( selectRes > 0 ){
+      assert(FD_ISSET(SocketFD, &sett));
+      
+      int bytesRead = recv( SocketFD, readbuf+readPos, 7-readPos, 0 );
+      readPos += bytesRead;
+    }
+  } else {
+    // here the server should have closed the connection
+    int selectRes = select(64, &sett, NULL, NULL, NULL);
+    
+    if( selectRes == 0 )
+      return;
+    
+    if( selectRes == -1 ){
+      perror( "Connection to websocket server failed as expected" );
+      int result = 266;
+      REPORT_RESULT();
+      emscripten_cancel_main_loop();
+      done = 1;
+    } 
+    
+    if( selectRes > 0 ){
+      printf( "Error: socket should not show up on select call anymore.\n" );
+      exit(EXIT_FAILURE);
+    }     
+  }
+  
+  return;
+}
+
+// Scenario: the server sends data and closes the connection after 7 bytes. 
+// This test should provoke the situation in which the underlying 
+// tcp connection has been torn down already but there is still data 
+// in the inQueue. The select call has to succeed as long the queue
+// still contains data and only then start to throw errors.
+int main(void)
+{
+  struct sockaddr_in stSockAddr;
+  int Res;
+  SocketFD = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+  if (-1 == SocketFD)
+  {
+    perror("cannot create socket");
+    exit(EXIT_FAILURE);
+  }
+
+  memset(&stSockAddr, 0, sizeof(stSockAddr));
+
+  stSockAddr.sin_family = AF_INET;
+  stSockAddr.sin_port = htons(
+#if EMSCRIPTEN
+    8995
+#else
+    8994
+#endif
+  );
+  Res = inet_pton(AF_INET, "127.0.0.1", &stSockAddr.sin_addr);
+
+  if (0 > Res) {
+    perror("error: first parameter is not a valid address family");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+  } else if (0 == Res) {
+    perror("char string (second parameter does not contain valid ipaddress)");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+  }
+
+  // This call should succeed (even if the server port is closed)
+  if (-1 == connect(SocketFD, (struct sockaddr *)&stSockAddr, sizeof(stSockAddr))) {
+    perror("connect failed");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+
+  }
+
+#if EMSCRIPTEN
+  emscripten_set_main_loop(iter, 0, 0);
+#else
+  while (!done) iter(NULL);
+#endif
+
+  return EXIT_SUCCESS;
+}
+

--- a/tests/websockets_select_server_closes_connection_rw.c
+++ b/tests/websockets_select_server_closes_connection_rw.c
@@ -1,0 +1,213 @@
+#include <errno.h>
+#include <sys/types.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/ioctl.h>
+#include <assert.h>
+#if EMSCRIPTEN
+#include <emscripten.h>
+#endif
+
+#define EXPECTED_BYTES 5
+
+int SocketFD;
+
+int done = 0;
+
+void iter(void *arg) {
+  static int state = 0;
+  static char writebuf[] = "01234567890123456789";
+  static int writePos = 0;
+  static char readbuf[1024];
+  static int readPos = 0;
+  int selectRes;
+  ssize_t transferAmount;
+  fd_set sett;
+  
+  
+  switch( state ){
+    case 0:
+      // writing 10 bytes to the server
+      
+      // the socket in the read file descriptors has to result in a 0 return value
+      // because the connection exists, but there is no data yet
+      FD_ZERO( &sett );
+      FD_SET(SocketFD, &sett);
+      selectRes = select(64, &sett, NULL, NULL, NULL);
+      if( selectRes != 0 ){
+        printf( "case 0: read select != 0\n" );
+        exit(EXIT_FAILURE);
+      }
+      
+      // the socket in the write file descriptors has to result in either a 0 or 1
+      // the connection either is setting up or is established and writing is possible
+      FD_ZERO( &sett );
+      FD_SET(SocketFD, &sett);
+      selectRes = select(64, NULL, &sett, NULL, NULL);
+      if( selectRes == -1 ){
+        printf( "case 0: write select == -1\n" );
+        exit(EXIT_FAILURE);
+      }
+      if( selectRes == 0 ){
+        return;
+      }
+      
+      // send a single byte
+      transferAmount = send( SocketFD, writebuf+writePos, 1, 0 );
+      writePos += transferAmount;
+   
+      // after 10 bytes switch to next state
+      if( writePos >= 10 ){
+        state = 1;
+      }
+      break;
+      
+    case 1:
+      // wait until we can read one byte to make sure the server
+      // has sent the data and then closed the connection
+      FD_ZERO( &sett );
+      FD_SET(SocketFD, &sett);
+      selectRes = select(64, &sett, NULL, NULL, NULL);
+      if( selectRes == -1 ){
+        printf( "case 1: read selectRes == -1\n" );
+        exit(EXIT_FAILURE);
+      }
+      if( selectRes == 0 )
+        return;
+
+      // read a single byte
+      transferAmount = recv( SocketFD, readbuf+readPos, 1, 0 );
+      readPos += transferAmount;
+   
+      // if successfully reading 1 byte, switch to next state
+      if( readPos >= 1 ){
+        state = 2;
+      }
+      break;
+    
+    case 2:
+      // calling select with the socket in the write file descriptors has
+      // to fail because the tcp network connection is already down
+      FD_ZERO( &sett );
+      FD_SET(SocketFD, &sett);
+      selectRes = select(64, NULL, &sett, NULL, NULL);
+      if( selectRes != -1 ){
+        printf( "case 2: write selectRes != -1\n" );
+        exit(EXIT_FAILURE);
+      }
+
+      // calling select with the socket in the read file descriptors 
+      // has to succeed because there is still data in the inQueue
+      FD_ZERO( &sett );
+      FD_SET(SocketFD, &sett);
+      selectRes = select(64, &sett, NULL, NULL, NULL);
+      if( selectRes != 1 ){
+        printf( "case 2: read selectRes != 1\n" );
+        exit(EXIT_FAILURE);
+      }
+      if( selectRes == 0 )
+        return;
+      
+      // read a single byte
+      transferAmount = recv( SocketFD, readbuf+readPos, 1, 0 );
+      readPos += transferAmount;
+      
+      // with 10 bytes read the inQueue is empty => switch state
+      if( readPos >= 10 ){
+        state = 3;
+      }
+      break;
+      
+    case 3:
+      // calling select with the socket in the read file descriptors 
+      // now also has to fail as the inQueue is empty
+      FD_ZERO( &sett );
+      FD_SET(SocketFD, &sett);
+      selectRes = select(64, &sett, NULL, NULL, NULL);
+      if( selectRes != -1 ){
+        printf( "case 3: read selectRes != -1\n" );
+        exit(EXIT_FAILURE);
+      }
+      
+      // report back success, the 266 is just an arbitrary value without 
+      // deeper meaning
+      int result = 266;
+      REPORT_RESULT();
+      break;
+      
+    default:
+      printf( "Impossible state!\n" );
+      exit(EXIT_FAILURE);
+      break;
+  }
+  
+  return;
+}
+
+// This test checks for an intended asymmetry in the behavior of the select function.
+// Scenario: the client sends data to the server. After 10 received bytes the 
+// server sends 10 bytes on its own and immediately afterwards closes the connection.
+// This mimics a typical connect-request-response-disconnect situation.
+// After the server closed the connection select calls with the socket in the write file 
+// descriptors have to fail as the tcp connection is already down and there is no way 
+// anymore to send data. 
+// Select calls with the socket in the read file descriptor list still have to succeed 
+// as there are still 10 bytes to read from the inQueue. So, for the same socket the 
+// select call behaves differently depending on whether the socket is listed in the
+// read or write file descriptors.
+int main(void)
+{
+  struct sockaddr_in stSockAddr;
+  int Res;
+  SocketFD = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+  if (-1 == SocketFD)
+  {
+    perror("cannot create socket");
+    exit(EXIT_FAILURE);
+  }
+
+  memset(&stSockAddr, 0, sizeof(stSockAddr));
+
+  stSockAddr.sin_family = AF_INET;
+  stSockAddr.sin_port = htons(
+#if EMSCRIPTEN
+    8999
+#else
+    8998
+#endif
+  );
+  Res = inet_pton(AF_INET, "127.0.0.1", &stSockAddr.sin_addr);
+
+  if (0 > Res) {
+    perror("error: first parameter is not a valid address family");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+  } else if (0 == Res) {
+    perror("char string (second parameter does not contain valid ipaddress)");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+  }
+
+  // This call should succeed (even if the server port is closed)
+  if (-1 == connect(SocketFD, (struct sockaddr *)&stSockAddr, sizeof(stSockAddr))) {
+    perror("connect failed");
+    close(SocketFD);
+    exit(EXIT_FAILURE);
+
+  }
+
+#if EMSCRIPTEN
+  emscripten_set_main_loop(iter, 0, 0);
+#else
+  while (!done) iter(NULL);
+#endif
+
+  return EXIT_SUCCESS;
+}
+


### PR DESCRIPTION
With this change the **select** function can report if the network connection failed to set up
(e.g. server down) or if an existing connection gets disconnected (e.g. TCP timeout).

This is especially important as the asynchronous **connect** call cannot report connection setup errors. Such errors need to be diagnosed by the following **select**, **recv**, **send**
calls. This commit here only implements the error handling for the **select** function, as this is as far my test code goes. I didn't look at the **recv** and **send** calls yet.

Note the preceding discussion in https://github.com/kripken/emscripten/pull/857 .
