### PR TITLE
Add `make install` rule for use when distibuting emscripten

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,16 @@ EXCLUDE_PATTERN=--exclude='*.pyc' --exclude='*/__pycache__'
 
 dist: $(DISTFILE)
 
-# Create an distributable archive of emscripten suitable for use
-# by end users.  This archive excludes parts of the codebase that
-# are you only used by emscripten developers.
-$(DISTFILE):
+install:
 	@rm -rf $(DISTDIR)
 	mkdir $(DISTDIR)
 	cp -ar * $(DISTDIR)
 	for exclude in $(EXCLUDES); do rm -rf $(DISTDIR)/$$exclude; done
+
+# Create an distributable archive of emscripten suitable for use
+# by end users.  This archive excludes parts of the codebase that
+# are you only used by emscripten developers.
+$(DISTFILE): install
 	tar cf $@ $(EXCLUDE_PATTERN) -C `dirname $(DISTDIR)` `basename $(DISTDIR)`
 
-.PHONY: dist
+.PHONY: dist install


### PR DESCRIPTION
I plan to use this on https://github.com/WebAssembly/waterfall/.