### PR TITLE
Make dlmalloc and emmalloc align to max_align_t

### DIFF
--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -26,6 +26,12 @@
 #define USE_SPIN_LOCKS 0 // Ensure we use pthread_mutex_t.
 #endif
 
+/* `mallloc`ed pointers must be aligned at least as strictly as max_align_t. */
+#ifndef MALLOC_ALIGNMENT
+#include <stddef.h>
+#define MALLOC_ALIGNMENT (__alignof__(max_align_t))
+#endif
+
 #endif
 
 

--- a/system/lib/emmalloc.cpp
+++ b/system/lib/emmalloc.cpp
@@ -40,6 +40,7 @@
  *    malloc.
  */
 
+#include <stddef.h>
 #include <stdint.h>
 #include <unistd.h>
 #include <memory.h>
@@ -61,7 +62,7 @@ extern "C"
 
 // Configuration: specifies the minimum alignment that malloc()ed memory outputs. Allocation requests with smaller alignment
 // than this will yield an allocation with this much alignment.
-#define MALLOC_ALIGNMENT 8
+#define MALLOC_ALIGNMENT __alignof__(max_align_t)
 
 // Configuration: If EMMALLOC_USE_64BIT_OPS is specified, emmalloc uses 64 buckets for free memory regions instead of just 32.
 // When building to target asm.js/wasm2js, 64-bit ops are disabled, but in Wasm builds, 64-bit ops are enabled. (this is

--- a/tests/core/test_emmalloc.cpp
+++ b/tests/core/test_emmalloc.cpp
@@ -114,7 +114,7 @@ void test_realloc() {
     // realloc copies
     char* ptr = (char*)malloc(10);
     *ptr = 123;
-    for (int i = 5; i <= 16; i++) {
+    for (int i = 5; i <= 24; i++) {
       char* temp = (char*)realloc(ptr, i);
       assert(*temp == 123);
       assert(temp == ptr);
@@ -123,7 +123,7 @@ void test_realloc() {
     malloc(1);
     malloc(100);
     {
-      char* temp = (char*)realloc(ptr, 17);
+      char* temp = (char*)realloc(ptr, 25);
       assert(*temp == 123);
       assert(temp != ptr);
       ptr = temp;

--- a/tests/core/test_malloc_alignment.c
+++ b/tests/core/test_malloc_alignment.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <assert.h>
+#include <stdalign.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    for(int i = 0; i < 16; ++i) {
+        void *p = malloc(i);
+        assert(((uintptr_t)p & (alignof(max_align_t) - 1)) == 0);
+    }
+
+    return 0;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8570,6 +8570,16 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['-DPOOL']
     test()
 
+  @parameterized({
+    'dlmalloc': ['dlmalloc'],
+    'emmalloc': ['emmalloc'],
+  })
+  def test_malloc_alignment(self, malloc):
+    self.set_setting('MALLOC', malloc)
+    self.emcc_args += ['-std=gnu11']
+    src = open(path_from_root('tests', 'core', 'test_malloc_alignment.c')).read()
+    self.do_run(src, '', basename='src.c')
+
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None):


### PR DESCRIPTION
Fixes #10072

emmalloc also had a small bug: it could return misaligned pointers if base alignment is greater than 8. I fixed that as well. 