### PR TITLE
GL emulation: fix glClientActiveTexture losing track of texture matrix

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -3125,6 +3125,9 @@ var LibraryGLEmulation = {
   glClientActiveTexture__sig: 'vi',
   glClientActiveTexture: function(texture) {
     GLImmediate.clientActiveTexture = texture - 0x84C0; // GL_TEXTURE0
+    if (GLImmediate.currentMatrix >= 2) { // Update the matrix stack when matrix mode is GL_TEXTURE.
+      GLImmediate.currentMatrix = 2 + GLImmediate.clientActiveTexture;
+    }
   },
 
   // Replace some functions with immediate-mode aware versions. If there are no client


### PR DESCRIPTION
Here's some (valid) code that is fixed by this:

```c
glClientActiveTexture(texUnit0);
glMatrixMode(GL_TEXTURE); // Emscripten switches to texture matrix 0.
glClientActiveTexture(texUnit1);
// ... not using glMatrixMode, because we're already on GL_TEXTURE.
glTranslatef(...); // Oops, Emscripten is still on texture matrix 0.
```