### PR TITLE
Remove the __native_client__ system define when using NaCl triple.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -510,7 +510,7 @@ COMPILER_OPTS = COMPILER_OPTS + ['-m32', '-U__i386__', '-U__i386', '-Ui386',
                                  '-target', LLVM_TARGET]
 
 if LLVM_TARGET == 'le32-unknown-nacl':
-  COMPILER_OPTS += ['-U__native_client__', '-U__pnacl__'] # The nacl target is originally used for Google Native Client. Emscripten is not NaCl, so remove the platform #define, when using their triple.
+  COMPILER_OPTS += ['-U__native_client__', '-U__pnacl__', '-U__ELF__'] # The nacl target is originally used for Google Native Client. Emscripten is not NaCl, so remove the platform #define, when using their triple.
 
 USE_EMSDK = not os.environ.get('EMMAKEN_NO_SDK')
 


### PR DESCRIPTION
 Emscripten does not implement Google Native Client/Pepper APIs.

I was quite surprised when after updating to newest Emscripten, my gfxapi engine builds started failing with the emscripten code including all native client headers! The #define **native_client** seems to come built-in from the nacl triple, so kill it when building.
