### PR TITLE
A few minor cleanups

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -114,7 +114,6 @@ def build(src, result_libs, args=[]):
       with_forced.append(result_lib)
 
     if need_forced:
-      print(str(need_forced))
       if os.environ.get('EMCC_FORCE_STDLIBS'):
         print('skipping forced (.bc) versions of .a libraries, since EMCC_FORCE_STDLIBS already set')
       else:

--- a/emscripten.py
+++ b/emscripten.py
@@ -14,6 +14,7 @@ if __name__ == '__main__':
 import difflib
 import os, sys, json, argparse, subprocess, re, time, logging
 import shutil
+import pprint
 from collections import OrderedDict
 
 from tools import shared
@@ -1934,9 +1935,9 @@ def read_metadata_wast(wast, DEBUG):
 
 
 def create_metadata_wasm(metadata_raw, DEBUG):
-  if DEBUG: logging.debug("METAraw %s", metadata_raw)
+  if DEBUG: logging.debug("Metadata raw: " + metadata_raw)
   metadata = load_metadata(metadata_raw)
-  if DEBUG: logging.debug(repr(metadata))
+  if DEBUG: logging.debug("Metadata parsed: " + pprint.pformat(metadata))
   return metadata
 
 
@@ -1946,7 +1947,7 @@ def create_exported_implemented_functions_wasm(pre, forwarded_json, metadata, se
   all_exported_functions = set(shared.expand_response(settings['EXPORTED_FUNCTIONS'])) # both asm.js and otherwise
   for additional_export in settings['DEFAULT_LIBRARY_FUNCS_TO_INCLUDE']: # additional functions to export from asm, if they are implemented
     all_exported_functions.add('_' + additional_export)
-  all_implemented = metadata['implementedFunctions'] + list(forwarded_json['Functions']['implementedFunctions'].keys()) # XXX perf?
+  all_implemented = get_all_implemented(forwarded_json, metadata)
 
   export_bindings = settings['EXPORT_BINDINGS']
   export_all = settings['EXPORT_ALL']

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1614,12 +1614,12 @@ class Building(object):
       env[k] = v
     if configure: # Useful in debugging sometimes to comment this out (and the lines below up to and including the |link| call)
       try:
-        Building.configure(configure + configure_args, env=env, stdout=open(os.path.join(project_dir, 'configure_'), 'w') if EM_BUILD_VERBOSE_LEVEL < 2 else None,
+        Building.configure(configure + configure_args, env=env, stdout=open(os.path.join(project_dir, 'configure_out'), 'w') if EM_BUILD_VERBOSE_LEVEL < 2 else None,
                                                                 stderr=open(os.path.join(project_dir, 'configure_err'), 'w') if EM_BUILD_VERBOSE_LEVEL < 1 else None)
       except subprocess.CalledProcessError as e:
         pass # Ignore exit code != 0
     def open_make_out(i, mode='r'):
-      return open(os.path.join(project_dir, 'make_' + str(i)), mode)
+      return open(os.path.join(project_dir, 'make_out' + str(i)), mode)
 
     def open_make_err(i, mode='r'):
       return open(os.path.join(project_dir, 'make_err' + str(i)), mode)


### PR DESCRIPTION
tools/shared.py:
 - fix name of `make_out` and `configure_out` files
embuilder.py:
 - Don't print blindly to stdout.  This was causing extra chatter on
   stdout for all users on first run.
emscripten.py:
 - use get_all_implemented function.
 - prettyprint the wasm metadata