### PR TITLE
Restore old behavior when compiling to object without -c

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9777,3 +9777,17 @@ Module.arguments has been replaced with plain arguments_
       f.write('var WebAssembly = null;\n' + js)
     for engine in JS_ENGINES:
       self.assertContained('hello, world!', run_js('a.out.js', engine=engine))
+
+  def test_link_to_object(self):
+    # Emscripten supports compiling to an object file when the output has an
+    # object extension.
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'hello1.o'])
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'hello2.o'])
+    content1 = open('hello1.o', 'r').read()
+    content2 = open('hello2.o', 'r').read()
+    self.assertEqual(content1, content2)
+
+    # We allow support linking object files together into other object files
+    run_process([PYTHON, EMCC, 'hello1.o', '-o', 'hello3.o'])
+    content3 = open('hello2.o', 'r').read()
+    self.assertEqual(content1, content3)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9783,11 +9783,11 @@ Module.arguments has been replaced with plain arguments_
     # object extension.
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'hello1.o'])
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'hello2.o'])
-    content1 = open('hello1.o', 'r').read()
-    content2 = open('hello2.o', 'r').read()
+    content1 = open('hello1.o', 'rb').read()
+    content2 = open('hello2.o', 'rb').read()
     self.assertEqual(content1, content2)
 
     # We allow support linking object files together into other object files
     run_process([PYTHON, EMCC, 'hello1.o', '-o', 'hello3.o'])
-    content3 = open('hello2.o', 'r').read()
+    content3 = open('hello2.o', 'rb').read()
     self.assertEqual(content1, content3)


### PR DESCRIPTION
Rather than run the linker, simply copy the object file to the
output.  This restores the previously behaviour.  In the future we
probably want to put this behavior behind a flag as link objects
together should be explicit.

See:  #9511
Fixes: #9571