### PR TITLE
Perform `npm install` after setting up emsdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ commands:
           command: |
             # Will add emsdk version of node to PATH
             source ~/emsdk-master/emsdk_env.sh
-            which node
             npm install
   build-upstream:
     description: "Install emsdk build all libraries using embuilder"
@@ -278,7 +277,6 @@ commands:
             CHROME_FLAGS_WASM: "--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer --no-wasm-disable-structured-cloning\""
             CHROME_FLAGS_NOCACHE: "--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
           command: |
-            which node
             export EMTEST_BROWSER="/usr/bin/google-chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE"
             python3 tests/runner.py sockets
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,16 @@ executors:
       EMCC_CORES: "4"
 
 commands:
+  npm-install:
+    description: "npm install"
+    steps:
+      - run:
+          name: npm install
+          command: |
+            # Will add emsdk version of node to PATH
+            source ~/emsdk-master/emsdk_env.sh
+            which node
+            npm install
   build-upstream:
     description: "Install emsdk build all libraries using embuilder"
     steps:
@@ -66,6 +76,7 @@ commands:
           name: freeze cache
           command: |
             echo "FROZEN_CACHE=True" >> ~/.emscripten
+      - npm-install
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory
           root: ~/
@@ -84,10 +95,11 @@ commands:
         description: "Test suites to run"
         type: string
     steps:
-      - checkout
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: ~/
+      - checkout
+      - npm-install
       - run:
           name: run tests
           command: |
@@ -100,10 +112,11 @@ commands:
         description: "Test suites to run"
         type: string
     steps:
-      - checkout
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: ~/
+      - checkout
+      - npm-install
       - run:
           name: Install brew package dependencies
           environment:
@@ -117,10 +130,11 @@ commands:
   test-firefox:
     description: "Runs emscripten tests under firefox"
     steps:
-      - checkout
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: ~/
+      - checkout
+      - npm-install
       - run:
           name: download firefox
           command: |
@@ -215,10 +229,11 @@ commands:
   test-chrome:
     description: "Runs emscripten browser tests under chrome"
     steps:
-      - checkout
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: ~/
+      - checkout
+      - npm-install
       - run:
           name: download chrome
           command: |
@@ -241,7 +256,6 @@ commands:
   test-upstream-sockets-chrome:
     description: "Runs emscripten sockets tests under chrome"
     steps:
-      - checkout
       - attach_workspace:
           # Must be absolute path or relative path from working_directory
           at: ~/
@@ -250,13 +264,8 @@ commands:
           command: |
             wget -O ~/chrome.deb https://dl.google.com/linux/direct/google-chrome-beta_current_amd64.deb
             dpkg -i ~/chrome.deb
-      - run:
-          name: install sockets test suite prerequisites
-          command: |
-            wget https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-x64.tar.xz
-            tar -xf node-v12.13.0-linux-x64.tar.xz
-            export PATH="`pwd`/node-v12.13.0-linux-x64/bin:${PATH}"
-            npm install ws
+      - checkout
+      - npm-install
       - run:
           name: run sockets tests
           environment:
@@ -269,11 +278,12 @@ commands:
             CHROME_FLAGS_WASM: "--enable-features=WebAssembly --enable-features=SharedArrayBuffer --disable-features=WebAssemblyTrapHandler --js-flags=\"--experimental-wasm-threads --harmony-sharedarraybuffer --no-wasm-disable-structured-cloning\""
             CHROME_FLAGS_NOCACHE: "--disk-cache-dir=/dev/null --disk-cache-size=1 --media-cache-size=1 --disable-application-cache --incognito"
           command: |
+            which node
             export EMTEST_BROWSER="/usr/bin/google-chrome $CHROME_FLAGS_BASE $CHROME_FLAGS_HEADLESS $CHROME_FLAGS_WASM $CHROME_FLAGS_NOCACHE"
             python3 tests/runner.py sockets
 
 jobs:
-  build:
+  build-fastcomp:
     executor: bionic
     steps:
       - checkout
@@ -305,6 +315,7 @@ jobs:
           name: freeze cache
           command: |
             echo "FROZEN_CACHE=True" >> ~/.emscripten
+      - npm-install
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory
           root: ~/
@@ -505,58 +516,58 @@ workflows:
     jobs:
       - flake8
       - build-docs
-      - build
+      - build-fastcomp
       - test-other:
           requires:
-            - build
+            - build-fastcomp
       - test-browser-firefox:
           requires:
-            - build
+            - build-fastcomp
       - test-browser-chrome:
           requires:
-            - build
+            - build-fastcomp
       - test-ab:
           requires:
-            - build
+            - build-fastcomp
       - test-c:
           requires:
-            - build
+            - build-fastcomp
       - test-d:
           requires:
-            - build
+            - build-fastcomp
       - test-e:
           requires:
-            - build
+            - build-fastcomp
       - test-f:
           requires:
-            - build
+            - build-fastcomp
       - test-ghi:
           requires:
-            - build
+            - build-fastcomp
       - test-jklmno:
           requires:
-            - build
+            - build-fastcomp
       - test-p:
           requires:
-            - build
+            - build-fastcomp
       - test-qrst:
           requires:
-            - build
+            - build-fastcomp
       - test-uvwxyz:
           requires:
-            - build
+            - build-fastcomp
       - test-wasm0:
           requires:
-            - build
+            - build-fastcomp
       - test-wasm2:
           requires:
-            - build
+            - build-fastcomp
       - test-wasm3:
           requires:
-            - build
+            - build-fastcomp
       - test-sanity:
           requires:
-            - build
+            - build-fastcomp
       - build-upstream-linux
       - test-upstream-wasm0:
           requires:

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,10 +32,10 @@
       "integrity": "sha1-eHphVEFPPJntg8V3IVOyD+sM7DI=",
       "dev": true,
       "requires": {
-        "commander": "2.1.0",
-        "nan": "1.0.0",
-        "options": "0.0.6",
-        "tinycolor": "0.0.1"
+        "commander": "~2.1.0",
+        "nan": "~1.0.0",
+        "options": ">=0.0.5",
+        "tinycolor": "0.x"
       }
     }
   }

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -450,9 +450,6 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
       self.working_dir = tempfile.mkdtemp(prefix='emscripten_test_' + self.__class__.__name__ + '_', dir=self.temp_dir)
     os.chdir(self.working_dir)
 
-    # Use emscripten root for node module lookup
-    os.environ['NODE_PATH'] = path_from_root('node_modules')
-
     if not self.save_dir:
       self.has_prev_ll = False
       for temp_file in os.listdir(TEMP_DIR):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -164,6 +164,10 @@ class sockets(BrowserCore):
     print('Running the socket tests. Make sure the browser allows popups from localhost.')
     print()
 
+    # Use emscripten root for node module lookup
+    print('Setting NODE_PATH=' + path_from_root('node_modules'))
+    os.environ['NODE_PATH'] = path_from_root('node_modules')
+
   def test_sockets_echo(self):
     sockets_include = '-I' + path_from_root('tests', 'sockets')
 


### PR DESCRIPTION
emsdk will run npm install in the version of emscripten that it
downloads, but we override with our own version from git and we need
to run `npm install` locally.

Previously we only did this for the socket tests which are currently
the only parts of emscripten that actually depend on `npm install`
having been run.  However we have plans to extend that.  See #9989.