### PR TITLE
Make wasi environ helper function JS-only

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -247,9 +247,7 @@ function JSify(data, functionsOnly) {
       } else if (typeof snippet === 'function') {
         isFunction = true;
         snippet = processLibraryFunction(snippet, ident, finalName);
-        // Functions that start with '$' should not be imported to asm.js/wasm module, since they are
-        // intended to be exclusive to JS code only.
-        if (ident[0] != '$') {
+        if (!isJsOnlyIdentifier(ident[0])) {
           Functions.libraryFunctions[finalName] = 1;
         }
       }

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -11,7 +11,7 @@ var WasiLibrary = {
     _exit(code);
   },
 
-  $getEnvStrings: ['$ENV', '_getExecutableName'],
+  $getEnvStrings__deps: ['$ENV', '_getExecutableName'],
   $getEnvStrings: function() {
     if (!getEnvStrings.strings) {
       // Default values.

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -11,9 +11,9 @@ var WasiLibrary = {
     _exit(code);
   },
 
-  $get_env_strings__deps: ['$ENV', '_getExecutableName'],
-  $get_env_strings: function() {
-    if (!get_env_strings.strings) {
+  $getEnvStrings: ['$ENV', '_getExecutableName'],
+  $getEnvStrings: function() {
+    if (!getEnvStrings.strings) {
       // Default values.
       var env = {
         'USER': 'web_user',
@@ -33,15 +33,15 @@ var WasiLibrary = {
       for (var x in env) {
         strings.push(x + '=' + env[x]);
       }
-      get_env_strings.strings = strings;
+      getEnvStrings.strings = strings;
     }
-    return get_env_strings.strings;
+    return getEnvStrings.strings;
   },
 
-  environ_sizes_get__deps: ['$get_env_strings'],
+  environ_sizes_get__deps: ['$getEnvStrings'],
   environ_sizes_get__sig: 'iii',
   environ_sizes_get: function(penviron_count, penviron_buf_size) {
-    var strings = get_env_strings();
+    var strings = getEnvStrings();
     {{{ makeSetValue('penviron_count', 0, 'strings.length', 'i32') }}};
     var bufSize = 0;
     strings.forEach(function(string) {
@@ -51,7 +51,7 @@ var WasiLibrary = {
     return 0;
   },
 
-  environ_get__deps: ['$get_env_strings'
+  environ_get__deps: ['$getEnvStrings'
 #if MINIMAL_RUNTIME
     , '$writeAsciiToMemory'
 #endif
@@ -59,7 +59,7 @@ var WasiLibrary = {
   environ_get__sig: 'iii',
   environ_get: function(__environ, environ_buf) {
     var bufSize = 0;
-    get_env_strings().forEach(function(string, i) {
+    getEnvStrings().forEach(function(string, i) {
       var ptr = environ_buf + bufSize;
       {{{ makeSetValue('__environ', 'i * 4', 'ptr', 'i32') }}};
       writeAsciiToMemory(string, ptr);

--- a/src/utility.js
+++ b/src/utility.js
@@ -205,6 +205,12 @@ function isArray(x) {
   }
 }
 
+// Functions that start with '$' should not be imported to asm.js/wasm module.
+// They are intended to be exclusive to JS code only.
+function isJsOnlyIdentifier(ident) {
+  return ident[0] == '$';
+}
+
 function isJsLibraryConfigIdentifier(ident) {
   return ident.endsWith('__sig') || ident.endsWith('__proxy') || ident.endsWith('__asm') || ident.endsWith('__inline')
    || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs') || ident.endsWith('__import');


### PR DESCRIPTION
This function returns a JS array is not useful to native code.