### PR TITLE
Remove FORCE_ALIGNED_MEMORY from settings.js

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -827,7 +827,6 @@ var asmPrintCounter = 0;
 // See makeSetValue
 function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSafe, forceAsm) {
   if (UNALIGNED_MEMORY) align = 1;
-  else if (FORCE_ALIGNED_MEMORY && !isIllegalType(type)) align = 8;
 
   if (isStructType(type)) {
     var typeData = Types.types[type];
@@ -908,7 +907,6 @@ function makeGetValueAsm(ptr, pos, type, unsigned) {
 //! @param noNeedFirst Whether to ignore the offset in the pointer itself.
 function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe, sep, forcedAlign, forceAsm) {
   if (UNALIGNED_MEMORY && !forcedAlign) align = 1;
-  else if (FORCE_ALIGNED_MEMORY && !isIllegalType(type)) align = 8;
 
   sep = sep || ';';
   if (isStructType(type)) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -160,14 +160,6 @@ var DOUBLE_MODE = 1;
 // the cost of slowness
 var UNALIGNED_MEMORY = 0;
 
-// If enabled, assumes all reads and writes are fully aligned for the type they
-// use. This is true in proper C code (no undefined behavior), but is sadly
-// common enough that we can't do it by default. See SAFE_HEAP.  For ways to
-// help find places in your code where unaligned reads/writes are done - you
-// might be able to refactor your codebase to prevent them, which leads to
-// smaller and faster code, or even the option to turn this flag on.
-var FORCE_ALIGNED_MEMORY = 0;
-
 // Warn at compile time about instructions that LLVM tells us are not fully
 // aligned.  This is useful to find places in your code where you might refactor
 // to ensure proper alignment.  This is currently only supported in asm.js, not

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5586,20 +5586,6 @@ return malloc(size);
                     includes=[path_from_root('tests', 'bullet', 'src')])
       test()
 
-      # TODO: test only worked in non-fastcomp (well, this section)
-      continue
-      assert 'asm2g' in core_test_modes
-      if self.run_name == 'asm2g' and not use_cmake:
-        # Test forced alignment
-        print('testing FORCE_ALIGNED_MEMORY', file=sys.stderr)
-        old = open('src.cpp.o.js').read()
-        self.set_setting('FORCE_ALIGNED_MEMORY', 1)
-        test()
-        new = open('src.cpp.o.js').read()
-        print(len(old), len(new), old.count('tempBigInt'), new.count('tempBigInt'))
-        assert len(old) > len(new)
-        assert old.count('tempBigInt') > new.count('tempBigInt')
-
   @no_windows('depends on freetype, which uses a ./configure which donsnt run on windows.')
   @is_slow_test
   def test_poppler(self):


### PR DESCRIPTION
Its gets added back via LEGACY_SETTINGS, but this removes it
from visibility.  Also remove any remaining uses.

See #8257