### PR TITLE
Fix test_dlfcn_self

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2743,7 +2743,8 @@ The current type of b is: 9
   @no_wasm('needs to be able to add JS functions to the wasm table')
   @needs_dlfcn
   def test_dlfcn_self(self):
-    self.prep_dlfcn_main()
+    self.set_setting('MAIN_MODULE')
+    self.set_setting('EXPORT_ALL')
 
     def post(filename):
       with open(filename) as f:


### PR DESCRIPTION
This test has been broken for a long time now but was not running
due to a bug in the use of decorators which was recently fixed in #8424
so this test started failing.
