### PR TITLE
Additions to keyCodes array.

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -94,7 +94,6 @@ var LibrarySDL = {
 
       17:  1248, // control (right, or left)
       18:  1250, // alt
-      173: 45, // minus
       16:  1249, // shift
       
       96: 88 | 1<<10, // keypad 0
@@ -125,6 +124,18 @@ var LibrarySDL = {
       190: 46, // period
       191: 47, // slash (/)
       192: 96, // backtick/backquote (`)
+      
+      219: 91, // left bracket ([)
+      220: 92, // backslash (\)
+      221: 93, // right bracket (])
+      
+      // Next 3 keycodes may vary across browsers, as seen in:
+      // http://www.javascripter.net/faq/keycodes.htm
+      // and might need to be determined programmatically.
+      // Assuming the codes common to MSIE, Safari and Chrome we should have:
+      186: 59, // semicolon (;)
+      187: 61, // equals (=)
+      189: 45, // minus (-)
     },
 
     scanCodes: { // SDL keycode ==> SDL scancode. See SDL_scancode.h


### PR DESCRIPTION
Added keycode mappings for left bracket, backslash, right bracket, semicolon, equals and minus. These last three may vary across browsers and might need to be determined programmatically in a future version. Additional mappings are still needed (for the Insert key, for instance).
