### PR TITLE
Timestamp issue for object files with absolute paths in static library archive

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1029,7 +1029,7 @@ class Building:
               dirname = os.path.dirname(content)
               if dirname and not os.path.exists(dirname):
                 os.makedirs(dirname)
-            Popen([LLVM_AR, 'x', f], stdout=PIPE).communicate() # if absolute paths, files will appear there. otherwise, in this directory
+            Popen([LLVM_AR, 'xo', f], stdout=PIPE).communicate() # if absolute paths, files will appear there. otherwise, in this directory
             contents = map(lambda content: os.path.join(temp_dir, content), contents)
             contents = filter(os.path.exists, map(os.path.abspath, contents))
             added_contents = set()


### PR DESCRIPTION
In my project, for various reasons we use absolute path names when using ar to create library archives. 

When emscripten links against a static library, it extracts the object files from the archive. If the object files have absolute paths, this results in the overwriting of the existing object files, and their timestamp is updated to the extraction time.

The ar command has a -o flag, which can be added to set the timestamp to the file's original modification time. This pull request enables this flag.
