### PR TITLE
Better guessing for LLVM_ROOT.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -111,7 +111,7 @@ else:
     config_file = config_file.replace('{{{ EMSCRIPTEN_ROOT }}}', __rootpath__)
     llvm_root = '/usr/bin'
     try:
-      llvm_root = os.path.dirname(Popen(['which', 'clang'], stdout=PIPE).communicate()[0].replace('\n', ''))
+      llvm_root = os.path.dirname(Popen(['which', 'llvm-dis'], stdout=PIPE).communicate()[0].replace('\n', ''))
     except:
       pass
     config_file = config_file.replace('{{{ LLVM_ROOT }}}', llvm_root)


### PR DESCRIPTION
On OS X, there is a system-wide clang that is the wrong version,
so the guessing goes wrong. Looking for llvm-dis is less likely
to go wrong and is also required by the build process.
