### PR TITLE
Skip other.test_symlink on Windows, since it doesn't have them. 

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -10307,6 +10307,8 @@ f.close()
       assert not os.path.exists('a.out') and not os.path.exists('a.exe'), 'Must not leave unneeded linker stubs'
 
     def test_symlink(self):
+      if os.name == 'nt':
+        return self.skip('Windows FS does not need to be tested for symlinks support, since it does not have them.')
       open(os.path.join(self.get_dir(), 'foobar.xxx'), 'w').write('int main(){ return 0; }')
       os.symlink(os.path.join(self.get_dir(), 'foobar.xxx'), os.path.join(self.get_dir(), 'foobar.c'))
       Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'foobar.c'), '-o', os.path.join(self.get_dir(), 'foobar')], stdout=PIPE, stderr=PIPE).communicate()


### PR DESCRIPTION
NTFS does have junction points, but it's a rather rarely used feature, and not a common dev aid like it is for linux/osx users.
