### PR TITLE
misc ungetc fixes

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1776,11 +1776,6 @@ LibraryManager.library = {
       return -1;
     } else {
       var bytesRead = 0;
-      while (stream.ungotten.length && nbyte > 0) {
-        {{{ makeSetValue('buf++', '0', 'stream.ungotten.pop()', 'i8') }}}
-        nbyte--;
-        bytesRead++;
-      }
       var contents = stream.object.contents;
       var size = Math.min(contents.length - offset, nbyte);
 #if USE_TYPED_ARRAYS == 2
@@ -1822,11 +1817,6 @@ LibraryManager.library = {
       if (stream.object.isDevice) {
         if (stream.object.input) {
           bytesRead = 0;
-          while (stream.ungotten.length && nbyte > 0) {
-            {{{ makeSetValue('buf++', '0', 'stream.ungotten.pop()', 'i8') }}}
-            nbyte--;
-            bytesRead++;
-          }
           for (var i = 0; i < nbyte; i++) {
             try {
               var result = stream.object.input();
@@ -1848,10 +1838,9 @@ LibraryManager.library = {
           return -1;
         }
       } else {
-        var ungotSize = stream.ungotten.length;
         bytesRead = _pread(fildes, buf, nbyte, stream.position);
         if (bytesRead != -1) {
-          stream.position += (stream.ungotten.length - ungotSize) + bytesRead;
+          stream.position += bytesRead;
         }
         return bytesRead;
       }
@@ -3208,7 +3197,7 @@ LibraryManager.library = {
       return -1;
     }
   },
-  fgetc__deps: ['$FS', 'read'],
+  fgetc__deps: ['$FS', 'fread'],
   fgetc__postset: '_fgetc.ret = allocate([0], "i8", ALLOC_STATIC);',
   fgetc: function(stream) {
     // int fgetc(FILE *stream);
@@ -3216,7 +3205,7 @@ LibraryManager.library = {
     if (!FS.streams[stream]) return -1;
     var streamObj = FS.streams[stream];
     if (streamObj.eof || streamObj.error) return -1;
-    var ret = _read(stream, _fgetc.ret, 1);
+    var ret = _fread(_fgetc.ret, 1, 1, stream);
     if (ret == 0) {
       streamObj.eof = true;
       return -1;
@@ -3378,16 +3367,24 @@ LibraryManager.library = {
     // size_t fread(void *restrict ptr, size_t size, size_t nitems, FILE *restrict stream);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/fread.html
     var bytesToRead = nitems * size;
-    if (bytesToRead == 0) return 0;
-    var bytesRead = _read(stream, ptr, bytesToRead);
+    if (bytesToRead == 0) {
+      return 0;
+    }
+    var bytesRead = 0;
     var streamObj = FS.streams[stream];
-    if (bytesRead == -1) {
+    while (streamObj.ungotten.length && bytesToRead > 0) {
+      {{{ makeSetValue('ptr++', '0', 'streamObj.ungotten.pop()', 'i8') }}}
+      bytesToRead--;
+      bytesRead++;
+    }
+    var err = _read(stream, ptr, bytesToRead);
+    if (err == -1) {
       if (streamObj) streamObj.error = true;
       return 0;
-    } else {
-      if (bytesRead < bytesToRead) streamObj.eof = true;
-      return Math.floor(bytesRead / size);
     }
+    bytesRead += err;
+    if (bytesRead < bytesToRead) streamObj.eof = true;
+    return Math.floor(bytesRead / size);
   },
   freopen__deps: ['$FS', 'fclose', 'fopen', '__setErrNo', '$ERRNO_CODES'],
   freopen: function(filename, mode, stream) {
@@ -3600,13 +3597,18 @@ LibraryManager.library = {
   ungetc: function(c, stream) {
     // int ungetc(int c, FILE *stream);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/ungetc.html
-    if (FS.streams[stream]) {
-      c = unSign(c & 0xFF);
-      FS.streams[stream].ungotten.push(c);
-      return c;
-    } else {
+    stream = FS.streams[stream];
+    if (!stream) {
       return -1;
     }
+    if (c === {{{ cDefine('EOF') }}}) {
+      // do nothing for EOF character
+      return c;
+    }
+    c = unSign(c & 0xFF);
+    stream.ungotten.push(c);
+    stream.eof = false;
+    return c;
   },
   system__deps: ['__setErrNo', '$ERRNO_CODES'],
   system: function(command) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1279,6 +1279,7 @@ var C_DEFINES = {'SI_MESGQ': '5',
    'SOCK_STREAM': '200',
    'SOCK_DGRAM': '20',
    'IPPROTO_TCP': '1',
-   'IPPROTO_UDP': '2'
+   'IPPROTO_UDP': '2',
+   'EOF': '-1'
 };
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -6731,6 +6731,10 @@ def process(filename):
         '''
       self.do_run(src, 'written=0')
 
+    def test_fgetc_ungetc(self):
+      src = open(path_from_root('tests', 'stdio', 'test_fgetc_ungetc.c'), 'r').read()
+      self.do_run(src, 'success', force_c=True)
+
     def test_fgetc_unsigned(self):
       if self.emcc_args is None: return self.skip('requires emcc')
       src = r'''

--- a/tests/stdio/test_fgetc_ungetc.c
+++ b/tests/stdio/test_fgetc_ungetc.c
@@ -1,0 +1,87 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+static void create_file(const char *path, const char *buffer, int mode) {
+  int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);
+  assert(fd >= 0);
+
+  int err = write(fd, buffer, sizeof(char) * strlen(buffer));
+  assert(err ==  (sizeof(char) * strlen(buffer)));
+
+  close(fd);
+}
+
+void setup() {
+  create_file("file.txt", "cd", 0666);
+}
+
+void cleanup() {
+  unlink("file.txt");
+}
+
+void test() {
+  FILE *file;
+  int err;
+  char buffer[256];
+
+  file = fopen("file.txt", "r");
+  assert(file);
+
+  // pushing EOF always returns EOF
+  rewind(file);
+  err = ungetc(EOF, file);
+  assert(err == EOF);
+
+  // ungetc should return itself
+  err = ungetc('a', file);
+  assert(err == (int)'a');
+
+  // push two chars and make sure they're read back in
+  // the correct order (both by fgetc and fread)
+  rewind(file);
+  ungetc('b', file);
+  ungetc('a', file);
+  err = fgetc(file);
+  assert(err == (int)'a');
+  fread(buffer, sizeof(char), sizeof(buffer), file);
+  assert(!strcmp(buffer, "bcd"));
+
+  // rewind and fseek should reset anything that's been
+  // pushed to the stream
+  ungetc('a', file);
+  rewind(file);
+  err = fgetc(file);
+  assert(err == (int)'c');
+  ungetc('a', file);
+  fseek(file, 0, SEEK_SET);
+  err = fgetc(file);
+  assert(err == (int)'c');
+
+  // fgetc, when nothing is left, should return EOF
+  fseek(file, 0, SEEK_END);
+  err = fgetc(file);
+  assert(err == EOF);
+  err = feof(file);
+  assert(err);
+
+  // ungetc should reset the EOF indicator
+  ungetc('e', file);
+  err = feof(file);
+  assert(!err);
+
+  fclose(file);
+
+  puts("success");
+}
+
+int main() {
+  atexit(cleanup);
+  signal(SIGABRT, cleanup);
+  setup();
+  test();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
I'm going through changes on my VFS branch and cherry-picking issues that aren't necessarily related, but that I made in the process.

This change namely moves out the checking of characters pushed by ungetc from pread / read to fread. As far as I can tell, this is a feature of the buffered stdio streams and shouldn't ever be considered when calling pread or read. A side effect of this was that fgetc now calls fread instead of read.

Also, there were a few small issues with ungetc. It wasn't early outing when receiving the EOF character, and it wasn't clearing the EOF indicator when called.

Ran o1 and other tests.
