### PR TITLE
Remove the SDL2 dummy video driver

### DIFF
--- a/tools/ports/sdl.py
+++ b/tools/ports/sdl.py
@@ -325,7 +325,7 @@ sdl_config_h = r'''/* include/SDL_config.h.  Generated from SDL_config.h.in by c
 /* #undef SDL_VIDEO_DRIVER_COCOA */
 /* #undef SDL_VIDEO_DRIVER_DIRECTFB */
 /* #undef SDL_VIDEO_DRIVER_DIRECTFB_DYNAMIC */
-#define SDL_VIDEO_DRIVER_DUMMY 1
+/* #undef SDL_VIDEO_DRIVER_DUMMY */
 /* #undef SDL_VIDEO_DRIVER_WINDOWS */
 /* #undef SDL_VIDEO_DRIVER_WAYLAND */
 /* #undef SDL_VIDEO_DRIVER_WAYLAND_QT_TOUCH */


### PR DESCRIPTION
On it's own, this shaves a few kb off the wasm size, with [these patches](https://github.com/emscripten-ports/SDL2/compare/smaller-build) I can reduce the size of an app that doesn't use renderers by ~150k and a test that does nothing other than create a window by 2/3rds of its size.