### PR TITLE
Enable binaryen0 with the wasm backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,10 +366,6 @@ jobs:
     <<: *test-defaults
     environment:
       - TEST_TARGET=binaryen2
-  test-upstream-wasmobj0:
-    <<: *test-defaults
-    environment:
-      - TEST_TARGET=wasmobj0
   test-upstream-wasmobj2:
     <<: *test-defaults
     environment:
@@ -447,9 +443,6 @@ workflows:
           requires:
             - build-upstream
       - test-upstream-binaryen2:
-          requires:
-            - build-upstream
-      - test-upstream-wasmobj0:
           requires:
             - build-upstream
       - test-upstream-wasmobj2:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,10 +358,18 @@ jobs:
             - .emscripten_cache/
             - .emscripten_ports/
             - .emscripten
+  test-upstream-binaryen0:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=binaryen0
   test-upstream-binaryen2:
     <<: *test-defaults
     environment:
       - TEST_TARGET=binaryen2
+  test-upstream-wasmobj0:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=wasmobj0
   test-upstream-wasmobj2:
     <<: *test-defaults
     environment:
@@ -435,7 +443,13 @@ workflows:
           requires:
             - build
       - build-upstream
+      - test-upstream-binaryen0:
+          requires:
+            - build-upstream
       - test-upstream-binaryen2:
+          requires:
+            - build-upstream
+      - test-upstream-wasmobj0:
           requires:
             - build-upstream
       - test-upstream-wasmobj2:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -241,6 +241,7 @@ class TestCoreBase(RunnerCore):
 
     self.do_run_in_out_file_test('tests', 'core', 'test_llvm_intrinsics')
 
+  @no_wasm_backend('test looks for js impls of intrinsics')
   def test_lower_intrinsics(self):
     self.emcc_args += ['-g1']
     self.do_run_in_out_file_test('tests', 'core', 'test_lower_intrinsics')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -518,7 +518,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
         'fmod.c', 'fmodf.c', 'fmodl.c',
         'log2.c', 'log2f.c', 'log10.c', 'log10f.c',
         'exp2.c', 'exp2f.c', 'exp10.c', 'exp10f.c',
-        'scalbn.c', '__fpclassifyl.c'
+        'scalbn.c', '__fpclassifyl.c',
+        '__signbitl.c', '__signbitf.c', '__signbit.c'
       ])
     string_files = files_in_path(
       path_components=['system', 'lib', 'libc', 'musl', 'src', 'string'],

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -510,6 +510,9 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     # issue as we do JS linking anyhow, and have asm.js-optimized versions of all the LLVM
     # intrinsics. But for wasm, we need a better solution. For now, make another archive
     # that gets included at the same time as compiler-rt.
+    # Note that this also includes things that may be depended on by those functions - fmin
+    # uses signbit, for example, so signbit must be here (so if fmin is added by codegen,
+    # it will have all it needs).
     math_files = files_in_path(
       path_components=['system', 'lib', 'libc', 'musl', 'src', 'math'],
       filenames=[


### PR DESCRIPTION
2 minor fixes were needed:

 * Add signbit functions from libc to wasm_libc_rt.
 * Disable a test that is asm.js-only, `test_lower_intrinsics`

wasmobj0 will take more work, as there is an EM_ASM issue that will require a binaryen fix.