### PR TITLE
Make emranlib actually do something

### DIFF
--- a/emranlib
+++ b/emranlib
@@ -1,9 +1,24 @@
 #!/usr/bin/env python
+# Copyright 2019 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
 
-'''
-emcc - ranlib helper script
+
+"""emranlib - ranlib helper script
 ===========================
 
 This script acts as a frontend replacement for ranlib. See emcc.
-'''
+"""
 
+
+from __future__ import print_function
+import sys
+from tools import shared
+
+def run():
+  newargs = [shared.LLVM_RANLIB] + sys.argv[1:]
+  return shared.run_process(newargs, stdin=sys.stdin, check=False).returncode
+
+if __name__ == '__main__':
+  sys.exit(run())

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9853,3 +9853,18 @@ Module.arguments has been replaced with plain arguments_
     stderr = self.expect_fail(cmd + ['-Werror'])
     self.assertContained('WARNING: not_object.bc is not a valid input file', stderr)
     self.assertContained('ERROR: treating warnings as errors (-Werror)', stderr)
+
+  def test_emranlib(self):
+    create_test_file('foo.c', 'int foo = 1;')
+    create_test_file('bar.c', 'int bar = 2;')
+    run_process([PYTHON, EMCC, '-c', 'foo.c', 'bar.c'])
+
+    # Create a library with no archive map
+    run_process([PYTHON, EMAR, 'crS', 'liba.a', 'foo.o', 'bar.o'])
+    output = run_process([shared.LLVM_NM, '--print-armap', 'liba.a'], stdout=PIPE).stdout
+    self.assertNotContained('Archive map', output)
+
+    # Add an archive map
+    run_process([PYTHON, EMRANLIB, 'liba.a'])
+    output = run_process([shared.LLVM_NM, '--print-armap', 'liba.a'], stdout=PIPE).stdout
+    self.assertContained('Archive map', output)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -796,6 +796,7 @@ CLANG_CPP = os.path.expanduser(build_clang_tool_path(exe_suffix('clang++')))
 CLANG = CLANG_CPP
 LLVM_LINK = build_llvm_tool_path(exe_suffix('llvm-link'))
 LLVM_AR = build_llvm_tool_path(exe_suffix('llvm-ar'))
+LLVM_RANLIB = build_llvm_tool_path(exe_suffix('llvm-ranlib'))
 LLVM_OPT = os.path.expanduser(build_llvm_tool_path(exe_suffix('opt')))
 LLVM_AS = os.path.expanduser(build_llvm_tool_path(exe_suffix('llvm-as')))
 LLVM_DIS = os.path.expanduser(build_llvm_tool_path(exe_suffix('llvm-dis')))


### PR DESCRIPTION
In this case we simply call directly through the llvm-ranlib.

I'm not sure why this was initially create empty but it can be useful
to run ranlib, for example if a build system doesn't by default create
a symbol index for archive files.