### PR TITLE
update to use cryptographic random if it is available

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1211,8 +1211,19 @@ mergeInto(LibraryManager.library, {
       FS.mkdev('/dev/tty', FS.makedev(5, 0));
       FS.mkdev('/dev/tty1', FS.makedev(6, 0));
       // setup /dev/[u]random
-      FS.createDevice('/dev', 'random', function() { return Math.floor(Math.random()*256); });
-      FS.createDevice('/dev', 'urandom', function() { return Math.floor(Math.random()*256); });
+      var random_device;
+      if (typeof crypto !== 'undefined') {
+        // for modern web browsers
+        random_device = function() { return crypto.getRandomValues(arguments[0])[0]; }.bind(undefined, new Uint8Array(1));
+      } else if (ENVIRONMENT_IS_NODE) {
+        // for nodejs
+        random_device = function() { return require('crypto').randomBytes(1)[0]; };
+      } else {
+        // default for ES5 platforms
+        random_device = function() { return Math.floor(Math.random()*256); };
+      }
+      FS.createDevice('/dev', 'random', random_device);
+      FS.createDevice('/dev', 'urandom', random_device);
       // we're not going to emulate the actual shm device,
       // just create the tmp dirs that reside in it commonly
       FS.mkdir('/dev/shm');


### PR DESCRIPTION
The pull-request based on https://github.com/kripken/emscripten/issues/2439#event-134356617.

References:
- https://dvcs.w3.org/hg/webcrypto-api/raw-file/tip/spec/Overview.html#RandomSource-description
- https://developer.mozilla.org/ja/docs/Web/API/window.crypto.getRandomValues#Browser_Compatibility
- http://nodejs.org/api/crypto.html#crypto_crypto_randombytes_size_callback

---

Result of `python tests/runner.py test_random_device`
- nodejs-0.10.25

```
test_random_device (test_core.default) ... (checking sanity from test runner)
INFO     root: (Emscripten: Running sanity checks)
ok

----------------------------------------------------------------------
Ran 1 test in 1.584s

OK
```

---

And, I tested Firefox-30 and Chromium-35 on Ubuntu-14.04 that is ok.
( The test is modify the code simply, add a logging in the code path and call std::random() and read std::ifstream("/dev/[u]random"). )
