### PR TITLE
Don't suggest using OUTLINING_LIMIT with large functions for WASM

### DIFF
--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -543,8 +543,13 @@ EMSCRIPTEN_FUNCS();
 
       if 'last' in passes and len(funcs):
         count = funcs[0][1].count('\n')
-        if count > 3000:
-          print('warning: Output contains some very large functions (%s lines in %s), consider building source files with -Os or -Oz, and/or trying OUTLINING_LIMIT to break them up (see settings.js; note that the parameter there affects AST nodes, while we measure lines here, so the two may not match up)' % (count, funcs[0][0]), file=sys.stderr)
+        if count > 3000 and not shared.Building.is_wasm_only:
+          print('warning: Output contains some very large functions '
+                '(%s lines in %s), consider building source files with -Os '
+                'or -Oz, and/or trying OUTLINING_LIMIT to break them up '
+                '(see settings.js; note that the parameter there affects AST '
+                'nodes, while we measure lines here, so the two may '
+                'not match up)' % (count, funcs[0][0]), file=sys.stderr)
 
       for func in funcs:
         f.write(func[1])


### PR DESCRIPTION
Currently when compiling large functions for WASM, the following warning is raised,
```
warning: Output contains some very large functions (11622 lines in _PyInit_algos),
 consider building source files with -Os or -Oz, and/or trying OUTLINING_LIMIT to 
break them up (see settings.js; note that the parameter there affects AST nodes, 
while we measure lines here, so the two may not match up)
```
at the same time the `OUTLINING_LIMIT` documentation indicates that,

> Note: For wasm there is usually no need to set OUTLINING_LIMIT, as VMs can handle large functions well anyhow.  

This PR disables this warning for WASM (i.e. when `shared.Building.is_wasm_only is True`). Also fixes flake8 code style issues in the place where this warning is raised.
