### PR TITLE
Add -fsanitize=vptr tests

### DIFF
--- a/tests/core/test_ubsan_full_static_cast.cpp
+++ b/tests/core/test_ubsan_full_static_cast.cpp
@@ -1,0 +1,19 @@
+struct S {
+  S() : a(0) {}
+  virtual ~S() {}
+  int a;
+};
+
+struct T : S {
+  int b;
+};
+
+struct R : S {
+  int c;
+};
+
+int main() {
+  T t;
+  S &s = t;
+  R &r = static_cast<R&>(s);
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7698,6 +7698,21 @@ extern "C" {
       "src.cpp:5:14: runtime error: reference binding to null pointer of type 'int'",
     ])
 
+  @parameterized({
+    'fsanitize_undefined': (['-fsanitize=undefined'],),
+    'fsanitize_vptr': (['-fsanitize=vptr'],),
+  })
+  @no_fastcomp('ubsan not supported on fastcomp')
+  def test_ubsan_full_static_cast(self, args):
+    self.emcc_args += args
+    self.do_run(open(path_from_root('tests', 'core', 'test_ubsan_full_static_cast.cpp')).read(),
+                expected_output=[
+      "vptr.cc:18:10: runtime error: downcast of address",
+      "which does not point to an object of type 'R'",
+      "note: object is of type 'T'",
+      "vptr for 'T'",
+    ])
+
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None):


### PR DESCRIPTION
After https://reviews.llvm.org/D62559 and #8651, `-fsanitize=vptr` now works.

This PR adds a test for `-fsanitize=vptr`.