### PR TITLE
Colored messages 

### DIFF
--- a/emcc
+++ b/emcc
@@ -121,10 +121,6 @@ shared.check_sanity(force=DEBUG)
 
 # Handle some global flags
 
-if len(sys.argv) == 1:
-  logging.error('no input files')
-  exit(1)
-
 # read response files very early on
 response_file = True
 while response_file:
@@ -138,23 +134,7 @@ while response_file:
       sys.argv[index:index+1] = extra_args
       break
 
-if sys.argv[1] == '--version':
-  revision = '(unknown revision)'
-  here = os.getcwd()
-  os.chdir(shared.path_from_root())
-  try:
-    revision = execute(['git', 'show'], stdout=PIPE, stderr=PIPE)[0].split('\n')[0]
-  except:
-    pass
-  finally:
-    os.chdir(here)
-  print '''emcc (Emscripten GCC-like replacement) %s (%s)
-Copyright (C) 2013 the Emscripten authors (see AUTHORS.txt)
-This is free and open source software under the MIT license.
-There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ''' % (shared.EMSCRIPTEN_VERSION, revision)
-  exit(0)
-elif sys.argv[1] == '--help':
+if len(sys.argv) == 1 or sys.argv[1] == '--help':
   this = os.path.basename('em++' if os.environ.get('EMMAKEN_CXX') else 'emcc')
 
   print '''%s [options] file...
@@ -499,6 +479,24 @@ emcc: supported targets: llvm bitcode, javascript, NOT elf
 (autoconf likes to see elf above to enable shared object support)
 ''' % (this, this, this)
   exit(0)
+
+elif sys.argv[1] == '--version':
+  revision = '(unknown revision)'
+  here = os.getcwd()
+  os.chdir(shared.path_from_root())
+  try:
+    revision = execute(['git', 'show'], stdout=PIPE, stderr=PIPE)[0].split('\n')[0]
+  except:
+    pass
+  finally:
+    os.chdir(here)
+  print '''emcc (Emscripten GCC-like replacement) %s (%s)
+Copyright (C) 2013 the Emscripten authors (see AUTHORS.txt)
+This is free and open source software under the MIT license.
+There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+  ''' % (shared.EMSCRIPTEN_VERSION, revision)
+  exit(0)  
+
 elif len(sys.argv) == 2 and sys.argv[1] == '-v': # -v with no inputs
   print 'emcc (Emscripten GCC-like replacement + linker emulating GNU ld ) 2.0'
   exit(subprocess.call([shared.CLANG, '-v']))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -47,7 +47,7 @@ class WindowsPopen:
       # Call the process with fixed streams.
       self.process = subprocess.Popen(args, bufsize, executable, self.stdin_, self.stdout_, self.stderr_, preexec_fn, close_fds, shell, cwd, env, universal_newlines, startupinfo, creationflags)
     except Exception, e:
-      print >> sys.stderr, '\nsubprocess.Popen(args=%s) failed! Exception %s\n' % (' '.join(args), str(e))
+      logging.error('\nsubprocess.Popen(args=%s) failed! Exception %s\n' % (' '.join(args), str(e)))
       raise e
 
   def communicate(self, input=None):
@@ -136,17 +136,17 @@ def add_coloring_to_emit_windows(fn):
     BACKGROUND_MAGENTA   = 0x0050
     BACKGROUND_YELLOW    = 0x0060
     BACKGROUND_GREY      = 0x0070
-    BACKGROUND_INTENSITY = 0x0080 # background color is intensified.     
+    BACKGROUND_INTENSITY = 0x0080 # background color is intensified.
     levelno = args[1].levelno
-    if(levelno>=50):
-        color = BACKGROUND_YELLOW | FOREGROUND_RED | FOREGROUND_INTENSITY | BACKGROUND_INTENSITY 
-    elif(levelno>=40):
+    if(levelno >= 50):
+        color = BACKGROUND_YELLOW | FOREGROUND_RED | FOREGROUND_INTENSITY | BACKGROUND_INTENSITY
+    elif(levelno >= 40):
         color = FOREGROUND_RED | FOREGROUND_INTENSITY
-    elif(levelno>=30):
+    elif(levelno >= 30):
         color = FOREGROUND_YELLOW | FOREGROUND_INTENSITY
-    elif(levelno>=20):
+    elif(levelno >= 20):
         color = FOREGROUND_GREEN
-    elif(levelno>=10):
+    elif(levelno >= 10):
         color = FOREGROUND_MAGENTA
     else:
         color =  FOREGROUND_WHITE
@@ -161,15 +161,15 @@ def add_coloring_to_emit_ansi(fn):
   # add methods we need to the class
   def new(*args):
     levelno = args[1].levelno
-    if(levelno>=50):
+    if(levelno >= 50):
       color = '\x1b[31m' # red
-    elif(levelno>=40):
+    elif(levelno >= 40):
       color = '\x1b[31m' # red
-    elif(levelno>=30):
+    elif(levelno >= 30):
       color = '\x1b[33m' # yellow
-    elif(levelno>=20):
-      color = '\x1b[32m' # green 
-    elif(levelno>=10):
+    elif(levelno >= 20):
+      color = '\x1b[32m' # green
+    elif(levelno >= 10):
       color = '\x1b[35m' # pink
     else:
       color = '\x1b[0m' # normal
@@ -1020,7 +1020,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)''' % { 'winfix': '' if not WINDOWS e
   @staticmethod
   def llvm_nm(filename, stdout=PIPE, stderr=None):
     if filename in Building.nm_cache:
-      #if DEBUG: print >> sys.stderr, 'loading nm results for %s from cache' % filename
+      #logging.debug('loading nm results for %s from cache' % filename)
       return Building.nm_cache[filename]
 
     # LLVM binary ==> list of symbols


### PR DESCRIPTION
Hi,
This message brings a bit of color to messages emitted. You can enable it with `emcc --color` or `EMSCRIPTEN_COLOR=1` environment var. This is useful in case you compile huge projects (with emconfigure, emmake) and want to see the emscripten message lost in thousands of make messages.
