### PR TITLE
Throw EINVAL for invalid whence in llseek

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1110,6 +1110,9 @@ mergeInto(LibraryManager.library, {
       if (!stream.seekable || !stream.stream_ops.llseek) {
         throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
       }
+      if (whence < 0 /* SEEK_SET */ || whence > 2 /* SEEK_END */) {
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+      }
       stream.position = stream.stream_ops.llseek(stream, offset, whence);
       stream.ungotten = [];
       return stream.position;

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1110,7 +1110,7 @@ mergeInto(LibraryManager.library, {
       if (!stream.seekable || !stream.stream_ops.llseek) {
         throw new FS.ErrnoError({{{ cDefine('ESPIPE') }}});
       }
-      if (whence < 0 /* SEEK_SET */ || whence > 2 /* SEEK_END */) {
+      if (whence != 0 /* SEEK_SET */ && whence != 1 /* SEEK_CUR */ && whence != 2 /* SEEK_END */) {
         throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       stream.position = stream.stream_ops.llseek(stream, offset, whence);

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -74,6 +74,8 @@ mergeInto(LibraryManager.library, {
         position += stream.position;
       } else if (whence === 2) {  // SEEK_END.
         position += fs.fstatSync(stream.nfd).size;
+      } else if (whence !== 0) {  // SEEK_SET.
+        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
       }
 
       if (position < 0) {

--- a/tests/fs/test_llseek.c
+++ b/tests/fs/test_llseek.c
@@ -14,6 +14,15 @@ int main()
     var stream = FS.open('testfile', 'a');
     fd = FS.write(stream, new Uint8Array([99, 61, 51]) /* c=3 */, 0, 3);
 
+    // check invalid whence
+    var ex;
+    try {
+      FS.llseek(stream, 0, 99);
+    } catch(e) {
+      ex = e;
+    }
+    assert(ex instanceof FS.ErrnoError && ex.errno === ERRNO_CODES.EINVAL);
+
     if (FS.llseek(stream, 0, 1 /* SEEK_CUR */) === 11) {
       console.log("success");
     }

--- a/tests/fs/test_llseek.c
+++ b/tests/fs/test_llseek.c
@@ -21,7 +21,7 @@ int main()
     } catch(e) {
       ex = e;
     }
-    assert(ex instanceof FS.ErrnoError && ex.errno === ERRNO_CODES.EINVAL);
+    assert(ex instanceof FS.ErrnoError && ex.errno === 22 /* EINVAL */);
 
     if (FS.llseek(stream, 0, 1 /* SEEK_CUR */) === 11) {
       console.log("success");


### PR DESCRIPTION
This was causing failures in [SDL2's tests](https://github.com/emscripten-ports/SDL2/blob/master/test/testautomation_rwops.c#L159).