### PR TITLE
Closure js

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1132,7 +1132,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if options.use_closure_compiler:
       shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
-      if not shared.check_closure_compiler():
+      if not shared.check_java_closure_compiler():
         exit_with_error('fatal: closure compiler is not configured correctly')
       # when we emit asm.js, closure 2 would break that, so warn (note that
       # with wasm2js in the wasm backend, we don't emit asm.js anyhow)

--- a/src/settings.js
+++ b/src/settings.js
@@ -224,6 +224,12 @@ var SIMD = 0;
 // Whether closure compiling is being run on this output
 var USE_CLOSURE_COMPILER = 0;
 
+// If set to 1 and Closure is enabled, uses JavaScript version of Closure compiler
+// instead of the Java version of the compiler. JS version of Closure compiler
+// can be somewhat slower than the Java version, but does not require installing
+// Java.
+var USE_JS_CLOSURE_COMPILER = 0;
+
 // If set to 1, each asm.js/wasm module export is individually declared with a
 // JavaScript "var" definition. This is the simple and recommended approach.
 // However, this does increase code size (especially if you have many such

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8725,8 +8725,9 @@ end
     # We must ignore various types of errors that are expected in this situation, as we
     # are including a lot of JS without corresponding compiled code for it. This still
     # lets us catch all other errors.
-    with env_modify({'EMCC_CLOSURE_ARGS': '--jscomp_off undefinedVars'}):
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
+    for args in [[], ['-s', 'USE_JS_CLOSURE_COMPILER=1']]:
+      with env_modify({'EMCC_CLOSURE_ARGS': '--jscomp_off undefinedVars'}):
+        run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'] + args)
 
   # Tests --closure-args command line flag
   def test_closure_externs(self):

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -233,34 +233,6 @@ class sanity(RunnerCore):
         elif 'runner.py' not in ' '.join(command):
           self.assertContained('ERROR', output) # sanity check should fail
 
-  def test_closure_compiler(self):
-    CLOSURE_FATAL = 'fatal: closure compiler'
-    CLOSURE_WARNING = 'does not exist'
-
-    # Sanity check should find closure
-    restore_and_set_up()
-    output = self.check_working(EMCC)
-    self.assertNotContained(CLOSURE_FATAL, output)
-    self.assertNotContained(CLOSURE_WARNING, output)
-
-    # Append a bad path for closure, will warn
-    f = open(CONFIG_FILE, 'a')
-    f.write('CLOSURE_COMPILER = "/tmp/nowhere/nothingtoseehere/kjadsfkjwelkjsdfkqgas/nonexistent.txt"\n')
-    f.close()
-    output = self.check_working(EMCC, CLOSURE_WARNING)
-
-    # And if you actually try to use the bad path, will be fatal
-    f = open(CONFIG_FILE, 'a')
-    f.write('CLOSURE_COMPILER = "/tmp/nowhere/nothingtoseehere/kjadsfkjwelkjsdfkqgas/nonexistent.txt"\n')
-    f.close()
-    output = self.check_working([EMCC, '-s', '--closure', '1'] + MINIMAL_HELLO_WORLD + ['-O2'], CLOSURE_FATAL)
-
-    # With a working path, all is well
-    restore_and_set_up()
-    try_delete('a.out.js')
-    output = self.check_working([EMCC, '-s', '--closure', '1'] + MINIMAL_HELLO_WORLD + ['-O2'], '')
-    self.assertExists('a.out.js', output)
-
   def test_llvm(self):
     LLVM_WARNING = 'LLVM version appears incorrect'
 


### PR DESCRIPTION
This adds JS version of Closure compiler for users who don't want to ship Java as part of their SDKs.

First I added google-closure-compiler in the tree directly, but after doing that, I realize that there are many dependencies to the closure compiler npm package and so many files to bundle (490) that would make it a bit awkward to put in the repository.

So I settled for a scheme that if one enables the JS closure compiler, it is `npm install`ed on demand. I am not sure if there would exist a minified version of closure-cli that we could easily embed, asked for that in https://github.com/google/closure-compiler/issues/3515.