### PR TITLE
 Use Building.get_binaryen_bin instead of shared.BINARYEN_ROOT

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1865,9 +1865,9 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
 
 
 def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
-  wasm_emscripten_finalize = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-emscripten-finalize')
-  wasm_as = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-as')
-  wasm_dis = os.path.join(shared.BINARYEN_ROOT, 'bin', 'wasm-dis')
+  wasm_emscripten_finalize = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-emscripten-finalize')
+  wasm_as = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-as')
+  wasm_dis = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-dis')
 
   def debug_copy(src, dst):
     if DEBUG:
@@ -2153,7 +2153,7 @@ def create_s2wasm_args(temp_s, wasm):
   compiler_rt_lib = shared.Cache.get('wasm_compiler_rt.a', wasm_rt_fail('wasm_compiler_rt.a'), 'a')
   libc_rt_lib = shared.Cache.get('wasm_libc_rt.a', wasm_rt_fail('wasm_libc_rt.a'), 'a')
 
-  s2wasm_path = os.path.join(shared.BINARYEN_ROOT, 'bin', 's2wasm')
+  s2wasm_path = os.path.join(shared.Building.get_binaryen_bin(), 's2wasm')
 
   args = [s2wasm_path, temp_s, '-o', wasm, '--emscripten-glue', '--emit-binary']
   args += ['--global-base=%d' % shared.Settings.GLOBAL_BASE]

--- a/emscripten.py
+++ b/emscripten.py
@@ -1865,9 +1865,9 @@ def build_wasm(temp_files, infile, outfile, settings, DEBUG):
 
 
 def build_wasm_lld(temp_files, infile, outfile, settings, DEBUG):
-  wasm_emscripten_finalize = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-emscripten-finalize')
-  wasm_as = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-as')
-  wasm_dis = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-dis')
+  wasm_emscripten_finalize = shared.Building.get_binaryen_bin('wasm-emscripten-finalize')
+  wasm_as = shared.Building.get_binaryen_bin('wasm-as')
+  wasm_dis = shared.Building.get_binaryen_bin('wasm-dis')
 
   def debug_copy(src, dst):
     if DEBUG:
@@ -2153,7 +2153,7 @@ def create_s2wasm_args(temp_s, wasm):
   compiler_rt_lib = shared.Cache.get('wasm_compiler_rt.a', wasm_rt_fail('wasm_compiler_rt.a'), 'a')
   libc_rt_lib = shared.Cache.get('wasm_libc_rt.a', wasm_rt_fail('wasm_libc_rt.a'), 'a')
 
-  s2wasm_path = os.path.join(shared.Building.get_binaryen_bin(), 's2wasm')
+  s2wasm_path = shared.Building.get_binaryen_bin('s2wasm')
 
   args = [s2wasm_path, temp_s, '-o', wasm, '--emscripten-glue', '--emit-binary']
   args += ['--global-base=%d' % shared.Settings.GLOBAL_BASE]

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -7,7 +7,6 @@ def needed(settings, shared, ports):
   try:
     if shared.BINARYEN_ROOT: # if defined, and not falsey, we don't need the port
       logging.debug('binaryen root already set to ' + shared.BINARYEN_ROOT)
-      settings.BINARYEN_ROOT = shared.BINARYEN_ROOT
       return False
   except:
     pass

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2405,6 +2405,14 @@ class Building(object):
   def get_binaryen():
     # fetch the port, so we have binaryen set up. indicate we need binaryen
     # using the settings
+    try:
+      if BINARYEN_ROOT:
+        # if defined, and not falsey, we don't need the port
+        Settings.BINARYEN_ROOT = BINARYEN_ROOT
+        return
+    except:
+      pass
+
     from . import system_libs
     old = Settings.WASM
     Settings.WASM = 1

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2290,7 +2290,7 @@ class Building(object):
     txt = json.dumps(graph)
     with open(temp, 'w') as f: f.write(txt)
     # run wasm-metadce
-    cmd = [os.path.join(Building.get_binaryen_bin(), 'wasm-metadce'), '--graph-file=' + temp, wasm_file, '-o', wasm_file]
+    cmd = [Building.get_binaryen_bin('wasm-metadce'), '--graph-file=' + temp, wasm_file, '-o', wasm_file]
     if debug_info:
       cmd += ['-g']
     out = run_process(cmd, stdout=PIPE).stdout
@@ -2420,9 +2420,12 @@ class Building(object):
     Settings.WASM = old
 
   @staticmethod
-  def get_binaryen_bin():
+  def get_binaryen_bin(program=None):
     Building.get_binaryen()
-    return os.path.join(Settings.BINARYEN_ROOT, 'bin')
+    if program is None:
+      return os.path.join(Settings.BINARYEN_ROOT, 'bin')
+    else:
+      return os.path.join(Settings.BINARYEN_ROOT, 'bin', program)
 
   @staticmethod
   def get_binaryen_lib():


### PR DESCRIPTION
Use `Building.get_binaryen` to set Settings.BINARYEN_ROOT, instead of the binaryen ports' `verify`.
Also let `get_binaryen_bin` be callable with a specific executable to get the path of.