### PR TITLE
Force TEXTDECODER=0 when USE_PTHREADS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1191,6 +1191,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.USE_PTHREADS:
         if shared.Settings.USE_PTHREADS == 2:
           exit_with_error('USE_PTHREADS=2 is not longer supported')
+        # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
+        shared.Settings.TEXTDECODER = 0
         options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
         newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
         shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -451,7 +451,10 @@ function UTF8ArrayToString(u8Array, idx) {
 
     var str = '';
     while (1) {
-      // For UTF8 byte structure, see http://en.wikipedia.org/wiki/UTF-8#Description and https://www.ietf.org/rfc/rfc2279.txt and https://tools.ietf.org/html/rfc3629
+      // For UTF8 byte structure, see:
+      // http://en.wikipedia.org/wiki/UTF-8#Description
+      // https://www.ietf.org/rfc/rfc2279.txt
+      // https://tools.ietf.org/html/rfc3629
       u0 = u8Array[idx++];
       if (!u0) return str;
       if (!(u0 & 0x80)) { str += String.fromCharCode(u0); continue; }

--- a/tests/pthread/test_pthread_utf8_funcs.cpp
+++ b/tests/pthread/test_pthread_utf8_funcs.cpp
@@ -1,0 +1,35 @@
+#include <pthread.h>
+#include <emscripten.h>
+#include <emscripten/threading.h>
+#include <assert.h>
+#include <string.h>
+
+char stringBuffer[1024];
+
+#define TEST_STRING "something long so that it hits the TextDecoder path"
+
+static void *thread1_start(void *arg) {
+  EM_ASM({
+   var mystr = UTF8ToString($0);
+   stringToUTF8(mystr, $1, 1024);
+  }, TEST_STRING, stringBuffer);
+  return nullptr;
+}
+
+int main() {
+  pthread_t thread;
+  pthread_create(&thread, NULL, thread1_start, 0);
+  pthread_join(thread, 0);
+
+  if (strcmp(TEST_STRING, stringBuffer) != 0) {
+#ifdef REPORT_RESULT
+    REPORT_RESULT(1);
+#endif
+    return 1;
+  }
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+  return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3569,6 +3569,9 @@ window.close = function() {
   def test_pthread_clock_drift(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_clock_drift.cpp'), expected='1', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
+  def test_pthread_utf8_funcs(self):
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_utf8_funcs.cpp'), expected='0', args=['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'])
+
   # test atomicrmw i64
   def test_atomicrmw_i64(self):
     # TODO: enable this with wasm, currently pthreads/atomics have limitations


### PR DESCRIPTION
UTF8Decoder.decode() doesn't work when passed a view of a
SharedArrayBuffer.  Rather than copy the UTF8 string into a none
shared array we can disable the TEXTDECODER option and force all
UTF8 conversion to go via the emscripten implementation.

Add a new test case that will fails without this change.