### PR TITLE
Allow again using EMCC_LOCAL_PORTS along with official ports

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -842,8 +842,6 @@ class Ports(object):
           shutil.copytree(path, os.path.join(fullname, subdir))
           Ports.clear_project_build(name)
           return
-      logging.error('could not find port %s' % name)
-      sys.exit(1)
 
     fullpath = fullname + ('.tar.bz2' if is_tarbz2 else '.zip')
 


### PR DESCRIPTION
EMCC_LOCAL_PORTS now overrides all ports, so it's not possible anymore to e.g. point to a patched SDL2 while using ZLIB.

(also, nice to see a clean-up in that area, but when changing a public interface with emcc, a note in ChangeLog.md please? :))
