### PR TITLE
Do not preprocess within <style> block.  Fixes issue #7700.

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -25,9 +25,9 @@ function processMacros(text) {
 // Param filenameHint can be passed as a description to identify the file that is being processed, used
 // to locate errors for reporting and for html files to stop expansion between <style> and </style>.
 function preprocess(text, filenameHint) {
-  var fileext = (filenameHint) ? filenameHint.split('.').pop().toLowerCase() : "";
-  var ishtml = (fileext == "html" || fileext == "htm") ? true : false;
-  var instyle = false;
+  var fileExt = (filenameHint) ? filenameHint.split('.').pop().toLowerCase() : "";
+  var isHtml = (fileExt == 'html' || fileExt == 'htm') ? true : false;
+  var inStyle = false;
   var lines = text.split('\n');
   var ret = '';
   var showStack = [];
@@ -37,33 +37,33 @@ function preprocess(text, filenameHint) {
       if (line[line.length-1] == '\r') {
         line = line.substr(0, line.length-1); // Windows will have '\r' left over from splitting over '\r\n'
       }
-      if (ishtml && line.indexOf('<style') != -1 && !instyle) {
-        instyle = true;
+      if (isHtml && line.indexOf('<style') != -1 && !inStyle) {
+        inStyle = true;
       }
-      if (ishtml && line.indexOf('</style') != -1 && instyle) {
-        instyle = false;
+      if (isHtml && line.indexOf('</style') != -1 && inStyle) {
+        inStyle = false;
       }
 
-      if (!instyle && line.indexOf('#if') === 0) {
+      if (!inStyle && line.indexOf('#if') === 0) {
         var parts = line.split(' ');
         var after = parts.slice(1).join(' ');
         var truthy = !!eval(after);
         showStack.push(truthy);
-      } else if (!instyle && line.indexOf('#include') === 0) {
+      } else if (!inStyle && line.indexOf('#include') === 0) {
         var filename = line.substr(line.indexOf(' ')+1);
         if (filename.indexOf('"') === 0) {
           filename = filename.substr(1, filename.length - 2);
         }
         var included = read(filename);
         ret += '\n' + preprocess(included, filename) + '\n';
-      } else if (!instyle && line.indexOf('#else') === 0) {
+      } else if (!inStyle && line.indexOf('#else') === 0) {
         assert(showStack.length > 0);
         showStack.push(!showStack.pop());
-      } else if (!instyle && line.indexOf('#endif') === 0) {
+      } else if (!inStyle && line.indexOf('#endif') === 0) {
         assert(showStack.length > 0);
         showStack.pop();
       } else {
-        if (!instyle && line[0] == '#') {
+        if (!inStyle && line[0] == '#') {
           printErr("Ignoring unclear preprocessor command: " + line);
         }
         if (showStack.indexOf(false) == -1) {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -65,7 +65,7 @@ function preprocess(text, filenameHint) {
           showStack.pop();
         } else {
           if (line[0] === '#') {
-            printErr("Ignoring unclear preprocessor command: " + line);
+            throw "Unclear preprocessor command on line " + i + ': ' + line;
           }
           if (showStack.indexOf(false) === -1) {
             ret += line + '\n';

--- a/tests/module/test_html_preprocess1.html
+++ b/tests/module/test_html_preprocess1.html
@@ -1,8 +1,15 @@
+<style>
+/* Disable preprocessing inside style block as syntax is ambiguous with CSS */
+#include {background-color: black;}
+#if { background-color: red;}
+#else {background-color: blue;}
+#endif {background-color: green;}
+</style>
 #if ASSERTIONS == 1
 T1:ASSERTIONS == 1
 #else
 T1:(else) ASSERTIONS != 1
-#endif 
+#endif
 #if ASSERTIONS != 1
 T2:ASSERTIONS != 1
 #else

--- a/tests/module/test_html_preprocess1.html
+++ b/tests/module/test_html_preprocess1.html
@@ -6,7 +6,6 @@
 #endif {background-color: green;}
 #xxx {background-color: purple;}
 </style>
-#xif Expect a warning on invalid preprocessor command
 #if ASSERTIONS == 1
 T1:ASSERTIONS == 1
 #else

--- a/tests/module/test_html_preprocess1.html
+++ b/tests/module/test_html_preprocess1.html
@@ -4,7 +4,9 @@
 #if { background-color: red;}
 #else {background-color: blue;}
 #endif {background-color: green;}
+#xxx {background-color: purple;}
 </style>
+#xif Expect a warning on invalid preprocessor command
 #if ASSERTIONS == 1
 T1:ASSERTIONS == 1
 #else

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8453,7 +8453,6 @@ int main() {
 #endif {background-color: green;}
 #xxx {background-color: purple;}
 </style>
-#xif Expect a warning on invalid preprocessor command
 T1:(else) ASSERTIONS != 1
 T2:ASSERTIONS != 1
 T3:ASSERTIONS < 2
@@ -8471,7 +8470,6 @@ T6:!ASSERTIONS""", output)
 #endif {background-color: green;}
 #xxx {background-color: purple;}
 </style>
-#xif Expect a warning on invalid preprocessor command
 T1:ASSERTIONS == 1
 T2:(else) ASSERTIONS == 1
 T3:ASSERTIONS < 2
@@ -8489,7 +8487,6 @@ T6:(else) !ASSERTIONS""", output)
 #endif {background-color: green;}
 #xxx {background-color: purple;}
 </style>
-#xif Expect a warning on invalid preprocessor command
 T1:(else) ASSERTIONS != 1
 T2:ASSERTIONS != 1
 T3:(else) ASSERTIONS >= 2

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8445,7 +8445,14 @@ int main() {
 
     run_process([PYTHON, EMCC, '-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=0'], stdout=PIPE, stderr=PIPE)
     output = open(output_file).read()
-    self.assertContained("""T1:(else) ASSERTIONS != 1
+    self.assertContained("""<style>
+/* Disable preprocessing inside style block as syntax is ambiguous with CSS */
+#include {background-color: black;}
+#if { background-color: red;}
+#else {background-color: blue;}
+#endif {background-color: green;}
+</style>
+T1:(else) ASSERTIONS != 1
 T2:ASSERTIONS != 1
 T3:ASSERTIONS < 2
 T4:(else) ASSERTIONS <= 1
@@ -8454,7 +8461,14 @@ T6:!ASSERTIONS""", output)
 
     run_process([PYTHON, EMCC, '-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=1'], stdout=PIPE, stderr=PIPE)
     output = open(output_file).read()
-    self.assertContained("""T1:ASSERTIONS == 1
+    self.assertContained("""<style>
+/* Disable preprocessing inside style block as syntax is ambiguous with CSS */
+#include {background-color: black;}
+#if { background-color: red;}
+#else {background-color: blue;}
+#endif {background-color: green;}
+</style>
+T1:ASSERTIONS == 1
 T2:(else) ASSERTIONS == 1
 T3:ASSERTIONS < 2
 T4:(else) ASSERTIONS <= 1
@@ -8463,7 +8477,14 @@ T6:(else) !ASSERTIONS""", output)
 
     run_process([PYTHON, EMCC, '-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=2'], stdout=PIPE, stderr=PIPE)
     output = open(output_file).read()
-    self.assertContained("""T1:(else) ASSERTIONS != 1
+    self.assertContained("""<style>
+/* Disable preprocessing inside style block as syntax is ambiguous with CSS */
+#include {background-color: black;}
+#if { background-color: red;}
+#else {background-color: blue;}
+#endif {background-color: green;}
+</style>
+T1:(else) ASSERTIONS != 1
 T2:ASSERTIONS != 1
 T3:(else) ASSERTIONS >= 2
 T4:ASSERTIONS > 1

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8451,7 +8451,9 @@ int main() {
 #if { background-color: red;}
 #else {background-color: blue;}
 #endif {background-color: green;}
+#xxx {background-color: purple;}
 </style>
+#xif Expect a warning on invalid preprocessor command
 T1:(else) ASSERTIONS != 1
 T2:ASSERTIONS != 1
 T3:ASSERTIONS < 2
@@ -8467,7 +8469,9 @@ T6:!ASSERTIONS""", output)
 #if { background-color: red;}
 #else {background-color: blue;}
 #endif {background-color: green;}
+#xxx {background-color: purple;}
 </style>
+#xif Expect a warning on invalid preprocessor command
 T1:ASSERTIONS == 1
 T2:(else) ASSERTIONS == 1
 T3:ASSERTIONS < 2
@@ -8483,7 +8487,9 @@ T6:(else) !ASSERTIONS""", output)
 #if { background-color: red;}
 #else {background-color: blue;}
 #endif {background-color: green;}
+#xxx {background-color: purple;}
 </style>
+#xif Expect a warning on invalid preprocessor command
 T1:(else) ASSERTIONS != 1
 T2:ASSERTIONS != 1
 T3:(else) ASSERTIONS >= 2

--- a/tools/preprocessor.js
+++ b/tools/preprocessor.js
@@ -138,6 +138,6 @@ load(settings_file);
 load('parseTools.js');
 
 var from_html = read(shell_file);
-var to_html = process_macros ? processMacros(preprocess(from_html)) : preprocess(from_html);
+var to_html = process_macros ? processMacros(preprocess(from_html, shell_file)) : preprocess(from_html, shell_file);
 
 print(to_html);

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3249,9 +3249,6 @@ def read_and_preprocess(filename, expand_macros=False):
   run_js(path_from_root('tools/preprocessor.js'), NODE_JS, args, True, stdout=open(stdout, 'w'), cwd=path)
   out = open(stdout, 'r').read()
 
-  os.remove(stdout)
-  os.remove(settings_file)
-
   return out
 
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3249,6 +3249,9 @@ def read_and_preprocess(filename, expand_macros=False):
   run_js(path_from_root('tools/preprocessor.js'), NODE_JS, args, True, stdout=open(stdout, 'w'), cwd=path)
   out = open(stdout, 'r').read()
 
+  os.remove(stdout)
+  os.remove(settings_file)
+
   return out
 
 


### PR DESCRIPTION
This PR is to address issue #7700 and causes the preprocessor to ignore contents of <style> blocks when preprocessing html files.