### PR TITLE
Ignore `-bind_at_load` linker flag

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -85,7 +85,7 @@ SUPPORTED_LINKER_FLAGS = (
 # Maps to true if the the flag takes an argument
 UNSUPPORTED_LLD_FLAGS = {
     # macOS-specific linker flag that libtool (ltmain.sh) will if macOS is detected.
-    '-bind_at_load', False,
+    '-bind_at_load': False,
     # wasm-ld doesn't support map files yet.
     '--print-map': False,
     '-M': False,

--- a/emcc.py
+++ b/emcc.py
@@ -84,8 +84,12 @@ SUPPORTED_LINKER_FLAGS = (
 
 # Maps to true if the the flag takes an argument
 UNSUPPORTED_LLD_FLAGS = {
+    # macOS-specific linker flag that libtool (ltmain.sh) will if macOS is detected.
+    '-bind_at_load', False,
+    # wasm-ld doesn't support map files yet.
     '--print-map': False,
     '-M': False,
+    # wasm-ld doesn't support soname yet
     '-soname': True
 }
 


### PR DESCRIPTION
This is an macOS-specific linker flag that some build system will add
when the build host is macOS.  Such build systems are technically
broken since they are not correctly detecting the fact that they are
cross compiling, but we help them out here by ignoring this flag
by default.