### PR TITLE
Update intArrayToString to match docs, and update docs

### DIFF
--- a/site/source/docs/api_reference/preamble.js.rst
+++ b/site/source/docs/api_reference/preamble.js.rst
@@ -234,7 +234,7 @@ Conversion functions — strings, pointers and arrays
 
 .. js:function:: intArrayFromString(stringy, dontAddNull[, length])
 
-  This converts a JavaScript string into a C-line array of numbers, 0-terminated.
+  This converts a JavaScript string into a C-line array of numbers, 0-terminated, encoded as UTF-8.
 
   :param stringy: The string to be converted.
   :type stringy: String
@@ -246,7 +246,7 @@ Conversion functions — strings, pointers and arrays
 
 .. js:function:: intArrayToString(array)
 
-  This creates a JavaScript string from a zero-terminated C-line array of numbers.
+  This creates a JavaScript string from an optionally zero-terminated C-line array of numbers, interpreted as UTF-8.
 
   :param array: The array to convert.
   :returns: A ``String``, containing the content of ``array``.

--- a/src/arrayUtils.js
+++ b/src/arrayUtils.js
@@ -13,16 +13,5 @@ function intArrayFromString(stringy, dontAddNull, length) {
 }
 
 function intArrayToString(array) {
-  var ret = [];
-  for (var i = 0; i < array.length; i++) {
-    var chr = array[i];
-    if (chr > 0xFF) {
-      if (ASSERTIONS) {
-        assert(false, 'Character code ' + chr + ' (' + String.fromCharCode(chr) + ')  at offset ' + i + ' not in 0x00-0xFF.');
-      }
-      chr &= 0xFF;
-    }
-    ret.push(String.fromCharCode(chr));
-  }
-  return ret.join('');
+  return UTF8ArrayToString(array, 0, array.length);
 }


### PR DESCRIPTION
intArrayToString is documented as taking null-terminated input, but previously did not stop at a 0 entry.

Switched it to use UTF8ArrayToString internally using the array length as maximum length. This both fixes the discrepancy with the documentation by allowing 0-terminated input arrays,
and improves general compatibility by allowing input data to contain UTF-8 strings without being corrupted on output to JavaScript.

Updated documentation for both intArrayToString and its almost-inverse, intArrayFromString, to indicate that UTF-8 is used (this was already the case, but not documented, for intArrayFromString).

Fixes #4840

I *think* this is a safe change to make based on the few uses of `intArrayToString` I see, mostly for taking bits and putting them into HTML via JS or doing shell in/output. Please advise if tests need to be added or any other fun stuff!