### PR TITLE
Avoid generating debugger; statement in release

### DIFF
--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -61,7 +61,11 @@ var imports = {
   'global.Math': Math,
   'asm2wasm': {
     'f64-rem': function(x, y) { return x % y; },
-    'debugger': function() { debugger; }
+    'debugger': function() {
+#if ASSERTIONS // Disable debugger; statement from being present in release builds to avoid Firefox deoptimizations, see https://bugzilla.mozilla.org/show_bug.cgi?id=1538375
+      debugger;
+#endif
+    }
   }
 #endif
 };

--- a/src/support.js
+++ b/src/support.js
@@ -56,7 +56,9 @@ var asm2wasmImports = { // special asm2wasm imports
         return x % y;
     },
     "debugger": function() {
+#if ASSERTIONS // Disable debugger; statement from being present in release builds to avoid Firefox deoptimizations, see https://bugzilla.mozilla.org/show_bug.cgi?id=1538375
         debugger;
+#endif
     }
 #if NEED_ALL_ASM2WASM_IMPORTS
     ,


### PR DESCRIPTION
Avoid generating debugger; statement in release, see https://bugzilla.mozilla.org/show_bug.cgi?id=1538375.

Release builds do not want `debugger;` in them anyways.