### PR TITLE
Fix test other.test_warn_undefined on Windows.

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -311,12 +311,16 @@ function compile(raw) {
 
 B = new Benchmarker();
 
-if (ll_file) {
-  if (ll_file.indexOf(String.fromCharCode(10)) == -1) {
-    compile(read(ll_file));
-  } else {
-    compile(ll_file); // we are given raw .ll
+try {
+  if (ll_file) {
+    if (ll_file.indexOf(String.fromCharCode(10)) == -1) {
+      compile(read(ll_file));
+    } else {
+      compile(ll_file); // we are given raw .ll
+    }
   }
+} catch(err) {
+  printErr('aborting from js compiler due to exception: ' + err);
 }
 
 //var M = keys(tokenCacheMisses).map(function(m) { return [m, misses[m]] }).sort(function(a, b) { return a[1] - b[1] });


### PR DESCRIPTION
Never throw uncaught exceptions out from compiler.js, but just report the exception message to stderr. Fixes other.test_warn_undefined on Windows, which would fail if Python spawned node.js in the case where it printed stderr and terminated to an uncaught exception, leaving unflushed data to stderr, and not all unresolved symbol errors were printed to console. Node.js stderr does not have a flush() mechanism, so must gracefully terminate the execution instead.

Fixes #1804 as well.

Not yet tested for merge, currently running try builds on the bots to see nothing breaks.
