### PR TITLE
Added 64-bit file support to seeking

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -88,7 +88,7 @@ a license to everyone to use it as detailed in LICENSE.)
 * Joseph Gentle <me@josephg.com>
 * Douglas T. Crosher <dtc-moz@scieneer.com> (copyright owned by Mozilla Foundation)
 * Douglas T. Crosher <info@jsstats.com> (copyright owned by Scieneer Pty Ltd.)
-* Soeren Balko <soeren.balko@gmail.com>
+* Soeren Balko <soeren.balko@gmail.com> (copyright owned by Clipchamp Pty Ltd.)
 * Ryan Kelly (ryan@rfk.id.au)
 * Michael Lelli <toadking@toadking.com>
 * Yu Kobayashi <yukoba@accelart.jp>
@@ -409,3 +409,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Denis Serebro <densilver3000@gmail.com>
 * Lucas Ramage <ramage.lucas@protonmail.com>
 * Andy Wingo <wingo@igalia.com> (copyright owned by Igalia)
+* Joshua Minter <josh@minteronline.com> (copyright owned by Clipchamp Pty Ltd.)

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -756,6 +756,9 @@ var SyscallsLibrary = {
     var DOUBLE_LIMIT = 0x20000000000000; // 2^53
     // we also check for equality since DOUBLE_LIMIT + 1 == DOUBLE_LIMIT
     if (offset <= -DOUBLE_LIMIT || offset >= DOUBLE_LIMIT) {
+#if ASSERTIONS
+      abort('reached accurate limit for doubles');
+#endif
       return -{{{ cDefine('EOVERFLOW') }}};
     }
 #else

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -755,9 +755,6 @@ var SyscallsLibrary = {
     var DOUBLE_LIMIT = 0x20000000000000; // 2^53
     // we also check for equality since DOUBLE_LIMIT + 1 == DOUBLE_LIMIT
     if (offset <= -DOUBLE_LIMIT || offset >= DOUBLE_LIMIT) {
-#if ASSERTIONS
-      abort('reached accurate limit for doubles');
-#endif
       return -{{{ cDefine('EOVERFLOW') }}};
     }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -570,10 +570,6 @@ var FILESYSTEM = 1;
 // some JS that does, you might need this.
 var FORCE_FILESYSTEM = 0;
 
-// Add support for 64-bit files. Do keep in mind however, that JavaScript cannot
-// accurately support all 64-bit values.
-var LARGE_FILESYSTEM = 0;
-
 // This mode is intended for use with Node.js (and will throw if the build runs
 // in other engines).  The File System API will directly use Node.js API without
 // requiring `FS.mount()`.  The initial working directory will be same as

--- a/src/settings.js
+++ b/src/settings.js
@@ -570,6 +570,10 @@ var FILESYSTEM = 1;
 // some JS that does, you might need this.
 var FORCE_FILESYSTEM = 0;
 
+// Add support for 64-bit files. Do keep in mind however, that JavaScript cannot
+// accurately support all 64-bit values.
+var LARGE_FILESYSTEM = 0;
+
 // This mode is intended for use with Node.js (and will throw if the build runs
 // in other engines).  The File System API will directly use Node.js API without
 // requiring `FS.mount()`.  The initial working directory will be same as

--- a/tests/fs/test_64bit.c
+++ b/tests/fs/test_64bit.c
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 The Emscripten Authors.  All rights reserved.
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
  * Emscripten is available under two separate licenses, the MIT license and the
  * University of Illinois/NCSA Open Source License.  Both these licenses can be
  * found in the LICENSE file.

--- a/tests/fs/test_64bit.c
+++ b/tests/fs/test_64bit.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2014 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <emscripten.h>
+#include <stdio.h>
+#include <assert.h>
+
+int main(int argc, char *argv[])
+{
+  EM_ASM({
+    var counter = FS.makedev(64, 0);
+
+    FS.registerDevice(counter, {
+      open: function(stream) {},
+      close: function(stream) {},
+      read: function(stream, buffer, offset, length, position) {
+        for (var i = 0; i < length; ++i) {
+          buffer[offset + i] = position + i;
+        }
+        return length;
+      },
+      llseek(stream, offset, whence) {
+        var position = offset;
+        if (whence === 1) {
+          position += stream.position;
+        }
+        return position;
+      }
+    });
+
+    FS.mkdev('/counter', counter);
+  });
+
+  FILE* file = fopen("/counter", "rb");
+  assert(file != NULL);
+  fseeko(file, 0x10000005A, SEEK_SET);
+  assert(fgetc(file) == 0x5A);
+  fclose(file);
+
+  puts("success");
+  return 0;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4895,7 +4895,6 @@ main( int argv, char ** argc ) {
     self.do_run(src, 'success', force_c=True, js_engines=js_engines)
 
   def test_fs_64bit(self, js_engines=None):
-    self.set_setting('LARGE_FILESYSTEM', 1)
     src = open(path_from_root('tests', 'fs', 'test_64bit.c')).read()
     self.do_run(src, 'success', force_c=True, js_engines=js_engines)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4894,6 +4894,11 @@ main( int argv, char ** argc ) {
     src = open(path_from_root('tests', 'fs', 'test_llseek.c')).read()
     self.do_run(src, 'success', force_c=True, js_engines=js_engines)
 
+  def test_fs_64bit(self, js_engines=None):
+    self.set_setting('LARGE_FILESYSTEM', 1)
+    src = open(path_from_root('tests', 'fs', 'test_64bit.c')).read()
+    self.do_run(src, 'success', force_c=True, js_engines=js_engines)
+
   def test_unistd_access(self):
     self.clear()
     orig_compiler_opts = self.emcc_args[:]


### PR DESCRIPTION
Can be optionally enabled with the `LARGE_FILESYSTEM` flag. There is still a hard limit at 2^53 due to the accuracy limit on JavaScript files but that is about 8 petabytes which is alot larger than the current limit of 2 gigabytes.

Relates to issue #5250.