### PR TITLE
Fix inaccurate round while being fast

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1569,7 +1569,7 @@ LibraryManager.library = {
   round__deps: ['llvm_copysign_f64'],
   round: function(d) {
     d = +d;
-    return +_llvm_copysign_f64(+Math_floor((+Math_abs(d) + +0.2499999999999999) + +0.2500000000000001), d);
+    return +Math_trunc(d + +_llvm_copysign_f64(+0.49999999999999994, d));
   },
 
   roundf__asm: true,
@@ -1577,7 +1577,7 @@ LibraryManager.library = {
   roundf__deps: ['llvm_copysign_f64'],
   roundf: function(d) {
     d = +d;
-    return +_llvm_copysign_f64(+Math_floor((+Math_abs(d) + +0.2499999999999999) + +0.2500000000000001), d);
+    return +Math_trunc(d + +_llvm_copysign_f64(+0.49999999999999994, d));
   },
 
   llvm_round_f64__asm: true,
@@ -1585,7 +1585,7 @@ LibraryManager.library = {
   llvm_round_f64__deps: ['llvm_copysign_f64'],
   llvm_round_f64: function(d) {
     d = +d;
-    return +_llvm_copysign_f64(+Math_floor((+Math_abs(d) + +0.2499999999999999) + +0.2500000000000001), d);
+    return +Math_trunc(d + +_llvm_copysign_f64(+0.49999999999999994, d));
   },
 
   llvm_round_f32__asm: true,
@@ -1593,7 +1593,7 @@ LibraryManager.library = {
   llvm_round_f32__deps: ['llvm_copysign_f64'],
   llvm_round_f32: function(f) {
     f = +f;
-    return +_llvm_copysign_f64(+Math_floor((+Math_abs(d) + +0.2499999999999999) + +0.2500000000000001), d);
+    return +Math_trunc(f + +_llvm_copysign_f64(+0.49999999999999994, f));
   },
 
   rintf__asm: true,

--- a/src/library.js
+++ b/src/library.js
@@ -1566,30 +1566,34 @@ LibraryManager.library = {
 
   round__asm: true,
   round__sig: 'dd',
+  round__deps: ['llvm_copysign_f64'],
   round: function(d) {
     d = +d;
-    return d >= +0 ? +Math_floor(d + +0.5) : +Math_ceil(d - +0.5);
+    return +_llvm_copysign_f64(+Math_floor((+Math_abs(d) + +0.2499999999999999) + +0.2500000000000001), d);
   },
 
   roundf__asm: true,
   roundf__sig: 'ff',
+  roundf__deps: ['llvm_copysign_f64'],
   roundf: function(d) {
     d = +d;
-    return d >= +0 ? +Math_floor(d + +0.5) : +Math_ceil(d - +0.5);
+    return +_llvm_copysign_f64(+Math_floor((+Math_abs(d) + +0.2499999999999999) + +0.2500000000000001), d);
   },
 
   llvm_round_f64__asm: true,
   llvm_round_f64__sig: 'dd',
+  llvm_round_f64__deps: ['llvm_copysign_f64'],
   llvm_round_f64: function(d) {
     d = +d;
-    return d >= +0 ? +Math_floor(d + +0.5) : +Math_ceil(d - +0.5);
+    return +_llvm_copysign_f64(+Math_floor((+Math_abs(d) + +0.2499999999999999) + +0.2500000000000001), d);
   },
 
   llvm_round_f32__asm: true,
   llvm_round_f32__sig: 'ff',
+  llvm_round_f32__deps: ['llvm_copysign_f64'],
   llvm_round_f32: function(f) {
     f = +f;
-    return f >= +0 ? +Math_floor(f + +0.5) : +Math_ceil(f - +0.5); // TODO: use fround?
+    return +_llvm_copysign_f64(+Math_floor((+Math_abs(d) + +0.2499999999999999) + +0.2500000000000001), d);
   },
 
   rintf__asm: true,


### PR DESCRIPTION
This patch applies a clever rounding approach to fix subtle correctness
bugs in the implementation of float rounding. It uses copysign to avoid
branching, and with the hope of using llvm intrinsics where available.

Work in progress, tests are missing.

Fixes #7306