### PR TITLE
Replace throw() with _NOEXCEPT defined in libcxx

### DIFF
--- a/system/include/libcxx/__sso_allocator
+++ b/system/include/libcxx/__sso_allocator
@@ -40,9 +40,9 @@ public:
     typedef _Tp*              pointer;
     typedef _Tp               value_type;
 
-    _LIBCPP_INLINE_VISIBILITY __sso_allocator() throw() : __allocated_(false) {}
-    _LIBCPP_INLINE_VISIBILITY __sso_allocator(const __sso_allocator&) throw() : __allocated_(false) {}
-    template <class _Up> _LIBCPP_INLINE_VISIBILITY __sso_allocator(const __sso_allocator<_Up, _Np>&) throw()
+    _LIBCPP_INLINE_VISIBILITY __sso_allocator() _NOEXCEPT : __allocated_(false) {}
+    _LIBCPP_INLINE_VISIBILITY __sso_allocator(const __sso_allocator&) _NOEXCEPT : __allocated_(false) {}
+    template <class _Up> _LIBCPP_INLINE_VISIBILITY __sso_allocator(const __sso_allocator<_Up, _Np>&) _NOEXCEPT
          : __allocated_(false) {}
 private:
     __sso_allocator& operator=(const __sso_allocator&);
@@ -63,7 +63,7 @@ public:
         else
             _VSTD::__libcpp_deallocate(__p, __n * sizeof(_Tp), _LIBCPP_ALIGNOF(_Tp));
     }
-    _LIBCPP_INLINE_VISIBILITY size_type max_size() const throw() {return size_type(~0) / sizeof(_Tp);}
+    _LIBCPP_INLINE_VISIBILITY size_type max_size() const _NOEXCEPT {return size_type(~0) / sizeof(_Tp);}
 
     _LIBCPP_INLINE_VISIBILITY
     bool operator==(__sso_allocator& __a) const {return &buf_ == &__a.buf_;}

--- a/system/include/libcxx/codecvt
+++ b/system/include/libcxx/codecvt
@@ -102,11 +102,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -137,11 +137,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -172,11 +172,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <class _Elem, unsigned long _Maxcode = 0x10ffff,
@@ -225,11 +225,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -260,11 +260,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -295,11 +295,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -330,11 +330,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -365,11 +365,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -400,11 +400,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <class _Elem, unsigned long _Maxcode = 0x10ffff,
@@ -453,11 +453,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -488,11 +488,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <>
@@ -523,11 +523,11 @@ protected:
     virtual result
         do_unshift(state_type& __st,
                    extern_type* __to, extern_type* __to_end, extern_type*& __to_nxt) const;
-    virtual int do_encoding() const throw();
-    virtual bool do_always_noconv() const throw();
+    virtual int do_encoding() const _NOEXCEPT;
+    virtual bool do_always_noconv() const _NOEXCEPT;
     virtual int do_length(state_type&, const extern_type* __frm, const extern_type* __end,
                           size_t __mx) const;
-    virtual int do_max_length() const throw();
+    virtual int do_max_length() const _NOEXCEPT;
 };
 
 template <class _Elem, unsigned long _Maxcode = 0x10ffff,

--- a/system/include/libcxx/ios
+++ b/system/include/libcxx/ios
@@ -431,7 +431,7 @@ class _LIBCPP_EXCEPTION_ABI ios_base::failure
 public:
     explicit failure(const string& __msg, const error_code& __ec = io_errc::stream);
     explicit failure(const char* __msg, const error_code& __ec = io_errc::stream);
-    virtual ~failure() throw();
+    virtual ~failure() _NOEXCEPT;
 };
 
 _LIBCPP_NORETURN inline _LIBCPP_INLINE_VISIBILITY

--- a/system/include/libcxx/memory
+++ b/system/include/libcxx/memory
@@ -2083,39 +2083,39 @@ private:
 public:
     typedef _Tp element_type;
 
-    _LIBCPP_INLINE_VISIBILITY explicit auto_ptr(_Tp* __p = 0) throw() : __ptr_(__p) {}
-    _LIBCPP_INLINE_VISIBILITY auto_ptr(auto_ptr& __p) throw() : __ptr_(__p.release()) {}
-    template<class _Up> _LIBCPP_INLINE_VISIBILITY auto_ptr(auto_ptr<_Up>& __p) throw()
+    _LIBCPP_INLINE_VISIBILITY explicit auto_ptr(_Tp* __p = 0) _NOEXCEPT : __ptr_(__p) {}
+    _LIBCPP_INLINE_VISIBILITY auto_ptr(auto_ptr& __p) _NOEXCEPT : __ptr_(__p.release()) {}
+    template<class _Up> _LIBCPP_INLINE_VISIBILITY auto_ptr(auto_ptr<_Up>& __p) _NOEXCEPT
         : __ptr_(__p.release()) {}
-    _LIBCPP_INLINE_VISIBILITY auto_ptr& operator=(auto_ptr& __p) throw()
+    _LIBCPP_INLINE_VISIBILITY auto_ptr& operator=(auto_ptr& __p) _NOEXCEPT
         {reset(__p.release()); return *this;}
-    template<class _Up> _LIBCPP_INLINE_VISIBILITY auto_ptr& operator=(auto_ptr<_Up>& __p) throw()
+    template<class _Up> _LIBCPP_INLINE_VISIBILITY auto_ptr& operator=(auto_ptr<_Up>& __p) _NOEXCEPT
         {reset(__p.release()); return *this;}
-    _LIBCPP_INLINE_VISIBILITY auto_ptr& operator=(auto_ptr_ref<_Tp> __p) throw()
+    _LIBCPP_INLINE_VISIBILITY auto_ptr& operator=(auto_ptr_ref<_Tp> __p) _NOEXCEPT
         {reset(__p.__ptr_); return *this;}
-    _LIBCPP_INLINE_VISIBILITY ~auto_ptr() throw() {delete __ptr_;}
+    _LIBCPP_INLINE_VISIBILITY ~auto_ptr() _NOEXCEPT {delete __ptr_;}
 
-    _LIBCPP_INLINE_VISIBILITY _Tp& operator*() const throw()
+    _LIBCPP_INLINE_VISIBILITY _Tp& operator*() const _NOEXCEPT
         {return *__ptr_;}
-    _LIBCPP_INLINE_VISIBILITY _Tp* operator->() const throw() {return __ptr_;}
-    _LIBCPP_INLINE_VISIBILITY _Tp* get() const throw() {return __ptr_;}
-    _LIBCPP_INLINE_VISIBILITY _Tp* release() throw()
+    _LIBCPP_INLINE_VISIBILITY _Tp* operator->() const _NOEXCEPT {return __ptr_;}
+    _LIBCPP_INLINE_VISIBILITY _Tp* get() const _NOEXCEPT {return __ptr_;}
+    _LIBCPP_INLINE_VISIBILITY _Tp* release() _NOEXCEPT
     {
         _Tp* __t = __ptr_;
         __ptr_ = 0;
         return __t;
     }
-    _LIBCPP_INLINE_VISIBILITY void reset(_Tp* __p = 0) throw()
+    _LIBCPP_INLINE_VISIBILITY void reset(_Tp* __p = 0) _NOEXCEPT
     {
         if (__ptr_ != __p)
             delete __ptr_;
         __ptr_ = __p;
     }
 
-    _LIBCPP_INLINE_VISIBILITY auto_ptr(auto_ptr_ref<_Tp> __p) throw() : __ptr_(__p.__ptr_) {}
-    template<class _Up> _LIBCPP_INLINE_VISIBILITY operator auto_ptr_ref<_Up>() throw()
+    _LIBCPP_INLINE_VISIBILITY auto_ptr(auto_ptr_ref<_Tp> __p) _NOEXCEPT : __ptr_(__p.__ptr_) {}
+    template<class _Up> _LIBCPP_INLINE_VISIBILITY operator auto_ptr_ref<_Up>() _NOEXCEPT
         {auto_ptr_ref<_Up> __t; __t.__ptr_ = release(); return __t;}
-    template<class _Up> _LIBCPP_INLINE_VISIBILITY operator auto_ptr<_Up>() throw()
+    template<class _Up> _LIBCPP_INLINE_VISIBILITY operator auto_ptr<_Up>() _NOEXCEPT
         {return auto_ptr<_Up>(release());}
 };
 

--- a/system/include/libcxx/regex
+++ b/system/include/libcxx/regex
@@ -976,7 +976,7 @@ class _LIBCPP_EXCEPTION_ABI regex_error
     regex_constants::error_type __code_;
 public:
     explicit regex_error(regex_constants::error_type __ecode);
-    virtual ~regex_error() throw();
+    virtual ~regex_error() _NOEXCEPT;
      _LIBCPP_INLINE_VISIBILITY
     regex_constants::error_type code() const {return __code_;}
 };

--- a/system/lib/libcxx/ios.cpp
+++ b/system/lib/libcxx/ios.cpp
@@ -84,7 +84,7 @@ ios_base::failure::failure(const char* msg, const error_code& ec)
 {
 }
 
-ios_base::failure::~failure() throw()
+ios_base::failure::~failure() _NOEXCEPT
 {
 }
 

--- a/system/lib/libcxx/regex.cpp
+++ b/system/lib/libcxx/regex.cpp
@@ -64,7 +64,7 @@ regex_error::regex_error(regex_constants::error_type ecode)
       __code_(ecode)
 {}
 
-regex_error::~regex_error() throw() {}
+regex_error::~regex_error() _NOEXCEPT {}
 
 namespace {
 

--- a/system/lib/libcxxabi/include/cxxabi.h
+++ b/system/lib/libcxxabi/include/cxxabi.h
@@ -32,24 +32,15 @@ class type_info; // forward declaration
 #endif
 }
 
-// XXX EMSCRIPTEN: Wasm exception handling has not yet implemented support for
-// exception specification. This temporarily changes 'throw()` with 'noexcept'
-// to make wasm EH working in the interim.
-#ifdef __USING_WASM_EXCEPTIONS__
-#define _NOTHROW noexcept
-#else
-#define _NOTHROW throw()
-#endif
-
 // runtime routines use C calling conventions, but are in __cxxabiv1 namespace
 namespace __cxxabiv1 {
 extern "C"  {
 
 // 2.4.2 Allocating the Exception Object
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_allocate_exception(size_t thrown_size) _NOTHROW;
+__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT;
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_free_exception(void *thrown_exception) _NOTHROW;
+__cxa_free_exception(void *thrown_exception) _NOEXCEPT;
 
 // 2.4.3 Throwing the Exception Object
 extern _LIBCXXABI_FUNC_VIS _LIBCXXABI_NORETURN void
@@ -62,9 +53,9 @@ __cxa_throw(void *thrown_exception, std::type_info *tinfo,
 
 // 2.5.3 Exception Handlers
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_get_exception_ptr(void *exceptionObject) _NOTHROW;
+__cxa_get_exception_ptr(void *exceptionObject) _NOEXCEPT;
 extern _LIBCXXABI_FUNC_VIS void *
-__cxa_begin_catch(void *exceptionObject) _NOTHROW;
+__cxa_begin_catch(void *exceptionObject) _NOEXCEPT;
 extern _LIBCXXABI_FUNC_VIS void __cxa_end_catch();
 #if defined(_LIBCXXABI_ARM_EHABI)
 extern _LIBCXXABI_FUNC_VIS bool
@@ -159,17 +150,17 @@ extern _LIBCXXABI_FUNC_VIS char *__cxa_demangle(const char *mangled_name,
 
 // Apple additions to support C++ 0x exception_ptr class
 // These are primitives to wrap a smart pointer around an exception object
-extern _LIBCXXABI_FUNC_VIS void *__cxa_current_primary_exception() _NOTHROW;
+extern _LIBCXXABI_FUNC_VIS void *__cxa_current_primary_exception() _NOEXCEPT;
 extern _LIBCXXABI_FUNC_VIS void
 __cxa_rethrow_primary_exception(void *primary_exception);
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_increment_exception_refcount(void *primary_exception) _NOTHROW;
+__cxa_increment_exception_refcount(void *primary_exception) _NOEXCEPT;
 extern _LIBCXXABI_FUNC_VIS void
-__cxa_decrement_exception_refcount(void *primary_exception) _NOTHROW;
+__cxa_decrement_exception_refcount(void *primary_exception) _NOEXCEPT;
 
 // Apple extension to support std::uncaught_exception()
-extern _LIBCXXABI_FUNC_VIS bool __cxa_uncaught_exception() _NOTHROW;
-extern _LIBCXXABI_FUNC_VIS unsigned int __cxa_uncaught_exceptions() _NOTHROW;
+extern _LIBCXXABI_FUNC_VIS bool __cxa_uncaught_exception() _NOEXCEPT;
+extern _LIBCXXABI_FUNC_VIS unsigned int __cxa_uncaught_exceptions() _NOEXCEPT;
 
 #if defined(__linux__) || defined(__Fuchsia__)
 // Linux and Fuchsia TLS support. Not yet an official part of the Itanium ABI.

--- a/system/lib/libcxxabi/readme.txt
+++ b/system/lib/libcxxabi/readme.txt
@@ -18,4 +18,9 @@ Local modifications are marked with the comment: 'XXX EMSCRIPTEN'
 2. Duplicate __isOurExceptionClass in cxa_handlers.cpp since we don't compile
    cxa_exception.cpp in Emscripten EH mode.
 
-3. Define and use _NOTHROW macro in cxxabi.h
+The following changes are not marked with 'XXX EMSCRIPTEN'.
+
+3. Replace throw() with _NOEXCEPT macro defined in libcxx/include/__config.
+
+4. Wasm exception handling support code is added and guarded by
+   '#ifdef __USING_WASM_EXCEPTIONS__'.

--- a/system/lib/libcxxabi/src/cxa_exception.cpp
+++ b/system/lib/libcxxabi/src/cxa_exception.cpp
@@ -181,7 +181,7 @@ extern "C" {
 //  object. Zero-fill the object. If memory can't be allocated, call
 //  std::terminate. Return a pointer to the memory to be used for the
 //  user's exception object.
-void *__cxa_allocate_exception(size_t thrown_size) _NOTHROW {
+void *__cxa_allocate_exception(size_t thrown_size) _NOEXCEPT {
     size_t actual_size = cxa_exception_size_from_exception_thrown_size(thrown_size);
 
     // Allocate extra space before the __cxa_exception header to ensure the
@@ -199,7 +199,7 @@ void *__cxa_allocate_exception(size_t thrown_size) _NOTHROW {
 
 
 //  Free a __cxa_exception object allocated with __cxa_allocate_exception.
-void __cxa_free_exception(void *thrown_object) _NOTHROW {
+void __cxa_free_exception(void *thrown_object) _NOEXCEPT {
     // Compute the size of the padding before the header.
     size_t header_offset = get_cxa_exception_offset();
     char *raw_buffer =
@@ -298,7 +298,7 @@ The adjusted pointer is computed by the personality routine during phase 1
 
   Requires:  exception is native
 */
-void *__cxa_get_exception_ptr(void *unwind_exception) _NOTHROW {
+void *__cxa_get_exception_ptr(void *unwind_exception) _NOEXCEPT {
 #if defined(_LIBCXXABI_ARM_EHABI)
     return reinterpret_cast<void*>(
         static_cast<_Unwind_Control_Block*>(unwind_exception)->barrier_cache.bitpattern[0]);
@@ -313,7 +313,7 @@ void *__cxa_get_exception_ptr(void *unwind_exception) _NOTHROW {
 The routine to be called before the cleanup.  This will save __cxa_exception in
 __cxa_eh_globals, so that __cxa_end_cleanup() can recover later.
 */
-bool __cxa_begin_cleanup(void *unwind_arg) _NOTHROW {
+bool __cxa_begin_cleanup(void *unwind_arg) _NOEXCEPT {
     _Unwind_Exception* unwind_exception = static_cast<_Unwind_Exception*>(unwind_arg);
     __cxa_eh_globals* globals = __cxa_get_globals();
     __cxa_exception* exception_header =
@@ -424,7 +424,7 @@ to terminate or unexpected during unwinding.
   _Unwind_Exception and return a pointer to that.
 */
 void*
-__cxa_begin_catch(void* unwind_arg) _NOTHROW
+__cxa_begin_catch(void* unwind_arg) _NOEXCEPT
 {
     _Unwind_Exception* unwind_exception = static_cast<_Unwind_Exception*>(unwind_arg);
     bool native_exception = __isOurExceptionClass(unwind_exception);
@@ -632,7 +632,7 @@ void __cxa_rethrow() {
     Requires:  If thrown_object is not NULL, it is a native exception.
 */
 void
-__cxa_increment_exception_refcount(void *thrown_object) _NOTHROW {
+__cxa_increment_exception_refcount(void *thrown_object) _NOEXCEPT {
     if (thrown_object != NULL )
     {
         __cxa_exception* exception_header = cxa_exception_from_thrown_object(thrown_object);
@@ -649,7 +649,7 @@ __cxa_increment_exception_refcount(void *thrown_object) _NOTHROW {
     Requires:  If thrown_object is not NULL, it is a native exception.
 */
 _LIBCXXABI_NO_CFI
-void __cxa_decrement_exception_refcount(void *thrown_object) _NOTHROW {
+void __cxa_decrement_exception_refcount(void *thrown_object) _NOEXCEPT {
     if (thrown_object != NULL )
     {
         __cxa_exception* exception_header = cxa_exception_from_thrown_object(thrown_object);
@@ -672,7 +672,7 @@ void __cxa_decrement_exception_refcount(void *thrown_object) _NOTHROW {
     been no exceptions thrown, ever, on this thread, we can return NULL without 
     the need to allocate the exception-handling globals.
 */
-void *__cxa_current_primary_exception() _NOTHROW {
+void *__cxa_current_primary_exception() _NOEXCEPT {
 //  get the current exception
     __cxa_eh_globals* globals = __cxa_get_globals_fast();
     if (NULL == globals)
@@ -744,10 +744,10 @@ __cxa_rethrow_primary_exception(void* thrown_object)
 }
 
 bool
-__cxa_uncaught_exception() _NOTHROW { return __cxa_uncaught_exceptions() != 0; }
+__cxa_uncaught_exception() _NOEXCEPT { return __cxa_uncaught_exceptions() != 0; }
 
 unsigned int
-__cxa_uncaught_exceptions() _NOTHROW
+__cxa_uncaught_exceptions() _NOEXCEPT
 {
     // This does not report foreign exceptions in flight
     __cxa_eh_globals* globals = __cxa_get_globals_fast();


### PR DESCRIPTION
This deletes [`_NOTHROW`](https://github.com/emscripten-core/emscripten/blob/fb64aea56c831fd8faba67469e67e8a184662e00/system/lib/libcxxabi/include/cxxabi.h#L35-L42) defined in libcxxabi by #10577 and uses
[`_NOEXCEPT`](https://github.com/emscripten-core/emscripten/blob/fb64aea56c831fd8faba67469e67e8a184662e00/system/include/libcxx/__config#L780-L786) already defined in libcxx/include/__config. This also
replaces some existing `throw()`s with `_NOEXCEPT`. `_NOEXCEPT` becomes
`noexcept` when it is available, i.e., this is C++11 or above, and falls
back to `throw()` if not.

The current libcxx/libcxxabi is a bit messy that many parts of
libcxx/libcxxabi are already using this `_NOEXCEPT` but not all of them.
This replaces most `throw()` with `_NOEXCEPT` but leaves some `throw()`,
the ones in files that are not built at all by Emscripten or not used
by wasm EH, to reduce deviations from the original library.

This is mostly for wasm EH to work because wasm EH does not support
exception specifications yet and does not have a short-term plan to
support it, but I think this is better in general (because exception
specification is deprecated already in C++11 and will be removed later)
and does not change semantics for users. Also, for many changes in
function declarations in the headers of libcxx here, their corresponding
definitions in cpp files are already using `_NOEXCEPT`. (Turns out
compiler considers `void foo() throw();` as a valid declaration for the
function body `void foo() noexcept { ... }`)

I'm planning to make a Clang change that ignores exception
specifications for wasm for a temporary measure (Windows frontend
[ignores](https://github.com/llvm/llvm-project/blob/09158252f777c2e2f06a86b154c44abcbcf9bb74/clang/lib/CodeGen/CGException.cpp#L467-L470) it too, so that shouldn't be a very serious problem for now). So
after this PR and that Clang change, Wasm EH will use `noexcept` with
C++11 or above and will ignore `throw()` in C++03 or below.