### PR TITLE
Bysyncify: pthreads support

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1536,6 +1536,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
               # they are indirect calls, since that is what they do - we can't see their
               # targets statically.
               shared.Settings.BYSYNCIFY_IMPORTS += ['invoke_*']
+            # with pthreads we may call main through the __call_main mechanism, which can
+            # therefore reach anything in the program, so mark it as possibly causing a
+            # sleep (the bysyncify analysis doesn't look through JS, just wasm, so it can't
+            # see what it itself calls)
+            if shared.Settings.USE_PTHREADS:
+              shared.Settings.BYSYNCIFY_IMPORTS += ['__call_main']
             if shared.Settings.BYSYNCIFY_IMPORTS:
               passes += ['--pass-arg=bysyncify-imports@%s' % ','.join(['env.' + i for i in shared.Settings.BYSYNCIFY_IMPORTS])]
         if shared.Settings.BINARYEN_EXTRA_PASSES:

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -577,7 +577,7 @@ mergeInto(LibraryManager.library, {
             ret[x] = function() {
               Bysyncify.exportCallStack.push(x);
 #if BYSYNCIFY_DEBUG >= 2
-              err('BYSYNCIFY: try', x);
+              err('BYSYNCIFY: ' + '  '.repeat(Bysyncify.exportCallStack.length) + ' try', x);
 #endif
               try {
                 return original.apply(null, arguments);
@@ -586,7 +586,7 @@ mergeInto(LibraryManager.library, {
                 var y = Bysyncify.exportCallStack.pop(x);
                 assert(y === x);
 #if BYSYNCIFY_DEBUG >= 2
-                err('BYSYNCIFY: finally', x);
+                err('BYSYNCIFY: ' + '  '.repeat(Bysyncify.exportCallStack.length + 1) + ' finally', x);
 #endif
                 if (Bysyncify.currData &&
                     Bysyncify.state === Bysyncify.State.Unwinding &&
@@ -613,8 +613,12 @@ mergeInto(LibraryManager.library, {
       var ptr = _malloc(Bysyncify.StackSize + 8);
       HEAP32[ptr >> 2] = ptr + 8;
       HEAP32[ptr + 4 >> 2] = ptr + 8 + Bysyncify.StackSize;
+      var bottomOfCallStack = Bysyncify.exportCallStack[0];
+#if BYSYNCIFY_DEBUG >= 2
+      err('BYSYNCIFY: allocateData, bottomOfCallStack is', bottomOfCallStack, new Error().stack);
+#endif
       Bysyncify.dataInfo[ptr] = {
-        bottomOfCallStack: Bysyncify.exportCallStack[0]
+        bottomOfCallStack: bottomOfCallStack
       };
       return ptr;
     },

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1104,7 +1104,11 @@ function createWasm(env) {
   // to any other async startup actions they are performing.
   if (Module['instantiateWasm']) {
     try {
-      return Module['instantiateWasm'](info, receiveInstance);
+      var exports = Module['instantiateWasm'](info, receiveInstance);
+#if BYSYNCIFY
+      exports = Bysyncify.instrumentWasmExports(exports);
+#endif
+      return exports;
     } catch(e) {
       err('Module.instantiateWasm callback failed with error: ' + e);
       return false;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3213,6 +3213,7 @@ window.close = function() {
       print(opts)
       self.btest('browser/async.cpp', '1', args=['-O' + str(opts), '-g2'] + self.get_async_args())
 
+  @no_fastcomp('emterpretify is not compatible with threads')
   @requires_threads
   def test_async_in_pthread(self):
     self.btest('browser/async.cpp', '1', args=self.get_async_args() + ['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1', '-g'])

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3213,6 +3213,10 @@ window.close = function() {
       print(opts)
       self.btest('browser/async.cpp', '1', args=['-O' + str(opts), '-g2'] + self.get_async_args())
 
+  @requires_threads
+  def test_async_in_pthread(self):
+    self.btest('browser/async.cpp', '1', args=self.get_async_args() + ['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1', '-g'])
+
   def test_async_2(self):
     # Error.stackTraceLimit default to 10 in chrome but this test relies on more
     # than 40 stack frames being reported.


### PR DESCRIPTION
 * Add the `__call_main` JS function (wasm calls that, which then calls main; if we don't add it to the list of potentially sleeping functions, we don't support unwinding the stack through it).
 * Add bysyncify support on the `Module['instantiateWasm']` code path, which is used by pthreads (and other things, so this fixes them too) - we need to instrument the exports on all paths.
 * Add more logging in `BYSYNCIFY_DEBUG` mode.