### PR TITLE
[webidl] Use sequences instead of arrays

### DIFF
--- a/tests/webidl/test.idl
+++ b/tests/webidl/test.idl
@@ -147,21 +147,21 @@ interface StructInArray {
 
 interface ArrayClass {
   void ArrayClass();
-  [BoundsChecked] attribute long[] int_array;
-  [Value] attribute StructInArray[] struct_array;
-  attribute StructInArray[] struct_ptr_array;
+  [BoundsChecked] attribute sequence<long> int_array;
+  [Value] attribute sequence<StructInArray> struct_array;
+  attribute sequence<StructInArray> struct_ptr_array;
 };
 
 interface ReceiveArrays {
   void ReceiveArrays();
 
-  void giveMeArrays(float[] vertices, long[] triangles, long num);
+  void giveMeArrays(sequence<float> vertices, sequence<long> triangles, long num);
 };
 
 interface StoreArray {
   void StoreArray();
 
-  void setArray([Const] long[] array);
+  void setArray([Const] sequence<long> array);
   long getArrayValue(long index);
 };
 

--- a/third_party/WebIDL.py
+++ b/third_party/WebIDL.py
@@ -2697,8 +2697,10 @@ class IDLAttribute(IDLInterfaceMember):
             raise WebIDLError("An attribute cannot be of a dictionary type",
                               [self.location])
         if self.type.isSequence() and not self.getExtendedAttribute("Cached"):
-            raise WebIDLError("A non-cached attribute cannot be of a sequence "
-                              "type", [self.location])
+            # Pass on this error until FrozenArray attributes are implemented.
+            # raise WebIDLError("A non-cached attribute cannot be of a sequence "
+            #                   "type", [self.location])
+            pass
         if self.type.isUnion():
             for f in self.type.unroll().flatMemberTypes:
                 if f.isDictionary():

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -345,8 +345,6 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
   bindings_name = class_name + '_' + func_name
   min_args = min(sigs.keys())
   max_args = max(sigs.keys())
-  if return_type.isSequence():
-    return_type = return_type.inner
 
   all_args = sigs.get(max_args)
 
@@ -659,6 +657,7 @@ for name in names:
     attr = m.identifier.name
 
     if m.type.isSequence():
+      get_return_type = m.type.inner
       get_sigs = { 1: [Dummy({ 'type': WebIDL.BuiltinTypes[WebIDL.IDLBuiltinType.Types.long] })] }
       set_sigs = { 2: [Dummy({ 'type': WebIDL.BuiltinTypes[WebIDL.IDLBuiltinType.Types.long] }),
                        Dummy({ 'type': m.type })] }
@@ -669,6 +668,7 @@ for name in names:
         get_call_content = "(%s, %s)" % (bounds_check, get_call_content)
         set_call_content = "(%s, %s)" % (bounds_check, set_call_content)
     else:
+      get_return_type = m.type
       get_sigs = { 0: [] }
       set_sigs = { 1: [Dummy({ 'type': m.type })] }
       get_call_content = take_addr_if_nonpointer(m) + 'self->' + attr
@@ -678,7 +678,7 @@ for name in names:
     mid_js += [r'''
   %s.prototype['%s'] = %s.prototype.%s = ''' % (name, get_name, name, get_name)]
     render_function(name,
-                    get_name, get_sigs, m.type,
+                    get_name, get_sigs, get_return_type,
                     None,
                     None,
                     None,


### PR DESCRIPTION
Arrays are no longer part of the current WebIDL standard.  This change adapts the test IDL file appropriately, relaxes the WebIDL parser to continue to allow sequence attributes (until FrozenArray is implemented), and adapts the bindings generator.

The bindings generator changes result in more usage of type objects instead of interpreting aspects about argument and return types from the name.

See #8476.