### PR TITLE
Don't double-report some GL errors related to TexImage/ReadPixels

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1454,7 +1454,13 @@ var LibraryGL = {
       return;
     }
 #endif
-    GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixels ? emscriptenWebGLGetTexPixelData(type, format, width, height, pixels, internalFormat) : null);
+    var pixelData = null;
+    if (pixels) {
+      pixelData = emscriptenWebGLGetTexPixelData(type, format, width, height, pixels, internalFormat);
+      if (!pixelData)
+        return;
+    }
+    GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixelData);
   },
 
   glTexSubImage2D__sig: 'viiiiiiiii',
@@ -1486,7 +1492,11 @@ var LibraryGL = {
     }
 #endif
     var pixelData = null;
-    if (pixels) pixelData = emscriptenWebGLGetTexPixelData(type, format, width, height, pixels, 0);
+    if (pixels) {
+      pixelData = emscriptenWebGLGetTexPixelData(type, format, width, height, pixels, 0);
+      if (!pixelData)
+        return;
+    }
     GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixelData);
   },
 
@@ -1508,13 +1518,8 @@ var LibraryGL = {
     }
 #endif
     var pixelData = emscriptenWebGLGetTexPixelData(type, format, width, height, pixels, format);
-    if (!pixelData) {
-      GL.recordError(0x0500/*GL_INVALID_ENUM*/);
-#if GL_ASSERTIONS
-      err('GL_INVALID_ENUM in glReadPixels: Unrecognized combination of type=' + type + ' and format=' + format + '!');
-#endif
+    if (!pixelData)
       return;
-    }
     GLctx.readPixels(x, y, width, height, format, type, pixelData);
   },
 


### PR DESCRIPTION
The `emscriptenWebGLGetTexPixelData` will already set `GL_INVALID_ENUM` when needed.  These code paths have two different incorrect and inconsistent ways of dealing with invalid enums:

- glTexImage2D/glTexSubImage2D would call `recordError` and print a message inside `emscritenWebGLGetTexPixelData`, and then still call the GL function which would itself report an error.  Calling `glGetError()` would return 2 (identical) errors for one API call.
- glReadPixels would call recordError inside the helper function, but it would then call it again and print a second message inside ReadPixels.

While GL does have an error stack, it's somewhat surprising for a single GL call to yield two identical errors.  Code out in the wild (e.g. bgfx) does error checks to see what formats are accepted by doing basically `flushGLErrors(); texImage2D(); err = glGetError();`   This works out fine except for the very last call, when there's still a bogus error left.