### PR TITLE
Disable other.test_js_optimizer_parse_error on windows until we figure that out.

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8572,6 +8572,7 @@ end
     if not self.is_wasm_backend(): # TODO: wasm backend main module
       self.do_other_test(os.path.join('other', 'extern_weak'), emcc_args=['-s', 'MAIN_MODULE=1', '-DLINKABLE'])
 
+  @no_windows('https://github.com/emscripten-core/emscripten/issues/9057')
   def test_js_optimizer_parse_error(self):
     # check we show a proper understandable error for JS parse problems
     create_test_file('src.cpp', r'''


### PR DESCRIPTION
This will unbreak the roll.