### PR TITLE
Fix other.test_wasm_sourcemap_relative_paths

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8945,7 +8945,7 @@ int main() {
     test('a.cpp')
 
     os.mkdir('inner')
-    test(os.path.join('inner', 'a.cpp'), 'inner')
+    test('inner/a.cpp', 'inner')
 
   def test_wasm_producers_section(self):
     # no producers section by default


### PR DESCRIPTION
Source map paths always use forward slashes, even on windows.
