### PR TITLE
Add diagnostics for thread quitting behavior.

### DIFF
--- a/tests/pthread/hello_thread.c
+++ b/tests/pthread/hello_thread.c
@@ -7,6 +7,7 @@
 
 #include <pthread.h>
 #include <emscripten.h>
+#include <emscripten/html5.h>
 
 void *thread_main(void *arg)
 {
@@ -21,5 +22,5 @@ int main()
 {
 	pthread_t thread;
 	pthread_create(&thread, NULL, thread_main, NULL);
-	EM_ASM(noExitRuntime=true);
+	emscripten_unwind_to_js_event_loop();
 }


### PR DESCRIPTION
Adds diagnostics for thread quitting behavior, a missing unwind throw, and adds testing coverage for the use of `emscripten_unwind_to_js_event_loop();` to keep a pthread body alive.