### PR TITLE
startup refactoring redux

### DIFF
--- a/emcc
+++ b/emcc
@@ -1439,7 +1439,7 @@ try:
   # Embed and preload files
   if len(preload_files) + len(embed_files) > 0:
     logging.debug('setting up files')
-    file_args = []
+    file_args = ['--pre-run']
     if len(preload_files) > 0:
       file_args.append('--preload')
       file_args += preload_files

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -42,7 +42,7 @@ function JSify(data, functionsOnly, givenFunctions) {
       // things out as they are ready.
 
       var shellParts = read(shellFile).split('{{BODY}}');
-      print(shellParts[0]);
+      print(processMacros(preprocess(shellParts[0])));
       var preFile = BUILD_AS_SHARED_LIB ? 'preamble_sharedlib.js' : 'preamble.js';
       var pre = processMacros(preprocess(read(preFile).replace('{{RUNTIME}}', getRuntime())));
       print(pre);
@@ -1738,14 +1738,14 @@ function JSify(data, functionsOnly, givenFunctions) {
     print(postParts[1]);
 
     var shellParts = read(shellFile).split('{{BODY}}');
-    print(shellParts[1]);
+    print(processMacros(preprocess(shellParts[1])));
     // Print out some useful metadata
     if (EMIT_GENERATED_FUNCTIONS || PGO) {
       var generatedFunctions = JSON.stringify(keys(Functions.implementedFunctions).filter(function(func) {
         return IGNORED_FUNCTIONS.indexOf(func.ident) < 0;
       }));
       if (PGO) {
-        print('PGOMonitor.allGenerated = ' + generatedFunctions + ';\nremoveRunDependency("pgo");\n');
+        print('PGOMonitor.initialize(' + generatedFunctions + ');\n');
       }
       if (EMIT_GENERATED_FUNCTIONS) {
         print('// EMSCRIPTEN_GENERATED_FUNCTIONS: ' + generatedFunctions + '\n');

--- a/src/library.js
+++ b/src/library.js
@@ -446,7 +446,6 @@ LibraryManager.library = {
             FS.createDataFile(parent, name, byteArray, canRead, canWrite);
           }
           if (onload) onload();
-          removeRunDependency('cp ' + fullname);
         }
         var handled = false;
         Module['preloadPlugins'].forEach(function(plugin) {
@@ -454,14 +453,12 @@ LibraryManager.library = {
           if (plugin['canHandle'](fullname)) {
             plugin['handle'](byteArray, fullname, finish, function() {
               if (onerror) onerror();
-              removeRunDependency('cp ' + fullname);
             });
             handled = true;
           }
         });
         if (!handled) finish(byteArray);
       }
-      addRunDependency('cp ' + fullname);
       if (typeof url == 'string') {
         Browser.asyncLoad(url, function(byteArray) {
           processData(byteArray);

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -464,11 +464,10 @@ mergeInto(LibraryManager.library, {
       xhr.send(null);
     },
 
-    asyncLoad: function(url, onload, onerror, noRunDep) {
+    asyncLoad: function(url, onload, onerror) {
       Browser.xhrLoad(url, function(arrayBuffer) {
         assert(arrayBuffer, 'Loading data file "' + url + '" failed (no arrayBuffer).');
         onload(new Uint8Array(arrayBuffer));
-        if (!noRunDep) removeRunDependency('al ' + url);
       }, function(event) {
         if (onerror) {
           onerror();
@@ -476,7 +475,6 @@ mergeInto(LibraryManager.library, {
           throw 'Loading data file "' + url + '" failed.';
         }
       });
-      if (!noRunDep) addRunDependency('al ' + url);
     },
 
     resizeListeners: [],

--- a/src/settings.js
+++ b/src/settings.js
@@ -376,6 +376,10 @@ var EMIT_GENERATED_FUNCTIONS = 0; // whether to emit the list of generated funct
 
 var JS_CHUNK_SIZE = 10240; // Used as a maximum size before breaking up expressions and lines into smaller pieces
 
+// Module configuration options
+var USE_MODULE_CLOSURE = 0;
+var MODULE_NAME = 'Module';
+
 // Compiler debugging options
 var DEBUG_TAGS_SHOWING = [];
   // Some useful items:

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -288,7 +288,10 @@ if has_preloaded:
       },
       send: function() {}
     };
-  '''
+
+    var preloadTotal = %d;
+    var preloaded = 0;
+  ''' % len(data_files)
 
 counter = 0
 for file_ in data_files:
@@ -312,12 +315,16 @@ for file_ in data_files:
     counter += 1
     dds = crunch and filename.endswith(CRUNCH_INPUT_SUFFIX)
 
-    prepare = ''
-    finish = "Module['removeRunDependency']('fp %s');\n" % filename
+    prefix = ''
+    finish = ''
+    suffix = ''
+
+    if pre_run:
+      finish = 'if (++preloaded >= preloadTotal) { cb(null); }\n'
 
     if dds:
       # decompress crunch format into dds
-      prepare = '''
+      prefix = '''
         var ddsHeader = byteArray.subarray(0, %(dds_header_size)d);
         requestDecrunch('%(filename)s', byteArray.subarray(%(dds_header_size)d), function(ddsData) {
           byteArray = new Uint8Array(ddsHeader.length + ddsData.length);
@@ -325,7 +332,7 @@ for file_ in data_files:
           byteArray.set(ddsData, %(dds_header_size)d);
 ''' % { 'filename': filename, 'dds_header_size': DDS_HEADER_SIZE }
 
-      finish += '''
+      suffix += '''
         });
 '''
 
@@ -337,12 +344,12 @@ for file_ in data_files:
       var arrayBuffer = %(varname)s.response;
       assert(arrayBuffer, 'Loading file %(filename)s failed.');
       var byteArray = !arrayBuffer.subarray ? new Uint8Array(arrayBuffer) : arrayBuffer;
-      %(prepare)s
-      Module['FS_createPreloadedFile']('/%(dirname)s', '%(basename)s', byteArray, true, true, function() {
+      %(prefix)s
+      Module['FS_createPreloadedFile']('/%(dirname)s', '%(basename)s', byteArray, true, true, function () {
         %(finish)s
       }%(fail)s);
+      %(suffix)s
     };
-    Module['addRunDependency']('fp %(filename)s');
     %(varname)s.send(null);
 ''' % {
         'request': 'DataRequest', # In the past we also supported XHRs here
@@ -350,9 +357,11 @@ for file_ in data_files:
         'filename': filename,
         'dirname': os.path.dirname(filename),
         'basename': os.path.basename(filename),
-        'prepare': prepare,
+        'prefix': prefix,
         'finish': finish,
-        'fail': '' if filename[-4:] not in AUDIO_SUFFIXES else ''', function() { Module['removeRunDependency']('fp %s') }''' % filename # workaround for chromium bug 124926 (still no audio with this, but at least we don't hang)
+        'suffix': suffix,
+        # silently fail for certain audio files (workaround for chromium bug 124926)
+        'fail': '' if filename[-4:] not in AUDIO_SUFFIXES else ''', function() { %s }''' % finish
   }
   else:
     assert 0
@@ -363,14 +372,15 @@ if has_preloaded:
   for file_ in data_files:
     if file_['mode'] == 'preload':
       use_data += '''
+      {
         curr = DataRequest.prototype.requests['%s'];
         var data = byteArray.subarray(%d, %d);
         var ptr = Module['_malloc'](%d);
         Module['HEAPU8'].set(data, ptr);
         curr.response = Module['HEAPU8'].subarray(ptr, ptr + %d);
         curr.onload();
+      }
       ''' % (file_['dstpath'], file_['data_start'], file_['data_end'], file_['data_end'] - file_['data_start'], file_['data_end'] - file_['data_start'])
-  use_data += "          Module['removeRunDependency']('datafile_%s');\n" % data_target
 
   if Compression.on:
     use_data = '''
@@ -532,16 +542,16 @@ if has_preloaded:
       var curr;
       %s
     };
-    Module['addRunDependency']('datafile_%s');
 
     function handleError(error) {
       console.error('package error:', error);
     };
-  ''' % (use_data, data_target) # use basename because from the browser's point of view, we need to find the datafile in the same dir as the html file
+  ''' % (use_data) # use basename because from the browser's point of view, we need to find the datafile in the same dir as the html file
 
   code += r'''
-    if (!Module.preloadResults)
+    if (!Module.preloadResults) {
       Module.preloadResults = {};
+    }
   '''
 
   if use_preload_cache:
@@ -584,22 +594,27 @@ if has_preloaded:
       Module.preloadResults[PACKAGE_NAME] = {fromCache: false};
       fetchRemotePackage(REMOTE_PACKAGE_NAME, processPackageData, handleError);
     '''
+else:
+  if pre_run:
+    code += '''
+      cb(null);
+    '''
 
 if pre_run:
   ret += '''
-  if (typeof Module == 'undefined') Module = {};
-  if (!Module['preRun']) Module['preRun'] = [];
-  Module["preRun"].push(function() {
+  Module.addPreRun(function (cb) {
 '''
+
 ret += code
 
 if pre_run:
-  ret += '  });\n'
+  ret += '''
+  });
+'''
 
 if crunch:
   ret += '''
-  if (!Module['postRun']) Module['postRun'] = [];
-  Module["postRun"].push(function() {
+  Module.addPostRun(function () {
     decrunchWorker.terminate();
   });
 '''


### PR DESCRIPTION
Alright, I took the original branch and stripped out the changes that had to do with _completely_ removing the Module global. Due to that, this pull has about half the amount of changes as the last.

In summary, here is what's going on with the new branch:
1. preInit and preRun no longer happen automatically upon evaluation of the script. They are called from preload (renamed from load as to not conflict with the existing Module.load which is used for some other purpose).
2. Exported addPreInit, addPreRun and addPostRun functions to replace the existing preInit, preRun and postRun properties. Replaced usage of add/removeRuntimeDependency with addPreRun.
3. Added module closure option (-s USE_MODULE_CLOSURE=1).
4. Added exports for AMD and CommonJS modules.
5. Added MODULE_NAME setting to control exported global Module property for browser builds (defaults to 'Module').

While this branch supports the global module for configuration, Module is now declared as a local variable at the top of shell.js. In order to maintain backwards compatibility, we save off the global Module variable if it exists before initializing the local instance, and we merge the global instance's properties back into the local instance at the end, right before autorun is invoked. With this, all of the tests are passing with very few modifications.

The compatibility breaking changes are:
1. preInit / preRun functions now require the callback property to be invoked.
2. preRun tasks are executed as a fifo queue now instead of a stack. It seems the original code intentionally executed them in this order, but that doesn't seem very intuitive to myself at least (it can be changed back to do that if you'd like).
3. If a user is using a custom shell, has async dependencies (e.g. the mem init file) and is manually calling run - they must now use preload() beforehand.

...

To preface this next bit, I realize at this point I may be going down the rabbit hole and the work is unneccessay, however, I'll throw it out there regardless.

After implementing these changes a second time, I do think the startup sequence could still benefit from some slight renaming. As of now, I haven't actually changed the order or naming of anything. Here is an overview of the startup process as it sits:

```
preload(callback)
 `- preInit
 |  `- preRun
 |     `- callback

run()
 `- setStatus
 `- _run
 |  `- ensureInitRuntime
 |     `- callRuntimeCallbacks(__ATINIT__)
 |  `- preMain
 |     `- callRuntimeCallbacks(__ATMAIN__)
 |  `- callMain
 |     `- ensureInitRuntime
 |        `- callRuntimeCallbacks(__ATINIT__)
 |     `- _main
 |  `- exitRuntime
 |     `- callRuntimeCallbacks(__ATEXIT__)
 |  `- postRun
```

However, to me, this seems a bit more clear:

```
preload(callback)
 `- preRun
 |   `- callback

run()
 `- setStatus
 `- _run
 |  `- preRun (if not already ran by preload)
 |  `- ensureInitRuntime
 |     `- callRuntimeCallbacks(__ATINIT__)
 |  `- preMain
 |     `- callRuntimeCallbacks(__ATMAIN__)
 |  `- callMain
 |     `- ensureInitRuntime
 |        `- callRuntimeCallbacks(__ATINIT__)
 |     `- _main
 |  `- postMain
 |  `- exitRuntime
 |     `- callRuntimeCallbacks(__ATEXIT__)
 |  `- postRun      
```

From working with the tests, it _seems_ most uses of preRun are postRun are truly synchronous preMain and postMain hooks. Any async asset related preRun task could be converted to addPreloadTask (e.g. the stuff in file_packager.py).

Anyways, again, I realize this may be unneccessay at this point and I don't want to waste your time, but if any compatibility breaking changes are going to be made I figured they should at least be something that won't get changed again for a while.
