### PR TITLE
Misc threads fixes

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -433,6 +433,7 @@ var LibraryPThread = {
             err('pthread sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
           };
 
+#if ENVIRONMENT_MAY_BE_NODE
           if (ENVIRONMENT_HAS_NODE) {
             worker.on('message', function(data) {
               worker.onmessage({ data: data });
@@ -444,6 +445,7 @@ var LibraryPThread = {
               console.log('worker exited - TODO: update the worker queue?');
             });
           }
+#endif
         }(worker));
       }  // for each worker
     },

--- a/src/modules.js
+++ b/src/modules.js
@@ -445,8 +445,13 @@ function exportRuntime() {
     // In pthreads mode, the following functions always need to be exported to
     // Module for closure compiler, and also for MODULARIZE (so worker.js can
     // access them).
-    ['PThread', 'ExitStatus', 'tempDoublePtr', 'wasmMemory', '_pthread_self',
-     'ExitStatus', 'tempDoublePtr'].forEach(function(x) {
+    var threadExports = ['PThread', 'ExitStatus', 'tempDoublePtr', '_pthread_self',
+    'tempDoublePtr'];
+    if (WASM) {
+      threadExports.push('wasmMemory');
+    }
+
+    threadExports.forEach(function(x) {
       EXPORTED_RUNTIME_METHODS_SET[x] = 1;
       runtimeElements.push(x);
     });

--- a/src/modules.js
+++ b/src/modules.js
@@ -445,8 +445,7 @@ function exportRuntime() {
     // In pthreads mode, the following functions always need to be exported to
     // Module for closure compiler, and also for MODULARIZE (so worker.js can
     // access them).
-    var threadExports = ['PThread', 'ExitStatus', 'tempDoublePtr', '_pthread_self',
-    'tempDoublePtr'];
+    var threadExports = ['PThread', 'ExitStatus', 'tempDoublePtr', '_pthread_self'];
     if (WASM) {
       threadExports.push('wasmMemory');
     }


### PR DESCRIPTION
1. Gate `ENVIRONMENT_HAS_NODE` behind `ENVIRONMENT_MAY_BE_NODE`.
2. `ExitStatus` was present twice in the threads exported objects.
3. Only export `wasmMemory` in wasm multithreading mode, not in asm.js multithreading mode.