### PR TITLE
Build crt1.o as a wasm object file

### DIFF
--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.exports
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.exports
@@ -1,0 +1,3 @@
+_start
+main
+memory

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
@@ -1,0 +1,5 @@
+$__original_main
+$_start
+$dlmalloc
+$main
+$sbrk

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.imports
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.imports
@@ -1,0 +1,1 @@
+proc_exit

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.sent
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.sent
@@ -1,0 +1,1 @@
+proc_exit

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8216,6 +8216,10 @@ int main() {
     # Growth support code is in the wasm
     'O3_grow_standalone': ('mem.c', ['-O3', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'STANDALONE_WASM'],
                            4, [], [], 6449,  4,  3,  6),         # noqa
+    # without argc/argv, no support code for them is emitted, even with lto
+    'O3_standalone_narg_flto':
+                          ('mem_no_argv.c', ['-O3', '-s', 'STANDALONE_WASM', '-flto'],
+                           1, [], [], 6309,  1,  3,  5),         # noqa
   })
   @no_fastcomp()
   def test_metadce_mem(self, filename, *args):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -775,7 +775,7 @@ class crt1(MuslInternalLibrary):
     return shared.Settings.STANDALONE_WASM
 
   def can_build(self):
-    return not shared.Settings.WASM_BACKEND
+    return shared.Settings.WASM_BACKEND
 
 
 class libc_extras(MuslInternalLibrary):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -774,6 +774,9 @@ class crt1(MuslInternalLibrary):
   def can_use(self):
     return shared.Settings.STANDALONE_WASM
 
+  def can_build(self):
+    return not shared.Settings.WASM_BACKEND
+
 
 class libc_extras(MuslInternalLibrary):
   """This library is separate from libc itself for fastcomp only so that the

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -766,6 +766,8 @@ class crt1(MuslInternalLibrary):
   src_dir = ['system', 'lib', 'libc']
   src_files = ['crt1.c']
 
+  force_object_files = True
+
   def get_ext(self):
     return '.o'
 


### PR DESCRIPTION
I'm not sure this is the right fix, let me know what you think!

The underlying issue is that if crt1.o is built with
WASM_OBJECT_FILES=0 then it's a bitcode file. That appears
to be linked together with the user's main **before** the linker
would create the `__original_main` function. As a result, the trick
with making that weak doesn't work.

The proposed solution here is to build crt1.o as a wasm object
file in all cases. Then it's linked in at the very end, and the
optimization works.

This may disable some possible LLVM LTO optimizations,
though? Or perhaps the linker could be smart about this?
