### PR TITLE
Implement command line passing to work to emrun when --emrun is passed.

### DIFF
--- a/emcc
+++ b/emcc
@@ -990,6 +990,7 @@ try:
     newargs = newargs + [default_cxx_std]
 
   if emrun:
+    pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
     post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
 
   if js_opts is None: js_opts = opt_level >= 2

--- a/src/emrun_prejs.js
+++ b/src/emrun_prejs.js
@@ -1,0 +1,5 @@
+// Route URL GET parameters to argc+argv
+Module['arguments'] = window.location.search.substr(1).trim().split('&');
+// If no args were passed arguments = [''], in which case kill the single empty string.
+if (!Module['arguments'][0])
+  Module['arguments'] = [];

--- a/tests/hello_world_exit.c
+++ b/tests/hello_world_exit.c
@@ -1,7 +1,13 @@
 #include<stdio.h>
 #include<stdlib.h>
 
-int main() {
+int main(int argc, char **argv) {
+  printf("argc: %d\n", argc);
+  for(int i = 0; i < argc; ++i) {
+    printf("argv[%d]: %s\n", i, argv[i]);
+  }
+  if (argc <= 1)
+    exit(1);
   printf("hello, world!\n");
   fprintf(stderr, "hello, error stream!\n");
   exit(100);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1697,8 +1697,10 @@ keydown(100);keyup(100); // trigger the end
     # and the browser will not close as part of the test, pinning down the cwd on Windows and it wouldn't be possible to delete it. Therefore switch away from that directory
     # before launching.
     os.chdir(path_from_root())
-    process = subprocess.Popen([PYTHON, path_from_root('emrun'), '--timeout', '30', '--verbose', os.path.join(outdir, 'hello_world.html')], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    process = subprocess.Popen([PYTHON, path_from_root('emrun'), '--timeout', '30', '--verbose', os.path.join(outdir, 'hello_world.html'), '1', '2', '3'], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     (stdout, stderr) = process.communicate()
     assert process.returncode == 100
+    assert 'argc: 4' in stdout
+    assert 'argv[3]: 3' in stdout
     assert 'hello, world!' in stdout
     assert 'hello, error stream!' in stderr


### PR DESCRIPTION
This commit adds support to emrun to pass

'emrun filename.html arg1 arg2 arg3'

which will spawn the URL

'http://localhost:6931/filename.html?arg1&arg2&arg3'

which will get routed to Module['arguments'], so that the application main() will then receive the arguments in argc and argv when built with --emrun.
