### PR TITLE
Add java bin directory to PATH for closure-compiler

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2470,10 +2470,11 @@ class Building(object):
   @staticmethod
   def closure_compiler(filename, pretty=True, advanced=True, extra_closure_args=[]):
     with ToolchainProfiler.profile_block('closure_compiler'):
+      env = os.environ.copy()
+
       def add_to_path(dirname):
         env['PATH'] = env['PATH'] + os.pathsep + dirname
 
-      env = os.environ.copy()
       add_to_path(get_node_directory())
       args = list(extra_closure_args)
       env_args = os.environ.get('EMCC_CLOSURE_ARGS', '')


### PR DESCRIPTION
The closure compiler driver requires "java" to be in the PATH in order
to use the java backend.

https://github.com/google/closure-compiler-npm/blob/308b9e49e8f96211060a0dc466bafe99cddd9f96/packages/google-closure-compiler/lib/node/closure-compiler.js#L157

This is yet another attempt for fix #10304.

Also address issue from #10328 where --closure-args was not being
honored