### PR TITLE
Build musl with _XOPEN_SOURCE=700

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -540,6 +540,8 @@ class MuslInternalLibrary(Library):
     ['system', 'lib', 'libc', 'musl', 'arch', 'js'],
   ]
 
+  cflags = ['-D_XOPEN_SOURCE=700']
+
 
 class AsanInstrumentedLibrary(Library):
   def __init__(self, **kwargs):


### PR DESCRIPTION
Which is how they build it upstream, and avoids some pitfalls with strings.h and the index() function (see #9506).