### PR TITLE
Make `main` symbol optional even in STANDALONE_WASM mode

### DIFF
--- a/system/lib/libc/crt1.c
+++ b/system/lib/libc/crt1.c
@@ -22,6 +22,13 @@ extern void __wasm_call_ctors(void) __attribute__((weak));
 extern int main(int argc, char** argv) __attribute__((weak));
 
 void _start(void) {
+  if (!main) {
+    if (__wasm_call_ctors) {
+      __wasm_call_ctors();
+    }
+    return;
+  }
+
   /* Fill in the arguments from WASI syscalls. */
   size_t argc;
   char **argv;
@@ -53,7 +60,7 @@ void _start(void) {
     __wasm_call_ctors();
   }
 
-  int r = main ? main(argc, argv) : 0;
+  int r = main(argc, argv);
 
   /* If main exited successfully, just return, otherwise call _Exit.
    * TODO(sbc): switch to _Exit */

--- a/system/lib/libc/crt1.c
+++ b/system/lib/libc/crt1.c
@@ -16,7 +16,10 @@
 #include <stdio.h>
 
 extern void __wasm_call_ctors(void) __attribute__((weak));
-extern int main(int argc, char** argv);
+
+// TODO(sbc): We shouldn't even link this file if there is no main:
+// https://github.com/emscripten-core/emscripten/issues/9640
+extern int main(int argc, char** argv) __attribute__((weak));
 
 void _start(void) {
   /* Fill in the arguments from WASI syscalls. */
@@ -50,7 +53,7 @@ void _start(void) {
     __wasm_call_ctors();
   }
 
-  int r = main(argc, argv);
+  int r = main ? main(argc, argv) : 0;
 
   /* If main exited successfully, just return, otherwise call _Exit.
    * TODO(sbc): switch to _Exit */

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8213,6 +8213,18 @@ extern "C" {
       }
     ''', ['abort(stack overflow)', '__handle_stack_overflow'], assert_returncode=None)
 
+  @also_with_standalone_wasm
+  def test_undefined_main(self):
+    # By default in emscripten we allow main to be undefined.  Its used when
+    # building library code that has no main.
+    # TODO(sbc): Simplify the code by making this an opt-in feature.
+    # https://github.com/emscripten-core/emscripten/issues/9640
+    src = '''
+    #include <emscripten.h>
+    EMSCRIPTEN_KEEPALIVE void foo() {}
+    '''
+    self.build(src, self.get_dir(), 'test.c')
+
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None):


### PR DESCRIPTION
See: https://github.com/emscripten-core/emscripten/issues/9640
Fixes: https://github.com/emscripten-core/emscripten/issues/9635
