### PR TITLE
Remove assertion regarding exports['table']

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -504,9 +504,6 @@ function loadWebAssemblyModule(binary, flags) {
       // the table should be unchanged
       assert(table === originalTable);
       assert(table === wasmTable);
-      if (instance.exports['table']) {
-        assert(table === instance.exports['table']);
-      }
       // the old part of the table should be unchanged
       for (var i = 0; i < tableBase; i++) {
         assert(table.get(i) === oldTable[i], 'old table entries must remain the same');


### PR DESCRIPTION
Emscripten wasm modules always import their wasm table and we don't look
for a table in their list of exports.

This assert was firing a if a module was to export a function or
variable that happened to be called 'table'.
