### PR TITLE
Consistent and improved naming for items built by emscripten ports

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -156,13 +156,6 @@ def build_port(port_name, lib_name, params):
   build(C_BARE, [lib_name] if lib_name else [], params)
 
 
-def static_library_name(name):
-  if shared.Settings.WASM_BACKEND and shared.Settings.WASM_OBJECT_FILES:
-    return name + '.a'
-  else:
-    return name + '.bc'
-
-
 def main():
   if len(sys.argv) < 2 or sys.argv[1] in ['-v', '-help', '--help', '-?', '?']:
     print_help()
@@ -190,6 +183,7 @@ def main():
   args = [a for a in args if not is_flag(a)]
 
   # process tasks
+  libname = shared.static_library_name
 
   auto_tasks = False
   tasks = args
@@ -229,20 +223,20 @@ def main():
         }
       ''', ['libcompiler_rt.a'])
     elif what == 'libc':
-      build(C_WITH_MALLOC, [static_library_name('libc')])
+      build(C_WITH_MALLOC, [libname('libc')])
     elif what == 'libc-extras':
       build('''
         extern char **environ;
         int main() {
           return (int)environ;
         }
-      ''', [static_library_name('libc-extras')])
+      ''', [libname('libc-extras')])
     elif what == 'struct_info':
       build(C_BARE, ['generated_struct_info.json'])
     elif what == 'emmalloc':
-      build(C_WITH_MALLOC, [static_library_name('libemmalloc')], ['-s', 'MALLOC="emmalloc"'])
+      build(C_WITH_MALLOC, [libname('libemmalloc')], ['-s', 'MALLOC="emmalloc"'])
     elif what == 'emmalloc_debug':
-      build(C_WITH_MALLOC, [static_library_name('libemmalloc_debug')], ['-s', 'MALLOC="emmalloc"', '-g'])
+      build(C_WITH_MALLOC, [libname('libemmalloc_debug')], ['-s', 'MALLOC="emmalloc"', '-g'])
     elif what.startswith('dlmalloc'):
       cmd = ['-s', 'MALLOC="dlmalloc"']
       if '_debug' in what:
@@ -253,11 +247,11 @@ def main():
         cmd += ['-s', 'USE_PTHREADS=1']
       if '_tracing' in what:
         cmd += ['-s', 'EMSCRIPTEN_TRACING=1']
-      build(C_WITH_MALLOC, [static_library_name('lib' + what)], cmd)
+      build(C_WITH_MALLOC, [libname('lib' + what)], cmd)
     elif what in ('libc-mt', 'pthreads'):
-      build(C_WITH_MALLOC, [static_library_name('libc-mt'), static_library_name('libpthreads')], ['-s', 'USE_PTHREADS=1'])
+      build(C_WITH_MALLOC, [libname('libc-mt'), libname('libpthreads')], ['-s', 'USE_PTHREADS=1'])
     elif what == 'libc-wasm':
-      build(C_WITH_STDLIB, [static_library_name('libc-wasm')], ['-s', 'WASM=1'])
+      build(C_WITH_STDLIB, [libname('libc-wasm')], ['-s', 'WASM=1'])
     elif what == 'libc++':
       build(CXX_WITH_STDLIB, ['libc++.a'], ['-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     elif what == 'libc++_noexcept':
@@ -271,7 +265,7 @@ def main():
           y->a();
           return y->y;
         }
-      ''', [static_library_name('libc++abi')])
+      ''', [libname('libc++abi')])
     elif what == 'gl' or what.startswith('gl-'):
       opts = []
       if '-mt' in what:
@@ -285,7 +279,7 @@ def main():
         int main() {
           return int(emscripten_GetProcAddress("waka waka"));
         }
-      ''', [static_library_name('lib' + what)], opts)
+      ''', [libname('lib' + what)], opts)
     elif what == 'native_optimizer':
       build(C_BARE, ['optimizer.2.exe'], ['-O2', '-s', 'WASM=0'])
     elif what == 'compiler_rt_wasm':
@@ -301,7 +295,7 @@ def main():
           return emscripten_compute_dom_pk_code(NULL);
         }
 
-      ''', [static_library_name('libhtml5')])
+      ''', [libname('libhtml5')])
     elif what == 'pthreads_stub':
       build('''
         #include <emscripten/threading.h>
@@ -309,7 +303,7 @@ def main():
           return emscripten_is_main_runtime_thread();
         }
 
-      ''', [static_library_name('libpthreads_stub')])
+      ''', [libname('libpthreads_stub')])
     elif what == 'al':
       build('''
         #include "AL/al.h"
@@ -317,43 +311,43 @@ def main():
           alGetProcAddress(0);
           return 0;
         }
-      ''', [static_library_name('libal')])
+      ''', [libname('libal')])
     elif what == 'icu':
-      build_port('icu', 'icu.bc', ['-s', 'USE_ICU=1'])
+      build_port('icu', libname('libicuuc'), ['-s', 'USE_ICU=1'])
     elif what == 'zlib':
       build_port('zlib', 'libz.a', ['-s', 'USE_ZLIB=1'])
     elif what == 'bullet':
-      build_port('bullet', 'bullet.bc', ['-s', 'USE_BULLET=1'])
+      build_port('bullet', libname('libbullet'), ['-s', 'USE_BULLET=1'])
     elif what == 'vorbis':
-      build_port('vorbis', 'vorbis.bc', ['-s', 'USE_VORBIS=1'])
+      build_port('vorbis', libname('libvorbis'), ['-s', 'USE_VORBIS=1'])
     elif what == 'ogg':
-      build_port('ogg', 'ogg.bc', ['-s', 'USE_OGG=1'])
+      build_port('ogg', libname('libogg'), ['-s', 'USE_OGG=1'])
     elif what == 'libpng':
-      build_port('libpng', 'libpng.bc', ['-s', 'USE_ZLIB=1', '-s', 'USE_LIBPNG=1'])
+      build_port('libpng', libname('libpng'), ['-s', 'USE_ZLIB=1', '-s', 'USE_LIBPNG=1'])
     elif what == 'sdl2':
-      build_port('sdl2', 'sdl2.bc', ['-s', 'USE_SDL=2'])
+      build_port('sdl2', libname('libSDL2'), ['-s', 'USE_SDL=2'])
     elif what == 'sdl2-gfx':
-      build_port('sdl2-gfx', 'sdl2-gfx.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'USE_SDL_GFX=2'])
+      build_port('sdl2-gfx', libname('libSDL2_gfx'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'USE_SDL_GFX=2'])
     elif what == 'sdl2-image':
-      build_port('sdl2-image', 'sdl2-image.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2'])
+      build_port('sdl2-image', libname('libSDL2_image'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2'])
     elif what == 'sdl2-image-png':
-      build_port('sdl2-image', 'sdl2-image-png.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'SDL2_IMAGE_FORMATS=["png"]'])
+      build_port('sdl2-image', libname('libSDL2_image'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'SDL2_IMAGE_FORMATS=["png"]'])
     elif what == 'sdl2-net':
-      build_port('sdl2-net', 'sdl2-net.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'])
+      build_port('sdl2-net', libname('libSDL2_net'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'])
     elif what == 'sdl2-mixer':
-      build_port('sdl2-mixer', 'sdl2-mixer.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'USE_VORBIS=1'])
+      build_port('sdl2-mixer', 'libSDL2_mixer.a', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'USE_VORBIS=1'])
     elif what == 'freetype':
-      build_port('freetype', 'freetype.bc', ['-s', 'USE_FREETYPE=1'])
+      build_port('freetype', 'libfreetype.a', ['-s', 'USE_FREETYPE=1'])
     elif what == 'harfbuzz':
-      build_port('harfbuzz', 'harfbuzz.bc', ['-s', 'USE_HARFBUZZ=1'])
+      build_port('harfbuzz', 'libharfbuzz.a', ['-s', 'USE_HARFBUZZ=1'])
     elif what == 'sdl2-ttf':
-      build_port('sdl2-ttf', 'sdl2-ttf.bc', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_TTF=2', '-s', 'USE_FREETYPE=1'])
+      build_port('sdl2-ttf', libname('libSDL2_ttf'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_TTF=2', '-s', 'USE_FREETYPE=1'])
     elif what == 'binaryen':
       build_port('binaryen', None, ['-s', 'WASM=1'])
     elif what == 'cocos2d':
-      build_port('cocos2d', 'cocos2d.bc', ['-s', 'USE_COCOS2D=3', '-s', 'USE_ZLIB=1', '-s', 'USE_LIBPNG=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
+      build_port('cocos2d', libname('libcocos2d'), ['-s', 'USE_COCOS2D=3', '-s', 'USE_ZLIB=1', '-s', 'USE_LIBPNG=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
     elif what == 'regal':
-      build_port('regal', 'regal.bc', ['-s', 'USE_REGAL=1'])
+      build_port('regal', libname('libregal'), ['-s', 'USE_REGAL=1'])
     else:
       logger.error('unfamiliar build target: ' + what)
       return 1

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3157,7 +3157,7 @@ window.close = function() {
   @no_wasm_backend('cocos2d needs to be ported')
   @requires_graphics_hardware
   def test_cocos2d_hello(self):
-    cocos2d_root = os.path.join(system_libs.Ports.get_build_dir(), 'Cocos2d')
+    cocos2d_root = os.path.join(system_libs.Ports.get_build_dir(), 'cocos2d')
     preload_file = os.path.join(cocos2d_root, 'samples', 'HelloCpp', 'Resources') + '@'
     self.btest('cocos2d_hello.cpp', reference='cocos2d_hello.png', reference_slack=1,
                args=['-s', 'USE_COCOS2D=3', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0', '--std=c++11', '--preload-file', preload_file, '--use-preload-plugins'],

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -96,13 +96,15 @@ class Cache(object):
   def get_path(self, shortname):
     return os.path.join(self.dirname, shortname)
 
+  def erase_file(self, shortname):
+    name = os.path.join(self.dirname, shortname)
+    if os.path.exists(name):
+      logging.info('Cache: deleting cached file: %s', name)
+      tempfiles.try_delete(name)
+
   # Request a cached file. If it isn't in the cache, it will be created with
   # the given creator function
-  def get(self, shortname, creator, extension=None, what=None, force=False):
-    if extension is not None:
-      shortname += extension
-    elif not os.path.splitext(shortname)[1]:
-      shortname += '.bc'
+  def get(self, shortname, creator, what=None, force=False):
     cachename = os.path.abspath(os.path.join(self.dirname, shortname))
 
     self.acquire_cache_lock()

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -3,7 +3,9 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from . import binaryen, bullet, cocos2d, freetype, harfbuzz, icu, libpng, ogg, regal, sdl2, sdl2_gfx, sdl2_image, sdl2_mixer, sdl2_ttf, sdl2_net, vorbis, zlib
+from . import binaryen, bullet, cocos2d, freetype, harfbuzz, icu, libpng
+from . import ogg, regal, sdl2, sdl2_gfx, sdl2_image, sdl2_mixer, sdl2_ttf
+from . import sdl2_net, vorbis, zlib
 
 # If port A depends on port B, then A should be _after_ B
 ports = [
@@ -26,6 +28,15 @@ ports = [
 ]
 
 ports_by_name = {}
-for port in ports:
-  name = port.__name__.split('.')[-1]
-  ports_by_name[name] = port
+
+
+def init():
+  expected_attrs = ['get', 'clear', 'process_args', 'show']
+  for port in ports:
+    name = port.__name__.split('.')[-1]
+    ports_by_name[name] = port
+    for a in expected_attrs:
+      assert hasattr(port, a), 'port %s is missing %s' % (port, a)
+
+
+init()

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -34,7 +34,11 @@ def get(ports, settings, shared):
     open(tag_file, 'w').write(TAG)
     return tag_file
 
-  return [shared.Cache.get('binaryen_tag_' + TAG, create, what='port', extension='.txt')]
+  return [shared.Cache.get('binaryen_tag_' + TAG + '.txt', create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file('binaryen_tag_' + TAG + '.txt')
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -15,6 +15,7 @@ def get(ports, settings, shared):
     return []
 
   ports.fetch_project('bullet', 'https://github.com/emscripten-ports/bullet/archive/' + TAG + '.zip', 'Bullet-' + TAG)
+  libname = ports.get_lib_name('libbullet')
 
   def create():
     logging.info('building port: bullet')
@@ -28,14 +29,18 @@ def get(ports, settings, shared):
     src_path = os.path.join(dest_path, 'bullet', 'src')
     includes = []
     for root, dirs, files in os.walk(src_path, topdown=False):
-        for dir in dirs:
-            includes.append(os.path.join(root, dir))
+      for dir in dirs:
+        includes.append(os.path.join(root, dir))
 
-    final = os.path.join(ports.get_build_dir(), 'bullet', 'libbullet.bc')
+    final = os.path.join(ports.get_build_dir(), 'bullet', libname)
     ports.build_port(src_path, final, includes=includes, exclude_dirs=['MiniCL'])
     return final
 
-  return [shared.Cache.get('bullet', create)]
+  return [shared.Cache.get(libname, create)]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libbullet'))
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -16,20 +16,22 @@ def get(ports, settings, shared):
     return []
 
   ports.fetch_project(
-    'Cocos2d', 'https://github.com/emscripten-ports/Cocos2d/archive/' + TAG + '.zip', 'Cocos2d-' + TAG)
+    'cocos2d', 'https://github.com/emscripten-ports/Cocos2d/archive/' + TAG + '.zip', 'Cocos2d-' + TAG)
+  libname = ports.get_lib_name('libcocos2d')
 
   def create():
-    logging.info('building port: Cocos2d v3')
-    logging.warn('Cocos2d: library is experimental, do not expect that it will work out of the box')
+    logging.info('building port: cocos2d v3')
+    logging.warn('cocos2d: library is experimental, do not expect that it will work out of the box')
 
-    cocos2d_build = os.path.join(ports.get_dir(), 'Cocos2d')
-    cocos2d_root = os.path.join(cocos2d_build, 'Cocos2d-' + TAG)
+    cocos2d_src = os.path.join(ports.get_dir(), 'cocos2d')
+    cocos2d_root = os.path.join(cocos2d_src, 'Cocos2d-' + TAG)
     cocos2dx_root = os.path.join(cocos2d_root, 'cocos2dx')
     cocos2dx_src = make_source_list(cocos2d_root, cocos2dx_root)
     cocos2dx_includes = make_includes(cocos2d_root, cocos2dx_root)
 
+    cocos2d_build = os.path.join(ports.get_build_dir(), 'cocos2d')
     shutil.copytree(os.path.join(cocos2d_root, 'samples', 'Cpp'),
-                    os.path.join(ports.get_build_dir(), 'Cocos2d', 'samples'))
+                    os.path.join(cocos2d_build, 'samples'))
 
     commands = []
     o_s = []
@@ -62,11 +64,15 @@ def get(ports, settings, shared):
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'Cocos2d', 'libcocos2d.bc')
+    final = os.path.join(cocos2d_build, libname)
     shared.Building.link_to_object(o_s, final)
     return final
 
-  return [shared.Cache.get('cocos2d', create, what='port')]
+  return [shared.Cache.get(libname, create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libcocos2d'))
 
 
 def process_dependencies(settings):
@@ -78,7 +84,7 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_COCOS2D == 3:
     get(ports, settings, shared)
-    cocos2d_build = os.path.join(ports.get_dir(), 'Cocos2d')
+    cocos2d_build = os.path.join(ports.get_dir(), 'cocos2d')
     cocos2d_root = os.path.join(cocos2d_build, 'Cocos2d-' + TAG)
     cocos2dx_root = os.path.join(cocos2d_root, 'cocos2dx')
     cocos2dx_includes = make_includes(cocos2d_root, cocos2dx_root)

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -98,7 +98,11 @@ def get(ports, settings, shared):
     assert os.path.exists(final)
     return final
 
-  return [shared.Cache.get('freetype', create, what='port')]
+  return [shared.Cache.get('libfreetype.a', create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file('libfreetype.a')
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -41,7 +41,11 @@ def get(ports, settings, shared):
     shared.Building.make(['make', '-C' + dest_path, 'install'])
     return os.path.join(dest_path, 'libharfbuzz.a')
 
-  return [shared.Cache.get('harfbuzz', create, what='port')]
+  return [shared.Cache.get('libharfbuzz.a', create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file('libharfbuzz.a')
 
 
 def process_dependencies(settings):

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -15,6 +15,7 @@ def get(ports, settings, shared):
     return []
 
   ports.fetch_project('icu', 'https://github.com/unicode-org/icu/archive/' + TAG + '.zip', 'icu-' + TAG)
+  libname = ports.get_lib_name('libicuuc')
 
   def create():
     logging.info('building port: icu')
@@ -25,11 +26,15 @@ def get(ports, settings, shared):
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
-    final = os.path.join(dest_path, 'libicuuc.bc')
+    final = os.path.join(dest_path, libname)
     ports.build_port(os.path.join(dest_path, 'icu4c', 'source', 'common'), final, [os.path.join(dest_path, 'icu4c', 'source', 'common')], ['--std=c++11', '-DU_COMMON_IMPLEMENTATION=1'])
     return final
 
-  return [shared.Cache.get('icu', create)]
+  return [shared.Cache.get(libname, create)]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libicuuc'))
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -16,6 +16,8 @@ def get(ports, settings, shared):
 
   ports.fetch_project('libpng', 'https://github.com/emscripten-ports/libpng/archive/' + TAG + '.zip', 'libpng-' + TAG)
 
+  libname = ports.get_lib_name('libpng')
+
   def create():
     logging.info('building port: libpng')
 
@@ -27,10 +29,15 @@ def get(ports, settings, shared):
 
     open(os.path.join(dest_path, 'pnglibconf.h'), 'w').write(pnglibconf_h)
 
-    final = os.path.join(ports.get_build_dir(), 'libpng', 'libpng.bc')
+    final = os.path.join(ports.get_build_dir(), 'libpng', libname)
     ports.build_port(dest_path, final, flags=['-s', 'USE_ZLIB=1'], exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
     return final
-  return [shared.Cache.get('libpng', create, what='port')]
+
+  return [shared.Cache.get(libname, create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libpng'))
 
 
 def process_dependencies(settings):

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -15,6 +15,7 @@ def get(ports, settings, shared):
     return []
 
   ports.fetch_project('ogg', 'https://github.com/emscripten-ports/ogg/archive/' + TAG + '.zip', 'Ogg-' + TAG)
+  libname = ports.get_lib_name('libogg')
 
   def create():
     logging.info('building port: ogg')
@@ -28,11 +29,15 @@ def get(ports, settings, shared):
 
     open(os.path.join(dest_path, 'include', 'ogg', 'config_types.h'), 'w').write(config_types_h)
 
-    final = os.path.join(dest_path, 'libogg.bc')
+    final = os.path.join(dest_path, libname)
     ports.build_port(os.path.join(dest_path, 'src'), final, [os.path.join(dest_path, 'include')])
     return final
 
-  return [shared.Cache.get('ogg', create)]
+  return [shared.Cache.get(libname, create)]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libogg'))
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -16,6 +16,7 @@ def get(ports, settings, shared):
 
   ports.fetch_project('regal', 'https://github.com/emscripten-ports/regal/archive/' + TAG + '.zip',
                       'regal-' + TAG)
+  libname = ports.get_lib_name('libregal')
 
   def create():
     logging.info('building port: regal')
@@ -145,13 +146,17 @@ def get(ports, settings, shared):
       o_s.append(o)
 
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'regal', 'libregal.bc')
+    final = os.path.join(ports.get_build_dir(), 'regal', libname)
     shared.try_delete(final)
-    shared.Building.link_to_object(o_s, final)
+    ports.create_lib(final, o_s)
     assert os.path.exists(final)
     return final
 
-  return [shared.Cache.get('regal', create, what='port')]
+  return [shared.Cache.get(libname, create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libregal'))
 
 
 def process_dependencies(settings):

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -16,10 +16,11 @@ def get(ports, settings, shared):
 
   # get the port
   ports.fetch_project('sdl2', 'https://github.com/emscripten-ports/SDL2/archive/' + TAG + '.zip', SUBDIR)
+  libname = ports.get_lib_name('libSDL2')
 
   def create():
     # we are rebuilding SDL, clear dependant projects so they copy in their includes to ours properly
-    ports.clear_project_build('sdl2-image')
+    ports.clear_project_build('sdl2_image')
     # copy includes to a location so they can be used as 'SDL2/'
     source_include_path = os.path.join(ports.get_dir(), 'sdl2', SUBDIR + '', 'include')
     dest_include_path = os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2', 'include')
@@ -39,11 +40,15 @@ def get(ports, settings, shared):
       commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src), '-O2', '-o', o, '-I' + dest_include_path, '-O2', '-DUSING_GENERATED_CONFIG_H', '-w'])
       o_s.append(o)
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'sdl2', 'libsdl2.bc')
-    shared.Building.link_to_object(o_s, final)
+    final = os.path.join(ports.get_build_dir(), 'sdl2', libname)
+    ports.create_lib(final, o_s)
     return final
 
-  return [shared.Cache.get('sdl2', create, what='port')]
+  return [shared.Cache.get(libname, create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libSDL2'))
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -16,25 +16,30 @@ def get(ports, settings, shared):
 
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_gfx'
-  ports.fetch_project('sdl2-gfx', 'https://github.com/svn2github/sdl2_gfx/archive/' + TAG + '.zip', 'sdl2_gfx-' + TAG)
+  ports.fetch_project('sdl2_gfx', 'https://github.com/svn2github/sdl2_gfx/archive/' + TAG + '.zip', 'sdl2_gfx-' + TAG)
+  libname = ports.get_lib_name('libSDL2_gfx')
 
   def create():
-    logging.info('building port: sdl2-gfx')
+    logging.info('building port: sdl2_gfx')
 
-    source_path = os.path.join(ports.get_dir(), 'sdl2-gfx', 'sdl2_gfx-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2-gfx')
+    source_path = os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG)
+    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_gfx')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
     for header in ['SDL2_framerate.h', 'SDL2_gfxPrimitives_font.h', 'SDL2_gfxPrimitives.h', 'SDL2_imageFilter.h', 'SDL2_rotozoom.h']:
-      shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-gfx', 'sdl2_gfx-' + TAG, header), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', header))
+      shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG, header), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', header))
 
-    final = os.path.join(dest_path, 'libsdl2_gfx.bc')
+    final = os.path.join(dest_path, libname)
     ports.build_port(dest_path, final, [dest_path], exclude_dirs=['test'])
     return final
 
-  return [shared.Cache.get('sdl2-gfx', create)]
+  return [shared.Cache.get(libname, create)]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libSDL2_gfx'))
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -15,15 +15,23 @@ def get(ports, settings, shared):
 
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_image'
-  ports.fetch_project('sdl2-image', 'https://github.com/emscripten-ports/SDL2_image/archive/' + TAG + '.zip', 'SDL2_image-' + TAG)
+  ports.fetch_project('sdl2_image', 'https://github.com/emscripten-ports/SDL2_image/archive/' + TAG + '.zip', 'SDL2_image-' + TAG)
+
+  settings.SDL2_IMAGE_FORMATS.sort()
+  formats = '-'.join(settings.SDL2_IMAGE_FORMATS)
+
+  libname = 'libSDL2_image'
+  if formats != '':
+    libname += '_' + formats
+  libname = ports.get_lib_name(libname)
 
   def create():
     # although we shouldn't really do this and could instead use '-Xclang
     # -isystem' as a kind of 'overlay' as sdl_mixer does,
     # by now people may be relying on headers being pulled in by '-s USE_SDL=2'
     # if sdl_image was built in the past
-    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-image', 'SDL2_image-' + TAG, 'SDL_image.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL_image.h'))
-    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-image', 'SDL2_image-' + TAG, 'SDL_image.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', 'SDL_image.h'))
+    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG, 'SDL_image.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL_image.h'))
+    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG, 'SDL_image.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', 'SDL_image.h'))
     srcs = 'IMG.c IMG_bmp.c IMG_gif.c IMG_jpg.c IMG_lbm.c IMG_pcx.c IMG_png.c IMG_pnm.c IMG_tga.c IMG_tif.c IMG_xcf.c IMG_xpm.c IMG_xv.c IMG_webp.c IMG_ImageIO.m'.split(' ')
     commands = []
     o_s = []
@@ -36,23 +44,20 @@ def get(ports, settings, shared):
       defs += ['-s', 'USE_LIBPNG=1']
 
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'sdl2-image', src + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2-image', 'SDL2_image-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'] + defs)
+      o = os.path.join(ports.get_build_dir(), 'sdl2_image', src + '.o')
+      commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'] + defs)
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'sdl2-image', 'libsdl2_image.bc')
-    shared.Building.link_to_object(o_s, final)
+    final = os.path.join(ports.get_build_dir(), 'sdl2_image', libname)
+    ports.create_lib(final, o_s)
     return final
 
-  settings.SDL2_IMAGE_FORMATS.sort()
-  formats = '-'.join(settings.SDL2_IMAGE_FORMATS)
+  return [shared.Cache.get(libname, create, what='port')]
 
-  name = 'sdl2-image'
-  if formats != '':
-      name = name + '-' + formats
 
-  return [shared.Cache.get(name, create, what='port')]
+def clear(ports, shared):
+  shared.Cache.get_path(ports.get_lib_name('libSDL2_image'))
 
 
 def process_dependencies(settings):

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -11,17 +11,17 @@ def get(ports, settings, shared):
 
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_mixer'
-  ports.fetch_project('sdl2-mixer', 'https://github.com/emscripten-ports/SDL2_mixer/archive/' + TAG + '.zip', 'SDL2_mixer-' + TAG)
+  ports.fetch_project('sdl2_mixer', 'https://github.com/emscripten-ports/SDL2_mixer/archive/' + TAG + '.zip', 'SDL2_mixer-' + TAG)
 
   def create():
     cwd = os.getcwd()
     commonflags = ['--disable-shared', '--disable-music-cmd', '--enable-sdltest', '--disable-smpegtest']
     formatflags = ['--enable-music-wave', '--disable-music-mod', '--disable-music-midi', '--enable-music-ogg', '--disable-music-ogg-shared', '--disable-music-flac', '--disable-music-mp3']
-    configure = os.path.join(ports.get_dir(), 'sdl2-mixer', 'SDL2_mixer-' + TAG, 'configure')
-    build_dir = os.path.join(ports.get_build_dir(), 'sdl2-mixer')
-    dist_dir = os.path.join(ports.get_build_dir(), 'sdl2-mixer', 'dist')
+    configure = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL2_mixer-' + TAG, 'configure')
+    build_dir = os.path.join(ports.get_build_dir(), 'sdl2_mixer')
+    dist_dir = os.path.join(ports.get_build_dir(), 'sdl2_mixer', 'dist')
     out = os.path.join(dist_dir, 'lib', 'libSDL2_mixer.a')
-    final = os.path.join(ports.get_build_dir(), 'sdl2-mixer', 'libsdl2_mixer.a')
+    final = os.path.join(ports.get_build_dir(), 'sdl2_mixer', 'libSDL2_mixer.a')
     shared.safe_ensure_dirs(build_dir)
 
     try:
@@ -34,7 +34,11 @@ def get(ports, settings, shared):
       os.chdir(cwd)
     return final
 
-  return [shared.Cache.get('sdl2-mixer', create, what='port')]
+  return [shared.Cache.get('libSDL2_mixer.a', create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libSDL2_mixer'))
 
 
 def process_dependencies(settings):
@@ -46,7 +50,7 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_SDL_MIXER == 2:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2-mixer', 'dist', 'include')]
+    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_mixer', 'dist', 'include')]
   return args
 
 

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -17,30 +17,35 @@ def get(ports, settings, shared):
 
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_net'
-  ports.fetch_project('sdl2-net', 'https://github.com/emscripten-ports/SDL2_net/archive/' + TAG + '.zip', 'SDL2_net-' + TAG)
+  ports.fetch_project('sdl2_net', 'https://github.com/emscripten-ports/SDL2_net/archive/' + TAG + '.zip', 'SDL2_net-' + TAG)
+  libname = ports.get_lib_name('libSDL2_net')
 
   def create():
-    logging.info('building port: sdl2-net')
+    logging.info('building port: sdl2_net')
     # although we shouldn't really do this and could instead use '-Xclang
     # -isystem' as a kind of 'overlay' as sdl_mixer does,
     # by now people may be relying on headers being pulled in by '-s USE_SDL=2'
     # if sdl_net was built in the past
-    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL_net.h'))
-    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2-net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', 'SDL_net.h'))
+    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL_net.h'))
+    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', 'SDL_net.h'))
     srcs = 'SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c'.split(' ')
     commands = []
     o_s = []
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'sdl2-net', src + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2-net', 'SDL2_net-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'])
+      o = os.path.join(ports.get_build_dir(), 'sdl2_net', src + '.o')
+      commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'])
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'sdl2-net', 'libsdl2_net.bc')
-    shared.Building.link_to_object(o_s, final)
+    final = os.path.join(ports.get_build_dir(), 'sdl2_net', libname)
+    ports.create_lib(final, o_s)
     return final
 
-  return [shared.Cache.get('sdl2-net', create, what='port')]
+  return [shared.Cache.get(libname, create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libSDL2_net'))
 
 
 def process_args(ports, args, settings, shared):

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -13,10 +13,11 @@ def get(ports, settings, shared):
   if settings.USE_SDL_TTF != 2:
     return []
 
-  ports.fetch_project('sdl2-ttf', 'https://github.com/emscripten-ports/SDL2_ttf/archive/' + TAG + '.zip', 'SDL2_ttf-' + TAG)
+  ports.fetch_project('sdl2_ttf', 'https://github.com/emscripten-ports/SDL2_ttf/archive/' + TAG + '.zip', 'SDL2_ttf-' + TAG)
+  libname = ports.get_lib_name('libSDL2_ttf')
 
   def create():
-    sdl_ttf_h = os.path.join(ports.get_dir(), 'sdl2-ttf', 'SDL2_ttf-' + TAG, 'SDL_ttf.h')
+    sdl_ttf_h = os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL2_ttf-' + TAG, 'SDL_ttf.h')
 
     shutil.copy2(sdl_ttf_h, os.path.join(ports.get_build_dir(), 'include'))
     shutil.copy2(sdl_ttf_h, os.path.join(ports.get_build_dir(), 'sdl2', 'include'))
@@ -27,20 +28,24 @@ def get(ports, settings, shared):
     o_s = []
 
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'sdl2-ttf', src + '.o')
+      o = os.path.join(ports.get_build_dir(), 'sdl2_ttf', src + '.o')
       command = [shared.PYTHON, shared.EMCC]
-      command += [os.path.join(ports.get_dir(), 'sdl2-ttf', 'SDL2_ttf-' + TAG, src)]
+      command += [os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL2_ttf-' + TAG, src)]
       command += ['-O2', '-s', 'USE_SDL=2', '-s', 'USE_FREETYPE=1', '-o', o, '-w']
       commands.append(command)
       o_s.append(o)
 
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'sdl2-ttf', 'libsdl2_ttf.bc')
+    final = os.path.join(ports.get_build_dir(), 'sdl2_ttf', libname)
     shared.Building.link_to_object(o_s, final)
     return final
 
-  return [shared.Cache.get('sdl2-ttf', create, what='port')]
+  return [shared.Cache.get(libname, create, what='port')]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libSDL2_ttf'))
 
 
 def process_dependencies(settings):

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -15,6 +15,7 @@ def get(ports, settings, shared):
     return []
 
   ports.fetch_project('vorbis', 'https://github.com/emscripten-ports/vorbis/archive/' + TAG + '.zip', 'Vorbis-' + TAG)
+  libname = ports.get_lib_name('libvorbis')
 
   def create():
     logging.info('building port: vorbis')
@@ -25,12 +26,16 @@ def get(ports, settings, shared):
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
-    final = os.path.join(dest_path, 'libvorbis.bc')
+    final = os.path.join(dest_path, libname)
     ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
                      ['-s', 'USE_OGG=1'], ['psytune', 'barkmel', 'tone', 'misc'])
     return final
 
-  return [shared.Cache.get('vorbis', create)]
+  return [shared.Cache.get(libname, create)]
+
+
+def clear(ports, shared):
+  shared.Cache.erase_file(ports.get_lib_name('libvorbis'))
 
 
 def process_dependencies(settings):

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -46,6 +46,10 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libz.a', create, what='port')]
 
 
+def clear(ports, shared):
+  shared.Cache.erase_file('libz.a')
+
+
 def process_args(ports, args, settings, shared):
   if settings.USE_ZLIB == 1:
     get(ports, settings, shared)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -779,18 +779,24 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 class Ports(object):
   """emscripten-ports library management (https://github.com/emscripten-ports).
   """
+
+  @staticmethod
+  def get_lib_name(name):
+    return shared.static_library_name(name)
+
   @staticmethod
   def build_port(src_path, output_path, includes=[], flags=[], exclude_files=[], exclude_dirs=[]):
     srcs = []
     for root, dirs, files in os.walk(src_path, topdown=False):
       if any((excluded in root) for excluded in exclude_dirs):
         continue
-      for file in files:
-          if (file.endswith('.c') or file.endswith('.cpp')) and not any((excluded in file) for excluded in exclude_files):
-              srcs.append(os.path.join(root, file))
+      for f in files:
+        ext = os.path.splitext(f)[1]
+        if ext in ('.c', '.cpp') and not any((excluded in f) for excluded in exclude_files):
+            srcs.append(os.path.join(root, f))
     include_commands = ['-I' + src_path]
     for include in includes:
-        include_commands.append('-I' + include)
+      include_commands.append('-I' + include)
 
     commands = []
     objects = []
@@ -800,11 +806,17 @@ class Ports(object):
       objects.append(obj)
 
     run_commands(commands)
+    print('create_lib', output_path)
     create_lib(output_path, objects)
+    return output_path
 
   @staticmethod
   def run_commands(commands): # make easily available for port objects
     run_commands(commands)
+
+  @staticmethod
+  def create_lib(libname, inputs): # make easily available for port objects
+    create_lib(libname, inputs)
 
   @staticmethod
   def get_dir():
@@ -846,8 +858,7 @@ class Ports(object):
         if name == local[0]:
           path = local[1]
           if name not in ports.ports_by_name:
-            logging.error('%s is not a known port' % name)
-            sys.exit(1)
+            shared.exit_with_error('%s is not a known port' % name)
           port = ports.ports_by_name[name]
           if not hasattr(port, 'SUBDIR'):
             logging.error('port %s lacks .SUBDIR attribute, which we need in order to override it locally, please update it' % name)
@@ -952,9 +963,9 @@ class Ports(object):
 
   @staticmethod
   def clear_project_build(name):
+    port = ports.ports_by_name[name]
+    port.clear(Ports, shared)
     shared.try_delete(os.path.join(Ports.get_build_dir(), name))
-    shared.try_delete(shared.Cache.get_path(name + '.bc'))
-    shared.try_delete(shared.Cache.get_path(name + '.a'))
 
   @staticmethod
   def build_native(subdir):


### PR DESCRIPTION
- Use .a when the library is an archive and .bc only when its bitcode
- always prefer .a archives over combined .o files when
  building with WASM_OBJECT_FILES=1.
- make library names consistent with upstream library names.
- Fix the directory names used by some ports so that they get cleared correctly by `clear_project_build`