### PR TITLE
Symlink support

### DIFF
--- a/emcc
+++ b/emcc
@@ -913,12 +913,11 @@ try:
       prev = newargs[i-1]
       if prev in ['-MT', '-install_name', '-I', '-L']: continue # ignore this gcc-style argument
 
-    if not arg.startswith('-') and (arg.endswith(SOURCE_SUFFIXES + BITCODE_SUFFIXES + DYNAMICLIB_SUFFIXES + ASSEMBLY_SUFFIXES) or shared.Building.is_ar(arg) or (os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_SUFFIXES + BITCODE_SUFFIXES + DYNAMICLIB_SUFFIXES + ASSEMBLY_SUFFIXES))): # we already removed -o <target>, so all these should be inputs
+    if (os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_SUFFIXES + BITCODE_SUFFIXES + DYNAMICLIB_SUFFIXES + ASSEMBLY_SUFFIXES)):
+      arg = os.path.realpath(arg)
+
+    if not arg.startswith('-') and (arg.endswith(SOURCE_SUFFIXES + BITCODE_SUFFIXES + DYNAMICLIB_SUFFIXES + ASSEMBLY_SUFFIXES) or shared.Building.is_ar(arg)): # we already removed -o <target>, so all these should be inputs
       newargs[i] = ''
-
-      if (os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_SUFFIXES + BITCODE_SUFFIXES + DYNAMICLIB_SUFFIXES + ASSEMBLY_SUFFIXES)):
-        arg = os.path.realpath(arg)
-
       if os.path.exists(arg):
         if arg.endswith(SOURCE_SUFFIXES):
           input_files.append(arg)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -9682,6 +9682,23 @@ f.close()
       self.assertContained('hello from lib', run_js(os.path.join(self.get_dir(), 'a.out.js')))
       assert not os.path.exists('a.out') and not os.path.exists('a.exe'), 'Must not leave unneeded linker stubs'
 
+    def test_symlink(self):
+      open(os.path.join(self.get_dir(), 'foobar.xxx'), 'w').write('int main(){ return 0; }')
+      os.symlink(os.path.join(self.get_dir(), 'foobar.xxx'), os.path.join(self.get_dir(), 'foobar.c'))
+      Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'foobar.c'), '-o', os.path.join(self.get_dir(), 'foobar')], stdout=PIPE, stderr=PIPE).communicate()
+      assert os.path.exists(os.path.join(self.get_dir(), 'foobar'))
+      try_delete(os.path.join(self.get_dir(), 'foobar'))
+      try_delete(os.path.join(self.get_dir(), 'foobar.xxx'))
+      try_delete(os.path.join(self.get_dir(), 'foobar.c'))
+
+      open(os.path.join(self.get_dir(), 'foobar.c'), 'w').write('int main(){ return 0; }')
+      os.symlink(os.path.join(self.get_dir(), 'foobar.c'), os.path.join(self.get_dir(), 'foobar.xxx'))
+      Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'foobar.xxx'), '-o', os.path.join(self.get_dir(), 'foobar')], stdout=PIPE, stderr=PIPE).communicate()
+      assert os.path.exists(os.path.join(self.get_dir(), 'foobar'))
+      try_delete(os.path.join(self.get_dir(), 'foobar'))
+      try_delete(os.path.join(self.get_dir(), 'foobar.xxx'))
+      try_delete(os.path.join(self.get_dir(), 'foobar.c'))
+      
     def test_multiply_defined_libsymbols(self):
       lib = "int mult() { return 1; }"
       lib_name = os.path.join(self.get_dir(), 'libA.c')


### PR DESCRIPTION
Hi.
This commit allows emcc to take symbolic links as input files, even if link has an unsupported extension. This allows to compiles with `libfoobar.so.0.0.0`, that is often used with configure/make. This should solve half of #1037.
