### PR TITLE
Optimize JS library aliases

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1769,16 +1769,19 @@ LibraryManager.library = {
   llvm_exp2_f32: function(x) {
     return Math.pow(2, x);
   },
+  llvm_exp2_f64__sig: 'dd',
   llvm_exp2_f64: 'llvm_exp2_f32',
 
   llvm_log2_f32: function(x) {
     return Math.log(x) / Math.LN2; // TODO: Math.log2, when browser support is there
   },
+  llvm_log2_f64__sig: 'dd',
   llvm_log2_f64: 'llvm_log2_f32',
 
   llvm_log10_f32: function(x) {
     return Math.log(x) / Math.LN10; // TODO: Math.log10, when browser support is there
   },
+  llvm_log10_f64__sig: 'dd',
   llvm_log10_f64: 'llvm_log10_f32',
 
   llvm_copysign_f32: function(x, y) {
@@ -2994,6 +2997,7 @@ LibraryManager.library = {
     {{{ makeSetValue('tp', C_STRUCTS.timespec.tv_nsec, '((now % 1000)*1000*1000)|0', 'i32') }}}; // nanoseconds
     return 0;
   },
+  __clock_gettime__sig: 'iii',
   __clock_gettime: 'clock_gettime', // musl internal alias
   clock_settime__deps: ['__setErrNo'],
   clock_settime: function(clk_id, tp) {

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2129,8 +2129,13 @@ var LibraryJSEvents = {
   _emscripten_webgl_power_preferences: "['default', 'low-power', 'high-performance']",
 
 #if !USE_PTHREADS
+  emscripten_webgl_create_context__sig: 'iii',
   emscripten_webgl_create_context: 'emscripten_webgl_do_create_context',
+
+  emscripten_webgl_get_current_context__sig: 'i',
   emscripten_webgl_get_current_context: 'emscripten_webgl_do_get_current_context',
+
+  emscripten_webgl_commit_frame__sig: 'i',
   emscripten_webgl_commit_frame: 'emscripten_webgl_do_commit_frame',
 #endif
 
@@ -2306,6 +2311,7 @@ var LibraryJSEvents = {
     else _emscripten_webgl_get_drawing_buffer_size_main_thread(contextHandle, width, height);
   },
 #else
+  emscripten_webgl_get_drawing_buffer_size__sig: 'iiii',
   emscripten_webgl_get_drawing_buffer_size: 'emscripten_webgl_get_drawing_buffer_size_calling_thread',
 #endif
 
@@ -2392,6 +2398,7 @@ var LibraryJSEvents = {
     return GL.contexts[contextHandle] ? _emscripten_webgl_destroy_context_calling_thread(contextHandle) : _emscripten_webgl_destroy_context_main_thread(contextHandle);
   },
 #else
+  emscripten_webgl_destroy_context__sig: 'vi',
   emscripten_webgl_destroy_context: 'emscripten_webgl_destroy_context_calling_thread',
 #endif
 
@@ -2422,6 +2429,7 @@ var LibraryJSEvents = {
     return GL.contexts[contextHandle] ? _emscripten_webgl_enable_extension_calling_thread(contextHandle, extension) : _emscripten_webgl_enable_extension_main_thread(contextHandle, extension);
   },
 #else
+  emscripten_webgl_enable_extension__sig: 'iii',
   emscripten_webgl_enable_extension: 'emscripten_webgl_enable_extension_calling_thread',
 #endif
 

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -169,7 +169,10 @@ var LibraryPThreadStub = {
     _pthread_cleanup_push.level = __ATEXIT__.length;
   },
 
+  _pthread_cleanup_push__sig: 'vii',
   _pthread_cleanup_push: 'pthread_cleanup_push',
+
+  _pthread_cleanup_pop__sig: 'v',
   _pthread_cleanup_pop: 'pthread_cleanup_pop',
 
   pthread_sigmask: function() { return 0; },
@@ -343,15 +346,34 @@ var LibraryPThreadStub = {
     {{{ makeStructuralReturn(['l', 'h']) }}};
   },
 
+  emscripten_atomic_add_u32__sig: 'iii',
   emscripten_atomic_add_u32: 'llvm_atomic_load_add_i32_p0i32',
+
+  emscripten_atomic_load_u64__sig: 'iii',
   emscripten_atomic_load_u64: '__atomic_load_8',
+
+  emscripten_atomic_store_u64__sig: 'viiii',
   emscripten_atomic_store_u64: '__atomic_store_8',
+
+  emscripten_atomic_cas_u64__sig: 'iiiiiiii',
   emscripten_atomic_cas_u64: '__atomic_compare_exchange_8',
+
+  emscripten_atomic_exchange_u64__sig: 'iiiii',
   emscripten_atomic_exchange_u64: '__atomic_exchange_8',
+
+  _emscripten_atomic_fetch_and_add_u64__sig: 'iiiii',
   _emscripten_atomic_fetch_and_add_u64: '__atomic_fetch_add_8',
+
+  _emscripten_atomic_fetch_and_sub_u64__sig: 'iiiii',
   _emscripten_atomic_fetch_and_sub_u64: '__atomic_fetch_sub_8',
+
+  _emscripten_atomic_fetch_and_and_u64__sig: 'iiiii',
   _emscripten_atomic_fetch_and_and_u64: '__atomic_fetch_and_8',
+
+  _emscripten_atomic_fetch_and_or_u64__sig: 'iiiii',
   _emscripten_atomic_fetch_and_or_u64: '__atomic_fetch_or_8',
+
+  _emscripten_atomic_fetch_and_xor_u64__sig: 'iiiii',
   _emscripten_atomic_fetch_and_xor_u64: '__atomic_fetch_xor_8',
 
   __wait: function() {},

--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -140,6 +140,7 @@ var funs = {
     _longjmp(env, value);
   },
 #else
+  siglongjmp__sig: 'vii',
   siglongjmp: 'longjmp',
 #endif
   sigpending: function(set) {

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -861,8 +861,11 @@ var SyscallsLibrary = {
     var stream = SYSCALLS.getStreamFromFD();
     return 0; // we can't do anything synchronously; the in-memory FS is already synced to
   },
+  __syscall150__sig: 'iii',
   __syscall150: '__syscall153',     // mlock
+  __syscall151__sig: 'iii',
   __syscall151: '__syscall153',     // munlock
+  __syscall152__sig: 'iii',
   __syscall152: '__syscall153',     // mlockall
   __syscall153: function(which, varargs) { // munlockall
     return 0;
@@ -972,8 +975,11 @@ var SyscallsLibrary = {
     FS.chown(path, owner, group); // XXX we ignore the 'l' aspect, and do the same as chown
     return 0;
   },
+  __syscall199__sig: 'iii',
   __syscall199: '__syscall202',     // getuid32
+  __syscall200__sig: 'iii',
   __syscall200: '__syscall202',     // getgid32
+  __syscall201__sig: 'iii',
   __syscall201: '__syscall202',     // geteuid32
   __syscall202: function(which, varargs) { // getgid32
     return 0;
@@ -988,8 +994,11 @@ var SyscallsLibrary = {
     FS.chown(path, owner, group);
     return 0;
   },
+  __syscall203__sig: 'iii',
   __syscall203: '__syscall214',     // setreuid32
+  __syscall204__sig: 'iii',
   __syscall204: '__syscall214',     // setregid32
+  __syscall213__sig: 'iii',
   __syscall213: '__syscall214',     // setuid32
   __syscall214: function(which, varargs) { // setgid32
     var uid = SYSCALLS.get();
@@ -1002,12 +1011,14 @@ var SyscallsLibrary = {
     {{{ makeSetValue('list', '0', '0', 'i32') }}};
     return 1;
   },
+  __syscall208__sig: 'iii',
   __syscall208: '__syscall210',     // setresuid32
   __syscall210: function(which, varargs) { // setresgid32
     var ruid = SYSCALLS.get(), euid = SYSCALLS.get(), suid = SYSCALLS.get();
     if (euid !== 0) return -ERRNO_CODES.EPERM;
     return 0;
   },
+  __syscall209__sig: 'iii',
   __syscall209: '__syscall211',     // getresuid
   __syscall211: function(which, varargs) { // getresgid32
 #if SYSCALL_DEBUG


### PR DESCRIPTION
Add support for generating optimized JS library function aliases that allow Closure to inline the alias functions away altogether. Optimizes -47 bytes (-0.83%) in minimal WebGL demo.