### PR TITLE
When JS library linking fails on a JS function being missing, print o…

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -306,7 +306,11 @@ function JSify(data, functionsOnly) {
         });
       });
       if (VERBOSE) printErr('adding ' + finalName + ' and deps ' + deps + ' : ' + (snippet + '').substr(0, 40));
-      var depsText = (deps ? '\n' + deps.map(function(dep){ addFromLibrary(dep, ident + "__deps: ['" + deps.join("','")+"']")}).filter(function(x) { return x != '' }).join('\n') : '');
+      var identDependents = ident + "__deps: ['" + deps.join("','")+"']";
+      function addDependency(dep) {
+        return addFromLibrary(dep, identDependents + ', referenced by ' + dependent);
+      }
+      var depsText = (deps ? '\n' + deps.map(addDependency).filter(function(x) { return x != '' }).join('\n') : '');
       var contentText;
       if (isFunction) {
         // Emit the body of a JS library function.

--- a/tests/test_chained_js_error_diagnostics.c
+++ b/tests/test_chained_js_error_diagnostics.c
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2011 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+
+void foo(void);
+
+int main() {
+  foo();
+  return 0;
+}
+

--- a/tests/test_chained_js_error_diagnostics.js
+++ b/tests/test_chained_js_error_diagnostics.js
@@ -1,0 +1,7 @@
+mergeInto(LibraryManager.library, {
+  bar__deps: ['nonexistent_function'],
+  bar: function() {},
+
+  foo__deps: ['bar'],
+  foo: function() {},
+});

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10766,3 +10766,9 @@ int main() {
   def test_linker_version(self):
     out = run_process([PYTHON, EMCC, '-Wl,--version'], stdout=PIPE).stdout
     self.assertContained('LLD ', out)
+
+  # Tests that if a JS library function is missing, the linker will print out which function depended on the
+  # missing function.
+  def test_chained_js_error_diagnostics(self):
+    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'test_chained_js_error_diagnostics.c'),'--js-library', path_from_root('tests', 'test_chained_js_error_diagnostics.js')])
+    self.assertContained("error: undefined symbol: nonexistent_function (referenced by bar__deps: ['nonexistent_function'], referenced by foo__deps: ['bar'], referenced by top-level compiled C/C++ code)", err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10770,5 +10770,5 @@ int main() {
   # Tests that if a JS library function is missing, the linker will print out which function depended on the
   # missing function.
   def test_chained_js_error_diagnostics(self):
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'test_chained_js_error_diagnostics.c'),'--js-library', path_from_root('tests', 'test_chained_js_error_diagnostics.js')])
+    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'test_chained_js_error_diagnostics.c'), '--js-library', path_from_root('tests', 'test_chained_js_error_diagnostics.js')])
     self.assertContained("error: undefined symbol: nonexistent_function (referenced by bar__deps: ['nonexistent_function'], referenced by foo__deps: ['bar'], referenced by top-level compiled C/C++ code)", err)


### PR DESCRIPTION
When JS library linking fails on a JS function being missing, print out where a dependency to that function came from.