### PR TITLE
Improve output of file comparison tests failures

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -805,20 +805,27 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
 
   # Tests that the given two multiline text content are identical, modulo line
   # ending differences (\r\n on Windows, \n on Unix).
-  def assertTextDataIdentical(self, text1, text2, msg=None):
+  def assertTextDataIdentical(self, text1, text2, msg=None,
+                              fromfile='expected', tofile='actual'):
     text1 = text1.replace('\r\n', '\n')
     text2 = text2.replace('\r\n', '\n')
-    return self.assertIdentical(text1, text2, msg)
+    return self.assertIdentical(text1, text2, msg, fromfile, tofile)
 
-  def assertIdentical(self, values, y, msg=None):
-    if type(values) not in [list, tuple]:
+  def assertIdentical(self, values, y, msg=None,
+                      fromfile='expected', tofile='actual'):
+    if type(values) not in (list, tuple):
       values = [values]
     for x in values:
       if x == y:
         return # success
-    diff_lines = difflib.unified_diff(x.split('\n'), y.split('\n'), fromfile='expected', tofile='actual')
+    diff_lines = difflib.unified_diff(x.split('\n'), y.split('\n'),
+                                      fromfile=fromfile, tofile=tofile)
     diff = ''.join([a.rstrip() + '\n' for a in diff_lines])
-    fail_message = "Expected to have '%s' == '%s', diff:\n\n%s" % (limit_size(values[0]), limit_size(y), limit_size(diff))
+    if EMTEST_VERBOSE:
+      print("Expected to have '%s' == '%s'" % limit_size(values[0]), limit_size(y))
+    fail_message = 'Unexpected difference:\n' + limit_size(diff)
+    if not EMTEST_VERBOSE:
+      fail_message += '\nFor full output run with EMTEST_VERBOSE=1.'
     if msg:
       fail_message += '\n' + msg
     self.fail(fail_message)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8094,9 +8094,9 @@ int main() {
       self.fail('Test expectation file not found: ' + filename + '.\n' +
                 'Run with EMTEST_REBASELINE to generate.')
     expected_content = open(filename).read()
-    message = ("Content mismach in: %s\n" % filename +
-               "Run with EMTEST_REBASELINE=1 to automatically update expectations")
-    self.assertTextDataIdentical(expected_content, contents, message)
+    message = "Run with EMTEST_REBASELINE=1 to automatically update expectations"
+    self.assertTextDataIdentical(expected_content, contents, message,
+                                 filename, filename + '.new')
 
   def run_metadce_test(self, filename, args, expected_sent, expected_exists,
                        expected_not_exists, expected_size, check_imports=True,


### PR DESCRIPTION
Showing the diff by default, but not the full content makes the
output more readable in most cases.  Also reporting the actual
filenames in question as part of the diff helps with clarity.