### PR TITLE
base64Utils.js include is no longer needed

### DIFF
--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -56,10 +56,6 @@ WebAssembly = {
   Instance: function(module, info) {
     // TODO: use the module and info somehow - right now the wasm2js output is embedded in
     // the main JS
-    // XXX hack to get an atob implementation
-    // TODO: Remove this once https://github.com/WebAssembly/binaryen/pull/2623 lands
-#include base64Utils.js
-    var atob = decodeBase64;
     // This will be replaced by the actual wasm2js code.
     var exports = Module['__wasm2jsInstantiate__'](asmLibraryArg, wasmMemory, wasmTable);
     return {


### PR DESCRIPTION
base64Utils.js include is no longer needed, as https://github.com/WebAssembly/binaryen/pull/2623 has landed

This might fix the Closure warning that was seen in #10385