### PR TITLE
Remove preamble function Module['applyStackValues']()

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1444,16 +1444,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # To ensure allocated thread stacks are aligned:
       shared.Settings.EXPORTED_FUNCTIONS += ['_memalign']
 
+      # pthread stack setup:
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$establishStackSpaceInJsModule']
+      shared.Settings.EXPORTED_FUNCTIONS += ['establishStackSpaceInJsModule']
+
       if shared.Settings.MODULARIZE:
         # MODULARIZE+USE_PTHREADS mode requires extra exports out to Module so that worker.js
         # can access them:
 
         # general threading variables:
         shared.Settings.EXPORTED_RUNTIME_METHODS += ['PThread', 'ExitStatus']
-
-        # pthread stack setup:
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$establishStackSpaceInJsModule']
-        shared.Settings.EXPORTED_FUNCTIONS += ['establishStackSpaceInJsModule']
 
         # stack check:
         if shared.Settings.STACK_OVERFLOW_CHECK:

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1329,19 +1329,18 @@ var LibraryPThread = {
     return func.apply(null, _emscripten_receive_on_main_thread_js_callArgs);
   },
 
-#if MODULARIZE
-  $establishStackSpaceInJsModule: function(stackBase, stackMax) {
-    STACK_BASE = stackBase;
-#if WASM_BACKEND
-    // The stack grows downwards
-    STACKTOP = stackMax;
-    STACK_MAX = stackBase;
-#else
-    STACKTOP = stackBase;
+  $establishStackSpaceInJsModule: function(stackTop, stackMax) {
+    STACK_BASE = STACKTOP = stackTop;
     STACK_MAX = stackMax;
+#if SAFE_STACK
+    ___set_stack_limit(STACK_MAX);
 #endif
+#if STACK_OVERFLOW_CHECK
+    writeStackCookie();
+#endif
+    // Call inside asm.js/wasm module to set up the stack frame for this pthread in asm.js/wasm module scope
+    establishStackSpace(stackTop, stackMax);
   },
-#endif
 };
 
 autoAddDeps(LibraryPThread, '$PThread');

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -376,20 +376,10 @@ if (ENVIRONMENT_IS_PTHREAD) {
   // At the 'load' stage of Worker startup, we are just loading this script
   // but not ready to run yet. At 'run' we receive proper values for the stack
   // etc. and can launch a pthread. Set some fake values there meanwhile to
-  // catch bugs, then set the real values in applyStackValues later.
+  // catch bugs, then set the real values in establishStackSpaceInJsModule later.
 #if ASSERTIONS || SAFE_STACK
   STACK_MAX = STACKTOP = STACK_MAX = 0x7FFFFFFF;
 #endif
-
-  Module['applyStackValues'] = function(stackBase, stackTop, stackMax) {
-    STACK_BASE = stackBase;
-    STACKTOP = stackTop;
-    STACK_MAX = stackMax;
-#if SAFE_STACK
-    Module['___set_stack_limit'](STACK_MAX);
-#endif
-  };
-
   // TODO DYNAMIC_BASE = Module['DYNAMIC_BASE'];
   // TODO DYNAMICTOP_PTR = Module['DYNAMICTOP_PTR'];
   // TODO tempDoublePtr = Module['tempDoublePtr'];

--- a/src/support.js
+++ b/src/support.js
@@ -1007,10 +1007,10 @@ GLOBAL_BASE = alignMemory(GLOBAL_BASE, {{{ MAX_GLOBAL_ALIGN || 1 }}});
 #endif
 
 #if WASM_BACKEND && USE_PTHREADS
-// The wasm backend path does not have a way to set the stack max, so we can
-// just implement this function in a trivial way
-function establishStackSpace(base, max) {
-  stackRestore(max);
+// The wasm backend path does not have a way to set the stack max, so ignore
+// the stack max parameter, this function only resets the stack base.
+function establishStackSpace(base/*, max*/) {
+  stackRestore(base);
 }
 
 // JS library code refers to Atomics in the manner used from asm.js, provide

--- a/src/worker.js
+++ b/src/worker.js
@@ -177,34 +177,23 @@ this.onmessage = function(e) {
       var max = e.data.stackBase + e.data.stackSize;
       var top = e.data.stackBase;
 #endif
-      Module['applyStackValues'](top, top, max);
 #if ASSERTIONS
       assert(threadInfoStruct);
       assert(selfThreadId);
       assert(parentThreadId);
       assert(top != 0);
+      assert(e.data.stackSize > 0);
 #if WASM_BACKEND
-      assert(max === e.data.stackBase);
       assert(top > max);
 #else
-      assert(max > e.data.stackBase);
       assert(max > top);
-      assert(e.data.stackBase === top);
 #endif
 #endif
-      // Call inside asm.js/wasm module to set up the stack frame for this pthread in asm.js/wasm module scope
-      Module['establishStackSpace'](e.data.stackBase, e.data.stackBase + e.data.stackSize);
-#if MODULARIZE
       // Also call inside JS module to set up the stack frame for this pthread in JS module scope
-      Module['establishStackSpaceInJsModule'](e.data.stackBase, e.data.stackBase + e.data.stackSize);
-#endif
+      Module['establishStackSpaceInJsModule'](top, max);
 #if WASM_BACKEND
       Module['_emscripten_tls_init']();
 #endif
-#if STACK_OVERFLOW_CHECK
-      Module['writeStackCookie']();
-#endif
-
       PThread.receiveObjectTransfer(e.data);
       PThread.setThreadStatus(Module['_pthread_self'](), 1/*EM_THREAD_STATUS_RUNNING*/);
 


### PR DESCRIPTION
Remove preamble function `Module['applyStackValues']()` that was introduced in #9569. That is same as JS library function `establishStackSpaceInJsModule()`.

This simplifies preamble.js and worker.js a little.