### PR TITLE
Vary libgl on FULL_ES3

### DIFF
--- a/system/lib/gl/webgl2.c
+++ b/system/lib/gl/webgl2.c
@@ -22,8 +22,10 @@ ASYNC_GL_FUNCTION_2(EM_FUNC_SIG_VII, void, glBeginQuery, GLenum, GLuint);
 ASYNC_GL_FUNCTION_1(EM_FUNC_SIG_VI, void, glEndQuery, GLenum);
 VOID_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glGetQueryiv, GLenum, GLenum, GLint *);
 VOID_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glGetQueryObjectuiv, GLuint, GLenum, GLuint *);
+#ifdef __EMSCRIPTEN_FULL_ES3__
 RET_SYNC_GL_FUNCTION_1(EM_FUNC_SIG_II, GLboolean, glUnmapBuffer, GLenum);
 VOID_SYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glGetBufferPointerv, GLenum, GLenum, void **);
+#endif
 VOID_SYNC_GL_FUNCTION_2(EM_FUNC_SIG_VII, void, glDrawBuffers, GLsizei, const GLenum *);
 VOID_SYNC_GL_FUNCTION_4(EM_FUNC_SIG_VIIII, void, glUniformMatrix2x3fv, GLint, GLsizei, GLboolean, const GLfloat *);
 VOID_SYNC_GL_FUNCTION_4(EM_FUNC_SIG_VIIII, void, glUniformMatrix3x2fv, GLint, GLsizei, GLboolean, const GLfloat *);
@@ -34,8 +36,10 @@ VOID_SYNC_GL_FUNCTION_4(EM_FUNC_SIG_VIIII, void, glUniformMatrix4x3fv, GLint, GL
 ASYNC_GL_FUNCTION_10(EM_FUNC_SIG_VIIIIIIIIII, void, glBlitFramebuffer, GLint, GLint, GLint, GLint, GLint, GLint, GLint, GLint, GLbitfield, GLenum);
 ASYNC_GL_FUNCTION_5(EM_FUNC_SIG_VIIIII, void, glRenderbufferStorageMultisample, GLenum, GLsizei, GLenum, GLsizei, GLsizei);
 ASYNC_GL_FUNCTION_5(EM_FUNC_SIG_VIIIII, void, glFramebufferTextureLayer, GLenum, GLenum, GLuint, GLint, GLint);
+#ifdef __EMSCRIPTEN_FULL_ES3__
 RET_SYNC_GL_FUNCTION_4(EM_FUNC_SIG_VIIII, void *, glMapBufferRange, GLenum, GLintptr, GLsizeiptr, GLbitfield);
 ASYNC_GL_FUNCTION_3(EM_FUNC_SIG_VIII, void, glFlushMappedBufferRange, GLenum, GLintptr, GLsizeiptr);
+#endif
 ASYNC_GL_FUNCTION_1(EM_FUNC_SIG_VI, void, glBindVertexArray, GLuint);
 VOID_SYNC_GL_FUNCTION_2(EM_FUNC_SIG_VII, void, glDeleteVertexArrays, GLsizei, const GLuint *);
 VOID_SYNC_GL_FUNCTION_2(EM_FUNC_SIG_VII, void, glGenVertexArrays, GLsizei, GLuint *);
@@ -188,8 +192,10 @@ void *emscripten_webgl2_get_proc_address(const char *name)
 	RETURN_FN(glEndQuery);
 	RETURN_FN(glGetQueryiv);
 	RETURN_FN(glGetQueryObjectuiv);
+#ifdef __EMSCRIPTEN_FULL_ES3__
 	RETURN_FN(glUnmapBuffer);
 	RETURN_FN(glGetBufferPointerv);
+#endif
 	RETURN_FN(glDrawBuffers);
 	RETURN_FN(glUniformMatrix2x3fv);
 	RETURN_FN(glUniformMatrix3x2fv);
@@ -200,8 +206,10 @@ void *emscripten_webgl2_get_proc_address(const char *name)
 	RETURN_FN(glBlitFramebuffer);
 	RETURN_FN(glRenderbufferStorageMultisample);
 	RETURN_FN(glFramebufferTextureLayer);
+#ifdef __EMSCRIPTEN_FULL_ES3__
 	RETURN_FN(glMapBufferRange);
 	RETURN_FN(glFlushMappedBufferRange);
+#endif
 	RETURN_FN(glBindVertexArray);
 	RETURN_FN(glDeleteVertexArrays);
 	RETURN_FN(glGenVertexArrays);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1925,7 +1925,7 @@ int f() {
       }
       ''')
 
-    for args in ([], ['-O2']):
+    for args in ([], ['-O1'], ['-s', 'USE_WEBGL2=1']):
       for action in ('WARN', 'ERROR', None):
         for value in ([0, 1]):
           try_delete('a.out.js')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -958,6 +958,7 @@ class libgl(MTLibrary):
     self.is_legacy = kwargs.pop('is_legacy')
     self.is_webgl2 = kwargs.pop('is_webgl2')
     self.is_ofb = kwargs.pop('is_ofb')
+    self.is_full_es3 = kwargs.pop('is_full_es3')
     super(libgl, self).__init__(**kwargs)
 
   def get_base_name(self):
@@ -968,6 +969,8 @@ class libgl(MTLibrary):
       name += '-webgl2'
     if self.is_ofb:
       name += '-ofb'
+    if self.is_full_es3:
+      name += '-full_es3'
     return name
 
   def get_cflags(self):
@@ -978,11 +981,14 @@ class libgl(MTLibrary):
       cflags += ['-DUSE_WEBGL2=1', '-s', 'USE_WEBGL2=1']
     if self.is_ofb:
       cflags += ['-D__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__']
+    if self.is_full_es3:
+      cflags += ['-D__EMSCRIPTEN_FULL_ES3__']
     return cflags
 
   @classmethod
   def vary_on(cls):
-    return super(libgl, cls).vary_on() + ['is_legacy', 'is_webgl2', 'is_ofb']
+    return super(libgl, cls).vary_on() + \
+           ['is_legacy', 'is_webgl2', 'is_ofb', 'is_full_es3']
 
   @classmethod
   def get_default_variation(cls, **kwargs):
@@ -990,6 +996,7 @@ class libgl(MTLibrary):
       is_legacy=shared.Settings.LEGACY_GL_EMULATION,
       is_webgl2=shared.Settings.USE_WEBGL2,
       is_ofb=shared.Settings.OFFSCREEN_FRAMEBUFFER,
+      is_full_es3=shared.Settings.FULL_ES3,
       **kwargs
     )
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -987,8 +987,7 @@ class libgl(MTLibrary):
 
   @classmethod
   def vary_on(cls):
-    return super(libgl, cls).vary_on() + \
-           ['is_legacy', 'is_webgl2', 'is_ofb', 'is_full_es3']
+    return super(libgl, cls).vary_on() + ['is_legacy', 'is_webgl2', 'is_ofb', 'is_full_es3']
 
   @classmethod
   def get_default_variation(cls, **kwargs):


### PR DESCRIPTION
Fixes a regression from #9684 in which using WebGL2 + GetProcAddress would error on missing FULL_ES3 methods.

If an app uses GetProcAddress, metadce can't remove GL functions (as it maps string names to them, the user can ask for any one). And as a result we end up with the entirety of libgl linked in even at the highest opt levels. And then it's a link error as the JS library side intentionally does not link in these functions (so that GetProcAddress will return "null" if asked for them, which is the correct behavior if FULL_ES3 is not used).

Reduce the -O2 to -O1 in the relevant test, as it's really just testing for opts vs not, which itself is of dubious importance; at least -O1 is faster to compile.