### PR TITLE
Some tweaks to make CSmith easier to setup / debug.

### DIFF
--- a/tests/fuzz/creduce_tester.py
+++ b/tests/fuzz/creduce_tester.py
@@ -1,53 +1,53 @@
 #!/usr/bin/python
 
 '''
-Runs csmith, a C fuzzer, and looks for bugs
+Usage: creduce ./creduce_tester.py newfail1.c
 '''
 
-import os, sys, difflib
+import os, sys
 from subprocess import Popen, PIPE, STDOUT
 
 sys.path += [os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'tools')]
-import shared
+import shared, jsrun
+
+# creduce will only pass the filename of the C file as the first arg, so other
+# configuration options will have to be hardcoded.
+CSMITH_CFLAGS = ['-I', os.path.join(os.environ['CSMITH_PATH'], 'runtime')]
+ENGINE = shared.JS_ENGINES[0]
+EMCC_ARGS = ['-O2', '-s', 'ASM_JS=1', '-s', 'PRECISE_I64_MATH=1', '-s',
+  'PRECISE_I32_MUL=1']
 
 filename = sys.argv[1]
+obj_filename = os.path.splitext(filename)[0]
+js_filename = obj_filename + '.js'
 print 'testing file', filename
 
-print '2) Compile natively'
-shared.try_delete(filename)
-shared.execute([shared.CLANG_CC, '-O2', filename + '.c', '-o', filename] + CSMITH_CFLAGS, stderr=PIPE)
-assert os.path.exists(filename)
-print '3) Run natively'
 try:
-  correct = shared.timeout_run(Popen([filename], stdout=PIPE, stderr=PIPE), 3)
+  print '2) Compile natively'
+  shared.check_execute([shared.CLANG_CC, '-O2', filename, '-o', obj_filename] + CSMITH_CFLAGS)
+  print '3) Run natively'
+  correct = jsrun.timeout_run(Popen([obj_filename], stdout=PIPE, stderr=PIPE), 3)
 except Exception, e:
   print 'Failed or infinite looping in native, skipping', e
-  notes['invalid'] += 1
-  os.exit(0) # boring 
+  sys.exit(1) # boring
 
 print '4) Compile JS-ly and compare'
 
 def try_js(args):
-  shared.try_delete(filename + '.js')
-  shared.execute([shared.EMCC, '-O2', '-s', 'ASM_JS=1', '-s', 'PRECISE_I64_MATH=1', '-s', 'PRECISE_I32_MUL=1', filename + '.c', '-o', filename + '.js'] + CSMITH_CFLAGS + args, stderr=PIPE)
-  assert os.path.exists(filename + '.js')
-  js = shared.run_js(filename + '.js', stderr=PIPE, engine=engine1)
-  assert correct == js, ''.join([a.rstrip()+'\n' for a in difflib.unified_diff(correct.split('\n'), js.split('\n'), fromfile='expected', tofile='actual')])
+  shared.check_execute([shared.EMCC] + EMCC_ARGS + CSMITH_CFLAGS + args +
+    [filename, '-o', js_filename])
+  js = shared.run_js(js_filename, stderr=PIPE, engine=ENGINE)
+  assert correct == js
 
 # Try normally, then try unaligned because csmith does generate nonportable code that requires x86 alignment
-ok = False
-normal = True
-for args, note in [([], None), (['-s', 'UNALIGNED_MEMORY=1'], 'unaligned')]:
+# If you are sure that alignment is not the cause, disable it for a faster reduction
+for args in [[]]:
   try:
     try_js(args)
-    ok = True
-    if note:
-      notes[note] += 1
     break
   except Exception, e:
-    print e
-    normal = False
-if not ok: sys.exit(1)
+    pass
+else:
+  sys.exit(0)
 
-sys.exit(0) # boring
-
+sys.exit(1) # boring

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1379,6 +1379,17 @@ def execute(cmd, *args, **kw):
     logging.error('Invoking Process failed: <<< ' + cmd + ' >>>')
     raise
 
+def check_execute(cmd, *args, **kw):
+  # TODO: use in more places. execute doesn't actually check that return values
+  # are nonzero
+  try:
+    kw['stderr'] = STDOUT
+    subprocess.check_output(cmd, *args, **kw)
+    logging.debug("Successfuly executed %s" % " ".join(cmd))
+  except subprocess.CalledProcessError as e:
+    logging.error("'%s' failed with output:\n%s" % (" ".join(e.cmd), e.output))
+    raise
+
 def suffix(name):
   parts = name.split('.')
   if len(parts) > 1:


### PR DESCRIPTION
I struggled a bit getting CSmith / CReduce running yesterday. These changes should help anyone making future attempts. In particular, I've:
- Changed the lookup for CSmith / CSmith's runtime to be based on environment variables instead of a hardcoded path
- Added a `check_execute` function in `shared.py` so that failed commands actually throw errors. I think most instances of `shared.execute` in Emscripten can actually be replaced by `check_execute`, but I can't be sure without actually combing through everything, so for now I'm just going to introduce it as an alternative.
- CReduce's testing script should return `1` for 'uninteresting' and `0` for interesting, which is the opposite of what is was doing. Despite this change, most CReduce passes fail to remove any code from the fuzz bug, so the script is still broken. However, I think it's still worth checking in so future work can build upon it.
