### PR TITLE
Remove EMMAKEN_CXX from docs

### DIFF
--- a/site/build/text/docs/tools_reference/emcc.txt
+++ b/site/build/text/docs/tools_reference/emcc.txt
@@ -593,10 +593,6 @@ Environment variables
 
    * "CONFIGURE_CC"
 
-   * "EMMAKEN_CXX"
-
-   * "EMMAKEN_CXX"
-
    * "EMMAKEN_COMPILER"
 
    * "EMMAKEN_CFLAGS"

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -460,8 +460,6 @@ Environment variables
   - ``EMMAKEN_JUST_CONFIGURE``
   - ``EMMAKEN_JUST_CONFIGURE_RECURSE``
   - ``CONFIGURE_CC``
-  - ``EMMAKEN_CXX``
-  - ``EMMAKEN_CXX``
   - ``EMMAKEN_COMPILER``
   - ``EMMAKEN_CFLAGS``
   - ``EMCC_DEBUG``


### PR DESCRIPTION
This environment variable is not used anywhere in the code.

Its last use was removed in #8156.