### PR TITLE
Assume spidermonkey path is set correctly in ~/.emscripten

### DIFF
--- a/tools/validate_asmjs.py
+++ b/tools/validate_asmjs.py
@@ -14,18 +14,9 @@
 import subprocess, sys, re, tempfile, os, time
 import shared
 
-# Looks up SpiderMonkey engine using the variable SPIDERMONKEY_ENGINE in ~/.emscripten, and if not set up there, via PATH.
-def find_spidermonkey_engine():
-  sm_engine = shared.SPIDERMONKEY_ENGINE if hasattr(shared, 'SPIDERMONKEY_ENGINE') else ['']
-  if not sm_engine or len(sm_engine[0]) == 0 or not os.path.exists(sm_engine[0]):
-    sm_engine[0] = shared.Building.which('js')
-    if sm_engine[0] == None:
-      return ['js-not-found']
-  return sm_engine
-
 # Given a .js file, returns True/False depending on if that file is valid asm.js
 def validate_asmjs_jsfile(filename, muteOutput):
-  cmd = find_spidermonkey_engine() + ['-c', filename]
+  cmd = shared.SPIDERMONKEY_ENGINE + ['-c', filename]
   if cmd[0] == 'js-not-found':
     print >> sys.stderr, 'Could not find SpiderMonkey engine! Please set tis location to SPIDERMONKEY_ENGINE in your ~/.emscripten configuration file!'
     return False


### PR DESCRIPTION
Following #2952, we know that SPIDERMONKEY_ENGINE has already been set in ~/.emscripten once a file has done `import shared` (if it hadn't we'd already have an error by that point).

So I think it makes sense to rely on the .emscripten file being the single point of truth, rather than trying a bit harder to find spidermonkey just for this single bit of functionality.

This PR should be reviewed/merged **AFTER** #2952 is merged (otherwise the diffs will include that PR).
