### PR TITLE
Deferred syncfs on file changes

### DIFF
--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -29,6 +29,21 @@ mergeInto(LibraryManager.library, {
           }
         });
       }, IDBFS.AUTOMATIC_SYNC_TIMEOUT);
+
+      // Also set an atExit hook (if we have not yet done so.)
+      if (!mount.atExitSyncFsHookAdded) {
+        mount.atExitSyncFsHookAdded = true;
+        Module['addOnExit'](function() {
+          // We might not need to syncfs() at this time ...
+          if (mount.mountSyncfsTimer) { return; }
+
+          IDBFS.syncfs(mount, false, function(err) {
+            if (err) {
+              console.log("IDBFS.syncfs threw an exception: ", err);
+            }
+          });
+        });
+      }
     },
 #endif
     syncfs: function(mount, populate, callback) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -253,7 +253,7 @@ var LEGACY_GL_EMULATION = 0; // Includes code to emulate various desktop GL feat
                              // in some cases, see http://kripken.github.io/emscripten-site/docs/porting/multimedia_and_graphics/OpenGL-support.html
 var GL_FFP_ONLY = 0; // If you specified LEGACY_GL_EMULATION = 1 and only use fixed function pipeline in your code,
                      // you can also set this to 1 to signal the GL emulation layer that it can perform extra
-                     // optimizations by knowing that the user code does not use shaders at all. If 
+                     // optimizations by knowing that the user code does not use shaders at all. If
                      // LEGACY_GL_EMULATION = 0, this setting has no effect.
 
 var STB_IMAGE = 0; // Enables building of stb-image, a tiny public-domain library for decoding images, allowing
@@ -299,11 +299,11 @@ var ASYNCIFY_FUNCTIONS = ['emscripten_sleep', // Functions that call any functio
                           'emscripten_wget',  // will be transformed
                           'emscripten_yield'];
 var ASYNCIFY_WHITELIST = ['qsort',   // Functions in this list are never considered async, even if they appear in ASYNCIFY_FUNCTIONS
-                          'trinkle', // In the asyncify transformation, any function that calls a function pointer is considered async 
+                          'trinkle', // In the asyncify transformation, any function that calls a function pointer is considered async
                           '__toread', // This whitelist is useful when a function is known to be sync
                           '__uflow',  // currently this link contains some functions in libc
-                          '__fwritex', 
-                          'MUSL_vfprintf']; 
+                          '__fwritex',
+                          'MUSL_vfprintf'];
 
 var EXPORTED_RUNTIME_METHODS = [ // Methods that are exported on Module. By default we export quite a bit, you can reduce this list to lower your code size,
                                  // especially when closure is run (exporting prevents closure from eliminating code)
@@ -361,7 +361,7 @@ var FS_LOG = 0; // Log all FS operations.  This is especially helpful when you'r
                 // so that you can create a virtual file system with all of the required files.
 var CASE_INSENSITIVE_FS = 0; // If set to nonzero, the provided virtual filesystem if treated case-insensitive, like
                              // Windows and OSX do. If set to 0, the VFS is case-sensitive, like on Linux.
-var MEMFS_APPEND_TO_TYPED_ARRAYS = 0; // If set to nonzero, MEMFS will always utilize typed arrays as the backing store 
+var MEMFS_APPEND_TO_TYPED_ARRAYS = 0; // If set to nonzero, MEMFS will always utilize typed arrays as the backing store
                                       // for appending data to files. The default behavior is to use typed arrays for files
                                       // when the file size doesn't change after initial creation, and for files that do
                                       // change size, use normal JS arrays instead.
@@ -600,6 +600,7 @@ var EMTERPRETIFY_ADVISE = 0; // Performs a static analysis to suggest which func
                              // appears they can be on the stack when a sync function is called in the EMTERPRETIFY_ASYNC option.
                              // After showing the suggested list, compilation will halt. You can apply the provided list as an
                              // emcc argument when compiling later.
+var IDBFS_AUTOMATIC_SYNC = 0; // Automatic call syncfs on the mount when file changes.
 
 var SPLIT_MEMORY = 0; // If > 0, we split memory into chunks, of the size given in this parameter.
                       //  * TOTAL_MEMORY becomes the maximum amount of memory, as chunks are allocated on

--- a/tests/fs/test_idbfs_defer_write.c
+++ b/tests/fs/test_idbfs_defer_write.c
@@ -1,0 +1,138 @@
+#include <stdio.h>
+#include <emscripten.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <string.h>
+
+int result = 1;
+
+void success()
+{
+  REPORT_RESULT();
+}
+
+void test_open_close() {
+  // In this test, open and close an empty file will invoke mknod() indirectly
+  // and close() directly, both should trigger deferredSyncFs but we should only
+  // ended up calling syncfs once.
+  struct stat st;
+  int fd;
+
+  if ((stat("/working1/empty.txt", &st) != -1) || (errno != ENOENT))
+    result = -1000 - errno;
+  fd = open("/working1/empty.txt", O_RDWR | O_CREAT, 0666);
+  if (fd == -1)
+    result = -2000 - errno;
+  else if (close(fd) != 0)
+    result = -3000 - errno;
+}
+
+void test_open_close2() {
+  // In this test, open and close an existing empty file will invoke close()
+  // directly but not mknod(), therefore assert close() alone will eventually
+  // trigger syncfs.
+  struct stat st;
+  int fd;
+
+  fd = open("/working1/empty.txt", O_RDWR | O_CREAT, 0666);
+  if (fd == -1)
+    result = -4000 - errno;
+  else if (close(fd) != 0)
+    result = -5000 - errno;
+}
+
+void test_fopen_fclose() {
+  // In this test, fopen and fclose an empty file will invoke mknod() indirectly
+  // and close() indirectly, and again both should trigger deferredSyncFs but
+  // we should only ended up calling syncfs once.
+  struct stat st;
+
+  if ((stat("/working1/empty2.txt", &st) != -1) || (errno != ENOENT))
+    result = -6000 - errno;
+
+  FILE *fp;
+  int res;
+
+  fp = fopen("/working1/empty2.txt", "wb+");
+  fclose(fp);
+}
+
+void test_rename() {
+  // We would also like to make sure rename() will trigger syncfs.
+  if (rename("/working1/empty2.txt", "/working1/empty3.txt") != 0)
+    result = -7000 - errno;
+}
+
+void test_unlink() {
+  // In this test, unlink() two files will invoke deferredSyncFs twice but
+  // again, we should only ended up calling syncfs once.
+
+  if (unlink("/working1/empty.txt") != 0)
+    result = -8000 - errno;
+
+  if (unlink("/working1/empty3.txt") != 0)
+    result = -9000 - errno;
+}
+
+int main() {
+
+  EM_ASM(
+    var i = 0;
+
+    // Set the timer to 0 to trigger syncfs at next tick.
+    var timeout = IDBFS.DEFER_WRITE_TIMEOUT;
+    IDBFS.DEFER_WRITE_TIMEOUT = 0;
+
+    // Wrap IDBFS.syncfs so we could tell when it is invoked (and completes).
+    IDBFS.realSyncFS = IDBFS.syncfs;
+    IDBFS.syncfs = function(mount, populate, callback) {
+      IDBFS.realSyncFS(mount, populate, function(err) {
+        callback(err);
+
+        assert(!err);
+        switch (i) {
+          case 0:
+            ccall('test_open_close2', 'v');
+            break;
+
+          case 1:
+            ccall('test_fopen_fclose', 'v');
+            break;
+
+          case 2:
+            ccall('test_rename', 'v');
+            break;
+
+          case 3:
+            ccall('test_unlink', 'v');
+            break;
+
+          case 4:
+            IDBFS.syncfs = IDBFS.realSyncFS;
+            delete IDBFS.realSyncFS;
+            IDBFS.AUTOMATIC_SYNC_TIMEOUT = timeout;
+
+            ccall('success', 'v');
+            break;
+
+          default:
+            assert(false, 'Should not reach here.');
+        }
+        i++;
+
+      });
+    };
+
+    FS.mkdir('/working1');
+    FS.mount(IDBFS, {}, '/working1');
+  );
+
+  // Start the first test.
+  test_open_close();
+
+  emscripten_exit_with_live_runtime();
+
+  return 0;
+}

--- a/tests/fs/test_idbfs_defer_write_on_exit.c
+++ b/tests/fs/test_idbfs_defer_write_on_exit.c
@@ -1,0 +1,40 @@
+#include <stdio.h>
+#include <emscripten.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include <errno.h>
+#include <string.h>
+
+int result = 1;
+
+int main() {
+  struct stat st;
+  int fd;
+
+  // We first open and close an empty file in the directory and leave, which
+  // should trigger syncfs() on exit. We will then verify the existance of the
+  // file on the !FIRST run.
+
+#if FIRST
+
+  if ((stat("/working1/empty.txt", &st) != -1) || (errno != ENOENT))
+    result = -1000 - errno;
+  fd = open("/working1/empty.txt", O_RDWR | O_CREAT, 0666);
+  if (fd == -1)
+    result = -2000 - errno;
+  else if (close(fd) != 0)
+    result = -3000 - errno;
+
+#else
+
+  if (stat("/working1/empty.txt", &st) != 0)
+    result = -4000 - errno;
+  if (unlink("/working1/empty.txt") != 0)
+    result = -5000 - errno;
+
+#endif
+
+  REPORT_RESULT();
+  return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1033,6 +1033,11 @@ keydown(100);keyup(100); // trigger the end
         self.btest(path_from_root('tests', 'fs', 'test_idbfs_sync.c'), '1', force_c=True, args=mode + ['-DFIRST', '-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test', '_success']'''])
         self.btest(path_from_root('tests', 'fs', 'test_idbfs_sync.c'), '1', force_c=True, args=mode + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test', '_success']'''] + extra)
 
+  def test_fs_idbfs_defer_write(self):
+    for mode in [[], ['-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1']]:
+      secret = str(time.time())
+      self.btest(path_from_root('tests', 'fs', 'test_idbfs_defer_write.c'), '1', force_c=True, args=mode + ['-s', 'IDBFS_AUTOMATIC_SYNC=1', '-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main', '_test_open_close2', '_test_fopen_fclose', '_test_rename', '_test_unlink', '_success']'''])
+
   def test_fs_idbfs_fsync(self):
     # sync from persisted state into memory before main()
     open(os.path.join(self.get_dir(), 'pre.js'), 'w').write('''


### PR DESCRIPTION
This implements #3453 behind a build config named `IDBFS_DEFER_WRITE`. Two tests are created to ensure syncfs triggers in various situations.

I am not really happy about the naming (`IDBFS_DEFER_WRITE`). I would love to change it if there is something better!

After this gets merged, I would like to patch the document of IDBFS to explain the features (this one and the previous `fsync` one.)

Thanks for you help!
