### PR TITLE
Efficient conversion between JS arrays and c++ vectors for numeric types

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -315,5 +315,6 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jiajie Hu <jiajie.hu@intel.com> (copyright owned by Intel Corporation)
 * Kamil Klimek <naresh@tlen.pl>
 * José Carlos Pujol <josecpujol(at)gmail.com>
+* Ron Cohen <ron28299@gmail.com>
 
 

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -532,7 +532,8 @@ namespace emscripten {
                     arrayType = "Float64Array";
                     break;
                 default:
-                    throw;
+                    //This should be never reached if the 'typeSupportsMemoryView' function returns true.
+                    throw std::logic_error("Unreachable");
             }
 
             val memory = val::module_property("buffer");

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -497,6 +497,7 @@ namespace emscripten {
     std::vector<T> vecFromJSArray(val v) {
         auto l = v["length"].as<unsigned>();
         std::vector<T> rv;
+        rv.reserve(l);
 
         if (internal::typeSupportsMemoryView<T>()) {
             rv.resize(l);


### PR DESCRIPTION
I added efficient implementation to the `vecFromJSArray` function for numeric types. The function checks if the requested vector type has a matching `TypedArray` and if so, uses it to copy the array  / array-like object directly into the Heap `buffer` and uses this memory as the vector backend.

This is useful for converting large numeric arrays as it faster in orders of magnitude.

There may be some compatibility issues when the array contains non-numeric values, as any such value would be converted to a numeric value by the JS engine (`NaN` would become zero), which I don't think is the current behavior caused by using `val::as` function to convert the JS value to c++ value.

Fixes #5519.