### PR TITLE
Fix setThrew() dependencies

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2958,7 +2958,11 @@ LibraryManager.library = {
     return '_saveSetjmp(' + env + ', label, setjmpTable)|0';
   },
 
-  longjmp__deps: ['saveSetjmp', 'testSetjmp', 'setThrew'],
+  longjmp__deps: ['saveSetjmp', 'testSetjmp'
+#if WASM_BACKEND == 0
+  , 'setThrew'
+#endif
+  ],
   longjmp: function(env, value) {
     _setThrew(env, value || 1);
     throw 'longjmp';

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -196,7 +196,11 @@ var LibraryExceptions = {
   // and free the exception. Note that if the dynCall on the destructor fails
   // due to calling apply on undefined, that means that the destructor is
   // an invalid index into the FUNCTION_TABLE, so something has gone wrong.
-  __cxa_end_catch__deps: ['__exception_caught', '__exception_last', '__exception_decRef', '__exception_deAdjust', 'setThrew'],
+  __cxa_end_catch__deps: ['__exception_caught', '__exception_last', '__exception_decRef', '__exception_deAdjust'
+#if WASM_BACKEND == 0
+  , 'setThrew'
+#endif
+  ],
   __cxa_end_catch: function() {
     // Clear state flag.
     _setThrew(0);


### PR DESCRIPTION
Fix setThrew() dependencies: setThrew() is not a JS function in wasm backend