### PR TITLE
Do we really need both ENVIRONMENT_IS_NODE and ENVIRONMENT_HAS_NODE?

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -199,7 +199,7 @@ ENVIRONMENT_MAY_BE_SHELL  = !ENVIRONMENT || ENVIRONMENTS.indexOf('shell') >= 0;
 // The worker case also includes Node.js workers when pthreads are
 // enabled and Node.js is one of the supported environments for the build to
 // run on. Node.js workers are detected as a combination of
-// ENVIRONMENT_IS_WORKER and ENVIRONMENT_HAS_NODE.
+// ENVIRONMENT_IS_WORKER and ENVIRONMENT_IS_NODE.
 ENVIRONMENT_MAY_BE_WORKER = !ENVIRONMENT || ENVIRONMENTS.indexOf('worker') >= 0 ||
                             (ENVIRONMENT_MAY_BE_NODE && USE_PTHREADS);
 

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -5,7 +5,7 @@
 
 mergeInto(LibraryManager.library, {
   $NODEFS__deps: ['$FS', '$PATH', '$ERRNO_CODES'],
-  $NODEFS__postset: 'if (ENVIRONMENT_HAS_NODE) { var fs = require("fs"); var NODEJS_PATH = require("path"); NODEFS.staticInit(); }',
+  $NODEFS__postset: 'if (ENVIRONMENT_IS_NODE) { var fs = require("fs"); var NODEJS_PATH = require("path"); NODEFS.staticInit(); }',
   $NODEFS: {
     isWindows: false,
     staticInit: function() {
@@ -38,7 +38,7 @@ mergeInto(LibraryManager.library, {
       return ERRNO_CODES[code];
     },
     mount: function (mount) {
-      assert(ENVIRONMENT_HAS_NODE);
+      assert(ENVIRONMENT_IS_NODE);
       return NODEFS.createNode(null, '/', NODEFS.getMode(mount.opts.root), 0);
     },
     createNode: function (parent, name, mode, dev) {

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -5,7 +5,7 @@
 
 mergeInto(LibraryManager.library, {
   $NODERAWFS__deps: ['$ERRNO_CODES', '$FS', '$NODEFS'],
-  $NODERAWFS__postset: 'if (ENVIRONMENT_HAS_NODE) {' +
+  $NODERAWFS__postset: 'if (ENVIRONMENT_IS_NODE) {' +
     'var _wrapNodeError = function(func) { return function() { try { return func.apply(this, arguments) } catch (e) { if (!e.code) throw e; throw new FS.ErrnoError(ERRNO_CODES[e.code]); } } };' +
     'var VFS = Object.assign({}, FS);' +
     'for (var _key in NODERAWFS) FS[_key] = _wrapNodeError(NODERAWFS[_key]);' +

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -359,7 +359,7 @@ var LibraryPThread = {
       };
 
 #if ENVIRONMENT_MAY_BE_NODE
-      if (ENVIRONMENT_HAS_NODE) {
+      if (ENVIRONMENT_IS_NODE) {
         worker.on('message', function(data) {
           worker.onmessage({ data: data });
         });
@@ -910,7 +910,7 @@ var LibraryPThread = {
     else PThread.threadExit(status);
 #if WASM_BACKEND
     // pthread_exit is marked noReturn, so we must not return from it.
-    if (ENVIRONMENT_HAS_NODE) {
+    if (ENVIRONMENT_IS_NODE) {
       // exit the pthread properly on node, as a normal JS exception will halt
       // the entire application.
       process.exit(status);

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1037,7 +1037,7 @@ function createWasm() {
     try {
       binary = getBinary();
 #if NODE_CODE_CACHING
-      if (ENVIRONMENT_HAS_NODE) {
+      if (ENVIRONMENT_IS_NODE) {
         var v8 = require('v8');
         // Include the V8 version in the cache name, so that we don't try to
         // load cached code from another version, which fails silently (it seems
@@ -1062,7 +1062,7 @@ err(module);
       if (!module) {
         module = new WebAssembly.Module(binary);
       }
-      if (ENVIRONMENT_HAS_NODE) {
+      if (ENVIRONMENT_IS_NODE) {
         if (!hasCached) {
 #if RUNTIME_LOGGING
           err('NODE_CODE_CACHING: saving module');

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -33,7 +33,7 @@ if (ENVIRONMENT_IS_PTHREAD) {
 #if USE_PTHREADS
     if (!(wasmMemory.buffer instanceof SharedArrayBuffer)) {
       err('requested a shared WebAssembly.Memory but the returned buffer is not a SharedArrayBuffer, indicating that while the browser has SharedArrayBuffer it does not have WebAssembly threads support - you may need to set a flag');
-      if (ENVIRONMENT_HAS_NODE) {
+      if (ENVIRONMENT_IS_NODE) {
         console.log('(on node you may need: --experimental-wasm-threads --experimental-wasm-bulk-memory and also use a recent version)');
       }
       throw Error('bad memory');

--- a/src/shell.js
+++ b/src/shell.js
@@ -92,10 +92,10 @@ var _scriptDir = import.meta.url;
 #else
 var _scriptDir = (typeof document !== 'undefined' && document.currentScript) ? document.currentScript.src : undefined;
 
-if (ENVIRONMENT_IS_NODE) {
-  _scriptDir = __filename;
-} else if (ENVIRONMENT_IS_WORKER) {
+if (ENVIRONMENT_IS_WORKER) {
   _scriptDir = self.location.href;
+} else if (ENVIRONMENT_IS_NODE) {
+  _scriptDir = __filename;
 }
 #endif
 #endif
@@ -127,7 +127,11 @@ if (ENVIRONMENT_IS_NODE) {
   if (!(typeof process === 'object' && typeof require === 'function')) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
 #endif
 #endif
-  scriptDirectory = __dirname + '/';
+  if (ENVIRONMENT_IS_WORKER) {
+    scriptDirectory = require('path').dirname(scriptDirectory) + '/';
+  } else {
+    scriptDirectory = __dirname + '/';
+  }
 
 #include "node_shell_read.js"
 


### PR DESCRIPTION
The ENVIRONMENT_IS_X checks are great because they do compress down to a single variable, so repeated environment checks are then all efficient for code size.

However they have a drawback that they are not DCEd away by Closure since they exist at top level (unless MODULARIZE is used), so they increase code size even if not used.

In https://github.com/emscripten-core/emscripten/pull/8594/files a new environment variable ENVIRONMENT_HAS_NODE was added (also slightly tweaked at https://github.com/emscripten-core/emscripten/pull/8736/files and https://github.com/emscripten-core/emscripten/pull/8832/files)

Looking at that set of changes, it seems to me that the variable `ENVIRONMENT_HAS_NODE` should not be necessary. Electron.js should be able to run with `ENVIRONMENT_IS_NODE` and `ENVIRONMENT_IS_WEB` being simultaneously true.

This PR drops ENVIRONMENT_HAS_NODE, and changes ENVIRONMENT_IS_NODE to be

```js
ENVIRONMENT_IS_NODE = typeof process === 'object'
                   && typeof process.versions === 'object'
                   && typeof process.versions.node === 'string';
```
instead of 
```js
ENVIRONMENT_IS_NODE = typeof process === 'object'
                   && typeof process.versions === 'object
                   && typeof process.versions.node === 'string'
                   && !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_WORKER;
```
because I cannot find a reason why `ENVIRONMENT_IS_NODE` should be enforced to be false if `ENVIRONMENT_IS_WEB` or `ENVIRONMENT_IS_WORKER` is true.

That should be simpler overall - having two variables `ENVIRONMENT_HAS_NODE` and `ENVIRONMENT_IS_NODE` can be confusing. I think we currently have had bugs in our JS library code that used the wrong one to check for Node.js environment.

CC @ericmandel 

I think this might also fix the React Native issue in https://github.com/emscripten-core/emscripten/pull/8982 . CC @brandonlehmann .