### PR TITLE
fix_minimal_runtime_warnonce

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1153,6 +1153,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # directory we use.
     shared.reconfigure_cache()
 
+    if shared.Settings.ASSERTIONS and shared.Settings.MINIMAL_RUNTIME:
+      # In ASSERTIONS-builds, functions UTF8ArrayToString() and stringToUTF8Array() (which are not JS library functions), both
+      # use warnOnce(), which in MINIMAL_RUNTIME is a JS library function, so explicitly have to mark dependency to warnOnce()
+      # in that case. If string functions are turned to library functions in the future, then JS dependency tracking can be
+      # used and this special directive can be dropped.
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$warnOnce']
+
     if shared.Settings.USE_PTHREADS:
       # These runtime methods are called from worker.js
       shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']

--- a/emcc.py
+++ b/emcc.py
@@ -1153,13 +1153,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # directory we use.
     shared.reconfigure_cache()
 
-    if shared.Settings.ASSERTIONS and shared.Settings.MINIMAL_RUNTIME:
-      # In ASSERTIONS-builds, functions UTF8ArrayToString() and stringToUTF8Array() (which are not JS library functions), both
-      # use warnOnce(), which in MINIMAL_RUNTIME is a JS library function, so explicitly have to mark dependency to warnOnce()
-      # in that case. If string functions are turned to library functions in the future, then JS dependency tracking can be
-      # used and this special directive can be dropped.
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$warnOnce']
-
     if shared.Settings.USE_PTHREADS:
       # These runtime methods are called from worker.js
       shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']
@@ -1438,6 +1431,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Remove the default exported functions 'memcpy', 'memset', 'malloc', 'free', etc. - those should only be linked in if used
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
+
+      if shared.Settings.ASSERTIONS and shared.Settings.MINIMAL_RUNTIME:
+        # In ASSERTIONS-builds, functions UTF8ArrayToString() and stringToUTF8Array() (which are not JS library functions), both
+        # use warnOnce(), which in MINIMAL_RUNTIME is a JS library function, so explicitly have to mark dependency to warnOnce()
+        # in that case. If string functions are turned to library functions in the future, then JS dependency tracking can be
+        # used and this special directive can be dropped.
+        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$warnOnce']
 
       # Always use the new HTML5 API event target lookup rules
       shared.Settings.DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1

--- a/src/modules.js
+++ b/src/modules.js
@@ -421,7 +421,6 @@ function exportRuntime() {
     'FS_unlink',
     'GL',
     'dynamicAlloc',
-    'warnOnce',
     'loadDynamicLibrary',
     'loadWebAssemblyModule',
     'getLEB',
@@ -448,6 +447,7 @@ function exportRuntime() {
 
   if (!MINIMAL_RUNTIME) {
     runtimeElements.push('Pointer_stringify');
+    runtimeElements.push('warnOnce');
   }
 
   if (MODULARIZE) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4911,6 +4911,16 @@ main( int argv, char ** argc ) {
     self.emcc_args += ['--embed-file', path_from_root('tests/utf8_corpus.txt') + '@/utf8_corpus.txt']
     self.do_run(open(path_from_root('tests', 'benchmark_utf8.cpp')).read(), 'OK.')
 
+  # Test that invalid character in UTF8 does not cause decoding to crash.
+  def test_utf8_invalid(self):
+    self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['UTF8ToString', 'stringToUTF8'])
+    opts = Building.COMPILER_TEST_OPTS[:]
+    for runtime in [[], ['-s', 'MINIMAL_RUNTIME=1']]:
+      for decoder_mode in [[], ['-s', 'TEXTDECODER=1']]:
+        Building.COMPILER_TEST_OPTS = opts + runtime + decoder_mode
+        print(str(runtime + decoder_mode))
+        self.do_run(open(path_from_root('tests', 'utf8_invalid.cpp')).read(), 'OK.')
+
   def test_utf16_textdecoder(self):
     self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['UTF16ToString', 'stringToUTF16', 'lengthBytesUTF16'])
     self.emcc_args += ['--embed-file', path_from_root('tests/utf16_corpus.txt') + '@/utf16_corpus.txt']

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4914,12 +4914,20 @@ main( int argv, char ** argc ) {
   # Test that invalid character in UTF8 does not cause decoding to crash.
   def test_utf8_invalid(self):
     self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['UTF8ToString', 'stringToUTF8'])
-    opts = Building.COMPILER_TEST_OPTS[:]
-    for runtime in [[], ['-s', 'MINIMAL_RUNTIME=1']]:
-      for decoder_mode in [[], ['-s', 'TEXTDECODER=1']]:
-        Building.COMPILER_TEST_OPTS = opts + runtime + decoder_mode
-        print(str(runtime + decoder_mode))
-        self.do_run(open(path_from_root('tests', 'utf8_invalid.cpp')).read(), 'OK.')
+    for decoder_mode in [[], ['-s', 'TEXTDECODER=1']]:
+      self.emcc_args += decoder_mode
+      print(str(decoder_mode))
+      self.do_run(open(path_from_root('tests', 'utf8_invalid.cpp')).read(), 'OK.')
+
+  # Test that invalid character in UTF8 does not cause decoding to crash.
+  @no_wasm_backend("TODO: MINIMAL_RUNTIME not yet available with wasm backend")
+  @no_emterpreter
+  def test_minimal_runtime_utf8_invalid(self):
+    self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['UTF8ToString', 'stringToUTF8'])
+    for decoder_mode in [[], ['-s', 'TEXTDECODER=1']]:
+      self.emcc_args += ['-s', 'MINIMAL_RUNTIME=1'] + decoder_mode
+      print(str(decoder_mode))
+      self.do_run(open(path_from_root('tests', 'utf8_invalid.cpp')).read(), 'OK.')
 
   def test_utf16_textdecoder(self):
     self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['UTF16ToString', 'stringToUTF16', 'lengthBytesUTF16'])

--- a/tests/utf8_invalid.cpp
+++ b/tests/utf8_invalid.cpp
@@ -1,0 +1,13 @@
+#include <emscripten/emscripten.h>
+#include <stdio.h>
+
+int main()
+{
+	char ch[256] = {};
+	for(int i = 0; i < 255; ++i)
+		ch[i] = i+1;
+	int totalLen = 0;
+	for(int i = 0; i < 256; ++i)
+		totalLen += EM_ASM_INT({return UTF8ToString($0).length}, ch);
+	printf("OK. Length: %d\n", totalLen);
+}


### PR DESCRIPTION
Fix warnOnce() being missing for UTF-8 string functions in ASSERTIONS-enabled builds when MINIMAL_RUNTIME is used.
