### PR TITLE
Define EMSCRIPTEN in the wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1017,6 +1017,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.STRICT:
       shared.Settings.ERROR_ON_MISSING_LIBRARIES = 1
+    else:
+      # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
+      # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
+      shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
 
     error_on_missing_libraries_cmdline = get_last_setting_change('ERROR_ON_MISSING_LIBRARIES')
     if error_on_missing_libraries_cmdline:
@@ -1082,10 +1086,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.STRICT:
       shared.Settings.DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1
-    else:
-      # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
-      # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
-      shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
 
     if AUTODEBUG:
       shared.Settings.AUTODEBUG = 1

--- a/src/settings.js
+++ b/src/settings.js
@@ -746,6 +746,11 @@ var LINKABLE = 0;
 // Emscripten 'strict' build mode: Drop supporting any deprecated build options.
 // Set the environment variable EMCC_STRICT=1 or pass -s STRICT=1 to test that a
 // codebase builds nicely in forward compatible manner.
+// Changes enabled by this:
+//   * ERROR_ON_MISSING_LIBRARIES is enabled
+//   * DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR is enabled
+//   * The C define EMSCRIPTEN is not defined (__EMSCRIPTEN__ always is, and
+//     is the correct thing to use).
 var STRICT = 0;
 
 // If set to 1, we will warn on any undefined symbols that are not resolved by

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9431,6 +9431,7 @@ int main () {
         emcc_args.extend(['--embed-file', f])
     self.do_other_test('mmap_and_munmap', emcc_args)
 
+  @no_fastcomp('fastcomp defines this in the backend itself, so it is always on there')
   def test_EMSCRIPTEN_and_STRICT(self):
     # __EMSCRIPTEN__ is the proper define; we support EMSCRIPTEN for legacy
     # code, unless STRICT is enabled.
@@ -9439,5 +9440,5 @@ int main () {
       #error "not defined"
       #endif
     ''')
-    run_process([PYTHON, EMCC, 'src.c'])
-    self.expect_fail([PYTHON, EMCC, 'src.c', '-s', 'STRICT'])
+    run_process([PYTHON, EMCC, 'src.c', '-c'])
+    self.expect_fail([PYTHON, EMCC, 'src.c', '-s', 'STRICT', '-c'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9430,3 +9430,14 @@ int main () {
         create_test_file(f, 'Test file')
         emcc_args.extend(['--embed-file', f])
     self.do_other_test('mmap_and_munmap', emcc_args)
+
+  def test_EMSCRIPTEN_and_STRICT(self):
+    # __EMSCRIPTEN__ is the proper define; we support EMSCRIPTEN for legacy
+    # code, unless STRICT is enabled.
+    create_test_file('src.c', '''
+      #ifndef EMSCRIPTEN
+      #error "not defined"
+      #endif
+    ''')
+    run_process([PYTHON, EMCC, 'src.c'])
+    self.expect_fail([PYTHON, EMCC, 'src.c', '-s', 'STRICT'])


### PR DESCRIPTION
This is useful for fastcomp backwards compatibility.

This is in addition to the more proper `__EMSCRIPTEN__` that the backend defines by itself.

Alternatively, perhaps we can not do this, and document in a prominent place that this is a breaking change.

Fixes #8921