### PR TITLE
update package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -82,7 +82,9 @@
         "chalk": "2.x",
         "google-closure-compiler-java": "^20191111.0.0",
         "google-closure-compiler-js": "^20191111.0.0",
+        "google-closure-compiler-linux": "^20191111.0.0",
         "google-closure-compiler-osx": "^20191111.0.0",
+        "google-closure-compiler-windows": "^20191111.0.0",
         "minimist": "1.x",
         "vinyl": "2.x",
         "vinyl-sourcemaps-apply": "^0.2.0"
@@ -98,10 +100,22 @@
       "resolved": "https://registry.npmjs.org/google-closure-compiler-js/-/google-closure-compiler-js-20191111.0.0.tgz",
       "integrity": "sha512-W3Oy5NF5CMgUv31CMbgLN7zhdCTVMTnNI//iEPYMotzXfX8viyOnTMipDDwJNeMnY7lfXbQrYOo+QkWP6WzZtg=="
     },
+    "google-closure-compiler-linux": {
+      "version": "20191111.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-linux/-/google-closure-compiler-linux-20191111.0.0.tgz",
+      "integrity": "sha512-pxxB83Ae7G9OHFSOEzOYlp844YyqQgU1RXBpCGBKeDAQrs3dykHqRhNGZdI7N1tsby/pT+hKL1US2l/CslPqag==",
+      "optional": true
+    },
     "google-closure-compiler-osx": {
       "version": "20191111.0.0",
       "resolved": "https://registry.npmjs.org/google-closure-compiler-osx/-/google-closure-compiler-osx-20191111.0.0.tgz",
       "integrity": "sha512-sviL1DLN+dDfYBLzmU6+2Yk19P1uzUHQuKaXrHxEYZkU4jTJNq/TC4xi6t0ZgvLQEm2Vf7xhOrt80TYKnoQaVg==",
+      "optional": true
+    },
+    "google-closure-compiler-windows": {
+      "version": "20191111.0.0",
+      "resolved": "https://registry.npmjs.org/google-closure-compiler-windows/-/google-closure-compiler-windows-20191111.0.0.tgz",
+      "integrity": "sha512-iKdz2bWrrM4zLv3USCRtWX4kLWzZhbj/afh/W6giLxg5XQzbNg+UpVF+2G6f/LEYK9UNBgS2TdyNTuw8mod+Mg==",
       "optional": true
     },
     "has-flag": {


### PR DESCRIPTION
Actually, I think  #10294 may be caused by an issue with google-closure-compiler package and not npm install itself?

It looks like if I do `npm install` twice and then capture package-lock.json, it stays stable. And it stays stable even for first time install.

That is, perhaps if we push package-lock.json in in this format, it should no longer diff.