### PR TITLE
Error constructor should not use a number

### DIFF
--- a/src/library_stack_trace.js
+++ b/src/library_stack_trace.js
@@ -66,7 +66,7 @@ var LibraryStackTrace = {
       // IE10+ special cases: It does have callstack info, but it is only populated if an Error object is thrown,
       // so try that as a special-case.
       try {
-        throw new Error(0);
+        throw new Error();
       } catch(e) {
         err = e;
       }


### PR DESCRIPTION
See: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error
The Error constructor should take either a string or nothing.