### PR TITLE
Fix rsp file escaping on Windows.

### DIFF
--- a/tools/response_file.py
+++ b/tools/response_file.py
@@ -6,8 +6,8 @@ def create_response_file(args, directory):
   (response_fd, response_filename) = tempfile.mkstemp(prefix='emscripten_', suffix='.rsp', dir=directory, text=True)
   response_fd = os.fdopen(response_fd, "w")
   #print >> sys.stderr, "Creating response file '%s'" % response_filename
-  args = map(lambda p: p.replace(' ', '').replace('\\', '\\\\').replace('"', '\\"'), args)
-  response_fd.write(' '.join(args))
+  args = map(lambda p: p.replace('\\', '\\\\').replace('"', '\\"'), args)
+  response_fd.write('"' + '" "'.join(args) + '"')
   response_fd.close()
   return response_filename
 


### PR DESCRIPTION
This commit removes the bad space-eating array->string serialization in response file generation. Instead, all array elements are enclosed in double-quotes " " to be able to preserve the array.

The same .rsp files are created by MSVC, which is why e.g. custom delimiter tricks or python array->string->array could not be used.

This pull request relates to issues #1471 and #1533.
