### PR TITLE
Ignore -s USE_WEBGL2=1 directive if one is not linking in WebGL at all

### DIFF
--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -1110,6 +1110,12 @@ var webgl2Funcs = [[0, 'endTransformFeedback pauseTransformFeedback resumeTransf
 
 #if USE_WEBGL2
 
+// If user passes -s USE_WEBGL2=1 -s STRICT=1 but not -lGL (to link in WebGL 1), then WebGL2 library should not
+// be linked in as well.
+if (typeof createGLPassthroughFunctions === 'undefined') {
+  throw 'In order to use WebGL 2 in strict mode with -s USE_WEBGL2=1, you need to link in WebGL support with -lGL!';
+}
+
 createGLPassthroughFunctions(LibraryWebGL2, webgl2Funcs);
 
 recordGLProcAddressGet(LibraryWebGL2);


### PR DESCRIPTION
Ignore -s USE_WEBGL2=1 directive if one is not linking in WebGL at all (-lGL was not passed while -s STRICT=1 is used)

Fixes #8673.

Was pondering whether to make `-s USE_WEBGL2=1` without `-lGL` an error, but that does not seem very productive, as missing linked in `gl*` symbols should hint user that they are missing a library they should link in - same as when omitting `-lGL` without `-s USE_WEBGL2=1`.