### PR TITLE
Remove __cxa_thread_atexit_impl

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -706,7 +706,6 @@ LibraryManager.library = {
   atexit: function(){},
   __cxa_atexit: function(){},
   __cxa_thread_atexit: function(){},
-  __cxa_thread_atexit_impl: function(){},
 #else
   atexit__proxy: 'sync',
   atexit__sig: 'iii',
@@ -722,7 +721,6 @@ LibraryManager.library = {
 
   // used in rust, clang when doing thread_local statics
   __cxa_thread_atexit: 'atexit',
-  __cxa_thread_atexit_impl: 'atexit',
 #endif
 
   // TODO: There are currently two abort() functions that get imported to asm module scope: the built-in runtime function abort(),

--- a/tests/core/test_atexit_threads.c
+++ b/tests/core/test_atexit_threads.c
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 
 extern int __cxa_thread_atexit(void (*dtor)(void *), void *obj, void *dso_symbol);
-extern int __cxa_thread_atexit_impl(void (*dtor)(void *), void *obj, void *dso_symbol);
 
 static void cleanA() { printf("A\n"); }
 static void cleanB() { printf("B\n"); }
@@ -19,6 +18,6 @@ int main() {
   atexit(cleanA);
   atexit(cleanB);
   __cxa_thread_atexit(cleanCarg, (void*)100, NULL);
-  __cxa_thread_atexit_impl(cleanCarg, (void*)234, NULL);
+  __cxa_thread_atexit(cleanCarg, (void*)234, NULL);
   return 0;
 }


### PR DESCRIPTION
This is an internal symbol in `libcxxabi/src/cxa_thread_atexit.cpp`.
We compile this file into out libcxxabi and we should be implementing
or testing this function (unless I'm missing something).