### PR TITLE
Ensure dyn_needed is bytes before writing it in make_shared_library.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3191,7 +3191,7 @@ class WebAssembly(object):
     # https://github.com/WebAssembly/tool-conventions/pull/77
     contents += WebAssembly.lebify(len(needed_dynlibs))
     for dyn_needed in needed_dynlibs:
-      dyn_needed = asbytes(dyn_needed)
+      dyn_needed = bytes(asbytes(dyn_needed))
       contents += WebAssembly.lebify(len(dyn_needed))
       contents += dyn_needed
 


### PR DESCRIPTION
It would work as a str, which was the case before #9132, but now these values may be unicode, which python2 will not write as binary, so we need to explicitly cast.

I don't fully understand why `asbytes` doesn't actually return bytes, but this is a subtle python2/3 issue I guess - when we remove python2 support we can simplify this.

Fixes current breakage on emscripten autoroller, tested locally with fastcomp and upstream and python2 and 3 (failure before was only python2 on fastcomp).