### PR TITLE
GL emulation: fix glDrawElements always drawing GL_TRIANGLES

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -466,3 +466,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * David García Paredes <davidgparedes@gmail.com>
 * Mike Swierczek <mike@swierczek.io>
 * Vasily <just.one.man@yandex.ru>
+* Jānis Rūcis <parasti@gmail.com>

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -2742,12 +2742,13 @@ var LibraryGLEmulation = {
 #endif
         GLctx.bindBuffer(GLctx.ELEMENT_ARRAY_BUFFER, GL.currentContext.tempQuadIndexBuffer);
         emulatedElementArrayBuffer = true;
+        GLImmediate.mode = GLctx.TRIANGLES;
       }
 
       renderer.prepare();
 
       if (numIndexes) {
-        GLctx.drawElements(GLctx.TRIANGLES, numIndexes, GLctx.UNSIGNED_SHORT, ptr);
+        GLctx.drawElements(GLImmediate.mode, numIndexes, GLctx.UNSIGNED_SHORT, ptr);
       } else {
         GLctx.drawArrays(GLImmediate.mode, startIndex, numVertexes);
       }


### PR DESCRIPTION
Seems like every test is only using glDrawElements with GL_TRIANGLES.

Not sure if this fix is good, but it got my triangle strips working.