### PR TITLE
Update metadce test expectations after upstream llvm change

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7939,9 +7939,9 @@ int main() {
     # test on libc++: see effects of emulated function pointers
     if self.is_wasm_backend():
       self.run_metadce_tests(path_from_root('tests', 'hello_libcxx.cpp'), [
-        (['-O2'], 32, [], ['waka'], 226582,  20,  32, 562), # noqa
+        (['-O2'], 32, [], ['waka'], 226582,  20,  33, 564), # noqa
         (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  32, [], ['waka'], 226582,  20,  32, 562), # noqa
+                  32, [], ['waka'], 226582,  20,  33, 564), # noqa
       ]) # noqa
     else:
       self.run_metadce_tests(path_from_root('tests', 'hello_libcxx.cpp'), [


### PR DESCRIPTION
The linker now generates a stub for the symbol mismatch
after https://reviews.llvm.org/D57909

This will fail CI because CI uses the lkgr revision of upstream llvm, and that
won't get updated until this change lands.