### PR TITLE
Remove dummy/fake version of malloc/free

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1164,8 +1164,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
 
     if not shared.Settings.WASM_BACKEND:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
-        'memset', 'memcpy', 'malloc', 'free', 'emscripten_get_heap_size']
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['memset', 'memcpy', 'emscripten_get_heap_size']
 
     if shared.Settings.MINIMAL_RUNTIME or 'MINIMAL_RUNTIME=1' in settings_changes or 'MINIMAL_RUNTIME=2' in settings_changes:
       # Remove the default exported functions 'malloc', 'free', etc. those should only be linked in if used
@@ -1403,7 +1402,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       forced_stdlibs.append('libembind')
 
     if not shared.Settings.MINIMAL_RUNTIME:
-      # Always need malloc and free to be kept alive and exported, for internal use and other modules
+      # Always need malloc and free to be kept alive and exported, for internal use and other
+      # modules
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
 
     if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:

--- a/src/library.js
+++ b/src/library.js
@@ -694,30 +694,6 @@ LibraryManager.library = {
   // stdlib.h
   // ==========================================================================
 
-#if !MINIMAL_RUNTIME && MALLOC != 'none'
-  // tiny, fake malloc/free implementation. If the program actually uses malloc,
-  // a compiled version will be used; this will only be used if the runtime
-  // needs to allocate something, for which this is good enough if otherwise
-  // no malloc is needed.
-  malloc: function(bytes) {
-    /* Over-allocate to make sure it is byte-aligned by 8.
-     * This will leak memory, but this is only the dummy
-     * implementation (replaced by dlmalloc normally) so
-     * not an issue.
-     */
-#if ASSERTIONS == 2
-    warnOnce('using stub malloc (reference it from C to have the real one included)');
-#endif
-    var ptr = dynamicAlloc(bytes + 8);
-    return (ptr+8) & 0xFFFFFFF8;
-  },
-  free: function() {
-#if ASSERTIONS == 2
-    warnOnce('using stub free (reference it from C to have the real one included)');
-#endif
-  },
-#endif
-
   abs: 'Math_abs',
   labs: 'Math_abs',
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6428,6 +6428,9 @@ return malloc(size);
       '2xi40',
       # current fastcomp limitations FIXME
       'quoted',
+      # assumes malloc exists in JS
+      'llvm_assume', 'longjmp_tiny', 'longjmp_tiny_invoke', 'longjmp_tiny_invoke_phi',
+      'longjmp_tiny_keepem', 'longjmp_tiny_keepem_cond', 'longjmp_tiny_phi', 'longjmp_tiny_phi2',
     ]
     skip_emterp = [
       'funcptr', # test writes to memory we store out bytecode! test is invalid

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4778,7 +4778,7 @@ main()
     # fail! not enough stdlibs
     'partial_only': [{'EMCC_FORCE_STDLIBS': 'libc++', 'EMCC_ONLY_FORCED_STDLIBS': '1'}, True],
     # force all the needed stdlibs, so this works even though we ignore the input file
-    'full_only': [{'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++,libpthread', 'EMCC_ONLY_FORCED_STDLIBS': '1'}, False],
+    'full_only': [{'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++,libpthread,libmalloc', 'EMCC_ONLY_FORCED_STDLIBS': '1'}, False],
   })
   def test_only_force_stdlibs(self, env, fail):
     with env_modify(env):


### PR DESCRIPTION
These symbols should always be part of the native code.  We
unconditioanlly add them to EXPORTED_FUNCTIONS so they should always
exist in the output binary.

This change help to unblock #10819.  Without it we assume malloc/free
are JS functions.