### PR TITLE
no_module_asmglobalarg

### DIFF
--- a/tests/optimizer/test-function-eliminator-double-parsed-correctly-output.js
+++ b/tests/optimizer/test-function-eliminator-double-parsed-correctly-output.js
@@ -11,5 +11,5 @@ function a() {
 }
 // EMSCRIPTEN_END_FUNCS
  var f = 0;
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 // EMSCRIPTEN_END_ASM

--- a/tests/optimizer/test-function-eliminator-double-parsed-correctly.js
+++ b/tests/optimizer/test-function-eliminator-double-parsed-correctly.js
@@ -15,7 +15,7 @@ var asm = (function(global, env, buffer) {
  }
 // EMSCRIPTEN_END_FUNCS
  var f = 0;
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 // EMSCRIPTEN_END_ASM
 // EMSCRIPTEN_GENERATED_FUNCTIONS
 

--- a/tests/optimizer/test-function-eliminator-replace-array-value-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-array-value-output.js
@@ -21,5 +21,5 @@ function a() {
 // EMSCRIPTEN_END_FUNCS
 
  var f = [ a ];
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 // EMSCRIPTEN_END_ASM

--- a/tests/optimizer/test-function-eliminator-replace-array-value-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-array-value-with-hash-info.js
@@ -27,6 +27,6 @@ function d()
   return;
 }
 
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 // {"b":"a"}

--- a/tests/optimizer/test-function-eliminator-replace-array-value.js
+++ b/tests/optimizer/test-function-eliminator-replace-array-value.js
@@ -19,5 +19,5 @@ var asm = (function(global, env, buffer) {
  }
 // EMSCRIPTEN_END_FUNCS
   var f = [ b ];
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 // EMSCRIPTEN_END_ASM

--- a/tests/optimizer/test-function-eliminator-replace-function-call-output-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call-output-with-hash-info.js
@@ -17,6 +17,6 @@ function d()
   return;
 }
 
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 // {"d":"c"}

--- a/tests/optimizer/test-function-eliminator-replace-function-call-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call-output.js
@@ -11,4 +11,4 @@ var asm = (function(global, env, buffer) {
   a();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-replace-function-call-two-passes-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call-two-passes-output.js
@@ -7,4 +7,4 @@ var asm = (function(global, env, buffer) {
   a();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-replace-function-call-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call-with-hash-info.js
@@ -22,6 +22,6 @@ function d()
   return;
 }
 
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 // {"b":"a"}

--- a/tests/optimizer/test-function-eliminator-replace-function-call.js
+++ b/tests/optimizer/test-function-eliminator-replace-function-call.js
@@ -14,7 +14,7 @@ var asm = (function(global, env, buffer) {
   b();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 
 

--- a/tests/optimizer/test-function-eliminator-replace-object-value-assignment-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-object-value-assignment-output.js
@@ -15,4 +15,4 @@ var asm = (function(global, env, buffer) {
   e();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-replace-object-value-assignment-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-object-value-assignment-with-hash-info.js
@@ -29,6 +29,6 @@ function d()
   return;
 }
 
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 // {"b":"a"}

--- a/tests/optimizer/test-function-eliminator-replace-object-value-assignment.js
+++ b/tests/optimizer/test-function-eliminator-replace-object-value-assignment.js
@@ -18,7 +18,7 @@ var asm = (function(global, env, buffer) {
   e();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 
 

--- a/tests/optimizer/test-function-eliminator-replace-variable-value-output.js
+++ b/tests/optimizer/test-function-eliminator-replace-variable-value-output.js
@@ -13,4 +13,4 @@ var asm = (function(global, env, buffer) {
   e();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-replace-variable-value-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-replace-variable-value-with-hash-info.js
@@ -27,6 +27,6 @@ function d()
   return;
 }
 
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 // {"b" : "a"}

--- a/tests/optimizer/test-function-eliminator-replace-variable-value.js
+++ b/tests/optimizer/test-function-eliminator-replace-variable-value.js
@@ -16,7 +16,7 @@ var asm = (function(global, env, buffer) {
   e();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 
 

--- a/tests/optimizer/test-function-eliminator-simple-output.js
+++ b/tests/optimizer/test-function-eliminator-simple-output.js
@@ -3,4 +3,4 @@ var asm = (function(global, env, buffer) {
  function a() {
   return 0;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-simple-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-simple-with-hash-info.js
@@ -10,6 +10,6 @@ function b()
 return 0;
 }
 
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 // {"b":"a"}

--- a/tests/optimizer/test-function-eliminator-simple.js
+++ b/tests/optimizer/test-function-eliminator-simple.js
@@ -6,7 +6,7 @@ var asm = (function(global, env, buffer) {
  function b() {
   return 0;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 
 

--- a/tests/optimizer/test-function-eliminator-variable-clash-output.js
+++ b/tests/optimizer/test-function-eliminator-variable-clash-output.js
@@ -15,4 +15,4 @@ var asm = (function(global, env, buffer) {
   b();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);

--- a/tests/optimizer/test-function-eliminator-variable-clash-with-hash-info.js
+++ b/tests/optimizer/test-function-eliminator-variable-clash-with-hash-info.js
@@ -26,6 +26,6 @@ function d()
   return;
 }
 
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 // {}

--- a/tests/optimizer/test-function-eliminator-variable-clash.js
+++ b/tests/optimizer/test-function-eliminator-variable-clash.js
@@ -15,7 +15,7 @@ var asm = (function(global, env, buffer) {
   b();
   return;
  }
-})(Module.asmGlobalArg, Module.asmLibraryArg, buffer);
+})(asmGlobalArg, Module.asmLibraryArg, buffer);
 
 
 

--- a/tools/distill_asm.py
+++ b/tools/distill_asm.py
@@ -29,7 +29,7 @@ module = asm_module.AsmModule(infile).asm_js
 
 if extra == 'swap-in':
   # we do |var asm = | just like the original codebase, so that gets overridden anyhow (assuming global scripts).
-  extra = r''' (Module.asmGlobalArg, Module.asmLibraryArg, Module['buffer']);
+  extra = r''' (asmGlobalArg, Module.asmLibraryArg, Module['buffer']);
  // special fixups
  asm.stackRestore(Module['asm'].stackSave()); // if this fails, make sure the original was built to be swappable (-s SWAPPABLE_ASM_MODULE=1)
  // Finish swap


### PR DESCRIPTION
asmGlobalArg does not need to be assigned in Module, but can be a standalone variable so Closure can optimize it better.

With `Module.asmGlobalArg`, we would get Closure-minified form

```js
m.g = { Math: Math, ... };  // Module.asmGlobalArg = { Math: Math, ... };
...
Module['asm'] = asm(m.g, m.x, m.y);
```

`asmGlobalArg` has never been exported to users, i.e. we access it via `Module.asmGlobalArg`, and not `Module['asmGlobalArg']`, so it did get minified from external use, and there are no interesting variables to access there for external users.

By changing this to `var asmGlobalArg = { ... };`, we will get

```js
var g = { Math: Math, ... };
...
Module['asm'] = asm(g, m.x, m.y);
```

which is exactly the same size, `len('m.g' + 'm.g')` == `len('var g' + 'g')`, but hopefully in the future when Closure implements https://github.com/google/closure-compiler/issues/3187, the above will turn into

```js
Module['asm'] = asm({ Math: Math, ... }, m.x, m.y);
```

to save `len('var g=' + ';' + 'g')` = 8 bytes, and JS engine can then drop a `Module.asmGlobalArg` variable from sticking around in memory.
