### PR TITLE
Pass Module to callback functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -460,3 +460,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Kirill Gavrilov <kirill@sview.ru>
 * Karl Semich <0xloem@gmail.com>
 * Louis DeScioli <descioli@google.com> (copyright owned by Google, LLC)
+* Kleis Auke Wolthuizen <info@kleisauke.nl>

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -454,7 +454,12 @@ function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
     if (typeof callback == 'function') {
+// In modularize mode, we pass the module as the first argument.
+#if MODULARIZE
+      callback(Module);
+#else
       callback();
+#endif
       continue;
     }
     var func = callback.func;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -454,12 +454,7 @@ function callRuntimeCallbacks(callbacks) {
   while(callbacks.length > 0) {
     var callback = callbacks.shift();
     if (typeof callback == 'function') {
-// In modularize mode, we pass the module as the first argument.
-#if MODULARIZE
-      callback(Module);
-#else
-      callback();
-#endif
+      callback(Module); // Pass the module as the first argument.
       continue;
     }
     var func = callback.func;


### PR DESCRIPTION
This ensures that users can still invoke runtime elements within the
`preRun` function that are exported on `Module` (for e.g. `ENV` or `FS`)
when compiling with `-s MODULARIZE=1`.

Example usage:
```js
var options = {
    preRun: [function (module) {
        module.ENV.hello = 'world';
        module.FS.createPreloadedFile('/', 'foo', 'bar', true, false);
    }]
};
Module(options).then(function (module) {

});
```
Note: this example requires that the code is compiled with
```bash
-s "EXTRA_EXPORTED_RUNTIME_METHODS=['FS', 'ENV']"
```

Resolves #9827.