### PR TITLE
Disable LTO for libcompiler_rt library

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8667,12 +8667,12 @@ wasm3 = make_run('wasm3', emcc_args=['-O3'])
 wasms = make_run('wasms', emcc_args=['-Os'])
 wasmz = make_run('wasmz', emcc_args=['-Oz'])
 
-wasmlto0 = make_run('wasmlto0', emcc_args=['-O0'], settings={'WASM_OBJECT_FILES': 0})
-wasmlto1 = make_run('wasmlto1', emcc_args=['-O1'], settings={'WASM_OBJECT_FILES': 0})
-wasmlto2 = make_run('wasmlto2', emcc_args=['-O2'], settings={'WASM_OBJECT_FILES': 0})
-wasmlto3 = make_run('wasmlto3', emcc_args=['-O3'], settings={'WASM_OBJECT_FILES': 0})
-wasmltos = make_run('wasmltos', emcc_args=['-Os'], settings={'WASM_OBJECT_FILES': 0})
-wasmltoz = make_run('wasmltoz', emcc_args=['-Oz'], settings={'WASM_OBJECT_FILES': 0})
+wasmlto0 = make_run('wasmlto0', emcc_args=['-O0', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
+wasmlto1 = make_run('wasmlto1', emcc_args=['-O1', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
+wasmlto2 = make_run('wasmlto2', emcc_args=['-O2', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
+wasmlto3 = make_run('wasmlto3', emcc_args=['-O3', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
+wasmltos = make_run('wasmltos', emcc_args=['-Os', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
+wasmltoz = make_run('wasmltoz', emcc_args=['-Oz', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
 
 if shared.Settings.WASM_BACKEND:
   wasm2js0 = make_run('wasm2js0', emcc_args=['-O0'], settings={'WASM': 0})

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -414,7 +414,7 @@ class Library(object):
     """
     Return the appropriate file extension for this library.
     """
-    return '.a' if shared.Settings.WASM_BACKEND and shared.Settings.WASM_OBJECT_FILES else '.bc'
+    return '.a' if shared.Settings.WASM_BACKEND else '.bc'
 
   def get_filename(self):
     """
@@ -618,8 +618,10 @@ class NoBCLibrary(Library):
     return '.a'
 
 
-class libcompiler_rt(NoBCLibrary):
+class libcompiler_rt(Library):
   name = 'libcompiler_rt'
+  # compiler_rt files can't currently be part of LTO although we are hoping to remove this
+  # restriction soon: https://reviews.llvm.org/D71738
   force_object_files = True
 
   cflags = ['-O2', '-fno-builtin']
@@ -1174,8 +1176,10 @@ class libpthread(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
     return 'libpthread' if self.is_mt else 'libpthread_stub'
 
 
-class CompilerRTWasmLibrary(NoBCLibrary):
+class CompilerRTWasmLibrary(Library):
   cflags = ['-O2', '-fno-builtin']
+  # compiler_rt files can't currently be part of LTO although we are hoping to remove this
+  # restriction soon: https://reviews.llvm.org/D71738
   force_object_files = True
 
   def can_build(self):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -58,10 +58,11 @@ def dir_is_newer(dir_a, dir_b):
 
 def get_cflags(force_object_files=False):
   flags = []
-  if force_object_files:
-    flags += ['-s', 'WASM_OBJECT_FILES=1']
-  elif not shared.Settings.WASM_OBJECT_FILES:
-    flags += ['-s', 'WASM_OBJECT_FILES=0']
+  if shared.Settings.WASM_BACKEND:
+    if force_object_files:
+      flags += ['-s', 'WASM_OBJECT_FILES=1']
+    elif not shared.Settings.WASM_OBJECT_FILES:
+      flags += ['-s', 'WASM_OBJECT_FILES=0']
   if shared.Settings.RELOCATABLE:
     flags += ['-s', 'RELOCATABLE']
   return flags

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -607,17 +607,19 @@ class CXXLibrary(Library):
 
 
 class NoBCLibrary(Library):
-  # Some libraries cannot be compiled as .bc files. This is because .bc files will link in every object in the library.
-  # While the optimizer will readily optimize out most of the unused functions, things like global constructors that
-  # are linked in cannot be optimized out, even though they are not actually needed. If we use .a files for such
-  # libraries, only the object files, and by extension, their contained global constructors, that are actually needed
-  # will be linked in.
+  # Some libraries cannot be compiled as .bc files. This is because .bc files will link in every
+  # object in the library.  While the optimizer will readily optimize out most of the unused
+  # functions, things like global constructors that are linked in cannot be optimized out, even
+  # though they are not actually needed. If we use .a files for such libraries, only the object
+  # files, and by extension, their contained global constructors, that are actually needed will be
+  # linked in.
   def get_ext(self):
     return '.a'
 
 
-class libcompiler_rt(Library):
+class libcompiler_rt(NoBCLibrary):
   name = 'libcompiler_rt'
+  force_object_files = True
 
   cflags = ['-O2', '-fno-builtin']
   src_dir = ['system', 'lib', 'compiler-rt', 'lib', 'builtins']


### PR DESCRIPTION
At least until we have fixed the linker this is not supported as
it can result in new undefined symbols appearing during LTO.

Also, never pass WASM_OBJECT_FILES unless building with wasm backend.

Also, never build '.bc' library files, even the wasm backend.  Even with LTO the wasm
backend we prefer normal `ar` archives containing bitcode object files.

Fixes: #10066