### PR TITLE
Optimize glUniformMatrix4fv for size and also pthreads+growth by hoisting the heap.

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -2427,11 +2427,13 @@ var LibraryGL = {
     if (4*count <= GL.MINI_TEMP_BUFFER_SIZE) {
       // avoid allocation when uploading few enough uniforms
       var view = GL.miniTempBufferFloatViews[4*count-1];
+      // hoist the heap out of the loop for size and for pthreads+growth.
+      var heap = HEAPF32;
       for (var i = 0; i < 4*count; i += 4) {
-        view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
-        view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
-        view[i+2] = {{{ makeGetValue('value', '4*i+8', 'float') }}};
-        view[i+3] = {{{ makeGetValue('value', '4*i+12', 'float') }}};
+        view[i] = heap[value + 4*i >> 2];
+        view[i+1] = heap[value + 4*i+4 >> 2];
+        view[i+2] = heap[value + 4*i+8 >> 2];
+        view[i+3] = heap[value + 4*i+12 >> 2];
       }
     } else
 #endif
@@ -2537,8 +2539,7 @@ var LibraryGL = {
     if (16*count <= GL.MINI_TEMP_BUFFER_SIZE) {
       // avoid allocation when uploading few enough uniforms
       var view = GL.miniTempBufferFloatViews[16*count-1];
-      // hoist the heap out of the loop to help optimize the case of
-      // pthreads + growth.
+      // hoist the heap out of the loop for size and for pthreads+growth.
       var heap = HEAPF32;
       for (var i = 0; i < 16*count; i += 16) {
         view[i] = heap[value + 4*i >> 2];

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -2537,23 +2537,26 @@ var LibraryGL = {
     if (16*count <= GL.MINI_TEMP_BUFFER_SIZE) {
       // avoid allocation when uploading few enough uniforms
       var view = GL.miniTempBufferFloatViews[16*count-1];
+      // hoist the heap out of the loop to help optimize the case of
+      // pthreads + growth.
+      var heap = HEAPF32;
       for (var i = 0; i < 16*count; i += 16) {
-        view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
-        view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
-        view[i+2] = {{{ makeGetValue('value', '4*i+8', 'float') }}};
-        view[i+3] = {{{ makeGetValue('value', '4*i+12', 'float') }}};
-        view[i+4] = {{{ makeGetValue('value', '4*i+16', 'float') }}};
-        view[i+5] = {{{ makeGetValue('value', '4*i+20', 'float') }}};
-        view[i+6] = {{{ makeGetValue('value', '4*i+24', 'float') }}};
-        view[i+7] = {{{ makeGetValue('value', '4*i+28', 'float') }}};
-        view[i+8] = {{{ makeGetValue('value', '4*i+32', 'float') }}};
-        view[i+9] = {{{ makeGetValue('value', '4*i+36', 'float') }}};
-        view[i+10] = {{{ makeGetValue('value', '4*i+40', 'float') }}};
-        view[i+11] = {{{ makeGetValue('value', '4*i+44', 'float') }}};
-        view[i+12] = {{{ makeGetValue('value', '4*i+48', 'float') }}};
-        view[i+13] = {{{ makeGetValue('value', '4*i+52', 'float') }}};
-        view[i+14] = {{{ makeGetValue('value', '4*i+56', 'float') }}};
-        view[i+15] = {{{ makeGetValue('value', '4*i+60', 'float') }}};
+        view[i] = heap[value + 4*i >> 2];
+        view[i+1] = heap[value + 4*i+4 >> 2];
+        view[i+2] = heap[value + 4*i+8 >> 2];
+        view[i+3] = heap[value + 4*i+12 >> 2];
+        view[i+4] = heap[value + 4*i+16 >> 2];
+        view[i+5] = heap[value + 4*i+20 >> 2];
+        view[i+6] = heap[value + 4*i+24 >> 2];
+        view[i+7] = heap[value + 4*i+28 >> 2];
+        view[i+8] = heap[value + 4*i+32 >> 2];
+        view[i+9] = heap[value + 4*i+36 >> 2];
+        view[i+10] = heap[value + 4*i+40 >> 2];
+        view[i+11] = heap[value + 4*i+44 >> 2];
+        view[i+12] = heap[value + 4*i+48 >> 2];
+        view[i+13] = heap[value + 4*i+52 >> 2];
+        view[i+14] = heap[value + 4*i+56 >> 2];
+        view[i+15] = heap[value + 4*i+60 >> 2];
       }
     } else
 #endif


### PR DESCRIPTION
This ends up with a single call to `GROWABLE_HEAP_F32()` instead
of 16. In theory the JS engine can inline all those, but this is an extreme
case with 16 accesses in a row, and best to be sure of good results.

It also makes the code a little smaller (also without pthreads+growth).