### PR TITLE
AJSDCE improvement: ignore trivial constructors

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 5069,
   "a.js.gz": 2418,
-  "a.wasm": 10894,
-  "a.wasm.gz": 6920,
+  "a.wasm": 10895,
+  "a.wasm.gz": 6927,
   "total": 16526,
-  "total_gz": 9715
+  "total_gz": 9722
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23671,
-  "a.js.gz": 8883,
+  "a.js": 23664,
+  "a.js.gz": 8885,
   "a.mem": 3168,
   "a.mem.gz": 2711,
   "total": 27427,
-  "total_gz": 11980
+  "total_gz": 11982
 }

--- a/tests/code_size/hello_webgl_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl_fastcomp_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 4780,
-  "a.js.gz": 2356,
+  "a.js": 4776,
+  "a.js.gz": 2355,
   "a.wasm": 7982,
   "a.wasm.gz": 4368,
   "total": 13325,
-  "total_gz": 7101
+  "total_gz": 7100
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 4558,
-  "a.js.gz": 2243,
-  "a.wasm": 10894,
-  "a.wasm.gz": 6920,
+  "a.js": 4554,
+  "a.js.gz": 2242,
+  "a.wasm": 10895,
+  "a.wasm.gz": 6927,
   "total": 16015,
-  "total_gz": 9540
+  "total_gz": 9546
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23165,
-  "a.js.gz": 8718,
+  "a.js": 23154,
+  "a.js.gz": 8722,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 26921,
-  "total_gz": 11815
+  "total": 26910,
+  "total_gz": 11819
 }

--- a/tests/code_size/hello_world_fastcomp_wasm.json
+++ b/tests/code_size/hello_world_fastcomp_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 665,
   "a.html.gz": 427,
-  "a.js": 630,
-  "a.js.gz": 423,
+  "a.js": 622,
+  "a.js.gz": 420,
   "a.wasm": 86,
   "a.wasm.gz": 103,
   "total": 1381,
-  "total_gz": 953
+  "total_gz": 950
 }

--- a/tests/code_size/hello_world_wasm.json
+++ b/tests/code_size/hello_world_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 665,
   "a.html.gz": 427,
-  "a.js": 450,
-  "a.js.gz": 321,
+  "a.js": 442,
+  "a.js.gz": 317,
   "a.wasm": 96,
   "a.wasm.gz": 109,
   "total": 1211,
-  "total_gz": 857
+  "total_gz": 853
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 697,
   "a.html.gz": 437,
-  "a.js": 2026,
-  "a.js.gz": 913,
+  "a.js": 2022,
+  "a.js.gz": 912,
   "a.mem": 6,
   "a.mem.gz": 32,
   "total": 2729,
-  "total_gz": 1382
+  "total_gz": 1381
 }

--- a/tests/code_size/random_printf_fastcomp_wasm.json
+++ b/tests/code_size/random_printf_fastcomp_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13468,
-  "a.html.gz": 7113,
-  "total": 13468,
-  "total_gz": 7113
+  "a.html": 13347,
+  "a.html.gz": 7076,
+  "total": 13347,
+  "total_gz": 7076
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13845,
-  "a.html.gz": 7353,
-  "total": 13845,
-  "total_gz": 7353
+  "a.html": 13732,
+  "a.html.gz": 7335,
+  "total": 13732,
+  "total_gz": 7335
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 20051,
-  "a.html.gz": 8371,
-  "total": 20051,
-  "total_gz": 8371
+  "a.html": 19933,
+  "a.html.gz": 8343,
+  "total": 19933,
+  "total_gz": 8343
 }

--- a/tests/optimizer/AJSDCE-output.js
+++ b/tests/optimizer/AJSDCE-output.js
@@ -33,4 +33,13 @@ function glue() {
 glue();
 null
 null
+null
+null
+null
+null
+null
+null
+null
+null
 new SomethingUnknownWithSideEffects("utf8");
+new TextDecoder(Unknown());

--- a/tests/optimizer/AJSDCE-output.js
+++ b/tests/optimizer/AJSDCE-output.js
@@ -31,15 +31,15 @@ function glue() {
 }
 
 glue();
-null
-null
-null
-null
-null
-null
-null
-null
-null
-null
+null;
+null;
+null;
+null;
+null;
+null;
+null;
+null;
+null;
+null;
 new SomethingUnknownWithSideEffects("utf8");
 new TextDecoder(Unknown());

--- a/tests/optimizer/AJSDCE-output.js
+++ b/tests/optimizer/AJSDCE-output.js
@@ -31,3 +31,6 @@ function glue() {
 }
 
 glue();
+null
+null
+new SomethingUnknownWithSideEffects("utf8");

--- a/tests/optimizer/AJSDCE.js
+++ b/tests/optimizer/AJSDCE.js
@@ -59,10 +59,21 @@ function glue() {
 }
 glue();
 
+var buffer = new ArrayBuffer(1024);
+
 // unnecessary leftovers that seem to have side effects
 "undefined" !== typeof TextDecoder && new TextDecoder("utf8");
 new TextDecoder("utf8");
+new Int8Array(buffer);
+new Uint8Array(buffer);
+new Int16Array(buffer);
+new Uint16Array(buffer);
+new Int32Array(buffer);
+new Uint32Array(buffer);
+new Float32Array(buffer);
+new Float64Array(buffer);
 
-// for comparison, a real side effect
+// for comparison, real side effects
 new SomethingUnknownWithSideEffects("utf8");
+new TextDecoder(Unknown());
 

--- a/tests/optimizer/AJSDCE.js
+++ b/tests/optimizer/AJSDCE.js
@@ -59,3 +59,10 @@ function glue() {
 }
 glue();
 
+// unnecessary leftovers that seem to have side effects
+"undefined" !== typeof TextDecoder && new TextDecoder("utf8");
+new TextDecoder("utf8");
+
+// for comparison, a real side effect
+new SomethingUnknownWithSideEffects("utf8");
+

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -124,6 +124,23 @@ function convertToNull(node) {
   node.name = 'null';
 }
 
+function convertToNullStatement(node) {
+  node.type = 'ExpressionStatement';
+  node.expression = {
+    type: "Literal",
+    value: null,
+    raw: "null",
+    start: 0,
+    end: 0,
+  };
+  node.start = 0;
+  node.end = 0;
+}
+
+function isNull(node) {
+  return node.type === 'Literal' && node.raw === 'null';
+}
+
 function setLiteralValue(item, value) {
   item.value = value;
   item.raw = "'" + value + "'";
@@ -312,8 +329,10 @@ function JSDCE(ast, aggressive) {
         },
         ExpressionStatement(node, c) {
           if (aggressive && !hasSideEffects(node)) {
-            convertToNull(node);
-            removed++;
+            if (!isNull(node.expression)) {
+              convertToNullStatement(node);
+              removed++;
+            }
           }
         },
         FunctionDeclaration(node, c) {

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -233,14 +233,20 @@ function hasSideEffects(node) {
       }
       case 'NewExpression': {
         // default to unsafe, but can be safe on some familiar objects
-        has = true;
         if (node.callee.type === 'Identifier') {
           var name = node.callee.name;
-          if (name === 'TextDecoder') {
-            // no side effects (but the arguments might, we walk them too)
-            has = false;
+          if (name === 'TextDecoder'  || name === 'ArrayBuffer' ||
+              name === 'Int8Array'    || name === 'Uint8Array' ||
+              name === 'Int16Array'   || name === 'Uint16Array' ||
+              name === 'Int32Array'   || name === 'Uint32Array' ||
+              name === 'Float32Array' || name === 'Float64Array') {
+            // no side effects, but the arguments might (we walk them in
+            // full walk as well)
+            break;
           }
         }
+        // not one of the safe cases
+        has = true;
         break;
       }
       default: {


### PR DESCRIPTION
Closure compiler may leave things like

```
new Int8Array(buffer);
```

since that has a side effect, in this case allocation, and also the
user may have monkey-patched Int8Array to something else.

For us, we depend on those things being not monkey-patched,
and we don't care about an allocation that is never seen. So we can
ignore those.

This reduces code size as you can see in the test updates. Mostly
just noticeable in the very smallest examples.
