### PR TITLE
FIXED: Using string to avoid Closure to rename the property name.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -427,3 +427,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Adrien Devresse <adev@adev.name>
 * Petr Penzin (petr.penzin@intel.com) (copyright owned by Intel Corporation)
 * Andrei Alexeyev <akari@taisei-project.org>
+* Cesar Guirao Robles <cesar@no2.es>

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1997,7 +1997,7 @@ var LibraryJSEvents = {
 #else
       var gamepadEvent = JSEvents.gamepadEvent;
 #endif
-      __fillGamepadEventData(gamepadEvent, e.gamepad);
+      __fillGamepadEventData(gamepadEvent, e["gamepad"]);
 
 #if USE_PTHREADS
       if (targetThread) JSEvents.queueEventHandlerOnThread_iiii(targetThread, callbackfunc, eventTypeId, gamepadEvent, userData);


### PR DESCRIPTION
When using the Closure compiler, the property `gamepad` of `event` is renamed breaking the gamepad support.