### PR TITLE
Fix for hidding global `crypto` library.

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1309,9 +1309,9 @@ mergeInto(LibraryManager.library, {
 #if ENVIRONMENT_MAY_BE_NODE
         // for nodejs with or without crypto support included
         try {
-            var crypto = require('crypto');
+            var crypto_module = require('crypto');
             // nodejs has crypto support
-            random_device = function() { return crypto['randomBytes'](1)[0]; };
+            random_device = function() { return crypto_module['randomBytes'](1)[0]; };
         } catch (e) {
             // nodejs doesn't have crypto support so fallback to Math.random
             random_device = function() { return (Math.random()*256)|0; };


### PR DESCRIPTION
Due variable hoisting, an undefined `crypto` variable was hiding global implementation. 
As a result of which a condition above: `typeof crypto === "object"` was failing