### PR TITLE
[wasm backend] Fix SDL2 + pthreads

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3013,7 +3013,6 @@ Module['onRuntimeInitialized'] = function() {
     self.run_browser('page.html', '', '/report_result?1')
 
   @requires_threads
-  @no_wasm_backend('need sdl2 build with pthreads')
   def test_sdl2_threads(self):
       self.btest('sdl2_threads.c', expected='4', args=['-s', 'USE_PTHREADS=1', '-s', 'USE_SDL=2', '-s', 'PROXY_TO_PTHREAD=1'])
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -46,7 +46,10 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2', 'src', src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src), '-O2', '-o', o, '-I' + dest_include_path, '-O2', '-DUSING_GENERATED_CONFIG_H', '-w'])
+      command = [shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src), '-O2', '-o', o, '-I' + dest_include_path, '-O2', '-DUSING_GENERATED_CONFIG_H', '-w']
+      if settings.USE_PTHREADS:
+        command += ['-s', 'USE_PTHREADS']
+      commands.append(command)
       o_s.append(o)
     ports.run_commands(commands)
     final = os.path.join(ports.get_build_dir(), 'sdl2', libname)


### PR DESCRIPTION
We included the extra SDL2 files for threading, but we were not building any of them with pthreads enabled.

See https://github.com/emscripten-core/emscripten/issues/8503