### PR TITLE
Typo - fastomp to fastcomp [ci skip]

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -46,7 +46,7 @@
 // libraries and other support code, so all flags are either link or
 // compile+link.
 //
-// The [fastomp-only] annotation means that a flag only affects code generation
+// The [fastcomp-only] annotation means that a flag only affects code generation
 // in fastcomp.
 //
 
@@ -134,7 +134,7 @@ var ABORTING_MALLOC = 1;
 // If 1, generated a version of memcpy() and memset() that unroll their
 // copy sizes. If 0, optimizes for size instead to generate a smaller memcpy.
 // This flag only has effect when targeting asm.js.
-// [fastomp-only]
+// [fastcomp-only]
 var FAST_UNROLLED_MEMCPY_AND_MEMSET = 1;
 
 // If false, we abort with an error if we try to allocate more memory than
@@ -205,7 +205,7 @@ var GLOBAL_BASE = -1;
 // load-store will make JS engines alter it if it is being stored to a typed
 // array for security reasons. That will 'fix' the number from being a NaN or an
 // infinite number.
-// [fastomp-only]
+// [fastcomp-only]
 var DOUBLE_MODE = 1;
 
 // Warn at compile time about instructions that LLVM tells us are not fully
@@ -232,7 +232,7 @@ var WARN_UNALIGNED = 0;
 //           all modern browsers, including Firefox, Chrome and Safari, but in IE is only
 //           present in IE11 and above. Therefore if you need to support legacy versions of
 //           IE, you should not enable PRECISE_F32 1 or 2.
-// [fastomp-only]
+// [fastcomp-only]
 // With upstream backend and WASM=0, JS output always uses Math.fround for consistent
 // behavior with WebAssembly.
 var PRECISE_F32 = 0;
@@ -271,11 +271,11 @@ var IGNORE_CLOSURE_COMPILER_ERRORS = 0;
 var INLINING_LIMIT = 0;
 
 // Run aggressiveVariableElimination in js-optimizer.js
-// [fastomp-only]
+// [fastcomp-only]
 var AGGRESSIVE_VARIABLE_ELIMINATION = 0;
 
 // Whether to simplify ifs in js-optimizer.js
-// [fastomp-only]
+// [fastcomp-only]
 var SIMPLIFY_IFS = 1;
 
 // Check each write to the heap, for example, this will give a clear
@@ -294,7 +294,7 @@ var RESERVED_FUNCTION_POINTERS = 0;
 // Whether to allow function pointers to alias if they have a different type.
 // This can greatly decrease table sizes in asm.js, but can break code that
 // compares function pointers across different types.
-// [fastomp-only]
+// [fastcomp-only]
 var ALIASING_FUNCTION_POINTERS = 0;
 
 // asm.js: By default we implement function pointers using asm.js function
@@ -315,7 +315,7 @@ var ALIASING_FUNCTION_POINTERS = 0;
 // efficient. When enabling emulation, we also use the Table *outside* the wasm
 // module, exactly as when emulating in asm.js, just replacing the plain JS
 // array with a Table.
-// [fastomp-only]
+// [fastcomp-only]
 var EMULATED_FUNCTION_POINTERS = 0;
 
 // Allows function pointers to be cast, wraps each call of an incorrect type
@@ -1045,13 +1045,13 @@ var BENCHMARK = 0;
 
 // If 1, generate code in asm.js format. If 2, emits the same code except for
 // omitting 'use asm'.
-// [fastomp-only]
+// [fastcomp-only]
 var ASM_JS = 1;
 
 // If 1, will finalize the final emitted code, including operations that prevent
 // later js optimizer passes from running, like converting +5 into 5.0 (the js
 // optimizer sees 5.0 as just 5).
-// [fastomp-only]
+// [fastcomp-only]
 var FINALIZE_ASM_JS = 1;
 
 // If 1, then all exports from the asm/wasm module will be accessed indirectly,
@@ -1064,7 +1064,7 @@ var FINALIZE_ASM_JS = 1;
 var SWAPPABLE_ASM_MODULE = 0;
 
 // see emcc --separate-asm
-// [fastomp-only]
+// [fastcomp-only]
 var SEPARATE_ASM = 0;
 
 // JS library functions on this list are not converted to JS, and calls to them
@@ -1103,7 +1103,7 @@ var EXPORT_NAME = 'Module';
 var DYNAMIC_EXECUTION = 1;
 
 // Runs tools/emterpretify on the compiler output.
-// [fastomp-only]
+// [fastcomp-only]
 var EMTERPRETIFY = 0;
 
 // If defined, a file to write bytecode to, otherwise the default is to embed it
@@ -1113,22 +1113,22 @@ var EMTERPRETIFY = 0;
 // Module.emterpreterFile contains an ArrayBuffer with the bytecode, when the
 // code loads.  Note: You might need to quote twice in the shell, something like
 // -s 'EMTERPRETIFY_FILE="waka"'
-// [fastomp-only]
+// [fastcomp-only]
 var EMTERPRETIFY_FILE = '';
 
 // Functions to not emterpret, that is, to run normally at full speed
-// [fastomp-only]
+// [fastcomp-only]
 var EMTERPRETIFY_BLACKLIST = [];
 
 // If this contains any functions, then only the functions in this list are
 // emterpreted (as if all the rest are blacklisted; this overrides the
 // BLACKLIST)
-// [fastomp-only]
+// [fastcomp-only]
 var EMTERPRETIFY_WHITELIST = [];
 
 // Allows sync code in the emterpreter, by saving the call stack, doing an async
 // delay, and resuming it
-// [fastomp-only]
+// [fastcomp-only]
 var EMTERPRETIFY_ASYNC = 0;
 
 // Performs a static analysis to suggest which functions should be run in the
@@ -1136,12 +1136,12 @@ var EMTERPRETIFY_ASYNC = 0;
 // called in the EMTERPRETIFY_ASYNC option.  After showing the suggested list,
 // compilation will halt. You can apply the provided list as an emcc argument
 // when compiling later.
-// [fastomp-only]
+// [fastcomp-only]
 var EMTERPRETIFY_ADVISE = 0;
 
 // If you have additional custom synchronous functions, add them to this list
 // and the advise mode will include them in its analysis.
-// [fastomp-only]
+// [fastcomp-only]
 var EMTERPRETIFY_SYNCLIST = [];
 
 // whether js opts will be run, after the main compiler
@@ -1229,7 +1229,7 @@ var BINARYEN_IGNORE_IMPLICIT_TRAPS = 0;
 //   allow: allow creating operations that can trap. this is the most
 //          compact, as we just emit a single wasm operation, with no
 //          guards to trapping values, and also often the fastest.
-// [fastomp-only]
+// [fastcomp-only]
 var BINARYEN_TRAP_MODE = "allow";
 
 // A comma-separated list of passes to run in the binaryen optimizer, for
@@ -1420,7 +1420,7 @@ var MEMORYPROFILER = 0;
 // This option is quite slow to run, as it processes and hashes all methods in
 // the codebase in multiple passes.
 //
-// [fastomp-only]
+// [fastcomp-only]
 var ELIMINATE_DUPLICATE_FUNCTIONS = 0; // disabled by default
 var ELIMINATE_DUPLICATE_FUNCTIONS_DUMP_EQUIVALENT_FUNCTIONS = 0;
 var ELIMINATE_DUPLICATE_FUNCTIONS_PASSES = 5;
@@ -1462,11 +1462,11 @@ var ELIMINATE_DUPLICATE_FUNCTIONS_PASSES = 5;
 var EVAL_CTORS = 0;
 
 // see http://kripken.github.io/emscripten-site/docs/debugging/CyberDWARF.html
-// [fastomp-only]
+// [fastcomp-only]
 var CYBERDWARF = 0;
 
 // Path to the CyberDWARF debug file passed to the compiler
-// [fastomp-only]
+// [fastcomp-only]
 var BUNDLED_CD_DEBUG_FILE = "";
 
 // Is enabled, use the JavaScript TextDecoder API for string marshalling.


### PR DESCRIPTION
Spotted by @gabrielcuvillier.