### PR TITLE
Fix one flakiness issue in browser.test_chunked_synchronous_xhr

### DIFF
--- a/tests/checksummer.c
+++ b/tests/checksummer.c
@@ -31,8 +31,8 @@ int main(int argc, char* argv[]) {
     long bufsize;
 
     if (argc != 2) {
-	fputs("Need 1 argument\n", stderr);
-	return (EXIT_FAILURE);
+        fputs("Need 1 argument\n", stderr);
+        return (EXIT_FAILURE);
     }
 
     unsigned char *source = NULL;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1687,8 +1687,10 @@ keydown(100);keyup(100); // trigger the end
 
     server = multiprocessing.Process(target=test_chunked_synchronous_xhr_server, args=(True, chunkSize, data, checksum, self.port))
     server.start()
-    self.run_browser(main, 'Chunked binary synchronous XHR in Web Workers!', '/report_result?' + str(checksum))
-    server.terminate()
+    try:
+      self.run_browser(main, 'Chunked binary synchronous XHR in Web Workers!', '/report_result?' + str(checksum))
+    finally:
+      server.terminate()
     # Avoid race condition on cleanup, wait a bit so that processes have released file locks so that test tearDown won't
     # attempt to rmdir() files in use.
     if WINDOWS:


### PR DESCRIPTION
The test is marked `@flaky` which runs it up to 3 times to try to avoid a random error. But we never shut down the server, so the second and later runs would just hit an error on trying to create a server on the same port. (Of course not shutting down the server was bad for other reasons too!)

Hopefully this will decrease dramatically the number of random failures on this test, but it won't eliminate them entirely.