### PR TITLE
Clean up test_webgl_offscreen_canvas_in_proxied_pthread

### DIFF
--- a/tests/gl_in_proxy_pthread.cpp
+++ b/tests/gl_in_proxy_pthread.cpp
@@ -47,8 +47,12 @@ int main()
     EMSCRIPTEN_RESULT r = emscripten_webgl_commit_frame();
     assert(r == EMSCRIPTEN_RESULT_SUCCESS);
 
+#if ASYNCIFY
+    emscripten_sleep(16);
+#else
     double now = emscripten_get_now();
     while(emscripten_get_now() - now < 16) /*no-op*/;
+#endif
   }
 
   emscripten_webgl_make_context_current(0);

--- a/tests/gl_in_proxy_pthread.cpp
+++ b/tests/gl_in_proxy_pthread.cpp
@@ -22,7 +22,6 @@ int main()
   }
   EmscriptenWebGLContextAttributes attr;
   emscripten_webgl_init_context_attributes(&attr);
-  attr.explicitSwapControl = EM_TRUE;
   EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
   printf("Created context with handle %u\n", (unsigned int)ctx);
   emscripten_webgl_make_context_current(ctx);
@@ -34,8 +33,6 @@ int main()
     color += 0.01;
     glClearColor(color, 0, 0, 1);
     glClear(GL_COLOR_BUFFER_BIT);
-    EMSCRIPTEN_RESULT r = emscripten_webgl_commit_frame();
-    assert(r == EMSCRIPTEN_RESULT_SUCCESS);
 
 #if ASYNCIFY
     emscripten_sleep(16);

--- a/tests/gl_in_proxy_pthread.cpp
+++ b/tests/gl_in_proxy_pthread.cpp
@@ -10,16 +10,6 @@
 #include <bits/errno.h>
 #include <stdlib.h>
 
-#if !defined(TEST_OFFSCREEN_CANVAS)
-// Defining EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES to empty string will cause no canvases to be transferred.
-#define EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES ""
-#elif TEST_OFFSCREEN_CANVAS == 1
-// Specifying #canvas should take Module.canvas to be transferred
-#define EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES "#canvas"
-#elif TEST_OFFSCREEN_CANVAS == 2
-// Leaving EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES undefined will also transfer the default Module.canvas object
-#endif
-
 int main()
 {
   if (!emscripten_supports_offscreencanvas())

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4250,9 +4250,15 @@ window.close = function() {
   @requires_offscreen_canvas
   def test_webgl_offscreen_canvas_in_proxied_pthread(self):
     for args in [[], ['-DTEST_OFFSCREEN_CANVAS=1'], ['-DTEST_OFFSCREEN_CANVAS=2']]:
-      cmd = args + ['-s', 'USE_PTHREADS=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'GL_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1']
-      print(str(cmd))
-      self.btest('gl_in_proxy_pthread.cpp', expected='1', args=cmd)
+      for async in [0, 1]:
+        cmd = args + ['-s', 'USE_PTHREADS=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'GL_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1']
+        if async:
+          if not self.is_wasm_backend():
+            continue
+          # given the synchronous render loop here, asyncify is needed to see intermediate frames and the gradual color change
+          cmd += ['-s', 'ASYNCIFY', '-DASYNCIFY']
+        print(str(cmd))
+        self.btest('gl_in_proxy_pthread.cpp', expected='1', args=cmd)
 
   @requires_threads
   @requires_graphics_hardware

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4249,9 +4249,9 @@ window.close = function() {
   @requires_threads
   @requires_offscreen_canvas
   def test_webgl_offscreen_canvas_in_proxied_pthread(self):
-    for async in [0, 1]:
+    for asyncify in [0, 1]:
       cmd = ['-s', 'USE_PTHREADS=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'GL_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1']
-      if async:
+      if asyncify:
         if not self.is_wasm_backend():
           continue
         # given the synchronous render loop here, asyncify is needed to see intermediate frames and the gradual color change

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4249,16 +4249,15 @@ window.close = function() {
   @requires_threads
   @requires_offscreen_canvas
   def test_webgl_offscreen_canvas_in_proxied_pthread(self):
-    for args in [[], ['-DTEST_OFFSCREEN_CANVAS=1'], ['-DTEST_OFFSCREEN_CANVAS=2']]:
-      for async in [0, 1]:
-        cmd = args + ['-s', 'USE_PTHREADS=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'GL_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1']
-        if async:
-          if not self.is_wasm_backend():
-            continue
-          # given the synchronous render loop here, asyncify is needed to see intermediate frames and the gradual color change
-          cmd += ['-s', 'ASYNCIFY', '-DASYNCIFY']
-        print(str(cmd))
-        self.btest('gl_in_proxy_pthread.cpp', expected='1', args=cmd)
+    for async in [0, 1]:
+      cmd = ['-s', 'USE_PTHREADS=1', '-s', 'OFFSCREENCANVAS_SUPPORT=1', '-lGL', '-s', 'GL_DEBUG=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1', '-s', 'OFFSCREEN_FRAMEBUFFER=1']
+      if async:
+        if not self.is_wasm_backend():
+          continue
+        # given the synchronous render loop here, asyncify is needed to see intermediate frames and the gradual color change
+        cmd += ['-s', 'ASYNCIFY', '-DASYNCIFY']
+      print(str(cmd))
+      self.btest('gl_in_proxy_pthread.cpp', expected='1', args=cmd)
 
   @requires_threads
   @requires_graphics_hardware


### PR DESCRIPTION
This removes some unused and unnecessary things in that test. After these changes, I think the test is close to a nice small example of `PROXY_TO_PTHREAD` plus `OFFSCREENCANVAS_SUPPORT`.

Also added an Asyncify variant, which shows smooth color changes because it can render frames in the middle of the synchronous render loop there. This also increases our coverage of Asyncify+pthreads.