### PR TITLE
Remove ENVIRONMENT_IS_PTHREAD variable.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Removed preamble variable ENVIRONMENT_IS_PTHREAD. Use the variable
+  ENVIRONMENT_IS_WORKER instead to detect code that is running in a pthread.
 - All ports now install their headers into a shared directory under
   `EM_CACHE`.  This should not really be a user visible change although one
   side effect is that once a give ports is built its headers are then

--- a/emscripten.py
+++ b/emscripten.py
@@ -827,7 +827,7 @@ def memory_and_global_initializers(pre, metadata, mem_init):
 
   pthread = ''
   if shared.Settings.USE_PTHREADS:
-    pthread = 'if (!ENVIRONMENT_IS_PTHREAD)'
+    pthread = 'if (!ENVIRONMENT_IS_WORKER)'
 
   global_initializers = ''
   if not shared.Settings.MINIMAL_RUNTIME:
@@ -977,7 +977,7 @@ def include_asm_consts(pre, forwarded_json, metadata):
         # indices to EM_ASM() blocks, so remap the EM_ASM() indices from 0, 1, 2,
         # ... over to the negative integers starting at -1.
         proxy_args = ['-1 - code', str(int(sync_proxy))] + args
-        pre_asm_const += '  if (ENVIRONMENT_IS_PTHREAD) { ' + proxy_debug_print(sync_proxy) + 'return _emscripten_proxy_to_main_thread_js(' + ', '.join(proxy_args) + '); }\n'
+        pre_asm_const += '  if (ENVIRONMENT_IS_WORKER) { ' + proxy_debug_print(sync_proxy) + 'return _emscripten_proxy_to_main_thread_js(' + ', '.join(proxy_args) + '); }\n'
 
     if shared.Settings.EMTERPRETIFY_ASYNC and shared.Settings.ASSERTIONS:
       # we cannot have an EM_ASM on the stack when saving/loading
@@ -2211,7 +2211,7 @@ def emscript_wasm_backend(infile, outfile, memfile, compiler_engine,
   pre = pre.replace('STATICTOP = STATIC_BASE + 0;', '''STATICTOP = STATIC_BASE + %d;
 /* global initializers */ %s __ATINIT__.push(%s);
 ''' % (staticbump,
-       'if (!ENVIRONMENT_IS_PTHREAD)' if shared.Settings.USE_PTHREADS else '',
+       'if (!ENVIRONMENT_IS_WORKER)' if shared.Settings.USE_PTHREADS else '',
        global_initializers))
 
   pre = apply_memory(pre)
@@ -2402,7 +2402,7 @@ function readAsmConstArgs(sigPtr, buf) {
         # to regular C compiled functions. Negative integers -1, -2, -3, ... denote
         # indices to EM_ASM() blocks, so remap the EM_ASM() indices from 0, 1, 2,
         # ... over to the negative integers starting at -1.
-        preamble += ('\n  if (ENVIRONMENT_IS_PTHREAD) { ' +
+        preamble += ('\n  if (ENVIRONMENT_IS_WORKER) { ' +
                      proxy_debug_print(sync_proxy) +
                      'return _emscripten_proxy_to_main_thread_js(-1 - code, ' +
                      str(int(sync_proxy)) +

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -52,7 +52,7 @@ var Fetch = {
 
   staticInit: function() {
 #if USE_FETCH_WORKER
-    var isMainThread = (typeof ENVIRONMENT_IS_FETCH_WORKER === 'undefined' && !ENVIRONMENT_IS_PTHREAD);
+    var isMainThread = (typeof ENVIRONMENT_IS_FETCH_WORKER === 'undefined' && !ENVIRONMENT_IS_WORKER);
 #else
     var isMainThread = (typeof ENVIRONMENT_IS_FETCH_WORKER === 'undefined');
 #endif

--- a/src/emrun_postjs.js
+++ b/src/emrun_postjs.js
@@ -3,7 +3,7 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
-if (typeof window === "object" && (typeof ENVIRONMENT_IS_PTHREAD === 'undefined' || !ENVIRONMENT_IS_PTHREAD)) {
+if (typeof window === "object" && (typeof ENVIRONMENT_IS_WORKER === 'undefined' || !ENVIRONMENT_IS_WORKER)) {
   function emrun_register_handlers() {
     // When C code exit()s, we may still have remaining stdout and stderr messages in flight. In that case, we can't close
     // the browser until all those XHRs have finished, so the following state variables track that all communication is done,

--- a/src/fetch-worker.js
+++ b/src/fetch-worker.js
@@ -47,7 +47,6 @@ function store4(ptr, value) { HEAP32[ptr>>2] = value; }
 
 var ENVIRONMENT_IS_FETCH_WORKER = true;
 var ENVIRONMENT_IS_WORKER = true;
-var ENVIRONMENT_IS_PTHREAD = true;
 var __pthread_is_main_runtime_thread=0;
 var DYNAMICTOP_PTR = 0;
 var nan = NaN;

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -281,7 +281,7 @@ function JSify(data, functionsOnly) {
           assert(typeof original === 'function');
           contentText = modifyFunction(snippet, function(name, args, body) {
             return 'function ' + name + '(' + args + ') {\n' +
-                   'if (ENVIRONMENT_IS_PTHREAD) return _emscripten_proxy_to_main_thread_js(' + proxiedFunctionTable.length + ', ' + (+sync) + (args ? ', ' : '') + args + ');\n' + body + '}\n';
+                   'if (ENVIRONMENT_IS_WORKER) return _emscripten_proxy_to_main_thread_js(' + proxiedFunctionTable.length + ', ' + (+sync) + (args ? ', ' : '') + args + ');\n' + body + '}\n';
           });
           proxiedFunctionTable.push(finalName);
         } else {
@@ -411,7 +411,7 @@ function JSify(data, functionsOnly) {
         });
         // write out the singleton big memory initialization value
         if (USE_PTHREADS) {
-          print('if (!ENVIRONMENT_IS_PTHREAD) {') // Pthreads should not initialize memory again, since it's shared with the main thread.
+          print('if (!ENVIRONMENT_IS_WORKER) {') // Pthreads should not initialize memory again, since it's shared with the main thread.
         }
         print('/* memory initializer */ ' + makePointer(memoryInitialization, null, 'ALLOC_NONE', 'i8', 'GLOBAL_BASE' + (SIDE_MODULE ? '+H_BASE' : ''), true));
         if (USE_PTHREADS) {
@@ -424,7 +424,7 @@ function JSify(data, functionsOnly) {
       if (!SIDE_MODULE && !WASM_BACKEND) {
         if (USE_PTHREADS) {
           print('var tempDoublePtr;');
-          print('if (!ENVIRONMENT_IS_PTHREAD) tempDoublePtr = ' + makeStaticAlloc(12) + ';');
+          print('if (!ENVIRONMENT_IS_WORKER) tempDoublePtr = ' + makeStaticAlloc(12) + ';');
         } else {
           print('var tempDoublePtr = ' + makeStaticAlloc(8) + '');
         }

--- a/src/library.js
+++ b/src/library.js
@@ -4006,7 +4006,7 @@ LibraryManager.library = {
 #endif
 #if USE_PTHREADS
 // Pthreads need their clocks synchronized to the execution of the main thread, so give them a special form of the function.
-                               "if (ENVIRONMENT_IS_PTHREAD) {\n" +
+                               "if (ENVIRONMENT_IS_WORKER) {\n" +
                                "  _emscripten_get_now = function() { return performance['now']() - __performance_now_clock_drift; };\n" +
                                "} else " +
 #endif

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1082,7 +1082,7 @@ var LibraryBrowser = {
     onerror = getFuncWrapper(onerror, 'v');
 
 #if USE_PTHREADS
-    if (ENVIRONMENT_IS_PTHREAD) {
+    if (ENVIRONMENT_IS_WORKER) {
       console.error('emscripten_async_load_script("' + UTF8ToString(url) + '") failed, emscripten_async_load_script is currently not available in pthreads!');
       return onerror ? onerror() : undefined;
     }

--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -7,7 +7,7 @@
 
 var LibraryFetch = {
 #if USE_PTHREADS
-  $Fetch__postset: 'if (!ENVIRONMENT_IS_PTHREAD) Fetch.staticInit();',
+  $Fetch__postset: 'if (!ENVIRONMENT_IS_WORKER) Fetch.staticInit();',
 #else
   $Fetch__postset: 'Fetch.staticInit();',
 #endif

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2399,7 +2399,7 @@ var LibraryJSEvents = {
 
 #if (USE_PTHREADS && OFFSCREEN_FRAMEBUFFER)
     // Create a WebGL context that is proxied to main thread if canvas was not found on worker, or if explicitly requested to do so.
-    if (ENVIRONMENT_IS_PTHREAD) {
+    if (ENVIRONMENT_IS_WORKER) {
       if (contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS') }}} ||
          (!canvas && contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK') }}})) {
         // When WebGL context is being proxied via the main thread, we must render using an offscreen FBO render target to avoid WebGL's
@@ -2722,7 +2722,7 @@ var LibraryJSEvents = {
 #if USE_PTHREADS && ASSERTIONS && OFFSCREENCANVAS_SUPPORT
     // TODO: for Offscreencanvas case, must first search locally in the calling thread if the given context is an OffscreenCanvas context on the calling thread,
     // and only if it's not, then try to proxy the call to main thread. I.e. this function cannot be unconditionally 'sync' proxied.
-    if (ENVIRONMENT_IS_PTHREAD) warnOnce('TODO: emscripten_is_webgl_context_lost() does not yet work properly in pthreads with OffscreenCanvas contexts');
+    if (ENVIRONMENT_IS_WORKER) warnOnce('TODO: emscripten_is_webgl_context_lost() does not yet work properly in pthreads with OffscreenCanvas contexts');
 #endif
     return !GL.contexts[target] || GL.contexts[target].GLctx.isContextLost(); // No context ~> lost context.
   },

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1573,7 +1573,7 @@ function modifyFunction(text, func) {
 
 function runOnMainThread(text) {
   if (USE_PTHREADS) {
-    return 'if (!ENVIRONMENT_IS_PTHREAD) { ' + text + ' }';
+    return 'if (!ENVIRONMENT_IS_WORKER) { ' + text + ' }';
   } else {
     return text;
   }

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -8,7 +8,7 @@ Module['asm'] = asm;
 #if MEM_INIT_IN_WASM == 0
 #if MEM_INIT_METHOD == 2
 #if USE_PTHREADS
-if (memoryInitializer && !ENVIRONMENT_IS_PTHREAD) (function(s) {
+if (memoryInitializer && !ENVIRONMENT_IS_WORKER) (function(s) {
 #else
 if (memoryInitializer) (function(s) {
 #endif
@@ -35,7 +35,7 @@ if (memoryInitializer) (function(s) {
 })(memoryInitializer);
 #else
 #if USE_PTHREADS
-if (memoryInitializer && !ENVIRONMENT_IS_PTHREAD) {
+if (memoryInitializer && !ENVIRONMENT_IS_WORKER) {
 #else
 if (memoryInitializer) {
 #endif
@@ -469,13 +469,13 @@ if (Module['noInitialRun']) shouldRunNow = false;
 
 #if EXIT_RUNTIME == 0
 #if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) // EXIT_RUNTIME=0 only applies to default behavior of the main browser thread
+if (!ENVIRONMENT_IS_WORKER) // EXIT_RUNTIME=0 only applies to default behavior of the main browser thread
 #endif
   noExitRuntime = true;
 #endif
 
 #if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) run();
+if (!ENVIRONMENT_IS_WORKER) run();
 #if EMBIND
 else {  // Embind must initialize itself on all threads, as it generates support JS.
   Module['___embind_register_native_and_builtin_types']();

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -27,7 +27,7 @@ function initRuntime(asm) {
 #endif
 
 #if USE_PTHREADS
-  if (ENVIRONMENT_IS_PTHREAD) return;
+  if (ENVIRONMENT_IS_WORKER) return;
   // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
   __register_pthread_ptr(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
   _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -34,7 +34,7 @@ function alignUp(x, multiple) {
 #include "runtime_sab_polyfill.js"
 
 #if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) {
+if (!ENVIRONMENT_IS_WORKER) {
 #endif
 
 var GLOBAL_BASE = {{{ GLOBAL_BASE }}},

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -381,14 +381,8 @@ Module['postMainLoop'] = function() {
 
 // Wait to start running until we receive some info from the client
 
-#if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) {
-#endif
-  addRunDependency('gl-prefetch');
-  addRunDependency('worker-init');
-#if USE_PTHREADS
-}
-#endif
+addRunDependency('gl-prefetch');
+addRunDependency('worker-init');
 
 // buffer messages until the program starts to run
 
@@ -477,9 +471,6 @@ function onMessageFromMainEmscriptenThread(message) {
       screen.height = Module.canvas.height_ = message.data.height;
       Module.canvas.boundingClientRect = message.data.boundingClientRect;
       document.URL = message.data.URL;
-#if USE_PTHREADS
-      currentScriptUrl = message.data.currentScriptUrl;
-#endif
       window.fireEvent({ type: 'load' });
       removeRunDependency('worker-init');
       break;
@@ -500,13 +491,7 @@ function onMessageFromMainEmscriptenThread(message) {
   }
 };
 
-#if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) {
-#endif
-  onmessage = onMessageFromMainEmscriptenThread;
-#if USE_PTHREADS
-}
-#endif
+onmessage = onMessageFromMainEmscriptenThread;
 
 // proxyWorker.js has defined 'document' and 'window' objects above, so need to
 // initialize them for library_html5.js explicitly here.

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -1,7 +1,7 @@
 // Create the main memory. (Note: this isn't used in STANDALONE_WASM mode since the wasm
 // memory is created in the wasm, not in JS.)
 #if USE_PTHREADS
-if (ENVIRONMENT_IS_PTHREAD) {
+if (ENVIRONMENT_IS_WORKER) {
   wasmMemory = Module['wasmMemory'];
   buffer = Module['buffer'];
 } else {
@@ -77,7 +77,7 @@ assert({{{ WASM_PAGE_SIZE }}} % WASM_PAGE_SIZE === 0);
 updateGlobalBufferAndViews(buffer);
 
 #if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) { // Pthreads have already initialized these variables in src/worker.js, where they were passed to the thread worker at startup time
+if (!ENVIRONMENT_IS_WORKER) { // Pthreads have already initialized these variables in src/worker.js, where they were passed to the thread worker at startup time
 #endif
 #if !STANDALONE_WASM // in standalone mode the value is in the wasm
 HEAP32[DYNAMICTOP_PTR>>2] = DYNAMIC_BASE;

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -87,13 +87,13 @@ function ready() {
 var _scriptDir = (typeof document !== 'undefined' && document.currentScript) ? document.currentScript.src : undefined;
 #endif
 
-var ENVIRONMENT_IS_PTHREAD;
-if (!ENVIRONMENT_IS_PTHREAD) ENVIRONMENT_IS_PTHREAD = false; // ENVIRONMENT_IS_PTHREAD=true will have been preset in pthread-main.js. Make it false in the main runtime thread.
+var ENVIRONMENT_IS_WORKER;
+if (!ENVIRONMENT_IS_WORKER) ENVIRONMENT_IS_WORKER = false; // ENVIRONMENT_IS_WORKER=true will have been preset in pthread-main.js. Make it false in the main runtime thread.
 
-if (typeof ENVIRONMENT_IS_PTHREAD === 'undefined') {
-  // ENVIRONMENT_IS_PTHREAD=true will have been preset in pthread-main.js. Make it false in the main runtime thread. 
+if (typeof ENVIRONMENT_IS_WORKER === 'undefined') {
+  // ENVIRONMENT_IS_WORKER=true will have been preset in pthread-main.js. Make it false in the main runtime thread. 
   // N.B. this line needs to appear without 'var' keyword to avoid 'var hoisting' from occurring. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/var)
-  ENVIRONMENT_IS_PTHREAD = false;
+  ENVIRONMENT_IS_WORKER = false;
 }
 #if MODULARIZE
 else {

--- a/src/shell_pthreads.js
+++ b/src/shell_pthreads.js
@@ -1,11 +1,4 @@
-// Three configurations we can be running in:
-// 1) We could be the application main() thread running in the main JS UI thread. (ENVIRONMENT_IS_WORKER == false and ENVIRONMENT_IS_PTHREAD == false)
-// 2) We could be the application main() thread proxied to worker. (with Emscripten -s PROXY_TO_WORKER=1) (ENVIRONMENT_IS_WORKER == true, ENVIRONMENT_IS_PTHREAD == false)
-// 3) We could be an application pthread running in a worker. (ENVIRONMENT_IS_WORKER == true and ENVIRONMENT_IS_PTHREAD == true)
-
-// ENVIRONMENT_IS_PTHREAD=true will have been preset in worker.js. Make it false in the main runtime thread.
-var ENVIRONMENT_IS_PTHREAD = Module['ENVIRONMENT_IS_PTHREAD'] || false;
-if (ENVIRONMENT_IS_PTHREAD) {
+if (ENVIRONMENT_IS_WORKER) {
   // Grab imports from the pthread to local scope.
   buffer = {{{EXPORT_NAME}}}['buffer'];
   tempDoublePtr = {{{EXPORT_NAME}}}['tempDoublePtr'];
@@ -15,3 +8,6 @@ if (ENVIRONMENT_IS_PTHREAD) {
   // These will be filled in at pthread startup time (the 'run' message for a pthread - pthread start establishes the stack frame)
 }
 
+// Internal: Because fastcomp emits a "if (!ENVIRONMENT_IS_PTHREAD)" check, still provide the variable ENVIRONMENT_IS_PTHREAD here. However
+// use ENVIRONMENT_IS_WORKER instead of ENVIRONMENT_IS_PTHREAD everywhere.
+var ENVIRONMENT_IS_PTHREAD = ENVIRONMENT_IS_WORKER;

--- a/src/support.js
+++ b/src/support.js
@@ -23,7 +23,7 @@ function dynamicAlloc(size) {
 #if ASSERTIONS
   assert(DYNAMICTOP_PTR);
 #if USE_PTHREADS
-  assert(!ENVIRONMENT_IS_PTHREAD); // this function is not thread-safe
+  assert(!ENVIRONMENT_IS_WORKER); // this function is not thread-safe
 #endif
 #endif
   var ret = HEAP32[DYNAMICTOP_PTR>>2];

--- a/src/worker.js
+++ b/src/worker.js
@@ -129,7 +129,7 @@ this.onmessage = function(e) {
 
 #endif
 
-      Module['ENVIRONMENT_IS_PTHREAD'] = true;
+      Module['ENVIRONMENT_IS_WORKER'] = true;
 
 #if MODULARIZE && EXPORT_ES6
       import(e.data.urlOrBlob).then(function({{{ EXPORT_NAME }}}) {

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -518,7 +518,7 @@ static void EMSCRIPTEN_KEEPALIVE emscripten_async_queue_call_on_thread(
     } else {
       int success = EM_ASM_INT(
         {
-          if (!ENVIRONMENT_IS_PTHREAD) {
+          if (!ENVIRONMENT_IS_WORKER) {
             if (!PThread.pthreads[$0] || !PThread.pthreads[$0].worker) {
               // #if DEBUG
               //						Module.printErr('Cannot send message

--- a/tests/pthread/test_pthread_run_script.cpp
+++ b/tests/pthread/test_pthread_run_script.cpp
@@ -18,12 +18,8 @@ void EMSCRIPTEN_KEEPALIVE FinishTest(int result)
 
 void TestAsyncRunScript()
 {
-  // 5. Test emscripten_async_run_script() runs in a pthread.
-#if __EMSCRIPTEN_PTHREADS__
-  emscripten_async_run_script("Module['_FinishTest'](ENVIRONMENT_IS_PTHREAD && ENVIRONMENT_IS_WORKER);", 1);
-#else
+  // 5. Test emscripten_async_run_script() runs in a worker.
   emscripten_async_run_script("Module['_FinishTest'](!ENVIRONMENT_IS_WORKER);", 1);
-#endif
 }
 
 void AsyncScriptLoaded()
@@ -42,14 +38,14 @@ int main() {
 
   // 1. Test that emscripten_run_script() works in a pthread, and it gets executed in the web worker and not on the main thread.
 #if __EMSCRIPTEN_PTHREADS__
-  emscripten_run_script("Module['ranScript'] = ENVIRONMENT_IS_PTHREAD && ENVIRONMENT_IS_WORKER;");
+  emscripten_run_script("Module['ranScript'] = ENVIRONMENT_IS_WORKER;");
 #else
   emscripten_run_script("Module['ranScript'] = true;");
 #endif
 
   // 2. Test that emscripten_run_script_int() works in a pthread and it gets executed in the web worker and not on the main thread.
 #if __EMSCRIPTEN_PTHREADS__
-  int result = emscripten_run_script_int("Module['ranScript'] && ENVIRONMENT_IS_PTHREAD && ENVIRONMENT_IS_WORKER;");
+  int result = emscripten_run_script_int("Module['ranScript'] && ENVIRONMENT_IS_WORKER;");
 #else
   int result = emscripten_run_script_int("Module['ranScript'];");
 #endif
@@ -58,7 +54,7 @@ int main() {
 
   // 3. Test emscripten_run_script_string() runs in a pthread.
 #if __EMSCRIPTEN_PTHREADS__
-  char *data = emscripten_run_script_string("ENVIRONMENT_IS_PTHREAD && ENVIRONMENT_IS_WORKER ? 'in pthread' : 'not in pthread';");
+  char *data = emscripten_run_script_string("ENVIRONMENT_IS_WORKER ? 'in pthread' : 'not in pthread';");
   printf("%s\n", data);
   assert(!strcmp(data, "in pthread"));
 #else

--- a/tests/pthread/test_pthread_run_script.cpp
+++ b/tests/pthread/test_pthread_run_script.cpp
@@ -19,7 +19,11 @@ void EMSCRIPTEN_KEEPALIVE FinishTest(int result)
 void TestAsyncRunScript()
 {
   // 5. Test emscripten_async_run_script() runs in a worker.
+#if __EMSCRIPTEN_PTHREADS__
+  emscripten_async_run_script("Module['_FinishTest'](ENVIRONMENT_IS_WORKER);", 1);
+#else
   emscripten_async_run_script("Module['_FinishTest'](!ENVIRONMENT_IS_WORKER);", 1);
+#endif
 }
 
 void AsyncScriptLoaded()


### PR DESCRIPTION
Remove ENVIRONMENT_IS_PTHREAD variable. The existence of this variable predates to the time when pthreads still supported --proxy-to-worker mode (and --proxy-to-pthread did not exist). After --proxy-to-pthread has proven itself as a more usable method and USE_PTHREADS + --proxy-to-worker was deprecated, there is no longer need to distinguish between "am I a worker" or "am I a pthread", as all workers are pthreads, and the scenario "worker that is the proxied main thread so not a pthread" no longer happens.