### PR TITLE
Fix broken telldir/seekdir testing

### DIFF
--- a/tests/dirent/test_readdir.c
+++ b/tests/dirent/test_readdir.c
@@ -117,20 +117,27 @@ void test() {
   rewinddir(dir);
   ent = readdir(dir);
   assert(!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..") || !strcmp(ent->d_name, "file.txt"));
-  char first[1024];
-  //printf("first: %s\n", ent->d_name);
-  strcpy(first, ent->d_name);
   loc = telldir(dir);
-  assert(loc >= 0);
+#ifndef __EMSCRIPTEN__
+  // TODO(https://github.com/emscripten-core/emscripten/issues/8526): Implement telldir/seekdir
+  assert(loc > 0);
+  //printf("loc=%d\n", loc);
+#endif
   ent = readdir(dir);
+  char name_at_loc[1024];
+  strcpy(name_at_loc, ent->d_name);
+  //printf("name_at_loc: %s\n", name_at_loc);
   assert(!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..") || !strcmp(ent->d_name, "file.txt"));
   ent = readdir(dir);
   assert(!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..") || !strcmp(ent->d_name, "file.txt"));
   seekdir(dir, loc);
   ent = readdir(dir);
   assert(ent);
-  //printf("check: %s / %s\n", ent->d_name, first);
-  assert(!strcmp(ent->d_name, first));
+#ifndef __EMSCRIPTEN__
+  // TODO(https://github.com/emscripten-core/emscripten/issues/8526: Implement telldir/seekdir
+  //printf("check: %s / %s\n", ent->d_name, name_at_loc);
+  assert(!strcmp(ent->d_name, name_at_loc));
+#endif
 
   //
   // do a normal read with readdir_r


### PR DESCRIPTION
This test was using telldir() to get the offset of the second directory
entry but then asserting that seekdir() rewound back to the first
entry.

Unfortunately when fixing this test it revealed that these function
don't currently work under emscripten.   In fact telldir() always
returns currently under emscripten and seekdir always rewinds to the
beginning.

See https://github.com/emscripten-core/emscripten/issues/8526
