### PR TITLE
Document that --memory-init-file is irrelevant for wasm. 

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -121,6 +121,19 @@ that is:
 [site_repo]: https://github.com/kripken/emscripten-site
 
 
+Updating the `emcc.py` help text
+--------------------------------
+
+`emcc --help` output is generated from the main documentation under `site/`,
+so it is the same as shown on the website, but it is rendered to text. After
+updating `emcc.rst` in a PR, the following should be done:
+
+1. In your emscripten repo checkout, enter `site`.
+2. Run `make clean` (without this, it may not emit the right output).
+2. Run `make text`.
+3. Add the changes to your PR.
+
+
 Packaging Emscripten
 --------------------
 

--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -443,6 +443,10 @@ Options that are modified or new in *emcc* are listed below:
 
 "--memory-init-file <on>"
    Specifies whether to emit a separate memory initialization file.
+
+      Note: Note that this is only relevant when *not* emitting
+        wasm, as wasm embeds the memory init data in the wasm binary.
+
    Possible "on" values are:
 
       * "0": Do not emit a separate memory initialization file.

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -362,7 +362,11 @@ Options that are modified or new in *emcc* are listed below:
 .. _emcc-memory-init-file:
 
 ``--memory-init-file <on>``
-  Specifies whether to emit a separate memory initialization file. Possible ``on`` values are:
+  Specifies whether to emit a separate memory initialization file.
+
+      .. note:: Note that this is only relevant when *not* emitting wasm, as wasm embeds the memory init data in the wasm binary.
+
+  Possible ``on`` values are:
 
     - ``0``: Do not emit a separate memory initialization file. Instead keep the static initialization inside the generated JavaScript as text. This is the default setting if compiling with -O0 or -O1 link-time optimization flags.
     - ``1``: Emit a separate memory initialization file in binary format. This is more efficient than storing it as text inside JavaScript, but does mean you have another file to publish. The binary file will also be loaded asynchronously, which means ``main()`` will not be called until the file is downloaded and applied; you cannot call any C functions until it arrives. This is the default setting when compiling with -O2 or higher.


### PR DESCRIPTION
Also update docs on updating the emcc --help docs.

Fixes #9781

cc @VirtualTim 