### PR TITLE
Add support for std::u16string and std::u32string

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -453,3 +453,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Austin Eng <enga@chromium.org> (copyright owned by Google, Inc.)
 * Hugo Amiard <hugo.amiard@laposte.net>
 * Diego Casorran <dcasorran@gmail.com>
+* Guillaume Racicot <gufideg@gmail.com>

--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -114,6 +114,8 @@ void EMSCRIPTEN_KEEPALIVE __embind_register_native_and_builtin_types() {
   _embind_register_std_string(
     TypeID<std::basic_string<unsigned char>>::get(), "std::basic_string<unsigned char>");
   _embind_register_std_wstring(TypeID<std::wstring>::get(), sizeof(wchar_t), "std::wstring");
+  _embind_register_std_wstring(TypeID<std::u16string>::get(), sizeof(char16_t), "std::u16string");
+  _embind_register_std_wstring(TypeID<std::u32string>::get(), sizeof(char32_t), "std::u32string");
   _embind_register_emval(TypeID<val>::get(), "emscripten::val");
 
   // Some of these types are aliases for each other. Luckily,

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -470,59 +470,41 @@ module({
             var e = cm.emval_test_take_and_return_std_string(string);
             assert.equal(string, e);
         });
+        
+        var utf16TestString = String.fromCharCode(10) +
+            String.fromCharCode(1234) +
+            String.fromCharCode(2345) +
+            String.fromCharCode(65535);
+        var utf32TestString = String.fromCharCode(10) +
+            String.fromCharCode(1234) +
+            String.fromCharCode(2345) +
+            String.fromCharCode(55357) +
+            String.fromCharCode(56833) +
+            String.fromCharCode(55357) +
+            String.fromCharCode(56960);
 
         test("non-ascii wstrings", function() {
-            var expected = String.fromCharCode(10) +
-                String.fromCharCode(1234) +
-                String.fromCharCode(2345) +
-                String.fromCharCode(65535);
-            assert.equal(expected, cm.get_non_ascii_wstring());
+            assert.equal(utf16TestString, cm.get_non_ascii_wstring());
         });
 
         test("non-ascii u16strings", function() {
-            var expected = String.fromCharCode(10) +
-                String.fromCharCode(1234) +
-                String.fromCharCode(2345) +
-                String.fromCharCode(65535);
-            assert.equal(expected, cm.get_non_ascii_u16string());
+            assert.equal(utf16TestString, cm.get_non_ascii_u16string());
         });
 
         test("non-ascii u32strings", function() {
-            var expected = String.fromCharCode(10) +
-                String.fromCharCode(1234) +
-                String.fromCharCode(2345) +
-                String.fromCharCode(55357) +
-                String.fromCharCode(56833) +
-                String.fromCharCode(55357) +
-                String.fromCharCode(56960);
-            assert.equal(expected, cm.get_non_ascii_u32string());
+            assert.equal(utf32TestString, cm.get_non_ascii_u32string());
         });
 
         test("passing unicode (wide) string into C++", function() {
-            var expected = String.fromCharCode(10) +
-                String.fromCharCode(1234) +
-                String.fromCharCode(2345) +
-                String.fromCharCode(65535);
-            assert.equal(expected, cm.take_and_return_std_wstring(expected));
+            assert.equal(utf16TestString, cm.take_and_return_std_wstring(utf16TestString));
         });
 
         test("passing unicode (utf-16) string into C++", function() {
-            var expected = String.fromCharCode(10) +
-                String.fromCharCode(1234) +
-                String.fromCharCode(2345) +
-                String.fromCharCode(65535);
-            assert.equal(expected, cm.take_and_return_std_u16string(expected));
+            assert.equal(utf16TestString, cm.take_and_return_std_u16string(utf16TestString));
         });
 
         test("passing unicode (utf-32) string into C++", function() {
-            var expected = String.fromCharCode(10) +
-                String.fromCharCode(1234) +
-                String.fromCharCode(2345) +
-                String.fromCharCode(55357) +
-                String.fromCharCode(56833) +
-                String.fromCharCode(55357) +
-                String.fromCharCode(56960);
-            assert.equal(expected, cm.take_and_return_std_u32string(expected));
+            assert.equal(utf32TestString, cm.take_and_return_std_u32string(utf32TestString));
         });
 
         if (cm.isMemoryGrowthEnabled) {

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -479,7 +479,26 @@ module({
             assert.equal(expected, cm.get_non_ascii_wstring());
         });
 
-        test("passing unicode string into C++", function() {
+        test("non-ascii u16strings", function() {
+            var expected = String.fromCharCode(10) +
+                String.fromCharCode(1234) +
+                String.fromCharCode(2345) +
+                String.fromCharCode(65535);
+            assert.equal(expected, cm.get_non_ascii_u16string());
+        });
+
+        test("non-ascii u32strings", function() {
+            var expected = String.fromCharCode(10) +
+                String.fromCharCode(1234) +
+                String.fromCharCode(2345) +
+                String.fromCharCode(55357) +
+                String.fromCharCode(56833) +
+                String.fromCharCode(55357) +
+                String.fromCharCode(56960);
+            assert.equal(expected, cm.get_non_ascii_u32string());
+        });
+
+        test("passing unicode (wide) string into C++", function() {
             var expected = String.fromCharCode(10) +
                 String.fromCharCode(1234) +
                 String.fromCharCode(2345) +
@@ -487,10 +506,39 @@ module({
             assert.equal(expected, cm.take_and_return_std_wstring(expected));
         });
 
+        test("passing unicode (utf-16) string into C++", function() {
+            var expected = String.fromCharCode(10) +
+                String.fromCharCode(1234) +
+                String.fromCharCode(2345) +
+                String.fromCharCode(65535);
+            assert.equal(expected, cm.take_and_return_std_u16string(expected));
+        });
+
+        test("passing unicode (utf-32) string into C++", function() {
+            var expected = String.fromCharCode(10) +
+                String.fromCharCode(1234) +
+                String.fromCharCode(2345) +
+                String.fromCharCode(55357) +
+                String.fromCharCode(56833) +
+                String.fromCharCode(55357) +
+                String.fromCharCode(56960);
+            assert.equal(expected, cm.take_and_return_std_u32string(expected));
+        });
+
         if (cm.isMemoryGrowthEnabled) {
             test("can access a literal wstring after a memory growth", function() {
                 cm.force_memory_growth();
                 assert.equal("get_literal_wstring", cm.get_literal_wstring());
+            });
+            
+            test("can access a literal u16string after a memory growth", function() {
+                cm.force_memory_growth();
+                assert.equal("get_literal_u16string", cm.get_literal_u16string());
+            });
+            
+            test("can access a literal u32string after a memory growth", function() {
+                cm.force_memory_growth();
+                assert.equal("get_literal_u32string", cm.get_literal_u32string());
             });
         }
 

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -159,8 +159,35 @@ std::wstring get_non_ascii_wstring() {
     return ws;
 }
 
+std::u16string get_non_ascii_u16string() {
+    std::u16string u16s(4, 0);
+    u16s[0] = 10;
+    u16s[1] = 1234;
+    u16s[2] = 2345;
+    u16s[3] = 65535;
+    return u16s;
+}
+
+std::u32string get_non_ascii_u32string() {
+    std::u32string u32s(6, 0);
+    u32s[0] = 10;
+    u32s[1] = 1234;
+    u32s[2] = 2345;
+    u32s[4] = 128513;
+    u32s[5] = 128640;
+    return u32s;
+}
+
 std::wstring get_literal_wstring() {
     return L"get_literal_wstring";
+}
+
+std::u16string get_literal_u16string() {
+    return u"get_literal_u16string";
+}
+
+std::u32string get_literal_u32string() {
+    return U"get_literal_u32string";
 }
 
 void force_memory_growth() {
@@ -186,6 +213,14 @@ std::basic_string<unsigned char> emval_test_take_and_return_std_basic_string_uns
 }
 
 std::wstring take_and_return_std_wstring(std::wstring str) {
+    return str;
+}
+
+std::u16string take_and_return_std_u16string(std::u16string str) {
+    return str;
+}
+
+std::u32string take_and_return_std_u32string(std::u32string str) {
     return str;
 }
 
@@ -1763,6 +1798,12 @@ EMSCRIPTEN_BINDINGS(tests) {
     function("emval_test_take_and_return_std_string_const_ref", &emval_test_take_and_return_std_string_const_ref);
     function("emval_test_take_and_return_std_basic_string_unsigned_char", &emval_test_take_and_return_std_basic_string_unsigned_char);
     function("take_and_return_std_wstring", &take_and_return_std_wstring);
+    function("take_and_return_std_u16string", &take_and_return_std_u16string);
+    function("take_and_return_std_u32string", &take_and_return_std_u32string);
+    function("get_non_ascii_u16string", &get_non_ascii_u16string);
+    function("get_non_ascii_u32string", &get_non_ascii_u32string);
+    function("get_literal_u16string", &get_literal_u16string);
+    function("get_literal_u32string", &get_literal_u32string);
 
     //function("emval_test_take_and_return_CustomStruct", &emval_test_take_and_return_CustomStruct);
 

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -169,12 +169,12 @@ std::u16string get_non_ascii_u16string() {
 }
 
 std::u32string get_non_ascii_u32string() {
-    std::u32string u32s(6, 0);
+    std::u32string u32s(5, 0);
     u32s[0] = 10;
     u32s[1] = 1234;
     u32s[2] = 2345;
-    u32s[4] = 128513;
-    u32s[5] = 128640;
+    u32s[3] = 128513;
+    u32s[4] = 128640;
     return u32s;
 }
 


### PR DESCRIPTION
C++11 Added two new character types: `char16_t` and `char32_t`, which are defined  to contain utf-16 and utf-32 respectively, and the STL also added aliases for string types.

Embind was not supporting these types out of the box, only the strange implementation defined wide execution character `wchar_t` with it's string type, `std::wstring`.

This patch allows `std::u16string` and `std::u32string` to be bound using embind without additional boilerplate.