### PR TITLE
Make STACK_BASE refer to the starting stack location on threads

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -183,7 +183,7 @@ this.onmessage = function(e) {
       var max = e.data.stackBase + e.data.stackSize;
       var top = e.data.stackBase;
 #endif
-      {{{ makeAsmExportAndGlobalAssignTargetInPthread('STACK_BASE') }}} = e.data.stackBase;
+      {{{ makeAsmExportAndGlobalAssignTargetInPthread('STACK_BASE') }}} = top;
       {{{ makeAsmExportAndGlobalAssignTargetInPthread('STACKTOP') }}} = top;
       {{{ makeAsmExportAndGlobalAssignTargetInPthread('STACK_MAX') }}} = max;
 #if ASSERTIONS
@@ -194,7 +194,6 @@ this.onmessage = function(e) {
 #if WASM_BACKEND
       assert(max === e.data.stackBase);
       assert(top > max);
-      assert(e.data.stackBase == max);
 #else
       assert(max > e.data.stackBase);
       assert(max > top);


### PR DESCRIPTION
This is already a case on the main thread. However, on WASM backend, `STACK_BASE == STACK_MAX ==` the lowest address on the stack, i.e. the point where the stack can grow to. This makes it impossible to find the highest address on the stack, i.e. the bottom of the stack.

This PR makes the behaviour consistent between the main thread and other threads by making other threads follow the conventions of the main thread.

We shall see if the tests pass.