### PR TITLE
Add GLFW 3.0 emulation

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1,7 +1,9 @@
 /*******************************************************************************
- * EMSCRIPTEN GLFW 2.7.7 emulation.
+ * EMSCRIPTEN GLFW 2.x-3.x emulation.
  * It tries to emulate the behavior described in
- * http://www.glfw.org/GLFWReference277.pdf
+ * http://www.glfw.org/docs/latest/
+ *
+ * This also implements parts of GLFW 2.x on top of GLFW 3.x.
  *
  * What it does:
  * - Creates a GL context.
@@ -11,135 +13,292 @@
  * What it does not but should probably do:
  * - Transmit events when glfwPollEvents, glfwWaitEvents or glfwSwapBuffers is
  *    called. Events callbacks are called as soon as event are received.
- * - Thread emulation.
  * - Joystick support.
- * - Image/Texture I/O support (that is deleted in GLFW 3).
- * - Video modes detection.
+ * - Input modes.
+ * - Gamma ramps.
+ * - Video modes.
+ * - Monitors.
+ * - Clipboard (not possible from javascript?).
+ * - Multiple windows.
+ * - Error codes && messages through callback.
+ * - Thread emulation. (removed in GLFW3).
+ * - Image/Texture I/O support (removed in GLFW 3).
  *
  * Authors:
+ * - Jari Vetoniemi <mailroxas@gmail.com>
  * - Éloi Rivard <eloi.rivard@gmail.com>
  * - Thomas Borsos <thomasborsos@gmail.com>
  *
  ******************************************************************************/
 
 var LibraryGLFW = {
+  $GLFW__deps: ['emscripten_get_now'],
   $GLFW: {
 
-    keyFunc: null,
-    charFunc: null,
-    mouseButtonFunc: null,
-    mousePosFunc: null,
-    mouseWheelFunc: null,
-    resizeFunc: null,
-    closeFunc: null,
-    refreshFunc: null,
-    params: null,
-    initTime: null,
-    wheelPos: 0,
-    buttons: 0,
-    keys: 0,
-    initWindowWidth: 640,
-    initWindowHeight: 480,
-    windowX: 0,
-    windowY: 0,
-    windowWidth: 0,
-    windowHeight: 0,
+    Window: function(id, width, height, title, monitor, share) {
+      this.id = id;
+      this.x = 0;
+      this.y = 0;
+      this.storedX = 0; // Used to store X before fullscreen
+      this.storedY = 0; // Used to store Y before fullscreen
+      this.width = width;
+      this.height = height;
+      this.storedWidth = width; // Used to store width before fullscreen
+      this.storedHeight = height; // Used to store height before fullscreen
+      this.title = title;
+      this.monitor = monitor;
+      this.share = share;
+      this.attributes = GLFW.hints;
+      this.inputModes = {
+        0x00033001:0x00034001, // GLFW_CURSOR (GLFW_CURSOR_NORMAL)
+        0x00033002:0, // GLFW_STICKY_KEYS
+        0x00033003:0, // GLFW_STICKY_MOUSE_BUTTONS
+      };
+      this.buttons = 0;
+      this.keys = new Array();
+      this.shouldClose = 0;
+      this.title = null;
+      this.windowPosFunc = null; // GLFWwindowposfun
+      this.windowSizeFunc = null; // GLFWwindowsizefun
+      this.windowCloseFunc = null; // GLFWwindowclosefun
+      this.windowRefreshFunc = null; // GLFWwindowrefreshfun
+      this.windowFocusFunc = null; // GLFWwindowfocusfun
+      this.windowIconifyFunc = null; // GLFWwindowiconifyfun
+      this.framebufferSizeFunc = null; // GLFWframebuffersizefun
+      this.mouseButtonFunc = null; // GLFWmousebuttonfun
+      this.cursorPosFunc = null; // GLFWcursorposfun
+      this.cursorEnterFunc = null; // GLFWcursorenterfun
+      this.scrollFunc = null; // GLFWscrollfun
+      this.keyFunc = null; // GLFWkeyfun
+      this.charFunc = null; // GLFWcharfun
+      this.userptr = null;
+    },
+
+    WindowFromId: function(id) {
+      if (id <= 0 || !GLFW.windows) return null;
+      return GLFW.windows[id - 1];
+    },
+
+    errorFunc: null, // GLFWerrorfun
+    monitorFunc: null, // GLFWmonitorfun
+    active: null, // active window
+    windows: null,
+    monitors: null,
+    monitorString: null,
+    versionString: null,
+    initialTime: null,
+    extensions: null,
+    hints: null,
+    defaultHints: {
+      0x00020001:0, // GLFW_FOCUSED
+      0x00020002:0, // GLFW_ICONIFIED
+      0x00020003:1, // GLFW_RESIZABLE
+      0x00020004:1, // GLFW_VISIBLE
+      0x00020005:1, // GLFW_DECORATED
+
+      0x00021001:8, // GLFW_RED_BITS
+      0x00021002:8, // GLFW_GREEN_BITS
+      0x00021003:8, // GLFW_BLUE_BITS
+      0x00021004:8, // GLFW_ALPHA_BITS
+      0x00021005:24, // GLFW_DEPTH_BITS
+      0x00021006:8, // GLFW_STENCIL_BITS
+      0x00021007:0, // GLFW_ACCUM_RED_BITS
+      0x00021008:0, // GLFW_ACCUM_GREEN_BITS
+      0x00021009:0, // GLFW_ACCUM_BLUE_BITS
+      0x0002100A:0, // GLFW_ACCUM_ALPHA_BITS
+      0x0002100B:0, // GLFW_AUX_BUFFERS
+      0x0002100C:0, // GLFW_STEREO
+      0x0002100D:0, // GLFW_SAMPLES
+      0x0002100E:0, // GLFW_SRGB_CAPABLE
+      0x0002100F:0, // GLFW_REFRESH_RATE
+
+      0x00022001:0x00030001, // GLFW_CLIENT_API (GLFW_OPENGL_API)
+      0x00022002:1, // GLFW_CONTEXT_VERSION_MAJOR
+      0x00022003:0, // GLFW_CONTEXT_VERSION_MINOR
+      0x00022004:0, // GLFW_CONTEXT_REVISION
+      0x00022005:0, // GLFW_CONTEXT_ROBUSTNESS
+      0x00022006:0, // GLFW_OPENGL_FORWARD_COMPAT
+      0x00022007:0, // GLFW_OPENGL_DEBUG_CONTEXT
+      0x00022008:0, // GLFW_OPENGL_PROFILE
+    },
 
 /*******************************************************************************
  * DOM EVENT CALLBACKS
  ******************************************************************************/
 
+    /* https://developer.mozilla.org/en/Document_Object_Model_%28DOM%29/KeyboardEvent and GLFW/glfw3.h */
     DOMToGLFWKeyCode: function(keycode) {
       switch (keycode) {
-        case 0x08: return 295 ; // DOM_VK_BACKSPACE -> GLFW_KEY_BACKSPACE
-        case 0x09: return 293 ; // DOM_VK_TAB -> GLFW_KEY_TAB
-        case 0x0D: return 294 ; // DOM_VK_ENTER -> GLFW_KEY_ENTER
-        case 0x1B: return 257 ; // DOM_VK_ESCAPE -> GLFW_KEY_ESC
-        case 0x6A: return 313 ; // DOM_VK_MULTIPLY -> GLFW_KEY_KP_MULTIPLY
-        case 0x6B: return 315 ; // DOM_VK_ADD -> GLFW_KEY_KP_ADD
-        case 0x6D: return 314 ; // DOM_VK_SUBTRACT -> GLFW_KEY_KP_SUBTRACT
-        case 0x6E: return 316 ; // DOM_VK_DECIMAL -> GLFW_KEY_KP_DECIMAL
-        case 0x6F: return 312 ; // DOM_VK_DIVIDE -> GLFW_KEY_KP_DIVIDE
-        case 0x70: return 258 ; // DOM_VK_F1 -> GLFW_KEY_F1
-        case 0x71: return 259 ; // DOM_VK_F2 -> GLFW_KEY_F2
-        case 0x72: return 260 ; // DOM_VK_F3 -> GLFW_KEY_F3
-        case 0x73: return 261 ; // DOM_VK_F4 -> GLFW_KEY_F4
-        case 0x74: return 262 ; // DOM_VK_F5 -> GLFW_KEY_F5
-        case 0x75: return 263 ; // DOM_VK_F6 -> GLFW_KEY_F6
-        case 0x76: return 264 ; // DOM_VK_F7 -> GLFW_KEY_F7
-        case 0x77: return 265 ; // DOM_VK_F8 -> GLFW_KEY_F8
-        case 0x78: return 266 ; // DOM_VK_F9 -> GLFW_KEY_F9
-        case 0x79: return 267 ; // DOM_VK_F10 -> GLFW_KEY_F10
-        case 0x7a: return 268 ; // DOM_VK_F11 -> GLFW_KEY_F11
-        case 0x7b: return 269 ; // DOM_VK_F12 -> GLFW_KEY_F12
-        case 0x25: return 285 ; // DOM_VK_LEFT -> GLFW_KEY_LEFT
-        case 0x26: return 283 ; // DOM_VK_UP -> GLFW_KEY_UP
-        case 0x27: return 286 ; // DOM_VK_RIGHT -> GLFW_KEY_RIGHT
-        case 0x28: return 284 ; // DOM_VK_DOWN -> GLFW_KEY_DOWN
-        case 0x21: return 298 ; // DOM_VK_PAGE_UP -> GLFW_KEY_PAGEUP
-        case 0x22: return 299 ; // DOM_VK_PAGE_DOWN -> GLFW_KEY_PAGEDOWN
-        case 0x24: return 300 ; // DOM_VK_HOME -> GLFW_KEY_HOME
-        case 0x23: return 301 ; // DOM_VK_END -> GLFW_KEY_END
-        case 0x2d: return 296 ; // DOM_VK_INSERT -> GLFW_KEY_INSERT
-        case 16  : return 287 ; // DOM_VK_SHIFT -> GLFW_KEY_LSHIFT
-        case 0x05: return 287 ; // DOM_VK_LEFT_SHIFT -> GLFW_KEY_LSHIFT
-        case 0x06: return 288 ; // DOM_VK_RIGHT_SHIFT -> GLFW_KEY_RSHIFT
-        case 17  : return 289 ; // DOM_VK_CONTROL -> GLFW_KEY_LCTRL
-        case 0x03: return 289 ; // DOM_VK_LEFT_CONTROL -> GLFW_KEY_LCTRL
-        case 0x04: return 290 ; // DOM_VK_RIGHT_CONTROL -> GLFW_KEY_RCTRL
-        case 18  : return 291 ; // DOM_VK_ALT -> GLFW_KEY_LALT
-        case 0x02: return 291 ; // DOM_VK_LEFT_ALT -> GLFW_KEY_LALT
-        case 0x01: return 292 ; // DOM_VK_RIGHT_ALT -> GLFW_KEY_RALT
-        case 96  : return 302 ; // GLFW_KEY_KP_0
-        case 97  : return 303 ; // GLFW_KEY_KP_1
-        case 98  : return 304 ; // GLFW_KEY_KP_2
-        case 99  : return 305 ; // GLFW_KEY_KP_3
-        case 100 : return 306 ; // GLFW_KEY_KP_4
-        case 101 : return 307 ; // GLFW_KEY_KP_5
-        case 102 : return 308 ; // GLFW_KEY_KP_6
-        case 103 : return 309 ; // GLFW_KEY_KP_7
-        case 104 : return 310 ; // GLFW_KEY_KP_8
-        case 105 : return 311 ; // GLFW_KEY_KP_9
-        default  : return keycode;
+        case 0x20:return 32; // DOM_VK_SPACE -> GLFW_KEY_SPACE
+        case 0xDE:return 39; // DOM_VK_QUOTE -> GLFW_KEY_APOSTROPHE
+        case 0xBC:return 44; // DOM_VK_COMMA -> GLFW_KEY_COMMA
+        case 0xAD:return 45; // DOM_VK_HYPHEN_MINUS -> GLFW_KEY_MINUS
+        case 0xBE:return 46; // DOM_VK_PERIOD -> GLFW_KEY_PERIOD
+        case 0xBF:return 47; // DOM_VK_SLASH -> GLFW_KEY_SLASH
+        case 0x30:return 48; // DOM_VK_0 -> GLFW_KEY_0
+        case 0x31:return 49; // DOM_VK_1 -> GLFW_KEY_1
+        case 0x32:return 50; // DOM_VK_2 -> GLFW_KEY_2
+        case 0x33:return 51; // DOM_VK_3 -> GLFW_KEY_3
+        case 0x34:return 52; // DOM_VK_4 -> GLFW_KEY_4
+        case 0x35:return 53; // DOM_VK_5 -> GLFW_KEY_5
+        case 0x36:return 54; // DOM_VK_6 -> GLFW_KEY_6
+        case 0x37:return 55; // DOM_VK_7 -> GLFW_KEY_7
+        case 0x38:return 56; // DOM_VK_8 -> GLFW_KEY_8
+        case 0x39:return 57; // DOM_VK_9 -> GLFW_KEY_9
+        case 0x3B:return 59; // DOM_VK_SEMICOLON -> GLFW_KEY_SEMICOLON
+        case 0x61:return 61; // DOM_VK_EQUALS -> GLFW_KEY_EQUAL
+        case 0x41:return 65; // DOM_VK_A -> GLFW_KEY_A
+        case 0x42:return 66; // DOM_VK_B -> GLFW_KEY_B
+        case 0x43:return 67; // DOM_VK_C -> GLFW_KEY_C
+        case 0x44:return 68; // DOM_VK_D -> GLFW_KEY_D
+        case 0x45:return 69; // DOM_VK_E -> GLFW_KEY_E
+        case 0x46:return 70; // DOM_VK_F -> GLFW_KEY_F
+        case 0x47:return 71; // DOM_VK_G -> GLFW_KEY_G
+        case 0x48:return 72; // DOM_VK_H -> GLFW_KEY_H
+        case 0x49:return 73; // DOM_VK_I -> GLFW_KEY_I
+        case 0x4A:return 74; // DOM_VK_J -> GLFW_KEY_J
+        case 0x4B:return 75; // DOM_VK_K -> GLFW_KEY_K
+        case 0x4C:return 76; // DOM_VK_L -> GLFW_KEY_L
+        case 0x4D:return 77; // DOM_VK_M -> GLFW_KEY_M
+        case 0x4E:return 78; // DOM_VK_N -> GLFW_KEY_N
+        case 0x4F:return 79; // DOM_VK_O -> GLFW_KEY_O
+        case 0x50:return 80; // DOM_VK_P -> GLFW_KEY_P
+        case 0x51:return 81; // DOM_VK_Q -> GLFW_KEY_Q
+        case 0x52:return 82; // DOM_VK_R -> GLFW_KEY_R
+        case 0x53:return 83; // DOM_VK_S -> GLFW_KEY_S
+        case 0x54:return 84; // DOM_VK_T -> GLFW_KEY_T
+        case 0x55:return 85; // DOM_VK_U -> GLFW_KEY_U
+        case 0x56:return 86; // DOM_VK_V -> GLFW_KEY_V
+        case 0x57:return 87; // DOM_VK_W -> GLFW_KEY_W
+        case 0x58:return 88; // DOM_VK_X -> GLFW_KEY_X
+        case 0x59:return 89; // DOM_VK_Y -> GLFW_KEY_Y
+        case 0x5a:return 90; // DOM_VK_Z -> GLFW_KEY_Z
+        case 0xDB:return 91; // DOM_VK_OPEN_BRACKET -> GLFW_KEY_LEFT_BRACKET
+        case 0xDC:return 92; // DOM_VK_BACKSLASH -> GLFW_KEY_BACKSLASH
+        case 0xDD:return 93; // DOM_VK_CLOSE_BRACKET -> GLFW_KEY_RIGHT_BRACKET
+        case 0xC0:return 94; // DOM_VK_BACK_QUOTE -> GLFW_KEY_GRAVE_ACCENT
+        case 0x1B:return 256; // DOM_VK_ESCAPE -> GLFW_KEY_ESCAPE
+        case 0x0D:return 257; // DOM_VK_RETURN -> GLFW_KEY_ENTER
+        case 0x09:return 258; // DOM_VK_TAB -> GLFW_KEY_TAB
+        case 0x08:return 259; // DOM_VK_BACK -> GLFW_KEY_BACKSPACE
+        case 0x2D:return 260; // DOM_VK_INSERT -> GLFW_KEY_INSERT
+        case 0x2E:return 261; // DOM_VK_DELETE -> GLFW_KEY_DELETE
+        case 0x27:return 262; // DOM_VK_RIGHT -> GLFW_KEY_RIGHT
+        case 0x25:return 263; // DOM_VK_LEFT -> GLFW_KEY_LEFT
+        case 0x28:return 264; // DOM_VK_DOWN -> GLFW_KEY_DOWN
+        case 0x26:return 265; // DOM_VK_UP -> GLFW_KEY_UP
+        case 0x21:return 266; // DOM_VK_PAGE_UP -> GLFW_KEY_PAGE_UP
+        case 0x22:return 267; // DOM_VK_PAGE_DOWN -> GLFW_KEY_PAGE_DOWN
+        case 0x24:return 268; // DOM_VK_HOME -> GLFW_KEY_HOME
+        case 0x23:return 269; // DOM_VK_END -> GLFW_KEY_END
+        case 0x14:return 280; // DOM_VK_CAPS_LOCK -> GLFW_KEY_CAPS_LOCK
+        case 0x91:return 281; // DOM_VK_SCROLL_LOCK -> GLFW_KEY_SCROLL_LOCK
+        case 0x90:return 282; // DOM_VK_NUM_LOCK -> GLFW_KEY_NUM_LOCK
+        case 0x2C:return 283; // DOM_VK_SNAPSHOT -> GLFW_KEY_PRINT_SCREEN
+        case 0x13:return 284; // DOM_VK_PAUSE -> GLFW_KEY_PAUSE
+        case 0x70:return 290; // DOM_VK_F1 -> GLFW_KEY_F1
+        case 0x71:return 291; // DOM_VK_F2 -> GLFW_KEY_F2
+        case 0x72:return 292; // DOM_VK_F3 -> GLFW_KEY_F3
+        case 0x73:return 293; // DOM_VK_F4 -> GLFW_KEY_F4
+        case 0x74:return 294; // DOM_VK_F5 -> GLFW_KEY_F5
+        case 0x75:return 295; // DOM_VK_F6 -> GLFW_KEY_F6
+        case 0x76:return 296; // DOM_VK_F7 -> GLFW_KEY_F7
+        case 0x77:return 297; // DOM_VK_F8 -> GLFW_KEY_F8
+        case 0x78:return 298; // DOM_VK_F9 -> GLFW_KEY_F9
+        case 0x79:return 299; // DOM_VK_F10 -> GLFW_KEY_F10
+        case 0x7A:return 300; // DOM_VK_F11 -> GLFW_KEY_F11
+        case 0x7B:return 301; // DOM_VK_F12 -> GLFW_KEY_F12
+        case 0x7C:return 302; // DOM_VK_F13 -> GLFW_KEY_F13
+        case 0x7D:return 303; // DOM_VK_F14 -> GLFW_KEY_F14
+        case 0x7E:return 304; // DOM_VK_F15 -> GLFW_KEY_F15
+        case 0x7F:return 305; // DOM_VK_F16 -> GLFW_KEY_F16
+        case 0x80:return 306; // DOM_VK_F17 -> GLFW_KEY_F17
+        case 0x81:return 307; // DOM_VK_F18 -> GLFW_KEY_F18
+        case 0x82:return 308; // DOM_VK_F19 -> GLFW_KEY_F19
+        case 0x83:return 309; // DOM_VK_F20 -> GLFW_KEY_F20
+        case 0x84:return 310; // DOM_VK_F21 -> GLFW_KEY_F21
+        case 0x85:return 311; // DOM_VK_F22 -> GLFW_KEY_F22
+        case 0x86:return 312; // DOM_VK_F23 -> GLFW_KEY_F23
+        case 0x87:return 313; // DOM_VK_F24 -> GLFW_KEY_F24
+        case 0x88:return 314; // 0x88 (not used?) -> GLFW_KEY_F25
+        case 0x60:return 320; // DOM_VK_NUMPAD0 -> GLFW_KEY_KP_0
+        case 0x61:return 321; // DOM_VK_NUMPAD1 -> GLFW_KEY_KP_1
+        case 0x62:return 322; // DOM_VK_NUMPAD2 -> GLFW_KEY_KP_2
+        case 0x63:return 323; // DOM_VK_NUMPAD3 -> GLFW_KEY_KP_3
+        case 0x64:return 324; // DOM_VK_NUMPAD4 -> GLFW_KEY_KP_4
+        case 0x65:return 325; // DOM_VK_NUMPAD5 -> GLFW_KEY_KP_5
+        case 0x66:return 326; // DOM_VK_NUMPAD6 -> GLFW_KEY_KP_6
+        case 0x67:return 327; // DOM_VK_NUMPAD7 -> GLFW_KEY_KP_7
+        case 0x68:return 328; // DOM_VK_NUMPAD8 -> GLFW_KEY_KP_8
+        case 0x69:return 329; // DOM_VK_NUMPAD9 -> GLFW_KEY_KP_9
+        case 0x6E:return 330; // DOM_VK_DECIMAL -> GLFW_KEY_KP_DECIMAL
+        case 0x6F:return 331; // DOM_VK_DIVIDE -> GLFW_KEY_KP_DIVIDE
+        case 0x6A:return 332; // DOM_VK_MULTIPLY -> GLFW_KEY_KP_MULTIPLY
+        case 0x6D:return 333; // DOM_VK_SUBTRACT -> GLFW_KEY_KP_SUBTRACT
+        case 0x6B:return 334; // DOM_VK_ADD -> GLFW_KEY_KP_ADD
+        // case 0x0D:return 335; // DOM_VK_RETURN -> GLFW_KEY_KP_ENTER (DOM_KEY_LOCATION_RIGHT)
+        // case 0x61:return 336; // DOM_VK_EQUALS -> GLFW_KEY_KP_EQUAL (DOM_KEY_LOCATION_RIGHT)
+        case 0x10:return 340; // DOM_VK_SHIFT -> GLFW_KEY_LEFT_SHIFT
+        case 0x11:return 341; // DOM_VK_CONTROL -> GLFW_KEY_LEFT_CONTROL
+        case 0x12:return 342; // DOM_VK_ALT -> GLFW_KEY_LEFT_ALT
+        case 0x5B:return 343; // DOM_VK_WIN -> GLFW_KEY_LEFT_SUPER
+        // case 0x10:return 344; // DOM_VK_SHIFT -> GLFW_KEY_RIGHT_SHIFT (DOM_KEY_LOCATION_RIGHT)
+        // case 0x11:return 345; // DOM_VK_CONTROL -> GLFW_KEY_RIGHT_CONTROL (DOM_KEY_LOCATION_RIGHT)
+        // case 0x12:return 346; // DOM_VK_ALT -> GLFW_KEY_RIGHT_ALT (DOM_KEY_LOCATION_RIGHT)
+        // case 0x5B:return 347; // DOM_VK_WIN -> GLFW_KEY_RIGHT_SUPER (DOM_KEY_LOCATION_RIGHT)
+        case 0x5D:return 348; // DOM_VK_CONTEXT_MENU -> GLFW_KEY_MENU
+
+        // XXX: GLFW_KEY_WORLD_1, GLFW_KEY_WORLD_2 what are these?
+        default:return -1; // GLFW_KEY_UNKNOWN
       };
     },
 
-    // UCS-2 to UTF16 (ISO 10646)
-    getUnicodeChar: function(value) {
-      var output = '';
-      if (value > 0xFFFF) {
-        value -= 0x10000;
-        output += String.fromCharCode(value >>> 10 & 0x3FF | 0xD800);
-        value = 0xDC00 | value & 0x3FF;
-      }
-      output += String.fromCharCode(value);
-      return output;
+    getModBits: function(win) {
+      var mod = 0;
+      if (win.keys[0x10]) mod |= 0x0001; // GLFW_MOD_SHIFT
+      if (win.keys[0x11]) mod |= 0x0002; // GLFW_MOD_CONTROL
+      if (win.keys[0x12]) mod |= 0x0004; // GLFW_MOD_ALT
+      if (win.keys[0x5B]) mod |= 0x0008; // GLFW_MOD_SUPER
+      return mod;
     },
 
     onKeyPress: function(event) {
-      // charCode is only available whith onKeyPress event
-      var char = GLFW.getUnicodeChar(event.charCode);
+      if (!GLFW.active || !GLFW.active.charFunc) return;
 
-      if (event.charCode) {
-        var char = GLFW.getUnicodeChar(event.charCode);
-        if (char !== null && GLFW.charFunc) {
-          Runtime.dynCall('vii', GLFW.charFunc, [event.charCode, 1]);
-        }
-      }
+      // correct unicode charCode is only available with onKeyPress event
+      var charCode = event.charCode;
+      if (charCode == 0 || (charCode >= 0x00 && charCode <= 0x1F)) return;
+
+#if USE_GLFW == 2
+      Runtime.dynCall('vii', GLFW.active.charFunc, [charCode, 1]);
+#endif
+
+#if USE_GLFW == 3
+      Runtime.dynCall('vii', GLFW.active.charFunc, [GLFW.active.id, charCode]);
+#endif
     },
 
     onKeyChanged: function(event, status) {
+      if (!GLFW.active) return;
+
       var key = GLFW.DOMToGLFWKeyCode(event.keyCode);
-      if (key) {
-        GLFW.keys[key] = status;
-        if (GLFW.keyFunc) {
-          Runtime.dynCall('vii', GLFW.keyFunc, [key, status]);
-        }
-      }
+      if (key == -1) return;
+
+      GLFW.active.keys[key] = status;
+      if (!GLFW.active.keyFunc) return;
+
+#if USE_GLFW == 2
+      Runtime.dynCall('vii', GLFW.active.keyFunc, [key, status]);
+#endif
+
+#if USE_GLFW == 3
+      Runtime.dynCall('viiiii', GLFW.active.keyFunc, [GLFW.active.id, key, event.keyCode, status, GLFW.getModBits(GLFW.active)]);
+#endif
     },
 
     onKeydown: function(event) {
-      GLFW.onKeyChanged(event, 1);// GLFW_PRESS
+      GLFW.onKeyChanged(event, 1); // GLFW_PRESS
+
       // This logic comes directly from the sdl implementation. We cannot
       // call preventDefault on all keydown events otherwise onKeyPress will
       // not get called
@@ -149,44 +308,37 @@ var LibraryGLFW = {
     },
 
     onKeyup: function(event) {
-      GLFW.onKeyChanged(event, 0);// GLFW_RELEASE
+      GLFW.onKeyChanged(event, 0); // GLFW_RELEASE
     },
 
     onMousemove: function(event) {
-      /* Send motion event only if the motion changed, prevents
-       * spamming our app with uncessary callback call. It does happen in
-       * Chrome on Windows.
-       */
-      var lastX = Browser.mouseX;
-      var lastY = Browser.mouseY;
-      Browser.calculateMouseEvent(event);
-      var newX = Browser.mouseX;
-      var newY = Browser.mouseY;
+      if (!GLFW.active) return;
 
-      if (event.target == Module["canvas"] && GLFW.mousePosFunc) {
-        event.preventDefault();
-        Runtime.dynCall('vii', GLFW.mousePosFunc, [lastX, lastY]);
-      }
+      Browser.calculateMouseEvent(event);
+
+      if (event.target != Module["canvas"] || !GLFW.active.cursorPosFunc) return;
+
+#if USE_GLFW == 2
+      Runtime.dynCall('vii', GLFW.active.cursorPosFunc, [Browser.mouseX, Browser.mouseY]);
+#endif
+
+#if USE_GLFW == 3
+      Runtime.dynCall('vidd', GLFW.active.cursorPosFunc, [GLFW.active.id, Browser.mouseX, Browser.mouseY]);
+#endif
     },
 
     onMouseButtonChanged: function(event, status) {
-      if (GLFW.mouseButtonFunc == null) {
-        return;
-      }
+      if (!GLFW.active || !GLFW.active.mouseButtonFunc) return;
 
       Browser.calculateMouseEvent(event);
 
-      if (event.target != Module["canvas"]) {
-        return;
-      }
+      if (event.target != Module["canvas"]) return;
 
-      if (status == 1) {// GLFW_PRESS
+      if (status == 1) { // GLFW_PRESS
         try {
           event.target.setCapture();
         } catch (e) {}
       }
-
-      event.preventDefault();
 
       // DOM and glfw have different button codes
       var eventButton = event['button'];
@@ -197,17 +349,26 @@ var LibraryGLFW = {
           eventButton = 1;
         }
       }
-      Runtime.dynCall('vii', GLFW.mouseButtonFunc, [eventButton, status]);
+
+#if USE_GLFW == 2
+      Runtime.dynCall('vii', GLFW.active.mouseButtonFunc, [eventButton, status]);
+#endif
+
+#if USE_GLFW == 3
+      Runtime.dynCall('viiii', GLFW.active.mouseButtonFunc, [GLFW.active.id, eventButton, status, GLFW.getModBits(GLFW.active)]);
+#endif
     },
 
     onMouseButtonDown: function(event) {
-      GLFW.buttons |= (1 << event['button']);
-      GLFW.onMouseButtonChanged(event, 1);// GLFW_PRESS
+      if (!GLFW.active) return;
+      GLFW.active.buttons |= (1 << event['button']);
+      GLFW.onMouseButtonChanged(event, 1); // GLFW_PRESS
     },
 
     onMouseButtonUp: function(event) {
-      GLFW.buttons &= ~(1 << event['button']);
-      GLFW.onMouseButtonChanged(event, 0);// GLFW_RELEASE
+      if (!GLFW.active) return;
+      GLFW.active.buttons &= ~(1 << event['button']);
+      GLFW.onMouseButtonChanged(event, 0); // GLFW_RELEASE
     },
 
     onMouseWheel: function(event) {
@@ -216,33 +377,59 @@ var LibraryGLFW = {
       delta = (delta == 0) ? 0 : (delta > 0 ? Math.max(delta, 1) : Math.min(delta, -1)); // Quantize to integer so that minimum scroll is at least +/- 1.
       GLFW.wheelPos += delta;
 
-      if (GLFW.mouseWheelFunc && event.target == Module["canvas"]) {
-        Runtime.dynCall('vi', GLFW.mouseWheelFunc, [GLFW.wheelPos]);
-        event.preventDefault();
+      if (!GLFW.active || !GLFW.active.scrollFunc || event.target != Module['canvas']) return;
+
+#if USE_GLFW == 2
+      Runtime.dynCall('vi', GLFW.mouseWheelFunc, [GLFW.wheelPos]);
+#endif
+
+#if USE_GLFW == 3
+      var sx = 0;
+      var sy = 0;
+      if (event.type == 'mousewheel') {
+        sx = event.wheelDeltaX;
+        sy = event.wheelDeltaY;
+      } else {
+        sx = event.deltaX;
+        sy = event.deltaY;
       }
+
+      Runtime.dynCall('viii', GLFW.active.scrollFunc, [GLFW.active.id, sx, sy]);
+#endif
+
+      event.preventDefault();
     },
 
-    // TODO add fullscreen API ala:
-    // http://johndyer.name/native-fullscreen-javascript-api-plus-jquery-plugin/
     onFullScreenEventChange: function(event) {
-      var width;
-      var height;
+      if (!GLFW.active) return;
+
       if (document["fullScreen"] || document["mozFullScreen"] || document["webkitIsFullScreen"]) {
-        width = screen["width"];
-        height = screen["height"];
+        GLFW.active.storedX = GLFW.active.x;
+        GLFW.active.storedY = GLFW.active.y;
+        GLFW.active.x = GLFW.active.y = 0;
+        GLFW.active.storedWidth = GLFW.active.width;
+        GLFW.active.storedHeight = GLFW.active.height;
+        GLFW.active.width = screen.width;
+        GLFW.active.height = screen.height;
       } else {
-        width = GLFW.windowWidth;
-        height = GLFW.windowHeight;
-        // TODO set position
         document.removeEventListener('fullscreenchange', GLFW.onFullScreenEventChange, true);
         document.removeEventListener('mozfullscreenchange', GLFW.onFullScreenEventChange, true);
         document.removeEventListener('webkitfullscreenchange', GLFW.onFullScreenEventChange, true);
+        GLFW.active.width = GLFW.active.storedWidth;
+        GLFW.active.height = GLFW.active.storedHeight;
       }
-      Browser.setCanvasSize(width, height);
 
-      if (GLFW.resizeFunc) {
-        Runtime.dynCall('vii', GLFW.resizeFunc, [width, height]);
-      }
+      Browser.setCanvasSize(GLFW.active.width, GLFW.active.height);
+
+      if (!GLFW.active.windowResizeFunc) return;
+
+#if USE_GLFW == 2
+      Runtime.dynCall('vii', GLFW.active.windowResizeFunc, [width, height]);
+#endif
+
+#if USE_GLFW == 3
+      Runtime.dynCall('viii', GLFW.active.windowResizeFunc, [GLFW.active.id, width, height]);
+#endif
     },
 
     requestFullScreen: function() {
@@ -261,6 +448,252 @@ var LibraryGLFW = {
                 document['webkitCancelFullScreen'] ||
           (function() {});
       CFS.apply(document, []);
+    },
+
+    getTime: function() {
+      return _emscripten_get_now() / 1000;
+    },
+
+    /* GLFW2 wrapping */
+
+    setWindowTitle: function(winid, title) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+
+      win.title = Pointer_stringify(title);
+      if (GLFW.active.id == win.id) {
+        document.title = win.title;
+      }
+    },
+
+    setKeyCallback: function(winid, cbfun) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.keyFunc = cbfun;
+    },
+
+    setCharCallback: function(winid, cbfun) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.charFunc = cbfun;
+    },
+
+    setMouseButtonCallback: function(winid, cbfun) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.mouseButtonFunc = cbfun;
+    },
+
+    setCursorPosCallback: function(winid, cbfun) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.mousePosFunc = cbfun;
+    },
+
+    setScrollCallback: function(winid, cbfun) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.mouseWheelFunc = cbfun;
+    },
+
+    setWindowSizeCallback: function(winid, cbfun) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.windowSizeFunc = cbfun;
+    },
+
+    setWindowCloseCallback: function(winid, cbfun) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.windowCloseFunc = cbfun;
+    },
+
+    setWindowRefreshCallback: function(winid, cbfun) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.windowRefreshFunc = cbfun;
+    },
+
+    getKey: function(winid, key) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return 0;
+      return win.keys[key];
+    },
+
+    getMouseButton: function(winid, button) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return 0;
+      return (win.buttons & (1 << button)) > 0;
+    },
+
+    getCursorPos: function(winid, x, y) {
+      setValue(x, Browser.mouseX, 'i32');
+      setValue(y, Browser.mouseY, 'i32');
+    },
+
+    setCursorPos: function(winid, x, y) {
+    },
+
+    getWindowPos: function(winid, x, y) {
+      var wx = 0;
+      var wy = 0;
+
+      var win = GLFW.WindowFromId(winid);
+      if (win) {
+        wx = win.x;
+        wy = win.y;
+      }
+
+      setValue(x, wx, 'i32');
+      setValue(y, wy, 'i32');
+    },
+
+    setWindowPos: function(winid, x, y) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+      win.x = x;
+      win.y = y;
+    },
+
+    getWindowSize: function(winid, width, height) {
+      var ww = 0;
+      var wh = 0;
+
+      var win = GLFW.WindowFromId(winid);
+      if (win) {
+        ww = win.width;
+        wh = win.height;
+      }
+
+      setValue(width, ww, 'i32');
+      setValue(height, wh, 'i32');
+    },
+
+    setWindowSize: function(winid, width, height) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+
+      if (GLFW.active.id == win.id) {
+        if (width == screen.width && height == screen.height) {
+          GLFW.requestFullScreen();
+        } else {
+          GLFW.cancelFullScreen();
+          Browser.setCanvasSize(width, height);
+          win.width = width;
+          win.height = height;
+        }
+      }
+
+      if (!win.windowResizeFunc) return;
+
+#if USE_GLFW == 2
+      Runtime.dynCall('vii', win.windowResizeFunc, [width, height]);
+#endif
+
+#if USE_GLFW == 3
+      Runtime.dynCall('viii', win.windowResizeFunc, [win.id, width, height]);
+#endif
+    },
+
+    createWindow: function(width, height, title, monitor, share) {
+      var i, id;
+      for (i = 0; i < GLFW.windows.length && GLFW.windows[i] !== null; i++);
+      if (i > 0) throw "glfwCreateWindow only supports one window at time currently";
+
+      // id for window
+      id = i + 1;
+
+      // not valid
+      if (width <= 0 || height <= 0) return 0;
+
+      if (monitor) {
+        GLFW.requestFullScreen();
+      } else {
+        Browser.setCanvasSize(width, height);
+      }
+
+      // Create context when there are no existing alive windows
+      for (i = 0; i < GLFW.windows.length && GLFW.windows[i] == null; i++);
+      if (i == GLFW.windows.length) {
+        var contextAttributes = {
+          antialias: (GLFW.hints[0x0002100D] > 1), // GLFW_SAMPLES
+          depth: (GLFW.hints[0x00021005] > 0),     // GLFW_DEPTH_BITS
+          stencil: (GLFW.hints[0x00021006] > 0)    // GLFW_STENCIL_BITS
+        }
+        Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
+      }
+
+      // Get non alive id
+      var win = new GLFW.Window(id, width, height, title, monitor, share);
+
+      // Set window to array
+      if (id - 1 == GLFW.windows.length) {
+        GLFW.windows.push(win);
+      } else {
+        GLFW.windows[id - 1] = win;
+      }
+
+      GLFW.active = win;
+      return win.id;
+    },
+
+    destroyWindow: function(winid) {
+      var win = GLFW.WindowFromId(winid);
+      if (!win) return;
+
+#if USE_GLFW == 3
+      if (win.windowCloseFunc)
+        Runtime.dynCall('vi', win.windowCloseFunc, [win.id]);
+#endif
+
+      GLFW.windows[win.id - 1] = null;
+      if (GLFW.active.id == win.id)
+        GLFW.active = null;
+
+      // Destroy context when no alive windows
+      for (var i = 0; i < GLFW.windows.length; i++)
+        if (GLFW.windows[i] !== null) return;
+
+      Module.ctx = Browser.destroyContext(Module['canvas'], true, true);
+    },
+
+    swapBuffers: function(winid) {
+    },
+
+    GLFW2ParamToGLFW3Param: function(param) {
+      table = {
+        0x00030001:0, // GLFW_MOUSE_CURSOR
+        0x00030002:0, // GLFW_STICKY_KEYS
+        0x00030003:0, // GLFW_STICKY_MOUSE_BUTTONS
+        0x00030004:0, // GLFW_SYSTEM_KEYS
+        0x00030005:0, // GLFW_KEY_REPEAT
+        0x00030006:0, // GLFW_AUTO_POLL_EVENTS
+        0x00020001:0, // GLFW_OPENED
+        0x00020002:0, // GLFW_ACTIVE
+        0x00020003:0, // GLFW_ICONIFIED
+        0x00020004:0, // GLFW_ACCELERATED
+        0x00020005:0x00021001, // GLFW_RED_BITS
+        0x00020006:0x00021002, // GLFW_GREEN_BITS
+        0x00020007:0x00021003, // GLFW_BLUE_BITS
+        0x00020008:0x00021004, // GLFW_ALPHA_BITS
+        0x00020009:0x00021005, // GLFW_DEPTH_BITS
+        0x0002000A:0x00021006, // GLFW_STENCIL_BITS
+        0x0002000B:0x0002100F, // GLFW_REFRESH_RATE
+        0x0002000C:0x00021007, // GLFW_ACCUM_RED_BITS
+        0x0002000D:0x00021008, // GLFW_ACCUM_GREEN_BITS
+        0x0002000E:0x00021009, // GLFW_ACCUM_BLUE_BITS
+        0x0002000F:0x0002100A, // GLFW_ACCUM_ALPHA_BITS
+        0x00020010:0x0002100B, // GLFW_AUX_BUFFERS
+        0x00020011:0x0002100C, // GLFW_STEREO
+        0x00020012:0, // GLFW_WINDOW_NO_RESIZE
+        0x00020013:0x0002100D, // GLFW_FSAA_SAMPLES
+        0x00020014:0x00022002, // GLFW_OPENGL_VERSION_MAJOR
+        0x00020015:0x00022003, // GLFW_OPENGL_VERSION_MINOR
+        0x00020016:0x00022006, // GLFW_OPENGL_FORWARD_COMPAT
+        0x00020017:0x00022007, // GLFW_OPENGL_DEBUG_CONTEXT
+        0x00020018:0x00022008, // GLFW_OPENGL_PROFILE
+      };
+      return table[param];
     }
   },
 
@@ -268,239 +701,481 @@ var LibraryGLFW = {
  * GLFW FUNCTIONS
  ******************************************************************************/
 
-  /* GLFW initialization, termination and version querying */
   glfwInit: function() {
-    GLFW.initTime = Date.now() / 1000;
+    if (GLFW.windows) return 1; // GL_TRUE
+
+    GLFW.initalTime = GLFW.getTime();
+    GLFW.hints = GLFW.defaultHints;
+    GLFW.windows = new Array()
+    GLFW.active = null;
 
     window.addEventListener("keydown", GLFW.onKeydown, true);
     window.addEventListener("keypress", GLFW.onKeyPress, true);
     window.addEventListener("keyup", GLFW.onKeyup, true);
-    window.addEventListener("mousemove", GLFW.onMousemove, true);
-    window.addEventListener("mousedown", GLFW.onMouseButtonDown, true);
-    window.addEventListener("mouseup", GLFW.onMouseButtonUp, true);
-    window.addEventListener('DOMMouseScroll', GLFW.onMouseWheel, true);
-    window.addEventListener('mousewheel', GLFW.onMouseWheel, true);
-
-    __ATEXIT__.push({ func: function() {
-      window.removeEventListener("keydown", GLFW.onKeydown, true);
-      window.removeEventListener("keypress", GLFW.onKeyPress, true);
-      window.removeEventListener("keyup", GLFW.onKeyup, true);
-      window.removeEventListener("mousemove", GLFW.onMousemove, true);
-      window.removeEventListener("mousedown", GLFW.onMouseButtonDown, true);
-      window.removeEventListener("mouseup", GLFW.onMouseButtonUp, true);
-      window.removeEventListener('DOMMouseScroll', GLFW.onMouseWheel, true);
-      window.removeEventListener('mousewheel', GLFW.onMouseWheel, true);
-      Module["canvas"].width = Module["canvas"].height = 1;
-    }});
-
-    //TODO: Init with correct values
-    GLFW.params = new Array();
-    GLFW.params[0x00030001] = true; // GLFW_MOUSE_CURSOR
-    GLFW.params[0x00030002] = false; // GLFW_STICKY_KEYS
-    GLFW.params[0x00030003] = true; // GLFW_STICKY_MOUSE_BUTTONS
-    GLFW.params[0x00030004] = false; // GLFW_SYSTEM_KEYS
-    GLFW.params[0x00030005] = false; // GLFW_KEY_REPEAT
-    GLFW.params[0x00030006] = true; // GLFW_AUTO_POLL_EVENTS
-    GLFW.params[0x00020001] = true; // GLFW_OPENED
-    GLFW.params[0x00020002] = true; // GLFW_ACTIVE
-    GLFW.params[0x00020003] = false; // GLFW_ICONIFIED
-    GLFW.params[0x00020004] = true; // GLFW_ACCELERATED
-    GLFW.params[0x00020005] = 0; // GLFW_RED_BITS
-    GLFW.params[0x00020006] = 0; // GLFW_GREEN_BITS
-    GLFW.params[0x00020007] = 0; // GLFW_BLUE_BITS
-    GLFW.params[0x00020008] = 0; // GLFW_ALPHA_BITS
-    GLFW.params[0x00020009] = 0; // GLFW_DEPTH_BITS
-    GLFW.params[0x0002000A] = 0; // GLFW_STENCIL_BITS
-    GLFW.params[0x0002000B] = 0; // GLFW_REFRESH_RATE
-    GLFW.params[0x0002000C] = 0; // GLFW_ACCUM_RED_BITS
-    GLFW.params[0x0002000D] = 0; // GLFW_ACCUM_GREEN_BITS
-    GLFW.params[0x0002000E] = 0; // GLFW_ACCUM_BLUE_BITS
-    GLFW.params[0x0002000F] = 0; // GLFW_ACCUM_ALPHA_BITS
-    GLFW.params[0x00020010] = 0; // GLFW_AUX_BUFFERS
-    GLFW.params[0x00020011] = 0; // GLFW_STEREO
-    GLFW.params[0x00020012] = 0; // GLFW_WINDOW_NO_RESIZE
-    GLFW.params[0x00020013] = 0; // GLFW_FSAA_SAMPLES
-    GLFW.params[0x00020014] = 0; // GLFW_OPENGL_VERSION_MAJOR
-    GLFW.params[0x00020015] = 0; // GLFW_OPENGL_VERSION_MINOR
-    GLFW.params[0x00020016] = 0; // GLFW_OPENGL_FORWARD_COMPAT
-    GLFW.params[0x00020017] = 0; // GLFW_OPENGL_DEBUG_CONTEXT
-    GLFW.params[0x00020018] = 0; // GLFW_OPENGL_PROFILE
-
-    GLFW.keys = new Array();
-
+    Module["canvas"].addEventListener("mousemove", GLFW.onMousemove, true);
+    Module["canvas"].addEventListener("mousedown", GLFW.onMouseButtonDown, true);
+    Module["canvas"].addEventListener("mouseup", GLFW.onMouseButtonUp, true);
+    Module["canvas"].addEventListener('wheel', GLFW.onMouseWheel, true);
+    Module["canvas"].addEventListener('mousewheel', GLFW.onMouseWheel, true);
     return 1; // GL_TRUE
   },
 
-  glfwTerminate: function() {},
+  glfwTerminate: function() {
+    window.removeEventListener("keydown", GLFW.onKeydown, true);
+    window.removeEventListener("keypress", GLFW.onKeyPress, true);
+    window.removeEventListener("keyup", GLFW.onKeyup, true);
+    Module["canvas"].removeEventListener("mousemove", GLFW.onMousemove, true);
+    Module["canvas"].removeEventListener("mousedown", GLFW.onMouseButtonDown, true);
+    Module["canvas"].removeEventListener("mouseup", GLFW.onMouseButtonUp, true);
+    Module["canvas"].removeEventListener('wheel', GLFW.onMouseWheel, true);
+    Module["canvas"].removeEventListener('mousewheel', GLFW.onMouseWheel, true);
+    Module["canvas"].width = Module["canvas"].height = 1;
+    GLFW.windows = null;
+    GLFW.active = null;
+  },
 
   glfwGetVersion: function(major, minor, rev) {
+#if USE_GLFW == 2
     setValue(major, 2, 'i32');
     setValue(minor, 7, 'i32');
     setValue(rev, 7, 'i32');
+#endif
+
+#if USE_GLFW == 3
+    setValue(major, 3, 'i32');
+    setValue(minor, 0, 'i32');
+    setValue(rev, 0, 'i32');
+#endif
   },
 
-  /* Window handling */
-  glfwOpenWindow__deps: ['$Browser'],
-  glfwOpenWindow: function(width, height, redbits, greenbits, bluebits, alphabits, depthbits, stencilbits, mode) {
-    if (width == 0 && height > 0) {
-      width = 4 * height / 3;
-    }
-    if (width > 0 && height == 0) {
-      height = 3 * width / 4;
-    }
-    GLFW.params[0x00020005] = redbits; // GLFW_RED_BITS
-    GLFW.params[0x00020006] = greenbits; // GLFW_GREEN_BITS
-    GLFW.params[0x00020007] = bluebits; // GLFW_BLUE_BITS
-    GLFW.params[0x00020008] = alphabits; // GLFW_ALPHA_BITS
-    GLFW.params[0x00020009] = depthbits; // GLFW_DEPTH_BITS
-    GLFW.params[0x0002000A] = stencilbits; // GLFW_STENCIL_BITS
-
-    if (mode == 0x00010001) {// GLFW_WINDOW
-      Browser.setCanvasSize(GLFW.initWindowWidth = width,
-                            GLFW.initWindowHeight = height);
-      GLFW.params[0x00030003] = true; // GLFW_STICKY_MOUSE_BUTTONS
-    } else if (mode == 0x00010002) {// GLFW_FULLSCREEN
-      GLFW.requestFullScreen();
-      GLFW.params[0x00030003] = false; // GLFW_STICKY_MOUSE_BUTTONS
-    } else {
-      throw "Invalid glfwOpenWindow mode.";
-    }
-
-    var contextAttributes = {
-      antialias: (GLFW.params[0x00020013] > 1), // GLFW_FSAA_SAMPLES
-      depth: (GLFW.params[0x00020009] > 0), // GLFW_DEPTH_BITS
-      stencil: (GLFW.params[0x0002000A] > 0) // GLFW_STENCIL_BITS
-    }
-    Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
-    return 1; // GL_TRUE
-  },
-
-  glfwOpenWindowHint: function(target, hint) {
-    GLFW.params[target] = hint;
-  },
-
-  glfwCloseWindow__deps: ['$Browser'],
-  glfwCloseWindow: function() {
-    if (GLFW.closeFunc) {
-      Runtime.dynCall('v', GLFW.closeFunc, []);
-    }
-    Module.ctx = Browser.destroyContext(Module['canvas'], true, true);
-  },
-
-  glfwSetWindowTitle: function(title) {
-    document.title = Pointer_stringify(title);
-  },
-
-  glfwGetWindowSize: function(width, height) {
-    setValue(width, Module['canvas'].width, 'i32');
-    setValue(height, Module['canvas'].height, 'i32');
-  },
-
-  glfwSetWindowSize: function(width, height) {
-    GLFW.cancelFullScreen();
-      Browser.setCanvasSize(width, height);
-      if (GLFW.resizeFunc) {
-        Runtime.dynCall('vii', GLFW.resizeFunc, [width, height]);
-      }
-  },
-
-  glfwSetWindowPos: function(x, y) {},
-
-  glfwIconifyWindow: function() {},
-
-  glfwRestoreWindow: function() {},
-
-  glfwSwapBuffers: function() {},
-
-  glfwSwapInterval: function(interval) {},
-
-  glfwGetWindowParam: function(param) {
-    return GLFW.params[param];
-  },
-
-  glfwSetWindowSizeCallback: function(cbfun) {
-    GLFW.resizeFunc = cbfun;
-    if (GLFW.resizeFunc) {
-      Runtime.dynCall('vii', GLFW.resizeFunc, [Module['canvas'].width, Module['canvas'].height]);
-    }
-  },
-
-  glfwSetWindowCloseCallback: function(cbfun) {
-    GLFW.closeFunc = cbfun;
-  },
-
-  glfwSetWindowRefreshCallback: function(cbfun) {
-    GLFW.refreshFunc = cbfun;
-  },
-
-  /* Video mode functions */
-  glfwGetVideoModes: function(list, maxcount) { throw "glfwGetVideoModes is not implemented."; },
-
-  glfwGetDesktopMode: function(mode) { throw "glfwGetDesktopMode is not implemented."; },
-
-  /* Input handling */
   glfwPollEvents: function() {},
 
   glfwWaitEvents: function() {},
 
-  glfwGetKey: function(key) {
-    return GLFW.keys[key];
-  },
-
-  glfwGetMouseButton: function(button) {
-    return (GLFW.buttons & (1 << button)) > 0;
-  },
-
-  glfwGetMousePos: function(xpos, ypos) {
-    setValue(xpos, Browser.mouseX, 'i32');
-    setValue(ypos, Browser.mouseY, 'i32');
-  },
-
-  // I believe it is not possible to move the mouse with javascript
-  glfwSetMousePos: function(xpos, ypos) {},
-
-  glfwGetMouseWheel: function() {
-    return GLFW.wheelPos;
-  },
-
-  glfwSetMouseWheel: function(pos) {
-    GLFW.wheelPos = pos;
-  },
-
-  glfwSetKeyCallback: function(cbfun) {
-    GLFW.keyFunc = cbfun;
-  },
-
-  glfwSetCharCallback: function(cbfun) {
-    GLFW.charFunc = cbfun;
-  },
-
-  glfwSetMouseButtonCallback: function(cbfun) {
-    GLFW.mouseButtonFunc = cbfun;
-  },
-
-  glfwSetMousePosCallback: function(cbfun) {
-    GLFW.mousePosFunc = cbfun;
-  },
-
-  glfwSetMouseWheelCallback: function(cbfun) {
-    GLFW.mouseWheelFunc = cbfun;
-  },
-
-  /* Joystick input */
-  glfwGetJoystickParam: function(joy, param) { throw "glfwGetJoystickParam is not implemented."; },
-
-  glfwGetJoystickPos: function(joy, pos, numaxes) { throw "glfwGetJoystickPos is not implemented."; },
-
-  glfwGetJoystickButtons: function(joy, buttons, numbuttons) { throw "glfwGetJoystickButtons is not implemented."; },
-
-  /* Time */
   glfwGetTime: function() {
-    return (Date.now()/1000) - GLFW.initTime;
+    return GLFW.getTime() - GLFW.initialTime;
   },
 
   glfwSetTime: function(time) {
-    GLFW.initTime = Date.now()/1000 + time;
+    GLFW.initialTime = GLFW.getTime() + time;
+  },
+
+  glfwExtensionSupported: function(extension) {
+    if (!GLFW.extensions) {
+      GLFW.extensions = Pointer_stringify(_glGetString(0x1F03)).split(' ');
+    }
+
+    if (GLFW.extensions.indexOf(extension) != -1) return 1;
+
+    // extensions from GLEmulations do not come unprefixed
+    // so, try with prefix
+    return (GLFW.extensions.indexOf("GL_" + extension) != -1);
+  },
+
+  glfwGetProcAddress__deps: ['emscripten_GetProcAddress'],
+  glfwGetProcAddress: function(procname) {
+    return _emscripten_GetProcAddress(Pointer_stringify(procname));
+  },
+
+  glfwSwapInterval: function(interval) {},
+
+#if USE_GLFW == 3
+  glfwGetVersionString: function() {
+    if (!GLFW.versionString) {
+      GLFW.versionString = allocate(intArrayFromString("3.0.0 JS WebGL Emscripten"), 'i8', ALLOC_NORMAL);
+    }
+    return GLFW.versionString;
+  },
+
+  glfwSetErrorCallback: function(cbfun) {
+    GLFW.errorFunc = cbfun;
+  },
+
+  glfwGetMonitors: function(count) {
+    setValue(count, 1, 'i32');
+    if (!GLFW.monitors) {
+      GLFW.monitors = allocate(Int32Array([1]), 'i32', ALLOC_NORMAL);
+    }
+    return GLFW.monitors;
+  },
+
+  glfwGetPrimaryMonitor: function() {
+    return 1;
+  },
+
+  glfwGetMonitorPos: function(monitor, x, y) {
+    setValue(x, 0, 'i32');
+    setValue(y, 0, 'i32');
+  },
+
+  glfwGetMonitorPhysicalSize: function(monitor, width, height) {
+    // AFAIK there is no way to do this in javascript
+    // Maybe with platform specific ccalls?
+    //
+    // Lets report 0 now which is wrong as it can get for end user.
+    setValue(width, 0, 'i32');
+    setValue(height, 0, 'i32');
+  },
+
+  glfwGetMonitorName: function(mon) {
+    if (!GLFW.monitorString) {
+      GLFW.monitorString = allocate(intArrayFromString("HTML5 WebGL Canvas"), 'i8', ALLOC_NORMAL);
+    }
+    return GLFW.monitorString;
+  },
+
+  glfwSetMonitorCallback: function(cbfun) {
+    GLFW.monitorFunc = cbfun;
+  },
+
+  // TODO: implement
+  glfwGetVideoModes: function(monitor, count) {
+    setValue(count, 0, 'i32');
+    return 0;
+  },
+
+  // TODO: implement
+  glfwGetVideoMode: function(monitor) { return 0; },
+
+  // TODO: implement
+  glfwSetGamma: function(monitor, gamma) { },
+
+  glfwGetGammaRamp: function(monitor) {
+    throw "glfwGetGammaRamp not implemented.";
+  },
+
+  glfwSetGammaRamp: function(monitor, ramp) {
+    throw "glfwSetGammaRamp not implemented.";
+  },
+
+  glfwDefaultWindowHints: function() {
+    GLFW.hints = GLFW.defaultHints;
+  },
+
+  glfwWindowHint: function(target, hint) {
+    GLFW.hints[target] = hint;
+  },
+
+  glfwCreateWindow: function(width, height, title, monitor, share) {
+    return GLFW.createWindow(width, height, title, monitor, share);
+  },
+
+  glfwDestroyWindow: function(winid) {
+    return GLFW.destroyWindow(winid);
+  },
+
+  glfwWindowShouldClose: function(winid) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return 0;
+    return win.shouldClose;
+  },
+
+  glfwSetWindowShouldClose: function(winid, value) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return;
+    win.shouldClose = value;
+  },
+
+  glfwSetWindowTitle: function(winid, title) {
+    GLFW.setWindowTitle(winid, title);
+  },
+
+  glfwGetWindowPos: function(winid, x, y) {
+    GLFW.getWindowPos(winid, x, y);
+  },
+
+  glfwSetWindowPos: function(winid, x, y) {
+    GLFW.setWindowPos(winid, x, y);
+  },
+
+  glfwGetWindowSize: function(winid, width, height) {
+    GLFW.getWindowSize(winid, width, height);
+  },
+
+  glfwSetWindowSize: function(winid, width, height) {
+    GLFW.setWindowSize(winid, width, height);
+  },
+
+  glfwGetFramebufferSize: function(winid, width, height) {
+    var ww = 0;
+    var wh = 0;
+
+    var win = GLFW.WindowFromId(winid);
+    if (win) {
+      ww = win.width;
+      wh = win.height;
+    }
+
+    setValue(width, ww, 'i32');
+    setValue(height, wh, 'i32');
+  },
+
+  glfwIconifyWindow: function(winid) {
+    GLFW.iconifyWindow(winid);
+  },
+
+  glfwRestoreWindow: function(winid) {
+    GLFW.restoreWindow(winid);
+  },
+
+  glfwShowWindow: function(winid) {},
+
+  glfwHideWindow: function(winid) {},
+
+  glfwGetWindowMonitor: function(winid) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return 0;
+    return win.monitor;
+  },
+
+  glfwGetWindowAttrib: function(winid, attrib) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return 0;
+    return win.attributes[attrib];
+  },
+
+  glfwSetWindowUserPointer: function(winid, ptr) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return;
+    win.userptr = ptr;
+  },
+
+  glfwGetWindowUserPointer: function(winid) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return 0;
+    return win.userptr;
+  },
+
+  glfwSetWindowPosCallback: function(winid, cbfun) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return;
+    win.windowPosFunc = cbfun;
+  },
+
+  glfwSetWindowSizeCallback: function(winid, cbfun) {
+    GLFW.setWindowSizeCallback(winid, cbfun);
+  },
+
+  glfwSetWindowCloseCallback: function(winid, cbfun) {
+    GLFW.setWindowCloseCallback(winid, cbfun);
+  },
+
+  glfwSetWindowRefreshCallback: function(winid, cbfun) {
+    GLFW.setWindowRefreshCallback(winid, cbfun);
+  },
+
+  glfwSetWindowFocusCallback: function(winid, cbfun) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return;
+    win.windowFocusFunc = cbfun;
+  },
+
+  glfwSetWindowIconifyCallback: function(winid, cbfun) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return;
+    win.windowIconifyFunc = cbfun;
+  },
+
+  glfwSetFramebufferSizeCallback: function(winid, cbfun) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return;
+    win.windowFramebufferSizeFunc = cbfun;
+  },
+
+  glfwGetInputMode: function(winid, mode) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return;
+    return win.inputModes[mode];
+  },
+
+  // TODO: implement
+  // GLFW_STICKY_KEYS == key stays pressed until pressed second time
+  // GLFW_STICKY_MOUSE_BUTTONS == same as above but for mouse buttons
+  // GLFW_CURSOR == NORMAL, HIDDEN (no pointer), DISABLED (hidden && always centered)
+  glfwSetInputMode: function(winid, mode, value) {},
+
+  glfwGetKey: function(winid, key) {
+    return GLFW.getKey(winid, key);
+  },
+
+  glfwGetMouseButton: function(winid, button) {
+    return GLFW.getMouseButton(winid, button);
+  },
+
+  glfwGetCursorPos: function(winid, x, y) {
+    GLFW.getCursorPos(winid, x, y);
+  },
+
+  // I believe it is not possible to move the mouse with javascript
+  glfwSetCursorPos: function(winid, x, y) {
+    GLFW.setCursorPos(winid, x, y);
+  },
+
+  glfwSetKeyCallback: function(winid, cbfun) {
+    GLFW.setKeyCallback(winid, cbfun);
+  },
+
+  glfwSetCharCallback: function(winid, cbfun) {
+    GLFW.setCharCallback(winid, cbfun);
+  },
+
+  glfwSetMouseButtonCallback: function(winid, cbfun) {
+    GLFW.setMouseButtonCallback(winid, cbfun);
+  },
+
+  glfwSetCursorPosCallback: function(winid, cbfun) {
+    GLFW.setCursorPosCallback(winid, cbfun);
+  },
+
+  glfwSetCursorEnterCallback: function(winid, cbfun) {
+    var win = GLFW.WindowFromId(winid);
+    if (!win) return;
+    win.cursorEnterFunc = cbfun;
+  },
+
+  glfwSetScrollCallback: function(winid, cbfun) {
+    GLFW.setScrollCallback(winid, cbfun);
+  },
+
+  glfwJoystickPresent: function(joy) { throw "glfwJoystickPresent is not implemented."; },
+
+  glfwGetJoystickAxes: function(joy, count) { throw "glfwGetJoystickParam is not implemented."; },
+
+  glfwGetJoystickButtons: function(joy, count) { throw "glfwGetJoystickButtons is not implemented."; },
+
+  glfwGetJoystickName: function(joy) { throw "glfwGetJoystickName is not implemented."; },
+
+  glfwSetClipboardString: function(win, string) {},
+
+  glfwGetClipboardString: function(win) {},
+
+  glfwMakeContextCurrent: function(winid) {},
+
+  glfwGetCurrentContext: function() {
+    return GLFW.active.id;
+  },
+
+  glfwSwapBuffers: function(winid) {
+    GLFW.swapBuffers(winid);
+  },
+
+#endif // GLFW 3
+
+#if USE_GLFW == 2
+  glfwOpenWindow: function(width, height, redbits, greenbits, bluebits, alphabits, depthbits, stencilbits, mode) {
+    GLFW.hints[0x00021001] = redbits;     // GLFW_RED_BITS
+    GLFW.hints[0x00021002] = greenbits;   // GLFW_GREEN_BITS
+    GLFW.hints[0x00021003] = bluebits;    // GLFW_BLUE_BITS
+    GLFW.hints[0x00021004] = alphabits;   // GLFW_ALPHA_BITS
+    GLFW.hints[0x00021005] = depthbits;   // GLFW_DEPTH_BITS
+    GLFW.hints[0x00021006] = stencilbits; // GLFW_STENCIL_BITS
+    GLFW.createWindow(width, height, "GLFW2 Window", 0, 0);
+    return 1; // GL_TRUE
+  },
+
+  glfwCloseWindow: function() {
+    GLFW.destroyWindow(GLFW.active.id);
+  },
+
+  glfwOpenWindowHint: function(target, hint) {
+    target = GLFW.GLFW2ParamToGLFW3Param(target);
+    GLFW.windowHint(target, hint);
+  },
+
+  glfwGetWindowSize: function(width, height) {
+    GLFW.getWindowSize(GLFW.active.id, width, height);
+  },
+
+  glfwSetWindowSize: function(width, height) {
+    GLFW.setWindowSize(GLFW.active.id, width, height);
+  },
+
+  glfwGetWindowPos: function(x, y) {
+    GLFW.getWindowPos(GLFW.active.id, x, y);
+  },
+
+  glfwSetWindowPos: function(x, y) {
+    GLFW.setWindowPos(GLFW.active.id, x, y);
+  },
+
+  glfwSetWindowTitle: function(title) {
+    GLFW.setWindowTitle(GLFW.active.id, title);
+  },
+
+  glfwIconifyWindow: function() {
+    GLFW.iconifyWindow(GLFW.active.id);
+  },
+
+  glfwRestoreWindow: function() {
+    GLFW.restoreWindow(GLFW.active.id);
+  },
+
+  glfwSwapBuffers: function() {
+    GLFW.swapBuffers(GLFW.active.id);
+  },
+
+  glfwGetWindowParam: function(param) {
+    param = GLFW.GLFW2ParamToGLFW3Param(param);
+    return GLFW.hints[param];
+  },
+
+  glfwSetWindowSizeCallback: function(cbfun) {
+    GLFW.setWindowSizeCallback(GLFW.active.id, cbfun);
+  },
+
+  glfwSetWindowCloseCallback: function(cbfun) {
+    GLFW.setWindowCloseCallback(GLFW.active.id, cbfun);
+  },
+
+  glfwSetWindowRefreshCallback: function(cbfun) {
+    GLFW.setWindowRefreshCallback(GLFW.active.id, cbfun);
+  },
+
+  glfwGetKey: function(key) {
+    return GLFW.getKey(GLFW.active.id, key);
+  },
+
+  glfwGetMouseButton: function(button) {
+    return GLFW.getMouseButton(GLFW.active.id, button);
+  },
+
+  glfwGetMousePos: function(x, y) {
+    GLFW.getCursorPos(GLFW.active.id, x, y);
+  },
+
+  glfwSetMousePos: function(x, y) {
+    GLFW.setCursorPos(GLFW.active.id, x, y);
+  },
+
+  glfwGetMouseWheel: function() {
+    return 0;
+  },
+
+  glfwSetMouseWheel: function(pos) {
+  },
+
+  glfwSetKeyCallback: function(cbfun) {
+    GLFW.setKeyCallback(GLFW.active.id, cbfun);
+  },
+
+  glfwSetCharCallback: function(cbfun) {
+    GLFW.setCharCallback(GLFW.active.id, cbfun);
+  },
+
+  glfwSetMouseButtonCallback: function(cbfun) {
+    GLFW.setMouseButtonCallback(GLFW.active.id, cbfun);
+  },
+
+  glfwSetMousePosCallback: function(cbfun) {
+    GLFW.setCursorPosCallback(GLFW.active.id, cbfun);
+  },
+
+  glfwSetMouseWheelCallback: function(cbfun) {
+    GLFW.setScrollCallback(GLFW.active.id, cbfun);
+  },
+
+  glfwGetDesktopMode: function(mode) {
+    throw "glfwGetDesktopMode is not implemented.";
   },
 
   glfwSleep__deps: ['sleep'],
@@ -508,14 +1183,14 @@ var LibraryGLFW = {
     _sleep(time);
   },
 
-  /* Extension support */
-  glfwExtensionSupported: function(extension) {
-    return Module.ctx.getSupportedExtensions().indexOf(Pointer_stringify(extension)) > -1;
+  glfwEnable: function(token) {
+    target = GLFW.GLFW2ParamToGLFW3Param(target);
+    GLFW.hints[target] = false;
   },
 
-  glfwGetProcAddress__deps: ['emscripten_GetProcAddress'],
-  glfwGetProcAddress: function(procname) {
-    return _emscripten_GetProcAddress(procname);
+  glfwDisable: function(token) {
+    target = GLFW.GLFW2ParamToGLFW3Param(target);
+    GLFW.hints[target] = true;
   },
 
   glfwGetGLVersion: function(major, minor, rev) {
@@ -524,7 +1199,6 @@ var LibraryGLFW = {
     setValue(rev, 1, 'i32');
   },
 
-  /* Threading support */
   glfwCreateThread: function(fun, arg) {
     var str = 'v';
     for (var i in arg) {
@@ -567,16 +1241,6 @@ var LibraryGLFW = {
     return 1;
   },
 
-  /* Enable/disable functions */
-  glfwEnable: function(token) {
-    GLFW.params[token] = false;
-  },
-
-  glfwDisable: function(token) {
-    GLFW.params[token] = true;
-  },
-
-  /* Image/texture I/O support */
   glfwReadImage: function(name, img, flags) { throw "glfwReadImage is not implemented."; },
 
   glfwReadMemoryImage: function(data, size, img, flags) { throw "glfwReadMemoryImage is not implemented."; },
@@ -588,9 +1252,8 @@ var LibraryGLFW = {
   glfwLoadMemoryTexture2D: function(data, size, flags) { throw "glfwLoadMemoryTexture2D is not implemented."; },
 
   glfwLoadTextureImage2D: function(img, flags) { throw "glfwLoadTextureImage2D is not implemented."; },
+#endif // GLFW2
 };
 
 autoAddDeps(LibraryGLFW, '$GLFW');
 mergeInto(LibraryManager.library, LibraryGLFW);
-
-

--- a/src/settings.js
+++ b/src/settings.js
@@ -567,6 +567,10 @@ var COMPILER_FASTPATHS = 1; // use fast-paths to speed up compilation
 
 var EMSCRIPTEN_TRACING = 0; // Add some calls to emscripten tracing APIs
 
+var USE_GLFW = 2; // Specify the GLFW version that is being linked against.
+                  // Only relevant, if you are linking against the GLFW library.
+                  // Valid options are 2 for GLFW2 and 3 for GLFW3.
+
 // Compiler debugging options
 var DEBUG_TAGS_SHOWING = [];
   // Some useful items:

--- a/system/include/GLFW/glfw3.h
+++ b/system/include/GLFW/glfw3.h
@@ -1,0 +1,2281 @@
+/*************************************************************************
+ * GLFW 3.0 - www.glfw.org
+ * A library for OpenGL, window and input
+ *------------------------------------------------------------------------
+ * Copyright (c) 2002-2006 Marcus Geelnard
+ * Copyright (c) 2006-2010 Camilla Berglund <elmindreda@elmindreda.org>
+ *
+ * This software is provided 'as-is', without any express or implied
+ * warranty. In no event will the authors be held liable for any damages
+ * arising from the use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not
+ *    claim that you wrote the original software. If you use this software
+ *    in a product, an acknowledgment in the product documentation would
+ *    be appreciated but is not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not
+ *    be misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source
+ *    distribution.
+ *
+ *************************************************************************/
+
+#ifndef _glfw3_h_
+#define _glfw3_h_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/*************************************************************************
+ * Doxygen documentation
+ *************************************************************************/
+
+/*! @defgroup clipboard Clipboard support
+ */
+/*! @defgroup context Context handling
+ */
+/*! @defgroup error Error handling
+ */
+/*! @defgroup init Initialization and version information
+ */
+/*! @defgroup input Input handling
+ */
+/*! @defgroup monitor Monitor handling
+ *
+ *  This is the reference documentation for monitor related functions and types.
+ *  For more information, see the @ref monitor.
+ */
+/*! @defgroup time Time input
+ */
+/*! @defgroup window Window handling
+ *
+ *  This is the reference documentation for window related functions and types,
+ *  including creation, deletion and event polling.  For more information, see
+ *  the @ref window.
+ */
+
+
+/*************************************************************************
+ * Global definitions
+ *************************************************************************/
+
+/* ------------------- BEGIN SYSTEM/COMPILER SPECIFIC -------------------- */
+
+/* Please report any problems that you find with your compiler, which may
+ * be solved in this section! There are several compilers that I have not
+ * been able to test this file with yet.
+ *
+ * First: If we are we on Windows, we want a single define for it (_WIN32)
+ * (Note: For Cygwin the compiler flag -mwin32 should be used, but to
+ * make sure that things run smoothly for Cygwin users, we add __CYGWIN__
+ * to the list of "valid Win32 identifiers", which removes the need for
+ * -mwin32)
+ */
+#if !defined(_WIN32) && (defined(__WIN32__) || defined(WIN32) || defined(__CYGWIN__))
+ #define _WIN32
+#endif /* _WIN32 */
+
+/* In order for extension support to be portable, we need to define an
+ * OpenGL function call method. We use the keyword APIENTRY, which is
+ * defined for Win32. (Note: Windows also needs this for <GL/gl.h>)
+ */
+#ifndef APIENTRY
+ #ifdef _WIN32
+  #define APIENTRY __stdcall
+ #else
+  #define APIENTRY
+ #endif
+#endif /* APIENTRY */
+
+/* The following three defines are here solely to make some Windows-based
+ * <GL/gl.h> files happy. Theoretically we could include <windows.h>, but
+ * it has the major drawback of severely polluting our namespace.
+ */
+
+/* Under Windows, we need WINGDIAPI defined */
+#if !defined(WINGDIAPI) && defined(_WIN32)
+ #if defined(_MSC_VER) || defined(__BORLANDC__) || defined(__POCC__)
+  /* Microsoft Visual C++, Borland C++ Builder and Pelles C */
+  #define WINGDIAPI __declspec(dllimport)
+ #elif defined(__LCC__)
+  /* LCC-Win32 */
+  #define WINGDIAPI __stdcall
+ #else
+  /* Others (e.g. MinGW, Cygwin) */
+  #define WINGDIAPI extern
+ #endif
+ #define GLFW_WINGDIAPI_DEFINED
+#endif /* WINGDIAPI */
+
+/* Some <GL/glu.h> files also need CALLBACK defined */
+#if !defined(CALLBACK) && defined(_WIN32)
+ #if defined(_MSC_VER)
+  /* Microsoft Visual C++ */
+  #if (defined(_M_MRX000) || defined(_M_IX86) || defined(_M_ALPHA) || defined(_M_PPC)) && !defined(MIDL_PASS)
+   #define CALLBACK __stdcall
+  #else
+   #define CALLBACK
+  #endif
+ #else
+  /* Other Windows compilers */
+  #define CALLBACK __stdcall
+ #endif
+ #define GLFW_CALLBACK_DEFINED
+#endif /* CALLBACK */
+
+/* Most GL/glu.h variants on Windows need wchar_t
+ * OpenGL/gl.h blocks the definition of ptrdiff_t by glext.h on OS X */
+#if !defined(GLFW_INCLUDE_NONE)
+ #include <stddef.h>
+#endif
+
+/* Include the chosen client API headers.
+ */
+#if defined(__APPLE_CC__)
+  #if defined(GLFW_INCLUDE_GLCOREARB)
+    #include <OpenGL/gl3.h>
+  #elif !defined(GLFW_INCLUDE_NONE)
+    #define GL_GLEXT_LEGACY
+    #include <OpenGL/gl.h>
+  #endif
+  #if defined(GLFW_INCLUDE_GLU)
+    #include <OpenGL/glu.h>
+  #endif
+#else
+  #if defined(GLFW_INCLUDE_GLCOREARB)
+    #include <GL/glcorearb.h>
+  #elif defined(GLFW_INCLUDE_ES1)
+    #include <GLES/gl.h>
+  #elif defined(GLFW_INCLUDE_ES2)
+    #include <GLES2/gl2.h>
+  #elif defined(GLFW_INCLUDE_ES3)
+    #include <GLES3/gl3.h>
+  #elif !defined(GLFW_INCLUDE_NONE)
+    #include <GL/gl.h>
+  #endif
+  #if defined(GLFW_INCLUDE_GLU)
+    #include <GL/glu.h>
+  #endif
+#endif
+
+#if defined(GLFW_DLL) && defined(_GLFW_BUILD_DLL)
+ /* GLFW_DLL is defined by users of GLFW when compiling programs that will link
+  * to the DLL version of the GLFW library.  _GLFW_BUILD_DLL is defined by the
+  * GLFW configuration header when compiling the DLL version of the library.
+  */
+ #error "You must not have both GLFW_DLL and _GLFW_BUILD_DLL defined"
+#endif
+
+#if defined(_WIN32) && defined(_GLFW_BUILD_DLL)
+
+ /* We are building a Win32 DLL */
+ #define GLFWAPI __declspec(dllexport)
+
+#elif defined(_WIN32) && defined(GLFW_DLL)
+
+ /* We are calling a Win32 DLL */
+ #if defined(__LCC__)
+  #define GLFWAPI extern
+ #else
+  #define GLFWAPI __declspec(dllimport)
+ #endif
+
+#elif defined(__GNUC__) && defined(_GLFW_BUILD_DLL)
+
+ #define GLFWAPI __attribute__((visibility("default")))
+
+#else
+
+ /* We are either building/calling a static lib or we are non-win32 */
+ #define GLFWAPI
+
+#endif
+
+/* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
+
+
+/*************************************************************************
+ * GLFW API tokens
+ *************************************************************************/
+
+/*! @name GLFW version macros
+ *  @{ */
+/*! @brief The major version number of the GLFW library.
+ *
+ *  This is incremented when the API is changed in non-compatible ways.
+ *  @ingroup init
+ */
+#define GLFW_VERSION_MAJOR          3
+/*! @brief The minor version number of the GLFW library.
+ *
+ *  This is incremented when features are added to the API but it remains
+ *  backward-compatible.
+ *  @ingroup init
+ */
+#define GLFW_VERSION_MINOR          0
+/*! @brief The revision number of the GLFW library.
+ *
+ *  This is incremented when a bug fix release is made that does not contain any
+ *  API changes.
+ *  @ingroup init
+ */
+#define GLFW_VERSION_REVISION       3
+/*! @} */
+
+/*! @name Key and button actions
+ *  @{ */
+/*! @brief The key or button was released.
+ *  @ingroup input
+ */
+#define GLFW_RELEASE                0
+/*! @brief The key or button was pressed.
+ *  @ingroup input
+ */
+#define GLFW_PRESS                  1
+/*! @brief The key was held down until it repeated.
+ *  @ingroup input
+ */
+#define GLFW_REPEAT                 2
+/*! @} */
+
+/*! @defgroup keys Keyboard keys
+ *
+ * These key codes are inspired by the *USB HID Usage Tables v1.12* (p. 53-60),
+ * but re-arranged to map to 7-bit ASCII for printable keys (function keys are
+ * put in the 256+ range).
+ *
+ * The naming of the key codes follow these rules:
+ *  - The US keyboard layout is used
+ *  - Names of printable alpha-numeric characters are used (e.g. "A", "R",
+ *    "3", etc.)
+ *  - For non-alphanumeric characters, Unicode:ish names are used (e.g.
+ *    "COMMA", "LEFT_SQUARE_BRACKET", etc.). Note that some names do not
+ *    correspond to the Unicode standard (usually for brevity)
+ *  - Keys that lack a clear US mapping are named "WORLD_x"
+ *  - For non-printable keys, custom names are used (e.g. "F4",
+ *    "BACKSPACE", etc.)
+ *
+ *  @ingroup input
+ *  @{
+ */
+
+/* The unknown key */
+#define GLFW_KEY_UNKNOWN            -1
+
+/* Printable keys */
+#define GLFW_KEY_SPACE              32
+#define GLFW_KEY_APOSTROPHE         39  /* ' */
+#define GLFW_KEY_COMMA              44  /* , */
+#define GLFW_KEY_MINUS              45  /* - */
+#define GLFW_KEY_PERIOD             46  /* . */
+#define GLFW_KEY_SLASH              47  /* / */
+#define GLFW_KEY_0                  48
+#define GLFW_KEY_1                  49
+#define GLFW_KEY_2                  50
+#define GLFW_KEY_3                  51
+#define GLFW_KEY_4                  52
+#define GLFW_KEY_5                  53
+#define GLFW_KEY_6                  54
+#define GLFW_KEY_7                  55
+#define GLFW_KEY_8                  56
+#define GLFW_KEY_9                  57
+#define GLFW_KEY_SEMICOLON          59  /* ; */
+#define GLFW_KEY_EQUAL              61  /* = */
+#define GLFW_KEY_A                  65
+#define GLFW_KEY_B                  66
+#define GLFW_KEY_C                  67
+#define GLFW_KEY_D                  68
+#define GLFW_KEY_E                  69
+#define GLFW_KEY_F                  70
+#define GLFW_KEY_G                  71
+#define GLFW_KEY_H                  72
+#define GLFW_KEY_I                  73
+#define GLFW_KEY_J                  74
+#define GLFW_KEY_K                  75
+#define GLFW_KEY_L                  76
+#define GLFW_KEY_M                  77
+#define GLFW_KEY_N                  78
+#define GLFW_KEY_O                  79
+#define GLFW_KEY_P                  80
+#define GLFW_KEY_Q                  81
+#define GLFW_KEY_R                  82
+#define GLFW_KEY_S                  83
+#define GLFW_KEY_T                  84
+#define GLFW_KEY_U                  85
+#define GLFW_KEY_V                  86
+#define GLFW_KEY_W                  87
+#define GLFW_KEY_X                  88
+#define GLFW_KEY_Y                  89
+#define GLFW_KEY_Z                  90
+#define GLFW_KEY_LEFT_BRACKET       91  /* [ */
+#define GLFW_KEY_BACKSLASH          92  /* \ */
+#define GLFW_KEY_RIGHT_BRACKET      93  /* ] */
+#define GLFW_KEY_GRAVE_ACCENT       96  /* ` */
+#define GLFW_KEY_WORLD_1            161 /* non-US #1 */
+#define GLFW_KEY_WORLD_2            162 /* non-US #2 */
+
+/* Function keys */
+#define GLFW_KEY_ESCAPE             256
+#define GLFW_KEY_ENTER              257
+#define GLFW_KEY_TAB                258
+#define GLFW_KEY_BACKSPACE          259
+#define GLFW_KEY_INSERT             260
+#define GLFW_KEY_DELETE             261
+#define GLFW_KEY_RIGHT              262
+#define GLFW_KEY_LEFT               263
+#define GLFW_KEY_DOWN               264
+#define GLFW_KEY_UP                 265
+#define GLFW_KEY_PAGE_UP            266
+#define GLFW_KEY_PAGE_DOWN          267
+#define GLFW_KEY_HOME               268
+#define GLFW_KEY_END                269
+#define GLFW_KEY_CAPS_LOCK          280
+#define GLFW_KEY_SCROLL_LOCK        281
+#define GLFW_KEY_NUM_LOCK           282
+#define GLFW_KEY_PRINT_SCREEN       283
+#define GLFW_KEY_PAUSE              284
+#define GLFW_KEY_F1                 290
+#define GLFW_KEY_F2                 291
+#define GLFW_KEY_F3                 292
+#define GLFW_KEY_F4                 293
+#define GLFW_KEY_F5                 294
+#define GLFW_KEY_F6                 295
+#define GLFW_KEY_F7                 296
+#define GLFW_KEY_F8                 297
+#define GLFW_KEY_F9                 298
+#define GLFW_KEY_F10                299
+#define GLFW_KEY_F11                300
+#define GLFW_KEY_F12                301
+#define GLFW_KEY_F13                302
+#define GLFW_KEY_F14                303
+#define GLFW_KEY_F15                304
+#define GLFW_KEY_F16                305
+#define GLFW_KEY_F17                306
+#define GLFW_KEY_F18                307
+#define GLFW_KEY_F19                308
+#define GLFW_KEY_F20                309
+#define GLFW_KEY_F21                310
+#define GLFW_KEY_F22                311
+#define GLFW_KEY_F23                312
+#define GLFW_KEY_F24                313
+#define GLFW_KEY_F25                314
+#define GLFW_KEY_KP_0               320
+#define GLFW_KEY_KP_1               321
+#define GLFW_KEY_KP_2               322
+#define GLFW_KEY_KP_3               323
+#define GLFW_KEY_KP_4               324
+#define GLFW_KEY_KP_5               325
+#define GLFW_KEY_KP_6               326
+#define GLFW_KEY_KP_7               327
+#define GLFW_KEY_KP_8               328
+#define GLFW_KEY_KP_9               329
+#define GLFW_KEY_KP_DECIMAL         330
+#define GLFW_KEY_KP_DIVIDE          331
+#define GLFW_KEY_KP_MULTIPLY        332
+#define GLFW_KEY_KP_SUBTRACT        333
+#define GLFW_KEY_KP_ADD             334
+#define GLFW_KEY_KP_ENTER           335
+#define GLFW_KEY_KP_EQUAL           336
+#define GLFW_KEY_LEFT_SHIFT         340
+#define GLFW_KEY_LEFT_CONTROL       341
+#define GLFW_KEY_LEFT_ALT           342
+#define GLFW_KEY_LEFT_SUPER         343
+#define GLFW_KEY_RIGHT_SHIFT        344
+#define GLFW_KEY_RIGHT_CONTROL      345
+#define GLFW_KEY_RIGHT_ALT          346
+#define GLFW_KEY_RIGHT_SUPER        347
+#define GLFW_KEY_MENU               348
+#define GLFW_KEY_LAST               GLFW_KEY_MENU
+
+/*! @} */
+
+/*! @defgroup mods Modifier key flags
+ *  @ingroup input
+ *  @{ */
+
+/*! @brief If this bit is set one or more Shift keys were held down.
+ */
+#define GLFW_MOD_SHIFT           0x0001
+/*! @brief If this bit is set one or more Control keys were held down.
+ */
+#define GLFW_MOD_CONTROL         0x0002
+/*! @brief If this bit is set one or more Alt keys were held down.
+ */
+#define GLFW_MOD_ALT             0x0004
+/*! @brief If this bit is set one or more Super keys were held down.
+ */
+#define GLFW_MOD_SUPER           0x0008
+
+/*! @} */
+
+/*! @defgroup buttons Mouse buttons
+ *  @ingroup input
+ *  @{ */
+#define GLFW_MOUSE_BUTTON_1         0
+#define GLFW_MOUSE_BUTTON_2         1
+#define GLFW_MOUSE_BUTTON_3         2
+#define GLFW_MOUSE_BUTTON_4         3
+#define GLFW_MOUSE_BUTTON_5         4
+#define GLFW_MOUSE_BUTTON_6         5
+#define GLFW_MOUSE_BUTTON_7         6
+#define GLFW_MOUSE_BUTTON_8         7
+#define GLFW_MOUSE_BUTTON_LAST      GLFW_MOUSE_BUTTON_8
+#define GLFW_MOUSE_BUTTON_LEFT      GLFW_MOUSE_BUTTON_1
+#define GLFW_MOUSE_BUTTON_RIGHT     GLFW_MOUSE_BUTTON_2
+#define GLFW_MOUSE_BUTTON_MIDDLE    GLFW_MOUSE_BUTTON_3
+/*! @} */
+
+/*! @defgroup joysticks Joysticks
+ *  @ingroup input
+ *  @{ */
+#define GLFW_JOYSTICK_1             0
+#define GLFW_JOYSTICK_2             1
+#define GLFW_JOYSTICK_3             2
+#define GLFW_JOYSTICK_4             3
+#define GLFW_JOYSTICK_5             4
+#define GLFW_JOYSTICK_6             5
+#define GLFW_JOYSTICK_7             6
+#define GLFW_JOYSTICK_8             7
+#define GLFW_JOYSTICK_9             8
+#define GLFW_JOYSTICK_10            9
+#define GLFW_JOYSTICK_11            10
+#define GLFW_JOYSTICK_12            11
+#define GLFW_JOYSTICK_13            12
+#define GLFW_JOYSTICK_14            13
+#define GLFW_JOYSTICK_15            14
+#define GLFW_JOYSTICK_16            15
+#define GLFW_JOYSTICK_LAST          GLFW_JOYSTICK_16
+/*! @} */
+
+/*! @defgroup errors Error codes
+ *  @ingroup error
+ *  @{ */
+/*! @brief GLFW has not been initialized.
+ */
+#define GLFW_NOT_INITIALIZED        0x00010001
+/*! @brief No context is current for this thread.
+ */
+#define GLFW_NO_CURRENT_CONTEXT     0x00010002
+/*! @brief One of the enum parameters for the function was given an invalid
+ *  enum.
+ */
+#define GLFW_INVALID_ENUM           0x00010003
+/*! @brief One of the parameters for the function was given an invalid value.
+ */
+#define GLFW_INVALID_VALUE          0x00010004
+/*! @brief A memory allocation failed.
+ */
+#define GLFW_OUT_OF_MEMORY          0x00010005
+/*! @brief GLFW could not find support for the requested client API on the
+ *  system.
+ */
+#define GLFW_API_UNAVAILABLE        0x00010006
+/*! @brief The requested client API version is not available.
+ */
+#define GLFW_VERSION_UNAVAILABLE    0x00010007
+/*! @brief A platform-specific error occurred that does not match any of the
+ *  more specific categories.
+ */
+#define GLFW_PLATFORM_ERROR         0x00010008
+/*! @brief The clipboard did not contain data in the requested format.
+ */
+#define GLFW_FORMAT_UNAVAILABLE     0x00010009
+/*! @} */
+
+#define GLFW_FOCUSED                0x00020001
+#define GLFW_ICONIFIED              0x00020002
+#define GLFW_RESIZABLE              0x00020003
+#define GLFW_VISIBLE                0x00020004
+#define GLFW_DECORATED              0x00020005
+
+#define GLFW_RED_BITS               0x00021001
+#define GLFW_GREEN_BITS             0x00021002
+#define GLFW_BLUE_BITS              0x00021003
+#define GLFW_ALPHA_BITS             0x00021004
+#define GLFW_DEPTH_BITS             0x00021005
+#define GLFW_STENCIL_BITS           0x00021006
+#define GLFW_ACCUM_RED_BITS         0x00021007
+#define GLFW_ACCUM_GREEN_BITS       0x00021008
+#define GLFW_ACCUM_BLUE_BITS        0x00021009
+#define GLFW_ACCUM_ALPHA_BITS       0x0002100A
+#define GLFW_AUX_BUFFERS            0x0002100B
+#define GLFW_STEREO                 0x0002100C
+#define GLFW_SAMPLES                0x0002100D
+#define GLFW_SRGB_CAPABLE           0x0002100E
+#define GLFW_REFRESH_RATE           0x0002100F
+
+#define GLFW_CLIENT_API             0x00022001
+#define GLFW_CONTEXT_VERSION_MAJOR  0x00022002
+#define GLFW_CONTEXT_VERSION_MINOR  0x00022003
+#define GLFW_CONTEXT_REVISION       0x00022004
+#define GLFW_CONTEXT_ROBUSTNESS     0x00022005
+#define GLFW_OPENGL_FORWARD_COMPAT  0x00022006
+#define GLFW_OPENGL_DEBUG_CONTEXT   0x00022007
+#define GLFW_OPENGL_PROFILE         0x00022008
+
+#define GLFW_OPENGL_API             0x00030001
+#define GLFW_OPENGL_ES_API          0x00030002
+
+#define GLFW_NO_ROBUSTNESS                   0
+#define GLFW_NO_RESET_NOTIFICATION  0x00031001
+#define GLFW_LOSE_CONTEXT_ON_RESET  0x00031002
+
+#define GLFW_OPENGL_ANY_PROFILE              0
+#define GLFW_OPENGL_CORE_PROFILE    0x00032001
+#define GLFW_OPENGL_COMPAT_PROFILE  0x00032002
+
+#define GLFW_CURSOR                 0x00033001
+#define GLFW_STICKY_KEYS            0x00033002
+#define GLFW_STICKY_MOUSE_BUTTONS   0x00033003
+
+#define GLFW_CURSOR_NORMAL          0x00034001
+#define GLFW_CURSOR_HIDDEN          0x00034002
+#define GLFW_CURSOR_DISABLED        0x00034003
+
+#define GLFW_CONNECTED              0x00040001
+#define GLFW_DISCONNECTED           0x00040002
+
+
+/*************************************************************************
+ * GLFW API types
+ *************************************************************************/
+
+/*! @brief Client API function pointer type.
+ *
+ *  Generic function pointer used for returning client API function pointers
+ *  without forcing a cast from a regular pointer.
+ *
+ *  @ingroup context
+ */
+typedef void (*GLFWglproc)(void);
+
+/*! @brief Opaque monitor object.
+ *
+ *  Opaque monitor object.
+ *
+ *  @ingroup monitor
+ */
+typedef struct GLFWmonitor GLFWmonitor;
+
+/*! @brief Opaque window object.
+ *
+ *  Opaque window object.
+ *
+ *  @ingroup window
+ */
+typedef struct GLFWwindow GLFWwindow;
+
+/*! @brief The function signature for error callbacks.
+ *
+ *  This is the function signature for error callback functions.
+ *
+ *  @param[in] error An [error code](@ref errors).
+ *  @param[in] description A UTF-8 encoded string describing the error.
+ *
+ *  @sa glfwSetErrorCallback
+ *
+ *  @ingroup error
+ */
+typedef void (* GLFWerrorfun)(int,const char*);
+
+/*! @brief The function signature for window position callbacks.
+ *
+ *  This is the function signature for window position callback functions.
+ *
+ *  @param[in] window The window that the user moved.
+ *  @param[in] xpos The new x-coordinate, in screen coordinates, of the
+ *  upper-left corner of the client area of the window.
+ *  @param[in] ypos The new y-coordinate, in screen coordinates, of the
+ *  upper-left corner of the client area of the window.
+ *
+ *  @sa glfwSetWindowPosCallback
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWwindowposfun)(GLFWwindow*,int,int);
+
+/*! @brief The function signature for window resize callbacks.
+ *
+ *  This is the function signature for window size callback functions.
+ *
+ *  @param[in] window The window that the user resized.
+ *  @param[in] width The new width, in screen coordinates, of the window.
+ *  @param[in] height The new height, in screen coordinates, of the window.
+ *
+ *  @sa glfwSetWindowSizeCallback
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWwindowsizefun)(GLFWwindow*,int,int);
+
+/*! @brief The function signature for window close callbacks.
+ *
+ *  This is the function signature for window close callback functions.
+ *
+ *  @param[in] window The window that the user attempted to close.
+ *
+ *  @sa glfwSetWindowCloseCallback
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWwindowclosefun)(GLFWwindow*);
+
+/*! @brief The function signature for window content refresh callbacks.
+ *
+ *  This is the function signature for window refresh callback functions.
+ *
+ *  @param[in] window The window whose content needs to be refreshed.
+ *
+ *  @sa glfwSetWindowRefreshCallback
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWwindowrefreshfun)(GLFWwindow*);
+
+/*! @brief The function signature for window focus/defocus callbacks.
+ *
+ *  This is the function signature for window focus callback functions.
+ *
+ *  @param[in] window The window that was focused or defocused.
+ *  @param[in] focused `GL_TRUE` if the window was focused, or `GL_FALSE` if
+ *  it was defocused.
+ *
+ *  @sa glfwSetWindowFocusCallback
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWwindowfocusfun)(GLFWwindow*,int);
+
+/*! @brief The function signature for window iconify/restore callbacks.
+ *
+ *  This is the function signature for window iconify/restore callback
+ *  functions.
+ *
+ *  @param[in] window The window that was iconified or restored.
+ *  @param[in] iconified `GL_TRUE` if the window was iconified, or `GL_FALSE`
+ *  if it was restored.
+ *
+ *  @sa glfwSetWindowIconifyCallback
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWwindowiconifyfun)(GLFWwindow*,int);
+
+/*! @brief The function signature for framebuffer resize callbacks.
+ *
+ *  This is the function signature for framebuffer resize callback
+ *  functions.
+ *
+ *  @param[in] window The window whose framebuffer was resized.
+ *  @param[in] width The new width, in pixels, of the framebuffer.
+ *  @param[in] height The new height, in pixels, of the framebuffer.
+ *
+ *  @sa glfwSetFramebufferSizeCallback
+ *
+ *  @ingroup window
+ */
+typedef void (* GLFWframebuffersizefun)(GLFWwindow*,int,int);
+
+/*! @brief The function signature for mouse button callbacks.
+ *
+ *  This is the function signature for mouse button callback functions.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] button The [mouse button](@ref buttons) that was pressed or
+ *  released.
+ *  @param[in] action One of `GLFW_PRESS` or `GLFW_RELEASE`.
+ *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
+ *  held down.
+ *
+ *  @sa glfwSetMouseButtonCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWmousebuttonfun)(GLFWwindow*,int,int,int);
+
+/*! @brief The function signature for cursor position callbacks.
+ *
+ *  This is the function signature for cursor position callback functions.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] xpos The new x-coordinate of the cursor.
+ *  @param[in] ypos The new y-coordinate of the cursor.
+ *
+ *  @sa glfwSetCursorPosCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWcursorposfun)(GLFWwindow*,double,double);
+
+/*! @brief The function signature for cursor enter/leave callbacks.
+ *
+ *  This is the function signature for cursor enter/leave callback functions.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] entered `GL_TRUE` if the cursor entered the window's client
+ *  area, or `GL_FALSE` if it left it.
+ *
+ *  @sa glfwSetCursorEnterCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWcursorenterfun)(GLFWwindow*,int);
+
+/*! @brief The function signature for scroll callbacks.
+ *
+ *  This is the function signature for scroll callback functions.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] xoffset The scroll offset along the x-axis.
+ *  @param[in] yoffset The scroll offset along the y-axis.
+ *
+ *  @sa glfwSetScrollCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWscrollfun)(GLFWwindow*,double,double);
+
+/*! @brief The function signature for keyboard key callbacks.
+ *
+ *  This is the function signature for keyboard key callback functions.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] key The [keyboard key](@ref keys) that was pressed or released.
+ *  @param[in] scancode The system-specific scancode of the key.
+ *  @param[in] action @ref GLFW_PRESS, @ref GLFW_RELEASE or @ref GLFW_REPEAT.
+ *  @param[in] mods Bit field describing which [modifier keys](@ref mods) were
+ *  held down.
+ *
+ *  @sa glfwSetKeyCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWkeyfun)(GLFWwindow*,int,int,int,int);
+
+/*! @brief The function signature for Unicode character callbacks.
+ *
+ *  This is the function signature for Unicode character callback functions.
+ *
+ *  @param[in] window The window that received the event.
+ *  @param[in] character The Unicode code point of the character.
+ *
+ *  @sa glfwSetCharCallback
+ *
+ *  @ingroup input
+ */
+typedef void (* GLFWcharfun)(GLFWwindow*,unsigned int);
+
+/*! @brief The function signature for monitor configuration callbacks.
+ *
+ *  This is the function signature for monitor configuration callback functions.
+ *
+ *  @param[in] monitor The monitor that was connected or disconnected.
+ *  @param[in] event One of `GLFW_CONNECTED` or `GLFW_DISCONNECTED`.
+ *
+ *  @sa glfwSetMonitorCallback
+ *
+ *  @ingroup monitor
+ */
+typedef void (* GLFWmonitorfun)(GLFWmonitor*,int);
+
+/*! @brief Video mode type.
+ *
+ *  This describes a single video mode.
+ *
+ *  @ingroup monitor
+ */
+typedef struct GLFWvidmode
+{
+    /*! The width, in screen coordinates, of the video mode.
+     */
+    int width;
+    /*! The height, in screen coordinates, of the video mode.
+     */
+    int height;
+    /*! The bit depth of the red channel of the video mode.
+     */
+    int redBits;
+    /*! The bit depth of the green channel of the video mode.
+     */
+    int greenBits;
+    /*! The bit depth of the blue channel of the video mode.
+     */
+    int blueBits;
+    /*! The refresh rate, in Hz, of the video mode.
+     */
+    int refreshRate;
+} GLFWvidmode;
+
+/*! @brief Gamma ramp.
+ *
+ *  This describes the gamma ramp for a monitor.
+ *
+ *  @sa glfwGetGammaRamp glfwSetGammaRamp
+ *
+ *  @ingroup monitor
+ */
+typedef struct GLFWgammaramp
+{
+    /*! An array of value describing the response of the red channel.
+     */
+    unsigned short* red;
+    /*! An array of value describing the response of the green channel.
+     */
+    unsigned short* green;
+    /*! An array of value describing the response of the blue channel.
+     */
+    unsigned short* blue;
+    /*! The number of elements in each array.
+     */
+    unsigned int size;
+} GLFWgammaramp;
+
+
+/*************************************************************************
+ * GLFW API functions
+ *************************************************************************/
+
+/*! @brief Initializes the GLFW library.
+ *
+ *  This function initializes the GLFW library.  Before most GLFW functions can
+ *  be used, GLFW must be initialized, and before a program terminates GLFW
+ *  should be terminated in order to free any resources allocated during or
+ *  after initialization.
+ *
+ *  If this function fails, it calls @ref glfwTerminate before returning.  If it
+ *  succeeds, you should call @ref glfwTerminate before the program exits.
+ *
+ *  Additional calls to this function after successful initialization but before
+ *  termination will succeed but will do nothing.
+ *
+ *  @return `GL_TRUE` if successful, or `GL_FALSE` if an error occurred.
+ *
+ *  @par New in GLFW 3
+ *  This function no longer registers @ref glfwTerminate with `atexit`.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @note This function may take several seconds to complete on some systems,
+ *  while on other systems it may take only a fraction of a second to complete.
+ *
+ *  @note **Mac OS X:** This function will change the current directory of the
+ *  application to the `Contents/Resources` subdirectory of the application's
+ *  bundle, if present.
+ *
+ *  @sa glfwTerminate
+ *
+ *  @ingroup init
+ */
+GLFWAPI int glfwInit(void);
+
+/*! @brief Terminates the GLFW library.
+ *
+ *  This function destroys all remaining windows, frees any allocated resources
+ *  and sets the library to an uninitialized state.  Once this is called, you
+ *  must again call @ref glfwInit successfully before you will be able to use
+ *  most GLFW functions.
+ *
+ *  If GLFW has been successfully initialized, this function should be called
+ *  before the program exits.  If initialization fails, there is no need to call
+ *  this function, as it is called by @ref glfwInit before it returns failure.
+ *
+ *  @remarks This function may be called before @ref glfwInit.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @warning No window's context may be current on another thread when this
+ *  function is called.
+ *
+ *  @sa glfwInit
+ *
+ *  @ingroup init
+ */
+GLFWAPI void glfwTerminate(void);
+
+/*! @brief Retrieves the version of the GLFW library.
+ *
+ *  This function retrieves the major, minor and revision numbers of the GLFW
+ *  library.  It is intended for when you are using GLFW as a shared library and
+ *  want to ensure that you are using the minimum required version.
+ *
+ *  @param[out] major Where to store the major version number, or `NULL`.
+ *  @param[out] minor Where to store the minor version number, or `NULL`.
+ *  @param[out] rev Where to store the revision number, or `NULL`.
+ *
+ *  @remarks This function may be called before @ref glfwInit.
+ *
+ *  @remarks This function may be called from any thread.
+ *
+ *  @sa glfwGetVersionString
+ *
+ *  @ingroup init
+ */
+GLFWAPI void glfwGetVersion(int* major, int* minor, int* rev);
+
+/*! @brief Returns a string describing the compile-time configuration.
+ *
+ *  This function returns a static string generated at compile-time according to
+ *  which configuration macros were defined.  This is intended for use when
+ *  submitting bug reports, to allow developers to see which code paths are
+ *  enabled in a binary.
+ *
+ *  The format of the string is as follows:
+ *  - The version of GLFW
+ *  - The name of the window system API
+ *  - The name of the context creation API
+ *  - Any additional options or APIs
+ *
+ *  For example, when compiling GLFW 3.0 with MinGW using the Win32 and WGL
+ *  back ends, the version string may look something like this:
+ *
+ *      3.0.0 Win32 WGL MinGW
+ *
+ *  @return The GLFW version string.
+ *
+ *  @remarks This function may be called before @ref glfwInit.
+ *
+ *  @remarks This function may be called from any thread.
+ *
+ *  @sa glfwGetVersion
+ *
+ *  @ingroup init
+ */
+GLFWAPI const char* glfwGetVersionString(void);
+
+/*! @brief Sets the error callback.
+ *
+ *  This function sets the error callback, which is called with an error code
+ *  and a human-readable description each time a GLFW error occurs.
+ *
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @remarks This function may be called before @ref glfwInit.
+ *
+ *  @note The error callback is called by the thread where the error was
+ *  generated.  If you are using GLFW from multiple threads, your error callback
+ *  needs to be written accordingly.
+ *
+ *  @note Because the description string provided to the callback may have been
+ *  generated specifically for that error, it is not guaranteed to be valid
+ *  after the callback has returned.  If you wish to use it after that, you need
+ *  to make your own copy of it before returning.
+ *
+ *  @ingroup error
+ */
+GLFWAPI GLFWerrorfun glfwSetErrorCallback(GLFWerrorfun cbfun);
+
+/*! @brief Returns the currently connected monitors.
+ *
+ *  This function returns an array of handles for all currently connected
+ *  monitors.
+ *
+ *  @param[out] count Where to store the size of the returned array.  This is
+ *  set to zero if an error occurred.
+ *  @return An array of monitor handles, or `NULL` if an error occurred.
+ *
+ *  @note The returned array is allocated and freed by GLFW.  You should not
+ *  free it yourself.
+ *
+ *  @note The returned array is valid only until the monitor configuration
+ *  changes.  See @ref glfwSetMonitorCallback to receive notifications of
+ *  configuration changes.
+ *
+ *  @sa glfwGetPrimaryMonitor
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI GLFWmonitor** glfwGetMonitors(int* count);
+
+/*! @brief Returns the primary monitor.
+ *
+ *  This function returns the primary monitor.  This is usually the monitor
+ *  where elements like the Windows task bar or the OS X menu bar is located.
+ *
+ *  @return The primary monitor, or `NULL` if an error occurred.
+ *
+ *  @sa glfwGetMonitors
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI GLFWmonitor* glfwGetPrimaryMonitor(void);
+
+/*! @brief Returns the position of the monitor's viewport on the virtual screen.
+ *
+ *  This function returns the position, in screen coordinates, of the upper-left
+ *  corner of the specified monitor.
+ *
+ *  @param[in] monitor The monitor to query.
+ *  @param[out] xpos Where to store the monitor x-coordinate, or `NULL`.
+ *  @param[out] ypos Where to store the monitor y-coordinate, or `NULL`.
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI void glfwGetMonitorPos(GLFWmonitor* monitor, int* xpos, int* ypos);
+
+/*! @brief Returns the physical size of the monitor.
+ *
+ *  This function returns the size, in millimetres, of the display area of the
+ *  specified monitor.
+ *
+ *  @param[in] monitor The monitor to query.
+ *  @param[out] width Where to store the width, in mm, of the monitor's display
+ *  area, or `NULL`.
+ *  @param[out] height Where to store the height, in mm, of the monitor's
+ *  display area, or `NULL`.
+ *
+ *  @note Some operating systems do not provide accurate information, either
+ *  because the monitor's EDID data is incorrect, or because the driver does not
+ *  report it accurately.
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI void glfwGetMonitorPhysicalSize(GLFWmonitor* monitor, int* width, int* height);
+
+/*! @brief Returns the name of the specified monitor.
+ *
+ *  This function returns a human-readable name, encoded as UTF-8, of the
+ *  specified monitor.
+ *
+ *  @param[in] monitor The monitor to query.
+ *  @return The UTF-8 encoded name of the monitor, or `NULL` if an error
+ *  occurred.
+ *
+ *  @note The returned string is allocated and freed by GLFW.  You should not
+ *  free it yourself.
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI const char* glfwGetMonitorName(GLFWmonitor* monitor);
+
+/*! @brief Sets the monitor configuration callback.
+ *
+ *  This function sets the monitor configuration callback, or removes the
+ *  currently set callback.  This is called when a monitor is connected to or
+ *  disconnected from the system.
+ *
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @bug **X11:** This callback is not yet called on monitor configuration
+ *  changes.
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI GLFWmonitorfun glfwSetMonitorCallback(GLFWmonitorfun cbfun);
+
+/*! @brief Returns the available video modes for the specified monitor.
+ *
+ *  This function returns an array of all video modes supported by the specified
+ *  monitor.  The returned array is sorted in ascending order, first by color
+ *  bit depth (the sum of all channel depths) and then by resolution area (the
+ *  product of width and height).
+ *
+ *  @param[in] monitor The monitor to query.
+ *  @param[out] count Where to store the number of video modes in the returned
+ *  array.  This is set to zero if an error occurred.
+ *  @return An array of video modes, or `NULL` if an error occurred.
+ *
+ *  @note The returned array is allocated and freed by GLFW.  You should not
+ *  free it yourself.
+ *
+ *  @note The returned array is valid only until this function is called again
+ *  for the specified monitor.
+ *
+ *  @sa glfwGetVideoMode
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI const GLFWvidmode* glfwGetVideoModes(GLFWmonitor* monitor, int* count);
+
+/*! @brief Returns the current mode of the specified monitor.
+ *
+ *  This function returns the current video mode of the specified monitor.  If
+ *  you are using a full screen window, the return value will therefore depend
+ *  on whether it is focused.
+ *
+ *  @param[in] monitor The monitor to query.
+ *  @return The current mode of the monitor, or `NULL` if an error occurred.
+ *
+ *  @note The returned struct is allocated and freed by GLFW.  You should not
+ *  free it yourself.
+ *
+ *  @sa glfwGetVideoModes
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI const GLFWvidmode* glfwGetVideoMode(GLFWmonitor* monitor);
+
+/*! @brief Generates a gamma ramp and sets it for the specified monitor.
+ *
+ *  This function generates a 256-element gamma ramp from the specified exponent
+ *  and then calls @ref glfwSetGammaRamp with it.
+ *
+ *  @param[in] monitor The monitor whose gamma ramp to set.
+ *  @param[in] gamma The desired exponent.
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI void glfwSetGamma(GLFWmonitor* monitor, float gamma);
+
+/*! @brief Retrieves the current gamma ramp for the specified monitor.
+ *
+ *  This function retrieves the current gamma ramp of the specified monitor.
+ *
+ *  @param[in] monitor The monitor to query.
+ *  @return The current gamma ramp, or `NULL` if an error occurred.
+ *
+ *  @note The value arrays of the returned ramp are allocated and freed by GLFW.
+ *  You should not free them yourself.
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI const GLFWgammaramp* glfwGetGammaRamp(GLFWmonitor* monitor);
+
+/*! @brief Sets the current gamma ramp for the specified monitor.
+ *
+ *  This function sets the current gamma ramp for the specified monitor.
+ *
+ *  @param[in] monitor The monitor whose gamma ramp to set.
+ *  @param[in] ramp The gamma ramp to use.
+ *
+ *  @note Gamma ramp sizes other than 256 are not supported by all hardware.
+ *
+ *  @ingroup monitor
+ */
+GLFWAPI void glfwSetGammaRamp(GLFWmonitor* monitor, const GLFWgammaramp* ramp);
+
+/*! @brief Resets all window hints to their default values.
+ *
+ *  This function resets all window hints to their
+ *  [default values](@ref window_hints_values).
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @sa glfwWindowHint
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwDefaultWindowHints(void);
+
+/*! @brief Sets the specified window hint to the desired value.
+ *
+ *  This function sets hints for the next call to @ref glfwCreateWindow.  The
+ *  hints, once set, retain their values until changed by a call to @ref
+ *  glfwWindowHint or @ref glfwDefaultWindowHints, or until the library is
+ *  terminated with @ref glfwTerminate.
+ *
+ *  @param[in] target The [window hint](@ref window_hints) to set.
+ *  @param[in] hint The new value of the window hint.
+ *
+ *  @par New in GLFW 3
+ *  Hints are no longer reset to their default values on window creation.  To
+ *  set default hint values, use @ref glfwDefaultWindowHints.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @sa glfwDefaultWindowHints
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwWindowHint(int target, int hint);
+
+/*! @brief Creates a window and its associated context.
+ *
+ *  This function creates a window and its associated context.  Most of the
+ *  options controlling how the window and its context should be created are
+ *  specified through @ref glfwWindowHint.
+ *
+ *  Successful creation does not change which context is current.  Before you
+ *  can use the newly created context, you need to make it current using @ref
+ *  glfwMakeContextCurrent.
+ *
+ *  Note that the created window and context may differ from what you requested,
+ *  as not all parameters and hints are
+ *  [hard constraints](@ref window_hints_hard).  This includes the size of the
+ *  window, especially for full screen windows.  To retrieve the actual
+ *  attributes of the created window and context, use queries like @ref
+ *  glfwGetWindowAttrib and @ref glfwGetWindowSize.
+ *
+ *  To create a full screen window, you need to specify the monitor to use.  If
+ *  no monitor is specified, windowed mode will be used.  Unless you have a way
+ *  for the user to choose a specific monitor, it is recommended that you pick
+ *  the primary monitor.  For more information on how to retrieve monitors, see
+ *  @ref monitor_monitors.
+ *
+ *  To create the window at a specific position, make it initially invisible
+ *  using the `GLFW_VISIBLE` window hint, set its position and then show it.
+ *
+ *  If a full screen window is active, the screensaver is prohibited from
+ *  starting.
+ *
+ *  @param[in] width The desired width, in screen coordinates, of the window.
+ *  This must be greater than zero.
+ *  @param[in] height The desired height, in screen coordinates, of the window.
+ *  This must be greater than zero.
+ *  @param[in] title The initial, UTF-8 encoded window title.
+ *  @param[in] monitor The monitor to use for full screen mode, or `NULL` to use
+ *  windowed mode.
+ *  @param[in] share The window whose context to share resources with, or `NULL`
+ *  to not share resources.
+ *  @return The handle of the created window, or `NULL` if an error occurred.
+ *
+ *  @remarks **Windows:** If the executable has an icon resource named
+ *  `GLFW_ICON,` it will be set as the icon for the window.  If no such icon is
+ *  present, the `IDI_WINLOGO` icon will be used instead.
+ *
+ *  @remarks **Mac OS X:** The GLFW window has no icon, as it is not a document
+ *  window, but the dock icon will be the same as the application bundle's icon.
+ *  Also, the first time a window is opened the menu bar is populated with
+ *  common commands like Hide, Quit and About.  The (minimal) about dialog uses
+ *  information from the application's bundle.  For more information on bundles,
+ *  see the Bundle Programming Guide provided by Apple.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @sa glfwDestroyWindow
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWwindow* glfwCreateWindow(int width, int height, const char* title, GLFWmonitor* monitor, GLFWwindow* share);
+
+/*! @brief Destroys the specified window and its context.
+ *
+ *  This function destroys the specified window and its context.  On calling
+ *  this function, no further callbacks will be called for that window.
+ *
+ *  @param[in] window The window to destroy.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @note This function may not be called from a callback.
+ *
+ *  @note If the window's context is current on the main thread, it is
+ *  detached before being destroyed.
+ *
+ *  @warning The window's context must not be current on any other thread.
+ *
+ *  @sa glfwCreateWindow
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwDestroyWindow(GLFWwindow* window);
+
+/*! @brief Checks the close flag of the specified window.
+ *
+ *  This function returns the value of the close flag of the specified window.
+ *
+ *  @param[in] window The window to query.
+ *  @return The value of the close flag.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @ingroup window
+ */
+GLFWAPI int glfwWindowShouldClose(GLFWwindow* window);
+
+/*! @brief Sets the close flag of the specified window.
+ *
+ *  This function sets the value of the close flag of the specified window.
+ *  This can be used to override the user's attempt to close the window, or
+ *  to signal that it should be closed.
+ *
+ *  @param[in] window The window whose flag to change.
+ *  @param[in] value The new value.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowShouldClose(GLFWwindow* window, int value);
+
+/*! @brief Sets the title of the specified window.
+ *
+ *  This function sets the window title, encoded as UTF-8, of the specified
+ *  window.
+ *
+ *  @param[in] window The window whose title to change.
+ *  @param[in] title The UTF-8 encoded window title.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowTitle(GLFWwindow* window, const char* title);
+
+/*! @brief Retrieves the position of the client area of the specified window.
+ *
+ *  This function retrieves the position, in screen coordinates, of the
+ *  upper-left corner of the client area of the specified window.
+ *
+ *  @param[in] window The window to query.
+ *  @param[out] xpos Where to store the x-coordinate of the upper-left corner of
+ *  the client area, or `NULL`.
+ *  @param[out] ypos Where to store the y-coordinate of the upper-left corner of
+ *  the client area, or `NULL`.
+ *
+ *  @sa glfwSetWindowPos
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwGetWindowPos(GLFWwindow* window, int* xpos, int* ypos);
+
+/*! @brief Sets the position of the client area of the specified window.
+ *
+ *  This function sets the position, in screen coordinates, of the upper-left
+ *  corner of the client area of the window.
+ *
+ *  If the specified window is a full screen window, this function does nothing.
+ *
+ *  If you wish to set an initial window position you should create a hidden
+ *  window (using @ref glfwWindowHint and `GLFW_VISIBLE`), set its position and
+ *  then show it.
+ *
+ *  @param[in] window The window to query.
+ *  @param[in] xpos The x-coordinate of the upper-left corner of the client area.
+ *  @param[in] ypos The y-coordinate of the upper-left corner of the client area.
+ *
+ *  @note It is very rarely a good idea to move an already visible window, as it
+ *  will confuse and annoy the user.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @note The window manager may put limits on what positions are allowed.
+ *
+ *  @bug **X11:** Some window managers ignore the set position of hidden (i.e.
+ *  unmapped) windows, instead placing them where it thinks is appropriate once
+ *  they are shown.
+ *
+ *  @sa glfwGetWindowPos
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowPos(GLFWwindow* window, int xpos, int ypos);
+
+/*! @brief Retrieves the size of the client area of the specified window.
+ *
+ *  This function retrieves the size, in screen coordinates, of the client area
+ *  of the specified window.
+ *
+ *  @param[in] window The window whose size to retrieve.
+ *  @param[out] width Where to store the width, in screen coordinates, of the
+ *  client area, or `NULL`.
+ *  @param[out] height Where to store the height, in screen coordinates, of the
+ *  client area, or `NULL`.
+ *
+ *  @sa glfwSetWindowSize
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwGetWindowSize(GLFWwindow* window, int* width, int* height);
+
+/*! @brief Sets the size of the client area of the specified window.
+ *
+ *  This function sets the size, in screen coordinates, of the client area of
+ *  the specified window.
+ *
+ *  For full screen windows, this function selects and switches to the resolution
+ *  closest to the specified size, without affecting the window's context.  As
+ *  the context is unaffected, the bit depths of the framebuffer remain
+ *  unchanged.
+ *
+ *  @param[in] window The window to resize.
+ *  @param[in] width The desired width of the specified window.
+ *  @param[in] height The desired height of the specified window.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @note The window manager may put limits on what window sizes are allowed.
+ *
+ *  @sa glfwGetWindowSize
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowSize(GLFWwindow* window, int width, int height);
+
+/*! @brief Retrieves the size of the framebuffer of the specified window.
+ *
+ *  This function retrieves the size, in pixels, of the framebuffer of the
+ *  specified window.
+ *
+ *  @param[in] window The window whose framebuffer to query.
+ *  @param[out] width Where to store the width, in pixels, of the framebuffer,
+ *  or `NULL`.
+ *  @param[out] height Where to store the height, in pixels, of the framebuffer,
+ *  or `NULL`.
+ *
+ *  @sa glfwSetFramebufferSizeCallback
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwGetFramebufferSize(GLFWwindow* window, int* width, int* height);
+
+/*! @brief Iconifies the specified window.
+ *
+ *  This function iconifies/minimizes the specified window, if it was previously
+ *  restored.  If it is a full screen window, the original monitor resolution is
+ *  restored until the window is restored.  If the window is already iconified,
+ *  this function does nothing.
+ *
+ *  @param[in] window The window to iconify.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @sa glfwRestoreWindow
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwIconifyWindow(GLFWwindow* window);
+
+/*! @brief Restores the specified window.
+ *
+ *  This function restores the specified window, if it was previously
+ *  iconified/minimized.  If it is a full screen window, the resolution chosen
+ *  for the window is restored on the selected monitor.  If the window is
+ *  already restored, this function does nothing.
+ *
+ *  @param[in] window The window to restore.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @sa glfwIconifyWindow
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwRestoreWindow(GLFWwindow* window);
+
+/*! @brief Makes the specified window visible.
+ *
+ *  This function makes the specified window visible, if it was previously
+ *  hidden.  If the window is already visible or is in full screen mode, this
+ *  function does nothing.
+ *
+ *  @param[in] window The window to make visible.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @sa glfwHideWindow
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwShowWindow(GLFWwindow* window);
+
+/*! @brief Hides the specified window.
+ *
+ *  This function hides the specified window, if it was previously visible.  If
+ *  the window is already hidden or is in full screen mode, this function does
+ *  nothing.
+ *
+ *  @param[in] window The window to hide.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @sa glfwShowWindow
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwHideWindow(GLFWwindow* window);
+
+/*! @brief Returns the monitor that the window uses for full screen mode.
+ *
+ *  This function returns the handle of the monitor that the specified window is
+ *  in full screen on.
+ *
+ *  @param[in] window The window to query.
+ *  @return The monitor, or `NULL` if the window is in windowed mode.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWmonitor* glfwGetWindowMonitor(GLFWwindow* window);
+
+/*! @brief Returns an attribute of the specified window.
+ *
+ *  This function returns an attribute of the specified window.  There are many
+ *  attributes, some related to the window and others to its context.
+ *
+ *  @param[in] window The window to query.
+ *  @param[in] attrib The [window attribute](@ref window_attribs) whose value to
+ *  return.
+ *  @return The value of the attribute, or zero if an error occurred.
+ *
+ *  @ingroup window
+ */
+GLFWAPI int glfwGetWindowAttrib(GLFWwindow* window, int attrib);
+
+/*! @brief Sets the user pointer of the specified window.
+ *
+ *  This function sets the user-defined pointer of the specified window.  The
+ *  current value is retained until the window is destroyed.  The initial value
+ *  is `NULL`.
+ *
+ *  @param[in] window The window whose pointer to set.
+ *  @param[in] pointer The new value.
+ *
+ *  @sa glfwGetWindowUserPointer
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwSetWindowUserPointer(GLFWwindow* window, void* pointer);
+
+/*! @brief Returns the user pointer of the specified window.
+ *
+ *  This function returns the current value of the user-defined pointer of the
+ *  specified window.  The initial value is `NULL`.
+ *
+ *  @param[in] window The window whose pointer to return.
+ *
+ *  @sa glfwSetWindowUserPointer
+ *
+ *  @ingroup window
+ */
+GLFWAPI void* glfwGetWindowUserPointer(GLFWwindow* window);
+
+/*! @brief Sets the position callback for the specified window.
+ *
+ *  This function sets the position callback of the specified window, which is
+ *  called when the window is moved.  The callback is provided with the screen
+ *  position of the upper-left corner of the client area of the window.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWwindowposfun glfwSetWindowPosCallback(GLFWwindow* window, GLFWwindowposfun cbfun);
+
+/*! @brief Sets the size callback for the specified window.
+ *
+ *  This function sets the size callback of the specified window, which is
+ *  called when the window is resized.  The callback is provided with the size,
+ *  in screen coordinates, of the client area of the window.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWwindowsizefun glfwSetWindowSizeCallback(GLFWwindow* window, GLFWwindowsizefun cbfun);
+
+/*! @brief Sets the close callback for the specified window.
+ *
+ *  This function sets the close callback of the specified window, which is
+ *  called when the user attempts to close the window, for example by clicking
+ *  the close widget in the title bar.
+ *
+ *  The close flag is set before this callback is called, but you can modify it
+ *  at any time with @ref glfwSetWindowShouldClose.
+ *
+ *  The close callback is not triggered by @ref glfwDestroyWindow.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @remarks **Mac OS X:** Selecting Quit from the application menu will
+ *  trigger the close callback for all windows.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWwindowclosefun glfwSetWindowCloseCallback(GLFWwindow* window, GLFWwindowclosefun cbfun);
+
+/*! @brief Sets the refresh callback for the specified window.
+ *
+ *  This function sets the refresh callback of the specified window, which is
+ *  called when the client area of the window needs to be redrawn, for example
+ *  if the window has been exposed after having been covered by another window.
+ *
+ *  On compositing window systems such as Aero, Compiz or Aqua, where the window
+ *  contents are saved off-screen, this callback may be called only very
+ *  infrequently or never at all.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @note On compositing window systems such as Aero, Compiz or Aqua, where the
+ *  window contents are saved off-screen, this callback may be called only very
+ *  infrequently or never at all.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWwindowrefreshfun glfwSetWindowRefreshCallback(GLFWwindow* window, GLFWwindowrefreshfun cbfun);
+
+/*! @brief Sets the focus callback for the specified window.
+ *
+ *  This function sets the focus callback of the specified window, which is
+ *  called when the window gains or loses focus.
+ *
+ *  After the focus callback is called for a window that lost focus, synthetic
+ *  key and mouse button release events will be generated for all such that had
+ *  been pressed.  For more information, see @ref glfwSetKeyCallback and @ref
+ *  glfwSetMouseButtonCallback.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWwindowfocusfun glfwSetWindowFocusCallback(GLFWwindow* window, GLFWwindowfocusfun cbfun);
+
+/*! @brief Sets the iconify callback for the specified window.
+ *
+ *  This function sets the iconification callback of the specified window, which
+ *  is called when the window is iconified or restored.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWwindowiconifyfun glfwSetWindowIconifyCallback(GLFWwindow* window, GLFWwindowiconifyfun cbfun);
+
+/*! @brief Sets the framebuffer resize callback for the specified window.
+ *
+ *  This function sets the framebuffer resize callback of the specified window,
+ *  which is called when the framebuffer of the specified window is resized.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup window
+ */
+GLFWAPI GLFWframebuffersizefun glfwSetFramebufferSizeCallback(GLFWwindow* window, GLFWframebuffersizefun cbfun);
+
+/*! @brief Processes all pending events.
+ *
+ *  This function processes only those events that have already been received
+ *  and then returns immediately.  Processing events will cause the window and
+ *  input callbacks associated with those events to be called.
+ *
+ *  This function is not required for joystick input to work.
+ *
+ *  @par New in GLFW 3
+ *  This function is no longer called by @ref glfwSwapBuffers.  You need to call
+ *  it or @ref glfwWaitEvents yourself.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @note This function may not be called from a callback.
+ *
+ *  @note On some platforms, certain callbacks may be called outside of a call
+ *  to one of the event processing functions.
+ *
+ *  @sa glfwWaitEvents
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwPollEvents(void);
+
+/*! @brief Waits until events are pending and processes them.
+ *
+ *  This function puts the calling thread to sleep until at least one event has
+ *  been received.  Once one or more events have been received, it behaves as if
+ *  @ref glfwPollEvents was called, i.e. the events are processed and the
+ *  function then returns immediately.  Processing events will cause the window
+ *  and input callbacks associated with those events to be called.
+ *
+ *  Since not all events are associated with callbacks, this function may return
+ *  without a callback having been called even if you are monitoring all
+ *  callbacks.
+ *
+ *  This function is not required for joystick input to work.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @note This function may not be called from a callback.
+ *
+ *  @note On some platforms, certain callbacks may be called outside of a call
+ *  to one of the event processing functions.
+ *
+ *  @sa glfwPollEvents
+ *
+ *  @ingroup window
+ */
+GLFWAPI void glfwWaitEvents(void);
+
+/*! @brief Returns the value of an input option for the specified window.
+ *
+ *  @param[in] window The window to query.
+ *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS` or
+ *  `GLFW_STICKY_MOUSE_BUTTONS`.
+ *
+ *  @sa glfwSetInputMode
+ *
+ *  @ingroup input
+ */
+GLFWAPI int glfwGetInputMode(GLFWwindow* window, int mode);
+
+/*! @brief Sets an input option for the specified window.
+ *  @param[in] window The window whose input mode to set.
+ *  @param[in] mode One of `GLFW_CURSOR`, `GLFW_STICKY_KEYS` or
+ *  `GLFW_STICKY_MOUSE_BUTTONS`.
+ *  @param[in] value The new value of the specified input mode.
+ *
+ *  If `mode` is `GLFW_CURSOR`, the value must be one of the supported input
+ *  modes:
+ *  - `GLFW_CURSOR_NORMAL` makes the cursor visible and behaving normally.
+ *  - `GLFW_CURSOR_HIDDEN` makes the cursor invisible when it is over the client
+ *    area of the window.
+ *  - `GLFW_CURSOR_DISABLED` disables the cursor and removes any limitations on
+ *    cursor movement.
+ *
+ *  If `mode` is `GLFW_STICKY_KEYS`, the value must be either `GL_TRUE` to
+ *  enable sticky keys, or `GL_FALSE` to disable it.  If sticky keys are
+ *  enabled, a key press will ensure that @ref glfwGetKey returns @ref
+ *  GLFW_PRESS the next time it is called even if the key had been released
+ *  before the call.  This is useful when you are only interested in whether
+ *  keys have been pressed but not when or in which order.
+ *
+ *  If `mode` is `GLFW_STICKY_MOUSE_BUTTONS`, the value must be either `GL_TRUE`
+ *  to enable sticky mouse buttons, or `GL_FALSE` to disable it.  If sticky
+ *  mouse buttons are enabled, a mouse button press will ensure that @ref
+ *  glfwGetMouseButton returns @ref GLFW_PRESS the next time it is called even
+ *  if the mouse button had been released before the call.  This is useful when
+ *  you are only interested in whether mouse buttons have been pressed but not
+ *  when or in which order.
+ *
+ *  @sa glfwGetInputMode
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwSetInputMode(GLFWwindow* window, int mode, int value);
+
+/*! @brief Returns the last reported state of a keyboard key for the specified
+ *  window.
+ *
+ *  This function returns the last state reported for the specified key to the
+ *  specified window.  The returned state is one of `GLFW_PRESS` or
+ *  `GLFW_RELEASE`.  The higher-level state `GLFW_REPEAT` is only reported to
+ *  the key callback.
+ *
+ *  If the `GLFW_STICKY_KEYS` input mode is enabled, this function returns
+ *  `GLFW_PRESS` the first time you call this function after a key has been
+ *  pressed, even if the key has already been released.
+ *
+ *  The key functions deal with physical keys, with [key tokens](@ref keys)
+ *  named after their use on the standard US keyboard layout.  If you want to
+ *  input text, use the Unicode character callback instead.
+ *
+ *  @param[in] window The desired window.
+ *  @param[in] key The desired [keyboard key](@ref keys).
+ *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
+ *
+ *  @note `GLFW_KEY_UNKNOWN` is not a valid key for this function.
+ *
+ *  @ingroup input
+ */
+GLFWAPI int glfwGetKey(GLFWwindow* window, int key);
+
+/*! @brief Returns the last reported state of a mouse button for the specified
+ *  window.
+ *
+ *  This function returns the last state reported for the specified mouse button
+ *  to the specified window.
+ *
+ *  If the `GLFW_STICKY_MOUSE_BUTTONS` input mode is enabled, this function
+ *  returns `GLFW_PRESS` the first time you call this function after a mouse
+ *  button has been pressed, even if the mouse button has already been released.
+ *
+ *  @param[in] window The desired window.
+ *  @param[in] button The desired [mouse button](@ref buttons).
+ *  @return One of `GLFW_PRESS` or `GLFW_RELEASE`.
+ *
+ *  @ingroup input
+ */
+GLFWAPI int glfwGetMouseButton(GLFWwindow* window, int button);
+
+/*! @brief Retrieves the last reported cursor position, relative to the client
+ *  area of the window.
+ *
+ *  This function returns the last reported position of the cursor to the
+ *  specified window.
+ *
+ *  If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
+ *  position is unbounded and limited only by the minimum and maximum values of
+ *  a `double`.
+ *
+ *  The coordinate can be converted to their integer equivalents with the
+ *  `floor` function.  Casting directly to an integer type works for positive
+ *  coordinates, but fails for negative ones.
+ *
+ *  @param[in] window The desired window.
+ *  @param[out] xpos Where to store the cursor x-coordinate, relative to the
+ *  left edge of the client area, or `NULL`.
+ *  @param[out] ypos Where to store the cursor y-coordinate, relative to the to
+ *  top edge of the client area, or `NULL`.
+ *
+ *  @sa glfwSetCursorPos
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwGetCursorPos(GLFWwindow* window, double* xpos, double* ypos);
+
+/*! @brief Sets the position of the cursor, relative to the client area of the window.
+ *
+ *  This function sets the position of the cursor.  The specified window must be
+ *  focused.  If the window does not have focus when this function is called, it
+ *  fails silently.
+ *
+ *  If the cursor is disabled (with `GLFW_CURSOR_DISABLED`) then the cursor
+ *  position is unbounded and limited only by the minimum and maximum values of
+ *  a `double`.
+ *
+ *  @param[in] window The desired window.
+ *  @param[in] xpos The desired x-coordinate, relative to the left edge of the
+ *  client area.
+ *  @param[in] ypos The desired y-coordinate, relative to the top edge of the
+ *  client area.
+ *
+ *  @sa glfwGetCursorPos
+ *
+ *  @ingroup input
+ */
+GLFWAPI void glfwSetCursorPos(GLFWwindow* window, double xpos, double ypos);
+
+/*! @brief Sets the key callback.
+ *
+ *  This function sets the key callback of the specific window, which is called
+ *  when a key is pressed, repeated or released.
+ *
+ *  The key functions deal with physical keys, with layout independent
+ *  [key tokens](@ref keys) named after their values in the standard US keyboard
+ *  layout.  If you want to input text, use the
+ *  [character callback](@ref glfwSetCharCallback) instead.
+ *
+ *  When a window loses focus, it will generate synthetic key release events
+ *  for all pressed keys.  You can tell these events from user-generated events
+ *  by the fact that the synthetic ones are generated after the window has lost
+ *  focus, i.e. `GLFW_FOCUSED` will be false and the focus callback will have
+ *  already been called.
+ *
+ *  The scancode of a key is specific to that platform or sometimes even to that
+ *  machine.  Scancodes are intended to allow users to bind keys that don't have
+ *  a GLFW key token.  Such keys have `key` set to `GLFW_KEY_UNKNOWN`, their
+ *  state is not saved and so it cannot be retrieved with @ref glfwGetKey.
+ *
+ *  Sometimes GLFW needs to generate synthetic key events, in which case the
+ *  scancode may be zero.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new key callback, or `NULL` to remove the currently
+ *  set callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWkeyfun glfwSetKeyCallback(GLFWwindow* window, GLFWkeyfun cbfun);
+
+/*! @brief Sets the Unicode character callback.
+ *
+ *  This function sets the character callback of the specific window, which is
+ *  called when a Unicode character is input.
+ *
+ *  The character callback is intended for text input.  If you want to know
+ *  whether a specific key was pressed or released, use the
+ *  [key callback](@ref glfwSetKeyCallback) instead.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWcharfun glfwSetCharCallback(GLFWwindow* window, GLFWcharfun cbfun);
+
+/*! @brief Sets the mouse button callback.
+ *
+ *  This function sets the mouse button callback of the specified window, which
+ *  is called when a mouse button is pressed or released.
+ *
+ *  When a window loses focus, it will generate synthetic mouse button release
+ *  events for all pressed mouse buttons.  You can tell these events from
+ *  user-generated events by the fact that the synthetic ones are generated
+ *  after the window has lost focus, i.e. `GLFW_FOCUSED` will be false and the
+ *  focus callback will have already been called.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWmousebuttonfun glfwSetMouseButtonCallback(GLFWwindow* window, GLFWmousebuttonfun cbfun);
+
+/*! @brief Sets the cursor position callback.
+ *
+ *  This function sets the cursor position callback of the specified window,
+ *  which is called when the cursor is moved.  The callback is provided with the
+ *  position relative to the upper-left corner of the client area of the window.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWcursorposfun glfwSetCursorPosCallback(GLFWwindow* window, GLFWcursorposfun cbfun);
+
+/*! @brief Sets the cursor enter/exit callback.
+ *
+ *  This function sets the cursor boundary crossing callback of the specified
+ *  window, which is called when the cursor enters or leaves the client area of
+ *  the window.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new callback, or `NULL` to remove the currently set
+ *  callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWcursorenterfun glfwSetCursorEnterCallback(GLFWwindow* window, GLFWcursorenterfun cbfun);
+
+/*! @brief Sets the scroll callback.
+ *
+ *  This function sets the scroll callback of the specified window, which is
+ *  called when a scrolling device is used, such as a mouse wheel or scrolling
+ *  area of a touchpad.
+ *
+ *  The scroll callback receives all scrolling input, like that from a mouse
+ *  wheel or a touchpad scrolling area.
+ *
+ *  @param[in] window The window whose callback to set.
+ *  @param[in] cbfun The new scroll callback, or `NULL` to remove the currently
+ *  set callback.
+ *  @return The previously set callback, or `NULL` if no callback was set or an
+ *  error occurred.
+ *
+ *  @ingroup input
+ */
+GLFWAPI GLFWscrollfun glfwSetScrollCallback(GLFWwindow* window, GLFWscrollfun cbfun);
+
+/*! @brief Returns whether the specified joystick is present.
+ *
+ *  This function returns whether the specified joystick is present.
+ *
+ *  @param[in] joy The joystick to query.
+ *  @return `GL_TRUE` if the joystick is present, or `GL_FALSE` otherwise.
+ *
+ *  @ingroup input
+ */
+GLFWAPI int glfwJoystickPresent(int joy);
+
+/*! @brief Returns the values of all axes of the specified joystick.
+ *
+ *  This function returns the values of all axes of the specified joystick.
+ *
+ *  @param[in] joy The joystick to query.
+ *  @param[out] count Where to store the size of the returned array.  This is
+ *  set to zero if an error occurred.
+ *  @return An array of axis values, or `NULL` if the joystick is not present.
+ *
+ *  @note The returned array is allocated and freed by GLFW.  You should not
+ *  free it yourself.
+ *
+ *  @note The returned array is valid only until the next call to @ref
+ *  glfwGetJoystickAxes for that joystick.
+ *
+ *  @ingroup input
+ */
+GLFWAPI const float* glfwGetJoystickAxes(int joy, int* count);
+
+/*! @brief Returns the state of all buttons of the specified joystick.
+ *
+ *  This function returns the state of all buttons of the specified joystick.
+ *
+ *  @param[in] joy The joystick to query.
+ *  @param[out] count Where to store the size of the returned array.  This is
+ *  set to zero if an error occurred.
+ *  @return An array of button states, or `NULL` if the joystick is not present.
+ *
+ *  @note The returned array is allocated and freed by GLFW.  You should not
+ *  free it yourself.
+ *
+ *  @note The returned array is valid only until the next call to @ref
+ *  glfwGetJoystickButtons for that joystick.
+ *
+ *  @ingroup input
+ */
+GLFWAPI const unsigned char* glfwGetJoystickButtons(int joy, int* count);
+
+/*! @brief Returns the name of the specified joystick.
+ *
+ *  This function returns the name, encoded as UTF-8, of the specified joystick.
+ *
+ *  @param[in] joy The joystick to query.
+ *  @return The UTF-8 encoded name of the joystick, or `NULL` if the joystick
+ *  is not present.
+ *
+ *  @note The returned string is allocated and freed by GLFW.  You should not
+ *  free it yourself.
+ *
+ *  @note The returned string is valid only until the next call to @ref
+ *  glfwGetJoystickName for that joystick.
+ *
+ *  @ingroup input
+ */
+GLFWAPI const char* glfwGetJoystickName(int joy);
+
+/*! @brief Sets the clipboard to the specified string.
+ *
+ *  This function sets the system clipboard to the specified, UTF-8 encoded
+ *  string.  The string is copied before returning, so you don't have to retain
+ *  it afterwards.
+ *
+ *  @param[in] window The window that will own the clipboard contents.
+ *  @param[in] string A UTF-8 encoded string.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @sa glfwGetClipboardString
+ *
+ *  @ingroup clipboard
+ */
+GLFWAPI void glfwSetClipboardString(GLFWwindow* window, const char* string);
+
+/*! @brief Retrieves the contents of the clipboard as a string.
+ *
+ *  This function returns the contents of the system clipboard, if it contains
+ *  or is convertible to a UTF-8 encoded string.
+ *
+ *  @param[in] window The window that will request the clipboard contents.
+ *  @return The contents of the clipboard as a UTF-8 encoded string, or `NULL`
+ *  if an error occurred.
+ *
+ *  @note This function may only be called from the main thread.
+ *
+ *  @note The returned string is allocated and freed by GLFW.  You should not
+ *  free it yourself.
+ *
+ *  @note The returned string is valid only until the next call to @ref
+ *  glfwGetClipboardString or @ref glfwSetClipboardString.
+ *
+ *  @sa glfwSetClipboardString
+ *
+ *  @ingroup clipboard
+ */
+GLFWAPI const char* glfwGetClipboardString(GLFWwindow* window);
+
+/*! @brief Returns the value of the GLFW timer.
+ *
+ *  This function returns the value of the GLFW timer.  Unless the timer has
+ *  been set using @ref glfwSetTime, the timer measures time elapsed since GLFW
+ *  was initialized.
+ *
+ *  @return The current value, in seconds, or zero if an error occurred.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @note The resolution of the timer is system dependent, but is usually on the
+ *  order of a few micro- or nanoseconds.  It uses the highest-resolution
+ *  monotonic time source on each supported platform.
+ *
+ *  @ingroup time
+ */
+GLFWAPI double glfwGetTime(void);
+
+/*! @brief Sets the GLFW timer.
+ *
+ *  This function sets the value of the GLFW timer.  It then continues to count
+ *  up from that value.
+ *
+ *  @param[in] time The new value, in seconds.
+ *
+ *  @note The resolution of the timer is system dependent, but is usually on the
+ *  order of a few micro- or nanoseconds.  It uses the highest-resolution
+ *  monotonic time source on each supported platform.
+ *
+ *  @ingroup time
+ */
+GLFWAPI void glfwSetTime(double time);
+
+/*! @brief Makes the context of the specified window current for the calling
+ *  thread.
+ *
+ *  This function makes the context of the specified window current on the
+ *  calling thread.  A context can only be made current on a single thread at
+ *  a time and each thread can have only a single current context at a time.
+ *
+ *  @param[in] window The window whose context to make current, or `NULL` to
+ *  detach the current context.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @sa glfwGetCurrentContext
+ *
+ *  @ingroup context
+ */
+GLFWAPI void glfwMakeContextCurrent(GLFWwindow* window);
+
+/*! @brief Returns the window whose context is current on the calling thread.
+ *
+ *  This function returns the window whose context is current on the calling
+ *  thread.
+ *
+ *  @return The window whose context is current, or `NULL` if no window's
+ *  context is current.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @sa glfwMakeContextCurrent
+ *
+ *  @ingroup context
+ */
+GLFWAPI GLFWwindow* glfwGetCurrentContext(void);
+
+/*! @brief Swaps the front and back buffers of the specified window.
+ *
+ *  This function swaps the front and back buffers of the specified window.  If
+ *  the swap interval is greater than zero, the GPU driver waits the specified
+ *  number of screen updates before swapping the buffers.
+ *
+ *  @param[in] window The window whose buffers to swap.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @par New in GLFW 3
+ *  This function no longer calls @ref glfwPollEvents.  You need to call it or
+ *  @ref glfwWaitEvents yourself.
+ *
+ *  @sa glfwSwapInterval
+ *
+ *  @ingroup context
+ */
+GLFWAPI void glfwSwapBuffers(GLFWwindow* window);
+
+/*! @brief Sets the swap interval for the current context.
+ *
+ *  This function sets the swap interval for the current context, i.e. the
+ *  number of screen updates to wait before swapping the buffers of a window and
+ *  returning from @ref glfwSwapBuffers.  This is sometimes called 'vertical
+ *  synchronization', 'vertical retrace synchronization' or 'vsync'.
+ *
+ *  Contexts that support either of the `WGL_EXT_swap_control_tear` and
+ *  `GLX_EXT_swap_control_tear` extensions also accept negative swap intervals,
+ *  which allow the driver to swap even if a frame arrives a little bit late.
+ *  You can check for the presence of these extensions using @ref
+ *  glfwExtensionSupported.  For more information about swap tearing, see the
+ *  extension specifications.
+ *
+ *  @param[in] interval The minimum number of screen updates to wait for
+ *  until the buffers are swapped by @ref glfwSwapBuffers.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @note Some GPU drivers do not honor the requested swap interval, either
+ *  because of user settings that override the request or due to bugs in the
+ *  driver.
+ *
+ *  @sa glfwSwapBuffers
+ *
+ *  @ingroup context
+ */
+GLFWAPI void glfwSwapInterval(int interval);
+
+/*! @brief Returns whether the specified extension is available.
+ *
+ *  This function returns whether the specified
+ *  [OpenGL or context creation API extension](@ref context_glext) is supported
+ *  by the current context.  For example, on Windows both the OpenGL and WGL
+ *  extension strings are checked.
+ *
+ *  @param[in] extension The ASCII encoded name of the extension.
+ *  @return `GL_TRUE` if the extension is available, or `GL_FALSE` otherwise.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @note As this functions searches one or more extension strings on each call,
+ *  it is recommended that you cache its results if it's going to be used
+ *  frequently.  The extension strings will not change during the lifetime of
+ *  a context, so there is no danger in doing this.
+ *
+ *  @ingroup context
+ */
+GLFWAPI int glfwExtensionSupported(const char* extension);
+
+/*! @brief Returns the address of the specified function for the current
+ *  context.
+ *
+ *  This function returns the address of the specified
+ *  [client API or extension function](@ref context_glext), if it is supported
+ *  by the current context.
+ *
+ *  @param[in] procname The ASCII encoded name of the function.
+ *  @return The address of the function, or `NULL` if the function is
+ *  unavailable.
+ *
+ *  @remarks This function may be called from secondary threads.
+ *
+ *  @note The addresses of these functions are not guaranteed to be the same for
+ *  all contexts, especially if they use different client APIs or even different
+ *  context creation hints.
+ *
+ *  @ingroup context
+ */
+GLFWAPI GLFWglproc glfwGetProcAddress(const char* procname);
+
+
+/*************************************************************************
+ * Global definition cleanup
+ *************************************************************************/
+
+/* ------------------- BEGIN SYSTEM/COMPILER SPECIFIC -------------------- */
+
+#ifdef GLFW_WINGDIAPI_DEFINED
+ #undef WINGDIAPI
+ #undef GLFW_WINGDIAPI_DEFINED
+#endif
+
+#ifdef GLFW_CALLBACK_DEFINED
+ #undef CALLBACK
+ #undef GLFW_CALLBACK_DEFINED
+#endif
+
+/* -------------------- END SYSTEM/COMPILER SPECIFIC --------------------- */
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _glfw3_h_ */
+

--- a/tests/glfw3.c
+++ b/tests/glfw3.c
@@ -1,0 +1,191 @@
+#include <GLFW/glfw3.h>
+#include <stdio.h>
+#include <assert.h>
+#include <string.h>
+
+static void errorcb(int error, const char *msg) { (void)error; (void)msg; }
+static void monitcb(GLFWmonitor *monitor, int event) { assert(monitor != NULL); (void)event; }
+static void wposicb(GLFWwindow *window, int x, int y) { assert(window != NULL); (void)x; (void)y; }
+static void wsizecb(GLFWwindow *window, int w, int h) { assert(window != NULL); (void)w; (void)h; }
+static void wcloscb(GLFWwindow *window) { assert(window != NULL); }
+static void wrfrscb(GLFWwindow *window) { assert(window != NULL); }
+static void wfocucb(GLFWwindow *window, int focused) { assert(window != NULL); (void)focused; }
+static void wiconcb(GLFWwindow *window, int iconified) { assert(window != NULL); (void)iconified; }
+static void wfsizcb(GLFWwindow *window, int w, int h) { assert(window != NULL); (void)w; (void)h; }
+static void wkeypcb(GLFWwindow *window, int key, int scancode, int action, int mods) {
+    assert(window != NULL); (void)key; (void)scancode; (void)action; (void)mods;
+}
+static void wcharcb(GLFWwindow *window, unsigned int cp) { assert(window != NULL); (void)cp; }
+static void wmbutcb(GLFWwindow *window, int button, int action, int mods) {
+    assert(window != NULL); (void)button; (void)action; (void)mods;
+}
+static void wcurpcb(GLFWwindow *window, double x, double y) { assert(window != NULL); (void)x; (void)y; }
+static void wcurecb(GLFWwindow *window, int entered) { assert(window != NULL); (void)entered; }
+static void wscrocb(GLFWwindow *window, double x, double y) { assert(window != NULL); (void)x; (void)y; }
+
+int main()
+{
+    GLFWwindow *window;
+    char *userptr = "userptr";
+
+    glfwSetErrorCallback(errorcb);
+    assert(glfwInit() == GL_TRUE);
+    assert(!strcmp(glfwGetVersionString(), "3.0.0 JS WebGL Emscripten"));
+
+    {
+        int major, minor, rev;
+        glfwGetVersion(&major, &minor, &rev);
+        assert(major == 3);
+        assert(minor == 0);
+        assert(rev == 0);
+    }
+
+    {
+        int count, x, y, w, h;
+        GLFWmonitor **monitors = glfwGetMonitors(&count);
+        assert(count == 1);
+        for (int i = 0; i < count; ++i) {
+            assert(monitors[i] != NULL);
+        }
+
+        assert(glfwGetPrimaryMonitor() != NULL);
+        glfwGetMonitorPos(monitors[0], &x, &y);
+        glfwGetMonitorPhysicalSize(monitors[0], &w, &h);
+        assert(glfwGetMonitorName(monitors[0]) != NULL);
+        glfwSetMonitorCallback(monitcb);
+
+        // XXX: not implemented
+        // assert(glfwGetVideoModes(monitors[0], &count) != NULL);
+        // assert(glfwGetVideoMode(monitors[0]) != NULL);
+        // glfwSetGamma(monitors[0], 1.0f);
+        // assert(glfwGetGammaRamp(monitors[0]) != NULL);
+        // glfwSetGammaRamp(monitors[0], ramp);
+    }
+
+    {
+        int x, y, w, h;
+        glfwDefaultWindowHints();
+        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+
+        window = glfwCreateWindow(640, 480, "glfw3.c", NULL, NULL);
+        assert(window != NULL);
+
+        glfwSetWindowPosCallback(window, wposicb);
+        glfwSetWindowSizeCallback(window, wsizecb);
+        glfwSetWindowCloseCallback(window, wcloscb);
+        glfwSetWindowRefreshCallback(window, wrfrscb);
+        glfwSetWindowFocusCallback(window, wfocucb);
+        glfwSetWindowIconifyCallback(window, wiconcb);
+        glfwSetFramebufferSizeCallback(window, wfsizcb);
+
+        assert(glfwWindowShouldClose(window) == 0);
+        glfwSetWindowShouldClose(window, 1);
+        assert(glfwWindowShouldClose(window) == 1);
+
+        glfwSetWindowTitle(window, "test");
+        glfwSetWindowTitle(window, "glfw3.c");
+
+        // XXX: not implemented
+        // glfwSetWindowPos(window, 1, 1);
+
+        glfwGetWindowPos(window, &x, &y); // stub
+        glfwGetWindowSize(window, &w, &h);
+        assert(w == 640 && h == 480);
+
+        glfwSetWindowSize(window, 1, 1);
+        glfwGetWindowSize(window, &w, &h);
+        assert(w == 1 && h == 1);
+
+        glfwSetWindowSize(window, 640, 480);
+        glfwGetFramebufferSize(window, &w, &h);
+
+        // XXX: not implemented
+        // glfwIconifyWindow(window);
+        // glfwRestoreWindow(window);
+        // glfwShowWindow(window);
+        // glfwHideWindow(window);
+
+        assert(glfwGetWindowMonitor(window) == NULL);
+        glfwDestroyWindow(window);
+
+        window = glfwCreateWindow(640, 480, "glfw3.c", glfwGetPrimaryMonitor(), NULL);
+        assert(window != NULL);
+        assert(glfwGetWindowMonitor(window) == glfwGetPrimaryMonitor());
+        glfwDestroyWindow(window);
+
+        window = glfwCreateWindow(640, 480, "glfw3.c", NULL, NULL);
+        assert(window != NULL);
+
+        assert(glfwGetWindowAttrib(window, GLFW_CLIENT_API) == GLFW_OPENGL_ES_API);
+
+        assert(glfwGetWindowUserPointer(window) == NULL);
+        glfwSetWindowUserPointer(window, userptr);
+        assert(glfwGetWindowUserPointer(window) == userptr);
+    }
+
+    {
+        double x, y;
+
+        glfwSetKeyCallback(window, wkeypcb);
+        glfwSetCharCallback(window, wcharcb);
+        glfwSetMouseButtonCallback(window, wmbutcb);
+        glfwSetCursorPosCallback(window, wcurpcb);
+        glfwSetCursorEnterCallback(window, wcurecb);
+        glfwSetScrollCallback(window, wscrocb);
+
+        // XXX: stub, events come immediatly
+        // glfwPollEvents();
+        // glfwWaitEvents();
+
+        assert(glfwGetInputMode(window, GLFW_CURSOR) == GLFW_CURSOR_NORMAL);
+
+        // XXX: not implemented
+        // glfwSetInputMode(window, GLFW_CURSOR, GLFW_CURSOR_HIDDEN);
+
+        glfwGetKey(window, GLFW_KEY_A);
+        glfwGetMouseButton(window, 0);
+        glfwGetCursorPos(window, &x, &y);
+
+        // XXX: not implemented
+        // glfwSetCursorPos(window, 0, 0);
+    }
+
+    {
+        // XXX: not implemented
+        // glfwJoystickPresent(joy);
+        // glfwGetJoystickAxes(joy, &count);
+        // glfwGetJoystickButtons(joy, &count);
+        // glfwGetJoystickName(joy);
+    }
+
+    {
+        // XXX: not implemented
+        // glfwSetClipboardString(window, "string");
+        // glfwGetClipboardString(window);
+    }
+
+    {
+        glfwGetTime();
+        glfwSetTime(0);
+    }
+
+    {
+        glfwMakeContextCurrent(window); // stub
+        assert(glfwGetCurrentContext() == window);
+        glfwSwapBuffers(window); // stub
+        glfwSwapInterval(0); // stub
+    }
+
+    {
+        assert(glfwExtensionSupported("nonexistant") == 0);
+        assert(glfwGetProcAddress("nonexistant") == NULL);
+    }
+
+    glfwTerminate();
+
+#ifdef REPORT_RESULT
+    int result = 1;
+    REPORT_RESULT();
+#endif
+    return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1228,6 +1228,7 @@ keydown(100);keyup(100); // trigger the end
 
   def test_glfw(self):
     self.btest('glfw.c', '1', args=['-s', 'LEGACY_GL_EMULATION=1'])
+    self.btest('glfw.c', '1', args=['-s', 'LEGACY_GL_EMULATION=1', '-s', 'USE_GLFW=2'])
 
   def test_egl(self):
     open(os.path.join(self.get_dir(), 'test_egl.c'), 'w').write(self.with_report_result(open(path_from_root('tests', 'test_egl.c')).read()))
@@ -2023,3 +2024,5 @@ open(filename, 'w').write(replaced)
     shutil.move('test.data', os.path.join('sub', 'test.data'))
     self.run_browser('page.html', None, '/report_result?1')
 
+  def test_glfw3(self):
+    self.btest(path_from_root('tests', 'glfw3.c'), args=['-s', 'LEGACY_GL_EMULATION=1', '-s', 'USE_GLFW=3'], expected='1')


### PR DESCRIPTION
Includes library_glfw3.js, providing most of the features in GLFW 3.0.

What it does:
- Creates a GL context.
- Manage keyboard and mouse events.
- GL Extensions support.

What it does not but should probably do:
- Transmit events when glfwPollEvents, glfwWaitEvents or glfwSwapBuffers
  is called. Events callbacks are called as soon as event are received.
- Joystick support.
- Input modes.
- Gamma ramps.
- Video modes.
- Monitors.
- Clipboard (not possible from javascript?)
- Multiple windows
- Error codes && messages through callback

Tests ran:
- tests/runner.py browser

Real world example using this code can be found here:
http://cloudef.pw/glhck
