### PR TITLE
TypeError: Document not active on exitFullscreen

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -370,13 +370,7 @@ var LibraryBrowser = {
         if ((document['fullscreenElement'] || document['mozFullScreenElement'] ||
              document['msFullscreenElement'] || document['webkitFullscreenElement'] ||
              document['webkitCurrentFullScreenElement']) === canvasContainer) {
-          canvas.exitFullscreen = document['exitFullscreen'] ||
-                                  document['cancelFullScreen'] ||
-                                  document['mozCancelFullScreen'] ||
-                                  document['msExitFullscreen'] ||
-                                  document['webkitCancelFullScreen'] ||
-                                  function() {};
-          canvas.exitFullscreen = canvas.exitFullscreen.bind(document);
+          canvas.exitFullscreen = Browser.exitFullscreen;
           if (Browser.lockPointer) canvas.requestPointerLock();
           Browser.isFullscreen = true;
           if (Browser.resizeCanvas) {
@@ -432,6 +426,24 @@ var LibraryBrowser = {
           return Browser.requestFullscreen(lockPointer, resizeCanvas, vrDevice);
         }
         return Browser.requestFullscreen(lockPointer, resizeCanvas, vrDevice);
+    },
+
+    exitFullscreen: function() {
+      // This is workaround for chrome. Trying to exit from fullscreen
+      // not in fullscreen state will cause "TypeError: Document not active"
+      // in chrome. See https://github.com/emscripten-core/emscripten/pull/8236
+      if (!Browser.isFullscreen) {
+        return false;
+      }
+
+      var CFS = document['exitFullscreen'] ||
+                document['cancelFullScreen'] ||
+                document['mozCancelFullScreen'] ||
+                document['msExitFullscreen'] ||
+                document['webkitCancelFullScreen'] ||
+          (function() {});
+      CFS.apply(document, []);
+      return true;
     },
 
     nextRAF: 0,

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -622,12 +622,7 @@ var LibraryGLFW = {
     },
 
     exitFullscreen: function() {
-      var CFS = document['exitFullscreen'] ||
-                document['cancelFullScreen'] ||
-                document['mozCancelFullScreen'] ||
-                document['webkitCancelFullScreen'] ||
-          (function() {});
-      CFS.apply(document, []);
+      Browser.exitFullscreen();
     },
 
     cancelFullScreen: function() {

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -316,12 +316,7 @@ var LibraryGLUT = {
     },
 
     exitFullscreen: function() {
-      var CFS = document['exitFullscreen'] ||
-                document['cancelFullScreen'] ||
-                document['mozCancelFullScreen'] ||
-                document['webkitCancelFullScreen'] ||
-          (function() {});
-      CFS.apply(document, []);
+      Browser.exitFullscreen();
     },
 
     cancelFullScreen: function() {

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2208,8 +2208,7 @@ var LibrarySDL = {
   SDL_WM_ToggleFullScreen__proxy: 'sync',
   SDL_WM_ToggleFullScreen__sig: 'ii',
   SDL_WM_ToggleFullScreen: function(surf) {
-    if (Browser.isFullscreen) {
-      Module['canvas'].exitFullscreen();
+    if (Browser.exitFullscreen()) {
       return 1;
     } else {
       if (!SDL.canRequestFullscreen) {


### PR DESCRIPTION
Hi have this error with chrome 71,72:

```
VM426:3 Uncaught (in promise) TypeError: Document not active
    at Object.exitFullscreen (eval at value (), <anonymous>:3:217832)
    at _glutReshapeWindow (eval at value (), <anonymous>:3:220223)
    at _glutMainLoop (eval at value (), <anonymous>:3:220391)
    at :8080/wasm-function[25745]:1138
    at :8080/wasm-function[25744]:550
    at :8080/wasm-function[25741]:11
    at :8080/wasm-function[22478]:65
    at :8080/wasm-function[22475]:23
    at :8080/wasm-function[579]:36
    at :8080/wasm-function[22430]:16
```

This wasm-function is just main -> glutInit, etc.

This bug is simmilar to https://github.com/jpilfold/ngx-image-viewer/issues/23. I believe that this is a chrome bug, but this is workaround.