### PR TITLE
Disable cache in chrome on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,8 @@ test-chrome: &test-chrome
           CHROME_FLAGS_BASE="--no-first-run -start-maximized --no-sandbox --use-gl=swiftshader --user-data-dir=/tmp/chrome-emscripten-profile"
           CHROME_FLAGS_HEADLESS="--headless --remote-debugging-port=1234"
           CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer --no-wasm-disable-structured-cloning\""
-          export EMTEST_BROWSER="/usr/bin/google-chrome-stable $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM"
+          CHROME_FLAGS_NOCACHE="--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
+          export EMTEST_BROWSER="/usr/bin/google-chrome-stable $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE"
           export EMTEST_LACKS_GRAPHICS_HARDWARE=1
           export EMCC_CORES=4
           ./emscripten/tests/runner.py browser


### PR DESCRIPTION
Recently we've gotten errors where one test loads a JS+wasm combo that contains either the JS or the wasm from the last test (!), manifesting as "import is not a function" as the imports provided by JS don't match the mismatched wasm. Oddly this happened on `sdl_pumpevents` multiple times on CI.

As this is only on Chrome, my guess is that it's a caching issue, but I can't reproduce it locally to verify. Disabling the cache seems to help, at least the run here was fully successful.