### PR TITLE
Remove COMPILER_ENGINE config option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,8 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+ - Remove redundnant `COMPILER_ENGINE` and `JS_ENGINE` options.  We only support
+   node as the compiler engine so just use a single `NODE_JS` option for that.
  - Module.abort is no longer exported by default. It can be exported in the normal
    way using `EXTRA_EXPORTED_RUNTIME_METHODS`, and as with other such changes in
    the past, forgetting to export it with show a clear error in `ASSERTIONS` mode.
@@ -27,7 +29,7 @@ v.1.38.44: 09/11/2019
  - Remove Binaryen from the ports system. This means that emscripten will
    no longer automatically build Binaryen from source. Instead, either use
    the emsdk (binaries are provided automatically, just like for LLVM), or
-   build it yourself and point BINARYEN_ROOT in .emscripten to it. See #9409
+   build it yourself and point `BINARYEN_ROOT` in .emscripten to it. See #9409
 
 v.1.38.43: 08/30/2019
 ---------------------
@@ -39,7 +41,7 @@ v.1.38.42: 08/19/2019
  - Add support for [address sanitizer](https://clang.llvm.org/docs/AddressSanitizer.html)
    and standalone [leak sanitizer](https://clang.llvm.org/docs/LeakSanitizer.html)
    with multiple threads. (#9060, #9076)
- - Remove ERROR_ON_MISSING_LIBRARIES setting (it's always on now)
+ - Remove `ERROR_ON_MISSING_LIBRARIES` setting (it's always on now)
  - Remove the ability to use Python operators in flags that support KB/MB/GB/TB
    suffixes, e.g. `TOTAL_MEMORY`. This means that `-s TOTAL_MEMORY=1024*1024`
    will no longer work. This is done because the mechanism may result in

--- a/docs/process.md
+++ b/docs/process.md
@@ -195,6 +195,3 @@ key values in that file include:
  * `BINARYEN_ROOT`: The path to binaryen (the binaries are expected in `/bin` under there; note that
     despite the name this differs from `LLVM_ROOT` which points directly to the binaries).
  * `NODE_JS`: The path to Node.js, which is needed internally.
- * `COMPILER_ENGINE`: The VM used internally for the JS compiler. Normally this should be `NODE_JS`.
- * `JS_ENGINES`: The full list of JS engines (or just `[NODE_JS]`). Used in the test suite.
-

--- a/emscripten.py
+++ b/emscripten.py
@@ -2725,5 +2725,5 @@ def run(infile, outfile, memfile, libraries):
 
   emscripter = emscript_wasm_backend if shared.Settings.WASM_BACKEND else emscript_fastcomp
   return temp_files.run_and_clean(lambda: emscripter(
-      infile, outfile_obj, memfile, libraries, shared.COMPILER_ENGINE, temp_files, shared.DEBUG)
+      infile, outfile_obj, memfile, libraries, shared.NODE_JS, temp_files, shared.DEBUG)
   )

--- a/site/source/docs/tools_reference/emsdk.rst
+++ b/site/source/docs/tools_reference/emsdk.rst
@@ -90,27 +90,17 @@ Below are typical **.emscripten** files created by *emsdk*. Note the variable na
   # .emscripten file from Windows SDK
 
   import os
-  SPIDERMONKEY_ENGINE = ''
-  NODE_JS = 'node'
   LLVM_ROOT='C:/Program Files/Emscripten/clang/e1.21.0_64bit'
   NODE_JS='C:/Program Files/Emscripten/node/0.10.17_64bit/node.exe'
-  PYTHON='C:/Program Files/Emscripten/python/2.7.5.3_64bit/python.exe'
   JAVA='C:/Program Files/Emscripten/java/7.45_64bit/bin/java.exe'
-  V8_ENGINE = ''
-  COMPILER_ENGINE = NODE_JS
-  JS_ENGINES = [NODE_JS]
 
 ::
 
   # .emscripten file from Linux SDK
 
   import os
-  SPIDERMONKEY_ENGINE = ''
   NODE_JS = 'nodejs'
   LLVM_ROOT='/home/ubuntu/emsdk_portable/clang/fastcomp/build_incoming_64/bin'
-  V8_ENGINE = ''
-  COMPILER_ENGINE = NODE_JS
-  JS_ENGINES = [NODE_JS]
 
 .. _emsdk_howto:
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
 from tools.shared import Building, PIPE, run_js, run_process, STDOUT, try_delete, listify
 from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS, MACOS, LLVM_ROOT, EMCONFIG, EM_BUILD_VERBOSE
 from tools.shared import CLANG, CLANG_CC, CLANG_CPP, LLVM_AR
-from tools.shared import COMPILER_ENGINE, NODE_JS, SPIDERMONKEY_ENGINE, JS_ENGINES, V8_ENGINE
+from tools.shared import NODE_JS, SPIDERMONKEY_ENGINE, JS_ENGINES, V8_ENGINE
 from tools.shared import WebAssembly
 from runner import RunnerCore, path_from_root, no_wasm_backend, no_fastcomp, is_slow_test
 from runner import needs_dlfcn, env_modify, no_windows, chdir, with_env_modify, create_test_file, parameterized
@@ -8391,28 +8391,28 @@ int main() {
       else:
         self.assertContained('no native wasm support detected', out)
 
-  def test_check_engine(self):
-    compiler_engine = COMPILER_ENGINE
-    bogus_engine = ['/fake/inline4']
-    print(compiler_engine)
+  def test_node_js(self):
+    print(NODE_JS)
     jsrun.WORKING_ENGINES = {}
     # Test that engine check passes
-    assert jsrun.check_engine(COMPILER_ENGINE)
+    self.assertTrue(jsrun.check_engine(NODE_JS))
     # Run it a second time (cache hit)
-    assert jsrun.check_engine(COMPILER_ENGINE)
+    self.assertTrue(jsrun.check_engine(NODE_JS))
+
     # Test that engine check fails
-    assert not jsrun.check_engine(bogus_engine)
-    assert not jsrun.check_engine(bogus_engine)
+    bogus_engine = ['/fake/inline4']
+    self.assertFalse(jsrun.check_engine(bogus_engine))
+    self.assertFalse(jsrun.check_engine(bogus_engine))
 
     # Test the other possible way (list vs string) to express an engine
-    if type(compiler_engine) is list:
-      engine2 = compiler_engine[0]
+    if type(NODE_JS) is list:
+      engine2 = NODE_JS[0]
     else:
-      engine2 = [compiler_engine]
+      engine2 = [NODE_JS]
     assert jsrun.check_engine(engine2)
 
     # Test that run_js requires the engine
-    jsrun.run_js(path_from_root('src', 'hello_world.js'), compiler_engine)
+    jsrun.run_js(path_from_root('src', 'hello_world.js'), NODE_JS)
     caught_exit = 0
     try:
       jsrun.run_js(path_from_root('src', 'hello_world.js'), bogus_engine)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8391,7 +8391,7 @@ int main() {
       else:
         self.assertContained('no native wasm support detected', out)
 
-  def test_node_js(self):
+  def test_jsrun(self):
     print(NODE_JS)
     jsrun.WORKING_ENGINES = {}
     # Test that engine check passes
@@ -8409,7 +8409,7 @@ int main() {
       engine2 = NODE_JS[0]
     else:
       engine2 = [NODE_JS]
-    assert jsrun.check_engine(engine2)
+    self.assertTrue(jsrun.check_engine(engine2))
 
     # Test that run_js requires the engine
     jsrun.run_js(path_from_root('src', 'hello_world.js'), NODE_JS)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -211,7 +211,7 @@ class sanity(RunnerCore):
       self.assertNotContained('}}}', config_file)
       self.assertContained('{{{', template_file)
       self.assertContained('}}}', template_file)
-      for content in ['EMSCRIPTEN_ROOT', 'LLVM_ROOT', 'NODE_JS', 'COMPILER_ENGINE', 'JS_ENGINES']:
+      for content in ['EMSCRIPTEN_ROOT', 'LLVM_ROOT', 'NODE_JS', 'JS_ENGINES']:
         self.assertContained(content, config_file)
 
       # The guessed config should be ok
@@ -221,7 +221,7 @@ class sanity(RunnerCore):
       # self.assertContained('hello, world!', run_js('a.out.js'), output)
 
       # Second run, with bad EM_CONFIG
-      for settings in ['blah', 'LLVM_ROOT="blarg"; JS_ENGINES=[]; COMPILER_ENGINE=NODE_JS=SPIDERMONKEY_ENGINE=[]']:
+      for settings in ['blah', 'LLVM_ROOT="blarg"; JS_ENGINES=[]; NODE_JS=[]; SPIDERMONKEY_ENGINE=[]']:
         f = open(CONFIG_FILE, 'w')
         f.write(settings)
         f.close()

--- a/tools/settings_template_readonly.py
+++ b/tools/settings_template_readonly.py
@@ -23,36 +23,28 @@ BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN', '')) # if not set, we w
 # EMSCRIPTEN_NATIVE_OPTIMIZER.
 # EMSCRIPTEN_NATIVE_OPTIMIZER='/path/to/custom/optimizer(.exe)'
 
-# See below for notes on which JS engine(s) you need
+# Location of the node binary to use for running the JS parts of the compiler.
+# This engine must exist, or nothing can be compiled.
 NODE_JS = os.path.expanduser(os.getenv('NODE', '{{{ NODE }}}')) # executable
-SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY', 'js'))] # executable
-V8_ENGINE = os.path.expanduser(os.getenv('V8', 'd8')) # executable
 
 JAVA = 'java' # executable
 
 # CLOSURE_COMPILER = '..' # define this to not use the bundled version
 
 ################################################################################
-
-
-# Pick the JS engine to use for running the compiler. This engine must exist, or
-# nothing can be compiled.
 #
-# This should be left on node.js, as that is the VM we test running the
-# compiler in. Other VMs may or may not work.
-
-COMPILER_ENGINE = NODE_JS
-
-
+# Test suite options:
+#
+# Alternative JS engines to use during testing:
+#
+# SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY', 'js'))] # executable
+# V8_ENGINE = os.path.expanduser(os.getenv('V8', 'd8')) # executable
+#
 # All JS engines to use when running the automatic tests. Not all the engines in
 # this list must exist (if they don't, they will be skipped in the test runner).
 #
-# Recommendation: If you already have node installed, use that. If you can, also
-#                 build spidermonkey from source as well to get more test
-#                 coverage.
-
-JS_ENGINES = [NODE_JS] # add this if you have spidermonkey installed too, SPIDERMONKEY_ENGINE]
-
+# JS_ENGINES = [NODE_JS] # add V8_ENGINE or SPIDERMONKEY_ENGINE if you have them installed too.
+#
 # Other options
 #
 # FROZEN_CACHE = True # never clears the cache, and disallows building to the cache

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -286,13 +286,11 @@ EM_POPEN_WORKAROUND = None
 SPIDERMONKEY_ENGINE = None
 V8_ENGINE = None
 LLVM_ROOT = None
-COMPILER_ENGINE = None
 LLVM_ADD_VERSION = None
 CLANG_ADD_VERSION = None
 CLOSURE_COMPILER = None
 EMSCRIPTEN_NATIVE_OPTIMIZER = None
 JAVA = None
-JS_ENGINE = None
 JS_ENGINES = []
 COMPILER_OPTS = []
 FROZEN_CACHE = False
@@ -315,12 +313,10 @@ def parse_config_file():
     'EMSCRIPTEN_NATIVE_OPTIMIZER',
     'V8_ENGINE',
     'LLVM_ROOT',
-    'COMPILER_ENGINE',
     'LLVM_ADD_VERSION',
     'CLANG_ADD_VERSION',
     'CLOSURE_COMPILER',
     'JAVA',
-    'JS_ENGINE',
     'JS_ENGINES',
     'COMPILER_OPTS',
     'FROZEN_CACHE',
@@ -360,7 +356,6 @@ parse_config_file()
 SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, listify(SPIDERMONKEY_ENGINE))
 NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
 V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
-COMPILER_ENGINE = listify(COMPILER_ENGINE)
 JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
 
 if EM_POPEN_WORKAROUND is None:
@@ -520,8 +515,8 @@ def perform_sanify_checks():
   logger.info('(Emscripten: Running sanity checks)')
 
   with ToolchainProfiler.profile_block('sanity compiler_engine'):
-    if not jsrun.check_engine(COMPILER_ENGINE):
-      exit_with_error('The JavaScript shell used for compiling (%s) does not seem to work, check the paths in %s', COMPILER_ENGINE, EM_CONFIG)
+    if not jsrun.check_engine(NODE_JS):
+      exit_with_error('The configured node executable (%s) does not seem to work, check the paths in %s', NODE_JS, EM_CONFIG)
 
   with ToolchainProfiler.profile_block('sanity LLVM'):
     for cmd in [CLANG, LLVM_AR, LLVM_AS, LLVM_NM]:
@@ -890,10 +885,7 @@ apply_configuration()
 
 # EM_CONFIG stuff
 if JS_ENGINES is None:
-  if JS_ENGINE is None:
-    raise 'ERROR: %s does not seem to have JS_ENGINES or JS_ENGINE set up' % EM_CONFIG
-  else:
-    JS_ENGINES = [JS_ENGINE]
+  JS_ENGINES = [NODE_JS]
 
 if CLOSURE_COMPILER is None:
   CLOSURE_COMPILER = path_from_root('third_party', 'closure-compiler', 'compiler.jar')


### PR DESCRIPTION
We only support NODE_JS for running the internal compiler tools and
we have no plans to support any other JS engine for this purpose so
this extra config option was just adding noise.

Also:
- remove legacy JS_ENGINE (singular) setting.
- JS_ENGINES now defaults to [NODE_JS] if its not configured.
- Remove some docs references to V8_ENGINE and SPIDERMONKEY_ENGINE since they not
  required and are purely for tests (i.e. should not be used by end
  users)
