### PR TITLE
srand() and simple rand() supporting seed

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3451,8 +3451,8 @@ LibraryManager.library = {
     {{{ makeSetValue('___rand_seed', 0, 'seed', 'i32') }}}
   }, 
   rand_r__deps: ['__rand_seed'],
-  rand_r: function(seed) { 
-    var val = {{{ makeGetValue('___rand_seed', 0, 'i32') }}};
+  rand_r: function(seedp) { 
+    var val = {{{ makeGetValue('seedp', 0, 'i32') }}};
     // calculate val * 31010991 + 0x676e6177
     // i32 multiplication will be rounded by javascript
     var valh = val >> 16;
@@ -3464,7 +3464,7 @@ LibraryManager.library = {
 
     val = (((valh * cl + vall * ch) << 16) + vall * cl + 0x676e6177) & 0x7fffffff;
 
-    {{{ makeSetValue('___rand_seed', 0, 'val', 'i32') }}}
+    {{{ makeSetValue('seedp', 0, 'val', 'i32') }}}
     return val;
   },
   rand__deps: ['rand_r'],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6583,6 +6583,11 @@ int main()
     srand(0xdeadbeef);
     for(int i = 0; i < 10; ++i)
         printf("%d\n", rand());
+
+    unsigned int seed = 0xdeadbeef;
+    for(int i = 0; i < 10; ++i)
+        printf("%d\n", rand_r(&seed));
+
     return 0;
 }
 '''
@@ -6595,7 +6600,18 @@ int main()
 983994184
 1982845871
 1210574360
-1479617503'''
+1479617503
+2073540312
+730128159
+1365227432
+1337224527
+792390264
+1952655743
+983994184
+1982845871
+1210574360
+1479617503
+'''
     self.do_run(src, expected)
 
   def test_strtod(self):


### PR DESCRIPTION
This is a simple LCG which used to be popular in implementations of c libraries. It might not be as good as Math.random() in terms of randomness, but it supports specifying seed, which is more important sometimes.

I have also considered porting other implementations (e.g. `random()`), but usually they involve lots of 32-bit integer multiplications, or even 64-bit. 

I wonder if the libraries written in JS can be split into submodules, such that each of them may be written in JS, or compile from C/C++ &mdash; kind of linking &mdash; there seems to be such mechanisms for many large projects (e.g. poppler) in `tests/`, but not for standard libraries. At least I feel that it might be better to compile a C version of `random()` instead of re-implement it in JavaScript, especially as it's a independent small library.

Are there any side effects in this way?
