### PR TITLE
fix: suppress warnings on `new Buffer`

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -418,3 +418,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Fernando Serboncini <fserb@google.com>
 * Christian Clauss <cclauss@me.com> (copyright owned by IBM)
 * Henry Kleynhans <hkleynhans@bloomberg.net> (copyright owned by Bloomberg L.P.)
+* FUJI Goro <g.psy.va@gmail.com>

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -107,7 +107,7 @@ mergeInto(LibraryManager.library, {
           if (ENVIRONMENT_IS_NODE) {
             // we will read data by chunks of BUFSIZE
             var BUFSIZE = 256;
-            var buf = new Buffer(BUFSIZE);
+            var buf = Buffer.alloc ? Buffer.alloc(BUFSIZE) : new Buffer(BUFSIZE);
             var bytesRead = 0;
 
             var isPosixPlatform = (process.platform != 'win32'); // Node doesn't offer a direct check, so test by exclusion


### PR DESCRIPTION
`new Buffer()` is now deprecated:

> [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.

If emscripten drops NodeJS < 6, just `Buffer.alloc(BUFSIZE)` is okay, but it's missing on NodeJS < 6.

