### PR TITLE
Fix an issue with Boost compilation.

### DIFF
--- a/system/include/compat/ctype.h
+++ b/system/include/compat/ctype.h
@@ -14,4 +14,21 @@
 
 #include_next <ctype.h>
 
+/* We undef these until libcxx is fixed. Without this,
+   some things can fail to compile correctly, like
+   Boost. Issue #1716. */
+
+#undef isalpha
+#undef isblank
+#undef iscntrl
+#undef isdigit
+#undef isgraph
+#undef islower
+#undef isprint
+#undef ispunct
+#undef isspace
+#undef isupper
+#undef isxdigit
+#undef isctype
+
 #endif /* _COMPAT_CTYPE_H_ */

--- a/system/include/compat/wchar.h
+++ b/system/include/compat/wchar.h
@@ -1,0 +1,23 @@
+#ifndef  _COMPAT_WCHAR_H_
+#define  _COMPAT_WCHAR_H_
+
+#include_next <wchar.h>
+
+/* We undef these until libcxx is fixed. Without this,
+   some things can fail to compile correctly, like
+   Boost. Issue #1716. */
+
+#undef iswalpha
+#undef iswblank
+#undef iswcntrl
+#undef iswdigit
+#undef iswgraph
+#undef iswlower
+#undef iswprint
+#undef iswpunct
+#undef iswspace
+#undef iswupper
+#undef iswxdigit
+#undef iswctype
+
+#endif /* _COMPAT_WCHAR_H_ */

--- a/system/include/compat/wctype.h
+++ b/system/include/compat/wctype.h
@@ -1,0 +1,23 @@
+#ifndef  _COMPAT_WCTYPE_H_
+#define  _COMPAT_WCTYPE_H_
+
+#include_next <wctype.h>
+
+/* We undef these until libcxx is fixed. Without this,
+   some things can fail to compile correctly, like
+   Boost. Issue #1716. */
+
+#undef iswalpha
+#undef iswblank
+#undef iswcntrl
+#undef iswdigit
+#undef iswgraph
+#undef iswlower
+#undef iswprint
+#undef iswpunct
+#undef iswspace
+#undef iswupper
+#undef iswxdigit
+#undef iswctype
+
+#endif /* _COMPAT_WCTYPE_H_ */

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2949,6 +2949,23 @@ Exiting setjmp function, level: 0, prev_jmp: -1
       '''
       self.do_run(src, '3.14159')
 
+  def test_iswdigit(self):
+      if self.emcc_args is None: return self.skip('no libcxx inclusion without emcc')
+
+      src = '''
+        #include <stdio.h>
+        #include <cctype>
+        #include <cwctype>
+
+        int main() {
+          using namespace std;
+          printf("%d ", isdigit('0'));
+          printf("%d ", iswdigit(L'0'));
+          return 0;
+        }
+      '''
+      self.do_run(src, '1 1')
+
   def test_polymorph(self):
       if self.emcc_args is None: return self.skip('requires emcc')
       src = '''


### PR DESCRIPTION
The issue is that when these macros are defined, libcxx
creates inline functions and so we end up with 2 separate
defintions of these functions (one inline in std and one
that is extern "C").

We undef these until libcxx is fixed. Without this,
some things can fail to compile correctly, like
Boost. Fixes issue #1716.
