### PR TITLE
Throw a wasm RuntimeError in abort

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -719,17 +719,21 @@ function abort(what) {
   EXITSTATUS = 1;
 
 #if ASSERTIONS == 0
-  throw 'abort(' + what + '). Build with -s ASSERTIONS=1 for more info.';
+  what = 'abort(' + what + '). Build with -s ASSERTIONS=1 for more info.';
 #else
-  var extra = '';
-  var output = 'abort(' + what + ') at ' + stackTrace() + extra;
+  var output = 'abort(' + what + ') at ' + stackTrace();
 #if EMTERPRETIFY_ASYNC
   abortDecorators.forEach(function(decorator) {
     output = decorator(output, what);
   });
 #endif
-  throw output;
+  what = output;
 #endif // ASSERTIONS
+
+  // Throw a wasm runtime error, because a JS error might be seen as a foreign
+  // exception, which means we'd run destructors on it. We need the error to
+  // simply make the program stop.
+  throw new WebAssembly.RuntimeError(what);
 }
 
 #if RELOCATABLE

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -733,7 +733,11 @@ function abort(what) {
   // Throw a wasm runtime error, because a JS error might be seen as a foreign
   // exception, which means we'd run destructors on it. We need the error to
   // simply make the program stop.
+#if WASM
   throw new WebAssembly.RuntimeError(what);
+#else
+  throw what;
+#endif
 }
 
 #if RELOCATABLE

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -69,7 +69,9 @@ WebAssembly = {
         });
       }
     };
-  }
+  },
+
+  RuntimeError: Error
 };
 
 // We don't need to actually download a wasm binary, mark it as present but empty.


### PR DESCRIPTION
Other JS errors may be seen as foreign exceptions which means native
wasm exception handling will run destructors, but we do not want anything
to run, and to just abort.

Fixes #9715 