### PR TITLE
docs: Improve discussion of running leak checker.

### DIFF
--- a/site/source/docs/debugging/Sanitizers.rst
+++ b/site/source/docs/debugging/Sanitizers.rst
@@ -266,9 +266,10 @@ Consider ``leak.cpp``:
   SUMMARY: AddressSanitizer: 40 byte(s) leaked in 1 allocation(s).
 
 Note that since leak checks take place at program exit, you must use
-``-s EXIT_RUNTIME``, or invoke ``__lsan::DoLeakCheck`` manually.
+``-s EXIT_RUNTIME``, or invoke ``__lsan_do_leak_check`` or
+``__lsan_do_recoverable_leak_check`` manually.
 
-You can detect that AddressSanitizer is enabled and run ``__lsan::DoLeakCheck``
+You can detect that AddressSanitizer is enabled and run ``__lsan_do_leak_check``
 by doing:
 
 .. code-block:: c
@@ -276,9 +277,13 @@ by doing:
   #if defined(__has_feature)
   #if __has_feature(address_sanitizer)
     // code for ASan-enabled builds
-    __lsan::DoLeakCheck();
+    __lsan_do_leak_check();
   #endif
   #endif
+
+This will be fatal if there are memory leaks. To check for memory leaks
+and allow the process to continue running, use
+``__lsan_do_recoverable_leak_check``.
 
 Also, if you only want to check for memory leaks, you may use
 ``-fsanitize=leak`` instead of ``-fsanitize=address``. ``-fsanitize=leak``

--- a/tests/pthread/test_pthread_lsan_leak.cpp
+++ b/tests/pthread/test_pthread_lsan_leak.cpp
@@ -22,9 +22,7 @@ void g(void) {
   while (1);
 }
 
-namespace __lsan {
-  void DoLeakCheck();
-}
+extern "C" void __lsan_do_leak_check(void);
 
 int main(int argc, char **argv) {
   std::thread t(g);
@@ -39,6 +37,6 @@ int main(int argc, char **argv) {
   memset(calloc(16, 128), 48, 2048);
   while (!atomic_load(&thread_done));
 
-  __lsan::DoLeakCheck();
+  __lsan_do_leak_check();
   fprintf(stderr, "LSAN TEST COMPLETE\n");
 }

--- a/tests/pthread/test_pthread_lsan_no_leak.cpp
+++ b/tests/pthread/test_pthread_lsan_no_leak.cpp
@@ -15,9 +15,7 @@ void g(void) {
   while (1);
 }
 
-namespace __lsan {
-  void DoLeakCheck();
-}
+extern "C" void __lsan_do_leak_check(void);
 
 int main(int argc, char **argv) {
   std::thread t(g);
@@ -29,6 +27,6 @@ int main(int argc, char **argv) {
   void *local_ptr = memset(calloc(16, 128), 48, 2048);
   while (!atomic_load(&thread_done));
 
-  __lsan::DoLeakCheck();
+  __lsan_do_leak_check();
   fprintf(stderr, "LSAN TEST COMPLETE\n");
 }


### PR DESCRIPTION
This changes the suggestion to using the actual public interface
to LSan (in advance of us actually supplying the header for that
public interface).