### PR TITLE
Embind improvements

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -188,8 +188,12 @@ var LibraryEmVal = {
   $emval_get_global: function() { return (function(){return Function;})()('return this')(); },
   _emval_get_global__deps: ['_emval_register', '$getStringOrSymbol', '$emval_get_global'],
   _emval_get_global: function(name) {
-    name = getStringOrSymbol(name);
-    return __emval_register(emval_get_global()[name]);
+    if(name===0){
+      return __emval_register(emval_get_global());
+    } else {
+      name = getStringOrSymbol(name);
+      return __emval_register(emval_get_global()[name]);
+    }
   },
 
   _emval_get_module_property__deps: ['$getStringOrSymbol', '_emval_register'],

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -300,7 +300,7 @@ namespace emscripten {
             return val(e);
         }
 
-        static val global(const char* name) {
+        static val global(const char* name = 0) {
             return val(internal::_emval_get_global(name));
         }
 

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -581,6 +581,10 @@ module({
             cm.emval_test_take_and_return_std_string_const_ref("foobar");
         });
 
+        test("can get global", function(){
+            assert.equal((new Function("return this;"))(), cm.embind_test_getglobal());
+        });
+
         test("can create new object", function() {
             assert.deepEqual({}, cm.embind_test_new_Object());
         });

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -1122,6 +1122,10 @@ void test_string_with_vec(const std::string& p1, std::vector<std::string>& v1) {
     printf("%s\n", p1.c_str());
 }
 
+val embind_test_getglobal() {
+    return val::global();
+}
+
 val embind_test_new_Object() {
     return val::global("Object").new_();
 }
@@ -1980,6 +1984,8 @@ EMSCRIPTEN_BINDINGS(tests) {
 
     register_map<std::string, int>("StringIntMap");
     function("embind_test_get_string_int_map", embind_test_get_string_int_map);
+
+    function("embind_test_getglobal", &embind_test_getglobal);
 
     function("embind_test_new_Object", &embind_test_new_Object);
     function("embind_test_new_factory", &embind_test_new_factory);


### PR DESCRIPTION
This PR contains the following changes : 
- Make val::__get_handle() private
- Factorize some duplicate code
- val::global() when call without arguments returns the global object

Remarks and comments are welcome.

cc @chadaustin 
