### PR TITLE
Fix build of SINGLE_FILE + ENVIRONMENT=web + Closure combined together (#7933)

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2849,7 +2849,7 @@ def generate_html(target, options, js_target, target_basename,
   # when script.inline isn't empty, add required helper functions such as tryParseAsDataURI
   if script.inline:
     for filename in ('arrayUtils.js', 'base64Utils.js', 'URIUtils.js'):
-      content = open(shared.path_from_root('src', filename)).read()
+      content = read_and_preprocess(shared.path_from_root('src', filename))
       script.inline = content + script.inline
 
     script.inline = 'var ASSERTIONS = %s;\n%s' % (shared.Settings.ASSERTIONS, script.inline)

--- a/src/base64Utils.js
+++ b/src/base64Utils.js
@@ -42,6 +42,7 @@ var decodeBase64 = typeof atob === 'function' ? atob : function (input) {
 // Converts a string of base64 into a byte array.
 // Throws error on invalid input.
 function intArrayFromBase64(s) {
+#if ENVIRONMENT_MAY_BE_NODE
   if (typeof ENVIRONMENT_IS_NODE === 'boolean' && ENVIRONMENT_IS_NODE) {
     var buf;
     try {
@@ -51,6 +52,7 @@ function intArrayFromBase64(s) {
     }
     return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   }
+#endif
 
   try {
     var decoded = decodeBase64(s);

--- a/src/library.js
+++ b/src/library.js
@@ -4261,17 +4261,22 @@ LibraryManager.library = {
   },
 
   emscripten_get_now: function() { abort() }, // replaced by the postset at startup time
-  emscripten_get_now__postset: "if (ENVIRONMENT_IS_NODE) {\n" +
+  emscripten_get_now__postset:
+#if ENVIRONMENT_MAY_BE_NODE
+                               "if (ENVIRONMENT_IS_NODE) {\n" +
                                "  _emscripten_get_now = function _emscripten_get_now_actual() {\n" +
                                "    var t = process['hrtime']();\n" +
                                "    return t[0] * 1e3 + t[1] / 1e6;\n" +
                                "  };\n" +
+                               "} else " +
+#endif
 #if USE_PTHREADS
 // Pthreads need their clocks synchronized to the execution of the main thread, so give them a special form of the function.
-                               "} else if (ENVIRONMENT_IS_PTHREAD) {\n" +
+                               "if (ENVIRONMENT_IS_PTHREAD) {\n" +
                                "  _emscripten_get_now = function() { return performance['now']() - __performance_now_clock_drift; };\n" +
+                               "} else " +
 #endif
-                               "} else if (typeof dateNow !== 'undefined') {\n" +
+                               "if (typeof dateNow !== 'undefined') {\n" +
                                "  _emscripten_get_now = dateNow;\n" +
                                "} else if (typeof self === 'object' && self['performance'] && typeof self['performance']['now'] === 'function') {\n" +
                                "  _emscripten_get_now = function() { return self['performance']['now'](); };\n" +

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1259,7 +1259,7 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_threads
   def test_emscripten_get_now(self):
-    for args in [[], ['-s', 'USE_PTHREADS=1']]:
+    for args in [[], ['-s', 'USE_PTHREADS=1'], ['-s', 'ENVIRONMENT=web', '-O2', '--closure', '1']]:
       self.btest('emscripten_get_now.cpp', '1', args=args)
 
   @unittest.skip('Skipping due to https://github.com/emscripten-core/emscripten/issues/2770')
@@ -4231,6 +4231,10 @@ window.close = function() {
   def test_single_file_html(self):
     self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1'], also_proxied=True)
     assert os.path.exists('test.html') and not os.path.exists('test.js') and not os.path.exists('test.worker.js')
+
+  # Tests that SINGLE_FILE works when built with ENVIRONMENT=web and Closure enabled (#7933)
+  def test_single_file_in_web_environment_with_closure(self):
+    self.btest('minimal_hello.c', '0', args=['-s', 'SINGLE_FILE=1', '-s', 'ENVIRONMENT=web', '-O2', '--closure', '1'])
 
   # Tests that SINGLE_FILE works as intended with locateFile
   def test_single_file_locate_file(self):


### PR DESCRIPTION
When Closuring with ENVIRONMENT=web, after #7846 we are no longer sloppy and pass Node.js externs to Closure compiler (since code is not to be run in Node.js at all).

As result, #7933 uncovered Node.js specific code that was still being generated in SINGLE_FILE=1 case, which contains a reference to global object `Buffer` that Closure could (rightfully) no longer understand.