### PR TITLE
Freetype ASM_JS warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@ src/relooper/*.o
 src/relooper/*.out
 
 tests/fake/
+tests/freetype/objs/*.o
+tests/freetype/objs/*.lo
 
 third_party/lzma.js/lzip/*.o
 third_party/lzma.js/lzma-native

--- a/tests/freetype/src/autofit/afdummy.c
+++ b/tests/freetype/src/autofit/afdummy.c
@@ -34,11 +34,11 @@
   static FT_Error
   af_dummy_hints_apply( AF_GlyphHints  hints,
                         FT_Outline*    outline,
-                        AF_ScriptMetrics  metrics )
+                        AF_ScriptMetrics  metrics ) /* XXX EMSCRIPTEN */
   {
     FT_UNUSED( hints );
     FT_UNUSED( outline );
-    FT_UNUSED( metrics );
+    FT_UNUSED( metrics ); /* XXX EMSCRIPTEN */
 
     return 0;
   }

--- a/tests/freetype/src/autofit/afdummy.c
+++ b/tests/freetype/src/autofit/afdummy.c
@@ -33,10 +33,12 @@
 
   static FT_Error
   af_dummy_hints_apply( AF_GlyphHints  hints,
-                        FT_Outline*    outline )
+                        FT_Outline*    outline,
+                        AF_ScriptMetrics  metrics )
   {
     FT_UNUSED( hints );
     FT_UNUSED( outline );
+    FT_UNUSED( metrics );
 
     return 0;
   }

--- a/tests/freetype/src/autofit/aftypes.h
+++ b/tests/freetype/src/autofit/aftypes.h
@@ -309,7 +309,7 @@ extern void*  _af_debug_hints;
   (*AF_Script_InitHintsFunc)( AF_GlyphHints     hints,
                               AF_ScriptMetrics  metrics );
 
-  typedef void
+  typedef FT_Error
   (*AF_Script_ApplyHintsFunc)( AF_GlyphHints     hints,
                                FT_Outline*       outline,
                                AF_ScriptMetrics  metrics );

--- a/tests/freetype/src/autofit/aftypes.h
+++ b/tests/freetype/src/autofit/aftypes.h
@@ -309,7 +309,7 @@ extern void*  _af_debug_hints;
   (*AF_Script_InitHintsFunc)( AF_GlyphHints     hints,
                               AF_ScriptMetrics  metrics );
 
-  typedef FT_Error
+  typedef FT_Error /* XXX EMSCRIPTEN */
   (*AF_Script_ApplyHintsFunc)( AF_GlyphHints     hints,
                                FT_Outline*       outline,
                                AF_ScriptMetrics  metrics );

--- a/tests/freetype/src/cff/cffcmap.c
+++ b/tests/freetype/src/cff/cffcmap.c
@@ -31,12 +31,12 @@
   /*************************************************************************/
 
   FT_CALLBACK_DEF( FT_Error )
-  cff_cmap_encoding_init( CFF_CMapStd  cmap )
+  cff_cmap_encoding_init( CFF_CMapStd  cmap, FT_Pointer init_data )
   {
     TT_Face       face     = (TT_Face)FT_CMAP_FACE( cmap );
     CFF_Font      cff      = (CFF_Font)face->extra.data;
     CFF_Encoding  encoding = &cff->encoding;
-
+    FT_UNUSED(init_data);
 
     cmap->gids  = encoding->codes;
 
@@ -133,14 +133,14 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  cff_cmap_unicode_init( PS_Unicodes  unicodes )
+  cff_cmap_unicode_init( PS_Unicodes  unicodes, FT_Pointer init_data )
   {
     TT_Face             face    = (TT_Face)FT_CMAP_FACE( unicodes );
     FT_Memory           memory  = FT_FACE_MEMORY( face );
     CFF_Font            cff     = (CFF_Font)face->extra.data;
     CFF_Charset         charset = &cff->charset;
     FT_Service_PsCMaps  psnames = (FT_Service_PsCMaps)cff->psnames;
-
+    FT_UNUSED(init_data);
 
     /* can't build Unicode map for CID-keyed font */
     /* because we don't know glyph names.         */

--- a/tests/freetype/src/cff/cffcmap.c
+++ b/tests/freetype/src/cff/cffcmap.c
@@ -31,12 +31,12 @@
   /*************************************************************************/
 
   FT_CALLBACK_DEF( FT_Error )
-  cff_cmap_encoding_init( CFF_CMapStd  cmap, FT_Pointer init_data )
+  cff_cmap_encoding_init( CFF_CMapStd  cmap, FT_Pointer init_data ) /* XXX EMSCRIPTEN */
   {
     TT_Face       face     = (TT_Face)FT_CMAP_FACE( cmap );
     CFF_Font      cff      = (CFF_Font)face->extra.data;
     CFF_Encoding  encoding = &cff->encoding;
-    FT_UNUSED(init_data);
+    FT_UNUSED(init_data); /* XXX EMSCRIPTEN */
 
     cmap->gids  = encoding->codes;
 
@@ -133,14 +133,14 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  cff_cmap_unicode_init( PS_Unicodes  unicodes, FT_Pointer init_data )
+  cff_cmap_unicode_init( PS_Unicodes  unicodes, FT_Pointer init_data ) /* XXX EMSCRIPTEN */
   {
     TT_Face             face    = (TT_Face)FT_CMAP_FACE( unicodes );
     FT_Memory           memory  = FT_FACE_MEMORY( face );
     CFF_Font            cff     = (CFF_Font)face->extra.data;
     CFF_Charset         charset = &cff->charset;
     FT_Service_PsCMaps  psnames = (FT_Service_PsCMaps)cff->psnames;
-    FT_UNUSED(init_data);
+    FT_UNUSED(init_data); /* XXX EMSCRIPTEN */
 
     /* can't build Unicode map for CID-keyed font */
     /* because we don't know glyph names.         */

--- a/tests/freetype/src/cid/cidload.c
+++ b/tests/freetype/src/cid/cidload.c
@@ -146,7 +146,8 @@
   }
 
 
-  FT_CALLBACK_DEF( FT_Error )
+/*  FT_CALLBACK_DEF( FT_Error )*/
+  FT_CALLBACK_DEF( void )
   parse_font_matrix( CID_Face     face,
                      CID_Parser*  parser )
   {
@@ -195,14 +196,16 @@
       offset->y  = temp[5] >> 16;
     }
 
-    return CID_Err_Ok;      /* this is a callback function; */
+    return;
+    /*return CID_Err_Ok;*/      /* this is a callback function; */
                             /* we must return an error code */
   }
 
 
-  FT_CALLBACK_DEF( FT_Error )
+/*  FT_CALLBACK_DEF( FT_Error ) */
+  FT_CALLBACK_DEF( void )
   parse_fd_array( CID_Face     face,
-                  CID_Parser*  parser )
+                  CID_Parser*  parser)
   {
     CID_FaceInfo  cid    = &face->cid;
     FT_Memory     memory = face->root.memory;
@@ -232,9 +235,10 @@
         dict->private_dict.lenIV = 4;
       }
     }
-
+    
   Exit:
-    return error;
+/*    return error; */
+  return;
   }
 
 
@@ -242,9 +246,10 @@
   /* and CID_FaceDictRec (both are public header files and can't  */
   /* changed); we simply copy the value                           */
 
-  FT_CALLBACK_DEF( FT_Error )
+/*  FT_CALLBACK_DEF( FT_Error ) */
+  FT_CALLBACK_DEF( void )
   parse_expansion_factor( CID_Face     face,
-                          CID_Parser*  parser )
+                          CID_Parser*  parser)
   {
     CID_FaceDict  dict;
 
@@ -257,7 +262,7 @@
       dict->private_dict.expansion_factor = dict->expansion_factor;
     }
 
-    return CID_Err_Ok;
+ /*   return CID_Err_Ok; */
   }
 
 

--- a/tests/freetype/src/cid/cidload.c
+++ b/tests/freetype/src/cid/cidload.c
@@ -146,8 +146,7 @@
   }
 
 
-/*  FT_CALLBACK_DEF( FT_Error )*/
-  FT_CALLBACK_DEF( void )
+  FT_CALLBACK_DEF( void ) /* XXX EMSCRIPTEN */
   parse_font_matrix( CID_Face     face,
                      CID_Parser*  parser )
   {
@@ -196,16 +195,13 @@
       offset->y  = temp[5] >> 16;
     }
 
-    return;
-    /*return CID_Err_Ok;*/      /* this is a callback function; */
-                            /* we must return an error code */
+    return; /* XXX EMSCRIPTEN */
   }
 
 
-/*  FT_CALLBACK_DEF( FT_Error ) */
-  FT_CALLBACK_DEF( void )
+  FT_CALLBACK_DEF( void ) /* XXX EMSCRIPTEN */
   parse_fd_array( CID_Face     face,
-                  CID_Parser*  parser)
+                  CID_Parser*  parser )
   {
     CID_FaceInfo  cid    = &face->cid;
     FT_Memory     memory = face->root.memory;
@@ -237,8 +233,7 @@
     }
     
   Exit:
-/*    return error; */
-  return;
+    return; /* XXX EMSCRIPTEN */
   }
 
 
@@ -246,8 +241,7 @@
   /* and CID_FaceDictRec (both are public header files and can't  */
   /* changed); we simply copy the value                           */
 
-/*  FT_CALLBACK_DEF( FT_Error ) */
-  FT_CALLBACK_DEF( void )
+  FT_CALLBACK_DEF( void ) /* XXX EMSCRIPTEN */
   parse_expansion_factor( CID_Face     face,
                           CID_Parser*  parser)
   {
@@ -262,7 +256,7 @@
       dict->private_dict.expansion_factor = dict->expansion_factor;
     }
 
- /*   return CID_Err_Ok; */
+    return; /* XXX EMSCRIPTEN */
   }
 
 

--- a/tests/freetype/src/pfr/pfrcmap.c
+++ b/tests/freetype/src/pfr/pfrcmap.c
@@ -23,11 +23,11 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  pfr_cmap_init( PFR_CMap  cmap )
+  pfr_cmap_init( PFR_CMap  cmap, FT_Pointer  init_data )
   {
     FT_Error  error = PFR_Err_Ok;
     PFR_Face  face  = (PFR_Face)FT_CMAP_FACE( cmap );
-
+    FT_UNUSED(init_data);
 
     cmap->num_chars = face->phy_font.num_chars;
     cmap->chars     = face->phy_font.chars;

--- a/tests/freetype/src/pfr/pfrcmap.c
+++ b/tests/freetype/src/pfr/pfrcmap.c
@@ -23,11 +23,11 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  pfr_cmap_init( PFR_CMap  cmap, FT_Pointer  init_data )
+  pfr_cmap_init( PFR_CMap  cmap, FT_Pointer  init_data ) /* XXX EMSCRIPTEN */
   {
     FT_Error  error = PFR_Err_Ok;
     PFR_Face  face  = (PFR_Face)FT_CMAP_FACE( cmap );
-    FT_UNUSED(init_data);
+    FT_UNUSED(init_data); /* XXX EMSCRIPTEN */
 
     cmap->num_chars = face->phy_font.num_chars;
     cmap->chars     = face->phy_font.chars;

--- a/tests/freetype/src/psaux/t1cmap.c
+++ b/tests/freetype/src/psaux/t1cmap.c
@@ -120,8 +120,9 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  t1_cmap_standard_init( T1_CMapStd  cmap )
+  t1_cmap_standard_init( T1_CMapStd  cmap, FT_Pointer init_data )
   {
+    FT_UNUSED(init_data);
     t1_cmap_std_init( cmap, 0 );
     return 0;
   }
@@ -142,8 +143,9 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  t1_cmap_expert_init( T1_CMapStd  cmap )
+  t1_cmap_expert_init( T1_CMapStd  cmap, FT_Pointer init_data )
   {
+    FT_UNUSED(init_data);
     t1_cmap_std_init( cmap, 1 );
     return 0;
   }
@@ -172,11 +174,11 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  t1_cmap_custom_init( T1_CMapCustom  cmap )
+  t1_cmap_custom_init( T1_CMapCustom  cmap, FT_Pointer init_data )
   {
     T1_Face      face     = (T1_Face)FT_CMAP_FACE( cmap );
     T1_Encoding  encoding = &face->type1.encoding;
-
+    FT_UNUSED(init_data);
 
     cmap->first   = encoding->code_first;
     cmap->count   = (FT_UInt)( encoding->code_last - cmap->first );
@@ -272,12 +274,12 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  t1_cmap_unicode_init( PS_Unicodes  unicodes )
+  t1_cmap_unicode_init( PS_Unicodes  unicodes, FT_Pointer init_data )
   {
     T1_Face             face    = (T1_Face)FT_CMAP_FACE( unicodes );
     FT_Memory           memory  = FT_FACE_MEMORY( face );
     FT_Service_PsCMaps  psnames = (FT_Service_PsCMaps)face->psnames;
-
+    FT_UNUSED(init_data);
 
     return psnames->unicodes_init( memory,
                                    unicodes,

--- a/tests/freetype/src/psaux/t1cmap.c
+++ b/tests/freetype/src/psaux/t1cmap.c
@@ -120,9 +120,9 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  t1_cmap_standard_init( T1_CMapStd  cmap, FT_Pointer init_data )
+  t1_cmap_standard_init( T1_CMapStd  cmap, FT_Pointer init_data ) /* XXX EMSCRIPTEN */
   {
-    FT_UNUSED(init_data);
+    FT_UNUSED(init_data); /* XXX EMSCRIPTEN */
     t1_cmap_std_init( cmap, 0 );
     return 0;
   }
@@ -143,9 +143,9 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  t1_cmap_expert_init( T1_CMapStd  cmap, FT_Pointer init_data )
+  t1_cmap_expert_init( T1_CMapStd  cmap, FT_Pointer init_data ) /* XXX EMSCRIPTEN */
   {
-    FT_UNUSED(init_data);
+    FT_UNUSED(init_data); /* XXX EMSCRIPTEN */
     t1_cmap_std_init( cmap, 1 );
     return 0;
   }
@@ -174,11 +174,11 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  t1_cmap_custom_init( T1_CMapCustom  cmap, FT_Pointer init_data )
+  t1_cmap_custom_init( T1_CMapCustom  cmap, FT_Pointer init_data ) /* XXX EMSCRIPTEN */
   {
     T1_Face      face     = (T1_Face)FT_CMAP_FACE( cmap );
     T1_Encoding  encoding = &face->type1.encoding;
-    FT_UNUSED(init_data);
+    FT_UNUSED(init_data); /* XXX EMSCRIPTEN */
 
     cmap->first   = encoding->code_first;
     cmap->count   = (FT_UInt)( encoding->code_last - cmap->first );
@@ -274,12 +274,12 @@
 
 
   FT_CALLBACK_DEF( FT_Error )
-  t1_cmap_unicode_init( PS_Unicodes  unicodes, FT_Pointer init_data )
+  t1_cmap_unicode_init( PS_Unicodes  unicodes, FT_Pointer init_data ) /* XXX EMSCRIPTEN */
   {
     T1_Face             face    = (T1_Face)FT_CMAP_FACE( unicodes );
     FT_Memory           memory  = FT_FACE_MEMORY( face );
     FT_Service_PsCMaps  psnames = (FT_Service_PsCMaps)face->psnames;
-    FT_UNUSED(init_data);
+    FT_UNUSED(init_data); /* XXX EMSCRIPTEN */
 
     return psnames->unicodes_init( memory,
                                    unicodes,

--- a/tests/freetype/src/raster/ftraster.c
+++ b/tests/freetype/src/raster/ftraster.c
@@ -3462,7 +3462,7 @@
   }
 
 
-  static int
+  static int /* XXX EMSCRIPTEN */
   ft_black_set_mode( PRaster        raster,
                      unsigned long  mode,
                      const char*    palette )
@@ -3486,7 +3486,7 @@
     FT_UNUSED( palette );
 
 #endif
-	return 0;
+	return 0; /* XXX EMSCRIPTEN */
   }
 
 

--- a/tests/freetype/src/raster/ftraster.c
+++ b/tests/freetype/src/raster/ftraster.c
@@ -3462,7 +3462,7 @@
   }
 
 
-  static void
+  static int
   ft_black_set_mode( PRaster        raster,
                      unsigned long  mode,
                      const char*    palette )
@@ -3486,6 +3486,7 @@
     FT_UNUSED( palette );
 
 #endif
+	return 0;
   }
 
 

--- a/tests/freetype/src/winfonts/winfnt.c
+++ b/tests/freetype/src/winfonts/winfnt.c
@@ -591,11 +591,11 @@
 
 
   static FT_Error
-  fnt_cmap_init( FNT_CMap  cmap )
+  fnt_cmap_init( FNT_CMap  cmap, FT_Pointer init_data )
   {
     FNT_Face  face = (FNT_Face)FT_CMAP_FACE( cmap );
     FNT_Font  font = face->font;
-
+	FT_UNUSED(init_data);
 
     cmap->first = (FT_UInt32)  font->header.first_char;
     cmap->count = (FT_UInt32)( font->header.last_char - cmap->first + 1 );
@@ -882,13 +882,14 @@
 
 
   static FT_Error
-  FNT_Size_Select( FT_Size  size )
+  FNT_Size_Select( FT_Size  size, FT_ULong  size_index )
   {
     FNT_Face          face   = (FNT_Face)size->face;
     FT_WinFNT_Header  header = &face->font->header;
 
 
     FT_Select_Metrics( size->face, 0 );
+    FT_UNUSED(size_index);
 
     size->metrics.ascender    = header->ascent * 64;
     size->metrics.descender   = -( header->pixel_height -
@@ -933,7 +934,7 @@
     if ( error )
       return error;
     else
-      return FNT_Size_Select( size );
+      return FNT_Size_Select( size, 0 );
   }
 
 

--- a/tests/freetype/src/winfonts/winfnt.c
+++ b/tests/freetype/src/winfonts/winfnt.c
@@ -591,11 +591,11 @@
 
 
   static FT_Error
-  fnt_cmap_init( FNT_CMap  cmap, FT_Pointer init_data )
+  fnt_cmap_init( FNT_CMap  cmap, FT_Pointer init_data ) /* XXX EMSCRIPTEN */
   {
     FNT_Face  face = (FNT_Face)FT_CMAP_FACE( cmap );
     FNT_Font  font = face->font;
-	FT_UNUSED(init_data);
+    FT_UNUSED(init_data); /* XXX EMSCRIPTEN */
 
     cmap->first = (FT_UInt32)  font->header.first_char;
     cmap->count = (FT_UInt32)( font->header.last_char - cmap->first + 1 );
@@ -882,14 +882,14 @@
 
 
   static FT_Error
-  FNT_Size_Select( FT_Size  size, FT_ULong  size_index )
+  FNT_Size_Select( FT_Size  size, FT_ULong  size_index ) /* XXX EMSCRIPTEN */
   {
     FNT_Face          face   = (FNT_Face)size->face;
     FT_WinFNT_Header  header = &face->font->header;
 
 
     FT_Select_Metrics( size->face, 0 );
-    FT_UNUSED(size_index);
+    FT_UNUSED(size_index); /* XXX EMSCRIPTEN */
 
     size->metrics.ascender    = header->ascent * 64;
     size->metrics.descender   = -( header->pixel_height -
@@ -934,7 +934,7 @@
     if ( error )
       return error;
     else
-      return FNT_Size_Select( size, 0 );
+      return FNT_Size_Select( size, 0 ); /* XXX EMSCRIPTEN */
   }
 
 


### PR DESCRIPTION
Hi,
This commit removes some function pointer cast warnings when compiling freetype with asm.js, as discussed in the mailing list. Some warning remain though, but they are not related to asm.js (if I'm right):

```
WARNING: While resolving call to function 'FTC_GNode_Compare' arguments were dropped!
WARNING: While resolving call to function 'FTC_GNode_Compare' arguments were dropped!
Warning: cannot have duplicate variable names: $strongs_0_i
```
