### PR TITLE
Add resize to bindings generated by register_vector.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -170,4 +170,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Warren Seine <warren.seine@aerys.in> (copyright owned by Aerys SAS)
 * Petr Babicka <babcca@gmail.com>
 * Akira Takahashi <faithandbrave@gmail.com>
+* Victor Costan <costan@gmail.com>
 

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1379,9 +1379,11 @@ namespace emscripten {
         typedef std::vector<T> VecType;
 
         void (VecType::*push_back)(const T&) = &VecType::push_back;
+        void (VecType::*resize)(const size_t) = &VecType::resize;
         return class_<std::vector<T>>(name)
             .template constructor<>()
             .function("push_back", push_back)
+            .function("resize", resize)
             .function("size", &VecType::size)
             .function("get", &internal::VectorAccess<VecType>::get)
             .function("set", &internal::VectorAccess<VecType>::set)

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -917,6 +917,29 @@ module({
             str.delete();
             vec.delete();
         });
+
+        test("resize appends the default value", function() {
+            var vec = cm.emval_test_return_vector();
+
+            vec.resize(5);
+            assert.equal(5, vec.size());
+            assert.equal(10, vec.get(0));
+            assert.equal(20, vec.get(1));
+            assert.equal(30, vec.get(2));
+            assert.equal(0, vec.get(3));
+            assert.equal(0, vec.get(4));
+            vec.delete();
+        });
+
+        test("resize preserves content when shrinking", function() {
+            var vec = cm.emval_test_return_vector();
+
+            vec.resize(2);
+            assert.equal(2, vec.size());
+            assert.equal(10, vec.get(0));
+            assert.equal(20, vec.get(1));
+            vec.delete();
+        });
     });
 
     BaseFixture.extend("map", function() {


### PR DESCRIPTION
register_vector currently generates push_back, size, get, and set. This is sufficient for growing vectors, but provides no way to delete elements and shrink vectors.  This change adds resize, which can be used to shrink vectors.

This is my first contribution, so I added myself to AUTHORS. I tried to follow the Contributing guide, and I welcome your feedback and help if I missed something.

Last, thank you very much for emscripten! This is really mindblowing!
