### PR TITLE
Reset selector before personality function call

### DIFF
--- a/system/lib/libunwind/src/Unwind-wasm.cpp
+++ b/system/lib/libunwind/src/Unwind-wasm.cpp
@@ -37,6 +37,9 @@ _Unwind_Reason_Code _Unwind_CallPersonality(void *exception_ptr) {
   _LIBUNWIND_TRACE_API("_Unwind_CallPersonality(exception_object=%p)",
                        (void *)exception_object);
 
+  // Reset the selector.
+  __wasm_lpad_context.selector = 0;
+
   // Call personality function. Wasm does not have two-phase unwinding, so we
   // only do the cleanup phase.
   _Unwind_Reason_Code ret = __gxx_personality_wasm0(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1480,14 +1480,13 @@ int main(int argc, char **argv)
       '''
       self.do_run(src, 'OK\n')
 
-  # TODO Enable @with_both_exception_handling (unknown error)
-  def test_exceptions_typed(self):
-    self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
+  @with_both_exception_handling
+  def test_exceptions_typed(self, js_engines):
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME', 1)
     self.emcc_args += ['-s', 'SAFE_HEAP=0'] # Throwing null will cause an ignorable null pointer access.
 
-    self.do_run_in_out_file_test('tests', 'core', 'test_exceptions_typed')
+    self.do_run_in_out_file_test('tests', 'core', 'test_exceptions_typed', js_engines=js_engines)
 
   # TODO Enable @with_both_exception_handling (EH spec is not supported yet)
   def test_exceptions_virtual_inheritance(self):


### PR DESCRIPTION
In libunwind, we need to reset the selector every time before we call
the personality function. If we don't do that, if the selector was set
to a specific value in the previous call and there's no matching `catch`
clause in the current call so the selector is not set, the previous
value will still remain and cause incorrect execution.

`test_exceptions_typed` should run fine after this and
https://github.com/llvm/llvm-project/commit/c87b5e7e22b2df92021ac5fcc69160901a5841a9.