### PR TITLE
no_copy_vfs_to_heap

### DIFF
--- a/emcc
+++ b/emcc
@@ -777,6 +777,7 @@ try:
   save_bc = False
   memory_init_file = False
   use_preload_cache = False
+  no_heap_copy = False
   proxy_to_worker = False
 
   if use_cxx:
@@ -896,6 +897,9 @@ try:
       newargs[i+1] = ''
     elif newargs[i].startswith('--use-preload-cache'):
       use_preload_cache = True
+      newargs[i] = ''
+    elif newargs[i].startswith('--no-heap-copy'):
+      no_heap_copy = True
       newargs[i] = ''
     elif newargs[i] == '--ignore-dynamic-linking':
       ignore_dynamic_linking = True
@@ -1667,6 +1671,8 @@ try:
       file_args += ['--compress', Compression.encoder, Compression.decoder, Compression.js_name]
     if use_preload_cache:
       file_args.append('--use-preload-cache')
+    if no_heap_copy:
+      file_args.append('--no-heap-copy')
     file_code = execute([shared.PYTHON, shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE)[0]
     pre_js = file_code + pre_js
 

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -225,9 +225,9 @@ mergeInto(LibraryManager.library, {
 #if ASSERTIONS
           assert(buffer.length);
 #endif
-          if (canOwn && buffer.buffer === HEAP8.buffer && offset === 0) {
-            node.contents = buffer; // this is a subarray of the heap, and we can own it
-            node.contentMode = MEMFS.CONTENT_OWNING;
+          if (canOwn && offset === 0) {
+            node.contents = buffer; // this could be a subarray of Emscripten HEAP, or allocated from some other source.
+            node.contentMode = (buffer.buffer === HEAP8.buffer) ? MEMFS.CONTENT_OWNING : MEMFS.CONTENT_FIXED;
           } else {
             node.contents = new Uint8Array(buffer.subarray(offset, offset+length));
             node.contentMode = MEMFS.CONTENT_FIXED;

--- a/tests/mmap_file.c
+++ b/tests/mmap_file.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <sys/mman.h>
+#include <emscripten.h>
+#include <string.h>
+#include <assert.h>
+
+int main() {
+    printf("*\n");
+    FILE *f = fopen("data.dat", "r");
+    char *m;
+    m = (char*)mmap(NULL, 9000, PROT_READ, MAP_PRIVATE, fileno(f), 0);
+    for (int i = 0; i < 20; i++) putchar(m[i]);
+    assert(!strncmp(m, "data from the file .", 20));
+    munmap(m, 9000);
+    printf("\n");
+    m = (char*)mmap(NULL, 9000, PROT_READ, MAP_PRIVATE, fileno(f), 5);
+    for (int i = 0; i < 20; i++) putchar(m[i]);
+    assert(!strncmp(m, "from the file ......", 20));
+    munmap(m, 9000);
+    printf("\n*\n");
+
+#ifdef REPORT_RESULT
+    int result = 1;
+    REPORT_RESULT();
+#endif
+    return 0;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8594,30 +8594,13 @@ void*:16
 
   def test_mmap_file(self):
     if self.emcc_args is None: return self.skip('requires emcc')
-    self.emcc_args += ['--embed-file', 'data.dat']
+    for extra_args in [[], ['--no-heap-copy']]:
+      self.emcc_args += ['--embed-file', 'data.dat'] + extra_args
 
-    open(self.in_dir('data.dat'), 'w').write('data from the file ' + ('.' * 9000))
+      open(self.in_dir('data.dat'), 'w').write('data from the file ' + ('.' * 9000))
 
-    src = r'''
-      #include <stdio.h>
-      #include <sys/mman.h>
-
-      int main() {
-        printf("*\n");
-        FILE *f = fopen("data.dat", "r");
-        char *m;
-        m = (char*)mmap(NULL, 9000, PROT_READ, MAP_PRIVATE, fileno(f), 0);
-        for (int i = 0; i < 20; i++) putchar(m[i]);
-        munmap(m, 9000);
-        printf("\n");
-        m = (char*)mmap(NULL, 9000, PROT_READ, MAP_PRIVATE, fileno(f), 5);
-        for (int i = 0; i < 20; i++) putchar(m[i]);
-        munmap(m, 9000);
-        printf("\n*\n");
-        return 0;
-      }
-    '''
-    self.do_run(src, '*\ndata from the file .\nfrom the file ......\n*\n')
+      src = open(path_from_root('tests', 'mmap_file.c')).read()
+      self.do_run(src, '*\ndata from the file .\nfrom the file ......\n*\n')
 
   def test_cubescript(self):
     if self.emcc_args is None: return self.skip('requires emcc')


### PR DESCRIPTION
Add command line parameter --no_copy_vfs_to_heap that optimizes for small memory footprint and fread() performance over the default behavior that copied VFS to HEAP, that is designed for mmap() performance.
