### PR TITLE
no_special_abortOnCannotGrowMemory

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1406,8 +1406,6 @@ function ftCall_%s(%s) {%s
 
 def create_basic_funcs(function_table_sigs, invoke_function_names):
   basic_funcs = ['abort', 'assert', 'setTempRet0', 'getTempRet0']
-  if shared.Settings.ABORTING_MALLOC:
-    basic_funcs += ['abortOnCannotGrowMemory']
   if shared.Settings.STACK_OVERFLOW_CHECK:
     basic_funcs += ['abortStackOverflow']
   if shared.Settings.EMTERPRETIFY:
@@ -2137,8 +2135,6 @@ def create_em_js(forwarded_json, metadata):
 
 def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
   basic_funcs = ['assert']
-  if shared.Settings.ABORTING_MALLOC:
-    basic_funcs += ['abortOnCannotGrowMemory']
   if shared.Settings.SAFE_HEAP:
     basic_funcs += ['segfault', 'alignfault']
 

--- a/src/library.js
+++ b/src/library.js
@@ -471,14 +471,22 @@ LibraryManager.library = {
     return TOTAL_MEMORY;
   },
 
-  emscripten_resize_heap__deps: ['emscripten_get_heap_size'],
+  $abortOnCannotGrowMemory: function(requestedSize) {
+#if WASM
+    abort('Cannot enlarge memory arrays to size ' + requestedSize + ' bytes. Either (1) compile with  -s TOTAL_MEMORY=X  with X higher than the current value ' + TOTAL_MEMORY + ', (2) compile with  -s ALLOW_MEMORY_GROWTH=1  which allows increasing the size at runtime, or (3) if you want malloc to return NULL (0) instead of this abort, compile with  -s ABORTING_MALLOC=0 ');
+#else
+    abort('Cannot enlarge memory arrays to size ' + requestedSize + ' bytes. Either (1) compile with  -s TOTAL_MEMORY=X  with X higher than the current value ' + TOTAL_MEMORY + ', (2) compile with  -s ALLOW_MEMORY_GROWTH=1  which allows increasing the size at runtime but prevents some optimizations, (3) set Module.TOTAL_MEMORY to a higher value before the program runs, or (4) if you want malloc to return NULL (0) instead of this abort, compile with  -s ABORTING_MALLOC=0 ');
+#endif
+  },
+
+  emscripten_resize_heap__deps: ['emscripten_get_heap_size', '$abortOnCannotGrowMemory'],
   emscripten_resize_heap: function(requestedSize) {
 #if USE_PTHREADS
     abort('Cannot enlarge memory arrays, since compiling with pthreads support enabled (-s USE_PTHREADS=1).');
 #else
 #if ALLOW_MEMORY_GROWTH == 0
 #if ABORTING_MALLOC
-    abortOnCannotGrowMemory();
+    abortOnCannotGrowMemory(requestedSize);
 #else
     return false; // malloc will report failure
 #endif
@@ -581,7 +589,7 @@ LibraryManager.library = {
   // We control the "dynamic" memory - DYNAMIC_BASE to DYNAMICTOP
   sbrk__asm: true,
   sbrk__sig: ['ii'],
-  sbrk__deps: ['__setErrNo', 'emscripten_get_heap_size', 'emscripten_resize_heap'],
+  sbrk__deps: ['__setErrNo', 'emscripten_get_heap_size', 'emscripten_resize_heap', '$abortOnCannotGrowMemory'],
   sbrk: function(increment) {
     increment = increment|0;
     var oldDynamicTop = 0;
@@ -602,7 +610,7 @@ LibraryManager.library = {
         | (newDynamicTop|0) < 0 // Also underflow, sbrk() should be able to be used to subtract.
         | (newDynamicTop|0) > (totalMemory|0)) {
 #if ABORTING_MALLOC
-        abortOnCannotGrowMemory()|0;
+        abortOnCannotGrowMemory(newDynamicTop|0)|0;
 #else
         ___setErrNo({{{ cDefine('ENOMEM') }}});
         return -1;
@@ -619,7 +627,7 @@ LibraryManager.library = {
     if (((increment|0) > 0 & (newDynamicTop|0) < (oldDynamicTop|0)) // Detect and fail if we would wrap around signed 32-bit int.
       | (newDynamicTop|0) < 0) { // Also underflow, sbrk() should be able to be used to subtract.
 #if ABORTING_MALLOC
-      abortOnCannotGrowMemory()|0;
+      abortOnCannotGrowMemory(newDynamicTop|0)|0;
 #endif
       ___setErrNo({{{ cDefine('ENOMEM') }}});
       return -1;
@@ -640,7 +648,7 @@ LibraryManager.library = {
 
   brk__asm: true,
   brk__sig: ['ii'],
-  brk__deps: ['__setErrNo', 'emscripten_get_heap_size', 'emscripten_resize_heap'],
+  brk__deps: ['__setErrNo', 'emscripten_get_heap_size', 'emscripten_resize_heap', '$abortOnCannotGrowMemory'],
   brk: function(newDynamicTop) {
     newDynamicTop = newDynamicTop|0;
     var totalMemory = 0;
@@ -650,7 +658,7 @@ LibraryManager.library = {
     // enlarge memory, so this needs to fail.
     if ((newDynamicTop|0) < 0 | (newDynamicTop|0) > (totalMemory|0)) {
 #if ABORTING_MALLOC
-      abortOnCannotGrowMemory()|0;
+      abortOnCannotGrowMemory(newDynamicTop|0)|0;
 #else
       ___setErrNo({{{ cDefine('ENOMEM') }}});
       return -1;
@@ -660,7 +668,7 @@ LibraryManager.library = {
 #else // singlethreaded build: (-s USE_PTHREADS=0)
     if ((newDynamicTop|0) < 0) {
 #if ABORTING_MALLOC
-      abortOnCannotGrowMemory()|0;
+      abortOnCannotGrowMemory(newDynamicTop|0)|0;
 #endif
       ___setErrNo({{{ cDefine('ENOMEM') }}});
       return -1;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -396,16 +396,6 @@ function abortStackOverflowEmterpreter() {
 }
 #endif
 
-#if ABORTING_MALLOC
-function abortOnCannotGrowMemory() {
-#if WASM
-  abort('Cannot enlarge memory arrays. Either (1) compile with  -s TOTAL_MEMORY=X  with X higher than the current value ' + TOTAL_MEMORY + ', (2) compile with  -s ALLOW_MEMORY_GROWTH=1  which allows increasing the size at runtime, or (3) if you want malloc to return NULL (0) instead of this abort, compile with  -s ABORTING_MALLOC=0 ');
-#else
-  abort('Cannot enlarge memory arrays. Either (1) compile with  -s TOTAL_MEMORY=X  with X higher than the current value ' + TOTAL_MEMORY + ', (2) compile with  -s ALLOW_MEMORY_GROWTH=1  which allows increasing the size at runtime but prevents some optimizations, (3) set Module.TOTAL_MEMORY to a higher value before the program runs, or (4) if you want malloc to return NULL (0) instead of this abort, compile with  -s ABORTING_MALLOC=0 ');
-#endif
-}
-#endif
-
 #if WASM == 0 && ALLOW_MEMORY_GROWTH
 if (!Module['reallocBuffer']) Module['reallocBuffer'] = function(size) {
   var ret;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1742,7 +1742,7 @@ int main(int argc, char **argv) {
     src = open(path_from_root('tests', 'core', 'test_memorygrowth.c')).read()
 
     # Fail without memory growth
-    self.do_run(src, 'Cannot enlarge memory arrays.')
+    self.do_run(src, 'Cannot enlarge memory arrays')
     fail = open('src.cpp.o.js').read()
 
     # Win with it
@@ -1782,7 +1782,7 @@ int main(int argc, char **argv) {
       src = open(path_from_root('tests', 'core', 'test_memorygrowth_2.c')).read()
 
       # Fail without memory growth
-      self.do_run(src, 'Cannot enlarge memory arrays.')
+      self.do_run(src, 'Cannot enlarge memory arrays')
       fail = open('src.cpp.o.js').read()
 
       # Win with it

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7862,7 +7862,7 @@ int main() {
                    0, [],         [],           8,   0,    0,  0), # noqa; totally empty!
         # we don't metadce with linkable code! other modules may want stuff
         (['-O3', '-s', 'MAIN_MODULE=1'],
-                1555, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+                1556, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')


### PR DESCRIPTION
Remove special handling of function abortOnCannotGrowMemory() but make it a regular JS library function.