### PR TITLE
Update binaryen to version_84

### DIFF
--- a/tools/ports/binaryen.py
+++ b/tools/ports/binaryen.py
@@ -6,7 +6,7 @@
 import os
 import logging
 
-TAG = 'version_83'
+TAG = 'version_84'
 
 
 def needed(settings, shared, ports):


### PR DESCRIPTION
This is needed to fix test_dylink_raii_exceptions on the waterfall.
