### PR TITLE
Revert "Added parameterized test support and use it for metadce"

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -19,7 +19,6 @@ http://kripken.github.io/emscripten-site/docs/getting_started/test-suite.html
 
 from __future__ import print_function
 from subprocess import PIPE, STDOUT
-from functools import wraps
 import argparse
 import atexit
 import contextlib
@@ -106,14 +105,13 @@ def skip_if(func, condition, explanation='', negate=False):
   assert callable(func)
   explanation_str = ' : %s' % explanation if explanation else ''
 
-  @wraps(func)
-  def decorated(self, *args, **kwargs):
+  def decorated(self):
     choice = self.__getattribute__(condition)()
     if negate:
       choice = not choice
     if choice:
       self.skipTest(condition + explanation_str)
-    func(self, *args, **kwargs)
+    func(self)
 
   return decorated
 
@@ -121,7 +119,6 @@ def skip_if(func, condition, explanation='', negate=False):
 def needs_dlfcn(func):
   assert callable(func)
 
-  @wraps(func)
   def decorated(self):
     self.check_dlfcn()
     return func(self)
@@ -132,7 +129,6 @@ def needs_dlfcn(func):
 def is_slow_test(func):
   assert callable(func)
 
-  @wraps(func)
   def decorated(self, *args, **kwargs):
     if EMTEST_SKIP_SLOW:
       return self.skipTest('skipping slow tests')
@@ -171,7 +167,6 @@ def flaky(f):
   assert callable(f)
   max_tries = 3
 
-  @wraps(f)
   def decorated(self):
     for i in range(max_tries - 1):
       try:
@@ -280,95 +275,7 @@ non_core_test_modes = [
 test_index = 0
 
 
-def parameterized(parameters):
-  """
-  Mark a test as parameterized.
-
-  Usage:
-    @parameterized({
-      'subtest1': (1, 2, 3),
-      'subtest2': (4, 5, 6),
-    })
-    def test_something(self, a, b, c):
-      ... # actual test body
-
-  This is equivalent to defining two tests:
-
-    def test_something_subtest1(self):
-      # runs test_something(1, 2, 3)
-
-    def test_something_subtest2(self):
-      # runs test_something(4, 5, 6)
-  """
-  def decorator(func):
-    func._parameterize = parameters
-    return func
-  return decorator
-
-
-class RunnerMeta(type):
-  @classmethod
-  def make_test(mcs, name, func, suffix, args):
-    """
-    This is a helper function to create new test functions for each parameterized form.
-
-    :param name: the original name of the function
-    :param func: the original function that we are parameterizing
-    :param suffix: the suffix to append to the name of the function for this parameterization
-    :param args: the positional arguments to pass to the original function for this parameterization
-    :returns: a tuple of (new_function_name, new_function_object)
-    """
-
-    # Create the new test function. It calls the original function with the specified args.
-    # We use @functools.wraps to copy over all the function attributes.
-    @wraps(func)
-    def resulting_test(self):
-      return func(self, *args)
-
-    # Add suffix to the function name so that it displays correctly.
-    resulting_test.__name__ = '%s_%s' % (name, suffix)
-
-    # On python 3, functions have __qualname__ as well. This is a full dot-separated path to the function.
-    # We add the suffix to it as well.
-    if hasattr(func, '__qualname__'):
-      resulting_test.__qualname__ = '%s_%s' % (func.__qualname__, suffix)
-
-    return resulting_test.__name__, resulting_test
-
-  def __new__(mcs, name, bases, attrs):
-    # This metaclass expands parameterized methods from `attrs` into separate ones in `new_attrs`.
-    new_attrs = {}
-
-    for attr_name, value in attrs.items():
-      # Check if a member of the new class has _parameterize, the tag inserted by @parameterized.
-      if hasattr(value, '_parameterize'):
-        # If it does, we extract the parameterization information, build new test functions.
-        for suffix, args in value._parameterize.items():
-          new_name, func = mcs.make_test(attr_name, value, suffix, args)
-          new_attrs[new_name] = func
-      else:
-        # If not, we just copy it over to new_attrs verbatim.
-        new_attrs[attr_name] = value
-
-    # We invoke type, the default metaclass, to actually create the new class, with new_attrs.
-    return type.__new__(mcs, name, bases, new_attrs)
-
-
-# This is a hack to make the metaclass work on both python 2 and python 3.
-#
-# On python 3, the code should be:
-#   class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
-#     ...
-#
-# On python 2, the code should be:
-#   class RunnerCore(unittest.TestCase):
-#     __metaclass__ = RunnerMeta
-#     ...
-#
-# To be compatible with both python 2 and python 3, we create a class by directly invoking the
-# metaclass, which is done in the same way on both python 2 and 3, and inherit from it,
-# since a class inherits the metaclass by default.
-class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
+class RunnerCore(unittest.TestCase):
   emcc_args = []
 
   # default temporary directory settings. set_temp_dir may be called later to

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -33,7 +33,7 @@ from tools.shared import CLANG, CLANG_CC, CLANG_CPP, LLVM_AR
 from tools.shared import COMPILER_ENGINE, NODE_JS, SPIDERMONKEY_ENGINE, JS_ENGINES, V8_ENGINE
 from tools.shared import WebAssembly
 from runner import RunnerCore, path_from_root, no_wasm_backend, no_fastcomp, is_slow_test
-from runner import needs_dlfcn, env_modify, no_windows, chdir, with_env_modify, create_test_file, parameterized
+from runner import needs_dlfcn, env_modify, no_windows, chdir, with_env_modify, create_test_file
 from tools import jsrun, shared
 import tools.line_endings
 import tools.js_optimizer
@@ -7914,89 +7914,77 @@ int main() {
     if expected_funcs is not None:
       self.assertEqual(funcs, expected_funcs)
 
-  @parameterized({
-    'O0': ([],      11, [], ['waka'],  9211,  5, 13, 16), # noqa
-    'O1': (['-O1'],  9, [], ['waka'],  7886,  2, 12, 10), # noqa
-    'O2': (['-O2'],  9, [], ['waka'],  7871,  2, 12, 10), # noqa
-    # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-    'O3': (['-O3'],  0, [], [],          85,  0,  2,  2), # noqa
-    'Os': (['-Os'],  0, [], [],          85,  0,  2,  2), # noqa
-    'Oz': (['-Oz'],  0, [], [],          54,  0,  1,  1), # noqa
-  })
-  @no_fastcomp()
-  def test_binaryen_metadce_minimal(self, *args):
-    self.run_metadce_test('minimal.c', *args)
+  def test_binaryen_metadce_minimal(self):
+    def run(*args):
+      self.run_metadce_test('minimal.c', *args)
 
-  @parameterized({
-    'O0': ([],      21, ['abort'], ['waka'], 22712, 22, 15, 30), # noqa
-    'O1': (['-O1'], 10, ['abort'], ['waka'], 10450,  7, 11, 11), # noqa
-    'O2': (['-O2'], 10, ['abort'], ['waka'], 10440,  7, 11, 11), # noqa
-    # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-    'O3': (['-O3'],  0, [],        [],          55,  0,  1, 1), # noqa
-    'Os': (['-Os'],  0, [],        [],          55,  0,  1, 1), # noqa
-    'Oz': (['-Oz'],  0, [],        [],          55,  0,  1, 1), # noqa
-  })
-  @no_wasm_backend()
-  def test_binaryen_metadce_minimal_fastcomp(self, *args):
-    self.run_metadce_test('minimal.c', *args)
+    if self.is_wasm_backend():
+      run([],      11, [], ['waka'],  9211,  5, 13, 16) # noqa
+      run(['-O1'],  9, [], ['waka'],  7886,  2, 12, 10) # noqa
+      run(['-O2'],  9, [], ['waka'],  7871,  2, 12, 10) # noqa
+      # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
+      run(['-O3'],  0, [], [],          85,  0,  2,  2) # noqa
+      run(['-Os'],  0, [], [],          85,  0,  2,  2) # noqa
+      run(['-Oz'],  0, [], [],          54,  0,  1,  1) # noqa
+    else:
+      run([],      21, ['abort'], ['waka'], 22712, 22, 15, 30) # noqa
+      run(['-O1'], 10, ['abort'], ['waka'], 10450,  7, 11, 11) # noqa
+      run(['-O2'], 10, ['abort'], ['waka'], 10440,  7, 11, 11) # noqa
+      # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
+      run(['-O3'],  0, [],        [],          55,  0,  1, 1) # noqa
+      run(['-Os'],  0, [],        [],          55,  0,  1, 1) # noqa
+      run(['-Oz'],  0, [],        [],          55,  0,  1, 1) # noqa
 
-  @no_fastcomp()
   def test_binaryen_metadce_cxx(self):
+    def run(*args):
+      self.run_metadce_test('hello_libcxx.cpp', *args)
+
     # test on libc++: see effects of emulated function pointers
-    self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  35, 562) # noqa
+    if self.is_wasm_backend():
+      run(['-O2'], 33, [], ['waka'], 226582,  21,  35, 562) # noqa
+    else:
+      run(['-O2'], 34, ['abort'], ['waka'], 186423,  29,  38, 539) # noqa
+      run(['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
+                   34, ['abort'], ['waka'], 186423,  29,  39, 519) # noqa
 
-  @parameterized({
-    'normal': (['-O2'], 34, ['abort'], ['waka'], 186423,  29,  38, 539), # noqa
-    'enumated_function_pointers':
-              (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                        34, ['abort'], ['waka'], 186423,  29,  39, 519), # noqa
-  })
-  @no_wasm_backend()
-  def test_binaryen_metadce_cxx_fastcomp(self, *args):
-    # test on libc++: see effects of emulated function pointers
-    self.run_metadce_test('hello_libcxx.cpp', *args)
+  def test_binaryen_metadce_hello(self):
+    def run(*args):
+      self.run_metadce_test('hello_world.cpp', *args)
 
-  @parameterized({
-    'O0': ([],      17, [], ['waka'], 22185, 11,  18, 57), # noqa
-    'O1': (['-O1'], 15, [], ['waka'], 10415,  9,  15, 31), # noqa
-    'O2': (['-O2'], 15, [], ['waka'], 10183,  9,  15, 25), # noqa
-    'O3': (['-O3'],  5, [], [],        2353,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
-    'Os': (['-Os'],  5, [], [],        2310,  7,   3, 15), # noqa
-    'Oz': (['-Oz'],  5, [], [],        2272,  7,   2, 14), # noqa
-    # finally, check what happens when we export nothing. wasm should be almost empty
-    'export_nothing':
-          (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                     0, [], [],          61,  0,   1,  1), # noqa
-    # we don't metadce with linkable code! other modules may want stuff
-    # don't compare the # of functions in a main module, which changes a lot
-    # TODO(sbc): Investivate why the number of exports is order of magnitude
-    # larger for wasm backend.
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1581, [], [], 517336, 172, 1484, None), # noqa
-    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10770,  17,   13, None), # noqa
-  })
-  @no_fastcomp()
-  def test_binaryen_metadce_hello(self, *args):
-    self.run_metadce_test('hello_world.cpp', *args)
-
-  @parameterized({
-    'O0': ([],      23, ['abort'], ['waka'], 42701,  24,   17, 57), # noqa
-    'O1': (['-O1'], 15, ['abort'], ['waka'], 13199,  15,   14, 33), # noqa
-    'O2': (['-O2'], 15, ['abort'], ['waka'], 12425,  15,   14, 28), # noqa
-    'O3': (['-O3'],  6, [],        [],        2443,   9,    2, 15), # noqa; in -O3, -Os and -Oz we metadce
-    'Os': (['-Os'],  6, [],        [],        2412,   9,    2, 17), # noqa
-    'Oz': (['-Oz'],  6, [],        [],        2389,   9,    2, 16), # noqa
-    # finally, check what happens when we export nothing. wasm should be almost empty
-    'export_nothing':
-           (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                      0, [],        [],           8,   0,    0,  0), # noqa; totally empty!
-    # we don't metadce with linkable code! other modules may want stuff
-    # don't compare the # of functions in a main module, which changes a lot
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1543, [], [], 226403, 30, 95, None), # noqa
-    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21), # noqa
-  })
-  @no_wasm_backend()
-  def test_binaryen_metadce_hello_fastcomp(self, *args):
-    self.run_metadce_test('hello_world.cpp', *args)
+    if self.is_wasm_backend():
+      run([],      17, [], ['waka'], 22185, 11,  18, 57) # noqa
+      run(['-O1'], 15, [], ['waka'], 10415,  9,  15, 31) # noqa
+      run(['-O2'], 15, [], ['waka'], 10183,  9,  15, 25) # noqa
+      run(['-O3'],  5, [], [],        2353,  7,   3, 14) # noqa; in -O3, -Os and -Oz we metadce
+      run(['-Os'],  5, [], [],        2310,  7,   3, 15) # noqa
+      run(['-Oz'],  5, [], [],        2272,  7,   2, 14) # noqa
+      # finally, check what happens when we export nothing. wasm should be almost empty
+      run(['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
+                    0, [], [],          61,  0,   1,  1) # noqa
+      # we don't metadce with linkable code! other modules may want stuff
+      # don't compare the # of functions in a main module, which changes a lot
+      # TODO(sbc): Investivate why the number of exports is order of magnitude
+      # larger for wasm backend.
+      run(['-O3', '-s', 'MAIN_MODULE=1'],
+                 1581, [],        [],      517336, 172,1484, None) # noqa
+      run(['-O3', '-s', 'MAIN_MODULE=2'],
+                   15, [],        [],      10770,   17,  13, None) # noqa
+    else:
+      run([],      23, ['abort'], ['waka'], 42701,  24,   17, 57) # noqa
+      run(['-O1'], 15, ['abort'], ['waka'], 13199,  15,   14, 33) # noqa
+      run(['-O2'], 15, ['abort'], ['waka'], 12425,  15,   14, 28) # noqa
+      run(['-O3'],  6, [],        [],        2443,   9,    2, 15) # noqa; in -O3, -Os and -Oz we metadce
+      run(['-Os'],  6, [],        [],        2412,   9,    2, 17) # noqa
+      run(['-Oz'],  6, [],        [],        2389,   9,    2, 16) # noqa
+      # finally, check what happens when we export nothing. wasm should be almost empty
+      run(['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
+                    0, [],        [],           8,   0,    0,  0) # noqa; totally empty!
+      # we don't metadce with linkable code! other modules may want stuff
+      # don't compare the # of functions in a main module, which changes a lot
+      run(['-O3', '-s', 'MAIN_MODULE=1'],
+                 1543, [],        [],      226403,  30,   95, None) # noqa
+      run(['-O3', '-s', 'MAIN_MODULE=2'],
+                   15, [],        [],       10571,  19,    9, 21) # noqa
 
   # ensures runtime exports work, even with metadce
   def test_extra_runtime_exports(self):


### PR DESCRIPTION
Reverts emscripten-core/emscripten#8649

Oddly, this failed on CI with an internal Python error, but due to that error the return code was 0 - it ran no tests, and none failed. So we did not detect this before landing...