### PR TITLE
windowHint isn't a wrapped function.

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1079,7 +1079,7 @@ var LibraryGLFW = {
 
   glfwOpenWindowHint: function(target, hint) {
     target = GLFW.GLFW2ParamToGLFW3Param(target);
-    GLFW.windowHint(target, hint);
+    GLFW.hints[target] = hint;
   },
 
   glfwGetWindowSize: function(width, height) {

--- a/tests/glfw.c
+++ b/tests/glfw.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <GL/glfw.h>
 #include <stdio.h>
+#include <assert.h>
 #include <emscripten/emscripten.h>
 
 void Init(void);
@@ -47,6 +48,12 @@ void Init()
  
   if (glfwInit() != GL_TRUE)
     Shut_Down(1);
+
+  int red_bits = glfwGetWindowParam(GLFW_RED_BITS);
+  glfwOpenWindowHint(GLFW_RED_BITS, 8);
+  assert(glfwGetWindowParam(GLFW_RED_BITS) == 8);
+  glfwOpenWindowHint(GLFW_RED_BITS, red_bits);
+
   // 800 x 600, 16 bit color, no depth, alpha or stencil buffers, windowed
   if (glfwOpenWindow(window_width, window_height, 5, 6, 5,
                   0, 0, 0, GLFW_WINDOW) != GL_TRUE)


### PR DESCRIPTION
The implementation is simple hints assignment, so just implement without
wrapping. Also adds test in test_glfw.c that tests this.

Fixes issue mentioned in comment:
https://github.com/kripken/emscripten/pull/1887#issuecomment-56706188
