### PR TITLE
Strip the wasm producers section by default

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1362,7 +1362,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if shared.Settings.GLOBAL_BASE >= 1024: # hardcoded value in the binaryen pass
             passes += ['--post-emscripten']
           if options.debug_level < 3:
-            passes += ['--strip']
+            passes += ['--strip-debug']
+          if not shared.Settings.EMIT_PRODUCERS_SECTION:
+            passes += ['--strip-producers']
           if passes:
             shared.Settings.BINARYEN_PASSES = ','.join(passes)
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1064,6 +1064,16 @@ var BINARYEN_ASYNC_COMPILATION = 1;
 // you can set it to override if you are a Binaryen developer.
 var BINARYEN_ROOT = "";
 
+// WebAssembly defines a "producers section" which compilers and tools can
+// annotate themselves in. Emscripten does not emit this by default, as it
+// increases code size, and some users may not want information about their tools
+// to be included in their builds for privacy or security reasons, see
+// https://github.com/WebAssembly/tool-conventions/issues/93.
+// TODO: currently this flag just controls whether we run the binaryen pass
+//       to strip it out from the wasm (where the LLVM wasm backend may have
+//       created it)
+var EMIT_PRODUCERS_SECTION = 0;
+
 // Whether to legalize the JS FFI interfaces (imports/exports) by wrapping them
 // to automatically demote i64 to i32 and promote f32 to f64. This is necessary
 // in order to interface with JavaScript, both for asm.js and wasm.  For

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7909,7 +7909,7 @@ int main() {
         (['-Oz'],  5, [],         [],        3309,  7,   2, 14), # noqa
         # finally, check what happens when we export nothing. wasm should be almost empty
         (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                   0, [],         [],        None,  0,   1,  1), # noqa; FIXME: should be almost totally empty! see https://github.com/WebAssembly/binaryen/pull/1875
+                   0, [],         [],          61,  0,   1,  1), # noqa
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')
@@ -8389,6 +8389,19 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
     output = open('a.out.wasm.map').read()
     # has only two entries
     self.assertRegexpMatches(output, r'"mappings":\s*"[A-Za-z0-9+/]+,[A-Za-z0-9+/]+"')
+
+  def test_wasm_producers_section(self):
+    # no producers section by default
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
+    with open('a.out.wasm') as f:
+      assert 'clang' not in f.read()
+    size = os.path.getsize('a.out.wasm')
+    if self.is_wasm_backend():
+      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EMIT_PRODUCERS_SECTION=1'])
+      with open('a.out.wasm') as f:
+        assert 'clang' in f.read()
+      size_with_section = os.path.getsize('a.out.wasm')
+      self.assertLess(size, size_with_section)
 
   def test_html_preprocess(self):
     test_file = path_from_root('tests', 'module', 'test_stdin.c')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8393,13 +8393,13 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
   def test_wasm_producers_section(self):
     # no producers section by default
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
-    with open('a.out.wasm') as f:
-      self.assertNotIn('clang', f.read())
+    with open('a.out.wasm', 'rb') as f:
+      self.assertNotIn('clang', str(f.read()))
     size = os.path.getsize('a.out.wasm')
     if self.is_wasm_backend():
       run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EMIT_PRODUCERS_SECTION=1'])
-      with open('a.out.wasm') as f:
-        self.assertIn('clang', f.read())
+      with open('a.out.wasm', 'rb') as f:
+        self.assertIn('clang', str(f.read()))
       size_with_section = os.path.getsize('a.out.wasm')
       self.assertLess(size, size_with_section)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8394,12 +8394,12 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
     # no producers section by default
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
     with open('a.out.wasm') as f:
-      assert 'clang' not in f.read()
+      self.assertNotIn('clang', f.read())
     size = os.path.getsize('a.out.wasm')
     if self.is_wasm_backend():
       run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EMIT_PRODUCERS_SECTION=1'])
       with open('a.out.wasm') as f:
-        assert 'clang' in f.read()
+        self.assertIn('clang', f.read())
       size_with_section = os.path.getsize('a.out.wasm')
       self.assertLess(size, size_with_section)
 

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -5,7 +5,7 @@
 
 import os, shutil, logging
 
-TAG = 'version_66'
+TAG = 'version_67'
 
 def needed(settings, shared, ports):
   if not settings.WASM:


### PR DESCRIPTION
Update binaryen to get the pass. Also use `--strip-debug` for debug (the old `--strip` means the same, but is less specific). See https://github.com/WebAssembly/binaryen/pull/1875

This lets us re-enable part of the metadce test (where the producers section was skewing the size of a tiny binary).