### PR TITLE
Fix 9068 newlines emcc error

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8589,7 +8589,6 @@ end
     if not self.is_wasm_backend(): # TODO: wasm backend main module
       self.do_other_test(os.path.join('other', 'extern_weak'), emcc_args=['-s', 'MAIN_MODULE=1', '-DLINKABLE'])
 
-  @no_windows('https://github.com/emscripten-core/emscripten/issues/9057')
   def test_js_optimizer_parse_error(self):
     # check we show a proper understandable error for JS parse problems
     create_test_file('src.cpp', r'''
@@ -8608,7 +8607,7 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
 ''', '''
 var ASM_CONSTS = [function() {var x = !<->5.;}];
                                        ^
-'''), stderr.replace('\r', ''))
+'''), stderr)
 
   def test_EM_ASM_ES6(self):
     # check we show a proper understandable error for JS parse problems

--- a/tools/node_modules/acorn/dist/acorn.js
+++ b/tools/node_modules/acorn/dist/acorn.js
@@ -2769,7 +2769,7 @@ pp$4.raise = function(pos, message) {
   message += " (" + loc.line + ":" + loc.column + ")";
   // XXX EMSCRIPTEN: add a quote of the error text, point to where
   // https://github.com/acornjs/acorn/pull/793
-  var lines = this.input.split('\n');
+  var lines = this.input.split(lineBreak);
   message = message + '\n' + lines[loc.line - 1] + '\n';
   for (var i = 0; i < loc.column; i++) {
     message += ' ';


### PR DESCRIPTION
This fixes a patch applied to `acorn.js` for quoting error-causing text in parse errors (https://github.com/acornjs/acorn/pull/793). Previously it splitted binary data on `\n` to get lines, which was inconsistent with the rest of the parser and caused excess `\r` in the error message on Windows, which caused #9057. Now it uses the same regex as the rest of acorn.js (e.g. `getLineInfo` used by error reporting).

It also fixes #9057 automatically, hence I enabled corresponding test and removed unnecessary change from #9052.

Tests ran on Windows:

```
python2 runner.py other.test_js_optimizer_parse_error
```