### PR TITLE
Refactor library_fs.js FSNode & FSStream to a Closure friendly format.

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -74,7 +74,7 @@ Object.defineProperties(FSNode.prototype, {
  }
 });
 FS.FSNode = FSNode;
-FS.staticInit();'` +
+FS.staticInit();` +
 #if USE_CLOSURE_COMPILER
            // Declare variable for Closure, FS.createPreloadedFile() below calls Browser.init()
            '/**@suppress {duplicate, undefinedVars}*/var Browser;' +

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -29,52 +29,52 @@ mergeInto(LibraryManager.library, {
     // We must statically create FS.FSNode here so that it is created in a manner
     // that is visible to Closure compiler. That lets us use type annotations for
     // Closure to the "this" pointer in various node creation functions.
-    return 'var FSNode = /** @constructor */ function(parent, name, mode, rdev) {\n'+
-             'if (!parent) {\n'+
-               'parent = this;  // root node sets parent to itself\n'+
-             '}\n'+
-             'this.parent = parent;\n'+
-             'this.mount = parent.mount;\n'+
-             'this.mounted = null;\n'+
-             'this.id = FS.nextInode++;\n'+
-             'this.name = name;\n'+
-             'this.mode = mode;\n'+
-             'this.node_ops = {};\n'+
-             'this.stream_ops = {};\n'+
-             'this.rdev = rdev;\n'+
-           '};\n'+
-           'var readMode = 292/*{{{ cDefine("S_IRUGO") }}}*/ | 73/*{{{ cDefine("S_IXUGO") }}}*/;\n'+
-           'var writeMode = 146/*{{{ cDefine("S_IWUGO") }}}*/;\n'+
-           'Object.defineProperties(FSNode.prototype, {\n'+
-            'read: {\n'+
-             'get: /** @this{FSNode} */function() {\n'+
-              'return (this.mode & readMode) === readMode;\n'+
-             '},\n'+
-             'set: /** @this{FSNode} */function(val) {\n'+
-              'val ? this.mode |= readMode : this.mode &= ~readMode;\n'+
-             '}\n'+
-            '},\n'+
-            'write: {\n'+
-             'get: /** @this{FSNode} */function() {\n'+
-              'return (this.mode & writeMode) === writeMode;\n'+
-             '},\n'+
-             'set: /** @this{FSNode} */function(val) {\n'+
-              'val ? this.mode |= writeMode : this.mode &= ~writeMode;\n'+
-             '}\n'+
-            '},\n'+
-            'isFolder: {\n'+
-             'get: /** @this{FSNode} */function() {\n'+
-              'return FS.isDir(this.mode);\n'+
-             '}\n'+
-            '},\n'+
-            'isDevice: {\n'+
-             'get: /** @this{FSNode} */function() {\n'+
-              'return FS.isChrdev(this.mode);\n'+
-             '}\n'+
-            '}\n'+
-           '});\n'+
-           'FS.FSNode = FSNode;\n' +
-           'FS.staticInit();' +
+    return `var FSNode = /** @constructor */ function(parent, name, mode, rdev) {
+  if (!parent) {
+    parent = this;  // root node sets parent to itself
+  }
+  this.parent = parent;
+  this.mount = parent.mount;
+  this.mounted = null;
+  this.id = FS.nextInode++;
+  this.name = name;
+  this.mode = mode;
+  this.node_ops = {};
+  this.stream_ops = {};
+  this.rdev = rdev;
+};
+var readMode = 292/*{{{ cDefine("S_IRUGO") }}}*/ | 73/*{{{ cDefine("S_IXUGO") }}}*/;
+var writeMode = 146/*{{{ cDefine("S_IWUGO") }}}*/;
+Object.defineProperties(FSNode.prototype, {
+ read: {
+  get: /** @this{FSNode} */function() {
+   return (this.mode & readMode) === readMode;
+  },
+  set: /** @this{FSNode} */function(val) {
+   val ? this.mode |= readMode : this.mode &= ~readMode;
+  }
+ },
+ write: {
+  get: /** @this{FSNode} */function() {
+   return (this.mode & writeMode) === writeMode;
+  },
+  set: /** @this{FSNode} */function(val) {
+   val ? this.mode |= writeMode : this.mode &= ~writeMode;
+  }
+ },
+ isFolder: {
+  get: /** @this{FSNode} */function() {
+   return FS.isDir(this.mode);
+  }
+ },
+ isDevice: {
+  get: /** @this{FSNode} */function() {
+   return FS.isChrdev(this.mode);
+  }
+ }
+});
+FS.FSNode = FSNode;
+FS.staticInit();'` +
 #if USE_CLOSURE_COMPILER
            // Declare variable for Closure, FS.createPreloadedFile() below calls Browser.init()
            '/**@suppress {duplicate, undefinedVars}*/var Browser;' +


### PR DESCRIPTION
This is a bit ugly, but was not able to find a reasonably better way.

The issue is that Closure does not like conditionally defined global types inside a function, but for all functions it needs to know what `this` is for the function bodies, if `this` is referenced in the function. In order to be able to do `/** @this{FSNode} */`, `FSNode` must live in global scope, but it is dynamically constructed, so ends up looking a bit tedious.