### PR TITLE
Remove explicit space from split in python3 check

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -94,7 +94,7 @@ def is_python3_version_supported():
   if not python3:
     return False
   output = run_process([python3, '--version'], stdout=PIPE).stdout
-  output = output.split(' ')[1]
+  output = output.split()[1]
   # ignore final component which can contains non-integers (e.g 'rc1')
   version = [int(x) for x in output.split('.')[:2]]
   return version >= [3, 5]


### PR DESCRIPTION
This should be strictly better.