### PR TITLE
Remove useless variable if SUPPORT_BASE64_EMBEDDING=0

### DIFF
--- a/src/node_shell_read.js
+++ b/src/node_shell_read.js
@@ -1,7 +1,6 @@
   read_ = function shell_read(filename, binary) {
-    var ret;
 #if SUPPORT_BASE64_EMBEDDING
-    ret = tryParseAsDataURI(filename);
+    var ret = tryParseAsDataURI(filename);
     if (ret) {
       return binary ? ret : ret.toString();
     }


### PR DESCRIPTION
`ret` is only used inside a `SUPPORT_BASE64_EMBEDDING` block, but defined outside the block.
Obviously a very minor change.