### PR TITLE
Fix closure errors in the JS library, in particular functions not at the beginning of a block

### DIFF
--- a/src/closure-annotations.js
+++ b/src/closure-annotations.js
@@ -202,8 +202,6 @@ var _glGetTexEnviv;
  */
 var _glGetTexEnvfv;
 
-var _glutPostRedisplay = function() {};
-
 /**
  * @suppress {undefinedVars}
  */

--- a/src/library.js
+++ b/src/library.js
@@ -2951,7 +2951,7 @@ LibraryManager.library = {
       var date = initDate();
       var value;
 
-      function getMatch(symbol) {
+      var getMatch = function(symbol) {
         var pos = capture.indexOf(symbol);
         // check if symbol appears in regexp
         if (pos >= 0) {
@@ -2959,7 +2959,7 @@ LibraryManager.library = {
           return matches[pos+1];
         }
         return;
-      }
+      };
 
       // seconds
       if ((value=getMatch('S'))) {

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 var LibraryGLUT = {
-  $GLUT__deps: ['$Browser'],
+  $GLUT__deps: ['$Browser', 'glutPostRedisplay'],
   $GLUT: {
     initTime: null,
     idleFunc: null,

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -544,7 +544,7 @@ var LibraryOpenAL = {
         var lUpY = listener.up[1];
         var lUpZ = listener.up[2];
 
-        function inverseMagnitude(x, y, z) {
+        var inverseMagnitude = function(x, y, z) {
           var length = Math.sqrt(x * x + y * y + z * z);
 
           if (length < Number.EPSILON) {
@@ -552,7 +552,7 @@ var LibraryOpenAL = {
           }
 
           return 1.0 / length;
-        }
+        };
 
         // Normalize the Back vector
         var invMag = inverseMagnitude(lBackX, lBackY, lBackZ);
@@ -2020,9 +2020,9 @@ var LibraryOpenAL = {
       // https://github.com/jpernst/emscripten/issues/2#issuecomment-312729735
       // if you're curious about why.
 
-      function lerp(from, to, progress) {
+      var lerp = function(from, to, progress) {
         return (1 - progress) * from + progress * to;
-      }
+      };
 
       for (var i = 0, frame_i = 0; frame_i < requestedFrameCount; ++frame_i) {
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2818,13 +2818,12 @@ var LibrarySDL = {
       // after loading. Therefore prepare an array of callback handlers to run when this audio decoding is complete, which
       // will then start the playback (with some delay).
       webAudio.onDecodeComplete = []; // While this member array exists, decoding hasn't finished yet.
-      function onDecodeComplete(data) {
+      var onDecodeComplete = function(data) {
         webAudio.decodedBuffer = data;
         // Call all handlers that were waiting for this decode to finish, and clear the handler list.
         webAudio.onDecodeComplete.forEach(function(e) { e(); });
         webAudio.onDecodeComplete = undefined; // Don't allow more callback handlers since audio has finished decoding.
-      }
-
+      };
       SDL.audioContext['decodeAudioData'](arrayBuffer, onDecodeComplete);
     } else if (audio === undefined && bytes) {
       // Here, we didn't find a preloaded audio but we either were passed a filepath for

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -712,10 +712,10 @@ var SyscallsLibrary = {
     var buf = SYSCALLS.get();
     if (!buf) return -ERRNO_CODES.EFAULT
     var layout = {{{ JSON.stringify(C_STRUCTS.utsname) }}};
-    function copyString(element, value) {
+    var copyString = function(element, value) {
       var offset = layout[element];
       writeAsciiToMemory(value, buf + offset);
-    }
+    };
     copyString('sysname', 'Emscripten');
     copyString('nodename', 'emscripten');
     copyString('release', '1.0');
@@ -781,9 +781,9 @@ var SyscallsLibrary = {
                   (writefds ? {{{ makeGetValue('writefds', 4, 'i32') }}} : 0) |
                   (exceptfds ? {{{ makeGetValue('exceptfds', 4, 'i32') }}} : 0);
 
-    function check(fd, low, high, val) {
+    var check = function(fd, low, high, val) {
       return (fd < 32 ? (low & val) : (high & val));
-    }
+    };
 
     for (var fd = 0; fd < nfds; fd++) {
       var mask = 1 << (fd % 32);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8357,6 +8357,14 @@ end
     proc = test(check=True, extra=['-s', 'IGNORE_CLOSURE_COMPILER_ERRORS=1'])
     self.assertEqual(proc.stderr, '')
 
+  def test_closure_full_js_library(self):
+    # test for closure errors in the entire JS library
+    # We must ignore various types of errors that are expected in this situation, as we
+    # are including a lot of JS without corresponding compiled code for it. This still
+    # lets us catch all other errors.
+    with env_modify({'EMCC_CLOSURE_ARGS': '--jscomp_off undefinedVars'}):
+      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
+
   def test_toolchain_profiler(self):
     environ = os.environ.copy()
     environ['EM_PROFILE_TOOLCHAIN'] = '1'


### PR DESCRIPTION
Fixes #7914 (but need confirmation).

Also adds a test for running closure on the entire JS library, which should prevent future regressions. The test must ignore missing symbols, as we are including a lot of JS without all the compiled code it expects, but this can still catch other closure errors, like the one mentioned in the title.