### PR TITLE
Fix test_python on Windows. After commit https://github.com/kripken/emsc...

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -832,6 +832,9 @@ mergeInto(LibraryManager.library, {
     readlink: function(path) {
       var lookup = FS.lookupPath(path);
       var link = lookup.node;
+      if (!link) {
+        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+      }
       if (!link.node_ops.readlink) {
         throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
       }


### PR DESCRIPTION
...ripten/commit/559c4f999b3dffda138f6e09cd068e2b662d9a3a , FS.lookupPath could return a JS object which has node==null, so test that as an error condition in readlink.
