### PR TITLE
Fix double-escaped paths on Windows

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -808,8 +808,8 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
 
   # Tests that the given two paths are identical, modulo path delimiters. E.g. "C:/foo" is equal to "C:\foo".
   def assertPathsIdentical(self, path1, path2):
-    path1 = path1.replace('\\', '/').replace('//', '/')
-    path2 = path2.replace('\\', '/').replace('//', '/')
+    path1 = path1.replace('\\', '/')
+    path2 = path2.replace('\\', '/')
     return self.assertIdentical(path1, path2)
 
   # Tests that the given two multiline text content are identical, modulo line

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -58,7 +58,7 @@ class Prefixes:
     if name in self.cache:
       return self.cache[name]
 
-    result = name
+    result = name.replace('\\', '/').replace('//', '/')
     for p in self.prefixes:
       if name.startswith(p['prefix']):
         if p['replacement'] is None:


### PR DESCRIPTION
On Windows, paths are using `\`, which is escaped to `\\` by llvm-dwarfdump in its output.

We need to unescape them before passing to source map encoder, as otherwise we end up with invalid paths and URLs that can't be resolved.

This wasn't caught before, because `assertPathsIdentical` was performing its own unescaping before comparing paths, which is not what happens in real source map consumers.

Fixes #9811.