### PR TITLE
clean up how PYTHON is specified.  it is not specified in .emscripten by default

### DIFF
--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -7,7 +7,9 @@ import os
 # this helps projects using emscripten find it
 EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN') or '{{{ EMSCRIPTEN_ROOT }}}') # directory
 LLVM_ROOT = os.path.expanduser(os.getenv('LLVM') or '{{{ LLVM_ROOT }}}') # directory
-PYTHON = os.path.expanduser(os.getenv('PYTHON') or '{{{ PYTHON }}}') # executable
+
+# If not specified, defaults to sys.executable.
+#PYTHON = 'python'
 
 # See below for notes on which JS engine(s) you need
 NODE_JS = os.path.expanduser(os.getenv('NODE') or '{{{ NODE }}}') # executable

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -216,9 +216,6 @@ else:
     config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
     node = find_executable('node') or find_executable('nodejs') or 'node'
     config_file = config_file.replace('\'{{{ NODE }}}\'', repr(node))
-    python = find_executable('python2') or find_executable('python') or \
-        sys.executable or 'python'
-    config_file = config_file.replace('\'{{{ PYTHON }}}\'', repr(python))
     if WINDOWS:
       tempdir = os.environ.get('TEMP') or os.environ.get('TMP') or 'c:\\temp'
     else:
@@ -238,7 +235,6 @@ A settings file has been copied to %s, at absolute path: %s
 It contains our best guesses for the important paths, which are:
 
   LLVM_ROOT       = %s
-  PYTHON          = %s
   NODE_JS         = %s
   EMSCRIPTEN_ROOT = %s
 
@@ -246,7 +242,7 @@ Please edit the file if any of those are incorrect.
 
 This command will now exit. When you are done editing those paths, re-run it.
 ==============================================================================
-''' % (EM_CONFIG, CONFIG_FILE, llvm_root, python, node, __rootpath__)
+''' % (EM_CONFIG, CONFIG_FILE, llvm_root, node, __rootpath__)
     sys.exit(0)
 try:
   config_text = open(CONFIG_FILE, 'r').read() if CONFIG_FILE else EM_CONFIG
@@ -640,8 +636,8 @@ except:
 try:
   PYTHON
 except:
-  logging.debug('PYTHON not defined in ~/.emscripten, using "python"')
-  PYTHON = 'python'
+  logging.debug('PYTHON not defined in ~/.emscripten, using "%s"' % (sys.executable,))
+  PYTHON = sys.executable
 
 try:
   JAVA


### PR DESCRIPTION
Clean up how PYTHON is configured.  This would have prevented some trouble we ran into where the default logic for discovering Python was finding Cygwin Python even when invoking emcc with Win32 Python.
