### PR TITLE
Use MINIMAL_RUNTIME in benchmarks

### DIFF
--- a/tests/matrix_multiply.cpp
+++ b/tests/matrix_multiply.cpp
@@ -5,9 +5,6 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#ifdef __EMSCRIPTEN__
-#include <emscripten.h>
-#endif
 #include "tick.h"
 
 // Naively computes dst = a * b, where a is a matrix of size YxI, and b is a matrix of size IxX. The output matrix dst will be of size YxX.
@@ -82,10 +79,6 @@ void Tick()
   if (++NumFramesDone >= NumFrames)
   {
     Done();
-#ifdef __EMSCRIPTEN__
-    if (ENVIRONMENT_IS_WEB)
-      emscripten_cancel_main_loop();
-#endif
     exit(0);
   }
 }
@@ -113,9 +106,6 @@ int main(int argc, char **argv)
     ItersPerFrame = atoi(argv[5]);
     Method = atoi(argv[6]);
   }
-#ifdef __EMSCRIPTEN__
-  ENVIRONMENT_IS_WEB = EM_ASM_INT(return ENVIRONMENT_IS_WEB);
-#endif
   printf("Performing %d multiplications of matrices of size %dx%d and %dx%d. Distributing multiplication across %d animation frames (matrix muls per frame=%d).\n", NumFrames*ItersPerFrame, A, B, B, C, NumFrames, ItersPerFrame);
 
 // #define EM_TIMING_SETTIMEOUT 0
@@ -127,21 +117,6 @@ int main(int argc, char **argv)
   mDst = new float[A*C];
   Init(mA, A, B);
   Init(mB, B, C);
-
-#ifdef __EMSCRIPTEN__
-  if (ENVIRONMENT_IS_WEB)
-  {
-    switch(Method)
-    {
-      case EM_TIMING_SETTIMEOUT: printf("Using setTimeout(0) to schedule frames.\n"); break;
-      case EM_TIMING_RAF: printf("Using requestAnimationFrame() to schedule frames.\n"); break;
-      case EM_TIMING_SETIMMEDIATE: printf("Using setImmediate/postMessage() to schedule frames.\n"); break;
-      default: printf("Invalid frame scheduling method %d specifiec!\n", Method); exit(1);
-    }
-    emscripten_set_main_loop(Tick, 0, 0);
-    emscripten_set_main_loop_timing(Method, 0);
-  }
-#endif
 
   t0 = tick();
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -202,7 +202,7 @@ class EmscriptenBenchmarker(Benchmarker):
       '-s', 'INITIAL_MEMORY=256MB',
       '-s', 'FILESYSTEM=0',
       '--closure', '1',
-      '-s', 'MINIMAL_RUNTIME=0',
+      '-s', 'MINIMAL_RUNTIME=1',
       '-s', 'BENCHMARK=%d' % (1 if IGNORE_COMPILATION and not has_output_parser else 0),
       '-o', final
     ] + shared_args + emcc_args + LLVM_FEATURE_FLAGS + self.extra_args
@@ -222,7 +222,7 @@ class EmscriptenBenchmarker(Benchmarker):
   def get_output_files(self):
     ret = [self.filename]
     if 'WASM=0' in self.cmd:
-      if 'MINIMAL_RUNTIME=1' in self.cmd:
+      if 'MINIMAL_RUNTIME=0' not in self.cmd:
         ret.append(self.filename[:-3] + '.asm.js')
         ret.append(self.filename[:-3] + '.mem')
       else:
@@ -444,7 +444,7 @@ class benchmark(runner.RunnerCore):
         return 0;
       }
     '''
-    self.do_benchmark('primes' if check else 'primes-nocheck', src, 'lastprime:' if check else '', shared_args=['-DCHECK'] if check else [], emcc_args=['-s', 'MINIMAL_RUNTIME=0'])
+    self.do_benchmark('primes' if check else 'primes-nocheck', src, 'lastprime:' if check else '', shared_args=['-DCHECK'] if check else [])
 
   # Also interesting to test it without the printfs which allow checking the output. Without
   # printf, code size is dominated by the runtime itself (the compiled code is just a few lines).
@@ -482,7 +482,7 @@ class benchmark(runner.RunnerCore):
         return 0;
       }
     '''
-    self.do_benchmark('memops', src, 'final:', emcc_args=['-s', 'MINIMAL_RUNTIME=0'])
+    self.do_benchmark('memops', src, 'final:')
 
   def zzztest_files(self):
     src = r'''
@@ -660,7 +660,7 @@ class benchmark(runner.RunnerCore):
         return 0;
       }
     '''
-    self.do_benchmark('conditionals', src, 'ok', reps=TEST_REPS, emcc_args=['-s', 'MINIMAL_RUNTIME=0'])
+    self.do_benchmark('conditionals', src, 'ok', reps=TEST_REPS)
 
   def test_fannkuch(self):
     src = open(path_from_root('tests', 'fannkuch.cpp'), 'r').read().replace(
@@ -908,7 +908,7 @@ class benchmark(runner.RunnerCore):
 
     self.do_benchmark('lua_' + benchmark, '', expected,
                       force_c=True, args=[benchmark + '.lua', DEFAULT_ARG],
-                      emcc_args=['--embed-file', benchmark + '.lua', '-s', 'FORCE_FILESYSTEM=1'],
+                      emcc_args=['--embed-file', benchmark + '.lua', '-s', 'FORCE_FILESYSTEM=1', '-s', 'MINIMAL_RUNTIME=0'], # not minimal because of files
                       lib_builder=lib_builder, native_exec=os.path.join('building', 'lua_native', 'src', 'lua'),
                       output_parser=output_parser, args_processor=args_processor)
 
@@ -986,7 +986,9 @@ class benchmark(runner.RunnerCore):
   def test_zzz_sqlite(self):
     src = open(path_from_root('tests', 'third_party', 'sqlite', 'sqlite3.c'), 'r').read() + open(path_from_root('tests', 'sqlite', 'speedtest1.c'), 'r').read()
 
-    self.do_benchmark('sqlite', src, 'TOTAL...', native_args=['-ldl', '-pthread'], shared_args=['-I' + path_from_root('tests', 'third_party', 'sqlite')], emcc_args=['-s', 'FILESYSTEM=1'], force_c=True)
+    self.do_benchmark('sqlite', src, 'TOTAL...', native_args=['-ldl', '-pthread'], shared_args=['-I' + path_from_root('tests', 'third_party', 'sqlite')],
+                      emcc_args=['-s', 'FILESYSTEM=1', '-s', 'MINIMAL_RUNTIME=0'], # not minimal because of files
+                      force_c=True)
 
   def test_zzz_poppler(self):
     with open('pre.js', 'w') as f:
@@ -1034,5 +1036,7 @@ class benchmark(runner.RunnerCore):
     # TODO: Fix poppler native build and remove skip_native=True
     self.do_benchmark('poppler', '', 'hashed printout',
                       shared_args=['-I' + path_from_root('tests', 'poppler', 'include'), '-I' + path_from_root('tests', 'freetype', 'include')],
-                      emcc_args=['-s', 'FILESYSTEM=1', '--pre-js', 'pre.js', '--embed-file', path_from_root('tests', 'poppler', 'emscripten_html5.pdf') + '@input.pdf', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'],
+                      emcc_args=['-s', 'FILESYSTEM=1', '--pre-js', 'pre.js', '--embed-file',
+                                 path_from_root('tests', 'poppler', 'emscripten_html5.pdf') + '@input.pdf', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0',
+                                 '-s', 'MINIMAL_RUNTIME=0'], # not minimal because of files
                       lib_builder=lib_builder, skip_native=True)


### PR DESCRIPTION
This has been ready for months now but we just forgot to
flip the switch. Almost all tests work with the new runtime,
except for a few that embed files and such. But all the
small ones (where JS size matters) do work and they
benefit by a 20% or so shrinking.

The matrix multiply test had some browser components
like main loop support, that I don't think we need (maybe
in the past we wanted to run this benchmark in the
browser too? but using the main loop would mess up
the timings...) so I removed those too.