### PR TITLE
Remove non-breaking space from library_glfw.js

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -576,7 +576,7 @@ var LibraryGLFW = {
       if (GLFW.active.id == win.id) {
         if (width == screen.width && height == screen.height) {
           GLFW.requestFullScreen();
-        } else {
+        } else {
           GLFW.cancelFullScreen();
           Browser.setCanvasSize(width, height);
           win.width = width;


### PR DESCRIPTION
See https://github.com/kripken/emscripten/blob/70173560dc471ed8d72eb834bba9c28d2507d828/src/library_glfw.js#L579 - github actually highlights the nbsp.

Example of the nbsp in master:

```
emsdk_portable/emscripten/master $ grep -bF 'GLFW.cancelFullScreen' src/library_glfw.js
21813:          GLFW.cancelFullScreen();
emsdk_portable/emscripten/master $ dd if=src/library_glfw.js bs=1 skip=21803 count=9 2>/dev/null | xxd
0000000: 7d20 656c 7365 c2a0 7b                   } else..{
```

This causes (at least) my version of Chromium to choke.
