### PR TITLE
Update upgrade and installation docs

### DIFF
--- a/site/source/docs/getting_started/downloads.rst
+++ b/site/source/docs/getting_started/downloads.rst
@@ -29,8 +29,11 @@ Run the following :ref:`emsdk <emsdk>` commands to get the latest tools from Git
 	
 	::
 
-		# Fetch the latest registry of available tools.
-		./emsdk update
+                # Fetch the latest verison of the emsdk script (only if you used git clone to install)
+		git pull
+		
+		# Fetch the latest registry of available tools. (use `./emsdk update` if you did NOT use git to install)
+		./emsdk update-tags
 		
 		# Download and install the latest SDK tools.
 		./emsdk install latest
@@ -135,8 +138,11 @@ Updating the SDK
 
 Type the following in a command prompt ::
 
-	# Fetch the latest registry of available tools.
-	./emsdk update
+	# Fetch the latest registry of available tools. (use `./emsdk update` if you did NOT install from git)
+	git pull
+	
+	# Fetch the latest registry of available tools. (use `./emsdk update` if you did NOT install from git)
+	./emsdk update-tags
 	
 	# Download and install the latest SDK tools.
 	./emsdk install latest


### PR DESCRIPTION
The old docs said to use `git clone`. Then proceeded to give instructions incompatible with `git clone`.

If `git clone` is the recommended way to install then it seems like the instructions should assume that's that what the user did and give instructions that work with that workflow.

#6582 