### PR TITLE
[Not active - see below for the bug discussion though] Fetch close done

### DIFF
--- a/system/lib/fetch/emscripten_fetch.cpp
+++ b/system/lib/fetch/emscripten_fetch.cpp
@@ -224,9 +224,13 @@ EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch)
 	// This fetch is aborted. Call the error handler if the fetch was still in progress and was canceled in flight.
 	if (fetch->readyState != 4 /*DONE*/ && fetch->__attributes.onerror)
 	{
+		fetch->readyState = 4;
 		fetch->status = (unsigned short)-1;
 		strcpy(fetch->statusText, "aborted with emscripten_fetch_close()");
+
 		fetch->__attributes.onerror(fetch);
+	} else {
+		fetch->readyState = 4;
 	}
 
 	fetch_free(fetch);

--- a/system/lib/fetch/emscripten_fetch.cpp
+++ b/system/lib/fetch/emscripten_fetch.cpp
@@ -221,16 +221,16 @@ EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch)
 	// which has not been yet closed. (double close is an error)
 	if (fetch->id == 0 || fetch->readyState > 4) return EMSCRIPTEN_RESULT_INVALID_PARAM;
 
+	unsigned short readyState = fetch->readyState;
+	fetch->readyState = 4; // DONE
+
 	// This fetch is aborted. Call the error handler if the fetch was still in progress and was canceled in flight.
-	if (fetch->readyState != 4 /*DONE*/ && fetch->__attributes.onerror)
+	if (readyState != 4 /*DONE*/ && fetch->__attributes.onerror)
 	{
-		fetch->readyState = 4;
 		fetch->status = (unsigned short)-1;
 		strcpy(fetch->statusText, "aborted with emscripten_fetch_close()");
 
 		fetch->__attributes.onerror(fetch);
-	} else {
-		fetch->readyState = 4;
 	}
 
 	fetch_free(fetch);

--- a/tests/fetch/to_memory.cpp
+++ b/tests/fetch/to_memory.cpp
@@ -11,6 +11,14 @@
 
 int result = 0;
 
+int onerrors = 0;
+
+void after_onerror(void*) {
+  printf("reporting delayed result\n");
+  result = 1;
+  REPORT_RESULT(result);
+}
+
 // This test is run in two modes: if FILE_DOES_NOT_EXIST defined,
 // then testing an XHR of a missing file.
 // #define FILE_DOES_NOT_EXIST
@@ -26,6 +34,9 @@ int main()
   attr.onsuccess = [](emscripten_fetch_t *fetch) {
 #if FILE_DOES_NOT_EXIST
     assert(false && "onsuccess handler called, but the file shouldn't exist"); // Shouldn't reach here if the file doesn't exist
+#endif
+#ifdef CLOSE_IMMEDIATELY
+    assert(false && "onsuccess handler called, but the the fetch was closed");
 #endif
     assert(fetch);
     printf("Finished downloading %llu bytes\n", fetch->numBytes);
@@ -75,16 +86,27 @@ int main()
 
   attr.onerror = [](emscripten_fetch_t *fetch) {
     printf("Download failed!\n");
-#ifndef FILE_DOES_NOT_EXIST
+    onerrors++;
+    assert(onerrors == 1 && "onerror should be called at most once");
+#if !defined(FILE_DOES_NOT_EXIST) && !defined(CLOSE_IMMEDIATELY)
     assert(false && "onerror handler called, but the transfer should have succeeded!"); // The file exists, shouldn't reach here.
 #endif
     assert(fetch);
     assert(fetch->id != 0);
     assert(!strcmp(fetch->url, "gears.png"));
     assert((uintptr_t)fetch->userData == 0x12345678);
+#ifdef CLOSE_IMMEDIATELY
+    // Wait to report the result - if we get an extra async onerror later, that is bad.
+    // There is some risk of random timing here, but it should be random successes, not fails,
+    // as we may not wait long enough to see the problem.
+    emscripten_async_call(after_onerror, NULL, 1000);
+    return;
+#endif
+
+    emscripten_fetch_close(fetch);
 
 #ifdef REPORT_RESULT
-#ifdef FILE_DOES_NOT_EXIST
+#if defined(FILE_DOES_NOT_EXIST) || defined(CLOSE_IMMEDIATELY)
     result = 1;
 #endif
     REPORT_RESULT(result);
@@ -92,6 +114,9 @@ int main()
   };
 
   emscripten_fetch_t *fetch = emscripten_fetch(&attr, "gears.png");
+#ifdef CLOSE_IMMEDIATELY
+  emscripten_fetch_close(fetch);
+#endif
   assert(fetch != 0);
   memset(&attr, 0, sizeof(attr)); // emscripten_fetch() must be able to operate without referencing to this structure after the call.
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4119,6 +4119,12 @@ window.close = function() {
                  args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1'] + arg,
                  also_asmjs=True)
 
+    # Test a case where the fetch is closed while still in progress.
+    self.btest('fetch/to_memory.cpp',
+               expected='1',
+               args=['--std=c++11', '-s', 'FETCH_DEBUG=1', '-s', 'FETCH=1', '-DCLOSE_IMMEDIATELY', '-g'],
+               also_asmjs=True)
+
   def test_fetch_to_indexdb(self):
     shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
     self.btest('fetch/to_indexeddb.cpp',


### PR DESCRIPTION
This PR is not for landing - it shows what I think is a problem. I tried to fix a bug with onerror being called more than once, however, even with the fix we still get multiple calls.

Is it possible it's called both from the fetch C code and from the Fetch.js?

Am I missing something - is it ok for onerrorto be called multiple times? One issue I've seen there is if onerror calls `fetch_close()` then close can be called more than once.