### PR TITLE
Fix WebIDL in the wasm backend. 

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2380,7 +2380,7 @@ function _emscripten_asm_const_%s(code, sig_ptr, argbuf) {
       buf += 8;
     } else if (c == 'i') {
       buf = align_to(buf, 4);
-      args.push(HEAPU32[(buf >> 2)]);
+      args.push(HEAP32[(buf >> 2)]);
       buf += 4;
     }
   }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6766,7 +6766,6 @@ someweirdtext
     self.do_run(src, '418')
 
   @sync
-  @no_wasm_backend()
   def test_webidl(self):
     assert 'asm2' in core_test_modes
     if self.run_name == 'asm2':

--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -78,9 +78,9 @@ Inner::+= => 2
 return char 127
 char: 127
 char: -1
-return unsigned char -1
+return unsigned char 255
 unsigned char: 255
-return unsigned short -1
+return unsigned short 65535
 unsigned short int: 65535
 return unsigned long -1
 unsigned long int: 4294967295

--- a/tests/webidl/output_DEFAULT.txt
+++ b/tests/webidl/output_DEFAULT.txt
@@ -78,9 +78,9 @@ Inner::+= => 2
 return char 127
 char: 127
 char: -1
-return unsigned char -1
+return unsigned char 255
 unsigned char: 255
-return unsigned short -1
+return unsigned short 65535
 unsigned short int: 65535
 return unsigned long -1
 unsigned long int: 4294967295

--- a/tests/webidl/output_FAST.txt
+++ b/tests/webidl/output_FAST.txt
@@ -78,9 +78,9 @@ Inner::+= => 2
 return char 127
 char: 127
 char: -1
-return unsigned char -1
+return unsigned char 255
 unsigned char: 255
-return unsigned short -1
+return unsigned short 65535
 unsigned short int: 65535
 return unsigned long -1
 unsigned long int: 4294967295

--- a/tests/webidl/post.js
+++ b/tests/webidl/post.js
@@ -153,21 +153,17 @@ console.log(TheModule.e_namespace_val);
 
 typeTester = new TheModule.TypeTestClass();
 
-console.log('return char ' + typeTester.ReturnCharMethod());
+console.log('return char ' + (typeTester.ReturnCharMethod() & 255));
 typeTester.AcceptCharMethod((2<<6)-1);
-// Prints -1 because the c++ code accepts unsigned char.
-typeTester.AcceptCharMethod((2<<7)-1);
+typeTester.AcceptCharMethod(-1);
 
-// Prints -1 because all integers are signed in javascript.
-console.log('return unsigned char ' + typeTester.ReturnUnsignedCharMethod());
+console.log('return unsigned char ' + (typeTester.ReturnUnsignedCharMethod() & 255));
 typeTester.AcceptUnsignedCharMethod((2<<7)-1);
 
-// Prints -1 because all integers are signed in javascript.
-console.log('return unsigned short ' + typeTester.ReturnUnsignedShortMethod());
+console.log('return unsigned short ' + (typeTester.ReturnUnsignedShortMethod() & 65535));
 typeTester.AcceptUnsignedShortMethod((2<<15)-1);
 
-// Prints -1 because all integers are signed in javascript.
-console.log('return unsigned long ' + typeTester.ReturnUnsignedLongMethod());
+console.log('return unsigned long ' + (typeTester.ReturnUnsignedLongMethod() | 0));
 typeTester.AcceptUnsignedLongMethod((2<<31)-1);
 var voidPointerUser = new TheModule.VoidPointerUser();
 


### PR DESCRIPTION
We disabled the test early in wasm backend's lifetime and forgot it was disabled, I think.

Looking now, it worked fine except for one HEAPU32 which should be HEAP32 (for performance; there is never a point to using the unsigned 32 bit heap unless you really really must).

Otherwise, it turns out the test encoded some JS/asm.js specific assumptions, like ignoring unsigned 8/16 bit integers. I removed that, but it does show that we don't strictly define an 'ABI' for 8 and 16 bit integers, we receive them from JS and they go through into wasm imports, and then if they are used in an operation depending on the size, that will do the right thing, but if they are passed to say printf immediately, then they remain as they arrive - which if the JS was wrong, might be wrong. Not sure if the webidl binder code should do anything about that; I modified the tests.
