### PR TITLE
Accept the python version 2.7.10 that comes out of the box on macOS

### DIFF
--- a/site/source/docs/building_from_source/toolchain_what_is_needed.rst
+++ b/site/source/docs/building_from_source/toolchain_what_is_needed.rst
@@ -23,7 +23,7 @@ Emscripten tools and dependencies
 A complete Emscripten environment requires the following tools. First test to see if they are already installed using the :ref:`instructions below <toolchain-test-which-dependencies-are-installed>`. Then install any missing tools using the instructions in the appropriate platform-specific build topic (:ref:`building-emscripten-on-linux`, :ref:`building-emscripten-on-windows-from-source`, :ref:`building-emscripten-on-macos-from-source`):
 
   - :term:`Node.js` (0.8 or above; 0.10.17 or above to run websocket-using servers in node):
-  - :term:`Python` 2.7.12 or above (Python 3.* may also work, work is ongoing)
+  - :term:`Python` 2.7.12 or above, or Python 3.5 or above (Python 2.7.0 or newer may also work, but is known to have SSL related issues, https://github.com/emscripten-core/emscripten/issues/6275)
   - :term:`Java` (1.6.0_31 or later).  Java is optional. It is required to use the :term:`Closure Compiler` (in order to minify your code).
   - :term:`Git` client. Git is required if building tools from source.
   - :term:`Fastcomp` (Emscripten's fork of LLVM and Clang)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -22,12 +22,12 @@ import subprocess
 import sys
 import tempfile
 
-if sys.version_info < (2, 7, 12):
-  print('emscripten requires python 2.7.12 or above', file=sys.stderr)
+if sys.version_info < (2, 7, 0):
+  print('emscripten requires python 2.7.0 or above (python 2.7.12 or newer is recommended, older python versions are known to run into SSL related issues, https://github.com/emscripten-core/emscripten/issues/6275)', file=sys.stderr)
   sys.exit(1)
 
 if sys.version_info[0] == 3 and sys.version_info < (3, 5):
-  print('emscripten requires at least python 3.5 (or python 2.7.12)', file=sys.stderr)
+  print('emscripten requires at least python 3.5 (or python 2.7.12 or above)', file=sys.stderr)
   sys.exit(1)
 
 from .toolchain_profiler import ToolchainProfiler
@@ -46,6 +46,9 @@ logging.basicConfig(format='%(name)s:%(levelname)s: %(message)s',
                     level=logging.DEBUG if DEBUG else logging.INFO)
 colored_logger.enable()
 logger = logging.getLogger('shared')
+
+if sys.version_info < (2, 7, 12):
+  logger.debug('python versions older than 2.7.12 are known to run into outdated SSL certificate related issues, https://github.com/emscripten-core/emscripten/issues/6275')
 
 
 def exit_with_error(msg, *args):


### PR DESCRIPTION
Accept the python version 2.7.10 that comes out of the box on macOS High Sierra 10.13.6. (older High Sierra came with python 2.7.4 which is also accepted)

An already installed Emscripten toolchain does not really need to download any files (if ports are not being used), hence we don't need to abort on requiring 2.7.12. (Otherwise we'd have to start shipping python installation as part of emsdk on macOS, or require MacPorts or brew or a custom install)