### PR TITLE
Parameterize test_cmake test. NFC.

### DIFF
--- a/tests/cmake/emscripten_version/CMakeLists.txt
+++ b/tests/cmake/emscripten_version/CMakeLists.txt
@@ -1,16 +1,22 @@
-# EMSCRIPTEN_VERSION CMake variable is introduced in Emscripten version 1.38.6, so test that the value is at least that new.
+project(emscripten_version)
+
+# EMSCRIPTEN_VERSION CMake variable is introduced in Emscripten version 1.38.6,
+# so test that the value is at least that new.
 
 if ("${EMSCRIPTEN_VERSION}" VERSION_GREATER 1.38.5)
-	message(STATUS "Emscripten version is at least 1.38.6")
+  message(STATUS "Emscripten version is at least 1.38.6")
 else()
-	message(FATAL_ERROR "EMSCRIPTEN_VERSION is not present, or is older than 1.38.6: '${EMSCRIPTEN_VERSION}'")
+  message(FATAL_ERROR "EMSCRIPTEN_VERSION is not present, or is older than 1.38.6: '${EMSCRIPTEN_VERSION}'")
 endif()
 
-# A particular gotcha about Emscripten version testing: do not use the following code:
+# A particular gotcha about Emscripten version testing: do not use the following
+# code:
 
 #    if (${EMSCRIPTEN_VERSION} VERSION_GREATER "1.38.5")
 
-# because this would fail when running on an Emscripten version older than 1.38.6. That is, note the needed double quotes
-# around ${EMSCRIPTEN_VERSION}. This is because in older Emscripten versions, the EMSCRIPTEN_VERSION CMake variable did
-# not yet exist, so the above if statement would expand to an empty left hand side: if ( VERSION_GREATER_EQUAL 1.38.6)
-# which would be a syntax error. if ("" VERSION_GREATER_EQUAL 1.38.6) is fine however.
+# because this would fail when running on an Emscripten version older than
+# 1.38.6. That is, note the needed double quotes around ${EMSCRIPTEN_VERSION}.
+# This is because in older Emscripten versions, the EMSCRIPTEN_VERSION CMake
+# variable did not yet exist, so the above if statement would expand to an empty
+# left hand side: if ( VERSION_GREATER_EQUAL 1.38.6) which would be a syntax
+# error. if ("" VERSION_GREATER_EQUAL 1.38.6) is fine however.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -596,108 +596,74 @@ f.close()
         output = run_process(cmd, stdout=PIPE).stdout
         self.assertContained(expected, output)
 
-  def test_cmake(self):
+  @parameterized({
+    # ('directory to the test', 'output filename', ['extra args to pass to
+    # CMake']) Testing all combinations would be too much work and the test
+    # would take 10 minutes+ to finish (CMake feature detection is slow), so
+    # combine multiple features into one to try to cover as much as possible
+    # while still keeping this test in sensible time limit.
+    'js':          ('target_js',      'test_cmake.js',         ['-DCMAKE_BUILD_TYPE=Debug']),
+    'html':        ('target_html',    'hello_world_gles.html', ['-DCMAKE_BUILD_TYPE=Release']),
+    'library':     ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=MinSizeRel']),
+    'static_cpp':  ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DCPP_LIBRARY_TYPE=STATIC']),
+    'stdproperty': ('stdproperty',    'helloworld.js',         [])
+  })
+  def test_cmake(self, test_dir, output_file, cmake_args):
     # Test all supported generators.
     if WINDOWS:
       generators = ['MinGW Makefiles', 'NMake Makefiles']
     else:
       generators = ['Unix Makefiles', 'Ninja', 'Eclipse CDT4 - Ninja']
 
-    def nmake_detect_error(configuration):
-      if Building.which(configuration['build'][0]):
-        return None
-      else:
-        return 'Skipping NMake test for CMake support, since nmake was not found in PATH. Run this test in Visual Studio command prompt to easily access nmake.'
-
-    def check_makefile(dirname):
-      self.assertExists(dirname + '/Makefile', 'CMake call did not produce a Makefile!')
-
-    configurations = {'MinGW Makefiles'     : {'prebuild': check_makefile, # noqa
-                                               'build'   : ['mingw32-make'], # noqa
-                      },
-                      'NMake Makefiles'     : {'detect'  : nmake_detect_error, # noqa
-                                               'prebuild': check_makefile, # noqa
-                                               'build'   : ['nmake', '/NOLOGO'], # noqa
-                      },
-                      'Unix Makefiles'      : {'prebuild': check_makefile, # noqa
-                                               'build'   : ['make'], # noqa
-                      },
-                      'Ninja'               : {'build'   : ['ninja'], # noqa
-                      },
-                      'Eclipse CDT4 - Ninja': {'build'   : ['ninja'], # noqa
-                      }
+    configurations = {'MinGW Makefiles'     : {'build'   : ['mingw32-make'] }, # noqa
+                      'NMake Makefiles'     : {'build'   : ['nmake', '/NOLOGO']}, # noqa
+                      'Unix Makefiles'      : {'build'   : ['make']}, # noqa
+                      'Ninja'               : {'build'   : ['ninja']}, # noqa
+                      'Eclipse CDT4 - Ninja': {'build'   : ['ninja']}, # noqa
     }
-
     for generator in generators:
       conf = configurations[generator]
 
-      make = conf['build']
-      detector = conf.get('detect')
-      prebuild = conf.get('prebuild')
-
-      if detector:
-        error = detector(conf)
-      elif len(make) == 1 and not Building.which(make[0]):
+      if not Building.which(conf['build'][0]):
         # Use simple test if applicable
-        error = 'Skipping %s test for CMake support, since it could not be detected.' % generator
-      else:
-        error = None
-
-      if error:
-        print(error)
+        print('Skipping %s test for CMake support; build tool found found: %s.' % (generator, conf['build'][0]))
         continue
 
-      # ('directory to the test', 'output filename', ['extra args to pass to
-      # CMake']) Testing all combinations would be too much work and the test
-      # would take 10 minutes+ to finish (CMake feature detection is slow), so
-      # combine multiple features into one to try to cover as much as possible
-      # while still keeping this test in sensible time limit.
-      cases = [
-        ('target_js',      'test_cmake.js',         ['-DCMAKE_BUILD_TYPE=Debug']),
-        ('target_html',    'hello_world_gles.html', ['-DCMAKE_BUILD_TYPE=Release']),
-        ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=MinSizeRel']),
-        ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DCPP_LIBRARY_TYPE=STATIC']),
-        ('stdproperty',    'helloworld.js',         [])
-      ]
-      for test_dir, output_file, cmake_args in cases:
-        cmakelistsdir = path_from_root('tests', 'cmake', test_dir)
-        with temp_directory(self.get_dir()) as tempdirname:
-          # Run Cmake
-          cmd = [emcmake, 'cmake'] + cmake_args + ['-G', generator, cmakelistsdir]
+      cmakelistsdir = path_from_root('tests', 'cmake', test_dir)
+      with temp_directory(self.get_dir()) as tempdirname:
+        # Run Cmake
+        cmd = [emcmake, 'cmake'] + cmake_args + ['-G', generator, cmakelistsdir]
 
-          env = os.environ.copy()
-          # https://github.com/emscripten-core/emscripten/pull/5145: Check that CMake works even if EMCC_SKIP_SANITY_CHECK=1 is passed.
-          if test_dir == 'target_html':
-            env['EMCC_SKIP_SANITY_CHECK'] = '1'
-          print(str(cmd))
-          ret = run_process(cmd, env=env, stdout=None if EM_BUILD_VERBOSE >= 2 else PIPE, stderr=None if EM_BUILD_VERBOSE >= 1 else PIPE)
-          if ret.stderr is not None and len(ret.stderr.strip()):
-            print(ret.stderr) # If there were any errors, print them directly to console for diagnostics.
-          if ret.stderr is not None and 'error' in ret.stderr.lower():
-            print('Failed command: ' + ' '.join(cmd))
-            print('Result:\n' + ret.stderr)
-            self.fail('cmake call failed!')
+        env = os.environ.copy()
+        # https://github.com/emscripten-core/emscripten/pull/5145: Check that CMake works even if EMCC_SKIP_SANITY_CHECK=1 is passed.
+        if test_dir == 'target_html':
+          env['EMCC_SKIP_SANITY_CHECK'] = '1'
+        print(str(cmd))
+        ret = run_process(cmd, env=env, stdout=None if EM_BUILD_VERBOSE >= 2 else PIPE, stderr=None if EM_BUILD_VERBOSE >= 1 else PIPE)
+        if ret.stderr is not None and len(ret.stderr.strip()):
+          print(ret.stderr) # If there were any errors, print them directly to console for diagnostics.
+        if ret.stderr is not None and 'error' in ret.stderr.lower():
+          print('Failed command: ' + ' '.join(cmd))
+          print('Result:\n' + ret.stderr)
+          self.fail('cmake call failed!')
 
-          if prebuild:
-            prebuild(tempdirname)
+        # Build
+        cmd = conf['build']
+        if EM_BUILD_VERBOSE >= 3 and 'Ninja' not in generator:
+          cmd += ['VERBOSE=1']
+        ret = run_process(cmd, stdout=None if EM_BUILD_VERBOSE >= 2 else PIPE)
+        if ret.stderr is not None and len(ret.stderr.strip()):
+          print(ret.stderr) # If there were any errors, print them directly to console for diagnostics.
+        if ret.stdout is not None and 'error' in ret.stdout.lower() and '0 error(s)' not in ret.stdout.lower():
+          print('Failed command: ' + ' '.join(cmd))
+          print('Result:\n' + ret.stdout)
+          self.fail('make failed!')
+        self.assertExists(tempdirname + '/' + output_file, 'Building a cmake-generated Makefile failed to produce an output file %s!' % tempdirname + '/' + output_file)
 
-          # Build
-          cmd = make
-          if EM_BUILD_VERBOSE >= 3 and 'Ninja' not in generator:
-            cmd += ['VERBOSE=1']
-          ret = run_process(cmd, stdout=None if EM_BUILD_VERBOSE >= 2 else PIPE)
-          if ret.stderr is not None and len(ret.stderr.strip()):
-            print(ret.stderr) # If there were any errors, print them directly to console for diagnostics.
-          if ret.stdout is not None and 'error' in ret.stdout.lower() and '0 error(s)' not in ret.stdout.lower():
-            print('Failed command: ' + ' '.join(cmd))
-            print('Result:\n' + ret.stdout)
-            self.fail('make failed!')
-          self.assertExists(tempdirname + '/' + output_file, 'Building a cmake-generated Makefile failed to produce an output file %s!' % tempdirname + '/' + output_file)
-
-          # Run through node, if CMake produced a .js file.
-          if output_file.endswith('.js'):
-            ret = run_process(NODE_JS + [tempdirname + '/' + output_file], stdout=PIPE).stdout
-            self.assertTextDataIdentical(open(cmakelistsdir + '/out.txt').read().strip(), ret.strip())
+        # Run through node, if CMake produced a .js file.
+        if output_file.endswith('.js'):
+          ret = run_process(NODE_JS + [tempdirname + '/' + output_file], stdout=PIPE).stdout
+          self.assertTextDataIdentical(open(cmakelistsdir + '/out.txt').read().strip(), ret.strip())
 
   # Test that the various CMAKE_xxx_COMPILE_FEATURES that are advertised for the Emscripten toolchain match with the actual language features that Clang supports.
   # If we update LLVM version and this test fails, copy over the new advertised features from Clang and place them to cmake/Modules/Platform/Emscripten.cmake.


### PR DESCRIPTION
Remove the `detect` and `prebuild` keys for each generator as they
seem pretty redundnat.  `nmake_detect_error` was just checking for the
the build command in the path, which is the default behaviour, and
`prebuild` was just checking for the existence of the Makefile after
cmake runs.
  
Also add `project` to tests/cmake/emscripten_version/CMakeLists.txt
to avoid warning.
