### PR TITLE
Flesh out emscripten metadata

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3007,21 +3007,14 @@ class WebAssembly(object):
       WebAssembly.lebify(EMSCRIPTEN_ABI_MINOR) +
 
       WebAssembly.lebify(mem_size) +
-
       WebAssembly.lebify(table_size) +
-
       WebAssembly.lebify(global_base) +
-
       WebAssembly.lebify(dynamic_base) +
-
       WebAssembly.lebify(dynamictop_ptr) +
-
-      WebAssembly.lebify(tempdouble_ptr) +
+      WebAssembly.lebify(tempdouble_ptr)
 
       # NB: more data can be appended here as long as you increase
       #     the EMSCRIPTEN_METADATA_MINOR
-
-      b''
     )
 
     orig = open(wasm_file, 'rb').read()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -518,7 +518,7 @@ EMSCRIPTEN_VERSION_MAJOR, EMSCRIPTEN_VERSION_MINOR, EMSCRIPTEN_VERSION_TINY = pa
 # For the Emscripten-specific WASM metadata section, follows semver, changes
 # whenever metadata section changes structure
 # NB: major version 0 implies no compatibility
-(EMSCRIPTEN_METADATA_MAJOR, EMSCRIPTEN_METADATA_MINOR) = (0, 0)
+(EMSCRIPTEN_METADATA_MAJOR, EMSCRIPTEN_METADATA_MINOR) = (0, 1)
 # For the JS/WASM ABI, specifies the minimum ABI version required of
 # the WASM runtime implementation by the generated WASM binary. It follows
 # semver and changes whenever C types change size/signedness or
@@ -2979,8 +2979,20 @@ class WebAssembly(object):
 
   @staticmethod
   def add_emscripten_metadata(js_file, wasm_file):
-    mem_size = Settings.STATIC_BUMP
+    WASM_PAGE_SIZE = 65536
+
+    mem_size = Settings.TOTAL_MEMORY // WASM_PAGE_SIZE
     table_size = Settings.WASM_TABLE_SIZE
+    global_base = Settings.GLOBAL_BASE
+
+    js = open(js_file).read()
+    m = re.search(r"tempDoublePtr\s+=\s+(\d+)", js)
+    tempdouble_ptr = int(m.group(1))
+    m = re.search(r"DYNAMIC_BASE\s+=\s+(\d+)", js)
+    dynamic_base = int(m.group(1))
+    m = re.search(r"DYNAMICTOP_PTR\s+=\s+(\d+)", js)
+    dynamictop_ptr = int(m.group(1))
+
     logger.debug('creating wasm emscripten metadata section with mem size %d, table size %d' % (mem_size, table_size,))
     name = b'\x13emscripten_metadata' # section name, including prefixed size
     contents = (
@@ -2994,13 +3006,22 @@ class WebAssembly(object):
       WebAssembly.lebify(EMSCRIPTEN_ABI_MAJOR) +
       WebAssembly.lebify(EMSCRIPTEN_ABI_MINOR) +
 
-      # static bump
       WebAssembly.lebify(mem_size) +
 
-      # table size
-      WebAssembly.lebify(table_size)
+      WebAssembly.lebify(table_size) +
+
+      WebAssembly.lebify(global_base) +
+
+      WebAssembly.lebify(dynamic_base) +
+
+      WebAssembly.lebify(dynamictop_ptr) +
+
+      WebAssembly.lebify(tempdouble_ptr) +
+
       # NB: more data can be appended here as long as you increase
       #     the EMSCRIPTEN_METADATA_MINOR
+
+      b''
     )
 
     orig = open(wasm_file, 'rb').read()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2986,12 +2986,12 @@ class WebAssembly(object):
     global_base = Settings.GLOBAL_BASE
 
     js = open(js_file).read()
-    m = re.search(r"tempDoublePtr\s+=\s+(\d+)", js)
-    tempdouble_ptr = int(m.group(1))
-    m = re.search(r"DYNAMIC_BASE\s+=\s+(\d+)", js)
-    dynamic_base = int(m.group(1))
-    m = re.search(r"DYNAMICTOP_PTR\s+=\s+(\d+)", js)
-    dynamictop_ptr = int(m.group(1))
+    m = re.search(r"(^|\s)tempDoublePtr\s+=\s+(\d+)", js)
+    tempdouble_ptr = int(m.group(2))
+    m = re.search(r"(^|\s)DYNAMIC_BASE\s+=\s+(\d+)", js)
+    dynamic_base = int(m.group(2))
+    m = re.search(r"(^|\s)DYNAMICTOP_PTR\s+=\s+(\d+)", js)
+    dynamictop_ptr = int(m.group(2))
 
     logger.debug('creating wasm emscripten metadata section with mem size %d, table size %d' % (mem_size, table_size,))
     name = b'\x13emscripten_metadata' # section name, including prefixed size


### PR DESCRIPTION
DYNAMICTOP_PTR and tempDoublePtr are no longer guaranteed to be
computable from STATIC_BUMP. Also GLOBAL_BASE is not always 1024.
Pass these through emscripten metadata for third-party runtimes
that consume Emscripten-generated WASM binaries.