### PR TITLE
Fix bug in rename() that occures if new filename starts with the old filename

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3454,8 +3454,7 @@ LibraryManager.library = {
       ___setErrNo(ERRNO_CODES.EBUSY);
       return -1;
     } else if (newObj.parentPath &&
-               newObj.parentPath.indexOf(oldObj.parentPath) == 0 &&
-               newObj.parentPath != oldObj.parentPath) {
+               newObj.parentPath.indexOf(oldObj.path) == 0) {
       ___setErrNo(ERRNO_CODES.EINVAL);
       return -1;
     } else if (newObj.exists && newObj.object.isFolder) {

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -3414,6 +3414,7 @@ Exiting setjmp function, level: 0, prev_jmp: -1
           FILE* fid;
 
           err = mkdir("/foo", 0777);
+          err = mkdir("/bar", 0777);
           fid = fopen("/foo/bar", "w+");
           fclose(fid);
 
@@ -3422,10 +3423,13 @@ Exiting setjmp function, level: 0, prev_jmp: -1
 
           err = rename("/foo", "/foo/foo");
           printf("%d\\n", err);
+
+          err = rename("/foo", "/bar/foo");
+          printf("%d\\n", err);
           return 0;
         }
       '''
-      self.do_run(src, '0\n-1\n', force_c=True)
+      self.do_run(src, '0\n-1\n0\n', force_c=True)
 
     def test_alloca_stack(self):
       if self.emcc_args is None: return # too slow in other modes


### PR DESCRIPTION
There is an error in emscripten's rename() function:
You cannot rename a file to a new filename that starts exactly like the old filename
(e.g. /tmp/myfile to /tmp/myfile_new)
