### PR TITLE
Prepare for mainReadsParams flag in wasm-emscripten-finalize metadata

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2524,6 +2524,7 @@ def load_metadata_wasm(metadata_raw, DEBUG):
     'asmConsts': {},
     'invokeFuncs': [],
     'features': [],
+    'mainReadsParams': 1,
   }
 
   assert 'tableSize' in metadata_json.keys()


### PR DESCRIPTION
This change avoids the binaryen addition of the flags causing tests to break, as we assert on surprising flags in emscripten.py.

It sets the value of that param to a pessimistic 1 (assume main does read its params). This does nothing for now. After this lands, the binaryen PR [1] can land, and then a PR that adds the actual optimization and testing here.

[1] https://github.com/WebAssembly/binaryen/pull/2247