### PR TITLE
ports: SDL2: fix mutexes

### DIFF
--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -33,9 +33,16 @@ def get(ports, settings, shared):
     # build
     srcs = 'SDL.c SDL_assert.c SDL_dataqueue.c SDL_error.c SDL_hints.c SDL_log.c atomic/SDL_atomic.c atomic/SDL_spinlock.c audio/SDL_audio.c audio/SDL_audiocvt.c audio/SDL_audiodev.c audio/SDL_audiotypecvt.c audio/SDL_mixer.c audio/SDL_wave.c cpuinfo/SDL_cpuinfo.c dynapi/SDL_dynapi.c events/SDL_clipboardevents.c events/SDL_dropevents.c events/SDL_events.c events/SDL_gesture.c events/SDL_keyboard.c events/SDL_mouse.c events/SDL_quit.c events/SDL_touch.c events/SDL_windowevents.c file/SDL_rwops.c haptic/SDL_haptic.c joystick/SDL_gamecontroller.c joystick/SDL_joystick.c libm/e_atan2.c libm/e_log.c libm/e_pow.c libm/e_rem_pio2.c libm/e_sqrt.c libm/k_cos.c libm/k_rem_pio2.c libm/k_sin.c libm/k_tan.c libm/s_atan.c libm/s_copysign.c libm/s_cos.c libm/s_fabs.c libm/s_floor.c libm/s_scalbn.c libm/s_sin.c libm/s_tan.c power/SDL_power.c render/SDL_d3dmath.c render/SDL_render.c render/SDL_yuv_mmx.c render/SDL_yuv_sw.c render/direct3d/SDL_render_d3d.c render/direct3d11/SDL_render_d3d11.c render/opengl/SDL_render_gl.c render/opengl/SDL_shaders_gl.c render/opengles/SDL_render_gles.c render/opengles2/SDL_render_gles2.c render/opengles2/SDL_shaders_gles2.c render/psp/SDL_render_psp.c render/software/SDL_blendfillrect.c render/software/SDL_blendline.c render/software/SDL_blendpoint.c render/software/SDL_drawline.c render/software/SDL_drawpoint.c render/software/SDL_render_sw.c render/software/SDL_rotate.c stdlib/SDL_getenv.c stdlib/SDL_iconv.c stdlib/SDL_malloc.c stdlib/SDL_qsort.c stdlib/SDL_stdlib.c stdlib/SDL_string.c thread/SDL_thread.c timer/SDL_timer.c video/SDL_RLEaccel.c video/SDL_blit.c video/SDL_blit_0.c video/SDL_blit_1.c video/SDL_blit_A.c video/SDL_blit_N.c video/SDL_blit_auto.c video/SDL_blit_copy.c video/SDL_blit_slow.c video/SDL_bmp.c video/SDL_clipboard.c video/SDL_egl.c video/SDL_fillrect.c video/SDL_pixels.c video/SDL_rect.c video/SDL_shape.c video/SDL_stretch.c video/SDL_surface.c video/SDL_video.c video/emscripten/SDL_emscriptenevents.c video/emscripten/SDL_emscriptenframebuffer.c video/emscripten/SDL_emscriptenmouse.c video/emscripten/SDL_emscriptenopengles.c video/emscripten/SDL_emscriptenvideo.c audio/emscripten/SDL_emscriptenaudio.c video/dummy/SDL_nullevents.c video/dummy/SDL_nullframebuffer.c video/dummy/SDL_nullvideo.c audio/disk/SDL_diskaudio.c audio/dummy/SDL_dummyaudio.c loadso/dlopen/SDL_sysloadso.c power/emscripten/SDL_syspower.c joystick/emscripten/SDL_sysjoystick.c filesystem/emscripten/SDL_sysfilesystem.c timer/unix/SDL_systimer.c haptic/dummy/SDL_syshaptic.c main/dummy/SDL_dummy_main.c'.split()
 
-    thread_srcs = ['SDL_syscond.c', 'SDL_sysmutex.c', 'SDL_syssem.c', 'SDL_systhread.c', 'SDL_systls.c']
+    thread_srcs = [
+        '{backend}/SDL_syscond.c',
+        'generic/SDL_sysmutex.c',
+        '{backend}/SDL_syssem.c',
+        '{backend}/SDL_systhread.c',
+        '{backend}/SDL_systls.c'
+    ]
+
     thread_backend = 'generic' if not settings.USE_PTHREADS else 'pthread'
-    srcs += ['thread/%s/%s' % (thread_backend, s) for s in thread_srcs]
+    srcs += ['thread/%s' % s.format(backend=thread_backend) for s in thread_srcs]
 
     commands = []
     o_s = []


### PR DESCRIPTION
The pthread backend implementation of mutexes in SDL2 is broken, and
deadlocks with Emscripten.

Fortunately, SDL2 also has a "generic" implementation of mutexes built
on top of semaphores, and this works as expected. This commit switches
to building the port with the generic semaphore backend.
