### PR TITLE
Replace broken _CTYPE_* definitions with correct.

### DIFF
--- a/system/include/libc/ctype.h
+++ b/system/include/libc/ctype.h
@@ -117,20 +117,6 @@ extern	__IMPORT _CONST char	_ctype_[];
 
 _END_STD_C
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 /*
  * Copyright (c) 2000, 2005, 2008 Apple Inc. All rights reserved.
  *
@@ -196,25 +182,15 @@ _END_STD_C
  *	@(#)ctype.h	8.4 (Berkeley) 1/21/94
  */
 
-#define	_CTYPE_A	0x00000100L		/* Alpha */
-#define	_CTYPE_C	0x00000200L		/* Control */
-#define	_CTYPE_D	0x00000400L		/* Digit */
-#define	_CTYPE_G	0x00000800L		/* Graph */
-#define	_CTYPE_L	0x00001000L		/* Lower */
-#define	_CTYPE_P	0x00002000L		/* Punct */
-#define	_CTYPE_S	0x00004000L		/* Space */
-#define	_CTYPE_U	0x00008000L		/* Upper */
-#define	_CTYPE_X	0x00010000L		/* X digit */
-#define	_CTYPE_B	0x00020000L		/* Blank */
-#define	_CTYPE_R	0x00040000L		/* Print */
-#define	_CTYPE_I	0x00080000L		/* Ideogram */
-#define	_CTYPE_T	0x00100000L		/* Special */
-#define	_CTYPE_Q	0x00200000L		/* Phonogram */
-#define	_CTYPE_SW0	0x20000000L		/* 0 width character */
-#define	_CTYPE_SW1	0x40000000L		/* 1 width character */
-#define	_CTYPE_SW2	0x80000000L		/* 2 width character */
-#define	_CTYPE_SW3	0xc0000000L		/* 3 width character */
-#define	_CTYPE_SWM	0xe0000000L		/* Mask for screen width data */
-#define	_CTYPE_SWS	30			/* Bits to shift to get width */
+#define _CTYPE_A  0x00000400   /* Alpha */
+#define _CTYPE_C  0x00000002   /* Control */
+#define _CTYPE_D  0x00000800   /* Digit */
+#define _CTYPE_L  0x00000200   /* Lower */
+#define _CTYPE_P  0x00000004   /* Punct */
+#define _CTYPE_S  0x00002000   /* Space */
+#define _CTYPE_U  0x00000100   /* Upper */
+#define _CTYPE_X  0x00001000   /* X digit */
+#define _CTYPE_B  0x00000001   /* Blank */
+#define _CTYPE_R  0x00004000   /* Print */
 
 #endif /* _CTYPE_H_ */


### PR DESCRIPTION
These aren't currently used, but are used in the updated libcxx
port.

Fixes issues #939.
