### PR TITLE
Replace test uses of deprecated canvas_size functions

### DIFF
--- a/tests/sdl_canvas_size.c
+++ b/tests/sdl_canvas_size.c
@@ -30,14 +30,14 @@ int main(int argc, char *argv[])
 
     // Test 2: Check that getting current canvas size works.
     int w, h;
-    emscripten_get_canvas_size("#canvas", &w, &h);
+    emscripten_get_canvas_element_size("#canvas", &w, &h);
     printf("w:%d,h:%d\n", w,h);
     assert(w == 700);
     assert(h == 200);
 
     // Test 3: Check that resizing the canvas works as well.
-    emscripten_set_canvas_size("#canvas", 640, 480);
-    emscripten_get_canvas_size("#canvas", &w, &h);
+    emscripten_set_canvas_element_size("#canvas", 640, 480);
+    emscripten_get_canvas_element_size("#canvas", &w, &h);
     printf("w:%d,h:%d\n", w,h);
     assert(w == 640);
     assert(h == 480);

--- a/tests/sdl_canvas_size.c
+++ b/tests/sdl_canvas_size.c
@@ -14,6 +14,7 @@
 #include <assert.h>
 
 #include <emscripten.h>
+#include <emscripten/html5.h>
 
 int main(int argc, char *argv[])
 {

--- a/tests/sdl_canvas_size.c
+++ b/tests/sdl_canvas_size.c
@@ -29,15 +29,15 @@ int main(int argc, char *argv[])
     screen = SDL_SetVideoMode( 0, 0, 16, SDL_OPENGL ); // *changed*
 
     // Test 2: Check that getting current canvas size works.
-    int w, h, fs;
-    emscripten_get_canvas_size(&w, &h, &fs);
+    int w, h;
+    emscripten_get_canvas_size("#canvas", &w, &h);
     printf("w:%d,h:%d\n", w,h);
     assert(w == 700);
     assert(h == 200);
 
     // Test 3: Check that resizing the canvas works as well.
-    emscripten_set_canvas_size(640, 480);
-    emscripten_get_canvas_size(&w, &h, &fs);
+    emscripten_set_canvas_size("#canvas", 640, 480);
+    emscripten_get_canvas_size("#canvas", &w, &h);
     printf("w:%d,h:%d\n", w,h);
     assert(w == 640);
     assert(h == 480);

--- a/tests/sdl_resize.c
+++ b/tests/sdl_resize.c
@@ -10,6 +10,7 @@
 #include <SDL/SDL_ttf.h>
 #include <assert.h>
 #include <emscripten.h>
+#include <emscripten/html5.h>
 
 int stage = 0;
 

--- a/tests/sdl_resize.c
+++ b/tests/sdl_resize.c
@@ -24,7 +24,7 @@ void loop() {
           case 0:
             assert(r->w == 100);
             assert(r->h == 200);
-            emscripten_set_canvas_size(123, 246);
+            emscripten_set_canvas_size("#canvas", 123, 246);
             stage++;
             break;
           case 1:
@@ -44,7 +44,7 @@ int main() {
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Surface *screen = SDL_SetVideoMode(600, 450, 32, SDL_HWSURFACE);
 
-  emscripten_set_canvas_size(100, 200);
+  emscripten_set_canvas_size("#canvas", 100, 200);
 
   emscripten_set_main_loop(loop, 0, 0);
 }

--- a/tests/sdl_resize.c
+++ b/tests/sdl_resize.c
@@ -24,7 +24,7 @@ void loop() {
           case 0:
             assert(r->w == 100);
             assert(r->h == 200);
-            emscripten_set_canvas_size("#canvas", 123, 246);
+            emscripten_set_canvas_element_size("#canvas", 123, 246);
             stage++;
             break;
           case 1:
@@ -44,7 +44,7 @@ int main() {
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Surface *screen = SDL_SetVideoMode(600, 450, 32, SDL_HWSURFACE);
 
-  emscripten_set_canvas_size("#canvas", 100, 200);
+  emscripten_set_canvas_element_size("#canvas", 100, 200);
 
   emscripten_set_main_loop(loop, 0, 0);
 }


### PR DESCRIPTION
Looks like some files were missed in #7998. Figured I'd change these to reduce the number of errors shown in the tests.