### PR TITLE
utime fixes

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -865,10 +865,6 @@ LibraryManager.library = {
     }
     var file = FS.findObject(Pointer_stringify(path));
     if (file === null) return -1;
-    if (!file.write) {
-      ___setErrNo(ERRNO_CODES.EPERM);
-      return -1;
-    }
     file.timestamp = time;
     return 0;
   },

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -7087,49 +7087,8 @@ def process(filename):
       self.do_run(src, re.sub('(^|\n)\s+', '\\1', expected))
 
     def test_utime(self):
-      add_pre_run_and_checks = '''
-def process(filename):
-  src = open(filename, 'r').read().replace(
-    '// {{PRE_RUN_ADDITIONS}}',
-    \'\'\'
-      var TEST_F1 = FS.createFolder('/', 'writeable', true, true);
-      var TEST_F2 = FS.createFolder('/', 'unwriteable', true, false);
-    \'\'\'
-  ).replace(
-    '// {{POST_RUN_ADDITIONS}}',
-    \'\'\'
-      Module.print('first changed: ' + (TEST_F1.timestamp == 1200000000000));
-      Module.print('second changed: ' + (TEST_F2.timestamp == 1200000000000));
-    \'\'\'
-  )
-  open(filename, 'w').write(src)
-'''
-      src = r'''
-        #include <stdio.h>
-        #include <errno.h>
-        #include <utime.h>
-
-        int main() {
-          struct utimbuf t = {1000000000, 1200000000};
-          char* writeable = "/writeable";
-          char* unwriteable = "/unwriteable";
-
-          utime(writeable, &t);
-          printf("writeable errno: %d\n", errno);
-
-          utime(unwriteable, &t);
-          printf("unwriteable errno: %d\n", errno);
-
-          return 0;
-        }
-        '''
-      expected = '''
-        writeable errno: 0
-        unwriteable errno: 1
-        first changed: true
-        second changed: false
-      '''
-      self.do_run(src, re.sub('(^|\n)\s+', '\\1', expected), post_build=add_pre_run_and_checks)
+      src = open(path_from_root('tests', 'utime', 'test_utime.c'), 'r').read()
+      self.do_run(src, 'success', force_c=True)
 
     def test_utf(self):
       self.banned_js_engines = [SPIDERMONKEY_ENGINE] # only node handles utf well

--- a/tests/utime/test_utime.c
+++ b/tests/utime/test_utime.c
@@ -1,0 +1,53 @@
+#include <assert.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <utime.h>
+#include <sys/stat.h>
+
+void setup() {
+  mkdir("writeable", 0777);
+  mkdir("unwriteable", 0111);
+}
+
+void cleanup() {
+  rmdir("writeable");
+  rmdir("unwriteable");
+}
+
+void test() {
+  struct stat s;
+  // currently, the most recent timestamp is shared for atime,
+  // ctime and mtime. using unique values for each in the test
+  // will fail
+  struct utimbuf t = {1000000000, 1000000000};
+
+  utime("writeable", &t);
+  assert(!errno);
+  memset(&s, 0, sizeof s);
+  stat("writeable", &s);
+  assert(s.st_atime == t.actime);
+  assert(s.st_mtime == t.modtime);
+
+  // write permissions aren't checked when setting node
+  // attributes unless the user uid isn't the owner (so
+  // therefor, this should work fine)
+  utime("unwriteable", &t);
+  assert(!errno);
+  memset(&s, 0, sizeof s);
+  stat("unwriteable", &s);
+  assert(s.st_atime == t.actime);
+  assert(s.st_mtime == t.modtime);
+
+  puts("success");
+}
+
+int main() {
+  atexit(cleanup);
+  signal(SIGABRT, cleanup);
+  setup();
+  test();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
http://pubs.opengroup.org/onlinepubs/009695399/functions/utime.html

From browsing the linux kernel source, it appears when setting inode attributes that permissions are only checked if the uid of the inode doesn't match the uid associated with the calling process. In emscripten's case, this is always true currently.

In similar vein to the other pull requests, I replaced the test with one with no JS API dependencies.
