### PR TITLE
Fix the dodgy call_sync_on_main_thread tests

### DIFF
--- a/tests/pthread/call_sync_on_main_thread.c
+++ b/tests/pthread/call_sync_on_main_thread.c
@@ -9,7 +9,7 @@
 #include <assert.h>
 #include <string.h>
 
-extern void getDomElementInnerHTML(const char *domElement, char *dst, int size);
+extern void getDomElementParentInnerHTML(const char *domElement, char *dst, int size);
 extern int isThisInWorker(void);
 extern int isThisInWorkerOnMainThread(void);
 extern int receivesAndReturnsAnInteger(int i);
@@ -21,7 +21,7 @@ int main()
 {
 	char dst[256];
 	char name[7] = "resize";
-	getDomElementInnerHTML(name, dst, sizeof(dst));
+	getDomElementParentInnerHTML(name, dst, sizeof(dst));
 	memset(name, 0, sizeof(name)); // Try to uncover if there might be a race condition and above line was not synchronously processed, and we could take name string away.
 	int inWorker1 = isThisInWorker(); // Build this application with -s USE_PTHREADS=1 -s PROXY_TO_PTHREAD=1 for this to return 1, otherwise returns 0.
 	int inWorker2 = isThisInWorkerOnMainThread(); // This should always return 0

--- a/tests/pthread/call_sync_on_main_thread.c
+++ b/tests/pthread/call_sync_on_main_thread.c
@@ -27,7 +27,7 @@ int main()
 	int inWorker2 = isThisInWorkerOnMainThread(); // This should always return 0
 	int returnedInt = receivesAndReturnsAnInteger(4);
 	printf("text: \"%s\". inWorker1: %d, inWorker2: %d, returnedInt: %d\n", dst, inWorker1, inWorker2, returnedInt);
-	assert(!strstr(dst, "Resize canvas"));
+	assert(strstr(dst, "Resize canvas"));
 	assert(inWorker1 == PROXY_TO_PTHREAD);
 	assert(inWorker2 == 0);
 	assert(returnedInt == 42 + 4);

--- a/tests/pthread/call_sync_on_main_thread.js
+++ b/tests/pthread/call_sync_on_main_thread.js
@@ -6,7 +6,7 @@ mergeInto(LibraryManager.library, {
   getDomElementInnerHTML__sig: 'viii',
   getDomElementInnerHTML: function(domElementId, dst, size) {
     var id = UTF8ToString(domElementId);
-    var text = document.getElementById(id).innerHTML;
+    var text = document.getElementById(id).parentElement.innerHTML;
     stringToUTF8(text, dst, size);
   },
 

--- a/tests/pthread/call_sync_on_main_thread.js
+++ b/tests/pthread/call_sync_on_main_thread.js
@@ -2,9 +2,9 @@ mergeInto(LibraryManager.library, {
   // Test accessing a DOM element on the main thread.
   // This function returns the inner text of the div by ID "status"
   // Because it accesses the DOM, it must be called on the main thread.
-  getDomElementInnerHTML__proxy: 'sync',
-  getDomElementInnerHTML__sig: 'viii',
-  getDomElementInnerHTML: function(domElementId, dst, size) {
+  getDomElementParentInnerHTML__proxy: 'sync',
+  getDomElementParentInnerHTML__sig: 'viii',
+  getDomElementParentInnerHTML: function(domElementId, dst, size) {
     var id = UTF8ToString(domElementId);
     var text = document.getElementById(id).parentElement.innerHTML;
     stringToUTF8(text, dst, size);


### PR DESCRIPTION
Previously these tests weren't actually checking the right thing. This should fix the logic to what I think the author was trying to do.
Fixes #8620.