### PR TITLE
Make emrun_postjs.js compile with closure

### DIFF
--- a/src/emrun_postjs.js
+++ b/src/emrun_postjs.js
@@ -4,13 +4,13 @@
 // found in the LICENSE file.
 
 if (typeof window === "object" && (typeof ENVIRONMENT_IS_PTHREAD === 'undefined' || !ENVIRONMENT_IS_PTHREAD)) {
-  function emrun_register_handlers() {
+  var emrun_register_handlers = function() {
     // When C code exit()s, we may still have remaining stdout and stderr messages in flight. In that case, we can't close
     // the browser until all those XHRs have finished, so the following state variables track that all communication is done,
     // after which we can close.
     var emrun_num_post_messages_in_flight = 0;
     var emrun_should_close_itself = false;
-    function postExit(msg) {
+    var postExit = function(msg) {
       var http = new XMLHttpRequest();
       // Don't do this immediately, this may race with the notification about the return code reaching the
       // server. Send a *sync* xhr so that we know for sure that the server has gotten the return code
@@ -22,8 +22,8 @@ if (typeof window === "object" && (typeof ENVIRONMENT_IS_PTHREAD === 'undefined'
         // and then emrun does not need to kill the whole browser process.
         window.close();
       } catch(e) {}
-    }
-    function post(msg) {
+    };
+    var post = function(msg) {
       var http = new XMLHttpRequest();
       ++emrun_num_post_messages_in_flight;
       http.onreadystatechange = function() {
@@ -33,38 +33,37 @@ if (typeof window === "object" && (typeof ENVIRONMENT_IS_PTHREAD === 'undefined'
       }
       http.open("POST", "stdio.html", true);
       http.send(msg);
-    }
+    };
     // If the address contains localhost, or we are running the page from port 6931, we can assume we're running the test runner and should post stdout logs.
     if (document.URL.search("localhost") != -1 || document.URL.search(":6931/") != -1) {
       var emrun_http_sequence_number = 1;
       var prevPrint = out;
       var prevErr = err;
-      function emrun_exit() { if (emrun_num_post_messages_in_flight == 0) postExit('^exit^'+EXITSTATUS); else emrun_should_close_itself = true; };
-      Module['addOnExit'](emrun_exit);
-      out = function emrun_print(text) { post('^out^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevPrint(text); }
-      err = function emrun_printErr(text) { post('^err^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevErr(text); }
+      Module['addOnExit'](function() { if (emrun_num_post_messages_in_flight == 0) postExit('^exit^'+EXITSTATUS); else emrun_should_close_itself = true; });
+      out = function(text) { post('^out^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevPrint(text); };
+      err = function(text) { post('^err^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevErr(text); };
 
       // Notify emrun web server that this browser has successfully launched the page. Note that we may need to
       // wait for the server to be ready.
-      function tryToSendPageload() {
+      var tryToSendPageload = function() {
         try {
           post('^pageload^');
         } catch (e) {
           setTimeout(tryToSendPageload, 50);
         }
-      }
+      };
       tryToSendPageload();
     }
-  }
+  };
 
   // POSTs the given binary data represented as a (typed) array data back to the emrun-based web server.
   // To use from C code, call e.g. EM_ASM({emrun_file_dump("file.dat", HEAPU8.subarray($0, $0 + $1));}, my_data_pointer, my_data_pointer_byte_length);
-  function emrun_file_dump(filename, data) {
+  var emrun_file_dump = function(filename, data) {
     var http = new XMLHttpRequest();
     out('Dumping out file "' + filename + '" with ' + data.length + ' bytes of data.');
     http.open("POST", "stdio.html?file=" + filename, true);
     http.send(data); // XXX  this does not work in workers, for some odd reason (issue #2681)
-  }
+  };
 
   if (typeof Module !== 'undefined' && typeof document !== 'undefined') emrun_register_handlers();
 }


### PR DESCRIPTION
Block-scoped function declarations are an ES6 feature; closure is set up to treat the input as ES5.

```
/tmp/emscripten_temp_2G6Cuu/taisei.wasm.o.js.pp.js.jso.js.jso.js.jso.js:18641: ERROR - This language feature is only supported for ECMASCRIPT6 mode or better: block-scoped function declaration.
 function emrun_register_handlers() {
 ^

/tmp/emscripten_temp_2G6Cuu/taisei.wasm.o.js.pp.js.jso.js.jso.js.jso.js:18667: ERROR - This language feature is only supported for ECMASCRIPT6 mode or better: block-scoped function declaration.
   function emrun_exit() {
   ^

/tmp/emscripten_temp_2G6Cuu/taisei.wasm.o.js.pp.js.jso.js.jso.js.jso.js:18679: ERROR - This language feature is only supported for ECMASCRIPT6 mode or better: block-scoped function declaration.
   function tryToSendPageload() {
   ^

3 error(s), 0 warning(s)
shared:ERROR: closure compiler failed (rc: 3.)
FAILED: src/taisei.html src/taisei.wasm src/taisei.js
```