### PR TITLE
Temporarily change throw() to noexcept for wasm EH

### DIFF
--- a/system/lib/libcxxabi/include/cxxabi.h
+++ b/system/lib/libcxxabi/include/cxxabi.h
@@ -33,6 +33,11 @@ class type_info; // forward declaration
 #endif
 }
 
+#ifdef __USING_WASM_EXCEPTIONS__
+#define NOTHROW noexcept
+#else
+#define NOTHROW throw()
+#endif
 
 // runtime routines use C calling conventions, but are in __cxxabiv1 namespace
 namespace __cxxabiv1 {
@@ -40,9 +45,9 @@ extern "C"  {
 
 // 2.4.2 Allocating the Exception Object
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_allocate_exception(size_t thrown_size) throw();
+__cxa_allocate_exception(size_t thrown_size) NOTHROW;
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_free_exception(void *thrown_exception) throw();
+__cxa_free_exception(void *thrown_exception) NOTHROW;
 
 // 2.4.3 Throwing the Exception Object
 extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void
@@ -51,9 +56,9 @@ __cxa_throw(void *thrown_exception, std::type_info *tinfo,
 
 // 2.5.3 Exception Handlers
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_get_exception_ptr(void *exceptionObject) throw();
+__cxa_get_exception_ptr(void *exceptionObject) NOTHROW;
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_begin_catch(void *exceptionObject) throw();
+__cxa_begin_catch(void *exceptionObject) NOTHROW;
 extern _LIBCXXABI_FUNC_VIS void __cxa_end_catch();
 #if defined(_LIBCXXABI_ARM_EHABI)
 extern _LIBCXXABI_FUNC_VIS bool
@@ -148,17 +153,17 @@ extern _LIBCXXABI_FUNC_VIS char *__cxa_demangle(const char *mangled_name,
 
 // Apple additions to support C++ 0x exception_ptr class
 // These are primitives to wrap a smart pointer around an exception object
-extern _LIBCXXABI_FUNC_VIS void *__cxa_current_primary_exception() throw();
+extern _LIBCXXABI_FUNC_VIS void *__cxa_current_primary_exception() NOTHROW;
 extern _LIBCXXABI_FUNC_VIS void
 __cxa_rethrow_primary_exception(void *primary_exception);
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_increment_exception_refcount(void *primary_exception) throw();
+__cxa_increment_exception_refcount(void *primary_exception) NOTHROW;
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_decrement_exception_refcount(void *primary_exception) throw();
+__cxa_decrement_exception_refcount(void *primary_exception) NOTHROW;
 
 // Apple extension to support std::uncaught_exception()
-extern _LIBCXXABI_FUNC_VIS bool __cxa_uncaught_exception() throw();
-extern _LIBCXXABI_FUNC_VIS unsigned int __cxa_uncaught_exceptions() throw();
+extern _LIBCXXABI_FUNC_VIS bool __cxa_uncaught_exception() NOTHROW;
+extern _LIBCXXABI_FUNC_VIS unsigned int __cxa_uncaught_exceptions() NOTHROW;
 
 #if defined(__linux__) || defined(__Fuchsia__)
 // Linux and Fuchsia TLS support. Not yet an official part of the Itanium ABI.

--- a/system/lib/libcxxabi/include/cxxabi.h
+++ b/system/lib/libcxxabi/include/cxxabi.h
@@ -33,6 +33,9 @@ class type_info; // forward declaration
 #endif
 }
 
+// XXX EMSCRIPTEN Wasm exception handling has not yet implemented support for
+// exception specification. This temporarily changes 'throw()` with 'noexcept'
+// to make wasm EH working in the interim.
 #ifdef __USING_WASM_EXCEPTIONS__
 #define NOTHROW noexcept
 #else

--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -182,7 +182,7 @@ extern "C" {
 //  object. Zero-fill the object. If memory can't be allocated, call
 //  std::terminate. Return a pointer to the memory to be used for the
 //  user's exception object.
-void *__cxa_allocate_exception(size_t thrown_size) throw() {
+void *__cxa_allocate_exception(size_t thrown_size) NOTHROW {
     size_t actual_size = cxa_exception_size_from_exception_thrown_size(thrown_size);
 
     // Allocate extra space before the __cxa_exception header to ensure the
@@ -200,7 +200,7 @@ void *__cxa_allocate_exception(size_t thrown_size) throw() {
 
 
 //  Free a __cxa_exception object allocated with __cxa_allocate_exception.
-void __cxa_free_exception(void *thrown_object) throw() {
+void __cxa_free_exception(void *thrown_object) NOTHROW {
     // Compute the size of the padding before the header.
     size_t header_offset = get_cxa_exception_offset();
     char *raw_buffer =
@@ -294,7 +294,7 @@ The adjusted pointer is computed by the personality routine during phase 1
 
   Requires:  exception is native
 */
-void *__cxa_get_exception_ptr(void *unwind_exception) throw() {
+void *__cxa_get_exception_ptr(void *unwind_exception) NOTHROW {
 #if defined(_LIBCXXABI_ARM_EHABI)
     return reinterpret_cast<void*>(
         static_cast<_Unwind_Control_Block*>(unwind_exception)->barrier_cache.bitpattern[0]);
@@ -420,7 +420,7 @@ to terminate or unexpected during unwinding.
   _Unwind_Exception and return a pointer to that.
 */
 void*
-__cxa_begin_catch(void* unwind_arg) throw()
+__cxa_begin_catch(void* unwind_arg) NOTHROW
 {
     _Unwind_Exception* unwind_exception = static_cast<_Unwind_Exception*>(unwind_arg);
     bool native_exception = __isOurExceptionClass(unwind_exception);
@@ -628,7 +628,7 @@ void __cxa_rethrow() {
     Requires:  If thrown_object is not NULL, it is a native exception.
 */
 void
-__cxa_increment_exception_refcount(void *thrown_object) throw() {
+__cxa_increment_exception_refcount(void *thrown_object) NOTHROW {
     if (thrown_object != NULL )
     {
         __cxa_exception* exception_header = cxa_exception_from_thrown_object(thrown_object);
@@ -645,7 +645,7 @@ __cxa_increment_exception_refcount(void *thrown_object) throw() {
     Requires:  If thrown_object is not NULL, it is a native exception.
 */
 _LIBCXXABI_NO_CFI
-void __cxa_decrement_exception_refcount(void *thrown_object) throw() {
+void __cxa_decrement_exception_refcount(void *thrown_object) NOTHROW {
     if (thrown_object != NULL )
     {
         __cxa_exception* exception_header = cxa_exception_from_thrown_object(thrown_object);
@@ -668,7 +668,7 @@ void __cxa_decrement_exception_refcount(void *thrown_object) throw() {
     been no exceptions thrown, ever, on this thread, we can return NULL without 
     the need to allocate the exception-handling globals.
 */
-void *__cxa_current_primary_exception() throw() {
+void *__cxa_current_primary_exception() NOTHROW {
 //  get the current exception
     __cxa_eh_globals* globals = __cxa_get_globals_fast();
     if (NULL == globals)
@@ -740,10 +740,10 @@ __cxa_rethrow_primary_exception(void* thrown_object)
 }
 
 bool
-__cxa_uncaught_exception() throw() { return __cxa_uncaught_exceptions() != 0; }
+__cxa_uncaught_exception() NOTHROW { return __cxa_uncaught_exceptions() != 0; }
 
 unsigned int
-__cxa_uncaught_exceptions() throw()
+__cxa_uncaught_exceptions() NOTHROW
 {
     // This does not report foreign exceptions in flight
     __cxa_eh_globals* globals = __cxa_get_globals_fast();


### PR DESCRIPTION
Clang frontend for Wasm EH does not yet support exception specification,
such as `throw()` or `throw(type)`. It supports `noexcept` fine.
Currently all uses of exception specification in libcxxabi are
`throw()`, so before going all the way down to support exception
specification in clang, which will take a while, this converts them to
`noexcept` for wasm EH. `throw()` and `noexcept` are not exactly
identical in their semantics: `throw()` calls `std::unexpected()` when
one of its instructions throws and `noexcept` calls `std::terminate()`
in the same case. But I don't think it will cause visible difference
from the user side.

This does not have a test case because this should be tested with wasm
EH support, which will be uploaded later. The reason I made this as a
separate PR is, unlike other changes for wasm EH, this is meant to be
temporary, and making this a separate PR makes it easy to be reverted.