### PR TITLE
Fix test_exported_response and test_asm_pgo on Windows.

### DIFF
--- a/emcc
+++ b/emcc
@@ -995,6 +995,7 @@ try:
     key, value = change.split('=')
     if value[0] == '@':
       value = '"@' + os.path.abspath(value[1:]) + '"'
+      value = value.replace('\\\\', '/').replace('\\', '/') # Convert backslash paths to forward slashes on Windows as well, since the JS compiler otherwise needs the backslashes escaped (alternative is to escape all input paths passing to JS, which feels clumsier to read)
     exec('shared.Settings.' + key + ' = ' + value)
 
   # Apply effects from settings


### PR DESCRIPTION
Fixes test_exported_response and test_asm_pgo on Windows.

Use forward slashes in response file path names on Windows to avoid json deserialization step(?) to treat c:\temp as having a \t tab character.
