### PR TITLE
Avoid assertions in other.test_lsan_no_leak to avoid extra warnings in stderr

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9456,7 +9456,7 @@ int main () {
   @no_fastcomp('lsan not supported on fastcomp')
   def test_lsan_no_leak(self, ext):
     self.do_smart_test(path_from_root('tests', 'other', 'test_lsan_no_leak.' + ext),
-                       emcc_args=['-fsanitize=leak', '-s', 'ALLOW_MEMORY_GROWTH=1'],
+                       emcc_args=['-fsanitize=leak', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'ASSERTIONS=0'],
                        regexes=[r'^\s*$'])
 
   @no_fastcomp('asan is not supported on fastcomp')


### PR DESCRIPTION
This should fix current flakiness ([e.g.](https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8905751094776190464/+/steps/Emscripten_testsuite__upstream__other_/0/stdout)), but @quantum5 has a better but more complicated fix in the works for the underlying issue as well. 