### PR TITLE
Improve error message for missing .emscripten file to advice "/emsdk activate latest" usage

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -204,7 +204,7 @@ if EM_CONFIG and not os.path.isfile(EM_CONFIG):
   if EM_CONFIG.startswith('-'):
     raise Exception('Passed --em-config without an argument. Usage: --em-config /path/to/.emscripten or --em-config EMSCRIPTEN_ROOT=/path/;LLVM_ROOT=/path;...')
   if not '=' in EM_CONFIG:
-    raise Exception('File ' + EM_CONFIG + ' passed to --em-config does not exist! Call "./emsdk activate latest" to do this for you')
+    raise Exception('File ' + EM_CONFIG + ' passed to --em-config does not exist! Call "./emsdk activate latest" to create this file for you')
   else:
     EM_CONFIG = EM_CONFIG.replace(';', '\n') + '\n'
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -204,7 +204,7 @@ if EM_CONFIG and not os.path.isfile(EM_CONFIG):
   if EM_CONFIG.startswith('-'):
     raise Exception('Passed --em-config without an argument. Usage: --em-config /path/to/.emscripten or --em-config EMSCRIPTEN_ROOT=/path/;LLVM_ROOT=/path;...')
   if not '=' in EM_CONFIG:
-    raise Exception('File ' + EM_CONFIG + ' passed to --em-config does not exist!')
+    raise Exception('File ' + EM_CONFIG + ' passed to --em-config does not exist! Call "./emsdk activate latest" to do this for you')
   else:
     EM_CONFIG = EM_CONFIG.replace(';', '\n') + '\n'
 


### PR DESCRIPTION
First PR :)
Based on this: [installing-the-portable-sdk](http://kripken.github.io/emscripten-site/docs/getting_started/downloads.html#windows-osx-and-linux-installing-the-portable-sdk)

If you missed this step:

```
# Make the "latest" SDK "active"
./emsdk activate latest
```

The result will be something like:

```
./emcc tests/hello_world.c
Traceback (most recent call last):
  File "./emcc", line 11, in <module>
    import emcc
  File "/home/sh/REPOS/emscripten/emsdk_portable/emscripten/master/emcc.py", line 28, in <module>
    from tools import shared, jsrun, system_libs
  File "/home/sh/REPOS/emscripten/emsdk_portable/emscripten/master/tools/shared.py", line 205, in <module>
    raise Exception('File ' + EM_CONFIG + ' passed to --em-config does not exist!')
Exception: File /home/sh/.emscripten passed to --em-config does not exist!
```

It took me some time to figure out that, I have missed something.
The raised exception message is not quite informative so basically it can be improved to something like:

```
if EM_CONFIG and not os.path.isfile(EM_CONFIG):
  if EM_CONFIG.startswith('-'):
    raise Exception('Passed --em-config without an argument. Usage: --em-config /path/to/.emscripten or --em-config EMSCRIPTEN_ROOT=/path/;LLVM_ROOT=/path;...')
  if not '=' in EM_CONFIG:
    raise Exception('File ' + EM_CONFIG + ' passed to --em-config does not exist! Call "./emsdk activate latest" to create this file for you')
  else:
    EM_CONFIG = EM_CONFIG.replace(';', '\n') + '\n'
```
