### PR TITLE
Update expectation for metadce test after upstream llvm change

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3069,8 +3069,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       options.binaryen_passes += ['--pass-arg=emscripten-sbrk-ptr@%d' % shared.Settings.DYNAMICTOP_PTR]
       if shared.Settings.STANDALONE_WASM:
         options.binaryen_passes += ['--pass-arg=emscripten-sbrk-val@%d' % shared.Settings.DYNAMIC_BASE]
-    if DEBUG:
-      shared.Building.save_intermediate(wasm_binary_target, 'pre-byn.wasm')
+    shared.Building.save_intermediate(wasm_binary_target, 'pre-byn.wasm')
     args = options.binaryen_passes
     shared.Building.run_wasm_opt(wasm_binary_target,
                                  wasm_binary_target,
@@ -3088,8 +3087,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       logger.debug('running binaryen script: ' + script)
       shared.check_call([shared.PYTHON, os.path.join(binaryen_scripts, script), final, wasm_text_target], env=script_env)
   if shared.Settings.EVAL_CTORS:
-    if DEBUG:
-      shared.Building.save_intermediate(wasm_binary_target, 'pre-ctors.wasm')
+    shared.Building.save_intermediate(wasm_binary_target, 'pre-ctors.wasm')
     shared.Building.eval_ctors(final, wasm_binary_target, binaryen_bin, debug_info=intermediate_debug_info)
 
   # after generating the wasm, do some final operations

--- a/tests/other/metadce/hello_world_O2.funcs
+++ b/tests/other/metadce/hello_world_O2.funcs
@@ -6,6 +6,7 @@ $__growWasmMemory
 $__overflow
 $__stdio_write
 $__towrite
+$__wasi_syscall_ret
 $__wasm_call_ctors
 $dlfree
 $dlmalloc

--- a/tests/other/metadce/hello_world_Os.funcs
+++ b/tests/other/metadce/hello_world_Os.funcs
@@ -4,6 +4,7 @@ $__fwritex
 $__overflow
 $__stdio_write
 $__towrite
+$__wasi_syscall_ret
 $__wasm_call_ctors
 $fwrite
 $main

--- a/tests/other/metadce/hello_world_Oz.funcs
+++ b/tests/other/metadce/hello_world_Oz.funcs
@@ -4,6 +4,7 @@ $__fwritex
 $__overflow
 $__stdio_write
 $__towrite
+$__wasi_syscall_ret
 $__wasm_call_ctors
 $fwrite
 $main

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8230,10 +8230,10 @@ int main() {
   @parameterized({
     'O0': ([],      10, [], ['waka'], 22874,  9,  18, 58), # noqa
     'O1': (['-O1'],  7, [], ['waka'], 10415,  6,  14, 30), # noqa
-    'O2': (['-O2'],  7, [], ['waka'], 10183,  6,  14, 24), # noqa
+    'O2': (['-O2'],  7, [], ['waka'], 10256,  6,  14, 25), # noqa
     'O3': (['-O3'],  4, [], [],        1957,  4,   2, 12), # noqa; in -O3, -Os and -Oz we metadce
-    'Os': (['-Os'],  4, [], [],        1963,  4,   2, 12), # noqa
-    'Oz': (['-Oz'],  4, [], [],        1929,  4,   2, 12), # noqa
+    'Os': (['-Os'],  4, [], [],        1963,  4,   2, 13), # noqa
+    'Oz': (['-Oz'],  4, [], [],        2031,  4,   2, 13), # noqa
     # finally, check what happens when we export nothing. wasm should be almost empty
     'export_nothing':
           (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],


### PR DESCRIPTION
This change seems to have effected the llvm codegen in way caused
binaryen to no longer be able to inline all calls to __wasi_syscall_ret:
https://reviews.llvm.org/D70247

This change will fail on emscripten CI and require a combined roll
into emscripten-release along with llvm.