### PR TITLE
Perform "linking to object file" as separate phase.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -892,7 +892,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     has_dash_c = '-c' in newargs
     has_dash_S = '-S' in newargs
     executable_endings = JS_CONTAINING_ENDINGS + ('.wasm',)
-    compile_only = final_suffix not in executable_endings or has_dash_c or has_dash_S
+    compile_only = has_dash_c or has_dash_S
 
     if not compile_only:
       newargs += shared.emsdk_ldflags(newargs)
@@ -1049,24 +1049,22 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
       newargs += ['-DEMSCRIPTEN']
 
-    consumed = process_libraries(libs, lib_dirs, input_files)
-    # Filter out libraries that are actually JS libs
-    link_flags = [l for l in link_flags if l[0] not in consumed]
-    # Filter out libraries that musl includes in libc itself, or with we
-    # otherwise privide implicitly.
-    link_flags = [l for l in link_flags if l[1] not in ('-lm', '-lrt', '-ldl', '-lpthread')]
+    def filter_out_dynamic_libs(inputs):
+      # If not compiling to JS, then we are compiling to an intermediate bitcode
+      # objects or library, so ignore dynamic linking, since multiple dynamic
+      # linkings can interfere with each other
+      if get_file_suffix(target) not in JS_CONTAINING_ENDINGS or options.ignore_dynamic_linking:
+        def check(input_file):
+          if get_file_suffix(input_file) in DYNAMICLIB_ENDINGS:
+            if not options.ignore_dynamic_linking:
+              logger.warning('ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
+            return False
+          else:
+            return True
+        return [f for f in inputs if check(f[1])]
+      return inputs
 
-    # If not compiling to JS, then we are compiling to an intermediate bitcode objects or library, so
-    # ignore dynamic linking, since multiple dynamic linkings can interfere with each other
-    if get_file_suffix(target) not in JS_CONTAINING_ENDINGS or options.ignore_dynamic_linking:
-      def check(input_file):
-        if get_file_suffix(input_file) in DYNAMICLIB_ENDINGS:
-          if not options.ignore_dynamic_linking:
-            logger.warning('ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
-          return False
-        else:
-          return True
-      input_files = [f for f in input_files if check(f[1])]
+    input_files = filter_out_dynamic_libs(input_files)
 
     if len(input_files) == 0:
       exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + BITCODE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
@@ -1909,23 +1907,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
               shared.Building.llvm_opt(temp_file, opts, new_temp_file)
               temp_files[pos] = (temp_files[pos][0], new_temp_file)
 
-      # Decide what we will link
-      if compile_only or not shared.Settings.WASM_BACKEND:
-        # Filter link flags, keeping only those that shared.Building.link knows
-        # how to deal with.  We currently can't handle flags with options (like
-        # -Wl,-rpath,/bin:/lib, where /bin:/lib is an option for the -rpath
-        # flag).
-        def supported(f):
-          if f in SUPPORTED_LINKER_FLAGS:
-            return True
-          if f.startswith('-l') or f.startswith('-L'):
-            return False
-          logger.warning('ignoring unsupported linker flag: `%s`', f)
-          return False
-        link_flags = [f for f in link_flags if supported(f[1])]
-
-      linker_inputs = [val for _, val in sorted(temp_files + link_flags)]
-
       # If we were just compiling stop here
       if compile_only:
         if not specified_target:
@@ -1933,47 +1914,74 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           for tempf, inputf in zip(temp_files, input_files):
             safe_move(tempf[1], unsuffixed_basename(inputf[1]) + final_suffix)
         else:
-          if len(input_files) == 1:
-            input_file = input_files[0][1]
-            temp_file = temp_files[0][1]
-            bitcode_target = specified_target if specified_target else unsuffixed_basename(input_file) + final_suffix
-            if temp_file != input_file:
-              safe_move(temp_file, bitcode_target)
-            else:
-              shutil.copyfile(temp_file, bitcode_target)
-            temp_output_base = unsuffixed(temp_file)
-            if os.path.exists(temp_output_base + '.d'):
-              # There was a .d file generated, from -MD or -MMD and friends, save a copy of it to where the output resides,
-              # adjusting the target name away from the temporary file name to the specified target.
-              # It will be deleted with the rest of the temporary directory.
-              deps = open(temp_output_base + '.d').read()
-              deps = deps.replace(temp_output_base + options.default_object_extension, specified_target)
-              with open(os.path.join(os.path.dirname(specified_target), os.path.basename(unsuffixed(input_file) + '.d')), "w") as out_dep:
-                out_dep.write(deps)
+          # Specifying -o with multiple input source files is not allowed.
+          # We error out much earlier in this case.
+          assert len(input_files) == 1
+          input_file = input_files[0][1]
+          temp_file = temp_files[0][1]
+          bitcode_target = specified_target if specified_target else unsuffixed_basename(input_file) + final_suffix
+          if temp_file != input_file:
+            safe_move(temp_file, bitcode_target)
           else:
-            # We have a specified target (-o <target>), which is not JavaScript or HTML, and
-            # we have multiple files: Link them
-            logger.debug('link: ' + str(linker_inputs) + specified_target)
-            shared.Building.link_to_object(linker_inputs, specified_target)
+            shutil.copyfile(temp_file, bitcode_target)
+          temp_output_base = unsuffixed(temp_file)
+          if os.path.exists(temp_output_base + '.d'):
+            # There was a .d file generated, from -MD or -MMD and friends, save a copy of it to where the output resides,
+            # adjusting the target name away from the temporary file name to the specified target.
+            # It will be deleted with the rest of the temporary directory.
+            deps = open(temp_output_base + '.d').read()
+            deps = deps.replace(temp_output_base + options.default_object_extension, specified_target)
+            with open(os.path.join(os.path.dirname(specified_target), os.path.basename(unsuffixed(input_file) + '.d')), "w") as out_dep:
+              out_dep.write(deps)
 
     # exit block 'process inputs'
     log_time('process inputs')
 
     if compile_only:
       logger.debug('stopping after compile phase')
-      if shared.Settings.SIDE_MODULE:
-        exit_with_error('SIDE_MODULE must only be used when compiling to an executable shared library, and not when emitting an object file.  That is, you should be emitting a .wasm file (for wasm) or a .js file (for asm.js). Note that when compiling to a typical native suffix for a shared library (.so, .dylib, .dll; which many build systems do) then Emscripten emits an object file, which you should then compile to .wasm or .js with SIDE_MODULE.')
-      if final_suffix.lower() in ('.so', '.dylib', '.dll'):
-        logger.warning('When Emscripten compiles to a typical native suffix for shared libraries (.so, .dylib, .dll) then it emits an object file. You should then compile that to an emscripten SIDE_MODULE (using that flag) with suffix .wasm (for wasm) or .js (for asm.js). (You may also want to adapt your build system to emit the more standard suffix for a an object file, \'.bc\' or \'.o\', which would avoid this warning.)')
       return 0
+
+    consumed = process_libraries(libs, lib_dirs, temp_files)
+    # Filter out libraries that are actually JS libs
+    link_flags = [l for l in link_flags if l[0] not in consumed]
+    # Filter out libraries that musl includes in libc itself, or with we
+    # otherwise privide implicitly.
+    link_flags = [l for l in link_flags if l[1] not in ('-lm', '-lrt', '-ldl', '-lpthread')]
+    temp_files = filter_out_dynamic_libs(temp_files)
+
+    # Decide what we will link
+    if not (shared.Settings.WASM_BACKEND and shared.Settings.WASM_OBJECT_FILES):
+      # Filter link flags, keeping only those that shared.Building.link knows
+      # how to deal with.  We currently can't handle flags with options (like
+      # -Wl,-rpath,/bin:/lib, where /bin:/lib is an option for the -rpath
+      # flag).
+      def supported(f):
+        if f in SUPPORTED_LINKER_FLAGS:
+          return True
+        if f.startswith('-l') or f.startswith('-L'):
+          return False
+        logger.warning('ignoring unsupported linker flag: `%s`', f)
+        return False
+      link_flags = [f for f in link_flags if supported(f[1])]
+
+    linker_inputs = [val for _, val in sorted(temp_files + link_flags)]
+
+    if final_suffix not in executable_endings:
+      with ToolchainProfiler.profile_block('linking to object file'):
+        # We have a specified target (-o <target>), which is not JavaScript or HTML, and
+        # we have multiple files: Link them
+        if shared.Settings.SIDE_MODULE:
+          exit_with_error('SIDE_MODULE must only be used when compiling to an executable shared library, and not when emitting an object file.  That is, you should be emitting a .wasm file (for wasm) or a .js file (for asm.js). Note that when compiling to a typical native suffix for a shared library (.so, .dylib, .dll; which many build systems do) then Emscripten emits an object file, which you should then compile to .wasm or .js with SIDE_MODULE.')
+        if final_suffix.lower() in ('.so', '.dylib', '.dll'):
+          logger.warning('When Emscripten compiles to a typical native suffix for shared libraries (.so, .dylib, .dll) then it emits an object file. You should then compile that to an emscripten SIDE_MODULE (using that flag) with suffix .wasm (for wasm) or .js (for asm.js). (You may also want to adapt your build system to emit the more standard suffix for a an object file, \'.bc\' or \'.o\', which would avoid this warning.)')
+        logger.debug('link_to_object: ' + str(linker_inputs) + ' -> ' + specified_target)
+        shared.Building.link_to_object(linker_inputs, specified_target)
+        logger.debug('stopping after linking to object file')
+        return 0
 
     ## Continue on to create JavaScript
 
     with ToolchainProfiler.profile_block('calculate system libraries'):
-      logger.debug('will generate JavaScript')
-
-      extra_files_to_link = []
-
       # link in ports and system libraries, if necessary
       if not LEAVE_INPUTS_RAW and \
          not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
@@ -1981,6 +1989,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
          not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
         extra_files_to_link = system_libs.get_ports(shared.Settings)
         extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, stdout_=None, stderr_=None, forced=forced_stdlibs)
+        linker_inputs += extra_files_to_link
 
     # exit block 'calculate system libraries'
     log_time('calculate system libraries')
@@ -2011,7 +2020,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return final
 
       # First, combine the bitcode files if there are several. We must also link if we have a singleton .a
-      linker_inputs += extra_files_to_link
       perform_link = len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND
       if not perform_link and not LEAVE_INPUTS_RAW:
         is_bc = suffix(temp_files[0][1]) in BITCODE_ENDINGS
@@ -3419,7 +3427,7 @@ def worker_js_script(proxy_worker_filename):
   return web_gl_client_src + '\n' + proxy_client_src
 
 
-def process_libraries(libs, lib_dirs, input_files):
+def process_libraries(libs, lib_dirs, temp_files):
   libraries = []
   consumed = []
 
@@ -3441,7 +3449,7 @@ def process_libraries(libs, lib_dirs, input_files):
           path = os.path.join(lib_dir, name)
           if os.path.exists(path):
             logger.debug('found library "%s" at %s', lib, path)
-            input_files.append((i, path))
+            temp_files.append((i, path))
             consumed.append(i)
             found = True
             break

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1068,25 +1068,21 @@ int main() {
       self.assertContained("unknown suffix", proc.stderr)
 
   def test_multiply_defined_libsymbols(self):
-    lib = "int mult() { return 1; }"
     lib_name = 'libA.c'
-    create_test_file(lib_name, lib)
-    a2 = "void x() {}"
     a2_name = 'a2.c'
-    create_test_file(a2_name, a2)
-    b2 = "void y() {}"
     b2_name = 'b2.c'
-    create_test_file(b2_name, b2)
-    main = r'''
+    main_name = 'main.c'
+    create_test_file(lib_name, 'int mult() { return 1; }')
+    create_test_file(a2_name, 'void x() {}')
+    create_test_file(b2_name, 'void y() {}')
+    create_test_file(main_name, r'''
       #include <stdio.h>
       int mult();
       int main() {
         printf("result: %d\n", mult());
         return 0;
       }
-    '''
-    main_name = 'main.c'
-    create_test_file(main_name, main)
+    ''')
 
     Building.emcc(lib_name, output_filename='libA.so')
 
@@ -3586,27 +3582,18 @@ int main() {
   def test_oz_size(self):
     sizes = {}
     for name, args in [
-        ('0', ['-o', 'dlmalloc.o']),
-        ('1', ['-o', 'dlmalloc.o', '-O1']),
-        ('2', ['-o', 'dlmalloc.o', '-O2']),
-        ('s', ['-o', 'dlmalloc.o', '-Os']),
-        ('z', ['-o', 'dlmalloc.o', '-Oz']),
-        ('3', ['-o', 'dlmalloc.o', '-O3']),
-        ('0c', ['-c']),
-        ('1c', ['-c', '-O1']),
-        ('2c', ['-c', '-O2']),
-        ('sc', ['-c', '-Os']),
-        ('zc', ['-c', '-Oz']),
-        ('3c', ['-c', '-O3']),
+        ('0', []),
+        ('1', ['-O1']),
+        ('2', ['-O2']),
+        ('s', ['-Os']),
+        ('z', ['-Oz']),
+        ('3', ['-O3']),
       ]:
       print(name, args)
       self.clear()
-      run_process([PYTHON, EMCC, path_from_root('system', 'lib', 'dlmalloc.c')] + args)
+      run_process([PYTHON, EMCC, '-c', path_from_root('system', 'lib', 'dlmalloc.c')] + args)
       sizes[name] = os.path.getsize('dlmalloc.o')
     print(sizes)
-    # -c should not affect code size
-    for name in ['0', '1', '2', '3', 's', 'z']:
-      self.assertEqual(sizes[name], sizes[name + 'c'])
     opt_min = min(sizes['1'], sizes['2'], sizes['3'], sizes['s'], sizes['z'])
     opt_max = max(sizes['1'], sizes['2'], sizes['3'], sizes['s'], sizes['z'])
     # 'opt builds are all fairly close'

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -332,7 +332,7 @@ class Library(object):
     cflags = self.get_cflags()
     for src in self.get_files():
       o = self.in_temp(os.path.basename(src) + '.o')
-      commands.append([shared.PYTHON, self.emcc, src, '-o', o] + cflags)
+      commands.append([shared.PYTHON, self.emcc, '-c', src, '-o', o] + cflags)
       objects.append(o)
     run_commands(commands)
     return objects


### PR DESCRIPTION
This change moves the "linking to object file" logic to separate
phase which runs after compilation, but before the real "linking"
phase.  We can also delay library processing until after this phase
as that is only needed for actual linking.

This change is a step towards more conventional library linking
See #8912.
