### PR TITLE
Main loop nag message less naggy

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1258,10 +1258,12 @@ var LibraryBrowser = {
       }
 #endif
 
+#if ASSERTIONS
       if (Browser.mainLoop.method === 'timeout' && Module.ctx) {
-        err('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
+        warnOnce('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
         Browser.mainLoop.method = ''; // just warn once per call to set main loop
       }
+#endif
 
       Browser.mainLoop.runIter(browserIterationFunc);
 


### PR DESCRIPTION
Wrapped the test in `ASSERTIONS` and print error using `warnOnce()`. Fix for #10051 (and an improvement over #10053.