### PR TITLE
Fixes in pread()

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1787,7 +1787,7 @@ LibraryManager.library = {
       }
       var contents = stream.object.contents;
       var size = Math.min(contents.length - offset, nbyte);
-      assert( size >= 0 );
+      assert(size >= 0);
       
 #if USE_TYPED_ARRAYS == 2
       if (contents.subarray) { // typed array
@@ -1856,7 +1856,7 @@ LibraryManager.library = {
       } else {
         var ungotSize = stream.ungotten.length;
         bytesRead = _pread(fildes, buf, nbyte, stream.position);
-        assert( bytesRead >= -1 );
+        assert(bytesRead >= -1);
         if (bytesRead != -1) {
           stream.position += (stream.ungotten.length - ungotSize) + bytesRead;
         }


### PR DESCRIPTION
The bug occurs when pread() doesn't return 0 when asked to read an
offset beyond its buffer.

This behavior is explicitly documented at:
http://pubs.opengroup.org/onlinepubs/000095399/functions/read.html

> If the starting position is at or after the end-of-file, 0
> shall be returned
