### PR TITLE
emar can receive --em-config. Don't pass along to llvm-ar.

### DIFF
--- a/emar
+++ b/emar
@@ -14,16 +14,7 @@ DEBUG = os.environ.get('EMCC_DEBUG')
 if DEBUG == "0":
    DEBUG = None
 
-newargs = [shared.LLVM_AR]
-
-skip = False
-for arg in sys.argv[1:]:
-  if not skip and arg != '--em-config':
-    newargs += [arg]
-  elif arg == '--em-config':
-    skip = True
-  elif skip:
-    skip = False
+newargs = [shared.LLVM_AR] + sys.argv[1:]
 
 if DEBUG:
   print >> sys.stderr, 'emar:', sys.argv, '  ==>  ', newargs

--- a/emcc
+++ b/emcc
@@ -653,10 +653,6 @@ try:
     elif newargs[i] == '--emrun':
       emrun = True
       newargs[i] = ''
-    elif newargs[i] == '--em-config':
-      # This option is parsed in tools/shared.py, here only clean it up from being passed to clang.
-      newargs[i] = ''
-      newargs[i+1] = ''
     elif newargs[i] == '--default-obj-ext':
       newargs[i] = ''
       default_object_extension = newargs[i+1]

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -184,6 +184,17 @@ else:
 
 try:
   EM_CONFIG = sys.argv[sys.argv.index('--em-config')+1]
+  # And now remove it from sys.argv
+  skip = False
+  newargs = []
+  for arg in sys.argv:
+    if not skip and arg != '--em-config':
+      newargs += [arg]
+    elif arg == '--em-config':
+      skip = True
+    elif skip:
+      skip = False
+  sys.argv = newargs
   # Emscripten compiler spawns other processes, which can reimport shared.py, so make sure that
   # those child processes get the same configuration file by setting it to the currently active environment.
   os.environ['EM_CONFIG'] = EM_CONFIG


### PR DESCRIPTION
I ran `python ./tests/runner.py other` and only the usual suspects failed.

Fixes issue #2886.
