### PR TITLE
Cleanup emcmake/emconfigure

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -4,17 +4,30 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import subprocess
+from __future__ import print_function
 import sys
 from tools import shared
+from subprocess import CalledProcessError
 
 
 #
 # Main run() function
 #
 def run():
-  configure_path = shared.path_from_root('emconfigure')
-  return subprocess.call([shared.PYTHON, configure_path] + sys.argv[1:])
+  if len(sys.argv) < 2 or sys.argv[1] in ('--version', '--help'):
+    print('''\
+emcmake is a helper for cmake, setting various environment
+variables so that emcc etc. are used. Typical usage:
+
+  emcmake cmake [FLAGS]
+''', file=sys.stderr)
+    return 1
+
+  try:
+    shared.Building.configure(sys.argv[1:])
+    return 0
+  except CalledProcessError as e:
+    return e.returncode
 
 
 if __name__ == '__main__':

--- a/emconfigure.py
+++ b/emconfigure.py
@@ -32,23 +32,18 @@ from subprocess import CalledProcessError
 #
 def run():
   if len(sys.argv) < 2 or sys.argv[1] in ('--version', '--help'):
-    print('''
-  emconfigure is a helper for configure, setting various environment
-  variables so that emcc etc. are used. Typical usage:
+    print('''\
+emconfigure is a helper for configure, setting various environment
+variables so that emcc etc. are used. Typical usage:
 
-    emconfigure ./configure [FLAGS]
+  emconfigure ./configure [FLAGS]
 
-  (but you can run any command instead of configure)
-
-  ''', file=sys.stderr)
+(but you can run any command instead of configure)''', file=sys.stderr)
     return 1
-  elif 'cmake' in sys.argv[1]:
-    node_js = shared.NODE_JS
-    if type(node_js) is list:
-      node_js = node_js[0]
-    node_js = shared.Building.which(node_js)
-    node_js = node_js.replace('"', '\"')
-    sys.argv = sys.argv[:2] + ['-DCMAKE_CROSSCOMPILING_EMULATOR="' + node_js + '"'] + sys.argv[2:]
+
+  if 'cmake' in sys.argv[1]:
+    print('error: use `emcmake` rather then `emconfigure` for cmake projects', file=sys.stderr)
+    return 1
 
   try:
     shared.Building.configure(sys.argv[1:])

--- a/emmake.py
+++ b/emmake.py
@@ -32,15 +32,13 @@ from subprocess import CalledProcessError
 #
 def run():
   if len(sys.argv) < 2 or sys.argv[1] in ('--version', '--help'):
-    print('''
-  emmake is a helper for make, setting various environment
-  variables so that emcc etc. are used. Typical usage:
+    print('''\
+emmake is a helper for make, setting various environment
+variables so that emcc etc. are used. Typical usage:
 
-    emmake make [FLAGS]
+  emmake make [FLAGS]
 
-  (but you can run any command instead of make)
-
-  ''', file=sys.stderr)
+(but you can run any command instead of make)''', file=sys.stderr)
     return 1
 
   try:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -619,9 +619,9 @@ f.close()
     }
 
     if WINDOWS:
-      emconfigure = path_from_root('emconfigure.bat')
+      emcmake = path_from_root('emcmake.bat')
     else:
-      emconfigure = path_from_root('emconfigure')
+      emcmake = path_from_root('emcmake')
 
     for generator in generators:
       conf = configurations[generator]
@@ -658,7 +658,7 @@ f.close()
         cmakelistsdir = path_from_root('tests', 'cmake', test_dir)
         with temp_directory(self.get_dir()) as tempdirname:
           # Run Cmake
-          cmd = [emconfigure, 'cmake'] + cmake_args + ['-G', generator, cmakelistsdir]
+          cmd = [emcmake, 'cmake'] + cmake_args + ['-G', generator, cmakelistsdir]
 
           env = os.environ.copy()
           # https://github.com/emscripten-core/emscripten/pull/5145: Check that CMake works even if EMCC_SKIP_SANITY_CHECK=1 is passed.
@@ -704,12 +704,12 @@ f.close()
       native_features = run_process(cmd, stdout=PIPE).stdout
 
     if WINDOWS:
-      emconfigure = path_from_root('emcmake.bat')
+      emcmake = path_from_root('emcmake.bat')
     else:
-      emconfigure = path_from_root('emcmake')
+      emcmake = path_from_root('emcmake')
 
     with temp_directory(self.get_dir()):
-      cmd = [emconfigure, 'cmake', path_from_root('tests', 'cmake', 'stdproperty')]
+      cmd = [emcmake, 'cmake', path_from_root('tests', 'cmake', 'stdproperty')]
       print(str(cmd))
       emscripten_features = run_process(cmd, stdout=PIPE).stdout
 
@@ -6086,7 +6086,7 @@ Descriptor desc;
     check('emmake', ['make'], fail=False)
     check('emconfigure', ['configure'], fail=False)
     check('emconfigure', ['./configure'], fail=False)
-    check('emconfigure', ['cmake'], fail=False)
+    check('emcmake', ['cmake'], fail=False)
 
     create_test_file('test.py', '''
 import os

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1572,8 +1572,9 @@ class Building(object):
 
     return None
 
-  # Returns a clone of the given environment with all directories that contain sh.exe removed from the PATH.
-  # Used to work around CMake limitation with MinGW Makefiles, where sh.exe is not allowed to be present.
+  # Returns a clone of the given environment with all directories that contain
+  # sh.exe removed from the PATH.  Used to work around CMake limitation with
+  # MinGW Makefiles, where sh.exe is not allowed to be present.
   @staticmethod
   def remove_sh_exe_from_path(env):
     env = env.copy()
@@ -1585,28 +1586,32 @@ class Building(object):
     return env
 
   @staticmethod
-  def handle_CMake_toolchain(args, env):
-
-    def has_substr(array, substr):
-      for arg in array:
-        if substr in arg:
-          return True
-      return False
+  def handle_cmake_toolchain(args, env):
+    def has_substr(args, substr):
+      return any(substr in s for s in args)
 
     # Append the Emscripten toolchain file if the user didn't specify one.
     if not has_substr(args, '-DCMAKE_TOOLCHAIN_FILE'):
       args.append('-DCMAKE_TOOLCHAIN_FILE=' + path_from_root('cmake', 'Modules', 'Platform', 'Emscripten.cmake'))
+    node_js = NODE_JS
 
-    # On Windows specify MinGW Makefiles or ninja if we have them and no other toolchain was specified, to keep CMake
-    # from pulling in a native Visual Studio, or Unix Makefiles.
+    if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
+      node_js = NODE_JS[0].replace('"', '\"')
+      args.append('-DCMAKE_CROSSCOMPILING_EMULATOR="%s"' % node_js)
+
+    # On Windows specify MinGW Makefiles or ninja if we have them and no other
+    # toolchain was specified, to keep CMake from pulling in a native Visual
+    # Studio, or Unix Makefiles.
     if WINDOWS and '-G' not in args:
       if Building.which('mingw32-make'):
         args += ['-G', 'MinGW Makefiles']
       elif Building.which('ninja'):
         args += ['-G', 'Ninja']
 
-    # CMake has a requirement that it wants sh.exe off PATH if MinGW Makefiles is being used. This happens quite often,
-    # so do this automatically on behalf of the user. See http://www.cmake.org/Wiki/CMake_MinGW_Compiler_Issues
+    # CMake has a requirement that it wants sh.exe off PATH if MinGW Makefiles
+    # is being used. This happens quite often, so do this automatically on
+    # behalf of the user. See
+    # http://www.cmake.org/Wiki/CMake_MinGW_Compiler_Issues
     if WINDOWS and 'MinGW Makefiles' in args:
       env = Building.remove_sh_exe_from_path(env)
 
@@ -1614,35 +1619,31 @@ class Building(object):
 
   @staticmethod
   def configure(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
-    if not args:
-      return
-    if env is None:
+    if env:
+      env = env.copy()
+    else:
       env = Building.get_building_env(cflags=cflags)
     if 'cmake' in args[0]:
-      # Note: EMMAKEN_JUST_CONFIGURE shall not be enabled when configuring with CMake. This is because CMake
-      #       does expect to be able to do config-time builds with emcc.
-      args, env = Building.handle_CMake_toolchain(args, env)
+      # Note: EMMAKEN_JUST_CONFIGURE shall not be enabled when configuring with
+      #       CMake. This is because CMake does expect to be able to do
+      #       config-time builds with emcc.
+      args, env = Building.handle_cmake_toolchain(args, env)
     else:
-      # When we configure via a ./configure script, don't do config-time compilation with emcc, but instead
-      # do builds natively with Clang. This is a heuristic emulation that may or may not work.
+      # When we configure via a ./configure script, don't do config-time
+      # compilation with emcc, but instead do builds natively with Clang. This
+      # is a heuristic emulation that may or may not work.
       env['EMMAKEN_JUST_CONFIGURE'] = '1'
-    if EM_BUILD_VERBOSE >= 3:
-      print('configure: ' + str(args), file=sys.stderr)
     if EM_BUILD_VERBOSE >= 2:
       stdout = None
     if EM_BUILD_VERBOSE >= 1:
       stderr = None
+    print('configure: ' + ' '.join(args), file=sys.stderr)
     run_process(args, stdout=stdout, stderr=stderr, env=env, **kwargs)
-    if 'EMMAKEN_JUST_CONFIGURE' in env:
-      del env['EMMAKEN_JUST_CONFIGURE']
 
   @staticmethod
   def make(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
     if env is None:
       env = Building.get_building_env(cflags=cflags)
-    if not args:
-      exit_with_error('Executable to run not specified.')
-    # args += ['VERBOSE=1']
 
     # On Windows prefer building with mingw32-make instead of make, if it exists.
     if WINDOWS:
@@ -1661,7 +1662,7 @@ class Building(object):
       stdout = None
     if EM_BUILD_VERBOSE >= 1:
       stderr = None
-    print('make: ' + str(args), file=sys.stderr)
+    print('make: ' + ' '.join(args), file=sys.stderr)
     run_process(args, stdout=stdout, stderr=stderr, env=env, shell=WINDOWS, **kwargs)
 
   @staticmethod


### PR DESCRIPTION
- Set CMAKE_CROSSCOMPILING_EMULATOR in the same way we set
  CMAKE_TOOLCHAIN_FILE.
- Consistent echoing of make/configure command.
- Don't silently succeed if passed no args