### PR TITLE
Fix early crash on abort if the argument is circular

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -410,3 +410,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Lucas Ramage <ramage.lucas@protonmail.com>
 * Andy Wingo <wingo@igalia.com> (copyright owned by Igalia)
 * Joshua Minter <josh@minteronline.com> (copyright owned by Clipchamp Pty Ltd.)
+* Ferris Kwaijtaal <ferrispc@hotmail.com>

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -410,7 +410,6 @@ function abort(what) {
   if (what !== undefined) {
     out(what);
     err(what);
-    what = JSON.stringify(what)
   } else {
     what = '';
   }

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -410,6 +410,7 @@ function abort(what) {
   if (what !== undefined) {
     out(what);
     err(what);
+    what = '"' + what + '"';
   } else {
     what = '';
   }


### PR DESCRIPTION
Previously passing an circular object to abort would cause an early crash without showing any relevant information.

This patch uses a modified version of the [MDN Circular Replacer Example](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Cyclic_object_value#Examples)

Example: 
```
TypeError: Converting circular structure to JSON
    at JSON.stringify (<anonymous>)
    at process.abort (zstd-codec/js/lib/zstd-codec-binding-wasm.js:8:1237371)
    at process.emit (events.js:198:15)
    at processPromiseRejections (internal/process/promises.js:139:20)
    at processTicksAndRejections (internal/process/task_queues.js:87:32)
```

