### PR TITLE
Remove unused EM_PROXIED_SYSCALL special hanling of syscalls

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1747,22 +1747,4 @@ for (var x in SyscallsLibrary) {
 #endif
 }
 
-#if USE_PTHREADS
-// emscripten_syscall is a switch over all compiled-in syscalls, used for proxying to the main thread
-var switcher =
-  'function(which, varargs) {\n' +
-  '  switch (which) {\n';
-DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.forEach(function(func) {
-  var m = /^__syscall(\d+)$/.exec(func);
-  if (!m) return;
-  var which = +m[1];
-  switcher += '    case ' + which + ': return ___syscall' + which + '(which, varargs);\n';
-});
-switcher +=
-  '    default: throw "surprising proxied syscall: " + which;\n' +
-  '  }\n' +
-  '}\n';
-SyscallsLibrary.emscripten_syscall = eval('(' + switcher + ')');
-#endif
-
 mergeInto(LibraryManager.library, SyscallsLibrary);

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1507,7 +1507,6 @@
         },
         "defines": [
             "EM_PROXIED_PTHREAD_CREATE",
-            "EM_PROXIED_SYSCALL",
             "EM_PROXIED_CREATE_CONTEXT",
             "EM_PROXIED_RESIZE_OFFSCREENCANVAS",
             "EM_PROXIED_JS_FUNCTION",

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -252,7 +252,6 @@ typedef int (*em_func_iiiiiiiiii)(int, int, int, int, int, int, int, int, int);
 #define EM_PROXIED_FUNC_SPECIAL(x) (EM_FUNC_SIG_SPECIAL_INTERNAL | ((x) << 20))
 
 #define EM_PROXIED_PTHREAD_CREATE (EM_PROXIED_FUNC_SPECIAL(0) | EM_FUNC_SIG_IIIII)
-#define EM_PROXIED_SYSCALL (EM_PROXIED_FUNC_SPECIAL(1) | EM_FUNC_SIG_III)
 #define EM_PROXIED_CREATE_CONTEXT (EM_PROXIED_FUNC_SPECIAL(2) | EM_FUNC_SIG_III)
 #define EM_PROXIED_RESIZE_OFFSCREENCANVAS (EM_PROXIED_FUNC_SPECIAL(3) | EM_FUNC_SIG_IIII)
 #define EM_PROXIED_JS_FUNCTION (EM_PROXIED_FUNC_SPECIAL(4) | EM_FUNC_SIG_D)
@@ -310,9 +309,6 @@ void emscripten_main_thread_process_queued_calls(void);
 void emscripten_current_thread_process_queued_calls(void);
 
 pthread_t emscripten_main_browser_thread_id(void);
-
-// Direct syscall access, second argument is a varargs pointer. used in proxying
-int emscripten_syscall(int, void*);
 
 // Synchronously sleeps the calling thread for the given number of milliseconds.
 // Note: Calling this on the main browser thread is _very_ _very_ bad for application logic throttling,

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -219,9 +219,6 @@ static void _do_call(em_queued_call* q) {
         pthread_create(q->args[0].vp, q->args[1].vp, q->args[2].vp, q->args[3].vp);
 #endif
       break;
-    case EM_PROXIED_SYSCALL:
-      q->returnValue.i = emscripten_syscall(q->args[0].i, q->args[1].vp);
-      break;
     case EM_PROXIED_CREATE_CONTEXT:
       q->returnValue.i = emscripten_webgl_create_context(q->args[0].cp, q->args[1].vp);
       break;


### PR DESCRIPTION
As far as I can tell syscalls currently get proxied just like any other
JS function.  I couldn't see this functionality used anywhere in the
codebase.  I'm in the process of updating the syscalls that is not
compatible with this mechanism in that it removes the first argument
(which was redundant) and also no longer uses varargs.

See #10474