### PR TITLE
Remove some closure compiler hacks

### DIFF
--- a/src/closure-defined-fs-annotation.js
+++ b/src/closure-defined-fs-annotation.js
@@ -11,16 +11,6 @@ var SDL;
 /**
  * @suppress {duplicate, undefinedVars}
  */
-var GL;
-
-/**
- * @suppress {duplicate, undefinedVars}
- */
-var GLctx;
-
-/**
- * @suppress {duplicate, undefinedVars}
- */
 var SOCKFS;
 
 /**

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -53,42 +53,6 @@ function JSify(data, functionsOnly) {
   var itemsDict = { type: [], GlobalVariableStub: [], functionStub: [], function: [], GlobalVariable: [], GlobalVariablePostSet: [] };
 
   if (mainPass) {
-    var shellFile = SHELL_FILE ? SHELL_FILE : (SIDE_MODULE ? 'shell_sharedlib.js' : (MINIMAL_RUNTIME ? 'shell_minimal.js' : 'shell.js'));
-
-    // We will start to print out the data, but must do so carefully - we are
-    // dealing with potentially *huge* strings. Convenient replacements and
-    // manipulations may create in-memory copies, and we may OOM.
-    //
-    // Final shape that will be created:
-    //    shell
-    //      (body)
-    //        preamble
-    //          runtime
-    //        generated code
-    //        postamble
-    //          global_vars
-    //
-    // First, we print out everything until the generated code. Then the
-    // functions will print themselves out as they are parsed. Finally, we
-    // will call finalCombiner in the main pass, to print out everything
-    // else. This lets us not hold any strings in memory, we simply print
-    // things out as they are ready.
-
-    var shellParts = read(shellFile).split('{{BODY}}');
-    print(processMacros(preprocess(shellParts[0], shellFile)));
-    var pre;
-    if (SIDE_MODULE) {
-      pre = processMacros(preprocess(read('preamble_sharedlib.js'), 'preamble_sharedlib.js'));
-    } else if (MINIMAL_RUNTIME) {
-      pre = processMacros(preprocess(read('preamble_minimal.js'), 'preamble_minimal.js'));
-    } else {
-      pre = processMacros(preprocess(read('support.js'), 'support.js')) +
-            processMacros(preprocess(read('preamble.js'), 'preamble.js'));
-    }
-    print(pre);
-  }
-
-  if (mainPass) {
     // Add additional necessary items for the main pass. We can now do this since types are parsed (types can be used through
     // generateStructInfo in library.js)
 
@@ -444,6 +408,21 @@ function JSify(data, functionsOnly) {
 
       return;
     }
+
+    var shellFile = SHELL_FILE ? SHELL_FILE : (SIDE_MODULE ? 'shell_sharedlib.js' : (MINIMAL_RUNTIME ? 'shell_minimal.js' : 'shell.js'));
+
+    var shellParts = read(shellFile).split('{{BODY}}');
+    print(processMacros(preprocess(shellParts[0], shellFile)));
+    var pre;
+    if (SIDE_MODULE) {
+      pre = processMacros(preprocess(read('preamble_sharedlib.js'), 'preamble_sharedlib.js'));
+    } else if (MINIMAL_RUNTIME) {
+      pre = processMacros(preprocess(read('preamble_minimal.js'), 'preamble_minimal.js'));
+    } else {
+      pre = processMacros(preprocess(read('support.js'), 'support.js')) +
+            processMacros(preprocess(read('preamble.js'), 'preamble.js'));
+    }
+    print(pre);
 
     // Print out global variables and postsets TODO: batching
     var legalizedI64sDefault = legalizedI64s;

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -753,6 +753,7 @@ var LibraryGLFW = {
 
       event.preventDefault();
 
+#if '$FS' in addedLibraryItems
       var filenames = allocate(new Array(event.dataTransfer.files.length*4), 'i8*', ALLOC_NORMAL);
       var filenamesArray = [];
       var count = event.dataTransfer.files.length;
@@ -793,6 +794,8 @@ var LibraryGLFW = {
       for (var i = 0; i < count; ++i) {
         save(event.dataTransfer.files[i]);
       }
+
+#endif // '$FS' in addedLibraryItems
 
       return false;
     },

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2378,12 +2378,10 @@ class Building(object):
 
       if not Settings.ASMFS:
         # If we have filesystem disabled, tell Closure not to bark when there are syscalls emitted that still reference the nonexisting FS object.
-        if not Settings.FILESYSTEM:
-          CLOSURE_ANNOTATIONS += ['--js', path_from_root('src', 'closure-undefined-fs-annotation.js')]
-
-        # If we do have filesystem enabled, tell Closure not to bark when FS references different libraries that might not exist.
-        if Settings.FILESYSTEM and not Settings.ASMFS:
+        if Settings.FILESYSTEM:
           CLOSURE_ANNOTATIONS += ['--js', path_from_root('src', 'closure-defined-fs-annotation.js')]
+        else:
+          CLOSURE_ANNOTATIONS += ['--js', path_from_root('src', 'closure-undefined-fs-annotation.js')]
 
       # Closure externs file contains known symbols to be extern to the minification, Closure
       # should not minify these symbol names.


### PR DESCRIPTION
The hacks for GL are not just ugly, but also bad for code size in some cases, it turns out (apparently closure will not optimize as much in their presence).

This is a step towards #8421, the changes for which end up causing closure to emit worse code if not for this PR.