### PR TITLE
Add wasm backend lto testing for libc++ [ci skip]

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8158,8 +8158,6 @@ int main() {
   @no_fastcomp('uses upstream specific option: WASM_OBJECT_FILES')
   def test_wasm_backend_lto(self):
     # test building of non-wasm-object-files libraries, building with them, and running them
-    if not self.is_wasm_backend():
-      self.skipTest('not using wasm backend')
 
     src = path_from_root('tests', 'hello_libcxx.cpp')
     # test codegen in lto mode, and compare to normal (wasm object) mode
@@ -8189,6 +8187,14 @@ int main() {
       print('use native object (non-LTO)')
       run_process([PYTHON, EMXX, 'hello_obj.o'] + args + ['-s', 'WASM_OBJECT_FILES=1'])
       self.assertContained('hello, world!', run_js('a.out.js'))
+
+  @parameterized({
+    'except': [],
+    'noexcept': ['-s', 'DISABLE_EXCEPTION_CATCHING=0']
+  })
+  @no_fastcomp('uses upstream specific option: WASM_OBJECT_FILES')
+  def test_wasm_backend_lto_libcxx(self, *args):
+    run_process([PYTHON, EMXX, path_from_root('tests', 'hello_libcxx.cpp')] + ['-s', 'WASM_OBJECT_FILES=0'] + list(args))
 
   def test_wasm_nope(self):
     for opts in [[], ['-O2']]:


### PR DESCRIPTION
This actually uses libc++ in LTO mode. Right now github CI builds that library, but does not run anything with it. As a result github broke while emscripten-releases CI did not catch this, as it does not run our build step, but just (a subset of) the tests. This PR will prevent that in the future.

This can't pass until the issue is fixed in LLVM. 