### PR TITLE
Speed up library builds by building many objects in one emcc invocation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -435,10 +435,6 @@ def find_output_arg(args):
   return specified_target, outargs
 
 
-class ThreadPoolExit(Exception):
-  pass
-
-
 #
 # Main run() function
 #

--- a/emcc.py
+++ b/emcc.py
@@ -1731,7 +1731,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         assert(os.path.exists(output_file))
 
       # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
-      for i, input_file in input_files:
+      def process_source_files(arg):
+        i, input_file = arg
         file_ending = get_file_suffix(input_file)
         if file_ending.endswith(SOURCE_ENDINGS):
           compile_source_file(i, input_file)
@@ -1753,6 +1754,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
               compile_source_file(i, input_file)
             else:
               exit_with_error(input_file + ': Unknown file suffix when compiling to LLVM bitcode!')
+
+      shared.Building.get_thread_pool().map(process_source_files, input_files)
 
     # exit block 'bitcodeize inputs'
     log_time('bitcodeize inputs')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9322,10 +9322,3 @@ int main () {
       for error, file in zip(errors, files):
         if not re.search(error, stderr):
           self.fail('try %d: cannot find the error message for %s:\n%s' % (n + 1, file, stderr))
-
-  @no_windows('ptys and select are not available on windows')
-  def test_build_error_color(self):
-    create_test_file('src.c', 'int main() {')
-    returncode, output = self.run_on_pty([PYTHON, EMCC, 'src.c'])
-    self.assertNotEqual(returncode, 0)
-    self.assertIn(b"\x1b[1msrc.c:1:13: \x1b[0m\x1b[0;1;31merror: \x1b[0m\x1b[1mexpected '}'\x1b[0m", output)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9307,13 +9307,13 @@ int main () {
   def test_multi_build_output(self):
     files = ['src%d.cpp' % i for i in range(1, 6)]
     for file in files:
-      with open(file, 'w') as f:
-        f.write('''
-          int main() {
-        ''')
-    errors = [r"%(file)s:3:9: error: expected '\}'\s+\^\n"
-              r"%(file)s:2:22: note: to match this '\{'\n\s+"
-              r"int main\(\) \{\s+\^\n"
+      create_test_file(file, 'int main() {')
+    errors = [r"%(file)s:1:13: error: expected '\}'\n"
+              r"int main\(\) {\n"
+              r"\s+\^\n"
+              r"%(file)s:1:12: note: to match this '\{'\n"
+              r"int main\(\) \{\n"
+              r"\s+\^\n"
               r"1 error generated\.\n"
               r"emcc:ERROR: compiler frontend failed to generate LLVM bitcode, halting" % {'file': re.escape(file)}
               for file in files]
@@ -9325,11 +9325,7 @@ int main () {
 
   @no_windows('ptys and select are not available on windows')
   def test_build_error_color(self):
-    with open('src.c', 'w') as f:
-      f.write('''
-        int main() {
-      ''')
-
+    create_test_file('src.c', 'int main() {')
     returncode, output = self.run_on_pty([PYTHON, EMCC, 'src.c'])
     self.assertNotEqual(returncode, 0)
-    self.assertIn(b"\x1b[1msrc.c:3:7: \x1b[0m\x1b[0;1;31merror: \x1b[0m\x1b[1mexpected '}'\x1b[0m", output)
+    self.assertIn(b"\x1b[1msrc.c:1:13: \x1b[0m\x1b[0;1;31merror: \x1b[0m\x1b[1mexpected '}'\x1b[0m", output)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1405,6 +1405,10 @@ class FakeMultiprocessor(object):
       results += [func(t)]
     return results
 
+  def imap(self, func, tasks, *args, **kwargs):
+    for t in tasks:
+      yield func(t)
+
   def map_async(self, func, tasks, *args, **kwargs):
     class Result:
       def __init__(self, func, tasks):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -284,15 +284,11 @@ class Library(object):
     By default, this builds all the source files returned by `self.get_files()`,
     with the `cflags` returned by `self.get_cflags()`.
     """
-    commands = []
-    objects = []
+    sources = self.get_files()
     cflags = self.get_cflags()
-    for src in self.get_files():
-      o = self.in_temp(os.path.basename(src) + '.o')
-      commands.append([shared.PYTHON, self.emcc, src, '-o', o] + cflags)
-      objects.append(o)
-    run_commands(commands)
-    return objects
+    command = [shared.PYTHON, self.emcc, '-c'] + cflags + sources
+    shared.run_process(command, cwd=self.in_temp())
+    return [self.in_temp(os.path.splitext(os.path.basename(src))[0] + '.o') for src in sources]
 
   def build(self):
     """Builds the library and returns the path to the file."""

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -286,7 +286,8 @@ class Library(object):
     """
     sources = self.get_files()
     cflags = self.get_cflags()
-    command = [shared.PYTHON, self.emcc, '-c'] + cflags + sources
+    command = [self.emcc, '-c'] + cflags + sources
+    command = [shared.PYTHON] + shared.Building.get_command_with_possible_response_file(command)
     shared.run_process(command, cwd=self.in_temp())
     return [self.in_temp(os.path.splitext(os.path.basename(src))[0] + '.o') for src in sources]
 


### PR DESCRIPTION
* Compile many object files in one call to `emcc`.
* `emcc`: use a thread pool to build all arguments in parallel.

We have to use a thread pool because the function depends on a lot of unpicklable internal state.

This appears to build libc 3 times faster than before.