### PR TITLE
Revert accidental change in output messages made in #8137

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -385,9 +385,12 @@ def run(args):
 
   # Additional compiler flags that we treat as if they were passed to us on the
   # commandline
-  EMCC_CFLAGS = os.environ.get('EMCC_CFLAGS', '')
+  EMCC_CFLAGS = os.environ.get('EMCC_CFLAGS')
   if DEBUG:
-    logger.warning('invocation: ' + ' '.join(args) + (' + ' + EMCC_CFLAGS) + '  (in ' + os.getcwd() + ')')
+    cmd =  ' '.join(args)
+    if EMCC_CFLAGS:
+      cmd += ' + ' + EMCC_CFLAGS
+    logger.warning('invocation: ' + cmd + '  (in ' + os.getcwd() + ')')
   if EMCC_CFLAGS:
     args.extend(shlex.split(EMCC_CFLAGS))
 

--- a/emcc.py
+++ b/emcc.py
@@ -387,7 +387,7 @@ def run(args):
   # commandline
   EMCC_CFLAGS = os.environ.get('EMCC_CFLAGS')
   if DEBUG:
-    cmd =  ' '.join(args)
+    cmd = ' '.join(args)
     if EMCC_CFLAGS:
       cmd += ' + ' + EMCC_CFLAGS
     logger.warning('invocation: ' + cmd + '  (in ' + os.getcwd() + ')')


### PR DESCRIPTION
The " + " part of the output message is now only displayed
when there are extra EMCC_ARGS, which was the original behavior.