### PR TITLE
Remove hardcoded transfer of OffscreenCanvas Module['canvas'] with the OffscreenCanvas API

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1484,6 +1484,11 @@ var EMBIND_STD_STRING_IS_UTF8 = 1;
 // contexts. This needs browser support for the OffscreenCanvas specification.
 var OFFSCREENCANVAS_SUPPORT = 0;
 
+// If you are using PROXY_TO_PTHREAD with OFFSCREENCANVAS_SUPPORT, then specify
+// here a comma separated list of CSS ID selectors to canvases to proxy over
+// to the pthread at program startup, e.g. '#canvas1, #canvas2'.
+var OFFSCREENCANVASES_TO_PTHREAD = "#canvas";
+
 // If set to 1, enables support for WebGL contexts to render to an offscreen
 // render target, to avoid the implicit swap behavior of WebGL where exiting any
 // event callback would automatically perform a "flip" to present rendered

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -946,19 +946,10 @@ int EMSCRIPTEN_KEEPALIVE proxy_main(int argc, char** argv) {
 #define EMSCRIPTEN_PTHREAD_STACK_SIZE (128 * 1024)
 
     pthread_attr_setstacksize(&attr, (EMSCRIPTEN_PTHREAD_STACK_SIZE));
-    // TODO: Add a -s PROXY_CANVASES_TO_THREAD=parameter or similar to allow configuring this
-#ifdef EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES
-    // If user has defined EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES, then transfer those canvases
-    // over to the pthread.
-    emscripten_pthread_attr_settransferredcanvases(
-      &attr, (EMSCRIPTEN_PTHREAD_TRANSFERRED_CANVASES));
-#else
-    // Otherwise by default, transfer whatever is set to Module.canvas, because in PROXY_TO_PTHREAD
-    // mode this is the only chance - this is the only pthread_create call that happens on the
-    // main thread, so it's the only chance to transfer the canvas from there.
-    if (EM_ASM_INT(return !!(Module['canvas'])))
-      emscripten_pthread_attr_settransferredcanvases(&attr, "#canvas");
-#endif
+    // Pass special ID -1 to the list of transferred canvases to denote that the thread creation
+    // should instead take a list of canvases that are specified from the command line with
+    // -s OFFSCREENCANVASES_TO_PTHREAD linker flag.
+    emscripten_pthread_attr_settransferredcanvases(&attr, (const char*)-1);
     _main_arguments.argc = argc;
     _main_arguments.argv = argv;
     pthread_t thread;


### PR DESCRIPTION
Remove hardcoded canvas proxying to pthread, and add linker flag -s OFFSCREENCANVASES_TO_PTHREAD='...' to specify which canvases to transfer. Default to transferring canvas with CSS ID 'canvas'.