### PR TITLE
Avoid spamming the console with DEMANGLE_SUPPORT suggestions

### DIFF
--- a/site/source/docs/porting/Debugging.rst
+++ b/site/source/docs/porting/Debugging.rst
@@ -69,7 +69,7 @@ Emscripten has a number of compiler settings that can be useful for debugging. T
 
   emcc -O1 -s ASSERTIONS=1 tests/hello_world
 
-The most important settings are:
+Some important settings are:
 
   -
     .. _debugging-ASSERTIONS:
@@ -91,6 +91,11 @@ The most important settings are:
     Passing the ``STACK_OVERFLOW_CHECK=1`` linker flag adds a runtime magic token value at the end of the stack, which is checked in certain locations to verify that the user code does not accidentally write past the end of the stack. While overrunning the Emscripten stack is not a security issue (JavaScript is sandboxed already), writing past the stack causes memory corruption in global data and dynamically allocated memory sections in the Emscripten HEAP, which makes the application fail in unexpected ways. The value ``STACK_OVERFLOW_CHECK=2`` enables slightly more detailed stack guard checks, which can give a more precise callstack at the expense of some performance. Default value is 2 if ``ASSERTIONS=1`` is set, and disabled otherwise.
 
 A number of other useful debug settings are defined in `src/settings.js <https://github.com/emscripten-core/emscripten/blob/master/src/settings.js>`_. For more information, search that file for the keywords "check" and "debug".
+
+  -
+    .. _debugging-DEMANGLE_SUPPORT:
+
+    ``DEMANGLE_SUPPORT=1`` links in code to automatically demangle stack traces, that is, emit human-readable C++ function names instead of ``_ZN..`` ones.
 
 
 .. _debugging-emcc-v:

--- a/site/source/docs/porting/Debugging.rst
+++ b/site/source/docs/porting/Debugging.rst
@@ -90,12 +90,12 @@ Some important settings are:
 
     Passing the ``STACK_OVERFLOW_CHECK=1`` linker flag adds a runtime magic token value at the end of the stack, which is checked in certain locations to verify that the user code does not accidentally write past the end of the stack. While overrunning the Emscripten stack is not a security issue (JavaScript is sandboxed already), writing past the stack causes memory corruption in global data and dynamically allocated memory sections in the Emscripten HEAP, which makes the application fail in unexpected ways. The value ``STACK_OVERFLOW_CHECK=2`` enables slightly more detailed stack guard checks, which can give a more precise callstack at the expense of some performance. Default value is 2 if ``ASSERTIONS=1`` is set, and disabled otherwise.
 
-A number of other useful debug settings are defined in `src/settings.js <https://github.com/emscripten-core/emscripten/blob/master/src/settings.js>`_. For more information, search that file for the keywords "check" and "debug".
-
   -
     .. _debugging-DEMANGLE_SUPPORT:
 
     ``DEMANGLE_SUPPORT=1`` links in code to automatically demangle stack traces, that is, emit human-readable C++ function names instead of ``_ZN..`` ones.
+
+A number of other useful debug settings are defined in `src/settings.js <https://github.com/emscripten-core/emscripten/blob/master/src/settings.js>`_. For more information, search that file for the keywords "check" and "debug".
 
 
 .. _debugging-emcc-v:
@@ -115,7 +115,7 @@ Manual print debugging
 
 You can also manually instrument the source code with ``printf()`` statements, then compile and run the code to investigate issues.
 
-If you have a good idea of the problem line you can add ``print(new Error().stack)`` to the JavaScript to get a stack trace at that point. Also available is :js:func:`stackTrace`, which emits a stack trace and tries to demangle C++ function names (if you don't want or need C++ demangling, you can call :js:func:`jsStackTrace`).
+If you have a good idea of the problem line you can add ``print(new Error().stack)`` to the JavaScript to get a stack trace at that point. Also available is :js:func:`stackTrace`, which emits a stack trace and also tries to demangle C++ function names if ``DEMANGLE_SUPPORT`` is enabled (if you don't want or need C++ demangling in a specific stack trace, you can call :js:func:`jsStackTrace`).
 
 Debug printouts can even execute arbitrary JavaScript. For example::
 

--- a/src/runtime_stack_trace.js
+++ b/src/runtime_stack_trace.js
@@ -25,9 +25,6 @@ function demangle(func) {
   // failure when using libcxxabi, don't demangle
   return func;
 #else // DEMANGLE_SUPPORT
-#if ASSERTIONS
-  warnOnce('warning: build with  -s DEMANGLE_SUPPORT=1  to link in libcxxabi demangling');
-#endif // ASSERTIONS
   return func;
 #endif // DEMANGLE_SUPPORT
 }


### PR DESCRIPTION
The suggestion to flip that option on is helpful, but it should not be emitted from a function that may not be writing to the console at all.

Writing it to the output of that function is an option, but it may break stack trace parsing, so seems risky.

Instead, I added more docs for this in the debugging section.

This should fix an odd intermittent error on emscripten-releases ci on `other.test_fflush-fs` - the warning is printed to the console there, messing up the output. I'm not totally sure why it gets emitted there, but when I realized we shouldn't even be emitting this, I figured it's faster to just remove it.