### PR TITLE
MSVC hex strings.

### DIFF
--- a/tools/optimizer/simple_ast.h
+++ b/tools/optimizer/simple_ast.h
@@ -829,8 +829,15 @@ struct JSPrinter {
         assert(d >= 0);
         unsigned long long uu = (unsigned long long)d;
         if (uu == d) {
-          snprintf(buffer, BUFFERSIZE-1, (e && !finalize) ? "0x%llx" : "%llu", uu);
-          sscanf(buffer, "%lf", &temp);
+          bool asHex = e && !finalize;
+          snprintf(buffer, BUFFERSIZE-1, asHex ? "0x%llx" : "%llu", uu);
+          if (asHex) {
+            unsigned long long tempULL;
+            sscanf(buffer, "%llx", &tempULL);
+            temp = (double)tempULL;
+          } else {
+            sscanf(buffer, "%lf", &temp);
+          }
         } else {
           // too large for a machine integer, just use floats
           snprintf(buffer, BUFFERSIZE-1, e ? "%e" : "%.0f", d); // even on integers, e with a dot is useful, e.g. 1.2e+200


### PR DESCRIPTION
Fix printNum on Visual Studio: sscanf does not scan unsigned hexadecimal 64-bit integers with format specifier "%lf" to a double, so instead explicitly scan hex strings with "%llx". Fixes parsing and writing string hex numbers such as "0x8000000000000000".
