### PR TITLE
utilize stack member from base Error class

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1102,7 +1102,9 @@ mergeInto(LibraryManager.library, {
           }
         }
         this.message = ERRNO_MESSAGES[errno];
-        this.stack = stackTrace();
+#if ASSERTIONS
+        if (this.stack) this.stack = demangleAll(this.stack);
+#endif
       };
       FS.ErrnoError.prototype = new Error();
       FS.ErrnoError.prototype.constructor = FS.ErrnoError;


### PR DESCRIPTION
Oh FS.ErrnoError... I was profiling quakejs today and noticed stackTrace() was taking up a huge amount of my frame due to a net call returning EAGAIN each frame:

http://i.imgur.com/4eyly10.jpg

While looking at it, I wondered why we weren't using the stack provided for us by the Error object. I changed up FS.ErrnorError to do so and this was the result:

http://i.imgur.com/5zfCsnu.jpg

Adding the EAGAIN error to the genericErrors list didn't show a noticeable improvement. I'm assuming the JS engines are somehow optimizing generating this stack property in certain situations?
