### PR TITLE
Split internal settings into settings_internal.js

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+ - Internal settings have moved from `settings.js` to `settings_internal.js`.
+   These are settings that are for internal use only and are not set-able from
+   the command line.  If we misclassified any of these please open a bug.
  - `STANDALONE_WASM` mode now supports settings up argv vai wasi APIs.
  - `STANDALONE_WASM` mode now supports running static constructors in `_start`.
 

--- a/emcc.py
+++ b/emcc.py
@@ -411,6 +411,9 @@ def apply_settings(changes):
     key, value = change.split('=', 1)
     key, value = standardize_setting_change(key, value)
 
+    if key in shared.Settings.internal_settings:
+      exit_with_error('%s is an internal setting and cannot be set from command line', key)
+
     # In those settings fields that represent amount of memory, translate suffixes to multiples of 1024.
     if key in ('TOTAL_STACK', 'TOTAL_MEMORY', 'MEMORY_GROWTH_STEP', 'GL_MAX_TEMP_BUFFER_SIZE',
                'WASM_MEM_MAX', 'DEFAULT_PTHREAD_STACK_SIZE'):
@@ -422,9 +425,10 @@ def apply_settings(changes):
     else:
       value = value.replace('\\', '\\\\')
     try:
-      setattr(shared.Settings, key, parse_value(value))
+      value = parse_value(value)
     except Exception as e:
       exit_with_error('a problem occured in evaluating the content after a "-s", specifically "%s": %s', change, str(e))
+    setattr(shared.Settings, key, value)
 
     if shared.Settings.WASM_BACKEND and key == 'BINARYEN_TRAP_MODE':
       exit_with_error('BINARYEN_TRAP_MODE is not supported by the LLVM wasm backend')

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -144,6 +144,7 @@ load('utility.js');
 // Load settings, can be overridden by commandline
 
 load('settings.js');
+load('settings_internal.js');
 
 var settings_file = arguments_[0];
 additionalLibraries = Array.prototype.slice.call(arguments_, 1);

--- a/src/settings.js
+++ b/src/settings.js
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 //
-// Various compiling-to-JS parameters. These are simply variables present when the
+// Various compiler settings. These are simply variables present when the
 // JS compiler runs. To set them, do something like:
 //
 //   emcc -s OPTION1=VALUE1 -s OPTION2=VALUE2 [..other stuff..]
@@ -22,6 +22,9 @@
 // These flags should only have an effect when compiling to JS, so there
 // should not be a need to have them when just compiling source to
 // bitcode. However, there will also be no harm either, so it is ok to.
+//
+// Settings in this file can be directly set from the command line.  Internal
+// settings that are not part of the user ABI live in the settings_internal.js.
 //
 
 // Tuning
@@ -1520,26 +1523,6 @@ var WASM_TABLE_SIZE = 0;
 // for effective code size optimizations to take place.
 var SUPPORT_ERRNO = 1;
 
-// Internal: Tracks whether Emscripten should link in exception throwing (C++ 'throw')
-// support library. This does not need to be set directly, but pass -fno-exceptions
-// to the build disable exceptions support. (This is basically -fno-exceptions, but
-// checked at final link time instead of individual .cpp file compile time)
-// If the program *does* contain throwing code (some source files were not compiled
-// with `-fno-exceptions`), and this flag is set at link time, then you will get
-// errors on undefined symbols, as the exception throwing code is not linked in. If
-// so you should either unset the option (if you do want exceptions) or fix the
-// compilation of the source files so that indeed no exceptions are used).
-var DISABLE_EXCEPTION_THROWING = 0;
-
-// Internal: An array of all symbols exported from asm.js/wasm module.
-var MODULE_EXPORTS = [];
-
-// Internal (testing only): Disables the blitOffscreenFramebuffer VAO path.
-var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = 0;
-
-// Internal (testing only): Forces memory growing to fail.
-var TEST_MEMORY_GROWTH_FAILS = 0;
-
 // Advanced: Customize this array to reduce the set of asm.js runtime variables
 // that are generated. This allows minifying extra bit of asm.js code from unused
 // runtime code, if you know some of these are not needed.
@@ -1567,14 +1550,6 @@ var USES_DYNAMIC_ALLOC = 1;
 // be beneficial.
 var RUNTIME_FUNCS_TO_IMPORT = ['abort', 'setTempRet0', 'getTempRet0']
 
-// Internal: stores the base name of the output file (-o TARGET_BASENAME.js)
-var TARGET_BASENAME = '';
-
-// If true, compiler supports setjmp() and longjmp(). If false, these APIs are not available.
-// If you are using C++ exceptions, but do not need setjmp()+longjmp() API, then you can set
-// this to 0 to save a little bit of code size and performance when catching exceptions.
-var SUPPORT_LONGJMP = 1;
-
 // If set to 1, disables old deprecated HTML5 API event target lookup behavior. When enabled,
 // there is no "Module.canvas" object, no magic "null" default handling, and DOM element
 // 'target' parameters are taken to refer to CSS selectors, instead of referring to DOM IDs.
@@ -1587,25 +1562,6 @@ var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 0;
 // to explicitly choose to disable HTML minification altogether.
 var MINIFY_HTML = 1;
 
-// Indicates that the syscalls (which we see statically) indicate that they need full
-// filesystem support. Otherwise, when just a small subset are used, we can get away without
-// including the full filesystem - in particular, if open() is never used, then we don't
-// actually need to support operations on streams.
-var SYSCALLS_REQUIRE_FILESYSTEM = 1;
-
-// A list of feature flags to pass to each binaryen invocation (like wasm-opt, etc.). This
-// is received from wasm-emscripten-finalize, which reads it from the features section.
-var BINARYEN_FEATURES = [];
-
-// Whether EMCC_AUTODEBUG is on, which automatically instruments code for runtime
-// logging that can help in debugging.
-var AUTODEBUG = 0;
-
-// Whether we should use binaryen's wasm2js to convert our wasm to JS. Set when
-// wasm backend is in use with WASM=0 (to enable non-wasm output, we compile to
-// wasm normally, then compile that to JS).
-var WASM2JS = 0;
-
 // Whether we *may* be using wasm2js. This compiles to wasm normally, but lets you
 // run wasm2js *later* on the wasm, and you can pick between running the normal
 // wasm or that wasm2js code. For details of how to do that, see the test_maybe_wasm2js
@@ -1613,46 +1569,15 @@ var WASM2JS = 0;
 // This option can be useful for debugging and bisecting.
 var MAYBE_WASM2JS = 0;
 
-// Whether we should link in the runtime for ubsan.
-// 0 means do not link ubsan, 1 means link minimal ubsan runtime.
-// This is not meant to be used with `-s`. Instead, to use ubsan, use clang flag
-// -fsanitize=undefined. To use minimal runtime, also pass `-fsanitize-minimal-runtime`.
-var UBSAN_RUNTIME = 0;
-
-// Whether we should link in LSan's runtime library. This is intended to be used
-// by -fsanitize=leak instead of used directly.
-var USE_LSAN = 0;
-
-// Whether we should link in ASan's runtime library. This is intended to be used
-// by -fsanitize=leak instead of used directly.
-var USE_ASAN = 0;
-
 // The size of our shadow memory.
 // By default, we have 32 MiB. This supports 256 MiB of real memory.
 var ASAN_SHADOW_SIZE = 33554432;
-
-// Whether we should load the WASM source map at runtime.
-// This is enabled automatically when using -g4 with sanitizers.
-var LOAD_SOURCE_MAP = 0;
 
 // Whether we should use the offset converter.
 // This is needed for older versions of v8 (<7.7) that does not give the hex module offset
 // into wasm binary in stack traces, as well as for avoiding using source map
 // entries across function boundaries.
 var USE_OFFSET_CONVERTER = 0;
-
-// Whether embind has been enabled.
-var EMBIND = 0;
-
-// Whether the main() function reads the argc/argv parameters.
-var MAIN_READS_PARAMS = 1;
-
-// The computed location of the pointer to the sbrk position.
-var DYNAMICTOP_PTR = -1;
-
-// The computed initial value of the program break (the sbrk position), which
-// is called DYNAMIC_BASE as it is the start of dynamically-allocated memory.
-var DYNAMIC_BASE = -1;
 
 // Legacy settings that have been removed or renamed.
 // For renamed settings the format is:

--- a/src/settings.js
+++ b/src/settings.js
@@ -1534,6 +1534,9 @@ var SUPPORT_ERRNO = 1;
 // compilation of the source files so that indeed no exceptions are used).
 var DISABLE_EXCEPTION_THROWING = 0;
 
+// Internal (testing only): Forces memory growing to fail.
+var TEST_MEMORY_GROWTH_FAILS = 0;
+
 // Advanced: Customize this array to reduce the set of asm.js runtime variables
 // that are generated. This allows minifying extra bit of asm.js code from unused
 // runtime code, if you know some of these are not needed.
@@ -1561,15 +1564,15 @@ var USES_DYNAMIC_ALLOC = 1;
 // be beneficial.
 var RUNTIME_FUNCS_TO_IMPORT = ['abort', 'setTempRet0', 'getTempRet0']
 
-// If set to 1, disables old deprecated HTML5 API event target lookup behavior. When enabled,
-// there is no "Module.canvas" object, no magic "null" default handling, and DOM element
-// 'target' parameters are taken to refer to CSS selectors, instead of referring to DOM IDs.
-var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 0;
-
 // If true, compiler supports setjmp() and longjmp(). If false, these APIs are not available.
 // If you are using C++ exceptions, but do not need setjmp()+longjmp() API, then you can set
 // this to 0 to save a little bit of code size and performance when catching exceptions.
 var SUPPORT_LONGJMP = 1;
+
+// If set to 1, disables old deprecated HTML5 API event target lookup behavior. When enabled,
+// there is no "Module.canvas" object, no magic "null" default handling, and DOM element
+// 'target' parameters are taken to refer to CSS selectors, instead of referring to DOM IDs.
+var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 0;
 
 // Specifies whether the generated .html file is run through html-minifier. The set of
 // optimization passes run by html-minifier depends on debug and optimization levels. In

--- a/src/settings.js
+++ b/src/settings.js
@@ -1523,6 +1523,17 @@ var WASM_TABLE_SIZE = 0;
 // for effective code size optimizations to take place.
 var SUPPORT_ERRNO = 1;
 
+// Internal: Tracks whether Emscripten should link in exception throwing (C++ 'throw')
+// support library. This does not need to be set directly, but pass -fno-exceptions
+// to the build disable exceptions support. (This is basically -fno-exceptions, but
+// checked at final link time instead of individual .cpp file compile time)
+// If the program *does* contain throwing code (some source files were not compiled
+// with `-fno-exceptions`), and this flag is set at link time, then you will get
+// errors on undefined symbols, as the exception throwing code is not linked in. If
+// so you should either unset the option (if you do want exceptions) or fix the
+// compilation of the source files so that indeed no exceptions are used).
+var DISABLE_EXCEPTION_THROWING = 0;
+
 // Advanced: Customize this array to reduce the set of asm.js runtime variables
 // that are generated. This allows minifying extra bit of asm.js code from unused
 // runtime code, if you know some of these are not needed.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1566,6 +1566,11 @@ var RUNTIME_FUNCS_TO_IMPORT = ['abort', 'setTempRet0', 'getTempRet0']
 // 'target' parameters are taken to refer to CSS selectors, instead of referring to DOM IDs.
 var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 0;
 
+// If true, compiler supports setjmp() and longjmp(). If false, these APIs are not available.
+// If you are using C++ exceptions, but do not need setjmp()+longjmp() API, then you can set
+// this to 0 to save a little bit of code size and performance when catching exceptions.
+var SUPPORT_LONGJMP = 1;
+
 // Specifies whether the generated .html file is run through html-minifier. The set of
 // optimization passes run by html-minifier depends on debug and optimization levels. In
 // -g2 and higher, no minification is performed. In -g1, minification is done, but whitespace

--- a/src/settings.js
+++ b/src/settings.js
@@ -1534,6 +1534,9 @@ var SUPPORT_ERRNO = 1;
 // compilation of the source files so that indeed no exceptions are used).
 var DISABLE_EXCEPTION_THROWING = 0;
 
+// Internal (testing only): Disables the blitOffscreenFramebuffer VAO path.
+var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = 0;
+
 // Internal (testing only): Forces memory growing to fail.
 var TEST_MEMORY_GROWTH_FAILS = 0;
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -1,20 +1,14 @@
-// Copyright 2010 The Emscripten Authors.  All rights reserved.
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
 // Emscripten is available under two separate licenses, the MIT license and the
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
-// Tracks whether Emscripten should link in exception throwing (C++ 'throw')
-// support library. This does not need to be set directly, but pass
-// -fno-exceptions to the build disable exceptions support. (This is basically
-// -fno-exceptions, but checked at final link time instead of individual .cpp
-// file compile time) If the program *does* contain throwing code (some source
-// files were not compiled with `-fno-exceptions`), and this flag is set at link
-// time, then you will get errors on undefined symbols, as the exception
-// throwing code is not linked in. If so you should either unset the option (if
-// you do want exceptions) or fix the compilation of the source files so that
-// indeed no exceptions are used).
-
-var DISABLE_EXCEPTION_THROWING = 0;
+//
+// Settings in this file work exactly like those in settings.js but are not
+// set-able from the command line and therefore are not part of the public
+// ABI.  This means that these settings are an internal detail of the toolchain
+// and can be added/removed/renamed without fear of breaking out users.
+//
 
 // An array of all symbols exported from asm.js/wasm module.
 var MODULE_EXPORTS = [];
@@ -28,23 +22,25 @@ var TEST_MEMORY_GROWTH_FAILS = 0;
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 
-// If true, compiler supports setjmp() and longjmp(). If false, these APIs are not available.
-// If you are using C++ exceptions, but do not need setjmp()+longjmp() API, then you can set
-// this to 0 to save a little bit of code size and performance when catching exceptions.
+// If true, compiler supports setjmp() and longjmp(). If false, these APIs are
+// not available.  If you are using C++ exceptions, but do not need
+// setjmp()+longjmp() API, then you can set this to 0 to save a little bit of
+// code size and performance when catching exceptions.
 var SUPPORT_LONGJMP = 1;
 
-// Indicates that the syscalls (which we see statically) indicate that they need full
-// filesystem support. Otherwise, when just a small subset are used, we can get away without
-// including the full filesystem - in particular, if open() is never used, then we don't
-// actually need to support operations on streams.
+// Indicates that the syscalls (which we see statically) indicate that they need
+// full filesystem support. Otherwise, when just a small subset are used, we can
+// get away without including the full filesystem - in particular, if open() is
+// never used, then we don't actually need to support operations on streams.
 var SYSCALLS_REQUIRE_FILESYSTEM = 1;
 
-// A list of feature flags to pass to each binaryen invocation (like wasm-opt, etc.). This
-// is received from wasm-emscripten-finalize, which reads it from the features section.
+// A list of feature flags to pass to each binaryen invocation (like wasm-opt,
+// etc.). This is received from wasm-emscripten-finalize, which reads it from
+// the features section.
 var BINARYEN_FEATURES = [];
 
-// Whether EMCC_AUTODEBUG is on, which automatically instruments code for runtime
-// logging that can help in debugging.
+// Whether EMCC_AUTODEBUG is on, which automatically instruments code for
+// runtime logging that can help in debugging.
 var AUTODEBUG = 0;
 
 // Whether we should use binaryen's wasm2js to convert our wasm to JS. Set when
@@ -55,7 +51,8 @@ var WASM2JS = 0;
 // Whether we should link in the runtime for ubsan.
 // 0 means do not link ubsan, 1 means link minimal ubsan runtime.
 // This is not meant to be used with `-s`. Instead, to use ubsan, use clang flag
-// -fsanitize=undefined. To use minimal runtime, also pass `-fsanitize-minimal-runtime`.
+// -fsanitize=undefined. To use minimal runtime, also pass
+// `-fsanitize-minimal-runtime`.
 var UBSAN_RUNTIME = 0;
 
 // Whether we should link in LSan's runtime library. This is intended to be used

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -16,9 +16,6 @@ var MODULE_EXPORTS = [];
 // testing only: Disables the blitOffscreenFramebuffer VAO path.
 var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = 0;
 
-// testing only: Forces memory growing to fail.
-var TEST_MEMORY_GROWTH_FAILS = 0;
-
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -22,12 +22,6 @@ var TEST_MEMORY_GROWTH_FAILS = 0;
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 
-// If true, compiler supports setjmp() and longjmp(). If false, these APIs are
-// not available.  If you are using C++ exceptions, but do not need
-// setjmp()+longjmp() API, then you can set this to 0 to save a little bit of
-// code size and performance when catching exceptions.
-var SUPPORT_LONGJMP = 1;
-
 // Indicates that the syscalls (which we see statically) indicate that they need
 // full filesystem support. Otherwise, when just a small subset are used, we can
 // get away without including the full filesystem - in particular, if open() is

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -13,9 +13,6 @@
 // An array of all symbols exported from asm.js/wasm module.
 var MODULE_EXPORTS = [];
 
-// testing only: Disables the blitOffscreenFramebuffer VAO path.
-var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = 0;
-
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -1,0 +1,84 @@
+// Copyright 2010 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+// Tracks whether Emscripten should link in exception throwing (C++ 'throw')
+// support library. This does not need to be set directly, but pass
+// -fno-exceptions to the build disable exceptions support. (This is basically
+// -fno-exceptions, but checked at final link time instead of individual .cpp
+// file compile time) If the program *does* contain throwing code (some source
+// files were not compiled with `-fno-exceptions`), and this flag is set at link
+// time, then you will get errors on undefined symbols, as the exception
+// throwing code is not linked in. If so you should either unset the option (if
+// you do want exceptions) or fix the compilation of the source files so that
+// indeed no exceptions are used).
+
+var DISABLE_EXCEPTION_THROWING = 0;
+
+// An array of all symbols exported from asm.js/wasm module.
+var MODULE_EXPORTS = [];
+
+// testing only: Disables the blitOffscreenFramebuffer VAO path.
+var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = 0;
+
+// testing only: Forces memory growing to fail.
+var TEST_MEMORY_GROWTH_FAILS = 0;
+
+// stores the base name of the output file (-o TARGET_BASENAME.js)
+var TARGET_BASENAME = '';
+
+// If true, compiler supports setjmp() and longjmp(). If false, these APIs are not available.
+// If you are using C++ exceptions, but do not need setjmp()+longjmp() API, then you can set
+// this to 0 to save a little bit of code size and performance when catching exceptions.
+var SUPPORT_LONGJMP = 1;
+
+// Indicates that the syscalls (which we see statically) indicate that they need full
+// filesystem support. Otherwise, when just a small subset are used, we can get away without
+// including the full filesystem - in particular, if open() is never used, then we don't
+// actually need to support operations on streams.
+var SYSCALLS_REQUIRE_FILESYSTEM = 1;
+
+// A list of feature flags to pass to each binaryen invocation (like wasm-opt, etc.). This
+// is received from wasm-emscripten-finalize, which reads it from the features section.
+var BINARYEN_FEATURES = [];
+
+// Whether EMCC_AUTODEBUG is on, which automatically instruments code for runtime
+// logging that can help in debugging.
+var AUTODEBUG = 0;
+
+// Whether we should use binaryen's wasm2js to convert our wasm to JS. Set when
+// wasm backend is in use with WASM=0 (to enable non-wasm output, we compile to
+// wasm normally, then compile that to JS).
+var WASM2JS = 0;
+
+// Whether we should link in the runtime for ubsan.
+// 0 means do not link ubsan, 1 means link minimal ubsan runtime.
+// This is not meant to be used with `-s`. Instead, to use ubsan, use clang flag
+// -fsanitize=undefined. To use minimal runtime, also pass `-fsanitize-minimal-runtime`.
+var UBSAN_RUNTIME = 0;
+
+// Whether we should link in LSan's runtime library. This is intended to be used
+// by -fsanitize=leak instead of used directly.
+var USE_LSAN = 0;
+
+// Whether we should link in ASan's runtime library. This is intended to be used
+// by -fsanitize=leak instead of used directly.
+var USE_ASAN = 0;
+
+// Whether we should load the WASM source map at runtime.
+// This is enabled automatically when using -g4 with sanitizers.
+var LOAD_SOURCE_MAP = 0;
+
+// Whether embind has been enabled.
+var EMBIND = 0;
+
+// Whether the main() function reads the argc/argv parameters.
+var MAIN_READS_PARAMS = 1;
+
+// The computed location of the pointer to the sbrk position.
+var DYNAMICTOP_PTR = -1;
+
+// The computed initial value of the program break (the sbrk position), which
+// is called DYNAMIC_BASE as it is the start of dynamically-allocated memory.
+var DYNAMIC_BASE = -1;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4932,7 +4932,7 @@ Size of file is: 32
   def test_emcc_s_typo(self):
     # with suggestions
     stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'DISABLE_EXCEPTION_CATCH=1'])
-    self.assertContained('Assigning a non-existent settings attribute "DISABLE_EXCEPTION_CATCH"', stderr)
+    self.assertContained("Attempt to set a non-existent setting: 'DISABLE_EXCEPTION_CATCH'", stderr)
     self.assertContained('did you mean one of DISABLE_EXCEPTION_CATCHING', stderr)
     # no suggestions
     stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'CHEEZ=1'])


### PR DESCRIPTION
This allows to add and remove internal settings without effecting the
public ABI and potentially breaking users.