### PR TITLE
Fix Building.user_requested_exports under wasm backend

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2459,8 +2459,9 @@ def create_jscall_funcs(sigs):
 
 def treat_as_user_function(name):
   library_functions_in_module = ('setTempRet0', 'getTempRet0', 'stackAlloc',
-      'stackSave', 'stackRestore', 'establishStackSpace', '__growWasmMemory',
-      '__heap_base', '__data_end')
+                                 'stackSave', 'stackRestore',
+                                 'establishStackSpace', '__growWasmMemory',
+                                 '__heap_base', '__data_end')
   if name.startswith('dynCall_'):
     return False
   if name in library_functions_in_module:

--- a/emscripten.py
+++ b/emscripten.py
@@ -2430,8 +2430,13 @@ def load_metadata_wasm(metadata_raw, DEBUG):
   if DEBUG:
     logger.debug("Metadata parsed: " + pprint.pformat(metadata))
 
-  # functions marked llvm.used in the code are exports requested by the user
-  shared.Building.user_requested_exports += metadata['exports']
+  # Calculate the subset of exports that were explicitly marked with llvm.used.
+  # These are any exports that were not requested on the command line and are
+  # not known auto-generated system functions.
+  unexpected_exports = [e for e in metadata['exports'] if treat_as_user_function(e)]
+  unexpected_exports = [asmjs_mangle(e) for e in unexpected_exports]
+  unexpected_exports = [e for e in unexpected_exports if e not in shared.Settings.EXPORTED_FUNCTIONS]
+  shared.Building.user_requested_exports += unexpected_exports
 
   return metadata
 
@@ -2452,18 +2457,27 @@ def create_jscall_funcs(sigs):
   return jscall_funcs
 
 
+def treat_as_user_function(name):
+  library_functions_in_module = ('setTempRet0', 'getTempRet0', 'stackAlloc',
+      'stackSave', 'stackRestore', 'establishStackSpace', '__growWasmMemory',
+      '__heap_base', '__data_end')
+  if name.startswith('dynCall_'):
+    return False
+  if name in library_functions_in_module:
+    return False
+  return True
+
+
 def asmjs_mangle(name):
   """Mangle a name the way asm.js/JSBackend globals are mangled.
 
   Prepends '_' and replaces non-alphanumerics with '_'.
   Used by wasm backend for JS library consistency with asm.js.
   """
-  library_functions_in_module = ('setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore', 'establishStackSpace')
-  if name.startswith('dynCall_'):
+  if treat_as_user_function(name):
+    return '_' + name
+  else:
     return name
-  if name in library_functions_in_module:
-    return name
-  return '_' + ''.join(['_' if not c.isalnum() else c for c in name])
 
 
 def normalize_line_endings(text):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7943,9 +7943,9 @@ int main() {
       run(['-O1'],  9, [], ['waka'],  8095,  2, 12, 10) # noqa
       run(['-O2'],  9, [], ['waka'],  8077,  2, 12, 10) # noqa
       # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-      run(['-O3'],  0, [], [],          61,  0,  1,  1) # noqa
-      run(['-Os'],  0, [], [],          61,  0,  1,  1) # noqa
-      run(['-Oz'],  0, [], [],           8,  0,  0,  0) # noqa
+      run(['-O3'],  0, [], [],          85,  0,  2,  2) # noqa
+      run(['-Os'],  0, [], [],          85,  0,  2,  2) # noqa
+      run(['-Oz'],  0, [], [],          54,  0,  1,  1) # noqa
     else:
       run([],      20, ['abort'], ['waka'], 22712, 20, 14, 27) # noqa
       run(['-O1'], 10, ['abort'], ['waka'], 10450,  7, 11, 11) # noqa


### PR DESCRIPTION
This list should contain names with the '_' prefix. With this the
metadce process was removing them.

Fixes: #8194