### PR TITLE
More INCOMING_MODULE_JS_API optimizations

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -360,9 +360,9 @@ function exportRuntime() {
         extra = '. Alternatively, forcing filesystem support (-s FORCE_FILESYSTEM=1) can export this for you';
       }
       if (!isNumber) {
-        return 'if (!Module["' + name + '"]) Module["' + name + '"] = function() { abort("\'' + name + '\' was not exported. add it to EXTRA_EXPORTED_RUNTIME_METHODS (see the FAQ)' + extra + '") };';
+        return 'if (!Object.getOwnPropertyDescriptor(Module, "' + name + '")) Module["' + name + '"] = function() { abort("\'' + name + '\' was not exported. add it to EXTRA_EXPORTED_RUNTIME_METHODS (see the FAQ)' + extra + '") };';
       } else {
-        return 'if (!Module["' + name + '"]) Object.defineProperty(Module, "' + name + '", { get: function() { abort("\'' + name + '\' was not exported. add it to EXTRA_EXPORTED_RUNTIME_METHODS (see the FAQ)' + extra + '") } });';
+        return 'if (!Object.getOwnPropertyDescriptor(Module, "' + name + '")) Object.defineProperty(Module, "' + name + '", { get: function() { abort("\'' + name + '\' was not exported. add it to EXTRA_EXPORTED_RUNTIME_METHODS (see the FAQ)' + extra + '") } });';
       }
     }
     return '';

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1614,3 +1614,20 @@ function makeModuleReceive(localName, moduleName) {
   // but sometimes they must differ.
   return "if (Module['" + moduleName + "']) " + localName + " = Module['" + moduleName + "'];";
 }
+
+function makeModuleReceiveWithVar(localName, moduleName, defaultValue) {
+  if (!moduleName) moduleName = localName;
+  var varDef = 'var ' + localName;
+  if (!expectToReceiveOnModule(moduleName)) {
+    if (defaultValue) {
+      varDef += ' = ' + defaultValue;
+    }
+    return varDef + ';';
+  }
+  if (defaultValue) {
+    return varDef + " = Module['" + moduleName + "'] || " + defaultValue + ";";
+  } else {
+    return varDef + ';\n' +
+           makeModuleReceive(localName, moduleName);
+  }
+}

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1623,7 +1623,7 @@ function makeModuleReceive(localName, moduleName) {
   return ret;
 }
 
-function makeModuleReceiveWithVar(localName, moduleName, defaultValue) {
+function makeModuleReceiveWithVar(localName, moduleName, defaultValue, noAssert) {
   if (!moduleName) moduleName = localName;
   var ret = 'var ' + localName;
   if (!expectToReceiveOnModule(moduleName)) {
@@ -1640,6 +1640,8 @@ function makeModuleReceiveWithVar(localName, moduleName, defaultValue) {
       return ret;
     }
   }
-  ret += makeRemovedModuleAPIAssert(moduleName, localName);
+  if (!noAssert) {
+    ret += makeRemovedModuleAPIAssert(moduleName, localName);
+  }
   return ret;
 }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1607,7 +1607,7 @@ function expectToReceiveOnModule(name) {
 function makeRemovedModuleAPIAssert(moduleName, localName) {
   if (!ASSERTIONS) return '';
   if (!localName) localName = moduleName;
-  return "\nif (!Object.getOwnPropertyDescriptor(Module, '" + moduleName + "')) Object.defineProperty(Module, '" + moduleName + "', { get: function() { abort('Module." + moduleName + " has been replaced with plain " + localName + "') } });";
+  return "if (!Object.getOwnPropertyDescriptor(Module, '" + moduleName + "')) Object.defineProperty(Module, '" + moduleName + "', { get: function() { abort('Module." + moduleName + " has been replaced with plain " + localName + "') } });";
 }
 
 // Make code to receive a value on the incoming Module object.
@@ -1635,7 +1635,7 @@ function makeModuleReceiveWithVar(localName, moduleName, defaultValue) {
     if (defaultValue) {
       ret += " = Module['" + moduleName + "'] || " + defaultValue + ";";
     } else {
-      ret += ';\n' +
+      ret += ';' +
              makeModuleReceive(localName, moduleName);
       return ret;
     }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1604,30 +1604,42 @@ function expectToReceiveOnModule(name) {
   return name in INCOMING_MODULE_JS_API;
 }
 
+function makeRemovedModuleAPIAssert(moduleName, localName) {
+  if (!ASSERTIONS) return '';
+  if (!localName) localName = moduleName;
+  return "\nif (!Object.getOwnPropertyDescriptor(Module, '" + moduleName + "')) Object.defineProperty(Module, '" + moduleName + "', { get: function() { abort('Module." + moduleName + " has been replaced with plain " + localName + "') } });";
+}
+
 // Make code to receive a value on the incoming Module object.
 function makeModuleReceive(localName, moduleName) {
   if (!moduleName) moduleName = localName;
-  if (!expectToReceiveOnModule(moduleName)) {
-    return '';
+  var ret = '';
+  if (expectToReceiveOnModule(moduleName)) {
+    // Usually the local we use is the same as the Module property name,
+    // but sometimes they must differ.
+    ret = "if (Module['" + moduleName + "']) " + localName + " = Module['" + moduleName + "'];";
   }
-  // Usually the local we use is the same as the Module property name,
-  // but sometimes they must differ.
-  return "if (Module['" + moduleName + "']) " + localName + " = Module['" + moduleName + "'];";
+  ret += makeRemovedModuleAPIAssert(moduleName, localName);
+  return ret;
 }
 
 function makeModuleReceiveWithVar(localName, moduleName, defaultValue) {
   if (!moduleName) moduleName = localName;
-  var varDef = 'var ' + localName;
+  var ret = 'var ' + localName;
   if (!expectToReceiveOnModule(moduleName)) {
     if (defaultValue) {
-      varDef += ' = ' + defaultValue;
+      ret += ' = ' + defaultValue;
     }
-    return varDef + ';';
-  }
-  if (defaultValue) {
-    return varDef + " = Module['" + moduleName + "'] || " + defaultValue + ";";
+    ret += ';';
   } else {
-    return varDef + ';\n' +
-           makeModuleReceive(localName, moduleName);
+    if (defaultValue) {
+      ret += " = Module['" + moduleName + "'] || " + defaultValue + ";";
+    } else {
+      ret += ';\n' +
+             makeModuleReceive(localName, moduleName);
+      return ret;
+    }
   }
+  ret += makeRemovedModuleAPIAssert(moduleName, localName);
+  return ret;
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -13,6 +13,8 @@ Module.realPrint = out;
 out = err = function(){};
 #endif
 
+{{{ makeModuleReceiveWithVar('wasmBinary') }}}
+
 #if WASM2JS
 #include "wasm2js.js"
 #endif
@@ -338,7 +340,7 @@ if (Module['TOTAL_STACK']) assert(TOTAL_STACK === Module['TOTAL_STACK'], 'the st
 Module['TOTAL_STACK'] = TOTAL_STACK;
 #endif
 
-var INITIAL_TOTAL_MEMORY = Module['TOTAL_MEMORY'] || {{{ TOTAL_MEMORY }}};
+{{{ makeModuleReceiveWithVar('INITIAL_TOTAL_MEMORY', 'TOTAL_MEMORY', TOTAL_MEMORY) }}}
 
 #if ASSERTIONS
 assert(INITIAL_TOTAL_MEMORY >= TOTAL_STACK, 'TOTAL_MEMORY should be larger than TOTAL_STACK, was ' + INITIAL_TOTAL_MEMORY + '! (TOTAL_STACK=' + TOTAL_STACK + ')');
@@ -382,9 +384,13 @@ if (ENVIRONMENT_IS_PTHREAD) {
 } else {
 #endif // USE_PTHREADS
 #if WASM
+
+#if expectToReceiveOnModule('wasmMemory')
   if (Module['wasmMemory']) {
     wasmMemory = Module['wasmMemory'];
-  } else {
+  } else
+#endif
+  {
     wasmMemory = new WebAssembly.Memory({
       'initial': INITIAL_TOTAL_MEMORY / WASM_PAGE_SIZE
 #if ALLOW_MEMORY_GROWTH
@@ -826,9 +832,10 @@ if (!isDataURI(wasmBinaryFile)) {
 
 function getBinary() {
   try {
-    if (Module['wasmBinary']) {
-      return new Uint8Array(Module['wasmBinary']);
+    if (wasmBinary) {
+      return new Uint8Array(wasmBinary);
     }
+
 #if SUPPORT_BASE64_EMBEDDING
     var binary = tryParseAsDataURI(wasmBinaryFile);
     if (binary) {
@@ -853,7 +860,7 @@ function getBinary() {
 function getBinaryPromise() {
   // if we don't have the binary yet, and have the Fetch api, use that
   // in some environments, like Electron's render process, Fetch api may be present, but have a different context than expected, let's only use it on the Web
-  if (!Module['wasmBinary'] && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) && typeof fetch === 'function') {
+  if (!wasmBinary && (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) && typeof fetch === 'function') {
     return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function(response) {
       if (!response['ok']) {
         throw "failed to load wasm binary file at '" + wasmBinaryFile + "'";
@@ -1060,7 +1067,7 @@ function createWasm(env) {
   // Prefer streaming instantiation if available.
 #if WASM_ASYNC_COMPILATION
   function instantiateAsync() {
-    if (!Module['wasmBinary'] &&
+    if (!wasmBinary &&
         typeof WebAssembly.instantiateStreaming === 'function' &&
         !isDataURI(wasmBinaryFile) &&
         typeof fetch === 'function') {

--- a/src/shell.js
+++ b/src/shell.js
@@ -383,14 +383,14 @@ assert(typeof Module['setWindowTitle'] === 'undefined', 'Module.setWindowTitle o
 {{{ makeRemovedModuleAPIAssert('read', 'read_') }}}
 {{{ makeRemovedModuleAPIAssert('readAsync') }}}
 {{{ makeRemovedModuleAPIAssert('readBinary') }}}
-{{{ makeRemovedModuleAPIAssert('setWindowTitle') }}}
+// TODO: add when SDL2 is fixed {{{ makeRemovedModuleAPIAssert('setWindowTitle') }}}
 
 #if USE_PTHREADS
 assert(ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER, 'Pthreads do not work in non-browser environments yet (need Web Workers, or an alternative to them)');
 #endif // USE_PTHREADS
 #endif // ASSERTIONS
 
-// TODO remove when SDL2 is fixed
+// TODO remove when SDL2 is fixed (also see above)
 #if USE_SDL == 2
 Module['setWindowTitle'] = setWindowTitle;
 #endif

--- a/src/shell.js
+++ b/src/shell.js
@@ -230,6 +230,14 @@ if (ENVIRONMENT_IS_SHELL) {
       quit(status);
     };
   }
+
+  if (typeof console !== 'undefined') {
+    // Support odd shell environments that lack console.* but have other stuff.
+    console = {
+      log: print,
+      warn: typeof printErr !== 'undefined' ? printErr : print
+    }
+  }
 } else
 #endif // ENVIRONMENT_MAY_BE_SHELL
 #if ENVIRONMENT_MAY_BE_WEB || ENVIRONMENT_MAY_BE_WORKER
@@ -340,8 +348,8 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 // console.log is checked first, as 'print' on the web will open a print dialogue
 // printErr is preferable to console.warn (works better in shells)
 // bind(console) is necessary to fix IE/Edge closed dev tools panel behavior.
-var out = Module['print'] || (typeof console !== 'undefined' ? console.log.bind(console) : (typeof print !== 'undefined' ? print : null));
-var err = Module['printErr'] || (typeof printErr !== 'undefined' ? printErr : ((typeof console !== 'undefined' && console.warn.bind(console)) || out));
+{{{ makeModuleReceiveWithVar('out', 'print',    'console.log.bind(console)') }}}
+{{{ makeModuleReceiveWithVar('err', 'printErr', 'console.warn.bind(console)') }}}
 
 // Merge back in the overrides
 for (key in moduleOverrides) {

--- a/src/shell.js
+++ b/src/shell.js
@@ -380,18 +380,17 @@ assert(typeof Module['read'] === 'undefined', 'Module.read option was removed (m
 assert(typeof Module['readAsync'] === 'undefined', 'Module.readAsync option was removed (modify readAsync in JS)');
 assert(typeof Module['readBinary'] === 'undefined', 'Module.readBinary option was removed (modify readBinary in JS)');
 assert(typeof Module['setWindowTitle'] === 'undefined', 'Module.setWindowTitle option was removed (modify setWindowTitle in JS)');
-// Assertions on removed outgoing Module JS APIs.
-Object.defineProperty(Module, 'read', { get: function() { abort('Module.read has been replaced with plain read') } });
-Object.defineProperty(Module, 'readAsync', { get: function() { abort('Module.readAsync has been replaced with plain readAsync') } });
-Object.defineProperty(Module, 'readBinary', { get: function() { abort('Module.readBinary has been replaced with plain readBinary') } });
-// TODO enable when SDL2 is fixed Object.defineProperty(Module, 'setWindowTitle', { get: function() { abort('Module.setWindowTitle has been replaced with plain setWindowTitle') } });
+{{{ makeRemovedModuleAPIAssert('read', 'read_') }}}
+{{{ makeRemovedModuleAPIAssert('readAsync') }}}
+{{{ makeRemovedModuleAPIAssert('readBinary') }}}
+{{{ makeRemovedModuleAPIAssert('setWindowTitle') }}}
 
 #if USE_PTHREADS
 assert(ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER, 'Pthreads do not work in non-browser environments yet (need Web Workers, or an alternative to them)');
 #endif // USE_PTHREADS
 #endif // ASSERTIONS
 
-// TODO remove when SDL2 is fixed; also add the above assertion
+// TODO remove when SDL2 is fixed
 #if USE_SDL == 2
 Module['setWindowTitle'] = setWindowTitle;
 #endif

--- a/src/shell.js
+++ b/src/shell.js
@@ -348,8 +348,8 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 // console.log is checked first, as 'print' on the web will open a print dialogue
 // printErr is preferable to console.warn (works better in shells)
 // bind(console) is necessary to fix IE/Edge closed dev tools panel behavior.
-{{{ makeModuleReceiveWithVar('out', 'print',    'console.log.bind(console)') }}}
-{{{ makeModuleReceiveWithVar('err', 'printErr', 'console.warn.bind(console)') }}}
+{{{ makeModuleReceiveWithVar('out', 'print',    'console.log.bind(console)',  true) }}}
+{{{ makeModuleReceiveWithVar('err', 'printErr', 'console.warn.bind(console)', true) }}}
 
 // Merge back in the overrides
 for (key in moduleOverrides) {

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -68,5 +68,5 @@ var WebAssembly = {
 };
 
 // We don't need to actually download a wasm binary, mark it as present but empty.
-Module['wasmBinary'] = [];
+wasmBinary = [];
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4125,6 +4125,7 @@ window.close = function() {
     # Check an absolute js code size, with some slack.
     size = os.path.getsize('test.js')
     print('size:', size)
+    # Note that this size includes test harness additions (for reporting the result, etc.).
     self.assertLess(abs(size - 6552), 100)
 
   # Tests that it is possible to initialize and render WebGL content in a pthread by using OffscreenCanvas.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4119,6 +4119,14 @@ window.close = function() {
     self.assertLess(td_without_fallback, just_fallback)
     self.assertLess(just_fallback, td_with_fallback)
 
+  @no_fastcomp('not optimized in fastcomp')
+  def test_small_js_flags(self):
+    self.btest('browser_test_hello_world.c', '0', args=['-O3', '--closure', '1', '-s', 'INCOMING_MODULE_JS_API=[]', '-s', 'ENVIRONMENT=web'])
+    # Check an absolute js code size, with some slack.
+    size = os.path.getsize('test.js')
+    print('size:', size)
+    self.assertLess(abs(size - 6552), 100)
+
   # Tests that it is possible to initialize and render WebGL content in a pthread by using OffscreenCanvas.
   # -DTEST_CHAINED_WEBGL_CONTEXT_PASSING: Tests that it is possible to transfer WebGL canvas in a chain from main thread -> thread 1 -> thread 2 and then init and render WebGL content there.
   @no_chrome('see https://crbug.com/961765')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9582,8 +9582,7 @@ int main () {
             }
           }
           check("read");
-          check("setWindowTitle");
-          check("print");
+          // TODO check("setWindowTitle");
           check("wasmBinary");
           check("arguments");
         });
@@ -9592,8 +9591,6 @@ int main () {
     run_process([PYTHON, EMCC, 'src.cpp', '-s', 'ASSERTIONS'])
     self.assertContained('''
 Module.read has been replaced with plain read_
-Module.setWindowTitle has been replaced with plain setWindowTitle
-Module.print has been replaced with plain out
 Module.wasmBinary has been replaced with plain wasmBinary
 Module.arguments has been replaced with plain arguments_
 ''', run_js('a.out.js', assert_returncode=None, stderr=PIPE))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9497,13 +9497,17 @@ int main () {
   @no_fastcomp('not optimized in fastcomp')
   def test_INCOMING_MODULE_JS_API(self):
     def test(args):
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O3'] + args)
-      self.assertContained('hello, world!', run_js('a.out.js'))
+      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O3', '--closure', '1'] + args)
+      for engine in JS_ENGINES:
+        self.assertContained('hello, world!', run_js('a.out.js', engine=engine))
       return os.path.getsize('a.out.js')
     normal = test([])
     changed = test(['-s', 'INCOMING_MODULE_JS_API=[]'])
-    # TODO: specific sizes once we stabilize
+    print('sizes', normal, changed)
+    # Changing this option to [] should decrease code size.
     self.assertLess(changed, normal)
+    # Check an absolute code size as well, with some slack.
+    self.assertLess(abs(changed - 6768), 100)
 
   def test_llvm_includes(self):
     self.build('#include <stdatomic.h>', self.get_dir(), 'atomics.c')


### PR DESCRIPTION
`Module.{wasmBinary,wasmMemory,TOTAL_MEMORY,print,printErr}` are optimized for that option. This should not be user-observable (as by default we assume they might be used; but if the option is used to say they will not, then we can optimize them out).

Reduces `./emcc tests/hello_world.c -O3 --closure 1 -g1 -s 'INCOMING_MODULE_JS_API=[]' -s ENVIRONMENT=web` by 5%.

Added a helper `makeModuleReceiveWithVar` that defines var, and gets a value from Module for it, if we expect one. This cleans up a bunch of code.