### PR TITLE
Add compatibility for source maps with v8's stack frame format

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1086,7 +1086,7 @@ function createWasm(env) {
         typeof fetch === 'function') {
       fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
 #if 'emscripten_generate_pc' in addedLibraryItems
-        response.clone().arrayBuffer().then(buffer => {
+        response.clone().arrayBuffer().then(function (buffer) {
           wasmOffsetConverter = new WasmOffsetConverter(new Uint8Array(buffer));
           removeRunDependency('offset-converter');
         });

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1086,6 +1086,8 @@ function createWasm(env) {
         typeof fetch === 'function') {
       fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
 #if 'emscripten_generate_pc' in addedLibraryItems
+        // This doesn't actually do another request, it only copies the Response object.
+        // Copying lets us consume it independently of WebAssembly.instantiateStreaming.
         response.clone().arrayBuffer().then(function (buffer) {
           wasmOffsetConverter = new WasmOffsetConverter(new Uint8Array(buffer));
           removeRunDependency('offset-converter');

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -897,6 +897,11 @@ var wasmSourceMap;
 #include "source_map_support.js"
 #endif
 
+#if 'emscripten_generate_pc' in addedLibraryItems
+var wasmOffsetConverter;
+#include "wasm_offset_converter.js"
+#endif
+
 // Create the wasm instance.
 // Receives the wasm imports, returns the exports.
 function createWasm(env) {
@@ -1055,8 +1060,16 @@ function createWasm(env) {
 #endif
   }
 
+#if 'emscripten_generate_pc' in addedLibraryItems
+  addRunDependency('offset-converter');
+#endif
+
   function instantiateArrayBuffer(receiver) {
     return getBinaryPromise().then(function(binary) {
+#if 'emscripten_generate_pc' in addedLibraryItems
+      wasmOffsetConverter = new WasmOffsetConverter(binary);
+      removeRunDependency('offset-converter');
+#endif
       return WebAssembly.instantiate(binary, info);
     }).then(receiver, function(reason) {
       err('failed to asynchronously prepare wasm: ' + reason);
@@ -1071,14 +1084,22 @@ function createWasm(env) {
         typeof WebAssembly.instantiateStreaming === 'function' &&
         !isDataURI(wasmBinaryFile) &&
         typeof fetch === 'function') {
-      return WebAssembly.instantiateStreaming(fetch(wasmBinaryFile, { credentials: 'same-origin' }), info)
-        .then(receiveInstantiatedSource, function(reason) {
-          // We expect the most common failure cause to be a bad MIME type for the binary,
-          // in which case falling back to ArrayBuffer instantiation should work.
-          err('wasm streaming compile failed: ' + reason);
-          err('falling back to ArrayBuffer instantiation');
-          instantiateArrayBuffer(receiveInstantiatedSource);
+      fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
+#if 'emscripten_generate_pc' in addedLibraryItems
+        response.clone().arrayBuffer().then(buffer => {
+          wasmOffsetConverter = new WasmOffsetConverter(new Uint8Array(buffer));
+          removeRunDependency('offset-converter');
         });
+#endif
+        return WebAssembly.instantiateStreaming(response, info)
+          .then(receiveInstantiatedSource, function(reason) {
+            // We expect the most common failure cause to be a bad MIME type for the binary,
+            // in which case falling back to ArrayBuffer instantiation should work.
+            err('wasm streaming compile failed: ' + reason);
+            err('falling back to ArrayBuffer instantiation');
+            instantiateArrayBuffer(receiveInstantiatedSource);
+          });
+      });
     } else {
       return instantiateArrayBuffer(receiveInstantiatedSource);
     }
@@ -1087,8 +1108,14 @@ function createWasm(env) {
   function instantiateSync() {
     var instance;
     var module;
+    var binary;
     try {
-      module = new WebAssembly.Module(getBinary());
+      binary = getBinary();
+#if 'emscripten_generate_pc' in addedLibraryItems
+      wasmOffsetConverter = new WasmOffsetConverter(binary);
+      removeRunDependency('offset-converter');
+#endif
+      module = new WebAssembly.Module(binary);
       instance = new WebAssembly.Instance(module, info);
     } catch (e) {
       err('failed to compile wasm module: ' + e);

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -39,6 +39,7 @@ function WasmSourceMap(sourceMap) {
 
   var offset = 0, src = 0, line = 1, col = 1, name = 0;
   sourceMap.mappings.split(',').forEach(function (segment, index) {
+    if (!segment) return;
     var data = decodeVLQ(segment);
     var info = {};
 

--- a/src/wasm_offset_converter.js
+++ b/src/wasm_offset_converter.js
@@ -1,4 +1,13 @@
 function WasmOffsetConverter(wasmBytes) {
+  // This class parses a WASM binary file, and constructs a mapping from
+  // function indices to the start of their code in the binary file.
+  //
+  // The main purpose of this module is to enable the conversion of function
+  // index and offset from start of function to an offset into the WASM binary.
+  // This is needed to look up the WASM source map as well as generate
+  // consistent program counter representations given v8's non-standard
+  // WASM stack trace format.
+
   var offset = 8;
   var count;
   var idx = 0;

--- a/src/wasm_offset_converter.js
+++ b/src/wasm_offset_converter.js
@@ -53,7 +53,7 @@ function WasmOffsetConverter(wasmBytes) {
         // since functions defined in the module are numbered after all imports
         var count = unsignedLEB128();
 
-        while (count --> 0) {
+        while (count-- > 0) {
           // skip module
           offset = unsignedLEB128() + offset;
           // skip name
@@ -79,7 +79,7 @@ function WasmOffsetConverter(wasmBytes) {
         break;
       case 10: // code section
         var count = unsignedLEB128();
-        while (count --> 0) {
+        while (count-- > 0) {
           var size = unsignedLEB128();
           this.map[funcidx++] = offset;
           offset += size;

--- a/src/wasm_offset_converter.js
+++ b/src/wasm_offset_converter.js
@@ -1,0 +1,73 @@
+function WasmOffsetConverter(wasmBytes) {
+  var offset = 8;
+  var count;
+  var idx = 0;
+
+  this.map = {};
+
+  function unsignedLEB128() {
+    var result = 0;
+    var shift = 0;
+    do {
+      var byte = wasmBytes[offset++];
+      result += (byte & 0x7F) << shift;
+      shift += 7;
+    } while (byte & 0x80);
+    return result;
+  }
+
+  function skipLimits() {
+    switch (wasmBytes[offset++]) {
+      case 1: unsignedLEB128(); // has both initial and maximum, fall through
+      case 0: unsignedLEB128(); // just initial
+    }
+  }
+
+  while (offset < wasmBytes.length) {
+    var start = offset;
+    var type = wasmBytes[offset++];
+    var end = unsignedLEB128() + offset;
+    switch (type) {
+      case 2: // import section
+        count = unsignedLEB128();
+
+        while (count --> 0) {
+          // skip module
+          offset = unsignedLEB128() + offset;
+          // skip name
+          offset = unsignedLEB128() + offset;
+
+          switch (wasmBytes[offset++]) {
+            case 0: // function import
+              ++idx;
+              unsignedLEB128(); // skip funcidx
+              break;
+            case 1: // table import
+              ++offset;
+              skipLimits();
+              break;
+            case 2: // memory import
+              skipLimits();
+              break;
+            case 3: // global import
+              offset += 2; // skip type id byte and mutability byte
+              break;
+          }
+        }
+        break;
+      case 10: // code section
+        count = unsignedLEB128();
+        while (count --> 0) {
+          var size = unsignedLEB128();
+          this.map[idx++] = offset;
+          offset += size;
+        }
+        return;
+    }
+    offset = end;
+  }
+}
+
+WasmOffsetConverter.prototype.convert = function (funcidx, offset) {
+  return this.map[funcidx] + offset;
+}

--- a/tests/core/test_ubsan_full_null_ref.cpp
+++ b/tests/core/test_ubsan_full_null_ref.cpp
@@ -1,4 +1,4 @@
-int main(void) {
+int main(int argc, char **argv) {
   int *p = nullptr;
   int &a = *p;
   auto &b = *p;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7711,9 +7711,26 @@ extern "C" {
       "which does not point to an object of type 'R'",
     ])
 
+  @parameterized({
+    'g': ('-g', [
+      "src.cpp:3:12: runtime error: reference binding to null pointer of type 'int'",
+      'in main',
+    ]),
+    'g4': ('-g4', [
+      "src.cpp:3:12: runtime error: reference binding to null pointer of type 'int'",
+      'in main /',
+      '/src.cpp:3:8'
+    ]),
+  })
   @no_fastcomp('ubsan not supported on fastcomp')
-  def test_ubsan_full_stack_trace(self):
-    self.emcc_args += ['-std=c++11', '-fsanitize=null', '-g']
+  def test_ubsan_full_stack_trace(self, g_flag, expected_output):
+    self.emcc_args += ['-std=c++11', '-fsanitize=null', g_flag, '-s', 'ALLOW_MEMORY_GROWTH=1']
+
+    if g_flag == '-g4':
+      if not self.get_setting('WASM'):
+        self.skipTest('wasm2js has no source map support')
+      elif '-Oz' in self.emcc_args:
+        self.skipTest('-Oz breaks stack traces')
 
     def modify_env(filename):
       with open(filename) as f:
@@ -7723,10 +7740,7 @@ extern "C" {
         f.write(contents)
 
     self.do_run(open(path_from_root('tests', 'core', 'test_ubsan_full_null_ref.cpp')).read(),
-                post_build=modify_env, assert_all=True, expected_output=[
-      "src.cpp:3:12: runtime error: reference binding to null pointer of type 'int'",
-      'in main wasm-function',
-    ])
+                post_build=modify_env, assert_all=True, expected_output=expected_output)
 
 
 # Generate tests for everything


### PR DESCRIPTION
This change also makes `__builtin_return_address` return consistent results on all engines.

Consider `null-read.c`:

```c
int main(void) {
    int *a = 0, b;
    b = *a;
}
```

Let's compile it with UBSan, enable debug info, turn on stack trace printing by changing the environment:

```console
$ emcc -g4 -fsanitize=null null-read.c
$ perl -pi -e "s/(?<=ENV=){}/{'UBSAN_OPTIONS': 'print_stacktrace=1'}/" a.out.js
```

Stack traces display properly on all major engines *with original file and line number*:

```console
$ node a.out.js 
null-read.c:3:9: runtime error: load of null pointer of type 'int'
    #0 0x72f in main /.../null-read.c:3:9
    #1 0x80001890 in Object.Module._main /.../a.out.js:6288:32

$ d8 a.out.js 
null-read.c:3:9: runtime error: load of null pointer of type 'int'
    #0 0x72f in main /.../null-read.c:3:9
    #1 0x80001890 in Object.Module._main a.out.js:6288:32

$ sm a.out.js 
null-read.c:3:9: runtime error: load of null pointer of type 'int'
    #0 0x72f in main /.../null-read.c:3:9
    #1 0x80001890 in Module._main a.out.js:6288:32
    #2 0x80001985 in callMain a.out.js:6533:22
    #3 0x800019bf in doRun a.out.js:6591:49
    #4 0x800019cd in run a.out.js:6605:5
    #5 0x8000196e in runCaller a.out.js:6510:29
    #6 0x800005e7 in removeRunDependency a.out.js:1511:7
    #7 0x800006ff in receiveInstance a.out.js:1791:5
    #8 0x80000715 in receiveInstantiatedSource a.out.js:1813:5
```