### PR TITLE
Fix offsets for canvas

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -443,6 +443,21 @@ var LibrarySDL = {
       return false;
     },
 
+    offsets: function(element) {
+      var left = 0;
+      var top = 0;
+
+      do {
+        left += element.offsetLeft;
+        top += element.offsetTop;
+      } while (element = element.offsetParent)
+
+      return { 
+        left: left,
+        top: top
+      }
+    },
+
     makeCEvent: function(event, ptr) {
       if (typeof event === 'number') {
         // This is a pointer to a native C event that was SDL_PushEvent'ed
@@ -524,8 +539,9 @@ var LibrarySDL = {
           } else {
             // Otherwise, calculate the movement based on the changes
             // in the coordinates.
-            var x = event.pageX - Module["canvas"].offsetLeft;
-            var y = event.pageY - Module["canvas"].offsetTop;
+            var offsets = SDL.offsets(Module["canvas"]);
+            var x = event.pageX - offsets.left;
+            var y = event.pageY - offsets.top;
             var movementX = x - SDL.mouseX;
             var movementY = y - SDL.mouseY;
           }
@@ -912,10 +928,11 @@ var LibrarySDL = {
 
   SDL_WarpMouse: function(x, y) {
     return; // TODO: implement this in a non-buggy way. Need to keep relative mouse movements correct after calling this
+    var offsets = SDL.offsets(Module["canvas"]);
     SDL.events.push({
       type: 'mousemove',
-      pageX: x + Module['canvas'].offsetLeft,
-      pageY: y + Module['canvas'].offsetTop
+      pageX: x + offsets.left,
+      pageY: y + offsets.top
     });
   },
 


### PR DESCRIPTION
If canvas embedded in div with `position: absolute` then simple call to Module['canvas'].offset Top|Left not enough to get mouse position.

```
.canvas {
    position: absolute;
    left: 0;
    width: 100%;
    top: 43px;
    bottom: 0;
}

.canvas #canvas {
    position: absolute;
    left: 0;
    width: 100%;
    top: 0px;
    height: 100%;
}
//...

  <div class="canvas">
    <canvas id="canvas" oncontextmenu="event.preventDefault()">
  </div>
```

In the snippet call to Module['canvas'].offsetTop returns 0, but real offset is 43px. So i fixed the code, but maybe i should implement cache for offset.
