### PR TITLE
WebGL: Fix memory leak.

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -998,7 +998,7 @@ var LibraryGL = {
       if (GL.currentContext === GL.contexts[contextHandle]) GL.currentContext = null;
       if (typeof JSEvents === 'object') JSEvents.removeAllHandlersOnTarget(GL.contexts[contextHandle].GLctx.canvas); // Release all JS event handlers on the DOM element that the GL context is associated with since the context is now deleted.
       if (GL.contexts[contextHandle] && GL.contexts[contextHandle].GLctx.canvas) GL.contexts[contextHandle].GLctx.canvas.GLctxObject = undefined; // Make sure the canvas object no longer refers to the context object so there are no GC surprises.
-      _free(GL.contexts[contextHandle]);
+      _free(GL.contexts[contextHandle].handle);
       GL.contexts[contextHandle] = null;
     },
 


### PR DESCRIPTION
There is a bit of memory allocated for bookkeeping info in registerContext:

    var handle = _malloc(8);
    var context = {
        handle: handle,
        attributes: webGLContextAttributes,
        version: webGLContextAttributes.majorVersion,
        GLctx: ctx
    };
    GL.contexts[handle] = context;

But in deleteContext, it was doing this:

    _free(GL.contexts[contextHandle]);

But the allocated value was being stored in the `handle` member,
so we need to free that, not the overall context value.