### PR TITLE
requestAnimationFrame-based SDL audio queue.

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1010,8 +1010,11 @@ mergeInto(LibraryManager.library, {
         }
       });
 
-      // Queue new audio data.
-      if (SDL && SDL.audio && SDL.audio.queueNewAudioData) SDL.audio.queueNewAudioData();
+      // Queue new audio data. This is important to be right after the main loop invocation, so that we will immediately be able
+      // to queue the newest produced audio samples.
+      // TODO: Consider adding pre- and post- rAF callbacks so that GL.newRenderingFrameStarted() and SDL.audio.queueNewAudioData()
+      //       do not need to be hardcoded into this function, but can be more generic.
+      if (typeof SDL === 'object' && SDL.audio && SDL.audio.queueNewAudioData) SDL.audio.queueNewAudioData();
 
       if (Browser.mainLoop.shouldPause) {
         // catch pauses from the main loop itself

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2142,7 +2142,7 @@ var LibrarySDL = {
       SDL.audio.bytesPerSample = (SDL.audio.format == 0x0008 /*AUDIO_U8*/ || SDL.audio.format == 0x8008 /*AUDIO_S8*/) ? 1 : 2;
       SDL.audio.bufferSize = totalSamples*SDL.audio.bytesPerSample;
       SDL.audio.bufferDurationSecs = SDL.audio.bufferSize / SDL.audio.bytesPerSample / SDL.audio.channels / SDL.audio.freq; // Duration of a single queued buffer in seconds.
-      SDL.audio.bufferingDelay = 150 / 1000; // Audio samples are played with a constant delay of this many seconds to account for browser and jitter.
+      SDL.audio.bufferingDelay = 50 / 1000; // Audio samples are played with a constant delay of this many seconds to account for browser and jitter.
       SDL.audio.buffer = _malloc(SDL.audio.bufferSize);
       
       // To account for jittering in frametimes, always have multiple audio buffers queued up for the audio output device.


### PR DESCRIPTION
This set of commit aims to improve the SDL buffered audio support:
- Remove code that implemented the Mozilla Audio Data API playback, since Firefox has killed support for that a long time ago.
- Remove the previous attempt where we'd use ScriptProcessorNode to drive the audio. That proved to be too flaky in practice, since it depends on an unspecified audio context sampling rate, and requires maintaining two paths.
- Try to improve the SDL audio queueing stability by calling the audio callback _also_ in the main `requestAnimationFrame` loop. Since it fires (ideally) at each 16msecs, this should provide a good stable granularity for feeding new audio data to Web Audio API. The issue with just using setTimeout() like the previous code is that browsers seem to have very wild jitter with that function, on the order of hundreds of msecs. With this PR, audio is pulled with both `rAF` and `setTimeout`. The reason why `setTimeout` is retained is that there might be SDL applications that don't need to call `emscripten_set_main_loop` and therefore don't have a `rAF` loop running at all in the application.

This was tested to improve audio quality with the JSMESS codebase, although they have migrated to using a custom JS audio backend since.

One existing issue with the SDL audio model is that it is inherently pull-based. This means that there is the audio callback which is periodically called to fetch new audio samples from the application. However when we invoke the SDL audio callback, we don't really know if the application has yet been able to generate enough audio data to play back, and it may end up giving us silent frames. This could be fixed with a custom extension to the SDL API, but that's a separate discussion and pull request. This push vs pull issue is one of the reasons that codebases are probably better off implementing streaming audio on top of OpenAL rather than SDL, since with OpenAL one needs to always push the audio data, vs SDL api, which always pulls. So with OpenAL, a codebase will avoid this problem that SDL has.
