### PR TITLE
Error at compile time on 2GB or higher initial memory sizes

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1593,6 +1593,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.WASM:
       if shared.Settings.TOTAL_MEMORY % 65536 != 0:
         exit_with_error('For wasm, TOTAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.TOTAL_MEMORY))
+      if shared.Settings.TOTAL_MEMORY >= 2 * 1024 * 1024 * 1024:
+        exit_with_error('TOTAL_MEMORY must be less than 2GB due to current spec limitations')
     else:
       if shared.Settings.TOTAL_MEMORY < 16 * 1024 * 1024:
         exit_with_error('TOTAL_MEMORY must be at least 16MB, was ' + str(shared.Settings.TOTAL_MEMORY))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10393,6 +10393,11 @@ int main() {
     self.assertContained('wasm-ld: error:', stderr)
     self.assertContained('main_0.o: undefined symbol: foo', stderr)
 
+  @no_fastcomp('lld only')
+  def test_4GB(self):
+    stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'TOTAL_MEMORY=2GB'])
+    self.assertContained('TOTAL_MEMORY must be less than 2GB due to current spec limitations', stderr)
+
   # Verifies that warning messages that Closure outputs are recorded to console
   def test_closure_warnings(self):
     proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=quiet'], stderr=PIPE)


### PR DESCRIPTION
For now wasm VMs disallow initializing to >=2GB (but may allow growing the memory up to 4GB). So error at compile time for >=2GB initial memory sizes.

I hope we don't need this though, I've proposed we just allow initialization to >=2GB as well - otherwise, people that want to start with more will just have to manually call `emscripten_grow_memory(4GB)`, which is annoying. But until we agree on that, let's make emscripten error on >=2GB.
