### PR TITLE
persist preventDefault function in synthetic mousewheel events

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -455,7 +455,10 @@ var LibrarySDL = {
               type: 'mouseup',
               button: button,
               pageX: event.pageX,
-              pageY: event.pageY
+              pageY: event.pageY,
+              preventDefault: (function(ev) {
+                return function() { return ev.preventDefault.apply(ev, arguments); };
+              }(event))
             };
           } else if (event.type == 'mousedown') {
             SDL.DOMButtons[event.button] = 1;


### PR DESCRIPTION
Mousewheel events were throwing exceptions because preventDefault didn't exist on the new, synthetic event object.
