### PR TITLE
preamble: don't attempt to use fetch in Node

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2336,7 +2336,7 @@ function integrateWasmJS() {
       });
     }
     // Prefer streaming instantiation if available.
-    if (!Module['wasmBinary'] && typeof WebAssembly.instantiateStreaming === 'function') {
+    if (!Module['wasmBinary'] && typeof WebAssembly.instantiateStreaming === 'function' && !ENVIRONMENT_IS_NODE) {
       WebAssembly.instantiateStreaming(fetch(wasmBinaryFile, { credentials: 'same-origin' }), info)
         .then(receiveInstantiatedSource)
         .catch(function(reason) {


### PR DESCRIPTION
Node v8.6.0 (at least) has the WebAssembly.instantiateStreaming API,
but node doesn't provide fetch.  This causes programs compiled like so:

  emcc -O1  main.c -s WASM=1 -s BINARYEN_METHOD=\'native-wasm\' -o main.js

To fail to run.  Add an additional guard to ensure we're not running
in node.