### PR TITLE
Fix #1668: whiteSpace in _scanString should use only char codes as keys

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1660,12 +1660,6 @@ LibraryManager.library = {
       __scanString.whiteSpace[{{{ charCode('\v') }}}] = 1;
       __scanString.whiteSpace[{{{ charCode('\f') }}}] = 1;
       __scanString.whiteSpace[{{{ charCode('\r') }}}] = 1;
-      __scanString.whiteSpace[' '] = 1;
-      __scanString.whiteSpace['\t'] = 1;
-      __scanString.whiteSpace['\n'] = 1;
-      __scanString.whiteSpace['\v'] = 1;
-      __scanString.whiteSpace['\f'] = 1;
-      __scanString.whiteSpace['\r'] = 1;
     }
     // Supports %x, %4x, %d.%d, %lld, %s, %f, %lf.
     // TODO: Support all format specifiers.
@@ -1903,7 +1897,7 @@ LibraryManager.library = {
             break;
         }
         fields++;
-      } else if (format[formatIndex] in __scanString.whiteSpace) {
+      } else if (format[formatIndex].charCodeAt(0) in __scanString.whiteSpace) {
         next = get();
         while (next in __scanString.whiteSpace) {
           if (next <= 0) break mainLoop;  // End of input.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1788,7 +1788,7 @@ f6: nan
 
           int xx, yy, zz;
           char s[32];
-          int cc = sscanf("abc_10.b1_xyz_543_defg", "abc_%d.%2x_xyz_%3d_%3s", &xx, &yy, &zz, s);
+          int cc = sscanf("abc_10.b1_xyz9_543_defg", "abc_%d.%2x_xyz9_%3d_%3s", &xx, &yy, &zz, s);
           printf("%d:%d,%d,%d,%s\\n", cc, xx, yy, zz, s);
 
           printf("%d\\n", argc);


### PR DESCRIPTION
The char code for `\t` is `9` thus `9` was an index of whiteSpace. If you now check if a character is a key in whiteSpace `9` will be detected as white space, too. To fix this I changed all checks to only use char codes.
