### PR TITLE
Deprecate passing a timestamp value in HTML5

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1121,6 +1121,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.STRICT_JS = 1
       shared.Settings.AUTO_JS_LIBRARIES = 0
       shared.Settings.AUTO_ARCHIVE_INDEXES = 0
+      shared.Settings.DISABLE_DEPRECATED_TIMESTAMP_IN_HTML5_EVENTS = 1
 
     if AUTODEBUG:
       shared.Settings.AUTODEBUG = 1

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -198,10 +198,12 @@ var LibraryJSEvents = {
       return (target && target.nodeName) ? target.nodeName : '';
     },
 
+#if !DISABLE_DEPRECATED_TIMESTAMP_IN_HTML5_EVENTS
     tick: function() {
       if (window['performance'] && window['performance']['now']) return window['performance']['now']();
       else return Date.now();
     },
+#endif
 
     fullscreenEnabled: function() {
       return document.fullscreenEnabled || document.mozFullScreenEnabled || document.webkitFullscreenEnabled || document.msFullscreenEnabled;
@@ -390,7 +392,9 @@ var LibraryJSEvents = {
   // target: Specifies a target DOM element that will be used as the reference to populate targetX and targetY parameters.
   _fillMouseEventData__deps: ['$JSEvents', '_getBoundingClientRect', '_specialEventTargets'],
   _fillMouseEventData: function(eventStruct, e, target) {
+#if !DISABLE_DEPRECATED_TIMESTAMP_IN_HTML5_EVENTS
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.timestamp, 'JSEvents.tick()', 'double') }}};
+#endif
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.screenX, 'e.screenX', 'i32') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.screenY, 'e.screenY', 'i32') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenMouseEvent.clientX, 'e.clientX', 'i32') }}};
@@ -766,7 +770,9 @@ var LibraryJSEvents = {
 
   _fillDeviceOrientationEventData__deps: ['$JSEvents'],
   _fillDeviceOrientationEventData: function(eventStruct, e, target) {
+#if !DISABLE_DEPRECATED_TIMESTAMP_IN_HTML5_EVENTS
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceOrientationEvent.timestamp, 'JSEvents.tick()', 'double') }}};
+#endif
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceOrientationEvent.alpha, 'e.alpha', 'double') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceOrientationEvent.beta, 'e.beta', 'double') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceOrientationEvent.gamma, 'e.gamma', 'double') }}};
@@ -838,7 +844,9 @@ var LibraryJSEvents = {
     a = a || {};
     ag = ag || {};
     rr = rr || {};
+#if !DISABLE_DEPRECATED_TIMESTAMP_IN_HTML5_EVENTS
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceMotionEvent.timestamp, 'JSEvents.tick()', 'double') }}};
+#endif
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceMotionEvent.accelerationX, 'a["x"]', 'double') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceMotionEvent.accelerationY, 'a["y"]', 'double') }}};
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceMotionEvent.accelerationZ, 'a["z"]', 'double') }}};

--- a/src/settings.js
+++ b/src/settings.js
@@ -1571,6 +1571,11 @@ var SUPPORT_LONGJMP = 1;
 // selectors, instead of referring to DOM IDs.
 var DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR = 1;
 
+// If set to 1, disables setting the timestamp field in HTML5 events. (Call
+// emscripten_get_now() or emscripten_performance_now() to get a timestamp
+// yourself if desirable.)
+var DISABLE_DEPRECATED_TIMESTAMP_IN_HTML5_EVENTS = 0;
+
 // Specifies whether the generated .html file is run through html-minifier. The
 // set of optimization passes run by html-minifier depends on debug and
 // optimization levels. In -g2 and higher, no minification is performed. In -g1,


### PR DESCRIPTION
Deprecate passing a timestamp value in HTML5 mouse, wheel, devicemotion and deviceorientation events. This is because due to Spectre, implementations of performance.now() have become deliberately slower that these calls to performance.now() show up in performance profiles, and many users do not need the timestamp. It is easy to get a timestamp manually by calling emscripten_get_now() or emscripten_performance_now() in the event handler anyways if needed.