### PR TITLE
Fix debug level change in --profiling - 

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2353,7 +2353,7 @@ def parse_args(newargs):
       options.requested_debug = newargs[i]
       newargs[i] = ''
     elif newargs[i] == '-profiling' or newargs[i] == '--profiling':
-      options.debug_level = 2
+      options.debug_level = max(options.debug_level, 2)
       options.profiling = True
       newargs[i] = ''
     elif newargs[i] == '-profiling-funcs' or newargs[i] == '--profiling-funcs':

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2658,11 +2658,6 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     if NODE_JS in JS_ENGINES:
       self.assertContained('bufferTest finished', run_js('main.js', engine=NODE_JS))
 
-    # Tidy up files that might have been created by this test.
-    try_delete(path_from_root('tests', 'Module-exports', 'test.js'))
-    try_delete(path_from_root('tests', 'Module-exports', 'test.js.map'))
-    try_delete(path_from_root('tests', 'Module-exports', 'test.js.mem'))
-
   def test_node_catch_exit(self):
     # Test that in node.js exceptions are not caught if NODEJS_EXIT_CATCH=0
     if NODE_JS not in JS_ENGINES:
@@ -8526,11 +8521,18 @@ int main() {
   def test_check_sourcemapurl_default(self):
     if not self.is_wasm():
       self.skipTest('only supported with wasm')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_123.c'), '-g4', '-o', 'a.js'])
-    output = open('a.wasm', 'rb').read()
-    # has sourceMappingURL section content and points to 'a.wasm.map' file
-    source_mapping_url_content = encode_leb(len('sourceMappingURL')) + b'sourceMappingURL' + encode_leb(len('a.wasm.map')) + b'a.wasm.map'
-    self.assertIn(source_mapping_url_content, output)
+    def test(args):
+      try_delete('a.wasm.map')
+      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_123.c'), '-g4', '-o', 'a.js'] + args)
+      output = open('a.wasm', 'rb').read()
+      # has sourceMappingURL section content and points to 'a.wasm.map' file
+      source_mapping_url_content = encode_leb(len('sourceMappingURL')) + b'sourceMappingURL' + encode_leb(len('a.wasm.map')) + b'a.wasm.map'
+      self.assertIn(source_mapping_url_content, output)
+
+    test([])
+    # we should still emit a source map if other options alter the debug level
+    # (see #8584)
+    test(['--profiling'])
 
   def test_wasm_sourcemap(self):
     # The no_main.c will be read (from relative location) due to speficied "-s"

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8521,6 +8521,7 @@ int main() {
   def test_check_sourcemapurl_default(self):
     if not self.is_wasm():
       self.skipTest('only supported with wasm')
+
     def test(args):
       try_delete('a.wasm.map')
       run_process([PYTHON, EMCC, path_from_root('tests', 'hello_123.c'), '-g4', '-o', 'a.js'] + args)


### PR DESCRIPTION
It should only raise it, not lower it. Without this fix, `-g4 --profiling` did not emit a source map. 

See #8584 