### PR TITLE
memory_growth_to_js_library

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -479,7 +479,61 @@ LibraryManager.library = {
 #endif
   },
 
-  emscripten_resize_heap__deps: ['emscripten_get_heap_size', '$abortOnCannotGrowMemory'],
+#if TEST_MEMORY_GROWTH_FAILS
+  $emscripten_realloc_buffer: function(size) {
+    return null;
+  },
+#else
+
+  $emscripten_realloc_buffer: function(size) {
+#if WASM
+    var PAGE_MULTIPLE = {{{ getPageSize() }}};
+    size = alignUp(size, PAGE_MULTIPLE); // round up to wasm page size
+    var old = Module['buffer'];
+    var oldSize = old.byteLength;
+    // native wasm support
+    try {
+      var result = wasmMemory.grow((size - oldSize) / {{{ WASM_PAGE_SIZE }}}); // .grow() takes a delta compared to the previous size
+      if (result !== (-1 | 0)) {
+        // success in native wasm memory growth, get the buffer from the memory
+        return Module['buffer'] = wasmMemory.buffer;
+      } else {
+        return null;
+      }
+    } catch(e) {
+#if ASSERTIONS
+      console.error('emscripten_realloc_buffer: Attempted to grow from ' + oldSize  + ' bytes to ' + size + ' bytes, but got error: ' + e);
+#endif
+      return null;
+    }
+#else // asm.js:
+    try {
+      var newBuffer = new ArrayBuffer(size);
+      if (newBuffer.byteLength != size) return false;
+      new Int8Array(newBuffer).set(HEAP8);
+    } catch(e) {
+      return false;
+    }
+    Module['_emscripten_replace_memory'](newBuffer);
+    HEAP8 = new Int8Array(newBuffer);
+    HEAP16 = new Int16Array(newBuffer);
+    HEAP32 = new Int32Array(newBuffer);
+    HEAPU8 = new Uint8Array(newBuffer);
+    HEAPU16 = new Uint16Array(newBuffer);
+    HEAPU32 = new Uint32Array(newBuffer);
+    HEAPF32 = new Float32Array(newBuffer);
+    HEAPF64 = new Float64Array(newBuffer);
+    buffer = newBuffer;
+    return newBuffer;
+#endif
+  },
+#endif // ~TEST_MEMORY_GROWTH_FAILS
+
+  emscripten_resize_heap__deps: ['emscripten_get_heap_size', '$abortOnCannotGrowMemory'
+#if ALLOW_MEMORY_GROWTH && !USE_PTHREADS
+  , '$emscripten_realloc_buffer'
+#endif
+  ],
   emscripten_resize_heap: function(requestedSize) {
 #if USE_PTHREADS
     abort('Cannot enlarge memory arrays, since compiling with pthreads support enabled (-s USE_PTHREADS=1).');
@@ -550,7 +604,7 @@ LibraryManager.library = {
     var start = Date.now();
 #endif
 
-    var replacement = Module['reallocBuffer'](newSize);
+    var replacement = emscripten_realloc_buffer(newSize);
     if (!replacement || replacement.byteLength != newSize) {
 #if ASSERTIONS
       err('Failed to grow the heap from ' + oldSize + ' bytes to ' + newSize + ' bytes, not enough memory!');

--- a/src/settings.js
+++ b/src/settings.js
@@ -1362,3 +1362,6 @@ var MODULE_EXPORTS = [];
 
 // Internal (testing only): Disables the blitOffscreenFramebuffer VAO path.
 var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = 0;
+
+// Internal (testing only): Forces memory growing to fail.
+var TEST_MEMORY_GROWTH_FAILS = 0;

--- a/tests/core/test_memorygrowth_3.c
+++ b/tests/core/test_memorygrowth_3.c
@@ -23,15 +23,6 @@ int main(int argc, char **argv)
   int totalMemory = get_TOTAL_MEMORY();
   int chunk = 1024*1024;
   volatile voidStar alloc;
-#ifdef FAIL_REALLOC_BUFFER
-  EM_ASM({
-    Module.seenOurReallocBuffer = false;
-    Module['reallocBuffer'] = function() {
-      Module.seenOurReallocBuffer = true;
-      return null;
-    };
-  });
-#endif
   for (int i = 0; i < (totalMemory/chunk)+2; i++) {
     // make sure state remains the same if malloc fails
     void* sbrk_before = sbrk(0);
@@ -44,11 +35,6 @@ int main(int argc, char **argv)
     }
   }
   assert(alloc == NULL);
-#ifdef FAIL_REALLOC_BUFFER
-  EM_ASM({
-    assert(Module.seenOurReallocBuffer, 'our override should have been called');
-  });
-#endif
   puts("ok.");
   return 0;
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1798,7 +1798,7 @@ int main(int argc, char **argv) {
     self.do_run_in_out_file_test('tests', 'core', 'test_memorygrowth_wasm_mem_max')
 
   def test_memorygrowth_3_force_fail_reallocBuffer(self):
-    self.emcc_args += ['-s', 'ALLOW_MEMORY_GROWTH=1', '-DFAIL_REALLOC_BUFFER']
+    self.emcc_args += ['-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'TEST_MEMORY_GROWTH_FAILS=1']
     self.do_run_in_out_file_test('tests', 'core', 'test_memorygrowth_3')
 
   def test_ssr(self): # struct self-ref

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6062,19 +6062,6 @@ int main() {
 #define CHUNK_SIZE (10 * 1024 * 1024)
 
 int main() {
-  EM_ASM({
-    // we want to allocate a lot until eventually we can't anymore. to simulate that, we limit how much
-    // can be allocated by Buffer, so that if we don't hit a limit before that, we don't keep going into
-    // swap space and other bad things.
-    var old = Module['reallocBuffer'];
-    Module['reallocBuffer'] = function(size) {
-      if (size > 500 * 1024 * 1024) {
-        return null;
-      }
-      return old(size);
-    };
-  });
-
   std::vector<void*> allocs;
   bool has = false;
   while (1) {
@@ -6106,6 +6093,7 @@ int main() {
 }
 ''' % (pre_fail, post_fail))
           args = [PYTHON, EMCC, 'main.cpp'] + opts
+          args += ['-s', 'TEST_MEMORY_GROWTH_FAILS=1'] # In this test, force memory growing to fail
           if growth:
             args += ['-s', 'ALLOW_MEMORY_GROWTH=1']
           if not aborting:
@@ -7862,7 +7850,7 @@ int main() {
                    0, [],         [],           8,   0,    0,  0), # noqa; totally empty!
         # we don't metadce with linkable code! other modules may want stuff
         (['-O3', '-s', 'MAIN_MODULE=1'],
-                1556, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+                1557, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')


### PR DESCRIPTION
Move reallocBuffer and emscripten_replace_memory to be handled in JS library functions