### PR TITLE
Re-enable mac testing but only for incoming, not for PR branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -628,10 +628,10 @@ workflows:
           requires:
             - build-upstream-mac
       - test-upstream-wasm0-mac:
-          # Limit mac testing the to incoming branch since it adds to much
-          # time and cost to run it on every incoming PR
+          # Limit mac testing the to master branch since it adds too much
+          # time and cost to run it on every PR
           filters:
             branches:
-              only: incoming
+              only: master
           requires:
             - build-upstream-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -533,6 +533,12 @@ jobs:
     steps:
       - run-tests-mac:
           test_targets: "other skip:other.test_native_link_error_message skip:other.test_emcc_v"
+  test-upstream-wasm0-mac:
+    macos:
+      xcode: "9.0"
+    steps:
+      - run-tests-mac:
+          test_targets: "wasm0"
 
 workflows:
   build-test:
@@ -619,5 +625,13 @@ workflows:
       - build-upstream-windows
       - build-upstream-mac
       - test-upstream-other-mac:
+          requires:
+            - build-upstream-mac
+      - test-upstream-wasm0-mac:
+          # Limit mac testing the to incoming branch since it adds to much
+          # time and cost to run it on every incoming PR
+          filters:
+            branches:
+              only: incoming
           requires:
             - build-upstream-mac


### PR DESCRIPTION
mac testing was disabled in 936dc036f36aa560d1160482def01d8277bf61a7 due
to time and cost concerns.

This change re-enables it but only for the incoming branch.