### PR TITLE
Support running a pthreads-using program in a worker

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -100,6 +100,8 @@ var _scriptDir = (typeof document !== 'undefined' && document.currentScript) ? d
 
 if (ENVIRONMENT_IS_NODE) {
   _scriptDir = __filename;
+} else if (ENVIRONMENT_IS_WORKER) {
+  _scriptDir = self.location.href;
 }
 #endif
 #endif

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4674,7 +4674,11 @@ window.close = function() {
   def test_pthreads_started_in_worker(self):
     create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'pthread', 'test_pthread_atomics.cpp')).read()))
     self.compile_btest(['src.cpp', '-o', 'test.js', '-s', 'TOTAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'])
-    create_test_file('test.html', '<script src="test.js"></script>')
+    create_test_file('test.html', '''
+      <script>
+        new Worker('test.js');
+      </script>
+    ''')
     self.run_browser('test.html', None, '/report_result?0')
 
   def test_access_file_after_heap_resize(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4666,6 +4666,17 @@ window.close = function() {
     self.assertExists('test.js')
     self.assertNotExists('test.worker.js')
 
+  # Tests that pthreads code works as intended in a Worker. That is, a pthreads-using
+  # program can run either on the main thread (normal tests) or when we start it in
+  # a Worker in this test (in that case, both the main application thread and the worker threads
+  # are all inside Web Workers).
+  @requires_threads
+  def test_pthreads_started_in_worker(self):
+    create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'pthread', 'test_pthread_atomics.cpp')).read()))
+    self.compile_btest(['src.cpp', '-o', 'test.js', '-s', 'TOTAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'])
+    create_test_file('test.html', '<script src="test.js"></script>')
+    self.run_browser('test.html', None, '/report_result?0')
+
   def test_access_file_after_heap_resize(self):
     create_test_file('test.txt', 'hello from file')
     create_test_file('page.c', self.with_report_result(open(path_from_root('tests', 'access_file_after_heap_resize.c'), 'r').read()))

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4673,7 +4673,7 @@ window.close = function() {
   @requires_threads
   def test_pthreads_started_in_worker(self):
     create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'pthread', 'test_pthread_atomics.cpp')).read()))
-    self.compile_btest(['src.cpp', '-o', 'test.js', '-s', 'TOTAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'])
+    self.compile_btest(['src.cpp', '-o', 'test.js', '-s', 'TOTAL_MEMORY=64MB', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'])
     create_test_file('test.html', '''
       <script>
         new Worker('test.js');


### PR DESCRIPTION
@juj noticed we were missing tests for this mode. Looks like
the test suite relies on the convenience of `PROXY_TO_PTHREAD`
and `--proxy-to-worker` for testing related things, but we didn't
test the case of the entire compiled application being instantiated
in a worker (in that case, an interesting thing is that both the main
application thread, and the pthreads, are all in Web Workers).

The only thing preventing this from working was that we didn't
have a line of code to get `_scriptDir` when in a worker (we just
had main thread and node.js).

This depends on workers being able to spawn workers, which
appears to be true everywhere but Safari currently.

edit: added last paragraphs