### PR TITLE
Fix glutReshapeFunc not being called (closes #7133)

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -298,6 +298,8 @@ var LibraryBrowser = {
         document.addEventListener('webkitpointerlockchange', pointerLockChange, false);
         document.addEventListener('mspointerlockchange', pointerLockChange, false);
 
+        window.addEventListener("resize", Browser.updateResizeListeners, true);
+
         if (Module['elementPointerLock']) {
           canvas.addEventListener("click", function(ev) {
             if (!Browser.pointerLock && Module['canvas'].requestPointerLock) {


### PR DESCRIPTION
This fixes the issue in #7133 for me and the reshape function callback is called on resize.

I also added { passive: false } to the mouse event listeners as Chrome is complaining about it.
I also noticed some quite old "requestFullScreen" deprecations, should i remove those methods as well? I would like to cleanup the glut library code a bit.