### PR TITLE
Add basic support for nonblocking read

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -78,4 +78,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * James Gregory <jgregory@zynga.com> (copyright owned by Zynga, Inc)
 * Dan Gohman <sunfish@google.com> (copyright owned by Google, Inc.)
 * Jeff Gilbert <jgilbert@mozilla.com> (copyright owned by Mozilla Foundation)
+* Marc Feeley <mfeeley@mozilla.com> (copyright owned by Mozilla Foundation)
 

--- a/src/library.js
+++ b/src/library.js
@@ -1805,6 +1805,10 @@ LibraryManager.library = {
               ___setErrNo(ERRNO_CODES.EIO);
               return -1;
             }
+            if (result === undefined && bytesRead === 0) {
+              ___setErrNo(ERRNO_CODES.EAGAIN);
+              return -1;
+            }
             if (result === null || result === undefined) break;
             bytesRead++;
             {{{ makeSetValue('buf', 'i', 'result', 'i8') }}}


### PR DESCRIPTION
This will allow nonblocking devices to tell "read" there are no bytes available to be read currently, by having their "input" function return "undefined".
