### PR TITLE
If the user explicitly sets `FILESYSTEM` to 0, mark `SYSCALLS_REQUIRE_FILESYSTEM` as 0 too

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -611,13 +611,17 @@ def optimize_syscalls(declares, DEBUG):
   if any(shared.Settings[s] for s in relevant_settings):
     return
 
-  syscall_prefix = '__syscall'
-  syscall_numbers = [d[len(syscall_prefix):] for d in declares if d.startswith(syscall_prefix)]
-  syscalls = [int(s) for s in syscall_numbers if is_int(s)]
-  if set(syscalls).issubset(set([6, 54, 140, 146])): # close, ioctl, llseek, writev
-    if DEBUG:
-      logger.debug('very limited syscalls (%s) so disabling full filesystem support', ', '.join(str(s) for s in syscalls))
+  if shared.Settings.FILESYSTEM == 0:
+    # without filesystem support, it doesn't matter what syscalls need
     shared.Settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
+  else:
+    syscall_prefix = '__syscall'
+    syscall_numbers = [d[len(syscall_prefix):] for d in declares if d.startswith(syscall_prefix)]
+    syscalls = [int(s) for s in syscall_numbers if is_int(s)]
+    if set(syscalls).issubset(set([6, 54, 140, 146])): # close, ioctl, llseek, writev
+      if DEBUG:
+        logger.debug('very limited syscalls (%s) so disabling full filesystem support', ', '.join(str(s) for s in syscalls))
+      shared.Settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
 
 
 def is_int(x):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5329,6 +5329,10 @@ main(const int argc, const char * const * const argv)
     self.assertGreater(yes_size - no_size, 100000)
     self.assertLess(no_size, 360000)
 
+  def test_no_filesystem_libcxx(self):
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'FILESYSTEM=0'])
+    self.assertContained('hello, world!', run_js('a.out.js'))
+
   def test_no_nuthin(self):
     # check FILESYSTEM is automatically set, and effective
 


### PR DESCRIPTION
Otherwise, we incorrectly try to use the filesystem in some cases, like the testcase added here with libc++ code. This also affected binaryen which is how I noticed.

Followup to #8438 and #8464.