### PR TITLE
Always use `.a` archive with wasm backend

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -16,11 +16,11 @@ import subprocess
 import sys
 
 from tools import shared
-from tools.system_libs import Library
+from tools import system_libs
 
 C_BARE = 'int main() {}'
 
-SYSTEM_LIBRARIES = Library.get_all_variations()
+SYSTEM_LIBRARIES = system_libs.Library.get_all_variations()
 SYSTEM_TASKS = list(SYSTEM_LIBRARIES.keys())
 
 # This is needed to build the generated_struct_info.json file.
@@ -152,7 +152,7 @@ def main():
     force = True
 
   # process tasks
-  libname = shared.static_library_name
+  libname = system_libs.Ports.get_lib_name
 
   auto_tasks = False
   tasks = args.targets

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1325,13 +1325,6 @@ def print_compiler_stage(cmd):
     sys.stderr.flush()
 
 
-def static_library_name(name):
-  if Settings.WASM_BACKEND and Settings.WASM_OBJECT_FILES:
-    return name + '.a'
-  else:
-    return name + '.bc'
-
-
 def mangle_c_symbol_name(name):
   return '_' + name if not name.startswith('$') else name[1:]
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -90,6 +90,10 @@ def run_commands(commands):
     pool.map_async(run_build_command, commands, chunksize=1).get(999999)
 
 
+def static_library_ext():
+  return '.a' if shared.Settings.WASM_BACKEND else '.bc'
+
+
 def create_lib(libname, inputs):
   """Create a library from a set of input objects."""
   suffix = os.path.splitext(libname)[1]
@@ -414,7 +418,7 @@ class Library(object):
     """
     Return the appropriate file extension for this library.
     """
-    return '.a' if shared.Settings.WASM_BACKEND else '.bc'
+    return static_library_ext()
 
   def get_filename(self):
     """
@@ -1487,7 +1491,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 
   if shared.Settings.USE_ASAN:
     force_include.add('libasan_rt_wasm')
-    add_library(system_libs_map['libasan_rt_wasm'])
+    dd_library(system_libs_map['libasan_rt_wasm'])
 
   if shared.Settings.STANDALONE_WASM:
     add_library(system_libs_map['libstandalonewasm'])
@@ -1530,7 +1534,7 @@ class Ports(object):
 
   @staticmethod
   def get_lib_name(name):
-    return shared.static_library_name(name)
+    return name + static_library_ext()
 
   @staticmethod
   def get_include_dir():

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1491,7 +1491,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
 
   if shared.Settings.USE_ASAN:
     force_include.add('libasan_rt_wasm')
-    dd_library(system_libs_map['libasan_rt_wasm'])
+    add_library(system_libs_map['libasan_rt_wasm'])
 
   if shared.Settings.STANDALONE_WASM:
     add_library(system_libs_map['libstandalonewasm'])


### PR DESCRIPTION
Even when building bitcode object files we should always prefer
ar archives.   There is no good reason to create `.bc` files (which
are basically fat object files).

With fastcomp `.bc` can be preferable since the linker doesn't grok
ar archives and has to extract then before linking.  But this doesn't
apply to the wasm backend.

Also, move this logic to single location in system_libs.py