### PR TITLE
Only deprecate WASM_OBJECT_FILES; don't remove it entirely yet

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,7 +32,7 @@ Current Trunk
 - Removed src/library_vr.js, as it was outdated and nonfunctional, and the WebVR
   specification has been obsoleted in favor of the upcoming WebXR specification.
   (#10460)
-- Remove WASM_OBJECT_FILES setting.  There are many standard ways to enable
+- Deprecate WASM_OBJECT_FILES setting.  There are many standard ways to enable
   bitcode abjects (-flto, -flto=full, -flto=thin, -emit-llvm).
 - Removed EmscriptenWebGLContextAttributes::preferLowPowerToHighPerformance
   option that has become unsupported by WebGL. Access

--- a/emcc.py
+++ b/emcc.py
@@ -435,6 +435,10 @@ def apply_settings(changes):
       # used for warnings in emscripten.py
       shared.Settings.USER_EXPORTED_FUNCTIONS = shared.Settings.EXPORTED_FUNCTIONS[:]
 
+    # TODO(sbc): Remove this legacy way.
+    if key == 'WASM_OBJECT_FILES':
+      shared.Settings.LTO = 0 if value else 'full'
+
 
 def find_output_arg(args):
   """Find and remove any -o arguments.  The final one takes precedence.
@@ -1126,10 +1130,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
     if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
       shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
-
-    # TODO(sbc): Remove this legacy way.
-    if 'WASM_OBJECT_FILES=0' in settings_changes:
-      shared.Settings.LTO = 'full'
 
     if shared.Settings.MINIMAL_RUNTIME or 'MINIMAL_RUNTIME=1' in settings_changes or 'MINIMAL_RUNTIME=2' in settings_changes:
       # Remove the default exported functions 'malloc', 'free', etc. those should only be linked in if used

--- a/emcc.py
+++ b/emcc.py
@@ -1127,6 +1127,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if 'WARN_ON_UNDEFINED_SYMBOLS=0' in settings_changes:
       shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
 
+    # TODO(sbc): Remove this legacy way.
+    if 'WASM_OBJECT_FILES=0' in settings_changes:
+      shared.Settings.LTO = 'full'
+
     if shared.Settings.MINIMAL_RUNTIME or 'MINIMAL_RUNTIME=1' in settings_changes or 'MINIMAL_RUNTIME=2' in settings_changes:
       # Remove the default exported functions 'malloc', 'free', etc. those should only be linked in if used
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []

--- a/src/settings.js
+++ b/src/settings.js
@@ -1794,7 +1794,8 @@ var LEGACY_SETTINGS = [
   ['SKIP_STACK_IN_SMALL', [0, 1], 'SKIP_STACK_IN_SMALL is no longer needed as the backend can optimize it directly'],
   ['SAFE_STACK', [0], 'Replace SAFE_STACK=1 with STACK_OVERFLOW_CHECK=2'],
   ['MEMORY_GROWTH_STEP', 'MEMORY_GROWTH_LINEAR_STEP'],
-  ['WASM_OBJECT_FILES', [0], 'For LTO, use -flto or -fto=thin instead; to disable LTO, just do not pass WASM_OBJECT_FILES=1 as 1 is the default anyhow'],
+  // WASM_OBJECT_FILES is handled in emcc.py, supporting both 0 and 1 for now.
+  ['WASM_OBJECT_FILES', [0, 1], 'For LTO, use -flto or -fto=thin instead; to disable LTO, just do not pass WASM_OBJECT_FILES=1 as 1 is the default anyhow'],
   ['TOTAL_MEMORY', 'INITIAL_MEMORY'],
   ['WASM_MEM_MAX', 'MAXIMUM_MEMORY'],
   ['BINARYEN_MEM_MAX', 'MAXIMUM_MEMORY'],

--- a/src/settings.js
+++ b/src/settings.js
@@ -1794,7 +1794,7 @@ var LEGACY_SETTINGS = [
   ['SKIP_STACK_IN_SMALL', [0, 1], 'SKIP_STACK_IN_SMALL is no longer needed as the backend can optimize it directly'],
   ['SAFE_STACK', [0], 'Replace SAFE_STACK=1 with STACK_OVERFLOW_CHECK=2'],
   ['MEMORY_GROWTH_STEP', 'MEMORY_GROWTH_LINEAR_STEP'],
-  ['WASM_OBJECT_FILES', [1], 'Use -flto or -fto=thin instead'],
+  ['WASM_OBJECT_FILES', [0], 'For LTO, use -flto or -fto=thin instead; to disable LTO, just do not pass WASM_OBJECT_FILES=1 as 1 is the default anyhow'],
   ['TOTAL_MEMORY', 'INITIAL_MEMORY'],
   ['WASM_MEM_MAX', 'MAXIMUM_MEMORY'],
   ['BINARYEN_MEM_MAX', 'MAXIMUM_MEMORY'],

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8528,10 +8528,17 @@ int main() {
     for flags, expect_bitcode in [
       ([], False),
       (['-flto'], True),
+      (['-flto=thin'], True),
+      (['-s', 'WASM_OBJECT_FILES=0'], True),
     ]:
       run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + flags + ['-c', '-o', 'a.o'])
       seen_bitcode = Building.is_bitcode('a.o')
       self.assertEqual(expect_bitcode, seen_bitcode, 'must emit LTO-capable bitcode when flags indicate so (%s)' % str(flags))
+
+  @no_fastcomp('wasm backend lto specific')
+  def test_lto_legacy_flags(self):
+    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'a.o', '-s', 'WASM_OBJECT_FILES=1'])
+    self.assertContained('Invalid command line option -s WASM_OBJECT_FILES=1: For LTO, use -flto or -fto=thin instead; to disable LTO, just do not pass WASM_OBJECT_FILES=1 as 1 is the default anyhow', err)
 
   def test_wasm_nope(self):
     for opts in [[], ['-O2']]:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8530,15 +8530,11 @@ int main() {
       (['-flto'], True),
       (['-flto=thin'], True),
       (['-s', 'WASM_OBJECT_FILES=0'], True),
+      (['-s', 'WASM_OBJECT_FILES=1'], False),
     ]:
       run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + flags + ['-c', '-o', 'a.o'])
       seen_bitcode = Building.is_bitcode('a.o')
       self.assertEqual(expect_bitcode, seen_bitcode, 'must emit LTO-capable bitcode when flags indicate so (%s)' % str(flags))
-
-  @no_fastcomp('wasm backend lto specific')
-  def test_lto_legacy_flags(self):
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'a.o', '-s', 'WASM_OBJECT_FILES=1'])
-    self.assertContained('Invalid command line option -s WASM_OBJECT_FILES=1: For LTO, use -flto or -fto=thin instead; to disable LTO, just do not pass WASM_OBJECT_FILES=1 as 1 is the default anyhow', err)
 
   def test_wasm_nope(self):
     for opts in [[], ['-O2']]:


### PR DESCRIPTION
This makes us still support `-s WASM_OBJECT_FILES=0` as a way
to get LTO. We can remove it entirely after a few releases, but should
not do so immediately, as it's been the documented way to get LTO
for a while.

`-s WASM_OBJECT_FILES=1` will error though, which hopefully is
a pretty rare thing for users to have done, as it's been the default
value for years now.

Followup to #10490 and an alternative to parts of #10619
