### PR TITLE
Remove arbitrary code execution in byte size settings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,10 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+ - Remove the ability to use Python operators in flags that support KB/MB/GB/TB
+   suffixes, e.g. `TOTAL_MEMORY`. This means that `-s TOTAL_MEMORY=1024*1024`
+   will no longer work. This is done because the mechanism may result in
+   execution of arbitrary code via command line flags.
 
 v.1.38.41: 08/07/2019
 ---------------------

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7834,12 +7834,12 @@ int main() {
       self.assertContained('TOTAL_MEMORY must be at least 16MB', ret)
 
     # Must be a multiple of 64KB
-    ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'TOTAL_MEMORY=32MB+1'])
+    ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'TOTAL_MEMORY=33554433']) # 32MB + 1 byte
     self.assertContained('TOTAL_MEMORY must be a multiple of 64KB', ret)
 
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM_MEM_MAX=33MB'])
 
-    ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM_MEM_MAX=33MB+1'])
+    ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM_MEM_MAX=34603009']) # 33MB + 1 byte
     self.assertContained('WASM_MEM_MAX must be a multiple of 64KB', ret)
 
   def test_invalid_output_dir(self):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1084,9 +1084,12 @@ def expand_byte_size_suffixes(value):
   """Given a string with KB/MB size suffixes, such as "32MB", computes how
   many bytes that is and returns it as an integer.
   """
-  match = re.match(r'\s*(\d+)\s*([kmgt]?b)', value, re.I)
+  match = re.match(r'\s*(\d+)\s*([kmgt]?b)$', value, re.I)
   if not match:
-    raise Exception("Invalid byte size, valid suffixes: KB, MB, GB, TB")
+    try:
+      return int(value)
+    except ValueError:
+      raise Exception("Invalid byte size, valid suffixes: KB, MB, GB, TB")
   value, suffix = match.groups()
   return int(value) * SIZE_SUFFIXES[suffix.lower()]
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1081,9 +1081,8 @@ SIZE_SUFFIXES = {suffix: 1024 ** i for i, suffix in enumerate(['b', 'kb', 'mb', 
 
 
 def expand_byte_size_suffixes(value):
-  """
-  Given a string with KB/MB size suffixes, such as "32MB", computes how many
-  bytes that is and returns it as an integer.
+  """Given a string with KB/MB size suffixes, such as "32MB", computes how
+  many bytes that is and returns it as an integer.
   """
   match = re.match(r'\s*(\d+)\s*([kmgt]?b)', value, re.I)
   if not match:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1077,16 +1077,19 @@ def unique_ordered(values):
   return list(filter(check, values))
 
 
+SIZE_SUFFIXES = {suffix: 1024 ** i for i, suffix in enumerate(['b', 'kb', 'mb', 'gb', 'tb'])}
+
+
 def expand_byte_size_suffixes(value):
-  """Given a string with arithmetic and/or KB/MB size suffixes, such as
-  "1024*1024" or "32MB", computes how many bytes that is and returns it as an
-  integer.
   """
-  value = value.lower().replace('tb', '*1024*1024*1024*1024').replace('gb', '*1024*1024*1024').replace('mb', '*1024*1024').replace('kb', '*1024').replace('b', '')
-  try:
-    return eval(value)
-  except:
+  Given a string with KB/MB size suffixes, such as "32MB", computes how many
+  bytes that is and returns it as an integer.
+  """
+  match = re.match(r'\s*(\d+)\s*([kmgt]?b)', value, re.I)
+  if not match:
     raise Exception("Invalid byte size, valid suffixes: KB, MB, GB, TB")
+  value, suffix = match.groups()
+  return int(value) * SIZE_SUFFIXES[suffix.lower()]
 
 
 # Settings. A global singleton. Not pretty, but nicer than passing |, settings| everywhere


### PR DESCRIPTION
Settings like `TOTAL_MEMORY` could be used for arbitrary code execution through carefully crafted values of command line flags. This may be problematic in say, online services similar to https://godbolt.org, if they happen to use Emscripten.