### PR TITLE
Add Wasm2JS code size tests

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9602,6 +9602,7 @@ int main () {
                                '--output_eol', 'linux']
 
     asmjs = ['-s', 'WASM=0', '--separate-asm', '-s', 'ELIMINATE_DUPLICATE_FUNCTIONS=1', '--memory-init-file', '1']
+    wasm2js = ['-s', 'WASM=0', '--memory-init-file', '1']
     opts = ['-O3', '--closure', '1', '-DNDEBUG', '-ffast-math']
 
     hello_world_sources = [path_from_root('tests', 'small_hello_world.c'),
@@ -9618,7 +9619,9 @@ int main () {
 
     if self.is_wasm_backend():
       test_cases = [
+        (wasm2js + opts, hello_world_sources, {'a.html': 697, 'a.js': 2227, 'a.mem': 6}),
         (opts, hello_world_sources, {'a.html': 665, 'a.js': 450, 'a.wasm': 172}),
+        (wasm2js + opts, hello_webgl_sources, {'a.html': 588, 'a.js': 25932, 'a.mem': 3168}),
         (opts, hello_webgl_sources, {'a.html': 563, 'a.js': 4629, 'a.wasm': 11731}),
         (opts, hello_webgl2_sources, {'a.html': 563, 'a.js': 5137, 'a.wasm': 11731}) # Compare how WebGL2 sizes stack up with WebGL 1
       ]


### PR DESCRIPTION
A bit of a difference still with wasm2js against fastcomp asm.js.

Current delta from fastcomp to wasm2js for minimal hello world:
```
size of a.html == 697, expected 682, delta=15 (+2.20%)
size of a.js == 2227, expected 289, delta=1938 (+670.59%)
size of a.mem == 6, expected 6, delta=0
Total output size=2915 bytes, expected total size=977, delta=1938 (+198.36%)
```

and current delta from fastcomp to wasm2js for minimal hello webgl:
```
size of a.html == 588, expected 580, delta=8 (+1.38%)
size of a.js == 25932, expected 4896, delta=21036 (+429.66%)
size of a.mem == 3168, expected 321, delta=2847 (+886.92%)
Total output size=29680 bytes, expected total size=5797, delta=23883 (+411.99%)
```
