### PR TITLE
cleanup runtime.js

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -187,8 +187,7 @@ if (VERBOSE) printErr('VERBOSE is on, this generates a lot of output and can slo
 load('modules.js');
 load('parseTools.js');
 load('jsifier.js');
-globalEval(processMacros(preprocess(read('runtime.js'), 'runtime.js')));
-Runtime.QUANTUM_SIZE = 4;
+load('runtime.js');
 
 // State computations
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -415,7 +415,7 @@ function JSify(data, functionsOnly) {
           print('for (var i = gb; i < gb + {{{ STATIC_BUMP }}}; ++i) HEAP8[i] = 0;\n');
         }
         // emit "metadata" in a comment. FIXME make this nicer
-        print('// STATICTOP = STATIC_BASE + ' + Runtime.alignMemory(Variables.nextIndexedOffset) + ';\n');
+        print('// STATICTOP = STATIC_BASE + ' + alignMemory(Variables.nextIndexedOffset) + ';\n');
       }
       var generated = itemsDict.function.concat(itemsDict.type).concat(itemsDict.GlobalVariableStub).concat(itemsDict.GlobalVariable);
       print(generated.map(function(item) { return item.JS; }).join('\n'));

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -50,25 +50,16 @@ function alignMemory(size, factor) {
 
 var Runtime = {
   getNativeTypeSize: getNativeTypeSize,
-  alignMemory: alignMemory,
 
   //! Returns the size of a structure field, as C/C++ would have it (in 32-bit,
   //! for now).
   //! @param type The type, by name.
   getNativeFieldSize: function(type) {
-    return Math.max(Runtime.getNativeTypeSize(type), Runtime.QUANTUM_SIZE);
+    return Math.max(getNativeTypeSize(type), Runtime.QUANTUM_SIZE);
   },
 
-  STACK_ALIGN: {{{ STACK_ALIGN }}},
   POINTER_SIZE: 4,
-
-  // type can be a native type or a struct (or null, for structs we only look at size here)
-  getAlignSize: function(type, size, vararg) {
-    // we align i64s and doubles on 64-bit boundaries, unlike x86
-    if (!vararg && (type == 'i64' || type == 'double')) return 8;
-    if (!type) return Math.min(size, 8); // align structures internally to 64 bits
-    return Math.min(size || (type ? Runtime.getNativeFieldSize(type) : 0), Runtime.QUANTUM_SIZE);
-  }
+  QUANTUM_SIZE: 4,
 };
 
 // Additional runtime elements, that need preprocessing

--- a/src/support.js
+++ b/src/support.js
@@ -770,4 +770,3 @@ var Atomics_load = Atomics.load;
 var Atomics_store = Atomics.store;
 var Atomics_compareExchange = Atomics.compareExchange;
 #endif
-


### PR DESCRIPTION
- Remove unused Runtime.STACK_ALIGN
- Remove unused Runtime.getAlignSize
- Move Runtime.QUANTUM_SIZE init into object itself.
- Remove mostly unused Runtime.alignMemory