### PR TITLE
MAYBE_WASM2JS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1468,6 +1468,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if any(s.startswith('MEM_INIT_METHOD=') for s in settings_changes):
         exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
       if shared.Settings.WASM2JS:
+        shared.Settings.MAYBE_WASM2JS = 1
         # wasm2js does not support passive segments or atomics
         if shared.Settings.USE_PTHREADS:
           exit_with_error('WASM2JS does not yet support pthreads')

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -15,8 +15,14 @@ out = err = function(){};
 
 {{{ makeModuleReceiveWithVar('wasmBinary') }}}
 
-#if WASM2JS
+#if MAYBE_WASM2JS && !WASM2JS
+if (Module['doWasm2JS']) {
+#endif
+#if MAYBE_WASM2JS
 #include "wasm2js.js"
+#endif
+#if MAYBE_WASM2JS && !WASM2JS
+}
 #endif
 
 #if WASM
@@ -891,7 +897,7 @@ var wasmOffsetConverter;
 // Create the wasm instance.
 // Receives the wasm imports, returns the exports.
 function createWasm(env) {
-#if WASM2JS || AUTODEBUG
+#if MAYBE_WASM2JS || AUTODEBUG
   // wasm2js legalization of i64 support code may require these
   // autodebug may also need them
   env['setTempRet0'] = setTempRet0;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1538,6 +1538,13 @@ var AUTODEBUG = 0;
 // wasm normally, then compile that to JS).
 var WASM2JS = 0;
 
+// Whether we *may* be using wasm2js. This compiles to wasm normally, but lets you
+// run wasm2js *later* on the wasm, and you can pick between running the normal
+// wasm or that wasm2js code. For details of how to do that, see the test_maybe_wasm2js
+// test.
+// This option can be useful for debugging and bisecting.
+var MAYBE_WASM2JS = 0;
+
 // Whether we should link in the runtime for ubsan.
 // 0 means do not link ubsan, 1 means link minimal ubsan runtime.
 // This is not meant to be used with `-s`. Instead, to use ubsan, use clang flag

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -1,7 +1,12 @@
 // wasm2js.js - enough of a polyfill for the WebAssembly object so that we can load
 // wasm2js code that way.
 
-var WebAssembly = {
+// Emit "var WebAssembly" if definitely using wasm2js. Otherwise, in MAYBE_WASM2JS
+// mode, we can't use a "var" since it would prevent normal wasm from working.
+#if WASM2JS
+var
+#endif
+WebAssembly = {
   Memory: function(opts) {
     return {
       buffer: new ArrayBuffer(opts['initial'] * {{{ WASM_PAGE_SIZE }}}),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7629,6 +7629,33 @@ extern "C" {
       with open('src.c.o.js.mem', 'rb') as f:
         self.assertTrue(f.read()[-1] != b'\0')
 
+  @no_fastcomp('wasm-backend specific feature')
+  def test_maybe_wasm2js(self):
+    if self.get_setting('WASM') == 0:
+      self.skipTest('redundant to test wasm2js in wasm2js* mode')
+    self.set_setting('MAYBE_WASM2JS', 1)
+    # see that running as wasm works
+    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
+    # run wasm2js, bundle the code, and use the wasm2js path
+    cmd = [os.path.join(Building.get_binaryen_bin(), 'wasm2js'), '--emscripten', 'src.c.o.wasm']
+    if is_optimizing(self.emcc_args):
+      cmd += ['-O2']
+    js = run_process(cmd, stdout=PIPE).stdout
+    # assign the instantiate function to where it will be used
+    js = js.replace('function instantiate(asmLibraryArg, wasmMemory, wasmTable) {',
+                    "Module['__wasm2jsInstantiate__'] = function(asmLibraryArg, wasmMemory, wasmTable) {")
+    # remove the wasm to make sure we never use it again
+    os.unlink('src.c.o.wasm')
+    # create the combined js to run in wasm2js mode
+    with open('do_wasm2js.js', 'w') as f:
+      f.write('var Module = { doWasm2JS: true };\n')
+      f.write('\n')
+      f.write(js)
+      f.write('\n')
+      with open('src.c.o.js') as original:
+        f.write(original.read())
+    self.assertContained('hello, world!', run_js('do_wasm2js.js'))
+
   def test_cxx_self_assign(self):
     # See https://github.com/emscripten-core/emscripten/pull/2688 and http://llvm.org/bugs/show_bug.cgi?id=18735
     self.do_run(r'''


### PR DESCRIPTION
This allows building a js+wasm combo that can optionally be compiled using wasm2js **later**. This can help debug wasm2js issues as it makes reduction simple - build once using this flag, then in the reduction you can reduce the wasm and compile it using wasm2js.

Actually doing the wasm2js is a little hackish, see the test, but it does work. Maybe it could be a script?