### PR TITLE
Don't export malloc and free in STANDALONE_WASM mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1388,8 +1388,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       forced_stdlibs.append('libembind')
 
     if not shared.Settings.MINIMAL_RUNTIME and not shared.Settings.STANDALONE_WASM:
-      # Always need malloc and free to be kept alive and exported, for internal use and other
-      # modules
+      # The normal JS runtime depends on malloc and free so always keep them alive.
+      # MINIMAL_RUNTIME avoids this dependency as does STANDALONE_WASM mode (since it has no
+      # JS runtime at all).
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
 
     if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:

--- a/emcc.py
+++ b/emcc.py
@@ -1387,7 +1387,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.EMBIND:
       forced_stdlibs.append('libembind')
 
-    if not shared.Settings.MINIMAL_RUNTIME:
+    if not shared.Settings.MINIMAL_RUNTIME and not shared.Settings.STANDALONE_WASM:
       # Always need malloc and free to be kept alive and exported, for internal use and other
       # modules
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
@@ -1,3 +1,3 @@
 $_start
+$dlmalloc
 $main
-$malloc

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8363,7 +8363,7 @@ int main() {
     # without argc/argv, no support code for them is emitted, even with lto
     'O3_standalone_narg_flto':
                           ('mem_no_argv.c', ['-O3', '-s', 'STANDALONE_WASM', '-flto'],
-                           [], [], 6309),         # noqa
+                           [], [], 4971),         # noqa
   })
   @no_fastcomp()
   def test_metadce_mem(self, filename, *args):


### PR DESCRIPTION
We normally force export of malloc and free so they can be used by
JS code but this doesn't apply to STANDALONE_WASM mode.

See #11012