### PR TITLE
Don't dump full debug info section when creating source maps

### DIFF
--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -178,7 +178,7 @@ def read_dwarf_entries(wasm, options):
     if not os.path.exists(options.dwarfdump):
       logger.error('llvm-dwarfdump not found: ' + options.dwarfdump)
       sys.exit(1)
-    process = Popen([options.dwarfdump, "-debug-info", "-debug-line", wasm], stdout=PIPE)
+    process = Popen([options.dwarfdump, "-debug-line", wasm], stdout=PIPE)
     output, err = process.communicate()
     exit_code = process.wait()
     if exit_code != 0:

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -178,7 +178,7 @@ def read_dwarf_entries(wasm, options):
     if not os.path.exists(options.dwarfdump):
       logger.error('llvm-dwarfdump not found: ' + options.dwarfdump)
       sys.exit(1)
-    process = Popen([options.dwarfdump, "-debug-line", wasm], stdout=PIPE)
+    process = Popen([options.dwarfdump, '-debug-info', '-debug-line', '--recurse-depth=0', wasm], stdout=PIPE)
     output, err = process.communicate()
     exit_code = process.wait()
     if exit_code != 0:


### PR DESCRIPTION
wasm-sourcemap.py dumps the entire `.debug_info` section when creating source maps (which really only contains the info from the `.debug_line` section). It does this because it wants to find the compilation directory (`DW_AT_comp_dir`) associated with each compile unit, and remove it from the path of each file in the debug line section. However dumping the entire debug info section is very slow for large wasm files, and is unnecessary. Instead, only dump the top-level entities (the `DW_TAG_compile_unit` and don't recurse into their children).

This goes a long way toward fixing #8948.