### PR TITLE
More cleanup of metadce tests

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8098,14 +8098,13 @@ int main() {
     self.assertTextDataIdentical(expected_content, contents, message,
                                  filename, filename + '.new')
 
-  def run_metadce_test(self, filename, args, expected_sent, expected_exists,
-                       expected_not_exists, expected_size, check_imports=True,
-                       check_exports=True, check_funcs=True):
+  def run_metadce_test(self, filename, args, expected_exists, expected_not_exists, expected_size,
+                       check_sent=True, check_imports=True, check_exports=True, check_funcs=True):
     size_slack = 0.05
 
     # in -Os, -Oz, we remove imports wasm doesn't need
-    print('Running metadce test: %s:' % filename, args, expected_sent, expected_exists,
-          expected_not_exists, expected_size, check_imports, check_exports, check_funcs)
+    print('Running metadce test: %s:' % filename, args, expected_exists,
+          expected_not_exists, expected_size, check_sent, check_imports, check_exports, check_funcs)
     filename = path_from_root('tests', 'other', 'metadce', filename)
 
     def clean_arg(arg):
@@ -8142,12 +8141,6 @@ int main() {
     sent = [x for x in sent if x]
     sent.sort()
 
-    if expected_sent is not None:
-      sent_file = expected_basename + '.sent'
-      sent_data = '\n'.join(sent) + '\n'
-      self.assertFileContents(sent_file, sent_data)
-      self.assertEqual(len(sent), expected_sent)
-
     for exists in expected_exists:
       self.assertIn(exists, sent)
     for not_exists in expected_not_exists:
@@ -8176,6 +8169,11 @@ int main() {
 
     funcs = [strip_numeric_suffixes(f) for f in funcs]
 
+    if check_sent:
+      sent_file = expected_basename + '.sent'
+      sent_data = '\n'.join(sent) + '\n'
+      self.assertFileContents(sent_file, sent_data)
+
     if check_imports:
       filename = expected_basename + '.imports'
       data = '\n'.join(imports) + '\n'
@@ -8192,48 +8190,47 @@ int main() {
       self.assertFileContents(filename, data)
 
   @parameterized({
-    'O0': ([],       7, [], ['waka'],  9766), # noqa
-    'O1': (['-O1'],  4, [], ['waka'],  7886), # noqa
-    'O2': (['-O2'],  4, [], ['waka'],  7871), # noqa
+    'O0': ([],      [], ['waka'],  9766), # noqa
+    'O1': (['-O1'], [], ['waka'],  7886), # noqa
+    'O2': (['-O2'], [], ['waka'],  7871), # noqa
     # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-    'O3': (['-O3'],  2, [], [],          85), # noqa
-    'Os': (['-Os'],  2, [], [],          85), # noqa
-    'Oz': (['-Oz'],  2, [], [],          85), # noqa
+    'O3': (['-O3'], [], [],          85), # noqa
+    'Os': (['-Os'], [], [],          85), # noqa
+    'Oz': (['-Oz'], [], [],          85), # noqa
   })
   @no_fastcomp()
   def test_metadce_minimal(self, *args):
     self.run_metadce_test('minimal.c', *args)
 
   @parameterized({
-    'O0': ([],      25, ['abort'], ['waka'], 22712), # noqa
-    'O1': (['-O1'], 16, ['abort'], ['waka'], 10450), # noqa
-    'O2': (['-O2'], 16, ['abort'], ['waka'], 10440), # noqa
+    'O0': ([],      ['abort'], ['waka'], 22712), # noqa
+    'O1': (['-O1'], ['abort'], ['waka'], 10450), # noqa
+    'O2': (['-O2'], ['abort'], ['waka'], 10440), # noqa
     # in -O3, -Os and -Oz we metadce, and they shrink it down to the minimal output we want
-    'O3': (['-O3'],  4, [],        [],          55), # noqa
-    'Os': (['-Os'],  4, [],        [],          55), # noqa
-    'Oz': (['-Oz'],  4, [],        [],          55), # noqa
+    'O3': (['-O3'], [],        [],          55), # noqa
+    'Os': (['-Os'], [],        [],          55), # noqa
+    'Oz': (['-Oz'], [],        [],          55), # noqa
   })
   @no_wasm_backend()
   def test_metadce_minimal_fastcomp(self, *args):
     self.run_metadce_test('minimal.c', *args)
 
   @parameterized({
-    'noexcept': (['-O2'],                    19, [], ['waka'], 218988), # noqa
+    'noexcept': (['-O2'],                    [], ['waka'], 218988), # noqa
     # exceptions increases code size significantly
-    'except':   (['-O2', '-fexceptions'],    52, [], ['waka'], 279827), # noqa
+    'except':   (['-O2', '-fexceptions'],    [], ['waka'], 279827), # noqa
     # exceptions does not pull in demangling by default, which increases code size
     'mangle':   (['-O2', '-fexceptions',
-                  '-s', 'DEMANGLE_SUPPORT'], 52, [], ['waka'], 408028), # noqa
+                  '-s', 'DEMANGLE_SUPPORT'], [], ['waka'], 408028), # noqa
   })
   @no_fastcomp()
   def test_metadce_cxx(self, *args):
     self.run_metadce_test('hello_libcxx.cpp', *args)
 
   @parameterized({
-    'normal': (['-O2'], 40, ['abort'], ['waka'], 186423),
+    'normal': (['-O2'], ['abort'], ['waka'], 186423),
     'emulated_function_pointers':
-              (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'],
-               40, ['abort'], ['waka'], 188310),
+              (['-O2', '-s', 'EMULATED_FUNCTION_POINTERS=1'], ['abort'], ['waka'], 188310),
   })
   @no_wasm_backend()
   def test_metadce_cxx_fastcomp(self, *args):
@@ -8241,21 +8238,20 @@ int main() {
     self.run_metadce_test('hello_libcxx.cpp', *args)
 
   @parameterized({
-    'O0': ([],      10, [], ['waka'], 22849,  9,  18, 58), # noqa
-    'O1': (['-O1'],  7, [], ['waka'], 10533,  6,  14, 30), # noqa
-    'O2': (['-O2'],  7, [], ['waka'], 10256,  6,  14, 25), # noqa
-    'O3': (['-O3'],  4, [], [],        1999,  4,   2, 12), # noqa; in -O3, -Os and -Oz we metadce
-    'Os': (['-Os'],  4, [], [],        2010,  4,   2, 13), # noqa
-    'Oz': (['-Oz'],  4, [], [],        2004,  4,   2, 13), # noqa
+    'O0': ([],      [], ['waka'], 22849), # noqa
+    'O1': (['-O1'], [], ['waka'], 10533), # noqa
+    'O2': (['-O2'], [], ['waka'], 10256), # noqa
+    'O3': (['-O3'], [], [],        1999), # noqa; in -O3, -Os and -Oz we metadce
+    'Os': (['-Os'], [], [],        2010), # noqa
+    'Oz': (['-Oz'], [], [],        2004), # noqa
     # finally, check what happens when we export nothing. wasm should be almost empty
     'export_nothing':
-          (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                     2, [], [],          61,  0,   1,  1), # noqa
+          (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],    [], [],     61), # noqa
     # we don't metadce with linkable code! other modules may want stuff
     # don't compare the # of functions in a main module, which changes a lot
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   12, [], [],  10652,   12,   10, None), # noqa
+    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [],  10652, True, True, True, False), # noqa
   })
   @no_fastcomp()
   @unittest.skip("Allow LLVM roll to proceed")
@@ -8263,19 +8259,18 @@ int main() {
     self.run_metadce_test('hello_world.cpp', *args)
 
   @parameterized({
-    'O0': ([],      27, ['abort'], ['waka'], 42701,  18,   16, 55), # noqa
-    'O1': (['-O1'], 19, ['abort'], ['waka'], 13199,   9,   13, 31), # noqa
-    'O2': (['-O2'], 19, ['abort'], ['waka'], 12425,   9,   13, 26), # noqa
-    'O3': (['-O3'],  7, [],        [],        2045,   6,    2, 14), # noqa; in -O3, -Os and -Oz we metadce
-    'Os': (['-Os'],  7, [],        [],        2064,   6,    2, 15), # noqa
-    'Oz': (['-Oz'],  7, [],        [],        2045,   6,    2, 14), # noqa
+    'O0': ([],      ['abort'], ['waka'], 42701), # noqa
+    'O1': (['-O1'], ['abort'], ['waka'], 13199), # noqa
+    'O2': (['-O2'], ['abort'], ['waka'], 12425), # noqa
+    'O3': (['-O3'], [],        [],        2045), # noqa; in -O3, -Os and -Oz we metadce
+    'Os': (['-Os'], [],        [],        2064), # noqa
+    'Oz': (['-Oz'], [],        [],        2045), # noqa
     # finally, check what happens when we export nothing. wasm should be almost empty
     'export_nothing':
-           (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],
-                      4, [],        [],           8,   0,    0,  0), # noqa; totally empty!
+           (['-Os', '-s', 'EXPORTED_FUNCTIONS=[]'],   [], [],     8), # noqa; totally empty!
     # we don't metadce with linkable code! other modules may want stuff
     # don't compare the # of functions in a main module, which changes a lot
-    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'],   13, [], [],  10017,   13,   9,   20), # noqa
+    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [], 10017), # noqa
   })
   @no_wasm_backend()
   def test_metadce_hello_fastcomp(self, *args):
@@ -8283,26 +8278,26 @@ int main() {
 
   @parameterized({
     'O3':                 ('mem.c', ['-O3'],
-                           3, [], [], 6100,  2,  3,  5),         # noqa
+                           [], [], 6100),         # noqa
     # argc/argv support code etc. is in the wasm
     'O3_standalone':      ('mem.c', ['-O3', '-s', 'STANDALONE_WASM'],
-                           3, [], [], 6309,  3,  3,  5),         # noqa
+                           [], [], 6309),         # noqa
     # without argc/argv, no support code for them is emitted
     'O3_standalone_narg': ('mem_no_argv.c', ['-O3', '-s', 'STANDALONE_WASM'],
-                           1, [], [], 6309,  1,  3,  4),         # noqa
+                           [], [], 6309),         # noqa
     # without main, no support code for argc/argv is emitted either
     'O3_standalone_lib':  ('mem_no_main.c', ['-O3', '-s', 'STANDALONE_WASM'],
-                           0, [], [], 6309,  0,  3,  4),         # noqa
+                           [], [], 6309),         # noqa
     # Growth support code is in JS, no significant change in the wasm
     'O3_grow':            ('mem.c', ['-O3', '-s', 'ALLOW_MEMORY_GROWTH'],
-                           3, [], [], 6098,  2,  3,  5),         # noqa
+                           [], [], 6098),         # noqa
     # Growth support code is in the wasm
     'O3_grow_standalone': ('mem.c', ['-O3', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'STANDALONE_WASM'],
-                           4, [], [], 6449,  4,  3,  6),         # noqa
+                           [], [], 6449),         # noqa
     # without argc/argv, no support code for them is emitted, even with lto
     'O3_standalone_narg_flto':
                           ('mem_no_argv.c', ['-O3', '-s', 'STANDALONE_WASM', '-flto'],
-                           1, [], [], 6309,  1,  3,  4),         # noqa
+                           [], [], 6309),         # noqa
   })
   @no_fastcomp()
   def test_metadce_mem(self, filename, *args):


### PR DESCRIPTION
This is a followup on #10416.  I missed a few test cases in that PR.
I also missed that the `.sent` file checking already handled checking
the number that was bring passed in `expected_sent`.