### PR TITLE
Fix other.test_js_optimizer_parse_error on windows

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8590,7 +8590,7 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
 ''', '''
 var ASM_CONSTS = [function() {var x = !<->5.;}];
                                        ^
-'''), stderr)
+'''), stderr.replace('\r', ''))
 
   def test_EM_ASM_ES6(self):
     # check we show a proper understandable error for JS parse problems


### PR DESCRIPTION
I believe the issue is the newline difference on that platform.

This should fix current broken rolls on this repo, e.g. https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8907222997982694992/+/steps/Emscripten_testsuite__upstream__other_/0/stdout