### PR TITLE
Fix lax option parsing for `--` options that take an argument

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2761,9 +2761,10 @@ def parse_args(newargs):
   eh_enabled = False
   wasm_eh_enabled = False
 
-  def check_bad_eq(arg):
-    if '=' in arg:
+  def check_arg(arg, value):
+    if arg.startswith(value) and '=' in arg:
       exit_with_error('Invalid parameter (do not use "=" with "--" options)')
+    return arg == value
 
   for i in range(len(newargs)):
     # On Windows Vista (and possibly others), excessive spaces in the command line
@@ -2783,15 +2784,13 @@ def parse_args(newargs):
         shared.Settings.SHRINK_LEVEL = 2
         settings_changes.append('INLINING_LIMIT=25')
       shared.Settings.OPT_LEVEL = validate_arg_level(options.requested_level, 3, 'Invalid optimization level: ' + newargs[i], clamp=True)
-    elif newargs[i].startswith('--js-opts'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--js-opts'):
       options.js_opts = int(newargs[i + 1])
       if options.js_opts:
         options.force_js_opts = True
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--llvm-opts'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--llvm-opts'):
       options.llvm_opts = parse_value(newargs[i + 1])
       newargs[i] = ''
       newargs[i + 1] = ''
@@ -2800,41 +2799,34 @@ def parse_args(newargs):
         shared.Settings.LTO = newargs[i].split('=')[1]
       else:
         shared.Settings.LTO = "full"
-    elif newargs[i].startswith('--llvm-lto'):
+    elif check_arg(newargs[i], '--llvm-lto'):
       if shared.Settings.WASM_BACKEND:
         logger.warning('--llvm-lto ignored when using llvm backend')
-      check_bad_eq(newargs[i])
       options.llvm_lto = int(newargs[i + 1])
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--closure-args'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--closure-args'):
       args = newargs[i + 1]
       options.closure_args += shlex.split(args)
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--closure'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--closure'):
       options.use_closure_compiler = int(newargs[i + 1])
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--js-transform'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--js-transform'):
       options.js_transform = newargs[i + 1]
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--pre-js'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--pre-js'):
       options.pre_js += open(newargs[i + 1]).read() + '\n'
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--post-js'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--post-js'):
       options.post_js += open(newargs[i + 1]).read() + '\n'
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--minify'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--minify'):
       assert newargs[i + 1] == '0', '0 is the only supported option for --minify; 1 has been deprecated'
       shared.Settings.DEBUG_LEVEL = max(1, shared.Settings.DEBUG_LEVEL)
       newargs[i] = ''
@@ -2897,18 +2889,15 @@ def parse_args(newargs):
       newargs[i] = ''
       shared.Settings.SYSTEM_JS_LIBRARIES.append(shared.path_from_root('src', 'embind', 'emval.js'))
       shared.Settings.SYSTEM_JS_LIBRARIES.append(shared.path_from_root('src', 'embind', 'embind.js'))
-    elif newargs[i].startswith('--embed-file'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--embed-file'):
       options.embed_files.append(newargs[i + 1])
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--preload-file'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--preload-file'):
       options.preload_files.append(newargs[i + 1])
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--exclude-file'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--exclude-file'):
       options.exclude_files.append(newargs[i + 1])
       newargs[i] = ''
       newargs[i + 1] = ''
@@ -2927,18 +2916,15 @@ def parse_args(newargs):
     elif newargs[i] == '-v':
       shared.PRINT_STAGES = True
       shared.check_sanity(force=True)
-    elif newargs[i].startswith('--shell-file'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--shell-file'):
       options.shell_path = newargs[i + 1]
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--source-map-base'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--source-map-base'):
       options.source_map_base = newargs[i + 1]
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i].startswith('--js-library'):
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--js-library'):
       shared.Settings.SYSTEM_JS_LIBRARIES.append(os.path.abspath(newargs[i + 1]))
       newargs[i] = ''
       newargs[i + 1] = ''
@@ -2948,8 +2934,7 @@ def parse_args(newargs):
     elif newargs[i] == '--jcache':
       logger.error('jcache is no longer supported')
       newargs[i] = ''
-    elif newargs[i] == '--cache':
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--cache'):
       os.environ['EM_CACHE'] = os.path.normpath(newargs[i + 1])
       shared.reconfigure_cache()
       newargs[i] = ''
@@ -2968,13 +2953,11 @@ def parse_args(newargs):
     elif newargs[i] == '--show-ports':
       system_libs.show_ports()
       should_exit = True
-    elif newargs[i] == '--save-bc':
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--save-bc'):
       options.save_bc = newargs[i + 1]
       newargs[i] = ''
       newargs[i + 1] = ''
-    elif newargs[i] == '--memory-init-file':
-      check_bad_eq(newargs[i])
+    elif check_arg(newargs[i], '--memory-init-file'):
       options.memory_init_file = int(newargs[i + 1])
       newargs[i] = ''
       newargs[i + 1] = ''

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10650,9 +10650,16 @@ int main() {
     self.assertContained('undefined symbol:', self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nostdlib']))
     self.assertContained('undefined symbol:', self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nodefaultlibs']))
 
-    # Buil again but with explit system libraries
+    # Build again but with explit system libraries
     libs = ['-lc', '-lcompiler_rt']
     if self.is_wasm_backend():
       libs.append('-lc_rt_wasm')
     run_process([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nostdlib'] + libs)
     run_process([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nodefaultlibs'] + libs)
+
+  def test_argument_match(self):
+    # Verify that emcc arguments match preciely.  We had a bug where only the prefix
+    # was matched
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-opts', '10'])
+    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-optsXX'])
+    self.assertContained("error: unsupported option '--js-optsXX'", err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8932,10 +8932,10 @@ end
   def test_noderawfs_disables_embedding(self):
     expected = '--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem'
     base = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'NODERAWFS=1']
-    err = self.expect_fail(base + ['--preload-files', 'somefile'])
-    assert expected in err
-    err = self.expect_fail(base + ['--embed-files', 'somefile'])
-    assert expected in err
+    err = self.expect_fail(base + ['--preload-file', 'somefile'])
+    self.assertContained(expected, err)
+    err = self.expect_fail(base + ['--embed-file', 'somefile'])
+    self.assertContained(expected, err)
 
   def test_node_code_caching(self):
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'),

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10658,7 +10658,7 @@ int main() {
     run_process([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nodefaultlibs'] + libs)
 
   def test_argument_match(self):
-    # Verify that emcc arguments match preciely.  We had a bug where only the prefix
+    # Verify that emcc arguments match precisely.  We had a bug where only the prefix
     # was matched
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-opts', '10'])
     err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-optsXX'])


### PR DESCRIPTION
Previously we were accepting any option name that contained that
correct prefix.  So, for example `--pre-jsxxx` was the same as
`--pre-js`

See https://github.com/emscripten-core/emscripten/issues/10769