### PR TITLE
Only print 'Preallocating ? workers for a pthread spawn pool' on PTHREADS_DEBUG

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -259,7 +259,9 @@ var LibraryPThread = {
     //                    ready to host pthreads. Optional. This is used to mitigate bug https://bugzilla.mozilla.org/show_bug.cgi?id=1049079
     allocateUnusedWorkers: function(numWorkers, onFinishedLoading) {
       if (typeof SharedArrayBuffer === 'undefined') return; // No multithreading support, no-op.
+#if PTHREADS_DEBUG
       out('Preallocating ' + numWorkers + ' workers for a pthread spawn pool.');
+#endif
 
       var numWorkersLoaded = 0;
       var pthreadMainJs = "{{{ PTHREAD_WORKER_FILE }}}";


### PR DESCRIPTION
Does Emscripten really need to print this out every time a thread is created?
I figured I'd open a PR for discussion.