### PR TITLE
fix GLFW glfwGetMouseWheel is reversed bug

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -197,7 +197,7 @@ var LibraryGLFW = {
     },
 
     onMouseWheel: function(event) {
-      GLFW.wheelPos += Browser.getMouseWheelDelta(event);
+      GLFW.wheelPos -= Browser.getMouseWheelDelta(event);
 
       if (GLFW.mouseWheelFunc && event.target == Module["canvas"]) {
         Runtime.dynCall('vi', GLFW.mouseWheelFunc, [GLFW.wheelPos]);


### PR DESCRIPTION
related: #2303 bug: wheel direction is reversed in GLFW2
