### PR TITLE
ADDED: missing OpenAL method 'alSourceRewind'

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -852,6 +852,28 @@ var LibraryOpenAL = {
     AL.setSourceState(src, 0x1014 /* AL_STOPPED */);
   },
 
+  alSourceRewind__deps: ['setSourceState'],
+  alSourceRewind: function(source) {
+    if (!AL.currentContext) {
+#if OPENAL_DEBUG
+      console.error("alSourceRewind called without a valid context");
+#endif
+      return;
+    }
+    var src = AL.currentContext.src[source - 1];
+    if (!src) {
+#if OPENAL_DEBUG
+      console.error("alSourceRewind called with an invalid source");
+#endif
+      AL.currentContext.err = 0xA001 /* AL_INVALID_NAME */;
+      return;
+    }
+    // Stop the source first to clear the source queue
+    AL.setSourceState(src, 0x1014 /* AL_STOPPED */);
+    // Now set the state of AL_INITIAL according to the specification
+    AL.setSourceState(src, 0x1011 /* AL_INITIAL */);
+  },
+
   alSourcePause__deps: ['setSourceState'],
   alSourcePause: function(source) {
     if (!AL.currentContext) {


### PR DESCRIPTION
This pull request adds a missing method to the openAL library, namely 'alSourceRewind'.

> alSourceRewind applied to an AL_INITIAL source is a legal NOP. alSourceRewind applied to a AL_PLAYING source will change its state to AL_STOPPED then AL_INITIAL. The source is exempt from processing: its current state is preserved, with the exception of the sampling offset, which is reset to the beginning. alSourceRewind applied to a AL_PAUSED source will change its state to AL_INITIAL, with the same consequences as on a AL_PLAYING source. alSourceRewind applied to an AL_STOPPED source promotes the source to AL_INITIAL, resetting the sampling offset to the beginning.

Check out the spec for more info: http://www.openal.org/documentation/openal-1.1-specification.pdf

As this is the extension of library code, no tests have been run. However, we have built and tested two games with this patch.
