### PR TITLE
fetch_support_indexeddb

### DIFF
--- a/src/fetch-worker.js
+++ b/src/fetch-worker.js
@@ -83,12 +83,12 @@ function processWorkQueue() {
   for(var i = 0; i < numQueuedItems; ++i) {
     var fetch = Atomics_load(HEAPU32, (queuedOperations >> 2)+i);
     function successcb(fetch) {
-      Atomics.compareExchange(HEAPU32, fetch + Fetch.fetch_t_offset___proxyState >> 2, 1, 2);
-      Atomics.wake(HEAP32, fetch + Fetch.fetch_t_offset___proxyState >> 2, 1);
+      Atomics.compareExchange(HEAPU32, fetch + {{{ C_STRUCTS.emscripten_fetch_t.__proxyState }}} >> 2, 1, 2);
+      Atomics.wake(HEAP32, fetch + {{{ C_STRUCTS.emscripten_fetch_t.__proxyState }}} >> 2, 1);
     }
     function errorcb(fetch) {
-      Atomics.compareExchange(HEAPU32, fetch + Fetch.fetch_t_offset___proxyState >> 2, 1, 2);
-      Atomics.wake(HEAP32, fetch + Fetch.fetch_t_offset___proxyState >> 2, 1);
+      Atomics.compareExchange(HEAPU32, fetch + {{{ C_STRUCTS.emscripten_fetch_t.__proxyState }}} >> 2, 1, 2);
+      Atomics.wake(HEAP32, fetch + {{{ C_STRUCTS.emscripten_fetch_t.__proxyState }}} >> 2, 1);
     }
     function progresscb(fetch) {
     }

--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -19,12 +19,19 @@ var LibraryFetch = {
     return _fetch_work_queue;
   },
 
+#if FETCH_SUPPORT_INDEXEDDB
   $__emscripten_fetch_delete_cached_data: __emscripten_fetch_delete_cached_data,
   $__emscripten_fetch_load_cached_data: __emscripten_fetch_load_cached_data,
   $__emscripten_fetch_cache_data: __emscripten_fetch_cache_data,
+#endif
   $__emscripten_fetch_xhr: __emscripten_fetch_xhr,
-  emscripten_start_fetch__deps: ['$Fetch', '$__emscripten_fetch_xhr', '$__emscripten_fetch_cache_data', '$__emscripten_fetch_load_cached_data', '$__emscripten_fetch_delete_cached_data', '_emscripten_get_fetch_work_queue', 'emscripten_is_main_runtime_thread'],
-  emscripten_start_fetch: emscripten_start_fetch
+
+  emscripten_start_fetch: emscripten_start_fetch,
+  emscripten_start_fetch__deps: ['$Fetch', '$__emscripten_fetch_xhr',
+#if FETCH_SUPPORT_INDEXEDDB
+  '$__emscripten_fetch_cache_data', '$__emscripten_fetch_load_cached_data', '$__emscripten_fetch_delete_cached_data',
+#endif
+  '_emscripten_get_fetch_work_queue', 'emscripten_is_main_runtime_thread']
 };
 
 mergeInto(LibraryManager.library, LibraryFetch);

--- a/src/settings.js
+++ b/src/settings.js
@@ -1288,6 +1288,10 @@ var OFFSCREENCANVAS_SUPPORT = 0;
 // back to Offscreen Framebuffer otherwise.
 var OFFSCREEN_FRAMEBUFFER = 0;
 
+// If nonzero, Fetch API (and hence ASMFS) supports backing to IndexedDB. If 0, IndexedDB is not utilized. Set to 0 if
+// IndexedDB support is not interesting for target application, to save a few kBytes.
+var FETCH_SUPPORT_INDEXEDDB = 1;
+
 // If nonzero, prints out debugging information in library_fetch.js
 var FETCH_DEBUG = 0;
 

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1551,5 +1551,50 @@
             ]
         },
         "defines": []
+    },
+    {
+        "file": "emscripten/fetch.h",
+        "structs": {
+            "emscripten_fetch_attr_t": [
+                "requestMethod",
+                "userData",
+                "onsuccess",
+                "onerror",
+                "onprogress",
+                "attributes",
+                "timeoutMSecs",
+                "withCredentials",
+                "destinationPath",
+                "userName",
+                "password",
+                "requestHeaders",
+                "overriddenMimeType",
+                "requestData",
+                "requestDataSize"
+            ],
+            "emscripten_fetch_t": [
+                "id",
+                "userData",
+                "url",
+                "data",
+                "numBytes",
+                "dataOffset",
+                "totalBytes",
+                "readyState",
+                "status",
+                "statusText",
+                "__proxyState",
+                "__attributes"
+            ]
+        },
+        "defines": ["EMSCRIPTEN_FETCH_LOAD_TO_MEMORY",
+            "EMSCRIPTEN_FETCH_STREAM_DATA",
+            "EMSCRIPTEN_FETCH_PERSIST_FILE",
+            "EMSCRIPTEN_FETCH_APPEND",
+            "EMSCRIPTEN_FETCH_REPLACE",
+            "EMSCRIPTEN_FETCH_NO_DOWNLOAD",
+            "EMSCRIPTEN_FETCH_SYNCHRONOUS",
+            "EMSCRIPTEN_FETCH_WAITABLE"
+        ]
     }
  ]

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4105,10 +4105,11 @@ window.close = function() {
 
     # Test the positive case when the file URL exists. (http 200)
     shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
-    self.btest('fetch/to_memory.cpp',
-               expected='1',
-               args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'],
-               also_asmjs=True)
+    for arg in [[], ['-s', 'FETCH_SUPPORT_INDEXEDDB=0']]:
+      self.btest('fetch/to_memory.cpp',
+                 expected='1',
+                 args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'] + arg,
+                 also_asmjs=True)
 
   def test_fetch_to_indexdb(self):
     shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3248,11 +3248,6 @@ def safe_copy(src, dst):
   shutil.copyfile(src, dst)
 
 
-def clang_preprocess(filename):
-  # TODO: REMOVE HACK AND PASS PREPROCESSOR FLAGS TO CLANG.
-  return run_process([CLANG_CC, '-DFETCH_DEBUG=1', '-E', '-P', '-C', '-x', 'c', filename], check=True, stdout=subprocess.PIPE).stdout
-
-
 def read_and_preprocess(filename, expand_macros=False):
   temp_dir = get_emscripten_temp_dir()
   # Create a settings file with the current settings to pass to the JS preprocessor
@@ -3309,5 +3304,5 @@ def make_fetch_worker(source_file, output_file):
     func_code = src[loc:end_loc]
     function_prologue = function_prologue + '\n' + func_code
 
-  fetch_worker_src = function_prologue + '\n' + clang_preprocess(path_from_root('src', 'fetch-worker.js'))
+  fetch_worker_src = function_prologue + '\n' + read_and_preprocess(path_from_root('src', 'fetch-worker.js'), expand_macros=True)
   open(output_file, 'w').write(fetch_worker_src)


### PR DESCRIPTION
Add FETCH_SUPPORT_INDEXEDDB option to allow disabling IndexedDB support for Fetch API, when not desired. Closure is not able to DCE away IndexedDB use, so need to manually allow the option.