### PR TITLE
Disable test_standalone_syscalls under fastcomp

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10573,6 +10573,7 @@ int main() {
 ''')
     run_process([PYTHON, EMCC, 'errno_type.c'])
 
+  @no_fastcomp("uses standalone mode")
   def test_standalone_syscalls(self):
     run_process([PYTHON, EMCC, path_from_root('tests', 'other', 'standalone_syscalls', 'test.cpp'), '-o', 'test.wasm'])
     with open(path_from_root('tests', 'other', 'standalone_syscalls', 'test.out')) as f:


### PR DESCRIPTION
standalone tests don't run under fastcomp.

On the CI this doesn't show up because it happens that we test
fastcomp with no WASM_ENGINES configured.