### PR TITLE
Ensure __bool_true_false_are_defined is defined.

### DIFF
--- a/system/include/stdbool.h
+++ b/system/include/stdbool.h
@@ -2,12 +2,13 @@
 #ifndef __stdbool_h__
 #define __stdbool_h__
 
+#define __bool_true_false_are_defined 1
+
 #ifndef __cplusplus
 
 #define bool                          _Bool
 #define true                          1
 #define false                         0
-#define __bool_true_false_are_defined 1
 
 #endif
 


### PR DESCRIPTION
Previously, when compiling in C++ mode, this wasn't defined which
led to test failures for the libcxx test suite.

This now behaves like it does on other platforms.
