### PR TITLE
Fix Firefox on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,10 @@ test-firefox: &test-firefox
     - run:
         name: download firefox
         command: |
-          FF_VERSION=65.0.2
-          wget https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FF_VERSION/linux-x86_64/en-US/firefox-$FF_VERSION.tar.bz2
-          tar xf firefox-$FF_VERSION.tar.bz2
-          # wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
-          # tar xf nightly.tar.bz2
+          # we should pin a version here, but llvm upstream now emits bulk memory for pthreads
+          # which requires very latest nightly as of Jul 13 2019
+          wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+          tar xf nightly.tar.bz2
     - run:
         name: configure firefox
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ test-firefox: &test-firefox
           export EMTEST_BROWSER="$HOME/firefox/firefox -profile tmp-firefox-profile/"
           export GALLIUM_DRIVER=softpipe # TODO: use the default llvmpipe when it supports more extensions
           export EMTEST_LACKS_SOUND_HARDWARE=1
+          export EMTEST_LACKS_OFFSCREEN_CANVAS=1 # looks broken in ff nightly
           export EMTEST_DETECT_TEMPFILE_LEAKS=0
           export DISPLAY=:0
           # Start an X session. Openbox might be optional for now, but

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -325,7 +325,8 @@ function __emscripten_fetch_xhr(fetch, onsuccess, onerror, onprogress, onreadyst
   xhr.open(requestMethod, url_, !fetchAttrSynchronous, userNameStr, passwordStr);
   if (!fetchAttrSynchronous) xhr.timeout = timeoutMsecs; // XHR timeout field is only accessible in async XHRs, and must be set after .open() but before .send().
   xhr.url_ = url_; // Save the url for debugging purposes (and for comparing to the responseURL that server side advertised)
-  xhr.responseType = fetchAttrStreamData ? 'moz-chunked-arraybuffer' : 'arraybuffer';
+  assert(!fetchAttrStreamData, 'streaming uses moz-chunked-arraybuffer which is no longer supported; TODO: rewrite using fetch()');
+  xhr.responseType = 'arraybuffer';
 
   if (overriddenMimeType) {
 #if FETCH_DEBUG


### PR DESCRIPTION
A newer version is needed anyhow because LLVM now emits bulk memory with pthreads, and firefox stable doesn't have that.

This upgrade requires two fixes:
 * `moz-chunked-arraybuffer` has been removed; show an error in the feature, add a TODO, and disable the test.
 * OffscreenCanvas seems partially done - previously the tests skipped because it didn't work at all, but now they try to run and firefox crashes, so it looks like it's still a wip there.
