### PR TITLE
Fix elimination of conditional expressions in registerizeHarder

### DIFF
--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -2237,18 +2237,30 @@ function registerizeHarder(ast) {
           break;
         case 'conditional':
           isInExpr++;
-          buildFlowGraph(node[1]);
-          var jEnter = markJunction();
-          var jExit = addJunction();
-          if (node[2]) {
-            buildFlowGraph(node[2]);
+          // If the conditional has no side-effects, we can treat it as a single
+          // block, which might open up opportunities to remove it entirely.
+          if (!hasSideEffects(node)) {
+            buildFlowGraph(node[1]);
+            if (node[2]) {
+              buildFlowGraph(node[2]);
+            }
+            if (node[3]) {
+              buildFlowGraph(node[3]);
+            }
+          } else {
+            buildFlowGraph(node[1]);
+            var jEnter = markJunction();
+            var jExit = addJunction();
+            if (node[2]) {
+              buildFlowGraph(node[2]);
+            }
+            joinJunction(jExit);
+            setJunction(jEnter);
+            if (node[3]) {
+              buildFlowGraph(node[3]);
+            }
+            joinJunction(jExit);
           }
-          joinJunction(jExit);
-          setJunction(jEnter);
-          if (node[3]) {
-            buildFlowGraph(node[3]);
-          }
-          joinJunction(jExit);
           isInExpr--;
           break;
         case 'while':

--- a/tools/test-js-optimizer-asm-regs-harder-output.js
+++ b/tools/test-js-optimizer-asm-regs-harder-output.js
@@ -129,4 +129,9 @@ function linkedVars() {
  }
  return i2 + i1;
 }
+function deadCondExpr(i2) {
+ i2 = i2 | 0;
+ var i1 = 0;
+ return i1 | 0;
+}
 

--- a/tools/test-js-optimizer-asm-regs-harder.js
+++ b/tools/test-js-optimizer-asm-regs-harder.js
@@ -149,5 +149,11 @@ function linkedVars() {
  }
  return outer1 + outer2;
 }
-// EMSCRIPTEN_GENERATED_FUNCTIONS: ["asm", "_doit", "stackRestore", "switchey", "switchey2", "iffey", "labelledJump", "linkedVars']
+function deadCondExpr(input) {
+  input = input|0;
+  var dead = 0, temp = 0;
+  dead = (!input ? -1 : input)|0;
+  return temp|0;
+}
+// EMSCRIPTEN_GENERATED_FUNCTIONS: ["asm", "_doit", "stackRestore", "switchey", "switchey2", "iffey", "labelledJump", "linkedVars", "deadCondExpr"]
 


### PR DESCRIPTION
Previously, attempts to eliminate a side-effect-free conditional expression like such as this:

```
x = (some_test ? 1 : 0) | 0;
// value of x not subsequently used, so the assignment can be eliminated
```

would corrupt internal block state, because the sub-nodes of the conditional expression are owned by a different block to the assignment node itself.

This PR fixes the problem but not splitting side-effect free conditionals across multiple blocks.  Effect-ful conditionals are still split into separate blocks so that assignments within each branch are properly tracked through the flow analysis, but this is safe since we never try to eliminate such exprs anyway.
