### PR TITLE
Remove setThrew hack in wasm backend

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1387,9 +1387,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if not shared.Settings.MINIMAL_RUNTIME:
       # Always need malloc and free to be kept alive and exported, for internal use and other modules
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
-      if shared.Settings.WASM_BACKEND:
-        # setjmp/longjmp and exception handling JS code depends on this so we
-        # include it by default.  Should be eliminated by meta-DCE if unused.
+
+    if shared.Settings.WASM_BACKEND:
+      if shared.Settings.DISABLE_EXCEPTION_CATCHING == 0 or shared.Settings.SUPPORT_LONGJMP:
         shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
 
     if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:

--- a/emcc.py
+++ b/emcc.py
@@ -1388,10 +1388,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # Always need malloc and free to be kept alive and exported, for internal use and other modules
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
 
-    if shared.Settings.WASM_BACKEND:
-      if shared.Settings.DISABLE_EXCEPTION_CATCHING == 0 or shared.Settings.SUPPORT_LONGJMP:
-        shared.Settings.EXPORTED_FUNCTIONS += ['_setThrew']
-
     if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
       exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
 

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -104,6 +104,8 @@
   "_embind_register_function": ["free"],
   "_embind_register_class": ["free"],
   "_embind_register_enum_value": ["free"],
-  "setjmp": "setThrew",
-  "longjmp": "setThrew"
+  "setjmp": ["setThrew", "realloc"],
+  "longjmp": ["setThrew", "realloc"],
+  "emscripten_longjmp_jmpbuf": ["setThrew", "realloc"],
+  "saveSetjmp": ["setThrew", "realloc"]
 }

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -66,10 +66,11 @@
   "__cxa_find_matching_catch_7": ["__cxa_is_pointer_type", "__cxa_can_catch"],
   "__cxa_find_matching_catch_8": ["__cxa_is_pointer_type", "__cxa_can_catch"],
   "__cxa_find_matching_catch_9": ["__cxa_is_pointer_type", "__cxa_can_catch"],
-  "__cxa_begin_catch": ["_ZSt18uncaught_exceptionv"],
+  "__cxa_begin_catch": ["_ZSt18uncaught_exceptionv", "setThrew"],
   "__cxa_end_catch": ["free"],
-  "__cxa_allocate_exception": ["malloc"],
+  "__cxa_allocate_exception": ["malloc", "setThrew"],
   "__cxa_free_exception": ["free"],
+  "__cxa_throw": ["setThrew"],
   "_formatString": ["strlen"],
   "setjmp": ["realloc"],
   "saveSetjmp": ["realloc"],
@@ -102,5 +103,7 @@
   "_embind_register_std_wstring": ["free"],
   "_embind_register_function": ["free"],
   "_embind_register_class": ["free"],
-  "_embind_register_enum_value": ["free"]
+  "_embind_register_enum_value": ["free"],
+  "setjmp": "setThrew",
+  "longjmp": "setThrew"
 }

--- a/tests/other/metadce/hello_libcxx_O2.exports
+++ b/tests/other/metadce/hello_libcxx_O2.exports
@@ -26,7 +26,6 @@ dynCall_viijii
 free
 main
 malloc
-setThrew
 stackAlloc
 stackRestore
 stackSave

--- a/tests/other/metadce/hello_libcxx_O2.funcs
+++ b/tests/other/metadce/hello_libcxx_O2.funcs
@@ -171,7 +171,6 @@ $sbrk
 $scalbn
 $scalbnl
 $scanexp
-$setThrew
 $sn_write
 $snprintf
 $sscanf

--- a/tests/other/metadce/minimal.exports
+++ b/tests/other/metadce/minimal.exports
@@ -7,7 +7,6 @@ add
 fflush
 free
 malloc
-setThrew
 stackAlloc
 stackRestore
 stackSave

--- a/tests/other/metadce/minimal.funcs
+++ b/tests/other/metadce/minimal.funcs
@@ -15,7 +15,6 @@ $dlmalloc
 $emscripten_get_sbrk_ptr
 $fflush
 $sbrk
-$setThrew
 $stackAlloc
 $stackRestore
 $stackSave

--- a/tests/other/metadce/minimal_O1.exports
+++ b/tests/other/metadce/minimal_O1.exports
@@ -5,7 +5,6 @@ __wasm_call_ctors
 add
 free
 malloc
-setThrew
 stackAlloc
 stackRestore
 stackSave

--- a/tests/other/metadce/minimal_O1.funcs
+++ b/tests/other/metadce/minimal_O1.funcs
@@ -6,7 +6,6 @@ $dlfree
 $dlmalloc
 $emscripten_get_sbrk_ptr
 $sbrk
-$setThrew
 $stackAlloc
 $stackRestore
 $stackSave

--- a/tests/other/metadce/minimal_O2.exports
+++ b/tests/other/metadce/minimal_O2.exports
@@ -5,7 +5,6 @@ __wasm_call_ctors
 add
 free
 malloc
-setThrew
 stackAlloc
 stackRestore
 stackSave

--- a/tests/other/metadce/minimal_O2.funcs
+++ b/tests/other/metadce/minimal_O2.funcs
@@ -5,7 +5,6 @@ $add
 $dlfree
 $dlmalloc
 $sbrk
-$setThrew
 $stackAlloc
 $stackRestore
 $stackSave

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1211,7 +1211,6 @@ int main() {
       self.do_run_from_file(path_from_root('tests', 'core', 'test_exceptions.cpp'), path_from_root('tests', 'core', 'test_exceptions_uncaught.out'), assert_returncode=None)
 
   @no_emterpreter
-  @no_wasm_backend('MINIMAL_RUNTIME not yet available in Wasm backend')
   def test_exceptions_minimal_runtime(self):
     self.set_setting('EXCEPTION_DEBUG', 1)
     self.maybe_closure()


### PR DESCRIPTION
Instead of always adding it, only add it using the usual
`deps_info` mechanism.

This removes some unnecessary code in builds with
metadce (as metadce would remove it anyhow), and
also enables exceptions in MINIMAL_RUNTIME. Without
this, we could still make MINIMAL_RUNTIME work but
it would regress the code size tests there (due to adding
`setThrew` to the output, which wasn't there before).
