### PR TITLE
Don't pass extra lld flags when linking with `-r/--relocatable`

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2318,7 +2318,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             # TODO(sbc): This is an incomplete list of __invoke functions.  Perhaps add
             # support for wildcard to wasm-ld.
             all_externals += ['emscripten_longjmp_jmpbuf', '__invoke_void', '__invoke_i32_i8*_...']
-          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, all_external_symbols=all_externals)
+          final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, external_symbol_list=all_externals)
         else:
           final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, just_calculate=just_calculate)
       else:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -867,6 +867,12 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     else:
       self.assertNotContained(value, string)
 
+  def assertBinaryEqual(self, file1, file2):
+    self.assertEqual(os.path.getsize(file1),
+                     os.path.getsize(file2))
+    self.assertEqual(open(file1, 'rb').read(),
+                     open(file2, 'rb').read())
+
   library_cache = {}
 
   def get_build_dir(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5676,12 +5676,6 @@ PORT: 3979
 
   # libc++ tests
 
-  def assertBinaryEqual(self, file1, file2):
-    self.assertEqual(os.path.getsize(file1),
-                     os.path.getsize(file2))
-    self.assertEqual(open(file1, 'rb').read(),
-                     open(file2, 'rb').read())
-
   def test_iostream_and_determinism(self):
     src = '''
       #include <iostream>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -482,31 +482,36 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     self.assertNotExists(path_from_root('tests', 'twopart_side.o'))
 
   def test_combining_object_files(self):
-    # Compiling two source files into a final JS.
-    run_process([PYTHON, EMCC, path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.cpp')])
-    self.assertContained('side got: hello from main, over', run_js('a.out.js'))
-
     # Compiling two files with -c will generate separate object files
-    self.clear()
     run_process([PYTHON, EMCC, path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.cpp'), '-c'])
     self.assertExists('twopart_main.o')
     self.assertExists('twopart_side.o')
 
-    # Compiling one of them alone is expected to fail
+    # Linking with just one of them is expected to fail
     err = self.expect_fail([PYTHON, EMCC, 'twopart_main.o'])
     self.assertContained('undefined symbol: _Z7theFuncPKc', err)
 
-    # Combining both object files into js should work
+    # Linking with both should work
     run_process([PYTHON, EMCC, 'twopart_main.o', 'twopart_side.o'])
     self.assertContained('side got: hello from main, over', run_js('a.out.js'))
 
-    # Combining object files into another object should also work
-    try_delete('a.out.js')
-    run_process([PYTHON, EMCC, 'twopart_main.o', 'twopart_side.o', '-o', 'combined.o'])
+    # Combining object files into another object should also work, using the `-r` flag
+    run_process([PYTHON, EMCC, '-r', 'twopart_main.o', 'twopart_side.o', '-o', 'combined.o'])
+    # We also support building without the `-r` flag but expect a warning
+    err = run_process([PYTHON, EMCC, 'twopart_main.o', 'twopart_side.o', '-o', 'combined2.o'],
+        stderr=PIPE).stderr
+    self.assertBinaryEqual('combined.o', 'combined2.o')
+    self.assertContained('warning: Assuming object file output in the absence of `-c`', err)
+
+    # Should be two symbols (and in the wasm backend, also __original_main)
     syms = Building.llvm_nm('combined.o')
-    assert len(syms.defs) in (2, 3) and 'main' in syms.defs, 'Should be two functions (and in the wasm backend, also __original_main)'
+    self.assertIn('main', syms.defs)
+    if self.is_wasm_backend():
+      self.assertEqual(len(syms.defs), 3)
+    else:
+      self.assertEqual(len(syms.defs), 2)
+
     run_process([PYTHON, EMCC, 'combined.o', '-o', 'combined.o.js'])
-    self.assertExists('combined.o.js')
     self.assertContained('side got: hello from main, over', run_js('combined.o.js'))
 
   def test_js_transform(self):
@@ -10473,19 +10478,14 @@ Module.arguments has been replaced with plain arguments_
     for engine in JS_ENGINES:
       self.assertContained('hello, world!', run_js('a.out.js', engine=engine))
 
-  def test_link_to_object(self):
+  def test_compile_only_with_object_extension(self):
     # Emscripten supports compiling to an object file when the output has an
     # object extension.
+    # Most compilers require the `-c` to be explict.
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'hello1.o'])
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'hello2.o'])
-    content1 = open('hello1.o', 'rb').read()
-    content2 = open('hello2.o', 'rb').read()
-    self.assertEqual(content1, content2)
-
-    # We allow support linking object files together into other object files
-    run_process([PYTHON, EMCC, 'hello1.o', '-o', 'hello3.o'])
-    content3 = open('hello2.o', 'rb').read()
-    self.assertEqual(content1, content3)
+    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'hello2.o'], stderr=PIPE).stderr
+    self.assertContained('warning: Assuming object file output in the absence of `-c`', err)
+    self.assertBinaryEqual('hello1.o', 'hello2.o')
 
   def test_backwards_deps_in_archive(self):
     # Test that JS dependencies from deps_info.json work for code linked via

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -498,8 +498,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # Combining object files into another object should also work, using the `-r` flag
     run_process([PYTHON, EMCC, '-r', 'twopart_main.o', 'twopart_side.o', '-o', 'combined.o'])
     # We also support building without the `-r` flag but expect a warning
-    err = run_process([PYTHON, EMCC, 'twopart_main.o', 'twopart_side.o', '-o', 'combined2.o'],
-        stderr=PIPE).stderr
+    err = run_process([PYTHON, EMCC, 'twopart_main.o', 'twopart_side.o', '-o', 'combined2.o'], stderr=PIPE).stderr
     self.assertBinaryEqual('combined.o', 'combined2.o')
     self.assertContained('warning: Assuming object file output in the absence of `-c`', err)
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1725,7 +1725,7 @@ class Building(object):
     return target
 
   @staticmethod
-  def calc_lld_flags(external_symbol_list):
+  def lld_flags_for_executable(external_symbol_list):
     cmd = []
     if external_symbol_list:
       undefs = configuration.get_temp_files().get('.undefined').name
@@ -1829,7 +1829,7 @@ class Building(object):
     # For relocatable output (generating an object file) we don't pass any of the normal linker
     # flags that are used when building and exectuable
     if '--relocatable' not in args and '-r' not in args:
-      cmd += Building.calc_lld_flags(external_symbol_list)
+      cmd += Building.lld_flags_for_executable(external_symbol_list)
 
     print_compiler_stage(cmd)
     cmd = Building.get_command_with_possible_response_file(cmd)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1745,7 +1745,6 @@ class Building(object):
     if Settings.USE_PTHREADS:
       cmd.append('--shared-memory')
 
-
     if Settings.DEBUG_LEVEL < 2 and (not Settings.EMIT_SYMBOL_MAP and
                                      not Settings.PROFILING_FUNCS and
                                      not Settings.ASYNCIFY):


### PR DESCRIPTION
Previously when running linking to an object file we were still adding
all the link flags needed for building an exectuable.

This change also refactored the two tests that we had for object
file linking.  Previously we have test_link_to_object and
test_combining_object_files doing similar things.  Now this is all
handled by test_combining_object_files and the remaining thing that
test_link_to_object also happend to test is preserved in
test_compile_only_with_object_extension (couldn't think of a better
name for this).