### PR TITLE
Fix SINGLE_FILE+MINIMAL_RUNTIME+WASM build in fastcomp

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2552,7 +2552,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             else:
               return ''
 
-          if shared.Settings.MINIMAL_RUNTIME and (shared.Settings.MEM_INIT_METHOD == 0 or shared.Settings.SINGLE_FILE):
+          if shared.Settings.MINIMAL_RUNTIME and (shared.Settings.MEM_INIT_METHOD == 0 or (shared.Settings.SINGLE_FILE and not shared.Settings.WASM)):
             # In MINIMAL_RUNTIME emit the base64 memory initializer directly into a HEAPU8.set() statement.
             mem_init_data = re.search(shared.JS.memory_initializer_pattern, open(final).read())
             src = open(final).read().replace('{{{ BASE64_MEMORY_INITIALIZER }}}', base64_encode(bytearray(parse_mem_bytes(mem_init_data.group(1)))))

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -163,7 +163,9 @@ function addFunctionWasm(func, sig) {
     if (!(err instanceof TypeError)) {
       throw err;
     }
+#if ASSERTIONS
     assert(typeof sig !== 'undefined', 'Missing signature argument to addFunction');
+#endif
     var wrapped = convertJsFunctionToWasm(func, sig);
     table.set(ret, wrapped);
   }

--- a/tests/code_size/random_printf_fastcomp_wasm.json
+++ b/tests/code_size/random_printf_fastcomp_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13347,
-  "a.html.gz": 7076,
-  "total": 13347,
-  "total_gz": 7076
+  "a.html": 14059,
+  "a.html.gz": 7504,
+  "total": 14059,
+  "total_gz": 7504
 }

--- a/tests/single_file_static_initializer.cpp
+++ b/tests/single_file_static_initializer.cpp
@@ -1,0 +1,18 @@
+// Copyright 2016 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <assert.h>
+#include <memory.h>
+#include <emscripten.h>
+
+const char *str = "this is static data";
+
+int main() {
+#ifdef REPORT_RESULT
+  REPORT_RESULT(strlen(str + 
+    // throw off optimization
+    (int)(emscripten_get_now() / 10000.0)));
+#endif
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4679,10 +4679,25 @@ window.close = function() {
 
   # Tests that SINGLE_FILE works as intended in generated HTML (with and without Worker)
   def test_single_file_html(self):
-    self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1'], also_proxied=True)
+    self.btest('single_file_static_initializer.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1'], also_proxied=True)
     self.assertExists('test.html')
     self.assertNotExists('test.js')
     self.assertNotExists('test.worker.js')
+    self.assertNotExists('test.wasm')
+    self.assertNotExists('test.mem')
+
+  # Tests that SINGLE_FILE works as intended in generated HTML with MINIMAL_RUNTIME
+  def test_minimal_runtime_single_file_html(self):
+    for wasm in [0, 1]:
+      for opts in [[], ['-O3']]:
+        self.btest('single_file_static_initializer.cpp', '19', args=opts + ['-s', 'MINIMAL_RUNTIME=1', '-s', 'SINGLE_FILE=1', '-s', 'WASM=' + str(wasm)])
+        self.assertExists('test.html')
+        self.assertNotExists('test.js')
+        self.assertNotExists('test.wasm')
+        self.assertNotExists('test.asm.js')
+        self.assertNotExists('test.mem')
+        self.assertNotExists('test.js')
+        self.assertNotExists('test.worker.js')
 
   # Tests that SINGLE_FILE works when built with ENVIRONMENT=web and Closure enabled (#7933)
   def test_single_file_in_web_environment_with_closure(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4679,7 +4679,7 @@ window.close = function() {
 
   # Tests that SINGLE_FILE works as intended in generated HTML (with and without Worker)
   def test_single_file_html(self):
-    self.btest('single_file_static_initializer.cpp', '1', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1'], also_proxied=True)
+    self.btest('single_file_static_initializer.cpp', '19', args=['-s', 'SINGLE_FILE=1', '-s', 'WASM=1'], also_proxied=True)
     self.assertExists('test.html')
     self.assertNotExists('test.js')
     self.assertNotExists('test.worker.js')


### PR DESCRIPTION
In wasm single_file minimal runtime builds, the memory initializer was stolen away from making it in to the .wasm file.

Same bug might have existed in wasm backend, though did not check (let the CI do that)