### PR TITLE
Also use emscripten_get_now for CLOCK_MONOTONIC_RAW

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2767,7 +2767,7 @@ LibraryManager.library = {
     var now;
     if (clk_id === {{{ cDefine('CLOCK_REALTIME') }}}) {
       now = Date.now();
-    } else if (clk_id === {{{ cDefine('CLOCK_MONOTONIC') }}} && _emscripten_get_now_is_monotonic) {
+    } else if ((clk_id === {{{ cDefine('CLOCK_MONOTONIC') }}} || clk_id === {{{ cDefine('CLOCK_MONOTONIC_RAW') }}}) && _emscripten_get_now_is_monotonic) {
       now = _emscripten_get_now();
     } else {
       ___setErrNo({{{ cDefine('EINVAL') }}});

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -210,7 +210,8 @@
             ["li", "CLOCKS_PER_SEC"],
             "TIME_UTC",
             "CLOCK_REALTIME",
-            "CLOCK_MONOTONIC"
+            "CLOCK_MONOTONIC",
+            "CLOCK_MONOTONIC_RAW"
         ],
         "structs": {
             "timezone": [


### PR DESCRIPTION
Currently SDL2 fails to use a high resolution timer for `SDL_GetPerformanceCounter` as it uses `CLOCK_MONOTONIC_RAW` if it is defined and falls back to `gettimeofday` if it fails.