### PR TITLE
Cleanup `build_library` test helper

### DIFF
--- a/tests/bullet/src/BulletMultiThreaded/GpuSoftBodySolvers/OpenCL/OpenCLC10/SolveCollisionsAndUpdateVelocities.cl
+++ b/tests/bullet/src/BulletMultiThreaded/GpuSoftBodySolvers/OpenCL/OpenCLC10/SolveCollisionsAndUpdateVelocities.cl
@@ -1,7 +1,5 @@
 MSTRINGIFY(
 
-#pragma OPENCL EXTENSION cl_amd_printf : enable\n
-
 float mydot3(float4 a, float4 b)
 {
    return a.x*b.x + a.y*b.y + a.z*b.z;


### PR DESCRIPTION
 - Use chdir context manager
- Remove used arguments
- Remove "build multiple times" loop.  It seems that its no longer
   needed.
    
This required a fix to the box2d build to remove an invalid pragma.
This file no longer exists in box2d upstream so it shouldn't be a
problem if we ever want to update.
