### PR TITLE
GL_UNSIGNED_SHORT_5_6_5_REV

### DIFF
--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -127,6 +127,15 @@ var LibraryWebGL2 = {
         return HEAPU16;
       case 0x1404 /* GL_INT */:
         return HEAP32;
+      case 0x1406 /* GL_FLOAT */:
+        return HEAPF32;
+      default:
+#if GL_ASSERTIONS
+        err('GL_INVALID_PARAMETER error in _heapObjectForWebGLType! Specified GL color format type=0x' + type.toString(16) + ' is not supported!');
+#endif
+        // Do not record a GL error, since the users of _heapObjectForWebGLType will call out to a WebGL function, so browser will record an error.
+        // Because of the ensuing error, we can return an arbitrary type from here. Choose to return the HEAPU32 type since most of the enumerant
+        // values are of this type: (that way Closure compiler might be able to fold these away)
       case 0x1405 /* GL_UNSIGNED_INT */:
       case 0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */:
       case 0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */:
@@ -134,8 +143,6 @@ var LibraryWebGL2 = {
       case 0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */:
       case 0x84FA /* GL_UNSIGNED_INT_24_8 */:
         return HEAPU32;
-      case 0x1406 /* GL_FLOAT */:
-        return HEAPF32;
     }
   },
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2663,6 +2663,10 @@ Module["preRun"].push(function () {
     self.btest(path_from_root('tests', 'webgl2_backwards_compatibility_emulation.cpp'), args=['-s', 'USE_WEBGL2=1', '-s', 'WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1'], expected='0')
 
   @requires_graphics_hardware
+  def test_webgl2_invalid_teximage2d_type(self):
+    self.btest(path_from_root('tests', 'webgl2_invalid_teximage2d_type.cpp'), args=['-s', 'USE_WEBGL2=1'], expected='0')
+
+  @requires_graphics_hardware
   def test_webgl_with_closure(self):
     self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'USE_WEBGL2=1', '--closure', '1', '-lGL'], expected='0')
 

--- a/tests/webgl2_invalid_teximage2d_type.cpp
+++ b/tests/webgl2_invalid_teximage2d_type.cpp
@@ -30,7 +30,8 @@ int main()
   GLuint tex;
   glGenTextures(1, &tex);
   glBindTexture(GL_TEXTURE_2D, tex);
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5_REV, 0);
+  void* data = new char[512];
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5_REV, data);
   assert(glGetError() != 0); // We should be getting an error
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);

--- a/tests/webgl2_invalid_teximage2d_type.cpp
+++ b/tests/webgl2_invalid_teximage2d_type.cpp
@@ -1,0 +1,38 @@
+// Copyright 2017 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <GLES3/gl3.h>
+#include <GLES2/gl2ext.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+// WebGL 2 core does not support GL_UNSIGNED_SHORT_5_6_5_REV extension.
+#define GL_UNSIGNED_SHORT_5_6_5_REV 0x8364
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+  attrs.majorVersion = 2;
+  attrs.minorVersion = 0;
+  attrs.enableExtensionsByDefault = 0; // Make sure we don't accidentally enable an extension that would bring GL_UNSIGNED_SHORT_5_6_5_REV support.
+
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context("#canvas", &attrs);
+  assert(context);
+  EMSCRIPTEN_RESULT res = emscripten_webgl_make_context_current(context);
+  assert(res == EMSCRIPTEN_RESULT_SUCCESS);
+  GLuint tex;
+  glGenTextures(1, &tex);
+  glBindTexture(GL_TEXTURE_2D, tex);
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 16, 16, 0, GL_RGB, GL_UNSIGNED_SHORT_5_6_5_REV, 0);
+  assert(glGetError() != 0); // We should be getting an error
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+}


### PR DESCRIPTION
This does two things:
1.  If using type GL_UNSIGNED_SHORT_5_6_5_REV causes exceptions to be thrown from browser's WebGL implementation due to undefined heap type being passed to WebGL API, this changes so that instead of `undefined` heap type being passed, `HEAPU32` will be passed instead.
2. If https://github.com/google/closure-compiler/issues/3513 is implemented in Closure compiler, this PR optimizes away 65 bytes,

`case 5125:case 34042:case 35902:case 33640:case 35899:case 34042:`

from a WebGL 2 using application.

However when testing, it did not look like 1. occurs, i.e. there does not seem to be an exception to be thrown when `undefined` is passed, and also the optimization 2. is not actually performed by Closure compiler at the moment. So this PR should not land until 1. or 2. becomes true.