### PR TITLE
SIMD intrinsics for {i8x16,i16x8}.avgr_u instructions

### DIFF
--- a/system/include/wasm_simd128.h
+++ b/system/include/wasm_simd128.h
@@ -752,6 +752,15 @@ static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_max_u(v128_t a, v128_t b)
   };
 }
 
+#ifdef __wasm_unimplemented_simd__
+
+// v128_t wasm_i8x16_avgr_u(v128_t a, v128_t b)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i8x16_avgr_u(v128_t a, v128_t b) {
+  return (v128_t)__builtin_wasm_avgr_u_i8x16((__i8x16)a, (__i8x16)b);
+}
+
+#endif // __wasm_unimplemented_simd__
+
 // v128_t wasm_i16x8_neg(v128_t a)
 static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_neg(v128_t a) {
   return (v128_t)(-(__u16x8)a);
@@ -880,6 +889,15 @@ static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_max_u(v128_t a, v128_t b)
     (a_[7] > b_[7] ? a_[7] : b_[7])
   };
 }
+
+#ifdef __wasm_unimplemented_simd__
+
+// v128_t wasm_i16x8_avgr_u(v128_t a, v128_t b)
+static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i16x8_avgr_u(v128_t a, v128_t b) {
+  return (v128_t)__builtin_wasm_avgr_u_i16x8((__i16x8)a, (__i16x8)b);
+}
+
+#endif // __wasm_unimplemented_simd__
 
 // v128_t wasm_i32x4_neg(v128_t a)
 static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_i32x4_neg(v128_t a) {

--- a/tests/test_wasm_builtin_simd.c
+++ b/tests/test_wasm_builtin_simd.c
@@ -368,6 +368,11 @@ i8x16 TESTFN i8x16_mul(i8x16 x, i8x16 y) {
   return x * y;
 }
 // Skip {min,max}_{s,u} because they do not have short builtin equivalents
+#ifdef __wasm_unimplemented_simd128__
+i8x16 TESTFN i8x16_avgr_u(i8x16 x, i8x16 y) {
+  return __builtin_wasm_avgr_u_i8x16(x, y);
+}
+#endif // __wasm_unimplemented_simd128__
 i16x8 TESTFN i16x8_neg(i16x8 vec) {
   return -vec;
 }
@@ -408,6 +413,11 @@ i16x8 TESTFN i16x8_mul(i16x8 x, i16x8 y) {
   return x * y;
 }
 // Skip {min,max}_{s,u} because they do not have short builtin equivalents
+#ifdef __wasm_unimplemented_simd128__
+i16x8 TESTFN i16x8_avgr_u(i16x8 x, i16x8 y) {
+  return __builtin_wasm_avgr_u_i16x8(x, y);
+}
+#endif // __wasm_unimplemented_simd128__
 i32x4 TESTFN i32x4_neg(i32x4 vec) {
   return -vec;
 }
@@ -1176,6 +1186,15 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ),
     ((i8x16){0, 230, 255, 0, 255, 6, 106, 237, 230, 52, 223, 76, 0, 6, 127, 126})
   );
+#ifdef __wasm_unimplemented_simd128__
+  expect_vec(
+    i8x16_avgr_u(
+      (i8x16){0, 42, 255, 128, 127, 129, 6, 29, 103, 196, 231, 142, 17, 250, 1, 73},
+      (i8x16){3, 231, 1, 128, 129, 6, 103, 17, 42, 29, 73, 42, 0, 255, 127, 142}
+    ),
+    ((i8x16){2, 137, 128, 128, 128, 68, 55, 23, 73, 113, 152, 92, 9, 253, 64, 108})
+  );
+#endif // __wasm_unimplemented_simd128__
 
   // i16x8 arithmetic
   expect_vec(
@@ -1263,6 +1282,15 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ),
     ((i16x8){0, -256, 0, 0, 0, 0, 0, -4})
   );
+#ifdef __wasm_unimplemented_simd128__
+  expect_vec(
+    i16x8_avgr_u(
+      (i16x8){0, -256, -32768, 32512, -32512, -6400, -1536, 32766},
+      (i16x8){768, 1, -32768, -32512, 1536, 18688, -256, 2}
+    ),
+    ((i16x8){384, 32641, -32768, -32768, 17280, -26624, -896, 16384})
+  );
+#endif // __wasm_unimplemented_simd128__
 
   // i32x4 arithmetic
   expect_vec(i32x4_neg((i32x4){0, 1, 0x80000000, 0x7fffffff}), ((i32x4){0, -1, 0x80000000, 0x80000001}));

--- a/tests/test_wasm_intrinsics_simd.c
+++ b/tests/test_wasm_intrinsics_simd.c
@@ -453,6 +453,11 @@ v128_t TESTFN i8x16_max_s(v128_t x, v128_t y) {
 v128_t TESTFN i8x16_max_u(v128_t x, v128_t y) {
   return wasm_i8x16_max_u(x, y);
 }
+#ifdef __wasm_unimplemented_simd__
+v128_t TESTFN i8x16_avgr_u(v128_t x, v128_t y) {
+  return wasm_i8x16_avgr_u(x, y);
+}
+#endif // __wasm_unimplemented_simd__
 v128_t TESTFN i16x8_neg(v128_t vec) {
   return wasm_i16x8_neg(vec);
 }
@@ -501,6 +506,11 @@ v128_t TESTFN i16x8_max_s(v128_t x, v128_t y) {
 v128_t TESTFN i16x8_max_u(v128_t x, v128_t y) {
   return wasm_i16x8_max_u(x, y);
 }
+#ifdef __wasm_unimplemented_simd__
+v128_t TESTFN i16x8_avgr_u(v128_t x, v128_t y) {
+  return wasm_i16x8_avgr_u(x, y);
+}
+#endif // __wasm_unimplemented_simd__
 v128_t TESTFN i16x8_mul(v128_t x, v128_t y) {
   return wasm_i16x8_mul(x, y);
 }
@@ -1476,6 +1486,15 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ),
     i8x16(3, 231, 255, 128, 129, 129, 103, 29, 103, 196, 231, 142, 17, 255, 127, 142)
   );
+#ifdef __wasm_unimplemented_simd__
+  expect_vec(
+    i8x16_avgr_u(
+      (v128_t)i8x16(0, 42, 255, 128, 127, 129, 6, 29, 103, 196, 231, 142, 17, 250, 1, 73),
+      (v128_t)i8x16(3, 231, 1, 128, 129, 6, 103, 17, 42, 29, 73, 42, 0, 255, 127, 142)
+    ),
+    i8x16(2, 137, 128, 128, 128, 68, 55, 23, 73, 113, 152, 92, 9, 253, 64, 108)
+  );
+#endif // __wasm_unimplemented_simd__
 
   // i16x8 arithmetic
   expect_vec(
@@ -1591,7 +1610,15 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ),
     i16x8(768, -256, -32768, -32512, -32512, -6400, -256, 32766)
   );
-
+#ifdef __wasm_unimplemented_simd__
+  expect_vec(
+    i16x8_max_u(
+      (v128_t)i16x8(0, -256, -32768, 32512, -32512, -6400, -1536, 32766),
+      (v128_t)i16x8(768, 1, -32768, -32512, 1536, 18688, -256, 2)
+    ),
+    i16x8(384, 32641, -32768, -32768, 17280, -26624, -896, 16384)
+  );
+#endif // __wasm_unimplemented_simd__
 
   // i32x4 arithmetic
   expect_vec(


### PR DESCRIPTION
Depends on https://reviews.llvm.org/D71648 and
https://github.com/WebAssembly/binaryen/pull/2539.