### PR TITLE
Implement _SC_NPROCESSORS_ONLN.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2403,6 +2403,7 @@ LibraryManager.library = {
       case {{{ cDefine('_SC_STREAM_MAX') }}}: return 16;
       case {{{ cDefine('_SC_TZNAME_MAX') }}}: return 6;
       case {{{ cDefine('_SC_THREAD_DESTRUCTOR_ITERATIONS') }}}: return 4;
+      case {{{ cDefine('_SC_NPROCESSORS_ONLN') }}}: return 1;
     }
     ___setErrNo(ERRNO_CODES.EINVAL);
     return -1;


### PR DESCRIPTION
This lets std::hardware_concurrency() give a valid return value.
