### PR TITLE
Fixed wrong variable declaration in library_sdl.js

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -491,7 +491,7 @@ var LibrarySDL = {
           SDL.updateRect(dstrect, dr);
         }
       }
-      var blitw, blitr;
+      var blitw, blith;
       if (scale) {
         blitw = dr.w; blith = dr.h;
       } else {


### PR DESCRIPTION
 'blith' was used as a automatic global variable because of the wrong declaration
