### PR TITLE
Add PTHREAD_WORKER_PRE_JS option

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1932,8 +1932,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       if shared.Settings.USE_PTHREADS:
         target_dir = os.path.dirname(os.path.abspath(target))
-        shutil.copyfile(shared.path_from_root('src', 'pthread-main.js'),
-                        os.path.join(target_dir, 'pthread-main.js'))
+        with open(os.path.join(target_dir, 'pthread-main.js'), 'w') as pthread_main:
+          if shared.Settings.PTHREAD_WORKER_PRE_JS:
+            with open(shared.Settings.PTHREAD_WORKER_PRE_JS) as custom_pre_contents:
+              pthread_main.write(custom_pre_contents.read())
+          with open(shared.path_from_root('src', 'pthread-main.js')) as base_contents:
+            pthread_main.write(base_contents.read())
 
       # Generate the fetch-worker.js script for multithreaded emscripten_fetch() support if targeting pthreads.
       if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:

--- a/src/pthread-main.js
+++ b/src/pthread-main.js
@@ -34,9 +34,9 @@ var ENVIRONMENT_IS_PTHREAD = true;
 // coherent clock across each of them (+/- 0.1msecs in testing)
 var __performance_now_clock_drift = 0;
 
-// Cannot use console.log or console.error in a web worker, since that would risk a browser deadlock! https://bugzilla.mozilla.org/show_bug.cgi?id=1049091
-// Therefore implement custom logging facility for threads running in a worker, which queue the messages to main thread to print.
-var Module = {};
+// Prepended JS code may have defined Module.
+var Module;
+if (!Module) Module = {};
 
 // When error objects propagate from Web Worker to main thread, they lose helpful call stack and thread ID information, so print out errors early here,
 // before that happens.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1136,6 +1136,11 @@ var PTHREADS_PROFILING = 0;
 // If true, add in debug traces for diagnosing pthreads related issues.
 var PTHREADS_DEBUG = 0;
 
+// Optional code that is prepended before pthread-main.js. This is JS that will
+// be executed in each worker thread before anything else (even before Module
+// etc. are defined - define it yourself if necessary, it will be detected).
+var PTHREAD_WORKER_PRE_JS = '';
+
 var MAX_GLOBAL_ALIGN = -1; // received from the backend
 var IMPLEMENTED_FUNCTIONS = []; // received from the backend
 var JSCALL_START_INDEX = 0; // received from the backend

--- a/tests/pthread/test_pthread_PTHREAD_WORKER_PRE_JS.cpp
+++ b/tests/pthread/test_pthread_PTHREAD_WORKER_PRE_JS.cpp
@@ -1,0 +1,80 @@
+// Copyright 2015 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <pthread.h>
+#include <emscripten.h>
+#include <emscripten/threading.h>
+#include <assert.h>
+
+#include <atomic>
+
+#if !defined(__EMSCRIPTEN_PTHREADS__) || __EMSCRIPTEN_PTHREADS__ != 1
+#error __EMSCRIPTEN_PTHREADS__ should have been defined to be equal to 1 when building with pthreads support enabled!
+#endif
+
+#define NUM_THREADS 8
+
+std::atomic<int> atomicSum;
+
+void *ThreadMain(void *arg)
+{
+  atomicSum += EM_ASM_INT({
+    return Module["something"];
+  });
+	pthread_exit(0);
+}
+
+void RunThreads()
+{	
+	pthread_attr_t attr;
+	pthread_attr_init(&attr);
+	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+	pthread_attr_setstacksize(&attr, 4*1024);
+
+	printf("Main thread has thread ID %d\n", (int)pthread_self());
+	assert(pthread_self() != 0);
+
+  pthread_t thread[NUM_THREADS];
+
+	for(int i = 0; i < NUM_THREADS; ++i)
+	{
+		int rc = pthread_create(&thread[i], &attr, ThreadMain, NULL);
+		assert(rc == 0);
+	}
+
+	pthread_attr_destroy(&attr);
+
+	for(int i = 0; i < NUM_THREADS; ++i)
+	{
+		int status = 1;
+		int rc = pthread_join(thread[i], (void**)&status);
+		assert(rc == 0);
+		assert(status == 0);
+	}
+}
+
+int main()
+{
+  atomicSum.store(0);
+
+	if (!emscripten_has_threading_support())
+	{
+#ifdef REPORT_RESULT
+		REPORT_RESULT(0);
+#endif
+		printf("Skipped: Threading is not supported.\n");
+		return 0;
+	}
+
+  RunThreads();
+
+  printf("%d threads, sum: %d\n", NUM_THREADS, atomicSum.load());
+
+#ifdef REPORT_RESULT
+	int result = (atomicSum == NUM_THREADS);
+	REPORT_RESULT(result);
+#endif
+}

--- a/tests/pthread/test_pthread_PTHREAD_WORKER_PRE_JS.cpp
+++ b/tests/pthread/test_pthread_PTHREAD_WORKER_PRE_JS.cpp
@@ -24,57 +24,57 @@ void *ThreadMain(void *arg)
   atomicSum += EM_ASM_INT({
     return Module["something"];
   });
-	pthread_exit(0);
+  pthread_exit(0);
 }
 
 void RunThreads()
-{	
-	pthread_attr_t attr;
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-	pthread_attr_setstacksize(&attr, 4*1024);
+{  
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
+  pthread_attr_setstacksize(&attr, 4*1024);
 
-	printf("Main thread has thread ID %d\n", (int)pthread_self());
-	assert(pthread_self() != 0);
+  printf("Main thread has thread ID %d\n", (int)pthread_self());
+  assert(pthread_self() != 0);
 
   pthread_t thread[NUM_THREADS];
 
-	for(int i = 0; i < NUM_THREADS; ++i)
-	{
-		int rc = pthread_create(&thread[i], &attr, ThreadMain, NULL);
-		assert(rc == 0);
-	}
+  for(int i = 0; i < NUM_THREADS; ++i)
+  {
+    int rc = pthread_create(&thread[i], &attr, ThreadMain, NULL);
+    assert(rc == 0);
+  }
 
-	pthread_attr_destroy(&attr);
+  pthread_attr_destroy(&attr);
 
-	for(int i = 0; i < NUM_THREADS; ++i)
-	{
-		int status = 1;
-		int rc = pthread_join(thread[i], (void**)&status);
-		assert(rc == 0);
-		assert(status == 0);
-	}
+  for(int i = 0; i < NUM_THREADS; ++i)
+  {
+    int status = 1;
+    int rc = pthread_join(thread[i], (void**)&status);
+    assert(rc == 0);
+    assert(status == 0);
+  }
 }
 
 int main()
 {
   atomicSum.store(0);
 
-	if (!emscripten_has_threading_support())
-	{
+  if (!emscripten_has_threading_support())
+  {
 #ifdef REPORT_RESULT
-		REPORT_RESULT(0);
+    REPORT_RESULT(0);
 #endif
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
+    printf("Skipped: Threading is not supported.\n");
+    return 0;
+  }
 
   RunThreads();
 
   printf("%d threads, sum: %d\n", NUM_THREADS, atomicSum.load());
 
 #ifdef REPORT_RESULT
-	int result = (atomicSum == NUM_THREADS);
-	REPORT_RESULT(result);
+  int result = (atomicSum == NUM_THREADS);
+  REPORT_RESULT(result);
 #endif
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3579,6 +3579,14 @@ window.close = function() {
       for args in [[], ['-s', 'USE_PTHREADS=1']]:
         self.btest(path_from_root('tests', 'gauge_available_memory.cpp'), expected='1', args=['-s', 'ABORTING_MALLOC=0'] + args + opts)
 
+  # Test PTHREAD_WORKER_PRE_JS
+  @requires_threads
+  def test_pthread_PTHREAD_WORKER_PRE_JS(self):
+    with open('pre.js', 'w') as f:
+      f.write('var Module = { something: 1 }\n')
+    for opts in [[], ['-O2']]:
+      self.btest(path_from_root('tests', 'pthread', 'test_pthread_PTHREAD_WORKER_PRE_JS.cpp'), expected='1', args=['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8', '-s', 'PTHREAD_WORKER_PRE_JS="pre.js"'] + opts)
+
   # Test that the proxying operations of user code from pthreads to main thread work
   @requires_threads
   def test_pthread_run_on_main_thread(self):


### PR DESCRIPTION
This prepends code to pthread-main.js, a convenient way to execute JS in each pthread Worker, before anything else happens there.