### PR TITLE
Add fallback for emval_get_global to support Web Workers

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -431,3 +431,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Cesar Guirao Robles <cesar@no2.es>
 * Mehdi Sabwat <mehdisabwat@gmail.com>
 * MinganMuon <mingan-muon@outlook.com>
+* Osman Turan <osman@osmanturan.com>

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -220,8 +220,8 @@ var LibraryEmVal = {
     }
     if (typeof global === 'object' && testGlobal(global)) {
       $$$embind_global$$$ = global;
-    } else if (typeof window === 'object' && testGlobal(window)) {
-      $$$embind_global$$$ = window;
+    } else if (typeof self === 'object' && testGlobal(self)) {
+      $$$embind_global$$$ = self; // This works for both "window" and "self" (Web Workers) global objects
     }
     if (typeof $$$embind_global$$$ === 'object') {
       return $$$embind_global$$$;


### PR DESCRIPTION
In generated WebAssembly modules, `emval_get_global` is used for accessing global variables. This function tries to get `globalThis` property with a fallback mechanism. Unfortunately, fallback mechanism does not use Web Workers environment global object (`self`). This commit fixes that problem.