### PR TITLE
Whitelist supported link flags

### DIFF
--- a/emcc
+++ b/emcc
@@ -64,6 +64,7 @@ DYNAMICLIB_ENDINGS = ('.dylib', '.so', '.dll')
 STATICLIB_ENDINGS = ('.a',)
 ASSEMBLY_ENDINGS = ('.ll',)
 HEADER_ENDINGS = ('.h', '.hxx', '.hpp', '.hh', '.H', '.HXX', '.HPP', '.HH')
+SUPPORTED_LINKER_FLAGS = ('--start-group', '-(', '--end-group', '-)')
 
 LIB_PREFIXES = ('', 'lib')
 
@@ -1177,7 +1178,12 @@ try:
       # (4, a), (4.25, b), (4.5, c), (4.75, d)
       link_flags_to_add = arg.split(',')[1:]
       for flag_index, flag in enumerate(link_flags_to_add):
-        link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
+        # Only keep flags that shared.Building.link knows how to deal with.
+        # We currently can't handle flags with options (like
+        # -Wl,-rpath,/bin:/lib, where /bin:/lib is an option for the -rpath
+        # flag).
+        if flag in SUPPORTED_LINKER_FLAGS:
+          link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
       newargs[i] = ''
 
   original_input_files = input_files[:]


### PR DESCRIPTION
Only keep known linker flags when parsing arguments. This avoids issues when passing linker flags with options like:

`-Wl,-rpath,/bin:/lib`

Which is turned into two arguments `-rpath` and `/bin:/lib` when passed to link(), the second of which is incorrectly interpreted as a file input (since it doesn't know about rpath).

This code will need to change if we need to support linker flags with options in the future, but I guess we'll cross that bridge when we get to it.
