### PR TITLE
testcase for minimal JS FFI legalization for invoke and dyncalls

### DIFF
--- a/tests/other/noffi.cpp
+++ b/tests/other/noffi.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <stdexcept>
+#include <cstdint>
+#include <dlfcn.h>
+
+using namespace std;
+
+uint64_t getbigint(){
+    int ran = rand() % 100;// v1 in the range 0 to 99
+    ++ran;
+    if(ran > -1)
+        throw new std::runtime_error("error!!");
+
+    return 1152921504606846975 + ran;
+}
+int main()
+{   
+    float safeY = 0.0f;
+    uint64_t mybig = 0;
+
+    try{
+        mybig = getbigint();
+    }
+    catch(std::runtime_error){};
+
+    return 0;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8013,8 +8013,10 @@ int main() {
       text = re.sub(r'param \$\d+', 'param ', text)
       text = re.sub(r' +', ' ', text)
       # print("text: %s" % text)
-      e_i64_i32 = re.search('func \$legalstub\$dyn.* \(type \$\d+\) \(result i32\)', text)
-      assert e_i64_i32, 'legal stub not generated for dyncall'
+      i_legalimport_i64 = re.search('\(import.*\$legalimport\$invoke_j.*', text)
+      e_legalstub_i32 = re.search('\(func.*\$legalstub\$dyn.*\(type \$\d+\).*\(result i32\)', text)
+      assert i_legalimport_i64, 'legal import not generated for invoke call'
+      assert e_legalstub_i32, 'legal stub not generated for dyncall'
 
   def test_sysconf_phys_pages(self):
     for args, expected in [

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7992,6 +7992,30 @@ int main() {
         assert not e_f32_f64, 'f32 converted to f64 in exports'
         assert e_i64_i64,     'i64 converted to i64 in exports'
 
+  def test_no_legalize_js_ffi(self):
+    # test minimal JS FFI legalization for invoke and dyncalls
+    wasm_dis = os.path.join(Building.get_binaryen_bin(), 'wasm-dis')
+    for (args, js_ffi) in [
+        (['-s', 'LEGALIZE_JS_FFI=0', '-s', 'MAIN_MODULE=2', '-O3', '-s', 'DISABLE_EXCEPTION_CATCHING=0'], False),
+      ]:
+      print(args)
+      try_delete('a.out.wasm')
+      try_delete('a.out.wast')
+      with env_modify({'EMCC_FORCE_STDLIBS': 'libc++'}):
+        cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'noffi.cpp'), '-g', '-o', 'a.out.js'] + args
+      print(' '.join(cmd))
+      run_process(cmd)
+      run_process([wasm_dis, 'a.out.wasm', '-o', 'a.out.wast'])
+      text = open('a.out.wast').read()
+      # remove internal comments and extra whitespace
+      text = re.sub(r'\(;[^;]+;\)', '', text)
+      text = re.sub(r'\$var\$*.', '', text)
+      text = re.sub(r'param \$\d+', 'param ', text)
+      text = re.sub(r' +', ' ', text)
+      # print("text: %s" % text)
+      e_i64_i32 = re.search('func \$legalstub\$dyn.* \(type \$\d+\) \(result i32\)', text)
+      assert e_i64_i32, 'legal stub not generated for dyncall'
+
   def test_sysconf_phys_pages(self):
     for args, expected in [
         ([], 1024),


### PR DESCRIPTION
adding a test case for issue faced in 
https://github.com/emscripten-core/emscripten/issues/7679