### PR TITLE
emscripten-version.txt changes

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -44,16 +44,37 @@ When:
 
 Requirements:
 
- * GitHub CI is green. (Currently, that includes good coverage for Linux, but
-   nothing else - we should keep trying to find resources to do better here.)
+ * [emscripten-releases build CI](https://ci.chromium.org/p/emscripten-releases/g/main/console)
+   is green on all OSes for the desired hash (where the hash is the git hash in
+   the
+   [emscripten-releases](https://chromium.googlesource.com/emscripten-releases)
+   repo, which then specifies through
+   [DEPS](https://chromium.googlesource.com/emscripten-releases/+/refs/heads/master/DEPS)
+   exactly which revisions to use in all other repos).
+ * [GitHub CI](https://github.com/emscripten-core/emscripten/branches) is green
+   on the incoming branch.
 
 How:
 
- * Ask on irc if there are any concerns.
- * The emscripten, emscripten-fastcomp, and emscripten-fastcomp-clang repos
-   should each be updated: the emscripten-version.txt file in each, and a git
-   tag (with the simple version number).
- * A tag should also be done in the binaryen repo.
+ * Open a PR for the emsdk to update
+   [emscripten-releases-tags.txt](https://github.com/emscripten-core/emsdk/blob/master/emscripten-releases-tags.txt),
+   adding the version and the hash. Updating the "latest" tag there to the new
+   release is possible, but can also be deferred if you want to do more testing
+   before users fetching "latest" get this release.
+ * Tag the emscripten repo on the emscripten commit used by that release (which
+   you can tell from the DEPS file), using something like
+   `git checkout [COMMIT]` ; `git tag [VERSION]` ; `git push --tags`.
+ * Update
+   [emscripten-version.txt](https://github.com/emscripten-core/emscripten/blob/incoming/emscripten-version.txt)
+   in the emscripten repo. This is a delayed update, in that the tag will refer
+   to the actual release, but the update to emscripten-version.txt is a new
+   commit to emscripten that happens later.
+   * To minimize the difference, we should pick hashes for releases that are
+     very recent, and try to avoid anything else landing in between - can ask
+     on irc/chat for people to not land anything, or do this at a time of day
+     when that's unlikely, etc.
+   * There is no need to open a PR for this change, you can optionally just
+     commit it directly.
 
 
 Major version update (1.X.Y to 1.(X+1).0)
@@ -65,7 +86,7 @@ When:
 
 Requirements:
 
- * GitHub CI is green.
+ * All the requirements for a minor update.
  * No major change recently landed.
  * No major recent regressions have been filed.
  * All tests pass locally for the person doing the update, including the main

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -331,21 +331,6 @@ class sanity(RunnerCore):
       open(path_from_root('tests', 'fake', 'bin', fake), 'w').write('.')
     try_delete(SANITY_FILE)
     self.check_working(EMCC, WARNING)
-    # make sure sanity checks notice there is no source dir with version #
-    make_fake_llc(path_from_root('tests', 'fake', 'bin', 'llc'), 'there IZ a js backend: JavaScript (asm.js, emscripten) backend')
-    try_delete(SANITY_FILE)
-    self.check_working(EMCC, 'clang version does not appear to include fastcomp')
-
-    VERSION_WARNING = 'Emscripten, llvm and clang build versions do not match, this is dangerous'
-
-    # add version number
-    make_fake_clang(path_from_root('tests', 'fake', 'bin', 'clang'), '%s (emscripten waka : waka)' % expected_llvm_version())
-    try_delete(SANITY_FILE)
-    self.check_working(EMCC, VERSION_WARNING)
-
-    restore_and_set_up()
-
-    self.check_working([EMCC] + MINIMAL_HELLO_WORLD + ['-s', 'ASM_JS=0'], 'ASM_JS can only be set to either 1 or 2')
 
   def test_node(self):
     NODE_WARNING = 'node version appears too old'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -458,17 +458,6 @@ def check_llvm():
       print('===========================================================================', file=sys.stderr)
       return False
 
-  if not Settings.WASM_BACKEND:
-    clang_v = run_process([CLANG, '--version'], stdout=PIPE).stdout
-    clang_v = clang_v.splitlines()[0]
-    if '(emscripten ' not in clang_v:
-      logger.error('clang version does not appear to include fastcomp (%s)', str(clang_v))
-      return False
-    llvm_build_version, clang_build_version = clang_v.split('(emscripten ')[1].split(')')[0].split(' : ')
-    if EMSCRIPTEN_VERSION != llvm_build_version or EMSCRIPTEN_VERSION != clang_build_version:
-      logger.error('Emscripten, llvm and clang build versions do not match, this is dangerous (%s, %s, %s)', EMSCRIPTEN_VERSION, llvm_build_version, clang_build_version)
-      logger.error('Make sure to rebuild llvm and clang after updating repos')
-
   return True
 
 


### PR DESCRIPTION
As discussed in #8660, we want the emsdk to set `emscripten-version.txt` because the new builders will know the version number, and that info won't be in the emscripten repo (except as git tags, after the fact). This PR prepares for that by setting the file in git to say "dev" - marking it as a development version.

One downside here is that we do have `#defines` for the emscripten version number's 3 part (`X.Y.Z`). Those will still work for users using the emsdk, since it will set the version number, but for users on a dev version we don't know the right number, so those are all set to 0. This seems potentially confusing, but I'm not sure how to improve it, aside from rethinking the entire plan.

Also update the process docs to mention the new build+tag process (which is not quite ready yet, but this documents that plan).