### PR TITLE
fix for dlclose refcount cleanup

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -5956,7 +5956,7 @@ LibraryManager.library = {
       return 1;
     } else {
       var lib_record = DLFCN_DATA.loadedLibs[handle];
-      if (lib_record.refcount-- == 0) {
+      if (--lib_record.refcount == 0) {
         delete DLFCN_DATA.loadedLibNames[lib_record.name];
         delete DLFCN_DATA.loadedLibs[handle];
       }


### PR DESCRIPTION
Converted the refcount decrement to a prefix operation so the shared library is cleaned up properly.
