### PR TITLE
Continue to support WASM_OBJECT_FILES (for now)

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -400,9 +400,6 @@ def apply_settings(changes):
     if key.startswith('NO_') and value in ('0', '1'):
       key = key[3:]
       value = str(1 - int(value))
-    # map legacy settings which have aliases to the new names
-    if key in shared.Settings.legacy_settings and key in shared.Settings.alt_names:
-      key = shared.Settings.alt_names[key]
     return key, value
 
   for change in changes:
@@ -412,9 +409,14 @@ def apply_settings(changes):
     if key in shared.Settings.internal_settings:
       exit_with_error('%s is an internal setting and cannot be set from command line', key)
 
+    if key in shared.Settings.legacy_settings and key in shared.Settings.alt_names:
+      actual_key = shared.Settings.alt_names[key]
+    else:
+      actual_key = key
+
     # In those settings fields that represent amount of memory, translate suffixes to multiples of 1024.
-    if key in ('TOTAL_STACK', 'INITIAL_MEMORY', 'MEMORY_GROWTH_LINEAR_STEP', 'MEMORY_GROWTH_GEOMETRIC_STEP',
-               'GL_MAX_TEMP_BUFFER_SIZE', 'MAXIMUM_MEMORY', 'DEFAULT_PTHREAD_STACK_SIZE'):
+    if actual_key in ('TOTAL_STACK', 'INITIAL_MEMORY', 'MEMORY_GROWTH_LINEAR_STEP', 'MEMORY_GROWTH_GEOMETRIC_STEP',
+                      'GL_MAX_TEMP_BUFFER_SIZE', 'MAXIMUM_MEMORY', 'DEFAULT_PTHREAD_STACK_SIZE'):
       value = str(shared.expand_byte_size_suffixes(value))
 
     if value[0] == '@':

--- a/emcc.py
+++ b/emcc.py
@@ -1129,6 +1129,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
       shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
 
+    # TODO(sbc): Remove this legacy way of selecting bitcode object files.
+    if 'WASM_OBJECT_FILES=0' in settings_changes:
+      shared.Settings.LTO = "full"
+
     if shared.Settings.MINIMAL_RUNTIME or 'MINIMAL_RUNTIME=1' in settings_changes or 'MINIMAL_RUNTIME=2' in settings_changes:
       # Remove the default exported functions 'malloc', 'free', etc. those should only be linked in if used
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []

--- a/src/settings.js
+++ b/src/settings.js
@@ -1794,7 +1794,7 @@ var LEGACY_SETTINGS = [
   ['SKIP_STACK_IN_SMALL', [0, 1], 'SKIP_STACK_IN_SMALL is no longer needed as the backend can optimize it directly'],
   ['SAFE_STACK', [0], 'Replace SAFE_STACK=1 with STACK_OVERFLOW_CHECK=2'],
   ['MEMORY_GROWTH_STEP', 'MEMORY_GROWTH_LINEAR_STEP'],
-  ['WASM_OBJECT_FILES', [1], 'Use -flto or -fto=thin instead'],
+  ['WASM_OBJECT_FILES', [0, 1], 'Use -flto or -fto=thin instead'],
   ['TOTAL_MEMORY', 'INITIAL_MEMORY'],
   ['WASM_MEM_MAX', 'MAXIMUM_MEMORY'],
   ['BINARYEN_MEM_MAX', 'MAXIMUM_MEMORY'],

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9787,6 +9787,22 @@ int main () {
     with env_modify({'EMCC_STRICT': '1'}):
       self.do_run(open(path_from_root('tests', 'hello_world.c')).read(), 'hello, world!')
 
+  def test_legacy_settings(self):
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'SPLIT_MEMORY=0']
+
+    # By default warnings are not shown
+    stderr = run_process(cmd, stderr=PIPE).stderr
+    self.assertNotContained('WARNING', stderr)
+
+    # Adding -Wall or -Wlegacy-settings enables the warning
+    stderr = run_process(cmd + ['-Wall'], stderr=PIPE).stderr
+    self.assertContained('WARNING: use of legacy setting: SPLIT_MEMORY', stderr)
+    self.assertContained('[-Wlegacy-settings]', stderr)
+
+    stderr = run_process(cmd + ['-Wlegacy-settings'], stderr=PIPE).stderr
+    self.assertContained('WARNING: use of legacy setting: SPLIT_MEMORY', stderr)
+    self.assertContained('[-Wlegacy-settings]', stderr)
+
   def test_strict_mode_legacy_settings(self):
     cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'SPLIT_MEMORY=0']
     run_process(cmd)
@@ -9817,7 +9833,7 @@ int main () {
     self.set_setting('STRICT', 1)
     self.do_run(src, 'invalid compiler setting: BINARYEN_METHOD')
 
-  def test_strict_mode_renamed_setting(self):
+  def test_renamed_setting(self):
     # Verify that renamed settings are available by either name (when not in
     # strict mode.
     self.set_setting('RETAIN_COMPILER_SETTINGS', 1)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -827,6 +827,8 @@ WarningManager.add_warning('absolute-paths', enabled=False, part_of_all=False)
 WarningManager.add_warning('separate-asm')
 WarningManager.add_warning('almost-asm')
 WarningManager.add_warning('invalid-input')
+# Don't show lecacy settings warnings by default
+WarningManager.add_warning('legacy-settings', enabled=False)
 
 
 class Configuration(object):
@@ -1166,13 +1168,14 @@ class SettingsManager(object):
           self.attrs.pop(a, None)
 
       if attr in self.legacy_settings:
+        # TODO(sbc): Rather then special case this we should have STRICT turn on the
+        # legacy-settings warning below
         if self.attrs['STRICT']:
           exit_with_error('legacy setting used in strict mode: %s', attr)
         fixed_values, error_message = self.legacy_settings[attr]
         if fixed_values and value not in fixed_values:
           exit_with_error('Invalid command line option -s ' + attr + '=' + str(value) + ': ' + error_message)
-        else:
-          logger.debug('Option -s ' + attr + '=' + str(value) + ' has been removed from the codebase. (' + error_message + ')')
+        WarningManager.warn('legacy-settings', 'use of legacy setting: %s (%s)', attr, error_message)
 
       if attr in self.alt_names:
         alt_name = self.alt_names[attr]


### PR DESCRIPTION
At least for a couple of releases we should continue to support this
legacy setting.