### PR TITLE
Avoid "let" in library_exceptions.js setup code

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -326,7 +326,7 @@ var LibraryExceptions = {
 // where the number specifies the number of arguments. In Emscripten, route all these to a single function '__cxa_find_matching_catch'
 // that variadically processes all of these functions using JS 'arguments' object.
 var maxExceptionArgs = 10; // arbitrary upper limit
-for(let n = 0; n < maxExceptionArgs; ++n) {
+for (var n = 0; n < maxExceptionArgs; ++n) {
   LibraryExceptions['__cxa_find_matching_catch_' + n] = '__cxa_find_matching_catch';
   LibraryExceptions['__cxa_find_matching_catch_' + n + '__sig'] = new Array(n + 2).join('i');
 }


### PR DESCRIPTION
This is not in shipped code, but in our compiler internals, where I guess this was added by mistake. Avoiding "let" allows us to run on older node.js versions.

fixes #9319
