### PR TITLE
Fix JSDCE of *.x

### DIFF
--- a/tests/optimizer/JSDCE-output.js
+++ b/tests/optimizer/JSDCE-output.js
@@ -71,5 +71,9 @@ var FS = {
  foo: function(stream, offset, length) {
   stream.allocate;
   FS;
+  for (var __exportedFunc in asm) {
+   var jsname = __exportedFunc;
+   global_object[jsname] = Module[jsname] = asm[__exportedFunc];
+  }
  }
 };

--- a/tests/optimizer/JSDCE-output.js
+++ b/tests/optimizer/JSDCE-output.js
@@ -66,3 +66,10 @@ function ___cxa_find_matching_catch_after() {
 ___cxa_find_matching_catch_after();
 
 var dotOther = Side.effect;
+
+var FS = {
+ foo: function(stream, offset, length) {
+  stream.allocate;
+  FS;
+ }
+};

--- a/tests/optimizer/JSDCE.js
+++ b/tests/optimizer/JSDCE.js
@@ -91,3 +91,12 @@ ___cxa_find_matching_catch_after();
 var dotMath = Math.something;
 var dotOther = Side.effect;
 
+function allocate() {
+}
+var FS = {
+ foo: function(stream, offset, length) {
+  stream.allocate; // this should not keep allocate() alive
+  FS; // keep FS alive itself
+ },
+};
+

--- a/tests/optimizer/JSDCE.js
+++ b/tests/optimizer/JSDCE.js
@@ -97,6 +97,11 @@ var FS = {
  foo: function(stream, offset, length) {
   stream.allocate; // this should not keep allocate() alive
   FS; // keep FS alive itself
+  // test we leave [] operations alone
+  for (var __exportedFunc in asm) {
+    var jsname = __exportedFunc;
+    global_object[jsname] = Module[jsname] = asm[__exportedFunc];
+  }
  },
 };
 

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -349,8 +349,9 @@ function JSDCE(ast, multipleIterations) {
       },
       MemberExpression(node, c) {
         c(node.object);
-        // ignore a property identifier (a.X)
-        if (node.property.type !== 'Identifier') {
+        // Ignore a property identifier (a.X), but notice a[X] (computed
+        // is true) and a["X"] (it will be a Literal and not Identifier).
+        if (node.property.type !== 'Identifier' || node.computed) {
           c(node.property);
         }
       },

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -347,6 +347,13 @@ function JSDCE(ast, multipleIterations) {
           c(node.value);
         });
       },
+      MemberExpression(node, c) {
+        c(node.object);
+        // ignore a property identifier (a.X)
+        if (node.property.type !== 'Identifier') {
+          c(node.property);
+        }
+      },
       FunctionDeclaration(node, c) {
         handleFunction(node, c, true /* defun */);
       },


### PR DESCRIPTION
`x` in `*.x` was being kept alive, as in the acorn AST it is
an Identifier node, so it looks like a free "`x`".

This shrinks libc++ hello world's JS by 2.5%, as a few
significant functions could not previously be cleaned out
due to this.