### PR TITLE
speed up make_table

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1107,8 +1107,9 @@ def make_function_tables_defs(implemented_functions, all_implemented, function_t
     end = raw.rindex(']')
     body = raw[start + 1:end].split(',')
     if shared.Settings.EMULATED_FUNCTION_POINTERS:
-      #this speeds up this section when all_implemented is very big > 150000
+      # this speeds up this section when all_implemented is very big > 150000
       notinImplemented = list(set(body) - set(all_implemented))
+
       def receive(item):
         if item == '0':
           return item

--- a/emscripten.py
+++ b/emscripten.py
@@ -1107,10 +1107,12 @@ def make_function_tables_defs(implemented_functions, all_implemented, function_t
     end = raw.rindex(']')
     body = raw[start + 1:end].split(',')
     if shared.Settings.EMULATED_FUNCTION_POINTERS:
+      #this speeds up this section when all_implemented is very big > 150000
+      notinImplemented = list(set(body) - set(all_implemented))
       def receive(item):
         if item == '0':
           return item
-        if item not in all_implemented:
+        if item in notinImplemented:
           # this is not implemented; it would normally be wrapped, but with emulation, we just use it directly outside
           return item
         in_table.add(item)


### PR DESCRIPTION
speed up make_function_tables_defs by checking if the item is in the not implemented list
this improves build time for us for our main wasm.
reduction from 12 -> 8 mins. 

issue:
our list of implemented functions is large > 150000 and the fix_item function is looping through it to check that the item is not in the list of > 150000. 

fix:
take the difference of items in body and all_implemented.
everything left is not implemented, and use that list instead.