### PR TITLE
Add failing test for overriding a method overloaded in the parent with embind

### DIFF
--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -876,6 +876,27 @@ module({
             p.delete();
         });
 */
+
+        test("overriding an overloaded function from the parent", function() {
+            var override_method_proto = cm.OverridesOverloadedDummy.prototype.dummy;
+            var parent_method_proto = cm.MultipleOverloadsDependingOnDummy.prototype.dummy;
+            if (override_method_proto.hasOwnProperty('overloadTable')) {
+                assert.true(override_method_proto.hasOwnProperty('overloadTable'));
+                assert.true(parent_method_proto.hasOwnProperty('overloadTable'));
+                // modify one overloadTable
+                override_method_proto.overloadTable.test = "test";
+                // the other should remain untouched
+                assert.false(parent_method_proto.overloadTable.hasOwnProperty('test'));
+            }
+
+            //calling the functions now
+            var o = new cm.OverridesOverloadedDummy();
+            var d = o.dummy();
+            // should still be able to call the parent functions
+            var p = new cm.MultipleOverloadsDependingOnDummy();
+            d = p.dummy();
+            d = p.dummy(d);
+        });
     });
 
     BaseFixture.extend("vector", function() {

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -2294,6 +2294,26 @@ struct ConstAndNonConst {
     }
 };
 
+class DummyForOverloads {};
+
+class MultipleOverloadsDependingOnDummy {
+public:
+    DummyForOverloads dummy() {
+        return DummyForOverloads();
+    }
+
+    virtual DummyForOverloads dummy(DummyForOverloads d) {
+        return d;
+    }
+};
+
+class OverridesOverloadedDummy : public MultipleOverloadsDependingOnDummy{
+public:
+    virtual DummyForOverloads dummy() {
+        return DummyForOverloads();
+    }
+};
+
 EMSCRIPTEN_BINDINGS(overloads) {
     function("overloaded_function", select_overload<int(int)>(&overloaded_function));
     function("overloaded_function", select_overload<int(int, int)>(&overloaded_function));
@@ -2336,6 +2356,19 @@ EMSCRIPTEN_BINDINGS(overloads) {
 
     class_<ConstAndNonConst>("ConstAndNonConst")
         .function("method", select_const(&ConstAndNonConst::method))
+        ;
+
+    class_<DummyForOverloads>("DummyForOverloads").constructor();
+
+    class_<MultipleOverloadsDependingOnDummy>("MultipleOverloadsDependingOnDummy")
+        .constructor()
+        .function("dummy", select_overload<DummyForOverloads()>(&MultipleOverloadsDependingOnDummy::dummy))
+        .function("dummy", select_overload<DummyForOverloads(DummyForOverloads)>(&MultipleOverloadsDependingOnDummy::dummy))
+        ;
+
+    class_<OverridesOverloadedDummy,base<MultipleOverloadsDependingOnDummy>>("OverridesOverloadedDummy")
+        .constructor()
+        .function("dummy", &OverridesOverloadedDummy::dummy)
         ;
 }
 


### PR DESCRIPTION
There is an issue with embind where adding an override for an overloaded function in the parent will replace the original method even in the parent.
The problem is that the two `overloadTable`s are the same object, so are both modified when registering the override.

I couldn't find a fix yet, but here is a failing test to reproduce the issue.
The failing assert is 
```
assert.false(parent_method_proto.overloadTable.hasOwnProperty('test'))
```
Even when commenting it, the test still fails, since the parent method is replaced by the child's method. When trying to call the parent method, embind asks for an instance of the child.