### PR TITLE
Fix a bug where we called the symbol map code unnecessarily

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3106,7 +3106,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
   # this will also remove debug info if we only kept it around in the intermediate invocations.
   # note that wasm2js handles the symbol map itself (as it manipulates and then
   # replaces the wasm with js)
-  if intermediate_debug_info and not shared.Settings.WASM2JS:
+  if options.emit_symbol_map and not shared.Settings.WASM2JS:
     shared.Building.handle_final_wasm_symbols(wasm_file=wasm_binary_target, symbols_file=symbols_file, debug_info=debug_info)
     save_intermediate_with_wasm('symbolmap', wasm_binary_target)
 


### PR DESCRIPTION
I think what happened is that `intermediate_debug_info` used to
mean the same as "use symbol map". Then we added more uses
for it, like asyncify that also needs debug into in the intermediate
files. And so we ended up calling this code unnecessarily (which
does nothing bad, but wastes time).