### PR TITLE
Embedding large files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -149,4 +149,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jonas Platte <mail@jonasplatte.de>
 * Sebastien Ronsse <sronsse@gmail.com>
 * Glenn R. Wichman <gwichman@zynga.com>
-
+* Sylvain Chevalier <sylvain.chevalier@gmail.com>

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -414,20 +414,12 @@ for file_ in data_files:
   if file_['mode'] == 'embed':
     # Embed
     data = map(ord, open(file_['srcpath'], 'rb').read())
-    if not data:
-      str_data = '[]'
-    else:
-      str_data = ''
+    code += '''fileData%d = [];\n''' % counter
+    if data:
       chunk_size = 10240
-      code += '''fileData%d = [];\n''' % counter
       while len(data) > 0:
-        chunk = data[:chunk_size]
+        code += '''fileData%d.push.apply(fileData%d, %s);\n''' % (counter, counter, str(data[:chunk_size]))
         data = data[chunk_size:]
-        code += '''fileData%d.push.apply(fileData%d, %s);\n''' % (counter, counter, str(chunk))
-        if not str_data:
-          str_data = str(chunk)
-        else:
-          str_data += '.concat(' + str(chunk) + ')'
     code += '''Module['FS_createDataFile']('%s', '%s', fileData%d, true, true);\n''' % (dirname, basename, counter)
     counter += 1
   elif file_['mode'] == 'preload':


### PR DESCRIPTION
When trying to package a large file using `tools/file_packager.py`, if the file is large enough (like 20MB for browser JavaScript interpreters, or 40MB for node.js), the generated JavaScript array is too long and the line does not execute successfully.

The proposed fix creates that array by concatenating chunks, so that there is no line larger than the limit.

This is necessary for instance in PocketSphinx.js which loads acoustic models sometimes having files as long as dozen of MB.

There is also a test in the core section: `test_file_large`, which takes a while to execute.
