### PR TITLE
Allow async library functions to return a promise

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -314,8 +314,13 @@ def function_tables_and_exports(funcs, metadata, mem_init, glue, forwarded_data,
   asm_global_vars = create_asm_global_vars(bg_vars, settings)
 
   the_global = create_the_global(metadata, settings)
-  sending_vars = basic_funcs + global_funcs + basic_vars + global_vars
-  sending = '{ ' + ', '.join(['"' + math_fix(s) + '": ' + s for s in sending_vars]) + ' }'
+  sending_vars = basic_funcs + basic_vars + global_vars
+  sending_vars_texts = ['"' + math_fix(s) + '": ' + s for s in sending_vars]
+  if settings.get('EMTERPRETIFY_ASYNC'):
+    sending_vars_texts += ['"' + math_fix(s) + '": emscripten_async_wrap(' + s + ')' for s in global_funcs]
+  else:
+    sending_vars_texts += ['"' + math_fix(s) + '": ' + s for s in global_funcs]
+  sending = '{ ' + ', '.join(sending_vars_texts) + ' }'
 
   receiving = create_receiving(function_table_data, function_tables_defs,
                                exported_implemented_functions, settings)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7181,6 +7181,45 @@ int main() {
 
     self.do_run(src, 'napped');
 
+  def test_async_promise(self):
+    if not self.is_emterpreter(): return self.skip('emterpreter-only test')
+
+    Settings.EMTERPRETIFY_ASYNC = 1
+    self.banned_js_engines = [SPIDERMONKEY_ENGINE, V8_ENGINE] # needs setTimeout which only node has
+
+    open('lib.js', 'w').write(r'''
+mergeInto(LibraryManager.library, {
+  sleep_with_return__deps: ['$EmterpreterAsync'],
+  sleep_with_return: function(ms) {
+    return new Promise( function(resolve, reject) {
+      var startTime = Date.now();
+      setTimeout(function() {
+        resolve( Date.now() - startTime );
+      }, ms);
+    });
+  }
+});
+''')
+
+    src = r'''
+#include <stdio.h>
+#include <assert.h>
+#include <emscripten.h>
+
+extern "C" {
+extern int sleep_with_return(int ms);
+}
+
+int main() {
+  int ms = sleep_with_return(1000);
+  assert(ms >= 900);
+  printf("napped for %d ms\n", ms);
+}
+'''
+    self.emcc_args += ['--js-library', 'lib.js']
+
+    self.do_run(src, 'napped');
+
   def test_async_exit(self):
     if not self.is_emterpreter(): return self.skip('emterpreter-only test')
 


### PR DESCRIPTION
This is an ugly nasty hack, with most of the code taken from EmterpreterAsync.handle even though I'm not sure it's all necessary. But it works!

I'm posting this as a proof of concept, and wouldn't expect it to be merged as-is.

One thing I forgot to add is a catch handler. I was thinking that the user could specify a custom catch handler, probably as a Module property.