### PR TITLE
Update test expectations after binaryen change

### DIFF
--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.sent
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.sent
@@ -1,4 +1,5 @@
 __memory_base
+__stack_pointer
 a
 b
 c
@@ -13,4 +14,3 @@ k
 l
 m
 n
-o


### PR DESCRIPTION
See https://github.com/WebAssembly/binaryen/pull/2219

This change won't pass CQ since it depends on recent llvm change [skip ci]
