### PR TITLE
Pass --disable-shared when configuring bullet

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1390,7 +1390,7 @@ def get_bullet_library(runner_core, use_cmake):
     configure_commands = ['sh', './configure']
     # Force a nondefault --host= so that the configure script will interpret that we are doing cross-compilation
     # and skip attempting to run the generated executable with './a.out', which would fail since we are building a .js file.
-    configure_args = ['--host=i686-pc-linux-gnu', '--disable-demos', '--disable-dependency-tracking']
+    configure_args = ['--disable-shared', '--host=i686-pc-linux-gnu', '--disable-demos', '--disable-dependency-tracking']
     generated_libs = [os.path.join('src', '.libs', 'libBulletDynamics.a'),
                       os.path.join('src', '.libs', 'libBulletCollision.a'),
                       os.path.join('src', '.libs', 'libLinearMath.a')]


### PR DESCRIPTION
Without this we were needlessly building a second copy of bullet with
-fPIC.  This was causing an llvm crash running wasm0.test_the_bullet.

We need to fix upstream llvm, but in the mean time we can fix the test
by simply not build build in the shared library version of bullet.

