### PR TITLE
Add a 'setting up' section to the test suite docs

### DIFF
--- a/site/source/docs/contributing/developers_guide.rst
+++ b/site/source/docs/contributing/developers_guide.rst
@@ -10,9 +10,10 @@ interested in helping out!
 
 .. tip:: The information will be less relevant if you're just using Emscripten, but may still be of interest.
 
+.. _developers-guide-setting-up:
 
-Getting Binaries
-================
+Setting up
+==========
 
 For contributing to core Emscripten code, such as ``emcc.py``, you don't need to
 build any binaries as ``emcc.py`` is in Python, and the core JS generation is

--- a/site/source/docs/getting_started/test-suite.rst
+++ b/site/source/docs/getting_started/test-suite.rst
@@ -8,6 +8,13 @@ Emscripten has a comprehensive test suite, which covers virtually all Emscripten
 
 This article explains how to run the test and benchmark suite, and provides an overview of what tests are available.
 
+Setting up
+==========
+
+To run the tests, you need an emscripten setup, as it will run ``emcc`` and other
+commands. See the :ref:`developer's guide <developers-guide-setting-up>` for
+how best to do that.
+
 Running tests
 =============
 


### PR DESCRIPTION
That points to the developer's guide section on setting
up the emsdk with a tot build etc.