### PR TITLE
Don't show 'view page source' links in emscripten docs

### DIFF
--- a/site/source/conf.py
+++ b/site/source/conf.py
@@ -221,7 +221,7 @@ html_static_path = ['_static']
 #html_split_index = False
 
 # If true, links to the reST sources are added to the pages.
-#html_show_sourcelink = True
+html_show_sourcelink = False
 
 # If true, "Created using Sphinx" is shown in the HTML footer. Default is True.
 #html_show_sphinx = True


### PR DESCRIPTION
They just show the .rst restructured text input, which is not
that useful for our users.