### PR TITLE
Temporarily disable test_emar_response_file on windows

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8716,7 +8716,12 @@ end
     create_test_file('file1', ' ')
     run_process([PYTHON, EMAR, 'cr', 'file1.a', 'file1', 'file1'])
 
+  # Temporarily disabled to allow this llvm change to roll
+  # https://reviews.llvm.org/D69665
+  @no_windows('Temporarily disabled under windows')
   def test_emar_response_file(self):
+    # Test that special character such as single quotes in filenames survive being
+    # sent via response file
     create_test_file("file'1", ' ')
     create_test_file("file'2", ' ')
     Building.emar('cr', 'libfoo.a', ("file'1", "file'2"))


### PR DESCRIPTION
There was an LLVM change to llvm-ar that is currently blocked
on this test failing: https://reviews.llvm.org/D69665

In the long run we need to decide if we want to support two different
quoting styles when generating out response files, or we need to start
passing --rsp-quoting=gnu.