### PR TITLE
Set stack pointer during `--post-emscripten` binaryen pass

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3222,6 +3222,11 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
 
   if options.binaryen_passes:
     if '--post-emscripten' in options.binaryen_passes and not shared.Settings.SIDE_MODULE:
+      if shared.Settings.WASM_BACKEND and not shared.Settings.RELOCATABLE:
+        # With the wasm backend stack point value is baked in at link time.  However, emscripten's
+        # JS compiler can allocate more static data which then shifts the stack pointer.
+        # See `makeStaticAlloc` in the JS compiler.
+        options.binaryen_passes += ['--pass-arg=stack-pointer@%d' % shared.Settings.STACK_BASE]
       # the value of the sbrk pointer has been computed by the JS compiler, and we can apply it in the wasm
       # (we can't add this value when we placed post-emscripten in the proper position in the list of
       # passes because that was before the value was computed)

--- a/emscripten.py
+++ b/emscripten.py
@@ -822,6 +822,7 @@ def apply_memory(js):
   logger.debug('global_base: %d stack_base: %d, stack_max: %d, dynamic_base: %d, static bump: %d', memory.global_base, memory.stack_base, memory.stack_max, memory.dynamic_base, memory.static_bump)
 
   shared.Settings.DYNAMIC_BASE = memory.dynamic_base
+  shared.Settings.STACK_BASE = memory.stack_base
 
   return js
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -201,3 +201,6 @@ var USE_CXX = 0;
 // JS symbols. This is used by LLD_REPORT_UNDEFINED to generate a list of all
 // JS library symbols.
 var ONLY_CALC_JS_SYMBOLS = 0;
+
+// Used internally to store the starting value of the stack pointer.
+var STACK_BASE = 0;

--- a/tests/core/test_safe_stack_alloca.c
+++ b/tests/core/test_safe_stack_alloca.c
@@ -2,12 +2,14 @@
 #include <string.h>
 #include <stdlib.h>
 
+#define STACK_SIZE 65536
+
 int f(int *ptr) {
-  for (int i = 0; i < 16384; ++i)
+  for (int i = 0; i < (STACK_SIZE/sizeof(int) + 1); ++i)
     ptr[i] = rand();
-  return ptr[16383];
+  return ptr[0];
 }
 
 int main() {
-  return f((int*) alloca(65536));
+  return f((int*) alloca(STACK_SIZE+1));
 }


### PR DESCRIPTION
With the wasm backend the initial value of the SP global is set by
wasm-ld, but then emscripten adds static data using makeStaticAlloc
which causes the stack and heap to shift upwards in the address space.

However, were never updating the value in the SP baked into the
wasm binary.

With this change we use the `--post-emscripten` binaryen pass to
inject the correct value.