### PR TITLE
no-eval fallback for cwrap

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -456,9 +456,13 @@ var cwrap, ccall;
   // NO_DYNAMIC_EXECUTION is on, so we can't use the fast version of cwrap.
   // Fall back to returning a bound version of ccall.
   cwrap = function cwrap(ident, returnType, argTypes) {
-     return function() {
-       return ccall(ident, returnType, argTypes, arguments);
-     }
+    return function() {
+#if ASSERTIONS
+      Runtime.warnOnce('NO_DYNAMIC_EXECUTION was set, '
+                     + 'using slow cwrap implementation');
+#endif
+      return ccall(ident, returnType, argTypes, arguments);
+    }
   }
 #endif
 })();


### PR DESCRIPTION
cwrap returns a dynamically generated function for better performances.

However, in some environments, calling eval is not possible.
So this patch proposes a static version of cwrap when NO_DYNAMIC_EXECUTION is activated.
