### PR TITLE
Remove `emscripten_get_env`

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -844,7 +844,6 @@ LibraryManager.library = {
     return _getenv.ret;
   },
   // Alias for sanitizers which intercept getenv.
-  emscripten_get_env: 'getenv',
   clearenv__deps: ['$ENV', '__buildEnvironment'],
   clearenv__proxy: 'sync',
   clearenv__sig: 'i',

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cc
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cc
@@ -544,8 +544,6 @@ uptr internal_clock_gettime(__sanitizer_clockid_t clk_id, void *tp) {
 #endif  // !SANITIZER_SOLARIS && !SANITIZER_NETBSD
 
 #if SANITIZER_EMSCRIPTEN
-extern "C" const char *emscripten_get_env(const char *name);
-
 int __clock_gettime(__sanitizer_clockid_t clk_id, void *tp);
 
 uptr internal_clock_gettime(__sanitizer_clockid_t clk_id, void *tp) {
@@ -558,7 +556,7 @@ uptr internal_clock_gettime(__sanitizer_clockid_t clk_id, void *tp) {
 // should be called first inside __asan_init.
 const char *GetEnv(const char *name) {
 #if SANITIZER_FREEBSD || SANITIZER_NETBSD || SANITIZER_OPENBSD || \
-    SANITIZER_SOLARIS
+    SANITIZER_SOLARIS || SANITIZER_EMSCRIPTEN
   if (::environ != 0) {
     uptr NameLen = internal_strlen(name);
     for (char **Env = ::environ; *Env != 0; Env++) {
@@ -591,8 +589,6 @@ const char *GetEnv(const char *name) {
     p = endp + 1;
   }
   return nullptr;  // Not found.
-#elif SANITIZER_EMSCRIPTEN
-  return emscripten_get_env(name);
 #else
 #error "Unsupported platform"
 #endif


### PR DESCRIPTION
This function existed solely for sanitizer_linux.cc, but was supposed
to bypass any allocation etc introduced by libc.  Intead simply use
the approach found on other platforms of partings the `environ` global.
This global gets initialized at startup on both fastcomp and llvm.

This change also unblocks #10819
