### PR TITLE
-Werror=foo should also enable foo warnings

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10562,6 +10562,10 @@ Module.arguments has been replaced with plain arguments_
     stderr = run_process(cmd + ['-Werror', '-Wno-error=invalid-input'], stderr=PIPE).stderr
     self.assertContained('emcc: warning: not_object.bc is not a valid input file [-Winvalid-input]', stderr)
 
+    # check that `-Werror=foo` also enales foo
+    stderr = self.expect_fail(cmd + ['-Werror=legacy-settings', '-s', 'TOTAL_MEMORY=1'])
+    self.assertContained('error: use of legacy setting: TOTAL_MEMORY (setting renamed to INITIAL_MEMORY) [-Wlegacy-settings] [-Werror]', stderr)
+
   def test_emranlib(self):
     create_test_file('foo.c', 'int foo = 1;')
     create_test_file('bar.c', 'int bar = 2;')

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -189,7 +189,10 @@ class WarningManager(object):
       if cmd_args[i].startswith('-Werror=') or cmd_args[i].startswith('-Wno-error='):
         warning_name = cmd_args[i].split('=', 1)[1]
         if warning_name in self.warnings:
-          self.warnings[warning_name]['error'] = not cmd_args[i].startswith('-Wno-')
+          enabled = not cmd_args[i].startswith('-Wno-')
+          self.warnings[warning_name]['error'] = enabled
+          if enabled:
+            self.warnings[warning_name]['enabled'] = True
           cmd_args[i] = ''
           continue
 


### PR DESCRIPTION
For warnigns that default of off `-Werror=` should also enable them.