### PR TITLE
Added workaround for window.scrollX compat.

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -479,16 +479,16 @@ mergeInto(LibraryManager.library, {
         var rect = Module["canvas"].getBoundingClientRect();
         var x, y;
         
-        //Neither .scrollX or .pageXOffset are defined in a spec, but
-        //we prefer .scrollX because it is currently in a spec draft.
-        //(see: http://www.w3.org/TR/2013/WD-cssom-view-20131217/)
+        // Neither .scrollX or .pageXOffset are defined in a spec, but
+        // we prefer .scrollX because it is currently in a spec draft.
+        // (see: http://www.w3.org/TR/2013/WD-cssom-view-20131217/)
         var scrollX = ((typeof window.scrollX !== 'undefined') ? window.scrollX : window.pageXOffset);
         var scrollY = ((typeof window.scrollY !== 'undefined') ? window.scrollY : window.pageYOffset);
-        #if ASSERTIONS
-        //If this assert lands, it's likely because the browser doesn't support scrollX or pageXOffset
-        //and we have no viable fallback.
+#if ASSERTIONS
+        // If this assert lands, it's likely because the browser doesn't support scrollX or pageXOffset
+        // and we have no viable fallback.
         assert((typeof scrollX !== 'undefined') && (typeof scrollY !== 'undefined'), 'Unable to retrieve scroll position, mouse positions likely broken.');
-        #endif
+#endif
         if (event.type == 'touchstart' ||
             event.type == 'touchend' ||
             event.type == 'touchmove') {


### PR DESCRIPTION
window.scrollX/Y is not available in IE11. As far as specifications go, is currently only specified in draft (http://dev.w3.org/csswg/cssom-view/#refsCSSOM). Falling back to 
window.pageXOffset seems like a good workaround.

On a related note; my Emscriptified project runs on IE11 although performance is very poor (mostly due to Internet Explorer itself, I think). It's pretty finicky about the shaders, as they introduced an extra set of requirements. (inout/in/out keywords not supported, can't construct mat3 from mat4, etc).
