### PR TITLE
SDL_SetVideoMode: Free old surface before creating new one

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -694,6 +694,11 @@ var LibrarySDL = {
       Module['canvas'].addEventListener(event, SDL.receiveEvent, true);
     });
     Browser.setCanvasSize(width, height, true);
+    // Free the old surface first.
+    if (SDL.screen) {
+      SDL.freeSurface(SDL.screen);
+      SDL.screen = null;
+    }
     SDL.screen = SDL.makeSurface(width, height, flags, true, 'screen');
     if (!SDL.addedResizeListener) {
       SDL.addedResizeListener = true;


### PR DESCRIPTION
https://github.com/kripken/emscripten/issues/1218

The C API does the same thing:
https://github.com/WinterMute/SDL-1.2/blob/master/src/video/SDL_video.c#L846

I looked into writing a small regression test for this, but there doesn't appear to be a sane way to check if an SDL surface has been free'd in the C API.
