### PR TITLE
Add hashing to emar archive members when using response file.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -317,4 +317,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * José Carlos Pujol <josecpujol(at)gmail.com>
 * Dannii Willis <curiousdannii@gmail.com>
 * Erik Dubbelboer <erik@dubbelboer.com>
-
+* Sergey Karchevsky <sergey.ext@gmail.com>

--- a/emar.py
+++ b/emar.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
 
 import os, subprocess, sys
 from tools import shared
-from tools.append_hashes import append_hash_to_file_list
+from tools.append_hashes import make_hashed_response_file
 
 #
 # Main run() function
@@ -29,7 +29,6 @@ def run():
   if DEBUG:
     print('emar:', sys.argv, '  ==>  ', newargs, file=sys.stderr)
 
-  to_delete = []
   if len(newargs) > 2:
     if 'r' in newargs[1]:
       # we are adding files to the archive.
@@ -40,16 +39,14 @@ def run():
       i = 1
       while i < len(newargs):
         if newargs[i].endswith('.a'):
-          (hashed_names, to_delete) = append_hash_to_file_list(newargs[(i + 1):])
-          newargs[(i + 1):] = hashed_names
-          break
+          rsp_filename = '%s%s' % ('@', make_hashed_response_file(newargs[(i + 1):], os.getcwd()))
+          newargs = newargs[0:(i + 1)]
+          newargs.append(rsp_filename)
         i += 1
 
   if DEBUG:
     print('Invoking ' + str(newargs))
   subprocess.call(newargs, stdin=sys.stdin)
-  for d in to_delete:
-    shared.try_delete(d)
 
 if __name__ == '__main__':
   run()

--- a/emar.py
+++ b/emar.py
@@ -14,6 +14,7 @@ if __name__ == '__main__':
 
 import os, subprocess, sys
 from tools import shared
+from tools.append_hashes import append_hash_to_file_list
 
 #
 # Main run() function
@@ -39,24 +40,8 @@ def run():
       i = 1
       while i < len(newargs):
         if newargs[i].endswith('.a'):
-          import hashlib, shutil
-          for j in range(i+1, len(newargs)):
-            orig_name = newargs[j]
-            full_name = os.path.abspath(orig_name)
-            dir_name = os.path.dirname(full_name)
-            base_name = os.path.basename(full_name)
-            h = hashlib.md5(full_name.encode('utf-8')).hexdigest()[:8]
-            parts = base_name.split('.')
-            parts[0] += '_' + h
-            newname = '.'.join(parts)
-            full_newname = os.path.join(dir_name, newname)
-            if not os.path.exists(full_newname):
-              try: # it is ok to fail here, we just don't get hashing
-                shutil.copyfile(orig_name, full_newname)
-                newargs[j] = full_newname
-                to_delete.append(full_newname)
-              except:
-                pass
+          (hashed_names, to_delete) = append_hash_to_file_list(newargs[(i + 1):])
+          newargs[(i + 1):] = hashed_names
           break
         i += 1
 

--- a/tools/append_hashes.py
+++ b/tools/append_hashes.py
@@ -1,0 +1,108 @@
+'''
+Recurrent response file traverser.
+
+Extends each file name from a file list with it's full path hash and copies original file to hashed file.
+Response files (i.e. whose name start with @ and who contain a list of other files) are processed recursively.
+
+Modifies response files content with hashed file names.
+Also returns list of copied files.
+
+Ar archivers (ar, llvm-ar) include only basename of their members whithout a full path,
+which leads to duplicate entries in an archive. When linking with *.a file containing duplicate entries,
+only the last one is taken into account, leading to unresolved external symbols.
+Appending full path hash to file name helps to avoid duplicate entries in archives, which takes place
+when we archive files with same basenames from different directories.
+'''
+
+
+import hashlib, os, shutil
+
+# appends absolute path hash to file_name
+def append_hash(file_name):
+  full_name = os.path.abspath(file_name)
+  full_name_hash = hashlib.md5(full_name.encode('utf-8')).hexdigest()[:8]
+  base_name = os.path.basename(file_name)
+  dir_name = os.path.dirname(file_name)
+  parts = base_name.split('.')
+  parts[0] = '%s_%s' % (parts[0], full_name_hash)
+  hashed_base_name = '.'.join(parts)
+  return os.path.join(dir_name, hashed_base_name)
+
+def find_unused_filename(file_name):
+  nonce = 0
+  while os.path.exists(file_name):
+    base_name = os.path.basename(file_name)
+    dir_name = os.path.dirname(file_name)
+    parts = base_name.split('.')
+    parts[0] = '%s_%d' % (parts[0], nonce)
+    nonced_base_name = '.'.join(parts)
+    file_name = os.path.join(dir_name, nonced_base_name)
+    nonce += 1
+  return file_name
+
+# Append hashes to all files referenced in file rsp_filename.
+# Original files are always copied to hashed files, as they could be altered since last copying.
+# Recursively processes other rsp files referenced in rsp_filename.
+def append_hash_to_rsp_file(rsp_filename):
+  with open(rsp_filename, 'r') as f:
+    rsp_content = f.read().replace('\n', '')
+  (hashed_names, copied_names) = append_hash_to_file_list(rsp_content_as_list(rsp_content))
+  with open(rsp_filename, 'w') as f:
+    f.write(' '.join(hashed_names))
+  return copied_names
+
+# parse response file content according to @file section from man ar(1)
+def rsp_content_as_list(rsp_content):
+  result = []
+  current = ''
+  verbatim = False
+  skip = False
+  for i in range(len(rsp_content)):
+    if skip:
+      skip = False
+      continue
+    if rsp_content[i] == '\\':
+      current += rsp_content[i + 1]
+      skip = True
+      continue
+    if rsp_content[i] == '"':
+      if verbatim:
+        result.append(current)
+        current = ''
+      verbatim = not verbatim
+      continue
+    if (rsp_content[i] == ' ') and (not verbatim):
+      if len(current) > 0:
+        result.append(current)
+        current = ''
+      continue
+    current += rsp_content[i]
+  if len(current) > 0:
+    result.append(current)
+  return result
+
+# Append hash to each file name from file_list.
+# Recursively call append_hash_to_rsp_file on each rsp file from file_list.
+def append_hash_to_file_list(file_list):
+  hashed_names = []
+  copied_names = []
+  for file_name in file_list:
+    if file_name.startswith('@'):
+      tobehashed_file_name = file_name[1:]
+    else:
+      tobehashed_file_name = file_name
+    # prevent any existing files from overwriting
+    hashed_name = find_unused_filename(append_hash(tobehashed_file_name))
+    full_hashed_name = os.path.abspath(hashed_name)
+    if file_name.startswith('@'): # prepend @ back to hashed file name
+      hashed_name = '@%s' % (hashed_name)
+    try: # it is ok to fail here, we just don't get hashing
+      shutil.copyfile(tobehashed_file_name, full_hashed_name)
+      hashed_names.append(hashed_name)
+      copied_names.append(full_hashed_name) # delete copied files only
+    except:
+      hashed_names.append(file_name)
+    if file_name.startswith('@'):
+      copied_names.extend(append_hash_to_rsp_file(hashed_names[-1][1:]))
+  hashed_names = map(lambda fname: '"%s"' % (fname) if ' ' in fname else fname, hashed_names)
+  return (hashed_names, copied_names)

--- a/tools/response_file.py
+++ b/tools/response_file.py
@@ -44,3 +44,15 @@ def read_response_file(response_filename):
     logging.warning('Read response file ' + response_filename + ': ' + str(args))
 
   return args
+
+# Expands response file recursively.
+# Returns contents of all response files as list of file names.
+def expand_response_files(args):
+  result = []
+  for arg in args:
+    if arg.startswith('@'):
+      rsp_content = read_response_file(arg)
+      result.extend(expand_response_files(rsp_content))
+    else:
+      result.append(arg)
+  return result


### PR DESCRIPTION
* Fix Duplicate file names in .r with response files (#5425)
* Another implementation of Add support for adding hash to object files listed inside response file (#5505)
* Indirect fix for Emscripten output static libs as archive (.a) instead of bitcode (.bc) when using CMake toolchain file (#3731)

Ar archiver does not take file paths into account, so emar appends full path hashes to filenames. It does not happen when response files (which contain lists of other files) are passed to emar, so the issue #3731 is still present when building with cmake.

An simple solution is to unroll response files manually and pass the unrolled list to llvm-ar, but this could break builds in OS with restricted command line length.

Thus, my approach is to duplicate all response and archive member files with their copies, appending hashes to file names and altering hashed versions of response files.

All response files are traversed recursively and parsed according to ar(1) manual.

All hashed file names are collected and files are removed after llvm-ar finish, so emar does not corrupt any existing files.
