### PR TITLE
Implemented dprintf. (Fixes #1250)

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2844,7 +2844,7 @@ LibraryManager.library = {
   vprintf: 'printf',
   vsprintf: 'sprintf',
   vasprintf: 'asprintf',
-  vdprintf: 'vdprintf',
+  vdprintf: 'dprintf',
   vscanf: 'scanf',
   vfscanf: 'fscanf',
   vsscanf: 'sscanf',


### PR DESCRIPTION
dprintf() is already declared in system/include/libc/stdio.h. This patch adds the JS implementation.
