### PR TITLE
-fcatch-undefined-behavior is deprecated.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -8743,7 +8743,7 @@ f.close()
           return 0;
         }
       ''')
-      Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'test.cpp'), '-fcatch-undefined-behavior']).communicate()
+      Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'test.cpp'), '-fsanitize=undefined']).communicate()
       self.assertContained('hello, world!', run_js(os.path.join(self.get_dir(), 'a.out.js')))
 
     def test_unaligned_memory(self):


### PR DESCRIPTION
Use -fsanitize=undefined.
