### PR TITLE
Rename generated fetch worker JS file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,10 @@ Current Trunk
    ad hoc constructed rules around default Emscripten uses. The old behavior
    will be deprecated and removed in the future. Build with -s ASSERTIONS=1
    to get diagnostics messages related to this transition.
+ - Breaking change with -s USE_PTHREADS=1 + -s FETCH=1: When building with
+   -o a.html, the generated worker script is now named "a.fetch.js" according
+   to the base name of the specified output, instead of having a fixed name
+   "fetch-worker.js".
 
 v1.38.26: 02/04/2019
 --------------------

--- a/emcc.py
+++ b/emcc.py
@@ -1120,6 +1120,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')))
       next_arg_index += 1
       options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
+      if shared.Settings.USE_PTHREADS:
+        shared.Settings.FETCH_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.fetch.js'
 
     forced_stdlibs = []
     if shared.Settings.DEMANGLE_SUPPORT:
@@ -2022,13 +2024,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         with open(worker_output, 'w') as f:
           f.write(shared.read_and_preprocess(shared.path_from_root('src', 'worker.js'), expand_macros=True))
 
-      # Generate the fetch-worker.js script for multithreaded emscripten_fetch() support if targeting pthreads.
+      # Generate the fetch.js worker script for multithreaded emscripten_fetch() support if targeting pthreads.
       if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:
         if shared.Settings.WASM:
-          # FIXME(https://github.com/emscripten-core/emscripten/issues/7024)
-          logger.warning('Blocking calls to the fetch API do not work under WASM')
+          logger.warning('Bug/TODO: Blocking calls to the fetch API do not currently work under WASM (https://github.com/emscripten-core/emscripten/issues/7024)')
         else:
-          shared.make_fetch_worker(final, os.path.join(os.path.dirname(os.path.abspath(target)), 'fetch-worker.js'))
+          shared.make_fetch_worker(final, shared.Settings.FETCH_WORKER_FILE)
 
     # exit block 'memory initializer'
     log_time('memory initializer')

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -112,11 +112,10 @@ var Fetch = {
     if (isMainThread) {
       addRunDependency('library_fetch_init');
 
-      var fetchJs = 'fetch-worker.js';
       // Allow HTML module to configure the location where the 'worker.js' file will be loaded from,
       // via Module.locateFile() function. If not specified, then the default URL 'worker.js' relative
       // to the main html file is loaded.
-      fetchJs = locateFile(fetchJs);
+      var fetchJs = locateFile('{{{ FETCH_WORKER_FILE }}}');
       Fetch.worker = new Worker(fetchJs);
       Fetch.worker.onmessage = function(e) {
         out('fetch-worker sent a message: ' + e.filename + ':' + e.lineno + ': ' + e.message);

--- a/src/settings.js
+++ b/src/settings.js
@@ -1294,6 +1294,10 @@ var FETCH_DEBUG = 0;
 // If nonzero, enables emscripten_fetch API.
 var FETCH = 0;
 
+// Internal: name of the file containing the Fetch *.fetch.js, if relevant
+// Do not set yourself.
+var FETCH_WORKER_FILE = '';
+
 // If set to 1, uses the multithreaded filesystem that is implemented within the
 // asm.js module, using emscripten_fetch. Implies -s FETCH=1.
 var ASMFS = 0;


### PR DESCRIPTION
Rename generated fetch worker JS file from being hardcoded `'fetch-worker.js'` to '`out.fetch.js'`.