### PR TITLE
nanosleep - don't write to rmtp if it's NULL

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -6131,8 +6131,10 @@ LibraryManager.library = {
     // int nanosleep(const struct timespec  *rqtp, struct timespec *rmtp);
     var seconds = {{{ makeGetValue('rqtp', C_STRUCTS.timespec.tv_sec, 'i32') }}};
     var nanoseconds = {{{ makeGetValue('rqtp', C_STRUCTS.timespec.tv_nsec, 'i32') }}};
-    {{{ makeSetValue('rmtp', C_STRUCTS.timespec.tv_sec, '0', 'i32') }}}
-    {{{ makeSetValue('rmtp', C_STRUCTS.timespec.tv_nsec, '0', 'i32') }}}
+    if (rmtp !== 0) {
+      {{{ makeSetValue('rmtp', C_STRUCTS.timespec.tv_sec, '0', 'i32') }}}
+      {{{ makeSetValue('rmtp', C_STRUCTS.timespec.tv_nsec, '0', 'i32') }}}
+    }
     return _usleep((seconds * 1e6) + (nanoseconds / 1000));
   },
   // TODO: Implement these for real.


### PR DESCRIPTION
rmtp can be NULL, so don't try to write to it if it is.
