### PR TITLE
Remove type checks for SIMD constant intrinsics

### DIFF
--- a/system/include/wasm_simd128.h
+++ b/system/include/wasm_simd128.h
@@ -32,14 +32,7 @@ typedef double __f64x2 __attribute__((__vector_size__(16), __aligned__(16)));
 
 #define __DEFAULT_FN_ATTRS __attribute__((__always_inline__, __nodebug__, __target__("simd128"), __min_vector_width__(128)))
 
-#ifdef __cplusplus
-#include <type_traits>
-#define __SAME_TYPE(t1, t2) (std::is_same<t1, t2>::value)
-#else
-#define __SAME_TYPE(t1, t2) (__builtin_types_compatible_p(t1, t2))
-#endif
-
-#define __REQUIRE_CONSTANT(e, ty, msg) _Static_assert(__builtin_constant_p(e) && __SAME_TYPE(__typeof__(e), ty), msg)
+#define __REQUIRE_CONSTANT(e) _Static_assert(__builtin_constant_p(e), "Expected constant")
 
 // v128 wasm_v128_load(void* mem)
 static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_v128_load(const void* __mem) {
@@ -196,78 +189,78 @@ static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_make(double c0, double c1
 // v128_t wasm_i8x16_constant(...)
 #define wasm_i8x16_const(c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15) \
   __extension__({                                                       \
-      __REQUIRE_CONSTANT(c0, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c1, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c2, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c3, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c4, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c5, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c6, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c7, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c8, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c9, int8_t, "expected constant int8_t");       \
-      __REQUIRE_CONSTANT(c10, int8_t, "expected constant int8_t");      \
-      __REQUIRE_CONSTANT(c11, int8_t, "expected constant int8_t");      \
-      __REQUIRE_CONSTANT(c12, int8_t, "expected constant int8_t");      \
-      __REQUIRE_CONSTANT(c13, int8_t, "expected constant int8_t");      \
-      __REQUIRE_CONSTANT(c14, int8_t, "expected constant int8_t");      \
-      __REQUIRE_CONSTANT(c15, int8_t, "expected constant int8_t");      \
+      __REQUIRE_CONSTANT(c0);                                           \
+      __REQUIRE_CONSTANT(c1);                                           \
+      __REQUIRE_CONSTANT(c2);                                           \
+      __REQUIRE_CONSTANT(c3);                                           \
+      __REQUIRE_CONSTANT(c4);                                           \
+      __REQUIRE_CONSTANT(c5);                                           \
+      __REQUIRE_CONSTANT(c6);                                           \
+      __REQUIRE_CONSTANT(c7);                                           \
+      __REQUIRE_CONSTANT(c8);                                           \
+      __REQUIRE_CONSTANT(c9);                                           \
+      __REQUIRE_CONSTANT(c10);                                          \
+      __REQUIRE_CONSTANT(c11);                                          \
+      __REQUIRE_CONSTANT(c12);                                          \
+      __REQUIRE_CONSTANT(c13);                                          \
+      __REQUIRE_CONSTANT(c14);                                          \
+      __REQUIRE_CONSTANT(c15);                                          \
       (v128_t)(__i8x16){c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11, c12, c13, c14, c15}; \
     })
 
 // v128_t wasm_i16x8_constant(...)
-#define wasm_i16x8_const(c0, c1, c2, c3, c4, c5, c6, c7) \
-  __extension__({                                                       \
-      __REQUIRE_CONSTANT(c0, int16_t, "expected constant int16_t");     \
-      __REQUIRE_CONSTANT(c1, int16_t, "expected constant int16_t");     \
-      __REQUIRE_CONSTANT(c2, int16_t, "expected constant int16_t");     \
-      __REQUIRE_CONSTANT(c3, int16_t, "expected constant int16_t");     \
-      __REQUIRE_CONSTANT(c4, int16_t, "expected constant int16_t");     \
-      __REQUIRE_CONSTANT(c5, int16_t, "expected constant int16_t");     \
-      __REQUIRE_CONSTANT(c6, int16_t, "expected constant int16_t");     \
-      __REQUIRE_CONSTANT(c7, int16_t, "expected constant int16_t");     \
-      (v128_t)(__i16x8){c0, c1, c2, c3, c4, c5, c6, c7}; \
+#define wasm_i16x8_const(c0, c1, c2, c3, c4, c5, c6, c7)        \
+  __extension__({                                               \
+      __REQUIRE_CONSTANT(c0);                                   \
+      __REQUIRE_CONSTANT(c1);                                   \
+      __REQUIRE_CONSTANT(c2);                                   \
+      __REQUIRE_CONSTANT(c3);                                   \
+      __REQUIRE_CONSTANT(c4);                                   \
+      __REQUIRE_CONSTANT(c5);                                   \
+      __REQUIRE_CONSTANT(c6);                                   \
+      __REQUIRE_CONSTANT(c7);                                   \
+      (v128_t)(__i16x8){c0, c1, c2, c3, c4, c5, c6, c7};        \
     })
 
 // v128_t wasm_i32x4_constant(...)
-#define wasm_i32x4_const(c0, c1, c2, c3) \
-  __extension__({                                                       \
-      __REQUIRE_CONSTANT(c0, int32_t, "expected constant int32_t");     \
-      __REQUIRE_CONSTANT(c1, int32_t, "expected constant int32_t");     \
-      __REQUIRE_CONSTANT(c2, int32_t, "expected constant int32_t");     \
-      __REQUIRE_CONSTANT(c3, int32_t, "expected constant int32_t");     \
-      (v128_t)(__i32x4){c0, c1, c2, c3};                                \
+#define wasm_i32x4_const(c0, c1, c2, c3)        \
+  __extension__({                               \
+      __REQUIRE_CONSTANT(c0);                   \
+      __REQUIRE_CONSTANT(c1);                   \
+      __REQUIRE_CONSTANT(c2);                   \
+      __REQUIRE_CONSTANT(c3);                   \
+      (v128_t)(__i32x4){c0, c1, c2, c3};        \
     })
 
 // v128_t wasm_f32x4_constant(...)
-#define wasm_f32x4_const(c0, c1, c2, c3)                        \
-  __extension__({                                               \
-      __REQUIRE_CONSTANT(c0, float, "expected constant float"); \
-      __REQUIRE_CONSTANT(c1, float, "expected constant float"); \
-      __REQUIRE_CONSTANT(c2, float, "expected constant float"); \
-      __REQUIRE_CONSTANT(c3, float, "expected constant float"); \
-      (v128_t)(__f32x4){c0, c1, c2, c3};                        \
+#define wasm_f32x4_const(c0, c1, c2, c3)        \
+  __extension__({                               \
+      __REQUIRE_CONSTANT(c0);                   \
+      __REQUIRE_CONSTANT(c1);                   \
+      __REQUIRE_CONSTANT(c2);                   \
+      __REQUIRE_CONSTANT(c3);                   \
+      (v128_t)(__f32x4){c0, c1, c2, c3};        \
     })
 
 #ifdef __wasm_unimplemented_simd128__
 
 // v128_t wasm_i64x2_constant(...)
-#define wasm_i64x2_const(c0, c1)                                        \
-  __extension__({                                                       \
-      __REQUIRE_CONSTANT(c0, int64_t, "expected constant int64_t");     \
-      __REQUIRE_CONSTANT(c1, int64_t, "expected constant int64_t");     \
-      (v128_t)(__i64x2){c0, c1};                                        \
+#define wasm_i64x2_const(c0, c1)                \
+  __extension__({                               \
+      __REQUIRE_CONSTANT(c0);                   \
+      __REQUIRE_CONSTANT(c1);                   \
+      (v128_t)(__i64x2){c0, c1};                \
     })
 
 // v128_t wasm_f64x2_constant(...)
 #define wasm_f64x2_const(c0, c1)                                        \
   __extension__({                                                       \
-      __REQUIRE_CONSTANT(c0, double, "expected constant double");     \
-      __REQUIRE_CONSTANT(c1, double, "expected constant double");     \
+      __REQUIRE_CONSTANT(c0);                                           \
+      __REQUIRE_CONSTANT(c1);                                           \
       (v128_t)(__f64x2){c0, c1};                                        \
     })
 
-#endif // __wasm_unimplemented_sidm128__
+#endif // __wasm_unimplemented_simd128__
 
 // v128_t wasm_i8x16_splat(int8_t a)
 static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_splat(int8_t a) {

--- a/tests/test_wasm_intrinsics_simd.c
+++ b/tests/test_wasm_intrinsics_simd.c
@@ -50,32 +50,25 @@ void TESTFN i8x16_store(void *ptr, v128_t vec) {
 }
 v128_t TESTFN i8x16_const(void) {
   return wasm_i8x16_const(
-      (int8_t)1, (int8_t)2, (int8_t)3, (int8_t)4,
-      (int8_t)5, (int8_t)6, (int8_t)7, (int8_t)8,
-      (int8_t)9, (int8_t)10, (int8_t)11, (int8_t)12,
-      (int8_t)13, (int8_t)14, (int8_t)15, (int8_t)16
-  );
+      1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16);
 }
 v128_t TESTFN i16x8_const(void) {
-  return wasm_i16x8_const(
-      (int16_t)1, (int16_t)2, (int16_t)3, (int16_t)4,
-      (int16_t)5, (int16_t)6, (int16_t)7, (int16_t)8
-  );
+  return wasm_i16x8_const(1, 2, 3, 4, 5, 6, 7, 8);
 }
 v128_t TESTFN i32x4_const(void) {
-  return wasm_i32x4_const((int32_t)1, (int32_t)2, (int32_t)3, (int32_t)4);
+  return wasm_i32x4_const(1, 2, 3, 4);
 }
 v128_t TESTFN f32x4_const(void) {
-  return wasm_f32x4_const(1.f, 2.f, 3.f, 4.f);
+  return wasm_f32x4_const(1, 2, 3, 4);
 }
 
 #ifdef __wasm_unimplemented_simd128__
 
 v128_t TESTFN i64x2_const(void) {
-  return wasm_i64x2_const((int64_t)1, (int64_t)2);
+  return wasm_i64x2_const(1, 2);
 }
 v128_t TESTFN f64x2_const(void) {
-  return wasm_f64x2_const(1., 2.);
+  return wasm_f64x2_const(1, 2);
 }
 
 #endif // __wasm_unimplemented_sidm128__


### PR DESCRIPTION
These checks are not consistent with how C is expected to behave and
cause more friction than they are worth, as evidenced by #9768.