### PR TITLE
Fix fastcomp asm.js in VMs without wasm support.

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -42,7 +42,10 @@ if (typeof WebAssembly !== 'object') {
 
 var wasmMemory;
 
-// Potentially used for direct table calls.
+// In fastcomp asm.js, we don't need a wasm Table at all.
+// In the wasm backend, we polyfill the WebAssembly object,
+// so this creates a (non-native-wasm) table for us.
+#if WASM_BACKEND || WASM
 var wasmTable = new WebAssembly.Table({
   'initial': {{{ getQuoted('WASM_TABLE_SIZE') }}},
 #if !ALLOW_TABLE_GROWTH
@@ -54,6 +57,7 @@ var wasmTable = new WebAssembly.Table({
 #endif // WASM_BACKEND
   'element': 'anyfunc'
 });
+#endif // WASM_BACKEND || WASM
 
 #if USE_PTHREADS
 // For sending to workers.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9794,3 +9794,13 @@ Module.arguments has been replaced with plain arguments_
     # don't actually exist in our standard library path.  Make sure we don't
     # error out when linking with these flags.
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lm', '-ldl', '-lrt', '-lpthread'])
+
+  def test_non_wasm_without_wasm_in_vm(self):
+    # Test that our non-wasm output does not depend on wasm support in the vm.
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=0'])
+    with open('a.out.js') as f:
+      js = f.read()
+    with open('a.out.js', 'w') as f:
+      f.write('var WebAssembly = null;\n' + js)
+    for engine in JS_ENGINES:
+      self.assertContained('hello, world!', run_js('a.out.js', engine=engine))


### PR DESCRIPTION
And add testing that our non-wasm output does not depend on wasm.

Fixes #9536
