### PR TITLE
Fix backwards dependencies on JS functions in -l archives

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3510,11 +3510,6 @@ def process_libraries(libs, lib_dirs, temp_files):
     logger.debug('looking for library "%s"', lib)
     suffixes = STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS
 
-    if shared.Settings.WASM_BACKEND:
-      # under the wasm .a files are found using the normal -l/-L flags to
-      # the linker.
-      suffixes = DYNAMICLIB_ENDINGS
-
     found = False
     for prefix in LIB_PREFIXES:
       for suff in suffixes:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9796,3 +9796,12 @@ Module.arguments has been replaced with plain arguments_
     run_process([PYTHON, EMCC, 'hello1.o', '-o', 'hello3.o'])
     content3 = open('hello2.o', 'rb').read()
     self.assertEqual(content1, content3)
+
+  def test_backwards_deps_in_archive(self):
+    # Test that JS dependencies from deps_info.json work for code linked via
+    # static archives using -l<name>
+    run_process([PYTHON, EMCC, path_from_root('tests', 'sockets', 'test_gethostbyname.c'), '-o', 'a.o'])
+    run_process([LLVM_AR, 'cr', 'liba.a', 'a.o'])
+    create_test_file('empty.c', 'static int foo = 0;')
+    run_process([PYTHON, EMCC, 'empty.c', '-la', '-L.'])
+    self.assertContained('success', run_js('a.out.js'))


### PR DESCRIPTION
Previously we were allowing -l<name> flags to flow all the way through
the linker, but that meant the library files they referred too were
not getting passed though to `system_libraries.calculate`.
    
This change reverts back to the previous behavior prior to #9436.
 
Fixes: #9566
