### PR TITLE
Ignore -rpath and -rpath-link linker flags

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -90,8 +90,11 @@ UNSUPPORTED_LLD_FLAGS = {
     # wasm-ld doesn't support map files yet.
     '--print-map': False,
     '-M': False,
-    # wasm-ld doesn't support soname yet
-    '-soname': True
+    # wasm-ld doesn't support soname or other dynamic linking flags (yet).   Ignore them
+    # in order to aid build systems that want to pass these flags.
+    '-soname': True,
+    '-rpath': True,
+    '-rpath-link': True
 }
 
 LIB_PREFIXES = ('', 'lib')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10409,6 +10409,12 @@ Module.arguments has been replaced with plain arguments_
     out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Xlinker', '--print-map'], stderr=PIPE).stderr
     self.assertContained('warning: ignoring unsupported linker flag: `--print-map`', out)
 
+    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,-rpath=foo'], stderr=PIPE).stderr
+    self.assertContained('warning: ignoring unsupported linker flag: `-rpath=foo`', out)
+
+    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,-rpath-link,foo'], stderr=PIPE).stderr
+    self.assertContained('warning: ignoring unsupported linker flag: `-rpath-link`', out)
+
     out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'),
                        '-Wl,--no-check-features,-mllvm,-debug'], stderr=PIPE).stderr
     self.assertNotContained('warning: ignoring unsupported linker flag', out)


### PR DESCRIPTION
Some build systems insist on passing these.  Apparently we can increase
compatibility by warning about their use but otherwise ignoring them.

Fixes: #11076