### PR TITLE
Implement _NSGetEnviron()

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -7554,6 +7554,16 @@ LibraryManager.library = {
   getpwent: function() { throw 'getpwent: TODO' },
   endpwent: function() { throw 'endpwent: TODO' },
 
+  // crt_externs.h
+
+  _NSGetEnviron__deps: ['$ENV', 'environ'],
+  _NSGetEnviron: function() {
+    // extern char ***_NSGetEnviron(void);
+    // https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man7/environ.7.html
+    var envPtr = {{{ makeGetValue(makeGlobalUse('_environ'), '0', 'i8**') }}};
+    return allocate([envPtr], 'i8**', ALLOC_NORMAL);
+  },
+
   // ==========================================================================
   // emscripten.h
   // ==========================================================================

--- a/system/include/libc/crt_externs.h
+++ b/system/include/libc/crt_externs.h
@@ -1,0 +1,1 @@
+extern char ***_NSGetEnviron(void);


### PR DESCRIPTION
Configure detects the presence of `_NSGetEnviron()` on OS X but fails during make. Harmless to include it? Or just my problem?
