### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,py}]
+charset = utf-8
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Add [EditorConfig](https://editorconfig.org/), mainly so that editors know that this project uses 2 space indents for Python instead of the more typical 4.
