### PR TITLE
Add comment about shutil.unpack_archive

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -916,6 +916,11 @@ class Ports(object):
     def unpack():
       logger.warning('unpacking port: ' + name)
       shared.safe_ensure_dirs(fullname)
+
+      # TODO: Someday when we are using Python 3, we might want to change the
+      # code below to use shlib.unpack_archive
+      # e.g.: shutil.unpack_archive(filename=fullpath, extract_dir=fullname)
+      # (https://docs.python.org/3/library/shutil.html#shutil.unpack_archive)
       if is_tarbz2:
         z = tarfile.open(fullpath, 'r:bz2')
       elif url.endswith('.tar.gz'):
@@ -928,6 +933,7 @@ class Ports(object):
         z.extractall()
       finally:
         os.chdir(cwd)
+
       State.unpacked = True
 
     # main logic. do this under a cache lock, since we don't want multiple jobs to


### PR DESCRIPTION
Add comment noting that [`shutil.unpack_archive`](https://docs.python.org/3/library/shutil.html#shutil.unpack_archive) can be used when the project moves to Python 3.