### PR TITLE
Missing runtime export: allocateUTF8OnStack

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -447,3 +447,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Peter Salomonsen <pjsalomonsen@gmail.com>
 * Niklas Fiekas <niklas.fiekas@backscattering.de>
 * Martín Lucas Golini <spartanj@gmail.com>
+* Bumsik Kim <k.bumsik@gmail.com>

--- a/src/modules.js
+++ b/src/modules.js
@@ -380,6 +380,7 @@ function exportRuntime() {
     'stringToUTF32',
     'lengthBytesUTF32',
     'allocateUTF8',
+    'allocateUTF8OnStack',
     'stackTrace',
     'addOnPreRun',
     'addOnInit',


### PR DESCRIPTION
I noticed that `allocateUTF8OnStack` is not registered as a runtime element so that it throws the following warning when I add it to EXTRA_EXPORTED_RUNTIME_METHODS:

> warning: invalid item (maybe a typo?) in EXPORTED_RUNTIME_METHODS: allocateUTF8OnStack

