### PR TITLE
Glfw extension supported

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -374,3 +374,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Kirill Smelkov <kirr@nexedi.com> (copyright owned by Nexedi)
 * Lutz Hören <laitch383@gmail.com>
 * Pedro K Custodio <git@pedrokcustodio.com>
+* Stéphane Ginier <stephaneginier@gmail.com>

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1172,11 +1172,12 @@ var LibraryGLFW = {
       GLFW.extensions = Pointer_stringify(_glGetString(0x1F03)).split(' ');
     }
 
-    if (GLFW.extensions.indexOf(extension) != -1) return 1;
+    var strExt = Pointer_stringify(extension);
+    if (GLFW.extensions.indexOf(strExt) != -1) return 1;
 
     // extensions from GLEmulations do not come unprefixed
     // so, try with prefix
-    return (GLFW.extensions.indexOf("GL_" + extension) != -1);
+    return (GLFW.extensions.indexOf("GL_" + strExt) != -1);
   },
 
   glfwGetProcAddress__deps: ['emscripten_GetProcAddress'],

--- a/tests/glfw3.c
+++ b/tests/glfw3.c
@@ -187,6 +187,8 @@ int main()
     {
         assert(glfwExtensionSupported("nonexistant") == 0);
         assert(glfwGetProcAddress("nonexistant") == NULL);
+        // 100% support since mid 2017
+        assert(glfwExtensionSupported("WEBGL_debug_renderer_info") == 1);
     }
 
     glfwTerminate();


### PR DESCRIPTION
For the extension test, in practice WEBGL_debug_renderer_info has 100% support in webgl2 (and 99% in webgl1).

Otherwise, you need to somehow test the existence of the extension in another way like:
```
if (glfwGetProcAddress("glDrawArraysInstanced") != NULL) assert(glfwExtensionSupported("ANGLE_instanced_arrays"));
```