### PR TITLE
Refine the assertion for Traceback in expect_fail

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -920,8 +920,11 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     """
     proc = run_process(cmd, check=False, stderr=PIPE, **args)
     self.assertNotEqual(proc.returncode, 0)
-    # When we check for failure we user-visible error, not a traceback
-    self.assertNotContained('Traceback', proc.stderr)
+    # When we check for failure we expect a user-visible error, not a traceback.
+    # However, on windows a python traceback can happen randomly sometimes,
+    # due to "Access is denied" https://github.com/emscripten-core/emscripten/issues/718
+    if not WINDOWS or 'Access is denied' not in proc.stderr:
+      self.assertNotContained('Traceback', proc.stderr)
     return proc.stderr
 
   def setup_runtimelink_test(self):


### PR DESCRIPTION
This has been happening more, recently, e.g. https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8901405253192371952/+/steps/Emscripten_testsuite__upstream__other_/0/stdout