### PR TITLE
Disable other.test_node_js_system on windows for now, as it broke on the roller

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9152,6 +9152,7 @@ test_module().then((test_module_instance) => {
     ret = run_process(NODE_JS + ['--experimental-wasm-threads'] + [os.path.join('subdir', moduleLoader)], stdout=PIPE).stdout
     self.assertContained('hello, world!', ret)
 
+  @no_windows('node system() does not seem to work, see https://github.com/emscripten-core/emscripten/pull/10547')
   def test_node_js_system(self):
     run_process([PYTHON, EMCC, '-DENV_NODE', path_from_root('tests', 'system.c'), '-o', 'a.js', '-O3'])
     ret = run_process(NODE_JS + ['a.js'], stdout=PIPE).stdout


### PR DESCRIPTION
See #10547