### PR TITLE
Webgl depth texture

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -221,14 +221,14 @@ var LibraryGL = {
           if (format == 0x1902 /* GL_DEPTH_COMPONENT */) {
             sizePerPixel = 2;
           } else {
-              throw 'Invalid format (' + format + ')';
+            throw 'Invalid format (' + format + ')';
           }
           break;
         case 0x1405 /* GL_UNSIGNED_INT */:
           if (format == 0x1902 /* GL_DEPTH_COMPONENT */) {
             sizePerPixel = 4;
           } else {
-              throw 'Invalid format (' + format + ')';
+            throw 'Invalid format (' + format + ')';
           }
           break;
         case 0x84FA /* UNSIGNED_INT_24_8_WEBGL */:


### PR DESCRIPTION
- Enable the WEBGL_depth_texture extension on context init, see http://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/

Note: Currently only Chrome implements this, Firefox doesn't support it. See https://bugzilla.mozilla.org/show_bug.cgi?id=783914 .
- Improve GL.getTexPixelData function so that it doesn't throw on WEBGL_depth_texture-related enums.
