### PR TITLE
Stop doing MAIN_MODULE tests that measure the number of exports etc.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2829,7 +2829,24 @@ Var: 42
     self.set_setting('MAIN_MODULE')
     self.set_setting('EXPORT_ALL')
 
-    self.do_run_in_out_file_test('tests', 'core', 'test_dlfcn_self')
+    def post(filename):
+      js = open(filename).read()
+      start = js.find('var NAMED_GLOBALS')
+      first = js.find('{', start)
+      last = js.find('}', start)
+      exports = js[first + 1:last]
+      exports = exports.split(',')
+      # ensure there aren't too many globals; we don't want unnamed_addr
+      exports = [e.split(':')[0].strip('"') for e in exports]
+      exports.sort()
+      self.assertGreater(len(exports), 20)
+      # wasm backend includes alias in NAMED_GLOBALS
+      if self.is_wasm_backend():
+        self.assertLess(len(exports), 44)
+      else:
+        self.assertLess(len(exports), 30)
+
+    self.do_run_in_out_file_test('tests', 'core', 'test_dlfcn_self', post_build=post)
 
   @needs_dlfcn
   def test_dlfcn_unique_sig(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2829,24 +2829,7 @@ Var: 42
     self.set_setting('MAIN_MODULE')
     self.set_setting('EXPORT_ALL')
 
-    def post(filename):
-      js = open(filename).read()
-      start = js.find('var NAMED_GLOBALS')
-      first = js.find('{', start)
-      last = js.find('}', start)
-      exports = js[first + 1:last]
-      exports = exports.split(',')
-      # ensure there aren't too many globals; we don't want unnamed_addr
-      exports = [e.split(':')[0].strip('"') for e in exports]
-      exports.sort()
-      self.assertGreater(len(exports), 20)
-      # wasm backend includes alias in NAMED_GLOBALS
-      if self.is_wasm_backend():
-        self.assertLess(len(exports), 44)
-      else:
-        self.assertLess(len(exports), 30)
-
-    self.do_run_in_out_file_test('tests', 'core', 'test_dlfcn_self', post_build=post)
+    self.do_run_in_out_file_test('tests', 'core', 'test_dlfcn_self')
 
   @needs_dlfcn
   def test_dlfcn_unique_sig(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8027,12 +8027,6 @@ int main() {
     'export_nothing':
           (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                      0, [], [],          61,  0,   1,  1), # noqa
-    # we don't metadce with linkable code! other modules may want stuff
-    # don't compare the # of functions in a main module, which changes a lot
-    # TODO(sbc): Investivate why the number of exports is order of magnitude
-    # larger for wasm backend.
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1610, [], [], 517336, 172, 1507, None), # noqa
-    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10770,  17,   13, None), # noqa
   })
   @no_fastcomp()
   def test_binaryen_metadce_hello(self, *args):
@@ -8049,10 +8043,6 @@ int main() {
     'export_nothing':
            (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                       0, [],        [],           8,   0,    0,  0), # noqa; totally empty!
-    # we don't metadce with linkable code! other modules may want stuff
-    # don't compare the # of functions in a main module, which changes a lot
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1575, [], [], 226403, 30, 96, None), # noqa
-    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21), # noqa
   })
   @no_wasm_backend()
   def test_binaryen_metadce_hello_fastcomp(self, *args):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8027,6 +8027,9 @@ int main() {
     'export_nothing':
           (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                      0, [], [],          61,  0,   1,  1), # noqa
+    # we don't metadce with linkable code! other modules may want stuff
+    # don't compare the # of functions in a main module, which changes a lot
+    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10770,  17,   13, None), # noqa
   })
   @no_fastcomp()
   def test_binaryen_metadce_hello(self, *args):
@@ -8043,6 +8046,9 @@ int main() {
     'export_nothing':
            (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
                       0, [],        [],           8,   0,    0,  0), # noqa; totally empty!
+    # we don't metadce with linkable code! other modules may want stuff
+    # don't compare the # of functions in a main module, which changes a lot
+    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21), # noqa
   })
   @no_wasm_backend()
   def test_binaryen_metadce_hello_fastcomp(self, *args):


### PR DESCRIPTION
That number changes a lot in upstream, and we don't actually care that much about the size of all of our libc (which is what is linked in there). We do care a lot about normal program sizes, so those metadce tests are kept.

This should fix the current LLVM test breakage.

btw @sbc100 there is a TODO in that deleted code that you added, but I think it's obsolete - the number of exports is smaller  in the wasm backend, actually.