### PR TITLE
Always use 'ar rcu' when using Emscripten in Lua benchmark

### DIFF
--- a/tests/third_party/lua/src/Makefile
+++ b/tests/third_party/lua/src/Makefile
@@ -28,7 +28,11 @@ MYLIBS=
 MYOBJS=
 
 # XXX EMSCRIPTEN - add this
+ifndef $(EMSCRIPTEN)
 AR_ARGS=rc
+else
+AR_ARGS=rcu
+endif
 
 # == END OF USER SETTINGS -- NO NEED TO CHANGE ANYTHING BELOW THIS LINE =======
 


### PR DESCRIPTION
Fixes a MacOS regression from #10952

I haven't tested this as I don't have a mac, but the regression
range shows this as the most likely suspect given it changed
the lua makefile. This makes the lua makefile behave like it
always did when EMSCRIPTEN is set.