### PR TITLE
Use headless Chrome in browser testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -401,12 +401,77 @@ workflows:
 
   build-test:
     jobs:
+      - flake8
+      - build-docs
       - build
+      - test-other:
+          requires:
+            - build
+      - test-browser-firefox:
+          requires:
+            - build
       - test-browser-chrome:
           requires:
             - build
+      - test-ab:
+          requires:
+            - build
+      - test-c:
+          requires:
+            - build
+      - test-d:
+          requires:
+            - build
+      - test-e:
+          requires:
+            - build
+      - test-f:
+          requires:
+            - build
+      - test-ghi:
+          requires:
+            - build
+      - test-jklmno:
+          requires:
+            - build
+      - test-p:
+          requires:
+            - build
+      - test-qrst:
+          requires:
+            - build
+      - test-uvwxyz:
+          requires:
+            - build
+      - test-wasm0:
+          requires:
+            - build
+      - test-wasm1:
+          requires:
+            - build
+      - test-wasm2:
+          requires:
+            - build
+      - test-wasm3:
+          requires:
+            - build
+      - test-sanity:
+          requires:
+            - build
       - build-upstream
+      - test-upstream-wasm0:
+          requires:
+            - build-upstream
+      - test-upstream-wasm2:
+          requires:
+            - build-upstream
+      - test-upstream-other:
+          requires:
+            - build-upstream
       - test-upstream-browser-chrome:
+          requires:
+            - build-upstream
+      - test-upstream-browser-firefox:
           requires:
             - build-upstream
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,9 +166,10 @@ test-chrome: &test-chrome
         command: |
           # --no-sandbox becasue we are running as root and chrome requires
           # this flag for now: https://crbug.com/638180
-          CHROME_FLAGS_BASE="--no-first-run -start-maximized --no-sandbox --use-gl=swiftshader"
+          CHROME_FLAGS_BASE="--no-first-run -start-maximized --no-sandbox --use-gl=swiftshader --user-data-dir=/tmp/chrome-emscripten-profile"
+          CHROME_FLAGS_HEADLESS="--headless --remote-debugging-port=1234"
           CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer --no-wasm-disable-structured-cloning\""
-          export EMTEST_BROWSER="xvfb-run -a -e /dev/stdout /usr/bin/google-chrome-stable $CHROME_FLAGS_BASE $CHROME_FLAGS_WASM"
+          export EMTEST_BROWSER="/usr/bin/google-chrome-stable $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM"
           export EMTEST_LACKS_GRAPHICS_HARDWARE=1
           export EMCC_CORES=4
           ./emscripten/tests/runner.py browser
@@ -400,77 +401,12 @@ workflows:
 
   build-test:
     jobs:
-      - flake8
-      - build-docs
       - build
-      - test-other:
-          requires:
-            - build
-      - test-browser-firefox:
-          requires:
-            - build
       - test-browser-chrome:
           requires:
             - build
-      - test-ab:
-          requires:
-            - build
-      - test-c:
-          requires:
-            - build
-      - test-d:
-          requires:
-            - build
-      - test-e:
-          requires:
-            - build
-      - test-f:
-          requires:
-            - build
-      - test-ghi:
-          requires:
-            - build
-      - test-jklmno:
-          requires:
-            - build
-      - test-p:
-          requires:
-            - build
-      - test-qrst:
-          requires:
-            - build
-      - test-uvwxyz:
-          requires:
-            - build
-      - test-wasm0:
-          requires:
-            - build
-      - test-wasm1:
-          requires:
-            - build
-      - test-wasm2:
-          requires:
-            - build
-      - test-wasm3:
-          requires:
-            - build
-      - test-sanity:
-          requires:
-            - build
       - build-upstream
-      - test-upstream-wasm0:
-          requires:
-            - build-upstream
-      - test-upstream-wasm2:
-          requires:
-            - build-upstream
-      - test-upstream-other:
-          requires:
-            - build-upstream
       - test-upstream-browser-chrome:
-          requires:
-            - build-upstream
-      - test-upstream-browser-firefox:
           requires:
             - build-upstream
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1343,7 +1343,7 @@ keydown(100);keyup(100); // trigger the end
   def test_fs_memfs_fsync(self):
     args = self.get_async_args() + ['-s', 'EXIT_RUNTIME=1']
     secret = str(time.time())
-    self.btest(path_from_root('tests', 'fs', 'test_memfs_fsync.c'), '1', force_c=True, args=args + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main']'''])
+    self.btest(path_from_root('tests', 'fs', 'test_memfs_fsync.c'), '1waka', force_c=True, args=args + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main']'''])
 
   def test_fs_workerfs_read(self):
     secret = 'a' * 10

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1343,7 +1343,7 @@ keydown(100);keyup(100); // trigger the end
   def test_fs_memfs_fsync(self):
     args = self.get_async_args() + ['-s', 'EXIT_RUNTIME=1']
     secret = str(time.time())
-    self.btest(path_from_root('tests', 'fs', 'test_memfs_fsync.c'), '1waka', force_c=True, args=args + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main']'''])
+    self.btest(path_from_root('tests', 'fs', 'test_memfs_fsync.c'), '1', force_c=True, args=args + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main']'''])
 
   def test_fs_workerfs_read(self):
     secret = 'a' * 10

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2480,7 +2480,7 @@ void *getBindBuffer() {
           args_base += ['--browser_args', ' ' + ' '.join(browser_args)]
     for args in [
         args_base,
-        args_base + ['--no_private_browsing']
+        args_base + ['--no_private_browsing', '--port', '6941']
     ]:
       args += [os.path.join(outdir, 'hello_world.html'), '1', '2', '--3']
       proc = run_process(args, check=False)


### PR DESCRIPTION
Instead of `xvfb-run`.

This is simpler, and I *hope* it fixes some of the big problems we've had with all tests failing and so forth. Some of that seems to have been tied to `xvfb` - maybe we were using it wrong, but aside from tests failing I've seen logs with tests running more than once, as if multiple browsers were running at the same time. Headless mode on the other hand seems much more stable, both locally and I did several runs on CI here.

One odd thing with headless mode is that the emrun test fails. Emrun loads another instance of chrome (separately from the test suite, that's what it does), and somehow in headless mode that instance stays around for a while longer. Instead of adding a `sleep` to try to work around that, I just made the second emrun invocation use another port (which also adds testing for the `--port` flag ;) )