### PR TITLE
use highp in fragment shader if possible

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -285,7 +285,7 @@ var LibraryGLEmulation = {
 
       function ensurePrecision(source) {
         if (!/precision +(low|medium|high)p +float *;/.test(source)) {
-          source = 'precision mediump float;\n' + source;
+          source = '#ifdef GL_FRAGMENT_PRECISION_HIGH\nprecision highp float;\n#else\nprecision mediump float;\n#endif\n' + source;
         }
         return source;
       }


### PR DESCRIPTION
using mediump in a fragment shader will often break lighting, especially specular
calculations which often use the world or view space of lights relative to the eye
which is almost always larger than mediump can handle
