### PR TITLE
wasm2js testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -394,6 +394,10 @@ jobs:
     environment:
       - TEST_TARGET=wasm3
       # TODO: test wasms
+  test-upstream-wasm2js1:
+    <<: *test-defaults
+    environment:
+      - TEST_TARGET=wasm2js1
   test-upstream-other:
     <<: *test-defaults
     environment:
@@ -471,6 +475,9 @@ workflows:
           requires:
             - build-upstream
       - test-upstream-wasm3:
+          requires:
+            - build-upstream
+      - test-upstream-wasm2js1:
           requires:
             - build-upstream
       - test-upstream-other:

--- a/emcc.py
+++ b/emcc.py
@@ -1651,7 +1651,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         exit_with_error('wasm2js is only available in the upstream wasm backend path')
       if use_source_map(options):
         exit_with_error('wasm2js does not support source maps yet (debug in wasm for now)')
-      logger.warning('emcc: JS support in the upstream LLVM+wasm2js path is very experimental currently (best to use fastcomp for asm.js for now)')
 
     # wasm outputs are only possible with a side wasm
     if target.endswith(WASM_ENDINGS):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -236,7 +236,6 @@ def create_test_file(name, contents, binary=False):
 # The core test modes
 core_test_modes = [
   'asm0',
-  'asm1',
   'asm2',
   'asm3',
   'asm2g',
@@ -253,7 +252,6 @@ core_test_modes = [
   'wasm2js3',
   'wasm2jss',
   'wasm2jsz',
-  'asmi',
   'asm2i',
 ]
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5842,9 +5842,6 @@ return malloc(size);
     # newer clang has a warning for implicit conversions that lose information,
     # which happens in sqlite (see #9138)
     self.emcc_args += ['-Wno-implicit-int-float-conversion']
-    # temporarily ignore unknown flags, which lets the above flag be used on our CI which doesn't
-    # yet have the new clang with that flag
-    self.emcc_args += ['-Wno-unknown-warning-option']
 
     src = '''
        #define SQLITE_DISABLE_LFS
@@ -8153,7 +8150,6 @@ def make_run(name, emcc_args, settings=None, env=None):
 
 # Main asm.js test modes
 asm0 = make_run('asm0', emcc_args=[], settings={'ASM_JS': 2, 'WASM': 0})
-asm1 = make_run('asm1', emcc_args=['-O1'], settings={'WASM': 0})
 asm2 = make_run('asm2', emcc_args=['-O2'], settings={'WASM': 0})
 asm3 = make_run('asm3', emcc_args=['-O3'], settings={'WASM': 0})
 asm2g = make_run('asm2g', emcc_args=['-O2', '-g'], settings={'WASM': 0, 'ASSERTIONS': 1, 'SAFE_HEAP': 1})
@@ -8198,7 +8194,6 @@ wasm2s = make_run('wasm2s', emcc_args=['-O2'], settings={'SAFE_HEAP': 1})
 wasm2ss = make_run('wasm2ss', emcc_args=['-O2'], settings={'SAFE_STACK': 1})
 
 # emterpreter
-asmi = make_run('asmi', emcc_args=[], settings={'ASM_JS': 2, 'EMTERPRETIFY': 1, 'WASM': 0})
 asm2i = make_run('asm2i', emcc_args=['-O2'], settings={'EMTERPRETIFY': 1, 'WASM': 0})
 
 lsan = make_run('lsan', emcc_args=['-fsanitize=leak'], settings={'ALLOW_MEMORY_GROWTH': 1})


### PR DESCRIPTION
This adds `wasm2js1` to CI here. This is the first large amount of wasm2js testing we add. I picked `-O1` because it's a mode we don't test for upstream currently, so this adds indirect coverage for that, and also `-O1` tests quite a bit of optimizations in wasm2js.

To balance CI load, I removed some old asm.js modes from testing, `asm1` (asm.js with `-O1`) and `asmi` (asm.js with emterpreter at `-O0`). We do still test asm.js at `-O0, -O2` (and some in `other`) so removing `-O1` seems not a big risk given fastcomp is going away, and the emterpreter stuff is still tested at `-O2` (which itself is perhaps excessive, but I didn't want to remove too much at once).

This removes the scary warning that wasm2js is not ready for normal use. After the initial bugreports we've not gotten any for a while, so I think it's usable.