### PR TITLE
Add an option to disable OES_half_float extensions if they are detected to be broken

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -457,6 +457,12 @@ var STB_IMAGE = 0;
 // If you do not care about old iOS 9 support, keep this disabled.
 var WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0;
 
+// From Safari 8 (where WebGL was introduced to Safari) onwards, OES_texture_half_float and OES_texture_half_float_linear extensions
+// are broken and do not function correctly, when used as source textures.
+// See https://bugs.webkit.org/show_bug.cgi?id=183321, https://bugs.webkit.org/show_bug.cgi?id=169999,
+// https://stackoverflow.com/questions/54248633/cannot-create-half-float-oes-texture-from-uint16array-on-ipad
+var GL_DISABLE_HALF_FLOAT_EXTENSION_IF_BROKEN = 0;
+
 // If set, enables polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround.
 var POLYFILL_OLD_MATH_FUNCTIONS = 0;
 


### PR DESCRIPTION
Disabled by default because many GL utilizing projects might not even use half-floats, and do not want to pay the increased code size.

Also it may be possible that if half-float textures cannot be used on Safari on macOS/iOS, that half-float textures may be usable as FBO render targets, although that has been untested. (if that part of the extension works, then there may be use to 