### PR TITLE
Some improvements to the documentation and AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -430,3 +430,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Andrei Alexeyev <akari@taisei-project.org>
 * Cesar Guirao Robles <cesar@no2.es>
 * Mehdi Sabwat <mehdisabwat@gmail.com>
+* MinganMuon <mingan-muon@outlook.com>

--- a/AUTHORS
+++ b/AUTHORS
@@ -321,7 +321,7 @@ a license to everyone to use it as detailed in LICENSE.)
 * Sergey Tsatsulin <tsatsulin@gmail.com>
 * varkor <github@varkor.com>
 * Stuart Knightley <website@stuartk.com>
-* Amadeus Guo<gliheng@foxmail.com>
+* Amadeus Guo <gliheng@foxmail.com>
 * Nathan Froyd <froydnj@gmail.com> (copyright owned by Mozilla Foundation)
 * Daniel Wirtz <dcode@dcode.io>
 * Kibeom Kim <kk1674@nyu.edu>
@@ -425,7 +425,7 @@ a license to everyone to use it as detailed in LICENSE.)
 * Sergey karchevsky <sergey.ext@gmail.com>
 * Ajay Patel <patel.ajay285@gmail.com>
 * Adrien Devresse <adev@adev.name>
-* Petr Penzin (petr.penzin@intel.com) (copyright owned by Intel Corporation)
+* Petr Penzin <petr.penzin@intel.com> (copyright owned by Intel Corporation)
 * Tayeb Al Karim <tay@google.com> (copyright owned by Google, Inc.)
 * Andrei Alexeyev <akari@taisei-project.org>
 * Cesar Guirao Robles <cesar@no2.es>

--- a/site/source/docs/building_from_source/verify_emscripten_environment.rst
+++ b/site/source/docs/building_from_source/verify_emscripten_environment.rst
@@ -19,7 +19,7 @@ Open a terminal in the directory in which you installed Emscripten (on Windows o
 
   ./emcc -v
 
-.. note:: On Windows, invoke the tool with **emsdk** instead of **./emsdk**.
+.. note:: On Windows, invoke the tool with **emcc** instead of **./emcc**.
 
 For example, the following output reports an installation where Java is missing::
   :emphasize-lines: 6


### PR DESCRIPTION
- Fixes a mention of an incorrect command in `verify_emscripten_environment.rst`
- Corrects the atypical usage of parentheses instead of angle brackets in one line in `AUTHORS`
- Adds a space to `AUTHORS` where one was missing
