### PR TITLE
Fail FS.lookupPath() with ENOENT when given path is empty

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -417,3 +417,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Zoltan Varga <vargaz@gmail.com> (copyright owned by Microsoft, Inc.)
 * Fernando Serboncini <fserb@google.com>
 * Christian Clauss <cclauss@me.com> (copyright owned by IBM)
+* Hayashida Ryuichi <lin90162@yahoo.co.jp>

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -68,7 +68,9 @@ mergeInto(LibraryManager.library, {
       path = PATH_FS.resolve(FS.cwd(), path);
       opts = opts || {};
 
-      if (!path) return { path: '', node: null };
+      if (!path) {
+        throw new FS.ErrnoError({{{ cDefine('ENOENT') }}});
+      }
 
       var defaults = {
         follow_mount: true,


### PR DESCRIPTION
Fixes #8937 

After some investigation, I found that `FS.lookupPath()` returned unexpected value as follows when given path is empty string `""`.

```javascript
{
  path: "",
  node: null
}
```

In this case, access(2) syscall fails because it does not assume returned `node` value is `null` and finally program crashes. This PR adds a check for `node` to avoid the issue.

For sure, I tried following C code and confirmed calling access(2) with empty string causes `ENOENT`.

```c
#include <unistd.h>
#include <errno.h>

int main()
{
    printf("%d\n", access("", 0755)); // -1
    printf("%d\n", errno); // 2
    return 0;
}
```