### PR TITLE
Fix missing __lock / __unlock.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -8900,6 +8900,8 @@ LibraryManager.library = {
   },
 
   // misc shims for musl
+  __lock: function() {},
+  __unlock: function() {},
   __lockfile: function() { return 1 },
   __unlockfile: function(){},
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3778,6 +3778,18 @@ int 123
 ok
 ''', post_build=self.dlfcn_post_build)
 
+  def test_random(self):
+    src = r'''#include <stdlib.h>
+#include <stdio.h>
+
+int main()
+{
+    srandom(0xdeadbeef);
+    printf("%ld", random());
+}
+'''
+    self.do_run(src, '956867869')
+
   def test_rand(self):
     src = r'''#include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
This was noticed as srandom / random use those.

Fixes issue #2916.
