### PR TITLE
Pointer_stringify(0)

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -634,7 +634,7 @@ function allocate(slab, types, allocator, ptr) {
 Module['allocate'] = allocate;
 
 function Pointer_stringify(ptr, /* optional */ length) {
-  if (length === 0) return '';
+  if (length === 0 || !ptr) return '';
   // TODO: use TextDecoder
   // Find the length, and check for UTF while doing so
   var hasUtf = false;


### PR DESCRIPTION
Define Pointer_stringify(x) with (x equal to 0, null or undefined) to return an empty string without performing a memory load from address 0.
