### PR TITLE
gl_state_cache

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1149,6 +1149,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         next_arg_index += 1
         js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
 
+      # If using GL state cache, compile in the C/C++ side caching mechanism.
+      if shared.Settings.GL_STATE_CACHE and shared.Settings.LEGACY_GL_EMULATION:
+          logging.error('-s GL_STATE_CACHE=1 cannot be applied when -s LEGACY_GL_EMULATION=1 is set!')
+          sys.exit(1)
+
       forced_stdlibs = []
       if shared.Settings.DEMANGLE_SUPPORT:
         shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']

--- a/src/settings.js
+++ b/src/settings.js
@@ -261,6 +261,9 @@ var GL_DEBUG = 0; // Print out all calls into WebGL. As with LIBRARY_DEBUG, you 
 var GL_TESTING = 0; // When enabled, sets preserveDrawingBuffer in the context, to allow tests to work (but adds overhead)
 var GL_MAX_TEMP_BUFFER_SIZE = 2097152; // How large GL emulation temp buffers are
 var GL_UNSAFE_OPTS = 1; // Enables some potentially-unsafe optimizations in GL emulation code
+var GL_STATE_CACHE = 0; // Enables a client side GL state cache, which can improve performance by optimizing out redundant state sets.
+                        // If the GL application commonly sets GL state redundantly, this can be a big performance win. However if the
+                        // application is already efficient in avoiding redundant GL state calls, this can even degrade performance.
 var FULL_ES2 = 0;   // Forces support for all GLES2 features, not just the WebGL-friendly subset.
 var USE_WEBGL2 = 0; // Enables WebGL2 native functions. This mode will also create a WebGL2
                     // context by default if no version is specified.

--- a/system/lib/gl_cache.c
+++ b/system/lib/gl_cache.c
@@ -1,0 +1,216 @@
+#include <GLES2/gl2.h>
+#include <GLES3/gl3.h>
+
+static GLuint _GL_ARRAY_BUFFER_BINDING = 0;
+static GLuint _GL_ELEMENT_ARRAY_BUFFER_BINDING = 0;
+
+GL_APICALL void GL_APIENTRY _emscripten_glBindBuffer(GLenum target, GLuint buffer);
+GL_APICALL void GL_APIENTRY _emscripten_glVertexAttribDivisor(GLuint index, GLuint divisor);
+GL_APICALL void GL_APIENTRY _emscripten_glEnableVertexAttribArray(GLuint index);
+GL_APICALL void GL_APIENTRY _emscripten_glDisableVertexAttribArray(GLuint index);
+GL_APICALL void GL_APIENTRY _emscripten_glUseProgram(GLuint program);
+GL_APICALL void GL_APIENTRY _emscripten_glActiveTexture(GLenum texture);
+GL_APICALL void GL_APIENTRY _emscripten_glDrawArrays(GLenum mode, GLint first, GLsizei count);
+GL_APICALL void GL_APIENTRY _emscripten_glDrawElements(GLenum mode, GLsizei count, GLenum type, const void *indices);
+GL_APICALL void GL_APIENTRY _emscripten_glDrawRangeElements(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void *indices);
+GL_APICALL void GL_APIENTRY _emscripten_glDrawArraysInstanced(GLenum mode, GLint first, GLsizei count, GLsizei instancecount);
+GL_APICALL void GL_APIENTRY _emscripten_glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount);
+GL_APICALL void GL_APIENTRY _emscripten_glVertexAttribPointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer);
+GL_APICALL void GL_APIENTRY _emscripten_glBindTexture(GLenum target, GLuint texture);
+GL_APICALL void GL_APIENTRY _emscripten_glTexParameterf(GLenum target, GLenum pname, GLfloat param);
+GL_APICALL void GL_APIENTRY _emscripten_glTexParameterfv(GLenum target, GLenum pname, const GLfloat *params);
+GL_APICALL void GL_APIENTRY _emscripten_glTexParameteri(GLenum target, GLenum pname, GLint param);
+GL_APICALL void GL_APIENTRY _emscripten_glTexParameteriv(GLenum target, GLenum pname, const GLint *params);
+GL_APICALL void GL_APIENTRY _emscripten_glGenerateMipmap(GLenum target);
+GL_APICALL void GL_APIENTRY _emscripten_glTexImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void *pixels);
+GL_APICALL void GL_APIENTRY _emscripten_glTexStorage2D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height);
+GL_APICALL void GL_APIENTRY _emscripten_glTexSubImage2D(GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void *pixels);
+
+
+GL_APICALL void GL_APIENTRY glBindBuffer(GLenum target, GLuint buffer)
+{
+  if (target == GL_ARRAY_BUFFER)
+  {
+    if (_GL_ARRAY_BUFFER_BINDING == buffer) return;
+    _emscripten_glBindBuffer(GL_ARRAY_BUFFER, buffer);
+    _GL_ARRAY_BUFFER_BINDING = buffer;
+  }
+  else if (target == GL_ELEMENT_ARRAY_BUFFER)
+  {
+    if (_GL_ELEMENT_ARRAY_BUFFER_BINDING == buffer) return;
+    _emscripten_glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buffer);
+    _GL_ELEMENT_ARRAY_BUFFER_BINDING = buffer;
+  }
+  else
+  {
+    _emscripten_glBindBuffer(target, buffer);
+  }
+}
+
+#define _GL_MAX_VERTEX_ATTRIBS 64
+
+static uint8_t _GL_VERTEX_ATTRIB_ARRAY_DIVISOR[_GL_MAX_VERTEX_ATTRIBS];
+
+GL_APICALL void GL_APIENTRY glVertexAttribDivisor(GLuint index, GLuint divisor)
+{
+  if (_GL_VERTEX_ATTRIB_ARRAY_DIVISOR[index] == (uint8_t)divisor) return;
+  _emscripten_glVertexAttribDivisor(index, divisor);
+  _GL_VERTEX_ATTRIB_ARRAY_DIVISOR[index] = (uint8_t)divisor;
+}
+
+static uint32_t _GL_VERTEX_ATTRIB_ARRAY_ENABLED;
+static uint32_t _GL_VERTEX_ATTRIB_ARRAY_pending_ENABLED;
+static uint32_t _GL_VERTEX_ATTRIB_ARRAY_pending_DISABLED;
+
+static inline void applyGlEnableVertexAttribArrays()
+{
+  _GL_VERTEX_ATTRIB_ARRAY_pending_ENABLED &= ~_GL_VERTEX_ATTRIB_ARRAY_ENABLED;
+  _GL_VERTEX_ATTRIB_ARRAY_pending_DISABLED &= _GL_VERTEX_ATTRIB_ARRAY_ENABLED;
+
+  _GL_VERTEX_ATTRIB_ARRAY_ENABLED |= _GL_VERTEX_ATTRIB_ARRAY_pending_ENABLED;
+  _GL_VERTEX_ATTRIB_ARRAY_ENABLED &= ~_GL_VERTEX_ATTRIB_ARRAY_pending_DISABLED;
+
+  int index = 0;
+  while(_GL_VERTEX_ATTRIB_ARRAY_pending_ENABLED)
+  {
+    if ((_GL_VERTEX_ATTRIB_ARRAY_pending_ENABLED & 1)) _emscripten_glEnableVertexAttribArray(index);
+    ++index;
+    _GL_VERTEX_ATTRIB_ARRAY_pending_ENABLED >>= 1;
+  }
+
+  index = 0;
+  while(_GL_VERTEX_ATTRIB_ARRAY_pending_DISABLED)
+  {
+    if ((_GL_VERTEX_ATTRIB_ARRAY_pending_DISABLED & 1)) _emscripten_glDisableVertexAttribArray(index);
+    ++index;
+    _GL_VERTEX_ATTRIB_ARRAY_pending_DISABLED >>= 1;
+  }
+}
+
+GL_APICALL void GL_APIENTRY glEnableVertexAttribArray(GLuint index)
+{
+  _GL_VERTEX_ATTRIB_ARRAY_pending_DISABLED &= ~(1U << index);
+  _GL_VERTEX_ATTRIB_ARRAY_pending_ENABLED |= (1U << index);
+}
+
+GL_APICALL void GL_APIENTRY glDisableVertexAttribArray(GLuint index)
+{
+  _GL_VERTEX_ATTRIB_ARRAY_pending_ENABLED &= ~(1U << index);
+  _GL_VERTEX_ATTRIB_ARRAY_pending_DISABLED |= (1U << index);
+}
+
+static GLuint _GL_CURRENT_PROGRAM = 0;
+
+GL_APICALL void GL_APIENTRY glUseProgram(GLuint program)
+{
+  if (program != _GL_CURRENT_PROGRAM)
+  {
+    _emscripten_glUseProgram(program);
+    _GL_CURRENT_PROGRAM = program;
+  }
+}
+
+static GLenum _GL_ACTIVE_TEXTURE = 0;
+static GLenum _GL_pending_ACTIVE_TEXTURE = 0;
+
+GL_APICALL void GL_APIENTRY glActiveTexture(GLenum texture)
+{
+  _GL_pending_ACTIVE_TEXTURE = texture;
+}
+
+static inline void applyGlActiveTexture()
+{
+  if (_GL_ACTIVE_TEXTURE == _GL_pending_ACTIVE_TEXTURE) return;
+  _emscripten_glActiveTexture(_GL_pending_ACTIVE_TEXTURE);
+  _GL_ACTIVE_TEXTURE = _GL_pending_ACTIVE_TEXTURE;
+}
+
+GL_APICALL void GL_APIENTRY glDrawArrays(GLenum mode, GLint first, GLsizei count)
+{
+  applyGlEnableVertexAttribArrays();
+  _emscripten_glDrawArrays(mode, first, count);
+}
+
+GL_APICALL void GL_APIENTRY glDrawElements(GLenum mode, GLsizei count, GLenum type, const void *indices)
+{
+  applyGlEnableVertexAttribArrays();
+  _emscripten_glDrawElements(mode, count, type, indices);
+}
+
+GL_APICALL void GL_APIENTRY glDrawRangeElements(GLenum mode, GLuint start, GLuint end, GLsizei count, GLenum type, const void *indices)
+{
+  applyGlEnableVertexAttribArrays();
+  _emscripten_glDrawRangeElements(mode, start, end, count, type, indices);
+}
+
+GL_APICALL void GL_APIENTRY glDrawArraysInstanced(GLenum mode, GLint first, GLsizei count, GLsizei instancecount)
+{
+  applyGlEnableVertexAttribArrays();
+  _emscripten_glDrawArraysInstanced(mode, first, count, instancecount);
+}
+
+GL_APICALL void GL_APIENTRY glDrawElementsInstanced(GLenum mode, GLsizei count, GLenum type, const void *indices, GLsizei instancecount)
+{
+  applyGlEnableVertexAttribArrays();
+  _emscripten_glDrawElementsInstanced(mode, count, type, indices, instancecount);
+}
+
+#define _GL_MAX_TEXTURES 32
+
+static GLuint _GL_TEXTURE_BINDING[_GL_MAX_TEXTURES];
+
+GL_APICALL void GL_APIENTRY glBindTexture(GLenum target, GLuint texture)
+{
+  if (_GL_TEXTURE_BINDING[_GL_pending_ACTIVE_TEXTURE-GL_TEXTURE0] == texture) return;
+  applyGlActiveTexture();
+  _emscripten_glBindTexture(target, texture);
+  _GL_TEXTURE_BINDING[_GL_pending_ACTIVE_TEXTURE-GL_TEXTURE0] = texture;
+}
+
+GL_APICALL void GL_APIENTRY glTexImage2D(GLenum target, GLint level, GLint internalformat, GLsizei width, GLsizei height, GLint border, GLenum format, GLenum type, const void *pixels)
+{
+  applyGlActiveTexture();
+  _emscripten_glTexImage2D(target, level, internalformat, width, height, border, format, type, pixels);
+}
+
+GL_APICALL void GL_APIENTRY glTexSubImage2D (GLenum target, GLint level, GLint xoffset, GLint yoffset, GLsizei width, GLsizei height, GLenum format, GLenum type, const void *pixels)
+{
+  applyGlActiveTexture();
+  _emscripten_glTexSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
+}
+
+GL_APICALL void GL_APIENTRY glTexStorage2D(GLenum target, GLsizei levels, GLenum internalformat, GLsizei width, GLsizei height)
+{
+  applyGlActiveTexture();
+  _emscripten_glTexStorage2D(target, levels, internalformat, width, height);
+}
+
+GL_APICALL void GL_APIENTRY glTexParameterf(GLenum target, GLenum pname, GLfloat param)
+{
+  applyGlActiveTexture();
+  _emscripten_glTexParameterf(target, pname, param);
+}
+
+GL_APICALL void GL_APIENTRY glTexParameterfv(GLenum target, GLenum pname, const GLfloat *params)
+{
+  applyGlActiveTexture();
+  _emscripten_glTexParameterfv(target, pname, params);
+}
+
+GL_APICALL void GL_APIENTRY glTexParameteri(GLenum target, GLenum pname, GLint param)
+{
+  applyGlActiveTexture();
+  _emscripten_glTexParameteri(target, pname, param);
+}
+
+GL_APICALL void GL_APIENTRY glTexParameteriv(GLenum target, GLenum pname, const GLint *params)
+{
+  applyGlActiveTexture();
+  _emscripten_glTexParameteriv(target, pname, params);
+}
+
+GL_APICALL void GL_APIENTRY glGenerateMipmap(GLenum target)
+{
+  applyGlActiveTexture();
+  _emscripten_glGenerateMipmap(target);
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2197,6 +2197,9 @@ Module["preRun"].push(function () {
   def test_webgl_with_closure(self):
     self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'USE_WEBGL2=1', '--closure', '1', '-lGL'], expected='0')
 
+  def test_webgl_state_cache(self):
+    self.btest(path_from_root('tests', 'webgl_state_cache.cpp'), args=['-s', 'USE_WEBGL2=1', '-s', 'GL_STATE_CACHE=1', '--js-library', path_from_root('tests', 'webgl_state_cache.js')], expected='3')
+
   def test_sdl_touch(self):
     for opts in [[], ['-O2', '-g1', '--closure', '1']]:
       print opts

--- a/tests/webgl_state_cache.cpp
+++ b/tests/webgl_state_cache.cpp
@@ -1,0 +1,44 @@
+#include <GLES3/gl3.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context;
+
+extern "C" {
+
+int getActiveAttribs();
+
+}
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+  attrs.majorVersion = 2;
+  attrs.minorVersion = 0;
+
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context(0, &attrs);
+  emscripten_webgl_make_context_current(context);
+
+  // Hit some GL_STATE_CACHE=1 entry points
+  glDisableVertexAttribArray(0);
+  glEnableVertexAttribArray(0);
+  glEnableVertexAttribArray(0);
+  glEnableVertexAttribArray(1);
+  glEnableVertexAttribArray(2);
+  glEnableVertexAttribArray(1);
+  glDisableVertexAttribArray(2);
+  glDisableVertexAttribArray(2);
+  glDrawArrays(0,0,0);
+
+  int result = getActiveAttribs();
+  printf("Active attribs: %d\n", result);
+#ifdef REPORT_RESULT
+  REPORT_RESULT();
+#endif
+  return 0;
+}

--- a/tests/webgl_state_cache.js
+++ b/tests/webgl_state_cache.js
@@ -1,0 +1,20 @@
+mergeInto(LibraryManager.library, {
+  activeAttribs: 0,
+
+  glEnableVertexAttribArray__deps: ['activeAttribs'],
+  glEnableVertexAttribArray: function(i) {
+    Module['print']('glEnableVertexAttribArray ' + i);
+    _activeAttribs |= (1 << i);
+  },
+
+  glDisableVertexAttribArray__deps: ['activeAttribs'],
+  glDisableVertexAttribArray: function(i) {
+    Module['print']('glDisableVertexAttribArray ' + i);
+    _activeAttribs &= ~(1 << i);
+  },
+
+  getActiveAttribs__deps: ['activeAttribs'],
+  getActiveAttribs: function() {
+    return _activeAttribs;
+  }
+});

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -196,6 +196,11 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     check_call([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', 'gl.c'), '-o', o])
     return o
 
+  def create_gl_cache(libname): # libname is ignored, this is just one .o file
+    o = in_temp('gl_cache.o')
+    check_call([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', 'gl_cache.c'), '-o', o])
+    return o
+
   def create_compiler_rt(libname):
     srcdir = shared.path_from_root('system', 'lib', 'compiler-rt', 'lib', 'builtins')
     filenames = ['divdc3.c', 'divsc3.c', 'muldc3.c', 'mulsc3.c']
@@ -355,6 +360,10 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       else:
         system_libs += [('dlmalloc', 'bc', create_dlmalloc_singlethreaded, [], [], False)]
         force.add('dlmalloc')
+
+  if shared.Settings.GL_STATE_CACHE:
+    system_libs += [('gl_cache',    'bc', create_gl_cache,    [],            [],   False)]
+    force.add('gl_cache')
 
   # if building to wasm, we need more math code, since we have less builtins
   if shared.Settings.BINARYEN:


### PR DESCRIPTION
Since WebGL calls can be quite slow, implement an opt in state cache for commonly set GL state variables. This can improve performance in applications which perform some redundant GL calls that have no effect.