### PR TITLE
Itsy bitsy change to print out stack on uncaught exceptions

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1749,7 +1749,7 @@ function makeStructuralAccess(ident, i) {
 }
 
 function makeThrow(what) {
-  return 'throw ' + what + (DISABLE_EXCEPTION_CATCHING == 1 ? ' + " - Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0 or DISABLE_EXCEPTION_CATCHING=2 to catch."' : '') + ';';
+  return 'throw ' + what + (DISABLE_EXCEPTION_CATCHING == 1 ? ' + " - Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0 or DISABLE_EXCEPTION_CATCHING=2 to catch." + new Error().stack' : '') + ';';
 }
 
 // From parseLLVMSegment


### PR DESCRIPTION
As per Alon's suggestion on Emscripten Google Group, just added the stack to the message printed when an exception is uncaught. Useful for asm.js debugging, when one can't catch exceptions.
