### PR TITLE
Fix formatting in EM_ASM and EM_ASM_INT macros

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -435,3 +435,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Osman Turan <osman@osmanturan.com>
 * Jaikanth J <jaikanthjay46@gmail.com>
 * Gernot Lassnig <gernot.lassnig@gmail.com>
+* Christian Boos <cboos@bct-technology.com>

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -151,7 +151,9 @@ Defines
 
     EM_ASM(console.log('hello ' + UTF8ToString($0)), "world!");
 
-    In the same manner, pointers to any type (including ``void *``) can be passed inside ``EM_ASM`` code, where they appear as integers like ``char *`` pointers above did. Accessing the data can be managed by reading the heap directly. ::
+  In the same manner, pointers to any type (including ``void *``) can be passed inside ``EM_ASM`` code, where they appear as integers like ``char *`` pointers above did. Accessing the data can be managed by reading the heap directly.
+
+  .. code-block:: none
 
     int arr[2] = { 30, 45 };
     EM_ASM({
@@ -176,7 +178,9 @@ Defines
 
     int y = EM_ASM_INT(return TOTAL_MEMORY);
 
-    Strings can be returned back to C from JavaScript, but one needs to be careful about memory management. ::
+  Strings can be returned back to C from JavaScript, but one needs to be careful about memory management.
+
+  .. code-block:: none
 
     char *str = (char*)EM_ASM_INT({
       var jsString = 'Hello with some exotic Unicode characters: Tässä on yksi lumiukko: ☃, ole hyvä.';

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -166,9 +166,7 @@ Defines
 
 .. c:macro:: EM_ASM_INT(code, ...)
 
-  EM_ASM_DOUBLE(code, ...)
-
-  These two functions behave like EM_ASM, but in addition they also return a value back to C code. The output value is passed back with a ``return`` statement:
+  This macro, as well as the :c:macro:`EM_ASM_DOUBLE` one, behave like :c:macro:`EM_ASM`, but in addition they also return a value back to C code. The output value is passed back with a ``return`` statement:
 
   .. code-block:: none
 
@@ -184,13 +182,19 @@ Defines
 
     char *str = (char*)EM_ASM_INT({
       var jsString = 'Hello with some exotic Unicode characters: Tässä on yksi lumiukko: ☃, ole hyvä.';
-      var lengthBytes = lengthBytesUTF8(jsString)+1; // 'jsString.length' would return the length of the string as UTF-16 units, but Emscripten C strings operate as UTF-8.
+      var lengthBytes = lengthBytesUTF8(jsString)+1;
+      // 'jsString.length' would return the length of the string as UTF-16
+      // units, but Emscripten C strings operate as UTF-8.
       var stringOnWasmHeap = _malloc(lengthBytes);
       stringToUTF8(jsString, stringOnWasmHeap, lengthBytes);
       return stringOnWasmHeap;
     });
     printf("UTF8 string says: %s\n", str);
     free(str); // Each call to _malloc() must be paired with free(), or heap memory will leak!
+
+.. c:macro:: EM_ASM_DOUBLE(code, ...)
+
+  Similar to :c:macro:`EM_ASM_INT` but for a ``double`` return value.
 
 
 Calling JavaScript From C/C++


### PR DESCRIPTION
While reading the docs in https://emscripten.org/docs/api_reference/emscripten.h.html#c.EM_ASM
I noticed that some code blocks needed to be split.
I tested the changes locally with Sphinx 1.8.5 and they seem to work fine.