### PR TITLE
Fix wasm backend and asyncify [ci skip]

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -765,7 +765,7 @@ mergeInto(LibraryManager.library, {
 if (EMTERPRETIFY_ASYNC && !EMTERPRETIFY) {
   error('You must enable EMTERPRETIFY to use EMTERPRETIFY_ASYNC');
 }
-if (ASYNCIFY) {
+if (WASM_BACKEND && ASYNCIFY) {
   DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$Asyncify');
 }
 


### PR DESCRIPTION
Sadly the last PR had a small error for fastcomp + asyncify, so we can't land the bysyncify=>asyncify double roll without this.