### PR TITLE
wasm2js + SINGLE_FILE: don't embed unnecessary wasm binary data

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3285,6 +3285,8 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
 
     if shared.Settings.WASM != 2:
       final = wasm2js
+      # if we only target JS, we don't need the wasm any more
+      shared.try_delete(wasm_binary_target)
 
     save_intermediate('wasm2js')
 
@@ -3318,11 +3320,6 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       shared.try_delete(target)
     with open(final, 'w') as f:
       f.write(js)
-
-  # if targeting only JS, delete the redundant temporary
-  # .wasm output file
-  if shared.Settings.WASM == 1 and shared.Settings.WASM2JS:
-    shared.try_delete(wasm_binary_target)
 
 
 def modularize():

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3006,6 +3006,9 @@ class JS(object):
     if data_uri is None:
       data_uri = Settings.SINGLE_FILE
     if data_uri:
+      # if the path does not exist, then there is no data to encode
+      if not os.path.exists(path):
+        return ''
       with open(path, 'rb') as f:
         data = base64.b64encode(f.read())
       return 'data:application/octet-stream;base64,' + asstr(data)


### PR DESCRIPTION
In wasm2js we don't need the wasm file, but we erased it at the very
end, and SINGLE_FILE ended up embedding it unnecessarily...

This erases it right after we finish with it, which is simpler anyhow,
and then also makes the SINGLE_FILE resource embedding code
aware that if a file doesn't exist, there is nothing to embed.

Helps #10386