### PR TITLE
No need for force all of libc++abi just to get __cxa_demangle

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1378,7 +1378,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.DEMANGLE_SUPPORT:
       shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
-      forced_stdlibs.append('libc++abi')
 
     if shared.Settings.FULL_ES3:
       shared.Settings.FULL_ES2 = 1

--- a/tests/other/metadce/hello_libcxx_O2_fexceptions_DEMANGLE_SUPPORT.funcs
+++ b/tests/other/metadce/hello_libcxx_O2_fexceptions_DEMANGLE_SUPPORT.funcs
@@ -207,7 +207,6 @@ $\28anonymous\20namespace\29::itanium_demangle::Node::Node\28\28anonymous\20name
 $\28anonymous\20namespace\29::itanium_demangle::Node::getBaseName\28\29\20const
 $\28anonymous\20namespace\29::itanium_demangle::Node::hasArray\28\28anonymous\20namespace\29::itanium_demangle::OutputStream&\29\20const
 $\28anonymous\20namespace\29::itanium_demangle::Node::hasFunction\28\28anonymous\20namespace\29::itanium_demangle::OutputStream&\29\20const
-$\28anonymous\20namespace\29::itanium_demangle::Node::hasRHSComponentSlow\28\28anonymous\20namespace\29::itanium_demangle::OutputStream&\29\20const
 $\28anonymous\20namespace\29::itanium_demangle::Node::hasRHSComponent\28\28anonymous\20namespace\29::itanium_demangle::OutputStream&\29\20const
 $\28anonymous\20namespace\29::itanium_demangle::Node::print\28\28anonymous\20namespace\29::itanium_demangle::OutputStream&\29\20const
 $\28anonymous\20namespace\29::itanium_demangle::NodeArray::NodeArray\28\29
@@ -533,6 +532,7 @@ $pad
 $pop_arg
 $pop_arg_long_double
 $printf_core
+$pthread_cond_wait
 $sbrk
 $scalbn
 $scalbnl


### PR DESCRIPTION
These two lines were both added back in:
812f051215f469a8f26768fde343c2e464114cc1

However, simply depending on the symbol should be enough to link it
in (and generate and error if its missing).

Split out from https://github.com/emscripten-core/emscripten/pull/11061