### PR TITLE
Update ChangeLog.md

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -16,13 +16,13 @@ full changeset diff at the end of each section.
 Current Trunk
 -------------
 
-v1.38.34: 06/03/2019
+v1.38.33: 06/03/2019
 --------------------
  - Add support for [undefined behavior sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html).
      - This allows `emcc -fsanitize=undefined` to work. (#8651)
      - The minimal runtime (`-fsanitize-minimal-runtime`) also works. (#8617)
 
-v1.38.33: 05/23/2019
+v1.38.32: 05/20/2019
 --------------------
  - First release to use the new chromium build infrastructure
    https://groups.google.com/forum/#!msg/emscripten-discuss/WhDtqVyW_Ak/8DfDnfk0BgAJ


### PR DESCRIPTION
As far as I see 1.38.33 tag wasn't released.
Also this ChangeLog didn't mention version 1.38.32