### PR TITLE
Support for embedded .emscripten config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Config file
+.emscripten
+.emscripten_sanity
+.emscripten_sanity_wasm
+
 # vim/emacs temporary/backup files
 *~
 *.swp

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -28,7 +28,11 @@ v.1.38.47: 10/02/2019
    should rebuild them. See #9545.
  - Removed build option -s ONLY_MY_CODE as we now have much better solutions
    for that, like building to a wasm object file or using STANDALONE_WASM
-   etc. (see https://github.com/emscripten-core/emscripten/wiki/WebAssembly-Standalone).
+   etc. (see
+   https://github.com/emscripten-core/emscripten/wiki/WebAssembly-Standalone).
+ - Emscripten now supports the config file (.emscripten) being placed in the
+   emscriten directory rather that the current user's home directory.
+   See #9543
 
 v.1.38.46: 09/25/2019
 ---------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,7 +31,7 @@ v.1.38.47: 10/02/2019
    etc. (see
    https://github.com/emscripten-core/emscripten/wiki/WebAssembly-Standalone).
  - Emscripten now supports the config file (.emscripten) being placed in the
-   emscriten directory rather that the current user's home directory.
+   emscripten directory rather that the current user's home directory.
    See #9543
 
 v.1.38.46: 09/25/2019

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -239,8 +239,8 @@ This command will now exit. When you are done editing those paths, re-run it.
 # The search order from the config file is as follows:
 # 1. Specified on the command line (--em-config)
 # 2. Specified via EM_CONFIG environment variable
-# 3. If emscripen-local .emescripten file is found, use that
-# 4. Fall back users home direcotry (~/.emscripten).
+# 3. If emscripten-local .emscripten file is found, use that
+# 4. Fall back users home directory (~/.emscripten).
 
 embedded_config = path_from_root('.emscripten')
 if '--em-config' in sys.argv:


### PR DESCRIPTION
emsdk has always had partial support for this.  With this change all
emscripten users can take advantage of embedded config.  This allows
different emscripten installations to have different configuration files
since they don't need to share a single config file in the user's home
directory.

As a followup and plan to make this location the default when generating
a new sample config file.

See #9543