### PR TITLE
Multithreading 15/N: Synchronous stdio

### DIFF
--- a/src/shell.html
+++ b/src/shell.html
@@ -1214,40 +1214,71 @@
     <div class="emscripten_border">
       <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()"></canvas>
     </div>
-    <textarea id="output" rows="8"></textarea>
+    <textarea id="output" rows="8" autocomplete=off></textarea>
 
     <script type='text/javascript'>
       var statusElement = document.getElementById('status');
       var progressElement = document.getElementById('progress');
       var spinnerElement = document.getElementById('spinner');
+      var consoleElement = document.getElementById('output');
+
+      function onkey(e) {
+        console.error(e);
+        if (e.ctrlKey || e.altKey) return;
+        if (e.key.length == 1) Module.writeStdin(e.key);
+        else if (e.key == "Enter") Module.writeStdin('\n');
+        else if (e.key == "Backspace") Module.writeStdin(0x08);
+      }
+      window.addEventListener('keypress', onkey);
+      consoleElement.addEventListener('paste', function(e) { var text = e.clipboardData.getData('Text'); Module.writeStdin(text); });
 
       var Module = {
         preRun: [],
         postRun: [],
-        print: (function() {
-          var element = document.getElementById('output');
-          if (element) element.value = ''; // clear browser cache
-          return function(text) {
-            if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-            // These replacements are necessary if you render to raw HTML
-            //text = text.replace(/&/g, "&amp;");
-            //text = text.replace(/</g, "&lt;");
-            //text = text.replace(/>/g, "&gt;");
-            //text = text.replace('\n', '<br>', 'g');
-            console.log(text);
-            if (element) {
-              element.value += text + "\n";
-              element.scrollTop = element.scrollHeight; // focus on bottom
-            }
-          };
-        })(),
-        printErr: function(text) {
-          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-          if (0) { // XXX disabled for safety typeof dump == 'function') {
-            dump(text + '\n'); // fast, straight to the real console
-          } else {
-            console.error(text);
+        fdBuf: ['', '', ''],
+        writeStdin: function(text) {
+          if (text == 0x08) {
+            if (Module.fdBuf[0].length > 0) Module.fdBuf[0] = Module.fdBuf[0].length.substr(0, Module.fdBuf[0].length-1);
+            return;
           }
+          var lastnl = text.lastIndexOf('\n');
+          if (lastnl == -1) {
+            Module.fdBuf[0] += text;
+            return;
+          }
+          Module.fdBuf[0] += text.substr(0, lastnl+1);
+          var len = lengthBytesUTF8(Module.fdBuf[0]);
+          var buf = _malloc(len+1);
+          stringToUTF8(Module.fdBuf[0], buf, len+1);
+          _writeStdin(buf, len);
+          _free(buf);
+          Module.fdBuf[0] = text.substr(lastnl+1);
+        },
+        writeOut: function(fd, ptr, len) {
+          if (!ptr) return;
+          var str = (typeof ptr === 'number') ? String.fromCharCode.apply(String, HEAPU8.subarray(ptr, ptr + len)) : ptr;
+          consoleElement.value += str;
+          consoleElement.scrollTop = consoleElement.scrollHeight;
+          var nl = str.indexOf('\n');
+          if (nl == -1) {
+            Module.fdBuf[fd] += str;
+            return;
+          }
+          var log = (fd == 2) ? console.error : console.log;
+          log(Module.fdBuf[fd] + str.substr(0, nl));
+          var nextnl = str.indexOf('\n', nl+1);
+          while (nextnl != -1) {
+            log(str.substr(nl+1), nextnl-nl-1);
+            nl = nextnl;
+            nextnl = str.indexOf('\n', nl+1);
+          }
+          Module.fdBuf[fd] = str.substr(nl+1);
+        },
+        print: function() {
+          Module.writeOut(1, Array.prototype.slice.call(arguments).join(' ') + '\n');
+        },
+        printErr: function() {
+          Module.writeOut(2, Array.prototype.slice.call(arguments).join(' ') + '\n');
         },
         canvas: (function() {
           var canvas = document.getElementById('canvas');


### PR DESCRIPTION
Implement synchronous blocking stdio for ASMFS and add new Module.writeOut and Module.writeStdin functions to perform non-linebuffered stdio.

This allows one to type and copy-paste in the textarea in the shell page, and those bytes become available for reading in the application that uses ASMFS. Likewise, printing to stdout will immediately appear in the console text box on the page without waiting for newline, but a newline is waited for until printing out to line-buffered `console.log()`.

Will need a bit more polish, but posting to accompany the conversation in #6080 so that we'll have a solution that works both for ASMFS and MEMFS equally. The general idea here follows the outline of #5290, i.e. the idea would be that Emscripten library side (MEMFS and ASMFS) would assume that printing is char-buffered, and have the shell file store buffer up full lines if/when needed. This resolves #2770.

However before this could be merged, ideally we'd #ifdef preprocess the html shell file, and gate this whole feature behind a `LINEBUFFERED_STDIO=0` option (for MEMFS, we can assume that ASMFS would always be non-linebuffered), so that people can configure which way their shell file is built up. That is, existing shell files that people use do not currently come with a `Module.writeStdin` or `Module.writeOut` function, so this would need to be an opt-in flag so that existing shell files won't break.