### PR TITLE
Fix test_exceptions_white_list_2 with llvm backend

### DIFF
--- a/tests/core/test_exceptions_white_list_2.c
+++ b/tests/core/test_exceptions_white_list_2.c
@@ -22,7 +22,7 @@ void nocatch(void) {
     }
 }
 
-int main(void) {
+int main(int argc, char* argv[]) {
     try {
         nocatch();
     }


### PR DESCRIPTION
The main function was being re-written by llvm to __original_main.
Update the signature of main to avoid the re-writing.