### PR TITLE
Add MINIMAL target to embuilder for using in CI. NFC.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,9 +68,10 @@ commands:
             $PYTHON_BIN ./embuilder.py build ALL
             $PYTHON_BIN tests/runner.py test_hello_world
       - run:
+
           name: embuilder (LTO)
           command: |
-            $PYTHON_BIN ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libdlmalloc-debug libemmalloc libemmalloc-64bit libpthread_stub libc_rt_wasm struct_info libc-wasm --lto
+            $PYTHON_BIN ./embuilder.py build MINIMAL --lto
             $PYTHON_BIN tests/runner.py test_hello_world
       - run:
           name: embuilder (PIC)
@@ -80,7 +81,7 @@ commands:
       - run:
           name: embuilder (PIC+LTO)
           command: |
-            $PYTHON_BIN ./embuilder.py build libcompiler_rt libc libc++abi libc++abi-noexcept libc++ libc++-noexcept libal libdlmalloc libdlmalloc-debug libemmalloc libemmalloc-64bit libpthread_stub libc_rt_wasm struct_info libc-wasm --pic --lto
+            $PYTHON_BIN ./embuilder.py build MINIMAL --pic --lto
             $PYTHON_BIN tests/runner.py test_hello_world
       - run:
           name: freeze cache

--- a/embuilder.py
+++ b/embuilder.py
@@ -27,6 +27,25 @@ SYSTEM_TASKS = list(SYSTEM_LIBRARIES.keys())
 # It is not a system library, but it needs to be built before running with FROZEN_CACHE.
 SYSTEM_TASKS += ['struct_info']
 
+# Minimal subset of SYSTEM_TASKS used by CI systems to build enough to useful
+MINIMAL_TASKS = [
+    'libcompiler_rt',
+    'libc',
+    'libc++abi',
+    'libc++abi-noexcept',
+    'libc++',
+    'libc++-noexcept',
+    'libal',
+    'libdlmalloc',
+    'libdlmalloc-debug',
+    'libemmalloc',
+    'libemmalloc-64bit',
+    'libpthread_stub',
+    'libc_rt_wasm',
+    'struct_info',
+    'libc-wasm'
+]
+
 USER_TASKS = [
     'binaryen',
     'boost_headers',
@@ -161,6 +180,9 @@ def main():
     auto_tasks = True
   elif 'USER' in tasks:
     tasks = USER_TASKS
+    auto_tasks = True
+  elif 'MINIMAL' in tasks:
+    tasks = MINIMAL_TASKS
     auto_tasks = True
   elif 'ALL' in tasks:
     tasks = SYSTEM_TASKS + USER_TASKS


### PR DESCRIPTION
I noticed as part of #10490 that this list was missing a couple of
items but I would be a lot nicer to maintain in central location.

This change doesn't add anything, just centralizes the list.