### PR TITLE
Remove internal musl symlink

### DIFF
--- a/system/include/libc/bits
+++ b/system/include/libc/bits
@@ -1,1 +1,0 @@
-../../lib/libc/musl/arch/emscripten/bits


### PR DESCRIPTION
This should unbreak the LLVM roll, as something in clang now appears to error early if a path is wrong (it sees the symlink as a normal file, and complains that it isn't a dir, instead of continuing as before to the next library include paths, where it would find the proper one).

The symlink appears to not be needed - we pass the full path to the parent of `/bits/` anyhow. Perhaps it was needed in the past for some reason? Maybe @juj remembers something.

We do need to confirm this works on windows though, as our precommit CI doesn't test that.