### PR TITLE
Fix 3066 glfw get cursor pos

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -527,6 +527,11 @@ var LibraryGLFW = {
     },
 
     getCursorPos: function(winid, x, y) {
+      setValue(x, Browser.mouseX, 'double');
+      setValue(y, Browser.mouseY, 'double');
+    },
+
+    getMousePos: function(winid, x, y) {
       setValue(x, Browser.mouseX, 'i32');
       setValue(y, Browser.mouseY, 'i32');
     },
@@ -1145,7 +1150,7 @@ var LibraryGLFW = {
   },
 
   glfwGetMousePos: function(x, y) {
-    GLFW.getCursorPos(GLFW.active.id, x, y);
+    GLFW.getMousePos(GLFW.active.id, x, y);
   },
 
   glfwSetMousePos: function(x, y) {


### PR DESCRIPTION
This is the fix commit for #3066.

---
1. fix `glfwGetCursorPos`(GLFW3 API):
   -  parameter type from 'i32' to 'double'.
2. add `GLFW.getMousePos`:
   - `i32` version for GLFW2.
3. fix `glfwGetMousePos`(GLFW2 API):
   - from call `GLFW.getCursorPos` to call `GLFW.getMousePos`
