### PR TITLE
Remove sdl_ttf from sdl_mouse test

### DIFF
--- a/tests/sdl_mouse.c
+++ b/tests/sdl_mouse.c
@@ -1,6 +1,5 @@
 #include <stdio.h>
 #include <SDL/SDL.h>
-#include <SDL/SDL_ttf.h>
 #include <assert.h>
 #include <emscripten.h>
 


### PR DESCRIPTION
sdl_ttf isn't being used at all.

```
➜  tests git:(incoming) ✗ python runner.py browser.test_sdl_mouse
[Browser harness server on process 80314]

Running the browser tests. Make sure the browser allows popups from localhost.

test_sdl_mouse (test_browser.browser) ... ok
[Browser harness server terminated]

----------------------------------------------------------------------
Ran 1 test in 5.055s

OK
```
