### PR TITLE
Correctly handle reading arguments when proxying an EM_ASM call

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2360,6 +2360,28 @@ def create_asm_consts_wasm(forwarded_json, metadata):
       all_sigs.append((sig, call_type))
 
   asm_const_funcs = []
+  asm_const_funcs.append(r'''
+function _read_asm_const_args(sig_ptr, buf) {
+  var args = [];
+  var sig = AsciiToString(sig_ptr);
+  function align_to(ptr, align) {
+    return (ptr+align-1) & ~(align-1);
+  }
+  for (var i = 0; i < sig.length; i++) {
+    var c = sig[i];
+    if (c == 'd' || c == 'f') {
+      buf = align_to(buf, 8);
+      args.push(HEAPF64[(buf >> 3)]);
+      buf += 8;
+    } else if (c == 'i') {
+      buf = align_to(buf, 4);
+      args.push(HEAP32[(buf >> 2)]);
+      buf += 4;
+    }
+  }
+  return args;
+}
+''')
   for sig, call_type in set(all_sigs):
     const_name = '_emscripten_asm_const_' + call_type + sig
     forwarded_json['Functions']['libraryFunctions'][const_name] = 1
@@ -2382,24 +2404,7 @@ def create_asm_consts_wasm(forwarded_json, metadata):
 
     asm_const_funcs.append(r'''
 function %s(code, sig_ptr, argbuf) {%s
-  var sig = AsciiToString(sig_ptr);
-  var args = [];
-  var align_to = function(ptr, align) {
-    return (ptr+align-1) & ~(align-1);
-  };
-  var buf = argbuf;
-  for (var i = 0; i < sig.length; i++) {
-    var c = sig[i];
-    if (c == 'd' || c == 'f') {
-      buf = align_to(buf, 8);
-      args.push(HEAPF64[(buf >> 3)]);
-      buf += 8;
-    } else if (c == 'i') {
-      buf = align_to(buf, 4);
-      args.push(HEAP32[(buf >> 2)]);
-      buf += 4;
-    }
-  }
+  var args = _read_asm_const_args(sig_ptr, argbuf);
   return ASM_CONSTS[code].apply(null, args);
 }''' % (const_name, preamble))
   return asm_consts, asm_const_funcs

--- a/emscripten.py
+++ b/emscripten.py
@@ -2361,7 +2361,7 @@ def create_asm_consts_wasm(forwarded_json, metadata):
 
   asm_const_funcs = []
   asm_const_funcs.append(r'''
-function _read_asm_const_args(sig_ptr, buf) {
+function readAsmConstArgs(sig_ptr, buf) {
   var args = [];
   var sig = AsciiToString(sig_ptr);
   function align_to(ptr, align) {
@@ -2404,7 +2404,7 @@ function _read_asm_const_args(sig_ptr, buf) {
 
     asm_const_funcs.append(r'''
 function %s(code, sig_ptr, argbuf) {%s
-  var args = _read_asm_const_args(sig_ptr, argbuf);
+  var args = readAsmConstArgs(sig_ptr, argbuf);
   return ASM_CONSTS[code].apply(null, args);
 }''' % (const_name, preamble))
   return asm_consts, asm_const_funcs

--- a/emscripten.py
+++ b/emscripten.py
@@ -2360,7 +2360,11 @@ def create_asm_consts_wasm(forwarded_json, metadata):
       all_sigs.append((sig, call_type))
 
   asm_const_funcs = []
-  asm_const_funcs.append(r'''
+
+  if all_sigs:
+    # emit the signature-reading helper function only if we have any EM_ASM
+    # functions in the module
+    asm_const_funcs.append(r'''
 function readAsmConstArgs(sig_ptr, buf) {
   var args = [];
   var sig = AsciiToString(sig_ptr);
@@ -2382,6 +2386,7 @@ function readAsmConstArgs(sig_ptr, buf) {
   return args;
 }
 ''')
+
   for sig, call_type in set(all_sigs):
     const_name = '_emscripten_asm_const_' + call_type + sig
     forwarded_json['Functions']['libraryFunctions'][const_name] = 1

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1257,9 +1257,9 @@ var LibraryPThread = {
       // EM_ASM arguments are stored in their own buffer in memory, that we need
       // to unpack in order to call. The proxied arguments are the code index,
       // signature pointer, and vararg buffer pointer, in that order.
-      var sig_ptr = _emscripten_receive_on_main_thread_js_callArgs[1];
-      var vararg_ptr = _emscripten_receive_on_main_thread_js_callArgs[2];
-      var args = _read_asm_const_args(sig_ptr, vararg_ptr);
+      var sigPtr = _emscripten_receive_on_main_thread_js_callArgs[1];
+      var varargPtr = _emscripten_receive_on_main_thread_js_callArgs[2];
+      var args = readAsmConstArgs(sigPtr, varargPtr);
       return func.apply(null, args);
     }
 #endif

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -225,7 +225,7 @@ var LibraryPThread = {
         var worker = PThread.runningWorkers[i];
         var pthread = worker.pthread;
 #if ASSERTIONS
-        assert(pthread); // This Worker should have a pthread it is executing
+        assert(pthread, 'This Worker should have a pthread it is executing');
 #endif
         PThread.freeThreadData(pthread);
         worker.terminate();
@@ -1250,9 +1250,21 @@ var LibraryPThread = {
     }
     // Proxied JS library funcs are encoded as positive values, and
     // EM_ASMs as negative values (see include_asm_consts)
-    var func = index > 0 ? proxiedFunctionTable[index] : ASM_CONSTS[-index - 1];
+    var isEmAsmConst = index < 0;
+    var func = !isEmAsmConst ? proxiedFunctionTable[index] : ASM_CONSTS[-index - 1];
+#if WASM_BACKEND
+    if (isEmAsmConst) {
+      // EM_ASM arguments are stored in their own buffer in memory, that we need
+      // to unpack in order to call. The proxied arguments are the code index,
+      // signature pointer, and vararg buffer pointer, in that order.
+      var sig_ptr = _emscripten_receive_on_main_thread_js_callArgs[1];
+      var vararg_ptr = _emscripten_receive_on_main_thread_js_callArgs[2];
+      var args = _read_asm_const_args(sig_ptr, vararg_ptr);
+      return func.apply(null, args);
+    }
+#endif
 #if ASSERTIONS
-    assert(func.length == numCallArgs);
+    assert(func.length == numCallArgs, 'Call args mismatch in emscripten_receive_on_main_thread_js');
 #endif
     return func.apply(null, _emscripten_receive_on_main_thread_js_callArgs);
   },


### PR DESCRIPTION
The current CI failures are because of the assert that call arguments were mismatched when proxying. We also weren't reading the arguments from the EM_ASM vararg buffer correctly, so the test (browser.test_main_thread_em_asm_signatures_pthreads) would then fail with the wrong result. This fixes both of those things.