### PR TITLE
Fix invoking a javascript function contained in an emscripten::val when compiled with closure.

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -159,7 +159,7 @@ var LibraryEmVal = {
         functionBody +=
             "var argType"+i+" = requireRegisteredType(HEAP32[(argTypes >> 2) + "+i+"], \"parameter "+i+"\");\n" +
             "var arg"+i+" = argType"+i+".readValueFromPointer(args);\n" +
-            "args += argType"+i+".argPackAdvance;\n";
+            "args += argType"+i+"['argPackAdvance'];\n";
     }
     functionBody +=
         "var obj = new constructor("+argsList+");\n" +
@@ -246,7 +246,7 @@ var LibraryEmVal = {
     for (var i = 0; i < argCount; ++i) {
         var type = types[i];
         args[i] = type['readValueFromPointer'](argv);
-        argv += type.argPackAdvance;
+        argv += type['argPackAdvance'];
     }
 
     var rv = handle.apply(undefined, args);
@@ -307,7 +307,7 @@ var LibraryEmVal = {
     for (var i = 0; i < argCount - 1; ++i) {
         functionBody +=
         "    var arg" + i + " = argType" + i + ".readValueFromPointer(args" + (offset ? ("+"+offset) : "") + ");\n";
-        offset += types[i + 1].argPackAdvance;
+        offset += types[i + 1]['argPackAdvance'];
     }
     functionBody +=
         "    var rv = handle[name](" + argsList + ");\n";


### PR DESCRIPTION
Calling a javascript function that was passed as an emscripten::val using embind causes the generated javascript to reference a null value when closure is enabled. Closure translates argPackAdvance to a small variable name, but does not translate 'argPackAdvance' which is used in other places.

I ran the other.test_embind suite, but the output is somewhat confusing (see below). I could not figure out how to run the test suite with closure enabled (since I cannot use the "ALL." prefix together with the "other." prefix that seems to be necessary for embind). Are the embind tests ever run with closure enabled? Because then I would expect the "can call functions from C++" test to fail.

```
c:\Program Files\Emscripten\emscripten\incoming>python tests/runner.py other.test_embind
test_embind (test_other.other) ... [] True
['--bind'] False
warning: unresolved symbol: _ZN17MultipleOverloads11staticValueE
['--bind', '-O1'] False
warning: unresolved symbol: _ZN17MultipleOverloads11staticValueE
['--bind', '-O2'] False
warning: unresolved symbol: _ZN17MultipleOverloads11staticValueE
ok

----------------------------------------------------------------------
Ran 1 test in 48.372s

OK
```
