### PR TITLE
FS - Support both '/path' and '/path/' for directories

### DIFF
--- a/src/library_path.js
+++ b/src/library_path.js
@@ -64,11 +64,9 @@ mergeInto(LibraryManager.library, {
       return root + dir;
     },
     basename: function(path) {
-      // EMSCRIPTEN return '/'' for '/', not an empty string
+      // EMSCRIPTEN return '/' for '/', not an empty string
       if (path === '/') return '/';
-      var lastSlash = path.lastIndexOf('/', path.length-2); //support both '/path' and '/path/'
-      if (lastSlash === -1) return path;
-      return path.substr(lastSlash+1);
+      return path.split('/').filter(function(item) {return item}).pop();
     },
     extname: function(path) {
       return PATH.splitPath(path)[3];

--- a/src/library_path.js
+++ b/src/library_path.js
@@ -66,7 +66,7 @@ mergeInto(LibraryManager.library, {
     basename: function(path) {
       // EMSCRIPTEN return '/'' for '/', not an empty string
       if (path === '/') return '/';
-      var lastSlash = path.lastIndexOf('/');
+      var lastSlash = path.lastIndexOf('/', path.length-2); //support both '/path' and '/path/'
       if (lastSlash === -1) return path;
       return path.substr(lastSlash+1);
     },


### PR DESCRIPTION
Previously trying to do something like `FS.mkdir('/a_directory/');` would throw. I think this change should fix all the related functions, since this seems to be the common point.