### PR TITLE
Fix warning: -nostdinc++ unused during compilation

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -385,7 +385,12 @@ USE_EMSDK = not os.environ.get('EMMAKEN_NO_SDK')
 if USE_EMSDK:
   # Disable system C and C++ include directories, and add our own (using -idirafter so they are last, like system dirs, which
   # allows projects to override them)
-  EMSDK_OPTS = ['-nostdinc', '-nostdinc++', '-Xclang', '-nobuiltininc', '-Xclang', '-nostdsysteminc',
+  EMSDK_OPTS = []
+  if os.environ.get('EMMAKEN_CXX'):
+    EMSDK_OPTS = ['-nostdinc++']
+  else:
+    EMSDK_OPTS = ['-nostdinc']
+  EMSDK_OPTS = EMSDK_OPTS + ['-Xclang', '-nobuiltininc', '-Xclang', '-nostdsysteminc',
     '-Xclang', '-isystem' + path_from_root('system', 'local', 'include'),
     '-Xclang', '-isystem' + path_from_root('system', 'include', 'libcxx'),
     '-Xclang', '-isystem' + path_from_root('system', 'include'),


### PR DESCRIPTION
This now only passes -nostdinc++ when using C++ and -nostdinc
when using C.
