### PR TITLE
WIP: Make format argument required for emscripten_log

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Require format string for emscripten_log.
 - Program entry points without extensions are now shell scripts rather than
   python programs. See #10729.  This means that `python emcc` no longer works.
   However `emcc`, `emcc.py` and `python emcc.py` all continue to work.

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1050,12 +1050,13 @@ Functions
   This is inline in the code, which tells the JavaScript engine to invoke the debugger if it gets there.
 
 
-.. c:function:: void emscripten_log(int flags, ...)
+.. c:function:: void emscripten_log(int flags, const char* format, ...)
 
   Prints out a message to the console, optionally with the callstack information.
 
   :param int flags: A binary OR of items from the list of :c:data:`EM_LOG_xxx <EM_LOG_CONSOLE>` flags that specify printing options.
-  :param ...: A ``printf``-style "format, ..." parameter list that is parsed according to the ``printf`` formatting rules.
+  :param const char* format: A ``printf``-style format string.
+  :param ...: A ``printf``-style "..." parameter list that is parsed according to the ``printf`` formatting rules.
 
 
 .. c:function:: int emscripten_get_callstack(int flags, char *out, int maxbytes)

--- a/src/library.js
+++ b/src/library.js
@@ -4342,16 +4342,11 @@ LibraryManager.library = {
   },
 
   emscripten_log__deps: ['_formatString', 'emscripten_log_js'],
-  emscripten_log: function(flags, varargs) {
-    // Extract the (optionally-existing) printf format specifier field from varargs.
-    var format = {{{ makeGetValue('varargs', '0', 'i32', undefined, undefined, true) }}};
-    varargs += {{{ Math.max(Runtime.getNativeFieldSize('i32'), Runtime.getAlignSize('i32', null, true)) }}};
+  emscripten_log: function(flags, format, varargs) {
     var str = '';
-    if (format) {
-      var result = __formatString(format, varargs);
-      for(var i = 0 ; i < result.length; ++i) {
-        str += String.fromCharCode(result[i]);
-      }
+    var result = __formatString(format, varargs);
+    for (var i = 0 ; i < result.length; ++i) {
+      str += String.fromCharCode(result[i]);
     }
     _emscripten_log_js(flags, str);
   },

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -247,7 +247,7 @@ char *emscripten_get_preloaded_image_data_from_FILE(FILE *file, int *w, int *h);
 #define EM_LOG_DEBUG    256
 #define EM_LOG_INFO     512
 
-void emscripten_log(int flags, ...);
+void emscripten_log(int flags, const char* format, ...);
 
 int emscripten_get_callstack(int flags, char *out, int maxbytes);
 

--- a/tests/emscripten_log/emscripten_log.cpp
+++ b/tests/emscripten_log/emscripten_log.cpp
@@ -13,11 +13,11 @@
 int result = 1; // If 1, this test succeeded.
 
 // A custom assert macro to test varargs routing to emscripten_log().
-#define MYASSERT(condition, ...) \
+#define MYASSERT(condition, msg, ...) \
 	do { \
 		if (!(condition)) { \
 			emscripten_log(EM_LOG_ERROR, "%s", "Condition '" #condition "' failed in file " __FILE__ ":" STRINGIZE(__LINE__) "!"); \
-			emscripten_log(EM_LOG_ERROR, ##__VA_ARGS__); \
+			emscripten_log(EM_LOG_ERROR, msg, ##__VA_ARGS__); \
 			result = 0; \
 		} \
 	} while(0)
@@ -44,10 +44,6 @@ void __attribute__((noinline)) kitten()
 
 	// Log only clean C callstack:
 	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_C_STACK | EM_LOG_DEMANGLE, "This message should have a clean C callstack:");
-
-	// We can leave out the message to just print out the callstack:
-	printf("The following line should show just the callstack without a message:\n");
-	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_ERROR | EM_LOG_C_STACK | EM_LOG_JS_STACK | EM_LOG_DEMANGLE);
 }
 
 void __attribute__((noinline)) bar(int = 0, char * = 0, double = 0) // Arbitrary function signature to add some content to callstack.
@@ -55,7 +51,7 @@ void __attribute__((noinline)) bar(int = 0, char * = 0, double = 0) // Arbitrary
 	if (1 == 2)
 		MYASSERT(2 == 1, "World falls apart!");
 	else
-		MYASSERT(1 == 1);
+		MYASSERT(1 == 1, "");
 
 	int flags = EM_LOG_NO_PATHS | EM_LOG_JS_STACK | EM_LOG_DEMANGLE | EM_LOG_FUNC_PARAMS;
 #ifndef RUN_FROM_JS_SHELL
@@ -108,10 +104,10 @@ void __attribute__((noinline)) bar(int = 0, char * = 0, double = 0) // Arbitrary
 	emscripten_get_callstack(EM_LOG_C_STACK | EM_LOG_DEMANGLE | EM_LOG_NO_PATHS | EM_LOG_FUNC_PARAMS, buffer, 20);
 #if EMTERPRETER
 	MYASSERT(!!strstr(buffer, "at emterpret ("), "Truncated emterpreter callstack was %s!", buffer);
-	MYASSERT(buffer[20] == 0x01);
+	MYASSERT(buffer[20] == 0x01, "");
 #else
 	MYASSERT(!!strstr(buffer, "at bar(int,"), "Truncated callstack was %s!", buffer);
-	MYASSERT(buffer[20] == 0x01);
+	MYASSERT(buffer[20] == 0x01, "");
 #endif
 	delete[] buffer;
 


### PR DESCRIPTION
This follows the convention of other printf-like functions.  I can't
see any reason why would want to support the single argument version
since it does nothing.

I think this should make for smaller JS and native code.