### PR TITLE
fix_gl_exts_without_auto_enable_extensions

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2496,6 +2496,12 @@ var LibraryJSEvents = {
     var context = GL.getContext(contextHandle);
     var extString = UTF8ToString(extension);
     if (extString.indexOf('GL_') == 0) extString = extString.substr(3); // Allow enabling extensions both with "GL_" prefix and without.
+
+    // Obtain function entry points to extension related functions.
+    if (extString == 'ANGLE_instanced_arrays') GL.acquireInstancedArraysExtension(GLctx);
+    else if (extString == 'OES_vertex_array_object') GL.acquireVertexArrayObjectExtension(GLctx);
+    else if (extString == 'WEBGL_draw_buffers') GL.acquireDrawBuffersExtension(GLctx);
+
     var ext = context.GLctx.getExtension(extString);
     return !!ext;
   },

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -868,6 +868,34 @@ var LibraryGL = {
       GL.contexts[contextHandle] = null;
     },
 
+    acquireInstancedArraysExtension: function(ctx) {
+      // Extension available from Firefox 26 and Google Chrome 30
+      var ext = ctx.getExtension('ANGLE_instanced_arrays');
+      if (ext) {
+        ctx['vertexAttribDivisor'] = function(index, divisor) { ext['vertexAttribDivisorANGLE'](index, divisor); };
+        ctx['drawArraysInstanced'] = function(mode, first, count, primcount) { ext['drawArraysInstancedANGLE'](mode, first, count, primcount); };
+        ctx['drawElementsInstanced'] = function(mode, count, type, indices, primcount) { ext['drawElementsInstancedANGLE'](mode, count, type, indices, primcount); };
+      }
+    },
+
+    acquireVertexArrayObjectExtension: function(ctx) {
+      // Extension available from Firefox 25 and WebKit
+      var ext = ctx.getExtension('OES_vertex_array_object');
+      if (ext) {
+        ctx['createVertexArray'] = function() { return ext['createVertexArrayOES'](); };
+        ctx['deleteVertexArray'] = function(vao) { ext['deleteVertexArrayOES'](vao); };
+        ctx['bindVertexArray'] = function(vao) { ext['bindVertexArrayOES'](vao); };
+        ctx['isVertexArray'] = function(vao) { return ext['isVertexArrayOES'](vao); };
+      }
+    },
+
+    acquireDrawBuffersExtension: function(ctx) {
+      var ext = ctx.getExtension('WEBGL_draw_buffers');
+      if (ext) {
+        ctx['drawBuffers'] = function(n, bufs) { ext['drawBuffersWEBGL'](n, bufs); };
+      }
+    },
+
     // In WebGL, extensions must be explicitly enabled to be active, see http://www.khronos.org/registry/webgl/specs/latest/1.0/#5.14.14
     // In GLES2, all extensions are enabled by default without additional operations. Init all extensions we need to give to GLES2 user
     // code here, so that GLES2 code can operate without changing behavior.
@@ -887,27 +915,9 @@ var LibraryGL = {
 #endif
 
       if (context.version < 2) {
-        // Extension available from Firefox 26 and Google Chrome 30
-        var instancedArraysExt = GLctx.getExtension('ANGLE_instanced_arrays');
-        if (instancedArraysExt) {
-          GLctx['vertexAttribDivisor'] = function(index, divisor) { instancedArraysExt['vertexAttribDivisorANGLE'](index, divisor); };
-          GLctx['drawArraysInstanced'] = function(mode, first, count, primcount) { instancedArraysExt['drawArraysInstancedANGLE'](mode, first, count, primcount); };
-          GLctx['drawElementsInstanced'] = function(mode, count, type, indices, primcount) { instancedArraysExt['drawElementsInstancedANGLE'](mode, count, type, indices, primcount); };
-        }
-
-        // Extension available from Firefox 25 and WebKit
-        var vaoExt = GLctx.getExtension('OES_vertex_array_object');
-        if (vaoExt) {
-          GLctx['createVertexArray'] = function() { return vaoExt['createVertexArrayOES'](); };
-          GLctx['deleteVertexArray'] = function(vao) { vaoExt['deleteVertexArrayOES'](vao); };
-          GLctx['bindVertexArray'] = function(vao) { vaoExt['bindVertexArrayOES'](vao); };
-          GLctx['isVertexArray'] = function(vao) { return vaoExt['isVertexArrayOES'](vao); };
-        }
-
-        var drawBuffersExt = GLctx.getExtension('WEBGL_draw_buffers');
-        if (drawBuffersExt) {
-          GLctx['drawBuffers'] = function(n, bufs) { drawBuffersExt['drawBuffersWEBGL'](n, bufs); };
-        }
+        GL.acquireInstancedArraysExtension(GLctx);
+        GL.acquireVertexArrayObjectExtension(GLctx);
+        GL.acquireDrawBuffersExtension(GLctx);
       }
 
       GLctx.disjointTimerQueryExt = GLctx.getExtension("EXT_disjoint_timer_query");

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -869,7 +869,7 @@ var LibraryGL = {
     },
 
     acquireInstancedArraysExtension: function(ctx) {
-      // Extension available from Firefox 26 and Google Chrome 30
+      // Extension available in WebGL 1 from Firefox 26 and Google Chrome 30 onwards. Core feature in WebGL 2.
       var ext = ctx.getExtension('ANGLE_instanced_arrays');
       if (ext) {
         ctx['vertexAttribDivisor'] = function(index, divisor) { ext['vertexAttribDivisorANGLE'](index, divisor); };
@@ -879,7 +879,7 @@ var LibraryGL = {
     },
 
     acquireVertexArrayObjectExtension: function(ctx) {
-      // Extension available from Firefox 25 and WebKit
+      // Extension available in WebGL 1 from Firefox 25 and WebKit 536.28/desktop Safari 6.0.3 onwards. Core feature in WebGL 2.
       var ext = ctx.getExtension('OES_vertex_array_object');
       if (ext) {
         ctx['createVertexArray'] = function() { return ext['createVertexArrayOES'](); };
@@ -890,6 +890,7 @@ var LibraryGL = {
     },
 
     acquireDrawBuffersExtension: function(ctx) {
+      // Extension available in WebGL 1 from Firefox 28 onwards. Core feature in WebGL 2.
       var ext = ctx.getExtension('WEBGL_draw_buffers');
       if (ext) {
         ctx['drawBuffers'] = function(n, bufs) { ext['drawBuffersWEBGL'](n, bufs); };

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4166,6 +4166,11 @@ window.close = function() {
   def test_webgl_offscreen_framebuffer(self):
     self.btest('webgl_draw_triangle.c', '0', args=['-lGL', '-s', 'OFFSCREEN_FRAMEBUFFER=1', '-DEXPLICIT_SWAP=1'])
 
+  # Tests that VAOs can be used even if WebGL enableExtensionsByDefault is set to 0.
+  @requires_graphics_hardware
+  def test_webgl_vao_without_automatic_extensions(self):
+    self.btest('test_webgl_no_auto_init_extensions.c', '0', args=['-lGL', '-s', 'GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS=0'])
+
   # Tests that offscreen framebuffer state restoration works
   @requires_graphics_hardware
   def test_webgl_offscreen_framebuffer_state_restoration(self):

--- a/tests/test_webgl_no_auto_init_extensions.c
+++ b/tests/test_webgl_no_auto_init_extensions.c
@@ -1,9 +1,10 @@
 #include <emscripten/html5.h>
-#include <GLES2/gl2.h>
 #include <string.h>
 #include <assert.h>
+#include <GLES2/gl2.h>
 
-GL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint *arrays);
+#define GL_GLEXT_PROTOTYPES
+#include <GLES2/gl2ext.h>
 
 int main()
 {

--- a/tests/test_webgl_no_auto_init_extensions.c
+++ b/tests/test_webgl_no_auto_init_extensions.c
@@ -3,7 +3,7 @@
 #include <string.h>
 #include <assert.h>
 
-GL_APICALL void GL_APIENTRY glGenVertexArrays(GLsizei n, GLuint *arrays);
+GL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint *arrays);
 
 int main()
 {
@@ -18,7 +18,7 @@ int main()
   if (hasVaos)
   {
     GLuint vao = 0;
-    glGenVertexArrays(1, &vao);
+    glGenVertexArraysOES(1, &vao);
     assert(vao != 0);
   }
 #ifdef REPORT_RESULT

--- a/tests/test_webgl_no_auto_init_extensions.c
+++ b/tests/test_webgl_no_auto_init_extensions.c
@@ -1,0 +1,27 @@
+#include <emscripten/html5.h>
+#include <GLES2/gl2.h>
+#include <string.h>
+#include <assert.h>
+
+GL_APICALL void GL_APIENTRY glGenVertexArrays(GLsizei n, GLuint *arrays);
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attr;
+  emscripten_webgl_init_context_attributes(&attr);
+  attr.majorVersion = 1;
+  attr.enableExtensionsByDefault = 0;
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
+  emscripten_webgl_make_context_current(ctx);
+
+  EM_BOOL hasVaos = emscripten_webgl_enable_extension(ctx, "OES_vertex_array_object");
+  if (hasVaos)
+  {
+    GLuint vao = 0;
+    glGenVertexArrays(1, &vao);
+    assert(vao != 0);
+  }
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+}


### PR DESCRIPTION
Fix accessing VAOs, instanced rendering, drawBuffers and disjoint Timer Query on WebGL1 when automatic GL extension initialization is not enabled