### PR TITLE
Use mainReadsParams metadata from wasm-emscripten-finalize

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -704,6 +704,7 @@ def update_settings_glue(metadata):
       # size does not include the reserved slot at zero for the null pointer.
       # Instead we use __table_base to offset the elements by 1.
       shared.Settings.WASM_TABLE_SIZE += 1
+    shared.Settings.MAIN_READS_PARAMS = metadata['mainReadsParams']
 
 
 # static code hooks

--- a/emscripten.py
+++ b/emscripten.py
@@ -2524,6 +2524,7 @@ def load_metadata_wasm(metadata_raw, DEBUG):
     'asmConsts': {},
     'invokeFuncs': [],
     'features': [],
+    'mainReadsParams': 1,
   }
 
   assert 'tableSize' in metadata_json.keys()

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -179,6 +179,9 @@ Module['callMain'] = function callMain(args) {
     HEAP32[(argv >> 2) + i] = allocateUTF8OnStack(args[i - 1]);
   }
   HEAP32[(argv >> 2) + argc] = 0;
+#else
+  var argc = 0;
+  var argv = 0;
 #endif // MAIN_READS_PARAMS
 
 #if EMTERPRETIFY_ASYNC
@@ -190,19 +193,13 @@ Module['callMain'] = function callMain(args) {
     var start = Date.now();
 #endif
 
-    var ret = Module[
 #if PROXY_TO_PTHREAD
-      // User requested the PROXY_TO_PTHREAD option, so call a stub main which pthread_create()s a new thread
-      // that will call the user's real main() for the application.
-      '_proxy_main'
+    // User requested the PROXY_TO_PTHREAD option, so call a stub main which pthread_create()s a new thread
+    // that will call the user's real main() for the application.
+    var ret = Module['_proxy_main'](argc, argv);
 #else
-      '_main'
+    var ret = Module['_main'](argc, argv);
 #endif
-    ](
-#if MAIN_READS_PARAMS
-      argc, argv
-#endif
-    );
 
 #if BENCHMARK
     Module.realPrint('main() took ' + (Date.now() - start) + ' milliseconds');

--- a/src/settings.js
+++ b/src/settings.js
@@ -1485,6 +1485,9 @@ var LOAD_SOURCE_MAP = 0;
 // Whether embind has been enabled.
 var EMBIND = 0;
 
+// Whether the main() function reads the argc/argv parameters.
+var MAIN_READS_PARAMS = 0;
+
 // Legacy settings that have been removed or renamed.
 // For renamed settings the format is:
 // [OLD_NAME, NEW_NAME]

--- a/src/settings.js
+++ b/src/settings.js
@@ -1486,7 +1486,7 @@ var LOAD_SOURCE_MAP = 0;
 var EMBIND = 0;
 
 // Whether the main() function reads the argc/argv parameters.
-var MAIN_READS_PARAMS = 0;
+var MAIN_READS_PARAMS = 1;
 
 // Legacy settings that have been removed or renamed.
 // For renamed settings the format is:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8037,9 +8037,9 @@ int main() {
     'O0': ([],      17, [], ['waka'], 22185, 11,  17, 57), # noqa
     'O1': (['-O1'], 15, [], ['waka'], 10415,  9,  14, 31), # noqa
     'O2': (['-O2'], 15, [], ['waka'], 10183,  9,  14, 25), # noqa
-    'O3': (['-O3'],  5, [], [],        2353,  7,   3, 14), # noqa; in -O3, -Os and -Oz we metadce
-    'Os': (['-Os'],  5, [], [],        2310,  7,   3, 15), # noqa
-    'Oz': (['-Oz'],  5, [], [],        2272,  7,   2, 14), # noqa
+    'O3': (['-O3'],  5, [], [],        2353,  7,   2, 13), # noqa; in -O3, -Os and -Oz we metadce
+    'Os': (['-Os'],  5, [], [],        2310,  7,   2, 14), # noqa
+    'Oz': (['-Oz'],  5, [], [],        2272,  7,   1, 13), # noqa
     # finally, check what happens when we export nothing. wasm should be almost empty
     'export_nothing':
           (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],


### PR DESCRIPTION
This lets the wasm backend path not emit code to set up argc/argv if main doesn't need them. It also avoids that code bringing in some string and stack allocation support (metadce improvements are from the latter).

This reduces `--closure 1 -O3` size of hello world by almost 10%.