### PR TITLE
Adding COPYWITHIN option for fast memcpy operations.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -923,9 +923,24 @@ LibraryManager.library = {
     return ret;
   },
 
+#if COPYWITHIN == 0
   emscripten_memcpy_big: function(dest, src, num) {
     HEAPU8.set(HEAPU8.subarray(src, src+num), dest);
   },
+#else
+#if COPYWITHIN == 2
+  emscripten_memcpy_big: function(dest, src, num) {
+    HEAPU8.copyWithin(dest, src, src+num);
+  },
+#else
+  emscripten_memcpy_big__postset:
+    "if (typeof Uint8Array.prototype.copyWithin == 'function') {\n" +
+    "  emscripten_memcpy_big = function(dest, src, num) { HEAPU8.copyWithin(dest, src, src + num); };\n" +
+    "} else {\n" +
+    "  emscripten_memcpy_big = function(dest, src, num) { HEAPU8.set(HEAPU8.subarray(src, src+num), dest); };\n" +
+    "}\n" +
+#endif
+#endif
 
   memcpy__asm: true,
   memcpy__sig: 'iiii',

--- a/src/settings.js
+++ b/src/settings.js
@@ -1507,6 +1507,12 @@ var BUNDLED_CD_DEBUG_FILE = "";
 // any JS code to fall back if it is missing.
 var TEXTDECODER = 1;
 
+// If enabled, use the TypedArray.copyWithin() method for the JS memcpy implementation.
+// Disabled by default, set this to 1 to enable.
+// If set to 2, we do not check for the method availability and assume an external
+// polyfill is in place.
+var COPYWITHIN = 0;
+
 // Embind specific: If enabled, assume UTF-8 encoded data in std::string binding.
 // Disable this to support binary data transfer.
 var EMBIND_STD_STRING_IS_UTF8 = 1;


### PR DESCRIPTION
as per results from https://jsfiddle.net/CoolCmd/two1qzfn/

Firefox 73 on Windows:

```
copyWithin      x 384,852 ops/sec ±0.68% (5 runs sampled)
set+subarray    x  46,700 ops/sec ±1.72% (5 runs sampled)
```

Chrome on macOS:

```
copyWithin      x 354,761 ops/sec ±0.86% (60 runs sampled)
set+subarray    x 177,087 ops/sec ±0.43% (64 runs sampled)
```

Been using the native copyWithin method under our [ffmpeg.js fork](https://github.com/meganz/ffmpeg.js/blob/8771d0133eb0edc4127357ad97697404bde38077/Makefile#L218) for a while now, so thought on submitting this patch for proper incorporation in upstream.

Thanks :)
