### PR TITLE
Remove .commit() from OffscreenCanvas support

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2418,19 +2418,15 @@ var LibraryJSEvents = {
       return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
     }
 #endif
-    if (!GL.currentContext.GLctx.commit) {
-#if GL_DEBUG
-      console.error('emscripten_webgl_commit_frame() failed: OffscreenCanvas is not supported by the current GL context!');
-#endif
-      return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
-    }
     if (!GL.currentContext.attributes.explicitSwapControl) {
 #if GL_DEBUG
       console.error('emscripten_webgl_commit_frame() cannot be called for canvases with implicit swap control mode!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
-    GL.currentContext.GLctx.commit();
+    // We would do GL.currentContext.GLctx.commit(); here, but the current implementation
+    // in browsers has removed it - swap is implicit, so this function is a no-op for now
+    // (until/unless the spec changes).
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 


### PR DESCRIPTION
I thought we already removed it, but apparently not completely...

This should fix current CI breakage on two OffscreenCanvas tests.

Oddly this problem happens on the bots and on my desktop, but *not* on my laptop - both running the exact same chrome, same flags. Very odd (my `chrome://version` does show differences in `Variations`, hmm...).

Another difference I see between the two machines: on the laptop, the tests (`test_webgl_offscreen_canvas_in_proxied_pthread, test_webgl_offscreen_canvas_only_in_pthread`) make the canvas turn red gradually properly, and on the other, it just snaps to red at the end, like it's not rendering as many intermediate frames. (The test passes regardless though...)

cc @kenrussell @kainino0x 