### PR TITLE
Remove Building.COMPILER settings

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -60,7 +60,7 @@ sys.path.append(__rootpath__)
 
 import parallel_runner
 from tools.shared import EM_CONFIG, TEMP_DIR, EMCC, EMXX, DEBUG, PYTHON, LLVM_TARGET, ASM_JS_TARGET, EMSCRIPTEN_TEMP_DIR, WASM_TARGET, SPIDERMONKEY_ENGINE, WINDOWS, EM_BUILD_VERBOSE
-from tools.shared import asstr, get_canonical_temp_dir, Building, run_process, try_delete, to_cc, asbytes, safe_copy, Settings
+from tools.shared import asstr, get_canonical_temp_dir, Building, run_process, try_delete, asbytes, safe_copy, Settings
 from tools import jsrun, shared, line_endings
 
 
@@ -1137,7 +1137,6 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
              check_for_error=True):
     if force_c or (main_file is not None and main_file[-2:]) == '.c':
       basename = 'src.c'
-      Building.COMPILER = to_cc(Building.COMPILER)
 
     if no_build:
       if src:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -371,8 +371,6 @@ class benchmark(runner.RunnerCore):
     fingerprint.append('llvm: ' + LLVM_ROOT)
     print('Running Emscripten benchmarks... [ %s ]' % ' | '.join(fingerprint))
 
-    Building.COMPILER = CLANG
-
   # avoid depending on argument reception from the commandline
   def hardcode_arguments(self, code):
     if not code or 'int main()' in code:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1344,7 +1344,6 @@ def asmjs_mangle(name):
 
 #  Building
 class Building(object):
-  COMPILER = CLANG
   multiprocessing_pool = None
   binaryen_checked = False
 
@@ -1501,7 +1500,6 @@ class Building(object):
     env['NM'] = quote(LLVM_NM)
     env['LDSHARED'] = quote(unsuffixed(EMCC)) if not WINDOWS else 'python %s' % quote(EMCC)
     env['RANLIB'] = quote(unsuffixed(EMRANLIB)) if not WINDOWS else 'python %s' % quote(EMRANLIB)
-    env['EMMAKEN_COMPILER'] = quote(Building.COMPILER)
     env['EMSCRIPTEN_TOOLS'] = path_from_root('tools')
     if cflags:
       env['CFLAGS'] = env['EMMAKEN_CFLAGS'] = ' '.join(cflags)


### PR DESCRIPTION
This was never actual used anywhere where it had an effect.

There were only 3 places it was used:

1. tests/test_benchmark.py.  Here it was set to shared.CLANG which
   is identical to the default value it is given on startup so has
   no effect at all.

2. tests/runner.py: Here is set to the to_cc() version of itself which
   would turn clang++ into clang when the test being compiled is a
   C source rather then a C++ source.  However the `build` method
   of the runner already sets the frontend to em++ vs emcc based on
   the filename which is the correct way to do this.

3. In `Building.get_building_env()` it was used to set EMMAKEN_COMPILER.
   However after removign the two places where it gets assigned we can
   assume its always just `CLANG` which is also the default for
   EMMAKEN_COMPILER.  What is more `get_building_env` sets CC and CXX
   appropriately so there is no need to set the underlying
   `EMMAKEN_COMPILER`

As a followup I think we can probably remove `EMMAKEN_COMPILER` too
but that could be more controversial since its an environment variable
and may have users we don't know about.