### PR TITLE
Third argument of mincore is unsigned char

### DIFF
--- a/system/include/bsd/sys/mman.h
+++ b/system/include/bsd/sys/mman.h
@@ -155,7 +155,7 @@ int	munlock __P((const void *, size_t));
 int	munmap __P((void *, size_t));
 #ifndef _POSIX_SOURCE
 int	madvise __P((void *, size_t, int));
-int	mincore __P((const void *, size_t, char *));
+int	mincore __P((const void *, size_t, unsigned char *));
 int	minherit __P((void *, size_t, int));
 #endif
 


### PR DESCRIPTION
The third argument of mincore is unsigned char.
Please see http://man7.org/linux/man-pages/man2/mincore.2.html
