### PR TITLE
Add PYTHON to emmake and emconfigure commands when building sdl2-mixer

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -574,7 +574,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # 0 - use native compilation for configure checks
     # 1 - use js when we think it will work
     # 2 - always use js for configure checks
-    use_js = int(os.environ.get('EMCONFIGURE_JS') or 2)
+    use_js = int(os.environ.get('EMCONFIGURE_JS', '2'))
 
     if debug_configure:
       tempout = '/tmp/emscripten_temp/out'

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -27,8 +27,8 @@ def get(ports, settings, shared):
     try:
       os.chdir(build_dir)
       os.chmod(configure, os.stat(configure).st_mode | stat.S_IEXEC)
-      ports.run_commands([[shared.EMCONFIGURE, configure, '--prefix=' + dist_dir] + formatflags + commonflags + ['CFLAGS=-s USE_VORBIS=1']])
-      ports.run_commands([[shared.EMMAKE, 'make', 'install']])
+      ports.run_commands([[shared.PYTHON, shared.EMCONFIGURE, configure, '--prefix=' + dist_dir] + formatflags + commonflags + ['CFLAGS=-s USE_VORBIS=1']])
+      ports.run_commands([[shared.PYTHON, shared.EMMAKE, 'make', 'install']])
       shutil.copyfile(out, final)
     finally:
       os.chdir(cwd)


### PR DESCRIPTION
This should fix the windows build where python scripts cannot be
executed directly.

Fixes: #8487