### PR TITLE
Add V8_STACK_SIZE and some misc debug options

### DIFF
--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -12,10 +12,18 @@ def timeout_run(proc, timeout, note='unnamed process', full_output=False):
   out = proc.communicate()
   return '\n'.join(out) if full_output else out[0]
 
-def run_js(filename, engine=None, args=[], check_timeout=False, stdout=PIPE, stderr=None, cwd=None, full_output=False):
+def run_js(filename, engine=None, args=[], check_timeout=False, stdout=PIPE, stderr=None, cwd=None, full_output=False, v8_stack_size=None, DEBUG=False):
   if type(engine) is not list:
     engine = [engine]
+
+  if v8_stack_size:
+    if 'node' in engine[0]: engine += ['--max-stack-size=%d' % (v8_stack_size * 1024)]
+    if 'node' in engine[0] or 'd8' in engine[0]: engine += ['--stack_size=%d' % (v8_stack_size)]
+
   command = engine + [filename] + (['--'] if 'd8' in engine[0] else []) + args
+
+  if DEBUG: print >>sys.stderr, "run_js: " + " ".join(command)
+    
   return timeout_run(
     Popen(
       command,

--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -35,6 +35,17 @@ COMPILER_ENGINE = NODE_JS
 #COMPILER_ENGINE = V8_ENGINE
 #COMPILER_ENGINE = SPIDERMONKEY_ENGINE
 
+# The default stack size for d8/node needs to be increased for some large projects,
+# especially on Windows.
+#
+# On Windows, this requires a node/d8 binary modified via
+# 'editbin /stack:33554432 node.exe' or built with the same stack
+# flag (in bytes) passed to the linker.
+#
+# Stack size, in kb.  If not specified, the default is used.  The environment
+# variable EMCC_V8_STACK_SIZE can also be used to control this (env var takes
+# precedence).
+#V8_STACK_SIZE = 16384
 
 # All JS engines to use when running the automatic tests. Not all the engines in this list
 # must exist (if they don't, they will be skipped in the test runner).


### PR DESCRIPTION
The V8_STACK_SIZE config option and EMCC_V8_STACK_SIZE environment
variable can be used to control the V8 stack size, which is
especially importat on windows for large codebases.

Also adds some debug prints and options, including EMCC_DEBUG=serialize
which will still chunkify processing, but execute serially in the same
thread instead of using multiprocessing.
