### PR TITLE
MAX_WEBGL_VERSION

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1270,7 +1270,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
 
     if shared.Settings.USE_WEBGL2:
-      shared.Settings.GL_MAX_FEATURE_LEVEL = 20
+      shared.Settings.MAX_WEBGL_VERSION = 2
 
     forced_stdlibs = []
 

--- a/emcc.py
+++ b/emcc.py
@@ -1269,6 +1269,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # stb_image 2.x need to have STB_IMAGE_IMPLEMENTATION defined to include the implementation when compiling
       newargs.append('-DSTB_IMAGE_IMPLEMENTATION')
 
+    if shared.Settings.USE_WEBGL2:
+      shared.Settings.GL_MAX_FEATURE_LEVEL = 20
+
     forced_stdlibs = []
 
     if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_ENDINGS:

--- a/site/source/docs/optimizing/Optimizing-WebGL.rst
+++ b/site/source/docs/optimizing/Optimizing-WebGL.rst
@@ -25,7 +25,7 @@ By default, if no special GL related linker flags are chosen, Emscripten targets
 
 - When targeting OpenGL ES 3, if one needs to render from client side memory, or the use of ``glMapBuffer*()`` API is needed, pass the linker flag ``-s FULL_ES3=1`` to emulate these features, which core WebGL 2 does not have. This emulation is expected to hurt performance, so using VBOs is recommended instead.
 
-- Even if your application does not need any WebGL 2/OpenGL ES 3 features, consider porting the application to run on WebGL 2, because JavaScript side performance in WebGL 2 has been optimized to generate no temporary garbage, which has been observed to give a solid 3-7% speed improvement, as well as reducing potential stuttering at render time. To enable these optimizations, build with the linker flag ``-s GL_MAX_FEATURE_LEVEL=20`` and make sure to create a WebGL 2 context at GL startup time (OpenGL ES 3 context if using EGL).
+- Even if your application does not need any WebGL 2/OpenGL ES 3 features, consider porting the application to run on WebGL 2, because JavaScript side performance in WebGL 2 has been optimized to generate no temporary garbage, which has been observed to give a solid 3-7% speed improvement, as well as reducing potential stuttering at render time. To enable these optimizations, build with the linker flag ``-s MAX_WEBGL_VERSION=2`` and make sure to create a WebGL 2 context at GL startup time (OpenGL ES 3 context if using EGL).
 
 How To Profile WebGL
 ====================

--- a/site/source/docs/optimizing/Optimizing-WebGL.rst
+++ b/site/source/docs/optimizing/Optimizing-WebGL.rst
@@ -25,7 +25,7 @@ By default, if no special GL related linker flags are chosen, Emscripten targets
 
 - When targeting OpenGL ES 3, if one needs to render from client side memory, or the use of ``glMapBuffer*()`` API is needed, pass the linker flag ``-s FULL_ES3=1`` to emulate these features, which core WebGL 2 does not have. This emulation is expected to hurt performance, so using VBOs is recommended instead.
 
-- Even if your application does not need any WebGL 2/OpenGL ES 3 features, consider porting the application to run on WebGL 2, because JavaScript side performance in WebGL 2 has been optimized to generate no temporary garbage, which has been observed to give a solid 3-7% speed improvement, as well as reducing potential stuttering at render time. To enable these optimizations, build with the linker flag ``-s USE_WEBGL2=1`` and make sure to create a WebGL 2 context at GL startup time (OpenGL ES 3 context if using EGL).
+- Even if your application does not need any WebGL 2/OpenGL ES 3 features, consider porting the application to run on WebGL 2, because JavaScript side performance in WebGL 2 has been optimized to generate no temporary garbage, which has been observed to give a solid 3-7% speed improvement, as well as reducing potential stuttering at render time. To enable these optimizations, build with the linker flag ``-s GL_MAX_FEATURE_LEVEL=20`` and make sure to create a WebGL 2 context at GL startup time (OpenGL ES 3 context if using EGL).
 
 How To Profile WebGL
 ====================

--- a/site/source/docs/porting/multimedia_and_graphics/OpenGL-support.rst
+++ b/site/source/docs/porting/multimedia_and_graphics/OpenGL-support.rst
@@ -25,9 +25,9 @@ To program against the WebGL subset of OpenGL ES, one uses the GL ES 2.0 header 
 
 This mode is used by default because it best matches the WebGL features brovided by browsers.
 
-To target WebGL 2, pass the linker flag ``-s GL_MAX_FEATURE_LEVEL=20``. Specifying this flag enables (and defaults to, unless otherwise specified at context creation time) the creation of WebGL 2 contexts at runtime, but it is still possible to create WebGL 1 contexts, so applications can choose whether to require WebGL 2 or whether to support a fallback to WebGL 1.
+To target WebGL 2, pass the linker flag ``-s MAX_WEBGL_VERSION=2``. Specifying this flag enables (and defaults to, unless otherwise specified at context creation time) the creation of WebGL 2 contexts at runtime, but it is still possible to create WebGL 1 contexts, so applications can choose whether to require WebGL 2 or whether to support a fallback to WebGL 1.
 
-To only target WebGL 2 and drop support for WebGL 1 altogether to save code size, pass the linker flags ``-s GL_MIN_FEATURE_LEVEL=20`` and ``-s GL_MAX_FEATURE_LEVEL=20``.
+To only target WebGL 2 and drop support for WebGL 1 altogether to save code size, pass the linker flags ``-s MIN_WEBGL_VERSION=2`` and ``-s MAX_WEBGL_VERSION=2``.
 
 .. _opengl-support-opengl-es2-0-emulation:
 

--- a/site/source/docs/porting/multimedia_and_graphics/OpenGL-support.rst
+++ b/site/source/docs/porting/multimedia_and_graphics/OpenGL-support.rst
@@ -25,7 +25,9 @@ To program against the WebGL subset of OpenGL ES, one uses the GL ES 2.0 header 
 
 This mode is used by default because it best matches the WebGL features brovided by browsers.
 
-To target WebGL 2, pass the linker flag ``-s USE_WEBGL2=1``. Specifying this flag enables (and defaults to, unless otherwise specified at context creation time) the creation of WebGL 2 contexts at runtime, but it is still possible to create WebGL 1 contexts, so applications can choose whether to require WebGL 2 or whether to support a fallback to WebGL 1.
+To target WebGL 2, pass the linker flag ``-s GL_MAX_FEATURE_LEVEL=20``. Specifying this flag enables (and defaults to, unless otherwise specified at context creation time) the creation of WebGL 2 contexts at runtime, but it is still possible to create WebGL 1 contexts, so applications can choose whether to require WebGL 2 or whether to support a fallback to WebGL 1.
+
+To only target WebGL 2 and drop support for WebGL 1 altogether to save code size, pass the linker flags ``-s GL_MIN_FEATURE_LEVEL=20`` and ``-s GL_MAX_FEATURE_LEVEL=20``.
 
 .. _opengl-support-opengl-es2-0-emulation:
 

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -312,10 +312,14 @@ var LibraryBrowser = {
         var contextAttributes = {
           antialias: false,
           alpha: false,
-#if USE_WEBGL2 // library_browser.js defaults: use the WebGL version chosen at compile time (unless overridden below)
+#if GL_MIN_FEATURE_LEVEL >= 20
+          majorVersion: 2,
+#else
+#if GL_MAX_FEATURE_LEVEL >= 20 // library_browser.js defaults: use the WebGL version chosen at compile time (unless overridden below)
           majorVersion: (typeof WebGL2RenderingContext !== 'undefined') ? 2 : 1,
 #else
           majorVersion: 1,
+#endif
 #endif
         };
 

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -312,10 +312,10 @@ var LibraryBrowser = {
         var contextAttributes = {
           antialias: false,
           alpha: false,
-#if GL_MIN_FEATURE_LEVEL >= 20
+#if MIN_WEBGL_VERSION >= 2
           majorVersion: 2,
 #else
-#if GL_MAX_FEATURE_LEVEL >= 20 // library_browser.js defaults: use the WebGL version chosen at compile time (unless overridden below)
+#if MAX_WEBGL_VERSION >= 2 // library_browser.js defaults: use the WebGL version chosen at compile time (unless overridden below)
           majorVersion: (typeof WebGL2RenderingContext !== 'undefined') ? 2 : 1,
 #else
           majorVersion: 1,

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -345,14 +345,14 @@ var LibraryEGL = {
       }
       contextAttribs += 8;
     }
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (glesContextVersion < 2 || glesContextVersion > 3) {
 #else
     if (glesContextVersion != 2) {
 #endif
 #if GL_ASSERTIONS
       if (glesContextVersion == 3) {
-        err('When initializing GLES3/WebGL2 via EGL, one must build with -s USE_WEBGL2=1 !');
+        err('When initializing GLES3/WebGL2 via EGL, one must build with -s GL_MAX_FEATURE_LEVEL=20 !');
       } else {
         err('When initializing GLES2/WebGL1 via EGL, one must pass EGL_CONTEXT_CLIENT_VERSION = 2 to GL context attributes! GLES version ' + glesContextVersion + ' is not supported!');
       }

--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -345,14 +345,14 @@ var LibraryEGL = {
       }
       contextAttribs += 8;
     }
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (glesContextVersion < 2 || glesContextVersion > 3) {
 #else
     if (glesContextVersion != 2) {
 #endif
 #if GL_ASSERTIONS
       if (glesContextVersion == 3) {
-        err('When initializing GLES3/WebGL2 via EGL, one must build with -s GL_MAX_FEATURE_LEVEL=20 !');
+        err('When initializing GLES3/WebGL2 via EGL, one must build with -s MAX_WEBGL_VERSION=2 !');
       } else {
         err('When initializing GLES2/WebGL1 via EGL, one must pass EGL_CONTEXT_CLIENT_VERSION = 2 to GL context attributes! GLES version ' + glesContextVersion + ' is not supported!');
       }

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -3339,7 +3339,7 @@ var LibraryGLEmulation = {
   glRotatef: 'glRotated',
 
   glDrawBuffer: function() { throw 'glDrawBuffer: TODO' },
-#if !USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL < 20
   glReadBuffer: function() { throw 'glReadBuffer: TODO' },
 #endif
 

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -3339,7 +3339,7 @@ var LibraryGLEmulation = {
   glRotatef: 'glRotated',
 
   glDrawBuffer: function() { throw 'glDrawBuffer: TODO' },
-#if GL_MAX_FEATURE_LEVEL < 20
+#if MAX_WEBGL_VERSION < 2
   glReadBuffer: function() { throw 'glReadBuffer: TODO' },
 #endif
 

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -21,13 +21,13 @@ var LibraryGL = {
     // Also the type HEAPU16 is not tested for explicitly, but any unrecognized type will return out HEAPU16.
     // (since most types are HEAPU16)
     type -= 0x1400;
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (type == {{{ 0x1400 - 0x1400/* GL_BYTE */ }}}) return HEAP8;
 #endif
 
     if (type == {{{ 0x1401 - 0x1400/* GL_UNSIGNED_BYTE */ }}}) return HEAPU8;
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (type == {{{ 0x1402 - 0x1400/* GL_SHORT */ }}}) return HEAP16;
 #endif
 
@@ -37,7 +37,7 @@ var LibraryGL = {
 
     if (type == {{{ 0x1405 - 0x1400 /* GL_UNSIGNED_INT */ }}}
       || type == {{{ 0x84FA - 0x1400 /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */ }}}
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
       || type == {{{ 0x8368 - 0x1400 /* GL_UNSIGNED_INT_2_10_10_10_REV */ }}}
       || type == {{{ 0x8C3B - 0x1400 /* GL_UNSIGNED_INT_10F_11F_11F_REV */ }}}
       || type == {{{ 0x8C3E - 0x1400 /* GL_UNSIGNED_INT_5_9_9_9_REV */ }}}
@@ -47,7 +47,7 @@ var LibraryGL = {
 
 #if GL_ASSERTIONS
       if (type != {{{ 0x1403 - 0x1400 /* GL_UNSIGNED_SHORT */ }}}
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
         && type != {{{ 0x140B - 0x1400 /* GL_HALF_FLOAT */ }}}
 #endif
         && type != {{{ 0x8033 - 0x1400 /* GL_UNSIGNED_SHORT_4_4_4_4 */ }}}
@@ -87,7 +87,7 @@ var LibraryGL = {
     currentContext: null,
     offscreenCanvases: {}, // DOM ID -> OffscreenCanvas mappings of <canvas> elements that have their rendering control transferred to offscreen.
     timerQueriesEXT: [],
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     queries: [],
     samplers: [],
     transformFeedbacks: [],
@@ -122,7 +122,7 @@ var LibraryGL = {
        } */
 
     stringCache: {},
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     stringiCache: {},
 #endif
 
@@ -416,7 +416,7 @@ var LibraryGL = {
           sizeBytes = 8;
           break;
         default:
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
           if (GL.currentContext.version >= 2) {
             if (dataType == 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */ || dataType == 0x8D9F /* GL_INT_2_10_10_10_REV */) {
               sizeBytes = 4;
@@ -531,7 +531,7 @@ var LibraryGL = {
       webGLContextAttributes['preserveDrawingBuffer'] = true;
 #endif
 
-#if USE_WEBGL2 && MIN_CHROME_VERSION <= 57
+#if GL_MAX_FEATURE_LEVEL >= 20 && MIN_CHROME_VERSION <= 57
       // BUG: Workaround Chrome WebGL 2 issue: the first shipped versions of WebGL 2 in Chrome 57 did not actually implement
       // the new garbage free WebGL 2 entry points that take an offset and a length to an existing heap (instead of having to
       // create a completely new heap view). In Chrome the entry points only were added in to Chrome 58 and newer. For
@@ -557,7 +557,7 @@ var LibraryGL = {
       // code has been downloaded.
       if (Module['preinitializedWebGLContext']) {
         var ctx = Module['preinitializedWebGLContext'];
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
         webGLContextAttributes.majorVersion = (typeof WebGL2RenderingContext !== 'undefined' && ctx instanceof WebGL2RenderingContext) ? 2 : 1;
 #else
         webGLContextAttributes.majorVersion = 1;
@@ -566,7 +566,7 @@ var LibraryGL = {
 #endif
 
       var ctx = 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
         (webGLContextAttributes.majorVersion > 1)
         ?
 #if MIN_CHROME_VERSION <= 57
@@ -654,7 +654,7 @@ var LibraryGL = {
       gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
       context.defaultFbo = fbo;
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
       context.defaultFboForbidBlitFramebuffer = false;
       if (gl.getContextAttributes().antialias) {
         context.defaultFboForbidBlitFramebuffer = true;
@@ -768,7 +768,7 @@ var LibraryGL = {
 
       var prevFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING);
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
       if (gl.blitFramebuffer && !context.defaultFboForbidBlitFramebuffer) {
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, context.defaultFbo);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
@@ -1171,7 +1171,7 @@ var LibraryGL = {
       case 0x1F02 /* GL_VERSION */:
         var glVersion = GLctx.getParameter(GLctx.VERSION);
         // return GLES version string corresponding to the version of the WebGL context
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
         if (GL.currentContext.version >= 2) glVersion = 'OpenGL ES 3.0 (' + glVersion + ')';
         else
 #endif
@@ -1230,7 +1230,7 @@ var LibraryGL = {
         }
 #endif
         return; // Do not write anything to the out pointer, since no binary formats are supported.
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
       case 0x87FE: // GL_NUM_PROGRAM_BINARY_FORMATS
 #endif
       case 0x8DF9: // GL_NUM_SHADER_BINARY_FORMATS
@@ -1242,7 +1242,7 @@ var LibraryGL = {
         var formats = GLctx.getParameter(0x86A3 /*GL_COMPRESSED_TEXTURE_FORMATS*/);
         ret = formats ? formats.length : 0;
         break;
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
       case 0x821D: // GL_NUM_EXTENSIONS
 #if GL_TRACK_ERRORS
         if (GL.currentContext.version < 2) {
@@ -1298,7 +1298,7 @@ var LibraryGL = {
               case 0x8CA7: // RENDERBUFFER_BINDING
               case 0x8069: // TEXTURE_BINDING_2D
               case 0x85B5: // WebGL 2 GL_VERTEX_ARRAY_BINDING, or WebGL 1 extension OES_vertex_array_object GL_VERTEX_ARRAY_BINDING_OES
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
               case 0x8919: // GL_SAMPLER_BINDING
               case 0x8E25: // GL_TRANSFORM_FEEDBACK_BINDING
 #endif
@@ -1395,7 +1395,7 @@ var LibraryGL = {
 
   glCompressedTexImage2D__sig: 'viiiiiiii',
   glCompressedTexImage2D: function(target, level, internalFormat, width, height, border, imageSize, data) {
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx['compressedTexImage2D'](target, level, internalFormat, width, height, border, imageSize, data);
@@ -1411,7 +1411,7 @@ var LibraryGL = {
 
   glCompressedTexSubImage2D__sig: 'viiiiiiiii',
   glCompressedTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, imageSize, data) {
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx['compressedTexSubImage2D'](target, level, xoffset, yoffset, width, height, format, imageSize, data);
@@ -1448,7 +1448,7 @@ var LibraryGL = {
       {{{ 0x190A /*GL_LUMINANCE_ALPHA*/ - 0x1902 }}}: 2,
       {{{ 0x8C40 /*(GL_SRGB_EXT)*/ - 0x1902 }}}: 3,
       {{{ 0x8C42 /*(GL_SRGB_ALPHA_EXT*/ - 0x1902 }}}: 4,
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
       // 0x1903 /* GL_RED */ - 0x1902: 1,
       {{{ 0x8227 /*GL_RG*/ - 0x1902 }}}: 2,
       {{{ 0x8228 /*GL_RG_INTEGER*/ - 0x1902 }}}: 2,
@@ -1485,12 +1485,12 @@ var LibraryGL = {
 
   glTexImage2D__sig: 'viiiiiiiii',
   glTexImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
                        , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
 #if WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION
     if (GL.currentContext.version >= 2) {
       // WebGL 1 unsized texture internalFormats are no longer supported in WebGL 2, so patch those format
@@ -1527,12 +1527,12 @@ var LibraryGL = {
 
   glTexSubImage2D__sig: 'viiiiiiiii',
   glTexSubImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
                           , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, type, pixels) {
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
 #if WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION
     if (GL.currentContext.version >= 2) {
       // In WebGL 1 to do half float textures, one uses the type enum GL_HALF_FLOAT_OES, but in
@@ -1561,12 +1561,12 @@ var LibraryGL = {
 
   glReadPixels__sig: 'viiiiiii',
   glReadPixels__deps: ['$emscriptenWebGLGetTexPixelData'
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
                        , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glReadPixels: function(x, y, width, height, format, type, pixels) {
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelPackBufferBinding) {
         GLctx.readPixels(x, y, width, height, format, type, pixels);
@@ -1705,7 +1705,7 @@ var LibraryGL = {
 
       if (id == GL.currArrayBuffer) GL.currArrayBuffer = 0;
       if (id == GL.currElementArrayBuffer) GL.currElementArrayBuffer = 0;
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
       if (id == GLctx.currentPixelPackBufferBinding) GLctx.currentPixelPackBufferBinding = 0;
       if (id == GLctx.currentPixelUnpackBufferBinding) GLctx.currentPixelUnpackBufferBinding = 0;
 #endif
@@ -1744,7 +1744,7 @@ var LibraryGL = {
         break;
     }
 #endif
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (data) {
         GLctx.bufferData(target, HEAPU8, usage, data, size);
@@ -1756,14 +1756,14 @@ var LibraryGL = {
       // N.b. here first form specifies a heap subarray, second form an integer size, so the ?: code here is polymorphic. It is advised to avoid
       // randomly mixing both uses in calling code, to avoid any potential JS engine JIT issues.
       GLctx.bufferData(target, data ? HEAPU8.subarray(data, data+size) : size, usage);
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     }
 #endif
   },
 
   glBufferSubData__sig: 'viiii',
   glBufferSubData: function(target, offset, size, data) {
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.bufferSubData(target, offset, HEAPU8, data, size);
       return;
@@ -2180,7 +2180,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to integer data passed to glUniform1iv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform1iv(GL.uniforms[location], HEAP32, value>>2, count);
       return;
@@ -2212,7 +2212,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to integer data passed to glUniform2iv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform2iv(GL.uniforms[location], HEAP32, value>>2, count*2);
       return;
@@ -2245,7 +2245,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to integer data passed to glUniform3iv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform3iv(GL.uniforms[location], HEAP32, value>>2, count*3);
       return;
@@ -2279,7 +2279,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to integer data passed to glUniform4iv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform4iv(GL.uniforms[location], HEAP32, value>>2, count*4);
       return;
@@ -2314,7 +2314,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniform1fv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform1fv(GL.uniforms[location], HEAPF32, value>>2, count);
       return;
@@ -2346,7 +2346,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniform2fv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform2fv(GL.uniforms[location], HEAPF32, value>>2, count*2);
       return;
@@ -2379,7 +2379,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniform3fv must be aligned to four bytes!' + value);
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform3fv(GL.uniforms[location], HEAPF32, value>>2, count*3);
       return;
@@ -2413,7 +2413,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniform4fv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform4fv(GL.uniforms[location], HEAPF32, value>>2, count*4);
       return;
@@ -2448,7 +2448,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniformMatrix2fv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniformMatrix2fv(GL.uniforms[location], !!transpose, HEAPF32, value>>2, count*4);
       return;
@@ -2483,7 +2483,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniformMatrix3fv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniformMatrix3fv(GL.uniforms[location], !!transpose, HEAPF32, value>>2, count*9);
       return;
@@ -2523,7 +2523,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniformMatrix4fv must be aligned to four bytes!');
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniformMatrix4fv(GL.uniforms[location], !!transpose, HEAPF32, value>>2, count*16);
       return;
@@ -2579,7 +2579,7 @@ var LibraryGL = {
     }
 #endif
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
     if (target == 0x88EB /*GL_PIXEL_PACK_BUFFER*/) {
       // In WebGL 2 glReadPixels entry point, we need to use a different WebGL 2 API function call when a buffer is bound to
       // GL_PIXEL_PACK_BUFFER_BINDING point, so must keep track whether that binding point is non-null to know what is

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -21,13 +21,13 @@ var LibraryGL = {
     // Also the type HEAPU16 is not tested for explicitly, but any unrecognized type will return out HEAPU16.
     // (since most types are HEAPU16)
     type -= 0x1400;
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (type == {{{ 0x1400 - 0x1400/* GL_BYTE */ }}}) return HEAP8;
 #endif
 
     if (type == {{{ 0x1401 - 0x1400/* GL_UNSIGNED_BYTE */ }}}) return HEAPU8;
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (type == {{{ 0x1402 - 0x1400/* GL_SHORT */ }}}) return HEAP16;
 #endif
 
@@ -37,7 +37,7 @@ var LibraryGL = {
 
     if (type == {{{ 0x1405 - 0x1400 /* GL_UNSIGNED_INT */ }}}
       || type == {{{ 0x84FA - 0x1400 /* GL_UNSIGNED_INT_24_8_WEBGL/GL_UNSIGNED_INT_24_8 */ }}}
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
       || type == {{{ 0x8368 - 0x1400 /* GL_UNSIGNED_INT_2_10_10_10_REV */ }}}
       || type == {{{ 0x8C3B - 0x1400 /* GL_UNSIGNED_INT_10F_11F_11F_REV */ }}}
       || type == {{{ 0x8C3E - 0x1400 /* GL_UNSIGNED_INT_5_9_9_9_REV */ }}}
@@ -47,7 +47,7 @@ var LibraryGL = {
 
 #if GL_ASSERTIONS
       if (type != {{{ 0x1403 - 0x1400 /* GL_UNSIGNED_SHORT */ }}}
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
         && type != {{{ 0x140B - 0x1400 /* GL_HALF_FLOAT */ }}}
 #endif
         && type != {{{ 0x8033 - 0x1400 /* GL_UNSIGNED_SHORT_4_4_4_4 */ }}}
@@ -87,7 +87,7 @@ var LibraryGL = {
     currentContext: null,
     offscreenCanvases: {}, // DOM ID -> OffscreenCanvas mappings of <canvas> elements that have their rendering control transferred to offscreen.
     timerQueriesEXT: [],
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     queries: [],
     samplers: [],
     transformFeedbacks: [],
@@ -122,7 +122,7 @@ var LibraryGL = {
        } */
 
     stringCache: {},
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     stringiCache: {},
 #endif
 
@@ -416,7 +416,7 @@ var LibraryGL = {
           sizeBytes = 8;
           break;
         default:
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
           if (GL.currentContext.version >= 2) {
             if (dataType == 0x8368 /* GL_UNSIGNED_INT_2_10_10_10_REV */ || dataType == 0x8D9F /* GL_INT_2_10_10_10_REV */) {
               sizeBytes = 4;
@@ -531,7 +531,7 @@ var LibraryGL = {
       webGLContextAttributes['preserveDrawingBuffer'] = true;
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20 && MIN_CHROME_VERSION <= 57
+#if MAX_WEBGL_VERSION >= 2 && MIN_CHROME_VERSION <= 57
       // BUG: Workaround Chrome WebGL 2 issue: the first shipped versions of WebGL 2 in Chrome 57 did not actually implement
       // the new garbage free WebGL 2 entry points that take an offset and a length to an existing heap (instead of having to
       // create a completely new heap view). In Chrome the entry points only were added in to Chrome 58 and newer. For
@@ -557,7 +557,7 @@ var LibraryGL = {
       // code has been downloaded.
       if (Module['preinitializedWebGLContext']) {
         var ctx = Module['preinitializedWebGLContext'];
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
         webGLContextAttributes.majorVersion = (typeof WebGL2RenderingContext !== 'undefined' && ctx instanceof WebGL2RenderingContext) ? 2 : 1;
 #else
         webGLContextAttributes.majorVersion = 1;
@@ -566,7 +566,7 @@ var LibraryGL = {
 #endif
 
       var ctx = 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
         (webGLContextAttributes.majorVersion > 1)
         ?
 #if MIN_CHROME_VERSION <= 57
@@ -654,7 +654,7 @@ var LibraryGL = {
       gl.bindFramebuffer(gl.FRAMEBUFFER, fbo);
       context.defaultFbo = fbo;
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
       context.defaultFboForbidBlitFramebuffer = false;
       if (gl.getContextAttributes().antialias) {
         context.defaultFboForbidBlitFramebuffer = true;
@@ -768,7 +768,7 @@ var LibraryGL = {
 
       var prevFbo = gl.getParameter(gl.FRAMEBUFFER_BINDING);
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
       if (gl.blitFramebuffer && !context.defaultFboForbidBlitFramebuffer) {
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, context.defaultFbo);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
@@ -1171,7 +1171,7 @@ var LibraryGL = {
       case 0x1F02 /* GL_VERSION */:
         var glVersion = GLctx.getParameter(GLctx.VERSION);
         // return GLES version string corresponding to the version of the WebGL context
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
         if (GL.currentContext.version >= 2) glVersion = 'OpenGL ES 3.0 (' + glVersion + ')';
         else
 #endif
@@ -1230,7 +1230,7 @@ var LibraryGL = {
         }
 #endif
         return; // Do not write anything to the out pointer, since no binary formats are supported.
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
       case 0x87FE: // GL_NUM_PROGRAM_BINARY_FORMATS
 #endif
       case 0x8DF9: // GL_NUM_SHADER_BINARY_FORMATS
@@ -1242,7 +1242,7 @@ var LibraryGL = {
         var formats = GLctx.getParameter(0x86A3 /*GL_COMPRESSED_TEXTURE_FORMATS*/);
         ret = formats ? formats.length : 0;
         break;
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
       case 0x821D: // GL_NUM_EXTENSIONS
 #if GL_TRACK_ERRORS
         if (GL.currentContext.version < 2) {
@@ -1298,7 +1298,7 @@ var LibraryGL = {
               case 0x8CA7: // RENDERBUFFER_BINDING
               case 0x8069: // TEXTURE_BINDING_2D
               case 0x85B5: // WebGL 2 GL_VERTEX_ARRAY_BINDING, or WebGL 1 extension OES_vertex_array_object GL_VERTEX_ARRAY_BINDING_OES
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
               case 0x8919: // GL_SAMPLER_BINDING
               case 0x8E25: // GL_TRANSFORM_FEEDBACK_BINDING
 #endif
@@ -1395,7 +1395,7 @@ var LibraryGL = {
 
   glCompressedTexImage2D__sig: 'viiiiiiii',
   glCompressedTexImage2D: function(target, level, internalFormat, width, height, border, imageSize, data) {
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx['compressedTexImage2D'](target, level, internalFormat, width, height, border, imageSize, data);
@@ -1411,7 +1411,7 @@ var LibraryGL = {
 
   glCompressedTexSubImage2D__sig: 'viiiiiiiii',
   glCompressedTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, imageSize, data) {
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx['compressedTexSubImage2D'](target, level, xoffset, yoffset, width, height, format, imageSize, data);
@@ -1448,7 +1448,7 @@ var LibraryGL = {
       {{{ 0x190A /*GL_LUMINANCE_ALPHA*/ - 0x1902 }}}: 2,
       {{{ 0x8C40 /*(GL_SRGB_EXT)*/ - 0x1902 }}}: 3,
       {{{ 0x8C42 /*(GL_SRGB_ALPHA_EXT*/ - 0x1902 }}}: 4,
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
       // 0x1903 /* GL_RED */ - 0x1902: 1,
       {{{ 0x8227 /*GL_RG*/ - 0x1902 }}}: 2,
       {{{ 0x8228 /*GL_RG_INTEGER*/ - 0x1902 }}}: 2,
@@ -1485,12 +1485,12 @@ var LibraryGL = {
 
   glTexImage2D__sig: 'viiiiiiiii',
   glTexImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
                        , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
 #if WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION
     if (GL.currentContext.version >= 2) {
       // WebGL 1 unsized texture internalFormats are no longer supported in WebGL 2, so patch those format
@@ -1527,12 +1527,12 @@ var LibraryGL = {
 
   glTexSubImage2D__sig: 'viiiiiiiii',
   glTexSubImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
                           , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, type, pixels) {
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
 #if WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION
     if (GL.currentContext.version >= 2) {
       // In WebGL 1 to do half float textures, one uses the type enum GL_HALF_FLOAT_OES, but in
@@ -1561,12 +1561,12 @@ var LibraryGL = {
 
   glReadPixels__sig: 'viiiiiii',
   glReadPixels__deps: ['$emscriptenWebGLGetTexPixelData'
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
                        , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
 #endif
   ],
   glReadPixels: function(x, y, width, height, format, type, pixels) {
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (GLctx.currentPixelPackBufferBinding) {
         GLctx.readPixels(x, y, width, height, format, type, pixels);
@@ -1705,7 +1705,7 @@ var LibraryGL = {
 
       if (id == GL.currArrayBuffer) GL.currArrayBuffer = 0;
       if (id == GL.currElementArrayBuffer) GL.currElementArrayBuffer = 0;
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
       if (id == GLctx.currentPixelPackBufferBinding) GLctx.currentPixelPackBufferBinding = 0;
       if (id == GLctx.currentPixelUnpackBufferBinding) GLctx.currentPixelUnpackBufferBinding = 0;
 #endif
@@ -1744,7 +1744,7 @@ var LibraryGL = {
         break;
     }
 #endif
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       if (data) {
         GLctx.bufferData(target, HEAPU8, usage, data, size);
@@ -1756,14 +1756,14 @@ var LibraryGL = {
       // N.b. here first form specifies a heap subarray, second form an integer size, so the ?: code here is polymorphic. It is advised to avoid
       // randomly mixing both uses in calling code, to avoid any potential JS engine JIT issues.
       GLctx.bufferData(target, data ? HEAPU8.subarray(data, data+size) : size, usage);
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     }
 #endif
   },
 
   glBufferSubData__sig: 'viiii',
   glBufferSubData: function(target, offset, size, data) {
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.bufferSubData(target, offset, HEAPU8, data, size);
       return;
@@ -2180,7 +2180,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to integer data passed to glUniform1iv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform1iv(GL.uniforms[location], HEAP32, value>>2, count);
       return;
@@ -2212,7 +2212,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to integer data passed to glUniform2iv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform2iv(GL.uniforms[location], HEAP32, value>>2, count*2);
       return;
@@ -2245,7 +2245,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to integer data passed to glUniform3iv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform3iv(GL.uniforms[location], HEAP32, value>>2, count*3);
       return;
@@ -2279,7 +2279,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to integer data passed to glUniform4iv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform4iv(GL.uniforms[location], HEAP32, value>>2, count*4);
       return;
@@ -2314,7 +2314,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniform1fv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform1fv(GL.uniforms[location], HEAPF32, value>>2, count);
       return;
@@ -2346,7 +2346,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniform2fv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform2fv(GL.uniforms[location], HEAPF32, value>>2, count*2);
       return;
@@ -2379,7 +2379,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniform3fv must be aligned to four bytes!' + value);
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform3fv(GL.uniforms[location], HEAPF32, value>>2, count*3);
       return;
@@ -2413,7 +2413,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniform4fv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniform4fv(GL.uniforms[location], HEAPF32, value>>2, count*4);
       return;
@@ -2448,7 +2448,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniformMatrix2fv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniformMatrix2fv(GL.uniforms[location], !!transpose, HEAPF32, value>>2, count*4);
       return;
@@ -2483,7 +2483,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniformMatrix3fv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniformMatrix3fv(GL.uniforms[location], !!transpose, HEAPF32, value>>2, count*9);
       return;
@@ -2523,7 +2523,7 @@ var LibraryGL = {
     assert((value & 3) == 0, 'Pointer to float data passed to glUniformMatrix4fv must be aligned to four bytes!');
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (GL.currentContext.version >= 2) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.uniformMatrix4fv(GL.uniforms[location], !!transpose, HEAPF32, value>>2, count*16);
       return;
@@ -2579,7 +2579,7 @@ var LibraryGL = {
     }
 #endif
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
     if (target == 0x88EB /*GL_PIXEL_PACK_BUFFER*/) {
       // In WebGL 2 glReadPixels entry point, we need to use a different WebGL 2 API function call when a buffer is bound to
       // GL_PIXEL_PACK_BUFFER_BINDING point, so must keep track whether that binding point is non-null to know what is

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -1014,12 +1014,12 @@ var webgl2Funcs = [[0, 'endTransformFeedback pauseTransformFeedback resumeTransf
  [9, 'copyTexSubImage3D'],
  [10, 'blitFramebuffer']];
 
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
 
-// If user passes -s GL_MAX_FEATURE_LEVEL >= 20 -s STRICT=1 but not -lGL (to link in WebGL 1), then WebGL2 library should not
+// If user passes -s MAX_WEBGL_VERSION >= 2 -s STRICT=1 but not -lGL (to link in WebGL 1), then WebGL2 library should not
 // be linked in as well.
 if (typeof createGLPassthroughFunctions === 'undefined') {
-  throw 'In order to use WebGL 2 in strict mode with -s GL_MAX_FEATURE_LEVEL=20, you need to link in WebGL support with -lGL!';
+  throw 'In order to use WebGL 2 in strict mode with -s MAX_WEBGL_VERSION=2, you need to link in WebGL support with -lGL!';
 }
 
 createGLPassthroughFunctions(LibraryWebGL2, webgl2Funcs);

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -1014,12 +1014,12 @@ var webgl2Funcs = [[0, 'endTransformFeedback pauseTransformFeedback resumeTransf
  [9, 'copyTexSubImage3D'],
  [10, 'blitFramebuffer']];
 
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
 
-// If user passes -s USE_WEBGL2=1 -s STRICT=1 but not -lGL (to link in WebGL 1), then WebGL2 library should not
+// If user passes -s GL_MAX_FEATURE_LEVEL >= 20 -s STRICT=1 but not -lGL (to link in WebGL 1), then WebGL2 library should not
 // be linked in as well.
 if (typeof createGLPassthroughFunctions === 'undefined') {
-  throw 'In order to use WebGL 2 in strict mode with -s USE_WEBGL2=1, you need to link in WebGL support with -lGL!';
+  throw 'In order to use WebGL 2 in strict mode with -s GL_MAX_FEATURE_LEVEL=20, you need to link in WebGL support with -lGL!';
 }
 
 createGLPassthroughFunctions(LibraryWebGL2, webgl2Funcs);

--- a/src/modules.js
+++ b/src/modules.js
@@ -134,7 +134,7 @@ var LibraryManager = {
       libraries.push('library_lz4.js');
     }
 
-    if (GL_MAX_FEATURE_LEVEL >= 20) {
+    if (MAX_WEBGL_VERSION >= 2) {
       libraries.push('library_webgl2.js');
     }
 

--- a/src/modules.js
+++ b/src/modules.js
@@ -134,7 +134,7 @@ var LibraryManager = {
       libraries.push('library_lz4.js');
     }
 
-    if (USE_WEBGL2) {
+    if (GL_MAX_FEATURE_LEVEL >= 20) {
       libraries.push('library_webgl2.js');
     }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -442,9 +442,18 @@ var GL_POOL_TEMP_BUFFERS = 1;
 // bug is only relevant to WebGL 1, the affected browsers do not support WebGL 2.
 var WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0;
 
-// Enables WebGL2 native functions. This mode will also create a WebGL2
-// context by default if no version is specified.
+// Deprecated. Pass -s GL_MAX_FEATURE_LEVEL=20 to target WebGL 2.0.
 var USE_WEBGL2 = 0;
+
+// Specifies the lowest WebGL version to target. Pass -s GL_MIN_FEATURE_LEVEL=10
+// to enable targeting WebGL 1, and -s GL_MIN_FEATURE_LEVEL=20 to drop support
+// for WebGL 1.0
+var GL_MIN_FEATURE_LEVEL = 10;
+
+// Specifies the highest WebGL version to target. Pass -s GL_MAX_FEATURE_LEVEL=20
+// to enable targeting WebGL 2. If WebGL 2 is enabled, some APIs (EGL, GLUT, SDL)
+// will default to creating a WebGL 2 context if no version is specified.
+var GL_MAX_FEATURE_LEVEL = 10;
 
 // If true, emulates some WebGL 1 features on WebGL 2 contexts, meaning that
 // applications that use WebGL 1/GLES 2 can initialize a WebGL 2/GLES3 context,

--- a/src/settings.js
+++ b/src/settings.js
@@ -442,18 +442,18 @@ var GL_POOL_TEMP_BUFFERS = 1;
 // bug is only relevant to WebGL 1, the affected browsers do not support WebGL 2.
 var WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0;
 
-// Deprecated. Pass -s GL_MAX_FEATURE_LEVEL=20 to target WebGL 2.0.
+// Deprecated. Pass -s MAX_WEBGL_VERSION=2 to target WebGL 2.0.
 var USE_WEBGL2 = 0;
 
-// Specifies the lowest WebGL version to target. Pass -s GL_MIN_FEATURE_LEVEL=10
-// to enable targeting WebGL 1, and -s GL_MIN_FEATURE_LEVEL=20 to drop support
+// Specifies the lowest WebGL version to target. Pass -s MIN_WEBGL_VERSION=1
+// to enable targeting WebGL 1, and -s MIN_WEBGL_VERSION=2 to drop support
 // for WebGL 1.0
-var GL_MIN_FEATURE_LEVEL = 10;
+var MIN_WEBGL_VERSION = 1;
 
-// Specifies the highest WebGL version to target. Pass -s GL_MAX_FEATURE_LEVEL=20
+// Specifies the highest WebGL version to target. Pass -s MAX_WEBGL_VERSION=2
 // to enable targeting WebGL 2. If WebGL 2 is enabled, some APIs (EGL, GLUT, SDL)
 // will default to creating a WebGL 2 context if no version is specified.
-var GL_MAX_FEATURE_LEVEL = 10;
+var MAX_WEBGL_VERSION = 1;
 
 // If true, emulates some WebGL 1 features on WebGL 2 contexts, meaning that
 // applications that use WebGL 1/GLES 2 can initialize a WebGL 2/GLES3 context,

--- a/system/lib/gl/gl.c
+++ b/system/lib/gl/gl.c
@@ -1819,7 +1819,7 @@ void* emscripten_GetProcAddress(const char *name_) {
 #if LEGACY_GL_EMULATION
   if (!ptr) ptr = emscripten_legacy_gl_emulation_GetProcAddress(name);
 #endif
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
   if (!ptr) ptr = emscripten_webgl2_get_proc_address(name);
   if (!ptr) ptr = _webgl2_match_ext_proc_address_without_suffix(name);
 #endif
@@ -1831,7 +1831,7 @@ void* emscripten_GetProcAddress(const char *name_) {
 extern void *emscripten_webgl_get_proc_address(const char *name)
 {
   void *ptr = emscripten_webgl1_get_proc_address(name);
-#if USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
   if (!ptr) ptr = emscripten_webgl2_get_proc_address(name);
 #endif
   return ptr;

--- a/system/lib/gl/gl.c
+++ b/system/lib/gl/gl.c
@@ -1819,7 +1819,7 @@ void* emscripten_GetProcAddress(const char *name_) {
 #if LEGACY_GL_EMULATION
   if (!ptr) ptr = emscripten_legacy_gl_emulation_GetProcAddress(name);
 #endif
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
   if (!ptr) ptr = emscripten_webgl2_get_proc_address(name);
   if (!ptr) ptr = _webgl2_match_ext_proc_address_without_suffix(name);
 #endif
@@ -1831,7 +1831,7 @@ void* emscripten_GetProcAddress(const char *name_) {
 extern void *emscripten_webgl_get_proc_address(const char *name)
 {
   void *ptr = emscripten_webgl1_get_proc_address(name);
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
   if (!ptr) ptr = emscripten_webgl2_get_proc_address(name);
 #endif
   return ptr;

--- a/tests/minimal_webgl/webgl.c
+++ b/tests/minimal_webgl/webgl.c
@@ -51,7 +51,7 @@ void init_webgl(int width, int height)
   EmscriptenWebGLContextAttributes attrs;
   emscripten_webgl_init_context_attributes(&attrs);
   attrs.alpha = 0;
-#if GL_MAX_FEATURE_LEVEL >= 20
+#if MAX_WEBGL_VERSION >= 2
   attrs.majorVersion = 2;
 #endif
   glContext = emscripten_webgl_create_context("canvas", &attrs);

--- a/tests/minimal_webgl/webgl.c
+++ b/tests/minimal_webgl/webgl.c
@@ -51,7 +51,7 @@ void init_webgl(int width, int height)
   EmscriptenWebGLContextAttributes attrs;
   emscripten_webgl_init_context_attributes(&attrs);
   attrs.alpha = 0;
-#ifdef USE_WEBGL2
+#if GL_MAX_FEATURE_LEVEL >= 20
   attrs.majorVersion = 2;
 #endif
   glContext = emscripten_webgl_create_context("canvas", &attrs);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1802,7 +1802,7 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_clientside_vertex_arrays_es3(self):
-    self.btest('clientside_vertex_arrays_es3.c', reference='gl_triangle.png', args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-s', 'FULL_ES3=1', '-s', 'USE_GLFW=3', '-lglfw', '-lGLESv2'])
+    self.btest('clientside_vertex_arrays_es3.c', reference='gl_triangle.png', args=['-s', 'MAX_WEBGL_VERSION=2', '-s', 'FULL_ES3=1', '-s', 'USE_GLFW=3', '-lglfw', '-lGLESv2'])
 
   def test_emscripten_api(self):
     self.btest('emscripten_api_browser.cpp', '1', args=['-s', '''EXPORTED_FUNCTIONS=['_main', '_third']''', '-lSDL'])
@@ -2617,46 +2617,46 @@ Module["preRun"].push(function () {
       ['-s', 'FULL_ES2=1'],
     ]:
       print(opts)
-      self.btest(path_from_root('tests', 'webgl2.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL'] + opts, expected='0')
+      self.btest(path_from_root('tests', 'webgl2.cpp'), args=['-s', 'MAX_WEBGL_VERSION=2', '-lGL'] + opts, expected='0')
 
   @requires_graphics_hardware
   @requires_threads
   def test_webgl2_pthreads(self):
     # test that a program can be compiled with pthreads and render WebGL2 properly on the main thread
     # (the testcase doesn't even use threads, but is compiled with thread support).
-    self.btest(path_from_root('tests', 'webgl2.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL', '-s', 'USE_PTHREADS=1'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2.cpp'), args=['-s', 'MAX_WEBGL_VERSION=2', '-lGL', '-s', 'USE_PTHREADS=1'], expected='0')
 
   def test_webgl2_objects(self):
-    self.btest(path_from_root('tests', 'webgl2_objects.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_objects.cpp'), args=['-s', 'MAX_WEBGL_VERSION=2', '-lGL'], expected='0')
 
   def test_webgl2_ubos(self):
-    self.btest(path_from_root('tests', 'webgl2_ubos.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_ubos.cpp'), args=['-s', 'MAX_WEBGL_VERSION=2', '-lGL'], expected='0')
 
   @requires_graphics_hardware
   def test_webgl2_garbage_free_entrypoints(self):
-    self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=1'], expected='1')
+    self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), args=['-s', 'MAX_WEBGL_VERSION=2', '-DTEST_WEBGL2=1'], expected='1')
     self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), expected='1')
 
   @requires_graphics_hardware
   def test_webgl2_backwards_compatibility_emulation(self):
-    self.btest(path_from_root('tests', 'webgl2_backwards_compatibility_emulation.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-s', 'WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_backwards_compatibility_emulation.cpp'), args=['-s', 'MAX_WEBGL_VERSION=2', '-s', 'WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1'], expected='0')
 
   @requires_graphics_hardware
   def test_webgl2_invalid_teximage2d_type(self):
-    self.btest(path_from_root('tests', 'webgl2_invalid_teximage2d_type.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_invalid_teximage2d_type.cpp'), args=['-s', 'MAX_WEBGL_VERSION=2'], expected='0')
 
   @requires_graphics_hardware
   def test_webgl_with_closure(self):
-    self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'GL_MAX_FEATURE_LEVEL=20', '--closure', '1', '-lGL'], expected='0')
+    self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'MAX_WEBGL_VERSION=2', '--closure', '1', '-lGL'], expected='0')
 
   # Tests that -s GL_ASSERTIONS=1 and glVertexAttribPointer with packed types works
   @requires_graphics_hardware
   def test_webgl2_packed_types(self):
-    self.btest(path_from_root('tests', 'webgl2_draw_packed_triangle.c'), args=['-lGL', '-s', 'GL_MAX_FEATURE_LEVEL=20', '-s', 'GL_ASSERTIONS=1'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_draw_packed_triangle.c'), args=['-lGL', '-s', 'MAX_WEBGL_VERSION=2', '-s', 'GL_ASSERTIONS=1'], expected='0')
 
   @requires_graphics_hardware
   def test_webgl2_pbo(self):
-    self.btest(path_from_root('tests', 'webgl2_pbo.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_pbo.cpp'), args=['-s', 'MAX_WEBGL_VERSION=2', '-lGL'], expected='0')
 
   def test_sdl_touch(self):
     for opts in [[], ['-O2', '-g1', '--closure', '1']]:
@@ -4293,16 +4293,16 @@ window.close = function() {
   def test_webgl_offscreen_framebuffer_state_restoration(self):
     for args in [
         # full state restoration path on WebGL 1.0
-        ['-s', 'GL_MAX_FEATURE_LEVEL=10', '-s', 'OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH=1'],
+        ['-s', 'MAX_WEBGL_VERSION=1', '-s', 'OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH=1'],
         # VAO path on WebGL 1.0
-        ['-s', 'GL_MAX_FEATURE_LEVEL=10'],
-        ['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=0'],
+        ['-s', 'MAX_WEBGL_VERSION=1'],
+        ['-s', 'MAX_WEBGL_VERSION=2', '-DTEST_WEBGL2=0'],
         # VAO path on WebGL 2.0
-        ['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=1', '-DTEST_REQUIRE_VAO=1'],
+        ['-s', 'MAX_WEBGL_VERSION=2', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=1', '-DTEST_REQUIRE_VAO=1'],
         # full state restoration path on WebGL 2.0
-        ['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=1', '-s', 'OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH=1'],
+        ['-s', 'MAX_WEBGL_VERSION=2', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=1', '-s', 'OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH=1'],
         # blitFramebuffer path on WebGL 2.0 (falls back to VAO on Firefox < 67)
-        ['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=0'],
+        ['-s', 'MAX_WEBGL_VERSION=2', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=0'],
       ]:
       cmd = args + ['-lGL', '-s', 'OFFSCREEN_FRAMEBUFFER=1', '-DEXPLICIT_SWAP=1']
       self.btest('webgl_offscreen_framebuffer_swap_with_bad_state.c', '0', args=cmd)
@@ -4315,7 +4315,7 @@ window.close = function() {
   # Tests that using an array of structs in GL uniforms works.
   @requires_graphics_hardware
   def test_webgl_array_of_structs_uniform(self):
-    self.btest('webgl_array_of_structs_uniform.c', args=['-lGL', '-s', 'GL_MAX_FEATURE_LEVEL=20'], reference='webgl_array_of_structs_uniform.png')
+    self.btest('webgl_array_of_structs_uniform.c', args=['-lGL', '-s', 'MAX_WEBGL_VERSION=2'], reference='webgl_array_of_structs_uniform.png')
 
   # Tests that if a WebGL context is created in a pthread on a canvas that has not been transferred to that pthread, WebGL calls are then proxied to the main thread
   # -DTEST_OFFSCREEN_CANVAS=1: Tests that if a WebGL context is created on a pthread that has the canvas transferred to it via using Emscripten's EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES="#canvas", then OffscreenCanvas is used

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1802,7 +1802,7 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_clientside_vertex_arrays_es3(self):
-    self.btest('clientside_vertex_arrays_es3.c', reference='gl_triangle.png', args=['-s', 'USE_WEBGL2=1', '-s', 'FULL_ES3=1', '-s', 'USE_GLFW=3', '-lglfw', '-lGLESv2'])
+    self.btest('clientside_vertex_arrays_es3.c', reference='gl_triangle.png', args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-s', 'FULL_ES3=1', '-s', 'USE_GLFW=3', '-lglfw', '-lGLESv2'])
 
   def test_emscripten_api(self):
     self.btest('emscripten_api_browser.cpp', '1', args=['-s', '''EXPORTED_FUNCTIONS=['_main', '_third']''', '-lSDL'])
@@ -2617,46 +2617,46 @@ Module["preRun"].push(function () {
       ['-s', 'FULL_ES2=1'],
     ]:
       print(opts)
-      self.btest(path_from_root('tests', 'webgl2.cpp'), args=['-s', 'USE_WEBGL2=1', '-lGL'] + opts, expected='0')
+      self.btest(path_from_root('tests', 'webgl2.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL'] + opts, expected='0')
 
   @requires_graphics_hardware
   @requires_threads
   def test_webgl2_pthreads(self):
     # test that a program can be compiled with pthreads and render WebGL2 properly on the main thread
     # (the testcase doesn't even use threads, but is compiled with thread support).
-    self.btest(path_from_root('tests', 'webgl2.cpp'), args=['-s', 'USE_WEBGL2=1', '-lGL', '-s', 'USE_PTHREADS=1'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL', '-s', 'USE_PTHREADS=1'], expected='0')
 
   def test_webgl2_objects(self):
-    self.btest(path_from_root('tests', 'webgl2_objects.cpp'), args=['-s', 'USE_WEBGL2=1', '-lGL'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_objects.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL'], expected='0')
 
   def test_webgl2_ubos(self):
-    self.btest(path_from_root('tests', 'webgl2_ubos.cpp'), args=['-s', 'USE_WEBGL2=1', '-lGL'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_ubos.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL'], expected='0')
 
   @requires_graphics_hardware
   def test_webgl2_garbage_free_entrypoints(self):
-    self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), args=['-s', 'USE_WEBGL2=1', '-DTEST_WEBGL2=1'], expected='1')
+    self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=1'], expected='1')
     self.btest(path_from_root('tests', 'webgl2_garbage_free_entrypoints.cpp'), expected='1')
 
   @requires_graphics_hardware
   def test_webgl2_backwards_compatibility_emulation(self):
-    self.btest(path_from_root('tests', 'webgl2_backwards_compatibility_emulation.cpp'), args=['-s', 'USE_WEBGL2=1', '-s', 'WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_backwards_compatibility_emulation.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-s', 'WEBGL2_BACKWARDS_COMPATIBILITY_EMULATION=1'], expected='0')
 
   @requires_graphics_hardware
   def test_webgl2_invalid_teximage2d_type(self):
-    self.btest(path_from_root('tests', 'webgl2_invalid_teximage2d_type.cpp'), args=['-s', 'USE_WEBGL2=1'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_invalid_teximage2d_type.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20'], expected='0')
 
   @requires_graphics_hardware
   def test_webgl_with_closure(self):
-    self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'USE_WEBGL2=1', '--closure', '1', '-lGL'], expected='0')
+    self.btest(path_from_root('tests', 'webgl_with_closure.cpp'), args=['-O2', '-s', 'GL_MAX_FEATURE_LEVEL=20', '--closure', '1', '-lGL'], expected='0')
 
   # Tests that -s GL_ASSERTIONS=1 and glVertexAttribPointer with packed types works
   @requires_graphics_hardware
   def test_webgl2_packed_types(self):
-    self.btest(path_from_root('tests', 'webgl2_draw_packed_triangle.c'), args=['-lGL', '-s', 'USE_WEBGL2=1', '-s', 'GL_ASSERTIONS=1'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_draw_packed_triangle.c'), args=['-lGL', '-s', 'GL_MAX_FEATURE_LEVEL=20', '-s', 'GL_ASSERTIONS=1'], expected='0')
 
   @requires_graphics_hardware
   def test_webgl2_pbo(self):
-    self.btest(path_from_root('tests', 'webgl2_pbo.cpp'), args=['-s', 'USE_WEBGL2=1', '-lGL'], expected='0')
+    self.btest(path_from_root('tests', 'webgl2_pbo.cpp'), args=['-s', 'GL_MAX_FEATURE_LEVEL=20', '-lGL'], expected='0')
 
   def test_sdl_touch(self):
     for opts in [[], ['-O2', '-g1', '--closure', '1']]:
@@ -4293,16 +4293,16 @@ window.close = function() {
   def test_webgl_offscreen_framebuffer_state_restoration(self):
     for args in [
         # full state restoration path on WebGL 1.0
-        ['-s', 'USE_WEBGL2=0', '-s', 'OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH=1'],
+        ['-s', 'GL_MAX_FEATURE_LEVEL=10', '-s', 'OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH=1'],
         # VAO path on WebGL 1.0
-        ['-s', 'USE_WEBGL2=0'],
-        ['-s', 'USE_WEBGL2=1', '-DTEST_WEBGL2=0'],
+        ['-s', 'GL_MAX_FEATURE_LEVEL=10'],
+        ['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=0'],
         # VAO path on WebGL 2.0
-        ['-s', 'USE_WEBGL2=1', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=1', '-DTEST_REQUIRE_VAO=1'],
+        ['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=1', '-DTEST_REQUIRE_VAO=1'],
         # full state restoration path on WebGL 2.0
-        ['-s', 'USE_WEBGL2=1', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=1', '-s', 'OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH=1'],
+        ['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=1', '-s', 'OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH=1'],
         # blitFramebuffer path on WebGL 2.0 (falls back to VAO on Firefox < 67)
-        ['-s', 'USE_WEBGL2=1', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=0'],
+        ['-s', 'GL_MAX_FEATURE_LEVEL=20', '-DTEST_WEBGL2=1', '-DTEST_ANTIALIAS=0'],
       ]:
       cmd = args + ['-lGL', '-s', 'OFFSCREEN_FRAMEBUFFER=1', '-DEXPLICIT_SWAP=1']
       self.btest('webgl_offscreen_framebuffer_swap_with_bad_state.c', '0', args=cmd)
@@ -4315,7 +4315,7 @@ window.close = function() {
   # Tests that using an array of structs in GL uniforms works.
   @requires_graphics_hardware
   def test_webgl_array_of_structs_uniform(self):
-    self.btest('webgl_array_of_structs_uniform.c', args=['-lGL', '-s', 'USE_WEBGL2=1'], reference='webgl_array_of_structs_uniform.png')
+    self.btest('webgl_array_of_structs_uniform.c', args=['-lGL', '-s', 'GL_MAX_FEATURE_LEVEL=20'], reference='webgl_array_of_structs_uniform.png')
 
   # Tests that if a WebGL context is created in a pthread on a canvas that has not been transferred to that pthread, WebGL calls are then proxied to the main thread
   # -DTEST_OFFSCREEN_CANVAS=1: Tests that if a WebGL context is created on a pthread that has the canvas transferred to it via using Emscripten's EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES="#canvas", then OffscreenCanvas is used

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1922,7 +1922,7 @@ int f() {
       }
       ''')
 
-    for args in ([], ['-O1'], ['-s', 'USE_WEBGL2=1']):
+    for args in ([], ['-O1'], ['-s', 'GL_MAX_FEATURE_LEVEL=20']):
       for action in ('WARN', 'ERROR', None):
         for value in ([0, 1]):
           try_delete('a.out.js')
@@ -9555,7 +9555,7 @@ int main () {
                            '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]',
                            '-s', 'USES_DYNAMIC_ALLOC=2', '-lGL',
                            '-s', 'MODULARIZE=1']
-    hello_webgl2_sources = hello_webgl_sources + ['-s', 'USE_WEBGL2=1']
+    hello_webgl2_sources = hello_webgl_sources + ['-s', 'GL_MAX_FEATURE_LEVEL=20']
 
     test_cases = [
       (asmjs + opts, hello_world_sources, {'a.html': 1453, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1922,7 +1922,7 @@ int f() {
       }
       ''')
 
-    for args in ([], ['-O1'], ['-s', 'GL_MAX_FEATURE_LEVEL=20']):
+    for args in ([], ['-O1'], ['-s', 'MAX_WEBGL_VERSION=2']):
       for action in ('WARN', 'ERROR', None):
         for value in ([0, 1]):
           try_delete('a.out.js')
@@ -9555,7 +9555,7 @@ int main () {
                            '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]',
                            '-s', 'USES_DYNAMIC_ALLOC=2', '-lGL',
                            '-s', 'MODULARIZE=1']
-    hello_webgl2_sources = hello_webgl_sources + ['-s', 'GL_MAX_FEATURE_LEVEL=20']
+    hello_webgl2_sources = hello_webgl_sources + ['-s', 'MAX_WEBGL_VERSION=2']
 
     test_cases = [
       (asmjs + opts, hello_world_sources, {'a.html': 1453, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1027,7 +1027,7 @@ class libgl(MTLibrary):
     if self.is_legacy:
       cflags += ['-DLEGACY_GL_EMULATION=1']
     if self.is_webgl2:
-      cflags += ['-DGL_MAX_FEATURE_LEVEL=20', '-s', 'GL_MAX_FEATURE_LEVEL=20']
+      cflags += ['-DMAX_WEBGL_VERSION=2', '-s', 'MAX_WEBGL_VERSION=2']
     if self.is_ofb:
       cflags += ['-D__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__']
     if self.is_full_es3:
@@ -1042,7 +1042,7 @@ class libgl(MTLibrary):
   def get_default_variation(cls, **kwargs):
     return super(libgl, cls).get_default_variation(
       is_legacy=shared.Settings.LEGACY_GL_EMULATION,
-      is_webgl2=shared.Settings.GL_MAX_FEATURE_LEVEL >= 20,
+      is_webgl2=shared.Settings.MAX_WEBGL_VERSION >= 2,
       is_ofb=shared.Settings.OFFSCREEN_FRAMEBUFFER,
       is_full_es3=shared.Settings.FULL_ES3,
       **kwargs

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1027,7 +1027,7 @@ class libgl(MTLibrary):
     if self.is_legacy:
       cflags += ['-DLEGACY_GL_EMULATION=1']
     if self.is_webgl2:
-      cflags += ['-DUSE_WEBGL2=1', '-s', 'USE_WEBGL2=1']
+      cflags += ['-DGL_MAX_FEATURE_LEVEL=20', '-s', 'GL_MAX_FEATURE_LEVEL=20']
     if self.is_ofb:
       cflags += ['-D__EMSCRIPTEN_OFFSCREEN_FRAMEBUFFER__']
     if self.is_full_es3:
@@ -1042,7 +1042,7 @@ class libgl(MTLibrary):
   def get_default_variation(cls, **kwargs):
     return super(libgl, cls).get_default_variation(
       is_legacy=shared.Settings.LEGACY_GL_EMULATION,
-      is_webgl2=shared.Settings.USE_WEBGL2,
+      is_webgl2=shared.Settings.GL_MAX_FEATURE_LEVEL >= 20,
       is_ofb=shared.Settings.OFFSCREEN_FRAMEBUFFER,
       is_full_es3=shared.Settings.FULL_ES3,
       **kwargs


### PR DESCRIPTION
Remove -s USE_WEBGL2=1 and replace it with -s MIN_WEBGL_VERSION=1/2 and -s MAX_WEBGL_VERSION=1/2.

This is originally the direction we decided for in #7612, splicing that part off from there and bringing it in here.

Does not yet actually enable dropping WebGL 1 support, that will be a followup.