### PR TITLE
Compile and copy all vorbis libraries, fixes #7879

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -437,3 +437,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Gernot Lassnig <gernot.lassnig@gmail.com>
 * Christian Boos <cboos@bct-technology.com>
 * Erik Scholz <greenNO@SPAMg-s.xyz>
+* Michael de Lang <kingoipo@gmail.com>

--- a/embuilder.py
+++ b/embuilder.py
@@ -240,7 +240,7 @@ def main():
     elif what == 'sdl2-net':
       build_port('sdl2-net', libname('libSDL2_net'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'])
     elif what == 'sdl2-mixer':
-      build_port('sdl2-mixer', 'libSDL2_mixer.a', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'USE_VORBIS=1'])
+      build_port('sdl2-mixer', libname('libSDL2_mixer'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'USE_VORBIS=1'])
     elif what == 'freetype':
       build_port('freetype', 'libfreetype.a', ['-s', 'USE_FREETYPE=1'])
     elif what == 'harfbuzz':

--- a/tests/sdl2_mixer.c
+++ b/tests/sdl2_mixer.c
@@ -37,6 +37,7 @@ int main(int argc, char* argv[]){
         return -1;
     if (Mix_PlayChannel(-1, wave, 0) == -1)
         return -1;
+    // Ensure that the test gives an error if OGG support was not compiled into SDL2_Mixer. See #7879
     if (Mix_Init(MIX_INIT_OGG) == -1)
         return -1;
     printf("Starting sound play loop\n");

--- a/tests/sdl2_mixer.c
+++ b/tests/sdl2_mixer.c
@@ -37,6 +37,8 @@ int main(int argc, char* argv[]){
         return -1;
     if (Mix_PlayChannel(-1, wave, 0) == -1)
         return -1;
+    if (Mix_Init(MIX_INIT_OGG) == -1)
+        return -1;
     printf("Starting sound play loop\n");
     emscripten_set_main_loop(sound_loop_then_quit, 0, 1);
     return 0;

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -35,7 +35,7 @@ def get(ports, settings, shared):
     commands = []
     o_s = []
     o = os.path.join(ports.get_build_dir(), 'boost_headers', 'dummy.cpp.o')
-    command = [shared.PYTHON, shared.EMCC, os.path.join(ports.get_build_dir(), 'boost_headers', 'dummy.cpp'), '-o', o]
+    command = [shared.PYTHON, shared.EMCC, '-c', os.path.join(ports.get_build_dir(), 'boost_headers', 'dummy.cpp'), '-o', o]
     commands.append(command)
     ports.run_commands(commands)
     final = os.path.join(ports.get_build_dir(), 'boost_headers', libname)

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -37,7 +37,7 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'bzip2', src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.PYTHON, shared.EMCC, os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w', ])
+      commands.append([shared.PYTHON, shared.EMCC, '-c', os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w', ])
       o_s.append(o)
     ports.run_commands(commands)
 

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -41,6 +41,7 @@ def get(ports, settings, shared):
       shared.safe_ensure_dirs(os.path.dirname(o))
       command = [shared.PYTHON,
                  shared.EMCC,
+                 '-c',
                  os.path.join(cocos2dx_root, 'proj.emscripten', src),
                  '-Wno-overloaded-virtual',
                  '-Wno-deprecated-declarations',

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -120,7 +120,7 @@ def get(ports, settings, shared):
       c = os.path.join(dest_path_src, src)
       o = os.path.join(dest_path_src, src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.PYTHON, shared.EMCC, c,
+      commands.append([shared.PYTHON, shared.EMCC, '-c', c,
                        # specify the defined symbols as the Regal Makefiles does for Emscripten+Release
                        # the define logic for other symbols will be handled automatically by Regal headers (SYS_EMSCRIPTEN, SYS_EGL, SYS_ES2, etc.)
                        '-DNDEBUG',

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -49,7 +49,7 @@ def get(ports, settings, shared):
 
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2_image', src + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'] + defs)
+      commands.append([shared.PYTHON, shared.EMCC, '-c', os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'] + defs)
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -28,6 +28,8 @@ def get(ports, settings, shared):
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
+    # necessary for proper including of SDL_mixer.h
+    os.symlink(dest_path, os.path.join(dest_path, 'SDL2'))
 
     final = os.path.join(dest_path, libname)
     ports.build_port(dest_path, final, [], ['-DOGG_MUSIC', '-s', 'USE_VORBIS=1'],

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -28,15 +28,16 @@ def get(ports, settings, shared):
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
-    os.symlink(dest_path, os.path.join(dest_path, 'SDL2'))
 
     final = os.path.join(dest_path, libname)
-    ports.build_port(os.path.join(dest_path, 'src'), final, [], ['-DOGG_MUSIC'], ['dynamic_flac', 'dynamic_fluidsynth', 'dynamic_mod', 'dynamic_modplug',
-                                                                                  'dynamic_mp3', 'dynamic_ogg', 'fluidsynth', 'load_mp3', 'music_cmd',
-                                                                                  'music_flac', 'music_mad', 'music_mod', 'music_modplug'])
+    ports.build_port(dest_path, final, [], ['-DOGG_MUSIC', '-s', 'USE_VORBIS=1'],
+                     ['dynamic_flac', 'dynamic_fluidsynth', 'dynamic_mod', 'dynamic_modplug', 'dynamic_mp3',
+                      'dynamic_ogg', 'fluidsynth', 'load_mp3', 'music_cmd', 'music_flac', 'music_mad', 'music_mod',
+                      'music_modplug', 'playmus.c', 'playwave.c'],
+                     ['external', 'native_midi'])
     return final
 
-  return [shared.Cache.get(libname, create)]
+  return [shared.Cache.get(libname, create, what='port')]
 
 
 def clear(ports, shared):

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -1,6 +1,11 @@
+# Copyright 2016 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
 import os
 import shutil
-import stat
+import logging
 
 TAG = 'release-2.0.1'
 HASH = '81fac757bd058adcb3eb5b2cc46addeaa44cee2cd4db653dad5d9666bdc0385cdc21bf5b72872e6dd6dd8eb65812a46d7752298827d6c61ad5ce2b6c963f7ed0'
@@ -13,29 +18,25 @@ def get(ports, settings, shared):
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_mixer'
   ports.fetch_project('sdl2_mixer', 'https://github.com/emscripten-ports/SDL2_mixer/archive/' + TAG + '.zip', 'SDL2_mixer-' + TAG, sha512hash=HASH)
+  libname = ports.get_lib_name('libSDL2_mixer')
 
   def create():
-    cwd = os.getcwd()
-    commonflags = ['--disable-shared', '--disable-music-cmd', '--enable-sdltest', '--disable-smpegtest']
-    formatflags = ['--enable-music-wave', '--disable-music-mod', '--disable-music-midi', '--enable-music-ogg', '--disable-music-ogg-shared', '--disable-music-flac', '--disable-music-mp3']
-    configure = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL2_mixer-' + TAG, 'configure')
-    build_dir = os.path.join(ports.get_build_dir(), 'sdl2_mixer')
-    dist_dir = os.path.join(ports.get_build_dir(), 'sdl2_mixer', 'dist')
-    out = os.path.join(dist_dir, 'lib', 'libSDL2_mixer.a')
-    final = os.path.join(ports.get_build_dir(), 'sdl2_mixer', 'libSDL2_mixer.a')
-    shared.safe_ensure_dirs(build_dir)
+    logging.info('building port: sdl2_mixer')
 
-    try:
-      os.chdir(build_dir)
-      os.chmod(configure, os.stat(configure).st_mode | stat.S_IEXEC)
-      shared.run_process([shared.PYTHON, shared.EMCONFIGURE, configure, '--prefix=' + dist_dir] + formatflags + commonflags + ['CFLAGS=-s USE_VORBIS=1'])
-      shared.run_process([shared.PYTHON, shared.EMMAKE, 'make', 'install'])
-      shutil.copyfile(out, final)
-    finally:
-      os.chdir(cwd)
+    source_path = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL2_mixer-' + TAG)
+    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_mixer')
+
+    shutil.rmtree(dest_path, ignore_errors=True)
+    shutil.copytree(source_path, dest_path)
+    os.symlink(dest_path, os.path.join(dest_path, 'SDL2'))
+
+    final = os.path.join(dest_path, libname)
+    ports.build_port(os.path.join(dest_path, 'src'), final, [], ['-DOGG_MUSIC'], ['dynamic_flac', 'dynamic_fluidsynth', 'dynamic_mod', 'dynamic_modplug', 'dynamic_mp3',
+                                                                     'dynamic_ogg', 'fluidsynth', 'load_mp3', 'music_cmd', 'music_flac', 'music_mad',
+                                                                     'music_mod', 'music_modplug'])
     return final
 
-  return [shared.Cache.get('libSDL2_mixer.a', create, what='port')]
+  return [shared.Cache.get(libname, create)]
 
 
 def clear(ports, shared):
@@ -51,7 +52,7 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_SDL_MIXER == 2:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_mixer', 'dist', 'include')]
+    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_mixer')]
   return args
 
 

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -36,7 +36,7 @@ def get(ports, settings, shared):
                      ['dynamic_flac', 'dynamic_fluidsynth', 'dynamic_mod', 'dynamic_modplug', 'dynamic_mp3',
                       'dynamic_ogg', 'fluidsynth', 'load_mp3', 'music_cmd', 'music_flac', 'music_mad', 'music_mod',
                       'music_modplug', 'playmus.c', 'playwave.c'],
-                     ['external', 'native_midi'])
+                     ['external', 'native_midi', 'timidity'])
     return final
 
   return [shared.Cache.get(libname, create, what='port')]

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -31,9 +31,9 @@ def get(ports, settings, shared):
     os.symlink(dest_path, os.path.join(dest_path, 'SDL2'))
 
     final = os.path.join(dest_path, libname)
-    ports.build_port(os.path.join(dest_path, 'src'), final, [], ['-DOGG_MUSIC'], ['dynamic_flac', 'dynamic_fluidsynth', 'dynamic_mod', 'dynamic_modplug', 'dynamic_mp3',
-                                                                     'dynamic_ogg', 'fluidsynth', 'load_mp3', 'music_cmd', 'music_flac', 'music_mad',
-                                                                     'music_mod', 'music_modplug'])
+    ports.build_port(os.path.join(dest_path, 'src'), final, [], ['-DOGG_MUSIC'], ['dynamic_flac', 'dynamic_fluidsynth', 'dynamic_mod', 'dynamic_modplug',
+                                                                                  'dynamic_mp3', 'dynamic_ogg', 'fluidsynth', 'load_mp3', 'music_cmd',
+                                                                                  'music_flac', 'music_mad', 'music_mod', 'music_modplug'])
     return final
 
   return [shared.Cache.get(libname, create)]

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -7,7 +7,6 @@ import os
 import shutil
 import logging
 
-
 TAG = 'version_2'
 HASH = '317b22ad9b6b2f7b40fac7b7c426da2fa2da1803bbe58d480631f1e5b190d730763f2768c77c72affa806c69a1e703f401b15a1be3ec611cd259950d5ebc3711'
 

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -33,7 +33,7 @@ def get(ports, settings, shared):
     o_s = []
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2_net', src + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'])
+      commands.append([shared.PYTHON, shared.EMCC, '-c', os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'])
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -31,7 +31,7 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2_ttf', src + '.o')
       command = [shared.PYTHON, shared.EMCC]
-      command += [os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL2_ttf-' + TAG, src)]
+      command += ['-c', os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL2_ttf-' + TAG, src)]
       command += ['-O2', '-s', 'USE_SDL=2', '-s', 'USE_FREETYPE=1', '-o', o, '-w']
       commands.append(command)
       o_s.append(o)

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -34,13 +34,18 @@ def get(ports, settings, shared):
         create.recreated_tree = True
 
       final = os.path.join(dest_path, library)
-      excluded_files = ['psytune', 'barkmel', 'tone', 'misc']
-      if library == lib_name_file or library == lib_name:
-        excluded_files.append('vorbisenc')
-      if library == lib_name_enc or library == lib_name:
-        excluded_files.append('vorbisfile')
-      ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
-                       ['-s', 'USE_OGG=1'], excluded_files)
+
+      if library == lib_name:
+        excluded_files = ['psytune', 'barkmel', 'tone', 'misc']
+        ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
+                         ['-s', 'USE_OGG=1'], excluded_files)
+      if library == lib_name_file:
+        ports.build_port(os.path.join(dest_path, 'lib', 'vorbisfile.c'), final, [os.path.join(dest_path, 'include')],
+                         ['-s', 'USE_OGG=1'])
+      if library == lib_name_enc:
+        ports.build_port(os.path.join(dest_path, 'lib', 'vorbisenc.c'), final, [os.path.join(dest_path, 'include')],
+                         ['-s', 'USE_OGG=1'])
+
       return final
     return internal_create
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -16,9 +16,9 @@ def get(ports, settings, shared):
     return []
 
   ports.fetch_project('vorbis', 'https://github.com/emscripten-ports/vorbis/archive/' + TAG + '.zip', 'Vorbis-' + TAG, sha512hash=HASH)
-  libname = ports.get_lib_name('libvorbis')
-  libnamefile = ports.get_lib_name('libvorbisfile')
-  libnameenc = ports.get_lib_name('libvorbisenc')
+  lib_name = ports.get_lib_name('libvorbis')
+  lib_name_file = ports.get_lib_name('libvorbisfile')
+  lib_name_enc = ports.get_lib_name('libvorbisenc')
 
   def create(library):
     def internal_create():
@@ -35,9 +35,9 @@ def get(ports, settings, shared):
 
       final = os.path.join(dest_path, library)
       excluded_files = ['psytune', 'barkmel', 'tone', 'misc']
-      if library == libnamefile or library == libname:
+      if library == lib_name_file or library == lib_name:
         excluded_files.append('vorbisenc')
-      if library == libnameenc or library == libname:
+      if library == lib_name_enc or library == lib_name:
         excluded_files.append('vorbisfile')
       ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
                        ['-s', 'USE_OGG=1'], excluded_files)
@@ -45,7 +45,7 @@ def get(ports, settings, shared):
     return internal_create
 
   create.recreated_tree = False
-  return [shared.Cache.get(libname, create(libname)), shared.Cache.get(libnamefile, create(libnamefile)), shared.Cache.get(libnameenc, create(libnameenc))]
+  return [shared.Cache.get(lib_name, create(lib_name)), shared.Cache.get(lib_name_file, create(lib_name_file)), shared.Cache.get(lib_name_enc, create(lib_name_enc))]
 
 
 def clear(ports, shared):

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -29,7 +29,7 @@ def get(ports, settings, shared):
 
       if not create.recreated_tree:
         logging.info('recreating tree %s %s %s' % (library, source_path, dest_path))
-        shutil.rmtree(dest_path, onerror=lambda func, path, info: logging.info('rmtree error %s %s' % (path, info)))
+        shutil.rmtree(dest_path, ignore_errors=True)
         shutil.copytree(source_path, dest_path)
         create.recreated_tree = True
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -16,41 +16,23 @@ def get(ports, settings, shared):
     return []
 
   ports.fetch_project('vorbis', 'https://github.com/emscripten-ports/vorbis/archive/' + TAG + '.zip', 'Vorbis-' + TAG, sha512hash=HASH)
-  lib_name = ports.get_lib_name('libvorbis')
-  lib_name_file = ports.get_lib_name('libvorbisfile')
-  lib_name_enc = ports.get_lib_name('libvorbisenc')
+  libname = ports.get_lib_name('libvorbis')
 
-  def create(library):
-    def internal_create():
-      logging.info('building port: vorbis')
+  def create():
+    logging.info('building port: vorbis')
 
-      source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
-      dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'vorbis')
+    source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
+    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'vorbis')
 
-      if not create.recreated_tree:
-        logging.info('recreating tree %s %s %s' % (library, source_path, dest_path))
-        shutil.rmtree(dest_path, ignore_errors=True)
-        shutil.copytree(source_path, dest_path)
-        create.recreated_tree = True
+    shutil.rmtree(dest_path, ignore_errors=True)
+    shutil.copytree(source_path, dest_path)
 
-      final = os.path.join(dest_path, library)
+    final = os.path.join(dest_path, libname)
+    ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
+                     ['-s', 'USE_OGG=1'], ['psytune', 'barkmel', 'tone', 'misc'])
+    return final
 
-      if library == lib_name:
-        excluded_files = ['psytune', 'barkmel', 'tone', 'misc']
-        ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
-                         ['-s', 'USE_OGG=1'], excluded_files)
-      if library == lib_name_file:
-        ports.build_port(os.path.join(dest_path, 'lib', 'vorbisfile.c'), final, [os.path.join(dest_path, 'include')],
-                         ['-s', 'USE_OGG=1'])
-      if library == lib_name_enc:
-        ports.build_port(os.path.join(dest_path, 'lib', 'vorbisenc.c'), final, [os.path.join(dest_path, 'include')],
-                         ['-s', 'USE_OGG=1'])
-
-      return final
-    return internal_create
-
-  create.recreated_tree = False
-  return [shared.Cache.get(lib_name, create(lib_name)), shared.Cache.get(lib_name_file, create(lib_name_file)), shared.Cache.get(lib_name_enc, create(lib_name_enc))]
+  return [shared.Cache.get(libname, create)]
 
 
 def clear(ports, shared):
@@ -65,7 +47,7 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_VORBIS == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'vorbis', 'include')]
+    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_mixer', 'include')]
   return args
 
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -47,7 +47,7 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_VORBIS == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_mixer', 'include')]
+    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'vorbis', 'include')]
   return args
 
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1494,20 +1494,14 @@ class Ports(object):
   @staticmethod
   def build_port(src_path, output_path, includes=[], flags=[], exclude_files=[], exclude_dirs=[]):
     srcs = []
-    include_commands = []
-    if os.path.isfile(src_path):
-      srcs = [src_path]
-      include_commands = ['-I' + os.path.dirname(src_path)]
-    else:
-      include_commands = ['-I' + src_path]
-      for root, dirs, files in os.walk(src_path, topdown=False):
-        if any((excluded in root) for excluded in exclude_dirs):
-          continue
-        for f in files:
-          ext = os.path.splitext(f)[1]
-          if ext in ('.c', '.cpp') and not any((excluded in f) for excluded in exclude_files):
-              srcs.append(os.path.join(root, f))
-
+    for root, dirs, files in os.walk(src_path, topdown=False):
+      if any((excluded in root) for excluded in exclude_dirs):
+        continue
+      for f in files:
+        ext = os.path.splitext(f)[1]
+        if ext in ('.c', '.cpp') and not any((excluded in f) for excluded in exclude_files):
+          srcs.append(os.path.join(root, f))
+    include_commands = ['-I' + src_path]
     for include in includes:
       include_commands.append('-I' + include)
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1494,14 +1494,20 @@ class Ports(object):
   @staticmethod
   def build_port(src_path, output_path, includes=[], flags=[], exclude_files=[], exclude_dirs=[]):
     srcs = []
-    for root, dirs, files in os.walk(src_path, topdown=False):
-      if any((excluded in root) for excluded in exclude_dirs):
-        continue
-      for f in files:
-        ext = os.path.splitext(f)[1]
-        if ext in ('.c', '.cpp') and not any((excluded in f) for excluded in exclude_files):
-            srcs.append(os.path.join(root, f))
-    include_commands = ['-I' + src_path]
+    include_commands = []
+    if os.path.isfile(src_path):
+      srcs = [src_path]
+      include_commands = ['-I' + os.path.dirname(src_path)]
+    else:
+      include_commands = ['-I' + src_path]
+      for root, dirs, files in os.walk(src_path, topdown=False):
+        if any((excluded in root) for excluded in exclude_dirs):
+          continue
+        for f in files:
+          ext = os.path.splitext(f)[1]
+          if ext in ('.c', '.cpp') and not any((excluded in f) for excluded in exclude_files):
+              srcs.append(os.path.join(root, f))
+
     for include in includes:
       include_commands.append('-I' + include)
 


### PR DESCRIPTION
Vorbis actually consists of three libraries: vorbis.a, vorbisfile.a and vorbisenc.a.

This pull request modifies the vorbis port to build and cache these files.

Fixes #7879