### PR TITLE
Generalize yielding execution back to browser

### DIFF
--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2395,6 +2395,11 @@ Functions
 
 .. c:function:: void emscripten_unwind_to_js_event_loop(void)
 
-  Throws a JavaScript exception that unwinds the stack and yields execution
-  back to the browser event loop. This function does not return execution
-  back to calling code.
+  Throws a JavaScript exception that unwinds the stack and yields execution back to the browser
+  event loop. This function does not return execution back to calling code.
+
+  This function can be useful when porting code that would enter an infinite loop. Instead of
+  actually running an infinite loop, which is not allowed on the Web, we can set up the body of
+  the loop to execute asynchronously (using emscripten_set_main_loop or something else), and call
+  this function to halt execution, which is important as we do not want execution to continue
+  normally.

--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2393,7 +2393,7 @@ Functions
 
   Invokes JavaScript throw statement and throws a string.
 
-.. c:function:: void emscripten_unwind_stack(void)
+.. c:function:: void emscripten_unwind_to_js_event_loop(void)
 
   Throws a JavaScript exception that unwinds the stack and yields execution
   back to the browser event loop. This function does not return execution

--- a/site/source/docs/api_reference/html5.h.rst
+++ b/site/source/docs/api_reference/html5.h.rst
@@ -2392,3 +2392,9 @@ Functions
 .. c:function:: void emscripten_throw_string(const char *utf8String)
 
   Invokes JavaScript throw statement and throws a string.
+
+.. c:function:: void emscripten_unwind_stack(void)
+
+  Throws a JavaScript exception that unwinds the stack and yields execution
+  back to the browser event loop. This function does not return execution
+  back to calling code.

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1285,7 +1285,7 @@ var LibraryBrowser = {
     }
 
     if (simulateInfiniteLoop) {
-      throw 'SimulateInfiniteLoop';
+      throw 'unwind';
     }
   },
 
@@ -1352,7 +1352,7 @@ var LibraryBrowser = {
   // Callable in pthread without __proxy needed.
   emscripten_exit_with_live_runtime: function() {
     noExitRuntime = true;
-    throw 'SimulateInfiniteLoop';
+    throw 'unwind';
   },
 
   emscripten_force_exit__proxy: 'sync',

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -664,7 +664,7 @@ var LibraryGLUT = {
   glutMainLoop: function() {
     _glutReshapeWindow(Module['canvas'].width, Module['canvas'].height);
     _glutPostRedisplay();
-    throw 'SimulateInfiniteLoop';
+    throw 'unwind';
   },
 
 };

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -3131,7 +3131,7 @@ var LibraryJSEvents = {
     throw UTF8ToString(str);
   },
 
-  emscripten_unwind_stack: function() {
+  emscripten_unwind_to_js_event_loop: function() {
     throw 'unwind';
   },
 

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -3131,6 +3131,10 @@ var LibraryJSEvents = {
     throw UTF8ToString(str);
   },
 
+  emscripten_unwind_stack: function() {
+    throw 'unwind';
+  },
+
   emscripten_get_device_pixel_ratio__proxy: 'sync',
   emscripten_get_device_pixel_ratio__sig: 'd',
   emscripten_get_device_pixel_ratio: function() {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -962,7 +962,7 @@ var LibraryPThread = {
       // the entire application.
       process.exit(status);
     }
-    throw 'pthread_exit';
+    throw 'unwind';
 #endif
   },
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -254,7 +254,7 @@ function callMain(args) {
       // exit() throws this once it's done to make sure execution
       // has been stopped completely
       return;
-    } else if (e == 'SimulateInfiniteLoop') {
+    } else if (e == 'unwind') {
       // running an evented main loop, don't immediately exit
       noExitRuntime = true;
 #if EMTERPRETIFY_ASYNC

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -426,7 +426,7 @@ assert(typeof Int32Array !== 'undefined' && typeof Float64Array !== 'undefined' 
 // Test runs in browsers should always be free from uncaught exceptions. If an uncaught exception is thrown, we fail browser test execution in the REPORT_RESULT() macro to output an error value.
 if (ENVIRONMENT_IS_WEB) {
   window.addEventListener('error', function(e) {
-    if (e.message.indexOf('SimulateInfiniteLoop') != -1) return;
+    if (e.message.indexOf('unwind') != -1) return;
     console.error('Page threw an exception ' + e);
     Module['pageThrewException'] = true;
   });

--- a/src/worker.js
+++ b/src/worker.js
@@ -226,7 +226,7 @@ this.onmessage = function(e) {
         if (e === 'Canceled!') {
           PThread.threadCancel();
           return;
-        } else if (e === 'SimulateInfiniteLoop' || e === 'pthread_exit') {
+        } else if (e == 'unwind') {
           return;
         } else {
           Atomics.store(HEAPU32, (threadInfoStruct + 4 /*C_STRUCTS.pthread.threadExitCode*/ ) >> 2, (e instanceof Module['ExitStatus']) ? e.status : -2 /*A custom entry specific to Emscripten denoting that the thread crashed.*/);

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -574,7 +574,7 @@ extern void emscripten_console_error(const char *utf8String);
 extern void emscripten_throw_number(double number);
 extern void emscripten_throw_string(const char *utf8String);
 
-extern void emscripten_unwind_stack(void) __attribute__((noreturn));
+extern void emscripten_unwind_to_js_event_loop(void) __attribute__((noreturn));
 
 #ifdef __cplusplus
 } // ~extern "C"

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -574,6 +574,8 @@ extern void emscripten_console_error(const char *utf8String);
 extern void emscripten_throw_number(double number);
 extern void emscripten_throw_string(const char *utf8String);
 
+extern void emscripten_unwind_stack(void) __attribute__((noreturn));
+
 #ifdef __cplusplus
 } // ~extern "C"
 #endif

--- a/tests/browser/test_emscripten_unwind_stack.c
+++ b/tests/browser/test_emscripten_unwind_stack.c
@@ -1,0 +1,22 @@
+#include <emscripten/html5.h>
+#include <stdio.h>
+
+void timeout(void *userData)
+{
+	printf("Got timeout handler\n");
+#ifdef REPORT_RESULT
+	// Test passed
+	REPORT_RESULT(1);
+#endif
+}
+
+int main()
+{
+	emscripten_set_timeout(timeout, 2000, 0);
+	emscripten_unwind_stack();
+	printf("This should not be called!\n");
+#ifdef REPORT_RESULT
+	// Should not reach here
+	REPORT_RESULT(-1);
+#endif
+}

--- a/tests/browser/test_emscripten_unwind_to_js_event_loop.c
+++ b/tests/browser/test_emscripten_unwind_to_js_event_loop.c
@@ -13,7 +13,7 @@ void timeout(void *userData)
 int main()
 {
 	emscripten_set_timeout(timeout, 2000, 0);
-	emscripten_unwind_stack();
+	emscripten_unwind_to_js_event_loop();
 	printf("This should not be called!\n");
 #ifdef REPORT_RESULT
 	// Should not reach here

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4886,6 +4886,6 @@ window.close = function() {
   def test_offset_converter(self, *args):
     self.btest(path_from_root('tests', 'browser', 'test_offset_converter.c'), '1', args=['-s', 'USE_OFFSET_CONVERTER', '-g4', '-s', 'PROXY_TO_PTHREAD', '-s', 'USE_PTHREADS'])
 
-  # Tests emscripten_unwind_stack() behavior
-  def test_emscripten_unwind_stack(self, *args):
-    self.btest(path_from_root('tests', 'browser', 'test_emscripten_unwind_stack.c'), '1', args=['-s', 'NO_EXIT_RUNTIME=1'])
+  # Tests emscripten_unwind_to_js_event_loop() behavior
+  def test_emscripten_unwind_to_js_event_loop(self, *args):
+    self.btest(path_from_root('tests', 'browser', 'test_emscripten_unwind_to_js_event_loop.c'), '1', args=['-s', 'NO_EXIT_RUNTIME=1'])

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4885,3 +4885,7 @@ window.close = function() {
   @no_fastcomp('offset converter is not supported on fastcomp')
   def test_offset_converter(self, *args):
     self.btest(path_from_root('tests', 'browser', 'test_offset_converter.c'), '1', args=['-s', 'USE_OFFSET_CONVERTER', '-g4', '-s', 'PROXY_TO_PTHREAD', '-s', 'USE_PTHREADS'])
+
+  # Tests emscripten_unwind_stack() behavior
+  def test_emscripten_unwind_stack(self, *args):
+    self.btest(path_from_root('tests', 'browser', 'test_emscripten_unwind_stack.c'), '1', args=['-s', 'NO_EXIT_RUNTIME=1'])


### PR DESCRIPTION
Generalize yielding execution back to browser under a common exception string 'unwind'.