### PR TITLE
Micro-optimize WebGL

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1102,12 +1102,14 @@ var LibraryGL = {
         ret = 1;
         break;
       case 0x8DF8: // GL_SHADER_BINARY_FORMATS
+#if GL_TRACK_ERRORS
         if (type != {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}} && type != {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}}) {
           GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
           err('GL_INVALID_ENUM in glGet' + type + 'v(GL_SHADER_BINARY_FORMATS): Invalid parameter type!');
 #endif
         }
+#endif
         return; // Do not write anything to the out pointer, since no binary formats are supported.
 #if USE_WEBGL2
       case 0x87FE: // GL_NUM_PROGRAM_BINARY_FORMATS
@@ -1123,10 +1125,12 @@ var LibraryGL = {
         break;
 #if USE_WEBGL2
       case 0x821D: // GL_NUM_EXTENSIONS
+#if GL_TRACK_ERRORS
         if (GL.currentContext.version < 2) {
           GL.recordError(0x0502 /* GL_INVALID_OPERATION */); // Calling GLES3/WebGL2 function with a GLES2/WebGL1 context
           return;
         }
+#endif
         var exts = GLctx.getSupportedExtensions();
         if (exts === null) {
           ret = 0;
@@ -1140,10 +1144,12 @@ var LibraryGL = {
         break;
       case 0x821B: // GL_MAJOR_VERSION
       case 0x821C: // GL_MINOR_VERSION
+#if GL_TRACK_ERRORS
         if (GL.currentContext.version < 2) {
           GL.recordError(0x0500); // GL_INVALID_ENUM
           return;
         }
+#endif
         ret = name_ == 0x821B ? 3 : 0; // return version 3.0
         break;
 #endif
@@ -1201,26 +1207,32 @@ var LibraryGL = {
                 case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'i32') }}}; break;
                 case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'float') }}}; break;
                 case {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}}: {{{ makeSetValue('p', 'i',   'result[i] ? 1 : 0', 'i8') }}}; break;
+#if GL_ASSERTIONS
                 default: throw 'internal glGet error, bad type: ' + type;
+#endif
               }
             }
             return;
           } else {
+#if GL_TRACK_ERRORS
             try {
+#endif
               ret = result.name | 0;
+#if GL_TRACK_ERRORS
             } catch(e) {
               GL.recordError(0x0500); // GL_INVALID_ENUM
               err('GL_INVALID_ENUM in glGet' + type + 'v: Unknown object returned from WebGL getParameter(' + name_ + ')! (error: ' + e + ')');
               return;
             }
+#endif
           }
           break;
+#if GL_TRACK_ERRORS
         default:
           GL.recordError(0x0500); // GL_INVALID_ENUM
-#if GL_ASSERTIONS
           err('GL_INVALID_ENUM in glGet' + type + 'v: Native code calling glGet' + type + 'v(' + name_ + ') and it returns ' + result + ' of type ' + typeof(result) + '!');
-#endif
           return;
+#endif
       }
     }
 
@@ -1229,7 +1241,9 @@ var LibraryGL = {
       case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('p', '0', 'ret', 'i32') }}};    break;
       case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}:   {{{ makeSetValue('p', '0', 'ret', 'float') }}};  break;
       case {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}}: {{{ makeSetValue('p', '0', 'ret ? 1 : 0', 'i8') }}}; break;
+#if GL_ASSERTIONS
       default: throw 'internal glGet error, bad type: ' + type;
+#endif
     }
   },
 

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1102,7 +1102,7 @@ var LibraryGL = {
         ret = 1;
         break;
       case 0x8DF8: // GL_SHADER_BINARY_FORMATS
-        if (type !== 'Integer' && type !== 'Integer64') {
+        if (type != {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}} && type != {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}}) {
           GL.recordError(0x0500); // GL_INVALID_ENUM
 #if GL_ASSERTIONS
           err('GL_INVALID_ENUM in glGet' + type + 'v(GL_SHADER_BINARY_FORMATS): Invalid parameter type!');
@@ -1198,9 +1198,9 @@ var LibraryGL = {
                      result instanceof Array) {
             for (var i = 0; i < result.length; ++i) {
               switch (type) {
-                case 'Integer': {{{ makeSetValue('p', 'i*4', 'result[i]',     'i32') }}};   break;
-                case 'Float':   {{{ makeSetValue('p', 'i*4', 'result[i]',     'float') }}}; break;
-                case 'Boolean': {{{ makeSetValue('p', 'i',   'result[i] ? 1 : 0', 'i8') }}};    break;
+                case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'i32') }}}; break;
+                case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('p', 'i*4', 'result[i]', 'float') }}}; break;
+                case {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}}: {{{ makeSetValue('p', 'i',   'result[i] ? 1 : 0', 'i8') }}}; break;
                 default: throw 'internal glGet error, bad type: ' + type;
               }
             }
@@ -1225,10 +1225,10 @@ var LibraryGL = {
     }
 
     switch (type) {
-      case 'Integer64': {{{ makeSetValue('p', '0', 'ret', 'i64') }}};    break;
-      case 'Integer': {{{ makeSetValue('p', '0', 'ret', 'i32') }}};    break;
-      case 'Float':   {{{ makeSetValue('p', '0', 'ret', 'float') }}};  break;
-      case 'Boolean': {{{ makeSetValue('p', '0', 'ret ? 1 : 0', 'i8') }}}; break;
+      case {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}}: {{{ makeSetValue('p', '0', 'ret', 'i64') }}};    break;
+      case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('p', '0', 'ret', 'i32') }}};    break;
+      case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}:   {{{ makeSetValue('p', '0', 'ret', 'float') }}};  break;
+      case {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}}: {{{ makeSetValue('p', '0', 'ret ? 1 : 0', 'i8') }}}; break;
       default: throw 'internal glGet error, bad type: ' + type;
     }
   },
@@ -1236,19 +1236,19 @@ var LibraryGL = {
   glGetIntegerv__sig: 'vii',
   glGetIntegerv__deps: ['$emscriptenWebGLGet'],
   glGetIntegerv: function(name_, p) {
-    emscriptenWebGLGet(name_, p, 'Integer');
+    emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
   },
 
   glGetFloatv__sig: 'vii',
   glGetFloatv__deps: ['$emscriptenWebGLGet'],
   glGetFloatv: function(name_, p) {
-    emscriptenWebGLGet(name_, p, 'Float');
+    emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
   },
 
   glGetBooleanv__sig: 'vii',
   glGetBooleanv__deps: ['$emscriptenWebGLGet'],
   glGetBooleanv: function(name_, p) {
-    emscriptenWebGLGet(name_, p, 'Boolean');
+    emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}});
   },
 
   glDeleteTextures__sig: 'vii',
@@ -1902,15 +1902,15 @@ var LibraryGL = {
     var data = GLctx.getUniform(GL.programs[program], GL.uniforms[location]);
     if (typeof data == 'number' || typeof data == 'boolean') {
       switch (type) {
-        case 'Integer': {{{ makeSetValue('params', '0', 'data', 'i32') }}}; break;
-        case 'Float': {{{ makeSetValue('params', '0', 'data', 'float') }}}; break;
+        case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', '0', 'data', 'i32') }}}; break;
+        case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', '0', 'data', 'float') }}}; break;
         default: throw 'internal emscriptenWebGLGetUniform() error, bad type: ' + type;
       }
     } else {
       for (var i = 0; i < data.length; i++) {
         switch (type) {
-          case 'Integer': {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
-          case 'Float': {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
+          case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
+          case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
           default: throw 'internal emscriptenWebGLGetUniform() error, bad type: ' + type;
         }
       }
@@ -1920,13 +1920,13 @@ var LibraryGL = {
   glGetUniformfv__sig: 'viii',
   glGetUniformfv__deps: ['$emscriptenWebGLGetUniform'],
   glGetUniformfv: function(program, location, params) {
-    emscriptenWebGLGetUniform(program, location, params, 'Float');
+    emscriptenWebGLGetUniform(program, location, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
   },
 
   glGetUniformiv__sig: 'viii',
   glGetUniformiv__deps: ['$emscriptenWebGLGetUniform'],
   glGetUniformiv: function(program, location, params) {
-    emscriptenWebGLGetUniform(program, location, params, 'Integer');
+    emscriptenWebGLGetUniform(program, location, params, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
   },
 
   glGetUniformLocation__sig: 'iii',
@@ -1972,17 +1972,17 @@ var LibraryGL = {
       {{{ makeSetValue('params', '0', 'data["name"]', 'i32') }}};
     } else if (typeof data == 'number' || typeof data == 'boolean') {
       switch (type) {
-        case 'Integer': {{{ makeSetValue('params', '0', 'data', 'i32') }}}; break;
-        case 'Float': {{{ makeSetValue('params', '0', 'data', 'float') }}}; break;
-        case 'FloatToInteger': {{{ makeSetValue('params', '0', 'Math.fround(data)', 'i32') }}}; break;
+        case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', '0', 'data', 'i32') }}}; break;
+        case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', '0', 'data', 'float') }}}; break;
+        case {{{ cDefine('EM_FUNC_SIG_PARAM_F2I') }}}: {{{ makeSetValue('params', '0', 'Math.fround(data)', 'i32') }}}; break;
         default: throw 'internal emscriptenWebGLGetVertexAttrib() error, bad type: ' + type;
       }
     } else {
       for (var i = 0; i < data.length; i++) {
         switch (type) {
-          case 'Integer': {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
-          case 'Float': {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
-          case 'FloatToInteger': {{{ makeSetValue('params', 'i*4', 'Math.fround(data[i])', 'i32') }}}; break;
+          case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'i32') }}}; break;
+          case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('params', 'i*4', 'data[i]', 'float') }}}; break;
+          case {{{ cDefine('EM_FUNC_SIG_PARAM_F2I') }}}: {{{ makeSetValue('params', 'i*4', 'Math.fround(data[i])', 'i32') }}}; break;
           default: throw 'internal emscriptenWebGLGetVertexAttrib() error, bad type: ' + type;
         }
       }
@@ -1994,7 +1994,7 @@ var LibraryGL = {
   glGetVertexAttribfv: function(index, pname, params) {
     // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttrib*f(),
     // otherwise the results are undefined. (GLES3 spec 6.1.12)
-    emscriptenWebGLGetVertexAttrib(index, pname, params, 'Float');
+    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}});
   },
 
   glGetVertexAttribiv__sig: 'viii',
@@ -2002,7 +2002,7 @@ var LibraryGL = {
   glGetVertexAttribiv: function(index, pname, params) {
     // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttrib*f(),
     // otherwise the results are undefined. (GLES3 spec 6.1.12)
-    emscriptenWebGLGetVertexAttrib(index, pname, params, 'FloatToInteger');
+    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefine('EM_FUNC_SIG_PARAM_F2I') }}});
   },
 
   glGetVertexAttribPointerv__sig: 'viii',

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -2033,13 +2033,8 @@ var LibraryGL = {
     var info = GLctx.getActiveUniform(program, index);
     if (!info) return; // If an error occurs, nothing will be written to length, size, type and name.
 
-    if (bufSize > 0 && name) {
-      var numBytesWrittenExclNull = stringToUTF8(info.name, name, bufSize);
-      if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
-    } else {
-      if (length) {{{ makeSetValue('length', '0', 0, 'i32') }}};
-    }
-
+    var numBytesWrittenExclNull = (bufSize > 0 && name) ? stringToUTF8(info.name, name, bufSize) : 0;
+    if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
     if (size) {{{ makeSetValue('size', '0', 'info.size', 'i32') }}};
     if (type) {{{ makeSetValue('type', '0', 'info.type', 'i32') }}};
   },
@@ -2520,13 +2515,8 @@ var LibraryGL = {
     var info = GLctx.getActiveAttrib(program, index);
     if (!info) return; // If an error occurs, nothing will be written to length, size and type and name.
 
-    if (bufSize > 0 && name) {
-      var numBytesWrittenExclNull = stringToUTF8(info.name, name, bufSize);
-      if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
-    } else {
-      if (length) {{{ makeSetValue('length', '0', 0, 'i32') }}};
-    }
-
+    var numBytesWrittenExclNull = (bufSize > 0 && name) ? stringToUTF8(info.name, name, bufSize) : 0;
+    if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
     if (size) {{{ makeSetValue('size', '0', 'info.size', 'i32') }}};
     if (type) {{{ makeSetValue('type', '0', 'info.type', 'i32') }}};
   },
@@ -2629,12 +2619,8 @@ var LibraryGL = {
 #endif
     var result = GLctx.getShaderSource(GL.shaders[shader]);
     if (!result) return; // If an error occurs, nothing will be written to length or source.
-    if (bufSize > 0 && source) {
-      var numBytesWrittenExclNull = stringToUTF8(result, source, bufSize);
-      if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
-    } else {
-      if (length) {{{ makeSetValue('length', '0', 0, 'i32') }}};
-    }
+    var numBytesWrittenExclNull = (bufSize > 0 && source) ? stringToUTF8(result, source, bufSize) : 0;
+    if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
   },
 
   glCompileShader__sig: 'vi',
@@ -2655,13 +2641,11 @@ var LibraryGL = {
     GL.validateGLObjectID(GL.shaders, shader, 'glGetShaderInfoLog', 'shader');
 #endif
     var log = GLctx.getShaderInfoLog(GL.shaders[shader]);
+#if GL_ASSERTIONS || GL_TRACK_ERRORS
     if (log === null) log = '(unknown error)';
-    if (maxLength > 0 && infoLog) {
-      var numBytesWrittenExclNull = stringToUTF8(log, infoLog, maxLength);
-      if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
-    } else {
-      if (length) {{{ makeSetValue('length', '0', 0, 'i32') }}};
-    }
+#endif
+    var numBytesWrittenExclNull = (maxLength > 0 && infoLog) ? stringToUTF8(log, infoLog, maxLength) : 0;
+    if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
   },
 
   glGetShaderiv__sig: 'viii',
@@ -2680,7 +2664,9 @@ var LibraryGL = {
 #endif
     if (pname == 0x8B84) { // GL_INFO_LOG_LENGTH
       var log = GLctx.getShaderInfoLog(GL.shaders[shader]);
+#if GL_ASSERTIONS || GL_TRACK_ERRORS
       if (log === null) log = '(unknown error)';
+#endif
       {{{ makeSetValue('p', '0', 'log.length + 1', 'i32') }}};
     } else if (pname == 0x8B88) { // GL_SHADER_SOURCE_LENGTH
       var source = GLctx.getShaderSource(GL.shaders[shader]);
@@ -2725,7 +2711,9 @@ var LibraryGL = {
 
     if (pname == 0x8B84) { // GL_INFO_LOG_LENGTH
       var log = GLctx.getProgramInfoLog(GL.programs[program]);
+#if GL_ASSERTIONS || GL_TRACK_ERRORS
       if (log === null) log = '(unknown error)';
+#endif
       {{{ makeSetValue('p', '0', 'log.length + 1', 'i32') }}};
     } else if (pname == 0x8B87 /* GL_ACTIVE_UNIFORM_MAX_LENGTH */) {
       {{{ makeSetValue('p', '0', 'ptable.maxUniformLength', 'i32') }}};
@@ -2833,14 +2821,11 @@ var LibraryGL = {
     GL.validateGLObjectID(GL.programs, program, 'glGetProgramInfoLog', 'program');
 #endif
     var log = GLctx.getProgramInfoLog(GL.programs[program]);
+#if GL_ASSERTIONS || GL_TRACK_ERRORS
     if (log === null) log = '(unknown error)';
-
-    if (maxLength > 0 && infoLog) {
-      var numBytesWrittenExclNull = stringToUTF8(log, infoLog, maxLength);
-      if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
-    } else {
-      if (length) {{{ makeSetValue('length', '0', 0, 'i32') }}};
-    }
+#endif
+    var numBytesWrittenExclNull = (maxLength > 0 && infoLog) ? stringToUTF8(log, infoLog, maxLength) : 0;
+    if (length) {{{ makeSetValue('length', '0', 'numBytesWrittenExclNull', 'i32') }}};
   },
 
   glUseProgram__sig: 'vi',

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -57,7 +57,7 @@ var LibraryWebGL2 = {
   glGetInteger64v__sig: 'vii',
   glGetInteger64v__deps: ['$emscriptenWebGLGet'],
   glGetInteger64v: function(name_, p) {
-    emscriptenWebGLGet(name_, p, 'Integer64');
+    emscriptenWebGLGet(name_, p, {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}});
   },
 
   glGetInternalformativ__sig: 'viiiii',
@@ -524,10 +524,10 @@ var LibraryWebGL2 = {
     }
 
     switch (type) {
-      case 'Integer64': {{{ makeSetValue('data', '0', 'ret', 'i64') }}};    break;
-      case 'Integer': {{{ makeSetValue('data', '0', 'ret', 'i32') }}};    break;
-      case 'Float':   {{{ makeSetValue('data', '0', 'ret', 'float') }}};  break;
-      case 'Boolean': {{{ makeSetValue('data', '0', 'ret ? 1 : 0', 'i8') }}}; break;
+      case {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}}: {{{ makeSetValue('data', '0', 'ret', 'i64') }}}; break;
+      case {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}}: {{{ makeSetValue('data', '0', 'ret', 'i32') }}}; break;
+      case {{{ cDefine('EM_FUNC_SIG_PARAM_F') }}}: {{{ makeSetValue('data', '0', 'ret', 'float') }}}; break;
+      case {{{ cDefine('EM_FUNC_SIG_PARAM_B') }}}: {{{ makeSetValue('data', '0', 'ret ? 1 : 0', 'i8') }}}; break;
       default: throw 'internal emscriptenWebGLGetIndexed() error, bad type: ' + type;
     }
   },
@@ -535,13 +535,13 @@ var LibraryWebGL2 = {
   glGetIntegeri_v__sig: 'viii',
   glGetIntegeri_v__deps: ['$emscriptenWebGLGetIndexed'],
   glGetIntegeri_v: function(target, index, data) {
-    emscriptenWebGLGetIndexed(target, index, data, 'Integer');
+    emscriptenWebGLGetIndexed(target, index, data, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
   },
 
   glGetInteger64i_v__sig: 'viii',
   glGetInteger64i_v__deps: ['$emscriptenWebGLGetIndexed'],
   glGetInteger64i_v: function(target, index, data) {
-    emscriptenWebGLGetIndexed(target, index, data, 'Integer64');
+    emscriptenWebGLGetIndexed(target, index, data, {{{ cDefine('EM_FUNC_SIG_PARAM_I64') }}});
   },
 
   // Uniform Buffer objects
@@ -804,7 +804,7 @@ var LibraryWebGL2 = {
   glGetUniformuiv__sig: 'viii',
   glGetUniformuiv__deps: ['$emscriptenWebGLGetUniform'],
   glGetUniformuiv: function(program, location, params) {
-    emscriptenWebGLGetUniform(program, location, params, 'Integer');
+    emscriptenWebGLGetUniform(program, location, params, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
   },
 
   glGetFragDataLocation__sig: 'iii',
@@ -820,7 +820,7 @@ var LibraryWebGL2 = {
   glGetVertexAttribIiv: function(index, pname, params) {
     // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttribI4iv(),
     // otherwise the results are undefined. (GLES3 spec 6.1.12)
-    emscriptenWebGLGetVertexAttrib(index, pname, params, 'Integer');
+    emscriptenWebGLGetVertexAttrib(index, pname, params, {{{ cDefine('EM_FUNC_SIG_PARAM_I') }}});
   },
 
   // N.B. This function may only be called if the vertex attribute was specified using the function glVertexAttribI4uiv(),

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1525,7 +1525,13 @@
             "EM_FUNC_SIG_I",
             "EM_FUNC_SIG_II",
             "EM_FUNC_SIG_III",
-            "EM_FUNC_SIG_IIII"
+            "EM_FUNC_SIG_IIII",
+            "EM_FUNC_SIG_PARAM_I",
+            "EM_FUNC_SIG_PARAM_I64",
+            "EM_FUNC_SIG_PARAM_F",
+            "EM_FUNC_SIG_PARAM_D",
+            "EM_FUNC_SIG_PARAM_B",
+            "EM_FUNC_SIG_PARAM_F2I"
             ]
     },
     {

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -196,6 +196,10 @@ typedef int (*em_func_iiiiiiiiii)(int, int, int, int, int, int, int, int, int);
 #define EM_FUNC_SIG_PARAM_D   0x3U
 #define EM_FUNC_SIG_SET_PARAM(i, type) ((EM_FUNC_SIGNATURE)(type) << (2*i))
 
+// Extra types used in WebGL glGet*() calls (not used in proxying)
+#define EM_FUNC_SIG_PARAM_B   0x4U
+#define EM_FUNC_SIG_PARAM_F2I 0x5U
+
 // In total, the above encoding scheme gives the following 32-bit structure for the proxied function signatures (highest -> lowest bit order):
 // RRRiiiiSbbaa99887766554433221100
 // where RRR is return type


### PR DESCRIPTION
Instead of using strings to identify types, use integers that are shorter. Put more code inside GL_TRACK_ERRORS and GL_ASSERTIONS, and micro-optimize sizes of `glGetActiveUniform()`, `glGetActiveAttrib()`, `glGetShaderSource()`, `glGetShaderInfoLog()` and `glGetProgramInfoLog()`.