### PR TITLE
fix for structures generated by manually calling generateStructInfo

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -247,7 +247,7 @@ var Runtime = {
       prev = curr;
       return curr;
     });
-    if (type.name_[0] === '[') {
+    if (type.name_ && type.name_[0] === '[') {
       // arrays have 2 elements, so we get the proper difference. then we scale here. that way we avoid
       // allocating a potentially huge array for [999999 x i8] etc.
       type.flatSize = parseInt(type.name_.substr(1))*type.flatSize/2;


### PR DESCRIPTION
Structures generated by manually calling Runtime.generateStructInfo don't have the name_ property set.

Not sure if manually calling this is deprecated now with all of the automated type info generation now, but I hit this when trying to recompile quakejs tonight.
