### PR TITLE
Cleanup of emcc -s argument parsing

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -615,20 +615,17 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       compiler = shared.to_cc(compiler)
 
     def filter_emscripten_options(argv):
-      idx = 0
       skip_next = False
-      for el in argv:
+      for idx, arg in enumerate(argv):
         if skip_next:
           skip_next = False
-          idx += 1
           continue
-        if not use_js and el == '-s' and is_minus_s_for_emcc(argv, idx): # skip -s X=Y if not using js for configure
+        if not use_js and arg == '-s' and is_minus_s_for_emcc(argv, idx):
+          # skip -s X=Y if not using js for configure
           skip_next = True
-        if not use_js and el == '--tracing':
-          pass
-        else:
-          yield el
-        idx += 1
+          continue
+        if use_js or arg != '--tracing':
+          yield arg
 
     if compiler in (shared.EMCC, shared.EMXX):
       compiler = [shared.PYTHON, compiler]
@@ -2256,6 +2253,10 @@ def parse_args(newargs):
   settings_changes = []
   should_exit = False
 
+  def check_bad_eq(arg):
+    if '=' in arg:
+      exit_with_error('Invalid parameter (do not use "=" with "--" options)')
+
   for i in range(len(newargs)):
     # On Windows Vista (and possibly others), excessive spaces in the command line
     # leak into the items in this array, so trim e.g. 'foo.cpp ' -> 'foo.cpp'
@@ -3204,25 +3205,27 @@ def parse_value(text):
       text = text.rstrip()
       assert text[-1] == text[0] and len(text) > 1, 'unclosed opened quoted string. expected final character to be "%s" and length to be greater than 1 in "%s"' % (text[0], text)
       return text[1:-1]
-    else:
-      return text
+    return text
 
-  def parse_string_list_members(text, sep):
+  def parse_string_list_members(text):
+    sep = ','
     values = text.split(sep)
     result = []
     index = 0
     while True:
       current = values[index].lstrip() # Cannot safely rstrip for cases like: "HERE-> ,"
-      assert len(current), "string array should not contain an empty value"
+      if not len(current):
+        exit_with_error('string array should not contain an empty value')
       first = current[0]
       if not(first == "'" or first == '"'):
         result.append(current.rstrip())
       else:
         start = index
         while True: # Continue until closing quote found
-          assert index < len(values), "unclosed quoted string. expected final character to be '%s' in '%s'" % (first, values[start])
+          if index >= len(values):
+            exit_with_error("unclosed quoted string. expected final character to be '%s' in '%s'" % (first, values[start]))
           new = values[index].rstrip()
-          if not len(new) == 0 and new[-1] == first:
+          if new and new[-1] == first:
             if start == index:
               result.append(current.rstrip()[1:-1])
             else:
@@ -3237,23 +3240,22 @@ def parse_value(text):
         break
     return result
 
-  if text[0] == '[':
+  def parse_string_list(text):
     text = text.rstrip()
-    assert text[-1] == ']', 'unclosed opened string list. expected final character to be "]" in "%s"' % (text)
+    if text[-1] != ']':
+      exit_with_error('unclosed opened string list. expected final character to be "]" in "%s"' % (text))
     inner = text[1:-1]
     if inner.strip() == "":
       return []
-    else:
-      return parse_string_list_members(inner, ",")
-  else:
-    try:
-      return int(text)
-    except ValueError:
-      return parse_string_value(text)
+    return parse_string_list_members(inner)
 
+  if text[0] == '[':
+    return parse_string_list(text)
 
-def check_bad_eq(arg):
-  assert '=' not in arg, 'Invalid parameter (do not use "=" with "--" options)'
+  try:
+    return int(text)
+  except ValueError:
+    return parse_string_value(text)
 
 
 def validate_arg_level(level_string, max_level, err_msg, clamp=False):


### PR DESCRIPTION
- remove else after return
- use enumerate() rather than manual counting
- remove constant sep argument to parse_string_list_members
- move `check_bad_eq` function inside `parse_args`