### PR TITLE
Allow data addresses (named globals) to be exported from native code

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1840,7 +1840,14 @@ Module['%(full)s'] = function() {
 
 def create_named_globals(metadata):
   if not shared.Settings.RELOCATABLE:
-    return ''.join(["Module['_%s'] = %s;\n" % (k, v) for k, v in metadata['namedGlobals'].items()])
+    named_globals = []
+    for k, v in metadata['namedGlobals'].items():
+      # We keep __data_end alive internally so that wasm-emscripten-finalize knows where the
+      # static data region ends.  Don't export this to JS like other user-exported global
+      # address.
+      if k not in ['__data_end']:
+        named_globals.append("Module['_%s'] = %s;" % (k, v))
+    return '\n'.join(named_globals)
 
   named_globals = '''
 var NAMED_GLOBALS = {

--- a/emscripten.py
+++ b/emscripten.py
@@ -1840,7 +1840,7 @@ Module['%(full)s'] = function() {
 
 def create_named_globals(metadata):
   if not shared.Settings.RELOCATABLE:
-    return ''
+    return ''.join(["Module['_%s'] = %s;\n" % (k, v) for k, v in metadata['namedGlobals'].items()])
 
   named_globals = '''
 var NAMED_GLOBALS = {
@@ -1865,7 +1865,7 @@ for (var named in NAMED_GLOBALS) {
   })(named);
 }
 '''
-  named_globals += ''.join(["Module['%s'] = Module['%s']\n" % (k, v) for k, v in metadata['aliases'].items()])
+  named_globals += ''.join(["Module['%s'] = Module['%s'];\n" % (k, v) for k, v in metadata['aliases'].items()])
   return named_globals
 
 

--- a/tests/other/metadce/minimal.c
+++ b/tests/other/metadce/minimal.c
@@ -3,3 +3,5 @@
 EMSCRIPTEN_KEEPALIVE int add(int x, int y) {
   return x + y;
 }
+
+EMSCRIPTEN_KEEPALIVE int global_val = 0;

--- a/tests/other/metadce/minimal.exports
+++ b/tests/other/metadce/minimal.exports
@@ -6,6 +6,7 @@ __wasm_call_ctors
 add
 fflush
 free
+global_val
 malloc
 stackAlloc
 stackRestore

--- a/tests/other/metadce/minimal_O1.exports
+++ b/tests/other/metadce/minimal_O1.exports
@@ -4,6 +4,7 @@ __growWasmMemory
 __wasm_call_ctors
 add
 free
+global_val
 malloc
 stackAlloc
 stackRestore

--- a/tests/other/metadce/minimal_O2.exports
+++ b/tests/other/metadce/minimal_O2.exports
@@ -4,6 +4,7 @@ __growWasmMemory
 __wasm_call_ctors
 add
 free
+global_val
 malloc
 stackAlloc
 stackRestore

--- a/tests/other/test_export_global_address.c
+++ b/tests/other/test_export_global_address.c
@@ -1,0 +1,22 @@
+#include <emscripten.h>
+#include <assert.h>
+#include <stdio.h>
+
+EMSCRIPTEN_KEEPALIVE int g_foo = 4;
+
+EM_JS(int*, get_foo_from_js, (void), {
+  assert(Module['_g_foo'] !== undefined, "g_foo not exported to JS");
+  return Module['_g_foo'];
+});
+
+int main() {
+  printf("get_foo_from_js: %d\n", *get_foo_from_js());
+  printf("g_foo: %d\n", g_foo);
+  if (get_foo_from_js() != &g_foo) {
+    printf("addresses failed to match\n");
+    printf("js: %p\n", get_foo_from_js());
+    printf("native: %p\n", &g_foo);
+    return 1;
+  }
+  return 0;
+}

--- a/tests/other/test_export_global_address.out
+++ b/tests/other/test_export_global_address.out
@@ -1,0 +1,2 @@
+get_foo_from_js: 4
+g_foo: 4

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10730,7 +10730,6 @@ int main() {
     self.emcc_args.append('foo.o')
     self.do_run_from_file(src, output)
 
-  @no_fastcomp('https://github.com/emscripten-core/emscripten-fastcomp/pull/269')
   def test_export_global_address(self):
     src = path_from_root('tests', 'other', 'test_export_global_address.c')
     output = path_from_root('tests', 'other', 'test_export_global_address.out')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10729,3 +10729,9 @@ int main() {
     output = path_from_root('tests', 'other', 'test_asm.out')
     self.emcc_args.append('foo.o')
     self.do_run_from_file(src, output)
+
+  @no_fastcomp('https://github.com/emscripten-core/emscripten-fastcomp/pull/269')
+  def test_export_global_address(self):
+    src = path_from_root('tests', 'other', 'test_export_global_address.c')
+    output = path_from_root('tests', 'other', 'test_export_global_address.out')
+    self.do_run_from_file(src, output)


### PR DESCRIPTION
This change depends on the following fastcomp change:
https://github.com/emscripten-core/emscripten-fastcomp/pull/269

This will allow us to directly exports address to JS and avoid accessor functions
in native code for this purpose.