### PR TITLE
Add support for MINIMAL_RUNTIME streaming Wasm instantiation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1134,6 +1134,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.EMTERPRETIFY_FILE and shared.Settings.SINGLE_FILE:
       exit_with_error('cannot have both EMTERPRETIFY_FILE and SINGLE_FILE enabled at the same time')
 
+    if shared.Settings.MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and shared.Settings.MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION:
+      exit_with_error('MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION are mutually exclusive!')
+
     if options.emrun:
       if shared.Settings.MINIMAL_RUNTIME:
         exit_with_error('--emrun is not compatible with -s MINIMAL_RUNTIME=1')
@@ -3292,7 +3295,9 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename,
   # Depending on whether streaming Wasm compilation is enabled or not, the minimal sized code to download Wasm looks a bit different.
   # Expand {{{ DOWNLOAD_WASM }}} block from here (if we added #define support, this could be done in the template directly)
   if shared.Settings.MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION:
-    if shared.Settings.MIN_SAFARI_VERSION != shared.Settings.TARGET_NOT_SUPPORTED or shared.Settings.ENVIRONMENT_MAY_BE_NODE:
+    if shared.Settings.MIN_SAFARI_VERSION != shared.Settings.TARGET_NOT_SUPPORTED or shared.Settings.ENVIRONMENT_MAY_BE_NODE or shared.Settings.MIN_FIREFOX_VERSION < 58 or shared.Settings.MIN_CHROME_VERSION < 61:
+      # Firefox 52 added Wasm support, but only Firefox 58 added compileStreaming.
+      # Chrome 57 added Wasm support, but only Chrome 61 added compileStreaming.
       # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming
       # In Safari and Node.js, WebAssembly.compileStreaming() is not supported, in which case fall back to regular download.
       download_wasm = "WebAssembly.compileStreaming ? WebAssembly.compileStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm')) : binary('{{{ TARGET_BASENAME }}}.wasm')"

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -69,18 +69,41 @@ var imports = {
 /*** ASM_MODULE_EXPORTS_DECLARES ***/
 #endif
 
+#if MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION
+// https://caniuse.com/#feat=wasm and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
+// Firefox 52 added Wasm support, but only Firefox 58 added instantiateStreaming.
+// Chrome 57 added Wasm support, but only Chrome 61 added instantiateStreaming.
+// Node.js and Safari do not support instantiateStreaming.
+#if MIN_FIREFOX_VERSION < 58 || MIN_CHROME_VERSION < 61 || ENVIRONMENT_MAY_BE_NODE || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
+#if ASSERTIONS
+// Module['wasm'] should contain a typed array of the Wasm object data, or a precompiled WebAssembly Module.
+if (!WebAssembly.instantiateStreaming && !Module['wasm']) throw 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM';
+#endif
+(WebAssembly.instantiateStreaming
+  ? WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports)
+  : WebAssembly.instantiate(Module['wasm'], imports)).then(function(output) {
+#else
+WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports).then(function(output) {
+#endif
+
+#else // Non-streaming instantiation
 #if ASSERTIONS
 // Module['wasm'] should contain a typed array of the Wasm object data, or a precompiled WebAssembly Module.
 if (!Module['wasm']) throw 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM';
 #endif
 WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
+#endif
 
-  // WebAssembly instantiation API gotcha: if Module['wasm'] above was a typed array, then the
-  // output object will have an output.instance and output.module objects. But if Module['wasm']
-  // is an already compiled WebAssembly module, then output is the WebAssembly instance itself.
-  // Depending on the build mode, Module['wasm'] can mean a different thing.
-#if MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION
-#if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED || ENVIRONMENT_MAY_BE_NODE
+// WebAssembly instantiation API gotcha: if Module['wasm'] above was a typed array, then the
+// output object will have an output.instance and output.module objects. But if Module['wasm']
+// is an already compiled WebAssembly module, then output is the WebAssembly instance itself.
+// Depending on the build mode, Module['wasm'] can mean a different thing.
+#if MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION || MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION
+// https://caniuse.com/#feat=wasm and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
+// Firefox 52 added Wasm support, but only Firefox 58 added compileStreaming & instantiateStreaming.
+// Chrome 57 added Wasm support, but only Chrome 61 added compileStreaming & instantiateStreaming.
+// Node.js and Safari do not support compileStreaming or instantiateStreaming.
+#if MIN_FIREFOX_VERSION < 58 || MIN_CHROME_VERSION < 61 || ENVIRONMENT_MAY_BE_NODE || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
   var asm = output.instance ? output.instance.exports : output.exports;
 #else
   var asm = output.exports;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1614,6 +1614,17 @@ var MINIMAL_RUNTIME = 0;
 // is no observable difference (also has a ~100 byte impact to code size)
 var MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION = 0;
 
+// If set to 1, MINIMAL_RUNTIME will utilize streaming WebAssembly instantiation,
+// where WebAssembly module is compiled+instantiated already while it is being
+// downloaded. Same restrictions/requirements apply as with
+// MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION.
+// MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and
+// MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION cannot be simultaneously active.
+// Which one of these two is faster depends on the size of the wasm module,
+// the size of the JS runtime file, and the size of the preloaded data file
+// to download, and the browser in question.
+var MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION = 0;
+
 // If building with MINIMAL_RUNTIME=1 and application uses sbrk()/malloc(),
 // enable this. If you are not using dynamic allocations, can set this to 0 to
 // save code size. This setting is ignored when building with -s

--- a/src/shell_minimal_runtime.html
+++ b/src/shell_minimal_runtime.html
@@ -42,14 +42,6 @@ function revokeURL(url) {
 // affect how code is downloaded. When developing your own shell file, you can copy the whole
 // matrix, or just focus on a single/specific set of download schemes to use.
 
-#if MODULARIZE && WASM
-  // Modularized wasm, no separate .mem init file
-  Promise.all([script('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
-    var js = r[0]; // Detour the JS code to a separate variable to avoid instantiating with 'r' as this to avoid strict ECMAScript/Firefox GC problems that cause a leak, see https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
-    js({ wasm: r[1] });
-  });
-#endif
-
 #if MODULARIZE && !WASM && !SEPARATE_ASM && MEM_INIT_METHOD == 0
   // Modularize + asm.js embedded in main runtime .js file, no separate .mem init file
   script('{{{ TARGET_BASENAME }}}.js').then((r) => {
@@ -78,15 +70,6 @@ function revokeURL(url) {
   Promise.all([script('{{{ TARGET_BASENAME }}}.js'), script('{{{ TARGET_BASENAME }}}.asm.js'), binary('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
     var js = r[0]; // Detour the JS code to a separate variable to avoid instantiating with 'r' as this to avoid strict ECMAScript/Firefox GC problems that cause a leak, see https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
     js({ asm: r[1], mem: r[2] });
-  });
-#endif
-
-#if !MODULARIZE && WASM
-  // No modularize, no separate .mem init file
-  Promise.all([binary('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
-    Module.wasm = r[1];
-    var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
-    script(url).then(() => { revokeURL(url) });
   });
 #endif
 
@@ -119,6 +102,73 @@ function revokeURL(url) {
     var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
     script(url).then(() => { revokeURL(url) });
   });
+#endif
+
+#if MODULARIZE && WASM && !MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION
+  // Modularized wasm, no separate .mem init file
+  Promise.all([script('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
+    var js = r[0]; // Detour the JS code to a separate variable to avoid instantiating with 'r' as this to avoid strict ECMAScript/Firefox GC problems that cause a leak, see https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
+    js({ wasm: r[1] });
+  });
+#endif
+
+#if MODULARIZE && WASM && MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION
+  // Modularized wasm, no separate .mem init file
+  Promise.all([script('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
+    var js = r[0]; // Detour the JS code to a separate variable to avoid instantiating with 'r' as this to avoid strict ECMAScript/Firefox GC problems that cause a leak, see https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
+    js({ wasm: r[1] });
+  });
+
+  // Modularize, no separate .mem init file, with streaming Wasm instantiation.
+  // https://caniuse.com/#feat=wasm and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
+  // Firefox 52 added Wasm support, but only Firefox 58 added instantiateStreaming.
+  // Chrome 57 added Wasm support, but only Chrome 61 added instantiateStreaming.
+  // Node.js and Safari do not support instantiateStreaming.
+#if MIN_FIREFOX_VERSION < 58 || MIN_CHROME_VERSION < 61 || ENVIRONMENT_MAY_BE_NODE || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
+  // Modularize, no separate .mem init file
+  Promise.all([binary('{{{ TARGET_BASENAME }}}.js'), WebAssembly.instantiateStreaming && binary('{{{ TARGET_BASENAME }}}.wasm')]).then((r) => {
+    var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
+    script(url).then((js) => {
+      js({ wasm: r[1] });
+      revokeURL(url);
+    });
+  });
+#else
+  // Modularize: WebAssembly.instantiateStreaming() is unconditionally supported - loading the .js file is very simple:
+  script('{{{ TARGET_BASENAME }}}.js').then((js) => {
+    js();
+  });
+#endif
+
+
+#endif
+
+#if !MODULARIZE && WASM && !MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION
+  // No modularize, no separate .mem init file
+  Promise.all([binary('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
+    Module.wasm = r[1];
+    var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
+    script(url).then(() => { revokeURL(url) });
+  });
+#endif
+
+#if !MODULARIZE && WASM && MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION
+  // No modularize, no separate .mem init file, with streaming Wasm instantiation.
+  // https://caniuse.com/#feat=wasm and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
+  // Firefox 52 added Wasm support, but only Firefox 58 added instantiateStreaming.
+  // Chrome 57 added Wasm support, but only Chrome 61 added instantiateStreaming.
+  // Node.js and Safari do not support instantiateStreaming.
+#if MIN_FIREFOX_VERSION < 58 || MIN_CHROME_VERSION < 61 || ENVIRONMENT_MAY_BE_NODE || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
+  // No modularize, no separate .mem init file
+  Promise.all([binary('{{{ TARGET_BASENAME }}}.js'), WebAssembly.instantiateStreaming && binary('{{{ TARGET_BASENAME }}}.wasm')]).then((r) => {
+    Module.wasm = r[1];
+    var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
+    script(url).then(() => { revokeURL(url) });
+  });
+#else
+  // WebAssembly.instantiateStreaming() is unconditionally supported - loading the .js file is very simple:
+  script('{{{ TARGET_BASENAME }}}.js');
+#endif
 #endif
 
 </script>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4911,7 +4911,7 @@ window.close = function() {
   # Tests that -s MINIMAL_RUNTIME=1 works well in different build modes
   @no_wasm_backend('MINIMAL_RUNTIME not yet available in Wasm backend')
   def test_minimal_runtime_hello_world(self):
-    for args in [[], ['-s', 'MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION=1', '--closure', '1']]:
+    for args in [[], ['-s', 'MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION=1', '--closure', '1'], ['-s', 'MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION=1', '--closure', '1']]:
       self.btest(path_from_root('tests', 'small_hello_world.c'), '0', args=args + ['-s', 'MINIMAL_RUNTIME=1'])
 
   @requires_threads

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8173,7 +8173,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_wasm2js('TODO: MINIMAL_RUNTIME with WASM2JS')
   def test_minimal_runtime_hello_world(self):
     self.banned_js_engines = [V8_ENGINE, SPIDERMONKEY_ENGINE] # TODO: Support for non-Node.js shells has not yet been added to MINIMAL_RUNTIME
-    for args in [[], ['-s', 'MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION=1'], ['-s', 'DECLARE_ASM_MODULE_EXPORTS=0']]:
+    for args in [[], ['-s', 'MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION=1'], ['-s', 'MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION=1'], ['-s', 'DECLARE_ASM_MODULE_EXPORTS=0']]:
       self.emcc_args = ['-s', 'MINIMAL_RUNTIME=1'] + args
       self.set_setting('MINIMAL_RUNTIME', 1)
       self.maybe_closure()


### PR DESCRIPTION
Enables support for MINIMAL_RUNTIME Wasm streaming instantiation so projects are able to pick the one that is faster.