### PR TITLE
synced library.js errno codes with sys/errno.h

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -6777,6 +6777,7 @@ LibraryManager.library = {
     ESTRPIPE: 143
   },
   $ERRNO_MESSAGES: {
+    0: 'Success',
     1: 'Not super-user',
     2: 'No such file or directory',
     3: 'No such process',

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -2203,8 +2203,8 @@ returned |umber one top notchfi FI FO FUM WHEN WHERE WHY HOW WHO|''', ['wowie', 
           }
           '''
         expected = '''
-          <Numerical argument out of domain>
-          <Resource temporarily unavailable>
+          <Math arg out of domain of func>
+          <No more processes>
           <34>
           <123>
           '''

--- a/tests/unistd/login.out
+++ b/tests/unistd/login.out
@@ -3,7 +3,7 @@ errno: 0
 
 gethostname/2 ret: -1
 gethostname/2: em------------------------
-errno: 36
+errno: 91
 
 gethostname/256 ret: 0
 gethostname/256: emscripten

--- a/tests/unistd/misc.out
+++ b/tests/unistd/misc.out
@@ -11,8 +11,8 @@ lockf(good): 0, errno: 0
 lockf(bad): -1, errno: 9
 nice: 0, errno: 1
 pause: -1, errno: 4
-pipe(good): -1, errno: 38
-pipe(bad): -1, errno: 38
+pipe(good): -1, errno: 88
+pipe(bad): -1, errno: 88
 execl: -1, errno: 8
 execle: -1, errno: 8
 execlp: -1, errno: 8
@@ -29,8 +29,8 @@ alarm: 0, errno: 0
 ualarm: 0, errno: 0
 fork: -1, errno: 11
 vfork: -1, errno: 11
-crypt: (null), errno: 38
-encrypt, errno: 38
+crypt: (null), errno: 88
+encrypt, errno: 88
 getgid: 0, errno: 0
 getegid: 0, errno: 0
 getuid: 0, errno: 0

--- a/tests/unistd/unlink.out
+++ b/tests/unistd/unlink.out
@@ -37,6 +37,6 @@ access(/empty-forbidden) after rmdir: 0
 access(/full) before: 0
 errno: 21
 access(/full) after unlink: 0
-errno: 39
+errno: 90
 access(/full) after rmdir: 0
 


### PR DESCRIPTION
I realized some of the codes in library.js were out of sync with libc/sys/errno.h (e.g. EADDRINUSE), so I regex'd through errno.h and generated new values for library.js
