### PR TITLE
fastcomp: error on unrecognised linker inputs

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -281,7 +281,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # emcc src.cpp -c    and   emcc src.cpp -o src.[o|bc] ==> should give a .bc file
     #      regression check: -o js should create "js", with bitcode content
     for args in [['-c'], ['-o', 'src.o'], ['-o', 'src.bc'], ['-o', 'src.so'], ['-o', 'js'], ['-O1', '-c', '-o', '/dev/null'], ['-O1', '-o', '/dev/null']]:
-      print('-c stuff', args)
+      print('args:', args)
       if '/dev/null' in args and WINDOWS:
         print('skip because windows')
         continue
@@ -292,12 +292,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         print('(no output)')
         continue
       syms = Building.llvm_nm(target)
-      assert 'main' in syms.defs
+      self.assertContained('main', syms.defs)
       if self.is_wasm_backend():
         # wasm backend will also have '__original_main' or such
-        assert len(syms.defs) == 2
+        self.assertEqual(len(syms.defs), 2)
       else:
-        assert len(syms.defs) == 1
+        self.assertEqual(len(syms.defs), 1)
       if target == 'js': # make sure emcc can recognize the target as a bitcode file
         shutil.move(target, target + '.bc')
         target += '.bc'
@@ -1043,7 +1043,7 @@ int main() {
 
   @parameterized({
     'expand_symlinks': [[]],
-    'no-canonical-prefixes': [['-no-canonical-prefixes']],
+    'no_canonical_prefixes': [['-no-canonical-prefixes']],
   })
   @no_windows('Windows does not support symlinks')
   def test_symlink_points_to_bad_suffix(self, flags):
@@ -1056,7 +1056,7 @@ int main() {
 
   @parameterized({
     'expand_symlinks': ([], True),
-    'no-canonical-prefixes': (['-no-canonical-prefixes'], False),
+    'no_canonical_prefixes': (['-no-canonical-prefixes'], False),
   })
   @no_windows('Windows does not support symlinks')
   def test_symlink_has_bad_suffix(self, flags, expect_success):
@@ -1294,17 +1294,16 @@ int f() {
 
     self.assertContained('result: 1', run_js('a.out.js'))
 
-  @no_wasm_backend('archive contents handling differ with lld')
   def test_dot_a_all_contents_invalid(self):
-    # check that we warn if an object file in a .a is not valid bitcode.
+    # check that we error if an object file in a .a is not valid bitcode.
     # do not silently ignore native object files, which may have been
     # built by mistake
-    create_test_file('side.cpp', r'int side() { return 5; }')
-    create_test_file('main.cpp', r'extern int side(); int main() { return side(); }')
-    run_process([CLANG, 'side.cpp', '-c', '-o', 'native.o'])
-    run_process([PYTHON, EMAR, 'crs', 'foo.a', 'native.o'])
-    proc = run_process([PYTHON, EMCC, 'main.cpp', 'foo.a', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'], stderr=PIPE)
-    self.assertContained('is not a valid object file for emscripten, cannot link', proc.stderr)
+    create_test_file('native.cpp', 'int native() { return 5; }')
+    create_test_file('main.cpp', 'extern int native(); int main() { return native(); }')
+    run_process([CLANG, 'native.cpp', '-c', '-o', 'native.o'])
+    run_process([PYTHON, EMAR, 'crs', 'libfoo.a', 'native.o'])
+    stderr = self.expect_fail([PYTHON, EMCC, 'main.cpp', 'libfoo.a'])
+    self.assertContained('unknown file type', stderr)
 
   def test_export_all(self):
     lib = r'''

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1298,11 +1298,11 @@ int f() {
     # check that we error if an object file in a .a is not valid bitcode.
     # do not silently ignore native object files, which may have been
     # built by mistake
-    create_test_file('native.cpp', 'int native() { return 5; }')
-    create_test_file('main.cpp', 'extern int native(); int main() { return native(); }')
-    run_process([CLANG, 'native.cpp', '-c', '-o', 'native.o'])
+    create_test_file('native.c', 'int native() { return 5; }')
+    create_test_file('main.c', 'extern int native(); int main() { return native(); }')
+    run_process([CLANG_CC, 'native.c', '-target', 'x86_64-linux', '-c', '-o', 'native.o'])
     run_process([PYTHON, EMAR, 'crs', 'libfoo.a', 'native.o'])
-    stderr = self.expect_fail([PYTHON, EMCC, 'main.cpp', 'libfoo.a'])
+    stderr = self.expect_fail([PYTHON, EMCC, 'main.c', 'libfoo.a'])
     self.assertContained('unknown file type', stderr)
 
   def test_export_all(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5913,10 +5913,10 @@ int main(void) {
     # when building a .a, we force-include all the objects inside it. but, some
     # may not be valid bitcode, e.g. if it contains metadata or something else
     # weird. we should just ignore those
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'a.bc'])
-    create_test_file('bad.bc', 'this is not a good file, it should be ignored!')
-    run_process([LLVM_AR, 'r', 'a.a', 'a.bc', 'bad.bc'])
-    run_process([PYTHON, EMCC, 'a.a'])
+    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', 'hello_world.o'])
+    create_test_file('bad.obj', 'this is not a good file, it should be ignored!')
+    run_process([LLVM_AR, 'cr', 'libfoo.a', 'hello_world.o', 'bad.obj'])
+    run_process([PYTHON, EMCC, 'libfoo.a'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_require(self):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1904,8 +1904,7 @@ class Building(object):
         return False
       # Check the object is valid for us, and not a native object file.
       if not Building.is_bitcode(f):
-        warning('object %s is not a valid object file for emscripten, cannot link', f)
-        return False
+        exit_with_error('unknown file type: %s', f)
       provided = new_symbols.defs.union(new_symbols.commons)
       do_add = force_add or not unresolved_symbols.isdisjoint(provided)
       if do_add:


### PR DESCRIPTION
Also, make the error messages consistent with wasm-ld when it
sees invalid input files.

Also, simplify the running wasm-opt and allow its error code to be
handled by `check_run` and allows its errors/warnings to be displayed
on stderr directly.

This change was split of from a larger change relating to handling
of linker inputs: #10560