### PR TITLE
Include git rev in emscripten-version.txt during `make dist`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 VERSION=$(shell cat emscripten-version.txt | sed s/\"//g)
+GIT_HASH=$(shell git rev-parse HEAD)
 DISTDIR=../emscripten-$(VERSION)
-EXCLUDES=tests site __pycache__ node_modules docs Makefile
+EXCLUDES=tests/third_party site __pycache__ node_modules docs Makefile
 DISTFILE=emscripten-$(VERSION).tar.bz2
 EXCLUDE_PATTERN=--exclude='*.pyc' --exclude='*/__pycache__'
 
@@ -13,6 +14,7 @@ $(DISTFILE):
 	@rm -rf $(DISTDIR)
 	mkdir $(DISTDIR)
 	cp -ar * $(DISTDIR)
+	echo "$(VERSION) ($(GIT_HASH))" > $(DISTDIR)/emscripten-version.txt
 	for exclude in $(EXCLUDES); do rm -rf $(DISTDIR)/$$exclude; done
 	tar cf $@ $(EXCLUDE_PATTERN) -C `dirname $(DISTDIR)` `basename $(DISTDIR)`
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -548,13 +548,18 @@ def check_node_version():
     return False
 
 
-def get_emscripten_version(path):
-  return open(path).read().strip().replace('"', '')
+def set_version_globals():
+  global EMSCRIPTEN_VERSION, EMSCRIPTEN_VERSION_MAJOR, EMSCRIPTEN_VERSION_MINOR, EMSCRIPTEN_VERSION_TINY
+  filename = path_from_root('emscripten-version.txt')
+  with open(filename) as f:
+    EMSCRIPTEN_VERSION = f.read().strip().replace('"', '')
+  version = EMSCRIPTEN_VERSION.split()[0]
+  parts = [int(x) for x in version.split('.')]
+  EMSCRIPTEN_VERSION_MAJOR, EMSCRIPTEN_VERSION_MINOR, EMSCRIPTEN_VERSION_TINY = parts
 
 
-EMSCRIPTEN_VERSION = get_emscripten_version(path_from_root('emscripten-version.txt'))
-parts = [int(x) for x in EMSCRIPTEN_VERSION.split('.')]
-EMSCRIPTEN_VERSION_MAJOR, EMSCRIPTEN_VERSION_MINOR, EMSCRIPTEN_VERSION_TINY = parts
+set_version_globals()
+
 # For the Emscripten-specific WASM metadata section, follows semver, changes
 # whenever metadata section changes structure.
 # NB: major version 0 implies no compatibility


### PR DESCRIPTION
This will allow emsdk and other distributions to include an accurate
git sha.

Also, include tests/ directory in archive, but not tests/third_party/.
This should have been part of #10761.

This fixes #10660 in a more satisfactory way.