### PR TITLE
Fix legalization of i64 return values in JS.legalize_sig.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3896,12 +3896,19 @@ ok
       int64_t testAdd(int64_t a) {
         return a + 1;
       }
+      int64_t testAddB(int a) {
+        return a + 1;
+      }
       typedef int64_t (*testAddHandler)(int64_t);
       testAddHandler h = &testAdd;
+      typedef int64_t (*testAddBHandler)(int);
+      testAddBHandler hb = &testAddB;
       int main() {
         printf("other says %lld.\n", sidey());
         int64_t r = h(42);
         printf("my fp says: %lld.\n", r);
+        int64_t rb = hb(42);
+        printf("my second fp says: %lld.\n", r);
       }
     ''', '''
       #include <stdint.h>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3918,7 +3918,7 @@ ok
         x = 18 - x;
         return x;
       }
-    ''', 'other says -1311768467750121224.\nmy fp says: 43.')
+    ''', 'other says -1311768467750121224.\nmy fp says: 43.\nmy second fp says: 43.')
 
   @needs_dlfcn
   def test_dylink_class(self):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3015,17 +3015,19 @@ class JS(object):
 
   @staticmethod
   def legalize_sig(sig):
+    legal = [sig[0]]
     # a return of i64 is legalized into an i32 (and the high bits are
     # accessible on the side through getTempRet0).
-    ret = ['i' if sig[0] == 'j' else sig[0]]
+    if legal[0] == 'j':
+      legal[0] = 'i'
     # a parameter of i64 is legalized into i32, i32
     for s in sig[1:]:
       if s != 'j':
-        ret.append(s)
+        legal.append(s)
       else:
-        ret.append('i')
-        ret.append('i')
-    return ''.join(ret)
+        legal.append('i')
+        legal.append('i')
+    return ''.join(legal)
 
   @staticmethod
   def is_legal_sig(sig):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3015,12 +3015,14 @@ class JS(object):
 
   @staticmethod
   def legalize_sig(sig):
-    ret = [sig[0]]
+    # a return of i64 is legalized into an i32 (and the high bits are
+    # accessible on the side through getTempRet0).
+    ret = ['i' if sig[0] == 'j' else sig[0]]
+    # a parameter of i64 is legalized into i32, i32
     for s in sig[1:]:
       if s != 'j':
         ret.append(s)
       else:
-        # an i64 is legalized into i32, i32
         ret.append('i')
         ret.append('i')
     return ''.join(ret)


### PR DESCRIPTION
#9810 mostly fixed i64 pointers in MAIN_MODULE, but it
turns out that a corner case was a function that is illegal
only due to its return value.

fixes #9850
