### PR TITLE
Remove calls to unimplemented syscalls in sanitizer_linux.cc

### DIFF
--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cc
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cc
@@ -207,7 +207,7 @@ int internal_mprotect(void *addr, uptr length, int prot) {
 #endif
 
 uptr internal_close(fd_t fd) {
-#ifdef __EMSCRIPTEN__
+#if SANITIZER_EMSCRIPTEN
   return __wasi_fd_close(fd);
 #else
   return internal_syscall(SYSCALL(close), fd);
@@ -453,6 +453,8 @@ void internal__exit(int exitcode) {
   Die();  // Unreachable.
 }
 
+
+#if !SANITIZER_EMSCRIPTEN
 unsigned int internal_sleep(unsigned int seconds) {
   struct timespec ts;
   ts.tv_sec = seconds;
@@ -467,6 +469,7 @@ uptr internal_execve(const char *filename, char *const argv[],
   return internal_syscall(SYSCALL(execve), (uptr)filename, (uptr)argv,
                           (uptr)envp);
 }
+#endif  // !SANITIZER_EMSCRIPTEN
 #endif  // !SANITIZER_SOLARIS && !SANITIZER_NETBSD
 
 // ----------------- sanitizer_common.h
@@ -501,8 +504,9 @@ tid_t GetTid() {
 #endif
 }
 
+#if !SANITIZER_EMSCRIPTEN
 int TgKill(pid_t pid, tid_t tid, int sig) {
-#if SANITIZER_LINUX || SANITIZER_EMSCRIPTEN
+#if SANITIZER_LINUX
   return internal_syscall(SYSCALL(tgkill), pid, tid, sig);
 #elif SANITIZER_FREEBSD
   return internal_syscall(SYSCALL(thr_kill2), pid, tid, sig);
@@ -515,8 +519,9 @@ int TgKill(pid_t pid, tid_t tid, int sig) {
 #endif
 }
 #endif
+#endif
 
-#if !SANITIZER_SOLARIS && !SANITIZER_NETBSD
+#if !SANITIZER_SOLARIS && !SANITIZER_NETBSD && !SANITIZER_EMSCRIPTEN
 u64 NanoTime() {
 #if SANITIZER_FREEBSD || SANITIZER_OPENBSD
   timeval tv;
@@ -528,21 +533,19 @@ u64 NanoTime() {
   return (u64)tv.tv_sec * 1000*1000*1000 + tv.tv_usec * 1000;
 }
 
+uptr internal_clock_gettime(__sanitizer_clockid_t clk_id, void *tp) {
+  return internal_syscall(SYSCALL(clock_gettime), clk_id, tp);
+}
+#endif  // !SANITIZER_SOLARIS && !SANITIZER_NETBSD
+
 #if SANITIZER_EMSCRIPTEN
+extern "C" const char *emscripten_get_env(const char *name);
+
 int __clock_gettime(__sanitizer_clockid_t clk_id, void *tp);
 
 uptr internal_clock_gettime(__sanitizer_clockid_t clk_id, void *tp) {
   return __clock_gettime(clk_id, tp);
 }
-#else
-uptr internal_clock_gettime(__sanitizer_clockid_t clk_id, void *tp) {
-  return internal_syscall(SYSCALL(clock_gettime), clk_id, tp);
-}
-#endif // SANITIZER_EMSCRIPTEN
-#endif  // !SANITIZER_SOLARIS && !SANITIZER_NETBSD
-
-#if SANITIZER_EMSCRIPTEN
-extern "C" const char *emscripten_get_env(const char *name);
 #endif
 
 // Like getenv, but reads env directly from /proc (on Linux) or parses the
@@ -758,11 +761,13 @@ struct linux_dirent {
 #endif
 
 #if !SANITIZER_SOLARIS && !SANITIZER_NETBSD
+#if !SANITIZER_EMSCRIPTEN
 // Syscall wrappers.
 uptr internal_ptrace(int request, int pid, void *addr, void *data) {
   return internal_syscall(SYSCALL(ptrace), request, pid, (uptr)addr,
                           (uptr)data);
 }
+#endif
 
 uptr internal_waitpid(int pid, int *status, int options) {
   return internal_syscall(SYSCALL(wait4), pid, (uptr)status, options,
@@ -788,7 +793,12 @@ uptr internal_getdents(fd_t fd, struct linux_dirent *dirp, unsigned int count) {
 }
 
 uptr internal_lseek(fd_t fd, OFF_T offset, int whence) {
+#if SANITIZER_EMSCRIPTEN
+  __wasi_filesize_t result;
+  return __wasi_syscall_ret(__wasi_fd_seek(fd, offset, whence, &result)) ? -1 : result;
+#else
   return internal_syscall(SYSCALL(lseek), fd, offset, whence);
+#endif
 }
 
 #if SANITIZER_LINUX
@@ -797,9 +807,11 @@ uptr internal_prctl(int option, uptr arg2, uptr arg3, uptr arg4, uptr arg5) {
 }
 #endif
 
+#if !SANITIZER_EMSCRIPTEN
 uptr internal_sigaltstack(const void *ss, void *oss) {
   return internal_syscall(SYSCALL(sigaltstack), (uptr)ss, (uptr)oss);
 }
+#endif
 
 int internal_fork() {
 #if SANITIZER_EMSCRIPTEN
@@ -903,6 +915,8 @@ uptr internal_sigprocmask(int how, __sanitizer_sigset_t *set,
                           __sanitizer_sigset_t *oldset) {
 #if SANITIZER_FREEBSD || SANITIZER_OPENBSD
   return internal_syscall(SYSCALL(sigprocmask), how, set, oldset);
+#elif SANITIZER_EMSCRIPTEN
+  return NULL;
 #else
   __sanitizer_kernel_sigset_t *k_set = (__sanitizer_kernel_sigset_t *)set;
   __sanitizer_kernel_sigset_t *k_oldset = (__sanitizer_kernel_sigset_t *)oldset;


### PR DESCRIPTION
The remove syscalls here are ones that emscripten does not implement.

This paves the way for #10439 which remove the SYS_<FOO> declarations
of non-implemented syscalls, which makes it a compilation error to
try to use one.