### PR TITLE
re-enabled non-asm.js shared lib support

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -185,8 +185,7 @@ if (ASM_JS) {
   assert(!ALLOW_MEMORY_GROWTH, 'Cannot grow asm.js heap');
   assert((TOTAL_MEMORY&(TOTAL_MEMORY-1)) == 0, 'asm.js heap must be power of 2');
 }
-assert(!BUILD_AS_SHARED_LIB, 'shared libs are deprecated');
-//assert(!(!NAMED_GLOBALS && BUILD_AS_SHARED_LIB), 'shared libraries must have named globals');
+assert(!(!NAMED_GLOBALS && BUILD_AS_SHARED_LIB), 'shared libraries must have named globals');
 
 // Output some info and warnings based on settings
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -278,7 +278,7 @@ function JSify(data, functionsOnly, givenFunctions) {
         // they would shadow similarly-named globals in the parent.
         item.JS = '';
       } else {
-      	item.JS = makeGlobalDef(item.ident);
+        item.JS = makeGlobalDef(item.ident);
       }
 
       if (!NAMED_GLOBALS && isIndexableGlobal(item.ident)) {
@@ -1628,7 +1628,7 @@ function JSify(data, functionsOnly, givenFunctions) {
     //
 
     if (!mainPass) {
-      if (phase == 'pre' && !Variables.generatedGlobalBase) {
+      if (phase == 'pre' && !Variables.generatedGlobalBase && !BUILD_AS_SHARED_LIB) {
         Variables.generatedGlobalBase = true;
         // Globals are done, here is the rest of static memory
         assert((TARGET_LE32 && Runtime.GLOBAL_BASE == 8) || (TARGET_X86 && Runtime.GLOBAL_BASE == 4)); // this is assumed in e.g. relocations for linkable modules
@@ -1672,24 +1672,26 @@ function JSify(data, functionsOnly, givenFunctions) {
         print('}\n');
 
         if (USE_TYPED_ARRAYS == 2) {
-          print('var tempDoublePtr = Runtime.alignMemory(allocate(12, "i8", ALLOC_STATIC), 8);\n');
-          print('assert(tempDoublePtr % 8 == 0);\n');
-          print('function copyTempFloat(ptr) { // functions, because inlining this code increases code size too much\n');
-          print('  HEAP8[tempDoublePtr] = HEAP8[ptr];\n');
-          print('  HEAP8[tempDoublePtr+1] = HEAP8[ptr+1];\n');
-          print('  HEAP8[tempDoublePtr+2] = HEAP8[ptr+2];\n');
-          print('  HEAP8[tempDoublePtr+3] = HEAP8[ptr+3];\n');
-          print('}\n');
-          print('function copyTempDouble(ptr) {\n');
-          print('  HEAP8[tempDoublePtr] = HEAP8[ptr];\n');
-          print('  HEAP8[tempDoublePtr+1] = HEAP8[ptr+1];\n');
-          print('  HEAP8[tempDoublePtr+2] = HEAP8[ptr+2];\n');
-          print('  HEAP8[tempDoublePtr+3] = HEAP8[ptr+3];\n');
-          print('  HEAP8[tempDoublePtr+4] = HEAP8[ptr+4];\n');
-          print('  HEAP8[tempDoublePtr+5] = HEAP8[ptr+5];\n');
-          print('  HEAP8[tempDoublePtr+6] = HEAP8[ptr+6];\n');
-          print('  HEAP8[tempDoublePtr+7] = HEAP8[ptr+7];\n');
-          print('}\n');
+          if (!BUILD_AS_SHARED_LIB) {
+            print('var tempDoublePtr = Runtime.alignMemory(allocate(12, "i8", ALLOC_STATIC), 8);\n');
+            print('assert(tempDoublePtr % 8 == 0);\n');
+            print('function copyTempFloat(ptr) { // functions, because inlining this code increases code size too much\n');
+            print('  HEAP8[tempDoublePtr] = HEAP8[ptr];\n');
+            print('  HEAP8[tempDoublePtr+1] = HEAP8[ptr+1];\n');
+            print('  HEAP8[tempDoublePtr+2] = HEAP8[ptr+2];\n');
+            print('  HEAP8[tempDoublePtr+3] = HEAP8[ptr+3];\n');
+            print('}\n');
+            print('function copyTempDouble(ptr) {\n');
+            print('  HEAP8[tempDoublePtr] = HEAP8[ptr];\n');
+            print('  HEAP8[tempDoublePtr+1] = HEAP8[ptr+1];\n');
+            print('  HEAP8[tempDoublePtr+2] = HEAP8[ptr+2];\n');
+            print('  HEAP8[tempDoublePtr+3] = HEAP8[ptr+3];\n');
+            print('  HEAP8[tempDoublePtr+4] = HEAP8[ptr+4];\n');
+            print('  HEAP8[tempDoublePtr+5] = HEAP8[ptr+5];\n');
+            print('  HEAP8[tempDoublePtr+6] = HEAP8[ptr+6];\n');
+            print('  HEAP8[tempDoublePtr+7] = HEAP8[ptr+7];\n');
+            print('}\n');
+          }
         }
       }
 
@@ -1724,11 +1726,13 @@ function JSify(data, functionsOnly, givenFunctions) {
 
       legalizedI64s = legalizedI64sDefault;
 
-      print('STACK_BASE = STACKTOP = Runtime.alignMemory(STATICTOP);\n');
-      print('staticSealed = true; // seal the static portion of memory\n');
-      print('STACK_MAX = STACK_BASE + ' + TOTAL_STACK + ';\n');
-      print('DYNAMIC_BASE = DYNAMICTOP = Runtime.alignMemory(STACK_MAX);\n');
-      print('assert(DYNAMIC_BASE < TOTAL_MEMORY); // Stack must fit in TOTAL_MEMORY; allocations from here on may enlarge TOTAL_MEMORY\n');
+      if (!BUILD_AS_SHARED_LIB) {
+        print('STACK_BASE = STACKTOP = Runtime.alignMemory(STATICTOP);\n');
+        print('staticSealed = true; // seal the static portion of memory\n');
+        print('STACK_MAX = STACK_BASE + ' + TOTAL_STACK + ';\n');
+        print('DYNAMIC_BASE = DYNAMICTOP = Runtime.alignMemory(STACK_MAX);\n');
+        print('assert(DYNAMIC_BASE < TOTAL_MEMORY); // Stack must fit in TOTAL_MEMORY; allocations from here on may enlarge TOTAL_MEMORY\n');
+      }
 
       if (asmLibraryFunctions.length > 0) {
         print('// ASM_LIBRARY FUNCTIONS');

--- a/src/settings.js
+++ b/src/settings.js
@@ -315,11 +315,12 @@ var SIDE_MODULE = 0; // Corresponds to MAIN_MODULE
 
 var BUILD_AS_SHARED_LIB = 0; // Whether to build the code as a shared library
                              // 0 here means this is not a shared lib: It is a main file.
-                             // All shared library options (1 and 2) are currently deprecated XXX
                              // 1 means this is a normal shared lib, load it with dlopen()
                              // 2 means this is a shared lib that will be linked at runtime,
                              //   which means it will insert its functions into
                              //   the global namespace. See STATIC_LIBS_TO_LOAD.
+                             //
+                             // Value 2 is currently deprecated.
 var RUNTIME_LINKED_LIBS = []; // If this is a main file (BUILD_AS_SHARED_LIB == 0), then
                               // we will link these at runtime. They must have been built with
                               // BUILD_AS_SHARED_LIB == 2.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1339,7 +1339,7 @@ Press any key to continue.'''
     self.btest('perspective.c', reference='perspective.png', args=['-s', 'LEGACY_GL_EMULATION=1'])
 
   def test_runtimelink(self):
-    return self.skip('shared libs are deprecated')
+    return self.skip('BUILD_AS_SHARED_LIB=2 is deprecated')
     main, supp = self.setup_runtimelink_test()
 
     open(self.in_dir('supp.cpp'), 'w').write(supp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5451,7 +5451,7 @@ The current type of b is: 9
         self.do_run(src, '*16,0,4,8,8,12|20,0,4,4,8,12,12,16|24,0,20,0,4,4,8,12,12,16*\n*0,0,0,1,2,64,68,69,72*\n*2*')
 
   def test_runtimelink(self):
-    return self.skip('shared libs are deprecated')
+    return self.skip('BUILD_AS_SHARED_LIB=2 is deprecated')
     if Building.LLVM_OPTS: return self.skip('LLVM opts will optimize printf into puts in the parent, and the child will still look for puts')
     if Settings.ASM_JS: return self.skip('asm does not support runtime linking')
 
@@ -5470,7 +5470,6 @@ The current type of b is: 9
     self.do_run(main, 'supp: 54,2\nmain: 56\nsupp see: 543\nmain see: 76\nok.')
 
   def test_dlfcn_basic(self):
-    return self.skip('shared libs are deprecated')
     if Settings.ASM_JS: return self.skip('TODO: dlopen in asm')
 
     Settings.NAMED_GLOBALS = 1
@@ -5525,7 +5524,6 @@ def process(filename):
                 post_build=add_pre_run_and_checks)
 
   def test_dlfcn_qsort(self):
-    return self.skip('shared libs are deprecated')
     if self.emcc_args is None: return self.skip('requires emcc')
     if Settings.ASM_JS: return self.skip('TODO: dlopen in asm')
 
@@ -5622,7 +5620,6 @@ def process(filename):
                 post_build=add_pre_run_and_checks)
 
   def test_dlfcn_data_and_fptr(self):
-    return self.skip('shared libs are deprecated')
     if Settings.ASM_JS: return self.skip('TODO: dlopen in asm')
     if Building.LLVM_OPTS: return self.skip('LLVM opts will optimize out parent_func')
 
@@ -5727,7 +5724,6 @@ def process(filename):
                  post_build=add_pre_run_and_checks)
 
   def test_dlfcn_alias(self):
-    return self.skip('shared libs are deprecated')
     if Settings.ASM_JS: return self.skip('TODO: dlopen in asm')
 
     Settings.LINKABLE = 1
@@ -5785,7 +5781,6 @@ def process(filename):
     Settings.INCLUDE_FULL_LIBRARY = 0
 
   def test_dlfcn_varargs(self):
-    return self.skip('shared libs are deprecated')
     if Settings.ASM_JS: return self.skip('TODO: dlopen in asm')
 
     Settings.LINKABLE = 1

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1033,7 +1033,7 @@ int main(int argc, char const *argv[])
     self.assertContained('hello from lib', run_js(os.path.join(self.get_dir(), 'a.out.js')))
 
   def test_runtimelink_multi(self):
-    return self.skip('shared libs are deprecated')
+    return self.skip('BUILD_AS_SHARED_LIB=2 is deprecated')
     if Settings.ASM_JS: return self.skip('asm does not support runtime linking yet')
 
     if SPIDERMONKEY_ENGINE not in JS_ENGINES: return self.skip('cannot run without spidermonkey due to node limitations')


### PR DESCRIPTION
This commit involves minor changes to jsifier to not output code for the shared modules that belongs to the parent module.

Tests are all re-enabled, but there is a problem with `test_dlopen_alias` due to:

```
azakai: looks like INCLUDE_FULL_LIBRARY=1 conflicts a bit with the new LEGACY_GL_EMULATION check
```

@kidanger sorry for procrastinating on this, not sure if it's still useful to you.
