### PR TITLE
cmake: allow users to define CMAKE_FIND_ROOT_PATH_MODE_XXX

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -179,13 +179,24 @@ endif()
 
 # To find programs to execute during CMake run time with find_program(), e.g. 'git' or so, we allow looking
 # into system paths.
-set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+# Still, allow users to set these variables beforehand.
+if (NOT CMAKE_FIND_ROOT_PATH_MODE_PROGRAM)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+endif()
 
 # Since Emscripten is a cross-compiler, we should never look at the system-provided directories like /usr/include and so on.
 # Therefore only CMAKE_FIND_ROOT_PATH should be used as a find directory. See http://www.cmake.org/cmake/help/v3.0/variable/CMAKE_FIND_ROOT_PATH_MODE_INCLUDE.html
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+if (NOT CMAKE_FIND_ROOT_PATH_MODE_LIBRARY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+endif()
+
+if (NOT CMAKE_FIND_ROOT_PATH_MODE_INCLUDE)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+
+if (NOT CMAKE_FIND_ROOT_PATH_MODE_PACKAGE)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+endif()
 
 set(CMAKE_SYSTEM_INCLUDE_PATH "${EMSCRIPTEN_ROOT_PATH}/system/include")
 


### PR DESCRIPTION
Hello,

I'm opening this PR to solve an issue I have with my setup, here is a short summary:

I'm using Conan at work to manage C++ dependencies, and we are trying to cross-build to WebAssembly with Emscripten. To do so, I created a "Toolchain package" which sets correct flags automatically for consumers of this package.

For CMake builds, I simply exposed the `CMAKE_TOOLCHAIN_FILE` to point to `Emscripten.cmake`.

The thing is `find_package` now fails to find any dependency, due to the `CMAKE_FIND_ROOT_PATH_MODE_PACKAGE` set to `ONLY`.

While this is a valid behavior for regular CMake use-case, it is quite inconvenient for us, since Conan packages are all located in different folders, but are still found easily with `CMAKE_PREFIX_PATH` being set with all the package folders' paths. However, `ONLY` prevents it from working, and I'd like to set every `MODE_XXX` setting to `BOTH`.

So I simply mimicked what's done in the Android NDK's toolchain file and added some if/endif guards around each `set()`. It allows users to specify a different value if they need. This works great for us when cross-building to Android with Conan.

Note:

I first tried to simply include Emscripten's Toolchain from a custom toolchain file, and reset those variables. However, the `CMakeSystemSpecificInformation.cmake` includes `Emscripten.cmake` right before processing the customer `CMakeLists.txt` and thus the variables are overriden with the default values.