### PR TITLE
Ensure thread stacks are aligned to STACK_ALIGN bytes

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1300,6 +1300,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       ]
 
     if shared.Settings.USE_PTHREADS:
+      # To ensure allocated thread stacks are aligned:
+      shared.Settings.EXPORTED_FUNCTIONS += ['_memalign']
+
       if shared.Settings.MODULARIZE:
         # MODULARIZE+USE_PTHREADS mode requires extra exports out to Module so that worker.js
         # can access them:

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -491,7 +491,7 @@ var LibraryPThread = {
     {{{ makeSetValue('__num_logical_cores', 0, 'cores', 'i32') }}};
   },
 
-  pthread_create__deps: ['_spawn_thread', 'pthread_getschedparam', 'pthread_self'],
+  pthread_create__deps: ['_spawn_thread', 'pthread_getschedparam', 'pthread_self', 'memalign'],
   pthread_create: function(pthread_ptr, attr, start_routine, arg) {
     if (typeof SharedArrayBuffer === 'undefined') {
       err('Current environment does not support SharedArrayBuffer, pthreads are not available!');
@@ -632,7 +632,7 @@ var LibraryPThread = {
     }
     var allocatedOwnStack = stackBase == 0; // If allocatedOwnStack == true, then the pthread impl maintains the stack allocation.
     if (allocatedOwnStack) {
-      stackBase = _malloc(stackSize); // Allocate a stack if the user doesn't want to place the stack in a custom memory area.
+      stackBase = _memalign({{{ STACK_ALIGN }}}, stackSize); // Allocate a stack if the user doesn't want to place the stack in a custom memory area.
     } else {
       // Musl stores the stack base address assuming stack grows downwards, so adjust it to Emscripten convention that the
       // stack grows upwards instead.


### PR DESCRIPTION
In upstream LLVM backend, malloc'd thread stacks were only aligned
to 8 bytes, which could create problems with code assuming 16-byte
alignment.

Pulls in memalign as a dep for pthreads mode, and uses it to align
the stack to STACK_ALIGN bytes as expected.

Fixes https://github.com/emscripten-core/emscripten/issues/8887