### PR TITLE
-s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 + --proxy-to-worker

### DIFF
--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -293,6 +293,13 @@ document.getElementById = function(id) {
   throw 'document.getElementById failed on ' + id;
 };
 
+document.querySelector = function(id) {
+  if (id === '#canvas' || id === '#application-canvas' || id === 'canvas' || id === 'application-canvas') {
+    return Module.canvas;
+  }
+  throw 'document.querySelector failed on ' + id;
+};
+
 document.documentElement = {};
 
 document.styleSheets = [{
@@ -500,6 +507,12 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 #if USE_PTHREADS
 }
 #endif
+
+// proxyWorker.js has defined 'document' and 'window' objects above, so need to
+// initialize them for library_html5.js explicitly here.
+if (typeof __specialEventTargets !== 'undefined') {
+  __specialEventTargets = [0, document, window];
+}
 
 function postCustomMessage(data) {
   postMessage({ target: 'custom', userData: data });


### PR DESCRIPTION
Make -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 to work with --proxy-to-worker mode.

Should fix #8733, although I was unable to test in exact conditions.
