### PR TITLE
Stop always exporting proxy_main,

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1225,10 +1225,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # Remove the default exported functions 'memcpy', 'memset', 'malloc', 'free', etc. - those should only be linked in if used
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
 
-    if shared.Settings.USE_PTHREADS:
-      # These runtime methods are called from worker.js
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace', 'dynCall_ii']
-
     if shared.Settings.STACK_OVERFLOW_CHECK:
       if shared.Settings.MINIMAL_RUNTIME:
         shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$abortStackOverflow']
@@ -1463,8 +1459,18 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       ]
 
     if shared.Settings.USE_PTHREADS:
-      # To ensure allocated thread stacks are aligned:
+      shared.Settings.EXPORTED_RUNTIME_METHODS += ['establishStackSpace']
+
+      # memalign is used to ensure allocated thread stacks are aligned.
       shared.Settings.EXPORTED_FUNCTIONS += ['_memalign']
+
+      # dynCall_ii is used to call pthread entry points in worker.js (as
+      # metadce does not consider worker.js, which is external, we must
+      # consider it a user export, i.e., one which can never be removed).
+      shared.Building.user_requested_exports += ['dynCall_ii']
+
+      if shared.Settings.PROXY_TO_PTHREAD:
+        shared.Settings.EXPORTED_FUNCTIONS += ['_proxy_main']
 
       # pthread stack setup:
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$establishStackSpaceInJsModule']

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -911,9 +911,7 @@ void* __emscripten_thread_main(void* param) {
 
 static main_args _main_arguments;
 
-// TODO: Create a separate library of this to be able to drop EMSCRIPTEN_KEEPALIVE from this
-// definition.
-int EMSCRIPTEN_KEEPALIVE proxy_main(int argc, char** argv) {
+int proxy_main(int argc, char** argv) {
   if (emscripten_has_threading_support()) {
     pthread_attr_t attr;
     pthread_attr_init(&attr);

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2606,7 +2606,7 @@ class Building(object):
         export = item['export']
         # wasm backend's exports are prefixed differently inside the wasm
         if Settings.WASM_BACKEND:
-          export = '_' + export
+          export = asmjs_mangle(export)
         if export in Building.user_requested_exports or Settings.EXPORT_ALL:
           item['root'] = True
     # in standalone wasm, always export the memory


### PR DESCRIPTION
Only do so when PROXY_TO_PTHREAD.

To allow that, properly export dynCall_ii which worker.js 
needs to call pthread entry points; this happened to be kept
alive by proxy_main, and masked a bug which disallowed
rooting a dynCall_* method which is not asmjs_mangled.