### PR TITLE
Remove dummy handler for SYS_clock_nanosleep

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1188,12 +1188,6 @@ var SyscallsLibrary = {
     exit(status);
     return 0;
   },
-  __syscall265: function(which, varargs) { // clock_nanosleep
-#if SYSCALL_DEBUG
-    err('warning: ignoring SYS_clock_nanosleep');
-#endif
-    return 0;
-  },
   __syscall268: function(which, varargs) { // statfs64
     var path = SYSCALLS.getStr(), size = SYSCALLS.get(), buf = SYSCALLS.get();
 #if ASSERTIONS

--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE.sent
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE.sent
@@ -339,7 +339,6 @@ __syscall219
 __syscall220
 __syscall221
 __syscall252
-__syscall265
 __syscall268
 __syscall269
 __syscall272

--- a/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE.sent
+++ b/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE.sent
@@ -346,7 +346,6 @@ ___syscall219
 ___syscall220
 ___syscall221
 ___syscall252
-___syscall265
 ___syscall268
 ___syscall269
 ___syscall272

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7957,7 +7957,7 @@ int main() {
     # don't compare the # of functions in a main module, which changes a lot
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1604, [], [], 517336, 172, 1484, None), # noqa
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1603, [], [], 517336, 172, 1484, None), # noqa
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10770,  17,   13, None), # noqa
   })
   @no_fastcomp()
@@ -7977,7 +7977,7 @@ int main() {
                       0, [],        [],           8,   0,    0,  0), # noqa; totally empty!
     # we don't metadce with linkable code! other modules may want stuff
     # don't compare the # of functions in a main module, which changes a lot
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1566, [], [], 226403, 30, 96, None), # noqa
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1565, [], [], 226403, 30, 96, None), # noqa
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21), # noqa
   })
   @no_wasm_backend()


### PR DESCRIPTION
While `SYS_clock_nanosleep` is defined as 267, its implementation was in `__syscall265`, which is `SYS_clock_gettime`, instead of `__syscall267`.

This PR changes the handler for `SYS_clock_nanosleep` to `__syscall267`, but also re-defines `__syscall265` as a stub handler for `SYS_clock_gettime` to keep existing code that may depend on it working.
