### PR TITLE
Fix PAGE_SIZE changes from #10284 

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -303,7 +303,7 @@ LibraryManager.library = {
 
   getpagesize: function() {
     // int getpagesize(void);
-    return {{{ FS_PAGE_SIZE }}};
+    return {{{ POSIX_PAGE_SIZE }}};
   },
 
   sysconf__deps: ['__setErrNo'],
@@ -313,7 +313,7 @@ LibraryManager.library = {
     // long sysconf(int name);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/sysconf.html
     switch(name) {
-      case {{{ cDefine('_SC_PAGE_SIZE') }}}: return {{{ FS_PAGE_SIZE }}};
+      case {{{ cDefine('_SC_PAGE_SIZE') }}}: return {{{ POSIX_PAGE_SIZE }}};
       case {{{ cDefine('_SC_PHYS_PAGES') }}}:
 #if WASM
         var maxHeapSize = 2*1024*1024*1024 - 65536;
@@ -326,7 +326,7 @@ LibraryManager.library = {
 #if !ALLOW_MEMORY_GROWTH
         maxHeapSize = HEAPU8.length;
 #endif
-        return maxHeapSize / {{{ FS_PAGE_SIZE }}};
+        return maxHeapSize / {{{ POSIX_PAGE_SIZE }}};
       case {{{ cDefine('_SC_ADVISORY_INFO') }}}:
       case {{{ cDefine('_SC_BARRIERS') }}}:
       case {{{ cDefine('_SC_ASYNCHRONOUS_IO') }}}:

--- a/src/library.js
+++ b/src/library.js
@@ -563,7 +563,7 @@ LibraryManager.library = {
     _emscripten_trace_report_memory_layout();
 #endif
 
-    var PAGE_MULTIPLE = {{{ FS_PAGE_SIZE }}};
+    var PAGE_MULTIPLE = {{{ 4 * FS_PAGE_SIZE }}};
 
     // Memory resize rules:
     // 1. When resizing, always produce a resized heap that is at least 16MB (to avoid tiny heap sizes receiving lots of repeated resizes at startup)

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -235,7 +235,7 @@ var SyscallsLibrary = {
     var allocated = false;
 
     // addr argument must be page aligned if MAP_FIXED flag is set.
-    if ((flags & {{{ cDefine('MAP_FIXED') }}}) !== 0 && (addr % {{{ FS_PAGE_SIZE }}}) !== 0) {
+    if ((flags & {{{ cDefine('MAP_FIXED') }}}) !== 0 && (addr % {{{ POSIX_PAGE_SIZE }}}) !== 0) {
       return -{{{ cDefine('EINVAL') }}};
     }
 
@@ -243,7 +243,7 @@ var SyscallsLibrary = {
     // but it is widely used way to allocate memory pages on Linux, BSD and Mac.
     // In this case fd argument is ignored.
     if ((flags & {{{ cDefine('MAP_ANONYMOUS') }}}) !== 0) {
-      ptr = _memalign({{{ FS_PAGE_SIZE }}}, len);
+      ptr = _memalign({{{ POSIX_PAGE_SIZE }}}, len);
       if (!ptr) return -{{{ cDefine('ENOMEM') }}};
       _memset(ptr, 0, len);
       allocated = true;

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -224,19 +224,18 @@ var SyscallsLibrary = {
     }
   },
 
-  _emscripten_syscall_mmap2__deps: ['memalign', 'memset', '$SYSCALLS', 'getpagesize',
+  _emscripten_syscall_mmap2__deps: ['memalign', 'memset', '$SYSCALLS',
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
     '$FS',
 #endif
   ],
   _emscripten_syscall_mmap2: function(addr, len, prot, flags, fd, off) {
-    var PAGE_SIZE = _getpagesize();
     off <<= 12; // undo pgoffset
     var ptr;
     var allocated = false;
 
     // addr argument must be page aligned if MAP_FIXED flag is set.
-    if ((flags & {{{ cDefine('MAP_FIXED') }}}) !== 0 && (addr % PAGE_SIZE) !== 0) {
+    if ((flags & {{{ cDefine('MAP_FIXED') }}}) !== 0 && (addr % {{{ FS_PAGE_SIZE }}}) !== 0) {
       return -{{{ cDefine('EINVAL') }}};
     }
 
@@ -244,7 +243,7 @@ var SyscallsLibrary = {
     // but it is widely used way to allocate memory pages on Linux, BSD and Mac.
     // In this case fd argument is ignored.
     if ((flags & {{{ cDefine('MAP_ANONYMOUS') }}}) !== 0) {
-      ptr = _memalign(PAGE_SIZE, len);
+      ptr = _memalign({{{ FS_PAGE_SIZE }}}, len);
       if (!ptr) return -{{{ cDefine('ENOMEM') }}};
       _memset(ptr, 0, len);
       allocated = true;

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1546,6 +1546,9 @@ function makeRetainedCompilerSettings() {
   return ret;
 }
 
+// Page size of the virtual filesystem.
+var FS_PAGE_SIZE = 16384;
+
 // In wasm, the heap size must be a multiple of 64KB.
 // In asm.js, it must be a multiple of 16MB.
 var WASM_PAGE_SIZE = 65536;

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1546,9 +1546,6 @@ function makeRetainedCompilerSettings() {
   return ret;
 }
 
-// Page size of the virtual filesystem.
-var FS_PAGE_SIZE = 16384;
-
 // In wasm, the heap size must be a multiple of 64KB.
 // In asm.js, it must be a multiple of 16MB.
 var WASM_PAGE_SIZE = 65536;
@@ -1557,6 +1554,13 @@ var ASMJS_PAGE_SIZE = 16777216;
 function getMemoryPageSize() {
   return WASM ? WASM_PAGE_SIZE : ASMJS_PAGE_SIZE;
 }
+
+// Page size reported by some POSIX calls, mostly filesystem. This does not
+// depend on the memory page size which differs between wasm and asm.js, and
+// makes us report a consistent value despite the compile target. However,
+// perhaps we should unify all the page sizes (especially after fastcomp is
+// gone TODO).
+var POSIX_PAGE_SIZE = 16384;
 
 // Receives a function as text, and a function that constructs a modified
 // function, to which we pass the parsed-out name, arguments, and body of the

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -312,7 +312,7 @@ function getMemory(size) {
 
 // Memory management
 
-var PAGE_SIZE = 16384;
+var PAGE_SIZE = {{{ FS_PAGE_SIZE }}};
 var WASM_PAGE_SIZE = {{{ WASM_PAGE_SIZE }}};
 var ASMJS_PAGE_SIZE = {{{ ASMJS_PAGE_SIZE }}};
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -312,7 +312,7 @@ function getMemory(size) {
 
 // Memory management
 
-var PAGE_SIZE = {{{ FS_PAGE_SIZE }}};
+var PAGE_SIZE = {{{ POSIX_PAGE_SIZE }}};
 var WASM_PAGE_SIZE = {{{ WASM_PAGE_SIZE }}};
 var ASMJS_PAGE_SIZE = {{{ ASMJS_PAGE_SIZE }}};
 


### PR DESCRIPTION
The wasm/asmjs page size is different from the filesystem page size, I think we mixed them up a little before.

This should also be smaller than before as it avoids calling `getpagesize()`.

Alternative to #10318