### PR TITLE
Fix infinite loop with promise

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -423,3 +423,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * James Kuszmaul <jabukuszmaul@gmail.com>
 * Wei Mingzhi <whistler_wmz@users.sourceforge.net>
 * Adrien Devresse <adev@adev.name>
+* xcodebuild <me@xcodebuild.com>

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -128,6 +128,7 @@ Module['then'] = function(func) {
   // We may already be ready to run code at this time. if
   // so, just queue a call to the callback.
   if (calledRun) {
+    delete Module.then;
     func(Module);
   } else {
     // we are not ready to call then() yet. we must call it
@@ -138,6 +139,7 @@ Module['then'] = function(func) {
     var old = Module['onRuntimeInitialized'];
     Module['onRuntimeInitialized'] = function() {
       if (old) old();
+      delete Module.then;
       func(Module);
     };
   }


### PR DESCRIPTION
`.then` in `Module` **like** Promise would cause infinite loop when user use it as a **real Promise like**

## Simplified code

```
const Module = {
  then(func) {
    func(a);
  }
};


Module.then(a => console.log(a));  //   works like a promise

Promise.resolve().then(() => Module).then(() => {}); //   boom

(async () => {
  const mod = await Module(); //   boom
})()

const moduleLoadedPromise = new Promise(resolve => {
  Module.then(resolve);    // boom
})
```

