### PR TITLE
Remove unused dependency from Fetch to emscripten_is_main_runtime_thread().

### DIFF
--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -34,7 +34,7 @@ var LibraryFetch = {
 #if FETCH_SUPPORT_INDEXEDDB
   '$__emscripten_fetch_cache_data', '$__emscripten_fetch_load_cached_data', '$__emscripten_fetch_delete_cached_data',
 #endif
-  '_emscripten_get_fetch_work_queue', 'emscripten_is_main_runtime_thread']
+  '_emscripten_get_fetch_work_queue']
 };
 
 mergeInto(LibraryManager.library, LibraryFetch);


### PR DESCRIPTION
This is no longer being referenced - looks like it got dropped at some point in time.