### PR TITLE
[WebIDL] Change arguments to use their specified names instead of arg%d

### DIFF
--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -105,9 +105,9 @@ struct_ptr_array[0]->attr2 == 101
 4 : 0.25
 9 : 0.01
 10 : -20.42
-Assertion failed: [CHECK FAILED] Parent::Parent(arg0:val): Expecting <integer>
+Assertion failed: [CHECK FAILED] Parent::Parent(val:val): Expecting <integer>
 Parent:42
-Assertion failed: [CHECK FAILED] Parent::voidStar(arg0:something): Expecting <pointer>
-Assertion failed: [CHECK FAILED] StringUser::Print(arg1:anotherString): Expecting <string>
+Assertion failed: [CHECK FAILED] Parent::voidStar(something:something): Expecting <pointer>
+Assertion failed: [CHECK FAILED] StringUser::Print(anotherString:anotherString): Expecting <string>
 
 done.

--- a/tests/webidl/test.idl
+++ b/tests/webidl/test.idl
@@ -30,8 +30,8 @@ interface Child2 {
   void virtualFunc2();
   void virtualFunc3(long x);
   void virtualFunc4(long x);
-  static void runVirtualFunc(Child2 self);
-  static void runVirtualFunc3(Child2 self, long x);
+  static void runVirtualFunc(Child2 myself);
+  static void runVirtualFunc3(Child2 myself, long x);
 };
 
 Child2 implements Parent;

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -361,7 +361,8 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
     for i in range(max_args):
       a = all_args[i]
       if isinstance(a, WebIDL.IDLArgument):
-        print(("  arg%d" % i), a.identifier, a.type, a.optional)
+        #print(("  arg%d" % i), a.identifier, a.type, a.optional)
+        print(' ', a.identifier.name, a.identifier, a.type, a.optional)
       else:
         print("  arg%d" % i)
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -361,7 +361,6 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
     for i in range(max_args):
       a = all_args[i]
       if isinstance(a, WebIDL.IDLArgument):
-        #print(("  arg%d" % i), a.identifier, a.type, a.optional)
         print(' ', a.identifier.name, a.identifier, a.type, a.optional)
       else:
         print("  arg%d" % i)

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -382,7 +382,7 @@ def render_function(class_name, func_name, sigs, return_type, non_pointer, copy,
       call_prefix += '!!('
       call_postfix += ')'
 
-  args = ['arg%d' % i for i in range(max_args)]
+  args = [(all_args[i].identifier.name if isinstance(all_args[i], WebIDL.IDLArgument) else ('arg%d' % i)) for i in range(max_args)]
   if not constructor:
     body = '  var self = this.ptr;\n'
     pre_arg = ['self']


### PR DESCRIPTION
This way instead of function calls being like `aClass.someMethod = function(arg0) {...}` they will now be like `aClass.someMethod = function(argNmaeFromIDL) {...}`

For the example IDL:
```
interface aClass{
  void someMethod(boolean argNmaeFromIDL);
}
```

This makes debugging much easier, as function args can have descriptive names.