### PR TITLE
Refactor emscripten_get_now() implementation to avoid Closure warnings.

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -247,6 +247,8 @@ function JSify(data, functionsOnly) {
         Functions.libraryFunctions[finalName] = 1;
       }
 
+      // If a JS library item specifies xxx_import: true, then explicitly mark that symbol to be imported
+      // to asm.js/wasm module.
       if (LibraryManager.library[ident + '__import']) {
         Functions.libraryFunctions[finalName] = 1;
       }

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -138,7 +138,8 @@ function JSify(data, functionsOnly) {
       if (typeof ident == 'function') return ident();
 
       // don't process any special identifiers. These are looked up when processing the base name of the identifier.
-      if (ident.endsWith('__sig') || ident.endsWith('__proxy') || ident.endsWith('__asm') || ident.endsWith('__inline') || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs')) {
+      if (ident.endsWith('__sig') || ident.endsWith('__proxy') || ident.endsWith('__asm') || ident.endsWith('__inline')
+       || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs') || ident.endsWith('__import')) {
         return '';
       }
 
@@ -237,16 +238,16 @@ function JSify(data, functionsOnly) {
           if (!redirectedIdent && (typeof target == 'function' || /Math_\w+/.exec(snippet))) {
             Functions.libraryFunctions[finalName] = 1;
           }
-        } else if (snippet.indexOf('function(') != -1) {
-          // Assume this is an inline defined function (like emscripten_memcpy_big), and it possibly
-          // needs to be imported to asm.js/wasm scope.
-          Functions.libraryFunctions[finalName] = 1;
         }
       } else if (typeof snippet === 'object') {
         snippet = stringifyWithFunctions(snippet);
       } else if (typeof snippet === 'function') {
         isFunction = true;
         snippet = processLibraryFunction(snippet, ident, finalName);
+        Functions.libraryFunctions[finalName] = 1;
+      }
+
+      if (LibraryManager.library[ident + '__import']) {
         Functions.libraryFunctions[finalName] = 1;
       }
 

--- a/src/library.js
+++ b/src/library.js
@@ -4048,10 +4048,10 @@ LibraryManager.library = {
     return Math.random();
   },
 
-  emscripten_get_now: '=(function() {' +
+  emscripten_get_now: ';' +
 #if ENVIRONMENT_MAY_BE_NODE
                                "if (ENVIRONMENT_IS_NODE) {\n" +
-                               "  return (function _emscripten_get_now_actual() {\n" +
+                               "  _emscripten_get_now = function() {\n" +
                                "    var t = process['hrtime']();\n" +
                                "    return t[0] * 1e3 + t[1] / 1e6;\n" +
                                "  };\n" +
@@ -4060,23 +4060,23 @@ LibraryManager.library = {
 #if USE_PTHREADS
 // Pthreads need their clocks synchronized to the execution of the main thread, so give them a special form of the function.
                                "if (ENVIRONMENT_IS_PTHREAD) {\n" +
-                               "  return (function() { return performance['now']() - Module['__performance_now_clock_drift']; });\n" +
+                               "  _emscripten_get_now = function() { return performance['now']() - Module['__performance_now_clock_drift']; };\n" +
                                "} else " +
 #endif
 #if ENVIRONMENT_MAY_BE_SHELL
                                "if (typeof dateNow !== 'undefined') {\n" +
-                               "  return dateNow;\n" +
+                               "  _emscripten_get_now = dateNow;\n" +
                                "} else " +
 #endif
 #if MIN_IE_VERSION <= 9 || MIN_FIREFOX_VERSION <= 14 || MIN_CHROME_VERSION <= 23 || MIN_SAFARI_VERSION <= 80400 // https://caniuse.com/#feat=high-resolution-time
-                               "if (typeof performance === 'object' && performance && typeof performance['now'] === 'function') {\n" +
-                               "  return performance['now'];\n" +
+                               "if (typeof performance !== 'undefined' && performance['now']) {\n" +
+                               "  _emscripten_get_now = performance['now'];\n" +
                                "} else {\n" +
-                               "  return Date.now;\n" +
+                               "  _emscripten_get_now = Date.now;\n" +
                                "}" +
 #else
                                // Modern environment where performance.now() is supported:
-                               "return performance['now'];\n" +
+                               "_emscripten_get_now = performance['now'];\n" +
 #endif
                       '})();',
 

--- a/src/library.js
+++ b/src/library.js
@@ -4060,7 +4060,7 @@ LibraryManager.library = {
 #if USE_PTHREADS
 // Pthreads need their clocks synchronized to the execution of the main thread, so give them a special form of the function.
                                "if (ENVIRONMENT_IS_PTHREAD) {\n" +
-                               "  _emscripten_get_now = function() { return performance['now']() - Module['__performance_now_clock_drift']; };\n" +
+                               "  _emscripten_get_now = function() { return performance.now() - Module['__performance_now_clock_drift']; };\n" +
                                "} else " +
 #endif
 #if ENVIRONMENT_MAY_BE_SHELL
@@ -4069,14 +4069,14 @@ LibraryManager.library = {
                                "} else " +
 #endif
 #if MIN_IE_VERSION <= 9 || MIN_FIREFOX_VERSION <= 14 || MIN_CHROME_VERSION <= 23 || MIN_SAFARI_VERSION <= 80400 // https://caniuse.com/#feat=high-resolution-time
-                               "if (typeof performance !== 'undefined' && performance['now']) {\n" +
-                               "  _emscripten_get_now = performance['now'];\n" +
+                               "if (typeof performance !== 'undefined' && performance.now) {\n" +
+                               "  _emscripten_get_now = performance.now;\n" +
                                "} else {\n" +
                                "  _emscripten_get_now = Date.now;\n" +
                                "}" +
 #else
                                // Modern environment where performance.now() is supported:
-                               "_emscripten_get_now = performance['now'];\n" +
+                               "_emscripten_get_now = performance.now;\n" +
 #endif
                       '})();',
 

--- a/src/library.js
+++ b/src/library.js
@@ -4073,12 +4073,11 @@ LibraryManager.library = {
                                "  _emscripten_get_now = performance.now;\n" +
                                "} else {\n" +
                                "  _emscripten_get_now = Date.now;\n" +
-                               "}" +
+                               "}",
 #else
                                // Modern environment where performance.now() is supported:
-                               "_emscripten_get_now = performance.now;\n" +
+                               "_emscripten_get_now = performance.now;\n",
 #endif
-                      '})();',
 
   emscripten_get_now_res: function() { // return resolution of get_now, in nanoseconds
 #if ENVIRONMENT_MAY_BE_NODE

--- a/src/library.js
+++ b/src/library.js
@@ -4072,13 +4072,14 @@ LibraryManager.library = {
 #endif
 #if MIN_IE_VERSION <= 9 || MIN_FIREFOX_VERSION <= 14 || MIN_CHROME_VERSION <= 23 || MIN_SAFARI_VERSION <= 80400 // https://caniuse.com/#feat=high-resolution-time
                                "if (typeof performance !== 'undefined' && performance.now) {\n" +
-                               "  _emscripten_get_now = performance.now;\n" +
+                               "  _emscripten_get_now = function() { return performance.now(); }\n" +
                                "} else {\n" +
                                "  _emscripten_get_now = Date.now;\n" +
                                "}",
 #else
                                // Modern environment where performance.now() is supported:
-                               "_emscripten_get_now = performance.now;\n",
+                               // N.B. a shorter form "_emscripten_get_now = return performance.now;" is unfortunately not allowed even in current browsers (e.g. FF Nightly 75).
+                               "_emscripten_get_now = function() { return performance.now(); }\n",
 #endif
 
   emscripten_get_now_res: function() { // return resolution of get_now, in nanoseconds

--- a/src/library.js
+++ b/src/library.js
@@ -942,6 +942,7 @@ LibraryManager.library = {
   //   AppleWebKit/605.1.15 Safari/604.1 Version/13.0.4 iPhone OS 13_3 on iPhone 6s with iOS 13.3
   //   AppleWebKit/605.1.15 Version/13.0.3 Intel Mac OS X 10_15_1 on Safari 13.0.3 (15608.3.10.1.4) on macOS Catalina 10.15.1
   // Hence the support status of .copyWithin() for Safari version range [10.0.0, 10.1.0] is unknown.
+  emscripten_memcpy_big__import: true,
   emscripten_memcpy_big: '= Uint8Array.prototype.copyWithin\n' +
     '  ? function(dest, src, num) { HEAPU8.copyWithin(dest, src, src + num); }\n' +
     '  : function(dest, src, num) { HEAPU8.set(HEAPU8.subarray(src, src+num), dest); }\n',
@@ -4048,6 +4049,7 @@ LibraryManager.library = {
     return Math.random();
   },
 
+  emscripten_get_now__import: true,
   emscripten_get_now: ';' +
 #if ENVIRONMENT_MAY_BE_NODE
                                "if (ENVIRONMENT_IS_NODE) {\n" +


### PR DESCRIPTION
In particular this does a change
```js
var _emscripten_get_now = performance.now;
```
as opposed to
```js
var _emscripten_get_now = function() { return performance.now(); };
```
That drops `this==performance` in invocations, and I really vaguely recall that some environment would not have liked that, but cannot remember which, and if we don't have a documented proof, we shouldn't do it.

(compare to Date.now, which was never invoked with `this==Date`)