### PR TITLE
add pkg-config files for some supported libraries

### DIFF
--- a/system/lib/pkgconfig/egl.pc
+++ b/system/lib/pkgconfig/egl.pc
@@ -1,0 +1,3 @@
+Name: egl
+Description: EGL library
+Version: 10.2.2

--- a/system/lib/pkgconfig/glesv2.pc
+++ b/system/lib/pkgconfig/glesv2.pc
@@ -1,0 +1,3 @@
+Name: glesv2
+Description: OpenGL ES 2.0 library
+Version: 10.2.2

--- a/system/lib/pkgconfig/libpng.pc
+++ b/system/lib/pkgconfig/libpng.pc
@@ -1,0 +1,3 @@
+Name: libpng
+Description: Loads and saves PNG files
+Version: 1.6.12

--- a/system/lib/pkgconfig/sdl.pc
+++ b/system/lib/pkgconfig/sdl.pc
@@ -1,0 +1,4 @@
+Name: sdl
+Description: Simple DirectMedia Layer is a cross-platform multimedia library designed to provide low level access to audio, keyboard, mouse, joystick, 3D hardware via OpenGL, and 2D video framebuffer.
+Version: 1.2.15
+Cflags: -D_GNU_SOURCE=1 -D_REENTRANT

--- a/system/lib/pkgconfig/zlib.pc
+++ b/system/lib/pkgconfig/zlib.pc
@@ -1,0 +1,3 @@
+Name: zlib
+Description: zlib compression library
+Version: 1.2.8


### PR DESCRIPTION
The pkg-config tool is widely used in autotools projects as it allows to automatically get CFLAGS for all libraries needed to be linked. When porting projects using Emscripten, most configure.ac files today need to be changed to remove checks using pkg-config. Applying this patch will allow pkg-config to find libraries and therefore autotools projects will now be able to build from vanilla sources.

Please note that the .pc files I imported have been modified from their original counterparts (Emscripten does not require -l, -I, or -L flags for these).

This can easily be tested by calling "emconfigure pkg-config --list-all". It should list the following libraries at this time:
- egl
- zlib
- libpng
- sdl
- glesv2
