### PR TITLE
 `class_<T>.function` to accept `std::function` and function object

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -417,3 +417,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Zoltan Varga <vargaz@gmail.com> (copyright owned by Microsoft, Inc.)
 * Fernando Serboncini <fserb@google.com>
 * Christian Clauss <cclauss@me.com> (copyright owned by IBM)
+* Henry Kleynhans <hkleynhans@bloomberg.net> (copyright owned by Bloomberg L.P.)

--- a/site/source/docs/api_reference/bind.h.rst
+++ b/site/source/docs/api_reference/bind.h.rst
@@ -602,43 +602,30 @@ Classes
       .. code-block:: cpp
 
          //prototype
-         template<typename ReturnType, typename... Args, typename... Policies>
-         EMSCRIPTEN_ALWAYS_INLINE const class_& function(const char* methodName, ReturnType (ClassType::*memberFunction)(Args...), Policies...) const
+         template<typename Signature = internal::DeduceArgumentsTag, typename Callable, typename... Policies>
+         EMSCRIPTEN_ALWAYS_INLINE const class_& function(const char* methodName, Callable callable, Policies...) const
 
       This method is for declaring a method belonging to a class.
 
-      On the JavaScript side this is a function that gets bound as a property of the prototype. For example ``.function("myClassMember", &MyClass::myClassMember)`` would bind ``myClassMember`` to ``MyClass.prototype.myClassMember`` in the JavaScript.
+      On the JavaScript side this is a function that gets bound as a property of the prototype. For example ``.function("myClassMember", &MyClass::myClassMember)``
+      would bind ``myClassMember`` to ``MyClass.prototype.myClassMember`` in the JavaScript.  This method will accept either a pointer-to-member-function, function
+      pointer, ``std::function`` object or function object.  When the ``Callable`` is not a pointer-to-member-function it must accept the ``ClassType`` as the first
+      (``this``) parameter.  When the ``Callable`` is a function object the function signature must be explicitly specified in the ``Signature`` template parameter
+      in the format ``ReturnType (Args...)``.  For ``Callable`` types other than function objects the method signature will be deduced.
 
-      :param const char* methodName
-      :param ReturnType (ClassType\:\:\*memberFunction)(Args...) Note that ``ReturnType`` is a template typename for this function and ``ClassType`` is a template typename for the class.
-      :param typename... Policies: |policies-argument|
-      :returns: |class_-function-returns|
-
-
-   .. cpp:function:: const class_& function(const char* methodName, ReturnType (ClassType::*memberFunction)(Args...) const, Policies...) const
+      The following are all valid calls to ``function``:
 
       .. code-block:: cpp
 
-         //prototype
-         template<typename ReturnType, typename... Args, typename... Policies>
-         EMSCRIPTEN_ALWAYS_INLINE const class_& function(const char* methodName, ReturnType (ClassType::*memberFunction)(Args...) const, Policies...) const
+         using namespace std::placeholders;
+         myClass.function("myClassMember", &MyClass::myClassMember)
+             .function("myFreeFunction", &my_free_function)
+             .function("myStdFunction", std::function<float(ClassType&, float, float)>(&my_function))
+             .function<val(const MyClass&)>("myFunctor", std::bind(&my_functor_taking_this, _1));
+
 
       :param const char* methodName
-      :param ReturnType (ClassType\:\:\*memberFunction)(Args...) const: Note that ``ReturnType`` is a template typename for this function and ``ClassType`` is a template typename for the class.
-      :param typename... Policies: |policies-argument|
-      :returns: |class_-function-returns|
-
-
-   .. cpp:function:: const class_& function(const char* methodName, ReturnType (*function)(ThisType, Args...), Policies...) const
-
-      .. code-block:: cpp
-
-         //prototype
-         template<typename ReturnType, typename ThisType, typename... Args, typename... Policies>
-         EMSCRIPTEN_ALWAYS_INLINE const class_& function(const char* methodName, ReturnType (*function)(ThisType, Args...), Policies...) const
-
-      :param const char* methodName
-      :param ReturnType (\*function)(ThisType, Args...)
+      :param Callable callable Note that ``Callable`` may be either a member function pointer, function pointer, ``std::function`` or function object.
       :param typename... Policies: |policies-argument|
       :returns: |class_-function-returns|
 

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -1192,6 +1192,22 @@ module({
             b.delete();
         });
 
+        test("function objects as class methods", function() {
+            let b = cm.ValHolder.makeValHolder("foo");
+
+            // get & set via std::function
+            assert.equal("foo", b.getValFunction());
+            b.setValFunction("bar");
+
+            // get & set via 'callable'
+            assert.equal("bar", b.getValFunctor());
+            b.setValFunctor("baz");
+
+            assert.equal("baz", b.getValFunction())
+
+            b.delete();
+        });
+
         test("can't call methods on deleted class instances", function() {
             var c = new cm.ValHolder(undefined);
             c.delete();

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -259,6 +259,14 @@ ValHolder emval_test_return_ValHolder() {
     return val::object();
 }
 
+val valholder_get_value_mixin(const ValHolder& target) {
+    return target.getVal();
+}
+
+void valholder_set_value_mixin(ValHolder& target, const val& value) {
+    target.setVal(value);
+}
+
 void emval_test_set_ValHolder_to_empty_object(ValHolder& vh) {
     vh.setVal(val::object());
 }
@@ -1784,6 +1792,8 @@ EMSCRIPTEN_BINDINGS(tests) {
         ;
     function("emval_test_take_and_return_ArrayInStruct", &emval_test_take_and_return_ArrayInStruct);
 
+    using namespace std::placeholders;
+
     class_<ValHolder>("ValHolder")
         .smart_ptr<std::shared_ptr<ValHolder>>("std::shared_ptr<ValHolder>")
         .constructor<val>()
@@ -1792,6 +1802,10 @@ EMSCRIPTEN_BINDINGS(tests) {
         .function("getConstVal", &ValHolder::getConstVal)
         .function("getValConstRef", &ValHolder::getValConstRef)
         .function("setVal", &ValHolder::setVal)
+        .function("getValFunction", std::function<val(const ValHolder&)>(&valholder_get_value_mixin))
+        .function("setValFunction", std::function<void(ValHolder&, const val&)>(&valholder_set_value_mixin))
+        .function<val(const ValHolder&)>("getValFunctor", std::bind(&valholder_get_value_mixin, _1))
+        .function<void(ValHolder&, const val&)>("setValFunctor", std::bind(&valholder_set_value_mixin, _1, _2))
         .property("val", &ValHolder::getVal, &ValHolder::setVal)
         .property("val_readonly", &ValHolder::getVal)
         .class_function("makeConst", &ValHolder::makeConst, allow_raw_pointer<ret_val>())


### PR DESCRIPTION
Enable `class_<T>.function` to accept both `std::function` and
function object types.  This is useful in scenarios where you want a
stateful function object for purposes such as gathering statistics or
performing other generic functionality on each call.