### PR TITLE
fix(nodefs): renamed files exists with old name

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -184,6 +184,7 @@ mergeInto(LibraryManager.library, {
           if (!e.code) throw e;
           throw new FS.ErrnoError(NODEFS.convertNodeCode(e));
         }
+        oldNode.name = newName;
       },
       unlink: function(parent, name) {
         var path = PATH.join2(NODEFS.realPath(parent), name);

--- a/tests/unistd/access.c
+++ b/tests/unistd/access.c
@@ -52,6 +52,17 @@ int main() {
     printf("\n");
   }
 
+  EM_ASM({FS.writeFile('filetorename',  'renametest');});
+  
+  rename("filetorename", "renamedfile");
+
+  errno = 0;
+  printf("F_OK(%s): %d\n", "filetorename", access("filetorename", F_OK));
+  printf("errno: %d\n", errno);
+  errno = 0;
+  printf("F_OK(%s): %d\n", "renamedfile", access("renamedfile", F_OK));
+  printf("errno: %d\n", errno);
+
 #ifndef __EMSCRIPTEN_ASMFS__
   // Restore full permissions on all created files so that python test runner rmtree
   // won't have problems on deleting the files. On Windows, calling shutil.rmtree()

--- a/tests/unistd/access.out
+++ b/tests/unistd/access.out
@@ -52,3 +52,7 @@ errno: 44
 W_OK(): -1
 errno: 44
 
+F_OK(filetorename): -1
+errno: 44
+F_OK(renamedfile): 0
+errno: 0


### PR DESCRIPTION
nodefs renames the file in the filesystem, but does not change the `name` property in the file node.

fixes #10628