### PR TITLE
Remove cmake_minimum_required version from cmake toolchain to avoid CMP0063 warnings

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -2,11 +2,6 @@
 # It teaches CMake about the Emscripten compiler, so that CMake can generate makefiles
 # from CMakeLists.txt that invoke emcc.
 
-# At the moment this required minimum version is not exact (i.e. we do not know of a feature that needs CMake 3.0.0 specifically)
-# It is possible that CMake 3.0.0 is too old and will not actually work. If you do find such a case, please report it at Emscripten
-# bug tracker to revise the minimum requirement. See also https://github.com/emscripten-core/emsdk/issues/108
-cmake_minimum_required(VERSION 3.0.0)
-
 # To use this toolchain file with CMake, invoke CMake with the following command line parameters
 # cmake -DCMAKE_TOOLCHAIN_FILE=<EmscriptenRoot>/cmake/Modules/Platform/Emscripten.cmake
 #       -DCMAKE_BUILD_TYPE=<Debug|RelWithDebInfo|Release|MinSizeRel>


### PR DESCRIPTION
See: https://cmake.org/cmake/help/latest/policy/CMP0063.html

Setting `cmake_minimum_required` to at least 3.3.0 automatically
applies the NEW policy for CMP0063, which avoids warnings coming from
`em_link_js_library` and similar.

---

If it is not desired to bump minimum cmake version to 3.3.0 (released over 4 years ago), the other option is to set this policy explicitly to NEW (or OLD), but [cmake docs](https://cmake.org/cmake/help/latest/command/cmake_policy.html#setting-policies-by-cmake-version) don't recommend it.

Edit:
As discussed in the thread, it is better to remove the `cmake_minimum_required` call altogether. Non of the official toolchains define this, so it's unlikely to be a bad solution. https://github.com/Kitware/CMake/tree/master/Modules/Platform 