### PR TITLE
Do not set mediump precision on vertex shaders

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -363,7 +363,6 @@ var LibraryGLEmulation = {
             source = 'varying float v_fogFragCoord;   \n' +
                      source.replace(/gl_FogFragCoord/g, 'v_fogFragCoord');
           }
-          source = ensurePrecision(source);
         } else { // Fragment shader
           for (i = 0; i < GLImmediate.MAX_TEXTURES; i++) {
             old = source;


### PR DESCRIPTION
vertex shaders in webgl default to highp

#8627