### PR TITLE
Make read, readAsync, readBinary, setWindowTitle normal JS variables

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,11 +18,18 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-
  - LLVM backend pthread builds no longer use external memory initialization
    files, replacing them with passive data segments.
  - LLVM backend now supports thread local storage via the C extension `__thread`
    and C11/C++11 keyword `thread_local`. (#8976)
+ - Internal API change: Move read, readAsync, readBinary, setWindowTitle from
+   the Module object to normal JS variables. If you use those internal APIs,
+   you must change Module.readAsync/()Module['readAsync']() to readAsync().
+   Note that read is also renamed to read_ (since "read" is an API call in
+   the SpiderMonkey shell). In builds with ASSERTIONS an error message is
+   shown about the API change. This change allows better JS minification
+   (the names read, readAsync etc. can be minified, and if the variables are
+   not used they can be removed entirely).
 
 v1.38.39: 07/16/2019
 --------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,12 +24,14 @@ Current Trunk
    and C11/C++11 keyword `thread_local`. (#8976)
  - Internal API change: Move read, readAsync, readBinary, setWindowTitle from
    the Module object to normal JS variables. If you use those internal APIs,
-   you must change Module.readAsync/()Module['readAsync']() to readAsync().
+   you must change Module.readAsync()/Module['readAsync']() to readAsync().
    Note that read is also renamed to read_ (since "read" is an API call in
    the SpiderMonkey shell). In builds with ASSERTIONS an error message is
    shown about the API change. This change allows better JS minification
    (the names read, readAsync etc. can be minified, and if the variables are
-   not used they can be removed entirely).
+   not used they can be removed entirely). Defining these APIs on Module
+   (which was never documented or intended, but happened to work) is also
+   no longer allowed (but you can override read_ etc. from JS).
 
 v1.38.39: 07/16/2019
 --------------------

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -710,7 +710,7 @@ var LibraryBrowser = {
 
     asyncLoad: function(url, onload, onerror, noRunDep) {
       var dep = !noRunDep ? getUniqueRunDependency('al ' + url) : '';
-      Module['readAsync'](url, function(arrayBuffer) {
+      readAsync(url, function(arrayBuffer) {
         assert(arrayBuffer, 'Loading data file "' + url + '" failed (no arrayBuffer).');
         onload(new Uint8Array(arrayBuffer));
         if (dep) removeRunDependency(dep);

--- a/src/library_debugger_toolkit.js
+++ b/src/library_debugger_toolkit.js
@@ -452,7 +452,7 @@ var CyberDWARFHeapPrinter = function(cdFileLocation) {
   function initialize_debugger(cb) {
     cdFileLocation = locateFile(cdFileLocation);
     if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
-      var data = Module['read'](cdFileLocation);
+      var data = read(cdFileLocation);
       install_cyberdwarf(data);
     } else {
       var applyCDFile = function(data) {
@@ -464,7 +464,7 @@ var CyberDWARFHeapPrinter = function(cdFileLocation) {
         }
       }
       var doBrowserLoad = function() {
-        Module['readAsync'](cdFileLocation, applyCDFile, function() {
+        readAsync(cdFileLocation, applyCDFile, function() {
           throw 'could not load debug data ' + cdFileLocation;
         });
       }

--- a/src/library_debugger_toolkit.js
+++ b/src/library_debugger_toolkit.js
@@ -452,7 +452,7 @@ var CyberDWARFHeapPrinter = function(cdFileLocation) {
   function initialize_debugger(cb) {
     cdFileLocation = locateFile(cdFileLocation);
     if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
-      var data = read(cdFileLocation);
+      var data = read_(cdFileLocation);
       install_cyberdwarf(data);
     } else {
       var applyCDFile = function(data) {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1668,12 +1668,12 @@ mergeInto(LibraryManager.library, {
       var success = true;
       if (typeof XMLHttpRequest !== 'undefined') {
         throw new Error("Lazy loading should have been performed (contents set) in createLazyFile, but it was not. Lazy loading only works in web workers. Use --embed-file or --preload-file in emcc on the main thread.");
-      } else if (read) {
+      } else if (read_) {
         // Command-line.
         try {
           // WARNING: Can't read binary files in V8's d8 or tracemonkey's js, as
           //          read() will try to parse UTF8.
-          obj.contents = intArrayFromString(read(obj.url), true);
+          obj.contents = intArrayFromString(read_(obj.url), true);
           obj.usedBytes = obj.contents.length;
         } catch (e) {
           success = false;

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1668,12 +1668,12 @@ mergeInto(LibraryManager.library, {
       var success = true;
       if (typeof XMLHttpRequest !== 'undefined') {
         throw new Error("Lazy loading should have been performed (contents set) in createLazyFile, but it was not. Lazy loading only works in web workers. Use --embed-file or --preload-file in emcc on the main thread.");
-      } else if (Module['read']) {
+      } else if (read) {
         // Command-line.
         try {
           // WARNING: Can't read binary files in V8's d8 or tracemonkey's js, as
           //          read() will try to parse UTF8.
-          obj.contents = intArrayFromString(Module['read'](obj.url), true);
+          obj.contents = intArrayFromString(read(obj.url), true);
           obj.usedBytes = obj.contents.length;
         } catch (e) {
           success = false;

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1733,8 +1733,8 @@ var LibrarySDL = {
   SDL_WM_SetCaption__proxy: 'sync',
   SDL_WM_SetCaption__sig: 'vii',
   SDL_WM_SetCaption: function(title, icon) {
-    if (title && typeof Module['setWindowTitle'] !== 'undefined') {
-      Module['setWindowTitle'](UTF8ToString(title));
+    if (title && typeof setWindowTitle !== 'undefined') {
+      setWindowTitle(UTF8ToString(title));
     }
     icon = icon && UTF8ToString(icon);
   },

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -43,7 +43,7 @@ if (memoryInitializer) {
     memoryInitializer = locateFile(memoryInitializer);
   }
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
-    var data = Module['readBinary'](memoryInitializer);
+    var data = readBinary(memoryInitializer);
     HEAPU8.set(data, GLOBAL_BASE);
   } else {
     addRunDependency('memory initializer');
@@ -62,7 +62,7 @@ if (memoryInitializer) {
       removeRunDependency('memory initializer');
     }
     var doBrowserLoad = function() {
-      Module['readAsync'](memoryInitializer, applyMemoryInitializer, function() {
+      readAsync(memoryInitializer, applyMemoryInitializer, function() {
         throw 'could not load memory initializer ' + memoryInitializer;
       });
     }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -702,7 +702,7 @@ addOnPreRun(function() {
   }
   // if we can load dynamic libraries synchronously, do so, otherwise, preload
 #if WASM
-  if (Module['dynamicLibraries'] && Module['dynamicLibraries'].length > 0 && !Module['readBinary']) {
+  if (Module['dynamicLibraries'] && Module['dynamicLibraries'].length > 0 && !readBinary) {
     // we can't read binary data synchronously, so preload
     addRunDependency('preload_dynamicLibraries');
     Promise.all(Module['dynamicLibraries'].map(function(lib) {
@@ -817,8 +817,8 @@ function getBinary() {
       return binary;
     }
 #endif
-    if (Module['readBinary']) {
-      return Module['readBinary'](wasmBinaryFile);
+    if (readBinary) {
+      return readBinary(wasmBinaryFile);
     } else {
 #if WASM_ASYNC_COMPILATION
       throw "both async and sync fetching of the wasm failed";

--- a/src/shell.js
+++ b/src/shell.js
@@ -112,14 +112,6 @@ var read,
     readBinary,
     setWindowTitle;
 
-#if ASSERTIONS
-// TODO: assert the user didn't provide them as inputs on Module
-Object.defineProperty(Module, 'read', { get: function() { abort('Module.read has been replaced with plain read') } });
-Object.defineProperty(Module, 'readAsync', { get: function() { abort('Module.readAsync has been replaced with plain readAsync') } });
-Object.defineProperty(Module, 'readBinary', { get: function() { abort('Module.readBinary has been replaced with plain readBinary') } });
-Object.defineProperty(Module, 'setWindowTitle', { get: function() { abort('Module.setWindowTitle has been replaced with plain setWindowTitle') } });
-#endif
-
 #if ENVIRONMENT_MAY_BE_NODE
 if (ENVIRONMENT_IS_NODE) {
 #if ENVIRONMENT
@@ -365,10 +357,21 @@ moduleOverrides = undefined;
 
 // perform assertions in shell.js after we set up out() and err(), as otherwise if an assertion fails it cannot print the message
 #if ASSERTIONS
+// Assertions on removed incoming Module JS APIs.
 assert(typeof Module['memoryInitializerPrefixURL'] === 'undefined', 'Module.memoryInitializerPrefixURL option was removed, use Module.locateFile instead');
 assert(typeof Module['pthreadMainPrefixURL'] === 'undefined', 'Module.pthreadMainPrefixURL option was removed, use Module.locateFile instead');
 assert(typeof Module['cdInitializerPrefixURL'] === 'undefined', 'Module.cdInitializerPrefixURL option was removed, use Module.locateFile instead');
 assert(typeof Module['filePackagePrefixURL'] === 'undefined', 'Module.filePackagePrefixURL option was removed, use Module.locateFile instead');
+assert(typeof Module['read'] === 'undefined', 'Module.read option was removed');
+assert(typeof Module['readAsync'] === 'undefined', 'Module.readAsync option was removed');
+assert(typeof Module['readBinary'] === 'undefined', 'Module.readBinary option was removed');
+assert(typeof Module['setWindowTitle'] === 'undefined', 'Module.setWindowTitle option was removed');
+// Assertions on removed outgoing Module JS APIs.
+Object.defineProperty(Module, 'read', { get: function() { abort('Module.read has been replaced with plain read') } });
+Object.defineProperty(Module, 'readAsync', { get: function() { abort('Module.readAsync has been replaced with plain readAsync') } });
+Object.defineProperty(Module, 'readBinary', { get: function() { abort('Module.readBinary has been replaced with plain readBinary') } });
+Object.defineProperty(Module, 'setWindowTitle', { get: function() { abort('Module.setWindowTitle has been replaced with plain setWindowTitle') } });
+
 #if USE_PTHREADS
 assert(ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER, 'Pthreads do not work in non-browser environments yet (need Web Workers, or an alternative to them)');
 #endif // USE_PTHREADS

--- a/src/shell.js
+++ b/src/shell.js
@@ -362,10 +362,10 @@ assert(typeof Module['memoryInitializerPrefixURL'] === 'undefined', 'Module.memo
 assert(typeof Module['pthreadMainPrefixURL'] === 'undefined', 'Module.pthreadMainPrefixURL option was removed, use Module.locateFile instead');
 assert(typeof Module['cdInitializerPrefixURL'] === 'undefined', 'Module.cdInitializerPrefixURL option was removed, use Module.locateFile instead');
 assert(typeof Module['filePackagePrefixURL'] === 'undefined', 'Module.filePackagePrefixURL option was removed, use Module.locateFile instead');
-assert(typeof Module['read'] === 'undefined', 'Module.read option was removed');
-assert(typeof Module['readAsync'] === 'undefined', 'Module.readAsync option was removed');
-assert(typeof Module['readBinary'] === 'undefined', 'Module.readBinary option was removed');
-assert(typeof Module['setWindowTitle'] === 'undefined', 'Module.setWindowTitle option was removed');
+assert(typeof Module['read'] === 'undefined', 'Module.read option was removed (modify read_ in JS)');
+assert(typeof Module['readAsync'] === 'undefined', 'Module.readAsync option was removed (modify readAsync in JS)');
+assert(typeof Module['readBinary'] === 'undefined', 'Module.readBinary option was removed (modify readBinary in JS)');
+assert(typeof Module['setWindowTitle'] === 'undefined', 'Module.setWindowTitle option was removed (modify setWindowTitle in JS)');
 // Assertions on removed outgoing Module JS APIs.
 Object.defineProperty(Module, 'read', { get: function() { abort('Module.read has been replaced with plain read') } });
 Object.defineProperty(Module, 'readAsync', { get: function() { abort('Module.readAsync has been replaced with plain readAsync') } });

--- a/src/shell.js
+++ b/src/shell.js
@@ -107,7 +107,7 @@ function locateFile(path) {
 }
 
 // Hooks that are implemented differently in different runtime environments.
-var read,
+var read_,
     readAsync,
     readBinary,
     setWindowTitle;
@@ -126,7 +126,7 @@ if (ENVIRONMENT_IS_NODE) {
   var nodeFS;
   var nodePath;
 
-  read = function shell_read(filename, binary) {
+  read_ = function shell_read(filename, binary) {
     var ret;
 #if SUPPORT_BASE64_EMBEDDING
     ret = tryParseAsDataURI(filename);
@@ -143,7 +143,7 @@ if (ENVIRONMENT_IS_NODE) {
   };
 
   readBinary = function readBinary(filename) {
-    var ret = read(filename, true);
+    var ret = read_(filename, true);
     if (!ret.buffer) {
       ret = new Uint8Array(ret);
     }
@@ -194,7 +194,7 @@ if (ENVIRONMENT_IS_SHELL) {
 #endif
 
   if (typeof read != 'undefined') {
-    read = function shell_read(f) {
+    read_ = function shell_read(f) {
 #if SUPPORT_BASE64_EMBEDDING
       var data = tryParseAsDataURI(f);
       if (data) {
@@ -264,7 +264,7 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 #endif
 #endif
 
-  read = function shell_read(url) {
+  read_ = function shell_read(url) {
 #if SUPPORT_BASE64_EMBEDDING
     try {
 #endif

--- a/src/shell.js
+++ b/src/shell.js
@@ -377,6 +377,11 @@ assert(ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER, 'Pthreads do not work in non
 #endif // USE_PTHREADS
 #endif // ASSERTIONS
 
+// TODO remove when SDL2 is fixed
+#if USE_SDL == 2
+Module['setWindowTitle'] = setWindowTitle;
+#endif
+
 {{BODY}}
 
 // {{MODULE_ADDITIONS}}

--- a/src/shell.js
+++ b/src/shell.js
@@ -113,6 +113,7 @@ var read,
     setWindowTitle;
 
 #if ASSERTIONS
+// TODO: assert the user didn't provide them as inputs on Module
 Object.defineProperty(Module, 'read', { get: function() { abort('Module.read has been replaced with plain read') } });
 Object.defineProperty(Module, 'readAsync', { get: function() { abort('Module.readAsync has been replaced with plain readAsync') } });
 Object.defineProperty(Module, 'readBinary', { get: function() { abort('Module.readBinary has been replaced with plain readBinary') } });

--- a/src/shell.js
+++ b/src/shell.js
@@ -370,14 +370,14 @@ assert(typeof Module['setWindowTitle'] === 'undefined', 'Module.setWindowTitle o
 Object.defineProperty(Module, 'read', { get: function() { abort('Module.read has been replaced with plain read') } });
 Object.defineProperty(Module, 'readAsync', { get: function() { abort('Module.readAsync has been replaced with plain readAsync') } });
 Object.defineProperty(Module, 'readBinary', { get: function() { abort('Module.readBinary has been replaced with plain readBinary') } });
-Object.defineProperty(Module, 'setWindowTitle', { get: function() { abort('Module.setWindowTitle has been replaced with plain setWindowTitle') } });
+// TODO enable when SDL2 is fixed Object.defineProperty(Module, 'setWindowTitle', { get: function() { abort('Module.setWindowTitle has been replaced with plain setWindowTitle') } });
 
 #if USE_PTHREADS
 assert(ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER, 'Pthreads do not work in non-browser environments yet (need Web Workers, or an alternative to them)');
 #endif // USE_PTHREADS
 #endif // ASSERTIONS
 
-// TODO remove when SDL2 is fixed
+// TODO remove when SDL2 is fixed; also add the above assertion
 #if USE_SDL == 2
 Module['setWindowTitle'] = setWindowTitle;
 #endif

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -96,7 +96,7 @@ if (!isDataURI(wasmBinaryFile)) {
 
 function getSourceMap() {
   try {
-    return JSON.parse(Module['read'](wasmSourceMapFile));
+    return JSON.parse(read(wasmSourceMapFile));
   } catch (err) {
     abort(err);
   }

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -96,7 +96,7 @@ if (!isDataURI(wasmBinaryFile)) {
 
 function getSourceMap() {
   try {
-    return JSON.parse(read(wasmSourceMapFile));
+    return JSON.parse(read_(wasmSourceMapFile));
   } catch (err) {
     abort(err);
   }

--- a/src/support.js
+++ b/src/support.js
@@ -188,14 +188,14 @@ function loadDynamicLibrary(lib, flags) {
       return fetchBinary(lib);
     }
     // load the binary synchronously
-    return Module['readBinary'](lib);
+    return readBinary(lib);
 #else
     // for js we only imitate async for both native & fs modes.
     var libData;
     if (flags.fs) {
       libData = flags.fs.readFile(lib, {encoding: 'utf8'});
     } else {
-      libData = Module['read'](lib);
+      libData = read(lib);
     }
     return flags.loadAsync ? Promise.resolve(libData) : libData;
 #endif

--- a/src/support.js
+++ b/src/support.js
@@ -195,7 +195,7 @@ function loadDynamicLibrary(lib, flags) {
     if (flags.fs) {
       libData = flags.fs.readFile(lib, {encoding: 'utf8'});
     } else {
-      libData = read(lib);
+      libData = read_(lib);
     }
     return flags.loadAsync ? Promise.resolve(libData) : libData;
 #endif

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5833,7 +5833,7 @@ return malloc(size);
 
       create_test_file('pre.js', '''
       Module.preRun = function() {
-        FS.createDataFile('/', 'paper.pdf', eval(Module.read('paper.pdf.js')), true, false, false);
+        FS.createDataFile('/', 'paper.pdf', eval(read('paper.pdf.js')), true, false, false);
       };
       Module.postRun = function() {
         var FileData = MEMFS.getFileDataAsRegularArray(FS.root.contents['filename-1.ppm']);

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5833,7 +5833,7 @@ return malloc(size);
 
       create_test_file('pre.js', '''
       Module.preRun = function() {
-        FS.createDataFile('/', 'paper.pdf', eval(read('paper.pdf.js')), true, false, false);
+        FS.createDataFile('/', 'paper.pdf', eval(read_('paper.pdf.js')), true, false, false);
       };
       Module.postRun = function() {
         var FileData = MEMFS.getFileDataAsRegularArray(FS.root.contents['filename-1.ppm']);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9492,7 +9492,7 @@ int main () {
         run_process(cmd)
 
   def test_assertions_on_internal_api_changes(self):
-    src = r'''
+    create_test_file('src.c', r'''
       #include <emscripten.h>
       int main(int argc, char **argv) {
         EM_ASM({
@@ -9504,21 +9504,15 @@ int main () {
           }
         });
       }
-    '''
-    create_test_file('src.c', src)
-
+    ''')
     run_process([PYTHON, EMCC, 'src.c', '-s', 'ASSERTIONS'])
-    out = run_js('a.out.js', stderr=PIPE, full_output=True, assert_returncode=None)
     self.assertContained('Module.read has been replaced with plain read', run_js('a.out.js'))
 
   def test_assertions_on_incoming_module_api_changes(self):
-    src = r'''
+    create_test_file('pre.js', r'''
       var Module = {
         read: function() {}
       }
-    '''
-    create_test_file('pre.js', src)
-
+    ''')
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'ASSERTIONS', '--pre-js', 'pre.js'])
-    out = run_js('a.out.js', stderr=PIPE, full_output=True, assert_returncode=None)
     self.assertContained('Module.read option was removed', run_js('a.out.js', assert_returncode=None, stderr=PIPE))


### PR DESCRIPTION
This replaces `Module['readBinary']` with `readBinary` etc., that is, moves them from Module to be just normal JS variables.

This change allows better JS minification: the names read, readAsync etc. can be minified now, and even better if the variables are not used then they can be removed entirely. On hello world this saves 5% of JS size in `-O3 --closure 1` with the wasm backend.

This is an internal API change. However, it's possible some users depend on it, so I added a mention in the changelog, and in builds with ASSERTIONS an error message is shown if the old APIs are used.

Note that `read` is also renamed to `read_` (since "read" is an API call in the SpiderMonkey shell).