### PR TITLE
Remove the use of copy2 in test_file_packager

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2554,14 +2554,15 @@ int f() {
     run_process([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'data1.txt', '--preload', 'subdir/data2.txt', '--js-output=immutable.js', '--separate-metadata'])
     self.assertExists('immutable.js.metadata')
     # verify js output JS file is not touched when the metadata is separated
-    shutil.copy2('immutable.js', 'immutable.js.copy') # copy with timestamp preserved
+    orig_timestamp = os.path.getmtime('immutable.js')
+    orig_content = open('immutable.js').read()
     # ensure some time passes before running the packager again so that if it does touch the
     # js file it will end up with the different timestamp.
     time.sleep(1.0)
     run_process([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'data1.txt', '--preload', 'subdir/data2.txt', '--js-output=immutable.js', '--separate-metadata'])
     # assert both file content and timestamp are the same as reference copy
-    self.assertTextDataIdentical(open('immutable.js.copy').read(), open('immutable.js').read())
-    self.assertEqual(os.path.getmtime('immutable.js.copy'), os.path.getmtime('immutable.js'))
+    self.assertTextDataIdentical(orig_content, open('immutable.js').read())
+    self.assertEqual(orig_timestamp, os.path.getmtime('immutable.js'))
     # verify the content of metadata file is correct
     with open('immutable.js.metadata') as f:
       metadata = json.load(f)


### PR DESCRIPTION
Relying on copy2 to preseve the timestamp exactly seems to be
causing failures on the emscripten-releases CI.

```
======================================================================
FAIL: test_file_packager (test_other.other)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/b/s/w/ir/cipd_bin_packages/cpython3/lib/python3.8/unittest/case.py", line 60, in testPartExecutor
    yield
  File "/b/s/w/ir/cipd_bin_packages/cpython3/lib/python3.8/unittest/case.py", line 676, in run
    self._callTestMethod(testMethod)
  File "/b/s/w/ir/cipd_bin_packages/cpython3/lib/python3.8/unittest/case.py", line 633, in _callTestMethod
    method()
  File "/b/s/w/ir/k/install/emscripten/tests/test_other.py", line 2564, in test_file_packager
    self.assertEqual(os.path.getmtime('immutable.js.copy'), os.path.getmtime('immutable.js'))
  File "/b/s/w/ir/cipd_bin_packages/cpython3/lib/python3.8/unittest/case.py", line 912, in assertEqual
    assertion_func(first, second, msg=msg)
  File "/b/s/w/ir/cipd_bin_packages/cpython3/lib/python3.8/unittest/case.py", line 905, in _baseAssertEqual
    raise self.failureException(msg)
AssertionError: 1578686737.168262 != 1578686737.1682627
```