### PR TITLE
Disable emcc colour output with same flags as clang

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -239,7 +239,6 @@ class EmccOptions(object):
     self.valid_abspaths = []
     self.separate_asm = False
     self.cfi = False
-    self.color = True
     # Specifies the line ending format to use for all generated text files.
     # Defaults to using the native EOL on each platform (\r\n on Windows, \n on
     # Linux & MacOS)
@@ -810,9 +809,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     else:
       # Compiling C code with .c files, don't enforce a default C++ std.
       clang_compiler = CC
-
-    if not options.color:
-      colored_logger.disable()
 
     if options.emrun:
       options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
@@ -2597,7 +2593,7 @@ def parse_args(newargs):
     elif newargs[i] == '-pthread':
       settings_changes.append('USE_PTHREADS=1')
     elif newargs[i] in ('-fno-diagnostics-color', '-fdiagnostics-color=never'):
-      options.color = False
+      colored_logger.disable()
 
   if should_exit:
     sys.exit(0)

--- a/emcc.py
+++ b/emcc.py
@@ -38,7 +38,7 @@ import sys
 import time
 from subprocess import PIPE
 
-from tools import shared, system_libs, client_mods, js_optimizer, jsrun
+from tools import shared, system_libs, client_mods, js_optimizer, jsrun, colored_logger
 from tools.shared import unsuffixed, unsuffixed_basename, WINDOWS, safe_copy, safe_move, run_process, asbytes, read_and_preprocess, exit_with_error, DEBUG
 from tools.response_file import substitute_response_files
 import tools.line_endings
@@ -239,6 +239,7 @@ class EmccOptions(object):
     self.valid_abspaths = []
     self.separate_asm = False
     self.cfi = False
+    self.color = True
     # Specifies the line ending format to use for all generated text files.
     # Defaults to using the native EOL on each platform (\r\n on Windows, \n on
     # Linux & MacOS)
@@ -809,6 +810,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     else:
       # Compiling C code with .c files, don't enforce a default C++ std.
       clang_compiler = CC
+
+    if not options.color:
+      colored_logger.use_color = False
 
     if options.emrun:
       options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
@@ -2592,6 +2596,8 @@ def parse_args(newargs):
     # Record USE_PTHREADS setting because it controls whether --shared-memory is passed to lld
     elif newargs[i] == '-pthread':
       settings_changes.append('USE_PTHREADS=1')
+    elif newargs[i] in ('-fno-diagnostics-color', '-fdiagnostics-color=never'):
+      options.color = False
 
   if should_exit:
     sys.exit(0)

--- a/emcc.py
+++ b/emcc.py
@@ -812,7 +812,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       clang_compiler = CC
 
     if not options.color:
-      colored_logger.use_color = False
+      colored_logger.disable()
 
     if options.emrun:
       options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9301,5 +9301,18 @@ int main () {
     self.assertIn(b"\x1b[1msrc.c:1:13: \x1b[0m\x1b[0;1;31merror: \x1b[0m\x1b[1mexpected '}'\x1b[0m", output)
     self.assertIn(b"shared:ERROR: \x1b[31mcompiler frontend failed to generate LLVM bitcode, halting\x1b[0m\r\n", output)
 
+  @parameterized({
+    'fno_diagnostics_color': ['-fno-diagnostics-color'],
+    'fdiagnostics_color_never': ['-fdiagnostics-color=never'],
+  })
+  @no_windows('ptys and select are not available on windows')
+  def test_pty_no_color(self, flag):
+    with open('src.c', 'w') as f:
+      f.write('int main() {')
+
+    returncode, output = self.run_on_pty([PYTHON, EMCC, flag, 'src.c'])
+    self.assertNotEqual(returncode, 0)
+    self.assertNotIn(b'\x1b', output)
+
   def test_llvm_includes(self):
     self.build('#include <stdatomic.h>', self.get_dir(), 'atomics.c')

--- a/tools/colored_logger.py
+++ b/tools/colored_logger.py
@@ -102,7 +102,7 @@ def add_coloring_to_emit_windows(fn):
     args[0]._set_color(old_color)
     return ret
 
-  new.old_func = fn
+  new.orig_func = fn
   return new
 
 
@@ -125,7 +125,7 @@ def add_coloring_to_emit_ansi(fn):
     args[1].msg = color + args[1].msg + '\x1b[0m'  # normal
     return fn(*args)
 
-  new.old_func = fn
+  new.orig_func = fn
   return new
 
 
@@ -138,4 +138,5 @@ def enable():
 
 
 def disable():
-  logging.StreamHandler.emit = logging.StreamHandler.emit.old_func
+  if hasattr(logging.StreamHandler.emit, 'orig_func'):
+    logging.StreamHandler.emit = logging.StreamHandler.emit.orig_func

--- a/tools/colored_logger.py
+++ b/tools/colored_logger.py
@@ -10,6 +10,8 @@ import ctypes
 import sys
 import logging
 
+use_color = True
+
 
 def add_coloring_to_emit_windows(fn):
   def _out_handle(self):
@@ -57,6 +59,9 @@ def add_coloring_to_emit_windows(fn):
   setattr(logging.StreamHandler, '_set_color', _set_color)
 
   def new(*args):
+    if not use_color:
+      return fn(*args)
+
     FOREGROUND_BLUE      = 0x0001 # noqa; text color contains blue.
     FOREGROUND_GREEN     = 0x0002 # noqa; text color contains green.
     FOREGROUND_RED       = 0x0004 # noqa; text color contains red.
@@ -108,6 +113,9 @@ def add_coloring_to_emit_windows(fn):
 def add_coloring_to_emit_ansi(fn):
   # add methods we need to the class
   def new(*args):
+    if not use_color:
+      return fn(*args)
+
     levelno = args[1].levelno
     if levelno >= 50:
       color = '\x1b[31m' # red


### PR DESCRIPTION
Make it so that when `-fno-diagnostic-color` or `-fdiagnostic-color=never` is passed to `emcc`, `colored_logger` does not add colour to `emcc`'s own logs.

Fixes #6650.

This is based on #8814. Diff is available at quantum5#2.