### PR TITLE
Remove duplicate copy of setThrew

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1340,19 +1340,6 @@ LibraryManager.library = {
     STACKTOP = top;
   },
 #endif
-
-#if WASM_BACKEND == 0
-  $setThrew__asm: true,
-  $setThrew__sig: 'vii',
-  $setThrew: function(threw, value) {
-    threw = threw|0;
-    value = value|0;
-    if ((__THREW__|0) == 0) {
-      __THREW__ = threw;
-      threwValue = value;
-    }
-  },
-#endif
 #endif
 
   llvm_flt_rounds: function() {


### PR DESCRIPTION
I believe the one on line 1271 is the one being used.  This copy has
as leading `$` which means fastcomp code won't see it and nor will
the reference on line 2175 of this file with has a leading `_`.