### PR TITLE
Fix access() crash (#9136)

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -116,8 +116,8 @@ var SyscallsLibrary = {
       var node;
       var lookup = FS.lookupPath(path, { follow: true });
       node = lookup.node;
-      if (node === null) {
-          return -{{{ cDefine('ENOENT') }}};
+      if (!node) {
+        return -{{{ cDefine('ENOENT') }}};
       }
       var perms = '';
       if (amode & {{{ cDefine('R_OK') }}}) perms += 'r';

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -116,6 +116,9 @@ var SyscallsLibrary = {
       var node;
       var lookup = FS.lookupPath(path, { follow: true });
       node = lookup.node;
+      if (node === null) {
+          return -{{{ cDefine('ENOENT') }}};
+      }
       var perms = '';
       if (amode & {{{ cDefine('R_OK') }}}) perms += 'r';
       if (amode & {{{ cDefine('W_OK') }}}) perms += 'w';

--- a/tests/unistd/access.c
+++ b/tests/unistd/access.c
@@ -33,8 +33,9 @@ int main() {
     FS.writeFile('allaccess', ''); FS.chmod('allaccess', 0777);
   );
 #endif
+  // Empty path checks #9136 fix
   char* files[] = {"readable", "writeable",
-                   "allaccess", "forbidden", "nonexistent"};
+                   "allaccess", "forbidden", "nonexistent", ""};
   for (int i = 0; i < sizeof files / sizeof files[0]; i++) {
     printf("F_OK(%s): %d\n", files[i], access(files[i], F_OK));
     printf("errno: %d\n", errno);

--- a/tests/unistd/access.out
+++ b/tests/unistd/access.out
@@ -43,3 +43,12 @@ errno: 2
 W_OK(nonexistent): -1
 errno: 2
 
+F_OK(): -1
+errno: 2
+R_OK(): -1
+errno: 2
+X_OK(): -1
+errno: 2
+W_OK(): -1
+errno: 2
+


### PR DESCRIPTION
The reason of #9136 is that callers of `lookupPath` don't consider it may return an invalid node object. By this patch, `lookupPath` now throws ENOENT error exception instead of returning an invalid node. Then callers of `lookupPath` now can handle the error properly.