### PR TITLE
fix_emscripten_is_webgl_context_lost

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2037,13 +2037,13 @@ Functions
   :rtype: |EMSCRIPTEN_RESULT|
 
 
-.. c:function:: EM_BOOL emscripten_is_webgl_context_lost(const char *target)
+.. c:function:: EM_BOOL emscripten_is_webgl_context_lost(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context)
 
-  Queries the given canvas element for whether its WebGL context is in a lost state.
+  Queries the given WebGL context if it is in a lost context state.
 
-  :param target: Reserved for future use, pass in 0.
-  :type target: const char*
-  :returns: ``true`` if the WebGL context is in a lost state.
+  :param target: Specifies a handle to the context to test.
+  :type target: EMSCRIPTEN_WEBGL_CONTEXT_HANDLE
+  :returns: ``true`` if the WebGL context is in a lost state (or the context does not exist)
   :rtype: |EM_BOOL|
 
 

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -473,7 +473,7 @@ typedef EM_BOOL (*em_webgl_context_callback)(int eventType, const void *reserved
 extern EMSCRIPTEN_RESULT emscripten_set_webglcontextlost_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
 extern EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
 
-extern EM_BOOL emscripten_is_webgl_context_lost(const char *target);
+extern EM_BOOL emscripten_is_webgl_context_lost(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
 extern EMSCRIPTEN_RESULT emscripten_webgl_commit_frame(void);
 


### PR DESCRIPTION
Fix buggy signature and documentation of emscripten_is_webgl_context_lost(). The lost state is a property of a context, and not the canvas.

Given the signature was just horribly wrong, it makes me wonder if this has ever been useful at all.