### PR TITLE
Revert "Strip -fPIC compiler flag during compilation (#10209)"

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1967,9 +1967,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return any(flag.startswith(x) for x in ('-l', '-L', '-Wl,'))
 
       compile_args = [a for a in newargs if a and not is_link_flag(a)]
-      if '-fPIC' in compile_args and not shared.Settings.RELOCATABLE:
-        shared.warning('ignoring -fPIC flag when not building with SIDE_MODULE or MAIN_MODULE')
-        compile_args.remove('-fPIC')
 
       # Bitcode args generation code
       def get_clang_command(input_files):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8593,7 +8593,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   def test_fpic_static(self):
     self.emcc_args.append('-fPIC')
-    self.emcc_args.remove('-Werror')
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
 
   @node_pthreads


### PR DESCRIPTION
Now that we have landed (for the third time) the binaryen fix for
https://github.com/WebAssembly/binaryen/issues/2180 we can once
again allow `-fPIC` at compile time as an alternative to MAIN_MODULE
or SIDE_MODULE.

This reverts commit 19a9e35062c0a49593b04c3e83c94c6b0efd91b9.