### PR TITLE
Remove unneeded libcxxabi paths from system libs

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -703,7 +703,6 @@ class libcxxabi(CXXLibrary, MTLibrary):
       cflags.append('-D_LIBCXXABI_HAS_NO_THREADS')
     return cflags
 
-  includes = ['system', 'lib', 'libcxxabi', 'include']
   src_dir = ['system', 'lib', 'libcxxabi', 'src']
   src_files = [
     'abort_message.cpp',
@@ -727,7 +726,6 @@ class libcxx(NoBCLibrary, CXXLibrary, NoExceptLibrary, MTLibrary):
   symbols = read_symbols(shared.path_from_root('system', 'lib', 'libcxx.symbols'))
   depends = ['libc++abi']
 
-  includes = ['system', 'lib', 'libcxxabi', 'include']
   cflags = ['-std=c++11', '-DLIBCXX_BUILDING_LIBCXXABI=1', '-D_LIBCPP_BUILDING_LIBRARY', '-Oz',
             '-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS']
 


### PR DESCRIPTION
Thanks for the explanation in the issue @quantum5 , here is a fix. We can just remove these as they were wrong anyhow, as emcc points to libcxxabi internally.

Fixes #9144
