### PR TITLE
Implement source map support for multithreaded LSan

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,7 @@ Current Trunk
  - Drop ExitStatus from inheriting from Error(), as that could capture the whole
    global scope, preventing temporary variables at page startup from being garbage
    collected. (#9108)
+ - `__builtin_return_address` now requires `-s USE_OFFSET_CONVERTER=1` to work. (#9073)
 
 v.1.38.40: 07/24/2019
 ---------------------

--- a/emcc.py
+++ b/emcc.py
@@ -1507,6 +1507,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         elif arg.startswith('-fno-sanitize='):
           sanitize.difference_update(arg.split('=', 1)[1].split(','))
 
+      if sanitize:
+        shared.Settings.USE_OFFSET_CONVERTER = 1
+
       if sanitize & UBSAN_SANITIZERS:
         if '-fsanitize-minimal-runtime' in newargs:
           shared.Settings.UBSAN_RUNTIME = 1

--- a/src/library.js
+++ b/src/library.js
@@ -4423,6 +4423,9 @@ LibraryManager.library = {
   // The exact return value depends in whether we are running WASM or JS, and whether
   // the engine supports offsets into WASM. See the function body for details.
   emscripten_generate_pc: function(frame) {
+#if !USE_OFFSET_CONVERTER
+    abort('Cannot use emscripten_generate_pc without -s USE_OFFSET_CONVERTER');
+#endif
     var match;
 
     if (match = /\bwasm-function\[\d+\]:(0x[0-9a-f]+)/.exec(frame)) {

--- a/src/library.js
+++ b/src/library.js
@@ -4424,7 +4424,7 @@ LibraryManager.library = {
   // the engine supports offsets into WASM. See the function body for details.
   emscripten_generate_pc: function(frame) {
 #if !USE_OFFSET_CONVERTER
-    abort('Cannot use emscripten_generate_pc without -s USE_OFFSET_CONVERTER');
+    abort('Cannot use emscripten_generate_pc (needed by __builtin_return_address) without -s USE_OFFSET_CONVERTER');
 #endif
     var match;
 
@@ -4435,8 +4435,7 @@ LibraryManager.library = {
       // other engines only give function index and offset in the function,
       // so we try using the offset converter. If that doesn't work,
       // we pack index and offset into a "return address"
-      return wasmOffsetConverter ? wasmOffsetConverter.convert(+match[1], +match[2]) :
-             (+match[1] << 16) + +match[2];
+      return wasmOffsetConverter.convert(+match[1], +match[2]);
     } else if (match = /:(\d+):\d+(?:\)|$)/.exec(frame)) {
       // if we are in js, we can use the js line number as the "return address"
       // this should work for wasm2js and fastcomp

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -350,6 +350,12 @@ var LibraryPThread = {
 #if WASM
           wasmMemory: wasmMemory,
           wasmModule: wasmModule,
+#if LOAD_SOURCE_MAP
+          wasmSourceMap: wasmSourceMap,
+#endif
+#if USE_OFFSET_CONVERTER
+          wasmOffsetConverter: wasmOffsetConverter,
+#endif
 #else
           buffer: HEAPU8.buffer,
           asmJsUrlOrBlob: Module["asmJsUrlOrBlob"],

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -878,8 +878,6 @@ function getBinaryPromise() {
 
 #if LOAD_SOURCE_MAP
 var wasmSourceMap;
-#if USE_PTHREADS
-#endif
 #include "source_map_support.js"
 #endif
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -878,10 +878,12 @@ function getBinaryPromise() {
 
 #if LOAD_SOURCE_MAP
 var wasmSourceMap;
+#if USE_PTHREADS
+#endif
 #include "source_map_support.js"
 #endif
 
-#if 'emscripten_generate_pc' in addedLibraryItems
+#if USE_OFFSET_CONVERTER
 var wasmOffsetConverter;
 #include "wasm_offset_converter.js"
 #endif
@@ -1042,13 +1044,13 @@ function createWasm(env) {
 #endif
   }
 
-#if 'emscripten_generate_pc' in addedLibraryItems
+#if USE_OFFSET_CONVERTER
   {{{ runOnMainThread("addRunDependency('offset-converter');") }}}
 #endif
 
   function instantiateArrayBuffer(receiver) {
     return getBinaryPromise().then(function(binary) {
-#if 'emscripten_generate_pc' in addedLibraryItems
+#if USE_OFFSET_CONVERTER
       wasmOffsetConverter = new WasmOffsetConverter(binary);
       {{{ runOnMainThread("removeRunDependency('offset-converter');") }}}
 #endif
@@ -1067,7 +1069,7 @@ function createWasm(env) {
         !isDataURI(wasmBinaryFile) &&
         typeof fetch === 'function') {
       fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
-#if 'emscripten_generate_pc' in addedLibraryItems
+#if USE_OFFSET_CONVERTER
         // This doesn't actually do another request, it only copies the Response object.
         // Copying lets us consume it independently of WebAssembly.instantiateStreaming.
         response.clone().arrayBuffer().then(function (buffer) {
@@ -1095,7 +1097,7 @@ function createWasm(env) {
     var binary;
     try {
       binary = getBinary();
-#if 'emscripten_generate_pc' in addedLibraryItems
+#if USE_OFFSET_CONVERTER
       wasmOffsetConverter = new WasmOffsetConverter(binary);
       {{{ runOnMainThread("removeRunDependency('offset-converter');") }}}
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -1544,7 +1544,7 @@ var ASAN_SHADOW_SIZE = 33554432;
 var LOAD_SOURCE_MAP = 0;
 
 // Whether we should use the offset converter.
-// This is needed for older versions of v8 that does not give the hex module offset
+// This is needed for older versions of v8 (<7.7) that does not give the hex module offset
 // into wasm binary in stack traces, as well as for avoiding using source map
 // entries across function boundaries.
 var USE_OFFSET_CONVERTER = 0;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1543,6 +1543,12 @@ var ASAN_SHADOW_SIZE = 33554432;
 // This is enabled automatically when using -g4 with sanitizers.
 var LOAD_SOURCE_MAP = 0;
 
+// Whether we should use the offset converter.
+// This is needed for older versions of v8 that does not give the hex module offset
+// into wasm binary in stack traces, as well as for avoiding using source map
+// entries across function boundaries.
+var USE_OFFSET_CONVERTER = 0;
+
 // Whether embind has been enabled.
 var EMBIND = 0;
 

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -56,7 +56,7 @@ function WasmSourceMap(sourceMap) {
 
 WasmSourceMap.prototype.lookup = function (offset) {
   var normalized = this.normalizeOffset(offset);
-#if 'emscripten_generate_pc' in addedLibraryItems
+#if USE_OFFSET_CONVERTER
   if (!wasmOffsetConverter.isSameFunc(offset, normalized)) {
     return null;
   }

--- a/src/worker.js
+++ b/src/worker.js
@@ -71,6 +71,9 @@ function threadAlert() {
 var err = threadPrintErr;
 this.alert = threadAlert;
 
+// When using postMessage to send an object, it is processed by the structured clone algorithm.
+// The prototype, and hence methods, on that object is then lost. This function adds back the lost prototype.
+// This does not work with nested objects that has prototypes, but it suffices for WasmSourceMap and WasmOffsetConverter.
 function resetPrototype(constructor, attrs) {
   var object = Object.create(constructor.prototype);
   for (var key in attrs) {

--- a/tests/pthread/test_pthread_lsan_leak.js
+++ b/tests/pthread/test_pthread_lsan_leak.js
@@ -4,12 +4,19 @@
     if (text == 'LSAN TEST COMPLETE') {
       var result = output.join('\n');
       var passed = [
-        'Direct leak of 2048 byte(s) in 1 object(s) allocated from',
         'Direct leak of 3432 byte(s) in 1 object(s) allocated from',
-        'Direct leak of 1234 byte(s) in 1 object(s) allocated from',
+        'Direct leak of 2048 byte(s) in 1 object(s) allocated from',
+        'test_pthread_lsan_leak.cpp:39:10',
         'Direct leak of 1337 byte(s) in 1 object(s) allocated from',
-        'Direct leak of 42 byte(s) in 1 object(s) allocated from',
+        'test_pthread_lsan_leak.cpp:33:16',
+        'Direct leak of 1234 byte(s) in 1 object(s) allocated from',
         'Direct leak of 420 byte(s) in 1 object(s) allocated from',
+        'test_pthread_lsan_leak.cpp:34:13',
+        'Direct leak of 42 byte(s) in 1 object(s) allocated from',
+        'test_pthread_lsan_leak.cpp:12:21',
+        'test_pthread_lsan_leak.cpp:38:3',
+        'SUMMARY: LeakSanitizer: 8513 byte(s) leaked in 6 allocation(s).',
+        ''
       ].every(function (snippet) {
         return result.indexOf(snippet) >= 0;
       });

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3903,13 +3903,13 @@ window.close = function() {
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_tls_main.cpp'), expected='1337', args=['-s', 'USE_PTHREADS', '-std=c++11'])
 
   @parameterized({
-    'leak': ['test_pthread_lsan_leak'],
+    'leak': ['test_pthread_lsan_leak', ['-g4']],
     'no_leak': ['test_pthread_lsan_no_leak'],
   })
   @no_fastcomp('LSan is only supported on WASM backend')
   @requires_threads
-  def test_pthread_lsan(self, name):
-    self.btest(path_from_root('tests', 'pthread', name + '.cpp'), expected='1', args=['-fsanitize=leak', '-s', 'TOTAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-std=c++11', '--pre-js', path_from_root('tests', 'pthread', name + '.js')])
+  def test_pthread_lsan(self, name, args=[]):
+    self.btest(path_from_root('tests', 'pthread', name + '.cpp'), expected='1', args=['-fsanitize=leak', '-s', 'TOTAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-std=c++11', '--pre-js', path_from_root('tests', 'pthread', name + '.js')] + args)
 
   # Tests MAIN_THREAD_EM_ASM_INT() function call signatures.
   @no_wasm_backend('MAIN_THREAD_EM_ASM() not yet implemented in Wasm backend')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7765,6 +7765,7 @@ extern "C" {
   @no_fastcomp('return address not supported on fastcomp')
   @no_optimize('return address test cannot work with optimizations')
   def test_return_address(self):
+    self.emcc_args += ['-s', 'USE_OFFSET_CONVERTER']
     self.do_run(open(path_from_root('tests', 'core', 'test_return_address.cpp')).read(), 'passed')
 
   @no_fastcomp('ubsan not supported on fastcomp')


### PR DESCRIPTION
Changes:

* Pass the offset converter and source map information to workers.
  * Add a function called `resetPrototype` to add back the methods that are lost to the structured clone algorithm
* Since the offset converter now interacts with `library_pthread.js`, we can't use `#if 'emscripten_generate_pc' in addedLibraryItems`. We are forced to introduce `-s USE_OFFSET_CONVERTER=1` to enable the functionality. When using sanitizers, this is done automatically.
  * As a consequence, the offset converter is always available to `emscripten_generate_pc`, so we can avoid the bit packing of function and offsets.
  * As a consequence, `__builtin_return_address` no longer works without `-s USE_OFFSET_CONVERTER=1`.

Limitations: Function names are not available for frames on different threads. This will be addressed separately.