### PR TITLE
Revise shell prints.

### DIFF
--- a/src/shell.html
+++ b/src/shell.html
@@ -1222,7 +1222,7 @@
         postRun: [],
         print: (function() {
           var element = document.getElementById('output');
-          element.value = ''; // clear browser cache
+          if (element) element.value = ''; // clear browser cache
           return function(text) {
             text = Array.prototype.slice.call(arguments).join(' ');
             // These replacements are necessary if you render to raw HTML
@@ -1230,8 +1230,11 @@
             //text = text.replace(/</g, "&lt;");
             //text = text.replace(/>/g, "&gt;");
             //text = text.replace('\n', '<br>', 'g');
-            element.value += text + "\n";
-            element.scrollTop = element.scrollHeight; // focus on bottom
+            console.log(text);
+            if (element) {
+              element.value += text + "\n";
+              element.scrollTop = element.scrollHeight; // focus on bottom
+            }
           };
         })(),
         printErr: function(text) {
@@ -1239,7 +1242,7 @@
           if (0) { // XXX disabled for safety typeof dump == 'function') {
             dump(text + '\n'); // fast, straight to the real console
           } else {
-            console.log(text);
+            console.error(text);
           }
         },
         canvas: document.getElementById('canvas'),

--- a/src/shell_minimal.html
+++ b/src/shell_minimal.html
@@ -78,7 +78,7 @@
         postRun: [],
         print: (function() {
           var element = document.getElementById('output');
-          element.value = ''; // clear browser cache
+          if (element) element.value = ''; // clear browser cache
           return function(text) {
             text = Array.prototype.slice.call(arguments).join(' ');
             // These replacements are necessary if you render to raw HTML
@@ -86,8 +86,11 @@
             //text = text.replace(/</g, "&lt;");
             //text = text.replace(/>/g, "&gt;");
             //text = text.replace('\n', '<br>', 'g');
-            element.value += text + "\n";
-            element.scrollTop = element.scrollHeight; // focus on bottom
+            console.log(text);
+            if (element) {
+              element.value += text + "\n";
+              element.scrollTop = element.scrollHeight; // focus on bottom
+            }
           };
         })(),
         printErr: function(text) {
@@ -95,7 +98,7 @@
           if (0) { // XXX disabled for safety typeof dump == 'function') {
             dump(text + '\n'); // fast, straight to the real console
           } else {
-            console.log(text);
+            console.error(text);
           }
         },
         canvas: document.getElementById('canvas'),


### PR DESCRIPTION
In default-provided shells, make standard C stdout always print out to console.log(), and C stderr print out to console.error(). Make the presence of a html page output textbox optional. These changes make the default shells more friendly for Firefox for Android and Firefox OS devices.
