### PR TITLE
Add generic method for overriding specific config variables via env vars

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,6 +32,8 @@ v1.38.48: 10/11/2019
    on the main thread. #9567
  - Remove `EMCONFIGURE_JS`. Since #6269 we have set it to "2" which means never
    use native, always use JS.
+ - Add support for override config variables using environment varaibles.  Any
+   config varaible `FOO` can be overridden by `EM_FOO` in the environment.
 
 v.1.38.47: 10/02/2019
 ---------------------
@@ -64,7 +66,7 @@ v.1.38.46: 09/25/2019
    that we want the wasm to be as standalone as possible. We may still emit JS in
    that case, but the JS would just be a convenient way to run the wasm on the Web
    or in Node.js.
- - ASYNCIFY_BLACKLIST and ASYNCIFY_WHITELIST now support simple '*' wildcard matching
+ - ASYNCIFY_BLACKLIST and ASYNCIFY_WHITELIST now support simple '\*' wildcard matching
 
 v.1.38.45: 09/12/2019
 ---------------------
@@ -123,21 +125,22 @@ v.1.38.40: 07/24/2019
    and C11/C++11 keyword `thread_local`. (#8976)
  - Internal API change: Move read, readAsync, readBinary, setWindowTitle from
    the Module object to normal JS variables. If you use those internal APIs,
-   you must change Module.readAsync()/Module['readAsync']() to readAsync().
-   Note that read is also renamed to read_ (since "read" is an API call in
+   you must change `Module.readAsync()/Module['readAsync']()` to `readAsync()`.
+   Note that read is also renamed to `read_` (since "`read`" is an API call in
    the SpiderMonkey shell). In builds with ASSERTIONS an error message is
    shown about the API change. This change allows better JS minification
    (the names read, readAsync etc. can be minified, and if the variables are
    not used they can be removed entirely). Defining these APIs on Module
    (which was never documented or intended, but happened to work) is also
-   no longer allowed (but you can override read_ etc. from JS).
+   no longer allowed (but you can override `read_` etc. from JS).
 
 v1.38.39: 07/16/2019
 --------------------
  - Add support for [address sanitizer](https://clang.llvm.org/docs/AddressSanitizer.html). (#8884)
    - Currently, only supports one thread without dynamic linking.
- - Rename Bysyncify (the name used during development) to Asyncify. This keeps the name consistent
-   with the old ASYNCIFY flag, no need for a new one, as they do basically the same thing.
+ - Rename Bysyncify (the name used during development) to Asyncify. This keeps
+   the name consistent with the old ASYNCIFY flag, no need for a new one, as
+   they do basically the same thing.
 
 v1.38.38: 07/08/2019
 --------------------
@@ -177,8 +180,8 @@ v1.38.35: 06/13/2019
 v1.38.34: 06/01/2019
 --------------------
  - Add support for [undefined behavior sanitizer](https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html).
-     - This allows `emcc -fsanitize=undefined` to work. (#8651)
-     - The minimal runtime (`-fsanitize-minimal-runtime`) also works. (#8617)
+    - This allows `emcc -fsanitize=undefined` to work. (#8651)
+    - The minimal runtime (`-fsanitize-minimal-runtime`) also works. (#8617)
 
 v1.38.33: 05/23/2019
 --------------------
@@ -189,21 +192,21 @@ v1.38.33: 05/23/2019
 
 v1.38.32: SKIPPED
 -----------------
- - The transition from the old to the new CI occured around here. To avoid ambiguity while
-   both CIs were still generating builds, we just tagged a new one (1.38.33) on the new CI
-   and skipped 1.38.32.
- - The transition also moves all builds and downloads away from the old mozilla-games
-   infrastructure to the new chromium ones. As a result all links to *mozilla-games* URLs
-   will not work (these were never documented, but could be seen from the internals of the
-   emsdk; the new emsdk uses the proper new URLs, so you can either use the sdk normally
-   or find the URLs from there).
+ - The transition from the old to the new CI occured around here. To avoid
+   ambiguity while both CIs were still generating builds, we just tagged a new
+   one (1.38.33) on the new CI and skipped 1.38.32.
+ - The transition also moves all builds and downloads away from the old
+   mozilla-games infrastructure to the new chromium ones. As a result all links
+   to *mozilla-games* URLs will not work (these were never documented, but could
+   be seen from the internals of the emsdk; the new emsdk uses the proper new
+   URLs, so you can either use the sdk normally or find the URLs from there).
 
 v1.38.31: 04/24/2019
 --------------------
- - Change ino_t/off_t to 64-bits. (#8467)
+ - Change `ino_t/off_t` to 64-bits. (#8467)
  - Add port for bzip2 library (`libbz2.a`). (#8349)
  - Add port for libjpeg library. (#8361)
- - Enable ERROR_ON_MISSING_LIBRARIES by by default (#8461)
+ - Enable `ERROR_ON_MISSING_LIBRARIES` by by default (#8461)
 
 v1.38.30: 03/21/2019
 --------------------
@@ -216,7 +219,7 @@ v1.38.29: 03/11/2019
 
 v1.38.28: 02/22/2019
 --------------------
- - Option -s EMTERPRETIFY_WHITELIST now accepts shell-style wildcards;
+ - Option `-s EMTERPRETIFY_WHITELIST` now accepts shell-style wildcards;
    this allows matching static functions with conflicting names that
    the linker distinguishes by appending a random suffix.
  - Normalize mouse wheel delta in `library_browser.js`. This changes the scroll
@@ -224,9 +227,9 @@ v1.38.28: 02/22/2019
 
 v1.38.27: 02/10/2019
 --------------------
- - Change how EMCC_LOCAL_PORTS works, to be more usable. See #7963
+ - Change how `EMCC_LOCAL_PORTS` works, to be more usable. See #7963
  - Remove deprecated Pointer_stringify (use UTF8ToString instead). See #8011
- - Added a new option -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 that
+ - Added a new option `-s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1` that
    changes the lookup semantics of DOM elements in html5.h event handler
    callback and WebGL context creation. New behavior is to use CSS selector
    strings to look up DOM elements over the old behavior, which was somewhat
@@ -245,7 +248,7 @@ v1.38.26: 02/04/2019
 v1.38.25: 01/18/2019
 --------------------
  - Move kripken/emscripten,emscripten-fastcomp,emscripten-fastcomp-clang to
-   emscripten-core/*
+   emscripten-core/\*
 
 v1.38.24: 01/17/2019
 --------------------
@@ -261,7 +264,7 @@ v1.38.22: 01/08/2019
 --------------------
  - Add Regal port. See #7674
  - System libraries have been renamed to include the `lib` prefix.  If you use
-   EMCC_FORCE_STDLIBS or EMCC_ONLY_FORCED_STDLIBS to select system libraries
+   `EMCC_FORCE_STDLIBS` or `EMCC_ONLY_FORCED_STDLIBS` to select system libraries
    you may need to add the `lib` prefix.
  - Rename `pthread-main.js` to `NAME.worker.js`, where `NAME` is the main
    name of your application, that is, if you emit `program.js` then you'll get

--- a/tools/settings_template.py
+++ b/tools/settings_template.py
@@ -3,7 +3,11 @@
 
 # Note: If you put paths relative to the home directory, do not forget
 # os.path.expanduser
-
+#
+# Any config setting <KEY> in this file can be overridden by setting the
+# EM_<KEY> environment variable. For example, settings EM_LLVM_ROOT override
+# the setting in this file.
+#
 # Note: On Windows, remember to escape backslashes! I.e. LLVM='c:\llvm\'
 # is not valid, but LLVM='c:\\llvm\\' and LLVM='c:/llvm/'
 # are.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -202,7 +202,7 @@ def check_call(cmd, *args, **kw):
 def generate_config(path, first_time=False):
   # Note: repr is used to ensure the paths are escaped correctly on Windows.
   # The full string is replaced so that the template stays valid Python.
-  config_file = open(path_from_root('tools', 'settings_template_readonly.py')).read().splitlines()
+  config_file = open(path_from_root('tools', 'settings_template.py')).read().splitlines()
   config_file = config_file[3:] # remove the initial comment
   config_file = '\n'.join(config_file)
   # autodetect some default paths
@@ -316,7 +316,10 @@ FROZEN_CACHE = False
 
 
 def parse_config_file():
-  """Parse the emscripten config file using python's exec"""
+  """Parse the emscripten config file using python's exec.
+
+  Also also EM_<KEY> environment variables to override specific config keys.
+  """
   global JS_ENGINES, JAVA, CLOSURE_COMPILER
 
   config = {}
@@ -329,7 +332,7 @@ def parse_config_file():
   CONFIG_KEYS = (
     'NODE_JS',
     'BINARYEN_ROOT',
-    'EM_POPEN_WORKAROUND',
+    'POPEN_WORKAROUND',
     'SPIDERMONKEY_ENGINE',
     'EMSCRIPTEN_NATIVE_OPTIMIZER',
     'V8_ENGINE',
@@ -348,7 +351,11 @@ def parse_config_file():
 
   # Only popogate certain settings from the config file.
   for key in CONFIG_KEYS:
-    if key in config:
+    env_var = 'EM_' + key
+    env_value = os.environ.get(env_var)
+    if env_value is not None:
+      globals()[key] = env_value
+    elif key in config:
       globals()[key] = config[key]
 
   # Certain keys are mandatory
@@ -403,9 +410,6 @@ NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
 V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
 JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
 WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
-
-if EM_POPEN_WORKAROUND is None:
-  EM_POPEN_WORKAROUND = os.environ.get('EM_POPEN_WORKAROUND')
 
 # Install our replacement Popen handler if we are running on Windows to avoid
 # python spawn process function.
@@ -960,8 +964,11 @@ def check_vanilla():
       return has_wasm_target(targets) and not has_asm_js_target(targets)
 
     def get_vanilla_file():
+      logger.debug('regenerating vanilla file: %s' % LLVM_ROOT)
       saved_file = os.path.join(temp_cache.dirname, 'is_vanilla.txt')
-      open(saved_file, 'w').write(('1' if check_vanilla() else '0') + ':' + LLVM_ROOT)
+      if os.path.exists(saved_file):
+        logger.debug('old: %s\n' % open(saved_file).read())
+      open(saved_file, 'w').write(('1' if check_vanilla() else '0') + ':' + LLVM_ROOT + '\n')
       return saved_file
 
     is_vanilla_file = temp_cache.get('is_vanilla.txt', get_vanilla_file)
@@ -969,12 +976,12 @@ def check_vanilla():
       logger.debug('config file changed since we checked vanilla; re-checking')
       is_vanilla_file = temp_cache.get('is_vanilla.txt', get_vanilla_file, force=True)
     try:
-      contents = open(is_vanilla_file).read()
+      contents = open(is_vanilla_file).read().strip()
       middle = contents.index(':')
       is_vanilla = int(contents[:middle])
       llvm_used = contents[middle + 1:]
       if llvm_used != LLVM_ROOT:
-        logger.debug('regenerating vanilla check since other llvm')
+        logger.debug('regenerating vanilla check since other llvm (%s vs %s)`', llvm_used, LLVM_ROOT)
         temp_cache.get('is_vanilla.txt', get_vanilla_file, force=True)
         is_vanilla = check_vanilla()
     except Exception as e:


### PR DESCRIPTION
For any config variable such as LLVM_ROOT you can now always set
EM_LLVM_ROOT to override it.
