### PR TITLE
Avoid crash if an option is missing its argument

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2761,7 +2761,6 @@ def parse_args(newargs):
   eh_enabled = False
   wasm_eh_enabled = False
 
-
   for i in range(len(newargs)):
     # On Windows Vista (and possibly others), excessive spaces in the command line
     # leak into the items in this array, so trim e.g. 'foo.cpp ' -> 'foo.cpp'
@@ -2777,10 +2776,10 @@ def parse_args(newargs):
       # Consume that option and its argument
       if len(newargs) <= i + 1:
         exit_with_error("option '%s' requires an argument" % arg)
-      rtn = newargs[i + 1]
+      ret = newargs[i + 1]
       newargs[i] = ''
       newargs[i + 1] = ''
-      return rtn
+      return ret
 
     if newargs[i].startswith('-O'):
       # Let -O default to -O2, which is what gcc does.
@@ -3037,7 +3036,7 @@ def parse_args(newargs):
   if should_exit:
     sys.exit(0)
 
-  newargs = [arg for arg in newargs if arg]
+  newargs = [a for a in newargs if a]
   return options, settings_changes, newargs
 
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10663,3 +10663,7 @@ int main() {
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-opts', '10'])
     err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-optsXX'])
     self.assertContained("error: unsupported option '--js-optsXX'", err)
+
+  def test_missing_argument(self):
+    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-opts'])
+    self.assertContained("error: option '--js-opts' requires an argument", err)


### PR DESCRIPTION
Verify that there are enough arguments present before reading the
argument associated with an option.

This also simplifies the code a little by removing duplication.