### PR TITLE
Ensure FS.hashName returns a positive integer

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -51,7 +51,7 @@ mergeInto(LibraryManager.library, {
       for (var i = 0; i < name.length; i++) {
         hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
       }
-      return (parentid + hash) % FS.name_table.length;
+      return ((parentid + hash) >>> 0) % FS.name_table.length;
     },
     hashAddNode: function(node) {
       var hash = FS.hashName(node.parent.id, node.name);


### PR DESCRIPTION
The FS.hashName() function can sometimes return negative numbers, which causes subsequent lookups to fail and produce ENOENT for files that are supposed to exist.

Since this is a pre-allocated array I'm assuming you want all the hashes to be positive integers.  This PR fixes the issue for me, but maybe there is a better way to do it by changing the hash function itself.
