### PR TITLE
webgl2_code_size_comparison

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -182,16 +182,17 @@ var LibraryManager = {
       }
     }
 
+    // If there are any explicitly specified system JS libraries to link to, add those to link.
+    if (SYSTEM_JS_LIBRARIES) {
+      libraries = libraries.concat(SYSTEM_JS_LIBRARIES.split(','));
+    }
+
     if (USE_WEBGL2) {
       libraries.push('library_webgl2.js');
     }
 
     if (LEGACY_GL_EMULATION) {
       libraries.push('library_glemu.js');
-    }
-    // If there are any explicitly specified system JS libraries to link to, add those to link.
-    if (SYSTEM_JS_LIBRARIES) {
-      libraries = libraries.concat(SYSTEM_JS_LIBRARIES.split(','));
     }
 
     libraries = libraries.concat(additionalLibraries);

--- a/tests/minimal_webgl/webgl.c
+++ b/tests/minimal_webgl/webgl.c
@@ -51,6 +51,9 @@ void init_webgl(int width, int height)
   EmscriptenWebGLContextAttributes attrs;
   emscripten_webgl_init_context_attributes(&attrs);
   attrs.alpha = 0;
+#ifdef USE_WEBGL2
+  attrs.majorVersion = 2;
+#endif
   glContext = emscripten_webgl_create_context("canvas", &attrs);
   assert(glContext);
   emscripten_webgl_make_context_current(glContext);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8960,12 +8960,14 @@ int main () {
 
     hello_world_sources = [path_from_root('tests', 'small_hello_world.c'), '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]', '-s', 'USES_DYNAMIC_ALLOC=0', '-s', 'ASM_PRIMITIVE_VARS=[STACKTOP]']
     hello_webgl_sources = [path_from_root('tests', 'minimal_webgl', 'main.cpp'), path_from_root('tests', 'minimal_webgl', 'webgl.c'), '--js-library', path_from_root('tests', 'minimal_webgl', 'library_js.js'), '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]', '-s', 'USES_DYNAMIC_ALLOC=2', '-lGL']
+    hello_webgl2_sources = hello_webgl_sources + ['-s', 'USE_WEBGL2=1']
 
     test_cases = [
       (asmjs + opts, hello_world_sources, {'a.html': 665, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
       (opts, hello_world_sources, {'a.html': 623, 'a.js': 624, 'a.wasm': 86}),
       (asmjs + opts, hello_webgl_sources, {'a.html': 665, 'a.js': 4949, 'a.asm.js': 10975, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 623, 'a.js': 5015, 'a.wasm': 8978})
+      (opts, hello_webgl_sources, {'a.html': 623, 'a.js': 5015, 'a.wasm': 8978}),
+      (opts, hello_webgl2_sources, {'a.html': 623, 'a.js': 6150, 'a.wasm': 8978}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True


### PR DESCRIPTION
Add a new test case to test_minimal_runtime_code_size to check how WebGL 2 sizes compare to WebGL 1. (+22.6% bigger JS in hello_webgl)