### PR TITLE
Convert js engine cfs to lists immediately after config read

### DIFF
--- a/emcc
+++ b/emcc
@@ -259,7 +259,7 @@ if CONFIGURE_CONFIG or CMAKE_CONFIG:
       shutil.copyfile(target, target[:-3])
       target = target[:-3]
     src = open(target).read()
-    full_node = ' '.join(shared.listify(shared.NODE_JS))
+    full_node = ' '.join(shared.NODE_JS)
     if os.path.sep not in full_node:
       full_node = '/usr/bin/' + full_node # TODO: use whereis etc. And how about non-*NIX?
     open(target, 'w').write('#!' + full_node + '\n' + src) # add shebang

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -430,7 +430,7 @@ f.close()
 
               # Run through node, if CMake produced a .js file.
               if cmake_outputs[i].endswith('.js'):
-                ret = Popen(listify(NODE_JS) + [tempdirname + '/' + cmake_outputs[i]], stdout=PIPE).communicate()[0]
+                ret = Popen(NODE_JS + [tempdirname + '/' + cmake_outputs[i]], stdout=PIPE).communicate()[0]
                 self.assertTextDataIdentical(open(cmakelistsdir + '/out.txt', 'r').read().strip(), ret.strip())
             finally:
               os.chdir(path_from_root('tests')) # Move away from the directory we are about to remove.
@@ -1238,7 +1238,7 @@ int f() {
     ''')
     open('my_test.input', 'w').write('abc')
     Building.emcc('main.cpp', ['--embed-file', 'my_test.input'], output_filename='a.out.js')
-    self.assertContained('zyx', Popen(listify(JS_ENGINES[0]) + ['a.out.js'], stdout=PIPE, stderr=PIPE).communicate()[0])
+    self.assertContained('zyx', Popen(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).communicate()[0])
 
   def test_abspaths(self):
     # Includes with absolute paths are generally dangerous, things like -I/usr/.. will get to system local headers, not our portable ones.
@@ -1932,7 +1932,7 @@ int f() {
        ['asm', 'ensureLabelSet']),
     ]:
       print input
-      output = Popen(listify(NODE_JS) + [path_from_root('tools', 'js-optimizer.js'), input] + passes, stdin=PIPE, stdout=PIPE).communicate()[0]
+      output = Popen(NODE_JS + [path_from_root('tools', 'js-optimizer.js'), input] + passes, stdin=PIPE, stdout=PIPE).communicate()[0]
       self.assertIdentical(expected, output.replace('\r\n', '\n').replace('\n\n', '\n'))
 
   def test_m_mm(self):
@@ -3063,7 +3063,6 @@ int main(int argc, char **argv) {
     ''')
     Popen([PYTHON, EMCC, 'src.cpp']).communicate()
     for engine in JS_ENGINES:
-      engine = listify(engine)
       print engine
       process = Popen(engine + ['a.out.js'], stdout=PIPE, stderr=PIPE)
       output = process.communicate()
@@ -4386,6 +4385,6 @@ int main(void) {
   def test_require(self):
     inname = path_from_root('tests', 'hello_world.c')
     Building.emcc(inname, output_filename='a.out.js')
-    output = Popen(listify(NODE_JS) + ['-e', 'require("./a.out.js")'], stdout=PIPE, stderr=PIPE).communicate()
+    output = Popen(NODE_JS + ['-e', 'require("./a.out.js")'], stdout=PIPE, stderr=PIPE).communicate()
     assert output == ('hello, world!\n \n', ''), 'expected no output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % output
 

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -80,13 +80,13 @@ class CompiledServerHarness:
   def __enter__(self):
     # assuming this is only used for WebSocket tests at the moment, validate that
     # the ws module is installed
-    child = Popen(listify(NODE_JS) + ['-e', 'require("ws");'])
+    child = Popen(NODE_JS + ['-e', 'require("ws");'])
     child.communicate()
     assert child.returncode == 0, 'ws module for Node.js not installed. Please run \'npm install\' from %s' % EMSCRIPTEN_ROOT
 
     # compile the server
     Popen([PYTHON, EMCC, path_from_root('tests', self.filename), '-o', 'server.js', '-DSOCKK=%d' % self.listen_port] + self.args).communicate()
-    process = Popen(listify(NODE_JS) + ['server.js'])
+    process = Popen(NODE_JS + ['server.js'])
     self.pids.append(process.pid)
 
   def __exit__(self, *args, **kwargs):
@@ -432,7 +432,7 @@ class sockets(BrowserCore):
 
     # note: you may need to run this manually yourself, if npm is not in the path, or if you need a version that is not in the path
     Popen(['npm', 'install', path_from_root('tests', 'sockets', 'p2p')]).communicate()
-    broker = Popen(listify(NODE_JS) + [path_from_root('tests', 'sockets', 'p2p', 'broker', 'p2p-broker.js')])
+    broker = Popen(NODE_JS + [path_from_root('tests', 'sockets', 'p2p', 'broker', 'p2p-broker.js')])
 
     expected = '1'
     self.run_browser(host_outfile, '.', ['/report_result?' + e for e in expected])

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -379,7 +379,6 @@ EMSCRIPTEN_FUNCS();
   return filename
 
 def run(filename, passes, js_engine=shared.NODE_JS, jcache=False, source_map=False, extra_info=None, just_split=False, just_concat=False):
-  js_engine = shared.listify(js_engine)
   return temp_files.run_and_clean(lambda: run_on_js(filename, passes, js_engine, jcache, source_map, extra_info, just_split, just_concat))
 
 if __name__ == '__main__':

--- a/tools/validate_asmjs.py
+++ b/tools/validate_asmjs.py
@@ -16,7 +16,7 @@ import shared
 
 # Looks up SpiderMonkey engine using the variable SPIDERMONKEY_ENGINE in ~/.emscripten, and if not set up there, via PATH.
 def find_spidermonkey_engine():
-  sm_engine = shared.listify(shared.SPIDERMONKEY_ENGINE) if hasattr(shared, 'SPIDERMONKEY_ENGINE') else ['']
+  sm_engine = shared.SPIDERMONKEY_ENGINE if hasattr(shared, 'SPIDERMONKEY_ENGINE') else ['']
   if not sm_engine or len(sm_engine[0]) == 0 or not os.path.exists(sm_engine[0]):
     sm_engine[0] = shared.Building.which('js')
     if sm_engine[0] == None:


### PR DESCRIPTION
PR created per https://github.com/kripken/emscripten/pull/2943#issuecomment-61139238

There are listify calls all over the place in emscripten and I've found it pretty difficult to figure out what's going on. So this PR turns all appropriate config items into lists as soon as they are read from the config.

I'm currently running the 'other' tests. I'll then do 'sockets' and the core ones, and then declare myself done (unless you see these second two as being unnecessary).
