### PR TITLE
Allow Emscripten to recognize and compile .m and .mm files

### DIFF
--- a/emcc
+++ b/emcc
@@ -629,9 +629,8 @@ header = False # pre-compiled headers. We fake that by just copying the file
 for i in range(1, len(sys.argv)):
   arg = sys.argv[i]
   if not arg.startswith('-'):
-    for extension in ['.c','.m']:
-      if arg.endswith(extension):
-        use_cxx = False
+    if arg.endswith(('.c','.m')):
+      use_cxx = False
     if arg.endswith('.h') and sys.argv[i-1] != '-include':
       header = True
 


### PR DESCRIPTION
This pull request simply allows Emscripten to recognize Objective-C and Objective-C++ source files. It doesn't add any support for the Objective-C runtime, but it is needed in order to support that development.
