### PR TITLE
exitPointerLock workaround to unblock Safari / Mobile Safari

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -202,7 +202,9 @@ mergeInto(LibraryManager.library, {
       canvas.exitPointerLock = document['exitPointerLock'] ||
                                document['mozExitPointerLock'] ||
                                document['webkitExitPointerLock'];
-      canvas.exitPointerLock = canvas.exitPointerLock.bind(document);
+      if(canvas.exitPointerLock) {
+        canvas.exitPointerLock = canvas.exitPointerLock.bind(document);
+      }
 
       function pointerLockChange() {
         Browser.pointerLock = document['pointerLockElement'] === canvas ||


### PR DESCRIPTION
Hi! I've only had a chance to test this on Safari 6.0.4 and the Mobile Safari bundled with iOS 6.1.2. Apologies if this is already being tracked - I couldn't find any references to it.

Without this change, Safari appears to hit a certain (shallow) point and then silently errors out with:

```
TypeError: 'undefined' is not an object (evaluating 'canvas.exitPointerLock.bind')
```

which is raised by this line:

```
canvas.exitPointerLock = canvas.exitPointerLock.bind(document);
```

So the change simply tests the existence of canvas.exitPointerLock prior to calling and skips the call if the test fails.
