### PR TITLE
Static glgears test.

### DIFF
--- a/tests/hello_world_gles_proxy.c
+++ b/tests/hello_world_gles_proxy.c
@@ -40,6 +40,7 @@
 
 #define _GNU_SOURCE
 
+#include <assert.h>
 #include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -613,10 +614,18 @@ gears_idle(void)
    static double tRot0 = -1.0, tRate0 = -1.0;
    double dt, t = glutGet(GLUT_ELAPSED_TIME) / 1000.0;
 
+#ifdef STATIC_GEARS
+   assert(t - tRot0 > 0); // Test that time does advance even though we are rendering a static image.
+#endif
+
    if (tRot0 < 0.0)
       tRot0 = t;
    dt = t - tRot0;
    tRot0 = t;
+
+#ifdef STATIC_GEARS
+   dt = t = 0.0; // Render the gears in a static position.
+#endif
 
    /* advance rotation for next frame */
    angle += 70.0 * dt;  /* 70 degrees per second */

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -758,7 +758,7 @@ window.close = function() {
     self.btest('sdl_canvas_proxy.c', reference='sdl_canvas_proxy.png', args=['--proxy-to-worker', '--preload-file', 'data.txt'], manual_reference=True, post_build=self.post_manual_reftest)
 
   def test_glgears_proxy(self):
-    self.btest('hello_world_gles_proxy.c', reference='gears.png', args=['--proxy-to-worker', '-s', 'GL_TESTING=1'], manual_reference=True, post_build=self.post_manual_reftest)
+    self.btest('hello_world_gles_proxy.c', reference='gears.png', args=['--proxy-to-worker', '-s', 'GL_TESTING=1', '-DSTATIC_GEARS=1'], manual_reference=True, post_build=self.post_manual_reftest)
 
     # test noProxy option applied at runtime
 


### PR DESCRIPTION
Remove timing dependency on browser.test_glgears_proxy by rendering a static nonanimated version of the gears in each rAF.
