### PR TITLE
Remove CLOSURE_COMPILER comment from default config

### DIFF
--- a/tools/settings_template.py
+++ b/tools/settings_template.py
@@ -33,8 +33,6 @@ NODE_JS = os.path.expanduser(os.getenv('NODE', '{{{ NODE }}}')) # executable
 
 JAVA = 'java' # executable
 
-# CLOSURE_COMPILER = '..' # define this to not use the bundled version
-
 ################################################################################
 #
 # Test suite options:


### PR DESCRIPTION
Now that this is installed via `npm install` people shouldn't be
configuring it in this way.  As a followup we should probably
remove this key completely from the config.