### PR TITLE
Default DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Default DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR to 1.
 - Remove deprecated `requestFullScreen` method from `library_browser.js`, please
   use `requestFullscreen` (without the capital S).
 - Remove deprecated `requestFullScreen` and `cancelFullScreen` from `library_glut.js`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,12 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- Default DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR to 1.
+- Default DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR to 1. See #9895.
+  With this change the old deprecated HTML5 API event target lookup behavior is
+  disabled. There is no "Module.canvas" object, no magic "null" default handling,
+  and DOM element 'target' parameters are taken to refer to CSS selectors, instead 
+  of referring to DOM IDs. For more information see:
+  https://groups.google.com/forum/#!msg/emscripten-discuss/xScZ_LRIByk/_gEy67utDgAJ
 - Remove deprecated `requestFullScreen` method from `library_browser.js`, please
   use `requestFullscreen` (without the capital S).
 - Remove deprecated `requestFullScreen` and `cancelFullScreen` from `library_glut.js`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- Default DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR to 1. See #9895.
+- Default `DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR` to 1. See #9895.
   With this change the old deprecated HTML5 API event target lookup behavior is
   disabled. There is no "Module.canvas" object, no magic "null" default handling,
   and DOM element 'target' parameters are taken to refer to CSS selectors, instead 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1617,7 +1617,7 @@ var SUPPORT_LONGJMP = 1;
 // If set to 1, disables old deprecated HTML5 API event target lookup behavior. When enabled,
 // there is no "Module.canvas" object, no magic "null" default handling, and DOM element
 // 'target' parameters are taken to refer to CSS selectors, instead of referring to DOM IDs.
-var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 0;
+var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1;
 
 // Specifies whether the generated .html file is run through html-minifier. The set of
 // optimization passes run by html-minifier depends on debug and optimization levels. In


### PR DESCRIPTION
Addresses the first part of #8047.
In a few releases this option should be removed entirely.