### PR TITLE
Disable poppler test on macOS

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -58,7 +58,7 @@ __rootpath__ = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(__rootpath__)
 
 import parallel_runner
-from tools.shared import EM_CONFIG, TEMP_DIR, EMCC, DEBUG, PYTHON, LLVM_TARGET, ASM_JS_TARGET, EMSCRIPTEN_TEMP_DIR, WASM_TARGET, SPIDERMONKEY_ENGINE, WINDOWS, V8_ENGINE, NODE_JS
+from tools.shared import EM_CONFIG, TEMP_DIR, EMCC, DEBUG, PYTHON, LLVM_TARGET, ASM_JS_TARGET, EMSCRIPTEN_TEMP_DIR, WASM_TARGET, SPIDERMONKEY_ENGINE, WINDOWS, MACOS, V8_ENGINE, NODE_JS
 from tools.shared import asstr, get_canonical_temp_dir, Building, run_process, try_delete, to_cc, asbytes, safe_copy, Settings
 from tools import jsrun, shared, line_endings
 
@@ -136,6 +136,12 @@ def no_wasm_backend(note=''):
 
 def no_windows(note=''):
   if WINDOWS:
+    return unittest.skip(note)
+  return lambda f: f
+
+
+def no_macos(note=''):
+  if MACOS:
     return unittest.skip(note)
   return lambda f: f
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,7 +24,7 @@ from tools.shared import Building, STDOUT, PIPE, run_js, run_process, try_delete
 from tools.shared import NODE_JS, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, PYTHON, EMCC, EMAR, WINDOWS, AUTODEBUGGER
 from tools import jsrun, shared
 from runner import RunnerCore, path_from_root, core_test_modes, get_bullet_library, get_freetype_library, get_poppler_library
-from runner import skip_if, no_wasm_backend, needs_dlfcn, no_windows, env_modify, with_env_modify, is_slow_test, create_test_file
+from runner import skip_if, no_wasm_backend, needs_dlfcn, no_windows, no_macos, env_modify, with_env_modify, is_slow_test, create_test_file
 
 # decorators for limiting which modes a test can run in
 
@@ -5706,6 +5706,7 @@ return malloc(size);
         assert len(old) > len(new)
         assert old.count('tempBigInt') > new.count('tempBigInt')
 
+  @no_macos('https://bugs.llvm.org/show_bug.cgi?id=40503 may be harming the bot due to output size')
   @no_windows('depends on freetype, which uses a ./configure which donsnt run on windows.')
   @is_slow_test
   def test_poppler(self):


### PR DESCRIPTION
A current open issue (https://bugs.llvm.org/show_bug.cgi?id=40503) causes large logging which may be harming the bot.