### PR TITLE
Strip -fPIC compiler flag during compilation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1937,6 +1937,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return any(flag.startswith(x) for x in ('-l', '-L', '-Wl,'))
 
       compile_args = [a for a in newargs if a and not is_link_flag(a)]
+      if '-fPIC' in compile_args and not shared.Settings.RELOCATABLE:
+        shared.warning('ignoring -fPIC flag when not building with SIDE_MODULE or MAIN_MODULE')
+        compile_args.remove('-fPIC')
 
       # Bitcode args generation code
       def get_clang_command(input_files):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8554,6 +8554,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   def test_fpic_static(self):
     self.emcc_args.append('-fPIC')
+    self.emcc_args.remove('-Werror')
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
 
   @node_pthreads


### PR DESCRIPTION
This is a partial revert of #9750.

The binaryen change that was designed to allow this to work was
reverted: https://github.com/WebAssembly/binaryen/pull/2513