### PR TITLE
Reverse logic so you can disable the fetch worker on fastcomp

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1271,7 +1271,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # we can still do basic synchronous fetches in the same places: if we can
     # block on another thread then we aren't the main thread, and if we aren't
     # the main thread then synchronous xhrs are legitimate.
-    if shared.Settings.FETCH and shared.Settings.WASM_BACKEND:
+    if (shared.Settings.FETCH and shared.Settings.WASM_BACKEND) or not shared.Settings.USE_PTHREADS:
       shared.Settings.USE_FETCH_WORKER = 0
 
     if shared.Settings.DEMANGLE_SUPPORT:

--- a/emcc.py
+++ b/emcc.py
@@ -1265,16 +1265,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.USE_PTHREADS:
         shared.Settings.FETCH_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.fetch.js'
 
-    if shared.Settings.FETCH:
-      # In asm.js+pthreads we can use a fetch worker, which is made from the main
-      # asm.js code. That lets us do sync operations by blocking on the worker etc.
-      # In the wasm backend we don't have a fetch worker implemented yet, however,
-      # we can still do basic synchronous fetches in the same places: if we can
-      # block on another thread then we aren't the main thread, and if we aren't
-      # the main thread then synchronous xhrs are legitimate.
-      if shared.Settings.USE_PTHREADS and shared.Settings.WASM_BACKEND and shared.Settings.USE_FETCH_WORKER:
-        logger.warning('USE_FETCH_WORKER is currently unsupported under WASM backend')
-        shared.Settings.USE_FETCH_WORKER = 0
+    # In asm.js+pthreads we can use a fetch worker, which is made from the main
+    # asm.js code. That lets us do sync operations by blocking on the worker etc.
+    # In the wasm backend we don't have a fetch worker implemented yet, however,
+    # we can still do basic synchronous fetches in the same places: if we can
+    # block on another thread then we aren't the main thread, and if we aren't
+    # the main thread then synchronous xhrs are legitimate.
+    if shared.Settings.FETCH and shared.Settings.WASM_BACKEND:
+      shared.Settings.USE_FETCH_WORKER = 0
 
     if shared.Settings.DEMANGLE_SUPPORT:
       shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']

--- a/emcc.py
+++ b/emcc.py
@@ -1265,13 +1265,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.USE_PTHREADS:
         shared.Settings.FETCH_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.fetch.js'
 
+    if not shared.Settings.USE_PTHREADS or not shared.Settings.FETCH:
+      shared.Settings.USE_FETCH_WORKER = 0
+
     # In asm.js+pthreads we can use a fetch worker, which is made from the main
     # asm.js code. That lets us do sync operations by blocking on the worker etc.
     # In the wasm backend we don't have a fetch worker implemented yet, however,
     # we can still do basic synchronous fetches in the same places: if we can
     # block on another thread then we aren't the main thread, and if we aren't
     # the main thread then synchronous xhrs are legitimate.
-    if (shared.Settings.FETCH and shared.Settings.WASM_BACKEND) or not shared.Settings.USE_PTHREADS:
+    if shared.Settings.FETCH and shared.Settings.WASM_BACKEND:
       shared.Settings.USE_FETCH_WORKER = 0
 
     if shared.Settings.DEMANGLE_SUPPORT:

--- a/emcc.py
+++ b/emcc.py
@@ -1272,8 +1272,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # we can still do basic synchronous fetches in the same places: if we can
       # block on another thread then we aren't the main thread, and if we aren't
       # the main thread then synchronous xhrs are legitimate.
-      if shared.Settings.USE_PTHREADS and not shared.Settings.WASM_BACKEND:
-        shared.Settings.USE_FETCH_WORKER = 1
+      if shared.Settings.USE_PTHREADS and shared.Settings.WASM_BACKEND and shared.Settings.USE_FETCH_WORKER:
+        logger.warning('USE_FETCH_WORKER is currently unsupported under WASM backend')
+        shared.Settings.USE_FETCH_WORKER = 0
 
     if shared.Settings.DEMANGLE_SUPPORT:
       shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']

--- a/src/settings.js
+++ b/src/settings.js
@@ -1401,7 +1401,8 @@ var FETCH = 0;
 // only relevant for fastcomp, where we support asm.js. As a result, some
 // synchronous fetch operations that depend on the fetch worker may not work
 // with the wasm backend, like waiting or IndexedDB.
-var USE_FETCH_WORKER = 0;
+// Currently will always be set to 0 on WASM backend.
+var USE_FETCH_WORKER = 1;
 
 // Internal: name of the file containing the Fetch *.fetch.js, if relevant
 // Do not set yourself.


### PR DESCRIPTION
I misread the logic in #9490, and thought I could disable the fetch worker on fastcomp. This PR adds the functionality, and defaults the fetch worker to disabled on both backends.

The the fetch worker does me no favours, and there's no point starting up a worker I'm not going to use.