### PR TITLE
When there's no exception, just drop the resume.

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -1167,6 +1167,11 @@ function JSify(data, functionsOnly, givenFunctions) {
     return ret + ';';
   });
   makeFuncLineActor('resume', function(item) {
+    if (item.ident == 0) {
+      // No exception to resume, so we can just bail.
+      // This is related to issue #917 and http://llvm.org/PR15518
+      return ';';
+    }
     // If there is no current exception, set this one as it (during a resume, the current exception can be wiped out)
     var ptr = makeStructuralAccess(item.ident, 0);
     return (EXCEPTION_DEBUG ? 'Module.print("Resuming exception");' : '') + 


### PR DESCRIPTION
This addresses part of what was raised in http://llvm.org/PR15518
and issue #917.
