### PR TITLE
Implement a warning message when building an dynamic library .so, .dll o...

### DIFF
--- a/emcc
+++ b/emcc
@@ -1122,6 +1122,10 @@ try:
         # Sort arg tuples and pass the extracted values to link.
         shared.Building.link(linker_inputs, specified_target)
     logging.debug('stopping at bitcode')
+    if final_suffix.lower() in ['so', 'dylib', 'dll']:
+      logging.warning('Dynamic libraries (.so, .dylib, .dll) are currently not supported by Emscripten. For build system emulation purposes, Emscripten'
+        + ' will now generate a static library file (.bc) with the suffix \'.' + final_suffix + '\'. For best practices,'
+        + ' please adapt your build system to directly generate a static LLVM bitcode library by setting the output suffix to \'.bc.\')')
     exit(0)
 
   log_time('process inputs')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2724,6 +2724,18 @@ int main()
     out, err = process.communicate()
     assert(warning not in err)
 
+  def test_warn_dylibs(self):
+    shared_suffixes = ['.so', '.dylib', '.dll']
+
+    for suffix in ['.o', '.a', '.bc', '.so', '.lib', '.dylib', '.js', '.html']:
+      process = Popen([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'out' + suffix], stdout=PIPE, stderr=PIPE)
+      out, err = process.communicate()
+      warning = 'Dynamic libraries (.so, .dylib, .dll) are currently not supported by Emscripten'
+      if suffix in shared_suffixes:
+        assert(warning in err)
+      else:
+        assert(warning not in err)
+
   def test_simplify_ifs(self):
     def test(src, nums):
       open('src.c', 'w').write(src)


### PR DESCRIPTION
...r a .dylib, which are currently not supported. Closes #2562.
