### PR TITLE
Allow wasm object files as input, even when WASM_OBJECT_FILES=0 is set

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -879,9 +879,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             has_header_inputs = True
           elif file_suffix.endswith(ASSEMBLY_ENDINGS) or shared.Building.is_bitcode(arg) or shared.Building.is_ar(arg):
             input_files.append((i, arg))
-          elif 'WASM_OBJECT_FILES=0' not in settings_changes and shared.Building.is_wasm(arg):
-            # this is before libraries, since wasm static libraries (wasm.so that contains wasm) are just
-            # object files to be linked
+          elif shared.Building.is_wasm(arg):
+            if not shared.Settings.WASM_BACKEND:
+              exit_with_error('fastcomp is not compatible with wasm object files:' + arg)
             input_files.append((i, arg))
           elif file_suffix.endswith(STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS):
             # if it's not, and it's a library, just add it to libs to find later

--- a/src/settings.js
+++ b/src/settings.js
@@ -979,6 +979,8 @@ var WASM_BACKEND = 0;
 
 // Whether to compile object files as wasm as opposed to the default
 // of using LLVM IR.
+// Setting to zero will enable LTO and at link time will also enable bitcode
+// versions of the standard libraries.
 var WASM_OBJECT_FILES = 1;
 
 // An optional comma-separated list of script hooks to run after binaryen,


### PR DESCRIPTION
Specifying WASM_OBJECT_FILES=0 on the link line is current needed if
one want to select LTO libraries.  However this should not exclude
some input being wasm object files.

Fixes #8599

