### PR TITLE
Enable MINIMAL_RUNTIME code size tests for Wasm backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - run:
           name: embuilder (LTO)
           command: |
-            python3 ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libdlmalloc-debug libemmalloc libemmalloc-64bit libpthread_stub libc_rt_wasm struct_info libc-wasm --lto
+            python3 ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libpthread_stub libc_rt_wasm struct_info libc-wasm --lto
             python3 tests/runner.py test_hello_world
       - run:
           name: embuilder (PIC)
@@ -60,7 +60,7 @@ commands:
       - run:
           name: embuilder (PIC+LTO)
           command: |
-            python3 ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libdlmalloc-debug libemmalloc libemmalloc-64bit libpthread_stub libc_rt_wasm struct_info libc-wasm --pic --lto
+            python3 ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libpthread_stub libc_rt_wasm struct_info libc-wasm --pic --lto
             python3 tests/runner.py test_hello_world
       - run:
           name: freeze cache
@@ -496,9 +496,11 @@ jobs:
   test-upstream-other-mac:
     macos:
       xcode: "9.0"
+    environment:
+      EMCC_DEBUG: "1"
     steps:
       - run-tests-mac:
-          test_targets: "other skip:other.test_native_link_error_message skip:other.test_emcc_v"
+          test_targets: "other.test_minimal_runtime_code_size"
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -496,11 +496,9 @@ jobs:
   test-upstream-other-mac:
     macos:
       xcode: "9.0"
-    environment:
-      EMCC_DEBUG: "1"
     steps:
       - run-tests-mac:
-          test_targets: "other.test_minimal_runtime_code_size"
+          test_targets: "other skip:other.test_native_link_error_message skip:other.test_emcc_v"
 
 workflows:
   build-test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ commands:
       - run:
           name: embuilder (LTO)
           command: |
-            python3 ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libpthread_stub libc_rt_wasm struct_info libc-wasm --lto
+            python3 ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libdlmalloc-debug libemmalloc libemmalloc-64bit libpthread_stub libc_rt_wasm struct_info libc-wasm --lto
             python3 tests/runner.py test_hello_world
       - run:
           name: embuilder (PIC)
@@ -60,7 +60,7 @@ commands:
       - run:
           name: embuilder (PIC+LTO)
           command: |
-            python3 ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libpthread_stub libc_rt_wasm struct_info libc-wasm --pic --lto
+            python3 ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libdlmalloc-debug libemmalloc libemmalloc-64bit libpthread_stub libc_rt_wasm struct_info libc-wasm --pic --lto
             python3 tests/runner.py test_hello_world
       - run:
           name: freeze cache

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2388,7 +2388,11 @@ var LibraryJSEvents = {
   // for all the messages, one of which is this GL-using one. This won't be
   // called if GL is not linked in, but also make sure to not add a dep on
   // GL unnecessarily from here, as that would cause a linker error.
-  emscripten_webgl_do_create_context__deps: maybeAddGLDep(['$JSEvents', '_emscripten_webgl_power_preferences', '_findEventTarget', '_findCanvasEventTarget']),
+  emscripten_webgl_do_create_context__deps: [
+#if LibraryManager.has('library_webgl.js')
+  '$GL',
+#endif
+  '$JSEvents', '_emscripten_webgl_power_preferences', '_findEventTarget', '_findCanvasEventTarget'],
   // This function performs proxying manually, depending on the style of context that is to be created.
   emscripten_webgl_do_create_context: function(target, attributes) {
 #if ASSERTIONS

--- a/src/modules.js
+++ b/src/modules.js
@@ -526,16 +526,3 @@ var PassManager = {
     */
   }
 };
-
-// Given a list of dependencies, maybe add GL to it, if it was linked in
-// (note that the item with this list of dependencies should not call GL code
-// if it is not; this just avoids even adding a dependency that would error).
-// This only matters in strict mode (specifically AUTO_JS_LIBRARIES=0), as in
-// non-strict mode the GL library is always linked in anyhow.
-function maybeAddGLDep(deps) {
-  if (AUTO_JS_LIBRARIES ||
-      SYSTEM_JS_LIBRARIES.indexOf('library_webgl.js') >= 0) {
-    deps.push('$GL');
-  }
-  return deps;
-}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9582,9 +9582,9 @@ int main () {
 
     if self.is_wasm_backend():
       test_cases = [
-        (opts, hello_world_sources, {'a.html': 1440, 'a.js': 484, 'a.wasm': 176}),
-        (opts, hello_webgl_sources, {'a.html': 1557, 'a.js': 4659, 'a.wasm': 11918}),
-        (opts, hello_webgl2_sources, {'a.html': 1557, 'a.js': 5168, 'a.wasm': 11918}) # Compare how WebGL2 sizes stack up with WebGL 1
+        (opts, hello_world_sources, {'a.html': 1445, 'a.js': 455, 'a.wasm': 176}),
+        (opts, hello_webgl_sources, {'a.html': 1565, 'a.js': 4636, 'a.wasm': 11918}),
+        (opts, hello_webgl2_sources, {'a.html': 1565, 'a.js': 5143, 'a.wasm': 11918}) # Compare how WebGL2 sizes stack up with WebGL 1
       ]
     else:
       test_cases = [

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9545,7 +9545,6 @@ int main () {
           test(['-s', 'WASM=0'], closure, opt)
           test(['-s', 'WASM=1', '-s', 'WASM_ASYNC_COMPILATION=0'], closure, opt)
 
-  @no_wasm_backend('tests asmjs, sizes sensitive to fastcomp')
   def test_minimal_runtime_code_size(self):
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'AGGRESSIVE_VARIABLE_ELIMINATION=1',
@@ -9581,13 +9580,20 @@ int main () {
                            '-s', 'MODULARIZE=1']
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'MAX_WEBGL_VERSION=2']
 
-    test_cases = [
-      (asmjs + opts, hello_world_sources, {'a.html': 1483, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
-      (opts, hello_world_sources, {'a.html': 1440, 'a.js': 604, 'a.wasm': 86}),
-      (asmjs + opts, hello_webgl_sources, {'a.html': 1606, 'a.js': 4880, 'a.asm.js': 11139, 'a.mem': 321}),
-      (opts, hello_webgl_sources, {'a.html': 1557, 'a.js': 4837, 'a.wasm': 8841}),
-      (opts, hello_webgl2_sources, {'a.html': 1557, 'a.js': 5324, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
-    ]
+    if self.is_wasm_backend():
+      test_cases = [
+        (opts, hello_world_sources, {'a.html': 1440, 'a.js': 484, 'a.wasm': 176}),
+        (opts, hello_webgl_sources, {'a.html': 1557, 'a.js': 4659, 'a.wasm': 11918}),
+        (opts, hello_webgl2_sources, {'a.html': 1557, 'a.js': 5168, 'a.wasm': 11918}) # Compare how WebGL2 sizes stack up with WebGL 1
+      ]
+    else:
+      test_cases = [
+        (asmjs + opts, hello_world_sources, {'a.html': 1483, 'a.js': 289, 'a.asm.js': 113, 'a.mem': 6}),
+        (opts, hello_world_sources, {'a.html': 1440, 'a.js': 604, 'a.wasm': 86}),
+        (asmjs + opts, hello_webgl_sources, {'a.html': 1606, 'a.js': 4880, 'a.asm.js': 11139, 'a.mem': 321}),
+        (opts, hello_webgl_sources, {'a.html': 1557, 'a.js': 4837, 'a.wasm': 8841}),
+        (opts, hello_webgl2_sources, {'a.html': 1557, 'a.js': 5324, 'a.wasm': 8841}) # Compare how WebGL2 sizes stack up with WebGL 1
+      ]
 
     success = True
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9576,7 +9576,7 @@ int main () {
                            path_from_root('tests', 'minimal_webgl', 'webgl.c'),
                            '--js-library', path_from_root('tests', 'minimal_webgl', 'library_js.js'),
                            '-s', 'RUNTIME_FUNCS_TO_IMPORT=[]',
-                           '-s', 'USES_DYNAMIC_ALLOC=2', '-lGL',
+                           '-s', 'USES_DYNAMIC_ALLOC=2', '-lwebgl.js',
                            '-s', 'MODULARIZE=1']
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'MAX_WEBGL_VERSION=2']
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2890,7 +2890,9 @@ class Building(object):
     library_files = []
     if library_name in js_system_libraries:
       if len(js_system_libraries[library_name]):
-        library_files += js_system_libraries[library_name] if isinstance(js_system_libraries[library_name], list) else [js_system_libraries[library_name]]
+        lib = js_system_libraries[library_name] if isinstance(js_system_libraries[library_name], list) else [js_system_libraries[library_name]]
+        library_files += lib
+        logger.debug('Linking in JS library ' + str(lib))
 
     elif library_name.endswith('.js') and os.path.isfile(path_from_root('src', 'library_' + library_name)):
       library_files += ['library_' + library_name]


### PR DESCRIPTION
Wasm backend seems to be about +30% bigger compared to fastcomp backend, haven't really digged in to what causes the differences, and if it's a constant/one-off size diff or a linear one. That's something to investigate later, but this establishes a good baseline.