### PR TITLE
Fix name of zlib library.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2490,7 +2490,7 @@ def run(infile, outfile, memfile, libraries):
         gen_struct_info.main(['-qo', out, path_from_root('src', 'struct_info.json')])
         return out
 
-    shared.Settings.STRUCT_INFO = shared.Cache.get(generated_struct_info_name, ensure_struct_info, extension='json')
+    shared.Settings.STRUCT_INFO = shared.Cache.get(generated_struct_info_name, ensure_struct_info)
   # do we need an else, to define it for the bootstrap case?
 
   outfile_obj = open(outfile, 'w')

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -98,9 +98,11 @@ class Cache(object):
 
   # Request a cached file. If it isn't in the cache, it will be created with
   # the given creator function
-  def get(self, shortname, creator, extension='.bc', what=None, force=False):
-    if not shortname.endswith(extension):
+  def get(self, shortname, creator, extension=None, what=None, force=False):
+    if extension is not None:
       shortname += extension
+    elif not os.path.splitext(shortname)[1]:
+      shortname += '.bc'
     cachename = os.path.abspath(os.path.join(self.dirname, shortname))
 
     self.acquire_cache_lock()

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -133,7 +133,7 @@ def get_native_optimizer():
       for cmake_generator in cmake_generators:
         # Delete CMakeCache.txt so that we can switch to a new CMake generator.
         shared.try_delete(os.path.join(build_path, 'CMakeCache.txt'))
-        proc = subprocess.Popen(['cmake', '-G', cmake_generator, '-DCMAKE_BUILD_TYPE='+cmake_build_type, shared.path_from_root('tools', 'optimizer')], cwd=build_path, stdin=log_output, stdout=log_output, stderr=log_output)
+        proc = subprocess.Popen(['cmake', '-G', cmake_generator, '-DCMAKE_BUILD_TYPE='+cmake_build_type, shared.path_from_root('tools', 'optimizer')], cwd=build_path, stdin=log_outpu, stdout=log_output, stderr=log_output)
         proc.communicate()
         if proc.returncode == 0:
           make = ['cmake', '--build', build_path]
@@ -175,9 +175,9 @@ def get_native_optimizer():
 
     use_cmake_to_configure = WINDOWS # Currently only Windows uses CMake to drive the optimizer build, but set this to True to use on other platforms as well.
     if use_cmake_to_configure:
-      return shared.Cache.get(name, create_optimizer_cmake, extension='exe')
+      return shared.Cache.get(name, create_optimizer_cmake)
     else:
-      return shared.Cache.get(name, create_optimizer, extension='exe')
+      return shared.Cache.get(name, create_optimizer)
 
   if NATIVE_OPTIMIZER == '1':
     return get_optimizer('optimizer.exe', [])

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -6,7 +6,24 @@
 from . import binaryen, bullet, cocos2d, freetype, harfbuzz, icu, libpng, ogg, regal, sdl2, sdl2_gfx, sdl2_image, sdl2_mixer, sdl2_ttf, sdl2_net, vorbis, zlib
 
 # If port A depends on port B, then A should be _after_ B
-ports = [icu, zlib, libpng, sdl2, sdl2_image, sdl2_gfx, ogg, vorbis, sdl2_mixer, bullet, freetype, harfbuzz, sdl2_ttf, sdl2_net, binaryen, cocos2d, regal]
+ports = [
+    icu,
+    zlib,
+    libpng,
+    sdl2,
+    sdl2_image,
+    sdl2_gfx,
+    ogg, vorbis,
+    sdl2_mixer,
+    bullet,
+    freetype,
+    harfbuzz,
+    sdl2_ttf,
+    sdl2_net,
+    binaryen,
+    cocos2d,
+    regal
+]
 
 ports_by_name = {}
 for port in ports:

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -5,7 +5,6 @@
 
 import os
 import shutil
-from subprocess import Popen
 
 TAG = 'version_1'
 
@@ -28,7 +27,7 @@ def get(ports, settings, shared):
     open(os.path.join(dest_path, 'zconf.h'), 'w').write(zconf_h)
 
     # build
-    srcs = 'adler32.c compress.c crc32.c deflate.c gzclose.c gzlib.c gzread.c gzwrite.c infback.c inffast.c inflate.c inftrees.c trees.c uncompr.c zutil.c'.split(' ')
+    srcs = 'adler32.c compress.c crc32.c deflate.c gzclose.c gzlib.c gzread.c gzwrite.c infback.c inffast.c inflate.c inftrees.c trees.c uncompr.c zutil.c'.split()
     commands = []
     o_s = []
     for src in srcs:
@@ -36,14 +35,15 @@ def get(ports, settings, shared):
       shared.safe_ensure_dirs(os.path.dirname(o))
       commands.append([shared.PYTHON, shared.EMCC, os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w'])
       o_s.append(o)
-
     ports.run_commands(commands)
+
     final = os.path.join(ports.get_build_dir(), 'zlib', 'libz.a')
     shared.try_delete(final)
-    Popen([shared.LLVM_AR, 'rc', final] + o_s).communicate()
+    ports.run_commands([[shared.EMAR, 'rc', final] + o_s])
     assert os.path.exists(final)
     return final
-  return [shared.Cache.get('zlib', create, what='port')]
+
+  return [shared.Cache.get('libz.a', create, what='port')]
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -712,7 +712,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     def do_create():
       return lib.create(name)
 
-    libfile = shared.Cache.get(name, do_create, extension=lib.suffix)
+    libfile = shared.Cache.get(name, do_create)
     need_whole_archive = lib.shortname in force_include and lib.suffix != 'bc'
     libs_to_link.append((libfile, need_whole_archive))
 
@@ -754,8 +754,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     add_library(lib)
 
   if shared.Settings.WASM_BACKEND:
-    libs_to_link.append((shared.Cache.get('libcompiler_rt_wasm.a', lambda: create_wasm_compiler_rt('libcompiler_rt_wasm.a'), extension='a'), False))
-    libs_to_link.append((shared.Cache.get('libc_rt_wasm.a', lambda: create_wasm_libc_rt('libc_rt_wasm.a'), extension='a'), False))
+    libs_to_link.append((shared.Cache.get('libcompiler_rt_wasm.a', lambda: create_wasm_compiler_rt('libcompiler_rt_wasm.a')), False))
+    libs_to_link.append((shared.Cache.get('libc_rt_wasm.a', lambda: create_wasm_libc_rt('libc_rt_wasm.a')), False))
 
   libs_to_link.sort(key=lambda x: x[0].endswith('.a')) # make sure to put .a files at the end.
 
@@ -993,16 +993,14 @@ class Ports(object):
 def get_ports(settings):
   ret = []
 
-  ok = False
   try:
     process_dependencies(settings)
     for port in ports.ports:
       # ports return their output files, which will be linked, or a txt file
       ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
-    ok = True
-  finally:
-    if not ok:
-      logging.error('a problem occurred when using an emscripten-ports library. try to run    emcc --clear-ports    and then run this command again')
+  except:
+    logging.error('a problem occurred when using an emscripten-ports library.  try to run `emcc --clear-ports` and then run this command again')
+    raise
 
   ret.reverse()
   return ret


### PR DESCRIPTION
The zlib library is always built as an 'ar' archive but was
using the '.bc' extension.

This changes the name of the if in the cache but should otherwise
be invisible to the user.

Also:
- use `ports.run_commands` rather than using Popen directly.
- use emar rather then llvm-ar directly building the library.
- Cache.get: infer file extension from the filename if it has one
- refactor strange use of try/finally in system_libs.py