### PR TITLE
Emit correct code for setjmp() calls when in UNALIGNED_MEMORY mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -52,4 +52,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Roger Braun <roger@rogerbraun.net>
 * Vladimir Vukicevic <vladimir@pobox.com> (copyright owned by Mozilla Foundation)
 * Lorant Pinter <lorant.pinter@prezi.com>
+* Tobias Doerffel <tobias.doerffel@gmail.com>
 

--- a/src/library.js
+++ b/src/library.js
@@ -6188,7 +6188,7 @@ LibraryManager.library = {
 
   setjmp__inline: function(env) {
     // Save the label
-    return '(tempInt = setjmpId++, mySetjmpIds[tempInt] = 1, setjmpLabels[tempInt] = label,' + makeSetValue(env, '0', 'tempInt', 'i32') + ', 0)';
+    return '(tempInt = setjmpId++, mySetjmpIds[tempInt] = 1, setjmpLabels[tempInt] = label,' + makeSetValue(env, '0', 'tempInt', 'i32', undefined, undefined, undefined, undefined,  ',') + ', 0)';
   },
 
   longjmp: function(env, value) {


### PR DESCRIPTION
makeSetValue() returns multiple statements when in UNALIGNED_MEMORY
mode and thus have to be separated by commas in this context.
