### PR TITLE
naive implementation of SDL_DisplayFormat

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1216,7 +1216,7 @@ var LibrarySDL = {
     return ret;
   },
 
-  SDL_DisplayFormat: 'SDL_DisplayformatAlpha',
+  SDL_DisplayFormat: 'SDL_DisplayFormatAlpha',
 
   SDL_FreeSurface: function(surf) {
     if (surf) SDL.freeSurface(surf);


### PR DESCRIPTION
`SDL_DisplayFormat` is similar with `SDL_DisplayFormatAlpha`, except for that the latter one processes the alpha channel.

But actually seems that the current version `DisplayFormatAlpha` in emscripten does not process the alpha channel, or is it processes internally? I'm not quite sure.

Please review. Thanks!
