### PR TITLE
Add new Fibers context-switching API

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1440,7 +1440,7 @@ Functions
     this one as the first argument to `emscripten_fiber_swap`. This will
     complete the continuation, allowing you to switch back to it later.
 
-.. c:function:: void emscripten_fiber_free(emscripten_fiber fiber)
+.. c:function:: void emscripten_fiber_destroy(emscripten_fiber fiber)
 
     Frees memory and any JS-side bookkeeping associated with `fiber`. This does
     not free the stack, that is your responsibility. It also does not "stop" or
@@ -1463,7 +1463,7 @@ Functions
     Re-initializes a fiber with a new entry point. The stack space is reused,
     and the stack pointer is reset to the base of the stack.
 
-    This can be used instead of a `emscripten_fiber_free` /
+    This can be used instead of a `emscripten_fiber_destroy` /
     `emscripten_fiber_create` pair to avoid unnecessary memory reallocations if
     you have a fiber that you no longer need (such as a finished one).
 

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1449,7 +1449,7 @@ Functions
 
 .. c:function:: void emscripten_fiber_swap(emscripten_fiber old_fiber, emscripten_fiber new_fiber)
 
-    Switches the execution context to the one represented by `new_fiber`
+    Switches the execution context to the one represented by `new_fiber`.
 
     `old_fiber` is updated with the current context just before the switch, such
     as that switching back into it via another `emscripten_fiber_swap` would

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1373,10 +1373,6 @@ Typedefs
 
     typedef void (*em_scan_func)(void*, void*)
 
-.. c:type:: emscripten_fiber
-
-    A handle to the structure used by fiber supporting functions.
-
 Functions
 ---------
 
@@ -1413,66 +1409,6 @@ Functions
     not happen at all.
 
   .. note:: This requires building with ``-s ASYNCIFY_LAZY_LOAD_CODE``.
-
-.. c:function:: emscripten_fiber emscripten_fiber_create(em_arg_callback_func func, void *arg, void *stack, int stack_size)
-
-    Creates a new fiber context. Fibers are light cooperative threads of
-    execution that can be used to implement stackful coroutines.
-
-    `func` is the fiber's entry point. It will be called with the argument `arg`
-    in the fiber's context when it's first entered.
-
-    `stack` must point to a pre-allocated memory region that will be used as the
-    fiber's stack. `stack_size` is the size of that region in bytes. `stack`
-    should be aligned to at least 16 bytes.
-
- .. note:: If `func` returns, the entire program will end, as if `main`
-    had returned. To avoid this, you can use `emscripten_fiber_swap` to jump to
-    another fiber.
-
-.. c:function:: emscripten_fiber emscripten_fiber_create_from_current_context()
-
-    Creates a new fiber that represents the current execution context. This is
-    needed in order to switch back from a fiber into the main context.
-
- .. warning:: The fiber returned by this function is incomplete and can not be
-    switched into immediately. You must first switch to another fiber, passing
-    this one as the first argument to `emscripten_fiber_swap`. This will
-    complete the continuation, allowing you to switch back to it later.
-
-.. c:function:: void emscripten_fiber_destroy(emscripten_fiber fiber)
-
-    Frees memory and any JS-side bookkeeping associated with `fiber`. This does
-    not free the stack, that is your responsibility. It also does not "stop" or
-    corrupt a "running" fiber, as the fiber struct essentially only represents
-    a continuation.
-
-.. c:function:: void emscripten_fiber_swap(emscripten_fiber old_fiber, emscripten_fiber new_fiber)
-
-    Switches the execution context to the one represented by `new_fiber`.
-
-    `old_fiber` is partially updated with the current context just before the
-    switch, such as that switching back into it via another
-    `emscripten_fiber_swap` would appear to return from the original
-    `emscripten_fiber_swap`.
-
-    If `old_fiber` == `new_fiber` or any of them is `NULL`, the behavior is
-    undefined.
-
- .. warning:: The swap operation invalidates `new_fiber`'s context. It must be
-    updated with another call to `emscripten_fiber_swap` (this time, with the
-    fiber passed as the `old_fiber` argument) before you can switch into the
-    same fiber instance again. Copying the context completely is currently not
-    supported.
-
-.. c:function:: void emscripten_fiber_recycle(emscripten_fiber fiber, em_arg_callback_func func, void *arg)
-
-    Re-initializes a fiber with a new entry point. The stack space is reused,
-    and the stack pointer is reset to the base of the stack.
-
-    This can be used instead of a `emscripten_fiber_destroy` /
-    `emscripten_fiber_create` pair to avoid unnecessary memory reallocations if
-    you have a fiber that you no longer need (such as a finished one).
 
 
 ABI functions

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1410,7 +1410,6 @@ Functions
 
   .. note:: This requires building with ``-s ASYNCIFY_LAZY_LOAD_CODE``.
 
-
 ABI functions
 =============
 

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1451,12 +1451,19 @@ Functions
 
     Switches the execution context to the one represented by `new_fiber`.
 
-    `old_fiber` is updated with the current context just before the switch, such
-    as that switching back into it via another `emscripten_fiber_swap` would
-    appear to return from the original `emscripten_fiber_swap`.
+    `old_fiber` is partially updated with the current context just before the
+    switch, such as that switching back into it via another
+    `emscripten_fiber_swap` would appear to return from the original
+    `emscripten_fiber_swap`.
 
     If `old_fiber` == `new_fiber` or any of them is `NULL`, the behavior is
     undefined.
+
+ .. warning:: The swap operation invalidates `new_fiber`'s context. It must be
+    updated with another call to `emscripten_fiber_swap` (this time, with the
+    fiber passed as the `old_fiber` argument) before you can switch into the
+    same fiber instance again. Copying the context completely is currently not
+    supported.
 
 .. c:function:: void emscripten_fiber_recycle(emscripten_fiber fiber, em_arg_callback_func func, void *arg)
 

--- a/site/source/docs/api_reference/fiber.h.rst
+++ b/site/source/docs/api_reference/fiber.h.rst
@@ -1,0 +1,102 @@
+.. _fiber-h:
+
+=======
+fiber.h
+=======
+
+`Fibers <https://en.wikipedia.org/wiki/Fiber_(computer_science)>`_ are light, co-operative threads of execution. The `fiber.h <https://github.com/emscripten-core/emscripten/blob/master/system/include/emscripten/fiber.h>`_ header defines a low-level API for manipulating Fibers in Emscripten. Fibers are implemented with :ref:`Asyncify`, so you must link your program with ``-s ASYNCIFY`` if you intend to use them.
+
+Fibers are intended as a building block for asynchronous control flow constructs, such as coroutines. They supersede the legacy coroutine API available in the fastcomp backend. This API is similar to, but distinct from, POSIX `ucontext <https://en.wikipedia.org/wiki/Setcontext>`_.
+
+.. contents:: Table of Contents
+    :local:
+    :depth: 3
+
+API Reference
+=============
+
+Types
+-----
+
+.. c:type:: emscripten_fiber_t
+
+  This structure represents a Fiber context `continuation <https://en.wikipedia.org/wiki/Continuation>`_. The runtime does not keep references to these objects, they only contain information needed to perform the context switch. The switch operation updates some of the contents, however.
+
+  .. c:member:: void *stack_base
+
+    Upper limit of the C stack region. The stack grows down, so this is the initial position of the stack pointer. Must be at least 16-byte aligned.
+
+  .. c:member:: void *stack_limit
+
+    Lower limit of the C stack region. Must be below :c:member:`emscripten_fiber_t.stack_base`.
+
+  .. c:member:: void *stack_ptr
+
+    Current position of the stack pointer. Must be between :c:member:`emscripten_fiber_t.stack_base` and :c:member:`emscripten_fiber_t.stack_limit`.
+
+  .. c:member:: em_arg_callback_func entry
+
+    Entry point. If not NULL, this function will be called when the fiber is switched into. Otherwise, :c:member:`emscripten_fiber_t.asyncify_data` is used to rewind the call stack.
+
+  .. c:member:: void *user_data
+
+    Opaque pointer, passed as-is to :c:member:`emscripten_fiber_t.entry`.
+
+  .. c:member:: asyncify_data_t asyncify_data
+
+    Asyncify data structure. Used to unwind and rewind the call stack when switching fibers.
+
+.. c:type:: asyncify_data_t
+
+  .. c:member:: void *stack_ptr
+
+    Current position of the Asyncify stack pointer.
+
+    The Asyncify stack is distinct from the C stack. It contains the call stack as well as the state of WASM locals. Unlike the C stack, it grows up.
+
+  .. c:member:: void *stack_limit
+
+    Upper limit of the Asyncify stack region.
+
+  .. c:member:: int rewind_id
+
+    Opaque handle to the function that needs to be called in order to rewind the call stack. This value is only meaningful to the runtime.
+
+    .. warning:: Rewind IDs are currently thread-specific. This makes it impossible to resume a fiber that has been started from a different thread.
+
+
+Functions
+---------
+
+.. c:function:: void emscripten_fiber_init(emscripten_fiber_t *fiber, em_arg_callback_func entry_func, void *entry_func_arg, void *c_stack, size_t c_stack_size, void *asyncify_stack, size_t asyncify_stack_size)
+
+  Initializes a fiber context. It can then be entered by calling :c:func:`emscripten_fiber_swap`.
+
+  :param emscripten_fiber_t* fiber: Pointer to the fiber structure.
+  :param em_arg_callback_func entry_func: Entry point function, called when the fiber is entered for the first time.
+  :param void* entry_func_arg: Opaque pointer passed to `entry_func`.
+  :param void* c_stack: Pointer to memory region to use for the C stack. Must be at least 16-byte aligned. This points to the lower bound of the stack, regardless of growth direction.
+  :param size_t c_stack_size: Size of the C stack memory region, in bytes.
+  :param void* asyncify_stack: Pointer to memory region to use for the Asyncify stack. No special alignment requirements.
+  :param size_t asyncify_stack_size: Size of the Asyncify stack memory region, in bytes.
+
+  .. note:: If `entry_func` returns, the entire program will end, as if `main` had returned. To avoid this, you can use :c:func:`emscripten_fiber_swap` to jump to another fiber.
+
+.. c:function:: void emscripten_fiber_init_from_current_context(emscripten_fiber_t *fiber, void *asyncify_stack, size_t asyncify_stack_size)
+
+  Partially initializes a fiber based on the currently active context. This is needed in order to switch back from a fiber into the thread's original context.
+
+  This function sets up :c:member:`emscripten_fiber_t.stack_base` and :c:member:`emscripten_fiber_t.stack_limit` to refer to the current stack boundaries, sets :c:member:`emscripten_fiber_t.entry` to `NULL`, and makes :c:member:`emscripten_fiber_t.asyncify_data` refer to the provided Asyncify stack memory. Other fields are not changed.
+
+  Fibers initialized by this function are not complete. They are only suitable to pass as the first argument to :c:func:`emscripten_fiber_swap`. Doing that completes the continuation, making it possible to switch back to the original context with another :c:func:`emscripten_fiber_swap`, as with a normal fiber.
+
+  :param emscripten_fiber_t* fiber: Pointer to the fiber structure.
+  :param void* asyncify_stack: Pointer to memory region to use for the Asyncify stack. No special alignment requirements.
+  :param size_t asyncify_stack_size: Size of the Asyncify stack memory region, in bytes.
+
+.. c:function:: void emscripten_fiber_swap(emscripten_fiber_t *old_fiber, emscripten_fiber_t *new_fiber)
+
+  Performs a fiber context switch.
+
+  :param emscripten_fiber_t* old_fiber: Fiber representing the current context. It will be partially updated, such as that switching back into it via another call to :c:func:`emscripten_fiber_swap` would appear to return from the original call.
+  :param emscripten_fiber_t* new_fiber: Fiber representing the target context. If the fiber has an entry point, it will be called in the new context and set to `NULL`. Otherwise, :c:member:`emscripten_fiber_t.asyncify_data` is used to rewind the call stack. If the fiber is invalid or incomplete, the behavior is undefined.

--- a/site/source/docs/api_reference/index.rst
+++ b/site/source/docs/api_reference/index.rst
@@ -36,6 +36,9 @@ This section lists Emscripten's public API, organised by header file. At a very 
 - :ref:`vr-h`:
   API for using WebVR from native code.
 
+- :ref:`fiber-h`:
+  API for working with Fibers (co-operative threads)
+
 - :ref:`api-reference-advanced-apis`:
   APIs for advanced users/core developers.
 
@@ -53,6 +56,7 @@ This section lists Emscripten's public API, organised by header file. At a very 
    bind.h
    trace.h
    vr.h
+   fiber.h
    advanced-apis
 
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -228,8 +228,8 @@ mergeInto(LibraryManager.library, {
   emscripten_fiber_recycle: function() {
     throw 'emscripten_fiber_recycle is not implemented for fastcomp ASYNCIFY';
   },
-  emscripten_fiber_free: function() {
-    throw 'emscripten_fiber_free is not implemented for fastcomp ASYNCIFY';
+  emscripten_fiber_destroy: function() {
+    throw 'emscripten_fiber_destroy is not implemented for fastcomp ASYNCIFY';
   },
   emscripten_fiber_swap: function() {
     throw 'emscripten_fiber_swap is not implemented for fastcomp ASYNCIFY';
@@ -569,8 +569,8 @@ mergeInto(LibraryManager.library, {
   emscripten_fiber_recycle: function() {
     throw 'emscripten_fiber_recycle is not implemented for EMTERPRETIFY_ASYNC';
   },
-  emscripten_fiber_free: function() {
-    throw 'emscripten_fiber_free is not implemented for EMTERPRETIFY_ASYNC';
+  emscripten_fiber_destroy: function() {
+    throw 'emscripten_fiber_destroy is not implemented for EMTERPRETIFY_ASYNC';
   },
   emscripten_fiber_swap: function() {
     throw 'emscripten_fiber_swap is not implemented for EMTERPRETIFY_ASYNC';
@@ -972,9 +972,9 @@ mergeInto(LibraryManager.library, {
     };
   },
 
-  emscripten_fiber_free__sig: 'vi',
-  emscripten_fiber_free__deps: ['$Asyncify', '$Fibers', 'free'],
-  emscripten_fiber_free: function(fiber) {
+  emscripten_fiber_destroy__sig: 'vi',
+  emscripten_fiber_destroy__deps: ['$Asyncify', '$Fibers', 'free'],
+  emscripten_fiber_destroy: function(fiber) {
     var asyncifyContext = {{{ makeGetValue('fiber', 0, 'i32') }}};
 
     // this may be undefined when asyncifyContext == 0, or when freeing the 'current' fiber
@@ -1069,8 +1069,8 @@ mergeInto(LibraryManager.library, {
   emscripten_fiber_recycle: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_recycle';
   },
-  emscripten_fiber_free: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_free';
+  emscripten_fiber_destroy: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_destroy';
   },
   emscripten_fiber_swap: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_swap';

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -795,6 +795,7 @@ mergeInto(LibraryManager.library, {
         runAndAbortIfError(Module['_asyncify_stop_rewind']);
         Asyncify.freeData(Asyncify.currData);
         Asyncify.currData = null;
+        noExitRuntime = false;
         // Call all sleep callbacks now that the sleep-resume is all done.
         Asyncify.sleepCallbacks.forEach(function(func) {
           func();
@@ -987,6 +988,8 @@ mergeInto(LibraryManager.library, {
           STACK_BASE = {{{ makeGetValue('f_new', 12, 'i32') }}};
           stack_ptr = {{{ makeGetValue('f_new', 4, 'i32') }}};
           stackRestore(stack_ptr);
+
+          noExitRuntime = false;
           Fibers.continuations[f_new]();
         };
       };

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -696,8 +696,8 @@ mergeInto(LibraryManager.library, {
       // The Asyncify ABI only interprets the first two fields, the rest is for the runtime.
       // We also embed a stack in the same memory region here, right next to the structure.
       // This struct is also defined as asyncify_data_t in emscripten/fiber.h
-      var ptr = _malloc(12 + Asyncify.StackSize);
-      Asyncify.setDataHeader(ptr, ptr + 12, Asyncify.StackSize);
+      var ptr = _malloc({{{ C_STRUCTS.asyncify_data_s.__size__ }}} + Asyncify.StackSize);
+      Asyncify.setDataHeader(ptr, ptr + {{{ C_STRUCTS.asyncify_data_s.__size__ }}}, Asyncify.StackSize);
       Asyncify.setDataRewindFunc(ptr);
       return ptr;
     },

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -935,7 +935,7 @@ mergeInto(LibraryManager.library, {
         Fibers.trampolineRunning = true;
         do {
           var fiber = Fibers.nextFiber;
-          Fibers.nextFiber = null;
+          Fibers.nextFiber = 0;
 #if ASYNCIFY_DEBUG >= 2
           err("ASYNCIFY/FIBER: trampoline jump into fiber", fiber, new Error().stack);
 #endif

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -810,7 +810,6 @@ mergeInto(LibraryManager.library, {
         runAndAbortIfError(Module['_asyncify_stop_rewind']);
         _free(Asyncify.currData);
         Asyncify.currData = null;
-        noExitRuntime = false;
         // Call all sleep callbacks now that the sleep-resume is all done.
         Asyncify.sleepCallbacks.forEach(function(func) {
           func();
@@ -921,8 +920,6 @@ mergeInto(LibraryManager.library, {
 
       stackRestore({{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.stack_ptr,   'i32') }}});
 
-      noExitRuntime = false;
-
       var entryPoint = {{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.entry, 'i32') }}};
 
       if (entryPoint !== 0) {
@@ -1015,7 +1012,6 @@ mergeInto(LibraryManager.library, {
       Asyncify.state = Asyncify.State.Normal;
       Module['_asyncify_stop_rewind']();
       Asyncify.currData = null;
-      noExitRuntime = false;
     }
   },
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -917,6 +917,11 @@ mergeInto(LibraryManager.library, {
     finishContextSwitch: function(newFiber) {
       STACK_BASE = {{{ makeGetValue('newFiber', C_STRUCTS.asyncify_fiber_s.stack_base,  'i32') }}};
       STACK_MAX =  {{{ makeGetValue('newFiber', C_STRUCTS.asyncify_fiber_s.stack_limit, 'i32') }}};
+
+#if WASM_BACKEND && STACK_OVERFLOW_CHECK >= 2
+      Module['___set_stack_limit'](STACK_MAX);
+#endif
+
       stackRestore({{{ makeGetValue('newFiber', C_STRUCTS.asyncify_fiber_s.stack_ptr,   'i32') }}});
 
       noExitRuntime = false;

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -730,10 +730,6 @@ mergeInto(LibraryManager.library, {
       return func;
     },
 
-    freeData: function(ptr) {
-      _free(ptr);
-    },
-
     handleSleep: function(startAsync) {
       if (ABORT) return;
       noExitRuntime = true;
@@ -812,7 +808,7 @@ mergeInto(LibraryManager.library, {
 #endif
         Asyncify.state = Asyncify.State.Normal;
         runAndAbortIfError(Module['_asyncify_stop_rewind']);
-        Asyncify.freeData(Asyncify.currData);
+        _free(Asyncify.currData);
         Asyncify.currData = null;
         noExitRuntime = false;
         // Call all sleep callbacks now that the sleep-resume is all done.

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -692,6 +692,10 @@ mergeInto(LibraryManager.library, {
       //  0  current stack pos
       //  4  max stack pos
       //  8  id of function at bottom of the call stack (callStackIdToFunc[id] == js function)
+      //
+      // The Asyncify ABI only interprets the first two fields, the rest is for the runtime.
+      // We also embed a stack in the same memory region here, right next to the structure.
+      // This struct is also defined as asyncify_data_t in emscripten/fiber.h
       var ptr = _malloc(12 + Asyncify.StackSize);
       Asyncify.setDataHeader(ptr, ptr + 12, Asyncify.StackSize);
       Asyncify.setDataRewindFunc(ptr);

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -219,17 +219,11 @@ mergeInto(LibraryManager.library, {
     );
   },
 
-  emscripten_fiber_create: function() {
-    throw 'emscripten_fiber_create is not implemented for fastcomp ASYNCIFY';
+  emscripten_fiber_init: function() {
+    throw 'emscripten_fiber_init is not implemented for fastcomp ASYNCIFY';
   },
-  emscripten_fiber_create_from_current_context: function() {
-    throw 'emscripten_fiber_create_from_current_context is not implemented for fastcomp ASYNCIFY';
-  },
-  emscripten_fiber_recycle: function() {
-    throw 'emscripten_fiber_recycle is not implemented for fastcomp ASYNCIFY';
-  },
-  emscripten_fiber_destroy: function() {
-    throw 'emscripten_fiber_destroy is not implemented for fastcomp ASYNCIFY';
+  emscripten_fiber_init_from_current_context: function() {
+    throw 'emscripten_fiber_init_from_current_context is not implemented for fastcomp ASYNCIFY';
   },
   emscripten_fiber_swap: function() {
     throw 'emscripten_fiber_swap is not implemented for fastcomp ASYNCIFY';
@@ -560,17 +554,11 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-  emscripten_fiber_create: function() {
-    throw 'emscripten_fiber_create is not implemented for EMTERPRETIFY_ASYNC';
+  emscripten_fiber_init: function() {
+    throw 'emscripten_fiber_init is not implemented for EMTERPRETIFY_ASYNC';
   },
-  emscripten_fiber_create_from_current_context: function() {
-    throw 'emscripten_fiber_create_from_current_context is not implemented for EMTERPRETIFY_ASYNC';
-  },
-  emscripten_fiber_recycle: function() {
-    throw 'emscripten_fiber_recycle is not implemented for EMTERPRETIFY_ASYNC';
-  },
-  emscripten_fiber_destroy: function() {
-    throw 'emscripten_fiber_destroy is not implemented for EMTERPRETIFY_ASYNC';
+  emscripten_fiber_init_from_current_context: function() {
+    throw 'emscripten_fiber_init_from_current_context is not implemented for EMTERPRETIFY_ASYNC';
   },
   emscripten_fiber_swap: function() {
     throw 'emscripten_fiber_swap is not implemented for EMTERPRETIFY_ASYNC';
@@ -998,12 +986,12 @@ mergeInto(LibraryManager.library, {
     },
   },
 
-  emscripten_fiber_create__sig: 'iiiii',
-  emscripten_fiber_create__deps: ['malloc'],
-  emscripten_fiber_create: function(entryPoint, userData, stack, stackSize) {
+  emscripten_fiber_init__sig: 'viiiiii',
+  emscripten_fiber_init__deps: ['$Asyncify'],
+  emscripten_fiber_init: function(fiber, sizeOfFiber, entryPoint, userData, stack, stackSize) {
+    var fiberDataSize = 20;
     var asyncifyDataSize = 12;
-    var asyncifyStackSize = Asyncify.StackSize;
-    var fiber = _malloc(20 + asyncifyDataSize + asyncifyStackSize);
+    var asyncifyStackSize = sizeOfFiber - fiberDataSize + asyncifyDataSize;
     var stackBase = stack + stackSize;
 
     {{{ makeSetValue('fiber',  0, 'stackBase', 'i32') }}};
@@ -1012,47 +1000,23 @@ mergeInto(LibraryManager.library, {
     {{{ makeSetValue('fiber', 12, 'entryPoint', 'i32') }}};
     {{{ makeSetValue('fiber', 16, 'userData', 'i32') }}};
 
-    var asyncifyData = fiber + 20;
+    var asyncifyData = fiber + fiberDataSize;
     Asyncify.setDataHeader(asyncifyData, asyncifyStackSize);
-
-    return fiber;
   },
 
-  emscripten_fiber_create_from_current_context__sig: 'i',
-  emscripten_fiber_create_from_current_context__deps: ['malloc', '$Asyncify'],
-  emscripten_fiber_create_from_current_context: function() {
+  emscripten_fiber_init_from_current_context__sig: 'vi',
+  emscripten_fiber_init_from_current_context__deps: ['$Asyncify'],
+  emscripten_fiber_init_from_current_context: function(fiber, sizeOfFiber) {
+    var fiberDataSize = 20;
     var asyncifyDataSize = 12;
-    var asyncifyStackSize = Asyncify.StackSize;
-    var fiber = _malloc(20 + asyncifyDataSize + asyncifyStackSize);
+    var asyncifyStackSize = sizeOfFiber - fiberDataSize + asyncifyDataSize;
 
     {{{ makeSetValue('fiber',  0, 'STACK_BASE', 'i32') }}};
     {{{ makeSetValue('fiber',  4, 'STACK_MAX', 'i32') }}};
     {{{ makeSetValue('fiber', 12, 0, 'i32') }}};
 
-    var asyncifyData = fiber + 20;
+    var asyncifyData = fiber + fiberDataSize;
     Asyncify.setDataHeader(asyncifyData, asyncifyStackSize);
-
-    return fiber;
-  },
-
-  emscripten_fiber_recycle__sig: 'viii',
-  emscripten_fiber_recycle__deps: ["$Asyncify"],
-  emscripten_fiber_recycle: function(fiber, entryPoint, userData) {
-    var stackBase = {{{ makeGetValue('fiber', 0, 'i32') }}};
-
-    {{{ makeSetValue('fiber',  8, 'stackBase', 'i32') }}};
-    {{{ makeSetValue('fiber', 12, 'entryPoint', 'i32') }}};
-    {{{ makeSetValue('fiber', 16, 'userData', 'i32') }}};
-
-    // Reset Asyncify stack pointer
-    var asyncifyData = fiber + 20;
-    {{{ makeSetValue('asyncifyData', 0, 'asyncifyData + 12', 'i32') }}};
-  },
-
-  emscripten_fiber_destroy__sig: 'vi',
-  emscripten_fiber_destroy__deps: ['free'],
-  emscripten_fiber_destroy: function(fiber) {
-    _free(fiber);
   },
 
   emscripten_fiber_swap__sig: 'vii',
@@ -1129,17 +1093,11 @@ mergeInto(LibraryManager.library, {
   emscripten_scan_registers: function(url, file) {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_scan_registers';
   },
-  emscripten_fiber_create: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_create';
+  emscripten_fiber_init: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_init';
   },
-  emscripten_fiber_create_from_current_context: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_create_from_current_context';
-  },
-  emscripten_fiber_recycle: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_recycle';
-  },
-  emscripten_fiber_destroy: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_destroy';
+  emscripten_fiber_init_from_current_context: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_init_from_current_context';
   },
   emscripten_fiber_swap: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_swap';

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -699,8 +699,8 @@ mergeInto(LibraryManager.library, {
     },
 
     setDataHeader: function(ptr, stackSize) {
-      HEAP32[ptr >> 2] = ptr + 12;
-      HEAP32[ptr + 4 >> 2] = ptr + 12 + stackSize;
+      {{{ makeSetValue('ptr', C_STRUCTS.asyncify_data_s.stack_ptr, 'ptr + 12', 'i32') }}};
+      {{{ makeSetValue('ptr', C_STRUCTS.asyncify_data_s.stack_limit, 'ptr + 12 + stackSize', 'i32') }}};
     },
 
     setDataRewindFunc: function(ptr) {
@@ -708,11 +708,12 @@ mergeInto(LibraryManager.library, {
 #if ASYNCIFY_DEBUG >= 2
       err('ASYNCIFY: setDataRewindFunc('+ptr+'), bottomOfCallStack is', bottomOfCallStack, new Error().stack);
 #endif
-      HEAP32[ptr + 8 >> 2] = Asyncify.getCallStackId(bottomOfCallStack);
+      var rewindId = Asyncify.getCallStackId(bottomOfCallStack);
+      {{{ makeSetValue('ptr', C_STRUCTS.asyncify_data_s.rewind_id, 'rewindId', 'i32') }}};
     },
 
     getDataRewindFunc: function(ptr) {
-      var id = HEAP32[ptr + 8 >> 2];
+      var id = {{{ makeGetValue('ptr', C_STRUCTS.asyncify_data_s.rewind_id, 'i32') }}};
       var func = Asyncify.callStackIdToFunc[id];
 
 #if ASYNCIFY_LAZY_LOAD_CODE
@@ -914,13 +915,13 @@ mergeInto(LibraryManager.library, {
      * NOTE: This function is the asynchronous part of emscripten_fiber_swap.
      */
     finishContextSwitch: function(newFiber) {
-      STACK_BASE = {{{ makeGetValue('newFiber', 0, 'i32') }}};
-      STACK_MAX = {{{ makeGetValue('newFiber', 4, 'i32') }}};
-      stackRestore({{{ makeGetValue('newFiber', 8, 'i32') }}});
+      STACK_BASE = {{{ makeGetValue('newFiber', C_STRUCTS.asyncify_fiber_s.stack_base,  'i32') }}};
+      STACK_MAX =  {{{ makeGetValue('newFiber', C_STRUCTS.asyncify_fiber_s.stack_limit, 'i32') }}};
+      stackRestore({{{ makeGetValue('newFiber', C_STRUCTS.asyncify_fiber_s.stack_ptr,   'i32') }}});
 
       noExitRuntime = false;
 
-      var entryPoint = {{{ makeGetValue('newFiber', 12, 'i32') }}};
+      var entryPoint = {{{ makeGetValue('newFiber', C_STRUCTS.asyncify_fiber_s.entry, 'i32') }}};
 
       if (entryPoint !== 0) {
 #if STACK_OVERFLOW_CHECK
@@ -930,9 +931,9 @@ mergeInto(LibraryManager.library, {
         err('ASYNCIFY/FIBER: entering fiber', newFiber, 'for the first time');
 #endif
         Asyncify.currData = null;
-        {{{ makeSetValue('newFiber', 12, 0, 'i32') }}};
+        {{{ makeSetValue('newFiber', C_STRUCTS.asyncify_fiber_s.entry, 0, 'i32') }}};
 
-        var userData = {{{ makeGetValue('newFiber', 16, 'i32') }}};
+        var userData = {{{ makeGetValue('newFiber', C_STRUCTS.asyncify_fiber_s.user_data, 'i32') }}};
         {{{ makeDynCall('vi') }}}(entryPoint, userData);
       } else {
         var asyncifyData = newFiber + 20;
@@ -955,33 +956,29 @@ mergeInto(LibraryManager.library, {
   emscripten_fiber_init__sig: 'viiiiii',
   emscripten_fiber_init__deps: ['$Asyncify'],
   emscripten_fiber_init: function(fiber, sizeOfFiber, entryPoint, userData, stack, stackSize) {
-    var fiberDataSize = 20;
-    var asyncifyDataSize = 12;
-    var asyncifyStackSize = sizeOfFiber - fiberDataSize + asyncifyDataSize;
+    var asyncifyStackSize = sizeOfFiber - {{{ C_STRUCTS.emscripten_fiber_s.asyncify_stack }}};
     var stackBase = stack + stackSize;
 
-    {{{ makeSetValue('fiber',  0, 'stackBase', 'i32') }}};
-    {{{ makeSetValue('fiber',  4, 'stack', 'i32') }}};
-    {{{ makeSetValue('fiber',  8, 'stackBase', 'i32') }}};
-    {{{ makeSetValue('fiber', 12, 'entryPoint', 'i32') }}};
-    {{{ makeSetValue('fiber', 16, 'userData', 'i32') }}};
+    {{{ makeSetValue('fiber', C_STRUCTS.asyncify_fiber_s.stack_base,  'stackBase',  'i32') }}};
+    {{{ makeSetValue('fiber', C_STRUCTS.asyncify_fiber_s.stack_limit, 'stack',      'i32') }}};
+    {{{ makeSetValue('fiber', C_STRUCTS.asyncify_fiber_s.stack_ptr,   'stackBase',  'i32') }}};
+    {{{ makeSetValue('fiber', C_STRUCTS.asyncify_fiber_s.entry,       'entryPoint', 'i32') }}};
+    {{{ makeSetValue('fiber', C_STRUCTS.asyncify_fiber_s.user_data,   'userData',   'i32') }}};
 
-    var asyncifyData = fiber + fiberDataSize;
+    var asyncifyData = fiber + {{{ C_STRUCTS.emscripten_fiber_s.asyncify_data }}};
     Asyncify.setDataHeader(asyncifyData, asyncifyStackSize);
   },
 
   emscripten_fiber_init_from_current_context__sig: 'vi',
   emscripten_fiber_init_from_current_context__deps: ['$Asyncify'],
   emscripten_fiber_init_from_current_context: function(fiber, sizeOfFiber) {
-    var fiberDataSize = 20;
-    var asyncifyDataSize = 12;
-    var asyncifyStackSize = sizeOfFiber - fiberDataSize + asyncifyDataSize;
+    var asyncifyStackSize = sizeOfFiber - {{{ C_STRUCTS.emscripten_fiber_s.asyncify_stack }}};
 
-    {{{ makeSetValue('fiber',  0, 'STACK_BASE', 'i32') }}};
-    {{{ makeSetValue('fiber',  4, 'STACK_MAX', 'i32') }}};
-    {{{ makeSetValue('fiber', 12, 0, 'i32') }}};
+    {{{ makeSetValue('fiber', C_STRUCTS.asyncify_fiber_s.stack_base,  'STACK_BASE', 'i32') }}};
+    {{{ makeSetValue('fiber', C_STRUCTS.asyncify_fiber_s.stack_limit, 'STACK_MAX',  'i32') }}};
+    {{{ makeSetValue('fiber', C_STRUCTS.asyncify_fiber_s.entry,       0,            'i32') }}};
 
-    var asyncifyData = fiber + fiberDataSize;
+    var asyncifyData = fiber + {{{ C_STRUCTS.emscripten_fiber_s.asyncify_data }}};
     Asyncify.setDataHeader(asyncifyData, asyncifyStackSize);
   },
 
@@ -996,7 +993,7 @@ mergeInto(LibraryManager.library, {
     if (Asyncify.state === Asyncify.State.Normal) {
       Asyncify.state = Asyncify.State.Unwinding;
 
-      var asyncifyData = oldFiber + 20;
+      var asyncifyData = oldFiber + {{{ C_STRUCTS.emscripten_fiber_s.asyncify_data }}};
       Asyncify.setDataRewindFunc(asyncifyData);
       Asyncify.currData = asyncifyData;
 
@@ -1006,7 +1003,7 @@ mergeInto(LibraryManager.library, {
       Module['_asyncify_start_unwind'](asyncifyData);
 
       var stackTop = stackSave();
-      {{{ makeSetValue('oldFiber', 8, 'stackTop', 'i32') }}};
+      {{{ makeSetValue('oldFiber', C_STRUCTS.asyncify_fiber_s.stack_ptr, 'stackTop', 'i32') }}};
 
 #if ASSERTIONS
       assert(!Asyncify.trampoline);

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -742,19 +742,15 @@ mergeInto(LibraryManager.library, {
       return ret;
     },
 
-    allocateDataStorage: function(stackSize) {
+    allocateData: function() {
       // An asyncify data structure has three fields:
       //  0  current stack pos
       //  4  max stack pos
       //  8  id of function at bottom of the call stack (callStackIdToFunc[id] == js function)
-      var data = _malloc(12 + stackSize);
-      return data;
-    },
-
-    allocateData: function() {
-      var data = Asyncify.allocateDataStorage(Asyncify.StackSize);
-      Asyncify.initializeData(data);
-      return data;
+      var ptr = _malloc(12 + Asyncify.StackSize);
+      Asyncify.setDataHeader(ptr, Asyncify.StackSize);
+      Asyncify.setDataRewindFunc(ptr);
+      return ptr;
     },
 
     setDataHeader: function(ptr, stackSize) {
@@ -773,11 +769,6 @@ mergeInto(LibraryManager.library, {
     getDataRewindFunc: function(ptr) {
       var id = HEAP32[ptr + 8 >> 2];
       return Asyncify.callStackIdToFunc[id];
-    },
-
-    initializeData: function(ptr) {
-      Asyncify.setDataHeader(ptr, Asyncify.StackSize);
-      Asyncify.setDataRewindFunc(ptr);
     },
 
     freeData: function(ptr) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -621,6 +621,7 @@ var ASYNCIFY_IMPORTS = [
   'emscripten_idb_store', 'emscripten_idb_delete', 'emscripten_idb_exists',
   'emscripten_idb_load_blob', 'emscripten_idb_store_blob', 'SDL_Delay',
   'emscripten_scan_registers', 'emscripten_lazy_load_code',
+  'emscripten_fiber_swap',
   'wasi_snapshot_preview1.fd_sync', '__wasi_fd_sync',
 ];
 

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1629,5 +1629,28 @@
             "EMSCRIPTEN_FETCH_SYNCHRONOUS",
             "EMSCRIPTEN_FETCH_WAITABLE"
         ]
+    },
+    {
+        "file": "emscripten/fiber.h",
+        "structs": {
+            "asyncify_fiber_s": [
+                "stack_base",
+                "stack_limit",
+                "stack_ptr",
+                "entry",
+                "user_data"
+            ],
+            "asyncify_data_s": [
+                "stack_ptr",
+                "stack_limit",
+                "rewind_id"
+            ],
+            "emscripten_fiber_s": [
+                "asyncify_fiber",
+                "asyncify_data",
+                "asyncify_stack"
+            ]
+        },
+        "defines": ["EM_FIBER_ASYNCIFY_STACK_SIZE"]
     }
  ]

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1633,24 +1633,20 @@
     {
         "file": "emscripten/fiber.h",
         "structs": {
-            "asyncify_fiber_s": [
-                "stack_base",
-                "stack_limit",
-                "stack_ptr",
-                "entry",
-                "user_data"
-            ],
             "asyncify_data_s": [
                 "stack_ptr",
                 "stack_limit",
                 "rewind_id"
             ],
             "emscripten_fiber_s": [
-                "asyncify_fiber",
-                "asyncify_data",
-                "asyncify_stack"
+                "stack_base",
+                "stack_limit",
+                "stack_ptr",
+                "entry",
+                "user_data",
+                "asyncify_data"
             ]
         },
-        "defines": ["EM_FIBER_ASYNCIFY_STACK_SIZE"]
+        "defines": []
     }
  ]

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -255,6 +255,20 @@ typedef void (*em_scan_func)(void*, void*);
 void emscripten_scan_registers(em_scan_func func);
 void emscripten_scan_stack(em_scan_func func);
 
+/* Deprecated and not available in upstream backend; use Fibers instead */
+typedef void * emscripten_coroutine;
+emscripten_coroutine emscripten_coroutine_create(em_arg_callback_func func, void *arg, int stack_size);
+int emscripten_coroutine_next(emscripten_coroutine);
+void emscripten_yield(void);
+
+/* Upstream backend + Asyncify only */
+typedef void * emscripten_fiber;
+emscripten_fiber emscripten_fiber_create(em_arg_callback_func func, void *arg, void *stack, int stack_size);
+emscripten_fiber emscripten_fiber_create_from_current_context(void);
+void emscripten_fiber_recycle(emscripten_fiber fiber, em_arg_callback_func func, void *arg);
+void emscripten_fiber_free(emscripten_fiber fiber);
+void emscripten_fiber_swap(emscripten_fiber old_fiber, emscripten_fiber new_fiber);
+
 /* ===================================== */
 /* Internal APIs. Be careful with these. */
 /* ===================================== */
@@ -265,11 +279,6 @@ void emscripten_sleep_with_yield(unsigned int ms);
 #else
 #define emscripten_sleep SDL_Delay
 #endif
-
-typedef void * emscripten_coroutine;
-emscripten_coroutine emscripten_coroutine_create(em_arg_callback_func func, void *arg, int stack_size);
-int emscripten_coroutine_next(emscripten_coroutine);
-void emscripten_yield(void);
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -266,7 +266,7 @@ typedef void * emscripten_fiber;
 emscripten_fiber emscripten_fiber_create(em_arg_callback_func func, void *arg, void *stack, int stack_size);
 emscripten_fiber emscripten_fiber_create_from_current_context(void);
 void emscripten_fiber_recycle(emscripten_fiber fiber, em_arg_callback_func func, void *arg);
-void emscripten_fiber_free(emscripten_fiber fiber);
+void emscripten_fiber_destroy(emscripten_fiber fiber);
 void emscripten_fiber_swap(emscripten_fiber old_fiber, emscripten_fiber new_fiber);
 
 /* ===================================== */

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -262,7 +262,7 @@ int emscripten_coroutine_next(emscripten_coroutine);
 void emscripten_yield(void);
 
 /* Upstream backend + Asyncify only */
-typedef void * emscripten_fiber;
+typedef struct emscripten_fiber_s *emscripten_fiber;  // NOTE: not a real pointer; this is a handle to a JS object
 emscripten_fiber emscripten_fiber_create(em_arg_callback_func func, void *arg, void *stack, int stack_size);
 emscripten_fiber emscripten_fiber_create_from_current_context(void);
 void emscripten_fiber_recycle(emscripten_fiber fiber, em_arg_callback_func func, void *arg);

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -262,7 +262,7 @@ int emscripten_coroutine_next(emscripten_coroutine);
 void emscripten_yield(void);
 
 /* Upstream backend + Asyncify only */
-typedef struct emscripten_fiber_s *emscripten_fiber;  // NOTE: not a real pointer; this is a handle to a JS object
+typedef struct emscripten_fiber_s *emscripten_fiber;
 emscripten_fiber emscripten_fiber_create(em_arg_callback_func func, void *arg, void *stack, int stack_size);
 emscripten_fiber emscripten_fiber_create_from_current_context(void);
 void emscripten_fiber_recycle(emscripten_fiber fiber, em_arg_callback_func func, void *arg);

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -280,8 +280,8 @@ typedef struct emscripten_fiber_s {
     char asyncify_stack[EM_FIBER_ASYNCIFY_STACK_SIZE];
 } emscripten_fiber_t;
 
-void emscripten_fiber_init(emscripten_fiber_t *fiber, size_t fiber_struct_size, em_arg_callback_func entry_func, void *entry_func_arg, void *stack, size_t stack_size);
-void emscripten_fiber_init_from_current_context(emscripten_fiber_t *fiber, size_t fiber_struct_size);
+void emscripten_fiber_init(emscripten_fiber_t *fiber, unsigned int fiber_struct_size, em_arg_callback_func entry_func, void *entry_func_arg, void *stack, unsigned int stack_size);
+void emscripten_fiber_init_from_current_context(emscripten_fiber_t *fiber, unsigned int fiber_struct_size);
 void emscripten_fiber_swap(emscripten_fiber_t *old_fiber, emscripten_fiber_t *new_fiber);
 
 // Old coroutines API

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -280,8 +280,8 @@ typedef struct emscripten_fiber_s {
     char asyncify_stack[EM_FIBER_ASYNCIFY_STACK_SIZE];
 } emscripten_fiber_t;
 
-void emscripten_fiber_init(emscripten_fiber_t *fiber, unsigned int fiber_struct_size, em_arg_callback_func entry_func, void *entry_func_arg, void *stack, unsigned int stack_size);
-void emscripten_fiber_init_from_current_context(emscripten_fiber_t *fiber, unsigned int fiber_struct_size);
+void emscripten_fiber_init(emscripten_fiber_t *fiber, size_t fiber_struct_size, em_arg_callback_func entry_func, void *entry_func_arg, void *stack, size_t stack_size);
+void emscripten_fiber_init_from_current_context(emscripten_fiber_t *fiber, size_t fiber_struct_size);
 void emscripten_fiber_swap(emscripten_fiber_t *old_fiber, emscripten_fiber_t *new_fiber);
 
 // Old coroutines API

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -255,19 +255,42 @@ typedef void (*em_scan_func)(void*, void*);
 void emscripten_scan_registers(em_scan_func func);
 void emscripten_scan_stack(em_scan_func func);
 
-/* Deprecated and not available in upstream backend; use Fibers instead */
+// Fibers API
+// Requires upstream backend and Asyncify
+
+#define EM_FIBER_ASYNCIFY_STACK_SIZE 4096
+
+typedef struct asyncify_fiber_s {
+    void *stack_base;
+    void *stack_limit;
+    void *stack_ptr;
+    em_arg_callback_func entry;
+    void *user_data;
+} asyncify_fiber_t;
+
+typedef struct asyncify_data_s {
+    void *stack_ptr;
+    void *stack_limit;
+    int rewind_id;
+} asyncify_data_t;
+
+typedef struct emscripten_fiber_s {
+    asyncify_fiber_t asyncify_fiber;
+    asyncify_data_t asyncify_data;
+    char asyncify_stack[EM_FIBER_ASYNCIFY_STACK_SIZE];
+} emscripten_fiber_t;
+
+void emscripten_fiber_init(emscripten_fiber_t *fiber, unsigned int fiber_struct_size, em_arg_callback_func entry_func, void *entry_func_arg, void *stack, unsigned int stack_size);
+void emscripten_fiber_init_from_current_context(emscripten_fiber_t *fiber, unsigned int fiber_struct_size);
+void emscripten_fiber_swap(emscripten_fiber_t *old_fiber, emscripten_fiber_t *new_fiber);
+
+// Old coroutines API
+// Deprecated and not available in upstream backend; use Fibers instead
+
 typedef void * emscripten_coroutine;
 emscripten_coroutine emscripten_coroutine_create(em_arg_callback_func func, void *arg, int stack_size);
 int emscripten_coroutine_next(emscripten_coroutine);
 void emscripten_yield(void);
-
-/* Upstream backend + Asyncify only */
-typedef struct emscripten_fiber_s *emscripten_fiber;
-emscripten_fiber emscripten_fiber_create(em_arg_callback_func func, void *arg, void *stack, int stack_size);
-emscripten_fiber emscripten_fiber_create_from_current_context(void);
-void emscripten_fiber_recycle(emscripten_fiber fiber, em_arg_callback_func func, void *arg);
-void emscripten_fiber_destroy(emscripten_fiber fiber);
-void emscripten_fiber_swap(emscripten_fiber old_fiber, emscripten_fiber new_fiber);
 
 /* ===================================== */
 /* Internal APIs. Be careful with these. */

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -255,35 +255,6 @@ typedef void (*em_scan_func)(void*, void*);
 void emscripten_scan_registers(em_scan_func func);
 void emscripten_scan_stack(em_scan_func func);
 
-// Fibers API
-// Requires upstream backend and Asyncify
-
-#define EM_FIBER_ASYNCIFY_STACK_SIZE 4096
-
-typedef struct asyncify_fiber_s {
-    void *stack_base;
-    void *stack_limit;
-    void *stack_ptr;
-    em_arg_callback_func entry;
-    void *user_data;
-} asyncify_fiber_t;
-
-typedef struct asyncify_data_s {
-    void *stack_ptr;
-    void *stack_limit;
-    int rewind_id;
-} asyncify_data_t;
-
-typedef struct emscripten_fiber_s {
-    asyncify_fiber_t asyncify_fiber;
-    asyncify_data_t asyncify_data;
-    char asyncify_stack[EM_FIBER_ASYNCIFY_STACK_SIZE];
-} emscripten_fiber_t;
-
-void emscripten_fiber_init(emscripten_fiber_t *fiber, unsigned int fiber_struct_size, em_arg_callback_func entry_func, void *entry_func_arg, void *stack, unsigned int stack_size);
-void emscripten_fiber_init_from_current_context(emscripten_fiber_t *fiber, unsigned int fiber_struct_size);
-void emscripten_fiber_swap(emscripten_fiber_t *old_fiber, emscripten_fiber_t *new_fiber);
-
 // Old coroutines API
 // Deprecated and not available in upstream backend; use Fibers instead
 

--- a/system/include/emscripten/fiber.h
+++ b/system/include/emscripten/fiber.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+#include <emscripten/emscripten.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define EM_FIBER_ASYNCIFY_STACK_SIZE 4096
+
+typedef struct asyncify_fiber_s {
+  void *stack_base;
+  void *stack_limit;
+  void *stack_ptr;
+  em_arg_callback_func entry;
+  void *user_data;
+} asyncify_fiber_t;
+
+typedef struct asyncify_data_s {
+  void *stack_ptr;
+  void *stack_limit;
+  int rewind_id;
+} asyncify_data_t;
+
+typedef struct emscripten_fiber_s {
+  asyncify_fiber_t asyncify_fiber;
+  asyncify_data_t asyncify_data;
+  char asyncify_stack[EM_FIBER_ASYNCIFY_STACK_SIZE];
+} emscripten_fiber_t;
+
+void emscripten_fiber_init(emscripten_fiber_t *fiber, size_t fiber_struct_size, em_arg_callback_func entry_func, void *entry_func_arg, void *stack, size_t stack_size);
+
+void emscripten_fiber_init_from_current_context(emscripten_fiber_t *fiber, size_t fiber_struct_size);
+
+void emscripten_fiber_swap(emscripten_fiber_t *old_fiber, emscripten_fiber_t *new_fiber);
+
+#ifdef __cplusplus
+}
+#endif

--- a/system/include/emscripten/fiber.h
+++ b/system/include/emscripten/fiber.h
@@ -15,9 +15,6 @@
 extern "C" {
 #endif
 
-typedef struct asyncify_fiber_s {
-} asyncify_fiber_t;
-
 typedef struct asyncify_data_s {
   void *stack_ptr;     /** Current position in the Asyncify stack (*not* the C stack) */
   void *stack_limit;   /** Where the Asyncify stack ends. */
@@ -34,24 +31,24 @@ typedef struct emscripten_fiber_s {
 } emscripten_fiber_t;
 
 void emscripten_fiber_init(
-    emscripten_fiber_t *fiber,
-    em_arg_callback_func entry_func,
-    void *entry_func_arg,
-    void *c_stack,
-    size_t c_stack_size,
-    void *asyncify_stack,
-    size_t asyncify_stack_size
+  emscripten_fiber_t *fiber,
+  em_arg_callback_func entry_func,
+  void *entry_func_arg,
+  void *c_stack,
+  size_t c_stack_size,
+  void *asyncify_stack,
+  size_t asyncify_stack_size
 );
 
 void emscripten_fiber_init_from_current_context(
-    emscripten_fiber_t *fiber,
-    void *asyncify_stack,
-    size_t asyncify_stack_size
+  emscripten_fiber_t *fiber,
+  void *asyncify_stack,
+  size_t asyncify_stack_size
 );
 
 void emscripten_fiber_swap(
-    emscripten_fiber_t *old_fiber,
-    emscripten_fiber_t *new_fiber
+  emscripten_fiber_t *old_fiber,
+  emscripten_fiber_t *new_fiber
 );
 
 #ifdef __cplusplus

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7843,6 +7843,7 @@ extern "C" {
     self.set_setting('ASYNCIFY', 1)
     # needs to flush stdio streams and to ensure destructors are called
     self.set_setting('EXIT_RUNTIME', 1)
+    self.emcc_args += ['-std=gnu++11']
     src = open(path_from_root('tests', 'test_fibers.cpp')).read()
     self.do_run(src, '*leaf-0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*\ndestructor\ndestructor\ndestructor')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7841,11 +7841,9 @@ extern "C" {
   @no_fastcomp('Fibers are not implemented for fastcomp')
   def test_fibers_asyncify(self):
     self.set_setting('ASYNCIFY', 1)
-    # needs to flush stdio streams and to ensure destructors are called
-    self.set_setting('EXIT_RUNTIME', 1)
     self.emcc_args += ['-std=gnu++11']
     src = open(path_from_root('tests', 'test_fibers.cpp')).read()
-    self.do_run(src, '*leaf-0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*\ndestructor\ndestructor\ndestructor')
+    self.do_run(src, '*leaf-0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*')
 
   @no_wasm_backend('ASYNCIFY is not supported in the LLVM wasm backend')
   @no_fastcomp('ASYNCIFY has been removed from fastcomp')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7838,6 +7838,14 @@ extern "C" {
   def test_coroutine_asyncify(self):
     self.do_test_coroutine({'ASYNCIFY': 1})
 
+  @no_fastcomp('Fibers are not implemented for fastcomp')
+  def test_fibers_asyncify(self):
+    self.set_setting('ASYNCIFY', 1)
+    # needs to flush stdio streams and to ensure destructors are called
+    self.set_setting('EXIT_RUNTIME', 1)
+    src = open(path_from_root('tests', 'test_fibers.cpp')).read()
+    self.do_run(src, '*leaf-0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*\ndestructor\ndestructor\ndestructor')
+
   @no_wasm_backend('ASYNCIFY is not supported in the LLVM wasm backend')
   @no_fastcomp('ASYNCIFY has been removed from fastcomp')
   def test_asyncify_unused(self):

--- a/tests/test_fibers.cpp
+++ b/tests/test_fibers.cpp
@@ -1,0 +1,105 @@
+// Copyright 2019 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+// Based on test_coroutines.cpp
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <emscripten.h>
+
+struct Fiber {
+    emscripten_fiber context;
+    void *stack;
+    int result;
+
+    static void bad(void *arg) {
+        abort();
+    }
+
+    void init(em_arg_callback_func entry, void *arg) {
+        const int stack_size = 1 << 13;
+        stack = malloc(stack_size);
+        context = emscripten_fiber_create(bad, nullptr, stack, stack_size);
+        emscripten_fiber_recycle(context, entry, arg);
+        result = 0;
+    }
+
+    ~Fiber() {
+        free(stack);
+        emscripten_fiber_free(context);
+        printf("\ndestructor");
+    }
+};
+
+static struct Globals {
+    emscripten_fiber main;
+    Fiber fibers[2];
+
+    Globals() {
+        main = emscripten_fiber_create_from_current_context();
+    }
+
+    ~Globals() {
+        emscripten_fiber_free(main);
+        printf("\ndestructor");
+    }
+} G;
+
+static void leaf(void) {
+    printf("leaf-");
+}
+
+static void fib(void * arg) {
+    int *p = (int*)arg;
+    int cur = 1;
+    int next = 1;
+    for(int i = 0; i < 9; ++i) {
+        *p = cur;
+        emscripten_fiber_swap(G.fibers[0].context, G.main);
+        int next2 = cur + next;
+        cur = next;
+        next = next2;
+    }
+}
+
+static void f(void *arg) {
+    int *p = (int*)arg;
+    *p = 0;
+    leaf();
+    emscripten_fiber_swap(G.fibers[0].context, G.main);
+    fib(arg);
+
+    G.fibers[0].result = 1;
+    emscripten_fiber_swap(G.fibers[0].context, G.main);
+    abort();
+}
+
+static void g(void *arg) {
+    int *p = (int*)arg;
+    for(int i = 0; i < 10; ++i) {
+        *p = 100+i;
+        emscripten_fiber_swap(G.fibers[1].context, G.main);
+    }
+
+    G.fibers[1].result = 1;
+    emscripten_fiber_swap(G.fibers[1].context, G.main);
+    abort();
+}
+
+int main(int argc, char **argv) {
+    int i;
+    G.fibers[0].init(f, &i);
+    G.fibers[1].init(g, &i);
+
+    printf("*");
+    while(emscripten_fiber_swap(G.main, G.fibers[0].context), !G.fibers[0].result) {
+        printf("%d-", i);
+        emscripten_fiber_swap(G.main, G.fibers[1].context);
+        printf("%d-", i);
+    }
+    printf("*");
+
+    return 0;
+}

--- a/tests/test_fibers.cpp
+++ b/tests/test_fibers.cpp
@@ -28,7 +28,7 @@ struct Fiber {
 
     ~Fiber() {
         free(stack);
-        emscripten_fiber_free(context);
+        emscripten_fiber_destroy(context);
         printf("\ndestructor");
     }
 };
@@ -42,7 +42,7 @@ static struct Globals {
     }
 
     ~Globals() {
-        emscripten_fiber_free(main);
+        emscripten_fiber_destroy(main);
         printf("\ndestructor");
     }
 } G;

--- a/tests/test_fibers.cpp
+++ b/tests/test_fibers.cpp
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <emscripten.h>
+#include <emscripten/fiber.h>
 
 struct Fiber {
     emscripten_fiber_t context;

--- a/tests/test_fibers.cpp
+++ b/tests/test_fibers.cpp
@@ -32,10 +32,6 @@ struct Fiber {
     void swap(emscripten_fiber_t *fiber) {
         emscripten_fiber_swap(&context, fiber);
     }
-
-    ~Fiber() {
-        printf("\ndestructor");
-    }
 };
 
 static struct Globals {
@@ -45,10 +41,6 @@ static struct Globals {
 
     Globals() {
         emscripten_fiber_init_from_current_context(&main, asyncify_stack, sizeof(asyncify_stack));
-    }
-
-    ~Globals() {
-        printf("\ndestructor");
     }
 } G;
 
@@ -106,7 +98,7 @@ int main(int argc, char **argv) {
         emscripten_fiber_swap(&G.main, &G.fibers[1].context);
         printf("%d-", i);
     }
-    printf("*");
+    printf("*\n");
 
     return 0;
 }


### PR DESCRIPTION
As discussed in #8979, this supersedes coroutines. Implemented for the Upstream backend + Asyncify only.

The API is slightly different from that of the [libkoishi backend](https://github.com/taisei-project/koishi/blob/b16c82fc6e86a1623d8ea553bfb934aee05033dc/src/asyncify/library_fiber.js) which it's based on. The main difference is that the fiber structure does not contain a stack. The user must allocate memory for a stack manually before creating a fiber.

Tests and documentation are still missing, I'll be adding it shortly.

cc @kripken @corwin-of-amber @sbc100 