### PR TITLE
Fix detection of CMake try_compile() invocations.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -405,7 +405,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   # If this is a configure-type thing, do not compile to JavaScript, instead use clang
   # to compile to a native binary (using our headers, so things make sense later)
   CONFIGURE_CONFIG = (os.environ.get('EMMAKEN_JUST_CONFIGURE') or 'conftest.c' in sys.argv) and not os.environ.get('EMMAKEN_JUST_CONFIGURE_RECURSE')
-  CMAKE_CONFIG = 'CMakeFiles/cmTryCompileExec.dir' in ' '.join(sys.argv)# or 'CMakeCCompilerId' in ' '.join(sys.argv)
+  CMAKE_CONFIG = False if os.environ.get('EMMAKEN_JUST_CONFIGURE_RECURSE') else \
+                 re.search('CMakeFiles[/' + re.escape(os.sep) + ']cmTryCompileExec\d*\.dir', ' '.join(sys.argv)) \
+                 or re.search('CMakeFiles[/' + re.escape(os.sep) + ']cmTC_[\da-f]{5,5}\.dir', ' '.join(sys.argv)) \
+                 # or 'CMakeCCompilerId' in ' '.join(sys.argv)
   if CONFIGURE_CONFIG or CMAKE_CONFIG:
     debug_configure = 0 # XXX use this to debug configure stuff. ./configure's generally hide our normal output including stderr so we write to a file
 


### PR DESCRIPTION
The test executable is no longer named cmTryCompileExec[1][2], and EMMAKEN_JUST_CONFIGURE_RECURSE should be respected to avoid endless recursion.

[1] https://gitlab.kitware.com/cmake/cmake/commit/4fbdce2b79b28566ae2c6708c99af5e0e8e0177b
[2] https://gitlab.kitware.com/cmake/cmake/commit/f3e9eeedf43f783c02b2a2a10fc0e632eaf7cfd0