### PR TITLE
Test wasm3 on upstream

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -300,10 +300,6 @@ jobs:
     <<: *test-defaults
     environment:
       - TEST_TARGET=wasm0
-  test-wasm1:
-    <<: *test-defaults
-    environment:
-      - TEST_TARGET=wasm1
   test-wasm2:
     <<: *test-defaults
     environment:
@@ -388,8 +384,12 @@ jobs:
   test-upstream-wasm2:
     <<: *test-defaults
     environment:
-      - TEST_TARGET=wasm2 wasm3.test_llvm_used
-      # TODO: test all of wasm3/wasms on LLVM wasm backend
+      - TEST_TARGET=wasm2
+  test-upstream-wasm3:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=wasm3
+      # TODO: test wasms
   test-upstream-other:
     <<: *test-defaults
     environment:
@@ -450,9 +450,6 @@ workflows:
       - test-wasm0:
           requires:
             - build
-      - test-wasm1:
-          requires:
-            - build
       - test-wasm2:
           requires:
             - build
@@ -467,6 +464,9 @@ workflows:
           requires:
             - build-upstream
       - test-upstream-wasm2:
+          requires:
+            - build-upstream
+      - test-upstream-wasm3:
           requires:
             - build-upstream
       - test-upstream-other:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2587,6 +2587,7 @@ class Building(object):
     for line in out.split('\n'):
       if SEP in line:
         old, new = line.strip().split(SEP)
+        assert old not in mapping, 'imports must be unique'
         mapping[old] = new
     # apply them
     passes = ['applyImportAndExportNameChanges']


### PR DESCRIPTION
This adds `wasm3` testing to CI here, which includes metadce and import/export minifying. This would have caught the recent regression on `wasm3.test_longjmp,test_freetype`.

To avoid increasing our overall load, this removes the `wasm1` from fastcomp. I think that's reasonable since `-O1` isn't that special, and we do have coverage for it in `other`, and we are moving away from fastcomp.

This also adds an assertion for that import minifying issue (duplicate imports), which would have made that regression even easier to understand.