### PR TITLE
Disable browser.test_cubegeom_normal_dap_far_glda_quad on firefox

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2036,6 +2036,7 @@ void *getBindBuffer() {
     self.btest('cubegeom_normal_dap_far_glda.c', reference='cubegeom_normal_dap_far_glda.png', args=['-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL'])
 
   @requires_graphics_hardware
+  @no_firefox('fails on CI but works locally')
   def test_cubegeom_normal_dap_far_glda_quad(self): # with quad
     self.btest('cubegeom_normal_dap_far_glda_quad.c', reference='cubegeom_normal_dap_far_glda_quad.png', args=['-s', 'LEGACY_GL_EMULATION=1', '-lGL', '-lSDL'])
 


### PR DESCRIPTION
I investigated that new consistent CI failure, and it works
locally for me on firefox dev, so it's possible there
is some weird combination of GPU driver on the bots +
a recent firefox change that interacts badly. Hard to know
where to send a bug report. Anyhow, this is a minor test so
we shouldn't be losing much coverage here (the test doesn't
really stress anything special, just yet another GL operation).