### PR TITLE
Support += in emcc.py -s notation: -s KEY+=[val1, val2] appends to the default

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -940,7 +940,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           newargs[i] = newargs[i + 1] = ''
           if arg == 'WASM_BACKEND=1':
             exit_with_error('do not set -s WASM_BACKEND, instead set EMCC_WASM_BACKEND=1 in the environment')
-    newargs = [arg for arg in newargs if arg]
+    newargs = [a for a in newargs if a]
 
     settings_key_changes = set()
     for s in settings_changes:

--- a/emcc.py
+++ b/emcc.py
@@ -944,7 +944,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     settings_key_changes = set()
     for s in settings_changes:
-      key, _ = s.split('=', 1)
+      key, arg = s.split('=', 1)
       settings_key_changes.add(key)
 
     # Find input files

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7183,6 +7183,19 @@ Resolved: "/" => "/"
     err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY=[Value1, \"Value2\"]"])
     self.assertNotContained('a problem occured in evaluating the content after a "-s", specifically', err)
 
+  def test_dash_s_plus_equals(self):
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "EXPORTED_FUNCTIONS+=[]"])
+    self.assertContained('hello, world!', run_js('a.out.js'))
+    # check that we can append properly. the commands below will error if an
+    # exported function is not present, so success shows we parsed it ok.
+    create_test_file('test.c', r'''
+      int main() {}
+      void foo() {}
+    ''')
+    run_process([PYTHON, EMCC, 'test.c', "-s", "EXPORTED_FUNCTIONS+=[_foo]"])
+    run_process([PYTHON, EMCC, 'test.c', "-s", "EXPORTED_FUNCTIONS+=['_foo']"])
+    self.expect_fail([PYTHON, EMCC, 'test.c', "-s", "EXPORTED_FUNCTIONS+=['_bar']"])
+
   def test_python_2_3(self):
     # check emcc/em++ can be called by any python
     def trim_py_suffix(filename):


### PR DESCRIPTION
This is useful for settings like `EXPORTED_FUNCTIONS`, the
asyncify lists, etc., where the user may want to just add more
but not remove the existing defaults.

If people like this idea perhaps we can replace the `EXTRA_*`
settings with this.