### PR TITLE
Asyncify: Add an assertion + docs for rewinding with compiled code on the stack

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -39,6 +39,8 @@ Current Trunk
   EmscriptenWebGLContextAttributes::powerPreference instead. (#10505)
 - When implementing forwarding function aliases in JS libraries, either the
   alias or the target function must contain a signature annotation. (#10550)
+- Add an check in Asyncify builds with `ASSERTIONS` that we do not have
+  compiled code on the stack when starting to rewind, which is dangerous.
 
 v1.39.8: 02/14/2020
 -------------------

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -286,6 +286,19 @@ if a function uses a global and assumes nothing else can modify it until it
 returns, but if that function sleeps and an event causes other code to
 change that global, then bad things can happen.
 
+Starting to rewind with compiled code on the stack
+**************************************************
+
+The examples above show `wakeUp()` being called from JS (after a callback,
+typically), and without any compiled code on the stack. If there *were* compiled
+code on the stack, then that could interfere with properly rewinding and
+resuming execution, in confusing ways, and therefore an assertion will be
+thrown in a build with ``ASSERTIONS``.
+
+Specifically, the problem there is that while rewinding will work properly,
+if you later unwind again, that unwinding will also unwind through that extra
+compiled code that was on the stack - causing a later rewind to behave badly.
+
 Migrating from older APIs
 #########################
 

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -295,9 +295,13 @@ code on the stack, then that could interfere with properly rewinding and
 resuming execution, in confusing ways, and therefore an assertion will be
 thrown in a build with ``ASSERTIONS``.
 
-Specifically, the problem there is that while rewinding will work properly,
+(Specifically, the problem there is that while rewinding will work properly,
 if you later unwind again, that unwinding will also unwind through that extra
-compiled code that was on the stack - causing a later rewind to behave badly.
+compiled code that was on the stack - causing a later rewind to behave badly.)
+
+A simple workaround you may find useful is to do a setTimeout of 0, replacing
+``wakeUp()`` with ``setTimeout(wakeUp, 0);``. That will run ``wakeUp`` in a
+later callback, when nothing else is on the stack.
 
 Migrating from older APIs
 #########################

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -758,6 +758,9 @@ mergeInto(LibraryManager.library, {
           assert(!handleSleepReturnValue || typeof handleSleepReturnValue === 'number'); // old emterpretify API supported other stuff
 #endif
           if (ABORT) return;
+#if ASSERTIONS
+          assert(!Asyncify.exportCallStack.length, 'Waking up (starting to rewind) must be done from JS, without compiled code on the stack.');
+#endif
           Asyncify.handleSleepReturnValue = handleSleepReturnValue || 0;
           reachedCallback = true;
           if (!reachedAfterCallback) {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -758,15 +758,20 @@ mergeInto(LibraryManager.library, {
           assert(!handleSleepReturnValue || typeof handleSleepReturnValue === 'number'); // old emterpretify API supported other stuff
 #endif
           if (ABORT) return;
-#if ASSERTIONS
-          assert(!Asyncify.exportCallStack.length, 'Waking up (starting to rewind) must be done from JS, without compiled code on the stack.');
-#endif
           Asyncify.handleSleepReturnValue = handleSleepReturnValue || 0;
           reachedCallback = true;
           if (!reachedAfterCallback) {
             // We are happening synchronously, so no need for async.
             return;
           }
+#if ASSERTIONS
+          // This async operation did not happen synchronously, so we did
+          // unwind. In that case there can be no compiled code on the stack,
+          // as it might break later operations (we can rewind ok now, but if
+          // we unwind again, we would unwind through the extra compiled code
+          // too).
+          assert(!Asyncify.exportCallStack.length, 'Waking up (starting to rewind) must be done from JS, without compiled code on the stack.');
+#endif
 #if ASYNCIFY_DEBUG
           err('ASYNCIFY: start rewind ' + Asyncify.currData);
 #endif

--- a/tests/core/asyncify_assertions.cpp
+++ b/tests/core/asyncify_assertions.cpp
@@ -1,0 +1,37 @@
+#include <stdio.h>
+#include <emscripten.h>
+
+extern "C" {
+
+EM_JS(void, suspend, (), {
+  return Asyncify.handleSleep(function(wakeUp) {
+    Module.resume = wakeUp;
+    setTimeout(function() {
+      Module._resume_from_inside_c();
+    }, 1);
+  });
+});
+
+EM_JS(void, resume, (), {
+  Module.resume();
+});
+
+EMSCRIPTEN_KEEPALIVE
+void resume_from_inside_c() {
+  // A C function that then resumes. This C code will be on the stack as we
+  // try to resume, but that is invalid - we need to start a resume from the
+  // *outside* of the wasm module. An assertion should catch this.
+  resume();
+}
+
+int main() {
+  printf("suspend\n");
+  suspend();
+  suspend();
+  suspend();
+  suspend();
+  suspend();
+  printf("finish\n");
+}
+
+}

--- a/tests/core/asyncify_assertions.txt
+++ b/tests/core/asyncify_assertions.txt
@@ -1,0 +1,1 @@
+Assertion failed: Waking up (starting to rewind) must be done from JS, without compiled code on the stack.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1333,7 +1333,7 @@ keydown(100);keyup(100); // trigger the end
   def test_fs_memfs_fsync(self):
     args = self.get_async_args() + ['-s', 'EXIT_RUNTIME=1']
     secret = str(time.time())
-    self.btest(path_from_root('tests', 'fs', 'test_memfs_fsync.c'), '1', force_c=True, args=args + ['-DSECRET=\"' + secret + '\"', '-s', '''EXPORTED_FUNCTIONS=['_main']'''])
+    self.btest(path_from_root('tests', 'fs', 'test_memfs_fsync.c'), '1', force_c=True, args=args + ['-DSECRET=\"' + secret + '\"'])
 
   def test_fs_workerfs_read(self):
     secret = 'a' * 10

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8118,6 +8118,13 @@ extern "C" {
     self.do_run_in_out_file_test('tests', 'core', 'emscripten_scan_registers')
 
   @no_fastcomp('wasm-backend specific feature')
+  def test_asyncify_assertions(self):
+    self.set_setting('ASYNCIFY', 1)
+    self.set_setting('ASYNCIFY_IMPORTS', ['suspend'])
+    self.set_setting('ASSERTIONS', 1)
+    self.do_run_in_out_file_test('tests', 'core', 'asyncify_assertions')
+
+  @no_fastcomp('wasm-backend specific feature')
   @no_wasm2js('TODO: lazy loading in wasm2js')
   @parameterized({
     'conditional': (True,),


### PR DESCRIPTION
Specifically, the problem there is that while rewinding will work properly,
if you later unwind again, that unwinding will also unwind through that extra
compiled code that was on the stack - causing a later rewind to behave badly.

This should avoid problems like the one mentioned in #10515 .