### PR TITLE
Remove used code from modules.js/jsifier.js

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -107,13 +107,7 @@ function JSify(data, functionsOnly) {
       libFuncsToInclude = DEFAULT_LIBRARY_FUNCS_TO_INCLUDE;
     }
     libFuncsToInclude.forEach(function(ident) {
-      var finalName = '_' + ident;
-      if (ident[0] === '$') {
-        finalName = ident.substr(1);
-      }
       data.functionStubs.push({
-        intertype: 'functionStub',
-        finalName: finalName,
         ident: '_' + ident
       });
     });
@@ -144,11 +138,6 @@ function JSify(data, functionsOnly) {
       LibraryManager.library[item.ident.substr(1)] = function() {
         return ___cxa_find_matching_catch.apply(null, arguments);
       };
-    }
-
-    // note the signature
-    if (item.returnType && item.params) {
-      functionStubSigs[item.ident] = Functions.getSignature(item.returnType.text, item.params.map(function(arg) { return arg.type }), false);
     }
 
     function addFromLibrary(ident) {
@@ -259,7 +248,6 @@ function JSify(data, functionsOnly) {
         if (postset && !addedLibraryItems[postsetId] && !SIDE_MODULE) {
           addedLibraryItems[postsetId] = true;
           itemsDict.GlobalVariablePostSet.push({
-            intertype: 'GlobalVariablePostSet',
             JS: postset + ';'
           });
         }

--- a/src/modules.js
+++ b/src/modules.js
@@ -49,54 +49,8 @@ var Functions = {
   nextIndex: firstTableIndex, // Start at a non-0 (even, see below) value
   neededTables: set('v', 'vi', 'ii', 'iii'), // signatures that appeared (initialized with library stuff
                                              // we always use), and we will need a function table for
-
   blockAddresses: {}, // maps functions to a map of block labels to label ids
-
   aliases: {}, // in shared modules (MAIN_MODULE or SHARED_MODULE), a list of aliases for functions that have them
-
-  getSignatureLetter: function(type) {
-    switch(type) {
-      case 'float': return 'f';
-      case 'double': return 'd';
-      case 'void': return 'v';
-      default: return 'i';
-    }
-  },
-
-  getSignatureType: function(letter) {
-    switch(letter) {
-      case 'v': return 'void';
-      case 'i': return 'i32';
-      case 'f': return 'float';
-      case 'd': return 'double';
-      default: throw 'what is this sig? ' + sig;
-    }
-  },
-
-  getSignature: function(returnType, argTypes, hasVarArgs) {
-    var sig = Functions.getSignatureLetter(returnType);
-    for (var i = 0; i < argTypes.length; i++) {
-      var type = argTypes[i];
-      if (!type) break; // varargs
-      if (type in Compiletime.FLOAT_TYPES) {
-        sig += Functions.getSignatureLetter(type);
-      } else {
-        var chunks = getNumIntChunks(type);
-        if (chunks > 0) {
-          for (var j = 0; j < chunks; j++) sig += 'i';
-        } else if (type !== '...') {
-          // some special type like a SIMD vector (anything but varargs, which we handle below)
-          sig += Functions.getSignatureLetter(type);
-        }
-      }
-    }
-    if (hasVarArgs) sig += 'i';
-    return sig;
-  },
-
-  getTable: function(sig) {
-    return 'FUNCTION_TABLE_' + sig
-  }
 };
 
 var LibraryManager = {


### PR DESCRIPTION
Removes some never-used fields from GlobalVariablePostSet and functionStubs.

Also remove some unused methods from modules.js:Functions.