### PR TITLE
Revert "Use chrome stable on CI for now as there is some breakage (#9572)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,8 +240,7 @@ commands:
       - run:
           name: download chrome
           command: |
-            # TODO: return to using beta once it stabilizes
-            wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
             dpkg -i ~/chrome.deb
       - run:
           name: run tests


### PR DESCRIPTION
The breakage on beta has been fixed.