### PR TITLE
shell: allow keyboard refocus when embedded in an iframe

### DIFF
--- a/src/shell.html
+++ b/src/shell.html
@@ -1212,7 +1212,7 @@
 
     
     <div class="emscripten_border">
-      <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+      <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1 onmouseenter="window.focus()" onclick="window.focus()"></canvas>
     </div>
     <textarea id="output" rows="8"></textarea>
 

--- a/src/shell_minimal.html
+++ b/src/shell_minimal.html
@@ -54,7 +54,7 @@
       <progress value="0" max="100" id="progress" hidden=1></progress>  
     </div>
     <div class="emscripten_border">
-      <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
+      <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1 onmouseenter="window.focus()" onclick="window.focus()"></canvas>
     </div>
     <hr/>
     <div class="emscripten">


### PR DESCRIPTION
Hi,

On sites such as itch.io, the game area is embedded in an iframe.
Clicking on outer webpage makes the game lose keyboard focus, but clicking on the game doesn't restore it.

#7484 does not help in that case: clicking on the canvas doesn't change the focus. For a SDL2 application, finding a bit of non-canvas document area to click on is a work-around, but not suitable if the canvas auto-adjusts to the document area.

I added 2 custom events to the canvas to fix keyboard focus:
- restore window focus on mouseenter
- restore window focus also on click, since mouseenter is not triggered in all situations (e.g. at the end of a selection event that starts in the outer document and that ends with the mouse on the canvas)

This is an issue that is common on such websites, and tricky to identify and fix, hence why I submit it here. If this is too specific, let me know if there's an other way to address this issue :)