### PR TITLE
Add support for reftypes for Binaryen's InstrumentLocals pass

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2471,6 +2471,14 @@ def add_standard_wasm_imports(send_items_map):
       console.log('get_f64 ' + [loc, index, value]);
       return value;
     }'''
+    send_items_map['get_anyref'] = '''function(loc, index, value) {
+      console.log('get_anyref ' + [loc, index, value]);
+      return value;
+    }'''
+    send_items_map['get_exnref'] = '''function(loc, index, value) {
+      console.log('get_exnref ' + [loc, index, value]);
+      return value;
+    }'''
     send_items_map['set_i32'] = '''function(loc, index, value) {
       console.log('set_i32 ' + [loc, index, value]);
       return value;
@@ -2486,6 +2494,14 @@ def add_standard_wasm_imports(send_items_map):
     }'''
     send_items_map['set_f64'] = '''function(loc, index, value) {
       console.log('set_f64 ' + [loc, index, value]);
+      return value;
+    }'''
+    send_items_map['set_anyref'] = '''function(loc, index, value) {
+      console.log('set_anyref ' + [loc, index, value]);
+      return value;
+    }'''
+    send_items_map['set_exnref'] = '''function(loc, index, value) {
+      console.log('set_exnref ' + [loc, index, value]);
       return value;
     }'''
     send_items_map['load_ptr'] = '''function(loc, bytes, offset, ptr) {


### PR DESCRIPTION
This adds support for anyref and exnref types for Binaryen's
InstrumentLocals pass. But at this point it is hard to add a test in
emscripten side because `anyref` is not generated by C/C++ programs and
`exnref` is used with exception handling feature, which has not been
added. And anyway there are no tests for existing `get_` and `set_`
functions for integer/float types in the emscripten side.

Companion to WebAssembly/binaryen#2375.