### PR TITLE
Re-enable firefox pthreads tests, now that the COEP pref is in Dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,8 +196,6 @@ commands:
             # OffscreenCanvas support is not yet done in Firefox.
             EMTEST_LACKS_OFFSCREEN_CANVAS: "1"
             EMTEST_DETECT_TEMPFILE_LEAKS: "0"
-            # Disable threads as dom.postMessage.sharedArrayBuffer.bypassCOOP_COEP.insecure.enabled is not yet present on dev edition.
-            EMTEST_LACKS_THREAD_SUPPORT: "1"
             DISPLAY: ":0"
           command: |
             export EMTEST_BROWSER="$HOME/firefox/firefox -profile $HOME/tmp-firefox-profile/"


### PR DESCRIPTION
This gets us more pthreads coverage, and in particular
the pthreads growth tests, which currently only run in
firefox.

cc @brion 