### PR TITLE
Make division of complex numbers work in the absence of logb.

### DIFF
--- a/system/include/libcxx/complex
+++ b/system/include/libcxx/complex
@@ -659,11 +659,12 @@ template<class _Tp>
 complex<_Tp>
 operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
 {
-    int __ilogbw = 0;
     _Tp __a = __z.real();
     _Tp __b = __z.imag();
     _Tp __c = __w.real();
     _Tp __d = __w.imag();
+#ifdef HAVE_LOGB
+    int __ilogbw = 0;
     _Tp __logbw = logb(fmax(fabs(__c), fabs(__d)));
     if (isfinite(__logbw))
     {
@@ -674,6 +675,11 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
     _Tp __denom = __c * __c + __d * __d;
     _Tp __x = scalbn((__a * __c + __b * __d) / __denom, -__ilogbw);
     _Tp __y = scalbn((__b * __c - __a * __d) / __denom, -__ilogbw);
+#else
+    _Tp __denom = __c * __c + __d * __d;
+    _Tp __x = (__a * __c + __b * __d) / __denom;
+    _Tp __y = (__b * __c - __a * __d) / __denom;
+#endif
     if (isnan(__x) && isnan(__y))
     {
         if ((__denom == _Tp(0)) && (!isnan(__a) || !isnan(__b)))
@@ -688,7 +694,11 @@ operator/(const complex<_Tp>& __z, const complex<_Tp>& __w)
             __x = _Tp(INFINITY) * (__a * __c + __b * __d);
             __y = _Tp(INFINITY) * (__b * __c - __a * __d);
         }
+#ifdef HAVE_LOGB
         else if (isinf(__logbw) && __logbw > _Tp(0) && isfinite(__a) && isfinite(__b))
+#else
+        else if ((isinf(__c) || isinf(__d)) && isfinite(__a) && isfinite(__b))
+#endif
         {
             __c = copysign(isinf(__c) ? _Tp(1) : _Tp(0), __c);
             __d = copysign(isinf(__d) ? _Tp(1) : _Tp(0), __d);


### PR DESCRIPTION
I noticed that the division operator for `std::complex<double>` does not work as it should, due to the fact that emscripten does not provide a `logb` implementation. I changed the code to work without that function.

This change might increase chances for an overflow, but will handle the most common cases, stay close to the original implementation, and work without too much loops to jump through. It would be possible to implement logb using a loop (probably squaring some variable at each run), but this comes at a much higher cost than the low-level bit-fiddling one would expect in this situation. So until JavaScript Math does provide reasonable primitives for bit operations on floating point numbers, this kind of optimization does not appear worth the effort. Another solution would be a reinterpretation of double variables as long. Portability might be a problem in this case, though, since implementations might use different formats for their numbers.
