### PR TITLE
Use beta versions of browsers on CI; enable pthreads tests again on chrome

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ test-chrome: &test-chrome
           CHROME_FLAGS_HEADLESS="--headless --remote-debugging-port=1234"
           CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer --no-wasm-disable-structured-cloning\""
           CHROME_FLAGS_NOCACHE="--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
-          export EMTEST_BROWSER="/usr/bin/google-chrome-stable $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE"
+          export EMTEST_BROWSER="/usr/bin/google-chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE"
           export EMTEST_LACKS_GRAPHICS_HARDWARE=1
           export EMCC_CORES=4
           ./emscripten/tests/runner.py browser

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,8 +49,8 @@ test-firefox: &test-firefox
         command: |
           # we should pin a version here, but llvm upstream now emits bulk memory for pthreads
           # which requires very latest nightly as of Jul 13 2019
-          wget -O nightly.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
-          tar xf nightly.tar.bz2
+          wget -O ff.tar.bz2 "https://download.mozilla.org/?product=firefox-beta-latest-ssl&os=linux64&lang=en-US"
+          tar xf ff.tar.bz2
     - run:
         name: configure firefox
         command: |
@@ -159,7 +159,7 @@ test-chrome: &test-chrome
     - run:
         name: download chrome
         command: |
-          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
           dpkg -i google-chrome-stable_current_amd64.deb
     - run:
         name: run tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,8 +159,8 @@ test-chrome: &test-chrome
     - run:
         name: download chrome
         command: |
-          wget https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
-          dpkg -i google-chrome-stable_current_amd64.deb
+          wget -O chrome.deb https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
+          dpkg -i chrome.deb
     - run:
         name: run tests
         command: |

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -110,8 +110,6 @@ def requires_threads(f):
   def decorated(self):
     if os.environ.get('EMTEST_LACKS_THREAD_SUPPORT'):
       self.skipTest('EMTEST_LACKS_THREAD_SUPPORT is set')
-    if is_chrome():
-      self.skipTest('Chrome leaks pthreads memory, https://bugs.chromium.org/p/v8/issues/detail?id=9075')
     return f(self)
 
   return decorated


### PR DESCRIPTION
Due to https://bugs.chromium.org/p/v8/issues/detail?id=9075 we disabled pthreads tests on chrome. The fix has reached beta now, so after upgrading to beta we can re-enable those tests.

I upgraded firefox to nightly recently, but @tlively mentioned that beta was new enough (for passive segments stuff), and looks like everything else works there too, so downgrading to beta (to avoid noise from nightly which might be unstable).

Overall beta seems like a reasonable compromise between new features and stability.