### PR TITLE
Warn if main exists but is not exported

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7461,6 +7461,12 @@ int main() {
     # when exported, all good
     test("Module['print']('print'); Module['printErr']('err'); ", 'print\nerr', ['-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["print", "printErr"]'])
 
+  def test_warn_unexported_main(self):
+    WARNING = 'main() is in the input files, but "_main" is not in EXPORTED_FUNCTIONS, which means it may be eliminated as dead code. Export it if you want main() to run.'
+
+    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=[]'], stderr=PIPE)
+    self.assertContained(WARNING, proc.stderr)
+
   def test_arc4random(self):
     create_test_file('src.c', r'''
 #include <stdlib.h>

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1105,6 +1105,16 @@ class libasan_rt_wasm(SanitizerLibrary):
   src_dir = ['system', 'lib', 'compiler-rt', 'lib', 'asan']
 
 
+# If main() is not in EXPORTED_FUNCTIONS, it may be dce'd out. This can be
+# confusing, so issue a warning.
+def warn_on_unexported_main(symbolses):
+  if '_main' not in shared.Settings.EXPORTED_FUNCTIONS:
+    for symbols in symbolses:
+      if 'main' in symbolses[0].defs:
+        logger.warning('main() is in the input files, but "_main" is not in EXPORTED_FUNCTIONS, which means it may be eliminated as dead code. Export it if you want main() to run.')
+        return
+
+
 def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   global stdout, stderr
   stdout = stdout_
@@ -1147,6 +1157,8 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 
   # Scan symbols
   symbolses = shared.Building.parallel_llvm_nm([os.path.abspath(t) for t in temp_files])
+
+  warn_on_unexported_main(symbolses)
 
   if len(symbolses) == 0:
     class Dummy(object):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1110,7 +1110,7 @@ class libasan_rt_wasm(SanitizerLibrary):
 def warn_on_unexported_main(symbolses):
   if '_main' not in shared.Settings.EXPORTED_FUNCTIONS:
     for symbols in symbolses:
-      if 'main' in symbolses[0].defs:
+      if 'main' in symbols.defs:
         logger.warning('main() is in the input files, but "_main" is not in EXPORTED_FUNCTIONS, which means it may be eliminated as dead code. Export it if you want main() to run.')
         return
 


### PR DESCRIPTION
As it may be dce'd, and then not run.

A possible reason this might happen is doing `./emcc -s EXPORTED_FUNCTIONS=["_myfunc"]` and forgetting to also have `_main` (which it is by default, but the commandline flag overrode the default value).

A possible downside to this patch is that it depends on emcc scanning symbols, which we have been hoping to avoid eventually. If we disallow that then logic like this would need to be in wasm-ld I guess.