### PR TITLE
Include debug info in system libraries

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7057,12 +7057,19 @@ err = err = function(){};
       # the file attribute is optional, but if it is present it needs to refer
       # the output file.
       self.assertPathsIdentical(map_referent, data['file'])
-    assert len(data['sources']) == 1, data['sources']
+    self.assertGreater(len(data['sources']), 1)
     self.assertPathsIdentical(os.path.abspath('src.cpp'), data['sources'][0])
+
+    # verify that we have libc symbols
+    basenames = [os.path.basename(s) for s in data['sources']]
+    self.assertIn('fwrite.c', basenames)
+    self.assertIn('printf.c', basenames)
+
     if hasattr(data, 'sourcesContent'):
       # the sourcesContent attribute is optional, but if it is present it
       # needs to containt valid source text.
       self.assertTextDataIdentical(src, data['sourcesContent'][0])
+
     mappings = json.loads(jsrun.run_js(
       path_from_root('tools', 'source-maps', 'sourcemap2json.js'),
       shared.NODE_JS, [map_filename]))
@@ -7071,8 +7078,8 @@ err = err = function(){};
       mappings = encode_utf8(mappings)
     seen_lines = set()
     for m in mappings:
-      self.assertPathsIdentical(os.path.abspath('src.cpp'), m['source'])
-      seen_lines.add(m['originalLine'])
+      if m['source'] == os.path.abspath('src.cpp'):
+        seen_lines.add(m['originalLine'])
     # ensure that all the 'meaningful' lines in the original code get mapped
     # when optimizing, the binaryen optimizer may remove some of them (by inlining, etc.)
     if is_optimizing(self.emcc_args):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7076,10 +7076,10 @@ int main() {
   return 0;
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.c', '-O2', '-g'])
+    run_process([PYTHON, EMCC, 'src.c', '-O2'])
     size = os.path.getsize('a.out.wasm')
     # size should be much smaller than the size of that zero-initialized buffer
-    self.assertLess(size, 123456 / 2)
+    self.assertLess(size, 1048576 / 2)
 
   @no_wasm_backend('asm.js')
   def test_separate_asm_warning(self):
@@ -7741,7 +7741,7 @@ int main() {
       code = open('a.out.wasm', 'rb').read()
       if expect_names:
         # name section adds the name of malloc (there is also another one for the export)
-        self.assertEqual(code.count(b'malloc'), 2)
+        self.assertGreater(code.count(b'malloc'), 1)
       else:
         # should be just malloc for the export
         self.assertEqual(code.count(b'malloc'), 1)
@@ -9443,14 +9443,14 @@ int main () {
 
   @parameterized({
     'c': ['c', [
-      r'in malloc.*a\.out\.wasm\+0x',
+      r'in malloc .*lsan/lsan_interceptors\.cc:\d*:\d*',
       r'(?im)in f (/|[a-z]:).*/test_lsan_leaks\.c:6:21$',
       r'(?im)in main (/|[a-z]:).*/test_lsan_leaks\.c:10:16$',
       r'(?im)in main (/|[a-z]:).*/test_lsan_leaks\.c:12:3$',
       r'(?im)in main (/|[a-z]:).*/test_lsan_leaks\.c:13:3$',
     ]],
     'cpp': ['cpp', [
-      r'in operator new\[\]\(unsigned long\).*a\.out\.wasm\+0x',
+      r'in operator new\[\]\(unsigned long\) .*lsan/lsan_interceptors\.cc:\d*:\d*',
       r'(?im)in f\(\) (/|[a-z]:).*/test_lsan_leaks\.cpp:4:21$',
       r'(?im)in main (/|[a-z]:).*/test_lsan_leaks\.cpp:8:16$',
       r'(?im)in main (/|[a-z]:).*/test_lsan_leaks\.cpp:10:3$',

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -37,7 +37,9 @@ def glob_in_path(path_components, glob_pattern, excludes=()):
 
 
 def get_cflags(force_object_files=False):
-  flags = ['-g4']
+  # We want debug information availabe in system libraries so that user can
+  # get source maps of that library code.
+  flags = ['-g']
   if force_object_files:
     flags += ['-s', 'WASM_OBJECT_FILES=1']
   elif not shared.Settings.WASM_OBJECT_FILES:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -37,7 +37,7 @@ def glob_in_path(path_components, glob_pattern, excludes=()):
 
 
 def get_cflags(force_object_files=False):
-  flags = []
+  flags = ['-g4']
   if force_object_files:
     flags += ['-s', 'WASM_OBJECT_FILES=1']
   elif not shared.Settings.WASM_OBJECT_FILES:


### PR DESCRIPTION
Add `-g` when building system libraries.  This does not effect the
optimization level but allows users who want it to have debug
information (e.g source maps) for the system libraries.

As far as I can tell the only downside to doing this is that slight
increase in the on-disk side of the system libraries and the minor cost
of the linker having to read this info.