### PR TITLE
Fix symbol mismatch on sdl2_mixer

### DIFF
--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -30,7 +30,7 @@ def get(ports, settings, shared):
     shutil.copytree(source_path, dest_path)
 
     final = os.path.join(dest_path, libname)
-    ports.build_port(dest_path, final, [], ['-DOGG_MUSIC', '-s', 'USE_VORBIS=1'],
+    ports.build_port(dest_path, final, [], ['-DOGG_MUSIC', '-O2', '-s', 'USE_VORBIS=1', '-s', 'USE_SDL=2'],
                      ['dynamic_flac', 'dynamic_fluidsynth', 'dynamic_mod', 'dynamic_modplug', 'dynamic_mp3',
                       'fluidsynth', 'load_mp3', 'music_cmd', 'music_flac', 'music_mad', 'music_mod',
                       'music_modplug', 'playmus.c', 'playwave.c'],


### PR DESCRIPTION
It was being built against the SDL1 headers which have a different
signature for SDL_Error and SDL_SetError.

Fixes: #10237