### PR TITLE
Fix lzma build on Cheerp

### DIFF
--- a/tests/lzma/Makefile
+++ b/tests/lzma/Makefile
@@ -10,7 +10,7 @@ OBJECTS = \
 all: lzma.a
 
 %.o: %.c
-	$(CC) -I. $< -o $@ -O2 -c
+	$(CC) $(CFLAGS) -I. $< -o $@ -O2 -c
 
 lzma.a: $(OBJECTS)
 	$(AR) rv $@ $(OBJECTS)

--- a/tests/lzma/Makefile
+++ b/tests/lzma/Makefile
@@ -10,7 +10,7 @@ OBJECTS = \
 all: lzma.a
 
 %.o: %.c
-	$(CC) $(CFLAGS) -I. $< -o $@ -O2 -c
+	$(CC) $(CFLAGS) -I. $< -o $@ -c
 
 lzma.a: $(OBJECTS)
 	$(AR) rv $@ $(OBJECTS)


### PR DESCRIPTION
Minor fix to build LZMA test using Cheerp. The only problem was that CFLAGS were not correctly used by the Makefile.