### PR TITLE
Make the linking order of --js-library files and -l directives on the command line matter

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2922,7 +2922,7 @@ def parse_args(newargs):
       options.no_entry = True
       newargs[i] = ''
     elif check_arg('--js-library'):
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((i+1, os.path.abspath(consume_arg())))
+      shared.Settings.SYSTEM_JS_LIBRARIES.append((i + 1, os.path.abspath(consume_arg())))
     elif newargs[i] == '--remove-duplicates':
       diagnostics.warning('legacy-settings', '--remove-duplicates is deprecated as it is no longer needed. If you cannot link without it, file a bug with a testcase')
       newargs[i] = ''

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -231,6 +231,10 @@ function JSify(data, functionsOnly) {
       var snippet = original;
       var redirectedIdent = null;
       var deps = LibraryManager.library[ident + '__deps'] || [];
+      if (!Array.isArray(deps)) {
+        error('JS library directive ' + ident + '__deps=' + deps.toString() + ' is of type ' + typeof deps + ', but it should be an array!');
+        return;
+      }
       deps.forEach(function(dep) {
         if (typeof snippet === 'string' && !(dep in LibraryManager.library)) warn('missing library dependency ' + dep + ', make sure you are compiling with the right options (see #ifdefs in src/library*.js)');
       });

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5005,7 +5005,7 @@ window.close = function() {
     # When WebGL is explicitly linked to in strict mode, the linking order on command line should enable overriding.
     self.btest(path_from_root('tests', 'test_override_system_js_lib_symbol.c'),
                expected='5121',
-               args=['-s', 'STRICT=1', '-lwebgl.js', '--js-library', path_from_root('tests', 'test_override_system_js_lib_symbol.js')])
+               args=['-s', 'AUTO_JS_LIBRARIES=0', '-lwebgl.js', '--js-library', path_from_root('tests', 'test_override_system_js_lib_symbol.js')])
 
   @no_fastcomp('only upstream supports 4GB')
   @no_firefox('no 4GB support yet')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4991,6 +4991,22 @@ window.close = function() {
   def test_system(self):
     self.btest(path_from_root('tests', 'system.c'), '0')
 
+  # Tests that it is possible to hook into/override a symbol defined in a system library.
+  @requires_graphics_hardware
+  def test_override_system_js_lib_symbol(self):
+    # This test verifies it is possible to override a symbol from WebGL library.
+
+    # When WebGL is implicitly linked in, the implicit linking should happen before any user --js-libraries, so that they can adjust
+    # the behavior afterwards.
+    self.btest(path_from_root('tests', 'test_override_system_js_lib_symbol.c'),
+               expected='5121',
+               args=['--js-library', path_from_root('tests', 'test_override_system_js_lib_symbol.js')])
+
+    # When WebGL is explicitly linked to in strict mode, the linking order on command line should enable overriding.
+    self.btest(path_from_root('tests', 'test_override_system_js_lib_symbol.c'),
+               expected='5121',
+               args=['-s', 'STRICT=1', '-lwebgl.js', '--js-library', path_from_root('tests', 'test_override_system_js_lib_symbol.js')])
+
   @no_fastcomp('only upstream supports 4GB')
   @no_firefox('no 4GB support yet')
   def test_zzz_zzz_4GB(self):

--- a/tests/test_override_system_js_lib_symbol.c
+++ b/tests/test_override_system_js_lib_symbol.c
@@ -1,0 +1,28 @@
+#include <emscripten.h>
+#include <emscripten/html5.h>
+#include <assert.h>
+#include <GLES2/gl2.h>
+#include <stdio.h>
+
+GLuint what_got_created(void);
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attr;
+  emscripten_webgl_init_context_attributes(&attr);
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
+  emscripten_webgl_make_context_current(ctx);
+
+  GLuint texture;
+  glGenTextures(1, &texture);
+  glBindTexture(GL_TEXTURE_2D, texture);
+
+  GLuint createType = GL_UNSIGNED_BYTE;
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, createType, 0);
+  GLuint whatGotCreated = what_got_created();
+  printf("Created texture of type 0x%x\n", whatGotCreated);
+  assert(createType == whatGotCreated);
+#ifdef REPORT_RESULT
+  REPORT_RESULT(whatGotCreated);
+#endif
+}

--- a/tests/test_override_system_js_lib_symbol.js
+++ b/tests/test_override_system_js_lib_symbol.js
@@ -1,0 +1,16 @@
+if (!LibraryManager.library.glTexImage2D) throw 'This file should be getting processed after library_webgl.js!';
+
+mergeInto(LibraryManager.library, {
+	orig_glTexImage2D__deps: LibraryManager.library.glTexImage2D__deps,
+	orig_glTexImage2D: LibraryManager.library.glTexImage2D,
+
+	glTexImage2D__deps: ['orig_glTexImage2D'],
+	glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
+		_glTexImage2D.createdType = type;
+		_orig_glTexImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
+	},
+
+	what_got_created: function() {
+		return _glTexImage2D.createdType;
+	}
+});

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2653,6 +2653,7 @@ class Building(object):
       'EGL': 'library_egl.js',
       'GL': 'library_webgl.js',
       'GLESv2': 'library_webgl.js',
+      'GLESv3': ['library_webgl.js', 'library_webgl2.js'],
       'GLEW': 'library_glew.js',
       'glfw': 'library_glfw.js',
       'glfw3': 'library_glfw.js',

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2653,7 +2653,7 @@ class Building(object):
       'EGL': 'library_egl.js',
       'GL': 'library_webgl.js',
       'GLESv2': 'library_webgl.js',
-      'GLESv3': ['library_webgl.js', 'library_webgl2.js'],
+      # N.b. there is no GLESv3 to link to (note [f] in https://www.khronos.org/registry/implementers_guide.html)
       'GLEW': 'library_glew.js',
       'glfw': 'library_glfw.js',
       'glfw3': 'library_glfw.js',


### PR DESCRIPTION
Make the linking order of --js-library files and -l directives on the command line matter for STRICT mode, and add a test that it is possible to override WebGL library symbols.