### PR TITLE
This allows bitcode files as inputs when using -c and the llvm wasm b…

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1010,7 +1010,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         file_suffix = get_file_suffix(arg)
         if file_suffix in SOURCE_ENDINGS + OBJECT_FILE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
           newargs[i] = ''
-          if file_suffix.endswith(SOURCE_ENDINGS) or (has_dash_c and file_suffix.endswith('.bc')):
+          if file_suffix.endswith(SOURCE_ENDINGS) or (has_dash_c and file_suffix == '.bc'):
             input_files.append((i, arg))
             has_source_inputs = True
           elif file_suffix.endswith(HEADER_ENDINGS):
@@ -2096,7 +2096,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
       for i, input_file in input_files:
         file_ending = get_file_suffix(input_file)
-        if file_ending.endswith(SOURCE_ENDINGS) or (has_dash_c and file_ending.endswith('.bc')):
+        if file_ending.endswith(SOURCE_ENDINGS) or (has_dash_c and file_ending == '.bc'):
           compile_source_file(i, input_file)
         else:
           if file_ending.endswith(OBJECT_FILE_ENDINGS):

--- a/emcc.py
+++ b/emcc.py
@@ -1010,7 +1010,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         file_suffix = get_file_suffix(arg)
         if file_suffix in SOURCE_ENDINGS + OBJECT_FILE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
           newargs[i] = ''
-          if file_suffix.endswith(SOURCE_ENDINGS):
+          if file_suffix.endswith(SOURCE_ENDINGS) or (has_dash_c and file_suffix.endswith(OBJECT_FILE_ENDINGS)):
             input_files.append((i, arg))
             has_source_inputs = True
           elif file_suffix.endswith(HEADER_ENDINGS):
@@ -2096,7 +2096,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
       for i, input_file in input_files:
         file_ending = get_file_suffix(input_file)
-        if file_ending.endswith(SOURCE_ENDINGS):
+        if file_ending.endswith(SOURCE_ENDINGS) or (has_dash_c and file_ending.endswith(OBJECT_FILE_ENDINGS)):
           compile_source_file(i, input_file)
         else:
           if file_ending.endswith(OBJECT_FILE_ENDINGS):

--- a/emcc.py
+++ b/emcc.py
@@ -1010,7 +1010,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         file_suffix = get_file_suffix(arg)
         if file_suffix in SOURCE_ENDINGS + OBJECT_FILE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS or shared.Building.is_ar(arg): # we already removed -o <target>, so all these should be inputs
           newargs[i] = ''
-          if file_suffix.endswith(SOURCE_ENDINGS) or (has_dash_c and file_suffix.endswith(OBJECT_FILE_ENDINGS)):
+          if file_suffix.endswith(SOURCE_ENDINGS) or (has_dash_c and file_suffix.endswith('.bc')):
             input_files.append((i, arg))
             has_source_inputs = True
           elif file_suffix.endswith(HEADER_ENDINGS):
@@ -2096,7 +2096,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # First, generate LLVM bitcode. For each input file, we get base.o with bitcode
       for i, input_file in input_files:
         file_ending = get_file_suffix(input_file)
-        if file_ending.endswith(SOURCE_ENDINGS) or (has_dash_c and file_ending.endswith(OBJECT_FILE_ENDINGS)):
+        if file_ending.endswith(SOURCE_ENDINGS) or (has_dash_c and file_ending.endswith('.bc')):
           compile_source_file(i, input_file)
         else:
           if file_ending.endswith(OBJECT_FILE_ENDINGS):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10402,3 +10402,12 @@ int main() {
     self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', proc.stderr)
 
     self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=error'])
+
+  @no_fastcomp('test wasm object files')
+  def test_bitcode_input(self):
+    # Verify that bitcode files are accepted as input
+    create_test_file('main.c', 'void foo(); int main() { return 0; }')
+    run_process([PYTHON, EMCC, '-emit-llvm', '-c', '-o', 'main.bc', 'main.c'])
+    self.assertTrue(shared.Building.is_bitcode('main.bc'))
+    run_process([PYTHON, EMCC, '-c', '-o', 'main.o', 'main.bc'])
+    self.assertTrue(shared.Building.is_wasm('main.o'))


### PR DESCRIPTION
This allows bitcode files as inputs when using -c and the llvm wasm backend, i.e.
```emcc -o foo.o -c foo.bc```
will compile the bc file into a wasm object file.
This is useful for compiling .bc files created by 3rd party compilers using the same flags that emcc
passes to clang, so they can be linked together later.