### PR TITLE
Closure warnings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,8 @@ v1.39.7: 02/03/2020
 - Added new linker option -s WASM=2 which produces a dual Wasm+JS build, which
   falls back to using a JavaScript version if WebAssembly is not supported in
   target browser/shell. (#10118)
+- Added new linker option -s CLOSURE_WARNINGS_ARE_ERRORS=1 that allows aborting
+  the build if Closure compiler produced any warnings.
 
 v1.39.6: 01/15/2020
 -------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,7 +33,7 @@ v1.39.7: 02/03/2020
 - Added new linker option -s WASM=2 which produces a dual Wasm+JS build, which
   falls back to using a JavaScript version if WebAssembly is not supported in
   target browser/shell. (#10118)
-- Added new linker option -s CLOSURE_WARNINGS_ARE_ERRORS=1 that allows aborting
+- Added new linker option -s CLOSURE_WARNINGS=quiet|warn|error that allows aborting
   the build if Closure compiler produced any warnings.
 
 v1.39.6: 01/15/2020

--- a/emcc.py
+++ b/emcc.py
@@ -1219,6 +1219,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
         shared.Settings.ASM_JS = 2
 
+    if shared.Settings.CLOSURE_WARNINGS not in ['quiet', 'warn', 'error']:
+      exit_with_error('Invalid option -s CLOSURE_WARNINGS=%s specified! Allowed values are "quiet", "warn" or "error".' % shared.Settings.CLOSURE_WARNINGS)
+
     if shared.Settings.MAIN_MODULE:
       assert not shared.Settings.SIDE_MODULE
       if shared.Settings.MAIN_MODULE == 1:

--- a/src/closure-externs.js
+++ b/src/closure-externs.js
@@ -815,9 +815,12 @@ WebAssembly.CompileError = function() {};
 WebAssembly.LinkError = function() {};
 /**
  * @constructor
+ * @param {string=} message
+ * @param {string=} fileName
+ * @param {number=} lineNumber
  * @extends {Error}
  */
-WebAssembly.RuntimeError = function() {};
+WebAssembly.RuntimeError = function(message, fileName, lineNumber) {};
 /**
  * Note: Closure compiler does not support function overloading, omit this overload for now.
  * {function(!WebAssembly.Module, Object=):!Promise<!WebAssembly.Instance>}
@@ -829,7 +832,7 @@ WebAssembly.RuntimeError = function() {};
  */
 WebAssembly.instantiate = function(moduleObject, importObject) {};
 /**
- * @param {!Promise<!Response>} source
+ * @param {!Promise<!Response>|!Response} source
  * @param {Object=} importObject
  * @return {!Promise<{module:WebAssembly.Module, instance:WebAssembly.Instance}>}
  */

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -895,6 +895,7 @@ function createWasm() {
   // Load the wasm module and create an instance of using native support in the JS engine.
   // handle a generated wasm instance, receiving its exports and
   // performing other necessary setup
+  /** @param {WebAssembly.Module=} module*/
   function receiveInstance(instance, module) {
     var exports = instance.exports;
 #if RELOCATABLE

--- a/src/settings.js
+++ b/src/settings.js
@@ -248,6 +248,10 @@ var SIMD = 0;
 // Whether closure compiling is being run on this output
 var USE_CLOSURE_COMPILER = 0;
 
+// Enable this flag to have Emscripten treat all Closure warnings as errors,
+// aborting compilation if any warnings were present.
+var CLOSURE_WARNINGS_ARE_ERRORS = 0;
+
 // If set to 1, each asm.js/wasm module export is individually declared with a
 // JavaScript "var" definition. This is the simple and recommended approach.
 // However, this does increase code size (especially if you have many such

--- a/src/settings.js
+++ b/src/settings.js
@@ -248,9 +248,11 @@ var SIMD = 0;
 // Whether closure compiling is being run on this output
 var USE_CLOSURE_COMPILER = 0;
 
-// Enable this flag to have Emscripten treat all Closure warnings as errors,
-// aborting compilation if any warnings were present.
-var CLOSURE_WARNINGS_ARE_ERRORS = 0;
+// Specifies how warnings emitted by Closure are treated. Possible
+// options: 'quiet', 'warn', 'error'. If set to 'warn', Closure warnings are printed
+// out to console. If set to 'error', Closure warnings are treated like errors,
+// similar to -Werror compiler flag.
+var CLOSURE_WARNINGS = 'quiet';
 
 // If set to 1, each asm.js/wasm module export is individually declared with a
 // JavaScript "var" definition. This is the simple and recommended approach.

--- a/tests/test_closure_warning.c
+++ b/tests/test_closure_warning.c
@@ -1,0 +1,6 @@
+#include <emscripten.h>
+
+int main()
+{
+	EM_ASM(foo = 2; var foo; console.log(foo));
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10312,9 +10312,13 @@ int main() {
 
   # Verifies that warning messages that Closure outputs are recorded to console
   def test_closure_warnings(self):
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1'], stderr=PIPE)
+    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=quiet'], stderr=PIPE)
+    assert proc.returncode == 0
+    self.assertNotContained('WARNING', proc.stderr)
+
+    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=warn'], stderr=PIPE)
     assert proc.returncode == 0
     self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', proc.stderr)
 
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS_ARE_ERRORS=1'], stderr=PIPE, check=False)
+    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=error'], stderr=PIPE, check=False)
     assert proc.returncode != 0

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10313,12 +10313,9 @@ int main() {
   # Verifies that warning messages that Closure outputs are recorded to console
   def test_closure_warnings(self):
     proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=quiet'], stderr=PIPE)
-    assert proc.returncode == 0
     self.assertNotContained('WARNING', proc.stderr)
 
     proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=warn'], stderr=PIPE)
-    assert proc.returncode == 0
     self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', proc.stderr)
 
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=error'], stderr=PIPE, check=False)
-    assert proc.returncode != 0
+    self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=error'], stderr=PIPE, check=False)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10312,5 +10312,9 @@ int main() {
 
   # Verifies that warning messages that Closure outputs are recorded to console
   def test_closure_warnings(self):
-    stderr = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1'], stderr=PIPE).stderr
-    self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', stderr)
+    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1'], stderr=PIPE)
+    assert proc.returncode == 0
+    self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', proc.stderr)
+
+    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS_ARE_ERRORS=1'], stderr=PIPE, check=False)
+    assert proc.returncode != 0

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10309,3 +10309,8 @@ int main() {
     stderr = self.expect_fail([PYTHON, EMCC, '-s', 'LLD_REPORT_UNDEFINED', 'main.c'])
     self.assertContained('wasm-ld: error:', stderr)
     self.assertContained('main_0.o: undefined symbol: foo', stderr)
+
+  # Verifies that warning messages that Closure outputs are recorded to console
+  def test_closure_warnings(self):
+    stderr = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1'], stderr=PIPE).stderr
+    self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', stderr)

--- a/third_party/closure-compiler/node-externs/tls.js
+++ b/third_party/closure-compiler/node-externs/tls.js
@@ -61,7 +61,7 @@ tls.ConnectOptions;
 tls.connect = function(port, host, options, callback) {};
 
 /**
- * @param {crypto.Credentials=} credentials
+ * XXX EMSCRIPTEN removed annotation on param {crypto.Credentials=} credentials, as it gives a warning [JSC_UNRECOGNIZED_TYPE_ERROR] Bad type annotation. Unknown type crypto.Credentials
  * @param {boolean=} isServer
  * @param {boolean=} requestCert
  * @param {boolean=} rejectUnauthorized

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2580,20 +2580,28 @@ class Building(object):
       # temp directory.
       try_delete(outfile + '.map')
 
+      # Print Closure diagnostics result up front.
+      if proc.returncode != 0:
+        logger.error('Closure compiler run failed:\n')
+      elif len(proc.stderr.strip()) > 0:
+        if Settings.CLOSURE_WARNINGS_ARE_ERRORS:
+          logger.error('Closure compiler completed with warnings and -s CLOSURE_WARNINGS_ARE_ERRORS=1 enabled, aborting!\n')
+        else:
+          logger.warn('Closure compiler completed with warnings:\n')
+
+      # Print input file (long wall of text!)
       if os.getenv('EMCC_DEBUG') and (proc.returncode != 0 or len(proc.stderr.strip()) > 0):
         logger.debug(open(filename, 'r').read())
 
       if proc.returncode != 0:
-        logger.error('Closure compiler run failed:\n')
-        logger.error(proc.stderr)
+        logger.error(proc.stderr) # print list of errors (possibly long wall of text if input was minified)
         exit_with_error('closure compiler failed (rc: %d.%s)', proc.returncode, '' if pretty else ' the error message may be clearer with -g1 and EMCC_DEBUG=1 set')
 
       if len(proc.stderr.strip()) > 0:
+        # print list of warnings (possibly long wall of text if input was minified)
         if Settings.CLOSURE_WARNINGS_ARE_ERRORS:
-          logger.error('Closure compiler completed with warnings and -s CLOSURE_WARNINGS_ARE_ERRORS=1 enabled, aborting!\n')
           logger.error(proc.stderr)
         else:
-          logger.warn('Closure compiler completed with warnings:\n')
           logger.warn(proc.stderr)
 
         if not pretty:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2589,12 +2589,20 @@ class Building(object):
         exit_with_error('closure compiler failed (rc: %d.%s)', proc.returncode, '' if pretty else ' the error message may be clearer with -g1 and EMCC_DEBUG=1 set')
 
       if len(proc.stderr.strip()) > 0:
-        logger.warn('Closure compiler completed with warnings:\n')
-        logger.warn(proc.stderr)
+        if Settings.CLOSURE_WARNINGS_ARE_ERRORS:
+          logger.error('Closure compiler completed with warnings and -s CLOSURE_WARNINGS_ARE_ERRORS=1 enabled, aborting!\n')
+          logger.error(proc.stderr)
+        else:
+          logger.warn('Closure compiler completed with warnings:\n')
+          logger.warn(proc.stderr)
+
         if not pretty:
           logger.warn('(rerun with -g1 linker flag for an unminified output)')
         elif not os.getenv('EMCC_DEBUG'):
           logger.warn('(rerun with EMCC_DEBUG=1 enabled to dump Closure input file)')
+
+        if Settings.CLOSURE_WARNINGS_ARE_ERRORS:
+          exit_with_error('closure compiler produced warnings and -s CLOSURE_WARNINGS_ARE_ERRORS=1 enabled')
 
       return outfile
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2580,20 +2580,21 @@ class Building(object):
       # temp directory.
       try_delete(outfile + '.map')
 
-      if len(proc.stderr.strip()) > 0:
+      if os.getenv('EMCC_DEBUG') and (proc.returncode != 0 or len(proc.stderr.strip()) > 0):
         logger.debug(open(filename, 'r').read())
 
-        if proc.returncode != 0:
-          logger.error('Closure compiler run failed:\n')
-          logger.error(proc.stderr)
-          exit_with_error('closure compiler failed (rc: %d.%s)', proc.returncode, '' if pretty else ' the error message may be clearer with -g1 and EMCC_DEBUG=1 set')
-        else:
-          logger.warn('Closure compiler completed with warnings:\n')
-          logger.warn(proc.stderr)
-          if not pretty:
-            logger.warn('(rerun with -g1 linker flag for an unminified output)')
-          elif not os.getenv('EMCC_DEBUG'):
-            logger.warn('(rerun with EMCC_DEBUG=1 enabled to dump Closure input file)')
+      if proc.returncode != 0:
+        logger.error('Closure compiler run failed:\n')
+        logger.error(proc.stderr)
+        exit_with_error('closure compiler failed (rc: %d.%s)', proc.returncode, '' if pretty else ' the error message may be clearer with -g1 and EMCC_DEBUG=1 set')
+
+      if len(proc.stderr.strip()) > 0:
+        logger.warn('Closure compiler completed with warnings:\n')
+        logger.warn(proc.stderr)
+        if not pretty:
+          logger.warn('(rerun with -g1 linker flag for an unminified output)')
+        elif not os.getenv('EMCC_DEBUG'):
+          logger.warn('(rerun with EMCC_DEBUG=1 enabled to dump Closure input file)')
 
       return outfile
 


### PR DESCRIPTION
If Closure compiler run results in warning messages, do not swallow them but print them out to console for user to fix.

Also if doing a EMCC_DEBUG=1 build, print out the whole Closure input file to console.