### PR TITLE
Fix strict js mode with wasm syncronous compilation

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -264,6 +264,10 @@ def use_source_map(options):
 
 
 def will_metadce(options):
+  # The metadce JS parsing code does not currently support the JS that gets generated
+  # when assertions are enabled.
+  if shared.Settings.ASSERTIONS:
+    return False
   return shared.Settings.OPT_LEVEL >= 3 or shared.Settings.SHRINK_LEVEL >= 1
 
 

--- a/site/source/docs/getting_started/FAQ.rst
+++ b/site/source/docs/getting_started/FAQ.rst
@@ -216,7 +216,7 @@ It is possible to allow access to local file system for code running in *node.js
 How can I tell when the page is fully loaded and it is safe to call compiled functions?
 =======================================================================================
 
-(You may need this answer if you see an error saying something like ``you need to wait for the runtime to be ready (e.g. wait for main() to be called)``, which is a check enabled in ``ASSERTIONS`` builds.)
+(You may need this answer if you see an error saying something like ``native function `x` called before runtime initialization``, which is a check enabled in ``ASSERTIONS`` builds.)
 
 Calling a compiled function before a page has fully loaded can result in an error, if the function relies on files that may not be present (for example the :ref:`.mem <emcc-memory-init-file>` file and :ref:`preloaded <emcc-preload-file>` files are loaded asynchronously, and therefore if you just place some JS that calls compiled code in a ``--post-js``, that code will be called synchronously at the end of the combined JS file, potentially before the asynchronous event happens, which is bad).
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -795,7 +795,7 @@ var cyberDWARFFile = '{{{ BUNDLED_CD_DEBUG_FILE }}}';
 #include "URIUtils.js"
 
 #if ASSERTIONS
-function createExportWrapper(name, asm) {
+function createExportWrapper(name, fixedasm) {
   return function() {
     var displayName = name;
 #if !WASM_BACKEND
@@ -803,12 +803,15 @@ function createExportWrapper(name, asm) {
       displayName = name.substr(1);
     }
 #endif
-    if (!asm) {
+    var asm = fixedasm;
+    if (!fixedasm) {
       asm = Module['asm'];
     }
-    assert(asm[name], 'exported native function `' + displayName + '` not found');
     assert(runtimeInitialized, 'native function `' + displayName + '` called before runtime initialization');
     assert(!runtimeExited, 'native function `' + displayName + '` called after runtime exit (use NO_EXIT_RUNTIME to keep it alive after main() exits)');
+    if (!asm[name]) {
+      assert(asm[name], 'exported native function `' + displayName + '` not found');
+    }
     return asm[name].apply(null, arguments);
   };
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -794,6 +794,26 @@ var cyberDWARFFile = '{{{ BUNDLED_CD_DEBUG_FILE }}}';
 
 #include "URIUtils.js"
 
+#if ASSERTIONS
+function createExportWrapper(name, asm) {
+  return function() {
+    var displayName = name;
+#if !WASM_BACKEND
+    if (name[0] == '_') {
+      displayName = name.substr(1);
+    }
+#endif
+    if (!asm) {
+      asm = Module['asm'];
+    }
+    assert(asm[name], 'exported native function `' + displayName + '` not found');
+    assert(runtimeInitialized, 'native function `' + displayName + '` called before runtime initialization');
+    assert(!runtimeExited, 'native function `' + displayName + '` called after runtime exit (use NO_EXIT_RUNTIME to keep it alive after main() exits)');
+    return asm[name].apply(null, arguments);
+  };
+}
+#endif
+
 #if WASM
 var wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
 if (!isDataURI(wasmBinaryFile)) {

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -559,8 +559,17 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
   def in_dir(self, *pathelems):
     return os.path.join(self.get_dir(), *pathelems)
 
-  def get_stdout_path(self):
-    return os.path.join(self.get_dir(), 'stdout')
+  def add_pre_run(self, code):
+    create_test_file('prerun.js', 'Module.preRun = function() { %s }' % code)
+    self.emcc_args += ['--pre-js', 'prerun.js']
+
+  def add_post_run(self, code):
+    create_test_file('postrun.js', 'Module.postRun = function() { %s }' % code)
+    self.emcc_args += ['--pre-js', 'postrun.js']
+
+  def add_on_exit(self, code):
+    create_test_file('onexit.js', 'Module.onExit = function() { %s }' % code)
+    self.emcc_args += ['--pre-js', 'onexit.js']
 
   def prep_ll_file(self, output_file, input_file, force_recompile=False, build_ll_hook=None):
     # force_recompile = force_recompile or os.path.getsize(filename + '.ll') > 50000

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2378,7 +2378,7 @@ void *getBindBuffer() {
       ('runtime_misuse.cpp', [], 600),
       ('runtime_misuse_2.cpp', ['--pre-js', 'pre_runtime.js'], 601) # 601, because no main means we *do* run another call after exit()
     ]:
-      for mode in [['-s', 'WASM=0'], ['-s', 'WASM=1']]:
+      for mode in [[], ['-s', 'WASM=0']]:
         if 'WASM=0' in mode and self.is_wasm_backend():
           continue
         print('\n', filename, extra_args, mode)
@@ -2387,10 +2387,10 @@ void *getBindBuffer() {
         self.btest(filename, expected='600', args=['--post-js', 'post.js', '--memory-init-file', '1', '-s', 'EXIT_RUNTIME=1'] + extra_args + mode)
         print('sync startup, call too late')
         create_test_file('post.js', post_prep + 'Module.postRun.push(function() { ' + post_test + ' });' + post_hook)
-        self.btest(filename, expected=str(second_code), args=['--post-js', 'post.js', '--memory-init-file', '0', '-s', 'EXIT_RUNTIME=1'] + extra_args + mode)
+        self.btest(filename, expected=str(second_code), args=['--post-js', 'post.js', '-s', 'EXIT_RUNTIME=1'] + extra_args + mode)
         print('sync, runtime still alive, so all good')
         create_test_file('post.js', post_prep + 'expected_ok = true; Module.postRun.push(function() { ' + post_test + ' });' + post_hook)
-        self.btest(filename, expected='606', args=['--post-js', 'post.js', '--memory-init-file', '0'] + extra_args + mode)
+        self.btest(filename, expected='606', args=['--post-js', 'post.js'] + extra_args + mode)
 
   def test_cwrap_early(self):
     self.btest(os.path.join('browser', 'cwrap_early.cpp'), args=['-O2', '-s', 'ASSERTIONS=1', '--pre-js', path_from_root('tests', 'browser', 'cwrap_early.js'), '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["cwrap"]'], expected='0')


### PR DESCRIPTION
The change modifies the way we inject assertion check into native functions.  Rather than
auto-generate them and/or modify that actual asm object we now instead create a wrapper
object that wraps all of the native entry points.  

Fixes: #11045