### PR TITLE
Warn if EXPORTED_FUNCTIONS is used with MAIN_MODULE=1/SIDE_MODULE=1

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1700,6 +1700,9 @@ def phase_linker_setup(options, state, newargs, settings_map):
     settings.LINKABLE = 1
     settings.EXPORT_ALL = 1
 
+  if settings.LINKABLE and settings.USER_EXPORTED_FUNCTIONS:
+    diagnostics.warning('unused-command-line-argument', 'EXPORTED_FUNCTIONS is not valid with LINKABLE set (normally due to SIDE_MODULE=1/MAIN_MODULE=1) since all functions are exported this mode.  To export only a subset use SIDE_MODULE=2/MAIN_MODULE=2')
+
   if settings.MAIN_MODULE:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
         '$getDylinkMetadata',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1989,7 +1989,9 @@ int main(int argc, char **argv) {
   def test_em_js(self, args, force_c):
     if '-sMAIN_MODULE' in args:
       self.check_dylink()
-    self.emcc_args += args + ['-sEXPORTED_FUNCTIONS=_main,_malloc']
+    self.emcc_args += args
+    if '-sMAIN_MODULE' not in args:
+      self.emcc_args += ['-sEXPORTED_FUNCTIONS=_main,_malloc']
 
     self.do_core_test('test_em_js.cpp', force_c=force_c)
     self.assertContained("no args returning int", read_file('test_em_js.js'))


### PR DESCRIPTION
This doesn't make sense since these imply all functionm are to be
exported.

The test code changes here are just to use @paramaterized.