### PR TITLE
Fix dlOpen to work in JS strict mode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -434,3 +434,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jonathan Feinberg <feinberg@google.com>
 * Osman Turan <osman@osmanturan.com>
 * Jaikanth J <jaikanthjay46@gmail.com>
+* Gernot Lassnig <gernot.lassnig@gmail.com>

--- a/src/library.js
+++ b/src/library.js
@@ -1695,7 +1695,7 @@ LibraryManager.library = {
     }
 
     try {
-      handle = loadDynamicLibrary(filename, flags)
+      var handle = loadDynamicLibrary(filename, flags)
     } catch (e) {
 #if ASSERTIONS
       err('Error in loading dynamic library ' + filename + ": " + e);


### PR DESCRIPTION
The variable handle is not declared before usage.