### PR TITLE
Add implementation for TTF_GlyphMetrics

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2927,6 +2927,27 @@ var LibrarySDL = {
     return 0;
   },
 
+  TTF_GlyphMetrics: function(font, ch, minx, maxx, miny, maxy, advance) {
+    var fontData = SDL.fonts[font];
+    var width = SDL.estimateTextWidth(fontData,  String.fromCharCode(ch));
+    
+    if (advance) {
+      {{{ makeSetValue('advance', '0', 'width', 'i32') }}};
+    }
+    if (minx) {
+      {{{ makeSetValue('minx', '0', '0', 'i32') }}}; 
+    }
+    if (maxx) {
+      {{{ makeSetValue('maxx', '0', 'width', 'i32') }}}; 
+    }
+    if (miny) {
+      {{{ makeSetValue('miny', '0', '0', 'i32') }}}; 
+    }
+    if (maxy) {
+      {{{ makeSetValue('maxy', '0', 'fontData.size', 'i32') }}}; 
+    }
+  },
+
   TTF_FontAscent: function(font) {
     var fontData = SDL.fonts[font];
     return (fontData.size*0.98)|0; // XXX


### PR DESCRIPTION
Looks like there are no way to calculate minx, maxx, miny, maxy for glyph, so this is approximate implementation.
