### PR TITLE
Fix SDL_SetColors && SDL_envets

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1231,11 +1231,11 @@ var LibrarySDL = {
       surfData.colors = new Uint8Array(256 * 3); //256 RGB colors
     } 
 
-    for (var i = firstColor; i < firstColor + nColors; i++) {
-      var index = i *3;
+    for (var i = 0; i < nColors; ++i) {
+      var index = (firstColor + i) * 3;
       surfData.colors[index] = {{{ makeGetValue('colors', 'i*4', 'i8', null, true) }}};
-      surfData.colors[index +1] = {{{ makeGetValue('colors', 'i*4 +1', 'i8', null, true) }}};
-      surfData.colors[index +2] = {{{ makeGetValue('colors', 'i*4 +2', 'i8', null, true) }}};
+      surfData.colors[index + 1] = {{{ makeGetValue('colors', 'i*4 + 1', 'i8', null, true) }}};
+      surfData.colors[index + 2] = {{{ makeGetValue('colors', 'i*4 + 2', 'i8', null, true) }}};
     }
 
     return 1;

--- a/system/include/SDL/SDL_events.h
+++ b/system/include/SDL/SDL_events.h
@@ -55,6 +55,7 @@ extern "C" {
  */
 typedef enum
 {
+    SDL_NOEVENT        = 0,
     SDL_FIRSTEVENT     = 0,     /**< Unused (do not remove) */
 
     /* Application events */

--- a/tests/sdl_canvas_palette.c
+++ b/tests/sdl_canvas_palette.c
@@ -42,7 +42,7 @@ int main() {
   //changing green color
   //to yellow
   pal[1].r = 255;
-  SDL_SetColors(screen, pal, 1, 1);
+  SDL_SetColors(screen, &pal[1], 1, 1);
 
   {
     SDL_Rect rect = { 300, 200, 300, 200 };


### PR DESCRIPTION
I found little mistake with implementation of  SDL_SetColors

``` c++
int SDL_SetColors(SDL_Surface *surface, SDL_Color *colors, int firstcolor, int ncolors);
```

firstColor - is offset for surface palette not for colors array. Look to sdl implementation:

``` c++
static void SetPalette_logical(SDL_Surface *screen, SDL_Color *colors,
                   int firstcolor, int ncolors)
{
    SDL_Palette *pal = screen->format->palette;
    SDL_Palette *vidpal;

    if ( colors != (pal->colors + firstcolor) ) {
        SDL_memcpy(pal->colors + firstcolor, colors,
               ncolors * sizeof(*colors));
    }

        //...
}
```

So i fixed it, also i fix the test. 
And i add missing SDL_NOEVENT in enum.

test: sdl_canvas_palette && sdl_canvas_palette_2 passed
