### PR TITLE
Micro optimize webgl

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -16,40 +16,44 @@ var LibraryGL = {
   _tempFixedLengthArray: [],
 
   _heapObjectForWebGLType: function(type) {
+    // Micro-optimization for size: Subtract lowest GL enum number (0x1400/* GL_BYTE */) from type to compare
+    // smaller values for the heap, for shorter generated code size.
+    // Also the type HEAPU16 is not tested for explicitly, but any unrecognized type will return out HEAPU16.
+    // (since most types are HEAPU16)
     type -= 0x1400;
 #if USE_WEBGL2
-    if (type == 0x1400 - 0x1400/* GL_BYTE */) return HEAP8;
+    if (type == {{{ 0x1400 - 0x1400/* GL_BYTE */ }}}) return HEAP8;
 #endif
 
-    if (type == 0x1401 - 0x1400/* GL_UNSIGNED_BYTE */) return HEAPU8;
+    if (type == {{{ 0x1401 - 0x1400/* GL_UNSIGNED_BYTE */ }}}) return HEAPU8;
 
 #if USE_WEBGL2
-    if (type == 0x1402 - 0x1400/* GL_SHORT */) return HEAP16;
+    if (type == {{{ 0x1402 - 0x1400/* GL_SHORT */ }}}) return HEAP16;
 #endif
 
-    if (type == 0x1404 - 0x1400/* GL_INT */) return HEAP32;
+    if (type == {{{ 0x1404 - 0x1400/* GL_INT */ }}}) return HEAP32;
 
-    if (type == 0x1406 - 0x1400/* GL_FLOAT */) return HEAPF32;
+    if (type == {{{ 0x1406 - 0x1400/* GL_FLOAT */ }}}) return HEAPF32;
 
-    if (type == 0x1405 - 0x1400 /* GL_UNSIGNED_INT */
-      || type == 0x84FA - 0x1400 /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */
+    if (type == {{{ 0x1405 - 0x1400 /* GL_UNSIGNED_INT */ }}}
+      || type == {{{ 0x84FA - 0x1400 /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */ }}}
 #if USE_WEBGL2
-      || type == 0x8368 - 0x1400 /* GL_UNSIGNED_INT_2_10_10_10_REV */
-      || type == 0x8C3B - 0x1400 /* GL_UNSIGNED_INT_10F_11F_11F_REV */
-      || type == 0x8C3E - 0x1400 /* GL_UNSIGNED_INT_5_9_9_9_REV */
+      || type == {{{ 0x8368 - 0x1400 /* GL_UNSIGNED_INT_2_10_10_10_REV */ }}}
+      || type == {{{ 0x8C3B - 0x1400 /* GL_UNSIGNED_INT_10F_11F_11F_REV */ }}}
+      || type == {{{ 0x8C3E - 0x1400 /* GL_UNSIGNED_INT_5_9_9_9_REV */ }}}
 #endif
       )
       return HEAPU32;
 
 #if GL_ASSERTIONS
-      if (type != 0x1403 - 0x1400 /* GL_UNSIGNED_SHORT */
+      if (type != {{{ 0x1403 - 0x1400 /* GL_UNSIGNED_SHORT */ }}}
 #if USE_WEBGL2
-        && type != 0x140B - 0x1400 /* GL_HALF_FLOAT */
+        && type != {{{ 0x140B - 0x1400 /* GL_HALF_FLOAT */ }}}
 #endif
-        && type != 0x8033 - 0x1400 /* GL_UNSIGNED_SHORT_4_4_4_4 */
-        && type != 0x8034 - 0x1400 /* GL_UNSIGNED_SHORT_5_5_5_1 */
-        && type != 0x8363 - 0x1400 /* GL_UNSIGNED_SHORT_5_6_5 */
-        && type != 0x8D61 - 0x1400 /* GL_HALF_FLOAT_OES */) {
+        && type != {{{ 0x8033 - 0x1400 /* GL_UNSIGNED_SHORT_4_4_4_4 */ }}}
+        && type != {{{ 0x8034 - 0x1400 /* GL_UNSIGNED_SHORT_5_5_5_1 */ }}}
+        && type != {{{ 0x8363 - 0x1400 /* GL_UNSIGNED_SHORT_5_6_5 */ }}}
+        && type != {{{ 0x8D61 - 0x1400 /* GL_HALF_FLOAT_OES */ }}}) {
         err('Invalid WebGL type 0x' + (type+0x1400).toString() + ' passed to _heapObjectForWebGLType!');
       }
 #endif
@@ -1419,19 +1423,19 @@ var LibraryGL = {
     var colorChannels = {
       // 0x1902 /* GL_DEPTH_COMPONENT */ - 0x1902: 1,
       // 0x1906 /* GL_ALPHA */ - 0x1902: 1,
-      5 /* 0x1907 (GL_RGB) - 0x1902 */: 3,
-      6 /* 0x1908 (GL_RGBA) - 0x1902 */: 4,
+      {{{ 0x1907 /* GL_RGB */ - 0x1902 }}}: 3,
+      {{{ 0x1908 /* GL_RGBA */ - 0x1902 }}}: 4,
       // 0x1909 /* GL_LUMINANCE */ - 0x1902: 1,
-      8 /* 0x190A (GL_LUMINANCE_ALPHA) - 0x1902 */: 2,
-      29502 /* 0x8C40 (GL_SRGB_EXT) - 0x1902 */: 3,
-      29504 /* 0x8C42 (GL_SRGB_ALPHA_EXT) - 0x1902 */: 4,
+      {{{ 0x190A /*GL_LUMINANCE_ALPHA*/ - 0x1902 }}}: 2,
+      {{{ 0x8C40 /*(GL_SRGB_EXT)*/ - 0x1902 }}}: 3,
+      {{{ 0x8C42 /*(GL_SRGB_ALPHA_EXT*/ - 0x1902 }}}: 4,
 #if USE_WEBGL2
       // 0x1903 /* GL_RED */ - 0x1902: 1,
-      26917 /* 0x8227 (GL_RG) - 0x1902 */: 2,
-      26918 /* 0x8228 (GL_RG_INTEGER) - 0x1902 */: 2,
+      {{{ 0x8227 /*GL_RG*/ - 0x1902 }}}: 2,
+      {{{ 0x8228 /*GL_RG_INTEGER*/ - 0x1902 }}}: 2,
       // 0x8D94 /* GL_RED_INTEGER */ - 0x1902: 1,
-      29846 /* 0x8D98 (GL_RGB_INTEGER) - 0x1902 */: 3,
-      29847 /* 0x8D99 (GL_RGBA_INTEGER) - 0x1902 */: 4
+      {{{ 0x8D98 /*GL_RGB_INTEGER*/ - 0x1902 }}}: 3,
+      {{{ 0x8D99 /*GL_RGBA_INTEGER*/ - 0x1902 }}}: 4
 #endif
     };
 #if GL_ASSERTIONS

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1507,7 +1507,7 @@ var LibraryGL = {
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
       } else if (pixels != 0) {
-        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
       } else {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, null);
       }
@@ -1538,7 +1538,7 @@ var LibraryGL = {
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
       } else if (pixels != 0) {
-        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
       } else {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, null);
       }
@@ -1562,7 +1562,7 @@ var LibraryGL = {
       if (GLctx.currentPixelPackBufferBinding) {
         GLctx.readPixels(x, y, width, height, format, type, pixels);
       } else {
-        GLctx.readPixels(x, y, width, height, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+        GLctx.readPixels(x, y, width, height, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
       }
       return;
     }

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -15,6 +15,51 @@ var LibraryGL = {
   _tempFixedLengthArray__postset: 'for (var i = 0; i < 32; i++) __tempFixedLengthArray.push(new Array(i));',
   _tempFixedLengthArray: [],
 
+  _heapObjectForWebGLType: function(type) {
+    type -= 0x1400;
+#if USE_WEBGL2
+    if (type == 0x1400 - 0x1400/* GL_BYTE */) return HEAP8;
+#endif
+
+    if (type == 0x1401 - 0x1400/* GL_UNSIGNED_BYTE */) return HEAPU8;
+
+#if USE_WEBGL2
+    if (type == 0x1402 - 0x1400/* GL_SHORT */) return HEAP16;
+#endif
+
+    if (type == 0x1404 - 0x1400/* GL_INT */) return HEAP32;
+
+    if (type == 0x1406 - 0x1400/* GL_FLOAT */) return HEAPF32;
+
+    if (type == 0x1405 - 0x1400 /* GL_UNSIGNED_INT */
+      || type == 0x84FA - 0x1400 /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */
+#if USE_WEBGL2
+      || type == 0x8368 - 0x1400 /* GL_UNSIGNED_INT_2_10_10_10_REV */
+      || type == 0x8C3B - 0x1400 /* GL_UNSIGNED_INT_10F_11F_11F_REV */
+      || type == 0x8C3E - 0x1400 /* GL_UNSIGNED_INT_5_9_9_9_REV */
+#endif
+      )
+      return HEAPU32;
+
+#if GL_ASSERTIONS
+      if (type != 0x1403 - 0x1400 /* GL_UNSIGNED_SHORT */
+#if USE_WEBGL2
+        && type != 0x140B - 0x1400 /* GL_HALF_FLOAT */
+#endif
+        && type != 0x8033 - 0x1400 /* GL_UNSIGNED_SHORT_4_4_4_4 */
+        && type != 0x8034 - 0x1400 /* GL_UNSIGNED_SHORT_5_5_5_1 */
+        && type != 0x8363 - 0x1400 /* GL_UNSIGNED_SHORT_5_6_5 */
+        && type != 0x8D61 - 0x1400 /* GL_HALF_FLOAT_OES */) {
+        err('Invalid WebGL type 0x' + (type+0x1400).toString() + ' passed to _heapObjectForWebGLType!');
+      }
+#endif
+    return HEAPU16;
+  },
+
+  _heapAccessShiftForWebGLHeap: function(heap) {
+    return 31 - Math.clz32(heap.BYTES_PER_ELEMENT);
+  },
+
   $GL__postset: 'var GLctx; GL.init()',
   $GL: {
 #if GL_DEBUG
@@ -1368,118 +1413,57 @@ var LibraryGL = {
     return height * alignedRowSize;
   },
 
-  _colorChannelsInGlTextureFormat: {
-    0x1906 /* GL_ALPHA */: 1,
-    0x1909 /* GL_LUMINANCE */: 1,
-    0x1902 /* GL_DEPTH_COMPONENT */: 1,
-    0x190A /* GL_LUMINANCE_ALPHA */: 2,
-    0x1907 /* GL_RGB */: 3,
-    0x8C40 /* GL_SRGB_EXT */: 3,
-    0x1908 /* GL_RGBA */: 4,
-    0x8C42 /* GL_SRGB_ALPHA_EXT */: 4,
+  _colorChannelsInGlTextureFormat: function(format) {
+    // Micro-optimizations for size: map format to size by subtracting smallest enum value (0x1902) from all values first.
+    // Also omit the most common size value (1) from the list, which is assumed by formats not on the list.
+    var colorChannels = {
+      // 0x1902 /* GL_DEPTH_COMPONENT */ - 0x1902: 1,
+      // 0x1906 /* GL_ALPHA */ - 0x1902: 1,
+      5 /* 0x1907 (GL_RGB) - 0x1902 */: 3,
+      6 /* 0x1908 (GL_RGBA) - 0x1902 */: 4,
+      // 0x1909 /* GL_LUMINANCE */ - 0x1902: 1,
+      8 /* 0x190A (GL_LUMINANCE_ALPHA) - 0x1902 */: 2,
+      29502 /* 0x8C40 (GL_SRGB_EXT) - 0x1902 */: 3,
+      29504 /* 0x8C42 (GL_SRGB_ALPHA_EXT) - 0x1902 */: 4,
 #if USE_WEBGL2
-    0x1903 /* GL_RED */: 1,
-    0x8D94 /* GL_RED_INTEGER */: 1,
-    0x8227 /* GL_RG */: 2,
-    0x8228 /* GL_RG_INTEGER*/: 2,
-    0x8D98 /* GL_RGB_INTEGER */: 3,
-    0x8D99 /* GL_RGBA_INTEGER */: 4
+      // 0x1903 /* GL_RED */ - 0x1902: 1,
+      26917 /* 0x8227 (GL_RG) - 0x1902 */: 2,
+      26918 /* 0x8228 (GL_RG_INTEGER) - 0x1902 */: 2,
+      // 0x8D94 /* GL_RED_INTEGER */ - 0x1902: 1,
+      29846 /* 0x8D98 (GL_RGB_INTEGER) - 0x1902 */: 3,
+      29847 /* 0x8D99 (GL_RGBA_INTEGER) - 0x1902 */: 4
 #endif
+    };
+#if GL_ASSERTIONS
+    if (!colorChannels[format - 0x1902]
+      && format != 0x1902 /* GL_DEPTH_COMPONENT */
+      && format != 0x1906 /* GL_ALPHA */
+      && format != 0x1909 /* GL_LUMINANCE */
+      && format != 0x1903 /* GL_RED */
+      && format != 0x8D94 /* GL_RED_INTEGER */) {
+      err('Invalid format=0x' + format.toString(16) + ' passed to function _colorChannelsInGlTextureFormat()!');
+    }
+#endif
+    return colorChannels[format - 0x1902]||1;
   },
 
-  _sizeOfGlTextureElementType: {
-    0x1401 /* GL_UNSIGNED_BYTE */: 1,
-    0x1403 /* GL_UNSIGNED_SHORT */: 2,
-    0x8D61 /* GL_HALF_FLOAT_OES */: 2,
-    0x1405 /* GL_UNSIGNED_INT */: 4,
-    0x1406 /* GL_FLOAT */: 4,
-    0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */: 4,
-    0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */: 2,
-    0x8033 /* GL_UNSIGNED_SHORT_4_4_4_4 */: 2,
-    0x8034 /* GL_UNSIGNED_SHORT_5_5_5_1 */: 2,
-#if USE_WEBGL2
-    0x1400 /* GL_BYTE */: 1,
-    0x140B /* GL_HALF_FLOAT */: 2,
-    0x1402 /* GL_SHORT */: 2,
-    0x1404 /* GL_INT */: 4,
-    0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */: 4,
-    0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */: 4,
-    0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */: 4,
-#endif
-  },
-
-  $emscriptenWebGLGetTexPixelData__deps: ['_computeUnpackAlignedImageSize', '_colorChannelsInGlTextureFormat', '_sizeOfGlTextureElementType'],
+  $emscriptenWebGLGetTexPixelData__deps: ['_computeUnpackAlignedImageSize', '_colorChannelsInGlTextureFormat', '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'],
   $emscriptenWebGLGetTexPixelData: function(type, format, width, height, pixels, internalFormat) {
-    var sizePerPixel = __colorChannelsInGlTextureFormat[format] * __sizeOfGlTextureElementType[type];
-    if (!sizePerPixel) {
-      GL.recordError(0x0500); // GL_INVALID_ENUM
-#if GL_ASSERTIONS
-      if (!__colorChannelsInGlTextureFormat[format]) err('GL_INVALID_ENUM due to unknown format in glTex[Sub]Image/glReadPixels, format: ' + format);
-      else err('GL_INVALID_ENUM in glTex[Sub]Image/glReadPixels, type: ' + type + ', format: ' + format);
-#endif
-      return;
-    }
+    var heap = __heapObjectForWebGLType(type);
+    var shift = __heapAccessShiftForWebGLHeap(heap);
+    var byteSize = 1<<shift;
+    var sizePerPixel = __colorChannelsInGlTextureFormat(format) * byteSize;
     var bytes = __computeUnpackAlignedImageSize(width, height, sizePerPixel, GL.unpackAlignment);
-    var end = pixels + bytes;
-    switch(type) {
-#if USE_WEBGL2
-      case 0x1400 /* GL_BYTE */:
-        return HEAP8.subarray(pixels, end);
-#endif
-      case 0x1401 /* GL_UNSIGNED_BYTE */:
-        return HEAPU8.subarray(pixels, end);
-#if USE_WEBGL2
-      case 0x1402 /* GL_SHORT */:
 #if GL_ASSERTIONS
-        assert((pixels & 1) == 0, 'Pointer to int16 data passed to texture get function must be aligned to two bytes!');
+    assert((pixels >> shift) << shift == pixels, 'Pointer to texture data passed to texture get function must be aligned to the byte size of the pixel type!');
 #endif
-        return HEAP16.subarray(pixels>>1, end>>1);
-      case 0x1404 /* GL_INT */:
-#if GL_ASSERTIONS
-        assert((pixels & 3) == 0, 'Pointer to integer data passed to texture get function must be aligned to four bytes!');
-#endif
-        return HEAP32.subarray(pixels>>2, end>>2);
-#endif
-      case 0x1406 /* GL_FLOAT */:
-#if GL_ASSERTIONS
-        assert((pixels & 3) == 0, 'Pointer to float data passed to texture get function must be aligned to four bytes!');
-#endif
-        return HEAPF32.subarray(pixels>>2, end>>2);
-      case 0x1405 /* GL_UNSIGNED_INT */:
-      case 0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */:
-#if USE_WEBGL2
-      case 0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */:
-      case 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */:
-      case 0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */:
-#endif
-#if GL_ASSERTIONS
-        assert((pixels & 3) == 0, 'Pointer to integer data passed to texture get function must be aligned to four bytes!');
-#endif
-        return HEAPU32.subarray(pixels>>2, end>>2);
-      case 0x1403 /* GL_UNSIGNED_SHORT */:
-      case 0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */:
-      case 0x8033 /* GL_UNSIGNED_SHORT_4_4_4_4 */:
-      case 0x8034 /* GL_UNSIGNED_SHORT_5_5_5_1 */:
-      case 0x8D61 /* GL_HALF_FLOAT_OES */:
-#if USE_WEBGL2
-      case 0x140B /* GL_HALF_FLOAT */:
-#endif
-#if GL_ASSERTIONS
-        assert((pixels & 1) == 0, 'Pointer to int16 data passed to texture get function must be aligned to two bytes!');
-#endif
-        return HEAPU16.subarray(pixels>>1, end>>1);
-      default:
-        GL.recordError(0x0500); // GL_INVALID_ENUM
-#if GL_ASSERTIONS
-        err('GL_INVALID_ENUM in glTex[Sub]Image/glReadPixels, type: ' + type);
-#endif
-    }
+    return heap.subarray(pixels >> shift, pixels + bytes >> shift);
   },
 
   glTexImage2D__sig: 'viiiiiiiii',
   glTexImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
 #if USE_WEBGL2
-                       , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLType'
+                       , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
@@ -1506,8 +1490,9 @@ var LibraryGL = {
       // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
-      } else if (pixels != 0) {
-        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
+      } else if (pixels) {
+        var heap = __heapObjectForWebGLType(type);
+        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, heap, pixels >> __heapAccessShiftForWebGLHeap(heap));
       } else {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, null);
       }
@@ -1520,7 +1505,7 @@ var LibraryGL = {
   glTexSubImage2D__sig: 'viiiiiiiii',
   glTexSubImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
 #if USE_WEBGL2
-                          , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLType'
+                          , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, type, pixels) {
@@ -1537,8 +1522,9 @@ var LibraryGL = {
       // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
-      } else if (pixels != 0) {
-        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
+      } else if (pixels) {
+        var heap = __heapObjectForWebGLType(type);
+        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, heap, pixels >> __heapAccessShiftForWebGLHeap(heap));
       } else {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, null);
       }
@@ -1553,7 +1539,7 @@ var LibraryGL = {
   glReadPixels__sig: 'viiiiiii',
   glReadPixels__deps: ['$emscriptenWebGLGetTexPixelData'
 #if USE_WEBGL2
-                       , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLType'
+                       , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glReadPixels: function(x, y, width, height, format, type, pixels) {
@@ -1562,7 +1548,8 @@ var LibraryGL = {
       if (GLctx.currentPixelPackBufferBinding) {
         GLctx.readPixels(x, y, width, height, format, type, pixels);
       } else {
-        GLctx.readPixels(x, y, width, height, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
+        var heap = __heapObjectForWebGLType(type);
+        GLctx.readPixels(x, y, width, height, format, type, heap, pixels >> __heapAccessShiftForWebGLHeap(heap));
       }
       return;
     }

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -146,22 +146,59 @@ var LibraryWebGL2 = {
     }
   },
 
-  _heapAccessShiftForWebGLType: {
-      0x1402 /* GL_SHORT */: 1,
-      0x1403 /* GL_UNSIGNED_SHORT */: 1,
-      0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */: 1,
-      0x8033 /* GL_UNSIGNED_SHORT_4_4_4_4 */: 1,
-      0x8034 /* GL_UNSIGNED_SHORT_5_5_5_1 */: 1,
-      0x8D61 /* GL_HALF_FLOAT_OES */: 1,
-      0x140B /* GL_HALF_FLOAT */: 1,
-      0x1404 /* GL_INT */: 2,
-      0x1406 /* GL_FLOAT */: 2,
-      0x1405 /* GL_UNSIGNED_INT */: 2,
-      0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */: 2,
-      0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */: 2,
-      0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */: 2,
-      0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */: 2,
-      0x84FA /* GL_UNSIGNED_INT_24_8 */: 2
+#if MINIMAL_RUNTIME && GL_ASSERTIONS
+  _heapAccessShiftForWebGLType__deps: ['$warnOnce'],
+#endif
+  _heapAccessShiftForWebGLType: function (type) {
+#if GL_ASSERTIONS
+    switch(type)
+    {
+      case 0x1400 /* GL_BYTE */:
+      case 0x1401 /* GL_UNSIGNED_BYTE */:
+      case 0x1402 /* GL_SHORT */:
+      case 0x1403 /* GL_UNSIGNED_SHORT */:
+      case 0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */:
+      case 0x8033 /* GL_UNSIGNED_SHORT_4_4_4_4 */:
+      case 0x8034 /* GL_UNSIGNED_SHORT_5_5_5_1 */:
+      case 0x8D61 /* GL_HALF_FLOAT_OES */:
+      case 0x140B /* GL_HALF_FLOAT */:
+      case 0x1404 /* GL_INT */:
+      case 0x1405 /* GL_UNSIGNED_INT */:
+      case 0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */:
+      case 0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */:
+      case 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */:
+      case 0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */:
+      case 0x84FA /* GL_UNSIGNED_INT_24_8 */:
+      case 0x1406 /* GL_FLOAT */:
+        break;
+      default:
+        warnOnce('GL_INVALID_ENUM in _heapAccessShiftForWebGLType: type=0x' + type.toString(16) + ' (not reported again for this type)');
+    }
+#endif
+    // Break down the actual type lookup to smaller and more efficient form than a sparse switch case.
+
+    // Uint8 array shifts: 0x1400 /* GL_BYTE */ and 0x1401 /* GL_UNSIGNED_BYTE */
+    if (type < 0x1402) return 0;
+
+    // Uint16 array shifts:
+    if (type < 0x1404 // type == 0x1402 /* GL_SHORT */ || type == 0x1403 /* GL_UNSIGNED_SHORT */
+      || type == 0x8363 /* GL_UNSIGNED_SHORT_5_6_5 */
+      || type == 0x8033 /* GL_UNSIGNED_SHORT_4_4_4_4 */
+      || type == 0x8034 /* GL_UNSIGNED_SHORT_5_5_5_1 */
+      || type == 0x8D61 /* GL_HALF_FLOAT_OES */
+      || type == 0x140B /* GL_HALF_FLOAT */)
+      return 1;
+
+    // All the rest are Uint32 array shifts. Avoid referring to them one by one for smallest code size.
+    // 0x1404 /* GL_INT */: 2,
+    // 0x1406 /* GL_FLOAT */: 2,
+    // 0x1405 /* GL_UNSIGNED_INT */: 2,
+    // 0x84FA /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */: 2,
+    // 0x8C3E /* GL_UNSIGNED_INT_5_9_9_9_REV */: 2,
+    // 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */: 2,
+    // 0x8C3B /* GL_UNSIGNED_INT_10F_11F_11F_REV */: 2,
+    // 0x84FA /* GL_UNSIGNED_INT_24_8 */: 2
+    return 2;
   },
 
   glGetBufferParameteri64v__sig: 'viii',
@@ -212,7 +249,7 @@ var LibraryWebGL2 = {
     if (GLctx.currentPixelUnpackBufferBinding) {
       GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, pixels);
     } else if (pixels != 0) {
-      GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+      GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
     } else {
       GLctx['texImage3D'](target, level, internalFormat, width, height, depth, border, format, type, null);
     }
@@ -224,7 +261,7 @@ var LibraryWebGL2 = {
     if (GLctx.currentPixelUnpackBufferBinding) {
       GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, pixels);
     } else if (pixels != 0) {
-      GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, __heapObjectForWebGLType(type), pixels >> (__heapAccessShiftForWebGLType[type]|0));
+      GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, __heapObjectForWebGLType(type), pixels >> __heapAccessShiftForWebGLType(type));
     } else {
       GLctx['texSubImage3D'](target, level, xoffset, yoffset, zoffset, width, height, depth, format, type, null);
     }

--- a/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE.sent
+++ b/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE.sent
@@ -403,6 +403,7 @@ ___wasi_proc_exit
 __addDays
 __arraySum
 __battery
+__colorChannelsInGlTextureFormat
 __computeUnpackAlignedImageSize
 __emscripten_do_request_fullscreen
 __emscripten_push_main_loop_blocker
@@ -426,6 +427,8 @@ __findEventTarget
 __formatString
 __get_canvas_element_size
 __glGenObject
+__heapAccessShiftForWebGLHeap
+__heapObjectForWebGLType
 __hideEverythingExceptGivenElement
 __inet_ntop4_raw
 __inet_ntop6_raw

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8228,7 +8228,7 @@ int main() {
                       4, [],        [],           8,   0,    0,  0), # noqa; totally empty!
     # we don't metadce with linkable code! other modules may want stuff
     # don't compare the # of functions in a main module, which changes a lot
-    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1601, [], [], 226403, None, 108, None), # noqa
+    'main_module_1': (['-O3', '-s', 'MAIN_MODULE=1'], 1604, [], [], 226403, None, 108, None), # noqa
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   13, [], [],  10017,   13,   9,   20), # noqa
   })
   @no_wasm_backend()
@@ -9529,7 +9529,7 @@ int main () {
     test_cases = [
       (asmjs + opts, hello_world_sources, {'a.html': 981, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
       (opts, hello_world_sources, {'a.html': 968, 'a.js': 604, 'a.wasm': 86}),
-      (asmjs + opts, hello_webgl_sources, {'a.html': 881, 'a.js': 4918, 'a.asm.js': 11094, 'a.mem': 321}),
+      (asmjs + opts, hello_webgl_sources, {'a.html': 881, 'a.js': 4918, 'a.asm.js': 11139, 'a.mem': 321}),
       (opts, hello_webgl_sources, {'a.html': 857, 'a.js': 4874, 'a.wasm': 8841}),
       (opts, hello_webgl2_sources, {'a.html': 857, 'a.js': 5507, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9527,11 +9527,11 @@ int main () {
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'USE_WEBGL2=1']
 
     test_cases = [
-#      (asmjs + opts, hello_world_sources, {'a.html': 981, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
-#      (opts, hello_world_sources, {'a.html': 968, 'a.js': 604, 'a.wasm': 86}),
-      (asmjs + opts, hello_webgl_sources, {'a.html': 881, 'a.js': 5035, 'a.asm.js': 11094, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 857, 'a.js': 5083, 'a.wasm': 8841}),
-      (opts, hello_webgl2_sources, {'a.html': 857, 'a.js': 6136, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
+      (asmjs + opts, hello_world_sources, {'a.html': 981, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
+      (opts, hello_world_sources, {'a.html': 968, 'a.js': 604, 'a.wasm': 86}),
+      (asmjs + opts, hello_webgl_sources, {'a.html': 881, 'a.js': 4918, 'a.asm.js': 11094, 'a.mem': 321}),
+      (opts, hello_webgl_sources, {'a.html': 857, 'a.js': 4874, 'a.wasm': 8841}),
+      (opts, hello_webgl2_sources, {'a.html': 857, 'a.js': 5507, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9531,7 +9531,7 @@ int main () {
       (opts, hello_world_sources, {'a.html': 968, 'a.js': 604, 'a.wasm': 86}),
       (asmjs + opts, hello_webgl_sources, {'a.html': 881, 'a.js': 5035, 'a.asm.js': 11094, 'a.mem': 321}),
       (opts, hello_webgl_sources, {'a.html': 857, 'a.js': 5083, 'a.wasm': 8841}),
-      (opts, hello_webgl2_sources, {'a.html': 857, 'a.js': 6192, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
+      (opts, hello_webgl2_sources, {'a.html': 857, 'a.js': 6136, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9527,8 +9527,8 @@ int main () {
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'USE_WEBGL2=1']
 
     test_cases = [
-      (asmjs + opts, hello_world_sources, {'a.html': 981, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
-      (opts, hello_world_sources, {'a.html': 968, 'a.js': 604, 'a.wasm': 86}),
+#      (asmjs + opts, hello_world_sources, {'a.html': 981, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
+#      (opts, hello_world_sources, {'a.html': 968, 'a.js': 604, 'a.wasm': 86}),
       (asmjs + opts, hello_webgl_sources, {'a.html': 881, 'a.js': 5035, 'a.asm.js': 11094, 'a.mem': 321}),
       (opts, hello_webgl_sources, {'a.html': 857, 'a.js': 5083, 'a.wasm': 8841}),
       (opts, hello_webgl2_sources, {'a.html': 857, 'a.js': 6136, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1


### PR DESCRIPTION
Optimizes WebGL 1 demo by -209 bytes (-4.11%) and WebGL 2 demo by 629 bytes (-10.25%).