### PR TITLE
Fix NaN Canoicalization Issue for SIMD Bitcasts

### DIFF
--- a/src/simd.js
+++ b/src/simd.js
@@ -16,6 +16,8 @@
   2. Altered source versions must be plainly marked as such, and must not be
      misrepresented as being the original software.
   3. This notice may not be removed or altered from any source distribution.
+
+  https://github.com/johnmccutchan/ecmascript_simd/blob/master/src/ecmascript_simd.js
 */
 
 "use strict";


### PR DESCRIPTION
Fix for continued discussion on https://github.com/kripken/emscripten/pull/1757

Btw,

1) I don't expect simd.js to change rapidly, but should we continue manually pull changes into Emscripten rather than using git submodules?

2) It'll be helpful in tests/runner.py to print out the js engine that it's running the test with.

3) It'll be helpful in tests/runner.py to print a message telling the user that v8 cannot be used instead of giving a mysterious message saying no available js engines when the user specified v8 in ~/.emscripten.

Thanks!!
