### PR TITLE
Nicer errors for missing exceptions symbols that can happen due to -fno-exceptions

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1226,6 +1226,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
          exit_with_error('EMTERPRETIFY requires valid asm.js, and is incompatible with closure 2 which disables that')
       assert not use_source_map(options), 'EMTERPRETIFY is not compatible with source maps (maps are not useful in emterpreted code, and splitting out non-emterpreted source maps is not yet implemented)'
 
+    if shared.Settings.DISABLE_EXCEPTION_THROWING and not shared.Settings.DISABLE_EXCEPTION_CATCHING:
+      exit_with_error("DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0). If you don't want exceptions, set DISABLE_EXCEPTION_CATCHING to 1; if you do want exceptions, don't link with -fno-exceptions")
+
     if shared.Settings.DEAD_FUNCTIONS:
       if not options.js_opts:
         logger.debug('enabling js opts for DEAD_FUNCTIONS')

--- a/src/library_exceptions_stub.js
+++ b/src/library_exceptions_stub.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010 The Emscripten Authors.  All rights reserved.
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
  * Emscripten is available under two separate licenses, the MIT license and the
  * University of Illinois/NCSA Open Source License.  Both these licenses can be
  * found in the LICENSE file.

--- a/src/library_exceptions_stub.js
+++ b/src/library_exceptions_stub.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2010 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * C++ exception handling support stubs. This is included when exception
+ * throwing is disabled - so no exceptions should exist at all. If the code still
+ * uses them, these stubs will throw at runtime.
+ */
+
+var LibraryExceptions = {};
+
+[
+  '__cxa_allocate_exception',
+  '__cxa_free_exception',
+  '__cxa_increment_exception_refcount',
+  '__cxa_decrement_exception_refcount',
+  '__cxa_throw',
+  '__cxa_rethrow',
+  'llvm_eh_exception',
+  'llvm_eh_selector',
+  'llvm_eh_typeid_for',
+  '__cxa_begin_catch',
+  '__cxa_end_catch',
+  '__cxa_get_exception_ptr',
+  '_ZSt18uncaught_exceptionv',
+  '__cxa_call_unexpected',
+  '__cxa_current_primary_exception',
+  '__cxa_rethrow_primary_exception',
+  '__cxa_find_matching_catch',
+  '__resumeException',
+].forEach(function(name) {
+  LibraryExceptions[name] = function() { abort(); };
+  LibraryExceptions[name + '__deps'] = [function() {
+    error('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required by symbol ' + name + '. Either do not set DISABLE_EXCEPTION_THROWING (if you do want exception throwing) or compile all source files with -fno-except (so that no exceptions support code is required); also make sure DISABLE_EXCEPTION_CATCHING is set to the right value - if you want exceptions, it should be off, and vice versa.');
+  }];
+});
+
+mergeInto(LibraryManager.library, LibraryExceptions);

--- a/src/modules.js
+++ b/src/modules.js
@@ -70,6 +70,8 @@ var LibraryManager = {
 
     if (!DISABLE_EXCEPTION_THROWING) {
       libraries.push('library_exceptions.js');
+    } else {
+      libraries.push('library_exceptions_stub.js');
     }
 
     if (!MINIMAL_RUNTIME) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1388,6 +1388,11 @@ var SUPPORT_ERRNO = 1;
 // support library. This does not need to be set directly, but pass -fno-exceptions
 // to the build disable exceptions support. (This is basically -fno-exceptions, but
 // checked at final link time instead of individual .cpp file compile time)
+// If the program *does* contain throwing code (some source files were not compiled
+// with `-fno-exceptions`), and this flag is set at link time, then you will get
+// errors on undefined symbols, as the exception throwing code is not linked in. If
+// so you should either unset the option (if you do want exceptions) or fix the
+// compilation of the source files so that indeed no exceptions are used).
 var DISABLE_EXCEPTION_THROWING = 0;
 
 // Internal: An array of all symbols exported from asm.js/wasm module.

--- a/tests/other/exceptions_modes_symbols_defined.cpp
+++ b/tests/other/exceptions_modes_symbols_defined.cpp
@@ -1,0 +1,8 @@
+int main () {
+  try {
+    throw 42;
+  } catch (int e) {
+    return e;
+  }
+  return 0;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9450,7 +9450,9 @@ int main () {
         for opts in [0, 1]:
           cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_THROWING=%d' % (1-throwing), '-s', 'DISABLE_EXCEPTION_CATCHING=%d' % (1-catching), '-O%d' % opts]
           print(cmd)
-          if not throwing and catching:
+          if not throwing and not catching:
+            self.assertContained('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required', self.expect_fail(cmd))
+          elif not throwing and catching:
             self.assertContained('DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0)', self.expect_fail(cmd))
           else:
             run_process(cmd)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9443,3 +9443,14 @@ int main () {
     ''')
     run_process([PYTHON, EMCC, 'src.c', '-c'])
     self.expect_fail([PYTHON, EMCC, 'src.c', '-s', 'STRICT', '-c'])
+
+  def test_exceptions_modes_symbols_defined(self):
+    for catching in [0, 1]:
+      for throwing in [0, 1]:
+        for opts in [0, 1]:
+          cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_THROWING=%d' % (1-throwing), '-s', 'DISABLE_EXCEPTION_CATCHING=%d' % (1-catching), '-O%d' % opts]
+          print(cmd)
+          if not throwing and catching:
+            self.assertContained('DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0)', self.expect_fail(cmd))
+          else:
+            run_process(cmd)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9444,15 +9444,13 @@ int main () {
     run_process([PYTHON, EMCC, 'src.c', '-c'])
     self.expect_fail([PYTHON, EMCC, 'src.c', '-s', 'STRICT', '-c'])
 
-  def test_exceptions_modes_symbols_defined(self):
-    for catching in [0, 1]:
-      for throwing in [0, 1]:
-        for opts in [0, 1]:
-          cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_THROWING=%d' % (1 - throwing), '-s', 'DISABLE_EXCEPTION_CATCHING=%d' % (1 - catching), '-O%d' % opts]
-          print(cmd)
-          if not throwing and not catching:
-            self.assertContained('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required', self.expect_fail(cmd))
-          elif not throwing and catching:
-            self.assertContained('DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0)', self.expect_fail(cmd))
-          else:
-            run_process(cmd)
+  def test_exception_settings(self):
+    for catching, throwing, opts in itertools.product([0, 1], repeat=3):
+      cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_THROWING=%d' % (1 - throwing), '-s', 'DISABLE_EXCEPTION_CATCHING=%d' % (1 - catching), '-O%d' % opts]
+      print(cmd)
+      if not throwing and not catching:
+        self.assertContained('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required', self.expect_fail(cmd))
+      elif not throwing and catching:
+        self.assertContained('DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0)', self.expect_fail(cmd))
+      else:
+        run_process(cmd)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9448,7 +9448,7 @@ int main () {
     for catching in [0, 1]:
       for throwing in [0, 1]:
         for opts in [0, 1]:
-          cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_THROWING=%d' % (1-throwing), '-s', 'DISABLE_EXCEPTION_CATCHING=%d' % (1-catching), '-O%d' % opts]
+          cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_THROWING=%d' % (1 - throwing), '-s', 'DISABLE_EXCEPTION_CATCHING=%d' % (1 - catching), '-O%d' % opts]
           print(cmd)
           if not throwing and not catching:
             self.assertContained('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required', self.expect_fail(cmd))


### PR DESCRIPTION
With that flag at link time we don't link in any symbols for throwing, but if source files have that symbol, that will lead to undefined symbol errors. Instead, show a nice error explaining the situation and what to do.

Also, `-fno-exceptions -s DISABLE_EXCEPTION_CATCHING=0` is wrong as well: if throwing is not allowed, then it is meaningless to enable exceptions. Also show a nicer error for this case.

possibly helps with #8963 