### PR TITLE
Fix pthreads stack alignment in fastcomp pthreads

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1898,7 +1898,7 @@ function asmJsEstablishStackFrame(stackBase, stackMax) {
   STACKTOP = stackBase;
   STACK_MAX = stackMax;
   tempDoublePtr = STACKTOP;
-  STACKTOP = (STACKTOP + 8)|0;
+  STACKTOP = (STACKTOP + 16)|0;
 }
 ''')
 

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1335,10 +1335,10 @@ var LibraryPThread = {
     // the stack by the bytes used.
     tempDoublePtr = STACK_BASE;
 #if ASSERTIONS
-    assert(tempDoublePtr % 8 == 0);
+    assert(tempDoublePtr % 16 == 0);
 #endif
-    STACK_BASE += 8;
-    STACKTOP += 8;
+    STACK_BASE += 16;
+    STACKTOP += 16;
 #endif
 
 #if WASM_BACKEND && STACK_OVERFLOW_CHECK >= 2


### PR DESCRIPTION
Fix pthreads stack alignment in fastcomp pthreads - stack must be 16 bytes aligned (LLVM does optimizations that turn stack + 8 -> stack | 8)