### PR TITLE
Make resize in std::vector bindings not assume a default constructor.

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1379,7 +1379,7 @@ namespace emscripten {
         typedef std::vector<T> VecType;
 
         void (VecType::*push_back)(const T&) = &VecType::push_back;
-        void (VecType::*resize)(const size_t) = &VecType::resize;
+        void (VecType::*resize)(const size_t, const T&) = &VecType::resize;
         return class_<std::vector<T>>(name)
             .template constructor<>()
             .function("push_back", push_back)

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -918,23 +918,23 @@ module({
             vec.delete();
         });
 
-        test("resize appends the default value", function() {
+        test("resize appends the given value", function() {
             var vec = cm.emval_test_return_vector();
 
-            vec.resize(5);
+            vec.resize(5, 42);
             assert.equal(5, vec.size());
             assert.equal(10, vec.get(0));
             assert.equal(20, vec.get(1));
             assert.equal(30, vec.get(2));
-            assert.equal(0, vec.get(3));
-            assert.equal(0, vec.get(4));
+            assert.equal(42, vec.get(3));
+            assert.equal(42, vec.get(4));
             vec.delete();
         });
 
         test("resize preserves content when shrinking", function() {
             var vec = cm.emval_test_return_vector();
 
-            vec.resize(2);
+            vec.resize(2, 42);
             assert.equal(2, vec.size());
             assert.equal(10, vec.get(0));
             assert.equal(20, vec.get(1));


### PR DESCRIPTION
This change uses the std::vector::resize variant that takes a value argument and uses it if the vector needs to be extended. The previous attempt of adding resize used the 1 argument version, which required that the vector's element type has a default constructor.
