### PR TITLE
Enable graphics on chrome on CI, which looks like it's working now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,7 +171,6 @@ test-chrome: &test-chrome
           CHROME_FLAGS_WASM="--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer --no-wasm-disable-structured-cloning\""
           CHROME_FLAGS_NOCACHE="--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
           export EMTEST_BROWSER="/usr/bin/google-chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE"
-          export EMTEST_LACKS_GRAPHICS_HARDWARE=1
           export EMCC_CORES=4
           ./emscripten/tests/runner.py browser
 


### PR DESCRIPTION
@sbc100 after you asked in that other PR I checked, and it works now - maybe due to the version update, maybe due to using headless.
