### PR TITLE
Mark EXPORTED_RUNTIME_METHODS as deprecated.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1234,7 +1234,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if options.emrun:
       if shared.Settings.MINIMAL_RUNTIME:
         exit_with_error('--emrun is not compatible with -s MINIMAL_RUNTIME=1')
-      shared.Settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
+      shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS.append('addOnExit')
 
     if options.use_closure_compiler:
       shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
@@ -1264,7 +1264,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.RELOCATABLE = 1
       assert not options.use_closure_compiler, 'cannot use closure compiler on shared modules'
       # shared modules need memory utilities to allocate their memory
-      shared.Settings.EXPORTED_RUNTIME_METHODS += [
+      shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS += [
         'allocate',
         'getMemory',
       ]
@@ -1320,9 +1320,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.STACK_OVERFLOW_CHECK:
       if shared.Settings.MINIMAL_RUNTIME:
         shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$abortStackOverflow']
-        shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
+        shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
       else:
-        shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie', 'abortStackOverflow']
+        shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie', 'abortStackOverflow']
 
     if shared.Settings.MODULARIZE_INSTANCE:
       shared.Settings.MODULARIZE = 1
@@ -1544,7 +1544,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # file packages not built together with emcc, but that are loaded at runtime
       # separately, and they need emcc's output to contain the support they need)
       if not shared.Settings.ASMFS:
-        shared.Settings.EXPORTED_RUNTIME_METHODS += [
+        shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS += [
           'FS_createFolder',
           'FS_createPath',
           'FS_createDataFile',
@@ -1555,7 +1555,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           'FS_unlink'
         ]
 
-      shared.Settings.EXPORTED_RUNTIME_METHODS += [
+      shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS += [
         'getMemory',
         'addRunDependency',
         'removeRunDependency',
@@ -1591,16 +1591,16 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # can access them:
 
         # general threading variables:
-        shared.Settings.EXPORTED_RUNTIME_METHODS += ['PThread']
+        shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS += ['PThread']
 
         # To keep code size to minimum, MINIMAL_RUNTIME does not utilize the global ExitStatus
         # object, only regular runtime has it.
         if not shared.Settings.MINIMAL_RUNTIME:
-          shared.Settings.EXPORTED_RUNTIME_METHODS += ['ExitStatus']
+          shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS += ['ExitStatus']
 
         # stack check:
         if shared.Settings.STACK_OVERFLOW_CHECK:
-          shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
+          shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
 
       if shared.Settings.LINKABLE:
         exit_with_error('-s LINKABLE=1 is not supported with -s USE_PTHREADS>0!')

--- a/src/modules.js
+++ b/src/modules.js
@@ -316,7 +316,7 @@ function cDefine(key) {
 	throw 'Missing C define ' + key + '! If you just added it to struct_info.json, you need to ./emcc --clear-cache';
 }
 
-var EXPORTED_RUNTIME_METHODS_SET = set(EXPORTED_RUNTIME_METHODS.concat(EXTRA_EXPORTED_RUNTIME_METHODS));
+var EXPORTED_RUNTIME_METHODS_SET = set(EXTRA_EXPORTED_RUNTIME_METHODS);
 EXPORTED_RUNTIME_METHODS = unset(EXPORTED_RUNTIME_METHODS_SET);
 EXTRA_EXPORTED_RUNTIME_METHODS = [];
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -721,22 +721,12 @@ var ASYNCIFY_LAZY_LOAD_CODE = 0;
 // Runtime debug logging from asyncify internals.
 var ASYNCIFY_DEBUG = 0;
 
-// Runtime elements that are exported on Module by default. We used to export
-// quite a lot here, but have removed them all, so this option is redundant
-// given that EXTRA_EXPORTED_RUNTIME_METHODS exists, and so this option exists
-// only for backwards compatibility. You should use
-// EXTRA_EXPORTED_RUNTIME_METHODS for things you want to export from the
-// runtime.  Note that methods on this list are only exported if they are
-// included (either automatically from linking, or due to being in
-// DEFAULT_LIBRARY_FUNCS_TO_INCLUDE).
-// Note that the name may be slightly misleading, as this is for any JS library
+// Runtime elements that are exported on Module by default.  Note that methods
+// on this list are only exported if they are included (either automatically
+// from linking, or due to being in DEFAULT_LIBRARY_FUNCS_TO_INCLUDE).  Note
+// that the name may be slightly misleading, as this is for any JS library
 // element, and not just methods. For example, we can export the FS object by
 // having "FS" in this list.
-var EXPORTED_RUNTIME_METHODS = [];
-
-// Additional methods to those in EXPORTED_RUNTIME_METHODS. Adjusting that list
-// lets you remove methods that would be exported by default; setting values in
-// this list lets you add to the default list without modifying it.
 var EXTRA_EXPORTED_RUNTIME_METHODS = [];
 
 // A list of incoming values on the Module object in JS that we care about. If
@@ -1841,4 +1831,5 @@ var LEGACY_SETTINGS = [
   ['TOTAL_MEMORY', 'INITIAL_MEMORY'],
   ['WASM_MEM_MAX', 'MAXIMUM_MEMORY'],
   ['BINARYEN_MEM_MAX', 'MAXIMUM_MEMORY'],
+  ['EXPORTED_RUNTIME_METHODS', 'EXTRA_EXPORTED_RUNTIME_METHODS'],
 ];

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10562,6 +10562,10 @@ Module.arguments has been replaced with plain arguments_
     stderr = run_process(cmd + ['-Werror', '-Wno-error=invalid-input'], stderr=PIPE).stderr
     self.assertContained('emcc: warning: not_object.bc is not a valid input file [-Winvalid-input]', stderr)
 
+    # check that `-Werror=foo` also enales foo
+    stderr = self.expect_fail(cmd + ['-Werror=legacy-settings', '-s', 'TOTAL_MEMORY=1'])
+    self.assertContained('error: use of legacy setting: TOTAL_MEMORY (setting renamed to INITIAL_MEMORY) [-Wlegacy-settings] [-Werror]', stderr)
+
   def test_emranlib(self):
     create_test_file('foo.c', 'int foo = 1;')
     create_test_file('bar.c', 'int bar = 2;')

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -189,7 +189,10 @@ class WarningManager(object):
       if cmd_args[i].startswith('-Werror=') or cmd_args[i].startswith('-Wno-error='):
         warning_name = cmd_args[i].split('=', 1)[1]
         if warning_name in self.warnings:
-          self.warnings[warning_name]['error'] = not cmd_args[i].startswith('-Wno-')
+          enabled = not cmd_args[i].startswith('-Wno-')
+          self.warnings[warning_name]['error'] = enabled
+          if enabled:
+            self.warnings[warning_name]['enabled'] = True
           cmd_args[i] = ''
           continue
 


### PR DESCRIPTION
From a user POV this setting was replaced by
EXTRA_EXPORTED_RUNTIME_METHODS. I would kind of rather deprecate
EXTRA_EXPORTED_RUNTIME_METHODS but it seem that we have been promoting
that version for a while now.

Also fix a bug where `-Werror=foo` was not also enabling `foo`.