### PR TITLE
Fix MEMFS use in ENVIRONMENT=web + closure. Fixes #8010

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1174,7 +1174,7 @@ mergeInto(LibraryManager.library, {
       try {
         if (stream.path && FS.trackingDelegate['onWriteToFile']) FS.trackingDelegate['onWriteToFile'](stream.path);
       } catch(e) {
-        console.log("FS.trackingDelegate['onWriteToFile']('"+path+"') threw an exception: " + e.message);
+        console.log("FS.trackingDelegate['onWriteToFile']('"+stream.path+"') threw an exception: " + e.message);
       }
       return bytesWritten;
     },

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1118,7 +1118,8 @@ var SyscallsLibrary = {
         return 0;
       }
       case {{{ cDefine('F_GETLK') }}}:
-      case {{{ cDefine('F_GETLK64') }}}: {
+      /* case {{{ cDefine('F_GETLK64') }}}: Currently in musl F_GETLK64 has same value as F_GETLK, so omitted to avoid duplicate case blocks. If that changes, uncomment this */ {
+        {{{ assert(cDefine('F_GETLK') === cDefine('F_GETLK64')), '' }}}
         var arg = SYSCALLS.get();
         var offset = {{{ C_STRUCTS.flock.l_type }}};
         // We're always unlocked.
@@ -1127,8 +1128,10 @@ var SyscallsLibrary = {
       }
       case {{{ cDefine('F_SETLK') }}}:
       case {{{ cDefine('F_SETLKW') }}}:
-      case {{{ cDefine('F_SETLK64') }}}:
-      case {{{ cDefine('F_SETLKW64') }}}:
+      /* case {{{ cDefine('F_SETLK64') }}}: Currently in musl F_SETLK64 has same value as F_SETLK, so omitted to avoid duplicate case blocks. If that changes, uncomment this */
+      /* case {{{ cDefine('F_SETLKW64') }}}: Currently in musl F_SETLKW64 has same value as F_SETLKW, so omitted to avoid duplicate case blocks. If that changes, uncomment this */
+        {{{ assert(cDefine('F_SETLK64') === cDefine('F_SETLK')), '' }}}
+        {{{ assert(cDefine('F_SETLKW64') === cDefine('F_SETLKW')), '' }}}
         return 0; // Pretend that the locking is successful.
       case {{{ cDefine('F_GETOWN_EX') }}}:
       case {{{ cDefine('F_SETOWN') }}}:

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -99,6 +99,7 @@ mergeInto(LibraryManager.library, {
       get_char: function(tty) {
         if (!tty.input.length) {
           var result = null;
+#if ENVIRONMENT_MAY_BE_NODE
           if (ENVIRONMENT_IS_NODE) {
             // we will read data by chunks of BUFSIZE
             var BUFSIZE = 256;
@@ -132,8 +133,9 @@ mergeInto(LibraryManager.library, {
             } else {
               result = null;
             }
-
-          } else if (typeof window != 'undefined' &&
+          } else
+#endif
+          if (typeof window != 'undefined' &&
             typeof window.prompt == 'function') {
             // Browser.
             result = window.prompt('Input: ');  // returns null on cancel

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1280,6 +1280,9 @@ keydown(100);keyup(100); // trigger the end
     for args in [[], ['-s', 'USE_PTHREADS=1'], ['-s', 'ENVIRONMENT=web', '-O2', '--closure', '1']]:
       self.btest('emscripten_get_now.cpp', '1', args=args)
 
+  def test_write_file_in_environment_web(self):
+    self.btest('write_file.cpp', '0', args=['-s', 'ENVIRONMENT=web', '-Os', '--closure', '1'])
+
   @unittest.skip('Skipping due to https://github.com/emscripten-core/emscripten/issues/2770')
   def test_fflush(self):
     self.btest('test_fflush.cpp', '0', args=['--shell-file', path_from_root('tests', 'test_fflush.html')])

--- a/tests/write_file.cpp
+++ b/tests/write_file.cpp
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <string.h>
+
+int main() {
+	FILE *handle = fopen("test", "wb");
+	fputs("hello from file!", handle);
+	fclose(handle);
+	handle = fopen("test", "r");
+	char str[256] = {};
+	fgets(str, 255, handle);
+	printf("%s\n", str);
+#ifdef REPORT_RESULT
+	REPORT_RESULT(strcmp(str, "hello from file!"));
+#endif
+	return 0;
+}


### PR DESCRIPTION
Also clean up Closure warnings about duplicate switch-case values.