### PR TITLE
Optimize (x<y)&1

### DIFF
--- a/tools/test-js-optimizer-asm-pre-output.js
+++ b/tools/test-js-optimizer-asm-pre-output.js
@@ -119,6 +119,16 @@ function sign_extension_simplification() {
   print(5);
  }
 }
+function compare_result_simplification() {
+ HEAP32[$4] = HEAP32[$5] < HEAP32[$6];
+ HEAP32[$4] = HEAP32[$5] > HEAP32[$6];
+ HEAP32[$4] = HEAP32[$5] <= HEAP32[$6];
+ HEAP32[$4] = HEAP32[$5] <= HEAP32[$6];
+ HEAP32[$4] = HEAP32[$5] == HEAP32[$6];
+ HEAP32[$4] = HEAP32[$5] === HEAP32[$6];
+ HEAP32[$4] = HEAP32[$5] != HEAP32[$6];
+ var x = HEAP32[$5] != HEAP32[$6] | 0;
+}
 function tempDoublePtr($45, $14, $28, $42) {
  $45 = $45 | 0;
  $14 = $14 | 0;

--- a/tools/test-js-optimizer-asm-pre.js
+++ b/tools/test-js-optimizer-asm-pre.js
@@ -122,6 +122,18 @@ function sign_extension_simplification() {
   print(5);
  }
 }
+function compare_result_simplification() {
+ // Eliminate these '&1's.
+ HEAP32[$4] = (HEAP32[$5] < HEAP32[$6]) & 1;
+ HEAP32[$4] = (HEAP32[$5] > HEAP32[$6]) & 1;
+ HEAP32[$4] = (HEAP32[$5] <= HEAP32[$6]) & 1;
+ HEAP32[$4] = (HEAP32[$5] <= HEAP32[$6]) & 1;
+ HEAP32[$4] = (HEAP32[$5] == HEAP32[$6]) & 1;
+ HEAP32[$4] = (HEAP32[$5] === HEAP32[$6]) & 1;
+ HEAP32[$4] = (HEAP32[$5] != HEAP32[$6]) & 1;
+ // Convert the &1 to |0 here, since we don't get an implicit coersion.
+ var x = (HEAP32[$5] != HEAP32[$6]) & 1;
+}
 function tempDoublePtr($45, $14, $28, $42) {
  $45 = $45 | 0;
  $14 = $14 | 0;


### PR DESCRIPTION
Add an optimization to simplifyExpressionsPre to replace (x<y)&1 with x<y
if possible. This comes up frequently in C++ with bool variables.
