### PR TITLE
WebGL2 wait sync fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -399,3 +399,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Timothy Trindle <titrindl@microsoft.com> (copyright owned by Microsoft, Inc.)
 * Matthew Andres Moreno <m.more500@gmail.com>
 * Eric Mandel <eric@cfa.harvard.edu>
+* Simon Cooper <simon.d.cooper@hotmail.co.uk>

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -748,7 +748,7 @@ var LibraryWebGL2 = {
     GL.syncs[id] = null;
   },
 
-  glClientWaitSync__sig: 'iiii',
+  glClientWaitSync__sig: 'iiiii',
   glClientWaitSync: function(sync, flags, timeoutLo, timeoutHi) {
     // WebGL2 vs GLES3 differences: in GLES3, the timeout parameter is a uint64, where 0xFFFFFFFFFFFFFFFFULL means GL_TIMEOUT_IGNORED.
     // In JS, there's no 64-bit value types, so instead timeout is taken to be signed, and GL_TIMEOUT_IGNORED is given value -1.
@@ -760,7 +760,7 @@ var LibraryWebGL2 = {
     return GLctx.clientWaitSync(GL.syncs[sync], flags, timeout);
   },
 
-  glWaitSync__sig: 'viii',
+  glWaitSync__sig: 'viiii',
   glWaitSync: function(sync, flags, timeoutLo, timeoutHi) {
     // See WebGL2 vs GLES3 difference on GL_TIMEOUT_IGNORED above (https://www.khronos.org/registry/webgl/specs/latest/2.0/#5.15)
     timeoutLo = timeoutLo >>> 0;

--- a/system/lib/gl/webgl2.c
+++ b/system/lib/gl/webgl2.c
@@ -93,7 +93,7 @@ void glWaitSync(GLsync p0, GLbitfield p1, GLuint64 p2) {
 	if (pthread_getspecific(currentThreadOwnsItsWebGLContext))
 		emscripten_glWaitSync(p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
 	else
-		emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_IIIII, &emscripten_glWaitSync, p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
+		emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_VIIII, &emscripten_glWaitSync, p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
 }
 VOID_SYNC_GL_FUNCTION_2(EM_FUNC_SIG_VII, void, glGetInteger64v, GLenum, GLint64 *);
 VOID_SYNC_GL_FUNCTION_5(EM_FUNC_SIG_VIIIII, void, glGetSynciv, GLsync, GLenum, GLsizei, GLsizei *, GLint *);

--- a/system/lib/gl/webgl2.c
+++ b/system/lib/gl/webgl2.c
@@ -88,10 +88,10 @@ GLenum glClientWaitSync(GLsync p0, GLbitfield p1, GLuint64 p2) {
 	else
 		return (GLenum)emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_IIIII, &emscripten_glClientWaitSync, p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
 }
-GLenum glWaitSync(GLsync p0, GLbitfield p1, GLuint64 p2) {
+void glWaitSync(GLsync p0, GLbitfield p1, GLuint64 p2) {
 	GL_FUNCTION_TRACE(glWaitSync);
 	if (pthread_getspecific(currentThreadOwnsItsWebGLContext))
-		emscripten_glClientWaitSync(p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
+		emscripten_glWaitSync(p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
 	else
 		emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_IIIII, &emscripten_glWaitSync, p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
 }

--- a/system/lib/gl/webgl2.c
+++ b/system/lib/gl/webgl2.c
@@ -81,8 +81,20 @@ ASYNC_GL_FUNCTION_5(EM_FUNC_SIG_VIIIII, void, glDrawElementsInstanced, GLenum, G
 RET_SYNC_GL_FUNCTION_2(EM_FUNC_SIG_III, GLsync, glFenceSync, GLenum, GLbitfield);
 RET_SYNC_GL_FUNCTION_1(EM_FUNC_SIG_II, GLboolean, glIsSync, GLsync);
 ASYNC_GL_FUNCTION_1(EM_FUNC_SIG_VI, void, glDeleteSync, GLsync);
-RET_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_IIII, GLenum, glClientWaitSync, GLsync, GLbitfield, GLuint64); // XXX TODO: 64-bit integer proxying, this is not right, proxying as 32-bit
-VOID_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glWaitSync, GLsync, GLbitfield, GLuint64); // XXX TODO: 64-bit integer proxying, this is not right, proxying as 32-bit
+GLenum glClientWaitSync(GLsync p0, GLbitfield p1, GLuint64 p2) {
+	GL_FUNCTION_TRACE(glClientWaitSync);
+	if (pthread_getspecific(currentThreadOwnsItsWebGLContext))
+		return emscripten_glClientWaitSync(p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
+	else
+		return (GLenum)emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_IIIII, &emscripten_glClientWaitSync, p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
+}
+GLenum glWaitSync(GLsync p0, GLbitfield p1, GLuint64 p2) {
+	GL_FUNCTION_TRACE(glWaitSync);
+	if (pthread_getspecific(currentThreadOwnsItsWebGLContext))
+		emscripten_glClientWaitSync(p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
+	else
+		emscripten_sync_run_in_main_runtime_thread(EM_FUNC_SIG_IIIII, &emscripten_glWaitSync, p0, p1, p2 & 0xFFFFFFFF, (p2 >> 32) & 0xFFFFFFFF);
+}
 VOID_SYNC_GL_FUNCTION_2(EM_FUNC_SIG_VII, void, glGetInteger64v, GLenum, GLint64 *);
 VOID_SYNC_GL_FUNCTION_5(EM_FUNC_SIG_VIIIII, void, glGetSynciv, GLsync, GLenum, GLsizei, GLsizei *, GLint *);
 VOID_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glGetInteger64i_v, GLenum, GLuint, GLint64 *);

--- a/system/lib/gl/webgl2.h
+++ b/system/lib/gl/webgl2.h
@@ -75,8 +75,8 @@ GL_APICALL void GL_APIENTRY emscripten_glDrawElementsInstanced (GLenum mode, GLs
 GL_APICALL GLsync GL_APIENTRY emscripten_glFenceSync (GLenum condition, GLbitfield flags);
 GL_APICALL GLboolean GL_APIENTRY emscripten_glIsSync (GLsync sync);
 GL_APICALL void GL_APIENTRY emscripten_glDeleteSync (GLsync sync);
-GL_APICALL GLenum GL_APIENTRY emscripten_glClientWaitSync (GLsync sync, GLbitfield flags, GLuint64 timeout);
-GL_APICALL void GL_APIENTRY emscripten_glWaitSync (GLsync sync, GLbitfield flags, GLuint64 timeout);
+GL_APICALL GLenum GL_APIENTRY emscripten_glClientWaitSync (GLsync sync, GLbitfield flags, GLuint timeoutLo, GLuint timeoutHi);
+GL_APICALL void GL_APIENTRY emscripten_glWaitSync (GLsync sync, GLbitfield flags, GLuint timeoutLo, GLuint timeoutHi);
 GL_APICALL void GL_APIENTRY emscripten_glGetInteger64v (GLenum pname, GLint64 *data);
 GL_APICALL void GL_APIENTRY emscripten_glGetSynciv (GLsync sync, GLenum pname, GLsizei bufSize, GLsizei *length, GLint *values);
 GL_APICALL void GL_APIENTRY emscripten_glGetInteger64i_v (GLenum target, GLuint index, GLint64 *data);


### PR DESCRIPTION
Fixes #8458 

A bit messy in the .c file, but I couldn't think of a good way of expanding the 64-bit int in a re-usable manner.

I tested this on Chrome 73 and Firefox 66, and it worked on both - however for some reason Chrome's max timeout for these functions is set to 0, so it instantly fails there.