### PR TITLE
Fix using emcc -E.

### DIFF
--- a/emcc
+++ b/emcc
@@ -556,6 +556,8 @@ if CONFIGURE_CONFIG or CMAKE_CONFIG:
     elif arg.endswith('.s'):
       if debug_configure: open(tempout, 'a').write('(compiling .s assembly, must use clang\n')
       use_js = 0
+    elif arg == '-E':
+      use_js = 0
 
   if src:
     if 'fopen' in src and '"w"' in src:


### PR DESCRIPTION
We don't want to pass this extra flag to emcc as it breaks when
doing EMCONFIGURE_JS=1 emconfigure ./configure ...
