### PR TITLE
Minimal embind support for pthreads

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1067,6 +1067,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     shared.Building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
 
     if options.bind:
+      shared.Settings.EMBIND = 1
       # If we are using embind and generating JS, now is the time to link in bind.cpp
       if final_suffix in JS_CONTAINING_ENDINGS:
         input_files.append((next_arg_index, shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')))

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -461,6 +461,11 @@ if (!ENVIRONMENT_IS_PTHREAD) // EXIT_RUNTIME=0 only applies to default behavior 
 
 #if USE_PTHREADS
 if (!ENVIRONMENT_IS_PTHREAD) run();
+#if EMBIND
+else {  // Embind must initialize itself on all threads, as it generates support JS.
+  Module['___embind_register_native_and_builtin_types']();
+}
+#endif // EMBIND
 #else
 run();
 #endif

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -506,9 +506,6 @@ function ensureInitRuntime() {
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
 #endif
-#if USE_PTHREADS
-  if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
-#endif
   if (runtimeInitialized) return;
   runtimeInitialized = true;
 #if USE_PTHREADS

--- a/src/settings.js
+++ b/src/settings.js
@@ -1429,6 +1429,9 @@ var UBSAN_RUNTIME = 0;
 // This is enabled automatically when using -g4 with sanitizers.
 var LOAD_SOURCE_MAP = 0;
 
+// Whether embind has been enabled.
+var EMBIND = 0;
+
 // Legacy settings that have been removed or renamed.
 // For renamed settings the format is:
 // [OLD_NAME, NEW_NAME]

--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -97,58 +97,67 @@ namespace {
     }
 }
 
-EMSCRIPTEN_BINDINGS(native_and_builtin_types) {
-    using namespace emscripten::internal;
+extern "C" {
+    void EMSCRIPTEN_KEEPALIVE __embind_register_native_and_builtin_types() {
+        using namespace emscripten::internal;
 
-    _embind_register_void(TypeID<void>::get(), "void");
+        _embind_register_void(TypeID<void>::get(), "void");
 
-    _embind_register_bool(TypeID<bool>::get(), "bool", sizeof(bool), true, false);
+        _embind_register_bool(TypeID<bool>::get(), "bool", sizeof(bool), true, false);
 
-    register_integer<char>("char");
-    register_integer<signed char>("signed char");
-    register_integer<unsigned char>("unsigned char");
-    register_integer<signed short>("short");
-    register_integer<unsigned short>("unsigned short");
-    register_integer<signed int>("int");
-    register_integer<unsigned int>("unsigned int");
-    register_integer<signed long>("long");
-    register_integer<unsigned long>("unsigned long");
+        register_integer<char>("char");
+        register_integer<signed char>("signed char");
+        register_integer<unsigned char>("unsigned char");
+        register_integer<signed short>("short");
+        register_integer<unsigned short>("unsigned short");
+        register_integer<signed int>("int");
+        register_integer<unsigned int>("unsigned int");
+        register_integer<signed long>("long");
+        register_integer<unsigned long>("unsigned long");
 
-    register_float<float>("float");
-    register_float<double>("double");
+        register_float<float>("float");
+        register_float<double>("double");
 
-    _embind_register_std_string(TypeID<std::string>::get(), "std::string");
-    _embind_register_std_string(TypeID<std::basic_string<unsigned char> >::get(), "std::basic_string<unsigned char>");
-    _embind_register_std_wstring(TypeID<std::wstring>::get(), sizeof(wchar_t), "std::wstring");
-    _embind_register_emval(TypeID<val>::get(), "emscripten::val");
+        _embind_register_std_string(TypeID<std::string>::get(), "std::string");
+        _embind_register_std_string(TypeID<std::basic_string<unsigned char> >::get(), "std::basic_string<unsigned char>");
+        _embind_register_std_wstring(TypeID<std::wstring>::get(), sizeof(wchar_t), "std::wstring");
+        _embind_register_emval(TypeID<val>::get(), "emscripten::val");
 
-    // Some of these types are aliases for each other. Luckily,
-    // embind.js's _embind_register_memory_view ignores duplicate
-    // registrations rather than asserting, so the first
-    // register_memory_view call for a particular type will take
-    // precedence.
+        // Some of these types are aliases for each other. Luckily,
+        // embind.js's _embind_register_memory_view ignores duplicate
+        // registrations rather than asserting, so the first
+        // register_memory_view call for a particular type will take
+        // precedence.
 
-    register_memory_view<char>("emscripten::memory_view<char>");
-    register_memory_view<signed char>("emscripten::memory_view<signed char>");
-    register_memory_view<unsigned char>("emscripten::memory_view<unsigned char>");
+        register_memory_view<char>("emscripten::memory_view<char>");
+        register_memory_view<signed char>("emscripten::memory_view<signed char>");
+        register_memory_view<unsigned char>("emscripten::memory_view<unsigned char>");
 
-    register_memory_view<short>("emscripten::memory_view<short>");
-    register_memory_view<unsigned short>("emscripten::memory_view<unsigned short>");
-    register_memory_view<int>("emscripten::memory_view<int>");
-    register_memory_view<unsigned int>("emscripten::memory_view<unsigned int>");
-    register_memory_view<long>("emscripten::memory_view<long>");
-    register_memory_view<unsigned long>("emscripten::memory_view<unsigned long>");
+        register_memory_view<short>("emscripten::memory_view<short>");
+        register_memory_view<unsigned short>("emscripten::memory_view<unsigned short>");
+        register_memory_view<int>("emscripten::memory_view<int>");
+        register_memory_view<unsigned int>("emscripten::memory_view<unsigned int>");
+        register_memory_view<long>("emscripten::memory_view<long>");
+        register_memory_view<unsigned long>("emscripten::memory_view<unsigned long>");
 
-    register_memory_view<int8_t>("emscripten::memory_view<int8_t>");
-    register_memory_view<uint8_t>("emscripten::memory_view<uint8_t>");
-    register_memory_view<int16_t>("emscripten::memory_view<int16_t>");
-    register_memory_view<uint16_t>("emscripten::memory_view<uint16_t>");
-    register_memory_view<int32_t>("emscripten::memory_view<int32_t>");
-    register_memory_view<uint32_t>("emscripten::memory_view<uint32_t>");
+        register_memory_view<int8_t>("emscripten::memory_view<int8_t>");
+        register_memory_view<uint8_t>("emscripten::memory_view<uint8_t>");
+        register_memory_view<int16_t>("emscripten::memory_view<int16_t>");
+        register_memory_view<uint16_t>("emscripten::memory_view<uint16_t>");
+        register_memory_view<int32_t>("emscripten::memory_view<int32_t>");
+        register_memory_view<uint32_t>("emscripten::memory_view<uint32_t>");
 
-    register_memory_view<float>("emscripten::memory_view<float>");
-    register_memory_view<double>("emscripten::memory_view<double>");
+        register_memory_view<float>("emscripten::memory_view<float>");
+        register_memory_view<double>("emscripten::memory_view<double>");
 #if __SIZEOF_LONG_DOUBLE__ == __SIZEOF_DOUBLE__
-    register_memory_view<long double>("emscripten::memory_view<long double>");
+        register_memory_view<long double>("emscripten::memory_view<long double>");
 #endif
+    }
 }
+
+EMSCRIPTEN_BINDINGS(native_and_builtin_types) {
+    // Normal initialization, executed through a global constructor. This
+    // happens on the main thread; pthreads will call it manually.
+    __embind_register_native_and_builtin_types();
+}
+

--- a/tests/embind_with_pthreads.cpp
+++ b/tests/embind_with_pthreads.cpp
@@ -1,0 +1,20 @@
+#include <assert.h>
+
+#include <string>
+
+#include <emscripten.h>
+#include <emscripten/val.h>
+
+using namespace emscripten;
+
+int main() {
+  EM_ASM({
+    globalProperty = {
+      foo: function() { return "bar" }
+    };
+  });
+  val globalProperty = val::global("globalProperty");
+  auto result = globalProperty.call<std::string>("foo");
+  REPORT_RESULT(result == "bar");
+}
+

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4615,6 +4615,10 @@ window.close = function() {
   def test_emscripten_performance_now(self):
     self.btest(path_from_root('tests', 'emscripten_performance_now.c'), '0', args=['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
+  @requires_threads
+  def test_embind_with_pthreads(self):
+    self.btest('embind_with_pthreads.cpp', '1', args=['--bind', '-std=c++11', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
+
   # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
   def test_emscripten_console_log(self):
     self.btest(path_from_root('tests', 'emscripten_console_log.c'), '0', args=['--pre-js', path_from_root('tests', 'emscripten_console_log_pre.js')])


### PR DESCRIPTION
This makes us run the embind startup code on all pthreads, and not just on the main thread. That allows using embind from there, as the handlers are all registered.

I don't love that this PR adds a special case for embind in pthreads startup code in js, but it seems unavoidable (unless there is some type of global constructor that is automatically run on each thread?).

Helps with #8299 but we may want do more to warn about attempts to use a JS object across threads, which can't work, see discussion there.