### PR TITLE
Add support for glutSetCursor function

### DIFF
--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -435,11 +435,26 @@ var LibraryGLUT = {
   glutSetCursor: function(cursor) {
     var cursorStyle = 'auto';
     switch(cursor) {
+      case 0x0000: /* GLUT_CURSOR_RIGHT_ARROW */
+        // No equivalent css cursor style, fallback to 'auto'
+        break;
+      case 0x0001: /* GLUT_CURSOR_LEFT_ARROW */
+        // No equivalent css cursor style, fallback to 'auto'
+        break;
       case 0x0002: /* GLUT_CURSOR_INFO */
         cursorStyle = 'pointer';
         break;
+      case 0x0003: /* GLUT_CURSOR_DESTROY */
+        // No equivalent css cursor style, fallback to 'auto'
+        break;
       case 0x0004: /* GLUT_CURSOR_HELP */
         cursorStyle = 'help';
+        break;
+      case 0x0005: /* GLUT_CURSOR_CYCLE */
+        // No equivalent css cursor style, fallback to 'auto'
+        break;
+      case 0x0006: /* GLUT_CURSOR_SPRAY */
+        // No equivalent css cursor style, fallback to 'auto'
         break;
       case 0x0007: /* GLUT_CURSOR_WAIT */
         cursorStyle = 'wait';
@@ -481,11 +496,13 @@ var LibraryGLUT = {
       case 0x0013: /* GLUT_CURSOR_BOTTOM_LEFT_CORNER */
         cursorStyle = 'sw-resize';
         break;
+      case 0x0064: /* GLUT_CURSOR_INHERIT */
+        break;
       case 0x0065: /* GLUT_CURSOR_NONE */
         cursorStyle = 'none';
         break;
       default:
-        break;
+        throw "glutSetCursor: Unknown cursor type: " + cursor;
     }
     Module['canvas'].style.cursor = cursorStyle;
   },


### PR DESCRIPTION
That pull request implements the glutSetCursor function.
The following GLUT cursor types are supported : 
- GLUT_CURSOR_INFO
- GLUT_CURSOR_HELP 
- GLUT_CURSOR_WAIT
- GLUT_CURSOR_TEXT
- GLUT_CURSOR_CROSSHAIR
- GLUT_CURSOR_UP_DOWN
- GLUT_CURSOR_LEFT_RIGHT
- GLUT_CURSOR_TOP_SIDE
- GLUT_CURSOR_BOTTOM_SIDE
- GLUT_CURSOR_LEFT_SIDE
- GLUT_CURSOR_RIGHT_SIDE
- GLUT_CURSOR_TOP_LEFT_CORNER
- GLUT_CURSOR_TOP_RIGHT_CORNER
- GLUT_CURSOR_BOTTOM_RIGHT_CORNER
- GLUT_CURSOR_BOTTOM_LEFT_CORNER
- GLUT_CURSOR_NONE 
