### PR TITLE
Improve test_wrap_malloc

### DIFF
--- a/tests/wrap_malloc.cpp
+++ b/tests/wrap_malloc.cpp
@@ -3,6 +3,7 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -32,12 +33,16 @@ void __attribute__((noinline)) free(void *ptr)
 
 }
 
+volatile void *out;
+
 int main()
 {
 	for(int i = 0; i < 20; ++i)
 	{
 		void *ptr = malloc(1024 * 1024);
+		out = ptr; // make it look used
 		free(ptr);
 	}
+	assert(totalAllocated == 20);
 	printf("OK.\n");
 }


### PR DESCRIPTION
The llvm optimizer was removing malloc calls, so we were not actually testing wrapping of malloc in `-O1`+ (and the assertion added here failed).

Another option would be to use `-fno-builtin`. I think that would be less good since it's less similar to what user code would do, but I'm not sure?
