### PR TITLE
Fix support for synchronous Fetches in fastcomp Wasm

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2029,8 +2029,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Generate the fetch.js worker script for multithreaded emscripten_fetch() support if targeting pthreads.
       if shared.Settings.FETCH and shared.Settings.USE_PTHREADS:
-        if shared.Settings.WASM:
-          logger.warning('Bug/TODO: Blocking calls to the fetch API do not currently work under WASM (https://github.com/emscripten-core/emscripten/issues/7024)')
+        if shared.Settings.WASM_BACKEND:
+          logger.warning('Bug/TODO: Blocking calls to the fetch API do not currently work under WASM backend (https://github.com/emscripten-core/emscripten/issues/7024)')
         else:
           shared.make_fetch_worker(final, shared.Settings.FETCH_WORKER_FILE)
 

--- a/src/fetch-worker.js
+++ b/src/fetch-worker.js
@@ -38,6 +38,13 @@ var Atomics_store = Atomics.store;
 var Atomics_sub = Atomics.sub;
 var Atomics_xor = Atomics.xor;
 
+function load1(ptr) { return HEAP8[ptr>>2]; }
+function store1(ptr, value) { HEAP8[ptr>>2] = value; }
+function load2(ptr) { return HEAP16[ptr>>2]; }
+function store2(ptr, value) { HEAP16[ptr>>2] = value; }
+function load4(ptr) { return HEAP32[ptr>>2]; }
+function store4(ptr, value) { HEAP32[ptr>>2] = value; }
+
 var ENVIRONMENT_IS_FETCH_WORKER = true;
 var ENVIRONMENT_IS_WORKER = true;
 var ENVIRONMENT_IS_PTHREAD = true;

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -28,13 +28,17 @@ extern "C" {
 // If passed, the final download will be stored in IndexedDB. If not specified, the file will only reside in browser memory.
 #define EMSCRIPTEN_FETCH_PERSIST_FILE 4
 
-// If the file already exists in IndexedDB, it is returned without redownload. If a partial transfer exists in IndexedDB,
-// the download will resume from where it left off and run to completion.
+// Looks up if the file already exists in IndexedDB, and if so, it is returned without redownload. If a partial transfer
+// exists in IndexedDB, the download will resume from where it left off and run to completion.
 // EMSCRIPTEN_FETCH_APPEND, EMSCRIPTEN_FETCH_REPLACE and EMSCRIPTEN_FETCH_NO_DOWNLOAD are mutually exclusive.
+// If none of these three flags is specified, the fetch operation is implicitly treated as if EMSCRIPTEN_FETCH_APPEND
+// had been passed.
 #define EMSCRIPTEN_FETCH_APPEND 8
 
 // If the file already exists in IndexedDB, the old file will be deleted and a new download is started.
 // EMSCRIPTEN_FETCH_APPEND, EMSCRIPTEN_FETCH_REPLACE and EMSCRIPTEN_FETCH_NO_DOWNLOAD are mutually exclusive.
+// If you would like to perform an XHR that neither reads or writes to IndexedDB, pass this flag EMSCRIPTEN_FETCH_REPLACE,
+// and do not pass the flag EMSCRIPTEN_FETCH_PERSIST_FILE.
 #define EMSCRIPTEN_FETCH_REPLACE 16
 
 // If specified, the file will only be looked up in IndexedDB, but if it does not exist, it is not attempted to be downloaded

--- a/system/lib/fetch/emscripten_fetch.cpp
+++ b/system/lib/fetch/emscripten_fetch.cpp
@@ -69,7 +69,7 @@ emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const 
 	if (!url) return 0;
 
 	const bool synchronous = (fetch_attr->attributes & EMSCRIPTEN_FETCH_SYNCHRONOUS) != 0;
-	const bool readFromIndexedDB = (fetch_attr->attributes & (EMSCRIPTEN_FETCH_APPEND | EMSCRIPTEN_FETCH_NO_DOWNLOAD)) != 0;
+	const bool readFromIndexedDB = (fetch_attr->attributes & (EMSCRIPTEN_FETCH_APPEND | EMSCRIPTEN_FETCH_NO_DOWNLOAD)) != 0 || ((fetch_attr->attributes & EMSCRIPTEN_FETCH_REPLACE) == 0);
 	const bool writeToIndexedDB = (fetch_attr->attributes & EMSCRIPTEN_FETCH_PERSIST_FILE) != 0 || !strncmp(fetch_attr->requestMethod, "EM_IDB_", strlen("EM_IDB_"));
 	const bool performXhr = (fetch_attr->attributes & EMSCRIPTEN_FETCH_NO_DOWNLOAD) == 0;
 	const bool isMainBrowserThread = emscripten_is_main_browser_thread() != 0;

--- a/tests/fetch/example_synchronous_fetch.cpp
+++ b/tests/fetch/example_synchronous_fetch.cpp
@@ -15,12 +15,8 @@ int main()
   strcpy(attr.requestMethod, "GET");
   attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY | EMSCRIPTEN_FETCH_SYNCHRONOUS;
   emscripten_fetch_t *fetch = emscripten_fetch(&attr, "gears.png");
-  
-  if (result == 0) {
-    result = 2;
-    printf("emscripten_fetch() failed to run synchronously!\n");
-  }
+  printf("Fetch finished with status %d\n", fetch->status);
 #ifdef REPORT_RESULT
-    REPORT_RESULT(result);
+  REPORT_RESULT(fetch->status);
 #endif
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4154,6 +4154,19 @@ window.close = function() {
     shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/sync_xhr.cpp', expected='1', args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-s', 'WASM=0', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
+  # Tests emscripten_fetch() usage when user passes none of the main 3 flags (append/replace/no_download).
+  # In that case, in append is implicitly understood.
+  @requires_threads
+  def test_fetch_implicit_append(self):
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
+    self.btest('fetch/example_synchronous_fetch.cpp', expected='200', args=['-s', 'FETCH=1', '-s', 'WASM=0', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
+
+  # Tests synchronous emscripten_fetch() usage from wasm pthread in fastcomp.
+  @no_wasm_backend("fetch API uses an asm.js based web worker to run synchronous XHRs and IDB operations")
+  def test_fetch_sync_xhr_in_wasm(self):
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
+    self.btest('fetch/example_synchronous_fetch.cpp', expected='200', args=['-s', 'FETCH=1', '-s', 'WASM=1', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
+
   # Tests that the Fetch API works for synchronous XHRs when used with --proxy-to-worker.
   @requires_threads
   def test_fetch_sync_xhr_in_proxy_to_worker(self):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3287,7 +3287,7 @@ def read_and_preprocess(filename, expand_macros=False):
 def make_fetch_worker(source_file, output_file):
   src = open(source_file, 'r').read()
   funcs_to_import = ['alignUp', '_emscripten_get_heap_size', '_emscripten_resize_heap', 'stringToUTF8', 'UTF8ToString', 'UTF8ArrayToString', 'intArrayFromString', 'lengthBytesUTF8', 'stringToUTF8Array', '_emscripten_is_main_runtime_thread', '_emscripten_futex_wait']
-  asm_funcs_to_import = ['_malloc', '_free', '_sbrk', '___pthread_mutex_lock', '___pthread_mutex_unlock']
+  asm_funcs_to_import = ['_malloc', '_free', '_sbrk', '___pthread_mutex_lock', '___pthread_mutex_unlock', '_pthread_mutexattr_init', '_pthread_mutex_init']
   function_prologue = '''this.onerror = function(e) {
   console.error(e);
 }


### PR DESCRIPTION
Fix support for synchronous Fetches in fastcomp Wasm. This uses a JS web worker even when compiled page itself is wasm. Also fix ambiguity bug in scenario when none of _APPEND, _REPLACE or _NO_DOWNLOAD flags is passed - in such scenario _APPEND is assumed. Add tests for both cases.

Bandaid for #8070 from upstream LLVM Wasm backend viewpoint.