### PR TITLE
Stop testing asm2i (Emterpreter -O2)

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -254,7 +254,6 @@ if not shared.Settings.WASM_BACKEND:
     'asm3',
     'asm2g',
     'asm2f',
-    'asm2i',
   ]
 
 # The default core test mode, used when none is specified


### PR DESCRIPTION
It's fastcomp, it has some test coverage in other suites, it's very slow, and also it broke now due to the node upgrade (node 10 breaks due to https://bugs.chromium.org/p/v8/issues/detail?id=8347 , 8 and 12 are ok).