### PR TITLE
Optimize memcpy using @diegocr's improved HEAPU8.copyWithin method.

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -233,6 +233,10 @@ function JSify(data, functionsOnly) {
           if (!redirectedIdent && (typeof target == 'function' || /Math_\w+/.exec(snippet))) {
             Functions.libraryFunctions[finalName] = 1;
           }
+        } else if (snippet.indexOf('function(') != -1) {
+          // Assume this is an inline defined function (like emscripten_memcpy_big), and it possibly
+          // needs to be imported to asm.js/wasm scope.
+          Functions.libraryFunctions[finalName] = 1;
         }
       } else if (typeof snippet === 'object') {
         snippet = stringifyWithFunctions(snippet);

--- a/src/library.js
+++ b/src/library.js
@@ -924,11 +924,9 @@ LibraryManager.library = {
   },
 
 #if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin
-  emscripten_memcpy_big: ';if (HEAPU8.copyWithin) {\n' +
-    '  _emscripten_memcpy_big = function(dest, src, num) { HEAPU8.copyWithin(dest, src, src + num); };\n' +
-    '} else {\n' +
-    '  _emscripten_memcpy_big = function(dest, src, num) { HEAPU8.set(HEAPU8.subarray(src, src+num), dest); };\n' +
-    '}',
+  emscripten_memcpy_big: '= HEAPU8.copyWithin\n' +
+    '  ? function(dest, src, num) { HEAPU8.copyWithin(dest, src, src + num); }\n' +
+    '  : function(dest, src, num) { HEAPU8.set(HEAPU8.subarray(src, src+num), dest); }\n',
 #else
   emscripten_memcpy_big: function(dest, src, num) {
     HEAPU8.copyWithin(dest, src, src + num);

--- a/src/library.js
+++ b/src/library.js
@@ -923,18 +923,19 @@ LibraryManager.library = {
     return ret;
   },
 
-#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100304 || STANDALONE_WASM
+#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101 || STANDALONE_WASM
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin lists browsers that support TypedArray.prototype.copyWithin, but it
   // has outdated information for Safari, saying it would not support it.
   // https://github.com/WebKit/webkit/commit/24a800eea4d82d6d595cdfec69d0f68e733b5c52#diff-c484911d8df319ba75fce0d8e7296333R1 suggests support was added on Aug 28, 2015.
   // Manual testing suggests:
   //   Safari/601.1 Version/9.0 on iPhone 4s with iOS 9.3.6 (released September 30, 2015) does not support copyWithin.
   // but the following systems do:
+  //   AppleWebKit/602.2.14 Safari/602.1 Version/10.0 Mobile/14B100 iPhone OS 10_1_1 on iPhone 5s with iOS 10.1.1 (released October 31, 2016)
   //   AppleWebKit/603.3.8 Safari/602.1 Version/10.0 on iPhone 5 with iOS 10.3.4 (released July 22, 2019)
   //   AppleWebKit/605.1.15 iPhone OS 12_3_1 Version/12.1.1 Safari/604.1 on iPhone SE with iOS 12.3.1
   //   AppleWebKit/605.1.15 Safari/604.1 Version/13.0.4 iPhone OS 13_3 on iPhone 6s with iOS 13.3
   //   AppleWebKit/605.1.15 Version/13.0.3 Intel Mac OS X 10_15_1 on Safari 13.0.3 (15608.3.10.1.4) on macOS Catalina 10.15.1
-  // Hence the support status for Safari version range [10.0.0, 10.3.3] is unknown.
+  // Hence the support status of .copyWithin() for Safari version range [10.0.0, 10.1.0] is unknown.
   emscripten_memcpy_big: '= Uint8Array.prototype.copyWithin\n' +
     '  ? function(dest, src, num) { HEAPU8.copyWithin(dest, src, src + num); }\n' +
     '  : function(dest, src, num) { HEAPU8.set(HEAPU8.subarray(src, src+num), dest); }\n',

--- a/src/library.js
+++ b/src/library.js
@@ -923,7 +923,18 @@ LibraryManager.library = {
     return ret;
   },
 
-#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED || STANDALONE_WASM // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin
+#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100304 || STANDALONE_WASM
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin lists browsers that support TypedArray.prototype.copyWithin, but it
+  // has outdated information for Safari, saying it would not support it.
+  // https://github.com/WebKit/webkit/commit/24a800eea4d82d6d595cdfec69d0f68e733b5c52#diff-c484911d8df319ba75fce0d8e7296333R1 suggests support was added on Aug 28, 2015.
+  // Manual testing suggests:
+  //   Safari/601.1 Version/9.0 on iPhone 4s with iOS 9.3.6 (released September 30, 2015) does not support copyWithin.
+  // but the following systems do:
+  //   AppleWebKit/603.3.8 Safari/602.1 Version/10.0 on iPhone 5 with iOS 10.3.4 (released July 22, 2019)
+  //   AppleWebKit/605.1.15 iPhone OS 12_3_1 Version/12.1.1 Safari/604.1 on iPhone SE with iOS 12.3.1
+  //   AppleWebKit/605.1.15 Safari/604.1 Version/13.0.4 iPhone OS 13_3 on iPhone 6s with iOS 13.3
+  //   AppleWebKit/605.1.15 Version/13.0.3 Intel Mac OS X 10_15_1 on Safari 13.0.3 (15608.3.10.1.4) on macOS Catalina 10.15.1
+  // Hence the support status for Safari version range [10.0.0, 10.3.3] is unknown.
   emscripten_memcpy_big: '= Uint8Array.prototype.copyWithin\n' +
     '  ? function(dest, src, num) { HEAPU8.copyWithin(dest, src, src + num); }\n' +
     '  : function(dest, src, num) { HEAPU8.set(HEAPU8.subarray(src, src+num), dest); }\n',

--- a/src/library.js
+++ b/src/library.js
@@ -923,8 +923,8 @@ LibraryManager.library = {
     return ret;
   },
 
-#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin
-  emscripten_memcpy_big: '= HEAPU8.copyWithin\n' +
+#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED || STANDALONE_WASM // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin
+  emscripten_memcpy_big: '= Uint8Array.prototype.copyWithin\n' +
     '  ? function(dest, src, num) { HEAPU8.copyWithin(dest, src, src + num); }\n' +
     '  : function(dest, src, num) { HEAPU8.set(HEAPU8.subarray(src, src+num), dest); }\n',
 #else

--- a/system/lib/libc/emscripten_memcpy.c
+++ b/system/lib/libc/emscripten_memcpy.c
@@ -25,7 +25,7 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t n)
   unsigned char *block_aligned_d_end;
   unsigned char *d_end;
 
-  if (n >= 8192) {
+  if (n >= 512) {
     emscripten_memcpy_big(dest, src, n);
     return dest;
   }

--- a/system/lib/standalone_wasm.c
+++ b/system/lib/standalone_wasm.c
@@ -51,11 +51,11 @@ void __unlock(void* ptr) {}
 
 void *emscripten_memcpy_big(void *restrict dest, const void *restrict src, size_t n) {
   // This normally calls out into JS which can do a single fast operation,
-  // but with wasi we can't do that. As this is called when n >= 8192, we
+  // but with wasi we can't do that. As this is called when n >= 512, we
   // can just split into smaller calls.
   // TODO optimize, maybe build our memcpy with a wasi variant, maybe have
   //      a SIMD variant, etc.
-  const int CHUNK = 4096;
+  const int CHUNK = 508;
   unsigned char* d = (unsigned char*)dest;
   unsigned char* s = (unsigned char*)src;
   while (n > 0) {

--- a/tests/benchmark_memcpy.cpp
+++ b/tests/benchmark_memcpy.cpp
@@ -98,7 +98,7 @@ void print_results()
 	for(size_t i = 0; i < copySizes.size(); ++i)
 	{
 		std::cout << copySizes[i];
-		if (i != copySizes.size()-1) std::cout << ",";
+		if (i != copySizes.size()-1) std::cout << ", ";
 		else std::cout << std::endl;
 		if (i % 10 == 9) std::cout << std::endl;
 	}
@@ -109,7 +109,7 @@ void print_results()
 	for(size_t i = 0; i < results.size(); ++i)
 	{
 		std::cout << results[i];
-		if (i != results.size()-1) std::cout << ",";
+		if (i != results.size()-1) std::cout << ", ";
 		else std::cout << std::endl;
 		if (i % 10 == 9) std::cout << std::endl;
 	}


### PR DESCRIPTION
Optimize memcpy using @diegocr's improved HEAPU8.copyWithin method. Rebalance emscripten_memcpy_big() cutoff point, lowered from 8k bytes to just 512 bytes.