### PR TITLE
emar: Don't crash when supplied with the same file multiple times

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -67,9 +67,9 @@ def run():
         parts[0] += '_' + h
         newname = '.'.join(parts)
         full_newname = os.path.join(dirname, newname)
-        newargs[j] = full_newname
         try:
           shutil.copyfile(orig_name, full_newname)
+          newargs[j] = full_newname
           to_delete.append(full_newname)
         except Exception:
           # it is ok to fail here, we just don't get hashing

--- a/emar.py
+++ b/emar.py
@@ -55,12 +55,6 @@ def run():
       else:
         out_arg_index = 2
 
-      contents = set()
-      if os.path.exists(newargs[out_arg_index]):
-        cmd = [shared.LLVM_AR, 't', newargs[out_arg_index]]
-        output = shared.check_call(cmd, stdout=shared.PIPE).stdout
-        contents.update(output.split('\n'))
-
       # Add a hash to colliding basename, to make them unique.
       for j in range(out_arg_index + 1, len(newargs)):
         orig_name = newargs[j]
@@ -73,15 +67,12 @@ def run():
         parts[0] += '_' + h
         newname = '.'.join(parts)
         full_newname = os.path.join(dirname, newname)
-        assert not os.path.exists(full_newname)
+        newargs[j] = full_newname
         try:
           shutil.copyfile(orig_name, full_newname)
-          newargs[j] = full_newname
           to_delete.append(full_newname)
-          contents.add(newname)
         except Exception:
           # it is ok to fail here, we just don't get hashing
-          contents.add(basename)
           pass
 
     if shared.DEBUG:
@@ -94,11 +85,10 @@ def run():
   if shared.DEBUG:
     print('emar:', sys.argv, '  ==>  ', newargs, file=sys.stderr)
 
-  try:
-    return shared.run_process(newargs, stdin=sys.stdin, check=False).returncode
-  finally:
-    for d in to_delete:
-      shared.try_delete(d)
+  rtn = shared.run_process(newargs, stdin=sys.stdin, check=False).returncode
+  for d in to_delete:
+    shared.try_delete(d)
+  return rtn
 
 
 if __name__ == '__main__':

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8541,6 +8541,13 @@ end
     self.assertContained('file1', result)
     self.assertContained('file2', result)
 
+  def test_emar_duplicate_inputs(self):
+    # Verify the we can supply the same intput muliple times without
+    # confusing emar.py:
+    # See https://github.com/emscripten-core/emscripten/issues/9733
+    create_test_file('file1', ' ')
+    run_process([PYTHON, EMAR, 'cr', 'file1.a', 'file1', 'file1'])
+
   def test_flag_aliases(self):
     def assert_aliases_match(flag1, flag2, flagarg, extra_args):
       results = {}


### PR DESCRIPTION
Also, remove the `contents` set, which is no longer used since #9654 landed.

Also, remove a try/catch block that was cleaning up even in the case
of an exception.  If an exception occurs its actually useful to leave
the temp files around to analyze the crash.

Fixes: #9733