### PR TITLE
Fix filesystem regression - enable them for workers, not just web

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -140,7 +140,7 @@ var LibraryManager = {
         libraries = libraries.concat([
           'library_lz4.js',
         ]);
-        if (ENVIRONMENT_MAY_BE_WEB) {
+        if (ENVIRONMENT_MAY_BE_WEB || ENVIRONMENT_MAY_BE_WORKER) {
           libraries = libraries.concat([
             'library_idbfs.js',
             'library_proxyfs.js',


### PR DESCRIPTION
When we added checks for environments for the libraries, we put the filesystem ones like IDBFS behind web, but it can be used in workers too.

fixes #8213