### PR TITLE
Adds c++11 std::async unit tests 

### DIFF
--- a/tests/async/test_async.cpp
+++ b/tests/async/test_async.cpp
@@ -1,0 +1,50 @@
+
+#include <emscripten.h>
+#include <emscripten/threading.h>
+#include <vector>
+#include <algorithm>
+#include <numeric>
+#include <future>
+
+// std::launch enum can be specified
+#ifndef STD_LAUNCH
+#define STD_LAUNCH std::launch::async
+#endif  // STD_LAUNCH 
+
+volatile int result = 0;
+
+template <typename _Iter>
+int parallel_sum(_Iter begin, _Iter end)
+{
+  EM_ASM(Module['print']('entering parallel_sum'););
+
+  auto len = end - begin;
+  if (len < 1000)
+      return std::accumulate(begin, end, 0);
+
+  _Iter mid = begin + len/2;
+  auto handle = std::async(STD_LAUNCH,
+                           parallel_sum<_Iter>, mid, end);
+  int sum = parallel_sum(begin, mid);
+  return sum + handle.get();
+}
+
+int main()
+{
+  if (!emscripten_has_threading_support())
+  {
+#ifdef REPORT_RESULT
+    result = 1;
+    REPORT_RESULT();
+#endif
+    printf("Skipped: Threading is not supported.\n");
+    return 0;
+  }
+
+  std::vector<int> v(10000, 1);
+  result = parallel_sum(v.begin(), v.end()) != v.size();
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT();
+#endif
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3323,6 +3323,14 @@ window.close = function() {
     Popen([PYTHON, EMCC, path_from_root('tests', 'atomicrmw_i64.ll'), '-s', 'USE_PTHREADS=1', '-s', 'IN_TEST_HARNESS=1', '-o', 'test.html']).communicate()
     self.run_browser('test.html', None, '/report_result?0')
 
+  # Test std::async with deferred launch policy.
+  def test_async_deferred(self):
+    self.btest(path_from_root('tests', 'async', 'test_async.cpp'), expected='0', args=['-O3', '-std=c++11', "-DSTD_LAUNCH=std::launch::deferred", '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8', '--separate-asm'], timeout=30)
+
+  # Test std::async with async launch policy.
+  def test_async_async(self):
+    self.btest(path_from_root('tests', 'async', 'test_async.cpp'), expected='0', args=['-O3', '-std=c++11', "-DSTD_LAUNCH=std::launch::async", '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8', '--separate-asm'], timeout=30)
+
   # Test that it is possible to send a signal via calling alarm(timeout), which in turn calls to the signal handler set by signal(SIGALRM, func);
   def test_sigalrm(self):
     self.btest(path_from_root('tests', 'sigalrm.cpp'), expected='0', args=['-O3'], timeout=30)


### PR DESCRIPTION
This PR adds c++11 std::async unit tests to reproduces issue #5430.

You might not want to accept it, no problem. The purpose is rather to have a simple test case to showcase the nonfunctional feature as discussed.

I added 2 tests, with the 2 launch modes proposed by the standard:
- test_async_deferred test passes because it doesn't require any new thread
- test_async_async test hangs.

Below is the log from test_async_async. We can see that threads are properly created. The synchronisation on std::future::get seems to dead lock.

```
Error in parsing value for ‘padding’.  Declaration dropped.  test.html:11:17
Preallocating 8 workers for a pthread spawn pool.  test.html:1237:13
pre-main prep time: 6321 ms  test.html:1249:13
entering parallel_sum test.html:1237:13
entering parallel_sum  pthread-main.js:32:3
entering parallel_sum test.html:1237:13
entering parallel_sum pthread-main.js:32:3
Preallocating 1 workers for a pthread spawn pool.  test.html:1237:13
entering parallel_sum pthread-main.js:32:3
Preallocating 1 workers for a pthread spawn pool. test.html:1237:13
entering parallel_sum  pthread-main.js:32:3
Preallocating 1 workers for a pthread spawn pool.  test.html:1237:13
entering parallel_sum pthread-main.js:32:3
Preallocating 1 workers for a pthread spawn pool.  test.html:1237:13
entering parallel_sum  pthread-main.js:32:3
Error: Script terminated by timeout at:
_emscripten_futex_wait@http://localhost:8888/test.js:5916:16
___timedwait_cp@http://localhost:8888/test.asm.js:11408:11
___pthread_cond_timedwait@http://localhost:8888/test.asm.js:12108:10
_pthread_cond_wait@http://localhost:8888/test.asm.js:12403:8
dynCall_iii@http://localhost:8888/test.asm.js:15918:10
invoke_iii@http://localhost:8888/test.js:6353:12
__ZNSt3__218condition_variable4waitERNS_11unique_lockINS_5mutexEEE@http://localhost:8888/test.asm.js:12576:9
__ZNSt3__217__assoc_sub_state10__sub_waitERNS_11unique_lockINS_5mutexEEE@http://localhost:8888/test.asm.js:13092:5
dynCall_vii@http://localhost:8888/test.asm.js:15876:3
invoke_vii@http://localhost:8888/test.js:6299:5
__ZNSt3__213__assoc_stateIiE4moveEv@http://localhost:8888/test.asm.js:3129:2
dynCall_ii@http://localhost:8888/test.asm.js:15883:10
invoke_ii@http://localhost:8888/test.js:6308:12
__ZNSt3__26futureIiE3getEv@http://localhost:8888/test.asm.js:1243:9
dynCall_ii@http://localhost:8888/test.asm.js:15883:10
invoke_ii@http://localhost:8888/test.js:6308:12
__Z12parallel_sumINSt3__211__wrap_iterIPiEEEiT_S4_@http://localhost:8888/test.asm.js:545:9
dynCall_iii@http://localhost:8888/test.asm.js:15918:10
invoke_iii@http://localhost:8888/test.js:6353:12
__Z12parallel_sumINSt3__211__wrap_iterIPiEEEiT_S4_@http://localhost:8888/test.asm.js:528:9
dynCall_iii@http://localhost:8888/test.asm.js:15918:10
invoke_iii@http://localhost:8888/test.js:6353:12
_main@http://localhost:8888/test.asm.js:264:9
asm._main@http://localhost:8888/test.js:6661:10
callMain@http://localhost:8888/test.js:6897:15
doRun@http://localhost:8888/test.js:6961:42
run/<@http://localhost:8888/test.js:6972:7
  test.js:5916:16
entering parallel_sum pthread-main.js:32:3
```
However I found that if enough threads (>= 15, don't know why!) are preallocated, then the test passes.