### PR TITLE
Don't use whole-archive unless actaully needed

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1339,10 +1339,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if not shared.Settings.GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS and shared.Settings.GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS:
       exit_with_error('-s GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS=0 only makes sense with -s GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS=0!')
 
-    forced_stdlibs = []
+    included_stdlibs = []
 
     if shared.Settings.ASMFS and final_suffix in JS_CONTAINING_ENDINGS:
-      forced_stdlibs.append('libasmfs')
+      included_stdlibs.append('libasmfs')
       cflags.append('-D__EMSCRIPTEN_ASMFS__=1')
       next_arg_index += 1
       shared.Settings.FILESYSTEM = 0
@@ -1358,7 +1358,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.SYSTEM_JS_LIBRARIES.append(shared.path_from_root('src', 'library_emmalloc.js'))
 
     if shared.Settings.FETCH and final_suffix in JS_CONTAINING_ENDINGS:
-      forced_stdlibs.append('libfetch')
+      included_stdlibs.append('libfetch')
       next_arg_index += 1
       shared.Settings.SYSTEM_JS_LIBRARIES.append(shared.path_from_root('src', 'library_fetch.js'))
       if shared.Settings.USE_PTHREADS:
@@ -1384,7 +1384,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.MAX_WEBGL_VERSION = max(2, shared.Settings.MAX_WEBGL_VERSION)
 
     if shared.Settings.EMBIND:
-      forced_stdlibs.append('libembind')
+      shared.Settings.EXPORTED_FUNCTIONS += ['___getTypeName']
+      included_stdlibs.append('libembind')
 
     if not shared.Settings.MINIMAL_RUNTIME and not shared.Settings.STANDALONE_WASM:
       # The normal JS runtime depends on malloc and free so always keep them alive.
@@ -2269,7 +2270,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
          not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
         extra_files_to_link = system_libs.get_ports(shared.Settings)
         if '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
-          extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, stdout_=None, stderr_=None, forced=forced_stdlibs)
+          extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, in_temp, always_include=included_stdlibs)
         linker_inputs += extra_files_to_link
 
     # exit block 'calculate system libraries'

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -396,7 +396,7 @@ var LibraryEmbind = {
     return ret;
   },
 
-  $getTypeName__deps: ['$readLatin1String'],
+  $getTypeName__deps: ['$readLatin1String', '__getTypeName'],
   $getTypeName: function(type) {
     var ptr = ___getTypeName(type);
     var rv = readLatin1String(ptr);

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1467,14 +1467,11 @@ def warn_on_unexported_main(symbolses):
         return
 
 
-def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
-  global stdout, stderr
-  stdout = stdout_
-  stderr = stderr_
+def calculate(temp_files, in_temp, always_include):
 
   # Set of libraries to include on the link line, as opposed to `force` which
   # is the set of libraries to force include (with --whole-archive).
-  always_include = set()
+  always_include = set(always_include)
 
   # Setting this will only use the forced libs in EMCC_FORCE_STDLIBS. This avoids spending time checking
   # for unresolved symbols in your project files, which can speed up linking, but if you do not have
@@ -1557,7 +1554,7 @@ def calculate(temp_files, in_temp, stdout_, stderr_, forced=[]):
   force = os.environ.get('EMCC_FORCE_STDLIBS')
   if force == '1':
     force = ','.join(name for name, lib in system_libs_map.items() if not lib.never_force)
-  force_include = set((force.split(',') if force else []) + forced)
+  force_include = set((force.split(',') if force else []))
   if force_include:
     logger.debug('forcing stdlibs: ' + str(force_include))
 


### PR DESCRIPTION
Sometime emcc wants to add extra libraries the link, but when it
does do there is no need to use `--whole-archive` which is what is
used for FORCE_STDLIBS

This change was split out from:
https://github.com/emscripten-core/emscripten/pull/10998