### PR TITLE
Make createContext return 0 on failure

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -513,7 +513,7 @@ var LibraryGL = {
 #if TRACE_WEBGL_CALLS
       if (ctx) GL.hookWebGL(ctx);
 #endif
-      return ctx && GL.registerContext(ctx, webGLContextAttributes);
+      return ctx ? GL.registerContext(ctx, webGLContextAttributes) : 0;
     },
 
 #if OFFSCREEN_FRAMEBUFFER

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1576,6 +1576,13 @@ keydown(100);keyup(100); // trigger the end
   def test_egl_width_height_with_proxy_to_pthread(self):
     self._test_egl_width_height_base('-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD=1')
 
+  @requires_graphics_hardware
+  def test_egl_createcontext_error(self):
+    create_test_file('test_egl_createcontext_error.c', self.with_report_result(open(path_from_root('tests', 'test_egl_createcontext_error.c')).read()))
+
+    self.compile_btest(['test_egl_createcontext_error.c', '-o', 'page.html', '-lEGL', '-lGL'])
+    self.run_browser('page.html', '', '/report_result?1')
+
   def do_test_worker(self, args=[]):
     # Test running in a web worker
     create_test_file('file.dat', 'data for worker')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1578,10 +1578,7 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_egl_createcontext_error(self):
-    create_test_file('test_egl_createcontext_error.c', self.with_report_result(open(path_from_root('tests', 'test_egl_createcontext_error.c')).read()))
-
-    self.compile_btest(['test_egl_createcontext_error.c', '-o', 'page.html', '-lEGL', '-lGL'])
-    self.run_browser('page.html', '', '/report_result?1')
+    self.btest('test_egl_createcontext_error.c', '1', args=['-lEGL', '-lGL'])
 
   def do_test_worker(self, args=[]):
     # Test running in a web worker

--- a/tests/test_egl_createcontext_error.c
+++ b/tests/test_egl_createcontext_error.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <EGL/egl.h>
+#include <emscripten.h>
+
+int result = 1; // Success
+#define assert(x) do { \
+  if (!(x)) { \
+    result = 0; \
+    printf("Assertion failure: %s in %s:%d!\n", #x, __FILE__, __LINE__); \
+  } \
+} while(0)
+
+int main(int argc, char *argv[]) {
+  EM_ASM({
+    Module['canvas'] = document.createElement('canvas');
+    Module['canvas'].getContext = function() {
+      return null;
+    };
+  });
+
+  EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  assert(display != NULL);
+  assert(eglInitialize(display, NULL, NULL));
+
+  EGLConfig config;
+  EGLint count;
+  assert(eglChooseConfig(display, NULL, &config, 1, &count));
+  assert(count == 1);
+
+  EGLint attribs[] = { EGL_CONTEXT_CLIENT_VERSION, 2, EGL_NONE };
+  assert(eglCreateContext(display, config, NULL, attribs) == NULL);
+  assert(eglGetError() == EGL_BAD_MATCH);
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT(result);
+#endif
+}


### PR DESCRIPTION
I noticed that in `library_egl.js` on line 369 that it will fail if `createContext` returns 0. However, checking the `createContext` code shows that it would instead return `null` (the return value of `getContext`) if it fails to create a context making EGL think that it was successful and then producing weird errors later.

As a side note, since unlike the previous PR, this one's copyright isn't owned by Clipchamp, is there a recommended way to represent that in the `AUTHORS` list? I don't mind too much just thought I might ask.