### PR TITLE
Remove Fastcomp's Asyncify, which has been deprecated for years

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,11 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+ - Remove fastcomp's implementation of Asyncify. This has been deprecated for
+   a long time, since we added Emterpreter-Async, and now we have a new Asyncify
+   implementation in the upstream wasm backend. It is recommended to upgrade to
+   the upstream backend and use Asyncify there if you need it. (If you do still
+   need the older version, you can use 1.38.40.)
 
 v.1.38.40: 07/24/2019
 ---------------------

--- a/emcc.py
+++ b/emcc.py
@@ -1220,6 +1220,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
       shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
 
+    if shared.Settings.ASYNCIFY:
+      if not shared.Settings.WASM_BACKEND:
+        exit_with_error('ASYNCIFY has been removed from fastcomp. There is a new implementation which can be used in the upstream wasm backend.')
+
     if shared.Settings.EMTERPRETIFY:
       shared.Settings.FINALIZE_ASM_JS = 0
       shared.Settings.SIMPLIFY_IFS = 0 # this is just harmful for emterpreting

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -23,7 +23,7 @@ for general background and details of how it works internally. The following
 expands on the Emscripten examples from that post.
 
 .. note:: This post talks about Asyncify using the new LLVM wasm backend.
-          There is also an older Asyncify implementation for the old fastcomp
+          There was an older Asyncify implementation for the old fastcomp
           backend. The two algorithms and implementations are entirely separate,
           so if you are using fastcomp, these docs may not be accurate - you
           should upgrade to the wasm backend and new Asyncify!

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2666,13 +2666,7 @@ Module["preRun"].push(function () {
 
   def test_wget(self):
     create_test_file('test.txt', 'emscripten')
-    if not self.is_wasm_backend():
-      print('asyncify+emterpreter')
-      self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'ASYNCIFY=1', '-s', 'EMTERPRETIFY=1'])
-      print('emterpreter by itself')
-      self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'])
-    else:
-      self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'ASYNCIFY=1'])
+    self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=self.get_async_args())
 
   def test_wget_data(self):
     create_test_file('test.txt', 'emscripten')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2672,8 +2672,6 @@ Module["preRun"].push(function () {
       self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'ASYNCIFY=1', '-s', 'EMTERPRETIFY=1'])
       print('emterpreter by itself')
       self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'])
-    else:
-      self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'ASYNCIFY=1'])
 
   def test_wget_data(self):
     create_test_file('test.txt', 'emscripten')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2667,11 +2667,12 @@ Module["preRun"].push(function () {
   def test_wget(self):
     create_test_file('test.txt', 'emscripten')
     if not self.is_wasm_backend():
-      self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'ASYNCIFY=1'])
       print('asyncify+emterpreter')
       self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'ASYNCIFY=1', '-s', 'EMTERPRETIFY=1'])
       print('emterpreter by itself')
       self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'EMTERPRETIFY=1', '-s', 'EMTERPRETIFY_ASYNC=1'])
+    else:
+      self.btest(path_from_root('tests', 'test_wget.c'), expected='1', args=['-s', 'ASYNCIFY=1'])
 
   def test_wget_data(self):
     create_test_file('test.txt', 'emscripten')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7169,13 +7169,8 @@ Success!
     if self.is_wasm_backend():
       self.set_setting('ASYNCIFY', 1)
     else:
-      if not emterpretify:
-        if self.is_emterpreter():
-          self.skipTest("don't test both emterpretify and asyncify at once")
-        self.set_setting('ASYNCIFY', 1)
-      else:
-        self.set_setting('EMTERPRETIFY', 1)
-        self.set_setting('EMTERPRETIFY_ASYNC', 1)
+      self.set_setting('EMTERPRETIFY', 1)
+      self.set_setting('EMTERPRETIFY_ASYNC', 1)
 
     src = r'''
 #include <stdio.h>
@@ -7474,10 +7469,12 @@ extern "C" {
     self.do_run(src, '*leaf-0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*')
 
   @no_wasm_backend('ASYNCIFY coroutines are not yet supported in the LLVM wasm backend')
+  @no_fastcomp('ASYNCIFY has been removed from fastcomp')
   def test_coroutine_asyncify(self):
     self.do_test_coroutine({'ASYNCIFY': 1})
 
   @no_wasm_backend('ASYNCIFY is not supported in the LLVM wasm backend')
+  @no_fastcomp('ASYNCIFY has been removed from fastcomp')
   def test_asyncify_unused(self):
     # test a program not using asyncify, but the pref is set
     self.set_setting('ASYNCIFY', 1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7168,9 +7168,11 @@ Success!
 
     if self.is_wasm_backend():
       self.set_setting('ASYNCIFY', 1)
-    else:
+    elif emterpretify:
       self.set_setting('EMTERPRETIFY', 1)
       self.set_setting('EMTERPRETIFY_ASYNC', 1)
+    else:
+      self.skipTest('fastcomp Asyncify was removed')
 
     src = r'''
 #include <stdio.h>


### PR DESCRIPTION
This was deprecated around when Emterpreter-Async came around, which was a long time ago. Also we now have a new Asyncify in the upstream backend, so it's a good time to remove the old one.

This will also make work on the new one easier (e.g. it had a whitelist already, and supporting two variants would be annoying).

People that still need Asyncify can use an older version (1.38.40), but upgrading to upstream and the new Asyncify is recommended.