### PR TITLE
Print strings from abort().

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -406,9 +406,9 @@ function abort(what) {
   if (ENVIRONMENT_IS_PTHREAD) console.error('Pthread aborting at ' + new Error().stack);
 #endif
   if (what !== undefined) {
+    what += '';
     out(what);
     err(what);
-    what = '"' + what + '"';
   } else {
     what = '';
   }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2250,7 +2250,7 @@ The current type of b is: 9
   def test_intentional_fault(self):
     # Some programs intentionally segfault themselves, we should compile that into a throw
     src = open(path_from_root('tests', 'core', 'test_intentional_fault.c')).read()
-    self.do_run(src, 'abort()' if self.run_name != 'asm2g' else 'abort("segmentation fault')
+    self.do_run(src, 'abort()' if self.run_name != 'asm2g' else 'abort(segmentation fault')
 
   def test_trickystring(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_trickystring')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6198,7 +6198,7 @@ int main() {
               self.assertContained('''managed another malloc!\n''', output)
           else:
             # we should see an abort
-            self.assertContained('''abort("Cannot enlarge memory arrays''', output)
+            self.assertContained('''abort(Cannot enlarge memory arrays''', output)
             self.assertContained(('''higher than the current value 16777216,''', '''higher than the current value 33554432,'''), output)
             self.assertContained('''compile with  -s ALLOW_MEMORY_GROWTH=1 ''', output)
             self.assertContained('''compile with  -s ABORTING_MALLOC=0 ''', output)


### PR DESCRIPTION
That led to errors in `browser.test_chunked_synchronous_xhr` as an object there could not be postMessage'd - the printing commands forwarded their inputs to the main thread, and `abort()` was sending them an object.

Remove the extra quotation marks there too - it's just extra code size for no reason.

This may not fix all random errors in that test, but at least when a random error occurs it will be able to print the error message now.