### PR TITLE
emscripten_wegbl_get_context_attributes and powerPreference

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -1945,9 +1945,9 @@ Struct
     If ``true``, the contents of the drawing buffer are preserved between consecutive ``requestAnimationFrame()`` calls. If ``false``, color, depth and stencil are cleared at the beginning of each ``requestAnimationFrame()``. Generally setting this to ``false`` gives better performance. Default value: ``false``.
 
 
-  .. c:member:: EM_BOOL preferLowPowerToHighPerformance
+  .. c:member:: EM_WEBGL_POWER_PREFERENCE powerPreference
 
-    If ``true``, hints the browser to initialize a low-power GPU rendering context. If ``false``, prefers to initialize a high-performance rendering context. Default value: ``false``.
+    Specifies a hint to the WebGL canvas implementation to how it should choose the use of available GPU resources. One of EM_WEBGL_POWER_PREFERENCE_DEFAULT, EM_WEBGL_POWER_PREFERENCE_LOW_POWER, EM_WEBGL_POWER_PREFERENCE_HIGH_PERFORMANCE.
 
   .. c:member:: EM_BOOL failIfMajorPerformanceCaveat
 
@@ -2087,6 +2087,15 @@ Functions
 
   :returns: The currently active WebGL rendering context, or 0 if no context is active.
   :rtype: |EMSCRIPTEN_WEBGL_CONTEXT_HANDLE|
+
+
+.. c:function:: EMSCRIPTEN_RESULT emscripten_webgl_get_context_attributes(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, EmscriptenWebGLContextAttributes *outAttributes)
+
+  Fetches the context creation attributes that were used to initialize the given WebGL context.
+
+  :param EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context: The WebGL context to query.
+  :param EmscriptenWebGLContextAttributes *outAttributes: The context creation attributes of the specified context will be filled in here. This pointer cannot be null.
+  :returns: On success, EMSCRIPTEN_RESULT_SUCCESS.
 
 
 .. c:function:: EMSCRIPTEN_RESULT emscripten_webgl_commit_frame()

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2068,7 +2068,7 @@ var LibraryJSEvents = {
     {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.antialias, 1, 'i32') }}};
     {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.premultipliedAlpha, 1, 'i32') }}};
     {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.preserveDrawingBuffer, 0, 'i32') }}};
-    {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.preferLowPowerToHighPerformance, 0, 'i32') }}};
+    {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.powerPreference, 0, 'i32') }}};
     {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.failIfMajorPerformanceCaveat, 0, 'i32') }}};
     {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.majorVersion, 1, 'i32') }}};
     {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.minorVersion, 0, 'i32') }}};
@@ -2086,13 +2086,15 @@ var LibraryJSEvents = {
     {{{ makeSetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.renderViaOffscreenBackBuffer, 0, 'i32') }}};
   },
 
+  _emscripten_webgl_power_preferences: "['default', 'low-power', 'high-performance']",
+
 #if !USE_PTHREADS
   emscripten_webgl_create_context: 'emscripten_webgl_do_create_context',
   emscripten_webgl_get_current_context: 'emscripten_webgl_do_get_current_context',
   emscripten_webgl_commit_frame: 'emscripten_webgl_do_commit_frame',
 #endif
 
-  emscripten_webgl_do_create_context__deps: ['$GL'],
+  emscripten_webgl_do_create_context__deps: ['$GL', '_emscripten_webgl_power_preferences'],
   // This function performs proxying manually, depending on the style of context that is to be created.
   emscripten_webgl_do_create_context: function(target, attributes) {
     var contextAttributes = {};
@@ -2102,7 +2104,8 @@ var LibraryJSEvents = {
     contextAttributes['antialias'] = !!{{{ makeGetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.antialias, 'i32') }}};
     contextAttributes['premultipliedAlpha'] = !!{{{ makeGetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.premultipliedAlpha, 'i32') }}};
     contextAttributes['preserveDrawingBuffer'] = !!{{{ makeGetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.preserveDrawingBuffer, 'i32') }}};
-    contextAttributes['preferLowPowerToHighPerformance'] = !!{{{ makeGetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.preferLowPowerToHighPerformance, 'i32') }}};
+    var powerPreference = {{{ makeGetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.powerPreference, 'i32') }}};
+    contextAttributes['powerPreference'] = __emscripten_webgl_power_preferences[powerPreference];
     contextAttributes['failIfMajorPerformanceCaveat'] = !!{{{ makeGetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.failIfMajorPerformanceCaveat, 'i32') }}};
     contextAttributes['majorVersion'] = {{{ makeGetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.majorVersion, 'i32') }}};
     contextAttributes['minorVersion'] = {{{ makeGetValue('attributes', C_STRUCTS.EmscriptenWebGLContextAttributes.minorVersion, 'i32') }}};
@@ -2299,6 +2302,35 @@ var LibraryJSEvents = {
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
     GL.currentContext.GLctx.commit();
+    return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
+  },
+
+  emscripten_webgl_get_context_attributes__deps: ['_emscripten_webgl_power_preferences'],
+  emscripten_webgl_get_context_attributes: function(c, a) {
+    if (!a) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
+    c = GL.contexts[c];
+    if (!c) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    var t = c.GLctx;
+    if (!t) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    t = t.getContextAttributes();
+
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.alpha, 't.alpha', 'i32') }}};
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.depth, 't.depth', 'i32') }}};
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.stencil, 't.stencil', 'i32') }}};
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.antialias, 't.antialias', 'i32') }}};
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.premultipliedAlpha, 't.premultipliedAlpha', 'i32') }}};
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.preserveDrawingBuffer, 't.preserveDrawingBuffer', 'i32') }}};
+    var power = __emscripten_webgl_power_preferences.indexOf(t['powerPreference']);
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.powerPreference, 'power', 'i32') }}};
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.failIfMajorPerformanceCaveat, 't.failIfMajorPerformanceCaveat', 'i32') }}};
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.majorVersion, 'c.version', 'i32') }}};
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.minorVersion, 0, 'i32') }}};
+#if GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.enableExtensionsByDefault, 'c.attributes["enableExtensionsByDefault"]', 'i32') }}};
+#endif
+#if GL_SUPPORT_EXPLICIT_SWAP_CONTROL
+    {{{ makeSetValue('a', C_STRUCTS.EmscriptenWebGLContextAttributes.explicitSwapControl, 'c.attributes["explicitSwapControl"]', 'i32') }}};
+#endif
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1392,7 +1392,7 @@
               "antialias",
               "premultipliedAlpha",
               "preserveDrawingBuffer",
-              "preferLowPowerToHighPerformance",
+              "powerPreference",
               "failIfMajorPerformanceCaveat",
               "majorVersion",
               "minorVersion",

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -426,6 +426,11 @@ typedef int EMSCRIPTEN_WEBGL_CONTEXT_PROXY_MODE;
 #define EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK 1
 #define EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS   2
 
+typedef int EM_WEBGL_POWER_PREFERENCE;
+#define EM_WEBGL_POWER_PREFERENCE_DEFAULT 0
+#define EM_WEBGL_POWER_PREFERENCE_LOW_POWER 1
+#define EM_WEBGL_POWER_PREFERENCE_HIGH_PERFORMANCE 2
+
 typedef struct EmscriptenWebGLContextAttributes {
   EM_BOOL alpha;
   EM_BOOL depth;
@@ -433,7 +438,10 @@ typedef struct EmscriptenWebGLContextAttributes {
   EM_BOOL antialias;
   EM_BOOL premultipliedAlpha;
   EM_BOOL preserveDrawingBuffer;
-  EM_BOOL preferLowPowerToHighPerformance;
+  union {
+    EM_BOOL preferLowPowerToHighPerformance; // DEPRECATED: do not access. (though aliases to same set of values as EM_WEBGL_POWER_PREFERENCE (false:EM_WEBGL_POWER_PREFERENCE_DEFAULT, true:EM_WEBGL_POWER_PREFERENCE_LOW_POWER) for backwards compatibility)
+    EM_WEBGL_POWER_PREFERENCE powerPreference;
+  };
   EM_BOOL failIfMajorPerformanceCaveat;
 
   int majorVersion;
@@ -454,6 +462,8 @@ extern EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_
 extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context(void);
 
 extern EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height);
+
+extern EMSCRIPTEN_RESULT emscripten_webgl_get_context_attributes(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, EmscriptenWebGLContextAttributes *outAttributes);
 
 extern EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 

--- a/tests/gl_textures.cpp
+++ b/tests/gl_textures.cpp
@@ -60,7 +60,7 @@ int main()
   emscripten_set_canvas_size(256, 256);
   EmscriptenWebGLContextAttributes attr;
   emscripten_webgl_init_context_attributes(&attr);
-  attr.alpha = attr.depth = attr.stencil = attr.antialias = attr.preserveDrawingBuffer = attr.preferLowPowerToHighPerformance = attr.failIfMajorPerformanceCaveat = 0;
+  attr.alpha = attr.depth = attr.stencil = attr.antialias = attr.preserveDrawingBuffer = attr.failIfMajorPerformanceCaveat = 0;
   attr.enableExtensionsByDefault = 1;
   attr.premultipliedAlpha = 0;
   attr.majorVersion = 1;

--- a/tests/test_html5_fullscreen.c
+++ b/tests/test_html5_fullscreen.c
@@ -188,7 +188,7 @@ int main()
 {
   EmscriptenWebGLContextAttributes attr;
   emscripten_webgl_init_context_attributes(&attr);
-  attr.alpha = attr.depth = attr.stencil = attr.antialias = attr.preserveDrawingBuffer = attr.preferLowPowerToHighPerformance = attr.failIfMajorPerformanceCaveat = 0;
+  attr.alpha = attr.depth = attr.stencil = attr.antialias = attr.preserveDrawingBuffer = attr.failIfMajorPerformanceCaveat = 0;
   attr.enableExtensionsByDefault = 1;
   attr.premultipliedAlpha = 0;
   attr.majorVersion = 1;

--- a/tests/webgl2.cpp
+++ b/tests/webgl2.cpp
@@ -25,13 +25,18 @@ int main()
   emscripten_webgl_init_context_attributes(&attrs);
   attrs.majorVersion = 2;
   attrs.minorVersion = 0;
+  attrs.powerPreference = EM_WEBGL_POWER_PREFERENCE_DEFAULT;
 
   int result = 0;
 
   EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context(0, &attrs);
   if (context)
   {
-    EMSCRIPTEN_RESULT res = emscripten_webgl_make_context_current(context);
+    memset(&attrs, -1, sizeof(attrs));
+    EMSCRIPTEN_RESULT res = emscripten_webgl_get_context_attributes(context, &attrs);
+    assert(res == EMSCRIPTEN_RESULT_SUCCESS);
+    assert(attrs.powerPreference == EM_WEBGL_POWER_PREFERENCE_DEFAULT || attrs.powerPreference == EM_WEBGL_POWER_PREFERENCE_LOW_POWER || attrs.powerPreference == EM_WEBGL_POWER_PREFERENCE_HIGH_PERFORMANCE);
+    res = emscripten_webgl_make_context_current(context);
     assert(res == EMSCRIPTEN_RESULT_SUCCESS);
     assert(emscripten_webgl_get_current_context() == context);
 

--- a/tests/webgl2_garbage_free_entrypoints.cpp
+++ b/tests/webgl2_garbage_free_entrypoints.cpp
@@ -24,7 +24,7 @@ int main(int argc, char *argv[])
   emscripten_set_canvas_size(256, 256);
   EmscriptenWebGLContextAttributes attr;
   emscripten_webgl_init_context_attributes(&attr);
-  attr.alpha = attr.depth = attr.stencil = attr.antialias = attr.preserveDrawingBuffer = attr.preferLowPowerToHighPerformance = attr.failIfMajorPerformanceCaveat = 0;
+  attr.alpha = attr.depth = attr.stencil = attr.antialias = attr.preserveDrawingBuffer = attr.failIfMajorPerformanceCaveat = 0;
   attr.enableExtensionsByDefault = 1;
   attr.premultipliedAlpha = 0;
 #ifdef TEST_WEBGL2


### PR DESCRIPTION
Add emscripten_webgl_get_context_attributes() function and support for WebGL powerPreference context creation attribute. (The old WebGL context creation attribute 'preferLowPowerToHighPerformance' was removed from the spec in a way that did not retain backwards compatibility, https://github.com/KhronosGroup/WebGL/pull/2283, https://bugs.webkit.org/show_bug.cgi?id=168269)