### PR TITLE
Fix --preload-file on image files on Opera.

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -60,7 +60,11 @@ mergeInto(LibraryManager.library, {
         console.log("warning: no blob constructor, cannot create blobs with mimetypes");
       }
       Browser.BlobBuilder = typeof MozBlobBuilder != "undefined" ? MozBlobBuilder : (typeof WebKitBlobBuilder != "undefined" ? WebKitBlobBuilder : (!Browser.hasBlobConstructor ? console.log("warning: no BlobBuilder") : null));
-      Browser.URLObject = typeof window != "undefined" ? (window.URL ? window.URL : window.webkitURL) : console.log("warning: cannot create object URLs");
+      Browser.URLObject = typeof window != "undefined" ? (window.URL ? window.URL : window.webkitURL) : undefined;
+      if (!Module.noImageDecoding && typeof Browser.URLObject === 'undefined') {
+        console.log("warning: Browser does not support creating object URLs. Built-in browser image decoding will not be available.");
+        Module.noImageDecoding = true;
+      }
 
       // Support for plugins that can process preloaded files. You can add more of these to
       // your app by creating and appending to Module.preloadPlugins.


### PR DESCRIPTION
Do not attempt browser image decoding if the browser does not have the window.URL or window.webkitURL objects. Fix the warning print to appear in that case on Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.16.

This allows loading image files without attempting to use browser codecs on Opera, e.g. using stb_image or similar custom C++ code.
