### PR TITLE
Add C preprocessor support to JS libraries.

### DIFF
--- a/tests/library_preprocess.c
+++ b/tests/library_preprocess.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <assert.h>
+
+int foo();
+int foo2();
+int foo3();
+int foo4();
+int foo5();
+int foo6();
+int foo7();
+int foo8();
+int foo9();
+int foo10();
+
+int main() {
+  assert(foo() == 1);
+  assert(foo2() == 1);
+  assert(foo3() == 1);
+  assert(foo4() == 1);
+  assert(foo5() == 1);
+  assert(foo6() == 1);
+  assert(foo7() == 1);
+  assert(foo8() == 1);
+  assert(foo9() == 1);
+  assert(foo10() == 1);
+  printf("success!\n");
+  return 1;
+}

--- a/tests/library_preprocess.js
+++ b/tests/library_preprocess.js
@@ -1,0 +1,90 @@
+#define VAR_DEFINED
+
+#define VAR_42 42
+
+#define VAR_A 0
+#define VAR_B 0
+#define VAR_C 1
+#define VAR_D 1
+
+var LibraryPreprocess = {
+#ifdef VAR_DEFINED 
+  foo: function() { return 1; },
+#endif
+#ifndef VAR_NOT_DEFINED
+  foo2: function() { return 1; },
+#endif
+#if VAR_DEFINED
+  foo3: function() { return 1; },
+#endif
+#if VAR_42 == 42
+  foo4: function() { return 1; },
+#endif
+#if VAR_42
+  foo5: function() { return 1; },
+#endif
+#if !(VAR_42 == 43)
+  foo6: function() { return 1; },
+#endif
+#if VAR_NOT_DEFINED
+compile error
+#endif
+#ifdef VAR_NOT_DEFINED
+compile error
+#endif
+#ifndef VAR_DEFINED
+compile error
+#endif
+#if VAR_42 > 42 || VAR_42 < 42
+compile error
+#endif
+#if VAR_A || VAR_B
+compile error
+#endif
+#if VAR_A && VAR_B
+compile error
+#endif
+#if !VAR_A
+  foo7: function() { return 1; },
+#endif
+#if !!VAR_A
+compile error
+#endif
+#if !VAR_C || !VAR_D
+compile error
+#endif
+#if !VAR_C && !VAR_D
+compile error
+#endif
+#if VAR_C && !VAR_A
+  foo8: function() { return 1; },
+#endif
+#if !(VAR_C && !VAR_A)
+compile error
+#endif
+#if defined(VAR_NOT_DEFINED)
+compile error
+#endif
+#if !defined(VAR_DEFINED)
+compile error
+#endif
+#if defined(VAR_NOT_DEFINED) || defined(VAR_A)
+  foo9: function() { return 1; },
+#endif
+#ifdef VAR_DEFINED
+#elif defined(VAR_D)
+#else
+compile_error
+#endif
+#ifdef VAR_NOT_DEFINED
+#elif defined(VAR_E)
+#else
+  foo10: function() { return 1; },
+#endif
+
+  dummy: 0
+};
+
+#warning This is a test warning message.
+
+mergeInto(LibraryManager.library, LibraryPreprocess);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2002,6 +2002,10 @@ done.
     assert '''hello_world.c"''' in out
     assert '''printf("hello, world!''' in out
 
+  def test_js_library_preprocess(self):
+    out, err = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-library', path_from_root('tests', 'library_preprocess.js')], stdout=PIPE).communicate()
+    self.assertContained('success!', run_js(os.path.join(self.get_dir(), 'a.out.js')))
+
   def test_demangle(self):
     open('src.cpp', 'w').write('''
       #include <stdio.h>


### PR DESCRIPTION
Implement better support for C preprocessing directives. Enables the use of #if <expression with (), &&, ||, <, >, <=, >=, ==, !=, defined()>. Adds support for #define, #undef, #ifdef, #ifndef, #elif, #warning and #error. Does not (yet?) implement support for preprocessor macros, or text substitution outside preprocessor directives with #define. Add unit test.
