### PR TITLE
Reinstate tests

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -7192,7 +7192,6 @@ void*:16
 
     def test_mmap(self):
       if self.emcc_args is None: return self.skip('requires emcc')
-      self.banned_js_engines = [NODE_JS] # slower, and fail on 64-bit
 
       Settings.TOTAL_MEMORY = 128*1024*1024
 


### PR DESCRIPTION
I'm using a 64 node 0.8.16 and these work for me:

```
batavia:emscripten bruce (incoming) $ file /usr/local/bin/node
/usr/local/bin/node: Mach-O 64-bit executable x86_64
batavia:emscripten bruce (incoming) $ node -v
v0.8.16
```
