### PR TITLE
Ignore -fPIC flag when not building relocatable code

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1883,6 +1883,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return any(flag.startswith(x) for x in ('-l', '-L', '-Wl,'))
 
       compile_args = [a for a in newargs if a and not is_link_flag(a)]
+      if '-fPIC' in compile_args and not shared.Settings.RELOCATABLE:
+        shared.warning('ignoring -fPIC flag when not building with SIDE_MODULE or MAIN_MODULE')
+        compile_args.remove('-fPIC')
 
       # Bitcode args generation code
       def get_clang_command(input_files):
@@ -3661,5 +3664,5 @@ if __name__ == '__main__':
   try:
     sys.exit(run(sys.argv))
   except KeyboardInterrupt:
-    logger.warning("KeyboardInterrupt")
+    logger.warning('KeyboardInterrupt')
     sys.exit(1)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8359,6 +8359,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
     '''
     self.build(src, self.get_dir(), 'test.c')
 
+  def test_fpic_static(self):
+    self.emcc_args.append('-fPIC')
+    self.emcc_args.remove('-Werror')
+    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
+
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None):


### PR DESCRIPTION
This issue was supposed to have been fixed in lld but it seems that
issues remain.  See https://reviews.llvm.org/D65922.

Fixes: #9690, #9013