### PR TITLE
Add emscripten cache directory to default library path

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -675,7 +675,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       compiler = [compiler]
     cmd = compiler + list(filter_emscripten_options(args))
     if not use_js:
-      cmd += shared.EMSDK_OPTS + ['-D__EMSCRIPTEN__']
+      cmd += shared.emsdk_cflags() + ['-D__EMSCRIPTEN__']
       # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
       # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
       if not shared.Settings.STRICT:
@@ -887,8 +887,15 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     has_source_inputs = False
     has_header_inputs = False
-    lib_dirs = [shared.path_from_root('system', 'local', 'lib'),
-                shared.path_from_root('system', 'lib')]
+    lib_dirs = []
+
+    has_dash_c = '-c' in newargs
+    has_dash_S = '-S' in newargs
+    executable_endings = JS_CONTAINING_ENDINGS + ('.wasm',)
+    compile_only = final_suffix not in executable_endings or has_dash_c or has_dash_S
+
+    if not compile_only:
+      newargs += shared.emsdk_ldflags(newargs)
 
     # find input files this a simple heuristic. we should really analyze
     # based on a full understanding of gcc params, right now we just assume that
@@ -957,9 +964,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       elif arg.startswith('-L'):
         lib_dirs.append(arg[2:])
         newargs[i] = ''
+        link_flags.append((i, arg))
       elif arg.startswith('-l'):
         libs.append((i, arg[2:]))
         newargs[i] = ''
+        link_flags.append((i, arg))
       elif arg.startswith('-Wl,'):
         # Multiple comma separated link flags can be specified. Create fake
         # fractional indices for these: -Wl,a,b,c,d at index 4 becomes:
@@ -970,8 +979,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             libs.append((i, flag[2:]))
           elif flag.startswith('-L'):
             lib_dirs.append(flag[2:])
-          else:
-            link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
+          link_flags.append((i + float(flag_index) / len(link_flags_to_add), flag))
 
         newargs[i] = ''
       elif arg == '-s':
@@ -985,8 +993,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if '-fno-rtti' in newargs:
       shared.Settings.USE_RTTI = 0
 
-    has_dash_c = '-c' in newargs
-    has_dash_S = '-S' in newargs
     if has_dash_c or has_dash_S:
       assert has_source_inputs or has_header_inputs, 'Must have source code or header inputs to use -c or -S'
       if has_dash_c:
@@ -1041,9 +1047,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if not shared.Settings.STRICT:
       # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
       # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
-      shared.COMPILER_OPTS += ['-DEMSCRIPTEN']
+      newargs += ['-DEMSCRIPTEN']
 
-    settings_changes.append(process_libraries(libs, lib_dirs, input_files))
+    consumed = process_libraries(libs, lib_dirs, input_files)
+    # Filter out libraries that are actually JS libs
+    link_flags = [l for l in link_flags if l[0] not in consumed]
+    # Filter out libraries that musl includes in libc itself
+    link_flags = [l for l in link_flags if l[1] not in ('-lm', '-lrt', '-ldl')]
 
     # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
     # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
@@ -1060,7 +1070,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if len(input_files) == 0:
       exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
 
-    newargs = shared.COMPILER_OPTS + newargs
+    newargs = shared.COMPILER_OPTS + shared.get_cflags(newargs) + newargs
 
     if options.separate_asm and final_suffix != '.html':
       shared.WarningManager.warn('SEPARATE_ASM')
@@ -1760,9 +1770,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     temp_files = []
 
-  executable_endings = JS_CONTAINING_ENDINGS + ('.wasm',)
-  compile_only = final_suffix not in executable_endings or has_dash_c or has_dash_S
-
   # exit block 'parse arguments and setup'
   log_time('parse arguments and setup')
 
@@ -1910,6 +1917,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         def supported(f):
           if f in SUPPORTED_LINKER_FLAGS:
             return True
+          if f.startswith('-l') or f.startswith('-L'):
+            return False
           logger.warning('ignoring unsupported linker flag: `%s`', f)
           return False
         link_flags = [f for f in link_flags if supported(f[1])]
@@ -2599,9 +2608,8 @@ def parse_args(newargs):
       options.ignore_dynamic_linking = True
       newargs[i] = ''
     elif newargs[i] == '-v':
-      shared.COMPILER_OPTS += ['-v']
+      shared.PRINT_STAGES = True
       shared.check_sanity(force=True)
-      newargs[i] = ''
     elif newargs[i].startswith('--shell-file'):
       check_bad_eq(newargs[i])
       options.shell_path = newargs[i + 1]
@@ -3412,10 +3420,19 @@ def worker_js_script(proxy_worker_filename):
 
 def process_libraries(libs, lib_dirs, input_files):
   libraries = []
+  consumed = []
 
   # Find library files
   for i, lib in libs:
     logger.debug('looking for library "%s"', lib)
+    if shared.Settings.WASM_BACKEND:
+      # under the wasm backend -l/-L flags already work with the linker
+      jslibs = shared.Building.path_to_system_js_libraries(lib)
+      if jslibs:
+        libraries += jslibs
+        consumed.append(i)
+      continue
+
     found = False
     for prefix in LIB_PREFIXES:
       for suff in STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS:
@@ -3434,7 +3451,8 @@ def process_libraries(libs, lib_dirs, input_files):
     if not found:
       libraries += shared.Building.path_to_system_js_libraries(lib)
 
-  return 'SYSTEM_JS_LIBRARIES="' + ','.join(libraries) + '"'
+  shared.Settings.SYSTEM_JS_LIBRARIES = libraries
+  return consumed
 
 
 class ScriptSource(object):

--- a/src/modules.js
+++ b/src/modules.js
@@ -137,10 +137,8 @@ var LibraryManager = {
       }
     }
 
-    // If there are any explicitly specified system JS libraries to link to, add those to link.
-    if (SYSTEM_JS_LIBRARIES) {
-      libraries = libraries.concat(SYSTEM_JS_LIBRARIES.split(','));
-    }
+    // Add any explicitly specified system JS libraries to link to, add those to link.
+    libraries = libraries.concat(SYSTEM_JS_LIBRARIES)
 
     if (LZ4) {
       libraries.push('library_lz4.js');

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -81,13 +81,13 @@ while 1:
   print('2) Compile natively')
   shared.try_delete(filename)
   try:
-    shared.run_process([COMP, '-m32', opts, fullname, '-o', filename + '1'] + CSMITH_CFLAGS + ['-w']) # + shared.EMSDK_OPTS
+    shared.run_process([COMP, '-m32', opts, fullname, '-o', filename + '1'] + CSMITH_CFLAGS + ['-w']) # + shared.get_cflags()
   except CalledProcessError:
     print('Failed to compile natively using clang')
     notes['invalid'] += 1
     continue
 
-  shared.run_process([COMP, '-m32', opts, '-emit-llvm', '-c', fullname, '-o', filename + '.bc'] + CSMITH_CFLAGS + shared.EMSDK_OPTS + ['-w'])
+  shared.run_process([COMP, '-m32', opts, '-emit-llvm', '-c', fullname, '-o', filename + '.bc'] + CSMITH_CFLAGS + shared.get_cflags() + ['-w'])
   shared.run_process([shared.path_from_root('tools', 'nativize_llvm.py'), filename + '.bc'], stderr=PIPE)
   shutil.move(filename + '.bc.run', filename + '2')
   shared.run_process([COMP, fullname, '-o', filename + '3'] + CSMITH_CFLAGS + ['-w'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6090,14 +6090,14 @@ Descriptor desc;
 import os
 print(os.environ.get('CROSS_COMPILE'))
 ''')
-    check('emconfigure', [PYTHON, 'test.py'], expect=path_from_root('em'), fail=False)
-    check('emmake', [PYTHON, 'test.py'], expect=path_from_root('em'), fail=False)
+    check('emconfigure', [PYTHON, 'test.py'], expect=path_from_root('em'))
+    check('emmake', [PYTHON, 'test.py'], expect=path_from_root('em'))
 
     create_test_file('test.py', '''
 import os
 print(os.environ.get('NM'))
 ''')
-    check('emconfigure', [PYTHON, 'test.py'], expect=shared.LLVM_NM, fail=False)
+    check('emconfigure', [PYTHON, 'test.py'], expect=shared.LLVM_NM)
 
   @no_windows('This test is broken, https://github.com/emscripten-core/emscripten/issues/8872')
   def test_emmake_python(self):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1359,7 +1359,7 @@ def g_multiprocessing_initializer(*args):
       os.environ[key] = value
 
 
-PRINT_STAGES = False
+PRINT_STAGES = int(os.getenv('EMCC_VERBOSE', '0'))
 
 
 def print_compiler_stage(cmd):


### PR DESCRIPTION
Also, allow -L/-l flags to pass all the way down the linker under the
wasm backend.

This change paves that way to include system librayies such as -lc on
the link line by default rather than including them via the `.symbols`
files.

See #8912
