### PR TITLE
split up FS.init

### DIFF
--- a/tests/filesystem/output.txt
+++ b/tests/filesystem/output.txt
@@ -7,7 +7,7 @@
   object.contents: ["123","456","deviceA","localLink","rootLink","relativeLink"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 /
   isRoot: true
@@ -15,10 +15,10 @@
   error: 0
   path: /
   name: /
-  object.contents: ["forbidden","abc","def"]
+  object.contents: ["tmp","dev","forbidden","abc","def"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 .
   isRoot: false
@@ -29,7 +29,7 @@
   object.contents: ["123","456","deviceA","localLink","rootLink","relativeLink"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 ..
   isRoot: true
@@ -37,10 +37,10 @@
   error: 0
   path: /
   name: /
-  object.contents: ["forbidden","abc","def"]
+  object.contents: ["tmp","dev","forbidden","abc","def"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 ../..
   isRoot: true
@@ -48,10 +48,10 @@
   error: 0
   path: /
   name: /
-  object.contents: ["forbidden","abc","def"]
+  object.contents: ["tmp","dev","forbidden","abc","def"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 /abc
   isRoot: false
@@ -62,7 +62,7 @@
   object.contents: ["123","456","deviceA","localLink","rootLink","relativeLink"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 /abc/123
   isRoot: false
@@ -114,10 +114,10 @@
   error: 0
   path: /
   name: /
-  object.contents: ["forbidden","abc","def"]
+  object.contents: ["tmp","dev","forbidden","abc","def"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 /abc/relativeLink
   isRoot: false
@@ -128,7 +128,7 @@
   object.contents: ["789","deviceB"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 /abc/relativeLink/deviceB
   isRoot: false
@@ -150,7 +150,7 @@
   object.contents: null
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 /abc/rootLink/abc/noexist
   isRoot: false
@@ -172,7 +172,7 @@
   object.contents: ["test"]
   parentExists: true
   parentPath: /
-  parentObject.contents: ["forbidden","abc","def"]
+  parentObject.contents: ["tmp","dev","forbidden","abc","def"]
 
 /forbidden/test
   isRoot: false


### PR DESCRIPTION
FS.init is mostly responsible for the FS-related initialization of the Module, not the FS.

I've split up the core FS initialization into FS.staticInit.

The point here was removing FS.ensureRoot hack, which doesn't exist in the vfs branch. FS.ensureRoot seems to have existed to handle the core initialization in case you'd disabled the default FS.init.

Ran o1, other and sanity tests.
