### PR TITLE
Add a default for JS_ENGINES

### DIFF
--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -417,7 +417,7 @@ def inspect_code(headers, cpp_opts, structs, defines):
     # Run the compiled program.
     show('Calling generated program...')
     try:
-      info = shared.run_js(js_file[1]).splitlines()
+      info = shared.run_js(js_file[1], shared.NODE_JS).splitlines()
     except subprocess.CalledProcessError:
       sys.stderr.write('FAIL: Running the generated program failed!\n')
       sys.exit(1)

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -417,7 +417,7 @@ def inspect_code(headers, cpp_opts, structs, defines):
     # Run the compiled program.
     show('Calling generated program...')
     try:
-      info = shared.run_js(js_file[1], shared.NODE_JS).splitlines()
+      info = shared.run_js(js_file[1]).splitlines()
     except subprocess.CalledProcessError:
       sys.stderr.write('FAIL: Running the generated program failed!\n')
       sys.exit(1)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -891,6 +891,9 @@ def apply_configuration():
 apply_configuration()
 
 # EM_CONFIG stuff
+if not JS_ENGINES:
+  JS_ENGINES = [NODE_JS]
+
 if CLOSURE_COMPILER is None:
   CLOSURE_COMPILER = path_from_root('third_party', 'closure-compiler', 'compiler.jar')
 


### PR DESCRIPTION
Since we are guaranteed that `NODE_JS` is part of the config (since
all users need this) we can set a sensible default for `JS_ENGINES`.

This default was supposed to be part of #9469, but a bug meant the code
was dead and it was removed in #9499.

`JS_ENGINES` is needed for any users that want to run test code.

