### PR TITLE
wasm2js branch fixes for IE 11

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1118,13 +1118,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.LEGACY_VM_SUPPORT:
       # legacy vms don't have wasm
-      assert not shared.Settings.WASM, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
+      assert not shared.Settings.WASM or shared.Settings.WASM2JS, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
       shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
       shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
 
     # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
-    if shared.Settings.WASM:
+    if shared.Settings.WASM and not shared.Settings.WASM2JS:
       shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
       shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -67,6 +67,6 @@ var WebAssembly = {
   }
 };
 
-// We don't need to actually download a wasm binary, mark it as present.
-Module['wasmBinary'] = true;
+// We don't need to actually download a wasm binary, mark it as present but empty.
+Module['wasmBinary'] = [];
 


### PR DESCRIPTION
A couple quick fixes for wasm2js mode in IE 11:
* workaround for instantiation of buffer
* allow POLYFILL_OLD_MATH_FUNCTIONS if WASM2JS in use

It still requires a Promise polyfill to be present, but seems to otherwise work for ogv.js's decoders.