### PR TITLE
#EMSCRIPTEN_ALWAYS_ALLOW_RAW_POINTERS preprocessor flag

### DIFF
--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -117,7 +117,13 @@ namespace emscripten {
 
         template<typename T>
         struct TypeID<T*> {
+#ifdef EMSCRIPTEN_ALWAYS_ALLOW_RAW_POINTERS
+            static constexpr TYPEID get() {
+                return LightTypeID<T*>::get();
+            }
+#else
             static_assert(!std::is_pointer<T*>::value, "Implicitly binding raw pointers is illegal.  Specify allow_raw_pointer<arg<?>>");
+#endif
         };
 
         template<typename T>


### PR DESCRIPTION
Some projects (*cough* PhysX) may require writing allow_raw_pointers() in dozens of different functions which is very time consuming and harder to maintain. Adding #EMSCRIPTEN_ALWAYS_ALLOW_RAW_POINTERS right before including bind.h would allow all raw pointers to go through.