### PR TITLE
More consistent UMD exports and then() support

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -119,7 +119,7 @@ if (memoryInitializer) {
 #endif
 
 #if MODULARIZE
-#if MODULARIZE_INSTANCE == 0
+
 // Modularize mode returns a function, which can be called to
 // create instances. The instances provide a then() method,
 // must like a Promise, that receives a callback. The callback
@@ -142,7 +142,18 @@ Module['then'] = function(func) {
   }
   return Module;
 };
-#endif
+
+// In MODULARIZE mode emcc.py will export the module in the proper place outside the wrapper
+#else // MODULARIZE
+
+if (typeof exports === 'object' && typeof module === 'object') {
+  module['exports'] = Module;
+} else if (typeof define === 'function' && define['amd']) {
+  define([], function() { return Module; });
+} else if (typeof exports === 'object') {
+  exports["{{{ EXPORT_NAME }}}"] = Module;
+}
+
 #endif
 
 /**

--- a/src/settings.js
+++ b/src/settings.js
@@ -610,9 +610,6 @@ var MODULARIZE_INSTANCE = 0; // Similar to MODULARIZE, but while that mode expor
                              // a singleton instance. In other words, it's the same as if you
                              // used MODULARIZE and did EXPORT_NAME = EXPORT_NAME() to create
                              // the instance manually.
-                             // Note that the promise-like API MODULARIZE provides isn't
-                             // available here (since you arean't creating the instance
-                             // yourself).
 
 var BENCHMARK = 0; // If 1, will just time how long main() takes to execute, and not
                    // print out anything at all whatsoever. This is useful for benchmarking.

--- a/src/shell.js
+++ b/src/shell.js
@@ -122,14 +122,6 @@ if (ENVIRONMENT_IS_NODE) {
 
   Module['arguments'] = process['argv'].slice(2);
 
-#if MODULARIZE
-  // MODULARIZE will export the module in the proper place outside, we don't need to export here
-#else
-  if (typeof module !== 'undefined') {
-    module['exports'] = Module;
-  }
-#endif
-
 #if NODEJS_CATCH_EXIT
   process['on']('uncaughtException', function(ex) {
     // suppress ExitStatus exceptions from showing an error


### PR DESCRIPTION
Do a full UMD export when not in MODULARIZE mode (fix #5864)

Also provide .then() when in MODULARIZE_INSTANCE mode (#6442)