### PR TITLE
Fix #9057: test_js_optimizer_parse_error fails on Windows

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -419,3 +419,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Christian Clauss <cclauss@me.com> (copyright owned by IBM)
 * Henry Kleynhans <hkleynhans@bloomberg.net> (copyright owned by Bloomberg L.P.)
 * FUJI Goro <g.psy.va@gmail.com>
+* Egor Suvorov <esuvorov@think-cell.com> (copyright owned by think-cell Software GmbH)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8572,7 +8572,6 @@ end
     if not self.is_wasm_backend(): # TODO: wasm backend main module
       self.do_other_test(os.path.join('other', 'extern_weak'), emcc_args=['-s', 'MAIN_MODULE=1', '-DLINKABLE'])
 
-  @no_windows('https://github.com/emscripten-core/emscripten/issues/9057')
   def test_js_optimizer_parse_error(self):
     # check we show a proper understandable error for JS parse problems
     create_test_file('src.cpp', r'''
@@ -8583,7 +8582,10 @@ int main() {
   });
 }
 ''')
-    stderr = self.expect_fail([PYTHON, EMCC, 'src.cpp', '-O2'])
+    # Due to https://github.com/emscripten-core/emscripten/issues/9068 we would like to get
+    # raw binary output of emcc and filter out any `\r` on Windows manually, Python
+    # will replace stray `\r` with `\n` and create a new line instead.
+    stderr = self.expect_fail([PYTHON, EMCC, 'src.cpp', '-O2'], universal_newlines=False)
     # wasm backend output doesn't have spaces in the EM_ASM function bodies
     self.assertContained(('''
 var ASM_CONSTS = [function() { var x = !<->5.; }];

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -161,7 +161,7 @@ class Py2CompletedProcess:
       raise Py2CalledProcessError(returncode=self.returncode, cmd=self.args, output=self.stdout, stderr=self.stderr)
 
 
-def run_process(cmd, check=True, input=None, universal_newlines=True, *args, **kw):
+def run_process(cmd, check=True, input=None, *args, **kw):
   kw.setdefault('universal_newlines', True)
 
   debug_text = '%sexecuted %s' % ('successfully ' if check else '', ' '.join(cmd))


### PR DESCRIPTION
See #9057 for discussion. This PR is based on #9070 (first two commits belong to #9070).