### PR TITLE
Bysyncify: fix invoke_*s

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1526,10 +1526,15 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if shared.Settings.BYSYNCIFY:
             # TODO: allow whitelist as in asyncify
             passes += ['--bysyncify']
-            if shared.Settings.BYSYNCIFY_IMPORTS:
-              passes += ['--pass-arg=bysyncify-imports@%s' % ','.join(['env.' + i for i in shared.Settings.BYSYNCIFY_IMPORTS])]
             if shared.Settings.BYSYNCIFY_IGNORE_INDIRECT:
               passes += ['--pass-arg=bysyncify-ignore-indirect']
+            else:
+              # if we are not ignoring indirect calls, then we must treat invoke_* as if
+              # they are indirect calls, since that is what they do - we can't see their
+              # targets statically.
+              shared.Settings.BYSYNCIFY_IMPORTS += ['invoke_*']
+            if shared.Settings.BYSYNCIFY_IMPORTS:
+              passes += ['--pass-arg=bysyncify-imports@%s' % ','.join(['env.' + i for i in shared.Settings.BYSYNCIFY_IMPORTS])]
         if shared.Settings.BINARYEN_EXTRA_PASSES:
           passes += parse_passes(shared.Settings.BINARYEN_EXTRA_PASSES)
         options.binaryen_passes = passes

--- a/tests/browser/async_longjmp.cpp
+++ b/tests/browser/async_longjmp.cpp
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <emscripten.h>
+#include <stdio.h>
+#include <setjmp.h>
+
+static jmp_buf buf;
+
+void second(void) {
+  printf("second\n");
+  emscripten_sleep(1);
+  longjmp(buf, -1);
+}
+
+void first(void) {
+  printf("first\n");  // prints
+  emscripten_sleep(1);
+  longjmp(buf, 1);  // jumps back to where setjmp was called - making setjmp now
+                    // return 1
+}
+
+int main() {
+  volatile int x = 0;
+  emscripten_sleep(1);
+  int jmpval = setjmp(buf);
+  if (!jmpval) {
+    x++;                  // should be properly restored once longjmp jumps back
+    first();              // when executed, setjmp returns 1
+    printf("skipped\n");  // does not print
+  } else if (jmpval == 1) {  // when first() jumps back, setjmp returns 1
+    printf("result: %d %d\n", x, jmpval);  // prints
+    x++;
+    emscripten_sleep(1);
+    second();                 // when executed, setjmp returns -1
+    emscripten_sleep(1);
+  } else if (jmpval == -1) {  // when second() jumps back, setjmp returns -1
+    printf("result: %d %d\n", x, jmpval);  // prints
+  }
+  emscripten_sleep(1);
+  REPORT_RESULT(x);
+}

--- a/tests/browser/async_longjmp.cpp
+++ b/tests/browser/async_longjmp.cpp
@@ -24,6 +24,11 @@ void first(void) {
                     // return 1
 }
 
+__attribute__((noinline)) // https://github.com/emscripten-core/emscripten/issues/8894
+void finish(int x) {
+  REPORT_RESULT(x);
+}
+
 int main() {
   volatile int x = 0;
   emscripten_sleep(1);
@@ -42,5 +47,5 @@ int main() {
     printf("result: %d %d\n", x, jmpval);  // prints
   }
   emscripten_sleep(1);
-  REPORT_RESULT(x);
+  finish(x);
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3228,8 +3228,8 @@ window.close = function() {
   # Test async sleeps in the presence of invoke_* calls, which can happen with
   # longjmp or exceptions.
   @parameterized({
-    '0': ([],), # noqa
-    '3': (['-O3'],), # noqa
+    'O0': ([],), # noqa
+    'O3': (['-O3'],), # noqa
   })
   def test_async_longjmp(self, args):
     self.btest('browser/async_longjmp.cpp', '2', args=args + self.get_async_args())

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3227,7 +3227,7 @@ window.close = function() {
 
   @parameterized({
     '0': ([],), # noqa
-    '1': (['-O1'],), # noqa
+    '3': (['-O3'],), # noqa
   })
   def test_async_longjmp(self, args):
     self.btest('browser/async_longjmp.cpp', '2', args=args + self.get_async_args())

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3225,6 +3225,8 @@ window.close = function() {
       print(opts)
       self.btest('browser/async_virtual_2.cpp', '1', args=['-O' + str(opts), '-s', 'ASSERTIONS=1', '-s', 'SAFE_HEAP=1', '-profiling'] + self.get_async_args())
 
+  # Test async sleeps in the presence of invoke_* calls, which can happen with
+  # longjmp or exceptions.
   @parameterized({
     '0': ([],), # noqa
     '3': (['-O3'],), # noqa

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3225,6 +3225,13 @@ window.close = function() {
       print(opts)
       self.btest('browser/async_virtual_2.cpp', '1', args=['-O' + str(opts), '-s', 'ASSERTIONS=1', '-s', 'SAFE_HEAP=1', '-profiling'] + self.get_async_args())
 
+  @parameterized({
+    '0': ([],), # noqa
+    '1': (['-O1'],), # noqa
+  })
+  def test_async_longjmp(self, args):
+    self.btest('browser/async_longjmp.cpp', '2', args=args + self.get_async_args())
+
   @no_wasm_backend('emterpretify, with emterpreter-specific error logging')
   def test_emterpreter_async_bad(self):
     for opts in [0, 3]:


### PR DESCRIPTION
An `invoke_*` call is basically the same as an indirect call, it just goes out into JS. The bysyncify analysis needs to be aware of that so it doesn't miss things.

Fixes bysyncify on code that uses invokes, which includes longjmp and exceptions.