### PR TITLE
Don't throw an exception on SDL_ThreadID()

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2675,7 +2675,7 @@ var LibrarySDL = {
 
   SDL_WaitThread: function() { throw 'SDL_WaitThread' },
   SDL_GetThreadID: function() { throw 'SDL_GetThreadID' },
-  SDL_ThreadID: function() { throw 'SDL_ThreadID' },
+  SDL_ThreadID: function() { return 0; },
   SDL_AllocRW: function() { throw 'SDL_AllocRW: TODO' },
   SDL_CondBroadcast: function() { throw 'SDL_CondBroadcast: TODO' },
   SDL_CondWaitTimeout: function() { throw 'SDL_CondWaitTimeout: TODO' },


### PR DESCRIPTION
This function is called by MESS as part of the SDL window initialization and the result is stored in a variable, but not really used for anything if multithreading is disabled (which it is in the Emscripten case). Currently we are stubbing it out in a --post-js file but might as well have it upstream in case other projects do the same thing. There's still a throw in SDL_CreateThread() if you actually try to use the threading functionality.
