### PR TITLE
Use `emscripten-revision.txt` file to store extra version information

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ install:
 	@rm -rf $(DISTDIR)
 	mkdir $(DISTDIR)
 	cp -ar * $(DISTDIR)
-	echo "$(VERSION) ($(GIT_HASH))" > $(DISTDIR)/emscripten-version.txt
+	echo "$(GIT_HASH)" > $(DISTDIR)/emscripten-revision.txt
 	for exclude in $(EXCLUDES); do rm -rf $(DISTDIR)/$$exclude; done
 
 # Create an distributable archive of emscripten suitable for use

--- a/docs/process.md
+++ b/docs/process.md
@@ -137,6 +137,10 @@ If you package Emscripten for users in some manner, the details in the rest of
 this document should be helpful with understanding versioning and so forth.
 This section goes into that in more detail.
 
+You can use `make install` or `make dist` to produce a cut down version of
+emscripten suitable for end users.  This mostly excludes certain parts of the
+source tree that are only relevant to emscripten developers.
+
 The core
 [DEPS](https://chromium.googlesource.com/emscripten-releases/+/refs/heads/master/DEPS)
 file in the chromium `emscripten-releases` contains all the information about versions

--- a/emcc.py
+++ b/emcc.py
@@ -633,7 +633,11 @@ emcc: supported targets: llvm bitcode, javascript, NOT elf
     # look up and find the revision in a parent directory that is a git repo
     revision = ''
     if os.path.exists(shared.path_from_root('.git')):
-      revision = ' (' + run_process(['git', 'show'], stdout=PIPE, stderr=PIPE, cwd=shared.path_from_root()).stdout.splitlines()[0] + ')'
+      revision = run_process(['git', 'rev-parse', 'HEAD'], stdout=PIPE, stderr=PIPE, cwd=shared.path_from_root()).stdout.strip()
+    elif os.path.exists(shared.path_from_root('emscripten-revision.txt')):
+      revision = open(shared.path_from_root('emscripten-revision.txt')).read().strip()
+    if revision:
+      revision = ' (%s)' % revision
     print('''emcc (Emscripten gcc/clang-like replacement) %s%s
 Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
 This is free and open source software under the MIT license.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -553,8 +553,7 @@ def set_version_globals():
   filename = path_from_root('emscripten-version.txt')
   with open(filename) as f:
     EMSCRIPTEN_VERSION = f.read().strip().replace('"', '')
-  version = EMSCRIPTEN_VERSION.split()[0]
-  parts = [int(x) for x in version.split('.')]
+  parts = [int(x) for x in EMSCRIPTEN_VERSION.split('.')]
   EMSCRIPTEN_VERSION_MAJOR, EMSCRIPTEN_VERSION_MINOR, EMSCRIPTEN_VERSION_TINY = parts
 
 


### PR DESCRIPTION
Rather than adding this to the existing `emscripten-version.txt` file.
Just in case anyone was parsing this outside of emscripten itself.

This is followup on #10789 based on feedback in that PR.

Also use `git rev-parse HEAD` to get the git revision for git users
which is slightly more efficient/reliable that trying to parse
`git show` output.