### PR TITLE
Support the new Asyncify warning notation from Binaryen

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8959,7 +8959,10 @@ T6:(else) !ASSERTIONS""", output)
 ''')
     proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'ASYNCIFY=1', '-s', "ASYNCIFY_WHITELIST=@a.txt"], stdout=PIPE, stderr=PIPE)
     # we should parse the response file properly, and then issue a proper warning for the missing function
-    self.assertContained('Asyncify whitelist contained a non-existing function name: DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)', proc.stderr)
+    # TODO remove the support for multiple binaryen versions' warning output ("function name" vs "pattern" etc.)
+    self.assertContained(('Asyncify whitelist contained a non-matching pattern: DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)',
+                          'Asyncify whitelist contained a non-existing function name: DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)'),
+                          proc.stderr)
 
   # Sockets and networking
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8960,9 +8960,10 @@ T6:(else) !ASSERTIONS""", output)
     proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'ASYNCIFY=1', '-s', "ASYNCIFY_WHITELIST=@a.txt"], stdout=PIPE, stderr=PIPE)
     # we should parse the response file properly, and then issue a proper warning for the missing function
     # TODO remove the support for multiple binaryen versions' warning output ("function name" vs "pattern" etc.)
-    self.assertContained(('Asyncify whitelist contained a non-matching pattern: DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)',
-                          'Asyncify whitelist contained a non-existing function name: DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)'),
-                          proc.stderr)
+    self.assertContained(
+        ('Asyncify whitelist contained a non-matching pattern: DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)',
+         'Asyncify whitelist contained a non-existing function name: DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)'),
+        proc.stderr)
 
   # Sockets and networking
 


### PR DESCRIPTION
Binaryen is currently not rolling due to

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8901492015302662960/+/steps/Emscripten_testsuite__upstream__other_/0/stdout

Part of the fix is https://github.com/WebAssembly/binaryen/pull/2351 which fixes the escaping. The other part is that the other text also changes in this case, from "function" to "pattern". This PR supports both, so CI keeps working before and after the roll.