### PR TITLE
Enable compiler-rt and all of libc to be part of LTO

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -49,7 +49,6 @@ MINIMAL_TASKS = [
     'libemmalloc-64bit',
     'libpthread_stub',
     'libsockets',
-    'libc_rt_wasm',
     'struct_info',
     'libc-wasm',
     'libstandalonewasm',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1598,7 +1598,6 @@ int main() {
     self.do_run_in_out_file_test('tests', 'core', 'test_complex')
 
   def test_float_builtins(self):
-    # tests wasm_libc_rt
     if not self.is_wasm_backend():
       self.skipTest('no __builtin_fmin support in JSBackend')
     self.do_run_in_out_file_test('tests', 'core', 'test_float_builtins')


### PR DESCRIPTION
The upstream llvm bug the prevented libcalls to be part of LTO
has now been fixed.