### PR TITLE
Fixed a typo

### DIFF
--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -133,7 +133,7 @@ def get_native_optimizer():
       for cmake_generator in cmake_generators:
         # Delete CMakeCache.txt so that we can switch to a new CMake generator.
         shared.try_delete(os.path.join(build_path, 'CMakeCache.txt'))
-        proc = subprocess.Popen(['cmake', '-G', cmake_generator, '-DCMAKE_BUILD_TYPE='+cmake_build_type, shared.path_from_root('tools', 'optimizer')], cwd=build_path, stdin=log_outpu, stdout=log_output, stderr=log_output)
+        proc = subprocess.Popen(['cmake', '-G', cmake_generator, '-DCMAKE_BUILD_TYPE='+cmake_build_type, shared.path_from_root('tools', 'optimizer')], cwd=build_path, stdin=log_output, stdout=log_output, stderr=log_output)
         proc.communicate()
         if proc.returncode == 0:
           make = ['cmake', '--build', build_path]


### PR DESCRIPTION
stdin=log_outpu causes the optimiser to fail to build (on Windows) when building from source.
