### PR TITLE
dlmalloc building optimization

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -61,7 +61,8 @@
 // exceed its size, whether all allocations (stack and static) are
 // of positive size, etc., whether we should throw if we encounter a bad __label__, i.e.,
 // if code flow runs into a fault
-// ASSERTIONS == 2 gives even more runtime checks, that may be very slow.
+// ASSERTIONS == 2 gives even more runtime checks, that may be very slow. That
+// includes internal dlmalloc assertions.
 var ASSERTIONS = 1;
 
 // Whether extra logging should be enabled.

--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -16,6 +16,8 @@
 /* dlmalloc has many checks, calls to abort() increase code size,
    leave them only in debug builds */
 #define ABORT __builtin_unreachable()
+/* allow malloc stats only in debug builds, which brings in stdio code. */
+#define NO_MALLOC_STATS 1
 #endif
 /* XXX Emscripten Tracing API. This defines away the code if tracing is disabled. */
 #include <emscripten/trace.h>
@@ -872,7 +874,9 @@ struct mallinfo mallinfo(void) __attribute__((weak, alias("dlmallinfo")));
 #endif
 int mallopt(int, int) __attribute__((weak, alias("dlmallopt")));
 int malloc_trim(size_t) __attribute__((weak, alias("dlmalloc_trim")));
+#if !NO_MALLOC_STATS
 void malloc_stats(void) __attribute__((weak, alias("dlmalloc_stats")));
+#endif
 size_t malloc_usable_size(const void*) __attribute__((weak, alias("dlmalloc_usable_size")));
 size_t malloc_footprint(void) __attribute__((weak, alias("dlmalloc_footprint")));
 size_t malloc_max_footprint(void) __attribute__((weak, alias("dlmalloc_max_footprint")));

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7087,7 +7087,7 @@ Resolved: "/" => "/"
     run_process([PYTHON, EMCC, 'src.cpp'])
     self.assertContained('double-freed', run_js('a.out.js'))
     # in debug mode, the double-free is caught
-    run_process([PYTHON, EMCC, 'src.cpp', '-g'])
+    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'ASSERTIONS=2'])
     seen_error = False
     out = '?'
     try:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1105,7 +1105,7 @@ class libmalloc(MTLibrary, NoBCLibrary):
   def get_default_variation(cls, **kwargs):
     return super(libmalloc, cls).get_default_variation(
       malloc=shared.Settings.MALLOC,
-      is_debug=shared.Settings.DEBUG_LEVEL >= 3,
+      is_debug=False,  # debug mode must be explicitly opted in
       use_errno=shared.Settings.SUPPORT_ERRNO,
       is_tracing=shared.Settings.EMSCRIPTEN_TRACING,
       use_64bit_ops=shared.Settings.MALLOC == 'emmalloc' and (shared.Settings.WASM == 1 or (shared.Settings.WASM_BACKEND and shared.Settings.WASM2JS == 0)),

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1105,7 +1105,7 @@ class libmalloc(MTLibrary, NoBCLibrary):
   def get_default_variation(cls, **kwargs):
     return super(libmalloc, cls).get_default_variation(
       malloc=shared.Settings.MALLOC,
-      is_debug=False,  # debug mode must be explicitly opted in
+      is_debug=shared.Settings.ASSERTIONS >= 2,
       use_errno=shared.Settings.SUPPORT_ERRNO,
       is_tracing=shared.Settings.EMSCRIPTEN_TRACING,
       use_64bit_ops=shared.Settings.MALLOC == 'emmalloc' and (shared.Settings.WASM == 1 or (shared.Settings.WASM_BACKEND and shared.Settings.WASM2JS == 0)),


### PR DESCRIPTION
1) Only enable debug mode if explicitly requested. For some reason we
always did it when linking with `-g` which seems a little odd. (Maybe it
should be tied to ASSERTIONS, if anything..?) Honestly, the dlmalloc
internal assertions have not really found anything in all the time they've
been on, to my knowledge, so their benefit seems minor, especially
now that we have ASan (which helps in memory corruption situations
which is the only thing I can think dlmalloc assertions would).

2) Only include `malloc_stats()` in debug mode. It brings in stdio code to
print out the status, which is pretty unnecessary. (This explains why
I saw fwrite getting linked in all the time when adding atexit support to
standalone mode.)