### PR TITLE
Don't use python's logging for user errors/warnings

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -40,7 +40,7 @@ import base64
 from subprocess import PIPE
 
 import emscripten
-from tools import shared, system_libs, client_mods, js_optimizer, jsrun, colored_logger
+from tools import shared, system_libs, client_mods, js_optimizer, jsrun, colored_logger, diagnostics
 from tools.shared import unsuffixed, unsuffixed_basename, WINDOWS, safe_copy, safe_move, run_process, asbytes, read_and_preprocess, exit_with_error, DEBUG
 from tools.response_file import substitute_response_files
 from tools.minimal_runtime_shell import generate_minimal_runtime_html
@@ -3007,6 +3007,7 @@ def parse_args(newargs):
       settings_changes.append('USE_PTHREADS=1')
     elif newargs[i] in ('-fno-diagnostics-color', '-fdiagnostics-color=never'):
       colored_logger.disable()
+      diagnostics.color_enabled = False
     elif newargs[i] == '-no-canonical-prefixes':
       options.expand_symlinks = False
     elif newargs[i] == '-Werror':

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9864,11 +9864,11 @@ int main () {
 
     # By default warnings are not shown
     stderr = run_process(cmd, stderr=PIPE).stderr
-    self.assertNotContained('WARNING', stderr)
+    self.assertNotContained('warning', stderr)
 
     # Adding or -Wlegacy-settings enables the warning
     stderr = run_process(cmd + ['-Wlegacy-settings'], stderr=PIPE).stderr
-    self.assertContained('WARNING: use of legacy setting: SPLIT_MEMORY', stderr)
+    self.assertContained('warning: use of legacy setting: SPLIT_MEMORY', stderr)
     self.assertContained('[-Wlegacy-settings]', stderr)
 
   def test_strict_mode_legacy_settings(self):
@@ -10083,7 +10083,7 @@ int main () {
     returncode, output = self.run_on_pty([PYTHON, EMCC, 'src.c'])
     self.assertNotEqual(returncode, 0)
     self.assertIn(b"\x1b[1msrc.c:1:13: \x1b[0m\x1b[0;1;31merror: \x1b[0m\x1b[1mexpected '}'\x1b[0m", output)
-    self.assertIn(b"shared:ERROR: \x1b[31m", output)
+    self.assertIn(b"\x1b[31merror: ", output)
 
   @parameterized({
     'fno_diagnostics_color': ['-fno-diagnostics-color'],
@@ -10356,10 +10356,10 @@ Module.arguments has been replaced with plain arguments_
   @no_fastcomp('lld-specific')
   def test_supported_linker_flags(self):
     out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,waka'], stderr=PIPE).stderr
-    self.assertContained('WARNING: ignoring unsupported linker flag: `waka', out)
+    self.assertContained('warning: ignoring unsupported linker flag: `waka', out)
     out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'),
                        '-Wl,--no-check-features,--no-threads,-mllvm,-debug,--trace,--trace-symbol=main'], stderr=PIPE).stderr
-    self.assertNotContained('WARNING: ignoring unsupported linker flag', out)
+    self.assertNotContained('warning: ignoring unsupported linker flag', out)
 
   def test_non_wasm_without_wasm_in_vm(self):
     # Test that our non-wasm output does not depend on wasm support in the vm.
@@ -10401,23 +10401,23 @@ Module.arguments has been replaced with plain arguments_
 
     # warning that is enabled by default
     stderr = run_process(cmd, stderr=PIPE).stderr
-    self.assertContained('WARNING: not_object.bc is not a valid input file [-Winvalid-input]', stderr)
+    self.assertContained('emcc: warning: not_object.bc is not a valid input file [-Winvalid-input]', stderr)
 
     # -w to suppress warnings
     stderr = run_process(cmd + ['-w'], stderr=PIPE).stderr
-    self.assertNotContained('WARNING', stderr)
+    self.assertNotContained('warning', stderr)
 
     # -Wno-invalid-input to suppress just this one warning
     stderr = run_process(cmd + ['-Wno-invalid-input'], stderr=PIPE).stderr
-    self.assertNotContained('WARNING', stderr)
+    self.assertNotContained('warning', stderr)
 
     # with -Werror should fail
     stderr = self.expect_fail(cmd + ['-Werror'])
-    self.assertContained('ERROR: not_object.bc is not a valid input file [-Winvalid-input] [-Werror]', stderr)
+    self.assertContained('emcc: error: not_object.bc is not a valid input file [-Winvalid-input] [-Werror]', stderr)
 
     # with -Werror + -Wno-error=<type> should only warn
     stderr = run_process(cmd + ['-Werror', '-Wno-error=invalid-input'], stderr=PIPE).stderr
-    self.assertContained('WARNING: not_object.bc is not a valid input file [-Winvalid-input]', stderr)
+    self.assertContained('emcc: warning: not_object.bc is not a valid input file [-Winvalid-input]', stderr)
 
   def test_emranlib(self):
     create_test_file('foo.c', 'int foo = 1;')

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -243,7 +243,7 @@ class sanity(RunnerCore):
         if 'LLVM_ROOT' not in settings:
           self.assertContained('Error in evaluating %s' % EM_CONFIG, output)
         elif 'runner.py' not in ' '.join(command):
-          self.assertContained('ERROR', output) # sanity check should fail
+          self.assertContained('error:', output) # sanity check should fail
 
   def test_llvm(self):
     LLVM_WARNING = 'LLVM version appears incorrect'

--- a/tools/colored_logger.py
+++ b/tools/colored_logger.py
@@ -49,12 +49,6 @@ def add_coloring_to_emit_windows(fn):
     ctypes.windll.kernel32.SetConsoleTextAttribute(hdl, code)
 
   def new(*args):
-    FOREGROUND_BLUE      = 0x0001 # noqa; text color contains blue.
-    FOREGROUND_GREEN     = 0x0002 # noqa; text color contains green.
-    FOREGROUND_RED       = 0x0004 # noqa; text color contains red.
-    FOREGROUND_INTENSITY = 0x0008 # noqa; text color is intensified.
-    FOREGROUND_WHITE     = FOREGROUND_BLUE|FOREGROUND_GREEN |FOREGROUND_RED # noqa
-
     # wincon.h
     FOREGROUND_BLACK     = 0x0000 # noqa
     FOREGROUND_BLUE      = 0x0001 # noqa
@@ -65,6 +59,8 @@ def add_coloring_to_emit_windows(fn):
     FOREGROUND_YELLOW    = 0x0006 # noqa
     FOREGROUND_GREY      = 0x0007 # noqa
     FOREGROUND_INTENSITY = 0x0008 # foreground color is intensified.
+
+    FOREGROUND_WHITE     = FOREGROUND_BLUE|FOREGROUND_GREEN |FOREGROUND_RED # noqa
 
     BACKGROUND_BLACK     = 0x0000 # noqa
     BACKGROUND_BLUE      = 0x0010 # noqa
@@ -88,6 +84,7 @@ def add_coloring_to_emit_windows(fn):
         color = FOREGROUND_MAGENTA
     else:
         color = FOREGROUND_WHITE
+
     old_color = _get_color()
     _set_color(color)
     ret = fn(*args)

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -1,0 +1,155 @@
+# Copyright 2011 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+"""Simple color-enabled diagnositics reporting functions.
+"""
+
+import ctypes
+import os
+import sys
+
+WINDOWS = sys.platform.startswith('win')
+
+color_enabled = sys.stderr.isatty()
+tool_name = os.path.splitext(os.path.basename(sys.argv[0]))[0]
+
+# diagnostic levels
+WARN = 1
+ERROR = 2
+FATAL = 3
+
+# available colors
+RED = 1
+GREEN = 2
+YELLOW = 3
+BLUE = 4
+MAGENTA = 5
+CYAN = 6
+WHITE = 7
+
+# color for use for each diagnostic level
+level_colors = {
+    WARN: MAGENTA,
+    ERROR: RED,
+}
+
+level_prefixes = {
+    WARN: 'warning: ',
+    ERROR: 'error: ',
+}
+
+# Constants from the Windows API
+STD_OUTPUT_HANDLE = -11
+
+
+def output_color_windows(color):
+  # TODO(sbc): This code is duplicated in colored_logger.py.  Refactor.
+  # wincon.h
+  FOREGROUND_BLACK     = 0x0000 # noqa
+  FOREGROUND_BLUE      = 0x0001 # noqa
+  FOREGROUND_GREEN     = 0x0002 # noqa
+  FOREGROUND_CYAN      = 0x0003 # noqa
+  FOREGROUND_RED       = 0x0004 # noqa
+  FOREGROUND_MAGENTA   = 0x0005 # noqa
+  FOREGROUND_YELLOW    = 0x0006 # noqa
+  FOREGROUND_GREY      = 0x0007 # noqa
+
+  color_map = {
+    RED: FOREGROUND_RED,
+    GREEN: FOREGROUND_GREEN,
+    YELLOW: FOREGROUND_YELLOW,
+    BLUE: FOREGROUND_BLUE,
+    MAGENTA: FOREGROUND_MAGENTA,
+    CYAN: FOREGROUND_CYAN,
+    WHITE: FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED
+  }
+
+  sys.stderr.flush()
+  hdl = ctypes.windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+  ctypes.windll.kernel32.SetConsoleTextAttribute(hdl, color_map[color])
+
+
+def get_color_windows():
+  SHORT = ctypes.c_short
+  WORD = ctypes.c_ushort
+
+  class COORD(ctypes.Structure):
+    _fields_ = [
+      ("X", SHORT),
+      ("Y", SHORT)]
+
+  class SMALL_RECT(ctypes.Structure):
+    _fields_ = [
+      ("Left", SHORT),
+      ("Top", SHORT),
+      ("Right", SHORT),
+      ("Bottom", SHORT)]
+
+  class CONSOLE_SCREEN_BUFFER_INFO(ctypes.Structure):
+    _fields_ = [
+      ("dwSize", COORD),
+      ("dwCursorPosition", COORD),
+      ("wAttributes", WORD),
+      ("srWindow", SMALL_RECT),
+      ("dwMaximumWindowSize", COORD)]
+
+  hdl = ctypes.windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+  csbi = CONSOLE_SCREEN_BUFFER_INFO()
+  ctypes.windll.kernel32.GetConsoleScreenBufferInfo(hdl, ctypes.byref(csbi))
+  return csbi.wAttributes
+
+
+def reset_color_windows():
+  sys.stderr.flush()
+  hdl = ctypes.windll.kernel32.GetStdHandle(STD_OUTPUT_HANDLE)
+  ctypes.windll.kernel32.SetConsoleTextAttribute(hdl, default_color)
+
+
+def output_color(color):
+  if WINDOWS:
+    return output_color_windows(color)
+  return '\033[3%sm' % color
+
+
+def reset_color():
+  if WINDOWS:
+    return reset_color_windows()
+  return '\033[0m'
+
+
+def diag(level, msg, *args):
+  # Format output message as:
+  # <tool>: <level>: msg
+  # With the `<level>:` part being colored accordingly.
+  sys.stderr.write(tool_name + ': ')
+
+  if color_enabled:
+    output = output_color(level_colors[level])
+    if output:
+      sys.stderr.write(output)
+
+  sys.stderr.write(level_prefixes[level])
+
+  if color_enabled:
+    output = reset_color()
+    if output:
+      sys.stderr.write(output)
+
+  if args:
+    msg = msg % args
+  sys.stderr.write(str(msg))
+  sys.stderr.write('\n')
+
+
+def error(msg, *args):
+  diag(ERROR, msg, *args)
+
+
+def warn(msg, *args):
+  diag(WARN, msg, *args)
+
+
+if WINDOWS:
+  default_color = get_color_windows()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -34,6 +34,8 @@ from .toolchain_profiler import ToolchainProfiler
 from .tempfiles import try_delete
 from . import jsrun, cache, tempfiles, colored_logger
 from . import response_file
+from . import diagnostics
+
 
 __rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 WINDOWS = sys.platform.startswith('win')
@@ -55,13 +57,13 @@ if sys.version_info < (2, 7, 12):
 
 
 def exit_with_error(msg, *args):
-  logger.error(str(msg), *args)
+  diagnostics.error(msg, *args)
   sys.exit(1)
 
 
 # TODO(sbc): Convert all caller to WarningManager
 def warning(msg, *args):
-  logger.warning(str(msg), *args)
+  diagnostics.warn(str(msg), *args)
   if Settings.WARNINGS_ARE_ERRORS:
     exit_with_error('treating warnings as errors (-Werror)')
 
@@ -816,7 +818,7 @@ class WarningManager(object):
       if warning_info['error']:
         exit_with_error(msg + ' [-Werror]')
       else:
-        logger.warning(msg)
+        diagnostics.warn(msg)
     else:
       logger.debug('disabled warning: ' + msg)
 
@@ -845,7 +847,7 @@ class Configuration(object):
         self.EMSCRIPTEN_TEMP_DIR = self.CANONICAL_TEMP_DIR
         safe_ensure_dirs(self.EMSCRIPTEN_TEMP_DIR)
       except Exception as e:
-        logger.error(str(e) + 'Could not create canonical temp dir. Check definition of TEMP_DIR in ' + hint_config_file_location())
+        exit_with_error(str(e) + 'Could not create canonical temp dir. Check definition of TEMP_DIR in ' + hint_config_file_location())
 
   def get_temp_files(self):
     return tempfiles.TempFiles(


### PR DESCRIPTION
The python `logging` module is really designed as a debug tool.  For
user-visible error messages we want more direct control.  We don't
want the extra information the logging module provides and we have
out own infrastructure for enabling/disabling warnings.

This change adds a new `diagnostics.py` module that handles displaying
user visible errors and warnings.

We still use `logging.py` for debug output (e.g. EMCC_DEBUG=1)

As a followup change I plan to move the WarningManager into this file.