### PR TITLE
expand_bare_minimum_html5_api_functions

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -24,7 +24,10 @@ The HTML5 specifications for APIs that are mapped by **html5.h** include:
   - `Touch Events <http://www.w3.org/TR/touch-events/>`_.
   - `Gamepad API <http://www.w3.org/TR/gamepad/>`_.
   - `Beforeunload event <http://www.whatwg.org/specs/web-apps/current-work/multipage/history.html#beforeunloadevent>`_.
-  - `WebGL context events <http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2>`_
+  - `WebGL context events <http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2>`_.
+  - `Animation and timing <https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame>`_.
+  - `Console <https://developer.mozilla.org/en-US/docs/Web/API/console>`_.
+  - `Throw <https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/throw>`_.
 
 
 .. contents:: Table of Contents
@@ -2127,8 +2130,6 @@ Functions
   :returns: EM_TRUE if the given extension is supported by the context, and EM_FALSE if the extension was not available.
   :rtype: |EM_BOOL|
 
-  .. comment : **HamishW** Are EM_TRUE, EM_FALSE defined?
-
 
 CSS
 ===
@@ -2182,3 +2183,191 @@ Functions
 
 .. _gamepad: http://www.w3.org/TR/gamepad/#gamepad-interface
 .. _webgl_context: http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.15.2
+
+Animation and Timing
+====================
+
+The API provided here are low-level functions that directly call the relevant Web APIs and nothing more. They don't integrate with the emscripten runtime, such as checking if the program has halted and cancelling a callback if so. For that purpose,
+see the function ``emscripten_set_main_loop()``.
+
+Functions
+---------
+
+.. c:function:: long emscripten_set_timeout(void (*cb)(void *userData), double msecs, void *userData)
+
+  Performs a setTimeout() callback call on the given function on the calling thread.
+
+  :param cb: The callback function to call.
+  :param msecs: Millisecond delay until the callback should fire.
+  :param userData: Specifies a pointer sized field of custom data that will be passed in to the callback function.
+  :returns: An ID to the setTimeout() call that can be passed to emscripten_clear_timeout() to cancel the pending timeout timer.
+
+
+.. c:function:: void emscripten_clear_timeout(long setTimeoutId)
+
+  Cancels a pending setTimeout() call on the calling thread. This function must be called on the same
+  thread as the emscripten_set_timeout() call that registered the callback.
+
+  :param setTimeoutId: An ID returned by function emscripten_set_timeout().
+
+
+.. c:function:: void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *userData), double intervalMsecs, void *userData)
+
+  Initializes a setTimeout() loop on the given function on the calling thread. The specified callback
+  function 'cb' needs to keep returning EM_TRUE as long as the animation loop should continue to run.
+  When the function returns false, the setTimeout() loop will stop.
+  Note: The loop will start immediately with a 0 msecs delay - the passed in intervalMsecs time specifies
+  the interval that the consecutive callback calls should fire at.
+
+  :param cb: The callback function to call.
+  :param intervalMsecs: Millisecond interval at which the callback should keep firing.
+  :param userData: Specifies a pointer sized field of custom data that will be passed in to the callback function.
+
+
+.. c:function:: long emscripten_request_animation_frame(EM_BOOL (*cb)(double time, void *userData), void *userData)
+
+  Performs a single requestAnimationFrame() callback call on the given function on the calling thread.
+
+  :param cb: The callback function to call. This function will receive the current high precision timer value
+    (value of performance.now()) at the time of the call.
+  :param userData: Specifies a pointer sized field of custom data that will be passed in to the callback function.
+  :returns: An ID to the requestAnimationFrame() call that can be passed to emscripten_cancel_animation_frame() to
+    cancel the pending requestAnimationFrame timer.
+
+
+.. c:function:: void emscripten_cancel_animation_frame(long requestAnimationFrameId)
+
+  Cancels a registered requestAnimationFrame() callback on the calling thread before it is run. This
+  function must be called on the same thread as the emscripten_request_animation_frame() call that
+  registered the callback.
+
+  :param requestAnimationFrameId: An ID returned by function emscripten_request_animation_frame().
+
+
+.. c:function:: void emscripten_request_animation_frame_loop(EM_BOOL (*cb)(double time, void *userData), void *userData)
+
+  Initializes a requestAnimationFrame() loop on the given function on the calling thread. The specified
+  callback function 'cb' needs to keep returning EM_TRUE as long as the animation loop should continue
+  to run. When the function returns false, the animation frame loop will stop.
+
+  :param cb: The callback function to call. This function will receive the current high precision timer value
+    (value of performance.now()) at the time of the call.
+  :param userData: Specifies a pointer sized field of custom data that will be passed in to the callback function.
+
+
+.. c:function:: long emscripten_set_immediate(void (*cb)(void *userData), void *userData)
+
+  Performs a setImmediate() callback call on the given function on the calling thread. Returns an ID
+  to the setImmediate() call that can be passed to emscripten_clear_immediate() function to cancel
+  a pending setImmediate() invocation.
+  TODO: Currently the polyfill of setImmediate() only works in the main browser thread, but not in pthreads.
+
+  :param cb: The callback function to call.
+  :param userData: Specifies a pointer sized field of custom data that will be passed in to the callback function.
+  :returns: An ID to the setImmediate() call that can be passed to emscripten_clear_immediate() to cancel the pending callback.
+
+
+.. c:function:: void emscripten_clear_immediate(long setImmediateId)
+
+  Cancels a pending setImmediate() call on the calling thread. This function must be called on the same
+  thread as the emscripten_set_immediate() call that registered the callback.
+
+  :param setImmediateId: An ID returned by function emscripten_set_immediate().
+
+
+.. c:function:: void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *userData), void *userData)
+
+  Initializes a setImmediate() loop on the given function on the calling thread. The specified callback
+  function 'cb' needs to keep returning EM_TRUE as long as the loop should continue to run.
+  When the function returns false, the setImmediate() loop will stop.
+  TODO: Currently the polyfill of setImmediate() only works in the main browser thread, but not in pthreads.
+
+  :param cb: The callback function to call.
+  :param userData: Specifies a pointer sized field of custom data that will be passed in to the callback function.
+
+
+.. c:function:: long emscripten_set_interval(void (*cb)(void *userData), double intervalMsecs, void *userData)
+
+  Initializes a setInterval() loop on the given function on the calling thread. Returns an ID to the
+  initialized loop. Call emscripten_clear_interval() with this ID to terminate the loop.
+  Note that this function will cause the given callback to be called repeatedly. Do not call
+  emscripten_set_interval() again on the same callback function from inside the callback, as that would
+  register multiple loops to run simultaneously.
+
+  :param cb: The callback function to call.
+  :param intervalMsecs: Millisecond interval at which the callback should keep firing.
+  :param userData: Specifies a pointer sized field of custom data that will be passed in to the callback function.
+  :returns: An ID to the setInterval() call that can be passed to emscripten_clear_interval() to cancel the
+    currently executing interval timer.
+
+
+.. c:function:: void emscripten_clear_interval(long setIntervalId)
+
+  Cancels a currently executing setInterval() loop on the calling thread. This function must be called on
+  the same thread as the emscripten_set_interval() call that registered the callback.
+
+  :param setIntervalId: An ID returned by function emscripten_set_interval().
+
+
+.. c:function:: double emscripten_date_now(void)
+
+  Calls JavaScript Date.now() function in the current thread.
+
+  :returns: The number of msecs elapsed since the UNIX epoch. (00:00:00 Thursday, 1 January 1970)
+
+
+.. c:function:: double emscripten_performance_now(void)
+
+  Calls JavaScript performance.now() function in the current thread. Note that the returned value of
+  this function is based on different time offset depending on which thread this function is called in.
+  That is, do not compare absolute time values returned by performance.now() across threads. (comparing
+  relative timing values is ok). On the main thread this function returns the number of milliseconds elapsed
+  since page startup time. In a Web Worker/pthread, this function returns the number of milliseconds since
+  the Worker hosting that pthread started up. (Workers are generally not torn down when a pthread quits and
+  a second one starts, but they are kept alive in a pool, so this function is not guaranteed to start
+  counting time from 0 at the time when a pthread starts)
+
+  :returns: A high precision wallclock time value in msecs.
+
+
+Console
+=======
+
+Functions
+---------
+
+.. c:function:: void emscripten_console_log(const char *utf8String)
+
+  Prints a string using console.log().
+
+  :param utf8String: A string encoded as UTF-8.
+
+
+.. c:function:: void emscripten_console_warn(const char *utf8String)
+
+  Prints a string using console.warn().
+
+  :param utf8String: A string encoded as UTF-8.
+
+
+.. c:function:: void emscripten_console_error(const char *utf8String)
+
+  Prints a string using console.error().
+
+  :param utf8String: A string encoded as UTF-8.
+
+
+Throw
+=====
+
+Functions
+---------
+
+.. c:function:: void emscripten_throw_number(double number)
+
+  Invokes JavaScript throw statement and throws a number.
+
+
+.. c:function:: void emscripten_throw_string(const char *utf8String)
+
+  Invokes JavaScript throw statement and throws a string.

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1321,12 +1321,6 @@ var LibraryBrowser = {
     exit(status);
   },
 
-  emscripten_get_device_pixel_ratio__proxy: 'sync',
-  emscripten_get_device_pixel_ratio__sig: 'd',
-  emscripten_get_device_pixel_ratio: function() {
-    return window.devicePixelRatio || 1.0;
-  },
-
   emscripten_hide_mouse__proxy: 'sync',
   emscripten_hide_mouse__sig: 'v',
   emscripten_hide_mouse: function() {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1350,7 +1350,6 @@ var EMIT_EMSCRIPTEN_METADATA = 0;
 // for effective code size optimizations to take place.
 var SUPPORT_ERRNO = 1;
 
-
 // Internal: points to a file that lists all asm.js/wasm module exports, annotated
 // with suppressions for Closure compiler, that can be passed as an --externs file
 // to Closure.

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -518,6 +518,31 @@ extern void emscripten_html5_remove_all_event_listeners(void);
 #define emscripten_set_webglcontextlost_callback(target, userData, useCapture, callback)      emscripten_set_webglcontextlost_callback_on_thread(     (target), (userData), (useCapture), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 #define emscripten_set_webglcontextrestored_callback(target, userData, useCapture, callback)  emscripten_set_webglcontextrestored_callback_on_thread( (target), (userData), (useCapture), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 
+extern long emscripten_set_timeout(void (*cb)(void *userData), double msecs, void *userData);
+extern void emscripten_clear_timeout(long setTimeoutId);
+extern void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *userData), double intervalMsecs, void *userData);
+
+extern long emscripten_request_animation_frame(EM_BOOL (*cb)(double time, void *userData), void *userData);
+extern void emscripten_cancel_animation_frame(long requestAnimationFrameId);
+extern void emscripten_request_animation_frame_loop(EM_BOOL (*cb)(double time, void *userData), void *userData);
+
+extern long emscripten_set_immediate(void (*cb)(void *userData), void *userData);
+extern void emscripten_clear_immediate(long setImmediateId);
+extern void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *userData), void *userData);
+
+extern long emscripten_set_interval(void (*cb)(void *userData), double intervalMsecs, void *userData);
+extern void emscripten_clear_interval(long setIntervalId);
+
+extern double emscripten_date_now(void);
+extern double emscripten_performance_now(void);
+
+extern void emscripten_console_log(const char *utf8String);
+extern void emscripten_console_warn(const char *utf8String);
+extern void emscripten_console_error(const char *utf8String);
+
+extern void emscripten_throw_number(double number);
+extern void emscripten_throw_string(const char *utf8String);
+
 #ifdef __cplusplus
 } // ~extern "C"
 #endif

--- a/tests/emscripten_console_log.c
+++ b/tests/emscripten_console_log.c
@@ -1,0 +1,15 @@
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+int main()
+{
+	emscripten_console_log("Hello!");
+	emscripten_console_warn("Hello!");
+	emscripten_console_error("Hello!");
+	if (EM_ASM_INT(return Module['testPassed']))
+	{
+#ifdef REPORT_RESULT
+		REPORT_RESULT(0);
+#endif
+	}
+}

--- a/tests/emscripten_console_log_pre.js
+++ b/tests/emscripten_console_log_pre.js
@@ -1,0 +1,21 @@
+console.realLog = console.log;
+console.realWarn = console.warn;
+console.realError = console.error;
+
+var logged = false;
+var warned = false;
+
+console.log = function(s) {
+	console.realLog(s);
+	if (s === 'Hello!') logged = true;
+}
+
+console.warn = function(s) {
+	console.realWarn(s);
+	if (s === 'Hello!' && logged) warned = true;
+}
+
+console.error = function(s) {
+	console.realError(s);
+	if (s === 'Hello!' && logged && warned) Module['testPassed'] = true;
+}

--- a/tests/emscripten_performance_now.c
+++ b/tests/emscripten_performance_now.c
@@ -1,0 +1,35 @@
+#include <emscripten/html5.h>
+#include <emscripten/threading.h>
+#include <assert.h>
+
+double performanceNow;
+double dateNow;
+
+void test(void *userData)
+{
+	double now2 = emscripten_performance_now();
+	assert(now2 >= performanceNow + 100);
+
+	double now3 = emscripten_date_now();
+	assert(now3 >= dateNow + 100);
+
+#ifdef REPORT_RESULT
+	REPORT_RESULT(0);
+#endif
+}
+
+int main()
+{
+	performanceNow = emscripten_performance_now();
+	assert(performanceNow < 10*1000); // Should take well less than 10 seconds to load up the page
+
+	dateNow = emscripten_date_now();
+	assert(dateNow > 1547568082); // == 2019-01-15T16:01:22+00:00)
+
+#ifdef __EMSCRIPTEN_PTHREADS__
+	emscripten_thread_sleep(200);
+	test(0);
+#else
+	emscripten_set_timeout(test, 200, 0);
+#endif
+}

--- a/tests/emscripten_request_animation_frame.c
+++ b/tests/emscripten_request_animation_frame.c
@@ -1,0 +1,51 @@
+#include <emscripten/html5.h>
+#include <assert.h>
+
+int func1Executed = 0;
+int func2Executed = 0;
+
+EM_BOOL func1(double time, void *userData);
+
+EM_BOOL func2(double time, void *userData)
+{
+	assert((int)userData == 2);
+	assert(time > 0);
+	++func2Executed;
+
+	if (func2Executed == 1)
+	{
+		// Test canceling an animation frame: register rAF() but then cancel it immediately
+		long id = emscripten_request_animation_frame(func1, (void*)2);
+		emscripten_cancel_animation_frame(id);
+
+		emscripten_request_animation_frame(func2, (void*)2);
+	}
+	if (func2Executed == 2)
+	{
+#ifdef REPORT_RESULT
+		assert(func1Executed == 1);
+		REPORT_RESULT(0);
+#endif
+	}
+	return 0;
+}
+
+EM_BOOL func1(double time, void *userData)
+{
+	assert((int)userData == 1);
+	assert(time > 0);
+	++func1Executed;
+
+#ifdef REPORT_RESULT
+	assert(func1Executed == 1);
+#endif
+
+	emscripten_request_animation_frame(func2, (void*)2);
+
+	return 0;
+}
+
+int main()
+{
+	emscripten_request_animation_frame(func1, (void*)1);
+}

--- a/tests/emscripten_request_animation_frame_loop.c
+++ b/tests/emscripten_request_animation_frame_loop.c
@@ -1,0 +1,32 @@
+#include <emscripten/html5.h>
+#include <assert.h>
+
+double previousRafTime = 0;
+int funcExecuted = 0;
+
+void testDone(void *userData)
+{
+	assert((int)userData == 2);
+	assert(funcExecuted == 10);
+#ifdef REPORT_RESULT
+	REPORT_RESULT(0);
+#endif
+}
+
+EM_BOOL tick(double time, void *userData)
+{
+	assert(time > previousRafTime);
+	previousRafTime = time;
+	assert((int)userData == 1);
+	++funcExecuted;
+	if (funcExecuted == 10)
+	{
+		emscripten_set_timeout(testDone, 300, (void*)2);
+	}
+	return funcExecuted < 10;
+}
+
+int main()
+{
+	emscripten_request_animation_frame_loop(tick, (void*)1);
+}

--- a/tests/emscripten_set_immediate.c
+++ b/tests/emscripten_set_immediate.c
@@ -1,0 +1,46 @@
+#include <emscripten/html5.h>
+#include <assert.h>
+
+int func1Executed = 0;
+int func2Executed = 0;
+
+void func1(void *userData);
+
+void func2(void *userData)
+{
+	assert((int)userData == 2);
+	++func2Executed;
+
+	if (func2Executed == 1)
+	{
+		// Test canceling a setImmediate: register a callback but then cancel it immediately
+		long id = emscripten_set_immediate(func1, (void*)2);
+		emscripten_clear_immediate(id);
+
+		emscripten_set_timeout(func2, 100, (void*)2);
+	}
+	if (func2Executed == 2)
+	{
+#ifdef REPORT_RESULT
+		assert(func1Executed == 1);
+		REPORT_RESULT(0);
+#endif
+	}
+}
+
+void func1(void *userData)
+{
+	assert((int)userData == 1);
+	++func1Executed;
+
+#ifdef REPORT_RESULT
+	assert(func1Executed == 1);
+#endif
+
+	emscripten_set_immediate(func2, (void*)2);
+}
+
+int main()
+{
+	emscripten_set_immediate(func1, (void*)1);
+}

--- a/tests/emscripten_set_immediate_loop.c
+++ b/tests/emscripten_set_immediate_loop.c
@@ -1,0 +1,29 @@
+#include <emscripten/html5.h>
+#include <assert.h>
+
+int funcExecuted = 0;
+
+void testDone(void *userData)
+{
+	assert((int)userData == 2);
+	assert(funcExecuted == 10);
+#ifdef REPORT_RESULT
+	REPORT_RESULT(0);
+#endif
+}
+
+EM_BOOL tick(void *userData)
+{
+	assert((int)userData == 1);
+	++funcExecuted;
+	if (funcExecuted == 10)
+	{
+		emscripten_set_timeout(testDone, 300, (void*)2);
+	}
+	return funcExecuted < 10;
+}
+
+int main()
+{
+	emscripten_set_immediate_loop(tick, (void*)1);
+}

--- a/tests/emscripten_set_interval.c
+++ b/tests/emscripten_set_interval.c
@@ -1,0 +1,36 @@
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <assert.h>
+
+int funcExecuted = 0;
+
+void testDone(void *userData)
+{
+	assert((int)userData == 2);
+	assert(funcExecuted == 10);
+#ifdef REPORT_RESULT
+	REPORT_RESULT(0);
+#endif
+}
+
+long intervalId = 0;
+
+void tick(void *userData)
+{
+	assert((int)userData == 1);
+	++funcExecuted;
+	if (funcExecuted == 10)
+	{
+		emscripten_set_timeout(testDone, 300, (void*)2);
+	}
+	if (funcExecuted >= 10)
+	{
+		emscripten_clear_interval(intervalId);
+	}
+}
+
+int main()
+{
+	intervalId = emscripten_set_interval(tick, 100, (void*)1);
+	EM_ASM(Module['noExitRuntime'] = 1);
+}

--- a/tests/emscripten_set_timeout.c
+++ b/tests/emscripten_set_timeout.c
@@ -1,0 +1,47 @@
+#include <emscripten/html5.h>
+#include <assert.h>
+
+int func1Executed = 0;
+int func2Executed = 0;
+
+void func1(void *userData);
+
+void func2(void *userData)
+{
+	assert((int)userData == 2);
+	++func2Executed;
+
+	if (func2Executed == 1)
+	{
+		// Test canceling a setTimeout: register a callback but then cancel it immediately
+		long id = emscripten_set_timeout(func1, 10, (void*)2);
+		emscripten_clear_timeout(id);
+
+		emscripten_set_timeout(func2, 100, (void*)2);
+	}
+	if (func2Executed == 2)
+	{
+#ifdef REPORT_RESULT
+		assert(func1Executed == 1);
+		REPORT_RESULT(0);
+#endif
+	}
+}
+
+void func1(void *userData)
+{
+	assert((int)userData == 1);
+	++func1Executed;
+
+#ifdef REPORT_RESULT
+	assert(func1Executed == 1);
+#endif
+
+	emscripten_set_timeout(func2, 100, (void*)2);
+}
+
+int main()
+{
+	emscripten_set_timeout(func1, 100, (void*)1);
+	EM_ASM(Module['noExitRuntime'] = 1);
+}

--- a/tests/emscripten_set_timeout_loop.c
+++ b/tests/emscripten_set_timeout_loop.c
@@ -1,0 +1,33 @@
+#include <emscripten/html5.h>
+#include <assert.h>
+
+double previousSetTimeouTime = 0;
+int funcExecuted = 0;
+
+void testDone(void *userData)
+{
+	assert((int)userData == 2);
+	assert(funcExecuted == 10);
+#ifdef REPORT_RESULT
+	REPORT_RESULT(0);
+#endif
+}
+
+EM_BOOL tick(double time, void *userData)
+{
+	assert(time >= previousSetTimeouTime);
+	previousSetTimeouTime = time;
+	assert((int)userData == 1);
+	++funcExecuted;
+	if (funcExecuted == 10)
+	{
+		emscripten_set_timeout(testDone, 300, (void*)2);
+	}
+	return funcExecuted < 10;
+}
+
+int main()
+{
+	emscripten_set_timeout_loop(tick, 100, (void*)1);
+	EM_ASM(Module['noExitRuntime'] = 1);
+}

--- a/tests/emscripten_throw_number.c
+++ b/tests/emscripten_throw_number.c
@@ -1,0 +1,9 @@
+#include <emscripten/html5.h>
+
+int main()
+{
+	emscripten_throw_number(42);
+#ifdef REPORT_RESULT
+	REPORT_RESULT(1); // failed
+#endif
+}

--- a/tests/emscripten_throw_number_pre.js
+++ b/tests/emscripten_throw_number_pre.js
@@ -1,0 +1,8 @@
+addEventListener('error', function(event) {
+  event.preventDefault();
+  event.stopPropagation();
+  var result = event.error === 42 ? 0 : 1;
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', 'http://localhost:8888/report_result?' + result, true);
+  xhr.send();
+});

--- a/tests/emscripten_throw_string.c
+++ b/tests/emscripten_throw_string.c
@@ -1,0 +1,9 @@
+#include <emscripten/html5.h>
+
+int main()
+{
+	emscripten_throw_string("Hello!");
+#ifdef REPORT_RESULT
+	REPORT_RESULT(1); // failed
+#endif
+}

--- a/tests/emscripten_throw_string_pre.js
+++ b/tests/emscripten_throw_string_pre.js
@@ -1,0 +1,8 @@
+addEventListener('error', function(event) {
+  event.preventDefault();
+  event.stopPropagation();
+  var result = event.error === 'Hello!' ? 0 : 1;
+  var xhr = new XMLHttpRequest();
+  xhr.open('GET', 'http://localhost:8888/report_result?' + result, true);
+  xhr.send();
+});

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4374,3 +4374,38 @@ window.close = function() {
 
   def test_modularize_Module_input(self):
     self.btest(path_from_root('tests', 'browser', 'modularize_Module_input.cpp'), '0', args=['--shell-file', path_from_root('tests', 'browser', 'modularize_Module_input.html'), '-s', 'MODULARIZE_INSTANCE=1'])
+
+  def test_emscripten_request_animation_frame(self):
+    self.btest(path_from_root('tests', 'emscripten_request_animation_frame.c'), '0')
+
+  def test_emscripten_request_animation_frame_loop(self):
+    self.btest(path_from_root('tests', 'emscripten_request_animation_frame_loop.c'), '0')
+
+  def test_emscripten_set_timeout(self):
+    self.btest(path_from_root('tests', 'emscripten_set_timeout.c'), '0', args=['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
+
+  def test_emscripten_set_timeout_loop(self):
+    self.btest(path_from_root('tests', 'emscripten_set_timeout_loop.c'), '0', args=['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
+
+  def test_emscripten_set_immediate(self):
+    self.btest(path_from_root('tests', 'emscripten_set_immediate.c'), '0')
+
+  def test_emscripten_set_immediate_loop(self):
+    self.btest(path_from_root('tests', 'emscripten_set_immediate_loop.c'), '0')
+
+  def test_emscripten_set_interval(self):
+    self.btest(path_from_root('tests', 'emscripten_set_interval.c'), '0', args=['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
+
+  # Test emscripten_performance_now() and emscripten_date_now()
+  def test_emscripten_performance_now(self):
+    self.btest(path_from_root('tests', 'emscripten_performance_now.c'), '0', args=['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
+
+  # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
+  def test_emscripten_console_log(self):
+    self.btest(path_from_root('tests', 'emscripten_console_log.c'), '0', args=['--pre-js', path_from_root('tests', 'emscripten_console_log_pre.js')])
+
+  def test_emscripten_throw_number(self):
+    self.btest(path_from_root('tests', 'emscripten_throw_number.c'), '0', args=['--pre-js', path_from_root('tests', 'emscripten_throw_number_pre.js')])
+
+  def test_emscripten_throw_string(self):
+    self.btest(path_from_root('tests', 'emscripten_throw_string.c'), '0', args=['--pre-js', path_from_root('tests', 'emscripten_throw_string_pre.js')])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7861,7 +7861,7 @@ int main() {
                    0, [],         [],           8,   0,    0,  0), # noqa; totally empty!
         # we don't metadce with linkable code! other modules may want stuff
         (['-O3', '-s', 'MAIN_MODULE=1'],
-                1505, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+                1524, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')


### PR DESCRIPTION
This PR adds more HTML5 API functions specifically related to animations, timing, direct access to console.log/warn/error and JS throw statement.

These are useful as a replacement to `library_browser.js` `emscripten_set_main_loop()` mechanism for considerably smaller code size.