### PR TITLE
Remove assert from being imported into asm.js/wasm

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1450,7 +1450,7 @@ function ftCall_%s(%s) {%s
 
 
 def create_basic_funcs(function_table_sigs, invoke_function_names):
-  basic_funcs = ['abort', 'assert', 'setTempRet0', 'getTempRet0']
+  basic_funcs = ['abort', 'setTempRet0', 'getTempRet0']
   if shared.Settings.STACK_OVERFLOW_CHECK:
     basic_funcs += ['abortStackOverflow']
   if shared.Settings.EMTERPRETIFY:
@@ -2160,7 +2160,7 @@ def create_em_js(forwarded_json, metadata):
 
 
 def create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json, metadata):
-  basic_funcs = ['assert']
+  basic_funcs = []
   if shared.Settings.SAFE_HEAP:
     basic_funcs += ['segfault', 'alignfault']
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -98,7 +98,7 @@ mergeInto(LibraryManager.library, {
     //  just undo a recent emscripten_alloc_async_context
     ctx = ctx|0;
 #if ASSERTIONS
-    assert((((___async_cur_frame + 8)|0) == (ctx|0))|0);
+    if ((((___async_cur_frame + 8)|0) != (ctx|0))|0) abort();
 #endif
     stackRestore(___async_cur_frame | 0);
     ___async_cur_frame = {{{ makeGetValueAsm('___async_cur_frame', 0, 'i32') }}};

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7907,9 +7907,9 @@ int main() {
 
       print('test on hello world')
       test(path_from_root('tests', 'hello_world.cpp'), [
-        ([],      16, [], ['waka'], 33171, 10,  15, 69), # noqa
-        (['-O1'], 14, [], ['waka'], 14720,  8,  14, 28), # noqa
-        (['-O2'], 14, [], ['waka'], 14569,  8,  14, 24), # noqa
+        ([],      16, [], ['waka'], 33171, 10,  15, 70), # noqa
+        (['-O1'], 14, [], ['waka'], 14720,  8,  14, 29), # noqa
+        (['-O2'], 14, [], ['waka'], 14569,  8,  14, 25), # noqa
         (['-O3'],  5, [], [],        3395,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
         (['-Os'],  5, [], [],        3350,  7,   3, 15), # noqa
         (['-Oz'],  5, [], [],        3309,  7,   2, 14), # noqa
@@ -7920,9 +7920,9 @@ int main() {
 
       print('test on a minimal pure computational thing')
       test('minimal.c', [
-        ([],      16, [], ['waka'], 14567,  9, 15, 24), # noqa
-        (['-O1'],  9, [], ['waka'], 11255,  2, 12, 10), # noqa
-        (['-O2'],  9, [], ['waka'], 11255,  2, 12, 10), # noqa
+        ([],      16, [], ['waka'], 14567,  9, 15, 25), # noqa
+        (['-O1'],  9, [], ['waka'], 11255,  2, 12, 11), # noqa
+        (['-O2'],  9, [], ['waka'], 11255,  2, 12, 11), # noqa
         # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
         (['-O3'],  0, [], [],        None,  0,  1,  1), # noqa FIXME see https://github.com/WebAssembly/binaryen/pull/1875
         (['-Os'],  0, [], [],        None,  0,  1,  1), # noqa FIXME see https://github.com/WebAssembly/binaryen/pull/1875
@@ -7931,9 +7931,9 @@ int main() {
 
       print('test on libc++: see effects of emulated function pointers')
       test(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 39, [], ['waka'], 348370,  27,  224, 727), # noqa
+        (['-O2'], 39, [], ['waka'], 348370,  27,  224, 728), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  39, [], ['waka'], 348249,  27,  224, 727), # noqa
+                  39, [], ['waka'], 348249,  27,  224, 728), # noqa
       ], size_slack) # noqa
 
   # ensures runtime exports work, even with metadce

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7909,7 +7909,7 @@ int main() {
       test(path_from_root('tests', 'hello_world.cpp'), [
         ([],      16, [], ['waka'], 33171, 10,  15, 70), # noqa
         (['-O1'], 14, [], ['waka'], 14720,  8,  14, 29), # noqa
-        (['-O2'], 14, [], ['waka'], 14569,  8,  14, 25), # noqa
+        (['-O2'], 14, [], ['waka'], 14569,  8,  14, 24), # noqa
         (['-O3'],  5, [], [],        3395,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
         (['-Os'],  5, [], [],        3350,  7,   3, 15), # noqa
         (['-Oz'],  5, [], [],        3309,  7,   2, 14), # noqa
@@ -7920,9 +7920,9 @@ int main() {
 
       print('test on a minimal pure computational thing')
       test('minimal.c', [
-        ([],      16, [], ['waka'], 14567,  9, 15, 25), # noqa
-        (['-O1'],  9, [], ['waka'], 11255,  2, 12, 11), # noqa
-        (['-O2'],  9, [], ['waka'], 11255,  2, 12, 11), # noqa
+        ([],      16, [], ['waka'], 14567,  9, 15, 24), # noqa
+        (['-O1'],  9, [], ['waka'], 11255,  2, 12, 10), # noqa
+        (['-O2'],  9, [], ['waka'], 11255,  2, 12, 10), # noqa
         # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
         (['-O3'],  0, [], [],        None,  0,  1,  1), # noqa FIXME see https://github.com/WebAssembly/binaryen/pull/1875
         (['-Os'],  0, [], [],        None,  0,  1,  1), # noqa FIXME see https://github.com/WebAssembly/binaryen/pull/1875

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7870,36 +7870,36 @@ int main() {
 
       print('test on hello world')
       test(path_from_root('tests', 'hello_world.cpp'), [
-        ([],      21, ['assert'], ['waka'], 46505,  22,   15, 58), # noqa
-        (['-O1'], 16, ['assert'], ['waka'], 12630,  14,   13, 30), # noqa
-        (['-O2'], 16, ['assert'], ['waka'], 12616,  14,   13, 30), # noqa
-        (['-O3'],  6, [],         [],        2690,   9,    2, 21), # noqa; in -O3, -Os and -Oz we metadce
-        (['-Os'],  6, [],         [],        2690,   9,    2, 21), # noqa
-        (['-Oz'],  6, [],         [],        2690,   9,    2, 21), # noqa
+        ([],      20, ['abort'], ['waka'], 46505,  22,   15, 58), # noqa
+        (['-O1'], 15, ['abort'], ['waka'], 12630,  14,   13, 30), # noqa
+        (['-O2'], 15, ['abort'], ['waka'], 12616,  14,   13, 30), # noqa
+        (['-O3'],  6, [],        [],        2690,   9,    2, 21), # noqa; in -O3, -Os and -Oz we metadce
+        (['-Os'],  6, [],        [],        2690,   9,    2, 21), # noqa
+        (['-Oz'],  6, [],        [],        2690,   9,    2, 21), # noqa
         # finally, check what happens when we export nothing. wasm should be almost empty
         (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                   0, [],         [],           8,   0,    0,  0), # noqa; totally empty!
+                   0, [],        [],           8,   0,    0,  0), # noqa; totally empty!
         # we don't metadce with linkable code! other modules may want stuff
         (['-O3', '-s', 'MAIN_MODULE=1'],
-                1557, [],         [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
+                1556, [],        [],      226057,  28,   75, None), # noqa; don't compare the # of functions in a main module, which changes a lot
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')
       test('minimal.c', [
-        ([],      21, ['assert'], ['waka'], 22712, 22, 14, 27), # noqa
-        (['-O1'], 11, ['assert'], ['waka'], 10450,  7, 11, 11), # noqa
-        (['-O2'], 11, ['assert'], ['waka'], 10440,  7, 11, 11), # noqa
+        ([],      20, ['abort'], ['waka'], 22712, 22, 14, 27), # noqa
+        (['-O1'], 10, ['abort'], ['waka'], 10450,  7, 11, 11), # noqa
+        (['-O2'], 10, ['abort'], ['waka'], 10440,  7, 11, 11), # noqa
         # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-        (['-O3'],  0, [],         [],          55,  0,  1, 1), # noqa
-        (['-Os'],  0, [],         [],          55,  0,  1, 1), # noqa
-        (['-Oz'],  0, [],         [],          55,  0,  1, 1), # noqa
+        (['-O3'],  0, [],        [],          55,  0,  1, 1), # noqa
+        (['-Os'],  0, [],        [],          55,  0,  1, 1), # noqa
+        (['-Oz'],  0, [],        [],          55,  0,  1, 1), # noqa
       ], size_slack)
 
       print('test on libc++: see effects of emulated function pointers')
       test(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 35, ['assert'], ['waka'], 196709,  28,   39, 659), # noqa
+        (['-O2'], 34, ['abort'], ['waka'], 196709,  28,   39, 659), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  35, ['assert'], ['waka'], 196709,  28,   20, 620), # noqa
+                  34, ['abort'], ['waka'], 196709,  28,   20, 620), # noqa
       ], size_slack) # noqa
     else:
       # wasm-backend
@@ -7907,33 +7907,33 @@ int main() {
 
       print('test on hello world')
       test(path_from_root('tests', 'hello_world.cpp'), [
-        ([],      17, ['assert'], ['waka'], 33171, 10,  15, 70), # noqa
-        (['-O1'], 15, ['assert'], ['waka'], 14720,  8,  14, 29), # noqa
-        (['-O2'], 15, ['assert'], ['waka'], 14569,  8,  14, 24), # noqa
-        (['-O3'],  5, [],         [],        3395,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
-        (['-Os'],  5, [],         [],        3350,  7,   3, 15), # noqa
-        (['-Oz'],  5, [],         [],        3309,  7,   2, 14), # noqa
+        ([],      16, [], ['waka'], 33171, 10,  15, 69), # noqa
+        (['-O1'], 14, [], ['waka'], 14720,  8,  14, 28), # noqa
+        (['-O2'], 14, [], ['waka'], 14569,  8,  14, 24), # noqa
+        (['-O3'],  5, [], [],        3395,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
+        (['-Os'],  5, [], [],        3350,  7,   3, 15), # noqa
+        (['-Oz'],  5, [], [],        3309,  7,   2, 14), # noqa
         # finally, check what happens when we export nothing. wasm should be almost empty
         (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                   0, [],         [],          61,  0,   1,  1), # noqa
+                   0, [], [],          61,  0,   1,  1), # noqa
       ], size_slack) # noqa
 
       print('test on a minimal pure computational thing')
       test('minimal.c', [
-        ([],      17, ['assert'], ['waka'], 14567,  9, 15, 24), # noqa
-        (['-O1'], 10, ['assert'], ['waka'], 11255,  2, 12, 10), # noqa
-        (['-O2'], 10, ['assert'], ['waka'], 11255,  2, 12, 10), # noqa
+        ([],      16, [], ['waka'], 14567,  9, 15, 24), # noqa
+        (['-O1'],  9, [], ['waka'], 11255,  2, 12, 10), # noqa
+        (['-O2'],  9, [], ['waka'], 11255,  2, 12, 10), # noqa
         # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-        (['-O3'],  0, [],         [],        None,  0,  1,  1), # noqa FIXME see https://github.com/WebAssembly/binaryen/pull/1875
-        (['-Os'],  0, [],         [],        None,  0,  1,  1), # noqa FIXME see https://github.com/WebAssembly/binaryen/pull/1875
-        (['-Oz'],  0, [],         [],        None,  0,  0,  0), # noqa XXX wasm backend ignores EMSCRIPTEN_KEEPALIVE https://github.com/emscripten-core/emscripten/issues/6233
+        (['-O3'],  0, [], [],        None,  0,  1,  1), # noqa FIXME see https://github.com/WebAssembly/binaryen/pull/1875
+        (['-Os'],  0, [], [],        None,  0,  1,  1), # noqa FIXME see https://github.com/WebAssembly/binaryen/pull/1875
+        (['-Oz'],  0, [], [],        None,  0,  0,  0), # noqa XXX wasm backend ignores EMSCRIPTEN_KEEPALIVE https://github.com/emscripten-core/emscripten/issues/6233
       ], size_slack)
 
       print('test on libc++: see effects of emulated function pointers')
       test(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 40, ['assert'], ['waka'], 348370,  27,  224, 728), # noqa
+        (['-O2'], 39, [], ['waka'], 348370,  27,  224, 727), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  40, ['assert'], ['waka'], 348249,  27,  224, 728), # noqa
+                  39, [], ['waka'], 348249,  27,  224, 727), # noqa
       ], size_slack) # noqa
 
   # ensures runtime exports work, even with metadce


### PR DESCRIPTION
We should not call out into JS to do a check, as that is silly and slow.

The users were the async code - rewrote those to do the checks in asm/wasm.