### PR TITLE
Add support for shell environments in MINIMAL_RUNTIME

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2770,10 +2770,11 @@ def module_export_name_substitution():
     replacement = "typeof %(EXPORT_NAME)s !== 'undefined' ? %(EXPORT_NAME)s : {}" % {"EXPORT_NAME": shared.Settings.EXPORT_NAME}
   with open(final, 'w') as f:
     src = src.replace(shared.JS.module_export_name_substitution_pattern, replacement)
-    # For Node.js, create an unminified Module object so that loading external .asm.js file that assigns to Module['asm'] works
-    # even when Closure is used.
-    if shared.Settings.MINIMAL_RUNTIME and shared.Settings.target_environment_may_be('node'):
-      src = 'if(typeof process!=="undefined"){var Module={};}' + src
+    # For Node.js and other shell environments, create an unminified Module object so that
+    # loading external .asm.js file that assigns to Module['asm'] works even when Closure is used.
+    if shared.Settings.MINIMAL_RUNTIME and (shared.Settings.target_environment_may_be('node') or
+                                            shared.Settings.target_environment_may_be('shell')):
+      src = 'if(typeof Module==="undefined"){var Module={};}' + src
     f.write(src)
   save_intermediate('module_export_name_substitution')
 

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -21,7 +21,7 @@ var ENVIRONMENT_IS_NODE = typeof process === 'object';
 var ENVIRONMENT_IS_SHELL = typeof read === 'function';
 #endif
 
-#if ASSERTIONS && ENVIRONMENT_MAY_BE_SHELL && ENVIRONMENT_MAY_BE_SHELL
+#if ASSERTIONS && ENVIRONMENT_MAY_BE_NODE && ENVIRONMENT_MAY_BE_SHELL
 if (ENVIRONMENT_IS_NODE && ENVIRONMENT_IS_SHELL) {
   throw 'unclear environment';
 }

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -15,6 +15,19 @@ var Module = {{{ EXPORT_NAME }}};
 
 #if ENVIRONMENT_MAY_BE_NODE
 var ENVIRONMENT_IS_NODE = typeof process === 'object';
+#endif
+
+#if ENVIRONMENT_MAY_BE_SHELL
+var ENVIRONMENT_IS_SHELL = typeof read === 'function';
+#endif
+
+#if ASSERTIONS && ENVIRONMENT_MAY_BE_SHELL && ENVIRONMENT_MAY_BE_SHELL
+if (ENVIRONMENT_IS_NODE && ENVIRONMENT_IS_SHELL) {
+  throw 'unclear environment';
+}
+#endif
+
+#if ENVIRONMENT_MAY_BE_NODE
 if (ENVIRONMENT_IS_NODE) {
   var fs = require('fs');
 #if WASM
@@ -22,6 +35,17 @@ if (ENVIRONMENT_IS_NODE) {
 #else
   eval(fs.readFileSync(__dirname + '/{{{ TARGET_BASENAME }}}.asm.js')+'');
   Module['mem'] = fs.readFileSync(__dirname + '/{{{ TARGET_BASENAME }}}.mem');
+#endif
+}
+#endif
+
+#if ENVIRONMENT_MAY_BE_SHELL
+if (ENVIRONMENT_IS_SHELL) {
+#if WASM
+  Module['wasm'] = read('{{{ TARGET_BASENAME }}}.wasm', 'binary');
+#else
+  eval(read('{{{ TARGET_BASENAME }}}.asm.js')+'');
+  Module['mem'] = read('{{{ TARGET_BASENAME }}}.mem', 'binary');
 #endif
 }
 #endif


### PR DESCRIPTION
This lets us test and benchmark minimal runtime code in d8 and js shells for example.