### PR TITLE
Remove EMCC_LEAVE_INPUTS_RAW environment variable

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Remove test-only environment variable handling for `EMCC_LEAVE_INPUTS_RAW`.
+  The two uses cases in our test code were covered by the `-nostdlib` option.
 
 v1.39.13: 04/17/2020
 --------------------

--- a/emcc.py
+++ b/emcc.py
@@ -116,19 +116,6 @@ LLVM_OPT_LEVEL = {
   3: ['-O3'],
 }
 
-# Do not compile .ll files into .bc, just compile them with emscripten directly
-# Not recommended, this is mainly for the test runner, or if you have some other
-# specific need.
-# One major limitation with this mode is that libc and libc++ cannot be
-# added in. Also, LLVM optimizations will not be done, nor dead code elimination
-LEAVE_INPUTS_RAW = int(os.environ.get('EMCC_LEAVE_INPUTS_RAW', '0'))
-
-# If emcc is running with LEAVE_INPUTS_RAW and then launches an emcc to build
-# something like the struct info, then we don't want LEAVE_INPUTS_RAW to be
-# active in that emcc subprocess.
-if LEAVE_INPUTS_RAW:
-  del os.environ['EMCC_LEAVE_INPUTS_RAW']
-
 # Target options
 final = None
 
@@ -608,9 +595,6 @@ def run(args):
 
   # Strip args[0] (program name)
   args = args[1:]
-
-  if DEBUG and LEAVE_INPUTS_RAW:
-    logger.warning('leaving inputs raw')
 
   misc_temp_files = shared.configuration.get_temp_files()
 
@@ -2181,11 +2165,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             ensure_archive_index(input_file)
             temp_files.append((i, input_file))
           elif file_ending.endswith(ASSEMBLY_ENDINGS):
-            if not LEAVE_INPUTS_RAW:
-              logger.debug('assembling assembly file: ' + input_file)
-              temp_file = in_temp(unsuffixed(uniquename(input_file)) + '.o')
-              shared.Building.llvm_as(input_file, temp_file)
-              temp_files.append((i, temp_file))
+            logger.debug('assembling assembly file: ' + input_file)
+            temp_file = in_temp(unsuffixed(uniquename(input_file)) + '.o')
+            shared.Building.llvm_as(input_file, temp_file)
+            temp_files.append((i, temp_file))
           elif has_fixed_language_mode:
             compile_source_file(i, input_file)
           elif input_file == '-':
@@ -2197,7 +2180,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     log_time('compile inputs')
 
     with ToolchainProfiler.profile_block('process inputs'):
-      if not LEAVE_INPUTS_RAW and not shared.Settings.WASM_BACKEND:
+      if not shared.Settings.WASM_BACKEND:
         assert len(temp_files) == len(input_files)
 
         # Optimize source files
@@ -2284,8 +2267,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     with ToolchainProfiler.profile_block('calculate system libraries'):
       # link in ports and system libraries, if necessary
-      if not LEAVE_INPUTS_RAW and \
-         not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
+      if not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
          not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
         extra_files_to_link = system_libs.get_ports(shared.Settings)
         if '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
@@ -2322,7 +2304,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # First, combine the bitcode files if there are several. We must also link if we have a singleton .a
       perform_link = len(linker_inputs) > 1 or shared.Settings.WASM_BACKEND
-      if not perform_link and not LEAVE_INPUTS_RAW:
+      if not perform_link:
         is_bc = suffix(temp_files[0][1]) in OBJECT_FILE_ENDINGS
         is_dylib = suffix(temp_files[0][1]) in DYNAMICLIB_ENDINGS
         is_ar = shared.Building.is_ar(temp_files[0][1])
@@ -2347,18 +2329,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, just_calculate=just_calculate)
       else:
         logger.debug('skipping linking: ' + str(linker_inputs))
-        if not LEAVE_INPUTS_RAW:
-          _, temp_file = temp_files[0]
-          _, input_file = input_files[0]
-          final = in_temp(target_basename + '.bc')
-          if temp_file != input_file:
-            shutil.move(temp_file, final)
-          else:
-            shutil.copyfile(temp_file, final)
-        else:
-          _, input_file = input_files[0]
-          final = in_temp(input_file)
-          shutil.copyfile(input_file, final)
+        input_file = input_files[0][1]
+        final = in_temp(input_file)
+        shutil.copyfile(input_file, final)
 
     # exit block 'link'
     log_time('link')
@@ -2367,63 +2340,59 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       with ToolchainProfiler.profile_block('post-link'):
         if DEBUG:
           logger.debug('saving intermediate processing steps to %s', shared.get_emscripten_temp_dir())
-          if not LEAVE_INPUTS_RAW:
-            save_intermediate('basebc', 'bc')
+          save_intermediate('basebc', 'bc')
 
         # Optimize, if asked to
-        if not LEAVE_INPUTS_RAW:
-          # remove LLVM debug if we are not asked for it
+        # remove LLVM debug if we are not asked for it
+        link_opts = []
+        if not need_llvm_debug_info(options):
+          link_opts += ['-strip-debug']
+        if not shared.Settings.ASSERTIONS:
+          link_opts += ['-disable-verify']
+        else:
+          # when verifying, LLVM debug info has some tricky linking aspects, and llvm-link will
+          # disable the type map in that case. we added linking to opt, so we need to do
+          # something similar, which we can do with a param to opt
+          link_opts += ['-disable-debug-info-type-map']
+
+        if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
+          logger.debug('running LLVM opts as pre-LTO')
+          final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
+          save_intermediate('opt', 'bc')
+
+        # If we can LTO, do it before dce, since it opens up dce opportunities
+        if (not shared.Settings.LINKABLE) and options.llvm_lto and options.llvm_lto != 2:
+          if not shared.Building.can_inline():
+            link_opts.append('-disable-inlining')
+          # add a manual internalize with the proper things we need to be kept alive during lto
+          link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
+          # execute it now, so it is done entirely before we get to the stage of legalization etc.
+          final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
+          save_intermediate('lto', 'bc')
           link_opts = []
-          if not need_llvm_debug_info(options):
-            link_opts += ['-strip-debug']
-          if not shared.Settings.ASSERTIONS:
-            link_opts += ['-disable-verify']
-          else:
-            # when verifying, LLVM debug info has some tricky linking aspects, and llvm-link will
-            # disable the type map in that case. we added linking to opt, so we need to do
-            # something similar, which we can do with a param to opt
-            link_opts += ['-disable-debug-info-type-map']
+        else:
+          # At minimum remove dead functions etc., this potentially saves a
+          # lot in the size of the generated code (and the time to compile it)
+          link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
 
-          if options.llvm_lto is not None and options.llvm_lto >= 2 and optimizing(options.llvm_opts):
-            logger.debug('running LLVM opts as pre-LTO')
-            final = shared.Building.llvm_opt(final, options.llvm_opts, DEFAULT_FINAL)
-            save_intermediate('opt', 'bc')
+        if options.cfi:
+          if use_cxx:
+             link_opts.append("-wholeprogramdevirt")
+          link_opts.append("-lowertypetests")
 
-          # If we can LTO, do it before dce, since it opens up dce opportunities
-          if (not shared.Settings.LINKABLE) and options.llvm_lto and options.llvm_lto != 2:
-            if not shared.Building.can_inline():
-              link_opts.append('-disable-inlining')
-            # add a manual internalize with the proper things we need to be kept alive during lto
-            link_opts += shared.Building.get_safe_internalize() + ['-std-link-opts']
-            # execute it now, so it is done entirely before we get to the stage of legalization etc.
+        if shared.Settings.AUTODEBUG:
+          # let llvm opt directly emit ll, to skip writing and reading all the bitcode
+          link_opts += ['-S']
+          final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
+          save_intermediate('linktime', 'll')
+        else:
+          if len(link_opts) > 0:
             final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-            save_intermediate('lto', 'bc')
-            link_opts = []
-          else:
-            # At minimum remove dead functions etc., this potentially saves a
-            # lot in the size of the generated code (and the time to compile it)
-            link_opts += shared.Building.get_safe_internalize() + ['-globaldce']
-
-          if options.cfi:
-            if use_cxx:
-               link_opts.append("-wholeprogramdevirt")
-            link_opts.append("-lowertypetests")
-
-          if shared.Settings.AUTODEBUG:
-            # let llvm opt directly emit ll, to skip writing and reading all the bitcode
-            link_opts += ['-S']
-            final = shared.Building.llvm_opt(final, link_opts, get_final() + '.link.ll')
-            save_intermediate('linktime', 'll')
-          else:
-            if len(link_opts) > 0:
-              final = shared.Building.llvm_opt(final, link_opts, DEFAULT_FINAL)
-              save_intermediate('linktime', 'bc')
-            if options.save_bc:
-              shutil.copyfile(final, options.save_bc)
+            save_intermediate('linktime', 'bc')
+          if options.save_bc:
+            shutil.copyfile(final, options.save_bc)
 
         # Prepare .ll for Emscripten
-        if LEAVE_INPUTS_RAW:
-          assert len(input_files) == 1
         if options.save_bc:
           save_intermediate('ll', 'll')
 

--- a/emcc.py
+++ b/emcc.py
@@ -2329,9 +2329,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, just_calculate=just_calculate)
       else:
         logger.debug('skipping linking: ' + str(linker_inputs))
+        temp_file = temp_files[0][1]
         input_file = input_files[0][1]
-        final = in_temp(input_file)
-        shutil.copyfile(input_file, final)
+        final = in_temp(target_basename + '.bc')
+        if temp_file != input_file:
+          shutil.move(temp_file, final)
+        else:
+          shutil.copyfile(temp_file, final)
 
     # exit block 'link'
     log_time('link')

--- a/tests/cases/breakinthemiddle.ll
+++ b/tests/cases/breakinthemiddle.ll
@@ -4,7 +4,7 @@ target triple = "asmjs-unknown-emscripten"
 
 @.str = private constant [15 x i8] c"hello, world!\0A\00", align 1 ; [#uses=1]
 
-define linkonce_odr i32 @main() align 2 {
+define i32 @main() {
   %1 = trunc i8 1 to i1                        ; [#uses=1]
   br i1 %1, label %label555, label %label569
 

--- a/tests/cases/breakinthemiddle2.ll
+++ b/tests/cases/breakinthemiddle2.ll
@@ -4,7 +4,7 @@ target triple = "asmjs-unknown-emscripten"
 
 @.str = private constant [15 x i8] c"hello, world!\0A\00", align 1 ; [#uses=1]
 
-define linkonce_odr i32 @main() align 2 {
+define i32 @main() {
   %a333 = call i32 @printf(i8* getelementptr inbounds ([15 x i8], [15 x i8]* @.str, i32 0, i32 0)) ; [#uses=0]
   %b199 = trunc i8 1 to i1                        ; [#uses=1]
   br i1 %b199, label %label555, label %label569

--- a/tests/cases/ptrtoint_blockaddr.ll
+++ b/tests/cases/ptrtoint_blockaddr.ll
@@ -4,7 +4,7 @@ target triple = "asmjs-unknown-emscripten"
 
 @.str = private constant [15 x i8] c"hello, world!\0A\00", align 1 ; [#uses=1]
 
-define linkonce_odr i32 @main() align 2 {
+define i32 @main() {
   %a199 = trunc i8 1 to i1                        ; [#uses=1]
   br i1 %a199, label %label555, label %label569
 

--- a/tests/cases/redundantswitch_fastcomp.ll
+++ b/tests/cases/redundantswitch_fastcomp.ll
@@ -5,7 +5,7 @@ target triple = "asmjs-unknown-emscripten"
 
 declare i32 @printf(i8*, ...)
 
-define linkonce_odr i32 @main() align 2 {
+define i32 @main() {
 entry:
   %temp32 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @.str, i32 0, i32 0), i32 5)
   switch i32 %temp32, label %mid1 [

--- a/tests/cases/switch64_ta2.ll
+++ b/tests/cases/switch64_ta2.ll
@@ -5,7 +5,7 @@ target triple = "asmjs-unknown-emscripten"
 
 declare i32 @printf(i8*, ...)
 
-define linkonce_odr i32 @main() align 2 {
+define i32 @main() {
   %a333 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @.str, i32 0, i32 0), i32 5)
   %a400 = zext i32 %a333 to i64
   %a444 = udiv i64 %a400, 3

--- a/tests/cases/switch64b_ta2.ll
+++ b/tests/cases/switch64b_ta2.ll
@@ -5,7 +5,7 @@ target triple = "asmjs-unknown-emscripten"
 
 declare i32 @printf(i8*, ...)
 
-define linkonce_odr i32 @main() align 2 {
+define i32 @main() {
   %a333 = call i32 (i8*, ...) @printf(i8* getelementptr inbounds ([18 x i8], [18 x i8]* @.str, i32 0, i32 0), i32 5)
   %a400 = zext i32 %a333 to i64
   %a444 = udiv i64 %a400, 3

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6411,8 +6411,8 @@ return malloc(size);
 
     emcc_args = self.emcc_args
 
-    # The following tests link to libc, and must be run with EMCC_LEAVE_INPUTS_RAW = 0
-    need_no_leave_inputs_raw = [
+    # The following tests link to libc, whereas others link with -nostdlib
+    needs_stdlib = [
       'muli33_ta2', 'philoop_ta2', 'uadd_overflow_64_ta2', 'i64toi8star',
       'legalizer_ta2', 'quotedlabel', 'alignedunaligned', 'sillybitcast',
       'invokeundef', 'loadbitcastgep', 'sillybitcast2', 'legalizer_b_ta2',
@@ -6461,14 +6461,6 @@ return malloc(size);
       if self.is_wasm() and basename in skip_wasm:
         continue
 
-      if basename in need_no_leave_inputs_raw:
-        leave_inputs = '0'
-        self.set_setting('FILESYSTEM', 1)
-      else:
-        leave_inputs = '1'
-        # no libc is linked in; with FILESYSTEM=0 we have a chance at printfing anyhow
-        self.set_setting('FILESYSTEM', 0)
-
       if '_noasm' in shortname and self.get_setting('ASM_JS'):
         print('case "%s" not relevant for asm.js' % shortname)
         continue
@@ -6484,12 +6476,17 @@ return malloc(size);
         output = 'hello, world!'
 
       if output.rstrip() != 'skip':
-        self.emcc_args = emcc_args
+        self.emcc_args = list(emcc_args)
+        if basename in needs_stdlib:
+          self.set_setting('FILESYSTEM', 1)
+        else:
+          self.emcc_args.append('-nostdlib')
+          # no libc is linked in; with FILESYSTEM=0 we have a chance at printfing anyhow
+          self.set_setting('FILESYSTEM', 0)
         if os.path.exists(shortname + '.emcc'):
           self.emcc_args += json.loads(open(shortname + '.emcc').read())
 
-        with env_modify({'EMCC_LEAVE_INPUTS_RAW': leave_inputs}):
-          self.do_ll_run(path_from_root('tests', 'cases', name), output, assert_returncode=None)
+        self.do_ll_run(path_from_root('tests', 'cases', name), output, assert_returncode=None)
 
       # Optional source checking, a python script that gets a global generated with the source
       src_checker = path_from_root('tests', 'cases', shortname + '.py')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2059,23 +2059,14 @@ int f() {
 
   @no_wasm_backend('depends on bc output')
   def test_save_bc(self):
-    for save in [0, 1]:
-      self.clear()
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world_loop_malloc.cpp')]
-      if save:
-        cmd += ['--save-bc', 'my_bitcode.bc']
-      run_process(cmd)
-      assert 'hello, world!' in run_js('a.out.js')
-      if save:
-        self.assertExists('my_bitcode.bc')
-      else:
-        self.assertNotExists('my_bitcode.bc')
-      if save:
-        try_delete('a.out.js')
-        Building.llvm_dis('my_bitcode.bc', 'my_ll.ll')
-        with env_modify({'EMCC_LEAVE_INPUTS_RAW': '1'}):
-          run_process([PYTHON, EMCC, 'my_ll.ll', '-o', 'two.js'])
-          assert 'hello, world!' in run_js('two.js')
+    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world_loop_malloc.cpp'), '--save-bc', 'my_bitcode.bc']
+    run_process(cmd)
+    assert 'hello, world!' in run_js('a.out.js')
+    self.assertExists('my_bitcode.bc')
+    try_delete('a.out.js')
+    Building.llvm_dis('my_bitcode.bc', 'my_ll.ll')
+    run_process([PYTHON, EMCC, 'my_ll.ll', '-nostdlib', '-o', 'two.js'])
+    assert 'hello, world!' in run_js('two.js')
 
   def test_js_optimizer(self):
     ACORN_PASSES = ['JSDCE', 'AJSDCE', 'applyImportAndExportNameChanges', 'emitDCEGraph', 'applyDCEGraphRemovals', 'growableHeap', 'unsignPointers']

--- a/tools/scons/site_scons/site_tools/emscripten/emscripten.py
+++ b/tools/scons/site_scons/site_tools/emscripten/emscripten.py
@@ -21,7 +21,7 @@ def generate(env, emscripten_path=None, **kw):
   # so manually route all environment variables referenced
   # by Emscripten to the child.
   for var in ['EM_CACHE', 'EMCC_DEBUG', 'EMSCRIPTEN_NATIVE_OPTIMIZER', 'EMTEST_BROWSER',
-              'EMMAKEN_JUST_CONFIGURE', 'EMCC_CFLAGS', 'EMCC_LEAVE_INPUTS_RAW', 'EMCC_TEMP_DIR',
+              'EMMAKEN_JUST_CONFIGURE', 'EMCC_CFLAGS', 'EMCC_TEMP_DIR',
               'EMCC_AUTODEBUG', 'EMMAKEN_JUST_CONFIGURE_RECURSE', 'CONFIGURE_CC',
               'EMMAKEN_COMPILER', 'EMMAKEN_CFLAGS', 'EMCC_JSOPT_BLACKLIST',
               'MOZ_DISABLE_AUTO_SAFE_MODE', 'EMCC_STDERR_FILE',


### PR DESCRIPTION
This was a strange and cross cutting option that is implemented as
an environment variable and only uses by a couple of fastcomp only tests.

It turns out that what these tests were really trying to achieve was
basically `-nostdlib`, so replace the two uses with that option.

There were a few `.ll` tests that are part of `test_zzz_cases` that
required a minor modification to continue to work.  It seems that
for some reason the `linkonce_odr` linkage type on `main` was causing
the globaldce pass to eliminate it, even when `main` was included
in the `-internalize-public-api` list.  I didn't try to get the bottom
of this but instead removed the linkage specifier from the main
functions.