### PR TITLE
dce_abortOnCannotGrowMemory

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1725,7 +1725,7 @@ int main(int argc, char **argv) {
     src = open(path_from_root('tests', 'core', 'test_memorygrowth.c')).read()
 
     # Fail without memory growth
-    self.do_run(src, 'Cannot enlarge memory arrays')
+    self.do_run(src, 'OOM')
     fail = open('src.cpp.o.js').read()
 
     # Win with it
@@ -1765,7 +1765,7 @@ int main(int argc, char **argv) {
       src = open(path_from_root('tests', 'core', 'test_memorygrowth_2.c')).read()
 
       # Fail without memory growth
-      self.do_run(src, 'Cannot enlarge memory arrays')
+      self.do_run(src, 'OOM')
       fail = open('src.cpp.o.js').read()
 
       # Win with it


### PR DESCRIPTION
When building with ABORTING_MALLOC==0, do not link in abortOnCannotGrowMemory(). Also optimize the error message to be a short 'oom' in release builds.