### PR TITLE
Don't report errors for undefined symbols that are declared as weak

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -703,6 +703,7 @@ def update_settings_glue(metadata, DEBUG):
 
   shared.Settings.MAX_GLOBAL_ALIGN = metadata['maxGlobalAlign']
   shared.Settings.IMPLEMENTED_FUNCTIONS = metadata['implementedFunctions']
+  shared.Settings.WEAK_DECLARES = metadata.get('weakDeclares', [])
 
   if metadata['asmConsts']:
     # emit the EM_ASM signature-reading helper function only if we have any EM_ASM

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -54,6 +54,8 @@ var NEED_ALL_ASM2WASM_IMPORTS = BINARYEN_TRAP_MODE == 'js';
 // static ctors, even if there is no user main.
 var HAS_MAIN = ('_main' in IMPLEMENTED_FUNCTIONS) || MAIN_MODULE || SIDE_MODULE || STANDALONE_WASM;
 
+WEAK_DECLARES = set(WEAK_DECLARES);
+
 // Mangles the given C/JS side function name to assembly level function name (adds an underscore)
 function mangleCSymbolName(f) {
   return f[0] == '$' ? f.substr(1) : '_' + f;
@@ -172,7 +174,7 @@ function JSify(data, functionsOnly) {
         usedExternPrimitives[ident] = 1;
         return;
       } else if ((!LibraryManager.library.hasOwnProperty(ident) && !LibraryManager.library.hasOwnProperty(ident + '__inline')) || SIDE_MODULE) {
-        if (!(finalName in IMPLEMENTED_FUNCTIONS) && !LINKABLE) {
+        if (!(finalName in IMPLEMENTED_FUNCTIONS) && !(finalName in WEAK_DECLARES) && !LINKABLE) {
           var msg = 'undefined symbol: ' + ident;
           if (ERROR_ON_UNDEFINED_SYMBOLS) {
             error(msg);

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -75,6 +75,8 @@ var MAX_GLOBAL_ALIGN = -1;
 // List of functions implemented in compiled code; received from the backend.
 var IMPLEMENTED_FUNCTIONS = [];
 
+var WEAK_DECLARES = [];
+
 // Name of the file containing the Fetch *.fetch.js, if relevant
 var FETCH_WORKER_FILE = '';
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -75,6 +75,8 @@ var MAX_GLOBAL_ALIGN = -1;
 // List of functions implemented in compiled code; received from the backend.
 var IMPLEMENTED_FUNCTIONS = [];
 
+// List of weakly undefined externals; received from the backend
+// fastcomp-only
 var WEAK_DECLARES = [];
 
 // Name of the file containing the Fetch *.fetch.js, if relevant

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8978,7 +8978,7 @@ end
     self.do_other_test(os.path.join('other', 'fflush_fs_exit'), emcc_args=['-s', 'FORCE_FILESYSTEM=1', '-s', 'EXIT_RUNTIME=1'])
 
   def test_extern_weak(self):
-    self.do_other_test(os.path.join('other', 'extern_weak'), emcc_args=['-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
+    self.do_other_test(os.path.join('other', 'extern_weak'))
     if not self.is_wasm_backend(): # TODO: wasm backend main module
       self.do_other_test(os.path.join('other', 'extern_weak'), emcc_args=['-s', 'MAIN_MODULE=1', '-DLINKABLE'])
 


### PR DESCRIPTION
This is a fastcomp only issue.  Right now if you declare a function
as weak and its undefined this symbols ends being reported as
undefined at link time.

This is why `test_extern_weak` currently has to set
`ERROR_ON_UNDEFINED_SYMBOLS=0`, as least for fastcomp.

This change allows fastcomp to emit a separate list of weakly
undefined externals.

See: https://github.com/emscripten-core/emscripten-fastcomp/pull/268