### PR TITLE
Simplified bytes allocation

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -313,6 +313,10 @@ if (!Module['quit']) {
   }
 }
 
+#if SIMPLE_ALLOCATION_API
+#include "simple_allocation_api.js"
+#endif
+
 // *** Environment setup code ***
 
 // Closure helpers

--- a/src/simple_allocation_api.js
+++ b/src/simple_allocation_api.js
@@ -1,0 +1,124 @@
+var pointers = [];
+/**
+  * Make Uint8Array of the value, since it might be any other TypedArray, while we're working with `Module['HEAPU8']`
+ *
+ * @param {!TypedArray|string} value
+ *
+ * @returns {!Uint8Array}
+ */
+function normalizeValue (value) {
+  if (value && value.buffer instanceof ArrayBuffer) {
+    value = new Uint8Array(value.buffer, value.byteOffset, value.byteLength);
+  } else if (typeof value === 'string') {
+    // `+ 1` means that NUL will be present at the end of the string
+    var length = value.length, array = new Uint8Array(length + 1);
+    for(var i = 0; i < length; ++i) {
+      array[i] = value.charCodeAt(i);
+    }
+    return array;
+  }
+  return value;
+}
+/**
+ * Creates pointer for specified address and data size
+ *
+ * @param {!Number|number} address
+ * @param {number} size
+ *
+ * @returns {!Number}
+ */
+function createPointer (address, size) {
+  var pointer;
+  pointer = new Number(address);
+  pointer['length'] = size;
+  /**
+   * @param {!TypedArray=Uint8Array} as
+   *
+   * @returns {!TypedArray}
+   */
+  pointer['get'] = function (as) {
+    as = as || Uint8Array;
+    // Create copy, since source buffer might be changed later
+    return (new as(buffer, pointer, size / as.BYTES_PER_ELEMENT)).slice();
+  };
+  /**
+   * @param {number=4} size
+   *
+   * @returns {!Number}
+   */
+  pointer['dereference'] = function (size) {
+    size = size || 4;
+    return createPointer(pointer['get'](Uint32Array)[0], size);
+  };
+  /**
+   * @param {!TypedArray|string} value
+   */
+  pointer['set'] = function (value) {
+    value = normalizeValue(value);
+    if (value.length > size) {
+      throw RangeError('invalid array length');
+    }
+    HEAPU8.set(value, pointer);
+  };
+  pointer['free'] = function () {
+    _free(pointer);
+    pointers.splice(pointers.indexOf(pointer), 1)
+  };
+  pointers.push(pointer);
+  return pointer;
+}
+/**
+ * Allocates pointer (with optional address), can be then passed to function where pointer to pointer is expected and afterwards dereferenced
+ *
+ * @param {!Number|number} address
+ *
+ * @returns {!Number}
+ */
+function allocatePointer (address) {
+  if (address) {
+    address = Uint32Array.of(address);
+  }
+  return allocateBytes(4, address);
+}
+/**
+ * Allocates specified number of bytes on the heap (optionally with default value) and returns object that can be used as pointer,
+ * but also has methods `get()`, `dereference()`, `set()`, `free()` and property `length`
+ *
+ * @param {number} size
+ * @param {!TypedArray|string} value
+ *
+ * @returns {!Number}
+ */
+function allocateBytes (size, value) {
+  var pointer;
+  value = normalizeValue(value);
+  // Compute size to be allocated from supplied value, allows writing cleaner code without `value.length` all the time
+  if (size === 0) {
+    size = value.length;
+  }
+  pointer = createPointer(_malloc(size), size);
+  if (value !== undefined) {
+    pointer['set'](value);
+    if (value.length < size) {
+      // Override with zeroes the rest of allocated memory
+      HEAPU8.fill(0, pointer + value.length, pointer + size);
+    }
+  } else {
+    // Like `_calloc()`, but not requiring it to be present
+    HEAPU8.fill(0, pointer, pointer + size);
+  }
+  return pointer;
+}
+/**
+ * Can be used to free all of the memory allocated with `Module.allocateBytes()` calls (useful for stateless libraries)
+ */
+function freeBytes () {
+  for (var i = 0, length = pointers.length; i < length; ++i) {
+    _free(pointers[i]);
+  }
+  pointers = [];
+}
+Module['createPointer'] = createPointer;
+Module['allocatePointer'] = allocatePointer;
+Module['allocateBytes'] = allocateBytes;
+Module['freeBytes'] = freeBytes;


### PR DESCRIPTION
Implements #5449

In one of the projects I'm working on it allows to reduce following:
```livescript
msgArrPtr     = supercop._malloc(message.length)
msgArr        = new Uint8Array(supercop.HEAPU8.buffer, msgArrPtr, message.length)
pubKeyArrPtr  = supercop._malloc(32)
pubKeyArr     = new Uint8Array(supercop.HEAPU8.buffer, pubKeyArrPtr, 32)
privKeyArrPtr = supercop._malloc(64)
privKeyArr    = new Uint8Array(supercop.HEAPU8.buffer, privKeyArrPtr, 64)
sigPtr        = supercop._malloc(64)
sig           = new Uint8Array(supercop.HEAPU8.buffer, sigPtr, 64)
msgArr.set(message)
pubKeyArr.set(publicKey)
privKeyArr.set(privateKey)
supercop
    .._ed25519_sign(sigPtr, msgArrPtr, message.length, pubKeyArrPtr, privKeyArrPtr)
    .._free(msgArrPtr)
    .._free(pubKeyArrPtr)
    .._free(privKeyArrPtr)
    .._free(sigPtr)
new Uint8Array(sig)
```

To this:
```livescript
message    = supercop.allocateBytes(0, message)
publicKey  = supercop.allocateBytes(0, publicKey)
privateKey = supercop.allocateBytes(0, privateKey)
signature  = supercop.allocateBytes(64)
supercop
  .._ed25519_sign(signature, message, message.length, publicKey, privateKey)
  ..freeBytes()
signature.get()
```

Code is written in LiveScript, but it shouldn't be too difficult to read (compiled JavaScript version of the first snippet is even longer).

Besides obvious readability and usability improvements it also allows to reduce the amount of code necessary to write during module consumption, which results in smaller browser bundles.

Let's stick to implementation discussion here and use #5449 to discuss the concept in general.

If this looks good, I'll update documentation and will probably even add some tests if someone helps me with that. Also I think this can be potentially hidden under compile-time option to reduce a few bytes for those who don't need this wrapper functions.