### PR TITLE
Remove FS.createStandardStreams in pthreads

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -136,9 +136,6 @@ this.onmessage = function(e) {
         Module = {{{ EXPORT_NAME }}}.default(Module);
         PThread = Module['PThread'];
         HEAPU32 = Module['HEAPU32'];
-#if !ASMFS
-        if (typeof FS !== 'undefined' && typeof FS.createStandardStreams === 'function') FS.createStandardStreams();
-#endif
         postMessage({ cmd: 'loaded' });
       });
 #else
@@ -154,10 +151,6 @@ this.onmessage = function(e) {
 #endif
       PThread = Module['PThread'];
       HEAPU32 = Module['HEAPU32'];
-
-#if !ASMFS
-      if (typeof FS !== 'undefined' && typeof FS.createStandardStreams === 'function') FS.createStandardStreams();
-#endif
       postMessage({ cmd: 'loaded' });
 #endif
     } else if (e.data.cmd === 'objectTransfer') {


### PR DESCRIPTION
Remove FS.createStandardStreams in pthreads: the stdin/stdout/stderr JS side handles no longer exist and FS operations are more aggressively proxied, so there is no pthread side JS data that need initializing.