### PR TITLE
Always call EMAR with PYTHON as arg0

### DIFF
--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -147,9 +147,7 @@ def get(ports, settings, shared):
 
     ports.run_commands(commands)
     final = os.path.join(ports.get_build_dir(), 'regal', libname)
-    shared.try_delete(final)
     ports.create_lib(final, o_s)
-    assert os.path.exists(final)
     return final
 
   return [shared.Cache.get(libname, create, what='port')]

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -38,9 +38,7 @@ def get(ports, settings, shared):
     ports.run_commands(commands)
 
     final = os.path.join(ports.get_build_dir(), 'zlib', 'libz.a')
-    shared.try_delete(final)
-    ports.run_commands([[shared.EMAR, 'rc', final] + o_s])
-    assert os.path.exists(final)
+    ports.create_lib(final, o_s)
     return final
 
   return [shared.Cache.get('libz.a', create, what='port')]


### PR DESCRIPTION
In this case we use the create_lib wrapper to ensure this.

Fixes #8341