### PR TITLE
Fix test_asm_pgo on Windows.

### DIFF
--- a/tools/response_file.py
+++ b/tools/response_file.py
@@ -1,4 +1,5 @@
 import tempfile, os, sys, shlex
+import shared
 
 # Routes the given cmdline param list in args into a new response file and returns the filename to it.
 # The returned filename has a suffix '.rsp'.
@@ -9,6 +10,11 @@ def create_response_file(args, directory):
   args = map(lambda p: p.replace('\\', '\\\\').replace('"', '\\"'), args)
   response_fd.write('"' + '" "'.join(args) + '"')
   response_fd.close()
+  
+  # Register the created .rsp file to be automatically cleaned up once this process finishes, so that
+  # caller does not have to remember to do it.
+  shared.configuration.get_temp_files().note(response_filename)
+  
   return response_filename
 
 # Reads a response file, and returns the list of cmdline params found in the file.


### PR DESCRIPTION
Fix test_asm_pgo on Windows by using response files. The test failed by exceeding Windows command line length limitations, giving an error "WindowsError: [Error 87] The parameter is incorrect". Also extend the logging given by EM_BUILD_VERBOSE=3 to print out the compiler invokations.
