### PR TITLE
Cleanup compiler.js entry point

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -4,138 +4,49 @@
  * SPDX-License-Identifier: MIT
  */
 
+// We can't currently use strict here because it applies to all code we eval
+// which is not yet conform the strict standards.
 //"use strict";
 
 // LLVM => JavaScript compiler, main entry point
 
-try {
-  // On SpiderMonkey, prepare a large amount of GC space
-  gcparam('maxBytes', 1024*1024*1024);
-} catch(e) {}
+var nodeFS = require('fs');
+var nodePath = require('path');
 
-
-// The environment setup code appears here, in js_optimizer.js and in tests/hello_world.js because it can't be shared. Keep them in sync!
-// It also appears, in modified form, in shell.js.
 // *** Environment setup code ***
-var arguments_ = [];
 
-var ENVIRONMENT_IS_WEB = typeof window === 'object';
-var ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
-var ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof require === 'function' && !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_WORKER;
-var ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
+// Expose functionality in the same simple way that the shells work
+// Note that we pollute the global namespace here, otherwise we break in node
+print = function(x) {
+  process['stdout'].write(x + '\n');
+};
 
-if (ENVIRONMENT_IS_NODE) {
-  // Expose functionality in the same simple way that the shells work
-  // Note that we pollute the global namespace here, otherwise we break in node
-  print = function(x) {
-    process['stdout'].write(x + '\n');
-  };
-  printErr = function(x) {
-    process['stderr'].write(x + '\n');
-  };
+printErr = function(x) {
+  process['stderr'].write(x + '\n');
+};
 
-  var nodeFS = require('fs');
-  var nodePath = require('path');
-
-  if (!nodeFS.existsSync) {
-    nodeFS.existsSync = function(path) {
-      try {
-        return !!nodeFS.readFileSync(path);
-      } catch(e) {
-        return false;
-      }
+function find(filename) {
+  var prefixes = [__dirname, process.cwd()];
+  for (var i = 0; i < prefixes.length; ++i) {
+    var combined = nodePath.join(prefixes[i], filename);
+    if (nodeFS.existsSync(combined)) {
+      return combined;
     }
   }
-
-  function find(filename) {
-    var prefixes = [__dirname, process.cwd()];
-    for (var i = 0; i < prefixes.length; ++i) {
-      var combined = nodePath.join(prefixes[i], filename);
-      if (nodeFS.existsSync(combined)) {
-        return combined;
-      }
-    }
-    return filename;
-  }
-
-  read = function(filename) {
-    var absolute = find(filename);
-    return nodeFS['readFileSync'](absolute).toString();
-  };
-
-  load = function(f) {
-    globalEval(read(f));
-  };
-
-  arguments_ = process['argv'].slice(2);
-
-} else if (ENVIRONMENT_IS_SHELL) {
-  // Polyfill over SpiderMonkey/V8 differences
-  if (!this['read']) {
-    this['read'] = function(f) { snarf(f) };
-  }
-
-  if (typeof scriptArgs != 'undefined') {
-    arguments_ = scriptArgs;
-  } else if (typeof arguments != 'undefined') {
-    arguments_ = arguments;
-  }
-
-} else if (ENVIRONMENT_IS_WEB) {
-  printErr = function(x) {
-    console.log(x);
-  };
-
-  if (!this['print']) this['print'] = printErr;
-
-  this['read'] = function(url) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, false);
-    xhr.send(null);
-    return xhr.responseText;
-  };
-
-  if (this['arguments']) {
-    arguments_ = arguments;
-  }
-} else if (ENVIRONMENT_IS_WORKER) {
-  // We can do very little here...
-
-  this['load'] = importScripts;
-
-} else {
-  throw 'Unknown runtime environment. Where are we?';
+  return filename;
 }
+
+read = function(filename) {
+  var absolute = find(filename);
+  return nodeFS['readFileSync'](absolute).toString();
+};
+
+load = function(f) {
+  globalEval(read(f));
+};
 
 function globalEval(x) {
   eval.call(null, x);
-}
-
-if (typeof load == 'undefined' && typeof read != 'undefined') {
-  this['load'] = function(f) {
-    globalEval(read(f));
-  };
-}
-
-if (typeof printErr === 'undefined') {
-  this['printErr'] = function(){};
-}
-
-if (typeof print === 'undefined') {
-  this['print'] = printErr;
-}
-// *** Environment setup code ***
-
-
-DEBUG_MEMORY = false;
-
-// Polyfilling
-
-if (!String.prototype.startsWith) {
-  String.prototype.startsWith = function(searchString, position) {
-    position = position || 0;
-    return this.indexOf(searchString, position) === position;
-  };
 }
 
 // Basic utilities
@@ -147,11 +58,12 @@ load('utility.js');
 load('settings.js');
 load('settings_internal.js');
 
+var arguments_ = process['argv'].slice(2);
 var settings_file = arguments_[0];
 
 if (settings_file) {
   var settings = JSON.parse(read(settings_file));
-  for (key in settings) {
+  for (var key in settings) {
     var value = settings[key];
     if (value[0] == '@') {
       // response file type thing, workaround for large inputs: value is @path-to-file
@@ -164,7 +76,6 @@ if (settings_file) {
     eval(key + ' = ' + JSON.stringify(value));
   }
 }
-
 
 EXPORTED_FUNCTIONS = set(EXPORTED_FUNCTIONS);
 EXCEPTION_CATCHING_WHITELIST = set(EXCEPTION_CATCHING_WHITELIST);
@@ -180,7 +91,9 @@ RUNTIME_DEBUG = LIBRARY_DEBUG || GL_DEBUG;
 
 // Output some info and warnings based on settings
 
-if (VERBOSE) printErr('VERBOSE is on, this generates a lot of output and can slow down compilation');
+if (VERBOSE) {
+  printErr('VERBOSE is on, this generates a lot of output and can slow down compilation');
+}
 
 // Load compiler code
 
@@ -221,21 +134,12 @@ if (!ENVIRONMENT_MAY_BE_WORKER && USE_PTHREADS) {
 //===============================
 
 B = new Benchmarker();
+var dummyData = {functionStubs: []}
 
 try {
-  var dummyData = {functionStubs: []}
   JSify(dummyData);
 
-  //dumpInterProf();
-  //printErr('paths (fast, slow): ' + [fastPaths, slowPaths]);
   B.print('glue');
-
-  if (DEBUG_MEMORY) {
-    print('zzz. last gc: ' + gc());
-    MemoryDebugger.dump();
-    print('zzz. hanging now!');
-    while(1){};
-  }
 } catch(err) {
   if (err.toString().indexOf('Aborting compilation due to previous errors') != -1) {
     // Compiler failed on user error, don't print the stacktrace in this case.
@@ -243,27 +147,24 @@ try {
   } else {
     // Compiler failed on internal compiler error!
     printErr('Internal compiler error in src/compiler.js!');
-    printErr('Please create a bug report at https://github.com/emscripten-core/emscripten/issues/ with a log of the build and the input files used to run. Exception message: "' + err + '" | ' + err.stack);
+    printErr('Please create a bug report at https://github.com/emscripten-core/emscripten/issues/');
+    printErr('with a log of the build and the input files used to run. Exception message: "' + err + '" | ' + err.stack);
   }
 
-  if (ENVIRONMENT_IS_NODE) {
-    // Work around a node.js bug where stdout buffer is not flushed at process exit:
-    // Instead of process.exit() directly, wait for stdout flush event.
-    // See https://github.com/joyent/node/issues/1669 and https://github.com/emscripten-core/emscripten/issues/2582
-    // Workaround is based on https://github.com/RReverser/acorn/commit/50ab143cecc9ed71a2d66f78b4aec3bb2e9844f6
-    process['stdout']['once']('drain', function () {
-      process['exit'](1);
-    });
-    console.log(' '); // Make sure to print something to force the drain event to occur, in case the stdout buffer was empty.
-    // Work around another node bug where sometimes 'drain' is never fired - make another effort
-    // to emit the exit status, after a significant delay (if node hasn't fired drain by then, give up)
-    setTimeout(function() {
-      process['exit'](1);
-    }, 500);
-  } else throw err;
+  // Work around a node.js bug where stdout buffer is not flushed at process exit:
+  // Instead of process.exit() directly, wait for stdout flush event.
+  // See https://github.com/joyent/node/issues/1669 and https://github.com/emscripten-core/emscripten/issues/2582
+  // Workaround is based on https://github.com/RReverser/acorn/commit/50ab143cecc9ed71a2d66f78b4aec3bb2e9844f6
+  process['stdout']['once']('drain', function () {
+    process['exit'](1);
+  });
+  // Make sure to print something to force the drain event to occur, in case the
+  // stdout buffer was empty.
+  console.log(' ');
+  // Work around another node bug where sometimes 'drain' is never fired - make
+  // another effort to emit the exit status, after a significant delay (if node
+  // hasn't fired drain by then, give up)
+  setTimeout(function() {
+    process['exit'](1);
+  }, 500);
 }
-
-//var M = keys(tokenCacheMisses).map(function(m) { return [m, misses[m]] }).sort(function(a, b) { return a[1] - b[1] });
-//printErr(dump(M.slice(M.length-10)));
-//printErr('hits: ' + hits);
-

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -4,10 +4,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-// We can't currently use strict here because it applies to all code we eval
-// which is not yet conform the strict standards.
-//"use strict";
-
 // LLVM => JavaScript compiler, main entry point
 
 var nodeFS = require('fs');

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8440,11 +8440,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
         wrong = 'node'
       # test with the right env
       self.set_setting('ENVIRONMENT', right)
-      print('  ', self.get_setting('ENVIRONMENT'))
+      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
       test()
       # test with the wrong env
       self.set_setting('ENVIRONMENT', wrong)
-      print('  ', self.get_setting('ENVIRONMENT'))
+      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
       try:
         test()
         raise Exception('unexpected success')
@@ -8452,7 +8452,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
         self.assertContained('not compiled for this environment', str(e))
       # test with a combined env
       self.set_setting('ENVIRONMENT', right + ',' + wrong)
-      print('  ', self.get_setting('ENVIRONMENT'))
+      print('ENVIRONMENT =', self.get_setting('ENVIRONMENT'))
       test()
 
   def test_dfe(self):


### PR DESCRIPTION
- Remove support for running outside of node.  We don't support that.
- Remove reference to MemoryDebugger which was deleted long ago.

I think we can remove the `drain` workaround on exit too, but I'll
leave that for a followup.