### PR TITLE
fix_test_atomic_cxx

### DIFF
--- a/tests/core/test_atomic_cxx.cpp
+++ b/tests/core/test_atomic_cxx.cpp
@@ -8,7 +8,7 @@
 #include <atomic>
 #include <cstdio>
 
-template<typename TYPE> void test(TYPE mask0, TYPE mask1, TYPE mask2) {
+template<typename TYPE, typename UNSIGNED_TYPE> void test(TYPE mask0, TYPE mask1, TYPE mask2) {
     typedef TYPE dog;
     
     const TYPE numMemoryOrders = 6;
@@ -54,54 +54,54 @@ template<typename TYPE> void test(TYPE mask0, TYPE mask1, TYPE mask2) {
     atomicDog = 0;
     for (TYPE i = 0; i < numMemoryOrders; i++) {
         TYPE old = atomicDog.fetch_add(1, memoryOrder[i]);
-        printf("fetch_add %lld: old=%lld new=%lld\n", (long long)i, (long long)old, TYPE(atomicDog));
+        printf("fetch_add %lld: old=%lld new=%lld\n", (long long)i, (long long)old, (long long)TYPE(atomicDog));
     }
 
     // fetch_sub
     for (TYPE i = 0; i < numMemoryOrders; i++) {
         TYPE old = atomicDog.fetch_sub(1, memoryOrder[i]);
-        printf("fetch_sub %lld: old=%lld new=%lld\n", (long long)i, (long long)old, TYPE(atomicDog));
+        printf("fetch_sub %lld: old=%lld new=%lld\n", (long long)i, (long long)old, (long long)TYPE(atomicDog));
     }
 
     // fetch_and
     for (TYPE i = 0; i < numMemoryOrders; i++) {
         atomicDog.store(mask0, memoryOrder[i]);
         TYPE old = atomicDog.fetch_and((1<<i), memoryOrder[i]);
-        printf("fetch_and %lld: old=%llx, new=%llx\n", (long long)i, (long long)old, TYPE(atomicDog));
+        printf("fetch_and %lld: old=%llx, new=%llx\n", (long long)i, (unsigned long long)UNSIGNED_TYPE(old), (unsigned long long)UNSIGNED_TYPE(atomicDog));
     }
 
     // fetch_or
     atomicDog = 0;
     for (TYPE i = 0; i < numMemoryOrders; i++) {
         TYPE old = atomicDog.fetch_or((1<<i), memoryOrder[i]);
-        printf("fetch_or %lld: old=%llx, new=%llx\n", (long long)i, (long long)old, TYPE(atomicDog));
+        printf("fetch_or %lld: old=%llx, new=%llx\n", (long long)i, (unsigned long long)UNSIGNED_TYPE(old), (unsigned long long)UNSIGNED_TYPE(atomicDog));
     }
 
     // fetch_xor
     atomicDog = 0;
     for (int i = 0; i < numMemoryOrders; i++) {
         int old = atomicDog.fetch_xor((1<<i), memoryOrder[i]);
-        printf("fetch_xor %lld: old=%llx, new=%llx\n", (long long)i, (long long)old, TYPE(atomicDog));
+        printf("fetch_xor %lld: old=%llx, new=%llx\n", (long long)i, (unsigned long long)UNSIGNED_TYPE(old), (unsigned long long)UNSIGNED_TYPE(atomicDog));
     }
 
     // operator++, --
     atomicDog = 0;
     atomicDog++;
-    printf("operator++: %lld\n", TYPE(atomicDog));
+    printf("operator++: %lld\n", (long long)TYPE(atomicDog));
     atomicDog--;
-    printf("operator--: %lld\n", TYPE(atomicDog));
+    printf("operator--: %lld\n", (long long)TYPE(atomicDog));
 
     // operator +=, -=, &=, |=, ^=
     atomicDog += 10;
-    printf("operator+=: %lld\n", TYPE(atomicDog));
+    printf("operator+=: %lld\n", (long long)TYPE(atomicDog));
     atomicDog -= 5;
-    printf("operator-=: %lld\n", TYPE(atomicDog));
+    printf("operator-=: %lld\n", (long long)TYPE(atomicDog));
     atomicDog |= mask0;
-    printf("operator|=: %llx\n", TYPE(atomicDog));
+    printf("operator|=: %llx\n", (unsigned long long)UNSIGNED_TYPE(atomicDog));
     atomicDog &= mask1;
-    printf("operator|=: %llx\n", TYPE(atomicDog));
+    printf("operator&=: %llx\n", (unsigned long long)UNSIGNED_TYPE(atomicDog));
     atomicDog ^= mask2;
-    printf("operator^=: %llx\n", TYPE(atomicDog));
+    printf("operator^=: %llx\n", (unsigned long long)UNSIGNED_TYPE(atomicDog));
 
 }
 
@@ -109,13 +109,13 @@ int main() {
 
     // test 8, 16, 32 and 64-bit data types
     printf("\n8 bits\n\n");
-    test<char>(0xFF, 0xF0, 0x0F);
+    test<char, unsigned char>(0xFF, 0xF0, 0x0F);
     printf("\n16 bits\n\n");
-    test<short>(0xFFFF, 0xF0F0, 0x0F0F);
+    test<short, unsigned short>(0xFFFF, 0xF0F0, 0x0F0F);
     printf("\n32 bits\n\n");
-    test<int>(0xFFFFFFFF, 0xF0F0F0F0, 0x0F0F0F0F);
+    test<int, unsigned int>(0xFFFFFFFF, 0xF0F0F0F0, 0x0F0F0F0F);
     printf("\n64 bits\n\n");
-    test<long long>(0xFFFFFFFFFFFFFFFF, 0xF0F0F0F0F0F0F0F0, 0x0F0F0F0F0F0F0F0F);
+    test<long long, unsigned long long>(0xFFFFFFFFFFFFFFFF, 0xF0F0F0F0F0F0F0F0, 0x0F0F0F0F0F0F0F0F);
 
     // test atomic_flag (should also have memory_orders, but probably doesn't matter 
     // to find the missing atomic functions)

--- a/tests/core/test_atomic_cxx.txt
+++ b/tests/core/test_atomic_cxx.txt
@@ -29,12 +29,12 @@ fetch_sub 2: old=4 new=3
 fetch_sub 3: old=3 new=2
 fetch_sub 4: old=2 new=1
 fetch_sub 5: old=1 new=0
-fetch_and 0: old=ffffffffffffffff, new=1
-fetch_and 1: old=ffffffffffffffff, new=2
-fetch_and 2: old=ffffffffffffffff, new=4
-fetch_and 3: old=ffffffffffffffff, new=8
-fetch_and 4: old=ffffffffffffffff, new=10
-fetch_and 5: old=ffffffffffffffff, new=20
+fetch_and 0: old=ff, new=1
+fetch_and 1: old=ff, new=2
+fetch_and 2: old=ff, new=4
+fetch_and 3: old=ff, new=8
+fetch_and 4: old=ff, new=10
+fetch_and 5: old=ff, new=20
 fetch_or 0: old=0, new=1
 fetch_or 1: old=1, new=3
 fetch_or 2: old=3, new=7
@@ -51,9 +51,9 @@ operator++: 1
 operator--: 0
 operator+=: 10
 operator-=: 5
-operator|=: ffffffff
-operator|=: fffffff0
-operator^=: ffffffff
+operator|=: ff
+operator&=: f0
+operator^=: ff
 
 16 bits
 
@@ -85,12 +85,12 @@ fetch_sub 2: old=4 new=3
 fetch_sub 3: old=3 new=2
 fetch_sub 4: old=2 new=1
 fetch_sub 5: old=1 new=0
-fetch_and 0: old=ffffffffffffffff, new=1
-fetch_and 1: old=ffffffffffffffff, new=2
-fetch_and 2: old=ffffffffffffffff, new=4
-fetch_and 3: old=ffffffffffffffff, new=8
-fetch_and 4: old=ffffffffffffffff, new=10
-fetch_and 5: old=ffffffffffffffff, new=20
+fetch_and 0: old=ffff, new=1
+fetch_and 1: old=ffff, new=2
+fetch_and 2: old=ffff, new=4
+fetch_and 3: old=ffff, new=8
+fetch_and 4: old=ffff, new=10
+fetch_and 5: old=ffff, new=20
 fetch_or 0: old=0, new=1
 fetch_or 1: old=1, new=3
 fetch_or 2: old=3, new=7
@@ -107,9 +107,9 @@ operator++: 1
 operator--: 0
 operator+=: 10
 operator-=: 5
-operator|=: ffffffff
-operator|=: fffff0f0
-operator^=: ffffffff
+operator|=: ffff
+operator&=: f0f0
+operator^=: ffff
 
 32 bits
 
@@ -141,12 +141,12 @@ fetch_sub 2: old=4 new=3
 fetch_sub 3: old=3 new=2
 fetch_sub 4: old=2 new=1
 fetch_sub 5: old=1 new=0
-fetch_and 0: old=ffffffffffffffff, new=1
-fetch_and 1: old=ffffffffffffffff, new=2
-fetch_and 2: old=ffffffffffffffff, new=4
-fetch_and 3: old=ffffffffffffffff, new=8
-fetch_and 4: old=ffffffffffffffff, new=10
-fetch_and 5: old=ffffffffffffffff, new=20
+fetch_and 0: old=ffffffff, new=1
+fetch_and 1: old=ffffffff, new=2
+fetch_and 2: old=ffffffff, new=4
+fetch_and 3: old=ffffffff, new=8
+fetch_and 4: old=ffffffff, new=10
+fetch_and 5: old=ffffffff, new=20
 fetch_or 0: old=0, new=1
 fetch_or 1: old=1, new=3
 fetch_or 2: old=3, new=7
@@ -164,7 +164,7 @@ operator--: 0
 operator+=: 10
 operator-=: 5
 operator|=: ffffffff
-operator|=: f0f0f0f0
+operator&=: f0f0f0f0
 operator^=: ffffffff
 
 64 bits
@@ -220,7 +220,7 @@ operator--: 0
 operator+=: 10
 operator-=: 5
 operator|=: ffffffffffffffff
-operator|=: f0f0f0f0f0f0f0f0
+operator&=: f0f0f0f0f0f0f0f0
 operator^=: ffffffffffffffff
 atomic_flag: false
 done.


### PR DESCRIPTION
Remove undefined behavior reading 32-bit variables as 64-bit in printf formatting in test_atomic_cxx. Fixes the test on OSX.
