### PR TITLE
[dynamic linking] Fix functionsInTableMap

### DIFF
--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -125,7 +125,7 @@ function addFunctionWasm(func, sig) {
 
   // It's not in the table, add it now.
 
-#if ASSERTIONS
+#if ASSERTIONS >= 2
   // Make sure functionsInTableMap is actually up to date, that is, that this
   // function is not actually in the wasm Table despite not being tracked in
   // functionsInTableMap.

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -168,7 +168,7 @@ function addFunctionWasm(func, sig) {
     table.set(ret, wrapped);
   }
 
-  functionsInTableMap[func] = ret;
+  functionsInTableMap.set(func, ret);
 
   return ret;
 }

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -124,6 +124,16 @@ function addFunctionWasm(func, sig) {
   }
 
   // It's not in the table, add it now.
+
+#if ASSERTIONS
+  // Make sure functionsInTableMap is actually up to date, that is, that this
+  // function is not actually in the wasm Table despite not being tracked in
+  // functionsInTableMap.
+  for (var i = 0; i < table.length; i++) {
+    assert(table.get(i) != func, 'function in Table but not functionsInTableMap');
+  }
+#endif
+
   var ret;
   // Reuse a free index if there is one, otherwise grow.
   if (freeTableIndexes.length) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -61,7 +61,7 @@
 // exceed its size, whether all allocations (stack and static) are
 // of positive size, etc., whether we should throw if we encounter a bad __label__, i.e.,
 // if code flow runs into a fault
-// ASSERTIONS == 2 gives even more runtime checks
+// ASSERTIONS == 2 gives even more runtime checks, that may be very slow.
 var ASSERTIONS = 1;
 
 // Whether extra logging should be enabled.

--- a/tests/interop/test_add_function.cpp
+++ b/tests/interop/test_add_function.cpp
@@ -21,6 +21,17 @@ extern "C" int baz() {
 }
 
 int main(int argc, char **argv) {
+#if defined(__wasm__) && defined(GROWTH)
+  EM_ASM({
+    // Get an export that isn't in the table (we never took its address in C).
+    var baz = asm["baz"];
+    var tableSizeBefore = wasmTable.length;
+    var bazIndex = addFunction(baz);
+    assert(bazIndex >= tableSizeBefore, "we actually added it");
+    assert(addFunction(baz) === bazIndex, "we never add it again");
+  });
+#endif
+
   int fp = atoi(argv[1]);
   printf("fp: %d\n", fp);
   void (*f)(int) = reinterpret_cast<void (*)(int)>(fp);
@@ -47,19 +58,6 @@ int main(int argc, char **argv) {
   }, &foo, &bar); // taking the addresses here ensures they are in the table
                   // (the optimizer can't remove these uses) which then lets
                   // us assume the table is of a certain size in the test.
-#ifdef GROWTH
-  EM_ASM({
-    // Add another function to counteract the removal from before, so we
-    // have no more free indexes, and new additions must actually add.
-    addFunction(function(){}, 'v');
-    // Get an export that isn't in the table (we never took its address in C).
-    var baz = asm["baz"];
-    var tableSizeBefore = wasmTable.length;
-    var bazIndex = addFunction(baz);
-    assert(bazIndex >= tableSizeBefore, "we actually added it");
-    assert(addFunction(baz) === bazIndex, "we never add it again");
-  });
-#endif
 #endif
   printf("ok\n");
   return 0;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6902,6 +6902,8 @@ return malloc(size);
       print('- with table growth')
       self.set_setting('ALLOW_TABLE_GROWTH', 1)
       self.emcc_args += ['-DGROWTH']
+      # enable costly assertions to verify correct table behavior
+      self.set_setting('ASSERTIONS', 2)
       self.do_run_in_out_file_test('tests', 'interop', 'test_add_function')
     else:
       self.do_run(open(src).read(), 'Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.', assert_returncode=None)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6902,6 +6902,7 @@ return malloc(size);
       self.do_run(open(src).read(), 'Unable to grow wasm table', assert_returncode=None)
       print('- with table growth')
       self.set_setting('ALLOW_TABLE_GROWTH', 1)
+      self.emcc_args += ['-DGROWTH']
       self.do_run_in_out_file_test('tests', 'interop', 'test_add_function')
     else:
       self.do_run(open(src).read(), 'Finished up all reserved function pointers. Use a higher value for RESERVED_FUNCTION_POINTERS.', assert_returncode=None)


### PR DESCRIPTION
We never actually wrote to it properly from JS, only from the
wasm module, and the existing test didn't check both cases.

I noticed this when adding assertions to actually verify that no
function is added more than once, also in this PR.