### PR TITLE
Fix large values in llvm_ctpop_i32().

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4950,7 +4950,7 @@ LibraryManager.library = {
     var ret = 0;
     while (x) {
       if (x&1) ret++;
-      x >>= 1;
+      x >>>= 1;
     }
     return ret;
   },

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1269,6 +1269,7 @@ m_divisor is 1091269979
             printf("%d,%d\n", (int)llvm_ctlz_i64(((int64_t)1) << 40), llvm_ctlz_i32(1<<10));
             printf("%d,%d\n", (int)llvm_cttz_i64(((int64_t)1) << 40), llvm_cttz_i32(1<<10));
             printf("%d,%d\n", (int)llvm_ctpop_i64((0x3101ULL << 32) | 1), llvm_ctpop_i32(0x3101));
+            printf("%d\n", (int)llvm_ctpop_i32(-594093059));
 
             printf("%d\n", llvm_expect_i32(x % 27, 3));
 
@@ -1286,6 +1287,7 @@ c5,de,15,8a
 23,21
 40,10
 5,4
+22
 13
 72057594037927936
 ''')


### PR DESCRIPTION
Large values looked like negative values, we have to do an
unsigned shift.

Fixes issue #966.
