### PR TITLE
Don’t remove JS event handlers on canvas on deleteContext

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -900,7 +900,6 @@ var LibraryGL = {
 
     deleteContext: function(contextHandle) {
       if (GL.currentContext === GL.contexts[contextHandle]) GL.currentContext = null;
-      if (typeof JSEvents === 'object') JSEvents.removeAllHandlersOnTarget(GL.contexts[contextHandle].GLctx.canvas); // Release all JS event handlers on the DOM element that the GL context is associated with since the context is now deleted.
       if (GL.contexts[contextHandle] && GL.contexts[contextHandle].GLctx.canvas) GL.contexts[contextHandle].GLctx.canvas.GLctxObject = undefined; // Make sure the canvas object no longer refers to the context object so there are no GC surprises.
       _free(GL.contexts[contextHandle]);
       GL.contexts[contextHandle] = null;


### PR DESCRIPTION
We are done with the context, but might want to continue to use the canvas.