### PR TITLE
Add support for skipping all modes of a single test...

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -447,6 +447,8 @@ process(sys.argv[1])
 
 sys.argv = map(lambda arg: arg if not arg.startswith('test_') else 'default.' + arg, sys.argv)
 
+test_modes = ['default', 'o1', 'o2', 'asm1', 'asm2', 'asm2g', 'asm2x86', 's_0_0', 's_0_1', 's_1_0', 's_1_1']
+
 test_index = 0
 
 if 'benchmark' not in str(sys.argv) and 'sanity' not in str(sys.argv) and 'browser' not in str(sys.argv):
@@ -454,10 +456,10 @@ if 'benchmark' not in str(sys.argv) and 'sanity' not in str(sys.argv) and 'brows
 
   print "Running Emscripten tests..."
 
-  if len(sys.argv) == 2 and 'ALL.' in sys.argv[1]:
+  if len(sys.argv) == 2 and sys.argv[1].startswith('ALL.'):
     ignore, test = sys.argv[1].split('.')
     print 'Running all test modes on test "%s"' % test
-    sys.argv = [sys.argv[0], 'default.'+test, 'o1.'+test, 'o2.'+test, 'asm1.'+test, 'asm2.'+test, 'asm2g.'+test, 'asm2x86.'+test, 's_0_0.'+test, 's_0_1.'+test, 's_1_0.'+test, 's_1_1.'+test]
+    sys.argv = [sys.argv[0]] + map(lambda mode: mode+'.'+test, test_modes)
 
   class T(RunnerCore): # Short name, to make it more fun to use manually on the commandline
     ## Does a complete test - builds, runs, checks output, etc.
@@ -13423,8 +13425,17 @@ if __name__ == '__main__':
     arg = sys.argv[i]
     if arg.startswith('skip:'):
       which = arg.split('skip:')[1]
-      print >> sys.stderr, 'will skip "%s"' % which
-      exec(which + ' = RunnerCore.skipme')
+      if which.startswith('ALL.'):
+        ignore, test = which.split('.')
+        which = map(lambda mode: mode+'.'+test, test_modes)
+      else:
+        which = [which]
+      
+      print >> sys.stderr, ','.join(which)
+      for test in which:
+        print >> sys.stderr, 'will skip "%s"' % test
+        exec(test + ' = RunnerCore.skipme')
+
       sys.argv[i] = ''
   sys.argv = filter(lambda arg: arg, sys.argv)
 


### PR DESCRIPTION
...with 'python tests/runner.py skip:ALL.test_freetype', instead of having to specify all the modes for the test to be skipped by hand.

A common way the buildbots break is that a new test mode is added, but the set of skipped tests is specified manually for each test mode type, and the new test mode is then not skipped, but executed and resulting in failure. This allows setting up the skipped tests list so that it skips certain tests even if there are new test modes added.
