### PR TITLE
Finding a renderer in the cache now takes into account the current VBO stride.

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -1874,6 +1874,8 @@ var LibraryGL = {
         var typeIndex = attribute.type - GL.byteSizeByTypeRoot; // ensure it starts at 0 to keep the cache items dense
         temp = cacheItem[typeIndex];
         cacheItem = temp ? temp : (cacheItem[typeIndex] = GL.immediate.rendererCacheItemTemplate.slice());
+        temp = cacheItem[attribute.stride];
+        cacheItem = temp ? temp : (cacheItem[attribute.stride] = GL.immediate.rendererCacheItemTemplate.slice());
       }
       var fogParam;
       if (GLEmulation.fogEnabled) {


### PR DESCRIPTION
This solves a problem where a VBO A is drawn with the same size elements as VBO B, but a different stride. In the case where VBO B was drawn first, the renderer that drew VBO B will be used to draw VBA A even though the stride value was different for the two VBOs.

When finding renderers in the cache, the stride of the current vertex buffer object is also taken into account.

This fixes a problem where a renderer could be used to draw a
vertex buffer object with a different stride value than the renderer
captured when the renderer was created.
