### PR TITLE
Fix (a bit) node.js error handling with threads

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -438,7 +438,7 @@ var LibraryPThread = {
               worker.onmessage({ data: data });
             });
             worker.on('error', function(data) {
-              worker.onerror(data.err);
+              worker.onerror(data);
             });
             worker.on('exit', function(data) {
               console.log('worker exited - TODO: update the worker queue?');


### PR DESCRIPTION
Before would print:
```
TypeError: Cannot read property 'filename' of undefined
    [...unhelpful stacktrace]
```
Now should print:
`pthread sent an error! undefined:undefined: [the exception]`

e.filename, e.lineno still don't resolve correctly, but better that than the exception logging throwing.