### PR TITLE
Add support for binaryen --compact-function-tables option.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2512,6 +2512,8 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       cmd += ['--wasm-only'] # this asm.js is code not intended to run as asm.js, it is only ever going to be wasm, an can contain special fastcomp-wasm support
     if shared.Settings.USE_PTHREADS:
       cmd += ['--enable-threads']
+    if shared.Settings.COMPRESS_FUNCTION_TABLE:
+      cmd += ['--compact-function-tables']
     if debug_info:
       cmd += ['-g']
     if emit_symbol_map:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1157,8 +1157,22 @@ def create_asm_setup(debug_tables, function_table_data, metadata):
       if len(table_contents) == 0: # empty table
         return 0
       return table_contents.count(',') + 1
+    def is_not_zero(str):
+      if str == "0":
+        return 0
+      return 1
+    def table_size_compress(table):
+      table_contents = table[table.index('[') + 1: table.index(']')]
+      if len(table_contents) == 0: # empty table
+        return 0
+      #table is either 0 or the symbol name
+      return sum (map(is_not_zero, table_contents.split(",")))
 
-    table_total_size = sum(map(table_size, list(function_table_data.values())))
+    if shared.Settings.COMPRESS_FUNCTION_TABLE:
+      table_total_size = sum(map(table_size_compress, list(function_table_data.values()))) + 1
+    else
+      table_total_size = sum(map(table_size, list(function_table_data.values())))
+
     asm_setup += "\nModule['wasmTableSize'] = %d;\n" % table_total_size
     if not shared.Settings.EMULATED_FUNCTION_POINTERS:
       asm_setup += "\nModule['wasmMaxTableSize'] = %d;\n" % table_total_size

--- a/src/settings.js
+++ b/src/settings.js
@@ -957,3 +957,5 @@ var ENVIRONMENT_MAY_BE_NODE = 1;
 var ENVIRONMENT_MAY_BE_SHELL = 1;
 var ENVIRONMENT_MAY_BE_WEB_OR_WORKER = 1;
 
+var COMPRESS_FUNCTION_TABLE = 0; //If nonzero, enables table compression of wasm files when ALIASING_FUNCTION_POINTERS=0 is used. Produces the smalest table size.
+


### PR DESCRIPTION
This option make it possible to use applications with a large number of function pointer and that requires aliasing to be disabled.

This requires the paired modification on binaryen's side. I could not figure out how to bump the dependency here - plus it's an unmerged
PR at this point: https://github.com/WebAssembly/binaryen/pull/1675