### PR TITLE
[docs] Mention upstream is the default + document table differences

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -155,7 +155,8 @@ v1.39.1: 10/30/2019
 v1.39.0: 10/18/2019
 -------------------
  - The emsdk defaults to the upstream backend (instead of fastcomp) from this
-   release onward (but both backends are still fully supported).
+   release onward (but both backends are still fully supported). See
+   https://emscripten.org/docs/compiling/WebAssembly.html#backends
  - Add support for overriding `.emscripten` config variables using environment
    variables.  Any config variable `FOO` can be overridden by `EM_FOO` in the
    environment.

--- a/site/source/docs/compiling/WebAssembly.rst
+++ b/site/source/docs/compiling/WebAssembly.rst
@@ -28,11 +28,11 @@ WebAssembly is emitted by default, without the need for any special flags.
 Backends
 --------
 
-Emscripten can currently (July 2019) use 2 backends to generate WebAssembly: **fastcomp** (the asm.js backend, together with asm2wasm) and the **upstream LLVM wasm backend**.
-
-Fastcomp is currently the default, but we hope to `switch the default soon to the upstream backend <https://v8.dev/blog/emscripten-llvm-wasm>`_.
-
-To use fastcomp, just use the emsdk normally to get ``latest``. For the upstream backend, use ``latest-upstream`` (or, if you are not using the emsdk, you can set LLVM in the ``.emscripten`` file to point to a build you make of very recent LLVM - preferably from git/svn master).
+Emscripten emits WebAssembly using the **upstream LLVM wasm backend**, since
+version ``1.39.0`` (October 2019), and the old **fastcomp** backend is
+deprecated (you can still use the deprecated fastcomp backend by getting
+``latest-fastcomp`` instead of the normal ``latest``, or ``1.39.0-fastcomp``
+instead of ``1.39.0``, etc.).
 
 There are some differences you may notice between the two backends, if you
 upgrade from fastcomp to upstream:
@@ -79,6 +79,11 @@ upgrade from fastcomp to upstream:
   format and cannot create archive indexes.  In particular, if you run GNU
   `strip` on an archive file that contains WebAssembly object files it will
   remove the index which makes the archive unusable at link time.
+
+* Fastcomp emits asm.js and so has some limitations on function pointers. For
+  example, the ``RESERVED_FUNCTION_POINTERS`` setting exists there to work
+  around the fact that we can't grow the table. In the upstream backend table
+  growth is easy, and you can just enable ``ALLOW_TABLE_GROWTH``.
 
 * Also see the `blocker bugs on the wasm backend <https://github.com/emscripten-core/emscripten/projects/1>`_, and the `wasm backend tagged issues <https://github.com/emscripten-core/emscripten/issues?utf8=✓&q=is%3Aissue+is%3Aopen+label%3A"LLVM+wasm+backend">`_.
 

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -104,7 +104,11 @@ function addFunctionWasm(func, sig) {
     if (!(err instanceof RangeError)) {
       throw err;
     }
+#if WASM_BACKEND
+    throw 'Unable to grow wasm table. Set ALLOW_TABLE_GROWTH.';
+#else
     throw 'Unable to grow wasm table. Use a higher value for RESERVED_FUNCTION_POINTERS or set ALLOW_TABLE_GROWTH.';
+#endif
   }
 
   // Insert new element

--- a/src/settings.js
+++ b/src/settings.js
@@ -310,6 +310,7 @@ var SAFE_HEAP_LOG = 0;
 // In asm.js mode, we cannot simply add function pointers to function tables, so
 // we reserve some slots for them. An alternative to this is to use
 // EMULATED_FUNCTION_POINTERS, in which case we don't need to reserve.
+// [fastcomp-only]
 var RESERVED_FUNCTION_POINTERS = 0;
 
 // Whether to allow function pointers to alias if they have a different type.


### PR DESCRIPTION
Specifically, `RESERVED_FUNCTION_POINTERS` is not needed
in upstream (since unlike asm.js, wasm tables can just grow). Fix
the error message for that.

Fixes https://github.com/emscripten-core/emsdk/issues/446

Also link to the differences doc from the changelog.
