### PR TITLE
don't check to enable OES_standard_derivatives in GL.getSource

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -210,6 +210,7 @@ var LibraryGL = {
       }
     },
 
+#if LEGACY_GL_EMULATION
     // Find a token in a shader source string
     findToken: function(source, token) {
       function isIdentChar(ch) {
@@ -238,6 +239,7 @@ var LibraryGL = {
       } while (true);
       return false;
     },
+#endif
 
     getSource: function(shader, count, string, length) {
       var source = '';
@@ -255,6 +257,7 @@ var LibraryGL = {
         }
         source += frag;
       }
+#if LEGACY_GL_EMULATION
       // Let's see if we need to enable the standard derivatives extension
       type = GLctx.getShaderParameter(GL.shaders[shader], 0x8B4F /* GL_SHADER_TYPE */);
       if (type == 0x8B30 /* GL_FRAGMENT_SHADER */) {
@@ -270,6 +273,7 @@ var LibraryGL = {
 #endif
         }
       }
+#endif
       return source;
     },
 

--- a/tests/hello_world_gles_deriv.c
+++ b/tests/hello_world_gles_deriv.c
@@ -645,6 +645,7 @@ static const char vertex_shader[] =
 
 static const char fragment_shader[] =
 "#ifdef GL_ES\n"
+"#extension GL_OES_standard_derivatives : enable\n"
 "precision mediump float;\n"
 "#endif\n"
 "varying vec4 Color;\n"


### PR DESCRIPTION
Was profiling renderer startup and noticed this now seems unnecessary. GL.initExtensions @ https://github.com/kripken/emscripten/blob/master/src/library_gl.js#L638 should handle this.
