### PR TITLE
Closure type annotations

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -240,9 +240,9 @@ if (ENVIRONMENT_IS_SHELL) {
 
   if (typeof print !== 'undefined') {
     // Prefer to use print/printErr where they exist, as they usually work better.
-    if (typeof console === 'undefined') console = {};
-    console.log = print;
-    console.warn = console.error = typeof printErr !== 'undefined' ? printErr : print;
+    if (typeof console === 'undefined') console = /** @type{!Console} */({});
+    console.log = /** @type{!function(this:Console, ...*): undefined} */ (print);
+    console.warn = console.error = /** @type{!function(this:Console, ...*): undefined} */ (typeof printErr !== 'undefined' ? printErr : print);
   }
 
 #if WASM == 2

--- a/src/spidermonkey-externs.js
+++ b/src/spidermonkey-externs.js
@@ -2,7 +2,7 @@
 
 /**
  * @param {string} filename
- * @param {string} type
+ * @param {string=} type
  * @return {string}
  * @suppress {duplicate}
  */
@@ -29,10 +29,10 @@ var readbuffer = function(filename) {};
  */
 var scriptArgs = [];
 /**
- * @const
+ * @param {number=} status
  * @suppress {duplicate}
  */
-var quit = function() {};
+var quit = function(status) {};
 /**
  * @return {number}
  * @suppress {duplicate}

--- a/src/v8-externs.js
+++ b/src/v8-externs.js
@@ -2,7 +2,7 @@
 
 /**
  * @param {string} filename
- * @param {string} type
+ * @param {string=} type
  * @return {string}
  * @suppress {duplicate}
  */
@@ -28,10 +28,10 @@ var readbuffer = function(filename) {};
  */
 var scriptArgs = [];
 /**
- * @const
+ * @param {number=} status
  * @suppress {duplicate}
  */
-var quit = function() {};
+var quit = function(status) {};
 /**
  * @return {number}
  * @suppress {duplicate}

--- a/src/web_or_worker_shell_read.js
+++ b/src/web_or_worker_shell_read.js
@@ -26,7 +26,7 @@
         xhr.open('GET', url, false);
         xhr.responseType = 'arraybuffer';
         xhr.send(null);
-        return new Uint8Array(xhr.response);
+        return new Uint8Array(/** @type{!ArrayBuffer} */(xhr.response));
 #if SUPPORT_BASE64_EMBEDDING
       } catch (err) {
         var data = tryParseAsDataURI(url);

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -937,12 +937,14 @@ function reattachComments(ast, comments) {
 // Main
 
 var arguments = process['argv'].slice(2);;
-var preserveComments = arguments.indexOf('--preserveComments');
-if (preserveComments > -1) {
-  arguments.splice(preserveComments, 1);
-  preserveComments = true;
+// If enabled, output retains parentheses and comments so that the
+// output can further be passed out to Closure.
+var closureFriendly = arguments.indexOf('--closureFriendly');
+if (closureFriendly > -1) {
+  arguments.splice(closureFriendly, 1);
+  closureFriendly = true;
 } else {
-  preserveComments = false;  
+  closureFriendly = false;
 }
 
 var infile = arguments[0];
@@ -955,9 +957,9 @@ if (extraInfoStart > 0) {
   extraInfo = JSON.parse(input.substr(extraInfoStart + 14));
 }
 // Collect all JS code comments to this array so that we can retain them in the outputted code
-// if --preserveComments was requested.
+// if --closureFriendly was requested.
 var sourceComments = [];
-var ast = acorn.parse(input, { ecmaVersion: 6, preserveParens: preserveComments, onComment: preserveComments ? sourceComments : undefined });
+var ast = acorn.parse(input, { ecmaVersion: 6, preserveParens: closureFriendly, onComment: closureFriendly ? sourceComments : undefined });
 
 var minifyWhitespace = false;
 var noPrint = false;
@@ -981,7 +983,7 @@ passes.forEach(function(pass) {
 if (!noPrint) {
   var terserAst = terser.AST_Node.from_mozilla_ast(ast);
 
-  if (preserveComments) {
+  if (closureFriendly) {
     reattachComments(terserAst, sourceComments);
   }
 

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -957,7 +957,7 @@ if (extraInfoStart > 0) {
 // Collect all JS code comments to this array so that we can retain them in the outputted code
 // if --preserveComments was requested.
 var sourceComments = [];
-var ast = acorn.parse(input, { ecmaVersion: 6, onComment: preserveComments ? sourceComments : undefined });
+var ast = acorn.parse(input, { ecmaVersion: 6, preserveParens: preserveComments, onComment: preserveComments ? sourceComments : undefined });
 
 var minifyWhitespace = false;
 var noPrint = false;

--- a/tools/node_modules/terser/terser.js
+++ b/tools/node_modules/terser/terser.js
@@ -504,6 +504,21 @@ var AST_SimpleStatement = DEFNODE("SimpleStatement", "body", {
     }
 }, AST_Statement);
 
+// XXX Emscripten localmod: Add a node type for a parenthesized expression so that we can retain
+// Closure annotations that need a form "/**annotation*/(expression)"
+var AST_ParenthesizedExpression = DEFNODE("ParenthesizedExpression", "body", {
+    $documentation: "An explicitly parenthesized expression, i.e. a = (1 + 2)",
+    $propdoc: {
+        body: "[AST_Node] an expression node (should not be instanceof AST_Statement)"
+    },
+    _walk: function(visitor) {
+        return visitor._visit(this, function() {
+            this.body._walk(visitor);
+        });
+    }
+}, AST_Statement);
+// XXX End of Emscripten localmod
+
 function walk_body(node, visitor) {
     var body = node.body;
     if (body instanceof AST_Node) {
@@ -6294,6 +6309,14 @@ function OutputStream(options) {
         self.body.print(output);
         output.semicolon();
     });
+// XXX Emscripten localmod: Add a node type for a parenthesized expression so that we can retain
+// Closure annotations that need a form "/**annotation*/(expression)"
+    DEFPRINT(AST_ParenthesizedExpression, function(self, output) {
+        output.print('(');
+        self.body.print(output);
+        output.print(')');
+    });
+// XXX End Emscripten localmod
     function print_braced_empty(self, output) {
         output.print("{");
         output.with_indent(output.next_indent(), function() {
@@ -7445,6 +7468,16 @@ function OutputStream(options) {
                 body: from_moz(M.expression)
             });
         },
+// XXX Emscripten localmod: Add a node type for a parenthesized expression so that we can retain
+// Closure annotations that need a form "/**annotation*/(expression)"
+        ParenthesizedExpression: function(M) {
+            return new AST_ParenthesizedExpression({
+                start: my_start_token(M),
+                end: my_end_token(M),
+                body: from_moz(M.expression)
+            });
+        },
+// XXX End Emscripten localmod
         TryStatement: function(M) {
             var handlers = M.handlers || [M.handler];
             if (handlers.length > 1 || M.guardedHandlers && M.guardedHandlers.length) {

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2393,7 +2393,7 @@ class Building(object):
     # Keep JS code comments intact through the acorn optimization pass so that JSDoc comments
     # will be carried over to a later Closure run.
     if acorn and Settings.USE_CLOSURE_COMPILER:
-      cmd += ['--preserveComments']
+      cmd += ['--closureFriendly']
     if not return_output:
       next = original_filename + '.jso.js'
       configuration.get_temp_files().note(next)


### PR DESCRIPTION
This enables Closure type casts with `/** @type{castedToType} */(someJavaScriptExpression)`. https://github.com/google/closure-compiler/wiki/Annotating-JavaScript-for-the-Closure-Compiler#type-casting