### PR TITLE
Fix path comparisons in source map and backtrace tests

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -795,8 +795,8 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
 
   # Tests that the given two paths are identical, modulo path delimiters. E.g. "C:/foo" is equal to "C:\foo".
   def assertPathsIdentical(self, path1, path2):
-    path1 = path1.replace('\\', '/')
-    path2 = path2.replace('\\', '/')
+    path1 = path1.replace('\\', '/').replace('//', '/')
+    path2 = path2.replace('\\', '/').replace('//', '/')
     return self.assertIdentical(path1, path2)
 
   # Tests that the given two multiline text content are identical, modulo line

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7768,7 +7768,7 @@ extern "C" {
     ]),
     'g4': ('-g4', [
       "src.cpp:3:12: runtime error: reference binding to null pointer of type 'int'",
-      'in main /',
+      'in main ',
       '/src.cpp:3:8'
     ]),
   })


### PR DESCRIPTION
assertPathsIdentical replaced `\` with `/` but Clang outputs paths with `\\`
in its DW_TAG_compile_unit fields (but not the rest of the debug info).
We should maybe fix that, but since the tests are already attempting to
paper over path differences, we can at least make them do it better.

Also remove expectation of a leading / in the backtrace test, since
windows path names don't start with that.