### PR TITLE
Clarify that for wasm we have a better option than ONLY_MY_CODE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1174,6 +1174,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if shared.Settings.BINARYEN_PASSES:
             shared.Settings.BINARYEN_PASSES += ','
           shared.Settings.BINARYEN_PASSES += 'safe-heap'
+        if shared.Settings.ONLY_MY_CODE:
+          logging.warning('Instead of ONLY_MY_CODE, for wasm it is recommended to use SIDE_MODULE, see https://github.com/kripken/emscripten/wiki/WebAssembly-Standalone')
 
       # wasm outputs are only possible with a side wasm
       if target.endswith(WASM_ENDINGS):

--- a/src/settings.js
+++ b/src/settings.js
@@ -619,6 +619,10 @@ var ONLY_MY_CODE = 0; // This disables linking and other causes of adding extra 
                       // automatically, and as a result, your output compiled code
                       // (in the .asm.js file, if you emit with --separate-asm) will
                       //  contain only the functions you provide.
+                      // Note: this still emits JS support code. If you want just
+                      //       a wasm file from your compiled code, without JS support
+                      //       or system libraries, you can use a wasm side module, see
+                      //       https://github.com/kripken/emscripten/wiki/WebAssembly-Standalone
 
 var PGO = 0; // Enables profile-guided optimization in the form of runtime checks for
              // which functions are actually called. Emits a list during shutdown that you


### PR DESCRIPTION
Namely, standalone wasm (side module), https://github.com/kripken/emscripten/wiki/WebAssembly-Standalone

People keep finding ONLY_MY_CODE first and asking about it. Perhaps we should even remove that option, not sure if anyone uses it.