### PR TITLE
Disable llvm MachineBlockPlacement

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1903,7 +1903,7 @@ class Building(object):
     # see binaryen#1054
     # and https://bugs.llvm.org/show_bug.cgi?id=39488
     args += ['-disable-lsr']
-    # see ???
+    # see https://github.com/emscripten-core/emscripten/pull/8233
     args += ['-disable-block-placement']
 
     return args

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1899,9 +1899,12 @@ class Building(object):
     # asm.js-style setjmp/longjmp handling
     args += ['-enable-emscripten-sjlj']
 
-    # better (smaller, sometimes faster) codegen, see binaryen#1054
+    # options for better (smaller, sometimes faster) codegen
+    # see binaryen#1054
     # and https://bugs.llvm.org/show_bug.cgi?id=39488
     args += ['-disable-lsr']
+    # see ???
+    args += ['-disable-block-placement']
 
     return args
 


### PR DESCRIPTION
That pass can create irreducible control flow, which is larger. That happens in fannkuch and in zlib, for example. Disabling it on zlib makes the wasm 1.5% smaller.

(There doesn't seem to be much of a speed benefit to doing this. Perhaps it is indeed only doing it to unlikely branches, and not interfering with important ones?)

Are there downsides to disabling the pass entirely?