### PR TITLE
Fix null pointer dereference in embind tests.

### DIFF
--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -2936,7 +2936,7 @@ private:
     }
 
     void release(T* px) {
-        if (--px->referenceCount == 0) {
+        if (px && --px->referenceCount == 0) {
             delete px;
         }
     }


### PR DESCRIPTION
This was visible under asan.