### PR TITLE
Add `make dist` target for creating a distibutable version of emscripten

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  create:
+    tags:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  archive:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: make dist
+      run: |
+        make dist
+        version=`cat emscripten-version.txt | sed s/\"//g`
+        echo "::set-env name=VERSION::$version"
+    - uses: actions/upload-artifact@v1
+      with:
+        name: emscripten-${{ env.VERSION }}
+        path: emscripten-${{ env.VERSION }}.tar.bz2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+VERSION=$(shell cat emscripten-version.txt | sed s/\"//g)
+DISTDIR=../emscripten-$(VERSION)
+EXCLUDES=tests site __pycache__ node_modules docs Makefile
+DISTFILE=emscripten-$(VERSION).tar.bz2
+EXCLUDE_PATTERN=--exclude='*.pyc' --exclude='*/__pycache__'
+
+dist: $(DISTFILE)
+
+# Create an distributable archive of emscripten suitable for use
+# by end users.  This archive excludes parts of the codebase that
+# are you only used by emscripten developers.
+$(DISTFILE):
+	@rm -rf $(DISTDIR)
+	mkdir $(DISTDIR)
+	cp -ar * $(DISTDIR)
+	for exclude in $(EXCLUDES); do rm -rf $(DISTDIR)/$$exclude; done
+	tar cf $@ $(EXCLUDE_PATTERN) -C `dirname $(DISTDIR)` `basename $(DISTDIR)`
+
+.PHONY: dist


### PR DESCRIPTION
This target creates an archive that excludes parts of the source tree
that are not needed by end users.

Significantly we don't include `.git` or `tests`.

The resulting archive is 29Mb compressed and 36Mb uncompressed where as
the unfiltered contents currently in emsdk is 114Mb compressed and nd
131Mb uncompressed.

Currently the only use for the rules is to upload an artifact to github
CI.  However as a followup we can start using this rule when building
the emsdk archives to save significant amount data for our users.