### PR TITLE
Test js libraries in core

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1306,38 +1306,6 @@ This pointer might make sense in another type signature: i: 0
 
     self.assertContained('TestA\nTestB\nTestA\n', run_js('main.js', engine=SPIDERMONKEY_ENGINE))
 
-  def test_js_libraries(self):
-    open(os.path.join(self.get_dir(), 'main.cpp'), 'w').write('''
-      #include <stdio.h>
-      extern "C" {
-        extern void printey();
-        extern int calcey(int x, int y);
-      }
-      int main() {
-        printey();
-        printf("*%d*\\n", calcey(10, 22));
-        return 0;
-      }
-    ''')
-    open(os.path.join(self.get_dir(), 'mylib1.js'), 'w').write('''
-      mergeInto(LibraryManager.library, {
-        printey: function() {
-          Module.print('hello from lib!');
-        }
-      });
-    ''')
-    open(os.path.join(self.get_dir(), 'mylib2.js'), 'w').write('''
-      mergeInto(LibraryManager.library, {
-        calcey: function(x, y) {
-          return x + y;
-        }
-      });
-    ''')
-
-    Popen([PYTHON, EMCC, os.path.join(self.get_dir(), 'main.cpp'), '--js-library', os.path.join(self.get_dir(), 'mylib1.js'),
-                                                                   '--js-library', os.path.join(self.get_dir(), 'mylib2.js')]).communicate()
-    self.assertContained('hello from lib!\n*32*\n', run_js(os.path.join(self.get_dir(), 'a.out.js')))
-
   def test_identical_basenames(self):
     # Issue 287: files in different dirs but with the same basename get confused as the same,
     # causing multiply defined symbol errors


### PR DESCRIPTION
Also minor change to ascii text data handling in assert() of that test (\r\n vs \n difference)
