### PR TITLE
stricter_gl_extension_headers

### DIFF
--- a/system/include/GLES3/gl2ext.h
+++ b/system/include/GLES3/gl2ext.h
@@ -27,162 +27,23 @@ extern "C" {
 ** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 ** MATERIALS OR THE USE OR OTHER DEALINGS IN THE MATERIALS.
 */
+
 /*
-** This header is generated from the Khronos OpenGL / OpenGL ES XML
-** API Registry. The current version of the Registry, generator scripts
-** used to make the header, and the header can be found at
-**   http://www.opengl.org/registry/
+** This header specifies the available
+** WebGL 1.0 and 2.0 extensions that can be used when compiling with Emscripten.
+** Note that with Emscripten, it is not necessary to dynamically query
+** function pointers to obtain entry points for extensions, but all extensions
+** are available via static linking by including this header.
 **
-** Khronos $Revision: 28335 $ on $Date: 2014-09-26 18:55:45 -0700 (Fri, 26 Sep 2014) $
+** Some of the extensions specified in this file are direct matches to the
+** the native GLES2 extensions, whereas some others are WebGL-specific.
 */
 
 #ifndef GL_APIENTRYP
 #define GL_APIENTRYP GL_APIENTRY*
 #endif
 
-/* Generated on date 20140926 */
-
-/* Generated C header for:
- * API: gles2
- * Profile: common
- * Versions considered: 2\.[0-9]
- * Versions emitted: _nomatch_^
- * Default extensions included: gles2
- * Additional extensions included: _nomatch_^
- * Extensions removed: _nomatch_^
- */
-
-#ifndef GL_KHR_blend_equation_advanced
-#define GL_KHR_blend_equation_advanced 1
-#define GL_MULTIPLY_KHR                   0x9294
-#define GL_SCREEN_KHR                     0x9295
-#define GL_OVERLAY_KHR                    0x9296
-#define GL_DARKEN_KHR                     0x9297
-#define GL_LIGHTEN_KHR                    0x9298
-#define GL_COLORDODGE_KHR                 0x9299
-#define GL_COLORBURN_KHR                  0x929A
-#define GL_HARDLIGHT_KHR                  0x929B
-#define GL_SOFTLIGHT_KHR                  0x929C
-#define GL_DIFFERENCE_KHR                 0x929E
-#define GL_EXCLUSION_KHR                  0x92A0
-#define GL_HSL_HUE_KHR                    0x92AD
-#define GL_HSL_SATURATION_KHR             0x92AE
-#define GL_HSL_COLOR_KHR                  0x92AF
-#define GL_HSL_LUMINOSITY_KHR             0x92B0
-typedef void (GL_APIENTRYP PFNGLBLENDBARRIERKHRPROC) (void);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glBlendBarrierKHR (void);
-#endif
-#endif /* GL_KHR_blend_equation_advanced */
-
-#ifndef GL_KHR_blend_equation_advanced_coherent
-#define GL_KHR_blend_equation_advanced_coherent 1
-#define GL_BLEND_ADVANCED_COHERENT_KHR    0x9285
-#endif /* GL_KHR_blend_equation_advanced_coherent */
-
-#ifndef GL_KHR_context_flush_control
-#define GL_KHR_context_flush_control 1
-#define GL_CONTEXT_RELEASE_BEHAVIOR_KHR   0x82FB
-#define GL_CONTEXT_RELEASE_BEHAVIOR_FLUSH_KHR 0x82FC
-#endif /* GL_KHR_context_flush_control */
-
-#ifndef GL_KHR_debug
-#define GL_KHR_debug 1
-typedef void (GL_APIENTRY  *GLDEBUGPROCKHR)(GLenum source,GLenum type,GLuint id,GLenum severity,GLsizei length,const GLchar *message,const void *userParam);
-#define GL_SAMPLER                        0x82E6
-#define GL_DEBUG_OUTPUT_SYNCHRONOUS_KHR   0x8242
-#define GL_DEBUG_NEXT_LOGGED_MESSAGE_LENGTH_KHR 0x8243
-#define GL_DEBUG_CALLBACK_FUNCTION_KHR    0x8244
-#define GL_DEBUG_CALLBACK_USER_PARAM_KHR  0x8245
-#define GL_DEBUG_SOURCE_API_KHR           0x8246
-#define GL_DEBUG_SOURCE_WINDOW_SYSTEM_KHR 0x8247
-#define GL_DEBUG_SOURCE_SHADER_COMPILER_KHR 0x8248
-#define GL_DEBUG_SOURCE_THIRD_PARTY_KHR   0x8249
-#define GL_DEBUG_SOURCE_APPLICATION_KHR   0x824A
-#define GL_DEBUG_SOURCE_OTHER_KHR         0x824B
-#define GL_DEBUG_TYPE_ERROR_KHR           0x824C
-#define GL_DEBUG_TYPE_DEPRECATED_BEHAVIOR_KHR 0x824D
-#define GL_DEBUG_TYPE_UNDEFINED_BEHAVIOR_KHR 0x824E
-#define GL_DEBUG_TYPE_PORTABILITY_KHR     0x824F
-#define GL_DEBUG_TYPE_PERFORMANCE_KHR     0x8250
-#define GL_DEBUG_TYPE_OTHER_KHR           0x8251
-#define GL_DEBUG_TYPE_MARKER_KHR          0x8268
-#define GL_DEBUG_TYPE_PUSH_GROUP_KHR      0x8269
-#define GL_DEBUG_TYPE_POP_GROUP_KHR       0x826A
-#define GL_DEBUG_SEVERITY_NOTIFICATION_KHR 0x826B
-#define GL_MAX_DEBUG_GROUP_STACK_DEPTH_KHR 0x826C
-#define GL_DEBUG_GROUP_STACK_DEPTH_KHR    0x826D
-#define GL_BUFFER_KHR                     0x82E0
-#define GL_SHADER_KHR                     0x82E1
-#define GL_PROGRAM_KHR                    0x82E2
-#define GL_VERTEX_ARRAY_KHR               0x8074
-#define GL_QUERY_KHR                      0x82E3
-#define GL_SAMPLER_KHR                    0x82E6
-#define GL_MAX_LABEL_LENGTH_KHR           0x82E8
-#define GL_MAX_DEBUG_MESSAGE_LENGTH_KHR   0x9143
-#define GL_MAX_DEBUG_LOGGED_MESSAGES_KHR  0x9144
-#define GL_DEBUG_LOGGED_MESSAGES_KHR      0x9145
-#define GL_DEBUG_SEVERITY_HIGH_KHR        0x9146
-#define GL_DEBUG_SEVERITY_MEDIUM_KHR      0x9147
-#define GL_DEBUG_SEVERITY_LOW_KHR         0x9148
-#define GL_DEBUG_OUTPUT_KHR               0x92E0
-#define GL_CONTEXT_FLAG_DEBUG_BIT_KHR     0x00000002
-#define GL_STACK_OVERFLOW_KHR             0x0503
-#define GL_STACK_UNDERFLOW_KHR            0x0504
-typedef void (GL_APIENTRYP PFNGLDEBUGMESSAGECONTROLKHRPROC) (GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint *ids, GLboolean enabled);
-typedef void (GL_APIENTRYP PFNGLDEBUGMESSAGEINSERTKHRPROC) (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *buf);
-typedef void (GL_APIENTRYP PFNGLDEBUGMESSAGECALLBACKKHRPROC) (GLDEBUGPROCKHR callback, const void *userParam);
-typedef GLuint (GL_APIENTRYP PFNGLGETDEBUGMESSAGELOGKHRPROC) (GLuint count, GLsizei bufSize, GLenum *sources, GLenum *types, GLuint *ids, GLenum *severities, GLsizei *lengths, GLchar *messageLog);
-typedef void (GL_APIENTRYP PFNGLPUSHDEBUGGROUPKHRPROC) (GLenum source, GLuint id, GLsizei length, const GLchar *message);
-typedef void (GL_APIENTRYP PFNGLPOPDEBUGGROUPKHRPROC) (void);
-typedef void (GL_APIENTRYP PFNGLOBJECTLABELKHRPROC) (GLenum identifier, GLuint name, GLsizei length, const GLchar *label);
-typedef void (GL_APIENTRYP PFNGLGETOBJECTLABELKHRPROC) (GLenum identifier, GLuint name, GLsizei bufSize, GLsizei *length, GLchar *label);
-typedef void (GL_APIENTRYP PFNGLOBJECTPTRLABELKHRPROC) (const void *ptr, GLsizei length, const GLchar *label);
-typedef void (GL_APIENTRYP PFNGLGETOBJECTPTRLABELKHRPROC) (const void *ptr, GLsizei bufSize, GLsizei *length, GLchar *label);
-typedef void (GL_APIENTRYP PFNGLGETPOINTERVKHRPROC) (GLenum pname, void **params);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glDebugMessageControlKHR (GLenum source, GLenum type, GLenum severity, GLsizei count, const GLuint *ids, GLboolean enabled);
-GL_APICALL void GL_APIENTRY glDebugMessageInsertKHR (GLenum source, GLenum type, GLuint id, GLenum severity, GLsizei length, const GLchar *buf);
-GL_APICALL void GL_APIENTRY glDebugMessageCallbackKHR (GLDEBUGPROCKHR callback, const void *userParam);
-GL_APICALL GLuint GL_APIENTRY glGetDebugMessageLogKHR (GLuint count, GLsizei bufSize, GLenum *sources, GLenum *types, GLuint *ids, GLenum *severities, GLsizei *lengths, GLchar *messageLog);
-GL_APICALL void GL_APIENTRY glPushDebugGroupKHR (GLenum source, GLuint id, GLsizei length, const GLchar *message);
-GL_APICALL void GL_APIENTRY glPopDebugGroupKHR (void);
-GL_APICALL void GL_APIENTRY glObjectLabelKHR (GLenum identifier, GLuint name, GLsizei length, const GLchar *label);
-GL_APICALL void GL_APIENTRY glGetObjectLabelKHR (GLenum identifier, GLuint name, GLsizei bufSize, GLsizei *length, GLchar *label);
-GL_APICALL void GL_APIENTRY glObjectPtrLabelKHR (const void *ptr, GLsizei length, const GLchar *label);
-GL_APICALL void GL_APIENTRY glGetObjectPtrLabelKHR (const void *ptr, GLsizei bufSize, GLsizei *length, GLchar *label);
-GL_APICALL void GL_APIENTRY glGetPointervKHR (GLenum pname, void **params);
-#endif
-#endif /* GL_KHR_debug */
-
-#ifndef GL_KHR_robust_buffer_access_behavior
-#define GL_KHR_robust_buffer_access_behavior 1
-#endif /* GL_KHR_robust_buffer_access_behavior */
-
-#ifndef GL_KHR_robustness
-#define GL_KHR_robustness 1
-#define GL_CONTEXT_ROBUST_ACCESS_KHR      0x90F3
-#define GL_LOSE_CONTEXT_ON_RESET_KHR      0x8252
-#define GL_GUILTY_CONTEXT_RESET_KHR       0x8253
-#define GL_INNOCENT_CONTEXT_RESET_KHR     0x8254
-#define GL_UNKNOWN_CONTEXT_RESET_KHR      0x8255
-#define GL_RESET_NOTIFICATION_STRATEGY_KHR 0x8256
-#define GL_NO_RESET_NOTIFICATION_KHR      0x8261
-#define GL_CONTEXT_LOST_KHR               0x0507
-typedef GLenum (GL_APIENTRYP PFNGLGETGRAPHICSRESETSTATUSKHRPROC) (void);
-typedef void (GL_APIENTRYP PFNGLREADNPIXELSKHRPROC) (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLsizei bufSize, void *data);
-typedef void (GL_APIENTRYP PFNGLGETNUNIFORMFVKHRPROC) (GLuint program, GLint location, GLsizei bufSize, GLfloat *params);
-typedef void (GL_APIENTRYP PFNGLGETNUNIFORMIVKHRPROC) (GLuint program, GLint location, GLsizei bufSize, GLint *params);
-typedef void (GL_APIENTRYP PFNGLGETNUNIFORMUIVKHRPROC) (GLuint program, GLint location, GLsizei bufSize, GLuint *params);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL GLenum GL_APIENTRY glGetGraphicsResetStatusKHR (void);
-GL_APICALL void GL_APIENTRY glReadnPixelsKHR (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLsizei bufSize, void *data);
-GL_APICALL void GL_APIENTRY glGetnUniformfvKHR (GLuint program, GLint location, GLsizei bufSize, GLfloat *params);
-GL_APICALL void GL_APIENTRY glGetnUniformivKHR (GLuint program, GLint location, GLsizei bufSize, GLint *params);
-GL_APICALL void GL_APIENTRY glGetnUniformuivKHR (GLuint program, GLint location, GLsizei bufSize, GLuint *params);
-#endif
-#endif /* GL_KHR_robustness */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/
 #ifndef GL_KHR_texture_compression_astc_hdr
 #define GL_KHR_texture_compression_astc_hdr 1
 #define GL_COMPRESSED_RGBA_ASTC_4x4_KHR   0x93B0
@@ -215,91 +76,41 @@ GL_APICALL void GL_APIENTRY glGetnUniformuivKHR (GLuint program, GLint location,
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR 0x93DD
 #endif /* GL_KHR_texture_compression_astc_hdr */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/
 #ifndef GL_KHR_texture_compression_astc_ldr
 #define GL_KHR_texture_compression_astc_ldr 1
 #endif /* GL_KHR_texture_compression_astc_ldr */
 
-#ifndef GL_OES_EGL_image
-#define GL_OES_EGL_image 1
-typedef void *GLeglImageOES;
-typedef void (GL_APIENTRYP PFNGLEGLIMAGETARGETTEXTURE2DOESPROC) (GLenum target, GLeglImageOES image);
-typedef void (GL_APIENTRYP PFNGLEGLIMAGETARGETRENDERBUFFERSTORAGEOESPROC) (GLenum target, GLeglImageOES image);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glEGLImageTargetTexture2DOES (GLenum target, GLeglImageOES image);
-GL_APICALL void GL_APIENTRY glEGLImageTargetRenderbufferStorageOES (GLenum target, GLeglImageOES image);
-#endif
-#endif /* GL_OES_EGL_image */
-
-#ifndef GL_OES_EGL_image_external
-#define GL_OES_EGL_image_external 1
-#define GL_TEXTURE_EXTERNAL_OES           0x8D65
-#define GL_TEXTURE_BINDING_EXTERNAL_OES   0x8D67
-#define GL_REQUIRED_TEXTURE_IMAGE_UNITS_OES 0x8D68
-#define GL_SAMPLER_EXTERNAL_OES           0x8D66
-#endif /* GL_OES_EGL_image_external */
-
-#ifndef GL_OES_compressed_ETC1_RGB8_sub_texture
-#define GL_OES_compressed_ETC1_RGB8_sub_texture 1
-#endif /* GL_OES_compressed_ETC1_RGB8_sub_texture */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/
 #ifndef GL_OES_compressed_ETC1_RGB8_texture
 #define GL_OES_compressed_ETC1_RGB8_texture 1
 #define GL_ETC1_RGB8_OES                  0x8D64
 #endif /* GL_OES_compressed_ETC1_RGB8_texture */
 
-#ifndef GL_OES_compressed_paletted_texture
-#define GL_OES_compressed_paletted_texture 1
-#define GL_PALETTE4_RGB8_OES              0x8B90
-#define GL_PALETTE4_RGBA8_OES             0x8B91
-#define GL_PALETTE4_R5_G6_B5_OES          0x8B92
-#define GL_PALETTE4_RGBA4_OES             0x8B93
-#define GL_PALETTE4_RGB5_A1_OES           0x8B94
-#define GL_PALETTE8_RGB8_OES              0x8B95
-#define GL_PALETTE8_RGBA8_OES             0x8B96
-#define GL_PALETTE8_R5_G6_B5_OES          0x8B97
-#define GL_PALETTE8_RGBA4_OES             0x8B98
-#define GL_PALETTE8_RGB5_A1_OES           0x8B99
-#endif /* GL_OES_compressed_paletted_texture */
-
-#ifndef GL_OES_depth24
-#define GL_OES_depth24 1
-#define GL_DEPTH_COMPONENT24_OES          0x81A6
-#endif /* GL_OES_depth24 */
-
-#ifndef GL_OES_depth32
-#define GL_OES_depth32 1
-#define GL_DEPTH_COMPONENT32_OES          0x81A7
-#endif /* GL_OES_depth32 */
-
+// Partially provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/
+// Some restrictions apply
 #ifndef GL_OES_depth_texture
 #define GL_OES_depth_texture 1
 #endif /* GL_OES_depth_texture */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/
+#ifndef GL_WEBGL_depth_texture
+#define GL_WEBGL_depth_texture 1
+#define GL_UNSIGNED_INT_24_8_WEBGL 0x84FA
+#endif /* GL_WEBGL_depth_texture */
+
+// Provided by https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/
 #ifndef GL_OES_element_index_uint
 #define GL_OES_element_index_uint 1
 #endif /* GL_OES_element_index_uint */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/OES_fbo_render_mipmap/
 #ifndef GL_OES_fbo_render_mipmap
 #define GL_OES_fbo_render_mipmap 1
 #endif /* GL_OES_fbo_render_mipmap */
 
-#ifndef GL_OES_fragment_precision_high
-#define GL_OES_fragment_precision_high 1
-#endif /* GL_OES_fragment_precision_high */
-
-#ifndef GL_OES_get_program_binary
-#define GL_OES_get_program_binary 1
-#define GL_PROGRAM_BINARY_LENGTH_OES      0x8741
-#define GL_NUM_PROGRAM_BINARY_FORMATS_OES 0x87FE
-#define GL_PROGRAM_BINARY_FORMATS_OES     0x87FF
-typedef void (GL_APIENTRYP PFNGLGETPROGRAMBINARYOESPROC) (GLuint program, GLsizei bufSize, GLsizei *length, GLenum *binaryFormat, void *binary);
-typedef void (GL_APIENTRYP PFNGLPROGRAMBINARYOESPROC) (GLuint program, GLenum binaryFormat, const void *binary, GLint length);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glGetProgramBinaryOES (GLuint program, GLsizei bufSize, GLsizei *length, GLenum *binaryFormat, void *binary);
-GL_APICALL void GL_APIENTRY glProgramBinaryOES (GLuint program, GLenum binaryFormat, const void *binary, GLint length);
-#endif
-#endif /* GL_OES_get_program_binary */
-
+// Provided by Emscripten's full OpenGL ES 2.0 emulation layer, which is enabled by building with the
+// linker flag -s FULL_ES2=1
 #ifndef GL_OES_mapbuffer
 #define GL_OES_mapbuffer 1
 #define GL_WRITE_ONLY_OES                 0x88B9
@@ -316,6 +127,8 @@ GL_APICALL void GL_APIENTRY glGetBufferPointervOES (GLenum target, GLenum pname,
 #endif
 #endif /* GL_OES_mapbuffer */
 
+// Partially provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/
+// Some restrictions apply
 #ifndef GL_OES_packed_depth_stencil
 #define GL_OES_packed_depth_stencil 1
 #define GL_DEPTH_STENCIL_OES              0x84F9
@@ -323,159 +136,34 @@ GL_APICALL void GL_APIENTRY glGetBufferPointervOES (GLenum target, GLenum pname,
 #define GL_DEPTH24_STENCIL8_OES           0x88F0
 #endif /* GL_OES_packed_depth_stencil */
 
-#ifndef GL_OES_required_internalformat
-#define GL_OES_required_internalformat 1
-#define GL_ALPHA8_OES                     0x803C
-#define GL_DEPTH_COMPONENT16_OES          0x81A5
-#define GL_LUMINANCE4_ALPHA4_OES          0x8043
-#define GL_LUMINANCE8_ALPHA8_OES          0x8045
-#define GL_LUMINANCE8_OES                 0x8040
-#define GL_RGBA4_OES                      0x8056
-#define GL_RGB5_A1_OES                    0x8057
-#define GL_RGB565_OES                     0x8D62
-#define GL_RGB8_OES                       0x8051
-#define GL_RGBA8_OES                      0x8058
-#define GL_RGB10_EXT                      0x8052
-#define GL_RGB10_A2_EXT                   0x8059
-#endif /* GL_OES_required_internalformat */
-
-#ifndef GL_OES_rgb8_rgba8
-#define GL_OES_rgb8_rgba8 1
-#endif /* GL_OES_rgb8_rgba8 */
-
-#ifndef GL_OES_sample_shading
-#define GL_OES_sample_shading 1
-#define GL_SAMPLE_SHADING_OES             0x8C36
-#define GL_MIN_SAMPLE_SHADING_VALUE_OES   0x8C37
-typedef void (GL_APIENTRYP PFNGLMINSAMPLESHADINGOESPROC) (GLfloat value);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glMinSampleShadingOES (GLfloat value);
-#endif
-#endif /* GL_OES_sample_shading */
-
-#ifndef GL_OES_sample_variables
-#define GL_OES_sample_variables 1
-#endif /* GL_OES_sample_variables */
-
-#ifndef GL_OES_shader_image_atomic
-#define GL_OES_shader_image_atomic 1
-#endif /* GL_OES_shader_image_atomic */
-
-#ifndef GL_OES_shader_multisample_interpolation
-#define GL_OES_shader_multisample_interpolation 1
-#define GL_MIN_FRAGMENT_INTERPOLATION_OFFSET_OES 0x8E5B
-#define GL_MAX_FRAGMENT_INTERPOLATION_OFFSET_OES 0x8E5C
-#define GL_FRAGMENT_INTERPOLATION_OFFSET_BITS_OES 0x8E5D
-#endif /* GL_OES_shader_multisample_interpolation */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/
 #ifndef GL_OES_standard_derivatives
 #define GL_OES_standard_derivatives 1
 #define GL_FRAGMENT_SHADER_DERIVATIVE_HINT_OES 0x8B8B
 #endif /* GL_OES_standard_derivatives */
 
-#ifndef GL_OES_stencil1
-#define GL_OES_stencil1 1
-#define GL_STENCIL_INDEX1_OES             0x8D46
-#endif /* GL_OES_stencil1 */
-
-#ifndef GL_OES_stencil4
-#define GL_OES_stencil4 1
-#define GL_STENCIL_INDEX4_OES             0x8D47
-#endif /* GL_OES_stencil4 */
-
-#ifndef GL_OES_surfaceless_context
-#define GL_OES_surfaceless_context 1
-#define GL_FRAMEBUFFER_UNDEFINED_OES      0x8219
-#endif /* GL_OES_surfaceless_context */
-
-#ifndef GL_OES_texture_3D
-#define GL_OES_texture_3D 1
-#define GL_TEXTURE_WRAP_R_OES             0x8072
-#define GL_TEXTURE_3D_OES                 0x806F
-#define GL_TEXTURE_BINDING_3D_OES         0x806A
-#define GL_MAX_3D_TEXTURE_SIZE_OES        0x8073
-#define GL_SAMPLER_3D_OES                 0x8B5F
-#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_3D_ZOFFSET_OES 0x8CD4
-typedef void (GL_APIENTRYP PFNGLTEXIMAGE3DOESPROC) (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void *pixels);
-typedef void (GL_APIENTRYP PFNGLTEXSUBIMAGE3DOESPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void *pixels);
-typedef void (GL_APIENTRYP PFNGLCOPYTEXSUBIMAGE3DOESPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height);
-typedef void (GL_APIENTRYP PFNGLCOMPRESSEDTEXIMAGE3DOESPROC) (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void *data);
-typedef void (GL_APIENTRYP PFNGLCOMPRESSEDTEXSUBIMAGE3DOESPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize, const void *data);
-typedef void (GL_APIENTRYP PFNGLFRAMEBUFFERTEXTURE3DOESPROC) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLint zoffset);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glTexImage3DOES (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLenum format, GLenum type, const void *pixels);
-GL_APICALL void GL_APIENTRY glTexSubImage3DOES (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, const void *pixels);
-GL_APICALL void GL_APIENTRY glCopyTexSubImage3DOES (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLint x, GLint y, GLsizei width, GLsizei height);
-GL_APICALL void GL_APIENTRY glCompressedTexImage3DOES (GLenum target, GLint level, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLint border, GLsizei imageSize, const void *data);
-GL_APICALL void GL_APIENTRY glCompressedTexSubImage3DOES (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLsizei imageSize, const void *data);
-GL_APICALL void GL_APIENTRY glFramebufferTexture3DOES (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLint zoffset);
-#endif
-#endif /* GL_OES_texture_3D */
-
-#ifndef GL_OES_texture_compression_astc
-#define GL_OES_texture_compression_astc 1
-#define GL_COMPRESSED_RGBA_ASTC_3x3x3_OES 0x93C0
-#define GL_COMPRESSED_RGBA_ASTC_4x3x3_OES 0x93C1
-#define GL_COMPRESSED_RGBA_ASTC_4x4x3_OES 0x93C2
-#define GL_COMPRESSED_RGBA_ASTC_4x4x4_OES 0x93C3
-#define GL_COMPRESSED_RGBA_ASTC_5x4x4_OES 0x93C4
-#define GL_COMPRESSED_RGBA_ASTC_5x5x4_OES 0x93C5
-#define GL_COMPRESSED_RGBA_ASTC_5x5x5_OES 0x93C6
-#define GL_COMPRESSED_RGBA_ASTC_6x5x5_OES 0x93C7
-#define GL_COMPRESSED_RGBA_ASTC_6x6x5_OES 0x93C8
-#define GL_COMPRESSED_RGBA_ASTC_6x6x6_OES 0x93C9
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_3x3x3_OES 0x93E0
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x3x3_OES 0x93E1
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4x3_OES 0x93E2
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_4x4x4_OES 0x93E3
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x4x4_OES 0x93E4
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5x4_OES 0x93E5
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_5x5x5_OES 0x93E6
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x5x5_OES 0x93E7
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6x5_OES 0x93E8
-#define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_6x6x6_OES 0x93E9
-#endif /* GL_OES_texture_compression_astc */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/OES_texture_float/
 #ifndef GL_OES_texture_float
 #define GL_OES_texture_float 1
 #endif /* GL_OES_texture_float */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/
 #ifndef GL_OES_texture_float_linear
 #define GL_OES_texture_float_linear 1
 #endif /* GL_OES_texture_float_linear */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/
 #ifndef GL_OES_texture_half_float
 #define GL_OES_texture_half_float 1
 #define GL_HALF_FLOAT_OES                 0x8D61
 #endif /* GL_OES_texture_half_float */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/
 #ifndef GL_OES_texture_half_float_linear
 #define GL_OES_texture_half_float_linear 1
 #endif /* GL_OES_texture_half_float_linear */
 
-#ifndef GL_OES_texture_npot
-#define GL_OES_texture_npot 1
-#endif /* GL_OES_texture_npot */
-
-#ifndef GL_OES_texture_stencil8
-#define GL_OES_texture_stencil8 1
-#define GL_STENCIL_INDEX_OES              0x1901
-#define GL_STENCIL_INDEX8_OES             0x8D48
-#endif /* GL_OES_texture_stencil8 */
-
-#ifndef GL_OES_texture_storage_multisample_2d_array
-#define GL_OES_texture_storage_multisample_2d_array 1
-#define GL_TEXTURE_2D_MULTISAMPLE_ARRAY_OES 0x9102
-#define GL_TEXTURE_BINDING_2D_MULTISAMPLE_ARRAY_OES 0x9105
-#define GL_SAMPLER_2D_MULTISAMPLE_ARRAY_OES 0x910B
-#define GL_INT_SAMPLER_2D_MULTISAMPLE_ARRAY_OES 0x910C
-#define GL_UNSIGNED_INT_SAMPLER_2D_MULTISAMPLE_ARRAY_OES 0x910D
-typedef void (GL_APIENTRYP PFNGLTEXSTORAGE3DMULTISAMPLEOESPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glTexStorage3DMultisampleOES (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth, GLboolean fixedsamplelocations);
-#endif
-#endif /* GL_OES_texture_storage_multisample_2d_array */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/
 #ifndef GL_OES_vertex_array_object
 #define GL_OES_vertex_array_object 1
 #define GL_VERTEX_ARRAY_BINDING_OES       0x85B5
@@ -491,22 +179,7 @@ GL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES (GLuint array);
 #endif
 #endif /* GL_OES_vertex_array_object */
 
-#ifndef GL_OES_vertex_half_float
-#define GL_OES_vertex_half_float 1
-#endif /* GL_OES_vertex_half_float */
-
-#ifndef GL_OES_vertex_type_10_10_10_2
-#define GL_OES_vertex_type_10_10_10_2 1
-#define GL_UNSIGNED_INT_10_10_10_2_OES    0x8DF6
-#define GL_INT_10_10_10_2_OES             0x8DF7
-#endif /* GL_OES_vertex_type_10_10_10_2 */
-
-#ifndef GL_AMD_compressed_3DC_texture
-#define GL_AMD_compressed_3DC_texture 1
-#define GL_3DC_X_AMD                      0x87F9
-#define GL_3DC_XY_AMD                     0x87FA
-#endif /* GL_AMD_compressed_3DC_texture */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/
 #ifndef GL_AMD_compressed_ATC_texture
 #define GL_AMD_compressed_ATC_texture 1
 #define GL_ATC_RGB_AMD                    0x8C92
@@ -514,77 +187,20 @@ GL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES (GLuint array);
 #define GL_ATC_RGBA_INTERPOLATED_ALPHA_AMD 0x87EE
 #endif /* GL_AMD_compressed_ATC_texture */
 
-#ifndef GL_AMD_performance_monitor
-#define GL_AMD_performance_monitor 1
-#define GL_COUNTER_TYPE_AMD               0x8BC0
-#define GL_COUNTER_RANGE_AMD              0x8BC1
-#define GL_UNSIGNED_INT64_AMD             0x8BC2
-#define GL_PERCENTAGE_AMD                 0x8BC3
-#define GL_PERFMON_RESULT_AVAILABLE_AMD   0x8BC4
-#define GL_PERFMON_RESULT_SIZE_AMD        0x8BC5
-#define GL_PERFMON_RESULT_AMD             0x8BC6
-typedef void (GL_APIENTRYP PFNGLGETPERFMONITORGROUPSAMDPROC) (GLint *numGroups, GLsizei groupsSize, GLuint *groups);
-typedef void (GL_APIENTRYP PFNGLGETPERFMONITORCOUNTERSAMDPROC) (GLuint group, GLint *numCounters, GLint *maxActiveCounters, GLsizei counterSize, GLuint *counters);
-typedef void (GL_APIENTRYP PFNGLGETPERFMONITORGROUPSTRINGAMDPROC) (GLuint group, GLsizei bufSize, GLsizei *length, GLchar *groupString);
-typedef void (GL_APIENTRYP PFNGLGETPERFMONITORCOUNTERSTRINGAMDPROC) (GLuint group, GLuint counter, GLsizei bufSize, GLsizei *length, GLchar *counterString);
-typedef void (GL_APIENTRYP PFNGLGETPERFMONITORCOUNTERINFOAMDPROC) (GLuint group, GLuint counter, GLenum pname, void *data);
-typedef void (GL_APIENTRYP PFNGLGENPERFMONITORSAMDPROC) (GLsizei n, GLuint *monitors);
-typedef void (GL_APIENTRYP PFNGLDELETEPERFMONITORSAMDPROC) (GLsizei n, GLuint *monitors);
-typedef void (GL_APIENTRYP PFNGLSELECTPERFMONITORCOUNTERSAMDPROC) (GLuint monitor, GLboolean enable, GLuint group, GLint numCounters, GLuint *counterList);
-typedef void (GL_APIENTRYP PFNGLBEGINPERFMONITORAMDPROC) (GLuint monitor);
-typedef void (GL_APIENTRYP PFNGLENDPERFMONITORAMDPROC) (GLuint monitor);
-typedef void (GL_APIENTRYP PFNGLGETPERFMONITORCOUNTERDATAAMDPROC) (GLuint monitor, GLenum pname, GLsizei dataSize, GLuint *data, GLint *bytesWritten);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glGetPerfMonitorGroupsAMD (GLint *numGroups, GLsizei groupsSize, GLuint *groups);
-GL_APICALL void GL_APIENTRY glGetPerfMonitorCountersAMD (GLuint group, GLint *numCounters, GLint *maxActiveCounters, GLsizei counterSize, GLuint *counters);
-GL_APICALL void GL_APIENTRY glGetPerfMonitorGroupStringAMD (GLuint group, GLsizei bufSize, GLsizei *length, GLchar *groupString);
-GL_APICALL void GL_APIENTRY glGetPerfMonitorCounterStringAMD (GLuint group, GLuint counter, GLsizei bufSize, GLsizei *length, GLchar *counterString);
-GL_APICALL void GL_APIENTRY glGetPerfMonitorCounterInfoAMD (GLuint group, GLuint counter, GLenum pname, void *data);
-GL_APICALL void GL_APIENTRY glGenPerfMonitorsAMD (GLsizei n, GLuint *monitors);
-GL_APICALL void GL_APIENTRY glDeletePerfMonitorsAMD (GLsizei n, GLuint *monitors);
-GL_APICALL void GL_APIENTRY glSelectPerfMonitorCountersAMD (GLuint monitor, GLboolean enable, GLuint group, GLint numCounters, GLuint *counterList);
-GL_APICALL void GL_APIENTRY glBeginPerfMonitorAMD (GLuint monitor);
-GL_APICALL void GL_APIENTRY glEndPerfMonitorAMD (GLuint monitor);
-GL_APICALL void GL_APIENTRY glGetPerfMonitorCounterDataAMD (GLuint monitor, GLenum pname, GLsizei dataSize, GLuint *data, GLint *bytesWritten);
-#endif
-#endif /* GL_AMD_performance_monitor */
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/
+#ifndef GL_WEBGL_compressed_texture_atc
+#define GL_WEBGL_compressed_texture_atc 1
+#define GL_COMPRESSED_RGB_ATC_WEBGL                     0x8C92
+#define GL_COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL     0x8C93
+#define GL_COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL 0x87EE
+#endif /* GL_WEBGL_compressed_texture_atc */
 
-#ifndef GL_AMD_program_binary_Z400
-#define GL_AMD_program_binary_Z400 1
-#define GL_Z400_BINARY_AMD                0x8740
-#endif /* GL_AMD_program_binary_Z400 */
-
-#ifndef GL_ANDROID_extension_pack_es31a
-#define GL_ANDROID_extension_pack_es31a 1
-#endif /* GL_ANDROID_extension_pack_es31a */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/
 #ifndef GL_ANGLE_depth_texture
 #define GL_ANGLE_depth_texture 1
 #endif /* GL_ANGLE_depth_texture */
 
-#ifndef GL_ANGLE_framebuffer_blit
-#define GL_ANGLE_framebuffer_blit 1
-#define GL_READ_FRAMEBUFFER_ANGLE         0x8CA8
-#define GL_DRAW_FRAMEBUFFER_ANGLE         0x8CA9
-#define GL_DRAW_FRAMEBUFFER_BINDING_ANGLE 0x8CA6
-#define GL_READ_FRAMEBUFFER_BINDING_ANGLE 0x8CAA
-typedef void (GL_APIENTRYP PFNGLBLITFRAMEBUFFERANGLEPROC) (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glBlitFramebufferANGLE (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
-#endif
-#endif /* GL_ANGLE_framebuffer_blit */
-
-#ifndef GL_ANGLE_framebuffer_multisample
-#define GL_ANGLE_framebuffer_multisample 1
-#define GL_RENDERBUFFER_SAMPLES_ANGLE     0x8CAB
-#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_ANGLE 0x8D56
-#define GL_MAX_SAMPLES_ANGLE              0x8D57
-typedef void (GL_APIENTRYP PFNGLRENDERBUFFERSTORAGEMULTISAMPLEANGLEPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glRenderbufferStorageMultisampleANGLE (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-#endif
-#endif /* GL_ANGLE_framebuffer_multisample */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
 #ifndef GL_ANGLE_instanced_arrays
 #define GL_ANGLE_instanced_arrays 1
 #define GL_VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE 0x88FE
@@ -598,32 +214,19 @@ GL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE (GLuint index, GLuint div
 #endif
 #endif /* GL_ANGLE_instanced_arrays */
 
-#ifndef GL_ANGLE_pack_reverse_row_order
-#define GL_ANGLE_pack_reverse_row_order 1
-#define GL_PACK_REVERSE_ROW_ORDER_ANGLE   0x93A4
-#endif /* GL_ANGLE_pack_reverse_row_order */
-
-#ifndef GL_ANGLE_program_binary
-#define GL_ANGLE_program_binary 1
-#define GL_PROGRAM_BINARY_ANGLE           0x93A6
-#endif /* GL_ANGLE_program_binary */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
 #ifndef GL_ANGLE_texture_compression_dxt3
 #define GL_ANGLE_texture_compression_dxt3 1
 #define GL_COMPRESSED_RGBA_S3TC_DXT3_ANGLE 0x83F2
 #endif /* GL_ANGLE_texture_compression_dxt3 */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
 #ifndef GL_ANGLE_texture_compression_dxt5
 #define GL_ANGLE_texture_compression_dxt5 1
 #define GL_COMPRESSED_RGBA_S3TC_DXT5_ANGLE 0x83F3
 #endif /* GL_ANGLE_texture_compression_dxt5 */
 
-#ifndef GL_ANGLE_texture_usage
-#define GL_ANGLE_texture_usage 1
-#define GL_TEXTURE_USAGE_ANGLE            0x93A2
-#define GL_FRAMEBUFFER_ATTACHMENT_ANGLE   0x93A3
-#endif /* GL_ANGLE_texture_usage */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/
 #ifndef GL_ANGLE_translated_shader_source
 #define GL_ANGLE_translated_shader_source 1
 #define GL_TRANSLATED_SHADER_SOURCE_LENGTH_ANGLE 0x93A0
@@ -633,153 +236,15 @@ GL_APICALL void GL_APIENTRY glGetTranslatedShaderSourceANGLE (GLuint shader, GLs
 #endif
 #endif /* GL_ANGLE_translated_shader_source */
 
-#ifndef GL_APPLE_clip_distance
-#define GL_APPLE_clip_distance 1
-#define GL_MAX_CLIP_DISTANCES_APPLE       0x0D32
-#define GL_CLIP_DISTANCE0_APPLE           0x3000
-#define GL_CLIP_DISTANCE1_APPLE           0x3001
-#define GL_CLIP_DISTANCE2_APPLE           0x3002
-#define GL_CLIP_DISTANCE3_APPLE           0x3003
-#define GL_CLIP_DISTANCE4_APPLE           0x3004
-#define GL_CLIP_DISTANCE5_APPLE           0x3005
-#define GL_CLIP_DISTANCE6_APPLE           0x3006
-#define GL_CLIP_DISTANCE7_APPLE           0x3007
-#endif /* GL_APPLE_clip_distance */
-
-#ifndef GL_APPLE_color_buffer_packed_float
-#define GL_APPLE_color_buffer_packed_float 1
-#endif /* GL_APPLE_color_buffer_packed_float */
-
-#ifndef GL_APPLE_copy_texture_levels
-#define GL_APPLE_copy_texture_levels 1
-typedef void (GL_APIENTRYP PFNGLCOPYTEXTURELEVELSAPPLEPROC) (GLuint destinationTexture, GLuint sourceTexture, GLint sourceBaseLevel, GLsizei sourceLevelCount);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glCopyTextureLevelsAPPLE (GLuint destinationTexture, GLuint sourceTexture, GLint sourceBaseLevel, GLsizei sourceLevelCount);
-#endif
-#endif /* GL_APPLE_copy_texture_levels */
-
-#ifndef GL_APPLE_framebuffer_multisample
-#define GL_APPLE_framebuffer_multisample 1
-#define GL_RENDERBUFFER_SAMPLES_APPLE     0x8CAB
-#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_APPLE 0x8D56
-#define GL_MAX_SAMPLES_APPLE              0x8D57
-#define GL_READ_FRAMEBUFFER_APPLE         0x8CA8
-#define GL_DRAW_FRAMEBUFFER_APPLE         0x8CA9
-#define GL_DRAW_FRAMEBUFFER_BINDING_APPLE 0x8CA6
-#define GL_READ_FRAMEBUFFER_BINDING_APPLE 0x8CAA
-typedef void (GL_APIENTRYP PFNGLRENDERBUFFERSTORAGEMULTISAMPLEAPPLEPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-typedef void (GL_APIENTRYP PFNGLRESOLVEMULTISAMPLEFRAMEBUFFERAPPLEPROC) (void);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glRenderbufferStorageMultisampleAPPLE (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-GL_APICALL void GL_APIENTRY glResolveMultisampleFramebufferAPPLE (void);
-#endif
-#endif /* GL_APPLE_framebuffer_multisample */
-
-#ifndef GL_APPLE_rgb_422
-#define GL_APPLE_rgb_422 1
-#define GL_RGB_422_APPLE                  0x8A1F
-#define GL_UNSIGNED_SHORT_8_8_APPLE       0x85BA
-#define GL_UNSIGNED_SHORT_8_8_REV_APPLE   0x85BB
-#define GL_RGB_RAW_422_APPLE              0x8A51
-#endif /* GL_APPLE_rgb_422 */
-
-#ifndef GL_APPLE_sync
-#define GL_APPLE_sync 1
-#define GL_SYNC_OBJECT_APPLE              0x8A53
-#define GL_MAX_SERVER_WAIT_TIMEOUT_APPLE  0x9111
-#define GL_OBJECT_TYPE_APPLE              0x9112
-#define GL_SYNC_CONDITION_APPLE           0x9113
-#define GL_SYNC_STATUS_APPLE              0x9114
-#define GL_SYNC_FLAGS_APPLE               0x9115
-#define GL_SYNC_FENCE_APPLE               0x9116
-#define GL_SYNC_GPU_COMMANDS_COMPLETE_APPLE 0x9117
-#define GL_UNSIGNALED_APPLE               0x9118
-#define GL_SIGNALED_APPLE                 0x9119
-#define GL_ALREADY_SIGNALED_APPLE         0x911A
-#define GL_TIMEOUT_EXPIRED_APPLE          0x911B
-#define GL_CONDITION_SATISFIED_APPLE      0x911C
-#define GL_WAIT_FAILED_APPLE              0x911D
-#define GL_SYNC_FLUSH_COMMANDS_BIT_APPLE  0x00000001
-#define GL_TIMEOUT_IGNORED_APPLE          0xFFFFFFFFFFFFFFFFull
-typedef GLsync (GL_APIENTRYP PFNGLFENCESYNCAPPLEPROC) (GLenum condition, GLbitfield flags);
-typedef GLboolean (GL_APIENTRYP PFNGLISSYNCAPPLEPROC) (GLsync sync);
-typedef void (GL_APIENTRYP PFNGLDELETESYNCAPPLEPROC) (GLsync sync);
-typedef GLenum (GL_APIENTRYP PFNGLCLIENTWAITSYNCAPPLEPROC) (GLsync sync, GLbitfield flags, GLuint64 timeout);
-typedef void (GL_APIENTRYP PFNGLWAITSYNCAPPLEPROC) (GLsync sync, GLbitfield flags, GLuint64 timeout);
-typedef void (GL_APIENTRYP PFNGLGETINTEGER64VAPPLEPROC) (GLenum pname, GLint64 *params);
-typedef void (GL_APIENTRYP PFNGLGETSYNCIVAPPLEPROC) (GLsync sync, GLenum pname, GLsizei bufSize, GLsizei *length, GLint *values);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL GLsync GL_APIENTRY glFenceSyncAPPLE (GLenum condition, GLbitfield flags);
-GL_APICALL GLboolean GL_APIENTRY glIsSyncAPPLE (GLsync sync);
-GL_APICALL void GL_APIENTRY glDeleteSyncAPPLE (GLsync sync);
-GL_APICALL GLenum GL_APIENTRY glClientWaitSyncAPPLE (GLsync sync, GLbitfield flags, GLuint64 timeout);
-GL_APICALL void GL_APIENTRY glWaitSyncAPPLE (GLsync sync, GLbitfield flags, GLuint64 timeout);
-GL_APICALL void GL_APIENTRY glGetInteger64vAPPLE (GLenum pname, GLint64 *params);
-GL_APICALL void GL_APIENTRY glGetSyncivAPPLE (GLsync sync, GLenum pname, GLsizei bufSize, GLsizei *length, GLint *values);
-#endif
-#endif /* GL_APPLE_sync */
-
-#ifndef GL_APPLE_texture_format_BGRA8888
-#define GL_APPLE_texture_format_BGRA8888 1
-#define GL_BGRA_EXT                       0x80E1
-#define GL_BGRA8_EXT                      0x93A1
-#endif /* GL_APPLE_texture_format_BGRA8888 */
-
-#ifndef GL_APPLE_texture_max_level
-#define GL_APPLE_texture_max_level 1
-#define GL_TEXTURE_MAX_LEVEL_APPLE        0x813D
-#endif /* GL_APPLE_texture_max_level */
-
-#ifndef GL_APPLE_texture_packed_float
-#define GL_APPLE_texture_packed_float 1
-#define GL_UNSIGNED_INT_10F_11F_11F_REV_APPLE 0x8C3B
-#define GL_UNSIGNED_INT_5_9_9_9_REV_APPLE 0x8C3E
-#define GL_R11F_G11F_B10F_APPLE           0x8C3A
-#define GL_RGB9_E5_APPLE                  0x8C3D
-#endif /* GL_APPLE_texture_packed_float */
-
-#ifndef GL_ARM_mali_program_binary
-#define GL_ARM_mali_program_binary 1
-#define GL_MALI_PROGRAM_BINARY_ARM        0x8F61
-#endif /* GL_ARM_mali_program_binary */
-
-#ifndef GL_ARM_mali_shader_binary
-#define GL_ARM_mali_shader_binary 1
-#define GL_MALI_SHADER_BINARY_ARM         0x8F60
-#endif /* GL_ARM_mali_shader_binary */
-
-#ifndef GL_ARM_rgba8
-#define GL_ARM_rgba8 1
-#endif /* GL_ARM_rgba8 */
-
-#ifndef GL_ARM_shader_framebuffer_fetch
-#define GL_ARM_shader_framebuffer_fetch 1
-#define GL_FETCH_PER_SAMPLE_ARM           0x8F65
-#define GL_FRAGMENT_SHADER_FRAMEBUFFER_FETCH_MRT_ARM 0x8F66
-#endif /* GL_ARM_shader_framebuffer_fetch */
-
-#ifndef GL_ARM_shader_framebuffer_fetch_depth_stencil
-#define GL_ARM_shader_framebuffer_fetch_depth_stencil 1
-#endif /* GL_ARM_shader_framebuffer_fetch_depth_stencil */
-
-#ifndef GL_DMP_program_binary
-#define GL_DMP_program_binary 1
-#define GL_SMAPHS30_PROGRAM_BINARY_DMP    0x9251
-#define GL_SMAPHS_PROGRAM_BINARY_DMP      0x9252
-#define GL_DMP_PROGRAM_BINARY_DMP         0x9253
-#endif /* GL_DMP_program_binary */
-
-#ifndef GL_DMP_shader_binary
-#define GL_DMP_shader_binary 1
-#define GL_SHADER_BINARY_DMP              0x9250
-#endif /* GL_DMP_shader_binary */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/
 #ifndef GL_EXT_blend_minmax
 #define GL_EXT_blend_minmax 1
 #define GL_MIN_EXT                        0x8007
 #define GL_MAX_EXT                        0x8008
 #endif /* GL_EXT_blend_minmax */
 
+// Partially provided by https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/
+// Some restrictions apply
 #ifndef GL_EXT_color_buffer_half_float
 #define GL_EXT_color_buffer_half_float 1
 #define GL_RGBA16F_EXT                    0x881A
@@ -790,54 +255,7 @@ GL_APICALL void GL_APIENTRY glGetSyncivAPPLE (GLsync sync, GLenum pname, GLsizei
 #define GL_UNSIGNED_NORMALIZED_EXT        0x8C17
 #endif /* GL_EXT_color_buffer_half_float */
 
-#ifndef GL_EXT_copy_image
-#define GL_EXT_copy_image 1
-typedef void (GL_APIENTRYP PFNGLCOPYIMAGESUBDATAEXTPROC) (GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glCopyImageSubDataEXT (GLuint srcName, GLenum srcTarget, GLint srcLevel, GLint srcX, GLint srcY, GLint srcZ, GLuint dstName, GLenum dstTarget, GLint dstLevel, GLint dstX, GLint dstY, GLint dstZ, GLsizei srcWidth, GLsizei srcHeight, GLsizei srcDepth);
-#endif
-#endif /* GL_EXT_copy_image */
-
-#ifndef GL_EXT_debug_label
-#define GL_EXT_debug_label 1
-#define GL_PROGRAM_PIPELINE_OBJECT_EXT    0x8A4F
-#define GL_PROGRAM_OBJECT_EXT             0x8B40
-#define GL_SHADER_OBJECT_EXT              0x8B48
-#define GL_BUFFER_OBJECT_EXT              0x9151
-#define GL_QUERY_OBJECT_EXT               0x9153
-#define GL_VERTEX_ARRAY_OBJECT_EXT        0x9154
-#define GL_TRANSFORM_FEEDBACK             0x8E22
-typedef void (GL_APIENTRYP PFNGLLABELOBJECTEXTPROC) (GLenum type, GLuint object, GLsizei length, const GLchar *label);
-typedef void (GL_APIENTRYP PFNGLGETOBJECTLABELEXTPROC) (GLenum type, GLuint object, GLsizei bufSize, GLsizei *length, GLchar *label);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glLabelObjectEXT (GLenum type, GLuint object, GLsizei length, const GLchar *label);
-GL_APICALL void GL_APIENTRY glGetObjectLabelEXT (GLenum type, GLuint object, GLsizei bufSize, GLsizei *length, GLchar *label);
-#endif
-#endif /* GL_EXT_debug_label */
-
-#ifndef GL_EXT_debug_marker
-#define GL_EXT_debug_marker 1
-typedef void (GL_APIENTRYP PFNGLINSERTEVENTMARKEREXTPROC) (GLsizei length, const GLchar *marker);
-typedef void (GL_APIENTRYP PFNGLPUSHGROUPMARKEREXTPROC) (GLsizei length, const GLchar *marker);
-typedef void (GL_APIENTRYP PFNGLPOPGROUPMARKEREXTPROC) (void);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glInsertEventMarkerEXT (GLsizei length, const GLchar *marker);
-GL_APICALL void GL_APIENTRY glPushGroupMarkerEXT (GLsizei length, const GLchar *marker);
-GL_APICALL void GL_APIENTRY glPopGroupMarkerEXT (void);
-#endif
-#endif /* GL_EXT_debug_marker */
-
-#ifndef GL_EXT_discard_framebuffer
-#define GL_EXT_discard_framebuffer 1
-#define GL_COLOR_EXT                      0x1800
-#define GL_DEPTH_EXT                      0x1801
-#define GL_STENCIL_EXT                    0x1802
-typedef void (GL_APIENTRYP PFNGLDISCARDFRAMEBUFFEREXTPROC) (GLenum target, GLsizei numAttachments, const GLenum *attachments);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glDiscardFramebufferEXT (GLenum target, GLsizei numAttachments, const GLenum *attachments);
-#endif
-#endif /* GL_EXT_discard_framebuffer */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/
 #ifndef GL_EXT_disjoint_timer_query
 #define GL_EXT_disjoint_timer_query 1
 #define GL_QUERY_COUNTER_BITS_EXT         0x8864
@@ -873,6 +291,7 @@ GL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT (GLuint id, GLenum pname, G
 #endif
 #endif /* GL_EXT_disjoint_timer_query */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/
 #ifndef GL_EXT_draw_buffers
 #define GL_EXT_draw_buffers 1
 #define GL_MAX_COLOR_ATTACHMENTS_EXT      0x8CDF
@@ -915,30 +334,7 @@ GL_APICALL void GL_APIENTRY glDrawBuffersEXT (GLsizei n, const GLenum *bufs);
 #endif
 #endif /* GL_EXT_draw_buffers */
 
-#ifndef GL_EXT_draw_buffers_indexed
-#define GL_EXT_draw_buffers_indexed 1
-#define GL_MIN                            0x8007
-#define GL_MAX                            0x8008
-typedef void (GL_APIENTRYP PFNGLENABLEIEXTPROC) (GLenum target, GLuint index);
-typedef void (GL_APIENTRYP PFNGLDISABLEIEXTPROC) (GLenum target, GLuint index);
-typedef void (GL_APIENTRYP PFNGLBLENDEQUATIONIEXTPROC) (GLuint buf, GLenum mode);
-typedef void (GL_APIENTRYP PFNGLBLENDEQUATIONSEPARATEIEXTPROC) (GLuint buf, GLenum modeRGB, GLenum modeAlpha);
-typedef void (GL_APIENTRYP PFNGLBLENDFUNCIEXTPROC) (GLuint buf, GLenum src, GLenum dst);
-typedef void (GL_APIENTRYP PFNGLBLENDFUNCSEPARATEIEXTPROC) (GLuint buf, GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha);
-typedef void (GL_APIENTRYP PFNGLCOLORMASKIEXTPROC) (GLuint index, GLboolean r, GLboolean g, GLboolean b, GLboolean a);
-typedef GLboolean (GL_APIENTRYP PFNGLISENABLEDIEXTPROC) (GLenum target, GLuint index);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glEnableiEXT (GLenum target, GLuint index);
-GL_APICALL void GL_APIENTRY glDisableiEXT (GLenum target, GLuint index);
-GL_APICALL void GL_APIENTRY glBlendEquationiEXT (GLuint buf, GLenum mode);
-GL_APICALL void GL_APIENTRY glBlendEquationSeparateiEXT (GLuint buf, GLenum modeRGB, GLenum modeAlpha);
-GL_APICALL void GL_APIENTRY glBlendFunciEXT (GLuint buf, GLenum src, GLenum dst);
-GL_APICALL void GL_APIENTRY glBlendFuncSeparateiEXT (GLuint buf, GLenum srcRGB, GLenum dstRGB, GLenum srcAlpha, GLenum dstAlpha);
-GL_APICALL void GL_APIENTRY glColorMaskiEXT (GLuint index, GLboolean r, GLboolean g, GLboolean b, GLboolean a);
-GL_APICALL GLboolean GL_APIENTRY glIsEnablediEXT (GLenum target, GLuint index);
-#endif
-#endif /* GL_EXT_draw_buffers_indexed */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
 #ifndef GL_EXT_draw_instanced
 #define GL_EXT_draw_instanced 1
 typedef void (GL_APIENTRYP PFNGLDRAWARRAYSINSTANCEDEXTPROC) (GLenum mode, GLint start, GLsizei count, GLsizei primcount);
@@ -949,55 +345,7 @@ GL_APICALL void GL_APIENTRY glDrawElementsInstancedEXT (GLenum mode, GLsizei cou
 #endif
 #endif /* GL_EXT_draw_instanced */
 
-#ifndef GL_EXT_geometry_point_size
-#define GL_EXT_geometry_point_size 1
-#endif /* GL_EXT_geometry_point_size */
-
-#ifndef GL_EXT_geometry_shader
-#define GL_EXT_geometry_shader 1
-#define GL_GEOMETRY_SHADER_EXT            0x8DD9
-#define GL_GEOMETRY_SHADER_BIT_EXT        0x00000004
-#define GL_GEOMETRY_LINKED_VERTICES_OUT_EXT 0x8916
-#define GL_GEOMETRY_LINKED_INPUT_TYPE_EXT 0x8917
-#define GL_GEOMETRY_LINKED_OUTPUT_TYPE_EXT 0x8918
-#define GL_GEOMETRY_SHADER_INVOCATIONS_EXT 0x887F
-#define GL_LAYER_PROVOKING_VERTEX_EXT     0x825E
-#define GL_LINES_ADJACENCY_EXT            0x000A
-#define GL_LINE_STRIP_ADJACENCY_EXT       0x000B
-#define GL_TRIANGLES_ADJACENCY_EXT        0x000C
-#define GL_TRIANGLE_STRIP_ADJACENCY_EXT   0x000D
-#define GL_MAX_GEOMETRY_UNIFORM_COMPONENTS_EXT 0x8DDF
-#define GL_MAX_GEOMETRY_UNIFORM_BLOCKS_EXT 0x8A2C
-#define GL_MAX_COMBINED_GEOMETRY_UNIFORM_COMPONENTS_EXT 0x8A32
-#define GL_MAX_GEOMETRY_INPUT_COMPONENTS_EXT 0x9123
-#define GL_MAX_GEOMETRY_OUTPUT_COMPONENTS_EXT 0x9124
-#define GL_MAX_GEOMETRY_OUTPUT_VERTICES_EXT 0x8DE0
-#define GL_MAX_GEOMETRY_TOTAL_OUTPUT_COMPONENTS_EXT 0x8DE1
-#define GL_MAX_GEOMETRY_SHADER_INVOCATIONS_EXT 0x8E5A
-#define GL_MAX_GEOMETRY_TEXTURE_IMAGE_UNITS_EXT 0x8C29
-#define GL_MAX_GEOMETRY_ATOMIC_COUNTER_BUFFERS_EXT 0x92CF
-#define GL_MAX_GEOMETRY_ATOMIC_COUNTERS_EXT 0x92D5
-#define GL_MAX_GEOMETRY_IMAGE_UNIFORMS_EXT 0x90CD
-#define GL_MAX_GEOMETRY_SHADER_STORAGE_BLOCKS_EXT 0x90D7
-#define GL_FIRST_VERTEX_CONVENTION_EXT    0x8E4D
-#define GL_LAST_VERTEX_CONVENTION_EXT     0x8E4E
-#define GL_UNDEFINED_VERTEX_EXT           0x8260
-#define GL_PRIMITIVES_GENERATED_EXT       0x8C87
-#define GL_FRAMEBUFFER_DEFAULT_LAYERS_EXT 0x9312
-#define GL_MAX_FRAMEBUFFER_LAYERS_EXT     0x9317
-#define GL_FRAMEBUFFER_INCOMPLETE_LAYER_TARGETS_EXT 0x8DA8
-#define GL_FRAMEBUFFER_ATTACHMENT_LAYERED_EXT 0x8DA7
-#define GL_REFERENCED_BY_GEOMETRY_SHADER_EXT 0x9309
-typedef void (GL_APIENTRYP PFNGLFRAMEBUFFERTEXTUREEXTPROC) (GLenum target, GLenum attachment, GLuint texture, GLint level);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glFramebufferTextureEXT (GLenum target, GLenum attachment, GLuint texture, GLint level);
-#endif
-#endif /* GL_EXT_geometry_shader */
-
-#ifndef GL_EXT_gpu_shader5
-#define GL_EXT_gpu_shader5 1
-#endif /* GL_EXT_gpu_shader5 */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
 #ifndef GL_EXT_instanced_arrays
 #define GL_EXT_instanced_arrays 1
 #define GL_VERTEX_ATTRIB_ARRAY_DIVISOR_EXT 0x88FE
@@ -1007,115 +355,7 @@ GL_APICALL void GL_APIENTRY glVertexAttribDivisorEXT (GLuint index, GLuint divis
 #endif
 #endif /* GL_EXT_instanced_arrays */
 
-#ifndef GL_EXT_map_buffer_range
-#define GL_EXT_map_buffer_range 1
-#define GL_MAP_READ_BIT_EXT               0x0001
-#define GL_MAP_WRITE_BIT_EXT              0x0002
-#define GL_MAP_INVALIDATE_RANGE_BIT_EXT   0x0004
-#define GL_MAP_INVALIDATE_BUFFER_BIT_EXT  0x0008
-#define GL_MAP_FLUSH_EXPLICIT_BIT_EXT     0x0010
-#define GL_MAP_UNSYNCHRONIZED_BIT_EXT     0x0020
-typedef void *(GL_APIENTRYP PFNGLMAPBUFFERRANGEEXTPROC) (GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
-typedef void (GL_APIENTRYP PFNGLFLUSHMAPPEDBUFFERRANGEEXTPROC) (GLenum target, GLintptr offset, GLsizeiptr length);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void *GL_APIENTRY glMapBufferRangeEXT (GLenum target, GLintptr offset, GLsizeiptr length, GLbitfield access);
-GL_APICALL void GL_APIENTRY glFlushMappedBufferRangeEXT (GLenum target, GLintptr offset, GLsizeiptr length);
-#endif
-#endif /* GL_EXT_map_buffer_range */
-
-#ifndef GL_EXT_multi_draw_arrays
-#define GL_EXT_multi_draw_arrays 1
-typedef void (GL_APIENTRYP PFNGLMULTIDRAWARRAYSEXTPROC) (GLenum mode, const GLint *first, const GLsizei *count, GLsizei primcount);
-typedef void (GL_APIENTRYP PFNGLMULTIDRAWELEMENTSEXTPROC) (GLenum mode, const GLsizei *count, GLenum type, const void *const*indices, GLsizei primcount);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glMultiDrawArraysEXT (GLenum mode, const GLint *first, const GLsizei *count, GLsizei primcount);
-GL_APICALL void GL_APIENTRY glMultiDrawElementsEXT (GLenum mode, const GLsizei *count, GLenum type, const void *const*indices, GLsizei primcount);
-#endif
-#endif /* GL_EXT_multi_draw_arrays */
-
-#ifndef GL_EXT_multisampled_render_to_texture
-#define GL_EXT_multisampled_render_to_texture 1
-#define GL_FRAMEBUFFER_ATTACHMENT_TEXTURE_SAMPLES_EXT 0x8D6C
-#define GL_RENDERBUFFER_SAMPLES_EXT       0x8CAB
-#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_EXT 0x8D56
-#define GL_MAX_SAMPLES_EXT                0x8D57
-typedef void (GL_APIENTRYP PFNGLRENDERBUFFERSTORAGEMULTISAMPLEEXTPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-typedef void (GL_APIENTRYP PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEEXTPROC) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLsizei samples);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glRenderbufferStorageMultisampleEXT (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-GL_APICALL void GL_APIENTRY glFramebufferTexture2DMultisampleEXT (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLsizei samples);
-#endif
-#endif /* GL_EXT_multisampled_render_to_texture */
-
-#ifndef GL_EXT_multiview_draw_buffers
-#define GL_EXT_multiview_draw_buffers 1
-#define GL_COLOR_ATTACHMENT_EXT           0x90F0
-#define GL_MULTIVIEW_EXT                  0x90F1
-#define GL_DRAW_BUFFER_EXT                0x0C01
-#define GL_READ_BUFFER_EXT                0x0C02
-#define GL_MAX_MULTIVIEW_BUFFERS_EXT      0x90F2
-typedef void (GL_APIENTRYP PFNGLREADBUFFERINDEXEDEXTPROC) (GLenum src, GLint index);
-typedef void (GL_APIENTRYP PFNGLDRAWBUFFERSINDEXEDEXTPROC) (GLint n, const GLenum *location, const GLint *indices);
-typedef void (GL_APIENTRYP PFNGLGETINTEGERI_VEXTPROC) (GLenum target, GLuint index, GLint *data);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glReadBufferIndexedEXT (GLenum src, GLint index);
-GL_APICALL void GL_APIENTRY glDrawBuffersIndexedEXT (GLint n, const GLenum *location, const GLint *indices);
-GL_APICALL void GL_APIENTRY glGetIntegeri_vEXT (GLenum target, GLuint index, GLint *data);
-#endif
-#endif /* GL_EXT_multiview_draw_buffers */
-
-#ifndef GL_EXT_occlusion_query_boolean
-#define GL_EXT_occlusion_query_boolean 1
-#define GL_ANY_SAMPLES_PASSED_EXT         0x8C2F
-#define GL_ANY_SAMPLES_PASSED_CONSERVATIVE_EXT 0x8D6A
-#endif /* GL_EXT_occlusion_query_boolean */
-
-#ifndef GL_EXT_primitive_bounding_box
-#define GL_EXT_primitive_bounding_box 1
-#define GL_PRIMITIVE_BOUNDING_BOX_EXT     0x92BE
-typedef void (GL_APIENTRYP PFNGLPRIMITIVEBOUNDINGBOXEXTPROC) (GLfloat minX, GLfloat minY, GLfloat minZ, GLfloat minW, GLfloat maxX, GLfloat maxY, GLfloat maxZ, GLfloat maxW);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glPrimitiveBoundingBoxEXT (GLfloat minX, GLfloat minY, GLfloat minZ, GLfloat minW, GLfloat maxX, GLfloat maxY, GLfloat maxZ, GLfloat maxW);
-#endif
-#endif /* GL_EXT_primitive_bounding_box */
-
-#ifndef GL_EXT_pvrtc_sRGB
-#define GL_EXT_pvrtc_sRGB 1
-#define GL_COMPRESSED_SRGB_PVRTC_2BPPV1_EXT 0x8A54
-#define GL_COMPRESSED_SRGB_PVRTC_4BPPV1_EXT 0x8A55
-#define GL_COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV1_EXT 0x8A56
-#define GL_COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV1_EXT 0x8A57
-#define GL_COMPRESSED_SRGB_ALPHA_PVRTC_2BPPV2_IMG 0x93F0
-#define GL_COMPRESSED_SRGB_ALPHA_PVRTC_4BPPV2_IMG 0x93F1
-#endif /* GL_EXT_pvrtc_sRGB */
-
-#ifndef GL_EXT_read_format_bgra
-#define GL_EXT_read_format_bgra 1
-#define GL_UNSIGNED_SHORT_4_4_4_4_REV_EXT 0x8365
-#define GL_UNSIGNED_SHORT_1_5_5_5_REV_EXT 0x8366
-#endif /* GL_EXT_read_format_bgra */
-
-#ifndef GL_EXT_robustness
-#define GL_EXT_robustness 1
-#define GL_GUILTY_CONTEXT_RESET_EXT       0x8253
-#define GL_INNOCENT_CONTEXT_RESET_EXT     0x8254
-#define GL_UNKNOWN_CONTEXT_RESET_EXT      0x8255
-#define GL_CONTEXT_ROBUST_ACCESS_EXT      0x90F3
-#define GL_RESET_NOTIFICATION_STRATEGY_EXT 0x8256
-#define GL_LOSE_CONTEXT_ON_RESET_EXT      0x8252
-#define GL_NO_RESET_NOTIFICATION_EXT      0x8261
-typedef GLenum (GL_APIENTRYP PFNGLGETGRAPHICSRESETSTATUSEXTPROC) (void);
-typedef void (GL_APIENTRYP PFNGLREADNPIXELSEXTPROC) (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLsizei bufSize, void *data);
-typedef void (GL_APIENTRYP PFNGLGETNUNIFORMFVEXTPROC) (GLuint program, GLint location, GLsizei bufSize, GLfloat *params);
-typedef void (GL_APIENTRYP PFNGLGETNUNIFORMIVEXTPROC) (GLuint program, GLint location, GLsizei bufSize, GLint *params);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL GLenum GL_APIENTRY glGetGraphicsResetStatusEXT (void);
-GL_APICALL void GL_APIENTRY glReadnPixelsEXT (GLint x, GLint y, GLsizei width, GLsizei height, GLenum format, GLenum type, GLsizei bufSize, void *data);
-GL_APICALL void GL_APIENTRY glGetnUniformfvEXT (GLuint program, GLint location, GLsizei bufSize, GLfloat *params);
-GL_APICALL void GL_APIENTRY glGetnUniformivEXT (GLuint program, GLint location, GLsizei bufSize, GLint *params);
-#endif
-#endif /* GL_EXT_robustness */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/
 #ifndef GL_EXT_sRGB
 #define GL_EXT_sRGB 1
 #define GL_SRGB_EXT                       0x8C40
@@ -1124,392 +364,33 @@ GL_APICALL void GL_APIENTRY glGetnUniformivEXT (GLuint program, GLint location, 
 #define GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT 0x8210
 #endif /* GL_EXT_sRGB */
 
-#ifndef GL_EXT_sRGB_write_control
-#define GL_EXT_sRGB_write_control 1
-#define GL_FRAMEBUFFER_SRGB_EXT           0x8DB9
-#endif /* GL_EXT_sRGB_write_control */
-
-#ifndef GL_EXT_separate_shader_objects
-#define GL_EXT_separate_shader_objects 1
-#define GL_ACTIVE_PROGRAM_EXT             0x8259
-#define GL_VERTEX_SHADER_BIT_EXT          0x00000001
-#define GL_FRAGMENT_SHADER_BIT_EXT        0x00000002
-#define GL_ALL_SHADER_BITS_EXT            0xFFFFFFFF
-#define GL_PROGRAM_SEPARABLE_EXT          0x8258
-#define GL_PROGRAM_PIPELINE_BINDING_EXT   0x825A
-typedef void (GL_APIENTRYP PFNGLACTIVESHADERPROGRAMEXTPROC) (GLuint pipeline, GLuint program);
-typedef void (GL_APIENTRYP PFNGLBINDPROGRAMPIPELINEEXTPROC) (GLuint pipeline);
-typedef GLuint (GL_APIENTRYP PFNGLCREATESHADERPROGRAMVEXTPROC) (GLenum type, GLsizei count, const GLchar **strings);
-typedef void (GL_APIENTRYP PFNGLDELETEPROGRAMPIPELINESEXTPROC) (GLsizei n, const GLuint *pipelines);
-typedef void (GL_APIENTRYP PFNGLGENPROGRAMPIPELINESEXTPROC) (GLsizei n, GLuint *pipelines);
-typedef void (GL_APIENTRYP PFNGLGETPROGRAMPIPELINEINFOLOGEXTPROC) (GLuint pipeline, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
-typedef void (GL_APIENTRYP PFNGLGETPROGRAMPIPELINEIVEXTPROC) (GLuint pipeline, GLenum pname, GLint *params);
-typedef GLboolean (GL_APIENTRYP PFNGLISPROGRAMPIPELINEEXTPROC) (GLuint pipeline);
-typedef void (GL_APIENTRYP PFNGLPROGRAMPARAMETERIEXTPROC) (GLuint program, GLenum pname, GLint value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM1FEXTPROC) (GLuint program, GLint location, GLfloat v0);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM1FVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM1IEXTPROC) (GLuint program, GLint location, GLint v0);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM1IVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLint *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM2FEXTPROC) (GLuint program, GLint location, GLfloat v0, GLfloat v1);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM2FVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM2IEXTPROC) (GLuint program, GLint location, GLint v0, GLint v1);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM2IVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLint *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM3FEXTPROC) (GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM3FVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM3IEXTPROC) (GLuint program, GLint location, GLint v0, GLint v1, GLint v2);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM3IVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLint *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM4FEXTPROC) (GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM4FVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM4IEXTPROC) (GLuint program, GLint location, GLint v0, GLint v1, GLint v2, GLint v3);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM4IVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLint *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX2FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX3FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX4FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLUSEPROGRAMSTAGESEXTPROC) (GLuint pipeline, GLbitfield stages, GLuint program);
-typedef void (GL_APIENTRYP PFNGLVALIDATEPROGRAMPIPELINEEXTPROC) (GLuint pipeline);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM1UIEXTPROC) (GLuint program, GLint location, GLuint v0);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM2UIEXTPROC) (GLuint program, GLint location, GLuint v0, GLuint v1);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM3UIEXTPROC) (GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM4UIEXTPROC) (GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM1UIVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLuint *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM2UIVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLuint *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM3UIVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLuint *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORM4UIVEXTPROC) (GLuint program, GLint location, GLsizei count, const GLuint *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX2X3FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX3X2FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX2X4FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX4X2FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX3X4FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLPROGRAMUNIFORMMATRIX4X3FVEXTPROC) (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glActiveShaderProgramEXT (GLuint pipeline, GLuint program);
-GL_APICALL void GL_APIENTRY glBindProgramPipelineEXT (GLuint pipeline);
-GL_APICALL GLuint GL_APIENTRY glCreateShaderProgramvEXT (GLenum type, GLsizei count, const GLchar **strings);
-GL_APICALL void GL_APIENTRY glDeleteProgramPipelinesEXT (GLsizei n, const GLuint *pipelines);
-GL_APICALL void GL_APIENTRY glGenProgramPipelinesEXT (GLsizei n, GLuint *pipelines);
-GL_APICALL void GL_APIENTRY glGetProgramPipelineInfoLogEXT (GLuint pipeline, GLsizei bufSize, GLsizei *length, GLchar *infoLog);
-GL_APICALL void GL_APIENTRY glGetProgramPipelineivEXT (GLuint pipeline, GLenum pname, GLint *params);
-GL_APICALL GLboolean GL_APIENTRY glIsProgramPipelineEXT (GLuint pipeline);
-GL_APICALL void GL_APIENTRY glProgramParameteriEXT (GLuint program, GLenum pname, GLint value);
-GL_APICALL void GL_APIENTRY glProgramUniform1fEXT (GLuint program, GLint location, GLfloat v0);
-GL_APICALL void GL_APIENTRY glProgramUniform1fvEXT (GLuint program, GLint location, GLsizei count, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniform1iEXT (GLuint program, GLint location, GLint v0);
-GL_APICALL void GL_APIENTRY glProgramUniform1ivEXT (GLuint program, GLint location, GLsizei count, const GLint *value);
-GL_APICALL void GL_APIENTRY glProgramUniform2fEXT (GLuint program, GLint location, GLfloat v0, GLfloat v1);
-GL_APICALL void GL_APIENTRY glProgramUniform2fvEXT (GLuint program, GLint location, GLsizei count, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniform2iEXT (GLuint program, GLint location, GLint v0, GLint v1);
-GL_APICALL void GL_APIENTRY glProgramUniform2ivEXT (GLuint program, GLint location, GLsizei count, const GLint *value);
-GL_APICALL void GL_APIENTRY glProgramUniform3fEXT (GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2);
-GL_APICALL void GL_APIENTRY glProgramUniform3fvEXT (GLuint program, GLint location, GLsizei count, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniform3iEXT (GLuint program, GLint location, GLint v0, GLint v1, GLint v2);
-GL_APICALL void GL_APIENTRY glProgramUniform3ivEXT (GLuint program, GLint location, GLsizei count, const GLint *value);
-GL_APICALL void GL_APIENTRY glProgramUniform4fEXT (GLuint program, GLint location, GLfloat v0, GLfloat v1, GLfloat v2, GLfloat v3);
-GL_APICALL void GL_APIENTRY glProgramUniform4fvEXT (GLuint program, GLint location, GLsizei count, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniform4iEXT (GLuint program, GLint location, GLint v0, GLint v1, GLint v2, GLint v3);
-GL_APICALL void GL_APIENTRY glProgramUniform4ivEXT (GLuint program, GLint location, GLsizei count, const GLint *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix2fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix3fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix4fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glUseProgramStagesEXT (GLuint pipeline, GLbitfield stages, GLuint program);
-GL_APICALL void GL_APIENTRY glValidateProgramPipelineEXT (GLuint pipeline);
-GL_APICALL void GL_APIENTRY glProgramUniform1uiEXT (GLuint program, GLint location, GLuint v0);
-GL_APICALL void GL_APIENTRY glProgramUniform2uiEXT (GLuint program, GLint location, GLuint v0, GLuint v1);
-GL_APICALL void GL_APIENTRY glProgramUniform3uiEXT (GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2);
-GL_APICALL void GL_APIENTRY glProgramUniform4uiEXT (GLuint program, GLint location, GLuint v0, GLuint v1, GLuint v2, GLuint v3);
-GL_APICALL void GL_APIENTRY glProgramUniform1uivEXT (GLuint program, GLint location, GLsizei count, const GLuint *value);
-GL_APICALL void GL_APIENTRY glProgramUniform2uivEXT (GLuint program, GLint location, GLsizei count, const GLuint *value);
-GL_APICALL void GL_APIENTRY glProgramUniform3uivEXT (GLuint program, GLint location, GLsizei count, const GLuint *value);
-GL_APICALL void GL_APIENTRY glProgramUniform4uivEXT (GLuint program, GLint location, GLsizei count, const GLuint *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix2x3fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix3x2fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix2x4fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix4x2fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix3x4fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glProgramUniformMatrix4x3fvEXT (GLuint program, GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-#endif
-#endif /* GL_EXT_separate_shader_objects */
-
-#ifndef GL_EXT_shader_framebuffer_fetch
-#define GL_EXT_shader_framebuffer_fetch 1
-#define GL_FRAGMENT_SHADER_DISCARDS_SAMPLES_EXT 0x8A52
-#endif /* GL_EXT_shader_framebuffer_fetch */
-
-#ifndef GL_EXT_shader_implicit_conversions
-#define GL_EXT_shader_implicit_conversions 1
-#endif /* GL_EXT_shader_implicit_conversions */
-
-#ifndef GL_EXT_shader_integer_mix
-#define GL_EXT_shader_integer_mix 1
-#endif /* GL_EXT_shader_integer_mix */
-
-#ifndef GL_EXT_shader_io_blocks
-#define GL_EXT_shader_io_blocks 1
-#endif /* GL_EXT_shader_io_blocks */
-
-#ifndef GL_EXT_shader_pixel_local_storage
-#define GL_EXT_shader_pixel_local_storage 1
-#define GL_MAX_SHADER_PIXEL_LOCAL_STORAGE_FAST_SIZE_EXT 0x8F63
-#define GL_MAX_SHADER_PIXEL_LOCAL_STORAGE_SIZE_EXT 0x8F67
-#define GL_SHADER_PIXEL_LOCAL_STORAGE_EXT 0x8F64
-#endif /* GL_EXT_shader_pixel_local_storage */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/
 #ifndef GL_EXT_shader_texture_lod
 #define GL_EXT_shader_texture_lod 1
 #endif /* GL_EXT_shader_texture_lod */
 
-#ifndef GL_EXT_shadow_samplers
-#define GL_EXT_shadow_samplers 1
-#define GL_TEXTURE_COMPARE_MODE_EXT       0x884C
-#define GL_TEXTURE_COMPARE_FUNC_EXT       0x884D
-#define GL_COMPARE_REF_TO_TEXTURE_EXT     0x884E
-#define GL_SAMPLER_2D_SHADOW_EXT          0x8B62
-#endif /* GL_EXT_shadow_samplers */
-
-#ifndef GL_EXT_tessellation_point_size
-#define GL_EXT_tessellation_point_size 1
-#endif /* GL_EXT_tessellation_point_size */
-
-#ifndef GL_EXT_tessellation_shader
-#define GL_EXT_tessellation_shader 1
-#define GL_PATCHES_EXT                    0x000E
-#define GL_PATCH_VERTICES_EXT             0x8E72
-#define GL_TESS_CONTROL_OUTPUT_VERTICES_EXT 0x8E75
-#define GL_TESS_GEN_MODE_EXT              0x8E76
-#define GL_TESS_GEN_SPACING_EXT           0x8E77
-#define GL_TESS_GEN_VERTEX_ORDER_EXT      0x8E78
-#define GL_TESS_GEN_POINT_MODE_EXT        0x8E79
-#define GL_ISOLINES_EXT                   0x8E7A
-#define GL_QUADS_EXT                      0x0007
-#define GL_FRACTIONAL_ODD_EXT             0x8E7B
-#define GL_FRACTIONAL_EVEN_EXT            0x8E7C
-#define GL_MAX_PATCH_VERTICES_EXT         0x8E7D
-#define GL_MAX_TESS_GEN_LEVEL_EXT         0x8E7E
-#define GL_MAX_TESS_CONTROL_UNIFORM_COMPONENTS_EXT 0x8E7F
-#define GL_MAX_TESS_EVALUATION_UNIFORM_COMPONENTS_EXT 0x8E80
-#define GL_MAX_TESS_CONTROL_TEXTURE_IMAGE_UNITS_EXT 0x8E81
-#define GL_MAX_TESS_EVALUATION_TEXTURE_IMAGE_UNITS_EXT 0x8E82
-#define GL_MAX_TESS_CONTROL_OUTPUT_COMPONENTS_EXT 0x8E83
-#define GL_MAX_TESS_PATCH_COMPONENTS_EXT  0x8E84
-#define GL_MAX_TESS_CONTROL_TOTAL_OUTPUT_COMPONENTS_EXT 0x8E85
-#define GL_MAX_TESS_EVALUATION_OUTPUT_COMPONENTS_EXT 0x8E86
-#define GL_MAX_TESS_CONTROL_UNIFORM_BLOCKS_EXT 0x8E89
-#define GL_MAX_TESS_EVALUATION_UNIFORM_BLOCKS_EXT 0x8E8A
-#define GL_MAX_TESS_CONTROL_INPUT_COMPONENTS_EXT 0x886C
-#define GL_MAX_TESS_EVALUATION_INPUT_COMPONENTS_EXT 0x886D
-#define GL_MAX_COMBINED_TESS_CONTROL_UNIFORM_COMPONENTS_EXT 0x8E1E
-#define GL_MAX_COMBINED_TESS_EVALUATION_UNIFORM_COMPONENTS_EXT 0x8E1F
-#define GL_MAX_TESS_CONTROL_ATOMIC_COUNTER_BUFFERS_EXT 0x92CD
-#define GL_MAX_TESS_EVALUATION_ATOMIC_COUNTER_BUFFERS_EXT 0x92CE
-#define GL_MAX_TESS_CONTROL_ATOMIC_COUNTERS_EXT 0x92D3
-#define GL_MAX_TESS_EVALUATION_ATOMIC_COUNTERS_EXT 0x92D4
-#define GL_MAX_TESS_CONTROL_IMAGE_UNIFORMS_EXT 0x90CB
-#define GL_MAX_TESS_EVALUATION_IMAGE_UNIFORMS_EXT 0x90CC
-#define GL_MAX_TESS_CONTROL_SHADER_STORAGE_BLOCKS_EXT 0x90D8
-#define GL_MAX_TESS_EVALUATION_SHADER_STORAGE_BLOCKS_EXT 0x90D9
-#define GL_PRIMITIVE_RESTART_FOR_PATCHES_SUPPORTED 0x8221
-#define GL_IS_PER_PATCH_EXT               0x92E7
-#define GL_REFERENCED_BY_TESS_CONTROL_SHADER_EXT 0x9307
-#define GL_REFERENCED_BY_TESS_EVALUATION_SHADER_EXT 0x9308
-#define GL_TESS_CONTROL_SHADER_EXT        0x8E88
-#define GL_TESS_EVALUATION_SHADER_EXT     0x8E87
-#define GL_TESS_CONTROL_SHADER_BIT_EXT    0x00000008
-#define GL_TESS_EVALUATION_SHADER_BIT_EXT 0x00000010
-typedef void (GL_APIENTRYP PFNGLPATCHPARAMETERIEXTPROC) (GLenum pname, GLint value);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glPatchParameteriEXT (GLenum pname, GLint value);
-#endif
-#endif /* GL_EXT_tessellation_shader */
-
-#ifndef GL_EXT_texture_border_clamp
-#define GL_EXT_texture_border_clamp 1
-#define GL_TEXTURE_BORDER_COLOR_EXT       0x1004
-#define GL_CLAMP_TO_BORDER_EXT            0x812D
-typedef void (GL_APIENTRYP PFNGLTEXPARAMETERIIVEXTPROC) (GLenum target, GLenum pname, const GLint *params);
-typedef void (GL_APIENTRYP PFNGLTEXPARAMETERIUIVEXTPROC) (GLenum target, GLenum pname, const GLuint *params);
-typedef void (GL_APIENTRYP PFNGLGETTEXPARAMETERIIVEXTPROC) (GLenum target, GLenum pname, GLint *params);
-typedef void (GL_APIENTRYP PFNGLGETTEXPARAMETERIUIVEXTPROC) (GLenum target, GLenum pname, GLuint *params);
-typedef void (GL_APIENTRYP PFNGLSAMPLERPARAMETERIIVEXTPROC) (GLuint sampler, GLenum pname, const GLint *param);
-typedef void (GL_APIENTRYP PFNGLSAMPLERPARAMETERIUIVEXTPROC) (GLuint sampler, GLenum pname, const GLuint *param);
-typedef void (GL_APIENTRYP PFNGLGETSAMPLERPARAMETERIIVEXTPROC) (GLuint sampler, GLenum pname, GLint *params);
-typedef void (GL_APIENTRYP PFNGLGETSAMPLERPARAMETERIUIVEXTPROC) (GLuint sampler, GLenum pname, GLuint *params);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glTexParameterIivEXT (GLenum target, GLenum pname, const GLint *params);
-GL_APICALL void GL_APIENTRY glTexParameterIuivEXT (GLenum target, GLenum pname, const GLuint *params);
-GL_APICALL void GL_APIENTRY glGetTexParameterIivEXT (GLenum target, GLenum pname, GLint *params);
-GL_APICALL void GL_APIENTRY glGetTexParameterIuivEXT (GLenum target, GLenum pname, GLuint *params);
-GL_APICALL void GL_APIENTRY glSamplerParameterIivEXT (GLuint sampler, GLenum pname, const GLint *param);
-GL_APICALL void GL_APIENTRY glSamplerParameterIuivEXT (GLuint sampler, GLenum pname, const GLuint *param);
-GL_APICALL void GL_APIENTRY glGetSamplerParameterIivEXT (GLuint sampler, GLenum pname, GLint *params);
-GL_APICALL void GL_APIENTRY glGetSamplerParameterIuivEXT (GLuint sampler, GLenum pname, GLuint *params);
-#endif
-#endif /* GL_EXT_texture_border_clamp */
-
-#ifndef GL_EXT_texture_buffer
-#define GL_EXT_texture_buffer 1
-#define GL_TEXTURE_BUFFER_EXT             0x8C2A
-#define GL_TEXTURE_BUFFER_BINDING_EXT     0x8C2A
-#define GL_MAX_TEXTURE_BUFFER_SIZE_EXT    0x8C2B
-#define GL_TEXTURE_BINDING_BUFFER_EXT     0x8C2C
-#define GL_TEXTURE_BUFFER_DATA_STORE_BINDING_EXT 0x8C2D
-#define GL_TEXTURE_BUFFER_OFFSET_ALIGNMENT_EXT 0x919F
-#define GL_SAMPLER_BUFFER_EXT             0x8DC2
-#define GL_INT_SAMPLER_BUFFER_EXT         0x8DD0
-#define GL_UNSIGNED_INT_SAMPLER_BUFFER_EXT 0x8DD8
-#define GL_IMAGE_BUFFER_EXT               0x9051
-#define GL_INT_IMAGE_BUFFER_EXT           0x905C
-#define GL_UNSIGNED_INT_IMAGE_BUFFER_EXT  0x9067
-#define GL_TEXTURE_BUFFER_OFFSET_EXT      0x919D
-#define GL_TEXTURE_BUFFER_SIZE_EXT        0x919E
-typedef void (GL_APIENTRYP PFNGLTEXBUFFEREXTPROC) (GLenum target, GLenum internalformat, GLuint buffer);
-typedef void (GL_APIENTRYP PFNGLTEXBUFFERRANGEEXTPROC) (GLenum target, GLenum internalformat, GLuint buffer, GLintptr offset, GLsizeiptr size);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glTexBufferEXT (GLenum target, GLenum internalformat, GLuint buffer);
-GL_APICALL void GL_APIENTRY glTexBufferRangeEXT (GLenum target, GLenum internalformat, GLuint buffer, GLintptr offset, GLsizeiptr size);
-#endif
-#endif /* GL_EXT_texture_buffer */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
 #ifndef GL_EXT_texture_compression_dxt1
 #define GL_EXT_texture_compression_dxt1 1
 #define GL_COMPRESSED_RGB_S3TC_DXT1_EXT   0x83F0
 #define GL_COMPRESSED_RGBA_S3TC_DXT1_EXT  0x83F1
 #endif /* GL_EXT_texture_compression_dxt1 */
 
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
 #ifndef GL_EXT_texture_compression_s3tc
 #define GL_EXT_texture_compression_s3tc 1
 #define GL_COMPRESSED_RGBA_S3TC_DXT3_EXT  0x83F2
 #define GL_COMPRESSED_RGBA_S3TC_DXT5_EXT  0x83F3
 #endif /* GL_EXT_texture_compression_s3tc */
 
-#ifndef GL_EXT_texture_cube_map_array
-#define GL_EXT_texture_cube_map_array 1
-#define GL_TEXTURE_CUBE_MAP_ARRAY_EXT     0x9009
-#define GL_TEXTURE_BINDING_CUBE_MAP_ARRAY_EXT 0x900A
-#define GL_SAMPLER_CUBE_MAP_ARRAY_EXT     0x900C
-#define GL_SAMPLER_CUBE_MAP_ARRAY_SHADOW_EXT 0x900D
-#define GL_INT_SAMPLER_CUBE_MAP_ARRAY_EXT 0x900E
-#define GL_UNSIGNED_INT_SAMPLER_CUBE_MAP_ARRAY_EXT 0x900F
-#define GL_IMAGE_CUBE_MAP_ARRAY_EXT       0x9054
-#define GL_INT_IMAGE_CUBE_MAP_ARRAY_EXT   0x905F
-#define GL_UNSIGNED_INT_IMAGE_CUBE_MAP_ARRAY_EXT 0x906A
-#endif /* GL_EXT_texture_cube_map_array */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/
 #ifndef GL_EXT_texture_filter_anisotropic
 #define GL_EXT_texture_filter_anisotropic 1
 #define GL_TEXTURE_MAX_ANISOTROPY_EXT     0x84FE
 #define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
 #endif /* GL_EXT_texture_filter_anisotropic */
 
-#ifndef GL_EXT_texture_format_BGRA8888
-#define GL_EXT_texture_format_BGRA8888 1
-#endif /* GL_EXT_texture_format_BGRA8888 */
-
-#ifndef GL_EXT_texture_rg
-#define GL_EXT_texture_rg 1
-#define GL_RED_EXT                        0x1903
-#define GL_RG_EXT                         0x8227
-#define GL_R8_EXT                         0x8229
-#define GL_RG8_EXT                        0x822B
-#endif /* GL_EXT_texture_rg */
-
-#ifndef GL_EXT_texture_sRGB_decode
-#define GL_EXT_texture_sRGB_decode 1
-#define GL_TEXTURE_SRGB_DECODE_EXT        0x8A48
-#define GL_DECODE_EXT                     0x8A49
-#define GL_SKIP_DECODE_EXT                0x8A4A
-#endif /* GL_EXT_texture_sRGB_decode */
-
-#ifndef GL_EXT_texture_storage
-#define GL_EXT_texture_storage 1
-#define GL_TEXTURE_IMMUTABLE_FORMAT_EXT   0x912F
-#define GL_ALPHA8_EXT                     0x803C
-#define GL_LUMINANCE8_EXT                 0x8040
-#define GL_LUMINANCE8_ALPHA8_EXT          0x8045
-#define GL_RGBA32F_EXT                    0x8814
-#define GL_RGB32F_EXT                     0x8815
-#define GL_ALPHA32F_EXT                   0x8816
-#define GL_LUMINANCE32F_EXT               0x8818
-#define GL_LUMINANCE_ALPHA32F_EXT         0x8819
-#define GL_ALPHA16F_EXT                   0x881C
-#define GL_LUMINANCE16F_EXT               0x881E
-#define GL_LUMINANCE_ALPHA16F_EXT         0x881F
-#define GL_R32F_EXT                       0x822E
-#define GL_RG32F_EXT                      0x8230
-typedef void (GL_APIENTRYP PFNGLTEXSTORAGE1DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
-typedef void (GL_APIENTRYP PFNGLTEXSTORAGE2DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
-typedef void (GL_APIENTRYP PFNGLTEXSTORAGE3DEXTPROC) (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
-typedef void (GL_APIENTRYP PFNGLTEXTURESTORAGE1DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
-typedef void (GL_APIENTRYP PFNGLTEXTURESTORAGE2DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
-typedef void (GL_APIENTRYP PFNGLTEXTURESTORAGE3DEXTPROC) (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glTexStorage1DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
-GL_APICALL void GL_APIENTRY glTexStorage2DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
-GL_APICALL void GL_APIENTRY glTexStorage3DEXT (GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
-GL_APICALL void GL_APIENTRY glTextureStorage1DEXT (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width);
-GL_APICALL void GL_APIENTRY glTextureStorage2DEXT (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
-GL_APICALL void GL_APIENTRY glTextureStorage3DEXT (GLuint texture, GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height, GLsizei depth);
-#endif
-#endif /* GL_EXT_texture_storage */
-
-#ifndef GL_EXT_texture_type_2_10_10_10_REV
-#define GL_EXT_texture_type_2_10_10_10_REV 1
-#define GL_UNSIGNED_INT_2_10_10_10_REV_EXT 0x8368
-#endif /* GL_EXT_texture_type_2_10_10_10_REV */
-
-#ifndef GL_EXT_texture_view
-#define GL_EXT_texture_view 1
-#define GL_TEXTURE_VIEW_MIN_LEVEL_EXT     0x82DB
-#define GL_TEXTURE_VIEW_NUM_LEVELS_EXT    0x82DC
-#define GL_TEXTURE_VIEW_MIN_LAYER_EXT     0x82DD
-#define GL_TEXTURE_VIEW_NUM_LAYERS_EXT    0x82DE
-#define GL_TEXTURE_IMMUTABLE_LEVELS       0x82DF
-typedef void (GL_APIENTRYP PFNGLTEXTUREVIEWEXTPROC) (GLuint texture, GLenum target, GLuint origtexture, GLenum internalformat, GLuint minlevel, GLuint numlevels, GLuint minlayer, GLuint numlayers);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glTextureViewEXT (GLuint texture, GLenum target, GLuint origtexture, GLenum internalformat, GLuint minlevel, GLuint numlevels, GLuint minlayer, GLuint numlayers);
-#endif
-#endif /* GL_EXT_texture_view */
-
-#ifndef GL_EXT_unpack_subimage
-#define GL_EXT_unpack_subimage 1
-#define GL_UNPACK_ROW_LENGTH_EXT          0x0CF2
-#define GL_UNPACK_SKIP_ROWS_EXT           0x0CF3
-#define GL_UNPACK_SKIP_PIXELS_EXT         0x0CF4
-#endif /* GL_EXT_unpack_subimage */
-
-#ifndef GL_FJ_shader_binary_GCCSO
-#define GL_FJ_shader_binary_GCCSO 1
-#define GL_GCCSO_SHADER_BINARY_FJ         0x9260
-#endif /* GL_FJ_shader_binary_GCCSO */
-
-#ifndef GL_IMG_multisampled_render_to_texture
-#define GL_IMG_multisampled_render_to_texture 1
-#define GL_RENDERBUFFER_SAMPLES_IMG       0x9133
-#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_IMG 0x9134
-#define GL_MAX_SAMPLES_IMG                0x9135
-#define GL_TEXTURE_SAMPLES_IMG            0x9136
-typedef void (GL_APIENTRYP PFNGLRENDERBUFFERSTORAGEMULTISAMPLEIMGPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-typedef void (GL_APIENTRYP PFNGLFRAMEBUFFERTEXTURE2DMULTISAMPLEIMGPROC) (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLsizei samples);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glRenderbufferStorageMultisampleIMG (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-GL_APICALL void GL_APIENTRY glFramebufferTexture2DMultisampleIMG (GLenum target, GLenum attachment, GLenum textarget, GLuint texture, GLint level, GLsizei samples);
-#endif
-#endif /* GL_IMG_multisampled_render_to_texture */
-
-#ifndef GL_IMG_program_binary
-#define GL_IMG_program_binary 1
-#define GL_SGX_PROGRAM_BINARY_IMG         0x9130
-#endif /* GL_IMG_program_binary */
-
-#ifndef GL_IMG_read_format
-#define GL_IMG_read_format 1
-#define GL_BGRA_IMG                       0x80E1
-#define GL_UNSIGNED_SHORT_4_4_4_4_REV_IMG 0x8365
-#endif /* GL_IMG_read_format */
-
-#ifndef GL_IMG_shader_binary
-#define GL_IMG_shader_binary 1
-#define GL_SGX_BINARY_IMG                 0x8C0A
-#endif /* GL_IMG_shader_binary */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/
 #ifndef GL_IMG_texture_compression_pvrtc
 #define GL_IMG_texture_compression_pvrtc 1
 #define GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG 0x8C00
@@ -1518,197 +399,7 @@ GL_APICALL void GL_APIENTRY glFramebufferTexture2DMultisampleIMG (GLenum target,
 #define GL_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG 0x8C03
 #endif /* GL_IMG_texture_compression_pvrtc */
 
-#ifndef GL_IMG_texture_compression_pvrtc2
-#define GL_IMG_texture_compression_pvrtc2 1
-#define GL_COMPRESSED_RGBA_PVRTC_2BPPV2_IMG 0x9137
-#define GL_COMPRESSED_RGBA_PVRTC_4BPPV2_IMG 0x9138
-#endif /* GL_IMG_texture_compression_pvrtc2 */
-
-#ifndef GL_INTEL_performance_query
-#define GL_INTEL_performance_query 1
-#define GL_PERFQUERY_SINGLE_CONTEXT_INTEL 0x00000000
-#define GL_PERFQUERY_GLOBAL_CONTEXT_INTEL 0x00000001
-#define GL_PERFQUERY_WAIT_INTEL           0x83FB
-#define GL_PERFQUERY_FLUSH_INTEL          0x83FA
-#define GL_PERFQUERY_DONOT_FLUSH_INTEL    0x83F9
-#define GL_PERFQUERY_COUNTER_EVENT_INTEL  0x94F0
-#define GL_PERFQUERY_COUNTER_DURATION_NORM_INTEL 0x94F1
-#define GL_PERFQUERY_COUNTER_DURATION_RAW_INTEL 0x94F2
-#define GL_PERFQUERY_COUNTER_THROUGHPUT_INTEL 0x94F3
-#define GL_PERFQUERY_COUNTER_RAW_INTEL    0x94F4
-#define GL_PERFQUERY_COUNTER_TIMESTAMP_INTEL 0x94F5
-#define GL_PERFQUERY_COUNTER_DATA_UINT32_INTEL 0x94F8
-#define GL_PERFQUERY_COUNTER_DATA_UINT64_INTEL 0x94F9
-#define GL_PERFQUERY_COUNTER_DATA_FLOAT_INTEL 0x94FA
-#define GL_PERFQUERY_COUNTER_DATA_DOUBLE_INTEL 0x94FB
-#define GL_PERFQUERY_COUNTER_DATA_BOOL32_INTEL 0x94FC
-#define GL_PERFQUERY_QUERY_NAME_LENGTH_MAX_INTEL 0x94FD
-#define GL_PERFQUERY_COUNTER_NAME_LENGTH_MAX_INTEL 0x94FE
-#define GL_PERFQUERY_COUNTER_DESC_LENGTH_MAX_INTEL 0x94FF
-#define GL_PERFQUERY_GPA_EXTENDED_COUNTERS_INTEL 0x9500
-typedef void (GL_APIENTRYP PFNGLBEGINPERFQUERYINTELPROC) (GLuint queryHandle);
-typedef void (GL_APIENTRYP PFNGLCREATEPERFQUERYINTELPROC) (GLuint queryId, GLuint *queryHandle);
-typedef void (GL_APIENTRYP PFNGLDELETEPERFQUERYINTELPROC) (GLuint queryHandle);
-typedef void (GL_APIENTRYP PFNGLENDPERFQUERYINTELPROC) (GLuint queryHandle);
-typedef void (GL_APIENTRYP PFNGLGETFIRSTPERFQUERYIDINTELPROC) (GLuint *queryId);
-typedef void (GL_APIENTRYP PFNGLGETNEXTPERFQUERYIDINTELPROC) (GLuint queryId, GLuint *nextQueryId);
-typedef void (GL_APIENTRYP PFNGLGETPERFCOUNTERINFOINTELPROC) (GLuint queryId, GLuint counterId, GLuint counterNameLength, GLchar *counterName, GLuint counterDescLength, GLchar *counterDesc, GLuint *counterOffset, GLuint *counterDataSize, GLuint *counterTypeEnum, GLuint *counterDataTypeEnum, GLuint64 *rawCounterMaxValue);
-typedef void (GL_APIENTRYP PFNGLGETPERFQUERYDATAINTELPROC) (GLuint queryHandle, GLuint flags, GLsizei dataSize, GLvoid *data, GLuint *bytesWritten);
-typedef void (GL_APIENTRYP PFNGLGETPERFQUERYIDBYNAMEINTELPROC) (GLchar *queryName, GLuint *queryId);
-typedef void (GL_APIENTRYP PFNGLGETPERFQUERYINFOINTELPROC) (GLuint queryId, GLuint queryNameLength, GLchar *queryName, GLuint *dataSize, GLuint *noCounters, GLuint *noInstances, GLuint *capsMask);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glBeginPerfQueryINTEL (GLuint queryHandle);
-GL_APICALL void GL_APIENTRY glCreatePerfQueryINTEL (GLuint queryId, GLuint *queryHandle);
-GL_APICALL void GL_APIENTRY glDeletePerfQueryINTEL (GLuint queryHandle);
-GL_APICALL void GL_APIENTRY glEndPerfQueryINTEL (GLuint queryHandle);
-GL_APICALL void GL_APIENTRY glGetFirstPerfQueryIdINTEL (GLuint *queryId);
-GL_APICALL void GL_APIENTRY glGetNextPerfQueryIdINTEL (GLuint queryId, GLuint *nextQueryId);
-GL_APICALL void GL_APIENTRY glGetPerfCounterInfoINTEL (GLuint queryId, GLuint counterId, GLuint counterNameLength, GLchar *counterName, GLuint counterDescLength, GLchar *counterDesc, GLuint *counterOffset, GLuint *counterDataSize, GLuint *counterTypeEnum, GLuint *counterDataTypeEnum, GLuint64 *rawCounterMaxValue);
-GL_APICALL void GL_APIENTRY glGetPerfQueryDataINTEL (GLuint queryHandle, GLuint flags, GLsizei dataSize, GLvoid *data, GLuint *bytesWritten);
-GL_APICALL void GL_APIENTRY glGetPerfQueryIdByNameINTEL (GLchar *queryName, GLuint *queryId);
-GL_APICALL void GL_APIENTRY glGetPerfQueryInfoINTEL (GLuint queryId, GLuint queryNameLength, GLchar *queryName, GLuint *dataSize, GLuint *noCounters, GLuint *noInstances, GLuint *capsMask);
-#endif
-#endif /* GL_INTEL_performance_query */
-
-#ifndef GL_NV_blend_equation_advanced
-#define GL_NV_blend_equation_advanced 1
-#define GL_BLEND_OVERLAP_NV               0x9281
-#define GL_BLEND_PREMULTIPLIED_SRC_NV     0x9280
-#define GL_BLUE_NV                        0x1905
-#define GL_COLORBURN_NV                   0x929A
-#define GL_COLORDODGE_NV                  0x9299
-#define GL_CONJOINT_NV                    0x9284
-#define GL_CONTRAST_NV                    0x92A1
-#define GL_DARKEN_NV                      0x9297
-#define GL_DIFFERENCE_NV                  0x929E
-#define GL_DISJOINT_NV                    0x9283
-#define GL_DST_ATOP_NV                    0x928F
-#define GL_DST_IN_NV                      0x928B
-#define GL_DST_NV                         0x9287
-#define GL_DST_OUT_NV                     0x928D
-#define GL_DST_OVER_NV                    0x9289
-#define GL_EXCLUSION_NV                   0x92A0
-#define GL_GREEN_NV                       0x1904
-#define GL_HARDLIGHT_NV                   0x929B
-#define GL_HARDMIX_NV                     0x92A9
-#define GL_HSL_COLOR_NV                   0x92AF
-#define GL_HSL_HUE_NV                     0x92AD
-#define GL_HSL_LUMINOSITY_NV              0x92B0
-#define GL_HSL_SATURATION_NV              0x92AE
-#define GL_INVERT_OVG_NV                  0x92B4
-#define GL_INVERT_RGB_NV                  0x92A3
-#define GL_LIGHTEN_NV                     0x9298
-#define GL_LINEARBURN_NV                  0x92A5
-#define GL_LINEARDODGE_NV                 0x92A4
-#define GL_LINEARLIGHT_NV                 0x92A7
-#define GL_MINUS_CLAMPED_NV               0x92B3
-#define GL_MINUS_NV                       0x929F
-#define GL_MULTIPLY_NV                    0x9294
-#define GL_OVERLAY_NV                     0x9296
-#define GL_PINLIGHT_NV                    0x92A8
-#define GL_PLUS_CLAMPED_ALPHA_NV          0x92B2
-#define GL_PLUS_CLAMPED_NV                0x92B1
-#define GL_PLUS_DARKER_NV                 0x9292
-#define GL_PLUS_NV                        0x9291
-#define GL_RED_NV                         0x1903
-#define GL_SCREEN_NV                      0x9295
-#define GL_SOFTLIGHT_NV                   0x929C
-#define GL_SRC_ATOP_NV                    0x928E
-#define GL_SRC_IN_NV                      0x928A
-#define GL_SRC_NV                         0x9286
-#define GL_SRC_OUT_NV                     0x928C
-#define GL_SRC_OVER_NV                    0x9288
-#define GL_UNCORRELATED_NV                0x9282
-#define GL_VIVIDLIGHT_NV                  0x92A6
-#define GL_XOR_NV                         0x1506
-typedef void (GL_APIENTRYP PFNGLBLENDPARAMETERINVPROC) (GLenum pname, GLint value);
-typedef void (GL_APIENTRYP PFNGLBLENDBARRIERNVPROC) (void);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glBlendParameteriNV (GLenum pname, GLint value);
-GL_APICALL void GL_APIENTRY glBlendBarrierNV (void);
-#endif
-#endif /* GL_NV_blend_equation_advanced */
-
-#ifndef GL_NV_blend_equation_advanced_coherent
-#define GL_NV_blend_equation_advanced_coherent 1
-#define GL_BLEND_ADVANCED_COHERENT_NV     0x9285
-#endif /* GL_NV_blend_equation_advanced_coherent */
-
-#ifndef GL_NV_copy_buffer
-#define GL_NV_copy_buffer 1
-#define GL_COPY_READ_BUFFER_NV            0x8F36
-#define GL_COPY_WRITE_BUFFER_NV           0x8F37
-typedef void (GL_APIENTRYP PFNGLCOPYBUFFERSUBDATANVPROC) (GLenum readTarget, GLenum writeTarget, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glCopyBufferSubDataNV (GLenum readTarget, GLenum writeTarget, GLintptr readOffset, GLintptr writeOffset, GLsizeiptr size);
-#endif
-#endif /* GL_NV_copy_buffer */
-
-#ifndef GL_NV_coverage_sample
-#define GL_NV_coverage_sample 1
-#define GL_COVERAGE_COMPONENT_NV          0x8ED0
-#define GL_COVERAGE_COMPONENT4_NV         0x8ED1
-#define GL_COVERAGE_ATTACHMENT_NV         0x8ED2
-#define GL_COVERAGE_BUFFERS_NV            0x8ED3
-#define GL_COVERAGE_SAMPLES_NV            0x8ED4
-#define GL_COVERAGE_ALL_FRAGMENTS_NV      0x8ED5
-#define GL_COVERAGE_EDGE_FRAGMENTS_NV     0x8ED6
-#define GL_COVERAGE_AUTOMATIC_NV          0x8ED7
-#define GL_COVERAGE_BUFFER_BIT_NV         0x00008000
-typedef void (GL_APIENTRYP PFNGLCOVERAGEMASKNVPROC) (GLboolean mask);
-typedef void (GL_APIENTRYP PFNGLCOVERAGEOPERATIONNVPROC) (GLenum operation);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glCoverageMaskNV (GLboolean mask);
-GL_APICALL void GL_APIENTRY glCoverageOperationNV (GLenum operation);
-#endif
-#endif /* GL_NV_coverage_sample */
-
-#ifndef GL_NV_depth_nonlinear
-#define GL_NV_depth_nonlinear 1
-#define GL_DEPTH_COMPONENT16_NONLINEAR_NV 0x8E2C
-#endif /* GL_NV_depth_nonlinear */
-
-#ifndef GL_NV_draw_buffers
-#define GL_NV_draw_buffers 1
-#define GL_MAX_DRAW_BUFFERS_NV            0x8824
-#define GL_DRAW_BUFFER0_NV                0x8825
-#define GL_DRAW_BUFFER1_NV                0x8826
-#define GL_DRAW_BUFFER2_NV                0x8827
-#define GL_DRAW_BUFFER3_NV                0x8828
-#define GL_DRAW_BUFFER4_NV                0x8829
-#define GL_DRAW_BUFFER5_NV                0x882A
-#define GL_DRAW_BUFFER6_NV                0x882B
-#define GL_DRAW_BUFFER7_NV                0x882C
-#define GL_DRAW_BUFFER8_NV                0x882D
-#define GL_DRAW_BUFFER9_NV                0x882E
-#define GL_DRAW_BUFFER10_NV               0x882F
-#define GL_DRAW_BUFFER11_NV               0x8830
-#define GL_DRAW_BUFFER12_NV               0x8831
-#define GL_DRAW_BUFFER13_NV               0x8832
-#define GL_DRAW_BUFFER14_NV               0x8833
-#define GL_DRAW_BUFFER15_NV               0x8834
-#define GL_COLOR_ATTACHMENT0_NV           0x8CE0
-#define GL_COLOR_ATTACHMENT1_NV           0x8CE1
-#define GL_COLOR_ATTACHMENT2_NV           0x8CE2
-#define GL_COLOR_ATTACHMENT3_NV           0x8CE3
-#define GL_COLOR_ATTACHMENT4_NV           0x8CE4
-#define GL_COLOR_ATTACHMENT5_NV           0x8CE5
-#define GL_COLOR_ATTACHMENT6_NV           0x8CE6
-#define GL_COLOR_ATTACHMENT7_NV           0x8CE7
-#define GL_COLOR_ATTACHMENT8_NV           0x8CE8
-#define GL_COLOR_ATTACHMENT9_NV           0x8CE9
-#define GL_COLOR_ATTACHMENT10_NV          0x8CEA
-#define GL_COLOR_ATTACHMENT11_NV          0x8CEB
-#define GL_COLOR_ATTACHMENT12_NV          0x8CEC
-#define GL_COLOR_ATTACHMENT13_NV          0x8CED
-#define GL_COLOR_ATTACHMENT14_NV          0x8CEE
-#define GL_COLOR_ATTACHMENT15_NV          0x8CEF
-typedef void (GL_APIENTRYP PFNGLDRAWBUFFERSNVPROC) (GLsizei n, const GLenum *bufs);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glDrawBuffersNV (GLsizei n, const GLenum *bufs);
-#endif
-#endif /* GL_NV_draw_buffers */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
 #ifndef GL_NV_draw_instanced
 #define GL_NV_draw_instanced 1
 typedef void (GL_APIENTRYP PFNGLDRAWARRAYSINSTANCEDNVPROC) (GLenum mode, GLint first, GLsizei count, GLsizei primcount);
@@ -1719,65 +410,7 @@ GL_APICALL void GL_APIENTRY glDrawElementsInstancedNV (GLenum mode, GLsizei coun
 #endif
 #endif /* GL_NV_draw_instanced */
 
-#ifndef GL_NV_explicit_attrib_location
-#define GL_NV_explicit_attrib_location 1
-#endif /* GL_NV_explicit_attrib_location */
-
-#ifndef GL_NV_fbo_color_attachments
-#define GL_NV_fbo_color_attachments 1
-#define GL_MAX_COLOR_ATTACHMENTS_NV       0x8CDF
-#endif /* GL_NV_fbo_color_attachments */
-
-#ifndef GL_NV_fence
-#define GL_NV_fence 1
-#define GL_ALL_COMPLETED_NV               0x84F2
-#define GL_FENCE_STATUS_NV                0x84F3
-#define GL_FENCE_CONDITION_NV             0x84F4
-typedef void (GL_APIENTRYP PFNGLDELETEFENCESNVPROC) (GLsizei n, const GLuint *fences);
-typedef void (GL_APIENTRYP PFNGLGENFENCESNVPROC) (GLsizei n, GLuint *fences);
-typedef GLboolean (GL_APIENTRYP PFNGLISFENCENVPROC) (GLuint fence);
-typedef GLboolean (GL_APIENTRYP PFNGLTESTFENCENVPROC) (GLuint fence);
-typedef void (GL_APIENTRYP PFNGLGETFENCEIVNVPROC) (GLuint fence, GLenum pname, GLint *params);
-typedef void (GL_APIENTRYP PFNGLFINISHFENCENVPROC) (GLuint fence);
-typedef void (GL_APIENTRYP PFNGLSETFENCENVPROC) (GLuint fence, GLenum condition);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glDeleteFencesNV (GLsizei n, const GLuint *fences);
-GL_APICALL void GL_APIENTRY glGenFencesNV (GLsizei n, GLuint *fences);
-GL_APICALL GLboolean GL_APIENTRY glIsFenceNV (GLuint fence);
-GL_APICALL GLboolean GL_APIENTRY glTestFenceNV (GLuint fence);
-GL_APICALL void GL_APIENTRY glGetFenceivNV (GLuint fence, GLenum pname, GLint *params);
-GL_APICALL void GL_APIENTRY glFinishFenceNV (GLuint fence);
-GL_APICALL void GL_APIENTRY glSetFenceNV (GLuint fence, GLenum condition);
-#endif
-#endif /* GL_NV_fence */
-
-#ifndef GL_NV_framebuffer_blit
-#define GL_NV_framebuffer_blit 1
-#define GL_READ_FRAMEBUFFER_NV            0x8CA8
-#define GL_DRAW_FRAMEBUFFER_NV            0x8CA9
-#define GL_DRAW_FRAMEBUFFER_BINDING_NV    0x8CA6
-#define GL_READ_FRAMEBUFFER_BINDING_NV    0x8CAA
-typedef void (GL_APIENTRYP PFNGLBLITFRAMEBUFFERNVPROC) (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glBlitFramebufferNV (GLint srcX0, GLint srcY0, GLint srcX1, GLint srcY1, GLint dstX0, GLint dstY0, GLint dstX1, GLint dstY1, GLbitfield mask, GLenum filter);
-#endif
-#endif /* GL_NV_framebuffer_blit */
-
-#ifndef GL_NV_framebuffer_multisample
-#define GL_NV_framebuffer_multisample 1
-#define GL_RENDERBUFFER_SAMPLES_NV        0x8CAB
-#define GL_FRAMEBUFFER_INCOMPLETE_MULTISAMPLE_NV 0x8D56
-#define GL_MAX_SAMPLES_NV                 0x8D57
-typedef void (GL_APIENTRYP PFNGLRENDERBUFFERSTORAGEMULTISAMPLENVPROC) (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glRenderbufferStorageMultisampleNV (GLenum target, GLsizei samples, GLenum internalformat, GLsizei width, GLsizei height);
-#endif
-#endif /* GL_NV_framebuffer_multisample */
-
-#ifndef GL_NV_generate_mipmap_sRGB
-#define GL_NV_generate_mipmap_sRGB 1
-#endif /* GL_NV_generate_mipmap_sRGB */
-
+// Provided by https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
 #ifndef GL_NV_instanced_arrays
 #define GL_NV_instanced_arrays 1
 #define GL_VERTEX_ATTRIB_ARRAY_DIVISOR_NV 0x88FE
@@ -1786,230 +419,6 @@ typedef void (GL_APIENTRYP PFNGLVERTEXATTRIBDIVISORNVPROC) (GLuint index, GLuint
 GL_APICALL void GL_APIENTRY glVertexAttribDivisorNV (GLuint index, GLuint divisor);
 #endif
 #endif /* GL_NV_instanced_arrays */
-
-#ifndef GL_NV_non_square_matrices
-#define GL_NV_non_square_matrices 1
-#define GL_FLOAT_MAT2x3_NV                0x8B65
-#define GL_FLOAT_MAT2x4_NV                0x8B66
-#define GL_FLOAT_MAT3x2_NV                0x8B67
-#define GL_FLOAT_MAT3x4_NV                0x8B68
-#define GL_FLOAT_MAT4x2_NV                0x8B69
-#define GL_FLOAT_MAT4x3_NV                0x8B6A
-typedef void (GL_APIENTRYP PFNGLUNIFORMMATRIX2X3FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLUNIFORMMATRIX3X2FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLUNIFORMMATRIX2X4FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLUNIFORMMATRIX4X2FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLUNIFORMMATRIX3X4FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-typedef void (GL_APIENTRYP PFNGLUNIFORMMATRIX4X3FVNVPROC) (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glUniformMatrix2x3fvNV (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glUniformMatrix3x2fvNV (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glUniformMatrix2x4fvNV (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glUniformMatrix4x2fvNV (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glUniformMatrix3x4fvNV (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-GL_APICALL void GL_APIENTRY glUniformMatrix4x3fvNV (GLint location, GLsizei count, GLboolean transpose, const GLfloat *value);
-#endif
-#endif /* GL_NV_non_square_matrices */
-
-#ifndef GL_NV_read_buffer
-#define GL_NV_read_buffer 1
-#define GL_READ_BUFFER_NV                 0x0C02
-typedef void (GL_APIENTRYP PFNGLREADBUFFERNVPROC) (GLenum mode);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glReadBufferNV (GLenum mode);
-#endif
-#endif /* GL_NV_read_buffer */
-
-#ifndef GL_NV_read_buffer_front
-#define GL_NV_read_buffer_front 1
-#endif /* GL_NV_read_buffer_front */
-
-#ifndef GL_NV_read_depth
-#define GL_NV_read_depth 1
-#endif /* GL_NV_read_depth */
-
-#ifndef GL_NV_read_depth_stencil
-#define GL_NV_read_depth_stencil 1
-#endif /* GL_NV_read_depth_stencil */
-
-#ifndef GL_NV_read_stencil
-#define GL_NV_read_stencil 1
-#endif /* GL_NV_read_stencil */
-
-#ifndef GL_NV_sRGB_formats
-#define GL_NV_sRGB_formats 1
-#define GL_SLUMINANCE_NV                  0x8C46
-#define GL_SLUMINANCE_ALPHA_NV            0x8C44
-#define GL_SRGB8_NV                       0x8C41
-#define GL_SLUMINANCE8_NV                 0x8C47
-#define GL_SLUMINANCE8_ALPHA8_NV          0x8C45
-#define GL_COMPRESSED_SRGB_S3TC_DXT1_NV   0x8C4C
-#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_NV 0x8C4D
-#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_NV 0x8C4E
-#define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_NV 0x8C4F
-#define GL_ETC1_SRGB8_NV                  0x88EE
-#endif /* GL_NV_sRGB_formats */
-
-#ifndef GL_NV_shadow_samplers_array
-#define GL_NV_shadow_samplers_array 1
-#define GL_SAMPLER_2D_ARRAY_SHADOW_NV     0x8DC4
-#endif /* GL_NV_shadow_samplers_array */
-
-#ifndef GL_NV_shadow_samplers_cube
-#define GL_NV_shadow_samplers_cube 1
-#define GL_SAMPLER_CUBE_SHADOW_NV         0x8DC5
-#endif /* GL_NV_shadow_samplers_cube */
-
-#ifndef GL_NV_texture_border_clamp
-#define GL_NV_texture_border_clamp 1
-#define GL_TEXTURE_BORDER_COLOR_NV        0x1004
-#define GL_CLAMP_TO_BORDER_NV             0x812D
-#endif /* GL_NV_texture_border_clamp */
-
-#ifndef GL_NV_texture_compression_s3tc_update
-#define GL_NV_texture_compression_s3tc_update 1
-#endif /* GL_NV_texture_compression_s3tc_update */
-
-#ifndef GL_NV_texture_npot_2D_mipmap
-#define GL_NV_texture_npot_2D_mipmap 1
-#endif /* GL_NV_texture_npot_2D_mipmap */
-
-#ifndef GL_QCOM_alpha_test
-#define GL_QCOM_alpha_test 1
-#define GL_ALPHA_TEST_QCOM                0x0BC0
-#define GL_ALPHA_TEST_FUNC_QCOM           0x0BC1
-#define GL_ALPHA_TEST_REF_QCOM            0x0BC2
-typedef void (GL_APIENTRYP PFNGLALPHAFUNCQCOMPROC) (GLenum func, GLclampf ref);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glAlphaFuncQCOM (GLenum func, GLclampf ref);
-#endif
-#endif /* GL_QCOM_alpha_test */
-
-#ifndef GL_QCOM_binning_control
-#define GL_QCOM_binning_control 1
-#define GL_BINNING_CONTROL_HINT_QCOM      0x8FB0
-#define GL_CPU_OPTIMIZED_QCOM             0x8FB1
-#define GL_GPU_OPTIMIZED_QCOM             0x8FB2
-#define GL_RENDER_DIRECT_TO_FRAMEBUFFER_QCOM 0x8FB3
-#endif /* GL_QCOM_binning_control */
-
-#ifndef GL_QCOM_driver_control
-#define GL_QCOM_driver_control 1
-typedef void (GL_APIENTRYP PFNGLGETDRIVERCONTROLSQCOMPROC) (GLint *num, GLsizei size, GLuint *driverControls);
-typedef void (GL_APIENTRYP PFNGLGETDRIVERCONTROLSTRINGQCOMPROC) (GLuint driverControl, GLsizei bufSize, GLsizei *length, GLchar *driverControlString);
-typedef void (GL_APIENTRYP PFNGLENABLEDRIVERCONTROLQCOMPROC) (GLuint driverControl);
-typedef void (GL_APIENTRYP PFNGLDISABLEDRIVERCONTROLQCOMPROC) (GLuint driverControl);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glGetDriverControlsQCOM (GLint *num, GLsizei size, GLuint *driverControls);
-GL_APICALL void GL_APIENTRY glGetDriverControlStringQCOM (GLuint driverControl, GLsizei bufSize, GLsizei *length, GLchar *driverControlString);
-GL_APICALL void GL_APIENTRY glEnableDriverControlQCOM (GLuint driverControl);
-GL_APICALL void GL_APIENTRY glDisableDriverControlQCOM (GLuint driverControl);
-#endif
-#endif /* GL_QCOM_driver_control */
-
-#ifndef GL_QCOM_extended_get
-#define GL_QCOM_extended_get 1
-#define GL_TEXTURE_WIDTH_QCOM             0x8BD2
-#define GL_TEXTURE_HEIGHT_QCOM            0x8BD3
-#define GL_TEXTURE_DEPTH_QCOM             0x8BD4
-#define GL_TEXTURE_INTERNAL_FORMAT_QCOM   0x8BD5
-#define GL_TEXTURE_FORMAT_QCOM            0x8BD6
-#define GL_TEXTURE_TYPE_QCOM              0x8BD7
-#define GL_TEXTURE_IMAGE_VALID_QCOM       0x8BD8
-#define GL_TEXTURE_NUM_LEVELS_QCOM        0x8BD9
-#define GL_TEXTURE_TARGET_QCOM            0x8BDA
-#define GL_TEXTURE_OBJECT_VALID_QCOM      0x8BDB
-#define GL_STATE_RESTORE                  0x8BDC
-typedef void (GL_APIENTRYP PFNGLEXTGETTEXTURESQCOMPROC) (GLuint *textures, GLint maxTextures, GLint *numTextures);
-typedef void (GL_APIENTRYP PFNGLEXTGETBUFFERSQCOMPROC) (GLuint *buffers, GLint maxBuffers, GLint *numBuffers);
-typedef void (GL_APIENTRYP PFNGLEXTGETRENDERBUFFERSQCOMPROC) (GLuint *renderbuffers, GLint maxRenderbuffers, GLint *numRenderbuffers);
-typedef void (GL_APIENTRYP PFNGLEXTGETFRAMEBUFFERSQCOMPROC) (GLuint *framebuffers, GLint maxFramebuffers, GLint *numFramebuffers);
-typedef void (GL_APIENTRYP PFNGLEXTGETTEXLEVELPARAMETERIVQCOMPROC) (GLuint texture, GLenum face, GLint level, GLenum pname, GLint *params);
-typedef void (GL_APIENTRYP PFNGLEXTTEXOBJECTSTATEOVERRIDEIQCOMPROC) (GLenum target, GLenum pname, GLint param);
-typedef void (GL_APIENTRYP PFNGLEXTGETTEXSUBIMAGEQCOMPROC) (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, void *texels);
-typedef void (GL_APIENTRYP PFNGLEXTGETBUFFERPOINTERVQCOMPROC) (GLenum target, void **params);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glExtGetTexturesQCOM (GLuint *textures, GLint maxTextures, GLint *numTextures);
-GL_APICALL void GL_APIENTRY glExtGetBuffersQCOM (GLuint *buffers, GLint maxBuffers, GLint *numBuffers);
-GL_APICALL void GL_APIENTRY glExtGetRenderbuffersQCOM (GLuint *renderbuffers, GLint maxRenderbuffers, GLint *numRenderbuffers);
-GL_APICALL void GL_APIENTRY glExtGetFramebuffersQCOM (GLuint *framebuffers, GLint maxFramebuffers, GLint *numFramebuffers);
-GL_APICALL void GL_APIENTRY glExtGetTexLevelParameterivQCOM (GLuint texture, GLenum face, GLint level, GLenum pname, GLint *params);
-GL_APICALL void GL_APIENTRY glExtTexObjectStateOverrideiQCOM (GLenum target, GLenum pname, GLint param);
-GL_APICALL void GL_APIENTRY glExtGetTexSubImageQCOM (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLint zoffset, GLsizei width, GLsizei height, GLsizei depth, GLenum format, GLenum type, void *texels);
-GL_APICALL void GL_APIENTRY glExtGetBufferPointervQCOM (GLenum target, void **params);
-#endif
-#endif /* GL_QCOM_extended_get */
-
-#ifndef GL_QCOM_extended_get2
-#define GL_QCOM_extended_get2 1
-typedef void (GL_APIENTRYP PFNGLEXTGETSHADERSQCOMPROC) (GLuint *shaders, GLint maxShaders, GLint *numShaders);
-typedef void (GL_APIENTRYP PFNGLEXTGETPROGRAMSQCOMPROC) (GLuint *programs, GLint maxPrograms, GLint *numPrograms);
-typedef GLboolean (GL_APIENTRYP PFNGLEXTISPROGRAMBINARYQCOMPROC) (GLuint program);
-typedef void (GL_APIENTRYP PFNGLEXTGETPROGRAMBINARYSOURCEQCOMPROC) (GLuint program, GLenum shadertype, GLchar *source, GLint *length);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glExtGetShadersQCOM (GLuint *shaders, GLint maxShaders, GLint *numShaders);
-GL_APICALL void GL_APIENTRY glExtGetProgramsQCOM (GLuint *programs, GLint maxPrograms, GLint *numPrograms);
-GL_APICALL GLboolean GL_APIENTRY glExtIsProgramBinaryQCOM (GLuint program);
-GL_APICALL void GL_APIENTRY glExtGetProgramBinarySourceQCOM (GLuint program, GLenum shadertype, GLchar *source, GLint *length);
-#endif
-#endif /* GL_QCOM_extended_get2 */
-
-#ifndef GL_QCOM_perfmon_global_mode
-#define GL_QCOM_perfmon_global_mode 1
-#define GL_PERFMON_GLOBAL_MODE_QCOM       0x8FA0
-#endif /* GL_QCOM_perfmon_global_mode */
-
-#ifndef GL_QCOM_tiled_rendering
-#define GL_QCOM_tiled_rendering 1
-#define GL_COLOR_BUFFER_BIT0_QCOM         0x00000001
-#define GL_COLOR_BUFFER_BIT1_QCOM         0x00000002
-#define GL_COLOR_BUFFER_BIT2_QCOM         0x00000004
-#define GL_COLOR_BUFFER_BIT3_QCOM         0x00000008
-#define GL_COLOR_BUFFER_BIT4_QCOM         0x00000010
-#define GL_COLOR_BUFFER_BIT5_QCOM         0x00000020
-#define GL_COLOR_BUFFER_BIT6_QCOM         0x00000040
-#define GL_COLOR_BUFFER_BIT7_QCOM         0x00000080
-#define GL_DEPTH_BUFFER_BIT0_QCOM         0x00000100
-#define GL_DEPTH_BUFFER_BIT1_QCOM         0x00000200
-#define GL_DEPTH_BUFFER_BIT2_QCOM         0x00000400
-#define GL_DEPTH_BUFFER_BIT3_QCOM         0x00000800
-#define GL_DEPTH_BUFFER_BIT4_QCOM         0x00001000
-#define GL_DEPTH_BUFFER_BIT5_QCOM         0x00002000
-#define GL_DEPTH_BUFFER_BIT6_QCOM         0x00004000
-#define GL_DEPTH_BUFFER_BIT7_QCOM         0x00008000
-#define GL_STENCIL_BUFFER_BIT0_QCOM       0x00010000
-#define GL_STENCIL_BUFFER_BIT1_QCOM       0x00020000
-#define GL_STENCIL_BUFFER_BIT2_QCOM       0x00040000
-#define GL_STENCIL_BUFFER_BIT3_QCOM       0x00080000
-#define GL_STENCIL_BUFFER_BIT4_QCOM       0x00100000
-#define GL_STENCIL_BUFFER_BIT5_QCOM       0x00200000
-#define GL_STENCIL_BUFFER_BIT6_QCOM       0x00400000
-#define GL_STENCIL_BUFFER_BIT7_QCOM       0x00800000
-#define GL_MULTISAMPLE_BUFFER_BIT0_QCOM   0x01000000
-#define GL_MULTISAMPLE_BUFFER_BIT1_QCOM   0x02000000
-#define GL_MULTISAMPLE_BUFFER_BIT2_QCOM   0x04000000
-#define GL_MULTISAMPLE_BUFFER_BIT3_QCOM   0x08000000
-#define GL_MULTISAMPLE_BUFFER_BIT4_QCOM   0x10000000
-#define GL_MULTISAMPLE_BUFFER_BIT5_QCOM   0x20000000
-#define GL_MULTISAMPLE_BUFFER_BIT6_QCOM   0x40000000
-#define GL_MULTISAMPLE_BUFFER_BIT7_QCOM   0x80000000
-typedef void (GL_APIENTRYP PFNGLSTARTTILINGQCOMPROC) (GLuint x, GLuint y, GLuint width, GLuint height, GLbitfield preserveMask);
-typedef void (GL_APIENTRYP PFNGLENDTILINGQCOMPROC) (GLbitfield preserveMask);
-#ifdef GL_GLEXT_PROTOTYPES
-GL_APICALL void GL_APIENTRY glStartTilingQCOM (GLuint x, GLuint y, GLuint width, GLuint height, GLbitfield preserveMask);
-GL_APICALL void GL_APIENTRY glEndTilingQCOM (GLbitfield preserveMask);
-#endif
-#endif /* GL_QCOM_tiled_rendering */
-
-#ifndef GL_QCOM_writeonly_rendering
-#define GL_QCOM_writeonly_rendering 1
-#define GL_WRITEONLY_RENDERING_QCOM       0x8823
-#endif /* GL_QCOM_writeonly_rendering */
-
-#ifndef GL_VIV_shader_binary
-#define GL_VIV_shader_binary 1
-#define GL_SHADER_BINARY_VIV              0x8FC4
-#endif /* GL_VIV_shader_binary */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Remove from #include <GLES3/gl2ext.h> references to all GLES2&GLES3 extensions that are not supported by either WebGL 1 or 2.

Our gl2ext.h file has been historically pulled in as-is from the Khronos reference header file. This header file contains declarations of all extensions that OpenGL ES 2.0, 3.0, 3.1 and 3.2 collectively recognize. Naturally for Emscripten & WebGL, we only support a tiny subset of those, but our header has had the full list, which would lead to builds passing but giving a warning of an undeclared symbol at link time, like seen in #4408.

It is better to have Emscripten not even recognize any GL extensions that it doesn't support, since that will allow build errors to occur directly at compile time instead of link time (currently in link time those are warnings, but after the long standing #2714 is implemented, those would also be errors).

Also, I think it will be good to start adding declarations and #define symbols of WebGL specific extensions. In this PR I've done this for a couple that we support, more can be added as support is added. Not sure though, perhaps we'll like to have those in `#include <emscripten/webgl.h>` and `#include <emscripten/webglext.h>` instead.
