### PR TITLE
don't expect an exit status to be returned from run or callMain

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2144,20 +2144,7 @@ LibraryManager.library = {
   _exit: function(status) {
     // void _exit(int status);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/exit.html
-
-    function ExitStatus() {
-      this.name = "ExitStatus";
-      this.message = "Program terminated with exit(" + status + ")";
-      this.status = status;
-      Module.print('Exit Status: ' + status);
-    };
-    ExitStatus.prototype = new Error();
-    ExitStatus.prototype.constructor = ExitStatus;
-
-    exitRuntime();
-    ABORT = true;
-
-    throw new ExitStatus();
+    Module['exit'](status);
   },
   fork__deps: ['__setErrNo', '$ERRNO_CODES'],
   fork: function() {
@@ -3922,8 +3909,7 @@ LibraryManager.library = {
   __cxa_atexit: 'atexit',
 
   abort: function() {
-    ABORT = true;
-    throw 'abort() at ' + (new Error().stack);
+    Module['abort']();
   },
 
   bsearch: function(key, base, num, size, compar) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -242,12 +242,6 @@ var tempI64, tempI64b;
 var tempRet0, tempRet1, tempRet2, tempRet3, tempRet4, tempRet5, tempRet6, tempRet7, tempRet8, tempRet9;
 #endif
 
-function abort(text) {
-  Module.print(text + ':\n' + (new Error).stack);
-  ABORT = true;
-  throw "Assertion: " + text;
-}
-
 function assert(condition, text) {
   if (!condition) {
     abort('Assertion failed: ' + text);


### PR DESCRIPTION
In revisiting the onload branch I figured I'd cherry-pick the more risky changes so they could be evaluated individually.

The main change here involves stopping callMain and run from returning incorrect exit statuses. Currently, callMain returns an exit status, which is bubbled up by run. However, this exit status is useless if the application isn't fully synchronous. Instead of trying to return a value, the correct value now always makes it to the new Module.exit function:
https://github.com/inolen/emscripten/commit/52a15b8c6a1f293b55a6c7a20efff3d6ebbc08b4#L1L115
However, at this time there is no way to externally hook into the exit event (note the TODO comment).

I've also added the Module.exit and Module.abort functions. Adding Module.exit lets us re-use the exit functionality for both forced-exits through calls to the libc exit, and natural exits when main peacefully returns in callMain.

The only compatibility concern is that now, callMain calls exitRuntime. However, I don't see any reason as to why it shouldn't. Currently, if the program is ran through callMain and the user calls the libc exit, the runtime will be exited, but if they simply return from main it won't, which doesn't seem right.

In the end, this change breaks `test_exit_stack` and `test_exit_status` from `o1`. Both functions are expecting "Exit Status: %status" message that's no longer printed. That message previously printed only when a user called exit, but since I've consolidated the exit routines it's hard to keep that way. Ultimately, it'd be great for the tests to do `Module.onexit(function (status) { assert(status == the status i want); });` or `Module.onexit(function (status) { Module.print("Exit Status: " + status); });` but that can't be resolved until the exit event interface is added. I'd like to just remove that expectation from the test for now. The `other` and `sanity` suites run fine.
