### PR TITLE
Don't build embind as a library

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -932,16 +932,6 @@ class libgl(MTLibrary):
     )
 
 
-class libembind(CXXLibrary):
-  name = 'libembind'
-  cflags = ['-std=c++11']
-  depends = ['libc++abi']
-  never_force = True
-
-  def get_files(self):
-    return [shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')]
-
-
 class libfetch(CXXLibrary, MTLibrary):
   name = 'libfetch'
   depends = ['libc++abi']


### PR DESCRIPTION
This is partial revert of #8817.  It turns out that all users of bind.h
have to agree on -fno-rtti.  In particular if a user passed -fno-rtti
to build their code the bind.cpp needs to be compiled with the same
settings.

Perhaps we can find a way to avoid this in the future but for now
it looks like we are stuck compiling bind.cpp on demand at link time.

Fixes: #9122
