### PR TITLE
Flag malloc_usable_size as weak.

### DIFF
--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -1275,7 +1275,8 @@ extern "C" {
      p = malloc(n);
      assert(malloc_usable_size(p) >= 256);
      */
-    size_t dlmalloc_usable_size(void*);
+    /* XXX EMSCRIPTEN: mark for export (and therefore weak) */
+    DLMALLOC_EXPORT size_t dlmalloc_usable_size(void*);
     
 #endif /* ONLY_MSPACES */
     

--- a/system/lib/libc.symbols
+++ b/system/lib/libc.symbols
@@ -55,7 +55,7 @@
          W malloc_set_footprint_limit
          W malloc_stats
          W malloc_trim
-         T malloc_usable_size
+         W malloc_usable_size
          W mallopt
          W memalign
          C optarg


### PR DESCRIPTION
This makes it match the other malloc symbols.
