### PR TITLE
Remove duplicate entries in deps_info.json.

### DIFF
--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -73,8 +73,6 @@
   "__cxa_free_exception": ["free"],
   "__cxa_throw": ["setThrew"],
   "_formatString": ["strlen"],
-  "setjmp": ["realloc"],
-  "saveSetjmp": ["realloc"],
   "glfwSleep": ["sleep"],
   "glBegin": ["malloc", "free"],
   "bind": ["htonl", "htons", "ntohs"],


### PR DESCRIPTION
These caused no harm (the last one takes precedence),
but might be confusing.