### PR TITLE
Fix ccallFunc to properly support UTF-8 strings

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -299,11 +299,10 @@ function ccallFunc(func, returnType, argTypes, args) {
   function toC(value, type) {
     if (type == 'string') {
       if (value === null || value === undefined || value === 0) return 0; // null string
-      if (!stack) stack = Runtime.stackSave();
-      var ret = Runtime.stackAlloc(value.length+1);
-      writeStringToMemory(value, ret);
-      return ret;
-    } else if (type == 'array') {
+      value = intArrayFromString(value);
+      type = 'array';
+    }
+    if (type == 'array') {
       if (!stack) stack = Runtime.stackSave();
       var ret = Runtime.stackAlloc(value.length);
       writeArrayToMemory(value, ret);


### PR DESCRIPTION
As pointed out in #1166, ccallFunc fails to calculate the required amount of memory for a string, if it contains non-ascii characters. I fixed it by converting the string into an array, then writing that array into memory. That's basically the same writeStringToMemory() does but I can use the array length to determine the necessary memory.
