### PR TITLE
Avoid a warning which turns into an error in sqlite.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5820,6 +5820,10 @@ return malloc(size);
       print("disabling inlining") # without registerize (which -g disables), we generate huge amounts of code
       self.set_setting('INLINING_LIMIT', 50)
 
+    # newer clang has a warning for implicit conversions that lose information,
+    # which happens in sqlite (see #9138)
+    self.emcc_args += ['-Wno-implicit-int-float-conversion']
+
     src = '''
        #define SQLITE_DISABLE_LFS
        #define LONGDOUBLE_TYPE double

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5823,6 +5823,9 @@ return malloc(size);
     # newer clang has a warning for implicit conversions that lose information,
     # which happens in sqlite (see #9138)
     self.emcc_args += ['-Wno-implicit-int-float-conversion']
+    # temporarily ignore unknown flags, which lets the above flag be used on our CI which doesn't
+    # yet have the new clang with that flag
+    self.emcc_args += ['-Wno-unknown-warning-option']
 
     src = '''
        #define SQLITE_DISABLE_LFS


### PR DESCRIPTION
Should unbreak the llvm autoroller.

The warning is
```
/b/s/w/ir/tmp/t/tmprZfbf9/emscripten_test_wasm0_C0rW8g/src.c:82483:38: error: implicit conversion from 'long long' to 'double' changes value from 9223372036854775806 to 9223372036854775808 [-Werror,-Wimplicit-int-float-conversion]
  if( n==0 && r>=0 && r<LARGEST_INT64-1 ){
                       ~~~~~~~~~~~~~~^~
/b/s/w/ir/tmp/t/tmprZfbf9/emscripten_test_wasm0_C0rW8g/src.c:82485:46: error: implicit conversion from 'long long' to 'double' changes value from 9223372036854775806 to 9223372036854775808 [-Werror,-Wimplicit-int-float-conversion]
  }else if( n==0 && r<0 && (-r)<LARGEST_INT64-1 ){
                               ~~~~~~~~~~~~~~^~
`