### PR TITLE
Use common include directory for all ports

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- All ports not install their headers into a shared directory under
+- All ports now install their headers into a shared directory under
   `EM_CACHE`.  This should not really be a user visible change although one
   side effect is that once a give ports is built its headers are then
   universally accessible, just like the library is universally available as

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,12 +17,17 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- Removed `timestamp` field from mouse, wheel, devicemotion and deviceorientation
-  events. The presence of a `timestamp` on these events was slightly arbitrary,
-  and populating this field caused a small profileable overhead that all users
-  might not care about. It is easy to get a timestamp of an event by calling
-  `emscripten_get_now()` or `emscripten_performance_now()` inside the event
-  handler function of any event.
+- All ports not install their headers into a shared directory under
+  `EM_CACHE`.  This should not really be a user visible change although one
+  side effect is that once a give ports is built its headers are then
+  universally accessible, just like the library is universally available as
+  `-l<name>`.
+- Removed `timestamp` field from mouse, wheel, devicemotion and
+  deviceorientation events. The presence of a `timestamp` on these events was
+  slightly arbitrary, and populating this field caused a small profileable
+  overhead that all users might not care about. It is easy to get a timestamp of
+  an event by calling `emscripten_get_now()` or `emscripten_performance_now()`
+  inside the event handler function of any event.
 - Add fine-grained options for specific legacy browser support,
   `MIN_FIREFOX_VERSION`, `MIN_SAFARI_VERSION`, `MIN_IE_VERSION`,
   `MIN_EDGE_VERSION`, `MIN_CHROME_VERSION`. The existing `LEGACY_VM_SUPPORT`

--- a/embuilder.py
+++ b/embuilder.py
@@ -18,9 +18,7 @@ import sys
 from tools import shared
 from tools.system_libs import Library
 
-C_BARE = '''
-        int main() {}
-      '''
+C_BARE = 'int main() {}'
 
 SYSTEM_LIBRARIES = Library.get_all_variations()
 SYSTEM_TASKS = list(SYSTEM_LIBRARIES.keys())
@@ -125,8 +123,8 @@ def build(src, result_libs, args=[]):
       shared.exit_with_error('not seeing that requested library %s has been built because file %s does not exist' % (lib, shared.Cache.get_path(lib)))
 
 
-def build_port(port_name, lib_name, params):
-  build(C_BARE, [lib_name] if lib_name else [], params)
+def build_port(port_name, lib_name, params, extra_source=''):
+  build(extra_source + '\n' + C_BARE, [lib_name] if lib_name else [], params)
 
 
 def main():
@@ -215,7 +213,7 @@ def main():
     elif what == 'native_optimizer':
       build(C_BARE, ['optimizer.2.exe'], ['-O2', '-s', 'WASM=0'])
     elif what == 'icu':
-      build_port('icu', libname('libicuuc'), ['-s', 'USE_ICU=1'])
+      build_port('icu', libname('libicuuc'), ['-s', 'USE_ICU=1'], '#include "unicode/ustring.h"')
     elif what == 'zlib':
       build_port('zlib', 'libz.a', ['-s', 'USE_ZLIB=1'])
     elif what == 'bzip2':

--- a/embuilder.py
+++ b/embuilder.py
@@ -123,7 +123,7 @@ def main():
                       help='build relocatable objects for suitable for dynamic linking')
   parser.add_argument('--force', action='store_true',
                       help='force rebuild of target (by removing it first)')
-  parser.add_argument('operation', help='currnetly only "build" is supported')
+  parser.add_argument('operation', help='currently only "build" is supported')
   parser.add_argument('targets', nargs='+', help='see above')
   args = parser.parse_args()
 

--- a/embuilder.py
+++ b/embuilder.py
@@ -58,12 +58,10 @@ logger = logging.getLogger('embuilder')
 force = False
 
 
-def print_help():
+def get_usage():
   all_tasks = SYSTEM_TASKS + USER_TASKS
   all_tasks.sort()
-  print('''
-Emscripten System Builder Tool
-==============================
+  return '''embuilder.py [flags]... OPERATION TARGET [TARGET]...
 
 You can use this tool to manually build parts of the emscripten system
 environment. In general emcc will build them automatically on demand, so
@@ -71,21 +69,11 @@ you do not strictly need to use this tool, but it gives you more control
 over the process (in particular, if emcc does this automatically, and you
 are running multiple build commands in parallel, confusion can occur).
 
-Usage:
-
-  embuilder.py OPERATION TASK1 [TASK2..] [--pic] [--lto]
-
 Available operations and tasks:
 
   build %s
 
 Issuing 'embuilder.py build ALL' causes each task to be built.
-
-Flags:
-
-  --force  Force rebuild of target (by removing it first)
-  --lto    Build bitcode files, for LTO with the LLVM wasm backend
-  --pic    Build as position independent code (used by MAIN_MODULE/SIDE_MODULE)
 
 It is also possible to build native_optimizer manually by using CMake. To
 do that, run
@@ -95,7 +83,7 @@ do that, run
    3. make (or mingw32-make/vcbuild/msbuild on Windows)
 
 and set up the location to the native optimizer in ~/.emscripten
-''' % '\n        '.join(all_tasks))
+''' % '\n        '.join(all_tasks)
 
 
 def build(src, result_libs, args=[]):
@@ -129,21 +117,15 @@ def build_port(port_name, lib_name, params, extra_source=''):
 
 def main():
   global force
-  parser = argparse.ArgumentParser(description=__doc__, usage="%(prog)s [operation] [targets ...]",
-                                   add_help=False)
-  parser.add_argument('--help', '-h', action='store_true', help='print help message')
+  parser = argparse.ArgumentParser(description=__doc__, usage=get_usage())
   parser.add_argument('--lto', action='store_true', help='build bitcode object for LTO')
   parser.add_argument('--pic', action='store_true',
                       help='build relocatable objects for suitable for dynamic linking')
   parser.add_argument('--force', action='store_true',
                       help='force rebuild of target (by removing it first)')
-  parser.add_argument('operation')
-  parser.add_argument('targets', nargs='+')
+  parser.add_argument('operation', help='currnetly only "build" is supported')
+  parser.add_argument('targets', nargs='+', help='see above')
   args = parser.parse_args()
-
-  if args.help:
-    print_help()
-    return 0
 
   if args.operation != 'build':
     shared.exit_with_error('unfamiliar operation: ' + args.operation)
@@ -237,9 +219,9 @@ def main():
     elif what == 'sdl2-image':
       build_port('sdl2-image', libname('libSDL2_image'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2'])
     elif what == 'sdl2-image-png':
-      build_port('sdl2-image', libname('libSDL2_image'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'SDL2_IMAGE_FORMATS=["png"]'])
+      build_port('sdl2-image', libname('libSDL2_image_png'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'SDL2_IMAGE_FORMATS=["png"]'])
     elif what == 'sdl2-image-jpg':
-      build_port('sdl2-image', libname('libSDL2_image'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'SDL2_IMAGE_FORMATS=["jpg"]'])
+      build_port('sdl2-image', libname('libSDL2_image_jpg'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_IMAGE=2', '-s', 'SDL2_IMAGE_FORMATS=["jpg"]'])
     elif what == 'sdl2-net':
       build_port('sdl2-net', libname('libSDL2_net'), ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'])
     elif what == 'sdl2-mixer':

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1187,7 +1187,7 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
   def get_freetype_library(self):
     if '-Werror' in self.emcc_args:
       self.emcc_args.remove('-Werror')
-    return self.get_library('freetype', os.path.join('objs', '.libs', 'libfreetype.a'), configure_args=['--disable-shared'])
+    return self.get_library('freetype', os.path.join('objs', '.libs', 'libfreetype.a'), configure_args=['--disable-shared', '--without-zlib'])
 
   def get_poppler_library(self):
     # The fontconfig symbols are all missing from the poppler build

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3221,7 +3221,9 @@ window.close = function() {
     cocos2d_root = os.path.join(system_libs.Ports.get_build_dir(), 'cocos2d')
     preload_file = os.path.join(cocos2d_root, 'samples', 'HelloCpp', 'Resources') + '@'
     self.btest('cocos2d_hello.cpp', reference='cocos2d_hello.png', reference_slack=1,
-               args=['-s', 'USE_COCOS2D=3', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0', '--std=c++11', '--preload-file', preload_file, '--use-preload-plugins'],
+               args=['-s', 'USE_COCOS2D=3', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0', '--std=c++11',
+                     '--preload-file', preload_file, '--use-preload-plugins',
+                     '-Wno-inconsistent-missing-override'],
                message='You should see Cocos2d logo')
 
   def test_async(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -798,7 +798,10 @@ f.close()
       includes = stderr[start:end]
       includes = [i.strip() for i in includes.splitlines()[1:-1]]
       for i in includes:
-        self.assertContained(path_from_root('system'), i)
+        if shared.Cache.dirname in i:
+          self.assertContained(shared.Cache.dirname, i)
+        else:
+          self.assertContained(path_from_root('system'), i)
 
     err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-v'], stderr=PIPE).stderr
     verify_includes(err)

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -26,8 +26,20 @@ def get(ports, settings, shared):
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
-
     src_path = os.path.join(dest_path, 'bullet', 'src')
+    src_path = os.path.join(dest_path, 'bullet', 'src')
+
+    dest_include_path = os.path.join(ports.get_include_dir(), 'bullet')
+    for base, dirs, files in os.walk(src_path):
+      for f in files:
+        if os.path.splitext(f)[1] != '.h':
+          continue
+        fullpath = os.path.join(base, f)
+        relpath = os.path.relpath(fullpath, src_path)
+        target = os.path.join(dest_include_path, relpath)
+        shared.safe_ensure_dirs(os.path.dirname(target))
+        shutil.copyfile(fullpath, target)
+
     includes = []
     for root, dirs, files in os.walk(src_path, topdown=False):
       for dir in dirs:
@@ -47,7 +59,7 @@ def clear(ports, shared):
 def process_args(ports, args, settings, shared):
   if settings.USE_BULLET == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'bullet', 'bullet', 'src')]
+    args += ['-I' + os.path.join(ports.get_include_dir(), 'bullet')]
   return args
 
 

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -43,6 +43,7 @@ def get(ports, settings, shared):
 
     final = os.path.join(ports.get_build_dir(), 'bzip2', 'libbz2.a')
     ports.create_lib(final, o_s)
+    ports.install_headers(source_path)
     return final
 
   return [shared.Cache.get('libbz2.a', create, what='port')]
@@ -55,7 +56,6 @@ def clear(ports, shared):
 def process_args(ports, args, settings, shared):
   if settings.USE_BZIP2 == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'bzip2')]
   return args
 
 

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -28,9 +28,10 @@ def get(ports, settings, shared):
     cocos2d_root = os.path.join(cocos2d_src, 'Cocos2d-' + TAG)
     cocos2dx_root = os.path.join(cocos2d_root, 'cocos2dx')
     cocos2dx_src = make_source_list(cocos2d_root, cocos2dx_root)
-    cocos2dx_includes = make_includes(cocos2d_root, cocos2dx_root)
+    cocos2dx_includes = make_includes(cocos2d_root)
 
     cocos2d_build = os.path.join(ports.get_build_dir(), 'cocos2d')
+    shared.try_delete(os.path.join(cocos2d_build, 'samples'))
     shutil.copytree(os.path.join(cocos2d_root, 'samples', 'Cpp'),
                     os.path.join(cocos2d_build, 'samples'))
 
@@ -41,8 +42,7 @@ def get(ports, settings, shared):
       shared.safe_ensure_dirs(os.path.dirname(o))
       command = [shared.PYTHON,
                  shared.EMCC,
-                 '-c',
-                 os.path.join(cocos2dx_root, 'proj.emscripten', src),
+                 '-c', src,
                  '-Wno-overloaded-virtual',
                  '-Wno-deprecated-declarations',
                  '-D__CC_PLATFORM_FILEUTILS_CPP__',
@@ -68,6 +68,11 @@ def get(ports, settings, shared):
     ports.run_commands(commands)
     final = os.path.join(cocos2d_build, libname)
     ports.create_lib(final, o_s)
+
+    for dirname in cocos2dx_includes:
+      target = os.path.join('cocos2d', os.path.relpath(dirname, cocos2d_root))
+      ports.install_header_dir(dirname, target=target)
+
     return final
 
   return [shared.Cache.get(libname, create, what='port')]
@@ -86,13 +91,8 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_COCOS2D == 3:
     get(ports, settings, shared)
-    cocos2d_build = os.path.join(ports.get_dir(), 'cocos2d')
-    cocos2d_root = os.path.join(cocos2d_build, 'Cocos2d-' + TAG)
-    cocos2dx_root = os.path.join(cocos2d_root, 'cocos2dx')
-    cocos2dx_includes = make_includes(cocos2d_root, cocos2dx_root)
-    args += ['-Xclang']
-    for include in cocos2dx_includes:
-      args.append('-isystem' + include)
+    for include in make_includes(os.path.join(ports.get_include_dir(), 'cocos2d')):
+      args.append('-I' + include)
   return args
 
 
@@ -133,30 +133,30 @@ def make_source_list(cocos2d_root, cocos2dx_root):
   return sources
 
 
-def make_includes(cocos2d_root, cocos2dx_root):
-  return [os.path.join(cocos2d_root, 'CocosDenshion', 'include'),
-          os.path.join(cocos2d_root, 'extensions'),
-          os.path.join(cocos2d_root, 'extensions', 'AssetsManager'),
-          os.path.join(cocos2d_root, 'extensions', 'CCArmature'),
-          os.path.join(cocos2d_root, 'extensions', 'CCBReader'),
-          os.path.join(cocos2d_root, 'extensions', 'GUI', 'CCControlExtension'),
-          os.path.join(cocos2d_root, 'extensions', 'GUI', 'CCEditBox'),
-          os.path.join(cocos2d_root, 'extensions', 'GUI', 'CCScrollView'),
-          os.path.join(cocos2d_root, 'extensions', 'network'),
-          os.path.join(cocos2d_root, 'extensions', 'Components'),
-          os.path.join(cocos2d_root, 'extensions', 'LocalStorage'),
-          os.path.join(cocos2d_root, 'extensions', 'physics_nodes'),
-          os.path.join(cocos2d_root, 'extensions', 'spine'),
-          os.path.join(cocos2d_root, 'external'),
-          os.path.join(cocos2d_root, 'external', 'chipmunk', 'include', 'chipmunk'),
-          cocos2dx_root,
-          os.path.join(cocos2dx_root, 'cocoa'),
-          os.path.join(cocos2dx_root, 'include'),
-          os.path.join(cocos2dx_root, 'kazmath', 'include'),
-          os.path.join(cocos2dx_root, 'platform'),
-          os.path.join(cocos2dx_root, 'platform', 'emscripten'),
-          os.path.join(cocos2dx_root, 'platform', 'third_party', 'linux', 'libfreetype2'),
-          os.path.join(cocos2dx_root, 'platform', 'third_party', 'common', 'etc'),
-          os.path.join(cocos2dx_root, 'platform', 'third_party', 'emscripten', 'libtiff', 'include'),
-          os.path.join(cocos2dx_root, 'platform', 'third_party', 'emscripten', 'libjpeg'),
-          os.path.join(cocos2dx_root, 'platform', 'third_party', 'emscripten', 'libwebp')]
+def make_includes(root):
+  return [os.path.join(root, 'CocosDenshion', 'include'),
+          os.path.join(root, 'extensions'),
+          os.path.join(root, 'extensions', 'AssetsManager'),
+          os.path.join(root, 'extensions', 'CCArmature'),
+          os.path.join(root, 'extensions', 'CCBReader'),
+          os.path.join(root, 'extensions', 'GUI', 'CCControlExtension'),
+          os.path.join(root, 'extensions', 'GUI', 'CCEditBox'),
+          os.path.join(root, 'extensions', 'GUI', 'CCScrollView'),
+          os.path.join(root, 'extensions', 'network'),
+          os.path.join(root, 'extensions', 'Components'),
+          os.path.join(root, 'extensions', 'LocalStorage'),
+          os.path.join(root, 'extensions', 'physics_nodes'),
+          os.path.join(root, 'extensions', 'spine'),
+          os.path.join(root, 'external'),
+          os.path.join(root, 'external', 'chipmunk', 'include', 'chipmunk'),
+          os.path.join(root, 'cocos2dx'),
+          os.path.join(root, 'cocos2dx', 'cocoa'),
+          os.path.join(root, 'cocos2dx', 'include'),
+          os.path.join(root, 'cocos2dx', 'kazmath', 'include'),
+          os.path.join(root, 'cocos2dx', 'platform'),
+          os.path.join(root, 'cocos2dx', 'platform', 'emscripten'),
+          os.path.join(root, 'cocos2dx', 'platform', 'third_party', 'linux', 'libfreetype2'),
+          os.path.join(root, 'cocos2dx', 'platform', 'third_party', 'common', 'etc'),
+          os.path.join(root, 'cocos2dx', 'platform', 'third_party', 'emscripten', 'libtiff', 'include'),
+          os.path.join(root, 'cocos2dx', 'platform', 'third_party', 'emscripten', 'libjpeg'),
+          os.path.join(root, 'cocos2dx', 'platform', 'third_party', 'emscripten', 'libwebp')]

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -5,7 +5,6 @@
 
 import os
 import shutil
-from subprocess import Popen
 
 TAG = 'version_1'
 HASH = '0d0b1280ba0501ad0a23cf1daa1f86821c722218b59432734d3087a89acd22aabd5c3e5e1269700dcd41e87073046e906060f167c032eb91a3ac8c5808a02783'
@@ -103,8 +102,10 @@ def get(ports, settings, shared):
     ports.run_commands(commands)
     final = os.path.join(ports.get_build_dir(), 'freetype', 'libfreetype.a')
     shared.try_delete(final)
-    Popen([shared.LLVM_AR, 'rc', final] + o_s).communicate()
-    assert os.path.exists(final)
+    shared.run_process([shared.LLVM_AR, 'rc', final] + o_s)
+
+    ports.install_header_dir(os.path.join(dest_path, 'include'),
+                             target=os.path.join('freetype2', 'freetype'))
     return final
 
   return [shared.Cache.get('libfreetype.a', create, what='port')]
@@ -117,7 +118,8 @@ def clear(ports, shared):
 def process_args(ports, args, settings, shared):
   if settings.USE_FREETYPE == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'freetype/include')]
+    args += ['-I' + os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')]
+
   return args
 
 

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -24,9 +24,8 @@ def get(ports, settings, shared):
     source_path = os.path.join(ports.get_dir(), 'harfbuzz', 'harfbuzz-' + TAG)
     dest_path = os.path.join(ports.get_build_dir(), 'harfbuzz')
 
-    freetype_dir = os.path.join(ports.get_build_dir(), 'freetype')
-    freetype_lib = os.path.join(freetype_dir, 'libfreetype.a')
-    freetype_include = os.path.join(freetype_dir, 'include')
+    freetype_lib = shared.Cache.get_path('libfreetype.a')
+    freetype_include = os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')
     freetype_include_dirs = freetype_include + ';' + os.path.join(freetype_include, 'config')
 
     configure_args = [
@@ -45,6 +44,9 @@ def get(ports, settings, shared):
 
     shared.Building.configure(configure_args)
     shared.Building.make(['make', '-j%d' % shared.Building.get_num_cores(), '-C' + dest_path, 'install'])
+
+    ports.install_header_dir(os.path.join(dest_path, 'include', 'harfbuzz'))
+
     return os.path.join(dest_path, 'libharfbuzz.a')
 
   return [shared.Cache.get('libharfbuzz' + ('-mt' if settings.USE_PTHREADS else '') + '.a', create, what='port')]
@@ -62,7 +64,7 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_HARFBUZZ == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(ports.get_build_dir(), 'harfbuzz', 'include', 'harfbuzz')]
+    args += ['-I' + os.path.join(ports.get_build_dir(), 'harfbuzz', 'include', 'harfbuzz')]
   return args
 
 

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -29,6 +29,8 @@ def get(ports, settings, shared):
 
     final = os.path.join(dest_path, libname)
     ports.build_port(os.path.join(dest_path, 'icu4c', 'source', 'common'), final, [os.path.join(dest_path, 'icu4c', 'source', 'common')], ['--std=c++11', '-DU_COMMON_IMPLEMENTATION=1'])
+
+    ports.install_header_dir(os.path.join(dest_path, 'icu4c', 'source', 'common', 'unicode'))
     return final
 
   return [shared.Cache.get(libname, create)]
@@ -41,7 +43,6 @@ def clear(ports, shared):
 def process_args(ports, args, settings, shared):
   if settings.USE_ICU == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'icu', 'icu4c', 'source', 'common')]
   return args
 
 

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -29,6 +29,7 @@ def get(ports, settings, shared):
     shutil.copytree(source_path, dest_path)
 
     open(os.path.join(dest_path, 'jconfig.h'), 'w').write(jconfig_h)
+    ports.install_headers(dest_path)
 
     final = os.path.join(ports.get_build_dir(), 'libjpeg', libname)
     ports.build_port(
@@ -51,7 +52,6 @@ def clear(ports, shared):
 def process_args(ports, args, settings, shared):
   if settings.USE_LIBJPEG == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'libjpeg')]
   return args
 
 

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -29,6 +29,7 @@ def get(ports, settings, shared):
     shutil.copytree(source_path, dest_path)
 
     open(os.path.join(dest_path, 'pnglibconf.h'), 'w').write(pnglibconf_h)
+    ports.install_headers(dest_path)
 
     final = os.path.join(ports.get_build_dir(), 'libpng', libname)
     ports.build_port(dest_path, final, flags=['-s', 'USE_ZLIB=1'], exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
@@ -49,7 +50,6 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_LIBPNG == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'libpng')]
   return args
 
 

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -30,8 +30,12 @@ def get(ports, settings, shared):
 
     open(os.path.join(dest_path, 'include', 'ogg', 'config_types.h'), 'w').write(config_types_h)
 
+    header_dir = os.path.join(ports.get_include_dir(), 'ogg')
+    shutil.rmtree(header_dir, ignore_errors=True)
+    shutil.copytree(os.path.join(dest_path, 'include', 'ogg'), header_dir)
+
     final = os.path.join(dest_path, libname)
-    ports.build_port(os.path.join(dest_path, 'src'), final, [os.path.join(dest_path, 'include')])
+    ports.build_port(os.path.join(dest_path, 'src'), final)
     return final
 
   return [shared.Cache.get(libname, create)]
@@ -44,7 +48,6 @@ def clear(ports, shared):
 def process_args(ports, args, settings, shared):
   if settings.USE_OGG == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'ogg', 'include')]
   return args
 
 

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -51,9 +51,8 @@ def get(ports, settings, shared):
     shutil.copytree(source_path_glslopt, dest_path_glslopt)
 
     # includes
-    source_path_include = os.path.join(ports.get_dir(), 'regal', 'regal-' + TAG, 'include')
-    dest_path_include = os.path.join(ports.get_build_dir(), 'regal', 'include')
-    shutil.copytree(source_path_include, dest_path_include)
+    source_path_include = os.path.join(ports.get_dir(), 'regal', 'regal-' + TAG, 'include', 'GL')
+    ports.install_header_dir(source_path_include)
 
     # build
     srcs_regal = ['regal/RegalShaderInstance.cpp',
@@ -134,7 +133,6 @@ def get(ports, settings, shared):
                        '-fvisibility=hidden',
                        '-O2',
                        '-o', o,
-                       '-I' + dest_path_include,
                        '-I' + dest_path_regal,
                        '-I' + os.path.join(dest_path_md5, 'include'),
                        '-I' + dest_path_lookup3,
@@ -166,7 +164,6 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_REGAL == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(ports.get_build_dir(), 'regal', 'include')]
   return args
 
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 
 TAG = 'version_18'
 HASH = '3a677c06d693c1568543eeb9179f9211a8c482738dab4400ccbc39aabe0cd1e57085e63ba1c25e9faefda1e06046d3b528298c96bb20c132b7c80e2e0aba972c'

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -29,12 +29,11 @@ def get(ports, settings, shared):
 
     # copy includes to a location so they can be used as 'SDL2/'
     source_include_path = os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'include')
-    dest_include_path = ports.get_include_dir()
-    shared.try_delete(dest_include_path)
-    shutil.copytree(source_include_path, os.path.join(dest_include_path, 'SDL2'))
+    ports.install_headers(source_include_path, target='SDL2')
 
     # write out an SDL_config.h file, that configure would normally emit
-    open(os.path.join(dest_include_path, 'SDL2', 'SDL_config.h'), 'w').write(sdl_config_h)
+    dest_include_path = os.path.join(ports.get_include_dir(), 'SDL2')
+    open(os.path.join(dest_include_path, 'SDL_config.h'), 'w').write(sdl_config_h)
 
     # build
     srcs = '''SDL.c SDL_assert.c SDL_dataqueue.c SDL_error.c SDL_hints.c SDL_log.c atomic/SDL_atomic.c
@@ -79,7 +78,7 @@ def get(ports, settings, shared):
       shared.safe_ensure_dirs(os.path.dirname(o))
       command = [shared.PYTHON, shared.EMCC,
                  '-c', os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src),
-                 '-o', o, '-I' + os.path.join(dest_include_path, 'SDL2'),
+                 '-o', o, '-I' + dest_include_path,
                  '-O2', '-DUSING_GENERATED_CONFIG_H', '-w']
       if settings.USE_PTHREADS:
         command += ['-s', 'USE_PTHREADS']

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -26,17 +26,48 @@ def get(ports, settings, shared):
     ports.clear_project_build('sdl2_net')
     ports.clear_project_build('sdl2_ttf')
     ports.clear_project_build('sdl2_gfx')
+
     # copy includes to a location so they can be used as 'SDL2/'
     source_include_path = os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'include')
-    dest_include_path = os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2', 'include')
+    dest_include_path = ports.get_include_dir()
     shared.try_delete(dest_include_path)
-    shutil.copytree(source_include_path, dest_include_path)
     shutil.copytree(source_include_path, os.path.join(dest_include_path, 'SDL2'))
+
     # write out an SDL_config.h file, that configure would normally emit
-    open(os.path.join(dest_include_path, 'SDL_config.h'), 'w').write(sdl_config_h)
     open(os.path.join(dest_include_path, 'SDL2', 'SDL_config.h'), 'w').write(sdl_config_h)
+
     # build
-    srcs = 'SDL.c SDL_assert.c SDL_dataqueue.c SDL_error.c SDL_hints.c SDL_log.c atomic/SDL_atomic.c atomic/SDL_spinlock.c audio/SDL_audio.c audio/SDL_audiocvt.c audio/SDL_audiodev.c audio/SDL_audiotypecvt.c audio/SDL_mixer.c audio/SDL_wave.c cpuinfo/SDL_cpuinfo.c dynapi/SDL_dynapi.c events/SDL_clipboardevents.c events/SDL_dropevents.c events/SDL_events.c events/SDL_gesture.c events/SDL_keyboard.c events/SDL_mouse.c events/SDL_quit.c events/SDL_touch.c events/SDL_windowevents.c file/SDL_rwops.c haptic/SDL_haptic.c joystick/SDL_gamecontroller.c joystick/SDL_joystick.c libm/e_atan2.c libm/e_log.c libm/e_pow.c libm/e_rem_pio2.c libm/e_sqrt.c libm/k_cos.c libm/k_rem_pio2.c libm/k_sin.c libm/k_tan.c libm/s_atan.c libm/s_copysign.c libm/s_cos.c libm/s_fabs.c libm/s_floor.c libm/s_scalbn.c libm/s_sin.c libm/s_tan.c power/SDL_power.c render/SDL_d3dmath.c render/SDL_render.c render/SDL_yuv_sw.c render/direct3d/SDL_render_d3d.c render/direct3d11/SDL_render_d3d11.c render/opengl/SDL_render_gl.c render/opengl/SDL_shaders_gl.c render/opengles/SDL_render_gles.c render/opengles2/SDL_render_gles2.c render/opengles2/SDL_shaders_gles2.c render/psp/SDL_render_psp.c render/software/SDL_blendfillrect.c render/software/SDL_blendline.c render/software/SDL_blendpoint.c render/software/SDL_drawline.c render/software/SDL_drawpoint.c render/software/SDL_render_sw.c render/software/SDL_rotate.c sensor/SDL_sensor.c stdlib/SDL_getenv.c stdlib/SDL_iconv.c stdlib/SDL_malloc.c stdlib/SDL_qsort.c stdlib/SDL_stdlib.c stdlib/SDL_string.c thread/SDL_thread.c timer/SDL_timer.c video/SDL_RLEaccel.c video/SDL_blit.c video/SDL_blit_0.c video/SDL_blit_1.c video/SDL_blit_A.c video/SDL_blit_N.c video/SDL_blit_auto.c video/SDL_blit_copy.c video/SDL_blit_slow.c video/SDL_bmp.c video/SDL_clipboard.c video/SDL_egl.c video/SDL_fillrect.c video/SDL_pixels.c video/SDL_rect.c video/SDL_shape.c video/SDL_stretch.c video/SDL_surface.c video/SDL_video.c video/SDL_yuv.c video/emscripten/SDL_emscriptenevents.c video/emscripten/SDL_emscriptenframebuffer.c video/emscripten/SDL_emscriptenmouse.c video/emscripten/SDL_emscriptenopengles.c video/emscripten/SDL_emscriptenvideo.c audio/emscripten/SDL_emscriptenaudio.c video/dummy/SDL_nullevents.c video/dummy/SDL_nullframebuffer.c video/dummy/SDL_nullvideo.c video/yuv2rgb/yuv_rgb.c audio/disk/SDL_diskaudio.c audio/dummy/SDL_dummyaudio.c loadso/dlopen/SDL_sysloadso.c power/emscripten/SDL_syspower.c joystick/emscripten/SDL_sysjoystick.c filesystem/emscripten/SDL_sysfilesystem.c timer/unix/SDL_systimer.c haptic/dummy/SDL_syshaptic.c main/dummy/SDL_dummy_main.c'.split()
+    srcs = '''SDL.c SDL_assert.c SDL_dataqueue.c SDL_error.c SDL_hints.c SDL_log.c atomic/SDL_atomic.c
+    atomic/SDL_spinlock.c audio/SDL_audio.c audio/SDL_audiocvt.c audio/SDL_audiodev.c
+    audio/SDL_audiotypecvt.c audio/SDL_mixer.c audio/SDL_wave.c cpuinfo/SDL_cpuinfo.c
+    dynapi/SDL_dynapi.c events/SDL_clipboardevents.c events/SDL_dropevents.c events/SDL_events.c
+    events/SDL_gesture.c events/SDL_keyboard.c events/SDL_mouse.c events/SDL_quit.c
+    events/SDL_touch.c events/SDL_windowevents.c file/SDL_rwops.c haptic/SDL_haptic.c
+    joystick/SDL_gamecontroller.c joystick/SDL_joystick.c libm/e_atan2.c libm/e_log.c libm/e_pow.c
+    libm/e_rem_pio2.c libm/e_sqrt.c libm/k_cos.c libm/k_rem_pio2.c libm/k_sin.c libm/k_tan.c
+    libm/s_atan.c libm/s_copysign.c libm/s_cos.c libm/s_fabs.c libm/s_floor.c libm/s_scalbn.c
+    libm/s_sin.c libm/s_tan.c power/SDL_power.c render/SDL_d3dmath.c render/SDL_render.c
+    render/SDL_yuv_sw.c render/direct3d/SDL_render_d3d.c render/direct3d11/SDL_render_d3d11.c
+    render/opengl/SDL_render_gl.c render/opengl/SDL_shaders_gl.c render/opengles/SDL_render_gles.c
+    render/opengles2/SDL_render_gles2.c render/opengles2/SDL_shaders_gles2.c
+    render/psp/SDL_render_psp.c render/software/SDL_blendfillrect.c render/software/SDL_blendline.c
+    render/software/SDL_blendpoint.c render/software/SDL_drawline.c render/software/SDL_drawpoint.c
+    render/software/SDL_render_sw.c render/software/SDL_rotate.c sensor/SDL_sensor.c
+    stdlib/SDL_getenv.c stdlib/SDL_iconv.c stdlib/SDL_malloc.c stdlib/SDL_qsort.c
+    stdlib/SDL_stdlib.c stdlib/SDL_string.c thread/SDL_thread.c timer/SDL_timer.c
+    video/SDL_RLEaccel.c video/SDL_blit.c video/SDL_blit_0.c video/SDL_blit_1.c video/SDL_blit_A.c
+    video/SDL_blit_N.c video/SDL_blit_auto.c video/SDL_blit_copy.c video/SDL_blit_slow.c
+    video/SDL_bmp.c video/SDL_clipboard.c video/SDL_egl.c video/SDL_fillrect.c video/SDL_pixels.c
+    video/SDL_rect.c video/SDL_shape.c video/SDL_stretch.c video/SDL_surface.c video/SDL_video.c
+    video/SDL_yuv.c video/emscripten/SDL_emscriptenevents.c
+    video/emscripten/SDL_emscriptenframebuffer.c video/emscripten/SDL_emscriptenmouse.c
+    video/emscripten/SDL_emscriptenopengles.c video/emscripten/SDL_emscriptenvideo.c
+    audio/emscripten/SDL_emscriptenaudio.c video/dummy/SDL_nullevents.c
+    video/dummy/SDL_nullframebuffer.c video/dummy/SDL_nullvideo.c video/yuv2rgb/yuv_rgb.c
+    audio/disk/SDL_diskaudio.c audio/dummy/SDL_dummyaudio.c loadso/dlopen/SDL_sysloadso.c
+    power/emscripten/SDL_syspower.c joystick/emscripten/SDL_sysjoystick.c
+    filesystem/emscripten/SDL_sysfilesystem.c timer/unix/SDL_systimer.c haptic/dummy/SDL_syshaptic.c
+    main/dummy/SDL_dummy_main.c'''.split()
     thread_srcs = ['SDL_syscond.c', 'SDL_sysmutex.c', 'SDL_syssem.c', 'SDL_systhread.c', 'SDL_systls.c']
     thread_backend = 'generic' if not settings.USE_PTHREADS else 'pthread'
     srcs += ['thread/%s/%s' % (thread_backend, s) for s in thread_srcs]
@@ -46,7 +77,10 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2', 'src', src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
-      command = [shared.PYTHON, shared.EMCC, '-c', os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src), '-O2', '-o', o, '-I' + dest_include_path, '-O2', '-DUSING_GENERATED_CONFIG_H', '-w']
+      command = [shared.PYTHON, shared.EMCC,
+                 '-c', os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'src', src),
+                 '-o', o, '-I' + os.path.join(dest_include_path, 'SDL2'),
+                 '-O2', '-DUSING_GENERATED_CONFIG_H', '-w']
       if settings.USE_PTHREADS:
         command += ['-s', 'USE_PTHREADS']
       commands.append(command)
@@ -65,10 +99,12 @@ def clear(ports, shared):
 
 def process_args(ports, args, settings, shared):
   if settings.USE_SDL == 1:
-      args += ['-Xclang', '-isystem' + shared.path_from_root('system', 'include', 'SDL')]
+    # TODO(sbc): remove this
+    args += ['-Xclang', '-isystem' + shared.path_from_root('system', 'include', 'SDL')]
   elif settings.USE_SDL == 2:
+    # TODO(sbc): remove this
+    args += ['-Xclang', '-isystem' + os.path.join(ports.get_include_dir(), 'SDL2')]
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2', 'include')]
   return args
 
 

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -28,12 +28,10 @@ def get(ports, settings, shared):
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
-
-    for header in ['SDL2_framerate.h', 'SDL2_gfxPrimitives_font.h', 'SDL2_gfxPrimitives.h', 'SDL2_imageFilter.h', 'SDL2_rotozoom.h']:
-      shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG, header), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', header))
-
     final = os.path.join(dest_path, libname)
     ports.build_port(dest_path, final, [dest_path], exclude_dirs=['test'])
+
+    ports.install_headers(source_path, target='SDL2')
     return final
 
   return [shared.Cache.get(libname, create)]

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 
 TAG = 'version_4'
 HASH = '30a7b04652239bccff3cb1fa7cd8ae602791b5f502a96df39585c13ebc4bb2b64ba1598c0d1f5382028d94e04a5ca02185ea06bf7f4b3520f6df4cc253f9dd24'
@@ -27,13 +26,10 @@ def get(ports, settings, shared):
   libname = ports.get_lib_name(libname)
 
   def create():
-    # although we shouldn't really do this and could instead use '-Xclang
-    # -isystem' as a kind of 'overlay' as sdl_mixer does,
-    # by now people may be relying on headers being pulled in by '-s USE_SDL=2'
-    # if sdl_image was built in the past
-    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG, 'SDL_image.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL_image.h'))
-    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG, 'SDL_image.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', 'SDL_image.h'))
-    srcs = 'IMG.c IMG_bmp.c IMG_gif.c IMG_jpg.c IMG_lbm.c IMG_pcx.c IMG_png.c IMG_pnm.c IMG_tga.c IMG_tif.c IMG_xcf.c IMG_xpm.c IMG_xv.c IMG_webp.c IMG_ImageIO.m'.split(' ')
+    src_dir = os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG)
+    ports.install_headers(src_dir, target='SDL2')
+    srcs = '''IMG.c IMG_bmp.c IMG_gif.c IMG_jpg.c IMG_lbm.c IMG_pcx.c IMG_png.c IMG_pnm.c IMG_tga.c
+              IMG_tif.c IMG_xcf.c IMG_xpm.c IMG_xv.c IMG_webp.c IMG_ImageIO.m'''.split()
     commands = []
     o_s = []
     defs = []
@@ -49,7 +45,8 @@ def get(ports, settings, shared):
 
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2_image', src + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, '-c', os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'] + defs)
+      commands.append([shared.PYTHON, shared.EMCC, '-c', os.path.join(src_dir, src),
+                       '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'] + defs)
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -60,7 +60,6 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_SDL_MIXER == 2:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_mixer', 'include')]
   return args
 
 

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 
 TAG = 'version_2'
@@ -22,18 +21,15 @@ def get(ports, settings, shared):
 
   def create():
     logging.info('building port: sdl2_net')
-    # although we shouldn't really do this and could instead use '-Xclang
-    # -isystem' as a kind of 'overlay' as sdl_mixer does,
-    # by now people may be relying on headers being pulled in by '-s USE_SDL=2'
-    # if sdl_net was built in the past
-    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL_net.h'))
-    shutil.copyfile(os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG, 'SDL_net.h'), os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2', 'SDL_net.h'))
-    srcs = 'SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c'.split(' ')
+    src_dir = os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG)
+    ports.install_headers(src_dir, target='SDL2')
+    srcs = 'SDLnet.c SDLnetselect.c SDLnetTCP.c SDLnetUDP.c'.split()
     commands = []
     o_s = []
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2_net', src + '.o')
-      commands.append([shared.PYTHON, shared.EMCC, '-c', os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG, src), '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'])
+      commands.append([shared.PYTHON, shared.EMCC, '-c', os.path.join(src_dir, src),
+                       '-O2', '-s', 'USE_SDL=2', '-o', o, '-w'])
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -18,11 +18,8 @@ def get(ports, settings, shared):
   libname = ports.get_lib_name('libSDL2_ttf')
 
   def create():
-    sdl_ttf_h = os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL2_ttf-' + TAG, 'SDL_ttf.h')
-
-    shutil.copy2(sdl_ttf_h, os.path.join(ports.get_build_dir(), 'include'))
-    shutil.copy2(sdl_ttf_h, os.path.join(ports.get_build_dir(), 'sdl2', 'include'))
-    shutil.copy2(sdl_ttf_h, os.path.join(ports.get_build_dir(), 'sdl2', 'include', 'SDL2'))
+    src_root = os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL2_ttf-' + TAG)
+    ports.install_headers(src_root, target='SDL2')
 
     srcs = ['SDL_ttf.c']
     commands = []
@@ -30,9 +27,9 @@ def get(ports, settings, shared):
 
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2_ttf', src + '.o')
-      command = [shared.PYTHON, shared.EMCC]
-      command += ['-c', os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL2_ttf-' + TAG, src)]
-      command += ['-O2', '-s', 'USE_SDL=2', '-s', 'USE_FREETYPE=1', '-o', o, '-w']
+      command = [shared.PYTHON, shared.EMCC,
+                '-c', os.path.join(src_root, src),
+                '-O2', '-s', 'USE_SDL=2', '-s', 'USE_FREETYPE=1', '-o', o, '-w']
       commands.append(command)
       o_s.append(o)
 

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 
 TAG = 'version_1'
 HASH = '6ce426de0411ba51dd307027c4ef00ff3de4ee396018e524265970039132ab20adb29c2d2e61576c393056374f03fd148dd96f0c4abf8dcee51853dd32f0778f'
@@ -28,8 +27,8 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'sdl2_ttf', src + '.o')
       command = [shared.PYTHON, shared.EMCC,
-                '-c', os.path.join(src_root, src),
-                '-O2', '-s', 'USE_SDL=2', '-s', 'USE_FREETYPE=1', '-o', o, '-w']
+                 '-c', os.path.join(src_root, src),
+                 '-O2', '-s', 'USE_SDL=2', '-s', 'USE_FREETYPE=1', '-o', o, '-w']
       commands.append(command)
       o_s.append(o)
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -30,6 +30,7 @@ def get(ports, settings, shared):
     final = os.path.join(dest_path, libname)
     ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
                      ['-s', 'USE_OGG=1'], ['psytune', 'barkmel', 'tone', 'misc'])
+    ports.install_header_dir(os.path.join(source_path, 'include', 'vorbis'))
     return final
 
   return [shared.Cache.get(libname, create)]
@@ -47,7 +48,6 @@ def process_dependencies(settings):
 def process_args(ports, args, settings, shared):
   if settings.USE_VORBIS == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'vorbis', 'include')]
   return args
 
 

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -26,6 +26,7 @@ def get(ports, settings, shared):
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
     open(os.path.join(dest_path, 'zconf.h'), 'w').write(zconf_h)
+    ports.install_headers(dest_path)
 
     # build
     srcs = 'adler32.c compress.c crc32.c deflate.c gzclose.c gzlib.c gzread.c gzwrite.c infback.c inffast.c inflate.c inftrees.c trees.c uncompr.c zutil.c'.split()
@@ -52,7 +53,6 @@ def clear(ports, shared):
 def process_args(ports, args, settings, shared):
   if settings.USE_ZLIB == 1:
     get(ports, settings, shared)
-    args += ['-Xclang', '-isystem' + os.path.join(shared.Cache.get_path('ports-builds'), 'zlib')]
   return args
 
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1047,7 +1047,8 @@ def emsdk_cflags():
     path_from_root('system', 'include'),
     path_from_root('system', 'include', 'libc'),
     path_from_root('system', 'lib', 'libc', 'musl', 'arch', 'emscripten'),
-    path_from_root('system', 'local', 'include')
+    path_from_root('system', 'local', 'include'),
+    Cache.get_path('include')
   ]
 
   cxx_include_paths = [

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1509,18 +1509,18 @@ class Ports(object):
       target = os.path.basename(src_dir)
     dest = os.path.join(Ports.get_include_dir(), target)
     shared.try_delete(dest)
-    print('installing headers: ' + dest)
+    logger.debug('installing headers: ' + dest)
     shutil.copytree(src_dir, dest)
 
   @staticmethod
   def install_headers(src_dir, pattern="*.h", target=None):
-    print("install_headers")
+    logger.debug("install_headers")
     dest = Ports.get_include_dir()
     if target:
       dest = os.path.join(dest, target)
       shared.safe_ensure_dirs(dest)
     for f in glob.glob(os.path.join(src_dir, pattern)):
-      print(os.path.join(dest, os.path.basename(f)))
+      logger.debug(os.path.join(dest, os.path.basename(f)))
       shutil.copyfile(f, os.path.join(dest, os.path.basename(f)))
 
   @staticmethod

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 
 from __future__ import print_function
+import glob
 import hashlib
 import itertools
 import json
@@ -1495,6 +1496,32 @@ class Ports(object):
   @staticmethod
   def get_lib_name(name):
     return shared.static_library_name(name)
+
+  @staticmethod
+  def get_include_dir():
+    dirname = shared.Cache.get_path('include')
+    shared.safe_ensure_dirs(dirname)
+    return dirname
+
+  @staticmethod
+  def install_header_dir(src_dir, target=None):
+    if not target:
+      target = os.path.basename(src_dir)
+    dest = os.path.join(Ports.get_include_dir(), target)
+    shared.try_delete(dest)
+    print('installing headers: ' + dest)
+    shutil.copytree(src_dir, dest)
+
+  @staticmethod
+  def install_headers(src_dir, pattern="*.h", target=None):
+    print("install_headers")
+    dest = Ports.get_include_dir()
+    if target:
+      dest = os.path.join(dest, target)
+      shared.safe_ensure_dirs(dest)
+    for f in glob.glob(os.path.join(src_dir, pattern)):
+      print(os.path.join(dest, os.path.basename(f)))
+      shutil.copyfile(f, os.path.join(dest, os.path.basename(f)))
 
   @staticmethod
   def build_port(src_path, output_path, includes=[], flags=[], exclude_files=[], exclude_dirs=[]):


### PR DESCRIPTION
We already use a common "lib" directory to install al the libs.  This
change simply installs headers in the same common "sysroot".

This makes the ports install more like normall "make install" scripts
would.

The only port I didn't include here was cocos2d because it seemed a
little overwhelming.