### PR TITLE
Improve error messages around missing llvm install

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -514,6 +514,7 @@ fi
     # Changing LLVM_ROOT, even without altering .emscripten, clears the cache
     self.ensure_cache()
     make_fake_clang(path_from_root('tests', 'fake', 'bin', 'clang'), expected_llvm_version())
+    make_fake_llc(path_from_root('tests', 'fake', 'bin', 'llc'), 'js - JavaScript (asm.js, emscripten)')
     with env_modify({'LLVM': path_from_root('tests', 'fake', 'bin')}):
       self.assertTrue(os.path.exists(Cache.dirname))
       output = self.do([PYTHON, EMCC])

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -403,6 +403,8 @@ def expected_llvm_version():
 def get_clang_version():
   global actual_clang_version
   if actual_clang_version is None:
+    if not os.path.exists(CLANG):
+      exit_with_error('clang executable not found at `%s`' % CLANG)
     proc = check_call([CLANG, '--version'], stdout=PIPE)
     m = re.search(r'[Vv]ersion\s+(\d+\.\d+)', proc.stdout)
     actual_clang_version = m and m.group(1)
@@ -419,6 +421,8 @@ def check_llvm_version():
 
 
 def get_llc_targets():
+  if not os.path.exists(LLVM_COMPILER):
+    exit_with_error('llc exectuable not found at `%s`' % LLVM_COMPILER)
   try:
     llc_version_info = run_process([LLVM_COMPILER, '--version'], stdout=PIPE).stdout
   except Exception as e:


### PR DESCRIPTION
We have a few bugs recently where python was throwing a somewhat cryptic error when llvm
was missing.