### PR TITLE
Remove arc4random compat

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1553,7 +1553,7 @@ v1.34.8: 9/9/2015
  - Fixed a race condition at worker startup (#3741)
  - Update emrun to latest, which improves unit test run automation with emrun.
  - Added support for LZ4 compressing file packages, used with the -s LZ4=1 linker flag. (#3754)
- - Fixed noisy build warning on "unexpected number of arguments in call to strtold" (#3760)
+ - Fixed noisy build warning on "t qunexpected number of arguments in call to strtold" (#3760)
  - Added new linker flag --separate-asm that splits the asm.js module and the
    handwritten JS functions to separate files.
  - Full list of changes:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1553,7 +1553,7 @@ v1.34.8: 9/9/2015
  - Fixed a race condition at worker startup (#3741)
  - Update emrun to latest, which improves unit test run automation with emrun.
  - Added support for LZ4 compressing file packages, used with the -s LZ4=1 linker flag. (#3754)
- - Fixed noisy build warning on "t qunexpected number of arguments in call to strtold" (#3760)
+ - Fixed noisy build warning on "unexpected number of arguments in call to strtold" (#3760)
  - Added new linker flag --separate-asm that splits the asm.js module and the
    handwritten JS functions to separate files.
  - Full list of changes:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Remove arc4random function form library.js.  This is a BSD-only library
+  function.  Anyone requiring BSD compat should be able to use something like
+  https://libbsd.freedesktop.org/.
 - Change the meaning of `ASYNCIFY_IMPORTS`: it now contains only new imports
   you add, and does not need to contain the list of default system imports like
   ``emscripten_sleep``. There is no harm in providing them, though, so this

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -1,5 +1,4 @@
 {
-  "arc4random": ["rand"],
   "freopen": ["free"],
   "munmap": ["free"],
   "getenv": ["malloc", "free", "_get_environ"],

--- a/src/library.js
+++ b/src/library.js
@@ -930,11 +930,6 @@ LibraryManager.library = {
     return limit;
   },
 
-  // For compatibility, call to rand() when code requests arc4random(), although this is *not* at all
-  // as strong as rc4 is. See https://man.openbsd.org/arc4random
-  arc4random__sig: 'i',
-  arc4random: 'rand',
-
   // ==========================================================================
   // string.h
   // ==========================================================================

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7638,20 +7638,6 @@ mergeInto(LibraryManager.library, {
     proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=[]'], stderr=PIPE)
     self.assertContained(WARNING, proc.stderr)
 
-  def test_arc4random(self):
-    create_test_file('src.c', r'''
-#include <stdlib.h>
-#include <stdio.h>
-
-int main() {
-  printf("%d\n", arc4random());
-  printf("%d\n", arc4random());
-}
-    ''')
-    run_process([PYTHON, EMCC, 'src.c', '-Wno-implicit-function-declaration'])
-
-    self.assertContained('0\n740882966\n', run_js('a.out.js'))
-
   ############################################################
   # Function eliminator tests
   ############################################################


### PR DESCRIPTION
This was added back in 2013 but the rational seems to be lost to
that sands of time.

See:  a5c78a58902abd6166a81a895cc9eea141c9cab4

I see no reason to maintain compatibility with this BSD-only function.

Fixes: #10709