### PR TITLE
Run js retcode assert

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1891,7 +1891,7 @@ This pointer might make sense in another type signature: i: 0
       Popen([PYTHON, EMCC, path_from_root('tests', 'embind', 'embind_test.cpp'), '--post-js', path_from_root('tests', 'embind', 'underscore-1.4.2.js'), '--post-js', path_from_root('tests', 'embind', 'imvu_test_adapter.js'), '--post-js', path_from_root('tests', 'embind', 'embind.test.js')] + args, stderr=PIPE if fail else None).communicate()
       assert os.path.exists(self.in_dir('a.out.js')) == (not fail)
       if not fail:
-        output = run_js(self.in_dir('a.out.js'), stdout=PIPE, stderr=PIPE, full_output=True)
+        output = run_js(self.in_dir('a.out.js'), stdout=PIPE, stderr=PIPE, full_output=True, assert_returncode=0)
         assert "FAIL" not in output, output
 
   def test_llvm_nativizer(self):

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -14,10 +14,10 @@ def timeout_run(proc, timeout=None, note='unnamed process', full_output=False):
   out = proc.communicate()
   out = map(lambda o: '' if o is None else o, out)
   if TRACK_PROCESS_SPAWNS:
-    logging.info('Process ' + str(proc.pid) + ' finished after ' + str(time.time() - start) + ' seconds.')
+    logging.info('Process ' + str(proc.pid) + ' finished after ' + str(time.time() - start) + ' seconds. Exit code: ' + str(proc.returncode))
   return '\n'.join(out) if full_output else out[0]
 
-def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdout=PIPE, stderr=None, cwd=None, full_output=False):
+def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdout=PIPE, stderr=None, cwd=None, full_output=False, assert_returncode=None):
   if type(engine) is not list:
     engine = [engine]
   command = engine + [filename] + (['--'] if 'd8' in engine[0] or 'jsc' in engine[0] else []) + args
@@ -30,8 +30,11 @@ def run_js(filename, engine=None, args=[], check_timeout=False, stdin=None, stdo
   timeout = 15*60 if check_timeout else None
   if TRACK_PROCESS_SPAWNS:
     logging.info('Blocking on process ' + str(proc.pid) + ': ' + str(command) + (' for ' + str(timeout) + ' seconds' if timeout else ' until it finishes.'))
-  return timeout_run(
+  ret = timeout_run(
     proc, 
     timeout,
     'Execution',
     full_output=full_output)
+  if assert_returncode is not None and proc.returncode is not assert_returncode:
+    raise Exception('Expected the command ' + str(command) + ' to finish with return code ' + str(assert_returncode) + ', but it returned with code ' + str(proc.returncode) + ' instead! Output: ' + str(ret))
+  return ret


### PR DESCRIPTION
Add support to function run_js() in jsrun.py to assert against a given process return code. This uncovers issues in other.test_embind which were not caught before. See #2335.
