### PR TITLE
Error on invalid archive member

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1272,9 +1272,9 @@ int f() {
     open('main.cpp', 'w').write(r'''extern int side(); int main() { return side(); }''')
     run_process([CLANG, 'side.cpp', '-c', '-o', 'native.o'])
     run_process([PYTHON, EMAR, 'crs', 'foo.a', 'native.o'])
-    err = run_process([PYTHON, EMCC, 'main.cpp', 'foo.a'], stderr=PIPE).stderr
-    self.assertContained('warning: unresolved symbol: _Z4sidev', err) # was native, could not link it
-    self.assertContained('is not LLVM bitcode, cannot link', err)
+    proc = run_process([PYTHON, EMCC, 'main.cpp', 'foo.a'], stderr=PIPE, check=False)
+    self.assertNotEqual(proc.returncode, 0)
+    self.assertIn('is not LLVM bitcode, cannot link', proc.stderr)
 
   def test_export_all(self):
     lib = r'''

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1989,8 +1989,7 @@ class Building(object):
       # Check the object is valid for us, and not a native object file.
       # TODO: for lld, also check if a wasm object file?
       if not Building.is_bitcode(f):
-        logging.warning('object %s is not LLVM bitcode, cannot link' % (f))
-        return False
+        exit_with_error('object %s is not LLVM bitcode, cannot link' % (f))
       provided = new_symbols.defs.union(new_symbols.commons)
       do_add = force_add or not unresolved_symbols.isdisjoint(provided)
       if do_add:


### PR DESCRIPTION
Other linkers (lld anyway) will error out if there is an
invalid archive memeber.  I don't see why we should be any
different and allow this.