### PR TITLE
Support a symbols file in wasm2js. 

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2884,14 +2884,17 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
                                     opt_level=options.opt_level,
                                     minify_whitespace=optimizer.minify_whitespace,
                                     use_closure_compiler=options.use_closure_compiler,
-                                    debug_info=intermediate_debug_info)
+                                    debug_info=intermediate_debug_info,
+                                    symbols_file=target + '.symbols' if options.emit_symbol_map else None)
     save_intermediate('wasm2js')
 
     shared.try_delete(wasm_binary_target)
 
   # emit a symbol map if requested. this will also remove debug info if we only
-  # kept it around in the intermediate invocations for the sake of the symbol map
-  if options.emit_symbol_map:
+  # kept it around in the intermediate invocations for the sake of the symbol map.
+  # note that wasm2js handles the symbol map itself (as it manipulates and then
+  # replaces the wasm with js)
+  if options.emit_symbol_map and not shared.Settings.WASM2JS:
     shared.Building.emit_wasm_symbol_map(wasm_file=wasm_binary_target, symbols_file=target + '.symbols', debug_info=debug_info)
     save_intermediate_with_wasm('symbolmap', wasm_binary_target)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3882,8 +3882,6 @@ EM_ASM({ _middle() });
 ''')
         cmd = [PYTHON, EMCC, 'src.c', '--emit-symbol-map'] + opts
         if not wasm:
-          if self.is_wasm_backend():
-            continue
           cmd += ['-s', 'WASM=0']
         run_process(cmd)
         # check that the map is correct

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2629,11 +2629,13 @@ class Building(object):
     return Building.acorn_optimizer(js_file, passes, extra_info=json.dumps(extra_info))
 
   @staticmethod
-  def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compiler, debug_info):
+  def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compiler, debug_info, symbols_file=None):
     logger.debug('wasm2js')
     cmd = [os.path.join(Building.get_binaryen_bin(), 'wasm2js'), '--emscripten', wasm_file]
     if opt_level > 0:
       cmd += ['-O']
+    if symbols_file:
+      cmd += ['--symbols-file=%s' % symbols_file]
     cmd += Building.get_binaryen_feature_flags()
     wasm2js_js = run_process(cmd, stdout=PIPE).stdout
     if DEBUG:


### PR DESCRIPTION
Depends on the binaryen change to land first, https://github.com/WebAssembly/binaryen/pull/2214