### PR TITLE
Remove EMCC_WASM_BACKEND_BINARYEN environment variable

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1909,9 +1909,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           passes += parse_passes(shared.Settings.BINARYEN_EXTRA_PASSES)
         options.binaryen_passes = passes
 
-        # to bootstrap struct_info, we need binaryen
-        os.environ['EMCC_WASM_BACKEND_BINARYEN'] = '1'
-
       # run safe-heap as a binaryen pass in fastcomp wasm, while in the wasm backend we
       # run it in binaryen_passes so that it can be synchronized with the sbrk ptr
       if shared.Settings.SAFE_HEAP and shared.Building.is_wasm_only() and not shared.Settings.WASM_BACKEND:

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -403,7 +403,7 @@ def inspect_code(headers, cpp_opts, structs, defines):
                                                    '-s', 'STRICT=1',
                                                    '-s', 'SINGLE_FILE=1']
   if not shared.Settings.WASM_BACKEND:
-    # Avoid the binaryen depednency if we are only using fastcomp
+    # Avoid the binaryen dependency if we are only using fastcomp
     cmd += ['-s', 'WASM=0']
   if shared.Settings.LTO:
     cmd += ['-flto=' + shared.Settings.LTO]

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -396,11 +396,12 @@ def inspect_code(headers, cpp_opts, structs, defines):
   show('Compiling generated code...')
   # -Oz optimizes enough to avoid warnings on code size/num locals
   cmd = [shared.PYTHON, shared.EMCC] + cpp_opts + ['-o', js_file[1], src_file[1],
-         '-O0', '--js-opts', '0', '--memory-init-file', '0', '-Werror', '-Wno-format',
-         '-s', 'BOOTSTRAPPING_STRUCT_INFO=1',
-         '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0',
-         '-s', 'STRICT=1',
-         '-s', 'SINGLE_FILE=1']
+                                                   '-O0', '--js-opts', '0', '--memory-init-file', '0',
+                                                   '-Werror', '-Wno-format',
+                                                   '-s', 'BOOTSTRAPPING_STRUCT_INFO=1',
+                                                   '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0',
+                                                   '-s', 'STRICT=1',
+                                                   '-s', 'SINGLE_FILE=1']
   if not shared.Settings.WASM_BACKEND:
     # Avoid the binaryen depednency if we are only using fastcomp
     cmd += ['-s', 'WASM=0']


### PR DESCRIPTION
This was being used to set `-s BINARYEN=1`, which is an alias for
`-s WASM=1`, which is the default.

Pass `-Werror` and `STRICT=1` when building struct info to ensure
its not using legacy settings, and that its output is silent.