### PR TITLE
add RGBA8888 pixel format check in various SDL APIs

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -260,6 +260,16 @@ var LibrarySDL = {
       };
     },
 
+    checkPixelFormat: function(fmt) {
+#if ASSERTIONS
+      // Canvas screens are always RGBA.
+      var format = {{{ makeGetValue('fmt', C_STRUCTS.SDL_PixelFormat.format, 'i32') }}};
+      if (format != {{{ cDefine('SDL_PIXELFORMAT_RGBA8888') }}}) {
+        Runtime.warnOnce('Unsupported pixel format!');
+      }
+#endif
+    },
+
     // Load SDL color into a CSS-style color specification
     loadColorToCSSRGB: function(color) {
       var rgba = {{{ makeGetValue('color', '0', 'i32') }}};
@@ -1840,17 +1850,20 @@ var LibrarySDL = {
   },
 
   SDL_MapRGB: function(fmt, r, g, b) {
-    // Canvas screens are always RGBA. We assume the machine is little-endian.
+    SDL.checkPixelFormat(fmt);
+    // We assume the machine is little-endian.
     return r&0xff|(g&0xff)<<8|(b&0xff)<<16|0xff000000;
   },
 
   SDL_MapRGBA: function(fmt, r, g, b, a) {
-    // Canvas screens are always RGBA. We assume the machine is little-endian.
+    SDL.checkPixelFormat(fmt);
+    // We assume the machine is little-endian.
     return r&0xff|(g&0xff)<<8|(b&0xff)<<16|(a&0xff)<<24;
   },
 
   SDL_GetRGB: function(pixel, fmt, r, g, b) {
-    // Canvas screens are always RGBA. We assume the machine is little-endian.
+    SDL.checkPixelFormat(fmt);
+    // We assume the machine is little-endian.
     if (r) {
       {{{ makeSetValue('r', '0', 'pixel&0xff', 'i8') }}};
     }
@@ -1863,7 +1876,8 @@ var LibrarySDL = {
   },
 
   SDL_GetRGBA: function(pixel, fmt, r, g, b, a) {
-    // Canvas screens are always RGBA. We assume the machine is little-endian.
+    SDL.checkPixelFormat(fmt);
+    // We assume the machine is little-endian.
     if (r) {
       {{{ makeSetValue('r', '0', 'pixel&0xff', 'i8') }}};
     }

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -871,7 +871,7 @@
     },
     {
         "file": "SDL/SDL_pixels.h",
-        "defines": [],
+        "defines": ["SDL_PIXELFORMAT_RGBA8888"], 
         "structs": {
             "SDL_Palette": [
                 "ncolors", 


### PR DESCRIPTION
Updated SDL_GetRGB/RGBA and SDL_MapRGB/RGBA to check that the pixel format passed as an argument is RGBA8888, the only format supported by the SDL emscripten port. A warning will be shown to the user if that format does not match - in this scenario, the current code still does the mapping anyway (this could be changed to return right away if you prefer). I also fixed an issue with the access to SDL_PIXELFORMAT_RGBA8888 from library_sdl.js as struct_info.json did not have this definition specified.
