### PR TITLE
Remove now-unnecessary PthreadWorkerInit

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -23,15 +23,6 @@
 // (using makeStaticAlloc)
 
 LibraryManager.library = {
-  // keep this low in memory, because we flatten arrays with them in them
-#if USE_PTHREADS
-  _impure_ptr: '; if (ENVIRONMENT_IS_PTHREAD) __impure_ptr = PthreadWorkerInit["__impure_ptr"]; else PthreadWorkerInit["__impure_ptr"] = {{{ makeStaticAlloc(4) }}}',
-  __dso_handle: '; if (ENVIRONMENT_IS_PTHREAD) ___dso_handle = PthreadWorkerInit["___dso_handle"]; else PthreadWorkerInit["___dso_handle"] = ___dso_handle = {{{ makeStaticAlloc(4) }}}',
-#else
-  _impure_ptr: '{{{ makeStaticAlloc(1) }}}',
-  __dso_handle: '{{{ makeStaticAlloc(1) }}}',
-#endif
-
   $PROCINFO: {
     // permissions
     /*
@@ -1879,17 +1870,11 @@ LibraryManager.library = {
   },
 
   // Statically allocated time struct.
-#if USE_PTHREADS
-  __tm_current: '; if (ENVIRONMENT_IS_PTHREAD) ___tm_current = PthreadWorkerInit["___tm_current"]; else PthreadWorkerInit["___tm_current"] = ___tm_current = {{{ makeStaticAlloc(C_STRUCTS.tm.__size__) }}}',
-  __tm_timezone: '; if (ENVIRONMENT_IS_PTHREAD) ___tm_timezone = PthreadWorkerInit["___tm_timezone"]; else PthreadWorkerInit["___tm_timezone"] = ___tm_timezone = {{{ makeStaticString("GMT") }}}',
-  __tm_formatted: '; if (ENVIRONMENT_IS_PTHREAD) ___tm_formatted = PthreadWorkerInit["___tm_formatted"]; else PthreadWorkerInit["___tm_formatted"] = ___tm_formatted = {{{ makeStaticAlloc(C_STRUCTS.tm.__size__) }}}',
-#else
   __tm_current: '{{{ makeStaticAlloc(C_STRUCTS.tm.__size__) }}}',
   // Statically allocated copy of the string "GMT" for gmtime() to point to
   __tm_timezone: '{{{ makeStaticString("GMT") }}}',
   // Statically allocated time strings.
   __tm_formatted: '{{{ makeStaticAlloc(C_STRUCTS.tm.__size__) }}}',
-#endif
   mktime__deps: ['tzset'],
   mktime: function(tmPtr) {
     _tzset();
@@ -3238,15 +3223,10 @@ LibraryManager.library = {
   // netinet/in.h
   // ==========================================================================
 
-#if USE_PTHREADS
-  in6addr_any: '; if (ENVIRONMENT_IS_PTHREAD) _in6addr_any = PthreadWorkerInit["_in6addr_any"]; else PthreadWorkerInit["_in6addr_any"] = _in6addr_any = {{{ makeStaticAlloc(16) }}}',
-  in6addr_loopback: '; if (ENVIRONMENT_IS_PTHREAD) _in6addr_loopback = PthreadWorkerInit["_in6addr_loopback"]; else PthreadWorkerInit["_in6addr_loopback"] = _in6addr_loopback = {{{ makeStaticAlloc(16) }}}',
-#else
   in6addr_any:
     '{{{ makeStaticAlloc(16) }}}',
   in6addr_loopback:
     '{{{ makeStaticAlloc(16) }}}',
-#endif
 
   // ==========================================================================
   // netdb.h

--- a/src/library.js
+++ b/src/library.js
@@ -23,6 +23,10 @@
 // (using makeStaticAlloc)
 
 LibraryManager.library = {
+#if !WASM_BACKEND
+  __dso_handle: '{{{ makeStaticAlloc(1) }}}',
+#endif
+
   $PROCINFO: {
     // permissions
     /*

--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -6,13 +6,8 @@
 #include Fetch.js
 
 var LibraryFetch = {
-#if USE_PTHREADS
-  $Fetch__postset: 'if (!ENVIRONMENT_IS_PTHREAD) Fetch.staticInit();',
-  fetch_work_queue: '; if (ENVIRONMENT_IS_PTHREAD) _fetch_work_queue = PthreadWorkerInit["_fetch_work_queue"]; else PthreadWorkerInit["_fetch_work_queue"] = _fetch_work_queue = {{{ makeStaticAlloc(12) }}}',
-#else
   $Fetch__postset: 'Fetch.staticInit();',
   fetch_work_queue: '{{{ makeStaticAlloc(12) }}}',
-#endif
   $Fetch: Fetch,
   _emscripten_get_fetch_work_queue__deps: ['fetch_work_queue'],
   _emscripten_get_fetch_work_queue: function() {

--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -6,7 +6,11 @@
 #include Fetch.js
 
 var LibraryFetch = {
+#if USE_PTHREADS
+  $Fetch__postset: 'if (!ENVIRONMENT_IS_PTHREAD) Fetch.staticInit();',
+#else
   $Fetch__postset: 'Fetch.staticInit();',
+#endif
   fetch_work_queue: '{{{ makeStaticAlloc(12) }}}',
   $Fetch: Fetch,
   _emscripten_get_fetch_work_queue__deps: ['fetch_work_queue'],

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -342,8 +342,7 @@ var LibraryPThread = {
           'tempDoublePtr': tempDoublePtr,
 #endif
           'DYNAMIC_BASE': DYNAMIC_BASE,
-          'DYNAMICTOP_PTR': DYNAMICTOP_PTR,
-          'PthreadWorkerInit': PthreadWorkerInit
+          'DYNAMICTOP_PTR': DYNAMICTOP_PTR
         });
         PThread.unusedWorkers.push(worker);
       }
@@ -576,7 +575,7 @@ var LibraryPThread = {
   },
 
   _num_logical_cores__deps: ['emscripten_force_num_logical_cores'],
-  _num_logical_cores: '; if (ENVIRONMENT_IS_PTHREAD) __num_logical_cores = PthreadWorkerInit["__num_logical_cores"]; else { PthreadWorkerInit["__num_logical_cores"] = __num_logical_cores = {{{ makeStaticAlloc(4) }}}; HEAPU32[__num_logical_cores>>2] = navigator["hardwareConcurrency"] || ' + {{{ PTHREAD_HINT_NUM_CORES }}} + '; }',
+  _num_logical_cores: '{{{ makeStaticAlloc(4) }}}; HEAPU32[__num_logical_cores>>2] = navigator["hardwareConcurrency"] || ' + {{{ PTHREAD_HINT_NUM_CORES }}},
 
   emscripten_has_threading_support: function() {
     return typeof SharedArrayBuffer !== 'undefined';
@@ -1082,7 +1081,7 @@ var LibraryPThread = {
   },
 
   // Stores the memory address that the main thread is waiting on, if any.
-  _main_thread_futex_wait_address: '; if (ENVIRONMENT_IS_PTHREAD) __main_thread_futex_wait_address = PthreadWorkerInit["__main_thread_futex_wait_address"]; else PthreadWorkerInit["__main_thread_futex_wait_address"] = __main_thread_futex_wait_address = {{{ makeStaticAlloc(4) }}}',
+  _main_thread_futex_wait_address: '{{{ makeStaticAlloc(4) }}}',
 
   // Returns 0 on success, or one of the values -ETIMEDOUT, -EWOULDBLOCK or -EINVAL on error.
   emscripten_futex_wait__deps: ['_main_thread_futex_wait_address', 'emscripten_main_thread_process_queued_calls'],

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -79,21 +79,17 @@ function ready() {
 
 var ENVIRONMENT_IS_PTHREAD;
 if (!ENVIRONMENT_IS_PTHREAD) ENVIRONMENT_IS_PTHREAD = false; // ENVIRONMENT_IS_PTHREAD=true will have been preset in pthread-main.js. Make it false in the main runtime thread.
-var PthreadWorkerInit; // Collects together variables that are needed at initialization time for the web workers that host pthreads.
-if (!ENVIRONMENT_IS_PTHREAD) PthreadWorkerInit = {};
 
 if (typeof ENVIRONMENT_IS_PTHREAD === 'undefined') {
   // ENVIRONMENT_IS_PTHREAD=true will have been preset in pthread-main.js. Make it false in the main runtime thread. 
   // N.B. this line needs to appear without 'var' keyword to avoid 'var hoisting' from occurring. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var)
   ENVIRONMENT_IS_PTHREAD = false;
-  var PthreadWorkerInit = {}; // Collects together variables that are needed at initialization time for the web workers that host pthreads.
 } else {
   var buffer = {{{EXPORT_NAME}}}.buffer;
   var tempDoublePtr = {{{EXPORT_NAME}}}.tempDoublePtr;
   var STATICTOP = {{{EXPORT_NAME}}}.STATICTOP;
   var DYNAMIC_BASE = {{{EXPORT_NAME}}}.DYNAMIC_BASE;
   var DYNAMICTOP_PTR = {{{EXPORT_NAME}}}.DYNAMICTOP_PTR;
-  var PthreadWorkerInit = {{{EXPORT_NAME}}}.PthreadWorkerInit;
   var STACK_BASE = {{{EXPORT_NAME}}}.STACK_BASE;
   var STACKTOP = {{{EXPORT_NAME}}}.STACKTOP;
   var STACK_MAX = {{{EXPORT_NAME}}}.STACK_MAX;

--- a/src/shell_pthreads.js
+++ b/src/shell_pthreads.js
@@ -5,16 +5,12 @@
 
 // ENVIRONMENT_IS_PTHREAD=true will have been preset in worker.js. Make it false in the main runtime thread.
 var ENVIRONMENT_IS_PTHREAD = Module['ENVIRONMENT_IS_PTHREAD'] || false;
-var PthreadWorkerInit;
-if (!ENVIRONMENT_IS_PTHREAD) {
-  PthreadWorkerInit = {}; // Collects together variables that are needed at initialization time for the web workers that host pthreads.
-} else {
+if (ENVIRONMENT_IS_PTHREAD) {
   // Grab imports from the pthread to local scope.
   buffer = {{{EXPORT_NAME}}}['buffer'];
   tempDoublePtr = {{{EXPORT_NAME}}}['tempDoublePtr'];
   DYNAMIC_BASE = {{{EXPORT_NAME}}}['DYNAMIC_BASE'];
   DYNAMICTOP_PTR = {{{EXPORT_NAME}}}['DYNAMICTOP_PTR'];
-  PthreadWorkerInit = {{{EXPORT_NAME}}}['PthreadWorkerInit'];
   // Note that not all runtime fields are imported above. Values for STACK_BASE, STACKTOP and STACK_MAX are not yet known at worker.js load time.
   // These will be filled in at pthread startup time (the 'run' message for a pthread - pthread start establishes the stack frame)
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -139,7 +139,6 @@ this.onmessage = function(e) {
 
 #endif
 
-      Module['PthreadWorkerInit'] = e.data.PthreadWorkerInit;
       Module['ENVIRONMENT_IS_PTHREAD'] = true;
 
 #if MODULARIZE && EXPORT_ES6

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8427,7 +8427,7 @@ int main() {
     if self.is_wasm_backend():
       self.assertContained('wasm-ld: error: initial memory too small', err)
     else:
-      self.assertContained('Memory is not large enough for static data (134016) plus the stack (1024), please increase TOTAL_MEMORY (65536)', err)
+      self.assertContained('Memory is not large enough for static data (134000) plus the stack (1024), please increase TOTAL_MEMORY (65536)', err)
 
   def test_o_level_clamp(self):
     for level in [3, 4, 20]:


### PR DESCRIPTION
That extra complexity is no longer needed after recent simplifications. This ends up making the pthreads and non-pthreads paths more similar too.

This saves 338 bytes, which more than makes up for the slight regression of 77 bytes from #9569.