### PR TITLE
Allow bitcode inputs files with -c when using wasm object files.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -911,6 +911,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if file_suffix.endswith(SOURCE_ENDINGS):
             input_files.append((i, arg))
             has_source_inputs = True
+          elif shared.Settings.WASM_OBJECT_FILES and file_suffix.endswith(BITCODE_ENDINGS):
+            input_files.append((i, arg))
+            has_source_inputs = True
           elif file_suffix.endswith(HEADER_ENDINGS):
             input_files.append((i, arg))
             has_header_inputs = True
@@ -1727,6 +1730,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       for i, input_file in input_files:
         file_ending = get_file_suffix(input_file)
         if file_ending.endswith(SOURCE_ENDINGS):
+          compile_source_file(i, input_file)
+        elif shared.Settings.WASM_OBJECT_FILES and has_dash_c and file_ending.endswith(BITCODE_ENDINGS):
           compile_source_file(i, input_file)
         else: # bitcode
           if file_ending.endswith(BITCODE_ENDINGS):

--- a/emcc.py
+++ b/emcc.py
@@ -908,10 +908,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         file_suffix = get_file_suffix(arg)
         if file_suffix in SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
           newargs[i] = ''
-          if file_suffix.endswith(SOURCE_ENDINGS):
-            input_files.append((i, arg))
-            has_source_inputs = True
-          elif shared.Settings.WASM_OBJECT_FILES and file_suffix.endswith(BITCODE_ENDINGS):
+          if file_suffix.endswith(SOURCE_ENDINGS) or file_suffix.endswith(BITCODE_ENDINGS):
             input_files.append((i, arg))
             has_source_inputs = True
           elif file_suffix.endswith(HEADER_ENDINGS):
@@ -1729,9 +1726,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
       for i, input_file in input_files:
         file_ending = get_file_suffix(input_file)
-        if file_ending.endswith(SOURCE_ENDINGS):
-          compile_source_file(i, input_file)
-        elif shared.Settings.WASM_OBJECT_FILES and has_dash_c and file_ending.endswith(BITCODE_ENDINGS):
+        if file_ending.endswith(SOURCE_ENDINGS) or (has_dash_c and file_ending.endswith(BITCODE_ENDINGS)):
           compile_source_file(i, input_file)
         else: # bitcode
           if file_ending.endswith(BITCODE_ENDINGS):

--- a/emcc.py
+++ b/emcc.py
@@ -883,7 +883,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
                 shared.path_from_root('system', 'lib')]
 
-    # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
+    # -c mean compile to object files(s), don't link
     has_dash_c = '-c' in newargs
 
     # find input files this a simple heuristic. we should really analyze

--- a/emcc.py
+++ b/emcc.py
@@ -883,6 +883,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
                 shared.path_from_root('system', 'lib')]
 
+    # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
+    has_dash_c = '-c' in newargs
+
     # find input files this a simple heuristic. we should really analyze
     # based on a full understanding of gcc params, right now we just assume that
     # what is left contains no more |-x OPT| things
@@ -908,7 +911,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         file_suffix = get_file_suffix(arg)
         if file_suffix in SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
           newargs[i] = ''
-          if file_suffix.endswith(SOURCE_ENDINGS) or file_suffix.endswith(BITCODE_ENDINGS):
+          if file_suffix.endswith(SOURCE_ENDINGS) or (has_dash_c and file_suffix.endswith(BITCODE_ENDINGS)):
             input_files.append((i, arg))
             has_source_inputs = True
           elif file_suffix.endswith(HEADER_ENDINGS):
@@ -977,8 +980,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     newargs = [a for a in newargs if a is not '']
 
-    # -c means do not link in gcc, and for us, the parallel is to not go all the way to JS, but stop at bitcode
-    has_dash_c = '-c' in newargs
     if has_dash_c:
       assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c'
       target = target_basename + '.o'


### PR DESCRIPTION
This allows bitcode files as inputs when using -c and the llvm wasm backend, i.e.
`emcc -o foo.o -c foo.bc`
will compile the bc file into a wasm object file.
This is useful for compiling .bc files created by 3rd party compilers using the same flags that emcc
passes to clang, so they can be linked together later.
