### PR TITLE
Cleanup add_emscripten_metadata. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2739,8 +2739,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
 
   # after generating the wasm, do some final operations
   if shared.Settings.EMIT_EMSCRIPTEN_METADATA:
-    wso = shared.WebAssembly.add_emscripten_metadata(final, wasm_binary_target)
-    shutil.move(wso, wasm_binary_target)
+    shared.WebAssembly.add_emscripten_metadata(final, wasm_binary_target)
 
   if shared.Settings.SIDE_MODULE:
     sys.exit(0) # and we are done.


### PR DESCRIPTION
get_js_data() used to parse the JS but its since been refactored
such that it can be removed.

