### PR TITLE
Micro-optimize size of _heapAccessShiftForWebGLType

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1507,7 +1507,7 @@ var LibraryGL = {
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
       } else if (pixels != 0) {
-        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
       } else {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, null);
       }
@@ -1538,7 +1538,7 @@ var LibraryGL = {
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
       } else if (pixels != 0) {
-        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
       } else {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, null);
       }
@@ -1562,7 +1562,7 @@ var LibraryGL = {
       if (GLctx.currentPixelPackBufferBinding) {
         GLctx.readPixels(x, y, width, height, format, type, pixels);
       } else {
-        GLctx.readPixels(x, y, width, height, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+        GLctx.readPixels(x, y, width, height, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
       }
       return;
     }

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -139,22 +139,59 @@ var LibraryWebGL2 = {
     }
   },
 
-  _heapAccessShiftForWebGLType: {
-      0x1402 /* GL_SHORT */: 1,
-      0x1403 /* GL_UNSIGNED_SHORT */: 1,
-      0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */: 1,
-      0x8033 /* GL_UNSIGNED_SHORT_4_4_4_4 */: 1,
-      0x8034 /* GL_UNSIGNED_SHORT_5_5_5_1 */: 1,
-      0x8D61 /* GL_HALF_FLOAT_OES */: 1,
-      0x140B /* GL_HALF_FLOAT */: 1,
-      0x1404 /* GL_INT */: 2,
-      0x1406 /* GL_FLOAT */: 2,
-      0x1405 /* GL_UNSIGNED_INT */: 2,
-      0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */: 2,
-      0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */: 2,
-      0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */: 2,
-      0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */: 2,
-      0x84FA /* GL_UNSIGNED_INT_24_8 */: 2
+#if MINIMAL_RUNTIME && GL_ASSERTIONS
+  _heapAccessShiftForWebGLType__deps: ['$warnOnce'],
+#endif
+  _heapAccessShiftForWebGLType: function (type) {
+#if GL_ASSERTIONS
+    switch(type)
+    {
+      case 0x1400 /* GL_BYTE */:
+      case 0x1401 /* GL_UNSIGNED_BYTE */:
+      case 0x1402 /* GL_SHORT */:
+      case 0x1403 /* GL_UNSIGNED_SHORT */:
+      case 0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */:
+      case 0x8033 /* GL_UNSIGNED_SHORT_4_4_4_4 */:
+      case 0x8034 /* GL_UNSIGNED_SHORT_5_5_5_1 */:
+      case 0x8D61 /* GL_HALF_FLOAT_OES */:
+      case 0x140B /* GL_HALF_FLOAT */:
+      case 0x1404 /* GL_INT */:
+      case 0x1405 /* GL_UNSIGNED_INT */:
+      case 0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */:
+      case 0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */:
+      case 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */:
+      case 0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */:
+      case 0x84FA /* GL_UNSIGNED_INT_24_8 */:
+      case 0x1406 /* GL_FLOAT */:
+        break;
+      default:
+        warnOnce('GL_INVALID_ENUM in _heapAccessShiftForWebGLType: type=0x' + type.toString(16) + ' (not reported again for this type)');
+    }
+#endif
+    // Break down the actual type lookup to smaller and more efficient form than a sparse switch case.
+
+    // Uint8 array shifts: 0x1400 /* GL_BYTE */ and 0x1401 /* GL_UNSIGNED_BYTE */
+    if (type < 0x1402) return 0;
+
+    // Uint16 array shifts:
+    if (type < 0x1404 // type == 0x1402 /* GL_SHORT */ || type == 0x1403 /* GL_UNSIGNED_SHORT */
+      || type == 0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */
+      || type == 0x8033 /* GL_UNSIGNED_SHORT_4_4_4_4 */
+      || type == 0x8034 /* GL_UNSIGNED_SHORT_5_5_5_1 */
+      || type == 0x8D61 /* GL_HALF_FLOAT_OES */
+      || type == 0x140B /* GL_HALF_FLOAT */)
+      return 1;
+
+    // All the rest are Uint32 array shifts. Avoid referring to them one by one for smallest code size.
+    // 0x1404 /* GL_INT */: 2,
+    // 0x1406 /* GL_FLOAT */: 2,
+    // 0x1405 /* GL_UNSIGNED_INT */: 2,
+    // 0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */: 2,
+    // 0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */: 2,
+    // 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */: 2,
+    // 0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */: 2,
+    // 0x84FA /* GL_UNSIGNED_INT_24_8 */: 2
+    return 2;
   },
 
   glGetBufferParameteri64v__sig: 'viii',
@@ -205,7 +242,7 @@ var LibraryWebGL2 = {
     if (GLctx.currentPixelUnpackBufferBinding) {
       GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, pixels);
     } else if (pixels != 0) {
-      GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+      GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
     } else {
       GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, null);
     }
@@ -217,7 +254,7 @@ var LibraryWebGL2 = {
     if (GLctx.currentPixelUnpackBufferBinding) {
       GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
     } else if (pixels != 0) {
-      GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+      GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
     } else {
       GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, null);
     }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9531,7 +9531,7 @@ int main () {
       (opts, hello_world_sources, {'a.html': 968, 'a.js': 604, 'a.wasm': 86}),
       (asmjs + opts, hello_webgl_sources, {'a.html': 881, 'a.js': 5035, 'a.asm.js': 11094, 'a.mem': 321}),
       (opts, hello_webgl_sources, {'a.html': 857, 'a.js': 5083, 'a.wasm': 8841}),
-      (opts, hello_webgl2_sources, {'a.html': 857, 'a.js': 6192, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
+      (opts, hello_webgl2_sources, {'a.html': 857, 'a.js': 6136, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True


### PR DESCRIPTION
Micro-optimize size of _heapAccessShiftForWebGLType to be 56 bytes smaller for WebGL 2 demo. (This also might improve performance, since sparse switch cases are often implemented as binary search, although this is not in a hot code path in any way to have a difference)

Not that these are particularly impressive or relevant, but the intent of this is to allow showcasing a 4K or a 16K demo with Wasm+WebGL 2, hence squeezing things like this to be as small as possible.