### PR TITLE
Code cleanup relating to reading/write dylink section. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3249,10 +3249,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
 
   # after generating the wasm, do some final operations
   if shared.Settings.SIDE_MODULE and not shared.Settings.WASM_BACKEND:
-    wso = shared.WebAssembly.make_shared_library(final, wasm_binary_target, shared.Settings.RUNTIME_LINKED_LIBS)
-    # replace the wasm binary output with the dynamic library.
-    # TODO: use a specific suffix for such files?
-    shutil.move(wso, wasm_binary_target)
+    shared.WebAssembly.make_shared_library(wasm_binary_target, shared.Settings.RUNTIME_LINKED_LIBS)
     if not DEBUG:
       os.unlink(asm_target) # we don't need the asm.js, it can just confuse
 

--- a/emcc.py
+++ b/emcc.py
@@ -3249,7 +3249,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
 
   # after generating the wasm, do some final operations
   if shared.Settings.SIDE_MODULE and not shared.Settings.WASM_BACKEND:
-    shared.WebAssembly.make_shared_library(wasm_binary_target, shared.Settings.RUNTIME_LINKED_LIBS)
+    shared.WebAssembly.add_dylink_section(wasm_binary_target, shared.Settings.RUNTIME_LINKED_LIBS)
     if not DEBUG:
       os.unlink(asm_target) # we don't need the asm.js, it can just confuse
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1014,7 +1014,10 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
 
         static const char *afunc_prev;
 
+        extern "C" {
         EMSCRIPTEN_KEEPALIVE void afunc(const char *s);
+        }
+
         void afunc(const char *s) {
           printf("a: %s (prev: %s)\n", s, afunc_prev);
           afunc_prev = s;
@@ -1032,8 +1035,11 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     create_test_file('libb.cpp', r'''
         #include <emscripten.h>
 
+        extern "C" {
         void afunc(const char *s);
         EMSCRIPTEN_KEEPALIVE void bfunc();
+        }
+
         void bfunc() {
           afunc("b");
         }
@@ -1042,8 +1048,11 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     create_test_file('libc.cpp', r'''
         #include <emscripten.h>
 
+        extern "C" {
         void afunc(const char *s);
         EMSCRIPTEN_KEEPALIVE void cfunc();
+        }
+
         void cfunc() {
           afunc("c");
         }
@@ -1072,10 +1081,12 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     self.set_setting('MAIN_MODULE', 1)
     self.set_setting('RUNTIME_LINKED_LIBS', ['libb' + so, 'libc' + so])
     do_run(r'''
+      extern "C" {
       void bfunc();
       void cfunc();
+      }
 
-      int _main() {
+      int test_main() {
         bfunc();
         cfunc();
         return 0;
@@ -1090,7 +1101,7 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
       #include <dlfcn.h>
       #include <stddef.h>
 
-      int _main() {
+      int test_main() {
         void *bdso, *cdso;
         void (*bfunc)(), (*cfunc)();
 
@@ -1100,9 +1111,9 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
         cdso = dlopen("libc%(so)s", RTLD_GLOBAL);
         assert(cdso != NULL);
 
-        bfunc = (void (*)())dlsym(bdso, "_Z5bfuncv");
+        bfunc = (void (*)())dlsym(bdso, "bfunc");
         assert(bfunc != NULL);
-        cfunc = (void (*)())dlsym(cdso, "_Z5cfuncv");
+        cfunc = (void (*)())dlsym(cdso, "cfunc");
         assert(cfunc != NULL);
 
         bfunc();

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3528,21 +3528,20 @@ window.close = function() {
   # verify that dynamic linking works in all kinds of in-browser environments.
   # don't mix different kinds in a single test.
   def test_dylink_dso_needed_wasm(self):
-    self._test_dylink_dso_needed(1, 0)
+    self._run_dylink_dso_needed(1, 0)
 
   def test_dylink_dso_needed_wasm_inworker(self):
-    self._test_dylink_dso_needed(1, 1)
+    self._run_dylink_dso_needed(1, 1)
 
   def test_dylink_dso_needed_asmjs(self):
-    self._test_dylink_dso_needed(0, 0)
+    self._run_dylink_dso_needed(0, 0)
 
   def test_dylink_dso_needed_asmjs_inworker(self):
-    self._test_dylink_dso_needed(0, 1)
+    self._run_dylink_dso_needed(0, 1)
 
   @no_wasm_backend('https://github.com/emscripten-core/emscripten/issues/8753')
   @requires_sync_compilation
-  def _test_dylink_dso_needed(self, wasm, inworker):
-    # here we reuse runner._test_dylink_dso_needed, but the code is run via browser.
+  def _run_dylink_dso_needed(self, wasm, inworker):
     print('\n# wasm=%d inworker=%d' % (wasm, inworker))
     self.set_setting('WASM', wasm)
     self.emcc_args += ['-O2']
@@ -3565,7 +3564,7 @@ window.close = function() {
         ''')
       src += r'''
         int main() {
-          _main();
+          test_main();
           EM_ASM({
             var expected = %r;
             assert(Module.printed === expected, ['stdout expected:', expected]);
@@ -3578,7 +3577,7 @@ window.close = function() {
         self.emcc_args += ['--proxy-to-worker']
       self.btest(src, '0', args=self.get_emcc_args() + ['--post-js', 'post.js'])
 
-    super(browser, self)._test_dylink_dso_needed(do_run)
+    self._test_dylink_dso_needed(do_run)
 
   @requires_graphics_hardware
   @requires_sync_compilation

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4583,7 +4583,7 @@ res64 - external 64\n''', header='''
   @no_wasm_backend('possible https://github.com/emscripten-core/emscripten/issues/9038')
   def test_dylink_dso_needed(self):
     def do_run(src, expected_output):
-      self.do_run(src + 'int main() { return _main(); }', expected_output)
+      self.do_run(src + 'int main() { return test_main(); }', expected_output)
     self._test_dylink_dso_needed(do_run)
 
   @needs_dlfcn

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3137,7 +3137,7 @@ class WebAssembly(object):
       f.write(orig[8:])
 
   @staticmethod
-  def make_shared_library(wasm_file, needed_dynlibs):
+  def add_dylink_section(wasm_file, needed_dynlibs):
     # a wasm shared library has a special "dylink" section, see tools-conventions repo
     assert not Settings.WASM_BACKEND
     mem_align = Settings.MAX_GLOBAL_ALIGN


### PR DESCRIPTION
I noticed we don't correctly write dylink dependencies into SIDE_MODULES
with the wasm backend.  As part of fixing that I plan to use
make_shared_library with the wasm backend too.

This change cleanups make_shared_library amd some ajecent code prior
to making that change.