### PR TITLE
Cleanup test_other.py

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4110,7 +4110,7 @@ int main(int argc, char **argv) {
     print('dd', sizes_dd)
 
     for sizes in [sizes_ii, sizes_dd]:
-      self.assertExists(sizes[-1], sizes[1]) # default is to alias
+      self.assertEqual(sizes[-1], sizes[1]) # default is to alias
       self.assertLess(sizes[1], sizes[0]) # without aliasing, we have more unique values and fat tables
 
   def test_bad_export(self):
@@ -4534,11 +4534,12 @@ dir
       }
     ''')
     run_process([PYTHON, EMCC, 'src.cpp'])
-    self.assertContained(r'''\
+    expected = '''\
 major: %d
 minor: %d
 tiny: %d
-''' % (shared.EMSCRIPTEN_VERSION_MAJOR, shared.EMSCRIPTEN_VERSION_MINOR, shared.EMSCRIPTEN_VERSION_TINY), run_js('a.out.js'))
+''' % (shared.EMSCRIPTEN_VERSION_MAJOR, shared.EMSCRIPTEN_VERSION_MINOR, shared.EMSCRIPTEN_VERSION_TINY)
+    self.assertContained(expected, run_js('a.out.js'))
 
   def test_libc_files_without_syscalls(self):
     # a program which includes FS due to libc js library support, but has no syscalls,

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -284,6 +284,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         print('skip because windows')
         continue
       target = args[1] if len(args) == 2 else 'hello_world.o'
+      self.clear()
       run_process([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix)] + args)
       if args[-1] == '/dev/null':
         print('(no output)')
@@ -5253,7 +5254,7 @@ main(const int argc, const char * const * const argv)
     ''')
     run_process([PYTHON, EMCC, 'src.cpp', '-s', 'EXIT_RUNTIME=1', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     self.assertContained('Constructed locale "C"\nThis locale is the global locale.\nThis locale is the C locale.', run_js('a.out.js', args=['C']))
-    self.assertContained('Can\'t construct locale "waka": collate_byname<char>::collate_byname failed to construct for waka', run_js('a.out.js', args=['waka'], assert_returncode=1))
+    self.assertContained('''Can't construct locale "waka": collate_byname<char>::collate_byname failed to construct for waka''', run_js('a.out.js', args=['waka'], assert_returncode=1))
 
   def test_cleanup_os(self):
     # issue 2644

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -227,9 +227,9 @@ class other(RunnerCore):
   def test_emcc_out_file(self):
     # Verify that "-ofile" works in addition to "-o" "file"
     run_process([PYTHON, EMCC, '-c', '-ofoo.o', path_from_root('tests', 'hello_world.c')])
-    assert os.path.exists('foo.o')
+    self.assertExists('foo.o')
     run_process([PYTHON, EMCC, '-ofoo.js', 'foo.o'])
-    assert os.path.exists('foo.js')
+    self.assertExists('foo.js')
 
   @parameterized({
     'c': [EMCC, '.c'],
@@ -284,7 +284,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         print('skip because windows')
         continue
       target = args[1] if len(args) == 2 else 'hello_world.o'
-      self.clear()
       run_process([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix)] + args)
       if args[-1] == '/dev/null':
         print('(no output)')
@@ -550,9 +549,9 @@ f.close()
         if not wasm and not self.is_wasm_backend():
           src = open('a.out.js').read()
           if opts == []:
-            assert 'almost asm' in src
+            self.assertContained('almost asm', src)
           else:
-            assert 'use asm' in src
+            self.assertContained('use asm', src)
 
   def test_emcc_cflags(self):
     output = run_process([PYTHON, EMCC, '--cflags'], stdout=PIPE)
@@ -880,8 +879,8 @@ f.close()
     src = test(['-O2', '-s', 'ASM_JS=1', '-g'])
     debug_size = len(src)
     print('debug', debug_size)
-    assert debug_size > unminified_size
-    assert 'function _malloc' in src
+    self.assertGreater(debug_size, unminified_size)
+    self.assertContained('function _malloc', src)
 
   @no_wasm_backend('tests fastcomp extra assertions for function pointer errors - do we need these?')
   def test_dangerous_func_cast(self):
@@ -1008,7 +1007,9 @@ f.close()
 
     self.assertContained('hello from lib', run_js(aout))
 
-    assert not os.path.exists('a.out') and not os.path.exists('a.exe'), 'Must not leave unneeded linker stubs'
+    # Must not leave unneeded linker stubs
+    self.assertNotExists('a.out')
+    self.assertNotExists('a.exe')
 
   def test_commons_link(self):
     create_test_file('a.h', r'''
@@ -1295,8 +1296,8 @@ int f() {
     # check that we warn if an object file in a .a is not valid bitcode.
     # do not silently ignore native object files, which may have been
     # built by mistake
-    create_test_file('side.cpp', r'''int side() { return 5; }''')
-    create_test_file('main.cpp', r'''extern int side(); int main() { return side(); }''')
+    create_test_file('side.cpp', r'int side() { return 5; }')
+    create_test_file('main.cpp', r'extern int side(); int main() { return side(); }')
     run_process([CLANG, 'side.cpp', '-c', '-o', 'native.o'])
     run_process([PYTHON, EMAR, 'crs', 'foo.a', 'native.o'])
     proc = run_process([PYTHON, EMCC, 'main.cpp', 'foo.a', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'], stderr=PIPE)
@@ -1581,7 +1582,7 @@ int f() {
     try_delete('libdup.a')
     run_process([LLVM_AR, 'rc', 'libdup.a', os.path.join('a', 'common.o'), os.path.join('b', 'common.o')])
     text = run_process([PYTHON, EMAR, 't', 'libdup.a'], stdout=PIPE).stdout
-    assert text.count('common.o') == 2, text
+    self.assertEqual(text.count('common.o'), 2)
 
     # With fastcomp we don't support duplicate members so this should generate
     # a warning.  With the wasm backend (lld) this is fully supported.
@@ -1661,9 +1662,9 @@ int f() {
     ensure_dir(self.in_dir('tst', 'test1'))
     ensure_dir(self.in_dir('tst', 'test2'))
 
-    open(self.in_dir('tst', 'aa.txt'), 'w').write('''frist''')
-    open(self.in_dir('tst', 'test1', 'aa.txt'), 'w').write('''sacond''')
-    open(self.in_dir('tst', 'test2', 'aa.txt'), 'w').write('''thard''')
+    open(self.in_dir('tst', 'aa.txt'), 'w').write('frist')
+    open(self.in_dir('tst', 'test1', 'aa.txt'), 'w').write('sacond')
+    open(self.in_dir('tst', 'test2', 'aa.txt'), 'w').write('thard')
     create_test_file('main.cpp', r'''
       #include <stdio.h>
       #include <string.h>
@@ -1691,10 +1692,10 @@ int f() {
     ensure_dir(self.in_dir('tst', 'abc.exe'))
     ensure_dir(self.in_dir('tst', 'abc.txt'))
 
-    open(self.in_dir('tst', 'hello.exe'), 'w').write('''hello''')
-    open(self.in_dir('tst', 'hello.txt'), 'w').write('''world''')
-    open(self.in_dir('tst', 'abc.exe', 'foo'), 'w').write('''emscripten''')
-    open(self.in_dir('tst', 'abc.txt', 'bar'), 'w').write('''!!!''')
+    open(self.in_dir('tst', 'hello.exe'), 'w').write('hello')
+    open(self.in_dir('tst', 'hello.txt'), 'w').write('world')
+    open(self.in_dir('tst', 'abc.exe', 'foo'), 'w').write('emscripten')
+    open(self.in_dir('tst', 'abc.txt', 'bar'), 'w').write('!!!')
     create_test_file('main.cpp', r'''
       #include <stdio.h>
       int main() {
@@ -1708,8 +1709,7 @@ int f() {
     ''')
 
     run_process([PYTHON, EMCC, 'main.cpp', '--embed-file', 'tst', '--exclude-file', '*.exe'])
-    output = run_js('a.out.js')
-    assert output == '' or output == ' \n'
+    self.assertEqual(run_js('a.out.js').strip(), '')
 
   def test_multidynamic_link(self):
     # Linking the same dynamic library in statically will error, normally, since we statically link it, causing dupe symbols
@@ -2275,7 +2275,7 @@ int f() {
         check_js(output, expected)
 
   def test_m_mm(self):
-    create_test_file('foo.c', '''#include <emscripten.h>''')
+    create_test_file('foo.c', '#include <emscripten.h>')
     for opt in ['M', 'MM']:
       proc = run_process([PYTHON, EMCC, 'foo.c', '-' + opt], stdout=PIPE, stderr=PIPE)
       assert 'foo.o: ' in proc.stdout, '-%s failed to produce the right output: %s' % (opt, proc.stdout)
@@ -2598,7 +2598,7 @@ int f() {
     self.assertContained(MESSAGE, err)
     # do not mention from emcc
     err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--preload-file', 'data.txt'], stdout=PIPE, stderr=PIPE).stderr
-    assert len(err) == 0, err
+    self.assertEqual(len(err), 0)
 
   def test_headless(self):
     shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'example.png')
@@ -2773,7 +2773,7 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
 
     # Check that test.js compiled with --closure 1 contains "module.exports", we want to verify that
     # "module['exports']" got minified to "module.exports" when compiling with --closure 1
-    assert "module.exports" in test_js_closure_1
+    self.assertContained("module.exports", test_js_closure_1)
 
     # Check that main.js (which requires test.js) completes successfully when run in node.js
     # in order to check that the exports are indeed functioning correctly.
@@ -3410,9 +3410,9 @@ int main() {
 }
 ''')
     output = run_process([PYTHON, EMCC, 'src.cpp', '-s', 'WASM=0', '-s', 'WARN_UNALIGNED=1', '-g'], stderr=PIPE)
-    assert 'emcc: warning: unaligned store' in output.stderr, output.stderr
-    assert 'emcc: warning: unaligned store' in output.stderr, output.stderr
-    assert '@line 11 "src.cpp"' in output.stderr, output.stderr
+    self.assertContained('emcc: warning: unaligned store', output.stderr)
+    self.assertContained('emcc: warning: unaligned store', output.stderr)
+    self.assertContained('@line 11 "src.cpp"', output.stderr)
 
   def test_LEGACY_VM_SUPPORT(self):
     # when modern features are lacking, we can polyfill them or at least warn
@@ -3588,7 +3588,7 @@ int main() {
             run_process(cmd)
             output = run_js('a.out.js', stderr=PIPE, full_output=True)
             exit = 1 - no_exit
-            assert 'hello' in output, output
+            self.assertContained('hello', output)
             assert ('world' in output) == (exit or flush), 'unflushed content is shown only when exiting the runtime'
             assert (no_exit and assertions and not flush) == ('stdio streams had content in them that was not flushed. you should set EXIT_RUNTIME to 1' in output), 'warning should be shown'
 
@@ -3735,8 +3735,8 @@ int main()
 }
 ''')
 
-    IMPLICIT_WARNING = '''warning: implicit declaration of function 'strnlen' is invalid in C99'''
-    IMPLICIT_ERROR = '''error: implicit declaration of function 'strnlen' is invalid in C99'''
+    IMPLICIT_WARNING = "warning: implicit declaration of function 'strnlen' is invalid in C99"
+    IMPLICIT_ERROR = "error: implicit declaration of function 'strnlen' is invalid in C99"
 
     for opts, expected, compile_expected in [
       ([], None, [IMPLICIT_ERROR]),
@@ -3746,10 +3746,10 @@ int main()
       print(opts, expected)
       try_delete('a.out.js')
       stderr = run_process([PYTHON, EMCC, 'src.c'] + opts, stderr=PIPE, check=False).stderr
-      for ce in compile_expected + ['''warning: incompatible pointer types''']:
+      for ce in compile_expected + ['warning: incompatible pointer types']:
         self.assertContained(ce, stderr)
       if expected is None:
-        assert not os.path.exists('a.out.js')
+        self.assertNotExists('a.out.js')
       else:
         output = run_js('a.out.js', stderr=PIPE, full_output=True)
         for e in expected:
@@ -4110,8 +4110,8 @@ int main(int argc, char **argv) {
     print('dd', sizes_dd)
 
     for sizes in [sizes_ii, sizes_dd]:
-      assert sizes[-1] == sizes[1] # default is to alias
-      assert sizes[1] < sizes[0] # without aliasing, we have more unique values and fat tables
+      self.assertExists(sizes[-1], sizes[1]) # default is to alias
+      self.assertLess(sizes[1], sizes[0]) # without aliasing, we have more unique values and fat tables
 
   def test_bad_export(self):
     for m in ['', ' ']:
@@ -4128,9 +4128,9 @@ int main(int argc, char **argv) {
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'DYNAMIC_EXECUTION=0'])
     self.assertContained('hello, world!', run_js('a.out.js'))
     src = open('a.out.js').read()
-    assert 'eval(' not in src
-    assert 'eval.' not in src
-    assert 'new Function' not in src
+    self.assertNotContained('eval(', src)
+    self.assertNotContained('eval.', src)
+    self.assertNotContained('new Function', src)
     try_delete('a.out.js')
 
     # Test that --preload-file doesn't add an use of eval().
@@ -4365,10 +4365,10 @@ int main(int argc, char **argv) {
     run_process([PYTHON, EMCC, 'src.cpp'])
 
     # cannot symlink nonexistents
-    self.assertContained(r'''Failed to symlink paths: , abc; errno=44''', run_js('a.out.js', args=['', 'abc']))
-    self.assertContained(r'''Failed to symlink paths: , ; errno=44''', run_js('a.out.js', args=['', '']))
-    self.assertContained(r'''ok''', run_js('a.out.js', args=['123', 'abc']))
-    self.assertContained(r'''Failed to symlink paths: abc, ; errno=44''', run_js('a.out.js', args=['abc', '']))
+    self.assertContained(r'Failed to symlink paths: , abc; errno=44', run_js('a.out.js', args=['', 'abc']))
+    self.assertContained(r'Failed to symlink paths: , ; errno=44', run_js('a.out.js', args=['', '']))
+    self.assertContained(r'ok', run_js('a.out.js', args=['123', 'abc']))
+    self.assertContained(r'Failed to symlink paths: abc, ; errno=44', run_js('a.out.js', args=['abc', '']))
 
   def test_rename_silly(self):
     create_test_file('src.cpp', r'''
@@ -4382,14 +4382,14 @@ int main(int argc, char **argv) {
     printf("ok\n");
   }
 }
-    ''')
+''')
     run_process([PYTHON, EMCC, 'src.cpp'])
 
     # cannot symlink nonexistents
-    self.assertContained(r'''Failed to rename paths: , abc; errno=44''', run_js('a.out.js', args=['', 'abc']))
-    self.assertContained(r'''Failed to rename paths: , ; errno=44''', run_js('a.out.js', args=['', '']))
-    self.assertContained(r'''Failed to rename paths: 123, abc; errno=44''', run_js('a.out.js', args=['123', 'abc']))
-    self.assertContained(r'''Failed to rename paths: abc, ; errno=44''', run_js('a.out.js', args=['abc', '']))
+    self.assertContained(r'Failed to rename paths: , abc; errno=44', run_js('a.out.js', args=['', 'abc']))
+    self.assertContained(r'Failed to rename paths: , ; errno=44', run_js('a.out.js', args=['', '']))
+    self.assertContained(r'Failed to rename paths: 123, abc; errno=44', run_js('a.out.js', args=['123', 'abc']))
+    self.assertContained(r'Failed to rename paths: abc, ; errno=44', run_js('a.out.js', args=['abc', '']))
 
   def test_readdir_r_silly(self):
     create_test_file('src.cpp', r'''
@@ -4534,7 +4534,8 @@ dir
       }
     ''')
     run_process([PYTHON, EMCC, 'src.cpp'])
-    self.assertContained(r'''major: %d
+    self.assertContained(r'''\
+major: %d
 minor: %d
 tiny: %d
 ''' % (shared.EMSCRIPTEN_VERSION_MAJOR, shared.EMSCRIPTEN_VERSION_MINOR, shared.EMSCRIPTEN_VERSION_TINY), run_js('a.out.js'))
@@ -5251,7 +5252,7 @@ main(const int argc, const char * const * const argv)
     ''')
     run_process([PYTHON, EMCC, 'src.cpp', '-s', 'EXIT_RUNTIME=1', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     self.assertContained('Constructed locale "C"\nThis locale is the global locale.\nThis locale is the C locale.', run_js('a.out.js', args=['C']))
-    self.assertContained('''Can't construct locale "waka": collate_byname<char>::collate_byname failed to construct for waka''', run_js('a.out.js', args=['waka'], assert_returncode=1))
+    self.assertContained('Can\'t construct locale "waka": collate_byname<char>::collate_byname failed to construct for waka', run_js('a.out.js', args=['waka'], assert_returncode=1))
 
   def test_cleanup_os(self):
     # issue 2644
@@ -6251,19 +6252,19 @@ int main() {
           print('can manage another:', can_manage_another, 'split:', split)
           output = run_js('a.out.js', stderr=PIPE, full_output=True, assert_returncode=0 if can_manage_another else None)
           if can_manage_another:
-            self.assertContained('''an allocation failed!\n''', output)
+            self.assertContained('an allocation failed!\n', output)
             if not split:
               # split memory allocation may fail due to GC objects no longer being allocatable,
               # and we can't expect to recover from that deterministically. So just check we
               # get to the fail.
               # otherwise, we should fail eventually, then free, then succeed
-              self.assertContained('''managed another malloc!\n''', output)
+              self.assertContained('managed another malloc!\n', output)
           else:
             # we should see an abort
-            self.assertContained('''abort(Cannot enlarge memory arrays''', output)
-            self.assertContained(('''higher than the current value 16777216,''', '''higher than the current value 33554432,'''), output)
-            self.assertContained('''compile with  -s ALLOW_MEMORY_GROWTH=1 ''', output)
-            self.assertContained('''compile with  -s ABORTING_MALLOC=0 ''', output)
+            self.assertContained('abort(Cannot enlarge memory arrays', output)
+            self.assertContained(('higher than the current value 16777216,', 'higher than the current value 33554432,'), output)
+            self.assertContained('compile with  -s ALLOW_MEMORY_GROWTH=1 ', output)
+            self.assertContained('compile with  -s ABORTING_MALLOC=0 ', output)
 
   def test_failing_growth_2gb(self):
     create_test_file('test.cpp', r'''
@@ -6822,31 +6823,32 @@ int main() {
     self.assertContained('ok', run_js('a.out.js'))
 
   def test_no_warn_exported_jslibfunc(self):
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["alGetError"]', '-s', 'EXPORTED_FUNCTIONS=["_main", "_alGetError"]'], stdout=PIPE, stderr=PIPE).stderr
-    self.assertNotContained('''function requested to be exported, but not implemented: "_alGetError"''', err)
+    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'),
+                       '-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["alGetError"]',
+                       '-s', 'EXPORTED_FUNCTIONS=["_main", "_alGetError"]'], stderr=PIPE).stderr
+    self.assertNotContained('function requested to be exported, but not implemented: "_alGetError"', err)
 
   @no_wasm_backend()
   def test_almost_asm_warning(self):
-    warning = "[-Walmost-asm]"
-    for args, expected in [
-      (['-O1', '-s', 'ALLOW_MEMORY_GROWTH=1'], True),  # default
-      # suppress almost-asm warning manually
-      (['-O1', '-s', 'ALLOW_MEMORY_GROWTH=1', '-Wno-almost-asm'], False),
-      # last warning flag should "win"
-      (['-O1', '-s', 'ALLOW_MEMORY_GROWTH=1', '-Wno-almost-asm', '-Walmost-asm'], True)
-    ]:
+    def run(args, expected):
       print(args, expected)
       err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0'] + args, stderr=PIPE).stderr
-      assert (warning in err) == expected, err
-      if not expected:
-        assert err == '', err
+      if expected:
+        self.assertContained('[-Walmost-asm]', err)
+      else:
+        self.assertEqual(err, '')
+
+    run(['-O1', '-s', 'ALLOW_MEMORY_GROWTH=1'], True),  # default
+    # suppress almost-asm warning manually
+    run(['-O1', '-s', 'ALLOW_MEMORY_GROWTH=1', '-Wno-almost-asm'], False),
+    # last warning flag should "win"
+    run(['-O1', '-s', 'ALLOW_MEMORY_GROWTH=1', '-Wno-almost-asm', '-Walmost-asm'], True)
 
   def test_musl_syscalls(self):
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
     src = open('a.out.js').read()
-    matches = re.findall(r'''function ___syscall(\d+)\(''', src)
     # there should be no musl syscalls in hello world output
-    self.assertEqual(matches, [])
+    self.assertNotContained('__syscall', src)
 
   @no_windows('posix-only')
   def test_emcc_dev_null(self):
@@ -6935,7 +6937,7 @@ main(int argc, char **argv)
 }
 ''')
     ensure_dir('boot')
-    open(os.path.join('boot', 'README.txt'), 'w').write(' ')
+    create_test_file(os.path.join('boot', 'README.txt'), ' ')
     run_process([PYTHON, EMCC, 'src.c', '--embed-file', 'boot'])
     self.assertContained('Resolved: /boot/README.txt', run_js('a.out.js'))
 
@@ -7007,7 +7009,7 @@ int main(int argc, char **argv)
 }
 ''')
     create_test_file('testfile.txt', '')
-    open(os.path.join('Folder', 'testfile.txt'), 'w').write('')
+    create_test_file(os.path.join('Folder', 'testfile.txt'), '')
     run_process([PYTHON, EMCC, 'src.c', '--embed-file', 'testfile.txt', '--embed-file', 'Folder'])
     self.assertContained('''Resolved: "testfile.txt" => "/testfile.txt"
 Resolved: "Folder/testfile.txt" => "/Folder/testfile.txt"
@@ -7024,7 +7026,7 @@ Resolved: "/" => "/"
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp')])
     # check that there is nothing in stderr for a regular compile
     err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp')], stderr=PIPE).stderr
-    assert err == '', err
+    self.assertEqual(err, '')
 
   @no_wasm_backend("uses EMTERPRETIFY")
   def test_emterpreter_file_suggestion(self):
@@ -7037,8 +7039,8 @@ Resolved: "/" => "/"
         print(cmd)
         stderr = run_process(cmd, stderr=PIPE).stderr
         need_warning = linkable and not to_file
-        assert ('''warning: emterpreter bytecode is fairly large''' in stderr) == need_warning, stderr
-        assert ('''It is recommended to use  -s EMTERPRETIFY_FILE=..''' in stderr) == need_warning, stderr
+        assert ('warning: emterpreter bytecode is fairly large' in stderr) == need_warning, stderr
+        assert ('It is recommended to use  -s EMTERPRETIFY_FILE=..' in stderr) == need_warning, stderr
 
   def test_llvm_lto(self):
     sizes = {}
@@ -7060,9 +7062,9 @@ Resolved: "/" => "/"
 
     # LTO should reduce code size
     # Skip mode 2 because it has historically increased code size, but not always
-    assert sizes[1] < sizes[0]
+    self.assertLess(sizes[1], sizes[0])
     if not self.is_wasm_backend():
-      assert sizes[3] < sizes[0]
+      self.assertLess(sizes[3], sizes[0])
 
   def test_dlmalloc_modes(self):
     create_test_file('src.cpp', r'''
@@ -7085,10 +7087,10 @@ Resolved: "/" => "/"
       out = run_js('a.out.js')
     except Exception:
       seen_error = True
-    assert seen_error, out
+    self.assertTrue(seen_error, out)
 
   def test_mallocs(self):
-    for opts in [[], ['-O2']]:
+    def run(opts):
       print(opts)
       sizes = {}
       for malloc, name in (
@@ -7108,6 +7110,8 @@ Resolved: "/" => "/"
       self.assertEqual(sizes['dlmalloc'], sizes['default'])
       # emmalloc is much smaller
       self.assertLess(sizes['emmalloc'], sizes['dlmalloc'] - 5000)
+    run([])
+    run(['-O2'])
 
   def test_sixtyfour_bit_return_value(self):
     # This test checks that the most significant 32 bits of a 64 bit long are correctly made available
@@ -7131,8 +7135,8 @@ Resolved: "/" => "/"
 
     # Run the test and confirm the output is as expected.
     out = run_js('testrun.js', full_output=True)
-    assert "low = 5678" in out
-    assert "high = 1234" in out
+    self.assertContained('low = 5678', out)
+    self.assertContained('high = 1234', out)
 
   def test_lib_include_flags(self):
     run_process([PYTHON, EMCC] + '-l m -l c -I'.split() + [path_from_root('tests', 'include_test'), path_from_root('tests', 'lib_include_flags.c')])
@@ -7148,8 +7152,8 @@ Resolved: "/" => "/"
 
   def test_dash_s_response_file_list(self):
     create_test_file('response_file', '["_main", "_malloc"]\n')
-    response_file = os.path.join(os.getcwd(), "response_file")
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=@%s' % response_file, '-std=c++03'])
+    response_file = os.path.abspath('response_file')
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=@' + response_file, '-std=c++03'])
 
   def test_dash_s_unclosed_quote(self):
     # Unclosed quote
@@ -7176,10 +7180,10 @@ Resolved: "/" => "/"
   def test_python_2_3(self):
     # check emcc/em++ can be called by any python
     def trim_py_suffix(filename):
-      '''remove .py from EMCC(=emcc.py)'''
+      """remove .py from EMCC(=emcc.py)"""
       return filename[:-3] if filename.endswith('.py') else filename
 
-    for python in ('python', 'python2', 'python3'):
+    def run(python):
       if python == 'python3':
         has = is_python3_version_supported()
       else:
@@ -7194,6 +7198,10 @@ Resolved: "/" => "/"
         run_process([python, EMCC, '--version'], stdout=PIPE)
         print('  checking em++.py...')
         run_process([python, EMXX, '--version'], stdout=PIPE)
+
+    run('python')
+    run('python2')
+    run('python3')
 
   def test_zeroinit(self):
     create_test_file('src.c', r'''
@@ -7919,7 +7927,7 @@ int main() {
       self.assertExists(os.path.join(temp_dir, 'a.asm.js'))
       self.assertExists(os.path.join(temp_dir, 'a.wasm'))
 
-      assert not os.path.exists(os.path.join(temp_dir, 'a.temp.asm.js'))
+      self.assertNotExists(os.path.join(temp_dir, 'a.temp.asm.js'))
 
   def test_binaryen_mem(self):
     for args, expect_initial, expect_max in [
@@ -8439,7 +8447,8 @@ int main() {
         run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', target] + opts)
         self.assertExists('out.wasm')
         if target.endswith('.wasm'):
-          assert not os.path.exists('out.js'), 'only wasm requested'
+          # only wasm requested
+          self.assertNotExists('out.js')
         wat = run_process([os.path.join(Building.get_binaryen_bin(), 'wasm-dis'), 'out.wasm'], stdout=PIPE).stdout
         wat_lines = wat.split('\n')
         exports = [line.strip().split(' ')[1].replace('"', '') for line in wat_lines if "(export " in line]
@@ -9186,7 +9195,7 @@ test_module().then((test_module_instance) => {
       proc = run_process([PYTHON, EMCC, 'src.c', '-s', export_arg], stdout=PIPE, stderr=PIPE, check=not expected)
       print(proc.stderr)
       if not expected:
-        assert not proc.stderr
+        self.assertFalse(proc.stderr)
       else:
         self.assertNotEqual(proc.returncode, 0)
         self.assertContained(expected, proc.stderr)
@@ -9457,7 +9466,7 @@ int main () {
       obtained_size = os.path.getsize(f)
       print('size of generated ' + f + ': ' + str(obtained_size))
       try_delete(f)
-      assert obtained_size < expected_size
+      self.assertLess(obtained_size, expected_size)
 
     run_process([PYTHON, path_from_root('tests', 'gen_many_js_functions.py'), 'library_long.js', 'main_long.c'])
     for wasm in [['-s', 'WASM=1'], ['-s', 'WASM=0']]:
@@ -9662,7 +9671,7 @@ int main () {
         print('Hey amazing, overall generated code size was improved by ' + str(total_expected_size - total_output_size) + ' bytes! Please update test other.test_minimal_runtime_code_size with the new updated size!')
       if total_output_size != total_expected_size:
         success = False
-    assert success
+    self.assertTrue(success)
 
   # Test that legacy settings that have been fixed to a specific value and their value can no longer be changed,
   def test_legacy_settings_forbidden_to_change(self):


### PR DESCRIPTION
- Remove use of builtin assert in favor of unittest assertions.
- Remove some loops to get more meaningful error message
- Remove some needless triple quotes