### PR TITLE
[SDL] Fixing SDL_UnlockSurface in IE10/IE11

### DIFF
--- a/tests/sdl_canvas.c
+++ b/tests/sdl_canvas.c
@@ -62,6 +62,8 @@ int main(int argc, char **argv) {
 
   printf("you should see two lines of text in different colors and a blue rectangle\n");
 
+  SDL_UnlockSurface(screen);
+  
   SDL_Quit();
 
   printf("done.\n");


### PR DESCRIPTION
Previously, just calling `SDL_UnlockSurface` in IE10/IE11 would throw an exception, since Emscripten assumed that the ImageData's `data` property was Uint8ClampedArray, which has a backing buffer.

IE10/IE11 still uses the deprecated CanvasPixelArray, which does not have a backing buffer property:
https://developer.mozilla.org/en-US/docs/Web/API/CanvasPixelArray

I've added an additional path to SDL_UnlockSurface for these browsers.

This fixes JSMESS in IE10/IE11: https://github.com/jsmess/jsmess/issues/33
