### PR TITLE
Add support for building optimized MINIMAL_RUNTIME code with Wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3292,12 +3292,12 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename,
     if shared.Settings.MIN_SAFARI_VERSION != shared.Settings.TARGET_NOT_SUPPORTED or shared.Settings.ENVIRONMENT_MAY_BE_NODE:
       # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/compileStreaming
       # In Safari and Node.js, WebAssembly.compileStreaming() is not supported, in which case fall back to regular download.
-      download_wasm = "WebAssembly.compileStreaming ? WebAssembly.compileStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm')) : b('{{{ TARGET_BASENAME }}}.wasm')"
+      download_wasm = "WebAssembly.compileStreaming ? WebAssembly.compileStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm')) : binary('{{{ TARGET_BASENAME }}}.wasm')"
     else:
       # WebAssembly.compileStreaming() is unconditionally supported:
       download_wasm = "WebAssembly.compileStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'))"
   else:
-    download_wasm = "b('{{{ TARGET_BASENAME }}}.wasm')"
+    download_wasm = "binary('{{{ TARGET_BASENAME }}}.wasm')"
 
   shell = shell.replace('{{{ DOWNLOAD_WASM }}}', download_wasm)
   shell = shell.replace('{{{ TARGET_BASENAME }}}', target_basename)

--- a/src/library.js
+++ b/src/library.js
@@ -1296,11 +1296,14 @@ LibraryManager.library = {
   },
 
 #if MINIMAL_RUNTIME
+#if WASM_BACKEND == 0
   $abortStackOverflow__deps: ['$stackSave'],
+#endif
   $abortStackOverflow: function(allocSize) {
     abort('Stack overflow! Attempted to allocate ' + allocSize + ' bytes on the stack, but stack has only ' + (STACK_MAX - stackSave() + allocSize) + ' bytes available!');
   },
 
+#if WASM_BACKEND == 0
   $stackAlloc__asm: true,
   $stackAlloc__sig: 'ii',
   $stackAlloc__deps: ['$abortStackOverflow'],
@@ -1328,6 +1331,7 @@ LibraryManager.library = {
     top = top|0;
     STACKTOP = top;
   },
+#endif
 
   $establishStackSpace__asm: true,
   $establishStackSpace__sig: 'vii',

--- a/src/shell_minimal_runtime.html
+++ b/src/shell_minimal_runtime.html
@@ -2,7 +2,7 @@
 <body>
 <canvas style='display:block; margin:auto;'></canvas>
 <script>
-  function b(url) { // Downloads a binary file and outputs it in the specified callback
+  function binary(url) { // Downloads a binary file and outputs it in the specified callback
     return new Promise((ok, err) => {
       var x = new XMLHttpRequest();
       x.open('GET', url, true);
@@ -12,7 +12,7 @@
     });
   }
 
-  function s(url) { // Downloads a script file and adds it to DOM
+  function script(url) { // Downloads a script file and adds it to DOM
     return new Promise((ok, err) => {
       var s = document.createElement('script');
       s.src = url;
@@ -44,7 +44,7 @@ function revokeURL(url) {
 
 #if MODULARIZE && WASM
   // Modularized wasm, no separate .mem init file
-  Promise.all([s('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
+  Promise.all([script('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
     var js = r[0]; // Detour the JS code to a separate variable to avoid instantiating with 'r' as this to avoid strict ECMAScript/Firefox GC problems that cause a leak, see https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
     js({ wasm: r[1] });
   });
@@ -52,14 +52,14 @@ function revokeURL(url) {
 
 #if MODULARIZE && !WASM && !SEPARATE_ASM && MEM_INIT_METHOD == 0
   // Modularize + asm.js embedded in main runtime .js file, no separate .mem init file
-  s('{{{ TARGET_BASENAME }}}.js').then((r) => {
+  script('{{{ TARGET_BASENAME }}}.js').then((r) => {
     r();
   });
 #endif
 
 #if MODULARIZE && !WASM && !SEPARATE_ASM && MEM_INIT_METHOD == 1
   // Modularize + asm.js embedded in main runtime .js file, separate .mem init file
-  Promise.all([s('{{{ TARGET_BASENAME }}}.js'), b('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
+  Promise.all([script('{{{ TARGET_BASENAME }}}.js'), binary('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
     var js = r[0]; // Detour the JS code to a separate variable to avoid instantiating with 'r' as this to avoid strict ECMAScript/Firefox GC problems that cause a leak, see https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
     js({ mem: r[1] });
   });
@@ -67,7 +67,7 @@ function revokeURL(url) {
 
 #if MODULARIZE && !WASM && SEPARATE_ASM && MEM_INIT_METHOD == 0
   // Modularize + asm.js in its own file, no separate .mem init file
-  Promise.all([s('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js')]).then((r) => {
+  Promise.all([script('{{{ TARGET_BASENAME }}}.js'), script('{{{ TARGET_BASENAME }}}.asm.js')]).then((r) => {
     var js = r[0]; // Detour the JS code to a separate variable to avoid instantiating with 'r' as this to avoid strict ECMAScript/Firefox GC problems that cause a leak, see https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
     js({ asm: r[1] });
   });
@@ -75,7 +75,7 @@ function revokeURL(url) {
 
 #if MODULARIZE && !WASM && SEPARATE_ASM && MEM_INIT_METHOD == 1
   // Modularize + asm.js in its own file, separate .mem init file
-  Promise.all([s('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js'), b('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
+  Promise.all([script('{{{ TARGET_BASENAME }}}.js'), script('{{{ TARGET_BASENAME }}}.asm.js'), binary('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
     var js = r[0]; // Detour the JS code to a separate variable to avoid instantiating with 'r' as this to avoid strict ECMAScript/Firefox GC problems that cause a leak, see https://bugzilla.mozilla.org/show_bug.cgi?id=1540101
     js({ asm: r[1], mem: r[2] });
   });
@@ -83,41 +83,41 @@ function revokeURL(url) {
 
 #if !MODULARIZE && WASM
   // No modularize, no separate .mem init file
-  Promise.all([b('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
+  Promise.all([binary('{{{ TARGET_BASENAME }}}.js'), {{{ DOWNLOAD_WASM }}}]).then((r) => {
     Module.wasm = r[1];
     var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
-    s(url).then(() => { revokeURL(url) });
+    script(url).then(() => { revokeURL(url) });
   });
 #endif
 
 #if !MODULARIZE && !WASM && !SEPARATE_ASM && MEM_INIT_METHOD == 0
   // No modularize, asm.js embedded in main runtime .js file, no separate .mem init file
-  s('{{{ TARGET_BASENAME }}}.js');
+  script('{{{ TARGET_BASENAME }}}.js');
 #endif
 
 #if !MODULARIZE && !WASM && !SEPARATE_ASM && MEM_INIT_METHOD == 1
   // No modularize, asm.js embedded in main runtime .js file, separate .mem init file
-  Promise.all([b('{{{ TARGET_BASENAME }}}.js'), b('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
+  Promise.all([binary('{{{ TARGET_BASENAME }}}.js'), binary('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
     Module.mem = r[1];
     var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
-    s(url).then(() => { revokeURL(url) });
+    script(url).then(() => { revokeURL(url) });
   });
 #endif
 
 #if !MODULARIZE && !WASM && SEPARATE_ASM && MEM_INIT_METHOD == 0
   // No modularize, asm.js in its own file, no separate .mem init file
-  Promise.all([b('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js')]).then((r) => {
+  Promise.all([binary('{{{ TARGET_BASENAME }}}.js'), script('{{{ TARGET_BASENAME }}}.asm.js')]).then((r) => {
     var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
-    s(url).then(() => { revokeURL(url) });
+    script(url).then(() => { revokeURL(url) });
   });
 #endif
 
 #if !MODULARIZE && !WASM && SEPARATE_ASM && MEM_INIT_METHOD == 1
   // No modularize, asm.js in its own file, separate .mem init file
-  Promise.all([b('{{{ TARGET_BASENAME }}}.js'), s('{{{ TARGET_BASENAME }}}.asm.js'), b('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
+  Promise.all([binary('{{{ TARGET_BASENAME }}}.js'), script('{{{ TARGET_BASENAME }}}.asm.js'), binary('{{{ TARGET_BASENAME }}}.mem')]).then((r) => {
     Module.mem = r[2];
     var url = URL.createObjectURL(new Blob([r[0]], { type: 'application/javascript' }));
-    s(url).then(() => { revokeURL(url) });
+    script(url).then(() => { revokeURL(url) });
   });
 #endif
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8163,8 +8163,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @no_lsan('TODO: LSan with MINIMAL_RUNTIME')
   @no_wasm2js('TODO: MINIMAL_RUNTIME with WASM2JS')
   def test_minimal_runtime_hello_world(self):
-    if '-O2' in self.emcc_args or '-O3' in self.emcc_args or '-Os' in self.emcc_args or '-Oz' in self.emcc_args:
-      return self.skipTest('TODO: -O2 and higher with wasm backend')
     self.banned_js_engines = [V8_ENGINE, SPIDERMONKEY_ENGINE] # TODO: Support for non-Node.js shells has not yet been added to MINIMAL_RUNTIME
     for args in [[], ['-s', 'MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION=1'], ['-s', 'DECLARE_ASM_MODULE_EXPORTS=0']]:
       self.emcc_args = ['-s', 'MINIMAL_RUNTIME=1'] + args

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9563,11 +9563,11 @@ int main () {
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'MAX_WEBGL_VERSION=2']
 
     test_cases = [
-      (asmjs + opts, hello_world_sources, {'a.html': 1453, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
-      (opts, hello_world_sources, {'a.html': 1415, 'a.js': 604, 'a.wasm': 86}),
-      (asmjs + opts, hello_webgl_sources, {'a.html': 1581, 'a.js': 4880, 'a.asm.js': 11139, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 1537, 'a.js': 4837, 'a.wasm': 8841}),
-      (opts, hello_webgl2_sources, {'a.html': 1537, 'a.js': 5324, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
+      (asmjs + opts, hello_world_sources, {'a.html': 1483, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
+      (opts, hello_world_sources, {'a.html': 1440, 'a.js': 604, 'a.wasm': 86}),
+      (asmjs + opts, hello_webgl_sources, {'a.html': 1606, 'a.js': 4880, 'a.asm.js': 11139, 'a.mem': 321}),
+      (opts, hello_webgl_sources, {'a.html': 1557, 'a.js': 4837, 'a.wasm': 8841}),
+      (opts, hello_webgl2_sources, {'a.html': 1557, 'a.js': 5324, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
     ]
 
     success = True

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -445,6 +445,12 @@ function applyImportAndExportNameChanges(ast) {
           setLiteralValue(value.property, mapping[name]);
         }
       }
+    } else if (node.type === 'CallExpression' && isAsmUse(node.callee)) { // asm["___wasm_call_ctors"](); -> asm["M"]();
+      var callee = node.callee;
+      var name = callee.property.value;
+      if (mapping[name]) {
+        setLiteralValue(callee.property, mapping[name]);
+      }
     } else if (isModuleAsmUse(node)) {
       var prop = node.property;
       var name = prop.value;


### PR DESCRIPTION
Adds support for >= -O2 and >= -Os builds, properly minimizing exports for Wasm backend.