### PR TITLE
Remove addition of legacy include path to shared.C_INCLUDE_PATHS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1007,13 +1007,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.WASM_OBJECT_FILES = 0
 
     if not shared.Settings.STRICT:
-      # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code in strict mode. Code should use the define __EMSCRIPTEN__ instead.
+      # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
+      # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
       shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
-
-      # The system include path system/include/emscripten/ is deprecated, i.e. instead of #include <emscripten.h>, one should pass in #include <emscripten/emscripten.h>.
-      # This path is not available in Emscripten strict mode.
-      if shared.USE_EMSDK:
-        shared.C_INCLUDE_PATHS += [shared.path_from_root('system', 'include', 'emscripten')]
 
     # Use settings
 


### PR DESCRIPTION
This addition was introduced in 815a35bd149, but has never had
any effect since C_INCLUDE_PATHS is only referenced when shared
is first imported.  Modifying it at runtime has no effect.  So,
we could make this work, but since its been this way since 2016
probably safer/better to just remove it.