### PR TITLE
Avoid adding cflags twice when building system libraries.

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -68,8 +68,8 @@ def get_cflags(force_object_files=False):
   return flags
 
 
-def _run_one_command(cmd):
-  # Helper function used by run_build_commands
+def run_one_command(cmd):
+  # Helper function used by run_build_commands.
   if shared.EM_BUILD_VERBOSE:
     print(' '.join(cmd))
   shared.run_process(cmd, stdout=stdout, stderr=stderr)
@@ -79,14 +79,14 @@ def run_build_commands(commands):
   cores = min(len(commands), shared.Building.get_num_cores())
   if cores <= 1:
     for command in commands:
-      _run_one_command(command)
+      run_one_command(command)
   else:
     pool = shared.Building.get_multiprocessing_pool()
     # https://stackoverflow.com/questions/1408356/keyboard-interrupts-with-pythons-multiprocessing-pool
     # https://bugs.python.org/issue8296
     # 999999 seconds (about 11 days) is reasonably huge to not trigger actual timeout
     # and is smaller than the maximum timeout value 4294967.0 for Python 3 on Windows (threading.TIMEOUT_MAX)
-    pool.map_async(_run_one_command, commands, chunksize=1).get(999999)
+    pool.map_async(run_one_command, commands, chunksize=1).get(999999)
 
 
 def static_library_ext():
@@ -1590,6 +1590,8 @@ class Ports(object):
 
   @staticmethod
   def run_commands(commands):
+    # Runs a sequence of compiler commands, adding importand cflags as defined by get_cflags() so
+    # that the ports are built in the correct configuration.
     def add_args(cmd):
       # this must only be called on a standard build command
       assert cmd[0] == shared.PYTHON and cmd[1] in (shared.EMCC, shared.EMXX)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -69,10 +69,8 @@ def get_cflags(force_object_files=False):
 
 
 def run_build_command(cmd):
-  # this must only be called on a standard build command
-  assert cmd[0] == shared.PYTHON and cmd[1] in (shared.EMCC, shared.EMXX)
-  # add standard cflags, but also allow the cmd to override them
-  cmd = cmd[:2] + get_cflags() + cmd[2:]
+  if shared.EM_BUILD_VERBOSE:
+    print(' '.join(cmd))
   shared.run_process(cmd, stdout=stdout, stderr=stderr)
 
 
@@ -1585,13 +1583,18 @@ class Ports(object):
       commands.append([shared.PYTHON, shared.EMCC, '-c', src, '-O2', '-o', obj, '-w'] + include_commands + flags)
       objects.append(obj)
 
-    run_commands(commands)
+    Ports.run_commands(commands)
     create_lib(output_path, objects)
     return output_path
 
   @staticmethod
-  def run_commands(commands): # make easily available for port objects
-    run_commands(commands)
+  def run_commands(commands):
+    def add_args(cmd):
+      # this must only be called on a standard build command
+      assert cmd[0] == shared.PYTHON and cmd[1] in (shared.EMCC, shared.EMXX)
+      # add standard cflags, but also allow the cmd to override them
+      return cmd[:2] + get_cflags() + cmd[2:]
+    run_commands([add_args(c) for c in commands])
 
   @staticmethod
   def create_lib(libname, inputs): # make easily available for port objects


### PR DESCRIPTION
The run_build_process routing was added flags which, in the ase
of system libraries were already addeded in Library:build_objects.

For ports we now add the cflags in Ports:run_commands instead.

Also, add logging of each command run when EM_BUILD_VERBOSE is set.