### PR TITLE
Add python3 version check

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -23,7 +23,11 @@ import sys
 import tempfile
 
 if sys.version_info < (2, 7, 12):
-  print('emscripten required python 2.7.12 or above', file=sys.stderr)
+  print('emscripten requires python 2.7.12 or above', file=sys.stderr)
+  sys.exit(1)
+
+if sys.version_info[0] == 3 and sys.version_info < (3, 5):
+  print('emscripten requires either python 3.5 or above or 2.7.12 or above)', file=sys.stderr)
   sys.exit(1)
 
 from .toolchain_profiler import ToolchainProfiler

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -27,7 +27,7 @@ if sys.version_info < (2, 7, 12):
   sys.exit(1)
 
 if sys.version_info[0] == 3 and sys.version_info < (3, 5):
-  print('emscripten requires either python 3.5 or above or 2.7.12 or above)', file=sys.stderr)
+  print('emscripten requires at least python 3.5 (or python 2.7.12)', file=sys.stderr)
   sys.exit(1)
 
 from .toolchain_profiler import ToolchainProfiler


### PR DESCRIPTION
Turns out we can't run on 3.4 or below due to circular dependencies
not working until 3.5.

See https://www.quora.com/Are-circular-dependencies-allowed-in-python-3-5-but-not-in-3-4

Fixes: #8570