### PR TITLE
check for existing /dev folder before creating

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -530,7 +530,7 @@ LibraryManager.library = {
       } catch(e) {}
 
       // Create the I/O devices.
-      var devFolder = FS.createFolder('/', 'dev', true, true);
+      var devFolder = FS.findObject("/dev") || FS.createFolder('/', 'dev', true, true);
       var stdin = FS.createDevice(devFolder, 'stdin', input);
       var stdout = FS.createDevice(devFolder, 'stdout', null, output);
       var stderr = FS.createDevice(devFolder, 'stderr', null, error);


### PR DESCRIPTION
This is to prevent emscripten trying to create /dev folder again if it has already been created for example in preRun()
