### PR TITLE
[SIMD] Add intrinsics for granular shuffles

### DIFF
--- a/system/include/wasm_simd128.h
+++ b/system/include/wasm_simd128.h
@@ -1176,6 +1176,18 @@ static __inline__ v128_t __DEFAULT_FN_ATTRS wasm_f64x2_convert_u64x2(v128_t a) {
   ((v128_t)(__builtin_shufflevector((__u8x16)(a), (__u8x16)(b), c0, c1, c2, c3, c4, c5, c6, c7,    \
     c8, c9, c10, c11, c12, c13, c14, c15)))
 
+// v128_t wasm_v16x8_shuffle(v128_t a, v128_t b, c0, ..., c7)
+#define wasm_v16x8_shuffle(a, b, c0, c1, c2, c3, c4, c5, c6, c7)        \
+  ((v128_t)(__builtin_shufflevector((__u16x8)(a), (__u16x8)(b), c0, c1, c2, c3, c4, c5, c6, c7)))
+
+// v128_t wasm_v32x4_shuffle(v128_t a, v128_t b, c0, ..., c3)
+#define wasm_v32x4_shuffle(a, b, c0, c1, c2, c3)                        \
+  ((v128_t)(__builtin_shufflevector((__u32x4)(a), (__u32x4)(b), c0, c1, c2, c3)))
+
+// v128_t wasm_v64x2_shuffle(v128_t a, v128_t b, c0, c1)
+#define wasm_v64x2_shuffle(a, b, c0, c1)                                \
+  ((v128_t)(__builtin_shufflevector((__u64x2)(a), (__u64x2)(b), c0, c1)))
+
 #ifdef __wasm_unimplemented_simd128__
 
 // v128_t wasm_v8x16_swizzle(v128_t a, v128_t b)

--- a/tests/test_wasm_intrinsics_simd.c
+++ b/tests/test_wasm_intrinsics_simd.c
@@ -96,8 +96,14 @@ v128_t TESTFN f64x2_make(double first) {
 v128_t TESTFN i8x16_shuffle_interleave_bytes(v128_t x, v128_t y) {
   return wasm_v8x16_shuffle(x, y, 0, 17, 2, 19, 4, 21, 6, 23, 8, 25, 10, 27, 12, 29, 14, 31);
 }
+v128_t TESTFN i16x8_shuffle_reverse(v128_t vec) {
+  return wasm_v16x8_shuffle(vec, vec, 7, 6, 5, 4, 3, 2, 1, 0);
+}
 v128_t TESTFN i32x4_shuffle_reverse(v128_t vec) {
-  return wasm_v8x16_shuffle(vec, vec, 12, 13, 14, 15, 8, 9, 10, 11, 4, 5, 6, 7, 0, 1, 2, 3);
+  return wasm_v32x4_shuffle(vec, vec, 3, 2, 1, 0);
+}
+v128_t TESTFN i64x2_shuffle_reverse(v128_t vec) {
+  return wasm_v64x2_shuffle(vec, vec, 1, 0);
 }
 
 #ifdef __wasm_unimplemented_simd128__
@@ -874,7 +880,14 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ),
     i8x16(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16)
   );
+  expect_vec(
+    i16x8_shuffle_reverse(
+      (v128_t)i16x8(1, 2, 3, 4, 5, 6, 7, 8)
+    ),
+    (v128_t)i16x8(8, 7, 6, 5, 4, 3, 2, 1)
+  );
   expect_vec(i32x4_shuffle_reverse((v128_t)i32x4(1, 2, 3, 4)), i32x4(4, 3, 2, 1));
+  expect_vec(i64x2_shuffle_reverse((v128_t)i64x2(1, 2)), i64x2(2, 1));
 
 #ifdef  __wasm_unimplemented_simd128__
 


### PR DESCRIPTION
These utilities are highly requested. Although they do not correspond
to separate instructions, they will still be commonly used and are
therefore worthy of inclusion in the header.

cc @zeux