### PR TITLE
Fix pthreads + memory growth

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1263,7 +1263,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           exit_with_error('Memory growth is not supported with pthreads without wasm')
         else:
           logging.warning('USE_PTHREADS + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271')
-          options.force_js_opts = options.js_opts = True # for JS instrumentation
       # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
       shared.Settings.TEXTDECODER = 0
       options.js_libraries.append(shared.path_from_root('src', 'library_pthread.js'))
@@ -2810,6 +2809,10 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
 
   if shared.Settings.SIDE_MODULE:
     sys.exit(0) # and we are done.
+
+  # pthreads memory growth requires some additional JS fixups
+  if shared.Settings.USE_PTHREADS and shared.Settings.ALLOW_MEMORY_GROWTH:
+    final = shared.Building.apply_wasm_memory_growth(final)
 
   if options.opt_level >= 2 and options.debug_level <= 2:
     # minify the JS

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -475,8 +475,7 @@ EMSCRIPTEN_FUNCS();
       temp_files.note(filename)
 
   with ToolchainProfiler.profile_block('split_closure_cleanup'):
-    wasm_pthreads_memory_growth = shared.Settings.WASM and shared.Settings.USE_PTHREADS and shared.Settings.ALLOW_MEMORY_GROWTH
-    if closure or cleanup or wasm_pthreads_memory_growth:
+    if closure or cleanup:
       # run on the shell code, everything but what we js-optimize
       start_asm = '// EMSCRIPTEN_START_ASM\n'
       end_asm = '// EMSCRIPTEN_END_ASM\n'
@@ -490,17 +489,6 @@ EMSCRIPTEN_FUNCS();
           f.write(cl_sep)
           f.write(post_2)
         cld = cle
-        if wasm_pthreads_memory_growth:
-          if DEBUG:
-            print('supporting wasm memory growth with pthreads', file=sys.stderr)
-          cld = run_on_chunk(js_engine + [JS_OPTIMIZER, cld, 'growableHeap'])
-          with open(cld, 'r') as f:
-            src = f.read()
-          with open(cld, 'w') as f:
-            with open(shared.path_from_root('src', 'growableHeap.js')) as g:
-              f.write(g.read() + '\n')
-            f.write(src)
-            f.write(suffix_marker)
         if closure:
           if DEBUG:
             print('running closure on shell code', file=sys.stderr)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2657,6 +2657,17 @@ class Building(object):
       try_delete(wasm_file)
     return js_file
 
+  @staticmethod
+  def apply_wasm_memory_growth(js_file):
+    logger.debug('supporting wasm memory growth with pthreads')
+    fixed = Building.js_optimizer_no_asmjs(js_file, ['growableHeap'])
+    ret = js_file + '.pgrow.js'
+    with open(fixed, 'r') as fixed_f:
+      with open(ret, 'w') as ret_f:
+        with open(path_from_root('src', 'growableHeap.js')) as support_code_f:
+          ret_f.write(support_code_f.read() + '\n' + fixed_f.read())
+    return ret
+
   # the exports the user requested
   user_requested_exports = []
 


### PR DESCRIPTION
Do not run the normal js optimizer, as in fastcomp that disallows wasm-only mode (it thinks asm.js is being optimized), which causes different codegen (no native i64s, differences in float-to-int conversions, larger code size, etc.). Instead, do this cleanly at the end of the compilation pipeline.