### PR TITLE
win_test_emconfigure_js_o

### DIFF
--- a/emcc
+++ b/emcc
@@ -229,7 +229,9 @@ if CONFIGURE_CONFIG or CMAKE_CONFIG:
         yield el
       idx += 1
 
-  cmd = [compiler] + list(filter_emscripten_options(sys.argv[1:]))
+  if compiler == shared.EMCC: compiler = [shared.PYTHON, shared.EMCC]
+  else: compiler = [compiler] 
+  cmd = compiler + list(filter_emscripten_options(sys.argv[1:]))
   if not use_js: cmd += shared.EMSDK_OPTS + ['-D__EMSCRIPTEN__', '-DEMSCRIPTEN']
   if use_js: cmd += ['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=1'] # configure tests should fail when an undefined symbol exists
 


### PR DESCRIPTION
Fix another missing 'python emcc' vs 'emcc' for Windows in other.test_emconfigure_js_o. After commit https://github.com/kripken/emscripten/commit/8a70c782a3afdfae49b08c9ad807691dcf4101b6 the test is still failing.
