### PR TITLE
Show a clear error on -o pointing to an invalid directory. fixes #8549

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -717,17 +717,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   # specified_target is the user-specified one, target is what we will generate
   if specified_target:
     target = specified_target
-    # show a clear error if the user sets a specified target to something
-    # no-existing like NONEXISTENT_DIR/something. Python will give an error
-    # "no such file" when we try to write to that file, which can be
-    # confusing. worse, this will happen on the first file we try to write
-    # to, which may be one of the helper files (.wasm, .mem, etc.), which
-    # is even more confusing.
-    # (note that we must check that dirname is not the empty string - if the
-    # target is just a basename, then dirname is '', which os.path.exists would
-    # report as not existing)
+    # check for the existence of the output directory now, to avoid having
+    # to do so repeatedly when each of the various output files (.mem, .wasm,
+    # etc) are written. This gives a more useful error message than the
+    # IOError and python backtrace that users would otherwise see.
     dirname = os.path.dirname(target)
-    if dirname and not os.path.exists(dirname):
+    if dirname and not os.path.isdir(dirname):
       exit_with_error("specified output file (%s) is in a directory that does not exist" % target)
   else:
     target = 'a.out.js'

--- a/emcc.py
+++ b/emcc.py
@@ -723,7 +723,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # confusing. worse, this will happen on the first file we try to write
     # to, which may be one of the helper files (.wasm, .mem, etc.), which
     # is even more confusing.
-    if not os.path.exists(os.path.dirname(target)):
+    # (note that we must check that dirname is not the empty string - if the
+    # target is just a basename, then dirname is '', which os.path.exists would
+    # report as not existing)
+    dirname = os.path.dirname(target)
+    if dirname and not os.path.exists(dirname):
       exit_with_error("specified output file (%s) is in a directory that does not exist" % target)
   else:
     target = 'a.out.js'

--- a/emcc.py
+++ b/emcc.py
@@ -717,6 +717,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   # specified_target is the user-specified one, target is what we will generate
   if specified_target:
     target = specified_target
+    # show a clear error if the user sets a specified target to something
+    # no-existing like NONEXISTENT_DIR/something. Python will give an error
+    # "no such file" when we try to write to that file, which can be
+    # confusing. worse, this will happen on the first file we try to write
+    # to, which may be one of the helper files (.wasm, .mem, etc.), which
+    # is even more confusing.
+    if not os.path.exists(os.path.dirname(target)):
+      exit_with_error("specified output file (%s) is in a directory that does not exist" % target)
   else:
     target = 'a.out.js'
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7847,6 +7847,10 @@ int main() {
     ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM_MEM_MAX=33MB+1'])
     self.assertContained('WASM_MEM_MAX must be a multiple of 64KB', ret)
 
+  def test_invalid_output_dir(self):
+    ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('NONEXISTING_DIRECTORY', 'out.js')])
+    self.assertContained('specified output file (NONEXISTING_DIRECTORY%sout.js) is in a directory that does not exist' % os.path.sep, ret)
+
   @unittest.skipIf(SPIDERMONKEY_ENGINE not in JS_ENGINES, 'cannot run without spidermonkey')
   def test_binaryen_ctors(self):
     # ctor order must be identical to js builds, deterministically


### PR DESCRIPTION
Without this, Python will give an error "no such file" when we try to write to that file, which can be confusing. Worse, this will happen on the first file we try to write to, which may be one of the helper files (.wasm, .mem, etc.), which is even more confusing.