### PR TITLE
Add support for AUDIO_F32 format to tests *_audio_beep_*.

### DIFF
--- a/tests/sdl2_audio_beep.cpp
+++ b/tests/sdl2_audio_beep.cpp
@@ -83,8 +83,21 @@ Beeper::~Beeper() {
 }
 
 template<typename T>
+struct AmplitudeInfo {
+    typedef int type;
+    static const type max() { return (sizeof(T) == 2) ? 28000 : 120; }
+};
+
+template<>
+struct AmplitudeInfo<float> {
+    typedef float type;
+    static const type max() { return 1.0f; }
+};
+
+template<typename T>
 void Beeper::generateSamples(T *stream, int length) {
-  const int AMPLITUDE = (sizeof(T) == 2) ? 28000 : 120;
+  typedef typename AmplitudeInfo<T>::type AmplitudeType;
+  const AmplitudeType AMPLITUDE = AmplitudeInfo<T>::max();
   const int offset = (sdlAudioFormat == AUDIO_U8) ? 120 : 0;
 
   int i = 0;
@@ -108,7 +121,7 @@ void Beeper::generateSamples(T *stream, int length) {
 
     while (i < samplesToDo) {
       for(int j = 0; j < numChannels; ++j) {
-        stream[numChannels*i+j] = (T)(offset + (int)(AMPLITUDE * std::sin(phase * 2 * M_PI / frequency)));
+        stream[numChannels*i+j] = (T)(offset + (AmplitudeType)(AMPLITUDE * std::sin(phase * 2 * M_PI / frequency)));
         if (numChannels > 1 && j == mutedChannel) {
           stream[numChannels*i+j] = 0;
         }
@@ -139,7 +152,7 @@ Beeper *beep = 0;
 // test will report you which work.
 const int freqs[] = { 8000, 11025, 16000, 22050, 32000, 44100, 48000, 96000 };
 const int channels[] = { 1, 2 };
-const int sdlAudioFormats[] = { AUDIO_U8, AUDIO_S16LSB /*, AUDIO_S8, AUDIO_U16LSB, AUDIO_U16MSB, AUDIO_S16MSB */ };
+const int sdlAudioFormats[] = { AUDIO_F32, AUDIO_U8, AUDIO_S16LSB /*, AUDIO_S8, AUDIO_U16LSB, AUDIO_U16MSB, AUDIO_S16MSB */ };
 
 const char *SdlAudioFormatToString(int sdlAudioType) {
   switch(sdlAudioType) {
@@ -149,6 +162,7 @@ const char *SdlAudioFormatToString(int sdlAudioType) {
   case AUDIO_U16MSB: return "AUDIO_U16MSB";
   case AUDIO_S16LSB: return "AUDIO_S16LSB";
   case AUDIO_S16MSB: return "AUDIO_S16MSB";
+  case AUDIO_F32: return "AUDIO_F32";
   default: return "(unknown)";
   }
 }
@@ -222,6 +236,10 @@ void audio_callback(void *_beeper, Uint8 *_stream, int _length) {
   } else if (beeper->sdlAudioFormat == AUDIO_S16LSB) {
     Sint16 *stream = (Sint16*) _stream;
     int length = _length / 2;
+    beeper->generateSamples(stream, length);
+}  else if (beeper->sdlAudioFormat == AUDIO_F32) {
+    float *stream = (float*) _stream;
+    int length = _length / sizeof(float);
     beeper->generateSamples(stream, length);
   } else {
     assert(false && "Audio sample generation not implemented for current format!\n");

--- a/tests/sdl_audio_beep.cpp
+++ b/tests/sdl_audio_beep.cpp
@@ -83,8 +83,21 @@ Beeper::~Beeper() {
 }
 
 template<typename T>
+struct AmplitudeInfo {
+    typedef int type;
+    static const type max() { return (sizeof(T) == 2) ? 28000 : 120; }
+};
+
+template<>
+struct AmplitudeInfo<float> {
+    typedef float type;
+    static const type max() { return 1.0f; }
+};
+
+template<typename T>
 void Beeper::generateSamples(T *stream, int length) {
-  const int AMPLITUDE = (sizeof(T) == 2) ? 28000 : 120;
+  typedef typename AmplitudeInfo<T>::type AmplitudeType;
+  const AmplitudeType AMPLITUDE = AmplitudeInfo<T>::max();
   const int offset = (sdlAudioFormat == AUDIO_U8) ? 120 : 0;
 
   int i = 0;
@@ -108,7 +121,7 @@ void Beeper::generateSamples(T *stream, int length) {
 
     while (i < samplesToDo) {
       for(int j = 0; j < numChannels; ++j) {
-        stream[numChannels*i+j] = (T)(offset + (int)(AMPLITUDE * std::sin(phase * 2 * M_PI / frequency)));
+        stream[numChannels*i+j] = (T)(offset + (AmplitudeType)(AMPLITUDE * std::sin(phase * 2 * M_PI / frequency)));
         if (numChannels > 1 && j == mutedChannel) {
           stream[numChannels*i+j] = 0;
         }
@@ -139,7 +152,7 @@ Beeper *beep = 0;
 // test will report you which work.
 const int freqs[] = { 8000, 11025, 16000, 22050, 32000, 44100, 48000, 96000 };
 const int channels[] = { 1, 2 };
-const int sdlAudioFormats[] = { AUDIO_U8, AUDIO_S16LSB /*, AUDIO_S8, AUDIO_U16LSB, AUDIO_U16MSB, AUDIO_S16MSB */ };
+const int sdlAudioFormats[] = { AUDIO_F32, AUDIO_U8, AUDIO_S16LSB /*, AUDIO_S8, AUDIO_U16LSB, AUDIO_U16MSB, AUDIO_S16MSB */ };
 
 const char *SdlAudioFormatToString(int sdlAudioType) {
   switch(sdlAudioType) {
@@ -149,6 +162,7 @@ const char *SdlAudioFormatToString(int sdlAudioType) {
   case AUDIO_U16MSB: return "AUDIO_U16MSB";
   case AUDIO_S16LSB: return "AUDIO_S16LSB";
   case AUDIO_S16MSB: return "AUDIO_S16MSB";
+  case AUDIO_F32: return "AUDIO_F32";
   default: return "(unknown)";
   }
 }
@@ -222,6 +236,10 @@ void audio_callback(void *_beeper, Uint8 *_stream, int _length) {
   } else if (beeper->sdlAudioFormat == AUDIO_S16LSB) {
     Sint16 *stream = (Sint16*) _stream;
     int length = _length / 2;
+    beeper->generateSamples(stream, length);
+}  else if (beeper->sdlAudioFormat == AUDIO_F32) {
+    float *stream = (float*) _stream;
+    int length = _length / sizeof(float);
     beeper->generateSamples(stream, length);
   } else {
     assert(false && "Audio sample generation not implemented for current format!\n");

--- a/tests/sdl_audio_beep_sleep.cpp
+++ b/tests/sdl_audio_beep_sleep.cpp
@@ -87,8 +87,21 @@ Beeper::~Beeper() {
 }
 
 template<typename T>
+struct AmplitudeInfo {
+    typedef int type;
+    static const type max() { return (sizeof(T) == 2) ? 28000 : 120; }
+};
+
+template<>
+struct AmplitudeInfo<float> {
+    typedef float type;
+    static const type max() { return 1.0f; }
+};
+
+template<typename T>
 void Beeper::generateSamples(T *stream, int length) {
-  const int AMPLITUDE = (sizeof(T) == 2) ? 28000 : 120;
+  typedef typename AmplitudeInfo<T>::type AmplitudeType;
+  const AmplitudeType AMPLITUDE = AmplitudeInfo<T>::max();
   const int offset = (sdlAudioFormat == AUDIO_U8) ? 120 : 0;
 
   int i = 0;
@@ -112,7 +125,7 @@ void Beeper::generateSamples(T *stream, int length) {
 
     while (i < samplesToDo) {
       for(int j = 0; j < numChannels; ++j) {
-        stream[numChannels*i+j] = (T)(offset + (int)(AMPLITUDE * std::sin(phase * 2 * M_PI / frequency)));
+        stream[numChannels*i+j] = (T)(offset + (AmplitudeType)(AMPLITUDE * std::sin(phase * 2 * M_PI / frequency)));
         if (numChannels > 1 && j == mutedChannel) {
           stream[numChannels*i+j] = 0;
         }
@@ -143,7 +156,7 @@ Beeper *beep = 0;
 // test will report you which work.
 const int freqs[] = { 8000, 11025, 16000, 22050, 32000, 44100, 48000, 96000 };
 const int channels[] = { 1, 2 };
-const int sdlAudioFormats[] = { AUDIO_U8, AUDIO_S16LSB /*, AUDIO_S8, AUDIO_U16LSB, AUDIO_U16MSB, AUDIO_S16MSB */ };
+const int sdlAudioFormats[] = { AUDIO_F32, AUDIO_U8, AUDIO_S16LSB /*, AUDIO_S8, AUDIO_U16LSB, AUDIO_U16MSB, AUDIO_S16MSB */ };
 
 const char *SdlAudioFormatToString(int sdlAudioType) {
   switch(sdlAudioType) {
@@ -153,6 +166,7 @@ const char *SdlAudioFormatToString(int sdlAudioType) {
   case AUDIO_U16MSB: return "AUDIO_U16MSB";
   case AUDIO_S16LSB: return "AUDIO_S16LSB";
   case AUDIO_S16MSB: return "AUDIO_S16MSB";
+  case AUDIO_F32: return "AUDIO_F32";
   default: return "(unknown)";
   }
 }
@@ -227,6 +241,10 @@ void audio_callback(void *_beeper, Uint8 *_stream, int _length) {
   } else if (beeper->sdlAudioFormat == AUDIO_S16LSB) {
     Sint16 *stream = (Sint16*) _stream;
     int length = _length / 2;
+    beeper->generateSamples(stream, length);
+}  else if (beeper->sdlAudioFormat == AUDIO_F32) {
+    float *stream = (float*) _stream;
+    int length = _length / sizeof(float);
     beeper->generateSamples(stream, length);
   } else {
     assert(false && "Audio sample generation not implemented for current format!\n");


### PR DESCRIPTION
Currently, SDL & SDL2 implementations only support AUDIO_F32 / 48000 format. Tests with audio beep fail with all tested formats & combinations. I propose to add support for working AUDIO_F32 / 48000.