### PR TITLE
Fix image loading in Safari.

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -91,7 +91,7 @@ mergeInto(LibraryManager.library, {
         if (Browser.hasBlobConstructor) {
           try {
             b = new Blob([byteArray], { type: getMimetype(name) });
-            if (b.size !== byteArray.length) { // safari 6 bug
+            if (b.size !== byteArray.length) { // Safari bug #118630
               // Safari's Blob can only take an ArrayBuffer
               b = new Blob([(new Uint8Array(byteArray)).buffer], { type: getMimetype(name) });
             }


### PR DESCRIPTION
The `test_sdl_image_*` tests now pass in Safari (as well as FF / Chrome).
