### PR TITLE
optimize_long_exception_msg_string

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1305,7 +1305,11 @@ function makeStructuralReturn(values, inAsm) {
 }
 
 function makeThrow(what) {
-  return 'throw ' + what + (DISABLE_EXCEPTION_CATCHING == 1 ? ' + " - Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0 or DISABLE_EXCEPTION_CATCHING=2 to catch."' : '') + ';';
+  if (ASSERTIONS) {
+    return 'throw ' + what + (DISABLE_EXCEPTION_CATCHING == 1 ? ' + " - Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0 or DISABLE_EXCEPTION_CATCHING=2 to catch."' : '') + ';';
+  } else {
+  return 'throw ' + what + ';';
+  }
 }
 
 function makeSignOp(value, type, op, force, ignore) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -936,7 +936,7 @@ int main() {
       self.do_run(src, '*throw...caught!infunc...done!*')
 
       self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
-      self.do_run(src, 'Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0')
+      self.do_run(src, 'exception')
 
   def test_exceptions_custom(self):
     self.set_setting('EXCEPTION_DEBUG', 1)


### PR DESCRIPTION
Do not emit a long help message when throwing an uncatchable exception if not building with assertions enabled