### PR TITLE
Fix the names of pthread stubs in presence of ASAN

### DIFF
--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -140,7 +140,7 @@ var LibraryPThreadStub = {
   pthread_attr_setschedparam: function() {},
   pthread_attr_setstacksize: function() {},
 
-  pthread_create: function() {
+  {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create: function() {
     return {{{ cDefine('EAGAIN') }}};
   },
   pthread_cancel: function() {},
@@ -150,7 +150,7 @@ var LibraryPThreadStub = {
   },
 
   pthread_equal: function(x, y) { return x == y },
-  pthread_join: function() {},
+  {{{ USE_LSAN ? 'emscripten_builtin_' : '' }}}pthread_join: function() {},
   pthread_detach: function() {},
 
   sem_init: function() {},

--- a/tests/other/test_asan_pthread_stubs.c
+++ b/tests/other/test_asan_pthread_stubs.c
@@ -1,0 +1,17 @@
+#include <stdlib.h>
+#include <pthread.h>
+
+#ifdef __EMSCRIPTEN_PTHREADS__
+#error "should be compiled without threads"
+#endif
+
+void* run(void* arg) {
+  return arg;
+}
+
+int main(int argc, char **argv) {
+  pthread_t thread;
+  int rtn = pthread_create(&thread, NULL, run, 0);
+  // Should fail since threads were not compiled in.
+  return rtn == 0 ? 1 : 0;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9849,6 +9849,10 @@ int main () {
       'SUMMARY: AddressSanitizer: 3427 byte(s) leaked in 3 allocation(s).',
     ])
 
+  @no_fastcomp('asan is not supported on fastcomp')
+  def test_asan_pthread_stubs(self):
+    self.do_smart_test(path_from_root('tests', 'other', 'test_asan_pthread_stubs.c'), emcc_args=['-fsanitize=address', '-s', 'ALLOW_MEMORY_GROWTH=1'])
+
   @parameterized({
     'async': ['-s', 'WASM_ASYNC_COMPILATION=1'],
     'sync': ['-s', 'WASM_ASYNC_COMPILATION=0'],


### PR DESCRIPTION
The names pthread_stub.js were out of sync with pthread.js here.