### PR TITLE
Fix embind to work (more) on MINIMAL_RUNTIME.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2845,6 +2845,9 @@ def parse_args(newargs):
       newargs[i] = ''
       shared.Settings.SYSTEM_JS_LIBRARIES.append(shared.path_from_root('src', 'embind', 'emval.js'))
       shared.Settings.SYSTEM_JS_LIBRARIES.append(shared.path_from_root('src', 'embind', 'embind.js'))
+      # XXX Hack: dependencies to _free are not seen from deps_info.json, so manually make sure to export
+      # _free() when using embind.
+      shared.Settings.EXPORTED_FUNCTIONS += ['_free']
       if options.default_cxx_std:
         # Force C++11 for embind code, but only if user has not explicitly overridden a standard.
         options.default_cxx_std = '-std=c++11'

--- a/emcc.py
+++ b/emcc.py
@@ -2845,9 +2845,6 @@ def parse_args(newargs):
       newargs[i] = ''
       shared.Settings.SYSTEM_JS_LIBRARIES.append(shared.path_from_root('src', 'embind', 'emval.js'))
       shared.Settings.SYSTEM_JS_LIBRARIES.append(shared.path_from_root('src', 'embind', 'embind.js'))
-      # XXX Hack: dependencies to _free are not seen from deps_info.json, so manually make sure to export
-      # _free() when using embind.
-      shared.Settings.EXPORTED_FUNCTIONS += ['_free']
       if options.default_cxx_std:
         # Force C++11 for embind code, but only if user has not explicitly overridden a standard.
         options.default_cxx_std = '-std=c++11'

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -97,5 +97,8 @@
   "pthread_create": ["malloc", "free", "emscripten_main_thread_process_queued_calls"],
   "$getTypeName": ["free"],
   "_embind_register_std_string": ["free"],
-  "_embind_register_std_wstring": ["free"]
+  "_embind_register_std_wstring": ["free"],
+  "_embind_register_function": ["free"],
+  "_embind_register_class": ["free"],
+  "_embind_register_enum_value": ["free"]
 }

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -94,5 +94,8 @@
   "_embind_register_std_string": ["malloc", "free"],
   "_embind_register_std_wstring": ["malloc", "free"],
   "__syscall192": ["emscripten_builtin_memalign"],
-  "pthread_create": ["malloc", "free", "emscripten_main_thread_process_queued_calls"]
+  "pthread_create": ["malloc", "free", "emscripten_main_thread_process_queued_calls"],
+  "$getTypeName": ["free"],
+  "_embind_register_std_string": ["free"],
+  "_embind_register_std_wstring": ["free"]
 }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1674,3 +1674,7 @@ function makeAsmImportsAccessInPthread(variable) {
     return variable;
   }
 }
+
+function hasExportedFunction(func) {
+  return Object.keys(EXPORTED_FUNCTIONS).indexOf(func) != -1;
+}

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -3,6 +3,7 @@
 
 {{{ exportRuntime() }}}
 
+#if hasExportedFunction('_main') // Only if user is exporting a C main(), we will generate a run() function that can be used to launch main.
 function run() {
 #if MEMORYPROFILER
   emscriptenMemoryProfiler.onPreloadComplete();
@@ -36,6 +37,7 @@ function run() {
   checkStackCookie();
 #endif
 }
+#endif
 
 function initRuntime(asm) {
 #if ASSERTIONS
@@ -145,10 +147,10 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
   wasmModule = output.module || Module['wasm'];
 #endif
 
-#if !(LibraryManager.has('library_exports.js') && (WASM || WASM_BACKEND))
-  // If not using the emscripten_get_exported_function() API, keep the 'asm' exports
-  // variable in local scope to this instantiate function. (otherwise access it without
-  // to export it to outer scope)
+#if !(LibraryManager.has('library_exports.js') && (WASM || WASM_BACKEND)) && !EMBIND
+  // If not using the emscripten_get_exported_function() API or embind, keep the 'asm'
+  // exports variable in local scope to this instantiate function to save code size.
+  // (otherwise access it without to export it to outer scope)
   var
 #endif
 

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -129,12 +129,18 @@ function err(text) {
 // compilation is ready. In that callback, call the function run() to start
 // the program.
 function ready() {
+#if INVOKE_RUN && hasExportedFunction('_main')
 #if USE_PTHREADS
   if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
     run();
 #if USE_PTHREADS
   }
+#endif
+#else
+#if ASSERTIONS
+  console.log('ready() called, and INVOKE_RUN=0. The runtime is now ready for you to call run() to invoke application _main(). You can also override ready() in a --pre-js file to get this signal as a callback')
+#endif
 #endif
 }
 


### PR DESCRIPTION
Fix embind to work (more) on MINIMAL_RUNTIME.

Remove old super-ancient pre-asm.js binding code from embind.

Helps towards #10386, though not sure if it will resolve all the issues seen there.