### PR TITLE
Disable --inline-main when DWARF is in use

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1800,7 +1800,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           passes += ['--post-emscripten']
           # always inline __original_main into main, as otherwise it makes debugging confusing,
           # and doing so is never bad for code size
-          passes += ['--inline-main']
+          # FIXME however, don't do it with DWARF for now, as inlining is not
+          #       fully handled in DWARF updating yet
+          if not shared.Settings.FULL_DWARF:
+            passes += ['--inline-main']
           if not shared.Settings.EXIT_RUNTIME:
             passes += ['--no-exit-runtime']
           if options.opt_level > 0 or options.shrink_level > 0:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7386,10 +7386,6 @@ err = err = function(){};
   @no_wasm2js('TODO: source maps in wasm2js')
   @no_fastcomp('DWARF is only supported in upstream')
   def test_dwarf(self):
-    # FIXME
-    if is_optimizing(self.emcc_args) and '-O1' not in self.emcc_args:
-      self.skipTest('optimizations above -O1 remove too much DWARF atm')
-
     self.emcc_args.append('-gforce_dwarf')
     self.emcc_args.remove('-Werror') # ignore warning on force-dwarf
 


### PR DESCRIPTION
This allows the current DWARF test to pass on all optimization levels.