### PR TITLE
Make aligned_alloc() weak linkage

### DIFF
--- a/system/lib/libc/musl/src/compat-emscripten/aligned_alloc.c
+++ b/system/lib/libc/musl/src/compat-emscripten/aligned_alloc.c
@@ -2,7 +2,7 @@
 
 // Musl has an aligned_alloc routine, but that builds on top of standard malloc(). We are using dlmalloc, so
 // can route to its implementation instead.
-void *aligned_alloc(size_t alignment, size_t size)
+void * __attribute__((weak)) aligned_alloc(size_t alignment, size_t size)
 {
   void *ptr;
   int ret = posix_memalign(&ptr, alignment, size);


### PR DESCRIPTION
Make aligned_alloc() weak linkage so it can be overridden in custom user code