### PR TITLE
Annotate settings.js flags that are relevant at compile time.

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -854,6 +854,7 @@ var LINKABLE = 0;
 //     is the correct thing to use).
 //   * STRICT_JS is enabled.
 //   * AUTO_JS_LIBRARIES is disabled.
+// [compile+link]
 var STRICT = 0;
 
 // Add "use strict;" to generated JS

--- a/src/settings.js
+++ b/src/settings.js
@@ -37,11 +37,14 @@
 // [link] - Should be passed at link time. This is the case for all JS flags,
 //          as we emit JS at link (and that is most of the flags here, and
 //          hence the default).
-// [compile&link] - A flag that has an effect at both compile and link time,
+// [compile+link] - A flag that has an effect at both compile and link time,
 //                  basically any time emcc is invoked. The same flag should be
-//                  passed at both times.
+//                  passed at both times in most cases.
 //
-// If not otherwise specified, a flag is [link].
+// If not otherwise specified, a flag is [link]. Note that no flag is only
+// relevant during compile time, as during link we may do codegen for system
+// libraries and other support code, so all flags are either link or
+// compile+link.
 //
 
 // Tuning
@@ -237,7 +240,7 @@ var IGNORE_CLOSURE_COMPILER_ERRORS = 0;
 // greater than 0, we will *not* inline in LLVM, and we will prevent inlining of
 // functions of this size or larger in closure. 50 is a reasonable setting if
 // you do not want inlining
-// [compile&link]
+// [compile+link]
 var INLINING_LIMIT = 0;
 
 // Run aggressiveVariableElimination in js-optimizer.js
@@ -537,12 +540,12 @@ var LZ4 = 0;
 //     as it may contain thrown exceptions that are never caught (e.g.
 //     just using std::vector can have that). -fno-rtti may help as well.
 //
-// [compile&link] - affects user code at compile and system libraries at link
+// [compile+link] - affects user code at compile and system libraries at link
 var DISABLE_EXCEPTION_CATCHING = 1;
 
 // Enables catching exception in the listed functions only, if
 // DISABLE_EXCEPTION_CATCHING = 2 is set
-// [compile&link] - affects user code at compile and system libraries at link
+// [compile+link] - affects user code at compile and system libraries at link
 var EXCEPTION_CATCHING_WHITELIST = [];
 
 // By default we handle exit() in node, by catching the Exit exception. However,
@@ -1126,7 +1129,7 @@ var WASM_BACKEND = 0;
 // of using LLVM IR.
 // Setting to zero will enable LTO and at link time will also enable bitcode
 // versions of the standard libraries.
-// [compile&link]
+// [compile+link]
 var WASM_OBJECT_FILES = 1;
 
 // An optional comma-separated list of script hooks to run after binaryen,
@@ -1287,7 +1290,7 @@ var SDL2_IMAGE_FORMATS = [];
 var IN_TEST_HARNESS = 0;
 
 // If true, enables support for pthreads.
-// [compile&link] - affects user code at compile and system libraries at link
+// [compile+link] - affects user code at compile and system libraries at link
 var USE_PTHREADS = 0;
 
 // PTHREAD_POOL_SIZE specifies the number of web workers that are created

--- a/src/settings.js
+++ b/src/settings.js
@@ -26,6 +26,23 @@
 // Settings in this file can be directly set from the command line.  Internal
 // settings that are not part of the user ABI live in the settings_internal.js.
 //
+// In general it is best to pass the same arguments at both compile and link
+// time, as whether wasm object files are used or not affects when codegen
+// happens (without wasm object files, or when using fastcomp, codegen is all
+// during link; otherwise, it is during compile). Flags affecting codegen must
+// be passed when codegen happens, so to let a build easily switch when codegen
+// happens (LTO vs normal), pass the flags at both times. The flags are also
+// annotated in this file:
+//
+// [link] - Should be passed at link time. This is the case for all JS flags,
+//          as we emit JS at link (and that is most of the flags here, and
+//          hence the default).
+// [compile&link] - A flag that has an effect at both compile and link time,
+//                  basically any time emcc is invoked. The same flag should be
+//                  passed at both times.
+//
+// If not otherwise specified, a flag is [link].
+//
 
 // Tuning
 
@@ -216,17 +233,11 @@ var DECLARE_ASM_MODULE_EXPORTS = 1;
 // Ignore closure warnings and errors (like on duplicate definitions)
 var IGNORE_CLOSURE_COMPILER_ERRORS = 0;
 
-// When enabled, does not push/pop the stack at all in functions that have no
-// basic stack usage. But, they may allocate stack later, and in a loop, this
-// can be very bad. In particular, when debugging, printf()ing a lot can exhaust
-// the stack very fast, with this option.  In particular, be careful with the
-// autodebugger! (We do turn this off automatically in that case, though.)
-var SKIP_STACK_IN_SMALL = 1;
-
 // A limit on inlining. If 0, we will inline normally in LLVM and closure. If
 // greater than 0, we will *not* inline in LLVM, and we will prevent inlining of
 // functions of this size or larger in closure. 50 is a reasonable setting if
 // you do not want inlining
+// [compile&link]
 var INLINING_LIMIT = 0;
 
 // Run aggressiveVariableElimination in js-optimizer.js
@@ -525,10 +536,13 @@ var LZ4 = 0;
 //     -fno-exceptions to really get rid of all exceptions code overhead,
 //     as it may contain thrown exceptions that are never caught (e.g.
 //     just using std::vector can have that). -fno-rtti may help as well.
+//
+// [compile&link] - affects user code at compile and system libraries at link
 var DISABLE_EXCEPTION_CATCHING = 1;
 
 // Enables catching exception in the listed functions only, if
 // DISABLE_EXCEPTION_CATCHING = 2 is set
+// [compile&link] - affects user code at compile and system libraries at link
 var EXCEPTION_CATCHING_WHITELIST = [];
 
 // By default we handle exit() in node, by catching the Exit exception. However,
@@ -1112,6 +1126,7 @@ var WASM_BACKEND = 0;
 // of using LLVM IR.
 // Setting to zero will enable LTO and at link time will also enable bitcode
 // versions of the standard libraries.
+// [compile&link]
 var WASM_OBJECT_FILES = 1;
 
 // An optional comma-separated list of script hooks to run after binaryen,
@@ -1272,6 +1287,7 @@ var SDL2_IMAGE_FORMATS = [];
 var IN_TEST_HARNESS = 0;
 
 // If true, enables support for pthreads.
+// [compile&link] - affects user code at compile and system libraries at link
 var USE_PTHREADS = 0;
 
 // PTHREAD_POOL_SIZE specifies the number of web workers that are created

--- a/src/settings.js
+++ b/src/settings.js
@@ -236,6 +236,13 @@ var DECLARE_ASM_MODULE_EXPORTS = 1;
 // Ignore closure warnings and errors (like on duplicate definitions)
 var IGNORE_CLOSURE_COMPILER_ERRORS = 0;
 
+// When enabled, does not push/pop the stack at all in functions that have no
+// basic stack usage. But, they may allocate stack later, and in a loop, this
+// can be very bad. In particular, when debugging, printf()ing a lot can exhaust
+// the stack very fast, with this option.  In particular, be careful with the
+// autodebugger! (We do turn this off automatically in that case, though.)
+var SKIP_STACK_IN_SMALL = 1;
+
 // A limit on inlining. If 0, we will inline normally in LLVM and closure. If
 // greater than 0, we will *not* inline in LLVM, and we will prevent inlining of
 // functions of this size or larger in closure. 50 is a reasonable setting if

--- a/tools/autodebugger.py
+++ b/tools/autodebugger.py
@@ -7,9 +7,6 @@
 
 You can then run the .ll file in the LLVM interpreter (lli) and
 compare that to the output when compiled using emscripten.
-
-Warning: You probably want to compile with SKIP_STACK_IN_SMALL=0! Otherwise
-         there may be weird errors.
 """
 
 from __future__ import print_function


### PR DESCRIPTION
99% of flags are link-only as they affect JS (or system libs). But a few affect compile as well.

Also remove a flag that is not used anywhere, SKIP_STACK_IN_SMALL.



cc @gabrielcuvillier 