### PR TITLE
Enable using -s EXIT_RUNTIME=0/1 when paired with -s PROXY_TO_PTHREAD=1 option.

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -408,6 +408,7 @@ var LibraryPThread = {
               if (detached) {
                 PThread.returnWorkerToPool(worker);
               }
+#if EXIT_RUNTIME // If building with -s EXIT_RUNTIME=0, no thread will post this message, so don't even compile it in.
             } else if (cmd === 'exitProcess') {
               // A pthread has requested to exit the whole application process (runtime).
               noExitRuntime = false;
@@ -417,6 +418,7 @@ var LibraryPThread = {
                 if (e instanceof ExitStatus) return;
                 throw e;
               }
+#endif
             } else if (cmd === 'cancelDone') {
               PThread.returnWorkerToPool(worker);
             } else if (cmd === 'objectTransfer') {
@@ -1228,7 +1230,9 @@ var LibraryPThread = {
 
   __call_main: function(argc, argv) {
     var returnCode = _main(argc, argv);
+#if EXIT_RUNTIME
     if (!noExitRuntime) postMessage({ 'cmd': 'exitProcess', 'returnCode': returnCode });
+#endif
     return returnCode;
   },
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -238,6 +238,9 @@ function callMain(args) {
     Module.realPrint('main() took ' + (Date.now() - start) + ' milliseconds');
 #endif
 
+    // In PROXY_TO_PTHREAD builds, we should never exit the runtime below, as execution is asynchronously handed
+    // off to a pthread.
+#if !PROXY_TO_PTHREAD
 #if EMTERPRETIFY_ASYNC || (WASM_BACKEND && ASYNCIFY)
     // if we are saving the stack, then do not call exit, we are not
     // really exiting now, just unwinding the JS stack
@@ -270,6 +273,7 @@ function callMain(args) {
       err('exception thrown: ' + toLog);
       quit_(1, e);
     }
+#endif // !PROXY_TO_PTHREAD
   } finally {
     calledMain = true;
   }

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -937,7 +937,6 @@ int EMSCRIPTEN_KEEPALIVE proxy_main(int argc, char** argv) {
       // Proceed by running main() on the main browser thread as a fallback.
       return __call_main(_main_arguments.argc, _main_arguments.argv);
     }
-    EM_ASM(noExitRuntime = true);
     return 0;
   } else {
     return __call_main(_main_arguments.argc, _main_arguments.argv);


### PR DESCRIPTION
Enable using -s EXIT_RUNTIME=1 when paired with -s PROXY_TO_PTHREAD=1. Previously PROXY_TO_PTHREAD=1 always implied EXIT_RUNTIME=0, and in this build mode, EXIT_RUNTIME=0 would specify the behavior of what the main browser thread would do after calling __proxy_main(). I.e. the main browser thread should not exit when the internal __proxy_main() function has been called. Users did not have a possibility to do -s PROXY_TO_PTHREAD=1 -s EXIT_RUNTIME=1 builds at all.

After this change, -s EXIT_RUNTIME=0/1 now applies to the main() function instead, like one would expect: specifying -s EXIT_RUNTIME=1 means that the application will quit immediately when the proxied main() returns. Specifying -s EXIT_RUNTIME=0 means that the application will continue on executing after the proxied main() returns.