### PR TITLE
 Fix source maps issues on windows; followup to #9882 

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9723,17 +9723,17 @@ int main () {
   @parameterized({
     'c': ['c', [
       r'in malloc.*a\.out\.wasm\+0x',
-      r'(?im)in f (|[/a-z\.]:).*/test_lsan_leaks\.c:6:21$',
-      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:10:16$',
-      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:12:3$',
-      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:13:3$',
+      r'(?im)in f (|[/a-z\.\\]:).*test_lsan_leaks\.c:6:21$',
+      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.c:10:16$',
+      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.c:12:3$',
+      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.c:13:3$',
     ]],
     'cpp': ['cpp', [
       r'in operator new\[\]\(unsigned long\).*a\.out\.wasm\+0x',
-      r'(?im)in f\(\) (|[/a-z\.]:).*/test_lsan_leaks\.cpp:4:21$',
-      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:8:16$',
-      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:10:3$',
-      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:11:3$',
+      r'(?im)in f\(\) (|[/a-z\.\\]:).*test_lsan_leaks\.cpp:4:21$',
+      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.cpp:8:16$',
+      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.cpp:10:3$',
+      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.cpp:11:3$',
     ]],
   })
   @no_fastcomp('lsan not supported on fastcomp')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9723,17 +9723,17 @@ int main () {
   @parameterized({
     'c': ['c', [
       r'in malloc.*a\.out\.wasm\+0x',
-      r'(?im)in f (|[/a-z\.\\]:).*test_lsan_leaks\.c:6:21$',
-      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.c:10:16$',
-      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.c:12:3$',
-      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.c:13:3$',
+      r'(?im)in f (|[/a-z\.]:).*/test_lsan_leaks\.c:6:21$',
+      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:10:16$',
+      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:12:3$',
+      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.c:13:3$',
     ]],
     'cpp': ['cpp', [
       r'in operator new\[\]\(unsigned long\).*a\.out\.wasm\+0x',
-      r'(?im)in f\(\) (|[/a-z\.\\]:).*test_lsan_leaks\.cpp:4:21$',
-      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.cpp:8:16$',
-      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.cpp:10:3$',
-      r'(?im)in main (|[/a-z\.\\]:).*test_lsan_leaks\.cpp:11:3$',
+      r'(?im)in f\(\) (|[/a-z\.]:).*/test_lsan_leaks\.cpp:4:21$',
+      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:8:16$',
+      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:10:3$',
+      r'(?im)in main (|[/a-z\.]:).*/test_lsan_leaks\.cpp:11:3$',
     ]],
   })
   @no_fastcomp('lsan not supported on fastcomp')

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -59,7 +59,6 @@ class Prefixes:
     if name in self.cache:
       return self.cache[name]
 
-    result = name.replace('\\', '/').replace('//', '/')
     for p in self.prefixes:
       if name.startswith(p['prefix']):
         if p['replacement'] is None:
@@ -270,6 +269,8 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, bas
       column = 1
     address = entry['address'] + code_section_offset
     file_name = entry['file']
+    # normalize between OSes
+    file_name = file_name.replace('\\', '/').replace('//', '/')
     # if prefixes were provided, we use that; otherwise, we emit a relative
     # path
     if prefixes.provided():


### PR DESCRIPTION
After #9882 we don't always call `.resolve`, so the path
normalization must be pulled into a place that dominates
all code paths.