### PR TITLE
Add DISABLE_UNSAFE_OPTS setting.

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -413,6 +413,12 @@ var DEBUG_TAGS_SHOWING = [];
   //    legalizer
 
 
+var DISABLE_UNSAFE_OPTS = 0;  // Explicitly disable the use of llvm options
+                              // that seem to be unsafe.  This may be useful
+                              // if optimizations are changing the behaviour
+                              // of the compiled code.
+
+
 // A cached set of defines, generated from the header files. This
 // lets the emscripten libc (library.js) see the right values.
 // If you the headers or use different ones, you will need to override

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1094,7 +1094,7 @@ set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)''' % { 'winfix': '' if not WINDOWS e
 
   @staticmethod
   def can_use_unsafe_opts():
-    return Settings.USE_TYPED_ARRAYS == 2
+    return Settings.USE_TYPED_ARRAYS == 2 and not Settings.DISABLE_UNSAFE_OPTS
 
   @staticmethod
   def can_inline():


### PR DESCRIPTION
This adds a DISABLE_UNSAFE_OPTS setting.  It allows the compilation to explicitly opt-out of LLVM optimisations that are suspected to be unsafe, per the can_use_unsafe_opts() method that already exists in the code.

I used this to work around the compilation issue described here:

```
https://groups.google.com/forum/#!topic/emscripten-discuss/HPMtJNVguWQ
```

It might be useful to expose this to help debugging/working-around similar issues in the future.
