### PR TITLE
Fail with ENOSYS on unsupported socketcalls

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -437,3 +437,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Gernot Lassnig <gernot.lassnig@gmail.com>
 * Christian Boos <cboos@bct-technology.com>
 * Erik Scholz <greenNO@SPAMg-s.xyz>
+* Gergely Nagy <ngg@tresorit.com>

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -75,6 +75,7 @@
   "bind": ["htonl", "htons", "ntohs"],
   "connect": ["htonl", "htons", "ntohs"],
   "socket": ["htonl", "htons", "ntohs"],
+  "socketpair": ["htons", "ntohs"],
   "sleep": ["usleep"],
   "recv": ["htons"],
   "send": ["htons"],

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -720,7 +720,12 @@ var SyscallsLibrary = {
 
         return bytesRead;
       }
-      default: abort('unsupported socketcall syscall ' + call);
+      default: {
+#if SYSCALL_DEBUG
+        err('    (socketcall: ' + call + ')');
+#endif
+        return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
+      }
     }
   },
   __syscall104: function(which, varargs) { // setitimer

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9240,6 +9240,22 @@ ok.
   def test_getprotobyname(self):
     self.do_run(open(path_from_root('tests', 'sockets', 'test_getprotobyname.c')).read(), 'success')
 
+  def test_socketpair(self):
+    self.do_run(r'''
+      #include <sys/socket.h>
+      #include <stdio.h>
+      int main() {
+        int fd[2];
+        int err;
+        err = socketpair(AF_INET, SOCK_STREAM, 0, fd);
+        if (err != 0) {
+          perror("socketpair error");
+          return 1;
+        }
+        puts("unexpected success.");
+      }
+    ''', 'socketpair error: Function not implemented', assert_returncode=None)
+
   def test_link(self):
     self.do_run(r'''
 #include <netdb.h>


### PR DESCRIPTION
There are some socketcalls that musl can call and are not handled
(for example socketpair). These currently abort the program instead of
returning an error code.