### PR TITLE
Fix Issue 8042 - _emscripten_traverse_stack updated

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4446,37 +4446,12 @@ LibraryManager.library = {
       );
   },
 
-  // Returns [parentFuncArguments, functionName, paramListName]
-  /*_emscripten_traverse_stack: function(args) {
-    if (!args || !args.callee || !args.callee.name) {
-      return [null, '', ''];
-    }
-
-    var funstr = args.callee.toString();
-    var funcname = args.callee.name;
-    var str = '(';
-    var first = true;
-    for (var i in args) {
-      var a = args[i];
-      if (!first) {
-        str += ", ";
-      }
-      first = false;
-      if (typeof a === 'number' || typeof a === 'string') {
-        str += a;
-      } else {
-        str += '(' + typeof a + ')';
-      }
-    }
-    str += ')';
-    var caller = args.callee.caller;
-    args = caller ? caller.arguments : [];
-    if (first)
-      str = '';
-    return [args, funcname, str];
+  // Function disabled
+  _emscripten_traverse_stack: function(args) {
+    return null;
   },
-  */
-  //emscripten_get_callstack_js__deps: ['_emscripten_traverse_stack'],
+
+  emscripten_get_callstack_js__deps: ['_emscripten_traverse_stack'],
   emscripten_get_callstack_js: function(flags) {
     var callstack = jsStackTrace();
 
@@ -4496,9 +4471,9 @@ LibraryManager.library = {
     var stack_args = null;
     if (flags & 128 /*EM_LOG_FUNC_PARAMS*/) {
       // To get the actual parameters to the functions, traverse the stack via the unfortunately deprecated 'arguments.callee' method, if it works:
-      /*stack_args = __emscripten_traverse_stack(arguments);
+      stack_args = __emscripten_traverse_stack(arguments);
       while (stack_args[1].indexOf('_emscripten_') >= 0)
-        stack_args = __emscripten_traverse_stack(stack_args[0]);*/
+        stack_args = __emscripten_traverse_stack(stack_args[0]);
     }
 
     // Process all lines:

--- a/src/library.js
+++ b/src/library.js
@@ -4543,7 +4543,7 @@ LibraryManager.library = {
           callstack = callstack.replace(/\s+$/, '');
           callstack += ' with values: ' + stack_args[1] + stack_args[2] + '\n';
         }
-        //stack_args = __emscripten_traverse_stack(stack_args[0]);
+        stack_args = __emscripten_traverse_stack(stack_args[0]);
       }
     }
     // Trim extra whitespace at the end of the output.

--- a/src/library.js
+++ b/src/library.js
@@ -4446,12 +4446,6 @@ LibraryManager.library = {
       );
   },
 
-  // Function disabled
-  _emscripten_traverse_stack: function(args) {
-    return null;
-  },
-
-  emscripten_get_callstack_js__deps: ['_emscripten_traverse_stack'],
   emscripten_get_callstack_js: function(flags) {
     var callstack = jsStackTrace();
 
@@ -4466,14 +4460,6 @@ LibraryManager.library = {
       warnOnce('Source map information is not available, emscripten_log with EM_LOG_C_STACK will be ignored. Build with "--pre-js $EMSCRIPTEN/src/emscripten-source-map.min.js" linker flag to add source map loading to code.');
       flags ^= 8/*EM_LOG_C_STACK*/;
       flags |= 16/*EM_LOG_JS_STACK*/;
-    }
-
-    var stack_args = null;
-    if (flags & 128 /*EM_LOG_FUNC_PARAMS*/) {
-      // To get the actual parameters to the functions, traverse the stack via the unfortunately deprecated 'arguments.callee' method, if it works:
-      stack_args = __emscripten_traverse_stack(arguments);
-      while (stack_args[1].indexOf('_emscripten_') >= 0)
-        stack_args = __emscripten_traverse_stack(stack_args[0]);
     }
 
     // Process all lines:
@@ -4537,14 +4523,6 @@ LibraryManager.library = {
         callstack += (haveSourceMap ? ('     = '+jsSymbolName) : ('    at '+cSymbolName)) + ' (' + file + ':' + lineno + ':' + column + ')\n';
       }
 
-      // If we are still keeping track with the callstack by traversing via 'arguments.callee', print the function parameters as well.
-      if (flags & 128 /*EM_LOG_FUNC_PARAMS*/ && stack_args[0]) {
-        if (stack_args[1] == jsSymbolName && stack_args[2].length > 0) {
-          callstack = callstack.replace(/\s+$/, '');
-          callstack += ' with values: ' + stack_args[1] + stack_args[2] + '\n';
-        }
-        stack_args = __emscripten_traverse_stack(stack_args[0]);
-      }
     }
     // Trim extra whitespace at the end of the output.
     callstack = callstack.replace(/\s+$/, '');

--- a/src/library.js
+++ b/src/library.js
@@ -4447,7 +4447,7 @@ LibraryManager.library = {
   },
 
   // Returns [parentFuncArguments, functionName, paramListName]
-  _emscripten_traverse_stack: function(args) {
+  /*_emscripten_traverse_stack: function(args) {
     if (!args || !args.callee || !args.callee.name) {
       return [null, '', ''];
     }
@@ -4475,8 +4475,8 @@ LibraryManager.library = {
       str = '';
     return [args, funcname, str];
   },
-
-  emscripten_get_callstack_js__deps: ['_emscripten_traverse_stack'],
+  */
+  //emscripten_get_callstack_js__deps: ['_emscripten_traverse_stack'],
   emscripten_get_callstack_js: function(flags) {
     var callstack = jsStackTrace();
 
@@ -4496,9 +4496,9 @@ LibraryManager.library = {
     var stack_args = null;
     if (flags & 128 /*EM_LOG_FUNC_PARAMS*/) {
       // To get the actual parameters to the functions, traverse the stack via the unfortunately deprecated 'arguments.callee' method, if it works:
-      stack_args = __emscripten_traverse_stack(arguments);
+      /*stack_args = __emscripten_traverse_stack(arguments);
       while (stack_args[1].indexOf('_emscripten_') >= 0)
-        stack_args = __emscripten_traverse_stack(stack_args[0]);
+        stack_args = __emscripten_traverse_stack(stack_args[0]);*/
     }
 
     // Process all lines:
@@ -4568,7 +4568,7 @@ LibraryManager.library = {
           callstack = callstack.replace(/\s+$/, '');
           callstack += ' with values: ' + stack_args[1] + stack_args[2] + '\n';
         }
-        stack_args = __emscripten_traverse_stack(stack_args[0]);
+        //stack_args = __emscripten_traverse_stack(stack_args[0]);
       }
     }
     // Trim extra whitespace at the end of the output.


### PR DESCRIPTION
https://github.com/emscripten-core/emscripten/blob/incoming/src/library.js

Changed function _emscripten_traverse_stack in library.js
Could not replicate same functionality in strict mode, so I disabled the function by removing the code and replacing it with "return null;"

Ran random100 tests and passed, but I do not know what to add to runner.py if anything.