### PR TITLE
Fix wasm-sourcemap when DWARF debug-line section has relative dirs

### DIFF
--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -210,7 +210,7 @@ def read_dwarf_entries(wasm, options):
 
     include_directories = {'0': comp_dir}
     for dir in re.finditer(r"include_directories\[\s*(\d+)\] = \"([^\"]*)", line_chunk):
-      include_directories[dir.group(1)] = dir.group(2)
+      include_directories[dir.group(1)] = (comp_dir + '/' if dir.group(2)[0] != '/' else '') + dir.group(2)
 
     files = {}
     for file in re.finditer(r"file_names\[\s*(\d+)\]:\s+name: \"([^\"]*)\"\s+dir_index: (\d+)", line_chunk):


### PR DESCRIPTION
The include_directories[] in the DWARF debug-info section may be relative (to the compilation unit directory). Fixing that in the wasm-sourcemap tool.