### PR TITLE
[embind] Add accessor for wrapped on wrapper object.

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -919,6 +919,10 @@ namespace emscripten {
             return wrapped.call<ReturnType>(name, std::forward<Args>(args)...);
         }
 
+        val get_wrapped() const {
+            return wrapped;
+        }
+
     private:
         val wrapped;
     };


### PR DESCRIPTION
cc: @chadaustin 

Passes `test_embind` / `test_embind_2` / `other.test_embind`.
