### PR TITLE
Adjust ASM_CONST indexes when building with `-s RELOCATABLE`

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2413,6 +2413,11 @@ function readAsmConstArgs(sigPtr, buf) {
                      str(int(sync_proxy)) +
                      ', code, sigPtr, argbuf); }')
 
+    if shared.Settings.RELOCATABLE:
+      # TODO(sbc): remove this conidtion after
+      # https://github.com/WebAssembly/binaryen/pull/2408 lands
+      preamble += '\n  if (code > %s) code -= %s;\n' % (shared.Settings.GLOBAL_BASE, shared.Settings.GLOBAL_BASE)
+
     asm_const_funcs.append(r'''
 function %s(code, sigPtr, argbuf) {%s
   var args = readAsmConstArgs(sigPtr, argbuf);


### PR DESCRIPTION
For reloctable code (i.e. MAIN_MODULE) ASM_CONST offsets are relative to
the GLOBAL_BASE.