### PR TITLE
SDL_SetVideoMode(0,0, ...)

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -786,6 +786,14 @@ var LibrarySDL = {
     ['mousedown', 'mouseup', 'mousemove', 'DOMMouseScroll', 'mousewheel', 'mouseout'].forEach(function(event) {
       Module['canvas'].addEventListener(event, SDL.receiveEvent, true);
     });
+
+    // (0,0) means 'use fullscreen' in native; in Emscripten, use the current canvas size.
+    if (width == 0 && height == 0) {
+      var canvas = Module['canvas'];
+      width = canvas.width;
+      height = canvas.height;
+    }
+
     Browser.setCanvasSize(width, height, true);
     // Free the old surface first.
     if (SDL.screen) {

--- a/tests/sdl_canvas_size.c
+++ b/tests/sdl_canvas_size.c
@@ -1,0 +1,191 @@
+/*******************************************************************
+ *                                                                 *
+ *                        Using SDL With OpenGL                    *
+ *                                                                 *
+ *                    Tutorial by Kyle Foley (sdw)                 *
+ *                                                                 *
+ * http://gpwiki.org/index.php/SDL:Tutorials:Using_SDL_with_OpenGL *
+ *                                                                 *
+ *******************************************************************/
+
+/*
+THIS WORK, INCLUDING THE SOURCE CODE, DOCUMENTATION
+AND RELATED MEDIA AND DATA, IS PLACED INTO THE PUBLIC DOMAIN.
+
+THE ORIGINAL AUTHOR IS KYLE FOLEY.
+
+THIS SOFTWARE IS PROVIDED AS-IS WITHOUT WARRANTY
+OF ANY KIND, NOT EVEN THE IMPLIED WARRANTY OF
+MERCHANTABILITY. THE AUTHOR OF THIS SOFTWARE,
+ASSUMES _NO_ RESPONSIBILITY FOR ANY CONSEQUENCE
+RESULTING FROM THE USE, MODIFICATION, OR
+REDISTRIBUTION OF THIS SOFTWARE.
+*/
+
+#include "SDL/SDL.h"
+#include "SDL/SDL_image.h"
+#include "SDL/SDL_opengl.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#ifdef EMSCRIPTEN
+#include <emscripten.h>
+#endif
+
+int main(int argc, char *argv[])
+{
+    SDL_Surface *screen;
+
+    // Slightly different SDL initialization
+    if ( SDL_Init(SDL_INIT_VIDEO) != 0 ) {
+        printf("Unable to initialize SDL: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    SDL_GL_SetAttribute( SDL_GL_DOUBLEBUFFER, 1 ); // *new*
+
+#ifdef EMSCRIPTEN
+    // Test 1: Check that initializing video mode with size (0,0) will use the size from the <canvas> element.
+    screen = SDL_SetVideoMode( 0, 0, 16, SDL_OPENGL ); // *changed*
+
+    // Test 2: Check that getting current canvas size works.
+    int w, h, fs;
+    emscripten_get_canvas_size(&w, &h, &fs);
+    printf("w:%d,h:%d\n", w,h);
+    assert(w == 700);
+    assert(h == 200);
+    
+    // Test 3: Check that resizing the canvas works as well.
+    emscripten_set_canvas_size(640, 480);
+    // Set the OpenGL state after creating the context with SDL_SetVideoMode
+#else
+    screen = SDL_SetVideoMode( 640, 480, 16, SDL_OPENGL ); // *changed*
+#endif
+
+     if ( !screen ) {
+        printf("Unable to set video mode: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    glClearColor( 0, 0, 0, 0 );
+
+    glEnable( GL_TEXTURE_2D ); // Needed when we're using the fixed-function pipeline.
+
+    glViewport( 0, 0, 640, 480 );
+
+    glMatrixMode( GL_PROJECTION );
+    glPushMatrix(); // just for testing
+    glLoadIdentity();
+
+    glOrtho( 0, 640, 480, 0, -1, 1 );
+
+    glMatrixMode( GL_MODELVIEW );
+    glLoadIdentity();
+
+    // Load the OpenGL texture
+
+    GLuint texture; // Texture object handle
+    SDL_Surface *surface; // Gives us the information to make the texture
+
+    if ( (surface = IMG_Load("screenshot.png")) ) {
+
+        // Check that the image's width is a power of 2
+        if ( (surface->w & (surface->w - 1)) != 0 ) {
+            printf("warning: image.bmp's width is not a power of 2\n");
+        }
+
+        // Also check if the height is a power of 2
+        if ( (surface->h & (surface->h - 1)) != 0 ) {
+            printf("warning: image.bmp's height is not a power of 2\n");
+        }
+
+        // Have OpenGL generate a texture object handle for us
+        glGenTextures( 1, &texture );
+
+        // Bind the texture object
+        glBindTexture( GL_TEXTURE_2D, texture );
+
+        // Set the texture's stretching properties
+        glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
+        glTexParameteri( GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
+
+        //SDL_LockSurface(surface);
+
+        // Add some greyness
+        memset(surface->pixels, 0x66, surface->w*surface->h);
+
+        // Edit the texture object's image data using the information SDL_Surface gives us
+        glTexImage2D( GL_TEXTURE_2D, 0, GL_RGBA, surface->w, surface->h, 0,
+                      GL_RGBA, GL_UNSIGNED_BYTE, surface->pixels );
+
+        //SDL_UnlockSurface(surface);
+    }
+    else {
+        printf("SDL could not load image.bmp: %s\n", SDL_GetError());
+        SDL_Quit();
+        return 1;
+    }
+
+    // Free the SDL_Surface only if it was successfully created
+    if ( surface ) {
+        SDL_FreeSurface( surface );
+    }
+
+    // Clear the screen before drawing
+    glClear( GL_COLOR_BUFFER_BIT );
+
+    // Bind the texture to which subsequent calls refer to
+    glBindTexture( GL_TEXTURE_2D, texture );
+
+    glBegin( GL_QUADS );
+        glTexCoord2i( 0, 0 ); glVertex3f( 10, 10, 0 );
+        glTexCoord2i( 1, 0 ); glVertex3f( 300, 10, 0 );
+        glTexCoord2i( 1, 1 ); glVertex3f( 300, 128, 0 );
+        glTexCoord2i( 0, 1 ); glVertex3f( 10, 128, 0 );
+
+        glTexCoord2f( 0, 0.5 ); glVertex3f( 410, 10, 0 );
+        glTexCoord2f( 1, 0.5 ); glVertex3f( 600, 10, 0 );
+        glTexCoord2f( 1, 1   ); glVertex3f( 630, 200, 0 );
+        glTexCoord2f( 0.5, 1 ); glVertex3f( 310, 250, 0 );
+    glEnd();
+
+    glBegin( GL_TRIANGLE_STRIP );
+        glTexCoord2i( 0, 0 ); glVertex3f( 100, 300, 0 );
+        glTexCoord2i( 1, 0 ); glVertex3f( 300, 300, 0 );
+        glTexCoord2i( 1, 1 ); glVertex3f( 300, 400, 0 );
+        glTexCoord2i( 0, 1 ); glVertex3f( 500, 410, 0 );
+    glEnd();
+
+    glDisable(GL_TEXTURE_2D);
+
+    glColor3ub(90, 255, 255);
+    glBegin( GL_QUADS );
+        glVertex3f( 10, 410, 0 );
+        glVertex3f( 300, 410, 0 );
+        glVertex3f( 300, 480, 0 );
+        glVertex3f( 10, 470, 0 );
+    glEnd();
+
+    glBegin( GL_QUADS );
+        glColor3f(1.0, 0, 1.0);   glVertex3f( 410, 410, 0 );
+        glColor3f(0, 1.0, 0);     glVertex3f( 600, 410, 0 );
+        glColor3f(0, 0, 1.0);     glVertex3f( 600, 480, 0 );
+        glColor3f(1.0, 1.0, 1.0); glVertex3f( 410, 470, 0 );
+    glEnd();
+
+    SDL_GL_SwapBuffers();
+
+#if !EMSCRIPTEN
+    // Wait for 3 seconds to give us a chance to see the image
+    SDL_Delay(3000);
+#endif
+
+    // Now we can delete the OpenGL texture and close down SDL
+    glDeleteTextures( 1, &texture );
+
+    SDL_Quit();
+
+    return 0;
+}

--- a/tests/sdl_canvas_size.html
+++ b/tests/sdl_canvas_size.html
@@ -1,0 +1,93 @@
+<!doctype html>
+<html lang="en-us">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <title>Emscripten-Generated Code</title>
+    <style>
+      .emscripten { padding-right: 0; margin-left: auto; margin-right: auto; display: block; }
+      textarea.emscripten { font-family: monospace; width: 80%; }
+      div.emscripten { text-align: center; }
+      div.emscripten_border { border: 1px solid black; }
+      /* the canvas *must not* have any border or padding, or mouse coords will be wrong */
+      canvas.emscripten { border: 0px none; }
+    </style>
+  </head>
+  <body>
+    <hr/>
+    <div class="emscripten" id="status">Downloading...</div>
+    <div class="emscripten">
+      <progress value="0" max="100" id="progress" hidden=1></progress>  
+    </div>
+    <div class="emscripten_border">
+    <!-- Pass custom width/height to test that SDL_SetVideoMode(0,0, ...) will use these. -->
+      <canvas class="emscripten" id="canvas" width="700" height="200" oncontextmenu="event.preventDefault()"></canvas>
+    </div>
+    <hr/>
+    <div class="emscripten">
+      <input type="checkbox" id="resize">Resize canvas
+      <input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer
+      &nbsp;&nbsp;&nbsp;
+      <input type="button" value="Fullscreen" onclick="Module.requestFullScreen(document.getElementById('pointerLock').checked, 
+                                                                                document.getElementById('resize').checked)">
+    </div>
+    
+    <hr/>
+    <textarea class="emscripten" id="output" rows="8"></textarea>
+    <hr>
+    <script type='text/javascript'>
+      // connect to canvas
+      var Module = {
+        preRun: [],
+        postRun: [],
+        print: (function() {
+          var element = document.getElementById('output');
+          element.value = ''; // clear browser cache
+          return function(text) {
+            text = Array.prototype.slice.call(arguments).join(' ');
+            // These replacements are necessary if you render to raw HTML
+            //text = text.replace(/&/g, "&amp;");
+            //text = text.replace(/</g, "&lt;");
+            //text = text.replace(/>/g, "&gt;");
+            //text = text.replace('\n', '<br>', 'g');
+            element.value += text + "\n";
+            element.scrollTop = 99999; // focus on bottom
+          };
+        })(),
+        printErr: function(text) {
+          text = Array.prototype.slice.call(arguments).join(' ');
+          if (0) { // XXX disabled for safety typeof dump == 'function') {
+            dump(text + '\n'); // fast, straight to the real console
+          } else {
+            console.log(text);
+          }
+        },
+        canvas: document.getElementById('canvas'),
+        setStatus: function(text) {
+          if (Module.setStatus.interval) clearInterval(Module.setStatus.interval);
+          var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+          var statusElement = document.getElementById('status');
+          var progressElement = document.getElementById('progress');
+          if (m) {
+            text = m[1];
+            progressElement.value = parseInt(m[2])*100;
+            progressElement.max = parseInt(m[4])*100;
+            progressElement.hidden = false;
+          } else {
+            progressElement.value = null;
+            progressElement.max = null;
+            progressElement.hidden = true;
+          }
+          statusElement.innerHTML = text;
+        },
+        totalDependencies: 0,
+        monitorRunDependencies: function(left) {
+          this.totalDependencies = Math.max(this.totalDependencies, left);
+          Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+        }
+      };
+      Module.setStatus('Downloading...');
+    </script>
+    <script async type='text/javascript'>{{{ SCRIPT_CODE }}}</script>
+  </body>
+</html>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -942,6 +942,11 @@ keydown(100);keyup(100); // trigger the end
     Popen([PYTHON, EMCC, '-O2', '--closure', '1', '--minify', '0', os.path.join(self.get_dir(), 'sdl_audio_beep.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0', '-o', 'page.html']).communicate()
     self.run_browser('page.html', '', '/report_result?1')
 
+  def test_sdl_canvas_size(self):
+    self.btest('sdl_canvas_size.c', reference='screenshot-gray-purple.png', reference_slack=1,
+      args=['-O2', '--minify', '0', '--shell-file', path_from_root('tests', 'sdl_canvas_size.html'), '--preload-file', os.path.join(self.get_dir(), 'screenshot.png') + '@/', '-s', 'LEGACY_GL_EMULATION=1'],
+      message='You should see an image with gray at the top.')
+
   def test_sdl_gl_read(self):
     # SDL, OpenGL, readPixels
     open(os.path.join(self.get_dir(), 'sdl_gl_read.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'sdl_gl_read.c')).read()))


### PR DESCRIPTION
Implement SDL_SetVideoMode(0,0, ...) to create the canvas in whatever size the <canvas> was in, and not try to resize the canvas to 0x0 pixels. Derive a new test for that from sdl_ogl.c. Fixes #1059.
