### PR TITLE
Add AudioWorklet related symbols to closure-externs.js

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -998,3 +998,75 @@ var noExitRuntime;
 // No BigInt in closure yet
 //    https://github.com/google/closure-compiler/issues/3167
 var BigInt;
+
+
+// Worklet
+/**
+ * @constructor
+ */
+function Worklet() {}
+/**
+ * @param {string} moduleURL
+ * @param {object} options
+ * @return {!Promise}
+ */
+Worklet.prototype.addModule = function(moduleURL, options) {};
+
+// AudioWorklet
+/**
+ * @constructor
+ * @extends {Worklet}
+ */
+function AudioWorklet() {}
+
+/** @type {?AudioWorklet} */
+BaseAudioContext.prototype.audioWorklet;
+
+// AudioWorkletProcessor
+/**
+ * @constructor
+ */
+function AudioWorkletProcessor() {}
+
+/** @type {!MessagePort} */
+AudioWorkletProcessor.prototype.port;
+
+// AudioWorkletNodeOptions 
+/**
+ * @constructor
+ */
+function AudioWorkletNodeOptions() {}
+/** @type {number} */
+AudioWorkletNodeOptions.prototype.numberOfInputs;
+/** @type {number} */
+AudioWorkletNodeOptions.prototype.numberOfOutputs;
+/** @type {!Array<number>} */
+AudioWorkletNodeOptions.prototype.outputChannelCount;
+/** @dict */
+AudioWorkletNodeOptions.prototype.parameterData
+/** @dict */
+AudioWorkletNodeOptions.prototype.processorOptions;
+
+// AudioWorkletNode
+/**
+ * @constructor
+ * @extends {AudioNode}
+ * @param {BaseAudioContext} context
+ * @param {string} name
+ * @param {AudioWorkletNodeOptions} options
+ */
+function AudioWorkletNode(context, name, options) {}
+/** @type {!MessagePort} */
+AudioWorkletNode.prototype.port;
+/** @type {?Object<string, number>} */
+AudioWorkletNode.prototype.parameters;
+/** @type {EventListener|(function():(undefined))} */
+AudioWorkletNode.prototype.onprocessorerror;
+
+/*
+ * AudioWorkletGlobalScope globals
+ */
+var registerProcessor = function(name, obj) {};
+var currentFrame;
+var currentTime;
+var sampleRate;


### PR DESCRIPTION
These are needed to stop Closure from mangling the worklet symbols etc. until they get added to the official repository