### PR TITLE
WIP for handling references in embind with a policy

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -271,6 +271,17 @@ namespace emscripten {
     struct allow_raw_pointer : public allow_raw_pointers {
     };
 
+    struct references_as_pointers {
+        template<typename InputType, int Index>
+        struct Transform {
+            typedef typename std::conditional<
+                std::is_reference<InputType>::value,
+                internal::RefAsPointer<typename std::remove_reference<InputType>::type>,
+                InputType
+            >::type type;
+        };
+    };
+
     ////////////////////////////////////////////////////////////////////////////////
     // select_overload and select_const
     ////////////////////////////////////////////////////////////////////////////////

--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -36,7 +36,7 @@ namespace emscripten {
         // We don't need the full std::type_info implementation.  We
         // just need a unique identifier per type and polymorphic type
         // identification.
-        
+
         template<typename T>
         struct CanonicalizedID {
             static char c;
@@ -100,7 +100,18 @@ namespace emscripten {
                 return LightTypeID<T*>::get();
             }
         };
-        
+
+        template<typename T>
+        struct RefAsPointer{
+        };
+
+        template<typename T>
+        struct TypeID<RefAsPointer<T>> {
+            static constexpr TYPEID get() {
+                return LightTypeID<T*>::get();
+            }
+        };
+
         // ExecutePolicies<>
 
         template<typename... Policies>
@@ -113,7 +124,7 @@ namespace emscripten {
                 typedef T type;
             };
         };
-        
+
         template<typename Policy, typename... Remaining>
         struct ExecutePolicies<Policy, Remaining...> {
             template<typename T, int Index>
@@ -322,6 +333,22 @@ namespace emscripten {
             static T* fromWireType(WireType wt) {
                 return wt;
             }
+        };
+
+        template<typename T>
+        struct BindingType<RefAsPointer<T>> {
+            typedef const T* WireType;
+            static WireType toWireType(const T& p) {
+                return &p;
+            }
+            static T& fromWireType(WireType wt) {
+                return *wt;
+            }
+        };
+
+        template<typename T>
+        struct BindingType<AllowedRawPointer<T>> : BindingType<T*> {
+
         };
 
         template<typename T>

--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -151,6 +151,11 @@ namespace emscripten {
             typedef TypeList<First, Rest...> type;
         };
 
+        template<typename... First, typename... Rest>
+        struct Cons<TypeList<First...>, TypeList<Rest...>> {
+            typedef TypeList<First..., Rest...> type;
+        };
+
         // Apply :: T, TypeList<types...> -> T<types...>
 
         template<template<typename...> class Output, typename TypeList>
@@ -187,6 +192,22 @@ namespace emscripten {
             >::type type;
         };
 
+        template<typename TypeToFilter, typename... Types>
+        struct FilterSubTypes;
+
+        template<typename TypeToFilter>
+        struct FilterSubTypes<TypeToFilter> {
+            typedef TypeList<> type;
+        };
+
+        template<typename TypeToFilter, typename Type>
+        struct FilterSubTypes<TypeToFilter, Type> {
+            typedef typename std::conditional<
+                std::is_base_of<TypeToFilter, Type>::value,
+                TypeList<Type>,
+                TypeList<>
+            >::type type;
+        };
 
         template<typename ArgList>
         struct ArgArrayGetter;
@@ -214,9 +235,11 @@ namespace emscripten {
                     return sizeof...(Args);
                 }
 
+                typedef typename MapWithIndex<TypeList, MapWithPolicies, Args...>::type type;
+
                 const TYPEID* getTypes() const {
                     return ArgArrayGetter<
-                        typename MapWithIndex<TypeList, MapWithPolicies, Args...>::type
+                        type
                     >::get();
                 }
             };
@@ -341,7 +364,7 @@ namespace emscripten {
             static WireType toWireType(const T& p) {
                 return &p;
             }
-            static T& fromWireType(WireType wt) {
+            static const T& fromWireType(WireType wt) {
                 return *wt;
             }
         };

--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -360,11 +360,12 @@ namespace emscripten {
 
         template<typename T>
         struct BindingType<RefAsPointer<T>> {
-            typedef const T* WireType;
-            static WireType toWireType(const T& p) {
+            typedef T* WireType;
+            static WireType toWireType(T& p) {
                 return &p;
             }
-            static const T& fromWireType(WireType wt) {
+
+            static T& fromWireType(WireType wt) {
                 return *wt;
             }
         };


### PR DESCRIPTION
Do not merge !

This is a WIP to show a possible handling of references within embind.
The `references_as_pointers` policy can be used to specify that the user wants to bind the references returned by the function as pointers. Currently, this only works for free functions.

Looking for comments or other ways this could be implemented (ideally transparently, but all my attemps to do that broke something else).

Related Issuse : #3480 