### PR TITLE
Reduce default stack size to 512KB.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,10 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Reduced program main thread stack size from 5MB to 512KB
+  (-s TOTAL_STACK=512KB) to save WebAssembly heap memory by default.
+- Reduced default pthread stack size attribute from 2MB to 512KB
+  (-s DEFAULT_PTHREAD_STACK_SIZE=512KB) to save memory by default.
 - All ports now install their headers into a shared directory under
   `EM_CACHE`.  This should not really be a user visible change although one
   side effect is that once a give ports is built its headers are then

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -739,7 +739,7 @@ var LibraryPThread = {
         schedPrio = {{{ makeGetValue('attr', 24/*_a_prio*/, 'i32') }}};
       }
     } else {
-      // According to http://man7.org/linux/man-pages/man3/pthread_create.3.html, default stack size if not specified is 2 MB, so follow that convention.
+      // Use the default thread stack size specified in global build settings.
       stackSize = {{{ DEFAULT_PTHREAD_STACK_SIZE }}};
     }
     var allocatedOwnStack = stackBase == 0; // If allocatedOwnStack == true, then the pthread impl maintains the stack allocation.

--- a/src/settings.js
+++ b/src/settings.js
@@ -102,7 +102,7 @@ var MEM_INIT_METHOD = 0;
 // value must be large enough for the program's requirements. If
 // assertions are on, we will assert on not exceeding this, otherwise,
 // it will fail silently.
-var TOTAL_STACK = 5*1024*1024;
+var TOTAL_STACK = 512*1024;
 
 // The total amount of memory to use. Using more memory than this will
 // cause us to expand the heap, which can be costly with typed arrays:
@@ -1357,14 +1357,14 @@ var PTHREAD_POOL_DELAY_LOAD = 0;
 // If not explicitly specified, this is the stack size to use for newly created
 // pthreads.  According to
 // http://man7.org/linux/man-pages/man3/pthread_create.3.html, default stack
-// size on Linux/x86-32 for a new thread is 2 megabytes, so follow the same
-// convention. Use pthread_attr_setstacksize() at thread creation time to
-// explicitly specify the stack size, in which case this value is ignored. Note
-// that the asm.js/wasm function call control flow stack is separate from this
+// size on Linux/x86-32 for a new thread is 2 megabytes. However in
+// WebAssembly/asm.js, function call control flow stack is separate from this
 // stack, and this stack only contains certain function local variables, such as
 // those that have their addresses taken, or ones that are too large to fit as
-// local vars in asm.js/wasm code.
-var DEFAULT_PTHREAD_STACK_SIZE = 2*1024*1024;
+// local vars in asm.js/wasm code. Therefore use a smaller thread stack
+// by default. Use pthread_attr_setstacksize() at thread creation time to
+// explicitly specify the stack size, in which case this value is ignored.
+var DEFAULT_PTHREAD_STACK_SIZE = 512*1024;
 
 // Specifies the value returned by the function emscripten_num_logical_cores()
 // if navigator.hardwareConcurrency is not supported. Pass in a negative number

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -1488,7 +1488,7 @@ private:
         Valid = 255,
         Deleted = 127,
     };
-    static constexpr size_t N_ = 1000000;
+    static constexpr size_t N_ = 10000;
     unsigned char d_[N_];
     T* ptr_;
 

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -48,7 +48,7 @@ int main()
   void *stack_addr;
   pthread_attr_getstack(&attr, &stack_addr, &stack_size);
   printf("stack_size: %d, stack_addr: %p\n", (int)stack_size, stack_addr);
-  if (stack_size != 2*1024*1024 || stack_addr == 0)
+  if (stack_size != 512*1024 || stack_addr == 0)
     result = -100; // Report failure.
 
   pthread_join(thr, 0);

--- a/tests/sdl_create_rgb_surface_from.c
+++ b/tests/sdl_create_rgb_surface_from.c
@@ -15,7 +15,7 @@
 
 int main() {
 
-  uint8_t pixels[width * height * 4];
+  static uint8_t pixels[width * height * 4];
   uint8_t *end = pixels + width * height * 4;
   uint8_t *pixel = pixels;
   SDL_Rect rect = {0, 0, width, height};

--- a/tests/test_webgl_context_attributes_common.c
+++ b/tests/test_webgl_context_attributes_common.c
@@ -138,7 +138,7 @@ static bool testAntiAliasing(bool activated) {
     
     bool antialiased = false;
     
-    unsigned char buffer[(WINDOWS_SIZE*WINDOWS_SIZE)*4];
+    static unsigned char buffer[(WINDOWS_SIZE*WINDOWS_SIZE)*4];
     glReadPixels(0, 0, WINDOWS_SIZE, WINDOWS_SIZE, GL_RGBA, GL_UNSIGNED_BYTE, &buffer[0]);
     glFinish();
     for (unsigned int i = 0 ; i < WINDOWS_SIZE ; ++i) {
@@ -234,7 +234,7 @@ static bool testAlpha(bool activated) {
     
     bool hasAlpha = true;
     
-    unsigned char buffer[(WINDOWS_SIZE*WINDOWS_SIZE)*4];
+    static unsigned char buffer[(WINDOWS_SIZE*WINDOWS_SIZE)*4];
     glReadPixels(0, 0, WINDOWS_SIZE, WINDOWS_SIZE, GL_RGBA, GL_UNSIGNED_BYTE, &buffer[0]);
     glFinish();
     for (unsigned int i = 0 ; i < WINDOWS_SIZE ; ++i) {


### PR DESCRIPTION
Reduce default main thread and pthread stack sizes to 512KB. This does not need to be as big as in native code, because control flow is not part of this stack.

This is something I have been meaning to propose for ages. E.g. In Visual Studio native ARM, x86 and x64 built code, [default stack size is 1MB](https://docs.microsoft.com/en-us/cpp/build/reference/stack-stack-allocations?view=vs-2019).

WebAssembly/JS is very special compared to native stack sizes in that **neither** execution control flow and regular local variables count into this size, but control flow is guarded inside browser, and regular locals are handled by local variables in JS code or in wasm. Only variables that have their addresses taken, or large structs or arrays utilize this limit.

Because of that specialty, I have never seen applications to need much of a stack at all. The largest usage I ever see come from applications that do something like temp `char str[4096];`s on their stack for string manipulation and similar. Even 512KB stack size here seems much larger than is typically needed, and on the safe side. Something like 64KB is probably of the order that applications commonly use.

And we have stack size checks in place, so when applications really need more, they should be able to catch any errors.