### PR TITLE
SIMD splatting and extending load intrinsics

### DIFF
--- a/system/include/wasm_simd128.h
+++ b/system/include/wasm_simd128.h
@@ -50,6 +50,106 @@ static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_load(const void* __mem) {
   return ((const struct __wasm_v128_load_struct*)__mem)->__v;
 }
 
+#ifdef __wasm_unimplemented_simd128__
+
+// v128_t wasm_v8x16_load_splat(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v8x16_load_splat(const void* __mem) {
+  struct __wasm_v8x16_load_splat_struct {
+    char __v;
+  } __attribute__((__packed__, __may_alias__));
+  char v = ((const struct __wasm_v8x16_load_splat_struct*)__mem)->__v;
+  return (v128_t)(__i8x16){v, v, v, v, v, v, v, v, v, v, v, v, v, v, v, v};
+}
+
+// v128_t wasm_v16x8_load_splat(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v16x8_load_splat(const void* __mem) {
+  struct __wasm_v16x8_load_splat_struct {
+    short __v;
+  } __attribute__((__packed__, __may_alias__));
+  short v = ((const struct __wasm_v16x8_load_splat_struct*)__mem)->__v;
+  return (v128_t)(__i16x8){v, v, v, v, v, v, v, v};
+}
+
+// v128_t wasm_v32x4_load_splat(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v32x4_load_splat(const void* __mem) {
+  struct __wasm_v32x4_load_splat_struct {
+    int __v;
+  } __attribute__((__packed__, __may_alias__));
+  int v = ((const struct __wasm_v32x4_load_splat_struct*)__mem)->__v;
+  return (v128_t)(__i32x4){v, v, v, v};
+}
+
+// v128_t wasm_v64x2_load_splat(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v64x2_load_splat(const void* __mem) {
+  struct __wasm_v64x2_load_splat_struct {
+    long long __v;
+  } __attribute__((__packed__, __may_alias__));
+  long long v = ((const struct __wasm_v64x2_load_splat_struct*)__mem)->__v;
+  return (v128_t)(__i64x2){v, v};
+}
+
+// v128_t wasm_i16x8_load_8x8(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_load_8x8(const void* __mem) {
+  typedef signed char __i8x8 __attribute__((__vector_size__(8), __aligned__(8)));
+  struct __wasm_i16x8_load_8x8_struct {
+    __i8x8 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __i8x8 v = ((const struct __wasm_i16x8_load_8x8_struct*)__mem)->__v;
+  return (v128_t)__builtin_convertvector(v, __i16x8);
+}
+
+// v128_t wasm_i16x8_load_8x8(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u16x8_load_8x8(const void* __mem) {
+  typedef unsigned char __u8x8 __attribute__((__vector_size__(8), __aligned__(8)));
+  struct __wasm_u16x8_load_8x8_struct {
+    __u8x8 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __u8x8 v = ((const struct __wasm_u16x8_load_8x8_struct*)__mem)->__v;
+  return (v128_t)__builtin_convertvector(v, __u16x8);
+}
+
+// v128_t wasm_i32x4_load_16x4(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_load_16x4(const void* __mem) {
+  typedef short __i16x4 __attribute__((__vector_size__(8), __aligned__(8)));
+  struct __wasm_i32x4_load_16x4_struct {
+    __i16x4 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __i16x4 v = ((const struct __wasm_i32x4_load_16x4_struct*)__mem)->__v;
+  return (v128_t)__builtin_convertvector(v, __i32x4);
+}
+
+// v128_t wasm_i32x4_load_16x4(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u32x4_load_16x4(const void* __mem) {
+  typedef unsigned short __u16x4 __attribute__((__vector_size__(8), __aligned__(8)));
+  struct __wasm_u32x4_load_16x4_struct {
+    __u16x4 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __u16x4 v = ((const struct __wasm_u32x4_load_16x4_struct*)__mem)->__v;
+  return (v128_t)__builtin_convertvector(v, __u32x4);
+}
+
+// v128_t wasm_i64x2_load_16x4(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i64x2_load_32x2(const void* __mem) {
+  typedef int __i32x2 __attribute__((__vector_size__(8), __aligned__(8)));
+  struct __wasm_i64x2_load_32x2_struct {
+    __i32x2 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __i32x2 v = ((const struct __wasm_i64x2_load_32x2_struct*)__mem)->__v;
+  return (v128_t)__builtin_convertvector(v, __i64x2);
+}
+
+// v128_t wasm_i64x2_load_16x4(void* mem)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_u64x2_load_32x2(const void* __mem) {
+  typedef unsigned int __u32x2 __attribute__((__vector_size__(8), __aligned__(8)));
+  struct __wasm_u64x2_load_32x2_struct {
+    __u32x2 __v;
+  } __attribute__((__packed__, __may_alias__));
+  __u32x2 v = ((const struct __wasm_u64x2_load_32x2_struct*)__mem)->__v;
+  return (v128_t)__builtin_convertvector(v, __u64x2);
+}
+
+#endif // __wasm_unimplemented_simd128__
+
 // wasm_v128_store(void* mem, v128 a)
 static __inline__ void __DEFAULT_FN_ATTRS wasm_v128_store(void* __mem, v128_t __a) {
   // UB-free unaligned access copied from xmmintrin.h

--- a/tests/test_wasm_builtin_simd.c
+++ b/tests/test_wasm_builtin_simd.c
@@ -14,10 +14,48 @@ typedef unsigned long long u64x2 __attribute((vector_size(16)));
 typedef float f32x4 __attribute((vector_size(16)));
 typedef double f64x2 __attribute((vector_size(16)));
 
+typedef char i8x8 __attribute((vector_size(8)));
+typedef unsigned char u8x8 __attribute((vector_size(8)));
+typedef short i16x4 __attribute((vector_size(8)));
+typedef unsigned short u16x4 __attribute((vector_size(8)));
+typedef int i32x2 __attribute((vector_size(8)));
+typedef unsigned int u32x2 __attribute((vector_size(8)));
+
 #define TESTFN EMSCRIPTEN_KEEPALIVE __attribute__((noinline))
 
 i8x16 TESTFN i8x16_load(i8x16 *ptr) {
   return *ptr;
+}
+i8x16 TESTFN v8x16_load_splat(int8_t *ptr) {
+  return (i8x16){*ptr, *ptr, *ptr, *ptr, *ptr, *ptr, *ptr, *ptr,
+                 *ptr, *ptr, *ptr, *ptr, *ptr, *ptr, *ptr, *ptr};
+}
+i16x8 TESTFN v16x8_load_splat(int16_t *ptr) {
+  return (i16x8){*ptr, *ptr, *ptr, *ptr, *ptr, *ptr, *ptr, *ptr};
+}
+i32x4 TESTFN v32x4_load_splat(int32_t *ptr) {
+  return (i32x4){*ptr, *ptr, *ptr, *ptr};
+}
+i64x2 TESTFN v64x2_load_splat(int64_t *ptr) {
+  return (i64x2){*ptr, *ptr};
+}
+i16x8 TESTFN i16x8_load8x8_s(i8x8 *ptr) {
+  return __builtin_convertvector(*ptr, i16x8);
+}
+i16x8 TESTFN i16x8_load8x8_u(i8x8 *ptr) {
+  return (i16x8)__builtin_convertvector(*(u8x8*)ptr, u16x8);
+}
+i32x4 TESTFN i32x4_load16x4_s(i16x4 *ptr) {
+  return __builtin_convertvector(*ptr, i32x4);
+}
+i32x4 TESTFN i32x4_load16x4_u(i16x4 *ptr) {
+  return (i32x4)__builtin_convertvector(*(u16x4*)ptr, u32x4);
+}
+i64x2 TESTFN i64x2_load32x2_s(i32x2 *ptr) {
+  return __builtin_convertvector(*ptr, i64x2);
+}
+i64x2 TESTFN i64x2_load32x2_u(i32x2 *ptr) {
+  return (i64x2) __builtin_convertvector(*(u32x2*)ptr, u64x2);
 }
 void TESTFN i8x16_store(i8x16 *ptr, i8x16 vec) {
   *ptr = vec;
@@ -556,9 +594,9 @@ static int failures = 0;
                               char: "%d",               \
                               unsigned char: "%d",      \
                               short: "%d",              \
-                              int64_t: "%ld",           \
                               int32_t: "%d",            \
                               uint32_t: "%d",           \
+                              int64_t: "%ld",           \
                               float: "%f",              \
                               double: "%f"              \
   )
@@ -632,6 +670,44 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     i8x16_store(&vec, (i8x16){7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7});
     expect_vec(i8x16_load(&vec),
               ((i8x16){7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7}));
+  }
+  {
+    i8x8 vec = {0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0};
+    expect_vec(
+      v8x16_load_splat((int8_t*)&vec),
+      ((i8x16){0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+               0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80})
+    );
+    expect_vec(
+      v16x8_load_splat((int16_t*)&vec),
+      ((i16x8){0x9080, 0x9080, 0x9080, 0x9080, 0x9080, 0x9080, 0x9080, 0x9080})
+    );
+    expect_vec(v32x4_load_splat((int32_t*)&vec), ((i32x4){0xb0a09080, 0xb0a09080, 0xb0a09080, 0xb0a09080}));
+    expect_vec(v64x2_load_splat((int64_t*)&vec), ((i64x2){0xf0e0d0c0b0a09080, 0xf0e0d0c0b0a09080}));
+    expect_vec(
+      i16x8_load8x8_s(&vec),
+      ((i16x8){0xff80, 0xff90, 0xffa0, 0xffb0, 0xffc0, 0xffd0, 0xffe0, 0xfff0})
+    );
+    expect_vec(
+      i16x8_load8x8_u(&vec),
+      ((i16x8){0x0080, 0x0090, 0x00a0, 0x00b0, 0x00c0, 0x00d0, 0x00e0, 0x00f0})
+    );
+    expect_vec(
+      i32x4_load16x4_s((i16x4*)&vec),
+      ((i32x4){0xffff9080, 0xffffb0a0, 0xffffd0c0, 0xfffff0e0})
+    );
+    expect_vec(
+      i32x4_load16x4_u((i16x4*)&vec),
+      ((i32x4){0x00009080, 0x0000b0a0, 0x0000d0c0, 0x0000f0e0})
+    );
+    expect_vec(
+      i64x2_load32x2_s((i32x2*)&vec),
+      ((i64x2){0xffffffffb0a09080, 0xfffffffff0e0d0c0})
+    );
+    expect_vec(
+      i64x2_load32x2_u((i32x2*)&vec),
+      ((i64x2){0x00000000b0a09080, 0x00000000f0e0d0c0})
+    );
   }
   expect_vec(i32x4_const(), ((i32x4){1, 2, 3, 4}));
   expect_vec(

--- a/tests/test_wasm_intrinsics_simd.c
+++ b/tests/test_wasm_intrinsics_simd.c
@@ -9,6 +9,42 @@
 v128_t TESTFN i8x16_load(void *ptr) {
   return wasm_v128_load(ptr);
 }
+
+#ifdef __wasm_unimplemented_simd128__
+
+v128_t TESTFN v8x16_load_splat(void *ptr) {
+  return wasm_v8x16_load_splat(ptr);
+}
+v128_t TESTFN v16x8_load_splat(void *ptr) {
+  return wasm_v16x8_load_splat(ptr);
+}
+v128_t TESTFN v32x4_load_splat(void *ptr) {
+  return wasm_v32x4_load_splat(ptr);
+}
+v128_t TESTFN v64x2_load_splat(void *ptr) {
+  return wasm_v64x2_load_splat(ptr);
+}
+v128_t TESTFN i16x8_load8x8_s(void *ptr) {
+  return wasm_i16x8_load_8x8(ptr);
+}
+v128_t TESTFN i16x8_load8x8_u(void *ptr) {
+  return wasm_u16x8_load_8x8(ptr);
+}
+v128_t TESTFN i32x4_load16x4_s(void *ptr) {
+  return wasm_i32x4_load_16x4(ptr);
+}
+v128_t TESTFN i32x4_load16x4_u(void *ptr) {
+  return wasm_u32x4_load_16x4(ptr);
+}
+v128_t TESTFN i64x2_load32x2_s(void *ptr) {
+  return wasm_i64x2_load_32x2(ptr);
+}
+v128_t TESTFN i64x2_load32x2_u(void *ptr) {
+  return wasm_u64x2_load_32x2(ptr);
+}
+
+#endif // __wasm_unimplemented_simd128__
+
 void TESTFN i8x16_store(void *ptr, v128_t vec) {
   wasm_v128_store(ptr, vec);
 }
@@ -763,6 +799,51 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     expect_vec(i8x16_load(&vec),
                i8x16(7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7, 7));
   }
+
+#ifdef __wasm_unimplemented_simd128__
+
+  {
+    char vec[8] = {0x80, 0x90, 0xa0, 0xb0, 0xc0, 0xd0, 0xe0, 0xf0};
+    void *ptr = &vec;
+    expect_vec(
+      v8x16_load_splat(ptr),
+      i8x16(0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80,
+            0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80, 0x80)
+    );
+    expect_vec(
+      v16x8_load_splat(ptr),
+      i16x8(0x9080, 0x9080, 0x9080, 0x9080, 0x9080, 0x9080, 0x9080, 0x9080)
+    );
+    expect_vec(v32x4_load_splat(ptr), i32x4(0xb0a09080, 0xb0a09080, 0xb0a09080, 0xb0a09080));
+    expect_vec(v64x2_load_splat(ptr), i64x2(0xf0e0d0c0b0a09080, 0xf0e0d0c0b0a09080));
+    expect_vec(
+      i16x8_load8x8_s(ptr),
+      i16x8(0xff80, 0xff90, 0xffa0, 0xffb0, 0xffc0, 0xffd0, 0xffe0, 0xfff0)
+    );
+    expect_vec(
+      i16x8_load8x8_u(ptr),
+      i16x8(0x0080, 0x0090, 0x00a0, 0x00b0, 0x00c0, 0x00d0, 0x00e0, 0x00f0)
+    );
+    expect_vec(
+      i32x4_load16x4_s(ptr),
+      i32x4(0xffff9080, 0xffffb0a0, 0xffffd0c0, 0xfffff0e0)
+    );
+    expect_vec(
+      i32x4_load16x4_u(ptr),
+      i32x4(0x00009080, 0x0000b0a0, 0x0000d0c0, 0x0000f0e0)
+    );
+    expect_vec(
+      i64x2_load32x2_s(ptr),
+      i64x2(0xffffffffb0a09080, 0xfffffffff0e0d0c0)
+    );
+    expect_vec(
+      i64x2_load32x2_u(ptr),
+      i64x2(0x00000000b0a09080, 0x00000000f0e0d0c0)
+    );
+  }
+
+#endif // __wasm_unimplemented_simd128__
+
   expect_vec(i8x16_const(), u8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16));
   expect_vec(i16x8_const(), u16x8(1, 2, 3, 4, 5, 6, 7, 8));
   expect_vec(i32x4_const(), u32x4(1, 2, 3, 4));


### PR DESCRIPTION
Adds intrinsics and end-to-end tests for the new load
instructions. These instructions are gated on
`-munimplemented-simd128` for now. This should work
now, but won't generate the desired instructions until
https://reviews.llvm.org/D68058 lands.

