### PR TITLE
Musl charfuncs

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3222,39 +3222,6 @@ LibraryManager.library = {
     {{{ makeStructuralReturn([makeGetTempDouble(0, 'i32'), makeGetTempDouble(1, 'i32')]) }}};
   },
 #endif
-  strtoll__deps: ['_parseInt64'],
-  strtoll: function(str, endptr, base) {
-    return __parseInt64(str, endptr, base, '-9223372036854775808', '9223372036854775807');  // LLONG_MIN, LLONG_MAX.
-  },
-  strtoll_l__deps: ['strtoll'],
-  strtoll_l: function(str, endptr, base) {
-    return _strtoll(str, endptr, base); // no locale support yet
-  },
-  strtol__deps: ['_parseInt'],
-  strtol: function(str, endptr, base) {
-    return __parseInt(str, endptr, base, -2147483648, 2147483647, 32);  // LONG_MIN, LONG_MAX.
-  },
-  strtol_l__deps: ['strtol'],
-  strtol_l: function(str, endptr, base) {
-    return _strtol(str, endptr, base); // no locale support yet
-  },
-  strtoul__deps: ['_parseInt'],
-  strtoul: function(str, endptr, base) {
-    return __parseInt(str, endptr, base, 0, 4294967295, 32, true);  // ULONG_MAX.
-  },
-  strtoul_l__deps: ['strtoul'],
-  strtoul_l: function(str, endptr, base) {
-    return _strtoul(str, endptr, base); // no locale support yet
-  },
-  strtoull__deps: ['_parseInt64'],
-  strtoull: function(str, endptr, base) {
-    return __parseInt64(str, endptr, base, 0, '18446744073709551615', true);  // ULONG_MAX.
-  },
-  strtoull_l__deps: ['strtoull'],
-  strtoull_l: function(str, endptr, base) {
-    return _strtoull(str, endptr, base); // no locale support yet
-  },
-
   environ: 'allocate(1, "i32*", ALLOC_STATIC)',
   __environ__deps: ['environ'],
   __environ: '_environ',
@@ -3619,28 +3586,6 @@ LibraryManager.library = {
     return pdest|0;
   },
 
-  strlwr__deps:['tolower'],
-  strlwr: function(pstr){
-    var i = 0;
-    while(1) {
-      var x = {{{ makeGetValue('pstr', 'i', 'i8') }}};
-      if (x == 0) break;
-      {{{ makeSetValue('pstr', 'i', '_tolower(x)', 'i8') }}};
-      i++;
-    }
-  },
-
-  strupr__deps:['toupper'],
-  strupr: function(pstr){
-    var i = 0;
-    while(1) {
-      var x = {{{ makeGetValue('pstr', 'i', 'i8') }}};
-      if (x == 0) break;
-      {{{ makeSetValue('pstr', 'i', '_toupper(x)', 'i8') }}};
-      i++;
-    }
-  },
-
   strcat__asm: true,
   strcat__sig: 'iii',
   strcat__deps: ['strlen'],
@@ -3681,132 +3626,6 @@ LibraryManager.library = {
   // ctype.h
   // ==========================================================================
 
-  isascii: function(chr) {
-    return chr >= 0 && (chr & 0x80) == 0;
-  },
-  toascii: function(chr) {
-    return chr & 0x7F;
-  },
-  toupper: function(chr) {
-    if (chr >= {{{ charCode('a') }}} && chr <= {{{ charCode('z') }}}) {
-      return chr - {{{ charCode('a') }}} + {{{ charCode('A') }}};
-    } else {
-      return chr;
-    }
-  },
-  _toupper: 'toupper',
-  toupper_l__deps: ['toupper'],
-  toupper_l: function(str, endptr, base) {
-    return _toupper(str, endptr, base); // no locale support yet
-  },
-
-  tolower__asm: true,
-  tolower__sig: 'ii',
-  tolower: function(chr) {
-    chr = chr|0;
-    if ((chr|0) < {{{ charCode('A') }}}) return chr|0;
-    if ((chr|0) > {{{ charCode('Z') }}}) return chr|0;
-    return (chr - {{{ charCode('A') }}} + {{{ charCode('a') }}})|0;
-  },
-  _tolower: 'tolower',
-  tolower_l__deps: ['tolower'],
-  tolower_l: function(chr) {
-    return _tolower(chr); // no locale support yet
-  },
-
-  // The following functions are defined as macros in glibc.
-  islower: function(chr) {
-    return chr >= {{{ charCode('a') }}} && chr <= {{{ charCode('z') }}};
-  },
-  islower_l__deps: ['islower'],
-  islower_l: function(chr) {
-    return _islower(chr); // no locale support yet
-  },
-  isupper: function(chr) {
-    return chr >= {{{ charCode('A') }}} && chr <= {{{ charCode('Z') }}};
-  },
-  isupper_l__deps: ['isupper'],
-  isupper_l: function(chr) {
-    return _isupper(chr); // no locale support yet
-  },
-  isalpha: function(chr) {
-    return (chr >= {{{ charCode('a') }}} && chr <= {{{ charCode('z') }}}) ||
-           (chr >= {{{ charCode('A') }}} && chr <= {{{ charCode('Z') }}});
-  },
-  isalpha_l__deps: ['isalpha'],
-  isalpha_l: function(chr) {
-    return _isalpha(chr); // no locale support yet
-  },
-  isdigit: function(chr) {
-    return chr >= {{{ charCode('0') }}} && chr <= {{{ charCode('9') }}};
-  },
-  isdigit_l__deps: ['isdigit'],
-  isdigit_l: function(chr) {
-    return _isdigit(chr); // no locale support yet
-  },
-  isxdigit: function(chr) {
-    return (chr >= {{{ charCode('0') }}} && chr <= {{{ charCode('9') }}}) ||
-           (chr >= {{{ charCode('a') }}} && chr <= {{{ charCode('f') }}}) ||
-           (chr >= {{{ charCode('A') }}} && chr <= {{{ charCode('F') }}});
-  },
-  isxdigit_l__deps: ['isxdigit'],
-  isxdigit_l: function(chr) {
-    return _isxdigit(chr); // no locale support yet
-  },
-  isalnum: function(chr) {
-    return (chr >= {{{ charCode('0') }}} && chr <= {{{ charCode('9') }}}) ||
-           (chr >= {{{ charCode('a') }}} && chr <= {{{ charCode('z') }}}) ||
-           (chr >= {{{ charCode('A') }}} && chr <= {{{ charCode('Z') }}});
-  },
-  isalnum_l__deps: ['isalnum'],
-  isalnum_l: function(chr) {
-    return _isalnum(chr); // no locale support yet
-  },
-  ispunct: function(chr) {
-    return (chr >= {{{ charCode('!') }}} && chr <= {{{ charCode('/') }}}) ||
-           (chr >= {{{ charCode(':') }}} && chr <= {{{ charCode('@') }}}) ||
-           (chr >= {{{ charCode('[') }}} && chr <= {{{ charCode('`') }}}) ||
-           (chr >= {{{ charCode('{') }}} && chr <= {{{ charCode('~') }}});
-  },
-  ispunct_l__deps: ['ispunct'],
-  ispunct_l: function(chr) {
-    return _ispunct(chr); // no locale support yet
-  },
-  isspace: function(chr) {
-    return (chr == 32) || (chr >= 9 && chr <= 13);
-  },
-  isspace_l__deps: ['isspace'],
-  isspace_l: function(chr) {
-    return _isspace(chr); // no locale support yet
-  },
-  isblank: function(chr) {
-    return chr == {{{ charCode(' ') }}} || chr == {{{ charCode('\t') }}};
-  },
-  isblank_l__deps: ['isblank'],
-  isblank_l: function(chr) {
-    return _isblank(chr); // no locale support yet
-  },
-  iscntrl: function(chr) {
-    return (0 <= chr && chr <= 0x1F) || chr === 0x7F;
-  },
-  iscntrl_l__deps: ['iscntrl'],
-  iscntrl_l: function(chr) {
-    return _iscntrl(chr); // no locale support yet
-  },
-  isprint: function(chr) {
-    return 0x1F < chr && chr < 0x7F;
-  },
-  isprint_l__deps: ['isprint'],
-  isprint_l: function(chr) {
-    return _isprint(chr); // no locale support yet
-  },
-  isgraph: function(chr) {
-    return 0x20 < chr && chr < 0x7F;
-  },
-  isgraph_l__deps: ['isgraph'],
-  isgraph_l: function(chr) {
-    return _isgraph(chr); // no locale support yet
-  },
   // Lookup tables for glibc ctype implementation.
   __ctype_b_loc__deps: ['malloc'],
   __ctype_b_loc: function() {

--- a/system/lib/libc.symbols
+++ b/system/lib/libc.symbols
@@ -40,6 +40,7 @@
          W _Znwj
          W _ZnwjRKSt9nothrow_t
          T __floatscan
+         T __intscan
          T __overflow
          T __shgetc
          T __shlim
@@ -57,6 +58,9 @@
          W free
          W independent_calloc
          W independent_comalloc
+         T isdigit
+         T isspace
+         T isupper
          W mallinfo
          W malloc
          W malloc_footprint
@@ -77,6 +81,12 @@
          T memcmp
          T memcpy
          T strtod
+         T strtoull
+         T strtoll
+         T strtoul
+         T strtol
+         T strtoimax
+         T strtoumax
          T strcoll
          T __strcoll_l
          W strcoll_l
@@ -89,4 +99,5 @@
          T strtof_l
          T strtold
          T strtold_l
+         T tolower
          W valloc

--- a/system/lib/libc/musl/src/compat/readme.txt
+++ b/system/lib/libc/musl/src/compat/readme.txt
@@ -1,0 +1,2 @@
+Files in this directory are not strictly standard musl libc, but implemented here for compatibility for Emscripten purposes.
+

--- a/system/lib/libc/musl/src/compat/strlwr.c
+++ b/system/lib/libc/musl/src/compat/strlwr.c
@@ -1,0 +1,10 @@
+#include <ctype.h>
+
+void strlwr(char *str)
+{
+	while(*str)
+	{
+		*str = tolower(*str);
+		++str;
+	}
+}

--- a/system/lib/libc/musl/src/compat/strtol_l.c
+++ b/system/lib/libc/musl/src/compat/strtol_l.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+#include <ctype.h>
+
+unsigned long long strtoull_l(const char *restrict s, char **restrict p, int base, locale_t loc)
+{
+	return strtoull(s, p, base);
+}
+
+long long strtoll_l(const char *restrict s, char **restrict p, int base, locale_t loc)
+{
+	return strtoll(s, p, base);
+}
+
+unsigned long strtoul_l(const char *restrict s, char **restrict p, int base, locale_t loc)
+{
+	return strtoul(s, p, base);
+}
+
+long strtol_l(const char *restrict s, char **restrict p, int base, locale_t loc)
+{
+	return strtol(s, p, base);
+}

--- a/system/lib/libc/musl/src/compat/strupr.c
+++ b/system/lib/libc/musl/src/compat/strupr.c
@@ -1,0 +1,10 @@
+#include <ctype.h>
+
+void strupr(char *str)
+{
+	while(*str)
+	{
+		*str = toupper(*str);
+		++str;
+	}
+}

--- a/system/lib/libc/musl/src/ctype/isalnum.c
+++ b/system/lib/libc/musl/src/ctype/isalnum.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isalnum(int c)
+{
+	return isalpha(c) || isdigit(c);
+}

--- a/system/lib/libc/musl/src/ctype/isalpha.c
+++ b/system/lib/libc/musl/src/ctype/isalpha.c
@@ -1,0 +1,7 @@
+#include <ctype.h>
+#undef isalpha
+
+int isalpha(int c)
+{
+	return ((unsigned)c|32)-'a' < 26;
+}

--- a/system/lib/libc/musl/src/ctype/isascii.c
+++ b/system/lib/libc/musl/src/ctype/isascii.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isascii(int c)
+{
+	return !(c&~0x7f);
+}

--- a/system/lib/libc/musl/src/ctype/isblank.c
+++ b/system/lib/libc/musl/src/ctype/isblank.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isblank(int c)
+{
+	return (c == ' ' || c == '\t');
+}

--- a/system/lib/libc/musl/src/ctype/iscntrl.c
+++ b/system/lib/libc/musl/src/ctype/iscntrl.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int iscntrl(int c)
+{
+	return (unsigned)c < 0x20 || c == 0x7f;
+}

--- a/system/lib/libc/musl/src/ctype/isdigit.c
+++ b/system/lib/libc/musl/src/ctype/isdigit.c
@@ -1,0 +1,7 @@
+#include <ctype.h>
+#undef isdigit
+
+int isdigit(int c)
+{
+	return (unsigned)c-'0' < 10;
+}

--- a/system/lib/libc/musl/src/ctype/isgraph.c
+++ b/system/lib/libc/musl/src/ctype/isgraph.c
@@ -1,0 +1,4 @@
+int isgraph(int c)
+{
+	return (unsigned)c-0x21 < 0x5e;
+}

--- a/system/lib/libc/musl/src/ctype/islower.c
+++ b/system/lib/libc/musl/src/ctype/islower.c
@@ -1,0 +1,7 @@
+#include <ctype.h>
+#undef islower
+
+int islower(int c)
+{
+	return (unsigned)c-'a' < 26;
+}

--- a/system/lib/libc/musl/src/ctype/isprint.c
+++ b/system/lib/libc/musl/src/ctype/isprint.c
@@ -1,0 +1,4 @@
+int isprint(int c)
+{
+	return (unsigned)c-0x20 < 0x5f;
+}

--- a/system/lib/libc/musl/src/ctype/ispunct.c
+++ b/system/lib/libc/musl/src/ctype/ispunct.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int ispunct(int c)
+{
+	return isgraph(c) && !isalnum(c);
+}

--- a/system/lib/libc/musl/src/ctype/isspace.c
+++ b/system/lib/libc/musl/src/ctype/isspace.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isspace(int c)
+{
+	return c == ' ' || (unsigned)c-'\t' < 5;
+}

--- a/system/lib/libc/musl/src/ctype/isupper.c
+++ b/system/lib/libc/musl/src/ctype/isupper.c
@@ -1,0 +1,7 @@
+#include <ctype.h>
+#undef isupper
+
+int isupper(int c)
+{
+	return (unsigned)c-'A' < 26;
+}

--- a/system/lib/libc/musl/src/ctype/isxdigit.c
+++ b/system/lib/libc/musl/src/ctype/isxdigit.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isxdigit(int c)
+{
+	return isdigit(c) || ((unsigned)c|32)-'a' < 6;
+}

--- a/system/lib/libc/musl/src/ctype/toascii.c
+++ b/system/lib/libc/musl/src/ctype/toascii.c
@@ -1,0 +1,7 @@
+#include <ctype.h>
+
+/* nonsense function that should NEVER be used! */
+int toascii(int c)
+{
+	return c & 0x7f;
+}

--- a/system/lib/libc/musl/src/ctype/tolower.c
+++ b/system/lib/libc/musl/src/ctype/tolower.c
@@ -1,0 +1,7 @@
+#include <ctype.h>
+
+int tolower(int c)
+{
+	if (isupper(c)) return c | 32;
+	return c;
+}

--- a/system/lib/libc/musl/src/ctype/toupper.c
+++ b/system/lib/libc/musl/src/ctype/toupper.c
@@ -1,0 +1,7 @@
+#include <ctype.h>
+
+int toupper(int c)
+{
+	if (islower(c)) return c & 0x5f;
+	return c;
+}

--- a/system/lib/libc/musl/src/locale/isalnum_l.c
+++ b/system/lib/libc/musl/src/locale/isalnum_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isalnum_l(int c, locale_t l)
+{
+	return isalnum(c);
+}

--- a/system/lib/libc/musl/src/locale/isalpha_l.c
+++ b/system/lib/libc/musl/src/locale/isalpha_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isalpha_l(int c, locale_t l)
+{
+	return isalpha(c);
+}

--- a/system/lib/libc/musl/src/locale/isblank_l.c
+++ b/system/lib/libc/musl/src/locale/isblank_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isblank_l(int c, locale_t l)
+{
+	return isblank(c);
+}

--- a/system/lib/libc/musl/src/locale/iscntrl_l.c
+++ b/system/lib/libc/musl/src/locale/iscntrl_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int iscntrl_l(int c, locale_t l)
+{
+	return iscntrl(c);
+}

--- a/system/lib/libc/musl/src/locale/isdigit_l.c
+++ b/system/lib/libc/musl/src/locale/isdigit_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isdigit_l(int c, locale_t l)
+{
+	return isdigit(c);
+}

--- a/system/lib/libc/musl/src/locale/isgraph_l.c
+++ b/system/lib/libc/musl/src/locale/isgraph_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isgraph_l(int c, locale_t l)
+{
+	return isgraph(c);
+}

--- a/system/lib/libc/musl/src/locale/islower_l.c
+++ b/system/lib/libc/musl/src/locale/islower_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int islower_l(int c, locale_t l)
+{
+	return islower(c);
+}

--- a/system/lib/libc/musl/src/locale/isprint_l.c
+++ b/system/lib/libc/musl/src/locale/isprint_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isprint_l(int c, locale_t l)
+{
+	return isprint(c);
+}

--- a/system/lib/libc/musl/src/locale/ispunct_l.c
+++ b/system/lib/libc/musl/src/locale/ispunct_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int ispunct_l(int c, locale_t l)
+{
+	return ispunct(c);
+}

--- a/system/lib/libc/musl/src/locale/isspace_l.c
+++ b/system/lib/libc/musl/src/locale/isspace_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isspace_l(int c, locale_t l)
+{
+	return isspace(c);
+}

--- a/system/lib/libc/musl/src/locale/isupper_l.c
+++ b/system/lib/libc/musl/src/locale/isupper_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isupper_l(int c, locale_t l)
+{
+	return isupper(c);
+}

--- a/system/lib/libc/musl/src/locale/isxdigit_l.c
+++ b/system/lib/libc/musl/src/locale/isxdigit_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int isxdigit_l(int c, locale_t l)
+{
+	return isxdigit(c);
+}

--- a/system/lib/libc/musl/src/locale/tolower_l.c
+++ b/system/lib/libc/musl/src/locale/tolower_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int tolower_l(int c, locale_t l)
+{
+	return tolower(c);
+}

--- a/system/lib/libc/musl/src/locale/toupper_l.c
+++ b/system/lib/libc/musl/src/locale/toupper_l.c
@@ -1,0 +1,6 @@
+#include <ctype.h>
+
+int toupper_l(int c, locale_t l)
+{
+	return toupper(c);
+}

--- a/system/lib/libc/musl/src/stdlib/strtol.c
+++ b/system/lib/libc/musl/src/stdlib/strtol.c
@@ -1,0 +1,64 @@
+#include "stdio_impl.h"
+#include "intscan.h"
+#include "shgetc.h"
+#include <inttypes.h>
+#include <limits.h>
+#include <ctype.h>
+#include "libc.h"
+
+static unsigned long long strtox(const char *s, char **p, int base, unsigned long long lim)
+{
+	/* FIXME: use a helper function or macro to setup the FILE */
+	FILE f;
+	f.flags = 0;
+	f.buf = f.rpos = (void *)s;
+	if ((size_t)s > (size_t)-1/2)
+		f.rend = (void *)-1;
+	else
+		f.rend = (unsigned char *)s+(size_t)-1/2;
+	f.lock = -1;
+	shlim(&f, 0);
+	unsigned long long y = __intscan(&f, base, 1, lim);
+	if (p) {
+		size_t cnt = shcnt(&f);
+		*p = (char *)s + cnt;
+	}
+	return y;
+}
+
+unsigned long long strtoull(const char *restrict s, char **restrict p, int base)
+{
+	return strtox(s, p, base, ULLONG_MAX);
+}
+
+long long strtoll(const char *restrict s, char **restrict p, int base)
+{
+	return strtox(s, p, base, LLONG_MIN);
+}
+
+unsigned long strtoul(const char *restrict s, char **restrict p, int base)
+{
+	return strtox(s, p, base, ULONG_MAX);
+}
+
+long strtol(const char *restrict s, char **restrict p, int base)
+{
+	return strtox(s, p, base, 0UL+LONG_MIN);
+}
+
+intmax_t strtoimax(const char *restrict s, char **restrict p, int base)
+{
+	return strtoll(s, p, base);
+}
+
+uintmax_t strtoumax(const char *restrict s, char **restrict p, int base)
+{
+	return strtoull(s, p, base);
+}
+
+weak_alias(strtol, __strtol_internal);
+weak_alias(strtoul, __strtoul_internal);
+weak_alias(strtoll, __strtoll_internal);
+weak_alias(strtoull, __strtoull_internal);
+weak_alias(strtoimax, __strtoimax_internal);
+weak_alias(strtoumax, __strtoumax_internal);

--- a/system/lib/libcextra.symbols
+++ b/system/lib/libcextra.symbols
@@ -1,7 +1,6 @@
          T __cos
          T __cosdf
          T __fputwc_unlocked
-         T __intscan
          W __iswctype_l
          T __lgamma_r
          T __lgammaf_r
@@ -46,6 +45,27 @@
          T ilogbf
          T ilogbl
          T index
+         T isascii
+         T islower
+         T islower_l
+         T isupper_l
+         T isalpha
+         T isalpha_l
+         T isblank_l
+         T isdigit_l
+         T isxdigit
+         T isxdigit_l
+         T isalnum
+         T isalnum_l
+         T ispunct
+         T ispunct_l
+         T isspace_l
+         T iscntrl
+         T iscntrl_l
+         T isprint
+         T isprint_l
+         T isgraph
+         T isgraph_l
          T iswalnum
          T iswalnum_l
          T iswalpha
@@ -122,6 +142,7 @@
          T strfmon_l
          T strlcat
          T strlcpy
+         T strlwr
          T strncasecmp_l
          T strncat
          T strndup
@@ -133,6 +154,11 @@
          T strstr
          T strtok
          T strtok_r
+         T strtoull_l
+         T strtoll_l
+         T strtoul_l
+         T strtol_l
+         T strupr
          T strverscmp
          T strxfrm
          W strxfrm_l
@@ -140,6 +166,10 @@
          T tgamma
          T tgammaf
          T tgammal
+         T toascii
+         T toupper
+         T toupper_l
+         T tolower_l
          T towctrans
          T towctrans_l
          T towlower

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -55,7 +55,14 @@ def calculate(temp_files, in_temp, stdout, stderr):
       os.path.join('libcxx', 'new.cpp'),
     ]
     musl_files = [
+      ['ctype', [
+       'isdigit.c',
+       'isspace.c',
+       'isupper.c',
+       'tolower.c',
+      ]],
       ['internal', [
+       'intscan.c',
        'floatscan.c',
        'shgetc.c',
       ]],
@@ -74,6 +81,7 @@ def calculate(temp_files, in_temp, stdout, stderr):
        'atoi.c',
        'atol.c',
        'strtod.c',
+       'strtol.c',
       ]],
       ['string', [
        'memcmp.c',
@@ -103,7 +111,22 @@ def calculate(temp_files, in_temp, stdout, stderr):
   def create_libcextra():
     logging.debug('building libcextra for cache')
     musl_files = [
+       ['compat', [
+        'strlwr.c',
+        'strtol_l.c',
+        'strupr.c'
+       ]],
        ['ctype', [
+        'isalnum.c',
+        'isalpha.c',
+        'isascii.c',
+        'isblank.c',
+        'iscntrl.c',
+        'isgraph.c',
+        'islower.c',
+        'isprint.c',
+        'ispunct.c',
+        'isxdigit.c',
         'iswalnum.c',
         'iswalpha.c',
         'iswblank.c',
@@ -117,19 +140,30 @@ def calculate(temp_files, in_temp, stdout, stderr):
         'iswspace.c',
         'iswupper.c',
         'iswxdigit.c',
+        'toascii.c',
+        'toupper.c',
         'towctrans.c',
         'wcswidth.c',
         'wctrans.c',
         'wcwidth.c',
-       ]],
-       ['internal', [
-        'intscan.c',
        ]],
        ['legacy', [
         'err.c',
        ]],
        ['locale', [
         'iconv.c',
+        'isalnum_l.c',
+        'isalpha_l.c',
+        'isblank_l.c',
+        'iscntrl_l.c',
+        'isdigit_l.c',
+        'isgraph_l.c',
+        'islower_l.c',
+        'isprint_l.c',
+        'ispunct_l.c',
+        'isspace_l.c',
+        'isupper_l.c',
+        'isxdigit_l.c',
         'iswalnum_l.c',
         'iswalpha_l.c',
         'iswblank_l.c',
@@ -148,6 +182,8 @@ def calculate(temp_files, in_temp, stdout, stderr):
         'strfmon.c',
         'strncasecmp_l.c',
         'strxfrm.c',
+        'tolower_l.c',
+        'toupper_l.c',
         'towctrans_l.c',
         'towlower_l.c',
         'towupper_l.c',


### PR DESCRIPTION
Moves several single-character functions and string functions to use musl 0.9.13.
