### PR TITLE
Make can_build/can_use respect class hierarchy

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -810,7 +810,7 @@ class libc_wasm(MuslInternalLibrary):
 
   def can_use(self):
     # if building to wasm, we need more math code, since we have fewer builtins
-    return shared.Settings.WASM
+    return super(libc_wasm, self).can_use() or shared.Settings.WASM
 
 
 class crt1(MuslInternalLibrary):
@@ -825,10 +825,10 @@ class crt1(MuslInternalLibrary):
     return '.o'
 
   def can_use(self):
-    return shared.Settings.STANDALONE_WASM
+    return super(crt1, self).can_use() or shared.Settings.STANDALONE_WASM
 
   def can_build(self):
-    return shared.Settings.WASM_BACKEND
+    return super(crt1, self).can_build() or shared.Settings.WASM_BACKEND
 
 
 class libc_extras(MuslInternalLibrary):
@@ -842,7 +842,8 @@ class libc_extras(MuslInternalLibrary):
   src_files = ['extras_fastcomp.c']
 
   def can_build(self):
-    return not shared.Settings.WASM_BACKEND
+    return super(libc_extras, self).can_build() or \
+           not shared.Settings.WASM_BACKEND
 
 
 class libcxxabi(CXXLibrary, NoExceptLibrary, MTLibrary):
@@ -995,7 +996,7 @@ class libmalloc(MTLibrary, NoBCLibrary):
     return name
 
   def can_use(self):
-    return shared.Settings.MALLOC != 'none'
+    return super(libmalloc, self).can_use() or shared.Settings.MALLOC != 'none'
 
   @classmethod
   def vary_on(cls):
@@ -1211,7 +1212,8 @@ class CompilerRTWasmLibrary(Library):
   force_object_files = True
 
   def can_build(self):
-    return shared.Settings.WASM_BACKEND
+    return super(CompilerRTWasmLibrary, self).can_build() or \
+           shared.Settings.WASM_BACKEND
 
 
 class libc_rt_wasm(AsanInstrumentedLibrary, CompilerRTWasmLibrary, MuslInternalLibrary):
@@ -1354,7 +1356,8 @@ class libstandalonewasm(MuslInternalLibrary):
     return base_files + time_files + exit_files + conf_files
 
   def can_build(self):
-    return shared.Settings.WASM_BACKEND
+    return super(libstandalonewasm, self).can_build() or \
+           shared.Settings.WASM_BACKEND
 
 
 # If main() is not in EXPORTED_FUNCTIONS, it may be dce'd out. This can be

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -810,7 +810,7 @@ class libc_wasm(MuslInternalLibrary):
 
   def can_use(self):
     # if building to wasm, we need more math code, since we have fewer builtins
-    return super(libc_wasm, self).can_use() or shared.Settings.WASM
+    return super(libc_wasm, self).can_use() and shared.Settings.WASM
 
 
 class crt1(MuslInternalLibrary):
@@ -825,10 +825,10 @@ class crt1(MuslInternalLibrary):
     return '.o'
 
   def can_use(self):
-    return super(crt1, self).can_use() or shared.Settings.STANDALONE_WASM
+    return super(crt1, self).can_use() and shared.Settings.STANDALONE_WASM
 
   def can_build(self):
-    return super(crt1, self).can_build() or shared.Settings.WASM_BACKEND
+    return super(crt1, self).can_build() and shared.Settings.WASM_BACKEND
 
 
 class libc_extras(MuslInternalLibrary):
@@ -842,8 +842,7 @@ class libc_extras(MuslInternalLibrary):
   src_files = ['extras_fastcomp.c']
 
   def can_build(self):
-    return super(libc_extras, self).can_build() or \
-           not shared.Settings.WASM_BACKEND
+    return super(libc_extras, self).can_build() and not shared.Settings.WASM_BACKEND
 
 
 class libcxxabi(CXXLibrary, NoExceptLibrary, MTLibrary):
@@ -996,7 +995,7 @@ class libmalloc(MTLibrary, NoBCLibrary):
     return name
 
   def can_use(self):
-    return super(libmalloc, self).can_use() or shared.Settings.MALLOC != 'none'
+    return super(libmalloc, self).can_use() and shared.Settings.MALLOC != 'none'
 
   @classmethod
   def vary_on(cls):
@@ -1212,8 +1211,7 @@ class CompilerRTWasmLibrary(Library):
   force_object_files = True
 
   def can_build(self):
-    return super(CompilerRTWasmLibrary, self).can_build() or \
-           shared.Settings.WASM_BACKEND
+    return super(CompilerRTWasmLibrary, self).can_build() and shared.Settings.WASM_BACKEND
 
 
 class libc_rt_wasm(AsanInstrumentedLibrary, CompilerRTWasmLibrary, MuslInternalLibrary):
@@ -1356,8 +1354,7 @@ class libstandalonewasm(MuslInternalLibrary):
     return base_files + time_files + exit_files + conf_files
 
   def can_build(self):
-    return super(libstandalonewasm, self).can_build() or \
-           shared.Settings.WASM_BACKEND
+    return super(libstandalonewasm, self).can_build() and shared.Settings.WASM_BACKEND
 
 
 # If main() is not in EXPORTED_FUNCTIONS, it may be dce'd out. This can be


### PR DESCRIPTION
This adds check for its superclass for all overridden methods of
`Library.can_build` and `Library.can_use`. Currently this is NFC because
there is no middle-level class that also override those functions, but
it's safe to do this anyway considering possible future modifications.