### PR TITLE
toNiceIdent() doesn't handle exclamation marks

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,4 +54,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Lorant Pinter <lorant.pinter@prezi.com>
 * Tobias Doerffel <tobias.doerffel@gmail.com>
 * Martin von Gagern <martin@von-gagern.net>
+* Ben Karel <eschew@gmail.com>
 

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -79,7 +79,7 @@ function toNiceIdent(ident) {
   if (parseFloat(ident) == ident) return ident;
   if (ident == 'null') return '0'; // see parseNumerical
   if (ident == 'undef') return '0';
-  return ident.replace('%', '$').replace(/["&\\ \.@:<>,\*\[\]\(\)-]/g, '_');
+  return ident.replace('%', '$').replace(/["&\\ \.!@:<>,\*\[\]\(\)-]/g, '_');
 }
 
 // Kind of a hack. In some cases we have strings that we do not want

--- a/tests/hello_world_bang.ll
+++ b/tests/hello_world_bang.ll
@@ -1,0 +1,18 @@
+; ModuleID = 'tests/hello_world.bc'
+target datalayout = "e-p:32:32:32-i1:8:8-i8:8:8-i16:16:16-i32:32:32-i64:32:64-f32:32:32-f64:32:64-v64:64:64-v128:128:128-a0:0:64-f80:32:32-n8:16:32-S128"
+target triple = "i386-pc-linux-gnu"
+
+@.str = private unnamed_addr constant [15 x i8] c"hello, world!\0A\00", align 1 ; [#uses=1 type=[15 x i8]*]
+
+; [#uses=0]
+define i32 @main() {
+entry:
+  %"!retval" = alloca i32, align 4                   ; [#uses=1 type=i32*]
+  store i32 1, i32* %"!retval"
+  %call = call i32 (i8*, ...)* @printf(i8* getelementptr inbounds ([15 x i8]* @.str, i32 0, i32 0)) ; [#uses=0 type=i32]
+  %rv = load i32* %"!retval"
+  ret i32 %rv
+}
+
+; [#uses=1]
+declare i32 @printf(i8*, ...)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -8626,6 +8626,12 @@ Options that are modified or new in %s include:
         assert os.path.exists('a.out.js'), '\n'.join(output)
         self.assertContained('hello, world!', run_js('a.out.js'))
 
+        self.clear()
+        output = Popen([PYTHON, compiler, path_from_root('tests', 'hello_world_bang.ll')], stdout=PIPE, stderr=PIPE).communicate()
+        assert len(output[0]) == 0, output[0]
+        assert os.path.exists('a.out.js'), '\n'.join(output)
+        self.assertContained('hello, world!', run_js('a.out.js'))
+
         # emcc [..] -o [path] ==> should work with absolute paths
         try:
           os.mkdir('a_dir')


### PR DESCRIPTION
Pull request corresponding to issue #896... attempt two.

Alon, I sincerely apologize for any mail-spam this has caused.

I ran the full test suite with this patch applied the other night, and the only errors were related to not having `scons` or the `CRUNCH` package installed.

With the augmented test suite but not the tweak to `src/parseTools.js` :

```
$ python tests/runner.py other.test_emcc
Running Emscripten tests...
(Emscripten: Running sanity checks)
test_emcc (__main__.other) ... 
/tmp/emscripten_test_other_oKQpMu/a.out.js:2175
  var $_!retval_;
        ^
SyntaxError: Unexpected token !
    at Module._compile (module.js:437:25)
    at Object.Module._extensions..js (module.js:467:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.runMain (module.js:492:10)
    at process.startup.processNextTick.process._tickCallback (node.js:244:9)
ERROR

======================================================================
ERROR: test_emcc (__main__.other)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests/runner.py", line 8633, in test_emcc
    self.assertContained('hello, world!', run_js('a.out.js'))
  File "tests/runner.py", line 327, in assertContained
    additional_info
Exception: Expected to find 'hello, world!' in '', diff:

--- expected
+++ actual
@@ -1 +1 @@
-hello, world!
+

```

With the whole patch:

```
$ python tests/runner.py other.test_emcc
Running Emscripten tests...
(Emscripten: Running sanity checks)
test_emcc (__main__.other) ... hello_world.c False
hello_malloc.cpp True
['-o', 'something.js'] 0 None 0 1
['-o', 'something.js', '-O0'] 0 None 0 0
['-o', 'something.js', '-O1'] 1 None 0 0
(etc)
```
