### PR TITLE
CircleCI: Upgrade flake8 to current version (v3.7.7)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
           command: |
             pip install sphinx==1.7.8
       - run: make -C site html
-  flake8-python2:
+  flake8:
     <<: *defaults
     steps:
       - checkout
@@ -246,18 +246,6 @@ jobs:
       - run: pip install --upgrade pip
       - run: pip install flake8==3.7.7
       - run: flake8
-  flake8-python3:
-    <<: *defaults
-    steps:
-      - checkout
-      - run:
-          name: install pip
-          command: |
-            apt-get update -q
-            apt-get install -q -y python3-pip
-      - run: pip install --upgrade pip
-      - run: pip install flake8==3.7.7
-      - run: flake8 --exit-zero
   test-other:
     <<: *test-defaults
     environment:
@@ -413,8 +401,7 @@ workflows:
 
   build-test:
     jobs:
-      - flake8-python2
-      - flake8-python3
+      - flake8
       - build-docs
       - build
       - test-other:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -234,7 +234,7 @@ jobs:
           command: |
             pip install sphinx==1.7.8
       - run: make -C site html
-  flake8:
+  flake8-python2:
     <<: *defaults
     steps:
       - checkout
@@ -243,8 +243,21 @@ jobs:
           command: |
             apt-get update -q
             apt-get install -q -y python-pip
-      - run: pip install flake8==3.4.1
+      - run: pip install --upgrade pip
+      - run: pip install flake8==3.7.7
       - run: flake8
+  flake8-python3:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: install pip
+          command: |
+            apt-get update -q
+            apt-get install -q -y python3-pip
+      - run: pip install --upgrade pip
+      - run: pip install flake8==3.7.7
+      - run: flake8 --exit-zero
   test-other:
     <<: *test-defaults
     environment:
@@ -400,7 +413,8 @@ workflows:
 
   build-test:
     jobs:
-      - flake8
+      - flake8-python2
+      - flake8-python3
       - build-docs
       - build
       - test-other:

--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,11 @@
 [flake8]
-ignore = E111,E114,E501,E261,E266,E121,E402,E241
+# should be fixed in future pull requests
+# E722 do not use bare 'except'
+# E741 ambiguous variable name 'l'
+# F632 use ==/!= to compare str, bytes, and int literals
+# W605 invalid escape sequence '\ ' -- Should be fixed or # noqa added
+# W606 ‘async’ and ‘await’ are reserved keywords starting with Python 3.7
+ignore = E111,E114,E121,E241,E261,E266,E402,E501,E722,F632,W504,W605,W606
 exclude =
  ./third_party/, # third-party code
  ./tools/filelock.py, # third-party code

--- a/.flake8
+++ b/.flake8
@@ -5,7 +5,7 @@
 # F632 use ==/!= to compare str, bytes, and int literals
 # W605 invalid escape sequence '\ ' -- Should be fixed or # noqa added
 # W606 ‘async’ and ‘await’ are reserved keywords starting with Python 3.7
-ignore = E111,E114,E121,E241,E261,E266,E402,E501,E722,F632,W504,W605,W606
+ignore = E111,E114,E121,E241,E261,E266,E402,E501,E722,E741,F632,W504,W605,W606
 exclude =
  ./third_party/, # third-party code
  ./tools/filelock.py, # third-party code


### PR DESCRIPTION
Also add a separate flake8 on Python instead of legacy Python.  This run is _temporarily_ run in __--exit-zero__ mode until we can fix the Python 3 syntax errors and undefined names (basestring, unicode, xrange, etc.).

Thank you for submitting a pull request!

If this is your first PR, make sure to add yourself to AUTHORS.
