### PR TITLE
Support reference-types for wasm-ld

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -442,3 +442,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jan Habermann <jan@habermann.io>
 * John Granström <granstrom.john@gmail.com>
 * Clemens Backes <clemensb@google.com> (copyright owned by Google, Inc.)
+* Valentin Churavy <v.churavy@gmail.com>

--- a/src/settings.js
+++ b/src/settings.js
@@ -1142,6 +1142,9 @@ var WASM_BACKEND = 0;
 // [compile+link]
 var WASM_OBJECT_FILES = 1;
 
+// Whether to enable LLVM's experimental support for reference types.
+var REFERENCE_TYPES = 0;
+
 // An optional comma-separated list of script hooks to run after binaryen,
 // in binaryen's /scripts dir.
 var BINARYEN_SCRIPTS = "";

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1824,6 +1824,9 @@ class Building(object):
     # and https://bugs.llvm.org/show_bug.cgi?id=39488
     args += ['-disable-lsr']
 
+    if Settings.REFERENCE_TYPES:
+      args += ['-mattr=reference-types']
+
     return args
 
   @staticmethod


### PR DESCRIPTION
I am working on supporting `anyref` in LLVM (x-ref: https://reviews.llvm.org/D66035) and I am opening this PR to gather feedback on
how to best integrate it into emscripten. Currently this works:

```llvm
target datalayout = "e-m:e-p:32:32-i64:64-n32:64-S128-ni:256"
target triple = "wasm32-unknown-unknown"

declare i8 addrspace(256)* @test(i8 addrspace(256)*)

define i8 addrspace(256)* @call_test(i8 addrspace(256)*) {
  %a = call i8 addrspace(256)* @test(i8 addrspace(256)* %0)
  ret i8 addrspace(256)* %a
}
```

Compiling it with

```
llc -mattr=reference-types --filetype=obj anyref.ll -o anyref.o
wasm-ld --allow-undefined --no-entry --export-dynamic -o anyref.wasm
wasm-dis anyref.wasm
(module
 (type $0 (func (param anyref) (result anyref)))
 (import "env" "test" (func $test (param anyref) (result anyref)))
 (memory $0 2)
 (table $0 1 1 funcref)
 (global $global$0 (mut i32) (i32.const 66560))
 (export "memory" (memory $0))
 (export "call_test" (func $call_test))
 (func $call_test (; 1 ;) (type $0) (param $0 anyref) (result anyref)
  (call $test
   (local.get $0)
  )
 )
)
```
And with:

```
emcc -g2 -s SIDE_MODULE=1 -s REFERENCE_TYPES=1 -s WASM=1 /data/vchuravy/llvm-project/llvm/test/CodeGen/WebAssembly/anyref.ll -o anyref.wasm
wasm-dis anyref.wasm
(module
 (type $0 (func))
 (type $1 (func (param anyref) (result anyref)))
 (import "env" "memory" (memory $3 0))
 (import "env" "table" (table $timport$4 0 funcref))
 (import "env" "__memory_base" (global $gimport$1 i32))
 (import "env" "__table_base" (global $gimport$2 i32))
 (import "env" "test" (func $test (param anyref) (result anyref)))
 (global $global$0 i32 (i32.const 0))
 (export "__wasm_apply_relocs" (func $__wasm_apply_relocs))
 (export "call_test" (func $call_test))
 (export "__dso_handle" (global $global$0))
 (export "__post_instantiate" (func $__post_instantiate))
 (func $__wasm_call_ctors (; 1 ;) (type $0)
  (call $__wasm_apply_relocs)
 )
 (func $__wasm_apply_relocs (; 2 ;) (type $0)
 )
 (func $call_test (; 3 ;) (type $1) (param $0 anyref) (result anyref)
  (call $test
   (local.get $0)
  )
 )
 (func $__post_instantiate (; 4 ;) (type $0)
  (call $__wasm_call_ctors)
 )
 ;; custom section "dylink", size 5
)
```
cc: @keno 