### PR TITLE
Set TARGET_SUPPORTS_SHARED_LIBS in cmake config

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -21,6 +21,7 @@ set(CMAKE_SYSTEM_NAME Emscripten)
 set(CMAKE_SYSTEM_VERSION 1)
 
 set(CMAKE_CROSSCOMPILING TRUE)
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
 
 # Advertise Emscripten as a 32-bit platform (as opposed to CMAKE_SYSTEM_PROCESSOR=x86_64 for 64-bit platform),
 # since some projects (e.g. OpenCV) use this to detect bitness.

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1370,7 +1370,7 @@ def get_zlib_library(runner_core):
   if WINDOWS:
     return runner_core.get_library('zlib', os.path.join('libz.a'),
                                    configure=[path_from_root('emconfigure.bat')],
-                                   configure_args=['cmake', '.', '-DBUILD_SHARED_LIBS=OFF'],
+                                   configure_args=['cmake', '.'],
                                    make=['mingw32-make'],
                                    make_args=[])
   else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5541,7 +5541,7 @@ return malloc(size);
     use_cmake_configure = WINDOWS
     if use_cmake_configure:
       make_args = []
-      configure = [PYTHON, path_from_root('emcmake'), 'cmake', '.', '-DBUILD_SHARED_LIBS=OFF']
+      configure = [PYTHON, path_from_root('emcmake'), 'cmake', '.']
     else:
       make_args = ['libz.a']
       configure = ['sh', './configure']
@@ -5646,7 +5646,7 @@ return malloc(size);
                             os.path.sep.join('codec/CMakeFiles/j2k_to_image.dir/convert.c.o'.split('/')),
                             os.path.sep.join('codec/CMakeFiles/j2k_to_image.dir/__/common/color.c.o'.split('/')),
                             os.path.join('bin', 'libopenjpeg.a')],
-                           configure=['cmake', '.', '-DBUILD_SHARED_LIBS=OFF'],
+                           configure=['cmake', '.'],
                            # configure_args=['--enable-tiff=no', '--enable-jp3d=no', '--enable-png=no'],
                            make_args=[]) # no -j 2, since parallel builds can fail
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -582,11 +582,9 @@ f.close()
       # while still keeping this test in sensible time limit.
       cases = [
         ('target_js',      'test_cmake.js',         ['-DCMAKE_BUILD_TYPE=Debug']),
-        ('target_html',    'hello_world_gles.html', ['-DCMAKE_BUILD_TYPE=Release',        '-DBUILD_SHARED_LIBS=OFF']),
-        ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=MinSizeRel',     '-DBUILD_SHARED_LIBS=OFF']),
+        ('target_html',    'hello_world_gles.html', ['-DCMAKE_BUILD_TYPE=Release']),
+        ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=MinSizeRel']),
         ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DCPP_LIBRARY_TYPE=STATIC']),
-        ('target_library', 'libtest_cmake.so',      ['-DCMAKE_BUILD_TYPE=Release',        '-DBUILD_SHARED_LIBS=ON']),
-        ('target_library', 'libtest_cmake.so',      ['-DCMAKE_BUILD_TYPE=Release',        '-DBUILD_SHARED_LIBS=ON', '-DCPP_LIBRARY_TYPE=SHARED']),
         ('stdproperty',    'helloworld.js',         [])
       ]
       for test_dir, output_file, cmake_args in cases:


### PR DESCRIPTION
This means we don't need to specify -DBUILD_SHARED_LIBS=OFF since
it will effectively be the default.