### PR TITLE
Remove BINARYEN_PASSES setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -36,6 +36,9 @@ Current Trunk
   compiler options.
 - Allow spaces in a path to Python interpreter when running emscripten from Unix
   shell (#11005).
+- Remove `BINARYEN_PASSES` settings.  We still have `BINARYEN_EXTRA_PASSES`, but
+  completely overriding the set of passes from the command line didn't make much
+  sense.
 
 v1.39.13: 04/17/2020
 --------------------

--- a/emcc.py
+++ b/emcc.py
@@ -1819,104 +1819,98 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # wasm backend output can benefit from the binaryen optimizer (in asm2wasm,
         # we run the optimizer during asm2wasm itself). use it, if not overridden.
 
-        # BINARYEN_PASSES and BINARYEN_EXTRA_PASSES are comma-separated, and we support both '-'-prefixed and unprefixed pass names
-        def parse_passes(string):
-          passes = string.split(',')
-          passes = [('--' + p) if p[0] != '-' else p for p in passes if p]
-          return passes
-
         passes = []
-        if 'BINARYEN_PASSES' in settings_key_changes:
-          if shared.Settings.BINARYEN_PASSES:
-            passes += parse_passes(shared.Settings.BINARYEN_PASSES)
-        else:
-          # safe heap must run before post-emscripten, so post-emscripten can apply the sbrk ptr
-          if shared.Settings.SAFE_HEAP:
-            passes += ['--safe-heap']
-          passes += ['--post-emscripten']
-          # always inline __original_main into main, as otherwise it makes debugging confusing,
-          # and doing so is never bad for code size
-          # FIXME however, don't do it with DWARF for now, as inlining is not
-          #       fully handled in DWARF updating yet
-          if shared.Settings.DEBUG_LEVEL < 3:
-            passes += ['--inline-main']
-          if not shared.Settings.EXIT_RUNTIME:
-            passes += ['--no-exit-runtime']
-          if shared.Settings.OPT_LEVEL > 0 or shared.Settings.SHRINK_LEVEL > 0:
-            passes += [shared.Building.opt_level_to_str(shared.Settings.OPT_LEVEL, shared.Settings.SHRINK_LEVEL)]
-          elif shared.Settings.STANDALONE_WASM:
-            # even if not optimizing, make an effort to remove all unused imports and
-            # exports, to make the wasm as standalone as possible
-            passes += ['--remove-unused-module-elements']
-          if shared.Settings.GLOBAL_BASE >= 1024: # hardcoded value in the binaryen pass
-            passes += ['--low-memory-unused']
-          if shared.Settings.DEBUG_LEVEL < 3:
-            passes += ['--strip-debug']
-          if not shared.Settings.EMIT_PRODUCERS_SECTION:
-            passes += ['--strip-producers']
-          if shared.Settings.AUTODEBUG:
-            # adding '--flatten' here may make these even more effective
-            passes += ['--instrument-locals']
-            passes += ['--log-execution']
-            passes += ['--instrument-memory']
-            passes += ['--legalize-js-interface']
-          if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
-            # note that this pass must run before asyncify, as if it runs afterwards we only
-            # generate the  byn$fpcast_emu  functions after asyncify runs, and so we wouldn't
-            # be able to whitelist them etc.
-            passes += ['--fpcast-emu']
-          if shared.Settings.ASYNCIFY:
-            # TODO: allow whitelist as in asyncify
-            passes += ['--asyncify']
-            if shared.Settings.ASSERTIONS:
-              passes += ['--pass-arg=asyncify-asserts']
-            if shared.Settings.ASYNCIFY_IGNORE_INDIRECT:
-              passes += ['--pass-arg=asyncify-ignore-indirect']
-            else:
-              # if we are not ignoring indirect calls, then we must treat invoke_* as if
-              # they are indirect calls, since that is what they do - we can't see their
-              # targets statically.
-              shared.Settings.ASYNCIFY_IMPORTS += ['invoke_*']
-            # with pthreads we may call main through the __call_main mechanism, which can
-            # therefore reach anything in the program, so mark it as possibly causing a
-            # sleep (the asyncify analysis doesn't look through JS, just wasm, so it can't
-            # see what it itself calls)
-            if shared.Settings.USE_PTHREADS:
-              shared.Settings.ASYNCIFY_IMPORTS += ['__call_main']
-            # add the default imports
-            shared.Settings.ASYNCIFY_IMPORTS += DEFAULT_ASYNCIFY_IMPORTS
+        # safe heap must run before post-emscripten, so post-emscripten can apply the sbrk ptr
+        if shared.Settings.SAFE_HEAP:
+          passes += ['--safe-heap']
+        passes += ['--post-emscripten']
+        # always inline __original_main into main, as otherwise it makes debugging confusing,
+        # and doing so is never bad for code size
+        # FIXME however, don't do it with DWARF for now, as inlining is not
+        #       fully handled in DWARF updating yet
+        if shared.Settings.DEBUG_LEVEL < 3:
+          passes += ['--inline-main']
+        if not shared.Settings.EXIT_RUNTIME:
+          passes += ['--no-exit-runtime']
+        if shared.Settings.OPT_LEVEL > 0 or shared.Settings.SHRINK_LEVEL > 0:
+          passes += [shared.Building.opt_level_to_str(shared.Settings.OPT_LEVEL, shared.Settings.SHRINK_LEVEL)]
+        elif shared.Settings.STANDALONE_WASM:
+          # even if not optimizing, make an effort to remove all unused imports and
+          # exports, to make the wasm as standalone as possible
+          passes += ['--remove-unused-module-elements']
+        if shared.Settings.GLOBAL_BASE >= 1024: # hardcoded value in the binaryen pass
+          passes += ['--low-memory-unused']
+        if shared.Settings.DEBUG_LEVEL < 3:
+          passes += ['--strip-debug']
+        if not shared.Settings.EMIT_PRODUCERS_SECTION:
+          passes += ['--strip-producers']
+        if shared.Settings.AUTODEBUG:
+          # adding '--flatten' here may make these even more effective
+          passes += ['--instrument-locals']
+          passes += ['--log-execution']
+          passes += ['--instrument-memory']
+          passes += ['--legalize-js-interface']
+        if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+          # note that this pass must run before asyncify, as if it runs afterwards we only
+          # generate the  byn$fpcast_emu  functions after asyncify runs, and so we wouldn't
+          # be able to whitelist them etc.
+          passes += ['--fpcast-emu']
+        if shared.Settings.ASYNCIFY:
+          # TODO: allow whitelist as in asyncify
+          passes += ['--asyncify']
+          if shared.Settings.ASSERTIONS:
+            passes += ['--pass-arg=asyncify-asserts']
+          if shared.Settings.ASYNCIFY_IGNORE_INDIRECT:
+            passes += ['--pass-arg=asyncify-ignore-indirect']
+          else:
+            # if we are not ignoring indirect calls, then we must treat invoke_* as if
+            # they are indirect calls, since that is what they do - we can't see their
+            # targets statically.
+            shared.Settings.ASYNCIFY_IMPORTS += ['invoke_*']
+          # with pthreads we may call main through the __call_main mechanism, which can
+          # therefore reach anything in the program, so mark it as possibly causing a
+          # sleep (the asyncify analysis doesn't look through JS, just wasm, so it can't
+          # see what it itself calls)
+          if shared.Settings.USE_PTHREADS:
+            shared.Settings.ASYNCIFY_IMPORTS += ['__call_main']
+          # add the default imports
+          shared.Settings.ASYNCIFY_IMPORTS += DEFAULT_ASYNCIFY_IMPORTS
 
-            # return the full import name, including module. The name may
-            # already have a module prefix; if not, we assume it is "env".
-            def get_full_import_name(name):
-              if '.' in name:
-                return name
-              return 'env.' + name
+          # return the full import name, including module. The name may
+          # already have a module prefix; if not, we assume it is "env".
+          def get_full_import_name(name):
+            if '.' in name:
+              return name
+            return 'env.' + name
 
-            shared.Settings.ASYNCIFY_IMPORTS = [get_full_import_name(i) for i in shared.Settings.ASYNCIFY_IMPORTS]
+          shared.Settings.ASYNCIFY_IMPORTS = [get_full_import_name(i) for i in shared.Settings.ASYNCIFY_IMPORTS]
 
-            passes += ['--pass-arg=asyncify-imports@%s' % ','.join(shared.Settings.ASYNCIFY_IMPORTS)]
+          passes += ['--pass-arg=asyncify-imports@%s' % ','.join(shared.Settings.ASYNCIFY_IMPORTS)]
 
-            # shell escaping can be confusing; try to emit useful warnings
-            def check_human_readable_list(items):
-              for item in items:
-                if item.count('(') != item.count(')'):
-                  logger.warning('''emcc: ASYNCIFY list contains an item without balanced parentheses ("(", ")"):''')
-                  logger.warning('''   ''' + item)
-                  logger.warning('''This may indicate improper escaping that led to splitting inside your names.''')
-                  logger.warning('''Try to quote the entire argument, like this: -s 'ASYNCIFY_WHITELIST=["foo(int, char)", "bar"]' ''')
-                  break
+          # shell escaping can be confusing; try to emit useful warnings
+          def check_human_readable_list(items):
+            for item in items:
+              if item.count('(') != item.count(')'):
+                logger.warning('''emcc: ASYNCIFY list contains an item without balanced parentheses ("(", ")"):''')
+                logger.warning('''   ''' + item)
+                logger.warning('''This may indicate improper escaping that led to splitting inside your names.''')
+                logger.warning('''Try to quote the entire argument, like this: -s 'ASYNCIFY_WHITELIST=["foo(int, char)", "bar"]' ''')
+                break
 
-            if shared.Settings.ASYNCIFY_BLACKLIST:
-              check_human_readable_list(shared.Settings.ASYNCIFY_BLACKLIST)
-              passes += ['--pass-arg=asyncify-blacklist@%s' % ','.join(shared.Settings.ASYNCIFY_BLACKLIST)]
-            if shared.Settings.ASYNCIFY_WHITELIST:
-              check_human_readable_list(shared.Settings.ASYNCIFY_WHITELIST)
-              passes += ['--pass-arg=asyncify-whitelist@%s' % ','.join(shared.Settings.ASYNCIFY_WHITELIST)]
-          if shared.Settings.BINARYEN_IGNORE_IMPLICIT_TRAPS:
-            passes += ['--ignore-implicit-traps']
+          if shared.Settings.ASYNCIFY_BLACKLIST:
+            check_human_readable_list(shared.Settings.ASYNCIFY_BLACKLIST)
+            passes += ['--pass-arg=asyncify-blacklist@%s' % ','.join(shared.Settings.ASYNCIFY_BLACKLIST)]
+          if shared.Settings.ASYNCIFY_WHITELIST:
+            check_human_readable_list(shared.Settings.ASYNCIFY_WHITELIST)
+            passes += ['--pass-arg=asyncify-whitelist@%s' % ','.join(shared.Settings.ASYNCIFY_WHITELIST)]
+        if shared.Settings.BINARYEN_IGNORE_IMPLICIT_TRAPS:
+          passes += ['--ignore-implicit-traps']
+
         if shared.Settings.BINARYEN_EXTRA_PASSES:
-          passes += parse_passes(shared.Settings.BINARYEN_EXTRA_PASSES)
+          # BINARYEN_EXTRA_PASSES is comma-separated, and we support both '-'-prefixed and
+          # unprefixed pass names
+          extras = shared.Settings.BINARYEN_EXTRA_PASSES.split(',')
+          passes += [('--' + p) if p[0] != '-' else p for p in extras if p]
         options.binaryen_passes = passes
 
       # run safe-heap as a binaryen pass in fastcomp wasm, while in the wasm backend we
@@ -3225,6 +3219,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       else:
         os.unlink(memfile)
     log_time('asm2wasm')
+
   if options.binaryen_passes:
     if '--post-emscripten' in options.binaryen_passes and not shared.Settings.SIDE_MODULE:
       # the value of the sbrk pointer has been computed by the JS compiler, and we can apply it in the wasm
@@ -3241,6 +3236,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
                                  wasm_binary_target,
                                  args=args,
                                  debug=intermediate_debug_info)
+
   if shared.Settings.BINARYEN_SCRIPTS:
     binaryen_scripts = os.path.join(shared.BINARYEN_ROOT, 'scripts')
     script_env = os.environ.copy()

--- a/src/settings.js
+++ b/src/settings.js
@@ -1294,22 +1294,9 @@ var BINARYEN_IGNORE_IMPLICIT_TRAPS = 0;
 // [fastcomp-only]
 var BINARYEN_TRAP_MODE = "allow";
 
-// A comma-separated list of passes to run in the binaryen optimizer, for
-// example, "dce,precompute,vacuum".  When set, this overrides/replaces
-// the default passes we would normally run.
-// Note that you can put any binaryen wasm-opt flag here, not just
-// passes. The key thing is that these flags are sent to the main wasm-opt
-// invocation to optimize the wasm binary, which is when we run several
-// important passes. We may also run wasm-opt for various other reasons,
-// like as part of metadce, and these flags are not passed at those times,
-// so they are a bunch of passes (+ other flags) for that one main
-// invocation.
-var BINARYEN_PASSES = "";
-
-// A comma-separated list of passes to run in the binaryen optimizer, like
-// BINARYEN_PASSES, but that is in addition to any default ones. That is,
-// setting this does not override/replace the default passes, and it is
-// appended at the end of the list of passes.
+// A comma-separated list of extra passes to run in the binaryen optimizer,
+// Setting this does not override/replace the default passes. It is appended at
+// the end of the list of passes.
 var BINARYEN_EXTRA_PASSES = "";
 
 // Whether to compile the wasm asynchronously, which is more efficient and does
@@ -1848,4 +1835,5 @@ var LEGACY_SETTINGS = [
   ['TOTAL_MEMORY', 'INITIAL_MEMORY'],
   ['WASM_MEM_MAX', 'MAXIMUM_MEMORY'],
   ['BINARYEN_MEM_MAX', 'MAXIMUM_MEMORY'],
+  ['BINARYEN_PASSES', [""], 'Use BINARYEN_EXTRA_PASSES to add additional passes'],
 ];

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -127,7 +127,7 @@ while 1:
           js_args += ['--js-opts', '1']
       if random.random() < 0.5:
         # pick random passes
-        BINARYEN_PASSES = [
+        BINARYEN_EXTRA_PASSES = [
           "code-pushing",
           "duplicate-function-elimination",
           "dce",
@@ -148,10 +148,10 @@ while 1:
         ]
         passes = []
         while 1:
-          passes.append(random.choice(BINARYEN_PASSES))
+          passes.append(random.choice(BINARYEN_EXTRA_PASSES))
           if random.random() < 0.1:
             break
-        js_args += ['-s', 'BINARYEN_PASSES="' + ','.join(passes) + '"']
+        js_args += ['-s', 'BINARYEN_EXTRA_PASSES="' + ','.join(passes) + '"']
     if random.random() < 0.5:
       js_args += ['-s', 'ALLOW_MEMORY_GROWTH=1']
     if random.random() < 0.5 and 'ALLOW_MEMORY_GROWTH=1' not in js_args and 'BINARYEN=1' not in js_args:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8129,23 +8129,18 @@ int main() {
     # sizes must be different, as the flag has an impact
     self.assertEqual(len(set(sizes)), 2)
 
-  @no_fastcomp('BINARYEN_PASSES is used to optimize only in the wasm backend (fastcomp uses flags to asm2wasm)')
-  def test_binaryen_passes(self):
+  @no_fastcomp('BINARYEN_EXTRA_PASSES is used to optimize only in the wasm backend (fastcomp uses flags to asm2wasm)')
+  def test_binaryen_passes_extra(self):
     def build(args=[]):
-      return run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1', '-O3'] + args, stdout=PIPE).stdout
+      return run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-O3'] + args, stdout=PIPE).stdout
 
     build()
     base_size = os.path.getsize('a.out.wasm')
-    build(['-s', 'BINARYEN_PASSES="--metrics"'])
-    replace_size = os.path.getsize('a.out.wasm')
-    # replacing the default -O3 etc. increases code size
-    self.assertLess(base_size, replace_size)
     out = build(['-s', 'BINARYEN_EXTRA_PASSES="--metrics"'])
-    add_size = os.path.getsize('a.out.wasm')
-    # adding --metrics does not affect code size
-    self.assertEqual(base_size, add_size)
     # and --metrics output appears
     self.assertContained('[funcs]', out)
+    # adding --metrics should not affect code size
+    self.assertEqual(base_size, os.path.getsize('a.out.wasm'))
 
   def assertFileContents(self, filename, contents):
     contents = contents.replace('\r', '')


### PR DESCRIPTION
We still have `BINARYEN_EXTRA_PASSES`, but completely overriding the set
of passes from the command line doesn't make much