### PR TITLE
Use `npm ci` to install node_modules

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,14 +14,14 @@ executors:
 
 commands:
   npm-install:
-    description: "npm install"
+    description: "npm ci"
     steps:
       - run:
-          name: npm install
+          name: npm ci
           command: |
             # Will add emsdk version of node to PATH
             source ~/emsdk-master/emsdk_env.sh
-            npm install
+            npm ci
   build-upstream:
     description: "Install emsdk build all libraries using embuilder"
     steps:


### PR DESCRIPTION
Apparently its faster, and also more correct to use this command in
CI.

See https://github.com/emscripten-core/emscripten/issues/10294