### PR TITLE
Unbreak Firefox on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,9 +188,11 @@ commands:
           environment:
             GALLIUM_DRIVER: softpipe # TODO: use the default llvmpipe when it supports more extensions
             EMTEST_LACKS_SOUND_HARDWARE: "1"
-            EMTEST_LACKS_OFFSCREEN_CANVAS: "1" # looks broken in ff nightly
+            # OffscreenCanvas support is not yet done in Firefox.
+            EMTEST_LACKS_OFFSCREEN_CANVAS: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
-            EMTEST_LACKS_THREAD_SUPPORT: "1" # wait for dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled to be present on dev edition
+            # Disable threads as dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled is not yet present on dev edition.
+            EMTEST_LACKS_THREAD_SUPPORT: "1"
             DISPLAY: ":0"
           command: |
             export EMTEST_BROWSER="$HOME/firefox/firefox -profile $HOME/tmp-firefox-profile/"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,9 +119,7 @@ commands:
       - run:
           name: download firefox
           command: |
-            # we should pin a version here, but llvm upstream now emits bulk memory for pthreads
-            # which requires very latest nightly as of Jul 13 2019
-            wget -O ~/ff.tar.bz2 "https://download.mozilla.org/?product=firefox-nightly-latest-ssl&os=linux64&lang=en-US"
+            wget -O ~/ff.tar.bz2 "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64&lang=en-US"
             tar -C ~ -xf ~/ff.tar.bz2
       - run:
           name: configure firefox
@@ -192,6 +190,7 @@ commands:
             EMTEST_LACKS_SOUND_HARDWARE: "1"
             EMTEST_LACKS_OFFSCREEN_CANVAS: "1" # looks broken in ff nightly
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
+            EMTEST_LACKS_THREAD_SUPPORT: "1" # wait for dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled to be present on dev edition
             DISPLAY: ":0"
           command: |
             export EMTEST_BROWSER="$HOME/firefox/firefox -profile $HOME/tmp-firefox-profile/"

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -3201,7 +3201,7 @@ var LibrarySDL = {
     surfData.ctx.save();
     surfData.ctx.fillStyle = color;
     surfData.ctx.font = fontString;
-    // use bottom alligment, because it works
+    // use bottom alignment, because it works
     // same in all browsers, more info here:
     // https://bugzilla.mozilla.org/show_bug.cgi?id=737852
     surfData.ctx.textBaseline = 'bottom';

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1721,15 +1721,16 @@ keydown(100);keyup(100); // trigger the end
       time.sleep(2)
 
   @requires_graphics_hardware
-  def test_glgears(self):
-    def test(args):
-      self.btest('hello_world_gles.c', reference='gears.png', reference_slack=3,
-                 args=['-DHAVE_BUILTIN_SINCOS', '-lGL', '-lglut'] + args)
-    # test normally
-    test([])
+  def test_glgears(self, extra_args=[]):
+    self.btest('hello_world_gles.c', reference='gears.png', reference_slack=3,
+               args=['-DHAVE_BUILTIN_SINCOS', '-lGL', '-lglut'] + extra_args)
+
+  @requires_graphics_hardware
+  @requires_threads
+  def test_glgears_pthreads(self, extra_args=[]):
     # test that a program that doesn't use pthreads still works with with pthreads enabled
     # (regression test for https://github.com/emscripten-core/emscripten/pull/8059#issuecomment-488105672)
-    test(['-s', 'USE_PTHREADS=1'])
+    self.test_glgears(['-s', 'USE_PTHREADS=1'])
 
   @requires_graphics_hardware
   def test_glgears_long(self):
@@ -3975,6 +3976,7 @@ window.close = function() {
     self.btest(path_from_root('tests', 'pthread', name + '.cpp'), expected='1', args=['-fsanitize=address', '-s', 'TOTAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-std=c++11', '--pre-js', path_from_root('tests', 'pthread', name + '.js')] + args)
 
   @no_fastcomp('ASan is only supported on WASM backend')
+  @requires_threads
   def test_pthread_asan_use_after_free(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_asan_use_after_free.cpp'), expected='1', args=['-fsanitize=address', '-s', 'TOTAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-std=c++11', '--pre-js', path_from_root('tests', 'pthread', 'test_pthread_asan_use_after_free.js')])
 


### PR DESCRIPTION
Nightly broke for unknown reasons. Switching to dev edition fixes that issue, but dev doesn't have the pref for pthreads testing, so disable pthreads tests on firefox for now.

Refactor some tests that were not marked as requiring pthreads (apparently all our CI had pthreads enabled anyhow so we didn't notice we broke on non-pthreads-supporting browsers).