### PR TITLE
Update binaryen and test expectations after optimized-build debug changes

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5857,7 +5857,7 @@ return malloc(size);
   # to process.
   @no_wasm_backend("uses bitcode compiled with asmjs, and we don't have unified triples")
   @is_slow_test
-  def test_cases(self):
+  def test_zzz_cases(self):
     if Building.LLVM_OPTS:
       self.skipTest("Our code is not exactly 'normal' llvm assembly")
 
@@ -7037,7 +7037,11 @@ err = err = function(){};
       self.assertPathsIdentical(os.path.abspath('src.cpp'), m['source'])
       seen_lines.add(m['originalLine'])
     # ensure that all the 'meaningful' lines in the original code get mapped
-    assert seen_lines.issuperset([6, 7, 11, 12])
+    # when optimizing, the binaryen optimizer may remove some of them (by inlining, etc.)
+    if is_optimizing(self.emcc_args):
+      assert seen_lines.issuperset([11, 12]), seen_lines
+    else:
+      assert seen_lines.issuperset([6, 7, 11, 12]), seen_lines
 
   def test_modularize_closure_pre(self):
     # test that the combination of modularize + closure + pre-js works. in that mode,

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7965,9 +7965,9 @@ int main() {
       run(['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
                   32, [], ['waka'], 226582,  20,  33, 563) # noqa
     else:
-      run(['-O2'], 34, ['abort'], ['waka'], 196709,  28,   36, 662) # noqa
+      run(['-O2'], 34, ['abort'], ['waka'], 186423,  28,   36, 534) # noqa
       run(['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  34, ['abort'], ['waka'], 196709,  28,   37, 644) # noqa
+                  34, ['abort'], ['waka'], 186423,  28,   37, 516) # noqa
 
   def test_binaryen_metadce_hello(self):
     def run(*args):
@@ -7986,10 +7986,10 @@ int main() {
     else:
       run([],      20, ['abort'], ['waka'], 42701,  20,   14, 49) # noqa
       run(['-O1'], 15, ['abort'], ['waka'], 12630,  14,   13, 30) # noqa
-      run(['-O2'], 15, ['abort'], ['waka'], 12616,  14,   13, 30) # noqa
-      run(['-O3'],  6, [],        [],        2690,   9,    2, 21) # noqa; in -O3, -Os and -Oz we metadce
-      run(['-Os'],  6, [],        [],        2690,   9,    2, 21) # noqa
-      run(['-Oz'],  6, [],        [],        2690,   9,    2, 21) # noqa
+      run(['-O2'], 15, ['abort'], ['waka'], 12616,  14,   13, 26) # noqa
+      run(['-O3'],  6, [],        [],        2515,   9,    2, 15) # noqa; in -O3, -Os and -Oz we metadce
+      run(['-Os'],  6, [],        [],        2515,   9,    2, 16) # noqa
+      run(['-Oz'],  6, [],        [],        2515,   9,    2, 16) # noqa
       # finally, check what happens when we export nothing. wasm should be almost empty
       run(['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                    0, [],        [],           8,   0,    0,  0) # noqa; totally empty!

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8009,8 +8009,8 @@ int main() {
     # test disabling of JS FFI legalization
     wasm_dis = os.path.join(Building.get_binaryen_bin(), 'wasm-dis')
     for (args, js_ffi) in [
-        (['-s', 'LEGALIZE_JS_FFI=1', '-s', 'SIDE_MODULE=1', '-O2', '-s', 'EXPORT_ALL=1'], True),
-        (['-s', 'LEGALIZE_JS_FFI=0', '-s', 'SIDE_MODULE=1', '-O2', '-s', 'EXPORT_ALL=1'], False),
+        (['-s', 'LEGALIZE_JS_FFI=1', '-s', 'SIDE_MODULE=1', '-O1', '-s', 'EXPORT_ALL=1'], True),
+        (['-s', 'LEGALIZE_JS_FFI=0', '-s', 'SIDE_MODULE=1', '-O1', '-s', 'EXPORT_ALL=1'], False),
         (['-s', 'LEGALIZE_JS_FFI=0', '-s', 'SIDE_MODULE=1', '-O0', '-s', 'EXPORT_ALL=1'], False),
         (['-s', 'LEGALIZE_JS_FFI=0', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0', '-O0'], False),
       ]:

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -6,7 +6,7 @@
 import os
 import logging
 
-TAG = 'version_69'
+TAG = 'version_70'
 
 
 def needed(settings, shared, ports):


### PR DESCRIPTION
Binaryen now runs optimizations normally even with debug info. It tries to keep them around, but no longer disables optimizations in order to do that.

Aside from metadce expectation changes (where we now do better since we run more opts), this updated `test_source_maps` to not expect all debug info to remain, and `test_legalize_js_ffi` to run at `-O1` instead of `-O2`, since it reads the wast and inlining makes it harder to find the function we care about.