### PR TITLE
`class_<T>.constructor` to accept `std::function` and function object

### DIFF
--- a/site/source/docs/api_reference/bind.h.rst
+++ b/site/source/docs/api_reference/bind.h.rst
@@ -533,17 +533,32 @@ Classes
       .. _embind-class-function-pointer-constructor:
 
 
-   .. cpp:function:: const class_& constructor(ReturnType (*factory)(Args...), Policies...) const
+   .. cpp:function:: const class_& constructor(Callable callable, Policies...) const
 
       .. code-block:: cpp
 
          //prototype
-         template<typename... Args, typename ReturnType, typename... Policies>
-         EMSCRIPTEN_ALWAYS_INLINE const class_& constructor(ReturnType (*factory)(Args...), Policies...) const
+         template<typename Signature = internal::DeduceArgumentsTag, typename Callable, typename... Policies>
+         EMSCRIPTEN_ALWAYS_INLINE const class_& constructor(Callable callable, Policies...) const
 
-      Class constructor for objects that use a factory function to create the object. See :ref:`embind-external-constructors` for more information.
+      Class constructor for objects that use a factory function to create the object.  This method will accept either a function pointer, ``std::function``
+      object or function object which will return a newly constructed object.  When the ``Callable`` is a function object the function signature must be
+      explicitly specified in the ``Signature`` template parameter in the format ``ReturnType (Args...)``.  For ``Callable`` types other than function objects
+      the method signature will be deduced.
 
-      :param ReturnType (\*factory)(Args...): The address of the class factory function.
+      The following are all valid calls to ``constructor``:
+
+      .. code-block:: cpp
+
+         using namespace std::placeholders;
+         myClass1.constructor(&my_factory);
+         myClass2.constructor(std::function<ClassType2(float, float)>(&class2_factory));
+         myClass3.constructor<ClassType3(const val&)>(std::bind(Class3Functor(), _1));
+
+      See :ref:`embind-external-constructors` for more information.
+
+
+      :param Callable callable Note that ``Callable`` may be either a member function pointer, function pointer, ``std::function`` or function object.
       :param Policies... policies: |policies-argument|
       :returns: |class_-function-returns|
 

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -1192,6 +1192,19 @@ module({
             b.delete();
         });
 
+        test("function objects as class constructors", function() {
+            let a = new cm.ConstructFromStdFunction("foo", 10);
+            assert.equal("foo", a.getVal());
+            assert.equal(10, a.getA());
+
+            let b = new cm.ConstructFromFunctionObject("bar", 12);
+            assert.equal("bar", b.getVal());
+            assert.equal(12, b.getA());
+
+            a.delete();
+            b.delete();
+        });
+
         test("function objects as class methods", function() {
             let b = cm.ValHolder.makeValHolder("foo");
 

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -1690,6 +1690,32 @@ unsigned long load_unsigned_long() {
 	return ulong;
 }
 
+template <int I>
+class ConstructFromFunctor {
+public:
+    ConstructFromFunctor(const val& v, int a)
+        : v_(v), a_(a)
+    {}
+
+    val getVal() const {
+        return v_;
+    }
+
+    int getA() const {
+        return a_;
+    }
+
+private:
+    val v_;
+    int a_;
+};
+
+template <int I>
+ConstructFromFunctor<I> construct_from_functor_mixin(const val& v, int i)
+{
+    return {v, i};
+}
+
 EMSCRIPTEN_BINDINGS(tests) {
     register_vector<int>("IntegerVector");
     register_vector<char>("CharVector");
@@ -1793,6 +1819,18 @@ EMSCRIPTEN_BINDINGS(tests) {
     function("emval_test_take_and_return_ArrayInStruct", &emval_test_take_and_return_ArrayInStruct);
 
     using namespace std::placeholders;
+
+    class_<ConstructFromFunctor<1>>("ConstructFromStdFunction")
+        .constructor(std::function<ConstructFromFunctor<1>(const val&, int)>(&construct_from_functor_mixin<1>))
+        .function("getVal", &ConstructFromFunctor<1>::getVal)
+        .function("getA", &ConstructFromFunctor<1>::getA)
+        ;
+
+    class_<ConstructFromFunctor<2>>("ConstructFromFunctionObject")
+        .constructor<ConstructFromFunctor<2>(const val&, int)>(std::bind(&construct_from_functor_mixin<2>, _1, _2))
+        .function("getVal", &ConstructFromFunctor<2>::getVal)
+        .function("getA", &ConstructFromFunctor<2>::getA)
+        ;
 
     class_<ValHolder>("ValHolder")
         .smart_ptr<std::shared_ptr<ValHolder>>("std::shared_ptr<ValHolder>")


### PR DESCRIPTION
Enable `class_<T>.constructor` to accept both `std::function` and
function object types. This is useful in scenarios where you want a
stateful function object for purposes such as gathering statistics or
performing other generic functionality on each call.
