### PR TITLE
Misc optimizer fixes

### DIFF
--- a/tools/optimizer/optimizer.cpp
+++ b/tools/optimizer/optimizer.cpp
@@ -3691,13 +3691,16 @@ void minifyLocals(Ref ast) {
 void asmLastOpts(Ref ast) {
   std::vector<Ref> statsStack;
   traverseFunctions(ast, [&](Ref fun) {
+    traversePre(fun, [&](Ref node) {
+      Ref type = node[0];
+      if (CONDITION_CHECKERS.has(type)) {
+        node[1] = simplifyCondition(node[1]);
+      }
+    });
     traversePrePost(fun, [&](Ref node) {
       Ref type = node[0];
       Ref stats = getStatements(node);
       if (!!stats) statsStack.push_back(stats);
-      if (CONDITION_CHECKERS.has(type)) {
-        node[1] = simplifyCondition(node[1]);
-      }
       if (type == WHILE && node[1][0] == NUM && node[1][1]->getNumber() == 1 && node[2][0] == BLOCK && node[2]->size() == 2) {
         // This is at the end of the pipeline, we can assume all other optimizations are done, and we modify loops
         // into shapes that might confuse other passes

--- a/tools/optimizer/parser.cpp
+++ b/tools/optimizer/parser.cpp
@@ -20,7 +20,6 @@ IString TOPLEVEL("toplevel"),
         ELSE("else"),
         WHILE("while"),
         DO("do"),
-        FOR("for"),
         SEQ("seq"),
         SUB("sub"),
         CALL("call"),
@@ -89,9 +88,9 @@ IString TOPLEVEL("toplevel"),
         NEW("new"),
         ARRAY("array"),
         OBJECT("object"),
-        THROW("throw"),
         SET("=");
 
+// Regardless of whether they're asm.js or not, keywords should be here to avoid treating them as idents
 IStringSet keywords("var const function if else do while for break continue return switch case default throw try catch finally true false null new");
 
 const char *OPERATOR_INITS = "+-*/%<>&^|~=!,?:.",

--- a/tools/optimizer/parser.h
+++ b/tools/optimizer/parser.h
@@ -33,7 +33,6 @@ extern IString TOPLEVEL,
                ELSE,
                WHILE,
                DO,
-               FOR,
                SEQ,
                SUB,
                CALL,
@@ -102,7 +101,6 @@ extern IString TOPLEVEL,
                NEW,
                ARRAY,
                OBJECT,
-               THROW,
                SET;
 
 extern IStringSet keywords;


### PR DESCRIPTION
The first commit is pretty boring - it removes some mentions of `function` and `for` in the context of being an ast node (since neither of them are actually created by the parser).

The second fixes the optimisation of things like

```
function x($p) {
 $p = $p | 0;
 while (1) {
  if (($p | 0) == 0) {
   break;
  }
 }
 return;
}
```

Previously:

```
/work $ ./emsdk/emscripten/incoming_64bit_optimizer/optimizer test.js asm asmLastOpts
function x($p) {
 $p = $p | 0;
 do {} while (($p | 0) != 0);
 return;
}
```

Now:

```
/work $ ./emsdk/emscripten/incoming_64bit_optimizer/optimizer test.js asm asmLastOpts
function x($p) {
 $p = $p | 0;
 do {} while ($p);
 return;
}
```

The problem (as described in the commit message) is that the `while () { if () {break} }` -> `do {} while ()` transformation lifts out the condition before the condition simplifier can get to it.

I'm mainly submitting this PR so you can tell me if this is a valid optimisation :wink: - I noticed it when working on my rust optimizer.
