### PR TITLE
Remove direct alias generation

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -212,7 +212,6 @@ var LibraryManager = {
           if (lib[target].indexOf('Math_') == 0) continue libloop;
           target = lib[target];
         }
-        if (lib[target + '__asm']) continue; // This is an alias of an asm library function. Also needs to be fully optimized.
         if (!isNaN(target)) continue; // This is a number, and so cannot be an alias target.
         if (typeof lib[target] === 'undefined' || typeof lib[target] === 'function') {
           // When functions are aliased, the alias target must provide a signature for the function so that an efficient form of forwarding can be implemented.


### PR DESCRIPTION
Do not generate direct 'var alias=target;' aliasing, since target might be defined only later. Instead generate a full stub function.

This fixes issues where generated code would get
```js
var _llvm_memcpy_i64 = _memcpy;
```
where `_memcpy` is not even defined yet. After this change, compiler emits
```js
function _llvm_memcpy_i64(a0,a1,a2
) {
return _memcpy(a0,a1,a2);
}
```
