### PR TITLE
WebIDL: Do not allocate redundant storage for identical strings.

### DIFF
--- a/tests/webidl/output.txt
+++ b/tests/webidl/output.txt
@@ -49,6 +49,9 @@ caught: a JSImplementation must implement all functions, you forgot Child2JS::vi
 |hello|43|world|41|
 12.35
 a returned string
+C string address: "string A" 0xa30
+C string address: "string B" 0xa40
+C string address: "string A" 0xa30
 10
 object
 10

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -103,6 +103,11 @@ suser.Print(41, "world");
 suser.PrintFloat(12.3456);
 TheModule.print(suser.returnAString());
 
+// Verify that subsequent calls with the same string value re-use the string storage.
+suser.PrintCStringAddress("string A");
+suser.PrintCStringAddress("string B");
+suser.PrintCStringAddress("string A");
+
 var bv = new TheModule.RefUser(10);
 var bv2 = new TheModule.RefUser(11);
 TheModule.print(bv2.getValue(bv));

--- a/tests/webidl/test.h
+++ b/tests/webidl/test.h
@@ -59,6 +59,10 @@ public:
   }
   void PrintFloat(float f) { printf("%.2f\n", f); }
   const char* returnAString() { return "a returned string"; }
+
+  void PrintCStringAddress(const char* s) {
+    printf("C string address: \"%s\" %p\n", s, s);
+  }
 };
 
 struct RefUser {

--- a/tests/webidl/test.idl
+++ b/tests/webidl/test.idl
@@ -52,6 +52,7 @@ interface StringUser {
   void Print(long anotherInteger, DOMString anotherString);
   void PrintFloat(float f);
   [Const] DOMString returnAString();
+  void PrintCStringAddress(DOMString str);
 };
 
 interface RefUser {

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -128,10 +128,20 @@ function getClass(obj) {
 Module['getClass'] = getClass;
 
 // Converts a value into a C-style string.
-function ensureString(value) {
-  if (typeof value == 'string') return allocate(intArrayFromString(value), 'i8', ALLOC_STACK);
-  return value;
-}
+var ensureString = (function() {
+  var stringCache = {};
+  function ensureString(value) {
+    if (typeof value == 'string') {
+      var cachedVal = stringCache[value];
+      if (cachedVal) return cachedVal;
+      var ret = allocate(intArrayFromString(value), 'i8', ALLOC_STACK);
+      stringCache[value] = ret;
+      return ret;
+    }
+    return value;
+  }
+  return ensureString;
+})();
 
 ''']
 


### PR DESCRIPTION
I'd also be thrilled to simply release the allocated memory after the function call returns (or re-use a statically allocated portion of the heap), however that would break any existing code that retained copies of `char *` parameters instead of copying the addressed memory.
