### PR TITLE
Handle new name for WebAssembly imported/exported memory

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -2164,7 +2164,7 @@ function integrateWasmJS() {
       Module['printErr']('no native wasm Memory in use');
       return false;
     }
-    env['memory'] = Module['wasmMemory'];
+    env['__linear_memory'] = Module['wasmMemory'];
     // Load the wasm module and create an instance of using native support in the JS engine.
     info['global'] = {
       'NaN': NaN,
@@ -2294,8 +2294,8 @@ function integrateWasmJS() {
 
     // polyfill interpreter expects an ArrayBuffer
     assert(providedBuffer === Module['buffer']);
-    env['memory'] = providedBuffer;
-    assert(env['memory'] instanceof ArrayBuffer);
+    env['__linear_memory'] = providedBuffer;
+    assert(env['__linear_memory'] instanceof ArrayBuffer);
 
     wasmJS['providedTotalMemory'] = Module['buffer'].byteLength;
 


### PR DESCRIPTION
This should be updated from just "memory" to "__linear_memory" to match the naming convention used by other builtin symbols such as "__wasm_call_ctors" and "__stack_pointer".

NB. I hope I've found all the places where this needs to be renamed!

Should be merged along with matching LLD change, which is waiting on this (assuming the name change is deemed sensible): https://reviews.llvm.org/D43675