### PR TITLE
Don't automatically add archive indexes in STRICT mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -477,11 +477,14 @@ def do_emscripten(infile, memfile):
 
 
 def ensure_archive_index(archive_file):
-  # Fastcomp linking works without archive indexes
-  if not shared.Settings.WASM_BACKEND:
+  # Fastcomp linking works without archive indexes.
+  if not shared.Settings.WASM_BACKEND or not shared.Settings.AUTO_ARCHIVE_INDEXES:
     return
   stdout = run_process([shared.LLVM_NM, '--print-armap', archive_file], stdout=PIPE).stdout
   stdout = stdout.strip()
+  # Ignore empty archives
+  if not stdout:
+    return
   if stdout.startswith('Archive map\n') or stdout.startswith('Archive index\n'):
     return
   shared.warning('%s: archive is missing an index; Use emar when creating libraries to ensure an index is created', archive_file)
@@ -1115,6 +1118,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1
       shared.Settings.STRICT_JS = 1
       shared.Settings.AUTO_JS_LIBRARIES = 0
+      shared.Settings.AUTO_ARCHIVE_INDEXES = 0
 
     if AUTODEBUG:
       shared.Settings.AUTODEBUG = 1

--- a/src/settings.js
+++ b/src/settings.js
@@ -847,8 +847,16 @@ var LINKABLE = 0;
 //     is the correct thing to use).
 //   * STRICT_JS is enabled.
 //   * AUTO_JS_LIBRARIES is disabled.
+//   * AUTO_ARCHIVE_INDEXES is disabled.
 // [compile+link]
 var STRICT = 0;
+
+// Automatically attempt to add archive indexes at link time to archives that 
+// don't already have them.  This can heppen when GNU ar or GNU ranlib is used
+// rather than `llvm-ar` or `emar` since the former don't understand the wasm
+// object format.
+// [link]
+var AUTO_ARCHIVE_INDEXES = 1;
 
 // Add "use strict;" to generated JS
 var STRICT_JS = 0;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8633,7 +8633,7 @@ end
     run_process([PYTHON, EMAR, 'cr', 'file1.a', 'file1', 'file1'])
 
   def test_archive_empty(self):
-    # This test added because we had an issue with the AUTO_ARCHIVE_INDEXES failing on empty 
+    # This test added because we had an issue with the AUTO_ARCHIVE_INDEXES failing on empty
     # archives (which inherently don't have indexes).
     run_process([PYTHON, EMAR, 'crS', 'libfoo.a'])
     run_process([PYTHON, EMCC, '-Werror', 'libfoo.a', path_from_root('tests', 'hello_world.c')])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8634,7 +8634,7 @@ end
 
   def test_archive_empty(self):
     # This test added because we had an issue with the AUTO_ARCHIVE_INDEXES failing on empty 
-    # archives (which inherantly don't have indexes).
+    # archives (which inherently don't have indexes).
     run_process([PYTHON, EMAR, 'crS', 'libfoo.a'])
     run_process([PYTHON, EMCC, '-Werror', 'libfoo.a', path_from_root('tests', 'hello_world.c')])
 
@@ -8650,7 +8650,7 @@ end
     if self.is_wasm_backend():
       stderr = self.expect_fail([PYTHON, EMCC, '-s', 'NO_AUTO_ARCHIVE_INDEXES', 'libfoo.a', 'hello_world.o'])
       self.assertContained('libfoo.a: archive has no index; run ranlib to add one', stderr)
-    # The default bahviour is to add archive indexes automatically.
+    # The default behavior is to add archive indexes automatically.
     run_process([PYTHON, EMCC, 'libfoo.a', 'hello_world.o'])
 
   def test_flag_aliases(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8632,12 +8632,25 @@ end
     create_test_file('file1', ' ')
     run_process([PYTHON, EMAR, 'cr', 'file1.a', 'file1', 'file1'])
 
+  def test_archive_empty(self):
+    # This test added because we had an issue with the AUTO_ARCHIVE_INDEXES failing on empty 
+    # archives (which inherantly don't have indexes).
+    run_process([PYTHON, EMAR, 'crS', 'libfoo.a'])
+    run_process([PYTHON, EMCC, '-Werror', 'libfoo.a', path_from_root('tests', 'hello_world.c')])
+
   def test_archive_no_index(self):
     create_test_file('foo.c', 'int foo = 1;')
     run_process([PYTHON, EMCC, '-c', 'foo.c'])
     run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')])
     # The `S` flag means don't add an archive index
     run_process([PYTHON, EMAR, 'crS', 'libfoo.a', 'foo.o'])
+    # The llvm backend (link GNU ld and lld) doesn't support linking archives with no index.
+    # However we have logic that will automatically add indexes (unless running with
+    # NO_AUTO_ARCHIVE_INDEXES).
+    if self.is_wasm_backend():
+      stderr = self.expect_fail([PYTHON, EMCC, '-s', 'NO_AUTO_ARCHIVE_INDEXES', 'libfoo.a', 'hello_world.o'])
+      self.assertContained('libfoo.a: archive has no index; run ranlib to add one', stderr)
+    # The default bahviour is to add archive indexes automatically.
     run_process([PYTHON, EMCC, 'libfoo.a', 'hello_world.o'])
 
   def test_flag_aliases(self):


### PR DESCRIPTION
Also, don't misclassify empty archives as archives that need to have
an index added.