### PR TITLE
Fix math function aliases

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -461,7 +461,6 @@ var LibraryManager = {
           lib[x] = new Function('return _' + target + '.apply(null, arguments)');
           if (!lib[x + '__deps']) lib[x + '__deps'] = [];
           lib[x + '__deps'].push(target);
-          continue;
         }
       }
     }


### PR DESCRIPTION
This prevents Math calls from going through the slow path and just letting them get mapped as they were previously.

This isn't identical behavior to a year ago as then, a call to `sqrtf()` would get compiled to `Math.sqrt()` while with this change, it gets compiled to `Math_sqrt()`

cc: @chadaustin
