### PR TITLE
Optimize accesses to domElement.getBoundingClientRect()

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -377,7 +377,7 @@ var LibraryJSEvents = {
   // eventStruct: the structure to populate.
   // e: The JS mouse event to read data from.
   // target: Specifies a target DOM element that will be used as the reference to populate targetX and targetY parameters.
-  _fillMouseEventData__deps: ['$JSEvents', '_getBoundingClientRect'],
+  _fillMouseEventData__deps: ['$JSEvents', '_getBoundingClientRect', '_specialEventTargets'],
   _fillMouseEventData: function(eventStruct, e, target) {
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.timestamp, 'JSEvents.tick()', 'double') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.screenX, 'e.screenX', 'i32') }}};
@@ -403,14 +403,10 @@ var LibraryJSEvents = {
       {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.canvasY, '0', 'i32') }}};
     }
 #endif
-    if (target) {
-      var rect = __getBoundingClientRect(target);
-      {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.targetX, 'e.clientX - rect.left', 'i32') }}};
-      {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.targetY, 'e.clientY - rect.top', 'i32') }}};
-    } else { // No specific target passed, return 0.
-      {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.targetX, '0', 'i32') }}};
-      {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.targetY, '0', 'i32') }}};
-    }
+    var rect = __specialEventTargets.indexOf(target) < 0 ? __getBoundingClientRect(target) : {'left':0,'top':0};
+    {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.targetX, 'e.clientX - rect.left', 'i32') }}};
+    {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.targetY, 'e.clientY - rect.top', 'i32') }}};
+
     // wheel and mousewheel events contain wrong screenX/screenY on chrome/opera
       // https://github.com/emscripten-core/emscripten/pull/4997
     // https://bugs.chromium.org/p/chromium/issues/detail?id=699956

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1135,8 +1135,13 @@ var LibraryJSEvents = {
     var cssWidth = strategy.softFullscreen ? innerWidth : screen.width;
     var cssHeight = strategy.softFullscreen ? innerHeight : screen.height;
     var rect = __getBoundingClientRect(target);
+#if LEGACY_VM_SUPPORT
+    var windowedCssWidth = rect.right - rect.left;
+    var windowedCssHeight = rect.bottom - rect.top;
+#else
     var windowedCssWidth = rect.width; // .getBoundingClientRect(element).width & .height do not work on IE 8 and older, IE 9+ is required
     var windowedCssHeight = rect.height;
+#endif
     var canvasSize = __get_canvas_element_size(target);
     var windowedRttWidth = canvasSize[0];
     var windowedRttHeight = canvasSize[1];
@@ -2811,9 +2816,14 @@ var LibraryJSEvents = {
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
 
     var rect = __getBoundingClientRect(target);
+#if LEGACY_VM_SUPPORT
+    {{{ makeSetValue('width', '0', 'rect.right - rect.left', 'double') }}};
+    {{{ makeSetValue('height', '0', 'rect.bottom - rect.top', 'double') }}};
+#else
     // N.b. .getBoundingClientRect(element).width & .height do not exist on IE 8, so IE 9+ is needed.
     {{{ makeSetValue('width', '0', 'rect.width', 'double') }}};
     {{{ makeSetValue('height', '0', 'rect.height', 'double') }}};
+#endif
 
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },

--- a/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE.sent
+++ b/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE.sent
@@ -425,6 +425,7 @@ __fillVisibilityChangeEventData
 __findCanvasEventTarget
 __findEventTarget
 __formatString
+__getBoundingClientRect
 __get_canvas_element_size
 __glGenObject
 __heapAccessShiftForWebGLHeap

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8228,7 +8228,7 @@ int main() {
                       4, [],        [],           8,   0,    0,  0), # noqa; totally empty!
     # we don't metadce with linkable code! other modules may want stuff
     # don't compare the # of functions in a main module, which changes a lot
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1604, [], [], 226403, None, 108, None), # noqa
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1605, [], [], 226403, None, 108, None), # noqa
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   13, [], [],  10017,   13,   9,   20), # noqa
   })
   @no_wasm_backend()


### PR DESCRIPTION
Optimize accesses to domElement.getBoundingClientRect() by manually outlining it for Closure, and refer to .width and .height (which drops support for IE 8 and older, https://caniuse.com/#search=getBoundingClientRect ). Also drops support for all browsers that do not have the .getBoundingClientRect() function at all, which are some ancient ones.