### PR TITLE
give a clear error when TOTAL_MEMORY is not big enough

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -755,7 +755,7 @@ class Memory():
     self.dynamic_base = align_memory(self.stack_high)
 
     if self.dynamic_base >= shared.Settings.TOTAL_MEMORY:
-     exit_with_error('Memory is not large enough for static initialization (%d) plus the stack (%d), please increase TOTAL_MEMORY (%d) to at least %d' % (self.static_bump, shared.Settings.TOTAL_STACK, shared.Settings.TOTAL_MEMORY, self.dynamic_base))
+     exit_with_error('Memory is not large enough for static data (%d) plus the stack (%d), please increase TOTAL_MEMORY (%d) to at least %d' % (self.static_bump, shared.Settings.TOTAL_STACK, shared.Settings.TOTAL_MEMORY, self.dynamic_base))
 
 
 def apply_memory(js):

--- a/emscripten.py
+++ b/emscripten.py
@@ -754,6 +754,9 @@ class Memory():
     #  * then dynamic memory begins
     self.dynamic_base = align_memory(self.stack_high)
 
+    if self.dynamic_base >= shared.Settings.TOTAL_MEMORY:
+     exit_with_error('Memory is not large enough for static initialization (%d) plus the stack (%d), please increase TOTAL_MEMORY (%d) to at least %d' % (self.static_bump, shared.Settings.TOTAL_STACK, shared.Settings.TOTAL_MEMORY, self.dynamic_base))
+
 
 def apply_memory(js):
   # Apply the statically-at-compile-time computed memory locations.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8246,28 +8246,17 @@ int main() {
     err = run_process([PYTHON, EMCC, 'hello_world.o', '-o', 'hello_world.js'], stdout=PIPE, stderr=PIPE, check=False).stderr
     self.assertContained('hello_world.o is not a valid input', err)
 
-  # Tests that we should a clear error on TOTAL_MEMORY not being enough for static initialization + stack
+  # Tests that we should give a clear error on TOTAL_MEMORY not being enough for static initialization + stack
   def test_clear_error_on_massive_static_data(self):
     with open('src.cpp', 'w') as f:
       f.write('''
-        #include <stdio.h>
-        double muchData[] = {
-      ''')
-      for i in range(50 * 1000):
-        f.write('1.2, 2.3, 3.4, 4.5, 5.6, 6.7, 7.8, 8.9, 9.9,\n')
-      f.write(r'''
-        };
+        char muchData[128 * 1024];
         int main() {
-          printf("%ld\n", sizeof muchData);
-          int ret = 0;
-          for (int i = 0; i < sizeof muchData; i++) {
-            ret += muchData[i];
-          }
-          return ret & 255;
+          return (int)&muchData;
         }
       ''')
-    err = run_process([PYTHON, EMCC, 'src.cpp', '-s', 'TOTAL_STACK=64KB', '-s', 'TOTAL_MEMORY=512KB'], check=False, stderr=PIPE).stderr
-    self.assertContained('Memory is not large enough for static initialization (3603824) plus the stack (65536), please increase TOTAL_MEMORY (524288)', err)
+    err = run_process([PYTHON, EMCC, 'src.cpp', '-s', 'TOTAL_STACK=1KB', '-s', 'TOTAL_MEMORY=64KB'], check=False, stderr=PIPE).stderr
+    self.assertContained('Memory is not large enough for static data (134032) plus the stack (1024), please increase TOTAL_MEMORY (65536)', err)
 
   def test_o_level_clamp(self):
     for level in [3, 4, 20]:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1979,34 +1979,6 @@ int f() {
     # with it, it should work
     self.do_other_test(os.path.join('other', 'GetProcAddress_LEGACY_GL_EMULATION'), run_args=['1'], emcc_args=['-s', 'LEGACY_GL_EMULATION=1'])
 
-  @no_wasm_backend('linker detects out-of-memory')
-  def test_toobig(self):
-    # very large [N x i8], we should not oom in the compiler
-    create_test_file('main.cpp', r'''
-      #include <stdio.h>
-
-      #define BYTES (50 * 1024 * 1024)
-
-      int main(int argc, char **argv) {
-        if (argc == 100) {
-          static char buf[BYTES];
-          static char buf2[BYTES];
-          for (int i = 0; i < BYTES; i++) {
-            buf[i] = i*i;
-            buf2[i] = i/3;
-          }
-          for (int i = 0; i < BYTES; i++) {
-            buf[i] = buf2[i/2];
-            buf2[i] = buf[i/3];
-          }
-          printf("%d\n", buf[10] + buf2[20]);
-        }
-        return 0;
-      }
-      ''')
-    run_process([PYTHON, EMCC, 'main.cpp'])
-    self.assertExists('a.out.js')
-
   def test_prepost(self):
     create_test_file('main.cpp', '''
       #include <stdio.h>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8228,7 +8228,10 @@ int main() {
         }
       ''')
     err = run_process([PYTHON, EMCC, 'src.cpp', '-s', 'TOTAL_STACK=1KB', '-s', 'TOTAL_MEMORY=64KB'], check=False, stderr=PIPE).stderr
-    self.assertContained('Memory is not large enough for static data (134032) plus the stack (1024), please increase TOTAL_MEMORY (65536)', err)
+    if self.is_wasm_backend():
+      self.assertContained('wasm-ld: error: initial memory too small', err)
+    else:
+      self.assertContained('Memory is not large enough for static data (134032) plus the stack (1024), please increase TOTAL_MEMORY (65536)', err)
 
   def test_o_level_clamp(self):
     for level in [3, 4, 20]:


### PR DESCRIPTION
(for all the static allocation + stack etc.)

Not catching this early leads to late validation errors in asm2wasm.

fixes https://github.com/WebAssembly/binaryen/issues/1968
