### PR TITLE
add test catching a bug with std::stof() + outlining limit

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -876,6 +876,13 @@ class T(RunnerCore): # Short name, to make it more fun to use manually on the co
 
       self.do_run_from_file(src, output)
 
+  def test_stof(self):
+      if self.run_name.startswith('s_'): 
+          return self.skip('Requires libc++')
+
+      Settings.OUTLINING_LIMIT = 5000
+      self.do_run(open(path_from_root('tests', 'test_stof.cpp'), 'r').read(), '0.5')
+
   def test_fcvt(self):
       if self.emcc_args is None: return self.skip('requires emcc')
 

--- a/tests/test_stof.cpp
+++ b/tests/test_stof.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main()
+{
+        std::cout << std::stof("0.5f") << "\n";
+}


### PR DESCRIPTION
I found a bug where std::stof() would return a very big nonsensical number for any float string when outlining limit is set to 5000. 

For example, std::stof("0.5f") outputs 1.05696e+09

This pull request adds a test which exposes this bug
