### PR TITLE
Fix a param-handling bug in normalizeAsm

### DIFF
--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -1603,6 +1603,7 @@ function normalizeAsm(func) {
     node = node[1];
     var name = node[2][1];
     if (func[2] && func[2].indexOf(name) < 0) break; // not an assign into a parameter, but a global
+    if (name in data.params) break; // already done that param, must be starting function body
     data.params[name] = detectAsmCoercion(node[3]);
     stats[i] = emptyNode();
     i++;

--- a/tools/test-js-optimizer-asm-regs-min-output.js
+++ b/tools/test-js-optimizer-asm-regs-min-output.js
@@ -33,4 +33,9 @@ function cl(b) {
  a(c);
  i1(b);
 }
+function cl(b) {
+ b = b | 0;
+ b = b + 4;
+ a(b);
+}
 

--- a/tools/test-js-optimizer-asm-regs-min.js
+++ b/tools/test-js-optimizer-asm-regs-min.js
@@ -33,5 +33,10 @@ function collideLocal(i1) {
  aGlobal(a); // multiple collisions, a and i1
  bGlobal(i1);
 }
+function collideLocal(i1) {
+ i1 = i1 | 0;
+ i1 = i1 + 4; // statement is of similar shape to a param coercion
+ aGlobal(i1);
+}
 // EMSCRIPTEN_GENERATED_FUNCTIONS
 // EXTRA_INFO: { "names": ["a", "b", "c", "d", "e", "f", "g", "h", "i", "i1", "cl"], "globals": { "aGlobal": "a", "bGlobal": "i1", "collideLocal": "cl" } }


### PR DESCRIPTION
normalizeAsm() can sometimes remove leading statements from the function body, if they are a similar shape to a parameter declaration.  This patch adds an additional check to be sure that each parameter is processed only once.
