### PR TITLE
doc: Pointer_stringify() was removed

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -222,7 +222,7 @@ Integers and floating point values can be passed as is. Pointers are
 simply integers in the generated code.
 
 Strings in JavaScript must be converted to pointers for compiled
-code -- the relevant function is :js:func:`Pointer_stringify`, which
+code -- the relevant function is :js:func:`UTF8ToString`, which
 given a pointer returns a JavaScript string. Converting a JavaScript
 string ``someString`` to a pointer can be accomplished using ``ptr = ``
 allocate(intArrayFromString(someString), 'i8', ALLOC_NORMAL) <allocate>``.


### PR DESCRIPTION
I found a obsolete documentation that says `Pointer_stringify()` should be used. I updated it with `UTF8ToString()`

(I didn't add myself to `AUTHORS` since I only edited a small piece of documentation. If I need, please let me know)