### PR TITLE
Remove --no-wasm-async-compilation for d8, add testRunner.waitUntilDone

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2253,7 +2253,8 @@ function integrateWasmJS() {
       // d8 shell doesn't always resolve the WebAssembly.instantiate promise
       // when exiting, so we need to call testRunner.waitUntilDone/.notifyDone,
       // which only exist in d8
-      return (ENVIRONMENT_IS_SHELL && testRunner &&
+      return (ENVIRONMENT_IS_SHELL &&
+              typeof testRunner === 'object' &&
               typeof testRunner.waitUntilDone === 'function' &&
               typeof testRunner.notifyDone === 'function');
     }
@@ -2276,6 +2277,8 @@ function integrateWasmJS() {
       trueModule = null;
 #endif
       if (isD8Shell()) {
+        // Need to tell d8 that we're done waiting to run promise code, and can
+        // exit normally when everything else finishes.
         testRunner.notifyDone();
       }
       receiveInstance(output['instance'], output['module']);
@@ -2309,6 +2312,8 @@ function integrateWasmJS() {
       instantiateArrayBuffer(receiveInstantiatedSource);
     }
     if (isD8Shell()) {
+      // Need to use a workaround to keep the d8 shell alive until it can resolve
+      // the WebAssembly.instantiate promise.
       testRunner.waitUntilDone();
     }
     return {}; // no exports yet; we'll fill them in later

--- a/src/shell.js
+++ b/src/shell.js
@@ -155,7 +155,9 @@ else if (ENVIRONMENT_IS_SHELL) {
 
   if (typeof quit === 'function') {
     Module['quit'] = function(status, toThrow) {
-      quit(status);
+      // In d8, calling quit in a promise causes deadlock. setTimeout gets
+      // around that: https://bugs.chromium.org/p/v8/issues/detail?id=7212#c1
+      setTimeout(function() { quit(status); });
     }
   }
 }

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -36,12 +36,9 @@ def make_command(filename, engine=None, args=[]):
   jsengine = os.path.split(engine[0])[-1]
   # Use "'d8' in" because the name can vary, e.g. d8_g, d8, etc.
   is_d8 = 'd8' in jsengine
-  # Disable true async compilation (async apis will in fact be synchronous) for now
-  # due to https://bugs.chromium.org/p/v8/issues/detail?id=6263
-  shell_option_flags = ['--no-wasm-async-compilation'] if is_d8 else []
   # Separates engine flags from script flags
   flag_separator = ['--'] if is_d8 or 'jsc' in jsengine else []
-  return engine + [filename] + shell_option_flags + flag_separator + args
+  return engine + [filename] + flag_separator + args
 
 
 def check_engine(engine):


### PR DESCRIPTION
The wasm waterfall is running into deadlocks when compiling torture tests with emscripten and running them with d8, after changes to compilation in v8. This fixes that by properly handling asynchronous compilation in d8.