### PR TITLE
other.test_minimal_runtime_code_size: apply slop to code sizes

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9080,9 +9080,11 @@ int main () {
         print('size of ' + f + ' == ' + str(size) + ', expected ' + str(expected_size) + ', delta=' + str(size - expected_size) + print_percent(size, expected_size))
 
         # Hack: Generated .mem initializer files have different sizes on different platforms (Windows gives x, CircleCI Linux gives x-17 bytes, my home Linux gives x+2 bytes..)
-        # TODO: identify what is causing this (until that, expected .mem initializer file sizes are conservative estimates that do not contribute to total size)
+        # Likewise asm.js files seem to be affected by the LLVM IR text names, which lead to asm.js names, which leads to difference code size, which leads to different
+        # relooper choices, as a result leading to slightly different total code sizes.
+        # TODO: identify what is causing this. in the meanwhile, allow some amount of slop
         mem_slop = 20
-        if f.endswith('.mem') or f.endswith('.wasm') and size <= expected_size + mem_slop and size >= expected_size - mem_slop:
+        if size <= expected_size + mem_slop and size >= expected_size - mem_slop:
           size = expected_size
 
         total_output_size += size

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9079,10 +9079,13 @@ int main () {
         size = os.path.getsize(f)
         print('size of ' + f + ' == ' + str(size) + ', expected ' + str(expected_size) + ', delta=' + str(size - expected_size) + print_percent(size, expected_size))
 
-        # Hack: Generated .mem initializer files have different sizes on different platforms (Windows gives x, CircleCI Linux gives x-17 bytes, my home Linux gives x+2 bytes..)
-        # Likewise asm.js files seem to be affected by the LLVM IR text names, which lead to asm.js names, which leads to difference code size, which leads to different
-        # relooper choices, as a result leading to slightly different total code sizes.
-        # TODO: identify what is causing this. in the meanwhile, allow some amount of slop
+        # Hack: Generated .mem initializer files have different sizes on different
+        # platforms (Windows gives x, CircleCI Linux gives x-17 bytes, my home
+        # Linux gives x+2 bytes..). Likewise asm.js files seem to be affected by
+        # the LLVM IR text names, which lead to asm.js names, which leads to
+        # difference code size, which leads to different relooper choices,
+        # as a result leading to slightly different total code sizes.
+        # TODO: identify what is causing this. meanwhile allow some amount of slop
         mem_slop = 20
         if size <= expected_size + mem_slop and size >= expected_size - mem_slop:
           size = expected_size


### PR DESCRIPTION
As there is a source of nondeterminism in the JS backend  - LLVM IR text names affect asm.js names, which leads to difference code size, which leads to different code sizes. In particular, on the exact same fastcomp+emscripten I get 7 byte larger code sizes locally than the bots do. This appears to have gotten more random since the recent change to LLVM IR debug name changes, but it was probably a problem all along, just became more noticeable.

This appears to be a JS backend issue, so it should not exist with the wasm backend, once we switch over.