### PR TITLE
Fix parsing of TOTAL_MEMORY=64MB

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -400,6 +400,9 @@ def apply_settings(changes):
     if key.startswith('NO_') and value in ('0', '1'):
       key = key[3:]
       value = str(1 - int(value))
+    # map legacy settings which have aliases to the new names
+    if key in shared.Settings.legacy_settings and key in shared.Settings.alt_names:
+      key = shared.Settings.alt_names[key]
     return key, value
 
   for change in changes:

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4978,6 +4978,6 @@ window.close = function() {
       ''')
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_create.cpp'),
                expected='0',
-               args=['-s', 'TOTAL_MEMORY=64MB', '-s', 'USE_PTHREADS=1', '-s',
-                     'PTHREAD_POOL_SIZE=8', '-s', 'MODULARIZE_INSTANCE=1',
+               args=['-s', 'INITIAL_MEMORY=64MB', '-s', 'USE_PTHREADS=1',
+                     '-s', 'PTHREAD_POOL_SIZE=8', '-s', 'MODULARIZE_INSTANCE=1',
                      '-s', 'EXPORT_NAME=MyModule', '--shell-file', 'shell.html'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8761,9 +8761,10 @@ end
       self.assertEqual(results[flag1 + '.js'], results[flag2 + '.js'], 'js results should be identical')
       self.assertEqual(results[flag1 + '.wasm'], results[flag2 + '.wasm'], 'wasm results should be identical')
 
-    assert_aliases_match('INITIAL_MEMORY', 'TOTAL_MEMORY', '16777216')
-    assert_aliases_match('MAXIMUM_MEMORY', 'WASM_MEM_MAX', '16777216', ['-s', 'ALLOW_MEMORY_GROWTH'])
-    assert_aliases_match('MAXIMUM_MEMORY', 'BINARYEN_MEM_MAX', '16777216', ['-s', 'ALLOW_MEMORY_GROWTH'])
+    #assert_aliases_match('INITIAL_MEMORY', 'TOTAL_MEMORY', '16777216')
+    assert_aliases_match('INITIAL_MEMORY', 'TOTAL_MEMORY', '64MB')
+    #assert_aliases_match('MAXIMUM_MEMORY', 'WASM_MEM_MAX', '16777216', ['-s', 'ALLOW_MEMORY_GROWTH'])
+    #assert_aliases_match('MAXIMUM_MEMORY', 'BINARYEN_MEM_MAX', '16777216', ['-s', 'ALLOW_MEMORY_GROWTH'])
 
   def test_IGNORE_CLOSURE_COMPILER_ERRORS(self):
     create_test_file('pre.js', r'''

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8761,10 +8761,10 @@ end
       self.assertEqual(results[flag1 + '.js'], results[flag2 + '.js'], 'js results should be identical')
       self.assertEqual(results[flag1 + '.wasm'], results[flag2 + '.wasm'], 'wasm results should be identical')
 
-    #assert_aliases_match('INITIAL_MEMORY', 'TOTAL_MEMORY', '16777216')
+    assert_aliases_match('INITIAL_MEMORY', 'TOTAL_MEMORY', '16777216')
     assert_aliases_match('INITIAL_MEMORY', 'TOTAL_MEMORY', '64MB')
-    #assert_aliases_match('MAXIMUM_MEMORY', 'WASM_MEM_MAX', '16777216', ['-s', 'ALLOW_MEMORY_GROWTH'])
-    #assert_aliases_match('MAXIMUM_MEMORY', 'BINARYEN_MEM_MAX', '16777216', ['-s', 'ALLOW_MEMORY_GROWTH'])
+    assert_aliases_match('MAXIMUM_MEMORY', 'WASM_MEM_MAX', '16777216', ['-s', 'ALLOW_MEMORY_GROWTH'])
+    assert_aliases_match('MAXIMUM_MEMORY', 'BINARYEN_MEM_MAX', '16777216', ['-s', 'ALLOW_MEMORY_GROWTH'])
 
   def test_IGNORE_CLOSURE_COMPILER_ERRORS(self):
     create_test_file('pre.js', r'''


### PR DESCRIPTION
This is a regression from #10566 which renamed that
setting to INITIAL_MEMORY, and #10449 which added
a test using that setting in that way, and landed close
enough that we didn't notice it was doing so. It should
have worked since we tried to support the old name of
the setting, but this uncovered a bug, so it's actually
good that it broke!

The bug is that we have special handling for expanding
things like `64MB` into a number, and that handling did
not work on aliases. As a solution, map aliases very
early in parsing.