### PR TITLE
Rewrite and move test_nostdincxx test

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -714,6 +714,22 @@ f.close()
 
     run_process([emcmake, 'cmake', path_from_root('tests', 'cmake', 'emscripten_version')])
 
+  def test_nostdincxx(self):
+    path_from_root('tests', 'hello_world.cpp')
+    cmd = [PYTHON, EMCC] + [path_from_root('tests', 'hello_world.cpp')]
+
+    err1 = run_process(cmd + ['-v'], stderr=PIPE).stderr
+    err2 = run_process(cmd + ['-v', '-nostdinc++'], stderr=PIPE).stderr
+
+    def focus(e):
+      assert 'search starts here:' in e, e
+      assert e.count('End of search list.') == 1, e
+      return e[e.index('search starts here:'):e.index('End of search list.') + 20]
+
+    err1 = focus(err1)
+    err2 = focus(err2)
+    assert err1 == err2, err1 + '\n\n\n\n' + err2
+
   def test_failure_error_code(self):
     for compiler in [EMCC, EMXX]:
       # Test that if one file is missing from the build, then emcc shouldn't succeed, and shouldn't produce an output file.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -714,22 +714,6 @@ f.close()
 
     run_process([emcmake, 'cmake', path_from_root('tests', 'cmake', 'emscripten_version')])
 
-  def test_nostdincxx(self):
-    path_from_root('tests', 'hello_world.cpp')
-    cmd = [PYTHON, EMCC] + [path_from_root('tests', 'hello_world.cpp')]
-
-    err1 = run_process(cmd + ['-v'], stderr=PIPE).stderr
-    err2 = run_process(cmd + ['-v', '-nostdinc++'], stderr=PIPE).stderr
-
-    def focus(e):
-      assert 'search starts here:' in e, e
-      assert e.count('End of search list.') == 1, e
-      return e[e.index('search starts here:'):e.index('End of search list.') + 20]
-
-    err1 = focus(err1)
-    err2 = focus(err2)
-    assert err1 == err2, err1 + '\n\n\n\n' + err2
-
   def test_failure_error_code(self):
     for compiler in [EMCC, EMXX]:
       # Test that if one file is missing from the build, then emcc shouldn't succeed, and shouldn't produce an output file.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -717,19 +717,17 @@ f.close()
   def test_nostdincxx(self):
     path_from_root('tests', 'hello_world.cpp')
     cmd = [PYTHON, EMCC] + [path_from_root('tests', 'hello_world.cpp')]
-    run_process(cmd) # run once to ensure cache is warmed up
 
-    proc1 = run_process(cmd + ['-v'], stdout=PIPE, stderr=PIPE)
-    proc2 = run_process(cmd + ['-v', '-nostdinc++'], stdout=PIPE, stderr=PIPE)
-    self.assertIdentical(proc1.stdout, proc2.stdout)
+    err1 = run_process(cmd + ['-v'], stderr=PIPE).stderr
+    err2 = run_process(cmd + ['-v', '-nostdinc++'], stderr=PIPE).stderr
 
     def focus(e):
       assert 'search starts here:' in e, e
       assert e.count('End of search list.') == 1, e
       return e[e.index('search starts here:'):e.index('End of search list.') + 20]
 
-    err1 = focus(proc1.stderr)
-    err2 = focus(proc2.stderr)
+    err1 = focus(err1)
+    err2 = focus(err2)
     assert err1 == err2, err1 + '\n\n\n\n' + err2
 
   def test_failure_error_code(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -715,13 +715,10 @@ f.close()
     run_process([emcmake, 'cmake', path_from_root('tests', 'cmake', 'emscripten_version')])
 
   def test_system_include_paths(self):
-    # Verify that all our default include paths are within `emscripten/system`
-    path_from_root('tests', 'hello_world.cpp')
-    cmd = [PYTHON, EMCC] + [path_from_root('tests', 'hello_world.c')]
-    cmd = [PYTHON, EMXX] + [path_from_root('tests', 'hello_world.cpp')]
+    # Verify that all default include paths are within `emscripten/system`
 
     def verify_includes(stderr):
-      assert '<...> search starts here:' in stderr, stderr
+      self.assertContained('<...> search starts here:', stderr)
       assert stderr.count('End of search list.') == 1, stderr
       start = stderr.index('<...> search starts here:')
       end = stderr.index('End of search list.')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -714,6 +714,24 @@ f.close()
 
     run_process([emcmake, 'cmake', path_from_root('tests', 'cmake', 'emscripten_version')])
 
+  def test_nostdincxx(self):
+    path_from_root('tests', 'hello_world.cpp')
+    cmd = [PYTHON, EMCC] + [path_from_root('tests', 'hello_world.cpp')]
+    run_process(cmd) # run once to ensure cache is warmed up
+
+    proc1 = run_process(cmd + ['-v'], stdout=PIPE, stderr=PIPE)
+    proc2 = run_process(cmd + ['-v', '-nostdinc++'], stdout=PIPE, stderr=PIPE)
+    self.assertIdentical(proc1.stdout, proc2.stdout)
+
+    def focus(e):
+      assert 'search starts here:' in e, e
+      assert e.count('End of search list.') == 1, e
+      return e[e.index('search starts here:'):e.index('End of search list.') + 20]
+
+    err1 = focus(proc1.stderr)
+    err2 = focus(proc2.stderr)
+    assert err1 == err2, err1 + '\n\n\n\n' + err2
+
   def test_failure_error_code(self):
     for compiler in [EMCC, EMXX]:
       # Test that if one file is missing from the build, then emcc shouldn't succeed, and shouldn't produce an output file.

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -573,30 +573,6 @@ fi
     else:
       self.assertTrue(os.path.exists(os.path.join(cache_dir_name, 'asmjs', 'libc.bc')))
 
-  def test_nostdincxx(self):
-    restore_and_set_up()
-    Cache.erase()
-
-    for compiler in [EMCC]:
-      print(compiler)
-      run_process([PYTHON, EMCC] + MINIMAL_HELLO_WORLD + ['-v']) # run once to ensure binaryen port is all ready
-      proc = run_process([PYTHON, EMCC] + MINIMAL_HELLO_WORLD + ['-v'], stdout=PIPE, stderr=PIPE)
-      out = proc.stdout
-      err = proc.stderr
-      proc2 = run_process([PYTHON, EMCC] + MINIMAL_HELLO_WORLD + ['-v', '-nostdinc++'], stdout=PIPE, stderr=PIPE)
-      out2 = proc2.stdout
-      err2 = proc2.stderr
-      self.assertIdentical(out, out2)
-
-      def focus(e):
-        assert 'search starts here:' in e, e
-        assert e.count('End of search list.') == 1, e
-        return e[e.index('search starts here:'):e.index('End of search list.') + 20]
-
-      err = focus(err)
-      err2 = focus(err2)
-      assert err == err2, err + '\n\n\n\n' + err2
-
   def test_emconfig(self):
     restore_and_set_up()
 


### PR DESCRIPTION
This test seems to have been written to verify that no external include paths were included by default.

This change rewrites it to check each path individually and moves it back out of "sanity" and into
"other" where is used to live.  It was moved becasuse it used to clear the cache, which is not longer
does.