### PR TITLE
Integer Size Issue with WebVR

### DIFF
--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -128,9 +128,9 @@ var LibraryWebVR = {
 
     var caps = display.capabilities;
 
-    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasPosition, 'caps.hasPosition ? 1 : 0', 'ui64') }}};
-    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasExternalDisplay, 'caps.hasExternalDisplay ? 1 : 0', 'ui64') }}};
-    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.canPresent, 'caps.canPresent ? 1 : 0', 'ui64') }}};
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasPosition, 'caps.hasPosition ? 1 : 0', 'uint64') }}};
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasExternalDisplay, 'caps.hasExternalDisplay ? 1 : 0', 'uint64') }}};
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.canPresent, 'caps.canPresent ? 1 : 0', 'uint64') }}};
 
     {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.maxLayers, 'caps.maxLayers', 'i64') }}};
 

--- a/src/library_vr.js
+++ b/src/library_vr.js
@@ -128,9 +128,9 @@ var LibraryWebVR = {
 
     var caps = display.capabilities;
 
-    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasPosition, 'caps.hasPosition ? 1 : 0', 'i32') }}};
-    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasExternalDisplay, 'caps.hasExternalDisplay ? 1 : 0', 'i32') }}};
-    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.canPresent, 'caps.canPresent ? 1 : 0', 'i32') }}};
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasPosition, 'caps.hasPosition ? 1 : 0', 'ui64') }}};
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.hasExternalDisplay, 'caps.hasExternalDisplay ? 1 : 0', 'ui64') }}};
+    {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.canPresent, 'caps.canPresent ? 1 : 0', 'ui64') }}};
 
     {{{ makeSetValue('capsPtr', C_STRUCTS.VRDisplayCapabilities.maxLayers, 'caps.maxLayers', 'i64') }}};
 

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -39,7 +39,7 @@ extern "C" {
  */
 #define EMSCRIPTEN_VR_API_VERSION 10101
 
-typedef int32_t VRDisplayHandle;
+typedef uint64_t VRDisplayHandle;
 
 typedef void (*em_vr_callback_func)(void);
 typedef void (*em_vr_arg_callback_func)(void*);
@@ -61,9 +61,9 @@ typedef struct VRQuaternion {
 } VRQuaternion;
 
 typedef struct VRDisplayCapabilities {
-    int32_t hasPosition;
-    int32_t hasExternalDisplay;
-    int32_t canPresent;
+    uint64_t hasPosition;
+    uint64_t hasExternalDisplay;
+    uint64_t canPresent;
     unsigned long maxLayers;
 } VRDisplayCapabilities;
 


### PR DESCRIPTION
resolves https://github.com/emscripten-core/emscripten/issues/8109
Changed the i32 to uint64 in vr.h and vr.js. This makes it so that the methods `emscripten_vr_get_display_capabilities` and `emscripten_vr_get_eye_parameters` do not go out of bounds. 