### PR TITLE
javascript_mime_type

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2883,7 +2883,7 @@ def generate_html(target, options, js_target, target_basename,
         }
       }
       %s
-      var blob = new Blob([code], { type: 'text/javascript' });
+      var blob = new Blob([code], { type: 'application/javascript' });
       codeXHR = null;
       var src = URL.createObjectURL(blob);
       var script = document.createElement('script');

--- a/emrun.py
+++ b/emrun.py
@@ -512,6 +512,8 @@ class HTTPHandler(SimpleHTTPRequestHandler):
     ctype = self.guess_type(guess_file_type)
     if guess_file_type.lower().endswith('.wasm'):
       ctype = 'application/wasm'
+    if guess_file_type.lower().endswith('.js'):
+      ctype = 'application/javascript'
     self.send_header("Content-type", ctype)
     fs = os.fstat(f.fileno())
     self.send_header("Content-Length", str(fs[6]))

--- a/src/library_trace.js
+++ b/src/library_trace.js
@@ -60,7 +60,7 @@ var LibraryTracing = {
     loadWorkerViaXHR: function(url, ready, scope) {
       var req = new XMLHttpRequest();
       req.addEventListener('load', function() {
-        var blob = new Blob([this.responseText], { type: 'text/javascript' });
+        var blob = new Blob([this.responseText], { type: 'application/javascript' });
         var worker = new Worker(window.URL.createObjectURL(blob));
         if (ready) {
           ready.call(scope, worker);

--- a/tests/manual_download_data.html
+++ b/tests/manual_download_data.html
@@ -160,7 +160,7 @@
       function addScriptToDom(scriptCode) {
         return new Promise(function(resolve, reject) {
           var script = document.createElement('script');
-          var blob = new Blob([scriptCode], { type: 'text/javascript' });
+          var blob = new Blob([scriptCode], { type: 'application/javascript' });
           var objectUrl = URL.createObjectURL(blob);
           script.src = objectUrl;
           script.onload = function() {

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1029,6 +1029,24 @@ def harness_server_func(q, port):
 
 def server_func(dir, q, port):
   class TestServerHandler(SimpleHTTPRequestHandler):
+    def send_head(self):
+      if self.path.endswith('.js'):
+        path = self.translate_path(self.path)
+        try:
+          f = open(path, 'rb')
+        except IOError:
+          self.send_error(404, "File not found: " + path)
+          return None
+        self.send_response(200)
+        self.send_header("Content-type", 'application/javascript')
+        self.send_header('Cache-Control', 'no-cache, must-revalidate')
+        self.send_header('Connection', 'close')
+        self.send_header('Expires', '-1')
+        self.end_headers()
+        return f
+      else:
+        return SimpleHTTPRequestHandler.send_head(self)
+
     def do_GET(self):
       if 'report_' in self.path:
         print('[server response:', self.path, ']')


### PR DESCRIPTION
I'm seeing tests fail when running locally, where web console says that it refused to do `importScripts(url)` because XHR of `url` was served back with `Content-type: text/plain` instead of `application/javascript`.

This is occurring when running pthreads tests in Chrome.

Make sure that .js files are served with MIME type application/javascript or pthreads importScripts() in src/worker.js can refuse to run them.