### PR TITLE
Remove '.' print in tools/js_optimizer.py. Fixes other.test_chunking on Windows.

### DIFF
--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -100,7 +100,7 @@ def run_on_chunk(command):
   f = open(filename, 'w')
   f.write(output)
   f.close()
-  if DEBUG: print >> sys.stderr, '.'
+  if DEBUG and not shared.WINDOWS: print >> sys.stderr, '.' # Skip debug progress indicator on Windows, since it doesn't buffer well with multiple threads printing to console.
   return filename
 
 def run_on_js(filename, passes, js_engine, jcache):


### PR DESCRIPTION
On Windows, prints to stdout/stderr do not appear coherently synchronized per-line if multiple threads print data simultaneously to console. This caused other.test_chunking tests to fail when they receive output like

emcc:    step took 5.09 seconds
emcc: running pre-closure post-opts
emcc: running post-closure post-opts
emcc: applying js optimization passes: ['eliminate', 'simplifyExpressionsPre', 'simplifyExpressionsPost', 'last']
splitting up js o.
ptimization into 2 chunks of size 1048576, using 2 cores  (total: 1.42 MB)
emcc:    step took 2.37 seconds
emcc: total time: 11.75 seconds

where the test looks for the string 'splitting up js optimization into' from the output. Note that the chunk processor thread has printed a single '.' in between the critical line, creating a race condition that randomly makes the test pass or fail, depending on where in the output the '.' lands in.
