### PR TITLE
Let -s RELOOPER work correctly.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1334,7 +1334,9 @@ def main(args, compiler_engine, cache, jcache, relooper, temp_files, DEBUG, DEBU
   # Compile the assembly to Javascript.
   if settings.get('RELOOP'):
     if not relooper:
-      relooper = cache.get_path('relooper.js')
+      relooper = settings.get('RELOOPER')
+      if not relooper:
+        relooper = cache.get_path('relooper.js')
     settings.setdefault('RELOOPER', relooper)
     if not os.path.exists(relooper):
       shared.Building.ensure_relooper(relooper)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1417,7 +1417,8 @@ class Building:
     os.environ['EMSCRIPTEN_SUPPRESS_USAGE_WARNING'] = '1'
 
     # Run Emscripten
-    Settings.RELOOPER = Cache.get_path('relooper.js')
+    if not os.path.exists(Settings.RELOOPER):
+      Settings.RELOOPER = Cache.get_path('relooper.js')
     settings = Settings.serialize()
     args = settings + extra_args
     if WINDOWS:


### PR DESCRIPTION
This lets someone pass a relooper to `emcc` and have it actually work.

The existing functionality remains and a bootstrap of the relooper works when running the slow tests.

cc: @chadaustin
