### PR TITLE
Don't call receiveObjectTransfer if not using OFFSCREENCANVAS_SUPPORT

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -193,8 +193,9 @@ this.onmessage = function(e) {
 #if STACK_OVERFLOW_CHECK
       {{{ makeAsmGlobalAccessInPthread('writeStackCookie') }}}();
 #endif
-
+#if OFFSCREENCANVAS_SUPPORT
       PThread.receiveObjectTransfer(e.data);
+#endif
       PThread.setThreadStatus({{{ makeAsmGlobalAccessInPthread('_pthread_self') }}}(), 1/*EM_THREAD_STATUS_RUNNING*/);
 
       try {


### PR DESCRIPTION
receiveObjectTransfer is only used in OFFSCREENCANVAS_SUPPORT. No point calling it each time a thread is run.

https://github.com/emscripten-core/emscripten/blob/30eb07a16404e6075c8672f63e1d35e190a6f476/src/library_pthread.js#L224-L236