### PR TITLE
Make USE_PTHREADS work with MODULARIZE mode.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2331,14 +2331,20 @@ def modularize(final):
   src = open(final).read()
   final = final + '.modular.js'
   f = open(final, 'w')
-  f.write('var ' + shared.Settings.EXPORT_NAME + ' = function(' + shared.Settings.EXPORT_NAME + ') {\n')
+  f.write('var ' + shared.Settings.EXPORT_NAME + '\n')
+  f.write('(function() {\n')
+  f.write('  var scriptSrc;\n')
+  f.write('  if (typeof document !== \'undefined\' && document.currentScript) scriptSrc = document.currentScript.src;\n')
+  f.write(shared.Settings.EXPORT_NAME + ' = function(' + shared.Settings.EXPORT_NAME + ') {\n')
   f.write('  ' + shared.Settings.EXPORT_NAME + ' = ' + shared.Settings.EXPORT_NAME + ' || {};\n')
+  f.write('  if (!' + shared.Settings.EXPORT_NAME + '.currentScriptUrl) ' + shared.Settings.EXPORT_NAME + '.currentScriptUrl = scriptSrc;\n')
   f.write('  var Module = ' + shared.Settings.EXPORT_NAME + ';\n') # included code may refer to Module (e.g. from file packager), so alias it
   f.write('\n')
   f.write(src)
   f.write('\n')
   f.write('  return ' + shared.Settings.EXPORT_NAME + ';\n')
   f.write('};\n')
+  f.write('})();\n');
   # Export the function if this is for Node (or similar UMD-style exporting), otherwise it is lost.
   f.write('if (typeof module === "object" && module.exports) {\n')
   f.write("  module['exports'] = " + shared.Settings.EXPORT_NAME + ';\n')

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -347,7 +347,11 @@ function JSify(data, functionsOnly) {
       if (!BUILD_AS_SHARED_LIB && !SIDE_MODULE) {
         if (USE_PTHREADS) {
           print('var tempDoublePtr;\n');
-          print('if (!ENVIRONMENT_IS_PTHREAD) tempDoublePtr = Runtime.alignMemory(allocate(12, "i8", ALLOC_STATIC), 8);\n');
+          print('if (ENVIRONMENT_IS_PTHREAD) {\n');
+          print('  tempDoublePtr = Module[\'tempDoublePtr\'];\n');
+          print('} else {\n');
+          print('  tempDoublePtr = Runtime.alignMemory(allocate(12, "i8", ALLOC_STATIC), 8);\n');
+          print('}\n');
         } else {
           print('var tempDoublePtr = ' + makeStaticAlloc(8) + '\n');
         }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -986,7 +986,12 @@ var STACK_BASE, STACKTOP, STACK_MAX; // stack area
 var DYNAMIC_BASE, DYNAMICTOP_PTR; // dynamic area handled by sbrk
 
 #if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) { // Pthreads have already initialized these variables in src/pthread-main.js, where they were passed to the thread worker at startup time
+if (ENVIRONMENT_IS_PTHREAD) { // Pthreads have passed these variables in from src/pthread-main.js, where they were passed to the thread worker at startup time
+  STATIC_BASE = Module['STATIC_BASE'] || 0;
+  STATICTOP = Module['STATICTOP'] || 0;
+  DYNAMIC_BASE = Module['DYNAMIC_BASE'] || 0;
+  DYNAMICTOP_PTR = Module['DYNAMICTOP_PTR'] || 0;
+} else {
 #endif
   STATIC_BASE = STATICTOP = STACK_BASE = STACKTOP = STACK_MAX = DYNAMIC_BASE = DYNAMICTOP_PTR = 0;
   staticSealed = false;
@@ -1174,7 +1179,11 @@ if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') 
 
 #if USE_PTHREADS
 if (typeof SharedArrayBuffer !== 'undefined') {
-  if (!ENVIRONMENT_IS_PTHREAD) buffer = new SharedArrayBuffer(TOTAL_MEMORY);
+  if (ENVIRONMENT_IS_PTHREAD) {
+    buffer = Module.buffer;
+  } else {
+    buffer = new SharedArrayBuffer(TOTAL_MEMORY);
+  }
   // Currently SharedArrayBuffer does not have a slice() operation, so polyfill it in.
   // Adapted from https://github.com/ttaubert/node-arraybuffer-slice, (c) 2014 Tim Taubert <tim@timtaubert.de>
   // arraybuffer-slice may be freely distributed under the MIT license.

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -2,31 +2,18 @@
 // This is the entry point file that is loaded first by each Web Worker
 // that executes pthreads on the Emscripten application.
 
-// Thread-local:
+// Thread-local, communicated via globals:
 var threadInfoStruct = 0; // Info area for this thread in Emscripten HEAP (shared). If zero, this worker is not currently hosting an executing pthread.
 var selfThreadId = 0; // The ID of this thread. 0 if not hosting a pthread.
 var parentThreadId = 0; // The ID of the parent pthread that launched this thread.
-var tempDoublePtr = 0; // A temporary memory area for global float and double marshalling operations.
 
-// Thread-local: Each thread has its own allocated stack space.
-var STACK_BASE = 0;
-var STACKTOP = 0;
-var STACK_MAX = 0;
-
-// These are system-wide memory area parameters that are set at main runtime startup in main thread, and stay constant throughout the application.
-var buffer; // All pthreads share the same Emscripten HEAP as SharedArrayBuffer with the main execution thread.
-var DYNAMICTOP_PTR = 0;
-var TOTAL_MEMORY = 0;
-var STATICTOP = 0;
-var staticSealed = true; // When threads are being initialized, the static memory area has been already sealed a long time ago.
-var DYNAMIC_BASE = 0;
-
-var ENVIRONMENT_IS_PTHREAD = true;
+// Send the pthreads mode and other params in through Module object settings
+var Module = {
+  ENVIRONMENT: 'PTHREAD'
+};
 
 // Cannot use console.log or console.error in a web worker, since that would risk a browser deadlock! https://bugzilla.mozilla.org/show_bug.cgi?id=1049091
 // Therefore implement custom logging facility for threads running in a worker, which queue the messages to main thread to print.
-var Module = {};
-
 function threadPrint() {
   var text = Array.prototype.slice.call(arguments).join(' ');
   console.log(text);
@@ -43,71 +30,71 @@ Module['print'] = threadPrint;
 Module['printErr'] = threadPrintErr;
 this.alert = threadAlert;
 
+// If modularized, we can't reuse the module's assert() function.
+function assert(condition, text) {
+  if (!condition) {
+    abort('Assertion failed: ' + text);
+  }
+}
+
 this.onmessage = function(e) {
   if (e.data.cmd === 'load') { // Preload command that is called once per worker to parse and load the Emscripten code.
     // Initialize the thread-local field(s):
-    tempDoublePtr = e.data.tempDoublePtr;
+    Module['tempDoublePtr'] = e.data.tempDoublePtr;
 
     // Initialize the global "process"-wide fields:
-    buffer = e.data.buffer;
-    Module['TOTAL_MEMORY'] = TOTAL_MEMORY = e.data.TOTAL_MEMORY;
-    STATICTOP = e.data.STATICTOP;
-    DYNAMIC_BASE = e.data.DYNAMIC_BASE;
-    DYNAMICTOP_PTR = e.data.DYNAMICTOP_PTR;
+    Module['buffer'] = e.data.buffer;
+    Module['TOTAL_MEMORY'] = e.data.TOTAL_MEMORY;
+    Module['STATICTOP'] = e.data.STATICTOP;
+    Module['DYNAMIC_BASE'] = e.data.DYNAMIC_BASE;
+    Module['DYNAMICTOP_PTR'] = e.data.DYNAMICTOP_PTR;
 
-    PthreadWorkerInit = e.data.PthreadWorkerInit;
+    Module['pthreadWorkerInit'] = e.data.PthreadWorkerInit;
     importScripts(e.data.url);
+    if (e.data.modularize) {
+      // Feed input options into the modularized constructor...
+      // 'this' is the Worker, which is also global scope.
+      Module = new this[e.data.moduleExportName](Module);
+    }
     if (typeof FS !== 'undefined') FS.createStandardStreams();
     postMessage({ cmd: 'loaded' });
   } else if (e.data.cmd === 'objectTransfer') {
-    PThread.receiveObjectTransfer(e.data);
+    Module.PThread.receiveObjectTransfer(e.data);
   } else if (e.data.cmd === 'run') { // This worker was idle, and now should start executing its pthread entry point.
     threadInfoStruct = e.data.threadInfoStruct;
-    __register_pthread_ptr(threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0); // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
+    Module.PThread.registerPthreadPtr(threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0); // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
     assert(threadInfoStruct);
     selfThreadId = e.data.selfThreadId;
     parentThreadId = e.data.parentThreadId;
     assert(selfThreadId);
     assert(parentThreadId);
-    // TODO: Emscripten runtime has these variables twice(!), once outside the asm.js module, and a second time inside the asm.js module.
-    //       Review why that is? Can those get out of sync?
-    STACK_BASE = STACKTOP = e.data.stackBase;
-    STACK_MAX = STACK_BASE + e.data.stackSize;
-    assert(STACK_BASE != 0);
-    assert(STACK_MAX > STACK_BASE);
-    Runtime.establishStackSpace(e.data.stackBase, e.data.stackBase + e.data.stackSize);
+    Module.PThread.setStackSpace(e.data.stackBase, e.data.stackBase + e.data.stackSize);
     var result = 0;
 
-    PThread.receiveObjectTransfer(e.data);
+    Module.PThread.receiveObjectTransfer(e.data);
 
-    PThread.setThreadStatus(_pthread_self(), 1/*EM_THREAD_STATUS_RUNNING*/);
+    Module.PThread.setThreadStatus(threadInfoStruct, 1/*EM_THREAD_STATUS_RUNNING*/);
 
     try {
-      // HACK: Some code in the wild has instead signatures of form 'void *ThreadMain()', which seems to be ok in native code.
-      // To emulate supporting both in test suites, use the following form. This is brittle!
-      if (typeof Module['asm']['dynCall_ii'] !== 'undefined') {
-        result = Module['asm'].dynCall_ii(e.data.start_routine, e.data.arg); // pthread entry points are always of signature 'void *ThreadMain(void *arg)'
-      } else {
-        result = Module['asm'].dynCall_i(e.data.start_routine); // as a hack, try signature 'i' as fallback.
-      }
+      Module.PThread.runThreadFunc(e.data.start_routine, e.data.arg);
     } catch(e) {
       if (e === 'Canceled!') {
-        PThread.threadCancel();
+        Module.PThread.threadCancel();
         return;
       } else {
-        Atomics.store(HEAPU32, (threadInfoStruct + 4 /*{{{ C_STRUCTS.pthread.threadExitCode }}}*/ ) >> 2, -2 /*A custom entry specific to Emscripten denoting that the thread crashed.*/);
-        Atomics.store(HEAPU32, (threadInfoStruct + 0 /*{{{ C_STRUCTS.pthread.threadStatus }}}*/ ) >> 2, 1); // Mark the thread as no longer running.
-        _emscripten_futex_wake(threadInfoStruct + 0 /*{{{ C_STRUCTS.pthread.threadStatus }}}*/, 0x7FFFFFFF/*INT_MAX*/); // wake all threads
+        Atomics.store(Module.HEAPU32, (threadInfoStruct + 4 /*{{{ C_STRUCTS.pthread.threadExitCode }}}*/ ) >> 2, -2 /*A custom entry specific to Emscripten denoting that the thread crashed.*/);
+        Atomics.store(Module.HEAPU32, (threadInfoStruct + 0 /*{{{ C_STRUCTS.pthread.threadStatus }}}*/ ) >> 2, 1); // Mark the thread as no longer running.
+        Module.PThread.wakeAllThreads();
         throw e;
       }
     }
     // The thread might have finished without calling pthread_exit(). If so, then perform the exit operation ourselves.
     // (This is a no-op if explicit pthread_exit() had been called prior.)
-    if (!Module['noExitRuntime']) PThread.threadExit(result);
+    if (!Module['noExitRuntime']) Module.PThread.threadExit(result);
     else console.log('pthread noExitRuntime: not quitting.');
   } else if (e.data.cmd === 'cancel') { // Main thread is asking for a pthread_cancel() on this thread.
-    if (threadInfoStruct && PThread.thisThreadCancelState == 0/*PTHREAD_CANCEL_ENABLE*/) {
-      PThread.threadCancel();
+    if (threadInfoStruct && Module.PThread.thisThreadCancelState == 0/*PTHREAD_CANCEL_ENABLE*/) {
+      Module.PThread.threadCancel();
     }
   } else {
     Module['printErr']('pthread-main.js received unknown command ' + e.data.cmd);

--- a/src/shell.js
+++ b/src/shell.js
@@ -53,6 +53,9 @@ if (Module['ENVIRONMENT']) {
     ENVIRONMENT_IS_NODE = true;
   } else if (Module['ENVIRONMENT'] === 'SHELL') {
     ENVIRONMENT_IS_SHELL = true;
+  } else if (Module['ENVIRONMENT'] === 'PTHREAD') {
+    ENVIRONMENT_IS_WORKER = true;
+    ENVIRONMENT_IS_PTHREAD = true;
   } else {
     throw new Error('The provided Module[\'ENVIRONMENT\'] value is not valid. It must be one of: WEB|WORKER|NODE|SHELL.');
   }
@@ -66,9 +69,9 @@ if (Module['ENVIRONMENT']) {
 #if USE_PTHREADS
 var ENVIRONMENT_IS_PTHREAD;
 if (!ENVIRONMENT_IS_PTHREAD) ENVIRONMENT_IS_PTHREAD = false; // ENVIRONMENT_IS_PTHREAD=true will have been preset in pthread-main.js. Make it false in the main runtime thread.
-var PthreadWorkerInit; // Collects together variables that are needed at initialization time for the web workers that host pthreads.
+var PthreadWorkerInit = Module['pthreadWorkerInit'] || undefined; // Collects together variables that are needed at initialization time for the web workers that host pthreads.
 if (!ENVIRONMENT_IS_PTHREAD) PthreadWorkerInit = {};
-var currentScriptUrl = ENVIRONMENT_IS_WORKER ? undefined : document.currentScript.src;
+var currentScriptUrl = Module['currentScriptUrl'] || (ENVIRONMENT_IS_WORKER ? undefined : document.currentScript.src);
 #endif
 
 if (ENVIRONMENT_IS_NODE) {


### PR DESCRIPTION
pthread-main.js was touching globals directly, which aren't
exposed as globals when the Module object is encapsulated
into a function constructor with MODULARIZE and EXPORT_NAME
options.

Modified pthread-main.js and library_pthread.js (and a little
modification to shell.js and jsifier.js) to use accessors for
a couple things, and to inject the initialized stuff for pthread
workers via options on the Module object instead of directly.

emcc.py is changed to support checking document.currentScript.src
at load time, outside the module wrapper constructor, and passes
the value in to the module via Module.currentScriptUrl; this is
overriding the document.currentScript.src check in shell.js.

Shouldn't break existing non-modular code, but does require that
pthread-main.js be updated when recompiling (as should happen
normally).

Fixes https://github.com/kripken/emscripten/issues/5009