### PR TITLE
Fix source_map on windows.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -275,6 +275,18 @@ process(sys.argv[1])
       print "Output: " + output[0]
     return output[0]
 
+  # Tests that the given two paths are identical, modulo path delimiters. E.g. "C:/foo" is equal to "C:\foo".
+  def assertPathsIdentical(self, path1, path2):
+    path1 = path1.replace('\\', '/')
+    path2 = path2.replace('\\', '/')
+    return self.assertIdentical(path1, path2)
+
+  # Tests that the given two multiline text content are identical, modulo line ending differences (\r\n on Windows, \n on Unix).
+  def assertTextDataIdentical(self, text1, text2):
+    text1 = text1.replace('\r\n', '\n')
+    text2 = text2.replace('\r\n', '\n')
+    return self.assertIdentical(text1, text2)
+
   def assertIdentical(self, values, y):
     if type(values) not in [list, tuple]: values = [values]
     for x in values:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9582,15 +9582,15 @@ def process(filename):
       self.assertIdentical(clean(no_maps_file), clean(out_file))
       map_filename = out_filename + '.map'
       data = json.load(open(map_filename, 'r'))
-      self.assertIdentical(out_filename, data['file'])
-      self.assertIdentical(src_filename, data['sources'][0])
-      self.assertIdentical(src, data['sourcesContent'][0])
+      self.assertPathsIdentical(out_filename, data['file'])
+      self.assertPathsIdentical(src_filename, data['sources'][0])
+      self.assertTextDataIdentical(src, data['sourcesContent'][0])
       mappings = json.loads(jsrun.run_js(
         path_from_root('tools', 'source-maps', 'sourcemap2json.js'),
         tools.shared.NODE_JS, [map_filename]))
       seen_lines = set()
       for m in mappings:
-        self.assertIdentical(src_filename, m['source'])
+        self.assertPathsIdentical(src_filename, m['source'])
         seen_lines.add(m['originalLine'])
       # ensure that all the 'meaningful' lines in the original code get mapped
       assert seen_lines.issuperset([6, 7, 11, 12])


### PR DESCRIPTION
The implementation of source map extraction did not work on Windows since it was introduced.

The issue was in the usual minor platform differences: in '\r\n' vs '\n' line endings, 'c:\' vs '/' absolute path detection, and '/' and '\' path separators. This fix normalized received data to sourcemapper on Windows to Unix form so that the mapper operates on Windows as well.

source_map tests checked to pass on Windows and Linux.
