### PR TITLE
Add IGNORE_MISSING_MAIN setting and --no-entry argument

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -260,6 +260,7 @@ class EmccOptions(object):
     # Whether we will expand the full path of any input files to remove any
     # symlinks.
     self.expand_symlinks = True
+    self.no_entry = False
 
 
 def use_source_map(options):
@@ -1180,6 +1181,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # Apply -s settings in newargs here (after optimization levels, so they can override them)
     apply_settings(settings_changes)
 
+    if options.no_entry and '_main' in shared.Settings.EXPORTED_FUNCTIONS:
+      shared.Settings.EXPORTED_FUNCTIONS.remove('_main')
+
     shared.verify_settings()
 
     def filter_out_dynamic_libs(inputs):
@@ -1214,6 +1218,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.STRICT_JS = 1
       shared.Settings.AUTO_JS_LIBRARIES = 0
       shared.Settings.AUTO_ARCHIVE_INDEXES = 0
+      shared.Settings.IGNORE_MISSING_MAIN = 0
 
     # If set to 1, we will run the autodebugger (the automatic debugging tool, see
     # tools/autodebugger).  Note that this will disable inclusion of libraries. This
@@ -2914,6 +2919,9 @@ def parse_args(newargs):
       options.shell_path = consume_arg()
     elif check_arg('--source-map-base'):
       options.source_map_base = consume_arg()
+    elif newargs[i] == '--no-entry':
+      options.no_entry = True
+      newargs[i] = ''
     elif check_arg('--js-library'):
       shared.Settings.SYSTEM_JS_LIBRARIES.append(os.path.abspath(consume_arg()))
     elif newargs[i] == '--remove-duplicates':

--- a/emscripten.py
+++ b/emscripten.py
@@ -920,6 +920,13 @@ def report_missing_symbols(all_implemented, pre):
       continue
     diagnostics.warning('undefined', 'undefined exported function: "%s"', requested)
 
+  # Handle main specially, unless IGNORE_MISSING_MAIN is set
+  if not shared.Settings.IGNORE_MISSING_MAIN:
+    if '_main' in shared.Settings.EXPORTED_FUNCTIONS and '_main' not in all_implemented:
+      # For compatibility with the output of wasm-ld we use the same wording here in our
+      # error message as if wasm-ld had failed (i.e. in LLD_REPORT_UNDEFINED mode).
+      exit_with_error('entry symbol not defined (pass --no-entry to suppress): main')
+
 
 def get_exported_implemented_functions(all_exported_functions, all_implemented, metadata):
   funcs = set(metadata['exports'])

--- a/src/settings.js
+++ b/src/settings.js
@@ -941,10 +941,17 @@ var LINKABLE = 0;
 //   * The C define EMSCRIPTEN is not defined (__EMSCRIPTEN__ always is, and
 //     is the correct thing to use).
 //   * STRICT_JS is enabled.
+//   * IGNORE_MISSING_MAIN is disabled.
 //   * AUTO_JS_LIBRARIES is disabled.
 //   * AUTO_ARCHIVE_INDEXES is disabled.
 // [compile+link]
 var STRICT = 0;
+
+// Allow program to link with or without `main` symbol.
+// If this is disabled then one must provide a `main` symbol or explicitly
+// opt out by passing `--no-entry` or an EXPORTED_FUNCTIONS list that doesn't
+// include `_main`.
+var IGNORE_MISSING_MAIN = 1;
 
 // Automatically attempt to add archive indexes at link time to archives that 
 // don't already have them.  This can happen when GNU ar or GNU ranlib is used

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1613,17 +1613,17 @@ int main() {
     self.do_run_in_out_file_test('tests', 'core', 'test_inherit')
 
   def test_isdigit_l(self):
-      # needs to flush stdio streams
-      self.set_setting('EXIT_RUNTIME', 1)
-      self.do_run_in_out_file_test('tests', 'core', 'test_isdigit_l')
+    # needs to flush stdio streams
+    self.set_setting('EXIT_RUNTIME', 1)
+    self.do_run_in_out_file_test('tests', 'core', 'test_isdigit_l')
 
   def test_iswdigit(self):
-      # needs to flush stdio streams
-      self.set_setting('EXIT_RUNTIME', 1)
-      self.do_run_in_out_file_test('tests', 'core', 'test_iswdigit')
+    # needs to flush stdio streams
+    self.set_setting('EXIT_RUNTIME', 1)
+    self.do_run_in_out_file_test('tests', 'core', 'test_iswdigit')
 
   def test_polymorph(self):
-      self.do_run_in_out_file_test('tests', 'core', 'test_polymorph')
+    self.do_run_in_out_file_test('tests', 'core', 'test_polymorph')
 
   def test_complex(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_complex')
@@ -8861,6 +8861,22 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('RESERVED_FUNCTION_POINTERS', 2)
     self.emcc_args += ['-lexports.js', '-s', 'MINIMAL_RUNTIME=1']
     self.do_run_in_out_file_test('tests', 'core', 'test_get_exported_function')
+
+  def test_auto_detect_main(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main')
+
+    # Disabling IGNORE_MISSING_MAIN should cause link to fail due to missing main
+    self.set_setting('IGNORE_MISSING_MAIN', 0)
+    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'core', 'test_ctors_no_main.cpp')] + self.get_emcc_args())
+    self.assertContained('error: entry symbol not defined (pass --no-entry to suppress): main', err)
+
+    # We can fix the error either by adding --no-entry or by setting EXPORTED_FUNCTIONS to empty
+    self.emcc_args.append('--no-entry')
+    self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main')
+
+    self.emcc_args.remove('--no-entry')
+    self.set_setting('EXPORTED_FUNCTIONS', [])
+    self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main')
 
 
 # Generate tests for everything

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1812,8 +1812,13 @@ class Building(object):
         '--initial-memory=%d' % Settings.INITIAL_MEMORY,
       ]
       use_start_function = Settings.STANDALONE_WASM
+
       if not use_start_function:
-        cmd += ['--no-entry']
+        expect_main = '_main' in Settings.EXPORTED_FUNCTIONS
+        if expect_main and not Settings.IGNORE_MISSING_MAIN:
+          cmd += ['--entry=main']
+        else:
+          cmd += ['--no-entry']
       if not Settings.ALLOW_MEMORY_GROWTH:
         cmd.append('--max-memory=%d' % Settings.INITIAL_MEMORY)
       elif Settings.MAXIMUM_MEMORY != -1:


### PR DESCRIPTION
This setting, wen disabled, forces they developer to be explicit
about the presence of absence of main their program.  It is enabled
by default but disabled in STRICT mode.

When disabled, if you want to build a program without an main function
one must either build with `--no-entry` or pass a list of
EXPORTED_FUNCTIONS the doesn't include `_main`.

The reason for adding the extra `--no-entry` method is that this
is what wasm-ld recommends in its corresponding error message.  Its
also a lot easier to type than `-s EXPORTED_FUNCTIONS=[]`.

This change is a step towards enabling better error reporting from lld
by enabling the removal of the `--allow-undefined` option.  See #10826

Partia fix for: #9640