### PR TITLE
Add a test for /dev/random access in the browser

### DIFF
--- a/tests/filesystem/dev_random.cpp
+++ b/tests/filesystem/dev_random.cpp
@@ -1,3 +1,8 @@
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
 #include <stdio.h>
 int main() {
   int byte_count = 64;
@@ -9,4 +14,3 @@ int main() {
   REPORT_RESULT(0);
   return 0;
 }
-

--- a/tests/filesystem/dev_random.cpp
+++ b/tests/filesystem/dev_random.cpp
@@ -1,0 +1,12 @@
+#include <stdio.h>
+int main() {
+  int byte_count = 64;
+  char data[64];
+  FILE *fp;
+  fp = fopen("/dev/random", "r");
+  fread(&data, 1, byte_count, fp);
+  fclose(fp);
+  REPORT_RESULT(0);
+  return 0;
+}
+

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -661,6 +661,9 @@ If manually bisecting:
     # create_test_file('shell.html', open(path_from_root('src', 'shell.html')).read().replace('var Module = {', 'var Module = { locateFile: function (path) {return "http:/localhost:8888/cdn/" + path;}, '))
     # test()
 
+  def test_dev_random(self):
+    self.btest(os.path.join('filesystem', 'dev_random.cpp'), expected='0')
+
   def test_sdl_swsurface(self):
     self.btest('sdl_swsurface.c', args=['-lSDL', '-lGL'], expected='1')
 


### PR DESCRIPTION
To avoid regressions like the one fixed by fb03abc13058b0090e9f5a2b1b8c7fb29e0bc8f6