### PR TITLE
Correctly free pthread TSD storage

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -211,7 +211,7 @@ var LibraryPThread = {
       if (pthread.threadInfoStruct) {
         var tlsMemory = {{{ makeGetValue('pthread.threadInfoStruct', C_STRUCTS.pthread.tsd, 'i32') }}};
         {{{ makeSetValue('pthread.threadInfoStruct', C_STRUCTS.pthread.tsd, 0, 'i32') }}};
-        _free(pthread.tlsMemory);
+        _free(tlsMemory);
         _free(pthread.threadInfoStruct);
       }
       pthread.threadInfoStruct = 0;


### PR DESCRIPTION
The pointer is stored `pthread.threadInfoStruct` under the `tsd` field, and retrieved as local variable `tlsMemory`. However, `pthread.tlsMemory` is freed. Printing confirms that `pthread.tlsMemory` is `undefined`.