### PR TITLE
Fix race condition in emar

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -55,6 +55,7 @@ def run():
       else:
         out_arg_index = 2
 
+      target_full_name = os.path.abspath(newargs[out_arg_index])
       # Add a hash to colliding basename, to make them unique.
       for j in range(out_arg_index + 1, len(newargs)):
         orig_name = newargs[j]
@@ -62,9 +63,10 @@ def run():
         dirname = os.path.dirname(full_name)
         basename = os.path.basename(full_name)
 
-        h = hashlib.md5(full_name.encode('utf-8')).hexdigest()[:8]
+        h1 = hashlib.md5(full_name.encode('utf-8')).hexdigest()[:8]
+        h2 = hashlib.md5(target_full_name.encode('utf-8')).hexdigest()[:8]
         parts = basename.split('.')
-        parts[0] += '_' + h
+        parts[0] += '_' + h1 + '_' + h2
         newname = '.'.join(parts)
         full_newname = os.path.join(dirname, newname)
         try:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1564,7 +1564,7 @@ int f() {
     self.assertEqual(text.count('common_'), 2)
     for line in text.split('\n'):
       # should not have huge hash names
-      self.assertLess(len(line), 20, line)
+      self.assertLess(len(line), 30, line)
 
     create_test_file('main.c', r'''
       void a(void);


### PR DESCRIPTION
Fixes #10151 by adding a second hash suffix based on the target's full path, not just object's full path. 