### PR TITLE
Support window selector in shell.html

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -22,6 +22,7 @@ var LibraryBrowser = {
       arg: 0, // The argument that will be passed to the main loop. (of type void*)
       timingMode: 0,
       timingValue: 0,
+      timingInitialized: 0,
       currentFrameNumber: 0,
       queue: [],
       pause: function() {
@@ -1037,6 +1038,9 @@ var LibraryBrowser = {
 
   // Runs natively in pthread, no __proxy needed.
   emscripten_set_main_loop_timing: function(mode, value) {
+    if (Browser.mainLoop.timingInitialized) {
+      return 1;
+    }
     Browser.mainLoop.timingMode = mode;
     Browser.mainLoop.timingValue = value;
 
@@ -1086,6 +1090,7 @@ var LibraryBrowser = {
       };
       Browser.mainLoop.method = 'immediate';
     }
+    Browser.mainLoop.timingInitialized = 1;
     return 0;
   },
 

--- a/src/shell.html
+++ b/src/shell.html
@@ -1199,6 +1199,7 @@
     <div class="emscripten" id="status">Downloading...</div>
 
 <span id='controls'>
+  <span><select id="windowSelector" hidden="true" onchange="Module.processWindowSelectorChange()"/></span>
   <span><input type="checkbox" id="resize">Resize canvas</span>
   <span><input type="checkbox" id="pointerLock" checked>Lock/hide mouse pointer &nbsp;&nbsp;&nbsp;</span>
   <span><input type="button" value="Fullscreen" onclick="Module.requestFullscreen(document.getElementById('pointerLock').checked, 

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -441,6 +441,14 @@ extern EMSCRIPTEN_RESULT emscripten_webgl_commit_frame();
 extern EMSCRIPTEN_RESULT emscripten_set_canvas_element_size(const char *target, int width, int height);
 extern EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char *target, int *width, int *height);
 
+#define EMSCRIPTEN_HAS_WINDOW_SELECTOR
+extern EMSCRIPTEN_RESULT emscripten_add_window(const char *title, void *data);
+extern EMSCRIPTEN_RESULT emscripten_set_window_title(const char *title, void *data);
+extern EMSCRIPTEN_RESULT emscripten_remove_window(void *data);
+extern void *emscripten_get_current_window_data(void);
+extern EMSCRIPTEN_RESULT emscripten_set_current_window(void *data);
+extern EMSCRIPTEN_RESULT emscripten_set_selected_window_change_callback(void (*func)(void));
+
 extern EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target, double width, double height);
 extern EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target, double *width, double *height);
 


### PR DESCRIPTION
In my port of QEMU to JavaScript I use their SDL2 UI for graphics. Previously, I had to disable every window except one, otherwise the canvas was messed up. There is also an issue #5081 on this topic.

In this PR I add the basic support for window selector to Emscripten. SDL2 support requires separate PR to its repository, though: emscripten-ports/SDL2#55.

PS: Frankly speaking, I'm not familiar with OpenGL at all, but it seems to work in my QEMU port. Corrections are welcome, of course.