### PR TITLE
Ensure unique function table indexes for side modules

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -575,6 +575,12 @@ function loadWebAssemblyModule(binary, flags) {
         assert(table.get(tableBase + i) !== undefined, 'table entry was not filled in');
       }
 #endif
+      for (var i = tableBase + 1; i < table.length; i++) {
+        var item = table.get(i);
+        if (item) {
+          functionsInTableMap.set(item, i);
+        }
+      }
       var exports = relocateExports(instance.exports, memoryBase, tableBase, moduleLocal);
       // initialize the module
       var init = exports['__post_instantiate'];

--- a/src/support.js
+++ b/src/support.js
@@ -575,11 +575,12 @@ function loadWebAssemblyModule(binary, flags) {
         assert(table.get(tableBase + i) !== undefined, 'table entry was not filled in');
       }
 #endif
-      if (!functionsInTableMap) var functionsInTableMap = new WeakMap();
-      for (var i = tableBase + 1; i < table.length; i++) {
-        var item = table.get(i);
-        if (item) {
-          functionsInTableMap.set(item, i);
+      if (functionsInTableMap) {
+        for (var i = tableBase + 1; i < table.length; i++) {
+          var item = table.get(i);
+          if (item) {
+            functionsInTableMap.set(item, i);
+          }
         }
       }
       var exports = relocateExports(instance.exports, memoryBase, tableBase, moduleLocal);

--- a/src/support.js
+++ b/src/support.js
@@ -575,6 +575,7 @@ function loadWebAssemblyModule(binary, flags) {
         assert(table.get(tableBase + i) !== undefined, 'table entry was not filled in');
       }
 #endif
+      if (!functionsInTableMap) var functionsInTableMap = new WeakMap();
       for (var i = tableBase + 1; i < table.length; i++) {
         var item = table.get(i);
         if (item) {


### PR DESCRIPTION
After #10741, main module's function pointer indexes are unique thanks to the tablemap which can be used to compare.
This tablemap however, is not populated for the side module.
In this commit, I populate the tablemap with the functions from the side module as well