### PR TITLE
Fix embind with -fno-rtti

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -984,6 +984,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     newargs = [a for a in newargs if a != '']
 
+    if '-fno-rtti' in newargs:
+      shared.Settings.USE_RTTI = 0
+
     has_dash_c = '-c' in newargs
     has_dash_S = '-S' in newargs
     if has_dash_c or has_dash_S:

--- a/src/settings.js
+++ b/src/settings.js
@@ -1391,6 +1391,7 @@ var EMSCRIPTEN_VERSION = '';
 // This will contain the optimization level (-Ox). You should not modify this.
 var OPT_LEVEL = 0;
 
+// Will be set to 0 if -fno-rtti is used on the command line.
 var USE_RTTI = 1;
 
 // This will contain the debug level (-gx). You should not modify this.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1391,6 +1391,8 @@ var EMSCRIPTEN_VERSION = '';
 // This will contain the optimization level (-Ox). You should not modify this.
 var OPT_LEVEL = 0;
 
+var USE_RTTI = 1;
+
 // This will contain the debug level (-gx). You should not modify this.
 var DEBUG_LEVEL = 0;
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -952,8 +952,11 @@ class libembind(CXXLibrary):
   def vary_on(cls):
     return super(libembind, cls).vary_on() + ['with_rtti']
 
-  def get_base_name_prefix(self):
-    return 'libembind-rtti' if self.with_rtti else 'libembind'
+  def get_base_name(self):
+    name = super(libembind, self).get_base_name()
+    if self.with_rtti:
+      name += '-rtti'
+    return name
 
   def get_files(self):
     return [shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')]

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -938,8 +938,29 @@ class libembind(CXXLibrary):
   depends = ['libc++abi']
   never_force = True
 
+  def __init__(self, **kwargs):
+    self.with_rtti = kwargs.pop('with_rtti', False)
+    super(libembind, self).__init__(**kwargs)
+
+  def get_cflags(self):
+    cflags = super(libembind, self).get_cflags()
+    if not self.with_rtti:
+      cflags += ['-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0']
+    return cflags
+
+  @classmethod
+  def vary_on(cls):
+    return super(libembind, cls).vary_on() + ['with_rtti']
+
+  def get_base_name_prefix(self):
+    return 'libembind-rtti' if self.with_rtti else 'libembind'
+
   def get_files(self):
     return [shared.path_from_root('system', 'lib', 'embind', 'bind.cpp')]
+
+  @classmethod
+  def get_default_variation(cls, **kwargs):
+    return super(libembind, cls).get_default_variation(with_rtti=shared.Settings.USE_RTTI, **kwargs)
 
 
 class libfetch(CXXLibrary, MTLibrary):


### PR DESCRIPTION
This adds a variant build of embind for use with `-fno-rtti`.

Fixes #9122
