### PR TITLE
Fix emscripten_get_(num_gamepads|gamepad_status) for Chrome

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1267,13 +1267,19 @@ var LibraryJSEvents = {
   
   emscripten_get_num_gamepads: function() {
     if (!navigator.getGamepads) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
-    return navigator.getGamepads().length;
+    var gamepads = navigator.getGamepads();
+    var index, count = 0;
+    for(index=0; index < gamepads.length; ++index )
+    {
+      if(gamepads[index] !== undefined) ++count;
+    }
+    return count;
   },
   
   emscripten_get_gamepad_status: function(index, gamepadState) {
     if (!navigator.getGamepads) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
     var gamepads = navigator.getGamepads();
-    if (index < 0 || index >= gamepads.length) {
+    if (index < 0 || index >= gamepads.length || gamepads[index] === null) {
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
     }
     JSEvents.fillGamepadEventData(gamepadState, gamepads[index]);


### PR DESCRIPTION
Chrome does not completely follows the specifications for Gamepads. It always returns an array of 4 elements, undefined if no pad is connected.

This fix handles gamepads array with undefined elements
