### PR TITLE
Allow pthreads to pause for the JS event loop to run

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1238,16 +1238,22 @@ var LibraryBrowser = {
   },
 
   emscripten_async_call: function(func, arg, millis) {
-    Module['noExitRuntime'] = true;
-
     function wrapper() {
       Runtime.getFuncWrapper(func, 'vi')(arg);
     }
 
-    if (millis >= 0) {
-      Browser.safeSetTimeout(wrapper, millis);
-    } else {
-      Browser.safeRequestAnimationFrame(wrapper);
+    if (ENVIRONMENT_IS_PTHREAD) {
+      setTimeout(wrapper, millis);
+      //Request animation frame doesn't make much sense on a pthread
+    }
+    else {
+      Module['noExitRuntime'] = true;
+
+      if (millis >= 0) {
+        Browser.safeSetTimeout(wrapper, millis);
+      } else {
+        Browser.safeRequestAnimationFrame(wrapper);
+      }
     }
   },
 

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -44,6 +44,8 @@ var LibraryPThread = {
 
     exitHandlers: null, // An array of C functions to run when this thread exits.
 
+    implicitPThreadExit: true, // Whether or not to implicitly exit the current pthread when the end of pthread-main.js is reached
+
 #if PTHREADS_PROFILING
     createProfilerBlock: function(pthreadPtr) {
       var profilerBlock = (pthreadPtr == PThread.mainThreadBlock) ? allocate({{{ C_STRUCTS.thread_profiler_block.__size__ }}}, "i32*", ALLOC_STATIC) : _malloc({{{ C_STRUCTS.thread_profiler_block.__size__ }}});
@@ -936,6 +938,10 @@ var LibraryPThread = {
 #if PTHREADS_PROFILING
     _emscripten_set_thread_name_js(threadId|0, name|0);
 #endif
+  },
+
+  emscripten_implicit_pthread_exit: function(value) {
+    PThread.implicitPThreadExit = value === 1;
   }
 };
 

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -3,6 +3,7 @@
 
 #include <inttypes.h>
 #include <pthread.h>
+#include <emscripten/emscripten.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -147,6 +148,9 @@ void emscripten_conditional_set_current_thread_status(EM_THREAD_STATUS expectedS
 // The name parameter is a UTF-8 encoded string which is truncated to 32 bytes.
 // When thread profiler is not enabled (not building with --threadprofiling), this is a no-op.
 void emscripten_set_thread_name(pthread_t threadId, const char *name);
+
+// Allows the implicit pthread_exit at the end of the pthread-main.js main method to be disabled by calling with 0 as the argument.  It can be re-enabled by calling 1, but only before the end of pthread-main.js is reached!  This is useful if you want async_callbacks to run on a pthread (e.g. to give control back to the browser to run the event loop).
+void emscripten_implicit_pthread_exit(int value);
 
 struct thread_profiler_block
 {


### PR DESCRIPTION
If you try and use a JS API that has callbacks (such as WebSockets) from within a pthread that has a long life, callbacks (such as onopen, onmessage, etc.) will not run until it has finished, as we are already running some other JS on that thread (the C++ code!).

This adds a function `emscripten_pthread_pause_for_event_loop` which will cause execution of the C++ code to stop, with a callback back to the C++ added to happen later in the event loop, so that other JS code can run in the meantime.  Obviously jumping out of C++ code like this requires some care, but without this sort of functionality you can't use a WebSocket on a pthread (or anything else where you might expect a callback).
