### PR TITLE
refactor check_all_implemented. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -852,23 +852,24 @@ def get_all_implemented(forwarded_json, metadata):
 
 
 def check_all_implemented(all_implemented, pre):
-  for requested in shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS:
-    if not is_already_implemented(requested, pre, all_implemented):
+  # we are not checking anyway, so just skip this
+  if not shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS and not shared.Settings.WARN_ON_UNDEFINED_SYMBOLS:
+    return
+  # only interested in those which are not in all_implemented
+  notinImplemented = list(set(shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS) - set(all_implemented))
+  # special-case malloc, EXPORTED by default for internal use, but we bake in a
+  # trivial allocator and warn at runtime if used in ASSERTIONS
+  if '_malloc' in notinImplemented:
+    notinImplemented.remove('_malloc')
+
+  for requested in notinImplemented:
+    in_pre = ('function ' + asstr(requested)) in pre
+    if not in_pre:
       # could be a js library func
       if shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS:
         exit_with_error('undefined exported function: "%s"', requested)
       elif shared.Settings.WARN_ON_UNDEFINED_SYMBOLS:
         logger.warning('undefined exported function: "%s"', requested)
-
-
-def is_already_implemented(requested, pre, all_implemented):
-  is_implemented = requested in all_implemented
-  # special-case malloc, EXPORTED by default for internal use, but we bake in a
-  # trivial allocator and warn at runtime if used in ASSERTIONS
-  is_exception = requested == '_malloc'
-  in_pre = ('function ' + asstr(requested)) in pre
-  return is_implemented or is_exception or in_pre
-
 
 def get_exported_implemented_functions(all_exported_functions, all_implemented, metadata):
   funcs = set(metadata['exports'])

--- a/emscripten.py
+++ b/emscripten.py
@@ -871,6 +871,7 @@ def check_all_implemented(all_implemented, pre):
       elif shared.Settings.WARN_ON_UNDEFINED_SYMBOLS:
         logger.warning('undefined exported function: "%s"', requested)
 
+
 def get_exported_implemented_functions(all_exported_functions, all_implemented, metadata):
   funcs = set(metadata['exports'])
   export_bindings = shared.Settings.EXPORT_BINDINGS

--- a/emscripten.py
+++ b/emscripten.py
@@ -855,14 +855,14 @@ def check_all_implemented(all_implemented, pre):
   # we are not checking anyway, so just skip this
   if not shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS and not shared.Settings.WARN_ON_UNDEFINED_SYMBOLS:
     return
-  # only interested in those which are not in all_implemented
-  notinImplemented = list(set(shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS) - set(all_implemented))
+  # the initial list of missing functions are those we expected to export, but were not implemented in compiled code
+  missing = list(set(shared.Settings.ORIGINAL_EXPORTED_FUNCTIONS) - set(all_implemented))
   # special-case malloc, EXPORTED by default for internal use, but we bake in a
   # trivial allocator and warn at runtime if used in ASSERTIONS
-  if '_malloc' in notinImplemented:
-    notinImplemented.remove('_malloc')
+  if '_malloc' in missing:
+    missing.remove('_malloc')
 
-  for requested in notinImplemented:
+  for requested in missing:
     in_pre = ('function ' + asstr(requested)) in pre
     if not in_pre:
       # could be a js library func


### PR DESCRIPTION
- return if we do not check for undefined_symbols
- refactor check_all_implemented
- removed unused function is_already_implemented

possible fix for #8447