### PR TITLE
Modify test.test_only_force_stdlibs to avoid data symbols

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4737,7 +4737,7 @@ main()
     with env_modify({'EMCC_FORCE_STDLIBS': 'libc'}):
       test('partial list, but ok since we grab them as needed')
 
-    with env_modify({'EMCC_FORCE_STDLIBS': 'libc', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):
+    with env_modify({'EMCC_FORCE_STDLIBS': 'libc++', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):
       test('fail! not enough stdlibs', fail=True)
 
     with env_modify({'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++,libpthreads_stub', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):


### PR DESCRIPTION
With lld (i.e. with the wasm backend) undefined data symbols are
not allows, since the linker cannot produce valid output in that
case.  So modify the test slightly to avoid the missing data symbols
dependencies on std::out.