### PR TITLE
OffscreenCanvas: if OFFSCREEN_FRAMEBUFFER is off, we don't provide context creation code in C (it's only for GL proxying)

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2205,7 +2205,9 @@ var LibraryJSEvents = {
 
   _emscripten_webgl_power_preferences: "['default', 'low-power', 'high-performance']",
 
-#if !USE_PTHREADS
+// In offscreen framebuffer mode, we implement these functions in C so that they enable
+// the proxying of GL commands. Otherwise, they are implemented here in JS.
+#if !(USE_PTHREADS && OFFSCREEN_FRAMEBUFFER)
   emscripten_webgl_create_context__sig: 'iii',
   emscripten_webgl_create_context: 'emscripten_webgl_do_create_context',
 

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -813,7 +813,9 @@ int EMSCRIPTEN_KEEPALIVE proxy_main(int argc, char **argv)
     // If user has defined EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES, then transfer those canvases over to the pthread.
     emscripten_pthread_attr_settransferredcanvases(&attr, (EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES));
 #else
-    // Otherwise by default, transfer whatever is set to Module.canvas.
+    // Otherwise by default, transfer whatever is set to Module.canvas, because in PROXY_TO_PTHREAD
+    // mode this is the only chance - this is the only pthread_create call that happens on the
+    // main thread, so it's the only chance to transfer the canvas from there.
     if (EM_ASM_INT(return !!(Module['canvas']))) emscripten_pthread_attr_settransferredcanvases(&attr, "#canvas");
 #endif
     _main_arguments.argc = argc;


### PR DESCRIPTION
Also add a useful comment in related code.

cc @kenrussell