### PR TITLE
Fix bugs in HTML5 events when using SAFE_HEAP

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -236,10 +236,10 @@ var LibraryJSEvents = {
       var handlerFunc = function(event) {
         var e = event || window.event;
         JSEvents.fillMouseEventData(JSEvents.wheelEvent, e);
-        {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaX, 'e.deltaX', 'double') }}}
-        {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaY, 'e.deltaY', 'double') }}}
-        {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaZ, 'e.deltaZ', 'double') }}}
-        {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaMode, 'e.deltaMode', 'i32') }}}
+        {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaX, 'e.deltaX', 'double') }}};
+        {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaY, 'e.deltaY', 'double') }}};
+        {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaZ, 'e.deltaZ', 'double') }}};
+        {{{ makeSetValue('JSEvents.wheelEvent', C_STRUCTS.EmscriptenWheelEvent.deltaMode, 'e.deltaMode', 'i32') }}};
         var shouldCancel = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, JSEvents.wheelEvent, userData]);
         if (shouldCancel) {
           e.preventDefault();
@@ -772,7 +772,8 @@ var LibraryJSEvents = {
 
         var confirmationMessage = Runtime.dynCall('iiii', callbackfunc, [eventTypeId, 0, userData]);
         
-        confirmationMessage = Pointer_stringify(confirmationMessage);
+        if (confirmationMessage)
+          confirmationMessage = Pointer_stringify(confirmationMessage);
         if (confirmationMessage) {
           e.preventDefault();
           e.returnValue = confirmationMessage;


### PR DESCRIPTION
This fixes a SAFE_HEAP_STORE is not a function error when using mouse events
and a segfault that occurs when the beforeunload callback returns 0.
