### PR TITLE
Fix an acorn optimizer regression from #10724

### DIFF
--- a/tests/optimizer/emitDCEGraph.js
+++ b/tests/optimizer/emitDCEGraph.js
@@ -99,3 +99,7 @@ Module['dynCall_vi'](ptr, 1); // use on module
 dynCall('vii', ptr, [2, 3]); // use indirectly, depending on analysis of dynCall(string, )
 // and viii is never used, so definitely legitimately eliminatable
 
+(function(output) {
+  x++;
+});
+

--- a/tests/optimizer/emitDCEGraph.js
+++ b/tests/optimizer/emitDCEGraph.js
@@ -99,6 +99,7 @@ Module['dynCall_vi'](ptr, 1); // use on module
 dynCall('vii', ptr, [2, 3]); // use indirectly, depending on analysis of dynCall(string, )
 // and viii is never used, so definitely legitimately eliminatable
 
+// Don't crash on this code pattern, which regressed in #10724
 (function(output) {
   x++;
 });

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -685,7 +685,7 @@ function emitDCEGraph(ast) {
               value = assign.right;
             }
           }
-          if (target.type === 'Identifier' && target.name === 'asm' && value) {
+          if (target && target.type === 'Identifier' && target.name === 'asm' && value) {
             if (value.type === 'MemberExpression' &&
                 value.object.type === 'MemberExpression' &&
                 value.object.object.type === 'Identifier' &&


### PR DESCRIPTION
Don't crash on certain lambda contents that partially match
what we are looking for, but are not identical. Specifically,
we assumed the first line in lambda was a `var` or an assign.