### PR TITLE
Fix __cxa_pure_virtual to work with MINIMAL_RUNTIME

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1488,8 +1488,15 @@ LibraryManager.library = {
 #endif
 
   __cxa_pure_virtual: function() {
+#if !MINIMAL_RUNTIME
     ABORT = true;
+#endif
+
+#if MINIMAL_RUNTIME && !ASSERTIONS
+    throw 'pv';
+#else
     throw 'Pure virtual function called!';
+#endif
   },
 
   llvm_flt_rounds: function() {

--- a/src/library.js
+++ b/src/library.js
@@ -1487,17 +1487,18 @@ LibraryManager.library = {
 #endif
 #endif
 
+#if MINIMAL_RUNTIME && !ASSERTIONS
+  __cxa_pure_virtual__sig: 'v',
+  __cxa_pure_virtual: 'abort',
+#else
   __cxa_pure_virtual: function() {
 #if !MINIMAL_RUNTIME
     ABORT = true;
 #endif
 
-#if MINIMAL_RUNTIME && !ASSERTIONS
-    throw 'pv';
-#else
     throw 'Pure virtual function called!';
-#endif
   },
+#endif
 
   llvm_flt_rounds: function() {
     return -1; // 'indeterminable' for FLT_ROUNDS

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -232,7 +232,9 @@ var LibraryExceptions = {
 
   __cxa_call_unexpected: function(exception) {
     err('Unexpected exception thrown, this is not properly supported - aborting');
+#if !MINIMAL_RUNTIME
     ABORT = true;
+#endif
     throw exception;
   },
 


### PR DESCRIPTION
Fix __cxa_pure_virtual to work with MINIMAL_RUNTIME and micro-optimize it in release builds.