### PR TITLE
Fast browser tests

### DIFF
--- a/tests/browser_harness.html
+++ b/tests/browser_harness.html
@@ -36,7 +36,11 @@
           iframe.src = url;
           document.getElementById('count').textContent = counter++;
         }
-        setTimeout(check, 100);
+        // Polling for the next test to start: we just keep asking if we
+        // should load a new page, since the iframe doesn't currently have
+        // a way to tell us it completed (even if it did, we'd need to poll
+        // the server to know when the next test page is ready to load).
+        setTimeout(check, 10);
       });
       request.addEventListener("error", function() {
         document.body.innerHTML = 'Tests complete. View log in console.';

--- a/tests/browser_harness.html
+++ b/tests/browser_harness.html
@@ -23,17 +23,20 @@
     }
   </style>
   <script>
+    var COMMAND_PREFIX = 'COMMAND:';
     var counter = 0;
     function check() {
       var request = new XMLHttpRequest();
       request.open('GET', '/check');
       request.send(null);
       request.addEventListener("load", function() {
-        if (request.responseText != 'False') {
-          iframe.src = request.responseText;
+        if (request.responseText.startsWith(COMMAND_PREFIX)) {
+          var url = request.responseText.substr(COMMAND_PREFIX.length);
+          console.log('commanded to load ' + url);
+          iframe.src = url;
           document.getElementById('count').textContent = counter++;
         }
-        setTimeout(check, 333);
+        setTimeout(check, 100);
       });
       request.addEventListener("error", function() {
         document.body.innerHTML = 'Tests complete. View log in console.';

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -24,7 +24,6 @@ import atexit
 import contextlib
 import difflib
 import fnmatch
-import functools
 import glob
 import hashlib
 import json
@@ -46,13 +45,11 @@ import urllib
 import webbrowser
 
 if sys.version_info.major == 2:
-  from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+  from BaseHTTPServer import HTTPServer
   from SimpleHTTPServer import SimpleHTTPRequestHandler
-  from httplib import HTTPConnection
   from urllib import unquote
 else:
-  from http.server import HTTPServer, BaseHTTPRequestHandler, SimpleHTTPRequestHandler
-  from http.client import HTTPConnection
+  from http.server import HTTPServer, SimpleHTTPRequestHandler
   from urllib.parse import unquote
 
 # Setup

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1062,6 +1062,9 @@ def harness_server_func(in_queue, out_queue, port):
       # don't log; too noisy
       pass
 
+  # allows streaming compilation to work
+  SimpleHTTPRequestHandler.extensions_map['.wasm'] = 'application/wasm'
+
   httpd = HTTPServer(('localhost', port), TestServerHandler)
   httpd.serve_forever() # test runner will kill us
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1005,37 +1005,20 @@ class RunnerCore(unittest.TestCase):
 # Run a server and a web page. When a test runs, we tell the server about it,
 # which tells the web page, which then opens a window with the test. Doing
 # it this way then allows the page to close() itself when done.
-def harness_server_func(q, port):
-  class TestServerHandler(BaseHTTPRequestHandler):
-    def do_GET(s):
-      s.send_response(200)
-      s.send_header("Content-type", "text/html")
-      s.end_headers()
-      if s.path == '/run_harness':
-        s.wfile.write(open(path_from_root('tests', 'browser_harness.html'), 'rb').read())
-      else:
-        result = b'False'
-        if not q.empty():
-          result = q.get()
-        s.wfile.write(result)
-
-    def log_request(code=0, size=0):
-      # don't log; too noisy
-      pass
-
-  httpd = HTTPServer(('localhost', port), TestServerHandler)
-  httpd.serve_forever() # test runner will kill us
-
-
-def server_func(dir, q, port):
+def harness_server_func(in_queue, out_queue, port):
   class TestServerHandler(SimpleHTTPRequestHandler):
     def do_GET(self):
-      if 'report_' in self.path:
-        print('[server response:', self.path, ']')
-        q.put(self.path)
-        # Send a default OK response to the browser.
+      if self.path == '/run_harness':
+        print('[server startup]')
         self.send_response(200)
-        self.send_header("Content-type", "text/plain")
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        self.wfile.write(open(path_from_root('tests', 'browser_harness.html'), 'rb').read())
+      elif 'report_' in self.path:
+        print('[server response:', self.path, ']')
+        out_queue.put(self.path)
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
         self.send_header('Cache-Control', 'no-cache, must-revalidate')
         self.send_header('Connection', 'close')
         self.send_header('Expires', '-1')
@@ -1051,16 +1034,27 @@ def server_func(dir, q, port):
             xhr.send();
         '''
         print('[server logging:', urllib.unquote_plus(self.path), ']')
+      elif self.path == '/check':
+        self.send_response(200)
+        self.send_header('Content-type', 'text/html')
+        self.end_headers()
+        if not in_queue.empty():
+          url, dir = in_queue.get()
+          print('[queue command:', url, dir, ']')
+          self.wfile.write('COMMAND:' + url)
+          os.chdir(dir)
+        else:
+          # the browser must keep polling
+          self.wfile.write('(wait)')
       else:
         # Use SimpleHTTPServer default file serving operation for GET.
+        print('[simple HTTP serving:', urllib.unquote_plus(self.path), ']')
         SimpleHTTPRequestHandler.do_GET(self)
 
     def log_request(code=0, size=0):
       # don't log; too noisy
       pass
 
-  SimpleHTTPRequestHandler.extensions_map['.wasm'] = 'application/wasm'
-  os.chdir(dir)
   httpd = HTTPServer(('localhost', port), TestServerHandler)
   httpd.serve_forever() # test runner will kill us
 
@@ -1081,8 +1075,7 @@ class BrowserCore(RunnerCore):
   def setUpClass(cls):
     super(BrowserCore, cls).setUpClass()
     cls.also_asmjs = int(os.getenv('EMTEST_BROWSER_ALSO_ASMJS', '0')) == 1
-    cls.test_port = int(os.getenv('EMTEST_BROWSER_TEST_PORT', '8888'))
-    cls.harness_port = int(os.getenv('EMTEST_BROWSER_HARNESS_PORT', '9999'))
+    cls.port = int(os.getenv('EMTEST_BROWSER_PORT', '8888'))
     if not has_browser():
       return
     if not EMTEST_BROWSER:
@@ -1096,11 +1089,12 @@ class BrowserCore(RunnerCore):
       webbrowser.open_new = run_in_other_browser
       print("Using Emscripten browser: " + str(cmd))
     cls.browser_timeout = 30
-    cls.harness_queue = multiprocessing.Queue()
-    cls.harness_server = multiprocessing.Process(target=harness_server_func, args=(cls.harness_queue, cls.harness_port))
+    cls.harness_in_queue = multiprocessing.Queue()
+    cls.harness_out_queue = multiprocessing.Queue()
+    cls.harness_server = multiprocessing.Process(target=harness_server_func, args=(cls.harness_in_queue, cls.harness_out_queue, cls.port))
     cls.harness_server.start()
     print('[Browser harness server on process %d]' % cls.harness_server.pid)
-    webbrowser.open_new('http://localhost:%s/run_harness' % cls.harness_port)
+    webbrowser.open_new('http://localhost:%s/run_harness' % cls.port)
 
   @classmethod
   def tearDownClass(cls):
@@ -1122,31 +1116,18 @@ class BrowserCore(RunnerCore):
     print('[browser launch:', html_file, ']')
     if expectedResult is not None:
       try:
-        queue = multiprocessing.Queue()
-        server = multiprocessing.Process(target=functools.partial(server_func, self.get_dir()), args=(queue, self.test_port))
-        server.start()
-        # Starting the web page server above is an asynchronous procedure, so before we tell the browser below to navigate to
-        # the test page, we need to know that the server has started up and is ready to process the site navigation.
-        # Therefore block until we can make a connection to the server.
-        for i in range(10):
-          httpconn = HTTPConnection('localhost:%s' % self.test_port, timeout=1)
-          try:
-            httpconn.connect()
-            httpconn.close()
-            break
-          except:
-            time.sleep(1)
-        else:
-          raise Exception('[Test harness server failed to start up in a timely manner]')
-        self.harness_queue.put(asbytes('http://localhost:%s/%s' % (self.test_port, html_file)))
+        self.harness_in_queue.put((
+          asbytes('http://localhost:%s/%s' % (self.port, html_file)),
+          self.get_dir()
+        ))
         received_output = False
         output = '[no http server activity]'
         start = time.time()
         if timeout is None:
           timeout = self.browser_timeout
         while time.time() - start < timeout:
-          if not queue.empty():
-            output = queue.get()
+          if not self.harness_out_queue.empty():
+            output = self.harness_out_queue.get()
             received_output = True
             break
           time.sleep(0.1)
@@ -1158,7 +1139,6 @@ class BrowserCore(RunnerCore):
         else:
           self.assertIdentical(expectedResult, output)
       finally:
-        server.terminate()
         time.sleep(0.1) # see comment about Windows above
     else:
       webbrowser.open_new(os.path.abspath(html_file))
@@ -1169,7 +1149,7 @@ class BrowserCore(RunnerCore):
       print('(moving on..)')
 
   def with_report_result(self, code):
-    return '#define EMTEST_PORT_NUMBER %d\n#include "%s"\n' % (self.test_port, path_from_root('tests', 'report_result.h')) + code
+    return '#define EMTEST_PORT_NUMBER %d\n#include "%s"\n' % (self.port, path_from_root('tests', 'report_result.h')) + code
 
   # @manually_trigger If set, we do not assume we should run the reftest when main() is done.
   #                   Instead, call doReftest() in JS yourself at the right time.
@@ -1270,7 +1250,7 @@ class BrowserCore(RunnerCore):
           setTimeout(realDoReftest, 1);
         };
       }
-''' % (self.test_port, basename, int(manually_trigger)))
+''' % (self.port, basename, int(manually_trigger)))
 
   def btest(self, filename, expected=None, reference=None, force_c=False,
             reference_slack=0, manual_reference=False, post_build=None,
@@ -1289,7 +1269,7 @@ class BrowserCore(RunnerCore):
     if 'WASM=0' not in args:
       # Filter out separate-asm, which is implied by wasm
       args = [a for a in args if a != '--separate-asm']
-    args += ['-DEMTEST_PORT_NUMBER=%d' % self.test_port, '-include', path_from_root('tests', 'report_result.h')]
+    args += ['-DEMTEST_PORT_NUMBER=%d' % self.port, '-include', path_from_root('tests', 'report_result.h')]
     if filename_is_src:
       filepath = os.path.join(self.get_dir(), 'main.c' if force_c else 'main.cpp')
       with open(filepath, 'w') as f:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -462,9 +462,11 @@ If manually bisecting:
     # chrome's limit on IndexedDB item sizes, see
     # https://cs.chromium.org/chromium/src/content/renderer/indexed_db/webidbdatabase_impl.cc?type=cs&q=%22The+serialized+value+is+too+large%22&sq=package:chromium&g=0&l=177
     # https://cs.chromium.org/chromium/src/out/Debug/gen/third_party/blink/public/mojom/indexeddb/indexeddb.mojom.h?type=cs&sq=package:chromium&g=0&l=60
-    for extra_size in (0, 50 * 1024 * 1024, 100 * 1024 * 1024, 150 * 1024 * 1024):
+    for extra_size in (0, 1 * 1024 * 1024, 100 * 1024 * 1024, 150 * 1024 * 1024):
+      if is_chrome() and extra_size >= 100 * 1024 * 1024:
+        continue
       create_test_file('somefile.txt', '''load me right before running the code please''' + ('_' * extra_size))
-      print(os.path.getsize('somefile.txt'))
+      print('size:', os.path.getsize('somefile.txt'))
       run_process([PYTHON, EMCC, 'main.cpp', '--use-preload-cache', '--js-library', 'test.js', '--preload-file', 'somefile.txt', '-o', 'page.html', '-s', 'ALLOW_MEMORY_GROWTH=1'])
       self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?1')
       self.run_browser('page.html', 'You should see |load me right before|.', '/report_result?2')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -793,17 +793,17 @@ window.close = function() {
       create_test_file(to + '.js', js_mod(open('test.js').read()))
 
     # run with noProxy, but make main thread fail
-    copy('two', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WEB) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.test_port, original),
+    copy('two', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WEB) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.port, original),
          lambda original: original.replace('function doReftest() {', 'function doReftest() { return; ')) # don't reftest on main thread, it would race
     self.run_browser('two.html?noProxy', None, ['/report_result?999'])
-    copy('two', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WEB) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.test_port, original))
+    copy('two', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WEB) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.port, original))
     self.run_browser('two.html', None, ['/report_result?0']) # this is still cool
 
     # run without noProxy, so proxy, but make worker fail
-    copy('three', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WORKER) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.test_port, original),
+    copy('three', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WORKER) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.port, original),
          lambda original: original.replace('function doReftest() {', 'function doReftest() { return; ')) # don't reftest on main thread, it would race
     self.run_browser('three.html', None, ['/report_result?999'])
-    copy('three', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WORKER) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.test_port, original))
+    copy('three', lambda original: re.sub(r'function _main\(\$(.+),\$(.+)\) {', r'function _main($\1,$\2) { if (ENVIRONMENT_IS_WORKER) { var xhr = new XMLHttpRequest(); xhr.open("GET", "http://localhost:%s/report_result?999");xhr.send(); return; }' % self.port, original))
     self.run_browser('three.html?noProxy', None, ['/report_result?0']) # this is still cool
 
   @requires_graphics_hardware
@@ -1573,7 +1573,7 @@ keydown(100);keyup(100); // trigger the end
         </script>
       </body>
       </html>
-    ''' % self.test_port)
+    ''' % self.port)
     html_file.close()
 
     for file_data in [1, 0]:
@@ -1626,7 +1626,7 @@ keydown(100);keyup(100); // trigger the end
         </script>
       </body>
       </html>
-    """ % self.test_port)
+    """ % self.port)
     html_file.close()
 
     c_source_filename = "checksummer.c"
@@ -1652,7 +1652,7 @@ keydown(100);keyup(100); // trigger the end
     data = os.urandom(10 * chunkSize + 1) # 10 full chunks and one 1 byte chunk
     checksum = zlib.adler32(data) & 0xffffffff # Python 2 compatibility: force bigint
 
-    server = multiprocessing.Process(target=test_chunked_synchronous_xhr_server, args=(True, chunkSize, data, checksum, self.test_port))
+    server = multiprocessing.Process(target=test_chunked_synchronous_xhr_server, args=(True, chunkSize, data, checksum, self.port))
     server.start()
     self.run_browser(main, 'Chunked binary synchronous XHR in Web Workers!', '/report_result?' + str(checksum))
     server.terminate()
@@ -2202,7 +2202,7 @@ void *getBindBuffer() {
         }
       }
       Module._note(4); // this happens too early! and is overwritten when the mem init arrives
-    ''' % self.test_port)
+    ''' % self.port)
 
     # with assertions, we notice when memory was written to too early
     self.btest('mem_init.cpp', expected='9', args=['-s', 'WASM=0', '--pre-js', 'pre.js', '--post-js', 'post.js', '--memory-init-file', '1'])
@@ -2232,7 +2232,7 @@ void *getBindBuffer() {
           }
           console.log('WARNING: ' + x);
         };
-      ''' % self.test_port)
+      ''' % self.port)
       self.btest('mem_init_request.cpp', expected=status, args=['-s', 'WASM=0', '--pre-js', 'pre.js', '--memory-init-file', '1'])
 
     test('test.html.mem', '1')
@@ -2304,7 +2304,7 @@ void *getBindBuffer() {
         xhr.send();
         setTimeout(function() { window.close() }, 1000);
       }, 1000);
-    ''' % self.test_port
+    ''' % self.port
 
     create_test_file('pre_runtime.js', r'''
       Module.onRuntimeInitialized = function(){
@@ -4520,7 +4520,7 @@ window.close = function() {
   @no_wasm_backend('this tests asm.js support')
   def test_two_separate_asm_files_on_same_page(self):
     html_file = open('main.html', 'w')
-    html_file.write(open(path_from_root('tests', 'two_separate_asm_files.html')).read().replace('localhost:8888', 'localhost:%s' % self.test_port))
+    html_file.write(open(path_from_root('tests', 'two_separate_asm_files.html')).read().replace('localhost:8888', 'localhost:%s' % self.port))
     html_file.close()
 
     cmd = [PYTHON, EMCC, path_from_root('tests', 'modularize_separate_asm.c'), '-o', 'page1.js', '-s', 'WASM=0', '--separate-asm', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=Module1', '-s', 'SEPARATE_ASM_MODULE_NAME=ModuleForPage1["asm"]']
@@ -4538,7 +4538,7 @@ window.close = function() {
   @no_wasm_backend('this tests asm.js support')
   def test_encapsulated_asmjs_page_load(self):
     html_file = open('main.html', 'w')
-    html_file.write(open(path_from_root('tests', 'encapsulated_asmjs_page_load.html')).read().replace('localhost:8888', 'localhost:%s' % self.test_port))
+    html_file.write(open(path_from_root('tests', 'encapsulated_asmjs_page_load.html')).read().replace('localhost:8888', 'localhost:%s' % self.port))
     html_file.close()
 
     cmd = [PYTHON, EMCC, path_from_root('tests', 'modularize_separate_asm.c'), '-o', 'a.js', '-s', 'WASM=0', '--separate-asm', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=EmscriptenCode', '-s', 'SEPARATE_ASM_MODULE_NAME="var EmscriptenCode"']


### PR DESCRIPTION
This makes the speed of running simple tests almost 2x faster - you can really notice this when running the tests, there are no odd stalls for no reason. Overall bot test times improve 33% (since a significant amount of time is spent in compilation, which has not changed).

What this PR does is replace two http servers with one. We had one for the harness, and created one for each test. This PR uses a single persistent one, so we save creating the per-test one on every test. That saves process creation overhead etc.

This also changes the polling speed that the JS code in the harness uses. This has a smaller effect but is still useful.

Also fix `test_preload_caching` for chrome, we must avoid trying to cache very large files there. Not sure what that started to fail here more - perhaps timing related, e.g. maybe chrome needs time between tests for something to happen to the IndexedDB cache. I made sure the test checks a bunch of interesting but smaller sizes.