### PR TITLE
Initialize test instance members during setUp method

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -371,23 +371,14 @@ class RunnerMeta(type):
 # metaclass, which is done in the same way on both python 2 and 3, and inherit from it,
 # since a class inherits the metaclass by default.
 class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
-  emcc_args = []
-
   # default temporary directory settings. set_temp_dir may be called later to
   # override these
   temp_dir = TEMP_DIR
   canonical_temp_dir = get_canonical_temp_dir(TEMP_DIR)
 
-  save_dir = EMTEST_SAVE_DIR
-  save_JS = 0
   # This avoids cluttering the test runner output, which is stderr too, with compiler warnings etc.
   # Change this to None to get stderr reporting, for debugging purposes
   stderr_redirect = STDOUT
-
-  env = {}
-  settings_mods = {}
-
-  temp_files_before_run = []
 
   def is_emterpreter(self):
     return self.get_setting('EMTERPRETIFY')
@@ -430,6 +421,11 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
   def setUp(self):
     super(RunnerCore, self).setUp()
     self.settings_mods = {}
+    self.emcc_args = []
+    self.save_dir = EMTEST_SAVE_DIR
+    self.save_JS = False
+    self.env = {}
+    self.temp_files_before_run = []
 
     if EMTEST_DETECT_TEMPFILE_LEAKS:
       for root, dirnames, filenames in os.walk(self.temp_dir):


### PR DESCRIPTION
This avoids the possibility of state leaking between test cases
via class members.
