### PR TITLE
Fix multitouch support - problem with leaking `isChanged` state between touch phases

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1849,6 +1849,7 @@ var LibraryJSEvents = {
       var touches = {};
       for(var i = 0; i < e.touches.length; ++i) {
         var touch = e.touches[i];
+        touch.changed = false;
         touches[touch.identifier] = touch;
       }
       for(var i = 0; i < e.changedTouches.length; ++i) {


### PR DESCRIPTION
Current implementation of touch support uses JS's `Touch` instances of touching points to store `changed` flag. Which is problematic as those instances can recirculate. This PR makes sure that we clean old flags before handling new touches.

I was able to reproduce this scenario by:
* hooking onto all *touch events
* put one finger and start moving it (which adds one Touch instance).
* while first finger was still moving I taped quickly with another finger. 

While a logic might look kind of correct, as I'm still moving the first finger, but it doesn't follow separation which is quarantined by standard: https://developer.mozilla.org/en-US/docs/Web/API/TouchEvent/changedTouches
That is, if I have a handler hooked into `touchstart` only touch points that actually have started should be placed in `changedTouched` list (or in case of Emscripten, I'd expect that only those are marked with `isChanged` flag) 

In current scenario it's possible that `isChanged` flag (carried by `[Touch].changed`) leaks from `touchmove` to either `touchstart` or `touchend`, which makes handling multi touch support much harder / impossible. 

----

For people struggling with that issue: It's possible to "patch" your current build with: 
```c++
const char* target = "#canvas";
const int useCapture = 1;

// Mitigation for: https://github.com/emscripten-core/emscripten/issues/8699
// It can be added in any time (after of before your target handlers)
// clang-format off
EM_ASM_({
    var targetName = UTF8ToString($0);
    var useCapture = $1;
    Module.touch_sanitizer = function(event) {
        var e = event || window.event;
        for (var i = 0; i < e.touches.length; i++) {
            e.touches[i].changed = false;
        }
    };
    var target = JSEvents.findEventTarget(targetName);
    if (target) {
        target.addEventListener("touchcancel", Module.touch_sanitizer, useCapture);
        target.addEventListener("touchstart", Module.touch_sanitizer, useCapture);
        target.addEventListener("touchmove", Module.touch_sanitizer, useCapture);
        target.addEventListener("touchend", Module.touch_sanitizer, useCapture);
    }
}, target, useCapture);
// clang-format on

```

Then `touch_sanitizer` will clean up old flags. 
