### PR TITLE
-nostdinc++ is needed to not pick up system C++ headers.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -385,8 +385,7 @@ USE_EMSDK = not os.environ.get('EMMAKEN_NO_SDK')
 if USE_EMSDK:
   # Disable system C and C++ include directories, and add our own (using -idirafter so they are last, like system dirs, which
   # allows projects to override them)
-  # Note that -nostdinc++ is not needed, since -nostdinc implies that!
-  EMSDK_OPTS = ['-nostdinc', '-Xclang', '-nobuiltininc', '-Xclang', '-nostdsysteminc',
+  EMSDK_OPTS = ['-nostdinc', '-Xclang', '-nostdinc++', '-Xclang', '-nobuiltininc', '-Xclang', '-nostdsysteminc',
     '-Xclang', '-isystem' + path_from_root('system', 'local', 'include'),
     '-Xclang', '-isystem' + path_from_root('system', 'include', 'libcxx'),
     '-Xclang', '-isystem' + path_from_root('system', 'include'),


### PR DESCRIPTION
This fixes an issue that Marcos Scriven found and discussed on the mailing list.

It undoes this comment from @ehsan https://github.com/kripken/emscripten/commit/74a7e8e which was part of pull request #478.

This doesn't change anything for me on OS X, but part of that might be that the target triple is not native, so I don't have directories for that stuff anyway. If that's the case, someone might check this on x86-linux.

I don't see any new warnings or spew like @ehsan was seeing before from having this enabled all the time.
