### PR TITLE
Add integer promotion tests for EM_ASM

### DIFF
--- a/tests/core/test_em_asm_types.cpp
+++ b/tests/core/test_em_asm_types.cpp
@@ -1,0 +1,47 @@
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <emscripten.h>
+
+struct WithBitField {
+    unsigned x:2;
+};
+
+enum SomeEnum { SIXTY = 60 };
+
+int main(int argc, char **argv) {
+  // Ensure that a subset of default argument converions is held.
+  // Promotions of arrays, function/member pointers and objects implicitly
+  // convertable to numbers are excluded because they will not be translated
+  // to corresponding JS objects.
+#define TEST_TYPE(type, value) EM_ASM({console.log(#type, $0);}, (type)(value));
+  TEST_TYPE(int*, 0);
+  TEST_TYPE(float, 1.5f);
+  TEST_TYPE(double, 2.5);
+  TEST_TYPE(char, 10);
+  TEST_TYPE(signed char, -10);
+  TEST_TYPE(unsigned char, 10);
+  TEST_TYPE(short, -20);
+  TEST_TYPE(unsigned short, 20);
+  TEST_TYPE(int, -30);
+  TEST_TYPE(unsigned int, 30);
+  TEST_TYPE(long, -40);
+  TEST_TYPE(unsigned long, 40);
+
+  struct WithBitField w;
+  w.x = 3;
+  EM_ASM({ console.log('bit field', $0); }, w.x);
+
+#ifdef __cplusplus
+  TEST_TYPE(bool, true);
+  TEST_TYPE(wchar_t, 50);
+#else
+  EM_ASM({console.log('bool 1')});
+  EM_ASM({console.log('wchar_t 50')});
+#endif
+
+  TEST_TYPE(enum SomeEnum, SIXTY);
+  return 0;
+}

--- a/tests/core/test_em_asm_types.out
+++ b/tests/core/test_em_asm_types.out
@@ -1,0 +1,16 @@
+int* 0
+float 1.5
+double 2.5
+char 10
+signed char -10
+unsigned char 10
+short -20
+unsigned short 20
+int -30
+unsigned int 30
+long -40
+unsigned long 40
+bit field 3
+bool 1
+wchar_t 50
+enum SomeEnum 60

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1779,6 +1779,10 @@ int main(int argc, char **argv) {
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_unicode')
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_unicode', force_c=True)
 
+  def test_em_asm_types(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_types')
+    self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_types', force_c=True)
+
   def test_em_asm_unused_arguments(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_em_asm_unused_arguments')
 


### PR DESCRIPTION
This is a part of #9054 : I've noticed that `EM_ASM` accepts not only `int`s, but `unsigned char`s and some other types as well (e.g. in [this test failure](https://circleci.com/gh/emscripten-core/emscripten/153580) `EM_ASM` gets a `uint8_t`, which turns out to be `unsigned char`).

This is, however, not tested in core tests, so I've added some.

Tests ran: `python2 tests/runner.py *.test_em_asm_types`, 22 ran, 2 failed (`asmi` and `asm2i`, I have LLVM backend only: `EMTERPRETIFY is not supported by the LLVM wasm backend`).