### PR TITLE
Revert "Remove wordexp.c from musl whitelist (#10413)"

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -747,7 +747,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         'proto.c', 'gethostbyaddr.c', 'gethostbyaddr_r.c', 'gethostbyname.c',
         'gethostbyname2_r.c', 'gethostbyname_r.c', 'gethostbyname2.c',
         'usleep.c', 'alarm.c', 'syscall.c', '_exit.c', 'popen.c',
-        'getgrouplist.c', 'initgroups.c', 'timer_create.c',
+        'getgrouplist.c', 'initgroups.c', 'wordexp.c', 'timer_create.c',
         'faccessat.c',
     ]
 


### PR DESCRIPTION
This reverts commit 7199e47a301aad71125d365f603dec164976a36d.

Turns out this file depends on of symbols we don't currently
implement at all (fork, etc).  I noticed when I started looking at
checking for undefined symbols by default at link time (wasm-ld).