### PR TITLE
Free GL eventhandlers

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -839,6 +839,7 @@ var LibraryGL = {
 
     deleteContext: function(contextHandle) {
       if (GL.currentContext === GL.contexts[contextHandle]) GL.currentContext = 0;
+      if (typeof JSEvents === 'object') JSEvents.removeAllHandlersOnTarget(GL.contexts[contextHandle].canvas); // Release all JS event handlers on the DOM element that the GL context is associated with since the context is now deleted.
       if (GL.contexts[contextHandle] && GL.contexts[contextHandle].GLctx.canvas) GL.contexts[contextHandle].GLctx.canvas.GLctxObject = undefined; // Make sure the canvas object no longer refers to the context object so there are no GC surprises.
       GL.contexts[contextHandle] = null;
     },

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -125,6 +125,16 @@ var LibraryJSEvents = {
 
     isInternetExplorer: function() { return navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0; },
 
+    // Removes all event handlers on the given DOM element of the given type. Pass in eventType == undefined/null to remove all event handlers regardless of the type.
+    removeAllHandlersOnTarget: function(target, eventTypeString) {
+      for(var i = 0; i < JSEvents.eventHandlers.length; ++i) {
+        if (JSEvents.eventHandlers[i].target == target && 
+          (!eventType || eventTypeString == JSEvents.eventHandlers[i].eventTypeString)) {
+           JSEvents._removeHandler(i--);
+         }
+      }
+    },
+
     _removeHandler: function(i) {
       var h = JSEvents.eventHandlers[i];
       h.target.removeEventListener(h.eventTypeString, h.eventListenerFunc, h.useCapture);


### PR DESCRIPTION
When user deletes a WebGL context, disconnect all event handlers associated with that context so that phantom GL context loss events or similar are not passed to user from contexts that are already supposed to be freed.
