### PR TITLE
Fix browser.test_gl_textures

### DIFF
--- a/tests/gl_textures.cpp
+++ b/tests/gl_textures.cpp
@@ -10,6 +10,7 @@
 #include <GLES2/gl2.h>
 #include <math.h>
 #include <assert.h>
+#include <stdlib.h>
 
 void report_result(int result)
 {
@@ -41,7 +42,7 @@ void draw()
   glClear(GL_COLOR_BUFFER_BIT);
   glDrawArrays(GL_TRIANGLES, 0, 6);
 
-  unsigned char imageData[256*256*4];
+  unsigned char* imageData = (unsigned char*)malloc(256*256*4*sizeof(unsigned char));
   glReadPixels(0, 0, 256, 256, GL_RGBA, GL_UNSIGNED_BYTE, imageData);
   for(int y = 0; y < 256; ++y)
     for(int x = 0; x < 256; ++x)
@@ -129,7 +130,7 @@ int main()
   glBindTexture(GL_TEXTURE_2D, tex);
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
   glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-  float texData[256*256];
+  float* texData = (float*)malloc(256*256*sizeof(float));
   for(int y = 0; y < 256; ++y)
     for(int x = 0; x < 256; ++x)
     {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1872,7 +1872,7 @@ keydown(100);keyup(100); // trigger the end
   @requires_graphics_hardware
   @requires_threads
   def test_gl_textures(self):
-    for args in [[], ['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1']]:
+    for args in [[], ['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1']]:
       self.btest('gl_textures.cpp', '0', args=['-lGL'] + args)
 
   @requires_graphics_hardware


### PR DESCRIPTION
The pthreads part was enabled there in #8715, fixing an oversight from before with args just being ignored. But it didn't actually pass, it turns out, due to (1) excessive stack allocation, and pthreads stacks are smaller, and (2) it calls glCreateShader etc. on a background thread, which requires offscreen canvas and/or offscreen framebuffer. The breakage was missed in random CI noise, sadly.

This will hopefully make the firefox CI green again.