### PR TITLE
Add explicit flag for AUTO_JS_LIBRARIES

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1097,6 +1097,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.STRICT:
       shared.Settings.DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1
       shared.Settings.STRICT_JS = 1
+      shared.Settings.AUTO_JS_LIBRARIES = 0
 
     if AUTODEBUG:
       shared.Settings.AUTODEBUG = 1
@@ -1439,6 +1440,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Always use the new HTML5 API event target lookup rules
       shared.Settings.DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1
+
+      # Require explicit -lfoo.js flags to link with JS libraries.
+      shared.Settings.AUTO_JS_LIBRARIES = 0
 
       # In asm.js always use memory init file to get the best code size, other modes are not currently supported.
       if not shared.Settings.WASM:

--- a/src/modules.js
+++ b/src/modules.js
@@ -88,8 +88,8 @@ var LibraryManager = {
         'library_pipefs.js',
       ]);
 
-      // Additional filesystem libraries (in strict mode, link to these explicitly via -lxxx.js)
-      if (!STRICT && !MINIMAL_RUNTIME) {
+      // Additional filesystem libraries (without AUTO_JS_LIBRARIES, link to these explicitly via -lxxx.js)
+      if (AUTO_JS_LIBRARIES) {
         if (ENVIRONMENT_MAY_BE_WEB || ENVIRONMENT_MAY_BE_WORKER) {
           libraries = libraries.concat([
             'library_idbfs.js',
@@ -109,8 +109,8 @@ var LibraryManager = {
       }
     }
 
-    // Additional JS libraries (in strict mode, link to these explicitly via -lxxx.js)
-    if (!STRICT && !MINIMAL_RUNTIME) {
+    // Additional JS libraries (without AUTO_JS_LIBRARIES, link to these explicitly via -lxxx.js)
+    if (AUTO_JS_LIBRARIES) {
       libraries = libraries.concat([
         'library_webgl.js',
         'library_openal.js',

--- a/src/settings.js
+++ b/src/settings.js
@@ -724,12 +724,12 @@ var RETAIN_COMPILER_SETTINGS = 0;
 // just functions. For example, you can include the Browser object by adding
 // "$Browser" to this list.
 var DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = [
-	'memcpy',
-	'memset',
-	'malloc',
-	'free',
-	'emscripten_get_heap_size', // Used by dynamicAlloc() and -s FETCH=1
-	];
+  'memcpy',
+  'memset',
+  'malloc',
+  'free',
+  'emscripten_get_heap_size', // Used by dynamicAlloc() and -s FETCH=1
+];
 
 // This list is also used to determine auto-exporting of library dependencies
 // (i.e., functions that might be dependencies of JS library functions, that if
@@ -810,10 +810,11 @@ var LINKABLE = 0;
 // Set the environment variable EMCC_STRICT=1 or pass -s STRICT=1 to test that a
 // codebase builds nicely in forward compatible manner.
 // Changes enabled by this:
-//   * DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR is enabled
+//   * DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR is enabled.
 //   * The C define EMSCRIPTEN is not defined (__EMSCRIPTEN__ always is, and
 //     is the correct thing to use).
-//   * STRICT_JS is enabled
+//   * STRICT_JS is enabled.
+//   * AUTO_JS_LIBRARIES is disabled.
 var STRICT = 0;
 
 // Add "use strict;" to generated JS
@@ -835,10 +836,6 @@ var WARN_ON_UNDEFINED_SYMBOLS = 1;
 // occur.  Any undefined symbols that are listed in EXPORTED_FUNCTIONS will also
 // be reported.
 var ERROR_ON_UNDEFINED_SYMBOLS = 1;
-
-// Specifies a list of Emscripten-provided JS libraries to link against.
-// (internal, use -lfoo or -lfoo.js to link to Emscripten system JS libraries)
-var SYSTEM_JS_LIBRARIES = [];
 
 // Use small chunk size for binary synchronous XHR's in Web Workers.  Used for
 // testing.  See test_chunked_synchronous_xhr in runner.py and library.js.
@@ -1388,9 +1385,19 @@ var SINGLE_FILE = 0;
 // to execute the file without the accompanying JS file.
 var EMIT_EMSCRIPTEN_METADATA = 0;
 
+// If set to 1, all JS libraries will be automaticially available at link time.
+// This gets set to 0 in STRICT mode (or with MINIMAL_RUNTIME) which mean you
+// need to explictly specify -lfoo.js in at link time in order to access
+// library function in library_foo.js.
+var AUTO_JS_LIBRARIES = 1;
+
 //==============================
 // Internal use only, from here
 //==============================
+
+// Specifies a list of Emscripten-provided JS libraries to link against.
+// (internal, use -lfoo or -lfoo.js to link to Emscripten system JS libraries)
+var SYSTEM_JS_LIBRARIES = [];
 
 // This will contain the emscripten version. You should not modify this. This
 // and the following few settings are useful in combination with


### PR DESCRIPTION
Previously this behaviour was enabled for STRICT and MINIMAL_RUNTIME,
but this gives at explicit name to the settings.  The idea with STRICT
mode is that it enables a certain set of settings that can each be
controlled independently.

