### PR TITLE
Refactor debug_copy

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2275,19 +2275,15 @@ def remove_trailing_zeros(memfile):
 
 
 def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
-  def debug_copy(src, dst):
-    if DEBUG:
-      shutil.copyfile(src, os.path.join(shared.CANONICAL_TEMP_DIR, dst))
-
   basename = shared.unsuffixed(outfile.name)
   wasm = basename + '.wasm'
   base_wasm = infile
-  debug_copy(infile, 'base.wasm')
+  shared.Building.debug_copy(infile, 'base.wasm')
 
   write_source_map = shared.Settings.DEBUG_LEVEL >= 4
   if write_source_map:
     shared.Building.emit_wasm_source_map(base_wasm, base_wasm + '.map')
-    debug_copy(base_wasm + '.map', 'base_wasm.map')
+    shared.Building.debug_copy(base_wasm + '.map', 'base_wasm.map')
 
   # tell binaryen to look at the features section, and if there isn't one, to use MVP
   # (which matches what llvm+lld has given us)
@@ -2327,8 +2323,8 @@ def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
                                                 args=args,
                                                 stdout=subprocess.PIPE)
   if write_source_map:
-    debug_copy(wasm + '.map', 'post_finalize.map')
-  debug_copy(wasm, 'post_finalize.wasm')
+    shared.Building.debug_copy(wasm + '.map', 'post_finalize.map')
+  shared.Building.debug_copy(wasm, 'post_finalize.wasm')
 
   if not shared.Settings.MEM_INIT_IN_WASM:
     # we have a separate .mem file. binaryen did not strip any trailing zeros,

--- a/emscripten.py
+++ b/emscripten.py
@@ -18,7 +18,6 @@ import subprocess
 import re
 import time
 import logging
-import shutil
 import pprint
 from collections import OrderedDict
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2909,11 +2909,22 @@ class Building(object):
       cmd += ['--output-source-map=' + outfile + '.map']
       cmd += ['--output-source-map-url=' + Settings.SOURCE_MAP_BASE + os.path.basename(Settings.WASM_BINARY_FILE) + '.map']
 
-    return run_process(cmd, stdout=stdout).stdout
+    ret = run_process(cmd, stdout=stdout).stdout
+    if outfile:
+      Building.debug_copy(outfile, 'rbc.%s.wasm' % tool)
+    return ret
 
   @staticmethod
   def run_wasm_opt(*args, **kwargs):
     return Building.run_binaryen_command('wasm-opt', *args, **kwargs)
+
+  debug_copy_counter = 0
+
+  @staticmethod
+  def debug_copy(src, dst):
+    if DEBUG:
+      shutil.copyfile(src, os.path.join(CANONICAL_TEMP_DIR, 'emdebug-%d-%s' % (Building.debug_copy_counter, dst)))
+      Building.debug_copy_counter += 1
 
 
 # compatibility with existing emcc, etc. scripts

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2910,7 +2910,7 @@ class Building(object):
 
     ret = run_process(cmd, stdout=stdout).stdout
     if outfile:
-      Building.debug_copy(outfile, 'rbc.%s.wasm' % tool)
+      Building.debug_copy(outfile, '%s.wasm' % tool)
     return ret
 
   @staticmethod


### PR DESCRIPTION
This moves the emscripten.py method of that name, which makes
a copy of the current file to the temp dir, for later debugging, to
shared.py.

It also uses it in `run_binaryen_command`, to make it easier to
debug.

It also adds an integer counter to the files, so their their order is
clear.

If this looks good to people, I'd like to continue this refactoring to
also subsume the current `emcc-*` temp files, so that we have a
single method for this in the entire codebase.