### PR TITLE
Fixed alGetSource3f function call.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -446,3 +446,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Benjamin Golinvaux <benjamin@golinvaux.com>
 * Peter Salomonsen <pjsalomonsen@gmail.com>
 * Niklas Fiekas <niklas.fiekas@backscattering.de>
+* Martín Lucas Golini <spartanj@gmail.com>

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -4503,7 +4503,7 @@ var LibraryOpenAL = {
 
   alGetSource3f__proxy: 'sync',
   alGetSource3f__sig: 'viiiii',
-  alGetSource3f: function(source, param, pValue0, pValue1, pValue2) {
+  alGetSource3f: function(sourceId, param, pValue0, pValue1, pValue2) {
     var val = AL.getSourceParam('alGetSource3f', sourceId, param);
     if (val === null) {
       return;


### PR DESCRIPTION
`alGetSource3f` is failing because of an incorrect parameter name. This should fix it.