### PR TITLE
Remove ambiguous CLANG variable and rename CLANG_CPP to CLANG_CXX

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -811,7 +811,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     return ret
 
   CXX = os.environ.get('EMMAKEN_COMPILER', shared.CLANG_CXX)
-  CC = shared.to_cc(CXX)
+  CC = cxx_to_c_compiler(CXX)
 
   EMMAKEN_CFLAGS = os.environ.get('EMMAKEN_CFLAGS')
   if EMMAKEN_CFLAGS:

--- a/emcc.py
+++ b/emcc.py
@@ -578,6 +578,13 @@ def filter_link_flags(flags, using_lld):
   return results
 
 
+def cxx_to_c_compiler(cxx):
+  # Convert C++ compiler name into C compiler name
+  dirname, basename = os.path.split(cxx)
+  basename = basename.replace('clang++', 'clang').replace('g++', 'gcc').replace('em++', 'emcc')
+  return os.path.join(dirname, basename)
+
+
 run_via_emxx = False
 
 
@@ -746,7 +753,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # if CONFIGURE_CC is defined, use that. let's you use local gcc etc. if you need that
     compiler = os.environ.get('CONFIGURE_CC') or shared.EMXX
     if not run_via_emxx:
-      compiler = shared.to_cc(compiler)
+      compiler = cxx_to_c_compiler(compiler)
 
     def filter_emscripten_options(argv):
       skip_next = False
@@ -803,7 +810,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         pass # can fail if e.g. writing the executable to /dev/null
     return ret
 
-  CXX = os.environ.get('EMMAKEN_COMPILER', shared.CLANG_CPP)
+  CXX = os.environ.get('EMMAKEN_COMPILER', shared.CLANG_CXX)
   CC = shared.to_cc(CXX)
 
   EMMAKEN_CFLAGS = os.environ.get('EMMAKEN_CFLAGS')

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -18,7 +18,7 @@ if __name__ == '__main__':
 
 import clang_native
 import runner
-from tools.shared import run_process, path_from_root, CLANG, Building, SPIDERMONKEY_ENGINE, LLVM_ROOT, CLANG_CC, V8_ENGINE, PIPE, try_delete, PYTHON, EMCC
+from tools.shared import run_process, path_from_root, Building, SPIDERMONKEY_ENGINE, LLVM_ROOT, V8_ENGINE, PIPE, try_delete, PYTHON, EMCC
 from tools import shared, jsrun
 
 # standard arguments for timing:
@@ -309,13 +309,10 @@ class CheerpBenchmarker(Benchmarker):
 
 # Benchmarkers
 
-benchmarkers = []
-
-if CLANG_CC and CLANG:
-  benchmarkers += [
-    # NativeBenchmarker('clang', CLANG_CC, CLANG),
-    # NativeBenchmarker('gcc',   'gcc',    'g++')
-  ]
+benchmarkers = [
+  # NativeBenchmarker('clang', shared.CLANG_CC, shared.CLANG_CXX),
+  # NativeBenchmarker('gcc',   'gcc',    'g++')
+]
 
 if V8_ENGINE and V8_ENGINE in shared.JS_ENGINES:
   # avoid the baseline compiler running, because it adds a lot of noise

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -31,7 +31,7 @@ if __name__ == '__main__':
 
 from tools.shared import Building, PIPE, run_js, run_process, STDOUT, try_delete, listify
 from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS, LLVM_ROOT, EMCONFIG, EM_BUILD_VERBOSE
-from tools.shared import CLANG, CLANG_CC, CLANG_CPP, LLVM_AR, LLVM_DWARFDUMP
+from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP
 from tools.shared import NODE_JS, SPIDERMONKEY_ENGINE, JS_ENGINES, WASM_ENGINES, V8_ENGINE
 from tools.shared import WebAssembly
 from runner import RunnerCore, path_from_root, no_wasm_backend, no_fastcomp, is_slow_test, ensure_dir
@@ -569,7 +569,7 @@ f.close()
     flags = output.stdout.strip()
     self.assertContained(' '.join(Building.doublequote_spaces(shared.emsdk_cflags())), flags)
     # check they work
-    cmd = [CLANG, path_from_root('tests', 'hello_world.cpp')] + shlex.split(flags.replace('\\', '\\\\')) + ['-c', '-emit-llvm', '-o', 'a.bc']
+    cmd = [CLANG_CXX, path_from_root('tests', 'hello_world.cpp')] + shlex.split(flags.replace('\\', '\\\\')) + ['-c', '-emit-llvm', '-o', 'a.bc']
     run_process(cmd)
     run_process([PYTHON, EMCC, 'a.bc'])
     self.assertContained('hello, world!', run_js('a.out.js'))
@@ -704,7 +704,7 @@ f.close()
   @no_windows('Skipped on Windows because CMake does not configure native Clang builds well on Windows.')
   def test_cmake_compile_features(self):
     with temp_directory(self.get_dir()):
-      cmd = ['cmake', '-DCMAKE_C_COMPILER=' + CLANG_CC, '-DCMAKE_CXX_COMPILER=' + CLANG_CPP, path_from_root('tests', 'cmake', 'stdproperty')]
+      cmd = ['cmake', '-DCMAKE_C_COMPILER=' + CLANG_CC, '-DCMAKE_CXX_COMPILER=' + CLANG_CXX, path_from_root('tests', 'cmake', 'stdproperty')]
       print(str(cmd))
       native_features = run_process(cmd, stdout=PIPE).stdout
 
@@ -3813,7 +3813,7 @@ int main()
       vs_env = shared.get_clang_native_env()
     except Exception:
       self.skipTest('Native clang env not found')
-    run_process([CLANG, 'minimal.cpp', '-target', 'x86_64-linux', '-c', '-emit-llvm', '-o', 'a.bc'] + clang_native.get_clang_native_args(), env=vs_env)
+    run_process([CLANG_CXX, 'minimal.cpp', '-target', 'x86_64-linux', '-c', '-emit-llvm', '-o', 'a.bc'] + clang_native.get_clang_native_args(), env=vs_env)
     err = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE, check=False).stderr
     if self.is_wasm_backend():
       self.assertContained('machine type must be wasm32', err)

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -176,7 +176,7 @@ def get_native_optimizer():
       shared.logging.debug('building native optimizer: ' + name)
       output = shared.Cache.get_path(name)
       shared.try_delete(output)
-      for compiler in [shared.CLANG, 'g++', 'clang++']: # try our clang first, otherwise hope for a system compiler in the path
+      for compiler in [shared.CLANG_CXX, 'g++', 'clang++']: # try our clang first, otherwise hope for a system compiler in the path
         shared.logging.debug('  using ' + compiler)
         try:
           shared.run_process([compiler,


### PR DESCRIPTION
Now all users of these variables need to clear if they want the C++
or C version of clang.

Also move and rename the `to_cc` function.