### PR TITLE
Optimize alignment rounding.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -588,7 +588,7 @@ function stackAlloc(size) {
   var ret = 0;
   ret = STACKTOP;
   STACKTOP = (STACKTOP + size)|0;
-''' + ('STACKTOP = ((STACKTOP + 3)>>2)<<2;' if settings['TARGET_X86'] else 'STACKTOP = ((STACKTOP + 7)>>3)<<3;') + '''
+''' + ('STACKTOP = (STACKTOP + 3)&-4;' if settings['TARGET_X86'] else 'STACKTOP = (STACKTOP + 7)&-8;') + '''
   return ret|0;
 }
 function stackSave() {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -644,7 +644,7 @@ Module['stringToUTF32'] = stringToUTF32;
 
 var PAGE_SIZE = 4096;
 function alignMemoryPage(x) {
-  return ((x+4095)>>12)<<12;
+  return (x+4095)&-4096;
 }
 
 var HEAP;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -112,8 +112,7 @@ var Runtime = {
     if (isNumber(target) && isNumber(quantum)) {
       return Math.ceil(target/quantum)*quantum;
     } else if (isNumber(quantum) && isPowerOfTwo(quantum)) {
-      var logg = log2(quantum);
-      return '((((' +target + ')+' + (quantum-1) + ')>>' + logg + ')<<' + logg + ')';
+      return '(((' +target + ')+' + (quantum-1) + ')&' + -quantum + ')';
     }
     return 'Math.ceil((' + target + ')/' + quantum + ')*' + quantum;
   },


### PR DESCRIPTION
Replace x>>2<<2 and x>>3<<3 with x&-4 and x&-8, respectively, since
an and is cheaper than two shifts.
