### PR TITLE
emrun: Set COOP,COEP and CORP headers

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -596,9 +596,9 @@ class HTTPHandler(SimpleHTTPRequestHandler):
     self.send_header('Connection', 'close')
     self.send_header('Expires', '-1')
     self.send_header('Access-Control-Allow-Origin', '*')
-    self.send_header('Cross-Origin-Opener-Policy', 'same-origin');
-    self.send_header('Cross-Origin-Embedder-Policy', 'require-corp');
-    self.send_header('Cross-Origin-Resource-Policy', 'cross-origin');
+    self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+    self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+    self.send_header('Cross-Origin-Resource-Policy', 'cross-origin')
     self.end_headers()
     page_last_served_time = tick()
     return f

--- a/emrun.py
+++ b/emrun.py
@@ -596,6 +596,9 @@ class HTTPHandler(SimpleHTTPRequestHandler):
     self.send_header('Connection', 'close')
     self.send_header('Expires', '-1')
     self.send_header('Access-Control-Allow-Origin', '*')
+    self.send_header('Cross-Origin-Opener-Policy', 'same-origin');
+    self.send_header('Cross-Origin-Embedder-Policy', 'require-corp');
+    self.send_header('Cross-Origin-Resource-Policy', 'cross-origin');
     self.end_headers()
     page_last_served_time = tick()
     return f


### PR DESCRIPTION
This enables emrun to serve pages by taking into account
the upcoming restrictions on Content Policy for Firefox 72.

In Firefox 71, we currently need to set these flags to test the
upcoming feature:
browser.tabs.remote.useCORP
browser.tabs.remote.useCrossOriginOpenerPolicy
browser.tabs.remote.useCrossOriginEmbedderPolicy
dom.postMessage.sharedArrayBuffer.withCOOP_COEP

This PR is a fwp on @VirtualTim ticket: 
Fixes #10014 