### PR TITLE
allocateutf8_out_from_preamble

### DIFF
--- a/src/library_gl.js
+++ b/src/library_gl.js
@@ -1025,7 +1025,7 @@ var LibraryGL = {
   },
 
   glGetString__sig: 'ii',
-  glGetString__deps: ['$stringToNewUTF8'],
+  glGetString__deps: ['$allocateUTF8'],
   glGetString: function(name_) {
     if (GL.stringCache[name_]) return GL.stringCache[name_];
     var ret;
@@ -1039,7 +1039,7 @@ var LibraryGL = {
           gl_exts.push("GL_" + exts[i]);
 #endif
         }
-        ret = stringToNewUTF8(gl_exts.join(' '));
+        ret = allocateUTF8(gl_exts.join(' '));
         break;
       case 0x1F00 /* GL_VENDOR */:
       case 0x1F01 /* GL_RENDERER */:
@@ -1056,7 +1056,7 @@ var LibraryGL = {
           err('GL_INVALID_ENUM in glGetString: Received empty parameter for query name ' + name_ + '!'); // This occurs e.g. if one attempts GL_UNMASKED_VENDOR_WEBGL when it is not supported.
 #endif
         }
-        ret = stringToNewUTF8(s);
+        ret = allocateUTF8(s);
         break;
 
 #if GL_EMULATE_GLES_VERSION_STRING_FORMAT
@@ -1070,7 +1070,7 @@ var LibraryGL = {
         {
           glVersion = 'OpenGL ES 2.0 (' + glVersion + ')';
         }
-        ret = stringToNewUTF8(glVersion);
+        ret = allocateUTF8(glVersion);
         break;
       case 0x8B8C /* GL_SHADING_LANGUAGE_VERSION */:
         var glslVersion = GLctx.getParameter(GLctx.SHADING_LANGUAGE_VERSION);
@@ -1081,7 +1081,7 @@ var LibraryGL = {
           if (ver_num[1].length == 3) ver_num[1] = ver_num[1] + '0'; // ensure minor version has 2 digits
           glslVersion = 'OpenGL ES GLSL ES ' + ver_num[1] + ' (' + glslVersion + ')';
         }
-        ret = stringToNewUTF8(glslVersion);
+        ret = allocateUTF8(glslVersion);
         break;
 #endif
       default:
@@ -1241,7 +1241,7 @@ var LibraryGL = {
   },
 
 #if USE_WEBGL2
-  glGetStringi__deps: ['$stringToNewUTF8'],
+  glGetStringi__deps: ['$allocateUTF8'],
   glGetStringi__sig: 'iii',
   glGetStringi: function(name, index) {
     if (GL.currentContext.version < 2) {
@@ -1264,9 +1264,9 @@ var LibraryGL = {
         var exts = GLctx.getSupportedExtensions();
         var gl_exts = [];
         for (var i = 0; i < exts.length; ++i) {
-          gl_exts.push(stringToNewUTF8(exts[i]));
+          gl_exts.push(allocateUTF8(exts[i]));
           // each extension is duplicated, first in unprefixed WebGL form, and then a second time with "GL_" prefix.
-          gl_exts.push(stringToNewUTF8('GL_' + exts[i]));
+          gl_exts.push(allocateUTF8('GL_' + exts[i]));
         }
         stringiCache = GL.stringiCache[name] = gl_exts;
         if (index < 0 || index >= stringiCache.length) {

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -10,7 +10,7 @@
 
 var LibraryGLEmulation = {
   // GL emulation: provides misc. functionality not present in OpenGL ES 2.0 or WebGL
-  $GLEmulation__deps: ['$GLImmediateSetup', 'glEnable', 'glDisable', 'glIsEnabled', 'glGetBooleanv', 'glGetIntegerv', 'glGetString', 'glCreateShader', 'glShaderSource', 'glCompileShader', 'glAttachShader', 'glDetachShader', 'glUseProgram', 'glDeleteProgram', 'glBindAttribLocation', 'glLinkProgram', 'glBindBuffer', 'glGetFloatv', 'glHint', 'glEnableVertexAttribArray', 'glDisableVertexAttribArray', 'glVertexAttribPointer', 'glActiveTexture', '$stringToNewUTF8'],
+  $GLEmulation__deps: ['$GLImmediateSetup', 'glEnable', 'glDisable', 'glIsEnabled', 'glGetBooleanv', 'glGetIntegerv', 'glGetString', 'glCreateShader', 'glShaderSource', 'glCompileShader', 'glAttachShader', 'glDetachShader', 'glUseProgram', 'glDeleteProgram', 'glBindAttribLocation', 'glLinkProgram', 'glBindBuffer', 'glGetFloatv', 'glHint', 'glEnableVertexAttribArray', 'glDisableVertexAttribArray', 'glVertexAttribPointer', 'glActiveTexture', '$allocateUTF8'],
   $GLEmulation__postset: 'GLEmulation.init();',
   $GLEmulation: {
     // Fog support. Partial, we assume shaders are used that implement fog. We just pass them uniforms
@@ -252,7 +252,7 @@ var LibraryGLEmulation = {
         if (GL.stringCache[name_]) return GL.stringCache[name_];
         switch(name_) {
           case 0x1F03 /* GL_EXTENSIONS */: // Add various extensions that we can support
-            var ret = stringToNewUTF8(GLctx.getSupportedExtensions().join(' ') +
+            var ret = allocateUTF8(GLctx.getSupportedExtensions().join(' ') +
                    ' GL_EXT_texture_env_combine GL_ARB_texture_env_crossbar GL_ATI_texture_env_combine3 GL_NV_texture_env_combine4 GL_EXT_texture_env_dot3 GL_ARB_multitexture GL_ARB_vertex_buffer_object GL_EXT_framebuffer_object GL_ARB_vertex_program GL_ARB_fragment_program GL_ARB_shading_language_100 GL_ARB_shader_objects GL_ARB_vertex_shader GL_ARB_fragment_shader GL_ARB_texture_cube_map GL_EXT_draw_range_elements' +
                    (GL.currentContext.compressionExt ? ' GL_ARB_texture_compression GL_EXT_texture_compression_s3tc' : '') +
                    (GL.currentContext.anisotropicExt ? ' GL_EXT_texture_filter_anisotropic' : '')

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2428,13 +2428,13 @@ var LibraryJSEvents = {
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 
-  emscripten_set_offscreencanvas_size_on_target_thread_js__deps: ['$stringToNewUTF8'],
+  emscripten_set_offscreencanvas_size_on_target_thread_js__deps: ['$allocateUTF8'],
   emscripten_set_offscreencanvas_size_on_target_thread_js: function(targetThread, targetCanvas, width, height) {
     var stackTop = stackSave();
     var varargs = stackAlloc(12);
     var targetCanvasPtr = 0;
     if (targetCanvas) {
-      targetCanvasPtr = stringToNewUTF8(targetCanvas);
+      targetCanvasPtr = allocateUTF8(targetCanvas);
     }
     {{{ makeSetValue('varargs', 0, 'targetCanvasPtr', 'i32')}}};
     {{{ makeSetValue('varargs', 4, 'width', 'i32')}}};

--- a/src/modules.js
+++ b/src/modules.js
@@ -382,7 +382,6 @@ function exportRuntime() {
     'UTF32ToString',
     'stringToUTF32',
     'lengthBytesUTF32',
-    'allocateUTF8',
     'stackTrace',
     'addOnPreRun',
     'addOnInit',

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -173,6 +173,11 @@ Module['callMain'] = function callMain(args) {
 
   ensureInitRuntime();
 
+#if BOOTSTRAPPING_STRUCT_INFO
+  // When bootstrapping struct info, allocateUTF8OnStack() is not included in build (and not used)
+  var argc = 0;
+  var argv = 0;
+#else
   var argc = args.length+1;
   var argv = stackAlloc((argc + 1) * {{{ Runtime.POINTER_SIZE }}});
   HEAP32[argv >> 2] = allocateUTF8OnStack(Module['thisProgram']);
@@ -180,6 +185,7 @@ Module['callMain'] = function callMain(args) {
     HEAP32[(argv >> 2) + i] = allocateUTF8OnStack(args[i - 1]);
   }
   HEAP32[(argv >> 2) + argc] = 0;
+#endif
 
 #if EMTERPRETIFY_ASYNC
   var initialEmtStackTop = Module['emtStackSave']();

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -738,23 +738,6 @@ function lengthBytesUTF32(str) {
   return len;
 }
 
-// Allocate heap space for a JS string, and write it there.
-// It is the responsibility of the caller to free() that memory.
-function allocateUTF8(str) {
-  var size = lengthBytesUTF8(str) + 1;
-  var ret = _malloc(size);
-  if (ret) stringToUTF8Array(str, HEAP8, ret, size);
-  return ret;
-}
-
-// Allocate stack space for a JS string, and write it there.
-function allocateUTF8OnStack(str) {
-  var size = lengthBytesUTF8(str) + 1;
-  var ret = stackAlloc(size);
-  stringToUTF8Array(str, HEAP8, ret, size);
-  return ret;
-}
-
 function demangle(func) {
 #if DEMANGLE_SUPPORT
   var __cxa_demangle_func = Module['___cxa_demangle'] || Module['__cxa_demangle'];

--- a/src/settings.js
+++ b/src/settings.js
@@ -694,7 +694,8 @@ var DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = [
 	'malloc',
 	'free',
 	'emscripten_get_heap_size', // Used by dynamicAlloc() and -s FETCH=1
-	'emscripten_resize_heap' // Used by dynamicAlloc() and -s FETCH=1
+	'emscripten_resize_heap', // Used by dynamicAlloc() and -s FETCH=1
+	'$allocateUTF8OnStack' // function callMain() in preamble.js uses this
 	];
 
 // This list is also used to determine auto-exporting of library dependencies

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7851,9 +7851,9 @@ int main() {
 
       print('test on hello world')
       test(path_from_root('tests', 'hello_world.cpp'), [
-        ([],      21, ['assert'], ['waka'], 46505,  22,   16, 59), # noqa
-        (['-O1'], 16, ['assert'], ['waka'], 12630,  14,   14, 31), # noqa
-        (['-O2'], 16, ['assert'], ['waka'], 12616,  14,   14, 31), # noqa
+        ([],      22, ['assert'], ['waka'], 46505,  22,   16, 59), # noqa
+        (['-O1'], 17, ['assert'], ['waka'], 12630,  14,   14, 31), # noqa
+        (['-O2'], 17, ['assert'], ['waka'], 12616,  14,   14, 31), # noqa
         (['-O3'],  6, [],         [],        2690,   9,    2, 21), # noqa; in -O3, -Os and -Oz we metadce
         (['-Os'],  6, [],         [],        2690,   9,    2, 21), # noqa
         (['-Oz'],  6, [],         [],        2690,   9,    2, 21), # noqa
@@ -7862,14 +7862,14 @@ int main() {
                    0, [],         [],           8,   0,    0,  0), # noqa; totally empty!
         # we don't metadce with linkable code! other modules may want stuff
         (['-O3', '-s', 'MAIN_MODULE=1'],
-                1526, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+                1527, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')
       test('minimal.c', [
-        ([],      21, ['assert'], ['waka'], 22712, 22, 15, 28), # noqa
-        (['-O1'], 11, ['assert'], ['waka'], 10450,  7, 12, 12), # noqa
-        (['-O2'], 11, ['assert'], ['waka'], 10440,  7, 12, 12), # noqa
+        ([],      22, ['assert'], ['waka'], 22712, 22, 15, 28), # noqa
+        (['-O1'], 12, ['assert'], ['waka'], 10450,  7, 12, 12), # noqa
+        (['-O2'], 12, ['assert'], ['waka'], 10440,  7, 12, 12), # noqa
         # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
         (['-O3'],  0, [],         [],          55,  0,  1, 1), # noqa
         (['-Os'],  0, [],         [],          55,  0,  1, 1), # noqa
@@ -7878,9 +7878,9 @@ int main() {
 
       print('test on libc++: see effects of emulated function pointers')
       test(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 35, ['assert'], ['waka'], 196709,  28,   41, 659), # noqa
+        (['-O2'], 37, ['assert'], ['waka'], 196709,  28,   41, 659), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  35, ['assert'], ['waka'], 196709,  28,   22, 620), # noqa
+                  37, ['assert'], ['waka'], 196709,  28,   22, 620), # noqa
       ], size_slack) # noqa
     else:
       # wasm-backend


### PR DESCRIPTION
Move allocateUTF8 and allocateUTF8OnStack from preamble.js to a JS library so their use can be DCEd.

Also collapse duplicate functionality between stringToNewUTF8 and allocateUTF8.