### PR TITLE
[GL] Allow others to register GL contexts.

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -813,6 +813,10 @@ var LibraryGL = {
       // possible GL_DEBUG entry point: ctx = wrapDebugGL(ctx);
 
       if (!ctx) return 0;
+      return GL.registerContext(ctx, webGLContextAttributes);
+    },
+
+    registerContext: function(ctx, webGLContextAttributes) {
       var handle = GL.getNewId(GL.contexts);
       var context = {
         handle: handle,


### PR DESCRIPTION
This makes it so that other users of emscripten can register a
context without having to copy/paste this body of code.
