### PR TITLE
Remove WASM_OBJECT_FILES settings.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ Current Trunk
 - Removed src/library_vr.js, as it was outdated and nonfunctional, and the WebVR
   specification has been obsoleted in favor of the upcoming WebXR specification.
   (#10460)
+- Remove WASM_OBJECT_FILES settting.  There are many standard ways to enable
+  bitcode abjects (-flto, -flto=full, -flto=thin, -emit-llvm).
 
 v1.39.8: 02/14/2020
 -------------------

--- a/emcc.py
+++ b/emcc.py
@@ -2078,6 +2078,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if shared.Settings.LTO:
             cmd.append('-flto=' + shared.Settings.LTO)
           else:
+            # With fastcomp (or with LTO mode) these args get passed instead
+            # at link time when the backend runs.
             for a in shared.Building.llvm_backend_args():
               cmd += ['-mllvm', a]
         else:

--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -547,9 +547,8 @@ Options that are modified or new in *emcc* are listed below:
 
       * <name> **.bc** : LLVM bitcode.
 
-      * <name> **.o** : LLVM bitcode (same as .bc), unless in
-        *WASM_OBJECT_FILES* mode, in which case it will contain a
-        WebAssembly object.
+      * <name> **.o** : WebAssembly object file (unless fastcomp or -flto is
+        used in which case it will be in LLVM bitcode format).
 
       * <name> **.wasm** : WebAssembly without JavaScript support
         code ("standalone wasm"; this enables "STANDALONE_WASM").

--- a/site/source/docs/compiling/WebAssembly.rst
+++ b/site/source/docs/compiling/WebAssembly.rst
@@ -59,11 +59,11 @@ upgrade from fastcomp to upstream:
     codegen. The simple and safe thing is to pass all ``-s`` flags at both
     compile and link time.
 
-  * You can disable wasm object files with ``-s WASM_OBJECT_FILES=0``, which
-    will make the wasm backend behave more like fastcomp. Neither
-    fastcomp nor the wasm backend without wasm object files will run the
-    LLVM optimization passes by default, even if using LLVM IR in object files;
-    for that you must pass ``--llvm-lto 1``.
+  * You can enable LTO object files with the usual llvm compiler flags (-flto,
+    -flto=full, -flto=thin, -emit-llvm).  These flags will make the wasm backend
+    behave more like fastcomp. Neither fastcomp nor the wasm backend without
+    wasm object files will run the LLVM optimization passes by default, even if
+    using LLVM IR in object files; for that you must pass ``--llvm-lto 1``.
 
   * Another thing you might notice is that fastcomp's link stage is able to
     perform some types of link time optimization by default that the LLVM

--- a/site/source/docs/optimizing/Optimizing-Code.rst
+++ b/site/source/docs/optimizing/Optimizing-Code.rst
@@ -97,9 +97,8 @@ Link Time Optimization (LTO) lets the compiler do more optimizations, as it can 
 Separately from that flag, the linker must also receive LLVM bitcode files in order to run LTO on them. With fastcomp that is always the case; with the LLVM wasm backend, object files main contain either wasm or bitcode. The linker can handle a mix of the two, but can only do LTO on the bitcode files. You can control that with the following flags:
 
 - The ``-flto`` flag tells the compiler to emit bitcode in object files, but does *not* affect system libraries.
-- The ``-s WASM_OBJECT_FILES=0`` flag also tells the compiler to emit bitcode in object files (like ``-flto``), and also to emit bitcode in system libraries.
 
-Thus, to allow maximal LTO opportunities with the LLVM wasm backend, build all source files with ``-s WASM_OBJECT_FILES=0`` and link with ``-s WASM_OBJECT_FILES=0 --llvm-lto 1``.
+Thus, to allow maximal LTO opportunities with the LLVM wasm backend, build all source files with ``-flto`` and link with ``-flto --llvm-lto 1``.
 
 Note that older versions of LLVM had bugs in this area. With the older fastcomp backend LTO should be used carefully.
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -425,7 +425,7 @@ Options that are modified or new in *emcc* are listed below:
     - <name> **.mjs** : ES6 JavaScript module (+ separate **<name>.wasm** file if emitting WebAssembly).
     - <name> **.html** : HTML + separate JavaScript file (**<name>.js**; + separate **<name>.wasm** file if emitting WebAssembly).
     - <name> **.bc** : LLVM bitcode.
-    - <name> **.o** : LLVM bitcode (same as .bc), unless in `WASM_OBJECT_FILES` mode, in which case it will contain a WebAssembly object.
+    - <name> **.o** : WebAssembly object file (unless fastcomp or -flto is used in which case it will be in LLVM bitcode format).
     - <name> **.wasm** : WebAssembly without JavaScript support code ("standalone wasm"; this enables ``STANDALONE_WASM``).
 
   .. note:: If ``--memory-init-file`` is used, a **.mem** file will be created in addition to the generated **.js** and/or **.html** file.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1217,13 +1217,6 @@ var STANDALONE_WASM = 0;
 // environment.
 var WASM_BACKEND = 0;
 
-// Whether to compile object files as wasm as opposed to the default
-// of using LLVM IR.
-// Setting to zero will enable LTO and at link time will also enable bitcode
-// versions of the standard libraries.
-// [compile+link]
-var WASM_OBJECT_FILES = 1;
-
 // An optional comma-separated list of script hooks to run after binaryen,
 // in binaryen's /scripts dir.
 var BINARYEN_SCRIPTS = "";
@@ -1791,5 +1784,6 @@ var LEGACY_SETTINGS = [
   ['EMITTING_JS', [1], 'The new STANDALONE_WASM flag replaces this (replace EMITTING_JS=0 with STANDALONE_WASM=1)'],
   ['SKIP_STACK_IN_SMALL', [0, 1], 'SKIP_STACK_IN_SMALL is no longer needed as the backend can optimize it directly'],
   ['SAFE_STACK', [0], 'Replace SAFE_STACK=1 with STACK_OVERFLOW_CHECK=2'],
-  ['MEMORY_GROWTH_STEP', 'MEMORY_GROWTH_LINEAR_STEP']
+  ['MEMORY_GROWTH_STEP', 'MEMORY_GROWTH_LINEAR_STEP'],
+  ['WASM_OBJECT_FILES', [1], 'Use -flto or -fto=thin instead'],
 ];

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -170,3 +170,6 @@ var TARGET_NOT_SUPPORTED = 0x7FFFFFFF;
 // the following functions. (it also does not mangle any function that starts with
 // string "dynCall_")
 var WASM_FUNCTIONS_THAT_ARE_NOT_NAME_MANGLED = ['setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore', '__growWasmMemory', '__heap_base', '__data_end'];
+
+// Internal: value of -flto argument (either full or thin)
+var LTO = 0;

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
@@ -1,4 +1,4 @@
 $_start
-$dlmalloc
 $main
+$malloc
 $sbrk

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6502,7 +6502,7 @@ return malloc(size);
     run_all('lto')
 
   def test_autodebug_bitcode(self):
-    if self.is_wasm_backend() and self.get_setting('WASM_OBJECT_FILES') == 1:
+    if self.is_wasm_backend() and '-flto' not in self.get_emcc_args():
       return self.skipTest('must use bitcode object files for bitcode autodebug')
 
     self.emcc_args += ['--llvm-opts', '0']
@@ -8875,12 +8875,12 @@ wasm3 = make_run('wasm3', emcc_args=['-O3'])
 wasms = make_run('wasms', emcc_args=['-Os'])
 wasmz = make_run('wasmz', emcc_args=['-Oz'])
 
-wasmlto0 = make_run('wasmlto0', emcc_args=['-O0', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
-wasmlto1 = make_run('wasmlto1', emcc_args=['-O1', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
-wasmlto2 = make_run('wasmlto2', emcc_args=['-O2', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
-wasmlto3 = make_run('wasmlto3', emcc_args=['-O3', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
-wasmltos = make_run('wasmltos', emcc_args=['-Os', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
-wasmltoz = make_run('wasmltoz', emcc_args=['-Oz', '--llvm-lto', '1'], settings={'WASM_OBJECT_FILES': 0})
+wasmlto0 = make_run('wasmlto0', emcc_args=['-flto', '-O0', '--llvm-lto', '1'])
+wasmlto1 = make_run('wasmlto1', emcc_args=['-flto', '-O1', '--llvm-lto', '1'])
+wasmlto2 = make_run('wasmlto2', emcc_args=['-flto', '-O2', '--llvm-lto', '1'])
+wasmlto3 = make_run('wasmlto3', emcc_args=['-flto', '-O3', '--llvm-lto', '1'])
+wasmltos = make_run('wasmltos', emcc_args=['-flto', '-Os', '--llvm-lto', '1'])
+wasmltoz = make_run('wasmltoz', emcc_args=['-flto', '-Oz', '--llvm-lto', '1'])
 
 if shared.Settings.WASM_BACKEND:
   wasm2js0 = make_run('wasm2js0', emcc_args=['-O0'], settings={'WASM': 0})

--- a/tools/autodebugger.py
+++ b/tools/autodebugger.py
@@ -120,6 +120,15 @@ f = open(filename, 'r')
 data = f.read()
 f.close()
 
+summaries = re.search(r'\^0 = module:', data)
+if summaries:
+  summaries_start = summaries.start()
+  # Strip ThinLTO summaries since we don't want to have to generate
+  # summaries for the functions we are adding.  Currently llvm-as will
+  # assert if it finds summaries for some, but not all, functions.
+  print("warning: stripping ThinLTO summaries", file=sys.stderr)
+  data = data[:summaries_start]
+
 if not re.search(r'(declare.*@printf\(|define.*@printf\()', data):
   POSTAMBLE += '''
 ; [#uses=1]

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -45,10 +45,8 @@ class Cache(object):
     if use_subdir:
       if shared.Settings.WASM_BACKEND:
         subdir = 'wasm'
-        if shared.Settings.WASM_OBJECT_FILES:
-          subdir += '-obj'
-        else:
-          subdir += '-bc'
+        if shared.Settings.LTO:
+          subdir += '-lto'
         if shared.Settings.RELOCATABLE:
           subdir += '-pic'
       else:

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -403,8 +403,8 @@ def inspect_code(headers, cpp_opts, structs, defines):
   cmd = [shared.PYTHON, shared.EMCC] + cpp_opts + ['-o', js_file[1], src_file[1], '-s', 'BOOTSTRAPPING_STRUCT_INFO=1', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0', '-O0', '--js-opts', '0', '--memory-init-file', '0', '-s', 'SINGLE_FILE=1', '-Wno-format']
   if not shared.Settings.WASM_BACKEND:
     cmd += ['-s', 'WASM=0']
-  if not shared.Settings.WASM_OBJECT_FILES:
-    cmd += ['-s', 'WASM_OBJECT_FILES=0']
+  if shared.Settings.LTO:
+    cmd += ['-flto=' + shared.Settings.LTO]
 
   show(cmd)
   try:

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -126,8 +126,6 @@ def get(ports, settings, shared):
                  '-Wno-unused-parameter']
       if settings.USE_PTHREADS:
         command += ['-pthread']
-      if settings.WASM_OBJECT_FILES != 1:
-        command += ['-flto']
       commands.append(command)
 
       o_s.append(o)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1748,7 +1748,7 @@ class Building(object):
     # other otherwise for linking of bitcode we must use our python
     # code (necessary for asm.js, for wasm bitcode see
     # https://bugs.llvm.org/show_bug.cgi?id=40654)
-    if Settings.WASM_BACKEND and Settings.WASM_OBJECT_FILES:
+    if Settings.WASM_BACKEND and not Settings.LTO:
       Building.link_lld(linker_inputs, target, ['--relocatable'])
     else:
       Building.link(linker_inputs, target)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -59,10 +59,8 @@ def dir_is_newer(dir_a, dir_b):
 def get_cflags(force_object_files=False):
   flags = []
   if shared.Settings.WASM_BACKEND:
-    if force_object_files:
-      flags += ['-s', 'WASM_OBJECT_FILES=1']
-    elif not shared.Settings.WASM_OBJECT_FILES:
-      flags += ['-s', 'WASM_OBJECT_FILES=0']
+    if shared.Settings.LTO and not force_object_files:
+      flags += ['-flto=' + shared.Settings.LTO]
   if shared.Settings.RELOCATABLE:
     flags += ['-s', 'RELOCATABLE']
   return flags
@@ -262,7 +260,7 @@ class Library(object):
   src_glob = None
   src_glob_exclude = None
 
-  # Whether to always generate WASM object files, even though WASM_OBJECT_FILES=0.
+  # Whether to always generate WASM object files, even when LTO is set
   force_object_files = False
 
   def __init__(self):


### PR DESCRIPTION
The standard clang option of `flto, -flto=full, -flto=thin, -emit-llvm`
should be used to enable LTO (bitcode object files).