### PR TITLE
Reduce stalebot timeout from 2 years to 1 year

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 730
+daysUntilStale: 365
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale
@@ -11,7 +11,7 @@ staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable
 markComment: >
   This issue has been automatically marked as stale because there has been no
-  activity in the past 2 years.  It will be closed automatically if no further
+  activity in the past year.  It will be closed automatically if no further
   activity occurs in the next 7 days.  Feel free to re-open at any time if this
   issue is still relevant.
 # Comment to post when closing a stale issue. Set to `false` to disable


### PR DESCRIPTION
We don't seem to have run into any issue with stalebot so I'm deceasing
the timeout from 2 years to 1 year to reduce the backlog further.
