### PR TITLE
Skip firefox on some tests due to a nightly regression

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -81,8 +81,18 @@ def is_chrome():
   return EMTEST_BROWSER and 'chrom' in EMTEST_BROWSER.lower()
 
 
-def no_chrome(note='chome is not supported'):
+def no_chrome(note='chrome is not supported'):
   if is_chrome():
+    return unittest.skip(note)
+  return lambda f: f
+
+
+def is_firefox():
+  return EMTEST_BROWSER and 'firefox' in EMTEST_BROWSER.lower()
+
+
+def no_firefox(note='firefox is not supported'):
+  if is_firefox():
     return unittest.skip(note)
   return lambda f: f
 
@@ -4221,6 +4231,7 @@ window.close = function() {
     self.run_browser('a.html', '...', '/report_result?0')
 
   # Tests that SINGLE_FILE works as intended in generated HTML (with and without Worker)
+  @no_firefox('see #1521239')
   def test_single_file_html(self):
     self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1'], also_proxied=True)
     assert os.path.exists('test.html') and not os.path.exists('test.js') and not os.path.exists('test.worker.js')
@@ -4255,6 +4266,7 @@ window.close = function() {
       self.run_browser('test.html', None, '/report_result?0')
 
   # Tests that SINGLE_FILE works as intended in a Worker in JS output
+  @no_firefox('see #1521239')
   def test_single_file_worker_js(self):
     create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'browser_test_hello_world.c')).read()))
     run_process([PYTHON, EMCC, 'src.cpp', '-o', 'test.js', '--proxy-to-worker', '-s', 'SINGLE_FILE=1', '-s', 'WASM=1'])


### PR DESCRIPTION
The firefox breakage on our CI is actually a nightly regression. Skipping those tests. Filed upstream as

https://bugzilla.mozilla.org/show_bug.cgi?id=1521239