### PR TITLE
Ignore --llvm-lto with llvm backend

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- `--llvm-lto` flag is now ignored when using the upstream llvm backend.
+  With the upstrema backend LTO is controlled via `-flto`.
 - Require format string for emscripten_log.
 - Program entry points without extensions are now shell scripts rather than
   python programs. See #10729.  This means that `python emcc` no longer works.

--- a/emcc.py
+++ b/emcc.py
@@ -2267,15 +2267,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         force_archive_contents = all(t.endswith(STATICLIB_ENDINGS) for _, t in temp_files) or shared.Settings.LINKABLE
 
         # if  EMCC_DEBUG=2  then we must link now, so the temp files are complete.
-        # if using the wasm backend, we might be using vanilla LLVM, which does not allow our fastcomp deferred linking opts.
+        # if using the wasm backend, we might be using vanilla LLVM, which does not allow our
+        # fastcomp deferred linking opts.
         # TODO: we could check if this is a fastcomp build, and still speed things up here
         just_calculate = DEBUG != 2 and not shared.Settings.WASM_BACKEND
         if shared.Settings.WASM_BACKEND:
-          # If LTO is enabled then use the -O opt level as the LTO level
-          if options.llvm_lto:
-            lto_level = shared.Settings.OPT_LEVEL
-          else:
-            lto_level = 0
           all_externals = None
           if shared.Settings.LLD_REPORT_UNDEFINED:
             all_externals = get_all_js_library_funcs(misc_temp_files)
@@ -2283,7 +2279,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             # TODO(sbc): This is an incomplete list of __invoke functions.  Perhaps add
             # support for wildcard to wasm-ld.
             all_externals += ['emscripten_longjmp_jmpbuf', '__invoke_void', '__invoke_i32_i8*_...']
-          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, lto_level=lto_level, all_external_symbols=all_externals)
+          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, all_external_symbols=all_externals)
         else:
           final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, just_calculate=just_calculate)
       else:
@@ -2774,6 +2770,8 @@ def parse_args(newargs):
       else:
         shared.Settings.LTO = "full"
     elif newargs[i].startswith('--llvm-lto'):
+      if shared.Settings.WASM_BACKEND:
+        logger.warning('--llvm-lto ignored when using llvm backend')
       check_bad_eq(newargs[i])
       options.llvm_lto = int(newargs[i + 1])
       newargs[i] = ''

--- a/site/source/docs/compiling/WebAssembly.rst
+++ b/site/source/docs/compiling/WebAssembly.rst
@@ -61,9 +61,10 @@ upgrade from fastcomp to upstream:
 
   * You can enable LTO object files with the usual llvm compiler flags (-flto,
     -flto=full, -flto=thin, -emit-llvm).  These flags will make the wasm backend
-    behave more like fastcomp. Neither fastcomp nor the wasm backend without
-    wasm object files will run the LLVM optimization passes by default, even if
-    using LLVM IR in object files; for that you must pass ``--llvm-lto 1``.
+    behave more like fastcomp. With fastcomp LTO optimization passes will not
+    be run by default; for that you must pass ``--llvm-lto 1``.  With the llvm
+    backend LTO passes will be run on any object files that are in bitcode
+    format.
 
   * Another thing you might notice is that fastcomp's link stage is able to
     perform some types of link time optimization by default that the LLVM

--- a/site/source/docs/optimizing/Optimizing-Code.rst
+++ b/site/source/docs/optimizing/Optimizing-Code.rst
@@ -92,15 +92,22 @@ The following compiler settings can help (see ``src/settings.js`` for more detai
 LTO
 ===
 
-Link Time Optimization (LTO) lets the compiler do more optimizations, as it can inline across separate compilation units, and even with system libraries. The :ref:`main relevant flag <emcc-llvm-lto>` is ``--llvm-lto 1`` at link time.
+Link Time Optimization (LTO) lets the compiler do more optimizations, as it can
+inline across separate compilation units, and even with system libraries. For
+fastcomp the :ref:`main relevant flag <emcc-llvm-lto>` is ``--llvm-lto 1`` at
+link time.
 
-Separately from that flag, the linker must also receive LLVM bitcode files in order to run LTO on them. With fastcomp that is always the case; with the LLVM wasm backend, object files main contain either wasm or bitcode. The linker can handle a mix of the two, but can only do LTO on the bitcode files. You can control that with the following flags:
+With the LLVM wasm backend, LTO triggered by compiling objects files with
+``-flto``.  The effect of this flag is to emit LTO object files (techinically
+this means emitting bitcode).  The linker can handle a mix wasm object files
+and LTO object files.  Passing ``-flto`` at link time will also trigger LTO
+system libraries to be used.
 
-- The ``-flto`` flag tells the compiler to emit bitcode in object files, but does *not* affect system libraries.
+Thus, to allow maximal LTO opportunities with the LLVM wasm backend, build all
+source files with ``-flto`` and also link with ``flto``.
 
-Thus, to allow maximal LTO opportunities with the LLVM wasm backend, build all source files with ``-flto`` and link with ``-flto --llvm-lto 1``.
-
-Note that older versions of LLVM had bugs in this area. With the older fastcomp backend LTO should be used carefully.
+Note that older versions of LLVM had bugs in this area. With the older fastcomp
+backend LTO should be used carefully.
 
 Very large codebases
 ====================

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
@@ -1,4 +1,3 @@
 $_start
 $main
 $malloc
-$sbrk

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7105,10 +7105,10 @@ Resolved: "/" => "/"
         assert ('warning: emterpreter bytecode is fairly large' in stderr) == need_warning, stderr
         assert ('It is recommended to use  -s EMTERPRETIFY_FILE=..' in stderr) == need_warning, stderr
 
+  @no_wasm_backend("llvm-lto is fastcomp only flag")
   def test_llvm_lto(self):
     sizes = {}
-    # wasm backend doesn't have the fancy lto modes 2 and 3
-    lto_levels = [0, 1, 2, 3] if not self.is_wasm_backend() else [0, 1]
+    lto_levels = [0, 1, 2, 3]
     for lto in lto_levels:
       cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-O2', '--llvm-lto', str(lto)]
       if self.is_wasm_backend():

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1719,7 +1719,7 @@ class Building(object):
     return target
 
   @staticmethod
-  def link_lld(args, target, opts=[], lto_level=0, all_external_symbols=None):
+  def link_lld(args, target, opts=[], all_external_symbols=None):
     if not os.path.exists(WASM_LD):
       exit_with_error('linker binary not found in LLVM directory: %s', WASM_LD)
     # runs lld to link things.
@@ -1741,7 +1741,6 @@ class Building(object):
         WASM_LD,
         '-o',
         target,
-        '--lto-O%d' % lto_level,
     ] + args
 
     if all_external_symbols:


### PR DESCRIPTION
With the wasm backend LTO is triggered simply by compiling with -flto.

See: #10324