### PR TITLE
Handle negative zero values correctly.

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -229,6 +229,9 @@ function JSify(data, functionsOnly, givenFunctions) {
 
   function parseConst(value, type, ident) {
     var constant = makeConst(value, type);
+    // Sadly, we've thrown away type information in makeConst, so we're not
+    // passing correct type info to parseNumerical which works around this
+    // lack.
     constant = flatten(constant).map(function(x) { return parseNumerical(x) })
     return constant;
   }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -956,8 +956,11 @@ function parseNumerical(value, type) {
   }
   if (isNumber(value)) {
     var ret = parseFloat(value); // will change e.g. 5.000000e+01 to 50
-    if (type === 'double' || type === 'float') {
-      if (value[0] === '-' && ret === 0) return '-.0'; // fix negative 0, toString makes it 0
+    // type may be undefined here, like when this is called from makeConst with a single argument.
+    // but if it is a number, then we can safely assume that this should handle negative zeros
+    // correctly.
+    if (type === undefined || type === 'double' || type === 'float') {
+      if (value[0] === '-' && ret === 0) { return '-.0'; } // fix negative 0, toString makes it 0
       if (!RUNNING_JS_OPTS) ret = asmEnsureFloat(ret, type);
     }
     return ret.toString();

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -961,6 +961,46 @@ nada
 -0.00, -0.00 ==> -0.00
 ''')
 
+  def test_literal_negative_zero(self):
+    src = r'''
+      #include <stdio.h>
+      #include <math.h>
+
+      static float XXXf = -0.0f;
+      static double XXXd = -0.0;
+
+      struct x {
+        float f;
+        double d;
+      };
+
+      static struct x xx[] = {
+        -0x0p+0,
+        -0x0p+0,
+      };
+
+      int main(int argc, char ** argv) {
+        float YYYf = -0.0f;
+        float YYYd = -0.0;
+
+        printf("\n");
+        printf("%.2f\n", XXXf);
+        printf("%.2f\n", XXXd);
+        printf("%.2f\n", YYYf);
+        printf("%.2f\n", YYYd);
+        printf("%.2f\n", xx->f);
+        printf("%.2f\n", xx->d);
+      }
+    '''
+    self.do_run(src, '''
+-0.00
+-0.00
+-0.00
+-0.00
+-0.00
+-0.00
+''')
+
   def test_llvm_intrinsics(self):
     if self.emcc_args == None: return self.skip('needs ta2')
 


### PR DESCRIPTION
This handles the situation when they're part of a global variable
whether it just be a float/double or embedded within a struct.

Fixes #1898.
