### PR TITLE
Refactor WarningManager. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1117,7 +1117,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.STRICT = int(strict_cmdline.split('=', 1)[1])
 
     if options.separate_asm and final_suffix != '.html':
-      shared.WarningManager.warn('SEPARATE_ASM')
+      shared.WarningManager.warn('separate-asm', "--separate-asm works best when compiling to HTML.  Otherwise, you must yourself load the '.asm.js' file that is emitted separately, and must do so before loading the main '.js' file.")
 
     # Apply optimization level settings
     shared.Settings.apply_opt_level(opt_level=options.opt_level, shrink_level=options.shrink_level, noisy=True)
@@ -1204,7 +1204,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # when we emit asm.js, closure 2 would break that, so warn (note that
       # with wasm2js in the wasm backend, we don't emit asm.js anyhow)
       if options.use_closure_compiler == 2 and shared.Settings.ASM_JS == 1 and not shared.Settings.WASM_BACKEND:
-        shared.WarningManager.warn('ALMOST_ASM', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
+        shared.WarningManager.warn('almost-asm', 'not all asm.js optimizations are possible with --closure 2, disabling those - your code will be run more slowly')
         shared.Settings.ASM_JS = 2
 
     if shared.Settings.CLOSURE_WARNINGS not in ['quiet', 'warn', 'error']:
@@ -1929,8 +1929,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.ASM_JS == 1:
       # this is an issue in asm.js, but not wasm
       if not shared.Settings.WASM:
-        shared.WarningManager.warn('ALMOST_ASM')
-        shared.Settings.ASM_JS = 2 # memory growth does not validate as asm.js http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
+        # memory growth does not validate as asm.js
+        # http://discourse.wicg.io/t/request-for-comments-switching-resizing-heaps-in-asm-js/641/23
+        shared.WarningManager.warn('almost-asm', 'not all asm.js optimizations are possible with ALLOW_MEMORY_GROWTH, disabling those.')
+        shared.Settings.ASM_JS = 2
 
     if shared.Settings.NODE_CODE_CACHING:
       if shared.Settings.WASM_ASYNC_COMPILATION:
@@ -2954,7 +2956,7 @@ def parse_args(newargs):
         # that are e.g. x86 specific and nonportable. The emscripten bundled
         # headers are modified to be portable, local system ones are generally not.
         shared.WarningManager.warn(
-            'ABSOLUTE_PATHS', '-I or -L of an absolute path "' + newargs[i] +
+            'absolute-paths', '-I or -L of an absolute path "' + newargs[i] +
             '" encountered. If this is to a local system header/library, it may '
             'cause problems (local system files make sense for compiling natively '
             'on your system, but not necessarily to JavaScript).')

--- a/emscripten.py
+++ b/emscripten.py
@@ -683,7 +683,7 @@ def update_settings_glue(metadata, DEBUG):
     shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
 
   if metadata.get('cantValidate') and shared.Settings.ASM_JS != 2:
-    shared.WarningManager.warn('ALMOST_ASM', 'disabling asm.js validation due to use of non-supported features: ' + metadata['cantValidate'])
+    shared.WarningManager.warn('almost-asm', 'disabling asm.js validation due to use of non-supported features: ' + metadata['cantValidate'])
     shared.Settings.ASM_JS = 2
 
   all_funcs = shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE + [shared.JS.to_nice_ident(d) for d in metadata['declares']]
@@ -695,7 +695,7 @@ def update_settings_glue(metadata, DEBUG):
   if metadata['simd']:
     shared.Settings.SIMD = 1
     if shared.Settings.ASM_JS != 2:
-      shared.WarningManager.warn('ALMOST_ASM', 'disabling asm.js validation due to use of SIMD')
+      shared.WarningManager.warn('almost-asm', 'disabling asm.js validation due to use of SIMD')
       shared.Settings.ASM_JS = 2
 
   shared.Settings.MAX_GLOBAL_ALIGN = metadata['maxGlobalAlign']

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3812,19 +3812,19 @@ int main()
   def test_valid_abspath(self):
     # Test whether abspath warning appears
     abs_include_path = os.path.abspath(self.get_dir())
-    err = run_process([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE).stderr
+    err = run_process([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
     warning = '-I or -L of an absolute path "-I%s" encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript).' % abs_include_path
-    assert(warning in err)
+    self.assertContained(warning, err)
 
     # Passing an absolute path to a directory inside the emscripten tree is always ok and should not issue a warning.
     abs_include_path = path_from_root('tests')
-    err = run_process([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE).stderr
+    err = run_process([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
     warning = '-I or -L of an absolute path "-I%s" encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript).' % abs_include_path
-    assert(warning not in err)
+    self.assertNotContained(warning, err)
 
     # Hide warning for this include path
-    err = run_process([PYTHON, EMCC, '--valid-abspath', abs_include_path, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stdout=PIPE, stderr=PIPE).stderr
-    assert(warning not in err)
+    err = run_process([PYTHON, EMCC, '--valid-abspath', abs_include_path, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
+    self.assertNotContained(warning, err)
 
   def test_valid_abspath_2(self):
     if WINDOWS:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -753,20 +753,17 @@ def get_canonical_temp_dir(temp_dir):
 
 class WarningManager(object):
   warnings = {
-    'ABSOLUTE_PATHS': {
+    'absolute-paths': {
       'enabled': False,  # warning about absolute-paths is disabled by default
       'printed': False,
-      'message': '-I or -L of an absolute path encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript).',
     },
-    'SEPARATE_ASM': {
+    'separate-asm': {
       'enabled': True,
       'printed': False,
-      'message': "--separate-asm works best when compiling to HTML. Otherwise, you must yourself load the '.asm.js' file that is emitted separately, and must do so before loading the main '.js' file.",
     },
-    'ALMOST_ASM': {
+    'almost-asm': {
       'enabled': True,
       'printed': False,
-      'message': 'not all asm.js optimizations are possible with ALLOW_MEMORY_GROWTH, disabling those.',
     },
   }
 
@@ -776,32 +773,25 @@ class WarningManager(object):
       if not cmd_args[i].startswith('-W'):
         continue
 
-      # special case pre-existing warn-absolute-paths
-      if cmd_args[i] == '-Wwarn-absolute-paths':
-        cmd_args[i] = ''
-        WarningManager.warnings['ABSOLUTE_PATHS']['enabled'] = True
-      elif cmd_args[i] == '-Wno-warn-absolute-paths':
-        cmd_args[i] = ''
-        WarningManager.warnings['ABSOLUTE_PATHS']['enabled'] = False
-      else:
-        # convert to string representation of Warning
-        warning_enum = cmd_args[i].replace('-Wno-', '').replace('-W', '')
-        warning_enum = warning_enum.upper().replace('-', '_')
+      warning_name = cmd_args[i].replace('-Wno-', '').replace('-W', '')
+      enabled = not cmd_args[i].startswith('-Wno-')
 
-        if warning_enum in WarningManager.warnings:
-          WarningManager.warnings[warning_enum]['enabled'] = not cmd_args[i].startswith('-Wno-')
-          cmd_args[i] = ''
+      # special case pre-existing warn-absolute-paths
+      if warning_name == 'warn-absolute-paths':
+        WarningManager.warnings['absolute-paths']['enabled'] = enabled
+        cmd_args[i] = ''
+      elif warning_name in WarningManager.warnings:
+        WarningManager.warnings[warning_name]['enabled'] = enabled
+        cmd_args[i] = ''
 
     return cmd_args
 
   @staticmethod
-  def warn(warning_type, message=None):
+  def warn(warning_type, message, *args):
     warning_info = WarningManager.warnings[warning_type]
     if warning_info['enabled'] and not warning_info['printed']:
       warning_info['printed'] = True
-      if message is None:
-        message = warning_info['message']
-      warning(message + ' [-W' + warning_type.lower().replace('_', '-') + ']')
+      warning((message % args) + ' [-W' + warning_type.lower().replace('_', '-') + ']')
 
 
 class Configuration(object):


### PR DESCRIPTION
Use the actual command line warnings names as the settings keys to make
it easier to grep for usage of, say `separate-asm` in the codebase.
This simplifies the code too.

Force all call sites to pass thier own message.  There was no use of the
shared messages within the codebase and having the error messages live
near the error site makes the code easier to navigate.

Both this changes were made in preparation for adding a new controllable
warning regarding the use of legacy settings.