### PR TITLE
fix(mmap): support read-only

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -259,7 +259,7 @@ var SyscallsLibrary = {
 #if CAN_ADDRESS_2GB
     ptr >>>= 0;
 #endif
-    SYSCALLS.mappings[ptr] = { malloc: ptr, len: len, allocated: allocated, fd: fd, flags: flags, offset: off };
+    SYSCALLS.mappings[ptr] = { malloc: ptr, len: len, allocated: allocated, fd: fd, prot: prot, flags: flags, offset: off };
     return ptr;
   },
 
@@ -281,7 +281,9 @@ var SyscallsLibrary = {
     if (len === info.len) {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
       var stream = FS.getStream(info.fd);
-      SYSCALLS.doMsync(addr, stream, len, info.flags, info.offset);
+      if (info.prot & {{{ cDefine('PROT_WRITE') }}}) {
+        SYSCALLS.doMsync(addr, stream, len, info.flags, info.offset);
+      }
       FS.munmap(stream);
 #else
 #if ASSERTIONS

--- a/tests/fs/test_mmap.out
+++ b/tests/fs/test_mmap.out
@@ -1,4 +1,5 @@
 /yolo/in.txt content=mmap ftw!
 /yolo/out.txt content=written mmap
+/yolo/outreadonly.txt content=readonly mmap
 /yolo/private.txt content=
 /yolo/sharedoffset.txt content=written shared mmap with offset 32768


### PR DESCRIPTION
only do msync on munmap if PROT_WRITE is set