### PR TITLE
Clear the cache on fastcomp build too, not just upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,6 +203,9 @@ jobs:
             cd -
             echo "final .emscripten:"
             cat ~/.emscripten
+            # Remove any system libs the emsdk installed: we want to rebuild
+            # them all from source here, to check whether new changes work.
+            rm -Rf ~/.emscripten_cache
       - run:
           name: embuilder build ALL
           command: |


### PR DESCRIPTION
In #8994 we fixed upstream builds on that, but forgot fastcomp somehow...

This should fix the current breakage on github CI.