### PR TITLE
don't pass the target buffer into FS.mmap, as it is always HEAPU8, an…

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1165,7 +1165,7 @@ mergeInto(LibraryManager.library, {
       }
       stream.stream_ops.allocate(stream, offset, length);
     },
-    mmap: function(stream, buffer, offset, length, position, prot, flags) {
+    mmap: function(stream, offset, length, position, prot, flags) {
       // TODO if PROT is PROT_WRITE, make sure we have write access
       if ((stream.flags & {{{ cDefine('O_ACCMODE') }}}) === {{{ cDefine('O_WRONLY')}}}) {
         throw new FS.ErrnoError(ERRNO_CODES.EACCES);
@@ -1173,7 +1173,7 @@ mergeInto(LibraryManager.library, {
       if (!stream.stream_ops.mmap) {
         throw new FS.ErrnoError(ERRNO_CODES.ENODEV);
       }
-      return stream.stream_ops.mmap(stream, buffer, offset, length, position, prot, flags);
+      return stream.stream_ops.mmap(stream, offset, length, position, prot, flags);
     },
     msync: function(stream, buffer, offset, length, mmapFlags) {
       if (!stream || !stream.stream_ops.msync) {

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -332,7 +332,7 @@ mergeInto(LibraryManager.library, {
         MEMFS.expandFileStorage(stream.node, offset + length);
         stream.node.usedBytes = Math.max(stream.node.usedBytes, offset + length);
       },
-      mmap: function(stream, buffer, offset, length, position, prot, flags) {
+      mmap: function(stream, offset, length, position, prot, flags) {
         if (!FS.isFile(stream.node.mode)) {
           throw new FS.ErrnoError(ERRNO_CODES.ENODEV);
         }
@@ -341,7 +341,7 @@ mergeInto(LibraryManager.library, {
         var contents = stream.node.contents;
         // Only make a new copy when MAP_PRIVATE is specified.
         if ( !(flags & {{{ cDefine('MAP_PRIVATE') }}}) &&
-              (contents.buffer === buffer || contents.buffer === buffer.buffer) ) {
+              (contents.buffer === buffer) ) {
           // We can't emulate MAP_SHARED when the file is not backed by the buffer
           // we're mapping to (e.g. the HEAP buffer).
           allocated = false;
@@ -360,7 +360,7 @@ mergeInto(LibraryManager.library, {
           if (!ptr) {
             throw new FS.ErrnoError(ERRNO_CODES.ENOMEM);
           }
-          buffer.set(contents, ptr);
+          HEAPU8.set(contents, ptr);
         }
         return { ptr: ptr, allocated: allocated };
       },

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -885,7 +885,7 @@ var SyscallsLibrary = {
     } else {
       var info = FS.getStream(fd);
       if (!info) return -ERRNO_CODES.EBADF;
-      var res = FS.mmap(info, HEAPU8, addr, len, off, prot, flags);
+      var res = FS.mmap(info, addr, len, off, prot, flags);
       ptr = res.ptr;
       allocated = res.allocated;
     }


### PR DESCRIPTION
…d it may change if malloc reallocates.

Also msync and maybe others need similar treatment, to make them work with memory growth.

Not tested, this is just to start discussion on what the right path here is. See #5187.