### PR TITLE
[embind tests] Give AbstractClassWithConstructor a virtual destructor.

### DIFF
--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -1201,6 +1201,8 @@ struct AbstractClassWithConstructor {
         : s(s)
     {}
 
+    virtual ~AbstractClassWithConstructor() {};
+
     virtual std::string abstractMethod() = 0;
     std::string concreteMethod() {
         return s;


### PR DESCRIPTION
This is required for the IMVU build as it errors on this.
