### PR TITLE
Optimize code size of UTF8ToString()

### DIFF
--- a/src/runtime_strings.js
+++ b/src/runtime_strings.js
@@ -148,7 +148,14 @@ function UTF8ArrayToString(u8Array, idx, maxBytesToRead) {
  * @return {string}
  */
 function UTF8ToString(ptr, maxBytesToRead) {
-  return ptr ? UTF8ArrayToString({{{ heapAndOffset('HEAPU8', 'ptr') }}}, maxBytesToRead) : '';
+#if TEXTDECODER == 2
+  if (!ptr) return '';
+  var maxPtr = ptr + maxBytesToRead;
+  for(var end = ptr; !(end >= maxPtr) && HEAPU8[end];) ++end;
+  return UTF8Decoder.decode(HEAPU8.subarray(ptr, end));
+#else
+  return ptr ? UTF8ArrayToString(HEAPU8, ptr, maxBytesToRead) : '';
+#endif
 }
 
 // Copies the given Javascript String object 'str' to the given byte array at address 'outIdx',


### PR DESCRIPTION
Optimize code size (and performance) of UTF8ToString() specifically for the case when TEXTDECODER==2. `UTF8ArrayToString()` no longer knows if it's being called with typed arrays or regular arrays, and hence has to do a check if subarray exists or not on whatever was passed to it. This information is still present in `UTF8ToString()` function which only deals with a typed array, so it can unconditionally call .subarray() on it.