### PR TITLE
check_engine should skip checking JS engine in run_js, because we're …

### DIFF
--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -63,7 +63,9 @@ def check_engine(engine):
     return WORKING_ENGINES[engine_path]
   try:
     logging.debug('Checking JS engine %s' % engine)
-    if 'hello, world!' in run_js(shared.path_from_root('src', 'hello_world.js'), engine):
+    output = run_js(shared.path_from_root('src', 'hello_world.js'), engine,
+                    skip_check=True)
+    if 'hello, world!' in output:
       WORKING_ENGINES[engine_path] = True
   except Exception as e:
     logging.info('Checking JS engine %s failed. Check your config file. Details: %s' % (str(engine), str(e)))


### PR DESCRIPTION
…already checking the engine

This fails very oddly, in that it logs an error but does not report one in the test runner, so I have no idea how long this has been happening.