### PR TITLE
Fix #9030: allow side effects for `EM_ASM` arguments

### DIFF
--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -122,14 +122,17 @@ struct __em_asm_sig_builder {};
 
 template<typename... Args>
 struct __em_asm_sig_builder<__em_asm_type_tuple<Args...> > {
-  char buffer[sizeof...(Args)+1] = { __em_asm_sig<Args>::value..., 0 };
+  static const char buffer[sizeof...(Args) + 1];
 };
+
+template<typename... Args>
+const char __em_asm_sig_builder<__em_asm_type_tuple<Args...> >::buffer[] = { __em_asm_sig<Args>::value..., 0 };
 
 // We move to type level with decltype(make_tuple(...)) to avoid double
 // evaluation of arguments. Use __typeof__ instead of decltype, though,
 // because the header should be able to compile with clang's -std=c++03.
 #define _EM_ASM_PREP_ARGS(...) \
-    , __em_asm_sig_builder<__typeof__(__em_asm_make_type_tuple(__VA_ARGS__))>().buffer, ##__VA_ARGS__
+    , __em_asm_sig_builder<__typeof__(__em_asm_make_type_tuple(__VA_ARGS__))>::buffer, ##__VA_ARGS__
 
 extern "C" {
 #endif // __cplusplus

--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -92,52 +92,44 @@
 // C++ needs to support vararg template parameter packs, e.g. like in
 // tests/core/test_em_asm_parameter_pack.cpp. Because of that, a macro-only
 // approach doesn't work (a macro applied to a parameter pack would expand
-// incorrectly). So we can use a template function instead to build a
-// std::string, and convert that to a C string.
-// String builder class is so the _sig functions can be mutually recursive.
-class __em_asm_sig_builder {
-private:
-  static char sig_char(float) {
-    return 'd';
-  }
-  static char sig_char(double) {
-    return 'd';
-  }
-  static char sig_char(int) {
-    return 'i';
-  }
-  static char sig_char(unsigned) {
-    return 'i';
-  }
-  static char sig_char(long) {
-    return 'i';
-  }
-  static char sig_char(unsigned long) {
-    return 'i';
-  }
-  template <typename T>
-  static char sig_char(T *arg) {
-    return 'i';
-  }
+// incorrectly). So we can use a template class instead to build a temporary
+// buffer of characters.
 
-  template <typename ...Args>
-  struct inner {
-    char buffer[sizeof...(Args)+1];
-  };
-public:
-  template <typename ...Args>
-  static const inner<Args...> __em_asm_sig(Args ...args) {
-    inner<Args...> temp;
-    char buf[sizeof...(Args)+1] = { sig_char(args)..., 0 };
-    for (int i = 0; i < sizeof...(Args)+1; ++i) {
-        temp.buffer[i] = buf[i];
-    }
-    return temp;
-  }
+// As emscripten is require to build successfully with -std=c++03, we cannot
+// use std::tuple or std::integral_constant. Using C++11 features is only a
+// warning in modern Clang, which are ignored in system headers.
+template<typename> struct __em_asm_sig {};
+template<> struct __em_asm_sig<float> { static const char value = 'd'; };
+template<> struct __em_asm_sig<double> { static const char value = 'd'; };
+template<> struct __em_asm_sig<int> { static const char value = 'i'; };
+template<> struct __em_asm_sig<unsigned> { static const char value = 'i'; };
+template<> struct __em_asm_sig<long> { static const char value = 'i'; };
+template<> struct __em_asm_sig<unsigned long> { static const char value = 'i'; };
+template<typename T> struct __em_asm_sig<T*> { static const char value = 'i'; };
+
+// Instead of std::tuple
+template<typename... Args>
+struct __em_asm_type_tuple {};
+
+// Instead of std::make_tuple
+template<typename... Args>
+__em_asm_type_tuple<Args...> __em_asm_make_type_tuple(Args... args) {
+    return {};
+}
+
+template<typename>
+struct __em_asm_sig_builder {};
+
+template<typename... Args>
+struct __em_asm_sig_builder<__em_asm_type_tuple<Args...> > {
+  char buffer[sizeof...(Args)+1] = { __em_asm_sig<Args>::value..., 0 };
 };
 
+// We move to type level with decltype(make_tuple(...)) to avoid double
+// evaluation of arguments. Use __typeof__ instead of decltype, though,
+// because the header should be able to compile with clang's -std=c++03.
 #define _EM_ASM_PREP_ARGS(...) \
-    , __em_asm_sig_builder::__em_asm_sig(__VA_ARGS__).buffer, ##__VA_ARGS__
+    , __em_asm_sig_builder<__typeof__(__em_asm_make_type_tuple(__VA_ARGS__))>().buffer, ##__VA_ARGS__
 
 extern "C" {
 #endif // __cplusplus

--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -101,10 +101,17 @@
 template<typename> struct __em_asm_sig {};
 template<> struct __em_asm_sig<float> { static const char value = 'd'; };
 template<> struct __em_asm_sig<double> { static const char value = 'd'; };
+template<> struct __em_asm_sig<char> { static const char value = 'i'; };
+template<> struct __em_asm_sig<signed char> { static const char value = 'i'; };
+template<> struct __em_asm_sig<unsigned char> { static const char value = 'i'; };
+template<> struct __em_asm_sig<short> { static const char value = 'i'; };
+template<> struct __em_asm_sig<unsigned short> { static const char value = 'i'; };
 template<> struct __em_asm_sig<int> { static const char value = 'i'; };
-template<> struct __em_asm_sig<unsigned> { static const char value = 'i'; };
+template<> struct __em_asm_sig<unsigned int> { static const char value = 'i'; };
 template<> struct __em_asm_sig<long> { static const char value = 'i'; };
 template<> struct __em_asm_sig<unsigned long> { static const char value = 'i'; };
+template<> struct __em_asm_sig<bool> { static const char value = 'i'; };
+template<> struct __em_asm_sig<wchar_t> { static const char value = 'i'; };
 template<typename T> struct __em_asm_sig<T*> { static const char value = 'i'; };
 
 // Instead of std::tuple

--- a/system/include/emscripten/em_asm.h
+++ b/system/include/emscripten/em_asm.h
@@ -98,7 +98,7 @@
 // As emscripten is require to build successfully with -std=c++03, we cannot
 // use std::tuple or std::integral_constant. Using C++11 features is only a
 // warning in modern Clang, which are ignored in system headers.
-template<typename> struct __em_asm_sig {};
+template<typename, typename = void> struct __em_asm_sig {};
 template<> struct __em_asm_sig<float> { static const char value = 'd'; };
 template<> struct __em_asm_sig<double> { static const char value = 'd'; };
 template<> struct __em_asm_sig<char> { static const char value = 'i'; };
@@ -113,6 +113,13 @@ template<> struct __em_asm_sig<unsigned long> { static const char value = 'i'; }
 template<> struct __em_asm_sig<bool> { static const char value = 'i'; };
 template<> struct __em_asm_sig<wchar_t> { static const char value = 'i'; };
 template<typename T> struct __em_asm_sig<T*> { static const char value = 'i'; };
+
+// Explicit support for enums, they're passed as int via variadic arguments.
+template<bool> struct __em_asm_if { };
+template<> struct __em_asm_if<true> { typedef void type; };
+template<typename T> struct __em_asm_sig<T, typename __em_asm_if<__is_enum(T)>::type> {
+    static const char value = 'i';
+};
 
 // Instead of std::tuple
 template<typename... Args>

--- a/tests/core/test_em_asm_arguments_side_effects.cpp
+++ b/tests/core/test_em_asm_arguments_side_effects.cpp
@@ -1,0 +1,18 @@
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <emscripten.h>
+
+int main(int argc, char **argv) {
+  int counter_1 = 3, counter_2 = 4;
+  // https://github.com/emscripten-core/emscripten/issues/9030
+  int result = EM_ASM_INT({
+     return $0 * 10 + $1;
+  }, counter_1++, counter_2++);
+  printf("counter_1=3, counter_2=4\n");
+  printf("counter_1++ * 10 + counter_2++=%d\n", result);
+  return 0;
+}

--- a/tests/core/test_em_asm_arguments_side_effects.cpp
+++ b/tests/core/test_em_asm_arguments_side_effects.cpp
@@ -9,10 +9,11 @@
 int main(int argc, char **argv) {
   int counter_1 = 3, counter_2 = 4;
   // https://github.com/emscripten-core/emscripten/issues/9030
+  printf("counter_1=%d, counter_2=%d\n", counter_1, counter_2);
   int result = EM_ASM_INT({
      return $0 * 10 + $1;
   }, counter_1++, counter_2++);
-  printf("counter_1=3, counter_2=4\n");
   printf("counter_1++ * 10 + counter_2++=%d\n", result);
+  printf("counter_1=%d, counter_2=%d\n", counter_1, counter_2);
   return 0;
 }

--- a/tests/core/test_em_asm_arguments_side_effects.out
+++ b/tests/core/test_em_asm_arguments_side_effects.out
@@ -1,0 +1,2 @@
+counter_1=3, counter_2=4
+counter_1++ * 10 + counter_2++=34

--- a/tests/core/test_em_asm_arguments_side_effects.out
+++ b/tests/core/test_em_asm_arguments_side_effects.out
@@ -1,2 +1,3 @@
 counter_1=3, counter_2=4
 counter_1++ * 10 + counter_2++=34
+counter_1=4, counter_2=5

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1795,9 +1795,8 @@ int main(int argc, char **argv) {
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_parameter_pack')
 
   def test_em_asm_arguments_side_effects(self):
-    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_arguments_side_effects', force_c=True)
-    self.emcc_args += ['-std=c++11']
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_arguments_side_effects')
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_arguments_side_effects', force_c=True)
 
   @parameterized({
     'normal': ([],),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1794,6 +1794,11 @@ int main(int argc, char **argv) {
     self.emcc_args += ['-std=c++11']
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_parameter_pack')
 
+  def test_em_asm_arguments_side_effects(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_arguments_side_effects', force_c=True)
+    self.emcc_args += ['-std=c++11']
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_arguments_side_effects')
+
   @parameterized({
     'normal': ([],),
     'linked': (['-s', 'MAIN_MODULE'],),


### PR DESCRIPTION
This fixes #9030.

Note that tests are run with C++03, even though variadic templates are used in `em_asm.h` (consequently, in `emscripten.h` and most test cases as well). It was the case before this PR as well: use of C++11 features is a warning only in Clang, and and warnings are ignored in system headers, see #9053 for details.

So, I had to manually implement some STL classes.

Also note that the test is added in a commit before the fix, so at 871f755 tests do not compile. Let me know if I should swap last two commits so the history is always consistent.

Following tests ran successfully both before (9 tests per line) and after the change (10 tests per line):

```
python2 tests/runner.py wasm0.*em_asm*
python2 tests/runner.py wasm1.*em_asm*
python2 tests/runner.py wasm2.*em_asm*
python2 tests/runner.py wasm3.*em_asm*
python2 tests/runner.py wasms.*em_asm*
python2 tests/runner.py wasmz.*em_asm*
```
