### PR TITLE
Enable test_dylink_function_pointer_equality under fastcomp

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3517,7 +3517,6 @@ ok
     self.do_basic_dylink_test()
 
   @needs_dlfcn
-  @no_fastcomp('https://github.com/emscripten-core/emscripten/issues/8268')
   def test_dylink_function_pointer_equality(self):
     self.dylink_test(r'''
       #include <stdio.h>


### PR DESCRIPTION
Recent changes to fastcomp mean that this test now passes.

Fixes: #8268
