### PR TITLE
Fix large memcpys in standalone mode. Fixes #9589

### DIFF
--- a/system/lib/standalone_wasm.c
+++ b/system/lib/standalone_wasm.c
@@ -54,7 +54,7 @@ void *emscripten_memcpy_big(void *restrict dest, const void *restrict src, size_
   // can just split into smaller calls.
   // TODO optimize, maybe build our memcpy with a wasi variant, maybe have
   //      a SIMD variant, etc.
-  const int CHUNK = 8192;
+  const int CHUNK = 4096;
   unsigned char* d = (unsigned char*)dest;
   unsigned char* s = (unsigned char*)src;
   while (n > 0) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2334,6 +2334,7 @@ The current type of b is: 9
   def test_memcpy3(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_memcpy3', assert_returncode=None)
 
+  @also_with_standalone_wasm
   def test_memcpy_alignment(self):
     self.do_run(open(path_from_root('tests', 'test_memcpy_alignment.cpp')).read(), 'OK.')
 


### PR DESCRIPTION
As the comment above this code says, we are called with n >= 8192, and to avoid infinite recursion must not call with the same amount, it must be strictly less.