### PR TITLE
Change fork() and system() to not return EAGAIN

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -250,7 +250,7 @@ LibraryManager.library = {
     // pid_t fork(void);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/fork.html
     // We don't support multiple processes.
-    ___setErrNo(ERRNO_CODES.EAGAIN);
+    ___setErrNo(ERRNO_CODES.ENOTSUP);
     return -1;
   },
   vfork: 'fork',
@@ -545,7 +545,7 @@ LibraryManager.library = {
     // int system(const char *command);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/system.html
     // Can't call external programs.
-    ___setErrNo(ERRNO_CODES.EAGAIN);
+    ___setErrNo(ERRNO_CODES.ENOTSUP);
     return -1;
   },
 


### PR DESCRIPTION
The error code EAGAIN implies "try again later", but Emscripten's fork() will never succeed. Some C programs, when getting EAGAIN, will actually wait a few seconds and try again, sometimes many times. This patch changes fork() and system() to return ENOTSUP.

Any other error code is probably fine too, as long as it's not EAGAIN :-)