### PR TITLE
Add a link to UBSan in porting/Debugging.rst

### DIFF
--- a/site/source/docs/debugging/Sanitizers.rst
+++ b/site/source/docs/debugging/Sanitizers.rst
@@ -4,6 +4,8 @@
 Debugging with Sanitizers
 =========================
 
+.. _sanitizer_ubsan:
+
 Undefined Behaviour Sanitizer
 =============================
 

--- a/site/source/docs/porting/Debugging.rst
+++ b/site/source/docs/porting/Debugging.rst
@@ -97,6 +97,13 @@ Some important settings are:
 
 A number of other useful debug settings are defined in `src/settings.js <https://github.com/emscripten-core/emscripten/blob/master/src/settings.js>`_. For more information, search that file for the keywords "check" and "debug".
 
+.. _debugging-sanitizers:
+
+Sanitizers
+==========
+
+Emscripten also supports Clang's undefined behaviour sanitizer. For details, see :ref:`sanitizer_ubsan`.
+
 
 .. _debugging-emcc-v:
 


### PR DESCRIPTION
Add a link on the porting/Debugging page to UBSan, as suggested in a comment on #8617.