### PR TITLE
Fixed small problems which exhibit themself when building projects with ...

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -113,3 +113,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Heidi Pan <heidi.pan@intel.com> (copyright owned by Intel)
 * Vasilis Kalintiris <ehostunreach@gmail.com>
 * Adam C. Clifton <adam@hulkamaniac.com>
+* Volo Zyko <volo.zyko@gmail.com>

--- a/cmake/Platform/Emscripten.cmake
+++ b/cmake/Platform/Emscripten.cmake
@@ -109,6 +109,8 @@ set(CMAKE_CXX_RESPONSE_FILE_LINK_FLAG "@")
 # Specify the program to use when building static libraries. Force Emscripten-related command line options to clang.
 set(CMAKE_CXX_ARCHIVE_CREATE "${CMAKE_AR} rc <TARGET> ${CMAKE_START_TEMP_FILE} <LINK_FLAGS> <OBJECTS>${CMAKE_END_TEMP_FILE}")
 set(CMAKE_C_ARCHIVE_CREATE "${CMAKE_AR} rc <TARGET> ${CMAKE_START_TEMP_FILE} <LINK_FLAGS> <OBJECTS>${CMAKE_END_TEMP_FILE}")
+set(CMAKE_CXX_ARCHIVE_APPEND "${CMAKE_AR} r <TARGET> ${CMAKE_START_TEMP_FILE} <LINK_FLAGS> <OBJECTS>${CMAKE_END_TEMP_FILE}")
+set(CMAKE_C_ARCHIVE_APPEND "${CMAKE_AR} r <TARGET> ${CMAKE_START_TEMP_FILE} <LINK_FLAGS> <OBJECTS>${CMAKE_END_TEMP_FILE}")
 
 # Set a global EMSCRIPTEN variable that can be used in client CMakeLists.txt to detect when building using Emscripten.
 # There seems to be some kind of bug with CMake, so you might need to define this manually on the command line with "-DEMSCRIPTEN=1".

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1094,7 +1094,7 @@ class Building:
     # 8k is a bit of an arbitrary limit, but a reasonable one
     # for max command line size before we use a respose file
     response_file = None
-    if WINDOWS and len(' '.join(link_cmd)) > 8192:
+    if len(' '.join(link_cmd)) > 8192:
       logging.debug('using response file for llvm-link')
       [response_fd, response_file] = mkstemp(suffix='.response', dir=TEMP_DIR)
 


### PR DESCRIPTION
...too many source files.

When there are too many source files and one builds static libraray cmake splits the whole list of files
into several invocations of library archiver. In order this to work cmake needs to know both how to create
and how to append to archive. Another related issue is that emscripten code fails when links a final
javascript code if a command line of a link command is too long (this 'too long' is very OS dependent).

Related discussion can be found in issue #1931.

Conflicts:
    AUTHORS
