### PR TITLE
Fix embind/asm.js in PRECISE_F32 mode

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -723,9 +723,16 @@ function requireFunction(signature, rawFunction) {
         //   possibly allocate.
         var dc = asm['dynCall_' + signature];
         if (dc === undefined) {
-            throwBindingError("No dynCall invoker for signature: " + signature);
+            // We will always enter this branch if the signature
+            // contains 'f' and PRECISE_F32 is not enabled.
+            //
+            // Try again, replacing 'f' with 'd'.
+            dc = asm['dynCall_' + signature.replace(/f/g, 'd')];
+            if (dc === undefined) {
+                throwBindingError("No dynCall invoker for signature: " + signature);
+            }
         }
-        fp = asm['dynCall_' + signature].bind(undefined, rawFunction);
+        fp = dc.bind(undefined, rawFunction);
     } else {
         fp = FUNCTION_TABLE[rawFunction];
     }

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -330,7 +330,7 @@ namespace emscripten {
         template<>
         struct SignatureCode<float> {
             static constexpr char get() {
-                return 'd';
+                return 'f';
             }
         };
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5657,7 +5657,6 @@ def process(filename):
 
   def test_embind_2(self):
     if self.emcc_args is None: return self.skip('requires emcc')
-    if self.run_name == 'asm2f': return self.skip('embind/asm.js not compatible with PRECISE_F32 because it changes signature strings')
     if self.run_name == 'slow2asm': return self.skip('embind/asm.js requires fastcomp')
     Building.COMPILER_TEST_OPTS += ['--bind', '--post-js', 'post.js']
     open('post.js', 'w').write('''


### PR DESCRIPTION
As discussed, this change makes embind tolerate both PRECISE_F32=1 and PRECISE_F32=0.

It uses 'f' for float, and if no table is found with that signature (which would always happen in PRECISE_F32=0) it would try again with 'd'.
