### PR TITLE
Correctly sort source map offsets for binary search

### DIFF
--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -50,7 +50,7 @@ function WasmSourceMap(sourceMap) {
     this.mapping[offset] = info;
     this.offsets.push(offset);
   }, this);
-  this.offsets.sort();
+  this.offsets.sort(function (a, b) { return a - b; });
 }
 
 WasmSourceMap.prototype.lookup = function (offset) {


### PR DESCRIPTION
Turns out that `Array.prototype.sort` sorts by comparing the string representations of numbers in UTF-16 order by default, instead of sorting numbers normally like you'd expect.