### PR TITLE
Fix error that broke inlining of aliases of asm functions like llvm_memcpy_*

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -444,7 +444,7 @@ var LibraryManager = {
     }
 
     // apply synonyms. these are typically not speed-sensitive, and doing it this way makes it possible to not include hacks in the compiler
-    // (and makes it simpler to switch between SDL verisons, fastcomp and non-fastcomp, etc.).
+    // (and makes it simpler to switch between SDL versions, fastcomp and non-fastcomp, etc.).
     var lib = LibraryManager.library;
     libloop: for (var x in lib) {
       if (x.lastIndexOf('__') > 0) continue; // ignore __deps, __*
@@ -455,6 +455,7 @@ var LibraryManager = {
           if (lib[target].indexOf('(') >= 0) continue libloop;
           target = lib[target];
         }
+        if (lib[target + '__asm']) continue; // This is an alias of an asm library function. Also needs to be fully optimized.
         if (typeof lib[target] === 'undefined' || typeof lib[target] === 'function') {
           if (target.indexOf('Math_') < 0) {
             lib[x] = new Function('return _' + target + '.apply(null, arguments)');


### PR DESCRIPTION
This caused a substantial performance drop in things that were generating calls to `llvm_memcpy_*`
