### PR TITLE
Properly metadce wasm exports in minimal runtime with asm = without var

### DIFF
--- a/tests/optimizer/minimal-runtime-2-emitDCEGraph-output.js
+++ b/tests/optimizer/minimal-runtime-2-emitDCEGraph-output.js
@@ -1,0 +1,56 @@
+[
+ {
+  "name": "emcc$defun$UTF8ArrayToString",
+  "reaches": []
+ },
+ {
+  "name": "emcc$defun$UTF8ToString",
+  "reaches": [
+   "emcc$defun$UTF8ArrayToString"
+  ]
+ },
+ {
+  "name": "emcc$defun$_emscripten_console_log",
+  "reaches": [
+   "emcc$defun$UTF8ToString"
+  ]
+ },
+ {
+  "name": "emcc$defun$initRuntime",
+  "reaches": [],
+  "root": true
+ },
+ {
+  "name": "emcc$defun$ready",
+  "reaches": [
+   "emcc$defun$run"
+  ],
+  "root": true
+ },
+ {
+  "name": "emcc$defun$run",
+  "reaches": [
+   "emcc$export$_main"
+  ]
+ },
+ {
+  "name": "emcc$export$_main",
+  "export": "_main",
+  "reaches": []
+ },
+ {
+  "name": "emcc$export$_unused",
+  "export": "c",
+  "reaches": []
+ },
+ {
+  "name": "emcc$import$_emscripten_console_log",
+  "import": [
+   "env",
+   "_emscripten_console_log"
+  ],
+  "reaches": [
+   "emcc$defun$_emscripten_console_log"
+  ]
+ }
+]

--- a/tests/optimizer/minimal-runtime-2-emitDCEGraph.js
+++ b/tests/optimizer/minimal-runtime-2-emitDCEGraph.js
@@ -1,0 +1,76 @@
+var Module = Module;
+function ready() {
+ run();
+}
+var UTF8Decoder = new TextDecoder("utf8");
+function UTF8ArrayToString(u8Array, idx) {
+ var endPtr = idx;
+ while (u8Array[endPtr]) ++endPtr;
+ return UTF8Decoder.decode(u8Array.subarray ? u8Array.subarray(idx, endPtr) : new Uint8Array(u8Array.slice(idx, endPtr)));
+}
+function UTF8ToString(ptr) {
+ return ptr ? UTF8ArrayToString(HEAPU8, ptr) : "";
+}
+var TOTAL_MEMORY = 16777216, STATIC_BASE = 1024;
+var wasmMaximumMemory = TOTAL_MEMORY;
+var wasmMemory = new WebAssembly.Memory({
+ "initial": TOTAL_MEMORY >> 16,
+ "maximum": wasmMaximumMemory >> 16
+});
+var buffer = wasmMemory.buffer;
+var HEAP8 = new Int8Array(buffer);
+var HEAP16 = new Int16Array(buffer);
+var HEAP32 = new Int32Array(buffer);
+var HEAPU8 = new Uint8Array(buffer);
+var HEAPU16 = new Uint16Array(buffer);
+var HEAPU32 = new Uint32Array(buffer);
+var HEAPF32 = new Float32Array(buffer);
+var HEAPF64 = new Float64Array(buffer);
+var __ATINIT__ = [];
+function _emscripten_console_log(str) {
+ console.log(UTF8ToString(str));
+}
+var asmLibraryArg = {
+ "a": _emscripten_console_log
+};
+function run() {
+ var ret = _main();
+}
+function initRuntime() {
+ for (var i in __ATINIT__) __ATINIT__[i].func();
+}
+var env = asmLibraryArg;
+env["memory"] = wasmMemory;
+env["table"] = new WebAssembly.Table({
+ "initial": 0,
+ "maximum": 0,
+ "element": "anyfunc"
+});
+env["__memory_base"] = STATIC_BASE;
+env["__table_base"] = 0;
+var imports = {
+ "env": env,
+ "global": {
+  "NaN": NaN,
+  "Infinity": Infinity
+ },
+ "global.Math": Math,
+ "asm2wasm": {
+  "f64-rem": (function(x, y) {
+   return x % y;
+  }),
+  "debugger": (function() {
+   debugger;
+  })
+ }
+};
+var _main, _unused, asm;
+WebAssembly.instantiate(Module["wasm"], imports).then((function(output) {
+ asm = output.instance.exports;
+ _main = asm["b"];
+ _unused = asm["c"];
+ initRuntime();
+ ready();
+}));
+
+// EXTRA_INFO: { "exports": [["_main","_main"]]}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2181,6 +2181,8 @@ int f() {
        ['noPrintMetadata', 'emterpretify', 'noEmitAst']),
       (path_from_root('tests', 'optimizer', 'minimal-runtime-emitDCEGraph.js'), open(path_from_root('tests', 'optimizer', 'minimal-runtime-emitDCEGraph-output.js')).read(),
        ['emitDCEGraph', 'noPrint']),
+      (path_from_root('tests', 'optimizer', 'minimal-runtime-2-emitDCEGraph.js'), open(path_from_root('tests', 'optimizer', 'minimal-runtime-2-emitDCEGraph-output.js')).read(),
+       ['emitDCEGraph', 'noPrint']),
       (path_from_root('tests', 'optimizer', 'standalone-emitDCEGraph.js'), open(path_from_root('tests', 'optimizer', 'standalone-emitDCEGraph-output.js')).read(),
        ['emitDCEGraph', 'noPrint']),
       (path_from_root('tests', 'optimizer', 'emittedJSPreservesParens.js'), open(path_from_root('tests', 'optimizer', 'emittedJSPreservesParens-output.js')).read(),

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -566,7 +566,8 @@ function emitDCEGraph(ast) {
   // or, in the minimal runtime, it looks like
   //
   //  WebAssembly.instantiate(Module["wasm"], imports).then(function(output) {
-  //   var asm = output.instance.exports;
+  //   var asm = output.instance.exports; // may also not have "var", if
+  //                                      // declared outside and used elsewhere
   //   ..
   //   _malloc = asm["malloc"];
   //   ..
@@ -663,38 +664,48 @@ function emitDCEGraph(ast) {
         var body = node.body.body;
         if (body.length >= 1) {
           var first = body[0];
+          var target, value; // "(var?) target = value"
+          // Look either for  var asm =  or just   asm =
           if (first.type === 'VariableDeclaration' && first.declarations.length === 1) {
             var decl = first.declarations[0];
-            if (decl.id.type === 'Identifier' && decl.id.name === 'asm') {
-              var value = decl.init;
-              if (value.type === 'MemberExpression' &&
-                  value.object.type === 'MemberExpression' &&
-                  value.object.object.type === 'Identifier' &&
-                  value.object.object.name === 'output' &&
-                  value.object.property.type === 'Identifier' &&
-                  value.object.property.name === 'instance' &&
-                  value.property.type === 'Identifier' &&
-                  value.property.name === 'exports') {
-                // This looks very much like what we are looking for.
-                assert(!foundMinimalRuntimeExports);
-                for (var i = 1; i < body.length; i++) {
-                  var item = body[i];
-                  if (item.type === 'ExpressionStatement' &&
-                      item.expression.type === 'AssignmentExpression' &&
-                      item.expression.operator === '=' &&
-                      item.expression.left.type === 'Identifier' &&
-                      item.expression.right.type === 'MemberExpression' &&
-                      item.expression.right.object.type === 'Identifier' &&
-                      item.expression.right.object.name === 'asm' &&
-                      item.expression.right.property.type === 'Literal') {
-                    var name = item.expression.left.name;
-                    var asmName = item.expression.right.property.value;
-                    saveAsmExport(name, asmName);
-                    emptyOut(item); // ignore all this in the second pass; this does not root
-                  }
+            target = decl.id;
+            value = decl.init;
+          } else if (first.type === 'ExpressionStatement' &&
+                     first.expression.type === 'AssignmentExpression') {
+            var assign = first.expression;
+            if (assign.operator === '=') {
+              target = assign.left;
+              value = assign.right;
+            }
+          }
+          if (target.type === 'Identifier' && target.name === 'asm' && value) {
+            if (value.type === 'MemberExpression' &&
+                value.object.type === 'MemberExpression' &&
+                value.object.object.type === 'Identifier' &&
+                value.object.object.name === 'output' &&
+                value.object.property.type === 'Identifier' &&
+                value.object.property.name === 'instance' &&
+                value.property.type === 'Identifier' &&
+                value.property.name === 'exports') {
+              // This looks very much like what we are looking for.
+              assert(!foundMinimalRuntimeExports);
+              for (var i = 1; i < body.length; i++) {
+                var item = body[i];
+                if (item.type === 'ExpressionStatement' &&
+                    item.expression.type === 'AssignmentExpression' &&
+                    item.expression.operator === '=' &&
+                    item.expression.left.type === 'Identifier' &&
+                    item.expression.right.type === 'MemberExpression' &&
+                    item.expression.right.object.type === 'Identifier' &&
+                    item.expression.right.object.name === 'asm' &&
+                    item.expression.right.property.type === 'Literal') {
+                  var name = item.expression.left.name;
+                  var asmName = item.expression.right.property.value;
+                  saveAsmExport(name, asmName);
+                  emptyOut(item); // ignore all this in the second pass; this does not root
                 }
-                foundMinimalRuntimeExports = true;
               }
+              foundMinimalRuntimeExports = true;
             }
           }
         }


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/pull/10663#discussion_r394211149
for background: the asm exports in that mode are not always
received as `var asm =` but sometimes just `asm =` if `asm` is declared
in the outer scope (if something might use them).

@juj note that it appears there is no `var asm` emitted yet? (so closure
errors on minimal runtime + embind for example)