### PR TITLE
NODEFS: Unable to open file with O_NOFOLLOW

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -460,3 +460,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Kirill Gavrilov <kirill@sview.ru>
 * Karl Semich <0xloem@gmail.com>
 * Louis DeScioli <descioli@google.com> (copyright owned by Google, LLC)
+* Michael Potthoff <michael@potthoff.eu>

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1066,7 +1066,7 @@ FS.staticInit();` +
         FS.truncate(node, 0);
       }
       // we've already handled these, don't pass down to the underlying vfs
-      flags &= ~({{{ cDefine('O_EXCL') }}} | {{{ cDefine('O_TRUNC') }}});
+      flags &= ~({{{ cDefine('O_EXCL') }}} | {{{ cDefine('O_TRUNC') }}} | {{{ cDefine('O_NOFOLLOW') }}});
 
       // register the stream with the filesystem
       var stream = FS.createStream({

--- a/tests/fs/test_nodefs_nofollow.c
+++ b/tests/fs/test_nodefs_nofollow.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+#include <fcntl.h>
+#include <emscripten.h>
+
+int main(void)
+{
+    EM_ASM(
+        FS.mkdir('/working');
+        FS.mount(NODEFS, {root: '.'}, '/working');
+        FS.close(FS.open('/working/test.txt', 'w'));
+    );
+    assert(open("/working/test.txt", O_NOFOLLOW) != -1);
+    printf("success\n");
+    return 0;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5329,6 +5329,11 @@ main( int argv, char ** argc ) {
     src = open(path_from_root('tests', 'fs', 'test_nodefs_home.c')).read()
     self.do_run(src, 'success', js_engines=[NODE_JS])
 
+  def test_fs_nodefs_nofollow(self):
+    self.emcc_args += ['-lnodefs.js']
+    src = open(path_from_root('tests', 'fs', 'test_nodefs_nofollow.c')).read()
+    self.do_run(src, 'success', js_engines=[NODE_JS])
+
   def test_fs_trackingdelegate(self):
     src = path_from_root('tests', 'fs', 'test_trackingdelegate.c')
     out = path_from_root('tests', 'fs', 'test_trackingdelegate.out')


### PR DESCRIPTION
This fixes that a call to `open()` with the `O_NOFOLLOW` flag results in `EINVAL` when the path is on a nodefs mountpoint.

The `O_NOFOLLOW` flag should be unset in `open()` of `library_fs` because it already gets handled there so the underlaying fs don't have to know about it. (Otherwise `flagsForNode` in `library_nodefs` will throw an error because of the unknown flag.)

Fixes #10839