### PR TITLE
Upgrade CircleCI Ubuntu to Bionic, use system sphinx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 defaults: &defaults
   docker:
-    - image: buildpack-deps:xenial
+    - image: buildpack-deps:bionic
       environment:
         LANG: C.UTF-8
         EMTEST_DETECT_TEMPFILE_LEAKS: 1
@@ -229,11 +229,7 @@ jobs:
           name: install pip
           command: |
             apt-get update -q
-            apt-get install -q -y python-pip
-      - run:
-          name: install sphinx
-          command: |
-            pip install sphinx==1.7.8
+            apt-get install -q -y sphinx-common
       - run: make -C site html
   flake8:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,7 +226,7 @@ jobs:
     steps:
       - checkout
       - run:
-          name: install pip
+          name: install sphinx
           command: |
             apt-get update -q
             DEBIAN_FRONTEND=noninteractive apt-get install -q -y sphinx-common
@@ -402,5 +402,76 @@ workflows:
 
   build-test:
     jobs:
+      - flake8
       - build-docs
-
+      - build
+      - test-other:
+          requires:
+            - build
+      - test-browser-firefox:
+          requires:
+            - build
+      - test-browser-chrome:
+          requires:
+            - build
+      - test-ab:
+          requires:
+            - build
+      - test-c:
+          requires:
+            - build
+      - test-d:
+          requires:
+            - build
+      - test-e:
+          requires:
+            - build
+      - test-f:
+          requires:
+            - build
+      - test-ghi:
+          requires:
+            - build
+      - test-jklmno:
+          requires:
+            - build
+      - test-p:
+          requires:
+            - build
+      - test-qrst:
+          requires:
+            - build
+      - test-uvwxyz:
+          requires:
+            - build
+      - test-wasm0:
+          requires:
+            - build
+      - test-wasm1:
+          requires:
+            - build
+      - test-wasm2:
+          requires:
+            - build
+      - test-wasm3:
+          requires:
+            - build
+      - test-sanity:
+          requires:
+            - build
+      - build-upstream
+      - test-upstream-wasm0:
+          requires:
+            - build-upstream
+      - test-upstream-wasm2:
+          requires:
+            - build-upstream
+      - test-upstream-other:
+          requires:
+            - build-upstream
+      - test-upstream-browser-chrome:
+          requires:
+            - build-upstream
+      - test-upstream-browser-firefox:
+          requires:
+            - build-upstream

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,7 +229,7 @@ jobs:
           name: install pip
           command: |
             apt-get update -q
-            apt-get install -q -y sphinx-common
+            DEBIAN_FRONTEND=noninteractive apt-get install -q -y sphinx-common
       - run: make -C site html
   flake8:
     <<: *defaults
@@ -402,76 +402,5 @@ workflows:
 
   build-test:
     jobs:
-      - flake8
       - build-docs
-      - build
-      - test-other:
-          requires:
-            - build
-      - test-browser-firefox:
-          requires:
-            - build
-      - test-browser-chrome:
-          requires:
-            - build
-      - test-ab:
-          requires:
-            - build
-      - test-c:
-          requires:
-            - build
-      - test-d:
-          requires:
-            - build
-      - test-e:
-          requires:
-            - build
-      - test-f:
-          requires:
-            - build
-      - test-ghi:
-          requires:
-            - build
-      - test-jklmno:
-          requires:
-            - build
-      - test-p:
-          requires:
-            - build
-      - test-qrst:
-          requires:
-            - build
-      - test-uvwxyz:
-          requires:
-            - build
-      - test-wasm0:
-          requires:
-            - build
-      - test-wasm1:
-          requires:
-            - build
-      - test-wasm2:
-          requires:
-            - build
-      - test-wasm3:
-          requires:
-            - build
-      - test-sanity:
-          requires:
-            - build
-      - build-upstream
-      - test-upstream-wasm0:
-          requires:
-            - build-upstream
-      - test-upstream-wasm2:
-          requires:
-            - build-upstream
-      - test-upstream-other:
-          requires:
-            - build-upstream
-      - test-upstream-browser-chrome:
-          requires:
-            - build-upstream
-      - test-upstream-browser-firefox:
-          requires:
-            - build-upstream
+

--- a/site/source/docs/index.rst
+++ b/site/source/docs/index.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. _documentzzzzzzzzzzzation-home:
+.. _documentation-home:
 
 ========================
 Emscripten Documentation
@@ -16,9 +16,8 @@ This comprehensive documentation set contains everything you need to know to use
 
 **Emscripten Fundamentals:**
 
-
-- :ref:`intezzzzzzzzzgrating-porting-index` illustrates the main differences between the native and Emscripten runtime environments, and explains the changes you need to make to prepare your C/C++ code for the Web.
-- :ref:`Optimizingwwwwwwwww-Code` shows how to optimise your code for size and performance.
+- :ref:`integrating-porting-index` illustrates the main differences between the native and Emscripten runtime environments, and explains the changes you need to make to prepare your C/C++ code for the Web.
+- :ref:`Optimizing-Code` shows how to optimise your code for size and performance.
 - :ref:`Optimizing-WebGL` gives tips for how to maximize WebGL rendering performance for your page.
 - :ref:`compiling-and-running-projects-index` demonstrates how to integrate Emscripten into your existing project build system.
 
@@ -32,10 +31,8 @@ This comprehensive documentation set contains everything you need to know to use
 
 - :ref:`api-reference-index` is a reference for the Emscripten toolchain.
 - :ref:`tools-reference` is a reference for the Emscripten integration APIs.
-- :ref:`CyberDWvvvvvvvvvvvARF` shows how to use the CyberDWARF debugging system
+- :ref:`CyberDWARF` shows how to use the CyberDWARF debugging system
 - :ref:`Sanitizers` shows how to debug with sanitizers
-
-:req:`wat`
 
 The full hierarchy of articles, opened to the second level, is shown below.
 

--- a/site/source/docs/index.rst
+++ b/site/source/docs/index.rst
@@ -1,6 +1,6 @@
 :orphan:
 
-.. _documentation-home:
+.. _documentzzzzzzzzzzzation-home:
 
 ========================
 Emscripten Documentation
@@ -16,8 +16,9 @@ This comprehensive documentation set contains everything you need to know to use
 
 **Emscripten Fundamentals:**
 
-- :ref:`integrating-porting-index` illustrates the main differences between the native and Emscripten runtime environments, and explains the changes you need to make to prepare your C/C++ code for the Web.
-- :ref:`Optimizing-Code` shows how to optimise your code for size and performance.
+
+- :ref:`intezzzzzzzzzgrating-porting-index` illustrates the main differences between the native and Emscripten runtime environments, and explains the changes you need to make to prepare your C/C++ code for the Web.
+- :ref:`Optimizingwwwwwwwww-Code` shows how to optimise your code for size and performance.
 - :ref:`Optimizing-WebGL` gives tips for how to maximize WebGL rendering performance for your page.
 - :ref:`compiling-and-running-projects-index` demonstrates how to integrate Emscripten into your existing project build system.
 
@@ -31,8 +32,10 @@ This comprehensive documentation set contains everything you need to know to use
 
 - :ref:`api-reference-index` is a reference for the Emscripten toolchain.
 - :ref:`tools-reference` is a reference for the Emscripten integration APIs.
-- :ref:`CyberDWARF` shows how to use the CyberDWARF debugging system
+- :ref:`CyberDWvvvvvvvvvvvARF` shows how to use the CyberDWARF debugging system
 - :ref:`Sanitizers` shows how to debug with sanitizers
+
+:req:`wat`
 
 The full hierarchy of articles, opened to the second level, is shown below.
 


### PR DESCRIPTION
This moves us from Xenial (16.04) to Bionic (18.04), the current LTS. This seems useful by itself as there are probably more users there.

Fixes #9044 by using the system sphinx (avoiding the the pip version of sphinx which has broken). The system version is 1.6.7, which is a downgrade from 1.7.8 - not great, not terrible; seems ok to me unless we wanted that newer version for some reason?