### PR TITLE
require_sigs_for_aliases

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,8 @@ Current Trunk
 - Removed EmscriptenWebGLContextAttributes::preferLowPowerToHighPerformance
   option that has become unsupported by WebGL. Access
   EmscriptenWebGLContextAttributes::powerPreference instead. (#10505)
+- When implementing forwarding function aliases in JS libraries, either the
+  alias or the target function must contain a signature annotation. (#10550)
 
 v1.39.8: 02/14/2020
 -------------------

--- a/src/library.js
+++ b/src/library.js
@@ -1114,16 +1114,19 @@ LibraryManager.library = {
   // When DECLARE_ASM_MODULE_EXPORTS==0, cannot alias asm.js functions from non-asm.js
   // functions, so use an intermediate function as a pass-through.
   _memcpy_js__deps: ['memcpy'],
+  _memcpy_js__sig: 'iiii',
   _memcpy_js: function(dst, src, num) {
     return _memcpy(dst, src, num);
   },
 
   _memmove_js__deps: ['memmove'],
+  _memmove_js__sig: 'iiii',
   _memmove_js: function(dst, src, num) {
     return _memmove(dst, src, num);
   },
 
   _memset_js__deps: ['memset'],
+  _memset_js__sig: 'iiii',
   _memset_js: function(ptr, value, num) {
     return _memset(ptr, value, num);
   },

--- a/src/library.js
+++ b/src/library.js
@@ -225,7 +225,8 @@ LibraryManager.library = {
   },
 
   execl__deps: ['__setErrNo'],
-  execl: function(/* ... */) {
+  execl__sig: 'iiii',
+  execl: function(path, arg0, varArgs) {
     // int execl(const char *path, const char *arg0, ... /*, (char *)0 */);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/exec.html
     // We don't support executing external code.
@@ -240,6 +241,7 @@ LibraryManager.library = {
   __execvpe: 'execl',
   fexecve: 'execl',
 
+  exit__sig: 'vi',
   exit: function(status) {
 #if MINIMAL_RUNTIME
     throw 'exit(' + status + ')';
@@ -263,6 +265,7 @@ LibraryManager.library = {
 #endif
 
   fork__deps: ['__setErrNo'],
+  fork__sig: 'i',
   fork: function() {
     // pid_t fork(void);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/fork.html
@@ -692,7 +695,7 @@ LibraryManager.library = {
   __cxa_thread_atexit_impl: function(){},
 #else
   atexit__proxy: 'sync',
-  atexit__sig: 'ii',
+  atexit__sig: 'iii',
   atexit: function(func, arg) {
 #if ASSERTIONS
 #if EXIT_RUNTIME == 0
@@ -892,7 +895,8 @@ LibraryManager.library = {
   },
 
   // For compatibility, call to rand() when code requests arc4random(), although this is *not* at all
-  // as strong as rc4 is. See https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man3/arc4random.3.html
+  // as strong as rc4 is. See https://man.openbsd.org/arc4random
+  arc4random__sig: 'i',
   arc4random: 'rand',
 
   // ==========================================================================
@@ -1088,6 +1092,10 @@ LibraryManager.library = {
     return (end-num)|0;
   },
 
+  memcpy__sig: 'iiii',
+  memmove__sig: 'iiii',
+  memset__sig: 'iiii',
+
 #if DECLARE_ASM_MODULE_EXPORTS
   llvm_memcpy_i32: 'memcpy',
   llvm_memcpy_i64: 'memcpy',
@@ -1277,6 +1285,7 @@ LibraryManager.library = {
   },
 #endif
 
+  terminate__sig: 'vi',
   terminate: '__cxa_call_unexpected',
 
   __gxx_personality_v0: function() {
@@ -1635,13 +1644,21 @@ LibraryManager.library = {
   // ==========================================================================
 
 #if MAIN_MODULE == 0
-  dlopen: function(/* ... */) {
+  dlopen: function(filename, flag) {
     abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/emscripten-core/emscripten/wiki/Linking");
   },
-  dlclose: 'dlopen',
-  dlsym:   'dlopen',
-  dlerror: 'dlopen',
-  dladdr:  'dlopen',
+  dlclose: function(handle) {
+    abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/emscripten-core/emscripten/wiki/Linking");
+  },
+  dlsym: function(handle, symbol) {
+    abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/emscripten-core/emscripten/wiki/Linking");
+  },
+  dlerror: function() {
+    abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/emscripten-core/emscripten/wiki/Linking");
+  },
+  dladdr: function(address, info) {
+    abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/emscripten-core/emscripten/wiki/Linking");
+  },
 #else // MAIN_MODULE != 0
 
   $DLFCN: {
@@ -1877,6 +1894,7 @@ LibraryManager.library = {
   // Statically allocated time strings.
   __tm_formatted: '{{{ makeStaticAlloc(C_STRUCTS.tm.__size__) }}}',
   mktime__deps: ['tzset'],
+  mktime__sig: 'ii',
   mktime: function(tmPtr) {
     _tzset();
     var date = new Date({{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900,
@@ -2831,14 +2849,17 @@ LibraryManager.library = {
   // sys/types.h
   // ==========================================================================
   // http://www.kernel.org/doc/man-pages/online/pages/man3/minor.3.html
+  makedev__sig: 'iii',
   makedev: function(maj, min) {
     return ((maj) << 8 | (min));
   },
   gnu_dev_makedev: 'makedev',
+  major__sig: 'ii',
   major: function(dev) {
     return ((dev) >> 8);
   },
   gnu_dev_major: 'major',
+  minor__sig: 'ii',
   minor: function(dev) {
     return ((dev) & 0xff);
   },
@@ -2936,6 +2957,7 @@ LibraryManager.library = {
   // ==========================================================================
 
   wait__deps: ['__setErrNo'],
+  wait__sig: 'ii',
   wait: function(stat_loc) {
     // pid_t wait(int *stat_loc);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/wait.html
@@ -4737,9 +4759,6 @@ LibraryManager.library = {
   __unlock: function() {},
   __lockfile: function() { return 1 },
   __unlockfile: function(){},
-
-  // USE_FULL_LIBRARY hacks
-  realloc: function() { throw 'bad realloc called' },
 
   // libunwind
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -1834,7 +1834,10 @@ var LibrarySDL = {
 
   SDL_SetError: function() {},
 
+  SDL_malloc__sig: 'ii',
   SDL_malloc: 'malloc',
+
+  SDL_free__sig: 'vi',
   SDL_free: 'free',
 
   SDL_CreateRGBSurface__proxy: 'sync',
@@ -3012,7 +3015,9 @@ var LibrarySDL = {
     return SDL.setGetVolume(SDL.music, volume);
   },
 
+  Mix_LoadMUS_RW__docs: '/** @param {number|boolean=} a1 */',
   Mix_LoadMUS_RW: 'Mix_LoadWAV_RW',
+
   Mix_LoadMUS__deps: ['Mix_LoadMUS_RW', 'SDL_RWFromFile', 'SDL_FreeRW'],
   Mix_LoadMUS__proxy: 'sync',
   Mix_LoadMUS__sig: 'ii',

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1472,6 +1472,7 @@ var SyscallsLibrary = {
     {{{ makeSetValue('pnum', 0, 'num', 'i32') }}}
     return 0;
   },
+  fd_close__sig: 'ii',
   fd_close: function(fd) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);
@@ -1491,12 +1492,14 @@ var SyscallsLibrary = {
 #endif
     return 0;
   },
+  fd_read__sig: 'iiiii',
   fd_read: function(fd, iov, iovcnt, pnum) {
     var stream = SYSCALLS.getStreamFromFD(fd);
     var num = SYSCALLS.doReadv(stream, iov, iovcnt);
     {{{ makeSetValue('pnum', 0, 'num', 'i32') }}}
     return 0;
   },
+  fd_seek__sig: 'iiiiii',
   fd_seek: function(fd, offset_low, offset_high, whence, newOffset) {
     var stream = SYSCALLS.getStreamFromFD(fd);
     var HIGH_OFFSET = 0x100000000; // 2^32
@@ -1514,6 +1517,7 @@ var SyscallsLibrary = {
     if (stream.getdents && offset === 0 && whence === {{{ cDefine('SEEK_SET') }}}) stream.getdents = null; // reset readdir state
     return 0;
   },
+  fd_fdstat_get__sig: 'iii',
   fd_fdstat_get: function(fd, pbuf) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);
@@ -1536,6 +1540,7 @@ var SyscallsLibrary = {
 #if EMTERPRETIFY_ASYNC
   fd_sync__deps: ['$EmterpreterAsync'],
 #endif
+  fd_sync__sig: 'ii',
   fd_sync: function(fd) {
     var stream = SYSCALLS.getStreamFromFD(fd);
 #if EMTERPRETIFY_ASYNC

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1452,6 +1452,7 @@ var SyscallsLibrary = {
   fd_write__postset: '__ATEXIT__.push(flush_NO_FILESYSTEM);',
 #endif
 #endif
+  fd_write__sig: 'iiiii',
   fd_write: function(fd, iov, iovcnt, pnum) {
 #if SYSCALLS_REQUIRE_FILESYSTEM
     var stream = SYSCALLS.getStreamFromFD(fd);

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -7,11 +7,13 @@
 
 var WasiLibrary = {
   proc_exit__deps: ['exit'],
+  proc_exit__sig: 'vi',
   proc_exit: function(code) {
-    return _exit(code);
+    _exit(code);
   },
 
   emscripten_get_environ__deps: ['$ENV', '_getExecutableName'],
+  emscripten_get_environ__sig: 'i',
   emscripten_get_environ: function() {
     if (!_emscripten_get_environ.strings) {
       // Default values.
@@ -39,6 +41,7 @@ var WasiLibrary = {
   },
 
   environ_sizes_get__deps: ['emscripten_get_environ'],
+  environ_sizes_get__sig: 'iii',
   environ_sizes_get: function(penviron_count, penviron_buf_size) {
     var strings = _emscripten_get_environ();
     {{{ makeSetValue('penviron_count', 0, 'strings.length', 'i32') }}};
@@ -55,6 +58,7 @@ var WasiLibrary = {
     , '$writeAsciiToMemory'
 #endif
   ],
+  environ_get__sig: 'iii',
   environ_get: function(__environ, environ_buf) {
     var strings = _emscripten_get_environ();
     var bufSize = 0;
@@ -67,6 +71,7 @@ var WasiLibrary = {
     return 0;
   },
 
+  args_sizes_get__sig: 'iii',
   args_sizes_get: function(pargc, pargv_buf_size) {
 #if MAIN_READS_PARAMS
     {{{ makeSetValue('pargc', 0, 'mainArgs.length', 'i32') }}};
@@ -81,6 +86,7 @@ var WasiLibrary = {
     return 0;
   },
 
+  args_get__sig: 'iii',
   args_get: function(argv, argv_buf) {
 #if MAIN_READS_PARAMS
     var bufSize = 0;

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -106,7 +106,7 @@ var WasiLibrary = {
 // lacks the attribute to set the import module and base names.
 if (!WASM_BACKEND) {
   for (var x in WasiLibrary) {
-    if (x.indexOf('__deps') >= 0) continue;
+    if (isJsLibraryConfigIdentifier(x)) continue;
     WasiLibrary['__wasi_' + x] = x;
   }
 }

--- a/src/modules.js
+++ b/src/modules.js
@@ -217,6 +217,17 @@ var LibraryManager = {
         if (typeof lib[target] === 'undefined' || typeof lib[target] === 'function') {
           // When functions are aliased, the alias target must provide a signature for the function so that an efficient form of forwarding can be implemented.
           // Primarily read the signature on the alias, and secondarily on the target.
+          function testStringType(sig) {
+            if (typeof lib[sig] !== 'undefined' && typeof typeof lib[sig] !== 'string') {
+              error(sig + ' should be a string! (was ' + typeof lib[sig]);
+            }
+          }
+          testStringType(x + '__sig');
+          testStringType(target + '__sig');
+          if (typeof lib[x + '__sig'] === 'string' && typeof lib[target + '__sig'] === 'string' && lib[x + '__sig'] != lib[target + '__sig']) {
+            error(x + '__sig (' + lib[x + '__sig'] + ')  differs from ' + target + '__sig (' + lib[target + '__sig'] + ')');
+          }
+
           var sig = lib[x + '__sig'] || lib[target + '__sig'];
           if (typeof sig !== 'string') {
             error('Function ' + x + ' aliases to target function ' + target + ', but neither the alias or the target provide a signature. Please add a ' + target + "__sig: 'vifj...' annotation or a " + x + "__sig: 'vifj...' annotation to describe the type of function forwarding that is needed!");

--- a/src/modules.js
+++ b/src/modules.js
@@ -219,7 +219,7 @@ var LibraryManager = {
           // Primarily read the signature on the alias, and secondarily on the target.
           var sig = lib[x + '__sig'] || lib[target + '__sig'];
           if (typeof sig !== 'string') {
-            error('Function ' + x + ' aliases to target function ' + target + ', but neither the alias or the target provide a signature. Please add a ' + target + "__sig: 'vifj...' annotation or a " + x + "__sig: 'vifj' annotation to describe the type of function forwarding that is needed!");
+            error('Function ' + x + ' aliases to target function ' + target + ', but neither the alias or the target provide a signature. Please add a ' + target + "__sig: 'vifj...' annotation or a " + x + "__sig: 'vifj...' annotation to describe the type of function forwarding that is needed!");
           }
 
           var argCount = sig.length - 1;

--- a/src/modules.js
+++ b/src/modules.js
@@ -215,25 +215,18 @@ var LibraryManager = {
         if (lib[target + '__asm']) continue; // This is an alias of an asm library function. Also needs to be fully optimized.
         if (!isNaN(target)) continue; // This is a number, and so cannot be an alias target.
         if (typeof lib[target] === 'undefined' || typeof lib[target] === 'function') {
-          // If the alias provides a signature, then construct a specific 'function foo(a0, a1, a2) { [return] _target(a0, a1, a2); }' form of forwarding.
-          // Otherwise construct a generic 'function foo() { return _target.apply(null, arguments); }' forwarding.
-          // The benefit of the first form is that Closure is able to fully inline and reason about the function.
-          // Note that the signature is checked on the alias function, not on the target function. That allows aliases to choose individually which form
-          // to use. 
-          if (lib[x + '__sig']) {
-            var argCount = lib[x + '__sig'].length - 1;
-            var ret = lib[x + '__sig'] == 'v' ? '' : 'return ';
-            var args = genArgSequence(argCount).join(',');
-            lib[x] = new Function(args, ret + '_' + target + '(' + args + ');');
-          } else {
-            // The alias we generate uses `arguments` to forward the call. If there is no explicit documentation for the alias, mark
-            // it variadic for Closure type checking to know.
-            var docs = lib[x + '__docs'];
-            if (!docs || (docs.indexOf('@type') == -1 && docs.indexOf('@param') == -1)) {
-              lib[x + '__docs'] = (docs || '') + '/** @type {function(...*):?} */';
-            }
-            lib[x] = new Function('return _' + target + '.apply(null, arguments)');
+          // When functions are aliased, the alias target must provide a signature for the function so that an efficient form of forwarding can be implemented.
+          // Primarily read the signature on the alias, and secondarily on the target.
+          var sig = lib[x + '__sig'] || lib[target + '__sig'];
+          if (typeof sig !== 'string') {
+            error('Function ' + x + ' aliases to target function ' + target + ', but neither the alias or the target provide a signature. Please add a ' + target + "__sig: 'vifj...' annotation or a " + x + "__sig: 'vifj' annotation to describe the type of function forwarding that is needed!");
           }
+
+          var argCount = sig.length - 1;
+          var ret = sig == 'v' ? '' : 'return ';
+          var args = genArgSequence(argCount).join(',');
+          lib[x] = new Function(args, ret + '_' + target + '(' + args + ');');
+
           if (!lib[x + '__deps']) lib[x + '__deps'] = [];
           lib[x + '__deps'].push(target);
         }

--- a/src/utility.js
+++ b/src/utility.js
@@ -204,6 +204,11 @@ function isArray(x) {
   }
 }
 
+function isJsLibraryConfigIdentifier(ident) {
+  return ident.endsWith('__sig') || ident.endsWith('__proxy') || ident.endsWith('__asm') || ident.endsWith('__inline')
+   || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs') || ident.endsWith('__import');
+}
+
 // Flattens something like [5, 6, 'hi', [1, 'bye'], 44] into
 // [5, 6, 'hi', 1, bye, 44].
 function flatten(x) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8795,7 +8795,7 @@ end
     # are including a lot of JS without corresponding compiled code for it. This still
     # lets us catch all other errors.
     with env_modify({'EMCC_CLOSURE_ARGS': '--jscomp_off undefinedVars'}):
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
+      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
 
   # Tests --closure-args command line flag
   def test_closure_externs(self):


### PR DESCRIPTION
Require that when aliasing functions, either the alias function or the target function must contain a signature, so that using 'arguments' object can always be avoided. This enables more efficient JS VM execution as it will not need to deopt around the use of arguments object, and Closure can inline the aliased call if it shrinks code size.