### PR TITLE
Optimize code size of invoke wrappers

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3195,6 +3195,7 @@ LibraryManager.library = {
   // setjmp.h
   // ==========================================================================
 
+#if SUPPORT_LONGJMP
   // asm.js-style setjmp/longjmp support for wasm binaryen backend.
   // In asm.js compilation, various variables including setjmpId will be
   // generated within 'var asm' in emscripten.py, while in wasm compilation,
@@ -3275,6 +3276,7 @@ LibraryManager.library = {
   emscripten_longjmp: function(env, value) {
     _longjmp(env, value);
   },
+#endif
 
   // ==========================================================================
   // sys/wait.h
@@ -4744,11 +4746,13 @@ LibraryManager.library = {
   },
 
   // misc definitions to avoid unnecessary unresolved symbols from fastcomp
+#if SUPPORT_LONGJMP
   emscripten_prep_setjmp: true,
   emscripten_cleanup_setjmp: true,
   emscripten_check_longjmp: true,
   emscripten_get_longjmp_result: true,
   emscripten_setjmp: true,
+#endif
   emscripten_preinvoke: true,
   emscripten_postinvoke: true,
   emscripten_resume: true,

--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -129,6 +129,7 @@ var funs = {
     ___setErrNo(ERRNO_CODES.EINTR);
     return -1;
   },
+#if SUPPORT_LONGJMP
 #if ASSERTIONS
   siglongjmp__deps: ['longjmp'],
   siglongjmp: function(env, value) {
@@ -143,6 +144,8 @@ var funs = {
   siglongjmp__sig: 'vii',
   siglongjmp: 'longjmp',
 #endif
+#endif
+
   sigpending: function(set) {
     {{{ makeSetValue('set', 0, 0, 'i32') }}};
     return 0;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1415,3 +1415,7 @@ var RUNTIME_FUNCS_TO_IMPORT = ['abort', 'setTempRet0', 'getTempRet0']
 // Internal: stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 
+// If true, compiler supports setjmp() and longjmp(). If false, these APIs are not available.
+// If you are using C++ exceptions, but do not need setjmp()+longjmp() API, then you can set
+// this to 0 to save a little bit of code size and performance when catching exceptions.
+var SUPPORT_LONGJMP = 1;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -904,36 +904,39 @@ int main() {
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME', 1)
 
-    self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
     self.maybe_closure()
 
-    src = '''
-      #include <stdio.h>
-      void thrower() {
-        printf("infunc...");
-        throw(99);
-        printf("FAIL");
-      }
-      int main() {
-        try {
-          printf("*throw...");
-          throw(1);
+    for support_longjmp in [0, 1]:
+      src = '''
+        #include <stdio.h>
+        void thrower() {
+          printf("infunc...");
+          throw(99);
           printf("FAIL");
-        } catch(...) {
-          printf("caught!");
         }
-        try {
-          thrower();
-        } catch(...) {
-          printf("done!*\\n");
+        int main() {
+          try {
+            printf("*throw...");
+            throw(1);
+            printf("FAIL");
+          } catch(...) {
+            printf("caught!");
+          }
+          try {
+            thrower();
+          } catch(...) {
+            printf("done!*\\n");
+          }
+          return 0;
         }
-        return 0;
-      }
-    '''
-    self.do_run(src, '*throw...caught!infunc...done!*')
+      '''
 
-    self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
-    self.do_run(src, 'Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0')
+      self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
+      self.set_setting('SUPPORT_LONGJMP', support_longjmp)
+      self.do_run(src, '*throw...caught!infunc...done!*')
+
+      self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
+      self.do_run(src, 'Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0')
 
   def test_exceptions_custom(self):
     self.set_setting('EXCEPTION_DEBUG', 1)


### PR DESCRIPTION
Optimize code size of invoke wrappers, and allow opting out from setjmp()/longjmp() support with -s SUPPORT_LONGJMP=0