### PR TITLE
Remove unused SYS_futimesat. NFC.

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1201,9 +1201,6 @@ var SyscallsLibrary = {
     FS.chown(path, owner, group);
     return 0;
   },
-  __syscall299: function(which, varargs) { // futimesat
-    abort('futimesat is obsolete');
-  },
   __syscall300: function(which, varargs) { // fstatat64
     var dirfd = SYSCALLS.get(), path = SYSCALLS.getStr(), buf = SYSCALLS.get(), flags = SYSCALLS.get();
     var nofollow = flags & {{{ cDefine('AT_SYMLINK_NOFOLLOW') }}};
@@ -1602,7 +1599,6 @@ var SYSCALL_CODE_TO_NAME = {
   296: "mkdirat",
   297: "mknodat",
   298: "fchownat",
-  299: "futimesat",
   300: "fstatat64",
   301: "unlinkat",
   302: "renameat",

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -95,7 +95,6 @@
 #define __NR_mkdirat		296
 #define __NR_mknodat		297
 #define __NR_fchownat		298
-#define __NR_futimesat		299
 #define __NR_fstatat64		300
 #define __NR_unlinkat		301
 #define __NR_renameat		302

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -206,7 +206,6 @@
 #define SYS_mkdirat		296
 #define SYS_mknodat		297
 #define SYS_fchownat		298
-#define SYS_futimesat		299
 #define SYS_fstatat64		300
 #define SYS_unlinkat		301
 #define SYS_renameat		302

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h.in
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h.in
@@ -95,7 +95,6 @@
 #define __NR_mkdirat		296
 #define __NR_mknodat		297
 #define __NR_fchownat		298
-#define __NR_futimesat		299
 #define __NR_fstatat64		300
 #define __NR_unlinkat		301
 #define __NR_renameat		302

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -129,7 +129,6 @@ long __syscall295(int which, ...);
 long __syscall296(int which, ...);
 long __syscall297(int which, ...);
 long __syscall298(int which, ...);
-long __syscall299(int which, ...);
 long __syscall300(int which, ...);
 long __syscall301(int which, ...);
 long __syscall302(int which, ...);
@@ -148,8 +147,6 @@ long __syscall334(int which, ...);
 long __syscall337(int which, ...);
 long __syscall340(int which, ...);
 long __syscall345(int which, ...);
-
-#undef SYS_futimesat
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
We were defining this and then undefining.  Better to just get rid of it
completely instead.