### PR TITLE
Improve support for LLD_REPORT_UNDEFINED

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -544,11 +544,6 @@ def get_all_js_syms(temp_files):
     shared.Settings.ONLY_CALC_JS_SYMBOLS = False
     shared.Settings.INCLUDE_FULL_LIBRARY = old_full
 
-  # Some of these functions are actually not JS functions at all but fallbacks
-  # missing undefined native symbols.  Ignore these.
-  for f in ['__cxa_call_unexpected', '_ZSt18uncaught_exceptionv']:
-    if f in library_fns_list:
-      library_fns_list.remove(f)
   return library_fns_list
 
 

--- a/emcc.py
+++ b/emcc.py
@@ -518,22 +518,19 @@ def ensure_archive_index(archive_file):
     run_process([shared.LLVM_RANLIB, archive_file])
 
 
-def get_all_js_library_funcs(temp_files):
-  # Runs the js compiler to generate a list of all functions available in the JS
+def get_all_js_syms(temp_files):
+  # Runs the js compiler to generate a list of all symbols available in the JS
   # libraries.  This must be done separately for each linker invokation since the
-  # list of library functions depends on what settings are used.
+  # list of symbols depends on what settings are used.
   # TODO(sbc): Find a way to optimize this.  Potentially we could add a super-set
   # mode of the js compiler that would generate a list of all possible symbols
   # that could be checked in.
   old_full = shared.Settings.INCLUDE_FULL_LIBRARY
-  old_linkable = shared.Settings.LINKABLE
   try:
     # Temporarily define INCLUDE_FULL_LIBRARY since we want a full list
     # of all available JS library functions.
     shared.Settings.INCLUDE_FULL_LIBRARY = True
-    # Temporarily set LINKABLE so that the jscompiler doesn't report
-    # undefined symbolls itself.
-    shared.Settings.LINKABLE = True
+    shared.Settings.ONLY_CALC_JS_SYMBOLS = True
     emscripten.generate_struct_info()
     glue, forwarded_data = emscripten.compile_settings(temp_files)
     forwarded_json = json.loads(forwarded_data)
@@ -543,13 +540,15 @@ def get_all_js_library_funcs(temp_files):
       if shared.is_c_symbol(name):
         name = shared.demangle_c_symbol_name(name)
         library_fns_list.append(name)
-        # TODO(sbc): wasm-ld shouldn't be reporting errors for symbols
-        # such as __wasi_fd_write which are defined with import_name attibutes
-        # but it currently does.  Remove this once we fix wasm-ld.
-        library_fns_list.append('__wasi_' + name)
   finally:
+    shared.Settings.ONLY_CALC_JS_SYMBOLS = False
     shared.Settings.INCLUDE_FULL_LIBRARY = old_full
-    shared.Settings.LINKABLE = old_linkable
+
+  # Some of these functions are actually not JS functions at all but fallbacks
+  # missing undefined native symbols.  Ignore these.
+  for f in ['__cxa_call_unexpected', '_ZSt18uncaught_exceptionv']:
+    if f in library_fns_list:
+      library_fns_list.remove(f)
   return library_fns_list
 
 
@@ -1199,6 +1198,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.ASSERTIONS:
       shared.Settings.STACK_OVERFLOW_CHECK = 2
 
+    if shared.Settings.LLD_REPORT_UNDEFINED:
+      # Reporting undefined symbols at wasm-ld time requires us to know if we have a `main` function
+      # or not.
+      shared.Settings.IGNORE_MISSING_MAIN = 0
+
     if shared.Settings.STRICT:
       shared.Settings.STRICT_JS = 1
       shared.Settings.AUTO_JS_LIBRARIES = 0
@@ -1417,7 +1421,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.EMBIND:
       forced_stdlibs.append('libembind')
 
-    if not shared.Settings.MINIMAL_RUNTIME:
+    if not shared.Settings.MINIMAL_RUNTIME and not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
       # Always need malloc and free to be kept alive and exported, for internal use and other
       # modules
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
@@ -1486,7 +1490,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # no longer always bundled in)
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$demangle', '$demangleAll', '$jsStackTrace', '$stackTrace']
 
-    if shared.Settings.FILESYSTEM:
+    if shared.Settings.FILESYSTEM and not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
       if shared.Settings.SUPPORT_ERRNO:
         shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location'] # so FS can report errno back to C
       # to flush streams on FS exit, we need to be able to call fflush
@@ -2325,14 +2329,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # TODO: we could check if this is a fastcomp build, and still speed things up here
         just_calculate = DEBUG != 2 and not shared.Settings.WASM_BACKEND
         if shared.Settings.WASM_BACKEND:
-          all_externals = None
-          if shared.Settings.LLD_REPORT_UNDEFINED:
-            all_externals = get_all_js_library_funcs(misc_temp_files)
+          js_funcs = None
+          if shared.Settings.LLD_REPORT_UNDEFINED and shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS:
+            js_funcs = get_all_js_syms(misc_temp_files)
             log_time('JS symbol generation')
-            # TODO(sbc): This is an incomplete list of __invoke functions.  Perhaps add
-            # support for wildcard to wasm-ld.
-            all_externals += ['emscripten_longjmp_jmpbuf', '__invoke_void', '__invoke_i32_i8*_...']
-          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, external_symbol_list=all_externals)
+          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, external_symbol_list=js_funcs)
         else:
           final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, just_calculate=just_calculate)
       else:

--- a/emcc.py
+++ b/emcc.py
@@ -1421,7 +1421,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.EMBIND:
       forced_stdlibs.append('libembind')
 
-    if not shared.Settings.MINIMAL_RUNTIME and not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
+    if not shared.Settings.MINIMAL_RUNTIME:
       # Always need malloc and free to be kept alive and exported, for internal use and other
       # modules
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
@@ -1490,7 +1490,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # no longer always bundled in)
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$demangle', '$demangleAll', '$jsStackTrace', '$stackTrace']
 
-    if shared.Settings.FILESYSTEM and not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
+    if shared.Settings.FILESYSTEM:
       if shared.Settings.SUPPORT_ERRNO:
         shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location'] # so FS can report errno back to C
       # to flush streams on FS exit, we need to be able to call fflush

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -263,6 +263,9 @@ function JSify(data, functionsOnly) {
         Functions.libraryFunctions[finalName] = 1;
       }
 
+      if (ONLY_CALC_JS_SYMBOLS)
+        return '';
+
       var postsetId = ident + '__postset';
       var postset = LibraryManager.library[postsetId];
       if (postset) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1779,8 +1779,6 @@ var USE_OFFSET_CONVERTER = 0;
 // report undefined symbols within the binary.  Without this option that linker
 // doesn't know which symmbols might be defined JS and so reporting of undefined
 // symbols is deleyed until the JS compiler is run.
-// There are some known issues with this flag.  e.g. EM_JS function:
-// https://github.com/emscripten-core/emscripten/issues/10779
 // [link]
 var LLD_REPORT_UNDEFINED = 0;
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -191,3 +191,8 @@ var EXCEPTION_HANDLING = 0;
 
 // Enabled when building C++ code (for example via em++ or via -c c++)
 var USE_CXX = 0;
+
+// Used internally when running the JS compiler simply to generate list of all
+// JS symbols. This is used by LLD_REPORT_UNDEFINED to generate a list of all
+// JS library symbols.
+var ONLY_CALC_JS_SYMBOLS = 0;

--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -56,7 +56,7 @@
 
 #define EM_JS(ret, name, params, ...)          \
   _EM_JS_CPP_BEGIN                             \
-  extern ret name params;                      \
+  extern ret name params EM_IMPORT(name);      \
   __attribute__((used, visibility("default"))) \
   const char* __em_js__##name() {              \
     return #params "<::>" #__VA_ARGS__;        \

--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -33,7 +33,7 @@
 //   EM_JS(int, foo, (int x, int y), { return 2 * x + y; })
 // would get translated into:
 //   int foo(int x, int y);
-//   __attribute__((used, visibility("default")))
+//   __attribute__((used, visibility("default"), import_name("foo")))
 //   const char* __em_js__foo() {
 //     return "(int x, int y)<::>{ return 2 * x + y; }";
 //   }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6952,9 +6952,8 @@ return malloc(size);
     self.emcc_args += extra_args
     self.set_setting('DEMANGLE_SUPPORT', 1)
     self.set_setting('ASSERTIONS', 1)
-    # unless `-g` is pass function names are not preserved by default.
-    if '-g' not in str(self.emcc_args):
-      self.emcc_args += ['--profiling-funcs', '--llvm-opts', '0']
+    # ensure function names are preserved
+    self.emcc_args += ['--profiling-funcs', '--llvm-opts', '0']
     # in the emterpreter, we interpret code execution and control flow,
     # so there is nothing on the browser-visible stack for meaningful
     # stack traces. enabling profiling makes the emterpreter call through

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9009,7 +9009,10 @@ if shared.Settings.WASM_BACKEND:
   asan = make_run('asan', emcc_args=['-fsanitize=address'], settings={'ALLOW_MEMORY_GROWTH': 1, 'ASAN_SHADOW_SIZE': 128 * 1024 * 1024})
   asani = make_run('asani', emcc_args=['-fsanitize=address', '--pre-js', os.path.join(os.path.dirname(__file__), 'asan-no-leak.js')],
                    settings={'ALLOW_MEMORY_GROWTH': 1})
+
+  # Experimental modes (not tested by CI)
   lld = make_run('lld', emcc_args=[], settings={'LLD_REPORT_UNDEFINED': 1})
+  strict = make_run('strict', emcc_args=[], settings={'STRICT': 1})
 
 # TestCoreBase is just a shape for the specific subclasses, we don't test it itself
 del TestCoreBase # noqa

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1759,6 +1759,8 @@ class Building(object):
         cmd.append('--no-gc-sections')
         cmd.append('--export-dynamic')
 
+    expect_main = '_main' in Settings.EXPORTED_FUNCTIONS
+
     if Settings.LINKABLE:
       cmd.append('--export-all')
     else:
@@ -1774,6 +1776,8 @@ class Building(object):
       if external_symbol_list:
         # Filter out symbols external/JS symbols
         c_exports = [e for e in c_exports if e not in external_symbol_list]
+        if expect_main and Settings.IGNORE_MISSING_MAIN:
+          c_exports.remove('main')
       for export in c_exports:
         cmd += ['--export', export]
 
@@ -1791,7 +1795,6 @@ class Building(object):
       use_start_function = Settings.STANDALONE_WASM
 
       if not use_start_function:
-        expect_main = '_main' in Settings.EXPORTED_FUNCTIONS
         if expect_main and not Settings.IGNORE_MISSING_MAIN:
           cmd += ['--entry=main']
         else:


### PR DESCRIPTION
Mark EM_JS function with import attributes so that wasm-ld will allow
them to be undefined.