### PR TITLE
Move shared.Building.emscripten into emcc.py

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -456,6 +456,7 @@ def do_emscripten(infile, memfile, js_libraries):
 
   return outfile
 
+
 #
 # Main run() function
 #

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2174,21 +2174,6 @@ class Building(object):
       assert os.path.exists(output_filename), 'emar could not create output file: ' + output_filename
 
   @staticmethod
-  def emscripten(infile, memfile, js_libraries):
-    if path_from_root() not in sys.path:
-      sys.path += [path_from_root()]
-    import emscripten
-    # Run Emscripten
-    outfile = infile + '.o.js'
-    with ToolchainProfiler.profile_block('emscripten.py'):
-      emscripten.run(infile, outfile, memfile, js_libraries)
-
-    # Detect compilation crashes and errors
-    assert os.path.exists(outfile), 'Emscripten failed to generate .js'
-
-    return outfile
-
-  @staticmethod
   def can_inline():
     return Settings.INLINING_LIMIT == 0
 


### PR DESCRIPTION
This is the only place it was called.  This also avoids the sys.path
hacking and the function-local-import of emscripten.py.
