### PR TITLE
COOP, COEP and CORP headers for browser tests harness

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1243,6 +1243,15 @@ def harness_server_func(in_queue, out_queue, port):
       else:
         return SimpleHTTPRequestHandler.send_head(self)
 
+    # Add COOP, COEP and CORP headers
+    def end_headers(self):
+      self.send_header('Access-Control-Allow-Origin', '*')
+      self.send_header('Cross-Origin-Opener-Policy', 'same-origin')
+      self.send_header('Cross-Origin-Embedder-Policy', 'require-corp')
+      self.send_header('Cross-Origin-Resource-Policy', 'cross-origin')
+
+      return SimpleHTTPRequestHandler.end_headers(self)
+
     def do_GET(self):
       if self.path == '/run_harness':
         if DEBUG:


### PR DESCRIPTION
In #10077 COOP, COEP and CORP headers were added to emrun.py to take
account upcomming restrictions on Conent Policy for Firefor 72.

This change adds similar headers to browser tests harness.

Note that it is needed to set following flags for Firefox:
browser.tabs.remote.useCORP
browser.tabs.remote.useCrossOriginOpenerPolicy
browser.tabs.remote.useCrossOriginEmbedderPolicy
dom.postMessage.sharedArrayBuffer.withCOOP_COEP