### PR TITLE
Remove TEMP_DIR support from emscripten config file

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -194,7 +194,6 @@ key values in that file include:
  * `LLVM_ROOT`: The path to the LLVM binaries.
  * `BINARYEN_ROOT`: The path to binaryen (the binaries are expected in `/bin` there).
  * `NODE_JS`: The path to Node.js, which is needed internally.
- * `TEMP_DIR`: The default temp directory.
  * `COMPILER_ENGINE`: The VM used internally for the JS compiler. Normally this should be `NODE_JS`.
  * `JS_ENGINES`: The full list of JS engines (or just `[NODE_JS]`). Used in the test suite.
 

--- a/site/source/docs/building_from_source/configuring_emscripten_settings.rst
+++ b/site/source/docs/building_from_source/configuring_emscripten_settings.rst
@@ -71,25 +71,6 @@ The compiler configuration file can be edited with the text editor of your choic
 
 	.. note:: Use forward slashes!
 
-#. Edit the variable ``TEMP_DIR`` to point to a valid path on your local system, e.g. ``TEMP_DIR = '/tmp'`` (``TEMP_DIR = 'c:/tmp'`` on Windows), and create that folder on the local filesystem if it doesn't exist.
-
 .. comment .. The settings are now correct in the configuration file, but the paths and environment variables are not set in the command prompt/terminal. **HamishW** Follow up with Jukka on this.
  
 After setting those paths, run ``emcc`` again. It should again perform the sanity checks to test the specified paths. There are further validation tests available at :ref:`verifying-the-emscripten-environment`.
-
-
-
-
-
-	
-	
-
-
-
-
-	
-
-
- 
-
-

--- a/site/source/docs/porting/Debugging.rst
+++ b/site/source/docs/porting/Debugging.rst
@@ -53,7 +53,7 @@ With ``EMCC_DEBUG=1`` set, :ref:`emcc <emccdoc>` emits debug output and generate
 
 The debug logs and intermediate files are output to
 **TEMP_DIR/emscripten_temp**, where ``TEMP_DIR`` is the OS default temporary
-direcotyr (e.g. **/tmp** on UNIX).
+directory (e.g. **/tmp** on UNIX).
 
 The debug logs can be analysed to profile and review the changes that were made in each step.
 

--- a/site/source/docs/porting/Debugging.rst
+++ b/site/source/docs/porting/Debugging.rst
@@ -51,7 +51,9 @@ The ``EMCC_DEBUG`` environment variable can be set to enable Emscripten's debug 
 
 With ``EMCC_DEBUG=1`` set, :ref:`emcc <emccdoc>` emits debug output and generates intermediate files for the compiler's various stages. ``EMCC_DEBUG=2`` additionally generates intermediate files for each JavaScript optimizer pass.
 
-The debug logs and intermediate files are output to **TEMP_DIR/emscripten_temp**, where ``TEMP_DIR`` is by default **/tmp** (it is defined in the :ref:`.emscripten configuration file <compiler-configuration-file>`).
+The debug logs and intermediate files are output to
+**TEMP_DIR/emscripten_temp**, where ``TEMP_DIR`` is the OS default temporary
+direcotyr (e.g. **/tmp** on UNIX).
 
 The debug logs can be analysed to profile and review the changes that were made in each step.
 

--- a/site/source/docs/tools_reference/emsdk.rst
+++ b/site/source/docs/tools_reference/emsdk.rst
@@ -97,7 +97,6 @@ Below are typical **.emscripten** files created by *emsdk*. Note the variable na
   PYTHON='C:/Program Files/Emscripten/python/2.7.5.3_64bit/python.exe'
   JAVA='C:/Program Files/Emscripten/java/7.45_64bit/bin/java.exe'
   V8_ENGINE = ''
-  TEMP_DIR = 'c:/users/hamis_~1/appdata/local/temp'
   COMPILER_ENGINE = NODE_JS
   JS_ENGINES = [NODE_JS]
 
@@ -110,7 +109,6 @@ Below are typical **.emscripten** files created by *emsdk*. Note the variable na
   NODE_JS = 'nodejs'
   LLVM_ROOT='/home/ubuntu/emsdk_portable/clang/fastcomp/build_incoming_64/bin'
   V8_ENGINE = ''
-  TEMP_DIR = '/tmp'
   COMPILER_ENGINE = NODE_JS
   JS_ENGINES = [NODE_JS]
 

--- a/tools/duplicate_function_eliminator.py
+++ b/tools/duplicate_function_eliminator.py
@@ -10,6 +10,7 @@ import subprocess
 import re
 import json
 import shutil
+import tempfile
 import logging
 import traceback
 
@@ -332,7 +333,7 @@ def save_temp_file(file_to_process):
   if os.environ.get('EMSCRIPTEN_SAVE_TEMP_FILES') and os.environ.get('EMSCRIPTEN_TEMP_FILES_DIR'):
     destinationFile = file_to_process
 
-    temp_dir_name = os.environ.get('TEMP_DIR')
+    temp_dir_name = tempfile.gettempdir()
     destinationFile = destinationFile.replace(temp_dir_name, os.environ.get('EMSCRIPTEN_TEMP_FILES_DIR'))
 
     if not os.path.exists(os.path.dirname(destinationFile)):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -493,21 +493,6 @@ def check_closure_compiler():
   return True
 
 
-# Finds the system temp directory without resorting to using the one configured in .emscripten
-def find_temp_directory():
-  if WINDOWS:
-    if os.getenv('TEMP') and os.path.isdir(os.getenv('TEMP')):
-      return os.getenv('TEMP')
-    elif os.getenv('TMP') and os.path.isdir(os.getenv('TMP')):
-      return os.getenv('TMP')
-    elif os.path.isdir('C:\\temp'):
-      return os.getenv('C:\\temp')
-    else:
-      return None # No luck!
-  else:
-    return '/tmp'
-
-
 def get_emscripten_version(path):
   return open(path).read().strip().replace('"', '')
 
@@ -892,18 +877,9 @@ class Configuration(object):
   def __init__(self, environ=os.environ):
     self.EMSCRIPTEN_TEMP_DIR = None
 
-    if "EMCC_TEMP_DIR" in environ:
-      TEMP_DIR = environ.get("EMCC_TEMP_DIR")
-    try:
-      self.TEMP_DIR = TEMP_DIR
-    except NameError:
-      self.TEMP_DIR = find_temp_directory()
-      if self.TEMP_DIR is None:
-        logger.critical('TEMP_DIR not defined in ' + hint_config_file_location() + ", and could not detect a suitable directory! Please configure .emscripten to contain a variable TEMP_DIR='/path/to/temp/dir'.")
-      logger.debug('TEMP_DIR not defined in ' + hint_config_file_location() + ', using ' + self.TEMP_DIR)
-
+    self.TEMP_DIR = environ.get("EMCC_TEMP_DIR", tempfile.gettempdir())
     if not os.path.isdir(self.TEMP_DIR):
-      logger.critical("The temp directory TEMP_DIR='" + self.TEMP_DIR + "' doesn't seem to exist! Please make sure that the path is correct.")
+      exit_with_error("The temporary directory `" + self.TEMP_DIR + "` does not exist! Please make sure that the path is correct.")
 
     self.CANONICAL_TEMP_DIR = get_canonical_temp_dir(self.TEMP_DIR)
 


### PR DESCRIPTION
Due to an oversight in #7412, TEMP_DIR has not been honored in the
config file for a long time now.  Rather than re-instant support
for this config variable this change simplifies the code by removing
special handling.

Instead rely on python's `tempfile.gettempdir()` which has OS-specific
defaults and allows for environment variable overrides.

See #9098
