### PR TITLE
Use malloc() in GL context creation only with pthreads

### DIFF
--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -93,7 +93,6 @@
   "emscripten_websocket_new": ["malloc"],
   "emscripten_wget_data": ["malloc"],
   "emscripten_webgl_destroy_context": ["emscripten_webgl_make_context_current", "emscripten_webgl_get_current_context"],
-  "emscripten_webgl_create_context": ["malloc", "free"],
   "emscripten_idb_async_load": ["malloc", "free"],
   "emscripten_idb_load": ["malloc", "free"],
   "wgpuDeviceCreateBuffer": ["malloc", "free"],

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1003,7 +1003,9 @@ var LibraryGL = {
       if (GL.currentContext === GL.contexts[contextHandle]) GL.currentContext = null;
       if (typeof JSEvents === 'object') JSEvents.removeAllHandlersOnTarget(GL.contexts[contextHandle].GLctx.canvas); // Release all JS event handlers on the DOM element that the GL context is associated with since the context is now deleted.
       if (GL.contexts[contextHandle] && GL.contexts[contextHandle].GLctx.canvas) GL.contexts[contextHandle].GLctx.canvas.GLctxObject = undefined; // Make sure the canvas object no longer refers to the context object so there are no GC surprises.
+#if USE_PTHREADS
       _free(GL.contexts[contextHandle].handle);
+#endif
       GL.contexts[contextHandle] = null;
     },
 

--- a/tests/code_size/hello_webgl2_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl2_fastcomp_asmjs.json
@@ -5,8 +5,8 @@
   "a.js.gz": 2505,
   "a.mem": 321,
   "a.mem.gz": 219,
-  "a.asm.js": 10514,
-  "a.asm.js.gz": 3662,
-  "total": 16751,
-  "total_gz": 6768
+  "a.asm.js": 9778,
+  "a.asm.js.gz": 3528,
+  "total": 16001,
+  "total_gz": 6634
 }

--- a/tests/code_size/hello_webgl2_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl2_fastcomp_asmjs.json
@@ -1,12 +1,12 @@
 {
   "a.html": 580,
   "a.html.gz": 382,
-  "a.js": 5336,
-  "a.js.gz": 2508,
+  "a.js": 5322,
+  "a.js.gz": 2505,
   "a.mem": 321,
   "a.mem.gz": 219,
   "a.asm.js": 10514,
   "a.asm.js.gz": 3662,
   "total": 16751,
-  "total_gz": 6771
+  "total_gz": 6768
 }

--- a/tests/code_size/hello_webgl2_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl2_fastcomp_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 5344,
   "a.js.gz": 2531,
-  "a.wasm": 8338,
-  "a.wasm.gz": 4488,
-  "total": 14265,
-  "total_gz": 7396
+  "a.wasm": 7982,
+  "a.wasm.gz": 4368,
+  "total": 13889,
+  "total_gz": 7276
 }

--- a/tests/code_size/hello_webgl2_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl2_fastcomp_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 5352,
-  "a.js.gz": 2540,
-  "a.wasm": 8350,
-  "a.wasm.gz": 4509,
+  "a.js": 5344,
+  "a.js.gz": 2531,
+  "a.wasm": 8338,
+  "a.wasm.gz": 4488,
   "total": 14265,
-  "total_gz": 7426
+  "total_gz": 7396
 }

--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 5133,
-  "a.js.gz": 2426,
-  "a.wasm": 11262,
-  "a.wasm.gz": 7065,
-  "total": 16958,
-  "total_gz": 9868
+  "a.js": 5123,
+  "a.js.gz": 2419,
+  "a.wasm": 11250,
+  "a.wasm.gz": 7052,
+  "total": 16946,
+  "total_gz": 9848
 }

--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 5123,
   "a.js.gz": 2419,
-  "a.wasm": 11250,
-  "a.wasm.gz": 7052,
-  "total": 16946,
-  "total_gz": 9848
+  "a.wasm": 10894,
+  "a.wasm.gz": 6920,
+  "total": 16580,
+  "total_gz": 9716
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 24457,
-  "a.js.gz": 9103,
+  "a.js": 23727,
+  "a.js.gz": 8896,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 28213,
-  "total_gz": 12200
+  "total": 27483,
+  "total_gz": 11993
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 24518,
-  "a.js.gz": 9124,
+  "a.js": 24457,
+  "a.js.gz": 9103,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 28274,
-  "total_gz": 12221
+  "total": 28213,
+  "total_gz": 12200
 }

--- a/tests/code_size/hello_webgl_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl_fastcomp_asmjs.json
@@ -5,8 +5,8 @@
   "a.js.gz": 2349,
   "a.mem": 321,
   "a.mem.gz": 219,
-  "a.asm.js": 10514,
-  "a.asm.js.gz": 3662,
-  "total": 16295,
-  "total_gz": 6612
+  "a.asm.js": 9778,
+  "a.asm.js.gz": 3528,
+  "total": 15547,
+  "total_gz": 6478
 }

--- a/tests/code_size/hello_webgl_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl_fastcomp_asmjs.json
@@ -1,12 +1,12 @@
 {
   "a.html": 580,
   "a.html.gz": 382,
-  "a.js": 4880,
-  "a.js.gz": 2353,
+  "a.js": 4868,
+  "a.js.gz": 2349,
   "a.mem": 321,
   "a.mem.gz": 219,
   "a.asm.js": 10514,
   "a.asm.js.gz": 3662,
   "total": 16295,
-  "total_gz": 6616
+  "total_gz": 6612
 }

--- a/tests/code_size/hello_webgl_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl_fastcomp_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 4844,
-  "a.js.gz": 2365,
-  "a.wasm": 8350,
-  "a.wasm.gz": 4509,
+  "a.js": 4837,
+  "a.js.gz": 2360,
+  "a.wasm": 8338,
+  "a.wasm.gz": 4488,
   "total": 13757,
-  "total_gz": 7251
+  "total_gz": 7225
 }

--- a/tests/code_size/hello_webgl_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl_fastcomp_wasm.json
@@ -2,9 +2,9 @@
   "a.html": 563,
   "a.html.gz": 377,
   "a.js": 4837,
-  "a.js.gz": 2360,
-  "a.wasm": 8338,
-  "a.wasm.gz": 4488,
-  "total": 13757,
-  "total_gz": 7225
+  "a.js.gz": 2361,
+  "a.wasm": 7982,
+  "a.wasm.gz": 4368,
+  "total": 13382,
+  "total_gz": 7106
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 4624,
-  "a.js.gz": 2254,
-  "a.wasm": 11262,
-  "a.wasm.gz": 7065,
-  "total": 16449,
-  "total_gz": 9696
+  "a.js": 4615,
+  "a.js.gz": 2248,
+  "a.wasm": 11250,
+  "a.wasm.gz": 7052,
+  "total": 16437,
+  "total_gz": 9677
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 4615,
   "a.js.gz": 2248,
-  "a.wasm": 11250,
-  "a.wasm.gz": 7052,
-  "total": 16437,
-  "total_gz": 9677
+  "a.wasm": 10894,
+  "a.wasm.gz": 6920,
+  "total": 16072,
+  "total_gz": 9545
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 24013,
-  "a.js.gz": 8962,
+  "a.js": 23952,
+  "a.js.gz": 8937,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 27769,
-  "total_gz": 12059
+  "total": 27708,
+  "total_gz": 12034
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23952,
-  "a.js.gz": 8937,
+  "a.js": 23222,
+  "a.js.gz": 8731,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 27708,
-  "total_gz": 12034
+  "total": 26978,
+  "total_gz": 11828
 }


### PR DESCRIPTION
A GL context is an opaque integer from the user's perspective. Internally
it is a heap allocation, and in pthreads we use that location in memory
to coordinate GL things between threads. However, in a non-pthreads
build that isn't necessary - we can just use an integer ID. Doing so
avoids using malloc/free, which in small programs can avoid bringing in
malloc/free unnecessarily.

This helps several of the code size tests by around 3% (see diff).

Noticed while looking at https://twitter.com/kripken/status/1245053277332357120
