### PR TITLE
when compiler.js fails, it should also return an error code and give a u...

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -308,18 +308,14 @@ function compile(raw) {
 
 B = new Benchmarker();
 
-try {
-  if (ll_file) {
-    if (phase === 'glue') {
-      compile(';');
-    } else if (ll_file.indexOf(String.fromCharCode(10)) == -1) {
-      compile(read(ll_file));
-    } else {
-      compile(ll_file); // we are given raw .ll
-    }
+if (ll_file) {
+  if (ephase === 'glue') {
+    compile(';');
+  } else if (ll_file.indexOf(String.fromCharCode(10)) == -1) {
+    compile(read(ll_file));
+  } else {
+    compile(ll_file); // we are given raw .ll
   }
-} catch(err) {
-  printErr('aborting from js compiler due to exception: ' + err + ' | ' + err.stack);
 }
 
 //var M = keys(tokenCacheMisses).map(function(m) { return [m, misses[m]] }).sort(function(a, b) { return a[1] - b[1] });


### PR DESCRIPTION
...seful error message (the printErr wasn't always doing that?)

For whatever reason, I was having a very hard time figuring out where a particular invocation of emcc was failing, and it turns out compiler.js was 1) not returning a nonzero exit code and 2) not printing a stack trace.

If I removed the catch clause, it did exactly what it should have, and made the problem easy to diagnose.
