### PR TITLE
Update changelog for 1.38.38

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,9 @@ See docs/process.md for how version tagging works.
 Current Trunk
 -------------
 
+v1.38.38: 07/08/2019
+--------------------
+
  - Add support for standalone [leak sanitizer](https://clang.llvm.org/docs/LeakSanitizer.html). (#8711)
 
 v1.38.37: 06/26/2019


### PR DESCRIPTION
5d4d0d0ed29f17da869530e102f65b4ec5ec6c27 did not update `ChangeLog.md`.