### PR TITLE
emterpreter: support wildcards in EMTERPRETIFY_WHITELIST (#7988)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -15,6 +15,9 @@ full changeset diff at the end of each section.
 
 Current Trunk
 -------------
+ - Option -s EMTERPRETIFY_WHITELIST now accepts shell-style wildcards;
+   this allows matching static functions with conflicting names that
+   the linker distinguishes by appending a random suffix.
  - Normalize mouse wheel delta in `library_browser.js`. This changes the scroll
    amount in SDL, GLFW, and GLUT. (#7968)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5691,6 +5691,34 @@ function _main() {
       run_process([PYTHON, EMCC, 'src.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_WHITELIST=["_fleefl"]', '-s', 'PRECISE_F32=1'])
       self.assertContained('result: ' + out, run_js('a.out.js'))
 
+  @no_wasm_backend('uses emterpreter')
+  def test_emterpreter_async_whitelist_wildcard(self):
+    # using wildcard to match homonymous functions that the linker
+    # unpredictably renamed
+    create_test_file('src1.c', r'''
+      #include <stdio.h>
+      extern void call_other_module();
+      static void homonymous() {
+          printf("result: 1\n");
+      }
+      int main() {
+          homonymous();
+          call_other_module();
+      }
+      ''')
+    create_test_file('src2.c', r'''
+      #include <emscripten.h>
+      static void homonymous() {
+          emscripten_sleep(1);
+          printf("result: 2\n");
+      }
+      void call_other_module() {
+          homonymous();
+      }
+      ''')
+    run_process([PYTHON, EMCC, 'src1.c', 'src2.c', '-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1', '-s', 'EMTERPRETIFY_WHITELIST=["_main", "_call_other_module", "_homonymous*"]'])
+    self.assertContained('result: 1\nresult: 2', run_js('a.out.js'))
+
   @no_wasm_backend('uses EMTERPRETIFY')
   def test_call_nonemterpreted_during_sleep(self):
     create_test_file('src.c', r'''

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -11,7 +11,7 @@ Currently this requires the asm.js code to have been built with -s FINALIZE_ASM_
 '''
 
 from __future__ import print_function
-import os, sys, re, json, shutil
+import os, sys, re, json, shutil, fnmatch
 
 sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -49,6 +49,12 @@ def handle_arg(arg):
     elif l == 'FILE': OUTPUT_FILE = r[1:-1]
     return False
   return True
+
+def wildcards_match(func, whitelist):
+  for w in whitelist:
+    if fnmatch.fnmatch(func, w):
+      return True
+  return False
 
 DEBUG = os.environ.get('EMCC_DEBUG')
 
@@ -782,7 +788,7 @@ if __name__ == '__main__':
 
   if len(WHITELIST):
     # we are using a whitelist: fill the blacklist with everything not whitelisted
-    BLACKLIST = set([func for func in asm.funcs if func not in WHITELIST])
+    BLACKLIST = set([func for func in asm.funcs if not wildcards_match(func, WHITELIST)])
 
   # decide which functions will be emterpreted, and find which are externally reachable (from outside other emterpreted code; those will need trampolines)
 


### PR DESCRIPTION
Cf. #7988
I used wildcards (not regexs) as it seems simpler, though this can be changed.