### PR TITLE
Remove cxx mangled catgets / catopen / catclose.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -6584,10 +6584,6 @@ LibraryManager.library = {
     return me.ret;
   },
 
-  _Z7catopenPKci: function() { throw 'catopen not implemented' },
-  _Z7catgetsP8_nl_catdiiPKc: function() { throw 'catgets not implemented' },
-  _Z8catcloseP8_nl_catd: function() { throw 'catclose not implemented' },
-
   // ==========================================================================
   // errno.h
   // ==========================================================================


### PR DESCRIPTION
In the old headers, these were not extern "C", so they would show
up mangled when built for C++. This is no longer the case with
the new libc headers.
