### PR TITLE
scanf: support '*', which matches without assigning to an argument.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -55,4 +55,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Tobias Doerffel <tobias.doerffel@gmail.com>
 * Martin von Gagern <martin@von-gagern.net>
 * Ting-Yuan Huang <thuang@mozilla.com>
-
+* Jacob Lee <artdent@gmail.com> (copyright owned by Google, Inc.)

--- a/src/library.js
+++ b/src/library.js
@@ -2513,6 +2513,11 @@ LibraryManager.library = {
 
       if (format[formatIndex] === '%') {
         formatIndex++;
+        var suppressAssignment = false;
+        if (format[formatIndex] == '*') {
+          suppressAssignment = true;
+          formatIndex++;
+        }
         var maxSpecifierStart = formatIndex;
         while (format[formatIndex].charCodeAt(0) >= {{{ charCode('0') }}} &&
                format[formatIndex].charCodeAt(0) <= {{{ charCode('9') }}}) {
@@ -2578,6 +2583,8 @@ LibraryManager.library = {
           unget();
         }
         if (buffer.length === 0) return 0;  // Failure.
+        if (suppressAssignment) continue;
+
         var text = buffer.join('');
         var argPtr = {{{ makeGetValue('varargs', 'argIndex', 'void*') }}};
         argIndex += Runtime.getNativeFieldSize('void*');

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -5743,6 +5743,24 @@ Pass: 0.000012 0.000012''')
       '''
       self.do_run(src, '2,  , black\n2, ., #001100\n2, X, #111100');
 
+    def test_sscanf_skip(self):
+      src = r'''
+        #include <stdio.h>
+
+        int main(){
+            int val1;
+            printf("%d\n", sscanf("10 20 30 40", "%*lld %*d %d", &val1));
+            printf("%d\n", val1);
+
+            int64_t large, val2;
+            printf("%d\n", sscanf("1000000 -1125899906842620 -123 -1073741823", "%lld %*lld %ld %*d", &large, &val2));
+            printf("%lld,%d\n", large, val2);
+
+            return 0;
+        }
+      '''
+      self.do_run(src, '1\n30\n2\n1000000,-123\n')
+
     def test_langinfo(self):
       src = open(path_from_root('tests', 'langinfo', 'test.c'), 'r').read()
       expected = open(path_from_root('tests', 'langinfo', 'output.txt'), 'r').read()


### PR DESCRIPTION
For example, sscanf("1 2 3", "%*d %d", &foo) stores 2 into foo.

I tested this by running test_sscanf\* and test_files.
