### PR TITLE
Remove 'ar' flag handling from emcc.py

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -645,11 +645,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   # ---------------- End configs -------------
 
-  if len(sys.argv) == 1 or sys.argv[1] in ['x', 't']:
-    # noop ar
-    logger.debug('just ar')
-    return 0
-
   # Check if a target is specified
   target = None
   if any(arg.startswith('-o=') for arg in sys.argv):


### PR DESCRIPTION
Not sure what this code was supposed to do but it doesn't seem to
be used anywhere.  It was part of the initial `emcc` commit back in
the 2011.
