### PR TITLE
Fix PVRTC textures on iOS when using automatic extension enabling

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -976,7 +976,10 @@ var LibraryGL = {
                                              "WEBGL_compressed_texture_pvrtc", "EXT_color_buffer_half_float", "WEBGL_color_buffer_float",
                                              "EXT_sRGB", "WEBGL_compressed_texture_etc1", "EXT_disjoint_timer_query",
                                              "WEBGL_compressed_texture_etc", "WEBGL_compressed_texture_astc", "EXT_color_buffer_float",
-                                             "WEBGL_compressed_texture_s3tc_srgb", "EXT_disjoint_timer_query_webgl2"];
+                                             "WEBGL_compressed_texture_s3tc_srgb", "EXT_disjoint_timer_query_webgl2",
+                                             // Old style prefixed forms of extensions (but still currently used on e.g. iPhone Xs as
+                                             // tested on iOS 12.4.1):
+                                             "WEBKIT_WEBGL_compressed_texture_pvrtc"];
 
       function shouldEnableAutomatically(extension) {
         var ret = false;


### PR DESCRIPTION
This extension was the only WEBKIT_ prefixed extension on iPhone Xs Safari 12, not sure if older Safaris may have had other WEBKIT_ prefixes still.