### PR TITLE
fixed stderr output to use printErr

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -559,25 +559,28 @@ LibraryManager.library = {
         };
       }
       var utf8 = new Runtime.UTF8Processor();
-      function simpleOutput(val) {
-        if (val === null || val === {{{ charCode('\n') }}}) {
-          output.printer(output.buffer.join(''));
-          output.buffer = [];
-        } else {
-          output.buffer.push(utf8.processCChar(val));
-        }
+      function createSimpleOutput() {
+        var fn = function (val) {
+          if (val === null || val === {{{ charCode('\n') }}}) {
+            fn.printer(fn.buffer.join(''));
+            fn.buffer = [];
+          } else {
+            fn.buffer.push(utf8.processCChar(val));
+          }
+        };
+        return fn;
       }
       if (!output) {
         stdoutOverridden = false;
-        output = simpleOutput;
+        output = createSimpleOutput();
       }
       if (!output.printer) output.printer = Module['print'];
       if (!output.buffer) output.buffer = [];
       if (!error) {
         stderrOverridden = false;
-        error = simpleOutput;
+        error = createSimpleOutput();
       }
-      if (!error.printer) error.printer = Module['print'];
+      if (!error.printer) error.printer = Module['printErr'];
       if (!error.buffer) error.buffer = [];
 
       // Create the temporary folder, if not already created

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -6853,7 +6853,7 @@ def process(filename):
       other.close()
 
       src = open(path_from_root('tests', 'files.cpp'), 'r').read()
-      self.do_run(src, 'size: 7\ndata: 100,-56,50,25,10,77,123\nloop: 100 -56 50 25 10 77 123 \ninput:hi there!\ntexto\ntexte\n$\n5 : 10,30,20,11,88\nother=some data.\nseeked=me da.\nseeked=ata.\nseeked=ta.\nfscanfed: 10 - hello\nok.\n',
+      self.do_run(src, 'size: 7\ndata: 100,-56,50,25,10,77,123\nloop: 100 -56 50 25 10 77 123 \ninput:hi there!\ntexto\n$\n5 : 10,30,20,11,88\nother=some data.\nseeked=me da.\nseeked=ata.\nseeked=ta.\nfscanfed: 10 - hello\nok.\ntexte\n',
                    post_build=post, extra_emscripten_args=['-H', 'libc/fcntl.h'])
 
     def test_files_m(self):
@@ -6885,7 +6885,7 @@ def process(filename):
           return 0;
         }
         '''
-      self.do_run(src, 'isatty? 0,0,1\ngot: 35\ngot: 45\ngot: 25\ngot: 15\n', post_build=post)
+      self.do_run(src, 'got: 35\ngot: 45\ngot: 25\ngot: 15\nisatty? 0,0,1\n', post_build=post)
 
     def test_fwrite_0(self):
       src = r'''


### PR DESCRIPTION
I noticed this issue when these two tests were failing in the VFS branch (combined with that guy's issues in IRC the other day).

The only unfortunate issue is that stdout and stderr writes are async in node.js when they are being redirected to a pipe (as they are when running tests), so the output order isn't guaranteed. I ran the tests a few times, and on my machine at least, the stderr was always flushing out after all the stdout writes were done so I adjusted the comparison text accordingly. However, I'm not sure if this is reliable.
