### PR TITLE
Avoid attempting to demangle _Z in middle of a word

### DIFF
--- a/src/library_stack_trace.js
+++ b/src/library_stack_trace.js
@@ -40,9 +40,9 @@ var LibraryStackTrace = {
   $demangleAll: function(text) {
     var regex =
 #if WASM_BACKEND
-      /_Z[\w\d_]+/g;
+      /\b_Z[\w\d_]+/g;
 #else
-      /__Z[\w\d_]+/g;
+      /\b__Z[\w\d_]+/g;
 #endif
     return text.replace(regex,
       function(x) {


### PR DESCRIPTION
`demangleAll` attempts to demangle stuff like `something_Zsomething` in temporary directory names in tests, resulting in spurious warnings to build with `-s DEMANGLE_SUPPORT=1`, causing test failures.