### PR TITLE
Musl include fix

### DIFF
--- a/system/include/libc/sys/types.h
+++ b/system/include/libc/sys/types.h
@@ -69,7 +69,6 @@ typedef long long quad_t;
 typedef unsigned long long u_quad_t;
 #include <endian.h>
 #include <sys/select.h>
-#include <sys/sysmacros.h>
 #endif
 
 #if defined(_LARGEFILE64_SOURCE) || defined(_GNU_SOURCE)

--- a/tests/stat/test_stat.c
+++ b/tests/stat/test_stat.c
@@ -17,6 +17,7 @@
 #include <utime.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 
 void create_file(const char *path, const char *buffer, int mode) {
   int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);


### PR DESCRIPTION
Remove sysmacros.h include from types.h in musl. This mirrors an upstream musl fix happening now: https://www.openwall.com/lists/musl/2019/06/14/5

fixes https://github.com/emscripten-core/emscripten/issues/8813