### PR TITLE
IE stack trace fix.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -8521,21 +8521,7 @@ LibraryManager.library = {
 
   emscripten_get_callstack_js__deps: ['_emscripten_traverse_stack'],
   emscripten_get_callstack_js: function(flags) {
-    var err = new Error();
-    if (!err.stack) {
-      // IE10+ special cases: It does have callstack info, but it is only populated if an Error object is thrown,
-      // so try that as a special-case.
-      try {
-        throw new Error(0);
-      } catch(e) {
-        err = e;
-      }
-      if (!err.stack) {
-        Runtime.warnOnce('emscripten_get_callstack_js is not supported on this browser!');
-        return '';
-      }
-    }
-    var callstack = err.stack.toString();
+    var callstack = jsStackTrace();
 
     // Find the symbols in the callstack that corresponds to the functions that report callstack information, and remove everyhing up to these from the output.
     var iThisFunc = callstack.lastIndexOf('_emscripten_log');

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -932,9 +932,25 @@ function demangleAll(text) {
   return text.replace(/__Z[\w\d_]+/g, function(x) { var y = demangle(x); return x === y ? x : (x + ' [' + y + ']') });
 }
 
+function jsStackTrace() {
+  var err = new Error();
+  if (!err.stack) {
+    // IE10+ special cases: It does have callstack info, but it is only populated if an Error object is thrown,
+    // so try that as a special-case.
+    try {
+      throw new Error(0);
+    } catch(e) {
+      err = e;
+    }
+    if (!err.stack) {
+      return '(no stack trace available)';
+    }
+  }
+  return err.stack.toString();
+}
+
 function stackTrace() {
-  var stack = new Error().stack;
-  return stack ? demangleAll(stack) : '(no stack trace available)'; // Stack trace is not available at least on IE10 and Safari 6.
+  return demangleAll(jsStackTrace());
 }
 
 // Memory management


### PR DESCRIPTION
Fix stackTrace() in preamble.js to support IE10 and IE11. Reuse code between library.js and preamble.js.
