### PR TITLE
fix nasty little bug in Module.ccall

### DIFF
--- a/tests/core/test_ccall.in
+++ b/tests/core/test_ccall.in
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#include <emscripten.h>
 
 extern "C" {
 int get_int() { return 5; }
@@ -16,6 +17,25 @@ int *pointer(int *in) {
   printf("%d\n", *in);
   static int ret = 21;
   return &ret;
+}
+
+// This test checks that ccall restores the stack correctly to whatever it was
+// when ccall was entered.  We save the stack pointer on the heap in stackChecker
+// and verify that ccall restores it correctly.
+struct test_struct {
+  int arg1, arg2, arg3;
+};
+static int* stackChecker = 0;
+int get_stack() { return EM_ASM_INT_V({ return Runtime.stackSave(); }); }
+int uses_stack(test_struct* t1) {
+  if (stackChecker == 0) stackChecker = (int*)malloc(sizeof(int));
+  *stackChecker = get_stack();
+  EM_ASM(Module.ccall('get_int', 'number'));
+  printf("stack is %s.\n", *stackChecker == get_stack() ? "ok" : "messed up");
+}
+void call_ccall_again() {
+  test_struct t1 = { 1, 2, 3 };
+  uses_stack(&t1);
 }
 }
 

--- a/tests/core/test_ccall.out
+++ b/tests/core/test_ccall.out
@@ -22,3 +22,4 @@ bret
 53
 *
 stack is ok.
+stack is ok.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5904,19 +5904,19 @@ def process(filename):
       Module.print(multi(2, 1.4, 3, 'atr'));
       Module.print(multi(8, 5.4, 4, 'bret'));
       Module.print('*');
-      // part 3: avoid stack explosion
+      // part 3: avoid stack explosion and check it's restored correctly
       for (var i = 0; i < TOTAL_STACK/60; i++) {
         ccall('multi', 'number', ['number', 'number', 'number', 'string'], [0, 0, 0, '123456789012345678901234567890123456789012345678901234567890']);
       }
       Module.print('stack is ok.');
+      ccall('call_ccall_again', null);
     });
     Module.callMain();
   \'\'\'
   open(filename, 'w').write(src)
 '''
 
-    Settings.EXPORTED_FUNCTIONS += ['_get_int', '_get_float', '_get_string', '_print_int', '_print_float', '_print_string', '_multi', '_pointer', '_malloc']
-
+    Settings.EXPORTED_FUNCTIONS += ['_get_int', '_get_float', '_get_string', '_print_int', '_print_float', '_print_string', '_multi', '_pointer', '_call_ccall_again', '_malloc']
     test_path = path_from_root('tests', 'core', 'test_ccall')
     src, output = (test_path + s for s in ('.in', '.out'))
 


### PR DESCRIPTION
In our code, we were entering C from JS using ccall, then inside the C calling back out to JS, which in turn re-entered the C code using ccall. Due to the use of the global in ccall, this can badly corrupt the stack, but usually nothing crashes. For weeks we hadn't tracked down the cause (SAFE_HEAP doesn't help here)!

Basically, the `stack` global here is just evil. In the case of nested calls, the inner ccall resets the stack on exit to the value stashed by the outer ccall. Even worse, ccall actually fails if called twice with different base stack values, because `stack` is not reset to zero anywhere in this code, so no matter how many times you use ccall, `stackSave` is only used in the first one.

Just use a local variable.

I've added a test which comprehensively crashes without the fix applied to preamble.js.
