### PR TITLE
avoid the need for replacing backslashes with slashes on windows for some settings

### DIFF
--- a/emcc
+++ b/emcc
@@ -864,7 +864,8 @@ try:
   for change in settings_changes:
     key, value = change.split('=')
     if value[0] == '@':
-      value = open(value[1:]).read()
+      value = '"@' + os.path.abspath(value[1:]) + '"'
+      value = value.replace('\\\\', '/').replace('\\', '/') # Convert backslash paths to forward slashes on Windows as well, since the JS compiler otherwise needs the backslashes escaped (alternative is to escape all input paths passing to JS, which feels clumsier to read)
     else:
       value = value.replace('\\', '\\\\')
     exec('shared.Settings.' + key + ' = ' + value)


### PR DESCRIPTION
This is something we've been using in IMVU land for some months ... it is necessary on Windows if you set some settings to paths to a file.

cc: @chadaustin 
