### PR TITLE
Switch the #! lines in all .py files to python3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ executors:
       EMTEST_DETECT_TEMPFILE_LEAKS: "1"
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
-      PYTHON_BIN: "python2"
+      PYTHON_BIN: "python3"
   mac:
     environment:
       EMSDK_NOTTY: "1"

--- a/em-config
+++ b/em-config
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 '''
 This is a helper tool which is designed to make it possible

--- a/emar.py
+++ b/emar.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2016 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/embuilder.py
+++ b/embuilder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2014 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/emcc.py
+++ b/emcc.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2011 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/emcmake.py
+++ b/emcmake.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2016 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/emconfigure.py
+++ b/emconfigure.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2016 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/emlink.py
+++ b/emlink.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2013 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/emmake.py
+++ b/emmake.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2016 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/emscons.py
+++ b/emscons.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """Wrapping the scons invocation, EMSCRIPTEN_TOOL_PATH is set in the process
 environment, and can be used to locate the emscripten SCons Tool.
 

--- a/site/source/docs/building_from_source/configuring_emscripten_settings.rst
+++ b/site/source/docs/building_from_source/configuring_emscripten_settings.rst
@@ -48,12 +48,12 @@ Compiler configuration file-format
 
 The file simply assigns paths to a number of *variables* representing the main tools used by Emscripten. For example, if the user installed python to the **C:/Python27/** directory, then the file might have the line: ::
 
-	PYTHON = 'C:\\Python27\\python2.exe'
+	PYTHON = 'C:\\Python38\\python.exe'
 	
 
 The default *emcc* configuration file often gets the paths from environment variables if defined. If no variable is defined the system will also attempt to find "system executables". For example:  ::
 
-	PYTHON = os.path.expanduser(os.getenv('PYTHON', 'C:\\Python27\\python2.exe'))
+	PYTHON = os.path.expanduser(os.getenv('PYTHON', 'C:\\Python38\\python.exe'))
 
 You can find out the other variable names from the default *.emscripten* file or the :ref:`example here <compiler-configuration-file>`. 
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2010 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/add_license.py
+++ b/tools/add_license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2018 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/debug/ll-strip.py
+++ b/tools/debug/ll-strip.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright 2017 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/emdebug_cd_merger.py
+++ b/tools/emdebug_cd_merger.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2016 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/emdump.py
+++ b/tools/emdump.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2018 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/emterpretify.py
+++ b/tools/emterpretify.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2014 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/exec_llvm.py
+++ b/tools/exec_llvm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # Copyright 2011 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/experimental/reproduceriter.py
+++ b/tools/experimental/reproduceriter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 # Copyright 2017 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/filelock.py
+++ b/tools/filelock.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/python3
 # This is free and unencumbered software released into the public domain.
 #
 # Anyone is free to copy, modify, publish, use, compile, sell, or

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2018 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be


### PR DESCRIPTION
This is one step towards using python3 by default everywhere.
Notably:
- python2 is still fully supported at this point
- The top level scripts such as `emcc` as opposed to `emcc.py` are
  still run under just "python" so will work with whatever the system
  default is.  This is because we still want to run on the default OSX
  install which doesn't python3 installed (and probably never will).

Also:
- switch circleci testing on linux to python2
- Update some docs that refer to python2

See #7198