### PR TITLE
Limit object file linking to certain file extensions.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5784,11 +5784,11 @@ return malloc(size);
       self.set_setting('AGGRESSIVE_VARIABLE_ELIMINATION', aggro)
       self.set_setting('TOTAL_MEMORY', total_memory)
       print(aggro)
-      self.do_run('',
+      lua_binary = self.get_library('lua', [os.path.join('src', 'lua'), os.path.join('src', 'liblua.a')], make=['make', 'generic'], configure=None)[0]
+      self.do_run(lua_binary,
                   'hello lua world!\n17\n1\n2\n3\n4\n7',
                   args=['-e', '''print("hello lua world!");print(17);for x = 1,4 do print(x) end;print(10-3)'''],
-                  libraries=self.get_library('lua', [os.path.join('src', 'lua'), os.path.join('src', 'liblua.a')], make=['make', 'generic'], configure=None),
-                  includes=[path_from_root('tests', 'lua')],
+                  no_build=True,
                   output_nicerizer=lambda string, err: (string + err).replace('\n\n', '\n').replace('\n\n', '\n'))
 
   @needs_make('configure script')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -276,9 +276,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     for compiler in [EMCC, EMXX]:
       suffix = '.c' if compiler == EMCC else '.cpp'
 
-      # emcc src.cpp -c    and   emcc src.cpp -o src.[o|bc] ==> should give a .bc file
-      #      regression check: -o js should create "js", with bitcode content
-      for args in [['-c'], ['-o', 'src.o'], ['-o', 'src.bc'], ['-o', 'src.so'], ['-o', 'js'], ['-O1', '-c', '-o', '/dev/null'], ['-O1', '-o', '/dev/null']]:
+      # emcc src.cpp -c and emcc src.cpp -o src.[o|bc] ==> should give an object file
+      for args in [['-c'], ['-o', 'src.o'], ['-o', 'src.bc'], ['-o', 'src.so'], ['-O1', '-c', '-o', '/dev/null'], ['-O1', '-o', '/dev/null']]:
         print('-c stuff', args)
         if '/dev/null' in args and WINDOWS:
           print('skip because windows')
@@ -290,15 +289,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           print('(no output)')
           continue
         syms = Building.llvm_nm(target)
-        assert 'main' in syms.defs
+        self.assertContained('main', syms.defs)
         if self.is_wasm_backend():
           # wasm backend will also have '__original_main' or such
-          assert len(syms.defs) == 2
+          self.assertEqual(len(syms.defs), 2)
         else:
-          assert len(syms.defs) == 1
-        if target == 'js': # make sure emcc can recognize the target as a bitcode file
-          shutil.move(target, target + '.bc')
-          target += '.bc'
+          self.assertEqual(len(syms.defs), 1)
         run_process([PYTHON, compiler, target, '-o', target + '.js'])
         self.assertContained('hello, world!', run_js(target + '.js'))
 


### PR DESCRIPTION
Previously if the output file didn't have an extension we would
outout an object file.  This might have been useful for tools like
autoconf that output binaries with no extension by default but its
somewhat confusing to get an object file without actually asking for
one.  So now we default of js output.

