### PR TITLE
dont_force_filesystem_in_pthreads

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1195,7 +1195,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.TEXTDECODER = 0
       options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
       newargs.append('-D__EMSCRIPTEN_PTHREADS__=1')
-      shared.Settings.FORCE_FILESYSTEM = 1 # proxying of utime requires the filesystem
       # set location of worker.js
       shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
     else:


### PR DESCRIPTION
Do not force filesystem to be enabled when building with -s USE_PTHREADS=1 (#8001)