### PR TITLE
Generalize RUNTIME_EXPORTS to handle all JS objects like FS

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -402,8 +402,6 @@ function exportRuntime() {
     'writeAsciiToMemory',
     'addRunDependency',
     'removeRunDependency',
-    'ENV',
-    'FS',
     'FS_createFolder',
     'FS_createPath',
     'FS_createDataFile',
@@ -412,7 +410,6 @@ function exportRuntime() {
     'FS_createLink',
     'FS_createDevice',
     'FS_unlink',
-    'GL',
     'dynamicAlloc',
     'loadDynamicLibrary',
     'loadWebAssemblyModule',
@@ -434,6 +431,14 @@ function exportRuntime() {
     'callMain',
     'abort',
   ];
+
+  // Add JS library elements such as FS, GL, ENV, etc. These are prefixed with
+  // '$ which indicates they are JS methods.
+  for (var ident in LibraryManager.library) {
+    if (ident[0] === '$') {
+      runtimeElements.push(ident.substr(1));
+    }
+  }
 
   if (!MINIMAL_RUNTIME) {
     runtimeElements.push('warnOnce');

--- a/src/settings.js
+++ b/src/settings.js
@@ -684,8 +684,8 @@ var ASYNCIFY_DEBUG = 0;
 // included (either automatically from linking, or due to being in
 // DEFAULT_LIBRARY_FUNCS_TO_INCLUDE).
 // Note that the name may be slightly misleading, as this is for any JS library
-// element, and not just methods. For example, we export the Runtime object by
-// having "Runtime" in this list.
+// element, and not just methods. For example, we can export the FS object by
+// having "FS" in this list.
 var EXPORTED_RUNTIME_METHODS = [];
 
 // Additional methods to those in EXPORTED_RUNTIME_METHODS. Adjusting that list

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8298,7 +8298,7 @@ int main() {
 
   # ensures runtime exports work, even with metadce
   def test_extra_runtime_exports(self):
-    exports = ['stackSave', 'stackRestore', 'stackAlloc']
+    exports = ['stackSave', 'stackRestore', 'stackAlloc', 'FS']
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1', '-Os', '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=%s' % str(exports)])
     js = open('a.out.js').read()
     for export in exports:


### PR DESCRIPTION
Do so automatically, by scanning the library.

fixes #10317