### PR TITLE
Clarify how to compile from source a little more

### DIFF
--- a/site/source/docs/building_from_source/index.rst
+++ b/site/source/docs/building_from_source/index.rst
@@ -8,21 +8,26 @@ Building Emscripten yourself is an alternative to getting binaries using the ems
 
 Emscripten's core codebase, which is in the main "emscripten" repo, does not need to be compiled (it uses Python for most of the scripting that glues together all the tools). What do need to be compiled are LLVM (which in particular provides clang and wasm-ld) and Binaryen. After compiling them, simply edit the ``.emscripten`` file to point to the right place for each of those tools (if the file doesn't exist yet, run ``emcc`` for the first time).
 
+Get the ``master`` branches, or check the `Packaging <https://github.com/emscripten-core/emscripten/blob/incoming/docs/process.md#packaging-emscripten>`_ instructions to identify precise commits in existing releases.
+
+
 Building LLVM
 -------------
 
-For using the LLVM wasm backend (recommended), simply build normal upstream LLVM from the `monorepo <https://github.com/llvm/llvm-project>`_, including clang and wasm-ld (using something like ``-DLLVM_ENABLE_PROJECTS='lld;clang'``) and the wasm backend (which is included by default; just don't disable it), following `that project's instructions <http://llvm.org/docs/CMake.html>`_. For example, something like this can work:
+For using the LLVM wasm backend (recommended), simply build normal upstream LLVM from the `monorepo <https://github.com/llvm/llvm-project>`_.
+Include clang and wasm-ld (using something like ``-DLLVM_ENABLE_PROJECTS='lld;clang'``) and the wasm backend (which is included by default; just don't disable it), following `that project's instructions <http://llvm.org/docs/CMake.html>`_.
+For example, something like this can work:
 
   ::
 
       mkdir build
       cd build/
       cmake ../llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS='lld;clang' -DLLVM_TARGETS_TO_BUILD="host;WebAssembly" -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF
-      make -j$(nproc)  # no need to install
+      cmake --build .
+
+Then point LLVM_ROOT in ``.emscripten`` to ``<llvm_src>/build/bin`` (no need to install).
 
 Please refer to the upstream docs for more detail.
-
-The version to select for e.g. 1.38.43 is --- TODO ---.
 
 For using the older fastcomp backend, see :ref:`the fastcomp docs <building-fastcomp-from-source>`.
 
@@ -30,8 +35,6 @@ Building Binaryen
 -----------------
 
 See the `Binaryen build instructions <https://github.com/WebAssembly/binaryen#building>`_.
-
-The version to select for e.g. 1.38.43 is --- TODO ---.
 
 .. toctree::
    :maxdepth: 1

--- a/site/source/docs/building_from_source/index.rst
+++ b/site/source/docs/building_from_source/index.rst
@@ -11,15 +11,18 @@ Emscripten's core codebase, which is in the main "emscripten" repo, does not nee
 Building LLVM
 -------------
 
-For using the LLVM wasm backend (recommended), simply build normal upstream LLVM from the monorepo, including clang and wasm-ld (using something like ``-DLLVM_ENABLE_PROJECTS=lld;clang'``) and the wasm backend (which is included by default; just don't disable it), following `that project's instructions <http://llvm.org/docs/CMake.html>`_. For example, something like this can work:
+For using the LLVM wasm backend (recommended), simply build normal upstream LLVM from the `monorepo <https://github.com/llvm/llvm-project>`_, including clang and wasm-ld (using something like ``-DLLVM_ENABLE_PROJECTS='lld;clang'``) and the wasm backend (which is included by default; just don't disable it), following `that project's instructions <http://llvm.org/docs/CMake.html>`_. For example, something like this can work:
 
   ::
 
       mkdir build
-      cd build
-      cmake .. -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS='lld;clang' -DLLVM_TARGETS_TO_BUILD="host;WebAssembly" -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF
+      cd build/
+      cmake ../llvm -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_PROJECTS='lld;clang' -DLLVM_TARGETS_TO_BUILD="host;WebAssembly" -DLLVM_INCLUDE_EXAMPLES=OFF -DLLVM_INCLUDE_TESTS=OFF
+      make -j$(nproc)  # no need to install
 
 Please refer to the upstream docs for more detail.
+
+The version to select for e.g. 1.38.43 is --- TODO ---.
 
 For using the older fastcomp backend, see :ref:`the fastcomp docs <building-fastcomp-from-source>`.
 
@@ -27,6 +30,8 @@ Building Binaryen
 -----------------
 
 See the `Binaryen build instructions <https://github.com/WebAssembly/binaryen#building>`_.
+
+The version to select for e.g. 1.38.43 is --- TODO ---.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
Following-up on the discussion from #9317 :)

Besides a couple trivial fixes, I think we need to explain what version of LLVM and Binaryen needs to be checked-out.

Also, I'm not sure whether there's a bug in tools/ports/binaryen.py since it still references v86, while the emsdk binaries grab v89 AFAIU. If that's intended so probably needs to be clarified, because the port is built and used automatically when BINARYEN_ROOT is empty.