### PR TITLE
Cheerp benchmarking improvements

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -384,3 +384,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Renaud Leroy <capitnflam@gmail.com>
 * Florian Stellbrink <florian@stellbr.ink>
 * Shane Peelar <lookatyouhacker@gmail.com>
+* Alessandro Pignotti <alessandro@leaningtech.com>

--- a/tests/bullet/src/BulletCollision/BroadphaseCollision/btDbvt.h
+++ b/tests/bullet/src/BulletCollision/BroadphaseCollision/btDbvt.h
@@ -92,7 +92,7 @@ subject to the following restrictions:
 #endif
 
 #if DBVT_USE_MEMMOVE
-#if !defined( __CELLOS_LV2__) && !defined(__MWERKS__)
+#if !defined( __CELLOS_LV2__) && !defined(__MWERKS__) && !defined(__CHEERP__)
 #include <memory.h>
 #endif
 #include <string.h>

--- a/tests/bullet/src/LinearMath/btSerializer.h
+++ b/tests/bullet/src/LinearMath/btSerializer.h
@@ -20,7 +20,7 @@ subject to the following restrictions:
 #include "btStackAlloc.h"
 #include "btHashMap.h"
 
-#if !defined( __CELLOS_LV2__) && !defined(__MWERKS__)
+#if !defined( __CELLOS_LV2__) && !defined(__MWERKS__) && !defined(__CHEERP__)
 #include <memory.h>
 #endif
 #include <string.h>

--- a/tests/fasta.cpp
+++ b/tests/fasta.cpp
@@ -188,7 +188,7 @@ static const char alu[] =
    "CCGGGAGGCGGAGGTTGCAGTGAGCCGAGATCGCGCCACTG"
    "CACTCCAGCCTGGGCGACAGAGCGAGACTCCGTCTCAAAAA";
 
-int main( int argc, const char *argv[] ) {
+int main( int argc, char *argv[] ) {
    const size_t n = ( argc > 1 ) ? atoi( argv[1] ) : 512;
 
    Repeater(alu)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -305,7 +305,11 @@ void webMain() {
     dirs_to_delete = []
     try:
       # print(cheerp_args)
-      cmd = [CHEERP_BIN + 'clang++'] + cheerp_args + [
+      if filename.endswith('.c'):
+        compiler = CHEERP_BIN + '/clang'
+      else:
+        compiler = CHEERP_BIN + '/clang++'
+      cmd = [compiler] + cheerp_args + [
         '-cheerp-linear-heap-size=256',
         '-cheerp-wasm-loader=' + final,
         cheerp_temp,

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -278,6 +278,7 @@ void webMain() {
     })
     cheerp_args = [
       '-target', 'cheerp',
+      '-fno-math-errno',
       '-Wno-c++11-narrowing',
       '-cheerp-mode=wasm'
     ]

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -304,6 +304,7 @@ void webMain() {
     final = final.replace('.cpp', '')
     try_delete(final)
     dirs_to_delete = []
+    cheerp_args += ['-cheerp-preexecute']
     try:
       # print(cheerp_args)
       if filename.endswith('.c'):

--- a/tests/zlib/zconf.h.in
+++ b/tests/zlib/zconf.h.in
@@ -198,7 +198,7 @@
 #endif
 
 /* Some Mac compilers merge all .h files incorrectly: */
-#if defined(__MWERKS__)||defined(applec)||defined(THINK_C)||defined(__SC__)
+#if defined(__MWERKS__)||defined(applec)||defined(THINK_C)||defined(__SC__)||defined(__CHEERP__)
 #  define NO_DUMMY_DECL
 #endif
 


### PR DESCRIPTION
This set of patches improves the Cheerp benchmarking capabilities. The following tests are known to be working, but others might work as well.

```base64, copy, corrections, fannkuch, fasta, havlak, memops, primes, skinning, zzz_box2d, zzz_bullet, zzz_zlib```