### PR TITLE
Handle a tiny {} function body in modifyFunction

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1594,7 +1594,7 @@ function modifyFunction(text, func) {
   var args = match[2];
   var rest = text.substr(match[0].length);
   var bodyStart = rest.indexOf('{');
-  assert(bodyStart > 0);
+  assert(bodyStart >= 0);
   var bodyEnd = rest.lastIndexOf('}');
   assert(bodyEnd > 0);
   return func(name, args, rest.substring(bodyStart + 1, bodyEnd));


### PR DESCRIPTION
This can happen when bysyncify adds extra assertion checks.