### PR TITLE
Don't run dlfcn tests on wasm2js

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -306,7 +306,7 @@ class RunnerCore(unittest.TestCase):
   def check_dlfcn(self):
     if self.get_setting('ALLOW_MEMORY_GROWTH') == 1 and not self.is_wasm():
       self.skipTest('no dlfcn with memory growth (without wasm)')
-    if self.get_setting('WASM2JS'):
+    if self.get_setting('WASM_BACKEND') and not self.get_setting('WASM'):
       self.skipTest('no dynamic library support in wasm2js yet')
 
   def uses_memory_init_file(self):


### PR DESCRIPTION
We don't run wasm2js* modes on the bots, but it does fix my local testing. Eventually we should enable those (maybe instead of some of the asmjs modes).