### PR TITLE
Some systems that do no use unicode directly for filepaths will use U…

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -215,7 +215,7 @@ def has_hidden_attribute(filepath):
     return False
     
   try:
-    attrs = ctypes.windll.kernel32.GetFileAttributesW(unicode(filepath))
+    attrs = ctypes.windll.kernel32.GetFileAttributesW(unicode(filepath.encode('utf-8')))
     assert attrs != -1
     result = bool(attrs & 2)
   except:


### PR DESCRIPTION
…TF-8. UTF-8 will also work for non UTF-8 file systems. This could return false even when it may have been able to get the non ascii filepath by first converting it to UTF-8. Seems that this was fixed with catch-all excpetion in this commit d0a002becc32a46bc268f5bf3b272ccd1ffb9488 but attempting to encode to UTF-8 may be an improvement.