### PR TITLE
spidermonkey_none

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2983,7 +2983,7 @@ def process(filename):
                 output_nicerizer=lambda x, err: x.replace('\n', '*'),
                 post_build=self.dlfcn_post_build)
 
-    if Settings.ASM_JS and os.path.exists(SPIDERMONKEY_ENGINE[0]):
+    if Settings.ASM_JS and SPIDERMONKEY_ENGINE and os.path.exists(SPIDERMONKEY_ENGINE[0]):
       out = run_js('liblib.so', engine=SPIDERMONKEY_ENGINE, full_output=True, stderr=STDOUT)
       if 'asm' in out:
         self.validate_asmjs(out)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -746,13 +746,14 @@ else:
 # Engine tweaks
 
 try:
-  new_spidermonkey = listify(SPIDERMONKEY_ENGINE)
-  if 'gcparam' not in str(new_spidermonkey):
-    new_spidermonkey += ['-e', "gcparam('maxBytes', 1024*1024*1024);"] # Our very large files need lots of gc heap
-  if '-w' not in str(new_spidermonkey):
-    new_spidermonkey += ['-w']
-  JS_ENGINES = map(lambda x: new_spidermonkey if x == SPIDERMONKEY_ENGINE else x, JS_ENGINES)
-  SPIDERMONKEY_ENGINE = new_spidermonkey
+  if SPIDERMONKEY_ENGINE:
+    new_spidermonkey = listify(SPIDERMONKEY_ENGINE)
+    if 'gcparam' not in str(new_spidermonkey):
+      new_spidermonkey += ['-e', "gcparam('maxBytes', 1024*1024*1024);"] # Our very large files need lots of gc heap
+    if '-w' not in str(new_spidermonkey):
+      new_spidermonkey += ['-w']
+    JS_ENGINES = map(lambda x: new_spidermonkey if x == SPIDERMONKEY_ENGINE else x, JS_ENGINES)
+    SPIDERMONKEY_ENGINE = new_spidermonkey
 except NameError:
   pass
 


### PR DESCRIPTION
Allow setting SPIDERMONKEY_ENGINE=None in .emscripten to simplify test runner operation.
