### PR TITLE
Fix for libsdl absolute mouse positioning when using pointerlock 

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -374,3 +374,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Kirill Smelkov <kirr@nexedi.com> (copyright owned by Nexedi)
 * Lutz Hören <laitch383@gmail.com>
 * Pedro K Custodio <git@pedrokcustodio.com>
+* Robert Isaacs <risaacs99@gmail.com>

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -593,16 +593,10 @@ var LibraryBrowser = {
           Browser.mouseMovementY = Browser.getMovementY(event);
         }
 
-        // check if SDL is available
-        if (typeof SDL != "undefined") {
-          Browser.mouseX = SDL.mouseX + Browser.mouseMovementX;
-          Browser.mouseY = SDL.mouseY + Browser.mouseMovementY;
-        } else {
-          // just add the mouse delta to the current absolut mouse position
-          // FIXME: ideally this should be clamped against the canvas size and zero
-          Browser.mouseX += Browser.mouseMovementX;
-          Browser.mouseY += Browser.mouseMovementY;
-        }
+        // just add the mouse delta to the current absolut mouse position
+        // FIXME: ideally this should be clamped against the canvas size and zero
+        Browser.mouseX += Browser.mouseMovementX;
+        Browser.mouseY += Browser.mouseMovementY;
       } else {
         // Otherwise, calculate the movement based on the changes
         // in the coordinates.

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -596,9 +596,9 @@ var LibraryBrowser = {
         // just add the mouse delta to the current absolut mouse position and clamp to surface size
         Browser.mouseX += Browser.mouseMovementX;
         Browser.mouseY += Browser.mouseMovementY;
-				var surface = (typeof SDL != 'undefined') ? SDL.surfaces[SDL.screen] : Module['canvas'];
-				Browser.mouseX = Math.min(Math.max(Browser.mouseX, 0), surface.width);
-				Browser.mouseY = Math.min(Math.max(Browser.mouseY, 0), surface.height);
+        var surface = (typeof SDL != 'undefined') ? SDL.surfaces[SDL.screen] : Module['canvas'];
+        Browser.mouseX = Math.min(Math.max(Browser.mouseX, 0), surface.width);
+        Browser.mouseY = Math.min(Math.max(Browser.mouseY, 0), surface.height);
       } else {
         // Otherwise, calculate the movement based on the changes
         // in the coordinates.

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -593,10 +593,12 @@ var LibraryBrowser = {
           Browser.mouseMovementY = Browser.getMovementY(event);
         }
 
-        // just add the mouse delta to the current absolut mouse position
-        // FIXME: ideally this should be clamped against the canvas size and zero
+        // just add the mouse delta to the current absolut mouse position and clamp to surface size
         Browser.mouseX += Browser.mouseMovementX;
         Browser.mouseY += Browser.mouseMovementY;
+				var surface = (typeof SDL != 'undefined') ? SDL.surfaces[SDL.screen] : Module['canvas'];
+				Browser.mouseX = Math.min(Math.max(Browser.mouseX, 0), surface.width);
+				Browser.mouseY = Math.min(Math.max(Browser.mouseY, 0), surface.height);
       } else {
         // Otherwise, calculate the movement based on the changes
         // in the coordinates.


### PR DESCRIPTION
Fixing a problem with SDL code that uses absolute mouse coordinates in pointerlock mode.

The logic in library_browser.js references mouseX and mouseY properties on SDL that were removed by the following commit:
https://github.com/kripken/emscripten/commit/48456b549b1262def4d84a2d058aa46abb22242e

Prior to this change the Browser.mouseX and Browser.mouseY would be stuck at zero when in pointerLock mode because the SDL.mouseX and SDL.mouseY properties were undefined. 

