### PR TITLE
Work around a current issue with bulk memory

### DIFF
--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -30,7 +30,7 @@ total_stack = int(sys.argv[4])
 global_base = int(sys.argv[5])
 binaryen_bin = sys.argv[6]
 debug_info = int(sys.argv[7])
-extra_args = args.argv[8:]
+extra_args = sys.argv[8:]
 
 wasm = not not binaryen_bin
 

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -30,6 +30,7 @@ total_stack = int(sys.argv[4])
 global_base = int(sys.argv[5])
 binaryen_bin = sys.argv[6]
 debug_info = int(sys.argv[7])
+extra_args = args.argv[8:]
 
 wasm = not not binaryen_bin
 
@@ -308,8 +309,7 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
 def eval_ctors_wasm(js, wasm_file, num):
   ctors_start, ctors_end, all_ctors, ctors = find_ctors_data(js, num)
   cmd = [os.path.join(binaryen_bin, 'wasm-ctor-eval'), wasm_file, '-o', wasm_file, '--ctors=' + ','.join(ctors)]
-  # XXX FIXME tlively
-  cmd += ['--disable-bulk-memory']
+  cmd += extra_args
   if debug_info:
     cmd += ['-g']
   logging.debug('wasm ctor cmd: ' + str(cmd))

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -308,6 +308,8 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
 def eval_ctors_wasm(js, wasm_file, num):
   ctors_start, ctors_end, all_ctors, ctors = find_ctors_data(js, num)
   cmd = [os.path.join(binaryen_bin, 'wasm-ctor-eval'), wasm_file, '-o', wasm_file, '--ctors=' + ','.join(ctors)]
+  # XXX FIXME tlively
+  cmd += ['--disable-bulk-memory']
   if debug_info:
     cmd += ['-g']
   logging.debug('wasm ctor cmd: ' + str(cmd))

--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -6,7 +6,7 @@
 import os
 import logging
 
-TAG = 'version_77'
+TAG = 'version_78'
 
 
 def needed(settings, shared, ports):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2298,7 +2298,10 @@ class Building(object):
   # evals ctors. if binaryen_bin is provided, it is the dir of the binaryen tool for this, and we are in wasm mode
   @staticmethod
   def eval_ctors(js_file, binary_file, binaryen_bin='', debug_info=False):
-    check_call([PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, binary_file, str(Settings.TOTAL_MEMORY), str(Settings.TOTAL_STACK), str(Settings.GLOBAL_BASE), binaryen_bin, str(int(debug_info))])
+    cmd = [PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, binary_file, str(Settings.TOTAL_MEMORY), str(Settings.TOTAL_STACK), str(Settings.GLOBAL_BASE), binaryen_bin, str(int(debug_info))]
+    if binaryen_bin:
+      cmd += Building.get_binaryen_feature_flags()
+    check_call(cmd)
 
   @staticmethod
   def eliminate_duplicate_funcs(filename):


### PR DESCRIPTION
Similar to the emscripten test suite, we need to pass this flag for now, so that we optimize memory segments properly. Without this, `other.test_binaryen_metadce_hello` fails because the `-Oz` version (which evals ctors) ends up with output that is much larger than it should be, due to lots of zeros ([e.g.](https://logs.chromium.org/logs/wasm/buildbucket/cr-buildbucket.appspot.com/8916648264990168256/+/steps/Execute_emscripten_testsuite__emwasm_/0/stdout)).

This should get the linux bot green.