### PR TITLE
WebGPU Compute fixes

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -451,3 +451,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Bumsik Kim <k.bumsik@gmail.com>
 * Corentin Wallez <cwallez@chromium.org> (copyright owned by Google, Inc.)
 * Austin Eng <enga@chromium.org> (copyright owned by Google, Inc.)
+* Hugo Amiard <hugo.amiard@laposte.net>

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -958,13 +958,13 @@ var LibraryWebGPU = {
     var fence = WebGPU.mgrFence.get(fenceId);
     var completionValue = {{{ gpu.makeU64ToNumber('completionValue_l', 'completionValue_h') }}};
 
-    var DAWN_FENCE_COMPLETION_STATUS_SUCCESS = 0;
-    var DAWN_FENCE_COMPLETION_STATUS_ERROR = 1;
+    var WEBGPU_FENCE_COMPLETION_STATUS_SUCCESS = 0;
+    var WEBGPU_FENCE_COMPLETION_STATUS_ERROR = 1;
 
     fence.onCompletion(completionValue).then(function() {
-      dynCall('vii', callback, [DAWN_FENCE_COMPLETION_STATUS_SUCCESS, userdata]);
+      dynCall('vii', callback, [WEBGPU_FENCE_COMPLETION_STATUS_SUCCESS, userdata]);
     }, function() {
-      dynCall('vii', callback, [DAWN_FENCE_COMPLETION_STATUS_ERROR, userdata]);
+      dynCall('vii', callback, [WEBGPU_FENCE_COMPLETION_STATUS_ERROR, userdata]);
     });
   },
 
@@ -1177,17 +1177,17 @@ var LibraryWebGPU = {
     var buffer = bufferEntry.object;
 
     buffer["mapReadAsync"]().then(function(mapped) {
-      var DAWN_BUFFER_MAP_ASYNC_STATUS_SUCCESS = 0;
+      var WEBGPU_BUFFER_MAP_ASYNC_STATUS_SUCCESS = 0;
       var data = _malloc(mapped.byteLength);
       HEAPU8.set(new Uint8Array(mapped), data);
       var dataLength_h = (mapped.byteLength / 0x100000000) | 0;
       var dataLength_l = mapped.byteLength | 0;
       // WGPUBufferMapAsyncStatus status, const void* data, uint64_t dataLength, void* userdata
-      dynCall('viiji', callback, [DAWN_BUFFER_MAP_ASYNC_STATUS_SUCCESS, data, dataLength_l, dataLength_h, userdata]);
+      dynCall('viiji', callback, [WEBGPU_BUFFER_MAP_ASYNC_STATUS_SUCCESS, data, dataLength_l, dataLength_h, userdata]);
     }, function() {
       // TODO(kainino0x): Figure out how to pick other error status values.
-      var DAWN_BUFFER_MAP_ASYNC_STATUS_ERROR = 1;
-      dynCall('viiji', callback, [DAWN_BUFFER_MAP_ASYNC_STATUS_ERROR, 0, 0, 0, userdata]);
+      var WEBGPU_BUFFER_MAP_ASYNC_STATUS_ERROR = 1;
+      dynCall('viiji', callback, [WEBGPU_BUFFER_MAP_ASYNC_STATUS_ERROR, 0, 0, 0, userdata]);
     });
   },
 
@@ -1195,8 +1195,8 @@ var LibraryWebGPU = {
     var bufferWrapper = WebGPU.mgrBuffer.objects[bufferId];
     var buffer = bufferWrapper.object;
 
-    var DAWN_BUFFER_MAP_ASYNC_STATUS_SUCCESS = 0;
-    var DAWN_BUFFER_MAP_ASYNC_STATUS_ERROR = 1;
+    var WEBGPU_BUFFER_MAP_ASYNC_STATUS_SUCCESS = 0;
+    var WEBGPU_BUFFER_MAP_ASYNC_STATUS_ERROR = 1;
     buffer["mapWriteAsync"]().then(function(mapped) {
       WebGPU.trackMapWrite(bufferWrapper, mapped);
 
@@ -1204,10 +1204,10 @@ var LibraryWebGPU = {
       var dataLength_h = (mapped.byteLength / 0x100000000) | 0;
       var dataLength_l = mapped.byteLength | 0;
       // WGPUBufferMapAsyncStatus status, void* data, uint64_t dataLength, void* userdata
-      dynCall('viiji', callback, [DAWN_BUFFER_MAP_ASYNC_STATUS_SUCCESS, data, dataLength_l, dataLength_h, userdata]);
+      dynCall('viiji', callback, [WEBGPU_BUFFER_MAP_ASYNC_STATUS_SUCCESS, data, dataLength_l, dataLength_h, userdata]);
     }, function() {
       // TODO(kainino0x): Figure out how to pick other error status values.
-      dynCall('viiji', callback, [DAWN_BUFFER_MAP_ASYNC_STATUS_ERROR, 0, 0, 0, userdata]);
+      dynCall('viiji', callback, [WEBGPU_BUFFER_MAP_ASYNC_STATUS_ERROR, 0, 0, 0, userdata]);
     });
   },
 


### PR DESCRIPTION
This PR adds a couple of missing functions to the `library_webgpu.js` library, fixes a bug in Compute Pipeline creation, and removes a few occurences of `dawn` which we probably want to read `webgpu`
I talked with @kainino0x about those fixes and I think he'd like to review those and have them merged, so here they are
For reference, those changes allow the following Compute example to run correctly on Chrome canary: https://hugoam.github.io/two/bgfx/24-nbody
