### PR TITLE
Add support for WebGL hardware instancing through extension ANGLE_instanced_arrays

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -4989,6 +4989,18 @@ var LibraryGL = {
     GL.instancedArraysExt.drawElementsInstancedANGLE(mode, count, type, indices, primcount);
   },
   
+  // OpenGL Desktop/ES 2.0 instancing extensions compatibility
+  
+  glVertexAttribDivisorNV: 'glVertexAttribDivisor',
+  glDrawArraysInstancedNV: 'glDrawArraysInstanced',
+  glDrawElementsInstancedNV: 'glDrawElementsInstanced',
+  glVertexAttribDivisorEXT: 'glVertexAttribDivisor',
+  glDrawArraysInstancedEXT: 'glDrawArraysInstanced',
+  glDrawElementsInstancedEXT: 'glDrawElementsInstanced',
+  glVertexAttribDivisorARB: 'glVertexAttribDivisor',
+  glDrawArraysInstancedARB: 'glDrawArraysInstanced',
+  glDrawElementsInstancedARB: 'glDrawElementsInstanced',
+  
   // signatures of simple pass-through functions, see later
 
   glActiveTexture__sig: 'vi',


### PR DESCRIPTION
That pull request adds WebGL hardware instancing support recently exposed
through the ANGLE_instanced_arrays extension. It is available since Firefox 26
and Google Chrome 30.
