### PR TITLE
assert on bad pointer in Pointer_stringify

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -525,6 +525,9 @@ function Pointer_stringify(ptr, /* optional */ length) {
   var t;
   var i = 0;
   while (1) {
+#if ASSERTIONS
+    assert(ptr + i < TOTAL_MEMORY);
+#endif
     t = {{{ makeGetValue('ptr', 'i', 'i8', 0, 1) }}};
     if (t >= 128) hasUtf = true;
     else if (t == 0 && !length) break;


### PR DESCRIPTION
Otherwise, it's easy to accidentally make Pointer_stringify hang indefinitely if you do something such as stringifying the same variable twice.
