### PR TITLE
Avoid extra bitcode link in poppler library testing. NFC.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -721,7 +721,9 @@ class RunnerCore(unittest.TestCase):
       os.makedirs(ret)
     return ret
 
-  def get_library(self, name, generated_libs, configure=['sh', './configure'], configure_args=[], make=['make'], make_args='help', cache=True, env_init={}, cache_name_extra='', native=False):
+  def get_library(self, name, generated_libs, configure=['sh', './configure'],
+                  configure_args=[], make=['make'], make_args='help',
+                  cache=True, env_init={}, cache_name_extra='', native=False):
     if make_args == 'help':
       make_args = ['-j', str(multiprocessing.cpu_count())]
 
@@ -747,8 +749,11 @@ class RunnerCore(unittest.TestCase):
 
     print('<building and saving %s into cache> ' % cache_name, file=sys.stderr)
 
-    return Building.build_library(name, build_dir, output_dir, generated_libs, configure, configure_args, make, make_args, self.library_cache, cache_name,
-                                  copy_project=True, env_init=env_init, native=native)
+    return Building.build_library(name, build_dir, output_dir, generated_libs,
+                                  configure, configure_args, make, make_args,
+                                  self.library_cache, cache_name,
+                                  copy_project=True, env_init=env_init,
+                                  native=native)
 
   def clear(self):
     for name in os.listdir(self.get_dir()):
@@ -1426,12 +1431,7 @@ def get_poppler_library(runner_core):
       env_init={'FONTCONFIG_CFLAGS': ' ', 'FONTCONFIG_LIBS': ' '},
       configure_args=['--disable-libjpeg', '--disable-libpng', '--disable-poppler-qt', '--disable-poppler-qt4', '--disable-cms', '--disable-cairo-output', '--disable-abiword-output', '--enable-shared=no'])
 
-  # Combine libraries
-
-  combined = os.path.join(runner_core.get_dir(), 'poppler-combined.bc')
-  Building.link_to_object(poppler + freetype, combined)
-
-  return combined
+  return poppler + freetype
 
 
 def check_js_engines():

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1016,7 +1016,7 @@ class benchmark(RunnerCore):
       ''' % DEFAULT_ARG)
 
     def lib_builder(name, native, env_init):
-      return [get_poppler_library(self)]
+      return get_poppler_library(self)
 
     # TODO: Fix poppler native build and remove skip_native=True
     self.do_benchmark('poppler', '', 'hashed printout',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5601,12 +5601,13 @@ return malloc(size);
         var FileData = MEMFS.getFileDataAsRegularArray(FS.root.contents['filename-1.ppm']);
         out("Data: " + JSON.stringify(FileData.map(function(x) { return unSign(x, 8) })));
       };
-''')
+      ''')
       self.emcc_args += ['--pre-js', 'pre.js']
 
-      self.do_ll_run(get_poppler_library(self),
-                     str(list(bytearray(open(path_from_root('tests', 'poppler', 'ref.ppm'), 'rb').read()))).replace(' ', ''),
-                     args='-scale-to 512 paper.pdf filename'.split(' '))
+      ppm_data = str(list(bytearray(open(path_from_root('tests', 'poppler', 'ref.ppm'), 'rb').read())))
+      self.do_run('', ppm_data.replace(' ', ''),
+                  libraries=get_poppler_library(self),
+                  args=['-scale-to', '512', 'paper.pdf', 'filename'])
 
     test()
 


### PR DESCRIPTION
This change removes a call to `do_ll_run` and `Building.link`
to link bitcode files.