### PR TITLE
emscripten_async_wget2_data doesn't handle errors from relative urls

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -968,7 +968,7 @@ var LibraryBrowser = {
 
     // LOAD
     http.onload = function http_onload(e) {
-      if (http.status >= 200 && http.status < 300 || _url.substr(0,4).toLowerCase() != "http") {
+      if (http.status >= 200 && http.status < 300 || (http.status === 0 && _url.substr(0,4).toLowerCase() != "http")) {
         var byteArray = new Uint8Array(http.response);
         var buffer = _malloc(byteArray.length);
         HEAPU8.set(byteArray, buffer);


### PR DESCRIPTION
Fixes #10338

I suppose whoever added `_url.substr(0,4).toLowerCase() != "http")` was meant to handle `file:///` requests, and as such `http.status === 0` should be checked for them (i guess)