### PR TITLE
In metadata, store paths parsed from .ll files using forward slashes on Windows.

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -114,7 +114,8 @@ var Debugging = {
         m = metadataToParentMetadata[m];
         assert(m, 'Confused as to parent metadata for llvm #' + l + ', metadata !' + m);
       }
-      this.llvmLineToSourceFile[l] = metadataToFilename[m];
+      // Normalize Windows path slashes coming from LLVM metadata, so that forward slashes can be assumed as path delimiters.
+      this.llvmLineToSourceFile[l] = metadataToFilename[m].replace(/\\5C/g, '/');
     }
 
     this.on = true;


### PR DESCRIPTION
Fixes safe heap line detection on Windows (the code splits on '/' only as path delimiter), closes issue #1233.
