### PR TITLE
Improve result reporting in browser tests

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1107,7 +1107,6 @@ assert(typeof Int32Array !== 'undefined' && typeof Float64Array !== 'undefined' 
 #endif
 
 #if IN_TEST_HARNESS
-
 // Test runs in browsers should always be free from uncaught exceptions. If an uncaught exception is thrown, we fail browser test execution in the REPORT_RESULT() macro to output an error value.
 if (ENVIRONMENT_IS_WEB) {
   window.addEventListener('error', function(e) {
@@ -1118,12 +1117,8 @@ if (ENVIRONMENT_IS_WEB) {
 }
 
 #if USE_PTHREADS
-if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') {
-  xhr = new XMLHttpRequest();
-  xhr.open('GET', 'http://localhost:8888/report_result?skipped:%20SharedArrayBuffer%20is%20not%20supported!');
-  xhr.send();
-  setTimeout(function() { window.close() }, 2000);
-}
+if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined')
+  reportResult('skipped:%20SharedArrayBuffer%20is%20not%20supported!');
 #endif
 #endif
 

--- a/tests/exit_code.c
+++ b/tests/exit_code.c
@@ -1,0 +1,5 @@
+// Calculate the meaning of life
+
+int main() {
+  return 42;
+}

--- a/tests/pthread/call_async_on_main_thread.js
+++ b/tests/pthread/call_async_on_main_thread.js
@@ -7,6 +7,6 @@ mergeInto(LibraryManager.library, {
       console.error('This function should be getting called on the main thread!');
     }
     console.log('got ' + param1 + ' ' + param2 + ' ' + param3);
-    __ReportResult(param1 + param2 * param3, 0);
+    reportResult(param1 + param2 * param3, 0);
   }
 });

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -86,6 +86,9 @@ class browser(BrowserCore):
     print('Running the browser tests. Make sure the browser allows popups from localhost.')
     print()
 
+  def test_exit_code(self):
+    self.btest('exit_code.c', expected='42')
+
   def test_sdl1_in_emscripten_nonstrict_mode(self):
     if 'EMCC_STRICT' in os.environ and int(os.environ['EMCC_STRICT']):
       self.skipTest('This test requires being run in non-strict mode (EMCC_STRICT env. variable unset)')


### PR DESCRIPTION
This change unifies the XMLHttpRequest result reporting into
single shared location and also allows the exit code (or return
code from main) to be reported by default.

As a followup we should be able to replace a lot of the REPORT_RESULT
macros with `exit()` or `return`.