### PR TITLE
Clear out asm assignments in minimal runtime metadce

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -2,9 +2,9 @@
   "a.html": 588,
   "a.html.gz": 386,
   "a.js": 24518,
-  "a.js.gz": 9119,
+  "a.js.gz": 9124,
   "a.mem": 3168,
   "a.mem.gz": 2711,
   "total": 28274,
-  "total_gz": 12216
+  "total_gz": 12221
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -2,9 +2,9 @@
   "a.html": 588,
   "a.html.gz": 386,
   "a.js": 24013,
-  "a.js.gz": 8955,
+  "a.js.gz": 8962,
   "a.mem": 3168,
   "a.mem.gz": 2711,
   "total": 27769,
-  "total_gz": 12052
+  "total_gz": 12059
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -2,9 +2,9 @@
   "a.html": 697,
   "a.html.gz": 437,
   "a.js": 2026,
-  "a.js.gz": 911,
+  "a.js.gz": 913,
   "a.mem": 6,
   "a.mem.gz": 32,
   "total": 2729,
-  "total_gz": 1380
+  "total_gz": 1382
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 20054,
-  "a.html.gz": 8394,
+  "a.html": 20051,
+  "a.html.gz": 8371,
   "total": 20054,
-  "total_gz": 8394
+  "total_gz": 8371
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
   "a.html": 20051,
   "a.html.gz": 8371,
-  "total": 20054,
+  "total": 20051,
   "total_gz": 8371
 }

--- a/tests/optimizer/minimal-runtime-applyDCEGraphRemovals-output.js
+++ b/tests/optimizer/minimal-runtime-applyDCEGraphRemovals-output.js
@@ -10,7 +10,7 @@ WebAssembly.instantiate(Module["wasm"], imports).then(function(output) {
  expD1 = asm["expD1"];
  expD2 = asm["expD2"];
  expD3 = asm["expD3"];
- expD4 = asm["expD4"];
+
  initRuntime(asm);
  ready();
 });

--- a/tests/optimizer/minimal-runtime-applyDCEGraphRemovals-output.js
+++ b/tests/optimizer/minimal-runtime-applyDCEGraphRemovals-output.js
@@ -1,0 +1,28 @@
+var name;
+
+var asmLibraryArg = {
+ "save1": 1,
+ "save2": 2
+};
+
+WebAssembly.instantiate(Module["wasm"], imports).then(function(output) {
+ asm = output.instance.exports;
+ expD1 = asm["expD1"];
+ expD2 = asm["expD2"];
+ expD3 = asm["expD3"];
+ expD4 = asm["expD4"];
+ initRuntime(asm);
+ ready();
+});
+
+expD1;
+
+Module["expD2"];
+
+asm["expD3"];
+
+expI1;
+
+Module["expI2"];
+
+asm["expI3"];

--- a/tests/optimizer/minimal-runtime-applyDCEGraphRemovals-output.js
+++ b/tests/optimizer/minimal-runtime-applyDCEGraphRemovals-output.js
@@ -20,9 +20,3 @@ expD1;
 Module["expD2"];
 
 asm["expD3"];
-
-expI1;
-
-Module["expI2"];
-
-asm["expI3"];

--- a/tests/optimizer/minimal-runtime-applyDCEGraphRemovals.js
+++ b/tests/optimizer/minimal-runtime-applyDCEGraphRemovals.js
@@ -17,8 +17,4 @@ expD1;
 Module['expD2'];
 asm['expD3'];
 
-expI1;
-Module['expI2'];
-asm['expI3'];
-
 // EXTRA_INFO: { "unused": ["emcc$import$number", "emcc$import$name", "emcc$import$func", "emcc$export$expD4", "emcc$export$expI4"] }

--- a/tests/optimizer/minimal-runtime-applyDCEGraphRemovals.js
+++ b/tests/optimizer/minimal-runtime-applyDCEGraphRemovals.js
@@ -1,0 +1,24 @@
+var name;
+var asmLibraryArg = { 'save1': 1, 'number': 33, 'name': name, 'func': function() {}, 'save2': 2 };
+
+// exports gotten directly in the minimal runtime style
+WebAssembly.instantiate(Module["wasm"], imports).then(function(output) {
+ asm = output.instance.exports;
+ expD1 = asm['expD1'];
+ expD2 = asm['expD2'];
+ expD3 = asm['expD3'];
+ expD4 = asm['expD4'];
+ initRuntime(asm);
+ ready();
+});
+
+// add uses for some of them, leave *4 as non-roots
+expD1;
+Module['expD2'];
+asm['expD3'];
+
+expI1;
+Module['expI2'];
+asm['expI3'];
+
+// EXTRA_INFO: { "unused": ["emcc$import$number", "emcc$import$name", "emcc$import$func", "emcc$export$expD4", "emcc$export$expI4"] }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2171,6 +2171,8 @@ int f() {
        ['emitDCEGraph', 'noPrint']),
       (path_from_root('tests', 'optimizer', 'emitDCEGraph5.js'), open(path_from_root('tests', 'optimizer', 'emitDCEGraph5-output.js')).read(),
        ['emitDCEGraph', 'noPrint']),
+      (path_from_root('tests', 'optimizer', 'minimal-runtime-applyDCEGraphRemovals.js'), open(path_from_root('tests', 'optimizer', 'minimal-runtime-applyDCEGraphRemovals-output.js')).read(),
+       ['applyDCEGraphRemovals']),
       (path_from_root('tests', 'optimizer', 'applyDCEGraphRemovals.js'), open(path_from_root('tests', 'optimizer', 'applyDCEGraphRemovals-output.js')).read(),
        ['applyDCEGraphRemovals']),
       (path_from_root('tests', 'optimizer', 'applyImportAndExportNameChanges.js'), open(path_from_root('tests', 'optimizer', 'applyImportAndExportNameChanges-output.js')).read(),


### PR DESCRIPTION
Before this, if X was never used (via metadce), we would still have
```javascript
 X = asm['X']
```
After this that doesn't exist.

Normally closure does this, so it turns out this doesn't help much
in practice. But it's good to have a guarantee I suppose, does
help one existing test, and does help in non-closure builds by
making them more readable.

Note the first two commits just create a new test and update
expectations before doing any actual change. The actual change
is in the last commit.
