### PR TITLE
Closure needs to see a JS object assigned to the variable Module

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3432,7 +3432,7 @@ def module_export_name_substitution():
   else:
     replacement = "typeof %(EXPORT_NAME)s !== 'undefined' ? %(EXPORT_NAME)s : {}" % {"EXPORT_NAME": shared.Settings.EXPORT_NAME}
   with open(final, 'w') as f:
-    src = src.replace(shared.JS.module_export_name_substitution_pattern, replacement)
+    src = re.sub(r'{[\'"]?__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__[\'"]?:1}', replacement, src)
     # For Node.js and other shell environments, create an unminified Module object so that
     # loading external .asm.js file that assigns to Module['asm'] works even when Closure is used.
     if shared.Settings.MINIMAL_RUNTIME and not shared.Settings.MODULARIZE_INSTANCE and (shared.Settings.target_environment_may_be('node') or shared.Settings.target_environment_may_be('shell')):

--- a/src/shell.js
+++ b/src/shell.js
@@ -23,8 +23,13 @@
 // can continue to use Module afterwards as well.
 #if USE_CLOSURE_COMPILER
 // if (!Module)` is crucial for Closure Compiler here as it will otherwise replace every `Module` occurrence with a string
-var Module;
-if (!Module) Module = "__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__";
+var /** @type {{
+  noImageDecoding: boolean,
+  noAudioDecoding: boolean,
+  canvas: HTMLCanvasElement
+}}
+ */ Module;
+if (!Module) /** @suppress{checkTypes}*/Module = {"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1};
 #else
 var Module = typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : {};
 #endif // USE_CLOSURE_COMPILER

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -6,8 +6,8 @@
 #if SIDE_MODULE == 0
 #if USE_CLOSURE_COMPILER
 // if (!Module)` is crucial for Closure Compiler here as it will otherwise replace every `Module` occurrence with a string
-var Module;
-if (!Module) Module = "__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__";
+var /** @type{Object} */ Module;
+if (!Module) /** @suppress{checkTypes}*/Module = {"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1};
 #else
 var Module = {{{ EXPORT_NAME }}};
 #endif // USE_CLOSURE_COMPILER

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -5,7 +5,7 @@
 
 #if SIDE_MODULE == 0
 #if USE_CLOSURE_COMPILER
-// if (!Module)` is crucial for Closure Compiler here as it will otherwise replace every `Module` occurrence with a string
+// if (!Module)` is crucial for Closure Compiler here as it will otherwise replace every `Module` occurrence with the object below
 var /** @type{Object} */ Module;
 if (!Module) /** @suppress{checkTypes}*/Module = {"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1};
 #else

--- a/tools/separate_asm.py
+++ b/tools/separate_asm.py
@@ -72,7 +72,7 @@ else:
   # closure compiler removes |var Module|, we need to find the closured name
   # seek a pattern like (e.ENVIRONMENT), which is in the shell.js if-cascade for the ENVIRONMENT override
   import re
-  m = re.search(r'(\w+)\s*=\s*"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__"', everything)
+  m = re.search(r'(\w+)\s*=\s*{"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1}', everything)
   if not m:
     m = re.search(r'(\w+)=typeof Module !== \'undefined\' \? Module : {}', everything)
   if not m:

--- a/tools/separate_asm.py
+++ b/tools/separate_asm.py
@@ -74,6 +74,8 @@ else:
   import re
   m = re.search(r'(\w+)\s*=\s*{"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1}', everything)
   if not m:
+    m = re.search(r'(\w+)\s*=\s*{__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__:1}', everything)
+  if not m:
     m = re.search(r'(\w+)=typeof Module !== \'undefined\' \? Module : {}', everything)
   if not m:
     m = re.search(r'\((\w+)\.ENVIRONMENT\)', everything)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2986,7 +2986,7 @@ class JS(object):
 
   global_initializers_pattern = r'/\* global initializers \*/ __ATINIT__.push\((.+)\);'
 
-  module_export_name_substitution_pattern = '"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__"'
+  module_export_name_substitution_pattern = '{"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1}'
 
   @staticmethod
   def to_nice_ident(ident): # limited version of the JS function toNiceIdent

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2986,8 +2986,6 @@ class JS(object):
 
   global_initializers_pattern = r'/\* global initializers \*/ __ATINIT__.push\((.+)\);'
 
-  module_export_name_substitution_pattern = '{"__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__":1}'
-
   @staticmethod
   def to_nice_ident(ident): # limited version of the JS function toNiceIdent
     return ident.replace('%', '$').replace('@', '_').replace('.', '_')


### PR DESCRIPTION
Closure needs to see a JS object assigned to the variable Module, otherwise with our assign-a-string hack it thinks that Module is always a string, and issues warnings.