### PR TITLE
Remove options.js_libraries

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2693,7 +2693,7 @@ def parse_args(newargs):
       newargs[i + 1] = ''
     elif newargs[i].startswith('--js-library'):
       check_bad_eq(newargs[i])
-      shared.Settings.SYSTEM_JS_LIBRARIES.append(newargs[i + 1])
+      shared.Settings.SYSTEM_JS_LIBRARIES.append(os.path.abspath(newargs[i + 1]))
       newargs[i] = ''
       newargs[i + 1] = ''
     elif newargs[i] == '--remove-duplicates':

--- a/emscripten.py
+++ b/emscripten.py
@@ -62,7 +62,7 @@ def access_quote(prop):
     return '.' + prop
 
 
-def emscript_fastcomp(infile, outfile, memfile, libraries, compiler_engine,
+def emscript_fastcomp(infile, outfile, memfile, compiler_engine,
                       temp_files, DEBUG):
   """Runs the emscripten LLVM-to-JS compiler.
 
@@ -93,7 +93,7 @@ def emscript_fastcomp(infile, outfile, memfile, libraries, compiler_engine,
       fixup_metadata_tables(metadata)
       funcs = fixup_functions(funcs, metadata)
     with ToolchainProfiler.profile_block('compiler_glue'):
-      glue, forwarded_data = compiler_glue(metadata, libraries, compiler_engine, temp_files, DEBUG)
+      glue, forwarded_data = compiler_glue(metadata, compiler_engine, temp_files, DEBUG)
 
     with ToolchainProfiler.profile_block('function_tables_and_exports'):
       (post, function_table_data, bundled_args) = (
@@ -230,7 +230,7 @@ def fixup_functions(funcs, metadata):
   return funcs
 
 
-def compiler_glue(metadata, libraries, compiler_engine, temp_files, DEBUG):
+def compiler_glue(metadata, compiler_engine, temp_files, DEBUG):
   if DEBUG:
     logger.debug('emscript: js compiler glue')
     t = time.time()
@@ -243,7 +243,7 @@ def compiler_glue(metadata, libraries, compiler_engine, temp_files, DEBUG):
   assert not (metadata['simd'] and shared.Settings.WASM), 'SIMD is used, but not supported in WASM mode yet'
   assert not (shared.Settings.SIMD and shared.Settings.WASM), 'SIMD is requested, but not supported in WASM mode yet'
 
-  glue, forwarded_data = compile_settings(compiler_engine, libraries, temp_files)
+  glue, forwarded_data = compile_settings(compiler_engine, temp_files)
 
   if DEBUG:
     logger.debug('  emscript: glue took %s seconds' % (time.time() - t))
@@ -745,7 +745,7 @@ def apply_forwarded_data(forwarded_data):
   StaticCodeHooks.atexits = str(forwarded_json['ATEXITS'])
 
 
-def compile_settings(compiler_engine, libraries, temp_files):
+def compile_settings(compiler_engine, temp_files):
   # Save settings to a file to work around v8 issue 1579
   with temp_files.get_file('.txt') as settings_file:
     with open(settings_file, 'w') as s:
@@ -755,7 +755,7 @@ def compile_settings(compiler_engine, libraries, temp_files):
     env = os.environ.copy()
     env['EMCC_BUILD_DIR'] = os.getcwd()
     out = jsrun.run_js_tool(path_from_root('src', 'compiler.js'), compiler_engine,
-                            [settings_file] + libraries, stdout=subprocess.PIPE, stderr=STDERR_FILE,
+                            [settings_file], stdout=subprocess.PIPE, stderr=STDERR_FILE,
                             cwd=path_from_root('src'), env=env)
   assert '//FORWARDED_DATA:' in out, 'Did not receive forwarded data in pre output - process failed?'
   glue, forwarded_data = out.split('//FORWARDED_DATA:')
@@ -2163,7 +2163,7 @@ HEAP_TYPE_INFOS = [
 ]
 
 
-def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
+def emscript_wasm_backend(infile, outfile, memfile, compiler_engine,
                           temp_files, DEBUG):
   # Overview:
   #   * Run wasm-emscripten-finalize to extract metadata and modify the binary
@@ -2182,7 +2182,7 @@ def emscript_wasm_backend(infile, outfile, memfile, libraries, compiler_engine,
 
   if DEBUG:
     t = time.time()
-  glue, forwarded_data = compile_settings(compiler_engine, libraries, temp_files)
+  glue, forwarded_data = compile_settings(compiler_engine, temp_files)
   if DEBUG:
     logger.debug('  emscript: glue took %s seconds' % (time.time() - t))
     t = time.time()
@@ -2753,7 +2753,7 @@ def normalize_line_endings(text):
   return text
 
 
-def run(infile, outfile, memfile, libraries):
+def run(infile, outfile, memfile):
   temp_files = get_configuration().get_temp_files()
   infile, outfile = substitute_response_files([infile, outfile])
 
@@ -2773,5 +2773,5 @@ def run(infile, outfile, memfile, libraries):
 
   emscripter = emscript_wasm_backend if shared.Settings.WASM_BACKEND else emscript_fastcomp
   return temp_files.run_and_clean(lambda: emscripter(
-      infile, outfile_obj, memfile, libraries, shared.NODE_JS, temp_files, shared.DEBUG)
+      infile, outfile_obj, memfile, shared.NODE_JS, temp_files, shared.DEBUG)
   )

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -147,7 +147,6 @@ load('settings.js');
 load('settings_internal.js');
 
 var settings_file = arguments_[0];
-additionalLibraries = Array.prototype.slice.call(arguments_, 1);
 
 if (settings_file) {
   var settings = JSON.parse(read(settings_file));

--- a/src/modules.js
+++ b/src/modules.js
@@ -142,8 +142,6 @@ var LibraryManager = {
       libraries.push('library_glemu.js');
     }
 
-    libraries = libraries.concat(additionalLibraries);
-
     if (BOOTSTRAPPING_STRUCT_INFO) libraries = ['library_bootstrap_structInfo.js', 'library_formatString.js'];
 
     // TODO: deduplicate libraries (not needed for correctness, but avoids unnecessary work)


### PR DESCRIPTION
SYSTEM_JS_LIBRARIES does the exact same thing and we don't need two mechanisms.