### PR TITLE
Added missing DedicatedWorkerGlobalScope members to closure-externs.js

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -442,3 +442,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jan Habermann <jan@habermann.io>
 * John Granström <granstrom.john@gmail.com>
 * Clemens Backes <clemensb@google.com> (copyright owned by Google, Inc.)
+* Tibor Klajnscek <tiborkl@numfum.com>

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -920,12 +920,18 @@ var worker;
  * @param {Object} message
  */
 var onmessage = function(message) {};
+var onmessageerror = function() {};
 
 /**
  * @param {string} type
  * @param {!Function} listener
  */
 var addEventListener = function (type, listener) {};
+
+/**
+ * @type {Function}
+ */
+var close;
 
 // Fetch.js/Fetch Worker
 


### PR DESCRIPTION
As mentioned in issue #9805 'close' and 'onmessageerror' needed adding to close-externs.js otherwise the closure compiler fails when optimizing webworker code.