### PR TITLE
fix some small issues found by closure compiler (IE incompatibilities)

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -5332,7 +5332,7 @@ LibraryManager.library = {
       '%R': '%H:%M',                    // Replaced by the time in 24-hour notation
       '%T': '%H:%M:%S',                 // Replaced by the time
       '%x': '%m/%d/%y',                 // Replaced by the locale's appropriate date representation
-      '%X': '%H:%M:%S',                 // Replaced by the locale's appropriate date representation
+      '%X': '%H:%M:%S'                  // Replaced by the locale's appropriate date representation
     };
     for (var rule in EXPANSION_RULES_1) {
       pattern = pattern.replace(new RegExp(rule, 'g'), EXPANSION_RULES_1[rule]);

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -214,11 +214,11 @@ mergeInto(LibraryManager.library, {
             set: function(val) { val ? this.mode |= writeMode : this.mode &= ~writeMode; }
           },
           isFolder: {
-            get: function() { return FS.isDir(this.mode); },
+            get: function() { return FS.isDir(this.mode); }
           },
           isDevice: {
-            get: function() { return FS.isChrdev(this.mode); },
-          },
+            get: function() { return FS.isChrdev(this.mode); }
+          }
         });
       }
 

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -55,7 +55,7 @@ mergeInto(LibraryManager.library, {
               setattr: MEMFS.node_ops.setattr
             },
             stream: FS.chrdev_stream_ops
-          },
+          }
         };
       }
       var node = FS.createNode(parent, name, mode, dev);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -907,7 +907,7 @@ function demangle(func) {
       return ret + flushList();
     }
   }
-  var final = func;
+  var parsed = func;
   try {
     // Special-case the entry point, since its name differs from other name mangling.
     if (func == 'Object._main' || func == '_main') {
@@ -921,14 +921,14 @@ function demangle(func) {
       case 'n': return 'operator new()';
       case 'd': return 'operator delete()';
     }
-    final = parse();
+    parsed = parse();
   } catch(e) {
-    final += '?';
+    parsed += '?';
   }
-  if (final.indexOf('?') >= 0 && !hasLibcxxabi) {
+  if (parsed.indexOf('?') >= 0 && !hasLibcxxabi) {
     Runtime.warnOnce('warning: a problem occurred in builtin C++ name demangling; build with  -s DEMANGLE_SUPPORT=1  to link in libcxxabi demangling');
   }
-  return final;
+  return parsed;
 }
 
 function demangleAll(text) {


### PR DESCRIPTION
Closure treats the trailing comma in object as an error. Avoiding "final" keyword as var name is also only needed for older browsers, but keeps tools happy.
