### PR TITLE
up_front_heap_allocation_2

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2319,6 +2319,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         else:
           script_replacement = '<script>\n%s\n</script>' % script_inline
         html_contents = shell.replace('{{{ SCRIPT }}}', script_replacement)
+        html_contents = html_contents.replace('{{{ TOTAL_MEMORY }}}', str(shared.Settings.TOTAL_MEMORY))
+        html_contents = html_contents.replace('{{{ BINARYEN_MEM_MAX }}}', str(shared.Settings.BINARYEN_MEM_MAX))
         html_contents = tools.line_endings.convert_line_endings(html_contents, '\n', output_eol)
         html.write(html_contents)
         html.close()

--- a/src/shell.html
+++ b/src/shell.html
@@ -10,28 +10,78 @@
         postRun: [],
       };
 
-      // For best stability on 32-bit browsers, allocate asm.js/WebAssembly heap up front before proceeding
-      // to load any other page content. This mitigates the chances that loading up page assets first would
-      // fragment the memory area of the browser process.
-      var supportsWasm = (typeof WebAssembly === 'object' && typeof WebAssembly.Memory === 'function');
-      var page_size = supportsWasm ? 64 * 1024 : 16 * 1024 * 1024;
-      var TOTAL_MEMORY = page_size * Math.ceil({{{ TOTAL_MEMORY }}} / page_size);
-      var MAX_MEMORY = Math.max(TOTAL_MEMORY, page_size * Math.ceil({{{ BINARYEN_MEM_MAX }}} / page_size));
-
-      if (supportsWasm) {
-        Module['wasmMemory'] = new WebAssembly.Memory({ initial: TOTAL_MEMORY / page_size, maximum: MAX_MEMORY / page_size });
-        Module['buffer'] = Module['wasmMemory'].buffer;
-      } else { // asm.js:
-        for(var mem = MAX_MEMORY; mem >= TOTAL_MEMORY; mem -= multiple) {
-          try {
-            Module['buffer'] = new ArrayBuffer(mem);
-            if (Module['buffer'].byteLength != TOTAL_MEMORY) throw 'Out of memory';
-            TOTAL_MEMORY = mem;
-          } catch(e) {}
-        }
-        if (Module['buffer'].byteLength != TOTAL_MEMORY) throw 'Out of memory';
+      function heuristicIsBrowser64Bit() {
+        function contains(str, substrList) { for(var i in substrList) if (str.indexOf(substrList[i]) != -1) return true; return false; }
+        var ua = (navigator.userAgent + ' ' + navigator.oscpu + ' ' + navigator.platform).toLowerCase();
+        if (contains(ua, ['wow64'])) return false; // 32bit browser on 64bit OS
+        if (contains(ua, ['x86_64', 'amd64', 'ia64', 'win64', 'x64', 'arm64', 'irix64', 'mips64', 'ppc64', 'sparc64'])) return true;
+        if (contains(ua, ['i386', 'i486', 'i586', 'i686', 'x86', 'arm7', 'android', 'mobile', 'win32'])) return false;
+        if (contains(ua, ['intel mac os'])) return true;
+        return false;
       }
-      Module['TOTAL_MEMORY'] = TOTAL_MEMORY;
+
+      // For best stability on 32-bit browsers, allocate asm.js/WebAssembly heap up front before proceeding
+      // to load any other page content. This mitigates the chances that loading up any page assets later
+      // could fragment the memory area of the browser process so that the heap allocation could not be
+      // satisfied.
+      var supportsWasm = (typeof WebAssembly === 'object' && typeof WebAssembly.Memory === 'function');
+      var pageSize = supportsWasm ? 64 * 1024 : 16 * 1024 * 1024;
+      var heuristicIs64Bit = heuristicIsBrowser64Bit();
+      function alignPageUp(size) { return pageSize * Math.ceil(size / pageSize); }
+
+      // MAX_MEMORY: Specify a strict upper bound to how large the application heap can grow. If the
+      // application attempts to allocate any more, it will fail. Specifying a limit here has two
+      // useful applications:
+      //  1) defensively impose a strict limit to an application to keep it from going rogue with its
+      //     memory usage beyond some undesired limit. Especially useful when porting code you are not
+      //     first hand familiar with, and the web page has other memory allocations so that the Wasm
+      //     code can't hog all of it.
+      //  2) if the page has large memory allocations outside the main heap and you are running out of
+      //     address space in 32-bit environments, try specifying a maximum limit specifically to
+      //     32-bit environments.
+
+      // The absolute maximum memory that is available to compiled code is currently one memory page
+      // short of 2GB. Pass in Infinity to not specify a max size.
+      var MAX_MEMORY = Math.min(alignPageUp(heuristicIs64Bit ? {{{ MAX_MEMORY_64BIT }}} : {{{ MAX_MEMORY_32BIT }}}), 2048 * 1024 * 1024 - pageSize);
+
+      // MIN_MEMORY: Specify a lower limit of how much memory the application needs at minimum to run.
+      // If the browser can't provide this, the page startup should abort to an out-of-memory
+      // exception.
+      var MIN_MEMORY = Math.min(alignPageUp(32 * 1024 * 1024), MAX_MEMORY);
+
+      // INITIAL_MEMORY: Specify the initial amount of reserved address space for the application.
+      // Note that this is only a hint, and this much memory may not actually be acquired. If this is
+      // not possible, the page will start up with anything as close to this INITIAL amount as
+      // possible, but at least MIN bytes.
+      var INITIAL_MEMORY = Math.min(Math.max(alignPageUp({{{ TOTAL_MEMORY }}}), MIN_MEMORY), MAX_MEMORY);
+
+      // RESERVE_MAX: If true, pass the max memory request over to WebAssembly Memory allocation to
+      // eagerly reserve the maximum amount of address space, if possible. If false, run without a
+      // specified maximum reserve.
+      var RESERVE_MAX = {{{ RESERVE_MAX }}};
+
+      // Try to get as much memory close to INITIAL, but at least MIN. For asm.js, we can't actually
+      // resize, so attempt to reserve up to MAX memory, but only on detected 64-bit browsers.
+      for (var mem = (heuristicIs64Bit && !supportsWasm) ? MAX_MEMORY : INITIAL_MEMORY; mem >= MIN_MEMORY; mem -= pageSize) {
+        try {
+          if (supportsWasm) {
+            if (RESERVE_MAX) Module['wasmMemory'] = new WebAssembly.Memory({ initial: mem / pageSize, maximum: MAX_MEMORY / pageSize });
+            else Module['wasmMemory'] = new WebAssembly.Memory({ initial: mem / pageSize });
+            Module['buffer'] = Module['wasmMemory'].buffer;
+          } else {
+            Module['buffer'] = new ArrayBuffer(mem);
+          }
+          if (Module['buffer'].byteLength != mem) throw 'Out of memory for heap';
+          break; // Success!
+        } catch(e) { /*nop*/ }
+      }
+      if (!Module['buffer'] || !(Module['buffer'].byteLength >= MIN_MEMORY)) throw 'Out of memory for heap';
+      Module['TOTAL_MEMORY'] = Module['buffer'].byteLength;
+      Module['MAX_MEMORY'] = MAX_MEMORY;
+      function MB(x) { return (x/1024/1024) + 'MB'; }
+#if ASSERTIONS
+      console.log('Initial memory size: ' + MB(Module['TOTAL_MEMORY']) + ' (MIN_MEMORY: ' + MB(MIN_MEMORY) + ', INITIAL_MEMORY: ' + MB(INITIAL_MEMORY) + ', MAX_MEMORY: ' + MB(MAX_MEMORY) + ', heuristicIs64Bit: ' + heuristicIs64Bit + ')');
+#endif
     </script>
 
     <title>Emscripten-Generated Code</title>

--- a/src/shell.html
+++ b/src/shell.html
@@ -3,6 +3,37 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+
+    <script>
+      var Module = {
+        preRun: [],
+        postRun: [],
+      };
+
+      // For best stability on 32-bit browsers, allocate asm.js/WebAssembly heap up front before proceeding
+      // to load any other page content. This mitigates the chances that loading up page assets first would
+      // fragment the memory area of the browser process.
+      var supportsWasm = (typeof WebAssembly === 'object' && typeof WebAssembly.Memory === 'function');
+      var page_size = supportsWasm ? 64 * 1024 : 16 * 1024 * 1024;
+      var TOTAL_MEMORY = page_size * Math.ceil({{{ TOTAL_MEMORY }}} / page_size);
+      var MAX_MEMORY = Math.max(TOTAL_MEMORY, page_size * Math.ceil({{{ BINARYEN_MEM_MAX }}} / page_size));
+
+      if (supportsWasm) {
+        Module['wasmMemory'] = new WebAssembly.Memory({ initial: TOTAL_MEMORY / page_size, maximum: MAX_MEMORY / page_size });
+        Module['buffer'] = Module['wasmMemory'].buffer;
+      } else { // asm.js:
+        for(var mem = MAX_MEMORY; mem >= TOTAL_MEMORY; mem -= multiple) {
+          try {
+            Module['buffer'] = new ArrayBuffer(mem);
+            if (Module['buffer'].byteLength != TOTAL_MEMORY) throw 'Out of memory';
+            TOTAL_MEMORY = mem;
+          } catch(e) {}
+        }
+        if (Module['buffer'].byteLength != TOTAL_MEMORY) throw 'Out of memory';
+      }
+      Module['TOTAL_MEMORY'] = TOTAL_MEMORY;
+    </script>
+
     <title>Emscripten-Generated Code</title>
     <style>
       body {
@@ -1217,79 +1248,78 @@
     <textarea id="output" rows="8"></textarea>
 
     <script type='text/javascript'>
-      var statusElement = document.getElementById('status');
-      var progressElement = document.getElementById('progress');
-      var spinnerElement = document.getElementById('spinner');
-
-      var Module = {
-        preRun: [],
-        postRun: [],
-        print: (function() {
-          var element = document.getElementById('output');
-          if (element) element.value = ''; // clear browser cache
-          return function(text) {
-            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-            // These replacements are necessary if you render to raw HTML
-            //text = text.replace(/&/g, "&amp;");
-            //text = text.replace(/</g, "&lt;");
-            //text = text.replace(/>/g, "&gt;");
-            //text = text.replace('\n', '<br>', 'g');
-            console.log(text);
-            if (element) {
-              element.value += text + "\n";
-              element.scrollTop = element.scrollHeight; // focus on bottom
-            }
-          };
-        })(),
-        printErr: function(text) {
+      Module['print'] = (function() {
+        var element = document.getElementById('output');
+        if (element) element.value = ''; // clear browser cache
+        return function(text) {
           if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-          if (0) { // XXX disabled for safety typeof dump == 'function') {
-            dump(text + '\n'); // fast, straight to the real console
-          } else {
-            console.error(text);
+          // These replacements are necessary if you render to raw HTML
+          //text = text.replace(/&/g, "&amp;");
+          //text = text.replace(/</g, "&lt;");
+          //text = text.replace(/>/g, "&gt;");
+          //text = text.replace('\n', '<br>', 'g');
+          console.log(text);
+          if (element) {
+            element.value += text + "\n";
+            element.scrollTop = element.scrollHeight; // focus on bottom
           }
-        },
-        canvas: (function() {
-          var canvas = document.getElementById('canvas');
+        };
+      })();
 
-          // As a default initial behavior, pop up an alert when webgl context is lost. To make your
-          // application robust, you may want to override this behavior before shipping!
-          // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
-          canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
-
-          return canvas;
-        })(),
-        setStatus: function(text) {
-          if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
-          if (text === Module.setStatus.text) return;
-          var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
-          var now = Date.now();
-          if (m && now - Date.now() < 30) return; // if this is a progress update, skip it if too soon
-          if (m) {
-            text = m[1];
-            progressElement.value = parseInt(m[2])*100;
-            progressElement.max = parseInt(m[4])*100;
-            progressElement.hidden = false;
-            spinnerElement.hidden = false;
-          } else {
-            progressElement.value = null;
-            progressElement.max = null;
-            progressElement.hidden = true;
-            if (!text) spinnerElement.style.display = 'none';
-          }
-          statusElement.innerHTML = text;
-        },
-        totalDependencies: 0,
-        monitorRunDependencies: function(left) {
-          this.totalDependencies = Math.max(this.totalDependencies, left);
-          Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+      Module['printErr'] = function(text) {
+        if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
+        if (0) { // XXX disabled for safety typeof dump == 'function') {
+          dump(text + '\n'); // fast, straight to the real console
+        } else {
+          console.error(text);
         }
       };
+
+      Module['canvas'] = (function() {
+        var canvas = document.getElementById('canvas');
+
+        // As a default initial behavior, pop up an alert when webgl context is lost. To make your
+        // application robust, you may want to override this behavior before shipping!
+        // See http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+        canvas.addEventListener("webglcontextlost", function(e) { alert('WebGL context lost. You will need to reload the page.'); e.preventDefault(); }, false);
+
+        return canvas;
+      })();
+
+      Module['setStatus'] = function(text) {
+        if (!Module.setStatus.last) Module.setStatus.last = { time: Date.now(), text: '' };
+        if (text === Module.setStatus.text) return;
+        var m = text.match(/([^(]+)\((\d+(\.\d+)?)\/(\d+)\)/);
+        var now = Date.now();
+        if (m && now - Date.now() < 30) return; // if this is a progress update, skip it if too soon
+        var progressElement = document.getElementById('progress');
+        var spinnerElement = document.getElementById('spinner');
+        if (m) {
+          text = m[1];
+          progressElement.value = parseInt(m[2])*100;
+          progressElement.max = parseInt(m[4])*100;
+          progressElement.hidden = false;
+          spinnerElement.hidden = false;
+        } else {
+          progressElement.value = null;
+          progressElement.max = null;
+          progressElement.hidden = true;
+          if (!text) spinnerElement.style.display = 'none';
+        }
+        document.getElementById('status').innerHTML = text;
+      };
+
+      Module['totalDependencies'] = 0;
+      Module['monitorRunDependencies'] = function(left) {
+        this.totalDependencies = Math.max(this.totalDependencies, left);
+        Module.setStatus(left ? 'Preparing... (' + (this.totalDependencies-left) + '/' + this.totalDependencies + ')' : 'All downloads complete.');
+      };
+
       Module.setStatus('Downloading...');
       window.onerror = function(event) {
         // TODO: do not warn on ok events like simulating an infinite loop or exitStatus
         Module.setStatus('Exception thrown, see JavaScript console');
-        spinnerElement.style.display = 'none';
+        document.getElementById('spinner').style.display = 'none';
         Module.setStatus = function(text) {
           if (text) Module.printErr('[post-exception status] ' + text);
         };


### PR DESCRIPTION
Bringing this up as a replacement alternative for #4811.

The feedback we've received from people trying to come up with good memory allocation strategies suggests we need to provide a solution that makes it simpler to come up with a proper allocation scheme.

Here's the observations:

1) Being required to specify a memory limit up front is known to be difficult, and most codebases don't know how much to allocate, since it is not feasible to profile the app in all possible control flows to know how much of memory it is using at maximum during its lifetime.

2) 32-bit address space fragmentation caused OOMing troubles are hard because they can be a problem that might not surface easily on developers' lab environment, but only on 32-bit browsers that have been open for a relatively long time, and people might realize only after having shipped their app to the wild, and even then only if they happen to have robust metrics collection infrastructure tied to the launch. People can have a problem even without knowing it (granted, the problem may affect only a few % of users in the wild)

3) Most developers we talk to still want to deploy asm.js as a fallback alongside wasm. Therefore the scheme needs to work well for both wasm and asm.js.

4) Memory address space burden is completely different in 32-bit and 64-bit applications. In 64-bit, address space is free, but on 32-bit, not so much. We need a scheme that allows developers to exploit this, i.e. in 64-bit browsers they can have all the address space and memory they want, but at the same time having the capability to be conservative with not just allocated memory, but also with address space they reserve to optimize for 32-bit and mobile.

5) Surprisingly many devs have been going for a blank "2GB everywhere" type of reserves, or "reserve as much as possibly can be obtained". We need to help the web so that these practices are effectively deployed only for 64-bit and that there's good fallbacks for 32-bit.

6) In 32-bit browsers, there is a conflicting pressure between available address space inside the heap versus allocations outside the heap. An application might be heavy for allocations on either side of the fence, i.e. do lots of allocations inside the heap, or outside the heap. Eagerly hogging all available address space (even if it is just the address space, and not committed) for use by the heap will give pressure to starve allocations outside the heap, and the opposite. I don't think this aspect is something that we can transparently hide, but we should provide a mechanism that allows developers to optimize for whether they think their memory address space pressure is inside or outside the heap.

7) The scheme has to be ready for multithreading support when it lands to wasm.

8) The scheme needs to be relatively simple, documented with example cases, and fully customizable. This is why it is good to locate it in the shell.html rather than building it directly into preamble.js so that people can change the behavior when they switch to using a custom shell file (the other requirement for being in the shell is that we need to do the allocation up front to avoid risking fragmentation)

The proposal is to have fields `MIN_MEMORY`, `INITIAL_MEMORY` and `MAX_MEMORY` to control the memory limits, as well as a `RESERVE_MAX` flag to choose whether to optimize address space for allocations inside the heap, or for outside the heap. `MIN_MEMORY` is the limit that the app won't run with, `MAX_MEMORY` is the limit that the app can't go above (separated for 32-bit and 64-bit), and `INITIAL_MEMORY` is the preferred amount of address space to start with (the application could get a reservation of anything between `MIN_MEMORY` and `INITIAL_MEMORY`). If `RESERVE_MAX` is set, we assume the application will be heavy for allocations inside the heap, so attempt to reserve optimistically, and if it is false, assume that the page is heavy for allocations outside the heap, so reserve pessimistically.

This set of flag has three advantages.

A) It overcomes an issue with WebAssembly.Memory `maximum` field, which is at the same time a hint for how much of address space to reserve up front, but also a hard restricted limit for a maximum of how much to ever allow for the app. That is, if an application knows that it is 80% likely to need e.g. 512MB of RAM, but developer is not sure (because proving that is hard), so he'd like to be able to grow up to bigger sizes when possible. So the developer does not want to run with

    new WebAssembly.Memory({ initial: 512MB, maximum: 512MB });

because that would give a hard limit of 512MB upper bound, even on 64bit where such a limit is not necessary. Similarly, developer might not want to do

    new WebAssembly.Memory({ initial: 512MB, maximum: 2GB });

since that might reserve too much address space on 32-bit if the application needs to be able to do large allocations outside the heap as well. Developer might try to settle for something like

    new WebAssembly.Memory({ initial: 512MB, maximum: 768MB });

but that again has the issue that perhaps in 5% of the runs the app might actually need more than 768MB, so even on 64-bit browsers, those 5% cases would run into problems. If the developer does

    new WebAssembly.Memory({ initial: 512MB });

it is practically the same as 

    new WebAssembly.Memory({ initial: 512MB, maximum: 512MB });

on 32-bit browsers and mobiles, where guarantees for growing the heap later are small. Essentially, a developer would like to be able to do

    if (address space is carefree, that is, we are on 64bit browser) new WebAssembly.Memory({initial: 512MB, maximum: 2GB });
    else new WebAssembly.Memory({ initial: 512MB, maximum: 768MB });

to have the widest possible coverage for people to be able to run. This is why there are two separate `MAX_MEMORY_32BIT` and `MAX_MEMORY_64BIT` limits for 64bit and 32bit scenarios. Developers can either set a wholesale `MAX_MEMORY` if they want to cover both cases, or set the limits separately.

B) Another thing here is that perhaps the developer might think that the earlier min requirement of 512MB above might not be a strict minimum limit, but perhaps the app would run ok for some workloads with just 384MB, even if 512MB would be preferred, so he would not want that `{ initial: 512MB }` to be set in stone. In that case, it would be nice to first try `new WebAssembly.Memory({initial: 512MB})`, and if that fails, settle for `new WebAssembly.Memory({initial: 384MB})` or something along those lines. That is why the initial address space reserve versus minimum needed address space reserve are separate, so that people can estimate a range of what is at least needed vs what one would prefer to have.

C) Developers generally know best whether they need to lots of C side `malloc()`s or JS side `new ArrayBuffer()`s in their apps. For 32-bit address space constrained situations, they might want to specify a hint to tell whether to prefer to reserve the address space inside the heap, or outside. Practically, the way that I understand `WebAssembly.Memory` works in 32-bit,

    new WebAssembly.Memory({ initial: 512MB, maximum: 1GB });

will cause an up front 1GB memory reservation ("will more likely need that address space for `malloc()`s"), and

    new WebAssembly.Memory({ initial: 512MB });

would be a strict 512MB reservation. ("will more likely need that address space for `new ArrayBuffer()`s")

With the `RESERVE_MAX` flag, a developer can tell which way the address space reserves should go to.

This PR only has the shell.html side implemented at the moment, but the intent is that there would be new `emcc` linker flags `-s MIN_MEMORY`, `-s INITIAL_MEMORY`, `-s MAX_MEMORY`, `-s MAX_MEMORY_32BIT`, `-s MAX_MEMORY_64BIT`, and `-s RESERVE_MAX` added. The current `-s TOTAL_MEMORY` and `-s BINARYEN_MEM_MAX` flags would map to these new flags. With these combinations, applications would have a good machinery for staying carefree about address space in detected 64-bit browsers, but still generating a strict conservative address space usage for 32-bit browsers and mobiles.