### PR TITLE
[system/include/libc/unistd] set posix libc headers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -428,3 +428,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Petr Penzin (petr.penzin@intel.com) (copyright owned by Intel Corporation)
 * Andrei Alexeyev <akari@taisei-project.org>
 * Cesar Guirao Robles <cesar@no2.es>
+* Mehdi Sabwat <mehdisabwat@gmail.com>

--- a/system/include/libc/unistd.h
+++ b/system/include/libc/unistd.h
@@ -221,11 +221,23 @@ int eaccess(const char *, int);
 #define _POSIX_FSYNC            _POSIX_VERSION
 #define _POSIX_NO_TRUNC         1
 #define _POSIX_RAW_SOCKETS      _POSIX_VERSION
+
+#ifndef __EMSCRIPTEN__
 #define _POSIX_REALTIME_SIGNALS _POSIX_VERSION
+#else
+#define _POSIX_REALTIME_SIGNALS -1
+#endif
+
 #define _POSIX_REGEXP           1
 #define _POSIX_SAVED_IDS        1
 #define _POSIX_SHELL            1
+
+#ifndef __EMSCRIPTEN__
 #define _POSIX_SPAWN            _POSIX_VERSION
+#else
+#define _POSIX_SPAWN            -1
+#endif
+
 #define _POSIX_VDISABLE         0
 
 #define _POSIX_THREADS          _POSIX_VERSION

--- a/system/lib/libc/README.md
+++ b/system/lib/libc/README.md
@@ -6,4 +6,5 @@ Some changes have been made to the version that was taken from upstream, includi
  * Backporting an operator-precedence warning fix from 6e76e1540fc58a418494bf5eb832b556f9c5763e in the upstream version.
  * Switch to using the wasi `fd_write` syscall instead of `writev`.
  * Simplify stdout stream handling: do not support seeking, terminal handling, etc., as it just increases code size and Emscripten doesn't have those features anyhow.
+ * Setting `_POSIX_REALTIME_SIGNALS` and `_POSIX_SPAWN` macros to -1, to exclude unsupported functions.
 


### PR DESCRIPTION
This fixes issue #9451.

_POSIX_REALTIME_SIGNALS and _POSIX_SPAWN are set to _POSIX_VERSION.
I suggest to set them to -1 because these functions are not implemented :

```
posix_spawn_file_actions_adddup2
posix_spawn_file_actions_destroy
posix_spawn_file_actions_init
sigtimedwait
```

Thank you for submitting a pull request!

If this is your first PR, make sure to add yourself to AUTHORS.
