### PR TITLE
[WIP] enable accessing member variables without copying

### DIFF
--- a/tests/embind/test_field_access.cpp
+++ b/tests/embind/test_field_access.cpp
@@ -1,0 +1,54 @@
+#include <stdio.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/bind.h>
+
+using namespace emscripten;
+
+struct vec2
+{
+  float x, y;
+};
+
+struct obj
+{
+  vec2 vector;
+  float f;
+};
+
+EMSCRIPTEN_BINDINGS(property) {
+  class_<vec2>("vec2")
+    .constructor<>()
+    .property("x", &vec2::x)
+    .property("y", &vec2::y);
+  class_<obj>("obj")
+    .constructor<>()
+    .ref_property("vector", &obj::vector)
+    .property("f", &obj::f);
+}
+
+int main()
+{
+  EM_ASM({
+	 var o = new Module.obj();
+	 // Test persistence assigning fields of the field.
+	 o.vector.x = 5;
+	 console.log('x = ' + o.vector.x);
+	 // Test assignment into the field.
+	 var v = new Module.vec2();
+	 v.x = 24; v.y = 75;
+	 o.vector = v;
+	 console.log('field is ' + o.vector.x + ' / ' + o.vector.y);
+	 // Test that o.vector and v are still separate.
+	 v.x = 3; v.y = 8;
+	 console.log('vector is ' + v.x + ' / ' + v.y);
+	 console.log('field is ' + o.vector.x + ' / ' + o.vector.y);
+	 // Test that assignment works the other way.
+	 v = o.vector;
+	 o.vector.x = 18; o.vector.y = 32;
+	 console.log('vector is ' + v.x + ' / ' + v.y);
+	 console.log('field is ' + o.vector.x + ' / ' + o.vector.y);
+	 o.delete();
+	 v.delete();
+    });
+  return 0;
+}

--- a/tests/embind/test_field_access.out
+++ b/tests/embind/test_field_access.out
@@ -1,0 +1,6 @@
+x = 5
+field is 24 / 75
+vector is 3 / 8
+field is 24 / 75
+vector is 24 / 75
+field is 18 / 32

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6724,6 +6724,11 @@ someweirdtext
     Building.COMPILER_TEST_OPTS += ['--bind']
     self.do_run_in_out_file_test('tests', 'core', 'test_embind_5')
 
+  def test_embind_field_access(self):
+    self.emcc_args += ['--bind']
+    self.do_run_from_file(path_from_root('tests', 'embind', 'test_field_access.cpp'),
+                          path_from_root('tests', 'embind', 'test_field_access.out'));
+
   def test_embind_unsigned(self):
     self.emcc_args += ['--bind', '--std=c++11']
     self.do_run_from_file(path_from_root('tests', 'embind', 'test_unsigned.cpp'), path_from_root('tests', 'embind', 'test_unsigned.out'))


### PR DESCRIPTION
Accessing member variables by copying, especially for non-trivial member
variable types, is inefficient and results in peculiar behavior when
using such members from JavaScript.  Let's add an alternative property
definition method, `ref_property`, that can be used to return certain
fields "by reference".

You lose the ability to assign *from* members that you declare with `ref_property`--at least as far as idiomatic JS goes, you might be able to use your knowledge that the member actually comes out as a pointer and fish around in Emscripten internals to dereference it.  I'm not sure if assigning from such members is an important feature, or whether it should simply be prominently warned against in the documentation.

Fixes #3551.