### PR TITLE
Add support for MODULARIZE=1 with MINIMAL_RUNTIME.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1292,7 +1292,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # In MINIMAL_RUNTIME when modularizing, by default output asm.js module under the same name as the JS module. This allows code to share same loading function for both JS and asm.js modules,
     # to save code size. The intent is that loader code captures the function variable from global scope to XHR loader local scope when it finishes loading, to avoid polluting global JS scope with
     # variables. This provides safety via encapsulation. See src/shell_minimal_runtime.html for an example.
-    if shared.Settings.MINIMAL_RUNTIME and not shared.Settings.SEPARATE_ASM_MODULE_NAME and not shared.Settings.WASM:
+    if shared.Settings.MINIMAL_RUNTIME and not shared.Settings.SEPARATE_ASM_MODULE_NAME and not shared.Settings.WASM and shared.Settings.MODULARIZE:
       shared.Settings.SEPARATE_ASM_MODULE_NAME = 'var ' + shared.Settings.EXPORT_NAME
 
     if shared.Settings.MODULARIZE and shared.Settings.SEPARATE_ASM and not shared.Settings.WASM and not shared.Settings.SEPARATE_ASM_MODULE_NAME:

--- a/emcc.py
+++ b/emcc.py
@@ -2719,13 +2719,15 @@ function(%(EXPORT_NAME)s) {
   }
 
   if not shared.Settings.MODULARIZE_INSTANCE:
-    # When MODULARIZE this JS may be executed later,
-    # after document.currentScript is gone, so we save it.
-    # (when MODULARIZE_INSTANCE, an instance is created
-    # immediately anyhow, like in non-modularize mode)
     if shared.Settings.MINIMAL_RUNTIME and not shared.Settings.USE_PTHREADS:
+      # Single threaded MINIMAL_RUNTIME programs do not need access to
+      # document.currentScript, so a simple export declaration is enough.
       src = 'var %s=%s' % (shared.Settings.EXPORT_NAME, src)
     else:
+      # When MODULARIZE this JS may be executed later,
+      # after document.currentScript is gone, so we save it.
+      # (when MODULARIZE_INSTANCE, an instance is created
+      # immediately anyhow, like in non-modularize mode)
       src = '''
 var %(EXPORT_NAME)s = (function() {
   var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;

--- a/emcc.py
+++ b/emcc.py
@@ -2762,7 +2762,7 @@ var %(EXPORT_NAME)s = (%(src)s)(typeof %(EXPORT_NAME)s === 'object' ? %(EXPORT_N
 
     if shared.Settings.EXPORT_ES6:
       f.write('''export default %s;''' % shared.Settings.EXPORT_NAME)
-    elif shared.Settings.target_environment_may_be('node') or shared.Settings.target_environment_may_be('shell'):
+    elif not shared.Settings.MINIMAL_RUNTIME:
       f.write('''if (typeof exports === 'object' && typeof module === 'object')
       module.exports = %(EXPORT_NAME)s;
     else if (typeof define === 'function' && define['amd'])

--- a/emcc.py
+++ b/emcc.py
@@ -1289,11 +1289,19 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.DECLARE_ASM_MODULE_EXPORTS = 1
       logger.warning('Enabling -s DECLARE_ASM_MODULE_EXPORTS=1, since MODULARIZE currently requires declaring asm.js/wasm module exports in full')
 
+    # In MINIMAL_RUNTIME when modularizing, by default output asm.js module under the same name as the JS module. This allows code to share same loading function for both JS and asm.js modules,
+    # to save code size. The intent is that loader code captures the function variable from global scope to XHR loader local scope when it finishes loading, to avoid polluting global JS scope with
+    # variables. This provides safety via encapsulation. See src/shell_minimal_runtime.html for an example.
+    if shared.Settings.MINIMAL_RUNTIME and not shared.Settings.SEPARATE_ASM_MODULE_NAME and not shared.Settings.WASM:
+      shared.Settings.SEPARATE_ASM_MODULE_NAME = 'var ' + shared.Settings.EXPORT_NAME
+
     if shared.Settings.MODULARIZE and shared.Settings.SEPARATE_ASM and not shared.Settings.WASM and not shared.Settings.SEPARATE_ASM_MODULE_NAME:
       exit_with_error('Targeting asm.js with --separate-asm and -s MODULARIZE=1 requires specifying the target variable name to which the asm.js module is loaded into. See https://github.com/emscripten-core/emscripten/pull/7949 for details')
     # Apply default option if no custom name is provided
     if not shared.Settings.SEPARATE_ASM_MODULE_NAME:
       shared.Settings.SEPARATE_ASM_MODULE_NAME = 'Module["asm"]'
+    elif shared.Settings.WASM:
+      exit_with_error('-s SEPARATE_ASM_MODULE_NAME option only applies to when targeting asm.js, not with WebAssembly!')
 
     if shared.Settings.MINIMAL_RUNTIME:
       # Minimal runtime uses a different default shell file
@@ -1440,6 +1448,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       if shared.Settings.USE_PTHREADS:
         exit_with_error('-s USE_PTHREADS=1 is not yet supported with -s MINIMAL_RUNTIME=1')
+
+      if shared.Settings.PRECISE_F32 == 2:
+        exit_with_error('-s PRECISE_F32=2 is not supported with -s MINIMAL_RUNTIME=1')
+
+      if shared.Settings.SINGLE_FILE:
+        exit_with_error('-s SINGLE_FILE=1 is not supported with -s MINIMAL_RUNTIME=1')
 
     if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
       # this is an issue in asm.js, but not wasm
@@ -2687,17 +2701,21 @@ def modularize():
   logger.debug('Modularizing, assigning to var ' + shared.Settings.EXPORT_NAME)
   src = open(final).read()
 
+  # TODO: exports object generation for MINIMAL_RUNTIME
+  exports_object = '{}' if shared.Settings.MINIMAL_RUNTIME else shared.Settings.EXPORT_NAME
+
   src = '''
 function(%(EXPORT_NAME)s) {
   %(EXPORT_NAME)s = %(EXPORT_NAME)s || {};
 
 %(src)s
 
-  return %(EXPORT_NAME)s;
+  return %(exports_object)s
 }
 ''' % {
     'EXPORT_NAME': shared.Settings.EXPORT_NAME,
-    'src': src
+    'src': src,
+    'exports_object': exports_object
   }
 
   if not shared.Settings.MODULARIZE_INSTANCE:
@@ -2705,15 +2723,18 @@ function(%(EXPORT_NAME)s) {
     # after document.currentScript is gone, so we save it.
     # (when MODULARIZE_INSTANCE, an instance is created
     # immediately anyhow, like in non-modularize mode)
-    src = '''
+    if shared.Settings.MINIMAL_RUNTIME and not shared.Settings.USE_PTHREADS:
+      src = 'var %s=%s' % (shared.Settings.EXPORT_NAME, src)
+    else:
+      src = '''
 var %(EXPORT_NAME)s = (function() {
   var _scriptDir = typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined;
   return (%(src)s);
 })();
 ''' % {
-      'EXPORT_NAME': shared.Settings.EXPORT_NAME,
-      'src': src
-    }
+        'EXPORT_NAME': shared.Settings.EXPORT_NAME,
+        'src': src
+      }
   else:
     # Create the MODULARIZE_INSTANCE instance
     # Note that we notice the global Module object, just like in normal
@@ -2732,9 +2753,10 @@ var %(EXPORT_NAME)s = (%(src)s)(typeof %(EXPORT_NAME)s === 'object' ? %(EXPORT_N
     f.write(src)
 
     # Export using a UMD style export, or ES6 exports if selected
+
     if shared.Settings.EXPORT_ES6:
       f.write('''export default %s;''' % shared.Settings.EXPORT_NAME)
-    else:
+    elif shared.Settings.target_environment_may_be('node') or shared.Settings.target_environment_may_be('shell'):
       f.write('''if (typeof exports === 'object' && typeof module === 'object')
       module.exports = %(EXPORT_NAME)s;
     else if (typeof define === 'function' && define['amd'])
@@ -2777,10 +2799,11 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename,
   if re.search('{{{\s*SCRIPT\s*}}}', shell):
     exit_with_error('--shell-file "' + options.shell_path + '": MINIMAL_RUNTIME uses a different kind of HTML page shell file than the traditional runtime! Please see $EMSCRIPTEN/src/shell_minimal_runtime.html for a template to use as a basis.')
 
-  html_contents = shell.replace('{{{ TARGET_BASENAME }}}', target_basename)
-  html_contents = tools.line_endings.convert_line_endings(html_contents, '\n', options.output_eol)
+  shell = shell.replace('{{{ TARGET_BASENAME }}}', target_basename)
+  shell = shell.replace('{{{ EXPORT_NAME }}}', shared.Settings.EXPORT_NAME)
+  shell = tools.line_endings.convert_line_endings(shell, '\n', options.output_eol)
   with open(target, 'wb') as f:
-    f.write(asbytes(html_contents))
+    f.write(asbytes(shell))
 
 
 def generate_traditional_runtime_html(target, options, js_target, target_basename,

--- a/emcc.py
+++ b/emcc.py
@@ -1321,6 +1321,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if not shared.Settings.WASM:
         options.memory_init_file = True
 
+    if shared.Settings.MODULARIZE and not shared.Settings.MODULARIZE_INSTANCE and shared.Settings.EXPORT_NAME == 'Module' and final_suffix == '.html' and \
+       (options.shell_path == shared.path_from_root('src', 'shell.html') or options.shell_path == shared.path_from_root('src', 'shell_minimal.html')):
+      exit_with_error('Due to collision in variable name "Module", the shell file "' + options.shell_path + '" is not compatible with build options "-s MODULARIZE=1 -s EXPORT_NAME=Module". Either provide your own shell file, change the name of the export to something else to avoid the name collision. (see https://github.com/emscripten-core/emscripten/issues/7950 for details)')
+
     if shared.Settings.WASM:
       if shared.Settings.SINGLE_FILE:
         # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen

--- a/src/settings.js
+++ b/src/settings.js
@@ -836,6 +836,14 @@ var DETERMINISTIC = 0;
 // the module. (This allows, in particular, for you to create multiple
 // instantiations, etc.)
 //
+// The default .html shell file provided in MINIMAL_RUNTIME mode shows
+// an example to how the module is instantiated from within the html file.
+// The default .html shell file provided by traditional runtime mode is only
+// compatible with MODULARIZE=0 mode, so when building with traditional
+// runtime, you should provided your own html shell file to perform the
+// instantiation when building with MODULARIZE=1. (For more details, see
+// https://github.com/emscripten-core/emscripten/issues/7950)
+//
 // If you add --pre-js or --post-js files, they will be included inside
 // the module with the rest of the emitted code. That way, they can be
 // optimized together with it. (If you want something outside of the module,

--- a/src/shell_minimal_runtime.html
+++ b/src/shell_minimal_runtime.html
@@ -17,9 +17,13 @@
       var s = document.createElement('script');
       s.src = url;
       s.onload = () => {
+#if MODULARIZE
         var c = {{{ EXPORT_NAME }}};
         delete {{{ EXPORT_NAME }}};
         ok(c);
+#else
+        ok();
+#endif
       };
       document.body.appendChild(s);
     });
@@ -52,14 +56,12 @@
 #else
 #if MEM_INIT_METHOD == 1
   Promise.all([b('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js'), b('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
-    Module.asm = r[1];
     Module.mem = r[2];
     var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
     s(url).then(() => { URL.revokeObjectURL(url) });
   });
 #else
   Promise.all([b('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js')]).then((r) => {
-    Module.asm = r[1];
     var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
     s(url).then(() => { URL.revokeObjectURL(url) });
   });

--- a/src/shell_minimal_runtime.html
+++ b/src/shell_minimal_runtime.html
@@ -2,41 +2,70 @@
 <body>
 <canvas style='display:block; margin:auto;'></canvas>
 <script>
-  var Module = {};
-
-  function s(url, cb) { // Downloads a script file and adds it to DOM
-    var s = document.createElement('script');
-    s.src = url;
-    s.onload = cb;
-    document.body.appendChild(s);
-  }
-
   function b(url, cb) { // Downloads a binary file and outputs it in the specified callback
-    var x = new XMLHttpRequest();
-    x.open('GET', url, true);
-    x.responseType = 'arraybuffer';
-    x.onload = function() { cb(x.response); }
-    x.send(null);
+    return new Promise((ok, err) => {
+      var x = new XMLHttpRequest();
+      x.open('GET', url, true);
+      x.responseType = 'arraybuffer';
+      x.onload = () => { ok(x.response); }
+      x.send(null);
+    });
   }
 
+  function s(url) { // Downloads a script file and adds it to DOM
+    return new Promise((ok, err) => {
+      var s = document.createElement('script');
+      s.src = url;
+      s.onload = () => {
+        var c = {{{ EXPORT_NAME }}};
+        delete {{{ EXPORT_NAME }}};
+        ok(c);
+      };
+      document.body.appendChild(s);
+    });
+  }
+
+#if MODULARIZE
 #if WASM
-  b('{{{ TARGET_BASENAME }}}.wasm', function(wasm) {
-    Module.wasm = wasm;
-    s('{{{ TARGET_BASENAME }}}.js');
+  Promise.all([s('{{{ TARGET_BASENAME }}}.js'), b('{{{ TARGET_BASENAME }}}.wasm')]).then((r) => {
+    r[0]({ wasm: r[1] });
   });
 #else
 #if MEM_INIT_METHOD == 1
-  b('{{{ TARGET_BASENAME }}}.mem', function(mem) {
-    Module.mem = mem;
-#endif
-    s('{{{ TARGET_BASENAME }}}.asm.js', function() {
-      s('{{{ TARGET_BASENAME }}}.js');
-    });
-#if MEM_INIT_METHOD == 1
+  Promise.all([s('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js'), b('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
+    r[0]({ asm: r[1], mem: r[2] });
   });
-#endif
-#endif
-
+#else
+  Promise.all([s('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js')]).then((r) => {
+    r[0]({ asm: r[1] });
+  });
+#endif // MEM_INIT_METHOD
+#endif // WASM
+#else // MODULARIZE
+  var Module = {};
+#if WASM
+  Promise.all([b('{{{ TARGET_BASENAME }}}.js'), b('{{{ TARGET_BASENAME }}}.wasm')]).then((r) => {
+    Module.wasm = r[1];
+    var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
+    s(url).then(() => { URL.revokeObjectURL(url) });
+  });
+#else
+#if MEM_INIT_METHOD == 1
+  Promise.all([b('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js'), b('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
+    Module.asm = r[1];
+    Module.mem = r[2];
+    var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
+    s(url).then(() => { URL.revokeObjectURL(url) });
+  });
+#else
+  Promise.all([b('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js')]).then((r) => {
+    Module.asm = r[1];
+    var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
+    s(url).then(() => { URL.revokeObjectURL(url) });
+  });
+#endif // MEM_INIT_METHOD
+#endif // WASM
+#endif // MODULARIZE
 </script>
 </body>
 </html>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4581,3 +4581,11 @@ window.close = function() {
   @no_wasm_backend('MINIMAL_RUNTIME not yet available in Wasm backend')
   def test_no_declare_asm_module_exports_wasm_minimal_runtime(self):
     self.btest(path_from_root('tests', 'declare_asm_module_exports.cpp'), '1', args=['-s', 'DECLARE_ASM_MODULE_EXPORTS=0', '-s', 'ENVIRONMENT=web', '-O3', '--closure', '1', '-s', 'MINIMAL_RUNTIME=1'])
+
+  # Tests that the different code paths in src/shell_minimal_runtime.html all work ok.
+  @no_wasm_backend('MINIMAL_RUNTIME not yet available in Wasm backend')
+  def test_minimal_runtime_loader_shell(self):
+    args = ['-s', 'MINIMAL_RUNTIME=2']
+    for wasm in [[], ['-s', 'WASM=0', '--memory-init-file', '0'], ['-s', 'WASM=0', '--memory-init-file', '1']]:
+      for modularize in [[], ['-s', 'MODULARIZE=1']]:
+        self.btest('minimal_hello.c', '0', args=args + wasm + modularize)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4588,4 +4588,5 @@ window.close = function() {
     args = ['-s', 'MINIMAL_RUNTIME=2']
     for wasm in [[], ['-s', 'WASM=0', '--memory-init-file', '0'], ['-s', 'WASM=0', '--memory-init-file', '1']]:
       for modularize in [[], ['-s', 'MODULARIZE=1']]:
+        print(str(args + wasm + modularize))
         self.btest('minimal_hello.c', '0', args=args + wasm + modularize)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9010,11 +9010,11 @@ int main () {
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'USE_WEBGL2=1']
 
     test_cases = [
-      (asmjs + opts, hello_world_sources, {'a.html': 993, 'a.js': 289, 'a.asm.js': 110, 'a.mem': 6}),
-      (opts, hello_world_sources, {'a.html': 952, 'a.js': 624, 'a.wasm': 86}),
-      (asmjs + opts, hello_webgl_sources, {'a.html': 817, 'a.js': 4969, 'a.asm.js': 10972, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 788, 'a.js': 5035, 'a.wasm': 8978}),
-      (opts, hello_webgl2_sources, {'a.html': 788, 'a.js': 6170, 'a.wasm': 8978}) # Compare how WebGL2 sizes stack up with WebGL 1
+      (asmjs + opts, hello_world_sources, {'a.html': 985, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
+      (opts, hello_world_sources, {'a.html': 972, 'a.js': 624, 'a.wasm': 86}),
+      (asmjs + opts, hello_webgl_sources, {'a.html': 885, 'a.js': 4969, 'a.asm.js': 10972, 'a.mem': 321}),
+      (opts, hello_webgl_sources, {'a.html': 861, 'a.js': 5035, 'a.wasm': 8978}),
+      (opts, hello_webgl2_sources, {'a.html': 861, 'a.js': 6170, 'a.wasm': 8978}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9005,15 +9005,16 @@ int main () {
     opts = ['-O3', '--closure', '1', '-DNDEBUG', '-ffast-math']
 
     hello_world_sources = [path_from_root('tests', 'small_hello_world.c'), '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]', '-s', 'USES_DYNAMIC_ALLOC=0', '-s', 'ASM_PRIMITIVE_VARS=[STACKTOP]']
-    hello_webgl_sources = [path_from_root('tests', 'minimal_webgl', 'main.cpp'), path_from_root('tests', 'minimal_webgl', 'webgl.c'), '--js-library', path_from_root('tests', 'minimal_webgl', 'library_js.js'), '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]', '-s', 'USES_DYNAMIC_ALLOC=2', '-lGL']
+    hello_webgl_sources = [path_from_root('tests', 'minimal_webgl', 'main.cpp'), path_from_root('tests', 'minimal_webgl', 'webgl.c'), '--js-library', path_from_root('tests', 'minimal_webgl', 'library_js.js'),
+                           '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]', '-s', 'USES_DYNAMIC_ALLOC=2', '-lGL', '-s', 'MODULARIZE=1']
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'USE_WEBGL2=1']
 
     test_cases = [
-      (asmjs + opts, hello_world_sources, {'a.html': 476, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
-      (opts, hello_world_sources, {'a.html': 452, 'a.js': 624, 'a.wasm': 86}),
-      (asmjs + opts, hello_webgl_sources, {'a.html': 476, 'a.js': 4960, 'a.asm.js': 10975, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 452, 'a.js': 5026, 'a.wasm': 8978}),
-      (opts, hello_webgl2_sources, {'a.html': 452, 'a.js': 6162, 'a.wasm': 8978}) # Compare how WebGL2 sizes stack up with WebGL 1
+      (asmjs + opts, hello_world_sources, {'a.html': 993, 'a.js': 289, 'a.asm.js': 110, 'a.mem': 6}),
+      (opts, hello_world_sources, {'a.html': 952, 'a.js': 624, 'a.wasm': 86}),
+      (asmjs + opts, hello_webgl_sources, {'a.html': 817, 'a.js': 4969, 'a.asm.js': 10972, 'a.mem': 321}),
+      (opts, hello_webgl_sources, {'a.html': 788, 'a.js': 5035, 'a.wasm': 8978}),
+      (opts, hello_webgl2_sources, {'a.html': 788, 'a.js': 6170, 'a.wasm': 8978}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9012,9 +9012,9 @@ int main () {
     test_cases = [
       (asmjs + opts, hello_world_sources, {'a.html': 985, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
       (opts, hello_world_sources, {'a.html': 972, 'a.js': 624, 'a.wasm': 86}),
-      (asmjs + opts, hello_webgl_sources, {'a.html': 885, 'a.js': 4969, 'a.asm.js': 10972, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 861, 'a.js': 5035, 'a.wasm': 8978}),
-      (opts, hello_webgl2_sources, {'a.html': 861, 'a.js': 6170, 'a.wasm': 8978}) # Compare how WebGL2 sizes stack up with WebGL 1
+      (asmjs + opts, hello_webgl_sources, {'a.html': 885, 'a.js': 4980, 'a.asm.js': 10972, 'a.mem': 321}),
+      (opts, hello_webgl_sources, {'a.html': 861, 'a.js': 5046, 'a.wasm': 8978}),
+      (opts, hello_webgl2_sources, {'a.html': 861, 'a.js': 6182, 'a.wasm': 8978}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True

--- a/tools/hacky_postprocess_around_closure_limitations.py
+++ b/tools/hacky_postprocess_around_closure_limitations.py
@@ -8,29 +8,38 @@ orig_size = len(f)
 f = f.strip()
 
 if '"use asm";' in f:
-    f = re.sub(r'\s*/\*\* @suppress {uselessCode} \*/\s*', '', f)
-    f = re.sub(r'\s*//\s*EMSCRIPTEN_START_FUNCS\s*', '', f)
-    f = re.sub(r'\s*//\s*EMSCRIPTEN_END_FUNCS\s*', '', f)
-    f = f.replace('Module["asm"] = (function(global,env,buffer) {', 'Module["asm"]=(function(global,env,buffer){')
+  f = re.sub(r'\s*/\*\* @suppress {uselessCode} \*/\s*', '', f)
+  f = re.sub(r'\s*//\s*EMSCRIPTEN_START_FUNCS\s*', '', f)
+  f = re.sub(r'\s*//\s*EMSCRIPTEN_END_FUNCS\s*', '', f)
+  f = f.replace('Module["asm"] = (function(global,env,buffer) {', 'Module["asm"]=(function(global,env,buffer){')
 else:
-    # The following are introduced to the output after Closure has run, so need to manually optimize them out.
-    f = re.sub(r'\s*//\s*EMSCRIPTEN_START_ASM\s*', '', f)
-    f = re.sub(r'\s*//\s*EMSCRIPTEN_END_ASM\s*', '', f)
+  # The following are introduced to the output after Closure has run, so need to manually optimize them out.
+  f = re.sub(r'\s*//\s*EMSCRIPTEN_START_ASM\s*', '', f)
+  f = re.sub(r'\s*//\s*EMSCRIPTEN_END_ASM\s*', '', f)
 
-    # https://github.com/google/closure-compiler/issues/3185
-    f = re.sub(r';new Int8Array\(\w+\);', ';', f)
-    f = re.sub(r';new Int16Array\(\w+\);', ';', f)
-    f = re.sub(r';new Int32Array\(\w+\);', ';', f)
-    f = re.sub(r';new Uint8Array\(\w+\);', ';', f)
-    f = re.sub(r';new Uint16Array\(\w+\);', ';', f)
-    f = re.sub(r';new Uint32Array\(\w+\);', ';', f)
-    f = re.sub(r';new Float32Array\(\w+\);', ';', f)
-    f = re.sub(r';new Float64Array\(\w+\);', ';', f)
-    f = f.replace(';new TextDecoder("utf8");', ';')
-    f = f.replace('}new TextDecoder("utf8");', '}')
-    f = f.replace(';new TextDecoder("utf-16le");', ';')
-    f = f.replace('}new TextDecoder("utf-16le");', '}')
-    f = re.sub(r'var (\w);\1\|\|\(\1=Module\);', r'var \1=Module;', f)
+  # https://github.com/google/closure-compiler/issues/3185
+  f = re.sub(r';new Int8Array\(\w+\);', ';', f)
+  f = re.sub(r';new Int16Array\(\w+\);', ';', f)
+  f = re.sub(r';new Int32Array\(\w+\);', ';', f)
+  f = re.sub(r';new Uint8Array\(\w+\);', ';', f)
+  f = re.sub(r';new Uint16Array\(\w+\);', ';', f)
+  f = re.sub(r';new Uint32Array\(\w+\);', ';', f)
+  f = re.sub(r';new Float32Array\(\w+\);', ';', f)
+  f = re.sub(r';new Float64Array\(\w+\);', ';', f)
+  f = f.replace(';new TextDecoder("utf8");', ';')
+  f = f.replace('}new TextDecoder("utf8");', '}')
+  f = f.replace(';new TextDecoder("utf-16le");', ';')
+  f = f.replace('}new TextDecoder("utf-16le");', '}')
+
+  # var a;a||(a=Module)
+  # ->
+  # var a=Module;
+  f = re.sub(r'var (\w);\1\|\|\(\1=Module\);', r'var \1=Module;', f)
+
+  # var Module=function(Module){Module =Module || {};var a=Module;
+  # ->
+  # var Module=function(a){
+  f = re.sub(r'\s*function\s*\(Module\)\s*{\s*Module\s*=\s*Module\s*\|\|\s*{\s*}\s*;\s*var\s+(\w+)\s*=\s*Module\s*;', r'function(\1){', f)
 
 f = re.sub(r'\s+', ' ', f)
 f = re.sub(r'[\n\s]+\n\s*', '\n', f)

--- a/tools/separate_asm.py
+++ b/tools/separate_asm.py
@@ -84,7 +84,7 @@ else:
   everything = everything.replace(asm_search, closured_name + '["asm"]')
 
 with open(asmfile, 'w') as o:
-  o.write(asm_module_name + ' = ')
+  o.write(asm_module_name + '=')
   o.write(asm_replace)
 
 with open(otherfile, 'w') as o:


### PR DESCRIPTION
This also changes the default shell_minimal_runtime.html to show how to download all input files in parallel to improve startup times. That regresses .html size a little bit, but parallel downloading is so critical that it is well worth the size increase. (Also it's in default html shell so people can still customize)

In MINIMAL_RUNTIME we default to a scheme where both modularized .js file and the generated .asm.js file will have a structure `var {{{ EXPORT_NAME }}} = function(...){}`. This way the same function in a shell can load both files, and even though the variable names technically collide, loading is implemented using a scheme where both instances never end up in persisting global scope (simultaneously). This scheme is only the default, so users can still configure EXPORT_NAME & SEPARATE_ASM_MODULE_NAME like they wish.

Also sharpens how the generated JS module looks like in MINIMAL_RUNTIME. Because the `Module` object is gone there, with a `-s EXPORT_NAME=MyCode` it is now generating a structure of form

```js
var MyCode = function(Module){
  // access Module.asm, Module.wasm or Module.mem for imports
  return {
    // exports go here
  };
}
```
The function parameter name still unfortunately says `Module`, but I'm looking to change that to `emImports` or similar. After that, the variable name `Module` should no longer appear in modularized builds at all, which will hopefully make the role of different variables read clearer.
