### PR TITLE
🔧 fix building Boost 1.72.0 with emscripten

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -552,10 +552,11 @@ emcc: supported targets: llvm bitcode, javascript, NOT elf
     except Exception:
       revision = '(unknown revision)'
     print('''emcc (Emscripten gcc/clang-like replacement) %s (%s)
+version %s
 Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
 This is free and open source software under the MIT license.
 There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-  ''' % (shared.EMSCRIPTEN_VERSION, revision))
+  ''' % (shared.EMSCRIPTEN_VERSION, revision, shared.EMSCRIPTEN_VERSION))
     return 0
 
   if len(args) == 1 and args[0] == '-v': # -v with no inputs


### PR DESCRIPTION
Dear @kripken,

It happens that since emscripten moved to upstream instead of fastcomp, the emcc.py did got some revamp and the Boost bjam compilation process requires to find a keyword version in front of the version number to determine the clang version it's using to perform the build and select cxx features etc.

As it considers em++ is a clang (which is true) it looks for the clang version in the form "version x.x.x".

What works in the tests I have is by adding the version on another line, as I was afraid of breaking potentially other stuffs like configure which looks for different patterns, but perhaps everything could be added on the same line.

Which tests should I run to check my changes are correct ?

Thank you very much for the awesome work  :wink:
