### PR TITLE
Add --disable-shared to freetype build used in testing

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1025,7 +1025,7 @@ class RunnerCore(unittest.TestCase):
   def get_freetype_library(self):
     self.set_setting('DEAD_FUNCTIONS', self.get_setting('DEAD_FUNCTIONS') + ['_inflateEnd', '_inflate', '_inflateReset', '_inflateInit2_'])
 
-    return self.get_library('freetype', os.path.join('objs', '.libs', 'libfreetype.a'))
+    return self.get_library('freetype', os.path.join('objs', '.libs', 'libfreetype.a'), configure_args=['--disable-shared'])
 
   def get_poppler_library(self):
     # The fontconfig symbols are all missing from the poppler build
@@ -1052,7 +1052,7 @@ class RunnerCore(unittest.TestCase):
         'poppler',
         [os.path.join('utils', 'pdftoppm.o'), os.path.join('utils', 'parseargs.o'), os.path.join('poppler', '.libs', 'libpoppler.a')],
         env_init={'FONTCONFIG_CFLAGS': ' ', 'FONTCONFIG_LIBS': ' '},
-        configure_args=['--disable-libjpeg', '--disable-libpng', '--disable-poppler-qt', '--disable-poppler-qt4', '--disable-cms', '--disable-cairo-output', '--disable-abiword-output', '--enable-shared=no'])
+        configure_args=['--disable-libjpeg', '--disable-libpng', '--disable-poppler-qt', '--disable-poppler-qt4', '--disable-cms', '--disable-cairo-output', '--disable-abiword-output', '--disable-shared'])
 
     return poppler + freetype
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5522,7 +5522,7 @@ return malloc(size);
     assert 'asm2g' in core_test_modes
     if self.run_name == 'asm2g':
       # flip for some more coverage here
-      self.set_setting('ALIASING_FUNCTION_POINTERS', 1)
+      self.set_setting('ALIASING_FUNCTION_POINTERS', 1 - self.get_setting('ALIASING_FUNCTION_POINTERS'))
 
     self.add_pre_run("FS.createDataFile('/', 'font.ttf', %s, true, false, false);" % str(
       list(bytearray(open(path_from_root('tests', 'freetype', 'LiberationSansBold.ttf'), 'rb').read()))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5522,7 +5522,7 @@ return malloc(size);
     assert 'asm2g' in core_test_modes
     if self.run_name == 'asm2g':
       # flip for some more coverage here
-      self.set_setting('ALIASING_FUNCTION_POINTERS', 1 - self.get_setting('ALIASING_FUNCTION_POINTERS'))
+      self.set_setting('ALIASING_FUNCTION_POINTERS', 1)
 
     self.add_pre_run("FS.createDataFile('/', 'font.ttf', %s, true, false, false);" % str(
       list(bytearray(open(path_from_root('tests', 'freetype', 'LiberationSansBold.ttf'), 'rb').read()))

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -86,15 +86,10 @@ sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tools import shared
 
-DEBUG = os.environ.get('EMCC_DEBUG')
-if DEBUG == "0":
-  DEBUG = None
-
 QUIET = (__name__ != '__main__')
 
 def show(msg):
-  global QUIET, DEBUG
-  if DEBUG or not QUIET:
+  if shared.DEBUG or not QUIET:
     sys.stderr.write('gen_struct_info: ' + msg + '\n')
 
 # Try to load pycparser.


### PR DESCRIPTION
This fixes the current crash on the waterfall due to a bug in
`wasm-ld --relocatable`.
