### PR TITLE
Add test for archives without index. NFC.

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8548,6 +8548,23 @@ end
     create_test_file('file1', ' ')
     run_process([PYTHON, EMAR, 'cr', 'file1.a', 'file1', 'file1'])
 
+  def test_archive_no_index(self):
+    create_test_file('foo.c', 'int foo = 1;')
+    run_process([PYTHON, EMCC, '-c', 'foo.c'])
+    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')])
+    # The `S` flag means don't add an archive index
+    run_process([PYTHON, EMAR, 'crS', 'libfoo.a', 'foo.o'])
+    if self.is_wasm_backend():
+      # TODO(sbc): Handle archive without index in wasm backend too:
+      # https://github.com/emscripten-core/emscripten/issues/9705
+      stderr = self.expect_fail([PYTHON, EMCC, 'libfoo.a', 'hello_world.o'])
+      self.assertContained('libfoo.a: archive has no index; run ranlib to add one', stderr)
+      # Add an index and then verify that makes the error go away.
+      run_process([PYTHON, EMRANLIB, 'libfoo.a'])
+      run_process([PYTHON, EMCC, 'libfoo.a', 'hello_world.o'])
+    else:
+      run_process([PYTHON, EMCC, 'libfoo.a', 'hello_world.o'])
+
   def test_flag_aliases(self):
     def assert_aliases_match(flag1, flag2, flagarg, extra_args):
       results = {}


### PR DESCRIPTION
This change only adds a test for the current behaviour. I plan to make
no-index archives work with upstream backend too in the future.