### PR TITLE
Fix timestamp between settings file and sanity file

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -556,7 +556,7 @@ def check_sanity(force=False):
       sanity_file += '_wasm'
     if os.path.exists(sanity_file):
       sanity_mtime = os.path.getmtime(sanity_file)
-      if sanity_mtime <= settings_mtime:
+      if sanity_mtime < settings_mtime:
         reason = 'settings file has changed'
       else:
         sanity_data = open(sanity_file).read().rstrip()


### PR DESCRIPTION
Many system such as macOS HFS only have timestamp resolutions of 1
second and on those systems emsdk (or at least the emsdk tests) will
often create the settings file and the sanity file in the same second
When this happens the next time emcc runs it incorrectly thinks the
timestamps have changed.

