### PR TITLE
Old style exceptions —> new style for Python 3

### DIFF
--- a/tests/fuzz/creduce_tester.py
+++ b/tests/fuzz/creduce_tester.py
@@ -32,7 +32,7 @@ try:
   shared.run_process([shared.CLANG_CC, '-O2', filename, '-o', obj_filename] + CSMITH_CFLAGS)
   print('3) Run natively')
   correct = jsrun.timeout_run(Popen([obj_filename], stdout=PIPE, stderr=PIPE), 3)
-except Exception, e:
+except Exception as e:
   print('Failed or infinite looping in native, skipping', e)
   sys.exit(1) # boring
 
@@ -52,7 +52,7 @@ for args in [[]]:
   try:
     try_js(args)
     break
-  except Exception, e:
+  except Exception as e:
     pass
 else:
   sys.exit(0)

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -104,7 +104,7 @@ while 1:
       raise Exception('segfault')
     if correct1 != correct3:
       raise Exception('clang opts change result')
-  except Exception, e:
+  except Exception as e:
     print('Failed or infinite looping in native, skipping', e)
     notes['invalid'] += 1
     continue
@@ -179,7 +179,7 @@ while 1:
       shared.run_process(js_args)
       assert os.path.exists(filename + '.js')
       return js_args
-    except:
+    except Exception:
       return False
 
   def execute_js(engine):


### PR DESCRIPTION
Old style exceptions are syntax errors in Python 3 but new style exceptions work as expected in both Python 2 and Python 3.

Thank you for submitting a pull request!

If this is your first PR, make sure to add yourself to AUTHORS.
