### PR TITLE
Build gl separately for OFFSCREEN_FRAMEBUFFER

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -45,14 +45,6 @@ SYSTEM_TASKS = [
     'compiler-rt',
     'emmalloc',
     'emmalloc_debug',
-    'gl',
-    'gl-emu',
-    'gl-emu-webgl2',
-    'gl-mt',
-    'gl-mt-emu',
-    'gl-mt-emu-webgl2',
-    'gl-mt-webgl2',
-    'gl-webgl2',
     'html5',
     'libc',
     'libc++',
@@ -69,6 +61,12 @@ for debug in ['', '_debug']:
     for threadsafe in ['', '_threadsafe']:
       for tracing in ['', '_tracing']:
         SYSTEM_TASKS += ['dlmalloc' + debug + noerrno + threadsafe + tracing]
+
+for mt in ['', '-mt']:
+  for emu in ['', '-emu']:
+    for webgl2 in ['', '-webgl2']:
+      for ofb in ['', '-ofb']:
+        SYSTEM_TASKS += ['gl' + mt + emu + webgl2 + ofb]
 
 USER_TASKS = [
     'binaryen',
@@ -282,6 +280,8 @@ def main():
         opts += ['-s', 'LEGACY_GL_EMULATION=1']
       if '-webgl2' in what:
         opts += ['-s', 'USE_WEBGL2=1']
+      if '-ofb' in what:
+        opts += ['-s', 'OFFSCREEN_FRAMEBUFFER=1']
       build('''
         extern "C" { extern void* emscripten_GetProcAddress(const char *x); }
         int main() {

--- a/system/lib/gl/webgl1.c
+++ b/system/lib/gl/webgl1.c
@@ -8,7 +8,7 @@
 #include "webgl1_ext.h"
 #include "webgl2.h"
 
-#ifdef __EMSCRIPTEN_PTHREADS__
+#if defined(__EMSCRIPTEN_PTHREADS__) && defined(__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__)
 
 extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_do_create_context(const char *target, const EmscriptenWebGLContextAttributes *attributes);
 extern EMSCRIPTEN_RESULT emscripten_webgl_make_context_current_calling_thread(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
@@ -625,7 +625,7 @@ RET_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glGetQueryObjectuivEXT, GLenum, G
 RET_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glGetQueryObjecti64vEXT, GLenum, GLenum, GLint64 *);
 RET_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glGetQueryObjectui64vEXT, GLenum, GLenum, GLuint64 *);
 
-#endif // ~__EMSCRIPTEN_PTHREADS__
+#endif // ~(__EMSCRIPTEN_PTHREADS__ && __EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__)
 
 void *emscripten_webgl1_get_proc_address(const char *name)
 {

--- a/system/lib/gl/webgl1.h
+++ b/system/lib/gl/webgl1.h
@@ -190,7 +190,7 @@ GL_APICALL void GL_APIENTRY emscripten_glViewport (GLint x, GLint y, GLsizei wid
 #define VOID_SYNC_GL_FUNCTION_10(sig, ret, functionName, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9) ret functionName(t0 p0, t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9) { GL_FUNCTION_TRACE(functionName); if (pthread_getspecific(currentThreadOwnsItsWebGLContext)) emscripten_##functionName(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9); else emscripten_sync_run_in_main_runtime_thread(sig, &emscripten_##functionName, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9); }
 #define VOID_SYNC_GL_FUNCTION_11(sig, ret, functionName, t0, t1, t2, t3, t4, t5, t6, t7, t8, t9, t10) ret functionName(t0 p0, t1 p1, t2 p2, t3 p3, t4 p4, t5 p5, t6 p6, t7 p7, t8 p8, t9 p9, t10 p10) { GL_FUNCTION_TRACE(functionName); if (pthread_getspecific(currentThreadOwnsItsWebGLContext)) emscripten_##functionName(p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10); else emscripten_sync_run_in_main_runtime_thread(sig, &emscripten_##functionName, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10); }
 
-#ifdef __EMSCRIPTEN_PTHREADS__
+#if defined(__EMSCRIPTEN_PTHREADS__) && defined(__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__)
 
 #include <pthread.h>
 

--- a/system/lib/gl/webgl2.c
+++ b/system/lib/gl/webgl2.c
@@ -6,7 +6,7 @@
 #include "webgl1.h"
 #include "webgl2.h"
 
-#ifdef __EMSCRIPTEN_PTHREADS__
+#if defined(__EMSCRIPTEN_PTHREADS__) && defined(__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__)
 
 ASYNC_GL_FUNCTION_1(EM_FUNC_SIG_VI, void, glReadBuffer, GLenum);
 ASYNC_GL_FUNCTION_6(EM_FUNC_SIG_VIIIIII, void, glDrawRangeElements, GLenum, GLuint, GLuint, GLsizei, GLenum, const void *); // TODO: Not async if rendering from client side memory

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1559,7 +1559,7 @@ keydown(100);keyup(100); // trigger the end
   @requires_threads
   @requires_graphics_hardware
   def test_egl_with_proxy_to_pthread(self):
-    self._test_egl_base('-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1')
+    self._test_egl_base('-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1')
 
   def _test_egl_width_height_base(self, *args):
     create_test_file('test_egl_width_height.c', self.with_report_result(open(path_from_root('tests', 'test_egl_width_height.c')).read()))
@@ -4067,7 +4067,7 @@ window.close = function() {
   @no_chrome('see #7374')
   @requires_threads
   def test_webgl_offscreen_canvas_only_in_pthread(self):
-    self.btest('gl_only_in_pthread.cpp', expected='0', args=['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1'])
+    self.btest('gl_only_in_pthread.cpp', expected='0', args=['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1'])
 
   # Tests that rendering from client side memory without default-enabling extensions works.
   @requires_graphics_hardware
@@ -4114,7 +4114,7 @@ window.close = function() {
   @no_chrome('see #7374')
   def test_webgl_offscreen_canvas_in_proxied_pthread(self):
     for args in [[], ['-DTEST_OFFSCREEN_CANVAS=1'], ['-DTEST_OFFSCREEN_CANVAS=2']]:
-      cmd = args + ['-s', 'USE_PTHREADS=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'GL_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1']
+      cmd = args + ['-s', 'USE_PTHREADS=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'GL_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1']
       print(str(cmd))
       self.btest('gl_in_proxy_pthread.cpp', expected='1', args=cmd)
 
@@ -4124,7 +4124,7 @@ window.close = function() {
   def test_webgl_resize_offscreencanvas_from_main_thread(self):
     for args1 in [[], ['-s', 'PROXY_TO_PTHREAD=1']]:
       for args2 in [[], ['-DTEST_SYNC_BLOCKING_LOOP=1']]:
-        for args3 in [[], ['-s', 'OFFSCREENCANVAS_SUPPORT=1']]:
+        for args3 in [[], ['-s', 'OFFSCREENCANVAS_SUPPORT=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1']]:
           cmd = args1 + args2 + args3 + ['-s', 'USE_PTHREADS=1', '-lGL', '-s', 'GL_DEBUG=1', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1']
           print(str(cmd))
           self.btest('resize_offscreencanvas_from_main_thread.cpp', expected='1', args=cmd)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1683,9 +1683,14 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_glgears(self):
-    self.btest('hello_world_gles.c', reference='gears.png', reference_slack=3,
-               args=['-DHAVE_BUILTIN_SINCOS', '-lGL', '-lglut'], outfile='something.html',
-               message='You should see animating gears.')
+    def test(args):
+      self.btest('hello_world_gles.c', reference='gears.png', reference_slack=3,
+                 args=['-DHAVE_BUILTIN_SINCOS', '-lGL', '-lglut'] + args)
+    # test normally
+    test([])
+    # test that a program that doesn't use pthreads still works with with pthreads enabled
+    # (regression test for https://github.com/emscripten-core/emscripten/pull/8059#issuecomment-488105672)
+    test(['-s', 'USE_PTHREADS=1'])
 
   @requires_graphics_hardware
   def test_glgears_long(self):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -212,6 +212,14 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
       assert '-webgl2' not in libname
       return []
 
+  def gl_offscreen_flags(libname):
+    if shared.Settings.OFFSCREEN_FRAMEBUFFER:
+      assert '-ofb' in libname
+      return ['-D__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__']
+    else:
+      assert '-ofb' not in libname
+      return []
+
   # libc
   def create_libc(libname):
     logger.debug(' building libc for cache')
@@ -420,6 +428,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     flags += threading_flags(libname)
     flags += legacy_gl_emulation_flags(libname)
     flags += gl_version_flags(libname)
+    flags += gl_offscreen_flags(libname)
     return build_libc(libname, files, flags)
 
   # al
@@ -654,6 +663,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     gl_name += '-emu'
   if shared.Settings.USE_WEBGL2:
     gl_name += '-webgl2'
+  if shared.Settings.OFFSCREEN_FRAMEBUFFER:
+    gl_name += '-ofb'
   system_libs += [Library(gl_name,        ext, create_gl,          gl_symbols,          [libc_name],   False)] # noqa
 
   if shared.Settings.USE_PTHREADS:


### PR DESCRIPTION
This lets a program use pthreads, but *not* `OFFSCREEN_FRAMEBUFFER`, and still work. Otherwise, the proxying code would have been reached anyhow, in the case that the context was created from JS. With this PR, it's not even linked in.

Note that I had to change some tests for this - do those look right?