### PR TITLE
Fix other.test_bad_triple.

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2577,7 +2577,7 @@ int main()
     assert 'asm.js' in output, 'spidermonkey should mention asm.js compilation: ' + output
 
   def test_bad_triple(self):
-    Popen([CLANG, path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm', '-o', 'a.bc'], stdout=PIPE, stderr=PIPE).communicate()
+    Popen([CLANG, path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm', '-o', 'a.bc'] + get_clang_native_args(), stdout=PIPE, stderr=PIPE).communicate()
     out, err = Popen([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE).communicate()
     assert 'warning' in err, err
     assert 'incorrect target triple' in err, err

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -495,6 +495,30 @@ def build_clang_tool_path(tool):
   else:
     return os.path.join(LLVM_ROOT, tool)
 
+# Whenever building a native executable for OSX, we must provide the OSX SDK version we want to target.
+def osx_find_native_sdk_path():
+  try:
+    sdk_root = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs'
+    sdks = os.walk(sdk_root).next()[1]
+    sdk_path = os.path.join(sdk_root, sdks[0]) # Just pick first one found, we don't care which one we found.
+    logging.debug('Targeting OSX SDK found at ' + sdk_path)
+    return sdk_path
+  except:
+    logging.warning('Could not find native OSX SDK path to target!')
+    return None
+
+# These extra args need to be passed to Clang when targeting a native host system executable
+CACHED_CLANG_NATIVE_ARGS=None
+def get_clang_native_args():
+  global CACHED_CLANG_NATIVE_ARGS
+  if CACHED_CLANG_NATIVE_ARGS is not None: return CACHED_CLANG_NATIVE_ARGS
+  CACHED_CLANG_NATIVE_ARGS = []
+  if sys.platform == 'darwin':
+    sdk_path = osx_find_native_sdk_path()
+    if sdk_path:
+      CACHED_CLANG_NATIVE_ARGS = ['-isysroot', osx_find_native_sdk_path()]
+  return CACHED_CLANG_NATIVE_ARGS
+
 CLANG_CC=os.path.expanduser(build_clang_tool_path('clang'))
 CLANG_CPP=os.path.expanduser(build_clang_tool_path('clang++'))
 CLANG=CLANG_CPP


### PR DESCRIPTION
When we build native OSX executables with Clang, we must tell Clang which OSX SDK version we are targeting. Add a function CLANG_NATIVE_ARGS() that returns a list of compiler args that need to be appended when building native executables for the current platform, which for OSX automatically find an SDK to target. Make the machinery lazy and cached so that it's not invoked if native executables are not built, and that it's invoked only once when needed. Fixed test other.test_bad_triple on OSX.
