### PR TITLE
Properly fix Lua Makefile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -544,7 +544,7 @@ jobs:
     executor: mac
     steps:
       - run-tests-mac:
-          test_targets: "other skip:other.test_native_link_error_message skip:other.test_emcc_v"
+          test_targets: "other wasm0.test_lua skip:other.test_native_link_error_message skip:other.test_emcc_v"
 
 workflows:
   build-test:

--- a/tests/third_party/lua/src/Makefile
+++ b/tests/third_party/lua/src/Makefile
@@ -13,7 +13,7 @@ CFLAGS= -O2 -Wall -DLUA_COMPAT_ALL $(SYSCFLAGS) $(MYCFLAGS)
 LIBS= -lm $(SYSLIBS) $(MYLIBS)
 
 #AR= ar
-ifndef $(EMSCRIPTEN)
+ifndef EMSCRIPTEN
 RANLIB= ranlib
 endif
 #RM= rm -f
@@ -28,7 +28,7 @@ MYLIBS=
 MYOBJS=
 
 # XXX EMSCRIPTEN - add this
-ifndef $(EMSCRIPTEN)
+ifndef EMSCRIPTEN
 AR_ARGS=rc
 else
 AR_ARGS=rcu


### PR DESCRIPTION
I had the wrong Makefile notation, so it was always using the
same one, no matter if on native or on emscripten.

Adding the failing test to the mac tests here, as @sbc100 reminded
me we have those, and as this failed once so it seems like a corner
case we want to track. I.e. it's good for confirming this PR works
but also I think we should keep running it.
