### PR TITLE
Pass `-c` when compiling SDL2 object files

### DIFF
--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -46,7 +46,7 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2', 'src', src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
-      command = [shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src), '-O2', '-o', o, '-I' + dest_include_path, '-O2', '-DUSING_GENERATED_CONFIG_H', '-w']
+      command = [shared.PYTHON, shared.EMCC, '-c', os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src), '-O2', '-o', o, '-I' + dest_include_path, '-O2', '-DUSING_GENERATED_CONFIG_H', '-w']
       if settings.USE_PTHREADS:
         command += ['-s', 'USE_PTHREADS']
       commands.append(command)


### PR DESCRIPTION
Without `-c` emscripten will try to run lld on the object files its
given to produce another object file.  We should probably disable that
for the single build case.  This breakage was introduced in #9444 and
we should probably address it, but compiling without `-c` is also
broken so fixing here.

Fixes #9510
