### PR TITLE
Move setThrew() function over to JS library

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -776,8 +776,6 @@ def get_exported_implemented_functions(all_exported_functions, all_implemented, 
       funcs.append('_emscripten_replace_memory')
     if not shared.Settings.SIDE_MODULE:
       funcs += ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace']
-    if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
-      funcs += ['setThrew']
     if shared.Settings.EMTERPRETIFY:
       funcs += ['emterpret']
       if shared.Settings.EMTERPRETIFY_ASYNC:
@@ -1488,7 +1486,7 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
 def create_asm_runtime_funcs():
   funcs = []
   if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE):
-    funcs += ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace', 'setThrew']
+    funcs += ['stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace']
   if shared.Settings.ONLY_MY_CODE:
     funcs = []
   return funcs
@@ -1628,14 +1626,6 @@ function establishStackSpace(stackBase, stackMax) {
   stackMax = stackMax|0;
   STACKTOP = stackBase;
   STACK_MAX = stackMax;
-}
-function setThrew(threw, value) {
-  threw = threw|0;
-  value = value|0;
-  if ((__THREW__|0) == 0) {
-    __THREW__ = threw;
-    threwValue = value;
-  }
 }
 ''' % stack_check]
 
@@ -2284,7 +2274,7 @@ def asmjs_mangle(name):
   Prepends '_' and replaces non-alphanumerics with '_'.
   Used by wasm backend for JS library consistency with asm.js.
   """
-  library_functions_in_module = ('setThrew', 'setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace')
+  library_functions_in_module = ('setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace')
   if name.startswith('dynCall_'):
     return name
   if name in library_functions_in_module:

--- a/src/library.js
+++ b/src/library.js
@@ -1290,6 +1290,17 @@ LibraryManager.library = {
     abort('Assertion failed: ' + (condition ? UTF8ToString(condition) : 'unknown condition') + ', at: ' + [filename ? UTF8ToString(filename) : 'unknown filename', line, func ? UTF8ToString(func) : 'unknown function']);
   },
 
+  setThrew__asm: true,
+  setThrew__sig: 'vii',
+  setThrew: function(threw, value) {
+    threw = threw|0;
+    value = value|0;
+    if ((__THREW__|0) == 0) {
+      __THREW__ = threw;
+      threwValue = value;
+    }
+  },
+
   $EXCEPTIONS__deps: ['__cxa_free_exception'],
   $EXCEPTIONS: {
     last: 0,
@@ -1458,10 +1469,10 @@ LibraryManager.library = {
   // and free the exception. Note that if the dynCall on the destructor fails
   // due to calling apply on undefined, that means that the destructor is
   // an invalid index into the FUNCTION_TABLE, so something has gone wrong.
-  __cxa_end_catch__deps: ['__cxa_free_exception', '$EXCEPTIONS'],
+  __cxa_end_catch__deps: ['__cxa_free_exception', '$EXCEPTIONS', 'setThrew'],
   __cxa_end_catch: function() {
     // Clear state flag.
-    Module['setThrew'](0);
+    _setThrew(0);
     // Call destructor if one is registered then clear it.
     var ptr = EXCEPTIONS.caught.pop();
 #if EXCEPTION_DEBUG
@@ -3116,9 +3127,9 @@ LibraryManager.library = {
     return '_saveSetjmp(' + env + ', label, setjmpTable)|0';
   },
 
-  longjmp__deps: ['saveSetjmp', 'testSetjmp'],
+  longjmp__deps: ['saveSetjmp', 'testSetjmp', 'setThrew'],
   longjmp: function(env, value) {
-    Module['setThrew'](env, value || 1);
+    _setThrew(env, value || 1);
     throw 'longjmp';
   },
   emscripten_longjmp__deps: ['longjmp'],

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7017,7 +7017,7 @@ int main() {
   def test_only_my_code(self):
     run_process([PYTHON, EMCC, '-O1', path_from_root('tests', 'hello_world.c'), '--separate-asm', '-s', 'WASM=0'])
     count = open('a.out.asm.js').read().count('function ')
-    assert count > 30, count # libc brings in a bunch of stuff
+    assert count > 29, count # libc brings in a bunch of stuff
 
     def test(filename, opts, expected_funcs, expected_vars):
       print(filename, opts)
@@ -7851,9 +7851,9 @@ int main() {
 
       print('test on hello world')
       test(path_from_root('tests', 'hello_world.cpp'), [
-        ([],      21, ['assert'], ['waka'], 46505,  22,   16, 59), # noqa
-        (['-O1'], 16, ['assert'], ['waka'], 12630,  14,   14, 31), # noqa
-        (['-O2'], 16, ['assert'], ['waka'], 12616,  14,   14, 31), # noqa
+        ([],      21, ['assert'], ['waka'], 46505,  22,   15, 58), # noqa
+        (['-O1'], 16, ['assert'], ['waka'], 12630,  14,   13, 30), # noqa
+        (['-O2'], 16, ['assert'], ['waka'], 12616,  14,   13, 30), # noqa
         (['-O3'],  6, [],         [],        2690,   9,    2, 21), # noqa; in -O3, -Os and -Oz we metadce
         (['-Os'],  6, [],         [],        2690,   9,    2, 21), # noqa
         (['-Oz'],  6, [],         [],        2690,   9,    2, 21), # noqa
@@ -7867,9 +7867,9 @@ int main() {
 
       print('test on a minimal pure computational thing')
       test('minimal.c', [
-        ([],      21, ['assert'], ['waka'], 22712, 22, 15, 28), # noqa
-        (['-O1'], 11, ['assert'], ['waka'], 10450,  7, 12, 12), # noqa
-        (['-O2'], 11, ['assert'], ['waka'], 10440,  7, 12, 12), # noqa
+        ([],      21, ['assert'], ['waka'], 22712, 22, 14, 27), # noqa
+        (['-O1'], 11, ['assert'], ['waka'], 10450,  7, 11, 11), # noqa
+        (['-O2'], 11, ['assert'], ['waka'], 10440,  7, 11, 11), # noqa
         # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
         (['-O3'],  0, [],         [],          55,  0,  1, 1), # noqa
         (['-Os'],  0, [],         [],          55,  0,  1, 1), # noqa
@@ -7878,9 +7878,9 @@ int main() {
 
       print('test on libc++: see effects of emulated function pointers')
       test(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 35, ['assert'], ['waka'], 196709,  28,   41, 659), # noqa
+        (['-O2'], 35, ['assert'], ['waka'], 196709,  28,   40, 658), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  35, ['assert'], ['waka'], 196709,  28,   22, 620), # noqa
+                  35, ['assert'], ['waka'], 196709,  28,   21, 619), # noqa
       ], size_slack) # noqa
     else:
       # wasm-backend

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2961,7 +2961,7 @@ function jsCall_%s(%s) {
   } catch(e) {
     stackRestore(sp);
     if (typeof e !== 'number' && e !== 'longjmp') throw e;
-    Module["setThrew"](1, 0);
+    _setThrew(1, 0);
   }
 }''' % ((' invoke_' + sig) if named else '', args, body)
     return ret


### PR DESCRIPTION
Not sure if `Module['setThrew']` was being used specifically for dynamic linking reasons, or why it was not just being invoked with `setThrew()`. Testing locally longjmp and setjmp tests all passed, but let's see what CI says.