### PR TITLE
Fix undefined behavior in skinning benchmark

### DIFF
--- a/tests/skinning_test_no_simd.cpp
+++ b/tests/skinning_test_no_simd.cpp
@@ -211,5 +211,7 @@ int main(int argc, char **argv) {
   }
 
   printf("blah=%f\n", sum);
+
+  return 0;
 }
 


### PR DESCRIPTION
This actually leads to the wasm backend emitting an unreachable there, which crashes the benchmark at the very end, and can cause a misreporting of the time.