### PR TITLE
Fix cache testing on CI, and fix a regression from #8973

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -345,6 +345,9 @@ jobs:
             cd -
             echo "final .emscripten:"
             cat ~/.emscripten
+            # Remove any system libs the emsdk installed: we want to rebuild
+            # them all from source here, to check whether new changes work.
+            rm -Rf ~/.emscripten_cache
       - run:
           name: embuilder build ALL
           command: |

--- a/system/lib/libc/musl/src/misc/emscripten_pthread.c
+++ b/system/lib/libc/musl/src/misc/emscripten_pthread.c
@@ -5,10 +5,12 @@
 #if !__EMSCRIPTEN_PTHREADS__
 static struct pthread __main_pthread;
 pthread_t pthread_self(void) {
-  // Ensure the locale is set up here, avoid a global ctor as done below for
-  // the pthreads case.
-  __main_pthread.locale = &libc.global_locale;
   return &__main_pthread;
+}
+
+__attribute__((constructor))
+void __emscripten_pthread_data_constructor(void) {
+  pthread_self()->locale = &libc.global_locale;
 }
 #endif // !__EMSCRIPTEN_PTHREADS__
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8004,13 +8004,13 @@ int main() {
   @no_fastcomp()
   def test_binaryen_metadce_cxx(self):
     # test on libc++: see effects of emulated function pointers
-    self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  32, 560) # noqa
+    self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  32, 559) # noqa
 
   @parameterized({
-    'normal': (['-O2'], 32, ['abort'], ['waka'], 186423,  29,  38, 540), # noqa
+    'normal': (['-O2'], 32, ['abort'], ['waka'], 186423,  29,  38, 539), # noqa
     'emulated_function_pointers':
               (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                        32, ['abort'], ['waka'], 186423,  29,  39, 520), # noqa
+                        32, ['abort'], ['waka'], 186423,  29,  39, 519), # noqa
   })
   @no_wasm_backend()
   def test_binaryen_metadce_cxx_fastcomp(self, *args):
@@ -8032,7 +8032,7 @@ int main() {
     # don't compare the # of functions in a main module, which changes a lot
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1611, [], [], 517336, 173, 1504, None), # noqa
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1611, [], [], 517336, 173, 1505, None), # noqa
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   16, [], [],  10770,  18,   13, None), # noqa
   })
   @no_fastcomp()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8004,13 +8004,13 @@ int main() {
   @no_fastcomp()
   def test_binaryen_metadce_cxx(self):
     # test on libc++: see effects of emulated function pointers
-    self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  32, 559) # noqa
+    self.run_metadce_test('hello_libcxx.cpp', ['-O2'], 33, [], ['waka'], 226582,  21,  32, 560) # noqa
 
   @parameterized({
-    'normal': (['-O2'], 32, ['abort'], ['waka'], 186423,  29,  38, 539), # noqa
-    'enumated_function_pointers':
+    'normal': (['-O2'], 32, ['abort'], ['waka'], 186423,  29,  38, 540), # noqa
+    'emulated_function_pointers':
               (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-                        32, ['abort'], ['waka'], 186423,  29,  39, 519), # noqa
+                        32, ['abort'], ['waka'], 186423,  29,  39, 520), # noqa
   })
   @no_wasm_backend()
   def test_binaryen_metadce_cxx_fastcomp(self, *args):
@@ -8032,7 +8032,7 @@ int main() {
     # don't compare the # of functions in a main module, which changes a lot
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1611, [], [], 517336, 173, 1505, None), # noqa
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1611, [], [], 517336, 173, 1504, None), # noqa
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   16, [], [],  10770,  18,   13, None), # noqa
   })
   @no_fastcomp()


### PR DESCRIPTION
The emsdk ships libc and a few other libs, and we used those, instead of building libc here - so we missed a regression that was only caught later on releases CI. I'm surprised we didn't hit more problems earlier, actually...

The regression was that we added a constructor priority in pthreads, and apparently that keeps it not just alive but separate from other ctors, which adds an extra function to the number. I refactored that code to make it clear what we do in the pthreads and non-pthreads cases, and made us only use the priority when using pthreads.