### PR TITLE
Fixed pthread worker pool manipulation (#9307)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -423,3 +423,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * James Kuszmaul <jabukuszmaul@gmail.com>
 * Wei Mingzhi <whistler_wmz@users.sourceforge.net>
 * Adrien Devresse <adev@adev.name>
+* Martin Klemsa <m.klemsa@gmail.com>


### PR DESCRIPTION
Fixed usage of pool arrays (#9307):
- Encapsulated worker pool functionality into a dedicated class
- Prevented worker dangling in case the pthread creation operation throws
- Prevented clean-up of thread data before workers are terminated when 'terminate all' happens
