### PR TITLE
wasm-backend: Handle namedGlobals in metadaa of wasm-emscripten-finalize

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2439,8 +2439,7 @@ def create_invoke_wrappers(invoke_funcs):
 def treat_as_user_function(name):
   library_functions_in_module = ('setTempRet0', 'getTempRet0', 'stackAlloc',
                                  'stackSave', 'stackRestore',
-                                 'establishStackSpace', '__growWasmMemory',
-                                 '__heap_base', '__data_end')
+                                 'establishStackSpace', '__growWasmMemory')
   if name.startswith('dynCall_'):
     return False
   if name in library_functions_in_module:

--- a/emscripten.py
+++ b/emscripten.py
@@ -2132,7 +2132,6 @@ def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
        'if (!ENVIRONMENT_IS_PTHREAD)' if shared.Settings.USE_PTHREADS else '',
        global_initializers))
 
-
   pre = apply_memory(pre)
   pre = apply_static_code_hooks(pre)
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -2438,7 +2438,8 @@ def create_invoke_wrappers(invoke_funcs):
 def treat_as_user_function(name):
   library_functions_in_module = ('setTempRet0', 'getTempRet0', 'stackAlloc',
                                  'stackSave', 'stackRestore',
-                                 'establishStackSpace', '__growWasmMemory')
+                                 'establishStackSpace', '__growWasmMemory',
+                                 '__heap_base', '__data_end')
   if name.startswith('dynCall_'):
     return False
   if name in library_functions_in_module:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1826,6 +1826,8 @@ class Building(object):
         '--import-table',
         '--export',
         '__wasm_call_ctors',
+        '--export',
+        '__data_end',
         '--lto-O%d' % lto_level,
     ] + args
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1826,8 +1826,6 @@ class Building(object):
         '--import-table',
         '--export',
         '__wasm_call_ctors',
-        '--export',
-        '__data_end',
         '--lto-O%d' % lto_level,
     ] + args
 


### PR DESCRIPTION
This is the way the MAIN_MODULE exports global addresses and one
step towards working dynamic linking.

See the corresponding binaryen change that must land after this one:
https://github.com/WebAssembly/binaryen/pull/1979/
