### PR TITLE
emar: make basename collision logic work with ar's q option

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -43,7 +43,7 @@ def run():
   # 'ar x libfoo.a'.
   if len(newargs) > 3:
     cmd = newargs[1]
-    if 'r' in cmd:
+    if 'r' in cmd or 'q' in cmd:
       # We are adding files to the archive.
       # Normally the output file is then arg 2, except in the case were the
       # a or b modifiers are used in which case its arg 3.


### PR DESCRIPTION
cmake uses the 'q' option instead of 'r' to add files to an archive:

https://gitlab.kitware.com/cmake/cmake/blob/84f9f63f/Modules/CMakeCInformation.cmake#L156

With this change, collision are avoided when building with cmake.

Thank you for submitting a pull request!

If this is your first PR, make sure to add yourself to AUTHORS.
