### PR TITLE
Cheerp benchmark improvements

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -236,9 +236,7 @@ class CheerpBenchmarker(Benchmarker):
       %(code)s
 #include <cheerp/client.h>
 void webMain() {
-  // The values here don't matter - the benchmark harness has created a main()
-  // with hardcoded parameters anyhow.
-  main(1, NULL);
+  main();
 }\n''' % {
       'code': code,
     })
@@ -265,7 +263,8 @@ void webMain() {
         'CXXFLAGS': ' '.join(cheerp_args),
         'CHEERP_PREFIX': CHEERP_BIN + '../',
       })
-    # cheerp_args += ['-cheerp-pretty-code'] # get function names, like emcc --profiling
+    if PROFILING:
+      cheerp_args += ['-cheerp-pretty-code'] # get function names, like emcc --profiling
     final = os.path.dirname(filename) + os.path.sep + self.name + ('_' if self.name else '') + os.path.basename(filename) + '.js'
     final = final.replace('.cpp', '')
     try_delete(final)
@@ -285,7 +284,7 @@ void webMain() {
         '-o', final.replace('.js', '.wasm')
       ] + shared_args
       # print(' '.join(cmd))
-      run_process(cmd)
+      run_process(cmd, stdout=PIPE, stderr=PIPE)
       self.filename = final
       # Inject command line arguments
       run_process(['sed', '-i', 's/"use strict";/"use strict";var args=typeof(scriptArgs) !== "undefined" ? scriptArgs : arguments;/', self.filename])


### PR DESCRIPTION
 * Fix cheerp main (broke when I moved to hardcoding arguments)
 * Add profiling option support
 * Cleanup stdout/err output

cc @alexp-sssup btw, I ran the benchmark suite on my machine, using `cheerp 2.0-1~cosmic`. Oddly, looking at the same benchmarks you did, I see emscripten as 8% faster, and not 5% slower, which is strange (maybe a different VM explains some difference, I tested on v8 `5a81b2075b2a6ddb1de75e5cce2b80d14ab31e70`, but still surprising.). Some other details I noticed:

 * Cheerp's malloc (newlib's?) is half the size of emscripten's (dlmalloc). This probably explains why Cheerp is 20% slower on Havlak, which is malloc-heavy. If Cheerp's default allocator is simpler&smaller, using emscripten's smaller allocator would be more apples-to-apples (it's a third the size of the default dlmalloc).
 * Thanks to looking carefully at wasm binary comparisons, I found many of the benchmarks include 2.5K of unnecessary code from musl, fix in https://github.com/emscripten-core/emscripten/pull/8133
 * Binaryen's `wasm-opt` shrinks Cheerp wasm files by around 5%, which shows that Cheerp improved, as before it was 15% iirc.