### PR TITLE
Fix LZ4 file packaging support when MODULARIZE=1

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1079,6 +1079,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
         shared.Settings.ALIASING_FUNCTION_POINTERS = 0
 
+      if shared.Settings.LZ4:
+        # Let the file packager code access LZ4 on Module
+        shared.Settings.EXPORTED_RUNTIME_METHODS += ['LZ4']
+
       if shared.Settings.LEGACY_VM_SUPPORT:
         # legacy vms don't have wasm
         assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'

--- a/src/modules.js
+++ b/src/modules.js
@@ -387,6 +387,7 @@ function exportRuntime() {
     'FS_createDevice',
     'FS_unlink',
     'GL',
+    'LZ4',
     'staticAlloc',
     'dynamicAlloc',
     'warnOnce',

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1358,6 +1358,14 @@ keydown(100);keyup(100); // trigger the end
     print('    opts')
     self.btest(os.path.join('fs', 'test_lz4fs.cpp'), '2', args=['--pre-js', 'files.js', '-s', 'LZ4=1', '-s', 'FORCE_FILESYSTEM=1', '-O2'], timeout=60)
 
+    # same as above, but with MODULARIZE=1
+    print('modularize')
+    out = subprocess.check_output([PYTHON, FILE_PACKAGER, 'files.data', '--preload', 'file1.txt', 'subdir/file2.txt', 'file3.txt', '--lz4'])
+    open('files.js', 'wb').write(out)
+    self.btest(os.path.join('fs', 'test_lz4fs.cpp'), '2', args=['--pre-js', 'files.js', '-s', 'LZ4=1', '-s', 'FORCE_FILESYSTEM=1', '-s', 'MODULARIZE=1'], timeout=60)
+    print('    opts')
+    self.btest(os.path.join('fs', 'test_lz4fs.cpp'), '2', args=['--pre-js', 'files.js', '-s', 'LZ4=1', '-s', 'FORCE_FILESYSTEM=1', '-O2', '-s', 'MODULARIZE=1'], timeout=60)
+
     # load the data into LZ4FS manually at runtime. This means we compress on the client. This is generally not recommended
     print('manual')
     subprocess.check_output([PYTHON, FILE_PACKAGER, 'files.data', '--preload', 'file1.txt', 'subdir/file2.txt', 'file3.txt', '--separate-metadata', '--js-output=files.js'])

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1362,9 +1362,7 @@ keydown(100);keyup(100); // trigger the end
     print('modularize')
     out = subprocess.check_output([PYTHON, FILE_PACKAGER, 'files.data', '--preload', 'file1.txt', 'subdir/file2.txt', 'file3.txt', '--lz4'])
     open('files.js', 'wb').write(out)
-    self.btest(os.path.join('fs', 'test_lz4fs.cpp'), '2', args=['--pre-js', 'files.js', '-s', 'LZ4=1', '-s', 'FORCE_FILESYSTEM=1', '-s', 'MODULARIZE=1'], timeout=60)
-    print('    opts')
-    self.btest(os.path.join('fs', 'test_lz4fs.cpp'), '2', args=['--pre-js', 'files.js', '-s', 'LZ4=1', '-s', 'FORCE_FILESYSTEM=1', '-O2', '-s', 'MODULARIZE=1'], timeout=60)
+    self.btest(os.path.join('fs', 'test_lz4fs.cpp'), '2', args=['--pre-js', 'files.js', '-s', 'LZ4=1', '-s', 'FORCE_FILESYSTEM=1', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="\'foo\'"'], timeout=60)
 
     # load the data into LZ4FS manually at runtime. This means we compress on the client. This is generally not recommended
     print('manual')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1360,7 +1360,7 @@ keydown(100);keyup(100); // trigger the end
 
     # same as above, but with MODULARIZE=1
     print('modularize')
-    out = subprocess.check_output([PYTHON, FILE_PACKAGER, 'files.data', '--preload', 'file1.txt', 'subdir/file2.txt', 'file3.txt', '--lz4'])
+    out = subprocess.check_output([PYTHON, FILE_PACKAGER, 'files.data',  '--preload', 'file1.txt', 'subdir/file2.txt', 'file3.txt', '--lz4', '--export-name=foo'])
     open('files.js', 'wb').write(out)
     self.btest(os.path.join('fs', 'test_lz4fs.cpp'), '2', args=['--pre-js', 'files.js', '-s', 'LZ4=1', '-s', 'FORCE_FILESYSTEM=1', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="\'foo\'"'], timeout=60)
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -452,8 +452,8 @@ if has_preloaded:
     use_data = '''
           var compressedData = %s;
           compressedData.data = byteArray;
-          assert(typeof LZ4 === 'object', 'LZ4 not present - was your app build with  -s LZ4=1  ?');
-          LZ4.loadPackage({ 'metadata': metadata, 'compressedData': compressedData });
+          assert(typeof Module.LZ4 === 'object', 'LZ4 not present - was your app build with  -s LZ4=1  ?');
+          Module.LZ4.loadPackage({ 'metadata': metadata, 'compressedData': compressedData });
           Module['removeRunDependency']('datafile_%s');
     ''' % (meta, shared.JS.escape_for_js_string(data_target))
 


### PR DESCRIPTION
This fixes a small bug that using the `--lz4` flag to `file_packager.py` doesn't work if `-s MODULARIZE=1`