### PR TITLE
Implement TTF_FontLineSkip

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2834,6 +2834,8 @@ var LibrarySDL = {
     return fontData.size;
   },
 
+  TTF_FontLineSkip: 'TTF_FontHeight', // XXX
+
   TTF_Quit: function() {
     Module.print('TTF_Quit called (and ignored)');
   },


### PR DESCRIPTION
Note that `TTF_FontLineSkip` and `TTF_FontHeight` should normally _not_ be the same value. However, since there's no equivalent to `FT_Face.height` available (or any metrics for that matter), I don't see any way that wouldn't be a horrible hack.
