### PR TITLE
Catch all errors in is_python3_version_supported

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -93,7 +93,7 @@ def is_python3_version_supported():
   try:
     python3 = Building.which('python3')
     output = run_process([python3, '--version'], stdout=PIPE).stdout
-    output = output.split(' ')[1]
+    output = output.split()[1]
     # ignore final component which can contains non-integers (e.g 'rc1')
     version = [int(x) for x in output.split('.')[:2]]
     return version >= [3, 5]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -97,7 +97,7 @@ def is_python3_version_supported():
     # ignore final component which can contains non-integers (e.g 'rc1')
     version = [int(x) for x in output.split('.')[:2]]
     return version >= [3, 5]
-  except:
+  except Exception:
     # If anything goes wrong (no python3, unexpected output format), then we do
     # not support this python3
     return False

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -90,14 +90,17 @@ def is_python3_version_supported():
 
   Note: Emscripten requires python3.5 or above since python3.4 and below do not
   support circular dependencies."""
-  python3 = Building.which('python3')
-  if not python3:
+  try:
+    python3 = Building.which('python3')
+    output = run_process([python3, '--version'], stdout=PIPE).stdout
+    output = output.split(' ')[1]
+    # ignore final component which can contains non-integers (e.g 'rc1')
+    version = [int(x) for x in output.split('.')[:2]]
+    return version >= [3, 5]
+  except:
+    # If anything goes wrong (no python3, unexpected output format), then we do
+    # not support this python3
     return False
-  output = run_process([python3, '--version'], stdout=PIPE).stdout
-  output = output.split()[1]
-  # ignore final component which can contains non-integers (e.g 'rc1')
-  version = [int(x) for x in output.split('.')[:2]]
-  return version >= [3, 5]
 
 
 def encode_leb(number):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -95,7 +95,7 @@ def is_python3_version_supported():
     python3 = Building.which('python3')
     print('  python3 =', python3)
     output = run_process([python3, '--version'], stdout=PIPE).stdout
-    print('  output =', output)
+    print('  output =', output, output.split())
     output = output.split()[1]
     # ignore final component which can contains non-integers (e.g 'rc1')
     version = [int(x) for x in output.split('.')[:2]]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -91,8 +91,11 @@ def is_python3_version_supported():
   Note: Emscripten requires python3.5 or above since python3.4 and below do not
   support circular dependencies."""
   try:
+    print('is_python3_version_supported')
     python3 = Building.which('python3')
+    print('  python3 =', python3)
     output = run_process([python3, '--version'], stdout=PIPE).stdout
+    print('  output =', output)
     output = output.split()[1]
     # ignore final component which can contains non-integers (e.g 'rc1')
     version = [int(x) for x in output.split('.')[:2]]


### PR DESCRIPTION
Fixes [build issues](https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8903948965079614896/+/steps/Emscripten_testsuite__upstream__other_/0/stdout)

I can't tell whether this is reasonable or not. On the one hand, I'm not sure why python3 exists but --version returns something formatted differently. On the other, this does encapsulate the reality that if something unusual happens then we don't support it.