### PR TITLE
Add BINARYEN_FEATURES, and use that to pass clang feature flags to binaryen

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2493,10 +2493,6 @@ def parse_args(newargs):
       else:
         shared.generate_config(optarg)
       should_exit = True
-    elif newargs[i] == '-mbleeding-edge':
-      shared.Settings.BINARYEN_FEATURES += ['--all-features']
-    elif newargs[i] == '-mnontrapping-fptoint':
-      shared.Settings.BINARYEN_FEATURES += ['--enable-nontrapping-float-to-int']
 
   if should_exit:
     sys.exit(0)

--- a/emcc.py
+++ b/emcc.py
@@ -2493,6 +2493,10 @@ def parse_args(newargs):
       else:
         shared.generate_config(optarg)
       should_exit = True
+    elif newargs[i] == '-mbleeding-edge':
+      shared.Settings.BINARYEN_FEATURES += ['--all-features']
+    elif newargs[i] == '-mnontrapping-fptoint':
+      shared.Settings.BINARYEN_FEATURES += ['--enable-nontrapping-float-to-int']
 
   if should_exit:
     sys.exit(0)
@@ -2686,7 +2690,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       cmd += ['--output-source-map-url=' + options.source_map_base + os.path.basename(wasm_binary_target) + '.map']
       if DEBUG:
         shared.safe_copy(wasm_source_map_target, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(wasm_source_map_target) + '.pre-byn'))
-    logger.debug('wasm-opt on BINARYEN_PASSES: %s', shared.Settings.BINARYEN_PASSES)
+    logger.debug('wasm-opt on BINARYEN_PASSES: %s', cmd)
     shared.print_compiler_stage(cmd)
     shared.check_call(cmd)
   if shared.Settings.BINARYEN_SCRIPTS:

--- a/emscripten.py
+++ b/emscripten.py
@@ -2205,6 +2205,9 @@ def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
 
   cmd = [wasm_emscripten_finalize, base_wasm, '-o', wasm,
          '--global-base=%s' % shared.Settings.GLOBAL_BASE]
+  # tell binaryen to look at the features section, and if there isn't one, to use MVP
+  # (which matches what llvm+lld has given us)
+  cmd += ['--detect-features']
   if shared.Settings.DEBUG_LEVEL >= 2 or shared.Settings.PROFILING_FUNCS:
     cmd.append('-g')
   if shared.Settings.LEGALIZE_JS_FFI != 1:

--- a/emscripten.py
+++ b/emscripten.py
@@ -2394,6 +2394,7 @@ def load_metadata_wasm(metadata_raw, DEBUG):
     'emJsFuncs': {},
     'asmConsts': {},
     'invokeFuncs': [],
+    'features': [],
   }
 
   assert 'tableSize' in metadata_json.keys()

--- a/emscripten.py
+++ b/emscripten.py
@@ -686,6 +686,7 @@ def update_settings_glue(metadata):
 
   if shared.Settings.WASM_BACKEND:
     shared.Settings.WASM_TABLE_SIZE = metadata['tableSize']
+    shared.Settings.BINARYEN_FEATURES = metadata['features']
 
 
 # static code hooks

--- a/src/settings.js
+++ b/src/settings.js
@@ -1025,6 +1025,10 @@ var BINARYEN_TRAP_MODE = "allow";
 // passes we would normally run.
 var BINARYEN_PASSES = "";
 
+// A list of flags to pass to each binaryen invocation (like wasm-opt, etc.),
+// which can contain things like features.
+var BINARYEN_FEATURES = [];
+
 // Set the maximum size of memory in the wasm module (in bytes).  Without this,
 // TOTAL_MEMORY is used (as it is used for the initial value), or if memory
 // growth is enabled, the default value here (-1) is to have no limit, but you

--- a/src/settings.js
+++ b/src/settings.js
@@ -1025,10 +1025,6 @@ var BINARYEN_TRAP_MODE = "allow";
 // passes we would normally run.
 var BINARYEN_PASSES = "";
 
-// A list of flags to pass to each binaryen invocation (like wasm-opt, etc.),
-// which can contain things like features.
-var BINARYEN_FEATURES = [];
-
 // Set the maximum size of memory in the wasm module (in bytes).  Without this,
 // TOTAL_MEMORY is used (as it is used for the initial value), or if memory
 // growth is enabled, the default value here (-1) is to have no limit, but you
@@ -1392,6 +1388,10 @@ var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 0;
 // is retained. Minification requires at least -O1 or -Os to be used. Pass -s MINIFY_HTML=0
 // to explicitly choose to disable HTML minification altogether.
 var MINIFY_HTML = 1;
+
+// A list of feature flags to pass to each binaryen invocation (like wasm-opt, etc.). This
+// is received from wasm-emscripten-finalize, which reads it from the features section.
+var BINARYEN_FEATURES = [];
 
 // Legacy settings that have been removed, and the values they are now fixed to.
 // These can no longer be changed:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5262,9 +5262,14 @@ int main(void) {
     self.do_run(src, output, ['3', '16'])
 
   def test_fasta(self):
-      results = [(1, '''GG*ctt**tgagc*'''),
-                 (20, '''GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTT*cttBtatcatatgctaKggNcataaaSatgtaaaDcDRtBggDtctttataattcBgtcg**tacgtgtagcctagtgtttgtgttgcgttatagtctatttgtggacacagtatggtcaaa**tgacgtcttttgatctgacggcgttaacaaagatactctg*'''),
-                 (50, '''GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGA*TCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACAT*cttBtatcatatgctaKggNcataaaSatgtaaaDcDRtBggDtctttataattcBgtcg**tactDtDagcctatttSVHtHttKtgtHMaSattgWaHKHttttagacatWatgtRgaaa**NtactMcSMtYtcMgRtacttctWBacgaa**agatactctgggcaacacacatacttctctcatgttgtttcttcggacctttcataacct**ttcctggcacatggttagctgcacatcacaggattgtaagggtctagtggttcagtgagc**ggaatatcattcgtcggtggtgttaatctatctcggtgtagcttataaatgcatccgtaa**gaatattatgtttatttgtcggtacgttcatggtagtggtgtcgccgatttagacgtaaa**ggcatgtatg*''')]
+    results = [(1, '''GG*ctt**tgagc*'''),
+               (20, '''GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTT*cttBtatcatatgctaKggNcataaaSatgtaaaDcDRtBggDtctttataattcBgtcg**tacgtgtagcctagtgtttgtgttgcgttatagtctatttgtggacacagtatggtcaaa**tgacgtcttttgatctgacggcgttaacaaagatactctg*'''),
+               (50, '''GGCCGGGCGCGGTGGCTCACGCCTGTAATCCCAGCACTTTGGGAGGCCGAGGCGGGCGGA*TCACCTGAGGTCAGGAGTTCGAGACCAGCCTGGCCAACAT*cttBtatcatatgctaKggNcataaaSatgtaaaDcDRtBggDtctttataattcBgtcg**tactDtDagcctatttSVHtHttKtgtHMaSattgWaHKHttttagacatWatgtRgaaa**NtactMcSMtYtcMgRtacttctWBacgaa**agatactctgggcaacacacatacttctctcatgttgtttcttcggacctttcataacct**ttcctggcacatggttagctgcacatcacaggattgtaagggtctagtggttcagtgagc**ggaatatcattcgtcggtggtgttaatctatctcggtgtagcttataaatgcatccgtaa**gaatattatgtttatttgtcggtacgttcatggtagtggtgtcgccgatttagacgtaaa**ggcatgtatg*''')]
+
+    old = self.emcc_args
+
+    def test(extra_args):
+      self.emcc_args = old + extra_args
       for precision in [0, 1, 2]:
         self.set_setting('PRECISE_F32', precision)
         for t in ['float', 'double']:
@@ -5273,6 +5278,12 @@ int main(void) {
           for i, j in results:
             self.do_run(src, j, [str(i)], lambda x, err: x.replace('\n', '*'), no_build=i > 1)
           shutil.copyfile('src.cpp.o.js', '%d_%s.js' % (precision, t))
+
+    test([])
+
+    # TODO: enable when we have bleeding edge node on the bots
+    # if self.is_wasm_backend():
+    #   test(['-mnontrapping-fptoint'])
 
   def test_whets(self):
     self.do_run(open(path_from_root('tests', 'whets.cpp')).read(), 'Single Precision C Whetstone Benchmark')

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -6,7 +6,7 @@
 import os
 import logging
 
-TAG = 'version_75'
+TAG = 'version_77'
 
 
 def needed(settings, shared, ports):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2688,6 +2688,7 @@ class Building(object):
       ret += ['--enable-threads']
     if Settings.SIMD:
       ret += ['--enable-simd']
+    ret += Settings.BINARYEN_FEATURES
     return ret
 
   @staticmethod


### PR DESCRIPTION
This allows using nontrapping float to int, which makes e.g. fasta 10% faster or so.