### PR TITLE
Only pass --output-source-map-url once, as each time adds a section

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2284,14 +2284,16 @@ def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
   base_wasm = infile
   debug_copy(infile, 'base.wasm')
 
+  args = ['--detect-features']
+
   write_source_map = shared.Settings.DEBUG_LEVEL >= 4
   if write_source_map:
     shared.Building.emit_wasm_source_map(base_wasm, base_wasm + '.map')
     debug_copy(base_wasm + '.map', 'base_wasm.map')
+    args += ['--output-source-map-url=' + shared.Settings.SOURCE_MAP_BASE + os.path.basename(shared.Settings.WASM_BINARY_FILE) + '.map']
 
   # tell binaryen to look at the features section, and if there isn't one, to use MVP
   # (which matches what llvm+lld has given us)
-  args = ['--detect-features']
   if shared.Settings.DEBUG_LEVEL >= 2 or shared.Settings.PROFILING_FUNCS or shared.Settings.EMIT_SYMBOL_MAP or shared.Settings.ASYNCIFY_WHITELIST or shared.Settings.ASYNCIFY_BLACKLIST:
     args.append('-g')
   if shared.Settings.LEGALIZE_JS_FFI != 1:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8825,7 +8825,7 @@ int main() {
     output = open('a.wasm', 'rb').read()
     # has sourceMappingURL section content and points to 'dir/a.wasm.map' file
     source_mapping_url_content = encode_leb(len('sourceMappingURL')) + b'sourceMappingURL' + encode_leb(len('dir/a.wasm.map')) + b'dir/a.wasm.map'
-    self.assertIn(source_mapping_url_content, output)
+    self.assertEqual(output.count(source_mapping_url_content), 1)
 
   def test_check_source_map_args(self):
     # -g4 is needed for source maps; -g is not enough

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2907,7 +2907,6 @@ class Building(object):
     if emit_source_map:
       cmd += ['--input-source-map=' + infile + '.map']
       cmd += ['--output-source-map=' + outfile + '.map']
-      cmd += ['--output-source-map-url=' + Settings.SOURCE_MAP_BASE + os.path.basename(Settings.WASM_BINARY_FILE) + '.map']
 
     return run_process(cmd, stdout=stdout).stdout
 


### PR DESCRIPTION
This removes duplicate source map url sections which accumulate
as after one is created, binaryen keeps it alive as it's just a custom
section it doesn't have special handling for.