### PR TITLE
Fix copyIndexedColorData to work correct with opaqueFrontBuffer flag

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -421,7 +421,7 @@ var LibrarySDL = {
           data[colorOffset   ] = colors[index   ];
           data[colorOffset +1] = colors[index +1];
           data[colorOffset +2] = colors[index +2];
-          //unused: data[colorOffset +3] = color[index +3];
+          data[colorOffset +3] = 255;
         }
       }
     },


### PR DESCRIPTION
Related to #2870

In past sdl implementation always make front buffer opaque on LockSurface, but now if opaqueFrontBuffer is set to false then we should set alpha value to 255 as in RGB color associated with the index.

@juj 
I just deploy new version of openxcom (http://epicport.com/en/xcom) with EM_ASM("SDL.defaults.copyOnLock = false; SDL.defaults.discardOnLock = true; SDL.defaults.opaqueFrontBuffer = false;");. Looks like the problem place is in copyIndexedColorData function. This function take little performance advantages by this flag i think. Can you take a look on this function, it is possible to tune it performance? Also openxcom works blazing fast in chrome and much slower in firefox.
