### PR TITLE
Remove unnecessary globalScope var

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -57,8 +57,6 @@ function assert(condition, text) {
   }
 }
 
-var globalScope = this;
-
 // Returns the C function with a specified identifier (for C++, you need to do manual name mangling)
 function getCFunc(ident) {
   var func = Module['_' + ident]; // closure exported function


### PR DESCRIPTION
This was used a very long time ago, but has no purpose any more.