### PR TITLE
Add a closure suppression only for fastcomp asm.js code

### DIFF
--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -380,9 +380,10 @@ EMSCRIPTEN_FUNCS();
 
       passes = list(filter(check_symbol_mapping, passes))
       asm_shell_pre, asm_shell_post = minifier.minify_shell(asm_shell, 'minifyWhitespace' in passes, source_map).split('EMSCRIPTEN_FUNCS();')
+      if not shared.Settings.WASM_BACKEND:
       # Restore a comment for Closure Compiler
-      asm_open_bracket = asm_shell_pre.find('(')
-      asm_shell_pre = asm_shell_pre[:asm_open_bracket + 1] + '/** @suppress {uselessCode} */' + asm_shell_pre[asm_open_bracket + 1:]
+        asm_open_bracket = asm_shell_pre.find('(')
+        asm_shell_pre = asm_shell_pre[:asm_open_bracket + 1] + '/** @suppress {uselessCode} */' + asm_shell_pre[asm_open_bracket + 1:]
       asm_shell_post = asm_shell_post.replace('});', '})')
       pre += asm_shell_pre + '\n' + start_funcs_marker
       post = end_funcs_marker + asm_shell_post + post

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -381,7 +381,7 @@ EMSCRIPTEN_FUNCS();
       passes = list(filter(check_symbol_mapping, passes))
       asm_shell_pre, asm_shell_post = minifier.minify_shell(asm_shell, 'minifyWhitespace' in passes, source_map).split('EMSCRIPTEN_FUNCS();')
       if not shared.Settings.WASM_BACKEND:
-      # Restore a comment for Closure Compiler
+        # Restore a comment for Closure Compiler
         asm_open_bracket = asm_shell_pre.find('(')
         asm_shell_pre = asm_shell_pre[:asm_open_bracket + 1] + '/** @suppress {uselessCode} */' + asm_shell_pre[asm_open_bracket + 1:]
       asm_shell_post = asm_shell_post.replace('});', '})')


### PR DESCRIPTION
It is not necessary for wasm2js with the wasm backend,
where things look very differently. This code just tried to
parse the wasm2js code and ended up with bad results,
putting the suppression in the middle of irrelevant code,
which was ignored by closure as a bad annotation, but
if warnings are errors then it is noticeable.