### PR TITLE
Fix issues with source map loading in Firefox

### DIFF
--- a/src/emscripten-source-map.min.js
+++ b/src/emscripten-source-map.min.js
@@ -4,7 +4,7 @@ var emscripten_sourcemap_xmlHttp = undefined;
 function emscripten_sourceMapLoaded() {
   if (emscripten_sourcemap_xmlHttp.readyState === 4) {
     Module['removeRunDependency']('sourcemap');
-    if (emscripten_sourcemap_xmlHttp.status === 200) {
+    if (emscripten_sourcemap_xmlHttp.status === 200 || emscripten_sourcemap_xmlHttp.status === 0) {
       emscripten_source_map = new window.sourceMap.SourceMapConsumer(emscripten_sourcemap_xmlHttp.responseText);
       console.log('Source map data loaded.');
     } else {
@@ -20,6 +20,7 @@ function emscripten_loadSourceMap() {
   emscripten_sourcemap_xmlHttp = new XMLHttpRequest();
   emscripten_sourcemap_xmlHttp.onreadystatechange = emscripten_sourceMapLoaded;
   emscripten_sourcemap_xmlHttp.open("GET", url, true);
+  emscripten_sourcemap_xmlHttp.responseType = "text";
   emscripten_sourcemap_xmlHttp.send(null);
 }
 


### PR DESCRIPTION
This fixes a few issues using emscripten-source-map.min.js to load
source map data in Firefox. Firefox by default tries to interpret any file
loaded from an XHR as an XML file, which the source map is not, producing
an error. This tells it to load as a text file instead. This allows a successful
read from a status code of 0, which is needed if reading from a non-HTTP source,
such as a local file.
