### PR TITLE
OpenAL testing improvement

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2214,7 +2214,7 @@ void *getBindBuffer() {
   def test_openal_error(self):
     for args in [
       [],
-      ['-lopenal','-s', 'STRICT'],
+      ['-lopenal', '-s', 'STRICT'],
       ['--closure', '1']
     ]:
       print(args)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2212,7 +2212,11 @@ void *getBindBuffer() {
     self.btest('gl_error.c', expected='1', args=['-s', 'LEGACY_GL_EMULATION=1', '-lGL'])
 
   def test_openal_error(self):
-    for args in [[], ['--closure', '1']]:
+    for args in [
+      [],
+      ['-lopenal','-s', 'STRICT'],
+      ['--closure', '1']
+    ]:
       print(args)
       self.btest('openal_error.c', expected='1', args=args)
 


### PR DESCRIPTION
Followup to #9830, where we noticed that the docs recommend
`-lopenal`. This adds testing of that.