### PR TITLE
Enable SSE2 test cases.

### DIFF
--- a/tests/test_sse2_full.cpp
+++ b/tests/test_sse2_full.cpp
@@ -5,15 +5,6 @@
 #define ENABLE_SSE2
 #include "test_sse_full.h"
 
-// We don't have an Int64x2 type, but we do emulate in scalar Int64x2 code. However, 
-// the PNaCl ExpandI64.cpp path fails to expand our emulated code when LLVM wants to pack or
-// unpack the 64bit elements to/from vectors. Therefore skip that path for now in release builds.
-// (debug builds work ok, since they avoid optimized smartness)
-// See https://github.com/kripken/emscripten/issues/3788
-#ifndef _DEBUG
-#define NO_INT64X2
-#endif
-
 #ifndef _DEBUG
 // The following tests break when optimizer is applied, so disable them for now. Baby steps.
 // See https://github.com/kripken/emscripten/issues/3789
@@ -32,51 +23,33 @@ void test_arithmetic()
 	// SSE2 Arithmetic instructions:
 	M128i_M128i_M128i(_mm_add_epi16);
 	M128i_M128i_M128i(_mm_add_epi32);
-#ifndef NO_INT64X2
 	M128i_M128i_M128i(_mm_add_epi64);
-#endif
 	M128i_M128i_M128i(_mm_add_epi8);
 	Ret_M128d_M128d(__m128d, _mm_add_pd);
 	Ret_M128d_M128d(__m128d, _mm_add_sd);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_adds_epi16);
-#endif
 	M128i_M128i_M128i(_mm_adds_epi8);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_adds_epu16);
-#endif
 	M128i_M128i_M128i(_mm_adds_epu8);
 	Ret_M128d_M128d(__m128d, _mm_div_pd);
 	Ret_M128d_M128d(__m128d, _mm_div_sd);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_madd_epi16);
-#endif
-#ifndef NO_INT64X2
 	M128i_M128i_M128i(_mm_mul_epu32);
-#endif
 	Ret_M128d_M128d(__m128d, _mm_mul_pd);
 	Ret_M128d_M128d(__m128d, _mm_mul_sd);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_mulhi_epi16);
 	M128i_M128i_M128i(_mm_mulhi_epu16);
-#endif
 	M128i_M128i_M128i(_mm_mullo_epi16);
 	M128i_M128i_M128i(_mm_sad_epu8);
 	M128i_M128i_M128i(_mm_sub_epi16);
 	M128i_M128i_M128i(_mm_sub_epi32);
-#ifndef NO_INT64X2
 	M128i_M128i_M128i(_mm_sub_epi64);
-#endif
 	M128i_M128i_M128i(_mm_sub_epi8);
 	Ret_M128d_M128d(__m128d, _mm_sub_pd);
 	Ret_M128d_M128d(__m128d, _mm_sub_sd);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_subs_epi16);
-#endif
 	M128i_M128i_M128i(_mm_subs_epi8);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_subs_epu16);
-#endif
 	M128i_M128i_M128i(_mm_subs_epu8);
 }
 
@@ -154,26 +127,18 @@ void test_convert()
 	Ret_M128(__m128d,  _mm_cvtps_pd);
 	Ret_M128(double, _mm_cvtsd_f64);
 	Ret_M128d(int, _mm_cvtsd_si32);
-#ifndef NO_INT64X2
 	Ret_M128d(int64_t, _mm_cvtsd_si64); // _mm_cvtsd_si64x is an alias to this.
-#endif
 	Ret_M128i(int, _mm_cvtsi128_si32);
-#ifndef NO_INT64X2
 	Ret_M128i(int64_t, _mm_cvtsi128_si64); // _mm_cvtsi128_si64x is an alias to this.
-#endif
 	Ret_M128d_int(__m128d, _mm_cvtsi32_sd);
 	Ret_int(__m128i, _mm_cvtsi32_si128);
-#ifndef NO_INT64X2
 	Ret_M128d_int64(__m128d, _mm_cvtsi64_sd); // _mm_cvtsi64x_sd is an alias to this.
 	Ret_int64(__m128i, _mm_cvtsi64_si128); // _mm_cvtsi64x_si128 is an alias to this.
-#endif
 	Ret_M128d_M128d(__m128d, _mm_cvtss_sd);
 	Ret_M128d(__m128i, _mm_cvttpd_epi32);
 	Ret_M128(__m128i, _mm_cvttps_epi32);
 	Ret_M128d(int, _mm_cvttsd_si32);
-#ifndef NO_INT64X2
 	Ret_M128d(int64_t, _mm_cvttsd_si64); // _mm_cvttsd_si64x is an alias to this.
-#endif
 }
 void test_elementarymath()
 {
@@ -197,18 +162,14 @@ void test_load()
 	Ret_DoublePtr(__m128d, _mm_load_pd, 2, 2);
 	Ret_DoublePtr(__m128d, _mm_load_pd1, 1, 1);
 	Ret_DoublePtr(__m128d, _mm_load_sd, 1, 1);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	Ret_IntPtr(__m128i, _mm_load_si128, __m128i*, 4, 4);
-#endif
 	Ret_DoublePtr(__m128d, _mm_load1_pd, 1, 1);
 	Ret_M128d_DoublePtr(__m128d, _mm_loadh_pd, double*, 1, 1);
 	Ret_IntPtr(__m128i, _mm_loadl_epi64, __m128i*, 2, 1);
 	Ret_M128d_DoublePtr(__m128d, _mm_loadl_pd, double*, 1, 1);
 	Ret_DoublePtr(__m128d, _mm_loadr_pd, 2, 2);
 	Ret_DoublePtr(__m128d, _mm_loadu_pd, 2, 1);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	Ret_IntPtr(__m128i, _mm_loadu_si128, __m128i*, 4, 1);
-#endif
 }
 
 void test_logical()
@@ -227,32 +188,24 @@ void test_logical()
 void test_misc()
 {
 	// SSE2 Miscellaneous instructions:
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	Ret_M128i(int, _mm_movemask_epi8);
-#endif
 	Ret_M128d(int, _mm_movemask_pd);
 	M128i_M128i_M128i(_mm_packs_epi16);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_packs_epi32);
-#endif
 	M128i_M128i_M128i(_mm_packus_epi16);
 }
 
 void test_move()
 {
 	// SSE2 Move instructions:
-#ifndef NO_INT64X2
 	Ret_M128i(__m128i, _mm_move_epi64);
-#endif
 	Ret_M128d_M128d(__m128d, _mm_move_sd);
 }
 
 void test_probability()
 {
 	// SSE2 Probability/Statistics instructions:
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_avg_epu16);
-#endif
 	M128i_M128i_M128i(_mm_avg_epu8);
 }
 
@@ -289,14 +242,10 @@ void test_shift()
 	// SSE2 Shift instructions:
 	M128i_M128i_M128i(_mm_sll_epi16);
 	M128i_M128i_M128i(_mm_sll_epi32);
-#ifndef NO_INT64X2
 	M128i_M128i_M128i(_mm_sll_epi64);
-#endif
 	Ret_M128i_Tint(__m128i, _mm_slli_epi16);
 	Ret_M128i_Tint(__m128i, _mm_slli_epi32);
-#ifndef NO_INT64X2
 	Ret_M128i_Tint(__m128i, _mm_slli_epi64);
-#endif
 	Ret_M128i_Tint(__m128i, _mm_slli_si128); // _mm_bslli_si128 is an alias to this.
 	M128i_M128i_M128i(_mm_sra_epi16);
 	M128i_M128i_M128i(_mm_sra_epi32);
@@ -304,32 +253,22 @@ void test_shift()
 	Ret_M128i_Tint(__m128i, _mm_srai_epi32);
 	M128i_M128i_M128i(_mm_srl_epi16);
 	M128i_M128i_M128i(_mm_srl_epi32);
-#ifndef NO_INT64X2
 	M128i_M128i_M128i(_mm_srl_epi64);
-#endif
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	Ret_M128i_Tint(__m128i, _mm_srli_epi16);
-#endif
 	Ret_M128i_Tint(__m128i, _mm_srli_epi32);
-#ifndef NO_INT64X2
 	Ret_M128i_Tint(__m128i, _mm_srli_epi64);
-#endif
 	Ret_M128i_Tint(__m128i, _mm_srli_si128); // _mm_bsrli_si128 is an alias to this.
 }
 
 void test_specialmath()
 {
 	// SSE2 Special Math instructions:
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_max_epi16);
 	M128i_M128i_M128i(_mm_max_epu8);
-#endif
 	Ret_M128d_M128d(__m128d, _mm_max_pd);
 	Ret_M128d_M128d(__m128d, _mm_max_sd);
-#ifndef BREAKS_UNDER_OPTIMIZATION
 	M128i_M128i_M128i(_mm_min_epi16);
 	M128i_M128i_M128i(_mm_min_epu8);
-#endif
 	Ret_M128d_M128d(__m128d, _mm_min_pd);
 	Ret_M128d_M128d(__m128d, _mm_min_sd);
 }
@@ -343,9 +282,7 @@ void test_store()
 	void_OutIntPtr_M128(_mm_store_si128, __m128i*, 16, 16);
 	void_OutDoublePtr_M128d(_mm_store1_pd, double*, 16, 16); // _mm_store_pd1 is an alias to this.
 	void_OutDoublePtr_M128d(_mm_storeh_pd, double*, 8, 1);
-#ifndef NO_INT64X2
 	void_OutIntPtr_M128(_mm_storel_epi64, __m128i*, 8, 1);
-#endif
 	void_OutDoublePtr_M128d(_mm_storel_pd, double*, 8, 1);
 	void_OutDoublePtr_M128d(_mm_storer_pd, double*, 16, 16);
 	void_OutDoublePtr_M128d(_mm_storeu_pd, double*, 16, 1);
@@ -353,9 +290,7 @@ void test_store()
 	void_OutDoublePtr_M128d(_mm_stream_pd, double*, 16, 16);
 	void_OutIntPtr_M128(_mm_stream_si128, __m128i*, 16, 16);
 	void_OutIntPtr_int(_mm_stream_si32, int*, 4, 1);
-#ifndef NO_INT64X2
 	void_OutIntPtr_int64(_mm_stream_si64, int64_t*, 8, 1);
-#endif
 }
 
 void test_swizzle()
@@ -369,16 +304,12 @@ void test_swizzle()
 	Ret_M128i_Tint(__m128i, _mm_shufflelo_epi16);
 	M128i_M128i_M128i(_mm_unpackhi_epi16);
 	M128i_M128i_M128i(_mm_unpackhi_epi32);
-#ifndef NO_INT64X2
 	M128i_M128i_M128i(_mm_unpackhi_epi64);
-#endif
 	M128i_M128i_M128i(_mm_unpackhi_epi8);
 	Ret_M128d_M128d(__m128d, _mm_unpackhi_pd);
 	M128i_M128i_M128i(_mm_unpacklo_epi16);
 	M128i_M128i_M128i(_mm_unpacklo_epi32);
-#ifndef NO_INT64X2
 	M128i_M128i_M128i(_mm_unpacklo_epi64);
-#endif
 	M128i_M128i_M128i(_mm_unpacklo_epi8);
 	Ret_M128d_M128d(__m128d, _mm_unpacklo_pd);
 }


### PR DESCRIPTION
Enable test cases from test_sse2_full which pass with optimizations enabled after https://github.com/kripken/emscripten-fastcomp/pull/124. Merge only after https://github.com/kripken/emscripten-fastcomp/pull/124 is merged.
