### PR TITLE
gracefully handle ExitStatus exception in async main loops

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -724,7 +724,15 @@ mergeInto(LibraryManager.library, {
         Module['preMainLoop']();
       }
 
-      Runtime.dynCall('v', func);
+      try {
+        Runtime.dynCall('v', func);
+      } catch (e) {
+        if (e instanceof ExitStatus) {
+          return;
+        } else {
+          throw e;
+        }
+      }
 
       if (Module['postMainLoop']) {
         Module['postMainLoop']();

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -126,7 +126,15 @@ function exit(status) {
 
   // exit the runtime
   exitRuntime();
- 
+
+  // TODO We should handle this differently based on environment.
+  // In the browser, the best we can do is throw an exception
+  // to halt execution, but in node we could process.exit and
+  // I'd imagine SM shell would have something equivalent.
+  // This would let us set a proper exit status (which
+  // would be great for checking test exit statuses).
+  // https://github.com/kripken/emscripten/issues/1371
+
   // throw an exception to halt the current execution
   throw new ExitStatus(status);
 }


### PR DESCRIPTION
Noticed this while revisiting test_stdin, it seems this should behave the same as when you're using a sync main function.
