### PR TITLE
Avoid os.linesep in other.test_emcc_1

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -200,7 +200,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # -dumpversion
       output = run_process([PYTHON, compiler, '-dumpversion'], stdout=PIPE, stderr=PIPE)
-      self.assertEqual(shared.EMSCRIPTEN_VERSION + os.linesep, output.stdout, 'results should be identical')
+      self.assertEqual(shared.EMSCRIPTEN_VERSION, output.stdout.rstrip(), 'results should be identical')
 
       # emcc src.cpp ==> writes a.out.js and a.out.wasm
       self.clear()


### PR DESCRIPTION
This may fix it on windows if we only emit a newline there.

(But maybe I should get a windows VM and test there directly...)