### PR TITLE
[SDL] SDL_JoystickEventState should default to SDL_ENABLE

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -715,7 +715,7 @@ var LibrarySDL = {
 
     // Joystick helper methods and state
 
-    joystickEventState: 0,
+    joystickEventState: 1, // SDL_ENABLE
     lastJoystickState: {}, // Map from SDL_Joystick* to their last known state. Required to determine if a change has occurred.
     // Maps Joystick names to pointers. Allows us to avoid reallocating memory for
     // joystick names each time this function is called.

--- a/tests/sdl_joystick.c
+++ b/tests/sdl_joystick.c
@@ -72,6 +72,10 @@ void main_2(void* arg) {
   assert(SDL_JoystickNumAxes(pad1) == 4);
   assert(SDL_JoystickNumButtons(pad1) == 16);
 
+  // By default, SDL will automatically process events. Test this behavior, and then disable it.
+  assert(SDL_JoystickEventState(SDL_QUERY) == SDL_ENABLE);
+  SDL_JoystickEventState(SDL_DISABLE);
+  assert(SDL_JoystickEventState(SDL_QUERY) == SDL_DISABLE);
   // Button events.
   emscripten_run_script("window.simulateGamepadButtonDown(0, 1)");
   // We didn't tell SDL to automatically update this joystick's state.


### PR DESCRIPTION
In my initial implementation, I incorrectly assumed that SDL_JoystickEventState defaulted to SDL_DISABLE.

The end result: Programs relying on the default setting, such as MESS, do not receive joystick input events. :frowning: 

I have fixed this issue, and added code to the test to test this behavior.
