### PR TITLE
default to mode 0666 in FS.open

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -478,8 +478,6 @@ LibraryManager.library = {
   open: function(path, oflag, varargs) {
     // int open(const char *path, int oflag, ...);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/open.html
-    // NOTE: This implementation tries to mimic glibc rather than strictly
-    // following the POSIX standard.
     var mode = {{{ makeGetValue('varargs', 0, 'i32') }}};
     path = Pointer_stringify(path);
     try {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1202,6 +1202,7 @@ mergeInto(LibraryManager.library, {
     open: function(path, flags, mode, fd_start, fd_end) {
       path = PATH.normalize(path);
       flags = typeof flags === 'string' ? FS.modeStringToFlags(flags) : flags;
+      mode = typeof mode === 'undefined' ? 0666 : mode;
       if ((flags & {{{ cDefine('O_CREAT') }}})) {
         mode = (mode & {{{ cDefine('S_IALLUGO') }}}) | {{{ cDefine('S_IFREG') }}};
       } else {


### PR DESCRIPTION
The libc functionality remains as is (since it'll always pass the mode argument to FS.open), however, for users of the JS API I'd like to default the mode to 0666 when creating files (node does the same thing).
