### PR TITLE
Improves EMTEST_BROWSER behavior for test runner

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -458,3 +458,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * SK Min <oranke@gmail.com>
 * Fabio Alessandrelli <fabio.alessandrelli@gmail.com>
 * Kirill Gavrilov <kirill@sview.ru>
+* Louis DeScioli <descioli@google.com> (copyright owned by Google, LLC)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1362,14 +1362,15 @@ class BrowserCore(RunnerCore):
       return
 
     browser_args = shlex.split(EMTEST_BROWSER)
-    # If the given browser is a string with no separators, assume it's one
-    # of the types that the webbrowser module accepts like `safari`,
-    # `firefox`, or `chrome`. See https://docs.python.org/2/library/webbrowser.html
-    # for the full list
-    if len(browser_args) == 1 and os.path.sep not in browser_args[0]:
-      logger.info('Using Emscripten browser: %s', browser_args[0])
-      webbrowser.get(browser_args[0]).open_new(url)
-      return
+    # If the given browser is a scalar, treat it like one of the possible types
+    # from https://docs.python.org/2/library/webbrowser.html
+    if len(browser_args) == 1:
+      try:
+        webbrowser.get(browser_args[0]).open_new(url)
+        logger.info('Using Emscripten browser: %s', browser_args[0])
+        return
+      except:
+        pass
     # Else assume the given browser is a specific program with additional
     # parameters and delegate to that
     logger.info('Using Emscripten browser: %s', str(browser_args))

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1366,10 +1366,12 @@ class BrowserCore(RunnerCore):
     # from https://docs.python.org/2/library/webbrowser.html
     if len(browser_args) == 1:
       try:
+        # This throws if the type of browser isn't available
         webbrowser.get(browser_args[0]).open_new(url)
         logger.info('Using Emscripten browser: %s', browser_args[0])
         return
       except:
+        # Ignore the exception and fallback to the custom command logic
         pass
     # Else assume the given browser is a specific program with additional
     # parameters and delegate to that

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1357,7 +1357,7 @@ class BrowserCore(RunnerCore):
   @staticmethod
   def browser_open(url):
     if not EMTEST_BROWSER:
-      print("Using default system browser")
+      logger.info('Using default system browser')
       webbrowser.open_new(url)
       return
 
@@ -1367,12 +1367,12 @@ class BrowserCore(RunnerCore):
     # `firefox`, or `chrome`. See https://docs.python.org/2/library/webbrowser.html
     # for the full list
     if len(browser_args) == 1 and os.path.sep not in browser_args[0]:
-      print("Using Emscripten browser: " + browser_args[0])
+      logger.info('Using Emscripten browser: %s', browser_args[0])
       webbrowser.get(browser_args[0]).open_new(url)
       return
     # Else assume the given browser is a specific program with additional
     # parameters and delegate to that
-    print("Using Emscripten browser: " + str(browser_args))
+    logger.info('Using Emscripten browser: %s', str(browser_args))
     subprocess.Popen(browser_args + [url])
 
   @classmethod

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1353,7 +1353,7 @@ class BrowserCore(RunnerCore):
 
   def __init__(self, *args, **kwargs):
     super(BrowserCore, self).__init__(*args, **kwargs)
-  
+
   def get_browser_open_func():
     if not EMTEST_BROWSER:
       print("Using default system browser")
@@ -1368,6 +1368,7 @@ class BrowserCore(RunnerCore):
     # delegate to that command
     else:
       print("Using Emscripten browser: " + str(browser_args))
+
       def run_browser_cmd(url):
         subprocess.Popen(browser_args + [url])
       return run_browser_cmd

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1370,7 +1370,7 @@ class BrowserCore(RunnerCore):
         webbrowser.get(browser_args[0]).open_new(url)
         logger.info('Using Emscripten browser: %s', browser_args[0])
         return
-      except:
+      except webbrowser.Error:
         # Ignore the exception and fallback to the custom command logic
         pass
     # Else assume the given browser is a specific program with additional


### PR DESCRIPTION
EMTEST_BROWSER will now accept any of the browser types that the
webbrowser module supports (see https://docs.python.org/2/library/webbrowser.html)
in addition to being able to specify custom browser open commands.
This removes a lot of the setup complexity required for testing in
browsers other than the developer's default.