### PR TITLE
Simplify exports of symbols needed by sanitizer code

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1793,6 +1793,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       if sanitize:
         shared.Settings.USE_OFFSET_CONVERTER = 1
+        shared.Settings.EXPORTED_FUNCTIONS += ['_memalign', '_emscripten_builtin_memalign',
+                                               '_emscripten_builtin_malloc', '_emscripten_builtin_free',
+                                               '___data_end', '___heap_base', '___global_base']
 
         if not shared.Settings.WASM_BACKEND:
           exit_with_error('Sanitizers are not compatible with the fastcomp backend. Please upgrade to the upstream wasm backend by following these instructions: https://v8.dev/blog/emscripten-llvm-wasm#testing')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -255,10 +255,6 @@ class Library(object):
   # returned by `read_symbols`.
   symbols = set()
 
-  # A list of symbols that must be exported to keep the JavaScript
-  # dependencies of this library working.
-  js_depends = []
-
   # Set to true to prevent EMCC_FORCE_STDLIBS from linking this library.
   never_force = False
 
@@ -1336,7 +1332,6 @@ class libsanitizer_common_rt_wasm(CompilerRTWasmLibrary, MTLibrary):
   name = 'libsanitizer_common_rt_wasm'
   depends = ['libc++abi']
   includes = [['system', 'lib', 'libc', 'musl', 'src', 'internal']]
-  js_depends = ['memalign', 'emscripten_builtin_memalign', '__data_end', '__heap_base']
   never_force = True
 
   src_dir = ['system', 'lib', 'compiler-rt', 'lib', 'sanitizer_common']
@@ -1354,7 +1349,6 @@ class SanitizerLibrary(CompilerRTWasmLibrary, MTLibrary):
 
 class libubsan_rt_wasm(SanitizerLibrary):
   name = 'libubsan_rt_wasm'
-  js_depends = ['emscripten_builtin_malloc', 'emscripten_builtin_free']
 
   cflags = ['-DUBSAN_CAN_USE_CXXABI']
   src_dir = ['system', 'lib', 'compiler-rt', 'lib', 'ubsan']
@@ -1362,7 +1356,6 @@ class libubsan_rt_wasm(SanitizerLibrary):
 
 class liblsan_common_rt_wasm(SanitizerLibrary):
   name = 'liblsan_common_rt_wasm'
-  js_depends = ['__global_base']
 
   src_dir = ['system', 'lib', 'compiler-rt', 'lib', 'lsan']
   src_glob = 'lsan_common*.cc'
@@ -1371,7 +1364,6 @@ class liblsan_common_rt_wasm(SanitizerLibrary):
 class liblsan_rt_wasm(SanitizerLibrary):
   name = 'liblsan_rt_wasm'
   depends = ['liblsan_common_rt_wasm']
-  js_depends = ['emscripten_builtin_malloc', 'emscripten_builtin_free']
 
   src_dir = ['system', 'lib', 'compiler-rt', 'lib', 'lsan']
   src_glob_exclude = ['lsan_common.cc', 'lsan_common_mac.cc', 'lsan_common_linux.cc',
@@ -1588,11 +1580,6 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
     # Recursively add dependencies
     for d in lib.get_depends():
       add_library(system_libs_map[d])
-
-    for d in lib.js_depends:
-      d = '_' + d
-      if d not in shared.Settings.EXPORTED_FUNCTIONS:
-        shared.Settings.EXPORTED_FUNCTIONS.append(d)
 
   if shared.Settings.STANDALONE_WASM:
     add_library(system_libs_map['crt1'])


### PR DESCRIPTION
This is a preparatory change for #9457 which is a move a way
from the complex dependency system in system_libs.py