### PR TITLE
Update other.test_implicit_func test expectations

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3740,6 +3740,7 @@ int main()
 
     IMPLICIT_WARNING = "warning: implicit declaration of function 'strnlen' is invalid in C99"
     IMPLICIT_ERROR = "error: implicit declaration of function 'strnlen' is invalid in C99"
+    INCOMPATIBLE_WARNINGS = ('warning: incompatible pointer types', 'warning: incompatible function pointer types')
 
     for opts, expected, compile_expected in [
       ([], None, [IMPLICIT_ERROR]),
@@ -3749,7 +3750,7 @@ int main()
       print(opts, expected)
       try_delete('a.out.js')
       stderr = run_process([PYTHON, EMCC, 'src.c'] + opts, stderr=PIPE, check=False).stderr
-      for ce in compile_expected + ['warning: incompatible pointer types']:
+      for ce in compile_expected + [INCOMPATIBLE_WARNINGS]:
         self.assertContained(ce, stderr)
       if expected is None:
         self.assertNotExists('a.out.js')


### PR DESCRIPTION
LLVM has renamed this slightly, adding "function" in the name. This
makes the test support both (which also supports fastcomp, and
avoids any churn if LLVM backs this out).

This fixes part of the current broken waterfall roll.