### PR TITLE
Em asm main thread wasm backend

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -704,9 +704,7 @@ def update_settings_glue(metadata, DEBUG):
           proxied_function_signatures.add(sig + '_async')
     return list(proxied_function_signatures)
 
-  # Proxying EM_ASM calls is not yet implemented in Wasm backend
-  if not shared.Settings.WASM_BACKEND:
-    shared.Settings.PROXIED_FUNCTION_SIGNATURES = read_proxied_function_signatures(metadata['asmConsts'])
+  shared.Settings.PROXIED_FUNCTION_SIGNATURES = read_proxied_function_signatures(metadata['asmConsts'])
 
   shared.Settings.STATIC_BUMP = align_static_bump(metadata)
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -2374,12 +2374,11 @@ def create_asm_consts_wasm(forwarded_json, metadata):
         # to regular C compiled functions. Negative integers -1, -2, -3, ... denote
         # indices to EM_ASM() blocks, so remap the EM_ASM() indices from 0, 1, 2,
         # ... over to the negative integers starting at -1.
-        preamble += ('\n  if (ENVIRONMENT_IS_PTHREAD) { '
-          + proxy_debug_print(sync_proxy)
-          + 'return _emscripten_proxy_to_main_thread_js(-1 - code, '
-          + str(int(sync_proxy))
-          + ', code, sig_ptr, argbuf); }'
-        )
+        preamble += ('\n  if (ENVIRONMENT_IS_PTHREAD) { ' +
+                     proxy_debug_print(sync_proxy) +
+                     'return _emscripten_proxy_to_main_thread_js(-1 - code, ' +
+                     str(int(sync_proxy)) +
+                     ', code, sig_ptr, argbuf); }')
 
     asm_const_funcs.append(r'''
 function %s(code, sig_ptr, argbuf) {%s

--- a/emscripten.py
+++ b/emscripten.py
@@ -2343,8 +2343,8 @@ def create_asm_consts_wasm(forwarded_json, metadata):
   asm_consts = [0] * len(metadata['asmConsts'])
   all_sigs = []
   for k, v in metadata['asmConsts'].items():
-    const = asstr(v[0])
-    sigs = v[1]
+    const, sigs, call_types = v
+    const = asstr(const)
     const = trim_asm_const_body(const)
     args = []
     max_arity = 16
@@ -2356,13 +2356,33 @@ def create_asm_consts_wasm(forwarded_json, metadata):
       args.append('$' + str(i))
     const = 'function(' + ', '.join(args) + ') {' + const + '}'
     asm_consts[int(k)] = const
-    all_sigs += sigs
+    for sig, call_type in zip(sigs, call_types):
+      all_sigs.append((sig, call_type))
 
   asm_const_funcs = []
-  for sig in set(all_sigs):
-    forwarded_json['Functions']['libraryFunctions']['_emscripten_asm_const_' + sig] = 1
+  for sig, call_type in set(all_sigs):
+    const_name = '_emscripten_asm_const_' + call_type + sig
+    forwarded_json['Functions']['libraryFunctions'][const_name] = 1
+
+    preamble = ''
+    if shared.Settings.USE_PTHREADS:
+      sync_proxy = call_type == 'sync_on_main_thread_'
+      async_proxy = call_type == 'async_on_main_thread_'
+      proxied = sync_proxy or async_proxy
+      if proxied:
+        # In proxied function calls, positive integers 1, 2, 3, ... denote pointers
+        # to regular C compiled functions. Negative integers -1, -2, -3, ... denote
+        # indices to EM_ASM() blocks, so remap the EM_ASM() indices from 0, 1, 2,
+        # ... over to the negative integers starting at -1.
+        preamble += ('\n  if (ENVIRONMENT_IS_PTHREAD) { '
+          + proxy_debug_print(sync_proxy)
+          + 'return _emscripten_proxy_to_main_thread_js(-1 - code, '
+          + str(int(sync_proxy))
+          + ', code, sig_ptr, argbuf); }'
+        )
+
     asm_const_funcs.append(r'''
-function _emscripten_asm_const_%s(code, sig_ptr, argbuf) {
+function %s(code, sig_ptr, argbuf) {%s
   var sig = AsciiToString(sig_ptr);
   var args = [];
   var align_to = function(ptr, align) {
@@ -2382,7 +2402,7 @@ function _emscripten_asm_const_%s(code, sig_ptr, argbuf) {
     }
   }
   return ASM_CONSTS[code].apply(null, args);
-}''' % sig)
+}''' % (const_name, preamble))
   return asm_consts, asm_const_funcs
 
 

--- a/tests/browser/test_em_asm_blocking.cpp
+++ b/tests/browser/test_em_asm_blocking.cpp
@@ -1,0 +1,23 @@
+#include <emscripten.h>
+#include <stdio.h>
+#include <thread>
+
+std::atomic<int> ret;
+
+void foo() {
+  int len = MAIN_THREAD_EM_ASM_INT({
+    var elem = document.getElementById('elem');
+    return elem.innerText.length;
+  });
+  atomic_store(&ret, len);
+}
+
+int main() {
+  std::thread t(foo);
+  t.join();
+  printf("ret: %d\n", atomic_load(&ret));
+#ifdef REPORT_RESULT
+  REPORT_RESULT(atomic_load(&ret));
+#endif
+  return atomic_load(&ret);
+}

--- a/tests/browser/test_em_asm_blocking.html
+++ b/tests/browser/test_em_asm_blocking.html
@@ -1,0 +1,8 @@
+<html>
+  <body>
+    <div id="elem">
+      contents
+    </div>
+    <script type="text/javascript" src="wasm.js"></script>
+  </body>
+</html>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3969,14 +3969,22 @@ window.close = function() {
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_asan_use_after_free.cpp'), expected='1', args=['-fsanitize=address', '-s', 'TOTAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-std=c++11', '--pre-js', path_from_root('tests', 'pthread', 'test_pthread_asan_use_after_free.js')])
 
   # Tests MAIN_THREAD_EM_ASM_INT() function call signatures.
-  @no_wasm_backend('MAIN_THREAD_EM_ASM() not yet implemented in Wasm backend')
   def test_main_thread_em_asm_signatures(self):
     self.btest(path_from_root('tests', 'core', 'test_em_asm_signatures.cpp'), expected='121', args=[])
 
-  @no_wasm_backend('MAIN_THREAD_EM_ASM() not yet implemented in Wasm backend')
   @requires_threads
   def test_main_thread_em_asm_signatures_pthreads(self):
     self.btest(path_from_root('tests', 'core', 'test_em_asm_signatures.cpp'), expected='121', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'ASSERTIONS=1'])
+
+  @requires_threads
+  def test_main_thread_em_asm_blocking(self):
+    create_test_file('page.html',
+      open(path_from_root('tests', 'browser', 'test_em_asm_blocking.html')).read())
+    create_test_file('wasm.cpp', self.with_report_result(
+      open(path_from_root('tests', 'browser', 'test_em_asm_blocking.cpp')).read()))
+
+    self.compile_btest(['wasm.cpp', '-O2', '-o', 'wasm.js', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+    self.run_browser('page.html', '', '/report_result?8')
 
   # test atomicrmw i64
   @no_wasm_backend('uses an asm.js .ll file')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3979,9 +3979,10 @@ window.close = function() {
   @requires_threads
   def test_main_thread_em_asm_blocking(self):
     create_test_file('page.html',
-      open(path_from_root('tests', 'browser', 'test_em_asm_blocking.html')).read())
-    create_test_file('wasm.cpp', self.with_report_result(
-      open(path_from_root('tests', 'browser', 'test_em_asm_blocking.cpp')).read()))
+                     open(path_from_root('tests', 'browser', 'test_em_asm_blocking.html')).read())
+    create_test_file('wasm.cpp',
+                     self.with_report_result(
+                       open(path_from_root('tests', 'browser', 'test_em_asm_blocking.cpp')).read()))
 
     self.compile_btest(['wasm.cpp', '-O2', '-o', 'wasm.js', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
     self.run_browser('page.html', '', '/report_result?8')


### PR DESCRIPTION
Supports EM_ASM proxying for wasm backend. Fixes https://github.com/emscripten-core/emscripten/issues/9410 , depends on https://github.com/WebAssembly/binaryen/pull/2367

Adds a test that fails when the proxying functionality is needed (e.g. accessing DOM); existing tests didn't cover that and we passed them without actually implementing proxying.