### PR TITLE
emscripten_log() - support also EM_LOG_INFO and EM_LOG_DEBUG flags

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -457,3 +457,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Guillaume Racicot <gufideg@gmail.com>
 * SK Min <oranke@gmail.com>
 * Fabio Alessandrelli <fabio.alessandrelli@gmail.com>
+* Kirill Gavrilov <kirill@sview.ru>

--- a/site/source/api_items.py
+++ b/site/source/api_items.py
@@ -72,6 +72,8 @@ def get_mapped_items():
     mapped_wiki_inline_code['EM_LOG_JS_STACK'] = ':c:macro:`EM_LOG_JS_STACK`'
     mapped_wiki_inline_code['EM_LOG_NO_PATHS'] = ':c:macro:`EM_LOG_NO_PATHS`'
     mapped_wiki_inline_code['EM_LOG_WARN'] = ':c:macro:`EM_LOG_WARN`'
+    mapped_wiki_inline_code['EM_LOG_INFO'] = ':c:macro:`EM_LOG_INFO`'
+    mapped_wiki_inline_code['EM_LOG_DEBUG'] = ':c:macro:`EM_LOG_DEBUG`'
     mapped_wiki_inline_code['EM_UTF8'] = ':c:macro:`EM_UTF8`'
     mapped_wiki_inline_code['EmscriptenBatteryEvent'] = ':c:type:`EmscriptenBatteryEvent`'
     mapped_wiki_inline_code['EmscriptenDeviceMotionEvent'] = ':c:type:`EmscriptenDeviceMotionEvent`'

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -978,9 +978,17 @@ Defines
 
   If specified, prints a warning message.
 
+.. c:macro:: EM_LOG_INFO
+
+  If specified, prints an info message to console (combined with :c:data:`EM_LOG_CONSOLE`).
+
+.. c:macro:: EM_LOG_DEBUG
+
+  If specified, prints a debug message to console (combined with :c:data:`EM_LOG_CONSOLE`).
+
 .. c:macro:: EM_LOG_ERROR
 
-  If specified, prints an error message. If neither :c:data:`EM_LOG_WARN` or :c:data:`EM_LOG_ERROR` is specified, an info message is printed. :c:data:`EM_LOG_WARN` and :c:data:`EM_LOG_ERROR` are mutually exclusive.
+  If specified, prints an error message. If neither :c:data:`EM_LOG_WARN`, :c:data:`EM_LOG_ERROR`, :c:data:`EM_LOG_INFO` nor :c:data:`EM_LOG_DEBUG` is specified, an info message is printed. :c:data:`EM_LOG_WARN`, :c:data:`EM_LOG_INFO`, :c:data:`EM_LOG_DEBUG` and :c:data:`EM_LOG_ERROR` are mutually exclusive.
 
 .. c:macro:: EM_LOG_C_STACK
 

--- a/src/library.js
+++ b/src/library.js
@@ -4298,6 +4298,10 @@ LibraryManager.library = {
         console.error(str);
       } else if (flags & 2 /*EM_LOG_WARN*/) {
         console.warn(str);
+      } else if (flags & 512 /*EM_LOG_INFO*/) {
+        console.info(str);
+      } else if (flags & 256 /*EM_LOG_DEBUG*/) {
+        console.debug(str);
       } else {
         console.log(str);
       }

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -244,6 +244,8 @@ char *emscripten_get_preloaded_image_data_from_FILE(FILE *file, int *w, int *h);
 #define EM_LOG_DEMANGLE 32
 #define EM_LOG_NO_PATHS 64
 #define EM_LOG_FUNC_PARAMS 128
+#define EM_LOG_DEBUG    256
+#define EM_LOG_INFO     512
 
 void emscripten_log(int flags, ...);
 

--- a/tests/emscripten_log/emscripten_log.cpp
+++ b/tests/emscripten_log/emscripten_log.cpp
@@ -33,6 +33,8 @@ void __attribute__((noinline)) kitten()
 	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_CONSOLE, "Info log to console: int: %d, string: %s", 42, "hello");
 	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_CONSOLE | EM_LOG_WARN, "Warning message to console.");
 	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_CONSOLE | EM_LOG_ERROR, "Error message to console! This should appear in red!");
+	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_CONSOLE | EM_LOG_INFO, "Info message to console.");
+	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_CONSOLE | EM_LOG_DEBUG, "Debug message to console.");
 
 	// Log to with full callstack information (both original C source and JS callstacks):
 	emscripten_log(EM_LOG_C_STACK | EM_LOG_JS_STACK | EM_LOG_DEMANGLE, "A message with as full call stack information as possible:");


### PR DESCRIPTION
It looks confusing that emscripten_log() lacks flags for printing Debug and Info (distinguished by some browsers) messages, so the proposes two new flags:

- EM_LOG_INFO|EM_LOG_CONSOLE redirects to console.info();
- EM_LOG_DEBUG|EM_LOG_CONSOLE redirects to console.debug().