### PR TITLE
Mouse wheel delta adjustments

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -382,3 +382,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Kai Ninomiya <kainino@chromium.org> (copyright owned by Google, Inc.)
 * Mickaël Schoentgen <contact@tiger-222.fr>
 * Renaud Leroy <capitnflam@gmail.com>
+* Florian Stellbrink <florian@stellbr.ink>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,8 @@ full changeset diff at the end of each section.
 
 Current Trunk
 -------------
+ - Normalize mouse wheel delta in `library_browser.js`. This changes the scroll
+   amount in SDL, GLFW, and GLUT. (#7968)
 
 v1.38.27: 02/10/2019
 --------------------

--- a/tests/test_sdl_mousewheel.c
+++ b/tests/test_sdl_mousewheel.c
@@ -32,8 +32,8 @@ int gotWheelClick = 0;
 
 void instruction()
 {
-  if (!gotWheelUp || !gotWheelButtonUp) printf("Please scroll the mouse wheel upwards (move your finger away from you towards the display).\n");
-  else if (!gotWheelDown || !gotWheelButtonDown) printf("Please scroll the mouse wheel downwards (move your finger towards you).\n");
+  if (!gotWheelUp || !gotWheelButtonUp) printf("Please scroll the mouse wheel upwards by a single notch (slowly move your finger away from you towards the display).\n");
+  else if (!gotWheelDown || !gotWheelButtonDown) printf("Please scroll the mouse wheel downwards by a single notch (slowly move your finger towards you).\n");
   else if (!gotWheelClick) printf("Please click the wheel button.\n");
   else if (gotWheelUp && gotWheelButtonUp && gotWheelDown && gotWheelButtonDown && gotWheelClick) report_result(0);
 }
@@ -47,12 +47,14 @@ void main_tick()
         printf("SDL_MOUSEWHEEL: timestamp: %u, windowID: %u, which: %u, x: %d, y: %d\n", event.wheel.timestamp, event.wheel.windowID, event.wheel.which, event.wheel.x, event.wheel.y);
         if (!gotWheelUp)
         {
-          if (event.wheel.y > 0) { gotWheelUp = 1; instruction(); }
+          if (event.wheel.y > 0 && event.wheel.y < 2) { gotWheelUp = 1; instruction(); }
+          else if (event.wheel.y >= 2) { printf("The scroll amount was too large. Either you scrolled very fast or the normalization is not working."); report_result(1); }
           else if (event.wheel.y < 0) { printf("You scrolled to the wrong direction (downwards)!\n"); report_result(1); }
         }
         else if (!gotWheelDown)
         {
-          if (event.wheel.y < 0) { gotWheelDown = 1; instruction(); }
+          if (event.wheel.y < 0 && event.wheel.y > -2) { gotWheelDown = 1; instruction(); }
+          else if (event.wheel.y <= -2) { printf("The scroll amount was too large. Either you scrolled very fast or the normalization is not working."); report_result(1); }
         }
         break;
       case SDL_MOUSEBUTTONDOWN:


### PR DESCRIPTION
### Description

Right now the mouse wheel delta is not scaled properly. See #6283 for a discussion of this issue.

This pull request handles all event types and modes separately. All units are converted into steps, i.e. wheel notches.

### Testing

Unfortunately I don't know how to automatically test this behavior.
I have manually tested this on Windows 10 with Chrome, Firefox, Edge, and IE11.

- For Chrome the value depends on the system scaling (100% -> 1 step, 150% -> 1,5 steps).
- All other browsers return exactly one step for mouse wheel notches, and look reasonable for touchpad scrolling.

You can use the following snippet to test this in isolation:

``` html
<html>
  <script src="index.js"></script>
</html>
```

``` js
window.addEventListener("wheel", testNormalize, true);
window.addEventListener("mousewheel", testNormalize, true);
window.addEventListener("DOMMouseScroll", testNormalize, true);

function testNormalize(event) {
  console.log(getMouseWheelDelta(event));
}
```