### PR TITLE
wasm-sourcemap.py: normalize path after relativization too

### DIFF
--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -249,6 +249,10 @@ def read_dwarf_entries(wasm, options):
   return sorted(entries, key=lambda entry: entry['address'])
 
 
+def normalize_path(path):
+  return path.replace('\\', '/').replace('//', '/')
+
+
 def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, base_path):
   sources = []
   sources_content = [] if collect_sources else None
@@ -269,14 +273,14 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, bas
       column = 1
     address = entry['address'] + code_section_offset
     file_name = entry['file']
-    # normalize between OSes
-    file_name = file_name.replace('\\', '/').replace('//', '/')
+    file_name = normalize_path(file_name)
     # if prefixes were provided, we use that; otherwise, we emit a relative
     # path
     if prefixes.provided():
       source_name = prefixes.sources.resolve(file_name)
     else:
       file_name = os.path.relpath(os.path.abspath(file_name), base_path)
+      file_name = normalize_path(file_name)
       source_name = file_name
     if source_name not in sources_map:
       source_id = len(sources)


### PR DESCRIPTION
(last fix wasn't complete, hopefully this one is!)