### PR TITLE
Fix cxa_thread_atexit() to properly register thread-local atexits

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -721,8 +721,6 @@ LibraryManager.library = {
 #if MINIMAL_RUNTIME && !EXIT_RUNTIME
   atexit: function(){},
   __cxa_atexit: function(){},
-  __cxa_thread_atexit: function(){},
-  __cxa_thread_atexit_impl: function(){},
 #else
   atexit__proxy: 'sync',
   atexit__sig: 'iii',
@@ -732,14 +730,18 @@ LibraryManager.library = {
     warnOnce('atexit() called, but EXIT_RUNTIME is not set, so atexits() will not be called. set EXIT_RUNTIME to 1 (see the FAQ)');
 #endif
 #endif
+
+#if EXIT_RUNTIME
     __ATEXIT__.unshift({ func: func, arg: arg });
+#endif
   },
   __cxa_atexit: 'atexit',
 
-  // used in rust, clang when doing thread_local statics
-  __cxa_thread_atexit: 'atexit',
-  __cxa_thread_atexit_impl: 'atexit',
 #endif
+
+  // used in rust, clang when doing thread_local statics
+  __cxa_thread_atexit: 'pthread_cleanup_push',
+  __cxa_thread_atexit_impl: 'pthread_cleanup_push',
 
   // TODO: There are currently two abort() functions that get imported to asm module scope: the built-in runtime function abort(),
   // and this function _abort(). Remove one of these, importing two functions for the same purpose is wasteful.

--- a/src/library.js
+++ b/src/library.js
@@ -719,6 +719,7 @@ LibraryManager.library = {
   },
 
 #if MINIMAL_RUNTIME && !EXIT_RUNTIME
+  atexit__sig: 'v', // atexit unsupported in MINIMAL_RUNTIME
   atexit: function(){},
   __cxa_atexit: function(){},
 #else

--- a/src/library.js
+++ b/src/library.js
@@ -740,8 +740,13 @@ LibraryManager.library = {
 #endif
 
   // used in rust, clang when doing thread_local statics
+#if USE_PTHREADS
   __cxa_thread_atexit: 'pthread_cleanup_push',
   __cxa_thread_atexit_impl: 'pthread_cleanup_push',
+#else
+  __cxa_thread_atexit: 'atexit',
+  __cxa_thread_atexit_impl: 'atexit',
+#endif
 
   // TODO: There are currently two abort() functions that get imported to asm module scope: the built-in runtime function abort(),
   // and this function _abort(). Remove one of these, importing two functions for the same purpose is wasteful.

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -92,7 +92,7 @@ var LibraryPThread = {
     },
     // Maps pthread_t to pthread info objects
     pthreads: {},
-    exitHandlers: null, // An array of C functions to run when this thread exits.
+    exitHandlers: [], // An array of C functions to run when this thread exits.
 
 #if PTHREADS_PROFILING
     createProfilerBlock: function(pthreadPtr) {
@@ -163,11 +163,8 @@ var LibraryPThread = {
 #endif
 
     runExitHandlers: function() {
-      if (PThread.exitHandlers !== null) {
-        while (PThread.exitHandlers.length > 0) {
-          PThread.exitHandlers.pop()();
-        }
-        PThread.exitHandlers = null;
+      while (PThread.exitHandlers.length > 0) {
+        PThread.exitHandlers.pop()();
       }
 
       // Call into the musl function that runs destructors of all thread-specific data.
@@ -1078,15 +1075,8 @@ var LibraryPThread = {
     return 0;
   },
 
+  pthread_cleanup_push__sig: 'vii',
   pthread_cleanup_push: function(routine, arg) {
-    if (PThread.exitHandlers === null) {
-      PThread.exitHandlers = [];
-#if EXIT_RUNTIME
-      if (!ENVIRONMENT_IS_PTHREAD) {
-        __ATEXIT__.push(function() { PThread.runExitHandlers(); });
-      }
-#endif
-    }
     PThread.exitHandlers.push(function() { {{{ makeDynCall('vi') }}}(routine, arg) });
   },
 

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -92,7 +92,7 @@ var LibraryPThread = {
     },
     // Maps pthread_t to pthread info objects
     pthreads: {},
-    exitHandlers: [], // An array of C functions to run when this thread exits.
+    threadExitHandlers: [], // An array of C functions to run when this thread exits.
 
 #if PTHREADS_PROFILING
     createProfilerBlock: function(pthreadPtr) {
@@ -163,8 +163,8 @@ var LibraryPThread = {
 #endif
 
     runExitHandlers: function() {
-      while (PThread.exitHandlers.length > 0) {
-        PThread.exitHandlers.pop()();
+      while (PThread.threadExitHandlers.length > 0) {
+        PThread.threadExitHandlers.pop()();
       }
 
       // Call into the musl function that runs destructors of all thread-specific data.
@@ -1077,11 +1077,11 @@ var LibraryPThread = {
 
   pthread_cleanup_push__sig: 'vii',
   pthread_cleanup_push: function(routine, arg) {
-    PThread.exitHandlers.push(function() { {{{ makeDynCall('vi') }}}(routine, arg) });
+    PThread.threadExitHandlers.push(function() { {{{ makeDynCall('vi') }}}(routine, arg) });
   },
 
   pthread_cleanup_pop: function(execute) {
-    var routine = PThread.exitHandlers.pop();
+    var routine = PThread.threadExitHandlers.pop();
     if (execute) routine();
   },
 

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -79,6 +79,7 @@ var LibraryPThreadStub = {
   pthread_setcancelstate: function() { return 0; },
   pthread_setcanceltype: function() { return 0; },
 
+  pthread_cleanup_push__sig: 'vii',
   pthread_cleanup_push: function(routine, arg) {
     __ATEXIT__.push(function() { {{{ makeDynCall('vi') }}}(routine, arg) })
     _pthread_cleanup_push.level = __ATEXIT__.length;

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -24,6 +24,9 @@ function run() {
 #if EXIT_RUNTIME
     callRuntimeCallbacks(__ATEXIT__);
     {{{ getQuoted('ATEXITS') }}}
+#if USE_PTHREADS
+    PThread.runExitHandlers();
+#endif
 #endif
 
 #if IN_TEST_HARNESS

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -518,6 +518,9 @@ function exitRuntime() {
 #if EXIT_RUNTIME
   callRuntimeCallbacks(__ATEXIT__);
   {{{ getQuoted('ATEXITS') }}}
+#if USE_PTHREADS
+  PThread.runExitHandlers();
+#endif
 #endif
   runtimeExited = true;
 }


### PR DESCRIPTION
Fix cxa_thread_atexit() to properly register thread-local atexits, and not process-global atexits. (Also microcleanup code a little). Fixes #10809.