### PR TITLE
Allow dynCall with 64-bit integers

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -949,7 +949,8 @@ function makeBigInt(low, high, unsigned) {
 function dynCall(sig, ptr, args) {
   if (args && args.length) {
 #if ASSERTIONS
-    assert(args.length == sig.length-1);
+    // j (64-bit integer) must be passed in as two numbers [low 32, high 32].
+    assert(args.length === sig.substring(1).replace(/j/g, '--').length);
 #endif
 #if ASSERTIONS
     assert(('dynCall_' + sig) in Module, 'bad function pointer type - no table for sig \'' + sig + '\'');

--- a/tests/core/dyncall_specific.c
+++ b/tests/core/dyncall_specific.c
@@ -6,25 +6,30 @@
  */
 
 #include <emscripten.h>
+#include <stdint.h>
+#include <stdio.h>
 
-void waka(int x, int y, int z) {
+void waka(int w, long long xy, int z) {
+  // xy should be 0xffff_ffff_0000_0004
+  int x = (int) xy;  // should be 4
+  int y = xy >> 32;  // should be -1
   EM_ASM({
-    out('received ' + [$0, $1, $2] + '.');
-  }, x, y, z);
+    out('received ' + [$0, $1, $2, $3] + '.');
+  }, w, x, y, z);
 }
 
 int main() {
   EM_ASM({
 #if DIRECT
-    dynCall_viii($0, 1, 4, 9);
+    dynCall_viji($0, 1, 4, 0xffffffff, 9);
     return;
 #endif
 #if EXPORTED
-    Module['dynCall_viii']($0, 1, 4, 9);
+    Module['dynCall_viji']($0, 1, 4, 0xffffffff, 9);
     return;
 #endif
 #if FROM_OUTSIDE
-    eval("Module['dynCall_viii'](" + $0 + ", 1, 4, 9)");
+    eval("Module['dynCall_viji'](" + $0 + ", 1, 4, 0xffffffff, 9)");
     return;
 #endif
     throw "no test mode";

--- a/tests/core/dyncall_specific.txt
+++ b/tests/core/dyncall_specific.txt
@@ -1,1 +1,1 @@
-received 1,4,9.
+received 1,4,-1,9.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6581,7 +6581,7 @@ return malloc(size);
     for which, exported_runtime_methods in [
         ('DIRECT', []),
         ('EXPORTED', []),
-        ('FROM_OUTSIDE', ['dynCall_viii'])
+        ('FROM_OUTSIDE', ['dynCall_viji'])
       ]:
       print(which)
       self.emcc_args = emcc_args + ['-D' + which]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6576,6 +6576,7 @@ return malloc(size);
     self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['dynCall', 'addFunction', 'lengthBytesUTF8', 'getTempRet0', 'setTempRet0'])
     self.do_run_in_out_file_test('tests', 'core', 'EXTRA_EXPORTED_RUNTIME_METHODS')
 
+  @no_fastcomp('fails mysteriously on fastcomp (dynCall_viji is not defined); ignored, because fastcomp is deprecated')
   def test_dyncall_specific(self):
     emcc_args = self.emcc_args[:]
     for which, exported_runtime_methods in [


### PR DESCRIPTION
If not for this assert, dynCall can already pass 64-bit integers. Fix the assert so that it expects two `number`s for a `j`.

(I'm not 100% sure this is actually supposed to work; I think I came up with this empirically by seeing how the numbers were showing up in my C code.)

Needed for library_webgpu to call C callbacks.