### PR TITLE
Fixed openal buffers

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -8,6 +8,12 @@ var LibraryOpenAL = {
     QUEUE_INTERVAL: 25,
     QUEUE_LOOKAHEAD: 100,
 
+    getCurrentTime: function(context) {
+      // currentTime is frozen during execution, use performance timers to
+      // emulate the current time at call time
+      return (window['performance']['now']() - context.startTime) / 1000.0;
+    },
+
     updateSources: function(context) {
       for (var i = 0; i < context.src.length; i++) {
         AL.updateSource(context.src[i]);
@@ -22,7 +28,7 @@ var LibraryOpenAL = {
         return;
       }
 
-      var currentTime = AL.currentContext.ctx.currentTime;
+      var currentTime = AL.getCurrentTime(AL.currentContext);
       var startTime = src.bufferPosition;
 
       for (var i = src.buffersPlayed; i < src.queue.length; i++) {
@@ -73,7 +79,7 @@ var LibraryOpenAL = {
         if (src.state !== 0x1013 /* AL_PAUSED */) {
           src.state = 0x1012 /* AL_PLAYING */;
           // Reset our position.
-          src.bufferPosition = AL.currentContext.ctx.currentTime;
+          src.bufferPosition = AL.getCurrentTime(AL.currentContext);
           src.buffersPlayed = 0;
 #if OPENAL_DEBUG
           console.log('setSourceState resetting and playing source ' + idx);
@@ -81,7 +87,7 @@ var LibraryOpenAL = {
         } else {
           src.state = 0x1012 /* AL_PLAYING */;
           // Use the current offset from src.bufferPosition to resume at the correct point.
-          src.bufferPosition = AL.currentContext.ctx.currentTime - src.bufferPosition;
+          src.bufferPosition = AL.getCurrentTime(AL.currentContext) - src.bufferPosition;
 #if OPENAL_DEBUG
           console.log('setSourceState resuming source ' + idx + ' at ' + src.bufferPosition.toFixed(4));
 #endif
@@ -92,7 +98,7 @@ var LibraryOpenAL = {
         if (src.state === 0x1012 /* AL_PLAYING */) {
           src.state = 0x1013 /* AL_PAUSED */;
           // Store off the current offset to restore with on resume.
-          src.bufferPosition = AL.currentContext.ctx.currentTime - src.bufferPosition;
+          src.bufferPosition = AL.getCurrentTime(AL.currentContext) - src.bufferPosition;
           AL.stopSourceQueue(src);
 #if OPENAL_DEBUG
           console.log('setSourceState pausing source ' + idx + ' at ' + src.bufferPosition.toFixed(4));
@@ -206,7 +212,8 @@ var LibraryOpenAL = {
         err: 0,
         src: [],
         buf: [],
-        interval: setInterval(function() { AL.updateSources(context); }, AL.QUEUE_INTERVAL)
+        interval: setInterval(function() { AL.updateSources(context); }, AL.QUEUE_INTERVAL),
+        startTime: window['performance']['now']()
       };
       AL.contexts.push(context);
       return AL.contexts.length;


### PR DESCRIPTION
According to the Mozilla bug report (https://bugzilla.mozilla.org/show_bug.cgi?id=901247) currentTime only updates on the event loop, which can cause bugs for us if a program wants to wait on an audio buffer to complete before continuing. To get around this, I changed the logic to use performance timers for audio queuing.
