### PR TITLE
Add missing removeEventListener extern.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -456,3 +456,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * sssooonnnggg <sssooonnnggg111@gmail.com>
 * Guillaume Racicot <gufideg@gmail.com>
 * SK Min <oranke@gmail.com>
+* Fabio Alessandrelli <fabio.alessandrelli@gmail.com>

--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -933,6 +933,12 @@ var onmessageerror = function() {};
 var addEventListener = function (type, listener, optionsOrUseCapture) {};
 
 /**
+ * @param {string} type
+ * @param {!Function} listener
+ */
+var removeEventListener = function (type, listener) {};
+
+/**
  * @type {Function}
  */
 var close;


### PR DESCRIPTION
Used in `src/library_html5.js` by `emscripten_exit_soft_fullscreen`:

See this test file compiled with: `EMCC_DEBUG=1 emcc main.cpp --closure 1`:
```cpp
#include <stdio.h>
#include <emscripten.h>
#include <emscripten/html5.h>

extern "C" {
    EM_BOOL canvasresized_callback(int eventType, const void *reserved, void *userData) {
                return true;
    }
}

int main(int argc, char **argv) {
  EmscriptenFullscreenStrategy strategy;
  strategy.scaleMode = EMSCRIPTEN_FULLSCREEN_SCALE_STRETCH;
  strategy.canvasResolutionScaleMode = EMSCRIPTEN_FULLSCREEN_CANVAS_SCALE_STDDEF;
  strategy.filteringMode = EMSCRIPTEN_FULLSCREEN_FILTERING_DEFAULT;
  strategy.canvasResizedCallback = canvasresized_callback;
  emscripten_enter_soft_fullscreen("canvas", &strategy);
  emscripten_exit_soft_fullscreen();
  return 0;
}
```

Was giving (now fixed):
```
shared:ERROR: Closure compiler run failed:

shared:ERROR: /tmp/emscripten_temp/a.out.wasm.o.js:307: WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration: stackSave
stackSave = stackRestore = stackAlloc = function() {
^^^^^^^^^

/tmp/emscripten_temp/a.out.wasm.o.js:307: WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration: stackRestore
stackSave = stackRestore = stackAlloc = function() {
            ^^^^^^^^^^^^

/tmp/emscripten_temp/a.out.wasm.o.js:307: WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration: stackAlloc
stackSave = stackRestore = stackAlloc = function() {
                           ^^^^^^^^^^

/tmp/emscripten_temp/a.out.wasm.o.js:2252: ERROR - [JSC_UNDEFINED_VARIABLE] variable removeEventListener is undeclared
        removeEventListener('resize', __softFullscreenResizeWebGLRenderTarget);
        ^^^^^^^^^^^^^^^^^^^

1 error(s), 3 warning(s)

shared:ERROR: closure compiler failed (rc: 1.)

```

----

Additionally, I noticed that if setting ` strategy.canvasResizedCallback = NULL;` instead, another error pops out due to missing dynamic bind, which is unneeded but the cc does not seem to like it anyway (not sure how to fix that, should I open an issue?):

```
shared:ERROR: Closure compiler run failed:

shared:ERROR: /tmp/emscripten_temp/a.out.wasm.o.js:307: WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration: stackSave
stackSave = stackRestore = stackAlloc = function() {
^^^^^^^^^

/tmp/emscripten_temp/a.out.wasm.o.js:307: WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration: stackRestore
stackSave = stackRestore = stackAlloc = function() {
            ^^^^^^^^^^^^

/tmp/emscripten_temp/a.out.wasm.o.js:307: WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration: stackAlloc
stackSave = stackRestore = stackAlloc = function() {
                           ^^^^^^^^^^

/tmp/emscripten_temp/a.out.wasm.o.js:2097: ERROR - [JSC_UNDEFINED_VARIABLE] variable dynCall_iiii is undeclared
            dynCall_iiii(__currentFullscreenStrategy.canvasResizedCallback, 37, 0, __currentFullscreenStrategy.canvasResizedCallbackUserData);
            ^^^^^^^^^^^^

1 error(s), 3 warning(s)

shared:ERROR: closure compiler failed (rc: 1.)
```