### PR TITLE
Support JS initial values for the C environment

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -721,6 +721,11 @@ LibraryManager.library = {
 #endif
   },
 
+  // This object can be modified by the user during startup, which affects
+  // the initial values of the environment accessible by getenv. (This works
+  // in both fastcomp and upstream.
+  $ENV: {},
+
   // This implementation of environ/getenv/etc. is used for fastcomp, due
   // to limitations in the system libraries (we can't easily add a global
   // ctor to create the environment without it always being linked in with
@@ -737,7 +742,8 @@ LibraryManager.library = {
     if (!___buildEnvironment.called) {
       ___buildEnvironment.called = true;
       // Set default values. Use string keys for Closure Compiler compatibility.
-      ENV['USER'] = ENV['LOGNAME'] = 'web_user';
+      ENV['USER'] = 'web_user';
+      ENV['LOGNAME'] = 'web_user';
       ENV['PATH'] = '/';
       ENV['PWD'] = '/';
       ENV['HOME'] = '/home/web_user';
@@ -780,7 +786,6 @@ LibraryManager.library = {
     }
     {{{ makeSetValue('envPtr', 'strings.length * ptrSize', '0', 'i8*') }}};
   },
-  $ENV: {},
   getenv__deps: ['$ENV'],
   getenv__proxy: 'sync',
   getenv__sig: 'ii',

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -11,19 +11,31 @@ var WasiLibrary = {
     return _exit(code);
   },
 
+  // This object can be modified by the user during startup, which affects
+  // the initial values of the environment accessible by getenv.
+  $ENV: {},
+
+  emscripten_get_environ__deps: ['$ENV'],
   emscripten_get_environ: function() {
     if (!_emscripten_get_environ.strings) {
-      var ENV = {};
-      ENV['USER'] = ENV['LOGNAME'] = 'web_user';
-      ENV['PATH'] = '/';
-      ENV['PWD'] = '/';
-      ENV['HOME'] = '/home/web_user';
-      // Browser language detection #8751
-      ENV['LANG'] = ((typeof navigator === 'object' &&navigator.languages && navigator.languages[0]) || 'C').replace('-', '_') + '.UTF-8';
-      ENV['_'] = thisProgram;
+      // Default values.
+      var env = {
+        'USER': 'web_user',
+        'LOGNAME': 'web_user',
+        'PATH': '/',
+        'PWD': '/',
+        'HOME': '/home/web_user',
+        // Browser language detection #8751
+        'LANG': ((typeof navigator === 'object' && navigator.languages && navigator.languages[0]) || 'C').replace('-', '_') + '.UTF-8',
+        '_': thisProgram
+      };
+      // Apply the user-provided values, if any.
+      for (var x in ENV) {
+        env[x] = ENV[x];
+      }
       var strings = [];
-      for (var key in ENV) {
-        strings.push(key + '=' + ENV[key]);
+      for (var x in env) {
+        strings.push(x + '=' + x[key]);
       }
       _emscripten_get_environ.strings = strings;
     }

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -35,7 +35,7 @@ var WasiLibrary = {
       }
       var strings = [];
       for (var x in env) {
-        strings.push(x + '=' + x[key]);
+        strings.push(x + '=' + env[x]);
       }
       _emscripten_get_environ.strings = strings;
     }

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -11,10 +11,6 @@ var WasiLibrary = {
     return _exit(code);
   },
 
-  // This object can be modified by the user during startup, which affects
-  // the initial values of the environment accessible by getenv.
-  $ENV: {},
-
   emscripten_get_environ__deps: ['$ENV'],
   emscripten_get_environ: function() {
     if (!_emscripten_get_environ.strings) {

--- a/tests/env/output-mini.txt
+++ b/tests/env/output-mini.txt
@@ -1,4 +1,5 @@
 USER=web_user
+LOGNAME=web_user
 PATH=/
 PWD=/
 HOME=/home/web_user

--- a/tests/env/output.txt
+++ b/tests/env/output.txt
@@ -1,6 +1,6 @@
 List:
-LOGNAME=web_user
 USER=web_user
+LOGNAME=web_user
 PATH=/
 PWD=/
 HOME=/home/web_user

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7368,7 +7368,7 @@ mergeInto(LibraryManager.library, {
         printf("|%s|\n", getenv("hello"));
       }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '--pre-js', 'pre.js']);
+    run_process([PYTHON, EMCC, 'src.cpp', '--pre-js', 'pre.js'])
     self.assertContained('|world|', run_js('a.out.js'))
 
   def test_warn_no_filesystem(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7321,7 +7321,7 @@ mergeInto(LibraryManager.library, {
         self.assertContained('ctorEval.js', err) # with a stack trace
       self.assertContained('ctor_evaller: not successful', err) # with logging
 
-  def test_override_environment(self):
+  def test_override_js_execution_environment(self):
     create_test_file('main.cpp', r'''
       #include <emscripten.h>
       int main() {
@@ -7353,6 +7353,23 @@ mergeInto(LibraryManager.library, {
         create_test_file('test.js', curr + src)
         seen = run_js('test.js', engine=engine, stderr=PIPE, full_output=True, assert_returncode=None)
         self.assertContained('Module.ENVIRONMENT has been deprecated. To force the environment, use the ENVIRONMENT compile-time option (for example, -s ENVIRONMENT=web or -s ENVIRONMENT=node', seen)
+
+  def test_override_c_environ(self):
+    create_test_file('pre.js', r'''
+      var Module = {
+        preRun: [function() { ENV.hello = 'world' }]
+      };
+    ''')
+    create_test_file('src.cpp', r'''
+      #include <stdlib.h>
+      #include <stdio.h>
+      extern char **environ;
+      int main() {
+        printf("|%s|\n", getenv("hello"));
+      }
+    ''')
+    run_process([PYTHON, EMCC, 'src.cpp', '--pre-js', 'pre.js']);
+    self.assertContained('|world|', run_js('a.out.js'))
 
   def test_warn_no_filesystem(self):
     WARNING = 'Filesystem support (FS) was not included. The problem is that you are using files from JS, but files were not used from C/C++, so filesystem support was not auto-included. You can force-include filesystem support with  -s FORCE_FILESYSTEM=1'


### PR DESCRIPTION
Followup to #9525, in which we stopped noticing if users changed ENV during startup. This re-allows that and adds a test.
