### PR TITLE
Always add hash to object file names in emar

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -67,9 +67,7 @@ def run():
         full_name = os.path.abspath(orig_name)
         dirname = os.path.dirname(full_name)
         basename = os.path.basename(full_name)
-        if basename not in contents:
-          contents.add(basename)
-          continue
+
         h = hashlib.md5(full_name.encode('utf-8')).hexdigest()[:8]
         parts = basename.split('.')
         parts[0] += '_' + h

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1551,8 +1551,7 @@ int f() {
 
     # Verify that archive contains basenames with hashes to avoid duplication
     text = run_process([PYTHON, EMAR, 't', 'liba.a'], stdout=PIPE).stdout
-    self.assertEqual(text.count('common.o'), 1)
-    self.assertContained('common_', text)
+    self.assertEqual(text.count('common_'), 2)
     for line in text.split('\n'):
       # should not have huge hash names
       self.assertLess(len(line), 20, line)


### PR DESCRIPTION
This fixes an issue where incremental builds can end up with
duplicated object files in static library archives
See: https://github.com/emscripten-core/emscripten/issues/9653