### PR TITLE
Updated the fetchRemotePackage function

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -331,3 +331,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Michael Droettboom <mdroettboom@mozilla.com>
 * Nicolas Bouquet <hgy01@hieroglyphe.net>
 * Miguel Saldivar <miguel.saldivar22@hotmail.com>
+* Prince Mathew <i.princemathew@gmail.com>

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -716,9 +716,7 @@ if has_preloaded:
         }
       };
       xhr.onerror = function(event) {
-        if (Module['setStatus']) Module['setStatus']('CORS May not be allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.');
-        throw new Error('CORS May not be allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.');
-        throw new Error("NetworkError for: " + packageName);
+        throw new Error('CORS May not be allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.\nNetworkError for: ' + packageName);
       }
       xhr.onload = function(event) {
         if (xhr.status == 200 || xhr.status == 304 || xhr.status == 206 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -716,10 +716,8 @@ if has_preloaded:
         }
       };
       xhr.onerror = function(event) {
-        if (window.location.protocol === "file:") {
-          if (Module['setStatus']) Module['setStatus']('CORS May not be allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.');
-          throw new Error('CORS May not be allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.');
-        }
+        if (Module['setStatus']) Module['setStatus']('CORS May not be allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.');
+        throw new Error('CORS May not be allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.');
         throw new Error("NetworkError for: " + packageName);
       }
       xhr.onload = function(event) {
@@ -732,7 +730,6 @@ if has_preloaded:
       }; 
       xhr.send(null);
     };
-
     function handleError(error) {
       console.error('package error:', error);
     };

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -730,8 +730,7 @@ if has_preloaded:
     };
     function handleError(error) {
       console.error('package error:', error);
-    };
-  '''
+    };'''
 
   code += r'''
     function processPackageData(arrayBuffer) {

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -682,51 +682,63 @@ if has_preloaded:
 
   ret += r'''
     function fetchRemotePackage(packageName, packageSize, callback, errback) {
-      var xhr = new XMLHttpRequest();
-      xhr.open('GET', packageName, true);
-      xhr.responseType = 'arraybuffer';
-      xhr.onprogress = function(event) {
-        var url = packageName;
-        var size = packageSize;
-        if (event.total) size = event.total;
-        if (event.loaded) {
-          if (!xhr.addedTotal) {
-            xhr.addedTotal = true;
-            if (!Module.dataFileDownloads) Module.dataFileDownloads = {};
-            Module.dataFileDownloads[url] = {
-              loaded: event.loaded,
-              total: size
-            };
+      /* Check if browser is Chrome/Safari/IE and if the protocol is `file:`. Gracefully exit if that is the case
+         Otherwise, run the XHR script. */
+      var isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+      var isSafari = /Safari/.test(navigator.userAgent) && /Apple Computer/.test(navigator.vendor);
+      var isIE = /MSIE/.test(navigator.userAgent) || /Trident\//.test(navigator.userAgent) || /Edge\//.test(navigator.userAgent);
+
+      if ((isChrome || isSafari || isIE) && window.location.protocol === "file:") {
+        //Time to retreat with a fallback or polyfill
+        if (Module['setStatus']) Module['setStatus']('CORS Not allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.');
+        throw new Error('CORS Not allowed on a file: URL. Use `python -m SimpleHTTPServer` to create a server at this location.');
+      } else {
+        var xhr = new XMLHttpRequest();
+        xhr.open('GET', packageName, true);
+        xhr.responseType = 'arraybuffer';
+        xhr.onprogress = function(event) {
+          var url = packageName;
+          var size = packageSize;
+          if (event.total) size = event.total;
+          if (event.loaded) {
+            if (!xhr.addedTotal) {
+              xhr.addedTotal = true;
+              if (!Module.dataFileDownloads) Module.dataFileDownloads = {};
+              Module.dataFileDownloads[url] = {
+                loaded: event.loaded,
+                total: size
+              };
+            } else {
+              Module.dataFileDownloads[url].loaded = event.loaded;
+            }
+            var total = 0;
+            var loaded = 0;
+            var num = 0;
+            for (var download in Module.dataFileDownloads) {
+            var data = Module.dataFileDownloads[download];
+              total += data.total;
+              loaded += data.loaded;
+              num++;
+            }
+            total = Math.ceil(total * Module.expectedDataFileDownloads/num);
+            if (Module['setStatus']) Module['setStatus']('Downloading data... (' + loaded + '/' + total + ')');
+          } else if (!Module.dataFileDownloads) {
+            if (Module['setStatus']) Module['setStatus']('Downloading data...');
+          }
+        };
+        xhr.onerror = function(event) {
+          throw new Error("NetworkError for: " + packageName);
+        }
+        xhr.onload = function(event) {
+          if (xhr.status == 200 || xhr.status == 304 || xhr.status == 206 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
+            var packageData = xhr.response;
+            callback(packageData);
           } else {
-            Module.dataFileDownloads[url].loaded = event.loaded;
+            throw new Error(xhr.statusText + " : " + xhr.responseURL);
           }
-          var total = 0;
-          var loaded = 0;
-          var num = 0;
-          for (var download in Module.dataFileDownloads) {
-          var data = Module.dataFileDownloads[download];
-            total += data.total;
-            loaded += data.loaded;
-            num++;
-          }
-          total = Math.ceil(total * Module.expectedDataFileDownloads/num);
-          if (Module['setStatus']) Module['setStatus']('Downloading data... (' + loaded + '/' + total + ')');
-        } else if (!Module.dataFileDownloads) {
-          if (Module['setStatus']) Module['setStatus']('Downloading data...');
-        }
-      };
-      xhr.onerror = function(event) {
-        throw new Error("NetworkError for: " + packageName);
+        };
+        xhr.send(null);
       }
-      xhr.onload = function(event) {
-        if (xhr.status == 200 || xhr.status == 304 || xhr.status == 206 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
-          var packageData = xhr.response;
-          callback(packageData);
-        } else {
-          throw new Error(xhr.statusText + " : " + xhr.responseURL);
-        }
-      };
-      xhr.send(null);
     };
 
     function handleError(error) {


### PR DESCRIPTION
If the Browse is Chrome/Safari/IE the file needs to be served using SimpleHTTPServer or the like. If the html file is run in these browsers, the XHR script throws an error. The XHR open call has been replaced with am if-else block that checks for the browser and protocol and gracefully exits.