### PR TITLE
Errno fixes

### DIFF
--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -13,7 +13,7 @@ mergeInto(LibraryManager.library, {
     createNode: function(parent, name, mode, dev) {
       if (FS.isBlkdev(mode) || FS.isFIFO(mode)) {
         // no supported
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
       if (!MEMFS.ops_table) {
         MEMFS.ops_table = {
@@ -192,7 +192,7 @@ mergeInto(LibraryManager.library, {
         }
       },
       lookup: function(parent, name) {
-        throw FS.genericErrors[ERRNO_CODES.ENOENT];
+        throw FS.genericErrors[{{{ cDefine('ENOENT') }}}];
       },
       mknod: function(parent, name, mode, dev) {
         return MEMFS.createNode(parent, name, mode, dev);
@@ -207,7 +207,7 @@ mergeInto(LibraryManager.library, {
           }
           if (new_node) {
             for (var i in new_node.contents) {
-              throw new FS.ErrnoError(ERRNO_CODES.ENOTEMPTY);
+              throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
             }
           }
         }
@@ -223,7 +223,7 @@ mergeInto(LibraryManager.library, {
       rmdir: function(parent, name) {
         var node = FS.lookupNode(parent, name);
         for (var i in node.contents) {
-          throw new FS.ErrnoError(ERRNO_CODES.ENOTEMPTY);
+          throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
         }
         delete parent.contents[name];
       },
@@ -244,7 +244,7 @@ mergeInto(LibraryManager.library, {
       },
       readlink: function(node) {
         if (!FS.isLink(node.mode)) {
-          throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
         }
         return node.link;
       },
@@ -332,7 +332,7 @@ mergeInto(LibraryManager.library, {
           }
         }
         if (position < 0) {
-          throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
         }
         return position;
       },
@@ -342,7 +342,7 @@ mergeInto(LibraryManager.library, {
       },
       mmap: function(stream, buffer, offset, length, position, prot, flags) {
         if (!FS.isFile(stream.node.mode)) {
-          throw new FS.ErrnoError(ERRNO_CODES.ENODEV);
+          throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }
         var ptr;
         var allocated;
@@ -366,7 +366,7 @@ mergeInto(LibraryManager.library, {
           allocated = true;
           ptr = _malloc(length);
           if (!ptr) {
-            throw new FS.ErrnoError(ERRNO_CODES.ENOMEM);
+            throw new FS.ErrnoError({{{ cDefine('ENOMEM') }}});
           }
           buffer.set(contents, ptr);
         }
@@ -374,7 +374,7 @@ mergeInto(LibraryManager.library, {
       },
       msync: function(stream, buffer, offset, length, mmapFlags) {
         if (!FS.isFile(stream.node.mode)) {
-          throw new FS.ErrnoError(ERRNO_CODES.ENODEV);
+          throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }
         if (mmapFlags & {{{ cDefine('MAP_PRIVATE') }}}) {
           // MAP_PRIVATE calls need not to be synced back to underlying fs

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 mergeInto(LibraryManager.library, {
-  $NODEFS__deps: ['$FS', '$PATH'],
+  $NODEFS__deps: ['$FS', '$PATH', '$ERRNO_CODES'],
   $NODEFS__postset: 'if (ENVIRONMENT_IS_NODE) { var fs = require("fs"); var NODEJS_PATH = require("path"); NODEFS.staticInit(); }',
   $NODEFS: {
     isWindows: false,
@@ -56,7 +56,7 @@ mergeInto(LibraryManager.library, {
         }
       } catch (e) {
         if (!e.code) throw e;
-        throw new FS.ErrnoError(e.code);
+        throw new FS.ErrnoError(ERRNO_CODES[e.code]);
       }
       return stat.mode;
     },
@@ -99,7 +99,7 @@ mergeInto(LibraryManager.library, {
           stat = fs.lstatSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
         // node.js v0.10.20 doesn't report blksize and blocks on Windows. Fake them with default blksize of 4096.
         // See http://support.microsoft.com/kb/140365
@@ -142,7 +142,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       lookup: function (parent, name) {
@@ -162,7 +162,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
         return node;
       },
@@ -173,7 +173,7 @@ mergeInto(LibraryManager.library, {
           fs.renameSync(oldPath, newPath);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       unlink: function(parent, name) {
@@ -182,7 +182,7 @@ mergeInto(LibraryManager.library, {
           fs.unlinkSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       rmdir: function(parent, name) {
@@ -191,7 +191,7 @@ mergeInto(LibraryManager.library, {
           fs.rmdirSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       readdir: function(node) {
@@ -200,7 +200,7 @@ mergeInto(LibraryManager.library, {
           return fs.readdirSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       symlink: function(parent, newName, oldPath) {
@@ -209,7 +209,7 @@ mergeInto(LibraryManager.library, {
           fs.symlinkSync(oldPath, newPath);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       readlink: function(node) {
@@ -220,7 +220,7 @@ mergeInto(LibraryManager.library, {
           return path;
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
     },
@@ -233,7 +233,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       close: function (stream) {
@@ -243,7 +243,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       read: function (stream, buffer, offset, length, position) {
@@ -252,14 +252,14 @@ mergeInto(LibraryManager.library, {
         try {
           return fs.readSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
         } catch (e) {
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       write: function (stream, buffer, offset, length, position) {
         try {
           return fs.writeSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
         } catch (e) {
-          throw new FS.ErrnoError(e.code);
+          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
         }
       },
       llseek: function (stream, offset, whence) {
@@ -272,7 +272,7 @@ mergeInto(LibraryManager.library, {
               var stat = fs.fstatSync(stream.nfd);
               position += stat.size;
             } catch (e) {
-              throw new FS.ErrnoError(e.code);
+              throw new FS.ErrnoError(ERRNO_CODES[e.code]);
             }
           }
         }

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -38,7 +38,7 @@ mergeInto(LibraryManager.library, {
     },
     createNode: function (parent, name, mode, dev) {
       if (!FS.isDir(mode) && !FS.isFile(mode) && !FS.isLink(mode)) {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
       var node = FS.createNode(parent, name, mode);
       node.node_ops = NODEFS.node_ops;
@@ -56,7 +56,7 @@ mergeInto(LibraryManager.library, {
         }
       } catch (e) {
         if (!e.code) throw e;
-        throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+        throw new FS.ErrnoError(e.code);
       }
       return stat.mode;
     },
@@ -88,7 +88,7 @@ mergeInto(LibraryManager.library, {
       if (!flags) {
         return newFlags;
       } else {
-        throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+        throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
       }
     },
     node_ops: {
@@ -99,7 +99,7 @@ mergeInto(LibraryManager.library, {
           stat = fs.lstatSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
         // node.js v0.10.20 doesn't report blksize and blocks on Windows. Fake them with default blksize of 4096.
         // See http://support.microsoft.com/kb/140365
@@ -142,7 +142,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       lookup: function (parent, name) {
@@ -162,7 +162,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
         return node;
       },
@@ -173,7 +173,7 @@ mergeInto(LibraryManager.library, {
           fs.renameSync(oldPath, newPath);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       unlink: function(parent, name) {
@@ -182,7 +182,7 @@ mergeInto(LibraryManager.library, {
           fs.unlinkSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       rmdir: function(parent, name) {
@@ -191,7 +191,7 @@ mergeInto(LibraryManager.library, {
           fs.rmdirSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       readdir: function(node) {
@@ -200,7 +200,7 @@ mergeInto(LibraryManager.library, {
           return fs.readdirSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       symlink: function(parent, newName, oldPath) {
@@ -209,7 +209,7 @@ mergeInto(LibraryManager.library, {
           fs.symlinkSync(oldPath, newPath);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       readlink: function(node) {
@@ -220,7 +220,7 @@ mergeInto(LibraryManager.library, {
           return path;
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
     },
@@ -233,7 +233,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       close: function (stream) {
@@ -243,7 +243,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       read: function (stream, buffer, offset, length, position) {
@@ -252,14 +252,14 @@ mergeInto(LibraryManager.library, {
         try {
           return fs.readSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
         } catch (e) {
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       write: function (stream, buffer, offset, length, position) {
         try {
           return fs.writeSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
         } catch (e) {
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(e.code);
         }
       },
       llseek: function (stream, offset, whence) {
@@ -272,13 +272,13 @@ mergeInto(LibraryManager.library, {
               var stat = fs.fstatSync(stream.nfd);
               position += stat.size;
             } catch (e) {
-              throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+              throw new FS.ErrnoError(e.code);
             }
           }
         }
 
         if (position < 0) {
-          throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
         }
 
         return position;

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 mergeInto(LibraryManager.library, {
-  $NODEFS__deps: ['$FS', '$PATH', '$ERRNO_CODES'],
+  $NODEFS__deps: ['$FS', '$PATH'],
   $NODEFS__postset: 'if (ENVIRONMENT_IS_NODE) { var fs = require("fs"); var NODEJS_PATH = require("path"); NODEFS.staticInit(); }',
   $NODEFS: {
     isWindows: false,
@@ -56,7 +56,7 @@ mergeInto(LibraryManager.library, {
         }
       } catch (e) {
         if (!e.code) throw e;
-        throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+        throw new FS.ErrnoError(-e.errno); // syscall errnos are negated, node's are not
       }
       return stat.mode;
     },
@@ -99,7 +99,7 @@ mergeInto(LibraryManager.library, {
           stat = fs.lstatSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
         // node.js v0.10.20 doesn't report blksize and blocks on Windows. Fake them with default blksize of 4096.
         // See http://support.microsoft.com/kb/140365
@@ -142,7 +142,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       lookup: function (parent, name) {
@@ -162,7 +162,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
         return node;
       },
@@ -173,7 +173,7 @@ mergeInto(LibraryManager.library, {
           fs.renameSync(oldPath, newPath);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       unlink: function(parent, name) {
@@ -182,7 +182,7 @@ mergeInto(LibraryManager.library, {
           fs.unlinkSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       rmdir: function(parent, name) {
@@ -191,7 +191,7 @@ mergeInto(LibraryManager.library, {
           fs.rmdirSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       readdir: function(node) {
@@ -200,7 +200,7 @@ mergeInto(LibraryManager.library, {
           return fs.readdirSync(path);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       symlink: function(parent, newName, oldPath) {
@@ -209,7 +209,7 @@ mergeInto(LibraryManager.library, {
           fs.symlinkSync(oldPath, newPath);
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       readlink: function(node) {
@@ -220,7 +220,7 @@ mergeInto(LibraryManager.library, {
           return path;
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
     },
@@ -233,7 +233,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       close: function (stream) {
@@ -243,7 +243,7 @@ mergeInto(LibraryManager.library, {
           }
         } catch (e) {
           if (!e.code) throw e;
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       read: function (stream, buffer, offset, length, position) {
@@ -252,14 +252,14 @@ mergeInto(LibraryManager.library, {
         try {
           return fs.readSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
         } catch (e) {
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       write: function (stream, buffer, offset, length, position) {
         try {
           return fs.writeSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
         } catch (e) {
-          throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+          throw new FS.ErrnoError(-e.errno);
         }
       },
       llseek: function (stream, offset, whence) {
@@ -272,7 +272,7 @@ mergeInto(LibraryManager.library, {
               var stat = fs.fstatSync(stream.nfd);
               position += stat.size;
             } catch (e) {
-              throw new FS.ErrnoError(ERRNO_CODES[e.code]);
+              throw new FS.ErrnoError(-e.errno);
             }
           }
         }

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -42,7 +42,7 @@ mergeInto(LibraryManager.library, {
       open: function(stream) {
         var tty = TTY.ttys[stream.node.rdev];
         if (!tty) {
-          throw new FS.ErrnoError(ERRNO_CODES.ENODEV);
+          throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }
         stream.tty = tty;
         stream.seekable = false;
@@ -56,7 +56,7 @@ mergeInto(LibraryManager.library, {
       },
       read: function(stream, buffer, offset, length, pos /* ignored */) {
         if (!stream.tty || !stream.tty.ops.get_char) {
-          throw new FS.ErrnoError(ERRNO_CODES.ENXIO);
+          throw new FS.ErrnoError({{{ cDefine('ENXIO') }}});
         }
         var bytesRead = 0;
         for (var i = 0; i < length; i++) {
@@ -64,10 +64,10 @@ mergeInto(LibraryManager.library, {
           try {
             result = stream.tty.ops.get_char(stream.tty);
           } catch (e) {
-            throw new FS.ErrnoError(ERRNO_CODES.EIO);
+            throw new FS.ErrnoError({{{ cDefine('EIO') }}});
           }
           if (result === undefined && bytesRead === 0) {
-            throw new FS.ErrnoError(ERRNO_CODES.EAGAIN);
+            throw new FS.ErrnoError({{{ cDefine('EAGAIN') }}});
           }
           if (result === null || result === undefined) break;
           bytesRead++;
@@ -80,14 +80,14 @@ mergeInto(LibraryManager.library, {
       },
       write: function(stream, buffer, offset, length, pos) {
         if (!stream.tty || !stream.tty.ops.put_char) {
-          throw new FS.ErrnoError(ERRNO_CODES.ENXIO);
+          throw new FS.ErrnoError({{{ cDefine('ENXIO') }}});
         }
         try {
           for (var i = 0; i < length; i++) {
             stream.tty.ops.put_char(stream.tty, buffer[offset+i]);
           }
         } catch (e) {
-          throw new FS.ErrnoError(ERRNO_CODES.EIO);
+          throw new FS.ErrnoError({{{ cDefine('EIO') }}});
         }
         if (length) {
           stream.node.timestamp = Date.now();

--- a/src/library_workerfs.js
+++ b/src/library_workerfs.js
@@ -99,19 +99,19 @@ mergeInto(LibraryManager.library, {
         }
       },
       lookup: function(parent, name) {
-        throw new FS.ErrnoError(ERRNO_CODES.ENOENT);
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
       },
       mknod: function (parent, name, mode, dev) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       },
       rename: function (oldNode, newDir, newName) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       },
       unlink: function(parent, name) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       },
       rmdir: function(parent, name) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       },
       readdir: function(node) {
         var entries = ['.', '..'];
@@ -124,10 +124,10 @@ mergeInto(LibraryManager.library, {
         return entries;
       },
       symlink: function(parent, newName, oldPath) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       },
       readlink: function(node) {
-        throw new FS.ErrnoError(ERRNO_CODES.EPERM);
+        throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       },
     },
     stream_ops: {
@@ -139,7 +139,7 @@ mergeInto(LibraryManager.library, {
         return chunk.size;
       },
       write: function (stream, buffer, offset, length, position) {
-        throw new FS.ErrnoError(ERRNO_CODES.EIO);
+        throw new FS.ErrnoError({{{ cDefine('EIO') }}});
       },
       llseek: function (stream, offset, whence) {
         var position = offset;
@@ -151,7 +151,7 @@ mergeInto(LibraryManager.library, {
           }
         }
         if (position < 0) {
-          throw new FS.ErrnoError(ERRNO_CODES.EINVAL);
+          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
         }
         return position;
       },


### PR DESCRIPTION
 * Use cDefine at compile time where possible, to avoid using `ERRNO_CODES` which closure errors on not being present (happens in later PRs; will be tested there).
 * Translate node errnos and our syscall errnos directly (just need to be negated).