### PR TITLE
Simplify logic for automatically running browser tests under asmjs

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -80,8 +80,6 @@ EMTEST_BROWSER = os.getenv('EMTEST_BROWSER')
 
 EMTEST_DETECT_TEMPFILE_LEAKS = int(os.getenv('EMTEST_DETECT_TEMPFILE_LEAKS', '0'))
 
-EMTEST_WASM_PTHREADS = int(os.getenv('EMTEST_WASM_PTHREADS', '1'))
-
 # Also suppot the old name: EM_SAVE_DIR
 EMTEST_SAVE_DIR = os.getenv('EMTEST_SAVE_DIR', os.getenv('EM_SAVE_DIR'))
 
@@ -1540,14 +1538,7 @@ class BrowserCore(RunnerCore):
     filename_is_src = '\n' in filename
     src = filename if filename_is_src else ''
     original_args = args[:]
-    if 'USE_PTHREADS=1' in args:
-      if not self.is_wasm_backend():
-        if 'ALLOW_MEMORY_GROWTH=1' not in args:
-          if EMTEST_WASM_PTHREADS:
-            also_asmjs = True
-          elif 'WASM=0' not in args:
-            args += ['-s', 'WASM=0']
-      else:
+    if 'USE_PTHREADS=1' in args and self.is_wasm_backend():
         # wasm2js does not support threads yet
         also_asmjs = False
     if 'WASM=0' not in args:


### PR DESCRIPTION
Currently we automatically run browser tests a second time with asmjs under a complex set of conditions which no longer make sense.

This change removes that logic in favor of only doing it globally when
EMTEST_BROWSER_ALSO_ASMJS=1 (off by default).
Tests can opt into both by passing also_asmjs=True as a btest() argument or
opt out of wasm by explicitly setting WASM=0 in the command args.