### PR TITLE
don't check COMPILE_STATUS in glCompileShader by default

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -1618,17 +1618,15 @@ var LibraryGL = {
       var glCompileShader = _glCompileShader;
       _glCompileShader = function(shader) {
         Module.ctx.compileShader(GL.shaders[shader]);
+#if GL_DEBUG
         if (!Module.ctx.getShaderParameter(GL.shaders[shader], Module.ctx.COMPILE_STATUS)) {
           Module.printErr('Failed to compile shader: ' + Module.ctx.getShaderInfoLog(GL.shaders[shader]));
           Module.printErr('Info: ' + JSON.stringify(GL.shaderInfos[shader]));
-#if GL_DEBUG
           Module.printErr('Original source: ' + GL.shaderOriginalSources[shader]);
           Module.printErr('Source: ' + GL.shaderSources[shader]);
           throw 'Shader compilation halt';
-#else
-          Module.printErr('Enable GL_DEBUG to see shader source');
-#endif
         }
+#endif
       };
 
       GL.programShaders = {};


### PR DESCRIPTION
Applications should be checking this themselves, we shouldn't automatically check it (or even worse, double up the amount of checks).

I believe I'd profiled this when doing the initial quake3 port and noticed that the check to COMPILE_STATUS for a few hundred shaders was taking an oddly noticeable amount of time.
