### PR TITLE
Use less generic names for variables.

### DIFF
--- a/system/include/libc/ctype.h
+++ b/system/include/libc/ctype.h
@@ -72,11 +72,14 @@ _CONST
 #define	isgraph(__c)	(__ctype_lookup(__c)&(CTYPE__P|CTYPE__U|CTYPE__L|CTYPE__N))
 #define iscntrl(__c)	(__ctype_lookup(__c)&CTYPE__C)
 
+/* XXX: EMSCRIPTEN: We alter the names of __typeof__ declarations to
+   reduce the chance of them conflicting when expanded */
+
 #if defined(__GNUC__) && \
     (!defined(__STRICT_ANSI__) || __STDC_VERSION__ >= 199901L)
 #define isblank(__c) \
-  __extension__ ({ __typeof__ (__c) __x = (__c);		\
-        (__ctype_lookup(__x)&_B) || (int) (__x) == '\t';})
+  __extension__ ({ __typeof__ (__c) __ctb_x = (__c);		\
+        (__ctype_lookup(__ctb_x)&_B) || (int) (__ctb_x) == '\t';})
 #endif
 
 
@@ -86,20 +89,20 @@ _CONST
 # if defined(__GNUC__)
 #  if !defined (_MB_EXTENDED_CHARSETS_ISO) && !defined (_MB_EXTENDED_CHARSETS_WINDOWS)
 #   define toupper(__c) \
-  __extension__ ({ __typeof__ (__c) __x = (__c);	\
-      islower (__x) ? (int) __x - 'a' + 'A' : (int) __x;})
+  __extension__ ({ __typeof__ (__c) __cttu_x = (__c);	\
+      islower (__cttu_x) ? (int) __cttu_x - 'a' + 'A' : (int) __cttu_x;})
 #   define tolower(__c) \
-  __extension__ ({ __typeof__ (__c) __x = (__c);	\
-      isupper (__x) ? (int) __x - 'A' + 'a' : (int) __x;})
+  __extension__ ({ __typeof__ (__c) __cttl_x = (__c);	\
+      isupper (__cttl_x) ? (int) __cttl_x - 'A' + 'a' : (int) __cttl_x;})
 #  else /* _MB_EXTENDED_CHARSETS* */
 /* Allow a gcc warning if the user passed 'char', but defer to the
    function.  */
 #   define toupper(__c) \
-  __extension__ ({ __typeof__ (__c) __x = (__c);	\
-      (void) __ctype_ptr__[__x]; (toupper) (__x);})
+  __extension__ ({ __typeof__ (__c) __cttu_x = (__c);	\
+      (void) __ctype_ptr__[__cttu_x]; (toupper) (__cttu_x);})
 #   define tolower(__c) \
-  __extension__ ({ __typeof__ (__c) __x = (__c);	\
-      (void) __ctype_ptr__[__x]; (tolower) (__x);})
+  __extension__ ({ __typeof__ (__c) __cttl_x = (__c);	\
+      (void) __ctype_ptr__[__cttl_x]; (tolower) (__cttl_x);})
 #  endif /* _MB_EXTENDED_CHARSETS* */
 # endif /* __GNUC__ */
 #endif /* !__cplusplus */

--- a/system/include/libc/math.h
+++ b/system/include/libc/math.h
@@ -210,25 +210,28 @@ extern int __signbitd (double x);
 	((sizeof(__x) == sizeof(float))  ?  __signbitf(__x) : \
 		__signbitd(__x))
 
+/* XXX: EMSCRIPTEN: We alter the names of __typeof__ declarations to
+   reduce the chance of them conflicting when expanded */
+
 #define isgreater(x,y) \
-          (__extension__ ({__typeof__(x) __x = (x); __typeof__(y) __y = (y); \
-                           !isunordered(__x,__y) && (__x > __y);}))
+          (__extension__ ({__typeof__(x) __isg_x = (x); __typeof__(y) __isg_y = (y); \
+                           !isunordered(__isg_x,__isg_y) && (__isg_x > __isg_y);}))
 #define isgreaterequal(x,y) \
-          (__extension__ ({__typeof__(x) __x = (x); __typeof__(y) __y = (y); \
-                           !isunordered(__x,__y) && (__x >= __y);}))
+          (__extension__ ({__typeof__(x) __isge_x = (x); __typeof__(y) __isge_y = (y); \
+                           !isunordered(__isge_x,__isge_y) && (__isge_x >= __isge_y);}))
 #define isless(x,y) \
-          (__extension__ ({__typeof__(x) __x = (x); __typeof__(y) __y = (y); \
-                           !isunordered(__x,__y) && (__x < __y);}))
+          (__extension__ ({__typeof__(x) __isl_x = (x); __typeof__(y) __isl_y = (y); \
+                           !isunordered(__isl_x,__isl_y) && (__isl_x < __isl_y);}))
 #define islessequal(x,y) \
-          (__extension__ ({__typeof__(x) __x = (x); __typeof__(y) __y = (y); \
-                           !isunordered(__x,__y) && (__x <= __y);}))
+          (__extension__ ({__typeof__(x) __isle_x = (x); __typeof__(y) __isle_y = (y); \
+                           !isunordered(__isle_x,__isle_y) && (__isle_x <= __isle_y);}))
 #define islessgreater(x,y) \
-          (__extension__ ({__typeof__(x) __x = (x); __typeof__(y) __y = (y); \
-                           !isunordered(__x,__y) && (__x < __y || __x > __y);}))
+          (__extension__ ({__typeof__(x) __islg_x = (x); __typeof__(y) __islg_y = (y); \
+                           !isunordered(__islg_x,__islg_y) && (__islg_x < __islg_y || __islg_x > __islg_y);}))
 
 #define isunordered(a,b) \
-          (__extension__ ({__typeof__(a) __a = (a); __typeof__(b) __b = (b); \
-                           fpclassify(__a) == FP_NAN || fpclassify(__b) == FP_NAN;}))
+          (__extension__ ({__typeof__(a) __isu_a = (a); __typeof__(b) __isu_b = (b); \
+                           fpclassify(__isu_a) == FP_NAN || fpclassify(__isu_b) == FP_NAN;}))
 
 /* Non ANSI double precision functions.  */
 


### PR DESCRIPTION
These are generic enough that in libcxx, they get expanded into
functions which also have variables named the same thing (__x, __y)
and that then leads to a buggy libcxx.

This might seem confusing, but this chunk of code (massively simplified) demonstrates the problem:

``` c++
#include <math.h>
#include <cassert>

template <class _A1, class _A2>
inline
bool
boom_isless(_A1 __x, _A2 __y)
{
    return isless(__x, __y);
}

void working_test_isless()
{
    assert(isless(-1.0, 0.F) == true);
}

void broken_test_isless()
{
    assert(boom_isless(-1.0, 0.F) == true);
}

int main()
{
    working_test_isless();
    broken_test_isless();
}
```
