### PR TITLE
Avoid asserting in glReadPixels for unsupported types, return GL_INVALID_ENUM instead

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -892,9 +892,13 @@ var LibraryGL = {
 
   glReadPixels__sig: 'viiiiiii',
   glReadPixels: function(x, y, width, height, format, type, pixels) {
-#if ASSERTIONS
-    assert(type == 0x1401 /* GL_UNSIGNED_BYTE */);
+    if (type != 0x1401/*GL_UNSIGNED_BYTE*/) {
+      GL.recordError(0x0500/*GL_INVALID_ENUM*/);
+#if GL_ASSERTIONS
+      Module.printErr('GL_INVALID_ENUM in glReadPixels: Unsupported type ' + type + '!');
 #endif
+      return;
+    }
     var sizePerPixel;
     switch (format) {
       case 0x1907 /* GL_RGB */:


### PR DESCRIPTION
We should never assert in any GL code.
