### PR TITLE
Skip test_unistd_truncate_noderawfs which fails on some node versions

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4909,6 +4909,9 @@ name: .
   @no_windows("Windows throws EPERM rather than EACCES or EINVAL")
   @unittest.skipIf(WINDOWS or os.geteuid() == 0, "Root access invalidates this test by being able to write on readonly files")
   def test_unistd_truncate_noderawfs(self):
+    # FIXME
+    self.skipTest('fails on some node versions and OSes, e.g. 10.13.0 on linux')
+
     self.emcc_args += ['-s', 'NODERAWFS=1']
     test_path = path_from_root('tests', 'unistd', 'truncate')
     src, output = (test_path + s for s in ('.c', '.out'))


### PR DESCRIPTION
In general NODERAWFS looks like it needs more work.