### PR TITLE
remove pkgconfig files for zlib/libpng

### DIFF
--- a/system/lib/pkgconfig/libpng.pc
+++ b/system/lib/pkgconfig/libpng.pc
@@ -1,3 +1,0 @@
-Name: libpng
-Description: Loads and saves PNG files
-Version: 1.6.12

--- a/system/lib/pkgconfig/zlib.pc
+++ b/system/lib/pkgconfig/zlib.pc
@@ -1,3 +1,0 @@
-Name: zlib
-Description: zlib compression library
-Version: 1.2.8


### PR DESCRIPTION
These aren't actually provided and the headers have already been removed.
