### PR TITLE
emcc: support merging static library into a single object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -539,3 +539,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Adam Leskis <leskis@gmail.com>
 * Raffaele Pertile <raffarti@zoho.com>
 * Patric Stout <github@truebrain.nl>
+* Jinoh Kang <jinoh.kang.kr@gmail.com>

--- a/emcc.py
+++ b/emcc.py
@@ -2097,12 +2097,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   if link_to_object:
     with ToolchainProfiler.profile_block('linking to object file'):
       logger.debug('link_to_object: ' + str(linker_inputs) + ' -> ' + target)
-      if len(temp_files) == 1:
-        temp_file = temp_files[0][1]
-        # skip running the linker and just copy the object file
-        safe_copy(temp_file, target)
-      else:
-        building.link_to_object(linker_inputs, target)
+      building.link_to_object(linker_inputs, target)
       logger.debug('stopping after linking to object file')
       return 0
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1443,7 +1443,7 @@ int f() {
       # Build libfile normally into an .so
       self.run_process([EMCC, os.path.join('libdir', 'libfile.cpp'), '-shared', '-o', os.path.join('libdir', 'libfile.so' + lib_suffix)])
       # Build libother and dynamically link it to libfile
-      self.run_process([EMCC, os.path.join('libdir', 'libother.cpp')] + link_flags + ['-shared', '-o', os.path.join('libdir', 'libother.so')])
+      self.run_process([EMCC, '-Llibdir', os.path.join('libdir', 'libother.cpp')] + link_flags + ['-shared', '-o', os.path.join('libdir', 'libother.so')])
       # Build the main file, linking in both the libs
       self.run_process([EMCC, '-Llibdir', os.path.join('main.cpp')] + link_flags + ['-lother', '-c'])
       print('...')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -439,6 +439,28 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     self.run_process([EMCC, 'combined.o', '-o', 'combined.o.js'])
     self.assertContained('side got: hello from main, over', self.run_js('combined.o.js'))
 
+  def test_combining_object_files_from_archive(self):
+    # Compiling two files with -c will generate separate object files
+    self.run_process([EMCC, path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.c'), '-c'])
+    self.assertExists('twopart_main.o')
+    self.assertExists('twopart_side.o')
+
+    # Combining object files into a library archive should work
+    self.run_process([EMAR, 'crs', 'combined.a', 'twopart_main.o', 'twopart_side.o'])
+    self.assertExists('combined.a')
+
+    # Combining library archive into an object should yield a valid object, using the `-r` flag
+    self.run_process([EMCC, '-r', '-o', 'combined.o', '-Wl,--whole-archive', 'combined.a'])
+    self.assertIsObjectFile('combined.o')
+
+    # Should be two symbols (and in the wasm backend, also __original_main)
+    syms = building.llvm_nm('combined.o')
+    self.assertIn('main', syms.defs)
+    self.assertEqual(len(syms.defs), 3)
+
+    self.run_process([EMCC, 'combined.o', '-o', 'combined.o.js'])
+    self.assertContained('side got: hello from main, over', self.run_js('combined.o.js'))
+
   def test_js_transform(self):
     with open('t.py', 'w') as f:
       f.write('''


### PR DESCRIPTION
The command `cc -o lib.o -r -Wl,--whole-archive lib.a` is commonly used to link (merge) all objects in a library archive to a single object.

In this case, however, emcc treats the `lib.a` as being a single object file, which results in the input library being simply copied to output.

Fix this by suppressing the short-circuiting behaviour when the linker input is not an intermediate object file emitted by the compiler but instead the actual input file passed to emcc.

This also avoids duplicating the file type check that has already been done in the command-line option processing phase.

**EDIT**: copy commit message for description instead