### PR TITLE
Allow ASM_CONSTS keys to be non-contiguous

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8684,8 +8684,8 @@ int main() {
 var ASM_CONSTS = [function() { var x = !<->5.; }];
                                         ^
 ''', '''
-var ASM_CONSTS = [function() {var x = !<->5.;}];
-                                       ^
+  0: function() {var x = !<->5.;}
+                          ^
 '''), stderr)
 
   def test_EM_ASM_ES6(self):


### PR DESCRIPTION
As part of the plan to fix #9013, I plan to use the absolute address
of the string in memory to index into this object.