### PR TITLE
Internalize 'emscripten_fetch' when FETCH setting is enabled

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1139,6 +1139,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       options.js_libraries.append(shared.path_from_root('src', 'library_fetch.js'))
       if shared.Settings.USE_PTHREADS:
         shared.Settings.FETCH_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.fetch.js'
+        # This is a hack for make_fetch_worker(), which requires
+        # emscripten_is_main_runtime_thread, which is called from emscripten_fetch()
+        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_fetch']
 
     forced_stdlibs = []
     if shared.Settings.DEMANGLE_SUPPORT:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2230,6 +2230,9 @@ class Building(object):
     internalize_public_api = '-internalize-public-api-'
     internalize_list = ','.join([exp[1:] for exp in exps])
 
+    if Settings.FETCH:
+      internalize_list += ",emscripten_fetch"
+
     # EXPORTED_FUNCTIONS can potentially be very large.
     # 8k is a bit of an arbitrary limit, but a reasonable one
     # for max command line size before we use a response file

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2230,9 +2230,6 @@ class Building(object):
     internalize_public_api = '-internalize-public-api-'
     internalize_list = ','.join([exp[1:] for exp in exps])
 
-    if Settings.FETCH:
-      internalize_list += ",emscripten_fetch"
-
     # EXPORTED_FUNCTIONS can potentially be very large.
     # 8k is a bit of an arbitrary limit, but a reasonable one
     # for max command line size before we use a response file


### PR DESCRIPTION
shared.make_fetch_worker() relies on the fetch runtime not being optimized away during dead code elimination. Adding 'emscripten_fetch' to the list of internalized symbols during LLVM optimization prevents
that from happening.

Fixes #8452
