### PR TITLE
This header is <arpa/inet.h>, not <net/arpa/...>

### DIFF
--- a/tests/799.cpp
+++ b/tests/799.cpp
@@ -7,7 +7,7 @@
 #include <netinet/in.h>
 
 #ifdef EMSCRIPTEN
-#include <net/arpa/inet.h>
+#include <arpa/inet.h>
 #endif
 
 #define uint16 uint16_t


### PR DESCRIPTION
This fixes an error that happens when using updated libc includes (forthcoming).
