### PR TITLE
Replace uses of LEGACY_VM_SUPPORT with the new MIN_xxx_VERSION fields

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1243,11 +1243,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.ALIASING_FUNCTION_POINTERS = 0
 
     if shared.Settings.LEGACY_VM_SUPPORT:
-      # legacy vms don't have wasm
-      assert not shared.Settings.WASM or shared.Settings.WASM2JS, 'LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0'
-      shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
-      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
-      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
+      if not shared.Settings.WASM or shared.Settings.WASM2JS:
+        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
 
       # Support all old browser versions
       shared.Settings.MIN_FIREFOX_VERSION = 0
@@ -1255,6 +1252,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.MIN_IE_VERSION = 0
       shared.Settings.MIN_EDGE_VERSION = 0
       shared.Settings.MIN_CHROME_VERSION = 0
+
+    if shared.Settings.MIN_SAFARI_VERSION <= 9 and (not shared.Settings.WASM or shared.Settings.WASM2JS):
+      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
+
+    if shared.Settings.MIN_CHROME_VERSION <= 37:
+      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
 
     # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
     if shared.Settings.WASM and not shared.Settings.WASM2JS:

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -1205,11 +1205,13 @@ var LibraryJSEvents = {
     var cssWidth = strategy.softFullscreen ? innerWidth : screen.width;
     var cssHeight = strategy.softFullscreen ? innerHeight : screen.height;
     var rect = __getBoundingClientRect(target);
-#if LEGACY_VM_SUPPORT
+#if MIN_IE_VERSION < 9
+    // .getBoundingClientRect(element).width & .height do not work on IE 8 and older, IE 9+ is required
+    // (https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
     var windowedCssWidth = rect.right - rect.left;
     var windowedCssHeight = rect.bottom - rect.top;
 #else
-    var windowedCssWidth = rect.width; // .getBoundingClientRect(element).width & .height do not work on IE 8 and older, IE 9+ is required
+    var windowedCssWidth = rect.width;
     var windowedCssHeight = rect.height;
 #endif
     var canvasSize = __get_canvas_element_size(target);
@@ -2968,11 +2970,12 @@ var LibraryJSEvents = {
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
 
     var rect = __getBoundingClientRect(target);
-#if LEGACY_VM_SUPPORT
+#if MIN_IE_VERSION < 9
+    // .getBoundingClientRect(element).width & .height do not work on IE 8 and older, IE 9+ is required
+    // (https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect)
     {{{ makeSetValue('width', '0', 'rect.right - rect.left', 'double') }}};
     {{{ makeSetValue('height', '0', 'rect.bottom - rect.top', 'double') }}};
 #else
-    // N.b. .getBoundingClientRect(element).width & .height do not exist on IE 8, so IE 9+ is needed.
     {{{ makeSetValue('width', '0', 'rect.width', 'double') }}};
     {{{ makeSetValue('height', '0', 'rect.height', 'double') }}};
 #endif

--- a/src/runtime_math.js
+++ b/src/runtime_math.js
@@ -1,4 +1,8 @@
-#if POLYFILL_OLD_MATH_FUNCTIONS
+#if POLYFILL_OLD_MATH_FUNCTIONS || LEGACY_VM_SUPPORT
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/imul
+#if MIN_CHROME_VERSION < 28 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 20 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000 // || MIN_NODE_VERSION < 0.12
+// || MIN_NODE_VERSION < 0.12
 // check for imul support, and also for correctness ( https://bugs.webkit.org/show_bug.cgi?id=126345 )
 if (!Math.imul || Math.imul(0xffffffff, 5) !== -5) Math.imul = function imul(a, b) {
   var ah  = a >>> 16;
@@ -7,7 +11,10 @@ if (!Math.imul || Math.imul(0xffffffff, 5) !== -5) Math.imul = function imul(a, 
   var bl = b & 0xffff;
   return (al*bl + ((ah*bl + al*bh) << 16))|0;
 };
+#endif
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/fround
+#if MIN_CHROME_VERSION < 38 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 26 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // || MIN_NODE_VERSION < 0.12
 #if PRECISE_F32
 #if PRECISE_F32 == 1
 if (!Math.fround) {
@@ -22,7 +29,10 @@ if (!Math.fround) Math.fround = function(x) { return x };
 if (!Math.fround) Math.fround = function(x) { return x };
 #endif
 #endif
+#endif
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/clz32
+#if MIN_CHROME_VERSION < 38 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 31 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED // || MIN_NODE_VERSION < 0.12
 if (!Math.clz32) Math.clz32 = function(x) {
   var n = 32;
   var y = x >> 16; if (y) { n -= 16; x = y; }
@@ -32,18 +42,23 @@ if (!Math.clz32) Math.clz32 = function(x) {
   y = x >> 1; if (y) return n - 2;
   return n - x;
 };
+#endif
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/trunc
+#if MIN_CHROME_VERSION < 38 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 25 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // || MIN_NODE_VERSION < 0.12
 if (!Math.trunc) Math.trunc = function(x) {
   return x < 0 ? Math.ceil(x) : Math.floor(x);
 };
-#else // POLYFILL_OLD_MATH_FUNCTIONS
+#endif
+
+#else // !POLYFILL_OLD_MATH_FUNCTIONS && !LEGACY_VM_SUPPORT:
 #if ASSERTIONS
 assert(Math.imul, 'This browser does not support Math.imul(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
 assert(Math.fround, 'This browser does not support Math.fround(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
 assert(Math.clz32, 'This browser does not support Math.clz32(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
 assert(Math.trunc, 'This browser does not support Math.trunc(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
 #endif
-#endif // LEGACY_VM_SUPPORT
+#endif // POLYFILL_OLD_MATH_FUNCTIONS || LEGACY_VM_SUPPORT
 
 var Math_abs = Math.abs;
 var Math_cos = Math.cos;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3410,8 +3410,6 @@ int main() {
 
     # when legacy is needed, we show an error indicating so
     test('build with LEGACY_VM_SUPPORT')
-    # wasm is on by default, and does not mix with legacy, so we show an error
-    test('LEGACY_VM_SUPPORT is only supported for asm.js, and not wasm. Build with -s WASM=0', ['-s', 'LEGACY_VM_SUPPORT=1'])
     # legacy + disabling wasm works
     if self.is_wasm_backend():
       return


### PR DESCRIPTION
This also adds support for passing `-s LEGACY_VM_SUPPORT=1` in conjunction with `-s WASM=1`, because of the new meaning for `-s LEGACY_VM_SUPPORT=1`, these usages may overlap.