### PR TITLE
Restore other.test_minimal_runtime_code_size and update sizes

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 5133,
   "a.js.gz": 2426,
-  "a.wasm": 11321,
-  "a.wasm.gz": 7107,
-  "total": 17017,
-  "total_gz": 9910
+  "a.wasm": 11351,
+  "a.wasm.gz": 7120,
+  "total": 17047,
+  "total_gz": 9923
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 25443,
-  "a.js.gz": 9923,
+  "a.js": 25485,
+  "a.js.gz": 9933,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 29199,
-  "total_gz": 13020
+  "total": 29241,
+  "total_gz": 13030
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 4624,
   "a.js.gz": 2254,
-  "a.wasm": 11321,
-  "a.wasm.gz": 7107,
-  "total": 16508,
-  "total_gz": 9738
+  "a.wasm": 11351,
+  "a.wasm.gz": 7120,
+  "total": 16538,
+  "total_gz": 9751
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 24938,
-  "a.js.gz": 9761,
+  "a.js": 24980,
+  "a.js.gz": 9769,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 28694,
-  "total_gz": 12858
+  "total": 28736,
+  "total_gz": 12866
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 14160,
-  "a.html.gz": 7539,
-  "total": 14160,
-  "total_gz": 7539
+  "a.html": 14124,
+  "a.html.gz": 7569,
+  "total": 14124,
+  "total_gz": 7569
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 20590,
-  "a.html.gz": 8594,
-  "total": 20590,
-  "total_gz": 8594
+  "a.html": 20535,
+  "a.html.gz": 8545,
+  "total": 20535,
+  "total_gz": 8545
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9598,8 +9598,6 @@ int main () {
         test(['-s', 'WASM=1', '-s', 'WASM_ASYNC_COMPILATION=0'], closure, opt)
 
   def test_minimal_runtime_code_size(self):
-    # TODO Remove this line and update expectation for the code size
-    self.skipTest('Temporarily skipping this for LLVM roll to succeed')
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'AGGRESSIVE_VARIABLE_ELIMINATION=1',
                                '-s', 'ENVIRONMENT=web',


### PR DESCRIPTION
Some values slightly regressed due to an LLVM change somewhere in

ab96ec41ead8..621388468b51

which we have not investigated. It might be interesting to find out more,
but it could be just noise.