### PR TITLE
Don't allow legacy settings in strict mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -829,8 +829,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     has_header_inputs = False
     lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
                 shared.path_from_root('system', 'lib')]
-    for i in range(len(newargs)): # find input files XXX this a simple heuristic. we should really analyze based on a full understanding of gcc params,
-                                  # right now we just assume that what is left contains no more |-x OPT| things
+
+    # find input files this a simple heuristic. we should really analyze
+    # based on a full understanding of gcc params, right now we just assume that
+    # what is left contains no more |-x OPT| things
+    for i in range(len(newargs)):
       arg = newargs[i]
       if i > 0:
         prev = newargs[i - 1]
@@ -945,18 +948,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if options.separate_asm:
       shared.Settings.SEPARATE_ASM = shared.JS.get_subresource_location(asm_target)
 
-    if 'EMCC_STRICT' in os.environ:
-      shared.Settings.STRICT = os.environ.get('EMCC_STRICT') != '0'
-
-    # Libraries are searched before settings_changes are applied, so apply the value for STRICT and ERROR_ON_MISSING_LIBRARIES from
-    # command line already now.
+    # Libraries are searched before settings_changes are applied, so apply the
+    # value for STRICT and ERROR_ON_MISSING_LIBRARIES from command line already
+    # now.
 
     def get_last_setting_change(setting):
       return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
 
     strict_cmdline = get_last_setting_change('STRICT')
     if strict_cmdline:
-      shared.Settings.STRICT = int(strict_cmdline[len('STRICT='):])
+      shared.Settings.STRICT = int(strict_cmdline.split('=', 1)[1])
 
     if shared.Settings.STRICT:
       shared.Settings.ERROR_ON_MISSING_LIBRARIES = 1

--- a/src/settings.js
+++ b/src/settings.js
@@ -1392,14 +1392,14 @@ var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 0;
 // to explicitly choose to disable HTML minification altogether.
 var MINIFY_HTML = 1;
 
-// Legacy settings that have been removed, and the values they are now fixed to. These can no
-// longer be changed:
-// [OPTION_NAME, POSSIBLE_VALUES, ERROR_EXPLANATION], where POSSIBLE_VALUES is an array of values that will
-// still be silently accepted by the compiler. First element in the list is the canonical/fixed value going forward.
-// This allows existing build systems to keep specifying one of the supported settings, for backwards compatibility.
+// Legacy settings that have been removed, and the values they are now fixed to.
+// These can no longer be changed:
+// [OPTION_NAME, POSSIBLE_VALUES, ERROR_EXPLANATION], where POSSIBLE_VALUES is
+// an array of values that will still be silently accepted by the compiler.
+// First element in the list is the canonical/fixed value going forward.
+// This allows existing build systems to keep specifying one of the supported
+// settings, for backwards compatibility.
 var LEGACY_SETTINGS = [
-  ['ASM_JS', [1, 2], 'ASM_JS must be enabled in fastcomp'],
-  ['SAFE_HEAP', [0, 1], 'safe heap must be 0 or 1 in fastcomp'],
   ['UNALIGNED_MEMORY', [0], 'forced unaligned memory not supported in fastcomp'],
   ['FORCE_ALIGNED_MEMORY', [0], 'forced aligned memory is not supported in fastcomp'],
   ['PGO', [0], 'pgo no longer supported'],

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9042,9 +9042,16 @@ int main () {
     asmjs = ['-s', 'WASM=0', '--separate-asm', '-s', 'ELIMINATE_DUPLICATE_FUNCTIONS=1', '--memory-init-file', '1']
     opts = ['-O3', '--closure', '1', '-DNDEBUG', '-ffast-math']
 
-    hello_world_sources = [path_from_root('tests', 'small_hello_world.c'), '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]', '-s', 'USES_DYNAMIC_ALLOC=0', '-s', 'ASM_PRIMITIVE_VARS=[STACKTOP]']
-    hello_webgl_sources = [path_from_root('tests', 'minimal_webgl', 'main.cpp'), path_from_root('tests', 'minimal_webgl', 'webgl.c'), '--js-library', path_from_root('tests', 'minimal_webgl', 'library_js.js'),
-                           '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]', '-s', 'USES_DYNAMIC_ALLOC=2', '-lGL', '-s', 'MODULARIZE=1']
+    hello_world_sources = [path_from_root('tests', 'small_hello_world.c'),
+                           '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]',
+                           '-s', 'USES_DYNAMIC_ALLOC=0',
+                           '-s', 'ASM_PRIMITIVE_VARS=[STACKTOP]']
+    hello_webgl_sources = [path_from_root('tests', 'minimal_webgl', 'main.cpp'),
+                           path_from_root('tests', 'minimal_webgl', 'webgl.c'),
+                           '--js-library', path_from_root('tests', 'minimal_webgl', 'library_js.js'),
+                           '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]',
+                           '-s', 'USES_DYNAMIC_ALLOC=2', '-lGL',
+                           '-s', 'MODULARIZE=1']
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'USE_WEBGL2=1']
 
     test_cases = [
@@ -9102,3 +9109,16 @@ int main () {
 
     run_process([PYTHON, EMCC, '-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1', path_from_root('tests', 'hello_world.c')])
     run_process([PYTHON, EMCC, '-s', 'PRECISE_I64_MATH=2', path_from_root('tests', 'hello_world.c')])
+
+  def test_legacy_settings_strict_mode(self):
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'SPLIT_MEMORY=0']
+    run_process(cmd)
+
+    with env_modify({'EMCC_STRICT': '1'}):
+      proc = run_process(cmd, stderr=PIPE, check=False)
+      self.assertNotEqual(proc.returncode, 0)
+      self.assertContained('legacy setting used in strict mode: SPLIT_MEMORY', proc.stderr)
+
+    proc = run_process(cmd + ['-s', 'STRICT=1'], stderr=PIPE, check=False)
+    self.assertNotEqual(proc.returncode, 0)
+    self.assertContained('legacy setting used in strict mode: SPLIT_MEMORY', proc.stderr)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -331,7 +331,7 @@ class sanity(RunnerCore):
 
     restore_and_set_up()
 
-    self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'ASM_JS=0'], '''ASM_JS must be enabled in fastcomp''')
+    self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'ASM_JS=0'], 'ASM_JS can only be set to either 1 or 2')
 
   def test_node(self):
     NODE_WARNING = 'node version appears too old'


### PR DESCRIPTION
In strict mode (`EMCC_STRICT=1` or `-s STRICT`) treat any usage
of legacy settings as an error.

We don't even attach the legacy settings in this case so it becomes
impossible to depend on legacy settings.

See #8257