### PR TITLE
Add support for WebGL extension EXT_texture_norm16.

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1056,6 +1056,7 @@ var LibraryGL = {
                                              "OES_element_index_uint", "EXT_texture_filter_anisotropic", "EXT_frag_depth",
                                              "WEBGL_draw_buffers", "ANGLE_instanced_arrays", "OES_texture_float_linear",
                                              "OES_texture_half_float_linear", "EXT_blend_minmax", "EXT_shader_texture_lod",
+                                             "EXT_texture_norm16",
                                              // Community approved WebGL extensions ordered by number:
                                              "WEBGL_compressed_texture_pvrtc", "EXT_color_buffer_half_float", "WEBGL_color_buffer_float",
                                              "EXT_sRGB", "WEBGL_compressed_texture_etc1", "EXT_disjoint_timer_query",

--- a/system/lib/gl/webgl1_ext.h
+++ b/system/lib/gl/webgl1_ext.h
@@ -227,3 +227,13 @@ void emscripten_webgl_getSupportedAstcProfiles(GLsizei bufSize, GLsizei *length,
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT 0x8C4D
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT 0x8C4E
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT 0x8C4F
+
+// 44. https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/
+#define GL_R16_EXT 0x822A
+#define GL_RG16_EXT 0x822C
+#define GL_RGB16_EXT 0x8054
+#define GL_RGBA16_EXT 0x805B
+#define GL_R16_SNORM_EXT 0x8F98
+#define GL_RG16_SNORM_EXT 0x8F99
+#define GL_RGB16_SNORM_EXT 0x8F9A
+#define GL_RGBA16_SNORM_EXT 0x8F9B


### PR DESCRIPTION
To land once https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/ is ratified.

CC @kainino0x @kenrussell.