### PR TITLE
Fix registerizeHarder handling unlabelled continue

### DIFF
--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -2087,11 +2087,17 @@ function registerizeHarder(ast) {
     function pushActiveLabels(onContinue, onBreak) {
       // Push the target junctions for continuing/breaking a loop.
       // This should be called before traversing into a loop.
-      var newLabels = copy(activeLabels[activeLabels.length-1]);
+      var prevLabels = activeLabels[activeLabels.length-1];
+      var newLabels = copy(prevLabels);
       newLabels[null] = [onContinue, onBreak];
       if (nextLoopLabel) {
         newLabels[nextLoopLabel] = [onContinue, onBreak];
         nextLoopLabel = null;
+      }
+      // An unlabelled 'continue' should jump to innermost loop,
+      // ignoring any nested 'switch' statements.
+      if (onContinue === null && prevLabels[null]) {
+        newLabels[null][0] = prevLabels[null][0];
       }
       activeLabels.push(newLabels);
     }


### PR DESCRIPTION
The registerizeHarder pass was not correctly handling an unlablled 'continue' inside a 'switch'.  Given e.g. this:

```
while(1) {
  switch (n) {
    case 0:
      continue
    ...
  }
}
```

It would treat the `continue` as if it jumped to the start of the `switch` context (which is nonsense and caused an error) rather than the start of the enclosing `while` context.  This PR fixes it by ensuring that the `onContinue` junction for a `switch` is set to the value from its enclosing context.

This fixes `asm3.test_freetype` for me.
