### PR TITLE
Enable pthreads+growth tests on Chrome as 79 has shipped

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4558,7 +4558,6 @@ window.close = function() {
         self.btest(path_from_root('tests', 'pthread', 'hello_thread.c'), expected='1', args=['-s', 'USE_PTHREADS=1'] + modularize + opts)
 
   # Tests memory growth in pthreads mode, but still on the main thread.
-  @no_chrome('https://bugs.chromium.org/p/v8/issues/detail?id=9062')
   @requires_threads
   def test_pthread_growth_mainthread(self):
     def run(emcc_args=[]):
@@ -4569,7 +4568,6 @@ window.close = function() {
     run(['-s', 'PROXY_TO_PTHREAD=1'])
 
   # Tests memory growth in a pthread.
-  @no_chrome('https://bugs.chromium.org/p/v8/issues/detail?id=9065')
   @requires_threads
   def test_pthread_growth(self):
     def run(emcc_args=[]):


### PR DESCRIPTION
That release contains all the fixes we need.