### PR TITLE
Work around problem with constexpr on Windows.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -374,10 +374,11 @@ except:
 # Force a simple, standard target as much as possible: target 32-bit linux, and disable various flags that hint at other platforms
 # -fno-ms-compatibility is passed, since on Windows, Clang enables a 'MS compatibility mode' by default, that disables char16_t and char32_t 
 #                       to be MSVC header -compatible. This would cause build errors in libcxx file __config.
+# -fno-delayed-template-parsing is needed on Windows due to http://llvm.org/PR15651
 COMPILER_OPTS = COMPILER_OPTS + ['-m32', '-U__i386__', '-U__x86_64__', '-U__i386', '-U__x86_64', '-Ui386', '-Ux86_64', '-U__SSE__', '-U__SSE2__', '-U__MMX__',
                                  '-UX87_DOUBLE_ROUNDING', '-UHAVE_GCC_ASM_FOR_X87', '-DEMSCRIPTEN', '-U__STRICT_ANSI__', '-U__CYGWIN__',
                                  '-D__STDC__', '-Xclang', '-triple=i386-pc-linux-gnu', '-D__IEEE_LITTLE_ENDIAN', '-fno-math-errno', 
-                                 '-fno-ms-compatibility']
+                                 '-fno-ms-compatibility', '-fno-delayed-template-parsing']
 
 USE_EMSDK = not os.environ.get('EMMAKEN_NO_SDK')
 


### PR DESCRIPTION
This is for libcxx compilation on Windows and is a result of
http://llvm.org/PR15651.

See issue #1019 for more detail.

This obsoletes pull request #1020 as well.
