### PR TITLE
Remove SDL_ttf from sdl_key{_proxy}

### DIFF
--- a/tests/sdl_key.c
+++ b/tests/sdl_key.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <SDL/SDL.h>
-#include <SDL/SDL_ttf.h>
 #include <emscripten.h>
 
 int result = 1;

--- a/tests/sdl_key_proxy.c
+++ b/tests/sdl_key_proxy.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <SDL/SDL.h>
-#include <SDL/SDL_ttf.h>
 #include <emscripten.h>
 
 int result = 1;


### PR DESCRIPTION
SDL_ttf wasn't used at all. No need to include it.

```
➜  tests git:(incoming) ✗ python runner.py browser.test_sdl_key browser.test_sdl_key_proxy
[Browser harness server on process 65057]

Running the browser tests. Make sure the browser allows popups from localhost.

test_sdl_key (test_browser.browser) ... ok
test_sdl_key_proxy (test_browser.browser) ... ok
[Browser harness server terminated]

----------------------------------------------------------------------
Ran 2 tests in 3.571s

OK
```
