### PR TITLE
Print more descriptive error messages on some assert failures

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -54,13 +54,13 @@ function preprocess(text, filenameHint) {
             ret += '\n' + preprocess(included, filename) + '\n'
           }
         } else if (line[2] == 'l') { // else
-          assert(showStack.length > 0);
+          assert(showStack.length > 0, 'preprocessing error parsing #else on line ' + i + ': ' + line);
           showStack.push(!showStack.pop());
         } else if (line[2] == 'n') { // endif
-          assert(showStack.length > 0);
+          assert(showStack.length > 0, 'preprocessing error parsing #endif on line ' + i + ': ' + line);
           showStack.pop();
         } else {
-          throw "Unclear preprocessor command: " + line;
+          throw "Unclear preprocessor command on line " + i + ': ' + line;
         }
       }
     } catch(e) {
@@ -68,7 +68,7 @@ function preprocess(text, filenameHint) {
       throw e;
     }
   }
-  assert(showStack.length == 0);
+  assert(showStack.length == 0, 'preprocessing error in file '+ filenameHint + ', no matching #endif found (' + showStack.length + ' unmatched preprocessing directives on stack)');
   return ret;
 }
 

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -33,7 +33,7 @@ function getNativeTypeSize(type) {
         return 4; // A pointer
       } else if (type[0] === 'i') {
         var bits = parseInt(type.substr(1));
-        assert(bits % 8 === 0);
+        assert(bits % 8 === 0, 'getNativeTypeSize invalid bits ' + bits + ', type ' + type);
         return bits / 8;
       } else {
         return 0;

--- a/src/support.js
+++ b/src/support.js
@@ -359,7 +359,9 @@ function loadWebAssemblyModule(binary, flags) {
     tableAlign = Math.pow(2, tableAlign);
     // finalize alignments and verify them
     memoryAlign = Math.max(memoryAlign, STACK_ALIGN); // we at least need stack alignment
-    assert(tableAlign === 1);
+#if ASSERTIONS
+    assert(tableAlign === 1, 'invalid tableAlign ' + tableAlign);
+#endif
     // prepare memory
     var memoryBase = alignMemory(getMemory(memorySize + memoryAlign), memoryAlign); // TODO: add to cleanups
     // The static area consists of explicitly initialized data, followed by zero-initialized data.


### PR DESCRIPTION
Was tracking some cryptic assertion failure in JS code parsing, add some more hints.