### PR TITLE
Remove PThread.preallocatedWorkers

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -781,17 +781,6 @@ var memoryInitializer = null;
 #include "memoryprofiler.js"
 #endif
 
-#if PTHREAD_POOL_SIZE > 0
-// To work around https://bugzilla.mozilla.org/show_bug.cgi?id=1049079, warm up a worker pool before starting up the application.
-#if PTHREAD_POOL_DELAY_LOAD
-// Spin up Workers, and also wait for the Worker pool to complete loading up.
-if (!ENVIRONMENT_IS_PTHREAD) addOnPreRun(function() { addRunDependency('pthreads'); PThread.allocateUnusedWorkers({{{PTHREAD_POOL_SIZE}}}, function() { removeRunDependency('pthreads'); }); });
-#else
-// Spin up a Worker pool, but don't wait up for the pool to load, but continue with main() immediately.
-if (!ENVIRONMENT_IS_PTHREAD) addOnPreRun(function() { PThread.allocateUnusedWorkers({{{PTHREAD_POOL_SIZE}}}); });
-#endif
-#endif
-
 #if ASSERTIONS && !('$FS' in addedLibraryItems) && !ASMFS
 // show errors on likely calls to FS when it was not included
 var FS = {
@@ -926,11 +915,27 @@ function createWasm() {
 #endif
 #endif
 #if USE_PTHREADS
-    // Keep a reference to the compiled module so we can post it to the workers.
+    // We now have the Wasm module loaded up, keep a reference to the compiled module so we can post it to the workers.
     wasmModule = module;
     // Instantiation is synchronous in pthreads and we assert on run dependencies.
-    if (!ENVIRONMENT_IS_PTHREAD) removeRunDependency('wasm-instantiate');
-#else
+    if (!ENVIRONMENT_IS_PTHREAD) {
+#if PTHREAD_POOL_SIZE > 0
+      var numWorkersToLoad = PThread.unusedWorkers.length;
+      PThread.unusedWorkers.forEach(function(w) { PThread.loadWasmModuleToWorker(w, function() {
+#if !PTHREAD_POOL_DELAY_LOAD
+        // PTHREAD_POOL_DELAY_LOAD==0: we wanted to synchronously wait until the Worker pool
+        // has loaded up. If all Workers have finished loading up the Wasm Module, proceed with main()
+        if (!--numWorkersToLoad) removeRunDependency('wasm-instantiate');
+#endif
+      })});
+#endif
+#if PTHREAD_POOL_DELAY_LOAD || PTHREAD_POOL_SIZE == 0
+      // PTHREAD_POOL_DELAY_LOAD==1 (or no preloaded pool in use): do not wait up for the Workers to
+      // instantiate the Wasm module, but proceed with main() immediately.
+      removeRunDependency('wasm-instantiate');
+#endif
+    }
+#else // singlethreaded build:
     removeRunDependency('wasm-instantiate');
 #endif
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1379,16 +1379,34 @@ var IN_TEST_HARNESS = 0;
 // [compile+link] - affects user code at compile and system libraries at link
 var USE_PTHREADS = 0;
 
-// PTHREAD_POOL_SIZE specifies the number of web workers that are created
-// before the main runtime is initialized. If 0, workers are created on
-// demand. If PTHREAD_POOL_DELAY_LOAD = 0, then the workers will be fully
-// loaded (available for use) prior to the main runtime being initialized. If
-// PTHREAD_POOL_DELAY_LOAD = 1, then the workers will only be created and
-// have their runtimes loaded on demand after the main runtime is initialized.
-// Note that this means that the workers cannot be joined from the main thread
-// unless PROXY_TO_PTHREAD is used.
+// In web browsers, Workers cannot be created while the main browser thread
+// is executing JS/Wasm code, but the main thread must regularly yield back
+// to the browser event loop for Worker initialization to occur.
+// This means that pthread_create() is essentially an asynchronous operation
+// when called from the main browser thread, and the main thread must
+// repeatedly yield back to the JS event loop in order for the thread to
+// actually start.
+// If your application needs to be able to synchronously create new threads,
+// you can pre-create a pthread pool by specifying -s PTHREAD_POOL_SIZE=x,
+// in which case the specified number of Workers will be preloaded into a pool
+// before the application starts, and that many threads can then be available
+// for synchronous creation.
+// [link] - affects generated JS runtime code at link time
 var PTHREAD_POOL_SIZE = 0;
-var PTHREAD_POOL_DELAY_LOAD = 0;
+
+// If your application does not need the ability to synchronously create
+// threads, but it would still like to opportunistically speed up initial thread
+// startup time by prewarming a pool of Workers, you can specify the size of
+// the pool with -s PTHREAD_POOL_SIZE=x, but then also specify
+// -s PTHREAD_POOL_DELAY_LOAD=0, which will cause the runtime to not wait up at
+// startup for the Worker pool to finish loading. Instead, the runtime will
+// immediately start up and the Worker pool will asynchronously spin up in
+// parallel on the background. This can shorten the time that pthread_create()
+// calls take to actually start a thread, but without actually slowing down
+// main application startup speed. If PTHREAD_POOL_DELAY_LOAD=1 (default),
+// then the runtime will wait for the pool to start up before running main().
+// [link] - affects generated JS runtime code at link time
+var PTHREAD_POOL_DELAY_LOAD = 1;
 
 // If not explicitly specified, this is the stack size to use for newly created
 // pthreads.  According to

--- a/src/settings.js
+++ b/src/settings.js
@@ -1398,15 +1398,15 @@ var PTHREAD_POOL_SIZE = 0;
 // threads, but it would still like to opportunistically speed up initial thread
 // startup time by prewarming a pool of Workers, you can specify the size of
 // the pool with -s PTHREAD_POOL_SIZE=x, but then also specify
-// -s PTHREAD_POOL_DELAY_LOAD=0, which will cause the runtime to not wait up at
+// -s PTHREAD_POOL_DELAY_LOAD=1, which will cause the runtime to not wait up at
 // startup for the Worker pool to finish loading. Instead, the runtime will
 // immediately start up and the Worker pool will asynchronously spin up in
 // parallel on the background. This can shorten the time that pthread_create()
 // calls take to actually start a thread, but without actually slowing down
-// main application startup speed. If PTHREAD_POOL_DELAY_LOAD=1 (default),
+// main application startup speed. If PTHREAD_POOL_DELAY_LOAD=0 (default),
 // then the runtime will wait for the pool to start up before running main().
 // [link] - affects generated JS runtime code at link time
-var PTHREAD_POOL_DELAY_LOAD = 1;
+var PTHREAD_POOL_DELAY_LOAD = 0;
 
 // If not explicitly specified, this is the stack size to use for newly created
 // pthreads.  According to

--- a/tests/pthread/test_pthread_file_io.cpp
+++ b/tests/pthread/test_pthread_file_io.cpp
@@ -7,6 +7,7 @@
 #include <emscripten.h>
 #include <emscripten/threading.h>
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/tests/pthread/test_pthread_preallocates_workers.cpp
+++ b/tests/pthread/test_pthread_preallocates_workers.cpp
@@ -47,15 +47,13 @@ int main()
 
   // This test should be run with a prewarmed pool of size 4. None
   // of the threads are allocated yet.
-  assert(EM_ASM_INT(return PThread.preallocatedWorkers.length) == 4);
-  assert(EM_ASM_INT(return PThread.unusedWorkers.length) == 0);
+  assert(EM_ASM_INT(return PThread.unusedWorkers.length) == 4);
   assert(EM_ASM_INT(return PThread.runningWorkers.length) == 0);
 
   CreateThread(0);
 
   // We have one running thread, allocated on demand.
-  assert(EM_ASM_INT(return PThread.preallocatedWorkers.length) == 3);
-  assert(EM_ASM_INT(return PThread.unusedWorkers.length) == 0);
+  assert(EM_ASM_INT(return PThread.unusedWorkers.length) == 3);
   assert(EM_ASM_INT(return PThread.runningWorkers.length) == 1);
 
   for (int i = 1; i < 5; ++i) {


### PR DESCRIPTION
When reviewing #10263 I noticed there is a new setting `PTHREAD_POOL_DELAY_LOAD` that has popped into existence in #9394.

This PR simplifies the implementation of that setting by refactoring not to need a preallocatedWorkers array.