### PR TITLE
Workaround for Chrome bug https://code.google.com/p/chromium/issues/deta...

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4947,17 +4947,7 @@ LibraryManager.library = {
            (chr >= {{{ charCode('{') }}} && chr <= {{{ charCode('~') }}});
   },
   isspace: function(chr) {
-    switch(chr) {
-      case 32:
-      case 9:
-      case 10:
-      case 11:
-      case 12:
-      case 13:
-        return true;
-      default:
-        return false;
-    };
+    return (chr == 32) || (chr >= 9 && chr <= 13);
   },
   isblank: function(chr) {
     return chr == {{{ charCode(' ') }}} || chr == {{{ charCode('\t') }}};


### PR DESCRIPTION
...il?id=269679 : switch statement I added in isspace to make it faster seemed to cause the whole function to be optimized away. Replace with simple range checks in conditional expression.
