### PR TITLE
Allow linker flags to pass through to wasm-ld by default.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Pass linker flags dirctly to wasm-ld by default.  We still filter out certain
+  flags explcitly.  If there are other flags that it would be useful for us
+  to ignore we can add them to the list of ignored flags.
 - Optionally support 2GB+ heap sizes. To do this we make the JS code have unsigned
   pointers (we need all 32 bits in them now), which can slightly increase code
   size (>>> instead of >>). This only happens when the heap size may be over
@@ -24,7 +27,7 @@ Current Trunk
   higher value (i.e. by default you do not get support for 2GB+ heaps).
   See #10601
 - `--llvm-lto` flag is now ignored when using the upstream llvm backend.
-  With the upstrema backend LTO is controlled via `-flto`.
+  With the upstream backend LTO is controlled via `-flto`.
 - Require format string for emscripten_log.
 - Program entry points without extensions are now shell scripts rather than
   python programs. See #10729.  This means that `python emcc` no longer works.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10420,11 +10420,17 @@ Module.arguments has been replaced with plain arguments_
 
   @no_fastcomp('lld-specific')
   def test_supported_linker_flags(self):
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,waka'], stderr=PIPE).stderr
-    self.assertContained('warning: ignoring unsupported linker flag: `waka', out)
+    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,--print-map'], stderr=PIPE).stderr
+    self.assertContained('warning: ignoring unsupported linker flag: `--print-map`', out)
+
     out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'),
-                       '-Wl,--no-check-features,--no-threads,-mllvm,-debug,--trace,--trace-symbol=main'], stderr=PIPE).stderr
+                       '-Wl,--no-check-features,--no-threads,-mllvm,-debug'], stderr=PIPE).stderr
     self.assertNotContained('warning: ignoring unsupported linker flag', out)
+
+  @no_fastcomp('lld-specific')
+  def test_linker_flags_pass_through(self):
+    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,--waka'])
+    self.assertContained('wasm-ld: error: unknown argument: --waka', err)
 
   def test_non_wasm_without_wasm_in_vm(self):
     # Test that our non-wasm output does not depend on wasm support in the vm.


### PR DESCRIPTION
Rather then maintain an ever growing whitelist of supported linker
flags, instead list the linker flags that we want to explicitly ignore
for compatibility purposed with existing build systems.