### PR TITLE
Re-enable a metadce test after a roll (#10369).

### DIFF
--- a/tests/other/metadce/hello_world.funcs
+++ b/tests/other/metadce/hello_world.funcs
@@ -6,6 +6,7 @@ $__errno_location
 $__fflush_unlocked
 $__fwritex
 $__growWasmMemory
+$__lock
 $__lockfile
 $__lshrti3
 $__ofl_lock
@@ -16,6 +17,7 @@ $__set_stack_limit
 $__stdio_write
 $__towrite
 $__trunctfdf2
+$__unlock
 $__unlockfile
 $__vfprintf_internal
 $__wasi_syscall_ret

--- a/tests/other/metadce/hello_world.imports
+++ b/tests/other/metadce/hello_world.imports
@@ -1,6 +1,4 @@
 __handle_stack_overflow
-__lock
-__unlock
 emscripten_memcpy_big
 emscripten_resize_heap
 fd_write

--- a/tests/other/metadce/hello_world.sent
+++ b/tests/other/metadce/hello_world.sent
@@ -1,6 +1,4 @@
 __handle_stack_overflow
-__lock
-__unlock
 emscripten_get_sbrk_ptr
 emscripten_memcpy_big
 emscripten_resize_heap

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8301,7 +8301,6 @@ int main() {
     'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [],  10652, True, True, True, False), # noqa
   })
   @no_fastcomp()
-  @unittest.skip("Allow LLVM roll to proceed")
   def test_metadce_hello(self, *args):
     self.run_metadce_test('hello_world.cpp', *args)
 


### PR DESCRIPTION
Updates reflect the moving of lock code from JS to C.