### PR TITLE
Fix serializing std::basic_string<unsigned char>

### DIFF
--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -284,37 +284,22 @@ namespace emscripten {
             }
         };
 
-        template<>
-        struct BindingType<std::string> {
+        template<typename T>
+        struct BindingType<std::basic_string<T>> {
+            using String = std::basic_string<T>;
+            static_assert(std::is_trivially_copyable<T>::value, "basic_string elements are memcpy'd");
             typedef struct {
                 size_t length;
-                char data[1]; // trailing data
+                T data[1]; // trailing data
             }* WireType;
-            static WireType toWireType(const std::string& v) {
-                WireType wt = (WireType)malloc(sizeof(size_t) + v.length());
+            static WireType toWireType(const String& v) {
+                WireType wt = (WireType)malloc(sizeof(size_t) + v.length() * sizeof(T));
                 wt->length = v.length();
-                memcpy(wt->data, v.data(), v.length());
+                memcpy(wt->data, v.data(), v.length() * sizeof(T));
                 return wt;
             }
-            static std::string fromWireType(WireType v) {
-                return std::string(v->data, v->length);
-            }
-        };
-
-        template<>
-        struct BindingType<std::wstring> {
-            typedef struct {
-                size_t length;
-                wchar_t data[1]; // trailing data
-            }* WireType;
-            static WireType toWireType(const std::wstring& v) {
-                WireType wt = (WireType)malloc(sizeof(size_t) + v.length() * sizeof(wchar_t));
-                wt->length = v.length();
-                wmemcpy(wt->data, v.data(), v.length());
-                return wt;
-            }
-            static std::wstring fromWireType(WireType v) {
-                return std::wstring(v->data, v->length);
+            static String fromWireType(WireType v) {
+                return String(v->data, v->length);
             }
         };
 

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -442,6 +442,12 @@ module({
             assert.equal('ABCD', e);
         });
 
+        test("can pass long string to std::basic_string<unsigned char>", function() {
+            var s = 'this string is long enough to exceed the short string optimization';
+            var e = cm.emval_test_take_and_return_std_basic_string_unsigned_char(s);
+            assert.equal(s, e);
+        });
+
         test("can pass Uint8ClampedArray to std::basic_string<unsigned char>", function() {
             var e = cm.emval_test_take_and_return_std_basic_string_unsigned_char(new Uint8ClampedArray([65, 66, 67, 68]));
             assert.equal('ABCD', e);


### PR DESCRIPTION
Fixes issue #7362 

It was silly to explicitly specialize wiretypes for `std::string` and `std::wstring`. Instead, generalize the serialization logic for all `std::basic_string<T>` where T is trivially copyable.