### PR TITLE
Avoid stack snapshot when sanitizer stack traces are disabled

### DIFF
--- a/system/lib/compiler-rt/lib/asan/asan_flags.cc
+++ b/system/lib/compiler-rt/lib/asan/asan_flags.cc
@@ -165,6 +165,11 @@ void InitializeFlags() {
   // TODO(eugenis): dump all flags at verbosity>=2?
   if (Verbosity()) ReportUnrecognizedFlags();
 
+#if SANITIZER_EMSCRIPTEN
+  if (common_flags()->malloc_context_size <= 1)
+    StackTrace::snapshot_stack = false;
+#endif // SANITIZER_EMSCRIPTEN
+
   if (common_flags()->help) {
     // TODO(samsonov): print all of the flags (ASan, LSan, common).
     asan_parser.PrintFlagDescriptions();

--- a/system/lib/compiler-rt/lib/lsan/lsan.cc
+++ b/system/lib/compiler-rt/lib/lsan/lsan.cc
@@ -80,6 +80,11 @@ static void InitializeFlags() {
   parser.ParseString(GetEnv("LSAN_OPTIONS"));
 #endif // SANITIZER_EMSCRIPTEN
 
+#if SANITIZER_EMSCRIPTEN
+  if (common_flags()->malloc_context_size <= 1)
+    StackTrace::snapshot_stack = false;
+#endif // SANITIZER_EMSCRIPTEN
+
   SetVerbosity(common_flags()->verbosity);
 
   if (Verbosity()) ReportUnrecognizedFlags();

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace.h
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace.h
@@ -64,6 +64,9 @@ struct StackTrace {
     return request_fast_unwind;
   }
 
+#if SANITIZER_EMSCRIPTEN
+  static bool snapshot_stack;
+#endif
   static uptr GetCurrentPc();
   static inline uptr GetPreviousInstructionPc(uptr pc);
   static uptr GetNextInstructionPc(uptr pc);

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_emscripten.cc
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_emscripten.cc
@@ -26,13 +26,14 @@ extern "C" {
   u32 emscripten_stack_unwind_buffer(uptr pc, uptr *buffer, u32 depth);
 }
 
+bool StackTrace::snapshot_stack = true;
+
 uptr StackTrace::GetCurrentPc() {
-  return emscripten_stack_snapshot();
+  return snapshot_stack ? emscripten_stack_snapshot() : 0;
 }
 
 void BufferedStackTrace::FastUnwindStack(uptr pc, uptr bp, uptr stack_top,
                                          uptr stack_bottom, u32 max_depth) {
-  bool saw_pc = false;
   max_depth = Min(max_depth, kStackTraceMax);
   size = emscripten_stack_unwind_buffer(pc, trace_buffer, max_depth);
   trace_buffer[0] = pc;

--- a/tests/other/test_lsan_leaks.c
+++ b/tests/other/test_lsan_leaks.c
@@ -12,3 +12,9 @@ int main(int argc, char **argv) {
   f();
   malloc(2048);
 }
+
+#ifdef DISABLE_CONTEXT
+const char *__lsan_default_options(void) {
+  return "malloc_context_size=0";
+}
+#endif

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9460,12 +9460,28 @@ int main () {
                        emcc_args=['-fsanitize=leak', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'ASSERTIONS=0'],
                        regexes=[r'^\s*$'])
 
+  def test_lsan_no_stack_trace(self):
+    self.do_smart_test(path_from_root('tests', 'other', 'test_lsan_leaks.c'),
+                       emcc_args=['-fsanitize=leak', '-s', 'ALLOW_MEMORY_GROWTH=1', '-DDISABLE_CONTEXT'],
+                       assert_returncode=None, literals=[
+      'Direct leak of 3427 byte(s) in 3 object(s) allocated from:',
+      'SUMMARY: LeakSanitizer: 3427 byte(s) leaked in 3 allocation(s).',
+    ])
+
   @no_fastcomp('asan is not supported on fastcomp')
   def test_asan_null_deref(self):
     self.do_smart_test(path_from_root('tests', 'other', 'test_asan_null_deref.c'),
                        emcc_args=['-fsanitize=address', '-s', 'ALLOW_MEMORY_GROWTH=1'],
                        assert_returncode=None, literals=[
       'AddressSanitizer: null-pointer-dereference on address',
+    ])
+
+  def test_asan_no_stack_trace(self):
+    self.do_smart_test(path_from_root('tests', 'other', 'test_lsan_leaks.c'),
+                       emcc_args=['-fsanitize=address', '-s', 'ALLOW_MEMORY_GROWTH=1', '-DDISABLE_CONTEXT', '-s', 'EXIT_RUNTIME'],
+                       assert_returncode=None, literals=[
+      'Direct leak of 3427 byte(s) in 3 object(s) allocated from:',
+      'SUMMARY: AddressSanitizer: 3427 byte(s) leaked in 3 allocation(s).',
     ])
 
   @parameterized({

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9460,6 +9460,7 @@ int main () {
                        emcc_args=['-fsanitize=leak', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'ASSERTIONS=0'],
                        regexes=[r'^\s*$'])
 
+  @no_fastcomp('lsan not supported on fastcomp')
   def test_lsan_no_stack_trace(self):
     self.do_smart_test(path_from_root('tests', 'other', 'test_lsan_leaks.c'),
                        emcc_args=['-fsanitize=leak', '-s', 'ALLOW_MEMORY_GROWTH=1', '-DDISABLE_CONTEXT'],
@@ -9476,6 +9477,7 @@ int main () {
       'AddressSanitizer: null-pointer-dereference on address',
     ])
 
+  @no_fastcomp('asan is not supported on fastcomp')
   def test_asan_no_stack_trace(self):
     self.do_smart_test(path_from_root('tests', 'other', 'test_lsan_leaks.c'),
                        emcc_args=['-fsanitize=address', '-s', 'ALLOW_MEMORY_GROWTH=1', '-DDISABLE_CONTEXT', '-s', 'EXIT_RUNTIME'],


### PR DESCRIPTION
This should make sanitized code run without severe penalty if malloc/free are called very frequently, at the cost of losing the stack traces.

Before, even disabling the stack traces will not avoid most of the cost, due to the assumption that `__builtin_return_address` is vastly cheaper than a full stack trace. On Emscripten, the cost is roughly the same.