### PR TITLE
emscripten.py: Simplify handling of exports from wasm backend

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2112,6 +2112,9 @@ def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
     t = time.time()
 
   forwarded_json = json.loads(forwarded_data)
+  # For the wasm backend the implementedFunctions from compiler.js should
+  # alwasys be empty. This only gets populated for __asm function when using
+  # the JS backend.
   assert not forwarded_json['Functions']['implementedFunctions']
 
   pre, post = glue.split('// EMSCRIPTEN_END_FUNCS')

--- a/emscripten.py
+++ b/emscripten.py
@@ -2137,6 +2137,9 @@ def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
   # merge forwarded data
   shared.Settings.EXPORTED_FUNCTIONS = forwarded_json['EXPORTED_FUNCTIONS']
 
+  all_implemented = metadata['exports']
+  check_all_implemented([asmjs_mangle(f) for f in all_implemented], pre)
+
   asm_consts, asm_const_funcs = create_asm_consts_wasm(forwarded_json, metadata)
   em_js_funcs = create_em_js(forwarded_json, metadata)
   pre = pre.replace(
@@ -2160,7 +2163,7 @@ def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
 
   sending = create_sending_wasm(invoke_funcs, jscall_sigs, forwarded_json,
                                 metadata)
-  receiving = create_receiving_wasm(metadata['exports'])
+  receiving = create_receiving_wasm(all_implemented)
 
   module = create_module_wasm(sending, receiving, invoke_funcs, jscall_sigs, metadata)
 


### PR DESCRIPTION
There was a lot of needless complexity in
get_exported_implemented_functions_wasm when we already know the
list of functions we want to recieve from the wasm module.  This is
always the total list of exports from the module.

Also remove a check that was always false (since the exports don't
have a leading "_" on them).