### PR TITLE
minor clean

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -6,7 +6,6 @@
 // Handy sets
 
 var STRUCT_LIST = set('struct', 'list');
-var UNDERSCORE_OPENPARENS = set('_', '(');
 var RELOOP_IGNORED_LASTS = set('return', 'unreachable', 'resume');
 
 var addedLibraryItems = {};


### PR DESCRIPTION
UNDERSCORE_OPENPARENS is not used anywhere else? 
What is it used for?
