### PR TITLE
Fix some failing LTO tests

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -126,12 +126,6 @@ LEAVE_INPUTS_RAW = int(os.environ.get('EMCC_LEAVE_INPUTS_RAW', '0'))
 if LEAVE_INPUTS_RAW:
   del os.environ['EMCC_LEAVE_INPUTS_RAW']
 
-# If set to 1, we will run the autodebugger (the automatic debugging tool, see
-# tools/autodebugger).  Note that this will disable inclusion of libraries. This
-# is useful because including dlmalloc makes it hard to compare native and js
-# builds
-AUTODEBUG = os.environ.get('EMCC_AUTODEBUG')
-
 # Target options
 final = None
 
@@ -1183,7 +1177,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.AUTO_JS_LIBRARIES = 0
       shared.Settings.AUTO_ARCHIVE_INDEXES = 0
 
-    if AUTODEBUG:
+    # If set to 1, we will run the autodebugger (the automatic debugging tool, see
+    # tools/autodebugger).  Note that this will disable inclusion of libraries. This
+    # is useful because including dlmalloc makes it hard to compare native and js
+    # builds
+    if os.environ.get('EMCC_AUTODEBUG'):
       shared.Settings.AUTODEBUG = 1
 
     # Use settings
@@ -1834,7 +1832,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             passes += ['--strip-debug']
           if not shared.Settings.EMIT_PRODUCERS_SECTION:
             passes += ['--strip-producers']
-          if shared.Settings.AUTODEBUG and not shared.Settings.LTO:
+          if shared.Settings.AUTODEBUG:
             # adding '--flatten' here may make these even more effective
             passes += ['--instrument-locals']
             passes += ['--log-execution']
@@ -2340,7 +2338,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
                link_opts.append("-wholeprogramdevirt")
             link_opts.append("-lowertypetests")
 
-          if AUTODEBUG:
+          if shared.Settings.AUTODEBUG:
             # let llvm opt directly emit ll, to skip writing and reading all the bitcode
             link_opts += ['-S']
             final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
@@ -2358,7 +2356,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if options.save_bc:
           save_intermediate('ll', 'll')
 
-        if AUTODEBUG:
+        if shared.Settings.AUTODEBUG:
           logger.debug('autodebug')
           next = get_final() + '.ad.ll'
           run_process([shared.PYTHON, shared.AUTODEBUGGER, final, next])

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 25417,
-  "a.js.gz": 9902,
+  "a.js": 25443,
+  "a.js.gz": 9923,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 29173,
-  "total_gz": 12999
+  "total": 29199,
+  "total_gz": 13020
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 24912,
-  "a.js.gz": 9737,
+  "a.js": 24938,
+  "a.js.gz": 9761,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 28668,
-  "total_gz": 12834
+  "total": 28694,
+  "total_gz": 12858
 }

--- a/tests/core/test_asan_memchr.c
+++ b/tests/core/test_asan_memchr.c
@@ -1,5 +1,5 @@
 #include <string.h>
 
 int main() {
-  memchr("hello", 'z', 7);
+  return (int)memchr("hello", 'z', 7);
 }

--- a/tests/core/test_malloc_usable_size.c
+++ b/tests/core/test_malloc_usable_size.c
@@ -1,8 +1,13 @@
 #include <emscripten/emmalloc.h>
 #include <stdio.h>
 
+// Mark as used to defeat LTO which can otherwise completely elimate the
+// calls to malloc below.
+void* ptr __attribute__((used));
+
 int main()
 {
-	void *ptr = malloc(1);
-	printf("%zu\n", malloc_usable_size(ptr));
+  ptr = malloc(1);
+  printf("%zu\n", malloc_usable_size(ptr));
+  return 0;
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6362,7 +6362,8 @@ return malloc(size);
   def test_lifetime(self):
     self.do_ll_run(path_from_root('tests', 'lifetime.ll'), 'hello, world!\n')
     if '-O1' in self.emcc_args or '-O2' in self.emcc_args:
-      assert 'a18' not in open('lifetime.ll.o.js').read(), 'lifetime stuff and their vars must be culled'
+      # lifetime stuff and their vars must be culled
+      self.assertNotContained('a18', open('lifetime.ll.o.js').read())
 
   # Test cases in separate files. Note that these files may contain invalid .ll!
   # They are only valid enough for us to read for test purposes, not for llvm-as

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9622,8 +9622,6 @@ int main () {
                            '-s', 'MODULARIZE=1']
     hello_webgl2_sources = hello_webgl_sources + ['-s', 'MAX_WEBGL_VERSION=2']
 
-    success = True
-
     def print_percent(actual, expected):
       if actual == expected:
         return ''
@@ -9740,8 +9738,6 @@ int main () {
           if total_output_size < total_expected_size:
             print('Hey amazing, overall generated code size was improved by ' + str(total_expected_size - total_output_size) + ' bytes! Rerun test with other.test_minimal_runtime_code_size with EMTEST_REBASELINE=1 to update the expected sizes!')
           self.assertEqual(total_output_size, total_expected_size)
-
-    self.assertTrue(success)
 
   # Test that legacy settings that have been fixed to a specific value and their value can no longer be changed,
   def test_legacy_settings_forbidden_to_change(self):

--- a/tests/wrap_malloc.cpp
+++ b/tests/wrap_malloc.cpp
@@ -33,16 +33,20 @@ void __attribute__((noinline)) free(void *ptr)
 
 }
 
-void *out;
+// Mark as used to defeat LTO which can otherwise completely elimate the
+// calls to malloc below.
+void *out __attribute__((used));
 
 int main()
 {
 	for(int i = 0; i < 20; ++i)
 	{
 		void *ptr = malloc(1024 * 1024);
-		out = ptr; // make it look used
+		out = ptr;
 		free(ptr);
 	}
+	printf("totalAllocated: %d\n", totalAllocated);
 	assert(totalAllocated == 20);
 	printf("OK.\n");
+	return 0;
 }

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -147,7 +147,19 @@ def get_wasm_libc_rt_files():
     path_components=['system', 'lib', 'libc'],
     filenames=['emscripten_memcpy.c', 'emscripten_memset.c',
                'emscripten_memmove.c'])
-  return math_files + other_files
+  # Calls to iprintf can be generated during codegen. Ideally we wouldn't
+  # compile these with -O2 like we do the rest of compiler-rt since its
+  # probably not performance sensitive.  However we don't currently have
+  # a way to set per-file compiler flags.  And hopefully we should be able
+  # move all this stuff back into libc once we it LTO compatible.
+  iprintf_files = files_in_path(
+    path_components=['system', 'lib', 'libc', 'musl', 'src', 'stdio'],
+    filenames=['__towrite.c', '__overflow.c', 'fwrite.c', 'fputs.c',
+               'printf.c', 'puts.c'])
+  iprintf_files += files_in_path(
+    path_components=['system', 'lib', 'libc', 'musl', 'src', 'string'],
+    filenames=['strlen.c'])
+  return math_files + other_files + iprintf_files
 
 
 class Library(object):


### PR DESCRIPTION
All but one of the non-slow tests now pass under LTO:

  EMTEST_SKIP_SLOW=1 ./tests/runner.py wasmlto2

Remaining failure is test_floatvars.

This changed moved a few source files from libc to libc_rt_wasm (the
parts of libc can are excluded from LTO because they contain libcall
implementations).  This means there was a slight impact on the output
due to the `-O2` vs `-Os`.
