### PR TITLE
Fix pthreads terminate assertion

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -196,9 +196,8 @@ var LibraryPThread = {
     terminateAllThreads: function() {
       for (var t in PThread.pthreads) {
         var pthread = PThread.pthreads[t];
-        if (pthread) {
-          PThread.freeThreadData(pthread);
-          if (pthread.worker) pthread.worker.terminate();
+        if (pthread && pthread.worker) {
+          PThread.returnWorkerToPool(pthread.worker);
         }
       }
       PThread.pthreads = {};


### PR DESCRIPTION
To clean up running threads, return them to the pool of available workers, so everything is in a consistent state (we afterwards terminate all available threads normally).

Fixes #9486, #9627
