### PR TITLE
Allow using cDefine() in the preprocessor called from python

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -180,16 +180,6 @@ RUNTIME_DEBUG = LIBRARY_DEBUG || GL_DEBUG;
 
 if (VERBOSE) printErr('VERBOSE is on, this generates a lot of output and can slow down compilation');
 
-if (!BOOTSTRAPPING_STRUCT_INFO && !ONLY_MY_CODE) {
-  // Load struct and define information.
-  var temp = JSON.parse(read(STRUCT_INFO));
-  C_STRUCTS = temp.structs;
-  C_DEFINES = temp.defines;
-} else {
-  C_STRUCTS = {};
-  C_DEFINES = {};
-}
-
 // Load compiler code
 
 load('modules.js');

--- a/src/modules.js
+++ b/src/modules.js
@@ -315,6 +315,16 @@ var LibraryManager = {
   }
 };
 
+if (!BOOTSTRAPPING_STRUCT_INFO && !ONLY_MY_CODE) {
+  // Load struct and define information.
+  var temp = JSON.parse(read(STRUCT_INFO));
+  C_STRUCTS = temp.structs;
+  C_DEFINES = temp.defines;
+} else {
+  C_STRUCTS = {};
+  C_DEFINES = {};
+}
+
 // Safe way to access a C define. We check that we don't add library functions with missing defines.
 function cDefine(key) {
 	if (key in C_DEFINES) return C_DEFINES[key];

--- a/tools/preprocessor.js
+++ b/tools/preprocessor.js
@@ -135,6 +135,8 @@ var shell_file = arguments_[1];
 var process_macros = arguments_.indexOf('--expandMacros') >= 0;
 
 load(settings_file);
+load('utility.js');
+load('modules.js');
 load('parseTools.js');
 
 var from_html = read(shell_file);


### PR DESCRIPTION
To allow that, load `C_STRUCTS|DEFINES` in modules.js, alongside the code that uses it, which is clearer anyhow. And load modules.js (and utilities which it requires) in the preprocessor so it can access that.