### PR TITLE
Use va_copy (C99) instead of __va_copy (GNU ext).

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -4016,7 +4016,7 @@ def process(filename):
 
             // Try it with copying
             va_list tempva;
-            __va_copy(tempva, v);
+            va_copy(tempva, v);
             vsnprintf(d, 20, s, tempva);
             puts(d);
 


### PR DESCRIPTION
musl libc headers don't have __va_copy as it is a GNU extension
and hasn't been needed for over a decade.
