### PR TITLE
Support nvm-installed Node.js for EMCONFIGURE_JS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -511,7 +511,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         src = open(target).read()
         full_node = ' '.join(shared.NODE_JS)
         if os.path.sep not in full_node:
-          full_node = '/usr/bin/' + full_node # TODO: use whereis etc. And how about non-*NIX?
+          full_node = '/usr/bin/env ' + full_node # TODO: use whereis etc. And how about non-*NIX?
         open(target, 'w').write('#!' + full_node + '\n' + src) # add shebang
         import stat
         try:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8163,3 +8163,14 @@ end
     assert expected in err
     err = run_process(base + ['--embed-files', 'somefile'], stderr=PIPE, check=False).stderr
     assert expected in err
+
+  def test_configurejs_envnode(self):
+    if WINDOWS:
+      return self.skip('Windows does not support running extension-less executable file')
+    environ = os.environ.copy()
+    environ['EMMAKEN_JUST_CONFIGURE'] = '1'
+    environ['EMCONFIGURE_JS'] = '2'
+    if os.path.sep in NODE_JS:
+      environ['PATH'] = NODE_JS + ';' if WINDOWS else ':' + environ['PATH']
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'hello'], env=environ)
+    run_process([os.path.join(self.get_dir(), 'hello')])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8171,6 +8171,6 @@ end
     environ['EMMAKEN_JUST_CONFIGURE'] = '1'
     environ['EMCONFIGURE_JS'] = '2'
     if os.path.sep in NODE_JS:
-      environ['PATH'] = NODE_JS + ';' if WINDOWS else ':' + environ['PATH']
+      environ['PATH'] = NODE_JS + (';' if WINDOWS else ':') + environ['PATH']
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'hello'], env=environ)
     run_process([os.path.join(self.get_dir(), 'hello')])


### PR DESCRIPTION
nvm installs Node.js in its own path instead of `/usr/bin`, so this PR allows to use it.