### PR TITLE
Hide all of the console.* stuff behind a compile time flag

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -41,7 +41,9 @@ var LibraryOpenAL = {
     }
 
     if (attrList) {
+#if OPENAL_DEBUG
       console.log("The attrList argument of alcCreateContext is not supported yet");
+#endif
       return 0;
     }
 
@@ -73,7 +75,9 @@ var LibraryOpenAL = {
   alDeleteSources: function(count, sources)
   {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alDeleteSources called without a valid context");
+#endif
       return;
     }
     for (var i = 0; i < count; ++i) {
@@ -84,7 +88,9 @@ var LibraryOpenAL = {
 
   alGenSources: function(count, sources) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alGenSources called without a valid context");
+#endif
       return;
     }
     for (var i = 0; i < count; ++i) {
@@ -113,11 +119,15 @@ var LibraryOpenAL = {
 
   alSourcei: function(source, param, value) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alSourcei called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alSourcei called with an invalid source");
+#endif
       return;
     }
     switch (param) {
@@ -132,18 +142,24 @@ var LibraryOpenAL = {
       }
       break;
     default:
+#if OPENAL_DEBUG
       console.log("alSourcei with param " + param + " not implemented yet");
+#endif
       break;
     }
   },
 
   alSourcef: function(source, param, value) {
     if (!AL.currentContext) {
-      consoue.error("alSourcef called without a valid context");
+#if OPENAL_DEBUG
+      console.error("alSourcef called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alSourcef called with an invalid source");
+#endif
       return;
     }
     switch (param) {
@@ -151,21 +167,29 @@ var LibraryOpenAL = {
       AL.currentContext.src[source - 1].gain.gain.value = value;
       break;
     case 0x1003 /* AL_PITCH */:
+#if OPENAL_DEBUG
       console.log("alSourcef was called with AL_PITCH, but Web Audio does not support static pitch changes");
+#endif
       break;
     default:
+#if OPENAL_DEBUG
       console.log("alSourcef with param " + param + " not implemented yet");
+#endif
       break;
     }
   },
 
   alSourcefv: function(source, param, value) {
     if (!AL.currentContext) {
-      consoue.error("alSourcefv called without a valid context");
+#if OPENAL_DEBUG
+      console.error("alSourcefv called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alSourcefv called with an invalid source");
+#endif
       return;
     }
     switch (param) {
@@ -184,28 +208,38 @@ var LibraryOpenAL = {
         );
       break;
     default:
+#if OPENAL_DEBUG
       console.log("alSourcefv with param " + param + " not implemented yet");
+#endif
       break;
     }
   },
 
   alSourceQueueBuffers: function(source, count, buffers) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alSourceQueueBuffers called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alSourceQueueBuffers called with an invalid source");
+#endif
       return;
     }
     if (count != 1) {
+#if OPENAL_DEBUG
       console.error("Queuing multiple buffers using alSourceQueueBuffers is not supported yet");
+#endif
       return;
     }
     for (var i = 0; i < count; ++i) {
       var buffer = {{{ makeGetValue('buffers', 'i', 'i32') }}};
       if (buffer > AL.currentContext.buf.length) {
+#if OPENAL_DEBUG
         console.error("alSourceQueueBuffers called with an invalid buffer");
+#endif
         return;
       }
       AL.currentContext.src[source - 1].buffer = AL.currentContext.buf[buffer - 1].buf;
@@ -215,15 +249,21 @@ var LibraryOpenAL = {
   alSourceUnqueueBuffers: function(source, count, buffers)
   {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alSourceUnqueueBuffers called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alSourceUnqueueBuffers called with an invalid source");
+#endif
       return;
     }
     if (count != 1) {
+#if OPENAL_DEBUG
       console.error("Queuing multiple buffers using alSourceUnqueueBuffers is not supported yet");
+#endif
       return;
     }
     for (var i = 0; i < count; ++i) {
@@ -241,7 +281,9 @@ var LibraryOpenAL = {
   alDeleteBuffers: function(count, buffers)
   {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alDeleteBuffers called without a valid context");
+#endif
       return;
     }
     for (var i = 0; i < count; ++i) {
@@ -259,7 +301,9 @@ var LibraryOpenAL = {
 
   alGenBuffers: function(count, buffers) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alGenBuffers called without a valid context");
+#endif
       return;
     }
     for (var i = 0; i < count; ++i) {
@@ -270,11 +314,15 @@ var LibraryOpenAL = {
 
   alBufferData: function(buffer, format, data, size, freq) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alBufferData called without a valid context");
+#endif
       return;
     }
     if (buffer > AL.currentContext.buf.length) {
+#if OPENAL_DEBUG
       console.error("alBufferData called with an invalid buffer");
+#endif
       return;
     }
     var channels, bytes;
@@ -296,7 +344,9 @@ var LibraryOpenAL = {
       channels = 2;
       break;
     default:
+#if OPENAL_DEBUG
       console.error("alBufferData called with invalid format " + format);
+#endif
       return;
     }
     AL.currentContext.buf[buffer - 1].buf = AL.currentContext.ctx.createBuffer(channels, size / (bytes * channels), freq);
@@ -323,11 +373,15 @@ var LibraryOpenAL = {
   alSourcePlay__deps: ["alSourceStop"],
   alSourcePlay: function(source) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alSourcePlay called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alSourcePlay called with an invalid source");
+#endif
       return;
     }
     var offset = 0;
@@ -353,11 +407,15 @@ var LibraryOpenAL = {
 
   alSourceStop: function(source) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alSourceStop called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alSourceStop called with an invalid source");
+#endif
       return;
     }
     if ("src" in AL.currentContext.src[source - 1]) {
@@ -368,11 +426,15 @@ var LibraryOpenAL = {
 
   alSourcePause: function(source) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alSourcePause called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alSourcePause called with an invalid source");
+#endif
       return;
     }
     if ("src" in AL.currentContext.src[source - 1] &&
@@ -387,11 +449,15 @@ var LibraryOpenAL = {
 
   alGetSourcei: function(source, param, value) {
     if (!AL.currentContext) {
+#if OPENAL_DEBUG
       console.error("alGetSourcei called without a valid context");
+#endif
       return;
     }
     if (source > AL.currentContext.src.length) {
+#if OPENAL_DEBUG
       console.error("alGetSourcei called with an invalid source");
+#endif
       return;
     }
     switch (param) {
@@ -440,12 +506,16 @@ var LibraryOpenAL = {
 
   alDistanceModel: function(model) {
     if (model != 0 /* AL_NONE */) {
+#if OPENAL_DEBUG
       console.log("Only alDistanceModel(AL_NONE) is currently supported");
+#endif
     }
   },
 
   alListenerfv: function(param, values) {
+#if OPENAL_DEBUG
     console.log("alListenerfv is not supported yet");
+#endif
   },
 
   alIsExtensionPresent: function(extName) {


### PR DESCRIPTION
This improves the performance of OpenAL code when these debugging outputs are not needed.
