### PR TITLE
Handle relocations on the main module

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1020,6 +1020,9 @@ function createWasm(env) {
   // performing other necessary setup
   function receiveInstance(instance, module) {
     var exports = instance.exports;
+#if RELOCATABLE
+    exports = relocateExports(exports, GLOBAL_BASE, 0);
+#endif
 #if WASM_BACKEND && ASYNCIFY
     exports = Asyncify.instrumentWasmExports(exports);
 #endif

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4039,6 +4039,7 @@ ok
 
   @needs_dlfcn
   def test_dylink_syslibs(self): # one module uses libcxx, need to force its inclusion when it isn't the main
+    self.banned_js_engines = [NODE_JS, V8_ENGINE] # https://bugs.chromium.org/p/v8/issues/detail?id=9678
 
     def test(syslibs, expect_pass=True, need_reverse=True):
       print('syslibs', syslibs, self.get_setting('ASSERTIONS'))
@@ -4144,6 +4145,8 @@ ok
 
   @needs_dlfcn
   def test_dylink_raii_exceptions(self):
+    self.banned_js_engines = [NODE_JS, V8_ENGINE] # https://bugs.chromium.org/p/v8/issues/detail?id=9678
+
     self.emcc_args += ['-s', 'DISABLE_EXCEPTION_CATCHING=0']
 
     self.dylink_test(main=r'''

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2013,6 +2013,7 @@ Success!''')
 
       self.do_run_in_out_file_test('tests', 'core', 'test_indirectbr')
 
+  @no_wasm2js('extremely deep nesting, hits stack limit on some VMs')
   def test_indirectbr_many(self):
       self.do_run_in_out_file_test('tests', 'core', 'test_indirectbr_many')
 


### PR DESCRIPTION
So it can dlopen itself properly. This fixes us after the breaking change on wasm globals to make them be objects. The fix is to move the relocation function around, and to just call it for the main module.

Disable some other dylink tests which hit a v8 bug

After this all tests should pass with new node on our CI.