### PR TITLE
emcc.py: add '.ao' to OBJECT_FILE_ENDINGS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -68,7 +68,7 @@ SOURCE_ENDINGS = C_ENDINGS + CXX_ENDINGS + OBJC_ENDINGS + OBJCXX_ENDINGS + SPECI
 C_ENDINGS = C_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES # consider the special endingless filenames like /dev/null to be C
 
 JS_CONTAINING_ENDINGS = ('.js', '.mjs', '.html')
-OBJECT_FILE_ENDINGS = ('.bc', '.o', '.obj', '.lo')
+OBJECT_FILE_ENDINGS = ('.bc', '.o', '.obj', '.lo', '.ao')
 DYNAMICLIB_ENDINGS = ('.dylib', '.so') # Windows .dll suffix is not included in this list, since those are never linked to directly on the command line.
 STATICLIB_ENDINGS = ('.a',)
 ASSEMBLY_ENDINGS = ('.ll',)


### PR DESCRIPTION
Some projects such as icu seem to produce .ao object files instead of .o object files when doing static compilation.
Maybe doing a mime check on the file would be more robust, albeit maybe slower.