### PR TITLE
minor fixes to return codes of closedir, telldir

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -737,7 +737,8 @@ LibraryManager.library = {
     // int closedir(DIR *dirp);
     // http://pubs.opengroup.org/onlinepubs/007908799/xsh/closedir.html
     if (!FS.streams[dirp] || !FS.streams[dirp].object.isFolder) {
-      return ___setErrNo(ERRNO_CODES.EBADF);
+      ___setErrNo(ERRNO_CODES.EBADF);
+      return -1;
     } else {
       _free(FS.streams[dirp].currentEntry);
       FS.streams[dirp] = null;
@@ -749,7 +750,8 @@ LibraryManager.library = {
     // long int telldir(DIR *dirp);
     // http://pubs.opengroup.org/onlinepubs/007908799/xsh/telldir.html
     if (!FS.streams[dirp] || !FS.streams[dirp].object.isFolder) {
-      return ___setErrNo(ERRNO_CODES.EBADF);
+      ___setErrNo(ERRNO_CODES.EBADF);
+      return -1;
     } else {
       return FS.streams[dirp].position;
     }

--- a/system/include/libc/sys/dirent.h
+++ b/system/include/libc/sys/dirent.h
@@ -24,6 +24,7 @@ DIR  *opendir(const char *);
 void  seekdir(DIR *, long);
 long  telldir(DIR *);
 DIR  *readdir(DIR *);
+int readdir_r(DIR *, struct dirent *, struct dirent **);
 int   closedir(DIR *dirp);
 void  rewinddir(DIR *dirp);
 int   scandir(const char *dirp,

--- a/tests/dirent/test_readdir.c
+++ b/tests/dirent/test_readdir.c
@@ -1,0 +1,132 @@
+#include <assert.h>
+#include <dirent.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+
+static void create_file(const char *path, const char *buffer, int mode) {
+  int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);
+  assert(fd >= 0);
+
+  int err = write(fd, buffer, sizeof(char) * strlen(buffer));
+  assert(err ==  (sizeof(char) * strlen(buffer)));
+
+  close(fd);
+}
+
+void setup() {
+  mkdir("nocanread", 0111);
+  mkdir("foobar", 0777);
+  create_file("foobar/file.txt", "ride into the danger zone", 0666);
+}
+
+void cleanup() {
+  rmdir("nocanread");
+  unlink("foobar/file.txt");
+  rmdir("foobar");
+}
+
+void test() {
+  int err;
+  int loc;
+  DIR *dir;
+  struct dirent *ent;
+  struct dirent ent_r;
+  struct dirent *result;
+
+  // check bad opendir input
+  dir = opendir("noexist");
+  assert(!dir);
+  assert(errno == ENOENT);
+  dir = opendir("nocanread");
+  assert(!dir);
+  assert(errno == EACCES);
+  dir = opendir("foobar/file.txt");
+  assert(!dir);
+  assert(errno == ENOTDIR);
+
+  // check bad readdir input
+  dir = opendir("foobar");
+  closedir(dir);
+  ent = readdir(dir);
+  assert(!ent);
+  assert(errno == EBADF);
+
+  // check bad readdir_r input
+  dir = opendir("foobar");
+  closedir(dir);
+  err = readdir_r(dir, NULL, &result);
+  assert(err == EBADF);
+  
+  //
+  // do a normal read with readdir
+  //
+  dir = opendir("foobar");
+  assert(dir);
+  ent = readdir(dir);
+  assert(!strcmp(ent->d_name, "."));
+  assert(ent->d_type & DT_DIR);
+  ent = readdir(dir);
+  assert(!strcmp(ent->d_name, ".."));
+  assert(ent->d_type & DT_DIR);
+  ent = readdir(dir);
+  assert(!strcmp(ent->d_name, "file.txt"));
+  assert(ent->d_type & DT_REG);
+  ent = readdir(dir);
+  assert(!ent);
+
+  // test rewinddir
+  rewinddir(dir);
+  ent = readdir(dir);
+  assert(!strcmp(ent->d_name, "."));
+
+  // test seek / tell
+  rewinddir(dir);
+  ent = readdir(dir);
+  assert(!strcmp(ent->d_name, "."));
+  loc = telldir(dir);
+  ent = readdir(dir);
+  assert(!strcmp(ent->d_name, ".."));
+  ent = readdir(dir);
+  assert(!strcmp(ent->d_name, "file.txt"));
+  seekdir(dir, loc);
+  ent = readdir(dir);
+  assert(!strcmp(ent->d_name, ".."));
+
+  //
+  // do a normal read with readdir_r
+  //
+  rewinddir(dir);
+  err = readdir_r(dir, &ent_r, &result);
+  assert(!err);
+  assert(&ent_r == result);
+  assert(!strcmp(ent_r.d_name, "."));
+  err = readdir_r(dir, &ent_r, &result);
+  assert(!err);
+  assert(&ent_r == result);
+  assert(!strcmp(ent_r.d_name, ".."));
+  err = readdir_r(dir, &ent_r, &result);
+  assert(!err);
+  assert(&ent_r == result);
+  assert(!strcmp(ent_r.d_name, "file.txt"));
+  err = readdir_r(dir, &ent_r, &result);
+  assert(!err);
+  assert(!result);
+
+  err = closedir(dir);
+  assert(!err);
+
+  puts("success");
+}
+
+int main() {
+  atexit(cleanup);
+  signal(SIGABRT, cleanup);
+  setup();
+  test();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
closedir should set errno and return -1: http://linux.die.net/man/3/closedir
telldir should do the same: http://linux.die.net/man/3/telldir
`readdir_r` was added to dirent.h

and finally, I replaced two existing tests (test_folders and test_readdir) with a test I'd written throughout the VFS work for testing the dirent family of functions.

My ration was that it's a good practice to have the tests as focused and self-contained as possible (in my case, I couldn't run those tests on the VFS branch until I'd shimmed the JS API). If the purpose of the replaced tests was to test the JS APIs, lets create tests _just_ for that, otherwise this tests a few more situations (rewinddir, readdir_r) and is focused solely on the few dirent functions.
