### PR TITLE
fix a bug in the accept call in library.js whereby if accept was called ...

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -8237,7 +8237,7 @@ LibraryManager.library = {
   },
 
   accept__deps: ['$FS', '$SOCKFS', '$DNS', '$ERRNO_CODES', '__setErrNo', '_write_sockaddr'],
-  accept: function(fd, addrp, addrlen) {
+  accept: function(fd, addr, addrlen) {
     var sock = SOCKFS.getSocket(fd);
     if (!sock) {
       ___setErrNo(ERRNO_CODES.EBADF);
@@ -8245,7 +8245,7 @@ LibraryManager.library = {
     }
     try {
       var newsock = sock.sock_ops.accept(sock);
-      if (addrp) {
+      if (addr) {
         var res = __write_sockaddr(addr, newsock.family, DNS.lookup_name(newsock.daddr), newsock.dport);
         assert(!res.errno);
       }

--- a/tests/sockets/test_sockets_echo_server.c
+++ b/tests/sockets/test_sockets_echo_server.c
@@ -72,7 +72,16 @@ void main_loop(void *arg) {
 #if !USE_UDP
   // for TCP sockets, we may need to accept a connection
   if (FD_ISSET(server.fd, &fdr)) {
+#if TEST_ACCEPT_ADDR
+    // Do an accept with non-NULL addr and addlen parameters. This tests a fix to a bug in the implementation of
+    // accept which had a parameter "addrp" but used "addr" internally if addrp was set - giving a ReferenceError.
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    socklen_t addrlen = sizeof(addr);
+    client.fd = accept(server.fd, (struct sockaddr *) &addr, &addrlen);
+#else
     client.fd = accept(server.fd, NULL, NULL);
+#endif
     assert(client.fd != -1);
   }
 #endif

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -235,7 +235,9 @@ class sockets(BrowserCore):
     harnesses = [
       (WebsockifyServerHarness(os.path.join('sockets', 'test_sockets_echo_server.c'), [sockets_include], 49160), 0),
       (CompiledServerHarness(os.path.join('sockets', 'test_sockets_echo_server.c'), [sockets_include, '-DTEST_DGRAM=0'], 49161), 0),
-      (CompiledServerHarness(os.path.join('sockets', 'test_sockets_echo_server.c'), [sockets_include, '-DTEST_DGRAM=1'], 49162), 1)
+      (CompiledServerHarness(os.path.join('sockets', 'test_sockets_echo_server.c'), [sockets_include, '-DTEST_DGRAM=1'], 49162), 1),
+      # The following forces non-NULL addr and addlen parameters for the accept call
+      (CompiledServerHarness(os.path.join('sockets', 'test_sockets_echo_server.c'), [sockets_include, '-DTEST_DGRAM=0', '-DTEST_ACCEPT_ADDR=1'], 49163), 0)
     ]
 
     for harness, datagram in harnesses:


### PR DESCRIPTION
fix a bug in the accept call in library.js whereby if accept was called with non-NULL addr and addrlen parameters a ReferenceError occurs because accept had a parameter of addrp but later used addr. Modified tests_sockets_echo_server.c to use non-NULL addr if TEST_ACCEPT_ADDR is defined and added test case to test_sockets.py
