### PR TITLE
Enable running benchmark suite in Node.js

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -330,6 +330,10 @@ if V8_ENGINE and V8_ENGINE in shared.JS_ENGINES:
   benchmarkers += [
     EmscriptenBenchmarker(os.environ.get('EMBENCH_NAME') or 'v8', V8_ENGINE),
   ]
+if shared.NODE_JS and shared.NODE_JS in shared.JS_ENGINES:
+  benchmarkers += [
+    EmscriptenBenchmarker('Node.js', shared.NODE_JS),
+  ]
 if os.path.exists(CHEERP_BIN):
   benchmarkers += [
     # CheerpBenchmarker('cheerp-sm-wasm', SPIDERMONKEY_ENGINE + ['--no-wasm-baseline']),


### PR DESCRIPTION
In default setup, running `python tests/runner.py benchmark` fails with "error, no benchmarkers", as people don't generally have V8 or SpiderMonkey installed.

This PR enables running benchmarks in Node.js, not sure why this didn't exist? Perhaps the benchmarking config dates back to when Node.js did not yet support Wasm?