### PR TITLE
emcc.py: Fixed handling of -x[lang] fixed language options

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -46,9 +46,10 @@ C_ENDINGS = ('.c', '.C', '.i')
 CXX_ENDINGS = ('.cpp', '.cxx', '.cc', '.c++', '.CPP', '.CXX', '.CC', '.C++', '.ii')
 OBJC_ENDINGS = ('.m', '.mi')
 OBJCXX_ENDINGS = ('.mm', '.mii')
+EC_ENDINGS = ('.ec',)
 SPECIAL_ENDINGLESS_FILENAMES = ('/dev/null',)
 
-SOURCE_ENDINGS = C_ENDINGS + CXX_ENDINGS + OBJC_ENDINGS + OBJCXX_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES
+SOURCE_ENDINGS = C_ENDINGS + CXX_ENDINGS + OBJC_ENDINGS + OBJCXX_ENDINGS + EC_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES
 C_ENDINGS = C_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES # consider the special endingless filenames like /dev/null to be C
 
 BITCODE_ENDINGS = ('.bc', '.o', '.obj', '.lo')
@@ -641,16 +642,18 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       options, settings_changes, newargs = parse_args(newargs)
 
-      for i in range(0, len(newargs)):
+      argscount = len(newargs)
+      for i in range(0, argscount):
         arg = newargs[i]
-        if arg == '-xc':
-          use_cxx = False
-          break
-        elif arg == '-xc++':
-          use_cxx = True
-          break
+        if arg == '-x' and i+1 < argscount:
+           if newargs[i+1] == 'c':
+             use_cxx = False
+             break
+           elif newargs[i+1] == 'c++':
+             use_cxx = True
+             break
         elif not arg.startswith('-'):
-          if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
+          if arg.endswith(C_ENDINGS + OBJC_ENDINGS + EC_ENDINGS):
             use_cxx = False
 
       if not use_cxx:

--- a/system/include/libc/endian.h
+++ b/system/include/libc/endian.h
@@ -22,19 +22,19 @@
 
 #include <stdint.h>
 
-static __inline uint16_t __bswap16(uint16_t __x)
+__attribute__((unused)) static __inline uint16_t __bswap16(uint16_t __x)
 {
-	return __x<<8 | __x>>8;
+	return (__x<<8) | (__x>>8);
 }
 
-static __inline uint32_t __bswap32(uint32_t __x)
+__attribute__((unused)) static __inline uint32_t __bswap32(uint32_t __x)
 {
-	return __x>>24 | __x>>8&0xff00 | __x<<8&0xff0000 | __x<<24;
+	return (__x>>24) | (__x>>8&0xff00) | (__x<<8&0xff0000) | (__x<<24);
 }
 
-static __inline uint64_t __bswap64(uint64_t __x)
+__attribute__((unused)) static __inline uint64_t __bswap64(uint64_t __x)
 {
-	return __bswap32(__x)+0ULL<<32 | __bswap32(__x>>32);
+	return ((uint64_t)__bswap32((uint32_t)(__x&0xffffffff))) <<32 | __bswap32((uint32_t)(__x>>32));
 }
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN


### PR DESCRIPTION
- The parsed args get tokenized as separate tokens, but it was being checked as a single arg
- Also avoiding to set C++ standard for eC source files