### PR TITLE
Remove cmake WASM=0 hack

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -45,12 +45,8 @@ set(UNIX 1)
 if (CMAKE_TOOLCHAIN_FILE)
 endif()
 
-# In order for check_function_exists() detection to work, we must signal it to pass an additional flag, which causes the compilation
-# to abort if linking results in any undefined symbols. The CMake detection mechanism depends on the undefined symbol error to be raised.
-# Disable wasm in cmake checks so that (1) we do not depend on wasm support just for configuration (perhaps the user does not intend
-# to build to wasm; using asm.js only depends on js which we need anyhow), and (2) we don't have issues with a separate .wasm file
-# on the side, async startup, etc..
-set(CMAKE_REQUIRED_FLAGS "-s WASM=0")
+# Use a single file to avoid issues with a separate .wasm file, and make startup synchronous.
+set(CMAKE_REQUIRED_FLAGS "-s SINGLE_FILE -s WASM_ASYNC_COMPILATION")
 
 # Locate where the Emscripten compiler resides in relative to this toolchain file.
 if ("${EMSCRIPTEN_ROOT_PATH}" STREQUAL "")

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -45,9 +45,6 @@ set(UNIX 1)
 if (CMAKE_TOOLCHAIN_FILE)
 endif()
 
-# Use a single file to avoid issues with a separate .wasm file, and make startup synchronous.
-set(CMAKE_REQUIRED_FLAGS "-s SINGLE_FILE -s WASM_ASYNC_COMPILATION")
-
 # Locate where the Emscripten compiler resides in relative to this toolchain file.
 if ("${EMSCRIPTEN_ROOT_PATH}" STREQUAL "")
 	get_filename_component(GUESS_EMSCRIPTEN_ROOT_PATH "${CMAKE_CURRENT_LIST_DIR}/../../../" ABSOLUTE)


### PR DESCRIPTION
It was there because we couldn't rely on wasm support being in node, but these days it is in node LTS (and in the node we ship with the emsdk). Using wasm avoids using wasm2js there which might be a problem with the wasm backend, as it doesn't support 100% of features.

There is some risk here - wasm does behave differently in some ways, like having a separate file, having async startup. Without seeing a concrete problem though it's not worth trying to add hacks for those things. But I do worry that we don't have enough test coverage here, as this PR fixes #8848 (see more details there) which noticed issues we don't cover in the test suite (but that I'm not sure are worth adding - basically, things that wasm2js can't do).

