### PR TITLE
export setCanvasSize to Module object

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -6,6 +6,7 @@ mergeInto(LibraryManager.library, {
   $Browser__deps: ['$PATH'],
   $Browser__postset: 'Module["requestFullScreen"] = function(lockPointer, resizeCanvas) { Browser.requestFullScreen(lockPointer, resizeCanvas) };\n' + // exports
                      'Module["requestAnimationFrame"] = function(func) { Browser.requestAnimationFrame(func) };\n' +
+                     'Module["setCanvasSize"] = function(width, height, noUpdates) { Browser.setCanvasSize(width, height, noUpdates) };\n' +
                      'Module["pauseMainLoop"] = function() { Browser.mainLoop.pause() };\n' +
                      'Module["resumeMainLoop"] = function() { Browser.mainLoop.resume() };\n' +
                      'Module["getUserMedia"] = function() { Browser.getUserMedia() }',


### PR DESCRIPTION
It's useful to export setCanvasSize so users can update the canvas size manually. This is useful if say, you'd like to resize the canvas as the window (or some other parent element) resizes.
