### PR TITLE
Minor typo fix in tools/shared.py

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -413,3 +413,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Joshua Minter <josh@minteronline.com> (copyright owned by Clipchamp Pty Ltd.)
 * Ferris Kwaijtaal <ferrispc@hotmail.com>
 * Konstantin Podsvirov <konstantin@podsvirov.pro>
+* Eduardo Bart <edub4rt@gmail.com>

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -425,7 +425,7 @@ def check_llvm_version():
 
 def get_llc_targets():
   if not os.path.exists(LLVM_COMPILER):
-    exit_with_error('llc exectuable not found at `%s`' % LLVM_COMPILER)
+    exit_with_error('llc executable not found at `%s`' % LLVM_COMPILER)
   try:
     llc_version_info = run_process([LLVM_COMPILER, '--version'], stdout=PIPE).stdout
   except Exception as e:


### PR DESCRIPTION
I got this error while trying emscripten:

```
shared:ERROR: llc exectuable not found at `/usr/lib/emscripten-llvm/llc
```

There is a typo in `exectuable` that I find annoying so I decided to make this minor PR with the fix.

