### PR TITLE
Add a setting to force inclusion of full DWARF info in object and wasm output

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2648,7 +2648,7 @@ def parse_args(newargs):
           # emit line tables, which can be represented in source maps
           newargs[i] = '-gline-tables-only'
       else:
-        if requested_level.startswith('dwarf'):
+        if requested_level.startswith('force_dwarf'):
           # Force clang to generate full debug info using -g. Set the FULL_DWARF
           # setting to avoid stripping it out later.
           newargs[i] = '-g'

--- a/emcc.py
+++ b/emcc.py
@@ -2652,7 +2652,7 @@ def parse_args(newargs):
           # Force clang to generate full debug info using -g. Set the FULL_DWARF
           # setting to avoid stripping it out later.
           newargs[i] = '-g'
-          shared.Settings.FULL_DWARF=1
+          shared.Settings.FULL_DWARF = 1
         # a non-integer level can be something like -gline-tables-only. keep
         # the flag for the clang frontend to emit the appropriate DWARF info.
         # set the emscripten debug level to 3 so that we do not remove that

--- a/emcc.py
+++ b/emcc.py
@@ -2670,7 +2670,7 @@ def parse_args(newargs):
           # setting to avoid stripping it out later.
           newargs[i] = '-g'
           shared.Settings.FULL_DWARF = 1
-          logger.warning('gforce_dwarf is a temporary option that will eventually disappear')
+          shared.warning('gforce_dwarf is a temporary option that will eventually disappear')
         # a non-integer level can be something like -gline-tables-only. keep
         # the flag for the clang frontend to emit the appropriate DWARF info.
         # set the emscripten debug level to 3 so that we do not remove that

--- a/emcc.py
+++ b/emcc.py
@@ -789,7 +789,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     return '-O0' not in opts
 
   def need_llvm_debug_info(options):
-    return options.debug_level >= 3 or shared.Settings.CYBERDWARF
+    return options.debug_level >= 3 or shared.Settings.CYBERDWARF or shared.Settings.FULL_DWARF
 
   with ToolchainProfiler.profile_block('parse arguments and setup'):
     ## Parse args
@@ -2648,6 +2648,11 @@ def parse_args(newargs):
           # emit line tables, which can be represented in source maps
           newargs[i] = '-gline-tables-only'
       else:
+        if requested_level.startswith('dwarf'):
+          # Force clang to generate full debug info using -g. Set the FULL_DWARF
+          # setting to avoid stripping it out later.
+          newargs[i] = '-g'
+          shared.Settings.FULL_DWARF=1
         # a non-integer level can be something like -gline-tables-only. keep
         # the flag for the clang frontend to emit the appropriate DWARF info.
         # set the emscripten debug level to 3 so that we do not remove that

--- a/emcc.py
+++ b/emcc.py
@@ -2653,6 +2653,7 @@ def parse_args(newargs):
           # setting to avoid stripping it out later.
           newargs[i] = '-g'
           shared.Settings.FULL_DWARF = 1
+          logger.warning('gforce_dwarf is a temporary option that will eventually disappear')
         # a non-integer level can be something like -gline-tables-only. keep
         # the flag for the clang frontend to emit the appropriate DWARF info.
         # set the emscripten debug level to 3 so that we do not remove that

--- a/src/settings.js
+++ b/src/settings.js
@@ -1407,9 +1407,6 @@ var CYBERDWARF = 0;
 // Path to the CyberDWARF debug file passed to the compiler
 var BUNDLED_CD_DEBUG_FILE = "";
 
-// Temporary setting to force generation and preservation of full DWARF debug info
-var FULL_DWARF = 0;
-
 // Is enabled, use the JavaScript TextDecoder API for string marshalling.
 // Enabled by default, set this to 0 to disable.
 // If set to 2, we assume TextDecoder is present and usable, and do not emit

--- a/src/settings.js
+++ b/src/settings.js
@@ -1407,6 +1407,9 @@ var CYBERDWARF = 0;
 // Path to the CyberDWARF debug file passed to the compiler
 var BUNDLED_CD_DEBUG_FILE = "";
 
+// Temporary setting to force generation and preservation of full DWARF debug info
+var FULL_DWARF = 0;
+
 // Is enabled, use the JavaScript TextDecoder API for string marshalling.
 // Enabled by default, set this to 0 to disable.
 // If set to 2, we assume TextDecoder is present and usable, and do not emit

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -70,3 +70,6 @@ var DYNAMIC_BASE = -1;
 
 // -Werror was specified on the command line.
 var WARNINGS_ARE_ERRORS = 0;
+
+// Temporary setting to force generation and preservation of full DWARF debug info
+var FULL_DWARF = 0;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2360,8 +2360,8 @@ int f() {
   @no_fastcomp()
   def test_force_dwarf(self):
     def compile_with_dwarf(args, output):
-      # Test that the -gdwarf flag forces enabling dwarf info in object files and linked wasm
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', output, '-gdwarf'] + args)
+      # Test that the -gforce_dwarf flag forces enabling dwarf info in object files and linked wasm
+      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', output, '-gforce_dwarf'] + args)
 
     def verify(output):
       info = run_process([LLVM_DWARFDUMP, '--all', output], stdout=PIPE).stdout

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
 from tools.shared import Building, PIPE, run_js, run_process, STDOUT, try_delete, listify
 from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS, LLVM_ROOT, EMCONFIG, EM_BUILD_VERBOSE
-from tools.shared import CLANG, CLANG_CC, CLANG_CPP, LLVM_AR
+from tools.shared import CLANG, CLANG_CC, CLANG_CPP, LLVM_AR, LLVM_DWARFDUMP
 from tools.shared import NODE_JS, SPIDERMONKEY_ENGINE, JS_ENGINES, V8_ENGINE
 from tools.shared import WebAssembly
 from runner import RunnerCore, path_from_root, no_wasm_backend, no_fastcomp, is_slow_test, ensure_dir
@@ -2356,6 +2356,22 @@ int f() {
     # we have full dwarf support
     self.assertEqual(no_size, line_size)
     self.assertEqual(line_size, full_size)
+
+  @no_fastcomp()
+  def test_force_dwarf(self):
+    def compile_with_dwarf(args, output):
+      # Test that the -gdwarf flag forces enabling dwarf info in object files and linked wasm
+      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', output, '-gdwarf'] + args)
+
+    def verify(output):
+      info = run_process([LLVM_DWARFDUMP, '--all', output], stdout=PIPE).stdout
+      self.assertIn('DW_TAG_subprogram', info) # Ensure there's a subprogram entry in .debug_info
+      self.assertIn('debug_line[0x', info) # Ensure there's a line table
+
+    compile_with_dwarf(['-c'], 'a.o')
+    verify('a.o')
+    compile_with_dwarf([], 'a.js')
+    verify('a.wasm')
 
   @unittest.skipIf(not scons_path, 'scons not found in PATH')
   @with_env_modify({'EMSCRIPTEN_ROOT': path_from_root()})

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2923,7 +2923,7 @@ class Building(object):
     if emit_source_map:
       cmd += ['--input-source-map=' + infile + '.map']
       cmd += ['--output-source-map=' + outfile + '.map']
-    if outfile and tool == 'wasm-opt':
+    if outfile and tool == 'wasm-opt' and not Settings.FULL_DWARF:
       # remove any dwarf debug info sections, as currently we are not able to
       # properly update it anyhow, and in the case of source maps, we have
       # that info in the map anyhow


### PR DESCRIPTION
For now this is enabled by passing -gforce_dwarf. In the future once things
stabilize we'll probably want to think more carefully about the flags.