### PR TITLE
Add the ability to fetch memory initializers from a cdn

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -2,7 +2,9 @@
 // === Auto-generated postamble setup entry stuff ===
 
 if (memoryInitializer) {
-  if (Module['memoryInitializerPrefixURL']) {
+  if (typeof Module['locateFilePackage']) === 'function') {
+    memoryInitializer = Module['locateFilePackage'](memoryInitializer);
+  } else if (Module['memoryInitializerPrefixURL']) {
     memoryInitializer = Module['memoryInitializerPrefixURL'] + memoryInitializer;
   }
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {


### PR DESCRIPTION
Done in a similar fashion to the generated REMOTE_PACKAGE_NAME in 

https://github.com/kripken/emscripten/commit/e8113b001b97aa807378092cae036f7c1eec83c1
