### PR TITLE
Add LSan and ASan test modes to non_core_test_modes

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -289,6 +289,8 @@ non_core_test_modes = [
   'sockets',
   'interactive',
   'benchmark',
+  'asan',
+  'lsan',
 ]
 
 test_index = 0


### PR DESCRIPTION
This allows glob patterns like `asan.test_a*` to be used on ASan and LSan tests.
