### PR TITLE
Re-instate _ATTRIBUTE() usages.

### DIFF
--- a/system/include/libc/_ansi.h
+++ b/system/include/libc/_ansi.h
@@ -105,9 +105,9 @@
 
 #ifndef _ATTRIBUTE /* XXX Emscripten */
 #ifdef __GNUC__
-#define _ATTRIBUTE(attrs) __attribute__ (attrs)
+#define _ATTRIBUTE(attr) __attribute__ ((attr))
 #else
-#define _ATTRIBUTE(attrs)
+#define _ATTRIBUTE(attr)
 #endif
 #endif /* XXX Emscripten */
 

--- a/system/include/libc/assert.h
+++ b/system/include/libc/assert.h
@@ -36,10 +36,10 @@ extern "C" {
 # endif /* !__ASSERT_FUNC */
 #endif /* !NDEBUG */
 
-void _EXFUN(__assert, (const char *, int, const char *));
-/*	    _ATTRIBUTE ((__noreturn__))); */
-void _EXFUN(__assert_func, (const char *, int, const char *, const char *));
-/*	    _ATTRIBUTE ((__noreturn__))); */
+void _EXFUN(__assert, (const char *, int, const char *)
+            _ATTRIBUTE(noreturn));
+void _EXFUN(__assert_func, (const char *, int, const char *, const char *)
+            _ATTRIBUTE(noreturn));
 
 #ifdef __cplusplus
 }

--- a/system/include/libc/stdio.h
+++ b/system/include/libc/stdio.h
@@ -184,22 +184,22 @@ int	_EXFUN(fflush, (FILE *));
 FILE *	_EXFUN(freopen, (const char *, const char *, FILE *));
 void	_EXFUN(setbuf, (FILE *, char *));
 int	_EXFUN(setvbuf, (FILE *, char *, int, size_t));
-int	_EXFUN(fprintf, (FILE *, const char *, ...));
-/* XXX Emscripten_ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
-int	_EXFUN(fscanf, (FILE *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 3)))); */
-int	_EXFUN(printf, (const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 1, 2)))); */
-int	_EXFUN(scanf, (const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 1, 2)))); */
-int	_EXFUN(sscanf, (const char *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 3)))); */
-int	_EXFUN(vfprintf, (FILE *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
-int	_EXFUN(vprintf, (const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 1, 0)))); */
-int	_EXFUN(vsprintf, (char *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
+int	_EXFUN(fprintf, (FILE *, const char *, ...)
+           _ATTRIBUTE (__format__ (__printf__, 2, 3)));
+int	_EXFUN(fscanf, (FILE *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 3)));
+int	_EXFUN(printf, (const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 1, 2)));
+int	_EXFUN(scanf, (const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 1, 2)));
+int	_EXFUN(sscanf, (const char *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 3)));
+int	_EXFUN(vfprintf, (FILE *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
+int	_EXFUN(vprintf, (const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 1, 0)));
+int	_EXFUN(vsprintf, (char *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
 int	_EXFUN(fgetc, (FILE *));
 char *  _EXFUN(fgets, (char *, int, FILE *));
 int	_EXFUN(fputc, (int, FILE *));
@@ -232,8 +232,8 @@ int	_EXFUN(ferror, (FILE *));
 void    _EXFUN(perror, (const char *));
 #ifndef _REENT_ONLY
 FILE *	_EXFUN(fopen, (const char *_name, const char *_type));
-int	_EXFUN(sprintf, (char *, const char *, ...));
-/* XXX EMSCRIPTEN _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
+int	_EXFUN(sprintf, (char *, const char *, ...)
+           _ATTRIBUTE (__format__ (__printf__, 2, 3)));
 int	_EXFUN(remove, (const char *));
 int	_EXFUN(rename, (const char *, const char *));
 #endif
@@ -248,68 +248,68 @@ off_t	_EXFUN(ftello, ( FILE *));
 #endif
 #if !defined(__STRICT_ANSI__) || (__STDC_VERSION__ >= 199901L)
 #ifndef _REENT_ONLY
-int	_EXFUN(asiprintf, (char **, const char *, ...));
-/* XXX EMSCRIPTEN _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
-char *	_EXFUN(asniprintf, (char *, size_t *, const char *, ...));
-/*                _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-char *	_EXFUN(asnprintf, (char *, size_t *, const char *, ...));
-/*                _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-int	_EXFUN(asprintf, (char **, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
+int	_EXFUN(asiprintf, (char **, const char *, ...)
+           _ATTRIBUTE (__format__ (__printf__, 2, 3)));
+char *	_EXFUN(asniprintf, (char *, size_t *, const char *, ...)
+                _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+char *	_EXFUN(asnprintf, (char *, size_t *, const char *, ...)
+                _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+int	_EXFUN(asprintf, (char **, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 2, 3)));
 #ifndef diprintf
-int	_EXFUN(diprintf, (int, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
+int	_EXFUN(diprintf, (int, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 2, 3)));
 #endif
 int	_EXFUN(fcloseall, (_VOID));
-int	_EXFUN(fiprintf, (FILE *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
-int	_EXFUN(fiscanf, (FILE *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 3)))); */
-int	_EXFUN(iprintf, (const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 1, 2)))); */
-int	_EXFUN(iscanf, (const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 1, 2)))); */
-int	_EXFUN(siprintf, (char *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
-int	_EXFUN(siscanf, (const char *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 3)))); */
-int	_EXFUN(snprintf, (char *, size_t, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-int	_EXFUN(sniprintf, (char *, size_t, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
+int	_EXFUN(fiprintf, (FILE *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 2, 3)));
+int	_EXFUN(fiscanf, (FILE *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 3)));
+int	_EXFUN(iprintf, (const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 1, 2)));
+int	_EXFUN(iscanf, (const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 1, 2)));
+int	_EXFUN(siprintf, (char *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 2, 3)));
+int	_EXFUN(siscanf, (const char *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 3)));
+int	_EXFUN(snprintf, (char *, size_t, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+int	_EXFUN(sniprintf, (char *, size_t, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
 char *	_EXFUN(tempnam, (const char *, const char *));
-int	_EXFUN(vasiprintf, (char **, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
-char *	_EXFUN(vasniprintf, (char *, size_t *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-char *	_EXFUN(vasnprintf, (char *, size_t *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(vasprintf, (char **, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
-int	_EXFUN(vdiprintf, (int, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
-int	_EXFUN(vfiprintf, (FILE *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
-int	_EXFUN(vfiscanf, (FILE *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 0)))); */
-int	_EXFUN(vfscanf, (FILE *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 0)))); */
-int	_EXFUN(viprintf, (const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 1, 0)))); */
-int	_EXFUN(viscanf, (const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 1, 0)))); */
-int	_EXFUN(vscanf, (const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 1, 0)))); */
-int	_EXFUN(vsiprintf, (char *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
-int	_EXFUN(vsiscanf, (const char *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 0)))); */
-int	_EXFUN(vsniprintf, (char *, size_t, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(vsnprintf, (char *, size_t, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(vsscanf, (const char *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 0)))); */
+int	_EXFUN(vasiprintf, (char **, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
+char *	_EXFUN(vasniprintf, (char *, size_t *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+char *	_EXFUN(vasnprintf, (char *, size_t *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(vasprintf, (char **, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
+int	_EXFUN(vdiprintf, (int, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
+int	_EXFUN(vfiprintf, (FILE *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
+int	_EXFUN(vfiscanf, (FILE *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 0)));
+int	_EXFUN(vfscanf, (FILE *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 0)));
+int	_EXFUN(viprintf, (const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 1, 0)));
+int	_EXFUN(viscanf, (const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 1, 0)));
+int	_EXFUN(vscanf, (const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 1, 0)));
+int	_EXFUN(vsiprintf, (char *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
+int	_EXFUN(vsiscanf, (const char *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 0)));
+int	_EXFUN(vsniprintf, (char *, size_t, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(vsnprintf, (char *, size_t, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(vsscanf, (const char *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 0)));
 #endif /* !_REENT_ONLY */
 #endif /* !__STRICT_ANSI__ */
 
@@ -344,8 +344,8 @@ int	_EXFUN(putchar_unlocked, (int));
 #ifndef __STRICT_ANSI__
 # ifndef _REENT_ONLY
 #  ifndef dprintf
-int	_EXFUN(dprintf, (int, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
+int	_EXFUN(dprintf, (int, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 2, 3)));
 #  endif
 FILE *	_EXFUN(fmemopen, (void *, size_t, const char *));
 /* getdelim - see __getdelim for now */
@@ -354,8 +354,8 @@ FILE *	_EXFUN(open_memstream, (char **, size_t *));
 #if defined (__CYGWIN__)
 int	_EXFUN(renameat, (int, const char *, int, const char *));
 #endif
-int	_EXFUN(vdprintf, (int, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
+int	_EXFUN(vdprintf, (int, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
 # endif
 #endif
 
@@ -363,18 +363,18 @@ int	_EXFUN(vdprintf, (int, const char *, __VALIST));
  * Recursive versions of the above.
  */
 
-int	_EXFUN(_asiprintf_r, (struct _reent *, char **, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-char *	_EXFUN(_asniprintf_r, (struct _reent *, char *, size_t *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 4, 5)))); */
-char *	_EXFUN(_asnprintf_r, (struct _reent *, char *, size_t *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 4, 5)))); */
-int	_EXFUN(_asprintf_r, (struct _reent *, char **, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-int	_EXFUN(_diprintf_r, (struct _reent *, int, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-int	_EXFUN(_dprintf_r, (struct _reent *, int, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
+int	_EXFUN(_asiprintf_r, (struct _reent *, char **, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+char *	_EXFUN(_asniprintf_r, (struct _reent *, char *, size_t *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 4, 5)));
+char *	_EXFUN(_asnprintf_r, (struct _reent *, char *, size_t *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 4, 5)));
+int	_EXFUN(_asprintf_r, (struct _reent *, char **, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+int	_EXFUN(_diprintf_r, (struct _reent *, int, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+int	_EXFUN(_dprintf_r, (struct _reent *, int, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
 int	_EXFUN(_fclose_r, (struct _reent *, FILE *));
 int	_EXFUN(_fcloseall_r, (struct _reent *));
 FILE *	_EXFUN(_fdopen_r, (struct _reent *, int, const char *));
@@ -388,21 +388,21 @@ int	_EXFUN(_fsetpos_r, (struct _reent *, FILE *, const _fpos_t *));
 int	_EXFUN(_fgetpos_r, (struct _reent *, FILE *, fpos_t *));
 int	_EXFUN(_fsetpos_r, (struct _reent *, FILE *, const fpos_t *));
 #endif
-int	_EXFUN(_fiprintf_r, (struct _reent *, FILE *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-int	_EXFUN(_fiscanf_r, (struct _reent *, FILE *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 3, 4)))); */
+int	_EXFUN(_fiprintf_r, (struct _reent *, FILE *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+int	_EXFUN(_fiscanf_r, (struct _reent *, FILE *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 3, 4)));
 FILE *	_EXFUN(_fmemopen_r, (struct _reent *, void *, size_t, const char *));
 FILE *	_EXFUN(_fopen_r, (struct _reent *, const char *, const char *));
 FILE *	_EXFUN(_freopen_r, (struct _reent *, const char *, const char *, FILE *));
-int	_EXFUN(_fprintf_r, (struct _reent *, FILE *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
+int	_EXFUN(_fprintf_r, (struct _reent *, FILE *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
 int	_EXFUN(_fpurge_r, (struct _reent *, FILE *));
 int	_EXFUN(_fputc_r, (struct _reent *, int, FILE *));
 int	_EXFUN(_fputs_r, (struct _reent *, const char *, FILE *));
 size_t	_EXFUN(_fread_r, (struct _reent *, _PTR, size_t _size, size_t _n, FILE *));
-int	_EXFUN(_fscanf_r, (struct _reent *, FILE *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 3, 4)))); */
+int	_EXFUN(_fscanf_r, (struct _reent *, FILE *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 3, 4)));
 int	_EXFUN(_fseek_r, (struct _reent *, FILE *, long, int));
 int	_EXFUN(_fseeko_r,(struct _reent *, FILE *, _off_t, int));
 long	_EXFUN(_ftell_r, (struct _reent *, FILE *));
@@ -414,14 +414,14 @@ int	_EXFUN(_getc_unlocked_r, (struct _reent *, FILE *));
 int	_EXFUN(_getchar_r, (struct _reent *));
 int	_EXFUN(_getchar_unlocked_r, (struct _reent *));
 char *	_EXFUN(_gets_r, (struct _reent *, char *));
-int	_EXFUN(_iprintf_r, (struct _reent *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
-int	_EXFUN(_iscanf_r, (struct _reent *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 3)))); */
+int	_EXFUN(_iprintf_r, (struct _reent *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 2, 3)));
+int	_EXFUN(_iscanf_r, (struct _reent *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 3)));
 FILE *	_EXFUN(_open_memstream_r, (struct _reent *, char **, size_t *));
 void	_EXFUN(_perror_r, (struct _reent *, const char *));
-int	_EXFUN(_printf_r, (struct _reent *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 3)))); */
+int	_EXFUN(_printf_r, (struct _reent *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 2, 3)));
 int	_EXFUN(_putc_r, (struct _reent *, int, FILE *));
 int	_EXFUN(_putc_unlocked_r, (struct _reent *, int, FILE *));
 int	_EXFUN(_putchar_unlocked_r, (struct _reent *, int));
@@ -430,64 +430,64 @@ int	_EXFUN(_puts_r, (struct _reent *, const char *));
 int	_EXFUN(_remove_r, (struct _reent *, const char *));
 int	_EXFUN(_rename_r, (struct _reent *,
 			   const char *_old, const char *_new));
-int	_EXFUN(_scanf_r, (struct _reent *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 3)))); */
-int	_EXFUN(_siprintf_r, (struct _reent *, char *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-int	_EXFUN(_siscanf_r, (struct _reent *, const char *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 3, 4)))); */
-int	_EXFUN(_sniprintf_r, (struct _reent *, char *, size_t, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 4, 5)))); */
-int	_EXFUN(_snprintf_r, (struct _reent *, char *, size_t, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 4, 5)))); */
-int	_EXFUN(_sprintf_r, (struct _reent *, char *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 4)))); */
-int	_EXFUN(_sscanf_r, (struct _reent *, const char *, const char *, ...));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 3, 4)))); */
+int	_EXFUN(_scanf_r, (struct _reent *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 3)));
+int	_EXFUN(_siprintf_r, (struct _reent *, char *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+int	_EXFUN(_siscanf_r, (struct _reent *, const char *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 3, 4)));
+int	_EXFUN(_sniprintf_r, (struct _reent *, char *, size_t, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 4, 5)));
+int	_EXFUN(_snprintf_r, (struct _reent *, char *, size_t, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 4, 5)));
+int	_EXFUN(_sprintf_r, (struct _reent *, char *, const char *, ...)
+               _ATTRIBUTE (__format__ (__printf__, 3, 4)));
+int	_EXFUN(_sscanf_r, (struct _reent *, const char *, const char *, ...)
+               _ATTRIBUTE (__format__ (__scanf__, 3, 4)));
 char *	_EXFUN(_tempnam_r, (struct _reent *, const char *, const char *));
 FILE *	_EXFUN(_tmpfile_r, (struct _reent *));
 char *	_EXFUN(_tmpnam_r, (struct _reent *, char *));
 int	_EXFUN(_ungetc_r, (struct _reent *, int, FILE *));
-int	_EXFUN(_vasiprintf_r, (struct _reent *, char **, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-char *	_EXFUN(_vasniprintf_r, (struct _reent*, char *, size_t *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 4, 0)))); */
-char *	_EXFUN(_vasnprintf_r, (struct _reent*, char *, size_t *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 4, 0)))); */
-int	_EXFUN(_vasprintf_r, (struct _reent *, char **, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(_vdiprintf_r, (struct _reent *, int, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(_vdprintf_r, (struct _reent *, int, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(_vfiprintf_r, (struct _reent *, FILE *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(_vfiscanf_r, (struct _reent *, FILE *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 3, 0)))); */
-int	_EXFUN(_vfprintf_r, (struct _reent *, FILE *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(_vfscanf_r, (struct _reent *, FILE *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 3, 0)))); */
-int	_EXFUN(_viprintf_r, (struct _reent *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
-int	_EXFUN(_viscanf_r, (struct _reent *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 0)))); */
-int	_EXFUN(_vprintf_r, (struct _reent *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 2, 0)))); */
-int	_EXFUN(_vscanf_r, (struct _reent *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 2, 0)))); */
-int	_EXFUN(_vsiprintf_r, (struct _reent *, char *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(_vsiscanf_r, (struct _reent *, const char *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 3, 0)))); */
-int	_EXFUN(_vsniprintf_r, (struct _reent *, char *, size_t, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 4, 0)))); */
-int	_EXFUN(_vsnprintf_r, (struct _reent *, char *, size_t, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 4, 0)))); */
-int	_EXFUN(_vsprintf_r, (struct _reent *, char *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__printf__, 3, 0)))); */
-int	_EXFUN(_vsscanf_r, (struct _reent *, const char *, const char *, __VALIST));
-/*               _ATTRIBUTE ((__format__ (__scanf__, 3, 0)))); */
+int	_EXFUN(_vasiprintf_r, (struct _reent *, char **, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+char *	_EXFUN(_vasniprintf_r, (struct _reent*, char *, size_t *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 4, 0)));
+char *	_EXFUN(_vasnprintf_r, (struct _reent*, char *, size_t *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 4, 0)));
+int	_EXFUN(_vasprintf_r, (struct _reent *, char **, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(_vdiprintf_r, (struct _reent *, int, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(_vdprintf_r, (struct _reent *, int, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(_vfiprintf_r, (struct _reent *, FILE *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(_vfiscanf_r, (struct _reent *, FILE *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 3, 0)));
+int	_EXFUN(_vfprintf_r, (struct _reent *, FILE *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(_vfscanf_r, (struct _reent *, FILE *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 3, 0)));
+int	_EXFUN(_viprintf_r, (struct _reent *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
+int	_EXFUN(_viscanf_r, (struct _reent *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 0)));
+int	_EXFUN(_vprintf_r, (struct _reent *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 2, 0)));
+int	_EXFUN(_vscanf_r, (struct _reent *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 2, 0)));
+int	_EXFUN(_vsiprintf_r, (struct _reent *, char *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(_vsiscanf_r, (struct _reent *, const char *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 3, 0)));
+int	_EXFUN(_vsniprintf_r, (struct _reent *, char *, size_t, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 4, 0)));
+int	_EXFUN(_vsnprintf_r, (struct _reent *, char *, size_t, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 4, 0)));
+int	_EXFUN(_vsprintf_r, (struct _reent *, char *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__printf__, 3, 0)));
+int	_EXFUN(_vsscanf_r, (struct _reent *, const char *, const char *, __VALIST)
+               _ATTRIBUTE (__format__ (__scanf__, 3, 0)));
 
 /* Other extensions.  */
 

--- a/system/include/libc/stdlib.h
+++ b/system/include/libc/stdlib.h
@@ -59,7 +59,7 @@ int	_EXFUN(__locale_mb_cur_max,(_VOID));
 
 #define MB_CUR_MAX __locale_mb_cur_max()
 
-_VOID	_EXFUN(abort,(_VOID)); /* _ATTRIBUTE ((noreturn))); */
+_VOID	_EXFUN(abort,(_VOID) _ATTRIBUTE(noreturn));
 int	_EXFUN(abs,(int));
 int	_EXFUN(atexit,(_VOID (*__func)(_VOID)));
 double	_EXFUN(atof,(const char *__nptr));
@@ -77,7 +77,7 @@ _PTR	_EXFUN(bsearch,(const _PTR __key,
 		       int _EXFNPTR(_compar,(const _PTR, const _PTR))));
 _PTR	_EXFUN_NOTHROW(calloc,(size_t __nmemb, size_t __size));
 div_t	_EXFUN(div,(int __numer, int __denom));
-_VOID	_EXFUN(exit,(int __status)); /* _ATTRIBUTE ((noreturn))); */
+_VOID	_EXFUN(exit,(int __status) _ATTRIBUTE(noreturn));
 _VOID	_EXFUN_NOTHROW(free,(_PTR));
 char *  _EXFUN(getenv,(const char *__string));
 char *	_EXFUN(_getenv_r,(struct _reent *, const char *__string));
@@ -107,14 +107,14 @@ int	_EXFUN(mkostemp,(char *, int));
 int	_EXFUN(mkostemps,(char *, int, int));
 int	_EXFUN(mkstemp,(char *));
 int	_EXFUN(mkstemps,(char *, int));
-char *	_EXFUN(mktemp,(char *)); /* _ATTRIBUTE ((__warning__ ("the use of `mktemp' is dangerous; use `mkstemp' instead")))); */
+char *	_EXFUN(mktemp,(char *) _ATTRIBUTE (__warning__ ("the use of `mktemp' is dangerous; use `mkstemp' instead")));
 #endif
 char *	_EXFUN(_mkdtemp_r, (struct _reent *, char *));
 int	_EXFUN(_mkostemp_r, (struct _reent *, char *, int));
 int	_EXFUN(_mkostemps_r, (struct _reent *, char *, int, int));
 int	_EXFUN(_mkstemp_r, (struct _reent *, char *));
 int	_EXFUN(_mkstemps_r, (struct _reent *, char *, int));
-char *	_EXFUN(_mktemp_r, (struct _reent *, char *)); /* _ATTRIBUTE ((__warning__ ("the use of `mktemp' is dangerous; use `mkstemp' instead")))); */
+char *	_EXFUN(_mktemp_r, (struct _reent *, char *) _ATTRIBUTE (__warning__ ("the use of `mktemp' is dangerous; use `mkstemp' instead")));
 #endif
 _VOID	_EXFUN(qsort,(_PTR __base, size_t __nmemb, size_t __size, int(*_compar)(const _PTR, const _PTR)));
 int	_EXFUN(rand,(_VOID));
@@ -144,7 +144,7 @@ long    _EXFUN(a64l,(const char *__input));
 char *  _EXFUN(l64a,(long __input));
 char *  _EXFUN(_l64a_r,(struct _reent *,long __input));
 int	_EXFUN(on_exit,(_VOID (*__func)(int, _PTR),_PTR __arg));
-_VOID	_EXFUN(_Exit,(int __status)); /* _ATTRIBUTE ((noreturn))); */
+_VOID	_EXFUN(_Exit,(int __status) _ATTRIBUTE(noreturn));
 int	_EXFUN(putenv,(char *__string));
 int	_EXFUN(_putenv_r,(struct _reent *, char *__string));
 _PTR	_EXFUN(_reallocf_r,(struct _reent *, _PTR, size_t));

--- a/system/include/libc/sys/unistd.h
+++ b/system/include/libc/sys/unistd.h
@@ -14,7 +14,7 @@ extern "C" {
 
 extern char **environ;
 
-void	_EXFUN(_exit, (int __status )); /* _ATTRIBUTE ((noreturn))); */
+void	_EXFUN(_exit, (int __status ) _ATTRIBUTE(noreturn));
 
 int	_EXFUN(access,(const char *__path, int __amode ));
 unsigned  _EXFUN(alarm, (unsigned __secs ));


### PR DESCRIPTION
These were broken because the definition of _ATTRIBUTE() from
libcxx was different, so change the libc definition and usage
to match.

Fixes issue #992.
