### PR TITLE
Sdl surface lock optimizations.

### DIFF
--- a/tests/hello_world_sdl.cpp
+++ b/tests/hello_world_sdl.cpp
@@ -1,6 +1,9 @@
 #include <stdio.h>
 #include <SDL/SDL.h>
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 extern "C" int main(int argc, char** argv) {
   printf("hello, world!\n");
@@ -8,11 +11,22 @@ extern "C" int main(int argc, char** argv) {
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Surface *screen = SDL_SetVideoMode(256, 256, 32, SDL_SWSURFACE);
 
+#ifdef TEST_SDL_LOCK_OPTS
+  EM_ASM("SDL.defaults.copyOnLock = false; SDL.defaults.discardOnLock = true; SDL.defaults.opaqueFrontBuffer = false;");
+#endif
+
   if (SDL_MUSTLOCK(screen)) SDL_LockSurface(screen);
   for (int i = 0; i < 256; i++) {
     for (int j = 0; j < 256; j++) {
-      // alpha component is actually ignored, since this is to the screen
-      *((Uint32*)screen->pixels + i * 256 + j) = SDL_MapRGBA(screen->format, i, j, 255-i, (i+j) % 255);
+#ifdef TEST_SDL_LOCK_OPTS
+      // Alpha behaves like in the browser, so write proper opaque pixels.
+      int alpha = 255;
+#else
+      // To emulate native behavior with blitting to screen, alpha component is ignored. Test that it is so by outputting
+      // data (and testing that it does get discarded)
+      int alpha = (i+j) % 255;
+#endif
+      *((Uint32*)screen->pixels + i * 256 + j) = SDL_MapRGBA(screen->format, i, j, 255-i, alpha);
     }
   }
   if (SDL_MUSTLOCK(screen)) SDL_UnlockSurface(screen);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -655,6 +655,10 @@ If manually bisecting:
   def test_sdl_swsurface(self):
     self.btest('sdl_swsurface.c', expected='1')
 
+  def test_sdl_surface_lock_opts(self):
+    # Test Emscripten-specific extensions to optimize SDL_LockSurface and SDL_UnlockSurface.
+    self.btest('hello_world_sdl.cpp', reference='htmltest.png', message='You should see "hello, world!" and a colored cube.', args=['-DTEST_SDL_LOCK_OPTS'])
+
   def test_sdl_image(self):
     # load an image file, get pixel data. Also O2 coverage for --preload-file, and memory-init
     shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), os.path.join(self.get_dir(), 'screenshot.jpg'))


### PR DESCRIPTION
Optimize Emscripten SDL handwritten JS-implemented SDL_LockSurface() and SDL_UnlockSurface() by adding an option to perform discarding locks that are fast no-ops and to avoid the screen-is-always-opaque emulation which fills alpha=0xFF bytes to each pixel on lock and unlock. Call something like EM_ASM("SDL.defaults.copyOnLock = false; SDL.defaults.discardOnLock = true; SDL.defaults.opaqueFrontBuffer = false;"); at startup to enable these.
