### PR TITLE
MINIMAL_RUNTIME always uses new event target lookup behavior.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1311,7 +1311,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.STRICT = 1
 
       # Always use the new HTML5 API event target lookup rules (TODO: enable this when the other PR lands)
-      # shared.Settings.DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1
+      shared.Settings.DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1
 
       # In asm.js always use memory init file to get the best code size, other modes are not currently supported.
       if not shared.Settings.WASM:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8912,8 +8912,8 @@ int main () {
     test_cases = [
       (asmjs + opts, hello_world_sources, {'a.html': 665, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
       (opts, hello_world_sources, {'a.html': 623, 'a.js': 624, 'a.wasm': 86}),
-      (asmjs + opts, hello_webgl_sources, {'a.html': 665, 'a.js': 5249, 'a.asm.js': 10965, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 623, 'a.js': 5313, 'a.wasm': 8978})
+      (asmjs + opts, hello_webgl_sources, {'a.html': 665, 'a.js': 4949, 'a.asm.js': 10975, 'a.mem': 321}),
+      (opts, hello_webgl_sources, {'a.html': 623, 'a.js': 5015, 'a.wasm': 8978})
     ]
 
     success = True


### PR DESCRIPTION
When switching to MINIMAL_RUNTIME, developer needs to adapt a number of things to new scheme, so make that mode always use new DOM event lookup rules to fast track towards adopting new behavior.