### PR TITLE
added addOnPreRun and addOnPostRun

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -6,7 +6,7 @@ var inMain;
 
 Module['callMain'] = Module.callMain = function callMain(args) {
   assert(runDependencies == 0, 'cannot call main when async dependencies remain! (listen on __ATMAIN__)');
-  assert(!Module['preRun'] || Module['preRun'].length == 0, 'cannot call main when preRun functions remain to be called');
+  assert(__ATPRERUN__.length == 0, 'cannot call main when preRun functions remain to be called');
 
   args = args || [];
 
@@ -74,17 +74,11 @@ function run(args) {
     return;
   }
 
-  if (Module['preRun']) {
-    if (typeof Module['preRun'] == 'function') Module['preRun'] = [Module['preRun']];
-    var toRun = Module['preRun'];
-    Module['preRun'] = [];
-    for (var i = toRun.length-1; i >= 0; i--) {
-      toRun[i]();
-    }
-    if (runDependencies > 0) {
-      // a preRun added a dependency, run will be called later
-      return;
-    }
+  preRun();
+
+  if (runDependencies > 0) {
+    // a preRun added a dependency, run will be called later
+    return;
   }
 
   function doRun() {
@@ -96,12 +90,8 @@ function run(args) {
     if (Module['_main'] && shouldRunNow) {
       Module['callMain'](args);
     }
-    if (Module['postRun']) {
-      if (typeof Module['postRun'] == 'function') Module['postRun'] = [Module['postRun']];
-      while (Module['postRun'].length > 0) {
-        Module['postRun'].pop()();
-      }
-    }
+
+    postRun();
   }
 
   if (Module['setStatus']) {


### PR DESCRIPTION
Added Module['addOnPreRun'] and Module['addOnPostRun'].

I also adjusted the preRun / postRun functionality to be in the same style as the init, preMain and exit code. Aside from `addPreRun` being changed to `addOnPreRun`, I don't think any of that risks breaking any compatibility.

As a side note, it seems preInit can be removed, as it currently appears to serve the exact same purpose as preRun. It also seems to make sense to execute preRun, init and preMain events in order instead of reverse order as I mentioned on IRC (perhaps that has something to do with why both exist?).

Ran o1, asm2 and other tests.
