### PR TITLE
tools: parse pre-release node.js version numbers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -104,4 +104,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Daniel Aquino <mr.danielaquino@gmail.com>
 * Remi Papillie <remi.papillie@gmail.com>
 * Fraser Adams <fraser.adams@blueyonder.co.uk>
-
+* Ben Noordhuis <info@bnoordhuis.nl>

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -217,7 +217,11 @@ class sanity(RunnerCore):
 
     try:
       os.environ['EM_IGNORE_SANITY'] = '1'
-      for version, succeed in [('v0.7.9', False), ('v0.8.0', True), ('v0.8.1', True), ('cheez', False)]:
+      for version, succeed in [('v0.7.9', False),
+                               ('v0.8.0', True),
+                               ('v0.8.1', True),
+                               ('v0.10.21-pre', True),
+                               ('cheez', False)]:
         f = open(path_from_root('tests', 'fake', 'nodejs'), 'w')
         f.write('#!/bin/sh\n')
         f.write('''if [ $1 = "--version" ]; then

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -284,7 +284,7 @@ def check_node_version():
   try:
     node = listify(NODE_JS)
     actual = Popen(node + ['--version'], stdout=PIPE).communicate()[0].strip()
-    version = tuple(map(int, actual.replace('v', '').split('.')))
+    version = tuple(map(int, actual.replace('v', '').replace('-pre', '').split('.')))
     if version >= EXPECTED_NODE_VERSION:
       return True
     logging.warning('node version appears too old (seeing "%s", expected "%s")' % (actual, 'v' + ('.'.join(map(str, EXPECTED_NODE_VERSION)))))


### PR DESCRIPTION
`node` binaries built from upstream git have a "-pre" suffix attached
to the version number.  Fix the version parser to handle those.
