### PR TITLE
fix(mmap): handle over-allocated files

### DIFF
--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -367,7 +367,7 @@ mergeInto(LibraryManager.library, {
           ptr = contents.byteOffset;
         } else {
           // Try to avoid unnecessary slices.
-          if (position > 0 || position + length < stream.node.usedBytes) {
+          if (position > 0 || position + length < contents.length) {
             if (contents.subarray) {
               contents = contents.subarray(position, position + length);
             } else {


### PR DESCRIPTION
fix for not writing buffer contents from expanded files beyond allocated memory
    
fixes #10527