### PR TITLE
emrun stability fix

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -456,14 +456,10 @@ class HTTPWebServer(socketserver.ThreadingMixIn, HTTPServer):
         if browser_quit_code is not None:
           delete_emrun_safe_firefox_profile()
           if not emrun_options.serve_after_close:
-            if not have_received_messages:
-              emrun_options.serve_after_close = True
-              logv('Warning: emrun got detached from the target browser process (the process quit with code ' + str(browser_quit_code) + '). Cannot detect when user closes the browser. Behaving as if --serve_after_close was passed in.')
-              if not emrun_options.browser:
-                logv('Try passing the --browser=/path/to/browser option to avoid this from occurring. See https://github.com/emscripten-core/emscripten/issues/3234 for more discussion.')
-            else:
-              self.shutdown()
-              logv('Browser process has quit. Shutting down web server.. Pass --serve_after_close to keep serving the page even after the browser closes.')
+            emrun_options.serve_after_close = True
+            logv('Warning: emrun got detached from the target browser process (the process quit with code ' + str(browser_quit_code) + '). Cannot detect when user closes the browser. Behaving as if --serve_after_close was passed in.')
+            if not emrun_options.browser:
+              logv('Try passing the --browser=/path/to/browser option to avoid this from occurring. See https://github.com/emscripten-core/emscripten/issues/3234 for more discussion.')
 
       # Serve HTTP
       self.handle_request()


### PR DESCRIPTION
If the browser process got detached, don't change behavior depending on whether we received messages or not, as that can be racy (depends if the messages managed to reach us in time or not). Instead, do the simple and robust behavior of continuing as if --serve_after_close was passed in.

Should help with #8495 (but unclear if it fixes it or not).

