### PR TITLE
UTF-8 fixes for fscanf and sscanf

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -54,4 +54,6 @@ a license to everyone to use it as detailed in LICENSE.)
 * Lorant Pinter <lorant.pinter@prezi.com>
 * Tobias Doerffel <tobias.doerffel@gmail.com>
 * Martin von Gagern <martin@von-gagern.net>
+* Sören Balko <soeren.balko@gmail.com>
+
 


### PR DESCRIPTION
Here is the "clean" patch to fix UTF-8 character handling in fscanf and sscanf. In the spirit of the optimization that was done to Pointer_stringify, I also included short-cuts for the (frequent) case of ASCII-7 characters. Test cases are included.
