### PR TITLE
Fix test runner returncode.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -766,11 +766,17 @@ an individual test with
     except:
       pass
 
+  numFailures = 0 # Keep count of the total number of failing tests.
+
   # Run the discovered tests
   if not len(suites):
     print >> sys.stderr, 'No tests found for %s' % str(sys.argv[1:])
+    numFailures = 1
   else:
     testRunner = unittest.TextTestRunner(verbosity=2)
     for suite in suites:
-      testRunner.run(suite)
+      results = testRunner.run(suite)
+      numFailures += len(results.errors) + len(results.failures)
 
+  # Return the number of failures as the process exit code for automating success/failure reporting.
+  exit(numFailures)


### PR DESCRIPTION
The recent refactor to the test runner architecture lost the runner ability to return the number of failures as process return code. This made the buildbots report all test runs as successes, since it derives the success/fail status from the process return code.

This commit reimplements the previous behavior so that buildbot reports success and failure properly.
