### PR TITLE
Update metadce expectations after LLVM change

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7843,9 +7843,9 @@ int main() {
       self.assertEqual(funcs, expected_funcs)
 
   @parameterized({
-    'O0': ([],      11, [], ['waka'],  9211,  5, 13, 16), # noqa
-    'O1': (['-O1'],  9, [], ['waka'],  7886,  2, 12, 10), # noqa
-    'O2': (['-O2'],  9, [], ['waka'],  7871,  2, 12, 10), # noqa
+    'O0': ([],      11, [], ['waka'],  9211,  5, 12, 16), # noqa
+    'O1': (['-O1'],  9, [], ['waka'],  7886,  2, 11, 10), # noqa
+    'O2': (['-O2'],  9, [], ['waka'],  7871,  2, 11, 10), # noqa
     # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
     'O3': (['-O3'],  0, [], [],          85,  0,  2,  2), # noqa
     'Os': (['-Os'],  0, [], [],          85,  0,  2,  2), # noqa
@@ -7871,7 +7871,7 @@ int main() {
   @no_fastcomp()
   def test_binaryen_metadce_cxx(self):
     # test on libc++: see effects of emulated function pointers
-    self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  34, 560) # noqa
+    self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  33, 560) # noqa
 
   @parameterized({
     'normal': (['-O2'], 34, ['abort'], ['waka'], 186423,  29,  38, 539), # noqa
@@ -7885,9 +7885,9 @@ int main() {
     self.run_metadce_test('hello_libcxx.cpp', *args)
 
   @parameterized({
-    'O0': ([],      17, [], ['waka'], 22185, 11,  18, 57), # noqa
-    'O1': (['-O1'], 15, [], ['waka'], 10415,  9,  15, 31), # noqa
-    'O2': (['-O2'], 15, [], ['waka'], 10183,  9,  15, 25), # noqa
+    'O0': ([],      17, [], ['waka'], 22185, 11,  17, 57), # noqa
+    'O1': (['-O1'], 15, [], ['waka'], 10415,  9,  14, 31), # noqa
+    'O2': (['-O2'], 15, [], ['waka'], 10183,  9,  14, 25), # noqa
     'O3': (['-O3'],  5, [], [],        2353,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
     'Os': (['-Os'],  5, [], [],        2310,  7,   3, 15), # noqa
     'Oz': (['-Oz'],  5, [], [],        2272,  7,   2, 14), # noqa


### PR DESCRIPTION
This change caused __heap_base to no longer be exported from
lld by default: https://reviews.llvm.org/D62744
