### PR TITLE
Use binaryen from the emsdk build, like llvm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,8 +89,6 @@ jobs:
             # we are trying to test.
             rm -Rf `find -name emscripten`
             cd -
-            # Use Binaryen from the ports version.
-            echo BINARYEN_ROOT="''" >> ~/.emscripten
             echo "final .emscripten:"
             cat ~/.emscripten
       - run:
@@ -340,8 +338,6 @@ jobs:
             # we are trying to test.
             rm -Rf `find -name "emscripten"`
             cd -
-            # Use Binaryen from the ports version.
-            echo BINARYEN_ROOT="''" >> ~/.emscripten
             echo "final .emscripten:"
             cat ~/.emscripten
       - run:


### PR DESCRIPTION
This is faster and less special-casey. Just like LLVM, sometimes we'll have temp breakage, but that exists in the old way too.

We may want to remove binaryen from ports entirely eventually, as discussed in the past.