### PR TITLE
Implement emscripten::val::isNumber and isString via JS glue

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -455,6 +455,18 @@ var LibraryEmVal = {
     return object instanceof constructor;
   },
   
+  _emval_is_number__deps: ['$requireHandle'],
+  _emval_is_number: function(handle ) {
+    handle = requireHandle(handle );
+    return typeof handle === 'number';
+  },
+
+  _emval_is_string__deps: ['$requireHandle'],
+  _emval_is_string: function(handle) {
+    handle = requireHandle(handle);
+    return typeof handle === 'string';
+  },
+
   _emval_in__deps: ['$requireHandle'],
   _emval_in: function(item, object) {
     item = requireHandle(item);

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -96,6 +96,8 @@ namespace emscripten {
                 EM_VAR_ARGS argv);
             EM_VAL _emval_typeof(EM_VAL value);
             bool _emval_instanceof(EM_VAL object, EM_VAL constructor);
+            bool _emval_is_number(EM_VAL object);
+            bool _emval_is_string(EM_VAL object);
             bool _emval_in(EM_VAL item, EM_VAL object);
             bool _emval_delete(EM_VAL object, EM_VAL property);
             bool _emval_throw(EM_VAL object);
@@ -403,11 +405,11 @@ namespace emscripten {
         }
 
         bool isNumber() const {
-            return typeOf().as<std::string>() == "number";
+            return internal::_emval_is_number(handle);
         }
 
         bool isString() const {
-            return typeOf().as<std::string>() == "string";
+            return internal::_emval_is_string(handle);
         }
 
         bool isArray() const {


### PR DESCRIPTION
Previously typeOf().as<std::string>() was used which resulted in:
* Extra memory allocations
* Extra calls from C++ to JavaScript

Tests ran (11/11 passed): `python2 runner.py test_embind*`

I bumped into this issue when I've tried to disable costly conversions to/from `std::string`  to avoid hidden costs in my application.