### PR TITLE
[WebIDL] Add support for 'long long' datatype

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.rst
@@ -472,10 +472,11 @@ The type names in WebIDL are not identical to those in C++. This section shows t
   "``char``", "``byte``"
   "``char*``", "``DOMString`` (represents a JavaScript string)"
   "``unsigned char``", "``octet``"
-  "``unsigned short int``", "``unsigned short``"
+  "``int``", "``long``"
+  "``long``", "``long``"
   "``unsigned short``", "``unsigned short``"
   "``unsigned long``", "``unsigned long``"
-  "``int``", "``long``"
+  "``long long``", "``long long``"
   "``void``", "``void``"
   "``void*``", "``any`` or ``VoidPtr`` (see :ref:`webidl-binder-voidstar`)"
 

--- a/tests/webidl/test.h
+++ b/tests/webidl/test.h
@@ -189,3 +189,7 @@ struct StoreArray {
   const int* int_array;
 };
 
+typedef struct LongLongTypes {
+  unsigned long long* lluArray;
+  long long ll;
+} LongLongTypes;

--- a/tests/webidl/test.idl
+++ b/tests/webidl/test.idl
@@ -165,3 +165,7 @@ interface StoreArray {
   long getArrayValue(long index);
 };
 
+interface LongLongTypes {
+  readonly attribute unsigned long long[] lluArray;
+  attribute long long ll;
+};

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -286,6 +286,10 @@ def type_to_c(t, non_pointing=False):
       ret = 'int'
     elif t == 'UnsignedLong':
       ret = 'unsigned int'
+    elif t == 'LongLong':
+      ret = 'long long'
+    elif t == 'UnsignedLongLong':
+      ret = 'unsigned long long'
     elif t == 'Short':
       ret = 'short'
     elif t == 'UnsignedShort':


### PR DESCRIPTION
This adds support for both signed/unsigned 'long long's. (see: https://heycam.github.io/webidl/#idl-long-long)
Most the work was already there, so this was straightforward.

Fixes #8896.