### PR TITLE
Fix Windows EMCC invocations to call 'python emcc' in a few places instead of just 'emcc'.

### DIFF
--- a/tests/fuzz/creduce_tester.py
+++ b/tests/fuzz/creduce_tester.py
@@ -34,7 +34,7 @@ except Exception, e:
 print '4) Compile JS-ly and compare'
 
 def try_js(args):
-  shared.check_execute([shared.EMCC] + EMCC_ARGS + CSMITH_CFLAGS + args +
+  shared.check_execute([shared.PYTHON, shared.EMCC] + EMCC_ARGS + CSMITH_CFLAGS + args +
     [filename, '-o', js_filename])
   js = shared.run_js(js_filename, stderr=PIPE, engine=ENGINE)
   assert correct == js

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -89,7 +89,7 @@ while 1:
   def try_js(args):
     shared.try_delete(filename + '.js')
     print '(compile)'
-    shared.check_execute([shared.EMCC, opts, fullname, '-o', filename + '.js'] + CSMITH_CFLAGS + args)
+    shared.check_execute([shared.PYTHON, shared.EMCC, opts, fullname, '-o', filename + '.js'] + CSMITH_CFLAGS + args)
     assert os.path.exists(filename + '.js')
     print '(run)'
     js = shared.run_js(filename + '.js', stderr=PIPE, engine=engine1, check_timeout=True)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -3,7 +3,7 @@ from runner import RunnerCore, path_from_root
 from tools.shared import *
 
 SANITY_FILE = CONFIG_FILE + '_sanity'
-commands = [[EMCC], [PYTHON, path_from_root('tests', 'runner.py'), 'blahblah']]
+commands = [[PYTHON, EMCC], [PYTHON, path_from_root('tests', 'runner.py'), 'blahblah']]
 
 def restore():
   shutil.copyfile(CONFIG_FILE + '_backup', CONFIG_FILE)
@@ -421,12 +421,12 @@ fi
     restore()
 
     def ensure_cache():
-      self.do([EMCC, '-O2', path_from_root('tests', 'hello_world.c')])
+      self.do([PYTHON, EMCC, '-O2', path_from_root('tests', 'hello_world.c')])
 
     # Manual cache clearing
     ensure_cache()
     assert os.path.exists(EMCC_CACHE)
-    output = self.do([EMCC, '--clear-cache'])
+    output = self.do([PYTHON, EMCC, '--clear-cache'])
     assert ERASING_MESSAGE in output
     assert not os.path.exists(EMCC_CACHE)
 
@@ -436,7 +436,7 @@ fi
     try:
       os.environ['LLVM'] = 'waka'
       assert os.path.exists(EMCC_CACHE)
-      output = self.do([EMCC])
+      output = self.do([PYTHON, EMCC])
       assert ERASING_MESSAGE in output
       assert not os.path.exists(EMCC_CACHE)
     finally:
@@ -594,7 +594,7 @@ fi
     temp_dir = tempfile.mkdtemp(prefix='emscripten_temp_')
 
     os.chdir(temp_dir)
-    self.do([EMCC, '-O2', '--em-config', custom_config_filename, path_from_root('tests', 'hello_world.c')])
+    self.do([PYTHON, EMCC, '-O2', '--em-config', custom_config_filename, path_from_root('tests', 'hello_world.c')])
     result = run_js('a.out.js')
     
     # Clean up created temp files.

--- a/tools/make_minigzip.py
+++ b/tools/make_minigzip.py
@@ -9,5 +9,5 @@ zlib = shared.Building.build_library('zlib', shared.EMSCRIPTEN_TEMP_DIR, shared.
 
 print 'Building minigzip'
 
-Popen(['python2', shared.EMCC, '-O2', shared.path_from_root('tests', 'zlib', 'minigzip.c'), zlib, '-o', shared.path_from_root('tools', 'minigzip.js')]).communicate()
+Popen([shared.PYTHON, shared.EMCC, '-O2', shared.path_from_root('tests', 'zlib', 'minigzip.c'), zlib, '-o', shared.path_from_root('tools', 'minigzip.js')]).communicate()
 


### PR DESCRIPTION
Looks like we are missing prepending the PYTHON interpreter var in some invocations of EMCC. This commit adds those in.
