### PR TITLE
Fix minifyGlobals on duplicate definitions

### DIFF
--- a/tests/optimizer/test-js-optimizer-minifyGlobals-output.js
+++ b/tests/optimizer/test-js-optimizer-minifyGlobals-output.js
@@ -1,0 +1,10 @@
+var first;
+for (var a = 25; a >= 0; --a) {
+ foo(a);
+}
+for (var a = 25; a >= 0; --a) {
+ foo(a);
+}
+
+
+// EXTRA_INFO:{"i":"a"}

--- a/tests/optimizer/test-js-optimizer-minifyGlobals.js
+++ b/tests/optimizer/test-js-optimizer-minifyGlobals.js
@@ -1,0 +1,12 @@
+// Ignore the first (used internally).
+var first;
+// A first definition.
+for (var i = 25; i >= 0; --i) {
+  foo(i);
+}
+// Another definition, which we need to minify to the same thing.
+for (var i = 25; i >= 0; --i) {
+  foo(i);
+}
+// EXTRA_INFO: { "globals": [] }
+

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2090,7 +2090,6 @@ int f() {
   def test_js_optimizer(self):
     ACORN_PASSES = ['JSDCE', 'AJSDCE', 'applyImportAndExportNameChanges', 'emitDCEGraph', 'applyDCEGraphRemovals', 'growableHeap']
     for input, expected, passes in [
-
       (path_from_root('tests', 'optimizer', 'eliminateDeadGlobals.js'), open(path_from_root('tests', 'optimizer', 'eliminateDeadGlobals-output.js')).read(),
        ['eliminateDeadGlobals']),
       (path_from_root('tests', 'optimizer', 'test-js-optimizer.js'), open(path_from_root('tests', 'optimizer', 'test-js-optimizer-output.js')).read(),
@@ -2187,6 +2186,8 @@ int f() {
        ['asm']),
       (path_from_root('tests', 'optimizer', 'test-growableHeap.js'), open(path_from_root('tests', 'optimizer', 'test-growableHeap-output.js')).read(),
        ['growableHeap']),
+      (path_from_root('tests', 'optimizer', 'test-js-optimizer-minifyGlobals.js'), open(path_from_root('tests', 'optimizer', 'test-js-optimizer-minifyGlobals-output.js')).read(),
+       ['minifyGlobals']),
     ]:
       print(input, passes)
 

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -4579,6 +4579,10 @@ function eliminateMemSafe(ast) {
 function minifyGlobals(ast) {
   var minified = {};
   var next = 0;
+  function getMinified(name) {
+    if (minified[name]) return minified[name];
+    return minified[name] = minifiedNames[next++];
+  }
   var first = true; // do not minify initial 'var asm ='
   // find the globals
   traverse(ast, function(node, type) {
@@ -4591,19 +4595,19 @@ function minifyGlobals(ast) {
       for (var i = 0; i < vars.length; i++) {
         var name = vars[i][0];
         ensureMinifiedNames(next);
-        vars[i][0] = minified[name] = minifiedNames[next++];
+        vars[i][0] = getMinified(name);
       }
     } else if (type === 'defun') {
       var name = node[1];
       ensureMinifiedNames(next);
-      node[1] = minified[name] = minifiedNames[next++];
+      node[1] = getMinified(name);
     }
   });
   // add all globals in function chunks, i.e. not here but passed to us
   for (var i = 0; i < extraInfo.globals.length; i++) {
     name = extraInfo.globals[i];
     ensureMinifiedNames(next);
-    minified[name] = minifiedNames[next++];
+    minified[name] = getMinified(name);
   }
   // apply minification
   traverse(ast, function(node, type) {


### PR DESCRIPTION
In JS it is valid to write
```
var a;
var a;
```
but that wasn't handled properly in minifyGlobals. This only
became a problem now (years after the pass was written)
because we added a loop in the mem init that uses `i`, and if
there are enough imports one of them might be `i` as well,
leading to incorrect minification and a bugreport from the
mailing list ("js output not running with 1.39.8").