### PR TITLE
Implement dynamic linking support for ASan/LSan

### DIFF
--- a/system/lib/compiler-rt/lib/asan/asan_emscripten.cc
+++ b/system/lib/compiler-rt/lib/asan/asan_emscripten.cc
@@ -6,9 +6,19 @@
 #include <emscripten.h>
 #include <cstddef>
 
+#if __PIC__
+uptr __real_memory_start;
+#endif // __PIC__
+
 namespace __asan {
 
 void InitializeShadowMemory() {
+#if __PIC__
+  __real_memory_start = EM_ASM_INT({
+    return GLOBAL_BASE;
+  });
+#endif // __PIC__
+
   // Poison the shadow memory of the shadow area at the start of the address
   // space. This helps catching null pointer dereference.
   FastPoisonShadow(kLowShadowBeg, kLowShadowEnd - kLowShadowBeg, 0xff);

--- a/system/lib/compiler-rt/lib/asan/asan_mapping_emscripten.h
+++ b/system/lib/compiler-rt/lib/asan/asan_mapping_emscripten.h
@@ -14,13 +14,20 @@
 #ifndef ASAN_MAPPING_EMSCRIPTEN_H
 #define ASAN_MAPPING_EMSCRIPTEN_H
 
+#if __PIC__
+extern uptr __real_memory_start;
+#define REAL_MEMORY_START __real_memory_start
+#else
 extern char __global_base;
+#define REAL_MEMORY_START ((uptr) &__global_base)
+#endif // __PIC__
 
-#define kLowMemBeg     ((uptr) &__global_base)
+
+#define kLowMemBeg     REAL_MEMORY_START
 #define kLowMemEnd     ((kLowShadowBeg << SHADOW_SCALE) - 1)
 
 #define kLowShadowBeg  0
-#define kLowShadowEnd  ((uptr) &__global_base - 1)
+#define kLowShadowEnd  (REAL_MEMORY_START - 1)
 
 #define kHighMemBeg    0
 

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cc
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cc
@@ -20,6 +20,7 @@
 #include <signal.h>
 
 #if SANITIZER_EMSCRIPTEN
+#include <emscripten/em_asm.h>
 
 namespace __sanitizer {
 
@@ -85,21 +86,10 @@ uptr internal_munmap(void *addr, uptr length) {
   return emscripten_builtin_munmap(addr, length);
 }
 
-extern "C" {
-  extern char __data_end;
-  extern char __heap_base;
-}
-
-inline uptr get_stack_bottom() {
-  // Align to 8 byte
-  return ((uptr) &__data_end + 7) & ~7;
-}
-
-
 void GetThreadStackTopAndBottom(bool at_initialization, uptr *stack_top,
                                 uptr *stack_bottom) {
-  *stack_top = (uptr) &__heap_base;
-  *stack_bottom = get_stack_bottom();
+  *stack_top = EM_ASM_INT({ return STACK_BASE; });
+  *stack_bottom = EM_ASM_INT({ return STACK_MAX; });
 }
 
 char *fake_argv[] = {0};
@@ -123,8 +113,9 @@ void GetThreadStackAndTls(bool main, uptr *stk_addr, uptr *stk_size,
                           uptr *tls_addr, uptr *tls_size) {
   *stk_addr = *stk_size = *tls_addr = *tls_size = 0;
   if (main) {
-    *stk_addr = get_stack_bottom();
-    *stk_size = (uptr) &__heap_base - get_stack_bottom();
+    uptr stk_top;
+    GetThreadStackTopAndBottom(true, &stk_top, stk_addr);
+    *stk_size = stk_top - *stk_addr;
   }
 }
 


### PR DESCRIPTION
Implement replacements for `__data_end`, `__heap_base` for when compiling ASan in PIC mode.

Things to do before this support is complete:

* [ ] LSan needs to scan global variables of shared libraries. This involves enumerating all libraries at runtime, and finding their data sections.
* [ ] PC value assignment for shared libraries. This will allow us to identify call sites in dynamic libraries.
* [ ] Source map support for dynamic libraries.