### PR TITLE
Fixes Node deprecation warning for Buffer when using nodefs

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -30,7 +30,7 @@ mergeInto(LibraryManager.library, {
       // Node.js < 4.5 compatibility: Buffer.from does not support ArrayBuffer
       // Buffer.from before 4.5 was just a method inherited from Uint8Array
       // Buffer.alloc has been added with Buffer.from together, so check it instead
-      return Buffer.alloc ? Buffer.from(arrayBuffer) : new Buffer(arrayBuffer);
+      return Buffer["alloc"] ? Buffer.from(arrayBuffer) : new Buffer(arrayBuffer);
     },
     mount: function (mount) {
       assert(ENVIRONMENT_HAS_NODE);


### PR DESCRIPTION
Closure's minification changes the test for `alloc` into a random two-letter combination, essentially skipping the test and taking the deprecated code path. Running closure on the existing [test_nodefs_rw.c](/emscripten-core/emscripten/blob/incoming/tests/fs/test_nodefs_rw.c) test results in:
```
(node:1100) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
This minor tweak stops closure minifying the `alloc` test.