### PR TITLE
Use OffscreenCanvas for text measure in SDL TTF

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -415,3 +415,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Konstantin Podsvirov <konstantin@podsvirov.pro>
 * Eduardo Bart <edub4rt@gmail.com>
 * Zoltan Varga <vargaz@gmail.com> (copyright owned by Microsoft, Inc.)
+* Fernando Serboncini <fserb@google.com>

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1052,10 +1052,8 @@ var LibrarySDL = {
 #if ASSERTIONS
       assert(tempCtx, 'TTF_Init must have been called');
 #endif
-      tempCtx.save();
       tempCtx.font = fontString;
       var ret = tempCtx.measureText(text).width | 0;
-      tempCtx.restore();
       return ret;
     },
 
@@ -3157,8 +3155,14 @@ var LibrarySDL = {
   TTF_Init__proxy: 'sync',
   TTF_Init__sig: 'i',
   TTF_Init: function() {
-    var canvas = document.createElement('canvas');
-    SDL.ttfContext = canvas.getContext('2d');
+    try {
+      var offscreen_canvas = new OffscreenCanvas(0, 0);
+      SDL.ttfContext = offscreen_canvas.getContext('2d');
+    } catch (ex) {
+      var canvas = document.createElement('canvas');
+      SDL.ttfContext = canvas.getContext('2d');
+    }
+
     return 0;
   },
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -3155,9 +3155,11 @@ var LibrarySDL = {
   TTF_Init__proxy: 'sync',
   TTF_Init__sig: 'i',
   TTF_Init: function() {
+    // OffscreenCanvas 2D is faster than Canvas for text operations, so we use
+    // it if it's available.
     try {
-      var offscreen_canvas = new OffscreenCanvas(0, 0);
-      SDL.ttfContext = offscreen_canvas.getContext('2d');
+      var offscreenCanvas = new OffscreenCanvas(0, 0);
+      SDL.ttfContext = offscreenCanvas.getContext('2d');
     } catch (ex) {
       var canvas = document.createElement('canvas');
       SDL.ttfContext = canvas.getContext('2d');


### PR DESCRIPTION
OffscreenCanvas setFont + measureText is 15-40% faster than the Canvas element version, when available. This detects if OffscreenCanvas 2D exists, and if so, uses it instead of the canvas. There should be no visible behavior change.