### PR TITLE
Implement wake all semantics

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1042,6 +1042,9 @@ var LibraryPThread = {
   emscripten_futex_wake: function(addr, count) {
     if (addr <= 0 || addr > HEAP8.length || addr&3 != 0 || count < 0) return -{{{ cDefine('EINVAL') }}};
     if (count == 0) return 0;
+    // Waking (at least) INT_MAX waiters is defined to mean wake all callers.
+    // For Atomics.notify() API Infinity is to be passed in that case.
+    if (count >= {{{ cDefine('INT_MAX') }}}) count = Infinity;
 //    dump('futex_wake addr:' + addr + ' by thread: ' + _pthread_self() + (ENVIRONMENT_IS_PTHREAD?'(pthread)':'') + '\n');
 
     // See if main thread is waiting on this address? If so, wake it up by resetting its wake location to zero.

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -86,7 +86,10 @@ uint16_t emscripten_atomic_xor_u16(void/*uint16_t*/ *addr, uint16_t val);
 uint32_t emscripten_atomic_xor_u32(void/*uint32_t*/ *addr, uint32_t val);
 uint64_t emscripten_atomic_xor_u64(void/*uint64_t*/ *addr, uint64_t val); // In Wasm, this is a native instruction. In asm.js this is emulated with locks, very slow!
 
+// If the given memory address contains value val, puts the calling thread to sleep waiting for that address to be notified.
 int emscripten_futex_wait(volatile void/*uint32_t*/ *addr, uint32_t val, double maxWaitMilliseconds);
+
+// Wakes the given number of threads waiting on a location. Pass count == INT_MAX to wake all waiters on that location.
 int emscripten_futex_wake(volatile void/*uint32_t*/ *addr, int count);
 
 typedef union em_variant_val

--- a/tests/pthread/test_futex_wake_all.cpp
+++ b/tests/pthread/test_futex_wake_all.cpp
@@ -1,0 +1,72 @@
+// Copyright 2016 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <emscripten/threading.h>
+#include <assert.h>
+#include <math.h>
+#include <limits.h>
+
+#define NUM_THREADS 8
+
+unsigned int futexVal = 0;
+
+unsigned int numAwoken = 0;
+
+void *WakingThread(void *arg)
+{
+	// Wake all threads waiting for the futex address
+	emscripten_atomic_store_u32(&futexVal, 1);
+	emscripten_futex_wake(&futexVal, INT_MAX);
+
+	pthread_exit(0);
+}
+
+void *WaitingThread(void *arg)
+{
+	// Last waiting thread creates the waking thread - this simplifies mutual synchronization needs
+	if ((int)arg == NUM_THREADS-1)
+	{
+		pthread_t wakingThread;
+		pthread_create(&wakingThread, 0, WakingThread, 0);
+	}
+
+	// Each waiting thread waits until wake thread changes the value at the wait address
+	while(emscripten_atomic_load_u32(&futexVal) == 0)
+	{
+		emscripten_futex_wait(&futexVal, 0, INFINITY);
+	}
+
+	// Tally up the number of awoken threads - last one to wake up signals test success
+	uint32_t old = emscripten_atomic_add_u32(&numAwoken, 1);
+	if (old + 1 == NUM_THREADS)
+	{
+#ifdef REPORT_RESULT
+		REPORT_RESULT(0);
+#endif
+	}
+
+	pthread_exit(0);
+}
+
+int main()
+{
+	if (!emscripten_has_threading_support())
+	{
+#ifdef REPORT_RESULT
+		REPORT_RESULT(0);
+#endif
+		printf("Skipped: Threading is not supported.\n");
+		return 0;
+	}
+
+	pthread_t waitingThreads[NUM_THREADS];
+	for(int i = 0; i < NUM_THREADS; ++i)
+	{
+		pthread_create(waitingThreads+i, 0, WaitingThread, (void*)i);
+	}
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3885,6 +3885,11 @@ window.close = function() {
   def test_pthread_utf8_funcs(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_utf8_funcs.cpp'), expected='0', args=['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'])
 
+  # Test the emscripten_futex_wake(addr, INT_MAX); functionality to wake all waiters
+  @requires_threads
+  def test_pthread_wake_all(self):
+    self.btest(path_from_root('tests', 'pthread', 'test_futex_wake_all.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_HINT_NUM_CORES=2', '-s', 'TOTAL_MEMORY=64MB'], also_asmjs=True)
+
   # Tests MAIN_THREAD_EM_ASM_INT() function call signatures.
   @no_wasm_backend('MAIN_THREAD_EM_ASM() not yet implemented in Wasm backend')
   def test_main_thread_em_asm_signatures(self):


### PR DESCRIPTION
Implement wake all semantics when `emscripten_futex_wake(addr, INT_MAX);` is called. Explicitly waking all might have a more efficient implementation compared to a "wake exactly 2 billion waiters" call.