### PR TITLE
Fix _scriptDir for node.js + USE_PTHREADS + MODULARIZE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3168,15 +3168,21 @@ function(%(EXPORT_NAME)s) {
         script_url = "import.meta.url"
       else:
         script_url = "typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined"
+        if shared.Settings.target_environment_may_be('node'):
+          script_url_node = "if (typeof __filename !== 'undefined') _scriptDir = _scriptDir || __filename;"
+        else:
+          script_url_node = ""
       src = '''
 var %(EXPORT_NAME)s = (function() {
   var _scriptDir = %(script_url)s;
+  %(script_url_node)s
   return (%(src)s);
 })();
 ''' % {
         'EXPORT_NAME': shared.Settings.EXPORT_NAME,
-        'src': src,
-        'script_url': script_url
+        'script_url': script_url,
+        'script_url_node': script_url_node,
+        'src': src
       }
   else:
     # Create the MODULARIZE_INSTANCE instance

--- a/emcc.py
+++ b/emcc.py
@@ -3158,6 +3158,7 @@ function(%(EXPORT_NAME)s) {
       # document.currentScript, so a simple export declaration is enough.
       src = 'var %s=%s' % (shared.Settings.EXPORT_NAME, src)
     else:
+      script_url_node = ""
       # When MODULARIZE this JS may be executed later,
       # after document.currentScript is gone, so we save it.
       # (when MODULARIZE_INSTANCE, an instance is created
@@ -3170,8 +3171,6 @@ function(%(EXPORT_NAME)s) {
         script_url = "typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined"
         if shared.Settings.target_environment_may_be('node'):
           script_url_node = "if (typeof __filename !== 'undefined') _scriptDir = _scriptDir || __filename;"
-        else:
-          script_url_node = ""
       src = '''
 var %(EXPORT_NAME)s = (function() {
   var _scriptDir = %(script_url)s;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8965,7 +8965,7 @@ T6:(else) !ASSERTIONS""", output)
 const Module = require("./module");
 Module().then((module_instance) => {
   module_instance._main();
-}
+});
 '''
     if not os.path.exists('subdir'):
       os.mkdir('subdir')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8967,12 +8967,12 @@ Module().then((module) => {
   module._main();
 }
 '''
+    if not os.path.exists('subdir'):
+      os.mkdir('subdir')
     with open(os.path.join('subdir', moduleLoader), 'w+', encoding='utf-8') as f:
       f.write(moduleLoaderContents)
 
     # build hello_world.c
-    if not os.path.exists('subdir'):
-      os.mkdir('subdir')
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', "ENVIRONMENT='worker','node'", '-s', "EXPORTED_FUNCTIONS=['_main']"])
 
     # run the module

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8963,9 +8963,10 @@ T6:(else) !ASSERTIONS""", output)
     # create module loader script
     moduleLoader = 'moduleLoader.js'
     moduleLoaderContents = '''
-const Module = require("./module");
-Module().then((module_instance) => {
-  module_instance._main();
+const test_module = require("./module");
+test_module().then((test_module_instance) => {
+  test_module_instance._main();
+  process.exit(0);
 });
 '''
     if not os.path.exists('subdir'):
@@ -8974,7 +8975,7 @@ Module().then((module_instance) => {
       f.write(moduleLoaderContents)
 
     # build hello_world.c
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', 'ENVIRONMENT=worker,node', '-s', 'EXPORTED_FUNCTIONS=["_main"]'])
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=test_module', '-s', 'ENVIRONMENT=worker,node'])
 
     # run the module
     ret = run_process(NODE_JS + ['--experimental-wasm-threads'] + [os.path.join('subdir', moduleLoader)], stdout=PIPE).stdout

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8967,7 +8967,7 @@ Module().then((module) => {
   module._main();
 }
 '''
-    with open(os.path.join('subdir', moduleLoader), 'w', encoding='utf-8') as f:
+    with open(os.path.join('subdir', moduleLoader), 'w+', encoding='utf-8') as f:
       f.write(moduleLoaderContents)
 
     # build hello_world.c

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8964,10 +8964,10 @@ T6:(else) !ASSERTIONS""", output)
     moduleLoaderContents = '''
 const module = require("./module");
 Module().then((module) => {
-	module._main();
+  module._main();
 }
 '''
-    with open(os.path.join('subdir', moduleLoader),'w', encoding='utf-8') as f:
+    with open(os.path.join('subdir', moduleLoader), 'w', encoding='utf-8') as f:
       f.write(moduleLoaderContents)
 
     # build hello_world.c

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8973,7 +8973,7 @@ Module().then((module) => {
       f.write(moduleLoaderContents)
 
     # build hello_world.c
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', "ENVIRONMENT='worker','node'", '-s', "EXPORTED_FUNCTIONS=['_main']"])
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', 'ENVIRONMENT=worker,node', '-s', 'EXPORTED_FUNCTIONS=["_main"]'])
 
     # run the module
     ret = run_process(NODE_JS + [os.path.join('subdir', moduleLoader)], stdout=PIPE).stdout

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8969,10 +8969,8 @@ test_module().then((test_module_instance) => {
   process.exit(0);
 });
 '''
-    if not os.path.exists('subdir'):
-      os.mkdir('subdir')
-    with open(os.path.join('subdir', moduleLoader), 'w+', encoding='utf-8') as f:
-      f.write(moduleLoaderContents)
+    os.makedirs('subdir', exist_ok=True)
+    create_test_file(os.path.join('subdir', moduleLoader), moduleLoaderContents)
 
     # build hello_world.c
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=test_module', '-s', 'ENVIRONMENT=worker,node'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8976,7 +8976,7 @@ Module().then((module_instance) => {
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', 'ENVIRONMENT=worker,node', '-s', 'EXPORTED_FUNCTIONS=["_main"]'])
 
     # run the module
-    ret = run_process(NODE_JS + [os.path.join('subdir', moduleLoader)], stdout=PIPE).stdout
+    ret = run_process(NODE_JS, '--experimental-wasm-threads', [os.path.join('subdir', moduleLoader)], stdout=PIPE).stdout
     self.assertContained('hello, world!', ret)
 
   def test_is_bitcode(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8958,6 +8958,7 @@ T6:(else) !ASSERTIONS""", output)
     self.assertContained('hello, world!', ret)
 
   # Tests that a pthreads + modularize build can be run in node js
+  @no_fastcomp('node pthreads only supported on wasm backend')
   def test_node_js_pthread_module(self):
     # create module loader script
     moduleLoader = 'moduleLoader.js'
@@ -8976,7 +8977,7 @@ Module().then((module_instance) => {
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', 'ENVIRONMENT=worker,node', '-s', 'EXPORTED_FUNCTIONS=["_main"]'])
 
     # run the module
-    ret = run_process(NODE_JS, '--experimental-wasm-threads', [os.path.join('subdir', moduleLoader)], stdout=PIPE).stdout
+    ret = run_process(NODE_JS + ['--experimental-wasm-threads'] + [os.path.join('subdir', moduleLoader)], stdout=PIPE).stdout
     self.assertContained('hello, world!', ret)
 
   def test_is_bitcode(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8962,9 +8962,9 @@ T6:(else) !ASSERTIONS""", output)
     # create module loader script
     moduleLoader = 'moduleLoader.js'
     moduleLoaderContents = '''
-const module = require("./module");
-Module().then((module) => {
-  module._main();
+const Module = require("./module");
+Module().then((module_instance) => {
+  module_instance._main();
 }
 '''
     if not os.path.exists('subdir'):


### PR DESCRIPTION
node.js doesn't have document.currentScript.src, so use __filename instead.
Since you can have a module designed for both node and the web default to document.currentScript.src, but fall back to __filename if that fails.