### PR TITLE
File Packager improvements

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -110,9 +110,13 @@ for arg in sys.argv[1:]:
   elif in_preload:
     if os.path.isfile(arg) or os.path.isdir(arg):
       data_files.append({ 'name': arg, 'mode': 'preload' })
+    else:
+      print >> sys.stderr, 'Warning: ' + arg + ' does not exist, ignoring.'
   elif in_embed:
     if os.path.isfile(arg) or os.path.isdir(arg):
       data_files.append({ 'name': arg, 'mode': 'embed' })
+    else:
+      print >> sys.stderr, 'Warning:' + arg + ' does not exist, ignoring.'
   elif in_compress:
     if in_compress == 1:
       Compression.encoder = arg


### PR DESCRIPTION
Hi.
This adds a `--js-output` argument to the file_packager, allowing users to specify an output js file. It displays usage when no argument is passed. Unexisting input files are ignored. If `--no-force` argument is passed, and no input file is valid, the packager creates no archive and outputs nothing. 
