### PR TITLE
Adding proper fsync errors signaling for pipes.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -403,3 +403,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Simon Cooper <simon.d.cooper@hotmail.co.uk>
 * Amir Rasouli <arasouli91@gmail.com>
 * Nico Weber <thakis@chromium.org>
+* Adam Bujalski <a.bujalski@samsung.com> (copyright owner by Samsung Electronics)

--- a/src/library_pipefs.js
+++ b/src/library_pipefs.js
@@ -79,6 +79,9 @@ mergeInto(LibraryManager.library, {
       ioctl: function (stream, request, varargs) {
         return ERRNO_CODES.EINVAL;
       },
+      fsync: function (stream) {
+        return ERRNO_CODES.EINVAL;
+      },
       read: function (stream, buffer, offset, length, position /* ignored */) {
         var pipe = stream.node.pipe;
         var currentLength = 0;

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -710,6 +710,9 @@ var SyscallsLibrary = {
       });
     });
 #else
+    if (stream.stream_ops.fsync) {
+        return -stream.stream_ops.fsync(stream);
+    }
     return 0; // we can't do anything synchronously; the in-memory FS is already synced to
 #endif
   },


### PR DESCRIPTION
This change sets properly errno flag for fsync function called on fd representing pipe.

This change fixes http://posixtest.sourceforge.net/ fsync/7-1 test.