### PR TITLE
Always preventDefault() on keydown if keypress is not needed.

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -406,7 +406,7 @@ var LibrarySDL = {
           // won't fire. However, it's fine (and in some cases necessary) to
           // preventDefault for keys that don't generate a character. Otherwise,
           // preventDefault is the right thing to do in general.
-          if (event.type !== 'keydown' || (event.keyCode === 8 /* backspace */ || event.keyCode === 9 /* tab */)) {
+          if (event.type !== 'keydown' || (!SDL.unicode && !SDL.textInput) || (event.keyCode === 8 /* backspace */ || event.keyCode === 9 /* tab */)) {
             event.preventDefault();
           }
 


### PR DESCRIPTION
Some browser shortcut keys activate if event.preventDefault()
is not called for the keydown event. This will prevent all such
hotkeys when keypress events aren't needed.

This is most helpful in Chrome. For example, it prevents moving through history when using alt with the arrow keys in a game in DOSBox. It also prevents some IE 11 hotkeys like Ctrl+T, but there are important things that can't be prevented, such as Alt opening the menu. Firefox probably does not need this.

BTW. I hope making that line longer is okay. I didn't read anything about a line length policy, and there are even longer lines in the file.
