### PR TITLE
Allow setters in embind with non-void return types

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -462,3 +462,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Louis DeScioli <descioli@google.com> (copyright owned by Google, LLC)
 * Kleis Auke Wolthuizen <info@kleisauke.nl>
 * Michael Potthoff <michael@potthoff.eu>
+* Abigail Bunyan <abigail@bold.claims> (copyright owned by Microsoft Corporation)

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -671,10 +671,10 @@ namespace emscripten {
         template<typename T>
         struct SetterPolicy;
 
-        template<typename SetterThisType, typename SetterArgumentType>
-        struct SetterPolicy<void (SetterThisType::*)(SetterArgumentType)> {
+        template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
+        struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType)> {
             typedef SetterArgumentType ArgumentType;
-            typedef void (SetterThisType::*Context)(SetterArgumentType);
+            typedef SetterReturnType (SetterThisType::*Context)(SetterArgumentType);
 
             typedef internal::BindingType<SetterArgumentType> Binding;
             typedef typename Binding::WireType WireType;
@@ -689,10 +689,10 @@ namespace emscripten {
             }
         };
 
-        template<typename SetterThisType, typename SetterArgumentType>
-        struct SetterPolicy<void (*)(SetterThisType&, SetterArgumentType)> {
+        template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
+        struct SetterPolicy<SetterReturnType (*)(SetterThisType&, SetterArgumentType)> {
             typedef SetterArgumentType ArgumentType;
-            typedef void (*Context)(SetterThisType&, SetterArgumentType);
+            typedef SetterReturnType (*Context)(SetterThisType&, SetterArgumentType);
 
             typedef internal::BindingType<SetterArgumentType> Binding;
             typedef typename Binding::WireType WireType;
@@ -707,10 +707,10 @@ namespace emscripten {
             }
         };
 
-        template<typename SetterThisType, typename SetterArgumentType>
-        struct SetterPolicy<std::function<void(SetterThisType&, SetterArgumentType)>> {
+        template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
+        struct SetterPolicy<std::function<SetterReturnType(SetterThisType&, SetterArgumentType)>> {
             typedef SetterArgumentType ArgumentType;
-            typedef std::function<void(SetterThisType&, SetterArgumentType)> Context;
+            typedef std::function<SetterReturnType(SetterThisType&, SetterArgumentType)> Context;
 
             typedef internal::BindingType<SetterArgumentType> Binding;
             typedef typename Binding::WireType WireType;


### PR DESCRIPTION
Some setters may have a return value - they may return `*this`, or the
previous value of the property, or something else. These return values
are now ignored, rather than required to be `void`. For example, the
following code is now valid:

```c++
class Widget {
public:
    Part getPart() const { return part_; }
    Widget& withPart(Part part) { part_ = part; return *this; }
private:
    Part part_;
};

EMSCRIPTEN_BINDINGS(Widget) {
    class_<Widget>("Widget")
        .property("part", &Widget::getPart, &Widget::withPart)
    ;
}
```