### PR TITLE
Ignore F_SETFD of FD_CLOEXEC, which is meaningless for a single process

### DIFF
--- a/system/lib/libc/musl/src/fcntl/fcntl.c
+++ b/system/lib/libc/musl/src/fcntl/fcntl.c
@@ -24,8 +24,10 @@ int fcntl(int fd, int cmd, ...)
 	if (cmd == F_DUPFD_CLOEXEC) {
 		int ret = __syscall(SYS_fcntl, fd, F_DUPFD_CLOEXEC, arg);
 		if (ret != -EINVAL) {
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 			if (ret >= 0)
 				__syscall(SYS_fcntl, ret, F_SETFD, FD_CLOEXEC);
+#endif
 			return __syscall_ret(ret);
 		}
 		ret = __syscall(SYS_fcntl, fd, F_DUPFD_CLOEXEC, 0);
@@ -38,7 +40,9 @@ int fcntl(int fd, int cmd, ...)
 			return __syscall_ret(-EINVAL);
 		}
 		ret = __syscall(SYS_fcntl, fd, F_DUPFD, arg);
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 		if (ret >= 0) __syscall(SYS_fcntl, ret, F_SETFD, FD_CLOEXEC);
+#endif
 		return __syscall_ret(ret);
 	}
 	switch (cmd) {

--- a/system/lib/libc/musl/src/fcntl/open.c
+++ b/system/lib/libc/musl/src/fcntl/open.c
@@ -15,8 +15,10 @@ int open(const char *filename, int flags, ...)
 	}
 
 	int fd = __sys_open_cp(filename, flags, mode);
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 	if (fd>=0 && (flags & O_CLOEXEC))
 		__syscall(SYS_fcntl, fd, F_SETFD, FD_CLOEXEC);
+#endif
 
 	return __syscall_ret(fd);
 }

--- a/system/lib/libc/musl/src/stdio/__fdopen.c
+++ b/system/lib/libc/musl/src/stdio/__fdopen.c
@@ -25,8 +25,10 @@ FILE *__fdopen(int fd, const char *mode)
 	/* Impose mode restrictions */
 	if (!strchr(mode, '+')) f->flags = (*mode == 'r') ? F_NOWR : F_NORD;
 
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 	/* Apply close-on-exec flag */
 	if (strchr(mode, 'e')) __syscall(SYS_fcntl, fd, F_SETFD, FD_CLOEXEC);
+#endif
 
 	/* Set append mode on fd if opened for append */
 	if (*mode == 'a') {

--- a/system/lib/libc/musl/src/stdio/__fopen_rb_ca.c
+++ b/system/lib/libc/musl/src/stdio/__fopen_rb_ca.c
@@ -8,7 +8,9 @@ FILE *__fopen_rb_ca(const char *filename, FILE *f, unsigned char *buf, size_t le
 
 	f->fd = sys_open(filename, O_RDONLY|O_CLOEXEC);
 	if (f->fd < 0) return 0;
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 	__syscall(SYS_fcntl, f->fd, F_SETFD, FD_CLOEXEC);
+#endif
 
 	f->flags = F_NOWR | F_PERM;
 	f->buf = buf + UNGET;

--- a/system/lib/libc/musl/src/stdio/fopen.c
+++ b/system/lib/libc/musl/src/stdio/fopen.c
@@ -20,8 +20,10 @@ FILE *fopen(const char *restrict filename, const char *restrict mode)
 
 	fd = sys_open(filename, flags, 0666);
 	if (fd < 0) return 0;
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 	if (flags & O_CLOEXEC)
 		__syscall(SYS_fcntl, fd, F_SETFD, FD_CLOEXEC);
+#endif
 
 	f = __fdopen(fd, mode);
 	if (f) return f;

--- a/system/lib/libc/musl/src/stdio/freopen.c
+++ b/system/lib/libc/musl/src/stdio/freopen.c
@@ -21,8 +21,10 @@ FILE *freopen(const char *restrict filename, const char *restrict mode, FILE *re
 	fflush(f);
 
 	if (!filename) {
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 		if (fl&O_CLOEXEC)
 			__syscall(SYS_fcntl, f->fd, F_SETFD, FD_CLOEXEC);
+#endif
 		fl &= ~(O_CREAT|O_EXCL|O_CLOEXEC);
 		if (syscall(SYS_fcntl, f->fd, F_SETFL, fl) < 0)
 			goto fail;

--- a/system/lib/libc/musl/src/unistd/dup3.c
+++ b/system/lib/libc/musl/src/unistd/dup3.c
@@ -15,7 +15,9 @@ int __dup3(int old, int new, int flags)
 		if (r!=-ENOSYS) return __syscall_ret(r);
 	}
 	while ((r=__syscall(SYS_dup2, old, new))==-EBUSY);
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 	if (flags & O_CLOEXEC) __syscall(SYS_fcntl, new, F_SETFD, FD_CLOEXEC);
+#endif
 #else
 	while ((r=__syscall(SYS_dup3, old, new, flags))==-EBUSY);
 #endif

--- a/system/lib/libc/musl/src/unistd/pipe2.c
+++ b/system/lib/libc/musl/src/unistd/pipe2.c
@@ -10,10 +10,12 @@ int pipe2(int fd[2], int flag)
 	if (ret != -ENOSYS) return __syscall_ret(ret);
 	ret = pipe(fd);
 	if (ret) return ret;
+#ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
 	if (flag & O_CLOEXEC) {
 		__syscall(SYS_fcntl, fd[0], F_SETFD, FD_CLOEXEC);
 		__syscall(SYS_fcntl, fd[1], F_SETFD, FD_CLOEXEC);
 	}
+#endif
 	if (flag & O_NONBLOCK) {
 		__syscall(SYS_fcntl, fd[0], F_SETFL, O_NONBLOCK);
 		__syscall(SYS_fcntl, fd[1], F_SETFL, O_NONBLOCK);


### PR DESCRIPTION
This handles all syscalls to fcntl with `F_SETFD` (aside for fcntl itself).