### PR TITLE
Changed the shebang!

### DIFF
--- a/emcc
+++ b/emcc
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 # -*- Mode: python -*-
 
 '''


### PR DESCRIPTION
env will search $PATH for python and then exec the first one.

If this does not work, we need to write a bash wrapper around this to test and set the required path.
