### PR TITLE
Remove wordexp.c from musl blacklist

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -674,7 +674,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         'proto.c', 'gethostbyaddr.c', 'gethostbyaddr_r.c', 'gethostbyname.c',
         'gethostbyname2_r.c', 'gethostbyname_r.c', 'gethostbyname2.c',
         'usleep.c', 'alarm.c', 'syscall.c', '_exit.c', 'popen.c',
-        'getgrouplist.c', 'initgroups.c', 'wordexp.c', 'timer_create.c',
+        'getgrouplist.c', 'initgroups.c', 'timer_create.c',
         'faccessat.c',
     ]
 


### PR DESCRIPTION
Its not clear how much of it will practically useful but it a least
seems to compile so we might well include it.

Fixes #10403