### PR TITLE
Adds 'throw_' method to val

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -453,6 +453,12 @@ var LibraryEmVal = {
     return delete object[property];
   },
 
+  _emval_throw__deps: ['$requireHandle'],
+  _emval_throw: function(object) {
+    object = requireHandle(object);
+    throw object;
+  },
+
 };
 
 mergeInto(LibraryManager.library, LibraryEmVal);

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -97,6 +97,7 @@ namespace emscripten {
             bool _emval_instanceof(EM_VAL object, EM_VAL constructor);
             bool _emval_in(EM_VAL item, EM_VAL object);
             bool _emval_delete(EM_VAL object, EM_VAL property);
+            bool _emval_throw(EM_VAL object);
         }
 
         template<const char* address>
@@ -509,6 +510,10 @@ namespace emscripten {
         template<typename T>
         bool delete_(const T& property) const {
             return internal::_emval_delete(handle, val(property).handle);
+        }
+
+        void throw_() const {
+            internal::_emval_throw(handle);
         }
 
     private:

--- a/tests/embind/test_val.cpp
+++ b/tests/embind/test_val.cpp
@@ -57,6 +57,16 @@ void ensure_js_not(string js_code)
   ensure_js(js_code);
 }
 
+void throw_js_error(val js_error)
+{
+  js_error.throw_();
+}
+
+EMSCRIPTEN_BINDINGS(test_bindings)
+{
+  emscripten::function("throw_js_error", &throw_js_error);
+}
+
 int main()
 {
   printf("start\n");
@@ -511,6 +521,29 @@ int main()
   ensure_js_not("0 in a");
   ensure_js_not("1 in a");
   ensure_js_not("'c' in a");
+  
+  test("void throw_() const");
+  EM_ASM(
+    test_val_throw_ = function(error)
+    {
+      try
+      {
+        Module.throw_js_error(error);
+        return false;
+      }
+      catch(error_thrown)
+      {
+        if (error_thrown != error)
+          throw error_thrown;
+      }
+      return true;
+    }
+  );
+  ensure_js("test_val_throw_(new Error)");
+  ensure_js("test_val_throw_(Error)");
+  ensure_js("test_val_throw_(2)");
+  ensure_js("test_val_throw_('message')");
+  ensure_js("test_val_throw_(new TypeError('message'))");
   
   // this test should probably go elsewhere as it is not a member of val
   test("template<typename T> std::vector<T> vecFromJSArray(val v)");

--- a/tests/embind/test_val.out
+++ b/tests/embind/test_val.out
@@ -224,6 +224,13 @@ pass
 pass
 pass
 test:
+void throw_() const
+pass
+pass
+pass
+pass
+pass
+test:
 template<typename T> std::vector<T> vecFromJSArray(val v)
 pass
 pass


### PR DESCRIPTION
As mentioned in #6330.
Something like this will now work:
```cpp
val::global("TypeError").new_(val("wrong type")).throw_();
```
In the tests found in `test_val.cpp` it can be seen that an error can be thrown in CPP and successfully caught in JS.