### PR TITLE
Use a generic constraint for test_inlinejs.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -3541,7 +3541,7 @@ def process(filename):
 
           double get() {
             double ret = 0;
-            __asm __volatile__("12/3.3":"=a"(ret));
+            __asm __volatile__("12/3.3":"=r"(ret));
             return ret;
           }
 


### PR DESCRIPTION
This being generic lets it work with multiple target triples
rather than being x86-specific. This works under both the
current target triple and le32-unknown-nacl.
