### PR TITLE
Cleanup test_iostream_and_determinism

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5648,11 +5648,11 @@ PORT: 3979
         self.assertBinaryEqual('src.cpp.o.js', 'src.js.previous')
       shutil.copy2('src.cpp.o.js', 'src.js.previous')
 
-      # Same but for the same file.
+      # Same but for the wasm file.
       if self.get_setting('WASM') and not self.get_setting('WASM2JS'):
-        if os.path.exists('src.wsam.previous'):
-          self.assertBinaryEqual('src.cpp.o.wasm', 'src.wsam.previous')
-        shutil.copy2('src.cpp.o.wasm', 'src.wsam.previous')
+        if os.path.exists('src.wasm.previous'):
+          self.assertBinaryEqual('src.cpp.o.wasm', 'src.wasm.previous')
+        shutil.copy2('src.cpp.o.wasm', 'src.wasm.previous')
 
   def test_stdvec(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_stdvec')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5638,12 +5638,17 @@ PORT: 3979
     num = 5
     for i in range(num):
       print('(iteration %d)' % i)
+
       # add some timing nondeterminism here, not that we need it, but whatever
       time.sleep(random.random() / (10 * num))
       self.do_run(src, 'hello world\n77.\n')
+
+      # Verify that this build is identical to the previous one
       if os.path.exists('src.js.previous'):
         self.assertBinaryEqual('src.cpp.o.js', 'src.js.previous')
       shutil.copy2('src.cpp.o.js', 'src.js.previous')
+
+      # Same but for the same file.
       if self.get_setting('WASM') and not self.get_setting('WASM2JS'):
         if os.path.exists('src.wsam.previous'):
           self.assertBinaryEqual('src.cpp.o.wasm', 'src.wsam.previous')


### PR DESCRIPTION
This change makes the test shorter and its output more clear.

The test currently fails of LTO builds and cleaning it up helps with
debugging.