### PR TITLE
Fix TRACE_WEBGL_CALLS throwing on context creation

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -426,3 +426,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Ajay Patel <patel.ajay285@gmail.com>
 * Adrien Devresse <adev@adev.name>
 * Petr Penzin (petr.penzin@intel.com) (copyright owned by Intel Corporation)
+* Andrei Alexeyev <akari@taisei-project.org>

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -508,10 +508,16 @@ var LibraryGL = {
       canvas.removeEventListener('webglcontextcreationerror', onContextCreationError, false);
       if (!ctx) {
         err('Could not create canvas: ' + [errorInfo, JSON.stringify(webGLContextAttributes)]);
+        return 0;
       }
+#else
+      if (!ctx) return 0;
 #endif
+
+      var handle = GL.registerContext(ctx, webGLContextAttributes);
+
 #if TRACE_WEBGL_CALLS
-      if (ctx) GL.hookWebGL(ctx);
+      GL.hookWebGL(ctx);
 #endif
 
 #if GL_DISABLE_HALF_FLOAT_EXTENSION_IF_BROKEN
@@ -545,7 +551,7 @@ var LibraryGL = {
       disableHalfFloatExtensionIfBroken(ctx);
 #endif
 
-      return ctx ? GL.registerContext(ctx, webGLContextAttributes) : 0;
+      return handle;
     },
 
 #if OFFSCREEN_FRAMEBUFFER


### PR DESCRIPTION
The issue here is that `hookWebGLFunction` tries to access `canvas.GLctxObject` (https://github.com/emscripten-core/emscripten/blob/095b841/src/library_webgl.js#L411), which is undefined until `GL.registerContext` returns.

Unfortunately I wasn't able to make use of tracing anyway; it crashes chrome and stalls firefox forever. So I'm not sure whether it's broken in some other way or just that slow.