### PR TITLE
Use a plain exception rather than CalledProcessError

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -11,7 +11,8 @@ def call_process(cmd):
   proc = Popen(cmd, stdout=stdout, stderr=stderr)
   proc.communicate()
   if proc.returncode != 0:
-    raise CalledProcessError(proc.returncode, cmd)
+    # Deliberately do not use CalledProcessError, see issue #2944
+    raise Exception('Command \'%s\' returned non-zero exit status %s' % (cmd, proc.returncode))
 
 CORES = int(os.environ.get('EMCC_CORES') or multiprocessing.cpu_count())
 


### PR DESCRIPTION
Because of http://bugs.python.org/issue9400, unpickling of exceptions with required arguments doesn't work. This includes CalledProcessError and means nonzero exit codes are masked by an opaque error message about arguments to **init** and the test doesn't abort as it should.

You can verify this for yourself with this script:

```
from __future__ import print_function
import multiprocessing
from subprocess import Popen, CalledProcessError
import sys

def loop(x):
    vals = ('mycmd', 1)
    if error == True:
        raise CalledProcessError(*vals)
    else:
        raise Exception('Command \'%s\' returned non-zero exit status %s' % vals)

if __name__ == '__main__':
    if len(sys.argv) < 2 or sys.argv[1] not in ['good', 'bad']:
        print("Specify good or bad")
        sys.exit(1)
    if sys.argv[1] == 'good':
        error = False
    else:
        error = True

    pool = multiprocessing.Pool(processes=1)
    pool.map(loop, range(1))
```

Example:

```
$ python2 xx.py good
Traceback (most recent call last):
  File "xx.py", line 23, in <module>
    pool.map(loop, range(1))
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 251, in map
    return self.map_async(func, iterable, chunksize).get()
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 558, in get
    raise self._value
Exception: Command 'mycmd' returned non-zero exit status 1
$ python2 xx.py bad
Exception in thread Thread-3:
Traceback (most recent call last):
  File "/usr/lib/python2.7/threading.py", line 810, in __bootstrap_inner
    self.run()
  File "/usr/lib/python2.7/threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib/python2.7/multiprocessing/pool.py", line 380, in _handle_results
    task = get()
TypeError: ('__init__() takes at least 3 arguments (1 given)', <class 'subprocess.CalledProcessError'>, ())

[...hangs...]
```

I assume the reason it hangs is because the exception has occurred in the inner workings of the multiprocessing module. You can't even kill it with ^C - I have success with ^Z and `kill %1`.
It's interesting to note that python 3 does not have this problem (for reasons described on the python ticket).
