### PR TITLE
Fix warn alias

### DIFF
--- a/system/lib/libc.symbols
+++ b/system/lib/libc.symbols
@@ -77,5 +77,5 @@
          W verrx
          W vwarn
          W vwarnx
-         W warn1
+         W warn
          W warnx

--- a/system/lib/libc/gen/warn.c
+++ b/system/lib/libc/gen/warn.c
@@ -46,4 +46,4 @@ _warn(const char *fmt, ...)
 
 /* PRINTFLIKE1 */
 void
-warn(const char *fmt, ...) __attribute__((weak, alias("warn")));
+warn(const char *fmt, ...) __attribute__((weak, alias("_warn")));


### PR DESCRIPTION
warn was defined to be aliasing warn instead of _warn.
