### PR TITLE
Avoid regex parsing of JS to get compiler state

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1334,6 +1334,7 @@ def create_asm_setup(debug_tables, function_table_data, invoke_function_names, m
 
     table_total_size = sum(table_size(s) for s in function_table_data.values())
     asm_setup += "\nModule['wasmTableSize'] = %d;\n" % table_total_size
+    shared.Settings.WASM_TABLE_SIZE = table_total_size
     if not shared.Settings.EMULATED_FUNCTION_POINTERS:
       asm_setup += "\nModule['wasmMaxTableSize'] = %d;\n" % table_total_size
 
@@ -2210,7 +2211,9 @@ def create_module_wasm(sending, receiving, invoke_funcs, jscall_sigs,
   if shared.Settings.USE_PTHREADS and not shared.Settings.WASM:
     module.append("if (typeof SharedArrayBuffer !== 'undefined') asmGlobalArg['Atomics'] = Atomics;\n")
 
-  module.append("Module['wasmTableSize'] = %s;\n" % metadata['tableSize'])
+  table_total_size = metadata['tableSize']
+  module.append("Module['wasmTableSize'] = %s;\n" % table_total_size)
+  shared.Settings.WASM_TABLE_SIZE = table_total_size
   module.append('Module%s = %s;\n' % (access_quote('asmLibraryArg'), sending))
   module.append("var asm = Module['asm'](%s, Module%s, buffer);\n" % ('asmGlobalArg', access_quote('asmLibraryArg')))
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1345,6 +1345,9 @@ var MINIFY_ASMJS_IMPORT_NAMES = 0;
 // to JS static allocations
 var STATIC_BUMP = -1;
 
+// the total initial wasm table size.
+var WASM_TABLE_SIZE = 0;
+
 // if set to 1, then generated WASM files will contain a custom
 // "emscripten_metadata" section that contains information necessary
 // to execute the file without the accompanying JS file.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3041,14 +3041,10 @@ class WebAssembly(object):
   @staticmethod
   def get_js_data(js_file, shared=False):
     js = open(js_file).read()
-    m = re.search(r"var STATIC_BUMP = (\d+);", js)
-    mem_size = int(m.group(1))
-    m = re.search(r"Module\['wasmTableSize'\] = (\d+);", js)
-    table_size = int(m.group(1))
+    mem_size = Settings.STATIC_BUMP
+    table_size = Settings.WASM_TABLE_SIZE
     if shared:
-      m = re.search(r'gb = alignMemory\(getMemory\(\d+ \+ (\d+)\), (\d+) \|\| 1\);', js)
-      assert m.group(1) == m.group(2), 'js must contain a clear alignment for the wasm shared library'
-      mem_align = int(m.group(1))
+      mem_align = Settings.MAX_GLOBAL_ALIGN
     else:
       mem_align = None
     return (mem_size, table_size, mem_align)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3040,7 +3040,6 @@ class WebAssembly(object):
 
   @staticmethod
   def get_js_data(js_file, shared=False):
-    js = open(js_file).read()
     mem_size = Settings.STATIC_BUMP
     table_size = Settings.WASM_TABLE_SIZE
     if shared:


### PR DESCRIPTION
Instead, store them in our global shared state (the Settings).