### PR TITLE
Added parameterized test support and use it for metadce

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -295,7 +295,7 @@ class RunnerMeta(type):
       return func(self, *args, **kwargs)
     resulting_test.__name__ = '%s_%s' % (name, suffix)
     if hasattr(func, '__qualname__'):
-      resulting_test.__qualname__ = '%s_%s' % (func.__qualname__, name)
+      resulting_test.__qualname__ = '%s_%s' % (func.__qualname__, suffix)
     return resulting_test.__name__, resulting_test
 
   def __new__(mcs, name, bases, attrs):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -319,7 +319,7 @@ class RunnerMeta(type):
     :returns: a tuple of (new_function_name, new_function_object)
     """
 
-    # Create the new test function. It calls the original function with the specified args and kwargs.
+    # Create the new test function. It calls the original function with the specified args.
     # We use @functools.wraps to copy over all the function attributes.
     @wraps(func)
     def resulting_test(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -33,7 +33,7 @@ from tools.shared import CLANG, CLANG_CC, CLANG_CPP, LLVM_AR
 from tools.shared import COMPILER_ENGINE, NODE_JS, SPIDERMONKEY_ENGINE, JS_ENGINES, V8_ENGINE
 from tools.shared import WebAssembly
 from runner import RunnerCore, path_from_root, no_wasm_backend, no_fastcomp, is_slow_test
-from runner import needs_dlfcn, env_modify, no_windows, chdir, with_env_modify, create_test_file
+from runner import needs_dlfcn, env_modify, no_windows, chdir, with_env_modify, create_test_file, parameterized
 from tools import jsrun, shared
 import tools.line_endings
 import tools.js_optimizer
@@ -120,6 +120,25 @@ def get_fastcomp_src_dir():
     else:
       d = os.path.dirname(d)
   return None
+
+
+def metadce_args_to_filename(args):
+  result = ''
+  for a in args:
+    if a == '-s':
+      continue
+    a = a.replace('-', '')
+    a = a.replace('=1', '')
+    a = a.replace('=[]', '_NONE')
+    a = a.replace('=', '_')
+    if a:
+      result += '_' + a
+
+  return result
+
+
+def parameterize_metadce(parameters):
+  return parameterized((metadce_args_to_filename(args[0]), args) for args in parameters)
 
 
 class other(RunnerCore):
@@ -7857,27 +7876,10 @@ int main() {
     print('Running metadce test: %s:' % filename, args, expected_sent, expected_exists, expected_not_exists, expected_size, expected_imports, expected_exports, expected_funcs)
     filename = path_from_root('tests', 'other', 'metadce', filename)
 
-    def clean_arg(arg):
-      return arg.replace('-', '')
-
-    def args_to_filename(args):
-      result = ''
-      for a in args:
-        if a == '-s':
-          continue
-        a = a.replace('-', '')
-        a = a.replace('=1', '')
-        a = a.replace('=[]', '_NONE')
-        a = a.replace('=', '_')
-        if a:
-          result += '_' + a
-
-      return result
-
     expected_basename = os.path.splitext(filename)[0]
     if not self.is_wasm_backend():
       expected_basename += '_fastcomp'
-    expected_basename += args_to_filename(args)
+    expected_basename += metadce_args_to_filename(args)
 
     run_process([PYTHON, EMCC, filename, '-g2'] + args)
     # find the imports we send from JS
@@ -7914,77 +7916,90 @@ int main() {
     if expected_funcs is not None:
       self.assertEqual(funcs, expected_funcs)
 
-  def test_binaryen_metadce_minimal(self):
-    def run(*args):
-      self.run_metadce_test('minimal.c', *args)
-
-    if self.is_wasm_backend():
-      run([],      11, [], ['waka'],  9211,  5, 13, 16) # noqa
-      run(['-O1'],  9, [], ['waka'],  7886,  2, 12, 10) # noqa
-      run(['-O2'],  9, [], ['waka'],  7871,  2, 12, 10) # noqa
+  @parameterize_metadce([
+    ([],      11, [], ['waka'],  9211,  5, 13, 16), # noqa
+    (['-O1'],  9, [], ['waka'],  7886,  2, 12, 10), # noqa
+    (['-O2'],  9, [], ['waka'],  7871,  2, 12, 10), # noqa
       # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-      run(['-O3'],  0, [], [],          85,  0,  2,  2) # noqa
-      run(['-Os'],  0, [], [],          85,  0,  2,  2) # noqa
-      run(['-Oz'],  0, [], [],          54,  0,  1,  1) # noqa
-    else:
-      run([],      21, ['abort'], ['waka'], 22712, 22, 15, 30) # noqa
-      run(['-O1'], 10, ['abort'], ['waka'], 10450,  7, 11, 11) # noqa
-      run(['-O2'], 10, ['abort'], ['waka'], 10440,  7, 11, 11) # noqa
-      # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-      run(['-O3'],  0, [],        [],          55,  0,  1, 1) # noqa
-      run(['-Os'],  0, [],        [],          55,  0,  1, 1) # noqa
-      run(['-Oz'],  0, [],        [],          55,  0,  1, 1) # noqa
+    (['-O3'],  0, [], [],          85,  0,  2,  2), # noqa
+    (['-Os'],  0, [], [],          85,  0,  2,  2), # noqa
+    (['-Oz'],  0, [], [],          54,  0,  1,  1), # noqa
+  ])
+  @no_fastcomp()
+  def test_binaryen_metadce_minimal(self, *args):
+    self.run_metadce_test('minimal.c', *args)
 
+  @parameterize_metadce([
+    ([],      21, ['abort'], ['waka'], 22712, 22, 15, 30), # noqa
+    (['-O1'], 10, ['abort'], ['waka'], 10450,  7, 11, 11), # noqa
+    (['-O2'], 10, ['abort'], ['waka'], 10440,  7, 11, 11), # noqa
+    # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
+    (['-O3'],  0, [],        [],          55,  0,  1, 1), # noqa
+    (['-Os'],  0, [],        [],          55,  0,  1, 1), # noqa
+    (['-Oz'],  0, [],        [],          55,  0,  1, 1), # noqa
+  ])
+  @no_wasm_backend()
+  def test_binaryen_metadce_minimal_fastcomp(self, *args):
+    self.run_metadce_test('minimal.c', *args)
+
+  @no_fastcomp()
   def test_binaryen_metadce_cxx(self):
-    def run(*args):
-      self.run_metadce_test('hello_libcxx.cpp', *args)
-
     # test on libc++: see effects of emulated function pointers
-    if self.is_wasm_backend():
-      run(['-O2'], 33, [], ['waka'], 226582,  21,  35, 562) # noqa
-    else:
-      run(['-O2'], 34, ['abort'], ['waka'], 186423,  29,  38, 539) # noqa
-      run(['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                   34, ['abort'], ['waka'], 186423,  29,  39, 519) # noqa
+    self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  35, 562) # noqa
 
-  def test_binaryen_metadce_hello(self):
-    def run(*args):
-      self.run_metadce_test('hello_world.cpp', *args)
+  @parameterize_metadce([
+    (['-O2'], 34, ['abort'], ['waka'], 186423,  29,  38, 539), # noqa
+    (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
+              34, ['abort'], ['waka'], 186423,  29,  39, 519), # noqa
+  ])
+  @no_wasm_backend()
+  def test_binaryen_metadce_cxx_fastcomp(self, *args):
+    # test on libc++: see effects of emulated function pointers
+    self.run_metadce_test('hello_libcxx.cpp', *args)
 
-    if self.is_wasm_backend():
-      run([],      17, [], ['waka'], 22185, 11,  18, 57) # noqa
-      run(['-O1'], 15, [], ['waka'], 10415,  9,  15, 31) # noqa
-      run(['-O2'], 15, [], ['waka'], 10183,  9,  15, 25) # noqa
-      run(['-O3'],  5, [], [],        2353,  7,   3, 14) # noqa; in -O3, -Os and -Oz we metadce
-      run(['-Os'],  5, [], [],        2310,  7,   3, 15) # noqa
-      run(['-Oz'],  5, [], [],        2272,  7,   2, 14) # noqa
-      # finally, check what happens when we export nothing. wasm should be almost empty
-      run(['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                    0, [], [],          61,  0,   1,  1) # noqa
-      # we don't metadce with linkable code! other modules may want stuff
-      # don't compare the # of functions in a main module, which changes a lot
-      # TODO(sbc): Investivate why the number of exports is order of magnitude
-      # larger for wasm backend.
-      run(['-O3', '-s', 'MAIN_MODULE=1'],
-                 1581, [],        [],      517336, 172,1484, None) # noqa
-      run(['-O3', '-s', 'MAIN_MODULE=2'],
-                   15, [],        [],      10770,   17,  13, None) # noqa
-    else:
-      run([],      23, ['abort'], ['waka'], 42701,  24,   17, 57) # noqa
-      run(['-O1'], 15, ['abort'], ['waka'], 13199,  15,   14, 33) # noqa
-      run(['-O2'], 15, ['abort'], ['waka'], 12425,  15,   14, 28) # noqa
-      run(['-O3'],  6, [],        [],        2443,   9,    2, 15) # noqa; in -O3, -Os and -Oz we metadce
-      run(['-Os'],  6, [],        [],        2412,   9,    2, 17) # noqa
-      run(['-Oz'],  6, [],        [],        2389,   9,    2, 16) # noqa
-      # finally, check what happens when we export nothing. wasm should be almost empty
-      run(['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                    0, [],        [],           8,   0,    0,  0) # noqa; totally empty!
-      # we don't metadce with linkable code! other modules may want stuff
-      # don't compare the # of functions in a main module, which changes a lot
-      run(['-O3', '-s', 'MAIN_MODULE=1'],
-                 1543, [],        [],      226403,  30,   95, None) # noqa
-      run(['-O3', '-s', 'MAIN_MODULE=2'],
-                   15, [],        [],       10571,  19,    9, 21) # noqa
+  @parameterize_metadce([
+    ([],      17, [], ['waka'], 22185, 11,  18, 57), # noqa
+    (['-O1'], 15, [], ['waka'], 10415,  9,  15, 31), # noqa
+    (['-O2'], 15, [], ['waka'], 10183,  9,  15, 25), # noqa
+    (['-O3'],  5, [], [],        2353,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
+    (['-Os'],  5, [], [],        2310,  7,   3, 15), # noqa
+    (['-Oz'],  5, [], [],        2272,  7,   2, 14), # noqa
+    # finally, check what happens when we export nothing. wasm should be almost empty
+    (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
+               0, [], [],          61,  0,   1,  1), # noqa
+    # we don't metadce with linkable code! other modules may want stuff
+    # don't compare the # of functions in a main module, which changes a lot
+    # TODO(sbc): Investivate why the number of exports is order of magnitude
+    # larger for wasm backend.
+    (['-O3', '-s', 'MAIN_MODULE=1'],
+            1581, [],        [],      517336, 172,1484, None), # noqa
+    (['-O3', '-s', 'MAIN_MODULE=2'],
+              15, [],        [],      10770,   17,  13, None), # noqa
+  ])
+  @no_fastcomp()
+  def test_binaryen_metadce_hello(self, *args):
+    self.run_metadce_test('hello_world.cpp', *args)
+
+  @parameterize_metadce([
+    ([],      23, ['abort'], ['waka'], 42701,  24,   17, 57), # noqa
+    (['-O1'], 15, ['abort'], ['waka'], 13199,  15,   14, 33), # noqa
+    (['-O2'], 15, ['abort'], ['waka'], 12425,  15,   14, 28), # noqa
+    (['-O3'],  6, [],        [],        2443,   9,    2, 15), # noqa; in -O3, -Os and -Oz we metadce
+    (['-Os'],  6, [],        [],        2412,   9,    2, 17), # noqa
+    (['-Oz'],  6, [],        [],        2389,   9,    2, 16), # noqa
+    # finally, check what happens when we export nothing. wasm should be almost empty
+    (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
+               0, [],        [],           8,   0,    0,  0), # noqa; totally empty!
+    # we don't metadce with linkable code! other modules may want stuff
+    # don't compare the # of functions in a main module, which changes a lot
+    (['-O3', '-s', 'MAIN_MODULE=1'],
+            1543, [],        [],      226403,  30,   95, None), # noqa
+    (['-O3', '-s', 'MAIN_MODULE=2'],
+              15, [],        [],       10571,  19,    9, 21), # noqa
+  ])
+  @no_wasm_backend()
+  def test_binaryen_metadce_hello_fastcomp(self, *args):
+    self.run_metadce_test('hello_world.cpp', *args)
 
   # ensures runtime exports work, even with metadce
   def test_extra_runtime_exports(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7964,7 +7964,7 @@ int main() {
     ('Os', (['-Os'],  5, [], [],        2310,  7,   3, 15)), # noqa
     ('Oz', (['-Oz'],  5, [], [],        2272,  7,   2, 14)), # noqa
     # finally, check what happens when we export nothing. wasm should be almost empty
-    ('export_nothing', 
+    ('export_nothing',
            (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                       0, [], [],          61,  0,   1,  1)), # noqa
     # we don't metadce with linkable code! other modules may want stuff

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7924,8 +7924,8 @@ int main() {
     'Oz': (['-Oz'],  0, [], [],          54,  0,  1,  1), # noqa
   })
   @no_fastcomp()
-  def test_binaryen_metadce_minimal(self, args, sent, exists, not_exists, size, imports, exports, funcs):
-    self.run_metadce_test('minimal.c', args, sent, exists, not_exists, size, imports, exports, funcs)
+  def test_binaryen_metadce_minimal(self, *args):
+    self.run_metadce_test('minimal.c', *args)
 
   @parameterized({
     'O0': ([],      21, ['abort'], ['waka'], 22712, 22, 15, 30), # noqa
@@ -7937,8 +7937,8 @@ int main() {
     'Oz': (['-Oz'],  0, [],        [],          55,  0,  1, 1), # noqa
   })
   @no_wasm_backend()
-  def test_binaryen_metadce_minimal_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
-    self.run_metadce_test('minimal.c', args, sent, exists, not_exists, size, imports, exports, funcs)
+  def test_binaryen_metadce_minimal_fastcomp(self, *args):
+    self.run_metadce_test('minimal.c', *args)
 
   @no_fastcomp()
   def test_binaryen_metadce_cxx(self):
@@ -7952,9 +7952,9 @@ int main() {
                         34, ['abort'], ['waka'], 186423,  29,  39, 519), # noqa
   })
   @no_wasm_backend()
-  def test_binaryen_metadce_cxx_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
+  def test_binaryen_metadce_cxx_fastcomp(self, *args):
     # test on libc++: see effects of emulated function pointers
-    self.run_metadce_test('hello_libcxx.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)
+    self.run_metadce_test('hello_libcxx.cpp', *args)
 
   @parameterized({
     'O0': ([],      17, [], ['waka'], 22185, 11,  18, 57), # noqa
@@ -7975,8 +7975,8 @@ int main() {
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10770,  17,   13, None), # noqa
   })
   @no_fastcomp()
-  def test_binaryen_metadce_hello(self, args, sent, exists, not_exists, size, imports, exports, funcs):
-    self.run_metadce_test('hello_world.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)
+  def test_binaryen_metadce_hello(self, *args):
+    self.run_metadce_test('hello_world.cpp', *args)
 
   @parameterized({
     'O0': ([],      23, ['abort'], ['waka'], 42701,  24,   17, 57), # noqa
@@ -7995,8 +7995,8 @@ int main() {
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21), # noqa
   })
   @no_wasm_backend()
-  def test_binaryen_metadce_hello_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
-    self.run_metadce_test('hello_world.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)
+  def test_binaryen_metadce_hello_fastcomp(self, *args):
+    self.run_metadce_test('hello_world.cpp', *args)
 
   # ensures runtime exports work, even with metadce
   def test_extra_runtime_exports(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7924,8 +7924,8 @@ int main() {
     ('Oz', (['-Oz'],  0, [], [],          54,  0,  1,  1)), # noqa
   ])
   @no_fastcomp()
-  def test_binaryen_metadce_minimal(self, *args):
-    self.run_metadce_test('minimal.c', *args)
+  def test_binaryen_metadce_minimal(self, args, sent, exists, not_exists, size, imports, exports, funcs):
+    self.run_metadce_test('minimal.c', args, sent, exists, not_exists, size, imports, exports, funcs)
 
   @parameterized([
     ('O0', ([],      21, ['abort'], ['waka'], 22712, 22, 15, 30)), # noqa
@@ -7937,8 +7937,8 @@ int main() {
     ('Oz', (['-Oz'],  0, [],        [],          55,  0,  1, 1)), # noqa
   ])
   @no_wasm_backend()
-  def test_binaryen_metadce_minimal_fastcomp(self, *args):
-    self.run_metadce_test('minimal.c', *args)
+  def test_binaryen_metadce_minimal_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
+    self.run_metadce_test('minimal.c', args, sent, exists, not_exists, size, imports, exports, funcs)
 
   @no_fastcomp()
   def test_binaryen_metadce_cxx(self):
@@ -7952,9 +7952,9 @@ int main() {
                          34, ['abort'], ['waka'], 186423,  29,  39, 519)), # noqa
   ])
   @no_wasm_backend()
-  def test_binaryen_metadce_cxx_fastcomp(self, *args):
+  def test_binaryen_metadce_cxx_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
     # test on libc++: see effects of emulated function pointers
-    self.run_metadce_test('hello_libcxx.cpp', *args)
+    self.run_metadce_test('hello_libcxx.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)
 
   @parameterized([
     ('O0', ([],      17, [], ['waka'], 22185, 11,  18, 57)), # noqa
@@ -7975,8 +7975,8 @@ int main() {
     ('main_module_2', (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10770,  17,   13, None)), # noqa
   ])
   @no_fastcomp()
-  def test_binaryen_metadce_hello(self, *args):
-    self.run_metadce_test('hello_world.cpp', *args)
+  def test_binaryen_metadce_hello(self, args, sent, exists, not_exists, size, imports, exports, funcs):
+    self.run_metadce_test('hello_world.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)
 
   @parameterized([
     ('O0', ([],      23, ['abort'], ['waka'], 42701,  24,   17, 57)), # noqa
@@ -7995,8 +7995,8 @@ int main() {
     ('main_module_2', (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21)), # noqa
   ])
   @no_wasm_backend()
-  def test_binaryen_metadce_hello_fastcomp(self, *args):
-    self.run_metadce_test('hello_world.cpp', *args)
+  def test_binaryen_metadce_hello_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
+    self.run_metadce_test('hello_world.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)
 
   # ensures runtime exports work, even with metadce
   def test_extra_runtime_exports(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7914,28 +7914,28 @@ int main() {
     if expected_funcs is not None:
       self.assertEqual(funcs, expected_funcs)
 
-  @parameterized([
-    ('O0', ([],      11, [], ['waka'],  9211,  5, 13, 16)), # noqa
-    ('O1', (['-O1'],  9, [], ['waka'],  7886,  2, 12, 10)), # noqa
-    ('O2', (['-O2'],  9, [], ['waka'],  7871,  2, 12, 10)), # noqa
+  @parameterized({
+    'O0': ([],      11, [], ['waka'],  9211,  5, 13, 16), # noqa
+    'O1': (['-O1'],  9, [], ['waka'],  7886,  2, 12, 10), # noqa
+    'O2': (['-O2'],  9, [], ['waka'],  7871,  2, 12, 10), # noqa
     # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-    ('O3', (['-O3'],  0, [], [],          85,  0,  2,  2)), # noqa
-    ('Os', (['-Os'],  0, [], [],          85,  0,  2,  2)), # noqa
-    ('Oz', (['-Oz'],  0, [], [],          54,  0,  1,  1)), # noqa
-  ])
+    'O3': (['-O3'],  0, [], [],          85,  0,  2,  2), # noqa
+    'Os': (['-Os'],  0, [], [],          85,  0,  2,  2), # noqa
+    'Oz': (['-Oz'],  0, [], [],          54,  0,  1,  1), # noqa
+  })
   @no_fastcomp()
   def test_binaryen_metadce_minimal(self, args, sent, exists, not_exists, size, imports, exports, funcs):
     self.run_metadce_test('minimal.c', args, sent, exists, not_exists, size, imports, exports, funcs)
 
-  @parameterized([
-    ('O0', ([],      21, ['abort'], ['waka'], 22712, 22, 15, 30)), # noqa
-    ('O1', (['-O1'], 10, ['abort'], ['waka'], 10450,  7, 11, 11)), # noqa
-    ('O2', (['-O2'], 10, ['abort'], ['waka'], 10440,  7, 11, 11)), # noqa
+  @parameterized({
+    'O0': ([],      21, ['abort'], ['waka'], 22712, 22, 15, 30), # noqa
+    'O1': (['-O1'], 10, ['abort'], ['waka'], 10450,  7, 11, 11), # noqa
+    'O2': (['-O2'], 10, ['abort'], ['waka'], 10440,  7, 11, 11), # noqa
     # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-    ('O3', (['-O3'],  0, [],        [],          55,  0,  1, 1)), # noqa
-    ('Os', (['-Os'],  0, [],        [],          55,  0,  1, 1)), # noqa
-    ('Oz', (['-Oz'],  0, [],        [],          55,  0,  1, 1)), # noqa
-  ])
+    'O3': (['-O3'],  0, [],        [],          55,  0,  1, 1), # noqa
+    'Os': (['-Os'],  0, [],        [],          55,  0,  1, 1), # noqa
+    'Oz': (['-Oz'],  0, [],        [],          55,  0,  1, 1), # noqa
+  })
   @no_wasm_backend()
   def test_binaryen_metadce_minimal_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
     self.run_metadce_test('minimal.c', args, sent, exists, not_exists, size, imports, exports, funcs)
@@ -7945,55 +7945,55 @@ int main() {
     # test on libc++: see effects of emulated function pointers
     self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  35, 562) # noqa
 
-  @parameterized([
-    ('normal', (['-O2'], 34, ['abort'], ['waka'], 186423,  29,  38, 539)), # noqa
-    ('enumated_function_pointers',
-               (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                         34, ['abort'], ['waka'], 186423,  29,  39, 519)), # noqa
-  ])
+  @parameterized({
+    'normal': (['-O2'], 34, ['abort'], ['waka'], 186423,  29,  38, 539), # noqa
+    'enumated_function_pointers':
+              (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
+                        34, ['abort'], ['waka'], 186423,  29,  39, 519), # noqa
+  })
   @no_wasm_backend()
   def test_binaryen_metadce_cxx_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
     # test on libc++: see effects of emulated function pointers
     self.run_metadce_test('hello_libcxx.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)
 
-  @parameterized([
-    ('O0', ([],      17, [], ['waka'], 22185, 11,  18, 57)), # noqa
-    ('O1', (['-O1'], 15, [], ['waka'], 10415,  9,  15, 31)), # noqa
-    ('O2', (['-O2'], 15, [], ['waka'], 10183,  9,  15, 25)), # noqa
-    ('O3', (['-O3'],  5, [], [],        2353,  7,   3, 14)), # noqa; in -O3, -Os and -Oz we metadce
-    ('Os', (['-Os'],  5, [], [],        2310,  7,   3, 15)), # noqa
-    ('Oz', (['-Oz'],  5, [], [],        2272,  7,   2, 14)), # noqa
+  @parameterized({
+    'O0': ([],      17, [], ['waka'], 22185, 11,  18, 57), # noqa
+    'O1': (['-O1'], 15, [], ['waka'], 10415,  9,  15, 31), # noqa
+    'O2': (['-O2'], 15, [], ['waka'], 10183,  9,  15, 25), # noqa
+    'O3': (['-O3'],  5, [], [],        2353,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
+    'Os': (['-Os'],  5, [], [],        2310,  7,   3, 15), # noqa
+    'Oz': (['-Oz'],  5, [], [],        2272,  7,   2, 14), # noqa
     # finally, check what happens when we export nothing. wasm should be almost empty
-    ('export_nothing',
-           (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                      0, [], [],          61,  0,   1,  1)), # noqa
+    'export_nothing':
+          (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
+                     0, [], [],          61,  0,   1,  1), # noqa
     # we don't metadce with linkable code! other modules may want stuff
     # don't compare the # of functions in a main module, which changes a lot
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    ('main_module_1', (['-O3', '-s', 'MAIN_MODULE=1'], 1581, [], [], 517336, 172, 1484, None)), # noqa
-    ('main_module_2', (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10770,  17,   13, None)), # noqa
-  ])
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1581, [], [], 517336, 172, 1484, None), # noqa
+    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10770,  17,   13, None), # noqa
+  })
   @no_fastcomp()
   def test_binaryen_metadce_hello(self, args, sent, exists, not_exists, size, imports, exports, funcs):
     self.run_metadce_test('hello_world.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)
 
-  @parameterized([
-    ('O0', ([],      23, ['abort'], ['waka'], 42701,  24,   17, 57)), # noqa
-    ('O1', (['-O1'], 15, ['abort'], ['waka'], 13199,  15,   14, 33)), # noqa
-    ('O2', (['-O2'], 15, ['abort'], ['waka'], 12425,  15,   14, 28)), # noqa
-    ('O3', (['-O3'],  6, [],        [],        2443,   9,    2, 15)), # noqa; in -O3, -Os and -Oz we metadce
-    ('Os', (['-Os'],  6, [],        [],        2412,   9,    2, 17)), # noqa
-    ('Oz', (['-Oz'],  6, [],        [],        2389,   9,    2, 16)), # noqa
+  @parameterized({
+    'O0': ([],      23, ['abort'], ['waka'], 42701,  24,   17, 57), # noqa
+    'O1': (['-O1'], 15, ['abort'], ['waka'], 13199,  15,   14, 33), # noqa
+    'O2': (['-O2'], 15, ['abort'], ['waka'], 12425,  15,   14, 28), # noqa
+    'O3': (['-O3'],  6, [],        [],        2443,   9,    2, 15), # noqa; in -O3, -Os and -Oz we metadce
+    'Os': (['-Os'],  6, [],        [],        2412,   9,    2, 17), # noqa
+    'Oz': (['-Oz'],  6, [],        [],        2389,   9,    2, 16), # noqa
     # finally, check what happens when we export nothing. wasm should be almost empty
-    ('export_nothing',
+    'export_nothing':
            (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                      0, [],        [],           8,   0,    0,  0)), # noqa; totally empty!
+                      0, [],        [],           8,   0,    0,  0), # noqa; totally empty!
     # we don't metadce with linkable code! other modules may want stuff
     # don't compare the # of functions in a main module, which changes a lot
-    ('main_module_1', (['-O3', '-s', 'MAIN_MODULE=1'], 1543, [], [], 226403, 30, 95, None)), # noqa
-    ('main_module_2', (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21)), # noqa
-  ])
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1543, [], [], 226403, 30, 95, None), # noqa
+    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21), # noqa
+  })
   @no_wasm_backend()
   def test_binaryen_metadce_hello_fastcomp(self, args, sent, exists, not_exists, size, imports, exports, funcs):
     self.run_metadce_test('hello_world.cpp', args, sent, exists, not_exists, size, imports, exports, funcs)


### PR DESCRIPTION
This converts a single tests that do the same thing with different parameters into multiple tests.

The advantages of doing this is that the tests can now run in parallel, and you can get feedback for all the subtests at the same time, instead of stopping the test after the first failure. You can also run the just one subtest, instead of running all or nothing.

This PR also adds `@functools.wraps` to decorators in `runner.py` to preserve function attributes after decorating them.