### PR TITLE
Always log from abort()

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -405,13 +405,9 @@ function abort(what) {
 #if USE_PTHREADS
   if (ENVIRONMENT_IS_PTHREAD) console.error('Pthread aborting at ' + new Error().stack);
 #endif
-  if (what !== undefined) {
-    what += '';
-    out(what);
-    err(what);
-  } else {
-    what = '';
-  }
+  what += '';
+  out(what);
+  err(what);
 
   ABORT = true;
   EXITSTATUS = 1;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2250,7 +2250,7 @@ The current type of b is: 9
   def test_intentional_fault(self):
     # Some programs intentionally segfault themselves, we should compile that into a throw
     src = open(path_from_root('tests', 'core', 'test_intentional_fault.c')).read()
-    self.do_run(src, 'abort()' if self.run_name != 'asm2g' else 'abort(segmentation fault')
+    self.do_run(src, 'abort(' if self.run_name != 'asm2g' else 'abort(segmentation fault')
 
   def test_trickystring(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_trickystring')


### PR DESCRIPTION
Even if no parameter is provided, to avoid confusion (exiting without anything logged can be puzzling).

Also the code is shorter this way!