### PR TITLE
javascript_mime_type

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -512,6 +512,8 @@ class HTTPHandler(SimpleHTTPRequestHandler):
     ctype = self.guess_type(guess_file_type)
     if guess_file_type.lower().endswith('.wasm'):
       ctype = 'application/wasm'
+    if guess_file_type.lower().endswith('.js'):
+      ctype = 'application/javascript'
     self.send_header("Content-type", ctype)
     fs = os.fstat(f.fileno())
     self.send_header("Content-Length", str(fs[6]))

--- a/tests/manual_download_data.html
+++ b/tests/manual_download_data.html
@@ -160,7 +160,7 @@
       function addScriptToDom(scriptCode) {
         return new Promise(function(resolve, reject) {
           var script = document.createElement('script');
-          var blob = new Blob([scriptCode], { type: 'text/javascript' });
+          var blob = new Blob([scriptCode], { type: 'application/javascript' });
           var objectUrl = URL.createObjectURL(blob);
           script.src = objectUrl;
           script.onload = function() {


### PR DESCRIPTION
Make sure that .js files are served with MIME type application/javascript or pthreads importScripts() in src/worker.js can refuse to run them

Left out the locations at runtime which still load with `text/javascript`, in case that affects IE or other old browser. Only the test harness is now updated.