### PR TITLE
SEPARATE_ASM_MODULE_NAME

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1280,6 +1280,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.DECLARE_ASM_MODULE_EXPORTS = 1
       logger.warning('Enabling -s DECLARE_ASM_MODULE_EXPORTS=1, since MODULARIZE currently requires declaring asm.js/wasm module exports in full')
 
+    if shared.Settings.MODULARIZE and shared.Settings.SEPARATE_ASM and not shared.Settings.WASM and not shared.Settings.SEPARATE_ASM_MODULE_NAME:
+      exit_with_error('Targeting asm.js with --separate-asm and -s MODULARIZE=1 requires specifying the target variable name to which the asm.js module is loaded into. See https://github.com/emscripten-core/emscripten/pull/7949 for details')
+    # Apply default option if no custom name is provided
+    if not shared.Settings.SEPARATE_ASM_MODULE_NAME:
+      shared.Settings.SEPARATE_ASM_MODULE_NAME = 'Module["asm"]'
+
     if shared.Settings.WASM:
       if shared.Settings.SINGLE_FILE:
         # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
@@ -2455,7 +2461,7 @@ def emit_js_source_maps(target, js_transform_tempfiles):
 def separate_asm_js(final, asm_target):
   """Separate out the asm.js code, if asked. Or, if necessary for another option"""
   logger.debug('separating asm')
-  shared.check_call([shared.PYTHON, shared.path_from_root('tools', 'separate_asm.py'), final, asm_target, final])
+  shared.check_call([shared.PYTHON, shared.path_from_root('tools', 'separate_asm.py'), final, asm_target, final, shared.Settings.SEPARATE_ASM_MODULE_NAME])
 
   # extra only-my-code logic
   if shared.Settings.ONLY_MY_CODE:

--- a/src/settings.js
+++ b/src/settings.js
@@ -873,6 +873,16 @@ var MODULARIZE = 0;
 // (since you aren't creating the instance yourself).
 var MODULARIZE_INSTANCE = 0;
 
+// If we separate out asm.js with the --separate-asm option,
+// this is the name of the variable where the generated asm.js
+// Module is assigned to. This name can either be a property
+// of Module, or a freestanding variable name, like "var asmJs".
+// If you are XHRing in multiple asm.js built files, use this option to
+// assign the generated asm.js modules to different variable names
+// so that they do not conflict. Default name is 'Module["asm"]' if a custom
+// name is not passed in.
+var SEPARATE_ASM_MODULE_NAME = '';
+
 // Export using an ES6 Module export rather than a UMD export.  MODULARIZE must
 // be enabled for ES6 exports.
 var EXPORT_ES6 = 0;

--- a/tests/encapsulated_asmjs_page_load.html
+++ b/tests/encapsulated_asmjs_page_load.html
@@ -1,0 +1,45 @@
+<!doctype html><html lang="en-us"><head><meta charset="utf-8"></head>
+<body>
+<script>
+  function script(url) {
+    return new Promise((resolve, reject) => {
+      var s = document.createElement('script');
+      s.src = url;
+      s.onload = function() {
+        var code = EmscriptenCode; // Capture the js/asm.js content from global scope to a local variable
+        delete EmscriptenCode;
+        resolve(code);
+      };
+      document.body.appendChild(s);
+    });
+  }
+
+  // Verify that browser script onload() happens tightly after it has evaluated the page, so that no other
+  // event handlers have a chance to get in between. (add event handlers that try to race to get in between)
+  setInterval(function(){ EmscriptenCode = null; }, 0);
+  setInterval(function(){ EmscriptenCode = null; }, 0);
+  setInterval(function(){ EmscriptenCode = null; }, 0);
+  setInterval(function(){ EmscriptenCode = null; }, 0);
+
+  var asmJs = script('a.asm.js');
+  var js = script('a.js');
+  Promise.all([asmJs, js]).then((result) => {
+    var asmJs = result[0];
+    var js = result[1];
+    var emscriptenModuleConfig = {
+      asm: asmJs,
+      /* other Emscripten module configuration go here */
+      inputData: 1
+    };
+
+    // Run the page
+    js(emscriptenModuleConfig);
+
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'http://localhost:8888/report_result?' + emscriptenModuleConfig.weHaveExecutedSomeCCode);
+    xhr.send();
+    setTimeout(function() { window.close() }, 1000);
+  });
+</script>
+</body>
+</html>

--- a/tests/modularize_separate_asm.c
+++ b/tests/modularize_separate_asm.c
@@ -1,0 +1,7 @@
+#include <emscripten.h>
+
+int main()
+{
+	// Copy a field around to mark to JavaScript code that we have successfully completed the main() of this program.
+	EM_ASM(Module.weHaveExecutedSomeCCode = Module.inputData);
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4496,3 +4496,35 @@ window.close = function() {
   @requires_graphics_hardware
   def test_closure_in_web_only_target_environment_webgl(self):
     self.btest('webgl_draw_triangle.c', '0', args=['-lGL', '-s', 'ENVIRONMENT=web', '-O3', '--closure', '1'])
+
+  # Tests that it is possible to load two asm.js compiled programs to one page when both --separate-asm and MODULARIZE=1 is used, by assigning
+  # the pages different asm module names to ensure they do not conflict when being XHRed in.
+  @no_wasm_backend('this tests asm.js support')
+  def test_two_separate_asm_files_on_same_page(self):
+    html_file = open('main.html', 'w')
+    html_file.write(open(path_from_root('tests', 'two_separate_asm_files.html')).read().replace('localhost:8888', 'localhost:%s' % self.test_port))
+    html_file.close()
+
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'modularize_separate_asm.c'), '-o', 'page1.js', '-s', 'WASM=0', '--separate-asm', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=Module1', '-s', 'SEPARATE_ASM_MODULE_NAME=ModuleForPage1["asm"]']
+    print(cmd)
+    subprocess.check_call(cmd)
+
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'modularize_separate_asm.c'), '-o', 'page2.js', '-s', 'WASM=0', '--separate-asm', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=Module2', '-s', 'SEPARATE_ASM_MODULE_NAME=ModuleForPage2["asm"]']
+    print(cmd)
+    subprocess.check_call(cmd)
+
+    self.run_browser('main.html', None, '/report_result?1')
+
+  # Tests that it is possible to encapsulate asm.js compiled programs by using --separate-asm + MODULARIZE=1. See
+  # encapsulated_asmjs_page_load.html for the example.
+  @no_wasm_backend('this tests asm.js support')
+  def test_encapsulated_asmjs_page_load(self):
+    html_file = open('main.html', 'w')
+    html_file.write(open(path_from_root('tests', 'encapsulated_asmjs_page_load.html')).read().replace('localhost:8888', 'localhost:%s' % self.test_port))
+    html_file.close()
+
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'modularize_separate_asm.c'), '-o', 'a.js', '-s', 'WASM=0', '--separate-asm', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=EmscriptenCode', '-s', 'SEPARATE_ASM_MODULE_NAME="var EmscriptenCode"']
+    print(cmd)
+    subprocess.check_call(cmd)
+
+    self.run_browser('main.html', None, '/report_result?1')

--- a/tests/two_separate_asm_files.html
+++ b/tests/two_separate_asm_files.html
@@ -1,0 +1,54 @@
+<!doctype html><html lang="en-us"><head><meta charset="utf-8"></head>
+<body>
+<script>
+  var Module = {};
+
+  function script(url, cb) {
+    var s = document.createElement('script');
+    s.src = url;
+    s.onload = cb;
+    document.body.appendChild(s);
+  }
+
+  function clone(object) {
+    return Object.assign({}, object);
+  }
+
+  var page1RunSuccessfully = false;
+  var page2RunSuccessfully = false;
+  function testDone() {
+    if (page1RunSuccessfully && page2RunSuccessfully) {
+      console.error('test passed!');
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', 'http://localhost:8888/report_result?1');
+      xhr.send();
+      setTimeout(function() { window.close() }, 1000);
+    }
+  }
+
+  var ModuleForPage1 = clone(Module);
+  script('page1.asm.js', function() {
+    script('page1.js', function() {
+      ModuleForPage1.inputData = 1;
+      Module1(ModuleForPage1);
+      if (ModuleForPage1.weHaveExecutedSomeCCode) {
+        page1RunSuccessfully = true;
+        testDone();
+      }
+    });
+  });
+
+  var ModuleForPage2 = clone(Module);
+  script('page2.asm.js', function() {
+    script('page2.js', function() {
+      ModuleForPage2.inputData = 1;
+      Module2(ModuleForPage2);
+      if (ModuleForPage2.weHaveExecutedSomeCCode) {
+        page2RunSuccessfully = true;
+        testDone();
+      }
+    });
+  });
+</script>
+</body>
+</html>

--- a/tools/separate_asm.py
+++ b/tools/separate_asm.py
@@ -18,6 +18,7 @@ from tools import asm_module
 infile = sys.argv[1]
 asmfile = sys.argv[2]
 otherfile = sys.argv[3]
+asm_module_name = sys.argv[4] if len(sys.argv) >= 5 else 'Module["asm"]'
 
 everything = open(infile).read()
 module = asm_module.AsmModule(infile).asm_js
@@ -37,7 +38,7 @@ else:
   everything = everything.replace(module, closured_name + '["asm"]')
 
 o = open(asmfile, 'w')
-o.write('Module["asm"] = ')
+o.write(asm_module_name + ' = ')
 o.write(module)
 o.write(';')
 o.close()


### PR DESCRIPTION
Add setting -s SEPARATE_ASM_MODULE_NAME=xxx to allow controlling the name under which --separate-asm lookup is done. This is needed when two pages built with --separate-asm and -s MODULARIZE=1 are loaded to the same website to ensure that the --separate-asmed files do not conflict assigning to `Module['asm']`.

That is, even if one uses `-s MODULARIZE=1`, the .asm.js files would generate

```js
Module['asm'] =  (/** @suppress {uselessCode} */ function(global, env, buffer) {
...
});
```

which causes a conflict if two of these are XHRed in, since the scripts are always evaluated at global scope, so they will race to assign `Module['asm']`. With this, one can have one .asm.js file assign to e.g. `Module1['asm']` and another to `Module2['asm']` so that they will load conflict free.

With `-s SEPARATE_ASM_MODULE_NAME='ModuleForPage1["asm"]'` + `-s SEPARATE_ASM_MODULE_NAME='ModuleForPage2["asm"]'` one can build code that assigns the asm.js functions to right Modules from inside the asm.js files without a conflict. The provided test showcases this scheme.