### PR TITLE
Include arpa/inet.h in netinet/in.h

### DIFF
--- a/system/include/net/netinet/in.h
+++ b/system/include/net/netinet/in.h
@@ -6,6 +6,8 @@
 extern "C" {
 #endif
 
+#include <arpa/inet.h>
+
 enum {
     IPPROTO_IP = 0,
 #define IPPROTO_IP IPPROTO_IP


### PR DESCRIPTION
Some systems require the inclusion of `netinet/in.h` instead of `arpa/inet.h` for `htonl, htons, ntohl, ntohs`.
