### PR TITLE
Use xcrun to find Mac SDKs instead of searching directories

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -121,7 +121,7 @@ class NativeBenchmarker(Benchmarker):
   def build(self, parent, filename, args, shared_args, emcc_args, native_args, native_exec, lib_builder, has_output_parser):
     self.parent = parent
     if lib_builder:
-      env = {'CC': self.cc, 'CXX': self.cxx, 'CXXFLAGS': "-Wno-c++11-narrowing"}
+      env = {'CC': self.cc, 'CXX': self.cxx, 'CXXFLAGS': "-Wno-c++11-narrowing", 'CFLAGS': ' '.join(shared.get_clang_native_args())}
       env.update(shared.get_clang_native_env())
       print(env)
       native_args += lib_builder(self.name, native=True, env_init=env)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -123,7 +123,6 @@ class NativeBenchmarker(Benchmarker):
     if lib_builder:
       env = {'CC': self.cc, 'CXX': self.cxx, 'CXXFLAGS': "-Wno-c++11-narrowing"}
       env.update(shared.get_clang_native_env())
-      print(env)
       native_args += lib_builder(self.name, native=True, env_init=env)
     if not native_exec:
       compiler = self.cxx if filename.endswith('cpp') else self.cc

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -121,7 +121,7 @@ class NativeBenchmarker(Benchmarker):
   def build(self, parent, filename, args, shared_args, emcc_args, native_args, native_exec, lib_builder, has_output_parser):
     self.parent = parent
     if lib_builder:
-      env = {'CC': self.cc, 'CXX': self.cxx, 'CXXFLAGS': "-Wno-c++11-narrowing", 'CFLAGS': ' '.join(shared.get_clang_native_args())}
+      env = {'CC': self.cc, 'CXX': self.cxx, 'CXXFLAGS': "-Wno-c++11-narrowing"}
       env.update(shared.get_clang_native_env())
       print(env)
       native_args += lib_builder(self.name, native=True, env_init=env)
@@ -316,7 +316,7 @@ benchmarkers = []
 
 if CLANG_CC and CLANG:
   benchmarkers += [
-    NativeBenchmarker('clang', CLANG_CC, CLANG),
+    # NativeBenchmarker('clang', CLANG_CC, CLANG),
     # NativeBenchmarker('gcc',   'gcc',    'g++')
   ]
 if SPIDERMONKEY_ENGINE and SPIDERMONKEY_ENGINE in shared.JS_ENGINES:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -121,7 +121,10 @@ class NativeBenchmarker(Benchmarker):
   def build(self, parent, filename, args, shared_args, emcc_args, native_args, native_exec, lib_builder, has_output_parser):
     self.parent = parent
     if lib_builder:
-      native_args += lib_builder(self.name, native=True, env_init={'CC': self.cc, 'CXX': self.cxx, 'CXXFLAGS': "-Wno-c++11-narrowing"})
+      env = {'CC': self.cc, 'CXX': self.cxx, 'CXXFLAGS': "-Wno-c++11-narrowing"}
+      env.update(shared.get_clang_native_env())
+      print(env)
+      native_args += lib_builder(self.name, native=True, env_init=env)
     if not native_exec:
       compiler = self.cxx if filename.endswith('cpp') else self.cc
       cmd = [
@@ -313,7 +316,7 @@ benchmarkers = []
 
 if CLANG_CC and CLANG:
   benchmarkers += [
-    # NativeBenchmarker('clang', CLANG_CC, CLANG),
+    NativeBenchmarker('clang', CLANG_CC, CLANG),
     # NativeBenchmarker('gcc',   'gcc',    'g++')
   ]
 if SPIDERMONKEY_ENGINE and SPIDERMONKEY_ENGINE in shared.JS_ENGINES:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -650,9 +650,10 @@ def get_clang_native_args():
     return CACHED_CLANG_NATIVE_ARGS
   CACHED_CLANG_NATIVE_ARGS = []
   if MACOS:
-    sdk_path = macos_find_native_sdk_path()
-    if sdk_path:
-      CACHED_CLANG_NATIVE_ARGS = ['-isysroot', macos_find_native_sdk_path()]
+    pass
+    #sdk_path = macos_find_native_sdk_path()
+    #if sdk_path:
+    #  CACHED_CLANG_NATIVE_ARGS = ['-isysroot', macos_find_native_sdk_path()]
   elif os.name == 'nt':
     CACHED_CLANG_NATIVE_ARGS = ['-DWIN32']
     # TODO: If Windows.h et al. are needed, will need to add something like '-isystemC:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Include'.
@@ -669,7 +670,11 @@ def get_clang_native_env():
     return CACHED_CLANG_NATIVE_ENV
   env = os.environ.copy()
 
-  if WINDOWS:
+  if MACOS:
+    path = run_process(['xcrun', '--show-sdk-path'], stdout=PIPE).stdout.strip()
+    logging.debug('Using MacOS SDKROOT: ' + path)
+    env['SDKROOT'] = path
+  elif WINDOWS:
     # If already running in Visual Studio Command Prompt manually, no need to
     # add anything here, so just return.
     if 'VSINSTALLDIR' in env and 'INCLUDE' in env and 'LIB' in env:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -626,20 +626,6 @@ def build_clang_tool_path(tool):
     return os.path.join(LLVM_ROOT, tool)
 
 
-# Whenever building a native executable for macOS, we must provide the macOS SDK
-# version we want to target.
-def macos_find_native_sdk_path():
-  try:
-    sdk_root = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs'
-    sdks = next(os.walk(sdk_root))[1]
-    sdk_path = os.path.join(sdk_root, sdks[0]) # Just pick first one found, we don't care which one we found.
-    logger.debug('Targeting macOS SDK found at ' + sdk_path)
-    return sdk_path
-  except (OSError, StopIteration):
-    logger.warning('Could not find native macOS SDK path to target!')
-    return None
-
-
 # These extra args need to be passed to Clang when targeting a native host system executable
 CACHED_CLANG_NATIVE_ARGS = None
 
@@ -650,10 +636,7 @@ def get_clang_native_args():
     return CACHED_CLANG_NATIVE_ARGS
   CACHED_CLANG_NATIVE_ARGS = []
   if MACOS:
-    pass
-    #sdk_path = macos_find_native_sdk_path()
-    #if sdk_path:
-    #  CACHED_CLANG_NATIVE_ARGS = ['-isysroot', macos_find_native_sdk_path()]
+    CACHED_CLANG_NATIVE_ARGS = ['-isystem', path_from_root('system', 'include', 'libcxx')]
   elif os.name == 'nt':
     CACHED_CLANG_NATIVE_ARGS = ['-DWIN32']
     # TODO: If Windows.h et al. are needed, will need to add something like '-isystemC:/Program Files (x86)/Microsoft SDKs/Windows/v7.1A/Include'.


### PR DESCRIPTION
Also: 
* Use the SDKROOT environment variable rather than the -isysroot flag to configure clang.
* Add a manual include of the emscripten libcxx headers since those are not included in the SDK.