### PR TITLE
Run standalone wasms in other.test_wasm_target_and_STANDALONE_WASM

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8325,6 +8325,11 @@ int main() {
         # verify the wasm runs with the JS
         if target.endswith('.js'):
           self.assertContained('hello, world!', run_js('out.js'))
+        # verify a standalone wasm
+        if standalone:
+          for engine in shared.WASM_ENGINES:
+            print(engine)
+            self.assertContained('hello, world!', run_js('out.wasm', engine=engine))
 
   def test_wasm_targets_side_module(self):
     # side modules do allow a wasm target


### PR DESCRIPTION
Add testing for `emcc -o X.wasm`, which turns on `STANDALONE_WASM`.

(We do test standalone mode in the core test suite now, but those always emit js+wasm.)