### PR TITLE
Adjust old sanity error message

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1034,7 +1034,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       assert shared.Settings.QUANTUM_SIZE == 4, 'altering the QUANTUM_SIZE is not supported'
     except Exception as e:
       logger.error('Compiler settings error: {}'.format(e))
-      exit_with_error('Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended, see http://kripken.github.io/emscripten-site/docs/building_from_source/LLVM-Backend.html')
+      exit_with_error('Very old compiler settings (pre-fastcomp) are no longer supported.')
 
     assert not shared.Settings.PGO, 'cannot run PGO in ASM_JS mode'
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -326,7 +326,7 @@ class sanity(RunnerCore):
 
     restore_and_set_up()
 
-    self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'ASM_JS=0'], '''Compiler settings are incompatible with fastcomp. You can fall back to the older compiler core, although that is not recommended''')
+    self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'ASM_JS=0'], '''Very old compiler settings (pre-fastcomp) are no longer supported.''')
 
   def test_node(self):
     NODE_WARNING = 'node version appears too old'


### PR DESCRIPTION
@sbc100 thanks for catching this in the other PR - there were two very similar error messages, one in tools/shared.py (removed) and one in emcc.py. I think the emcc.py one might be worth keeping, so I just fixed the message and updated the test.