### PR TITLE
Don't include fastcomp-specifc JS environ handlers under wasm

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -16,8 +16,13 @@ var STRUCT_LIST = set('struct', 'list');
 var addedLibraryItems = {};
 var asmLibraryFunctions = [];
 
-var allExternPrimitives = ['Math_floor', 'Math_abs', 'Math_sqrt', 'Math_pow', 'Math_cos', 'Math_sin', 'Math_tan', 'Math_acos', 'Math_asin', 'Math_atan', 'Math_atan2', 'Math_exp', 'Math_log', 'Math_ceil', 'Math_imul', 'Math_min', 'Math_max', 'Math_clz32', 'Math_fround',
-                           'Int8Array', 'Uint8Array', 'Int16Array', 'Uint16Array', 'Int32Array', 'Uint32Array', 'Float32Array', 'Float64Array'];
+var allExternPrimitives = ['Math_floor', 'Math_abs', 'Math_sqrt', 'Math_pow',
+  'Math_cos', 'Math_sin', 'Math_tan', 'Math_acos', 'Math_asin', 'Math_atan',
+  'Math_atan2', 'Math_exp', 'Math_log', 'Math_ceil', 'Math_imul', 'Math_min',
+  'Math_max', 'Math_clz32', 'Math_fround',
+  'Int8Array', 'Uint8Array', 'Int16Array', 'Uint16Array', 'Int32Array',
+  'Uint32Array', 'Float32Array', 'Float64Array'];
+
 // Specifies the set of referenced built-in primitives such as Math.max etc.
 var usedExternPrimitives = {};
 

--- a/src/library.js
+++ b/src/library.js
@@ -765,6 +765,7 @@ LibraryManager.library = {
   // in both fastcomp and upstream.
   $ENV: {},
 
+#if !WASM_BACKEND
   // This implementation of environ/getenv/etc. is used for fastcomp, due
   // to limitations in the system libraries (we can't easily add a global
   // ctor to create the environment without it always being linked in with
@@ -843,7 +844,6 @@ LibraryManager.library = {
     _getenv.ret = allocateUTF8(ENV[name]);
     return _getenv.ret;
   },
-  // Alias for sanitizers which intercept getenv.
   clearenv__deps: ['$ENV', '__buildEnvironment'],
   clearenv__proxy: 'sync',
   clearenv__sig: 'i',
@@ -923,6 +923,7 @@ LibraryManager.library = {
     }
     return 0;
   },
+#endif
 
   getloadavg: function(loadavg, nelem) {
     // int getloadavg(double loadavg[], int nelem);

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -3538,8 +3538,10 @@ var LibrarySDL = {
   SDL_ClearError: function() {},
 
   SDL_getenv: 'getenv',
+  SDL_getenv__sig: 'ii',
 
   SDL_putenv: 'putenv',
+  SDL_putenv__sig: 'ii',
 
   // TODO
 

--- a/src/modules.js
+++ b/src/modules.js
@@ -157,7 +157,9 @@ var LibraryManager = {
       libraries.push('library_webgpu.js');
     }
 
-    if (BOOTSTRAPPING_STRUCT_INFO) libraries = ['library_bootstrap_structInfo.js', 'library_formatString.js'];
+    if (BOOTSTRAPPING_STRUCT_INFO) {
+      libraries = ['library_bootstrap_structInfo.js', 'library_formatString.js'];
+    }
 
     // Deduplicate libraries to avoid processing any library file multiple times
     libraries = libraries.filter(function(item, pos) {

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1501,6 +1501,9 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
         added.add(ident)
         more = True
         for dep in deps:
+          # certain symbols in deps_info.json don't exist in the wasm backend
+          if shared.Settings.WASM_BACKEND and dep in ['_get_environ']:
+            continue
           need.undefs.add(dep)
           if shared.Settings.VERBOSE:
             logger.debug('adding dependency on %s due to deps-info on %s' % (dep, ident))


### PR DESCRIPTION
Also ignore _get_environ in deps_info.json under the wasm backend
since this symbol only exists under fastcomp