### PR TITLE
Fix FP env issues

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,10 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Stop defining `FE_INEXACT` and other floating point exception macros in libc,
+  since we don't support them. That also prevents musl from including code using
+  pragmas that don't make sense for wasm. Ifdef out other uses of those pragmas
+  as well, as tip of tree LLVM now fails to compile them on wasm. (#11087)
 - Update libcxx and libcxxabi to LLVM 10 release branch (#11038).
 - Remove `BINARYEN_PASSES` setting (#11057). We still have
   `BINARYEN_EXTRA_PASSES` (the removed setting completely overrides the set

--- a/system/lib/libc/musl/arch/emscripten/bits/fenv.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/fenv.h
@@ -1,11 +1,4 @@
-#define FE_INVALID    1
-#define __FE_DENORM   2
-#define FE_DIVBYZERO  4
-#define FE_OVERFLOW   8
-#define FE_UNDERFLOW  16
-#define FE_INEXACT    32
-
-#define FE_ALL_EXCEPT 63
+#define FE_ALL_EXCEPT 0
 
 #define FE_TONEAREST  0
 #define FE_DOWNWARD   0x400

--- a/system/lib/libc/musl/src/math/fma.c
+++ b/system/lib/libc/musl/src/math/fma.c
@@ -79,7 +79,9 @@ static int getexp(long double x)
 
 double fma(double x, double y, double z)
 {
+#ifndef __EMSCRIPTEN_
 	#pragma STDC FENV_ACCESS ON
+#endif
 	long double hi, lo1, lo2, xy;
 	int round, ez, exy;
 
@@ -331,7 +333,9 @@ static inline struct dd dd_mul(double a, double b)
  */
 double fma(double x, double y, double z)
 {
+#ifndef __EMSCRIPTEN_
 	#pragma STDC FENV_ACCESS ON
+#endif
 	double xs, ys, zs, adj;
 	struct dd xy, r;
 	int oround;

--- a/system/lib/libc/musl/src/math/fma.c
+++ b/system/lib/libc/musl/src/math/fma.c
@@ -79,7 +79,7 @@ static int getexp(long double x)
 
 double fma(double x, double y, double z)
 {
-#ifndef __EMSCRIPTEN_
+#ifndef __EMSCRIPTEN__
 	#pragma STDC FENV_ACCESS ON
 #endif
 	long double hi, lo1, lo2, xy;
@@ -333,7 +333,7 @@ static inline struct dd dd_mul(double a, double b)
  */
 double fma(double x, double y, double z)
 {
-#ifndef __EMSCRIPTEN_
+#ifndef __EMSCRIPTEN__
 	#pragma STDC FENV_ACCESS ON
 #endif
 	double xs, ys, zs, adj;

--- a/system/lib/libc/musl/src/math/fmaf.c
+++ b/system/lib/libc/musl/src/math/fmaf.c
@@ -38,7 +38,7 @@
  */
 float fmaf(float x, float y, float z)
 {
-#ifndef __EMSCRIPTEN_
+#ifndef __EMSCRIPTEN__
 	#pragma STDC FENV_ACCESS ON
 #endif
 	double xy, result;

--- a/system/lib/libc/musl/src/math/fmaf.c
+++ b/system/lib/libc/musl/src/math/fmaf.c
@@ -38,7 +38,9 @@
  */
 float fmaf(float x, float y, float z)
 {
+#ifndef __EMSCRIPTEN_
 	#pragma STDC FENV_ACCESS ON
+#endif
 	double xy, result;
 	union {double f; uint64_t i;} u;
 	int e;

--- a/system/lib/libc/musl/src/math/fmal.c
+++ b/system/lib/libc/musl/src/math/fmal.c
@@ -164,7 +164,9 @@ static inline struct dd dd_mul(long double a, long double b)
  */
 long double fmal(long double x, long double y, long double z)
 {
+#ifndef __EMSCRIPTEN_
 	#pragma STDC FENV_ACCESS ON
+#endif
 	long double xs, ys, zs, adj;
 	struct dd xy, r;
 	int oround;

--- a/system/lib/libc/musl/src/math/fmal.c
+++ b/system/lib/libc/musl/src/math/fmal.c
@@ -164,7 +164,7 @@ static inline struct dd dd_mul(long double a, long double b)
  */
 long double fmal(long double x, long double y, long double z)
 {
-#ifndef __EMSCRIPTEN_
+#ifndef __EMSCRIPTEN__
 	#pragma STDC FENV_ACCESS ON
 #endif
 	long double xs, ys, zs, adj;

--- a/system/lib/libc/musl/src/math/ilogb.c
+++ b/system/lib/libc/musl/src/math/ilogb.c
@@ -3,7 +3,7 @@
 
 int ilogb(double x)
 {
-#ifndef __EMSCRIPTEN_
+#ifndef __EMSCRIPTEN__
 	#pragma STDC FENV_ACCESS ON
 #endif
 	union {double f; uint64_t i;} u = {x};

--- a/system/lib/libc/musl/src/math/ilogb.c
+++ b/system/lib/libc/musl/src/math/ilogb.c
@@ -3,7 +3,9 @@
 
 int ilogb(double x)
 {
+#ifndef __EMSCRIPTEN_
 	#pragma STDC FENV_ACCESS ON
+#endif
 	union {double f; uint64_t i;} u = {x};
 	uint64_t i = u.i;
 	int e = i>>52 & 0x7ff;

--- a/system/lib/libc/musl/src/math/ilogbf.c
+++ b/system/lib/libc/musl/src/math/ilogbf.c
@@ -3,7 +3,7 @@
 
 int ilogbf(float x)
 {
-#ifndef __EMSCRIPTEN_
+#ifndef __EMSCRIPTEN__
 	#pragma STDC FENV_ACCESS ON
 #endif
 	union {float f; uint32_t i;} u = {x};

--- a/system/lib/libc/musl/src/math/ilogbf.c
+++ b/system/lib/libc/musl/src/math/ilogbf.c
@@ -3,7 +3,9 @@
 
 int ilogbf(float x)
 {
+#ifndef __EMSCRIPTEN_
 	#pragma STDC FENV_ACCESS ON
+#endif
 	union {float f; uint32_t i;} u = {x};
 	uint32_t i = u.i;
 	int e = i>>23 & 0xff;

--- a/system/lib/libc/musl/src/math/ilogbl.c
+++ b/system/lib/libc/musl/src/math/ilogbl.c
@@ -9,7 +9,9 @@ int ilogbl(long double x)
 #elif LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384
 int ilogbl(long double x)
 {
+#ifndef __EMSCRIPTEN_
 	#pragma STDC FENV_ACCESS ON
+#endif
 	union ldshape u = {x};
 	uint64_t m = u.i.m;
 	int e = u.i.se & 0x7fff;
@@ -32,7 +34,9 @@ int ilogbl(long double x)
 #elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384
 int ilogbl(long double x)
 {
+#ifndef __EMSCRIPTEN_
 	#pragma STDC FENV_ACCESS ON
+#endif
 	union ldshape u = {x};
 	int e = u.i.se & 0x7fff;
 

--- a/system/lib/libc/musl/src/math/ilogbl.c
+++ b/system/lib/libc/musl/src/math/ilogbl.c
@@ -9,7 +9,7 @@ int ilogbl(long double x)
 #elif LDBL_MANT_DIG == 64 && LDBL_MAX_EXP == 16384
 int ilogbl(long double x)
 {
-#ifndef __EMSCRIPTEN_
+#ifndef __EMSCRIPTEN__
 	#pragma STDC FENV_ACCESS ON
 #endif
 	union ldshape u = {x};
@@ -34,7 +34,7 @@ int ilogbl(long double x)
 #elif LDBL_MANT_DIG == 113 && LDBL_MAX_EXP == 16384
 int ilogbl(long double x)
 {
-#ifndef __EMSCRIPTEN_
+#ifndef __EMSCRIPTEN__
 	#pragma STDC FENV_ACCESS ON
 #endif
 	union ldshape u = {x};


### PR DESCRIPTION
1. Define only floating point exceptions we support (none). That
  avoids a lot of float pragmas we don't support.
2. Ifdef out the remaining such pragmas.

Helps #11086 , but does not fix it as user code may still be broken
due to LLVM failing ISel on those pragmas now.
