### PR TITLE
Move link flag processing until after compilation phase

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1313,9 +1313,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       diagnostics.warning('emcc', 'Assuming object file output in the absence of `-c`, based on output filename. Add with `-c` or `-r` to avoid this warning')
       link_to_object = True
 
-    using_lld = shared.Settings.WASM_BACKEND and not (link_to_object and shared.Settings.LTO)
-    link_flags = filter_link_flags(link_flags, using_lld)
-
     if shared.Settings.STACK_OVERFLOW_CHECK:
       if shared.Settings.MINIMAL_RUNTIME:
         shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$abortStackOverflow']
@@ -2240,7 +2237,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if compile_only:
       logger.debug('stopping after compile phase')
+      for flag in link_flags:
+        diagnostics.warning('unused-command-line-argument', "argument unused during compilation: '%s'" % flag[1])
       return 0
+
+    using_lld = shared.Settings.WASM_BACKEND and not (link_to_object and shared.Settings.LTO)
+    link_flags = filter_link_flags(link_flags, using_lld)
 
     # Decide what we will link
     consumed = process_libraries(libs, lib_dirs, temp_files)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10509,6 +10509,10 @@ Module.arguments has been replaced with plain arguments_
     err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Xlinker', '--waka'])
     self.assertContained('wasm-ld: error: unknown argument: --waka', err)
 
+  def test_linker_flags_unused(self):
+    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-lbar'], stderr=PIPE).stderr
+    self.assertContained("warning: argument unused during compilation: '-lbar' [-Wunused-command-line-argument]", err)
+
   def test_non_wasm_without_wasm_in_vm(self):
     # Test that our non-wasm output does not depend on wasm support in the vm.
     run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=0'])

--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -158,10 +158,12 @@ def warn(msg, *args):
 class WarningManager(object):
   warnings = {}
 
-  def add_warning(self, name, enabled=True, part_of_all=True):
+  def add_warning(self, name, enabled=True, part_of_all=True, shared=False):
     self.warnings[name] = {
       'enabled': enabled,
       'part_of_all': part_of_all,
+      # True for flags that are shared with the underlying clang driver
+      'shared': shared,
       'error': False,
     }
 
@@ -207,7 +209,8 @@ class WarningManager(object):
 
       if warning_name in self.warnings:
         self.warnings[warning_name]['enabled'] = enabled
-        cmd_args[i] = ''
+        if not self.warnings[warning_name]['shared']:
+          cmd_args[i] = ''
         continue
 
     return cmd_args
@@ -224,8 +227,8 @@ class WarningManager(object):
       logger.debug('disabled warning: ' + msg)
 
 
-def add_warning(name, enabled=True, part_of_all=True):
-  manager.add_warning(name, enabled, part_of_all)
+def add_warning(name, enabled=True, part_of_all=True, shared=False):
+  manager.add_warning(name, enabled, part_of_all, shared)
 
 
 def enable_warning(name, as_error=False):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -67,6 +67,7 @@ diagnostics.add_warning('linkflags')
 diagnostics.add_warning('emcc')
 diagnostics.add_warning('undefined')
 diagnostics.add_warning('version-check')
+diagnostics.add_warning('unused-command-line-argument', shared=True)
 
 
 def exit_with_error(msg, *args):


### PR DESCRIPTION
Also report any link flags as unused when only compiling.

Split out from #9457