### PR TITLE
Allow --fatal-warnings to be passed to lld

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -89,6 +89,7 @@ SUPPORTED_LLD_LINKER_FLAG_PREFIXES = (
     '--export')
 
 SUPPORTED_LLD_LINKER_FLAGS = (
+    '--fatal-warnings',
     '--no-check-features',
     '--trace',
     '--no-threads',

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10271,3 +10271,12 @@ int main() {
   def test_webgpu_compiletest(self):
     for args in [[], ['-s', 'ASSERTIONS=1']]:
       run_process([PYTHON, EMCC, path_from_root('tests', 'webgpu_dummy.cpp'), '-s', 'USE_WEBGPU=1'] + args)
+
+  @no_fastcomp('lld only')
+  def test_signature_mismatch(self):
+    create_test_file('a.c', 'void foo(); int main() { foo(); return 0; }')
+    create_test_file('b.c', 'int foo() { return 1; }')
+    stderr = run_process([PYTHON, EMCC, 'a.c', 'b.c'], stderr=PIPE).stderr
+    self.assertContained('function signature mismatch: foo', stderr)
+    self.expect_fail([PYTHON, EMCC, '-Wl,--fatal-warnings', 'a.c', 'b.c'])
+    self.expect_fail([PYTHON, EMCC, '-s', 'STRICT', 'a.c', 'b.c'])

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1904,6 +1904,9 @@ class Building(object):
       args.insert(0, '--whole-archive')
       args.append('--no-whole-archive')
 
+    if Settings.STRICT:
+      args.append('--fatal-warnings')
+
     cmd = [
         WASM_LD,
         '-o',


### PR DESCRIPTION
Also, enable this by default if -Werror is enabled.
See #10226