### PR TITLE
Make malloc(0) consistent between emmalloc and dlmalloc

### DIFF
--- a/system/lib/emmalloc.cpp
+++ b/system/lib/emmalloc.cpp
@@ -802,9 +802,10 @@ static Region* newAllocation(size_t size) {
 // Internal mirror of public API.
 
 static void* emmalloc_malloc(size_t size) {
-  // malloc() spec defines malloc(0) => nullptr.
+  // for consistency with dlmalloc, for malloc(0), allocate a block of memory,
+  // though returning nullptr is permitted by the standard.
   if (size == 0)
-    return nullptr;
+    size = 1;
   // Look in the freelist first.
   Region* region = tryFromFreeList(size);
   if (!region) {

--- a/tests/core/test_emmalloc.cpp
+++ b/tests/core/test_emmalloc.cpp
@@ -43,7 +43,8 @@ void basics() {
   stage("basics");
   stage("allocate 0");
   void* ptr = malloc(0);
-  assert(ptr == 0);
+  assert(ptr != 0);
+  free(ptr);
   stage("allocate 100");
   void* first = malloc(100);
   stage("free 100");
@@ -86,7 +87,9 @@ void blank_slate() {
   for (int i = 0; i < 3; i++) {
     emmalloc_blank_slate_from_orbit();
     void* two = malloc(0);
-    assert(two == ptr);
+    // emmalloc_blank_slate_from_orbit clears out the free list without freeing the blocks on it
+    // Effectively, memory is leaked and we do not expect the pointers to be the same
+    assert(two != ptr);
     free(two);
   }
 }


### PR DESCRIPTION
Fixes #9364.

I think there is some problem with `blank_slate` in the `test_emmalloc.cpp`. Since the test only allocates 0 sized blocks, no memory was ever allocated in the test, and it is just asserting if `nullptr` is returned.

Now that I changed `emmalloc` to allocate for `malloc(0)`, it becomes apparent that `emmalloc_blank_slate_from_orbit` just destroys the free list and leaks the memory inside. I am not sure what the best way to deal with this. Currently, I just toggled the assertion.