### PR TITLE
Icase vfs

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -120,6 +120,11 @@ mergeInto(LibraryManager.library, {
     //
     hashName: function(parentid, name) {
       var hash = 0;
+
+#if CASE_INSENSITIVE_FS
+      name = name.toLowerCase();
+#endif
+
       for (var i = 0; i < name.length; i++) {
         hash = ((hash << 5) - hash + name.charCodeAt(i)) | 0;
       }
@@ -151,8 +156,15 @@ mergeInto(LibraryManager.library, {
         throw new FS.ErrnoError(err);
       }
       var hash = FS.hashName(parent.id, name);
+#if CASE_INSENSITIVE_FS
+      name = name.toLowerCase();
+#endif
       for (var node = FS.nameTable[hash]; node; node = node.name_next) {
-        if (node.parent.id === parent.id && node.name === name) {
+        var nodeName = node.name;
+#if CASE_INSENSITIVE_FS
+        nodeName = nodeName.toLowerCase();
+#endif
+        if (node.parent.id === parent.id && nodeName === name) {
           return node;
         }
       }

--- a/src/settings.js
+++ b/src/settings.js
@@ -266,6 +266,8 @@ var CORRECT_ROUNDINGS = 1; // C rounds to 0 (-5.5 to -5, +5.5 to 5), while JS ha
 var FS_LOG = 0; // Log all FS operations.  This is especially helpful when you're porting
                 // a new project and want to see a list of file system operations happening
                 // so that you can create a virtual file system with all of the required files.
+var CASE_INSENSITIVE_FS = 0; // If set to nonzero, the provided virtual filesystem if treated case-insensitive, like
+                             // Windows and OSX do. If set to 0, the VFS is case-sensitive, like on Linux.
 
 var USE_BSS = 1; // https://en.wikipedia.org/wiki/.bss
                  // When enabled, 0-initialized globals are sorted to the end of the globals list,


### PR DESCRIPTION
Add -s CASE_INSENSITIVE_FS=1 linker option to allow VFS to lookup files in case-insensitive mode.

This allows porting applications which have inconsistencies in the file cases.
