### PR TITLE
Use response files when invoking emar

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 
 import os, sys
 from tools import shared
-from tools.response_file import substitute_response_files
+from tools.response_file import substitute_response_files, create_response_file
 
 #
 # Main run() function
@@ -66,6 +66,12 @@ def run():
                 pass
           break
         i += 1
+
+  response_filename = None
+  if len(newargs) > 3:
+    response_filename = create_response_file(newargs[3:], shared.get_emscripten_temp_dir())
+    to_delete += [response_filename]
+    newargs = newargs[:3] + ['@' + response_filename]
 
   try:
     return shared.run_process(newargs, stdin=sys.stdin).returncode

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2242,7 +2242,15 @@ class Building(object):
   @staticmethod
   def emar(action, output_filename, filenames, stdout=None, stderr=None, env=None):
     try_delete(output_filename)
-    run_process([PYTHON, EMAR, action, output_filename] + filenames, stdout=stdout, stderr=stderr, env=env)
+    cmd = [PYTHON, EMAR, action, output_filename] + filenames[:5]
+
+    response_filename = response_file.create_response_file(filenames, TEMP_DIR)
+    cmd = [PYTHON, EMAR, action, output_filename] + ['@' + response_filename]
+    try:
+      run_process(cmd, stdout=stdout, stderr=stderr, env=env)
+    finally:
+      try_delete(response_filename)
+
     if 'c' in action:
       assert os.path.exists(output_filename), 'emar could not create output file: ' + output_filename
 


### PR DESCRIPTION
Use response files when invoking emar to avoid libc build creating too long command lines on Windows