### PR TITLE
Remove some more silly Module.wasm* things

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -364,9 +364,7 @@ function JSify(data, functionsOnly) {
       if (!Variables.generatedGlobalBase) {
         Variables.generatedGlobalBase = true;
         // Globals are done, here is the rest of static memory
-        if (!SIDE_MODULE) {
-          print('STATIC_BASE = GLOBAL_BASE;\n');
-        } else {
+        if (SIDE_MODULE) {
           print('gb = alignMemory(getMemory({{{ STATIC_BUMP }}} + ' + MAX_GLOBAL_ALIGN + '), ' + MAX_GLOBAL_ALIGN + ' || 1);\n');
           // The static area consists of explicitly initialized data, followed by zero-initialized data.
           // The latter may need zeroing out if the MAIN_MODULE has already used this memory area before
@@ -377,12 +375,6 @@ function JSify(data, functionsOnly) {
         }
         // emit "metadata" in a comment. FIXME make this nicer
         print('// STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n');
-        if (WASM) {
-          // export static base and bump, needed for linking in wasm binary's memory, dynamic linking, etc.
-          print('var STATIC_BUMP = {{{ STATIC_BUMP }}};');
-          print('Module["STATIC_BASE"] = STATIC_BASE;');
-          print('Module["STATIC_BUMP"] = STATIC_BUMP;');
-        }
       }
       var generated = itemsDict.function.concat(itemsDict.type).concat(itemsDict.GlobalVariableStub).concat(itemsDict.GlobalVariable);
       print(generated.map(function(item) { return item.JS; }).join('\n'));

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -350,25 +350,25 @@ var LibraryPThread = {
 
         // Ask the new worker to load up the Emscripten-compiled page. This is a heavy operation.
         worker.postMessage({
-            cmd: 'load',
-            // If the application main .js file was loaded from a Blob, then it is not possible
-            // to access the URL of the current script that could be passed to a Web Worker so that
-            // it could load up the same file. In that case, developer must either deliver the Blob
-            // object in Module['mainScriptUrlOrBlob'], or a URL to it, so that pthread Workers can
-            // independently load up the same main application file.
-            urlOrBlob: Module['mainScriptUrlOrBlob'] || currentScriptUrl,
+          cmd: 'load',
+          // If the application main .js file was loaded from a Blob, then it is not possible
+          // to access the URL of the current script that could be passed to a Web Worker so that
+          // it could load up the same file. In that case, developer must either deliver the Blob
+          // object in Module['mainScriptUrlOrBlob'], or a URL to it, so that pthread Workers can
+          // independently load up the same main application file.
+          urlOrBlob: Module['mainScriptUrlOrBlob'] || currentScriptUrl,
 #if WASM
-            wasmMemory: Module['wasmMemory'],
-            wasmModule: Module['wasmModule'],
+          wasmMemory: wasmMemory,
+          wasmModule: wasmModule,
 #else
-            buffer: HEAPU8.buffer,
+          buffer: HEAPU8.buffer,
 #endif
-            tempDoublePtr: tempDoublePtr,
-            TOTAL_MEMORY: TOTAL_MEMORY,
-            DYNAMIC_BASE: DYNAMIC_BASE,
-            DYNAMICTOP_PTR: DYNAMICTOP_PTR,
-            PthreadWorkerInit: PthreadWorkerInit
-          });
+          tempDoublePtr: tempDoublePtr,
+          TOTAL_MEMORY: TOTAL_MEMORY,
+          DYNAMIC_BASE: DYNAMIC_BASE,
+          DYNAMICTOP_PTR: DYNAMICTOP_PTR,
+          PthreadWorkerInit: PthreadWorkerInit
+        });
         PThread.unusedWorkerPool.push(worker);
       }
     },

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -32,6 +32,11 @@ var wasmMemory;
 // Potentially used for direct table calls.
 var wasmTable;
 
+#if USE_PTHREADS
+// For sending to workers.
+var wasmModule;
+#endif
+
 //========================================
 // Runtime essentials
 //========================================
@@ -1020,7 +1025,7 @@ function createWasm(env) {
     Module['asm'] = exports;
 #if USE_PTHREADS
     // Keep a reference to the compiled module so we can post it to the workers.
-    Module['wasmModule'] = module;
+    wasmModule = module;
     // Instantiation is synchronous in pthreads and we assert on run dependencies.
     if (!ENVIRONMENT_IS_PTHREAD) removeRunDependency('wasm-instantiate');
 #else

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -25,6 +25,13 @@ if (typeof WebAssembly !== 'object') {
 
 #include "runtime_safe_heap.js"
 
+// Wasm globals
+
+var wasmMemory;
+
+// Potentially used for direct table calls.
+var wasmTable;
+
 //========================================
 // Runtime essentials
 //========================================
@@ -483,11 +490,11 @@ updateGlobalBufferViews();
 #else
 if (!ENVIRONMENT_IS_PTHREAD) {
 #if ALLOW_MEMORY_GROWTH
-  Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE , 'maximum': {{{ WASM_MEM_MAX }}} / WASM_PAGE_SIZE, 'shared': true });
+  wasmMemory = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE , 'maximum': {{{ WASM_MEM_MAX }}} / WASM_PAGE_SIZE, 'shared': true });
 #else
-  Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE , 'maximum': TOTAL_MEMORY / WASM_PAGE_SIZE, 'shared': true });
+  wasmMemory = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE , 'maximum': TOTAL_MEMORY / WASM_PAGE_SIZE, 'shared': true });
 #endif
-  buffer = Module['wasmMemory'].buffer;
+  buffer = wasmMemory.buffer;
   assert(buffer instanceof SharedArrayBuffer, 'requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag');
 }
 
@@ -513,14 +520,14 @@ if (Module['buffer']) {
 #if ASSERTIONS
     assert({{{ WASM_MEM_MAX }}} % WASM_PAGE_SIZE == 0);
 #endif
-    Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE, 'maximum': {{{ WASM_MEM_MAX }}} / WASM_PAGE_SIZE });
+    wasmMemory = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE, 'maximum': {{{ WASM_MEM_MAX }}} / WASM_PAGE_SIZE });
 #else
-    Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE });
+    wasmMemory = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE });
 #endif // WASM_MEM_MAX
 #else
-    Module['wasmMemory'] = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE, 'maximum': TOTAL_MEMORY / WASM_PAGE_SIZE });
+    wasmMemory = new WebAssembly.Memory({ 'initial': TOTAL_MEMORY / WASM_PAGE_SIZE, 'maximum': TOTAL_MEMORY / WASM_PAGE_SIZE });
 #endif // ALLOW_MEMORY_GROWTH
-    buffer = Module['wasmMemory'].buffer;
+    buffer = wasmMemory.buffer;
   } else
 #endif // WASM
   {
@@ -934,7 +941,7 @@ function mergeMemory(newBuffer) {
 #if MEM_INIT_IN_WASM == 0
   // If we have a mem init file, do not trample it
   if (!memoryInitializer) {
-    oldView.set(newView.subarray(Module['STATIC_BASE'], Module['STATIC_BASE'] + Module['STATIC_BUMP']), Module['STATIC_BASE']);
+    oldView.set(newView.subarray({{{ GLOBAL_BASE }}}, {{{ GLOBAL_BASE }}} + {{{ getQuoted('STATIC_BUMP') }}}), {{{ GLOBAL_BASE }}});
   }
 #endif
 
@@ -992,11 +999,6 @@ function getBinaryPromise() {
 // Receives the wasm imports, returns the exports.
 function createWasm(env) {
   // prepare imports
-  if (!(Module['wasmMemory'] instanceof WebAssembly.Memory)) {
-    err('no native wasm Memory in use');
-    return false;
-  }
-  env['memory'] = Module['wasmMemory'];
   var info = {
     'env': env
 #if WASM_BACKEND == 0
@@ -1122,10 +1124,10 @@ var wasmReallocBuffer = function(size) {
   var oldSize = old.byteLength;
   // native wasm support
   try {
-    var result = Module['wasmMemory'].grow((size - oldSize) / {{{ WASM_PAGE_SIZE }}}); // .grow() takes a delta compared to the previous size
+    var result = wasmMemory.grow((size - oldSize) / {{{ WASM_PAGE_SIZE }}}); // .grow() takes a delta compared to the previous size
     if (result !== (-1 | 0)) {
       // success in native wasm memory growth, get the buffer from the memory
-      return Module['buffer'] = Module['wasmMemory'].buffer;
+      return Module['buffer'] = wasmMemory.buffer;
     } else {
       return null;
     }
@@ -1141,37 +1143,28 @@ Module['reallocBuffer'] = function(size) {
   return wasmReallocBuffer(size);
 };
 
-// Potentially used for direct table calls.
-var wasmTable;
-
 // Provide an "asm.js function" for the application, called to "link" the asm.js module. We instantiate
 // the wasm module at that time, and it receives imports and provides exports and so forth, the app
 // doesn't need to care that it is wasm or asm.js.
 
 Module['asm'] = function(global, env, providedBuffer) {
+  // memory was already allocated (so js could use the buffer)
+  env['memory'] = wasmMemory;
   // import table
-  if (!env['table']) {
-    wasmTable = env['table'] = new WebAssembly.Table({
-      'initial': {{{ getQuoted('WASM_TABLE_SIZE') }}},
+  env['table'] = wasmTable = new WebAssembly.Table({
+    'initial': {{{ getQuoted('WASM_TABLE_SIZE') }}},
 #if !ALLOW_TABLE_GROWTH
-      'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}},
+    'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}},
 #endif // WASM_BACKEND
-      'element': 'anyfunc'
-    });
-  }
+    'element': 'anyfunc'
+  });
+  env['__memory_base'] = {{{ GLOBAL_BASE }}}; // tell the memory segments where to place themselves
+  env['__table_base'] = 0; // table starts at 0 by default (even in dynamic linking, for the main module)
 
-  if (!env['__memory_base']) {
-    env['__memory_base'] = Module['STATIC_BASE']; // tell the memory segments where to place themselves
-  }
-  if (!env['__table_base']) {
-    env['__table_base'] = 0; // table starts at 0 by default, in dynamic linking this will change
-  }
   var exports = createWasm(env);
-
 #if ASSERTIONS
   assert(exports, 'binaryen setup failed (no wasm support?)');
 #endif
-
   return exports;
 };
 #endif

--- a/src/worker.js
+++ b/src/worker.js
@@ -67,13 +67,15 @@ this.alert = threadAlert;
 Module['instantiateWasm'] = function(info, receiveInstance) {
   // Instantiate from the module posted from the main thread.
   // We can just use sync instantiation in the worker.
-  instance = new WebAssembly.Instance(Module['wasmModule'], info);
+  instance = new WebAssembly.Instance(wasmModule, info);
   // We don't need the module anymore; new threads will be spawned from the main thread.
-  delete Module['wasmModule'];
+  wasmModule = null;
   receiveInstance(instance); // The second 'module' parameter is intentionally null here, we don't need to keep a ref to the Module object from here.
   return instance.exports;
 }
 //#endif
+
+var wasmModule;
 
 this.onmessage = function(e) {
   try {
@@ -90,9 +92,9 @@ this.onmessage = function(e) {
 //#if WASM
       if (e.data.wasmModule) {
         // Module and memory were sent from main thread
-        Module['wasmModule'] = e.data.wasmModule;
-        Module['wasmMemory'] = e.data.wasmMemory;
-        buffer = Module['wasmMemory'].buffer;
+        wasmModule = e.data.wasmModule;
+        wasmMemory = e.data.wasmMemory;
+        buffer = wasmMemory.buffer;
       } else {
 //#else
         buffer = e.data.buffer;


### PR DESCRIPTION
Similar to the recent optimization for tables, this does the same for the memory and module.

Saves over 2% of JS size.