### PR TITLE
Remove handling of special symbols in Building.link_lld. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1393,6 +1393,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # JS runtime at all).
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
 
+    if shared.Settings.WASM_BACKEND:
+      # We need to preserve the __data_end symbol so that wasm-emscripten-finalize can determine
+      # the STATIC_BUMP value.
+      shared.Settings.EXPORTED_FUNCTIONS += ['___data_end']
+      if not shared.Settings.STANDALONE_WASM:
+        # in standalone mode, crt1 will call the constructors from inside the wasm
+        shared.Settings.EXPORTED_FUNCTIONS.append('___wasm_call_ctors')
+
     if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
       exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1563,12 +1563,6 @@ class Building(object):
     if Settings.LINKABLE:
       cmd.append('--export-all')
     else:
-      # in standalone mode, crt1 will call the constructors from inside the wasm
-      if not Settings.STANDALONE_WASM:
-        cmd += ['--export', '__wasm_call_ctors']
-
-      cmd += ['--export', '__data_end']
-
       c_exports = [e for e in Settings.EXPORTED_FUNCTIONS if is_c_symbol(e)]
       # Strip the leading underscores
       c_exports = [demangle_c_symbol_name(e) for e in c_exports]


### PR DESCRIPTION
Its cleaner to add these to EXPORTED_FUNCTION like other symbols that
emscripten decides its needs to keep alive.

Also, add some docs on why we keep __data_end alive.