### PR TITLE
Support not having ports

### DIFF
--- a/docs/process.md
+++ b/docs/process.md
@@ -213,6 +213,3 @@ key values in that file include:
 
 If you package emscripten and don't want the ports system to be used, you can
 simply delete the `tools/ports/` directory.
-
-You can also add custom ports to there as well; the system library code will
-just scan to see what exists and use it.

--- a/docs/process.md
+++ b/docs/process.md
@@ -208,3 +208,11 @@ key values in that file include:
  * `BINARYEN_ROOT`: The path to binaryen (the binaries are expected in `/bin` under there; note that
     despite the name this differs from `LLVM_ROOT` which points directly to the binaries).
  * `NODE_JS`: The path to Node.js, which is needed internally.
+
+## Ports
+
+If you package emscripten and don't want the ports system to be used, you can
+simply delete the `tools/ports/` directory.
+
+You can also add custom ports to there as well; the system library code will
+just scan to see what exists and use it.

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -17,9 +17,20 @@ import tarfile
 import zipfile
 from glob import iglob
 
-from . import ports
 from . import shared
 from tools.shared import mangle_c_symbol_name, demangle_c_symbol_name
+
+
+try:
+  from . import ports
+except ImportError:
+  # it's ok if the ports dir doesn't exist: then there are no ports
+  class NoPorts:
+    ports = []
+    ports_by_name = {}
+
+  ports = NoPorts()
+
 
 stdout = None
 stderr = None

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -20,17 +20,16 @@ from glob import iglob
 from . import shared
 from tools.shared import mangle_c_symbol_name, demangle_c_symbol_name
 
-
 try:
   from . import ports
+  # it's ok if the ports dir exists but is empty: then there are no ports
+  if not hasattr(ports, 'ports'):
+    ports.ports = []
 except ImportError:
   # it's ok if the ports dir doesn't exist: then there are no ports
   class NoPorts:
     ports = []
-    ports_by_name = {}
-
   ports = NoPorts()
-
 
 stdout = None
 stderr = None


### PR DESCRIPTION
This allows a packager to either remove the `tools/ports/`
directory entirely, or to have it exist but be empty. Everything
else will still work, but not ports.