### PR TITLE
Remove SWAPPABLE_ASM_MODULE option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Remove SWAPPABLE_ASM_MODULE option (#10282).
 - Add new Fibers API for context switching, that supercedes the old coroutine
   API that only ran on fastcomp. See #9859
 - Added new linker option -s WASM=2 which produces a dual Wasm+JS build, which

--- a/emscripten.py
+++ b/emscripten.py
@@ -1734,7 +1734,7 @@ asm["%(name)s"] = function() {%(runtime_assertions)s
   module_exports = exported_implemented_functions + function_tables(function_table_data)
   shared.Settings.MODULE_EXPORTS = [(f, f) for f in module_exports]
 
-  if not shared.Settings.SWAPPABLE_ASM_MODULE:
+  if shared.Settings.MINIMAL_RUNTIME or not shared.Settings.WASM_ASYNC_COMPILATION:
     if shared.Settings.DECLARE_ASM_MODULE_EXPORTS:
       imported_exports = [s for s in module_exports if s not in initializers]
 
@@ -2641,7 +2641,7 @@ asm["%(e)s"] = function() {%(assertions)s
 };
 ''' % {'mangled': asmjs_mangle(e), 'e': e, 'assertions': runtime_assertions})
 
-  if not shared.Settings.SWAPPABLE_ASM_MODULE:
+  if shared.Settings.MINIMAL_RUNTIME or not shared.Settings.WASM_ASYNC_COMPILATION:
     if shared.Settings.DECLARE_ASM_MODULE_EXPORTS:
       if shared.Settings.WASM and shared.Settings.MINIMAL_RUNTIME:
         # In Wasm exports are assigned inside a function to variables existing in top level JS scope, i.e.

--- a/site/source/docs/porting/emterpreter.rst
+++ b/site/source/docs/porting/emterpreter.rst
@@ -31,18 +31,8 @@ Specific Use Cases
 
 A couple of examples are given below of how the Emterpreter can be useful in general.
 
-Improving Startup 1: Swapping
------------------------------
-
-As mentioned earlier, the Emterpreter and its binary bytecode load faster than JavaScript and asm.js can. Just building with the Emterpreter option gives you that, but it also makes the code run more slowly. A hybrid solution is to start up quickly in the Emterpreter, then switch to faster execution in full asm.js speed later. This is possible by **swapping** the asm.js module - first load the Emterpreted one, then load the fast one in the background and switch to it when it's ready.
-
-To do this, build the project twice:
-
- * Once with the Emterpreter option enabled, and ``SWAPPABLE_ASM_MODULE``. This is the module you will start up with, and swap out when the fast one is ready.
- * Again to normal asm.js, then run ``tools/distill_asm.py infile.js outfile.js swap-in``. The output, ``outfile.js``, will be just the asm module itself. You can then load this in a script tag on the same page, and it will swap itself in when it is ready.
-
-Improving Startup 2: Set Aside Cold Code
-----------------------------------------
+Improving Startup: Set Aside Cold Code
+--------------------------------------
 
 If you have a method that you know will only ever run exactly once, and doesn't need to be fast, you can run that specific method in the Emterpreter: As mentioned above, the JavaScript engine won't need to compile it, and the bytecode is smaller than asm.js, so both download and startup will be faster. Another example is exception-handling or assertion reporting code, something that should never run, and if it does, is ok to run at a slower speed.
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1061,15 +1061,6 @@ var ASM_JS = 1;
 // [fastcomp-only]
 var FINALIZE_ASM_JS = 1;
 
-// If 1, then all exports from the asm/wasm module will be accessed indirectly,
-// which allow the module to be swapped later, simply by replacing
-// Module['asm'].
-//
-// Note: It is very important that the replacement module be built with the same
-// optimizations and so forth, as we depend on them being a drop-in replacement
-// for each other (same globals on the heap at the same locations, etc.)
-var SWAPPABLE_ASM_MODULE = 0;
-
 // see emcc --separate-asm
 // [fastcomp-only]
 var SEPARATE_ASM = 0;
@@ -1738,6 +1729,7 @@ var ASM_PRIMITIVE_VARS = ['__THREW__', 'threwValue', 'setjmpId', 'tempInt', 'tem
 // settings, for backwards compatibility.
 var LEGACY_SETTINGS = [
   ['BINARYEN_ASYNC_COMPILATION', 'WASM_ASYNC_COMPILATION'],
+  ['SWAPPABLE_ASM_MODULE', [0], 'Removed support SWAPPABLE_ASM_MODULE'],
   ['UNALIGNED_MEMORY', [0], 'forced unaligned memory not supported in fastcomp'],
   ['FORCE_ALIGNED_MEMORY', [0], 'forced aligned memory is not supported in fastcomp'],
   ['PGO', [0], 'pgo no longer supported'],

--- a/tools/distill_asm.py
+++ b/tools/distill_asm.py
@@ -27,16 +27,7 @@ extra = sys.argv[3] if len(sys.argv) >= 4 else ';'
 
 module = asm_module.AsmModule(infile).asm_js
 
-if extra == 'swap-in':
-  # we do |var asm = | just like the original codebase, so that gets overridden anyhow (assuming global scripts).
-  extra = r''' (asmGlobalArg, asmLibraryArg, buffer);
- // special fixups
- asm.stackRestore(Module['asm'].stackSave()); // if this fails, make sure the original was built to be swappable (-s SWAPPABLE_ASM_MODULE=1)
- // Finish swap
- Module['asm'] = asm;
- if (Module['onAsmSwap']) Module['onAsmSwap']();
-'''
-elif extra == 'just-func':
+if extra == 'just-func':
   module = module[module.find('=') + 1:] # strip the initial "var asm =" bit, leave just the raw module as a function
   extra = ';'
 

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -35,7 +35,6 @@ ZERO = False
 ASYNC = False
 ASSERTIONS = False
 PROFILING = False
-SWAPPABLE = False
 FROUND = False
 ADVISE = False
 MEMORY_SAFE = False
@@ -799,9 +798,6 @@ if __name__ == '__main__':
   if len(sys.argv) >= 6:
     SYNC_FUNCS.update(read_json_list(sys.argv[5]))
 
-  if len(sys.argv) >= 7:
-    SWAPPABLE = int(sys.argv[6])
-
   if ADVISE:
     # Advise the user on which functions should likely be emterpreted
     data = shared.Building.calculate_reachable_functions(infile, list(SYNC_FUNCS))
@@ -831,7 +827,7 @@ if __name__ == '__main__':
 
   BLACKLIST = set(list(BLACKLIST) + extra_blacklist)
 
-  if DEBUG or SWAPPABLE:
+  if DEBUG:
     orig = infile + '.orig.js'
     shared.logger.debug('saving original (non-emterpreted) code to ' + orig)
     shutil.copyfile(infile, orig)


### PR DESCRIPTION
This is an asm.js flag that was used to allow emterpreter builds to be
swapped in at runtime.  I noticed that we don't really support this
in wasm especially since #9922 landed so I'd like to simply remove this
flag to avoid confusion.