### PR TITLE
Fix other.test_warn_undefined on Windows.

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -316,7 +316,7 @@ function compile(raw) {
 
 B = new Benchmarker();
 
-//try {
+try {
   if (ll_file) {
     if (phase === 'glue') {
       compile(';');
@@ -326,7 +326,6 @@ B = new Benchmarker();
       compile(ll_file); // we are given raw .ll
     }
   }
-/*
 } catch(err) {
   if (err.indexOf('Aborting compilation due to previous errors') != -1) {
     // Compiler failed on user error, print out the error message.
@@ -352,7 +351,6 @@ B = new Benchmarker();
     }, 500);
   } else throw err;
 }
-*/
 
 //var M = keys(tokenCacheMisses).map(function(m) { return [m, misses[m]] }).sort(function(a, b) { return a[1] - b[1] });
 //printErr(dump(M.slice(M.length-10)));


### PR DESCRIPTION
Restores code that was commented out in https://github.com/kripken/emscripten/commit/424b709cac07c3735007b2c31c24caed5dcedc24#diff-b0b85d67c2201828828422795fb44581R311 , fixes the test `other.test_warn_undefined` on Windows.

Tested on Windows that node.js still suffers the flush bug in latest 0.10.31, so the workaround is still needed.
