### PR TITLE
Expose 'lstat64' as a simple alias for 'lstat'.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1115,6 +1115,7 @@ LibraryManager.library = {
   },
   stat64: 'stat',
   fstat64: 'fstat',
+  lstat64: 'lstat',
   __01fstat64_: 'fstat',
   __01stat64_: 'stat',
   __01lstat64_: 'lstat',


### PR DESCRIPTION
This seems to be inline with how stat64 and fstat64 are handled.
