### PR TITLE
Update expectations for test_binaryen_metadce_hello under wasm backend

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7919,7 +7919,7 @@ int main() {
       run(['-O3', '-s', 'MAIN_MODULE=1'],
                  1581, [],        [],      517336, 172,1484, None) # noqa
       run(['-O3', '-s', 'MAIN_MODULE=2'],
-                   15, [],        [],      10770,   18,  13, None) # noqa
+                   15, [],        [],      10770,   17,  13, None) # noqa
     else:
       run([],      23, ['abort'], ['waka'], 42701,  24,   17, 57) # noqa
       run(['-O1'], 15, ['abort'], ['waka'], 13199,  15,   14, 33) # noqa

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7917,9 +7917,9 @@ int main() {
       # TODO(sbc): Investivate why the number of exports is order of magnitude
       # larger for wasm backend.
       run(['-O3', '-s', 'MAIN_MODULE=1'],
-                 1576, [],        [],      517336, 167,1484, None) # noqa
+                 1581, [],        [],      517336, 172,1484, None) # noqa
       run(['-O3', '-s', 'MAIN_MODULE=2'],
-                 13,   [],        [],      10770,   16,  13, None) # noqa
+                   15, [],        [],      10770,   18,  13, None) # noqa
     else:
       run([],      23, ['abort'], ['waka'], 42701,  24,   17, 57) # noqa
       run(['-O1'], 15, ['abort'], ['waka'], 13199,  15,   14, 33) # noqa


### PR DESCRIPTION
Update expectations for test_binaryen_metadce_hello under wasm backend
    
This change is caused by the upstream llvm change: https://reviews.llvm.org/D61772

This change won't pass emscripten CI because it relies on the waterfall LKGR which
needs to update first.
