### PR TITLE
Add -D_XOPEN_SOURCE=700 when building musl

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -613,7 +613,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
   # functions to something else based on assumptions that they behave exactly
   # like the standard library. This can cause unexpected bugs when we use our
   # custom standard library. The same for other libc/libm builds.
-  cflags = ['-Os', '-fno-builtin']
+  cflags = ['-Os', '-fno-builtin', '-D_XOPEN_SOURCE=700']
 
   # Hide several musl warnings that produce a lot of spam to unit test build server logs.
   # TODO: When updating musl the next time, feel free to recheck which of their warnings might have been fixed, and which ones of these could be cleaned up.


### PR DESCRIPTION
This is defined in the upstream Makefile and we should mimik that where
possible.

This has some subtle effects on the build, one of which is not defining
_BSD_SOURCE which in turn means `<strings.h>` is *not* included by
`<string.h>` which allows `__tz.c` to build.

See #9506
