### PR TITLE
Always output to target directly when compiling a single source file

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -993,7 +993,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if '-emit-llvm' in newargs:
           final_suffix = '.bc'
         else:
-          final_suffix = '.o'
+          final_suffix = options.default_object_extension
       elif has_dash_S:
         if '-emit-llvm' in newargs:
           final_suffix = '.ll'
@@ -1822,7 +1822,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if specified_target:
             return specified_target
           else:
-            return unsuffixed_basename(input_files[0][1]) + final_suffix
+            return unsuffixed_basename(input_files[0][1]) + options.default_object_extension
         else:
           return in_temp(unsuffixed(uniquename(input_file)) + options.default_object_extension)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3204,20 +3204,18 @@ printErr('dir was ' + process.env.EMCC_BUILD_DIR);
     process = run_process([PYTHON, EMCC, path_from_root('tests', 'float+.c')], stdout=PIPE, stderr=PIPE)
     assert process.returncode == 0, 'float.h should agree with our system: ' + process.stdout + '\n\n\n' + process.stderr
 
+  def test_output_is_dir(self):
+    outdir = 'out_dir/'
+    os.mkdir(outdir)
+    err = self.expect_fail([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', outdir])
+    self.assertContained('error: unable to open output file', err)
+
   def test_default_obj_ext(self):
-    outdir = 'out_dir' + '/'
+    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')])
+    self.assertExists('hello_world.o')
 
-    self.clear()
-    os.mkdir(outdir)
-    err = run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', outdir], stderr=PIPE).stderr
-    assert not err, err
-    assert os.path.isfile(outdir + 'hello_world.o')
-
-    self.clear()
-    os.mkdir(outdir)
-    err = run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', outdir, '--default-obj-ext', 'obj'], stderr=PIPE).stderr
-    assert not err, err
-    assert os.path.isfile(outdir + 'hello_world.obj')
+    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '--default-obj-ext', 'obj'])
+    self.assertExists('hello_world.obj')
 
   def test_doublestart_bug(self):
     create_test_file('code.cpp', r'''

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3179,6 +3179,7 @@ def safe_move(src, dst):
     return
   if dst == '/dev/null':
     return
+  logging.debug('move: %s -> %s', src, dst)
   shutil.move(src, dst)
 
 


### PR DESCRIPTION
As opposed to writing the tmp file then moving the file into place.  This
fixes an issue where object files were incorrectly being written alongside
source files.

This change does remove one non-standard feature from which is that
ability to specify a directory with `-o` e.g.:
    
    $ ./emcc hello.c -o /tmp/
    
clang and gcc can't do this so I don't see why emscripten should add
it.


