### PR TITLE
Pass Binaryen feature flags to wasm-metadce

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3738,7 +3738,7 @@ window.close = function() {
   # Test thread-specific data (TLS).
   @requires_threads
   def test_pthread_thread_local_storage(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_thread_local_storage.cpp'), expected='0', args=['-s', 'TOTAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'])
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_thread_local_storage.cpp'), expected='0', args=['-s', 'TOTAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8', '-s', 'ASSERTIONS=1'])
 
   # Test the pthread condition variable creation and waiting.
   @requires_threads

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2553,6 +2553,7 @@ class Building(object):
       f.write(txt)
     # run wasm-metadce
     cmd = [os.path.join(Building.get_binaryen_bin(), 'wasm-metadce'), '--graph-file=' + temp, wasm_file, '-o', wasm_file]
+    cmd += Building.get_binaryen_feature_flags()
     if debug_info:
       cmd += ['-g']
     out = run_process(cmd, stdout=PIPE).stdout


### PR DESCRIPTION
This ensures that modules validate and are correctly emitted after
https://github.com/WebAssembly/binaryen/pull/2364.
