### PR TITLE
Rename legacy GL emulation related sloppy GL extension lookup functions

### DIFF
--- a/system/lib/gl/gl.c
+++ b/system/lib/gl/gl.c
@@ -1570,9 +1570,9 @@ GLAPI void APIENTRY emscripten_glGetInfoLog (GLhandleARB obj, GLsizei maxLength,
 GLAPI void APIENTRY emscripten_glBindProgram (GLenum target, GLuint program);
 
 extern void *emscripten_webgl1_get_proc_address(const char *name);
-extern void *emscripten_webgl1_ext_get_proc_address(const char *name);
+extern void *_webgl1_match_ext_proc_address_without_suffix(const char *name);
 extern void *emscripten_webgl2_get_proc_address(const char *name);
-extern void *emscripten_webgl2_ext_get_proc_address(const char *name);
+extern void *_webgl2_match_ext_proc_address_without_suffix(const char *name);
 
 #ifdef LEGACY_GL_EMULATION
 
@@ -1814,14 +1814,14 @@ void* emscripten_GetProcAddress(const char *name_) {
 
   void *ptr = emscripten_webgl1_get_proc_address(name);
 
-  if (!ptr) ptr = emscripten_webgl1_ext_get_proc_address(name);
+  if (!ptr) ptr = _webgl1_match_ext_proc_address_without_suffix(name);
 
 #if LEGACY_GL_EMULATION
   if (!ptr) ptr = emscripten_legacy_gl_emulation_GetProcAddress(name);
 #endif
 #if USE_WEBGL2
   if (!ptr) ptr = emscripten_webgl2_get_proc_address(name);
-  if (!ptr) ptr = emscripten_webgl2_ext_get_proc_address(name);
+  if (!ptr) ptr = _webgl2_match_ext_proc_address_without_suffix(name);
 #endif
 
   free(name);

--- a/system/lib/gl/webgl1.c
+++ b/system/lib/gl/webgl1.c
@@ -627,7 +627,10 @@ RET_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glGetQueryObjectui64vEXT, GLenum,
 
 #endif // ~__EMSCRIPTEN_PTHREADS__
 
-void *emscripten_webgl1_ext_get_proc_address(const char *name)
+// Returns a function pointer to the given WebGL 1 extension function, when queried without
+// a GL extension suffix such as "EXT", "OES", or "ANGLE". This function is used by
+// emscripten_GetProcAddress() to implement legacy GL emulation semantics for portability.
+void *_webgl1_match_ext_proc_address_without_suffix(const char *name)
 {
   RETURN_FN_WITH_SUFFIX(glGenQueries, EXT);
   RETURN_FN_WITH_SUFFIX(glDeleteQueries, EXT);

--- a/system/lib/gl/webgl2.c
+++ b/system/lib/gl/webgl2.c
@@ -147,7 +147,10 @@ GL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES(GLuint array) { return glIsV
 GL_APICALL void GL_APIENTRY glDrawBuffersEXT(GLsizei n, const GLenum *bufs) { glDrawBuffers(n, bufs); }
 GL_APICALL void GL_APIENTRY glDrawBuffersWEBGL(GLsizei n, const GLenum *bufs) { glDrawBuffers(n, bufs); }
 
-void *emscripten_webgl2_ext_get_proc_address(const char *name)
+// Returns a function pointer to the given WebGL 2 extension function, when queried without
+// a GL extension suffix such as "EXT", "OES", or "ANGLE". This function is used by
+// emscripten_GetProcAddress() to implement legacy GL emulation semantics for portability.
+void *_webgl2_match_ext_proc_address_without_suffix(const char *name)
 {
 	RETURN_FN_WITH_SUFFIX(glVertexAttribDivisor, EXT);
 	RETURN_FN_WITH_SUFFIX(glVertexAttribDivisor, ARB);


### PR DESCRIPTION
Rename legacy GL emulation related sloppy GL extension lookup functions to distance their usage from emscripten_webgl1/2_get_proc_address() functions.