### PR TITLE
Make sbrk() compatible with 2GB+ heaps

### DIFF
--- a/system/include/emscripten/heap.h
+++ b/system/include/emscripten/heap.h
@@ -22,7 +22,7 @@ intptr_t *emscripten_get_sbrk_ptr(void);
 // be overallocated, see src/settings.js variables MEMORY_GROWTH_GEOMETRIC_STEP,
 // MEMORY_GROWTH_GEOMETRIC_CAP and MEMORY_GROWTH_LINEAR_STEP. This function
 // cannot be used to shrink the size of the heap.
-int emscripten_resize_heap(size_t requested_growth_bytes);
+int emscripten_resize_heap(size_t requested_size);
 
 // Returns the current size of the WebAssembly heap.
 size_t emscripten_get_heap_size(void);

--- a/system/lib/sbrk.c
+++ b/system/lib/sbrk.c
@@ -52,16 +52,6 @@ void *sbrk(intptr_t increment) {
     intptr_t old_brk = *sbrk_ptr;
 #endif
     intptr_t new_brk = old_brk + increment;
-    // ArrayBuffers are currently limited in practice to 2GB, the size of a
-    // signed integer, because VMs do not properly support 4GB. They may not
-    // report an error when trying to allocate past that boundary, but later
-    // accessing the memory will fail on out of  bounds. So we need to guard
-    // against it here.
-    // TODO When 4GB support arrives, we'll want to add an option
-    //      to ignore this check there.
-    if ((uint32_t)new_brk > (uint32_t)INT_MAX) {
-      RETURN_ERROR();
-    }
 #ifdef __wasm__
     uintptr_t old_size = __builtin_wasm_memory_size(0) * WASM_PAGE_SIZE;
 #else

--- a/tests/code_size/hello_webgl2_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl2_fastcomp_asmjs.json
@@ -5,8 +5,8 @@
   "a.js.gz": 2508,
   "a.mem": 321,
   "a.mem.gz": 219,
-  "a.asm.js": 10579,
-  "a.asm.js.gz": 3691,
-  "total": 16833,
-  "total_gz": 6800
+  "a.asm.js": 10514,
+  "a.asm.js.gz": 3662,
+  "total": 16751,
+  "total_gz": 6771
 }

--- a/tests/code_size/hello_webgl2_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl2_fastcomp_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 5352,
   "a.js.gz": 2540,
-  "a.wasm": 8378,
-  "a.wasm.gz": 4568,
+  "a.wasm": 8364,
+  "a.wasm.gz": 4520,
   "total": 14293,
-  "total_gz": 7485
+  "total_gz": 7437
 }

--- a/tests/code_size/hello_webgl_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl_fastcomp_asmjs.json
@@ -5,8 +5,8 @@
   "a.js.gz": 2353,
   "a.mem": 321,
   "a.mem.gz": 219,
-  "a.asm.js": 10579,
-  "a.asm.js.gz": 3691,
-  "total": 16377,
-  "total_gz": 6645
+  "a.asm.js": 10514,
+  "a.asm.js.gz": 3662,
+  "total": 16295,
+  "total_gz": 6616
 }

--- a/tests/code_size/hello_webgl_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl_fastcomp_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 4844,
   "a.js.gz": 2365,
-  "a.wasm": 8378,
-  "a.wasm.gz": 4568,
-  "total": 13786,
-  "total_gz": 7310
+  "a.wasm": 8364,
+  "a.wasm.gz": 4520,
+  "total": 13785,
+  "total_gz": 7262
 }

--- a/tests/code_size/random_printf_fastcomp_asmjs.json
+++ b/tests/code_size/random_printf_fastcomp_asmjs.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 2913,
-  "a.html.gz": 1239,
-  "total": 2941,
-  "total_gz": 1239
+  "a.html": 2907,
+  "a.html.gz": 1231,
+  "total": 2913,
+  "total_gz": 1231
 }

--- a/tests/code_size/random_printf_fastcomp_wasm.json
+++ b/tests/code_size/random_printf_fastcomp_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13744,
-  "a.html.gz": 7296,
-  "total": 13772,
-  "total_gz": 7296
+  "a.html": 13704,
+  "a.html.gz": 7262,
+  "total": 13744,
+  "total_gz": 7262
 }


### PR DESCRIPTION
This just removes the restriction. The check was not actually
necessary before as we check this when growing memory anyhow.

Turns out this save some code size.

Also rename a parameter that had a misleading name which
I noticed while doing this.

This is part of a set of 3+ PRs for #6566