### PR TITLE
Embind: allow custom (un)marshalling for groups of types via SFINAE

### DIFF
--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -99,7 +99,9 @@ namespace emscripten {
             return LightTypeID<T>::get();
         }
 
-        template<typename T>
+        // The second typename is an unused stub so it's possible to
+        // specialize groups of classes via SFINAE.
+        template<typename T, typename = void>
         struct TypeID {
             static constexpr TYPEID get() {
                 return LightTypeID<T>::get();
@@ -241,7 +243,9 @@ namespace emscripten {
 
         // BindingType<T>
 
-        template<typename T>
+        // The second typename is an unused stub so it's possible to
+        // specialize groups of classes via SFINAE.
+        template<typename T, typename = void>
         struct BindingType;
 
 #define EMSCRIPTEN_DEFINE_NATIVE_BINDING_TYPE(type)                 \
@@ -381,7 +385,7 @@ namespace emscripten {
         };
 
         // catch-all generic binding
-        template<typename T>
+        template<typename T, typename>
         struct BindingType : std::conditional<
             std::is_enum<T>::value,
             EnumBindingType<T>,

--- a/tests/embind/test_custom_marshal.cpp
+++ b/tests/embind/test_custom_marshal.cpp
@@ -1,0 +1,71 @@
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <emscripten.h>
+#include <emscripten/bind.h>
+#include <emscripten/val.h>
+#include <type_traits>
+#include <string>
+
+using namespace emscripten;
+
+// Class which wraps int and have no explicit or implicit conversions.
+struct IntWrapper {
+  int get() const {
+    return value;
+  }
+  static IntWrapper create(int v) {
+    return IntWrapper(v);
+  }
+
+private:
+  explicit IntWrapper(int v) : value(v) {}
+  int value;
+};
+
+// Need for SFINAE-based specialization testing.
+template<typename T> struct IsIntWrapper : std::false_type {};
+template<> struct IsIntWrapper<IntWrapper> : std::true_type {};
+
+// Specify custom (un)marshalling for all types satisfying IsIntWrapper.
+namespace emscripten {
+namespace internal {
+template<typename T>
+struct TypeID<T, typename std::enable_if<IsIntWrapper<typename std::remove_cv<typename std::remove_reference<T>::type>::type>::value, void>::type> {
+  static constexpr TYPEID get() {
+    return TypeID<int>::get();
+  }
+};
+
+template<typename T>
+struct BindingType<T, typename std::enable_if<IsIntWrapper<T>::value, void>::type> {
+  typedef typename BindingType<int>::WireType WireType;
+
+  constexpr static WireType toWireType(const T& v) {
+    return v.get();
+  }
+  constexpr static T fromWireType(WireType v) {
+    return T::create(v);
+  }
+};
+} // namespace internal
+} // namespace emscripten
+
+template<typename T>
+void test() {
+  IntWrapper x = IntWrapper::create(10);
+  val js_func = val::module_property("js_func");
+  IntWrapper y = js_func(val(std::forward<T>(x))).as<IntWrapper>();
+  printf("C++ got %d\n", y.get());
+}
+
+int main(int argc, char **argv) {
+  test<IntWrapper>();
+  test<IntWrapper&>();
+  test<const IntWrapper>();
+  test<const IntWrapper&>();
+  return 0;
+}

--- a/tests/embind/test_custom_marshal.cpp
+++ b/tests/embind/test_custom_marshal.cpp
@@ -38,6 +38,7 @@ using IntWrapperIntermediate = int;
 // Specify custom (un)marshalling for all types satisfying IsIntWrapper.
 namespace emscripten {
 namespace internal {
+// remove_cv/remove_reference are required for TypeID, but not BindingType, see https://github.com/emscripten-core/emscripten/issues/7292
 template<typename T>
 struct TypeID<T, typename std::enable_if<IsIntWrapper<typename std::remove_cv<typename std::remove_reference<T>::type>::type>::value, void>::type> {
   static constexpr TYPEID get() {

--- a/tests/embind/test_custom_marshal.js
+++ b/tests/embind/test_custom_marshal.js
@@ -1,0 +1,4 @@
+Module.js_func = function(x) {
+    console.log('JS got', x, typeof(x));
+    return 20;
+}

--- a/tests/embind/test_custom_marshal.out
+++ b/tests/embind/test_custom_marshal.out
@@ -1,0 +1,8 @@
+JS got 10 number
+C++ got 20
+JS got 10 number
+C++ got 20
+JS got 10 number
+C++ got 20
+JS got 10 number
+C++ got 20

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6800,6 +6800,10 @@ someweirdtext
     self.emcc_args += ['--bind']
     self.do_run_in_out_file_test('tests', 'core', 'test_embind_5')
 
+  def test_embind_custom_marshal(self):
+    self.emcc_args += ['--bind', '-std=c++11', '--pre-js', path_from_root('tests', 'embind', 'test_custom_marshal.js')]
+    self.do_run_in_out_file_test('tests', 'embind', 'test_custom_marshal', assert_identical=True)
+
   def test_embind_float_constants(self):
     self.emcc_args += ['--bind']
     self.do_run_from_file(path_from_root('tests', 'embind', 'test_float_constants.cpp'),


### PR DESCRIPTION
This PR introduces a small change in `emscripten/wire.h` which allows users to specialize `TypeID`/`BindingType` not only for specific types, but for whole classes of types (e.g. all derived from `MySerializable`).

It also includes an example test, which leads to stabilizing this API (#9022). I can also write and add a site documentation in this or separate PR as well which describes embind's internal workings.