### PR TITLE
Fix a wasm2js minification bug with localNames being for the whole set of functions

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 25431,
-  "a.js.gz": 9920,
+  "a.js": 24667,
+  "a.js.gz": 9175,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 29187,
-  "total_gz": 13017
+  "total": 28423,
+  "total_gz": 12272
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 24926,
-  "a.js.gz": 9756,
+  "a.js": 24162,
+  "a.js.gz": 9012,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 28682,
-  "total_gz": 12853
+  "total": 27918,
+  "total_gz": 12109
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 20504,
-  "a.html.gz": 8537,
-  "total": 20504,
-  "total_gz": 8537
+  "a.html": 20529,
+  "a.html.gz": 8546,
+  "total": 20529,
+  "total_gz": 8546
 }

--- a/tests/optimizer/wasm2js-output.js
+++ b/tests/optimizer/wasm2js-output.js
@@ -1,0 +1,436 @@
+// EMSCRIPTEN_START_ASM
+function a(asmLibraryArg, wasmMemory, wasmTable) {
+ function b(global, env, buffer) {
+  var memory = env.memory;
+  var c = wasmTable;
+  var d = new global.Int8Array(buffer);
+  var e = new global.Int16Array(buffer);
+  var f = new global.Int32Array(buffer);
+  var g = new global.Uint8Array(buffer);
+  var h = new global.Uint16Array(buffer);
+  var i = new global.Uint32Array(buffer);
+  var j = new global.Float32Array(buffer);
+  var k = new global.Float64Array(buffer);
+  var l = global.Math.imul;
+  var m = global.Math.fround;
+  var n = global.Math.abs;
+  var o = global.Math.clz32;
+  var p = global.Math.min;
+  var q = global.Math.max;
+  var r = global.Math.floor;
+  var s = global.Math.ceil;
+  var t = global.Math.sqrt;
+  var u = env.abort;
+  var v = global.NaN;
+  var w = global.Infinity;
+  var x = env.fd_write;
+  var y = env.emscripten_memcpy_big;
+  var z = 5245632;
+  var A = 0;
+  
+// EMSCRIPTEN_START_FUNCS
+function F(a, b, c) {
+ var e = 0, h = 0;
+ if (c >>> 0 >= 512) {
+  y(a | 0, b | 0, c | 0) | 0;
+  return;
+ }
+ e = a + c | 0;
+ a : {
+  if (!((a ^ b) & 3)) {
+   b : {
+    if ((c | 0) < 1) {
+     c = a;
+     break b;
+    }
+    if (!(a & 3)) {
+     c = a;
+     break b;
+    }
+    c = a;
+    while (1) {
+     d[c | 0] = g[b | 0];
+     b = b + 1 | 0;
+     c = c + 1 | 0;
+     if (c >>> 0 >= e >>> 0) {
+      break b;
+     }
+     if (c & 3) {
+      continue;
+     }
+     break;
+    }
+   }
+   a = e & -4;
+   c : {
+    if (a >>> 0 < 64) {
+     break c;
+    }
+    h = a + -64 | 0;
+    if (c >>> 0 > h >>> 0) {
+     break c;
+    }
+    while (1) {
+     f[c >> 2] = f[b >> 2];
+     f[c + 4 >> 2] = f[b + 4 >> 2];
+     f[c + 8 >> 2] = f[b + 8 >> 2];
+     f[c + 12 >> 2] = f[b + 12 >> 2];
+     f[c + 16 >> 2] = f[b + 16 >> 2];
+     f[c + 20 >> 2] = f[b + 20 >> 2];
+     f[c + 24 >> 2] = f[b + 24 >> 2];
+     f[c + 28 >> 2] = f[b + 28 >> 2];
+     f[c + 32 >> 2] = f[b + 32 >> 2];
+     f[c + 36 >> 2] = f[b + 36 >> 2];
+     f[c + 40 >> 2] = f[b + 40 >> 2];
+     f[c + 44 >> 2] = f[b + 44 >> 2];
+     f[c + 48 >> 2] = f[b + 48 >> 2];
+     f[c + 52 >> 2] = f[b + 52 >> 2];
+     f[c + 56 >> 2] = f[b + 56 >> 2];
+     f[c + 60 >> 2] = f[b + 60 >> 2];
+     b = b - -64 | 0;
+     c = c - -64 | 0;
+     if (c >>> 0 <= h >>> 0) {
+      continue;
+     }
+     break;
+    }
+   }
+   if (c >>> 0 >= a >>> 0) {
+    break a;
+   }
+   while (1) {
+    f[c >> 2] = f[b >> 2];
+    b = b + 4 | 0;
+    c = c + 4 | 0;
+    if (c >>> 0 < a >>> 0) {
+     continue;
+    }
+    break;
+   }
+   break a;
+  }
+  if (e >>> 0 < 4) {
+   c = a;
+   break a;
+  }
+  h = e + -4 | 0;
+  if (h >>> 0 < a >>> 0) {
+   c = a;
+   break a;
+  }
+  c = a;
+  while (1) {
+   d[c | 0] = g[b | 0];
+   d[c + 1 | 0] = g[b + 1 | 0];
+   d[c + 2 | 0] = g[b + 2 | 0];
+   d[c + 3 | 0] = g[b + 3 | 0];
+   b = b + 4 | 0;
+   c = c + 4 | 0;
+   if (c >>> 0 <= h >>> 0) {
+    continue;
+   }
+   break;
+  }
+ }
+ if (c >>> 0 < e >>> 0) {
+  while (1) {
+   d[c | 0] = g[b | 0];
+   b = b + 1 | 0;
+   c = c + 1 | 0;
+   if ((e | 0) != (c | 0)) {
+    continue;
+   }
+   break;
+  }
+ }
+}
+function I(a, b, c) {
+ a = a | 0;
+ b = b | 0;
+ c = c | 0;
+ var d = 0, e = 0, g = 0, h = 0, i = 0, j = 0;
+ d = z - 32 | 0;
+ z = d;
+ e = f[a + 28 >> 2];
+ f[d + 16 >> 2] = e;
+ g = f[a + 20 >> 2];
+ f[d + 28 >> 2] = c;
+ f[d + 24 >> 2] = b;
+ b = g - e | 0;
+ f[d + 20 >> 2] = b;
+ e = b + c | 0;
+ i = 2;
+ b = d + 16 | 0;
+ a : {
+  b : {
+   c : {
+    if (!E(x(f[a + 60 >> 2], d + 16 | 0, 2, d + 12 | 0) | 0)) {
+     while (1) {
+      g = f[d + 12 >> 2];
+      if ((g | 0) == (e | 0)) {
+       break c;
+      }
+      if ((g | 0) <= -1) {
+       break b;
+      }
+      h = f[b + 4 >> 2];
+      j = g >>> 0 > h >>> 0;
+      b = j ? b + 8 | 0 : b;
+      h = g - (j ? h : 0) | 0;
+      f[b >> 2] = h + f[b >> 2];
+      f[b + 4 >> 2] = f[b + 4 >> 2] - h;
+      e = e - g | 0;
+      i = i - j | 0;
+      if (!E(x(f[a + 60 >> 2], b | 0, i | 0, d + 12 | 0) | 0)) {
+       continue;
+      }
+      break;
+     }
+    }
+    f[d + 12 >> 2] = -1;
+    if ((e | 0) != -1) {
+     break b;
+    }
+   }
+   b = f[a + 44 >> 2];
+   f[a + 28 >> 2] = b;
+   f[a + 20 >> 2] = b;
+   f[a + 16 >> 2] = b + f[a + 48 >> 2];
+   a = c;
+   break a;
+  }
+  f[a + 28 >> 2] = 0;
+  f[a + 16 >> 2] = 0;
+  f[a + 20 >> 2] = 0;
+  f[a >> 2] = f[a >> 2] | 32;
+  a = 0;
+  if ((i | 0) == 2) {
+   break a;
+  }
+  a = c - f[b + 4 >> 2] | 0;
+ }
+ z = d + 32 | 0;
+ return a | 0;
+}
+function C(a, b) {
+ var e = 0, h = 0, i = 0, j = 0, k = 0;
+ j = 1024;
+ e = f[b + 16 >> 2];
+ a : {
+  if (!e) {
+   if (D(b)) {
+    break a;
+   }
+   e = f[b + 16 >> 2];
+  }
+  i = f[b + 20 >> 2];
+  if (e - i >>> 0 < a >>> 0) {
+   return c[f[b + 36 >> 2]](b, 1024, a) | 0;
+  }
+  b : {
+   if (d[b + 75 | 0] < 0) {
+    break b;
+   }
+   h = a;
+   while (1) {
+    e = h;
+    if (!e) {
+     break b;
+    }
+    h = e + -1 | 0;
+    if (g[h + 1024 | 0] != 10) {
+     continue;
+    }
+    break;
+   }
+   h = c[f[b + 36 >> 2]](b, 1024, e) | 0;
+   if (h >>> 0 < e >>> 0) {
+    break a;
+   }
+   a = a - e | 0;
+   j = e + 1024 | 0;
+   i = f[b + 20 >> 2];
+   k = e;
+  }
+  F(i, j, a);
+  f[b + 20 >> 2] = f[b + 20 >> 2] + a;
+  h = a + k | 0;
+ }
+ return h;
+}
+function M(a) {
+ var b = 0, e = 0, g = 0;
+ b = z - 16 | 0;
+ z = b;
+ d[b + 15 | 0] = 10;
+ e = f[a + 16 >> 2];
+ a : {
+  if (!e) {
+   if (D(a)) {
+    break a;
+   }
+   e = f[a + 16 >> 2];
+  }
+  g = f[a + 20 >> 2];
+  if (!(d[a + 75 | 0] == 10 | g >>> 0 >= e >>> 0)) {
+   f[a + 20 >> 2] = g + 1;
+   d[g | 0] = 10;
+   break a;
+  }
+  if ((c[f[a + 36 >> 2]](a, b + 15 | 0, 1) | 0) != 1) {
+   break a;
+  }
+ }
+ z = b + 16 | 0;
+}
+function K() {
+ var a = 0, b = 0, c = 0;
+ b = 1024;
+ while (1) {
+  a = b;
+  b = a + 4 | 0;
+  c = f[a >> 2];
+  if (!((c ^ -1) & c + -16843009 & -2139062144)) {
+   continue;
+  }
+  break;
+ }
+ if (!(c & 255)) {
+  return a - 1024 | 0;
+ }
+ while (1) {
+  c = g[a + 1 | 0];
+  b = a + 1 | 0;
+  a = b;
+  if (c) {
+   continue;
+  }
+  break;
+ }
+ return b - 1024 | 0;
+}
+function L() {
+ var a = 0, b = 0;
+ a = f[260];
+ a;
+ b = K();
+ a : {
+  if ((((N(b, a) | 0) != (b | 0) ? -1 : 0) | 0) < 0) {
+   break a;
+  }
+  b : {
+   if (g[a + 75 | 0] == 10) {
+    break b;
+   }
+   b = f[a + 20 >> 2];
+   if (b >>> 0 >= i[a + 16 >> 2]) {
+    break b;
+   }
+   f[a + 20 >> 2] = b + 1;
+   d[b | 0] = 10;
+   break a;
+  }
+  M(a);
+ }
+}
+function D(a) {
+ var b = 0;
+ b = g[a + 74 | 0];
+ d[a + 74 | 0] = b + -1 | b;
+ b = f[a >> 2];
+ if (b & 8) {
+  f[a >> 2] = b | 32;
+  return -1;
+ }
+ f[a + 4 >> 2] = 0;
+ f[a + 8 >> 2] = 0;
+ b = f[a + 44 >> 2];
+ f[a + 28 >> 2] = b;
+ f[a + 20 >> 2] = b;
+ f[a + 16 >> 2] = b + f[a + 48 >> 2];
+ return 0;
+}
+function N(a, b) {
+ var c = 0, d = 0;
+ c = a;
+ d = c;
+ a : {
+  if (f[b + 76 >> 2] <= -1) {
+   b = C(c, b);
+   break a;
+  }
+  b = C(c, b);
+ }
+ if ((d | 0) == (b | 0)) {
+  return a;
+ }
+ return b;
+}
+function G(a, b, c, d) {
+ a = a | 0;
+ b = b | 0;
+ c = c | 0;
+ d = d | 0;
+ A = 0;
+ return 0;
+}
+function E(a) {
+ if (!a) {
+  return 0;
+ }
+ f[300] = a;
+ return -1;
+}
+function O(a, b) {
+ a = a | 0;
+ b = b | 0;
+ L();
+ return 0;
+}
+function J(a) {
+ a = a | 0;
+ return u() | 0;
+}
+function H(a) {
+ a = a | 0;
+ return 0;
+}
+function P() {}
+
+
+
+
+// EMSCRIPTEN_END_FUNCS
+
+  c[1] = H;
+  c[2] = I;
+  c[3] = G;
+  function B() {
+   return buffer.byteLength / 65536 | 0;
+  }
+  return {
+   "__wasm_call_ctors": P,
+   "main": O,
+   "__growWasmMemory": J
+  };
+ }
+ return b({
+  "Int8Array": Int8Array,
+  "Int16Array": Int16Array,
+  "Int32Array": Int32Array,
+  "Uint8Array": Uint8Array,
+  "Uint16Array": Uint16Array,
+  "Uint32Array": Uint32Array,
+  "Float32Array": Float32Array,
+  "Float64Array": Float64Array,
+  "NaN": NaN,
+  "Infinity": Infinity,
+  "Math": Math
+ }, asmLibraryArg, wasmMemory.buffer);
+}
+
+
+// EMSCRIPTEN_END_ASM
+
+
+

--- a/tests/optimizer/wasm2js.js
+++ b/tests/optimizer/wasm2js.js
@@ -1,0 +1,452 @@
+// EMSCRIPTEN_START_ASM
+function instantiate(asmLibraryArg, wasmMemory, wasmTable) {
+
+function asmFunc(global, env, buffer) {
+ var memory = env.memory;
+ var FUNCTION_TABLE = wasmTable;
+ var HEAP8 = new global.Int8Array(buffer);
+ var HEAP16 = new global.Int16Array(buffer);
+ var HEAP32 = new global.Int32Array(buffer);
+ var HEAPU8 = new global.Uint8Array(buffer);
+ var HEAPU16 = new global.Uint16Array(buffer);
+ var HEAPU32 = new global.Uint32Array(buffer);
+ var HEAPF32 = new global.Float32Array(buffer);
+ var HEAPF64 = new global.Float64Array(buffer);
+ var Math_imul = global.Math.imul;
+ var Math_fround = global.Math.fround;
+ var Math_abs = global.Math.abs;
+ var Math_clz32 = global.Math.clz32;
+ var Math_min = global.Math.min;
+ var Math_max = global.Math.max;
+ var Math_floor = global.Math.floor;
+ var Math_ceil = global.Math.ceil;
+ var Math_sqrt = global.Math.sqrt;
+ var abort = env.abort;
+ var nan = global.NaN;
+ var infinity = global.Infinity;
+ var fimport$0 = env.fd_write;
+ var fimport$1 = env.emscripten_memcpy_big;
+ var global$0 = 5245632;
+ var i64toi32_i32$HIGH_BITS = 0;
+ // EMSCRIPTEN_START_FUNCS
+;
+ function $0($0_1, $1_1) {
+  var $2_1 = 0, $3_1 = 0, $4_1 = 0, $5_1 = 0, $6_1 = 0;
+  $5_1 = 1024;
+  $2_1 = HEAP32[$1_1 + 16 >> 2];
+  label$1 : {
+   if (!$2_1) {
+    if ($1($1_1)) {
+     break label$1
+    }
+    $2_1 = HEAP32[$1_1 + 16 >> 2];
+   }
+   $4_1 = HEAP32[$1_1 + 20 >> 2];
+   if ($2_1 - $4_1 >>> 0 < $0_1 >>> 0) {
+    return FUNCTION_TABLE[HEAP32[$1_1 + 36 >> 2]]($1_1, 1024, $0_1) | 0
+   }
+   label$5 : {
+    if (HEAP8[$1_1 + 75 | 0] < 0) {
+     break label$5
+    }
+    $3_1 = $0_1;
+    while (1) {
+     $2_1 = $3_1;
+     if (!$2_1) {
+      break label$5
+     }
+     $3_1 = $2_1 + -1 | 0;
+     if (HEAPU8[$3_1 + 1024 | 0] != 10) {
+      continue
+     }
+     break;
+    };
+    $3_1 = FUNCTION_TABLE[HEAP32[$1_1 + 36 >> 2]]($1_1, 1024, $2_1) | 0;
+    if ($3_1 >>> 0 < $2_1 >>> 0) {
+     break label$1
+    }
+    $0_1 = $0_1 - $2_1 | 0;
+    $5_1 = $2_1 + 1024 | 0;
+    $4_1 = HEAP32[$1_1 + 20 >> 2];
+    $6_1 = $2_1;
+   }
+   $3($4_1, $5_1, $0_1);
+   HEAP32[$1_1 + 20 >> 2] = HEAP32[$1_1 + 20 >> 2] + $0_1;
+   $3_1 = $0_1 + $6_1 | 0;
+  }
+  return $3_1;
+ }
+ 
+ function $1($0_1) {
+  var $1_1 = 0;
+  $1_1 = HEAPU8[$0_1 + 74 | 0];
+  HEAP8[$0_1 + 74 | 0] = $1_1 + -1 | $1_1;
+  $1_1 = HEAP32[$0_1 >> 2];
+  if ($1_1 & 8) {
+   HEAP32[$0_1 >> 2] = $1_1 | 32;
+   return -1;
+  }
+  HEAP32[$0_1 + 4 >> 2] = 0;
+  HEAP32[$0_1 + 8 >> 2] = 0;
+  $1_1 = HEAP32[$0_1 + 44 >> 2];
+  HEAP32[$0_1 + 28 >> 2] = $1_1;
+  HEAP32[$0_1 + 20 >> 2] = $1_1;
+  HEAP32[$0_1 + 16 >> 2] = $1_1 + HEAP32[$0_1 + 48 >> 2];
+  return 0;
+ }
+ 
+ function $2($0_1) {
+  if (!$0_1) {
+   return 0
+  }
+  HEAP32[300] = $0_1;
+  return -1;
+ }
+ 
+ function $3($0_1, $1_1, $2_1) {
+  var $3_1 = 0, $4_1 = 0;
+  if ($2_1 >>> 0 >= 512) {
+   fimport$1($0_1 | 0, $1_1 | 0, $2_1 | 0) | 0;
+   return;
+  }
+  $3_1 = $0_1 + $2_1 | 0;
+  label$2 : {
+   if (!(($0_1 ^ $1_1) & 3)) {
+    label$4 : {
+     if (($2_1 | 0) < 1) {
+      $2_1 = $0_1;
+      break label$4;
+     }
+     if (!($0_1 & 3)) {
+      $2_1 = $0_1;
+      break label$4;
+     }
+     $2_1 = $0_1;
+     while (1) {
+      HEAP8[$2_1 | 0] = HEAPU8[$1_1 | 0];
+      $1_1 = $1_1 + 1 | 0;
+      $2_1 = $2_1 + 1 | 0;
+      if ($2_1 >>> 0 >= $3_1 >>> 0) {
+       break label$4
+      }
+      if ($2_1 & 3) {
+       continue
+      }
+      break;
+     };
+    }
+    $0_1 = $3_1 & -4;
+    label$8 : {
+     if ($0_1 >>> 0 < 64) {
+      break label$8
+     }
+     $4_1 = $0_1 + -64 | 0;
+     if ($2_1 >>> 0 > $4_1 >>> 0) {
+      break label$8
+     }
+     while (1) {
+      HEAP32[$2_1 >> 2] = HEAP32[$1_1 >> 2];
+      HEAP32[$2_1 + 4 >> 2] = HEAP32[$1_1 + 4 >> 2];
+      HEAP32[$2_1 + 8 >> 2] = HEAP32[$1_1 + 8 >> 2];
+      HEAP32[$2_1 + 12 >> 2] = HEAP32[$1_1 + 12 >> 2];
+      HEAP32[$2_1 + 16 >> 2] = HEAP32[$1_1 + 16 >> 2];
+      HEAP32[$2_1 + 20 >> 2] = HEAP32[$1_1 + 20 >> 2];
+      HEAP32[$2_1 + 24 >> 2] = HEAP32[$1_1 + 24 >> 2];
+      HEAP32[$2_1 + 28 >> 2] = HEAP32[$1_1 + 28 >> 2];
+      HEAP32[$2_1 + 32 >> 2] = HEAP32[$1_1 + 32 >> 2];
+      HEAP32[$2_1 + 36 >> 2] = HEAP32[$1_1 + 36 >> 2];
+      HEAP32[$2_1 + 40 >> 2] = HEAP32[$1_1 + 40 >> 2];
+      HEAP32[$2_1 + 44 >> 2] = HEAP32[$1_1 + 44 >> 2];
+      HEAP32[$2_1 + 48 >> 2] = HEAP32[$1_1 + 48 >> 2];
+      HEAP32[$2_1 + 52 >> 2] = HEAP32[$1_1 + 52 >> 2];
+      HEAP32[$2_1 + 56 >> 2] = HEAP32[$1_1 + 56 >> 2];
+      HEAP32[$2_1 + 60 >> 2] = HEAP32[$1_1 + 60 >> 2];
+      $1_1 = $1_1 - -64 | 0;
+      $2_1 = $2_1 - -64 | 0;
+      if ($2_1 >>> 0 <= $4_1 >>> 0) {
+       continue
+      }
+      break;
+     };
+    }
+    if ($2_1 >>> 0 >= $0_1 >>> 0) {
+     break label$2
+    }
+    while (1) {
+     HEAP32[$2_1 >> 2] = HEAP32[$1_1 >> 2];
+     $1_1 = $1_1 + 4 | 0;
+     $2_1 = $2_1 + 4 | 0;
+     if ($2_1 >>> 0 < $0_1 >>> 0) {
+      continue
+     }
+     break;
+    };
+    break label$2;
+   }
+   if ($3_1 >>> 0 < 4) {
+    $2_1 = $0_1;
+    break label$2;
+   }
+   $4_1 = $3_1 + -4 | 0;
+   if ($4_1 >>> 0 < $0_1 >>> 0) {
+    $2_1 = $0_1;
+    break label$2;
+   }
+   $2_1 = $0_1;
+   while (1) {
+    HEAP8[$2_1 | 0] = HEAPU8[$1_1 | 0];
+    HEAP8[$2_1 + 1 | 0] = HEAPU8[$1_1 + 1 | 0];
+    HEAP8[$2_1 + 2 | 0] = HEAPU8[$1_1 + 2 | 0];
+    HEAP8[$2_1 + 3 | 0] = HEAPU8[$1_1 + 3 | 0];
+    $1_1 = $1_1 + 4 | 0;
+    $2_1 = $2_1 + 4 | 0;
+    if ($2_1 >>> 0 <= $4_1 >>> 0) {
+     continue
+    }
+    break;
+   };
+  }
+  if ($2_1 >>> 0 < $3_1 >>> 0) {
+   while (1) {
+    HEAP8[$2_1 | 0] = HEAPU8[$1_1 | 0];
+    $1_1 = $1_1 + 1 | 0;
+    $2_1 = $2_1 + 1 | 0;
+    if (($3_1 | 0) != ($2_1 | 0)) {
+     continue
+    }
+    break;
+   }
+  }
+ }
+ 
+ function $4($0_1, $1_1, $2_1, $3_1) {
+  $0_1 = $0_1 | 0;
+  $1_1 = $1_1 | 0;
+  $2_1 = $2_1 | 0;
+  $3_1 = $3_1 | 0;
+  i64toi32_i32$HIGH_BITS = 0;
+  return 0;
+ }
+ 
+ function $5($0_1) {
+  $0_1 = $0_1 | 0;
+  return 0;
+ }
+ 
+ function $6($0_1, $1_1, $2_1) {
+  $0_1 = $0_1 | 0;
+  $1_1 = $1_1 | 0;
+  $2_1 = $2_1 | 0;
+  var $3_1 = 0, $4_1 = 0, $5_1 = 0, $6_1 = 0, $7_1 = 0, $8_1 = 0;
+  $3_1 = global$0 - 32 | 0;
+  global$0 = $3_1;
+  $4_1 = HEAP32[$0_1 + 28 >> 2];
+  HEAP32[$3_1 + 16 >> 2] = $4_1;
+  $5_1 = HEAP32[$0_1 + 20 >> 2];
+  HEAP32[$3_1 + 28 >> 2] = $2_1;
+  HEAP32[$3_1 + 24 >> 2] = $1_1;
+  $1_1 = $5_1 - $4_1 | 0;
+  HEAP32[$3_1 + 20 >> 2] = $1_1;
+  $4_1 = $1_1 + $2_1 | 0;
+  $7_1 = 2;
+  $1_1 = $3_1 + 16 | 0;
+  label$1 : {
+   label$2 : {
+    label$3 : {
+     if (!$2(fimport$0(HEAP32[$0_1 + 60 >> 2], $3_1 + 16 | 0, 2, $3_1 + 12 | 0) | 0)) {
+      while (1) {
+       $5_1 = HEAP32[$3_1 + 12 >> 2];
+       if (($5_1 | 0) == ($4_1 | 0)) {
+        break label$3
+       }
+       if (($5_1 | 0) <= -1) {
+        break label$2
+       }
+       $6_1 = HEAP32[$1_1 + 4 >> 2];
+       $8_1 = $5_1 >>> 0 > $6_1 >>> 0;
+       $1_1 = $8_1 ? $1_1 + 8 | 0 : $1_1;
+       $6_1 = $5_1 - ($8_1 ? $6_1 : 0) | 0;
+       HEAP32[$1_1 >> 2] = $6_1 + HEAP32[$1_1 >> 2];
+       HEAP32[$1_1 + 4 >> 2] = HEAP32[$1_1 + 4 >> 2] - $6_1;
+       $4_1 = $4_1 - $5_1 | 0;
+       $7_1 = $7_1 - $8_1 | 0;
+       if (!$2(fimport$0(HEAP32[$0_1 + 60 >> 2], $1_1 | 0, $7_1 | 0, $3_1 + 12 | 0) | 0)) {
+        continue
+       }
+       break;
+      }
+     }
+     HEAP32[$3_1 + 12 >> 2] = -1;
+     if (($4_1 | 0) != -1) {
+      break label$2
+     }
+    }
+    $1_1 = HEAP32[$0_1 + 44 >> 2];
+    HEAP32[$0_1 + 28 >> 2] = $1_1;
+    HEAP32[$0_1 + 20 >> 2] = $1_1;
+    HEAP32[$0_1 + 16 >> 2] = $1_1 + HEAP32[$0_1 + 48 >> 2];
+    $0_1 = $2_1;
+    break label$1;
+   }
+   HEAP32[$0_1 + 28 >> 2] = 0;
+   HEAP32[$0_1 + 16 >> 2] = 0;
+   HEAP32[$0_1 + 20 >> 2] = 0;
+   HEAP32[$0_1 >> 2] = HEAP32[$0_1 >> 2] | 32;
+   $0_1 = 0;
+   if (($7_1 | 0) == 2) {
+    break label$1
+   }
+   $0_1 = $2_1 - HEAP32[$1_1 + 4 >> 2] | 0;
+  }
+  global$0 = $3_1 + 32 | 0;
+  return $0_1 | 0;
+ }
+ 
+ function $7($0_1) {
+  $0_1 = $0_1 | 0;
+  return abort() | 0;
+ }
+ 
+ function $8() {
+  var $0_1 = 0, $1_1 = 0, $2_1 = 0;
+  $1_1 = 1024;
+  while (1) {
+   $0_1 = $1_1;
+   $1_1 = $0_1 + 4 | 0;
+   $2_1 = HEAP32[$0_1 >> 2];
+   if (!(($2_1 ^ -1) & $2_1 + -16843009 & -2139062144)) {
+    continue
+   }
+   break;
+  };
+  if (!($2_1 & 255)) {
+   return $0_1 - 1024 | 0
+  }
+  while (1) {
+   $2_1 = HEAPU8[$0_1 + 1 | 0];
+   $1_1 = $0_1 + 1 | 0;
+   $0_1 = $1_1;
+   if ($2_1) {
+    continue
+   }
+   break;
+  };
+  return $1_1 - 1024 | 0;
+ }
+ 
+ function $9() {
+  var $0_1 = 0, $1_1 = 0;
+  $0_1 = HEAP32[260];
+  $0_1;
+  $1_1 = $8();
+  label$3 : {
+   if (((($11($1_1, $0_1) | 0) != ($1_1 | 0) ? -1 : 0) | 0) < 0) {
+    break label$3
+   }
+   label$4 : {
+    if (HEAPU8[$0_1 + 75 | 0] == 10) {
+     break label$4
+    }
+    $1_1 = HEAP32[$0_1 + 20 >> 2];
+    if ($1_1 >>> 0 >= HEAPU32[$0_1 + 16 >> 2]) {
+     break label$4
+    }
+    HEAP32[$0_1 + 20 >> 2] = $1_1 + 1;
+    HEAP8[$1_1 | 0] = 10;
+    break label$3;
+   }
+   $10($0_1);
+  }
+ }
+ 
+ function $10($0_1) {
+  var $1_1 = 0, $2_1 = 0, $3_1 = 0;
+  $1_1 = global$0 - 16 | 0;
+  global$0 = $1_1;
+  HEAP8[$1_1 + 15 | 0] = 10;
+  $2_1 = HEAP32[$0_1 + 16 >> 2];
+  label$1 : {
+   if (!$2_1) {
+    if ($1($0_1)) {
+     break label$1
+    }
+    $2_1 = HEAP32[$0_1 + 16 >> 2];
+   }
+   $3_1 = HEAP32[$0_1 + 20 >> 2];
+   if (!(HEAP8[$0_1 + 75 | 0] == 10 | $3_1 >>> 0 >= $2_1 >>> 0)) {
+    HEAP32[$0_1 + 20 >> 2] = $3_1 + 1;
+    HEAP8[$3_1 | 0] = 10;
+    break label$1;
+   }
+   if ((FUNCTION_TABLE[HEAP32[$0_1 + 36 >> 2]]($0_1, $1_1 + 15 | 0, 1) | 0) != 1) {
+    break label$1
+   }
+  }
+  global$0 = $1_1 + 16 | 0;
+ }
+ 
+ function $11($0_1, $1_1) {
+  var $2_1 = 0, $3_1 = 0;
+  $2_1 = $0_1;
+  $3_1 = $2_1;
+  label$1 : {
+   if (HEAP32[$1_1 + 76 >> 2] <= -1) {
+    $1_1 = $0($2_1, $1_1);
+    break label$1;
+   }
+   $1_1 = $0($2_1, $1_1);
+  }
+  if (($3_1 | 0) == ($1_1 | 0)) {
+   return $0_1
+  }
+  return $1_1;
+ }
+ 
+ function $12($0_1, $1_1) {
+  $0_1 = $0_1 | 0;
+  $1_1 = $1_1 | 0;
+  $9();
+  return 0;
+ }
+ 
+ function $13() {
+  
+ }
+ 
+ // EMSCRIPTEN_END_FUNCS
+;
+ FUNCTION_TABLE[1] = $5;
+ FUNCTION_TABLE[2] = $6;
+ FUNCTION_TABLE[3] = $4;
+ function __wasm_memory_size() {
+  return buffer.byteLength / 65536 | 0;
+ }
+ 
+ return {
+  "__wasm_call_ctors": $13, 
+  "main": $12, 
+  "__growWasmMemory": $7
+ };
+}
+
+return asmFunc({
+    'Int8Array': Int8Array,
+    'Int16Array': Int16Array,
+    'Int32Array': Int32Array,
+    'Uint8Array': Uint8Array,
+    'Uint16Array': Uint16Array,
+    'Uint32Array': Uint32Array,
+    'Float32Array': Float32Array,
+    'Float64Array': Float64Array,
+    'NaN': NaN,
+    'Infinity': Infinity,
+    'Math': Math
+  },
+  asmLibraryArg,
+  wasmMemory.buffer
+)
+
+}
+// EMSCRIPTEN_END_ASM
+// EMSCRIPTEN_GENERATED_FUNCTIONS
+

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2278,6 +2278,14 @@ int f() {
         output = run_process([tools.js_optimizer.get_native_optimizer(), input] + passes, stdin=PIPE, stdout=PIPE).stdout
         check_js(output, expected)
 
+  def test_js_optimizer_wasm2js(self):
+    # run the js optimizer in a similar way as wasm2js does
+    shutil.copyfile(path_from_root('tests', 'optimizer', 'wasm2js.js'), 'wasm2js.js')
+    run_process([PYTHON, path_from_root('tools', 'js_optimizer.py'), 'wasm2js.js', 'minifyNames', 'last'])
+    with open(path_from_root('tests', 'optimizer', 'wasm2js-output.js')) as expected:
+      with open('wasm2js.js.jsopt.js') as actual:
+        self.assertIdentical(expected.read(), actual.read())
+
   def test_m_mm(self):
     create_test_file('foo.c', '#include <emscripten.h>')
     for opt in ['M', 'MM']:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2278,6 +2278,7 @@ int f() {
         output = run_process([tools.js_optimizer.get_native_optimizer(), input] + passes, stdin=PIPE, stdout=PIPE).stdout
         check_js(output, expected)
 
+  @no_fastcomp('wasm2js-only')
   def test_js_optimizer_wasm2js(self):
     # run the js optimizer in a similar way as wasm2js does
     shutil.copyfile(path_from_root('tests', 'optimizer', 'wasm2js.js'), 'wasm2js.js')

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -4637,7 +4637,7 @@ function minifyLocals(ast) {
       for (var param in fun[2]) {
         localNames[param] = 1;
       }
-      traverse(ast, function(node, type) {
+      traverse(fun, function(node, type) {
         if (type === 'var') {
           node[1].forEach(function(defn) {
             var name = defn[0];


### PR DESCRIPTION
This is an embarrassing bug: a small typo caused us to scan the whole
set of functions being optimized (we optimize in chunks) for locals, as
opposed to just the actual locals in the current function. As a result, we
thought each function had a lot more locals. That prevented us from
using smaller local names in the minification.

This improves wasm2js code sizes by 3% on a few quick benchmarks
I did, and on the minimal runtime tests. It also speeds up compilation by
a factor of 2 (!) on a quick benchmark. These two benefits may be
even larger on a huge codebase, so it makes me wonder (cc @juj who
mentioned wasm2js code size issues).

May fix both #10673 and #10675, as this is more than just a nice
improvement, it also could have been buggy before: consider if we
need to call a function `foo` but it looks like `foo` is one of our locals,
then we'd get confused and call something wrong.

This was exceptionally hard to debug, as it only happens on big-enough
projects (where there are enough locals and globals to collide), namely
those two bugs just linked. Also one of them can't provide source and the
other only reproduces it on CI but not locally, which appears to be due
to nondeterminism - part of which is due to this very issue, but I have
another PR in the works as well. Also making this hard to debug was
that the problem is in name minification, so preserving function names -
the most minimal amount of debug info - hides the bug...
