### PR TITLE
Consistent handling `-l` and `-L` flags in `-Wl,` and `-Wl,@rsp`

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -920,7 +920,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # (4, a), (4.25, b), (4.5, c), (4.75, d)
         link_flags_to_add = arg.split(',')[1:]
         for flag_index, flag in enumerate(link_flags_to_add):
-          link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
+          if flag.startswith('-l'):
+            libs.append((i, flag[2:]))
+          elif flag.startswith('-L'):
+            lib_dirs.append((i, flag[2:]))
+          else:
+            link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
 
         newargs[i] = ''
       elif arg == '-s':
@@ -1699,7 +1704,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # how to deal with.  We currently can't handle flags with options (like
         # -Wl,-rpath,/bin:/lib, where /bin:/lib is an option for the -rpath
         # flag).
-        link_flags = [f for f in link_flags if f[1] in SUPPORTED_LINKER_FLAGS]
+        def supported(f):
+          if f in SUPPORTED_LINKER_FLAGS:
+            return True
+          if f.startswith('-l'):
+            return True
+          else:
+            logger.warning('ignoreing unsupported linker flag: `%s`', f)
+        link_flags = [f for f in link_flags if supported(f[1])]
 
       linker_inputs = [val for _, val in sorted(temp_files + link_flags)]
 

--- a/emcc.py
+++ b/emcc.py
@@ -1707,10 +1707,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         def supported(f):
           if f in SUPPORTED_LINKER_FLAGS:
             return True
-          if f.startswith('-l'):
-            return True
-          else:
-            logger.warning('ignoreing unsupported linker flag: `%s`', f)
+          logger.warning('ignoring unsupported linker flag: `%s`', f)
+          return False
         link_flags = [f for f in link_flags if supported(f[1])]
 
       linker_inputs = [val for _, val in sorted(temp_files + link_flags)]

--- a/emcc.py
+++ b/emcc.py
@@ -923,7 +923,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if flag.startswith('-l'):
             libs.append((i, flag[2:]))
           elif flag.startswith('-L'):
-            lib_dirs.append((i, flag[2:]))
+            lib_dirs.append(flag[2:])
           else:
             link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -963,20 +963,20 @@ f.close()
     aout = 'a.out.js'
 
     def build(path, args):
-      run_process([PYTHON, EMCC, self.in_dir(*path)] + args)
+      run_process([PYTHON, EMCC, path] + args)
 
     # Test linking the library built here by emcc
-    build(['libdir', 'libfile.cpp'], ['-c'])
+    build('libfile.cpp', ['-c'])
     shutil.move('libfile.o', libfile)
-    build(['main.cpp'], ['-L' + 'libdir', '-lfile'])
+    build('main.cpp', ['-L' + 'libdir', '-lfile'])
 
     self.assertContained('hello from lib', run_js(aout))
 
     # Also test execution with `-l c` and space-separated library linking syntax
     os.remove(aout)
-    build(['libdir', 'libfile.cpp'], ['-c', '-l', 'c'])
+    build('libfile.cpp', ['-c', '-l', 'c'])
     shutil.move('libfile.o', libfile)
-    build(['main.cpp'], ['-L', 'libdir', '-l', 'file'])
+    build('main.cpp', ['-L', 'libdir', '-l', 'file'])
 
     self.assertContained('hello from lib', run_js(aout))
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -913,17 +913,44 @@ f.close()
     # check empty tables work with assertions 2 in this mode (#6554)
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EMULATED_FUNCTION_POINTERS=1', '-s', 'ASSERTIONS=2'])
 
-  def test_l_link(self):
-    # Linking with -lLIBNAME and -L/DIRNAME should work, also should work with spaces
-
-    def build(path, args):
-      run_process([PYTHON, EMCC, self.in_dir(*path)] + args)
-
+  def test_wl_linkflags(self):
+    # Test path -L and -l via -Wl, arguments and -Wl, response files
     create_test_file('main.cpp', '''
       extern void printey();
       int main() {
         printey();
         return 0;
+      }
+    ''')
+    create_test_file('libfile.cpp', '''
+      #include <stdio.h>
+      void printey() {
+        printf("hello from lib\\n");
+      }
+    ''')
+    create_test_file('linkflags.txt', '''
+    -L.
+    -lfoo
+    ''')
+    run_process([PYTHON, EMCC, '-o', 'libfile.o', 'libfile.cpp'])
+    run_process([PYTHON, EMAR, 'rv', 'libfoo.a', 'libfile.o'])
+    run_process([PYTHON, EMCC, 'main.cpp', '-L.', '-lfoo'])
+    run_process([PYTHON, EMCC, 'main.cpp', '-Wl,-L.', '-Wl,-lfoo'])
+    run_process([PYTHON, EMCC, 'main.cpp', '-Wl,@linkflags.txt'])
+
+  def test_l_link(self):
+    # Linking with -lLIBNAME and -L/DIRNAME should work, also should work with spaces
+    create_test_file('main.cpp', '''
+      extern void printey();
+      int main() {
+        printey();
+        return 0;
+      }
+    ''')
+    create_test_file('libfile.cpp', '''
+      #include <stdio.h>
+      void printey() {
+        printf("hello from lib\\n");
       }
     ''')
 
@@ -932,15 +959,11 @@ f.close()
     except:
       pass
 
-    create_test_file(os.path.join('libdir', 'libfile.cpp'), '''
-      #include <stdio.h>
-      void printey() {
-        printf("hello from lib\\n");
-      }
-    ''')
-
     libfile = self.in_dir('libdir', 'libfile.so')
     aout = 'a.out.js'
+
+    def build(path, args):
+      run_process([PYTHON, EMCC, self.in_dir(*path)] + args)
 
     # Test linking the library built here by emcc
     build(['libdir', 'libfile.cpp'], ['-c'])


### PR DESCRIPTION
This means `-Wl,-lfoo` will result in the same behaviour as
`-lfoo` and `-Wl,@rsp_with_lfoo.txt`

Also warn when ignoring an unsupported linker flag.
