### PR TITLE
Use ES6 spread syntax

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -105,7 +105,11 @@ var LibraryJSEvents = {
         var call = JSEvents.deferredCalls[i];
         JSEvents.deferredCalls.splice(i, 1);
         --i;
+#if MIN_CHROME_VERSION < 46 || MIN_FIREFOX_VERSION < 27 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls
         call.targetFunction.apply(null, call.argsList);
+#else
+        call.targetFunction(...call.argsList);
+#endif
       }
     },
 

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1316,13 +1316,21 @@ var LibraryPThread = {
       var sigPtr = _emscripten_receive_on_main_thread_js_callArgs[1];
       var varargPtr = _emscripten_receive_on_main_thread_js_callArgs[2];
       var constArgs = readAsmConstArgs(sigPtr, varargPtr);
+#if MIN_CHROME_VERSION < 46 || MIN_FIREFOX_VERSION < 27 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls
       return func.apply(null, constArgs);
+#else
+      return func(...constArgs);
+#endif
     }
 #endif
 #if ASSERTIONS
     assert(func.length == numCallArgs, 'Call args mismatch in emscripten_receive_on_main_thread_js');
 #endif
+#if MIN_CHROME_VERSION < 46 || MIN_FIREFOX_VERSION < 27 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls
     return func.apply(null, _emscripten_receive_on_main_thread_js_callArgs);
+#else
+    return func(..._emscripten_receive_on_main_thread_js_callArgs);
+#endif
   },
 
   $establishStackSpace: function(stackTop, stackMax) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -143,7 +143,12 @@ function ccall(ident, returnType, argTypes, args, opts) {
       }
     }
   }
+#if MIN_CHROME_VERSION < 46 || MIN_FIREFOX_VERSION < 27 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls
   var ret = func.apply(null, cArgs);
+#else
+  var ret = func(...cArgs);
+#endif
+
 #if EMTERPRETIFY_ASYNC
   if (typeof EmterpreterAsync === 'object' && EmterpreterAsync.state) {
 #if ASSERTIONS

--- a/src/support.js
+++ b/src/support.js
@@ -721,7 +721,11 @@ function dynCall(sig, ptr, args) {
 #if ASSERTIONS
     assert(('dynCall_' + sig) in Module, 'bad function pointer type - no table for sig \'' + sig + '\'');
 #endif
+#if MIN_CHROME_VERSION < 46 || MIN_FIREFOX_VERSION < 27 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Spread_syntax#Spread_in_function_calls
     return Module['dynCall_' + sig].apply(null, [ptr].concat(args));
+#else
+    return Module['dynCall_' + sig](ptr, ...args);
+#endif
   } else {
 #if ASSERTIONS
     assert(sig.length == 1);


### PR DESCRIPTION
Use ES6 spread syntax to micro-optimize code size (and perhaps perf) on some function calls.