### PR TITLE
Force java version of closure compile on windows

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2526,8 +2526,8 @@ class Building(object):
         args.append('--jscomp_off=*')
       if pretty:
         args += ['--formatting', 'PRETTY_PRINT']
-      if os.environ.get('EMCC_CLOSURE_ARGS'):
-        args += shlex.split(os.environ.get('EMCC_CLOSURE_ARGS'))
+      if 'EMCC_CLOSURE_ARGS' in os.environ:
+        args += shlex.split(os.environ['EMCC_CLOSURE_ARGS'])
       args += extra_closure_args
       args += ['--js', filename]
       logger.debug('closure compiler: ' + ' '.join(args))
@@ -2538,6 +2538,11 @@ class Building(object):
       java_home = os.path.dirname(JAVA)
       if java_home:
         env.setdefault('JAVA_HOME', java_home)
+      if WINDOWS and '--platform' not in os.environ.get('EMCC_CLOSURE_ARGS'):
+        # Disable native compiler on windows until upstream issue if fixes
+        # https://github.com/google/closure-compiler-npm/issues/147
+        args.append('--platform=java')
+
       proc = run_process(args, stderr=PIPE, check=False, env=env)
       if proc.returncode != 0:
         sys.stderr.write(proc.stderr)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2540,7 +2540,7 @@ class Building(object):
       if java_home:
         env.setdefault('JAVA_HOME', java_home)
       if WINDOWS and '--platform' not in user_args:
-        # Disable native compiler on windows until upstream issue if fixes
+        # Disable native compiler on windows until upstream issue is fixed:
         # https://github.com/google/closure-compiler-npm/issues/147
         args.append('--platform=java')
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2526,8 +2526,9 @@ class Building(object):
         args.append('--jscomp_off=*')
       if pretty:
         args += ['--formatting', 'PRETTY_PRINT']
-      if 'EMCC_CLOSURE_ARGS' in os.environ:
-        args += shlex.split(os.environ['EMCC_CLOSURE_ARGS'])
+      user_args = os.environ.get('EMCC_CLOSURE_ARGS')
+      if user_args:
+        args += shlex.split(user_args)
       args += extra_closure_args
       args += ['--js', filename]
       logger.debug('closure compiler: ' + ' '.join(args))
@@ -2538,7 +2539,7 @@ class Building(object):
       java_home = os.path.dirname(JAVA)
       if java_home:
         env.setdefault('JAVA_HOME', java_home)
-      if WINDOWS and '--platform' not in os.environ.get('EMCC_CLOSURE_ARGS'):
+      if WINDOWS and '--platform' not in user_args:
         # Disable native compiler on windows until upstream issue if fixes
         # https://github.com/google/closure-compiler-npm/issues/147
         args.append('--platform=java')


### PR DESCRIPTION
At least until the upstream issue with the native version is
fixed.  See https://github.com/google/closure-compiler-npm/issues/147

Users who really want to try out the native version have the right DLLs installed
can still use the native vesrsion by setting `--platform=native` in 
`$EMCC_CLOSURE_ARGS`