### PR TITLE
GLES2 max program identifier lengths.

### DIFF
--- a/tests/gles2_uniform_arrays.cpp
+++ b/tests/gles2_uniform_arrays.cpp
@@ -35,6 +35,15 @@ void RunTest(int testVariant)
     glBindAttribLocation(program, 0, "pos");
     glLinkProgram(program);
 
+    // Also test that GL_ACTIVE_ATTRIBUTE_MAX_LENGTH and GL_ACTIVE_UNIFORM_MAX_LENGTH work. See https://github.com/kripken/emscripten/issues/1796.
+    GLint param;
+    glGetProgramiv(program, GL_ACTIVE_ATTRIBUTE_MAX_LENGTH, &param);
+    printf("active attrib max length: %d\n", param);
+    assert(param == 4); // "pos"+null terminator
+    glGetProgramiv(program, GL_ACTIVE_UNIFORM_MAX_LENGTH, &param);
+    printf("active uniform max length: %d\n", param);
+    assert(param == 10); // "colors[0]"+null terminator
+
     int color_loc = glGetUniformLocation(program, "color");
     assert(color_loc != -1);
 


### PR DESCRIPTION
Implement support for glGetProgramiv(GL_ACTIVE_UNIFORM_MAX_LENGTH) and glGetProgramiv(GL_ACTIVE_ATTRIBUTE_MAX_LENGTH). Test this as part of gles2_uniform_arrays.cpp. Closes #1796.
