### PR TITLE
Fast unrolled memcpy and memset

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2097,7 +2097,7 @@ Functions
   Fetches the context creation attributes that were used to initialize the given WebGL context.
 
   :param EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context: The WebGL context to query.
-  :param EmscriptenWebGLContextAttributes *outAttributes: The context creation attributes of the specified context will be filled in here. This pointer cannot be null.
+  :param EmscriptenWebGLContextAttributes \*outAttributes: The context creation attributes of the specified context will be filled in here. This pointer cannot be null.
   :returns: On success, EMSCRIPTEN_RESULT_SUCCESS.
 
 

--- a/src/library.js
+++ b/src/library.js
@@ -960,6 +960,7 @@ LibraryManager.library = {
         num = (num-1)|0;
       }
       aligned_dest_end = (dest_end & -4)|0;
+#if FAST_UNROLLED_MEMCPY_AND_MEMSET
       block_aligned_dest_end = (aligned_dest_end - 64)|0;
       while ((dest|0) <= (block_aligned_dest_end|0) ) {
 #if SIMD
@@ -988,6 +989,7 @@ LibraryManager.library = {
         dest = (dest+64)|0;
         src = (src+64)|0;
       }
+#endif
       while ((dest|0) < (aligned_dest_end|0) ) {
         {{{ makeSetValueAsm('dest', 0, makeGetValueAsm('src', 0, 'i32'), 'i32') }}};
         dest = (dest+4)|0;
@@ -1059,8 +1061,11 @@ LibraryManager.library = {
       }
 
       aligned_end = (end & -4)|0;
-      block_aligned_end = (aligned_end - 64)|0;
       value4 = value | (value << 8) | (value << 16) | (value << 24);
+
+#if FAST_UNROLLED_MEMCPY_AND_MEMSET
+      block_aligned_end = (aligned_end - 64)|0;
+
 #if SIMD
       value16 = SIMD_Int32x4_splat(value4);
 #endif
@@ -1091,6 +1096,7 @@ LibraryManager.library = {
 #endif
         ptr = (ptr + 64)|0;
       }
+#endif
 
       while ((ptr|0) < (aligned_end|0) ) {
         {{{ makeSetValueAsm('ptr', 0, 'value4', 'i32') }}};

--- a/src/settings.js
+++ b/src/settings.js
@@ -113,6 +113,11 @@ var MALLOC = "dlmalloc";
 // returning NULL (0) when it fails.
 var ABORTING_MALLOC = 1;
 
+// If 1, generated a version of memcpy() and memset() that unroll their
+// copy sizes. If 0, optimizes for size instead to generate a smaller memcpy.
+// This flag only has effect when targeting asm.js.
+var FAST_UNROLLED_MEMCPY_AND_MEMSET = 1;
+
 // If false, we abort with an error if we try to allocate more memory than
 // we can (TOTAL_MEMORY). If true, we will grow the memory arrays at
 // runtime, seamlessly and dynamically. This has a performance cost in asm.js,


### PR DESCRIPTION
Add FAST_UNROLLED_MEMCPY_AND_MEMSET options to allow disabling heavy unrolling when optimizing for code size.