### PR TITLE
Avoid emitting an empty setupEnums() function.

### DIFF
--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -774,7 +774,8 @@ for name, enum in enums.items():
       raise Exception("Illegal enum value %s" % value)
 
 mid_c += ['\n}\n\n']
-mid_js += ['''
+if len(deferred_js):
+  mid_js += ['''
 (function() {
   function setupEnums() {
     %s


### PR DESCRIPTION
This is basically meant to prevent an exception accessing `runtimeInitialized` under a `MINIMAL_RUNTIME` build, so ideally the IDL-generated code must be adapted for that runtime, but meanwhile this patch does suffices my use-case/need...
