### PR TITLE
Update Binaryen

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1395,8 +1395,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             passes += ['--no-exit-runtime']
           if options.opt_level > 0 or options.shrink_level > 0:
             passes += [shared.Building.opt_level_to_str(options.opt_level, options.shrink_level)]
+          passes += ['--post-emscripten']
           if shared.Settings.GLOBAL_BASE >= 1024: # hardcoded value in the binaryen pass
-            passes += ['--post-emscripten']
+            passes += ['--low-memory-unused']
           if options.debug_level < 3:
             passes += ['--strip-debug']
           if not shared.Settings.EMIT_PRODUCERS_SECTION:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9044,8 +9044,8 @@ int main () {
       (asmjs + opts, hello_world_sources, {'a.html': 985, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
       (opts, hello_world_sources, {'a.html': 972, 'a.js': 624, 'a.wasm': 86}),
       (asmjs + opts, hello_webgl_sources, {'a.html': 885, 'a.js': 4980, 'a.asm.js': 10972, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 861, 'a.js': 5046, 'a.wasm': 8922}),
-      (opts, hello_webgl2_sources, {'a.html': 861, 'a.js': 6182, 'a.wasm': 8922}) # Compare how WebGL2 sizes stack up with WebGL 1
+      (opts, hello_webgl_sources, {'a.html': 861, 'a.js': 5046, 'a.wasm': 8842}),
+      (opts, hello_webgl2_sources, {'a.html': 861, 'a.js': 6182, 'a.wasm': 8842}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7966,9 +7966,9 @@ int main() {
 
     # test on libc++: see effects of emulated function pointers
     if self.is_wasm_backend():
-      run(['-O2'], 32, [], ['waka'], 226582,  20,  33, 563) # noqa
+      run(['-O2'], 32, [], ['waka'], 226582,  20,  33, 562) # noqa
       run(['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                  32, [], ['waka'], 226582,  20,  33, 563) # noqa
+                  32, [], ['waka'], 226582,  20,  33, 562) # noqa
     else:
       run(['-O2'], 34, ['abort'], ['waka'], 186423,  28,   36, 534) # noqa
       run(['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -6,7 +6,7 @@
 import os
 import logging
 
-TAG = 'version_70'
+TAG = 'version_71'
 
 
 def needed(settings, shared, ports):


### PR DESCRIPTION
After WebAssembly/binaryen#1924 Binaryen has a `--low-memory-unused` flag that we should use (and the `--post-emscripten` pass no longer has any part relevant to `GLOBAL_BASE`, that's all in that new flag).

Better optimization of offsets thanks to that PR improves code size and enables a little more inlining etc., improving the metadce stats.