### PR TITLE
Update test for extra export

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2839,7 +2839,7 @@ Var: 42
       self.assertGreater(len(exports), 20)
       # wasm backend includes alias in NAMED_GLOBALS
       if self.is_wasm_backend():
-        self.assertLess(len(exports), 43)
+        self.assertLess(len(exports), 44)
       else:
         self.assertLess(len(exports), 30)
 


### PR DESCRIPTION
https://reviews.llvm.org/D63833 added a new __global_base symbol that
was breaking this test.