### PR TITLE
Don't output code for JS primitives that libraries depend on

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -185,6 +185,7 @@ function JSify(data, functionsOnly) {
 
       if (allExternPrimitives.indexOf(ident) != -1) {
         usedExternPrimitives[ident] = 1;
+        return;
       } else if ((!LibraryManager.library.hasOwnProperty(ident) && !LibraryManager.library.hasOwnProperty(ident + '__inline')) || SIDE_MODULE) {
         if (!(finalName in IMPLEMENTED_FUNCTIONS)) {
           if (VERBOSE || ident.substr(0, 11) !== 'emscripten_') { // avoid warning on emscripten_* functions which are for internal usage anyhow

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3214,7 +3214,7 @@ int main() {
 
     create_test_file('lib.js', r'''
 mergeInto(LibraryManager.library, {
-  foo__deps: ['Int8Array'],
+  foo__deps: ['Int8Array', 'NonPrimitive'],
   foo: function() {},
 });
 ''')
@@ -3226,9 +3226,9 @@ int main(int argc, char** argv) {
   return 0;
 }
 ''')
-    run_process([PYTHON, EMCC, '-O0', 'main.c', '--js-library', 'lib.js'])
+    run_process([PYTHON, EMCC, '-O0', 'main.c', '--js-library', 'lib.js', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
     generated = open('a.out.js').read()
-    self.assertNotContained('var Int8Array=', generated)
+    self.assertContained('var _NonPrimitive=', generated)
     self.assertNotContained('var _Int8Array=', generated)
 
   def test_js_lib_using_asm_lib(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3231,7 +3231,6 @@ int main(int argc, char** argv) {
     self.assertNotContained('var Int8Array=', generated)
     self.assertNotContained('var _Int8Array=', generated)
 
-
   def test_js_lib_using_asm_lib(self):
     create_test_file('lib.js', r'''
 mergeInto(LibraryManager.library, {


### PR DESCRIPTION
Previously we were outputing this kind of thing:

```
var _Int8Array=undefined;
var _Math_atan2=undefined;
```

We now error out if the snippet for a given library item is
undefined, but also skip over the primitives to avoid outputing
this.