### PR TITLE
Fix test_lua on Windows buildbot.

### DIFF
--- a/tests/lua/Makefile
+++ b/tests/lua/Makefile
@@ -51,8 +51,9 @@ R= $V.1
 # Targets start here.
 all:	$(PLAT)
 
+# XXX Emscripten Added quotes to $(MAKE) to properly call make when the path contains spaces
 $(PLATS) clean:
-	cd src && $(MAKE) $@
+	cd src && "$(MAKE)" $@
 
 test:	dummy
 	src/lua -v


### PR DESCRIPTION
Fix Makefile in test_lua in the case when make is in a path that contains spaces (e.g. c:\program files\emscripten...\mingw32-make).
