### PR TITLE
Limit testsuite parallelism to number of tests

### DIFF
--- a/tests/parallel_runner.py
+++ b/tests/parallel_runner.py
@@ -39,10 +39,11 @@ class ParallelTestSuite(unittest.BaseTestSuite):
   Creates worker threads, manages the task queue, and combines the results.
   """
 
-  def __init__(self):
+  def __init__(self, max_cores):
     super(ParallelTestSuite, self).__init__()
     self.processes = None
     self.result_queue = None
+    self.max_cores = max_cores
 
   def run(self, result):
     test_queue = self.create_test_queue()
@@ -73,10 +74,11 @@ class ParallelTestSuite(unittest.BaseTestSuite):
     return tests[::-1]
 
   def init_processes(self, test_queue):
+    use_cores = min(self.max_cores, num_cores())
+    print('Using %s parallel test processes' % use_cores)
     self.processes = []
     self.result_queue = multiprocessing.Queue()
-    self.dedicated_temp_dirs = [tempfile.mkdtemp() for x in range(num_cores())]
-    print('Using %s parallel test processes' % len(self.dedicated_temp_dirs))
+    self.dedicated_temp_dirs = [tempfile.mkdtemp() for x in range(use_cores)]
     for temp_dir in self.dedicated_temp_dirs:
       p = multiprocessing.Process(target=g_testing_thread,
                                   args=(test_queue, self.result_queue, temp_dir))

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1948,7 +1948,7 @@ def suite_for_module(module, tests):
   has_multiple_tests = len(tests) > 1
   has_multiple_cores = parallel_runner.num_cores() > 1
   if suite_supported and has_multiple_tests and has_multiple_cores:
-    return parallel_runner.ParallelTestSuite()
+    return parallel_runner.ParallelTestSuite(len(tests))
   return unittest.TestSuite()
 
 


### PR DESCRIPTION
This means that we never start more processes that we have tests
to run.  This was happening on my machine which would start 56
processes when I run just 2 tests.