### PR TITLE
Fix SAFE_HEAP_LOG + WASM

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1541,9 +1541,9 @@ def create_basic_funcs(function_table_sigs, invoke_function_names):
   if shared.Settings.EMTERPRETIFY:
     basic_funcs += ['abortStackOverflowEmterpreter']
   if shared.Settings.SAFE_HEAP:
-    if asm_safe_heap():
+    if asm_safe_heap() or shared.Settings.WASM:
       basic_funcs += ['segfault', 'alignfault', 'ftfault']
-    else:
+    if not asm_safe_heap():
       basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
   if shared.Settings.ASSERTIONS:
     for sig in function_table_sigs:

--- a/emscripten.py
+++ b/emscripten.py
@@ -1541,10 +1541,14 @@ def create_basic_funcs(function_table_sigs, invoke_function_names):
   if shared.Settings.EMTERPRETIFY:
     basic_funcs += ['abortStackOverflowEmterpreter']
   if shared.Settings.SAFE_HEAP:
-    if asm_safe_heap() or shared.Settings.WASM:
+    if asm_safe_heap():
       basic_funcs += ['segfault', 'alignfault', 'ftfault']
-    if not asm_safe_heap():
+    else:
+      # Binaryen generates calls to these two so they are always needed with wasm
+      if shared.Settings.WASM:
+        basic_funcs += ['segfault', 'alignfault']
       basic_funcs += ['SAFE_HEAP_LOAD', 'SAFE_HEAP_LOAD_D', 'SAFE_HEAP_STORE', 'SAFE_HEAP_STORE_D', 'SAFE_FT_MASK']
+
   if shared.Settings.ASSERTIONS:
     for sig in function_table_sigs:
       basic_funcs += ['nullFunc_' + sig]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2527,8 +2527,8 @@ seeked= file.
 
     run_process([PYTHON, EMCC, 'main.o', '-s', 'supp.o', '-s', 'SAFE_HEAP=1'])
     self.assertContained('yello', run_js('a.out.js'))
-    code = open('a.out.js').read()
-    assert 'SAFE_HEAP' in code, 'valid -s option had an effect'
+    # Check that valid -s option had an effect'
+    self.assertContained('SAFE_HEAP', open('a.out.js').read())
 
   def test_conftest_s_flag_passing(self):
     create_test_file('conftest.c', r'''
@@ -9117,3 +9117,14 @@ int main () {
     proc = run_process(cmd + ['-s', 'STRICT=1'], stderr=PIPE, check=False)
     self.assertNotEqual(proc.returncode, 0)
     self.assertContained('legacy setting used in strict mode: SPLIT_MEMORY', proc.stderr)
+
+  def test_safe_heap_log(self):
+    self.set_setting('SAFE_HEAP')
+    self.set_setting('SAFE_HEAP_LOG')
+    self.set_setting('EXIT_RUNTIME')
+    src = open(path_from_root('tests', 'hello_world.c')).read()
+    self.do_run(src, 'SAFE_HEAP load: ')
+
+    if not self.is_wasm_backend():
+      self.set_setting('WASM', 0)
+      self.do_run(src, 'SAFE_HEAP load: ')


### PR DESCRIPTION
With wasm SAFE_HEAP always requires `segfault` and friends because
calls to them are constructed by the binaryen pass.