### PR TITLE
support coroutine

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -995,3 +995,36 @@ Typedefs
 	.. note:: It is better to avoid unaligned operations, but if you are reading from a packed stream of bytes or such, these types may be useful!
 
 		
+Asyncify functions
+==================
+
+Asyncify functions are asynchronous functions that appear synchronously in C, the linker flag `-s ASYNCIFY=1` is required to use these functions. See `Asyncify <https://github.com/kripken/emscripten/wiki/Asyncify>`_ for more details.
+
+Typedefs
+--------
+
+.. c:type:: emscripten_coroutine
+
+    A handle to the strcture used by coroutine supporting functions.
+
+Functions
+---------
+
+.. c::function:: void emscripten_sleep(unsinged int ms)
+
+    Sleep for `ms` milliseconds.
+
+.. c::function:: emscripten_coroutine emscripten_coroutine_create(em_arg_callback_func func, void *arg, int stack_size)
+
+    Create a coroutine which will be run as `func(arg)`.
+
+    :param int stack_size: the stack size that should be allocated for the coroutine, use 0 for the default value.
+
+.. c::function:: int emscripten_coroutine_next(emscripten_coroutine coroutine)
+
+    Run `coroutine` until it returns, or `emscripten_yield` is called. A non-zero value is returned if `emscripten_yield` is called, otherwise 0 is returned, and future calls of `emscripten_coroutine_next` on this coroutine is undefined behaviour.
+
+.. c::function:: void emscripten_yield(void)
+
+    This function should only be called in a coroutine created by `emscripten_coroutine_create`, when it called, the coroutine is paused and the caller will continue.
+    

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -1,3 +1,5 @@
+mergeInto(LibraryManager.library, {
+#if ASYNCIFY
 /*
  * The layout of normal and async stack frames
  *
@@ -13,15 +15,14 @@
  * --------------------- <-- STACKTOP
  *
  */
-
-mergeInto(LibraryManager.library, {
-#if ASYNCIFY
   __async: 0, // whether a truly async function has been called
   __async_unwind: 1, // whether to unwind the async stack frame
   __async_retval: 'allocate(2, "i32", ALLOC_STATIC)', // store the return value for async functions
   __async_cur_frame: 0, // address to the current frame, which stores previous frame, stack pointer and async context
 
-  emscripten_async_resume__deps: ['__async', '__async_unwind', '__async_cur_frame'],
+  // __async_retval is not actually required in emscripten_async_resume
+  // but we want it included when ASYNCIFY is enabled
+  emscripten_async_resume__deps: ['__async', '__async_unwind', '__async_retval', '__async_cur_frame'],
   emscripten_async_resume__sig: 'v',
   emscripten_async_resume__asm: true,
   emscripten_async_resume: function() {
@@ -99,10 +100,102 @@ mergeInto(LibraryManager.library, {
   emscripten_do_not_unwind_async: true,
 
   emscripten_get_async_return_value_addr__deps: ['__async_retval'],
-  emscripten_get_async_return_value_addr: true
+  emscripten_get_async_return_value_addr: true,
+
+/*
+ * Layout of a coroutine structure
+ *
+ *  0 callee's async ctx
+ *  4 callee's STACKTOP
+ *  8 callee's STACK_MAX
+ * 12 my async ctx
+ * 16 my STACKTOP
+ * 20 my stack size
+ * 24 coroutine function
+ * 28 coroutine arg
+ * 32 my stack:
+ *    ...
+ */
+  emscripten_coroutine_create__sig: 'iii',
+  emscripten_coroutine_create__asm: true,
+  emscripten_coroutine_create__deps: ['malloc'],
+  emscripten_coroutine_create: function(f, arg, stack_size) {
+    f = f|0;
+    arg = arg|0;
+    stack_size = stack_size|0;
+    var coroutine = 0;
+
+    if(stack_size <= 0) stack_size = 4096;
+
+    coroutine = _malloc(stack_size)|0;
+    {{{ makeSetValueAsm('coroutine', 12, 0, 'i32') }}}; 
+    {{{ makeSetValueAsm('coroutine', 16, '(coroutine+32)', 'i32') }}};
+    {{{ makeSetValueAsm('coroutine', 20, 'stack_size', 'i32') }}};
+    {{{ makeSetValueAsm('coroutine', 24, 'f', 'i32') }}};
+    {{{ makeSetValueAsm('coroutine', 28, 'arg', 'i32') }}};
+    return coroutine|0;
+  },
+  emscripten_coroutine_next__sig: 'ii',
+  emscripten_coroutine_next__asm: true,
+  emscripten_coroutine_next__deps: ['__async_cur_frame', '__async', 'emscripten_async_resume', 'free'],
+  emscripten_coroutine_next: function(coroutine) {
+    coroutine = coroutine|0;
+    var coroutine_not_finished = 0;
+    // switch context
+    {{{ makeSetValueAsm('coroutine', 0, '___async_cur_frame', 'i32') }}};
+    {{{ makeSetValueAsm('coroutine', 4, 'stackSave()|0', 'i32') }}};
+    {{{ makeSetValueAsm('coroutine', 8, 'STACK_MAX', 'i32') }}};
+    ___async_cur_frame = {{{ makeGetValueAsm('coroutine', 12, 'i32') }}};
+    stackRestore({{{ makeGetValueAsm('coroutine', 16, 'i32') }}});
+    STACK_MAX = coroutine + 32 + {{{ makeGetValueAsm('coroutine', 20, 'i32') }}};
+
+    if (!___async_cur_frame) {
+      // first run
+      dynCall_vi(
+        {{{ makeGetValueAsm('coroutine', 24, 'i32') }}},
+        {{{ makeGetValueAsm('coroutine', 28, 'i32') }}}
+      );
+    } else {
+      _emscripten_async_resume();
+    }
+
+    // switch context
+    {{{ makeSetValueAsm('coroutine', 12, '___async_cur_frame', 'i32') }}};
+    {{{ makeSetValueAsm('coroutine', 16, 'stackSave()|0', 'i32') }}};
+    ___async_cur_frame = {{{ makeGetValueAsm('coroutine', 0, 'i32') }}};
+    stackRestore({{{ makeGetValueAsm('coroutine', 4, 'i32') }}});
+    STACK_MAX = {{{ makeGetValueAsm('coroutine', 8, 'i32') }}};
+
+    coroutine_not_finished = ___async;
+    if (!coroutine_not_finished) {
+      // coroutine has finished
+      _free(coroutine);
+    }
+    // coroutine may be created during an async function
+    // we do not want to affect the original async ctx
+    // strictly we should backup and restore ___async, ___async_retval and ___async_unwind
+    // but ___async=0 seems enough
+    ___async = 0;
+
+    return coroutine_not_finished|0;
+  },
+  emscripten_yield__sig: 'v',
+  emscripten_yield__asm: true,
+  emscripten_yield: function() {
+    ___async = 1;
+  }
 #else // ASYNCIFY
   emscripten_sleep: function() {
     throw 'Please compile your program with -s ASYNCIFY=1 in order to use asynchronous operations like emscripten_sleep';
+  },
+  emscripten_coroutine_create: function() {
+    throw 'Please compile your program with -s ASYNCIFY=1 in order to use asynchronous operations like emscripten_coroutine_create';
+  },
+  emscripten_coroutine_next: function() {
+    throw 'Please compile your program with -s ASYNCIFY=1 in order to use asynchronous operations like emscripten_coroutine_next';
+  },
+  emscripten_yield: function() {
+    throw 'Please compile your program with -s ASYNCIFY=1 in order to use asynchronous operations like emscripten_yield';
   }
 #endif
 });

--- a/src/settings.js
+++ b/src/settings.js
@@ -298,7 +298,8 @@ var ASYNCIFY = 0; // Whether to enable asyncify transformation
                   // This allows to inject some async functions to the C code that appear to be sync
                   // e.g. emscripten_sleep
 var ASYNCIFY_FUNCTIONS = ['emscripten_sleep', // Functions that call any funcion in the list, directly or indirectly
-                          'emscripten_wget']; // will be transfromed
+                          'emscripten_wget',  // will be transformed
+                          'emscripten_yield'];
 var ASYNCIFY_WHITELIST = ['qsort',   // Functions in this list are never considered async, even if they appear in ASYNCIFY_FUNCTIONS
                           'trinkle', // In the asyncify transformation, any function that calls a function pointer is considered async 
                           '__toread', // This whitelist is useful when a function is known to be sync

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -233,15 +233,17 @@ void emscripten_asm_const(const char *code);
 int emscripten_asm_const_int(const char *code, ...);
 double emscripten_asm_const_double(const char *code, ...);
 
-/*
- * Sleep for `ms` milliseconds
- * This function should only be used when ASYNCIFY is enabled
- */
 #if __EMSCRIPTEN__
 void emscripten_sleep(unsigned int ms);
 #else
 #define emscripten_sleep SDL_Delay
 #endif
+
+typedef void * emscripten_coroutine;
+emscripten_coroutine emscripten_coroutine_create(em_arg_callback_func func, void *arg, int stack_size);
+int emscripten_coroutine_next(emscripten_coroutine);
+void emscripten_yield(void);
+
 
 #ifdef __cplusplus
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6895,6 +6895,55 @@ int main() {
     Settings.ASYNCIFY = 1;
     self.do_run(src, 'HelloWorld!99');
 
+  def test_coroutine(self):
+    if not Settings.ASM_JS: return self.skip('asyncify requires asm.js')
+    if os.environ.get('EMCC_FAST_COMPILER') == '0': return self.skip('asyncify requires fastcomp')
+
+    src = r'''
+#include <stdio.h>
+#include <emscripten.h>
+void fib(void * arg) {
+    int * p = (int*)arg;
+    int cur = 1;
+    int next = 1;
+    for(int i = 0; i < 9; ++i) {
+        *p = cur;
+        emscripten_yield();
+        int next2 = cur + next;
+        cur = next;
+        next = next2;
+    }
+}
+void f(void * arg) {
+    int * p = (int*)arg;
+    *p = 0;
+    emscripten_yield();
+    fib(arg); // emscripten_yield in fib() can `pass through` f() back to main(), and then we can assume inside fib()
+}
+void g(void * arg) {
+    int * p = (int*)arg;
+    for(int i = 0; i < 10; ++i) {
+        *p = 100+i;
+        emscripten_yield();
+    }
+}
+int main(int argc, char **argv) {
+    int i;
+    emscripten_coroutine co = emscripten_coroutine_create(f, (void*)&i, 0);
+    emscripten_coroutine co2 = emscripten_coroutine_create(g, (void*)&i, 0);
+    printf("*");
+    while(emscripten_coroutine_next(co)) {
+        printf("%d-", i);
+        emscripten_coroutine_next(co2);
+        printf("%d-", i);
+    }
+    printf("*");
+    return 0;
+}
+'''
+    Settings.ASYNCIFY = 1;
+    self.do_run(src, '*0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*');
+
 # Generate tests for everything
 def make_run(fullname, name=-1, compiler=-1, embetter=0, quantum_size=0,
     typed_arrays=0, emcc_args=None, env=None):


### PR DESCRIPTION
A few questions
- How about a variance of `emscripten_coroutine_create` that allows customized stack size?
- Do we need `emscriptens_coroutine_destroy`, for those coroutine we don't need anymore, but still running?
- Do we need to save and restore STACK_MAX?
- The code is not actually asm.js validated, not sure how to make _malloc and _free work.
