### PR TITLE
-Werror-return-type

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -746,6 +746,10 @@ if LLVM_TARGET == 'asmjs-unknown-emscripten' or LLVM_TARGET == 'le32-unknown-nac
   #   -Wno-implicit-function-declaration
   COMPILER_OPTS += ['-Werror=implicit-function-declaration']
 
+# Emscripten doesn't support assembly code, so implicit 'return eax' from functions that return an int
+# cannot be supported.
+COMPILER_OPTS += ['-Werror=return-type']
+
 USE_EMSDK = not os.environ.get('EMMAKEN_NO_SDK')
 
 if USE_EMSDK:


### PR DESCRIPTION
Always pass -Werror=return-type on builds since we can't return eax on int functions that fall through without a return statement. Closes #3025.
