### PR TITLE
Tiny benchmark improvements

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -45,6 +45,8 @@ OPTIMIZATIONS = '-O3'
 
 PROFILING = 0
 
+LLVM_FEATURE_FLAGS = ['-mnontrapping-fptoint']
+
 
 class Benchmarker(object):
   def __init__(self, name):
@@ -185,7 +187,7 @@ class EmscriptenBenchmarker(Benchmarker):
       '-s', 'MINIMAL_RUNTIME=0',
       '-s', 'BENCHMARK=%d' % (1 if IGNORE_COMPILATION and not has_output_parser else 0),
       '-o', final
-    ] + shared_args + emcc_args + self.extra_args
+    ] + shared_args + emcc_args + LLVM_FEATURE_FLAGS + self.extra_args
     if 'FORCE_FILESYSTEM=1' in cmd:
       cmd = [arg if arg != 'FILESYSTEM=0' else 'FILESYSTEM=1' for arg in cmd]
     if PROFILING:
@@ -317,7 +319,7 @@ if SPIDERMONKEY_ENGINE and SPIDERMONKEY_ENGINE in shared.JS_ENGINES:
   ]
 if V8_ENGINE and V8_ENGINE in shared.JS_ENGINES:
   benchmarkers += [
-    EmscriptenBenchmarker('v8', V8_ENGINE),
+    EmscriptenBenchmarker(os.environ.get('EMBENCH_NAME') or 'v8', V8_ENGINE),
   ]
 if os.path.exists(CHEERP_BIN):
   benchmarkers += [

--- a/tools/jsrun.py
+++ b/tools/jsrun.py
@@ -43,7 +43,7 @@ def make_command(filename, engine=None, args=[]):
   # label a path to nodejs containing a 'd8' as spidermonkey instead.
   jsengine = os.path.basename(engine[0])
   # Use "'d8' in" because the name can vary, e.g. d8_g, d8, etc.
-  is_d8 = 'd8' in jsengine
+  is_d8 = 'd8' in jsengine or 'v8' in jsengine
   is_jsc = 'jsc' in jsengine
   # Disable true async compilation (async apis will in fact be synchronous) for now
   # due to https://bugs.chromium.org/p/v8/issues/detail?id=6263


### PR DESCRIPTION
 * Use `nontrapping-fptoint` by default.
 * Recognize `v8` (which is how jsvu names it, unlike when building v8 when it arrives as `d8`).
 * Add an `EMBENCH_NAME` env var in the benchmark runner, which is useful when running a single VM in each invocation of the benchmark suite.