### PR TITLE
NODE_CODE_CACHING updates

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1959,6 +1959,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         exit_with_error('NODE_CODE_CACHING requires sync compilation (WASM_ASYNC_COMPILATION=0)')
       if not shared.Settings.target_environment_may_be('node'):
         exit_with_error('NODE_CODE_CACHING only works in node, but target environments do not include it')
+      if shared.Settings.SINGLE_FILE:
+        exit_with_error('NODE_CODE_CACHING saves a file on the side and is not compatible with SINGLE_FILE')
 
     # safe heap in asm.js uses the js optimizer (in wasm-only mode we can use binaryen)
     if shared.Settings.SAFE_HEAP and not shared.Building.is_wasm_only():

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1069,6 +1069,7 @@ function createWasm() {
         // to load ok, but we do actually recompile the binary every time).
         var cachedCodeFile = '{{{ WASM_BINARY_FILE }}}.' + v8.cachedDataVersionTag() + '.cached';
         cachedCodeFile = locateFile(cachedCodeFile);
+        if (!nodeFS) nodeFS = require('fs');
         var hasCached = nodeFS.existsSync(cachedCodeFile);
         if (hasCached) {
 #if RUNTIME_LOGGING
@@ -1077,7 +1078,7 @@ function createWasm() {
           try {
             module = v8.deserialize(nodeFS.readFileSync(cachedCodeFile));
           } catch (e) {
-            err('NODE_CODE_CACHING: failed to deserialize, bad cache file?');
+            err('NODE_CODE_CACHING: failed to deserialize, bad cache file? (' + cachedCodeFile + ')');
             // Save the new compiled code when we have it.
             hasCached = false;
           }

--- a/src/settings.js
+++ b/src/settings.js
@@ -824,10 +824,9 @@ var NODERAWFS = 0;
 // The V8 version used in node is included in the cache name so that we don't
 // try to load cached code from another version, which fails silently (it seems
 // to load ok, but we do actually recompile).
-//  * This requires a somewhat recent node, but unclear what version, see
-//    https://github.com/nodejs/node/issues/18265#issuecomment-471237531
-//  * This option requires WASM_ASYNC_COMPILATION=0 (we load and save code
-//    in the sync compilation path for simplicity).
+//  * The only version known to work for sure is node 12.9.1, as this has
+//    regressed, see
+//    https://github.com/nodejs/node/issues/18265#issuecomment-622971547
 //  * The default location of the .cached files is alongside the wasm binary,
 //    as mentioned earlier. If that is in a read-only directory, you may need
 //    to place them elsewhere. You can use the locateFile() hook to do so.


### PR DESCRIPTION
* Note that this is broken on newer node, and mention where it works.
  see https://github.com/nodejs/node/issues/18265#issuecomment-622971547
* Show a proper error in SINGLE_FILE mode, where this can't work.
* Add a missing initialization so we always work properly.
* Better error logging.