### PR TITLE
Remove include of stdio.h from emscripten.h to avoid include pollution.

### DIFF
--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -28,8 +28,6 @@
 extern "C" {
 #endif
 
-#include <stdio.h>
-
 #if !__EMSCRIPTEN__
 #include <SDL/SDL.h> /* for SDL_Delay in async_call */
 #endif
@@ -231,6 +229,10 @@ int emscripten_get_worker_queue_size(worker_handle worker);
 int emscripten_get_compiler_setting(const char *name);
 
 void emscripten_debugger(void);
+
+// Forward declare FILE from musl libc headers to avoid needing to #include <stdio.h> from emscripten.h
+struct _IO_FILE;
+typedef struct _IO_FILE FILE;
 
 char *emscripten_get_preloaded_image_data(const char *path, int *w, int *h);
 char *emscripten_get_preloaded_image_data_from_FILE(FILE *file, int *w, int *h);

--- a/system/lib/gl/webgl1.c
+++ b/system/lib/gl/webgl1.c
@@ -2,6 +2,7 @@
 #include <emscripten.h>
 #include <string.h>
 #include <stdlib.h>
+#include <sys/types.h>
 
 #include "webgl1.h"
 #include "webgl1_ext.h"

--- a/tests/core/FS_exports.cpp
+++ b/tests/core/FS_exports.cpp
@@ -3,7 +3,8 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
-#include<emscripten.h>
+#include <emscripten.h>
+#include <stdio.h>
 
 int main() {
 #ifdef USE_FILES

--- a/tests/idbstore.c
+++ b/tests/idbstore.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <assert.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 #include <emscripten.h>
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3226,6 +3226,7 @@ mergeInto(LibraryManager.library, {
 ''')
     create_test_file('src.cpp', r'''
 #include <emscripten.h>
+#include <stdio.h>
 extern "C" int jslibfunc(int x);
 int main() {
   printf("c calling: %d\n", jslibfunc(6));
@@ -5741,6 +5742,7 @@ function _main() {
       ''')
     create_test_file('src2.c', r'''
       #include <emscripten.h>
+      #include <stdio.h>
       static void homonymous() {
           emscripten_sleep(1);
           printf("result: 2\n");


### PR DESCRIPTION
Remove include of stdio.h from emscripten.h to avoid include pollution. Fixes #8089
