### PR TITLE
Improve emcc input file detection to ignore all arguments that precede a...

### DIFF
--- a/emcc
+++ b/emcc
@@ -902,7 +902,7 @@ try:
 
     if i > 0:
       prev = newargs[i-1]
-      if prev in ['-MT', '-install_name', '-I', '-L']: continue # ignore this gcc-style argument
+      if prev in ['-MT', '-MF', '-MQ', '-D', '-U', '-o', '-x', '-Xpreprocessor', '-include', '-imacros', '-idirafter', '-iprefix', '-iwithprefix', '-iwithprefixbefore', '-isysroot', '-imultilib', '-A', '-isystem', '-iquote', '-install_name', '-I', '-L']: continue # ignore this gcc-style argument
 
     if (os.path.islink(arg) and os.path.realpath(arg).endswith(SOURCE_SUFFIXES + BITCODE_SUFFIXES + DYNAMICLIB_SUFFIXES + ASSEMBLY_SUFFIXES)):
       arg = os.path.realpath(arg)


### PR DESCRIPTION
... GCC preprocessor command line option from http://gcc.gnu.org/onlinedocs/gcc/Preprocessor-Options.html .

ScummVM build chain used -MF and -MQ, but figured it'd be good to throughly add all params, even though they might not be used/supported in emscripten.
