### PR TITLE
Restore after roll and update tests

### DIFF
--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.imports
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.imports
@@ -4,6 +4,5 @@ __table_base
 emscripten_memcpy_big
 emscripten_resize_heap
 fd_write
-g$stdout
 memory
 table

--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.sent
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.sent
@@ -4,6 +4,5 @@ __table_base
 emscripten_memcpy_big
 emscripten_resize_heap
 fd_write
-g$stdout
 memory
 table

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8354,8 +8354,7 @@ int main() {
     # don't compare the # of functions in a main module, which changes a lot
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    # FIXME disable for binaryen roll with g$ changes
-    # 'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [],  10652, True, True, True, False), # noqa
+    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [],  10652, True, True, True, False), # noqa
   })
   @no_fastcomp()
   def test_metadce_hello(self, *args):


### PR DESCRIPTION
Binaryen now optimizes away unneeded `g$` stuff.