### PR TITLE
Fix memory leak in Chrome - Error objects do not like to be persistent

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,9 @@ Current Trunk
    implementation in the upstream wasm backend. It is recommended to upgrade to
    the upstream backend and use Asyncify there if you need it. (If you do still
    need the older version, you can use 1.38.40.)
+ - Drop ExitStatus from inheriting from Error(), as that could capture the whole
+   global scope, preventing temporary variables at page startup from being garbage
+   collected. (#9108)
 
 v.1.38.40: 07/24/2019
 ---------------------

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -146,7 +146,6 @@ Module['then'] = function(func) {
 
 /**
  * @constructor
- * @extends {Error}
  * @this {ExitStatus}
  */
 function ExitStatus(status) {
@@ -154,8 +153,6 @@ function ExitStatus(status) {
   this.message = "Program terminated with exit(" + status + ")";
   this.status = status;
 }
-ExitStatus.prototype = new Error();
-ExitStatus.prototype.constructor = ExitStatus;
 
 var calledMain = false;
 


### PR DESCRIPTION
Fix memory leak in Chrome - Error objects do not like to be persistent, they seem to heavily capture variables they have in their scope.

In Chrome, calling `var x = new Error();` in global scope causes an immediate capture of the scope, which leads in `Module` being captured, along with `.data`, `.wasm`, `.mem` etc. raw byte arrays, never reclaiming the memory.

I don't think there's any pressing reason for ExitStatus  to inherit from Error anyways? (was it due to convenience to get a pretty-printed error callstack?)