### PR TITLE
Disable SIMD tests for opcode renumbering

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6003,6 +6003,7 @@ return malloc(size);
     self.do_run_in_out_file_test('tests', 'core', 'test_relocatable_void_function')
 
   @wasm_simd
+  @unittest.skip("Disabled to allow SIMD opcode renumbering to roll")
   def test_wasm_builtin_simd(self, js_engines):
     # Improves test readability
     self.emcc_args.append('-Wno-c++11-narrowing')
@@ -6013,6 +6014,7 @@ return malloc(size);
                self.get_dir(), os.path.join(self.get_dir(), 'src.cpp'))
 
   @wasm_simd
+  @unittest.skip("Disabled to allow SIMD opcode renumbering to roll")
   def test_wasm_intrinsics_simd(self, js_engines):
     def run():
       self.do_run(

--- a/tests/test_wasm_builtin_simd.cpp
+++ b/tests/test_wasm_builtin_simd.cpp
@@ -545,25 +545,11 @@ i32x4 TESTFN i32x4_trunc_s_f32x4_sat(f32x4 vec) {
 i32x4 TESTFN i32x4_trunc_u_f32x4_sat(f32x4 vec) {
   return __builtin_wasm_trunc_saturate_u_i32x4_f32x4(vec);
 }
-#ifdef __wasm_unimplemented_simd128__
-i64x2 TESTFN i64x2_trunc_s_f64x2_sat(f64x2 vec) {
-  return __builtin_wasm_trunc_saturate_s_i64x2_f64x2(vec);
-}
-i64x2 TESTFN i64x2_trunc_u_f64x2_sat(f64x2 vec) {
-  return __builtin_wasm_trunc_saturate_u_i64x2_f64x2(vec);
-}
-#endif // __wasm_unimplemented_simd128__
 f32x4 TESTFN f32x4_convert_s_i32x4(i32x4 vec) {
   return __builtin_convertvector(vec, f32x4);
 }
 f32x4 TESTFN f32x4_convert_u_i32x4(i32x4 vec) {
   return __builtin_convertvector((u32x4)vec, f32x4);
-}
-f64x2 TESTFN f64x2_convert_s_i64x2(i64x2 vec) {
-  return __builtin_convertvector(vec, f64x2);
-}
-f64x2 TESTFN f64x2_convert_u_i64x2(i64x2 vec) {
-  return __builtin_convertvector((u64x2)vec, f64x2);
 }
 i8x16 TESTFN i8x16_narrow_i16x8_s(i16x8 a, i16x8 b) {
   return __builtin_wasm_narrow_s_i8x16_i16x8(a, b);
@@ -1357,20 +1343,8 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
   // conversions
   expect_vec(i32x4_trunc_s_f32x4_sat((f32x4){42, NAN, INFINITY, -INFINITY}), ((i32x4){42, 0, 2147483647, -2147483648ll}));
   expect_vec(i32x4_trunc_u_f32x4_sat((f32x4){42, NAN, INFINITY, -INFINITY}), ((i32x4){42, 0, 4294967295ull, 0}));
-#ifdef __wasm_unimplemented_simd128__
-  expect_vec(i64x2_trunc_s_f64x2_sat((f64x2){42, NAN}), ((i64x2){42, 0}));
-  expect_vec(i64x2_trunc_s_f64x2_sat((f64x2){INFINITY, -INFINITY}), ((i64x2){9223372036854775807ll, -9223372036854775807ll - 1}));
-  expect_vec(i64x2_trunc_u_f64x2_sat((f64x2){42, NAN}), ((i64x2){42, 0}));
-  expect_vec(i64x2_trunc_u_f64x2_sat((f64x2){INFINITY, -INFINITY}), ((i64x2){18446744073709551615ull, 0}));
-#endif // __wasm_unimplemented_simd128__
   expect_vec(f32x4_convert_s_i32x4((i32x4){0, -1, 2147483647, -2147483647 - 1}), ((f32x4){0, -1, 2147483648., -2147483648.}));
   expect_vec(f32x4_convert_u_i32x4((i32x4){0, -1, 2147483647, -2147483647 - 1}), ((f32x4){0, 4294967296., 2147483648., 2147483648.}));
-#ifdef __wasm_unimplemented_simd128__
-  expect_vec(f64x2_convert_s_i64x2((i64x2){0, -1}), ((f64x2){0, -1}));
-  expect_vec(f64x2_convert_s_i64x2((i64x2){9223372036854775807, -9223372036854775807 - 1}), ((f64x2){9223372036854775807., -9223372036854775808.}));
-  expect_vec(f64x2_convert_u_i64x2((i64x2){0, -1}), ((f64x2){0, 18446744073709551616.}));
-  expect_vec(f64x2_convert_u_i64x2((i64x2){9223372036854775807 , -9223372036854775808.}), ((f64x2){9223372036854775807., 9223372036854775808.}));
-#endif // __wasm_unimplemented_simd128__
   expect_vec(
     i8x16_narrow_i16x8_s(
       (i16x8){129, 127, -32767, 32767, -32768, -1, 1, 0},

--- a/tests/test_wasm_intrinsics_simd.c
+++ b/tests/test_wasm_intrinsics_simd.c
@@ -645,34 +645,12 @@ v128_t TESTFN i32x4_trunc_u_f32x4_sat(v128_t vec) {
   return wasm_u32x4_trunc_saturate_f32x4(vec);
 }
 
-#ifdef __wasm_unimplemented_simd128__
-
-v128_t TESTFN i64x2_trunc_s_f64x2_sat(v128_t vec) {
-  return wasm_i64x2_trunc_saturate_f64x2(vec);
-}
-v128_t TESTFN i64x2_trunc_u_f64x2_sat(v128_t vec) {
-  return wasm_u64x2_trunc_saturate_f64x2(vec);
-}
-
-#endif // __wasm_unimplemented_simd128__
-
 v128_t TESTFN f32x4_convert_s_i32x4(v128_t vec) {
   return wasm_f32x4_convert_i32x4(vec);
 }
 v128_t TESTFN f32x4_convert_u_i32x4(v128_t vec) {
   return wasm_f32x4_convert_u32x4(vec);
 }
-
-#ifdef __wasm_unimplemented_simd128__
-
-v128_t TESTFN f64x2_convert_s_i64x2(v128_t vec) {
-  return wasm_f64x2_convert_i64x2(vec);
-}
-v128_t TESTFN f64x2_convert_u_i64x2(v128_t vec) {
-  return wasm_f64x2_convert_u64x2(vec);
-}
-
-#endif // __wasm_unimplemented_simd128__
 
 v128_t TESTFN i8x16_narrow_i16x8_s(v128_t a, v128_t b) {
   return wasm_i8x16_narrow_i16x8(a, b);
@@ -1741,22 +1719,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     i32x4_trunc_u_f32x4_sat((v128_t)f32x4(42, NAN, INFINITY, -INFINITY)),
     u32x4(42, 0, 4294967295ull, 0)
   );
-
-#ifdef __wasm_unimplemented_simd128__
-
-  expect_vec(i64x2_trunc_s_f64x2_sat((v128_t)f64x2(42, NAN)), i64x2(42, 0));
-  expect_vec(
-    i64x2_trunc_s_f64x2_sat((v128_t)f64x2(INFINITY, -INFINITY)),
-    i64x2(9223372036854775807ll, -9223372036854775807ll - 1)
-  );
-  expect_vec(i64x2_trunc_u_f64x2_sat((v128_t)f64x2(42, NAN)), u64x2(42, 0));
-  expect_vec(
-    i64x2_trunc_u_f64x2_sat((v128_t)f64x2(INFINITY, -INFINITY)),
-    u64x2(18446744073709551615ull, 0)
-  );
-
-#endif // __wasm_unimplemented_simd128__
-
   expect_vec(
     f32x4_convert_s_i32x4((v128_t)i32x4(0, -1, 2147483647, -2147483647 - 1)),
     f32x4(0, -1, 2147483648., -2147483648.)
@@ -1765,25 +1727,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     f32x4_convert_u_i32x4((v128_t)u32x4(0, -1, 2147483647, -2147483647 - 1)),
     f32x4(0, 4294967296., 2147483648., 2147483648.)
   );
-
-#ifdef __wasm_unimplemented_simd128__
-
-  expect_vec(f64x2_convert_s_i64x2((v128_t)i64x2(0, -1)), f64x2(0, -1));
-  expect_vec(
-    f64x2_convert_s_i64x2((v128_t)i64x2(9223372036854775807, -9223372036854775807 - 1)),
-    f64x2(9223372036854775807., -9223372036854775808.)
-  );
-  expect_vec(
-    f64x2_convert_u_i64x2((v128_t)u64x2(0, -1)),
-    f64x2(0, 18446744073709551616.)
-  );
-  expect_vec(
-    f64x2_convert_u_i64x2((v128_t)i64x2(9223372036854775807 , -9223372036854775808.)),
-    f64x2(9223372036854775807., 9223372036854775808.)
-  );
-
-#endif // __wasm_unimplemented_simd128__
-
   expect_vec(
     i8x16_narrow_i16x8_s(
       (v128_t)i16x8(129, 127, -32767, 32767, -32768, -1, 1, 0),


### PR DESCRIPTION
Also remove the old nonstandard 64x2 conversion ops from the tests
because they are being removed in LLVM.