### PR TITLE
Nonprefixed library functions

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -465,8 +465,8 @@ def emscript(infile, settings, outfile, libraries=[], compiler_engine=None,
     basic_float_vars = ['NaN', 'Infinity']
 
     if forwarded_json['Types']['preciseI64MathUsed'] or \
-       forwarded_json['Functions']['libraryFunctions'].get('llvm_cttz_i32') or \
-       forwarded_json['Functions']['libraryFunctions'].get('llvm_ctlz_i32'):
+       forwarded_json['Functions']['libraryFunctions'].get('_llvm_cttz_i32') or \
+       forwarded_json['Functions']['libraryFunctions'].get('_llvm_ctlz_i32'):
       basic_vars += ['cttz_i8', 'ctlz_i8']
 
     if settings.get('DLOPEN_SUPPORT'):
@@ -529,7 +529,7 @@ def emscript(infile, settings, outfile, libraries=[], compiler_engine=None,
       pass
     # If no named globals, only need externals
     global_vars = map(lambda g: g['name'], filter(lambda g: settings['NAMED_GLOBALS'] or g.get('external') or g.get('unIndexable'), forwarded_json['Variables']['globals'].values()))
-    global_funcs = ['_' + key for key, value in forwarded_json['Functions']['libraryFunctions'].iteritems() if value != 2]
+    global_funcs = [key for key, value in forwarded_json['Functions']['libraryFunctions'].iteritems() if value != 2]
     def math_fix(g):
       return g if not g.startswith('Math_') else g.split('_')[1]
     asm_global_funcs = ''.join(['  var ' + g.replace('.', '_') + '=global.' + g + ';\n' for g in maths]) + \
@@ -1062,8 +1062,8 @@ def emscript_fast(infile, settings, outfile, libraries=[], compiler_engine=None,
       basic_float_vars = ['NaN', 'Infinity']
 
       if metadata.get('preciseI64MathUsed') or \
-         forwarded_json['Functions']['libraryFunctions'].get('llvm_cttz_i32') or \
-         forwarded_json['Functions']['libraryFunctions'].get('llvm_ctlz_i32'):
+         forwarded_json['Functions']['libraryFunctions'].get('_llvm_cttz_i32') or \
+         forwarded_json['Functions']['libraryFunctions'].get('_llvm_ctlz_i32'):
         basic_vars += ['cttz_i8', 'ctlz_i8']
 
       if settings.get('DLOPEN_SUPPORT'):
@@ -1126,7 +1126,7 @@ def emscript_fast(infile, settings, outfile, libraries=[], compiler_engine=None,
         pass
       # If no named globals, only need externals
       global_vars = metadata['externs'] #+ forwarded_json['Variables']['globals']
-      global_funcs = list(set(['_' + key for key, value in forwarded_json['Functions']['libraryFunctions'].iteritems() if value != 2]).difference(set(global_vars)).difference(implemented_functions))
+      global_funcs = list(set([key for key, value in forwarded_json['Functions']['libraryFunctions'].iteritems() if value != 2]).difference(set(global_vars)).difference(implemented_functions))
       def math_fix(g):
         return g if not g.startswith('Math_') else g.split('_')[1]
       asm_global_funcs = ''.join(['  var ' + g.replace('.', '_') + '=global.' + g + ';\n' for g in maths]) + \

--- a/src/library.js
+++ b/src/library.js
@@ -4041,7 +4041,7 @@ LibraryManager.library = {
     {{{ makeStructuralReturn(['thrown', 'throwntype']) }}};
   },
 
-  __resumeException__deps: [function() { Functions.libraryFunctions['__resumeException'] = 1 }, '__cxa_last_thrown_exception'], // will be called directly from compiled code
+  __resumeException__deps: [function() { Functions.libraryFunctions['___resumeException'] = 1 }, '__cxa_last_thrown_exception'], // will be called directly from compiled code
   __resumeException: function(ptr) {
 #if EXCEPTION_DEBUG
     Module.print("Resuming exception");


### PR DESCRIPTION
This fixes issue #2395.

It is close to working fully in that some tests fail currently.

Notably, everything in `slow2` is failing (not sure why) and `test_dlfcn_stacks` and `test_asm_pgo` are failing in `slow2asm`.

All of `default` is passing however.

This is a requirement for pull request #2240 to be able to land.
