### PR TITLE
Update NodeJS externs to head.

### DIFF
--- a/third_party/closure-compiler/node-externs/domain.js
+++ b/third_party/closure-compiler/node-externs/domain.js
@@ -64,14 +64,14 @@ domain.Domain.prototype.add = function(emitter) {};
 domain.Domain.prototype.remove = function(emitter) {};
 
 /**
- * @param {function(...[*])} callback
- * @return {function(...[*])}
+ * @param {function(...*)} callback
+ * @return {function(...*)}
  */
 domain.Domain.prototype.bind = function(callback) {};
 
 /**
- * @param {function(...[*])} callback
- * @return {function(...[*])}
+ * @param {function(...*)} callback
+ * @return {function(...*)}
  */
 domain.Domain.prototype.intercept = function(callback) {};
 


### PR DESCRIPTION
Fixes warnings with closure compiler:

/build/work/720d0796279fe09fc10eefb9ff94c9eb673e/google3/third_party/emscripten/stable/third_party/closure-compiler/node-externs/domain.js:67: WARNING - Bad type annotation. type not recognized due to syntax error. See https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler for more information.
 * @param {function(...[*])} callback
                       ^

/build/work/720d0796279fe09fc10eefb9ff94c9eb673e/google3/third_party/emscripten/stable/third_party/closure-compiler/node-externs/domain.js:68: WARNING - Bad type annotation. type not recognized due to syntax error. See https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler for more information.
 * @return {function(...[*])}
                        ^

/build/work/720d0796279fe09fc10eefb9ff94c9eb673e/google3/third_party/emscripten/stable/third_party/closure-compiler/node-externs/domain.js:73: WARNING - Bad type annotation. type not recognized due to syntax error. See https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler for more information.
 * @param {function(...[*])} callback
                       ^

/build/work/720d0796279fe09fc10eefb9ff94c9eb673e/google3/third_party/emscripten/stable/third_party/closure-compiler/node-externs/domain.js:74: WARNING - Bad type annotation. type not recognized due to syntax error. See https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler for more information.
 * @return {function(...[*])}
                        ^