### PR TITLE
Improve and document the issue with test_stack_varargs*

### DIFF
--- a/tests/core/test_stack_varargs.c
+++ b/tests/core/test_stack_varargs.c
@@ -17,7 +17,7 @@ void func(int i) {
       i, i, i, i, i, i, i, i, i, i, i, i, i, i);
 }
 int main() {
-  for (int i = 0; i < 2048; i++) func(i);
+  for (int i = 0; i < 4 * 1024; i++) func(i);
   printf("ok!\n");
   return 0;
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1404,7 +1404,7 @@ int main() {
     self.do_run_in_out_file_test('tests', 'core', 'test_stack_varargs')
 
   def test_stack_varargs2(self):
-    self.set_setting('TOTAL_STACK', 4096)
+    self.set_setting('TOTAL_STACK', 8 * 1024)
     src = r'''
       #include <stdio.h>
       #include <stdlib.h>
@@ -1412,7 +1412,7 @@ int main() {
       void func(int i) {
       }
       int main() {
-        for (int i = 0; i < 3072; i++) {
+        for (int i = 0; i < 7000; i++) {
           printf("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d\n",
                    i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i);
         }
@@ -1429,7 +1429,7 @@ int main() {
       #include <stdlib.h>
 
       int main() {
-        for (int i = 0; i < 3072; i++) {
+        for (int i = 0; i < 7000; i++) {
           int j = printf("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d",
                    i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i);
           printf(" (%d)\n", j);
@@ -1465,7 +1465,7 @@ int main() {
       }
 
       int main() {
-        for (int i = 0; i < 3072; i++) {
+        for (int i = 0; i < 7000; i++) {
           int j = printf("%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d,%d",
                    i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i, i);
           printf(" (%d)\n", j);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1398,12 +1398,20 @@ int main() {
     self.do_run_in_out_file_test('tests', 'core', 'test_stack_byval')
 
   def test_stack_varargs(self):
+    # in node.js we allocate argv[0] on the stack, which means the  length
+    # of the program directory influences how much stack we need, and so
+    # long random temp dir names can lead to random failures. The stack
+    # size was increased here to avoid that.
     self.set_setting('INLINING_LIMIT', 50)
-    self.set_setting('TOTAL_STACK', 4096)
+    self.set_setting('TOTAL_STACK', 8 * 1024)
 
     self.do_run_in_out_file_test('tests', 'core', 'test_stack_varargs')
 
   def test_stack_varargs2(self):
+    # in node.js we allocate argv[0] on the stack, which means the  length
+    # of the program directory influences how much stack we need, and so
+    # long random temp dir names can lead to random failures. The stack
+    # size was increased here to avoid that.
     self.set_setting('TOTAL_STACK', 8 * 1024)
     src = r'''
       #include <stdio.h>


### PR DESCRIPTION
I found out why these fail sometimes - in node.js, we set `argv[0]` to the native program being run. We allocate that on the stack (I guess to avoid a malloc). And so the filename of the program being run influences how much stack we use. As a result, if a random temp dir is used with a particularly long name, we can error in tests that check for not exceeding a minimal amount of stack usage.

Amusingly, in particular this explains why I couldn't see it locally, where I run with `EMTEST_SAVE_DIR` - that makes it use a standard (short) test dir name, not a random one which might be long...

I doubled the amount of stack we allow in those tests (they check that loops don't increase stack space unboundedly), which should make them ok even with a path name of a few K now, and documented it to avoid future confusion should they fail again.