### PR TITLE
Standalone mode testing for argc/argv usage

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -422,6 +422,7 @@ class TestCoreBase(RunnerCore):
     shutil.copyfile(path_from_root('tests', 'cube2md5.txt'), 'cube2md5.txt')
     self.do_run(open(path_from_root('tests', 'cube2md5.cpp')).read(), open(path_from_root('tests', 'cube2md5.ok')).read(), assert_returncode=None)
 
+  @also_with_standalone_wasm
   @needs_make('make')
   def test_cube2hash(self):
     # A good test of i64 math


### PR DESCRIPTION
This is a nontrivial testcase that checks that it gets exactly one commandline argument, and prints a hash computed from that input.