### PR TITLE
Ignore third component of python version

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -94,11 +94,10 @@ def is_python3_version_supported():
   if not python3:
     return False
   output = run_process([python3, '--version'], stdout=PIPE).stdout
-  # strip out 'rc1' etc., we don't care about release candidates
-  if 'rc' in output:
-    output = output.split('rc')[0]
-  version = [int(x) for x in output.split(' ')[1].split('.')]
-  return version >= [3, 5, 0]
+  output = output.split(' ')[1]
+  # ignore final component which can contains non-integers (e.g 'rc1')
+  version = [int(x) for x in output.split('.')[:2]]
+  return version >= [3, 5]
 
 
 def encode_leb(number):


### PR DESCRIPTION
We were already ignoring the 'rc' suffix but the third component
can have other suffixed too.
