### PR TITLE
Pin firefox used during testing to specific version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,11 +171,11 @@ jobs:
       - run:
           name: download firefox
           command: |
-            # wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/62.0.2/linux-x86_64/en-US/firefox-62.0.2.tar.bz2
-            # tar xf firefox-62.0.2.tar.bz2
-            # Currently we need firefox nightly to test wasm threads
-            wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
-            tar xf nightly.tar.bz2
+            FF_VERSION=65.0.2
+            wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FF_VERSION/linux-x86_64/en-US/firefox-$FF_VERSION.tar.bz2
+            tar xf firefox-$FF_VERSION.tar.bz2
+            # wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+            # tar xf nightly.tar.bz2
       - run:
           name: configure firefox
           command: |


### PR DESCRIPTION
The nightly build was crashing during test_cococ2d_hello:
[Parent 5567, Gecko_IOThread] WARNING: pipe error (103): Connection reset by peer: file /builds/worker/workspace/build/src/ipc/chromium/src/chrome/common/ipc_channel_posix.cc, line 357?