### PR TITLE
Prevent superfluous try{}catches when SYSCALLS_REQUIRE_FILESYSTEM=0

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1713,6 +1713,9 @@ for (var x in SyscallsLibrary) {
   var canThrow = SyscallsLibrary[x + '__nothrow'] !== true;
   delete SyscallsLibrary[x + '__nothrow'];
   var handler = '';
+#if SYSCALLS_REQUIRE_FILESYSTEM == 0
+  canThrow = false;
+#endif
   if (canThrow) {
     pre += 'try {\n';
     handler +=

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4260,7 +4260,7 @@ window.close = function() {
     size = os.path.getsize('test.js')
     print('size:', size)
     # Note that this size includes test harness additions (for reporting the result, etc.).
-    self.assertLess(abs(size - 5661), 100)
+    self.assertLess(abs(size - 5600), 100)
 
   # Tests that it is possible to initialize and render WebGL content in a pthread by using OffscreenCanvas.
   # -DTEST_CHAINED_WEBGL_CONTEXT_PASSING: Tests that it is possible to transfer WebGL canvas in a chain from main thread -> thread 1 -> thread 2 and then init and render WebGL content there.


### PR DESCRIPTION
In such configuration, there is no point on embedding functions in a try/catch because we would never be able to check whether the exceptions are an instance of `FS.ErrnoError`, which will yield to invoke `abort()` that just does throws the caught exception.

Hence, i think we can get rid of such try{}catches and let the engine just throw the exceptions on his own without having to catch anything ourselves, that will make code faster and smaller.
