### PR TITLE
Fix missing SDL_LockSurface reference

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1220,6 +1220,7 @@ var LibrarySDL = {
     if (surf) SDL.freeSurface(surf);
   },
 
+  SDL_UpperBlit__deps: ['SDL_LockSurface'],
   SDL_UpperBlit: function(src, srcrect, dst, dstrect) {
     var srcData = SDL.surfaces[src];
     var dstData = SDL.surfaces[dst];


### PR DESCRIPTION
Prior to this change, when blitting from the screen to a memory buffer
the code could throw a "ReferenceError: _SDL_LockSurface is not defined"
if SDL_LockSurface was not used elsewhere in the C code.
