### PR TITLE
Support -gseparate-dwarf with SINGLE_FILE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1200,6 +1200,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.WASM == 2 and shared.Settings.SINGLE_FILE:
       exit_with_error('cannot have both WASM=2 and SINGLE_FILE enabled at the same time (pick either JS to target with -s WASM=0 or Wasm to target with -s WASM=1)')
 
+    if shared.Settings.SEPARATE_DWARF and shared.Settings.WASM2JS:
+      exit_with_error('cannot have both SEPARATE_DWARF and WASM2JS at the same time (as there is no wasm file)')
+
     if shared.Settings.MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and shared.Settings.MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION:
       exit_with_error('MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION are mutually exclusive!')
 
@@ -3310,6 +3313,9 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
     shared.Building.handle_final_wasm_symbols(wasm_file=wasm_binary_target, symbols_file=symbols_file, debug_info=debug_info)
     save_intermediate_with_wasm('symbolmap', wasm_binary_target)
 
+  if shared.Settings.DEBUG_LEVEL >= 3 and shared.Settings.SEPARATE_DWARF and os.path.exists(wasm_binary_target):
+    shared.Building.emit_debug_on_side(wasm_binary_target)
+
   # replace placeholder strings with correct subresource locations
   if shared.Settings.SINGLE_FILE:
     js = open(final).read()
@@ -3332,9 +3338,6 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       shared.try_delete(target)
     with open(final, 'w') as f:
       f.write(js)
-
-  if shared.Settings.DEBUG_LEVEL >= 3 and shared.Settings.SEPARATE_DWARF:
-    shared.Building.emit_debug_on_side(wasm_binary_target)
 
 
 def modularize():


### PR DESCRIPTION
In `SINGLE_FILE` the wasm is embedded in the JS. We need to
emit the file with DWARF on the side first, before we remove it.

Also add an error for `SEPARATE_DWARF and WASM2JS` which
the test caught. In that case there is no wasm file at all - we are just
emitting JS - so having DWARF doesn't make sense.

Also improve the test for this to remove some unnecessary
combinations, wasm+meminit (we never emit a mem init file
in that case) and closure+debug (debug disables closure).

Fixes #10758
