### PR TITLE
Don't set broken CFLAGS when building libraries

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1535,7 +1535,6 @@ class Building(object):
       env['CC'] = quote(CLANG_CC)
       env['CXX'] = quote(CLANG_CPP)
       env['LD'] = quote(CLANG)
-      env['CFLAGS'] = '-O2 -fno-math-errno'
       # get a non-native one, and see if we have some of its effects - remove them if so
       non_native = Building.get_building_env(cflags=cflags)
       # the ones that a non-native would modify
@@ -1561,7 +1560,8 @@ class Building(object):
     env['RANLIB'] = quote(unsuffixed(EMRANLIB)) if not WINDOWS else 'python %s' % quote(EMRANLIB)
     env['EMMAKEN_COMPILER'] = quote(Building.COMPILER)
     env['EMSCRIPTEN_TOOLS'] = path_from_root('tools')
-    env['CFLAGS'] = env['EMMAKEN_CFLAGS'] = ' '.join(cflags)
+    if cflags:
+      env['CFLAGS'] = env['EMMAKEN_CFLAGS'] = ' '.join(cflags)
     env['HOST_CC'] = quote(CLANG_CC)
     env['HOST_CXX'] = quote(CLANG_CPP)
     env['HOST_CFLAGS'] = "-W" # if set to nothing, CFLAGS is used, which we don't want


### PR DESCRIPTION
It seems like we are overriding libraries to use `-O2` on native for no apparent reason, when the library should have been built with `-O3`. This would be skewing our benchmark numbers.

Also, we should omit `CFLAGS` when `get_building_env` receives a blank `cflags`. By passing an empty string, some libraries, such as `zlib`, are built with no flags, instead of their default flags.

In the case of `zlib`, the library is built with `-O0` (through omission of any `-O` flags) instead of `-O3`. This was not a problem because we used to pass in `-O3` via `RunnerCore.emcc_args` in the benchmark suite. According to @kripken, using `emcc_args` in `test_benchmark.py` is wrong, and this has been rectified in #8834, with the result that `zlib` is now built with `-O0`.