### PR TITLE
Enable sound and see how circleci responds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,7 @@ commands:
             EMTEST_LACKS_THREAD_SUPPORT: "1"
             DISPLAY: ":0"
           command: |
+            pactl list sinks short
             export EMTEST_BROWSER="$HOME/firefox/firefox -profile $HOME/tmp-firefox-profile/"
             # Start an X session. Openbox might be optional for now, but
             # an ICCCM/EWMH compliant window manager is potentially needed
@@ -217,7 +218,6 @@ commands:
             EXTRA_AUTOSTART=$TMPDIR/autostart startx /usr/bin/openbox-session -- $DISPLAY -config ~/.config/X11/xorg.conf -nolisten tcp &
             cat $TMPDIR/fifo > /dev/null # wait until $EXTRA_AUTOSTART is spawned, which indicates the end of Openbox initialization
             rm -r $TMPDIR
-            pactl list sinks short
             python3 tests/runner.py browser skip:browser.test_sdl2_mouse skip:browser.test_html5_webgl_create_context skip:browser.test_webgl_offscreen_canvas_in_pthread skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread skip:browser.test_glut_glutget
             openbox --exit
             wait || true # wait for startx to shutdown cleanly, or not

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,10 @@ commands:
           # Must be absolute path or relative path from working_directory
           at: ~/
       - run:
+          name: install pulseaudio
+          command: |
+            sudo apt install --yes pulseaudio-utils
+      - run:
           name: download firefox
           command: |
             wget -O ~/ff.tar.bz2 "https://download.mozilla.org/?product=firefox-devedition-latest-ssl&os=linux64&lang=en-US"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ commands:
       - run:
           name: install pulseaudio
           command: |
-            sudo apt install --yes pulseaudio-utils
+            apt install --yes pulseaudio-utils
       - run:
           name: download firefox
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,9 @@ commands:
           name: run tests
           environment:
             GALLIUM_DRIVER: softpipe # TODO: use the default llvmpipe when it supports more extensions
-            EMTEST_LACKS_SOUND_HARDWARE: "1"
+            EMTEST_LACKS_SOUND_HARDWARE: "0"
+            SDL_AUDIODRIVER: "pulseaudio"
+            PULSE_SINK: 0
             # OffscreenCanvas support is not yet done in Firefox.
             EMTEST_LACKS_OFFSCREEN_CANVAS: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
@@ -211,6 +213,7 @@ commands:
             EXTRA_AUTOSTART=$TMPDIR/autostart startx /usr/bin/openbox-session -- $DISPLAY -config ~/.config/X11/xorg.conf -nolisten tcp &
             cat $TMPDIR/fifo > /dev/null # wait until $EXTRA_AUTOSTART is spawned, which indicates the end of Openbox initialization
             rm -r $TMPDIR
+            pactl list sinks short
             python3 tests/runner.py browser skip:browser.test_sdl2_mouse skip:browser.test_html5_webgl_create_context skip:browser.test_webgl_offscreen_canvas_in_pthread skip:browser.test_webgl_offscreen_canvas_in_mainthread_after_pthread skip:browser.test_glut_glutget
             openbox --exit
             wait || true # wait for startx to shutdown cleanly, or not


### PR DESCRIPTION
#9913 showed that a couple of tests are skipped because of a lack of sound on circleci. This PR aims to enable it.