### PR TITLE
Fix postset order

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -296,3 +296,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Yair Levinson (copyright owned by Autodesk, Inc.)
 * Matjaž Drolc <mdrolc@gmail.com>
 * James Swift <james@3dengineer.com> (copyright owned by PSPDFKit GmbH)
+* Ingvar Stepanyan <me@rreverser.com>

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -196,19 +196,22 @@ function JSify(data, functionsOnly) {
         Functions.libraryFunctions[finalName] = 1;
       }
 
+      if (redirectedIdent) {
+        deps = deps.concat(LibraryManager.library[redirectedIdent + '__deps'] || []);
+      }
+
       var postsetId = ident + '__postset';
       var postset = LibraryManager.library[postsetId];
       if (postset && !addedLibraryItems[postsetId] && !SIDE_MODULE) {
         addedLibraryItems[postsetId] = true;
         itemsDict.GlobalVariablePostSet.push({
           intertype: 'GlobalVariablePostSet',
-          JS: postset + ';'
+          JS: postset + ';',
+          ident: ident,
+          dependencies: deps
         });
       }
 
-      if (redirectedIdent) {
-        deps = deps.concat(LibraryManager.library[redirectedIdent + '__deps'] || []);
-      }
       // In asm, dependencies implemented in C might be needed by JS library functions.
       // We don't know yet if they are implemented in C or not. To be safe, export such
       // special cases.
@@ -275,7 +278,7 @@ function JSify(data, functionsOnly) {
     var limit = orderedPostSets.length * orderedPostSets.length;
     for (var i = 0; i < orderedPostSets.length; i++) {
       for (var j = i+1; j < orderedPostSets.length; j++) {
-        if (orderedPostSets[j].ident in orderedPostSets[i].dependencies) {
+        if (orderedPostSets[i].dependencies.indexOf(orderedPostSets[j].ident) >= 0) {
           var temp = orderedPostSets[i];
           orderedPostSets[i] = orderedPostSets[j];
           orderedPostSets[j] = temp;

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -1,5 +1,6 @@
 mergeInto(LibraryManager.library, {
-  $IDBFS__deps: ['$FS', '$MEMFS', '$PATH'],
+  // implicitly relies on $FS being already available
+  $IDBFS__deps: ['$MEMFS', '$PATH'],
   $IDBFS: {
     dbs: {},
     indexedDB: function() {

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -1,5 +1,5 @@
 mergeInto(LibraryManager.library, {
-  $MEMFS__deps: ['$FS'],
+  // implicitly relies on $FS being already available
   $MEMFS: {
     ops_table: null,
     mount: function(mount) {
@@ -71,7 +71,7 @@ mergeInto(LibraryManager.library, {
         // When the byte data of the file is populated, this will point to either a typed array, or a normal JS array. Typed arrays are preferred
         // for performance, and used by default. However, typed arrays are not resizable like normal JS arrays are, so there is a small disk size
         // penalty involved for appending file writes that continuously grow a file similar to std::vector capacity vs used -scheme.
-        node.contents = null; 
+        node.contents = null;
       } else if (FS.isLink(node.mode)) {
         node.node_ops = MEMFS.ops_table.link.node;
         node.stream_ops = MEMFS.ops_table.link.stream;

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -1,4 +1,5 @@
 mergeInto(LibraryManager.library, {
+  // implicitly relies on $FS being already available
   $NODEFS__deps: ['$PATH'],
   $NODEFS__postset: 'if (ENVIRONMENT_IS_NODE) { var fs = require("fs"); var NODEJS_PATH = require("path"); NODEFS.staticInit(); }',
   $NODEFS: {

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -1,5 +1,5 @@
 mergeInto(LibraryManager.library, {
-  $NODEFS__deps: ['$FS', '$PATH'],
+  $NODEFS__deps: ['$PATH'],
   $NODEFS__postset: 'if (ENVIRONMENT_IS_NODE) { var fs = require("fs"); var NODEJS_PATH = require("path"); NODEFS.staticInit(); }',
   $NODEFS: {
     isWindows: false,

--- a/src/library_proxyfs.js
+++ b/src/library_proxyfs.js
@@ -1,5 +1,6 @@
 mergeInto(LibraryManager.library, {
-  $PROXYFS__deps: ['$FS', '$PATH'],
+  // implicitly relies on $FS being already available
+  $PROXYFS__deps: ['$PATH'],
   $PROXYFS: {
     mount: function (mount) {
       return PROXYFS.createNode(null, '/', mount.opts.fs.lstat(mount.opts.root).mode, 0);

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -1,11 +1,11 @@
 mergeInto(LibraryManager.library, {
+  // implicitly relies on $FS being already available
   $SOCKFS__postset: '__ATINIT__.push(function() { SOCKFS.root = FS.mount(SOCKFS, {}, null); });',
-  $SOCKFS__deps: ['$FS'],
   $SOCKFS: {
     mount: function(mount) {
       // If Module['websocket'] has already been defined (e.g. for configuring
       // the subprotocol/url) use that, if not initialise it to a new object.
-      Module['websocket'] = (Module['websocket'] && 
+      Module['websocket'] = (Module['websocket'] &&
                              ('object' === typeof Module['websocket'])) ? Module['websocket'] : {};
 
       // Add the Event registration mechanism to the exported websocket configuration
@@ -325,7 +325,7 @@ mergeInto(LibraryManager.library, {
           });
           peer.socket.on('error', function(error) {
             // Although the ws library may pass errors that may be more descriptive than
-            // ECONNREFUSED they are not necessarily the expected error code e.g. 
+            // ECONNREFUSED they are not necessarily the expected error code e.g.
             // ENOTFOUND on getaddrinfo seems to be node.js specific, so using ECONNREFUSED
             // is still probably the most useful thing to do.
             sock.error = ERRNO_CODES.ECONNREFUSED; // Used in getsockopt for SOL_SOCKET/SO_ERROR test.
@@ -520,7 +520,7 @@ mergeInto(LibraryManager.library, {
         });
         sock.server.on('error', function(error) {
           // Although the ws library may pass errors that may be more descriptive than
-          // ECONNREFUSED they are not necessarily the expected error code e.g. 
+          // ECONNREFUSED they are not necessarily the expected error code e.g.
           // ENOTFOUND on getaddrinfo seems to be node.js specific, so using EHOSTUNREACH
           // is still probably the most useful thing to do. This error shouldn't
           // occur in a well written app as errors should get trapped in the compiled

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -1,5 +1,4 @@
 mergeInto(LibraryManager.library, {
-  $TTY__deps: ['$FS'],
   $TTY__postset: '__ATINIT__.unshift(function() { TTY.init() });' +
                  '__ATEXIT__.push(function() { TTY.shutdown() });',
   $TTY: {

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -1,4 +1,5 @@
 mergeInto(LibraryManager.library, {
+  // implicitly relies on $FS being already available
   $TTY__postset: '__ATINIT__.unshift(function() { TTY.init() });' +
                  '__ATEXIT__.push(function() { TTY.shutdown() });',
   $TTY: {

--- a/src/library_workerfs.js
+++ b/src/library_workerfs.js
@@ -1,5 +1,5 @@
 mergeInto(LibraryManager.library, {
-  $WORKERFS__deps: ['$FS'],
+  // implicitly relies on $FS being already available
   $WORKERFS: {
     DIR_MODE: {{{ cDefine('S_IFDIR') }}} | 511 /* 0777 */,
     FILE_MODE: {{{ cDefine('S_IFREG') }}} | 511 /* 0777 */,


### PR DESCRIPTION
finalCombiner's ordering code was unused because there is just one place that adds to GlobalVariablePostSet and it didn't add "ident" and "dependencies". This commit adds them and changes finalCombiner to expecte "dependencies" to be an array (it's usually pretty small, so indexOf shouldn't be a bottleneck).

Fixes #5283.