### PR TITLE
Fix workerfs inode

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -461,3 +461,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Karl Semich <0xloem@gmail.com>
 * Louis DeScioli <descioli@google.com> (copyright owned by Google, LLC)
 * Kleis Auke Wolthuizen <info@kleisauke.nl>
+* David García Paredes <davidgparedes@gmail.com>

--- a/src/library_workerfs.js
+++ b/src/library_workerfs.js
@@ -77,7 +77,7 @@ mergeInto(LibraryManager.library, {
       getattr: function(node) {
         return {
           dev: 1,
-          ino: undefined,
+          ino: node.id,
           mode: node.mode,
           nlink: 1,
           uid: 0,


### PR DESCRIPTION
Currently I am having issues with some programs (like gcc and clang) that use inode number to uniquely identify files and folders for caching.
I found that the problem is `getattr` function is returning `ino: undefined` in WORKERFS. I found that I can easily fix this just returning `node.id` in that function.