### PR TITLE
Don't try to handle complex things in dynamicAlloc, abort() on errors

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -639,7 +639,6 @@ var DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = [
 	'malloc',
 	'free',
 	'emscripten_get_heap_size', // Used by dynamicAlloc() and -s FETCH=1
-	'emscripten_resize_heap' // Used by dynamicAlloc() and -s FETCH=1
 	];
 
 // This list is also used to determine auto-exporting of library dependencies

--- a/src/support.js
+++ b/src/support.js
@@ -28,16 +28,12 @@ function dynamicAlloc(size) {
 #endif
   var ret = HEAP32[DYNAMICTOP_PTR>>2];
   var end = (ret + size + 15) & -16;
-  if (end <= _emscripten_get_heap_size()) {
-    HEAP32[DYNAMICTOP_PTR>>2] = end;
-  } else {
-#if ALLOW_MEMORY_GROWTH
-    var success = _emscripten_resize_heap(end);
-    if (!success) return 0;
-#else
+  if (end > _emscripten_get_heap_size()) {
+    // dynamicAlloc does not support memory growth - call malloc/sbrk
+    // normally for that
     return 0;
-#endif
   }
+  HEAP32[DYNAMICTOP_PTR>>2] = end;
   return ret;
 }
 

--- a/src/support.js
+++ b/src/support.js
@@ -29,9 +29,11 @@ function dynamicAlloc(size) {
   var ret = HEAP32[DYNAMICTOP_PTR>>2];
   var end = (ret + size + 15) & -16;
   if (end > _emscripten_get_heap_size()) {
-    // dynamicAlloc does not support memory growth - call malloc/sbrk
-    // normally for that
-    return 0;
+#if ASSERTIONS
+    abort('failure to dynamicAlloc - memory growth etc. is not supported there, call malloc/sbrk directly');
+#else
+    abort();
+#endif
   }
   HEAP32[DYNAMICTOP_PTR>>2] = end;
   return ret;


### PR DESCRIPTION
We only use this in JS during startup (before compiled code is ready to run). Other usages should call malloc/sbrk directly for the full functionality.

Fixes #8637 