### PR TITLE
Browser suite fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,117 @@ test-defaults: &test-defaults
         command: |
           EMCC_CORES=4 python3 emscripten/tests/runner.py $TEST_TARGET
 
+test-firefox: &test-firefox
+  <<: *defaults
+  environment:
+  working_directory: ~/
+  steps:
+    - checkout:
+        path: emscripten/
+    - attach_workspace:
+        # Must be absolute path or relative path from working_directory
+        at: ~/
+    - run:
+        name: install package dependencies
+        command: |
+          apt-get update -q
+          apt-get install -q -y python3 cmake build-essential openjdk-8-jre-headless
+          # preseed packages so that apt-get won't prompt for user input
+          echo "keyboard-configuration keyboard-configuration/layoutcode string us" | debconf-set-selections
+          echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
+          apt-get install -q -y dbus-x11 firefox menu openbox ttf-mscorefonts-installer xinit xserver-xorg xserver-xorg-video-dummy
+    - run:
+        name: download firefox
+        command: |
+          FF_VERSION=65.0.2
+          wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FF_VERSION/linux-x86_64/en-US/firefox-$FF_VERSION.tar.bz2
+          tar xf firefox-$FF_VERSION.tar.bz2
+          # wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+          # tar xf nightly.tar.bz2
+    - run:
+        name: configure firefox
+        command: |
+          mkdir tmp-firefox-profile/
+          cat > tmp-firefox-profile/user.js <<EOF
+          user_pref("gfx.offscreencanvas.enabled", true);
+          user_pref("javascript.options.shared_memory", true);
+          EOF
+    - run:
+        name: configure openbox
+        command: |
+          # Set up X and Openbox config (if we move to a headless browser, this may not be needed).
+          mkdir -p .config/X11
+          cat > .config/X11/xorg.conf <<EOF
+          Section "ServerLayout"
+            Identifier "X.org Configured"
+            Screen 0 "Screen0" 0 0
+          EndSection
+
+          Section "Monitor"
+            Identifier "Monitor0"
+            HorizSync 72
+            Modeline "1920x1080@60" 144 1920 1920 1960 2000 1080 1080 1140 1200
+          EndSection
+
+          Section "Device"
+            Identifier "Card0"
+            Driver "dummy"
+            VideoRam 1048576
+          EndSection
+
+          Section "Screen"
+            Identifier "Screen0"
+            Device "Card0"
+            Monitor "Monitor0"
+            DefaultDepth 24
+            SubSection "Display"
+              Depth 24
+              Modes "1920x1080@60"
+            EndSubSection
+          EndSection
+          EOF
+          mkdir -p .config/openbox
+          echo "[ -f \"\$EXTRA_AUTOSTART\" ] && sh \"\$EXTRA_AUTOSTART\"" > .config/openbox/autostart
+          mkdir -p .config/autostart
+          cat > .config/autostart/at-spi-dbus-bus.desktop <<EOF
+          [Desktop Entry]
+          Type=Application
+          Name=AT-SPI D-Bus Bus
+          Hidden=true # do not auto-start AT-SPI to suppress one warning
+          EOF
+    - run:
+        # browser.test_sdl2_mouse and/or SDL2 should be fixed. The case happens
+        # to be failing here, and the root cause might be related with the
+        # initial position of the mouse pointer relative to the canvas.
+        # browser.test_html5_webgl_create_context is skipped because
+        # anti-aliasing is not well supported.
+        # browser.test_webgl_offscreen_canvas_in_pthread and
+        # browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
+        # are crashing Firefox (bugzil.la/1281796). The former case is
+        # further blocked by issue #6897.
+        # TODO: use Firefox headless mode when https://bugzil.la/1375585 resolves
+        name: run tests
+        command: |
+          export EMTEST_BROWSER="$HOME/firefox/firefox -profile tmp-firefox-profile/"
+          export GALLIUM_DRIVER=softpipe # TODO: use the default llvmpipe when it supports more extensions
+          export EMTEST_LACKS_SOUND_HARDWARE=1
+          export EMTEST_DETECT_TEMPFILE_LEAKS=0
+          export DISPLAY=:0
+          # Start an X session. Openbox might be optional for now, but
+          # an ICCCM/EWMH compliant window manager is potentially needed
+          # for tests with fullscreen toggling (if we move to a headless
+          # browser, this may not be needed eventually).
+          TMPDIR=`mktemp -d`
+          mkfifo $TMPDIR/fifo
+          echo "echo -n > $TMPDIR/fifo" > $TMPDIR/autostart
+          EXTRA_AUTOSTART=$TMPDIR/autostart startx /usr/bin/openbox-session -- $DISPLAY -config ~/.config/X11/xorg.conf -nolisten tcp &
+          cat $TMPDIR/fifo > /dev/null # wait until $EXTRA_AUTOSTART is spawned, which indicates the end of Openbox initialization
+          rm -r $TMPDIR
+          export EMCC_CORES=4
+          ./emscripten/tests/runner.py browser skip:browser.test_sdl2_mouse skip:browser.test_html5_webgl_create_context skip:browser.test_webgl_offscreen_canvas_in_pthread skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread skip:browser.test_glut_glutget
+          openbox --exit
+          wait # wait for startx to shutdown cleanly
+
 test-chrome: &test-chrome
   <<: *defaults
   environment:
@@ -142,115 +253,7 @@ jobs:
       # CircleCI actively kills memory-over-consuming process
       # skip llvm-lit tests which need lit, and pip to get lit, but pip has broken on CI
   test-browser-firefox:
-    <<: *defaults
-    environment:
-    working_directory: ~/
-    steps:
-      - checkout:
-          path: emscripten/
-      - attach_workspace:
-          # Must be absolute path or relative path from working_directory
-          at: ~/
-      - run:
-          name: install package dependencies
-          command: |
-            apt-get update -q
-            apt-get install -q -y python3 cmake build-essential openjdk-8-jre-headless
-            # preseed packages so that apt-get won't prompt for user input
-            echo "keyboard-configuration keyboard-configuration/layoutcode string us" | debconf-set-selections
-            echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
-            apt-get install -q -y dbus-x11 firefox menu openbox ttf-mscorefonts-installer xinit xserver-xorg xserver-xorg-video-dummy
-      - run:
-          name: download firefox
-          command: |
-            FF_VERSION=65.0.2
-            wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FF_VERSION/linux-x86_64/en-US/firefox-$FF_VERSION.tar.bz2
-            tar xf firefox-$FF_VERSION.tar.bz2
-            # wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
-            # tar xf nightly.tar.bz2
-      - run:
-          name: configure firefox
-          command: |
-            mkdir tmp-firefox-profile/
-            cat > tmp-firefox-profile/user.js <<EOF
-            user_pref("gfx.offscreencanvas.enabled", true);
-            user_pref("javascript.options.shared_memory", true);
-            EOF
-      - run:
-          name: configure openbox
-          command: |
-            # Set up X and Openbox config (if we move to a headless browser, this may not be needed).
-            mkdir -p .config/X11
-            cat > .config/X11/xorg.conf <<EOF
-            Section "ServerLayout"
-              Identifier "X.org Configured"
-              Screen 0 "Screen0" 0 0
-            EndSection
-
-            Section "Monitor"
-              Identifier "Monitor0"
-              HorizSync 72
-              Modeline "1920x1080@60" 144 1920 1920 1960 2000 1080 1080 1140 1200
-            EndSection
-
-            Section "Device"
-              Identifier "Card0"
-              Driver "dummy"
-              VideoRam 1048576
-            EndSection
-
-            Section "Screen"
-              Identifier "Screen0"
-              Device "Card0"
-              Monitor "Monitor0"
-              DefaultDepth 24
-              SubSection "Display"
-                Depth 24
-                Modes "1920x1080@60"
-              EndSubSection
-            EndSection
-            EOF
-            mkdir -p .config/openbox
-            echo "[ -f \"\$EXTRA_AUTOSTART\" ] && sh \"\$EXTRA_AUTOSTART\"" > .config/openbox/autostart
-            mkdir -p .config/autostart
-            cat > .config/autostart/at-spi-dbus-bus.desktop <<EOF
-            [Desktop Entry]
-            Type=Application
-            Name=AT-SPI D-Bus Bus
-            Hidden=true # do not auto-start AT-SPI to suppress one warning
-            EOF
-      - run:
-          # browser.test_sdl2_mouse and/or SDL2 should be fixed. The case happens
-          # to be failing here, and the root cause might be related with the
-          # initial position of the mouse pointer relative to the canvas.
-          # browser.test_html5_webgl_create_context is skipped because
-          # anti-aliasing is not well supported.
-          # browser.test_webgl_offscreen_canvas_in_pthread and
-          # browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread
-          # are crashing Firefox (bugzil.la/1281796). The former case is
-          # further blocked by issue #6897.
-          # TODO: use Firefox headless mode when https://bugzil.la/1375585 resolves
-          name: run tests
-          command: |
-            export EMTEST_BROWSER="$HOME/firefox/firefox -profile tmp-firefox-profile/"
-            export GALLIUM_DRIVER=softpipe # TODO: use the default llvmpipe when it supports more extensions
-            export EMTEST_LACKS_SOUND_HARDWARE=1
-            export EMTEST_DETECT_TEMPFILE_LEAKS=0
-            export DISPLAY=:0
-            # Start an X session. Openbox might be optional for now, but
-            # an ICCCM/EWMH compliant window manager is potentially needed
-            # for tests with fullscreen toggling (if we move to a headless
-            # browser, this may not be needed eventually).
-            TMPDIR=`mktemp -d`
-            mkfifo $TMPDIR/fifo
-            echo "echo -n > $TMPDIR/fifo" > $TMPDIR/autostart
-            EXTRA_AUTOSTART=$TMPDIR/autostart startx /usr/bin/openbox-session -- $DISPLAY -config ~/.config/X11/xorg.conf -nolisten tcp &
-            cat $TMPDIR/fifo > /dev/null # wait until $EXTRA_AUTOSTART is spawned, which indicates the end of Openbox initialization
-            rm -r $TMPDIR
-            export EMCC_CORES=4
-            ./emscripten/tests/runner.py browser skip:browser.test_sdl2_mouse skip:browser.test_html5_webgl_create_context skip:browser.test_webgl_offscreen_canvas_in_pthread skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread skip:browser.test_glut_glutget
-            openbox --exit
-            wait # wait for startx to shutdown cleanly
+    <<: *test-firefox
   test-browser-chrome:
     <<: *test-chrome
   test-ab:
@@ -389,6 +392,8 @@ jobs:
       # see explanations in the fastcomp skips for these, earlier
   test-upstream-browser-chrome:
     <<: *test-chrome
+  test-upstream-browser-firefox:
+    <<: *test-firefox
 
 workflows:
   version: 2
@@ -463,6 +468,9 @@ workflows:
           requires:
             - build-upstream
       - test-upstream-browser-chrome:
+          requires:
+            - build-upstream
+      - test-upstream-browser-firefox:
           requires:
             - build-upstream
 

--- a/tests/gl_only_in_pthread.cpp
+++ b/tests/gl_only_in_pthread.cpp
@@ -90,6 +90,14 @@ void PollThreadExit(void *)
 
 int main()
 {
+  if (!emscripten_supports_offscreencanvas())
+  {
+    printf("Current browser does not support OffscreenCanvas. Skipping this test.\n");
+#ifdef REPORT_RESULT
+    REPORT_RESULT(0);
+#endif
+    return 0;
+  }
   EM_ASM(Module['noExitRuntime'] = true;);
   CreateThread();
   emscripten_async_call(PollThreadExit, 0, 100);

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1502,12 +1502,12 @@ class BrowserCore(RunnerCore):
       }
 ''' % (reporting.read(), basename, int(manually_trigger)))
 
-  def skip_if_wasm_backend_pthreads_js(self, args):
-    if self.is_wasm_backend() and ('USE_PTHREADS=1' in args or '-pthread' in args) and 'WASM=0' in args:
-      self.skipTest('wasm2js does not support threads yet')
+  def check_btest_skip(self, args):
+    if self.is_wasm_backend() and 'WASM=0' in args:
+      self.skipTest('wasm2js does not yet support threads, dynamic linking, and some other features; skip browser testing for now')
 
   def compile_btest(self, args):
-    self.skip_if_wasm_backend_pthreads_js(args)
+    self.check_btest_skip(args)
     run_process([PYTHON, EMCC] + args + ['--pre-js', path_from_root('tests', 'browser_reporting.js')])
 
   def btest(self, filename, expected=None, reference=None, force_c=False,
@@ -1516,7 +1516,7 @@ class BrowserCore(RunnerCore):
             url_suffix='', timeout=None, also_asmjs=False,
             manually_trigger_reftest=False):
     assert expected or reference, 'a btest must either expect an output, or have a reference image'
-    self.skip_if_wasm_backend_pthreads_js(args)
+    self.check_btest_skip(args)
     # if we are provided the source and not a path, use that
     filename_is_src = '\n' in filename
     src = filename if filename_is_src else ''

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3449,7 +3449,7 @@ window.close = function() {
   def test_dylink_dso_needed_asmjs_inworker(self):
     self._test_dylink_dso_needed(0, 1)
 
-  @no_wasm_backend('#8753')
+  @no_wasm_backend('https://github.com/emscripten-core/emscripten/issues/8753')
   @requires_sync_compilation
   def _test_dylink_dso_needed(self, wasm, inworker):
     # here we reuse runner._test_dylink_dso_needed, but the code is run via browser.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -110,7 +110,7 @@ def requires_threads(f):
   def decorated(self):
     if os.environ.get('EMTEST_LACKS_THREAD_SUPPORT'):
       self.skipTest('EMTEST_LACKS_THREAD_SUPPORT is set')
-    if EMTEST_BROWSER and 'chrom' in EMTEST_BROWSER.lower():
+    if is_chrome():
       self.skipTest('Chrome leaks pthreads memory, https://bugs.chromium.org/p/v8/issues/detail?id=9075')
     return f(self)
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -110,6 +110,8 @@ def requires_threads(f):
   def decorated(self):
     if os.environ.get('EMTEST_LACKS_THREAD_SUPPORT'):
       self.skipTest('EMTEST_LACKS_THREAD_SUPPORT is set')
+    if EMTEST_BROWSER and 'chrom' in EMTEST_BROWSER.lower():
+      self.skipTest('Chrome leaks pthreads memory, https://bugs.chromium.org/p/v8/issues/detail?id=9075')
     return f(self)
 
   return decorated

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1925,7 +1925,7 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_matrix_identity(self):
-    self.btest('gl_matrix_identity.c', expected=['-1882984448', '460451840', '1588195328'], args=['-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL'])
+    self.btest('gl_matrix_identity.c', expected=['-1882984448', '460451840', '1588195328', '2411982848'], args=['-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
   @no_swiftshader

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3044,7 +3044,7 @@ Module['onRuntimeInitialized'] = function() {
     self.btest('sdl2_canvas_palette_2.c', reference='sdl_canvas_palette_b.png', args=['-s', 'USE_SDL=2', '--pre-js', 'args-b.js'])
 
   def test_sdl2_swsurface(self):
-    self.btest('sdl2_swsurface.c', expected='1', args=['-s', 'USE_SDL=2'])
+    self.btest('sdl2_swsurface.c', expected='1', args=['-s', 'USE_SDL=2', '-s', 'TOTAL_MEMORY=64MB'])
 
   @requires_graphics_hardware
   def test_sdl2_image_prepare(self):
@@ -3449,6 +3449,7 @@ window.close = function() {
   def test_dylink_dso_needed_asmjs_inworker(self):
     self._test_dylink_dso_needed(0, 1)
 
+  @no_wasm_backend('#8753')
   @requires_sync_compilation
   def _test_dylink_dso_needed(self, wasm, inworker):
     # here we reuse runner._test_dylink_dso_needed, but the code is run via browser.
@@ -4360,6 +4361,7 @@ window.close = function() {
 
   # Tests memory growth in pthreads mode, but still on the main thread.
   @no_chrome('https://bugs.chromium.org/p/v8/issues/detail?id=9062')
+  @no_wasm_backend('TODO - fix final pthreads tests (#8718)')
   @requires_threads
   def test_pthread_growth_mainthread(self):
     def run(emcc_args=[]):
@@ -4371,6 +4373,7 @@ window.close = function() {
 
   # Tests memory growth in a pthread.
   @no_chrome('https://bugs.chromium.org/p/v8/issues/detail?id=9065')
+  @no_wasm_backend('TODO - fix final pthreads tests (#8718)')
   @requires_threads
   def test_pthread_growth(self):
     def run(emcc_args=[]):


### PR DESCRIPTION
Latest Chrome stable has a bug with pthreads that breaks our CI, https://bugs.chromium.org/p/v8/issues/detail?id=9075 To work around that, disable pthreads tests on Chrome for now.

To avoid test coverage loss, add a `firefox-upstream` test mode (previously we only tested the upstream backend on chrome).

This noticed a few bugs that our lower coverage from earlier missed, and includes fixes for them.

Also skip wasm2js in the browser tests for now, as it is missing a bunch of features (dynamic linking, pthreads, etc.).