### PR TITLE
Configure the Emscripten cache directory from the command line.

### DIFF
--- a/emcc
+++ b/emcc
@@ -616,6 +616,12 @@ try:
       logging.warning('jcache is deprecated')
       jcache = True
       newargs[i] = ''
+    elif newargs[i] == '--cache':
+      check_bad_eq(newargs[i])
+      os.environ['EM_CACHE'] = newargs[i+1]
+      shared.reconfigure_cache()
+      newargs[i] = ''
+      newargs[i+1] = ''
     elif newargs[i] == '--clear-cache':
       newargs[i] = ''
       logging.warning('clearing cache')

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -347,7 +347,20 @@ Options that are modified or new in *emcc* are listed below:
 	This will pass ``-v`` to *Clang*, and also enable ``EMCC_DEBUG`` to generate intermediate files for the compiler’s various stages. It will also run Emscripten's internal sanity checks on the toolchain, etc. 
 	
 	.. tip:: ``emcc -v`` is a useful tool for diagnosing errors. It works with or without other arguments. 
-	
+
+.. _emcc-cache:
+
+``--cache``
+  Sets the directory to use as the Emscripten cache. The Emscripten cache
+  is used to store pre-built versions of ``libc``, ``libcxx`` and other
+  libraries.
+
+  If using this in combination with ``--clear-cache``, be sure to specify
+  this argument first.
+
+  The Emscripten cache defaults to being located in the path name stored
+  in the ``EM_CACHE`` environment variable or ``~/.emscripten_cache``.
+
 .. _emcc-clear-cache:
 	 
 ``--clear-cache``

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -275,6 +275,27 @@ f.close()
   def test_emcc_nonfastcomp(self):
     nonfastcomp(self.test_emcc)
 
+  def test_emcc_cache_flag(self):
+    tempdirname = tempfile.mkdtemp(prefix='emscripten_test_emcache_', dir=TEMP_DIR)
+    try:
+      os.chdir(tempdirname)
+      c_file = os.path.join(tempdirname, 'test.c')
+      cache_dir_name = os.path.join(tempdirname, 'emscripten_cache')
+      assert os.path.exists(cache_dir_name) == False, 'The cache directory %s must not already exist' % cache_dir_name
+      open(c_file, 'w').write(r'''
+        #include <stdio.h>
+        int main() {
+          printf("hello, world!\n");
+          return 0;
+        }
+        ''')
+      Popen([PYTHON, EMCC, c_file, '--cache', cache_dir_name]).communicate()
+      assert os.path.exists(cache_dir_name), 'The cache directory %s must exist after the build' % cache_dir_name
+      assert os.path.exists(os.path.join(cache_dir_name, 'libc.bc')), 'The cache directory must contain a built libc'
+    finally:
+      os.chdir(path_from_root('tests')) # Move away from the directory we are about to remove.
+      shutil.rmtree(tempdirname)
+
   def test_cmake(self):
     # Test all supported generators.
     if WINDOWS:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1721,6 +1721,10 @@ Cache = cache.Cache(debug=DEBUG_CACHE)
 JCache = cache.JCache(Cache)
 chunkify = cache.chunkify
 
+def reconfigure_cache():
+  global Cache
+  Cache = cache.Cache(debug=DEBUG_CACHE)
+
 class JS:
   memory_initializer_pattern = '/\* memory initializer \*/ allocate\(\[([\d, ]+)\], "i8", ALLOC_NONE, ([\d+Runtime\.GLOBAL_BASEH]+)\);'
   no_memory_initializer_pattern = '/\* no memory initializer \*/'


### PR DESCRIPTION
This allows passing --cache to emcc to set the Emscripten cache
directory rather than only allowing this to be configured via
the EM_CACHE environment variable.
