### PR TITLE
Added header guards around emscripten.h

### DIFF
--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -1,3 +1,6 @@
+#ifndef __emscripten_h__
+#define __emscripten_h__
+
 /**
  * This file contains a few useful things for compiling C/C++ code
  * with Emscripten, an LLVM-to-JavaScript compiler.
@@ -380,4 +383,6 @@ void emscripten_jcache_printf_(...); /* internal use */
 #ifdef __cplusplus
 }
 #endif
+
+#endif // __emscripten_h__
 


### PR DESCRIPTION
This is just for folks (like me) who are using that header in native builds (with a .c implementation of some of the methods) for testing.
