### PR TITLE
-s MALLOC=none

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -794,7 +794,7 @@ LibraryManager.library = {
   // stdlib.h
   // ==========================================================================
 
-#if !MINIMAL_RUNTIME
+#if !MINIMAL_RUNTIME && MALLOC != 'none'
   // tiny, fake malloc/free implementation. If the program actually uses malloc,
   // a compiled version will be used; this will only be used if the runtime
   // needs to allocate something, for which this is good enough if otherwise

--- a/src/settings.js
+++ b/src/settings.js
@@ -86,6 +86,8 @@ var TOTAL_MEMORY = 16777216;
 // What malloc()/free() to use, out of
 //  * dlmalloc - a powerful general-purpose malloc
 //  * emmalloc - a simple and compact malloc designed for emscripten
+//  * none     - no malloc() implementation is provided, but you must implement
+//               malloc() and free() yourself.
 // dlmalloc is necessary for multithreading, split memory, and other special
 // modes, and will be used automatically in those cases.
 // In general, if you don't need one of those special modes, and if you don't

--- a/tests/malloc_none.c
+++ b/tests/malloc_none.c
@@ -1,0 +1,6 @@
+#include <stdlib.h>
+
+int main()
+{
+	return (int)malloc(4);
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9224,3 +9224,8 @@ int main () {
     assert lf - 900 <= f <= lf - 500
     # both is a little bigger still
     assert both - 100 <= lf <= both - 50
+
+  # Tests that passing -s MALLOC=none will not include system malloc() to the build.
+  def test_malloc_none(self):
+    stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'malloc_none.c'), '-s', 'MALLOC=none'])
+    self.assertContained('undefined symbol: malloc', stderr)


### PR DESCRIPTION
Add -s MALLOC=none option to enable forcing opt out of system provided allocators altogether

This helps codebases guard against accidents where they might not be properly linking in their own malloc implementation, and then silently start getting the Emscripten default malloc implementation. With -s MALLOC=none, there will be an explicit undefined symbol error in such case.