### PR TITLE
Remove Settings.BINARYEN_ROOT

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2632,7 +2632,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
     logger.debug('wasm-opt on BINARYEN_PASSES: ' + ' '.join(cmd))
     shared.check_call(cmd)
   if shared.Settings.BINARYEN_SCRIPTS:
-    binaryen_scripts = os.path.join(shared.Settings.BINARYEN_ROOT, 'scripts')
+    binaryen_scripts = os.path.join(shared.BINARYEN_ROOT, 'scripts')
     script_env = os.environ.copy()
     root_dir = os.path.abspath(os.path.dirname(__file__))
     if script_env.get('PYTHONPATH'):

--- a/src/settings.js
+++ b/src/settings.js
@@ -1078,10 +1078,6 @@ var WASM_MEM_MAX = -1;
 // smallest modules to run in V8
 var BINARYEN_ASYNC_COMPILATION = 1;
 
-// Directory where we can find Binaryen. Will be automatically set for you, but
-// you can set it to override if you are a Binaryen developer.
-var BINARYEN_ROOT = "";
-
 // WebAssembly defines a "producers section" which compilers and tools can
 // annotate themselves in. Emscripten does not emit this by default, as it
 // increases code size, and some users may not want information about their tools

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -288,7 +288,6 @@ void webMain() {
       self.filename = final
       # Inject command line arguments
       run_process(['sed', '-i', 's/"use strict";/"use strict";var args=typeof(scriptArgs) !== "undefined" ? scriptArgs : arguments;/', self.filename])
-      Building.get_binaryen()
       if self.binaryen_opts:
         run_binaryen_opts(final.replace('.js', '.wasm'), self.binaryen_opts)
     finally:

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -14,10 +14,9 @@ def needed(settings, shared, ports):
     return False
   if shared.BINARYEN_ROOT: # if defined, and not falsey, we don't need the port
     logging.debug('binaryen root already set to ' + shared.BINARYEN_ROOT)
-    settings.BINARYEN_ROOT = shared.BINARYEN_ROOT
     return False
-  settings.BINARYEN_ROOT = os.path.join(ports.get_dir(), 'binaryen', 'binaryen-' + TAG)
-  logging.debug('setting binaryen root to ' + settings.BINARYEN_ROOT)
+  shared.BINARYEN_ROOT = os.path.join(ports.get_dir(), 'binaryen', 'binaryen-' + TAG)
+  logging.debug('setting binaryen root to ' + shared.BINARYEN_ROOT)
   return True
 
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2821,19 +2821,14 @@ class Building(object):
     return ret
 
   @staticmethod
-  def get_binaryen():
-    # fetch the port, so we have binaryen set up. indicate we need binaryen
-    # using the settings
-    from . import system_libs
-    old = Settings.WASM
-    Settings.WASM = 1
-    system_libs.get_port('binaryen', Settings)
-    Settings.WASM = old
-
-  @staticmethod
   def get_binaryen_bin():
-    Building.get_binaryen()
-    return os.path.join(Settings.BINARYEN_ROOT, 'bin')
+    assert Settings.WASM, 'non wasm builds should not ask for binaryen'
+    if not BINARYEN_ROOT:
+      # ensure we have the port available if needed.
+      from . import system_libs
+      system_libs.get_port('binaryen', Settings)
+      assert os.path.exists(BINARYEN_ROOT)
+    return os.path.join(BINARYEN_ROOT, 'bin')
 
 
 # compatibility with existing emcc, etc. scripts

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -991,14 +991,10 @@ class Ports(object):
 def get_ports(settings):
   ret = []
 
-  try:
-    process_dependencies(settings)
-    for port in ports.ports:
-      # ports return their output files, which will be linked, or a txt file
-      ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
-  except:
-    logging.error('a problem occurred when using an emscripten-ports library.  try to run `emcc --clear-ports` and then run this command again')
-    raise
+  process_dependencies(settings)
+  for port in ports.ports:
+    # ports return their output files, which will be linked, or a txt file
+    ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
 
   ret.reverse()
   return ret

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -991,10 +991,14 @@ class Ports(object):
 def get_ports(settings):
   ret = []
 
-  process_dependencies(settings)
-  for port in ports.ports:
-    # ports return their output files, which will be linked, or a txt file
-    ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
+  try:
+    process_dependencies(settings)
+    for port in ports.ports:
+      # ports return their output files, which will be linked, or a txt file
+      ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
+  except:
+    logging.error('a problem occurred when using an emscripten-ports library.  try to run `emcc --clear-ports` and then run this command again')
+    raise
 
   ret.reverse()
   return ret


### PR DESCRIPTION
We already have shared.BINARYEN_ROOT which is set from the config file.
There is no need for this path to be available to JS so make it
completely internal thing and avoid duplicating it under both `Settings`
and `shared`. This matches the behavior for the LLVM_ROOT which is
only in the emscripten config and not in Settings.