### PR TITLE
Documented workaround for #10697

### DIFF
--- a/site/source/docs/getting_started/FAQ.rst
+++ b/site/source/docs/getting_started/FAQ.rst
@@ -263,6 +263,17 @@ Another option is to use the ``MODULARIZE`` option, using ``-s MODULARIZE=1``. T
     MyCode().then(function(Module) {
       // this is reached when everything is ready, and you can call methods on Module
     });
+    
+.. note:: Be careful with using ``Module.then()`` inside ``Promise.resolve()`` or ``await`` statements. ``Module.then()`` resolves with ``Module`` which still has ``then``, so the ``await`` statement loops indefinitely. If you need to use ``Module.then()`` with ``await`` statement, you can use this workaround:
+
+    ::
+
+         await Module.then(m => {
+           delete m['then'];
+           resolve(m);
+         });
+
+    For more information read `this issue <https://github.com/emscripten-core/emscripten/pull/10697>`_.
 
 .. _faq-NO_EXIT_RUNTIME:
 


### PR DESCRIPTION
Hi. Not sure that my English is correct, anyway this PR is proposal where to put documentation about `Module.then` problem. Output looks like this:

![изображение](https://user-images.githubusercontent.com/1727152/79706924-06b70200-82e5-11ea-8576-52f72ee6838e.png)

