### PR TITLE
Use atomics in musl lock/unlock in pthreads builds. fixes #10595

### DIFF
--- a/system/lib/libc/musl/src/stdio/__lockfile.c
+++ b/system/lib/libc/musl/src/stdio/__lockfile.c
@@ -3,7 +3,7 @@
 
 int __lockfile(FILE *f)
 {
-#ifndef __EMSCRIPTEN__ // XXX EMSCRIPTEN: for now no pthreads; ignore locking
+#if defined(__EMSCRIPTEN_PTHREADS__)
 	int owner, tid = __pthread_self()->tid;
 	if (f->lock == tid)
 		return 0;
@@ -15,7 +15,7 @@ int __lockfile(FILE *f)
 
 void __unlockfile(FILE *f)
 {
-#ifndef __EMSCRIPTEN__
+#if defined(__EMSCRIPTEN_PTHREADS__)
 	a_store(&f->lock, 0);
 
 	/* The following read is technically invalid under situations


### PR DESCRIPTION
This will make our pthreads builds a little slower on stdio, but
as @sbc100 noted, this has just not been correct all this time:
while our filesystem backends are in JS and so single-threaded,
musl uses this locking for its internal stdio data structures too.