### PR TITLE
Update fetch dependencies

### DIFF
--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -33,7 +33,7 @@ var LibraryFetch = {
 #if FETCH_SUPPORT_INDEXEDDB
   '$__emscripten_fetch_cache_data', '$__emscripten_fetch_load_cached_data', '$__emscripten_fetch_delete_cached_data',
 #endif
-  '_emscripten_get_fetch_work_queue', 'emscripten_is_main_runtime_thread']
+  '_emscripten_get_fetch_work_queue', 'emscripten_is_main_browser_thread']
 };
 
 mergeInto(LibraryManager.library, LibraryFetch);

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3367,7 +3367,7 @@ def read_and_preprocess(filename, expand_macros=False):
 # worker in -s ASMFS=1 mode.
 def make_fetch_worker(source_file, output_file):
   src = open(source_file, 'r').read()
-  funcs_to_import = ['alignUp', '_emscripten_get_heap_size', '_emscripten_resize_heap', 'stringToUTF8', 'UTF8ToString', 'UTF8ArrayToString', 'intArrayFromString', 'lengthBytesUTF8', 'stringToUTF8Array', '_emscripten_is_main_runtime_thread', '_emscripten_futex_wait', '_emscripten_get_sbrk_ptr']
+  funcs_to_import = ['alignUp', '_emscripten_get_heap_size', '_emscripten_resize_heap', 'stringToUTF8', 'UTF8ToString', 'UTF8ArrayToString', 'intArrayFromString', 'lengthBytesUTF8', 'stringToUTF8Array', '_emscripten_is_main_browser_thread', '_emscripten_futex_wait', '_emscripten_get_sbrk_ptr']
   asm_funcs_to_import = ['_malloc', '_free', '_sbrk', '___pthread_mutex_lock', '___pthread_mutex_unlock', '_pthread_mutexattr_init', '_pthread_mutex_init']
   function_prologue = '''this.onerror = function(e) {
   console.error(e);


### PR DESCRIPTION
Seems like fetch depends on `emscripten_is_main_browser_thread` and not
on `emscripten_is_main_runtime_thread`.

I'm not sure how write a test for this but is came up as part of
https://github.com/emscripten-core/emscripten/pull/9740.