### PR TITLE
Fix non-wasm minification which broke with acorn_optimizer landing

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -341,10 +341,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if 'WASM=0' in params:
             if opt_level >= 2 and '-g' in params:
               assert re.search('HEAP8\[\$?\w+ ?\+ ?\(+\$?\w+ ?', generated) or re.search('HEAP8\[HEAP32\[', generated) or re.search('[i$]\d+ & ~\(1 << [i$]\d+\)', generated), 'eliminator should create compound expressions, and fewer one-time vars' # also in -O1, but easier to test in -O2
+            looks_unminified = ' = {}' in generated and ' = []' in generated
+            looks_minified = '={}' in generated and '=[]' and ';var' in generated
+            assert not (looks_minified and looks_unminified)
             if opt_level == 0 or '-g' in params:
-              assert 'function _main() {' in generated or 'function _main(){' in generated, 'Should be unminified'
+              assert looks_unminified
             elif opt_level >= 2:
-              assert ('function _main(){' in generated or '"use asm";var a=' in generated), 'Should be whitespace-minified'
+              assert looks_minified
 
   @no_wasm_backend('tests for asmjs optimzer')
   def test_emcc_5(self):

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -499,10 +499,10 @@ EMSCRIPTEN_FUNCS();
           temp_files.note(cld)
         elif cleanup:
           if DEBUG: print('running cleanup on shell code', file=sys.stderr)
-          passes = ['JSDCE']
+          acorn_passes = ['JSDCE']
           if 'minifyWhitespace' in passes:
-            passes.append('minifyWhitespace')
-          cld = shared.Building.acorn_optimizer(cld, passes)
+            acorn_passes.append('minifyWhitespace')
+          cld = shared.Building.acorn_optimizer(cld, acorn_passes)
           temp_files.note(cld)
         coutput = open(cld).read()
 


### PR DESCRIPTION
Sadly the test was not good enough to catch this.

The bug was just a silly name mixup on the `passes` variable.

Fixes #8072