### PR TITLE
use correct bufferData method when passing a NULL pointer

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -957,7 +957,11 @@ var LibraryGL = {
         usage = 0x88E8; // GL_DYNAMIC_DRAW
         break;
     }
-    GLctx.bufferData(target, HEAPU8.subarray(data, data+size), usage);
+    if (!data) {
+      GLctx.bufferData(target, size, usage);
+    } else {
+      GLctx.bufferData(target, HEAPU8.subarray(data, data+size), usage);
+    }
   },
 
   glBufferSubData__sig: 'viiii',


### PR DESCRIPTION
It's not uncommon to pass a NULL pointer to glBufferData to invalidate the current buffer before updating parts of it with glBufferSubData:

http://www.opengl.org/wiki/Buffer_Object#Invalidation

In this case, we shouldn't upload a new buffer.
