### PR TITLE
Fix file packager on Windows.

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -40,7 +40,7 @@ TODO:        You can also provide .crn files yourself, pre-crunched. With this o
 '''
 
 import os, sys, shutil, random, uuid, ctypes
-
+import posixpath
 import shared
 from shared import Compression, execute, suffix, unsuffixed
 from subprocess import Popen, PIPE, STDOUT
@@ -217,7 +217,7 @@ for file_ in data_files:
   if file_['dstpath'].endswith('/'): # If user has submitted a directory name as the destination but omitted the destination filename, use the filename from source file
     file_['dstpath'] = file_['dstpath'] + os.path.basename(file_['srcpath'])
   # make destination path always relative to the root
-  file_['dstpath'] = os.path.normpath(os.path.join('/', file_['dstpath']))
+  file_['dstpath'] = posixpath.normpath(os.path.join('/', file_['dstpath']))
   if DEBUG:
     print >> sys.stderr, 'Packaging file "' + file_['srcpath'] + '" to VFS in path "' + file_['dstpath'] + '".'
 


### PR DESCRIPTION
Fixes file packager to generate a virtual filesystem with '/' as path separators when the host is Windows.

The recent file packager fixes had an unfortunate side effect of making Windows builds generate VFS filenames using backslashes as directory delimiters, which would get treated as an escape character in JS, and loading the generated .html files would fail with an invalid symbol error. This restores browser.test_preload_file to work on Windows.
