### PR TITLE
Pin Wasmtime to 0.8.0, as the rolling "dev" is no longer present

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,9 +427,10 @@ jobs:
           name: get wasmtime
           command: |
             # use a pinned version due to https://github.com/bytecodealliance/wasmtime/issues/714
-            wget https://github.com/bytecodealliance/wasmtime/releases/download/v0.8.0/wasmtime-v0.8.0-x86_64-linux.tar.xz
-            tar -xf wasmtime-*-x86_64-linux.tar.xz
-            cp wasmtime-*-x86_64-linux/wasmtime ~/vms
+            export VERSION=v0.8.0
+            wget https://github.com/bytecodealliance/wasmtime/releases/download/v0.8.0/wasmtime-$VERSION-x86_64-linux.tar.xz
+            tar -xf wasmtime-$VERSION-x86_64-linux.tar.xz
+            cp wasmtime-$VERSION-x86_64-linux/wasmtime ~/vms
       - run:
           name: get v8
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,7 +426,8 @@ jobs:
       - run:
           name: get wasmtime
           command: |
-            wget https://github.com/CraneStation/wasmtime/releases/download/dev/wasmtime-dev-x86_64-linux.tar.xz
+            # use a pinned version due to https://github.com/bytecodealliance/wasmtime/issues/714
+            wget https://github.com/bytecodealliance/wasmtime/releases/download/v0.8.0/wasmtime-v0.8.0-x86_64-linux.tar.xz
             tar -xf wasmtime-dev-x86_64-linux.tar.xz
             cp wasmtime-dev-x86_64-linux/wasmtime ~/vms
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -428,8 +428,8 @@ jobs:
           command: |
             # use a pinned version due to https://github.com/bytecodealliance/wasmtime/issues/714
             wget https://github.com/bytecodealliance/wasmtime/releases/download/v0.8.0/wasmtime-v0.8.0-x86_64-linux.tar.xz
-            tar -xf wasmtime-dev-x86_64-linux.tar.xz
-            cp wasmtime-dev-x86_64-linux/wasmtime ~/vms
+            tar -xf wasmtime-*-x86_64-linux.tar.xz
+            cp wasmtime-*-x86_64-linux/wasmtime ~/vms
       - run:
           name: get v8
           command: |


### PR DESCRIPTION
See https://github.com/bytecodealliance/wasmtime/issues/714 more.