### PR TITLE
implement eglGetProcAddress

### DIFF
--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -489,6 +489,11 @@ var LibraryEGL = {
   eglSwapBuffers: function() {
     EGL.setErrorCode(0x3000 /* EGL_SUCCESS */);
   },
+
+  eglGetProcAddress__deps: ['emscripten_GetProcAddress'],
+  eglGetProcAddress: function(name_) {
+    return _emscripten_GetProcAddress(Pointer_stringify(name_));
+  },
 };
 
 autoAddDeps(LibraryEGL, '$EGL');


### PR DESCRIPTION
According to spec:

[eglGetProcAddress may be queried for all GL and EGL extension functions.](http://www.khronos.org/registry/egl/sdk/docs/man/xhtml/eglGetProcAddress.html)

Implemented for GL functions. EGL functions I believe are only needed for extensions and the normal calls are always exported, but I may be wrong about this.
