### PR TITLE
Set user language from HTTP Accept-Language

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,7 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Set ENV['LANG'] following the user's preferred language (HTTP Accept-Language / navigator.languages[0])
 
  - `emscripten_run_script_string` now returns C `NULL` instead of the string `null`
    or `undefined` when the result of the `eval` is JavaScript `null` or `undefined`.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,7 +18,7 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- Set ENV['LANG'] following the user's preferred language (HTTP Accept-Language / navigator.languages[0])
+ - Set ENV['LANG'] following the user's preferred language (HTTP Accept-Language / navigator.languages[0])
 
  - `emscripten_run_script_string` now returns C `NULL` instead of the string `null`
    or `undefined` when the result of the `eval` is JavaScript `null` or `undefined`.

--- a/src/library.js
+++ b/src/library.js
@@ -884,7 +884,7 @@ LibraryManager.library = {
       ENV['HOME'] = '/home/web_user';
       ENV['LANG'] = 'C.UTF-8';
       // Browser language detection #8751
-      ENV['LANG'] = (typeof navigator === 'object' && navigator.languages && navigator.languages[0] || 'C').replace('-', '_') + '.UTF-8';
+      ENV['LANG'] = ((typeof navigator === 'object' && navigator.languages && navigator.languages[0]) || 'C').replace('-', '_') + '.UTF-8';
       ENV['_'] = Module['thisProgram'];
       // Allocate memory.
 #if !MINIMAL_RUNTIME // TODO: environment support in MINIMAL_RUNTIME

--- a/src/library.js
+++ b/src/library.js
@@ -883,9 +883,8 @@ LibraryManager.library = {
       ENV['PWD'] = '/';
       ENV['HOME'] = '/home/web_user';
       ENV['LANG'] = 'C.UTF-8';
-      if (typeof navigator === 'object' && typeof navigator.languages === 'object' && navigator.languages.length > 0) {
-        ENV['LANG'] = navigator.languages[0].replace('-', '_') + '.UTF-8';
-      }
+      // Browser language detection #8751
+      ENV['LANG'] = (typeof navigator === 'object' && navigator.languages && navigator.languages[0] || 'C').replace('-', '_') + '.UTF-8';
       ENV['_'] = Module['thisProgram'];
       // Allocate memory.
 #if !MINIMAL_RUNTIME // TODO: environment support in MINIMAL_RUNTIME

--- a/src/library.js
+++ b/src/library.js
@@ -883,6 +883,9 @@ LibraryManager.library = {
       ENV['PWD'] = '/';
       ENV['HOME'] = '/home/web_user';
       ENV['LANG'] = 'C.UTF-8';
+      if (typeof navigator === 'object' && typeof navigator.languages === 'object' && navigator.languages.length > 0) {
+        ENV['LANG'] = navigator.languages[0].replace('-', '_') + '.UTF-8';
+      }
       ENV['_'] = Module['thisProgram'];
       // Allocate memory.
 #if !MINIMAL_RUNTIME // TODO: environment support in MINIMAL_RUNTIME

--- a/tests/test_browser_language_detection.c
+++ b/tests/test_browser_language_detection.c
@@ -3,10 +3,13 @@
 #include <locale.h>
 
 int main(int argc, char** argv) {
-  printf("%s\n", getenv("LANG"));
+  if (getenv("LANG")) {
+    printf("%s\n", getenv("LANG"));
+  }
 
 #ifndef __EMSCRIPTEN__
-  // emscripten has no locale support in *scanf as of 2019-06
+  // Emscripten has no locale support in *scanf as of 2019-06.
+  // These tests for future use - or native/desktop testing:
   char* cur_locale = setlocale(LC_ALL, "");
   printf("locale: %s\n", cur_locale);
   float ret = 0;
@@ -16,8 +19,9 @@ int main(int argc, char** argv) {
   printf("%f\n", ret);
   
   // Expected results:
-  // LANG=C: 1 / 3.4
-  // LANG=fr_FR.UTF-8: 1,2 / 3
-  // Note: locale needs to be installed (cf. `locale -a`)
+  // LANG=C ./a.out: 1 / 3.4
+  // LANG=fr_FR.UTF-8 ./a.out: 1,2 / 3
+  // Note: requested locale needs to be installed locally (cf. `locale -a`)
+  //       otherwise setlocale(3) is no-op
 #endif
 }

--- a/tests/test_browser_language_detection.c
+++ b/tests/test_browser_language_detection.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <locale.h>
+
+int main(int argc, char** argv) {
+  printf("%s\n", getenv("LANG"));
+
+#ifndef __EMSCRIPTEN__
+  // emscripten has no locale support in *scanf as of 2019-06
+  char* cur_locale = setlocale(LC_ALL, "");
+  printf("locale: %s\n", cur_locale);
+  float ret = 0;
+  sscanf("1,2", "%f", &ret);
+  printf("%f\n", ret);
+  sscanf("3.4", "%f", &ret);
+  printf("%f\n", ret);
+  
+  // Expected results:
+  // LANG=C: 1 / 3.4
+  // LANG=fr_FR.UTF-8: 1,2 / 3
+  // Note: locale needs to be installed (cf. `locale -a`)
+#endif
+}


### PR DESCRIPTION
This allows users to start the app/game with LANG set to their preferred language, avoiding the need to explicitly change it in the app's GUI, POSIX-style.
e.g. 
```
Accept-Language: fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3
> navigator.languages = Array(4) [ "fr", "fr-FR", "en-US", "en" ]
> LANG=fr.UTF-8
```
