### PR TITLE
Include signal h

### DIFF
--- a/tests/dirent/test_readdir.c
+++ b/tests/dirent/test_readdir.c
@@ -2,6 +2,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/fcntl-open/src.c
+++ b/tests/fcntl-open/src.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/stat/test_chmod.c
+++ b/tests/stat/test_chmod.c
@@ -2,6 +2,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/stat/test_mknod.c
+++ b/tests/stat/test_mknod.c
@@ -2,6 +2,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/stat/test_stat.c
+++ b/tests/stat/test_stat.c
@@ -2,6 +2,7 @@
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/stdio/test_fgetc_ungetc.c
+++ b/tests/stdio/test_fgetc_ungetc.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/unistd/unlink.c
+++ b/tests/unistd/unlink.c
@@ -1,6 +1,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/tests/utime/test_utime.c
+++ b/tests/utime/test_utime.c
@@ -1,5 +1,6 @@
 #include <assert.h>
 #include <errno.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
This fixes some issues that come up when I'm using musl libc headers.

It passes `o1` tests on current `incoming`.
