### PR TITLE
Handle EM_JS functions starting with _ in the wasm backend. Fixes #8712

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2425,7 +2425,9 @@ def create_sending_wasm(invoke_funcs, forwarded_json, metadata):
     # symbols.  Emscripten currently expects symbols to start with '_' so we
     # artificially add them to the output of emscripten-wasm-finalize and them
     # strip them again here.
-    if g.startswith('_'):
+    # note that we don't do this for EM_JS functions (which, rarely, may have
+    # a '_' prefix)
+    if g.startswith('_') and g not in metadata['emJsFuncs']:
       return g[1:]
     return g
 

--- a/tests/core/test_em_js.cpp
+++ b/tests/core/test_em_js.cpp
@@ -70,6 +70,10 @@ EM_JS(const char*, return_str, (void), {
   return stringOnWasmHeap;
 });
 
+EM_JS(int, _prefixed, (void), {
+  return 1;
+});
+
 int main() {
   printf("BEGIN\n");
   noarg();
@@ -89,6 +93,8 @@ int main() {
 
   printf("    return_str returned: %s\n", return_str());
   printf("    return_utf8_str returned: %s\n", return_utf8_str());
+
+  printf("    _prefixed: %d\n", _prefixed());
 
   printf("END\n");
   return 0;

--- a/tests/core/test_em_js.out
+++ b/tests/core/test_em_js.out
@@ -24,4 +24,5 @@ no args returning double
     user_comma returned: 2
     return_str returned: hello from js
     return_utf8_str returned: こんにちは
+    _prefixed: 1
 END


### PR DESCRIPTION
They basically need to be left alone when emitting the asmLibraryArg that is sent to the wasm imports. The general code that removes a `_` broke on it. (I'm not sure why that code is conditional? Perhaps to differentiate unprefixed JS library functions?)

cc @floooh 