### PR TITLE
Add '-c' compile flag to zlip port

### DIFF
--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -34,7 +34,7 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'zlib', src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.PYTHON, shared.EMCC, os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w'])
+      commands.append([shared.PYTHON, shared.EMCC, os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w', '-c'])
       o_s.append(o)
     ports.run_commands(commands)
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1579,7 +1579,7 @@ class Ports(object):
 
     def retrieve():
       # retrieve from remote server
-      logger.warning('retrieving port: ' + name + ' from ' + url)
+      logger.info('retrieving port: ' + name + ' from ' + url)
       try:
         import requests
         response = requests.get(url)
@@ -1616,7 +1616,7 @@ class Ports(object):
       return bool(re.match(subdir + r'(\\|/|$)', names[0]))
 
     def unpack():
-      logger.warning('unpacking port: ' + name)
+      logger.info('unpacking port: ' + name)
       shared.safe_ensure_dirs(fullname)
 
       # TODO: Someday when we are using Python 3, we might want to change the


### PR DESCRIPTION
Due to #9600 building this port will display numerous errors.
Other ports may also need that flag added, but I don't use any other ports, so I'm not confident this is the correct change for everything.

I've also changed the 'warning' about downloading ports to an 'info'.