### PR TITLE
Simplify browser.test_sdl2_ttf in hopes of reducing flakes

### DIFF
--- a/tests/sdl2_ttf.c
+++ b/tests/sdl2_ttf.c
@@ -8,13 +8,12 @@
 #include <stdio.h>
 #include <SDL.h>
 #include <SDL_ttf.h>
-#include <emscripten.h>
 
 SDL_Window *window;
 SDL_Renderer *renderer;
 TTF_Font *font;
 
-void frame()
+void render()
 {
     static SDL_Color colorA = { 0xff, 0x99, 0x00, 0xff };
     static SDL_Color colorB = { 0x11, 0xff, 0xff, 0xff };
@@ -44,5 +43,5 @@ int main()
     TTF_Init();
     SDL_CreateWindowAndRenderer(640, 480, 0, &window, &renderer);
     font = TTF_OpenFont("LiberationSansBold.ttf", 40);
-    emscripten_set_main_loop(frame, -1, 1);
+    render();
 }


### PR DESCRIPTION
My theory (which I cannot test as no matter how much I
run this locally it never fails), is that the excess main loop
adds an async timing difference that somehow becomes
significant. We just don't need it anyhow, I suspect it's a
leftover from the the test this was copied off of, so this is
nice anyhow.