### PR TITLE
Rename _emscripten_read_asm_const_args -> $readAsmConstArgs

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -705,7 +705,7 @@ def update_settings_glue(metadata, DEBUG):
   if metadata['asmConsts']:
     # emit the EM_ASM signature-reading helper function only if we have any EM_ASM
     # functions in the module.
-    shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_read_asm_const_args']
+    shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$readAsmConstArgs']
 
     # Extract the list of function signatures that MAIN_THREAD_EM_ASM blocks in
     # the compiled code have, each signature will need a proxy function invoker
@@ -2431,7 +2431,7 @@ def create_asm_consts_wasm(forwarded_json, metadata):
 
     asm_const_funcs.append(r'''
 function %s(code, sigPtr, argbuf) {%s
-  var args = _emscripten_read_asm_const_args(sigPtr, argbuf);
+  var args = readAsmConstArgs(sigPtr, argbuf);
   return ASM_CONSTS[code].apply(null, args);
 }''' % (const_name, preamble))
   asm_consts = [(key, value) for key, value in asm_consts.items()]

--- a/src/library.js
+++ b/src/library.js
@@ -4581,11 +4581,11 @@ LibraryManager.library = {
     return STACK_BASE;
   },
 
-  emscripten_read_asm_const_args: function(sigPtr, buf) {
-    if (!_emscripten_read_asm_const_args.array) {
-      _emscripten_read_asm_const_args.array = [];
+  $readAsmConstArgs: function(sigPtr, buf) {
+    if (!readAsmConstArgs.array) {
+      readAsmConstArgs.array = [];
     }
-    var args = _emscripten_read_asm_const_args.array;
+    var args = readAsmConstArgs.array;
     args.length = 0;
     var ch;
     while (ch = HEAPU8[sigPtr++]) {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1309,7 +1309,10 @@ var LibraryPThread = {
 
   emscripten_receive_on_main_thread_js_callArgs: '=[]',
 
-  emscripten_receive_on_main_thread_js__deps: ['emscripten_proxy_to_main_thread_js', 'emscripten_receive_on_main_thread_js_callArgs', 'emscripten_read_asm_const_args'],
+  emscripten_receive_on_main_thread_js__deps: [
+    'emscripten_proxy_to_main_thread_js',
+    'emscripten_receive_on_main_thread_js_callArgs',
+    '$readAsmConstArgs'],
   emscripten_receive_on_main_thread_js: function(index, numCallArgs, args) {
     _emscripten_receive_on_main_thread_js_callArgs.length = numCallArgs;
     var b = args >> 3;
@@ -1327,7 +1330,7 @@ var LibraryPThread = {
       // signature pointer, and vararg buffer pointer, in that order.
       var sigPtr = _emscripten_receive_on_main_thread_js_callArgs[1];
       var varargPtr = _emscripten_receive_on_main_thread_js_callArgs[2];
-      var constArgs = _emscripten_read_asm_const_args(sigPtr, varargPtr);
+      var constArgs = readAsmConstArgs(sigPtr, varargPtr);
       return func.apply(null, constArgs);
     }
 #endif


### PR DESCRIPTION
This is an internal library function and we signal that by using the
dollar sign prefix and the camel case name.