### PR TITLE
Use bzip2 from an emscripten-ports mirror

### DIFF
--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -6,8 +6,8 @@
 import os
 import shutil
 
-VERSION = 'master' # TODO: '1.0.6'
-HASH = '7f7b894e65d4028b64df9316321baf0f5898d630579aaca4cb0bbe8acb00d2929eb3539f71ad71b6cd1fdb1d205c7d6761aca82894eeb6b01f8a1640e3eb0f86'
+VERSION = '1.0.6'
+HASH = '512cbfde5144067f677496452f3335e9368fd5d7564899cb49e77847b9ae7dca598218276637cbf5ec524523be1e8ace4ad36a148ef7f4badf3f6d5a002a4bb2'
 
 
 def get(ports, settings, shared):

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -6,20 +6,20 @@
 import os
 import shutil
 
-VERSION = '1.0.6'
-HASH = '00ace5438cfa0c577e5f578d8a808613187eff5217c35164ffe044fbafdfec9e98f4192c02a7d67e01e5a5ccced630583ad1003c37697219b0f147343a3fdd12'
+VERSION = 'master' # TODO: '1.0.6'
+HASH = '7f7b894e65d4028b64df9316321baf0f5898d630579aaca4cb0bbe8acb00d2929eb3539f71ad71b6cd1fdb1d205c7d6761aca82894eeb6b01f8a1640e3eb0f86'
 
 
 def get(ports, settings, shared):
   if settings.USE_BZIP2 != 1:
     return []
 
-  ports.fetch_project('bzip2', 'https://sourceware.org/pub/bzip2/bzip2-1.0.6.tar.gz', 'bzip2-1.0.6', sha512hash=HASH)
+  ports.fetch_project('bzip2', 'https://github.com/emscripten-ports/bzip2/archive/' + VERSION + '.zip', 'bzip2-' + VERSION, sha512hash=HASH)
 
   def create():
     ports.clear_project_build('bzip2')
 
-    source_path = os.path.join(ports.get_dir(), 'bzip2', 'bzip2-1.0.6')
+    source_path = os.path.join(ports.get_dir(), 'bzip2', 'bzip2-' + VERSION)
     dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'bzip2')
     shared.try_delete(dest_path)
     os.makedirs(dest_path)


### PR DESCRIPTION
sourceware.org downloads are broken atm, and have been in the
past, so let's just use a mirror on emscripten-ports (that I created
now, getting 1.0.6 from the sourceware ftp which still works).

This should fix the current broken roll as well as github CI failures.