### PR TITLE
Fix conversion from/to UTF-32

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -786,13 +786,7 @@ var LibraryEmbind = {
             return str;
         },
         'toWireType': function(destructors, value) {
-            if (value instanceof ArrayBuffer) {
-                value = new Uint8Array(value);
-            }
-
-            var valueIsOfTypeString = (typeof value === 'string');
-
-            if (!(valueIsOfTypeString || value instanceof Uint8Array || value instanceof Uint8ClampedArray || value instanceof Int8Array)) {
+            if (!(typeof value === 'string')) {
                 throwBindingError('Cannot pass non-string to C++ string type ' + name);
             }
 

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -747,6 +747,7 @@ var LibraryEmbind = {
     registerType(rawType, {
         name: name,
         'fromWireType': function(value) {
+            // Code mostly taken from _embind_register_std_string fromWireType
             var length = HEAPU32[value >> 2];
             var HEAP = getHeap();
             var str;

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -793,7 +793,7 @@ var LibraryEmbind = {
             var valueIsOfTypeString = (typeof value === 'string');
 
             if (!(valueIsOfTypeString || value instanceof Uint8Array || value instanceof Uint8ClampedArray || value instanceof Int8Array)) {
-                throwBindingError('Cannot pass non-string to std::basic_string');
+                throwBindingError('Cannot pass non-string to C++ string type ' + name);
             }
 
             // assumes 4-byte alignment


### PR DESCRIPTION
Fixes the issue #8954 and should fix the tests for #8931 

I made it work by copying the code that translated UTF-8, but using the UTF 16 and 32 functions.

If it smells to much like duplicated code, I can try to improve it.