### PR TITLE
Optimize checks for fullscreenEnabled support

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1087,7 +1087,7 @@ var LibraryJSEvents = {
   emscripten_set_fullscreenchange_callback_on_thread__sig: 'iiiiii',
   emscripten_set_fullscreenchange_callback_on_thread__deps: ['$JSEvents', '_registerFullscreenChangeEventCallback', '_findEventTarget', '_specialEventTargets'],
   emscripten_set_fullscreenchange_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    if (typeof JSEvents.fullscreenEnabled() === 'undefined') return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     target = __findEventTarget(target);
 #else
@@ -1105,7 +1105,7 @@ var LibraryJSEvents = {
   emscripten_get_fullscreen_status__sig: 'ii',
   emscripten_get_fullscreen_status__deps: ['$JSEvents', '_fillFullscreenChangeEventData'],
   emscripten_get_fullscreen_status: function(fullscreenStatus) {
-    if (typeof JSEvents.fullscreenEnabled() === 'undefined') return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
     __fillFullscreenChangeEventData(fullscreenStatus);
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
@@ -1128,11 +1128,7 @@ var LibraryJSEvents = {
     } else if (target.webkitRequestFullscreen) {
       target.webkitRequestFullscreen(Element.ALLOW_KEYBOARD_INPUT);
     } else {
-      if (typeof JSEvents.fullscreenEnabled() === 'undefined') {
-        return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
-      } else {
-        return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
-      }
+      return JSEvents.fullscreenEnabled() ? {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}} : {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
     }
 
     if (strategy.canvasResizedCallback) {
@@ -1386,8 +1382,7 @@ var LibraryJSEvents = {
   // https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Using_full_screen_mode  
   _emscripten_do_request_fullscreen__deps: ['$JSEvents', '_setLetterbox', 'emscripten_set_canvas_element_size', 'emscripten_get_canvas_element_size', '_get_canvas_element_size', '_set_canvas_element_size', 'JSEvents_requestFullscreen', '_findEventTarget'],
   _emscripten_do_request_fullscreen: function(target, strategy) {
-    if (typeof JSEvents.fullscreenEnabled() === 'undefined') return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
-    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
+    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
 #if !DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     if (!target) target = '#canvas';
 #endif
@@ -1520,7 +1515,7 @@ var LibraryJSEvents = {
   emscripten_exit_fullscreen__proxy: 'sync',
   emscripten_exit_fullscreen__sig: 'i',
   emscripten_exit_fullscreen: function() {
-    if (typeof JSEvents.fullscreenEnabled() === 'undefined') return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
+    if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
     // Make sure no queued up calls will fire after this.
     JSEvents.removeDeferredCalls(_JSEvents_requestFullscreen);
 

--- a/tests/test_html5.c
+++ b/tests/test_html5.c
@@ -51,7 +51,7 @@ EM_BOOL key_callback(int eventType, const EmscriptenKeyboardEvent *e, void *user
     TEST_RESULT(emscripten_get_fullscreen_status);
     if (!fsce.isFullscreen) {
       printf("Requesting fullscreen..\n");
-      ret = emscripten_request_fullscreen(0, 1);
+      ret = emscripten_request_fullscreen("#canvas", 1);
       TEST_RESULT(emscripten_request_fullscreen);
     } else {
       printf("Exiting fullscreen..\n");

--- a/tests/test_html5_fullscreen.c
+++ b/tests/test_html5_fullscreen.c
@@ -60,7 +60,7 @@ EM_BOOL key_callback(int eventType, const EmscriptenKeyboardEvent *e, void *user
     TEST_RESULT(emscripten_get_fullscreen_status);
     if (!fsce.isFullscreen) {
       printf("Requesting fullscreen..\n");
-      ret = emscripten_request_fullscreen(0, 1);
+      ret = emscripten_request_fullscreen("#canvas", 1);
       TEST_RESULT(emscripten_request_fullscreen);
     } else {
       printf("Exiting fullscreen..\n");


### PR DESCRIPTION
The previous checks did work, but were presented a bit odd - just checking trueness is enough and shorter.