### PR TITLE
Refactor binaryen command running

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3013,19 +3013,17 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
         options.binaryen_passes += ['--pass-arg=emscripten-sbrk-val@%d' % shared.Settings.DYNAMIC_BASE]
     if DEBUG:
       shared.safe_copy(wasm_binary_target, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(wasm_binary_target) + '.pre-byn'))
-    cmd = shared.Building.get_wasm_opt_command(wasm_binary_target,
-                                               wasm_binary_target,
-                                               options.binaryen_passes,
-                                               debug=intermediate_debug_info)
+    args = options.binaryen_passes
     if use_source_map(options):
-      cmd += ['--input-source-map=' + wasm_source_map_target]
-      cmd += ['--output-source-map=' + wasm_source_map_target]
-      cmd += ['--output-source-map-url=' + options.source_map_base + os.path.basename(wasm_binary_target) + '.map']
+      args += ['--input-source-map=' + wasm_source_map_target]
+      args += ['--output-source-map=' + wasm_source_map_target]
+      args += ['--output-source-map-url=' + options.source_map_base + os.path.basename(wasm_binary_target) + '.map']
       if DEBUG:
         shared.safe_copy(wasm_source_map_target, os.path.join(shared.get_emscripten_temp_dir(), os.path.basename(wasm_source_map_target) + '.pre-byn'))
-    logger.debug('wasm-opt on binaryen passes: %s', cmd)
-    shared.print_compiler_stage(cmd)
-    shared.check_call(cmd)
+    shared.Building.run_wasm_opt(wasm_binary_target,
+                                 wasm_binary_target,
+                                 args=args,
+                                 debug=intermediate_debug_info)
   if shared.Settings.BINARYEN_SCRIPTS:
     binaryen_scripts = os.path.join(shared.BINARYEN_ROOT, 'scripts')
     script_env = os.environ.copy()

--- a/emscripten.py
+++ b/emscripten.py
@@ -2267,15 +2267,9 @@ def remove_trailing_zeros(memfile):
 
 
 def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
-  wasm_emscripten_finalize = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-emscripten-finalize')
-  wasm_dis = os.path.join(shared.Building.get_binaryen_bin(), 'wasm-dis')
-
   def debug_copy(src, dst):
     if DEBUG:
       shutil.copyfile(src, os.path.join(shared.CANONICAL_TEMP_DIR, dst))
-      if src[-2:] == '.o' or src[-5:] == '.wasm':
-        tmp = dst + '.wast'
-        shared.check_call([wasm_dis, src, '-o', os.path.join(shared.CANONICAL_TEMP_DIR, tmp)])
 
   basename = shared.unsuffixed(outfile.name)
   wasm = basename + '.wasm'
@@ -2294,22 +2288,21 @@ def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
     shared.check_call(sourcemap_cmd)
     debug_copy(base_source_map, 'base_wasm.map')
 
-  cmd = [wasm_emscripten_finalize, base_wasm, '-o', wasm]
   # tell binaryen to look at the features section, and if there isn't one, to use MVP
   # (which matches what llvm+lld has given us)
-  cmd += ['--detect-features']
+  args = ['--detect-features']
   if shared.Settings.DEBUG_LEVEL >= 2 or shared.Settings.PROFILING_FUNCS or shared.Settings.EMIT_SYMBOL_MAP or shared.Settings.ASYNCIFY_WHITELIST or shared.Settings.ASYNCIFY_BLACKLIST:
-    cmd.append('-g')
+    args.append('-g')
   if shared.Settings.LEGALIZE_JS_FFI != 1:
-    cmd.append('--no-legalize-javascript-ffi')
+    args.append('--no-legalize-javascript-ffi')
   if write_source_map:
-    cmd.append('--input-source-map=' + base_source_map)
-    cmd.append('--output-source-map=' + wasm + '.map')
-    cmd.append('--output-source-map-url=' + shared.Settings.SOURCE_MAP_BASE + os.path.basename(shared.Settings.WASM_BINARY_FILE) + '.map')
+    args.append('--input-source-map=' + base_source_map)
+    args.append('--output-source-map=' + wasm + '.map')
+    args.append('--output-source-map-url=' + shared.Settings.SOURCE_MAP_BASE + os.path.basename(shared.Settings.WASM_BINARY_FILE) + '.map')
   if not shared.Settings.MEM_INIT_IN_WASM:
-    cmd.append('--separate-data-segments=' + memfile)
+    args.append('--separate-data-segments=' + memfile)
   if shared.Settings.SIDE_MODULE:
-    cmd.append('--side-module')
+    args.append('--side-module')
   else:
     # --global-base is used by wasm-emscripten-finalize to calculate the size
     # of the static data used.  The argument we supply here needs to match the
@@ -2319,15 +2312,18 @@ def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
     # TODO(sbc): Can we remove this argument infer this from the segment
     # initializer?
     if shared.Settings.RELOCATABLE:
-      cmd.append('--global-base=0')
+      args.append('--global-base=0')
     else:
-      cmd.append('--global-base=%s' % shared.Settings.GLOBAL_BASE)
+      args.append('--global-base=%s' % shared.Settings.GLOBAL_BASE)
   if shared.Settings.SAFE_STACK:
-    cmd.append('--check-stack-overflow')
+    args.append('--check-stack-overflow')
   if shared.Settings.STANDALONE_WASM:
-    cmd.append('--standalone-wasm')
-  shared.print_compiler_stage(cmd)
-  stdout = shared.check_call(cmd, stdout=subprocess.PIPE).stdout
+    args.append('--standalone-wasm')
+  stdout = shared.Building.run_binaryen_command('wasm-emscripten-finalize',
+                                                infile=base_wasm,
+                                                outfile=wasm,
+                                                args=args,
+                                                stdout=subprocess.PIPE)
   if write_source_map:
     debug_copy(wasm + '.map', 'post_finalize.map')
   debug_copy(wasm, 'post_finalize.wasm')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2615,12 +2615,12 @@ class Building(object):
     with open(temp, 'w') as f:
       f.write(txt)
     # run wasm-metadce
-    cmd = Building.get_binaryen_command('wasm-metadce',
+    out = Building.run_binaryen_command('wasm-metadce',
                                         wasm_file,
                                         wasm_file,
                                         ['--graph-file=' + temp],
-                                        debug=debug_info)
-    out = run_process(cmd, stdout=PIPE).stdout
+                                        debug=debug_info,
+                                        stdout=PIPE)
     # find the unused things in js
     unused = []
     PREFIX = 'unused: '
@@ -2642,37 +2642,34 @@ class Building(object):
     # create the lazy-loaded wasm. remove the memory segments from it, as memory
     # segments have already been applied by the initial wasm, and apply the knowledge
     # that it will only rewind, after which optimizations can remove some code
-    cmd = Building.get_wasm_opt_command(wasm_binary_target,
-                                        wasm_binary_target + '.lazy.wasm',
-                                        args=['--remove-memory',
-                                              '--mod-asyncify-never-unwind'],
-                                        debug=debug)
+    args = ['--remove-memory', '--mod-asyncify-never-unwind']
     if options.opt_level > 0:
-      cmd.append(Building.opt_level_to_str(options.opt_level, options.shrink_level))
-    print_compiler_stage(cmd)
-    check_call(cmd)
+      args.append(Building.opt_level_to_str(options.opt_level, options.shrink_level))
+    Building.run_wasm_opt(wasm_binary_target,
+                          wasm_binary_target + '.lazy.wasm',
+                          args=args,
+                          debug=debug)
     # re-optimize the original, by applying the knowledge that imports will
     # definitely unwind, and we never rewind, after which optimizations can remove
     # a lot of code
     # TODO: support other asyncify stuff, imports that don't always unwind?
     # TODO: source maps etc.
-    cmd = Building.get_wasm_opt_command(infile=wasm_binary_target,
-                                        outfile=wasm_binary_target,
-                                        args=['--mod-asyncify-always-and-only-unwind'],
-                                        debug=debug)
+    args = ['--mod-asyncify-always-and-only-unwind']
     if options.opt_level > 0:
-      cmd.append(Building.opt_level_to_str(options.opt_level, options.shrink_level))
-    print_compiler_stage(cmd)
-    check_call(cmd)
+      args.append(Building.opt_level_to_str(options.opt_level, options.shrink_level))
+    Building.run_wasm_opt(infile=wasm_binary_target,
+                          outfile=wasm_binary_target,
+                          args=args,
+                          debug=debug)
 
   @staticmethod
   def minify_wasm_imports_and_exports(js_file, wasm_file, minify_whitespace, minify_exports, debug_info):
     logger.debug('minifying wasm imports and exports')
     # run the pass
-    cmd = Building.get_wasm_opt_command(wasm_file, wasm_file,
-                                        ['--minify-imports-and-exports' if minify_exports else '--minify-imports'],
-                                        debug=debug_info)
-    out = check_call(cmd, stdout=PIPE).stdout
+    out = Building.run_wasm_opt(wasm_file, wasm_file,
+                                ['--minify-imports-and-exports' if minify_exports else '--minify-imports'],
+                                debug=debug_info,
+                                stdout=PIPE)
     # get the mapping
     SEP = ' => '
     mapping = {}
@@ -2691,14 +2688,15 @@ class Building(object):
   @staticmethod
   def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compiler, debug_info, symbols_file=None):
     logger.debug('wasm2js')
-    cmd = Building.get_binaryen_command('wasm2js', wasm_file,
-                                        args=['--emscripten'],
-                                        debug=debug_info)
+    args = ['--emscripten']
     if opt_level > 0:
-      cmd += ['-O']
+      args += ['-O']
     if symbols_file:
-      cmd += ['--symbols-file=%s' % symbols_file]
-    wasm2js_js = run_process(cmd, stdout=PIPE).stdout
+      args += ['--symbols-file=%s' % symbols_file]
+    wasm2js_js = Building.run_binaryen_command('wasm2js', wasm_file,
+                                               args=args,
+                                               debug=debug_info,
+                                               stdout=PIPE)
     if DEBUG:
       with open(os.path.join(get_emscripten_temp_dir(), 'wasm2js-output.js'), 'w') as f:
         f.write(wasm2js_js)
@@ -2777,14 +2775,14 @@ class Building(object):
   @staticmethod
   def handle_final_wasm_symbols(wasm_file, symbols_file, debug_info):
     logger.debug('handle_final_wasm_symbols')
-    cmd = Building.get_wasm_opt_command(wasm_file)
+    args = []
     if symbols_file:
-      cmd += ['--print-function-map']
+      args += ['--print-function-map']
     if not debug_info:
       # to remove debug info, we just write to that same file, and without -g
-      cmd += ['-o', wasm_file]
+      args += ['-o', wasm_file]
     # ignore stderr because if wasm-opt is run without a -o it will warn
-    output = run_process(cmd, stdout=PIPE, stderr=PIPE).stdout
+    output = Building.run_wasm_opt(wasm_file, args=args, stdout=PIPE)
     if symbols_file:
       with open(symbols_file, 'w') as f:
         f.write(output)
@@ -2883,7 +2881,7 @@ class Building(object):
     return os.path.join(BINARYEN_ROOT, 'bin')
 
   @staticmethod
-  def get_binaryen_command(tool, infile, outfile=None, args=[], debug=False):
+  def run_binaryen_command(tool, infile, outfile=None, args=[], debug=False, stdout=None):
     cmd = [os.path.join(Building.get_binaryen_bin(), tool)] + args
     if infile:
       cmd += [infile]
@@ -2892,11 +2890,15 @@ class Building(object):
     if debug:
       cmd += ['-g'] # preserve the debug info
     cmd += Building.get_binaryen_feature_flags()
-    return cmd
+    print_compiler_stage(cmd)
+    if stdout is not None:
+      return run_process(cmd, stdout=stdout).stdout
+    else:
+      run_process(cmd)
 
   @staticmethod
-  def get_wasm_opt_command(*args, **kwargs):
-    return Building.get_binaryen_command('wasm-opt', *args, **kwargs)
+  def run_wasm_opt(*args, **kwargs):
+    return Building.run_binaryen_command('wasm-opt', *args, **kwargs)
 
 
 # compatibility with existing emcc, etc. scripts

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2889,7 +2889,9 @@ class Building(object):
       cmd += ['-o', outfile]
     if debug:
       cmd += ['-g'] # preserve the debug info
-    cmd += Building.get_binaryen_feature_flags()
+    # if the features are not already handled, handle them
+    if '--detect-features' not in cmd:
+      cmd += Building.get_binaryen_feature_flags()
     print_compiler_stage(cmd)
     if stdout is not None:
       return run_process(cmd, stdout=stdout).stdout


### PR DESCRIPTION
Replace `get_binaryen_command` with `run_binaryen_command`
which also runs it. That lets it handle more things for us in a central
place, like debug info which I'm working on and this will help in a
subsequent PR.

This also starts to use those methods in calling wasm-emscripten-finalize.
