### PR TITLE
GLES2 glGetXXs()

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -558,6 +558,7 @@ var LibraryGL = {
       case 0x8DFA: // GL_SHADER_COMPILER
         {{{ makeSetValue('p', '0', '1', 'i32') }}};
         return;
+      case 0x8DF8: // GL_SHADER_BINARY_FORMATS
       case 0x8DF9: // GL_NUM_SHADER_BINARY_FORMATS
         {{{ makeSetValue('p', '0', '0', 'i32') }}};
         return;
@@ -621,6 +622,27 @@ var LibraryGL = {
 
   glGetFloatv__sig: 'vii',
   glGetFloatv: function(name_, p) {
+    switch(name_) {
+      case 0x8DFA: // GL_SHADER_COMPILER
+        {{{ makeSetValue('p', '0', '1', 'float') }}};
+        return;
+      case 0x8DF8: // GL_SHADER_BINARY_FORMATS
+        GL.recordError(0x0500/*GL_INVALID_ENUM*/);
+#if GL_ASSERTIONS
+        Module.printErr('GL_INVALID_ENUM in glGetFloatv(GL_SHADER_BINARY_FORMATS): Invalid parameter type!');
+#endif
+        return;
+      case 0x8DF9: // GL_NUM_SHADER_BINARY_FORMATS
+        {{{ makeSetValue('p', '0', '0', 'float') }}};
+        return;
+      case 0x86A2: // GL_NUM_COMPRESSED_TEXTURE_FORMATS
+        // WebGL doesn't have GL_NUM_COMPRESSED_TEXTURE_FORMATS (it's obsolete since GL_COMPRESSED_TEXTURE_FORMATS returns a JS array that can be queried for length),
+        // so implement it ourselves to allow C++ GLES2 code get the length.
+        var formats = Module.ctx.getParameter(0x86A3 /*GL_COMPRESSED_TEXTURE_FORMATS*/);
+        {{{ makeSetValue('p', '0', 'formats.length', 'float') }}};
+        return;
+    }
+    
     var result = Module.ctx.getParameter(name_);
     switch (typeof(result)) {
       case "number":
@@ -674,6 +696,27 @@ var LibraryGL = {
 
   glGetBooleanv__sig: 'vii',
   glGetBooleanv: function(name_, p) {
+    switch(name_) {
+      case 0x8DFA: // GL_SHADER_COMPILER
+        {{{ makeSetValue('p', '0', '1', 'i8') }}};
+        return;
+      case 0x8DF8: // GL_SHADER_BINARY_FORMATS
+        GL.recordError(0x0500/*GL_INVALID_ENUM*/);
+#if GL_ASSERTIONS
+        Module.printErr('GL_INVALID_ENUM in glGetBooleanv(GL_SHADER_BINARY_FORMATS): Invalid parameter type!');
+#endif
+        return;
+      case 0x8DF9: // GL_NUM_SHADER_BINARY_FORMATS
+        {{{ makeSetValue('p', '0', '0', 'i8') }}};
+        return;
+      case 0x86A2: // GL_NUM_COMPRESSED_TEXTURE_FORMATS
+        // WebGL doesn't have GL_NUM_COMPRESSED_TEXTURE_FORMATS (it's obsolete since GL_COMPRESSED_TEXTURE_FORMATS returns a JS array that can be queried for length),
+        // so implement it ourselves to allow C++ GLES2 code get the length.
+        var hasCompressedFormats = Module.ctx.getParameter(0x86A3 /*GL_COMPRESSED_TEXTURE_FORMATS*/).length > 0 ? 1 : 0;
+        {{{ makeSetValue('p', '0', 'hasCompressedFormats', 'i8') }}};
+        return;
+    }
+
     var result = Module.ctx.getParameter(name_);
     switch (typeof(result)) {
       case "number":

--- a/tests/gles2_conformance.cpp
+++ b/tests/gles2_conformance.cpp
@@ -1,0 +1,76 @@
+#include "SDL/SDL.h"
+
+#include <GLES2/gl2.h>
+
+#include <stdio.h>
+#include <string.h>
+
+int result = 1; // Success
+#define assert(x) do { if (!(x)) {result = 0; printf("Assertion failure: %s in %s:%d!\n", #x, __FILE__, __LINE__); } } while(0)
+
+int main(int argc, char *argv[])
+{
+    SDL_Surface *screen;
+
+    // Slightly different SDL initialization
+    if ( SDL_Init(SDL_INIT_VIDEO) != 0 ) {
+        printf("Unable to initialize SDL: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    screen = SDL_SetVideoMode( 640, 480, 16, SDL_OPENGL ); // *changed*
+    if ( !screen ) {
+        printf("Unable to set video mode: %s\n", SDL_GetError());
+        return 1;
+    }
+
+    // Test that code containing functions related to GLES2 binary shader API will successfully compile ad run
+    // (will be nonfunctional no-ops since WebGL doesn't have binary shaders)
+    GLuint vs = glCreateShader(GL_VERTEX_SHADER);
+    glShaderBinary(1, &vs, 0, 0, 0);
+    assert(glGetError() != GL_NO_ERROR);
+
+    GLboolean b = GL_TRUE;
+    GLint i = -1;
+    GLfloat f = -1.f;
+    glGetBooleanv(GL_NUM_SHADER_BINARY_FORMATS, &b);
+    assert(glGetError() == GL_NO_ERROR);
+    assert(b == GL_FALSE);
+    glGetIntegerv(GL_NUM_SHADER_BINARY_FORMATS, &i);
+    assert(glGetError() == GL_NO_ERROR);
+    assert(i == 0);
+    glGetFloatv(GL_NUM_SHADER_BINARY_FORMATS, &f);
+    assert(glGetError() == GL_NO_ERROR);
+    assert(f == 0.f);
+
+    // Currently testing that glGetIntegerv(GL_SHADER_BINARY_FORMATS) should be a no-op.
+    // The spec is somewhat vague here, equally as good could be to return GL_INVALID_ENUM here.
+    i = 123;
+    glGetIntegerv(GL_SHADER_BINARY_FORMATS, &i);
+    assert(glGetError() == GL_NO_ERROR);
+    assert(i == 0);
+
+    // Spec does not say what to report on the following, but since GL_SHADER_BINARY_FORMATS is supposed
+    // to return a a pointer to an array representing a list, the pointer can't be converted to bool or float,
+    // so report a GL_INVALID_ENUM.
+    glGetBooleanv(GL_SHADER_BINARY_FORMATS, &b);
+    assert(glGetError() == GL_INVALID_ENUM);
+    
+    glGetFloatv(GL_SHADER_BINARY_FORMATS, &f);
+    assert(glGetError() == GL_INVALID_ENUM);
+
+    // Test that we can query for shader compiler support.
+    glGetIntegerv(GL_SHADER_COMPILER, &i);
+    assert(glGetError() == GL_NO_ERROR);
+    assert(i != 0);
+    glGetBooleanv(GL_SHADER_COMPILER, &b);
+    assert(glGetError() == GL_NO_ERROR);
+    assert(b == GL_TRUE);
+    glGetFloatv(GL_SHADER_COMPILER, &f);
+    assert(glGetError() == GL_NO_ERROR);
+    assert(f == 1.f);
+    
+#ifdef REPORT_RESULT
+    REPORT_RESULT();
+#endif
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1449,6 +1449,9 @@ keydown(100);keyup(100); // trigger the end
   # def test_gles2_uniform_arrays(self):
   #  self.btest('gles2_uniform_arrays.cpp', args=['-s', 'GL_ASSERTIONS=1'], expected=['1'])
 
+  def test_gles2_conformance(self):
+    self.btest('gles2_conformance.cpp', args=['-s', 'GL_ASSERTIONS=1'], expected=['1'])
+
   def test_matrix_identity(self):
     self.btest('gl_matrix_identity.c', expected=['-1882984448', '460451840'], args=['-s', 'LEGACY_GL_EMULATION=1'])
 


### PR DESCRIPTION
Implement more complete glGetXXv() for GLES2 binary shader format and shader compiler enums that WebGL will not implement for us. Fixes #1803.
