### PR TITLE
Cleanup early parsing of -x and -o flags

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -398,8 +398,11 @@ def run(args):
   if DEBUG and LEAVE_INPUTS_RAW:
     logger.warning('leaving inputs raw')
 
-  EMCC_CXX = '--emscripten-cxx' in args
-  args = [x for x in args if x != '--emscripten-cxx']
+  if '--emscripten-cxx' in args:
+    run_via_emxx = True
+    args = [x for x in args if x != '--emscripten-cxx']
+  else:
+    run_via_emxx = False
 
   misc_temp_files = shared.configuration.get_temp_files()
 
@@ -447,7 +450,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   if len(args) == 1 and args[0] == '-v': # -v with no inputs
     # autoconf likes to see 'GNU' in the output to enable shared object support
     print('emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) %s' % shared.EMSCRIPTEN_VERSION, file=sys.stderr)
-    code = run_process([shared.CLANG, '-v'], check=False).returncode
+    code = run_process([shared.CLANG_CC, '-v'], check=False).returncode
     shared.check_sanity(force=True)
     return code
 
@@ -480,6 +483,36 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       parts = [x for x in parts if x != '-c' and x != '-o' and input_file not in x and temp_target not in x and '-emit-llvm' not in x]
       print(' '.join(shared.Building.doublequote_spaces(parts[1:])))
     return 0
+
+  # Default to using C++.
+  use_cxx = True
+
+  def get_language_mode(args):
+    return_next = False
+    for item in args:
+      if return_next:
+        return item
+      if item == '-x':
+        return_next = True
+        continue
+      if item.startswith('-x'):
+        return item[2:]
+    return None
+
+  def has_c_source(args):
+    for a in args:
+      if a[0] != '-' and a.endswith(C_ENDINGS + OBJC_ENDINGS):
+        return True
+    return False
+
+  language_mode = get_language_mode(args)
+  has_fixed_language_mode = language_mode is not None
+  if language_mode == 'c':
+    use_cxx = False
+
+  if not has_fixed_language_mode:
+    if not run_via_emxx and has_c_source(args):
+      use_cxx = False
 
   def is_minus_s_for_emcc(args, i):
     # -s OPT=VALUE or -s OPT are interpreted as emscripten flags.
@@ -549,7 +582,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     compiler = os.environ.get('CONFIGURE_CC')
     if not compiler:
       compiler = shared.EMXX if use_js else shared.CLANG_CPP
-    if 'CXXCompiler' not in ' '.join(args) and not EMCC_CXX:
+    if 'CXXCompiler' not in ' '.join(args) and not use_cxx:
       compiler = shared.to_cc(compiler)
 
     def filter_emscripten_options(argv):
@@ -631,16 +664,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         pass # can fail if e.g. writing the executable to /dev/null
     return ret
 
-  if os.environ.get('EMMAKEN_COMPILER'):
-    CXX = os.environ['EMMAKEN_COMPILER']
-  else:
-    CXX = shared.CLANG
-
+  CXX = os.environ.get('EMMAKEN_COMPILER', shared.CLANG_CPP)
   CC = shared.to_cc(CXX)
-
-  # If we got here from a redirection through em++.py, then force a C++ compiler here
-  if EMCC_CXX:
-    CC = CXX
 
   EMMAKEN_CFLAGS = os.environ.get('EMMAKEN_CFLAGS')
   if EMMAKEN_CFLAGS:
@@ -662,18 +687,34 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   # ---------------- End configs -------------
 
   # Check if a target is specified
-  target = None
-  if any(arg.startswith('-o=') for arg in args):
-    raise Exception('Invalid syntax: do not use -o=X, use -o X')
 
-  for i in reversed(range(len(args) - 1)): # Last -o directive should take precedence, if multiple are specified
-    if args[i] == '-o':
-      target = args[i + 1]
-      args = args[:i] + args[i + 2:]
-      break
+  # Find and remove any -o argumnts.  Final one should take precedence, if
+  # multiple are specified.
+  def strip_specified_target(args):
+    outargs = []
+    specified_target = None
+    use_next = False
+    for arg in args:
+      if use_next:
+        specified_target = arg
+        use_next = False
+        continue
+      if arg == '-o':
+        use_next = True
+      elif arg.startswith('-o'):
+        specified_target = arg[2:]
+      else:
+        outargs.append(arg)
+    return specified_target, outargs
 
-  specified_target = target
-  target = specified_target if specified_target is not None else 'a.out.js' # specified_target is the user-specified one, target is what we will generate
+  specified_target, args = strip_specified_target(args)
+
+  # specified_target is the user-specified one, target is what we will generate
+  if specified_target:
+    target = specified_target
+  else:
+    target = 'a.out.js'
+
   shared.Settings.TARGET_BASENAME = target_basename = unsuffixed_basename(target)
 
   final_suffix = suffix(target)
@@ -697,8 +738,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   def optimizing(opts):
     return '-O0' not in opts
 
-  use_cxx = True
-
   with ToolchainProfiler.profile_block('parse arguments and setup'):
     ## Parse args
 
@@ -716,46 +755,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         newargs[i] += newargs[i + 1]
         newargs[i + 1] = ''
 
-    def detect_fixed_language_mode(args):
-      check_next = False
-      for item in args:
-        if check_next:
-          if item in ('c++', 'c'):
-            return True
-          else:
-            check_next = False
-        if item.startswith('-x'):
-          lmode = item[2:] if len(item) > 2 else None
-          if lmode in ('c++', 'c'):
-            return True
-          else:
-            check_next = True
-            continue
-      return False
-
-    has_fixed_language_mode = detect_fixed_language_mode(newargs)
-
     options, settings_changes, newargs = parse_args(newargs)
 
-    for arg in newargs:
-      if arg == '-xc':
-        use_cxx = False
-        break
-      elif arg == '-xc++':
-        use_cxx = True
-        break
-      elif not arg.startswith('-'):
-        if arg.endswith(C_ENDINGS + OBJC_ENDINGS):
-          use_cxx = False
-
-    if not use_cxx:
-      options.default_cxx_std = '' # Compiling C code with .c files, don't enforce a default C++ std.
-
-    call = CXX if use_cxx else CC
-
-    # If user did not specify a default -std for C++ code, specify the emscripten default.
-    if options.default_cxx_std:
-      newargs = newargs + [options.default_cxx_std]
+    if use_cxx:
+      clang_compiler = CXX
+      # If user did not specify a default -std for C++ code, specify the emscripten default.
+      if options.default_cxx_std:
+        newargs += [options.default_cxx_std]
+    else:
+      # Compiling C code with .c files, don't enforce a default C++ std.
+      clang_compiler = CC
 
     if options.emrun:
       options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
@@ -1553,8 +1562,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if specified_target:
           args += ['-o', specified_target]
         args = system_libs.process_args(args, shared.Settings)
-        logger.debug("running (for precompiled headers): " + call + ' ' + ' '.join(args))
-        return run_process([call] + args, check=False).returncode
+        logger.debug("running (for precompiled headers): " + clang_compiler + ' ' + ' '.join(args))
+        return run_process([clang_compiler] + args, check=False).returncode
 
       def get_bitcode_file(input_file):
         if final_suffix not in JS_CONTAINING_ENDINGS:
@@ -1581,7 +1590,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Bitcode args generation code
       def get_clang_args(input_files):
-        args = [call] + newargs + input_files
+        args = [clang_compiler] + newargs + input_files
         if not shared.Building.can_inline():
           args.append('-fno-inline-functions')
         # For fastcomp backend, no LLVM IR functions should ever be annotated
@@ -2326,7 +2335,7 @@ def parse_args(newargs):
         options.default_cxx_std = '-std=c++11'
     elif newargs[i].startswith('-std=') or newargs[i].startswith('--std='):
       # User specified a standard to use, clear Emscripten from specifying it.
-      options.default_cxx_std = ''
+      options.default_cxx_std = None
     elif newargs[i].startswith('--embed-file'):
       check_bad_eq(newargs[i])
       options.embed_files.append(newargs[i + 1])

--- a/emcc.py
+++ b/emcc.py
@@ -375,7 +375,7 @@ def apply_settings(changes):
 
 
 def find_output_arg(args):
-  """Find and remove any -o argumnts.  The final one takes precedence.
+  """Find and remove any -o arguments.  The final one takes precedence.
   Return the final -o target along with the remaining (non-o) arguments.
   """
   outargs = []

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -162,6 +162,13 @@ class other(RunnerCore):
     # any tests for EXPORT_ES6 but once we do this should be enabled.
     # self.assertContained('hello, world!', run_js('hello_world.mjs'))
 
+  def test_emcc_out_file(self):
+    # Verify that "-ofile" works in addition to "-o" "file"
+    run_process([PYTHON, EMCC, '-c', '-ofoo.o', path_from_root('tests', 'hello_world.c')])
+    assert os.path.exists('foo.o')
+    run_process([PYTHON, EMCC, '-ofoo.js', 'foo.o'])
+    assert os.path.exists('foo.js')
+
   def test_emcc_1(self):
     for compiler, suffix in [(EMCC, '.c'), (EMXX, '.cpp')]:
       # --version


### PR DESCRIPTION
We were parsing -x flags twice.  The new code also allows for
'-ofoo.o' we previously did not accept.