### PR TITLE
Make emscripten_get_now() work when running in SpiderMonkey shell. 

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -707,8 +707,9 @@ mergeInto(LibraryManager.library, {
     if (ENVIRONMENT_IS_NODE) {
         var t = process['hrtime']();
         return t[0] * 1e3 + t[1] / 1e6;
-    }
-    else if (window['performance'] && window['performance']['now']) {
+    } else if (ENVIRONMENT_IS_SHELL) {
+        return dateNow();
+    } else if (window['performance'] && window['performance']['now']) {
       return window['performance']['now']();
     } else {
       return Date.now();


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/SpiderMonkey/Hacking_Tips

I want to run MathGeoLib benchmarks through IonMonkey-enabled SpiderMonkey, and emscripten_get_now() fails there (no object window). Calling Date.now() gives only millisecond-precision, dateNow() returns sub-millisecond precision.

This pull request hasn't been tested at all in other environments. Is ENVIRONMENT_IS_SHELL the appropriate mechanism to detect SpiderMonkey?
