### PR TITLE
Fix test_lua on Windows.

### DIFF
--- a/tests/lua/src/Makefile
+++ b/tests/lua/src/Makefile
@@ -59,8 +59,9 @@ o:	$(ALL_O)
 
 a:	$(ALL_A)
 
+# XXX EMSCRIPTEN: add AR_ARGS
 $(LUA_A): $(BASE_O)
-	$(AR) $(AR_ARGS) $@ $(BASE_O) # XXX EMSCRIPTEN: add AR_ARGS
+	$(AR) $(AR_ARGS) $@ $(BASE_O)
 	$(RANLIB) $@
 
 $(LUA_T): $(LUA_O) $(LUA_A)


### PR DESCRIPTION
Fix test_lua on Windows when built using mingw32-make. That tool got confused by a '#' comment at the end of a command line, so move the comment to its own separate line.
