### PR TITLE
Update tutorial locations for new emsdk directory structure

### DIFF
--- a/site/source/docs/getting_started/Tutorial.rst
+++ b/site/source/docs/getting_started/Tutorial.rst
@@ -20,9 +20,9 @@ For the next section you will need to open a command prompt:
 - On Linux or macOS, open a *Terminal*.
 - On Windows open the :ref:`Emscripten Command Prompt <emcmdprompt>`, a command prompt that has been pre-configured with the correct system paths and settings to point to the :term:`active <Active Tool/SDK>` Emscripten tools. To access this prompt, type **Emscripten** in the Windows 8 start screen, and then select the **Emscripten Command Prompt** option.
 
-Navigate with the command prompt to the :term:`SDK root directory` for your target SDK. This is an SDK-version-specific folder below the :term:`emsdk root directory`, for example **<emsdk root directory>/emscripten/1.20.0/**.
+Navigate with the command prompt to the emscripten directory under the SDK. This is a folder below the :term:`emsdk root directory`, typically **<emsdk root directory>/fastcomp/emscripten/** (for the older "fastcomp" compiler; for the newer upstream LLVM wasm backend it will be **<emsdk root directory>/upstream/emscripten/**). The examples below will depend on finding files relative to that location.
 
-.. note:: The tests should be compiled from the "SDK Root" directory. This is required because some tests load files, and the locations of these files within Emscripten's virtual file system root is relative to the current directory at build time.
+.. note:: In older emscripten versions the directory structure was different: the version number appeared, and the backend (fastcomp/upstream) did not, so you would use something like **<emsdk root directory>/emscripten/1.20.0/**.
 
 
 Verifying Emscripten
@@ -131,7 +131,7 @@ For more information about working with the file system see the :ref:`file-syste
 Optimizing code
 ===============
 
-Emscripten, like *gcc* and *clang*, generates unoptimized code by default. You can generate :ref:`slightly-optimized <emcc-O1>` code with the ``-O1`` command line argument (run the test code from the :term:`SDK root directory`): ::
+Emscripten, like *gcc* and *clang*, generates unoptimized code by default. You can generate :ref:`slightly-optimized <emcc-O1>` code with the ``-O1`` command line argument: ::
 
     ./emcc -O1 tests/hello_world.cpp
 


### PR DESCRIPTION
We no longer have the version number in the path, and we do have fastcomp or upstream.

Fixes https://github.com/emscripten-core/emscripten/issues/8927