### PR TITLE
Remove duplicate key in .circleci/config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,12 +153,6 @@ jobs:
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: ~/
-    steps:
-      - checkout:
-          path: emscripten/
-      - attach_workspace:
-          # Must be absolute path or relative path from working_directory
-          at: ~/
       - run:
           name: install package dependencies
           command: |


### PR DESCRIPTION
We've been seeing some issues recently where some of our circleci
builds we failing (but not all of them).
