### PR TITLE
Another NODEFS symlink test part which we should disable on MacOS

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4928,8 +4928,9 @@ name: .
     src = open(path_from_root('tests', 'unistd', 'unlink.c')).read()
     for fs in ['MEMFS', 'NODEFS']:
       Building.COMPILER_TEST_OPTS = orig_compiler_opts + ['-D' + fs]
-      # symlinks on node.js on Windows require administrative privileges, so skip testing those bits on that combination.
-      if WINDOWS and fs == 'NODEFS':
+      # symlinks on node.js on non-linux behave differently (e.g. on Windows they require administrative privileges)
+      # so skip testing those bits on that combination.
+      if fs == 'NODEFS' and (WINDOWS or MACOS):
         Building.COMPILER_TEST_OPTS += ['-DNO_SYMLINK=1']
       self.do_run(src, 'success', force_c=True, js_engines=[NODE_JS])
     # Several differences/bugs on non-linux including https://github.com/nodejs/node/issues/18014


### PR DESCRIPTION
Hopefully with this that bot will be finally green.