### PR TITLE
JSEvents_diet

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7862,7 +7862,7 @@ int main() {
                    0, [],         [],           8,   0,    0,  0), # noqa; totally empty!
         # we don't metadce with linkable code! other modules may want stuff
         (['-O3', '-s', 'MAIN_MODULE=1'],
-                1526, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+                1555, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')


### PR DESCRIPTION
Move register* and fill* functions away from JSEvents to slim down the size of the generated JSEvents object.

Fixes #2999.