### PR TITLE
Use `create_lib` over `link_to_object` in ports

### DIFF
--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -65,7 +65,7 @@ def get(ports, settings, shared):
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
     final = os.path.join(cocos2d_build, libname)
-    shared.Building.link_to_object(o_s, final)
+    ports.create_lib(final, o_s)
     return final
 
   return [shared.Cache.get(libname, create, what='port')]

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -38,7 +38,7 @@ def get(ports, settings, shared):
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
     final = os.path.join(ports.get_build_dir(), 'sdl2_ttf', libname)
-    shared.Building.link_to_object(o_s, final)
+    ports.create_lib(final, o_s)
     return final
 
   return [shared.Cache.get(libname, create, what='port')]


### PR DESCRIPTION
Ports can be bitcode file or archives depending on weather we are
using object files or bitcode files.  create_lib will do the right
thing whereas link_to_object will alwasy produce one big object.