### PR TITLE
Add setting fields to control which browser versions to support

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -863,6 +863,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # If not = is specified default to 1
           if '=' not in key:
             key += '=1'
+
+          # Special handling of browser version targets. A version -1 means that the specific version
+          # is not supported at all. Replace those with Infinity to make it possible to compare e.g.
+          # #if OLDEST_SUPPORTED_FIREFOX_VERSION < 68
+          try:
+            if key.startswith('OLDEST_SUPPORTED_') and int(key.split('=')[1]) < 0:
+              key = key.split('=')[0] + '=Infinity'
+          except Exception:
+            pass
+
           settings_changes.append(key)
           newargs[i] = newargs[i + 1] = ''
           if key == 'WASM_BACKEND=1':

--- a/emcc.py
+++ b/emcc.py
@@ -866,9 +866,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
           # Special handling of browser version targets. A version -1 means that the specific version
           # is not supported at all. Replace those with Infinity to make it possible to compare e.g.
-          # #if OLDEST_SUPPORTED_FIREFOX_VERSION < 68
+          # #if MIN_FIREFOX_VERSION < 68
           try:
-            if key.startswith('OLDEST_SUPPORTED_') and int(key.split('=')[1]) < 0:
+            if re.match(r'MIN_.*_VERSION(=.*)?', key) and int(key.split('=')[1]) < 0:
               key = key.split('=')[0] + '=Infinity'
           except Exception:
             pass

--- a/emcc.py
+++ b/emcc.py
@@ -1243,6 +1243,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
 
+      # Support all old browser versions
+      shared.Settings.MIN_FIREFOX_VERSION = 0
+      shared.Settings.MIN_SAFARI_VERSION = 0
+      shared.Settings.MIN_IE_VERSION = 0
+      shared.Settings.MIN_EDGE_VERSION = 0
+      shared.Settings.MIN_CHROME_VERSION = 0
+
     # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
     if shared.Settings.WASM and not shared.Settings.WASM2JS:
       shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -114,7 +114,7 @@ var LibraryJSEvents = {
     // Stores objects representing each currently registered JS event handler.
     eventHandlers: [],
 
-#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
     isInternetExplorer: function() { return navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0; },
 #endif
 
@@ -250,7 +250,7 @@ var LibraryJSEvents = {
 
     var eventHandler = {
       target: __findEventTarget(target),
-#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
       allowsDeferredCalls: JSEvents.isInternetExplorer() ? false : true, // MSIE doesn't allow fullscreen and pointerlock requests from key handlers, others do.
 #else
       allowsDeferredCalls: true,
@@ -456,7 +456,7 @@ var LibraryJSEvents = {
       handlerFunc: mouseEventHandlerFunc,
       useCapture: useCapture
     };
-#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
     // In IE, mousedown events don't either allow deferred calls to be run!
     if (JSEvents.isInternetExplorer() && eventTypeString == 'mousedown') eventHandler.allowsDeferredCalls = false;
 #endif
@@ -1299,7 +1299,7 @@ var LibraryJSEvents = {
   // Add letterboxes to a fullscreen element in a cross-browser way.
   _setLetterbox__deps: ['$JSEvents'],
   _setLetterbox: function(element, topBottom, leftRight) {
-#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
     if (JSEvents.isInternetExplorer()) {
       // Cannot use padding on IE11, because IE11 computes padding in addition to the size, unlike
       // other browsers, which treat padding to be part of the size.
@@ -1314,7 +1314,7 @@ var LibraryJSEvents = {
       // Cannot use margin to specify letterboxes in FF or Chrome, since those ignore margins in fullscreen mode.
       element.style.paddingLeft = element.style.paddingRight = leftRight + 'px';
       element.style.paddingTop = element.style.paddingBottom = topBottom + 'px';
-#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
     }
 #endif
   },

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -114,7 +114,9 @@ var LibraryJSEvents = {
     // Stores objects representing each currently registered JS event handler.
     eventHandlers: [],
 
+#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
     isInternetExplorer: function() { return navigator.userAgent.indexOf('MSIE') !== -1 || navigator.appVersion.indexOf('Trident/') > 0; },
+#endif
 
     // Removes all event handlers on the given DOM element of the given type. Pass in eventTypeString == undefined/null to remove all event handlers regardless of the type.
     removeAllHandlersOnTarget: function(target, eventTypeString) {
@@ -248,7 +250,11 @@ var LibraryJSEvents = {
 
     var eventHandler = {
       target: __findEventTarget(target),
+#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
       allowsDeferredCalls: JSEvents.isInternetExplorer() ? false : true, // MSIE doesn't allow fullscreen and pointerlock requests from key handlers, others do.
+#else
+      allowsDeferredCalls: true,
+#endif
       eventTypeString: eventTypeString,
       callbackfunc: callbackfunc,
       handlerFunc: keyEventHandlerFunc,
@@ -450,8 +456,10 @@ var LibraryJSEvents = {
       handlerFunc: mouseEventHandlerFunc,
       useCapture: useCapture
     };
+#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
     // In IE, mousedown events don't either allow deferred calls to be run!
     if (JSEvents.isInternetExplorer() && eventTypeString == 'mousedown') eventHandler.allowsDeferredCalls = false;
+#endif
     JSEvents.registerOrRemoveHandler(eventHandler);
   },
 
@@ -1291,6 +1299,7 @@ var LibraryJSEvents = {
   // Add letterboxes to a fullscreen element in a cross-browser way.
   _setLetterbox__deps: ['$JSEvents'],
   _setLetterbox: function(element, topBottom, leftRight) {
+#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
     if (JSEvents.isInternetExplorer()) {
       // Cannot use padding on IE11, because IE11 computes padding in addition to the size, unlike
       // other browsers, which treat padding to be part of the size.
@@ -1301,10 +1310,13 @@ var LibraryJSEvents = {
       element.style.marginLeft = element.style.marginRight = leftRight + 'px';
       element.style.marginTop = element.style.marginBottom = topBottom + 'px';
     } else {
+#endif
       // Cannot use margin to specify letterboxes in FF or Chrome, since those ignore margins in fullscreen mode.
       element.style.paddingLeft = element.style.paddingRight = leftRight + 'px';
       element.style.paddingTop = element.style.paddingBottom = topBottom + 'px';
+#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED
     }
+#endif
   },
 
   _currentFullscreenStrategy: {},

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -554,7 +554,7 @@ var LibraryGL = {
 #endif
         (canvas.getContext("webgl", webGLContextAttributes)
           // https://caniuse.com/#feat=webgl
-#if OLDEST_SUPPORTED_IE_VERSION <= 10 || OLDEST_SUPPORTED_EDGE_VERSION <= 18 || OLDEST_SUPPORTED_FIREFOX_VERSION <= 23 || OLDEST_SUPPORTED_CHROME_VERSION <= 32 || OLDEST_SUPPORTED_SAFARI_VERSION <= 70101
+#if MIN_IE_VERSION <= 10 || MIN_EDGE_VERSION <= 18 || MIN_FIREFOX_VERSION <= 23 || MIN_CHROME_VERSION <= 32 || MIN_SAFARI_VERSION <= 70101
           || canvas.getContext("experimental-webgl", webGLContextAttributes)
 #endif
           );

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -552,7 +552,12 @@ var LibraryGL = {
 #if USE_WEBGL2
         (webGLContextAttributes.majorVersion > 1) ? canvas.getContext("webgl2", webGLContextAttributes) :
 #endif
-        (canvas.getContext("webgl", webGLContextAttributes) || canvas.getContext("experimental-webgl", webGLContextAttributes));
+        (canvas.getContext("webgl", webGLContextAttributes)
+          // https://caniuse.com/#feat=webgl
+#if OLDEST_SUPPORTED_IE_VERSION <= 10 || OLDEST_SUPPORTED_EDGE_VERSION <= 18 || OLDEST_SUPPORTED_FIREFOX_VERSION <= 23 || OLDEST_SUPPORTED_CHROME_VERSION <= 32 || OLDEST_SUPPORTED_SAFARI_VERSION <= 70101
+          || canvas.getContext("experimental-webgl", webGLContextAttributes)
+#endif
+          );
 
 #if GL_PREINITIALIZED_CONTEXT
       }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -8,6 +8,10 @@
 
 //"use strict";
 
+// Internal constant: Represents a preprocessor constant value for a browser/shell version that is not supported at all.
+// Used e.g. in form "#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED" to test if any version of IE should be suported.
+var TARGET_NOT_SUPPORTED = Infinity;
+
 // Does simple 'macro' substitution, using Django-like syntax,
 // {{{ code }}} will be replaced with |eval(code)|.
 // NOTE: Be careful with that ret check. If ret is |0|, |ret ? ret.toString() : ''| would result in ''!

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -9,7 +9,7 @@
 //"use strict";
 
 // Internal constant: Represents a preprocessor constant value for a browser/shell version that is not supported at all.
-// Used e.g. in form "#if OLDEST_SUPPORTED_IE_VERSION != TARGET_NOT_SUPPORTED" to test if any version of IE should be suported.
+// Used e.g. in form "#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED" to test if any version of IE should be suported.
 var TARGET_NOT_SUPPORTED = Infinity;
 
 // Does simple 'macro' substitution, using Django-like syntax,

--- a/src/settings.js
+++ b/src/settings.js
@@ -498,6 +498,7 @@ var POLYFILL_OLD_MATH_FUNCTIONS = 0;
 //  * Work around iOS 9 right shift bug (-s WORKAROUND_IOS_9_RIGHT_SHIFT_BUG=1)
 //  * Work around old Chromium WebGL 1 bug (-s WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG=1)
 //  * Disable WebAssembly. (Must be paired with -s WASM=0)
+//  * Adjusts MIN_X_VERSION settings to 0 to include support for all browser versions.
 // You can also configure the above options individually.
 var LEGACY_VM_SUPPORT = 0;
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1646,9 +1646,6 @@ var ASAN_SHADOW_SIZE = 33554432;
 // entries across function boundaries.
 var USE_OFFSET_CONVERTER = 0;
 
-// Browser version identifier that represents that the given browser is not to be supported at all.
-const TARGET_NOT_SUPPORTED = Infinity;
-
 // Specifies the oldest major version of Firefox to target. I.e. all Firefox versions >= OLDEST_SUPPORTED_FIREFOX_VERSION
 // are desired to work. Pass -s OLDEST_SUPPORTED_FIREFOX_VERSION=majorVersion to drop support for Firefox versions older than
 // < majorVersion.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1649,21 +1649,21 @@ var USE_OFFSET_CONVERTER = 0;
 // Specifies the oldest major version of Firefox to target. I.e. all Firefox versions >= MIN_FIREFOX_VERSION
 // are desired to work. Pass -s MIN_FIREFOX_VERSION=majorVersion to drop support for Firefox versions older than
 // < majorVersion.
-var MIN_FIREFOX_VERSION = 0;
+var MIN_FIREFOX_VERSION = 65; // Firefox ESR 60.5 (Firefox 65) was released on 2019-01-29.
 
 // Specifies the oldest version of desktop Safari to target. Version is encoded in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
-var MIN_SAFARI_VERSION = 0;
+var MIN_SAFARI_VERSION = 120000; // Safari 12.0.0 was released on September 17, 2018, bundled with macOS 10.14.0 Mojave
 
 // Specifies the oldest version of Internet Explorer to target. E.g. pass -s MIN_IE_VERSION = 11 to drop support
 // for IE 10 and older.
-var MIN_IE_VERSION = 0;
+var MIN_IE_VERSION = -1; // Internet Explorer is at end of life and does not support WebAssembly
 
 // Specifies the oldest version of Edge (EdgeHTML, the non-Chromium based flavor) to target. E.g. pass -s MIN_EDGE_VERSION=40
 // to drop support for EdgeHTML 39 and older.
-var MIN_EDGE_VERSION = 0;
+var MIN_EDGE_VERSION = 44; // Edge 44.17763 was released on November 13, 2018
 
 // Specifies the oldest version of Chrome. E.g. pass -s MIN_CHROME_VERSION=58 to drop support for Chrome 57 and older.
-var MIN_CHROME_VERSION = 0;
+var MIN_CHROME_VERSION = 75; // Chrome 75.0.3770 was released on 2019-06-04
 
 // Legacy settings that have been removed or renamed.
 // For renamed settings the format is:

--- a/src/settings.js
+++ b/src/settings.js
@@ -1646,27 +1646,27 @@ var ASAN_SHADOW_SIZE = 33554432;
 // entries across function boundaries.
 var USE_OFFSET_CONVERTER = 0;
 
-// Specifies the oldest major version of Firefox to target. I.e. all Firefox versions >= OLDEST_SUPPORTED_FIREFOX_VERSION
-// are desired to work. Pass -s OLDEST_SUPPORTED_FIREFOX_VERSION=majorVersion to drop support for Firefox versions older than
+// Specifies the oldest major version of Firefox to target. I.e. all Firefox versions >= MIN_FIREFOX_VERSION
+// are desired to work. Pass -s MIN_FIREFOX_VERSION=majorVersion to drop support for Firefox versions older than
 // < majorVersion.
-var OLDEST_SUPPORTED_FIREFOX_VERSION = 0;
+var MIN_FIREFOX_VERSION = 0;
 
 // Specifies the oldest version of desktop Safari to target. Version is encoded in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
-var OLDEST_SUPPORTED_SAFARI_VERSION = 0;
+var MIN_SAFARI_VERSION = 0;
 
 // Specifies the oldest version of mobile iOS Safari to target. Version is encoded in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
-var OLDEST_SUPPORTED_IOS_SAFARI_VERSION = 0;
+var MIN_IOS_SAFARI_VERSION = 0;
 
-// Specifies the oldest version of Internet Explorer to target. E.g. pass -s OLDEST_SUPPORTED_IE_VERSION = 11 to drop support
+// Specifies the oldest version of Internet Explorer to target. E.g. pass -s MIN_IE_VERSION = 11 to drop support
 // for IE 10 and older.
-var OLDEST_SUPPORTED_IE_VERSION = 0;
+var MIN_IE_VERSION = 0;
 
-// Specifies the oldest version of Edge (EdgeHTML, the non-Chromium based flavor) to target. E.g. pass -s OLDEST_SUPPORTED_EDGE_VERSION=40
+// Specifies the oldest version of Edge (EdgeHTML, the non-Chromium based flavor) to target. E.g. pass -s MIN_EDGE_VERSION=40
 // to drop support for EdgeHTML 39 and older.
-var OLDEST_SUPPORTED_EDGE_VERSION = 0;
+var MIN_EDGE_VERSION = 0;
 
-// Specifies the oldest version of Chrome. E.g. pass -s OLDEST_SUPPORTED_CHROME_VERSION=58 to drop support for Chrome 57 and older.
-var OLDEST_SUPPORTED_CHROME_VERSION = 0;
+// Specifies the oldest version of Chrome. E.g. pass -s MIN_CHROME_VERSION=58 to drop support for Chrome 57 and older.
+var MIN_CHROME_VERSION = 0;
 
 // Legacy settings that have been removed or renamed.
 // For renamed settings the format is:

--- a/src/settings.js
+++ b/src/settings.js
@@ -1646,6 +1646,31 @@ var ASAN_SHADOW_SIZE = 33554432;
 // entries across function boundaries.
 var USE_OFFSET_CONVERTER = 0;
 
+// Browser version identifier that represents that the given browser is not to be supported at all.
+const TARGET_NOT_SUPPORTED = Infinity;
+
+// Specifies the oldest major version of Firefox to target. I.e. all Firefox versions >= OLDEST_SUPPORTED_FIREFOX_VERSION
+// are desired to work. Pass -s OLDEST_SUPPORTED_FIREFOX_VERSION=majorVersion to drop support for Firefox versions older than
+// < majorVersion.
+var OLDEST_SUPPORTED_FIREFOX_VERSION = 0;
+
+// Specifies the oldest version of desktop Safari to target. Version is encoded in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
+var OLDEST_SUPPORTED_SAFARI_VERSION = 0;
+
+// Specifies the oldest version of mobile iOS Safari to target. Version is encoded in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
+var OLDEST_SUPPORTED_IOS_SAFARI_VERSION = 0;
+
+// Specifies the oldest version of Internet Explorer to target. E.g. pass -s OLDEST_SUPPORTED_IE_VERSION = 11 to drop support
+// for IE 10 and older.
+var OLDEST_SUPPORTED_IE_VERSION = 0;
+
+// Specifies the oldest version of Edge (EdgeHTML, the non-Chromium based flavor) to target. E.g. pass -s OLDEST_SUPPORTED_EDGE_VERSION=40
+// to drop support for EdgeHTML 39 and older.
+var OLDEST_SUPPORTED_EDGE_VERSION = 0;
+
+// Specifies the oldest version of Chrome. E.g. pass -s OLDEST_SUPPORTED_CHROME_VERSION=58 to drop support for Chrome 57 and older.
+var OLDEST_SUPPORTED_CHROME_VERSION = 0;
+
 // Legacy settings that have been removed or renamed.
 // For renamed settings the format is:
 // [OLD_NAME, NEW_NAME]

--- a/src/settings.js
+++ b/src/settings.js
@@ -1654,9 +1654,6 @@ var MIN_FIREFOX_VERSION = 0;
 // Specifies the oldest version of desktop Safari to target. Version is encoded in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
 var MIN_SAFARI_VERSION = 0;
 
-// Specifies the oldest version of mobile iOS Safari to target. Version is encoded in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
-var MIN_IOS_SAFARI_VERSION = 0;
-
 // Specifies the oldest version of Internet Explorer to target. E.g. pass -s MIN_IE_VERSION = 11 to drop support
 // for IE 10 and older.
 var MIN_IE_VERSION = 0;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10146,15 +10146,15 @@ int main() {
       run_process([PYTHON, EMCC, '-x', 'c++', '-'], input=f.read())
     self.assertContained('hello, world!', run_js('a.out.js'))
 
-  # Test that passing -s OLDEST_SUPPORTED_X_VERSION=-1 on the command line will result in browser X being not supported at all.
-  # I.e. -s OLDEST_SUPPORTED_X_VERSION=-1 is equal to -s OLDEST_SUPPORTED_X_VERSION=Infinity
+  # Test that passing -s MIN_X_VERSION=-1 on the command line will result in browser X being not supported at all.
+  # I.e. -s MIN_X_VERSION=-1 is equal to -s MIN_X_VERSION=Infinity
   def test_drop_support_for_browser(self):
     # Test that -1 means "not supported"
-    run_process([PYTHON, EMCC, path_from_root('tests', 'test_html5.c'), '-s', 'OLDEST_SUPPORTED_IE_VERSION=-1'])
+    run_process([PYTHON, EMCC, path_from_root('tests', 'test_html5.c'), '-s', 'MIN_IE_VERSION=-1'])
     self.assertContained('allowsDeferredCalls: true', open('a.out.js').read())
     self.assertNotContained('allowsDeferredCalls: JSEvents.isInternetExplorer()', open('a.out.js').read())
 
     # Also test if someone wants to pass Infinity explicitly
-    run_process([PYTHON, EMCC, path_from_root('tests', 'test_html5.c'), '-s', 'OLDEST_SUPPORTED_IE_VERSION=Infinity'])
+    run_process([PYTHON, EMCC, path_from_root('tests', 'test_html5.c'), '-s', 'MIN_IE_VERSION=Infinity'])
     self.assertContained('allowsDeferredCalls: true', open('a.out.js').read())
     self.assertNotContained('allowsDeferredCalls: JSEvents.isInternetExplorer()', open('a.out.js').read())

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10145,3 +10145,16 @@ int main() {
     with open(path_from_root('tests', 'hello_world.cpp')) as f:
       run_process([PYTHON, EMCC, '-x', 'c++', '-'], input=f.read())
     self.assertContained('hello, world!', run_js('a.out.js'))
+
+  # Test that passing -s OLDEST_SUPPORTED_X_VERSION=-1 on the command line will result in browser X being not supported at all.
+  # I.e. -s OLDEST_SUPPORTED_X_VERSION=-1 is equal to -s OLDEST_SUPPORTED_X_VERSION=Infinity
+  def test_drop_support_for_browser(self):
+    # Test that -1 means "not supported"
+    run_process([PYTHON, EMCC, path_from_root('tests', 'test_html5.c'), '-s', 'OLDEST_SUPPORTED_IE_VERSION=-1'])
+    self.assertContained('allowsDeferredCalls: true', open('a.out.js').read())
+    self.assertNotContained('allowsDeferredCalls: JSEvents.isInternetExplorer()', open('a.out.js').read())
+
+    # Also test if someone wants to pass Infinity explicitly
+    run_process([PYTHON, EMCC, path_from_root('tests', 'test_html5.c'), '-s', 'OLDEST_SUPPORTED_IE_VERSION=Infinity'])
+    self.assertContained('allowsDeferredCalls: true', open('a.out.js').read())
+    self.assertNotContained('allowsDeferredCalls: JSEvents.isInternetExplorer()', open('a.out.js').read())


### PR DESCRIPTION
Add setting fields to control which browser versions to support, and apply it to experimental-webgl.