### PR TITLE
Use conventional object file naming when building system libraries

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -112,7 +112,8 @@ def create_lib(libname, inputs):
   suffix = os.path.splitext(libname)[1]
   if suffix in ('.bc', '.o'):
     if len(inputs) == 1:
-      shutil.copyfile(inputs[0], libname)
+      if inputs[0] != libname:
+        shutil.copyfile(inputs[0], libname)
     else:
       shared.Building.link_to_object(inputs, libname)
   elif suffix == '.a':
@@ -384,7 +385,7 @@ class Library(object):
     objects = []
     cflags = self.get_cflags()
     for src in self.get_files():
-      o = self.in_temp(os.path.basename(src) + '.o')
+      o = self.in_temp(os.path.splitext(os.path.basename(src))[0] + '.o')
       commands.append([shared.PYTHON, self.emcc, '-c', src, '-o', o] + cflags)
       objects.append(o)
     run_build_commands(commands)


### PR DESCRIPTION
This changes the object files in the all he system libraries
from `foo.c.o` to `foo.o`.  Normally this doesn't matter but it makes
the error messages form wasm-ld a little more normal.