### PR TITLE
Fix JS memory handling for STANDALONE_WASM

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -412,9 +412,17 @@ if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') 
 #endif
 
 #include "runtime_sab_polyfill.js"
-#if !STANDALONE_WASM // in standalone mode, the wasm creates the memory
+
+// In standalone mode, the wasm creates the memory, and the user can't provide it.
+#if STANDALONE_WASM
+#if ASSERTIONS
+assert(!Module['wasmMemory']);
+#endif // ASSERTIONS
+#else // !STANDALONE_WASM
+// In non-standalone/normal mode, we create the memory here.
 #include "runtime_init_memory.js"
 #endif // !STANDALONE_WASM
+
 #include "runtime_stack_check.js"
 #include "runtime_assertions.js"
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -412,89 +412,9 @@ if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') 
 #endif
 
 #include "runtime_sab_polyfill.js"
-
-#if USE_PTHREADS
-if (ENVIRONMENT_IS_PTHREAD) {
-#if MODULARIZE && WASM
-  // In pthreads mode the wasmMemory and others are received in an onmessage, and that
-  // onmessage then loadScripts us, sending wasmMemory etc. on Module. Here we recapture
-  // it to a local so it can be used normally.
-  wasmMemory = Module['wasmMemory'];
-#endif
-} else {
-#endif // USE_PTHREADS
-#if WASM
-
-#if expectToReceiveOnModule('wasmMemory')
-  if (Module['wasmMemory']) {
-    wasmMemory = Module['wasmMemory'];
-  } else
-#endif
-  {
-    wasmMemory = new WebAssembly.Memory({
-      'initial': INITIAL_TOTAL_MEMORY / WASM_PAGE_SIZE
-#if ALLOW_MEMORY_GROWTH
-#if WASM_MEM_MAX != -1
-      ,
-      'maximum': {{{ WASM_MEM_MAX }}} / WASM_PAGE_SIZE
-#endif
-#else
-      ,
-      'maximum': INITIAL_TOTAL_MEMORY / WASM_PAGE_SIZE
-#endif // ALLOW_MEMORY_GROWTH
-#if USE_PTHREADS
-      ,
-      'shared': true
-#endif
-    });
-#if USE_PTHREADS
-    assert(wasmMemory.buffer instanceof SharedArrayBuffer, 'requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag');
-#endif
-  }
-
-#else // WASM
-
-  if (Module['buffer']) {
-    buffer = Module['buffer'];
-  }
-#ifdef USE_PTHREADS
-  else if (typeof SharedArrayBuffer !== 'undefined') {
-    buffer = new SharedArrayBuffer(INITIAL_TOTAL_MEMORY);
-  }
-#endif
-  else {
-    buffer = new ArrayBuffer(INITIAL_TOTAL_MEMORY);
-  }
-#endif // WASM
-#if USE_PTHREADS
-}
-#endif
-
-#if WASM
-if (wasmMemory) {
-  buffer = wasmMemory.buffer;
-}
-#endif
-
-// If the user provides an incorrect length, just use that length instead rather than providing the user to
-// specifically provide the memory length with Module['TOTAL_MEMORY'].
-INITIAL_TOTAL_MEMORY = buffer.byteLength;
-#ifdef ASSERTIONS && WASM
-assert(INITIAL_TOTAL_MEMORY % WASM_PAGE_SIZE === 0);
-#ifdef ALLOW_MEMORY_GROWTH && WASM_MEM_MAX != -1
-assert({{{ WASM_PAGE_SIZE }}} % WASM_PAGE_SIZE === 0);
-#endif
-#endif
-updateGlobalBufferAndViews(buffer);
-
-#if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) { // Pthreads have already initialized these variables in src/worker.js, where they were passed to the thread worker at startup time
-#endif
-HEAP32[DYNAMICTOP_PTR>>2] = DYNAMIC_BASE;
-#if USE_PTHREADS
-}
-#endif
-
+#if !STANDALONE_WASM // in standalone mode, the wasm creates the memory
+#include "runtime_init_memory.js"
+#endif // !STANDALONE_WASM
 #include "runtime_stack_check.js"
 #include "runtime_assertions.js"
 
@@ -994,6 +914,9 @@ function createWasm() {
     // then exported.
     // TODO: do not create a Memory earlier in JS
     updateGlobalBufferAndViews(exports['memory'].buffer);
+#if ASSERTIONS
+    writeStackCookie();
+#endif
 #endif
 #if USE_PTHREADS
     // Keep a reference to the compiled module so we can post it to the workers.

--- a/src/runtime_assertions.js
+++ b/src/runtime_assertions.js
@@ -1,7 +1,11 @@
 #if ASSERTIONS
 // Endianness check (note: assumes compiler arch was little-endian)
-HEAP16[1] = 0x6373;
-if (HEAPU8[2] !== 0x73 || HEAPU8[3] !== 0x63) throw 'Runtime error: expected the system to be little-endian!';
+(function() {
+  var h16 = new Int16Array(1);
+  var h8 = new Int8Array(h16.buffer);
+  h16[0] = 0x6373;
+  if (h8[0] !== 0x73 || h8[1] !== 0x63) throw 'Runtime error: expected the system to be little-endian!';
+})();
 
 function abortFnPtrError(ptr, sig) {
 #if ASSERTIONS >= 2

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -1,3 +1,5 @@
+// Create the main memory. (Note: this isn't used in STANDALONE_WASM mode since the wasm
+// memory is created in the wasm, not in JS.)
 #if USE_PTHREADS
 if (ENVIRONMENT_IS_PTHREAD) {
 #if MODULARIZE && WASM
@@ -79,4 +81,3 @@ HEAP32[DYNAMICTOP_PTR>>2] = DYNAMIC_BASE;
 #if USE_PTHREADS
 }
 #endif
-

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -1,0 +1,82 @@
+#if USE_PTHREADS
+if (ENVIRONMENT_IS_PTHREAD) {
+#if MODULARIZE && WASM
+  // In pthreads mode the wasmMemory and others are received in an onmessage, and that
+  // onmessage then loadScripts us, sending wasmMemory etc. on Module. Here we recapture
+  // it to a local so it can be used normally.
+  wasmMemory = Module['wasmMemory'];
+#endif
+} else {
+#endif // USE_PTHREADS
+#if WASM
+
+#if expectToReceiveOnModule('wasmMemory')
+  if (Module['wasmMemory']) {
+    wasmMemory = Module['wasmMemory'];
+  } else
+#endif
+  {
+    wasmMemory = new WebAssembly.Memory({
+      'initial': INITIAL_TOTAL_MEMORY / WASM_PAGE_SIZE
+#if ALLOW_MEMORY_GROWTH
+#if WASM_MEM_MAX != -1
+      ,
+      'maximum': {{{ WASM_MEM_MAX }}} / WASM_PAGE_SIZE
+#endif
+#else
+      ,
+      'maximum': INITIAL_TOTAL_MEMORY / WASM_PAGE_SIZE
+#endif // ALLOW_MEMORY_GROWTH
+#if USE_PTHREADS
+      ,
+      'shared': true
+#endif
+    });
+#if USE_PTHREADS
+    assert(wasmMemory.buffer instanceof SharedArrayBuffer, 'requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag');
+#endif
+  }
+
+#else // WASM
+
+  if (Module['buffer']) {
+    buffer = Module['buffer'];
+  }
+#ifdef USE_PTHREADS
+  else if (typeof SharedArrayBuffer !== 'undefined') {
+    buffer = new SharedArrayBuffer(INITIAL_TOTAL_MEMORY);
+  }
+#endif
+  else {
+    buffer = new ArrayBuffer(INITIAL_TOTAL_MEMORY);
+  }
+#endif // WASM
+#if USE_PTHREADS
+}
+#endif
+
+#if WASM
+if (wasmMemory) {
+  buffer = wasmMemory.buffer;
+}
+#endif
+
+// If the user provides an incorrect length, just use that length instead rather than providing the user to
+// specifically provide the memory length with Module['TOTAL_MEMORY'].
+INITIAL_TOTAL_MEMORY = buffer.byteLength;
+#ifdef ASSERTIONS && WASM
+assert(INITIAL_TOTAL_MEMORY % WASM_PAGE_SIZE === 0);
+#ifdef ALLOW_MEMORY_GROWTH && WASM_MEM_MAX != -1
+assert({{{ WASM_PAGE_SIZE }}} % WASM_PAGE_SIZE === 0);
+#endif
+#endif
+updateGlobalBufferAndViews(buffer);
+
+#if USE_PTHREADS
+if (!ENVIRONMENT_IS_PTHREAD) { // Pthreads have already initialized these variables in src/worker.js, where they were passed to the thread worker at startup time
+#endif
+HEAP32[DYNAMICTOP_PTR>>2] = DYNAMIC_BASE;
+#if USE_PTHREADS
+}
+#endif
+

--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -10,6 +10,11 @@ function writeStackCookie() {
   HEAPU32[(STACK_MAX >> 2)-1] = 0x02135467;
   HEAPU32[(STACK_MAX >> 2)-2] = 0x89BACDFE;
 #endif
+#if !USE_ASAN
+  // Also test the global address 0 for integrity.
+  // We don't do this with ASan because ASan does its own checks for this.
+  HEAP32[0] = 0x63736d65; /* 'emsc' */
+#endif
 }
 
 function checkStackCookie() {
@@ -37,15 +42,3 @@ function abortStackOverflow(allocSize) {
 #endif
 
 #endif
-
-#if STACK_OVERFLOW_CHECK && !USE_ASAN
-#if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) {
-#endif
-  HEAP32[0] = 0x63736d65; /* 'emsc' */
-#if USE_PTHREADS
-} else {
-  if (HEAP32[0] !== 0x63736d65) abort('Runtime error: The application has corrupted its heap memory area (address zero)!');
-}
-#endif // USE_PTHREADS
-#endif // STACK_OVERFLOW_CHECK

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8291,6 +8291,7 @@ int main() {
     # STANDALONE_WASM means we never minify imports and exports.
     for opts, potentially_expect_minified_exports_and_imports in (
       ([],                               False),
+      (['-s', 'STANDALONE_WASM'],        False),
       (['-O2'],                          False),
       (['-O3'],                          True),
       (['-O3', '-s', 'STANDALONE_WASM'], False),


### PR DESCRIPTION
Don't create the wasm Memory in JS since wasm will do so in standalone mode. With that done, various things need fixing since they assumed memory was already present, which is the rest of the work in this PR.

Move the memory init code into a new file, `runtime_init_memory.js` (no changes to that code). The file is conditionally included if not standalone.

Fix stack cookie checking for standalone mode:

 * Write the cookie after the wasm memory actually arrives.
 * Do the endianness check in a new buffer (it's just in assertions mode, so perf isn't an issue, and this disentangles it from the main memory, which in standalone mode isn't ready yet).
 * Move the address-0-integrity write into `writeStackCookie`, which matches where it is checked, which is in `checkStackCookie`. That way it is done at the right time and not synchronously during startup (which is invalid in standalone mode).

Add more testing of standalone wasm in `-O0`, now that this stuff works.