### PR TITLE
Add `-r` command line flag for linking to object file.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -911,6 +911,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     has_dash_c = '-c' in newargs
     has_dash_S = '-S' in newargs
+    link_to_object = False
     executable_endings = JS_CONTAINING_ENDINGS + ('.wasm',)
     compile_only = has_dash_c or has_dash_S
 
@@ -990,8 +991,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             has_source_inputs = True
           else:
             exit_with_error(arg + ": Input file has an unknown suffix, don't know what to do with it!")
-      elif arg.startswith('-L'):
-        add_link_flag(i, arg)
+      elif arg.startswith('-r'):
+        link_to_object = True
         newargs[i] = ''
       elif arg.startswith('-l'):
         add_link_flag(i, arg)
@@ -1191,7 +1192,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       newargs += ['-DEMSCRIPTEN']
 
     newargs = shared.COMPILER_OPTS + shared.get_cflags(newargs) + newargs
-    link_to_object = final_suffix not in executable_endings
+    if not link_to_object and not compile_only and final_suffix not in executable_endings:
+      # TODO(sbc): Remove this emscripten-specific special case.
+      logger.warning('Assuming object file output in the absence of `-c`, based on output filename. Please add with `-c` or `-r` to avoid this warning')
+      link_to_object = True
 
     using_lld = shared.Settings.WASM_BACKEND and not (link_to_object and not shared.Settings.WASM_OBJECT_FILES)
 

--- a/emcc.py
+++ b/emcc.py
@@ -994,6 +994,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       elif arg.startswith('-r'):
         link_to_object = True
         newargs[i] = ''
+      elif arg.startswith('-L'):
+        add_link_flag(i, arg)
+        newargs[i] = ''
       elif arg.startswith('-l'):
         add_link_flag(i, arg)
         newargs[i] = ''

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -86,9 +86,17 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'freetype', src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.PYTHON, shared.EMCC, os.path.join(dest_path, src), '-DFT2_BUILD_LIBRARY', '-O2', '-o', o, '-I' + dest_path + '/include',
-                       '-I' + dest_path + '/truetype', '-I' + dest_path + '/sfnt', '-I' + dest_path + '/autofit', '-I' + dest_path + '/smooth',
-                       '-I' + dest_path + '/raster', '-I' + dest_path + '/psaux', '-I' + dest_path + '/psnames', '-I' + dest_path + '/truetype',
+      commands.append([shared.PYTHON, shared.EMCC, '-c', os.path.join(dest_path, src), '-o', o,
+                       '-DFT2_BUILD_LIBRARY', '-O2',
+                       '-I' + dest_path + '/include',
+                       '-I' + dest_path + '/truetype',
+                       '-I' + dest_path + '/sfnt',
+                       '-I' + dest_path + '/autofit',
+                       '-I' + dest_path + '/smooth',
+                       '-I' + dest_path + '/raster',
+                       '-I' + dest_path + '/psaux',
+                       '-I' + dest_path + '/psnames',
+                       '-I' + dest_path + '/truetype',
                        '-w'])
       o_s.append(o)
 


### PR DESCRIPTION
Also add a warning when neither -c nor -r is used but we generate
an object file.   This is a legacy emscripten behaviour that we don't
want people to rely on.

