### PR TITLE
Allow overwriting of CMAKE_FIND_ROOT_PATH_MODE_LIBRARY & INCLUDE & PACKAGE

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -210,12 +210,18 @@ endif()
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
 
 # Since Emscripten is a cross-compiler, we should never look at the
-# system-provided directories like /usr/include and so on.  Therefore only
+# system-provided directories like /usr/include and so on. Therefore only
 # CMAKE_FIND_ROOT_PATH should be used as a find directory. See
 # http://www.cmake.org/cmake/help/v3.0/variable/CMAKE_FIND_ROOT_PATH_MODE_INCLUDE.html
-set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
-set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+if (NOT CMAKE_FIND_ROOT_PATH_MODE_LIBRARY)
+  set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+endif()
+if (NOT CMAKE_FIND_ROOT_PATH_MODE_INCLUDE)
+  set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+endif()
+if (NOT CMAKE_FIND_ROOT_PATH_MODE_PACKAGE)
+  set(CMAKE_FIND_ROOT_PATH_MODE_PACKAGE ONLY)
+endif()
 
 set(CMAKE_SYSTEM_INCLUDE_PATH "${EMSCRIPTEN_ROOT_PATH}/system/include")
 


### PR DESCRIPTION
This matches the behaviour of the Android toolchain cmake file [1] and it allows providing self-compiled libraries as argued in this git issue [2].

[1] https://android.googlesource.com/platform/ndk/+/master/build/cmake/android.toolchain.cmake#281
[2] https://github.com/android-ndk/ndk/issues/517

----------------------

Context why I want this:
I build the dependencies for my executable via emconfigure/emcmake into a folder "\~/deps/emscripten" which means e.g. "make install" install libpng as "\~/deps/emscripten/include/libpng16/*" and "\~/deps/emscripten/lib/libpng.a"

Using -DCMAKE_FIND_ROOT_PATH="\~/deps/emscripten" does not work because when I use this CMake will search in "\~/deps/emscripten/usr/include" and "\~/deps/emscripten/usr/lib" and the result is that the library is not found.

By allowing me to overwrite the FIND_ROOT_PATH_* stuff with BOTH I can just use -DCMAKE_PREFIX_PATH="\~/deps/emscripten" and it will work.
