### PR TITLE
EMSCRIPTEN_NO_STDIO_H for optional stdio.h inclusion

### DIFF
--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -28,7 +28,9 @@
 extern "C" {
 #endif
 
+#if !defined(EMSCRIPTEN_NO_STDIO_H)
 #include <stdio.h>
+#endif
 
 #if !__EMSCRIPTEN__
 #include <SDL/SDL.h> /* for SDL_Delay in async_call */
@@ -233,7 +235,9 @@ int emscripten_get_compiler_setting(const char *name);
 void emscripten_debugger(void);
 
 char *emscripten_get_preloaded_image_data(const char *path, int *w, int *h);
+#if !defined(EMSCRIPTEN_NO_STDIO_H)
 char *emscripten_get_preloaded_image_data_from_FILE(FILE *file, int *w, int *h);
+#endif
 
 #define EM_LOG_CONSOLE   1
 #define EM_LOG_WARN      2


### PR DESCRIPTION
An embeddable thing I'm working on is adamant about not wanting any stdio.h linkage.  (It does its own formatted I/O, and any printf()s that leak through are considered bugs--it shouldn't link any of that in).  Attempting to `#include <stdio.h>` in the release build causes errors.

However, emscripten.h has an unconditional inclusion of `<stdio.h>`.  It seems to be just for one API function that needs `FILE*`...`emscripten_get_preloaded_image_data_from_FILE()`.

It would be convenient for me (and perhaps others in unusual compilation configurations?) if there were a way to ask stdio.h to not be included.  Here's a suggestion.