### PR TITLE
group_global_initializers

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -402,6 +402,31 @@ def collapse_redundant_vars(code):
   return code
 
 
+def global_initializer_funcs(initializers):
+  # If we have at most one global ctor, no need to group global initializers.
+  # Also in EVAL_CTORS mode, we want to try to evaluate the individual ctor functions, so in that mode,
+  # do not group ctors into one.
+  return ['globalCtors'] if (len(initializers) > 1 and not shared.Settings.EVAL_CTORS) else initializers
+
+
+# Each .cpp file with global constructors generates a __GLOBAL__init() function that needs to be
+# called to construct the global objects in that compilation unit. This function groups all these
+# global initializer functions together into a single globalCtors() function that lives inside the
+# asm.js/wasm module, and gets exported out to JS scope to be called at the startup of the application.
+def create_global_initializer(initializers):
+  # If we have no global ctors, don't even generate a dummy empty function to save code space
+  # Also in EVAL_CTORS mode, we want to try to evaluate the individual ctor functions, so in that mode,
+  # we do not group ctors into one.
+  if 'globalCtors' not in global_initializer_funcs(initializers):
+    return ''
+
+  global_initializer = '''  function globalCtors() {
+    %s
+  }''' % '\n    '.join(i + '();' for i in initializers)
+
+  return global_initializer
+
+
 def create_module_asmjs(function_table_sigs, metadata,
                         funcs_js, asm_setup, the_global, sending, receiving, asm_global_vars,
                         asm_global_funcs, pre_tables, final_function_tables, exports):
@@ -428,12 +453,14 @@ def create_module_asmjs(function_table_sigs, metadata,
   asm_end = create_asm_end(exports)
 
   asm_variables = collapse_redundant_vars(memory_views + asm_global_vars + asm_temp_vars + asm_runtime_thread_local_vars + '\n' + asm_global_funcs + stack + temp_float + async_state + f0_fround)
+  asm_global_initializer = create_global_initializer(metadata['initializers'])
 
   module = [
     asm_start_pre,
     asm_variables,
     replace_memory,
-    start_funcs_marker
+    start_funcs_marker,
+    asm_global_initializer
   ] + runtime_funcs + funcs_js + [
     '\n  ',
     pre_tables, final_function_tables, asm_end,
@@ -690,8 +717,6 @@ def apply_table(js):
 
 
 def memory_and_global_initializers(pre, metadata, mem_init):
-  global_initializers = ', '.join('{ func: function() { %s() } }' % i for i in metadata['initializers'])
-
   if shared.Settings.SIMD == 1:
     pre = open(path_from_root(os.path.join('src', 'ecmascript_simd.js'))).read() + '\n\n' + pre
 
@@ -701,7 +726,9 @@ def memory_and_global_initializers(pre, metadata, mem_init):
   if shared.Settings.USE_PTHREADS:
     pthread = 'if (!ENVIRONMENT_IS_PTHREAD)'
 
+  global_initializers = global_initializer_funcs(metadata['initializers'])
   if len(global_initializers) > 0:
+    global_initializers = ', '.join('{ func: function() { %s() } }' % i for i in global_initializers)
     global_initializers = '/* global initializers */ {pthread} __ATINIT__.push({global_initializers});'.format(pthread=pthread, global_initializers=global_initializers)
   else:
     global_initializers = '/* global initializers */ /*__ATINIT__.push();*/'
@@ -776,7 +803,8 @@ def get_exported_implemented_functions(all_exported_functions, all_implemented, 
     if key in all_exported_functions or export_all or (export_bindings and key.startswith('_emscripten_bind')):
       funcs.add(key)
 
-  funcs = list(funcs) + metadata['initializers']
+  funcs = list(funcs) + global_initializer_funcs(metadata['initializers'])
+
   if not shared.Settings.ONLY_MY_CODE:
     if shared.Settings.ALLOW_MEMORY_GROWTH:
       funcs.append('_emscripten_replace_memory')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3654,9 +3654,32 @@ Waste<3> *getMore() {
       src = open('a.out.js').read()
       self.assertContained('argc: 1\n16\n17\n10\n', run_js('a.out.js'))
       if has_global:
-        self.assertContained('_GLOBAL_', src)
+        self.assertContained('globalCtors', src)
       else:
-        self.assertNotContained('_GLOBAL_', src)
+        self.assertNotContained('globalCtors', src)
+
+  # Tests that when there are only 0 or 1 global initializers, that a grouped global initializer function will not be generated
+  # (that would just consume excess code size)
+  def test_no_global_inits(self):
+    create_test_file('one_global_initializer.cpp', r'''
+#include <emscripten.h>
+#include <stdio.h>
+double t = emscripten_get_now();
+int main() { printf("t:%d\n", (int)(t>0)); }
+''')
+    run_process([PYTHON, EMCC, 'one_global_initializer.cpp'])
+    # Above file has one global initializer, should not generate a redundant grouped globalCtors function
+    self.assertNotContained('globalCtors', open('a.out.js').read())
+    self.assertContained('t:1', run_js('a.out.js'))
+
+    create_test_file('zero_global_initializers.cpp', r'''
+#include <stdio.h>
+int main() { printf("t:1\n"); }
+''')
+    run_process([PYTHON, EMCC, 'zero_global_initializers.cpp'])
+    # Above file should have zero global initializers, should not generate any global initializer functions
+    self.assertNotContained('__GLOBAL__sub_', open('a.out.js').read())
+    self.assertContained('t:1', run_js('a.out.js'))
 
   def test_implicit_func(self):
     create_test_file('src.c', r'''
@@ -7878,9 +7901,9 @@ int main() {
 
       print('test on libc++: see effects of emulated function pointers')
       test(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 35, ['assert'], ['waka'], 196709,  28,   40, 658), # noqa
+        (['-O2'], 35, ['assert'], ['waka'], 196709,  28,   39, 659), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  35, ['assert'], ['waka'], 196709,  28,   21, 619), # noqa
+                  35, ['assert'], ['waka'], 196709,  28,   20, 620), # noqa
       ], size_slack) # noqa
     else:
       # wasm-backend


### PR DESCRIPTION
Group all global initializers into one function and only export that function to JS scope to save code size.