### PR TITLE
EGL: add support for WebGL context attributes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -326,3 +326,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Kibeom Kim <kk1674@nyu.edu>
 * Marcel Klammer <m.klammer@tastenkunst.com>
 * Axel Forsman <axelsfor@gmail.com>
+* Scott Percival <code@moral.net.au>

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -37,7 +37,7 @@ var LibraryEGL = {
         EGL.setErrorCode(0x300C /* EGL_BAD_PARAMETER */);
         return 0;
       }
-      for(;;) {
+      while (1) {
         var param = {{{ makeGetValue('attribList', '0', 'i32') }}};
         if (param == 0x3038) { // EGL_NONE
           break;
@@ -159,7 +159,7 @@ var LibraryEGL = {
       {{{ makeSetValue('value', '0', '32' /* 8 bits for each A,R,G,B. */, 'i32') }}};
       return 1;
     case 0x3021: // EGL_ALPHA_SIZE
-      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.alpha?8:0' /* 8 bits for alpha channel. */, 'i32') }}};
+      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.alpha ? 8 : 0' /* 8 bits for alpha channel. */, 'i32') }}};
       return 1;
     case 0x3022: // EGL_BLUE_SIZE
       {{{ makeSetValue('value', '0', '8' /* 8 bits for blue channel. */, 'i32') }}};
@@ -171,10 +171,10 @@ var LibraryEGL = {
       {{{ makeSetValue('value', '0', '8' /* 8 bits for red channel. */, 'i32') }}};
       return 1;
     case 0x3025: // EGL_DEPTH_SIZE
-      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.depth?24:0' /* 24 bits for depth buffer. */, 'i32') }}};
+      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.depth ? 24 : 0' /* 24 bits for depth buffer. */, 'i32') }}};
       return 1;
     case 0x3026: // EGL_STENCIL_SIZE
-      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.stencil?8:0' /* 8 bits for stencil buffer. */, 'i32') }}};
+      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.stencil ? 8 : 0' /* 8 bits for stencil buffer. */, 'i32') }}};
       return 1;
     case 0x3027: // EGL_CONFIG_CAVEAT
       // We can return here one of EGL_NONE (0x3038), EGL_SLOW_CONFIG (0x3050) or EGL_NON_CONFORMANT_CONFIG (0x3051).
@@ -205,10 +205,10 @@ var LibraryEGL = {
       {{{ makeSetValue('value', '0', '0x3038' /* EGL_NONE */, 'i32') }}};
       return 1;
     case 0x3031: // EGL_SAMPLES
-      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.antialias?4:0' /* 2x2 Multisampling */, 'i32') }}};
+      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.antialias ? 4 : 0' /* 2x2 Multisampling */, 'i32') }}};
       return 1;
     case 0x3032: // EGL_SAMPLE_BUFFERS
-      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.antialias?1:0' /* Multisampling enabled */, 'i32') }}};
+      {{{ makeSetValue('value', '0', 'EGL.contextAttributes.antialias ? 1 : 0' /* Multisampling enabled */, 'i32') }}};
       return 1;
     case 0x3033: // EGL_SURFACE_TYPE
       {{{ makeSetValue('value', '0', '0x0004' /* EGL_WINDOW_BIT */, 'i32') }}};
@@ -303,7 +303,7 @@ var LibraryEGL = {
     // EGL 1.4 spec says default EGL_CONTEXT_CLIENT_VERSION is GLES1, but this is not supported by Emscripten.
     // So user must pass EGL_CONTEXT_CLIENT_VERSION == 2 to initialize EGL.
     var glesContextVersion = 1;
-    for(;;) {
+    while (1) {
       var param = {{{ makeGetValue('contextAttribs', '0', 'i32') }}};
       if (param == 0x3098 /*EGL_CONTEXT_CLIENT_VERSION*/) {
         glesContextVersion = {{{ makeGetValue('contextAttribs', '4', 'i32') }}};

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -119,6 +119,12 @@ var LibraryEGL = {
     EGL.currentReadSurface = 0;
     EGL.currentDrawSurface = 0;
     EGL.defaultDisplayInitialized = false;
+    EGL.contextAttributes = {
+      alpha: false,
+      depth: false,
+      stencil: false,
+      antialias: false
+    };
     EGL.setErrorCode(0x3000 /* EGL_SUCCESS */);
     return 1;
   },

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -42,11 +42,11 @@ var LibraryEGL = {
     chooseConfig: function(display, attribList, config, config_size, numConfigs) { 
       if (display != 62000 /* Magic ID for Emscripten 'default display' */) {
         EGL.setErrorCode(0x3008 /* EGL_BAD_DISPLAY */);
-        return 0;
+        return 0; // EGL_FALSE
       }
       if ((!config || !config_size) && !numConfigs) {
         EGL.setErrorCode(0x300C /* EGL_BAD_PARAMETER */);
-        return 0;
+        return 0; // EGL_FALSE
       }
 
       // config variables to compare against
@@ -61,6 +61,10 @@ var LibraryEGL = {
           var param = {{{ makeGetValue('attribList', '0', 'i32') }}};
           if (param == 0x3038) { // EGL_NONE
             break;
+          // Check that the attribute ID is within range
+          } else if ((param < 0x3020) || (param > 0x3042)) {
+            EGL.setErrorCode(0x3004 /* EGL_BAD_ATTRIBUTE */);
+            return 0; // EGL_FALSE            
           }
 
           var value = {{{ makeGetValue('attribList', '4', 'i32') }}};
@@ -89,7 +93,7 @@ var LibraryEGL = {
         }
       }
       var configCount = 0;
-      for (var i=0; i<EGL.configAttribs.length; i++) {
+      for (var i = 0; i < EGL.configAttribs.length; i++) {
         if (EGL.configAttribs[i].alpha >= alpha &&
           EGL.configAttribs[i].samples >= samples &&
           EGL.configAttribs[i].buffers >= buffers &&
@@ -110,7 +114,7 @@ var LibraryEGL = {
       }
       
       EGL.setErrorCode(0x3000 /* EGL_SUCCESS */);
-      return 1;
+      return 1; // EGL_TRUE
     },
   },
 


### PR DESCRIPTION
WebGL allows limited configuration of the rendering context with a set of boolean [context attributes](https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext). The equivalent in EGL would be some of the attributes passed to [eglChooseConfig](https://www.khronos.org/registry/egl/sdk/docs/man/html/eglChooseConfig.xhtml) before creating the context. Right now the EGL shim has the 'depth', 'stencil' and 'antialias' attributes hardcoded to true by default, which can cause issues (e.g. https://github.com/kripken/emscripten/issues/4730). Patch makes EGL watch for positive requests for EGL_DEPTH_SIZE, EGL_STENCIL_SIZE, EGL_SAMPLE_BUFFERS and EGL_ALPHA_SIZE, and passes them as flags to glutInitDisplayMode, which in turn passes them to HTMLCanvasElement.getContext

Tests run: browser.test_egl*, browser.test_gl*, browser.test_sdl*