### PR TITLE
Fix '-r' command line flag bug.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -452,3 +452,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Corentin Wallez <cwallez@chromium.org> (copyright owned by Google, Inc.)
 * Austin Eng <enga@chromium.org> (copyright owned by Google, Inc.)
 * Hugo Amiard <hugo.amiard@laposte.net>
+* sssooonnnggg <sssooonnnggg111@gmail.com>

--- a/emcc.py
+++ b/emcc.py
@@ -1049,7 +1049,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             has_source_inputs = True
           else:
             exit_with_error(arg + ": Input file has an unknown suffix, don't know what to do with it!")
-      elif arg.startswith('-r'):
+      elif arg == '-r':
         link_to_object = True
         newargs[i] = ''
       elif arg.startswith('-L'):


### PR DESCRIPTION
This bug caused CMake `check_function_exists` macro always return `true`.

It seems that `-rdynamic` and `-r` have different meanings, but because of same prefix,  `-rdynaimc` will execute the same code as `-r` does.

CMake passes an extra link flag `-rdynamic` to `emcc` and compile a test program to check if a function exists，and the emcc parsed it to `-r` flag, then always try to link to object. No compile error is generated, so CMake thinks the function exists.

[https://github.com/Kitware/CMake/blob/master/Modules/CheckFunctionExists.cmake](url)

Sorry for my poor English.:<