### PR TITLE
Fix SINGLE_FILE with wasm2js

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1483,7 +1483,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           exit_with_error('WASM2JS does not yet support pthreads')
         # in wasm2js, keep the mem init in the wasm itself if we can and if the
         # options wouldn't tell a js build to use a separate mem init file
-        shared.Settings.MEM_INIT_IN_WASM = not options.memory_init_file
+        shared.Settings.MEM_INIT_IN_WASM = not options.memory_init_file or shared.Settings.SINGLE_FILE
       else:
         # wasm includes the mem init in the wasm binary. The exception is
         # wasm2js, which behaves more like js.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8469,7 +8469,7 @@ int main() {
       expect_success = not (emterpreter_file_enabled and single_file_enabled)
       expect_wast = debug_enabled and wasm_enabled and not self.is_wasm_backend()
 
-      if self.is_wasm_backend() and (emterpreter_enabled or not wasm_enabled):
+      if self.is_wasm_backend() and emterpreter_enabled:
         continue
 
       # currently, the emterpreter always fails with JS output since we do not preload the emterpreter file, which in non-HTML we would need to do manually


### PR DESCRIPTION
The relevant test was disabled internally, which is why I missed it when I triaged all the disabled tests (I was looking for decorators etc.).

Fix is pretty simple, the logic for when to use a mem init file was not aware of SINGLE_FILE. (There may be an even simpler way to rewrite that  code, but let's wait until after fastcomp is removed for any major refactoring.)

Fixes #9380