### PR TITLE
Bysyncify: stack overflow check improvements

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -555,7 +555,7 @@ mergeInto(LibraryManager.library, {
       Rewinding: 2
     },
     state: 0,
-    DataSize: 4096,
+    StackSize: {{{ BYSYNCIFY_STACK_SIZE }}},
     currData: null,
     // A map from data pointers to extra info about the data.
     // That includes the name of the function on the bottom
@@ -610,9 +610,9 @@ mergeInto(LibraryManager.library, {
     allocateData: function() {
       // A bysyncify data structure has two fields: the
       // current stack pos, and the max pos.
-      var ptr = _malloc(Bysyncify.DataSize);
+      var ptr = _malloc(Bysyncify.StackSize + 8);
       HEAP32[ptr >> 2] = ptr + 8;
-      HEAP32[ptr + 4 >> 2] = ptr + Bysyncify.DataSize;
+      HEAP32[ptr + 4 >> 2] = ptr + 8 + Bysyncify.StackSize;
       Bysyncify.dataInfo[ptr] = {
         bottomOfCallStack: Bysyncify.exportCallStack[0]
       };

--- a/src/settings.js
+++ b/src/settings.js
@@ -565,6 +565,12 @@ var BYSYNCIFY_IMPORTS = ['emscripten_sleep', 'emscripten_wget', 'emscripten_wget
 // must assume an indirect call can reach almost everywhere.
 var BYSYNCIFY_IGNORE_INDIRECT = 0;
 
+// The size of the Bysyncify stack - the region used to store unwind/rewind info.
+// This must be large enough to store the call stack and locals. If it is too
+// small, you will see a wasm trap due to executing an "unreachable" instruction.
+// In that case, you should increase this size.
+var BYSYNCIFY_STACK_SIZE = 4096;
+
 // Runtime debug logging from bysyncify internals.
 var BYSYNCIFY_DEBUG = 0;
 

--- a/tests/browser/async_stack_overflow.cpp
+++ b/tests/browser/async_stack_overflow.cpp
@@ -1,0 +1,42 @@
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <emscripten.h>
+
+int main() {
+  EM_ASM({
+    window.onerror = function(e) {
+      var success = e.toString().indexOf("unreachable") > 0;
+      if (success && !Module.reported) {
+        Module.reported = true;
+        console.log("reporting success");
+        // manually REPORT_RESULT; we shouldn't call back into native code at this point
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", "http://localhost:8888/report_result?0");
+        xhr.onload = xhr.onerror = function() {
+          window.close();
+        };
+        xhr.send();
+      }
+    };
+  });
+
+  volatile int x = 0;
+  volatile int y = 0;
+  volatile int z = 0;
+  x++;
+  y++;
+  z++;
+  emscripten_sleep(1);
+
+  // We should not get here - the unwind will fail as the stack is too small
+  printf("We should not get here %d %d %d\n", x, y, z);
+
+  REPORT_RESULT(1);
+
+  return 0;
+}
+

--- a/tests/browser/async_stack_overflow.cpp
+++ b/tests/browser/async_stack_overflow.cpp
@@ -9,7 +9,9 @@
 int main() {
   EM_ASM({
     window.onerror = function(e) {
-      var success = e.toString().indexOf("unreachable") > 0;
+      var message = e.toString();
+      var success = message.indexOf("unreachable") >= 0 || // firefox
+                    message.indexOf("Script error.") >= 0; // chrome
       if (success && !Module.reported) {
         Module.reported = true;
         console.log("reporting success");

--- a/tests/browser/async_stack_overflow.cpp
+++ b/tests/browser/async_stack_overflow.cpp
@@ -7,7 +7,7 @@
 #include <emscripten.h>
 
 int main() {
-  EM_ASM({
+  int x = EM_ASM_INT({
     window.onerror = function(e) {
       var message = e.toString();
       var success = message.indexOf("unreachable") >= 0 || // firefox
@@ -24,16 +24,15 @@ int main() {
         xhr.send();
       }
     };
+    return 0;
   });
 
-  volatile int x = 0;
-  volatile int y = 0;
-  volatile int z = 0;
+  int y = x * x;
+  int z = y * y;
   x++;
   y++;
   z++;
   emscripten_sleep(1);
-
   // We should not get here - the unwind will fail as the stack is too small
   printf("We should not get here %d %d %d\n", x, y, z);
 
@@ -41,4 +40,3 @@ int main() {
 
   return 0;
 }
-

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3296,6 +3296,10 @@ window.close = function() {
   def test_async_returnvalue(self, args):
     self.btest('browser/async_returnvalue.cpp', '0', args=['-s', 'BYSYNCIFY', '-s', 'BYSYNCIFY_IGNORE_INDIRECT', '--js-library', path_from_root('tests', 'browser', 'async_returnvalue.js')] + args + ['-s', 'ASSERTIONS=1'])
 
+  @no_fastcomp('bysyncify specific')
+  def test_async_stack_overflow(self):
+    self.btest('browser/async_stack_overflow.cpp', '0', args=['-s', 'BYSYNCIFY', '-s', 'BYSYNCIFY_STACK_SIZE=4'])
+
   @requires_sync_compilation
   def test_modularize(self):
     for opts in [[], ['-O1'], ['-O2', '-profiling'], ['-O2'], ['-O2', '--closure', '1']]:


### PR DESCRIPTION
Add an option `BYSYNCIFY_STACK_SIZE` to allow customizing the stack size (as some programs may need very large stacks).

Add a test that when the stack is too small an exception is thrown as expected (instead of silent corruption).

cc @Keno - please test if you can. With latest binaryen master we should have proper checks for overflow now.