### PR TITLE
Changed changelog link to point from master to incoming

### DIFF
--- a/site/source/docs/introducing_emscripten/release_notes.rst
+++ b/site/source/docs/introducing_emscripten/release_notes.rst
@@ -21,8 +21,8 @@ information. The easiest way to find these posts is to use `this search
 ChangeLog
 =========
 
-The ChangeLog for Emscripten |release| (|today|) is listed below (master version
-`here <https://github.com/emscripten-core/emscripten/blob/master/ChangeLog.md>`_).
+The ChangeLog for Emscripten |release| (|today|) is listed below (incoming version
+`here <https://github.com/emscripten-core/emscripten/blob/incoming/ChangeLog.md>`_).
 
 .. include::   ../../../../ChangeLog.md
    :literal:


### PR DESCRIPTION
Made this change because the master changelog is way out of date.