### PR TITLE
memfs: allow owning non-HEAP buffers with ALLOW_MEMORY_GROWTH

### DIFF
--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -272,6 +272,10 @@ mergeInto(LibraryManager.library, {
       //         with canOwn=true, creating a copy of the bytes is avoided, but the caller shouldn't touch the passed in range
       //         of bytes anymore since their contents now represent file data inside the filesystem.
       write: function(stream, buffer, offset, length, position, canOwn) {
+#if ASSERTIONS
+        // The data buffer should be a typed array view
+        assert(!(buffer instanceof ArrayBuffer));
+#endif
 #if ALLOW_MEMORY_GROWTH
         // If memory can grow, we don't want to hold on to references of
         // the memory Buffer, as they may get invalidated. That means
@@ -341,6 +345,10 @@ mergeInto(LibraryManager.library, {
         stream.node.usedBytes = Math.max(stream.node.usedBytes, offset + length);
       },
       mmap: function(stream, buffer, offset, length, position, prot, flags) {
+#if ASSERTIONS
+        // The data buffer should be a typed array view
+        assert(!(buffer instanceof ArrayBuffer));
+#endif
         if (!FS.isFile(stream.node.mode)) {
           throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }
@@ -349,7 +357,7 @@ mergeInto(LibraryManager.library, {
         var contents = stream.node.contents;
         // Only make a new copy when MAP_PRIVATE is specified.
         if ( !(flags & {{{ cDefine('MAP_PRIVATE') }}}) &&
-              (contents.buffer === buffer || contents.buffer === buffer.buffer) ) {
+              contents.buffer === buffer.buffer ) {
           // We can't emulate MAP_SHARED when the file is not backed by the buffer
           // we're mapping to (e.g. the HEAP buffer).
           allocated = false;

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -277,19 +277,22 @@ mergeInto(LibraryManager.library, {
         assert(!(buffer instanceof ArrayBuffer));
 #endif
 #if ALLOW_MEMORY_GROWTH
-        // If memory can grow, we don't want to hold on to references of
-        // the memory Buffer, as they may get invalidated. That means
-        // we need to do a copy here.
+        // If the buffer is located in main memory (HEAP), and if
+        // memory can grow, we can't hold on to references of the
+        // memory buffer, as they may get invalidated. That means we
+        // need to do copy its contents.
+        if (buffer.buffer === HEAP8.buffer) {
 #if ASSERTIONS
-        // FIXME: this is inefficient as the file packager may have
-        //        copied the data into memory already - we may want to
-        //        integrate more there and let the file packager loading
-        //        code be able to query if memory growth is on or off.
-        if (canOwn) {
-          warnOnce('file packager has copied file data into memory, but in memory growth we are forced to copy it again (see --no-heap-copy)');
-        }
+          // FIXME: this is inefficient as the file packager may have
+          //        copied the data into memory already - we may want to
+          //        integrate more there and let the file packager loading
+          //        code be able to query if memory growth is on or off.
+          if (canOwn) {
+            warnOnce('file packager has copied file data into memory, but in memory growth we are forced to copy it again (see --no-heap-copy)');
+          }
 #endif // ASSERTIONS
-        canOwn = false;
+          canOwn = false;
+        }
 #endif // ALLOW_MEMORY_GROWTH
 
         if (!length) return 0;


### PR DESCRIPTION
Memory growth may obsolete HEAP references, hence memfs disables 'canOwn' and forces copying.
memfs tests for this situation and suggests using --no-heap-copy.

However, the test is too strict: the same warning also appears with --no-heap-copy.

The test needs only prevent copying from HEAP, and accept other sources (e.g. xhr.response).