### PR TITLE
Add colours to sanitizers if possible or requested

### DIFF
--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cc
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cc
@@ -41,18 +41,18 @@ void ReportErrorSummary(const char *error_type, const AddressInfo &info,
 #endif
 
 #if SANITIZER_EMSCRIPTEN
-#include <emscripten/em_js.h>
+#include <emscripten/em_asm.h>
 
-EM_JS(bool, emsan_support_colors, (), {
-  var setting = Module['sanitizer_use_color'];
-  if (setting != null) {
-    return setting;
-  } else {
-    return ENVIRONMENT_IS_NODE && process.stderr.isTTY;
-  }
-});
-
-static INLINE bool ReportSupportsColors() { return emsan_support_colors(); }
+static INLINE bool ReportSupportsColors() {
+  return !!EM_ASM_INT({
+    var setting = Module['sanitizer_use_color'];
+    if (setting != null) {
+      return setting;
+    } else {
+      return ENVIRONMENT_IS_NODE && process.stderr.isTTY;
+    }
+  });
+}
 
 #elif !SANITIZER_FUCHSIA
 

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cc
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cc
@@ -44,7 +44,12 @@ void ReportErrorSummary(const char *error_type, const AddressInfo &info,
 #include <emscripten/em_js.h>
 
 EM_JS(bool, emsan_support_colors, (), {
-  return ENVIRONMENT_IS_NODE && process.stderr.isTTY;
+  var setting = Module['sanitizer_use_color'];
+  if (setting != null) {
+    return setting;
+  } else {
+    return ENVIRONMENT_IS_NODE && process.stderr.isTTY;
+  }
 });
 
 static INLINE bool ReportSupportsColors() { return emsan_support_colors(); }

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cc
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_symbolizer_report.cc
@@ -41,9 +41,13 @@ void ReportErrorSummary(const char *error_type, const AddressInfo &info,
 #endif
 
 #if SANITIZER_EMSCRIPTEN
+#include <emscripten/em_js.h>
 
-// Most JavaScript consoles do not handle colors.
-static INLINE bool ReportSupportsColors() { return false; }
+EM_JS(bool, emsan_support_colors, (), {
+  return ENVIRONMENT_IS_NODE && process.stderr.isTTY;
+});
+
+static INLINE bool ReportSupportsColors() { return emsan_support_colors(); }
 
 #elif !SANITIZER_FUCHSIA
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9314,5 +9314,18 @@ int main () {
     self.assertNotEqual(returncode, 0)
     self.assertNotIn(b'\x1b', output)
 
+  def test_sanitizer_color(self):
+    create_test_file('src.c', '''
+      #include <emscripten.h>
+      int main() {
+        int *p = 0, q;
+        EM_ASM({ Module.sanitizer_use_color = true; });
+        q = *p;
+      }
+    ''')
+    run_process([PYTHON, EMCC, '-fsanitize=null', 'src.c'])
+    output = run_js('a.out.js', stderr=PIPE, full_output=True)
+    self.assertIn('\x1b[1msrc.c', output)
+
   def test_llvm_includes(self):
     self.build('#include <stdatomic.h>', self.get_dir(), 'atomics.c')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9314,6 +9314,7 @@ int main () {
     self.assertNotEqual(returncode, 0)
     self.assertNotIn(b'\x1b', output)
 
+  @no_fastcomp('sanitizers are not supported on fastcomp')
   def test_sanitizer_color(self):
     create_test_file('src.c', '''
       #include <emscripten.h>


### PR DESCRIPTION
Adds a new module setting `Module.sanitizer_use_color`, which:

* when set to `true`, forces sanitizers to use coloured output.
* when set to `false`, forces sanitizers to not use colours.
* when unset, or set to `null`, makes sanitizers use colours if possible.

Currently, we consider using colours "possible" if the user is on node and `stderr` is a TTY.