### PR TITLE
Re-allow `-fPIC` compiler flag during compilation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1896,9 +1896,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return any(flag.startswith(x) for x in ('-l', '-L', '-Wl,'))
 
       compile_args = [a for a in newargs if a and not is_link_flag(a)]
-      if '-fPIC' in compile_args and not shared.Settings.RELOCATABLE:
-        shared.warning('ignoring -fPIC flag when not building with SIDE_MODULE or MAIN_MODULE')
-        compile_args.remove('-fPIC')
 
       # Bitcode args generation code
       def get_clang_command(input_files):

--- a/emscripten.py
+++ b/emscripten.py
@@ -2414,9 +2414,7 @@ function readAsmConstArgs(sigPtr, buf) {
                      ', code, sigPtr, argbuf); }')
 
     if shared.Settings.RELOCATABLE:
-      # TODO(sbc): remove this conidtion after
-      # https://github.com/WebAssembly/binaryen/pull/2408 lands
-      preamble += '\n  if (code >= %s) code -= %s;\n' % (shared.Settings.GLOBAL_BASE, shared.Settings.GLOBAL_BASE)
+      preamble += '\n  code -= %s;\n' % shared.Settings.GLOBAL_BASE
 
     asm_const_funcs.append(r'''
 function %s(code, sigPtr, argbuf) {%s

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8392,7 +8392,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   def test_fpic_static(self):
     self.emcc_args.append('-fPIC')
-    self.emcc_args.remove('-Werror')
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
 
   @node_pthreads


### PR DESCRIPTION
We were temporally disabling this flag due to issues with PIC code
in static linking.  These issues should not be resolved.

Fixes: #9013