### PR TITLE
Use WebAssembly.Function constructor if available

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -441,3 +441,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Gergely Nagy <ngg@tresorit.com>
 * Jan Habermann <jan@habermann.io>
 * John Granström <granstrom.john@gmail.com>
+* Clemens Backes <clemensb@google.com> (copyright owned by Google, Inc.)

--- a/src/support.js
+++ b/src/support.js
@@ -679,7 +679,7 @@ function convertJsFunctionToWasm(func, sig) {
     };
     var type = {
       parameters: sig.slice(1).split().map(c => typeNames[c]),
-      results: [typeNames[sig[0]]]
+      results: sig[0] == 'v' ? [] : [typeNames[sig[0]]]
     };
     return new WebAssembly.Function(type, func);
   }

--- a/src/support.js
+++ b/src/support.js
@@ -669,6 +669,24 @@ function convertJsFunctionToWasm(func, sig) {
   return func;
 #else // WASM2JS
 
+  // If the type reflection proposal is available, use the new
+  // "WebAssembly.Function" constructor.
+  // Otherwise, construct a minimal wasm module importing the JS function and
+  // reexporting it.
+  if (typeof WebAssembly.Function == "function") {
+    var typeNames = {
+      'i': 'i32',
+      'j': 'i64',
+      'f': 'f32',
+      'd': 'f64'
+    };
+    var type = {
+      parameters: sig.slice(1).split().map(c => typeNames[c]),
+      results: [typeNames[sig[0]]]
+    };
+    return new WebAssembly.Function(type, func);
+  }
+
   // The module is static, with the exception of the type section, which is
   // generated based on the signature passed in.
   var typeSection = [

--- a/src/support.js
+++ b/src/support.js
@@ -661,9 +661,6 @@ var functionPointers = new Array({{{ RESERVED_FUNCTION_POINTERS }}});
 
 #if WASM
 // Wraps a JS function as a wasm function with a given signature.
-// In the future, we may get a WebAssembly.Function constructor. Until then,
-// we create a wasm module that takes the JS function as an import with a given
-// signature, and re-exports that as a wasm function.
 function convertJsFunctionToWasm(func, sig) {
 #if WASM2JS
   return func;
@@ -673,7 +670,7 @@ function convertJsFunctionToWasm(func, sig) {
   // "WebAssembly.Function" constructor.
   // Otherwise, construct a minimal wasm module importing the JS function and
   // re-exporting it.
-  if (typeof WebAssembly.Function == "function") {
+  if (typeof WebAssembly.Function === "function") {
     var typeNames = {
       'i': 'i32',
       'j': 'i64',

--- a/src/support.js
+++ b/src/support.js
@@ -678,9 +678,12 @@ function convertJsFunctionToWasm(func, sig) {
       'd': 'f64'
     };
     var type = {
-      parameters: sig.slice(1).split().map(c => typeNames[c]),
+      parameters: [],
       results: sig[0] == 'v' ? [] : [typeNames[sig[0]]]
     };
+    for (var i = 1; i < sig.length; ++i) {
+      type.parameters.push(typeNames[sig[i]]);
+    }
     return new WebAssembly.Function(type, func);
   }
 

--- a/src/support.js
+++ b/src/support.js
@@ -672,7 +672,7 @@ function convertJsFunctionToWasm(func, sig) {
   // If the type reflection proposal is available, use the new
   // "WebAssembly.Function" constructor.
   // Otherwise, construct a minimal wasm module importing the JS function and
-  // reexporting it.
+  // re-exporting it.
   if (typeof WebAssembly.Function == "function") {
     var typeNames = {
       'i': 'i32',


### PR DESCRIPTION
With the type reflection proposal, we will get a way more efficient way
to convert a JS function into a wasm exported function. Use that if
available.