### PR TITLE
Fix use of wrong compiler during configure tests

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -745,7 +745,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     # if CONFIGURE_CC is defined, use that. let's you use local gcc etc. if you need that
     compiler = os.environ.get('CONFIGURE_CC') or shared.EMXX
-    if run_via_emxx:
+    if not run_via_emxx:
       compiler = shared.to_cc(compiler)
 
     def filter_emscripten_options(argv):


### PR DESCRIPTION
I got the logic backwards here as part of #10879.

This causes all configure with `-Werror` to fail which means test such
as `test_the_bullet` fail with:

```
clang-11: error: treating 'c' input as 'c++' when in C++ mode, this behavior is deprecated [-Werror,-Wdeprecated]
```

I have no idea who #10879 was able to get past CI since its a
consistent failure.