### PR TITLE
avoid the need for replacing backslashes with slashes on windows for some settings

### DIFF
--- a/emcc
+++ b/emcc
@@ -1256,6 +1256,8 @@ try:
     if value[0] == '@':
       value = '"@' + os.path.abspath(value[1:]) + '"'
       value = value.replace('\\\\', '/').replace('\\', '/') # Convert backslash paths to forward slashes on Windows as well, since the JS compiler otherwise needs the backslashes escaped (alternative is to escape all input paths passing to JS, which feels clumsier to read)
+    else:
+      value = value.replace('\\', '\\\\')
     exec('shared.Settings.' + key + ' = ' + value)
     if key == 'EXPORTED_FUNCTIONS':
       shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS = shared.Settings.EXPORTED_FUNCTIONS[:] # used for warnings in emscripten.py


### PR DESCRIPTION
This is my fix, kindly tested by @chadaustin, for the problem where passing a setting using Windows file paths and the first character of a directory name or file name was `n` would cause things to break.

The issue where we had this was for a setting for the `SHELL_FILE` and it was in ``C:\imvu\northstar... and this was getting converted to newlines, causing things to choke and die.

This was discussed on IRC with @kripken and @juj as well.
