### PR TITLE
Fix variable name typo in jsifier.js

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -201,17 +201,17 @@ function JSify(data, functionsOnly) {
         }
         if (!(MAIN_MODULE || SIDE_MODULE)) {
           // emit a stub that will fail at runtime
-          LibraryManager.library[shortident] = new Function("err('missing function: " + shortident + "'); abort(-1);");
+          LibraryManager.library[ident] = new Function("err('missing function: " + ident + "'); abort(-1);");
         } else {
-          var target = (MAIN_MODULE ? '' : 'parent') + "Module['_" + shortident + "']";
+          var target = (MAIN_MODULE ? '' : 'parent') + "Module['_" + ident + "']";
           var assertion = '';
           if (ASSERTIONS)
-            assertion = '  if (!' + target + ')\n    abort("external function \'' + shortident + '\' is missing. perhaps a side module was not linked in? if this function was expected to arrive from a system library, try to build the MAIN_MODULE with EMCC_FORCE_STDLIBS=1 in the environment");\n';
-          LibraryManager.library[shortident] = new Function(assertion + "  return " + target + ".apply(null, arguments);");
+            assertion = 'if (!' + target + ') abort("external function \'' + ident + '\' is missing. perhaps a side module was not linked in? if this function was expected to arrive from a system library, try to build the MAIN_MODULE with EMCC_FORCE_STDLIBS=1 in the environment");';
+          LibraryManager.library[ident] = new Function(assertion + "return " + target + ".apply(null, arguments);");
           if (SIDE_MODULE) {
             // no dependencies, just emit the thunk
             Functions.libraryFunctions[finalName] = 1;
-            return processLibraryFunction(LibraryManager.library[shortident], ident, finalName);
+            return processLibraryFunction(LibraryManager.library[ident], ident, finalName);
           }
           noExport = true;
         }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3236,8 +3236,8 @@ int main(int argc, char** argv) {
 ''')
     run_process([PYTHON, EMCC, '-O0', 'main.c', '--js-library', 'lib.js', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
     generated = open('a.out.js').read()
-    self.assertContained('var _NonPrimitive=', generated)
-    self.assertNotContained('var _Int8Array=', generated)
+    self.assertContained('missing function: NonPrimitive', generated)
+    self.assertNotContained('missing function: Int8Array', generated)
 
   def test_js_lib_using_asm_lib(self):
     create_test_file('lib.js', r'''
@@ -8006,7 +8006,7 @@ int main() {
                    0, [],        [],           8,   0,    0,  0) # noqa; totally empty!
       # we don't metadce with linkable code! other modules may want stuff
       run(['-O3', '-s', 'MAIN_MODULE=1'],
-                1533, [],        [],      226403,  28,   93, None) # noqa; don't compare the # of functions in a main module, which changes a lot
+                1537, [],        [],      226403,  28,   93, None) # noqa; don't compare the # of functions in a main module, which changes a lot
 
   # ensures runtime exports work, even with metadce
   def test_extra_runtime_exports(self):


### PR DESCRIPTION
In most cases the `ident` argument and the `shortident` from the
enclosing scope match so it doesn't have much a effect.

However on the recurisve call the `shortident` ends up pointing to
the previous symbol name and the wrong 'missing function' stub is
generated.

This added assertion will fire in some cases without this change.