### PR TITLE
Add a flag NODEJS_CATCH_REJECTION to control handling of unhandled rejections in node

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -519,9 +519,17 @@ var EXCEPTION_CATCHING_WHITELIST = [];
 // longer do that, and exceptions work normally, which can be useful for libraries
 // or programs that don't need exit() to work.
 
-// For more explanations of this option, please visit
-// https://github.com/emscripten-core/emscripten/wiki/Asyncify
+// Emscripten uses an ExitStatus exception to halt when exit() is called.
+// With this option, we prevent that from showing up as an unhandled
+// exception.
 var NODEJS_CATCH_EXIT = 1;
+
+// Catch unhandled rejections in node. Without this, node may print the error,
+// and that this behavior will change in future node, wait a few seconds, and
+// then exit with 0 (which hides the error if you don't read the log). With
+// this, we catch any unhandled rejection and throw an actual error, which will
+// make the process exit immediately with a non-0 return code.
+var NODEJS_CATCH_REJECTION = 1;
 
 // Whether to enable asyncify transformation
 // This allows to inject some async functions to the C code that appear to be sync

--- a/src/shell.js
+++ b/src/shell.js
@@ -167,9 +167,10 @@ if (ENVIRONMENT_IS_NODE) {
     }
   });
 #endif
-  // Currently node will swallow unhandled rejections, but this behavior is
-  // deprecated, and in the future it will exit with error status.
+
+#if NODEJS_CATCH_REJECTION
   process['on']('unhandledRejection', abort);
+#endif
 
   Module['quit'] = function(status) {
     process['exit'](status);

--- a/src/shell.js
+++ b/src/shell.js
@@ -167,6 +167,9 @@ if (ENVIRONMENT_IS_NODE) {
     }
   });
 #endif
+  // Currently node will swallow unhandled rejections, but this behavior is
+  // deprecated, and in the future it will exit with error status.
+  process['on']('unhandledRejection', abort);
 
   Module['quit'] = function(status) {
     process['exit'](status);

--- a/src/shell.js
+++ b/src/shell.js
@@ -167,9 +167,6 @@ if (ENVIRONMENT_IS_NODE) {
     }
   });
 #endif
-  // Currently node will swallow unhandled rejections, but this behavior is
-  // deprecated, and in the future it will exit with error status.
-  process['on']('unhandledRejection', abort);
 
   Module['quit'] = function(status) {
     process['exit'](status);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4694,10 +4694,9 @@ main()
       print(name)
       run_process([PYTHON, EMXX, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
       if fail:
-        proc = run_process(NODE_JS + ['a.out.js'], stdout=PIPE, stderr=PIPE, check=False)
-        self.assertNotEqual(proc.returncode, 0)
+        self.assertContained('abort(-1)', run_js('a.out.js', stdout=PIPE, stderr=STDOUT, assert_returncode=None))
       else:
-        self.assertContained('hello, world!', run_js('a.out.js', stderr=PIPE))
+        self.assertContained('hello, world!', run_js('a.out.js'))
 
     with env_modify({'EMCC_FORCE_STDLIBS': None}):
       test('normal') # normally is ok

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4694,9 +4694,10 @@ main()
       print(name)
       run_process([PYTHON, EMXX, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
       if fail:
-        self.assertContained('abort(-1)', run_js('a.out.js', stdout=PIPE, stderr=STDOUT, assert_returncode=None))
+        proc = run_process(NODE_JS + ['a.out.js'], stdout=PIPE, stderr=PIPE, check=False)
+        self.assertNotEqual(proc.returncode, 0)
       else:
-        self.assertContained('hello, world!', run_js('a.out.js'))
+        self.assertContained('hello, world!', run_js('a.out.js', stderr=PIPE))
 
     with env_modify({'EMCC_FORCE_STDLIBS': None}):
       test('normal') # normally is ok


### PR DESCRIPTION
Helps #7855, #9028 in that it enables users to disable this.

We can't disable it by default because due to the current node behavior, some errors would not be reported (the node return code would be 0).