### PR TITLE
make FS.readdir easier to use

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -100,7 +100,7 @@ LibraryManager.library = {
     }
     var entries;
     try {
-      entries = FS.readdir(stream);
+      entries = FS.readdir(stream.path);
     } catch (e) {
       return FS.handleFSError(e);
     }

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -730,6 +730,9 @@ mergeInto(LibraryManager.library, {
       });
       // use a custom read function
       stream_ops.read = function(stream, buffer, offset, length, position) {
+        if (!FS.forceLoadFile(node)) {
+          throw new FS.ErrnoError(ERRNO_CODES.EIO);
+        }
         var contents = stream.node.contents;
         var size = Math.min(contents.length - position, length);
         if (contents.slice) { // normal array
@@ -1035,7 +1038,7 @@ mergeInto(LibraryManager.library, {
       FS.hashRemoveNode(old_node);
       // do the underlying fs rename
       try {
-        old_node.node_ops.rename(old_node, new_dir, new_name);
+        old_dir.node_ops.rename(old_node, new_dir, new_name);
       } catch (e) {
         throw e;
       } finally {
@@ -1061,6 +1064,14 @@ mergeInto(LibraryManager.library, {
       }
       parent.node_ops.rmdir(parent, name);
       FS.destroyNode(node);
+    },
+    readdir: function(path) {
+      var lookup = FS.lookupPath(path, { follow: true });
+      var node = lookup.node;
+      if (!node.node_ops.readdir) {
+        throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
+      }
+      return node.node_ops.readdir(node);
     },
     unlink: function(path) {
       var lookup = FS.lookupPath(path, { parent: true });
@@ -1279,12 +1290,6 @@ mergeInto(LibraryManager.library, {
         throw new FS.ErrnoError(ERRNO_CODES.ESPIPE);
       }
       return stream.stream_ops.llseek(stream, offset, whence);
-    },
-    readdir: function(stream) {
-      if (!stream.stream_ops.readdir) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
-      }
-      return stream.stream_ops.readdir(stream);
     },
     read: function(stream, buffer, offset, length, position) {
       if (length < 0 || position < 0) {


### PR DESCRIPTION
Was integrating the new filesystem changes into quakejs tonight and realized there wasn't much reason to make users FS.open, FS.readdir and FS.close to read directory contents.

With that said, FS.readdir now takes in a path instead of a stream instance.

Ran o1, other and browser.
