### PR TITLE
Implement glGetIntegerv(GL_NUM_COMPRESSED_TEXTURE_FORMATS).

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -372,6 +372,12 @@ var LibraryGL = {
       case 0x8DF9: // GL_NUM_SHADER_BINARY_FORMATS
         {{{ makeSetValue('p', '0', '0', 'i32') }}};
         return;
+      case 0x86A2: // GL_NUM_COMPRESSED_TEXTURE_FORMATS
+        // WebGL doesn't have GL_NUM_COMPRESSED_TEXTURE_FORMATS (it's obsolete since GL_COMPRESSED_TEXTURE_FORMATS returns a JS array that can be queried for length),
+        // so implement it ourselves to allow C++ GLES2 code get the length.
+        var formats = Module.ctx.getParameter(0x86A3 /*GL_COMPRESSED_TEXTURE_FORMATS*/);
+        {{{ makeSetValue('p', '0', 'formats.length', 'i32') }}};
+        return;
     }
     var result = Module.ctx.getParameter(name_);
     switch (typeof(result)) {


### PR DESCRIPTION
Allows GL code to query GL_NUM_COMPRESSED_TEXTURE_FORMATS + GL_COMPRESSED_TEXTURE_FORMATS to check for available compressed texture format support.
