### PR TITLE
Add necessary ogg file to compilation of sdl2_mixer

### DIFF
--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -34,7 +34,7 @@ def get(ports, settings, shared):
     final = os.path.join(dest_path, libname)
     ports.build_port(dest_path, final, [], ['-DOGG_MUSIC', '-s', 'USE_VORBIS=1'],
                      ['dynamic_flac', 'dynamic_fluidsynth', 'dynamic_mod', 'dynamic_modplug', 'dynamic_mp3',
-                      'dynamic_ogg', 'fluidsynth', 'load_mp3', 'music_cmd', 'music_flac', 'music_mad', 'music_mod',
+                      'fluidsynth', 'load_mp3', 'music_cmd', 'music_flac', 'music_mad', 'music_mod',
                       'music_modplug', 'playmus.c', 'playwave.c'],
                      ['external', 'native_midi', 'timidity'])
     return final


### PR DESCRIPTION
I'm unsure why the automated tests did not catch this in PR #9849, as dynamic_ogg.c contains the definition of the variable `vorbis`, which is referenced as an extern in a file that did get compiled in. Anyways, add the file to the port, as it otherwise breaks compilation.