### PR TITLE
Asyncify: fix abort() handling

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4766,6 +4766,16 @@ LibraryManager.library = {
     err('TODO: Unwind_DeleteException');
   },
 
+  // error handling
+
+  $runAndAbortIfError: function(func) {
+    try {
+      return func();
+    } catch (e) {
+      abort(e);
+    }
+  },
+
   // autodebugging
 
   emscripten_autodebug_i64: function(line, valuel, valueh) {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -547,7 +547,7 @@ mergeInto(LibraryManager.library, {
 #else // EMTERPRETIFY_ASYNC
 
 #if BYSYNCIFY
-  $Bysyncify__deps: ['$Browser'],
+  $Bysyncify__deps: ['$Browser', '$runAndAbortIfError'],
   $Bysyncify: {
     State: {
       Normal: 0,
@@ -596,7 +596,7 @@ mergeInto(LibraryManager.library, {
                   err('BYSYNCIFY: stop unwind');
 #endif
                   Bysyncify.state = Bysyncify.State.Normal;
-                  Module['_bysyncify_stop_unwind']();
+                  runAndAbortIfError(Module['_bysyncify_stop_unwind']);
                 }
               }
             };
@@ -654,7 +654,7 @@ mergeInto(LibraryManager.library, {
           err('BYSYNCIFY: start rewind ' + Bysyncify.currData);
 #endif
           Bysyncify.state = Bysyncify.State.Rewinding;
-          Module['_bysyncify_start_rewind'](Bysyncify.currData);
+          runAndAbortIfError(function() { Module['_bysyncify_start_rewind'](Bysyncify.currData) });
           if (Browser.mainLoop.func) {
             Browser.mainLoop.resume();
           }
@@ -672,7 +672,7 @@ mergeInto(LibraryManager.library, {
 #if BYSYNCIFY_DEBUG
           err('BYSYNCIFY: start unwind ' + Bysyncify.currData);
 #endif
-          Module['_bysyncify_start_unwind'](Bysyncify.currData);
+          runAndAbortIfError(function() { Module['_bysyncify_start_unwind'](Bysyncify.currData) });
           if (Browser.mainLoop.func) {
             Browser.mainLoop.pause();
           }
@@ -683,7 +683,7 @@ mergeInto(LibraryManager.library, {
         err('BYSYNCIFY: stop rewind');
 #endif
         Bysyncify.state = Bysyncify.State.Normal;
-        Module['_bysyncify_stop_rewind']();
+        runAndAbortIfError(Module['_bysyncify_stop_rewind']);
         Bysyncify.freeData(Bysyncify.currData);
         Bysyncify.currData = null;
       } else {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -654,7 +654,7 @@ mergeInto(LibraryManager.library, {
           err('ASYNCIFY: start rewind ' + Asyncify.currData);
 #endif
           Asyncify.state = Asyncify.State.Rewinding;
-          runAndAbortIfError(function() { Module['_asyncify_start_rewind'](Bysyncify.currData) });
+          runAndAbortIfError(function() { Module['_asyncify_start_rewind'](Asyncify.currData) });
           if (Browser.mainLoop.func) {
             Browser.mainLoop.resume();
           }
@@ -672,7 +672,7 @@ mergeInto(LibraryManager.library, {
 #if ASYNCIFY_DEBUG
           err('ASYNCIFY: start unwind ' + Asyncify.currData);
 #endif
-          runAndAbortIfError(function() { Module['_asyncify_start_unwind'](Bysyncify.currData) });
+          runAndAbortIfError(function() { Module['_asyncify_start_unwind'](Asyncify.currData) });
           if (Browser.mainLoop.func) {
             Browser.mainLoop.pause();
           }

--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE.sent
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE.sent
@@ -1543,6 +1543,7 @@ rintf
 rotozoomSurface
 round
 roundf
+runAndAbortIfError
 saveSetjmp
 sbrk
 sched_yield

--- a/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE.sent
+++ b/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE.sent
@@ -1570,6 +1570,7 @@ invoke_iiiiii
 invoke_v
 invoke_vi
 invoke_vii
+runAndAbortIfError
 setTempRet0
 stringToNewUTF8
 tempDoublePtr

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8032,7 +8032,7 @@ int main() {
     # don't compare the # of functions in a main module, which changes a lot
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1611, [], [], 517336, 173, 1505, None), # noqa
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1612, [], [], 517336, 173, 1505, None), # noqa
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   16, [], [],  10770,  18,   13, None), # noqa
   })
   @no_fastcomp()
@@ -8052,7 +8052,7 @@ int main() {
                       0, [],        [],           8,   0,    0,  0), # noqa; totally empty!
     # we don't metadce with linkable code! other modules may want stuff
     # don't compare the # of functions in a main module, which changes a lot
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1575, [], [], 226403, 30, 96, None), # noqa
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1576, [], [], 226403, 30, 96, None), # noqa
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   15, [], [],  10571, 19,  9,   21), # noqa
   })
   @no_wasm_backend()


### PR DESCRIPTION
Asyncify wasm error handling leads to `unreachable`s being thrown. This PR maps those errors into calls to `abort()`, which ensures the runtime is properly shut down if they occur. In particular, no more code will be run, which could previously be confusing while debugging.