### PR TITLE
Final test tweaks for wasm2js

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1527,6 +1527,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.WASM2JS:
       if not shared.Settings.WASM_BACKEND:
         exit_with_error('wasm2js is only available in the upstream wasm backend path')
+      if use_source_map(options):
+        exit_with_error('wasm2js does not support source maps yet (debug in wasm for now)')
       logger.warning('emcc: JS support in the upstream LLVM+wasm2js path is very experimental currently (best to use fastcomp for asm.js for now)')
 
     # wasm outputs are only possible with a side wasm

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -50,7 +50,7 @@ def wasm_simd(f):
       self.skipTest('wasm simd not compatible with asm.js or asm2wasm')
     if not V8_ENGINE or V8_ENGINE not in JS_ENGINES:
       self.skipTest('wasm simd only supported in d8 for now')
-    if self.get_setting('WASM2JS'):
+    if self.is_wasm_backend() and not self.get_setting('WASM'):
       self.skipTest('wasm2js only supports MVP for now')
     self.set_setting('SIMD', 1)
     self.emcc_args.append('-fno-lax-vector-conversions')
@@ -68,6 +68,14 @@ def no_wasm(note=''):
 
   def decorated(f):
     return skip_if(f, 'is_wasm', note)
+  return decorated
+
+
+def no_wasm2js(f):
+  def decorated(self):
+    if self.is_wasm_backend() and not self.get_setting('WASM'):
+      self.skipTest('wasm2js not supported')
+    f(self)
   return decorated
 
 
@@ -1863,6 +1871,7 @@ int main(int argc, char **argv) {
   def test_cxx03_do_run(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_cxx03_do_run')
 
+  @no_wasm2js # massive switches can break js engines
   @no_emterpreter
   def test_bigswitch(self):
     src = open(path_from_root('tests', 'bigswitch.cpp')).read()
@@ -1872,6 +1881,7 @@ int main(int argc, char **argv) {
 3060: what?
 ''', args=['34962', '26214', '35040', str(0xbf4)])
 
+  @no_wasm2js # massive switches can break js engines
   @no_emterpreter
   @is_slow_test
   def test_biggerswitch(self):
@@ -6402,6 +6412,7 @@ return malloc(size);
                 ('|1.266,1|',                 # asm.js, double <-> int
                  '|1.266,1413754136|')) # wasm, reinterpret the bits
 
+  @no_wasm2js # TODO: nicely printed names in wasm2js
   def test_demangle_stacks(self):
     self.set_setting('DEMANGLE_SUPPORT', 1)
     self.set_setting('ASSERTIONS', 1)
@@ -6780,6 +6791,7 @@ err = err = function(){};
 
   ### Tests for tools
 
+  @no_wasm2js # TODO: source maps in wasm2js
   @no_emterpreter
   def test_source_map(self):
     if not jsrun.check_engine(NODE_JS):


### PR DESCRIPTION
Disable the big switch and debug info tests there, see https://github.com/WebAssembly/binaryen/issues/1929#issuecomment-499695920