### PR TITLE
REMOVED_SETTINGS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1017,17 +1017,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     # Use settings
 
-    try:
-      assert shared.Settings.ASM_JS > 0, 'ASM_JS must be enabled in fastcomp'
-      assert shared.Settings.SAFE_HEAP in [0, 1], 'safe heap must be 0 or 1 in fastcomp'
-      assert shared.Settings.UNALIGNED_MEMORY == 0, 'forced unaligned memory not supported in fastcomp'
-      assert shared.Settings.FORCE_ALIGNED_MEMORY == 0, 'forced aligned memory is not supported in fastcomp'
-      assert shared.Settings.PGO == 0, 'pgo not supported in fastcomp'
-      assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
-    except Exception as e:
-      logger.error('Compiler settings error: {}'.format(e))
-      exit_with_error('Very old compiler settings (pre-fastcomp) are no longer supported.')
-
     if options.debug_level > 1 and options.use_closure_compiler:
       logger.warning('disabling closure because debug info was requested')
       options.use_closure_compiler = False

--- a/src/settings.js
+++ b/src/settings.js
@@ -1448,18 +1448,18 @@ var MINIFY_HTML = 1;
 // [OPTION_NAME, POSSIBLE_VALUES, ERROR_EXPLANATION], where POSSIBLE_VALUES is an array of values that will
 // still be silently accepted by the compiler. First element in the list is the canonical/fixed value going forward.
 // This allows existing build systems to keep specifying one of the supported settings, for backwards compatibility.
-var REMOVED_SETTINGS = [
+var LEGACY_SETTINGS = [
   ['ASM_JS', [1, 2], 'ASM_JS must be enabled in fastcomp'],
   ['SAFE_HEAP', [0, 1], 'safe heap must be 0 or 1 in fastcomp'],
   ['UNALIGNED_MEMORY', [0], 'forced unaligned memory not supported in fastcomp'],
   ['FORCE_ALIGNED_MEMORY', [0], 'forced aligned memory is not supported in fastcomp'],
   ['PGO', [0], 'pgo not supported in fastcomp'],
   ['QUANTUM_SIZE', [4], 'altering the QUANTUM_SIZE is not supported'],
-  ['FUNCTION_POINTER_ALIGNMENT', [2], 'Starting from Emscripten 1.37.29, no longer available. (https://github.com/emscripten-core/emscripten/pull/6091)'],
-  ['BUILD_AS_SHARED_LIB', [0], 'Starting from Emscripten 1.38.16, no longer available. (https://github.com/emscripten-core/emscripten/pull/7433)'],
-  ['SAFE_SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SAFE_SPLIT_MEMORY codegen is no longer available! (https://github.com/emscripten-core/emscripten/pull/7465)'],
-  ['SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SPLIT_MEMORY codegen is no longer available! (https://github.com/emscripten-core/emscripten/pull/7465)'],
+  ['FUNCTION_POINTER_ALIGNMENT', [2], 'Starting from Emscripten 1.37.29, no longer available (https://github.com/emscripten-core/emscripten/pull/6091)'],
+  ['BUILD_AS_SHARED_LIB', [0], 'Starting from Emscripten 1.38.16, no longer available (https://github.com/emscripten-core/emscripten/pull/7433)'],
+  ['SAFE_SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SAFE_SPLIT_MEMORY codegen is no longer available (https://github.com/emscripten-core/emscripten/pull/7465)'],
+  ['SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SPLIT_MEMORY codegen is no longer available (https://github.com/emscripten-core/emscripten/pull/7465)'],
   ['BINARYEN_METHOD', ['native-wasm'], 'Starting from Emscripten 1.38.23, Emscripten now always builds either to Wasm (-s WASM=1 - default), or to asm.js (-s WASM=0), other methods are not supported (https://github.com/emscripten-core/emscripten/pull/7836)'],
   ['PRECISE_I64_MATH', [1, 2], 'Starting from Emscripten 1.38.26, PRECISE_I64_MATH is always enabled (https://github.com/emscripten-core/emscripten/pull/7935)'],
-  ['MEMFS_APPEND_TO_TYPED_ARRAYS', [1], 'Starting from Emscripten 1.38.26, MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported! MEMFS no longer supports using JS arrays for file data. (https://github.com/emscripten-core/emscripten/pull/7918)'],
+  ['MEMFS_APPEND_TO_TYPED_ARRAYS', [1], 'Starting from Emscripten 1.38.26, MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported. MEMFS no longer supports using JS arrays for file data (https://github.com/emscripten-core/emscripten/pull/7918)'],
 ];

--- a/src/settings.js
+++ b/src/settings.js
@@ -1442,3 +1442,18 @@ var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 0;
 // is retained. Minification requires at least -O1 or -Os to be used. Pass -s MINIFY_HTML=0
 // to explicitly choose to disable HTML minification altogether.
 var MINIFY_HTML = 1;
+
+// Legacy settings that have been removed, and the values they are now fixed to. These can no
+// longer be changed:
+// [OPTION_NAME, POSSIBLE_VALUES, ERROR_EXPLANATION], where POSSIBLE_VALUES is an array of values that will
+// still be silently accepted by the compiler. First element in the list is the canonical/fixed value going forward.
+// This allows existing build systems to keep specifying one of the supported settings, for backwards compatibility.
+var REMOVED_SETTINGS = [
+	['MEMFS_APPEND_TO_TYPED_ARRAYS', [1], 'Starting from Emscripten 1.38.26, MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported! MEMFS no longer supports using JS arrays for file data. (https://github.com/emscripten-core/emscripten/pull/7918)'],
+	['PRECISE_I64_MATH', [1,2], 'Starting from Emscripten 1.38.26, PRECISE_I64_MATH is always enabled (https://github.com/emscripten-core/emscripten/pull/7935)'],
+	['BINARYEN_METHOD', ['native-wasm'], 'Starting from Emscripten 1.38.23, Emscripten now always builds either to Wasm (-s WASM=1 - default), or to asm.js (-s WASM=0), other methods are not supported (https://github.com/emscripten-core/emscripten/pull/7836)'],
+	['SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SPLIT_MEMORY codegen is no longer available! (https://github.com/emscripten-core/emscripten/pull/7465)'],
+	['SAFE_SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SAFE_SPLIT_MEMORY codegen is no longer available! (https://github.com/emscripten-core/emscripten/pull/7465)'],
+	['BUILD_AS_SHARED_LIB', [0], 'Starting from Emscripten 1.38.16, no longer available. (https://github.com/emscripten-core/emscripten/pull/7433)'],
+	['FUNCTION_POINTER_ALIGNMENT', [2], 'Starting from Emscripten 1.37.29, no longer available. (https://github.com/emscripten-core/emscripten/pull/6091)'],
+];

--- a/src/settings.js
+++ b/src/settings.js
@@ -1449,11 +1449,17 @@ var MINIFY_HTML = 1;
 // still be silently accepted by the compiler. First element in the list is the canonical/fixed value going forward.
 // This allows existing build systems to keep specifying one of the supported settings, for backwards compatibility.
 var REMOVED_SETTINGS = [
-	['MEMFS_APPEND_TO_TYPED_ARRAYS', [1], 'Starting from Emscripten 1.38.26, MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported! MEMFS no longer supports using JS arrays for file data. (https://github.com/emscripten-core/emscripten/pull/7918)'],
-	['PRECISE_I64_MATH', [1,2], 'Starting from Emscripten 1.38.26, PRECISE_I64_MATH is always enabled (https://github.com/emscripten-core/emscripten/pull/7935)'],
-	['BINARYEN_METHOD', ['native-wasm'], 'Starting from Emscripten 1.38.23, Emscripten now always builds either to Wasm (-s WASM=1 - default), or to asm.js (-s WASM=0), other methods are not supported (https://github.com/emscripten-core/emscripten/pull/7836)'],
-	['SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SPLIT_MEMORY codegen is no longer available! (https://github.com/emscripten-core/emscripten/pull/7465)'],
-	['SAFE_SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SAFE_SPLIT_MEMORY codegen is no longer available! (https://github.com/emscripten-core/emscripten/pull/7465)'],
-	['BUILD_AS_SHARED_LIB', [0], 'Starting from Emscripten 1.38.16, no longer available. (https://github.com/emscripten-core/emscripten/pull/7433)'],
-	['FUNCTION_POINTER_ALIGNMENT', [2], 'Starting from Emscripten 1.37.29, no longer available. (https://github.com/emscripten-core/emscripten/pull/6091)'],
+  ['ASM_JS', [1, 2], 'ASM_JS must be enabled in fastcomp'],
+  ['SAFE_HEAP', [0, 1], 'safe heap must be 0 or 1 in fastcomp'],
+  ['UNALIGNED_MEMORY', [0], 'forced unaligned memory not supported in fastcomp'],
+  ['FORCE_ALIGNED_MEMORY', [0], 'forced aligned memory is not supported in fastcomp'],
+  ['PGO', [0], 'pgo not supported in fastcomp'],
+  ['QUANTUM_SIZE', [4], 'altering the QUANTUM_SIZE is not supported'],
+  ['FUNCTION_POINTER_ALIGNMENT', [2], 'Starting from Emscripten 1.37.29, no longer available. (https://github.com/emscripten-core/emscripten/pull/6091)'],
+  ['BUILD_AS_SHARED_LIB', [0], 'Starting from Emscripten 1.38.16, no longer available. (https://github.com/emscripten-core/emscripten/pull/7433)'],
+  ['SAFE_SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SAFE_SPLIT_MEMORY codegen is no longer available! (https://github.com/emscripten-core/emscripten/pull/7465)'],
+  ['SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SPLIT_MEMORY codegen is no longer available! (https://github.com/emscripten-core/emscripten/pull/7465)'],
+  ['BINARYEN_METHOD', ['native-wasm'], 'Starting from Emscripten 1.38.23, Emscripten now always builds either to Wasm (-s WASM=1 - default), or to asm.js (-s WASM=0), other methods are not supported (https://github.com/emscripten-core/emscripten/pull/7836)'],
+  ['PRECISE_I64_MATH', [1, 2], 'Starting from Emscripten 1.38.26, PRECISE_I64_MATH is always enabled (https://github.com/emscripten-core/emscripten/pull/7935)'],
+  ['MEMFS_APPEND_TO_TYPED_ARRAYS', [1], 'Starting from Emscripten 1.38.26, MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported! MEMFS no longer supports using JS arrays for file data. (https://github.com/emscripten-core/emscripten/pull/7918)'],
 ];

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9060,7 +9060,7 @@ int main () {
   # Test that legacy settings that have been fixed to a specific value and their value can no longer be changed,
   def test_legacy_settings_forbidden_to_change(self):
     output = run_process([PYTHON, EMCC, '-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=0', path_from_root('tests', 'hello_world.c')], check=False, stderr=PIPE).stderr
-    assert 'MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported!' in output
+    assert 'MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported' in output
 
     run_process([PYTHON, EMCC, '-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1', path_from_root('tests', 'hello_world.c')])
     run_process([PYTHON, EMCC, '-s', 'PRECISE_I64_MATH=2', path_from_root('tests', 'hello_world.c')])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9056,3 +9056,11 @@ int main () {
       if total_output_size != total_expected_size:
         success = False
     assert success
+
+  # Test that legacy settings that have been fixed to a specific value and their value can no longer be changed,
+  def test_legacy_settings_forbidden_to_change(self):
+    output = run_process([PYTHON, EMCC, '-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=0', path_from_root('tests', 'hello_world.c')], check=False, stderr=PIPE).stderr
+    assert 'MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported!' in output
+
+    run_process([PYTHON, EMCC, '-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1', path_from_root('tests', 'hello_world.c')])
+    run_process([PYTHON, EMCC, '-s', 'PRECISE_I64_MATH=2', path_from_root('tests', 'hello_world.c')])

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -328,7 +328,7 @@ class sanity(RunnerCore):
 
     restore_and_set_up()
 
-    self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'ASM_JS=0'], '''Very old compiler settings (pre-fastcomp) are no longer supported.''')
+    self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'ASM_JS=0'], '''ASM_JS must be enabled in fastcomp''')
 
   def test_node(self):
     NODE_WARNING = 'node version appears too old'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1233,8 +1233,7 @@ class SettingsManager(object):
     def __setattr__(self, attr, value):
       for legacy_attr, fixed_values, error_message in self.attrs['REMOVED_SETTINGS']:
         if attr == legacy_attr and value not in fixed_values:
-          logger.error('Invalid command line option -s ' + attr + '=' + str(value) + ': ' + error_message)
-          sys.exit(1)
+          exit_with_error('Invalid command line option -s ' + attr + '=' + str(value) + ': ' + error_message)
 
       if attr not in self.attrs:
         logger.error('Assigning a non-existent settings attribute "%s"' % attr)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1190,7 +1190,7 @@ class SettingsManager(object):
       settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
       exec(settings, {'attrs': self.attrs})
 
-      for opt, fixed_values, _ in self.attrs['REMOVED_SETTINGS']:
+      for opt, fixed_values, _ in self.attrs['LEGACY_SETTINGS']:
         self.attrs[opt] = fixed_values[0]
 
       if get_llvm_target() == WASM_TARGET:
@@ -1231,9 +1231,12 @@ class SettingsManager(object):
         raise AttributeError
 
     def __setattr__(self, attr, value):
-      for legacy_attr, fixed_values, error_message in self.attrs['REMOVED_SETTINGS']:
-        if attr == legacy_attr and value not in fixed_values:
-          exit_with_error('Invalid command line option -s ' + attr + '=' + str(value) + ': ' + error_message)
+      for legacy_attr, fixed_values, error_message in self.attrs['LEGACY_SETTINGS']:
+        if attr == legacy_attr:
+          if value not in fixed_values:
+            exit_with_error('Invalid command line option -s ' + attr + '=' + str(value) + ': ' + error_message)
+          else:
+            logging.debug('Option -s ' + attr + '=' + str(value) + ' has been removed from the codebase. (' + error_message + ')')
 
       if attr not in self.attrs:
         logger.error('Assigning a non-existent settings attribute "%s"' % attr)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1190,6 +1190,9 @@ class SettingsManager(object):
       settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
       exec(settings, {'attrs': self.attrs})
 
+      for opt, fixed_values, _ in self.attrs['REMOVED_SETTINGS']:
+        self.attrs[opt] = fixed_values[0]
+
       if get_llvm_target() == WASM_TARGET:
         self.attrs['WASM_BACKEND'] = 1
 
@@ -1228,6 +1231,11 @@ class SettingsManager(object):
         raise AttributeError
 
     def __setattr__(self, attr, value):
+      for legacy_attr, fixed_values, error_message in self.attrs['REMOVED_SETTINGS']:
+        if attr == legacy_attr and value not in fixed_values:
+          logger.error('Invalid command line option -s ' + attr + '=' + str(value) + ': ' + error_message)
+          sys.exit(1)
+
       if attr not in self.attrs:
         logger.error('Assigning a non-existent settings attribute "%s"' % attr)
         suggestions = ', '.join(difflib.get_close_matches(attr, list(self.attrs.keys())))


### PR DESCRIPTION
Make the compiler silently allow removed -s settings, if their value aligns with behavior that is now the only supported option.

Without this, whenever an option is removed, it destroys backwards compatibility in build systems.  See https://github.com/emscripten-core/emscripten/pull/7422#issuecomment-461417994