### PR TITLE
Fix SDL2 LTO

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -181,6 +181,7 @@ def main():
       arg = arg[2:]
       if arg == 'lto':
         shared.Settings.WASM_OBJECT_FILES = 0
+        os.environ['EMMAKEN_CFLAGS'] = '-s WASM_OBJECT_FILES=0'
       elif arg == 'pic':
         shared.Settings.RELOCATABLE = 1
       # Reconfigure the cache dir to reflect the change

--- a/embuilder.py
+++ b/embuilder.py
@@ -181,7 +181,6 @@ def main():
       arg = arg[2:]
       if arg == 'lto':
         shared.Settings.WASM_OBJECT_FILES = 0
-        os.environ['EMMAKEN_CFLAGS'] = '-s WASM_OBJECT_FILES=0'
       elif arg == 'pic':
         shared.Settings.RELOCATABLE = 1
       # Reconfigure the cache dir to reflect the change

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -27,8 +27,8 @@ def get(ports, settings, shared):
     try:
       os.chdir(build_dir)
       os.chmod(configure, os.stat(configure).st_mode | stat.S_IEXEC)
-      ports.run_commands([[shared.PYTHON, shared.EMCONFIGURE, configure, '--prefix=' + dist_dir] + formatflags + commonflags + ['CFLAGS=-s USE_VORBIS=1']])
-      ports.run_commands([[shared.PYTHON, shared.EMMAKE, 'make', 'install']])
+      shared.run_process([shared.PYTHON, shared.EMCONFIGURE, configure, '--prefix=' + dist_dir] + formatflags + commonflags + ['CFLAGS=-s USE_VORBIS=1'])
+      shared.run_process([shared.PYTHON, shared.EMMAKE, 'make', 'install'])
       shutil.copyfile(out, final)
     finally:
       os.chdir(cwd)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2001,6 +2001,8 @@ class Building(object):
             # If there are no archives then we can simply link all valid object
             # files and skip the symbol table stuff.
             actual_files.append(f)
+        else:
+          logging.debug('ignoring non-bitcode file for link: %s' % absolute_path_f)
       else:
         # Extract object files from ar archives, and link according to gnu ld semantics
         # (link in an entire .o from the archive if it supplies symbols still unresolved)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -42,7 +42,7 @@ def get_cflags(force_object_files=False):
 
 def run_build_command(cmd):
   # this must only be called on a standard build command
-  assert cmd[0] == shared.PYTHON and cmd[1] == shared.EMCC
+  assert cmd[0] == shared.PYTHON and cmd[1] in (shared.EMCC, shared.EMXX)
   # add standard cflags, but also allow the cmd to override them
   cmd = cmd[:2] + get_cflags() + cmd[2:]
   shared.run_process(cmd, stdout=stdout, stderr=stderr)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -24,24 +24,6 @@ stderr = None
 logger = logging.getLogger('system_libs')
 
 
-def call_process(cmd):
-  shared.run_process(cmd, stdout=stdout, stderr=stderr)
-
-
-def run_commands(commands):
-  cores = min(len(commands), shared.Building.get_num_cores())
-  if cores <= 1:
-    for command in commands:
-      call_process(command)
-  else:
-    pool = shared.Building.get_multiprocessing_pool()
-    # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
-    # https://bugs.python.org/issue8296
-    # 999999 seconds (about 11 days) is reasonably huge to not trigger actual timeout
-    # and is smaller than the maximum timeout value 4294967.0 for Python 3 on Windows (threading.TIMEOUT_MAX)
-    pool.map_async(call_process, commands, chunksize=1).get(999999)
-
-
 def files_in_path(path_components, filenames):
   srcdir = shared.path_from_root(*path_components)
   return [os.path.join(srcdir, f) for f in filenames]
@@ -56,6 +38,28 @@ def get_cflags(force_object_files=False):
   if shared.Settings.RELOCATABLE:
     flags += ['-s', 'RELOCATABLE']
   return flags
+
+
+def run_build_command(cmd):
+  # this must only be called on a standard build command
+  assert cmd[0] == shared.PYTHON and cmd[1] == shared.EMCC
+  # add standard cflags, but also allow the cmd to override them
+  cmd = cmd[:2] + get_cflags() + cmd[2:]
+  shared.run_process(cmd, stdout=stdout, stderr=stderr)
+
+
+def run_commands(commands):
+  cores = min(len(commands), shared.Building.get_num_cores())
+  if cores <= 1:
+    for command in commands:
+      run_build_command(command)
+  else:
+    pool = shared.Building.get_multiprocessing_pool()
+    # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
+    # https://bugs.python.org/issue8296
+    # 999999 seconds (about 11 days) is reasonably huge to not trigger actual timeout
+    # and is smaller than the maximum timeout value 4294967.0 for Python 3 on Windows (threading.TIMEOUT_MAX)
+    pool.map_async(run_build_command, commands, chunksize=1).get(999999)
 
 
 def create_lib(libname, inputs):
@@ -160,7 +164,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
               '-Wno-empty-body']
     for src in files:
       o = in_temp(os.path.basename(src) + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-o', o] + musl_internal_includes() + default_opts + c_opts + lib_opts + get_cflags())
+      commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-o', o] + musl_internal_includes() + default_opts + c_opts + lib_opts)
       o_s.append(o)
     run_commands(commands)
     create_lib(in_temp(lib_filename), o_s)
@@ -180,7 +184,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     for src in files:
       o = in_temp(src + '.o')
       srcfile = shared.path_from_root(src_dirname, src)
-      commands.append([shared.PYTHON, shared.EMXX, srcfile, '-o', o, '-std=c++11'] + opts + get_cflags())
+      commands.append([shared.PYTHON, shared.EMXX, srcfile, '-o', o, '-std=c++11'] + opts)
       o_s.append(o)
     run_commands(commands)
     create_lib(in_temp(lib_filename), o_s)
@@ -453,7 +457,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     commands = []
     for src in files:
       o = in_temp(os.path.basename(src) + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-O2', '-o', o] + get_cflags())
+      commands.append([shared.PYTHON, shared.EMCC, shared.path_from_root('system', 'lib', src), '-O2', '-o', o])
       o_s.append(o)
     run_commands(commands)
     shared.Building.emar('cr', in_temp(libname), o_s)
@@ -824,7 +828,7 @@ class Ports(object):
     objects = []
     for src in srcs:
       obj = src + '.o'
-      commands.append([shared.PYTHON, shared.EMCC, '-c', src, '-O2', '-o', obj, '-w'] + include_commands + flags + get_cflags())
+      commands.append([shared.PYTHON, shared.EMCC, '-c', src, '-O2', '-o', obj, '-w'] + include_commands + flags)
       objects.append(obj)
 
     run_commands(commands)


### PR DESCRIPTION
Refactor `system_libs/run_build_command()` to add cflags. This lets all the users of that code, which includes ports, automatically get cflags properly. (The issue here was the cflag for WASM_OBJECT_FILES being 0 for lto).

This allows some cleanup and removal of other cflags additions that are no longer needed - one only needs to add cflags in system_libs and in ports if one does not call `run_build_command`.

Also fix the sdl2_mixer port, which used `ports.run_commands` to run a single command ( so no need for using a worker pool), and which is not even an emcc build command. Just use `run_process` there normally.