### PR TITLE
Implement addFunction under wasm backend purely in terms of the wasm table

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -665,15 +665,6 @@ def update_settings_glue(metadata):
   shared.Settings.MAX_GLOBAL_ALIGN = metadata['maxGlobalAlign']
   shared.Settings.IMPLEMENTED_FUNCTIONS = metadata['implementedFunctions']
 
-  # addFunction support for Wasm backend
-  if shared.Settings.WASM_BACKEND and shared.Settings.RESERVED_FUNCTION_POINTERS > 0:
-    start_index = metadata['jsCallStartIndex']
-    # e.g. jsCallFunctionType ['v', 'ii'] -> sig2order{'v': 0, 'ii': 1}
-    sig2order = {sig: i for i, sig in enumerate(metadata['jsCallFuncType'])}
-    # Index in the Wasm function table in which jsCall thunk function starts
-    shared.Settings.JSCALL_START_INDEX = start_index
-    shared.Settings.JSCALL_SIG_ORDER = sig2order
-
   # Extract the list of function signatures that MAIN_THREAD_EM_ASM blocks in
   # the compiled code have, each signature will need a proxy function invoker
   # generated for it.
@@ -2382,8 +2373,6 @@ def load_metadata_wasm(metadata_raw, DEBUG):
     'externs': [],
     'simd': False,
     'maxGlobalAlign': 0,
-    'jsCallStartIndex': 0,
-    'jsCallFuncType': [],
     'staticBump': 0,
     'tableSize': 0,
     'initializers': [],

--- a/src/library.js
+++ b/src/library.js
@@ -2215,7 +2215,7 @@ LibraryManager.library = {
     // Insert the function into the wasm table.  Since we know the function
     // comes directly from the loaded wasm module we can insert it directly
     // into the table, avoiding any JS interaction.
-    return addWasmFunction(result);
+    return addFunctionWasm(result);
 #else
     // convert the exported function into a function pointer using our generic
     // JS mechanism.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1019,7 +1019,11 @@ Module['asm'] = function(global, env, providedBuffer) {
   env['table'] = wasmTable = new WebAssembly.Table({
     'initial': {{{ getQuoted('WASM_TABLE_SIZE') }}},
 #if !ALLOW_TABLE_GROWTH
+#if WASM_BACKEND
+    'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}} + {{{ RESERVED_FUNCTION_POINTERS }}},
+#else
     'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}},
+#endif
 #endif // WASM_BACKEND
     'element': 'anyfunc'
   });

--- a/src/settings.js
+++ b/src/settings.js
@@ -1163,8 +1163,6 @@ var PTHREADS_DEBUG = 0;
 
 var MAX_GLOBAL_ALIGN = -1; // received from the backend
 var IMPLEMENTED_FUNCTIONS = []; // received from the backend
-var JSCALL_START_INDEX = 0; // received from the backend
-var JSCALL_SIG_ORDER = {}; // received from the backend
 
 // Duplicate function elimination. This coalesces function bodies that are
 // identical, which can happen e.g. if two methods have different C/C++ or LLVM

--- a/src/settings.js
+++ b/src/settings.js
@@ -287,9 +287,7 @@ var ALIASING_FUNCTION_POINTERS = 0;
 // By default we use a wasm Table for function pointers, which is fast and
 // efficient. When enabling emulation, we also use the Table *outside* the wasm
 // module, exactly as when emulating in asm.js, just replacing the plain JS
-// array with a Table. However, Tables have some limitations currently, like not
-// being able to assign an arbitrary JS method to them, which we have yet to
-// work around.
+// array with a Table.
 var EMULATED_FUNCTION_POINTERS = 0;
 
 // Allows function pointers to be cast, wraps each call of an incorrect type

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2940,7 +2940,6 @@ class JS(object):
   def make_jscall(sig):
     fnargs = ','.join('a' + str(i) for i in range(1, len(sig)))
     args = (',' if fnargs else '') + fnargs
-    index = 'index'
     ret = '''\
 function jsCall_%s(index%s) {
     %sfunctionPointers[index](%s);

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2937,29 +2937,14 @@ class JS(object):
     return ret
 
   @staticmethod
-  def make_jscall(sig, sig_order=None):
+  def make_jscall(sig):
     fnargs = ','.join('a' + str(i) for i in range(1, len(sig)))
-    args = 'index' + (',' if fnargs else '') + fnargs
-    # While asm.js/fastcomp's addFunction support preallocates
-    # Settings.RESERVED_FUNCTION_POINTERS slots in functionPointers array, on
-    # the Wasm backend we reserve that number of slots for each possible
-    # function signature, so it is (Settings.RESERVED_FUNCTION_POINTERS * # of
-    # indirectly called function signatures) slots in total. So the index to
-    # functionPointers array should be adjusted according to the order of the
-    # function signature. The reason we do this is Wasm has a single unified
-    # function table while asm.js maintains separate function table per
-    # signature.
-    # e.g. When there are three possible function signature, ['v', 'ii', 'ff'],
-    # the 'sig_order' parameter will be 0 for 'v', 1 for 'ii', and so on.
-    if Settings.WASM_BACKEND:
-      assert sig_order is not None
-      index = 'index + %d' % (Settings.RESERVED_FUNCTION_POINTERS * sig_order)
-    else:
-      index = 'index'
+    args = (',' if fnargs else '') + fnargs
+    index = 'index'
     ret = '''\
-function jsCall_%s(%s) {
-    %sfunctionPointers[%s](%s);
-}''' % (sig, args, 'return ' if sig[0] != 'v' else '', index, fnargs)
+function jsCall_%s(index%s) {
+    %sfunctionPointers[index](%s);
+}''' % (sig, args, 'return ' if sig[0] != 'v' else '', fnargs)
     return ret
 
   @staticmethod


### PR DESCRIPTION
This removes the need for any wasm-side `jsCall` thunks.

In order to call `addFunction` either ALLOW_MEMORY_GROWTH or
RESERVED_FUNCTION_POINTERS is still required.

Also, if a JS function is added its signature is still required.

The corresponding binaryen change is: https://github.com/WebAssembly/binaryen/pull/1938