### PR TITLE
Lambdas do not accept tuples in Python 3

### DIFF
--- a/tools/find_bigfuncs.py
+++ b/tools/find_bigfuncs.py
@@ -87,7 +87,7 @@ def uniq_compare(data1, data2):
 
 def list_bigfuncs(data):
     data = list(data.items())
-    data.sort(key=lambda (f, d): d[0])
+    data.sort(key=lambda f, d: d[0])
     print(''.join(['%6d lines (%6s) : %s' % (d[0], humanbytes(d[1]), f) for f, d in data]))
 
 

--- a/tools/find_bigfuncs.py
+++ b/tools/find_bigfuncs.py
@@ -87,7 +87,7 @@ def uniq_compare(data1, data2):
 
 def list_bigfuncs(data):
     data = list(data.items())
-    data.sort(key=lambda f, d: d[0])
+    data.sort(key=lambda f_d: f_d[1][0])
     print(''.join(['%6d lines (%6s) : %s' % (d[0], humanbytes(d[1]), f) for f, d in data]))
 
 


### PR DESCRIPTION
__python3 -c "lambda (a, b): a"__  # —> syntax error

https://portingguide.readthedocs.io/en/latest/syntax.html?highlight=Lambda#tuple-unpacking-in-parameter-lists
