### PR TITLE
Refactor sdl_canvas_size

### DIFF
--- a/tests/sdl_canvas_size.c
+++ b/tests/sdl_canvas_size.c
@@ -22,7 +22,6 @@ int main(int argc, char *argv[])
 
     // Test 1: Check that initializing video mode with size (0,0) will use the size from the <canvas> element.
     screen = SDL_SetVideoMode( 0, 0, 16, SDL_OPENGL ); // *changed*
-    result += 1;
 
     // Test 2: Check that getting current canvas size works.
     int w, h, fs;
@@ -30,7 +29,6 @@ int main(int argc, char *argv[])
     printf("w:%d,h:%d\n", w,h);
     assert(w == 700);
     assert(h == 200);
-    result += 1;
 
     // Test 3: Check that resizing the canvas works as well.
     emscripten_set_canvas_size(640, 480);
@@ -38,7 +36,6 @@ int main(int argc, char *argv[])
     printf("w:%d,h:%d\n", w,h);
     assert(w == 640);
     assert(h == 480);
-    result += 1;
 
     SDL_Quit();
     REPORT_RESULT();

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1127,7 +1127,7 @@ keydown(100);keyup(100); // trigger the end
     self.btest('sdl_pumpevents.c', expected='7', args=['--pre-js', 'pre.js'])
 
   def test_sdl_canvas_size(self):
-    self.btest('sdl_canvas_size.c', expected='4',
+    self.btest('sdl_canvas_size.c', expected='1',
       args=['-O2', '--minify', '0', '--shell-file', path_from_root('tests', 'sdl_canvas_size.html')])
 
   def test_sdl_gl_read(self):


### PR DESCRIPTION
There's no need to load all the OpenGL stuff to test canvas size and resizing. There's a separate test that tests the OpenGL stuff.
