### PR TITLE
Fix check_closure_compiler to match the environment we run it in

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1159,7 +1159,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if options.use_closure_compiler:
       shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
-      shared.check_closure_compiler()
       # when we emit asm.js, closure 2 would break that, so warn (note that
       # with wasm2js in the wasm backend, we don't emit asm.js anyhow)
       if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1 and not shared.Settings.WASM_BACKEND:


### PR DESCRIPTION
As a side effect this also removes the preliminary call to
check_closure_compiler.  Now we only call this function when
the compiler is about to run.