### PR TITLE
Rename args to constArgs to avoid name conflicts

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1259,8 +1259,8 @@ var LibraryPThread = {
       // signature pointer, and vararg buffer pointer, in that order.
       var sigPtr = _emscripten_receive_on_main_thread_js_callArgs[1];
       var varargPtr = _emscripten_receive_on_main_thread_js_callArgs[2];
-      var args = readAsmConstArgs(sigPtr, varargPtr);
-      return func.apply(null, args);
+      var constArgs = readAsmConstArgs(sigPtr, varargPtr);
+      return func.apply(null, constArgs);
     }
 #endif
 #if ASSERTIONS


### PR DESCRIPTION
The problem is only apparent in `browser.test_pthread_printf` because we set `LIBRARY_DEBUG`, which wraps the body as an anonymous function, which causes the `var args` hoisting to clobber the (now outer-)function argument.