### PR TITLE
Apply --whole-archive to groups of libraries, not just individual ones. NFC

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -770,11 +770,17 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   # Wrap libraries in --whole-archive, as needed.  We need to do this last
   # since otherwise the abort sorting won't make sense.
   ret = []
+  in_group = False
   for name, need_whole_archive in libs_to_link:
-    if need_whole_archive:
-      ret += ['--whole-archive', name, '--no-whole-archive']
-    else:
-      ret.append(name)
+    if need_whole_archive and not in_group:
+      ret.append('--whole-archive')
+      in_group = True
+    if in_group and not need_whole_archive:
+      ret.append('--no-whole-archive')
+      in_group = False
+    ret.append(name)
+  if in_group:
+    ret.append('--no-whole-archive')
 
   return ret
 


### PR DESCRIPTION
This is reduces the number redundant argument on the linker command line.  Mostly useful for EMCC_FORCE_STDLIBS=1 where all libraries are forced.