### PR TITLE
Log out commands in run_process, and not just in check_call

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -172,8 +172,7 @@ def run_process(cmd, check=True, input=None, universal_newlines=True, *args, **k
 
 def check_call(cmd, *args, **kw):
   try:
-    proc = run_process(cmd, *args, **kw)
-    return proc
+    return run_process(cmd, *args, **kw)
   except subprocess.CalledProcessError as e:
     exit_with_error("'%s' failed (%d)", ' '.join(cmd), e.returncode)
   except OSError as e:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -164,13 +164,15 @@ def run_process(cmd, check=True, input=None, universal_newlines=True, *args, **k
   result = Py2CompletedProcess(cmd, proc.returncode, stdout, stderr)
   if check:
     result.check_returncode()
+    logger.debug('Successfully executed %s' % ' '.join(cmd))
+  else:
+    logger.debug('Executed %s' % ' '.join(cmd))
   return result
 
 
 def check_call(cmd, *args, **kw):
   try:
     proc = run_process(cmd, *args, **kw)
-    logger.debug('Successfully executed %s' % ' '.join(cmd))
     return proc
   except subprocess.CalledProcessError as e:
     exit_with_error("'%s' failed (%d)", ' '.join(cmd), e.returncode)


### PR DESCRIPTION
`check_call` calls run_process, so this adds logging to more processes, making EMCC_DEBUG output more complete.