### PR TITLE
emar: Only use minimal name mangling

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -11,7 +11,6 @@ This is needed because, unlike a traditional linker, emscripten can't handle
 archive with duplicate member names.  This is because emscripten extracts
 archive to a temporary location and duplicate filenames will clobber each
 other in this case.
-
 """
 
 # TODO(sbc): Implement `ar x` within emscripten, in python, to avoid this issue
@@ -49,30 +48,42 @@ def run():
       # normally the output file is then arg 2, except in the case were the
       # a or b modifiers are used in which case its arg 3.
       if 'a' in cmd or 'b' in cmd:
-        new_member_args_start = 4
+        out_arg_index = 3
       else:
-        new_member_args_start = 3
+        out_arg_index = 2
+
+      contents = set()
+      if os.path.exists(newargs[out_arg_index]):
+        cmd = [shared.LLVM_AR, 't', newargs[out_arg_index]]
+        output = shared.check_call(cmd, stdout=shared.PIPE).stdout
+        contents.update(output.split('\n'))
 
       # we add a hash to each input, to make them unique as
       # possible, as llvm-ar cannot extract duplicate names
       # (and only the basename is used!)
-      for j in range(new_member_args_start, len(newargs)):
+      for j in range(out_arg_index + 1, len(newargs)):
         orig_name = newargs[j]
         full_name = os.path.abspath(orig_name)
-        dir_name = os.path.dirname(full_name)
-        base_name = os.path.basename(full_name)
+        dirname = os.path.dirname(full_name)
+        basename = os.path.basename(full_name)
+        if basename not in contents:
+          contents.add(basename)
+          continue
         h = hashlib.md5(full_name.encode('utf-8')).hexdigest()[:8]
-        parts = base_name.split('.')
+        parts = basename.split('.')
         parts[0] += '_' + h
         newname = '.'.join(parts)
-        full_newname = os.path.join(dir_name, newname)
-        if not os.path.exists(full_newname):
-          try: # it is ok to fail here, we just don't get hashing
-            shutil.copyfile(orig_name, full_newname)
-            newargs[j] = full_newname
-            to_delete.append(full_newname)
-          except:
-            pass
+        full_newname = os.path.join(dirname, newname)
+        assert not os.path.exists(full_newname)
+        try:
+          shutil.copyfile(orig_name, full_newname)
+          newargs[j] = full_newname
+          to_delete.append(full_newname)
+          contents.add(newname)
+        except:
+          # it is ok to fail here, we just don't get hashing
+          contents.add(basename)
+          pass
 
     if shared.DEBUG:
       print('emar:', sys.argv, '  ==>  ', newargs, file=sys.stderr)

--- a/emar.py
+++ b/emar.py
@@ -39,13 +39,13 @@ def run():
 
   to_delete = []
 
-  # The 3 argment form of ar doesn't involve other files. For example
+  # The 3 argmuent form of ar doesn't involve other files. For example
   # 'ar x libfoo.a'.
   if len(newargs) > 3:
     cmd = newargs[1]
     if 'r' in cmd:
-      # we are adding files to the archive.
-      # normally the output file is then arg 2, except in the case were the
+      # We are adding files to the archive.
+      # Normally the output file is then arg 2, except in the case were the
       # a or b modifiers are used in which case its arg 3.
       if 'a' in cmd or 'b' in cmd:
         out_arg_index = 3
@@ -58,9 +58,7 @@ def run():
         output = shared.check_call(cmd, stdout=shared.PIPE).stdout
         contents.update(output.split('\n'))
 
-      # we add a hash to each input, to make them unique as
-      # possible, as llvm-ar cannot extract duplicate names
-      # (and only the basename is used!)
+      # Add a hash to colliding basename, to make them unique.
       for j in range(out_arg_index + 1, len(newargs)):
         orig_name = newargs[j]
         full_name = os.path.abspath(orig_name)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1573,10 +1573,11 @@ int f() {
 
     # Verify that archive contains basenames with hashes to avoid duplication
     text = run_process([PYTHON, EMAR, 't', 'liba.a'], stdout=PIPE).stdout
-    self.assertNotIn('common.o', text)
-    assert text.count('common_') == 2, text
+    self.assertEqual(text.count('common.o'), 1)
+    self.assertContained('common_', text)
     for line in text.split('\n'):
-      assert len(line) < 20, line # should not have huge hash names
+      # should not have huge hash names
+      self.assertLess(len(line), 20, line)
 
     create_test_file('main.c', r'''
       void a(void);


### PR DESCRIPTION
Previously we were mangling every single filename just in case
it collided with another.  Now we only mangle names that would
collide with existing names.

This cost of this is that we need to read the archive contents
on startup when that archive we are adding to already exists.
However we should actually expect a performance increase here since
only files that collide will need to be copied.

Another motivating factor for this change is that it makes linker errors more
sensible since the filenames in the archives will match those on disk.

