### PR TITLE
React Native needs to be treated like a node environment

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -78,6 +78,13 @@ ENVIRONMENT_IS_NODE = ENVIRONMENT_HAS_NODE && !ENVIRONMENT_IS_WEB && !ENVIRONMEN
 ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
 #endif // ENVIRONMENT
 
+/* React native should be treated like a node environment */
+if (typeof navigator !== 'undefined' && typeof navigator.product === 'string' && navigator.product.toLowerCase() === 'reactnative') {
+  ENVIRONMENT_IS_NODE = true;
+  ENVIRONMENT_IS_WEB = false;
+  ENVIRONMENT_IS_WORKER = false;
+}
+
 #if ASSERTIONS
 if (Module['ENVIRONMENT']) {
   throw new Error('Module.ENVIRONMENT has been deprecated. To force the environment, use the ENVIRONMENT compile-time option (for example, -s ENVIRONMENT=web or -s ENVIRONMENT=node)');


### PR DESCRIPTION
We consistently see issues whereby React Native is not detected properly and thus generated JS does not load. React Native needs to be treated as if it is Node for modules to initialize correctly.

