### PR TITLE
Fix 3 issues with formatting (printf)

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1974,6 +1974,7 @@ LibraryManager.library = {
         var flagLeftAlign = false;
         var flagAlternative = false;
         var flagZeroPad = false;
+        var flagPadSign = false;
         flagsLoop: while (1) {
           switch (next) {
             case {{{ charCode('+') }}}:
@@ -1992,6 +1993,9 @@ LibraryManager.library = {
                 flagZeroPad = true;
                 break;
               }
+            case {{{ charCode(' ') }}}:
+              flagPadSign = true;
+              break;
             default:
               break flagsLoop;
           }
@@ -2158,8 +2162,12 @@ LibraryManager.library = {
             }
 
             // Add sign if needed
-            if (flagAlwaysSigned && currArg >= 0) {
-              prefix = '+' + prefix;
+            if (currArg >= 0) {
+              if (flagAlwaysSigned) {
+                prefix = '+' + prefix;
+              } else if (flagPadSign) {
+                prefix = ' ' + prefix;
+              }
             }
 
             // Move sign to prefix so we zero-pad after the sign
@@ -2250,8 +2258,12 @@ LibraryManager.library = {
               if (next == {{{ charCode('E') }}}) argText = argText.toUpperCase();
 
               // Add sign.
-              if (flagAlwaysSigned && currArg >= 0) {
-                argText = '+' + argText;
+              if (currArg >= 0) {
+                if (flagAlwaysSigned) {
+                  argText = '+' + argText;
+                } else if (flagPadSign) {
+                  argText = ' ' + argText;
+                }
               }
             }
 

--- a/tests/printf/output.txt
+++ b/tests/printf/output.txt
@@ -6,9 +6,12 @@ Decimals: 1977 650000 12 4
 Preceding with blanks:       1977      -1977
 Preceding with zeros: 0000001977 -000001977
 Force sign: +1977 -1977  +1977  -1977
+Force sign or space:  1977 -1977   1977  -1977
+Sign overrides space: +1977 -1977  +1977  -1977
 Some different radixes: 100 64 144 0x64 0144
 floats: 3.14 +3e+00 3.141600E+00 00003.14
 negative floats: -3.14 -3e+00 -3.141600E+00 -0003.14
+Force sign or space:  3.14 -3.14   3.14  -3.14
 Width trick:    10
 A string %
 Null string:  (null)

--- a/tests/printf/output_i64_1.txt
+++ b/tests/printf/output_i64_1.txt
@@ -6,9 +6,12 @@ Decimals: 1977 650000 12 4
 Preceding with blanks:       1977      -1977
 Preceding with zeros: 0000001977 -000001977
 Force sign: +1977 -1977  +1977  -1977
+Force sign or space:  1977 -1977   1977  -1977
+Sign overrides space: +1977 -1977  +1977  -1977
 Some different radixes: 100 64 144 0x64 0144
 floats: 3.14 +3e+00 3.141600E+00 00003.14
 negative floats: -3.14 -3e+00 -3.141600E+00 -0003.14
+Force sign or space:  3.14 -3.14   3.14  -3.14
 Width trick:    10
 A string %
 Null string:  (null)

--- a/tests/printf/test.c
+++ b/tests/printf/test.c
@@ -11,9 +11,12 @@ int main() {
   printf("Preceding with blanks: %10d %10d\n", 1977, -1977);
   printf("Preceding with zeros: %010d %010d\n", 1977, -1977);
   printf("Force sign: %+d %+d %+6d %+6d\n", 1977, -1977, 1977, -1977);
+  printf("Force sign or space: % d % d % 6d % 6d\n", 1977, -1977, 1977, -1977);
+  printf("Sign overrides space: % +d % +d % +6d % +6d\n", 1977, -1977, 1977, -1977);
   printf("Some different radixes: %d %x %o %#x %#o\n", 100, 100, 100, 100, 100);
   printf("floats: %4.2f %+.0e %E %08.2f\n", 3.1416, 3.1416, 3.1416, 3.1416);
   printf("negative floats: %4.2f %+.0e %E %08.2f\n", -3.1416, -3.1416, -3.1416, -3.1416);
+  printf("Force sign or space: % .2f % .2f % 6.2f % 6.2f\n", 3.1416, -3.1416, 3.1416, -3.1416);
   printf("Width trick: %*d\n", 5, 10);
   printf("%s %%\n", "A string");
   printf("Null string: %7s\n", NULL);


### PR DESCRIPTION
This fixes three bugs with the formatting code (used by printf et al) .. well, arguably one of them is a new feature (one called for by the spec).
1. If you zero-pad a negative integer (as with %010d), the zeros would appear before the negative sign (00000-1977) instead of after (-000001977). This was only a bug with integers, not with floats.
2. If you force the display of the sign on a negative integer (as with %+d), the sign would be printed twice (--1977 instead of just -1977). Again, this only seemed to be a problem on integers.
3. The "space" formatting flag (which is basically the same as + but prints a space instead of a positive sign) was not implemented.

I've added tests for all 3 new cases. I did note however that test_printf seems to have two reference output files, one for regular and one for precise 64-bit math. However there does not seem to be a way to run the test with precise 64-bit math. It looks like there was intended to be, but I don't see a way to trigger it.

As for running the existing tests, I get 7 errors (out of 2718 tests) running all core tests on the incoming branch. This is before my changes, not after. The tests with errors are default.test_bigswitch, asm1.test_cases, asm2.test_cases, asm2.test_fuzz, asm2g.test_cases, asm2g.test_fuzz, asm2x86.test_cases. With my changes, the errors are exactly the same. I did not cause any of the errors, nor am I sure what is causing them.

Let me know if you have any questions.. thanks!
