### PR TITLE
look for python2 before python for default .emscripten

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -61,4 +61,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Alexander Gladysh <ag@logiceditor.com>
 * Arlo Breault <arlolra@gmail.com>
 * Jacob Lee <artdent@gmail.com> (copyright owned by Google, Inc.)
+* Robert Bragg <robert.bragg@intel.com> (copyright owned by Intel Corporation)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -109,7 +109,8 @@ else:
     config_file = config_file.replace('{{{ NODE }}}', node)
     python = 'python'
     try:
-      python = Popen(['which', 'python'], stdout=PIPE).communicate()[0].replace('\n', '')
+      python = Popen(['which', 'python2'], stdout=PIPE).communicate()[0].replace('\n', '') or \
+               Popen(['which', 'python'], stdout=PIPE).communicate()[0].replace('\n', '') or python
     except:
       pass
     config_file = config_file.replace('{{{ PYTHON }}}', python)    


### PR DESCRIPTION
emscripten requires python 2 but some systems have multiple versions of
python installed and the 'python' binary will correspond to python 3. We
now explicitly look for a python2 first when setting up a default
.emscripten config file.
