### PR TITLE
Swallow ExitStatus exceptions in pthread worker message handler

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -314,7 +314,12 @@ var LibraryPThread = {
             } else if (d.cmd === 'exitProcess') {
               // A pthread has requested to exit the whole application process (runtime).
               Module['noExitRuntime'] = false;
-              exit(d.returnCode);
+              try {
+                exit(d.returnCode);
+              } catch (e) {
+                if (e instanceof ExitStatus) return;
+                throw e;
+              }
             } else if (d.cmd === 'cancelDone') {
               PThread.returnWorkerToPool(worker);
             } else if (d.cmd === 'objectTransfer') {


### PR DESCRIPTION
When a worker sends a message to terminate, the handler calls exit()
to exit the runtime and record exit status, but exit() also throws,
so it can be called from anywhere. The pthread message handler
can just return, so swallowing the exception keeps unhandled exceptions
from being reported.
