### PR TITLE
WIP: Fix function pointer calls with new signatures in side modules

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -438,7 +438,7 @@ function loadWebAssemblyModule(binary, flags) {
           // and the dynamic library cannot provide JS for it. Generate
           // a closure to call the underlying dynCall.
           var dynCallName = 'dynCall_' + prop.slice(7);
-          if (Module.hasOwnProperty(dynCallName) && false) {
+          if (Module.hasOwnProperty(dynCallName)) {
             return env[prop] = function() {
               var sp = stackSave();
               try {

--- a/src/support.js
+++ b/src/support.js
@@ -437,8 +437,8 @@ function loadWebAssemblyModule(binary, flags) {
           // present in the dynamic library but not in the main JS,
           // and the dynamic library cannot provide JS for it. Generate
           // a closure to call the underlying dynCall.
+          var dynCallName = 'dynCall_' + prop.slice(7);
           if (Module.hasOwnProperty(dynCallName)) {
-            var dynCallName = 'dynCall_' + prop.slice(7);
             return env[prop] = function() {
               var sp = stackSave();
               try {

--- a/src/support.js
+++ b/src/support.js
@@ -442,7 +442,11 @@ function loadWebAssemblyModule(binary, flags) {
             var sp = stackSave();
             try {
               var args = Array.prototype.slice.call(arguments);
-              return Module[dynCallName].apply(null, args);
+              if (Module.hasOwnProperty(dynCallName)) {
+                return Module[dynCallName].apply(null, args);
+              } else {
+                return Module['wasmTable'].get(args[0]).apply(null, args.slice(1));
+              }
             } catch(e) {
               stackRestore(sp);
               if (typeof e !== 'number' && e !== 'longjmp') throw e;

--- a/src/support.js
+++ b/src/support.js
@@ -438,7 +438,7 @@ function loadWebAssemblyModule(binary, flags) {
           // and the dynamic library cannot provide JS for it. Generate
           // a closure to call the underlying dynCall.
           var dynCallName = 'dynCall_' + prop.slice(7);
-          if (Module.hasOwnProperty(dynCallName)) {
+          if (Module.hasOwnProperty(dynCallName) && false) {
             return env[prop] = function() {
               var sp = stackSave();
               try {

--- a/src/support.js
+++ b/src/support.js
@@ -436,7 +436,7 @@ function loadWebAssemblyModule(binary, flags) {
           // A missing invoke, i.e., an invoke for a function type
           // present in the dynamic library but not in the main JS,
           // and the dynamic library cannot provide JS for it. Generate
-          // a closure for it.
+          // a closure to call the underlying dynCall.
           var dynCallName = 'dynCall_' + prop.slice(7);
           env[prop] = function() {
             var sp = stackSave();

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3151,7 +3151,6 @@ ok
 
       // Issue #7708: Making indirect calls in a side module to a function with
       // a signature that doesn't exist in the main module fails.
-
       int indirect_func(int a, int b, int c) {
         return a * b * c;
       }
@@ -3164,6 +3163,8 @@ ok
         static int i = 0;
         i++;
         if (i == 10) longjmp(buf, i);
+        jmp_buf buf;
+        int jmpval = setjmp(buf);
         if (func_ptr((double)i, (double)i, (double)i) != i*i*i) {
           printf("fail\n");
         }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3149,10 +3149,24 @@ ok
       #include <setjmp.h>
       #include <stdio.h>
 
+      // Issue #7708: Making indirect calls in a side module to a function with
+      // a signature that doesn't exist in the main module fails.
+
+      int indirect_func(int a, int b, int c) {
+        return a * b * c;
+      }
+
+      typedef int (*indirect_ptr)(int, int, int);
+
       void jumpy(jmp_buf buf) {
+        indirect_ptr func_ptr = &indirect_func;
+
         static int i = 0;
         i++;
         if (i == 10) longjmp(buf, i);
+        if (func_ptr((double)i, (double)i, (double)i) != i*i*i) {
+          printf("fail\n");
+        }
         printf("pre %d\n", i);
       }
       '''

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3163,8 +3163,9 @@ ok
         static int i = 0;
         i++;
         if (i == 10) longjmp(buf, i);
-        jmp_buf buf;
-        int jmpval = setjmp(buf);
+        jmp_buf buf2;
+        // Call setjmp to trigger the use of invoke_iiii below
+        int jmpval = setjmp(buf2);
         if (func_ptr((double)i, (double)i, (double)i) != i*i*i) {
           printf("fail\n");
         }


### PR DESCRIPTION
I seem to be encountering a bug in emulated function pointer calls.

If a `SIDE_MODULE` makes a function pointer call (even internally) and that function has a signature that isn't present in the `MAIN_MODULE`, it ends up calling `invoke_X` which fails with:

```
TypeError: cannot pass i64 to or from JS
invoke_X()@https://extremely-alpha.iodide.app/pyodide-0.4.0/pyodide.asm.js:8:690227
```

I'm not exactly sure why we hit this particular message, since the function itself doesn't have any i64 arguments, but clearly the generic wasm function calling approach in `invoke_X` is failing us here.

The solution that's working for me is to generate a closure that calls the underlying `dynCall_...` function rather than doing the very most generic thing that `invoke_X` does.

All of this was discovered in Pyodide, but I'm struggling to produce a minimal example.  This requires that the generated wasm includes calls to the Javascript `invoke_` function, which happens in the context of Pyodide, but not in my minimal example.  Is there some flag or scenario that triggers the generation of `call $invoke_...`?