### PR TITLE
Remove tempDoublePtr on wasm backend

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -406,7 +406,7 @@ function JSify(data, functionsOnly) {
         print('/* no memory initializer */'); // test purposes
       }
 
-      if (!SIDE_MODULE) {
+      if (!SIDE_MODULE && !WASM_BACKEND) {
         if (USE_PTHREADS) {
           print('var tempDoublePtr;');
           print('if (!ENVIRONMENT_IS_PTHREAD) tempDoublePtr = ' + makeStaticAlloc(12) + ';');

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -332,9 +332,11 @@ var LibraryPThread = {
           };
         }(worker));
 
+#if !WASM_BACKEND
         // Allocate tempDoublePtr for the worker. This is done here on the worker's behalf, since we may need to do this statically
         // if the runtime has not been loaded yet, etc. - so we just use getMemory, which is main-thread only.
         var tempDoublePtr = getMemory(8); // TODO: leaks. Cleanup after worker terminates.
+#endif
 
         // Ask the new worker to load up the Emscripten-compiled page. This is a heavy operation.
         worker.postMessage({
@@ -352,7 +354,9 @@ var LibraryPThread = {
           buffer: HEAPU8.buffer,
           asmJsUrlOrBlob: Module["asmJsUrlOrBlob"],
 #endif
+#if !WASM_BACKEND
           tempDoublePtr: tempDoublePtr,
+#endif
           DYNAMIC_BASE: DYNAMIC_BASE,
           DYNAMICTOP_PTR: DYNAMICTOP_PTR,
           PthreadWorkerInit: PthreadWorkerInit

--- a/src/worker.js
+++ b/src/worker.js
@@ -11,7 +11,9 @@
 var threadInfoStruct = 0; // Info area for this thread in Emscripten HEAP (shared). If zero, this worker is not currently hosting an executing pthread.
 var selfThreadId = 0; // The ID of this thread. 0 if not hosting a pthread.
 var parentThreadId = 0; // The ID of the parent pthread that launched this thread.
+#if !WASM_BACKEND
 var tempDoublePtr = 0; // A temporary memory area for global float and double marshalling operations.
+#endif
 
 // Thread-local: Each thread has its own allocated stack space.
 var STACK_BASE = 0;
@@ -92,8 +94,10 @@ var wasmMemory;
 this.onmessage = function(e) {
   try {
     if (e.data.cmd === 'load') { // Preload command that is called once per worker to parse and load the Emscripten code.
+#if !WASM_BACKEND
       // Initialize the thread-local field(s):
       {{{ makeAsmGlobalAccessInPthread('tempDoublePtr') }}} = e.data.tempDoublePtr;
+#endif
 
       // Initialize the global "process"-wide fields:
       {{{ makeAsmExportAndGlobalAssignTargetInPthread('DYNAMIC_BASE') }}} = e.data.DYNAMIC_BASE;

--- a/tests/core/test_main_module_static_align.cpp
+++ b/tests/core/test_main_module_static_align.cpp
@@ -3,6 +3,8 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
+#include <assert.h>
+#include <stddef.h>
 #include <emscripten.h>
 
 __attribute__((aligned(16))) volatile char aligned;
@@ -11,7 +13,7 @@ int main() {
   assert((((size_t) &aligned) % 16) == 0);
 #if __wasm__
   EM_ASM({
-    out('tempDoublePtr alignment: 0');
+    out('tempDoublePtr alignment: 0.');
   });
 #else
   EM_ASM({

--- a/tests/core/test_main_module_static_align.cpp
+++ b/tests/core/test_main_module_static_align.cpp
@@ -8,11 +8,17 @@
 __attribute__((aligned(16))) volatile char aligned;
 
 int main() {
-  emscripten_log(EM_LOG_WARN, "16-byte aligned char: %d.", int(&aligned));
+  assert((((size_t) &aligned) % 16) == 0);
+#if __wasm__
+  EM_ASM({
+    out('tempDoublePtr alignment: 0');
+  });
+#else
   EM_ASM({
     // whether the char was properly aligned affects tempDoublePtr, which is after the static aligns
     out('tempDoublePtr: ' + tempDoublePtr + '.');
     out('tempDoublePtr alignment: ' + (tempDoublePtr % 16) + '.');
   });
+#endif
 }
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5237,7 +5237,6 @@ PORT: 3979
     self.do_run(src, expected)
 
   @needs_dlfcn
-  @no_wasm_backend('only tests tempDoublePtr alignment which does not exist on WASM backend')
   def test_main_module_static_align(self):
     if self.get_setting('ALLOW_MEMORY_GROWTH'):
       self.skipTest('no shared modules with memory growth')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5237,6 +5237,7 @@ PORT: 3979
     self.do_run(src, expected)
 
   @needs_dlfcn
+  @no_wasm_backend('only tests tempDoublePtr alignment which does not exist on WASM backend')
   def test_main_module_static_align(self):
     if self.get_setting('ALLOW_MEMORY_GROWTH'):
       self.skipTest('no shared modules with memory growth')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3099,8 +3099,11 @@ class WebAssembly(object):
     global_base = Settings.GLOBAL_BASE
 
     js = open(js_file).read()
-    m = re.search(r"(^|\s)tempDoublePtr\s+=\s+(\d+)", js)
-    tempdouble_ptr = int(m.group(2))
+    if Settings.WASM_BACKEND:
+      tempdouble_ptr = 0
+    else:
+      m = re.search(r"(^|\s)tempDoublePtr\s+=\s+(\d+)", js)
+      tempdouble_ptr = int(m.group(2))
     m = re.search(r"(^|\s)DYNAMIC_BASE\s+=\s+(\d+)", js)
     dynamic_base = int(m.group(2))
     m = re.search(r"(^|\s)DYNAMICTOP_PTR\s+=\s+(\d+)", js)


### PR DESCRIPTION
This is allocated and leaked, and reported as such by LSan/ASan.