### PR TITLE
Fix conditional #include in js preprocessor

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -51,12 +51,14 @@ function preprocess(text, filenameHint) {
           var truthy = !!eval(after);
           showStack.push(truthy);
         } else if (line.indexOf('#include') === 0) {
-          var filename = line.substr(line.indexOf(' ')+1);
-          if (filename.indexOf('"') === 0) {
-            filename = filename.substr(1, filename.length - 2);
+          if (showStack.indexOf(false) === -1) {
+            var filename = line.substr(line.indexOf(' ')+1);
+            if (filename.indexOf('"') === 0) {
+              filename = filename.substr(1, filename.length - 2);
+            }
+            var included = read(filename);
+            ret += '\n' + preprocess(included, filename) + '\n';
           }
-          var included = read(filename);
-          ret += '\n' + preprocess(included, filename) + '\n';
         } else if (line.indexOf('#else') === 0) {
           assert(showStack.length > 0);
           showStack.push(!showStack.pop());


### PR DESCRIPTION
Previously we always did the include, and emitted it, even if we were in a block that was ifdefed out.