### PR TITLE
Initialize main thread ID after calling ctors

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1269,7 +1269,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         newargs += ['-pthread']
         # some pthreads code is in asm.js library functions, which are auto-exported; for the wasm backend, we must
         # manually export them
-        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_get_global_libc', '___pthread_tsd_run_dtors', '__register_pthread_ptr', '_pthread_self']
+        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_get_global_libc', '___pthread_tsd_run_dtors', '__register_pthread_ptr', '_pthread_self', '___emscripten_pthread_data_constructor']
 
       # set location of worker.js
       shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -19,6 +19,14 @@ var LibraryPThread = {
     runningWorkers: [],
     // Points to a pthread_t structure in the Emscripten main heap, allocated on demand if/when first needed.
     // mainThreadBlock: undefined,
+    initRuntime: function() {
+      // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
+      // Global constructors trying to access this value will read the wrong value, but that is UB anyway.
+      __register_pthread_ptr(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
+      _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);
+      // Initialize data on main pthread now that we have initialized the thread id
+      ___emscripten_pthread_data_constructor();
+    },
     initMainThreadBlock: function() {
       if (ENVIRONMENT_IS_PTHREAD) return undefined;
       PThread.mainThreadBlock = {{{ makeStaticAlloc(C_STRUCTS.pthread.__size__) }}};

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -511,10 +511,7 @@ function initRuntime() {
   {{{ getQuoted('ATINITS') }}}
   callRuntimeCallbacks(__ATINIT__);
 #if USE_PTHREADS
-  // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
-  // Global constructors trying to access this value will read the wrong value, but that is UB anyway.
-  __register_pthread_ptr(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
-  _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);
+  PThread.initRuntime();
 #endif
 }
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -508,13 +508,14 @@ function initRuntime() {
   assert(!runtimeInitialized);
 #endif
   runtimeInitialized = true;
+  {{{ getQuoted('ATINITS') }}}
+  callRuntimeCallbacks(__ATINIT__);
 #if USE_PTHREADS
   // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
+  // Global constructors trying to access this value will read the wrong value, but that is UB anyway.
   __register_pthread_ptr(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
   _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);
 #endif
-  {{{ getQuoted('ATINITS') }}}
-  callRuntimeCallbacks(__ATINIT__);
 }
 
 function preMain() {

--- a/system/lib/libc/musl/src/misc/emscripten_pthread.c
+++ b/system/lib/libc/musl/src/misc/emscripten_pthread.c
@@ -9,11 +9,14 @@ pthread_t pthread_self(void) {
 }
 #endif // !__EMSCRIPTEN_PTHREADS__
 
+#if __EMSCRIPTEN_PTHREADS__
 // Needs to be called after PThread.initRuntime, which in turn needs to be
 // called after constructors have run and memory is initialized.
-#if __EMSCRIPTEN_PTHREADS__
 EMSCRIPTEN_KEEPALIVE
+#else
+// Without threads, no reason not to just run this from C.
+__attribute__((constructor))
+#endif // __EMSCRIPTEN_PTHREADS__
 void __emscripten_pthread_data_constructor(void) {
     pthread_self()->locale = &libc.global_locale;
 }
-#endif // __EMSCRIPTEN_PTHREADS__

--- a/system/lib/libc/musl/src/misc/emscripten_pthread.c
+++ b/system/lib/libc/musl/src/misc/emscripten_pthread.c
@@ -9,7 +9,9 @@ pthread_t pthread_self(void) {
 }
 #endif
 
-__attribute__((constructor))
+// Needs to be called after PThread.initRuntime, which in turn needs to be
+// called after constructors have run and memory is initialized.
+EMSCRIPTEN_KEEPALIVE
 void __emscripten_pthread_data_constructor(void) {
     pthread_self()->locale = &libc.global_locale;
 }

--- a/system/lib/libc/musl/src/misc/emscripten_pthread.c
+++ b/system/lib/libc/musl/src/misc/emscripten_pthread.c
@@ -7,11 +7,13 @@ static struct pthread __main_pthread;
 pthread_t pthread_self(void) {
     return &__main_pthread;
 }
-#endif
+#endif // !__EMSCRIPTEN_PTHREADS__
 
 // Needs to be called after PThread.initRuntime, which in turn needs to be
 // called after constructors have run and memory is initialized.
+#if __EMSCRIPTEN_PTHREADS__
 EMSCRIPTEN_KEEPALIVE
 void __emscripten_pthread_data_constructor(void) {
     pthread_self()->locale = &libc.global_locale;
 }
+#endif // __EMSCRIPTEN_PTHREADS__

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4339,7 +4339,6 @@ window.close = function() {
     self.btest('asmfs/relative_paths.cpp', expected='0', args=['-s', 'ASMFS=1', '-s', 'WASM=0', '-s', 'USE_PTHREADS=1', '-s', 'FETCH_DEBUG=1'])
 
   @requires_threads
-  @no_wasm_backend('TODO - fix final pthreads tests (#8718)')
   def test_pthread_locale(self):
     for args in [
         [],


### PR DESCRIPTION
Experimentation with passive segments uncovered the fact that global
constructors were being run after the main thread id was
initialized. In the C code the main thread id is initialized to zero,
so when the BSS was being loaded into memory it was clobbering the
manually initialized value. This issue only surfaces with passive
segments because the BSS is otherwise optimized out by binaryen.