### PR TITLE
BUGFIX: lists cannot be llvm_va_copy was broken, didn't copy list offset

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -5000,6 +5000,7 @@ LibraryManager.library = {
 
   llvm_va_copy: function(ppdest, ppsrc) {
     {{{ makeCopyValues('ppdest', 'ppsrc', Runtime.QUANTUM_SIZE, 'null', null, 1) }}};
+    {{{ makeCopyValues('(ppdest+4)', '(ppsrc+4)', Runtime.QUANTUM_SIZE, 'null', null, 1) }}};
     /* Alternate implementation that copies the actual DATA; it assumes the va_list is prefixed by its size
     var psrc = IHEAP[ppsrc]-1;
     var num = IHEAP[psrc]; // right before the data, is the number of (flattened) values


### PR DESCRIPTION
It seems va_list handling is seriously broken and incompatible.
Check out this testcase, the output at the top of the page is from the native executable https://dl.dropboxusercontent.com/u/20452169/drahtwerk/vabug.html
Here is the corresponding cpp code https://dl.dropboxusercontent.com/u/20452169/drahtwerk/vabug.cpp

The pull request fixes the issue and the tests run identical to native code.
