### PR TITLE
workaround_node_js_stdout_exit

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -175,7 +175,14 @@ function exit(status) {
   exitRuntime();
 
   if (ENVIRONMENT_IS_NODE) {
-    process['exit'](status);
+    // Work around a node.js bug where stdout buffer is not flushed at process exit:
+    // Instead of process.exit() directly, wait for stdout flush event.
+    // See https://github.com/joyent/node/issues/1669 and https://github.com/kripken/emscripten/issues/2582
+    // Workaround is based on https://github.com/RReverser/acorn/commit/50ab143cecc9ed71a2d66f78b4aec3bb2e9844f6
+    process.stdout.once('drain', function () {
+      process['exit'](status);
+    });
+    console.log(' '); // Make sure to print something to force the drain event to occur, in case the stdout buffer was empty.
   } else if (ENVIRONMENT_IS_SHELL && typeof quit === 'function') {
     quit(status);
   } else {


### PR DESCRIPTION
Work around node.js bug https://github.com/joyent/node/issues/1669 where stdout buffer is not flushed at process exit and console.log()s performed by the application might not get printed. Fixes https://github.com/kripken/emscripten/issues/2582
