### PR TITLE
Separate STRICT from MINIMAL_RUNTIME

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1334,9 +1334,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # Remove the default exported functions 'memcpy', 'memset', 'malloc', 'free', etc. - those should only be linked in if used
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
 
-      # Always build with STRICT mode enabled
-      shared.Settings.STRICT = 1
-
       # Always use the new HTML5 API event target lookup rules
       shared.Settings.DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1
 

--- a/src/modules.js
+++ b/src/modules.js
@@ -82,7 +82,7 @@ var LibraryManager = {
       ]);
 
       // Additional filesystem libraries (in strict mode, link to these explicitly via -lxxx.js)
-      if (!STRICT) {
+      if (!STRICT && !MINIMAL_RUNTIME) {
         libraries = libraries.concat([
           'library_lz4.js',
         ]);
@@ -106,26 +106,21 @@ var LibraryManager = {
     }
 
     // Additional JS libraries (in strict mode, link to these explicitly via -lxxx.js)
-    if (!STRICT) {
+    if (!STRICT && !MINIMAL_RUNTIME) {
       libraries = libraries.concat([
         'library_webgl.js',
         'library_openal.js',
-        'library_vr.js'
+        'library_vr.js',
+        'library_sdl.js',
+        'library_glut.js',
+        'library_xlib.js',
+        'library_egl.js',
+        'library_glfw.js',
+        'library_uuid.js',
+        'library_glew.js',
+        'library_idbstore.js',
+        'library_async.js'
       ]);
-
-      if (!MINIMAL_RUNTIME) {
-        libraries = libraries.concat([
-          'library_sdl.js',
-          'library_glut.js',
-          'library_xlib.js',
-          'library_egl.js',
-          'library_glfw.js',
-          'library_uuid.js',
-          'library_glew.js',
-          'library_idbstore.js',
-          'library_async.js'
-        ]);
-      }
     }
 
     // If there are any explicitly specified system JS libraries to link to, add those to link.


### PR DESCRIPTION
This allows us to add more incompatibility checking to the STRICT
option without forcing it on all users or MINIMAL_RUNTIME.

This is part of #8317.
    
In particular we already already error on the use legacy settings
when in STRICT mode, but I understand that at least on major user (@juj)
wants to be able to continue to use legacy command line settings and
also wants to use MINIMAL_RUNTIME.
