### PR TITLE
Tiny WebIDL simplification

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -760,7 +760,7 @@ mid_js += ['''
   function setupEnums() {
     %s
   }
-  if (Module['calledRun']) setupEnums();
+  if (runtimeInitialized) setupEnums();
   else addOnPreMain(setupEnums);
 })();
 ''' % '\n    '.join(deferred_js)]


### PR DESCRIPTION
WebIDL glue code is compiled together with the rest of the JS, no need to use external Module interfaces unnecessarily.