### PR TITLE
Strip out trailing zeros from the mem init file. 

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2309,6 +2309,19 @@ def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
     debug_copy(wasm + '.map', 'post_finalize.map')
   debug_copy(wasm, 'post_finalize.wasm')
 
+  if not shared.Settings.MEM_INIT_IN_WASM:
+    # we have a separate .mem file. binaryen did not strip any trailing zeros,
+    # because it's an ABI question as to whether it is valid to do so or not.
+    # we can do so here, since we make sure to zero out that memory (even in
+    # the dynamic linking case, our loader zeros it out)
+    with open(memfile, 'rb') as f:
+      mem_data = f.read()
+    end = len(mem_data)
+    while end > 0 and (mem_data[end - 1] == b'\0' or mem_data[end - 1] == 0):
+      end -= 1
+    with open(memfile, 'wb') as f:
+      f.write(mem_data[:end])
+
   return load_metadata_wasm(stdout, DEBUG)
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -2246,6 +2246,16 @@ def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
   outfile.close()
 
 
+def remove_trailing_zeros(memfile):
+  with open(memfile, 'rb') as f:
+    mem_data = f.read()
+  end = len(mem_data)
+  while end > 0 and (mem_data[end - 1] == b'\0' or mem_data[end - 1] == 0):
+    end -= 1
+  with open(memfile, 'wb') as f:
+    f.write(mem_data[:end])
+
+
 def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
   wasm_emscripten_finalize = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-emscripten-finalize')
   wasm_dis = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-dis')
@@ -2314,13 +2324,7 @@ def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
     # because it's an ABI question as to whether it is valid to do so or not.
     # we can do so here, since we make sure to zero out that memory (even in
     # the dynamic linking case, our loader zeros it out)
-    with open(memfile, 'rb') as f:
-      mem_data = f.read()
-    end = len(mem_data)
-    while end > 0 and (mem_data[end - 1] == b'\0' or mem_data[end - 1] == 0):
-      end -= 1
-    with open(memfile, 'wb') as f:
-      f.write(mem_data[:end])
+    remove_trailing_zeros(memfile)
 
   return load_metadata_wasm(stdout, DEBUG)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7368,6 +7368,9 @@ extern "C" {
     expect_memory_init_file = self.uses_memory_init_file()
     see_memory_init_file = os.path.exists('src.c.o.js.mem')
     assert expect_memory_init_file == see_memory_init_file, 'memory init file expectation wrong: %s' % expect_memory_init_file
+    if see_memory_init_file:
+      with open('src.c.o.js.mem', 'rb') as f:
+        self.assertTrue(f.read()[-1] != b'\0')
 
   def test_cxx_self_assign(self):
     # See https://github.com/emscripten-core/emscripten/pull/2688 and http://llvm.org/bugs/show_bug.cgi?id=18735


### PR DESCRIPTION
This helps wasm2js and pthreads currently, as those modes use a mem file.
