### PR TITLE
Honor SIDE_MODULE=2 with wasm backend

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1808,7 +1808,7 @@ class Building(object):
       export_all = True
 
     if Settings.RELOCATABLE:
-      if Settings.MAIN_MODULE == 2:
+      if Settings.MAIN_MODULE == 2 or Settings.SIDE_MODULE == 2:
         cmd.append('--no-export-dynamic')
       else:
         cmd.append('--no-gc-sections')


### PR DESCRIPTION
With SIDE_MODULE=2 we don't want to export all visibility `default`
symbols.  Only the symbols we explicitly export from the command line.

For this to actually work we need to wait for the following change
to land in llvm: https://reviews.llvm.org/D66359

This change is part of the fix for #9038.
