### PR TITLE
--extern-pre-js / --extern-post-js

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -36,7 +36,10 @@ Current Trunk
   them are mandatory like setting the sbrk ptr).
 - Remove `MODULARIZE_INSTANCE` build option (#11037). This was a seldom used
   option that was complicating the logic for `MODULARIZE`. Module instances can
-  be created by using `MODULARIZE` and calling the factory function explicitly. 
+  be created by using `MODULARIZE` and calling the factory function explicitly.
+  See the new `--extern-post-js` option added in this release, which can help
+  code that used `MODULARIZE_INSTANCE` (you can add an extern post js which
+  does `Module = Module();` for example).
 
 1.39.14: 05/01/2020
 -------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,7 +19,8 @@ Current Trunk
 -------------
 - Add `--extern-pre-js` and `--extern-post-js` emcc flags. Files provided there
   are prepended/appended to the final JavaScript output, *after* all other
-  work has been done, including optimization. They are the same as prepending/
+  work has been done, including optimization, optional `MODULARIZE`,
+  instrumentation like `SAFE_HEAP`, etc. They are the same as prepending/
   appending those files after `emcc` finishes running, and are just a convenient
   way to do that. (For comparison, `--pre-js` and `--post-js` include the code
   with the rest of the optimized output.)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,12 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Add `--extern-pre-js` and `--extern-post-js` emcc flags. Files provided there
+  are prepended/appended to the final JavaScript output, *after* all other
+  work has been done, including optimization. They are the same as prepending/
+  appending those files after `emcc` finishes running, and are just a convenient
+  way to do that. (For comparison, `--pre-js` and `--post-js` include the code
+  with the rest of the optimized output.)
 - Update libcxx and libcxxabi to LLVM 10 release branch (#11038).
 - Remove `BINARYEN_PASSES` setting (#11057). We still have
   `BINARYEN_EXTRA_PASSES` (the removed setting completely overrides the set

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,11 +19,12 @@ Current Trunk
 -------------
 - Add `--extern-pre-js` and `--extern-post-js` emcc flags. Files provided there
   are prepended/appended to the final JavaScript output, *after* all other
-  work has been done, including optimization, optional `MODULARIZE`,
+  work has been done, including optimization, optional `MODULARIZE`-ation,
   instrumentation like `SAFE_HEAP`, etc. They are the same as prepending/
   appending those files after `emcc` finishes running, and are just a convenient
-  way to do that. (For comparison, `--pre-js` and `--post-js` include the code
-  with the rest of the optimized output.)
+  way to do that. (For comparison, `--pre-js` and `--post-js` optimize that code
+  together with everything else, keep it in the same scope if running
+  `MODULARIZE`, etc.).
 - Stop defining `FE_INEXACT` and other floating point exception macros in libc,
   since we don't support them. That also prevents musl from including code using
   pragmas that don't make sense for wasm. Ifdef out other uses of those pragmas

--- a/emcc.py
+++ b/emcc.py
@@ -220,6 +220,8 @@ class EmccOptions(object):
     self.js_transform = None
     self.pre_js = '' # before all js
     self.post_js = '' # after all js
+    self.extern_pre_js = '' # before all js, external to optimized code
+    self.extern_post_js = '' # after all js, external to optimized code
     self.preload_files = []
     self.embed_files = []
     self.exclude_files = []
@@ -564,6 +566,13 @@ def filter_link_flags(flags, using_lld):
       results.append(f)
 
   return results
+
+
+def fix_windows_newlines(text):
+  # Avoid duplicating \r\n to \r\r\n when writing out text.
+  if WINDOWS:
+    text = text.replace('\r\n', '\n')
+  return text
 
 
 def cxx_to_c_compiler(cxx):
@@ -2478,16 +2487,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         logger.debug('applying pre/postjses')
         src = open(final).read()
         final += '.pp.js'
-        if WINDOWS: # Avoid duplicating \r\n to \r\r\n when writing out.
-          if options.pre_js:
-            options.pre_js = options.pre_js.replace('\r\n', '\n')
-          if options.post_js:
-            options.post_js = options.post_js.replace('\r\n', '\n')
         with open(final, 'w') as f:
           # pre-js code goes right after the Module integration code (so it
           # can use Module), we have a marker for it
-          f.write(src.replace('// {{PRE_JSES}}', options.pre_js))
-          f.write(options.post_js)
+          f.write(src.replace('// {{PRE_JSES}}', fix_windows_newlines(options.pre_js)))
+          f.write(fix_windows_newlines(options.post_js))
         options.pre_js = src = options.post_js = None
         save_intermediate('pre-post')
 
@@ -2728,6 +2732,17 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if not shared.Settings.WASM and shared.Settings.SEPARATE_ASM:
           shared.run_process([shared.PYTHON, shared.path_from_root('tools', 'hacky_postprocess_around_closure_limitations.py'), asm_target])
 
+      # Apply pre and postjs files
+      if options.extern_pre_js or options.extern_post_js:
+        logger.debug('applying extern pre/postjses')
+        src = open(final).read()
+        final += '.epp.js'
+        with open(final, 'w') as f:
+          f.write(fix_windows_newlines(options.extern_pre_js))
+          f.write(src)
+          f.write(fix_windows_newlines(options.extern_post_js))
+        save_intermediate('extern-pre-post')
+
       # The JS is now final. Move it to its final location
       shutil.move(final, js_target)
 
@@ -2828,6 +2843,10 @@ def parse_args(newargs):
       options.pre_js += open(consume_arg()).read() + '\n'
     elif check_arg('--post-js'):
       options.post_js += open(consume_arg()).read() + '\n'
+    elif check_arg('--extern-pre-js'):
+      options.extern_pre_js += open(consume_arg()).read() + '\n'
+    elif check_arg('--extern-post-js'):
+      options.extern_post_js += open(consume_arg()).read() + '\n'
     elif check_arg('--minify'):
       arg = consume_arg()
       if arg != '0':

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -242,7 +242,17 @@ Options that are modified or new in *emcc* are listed below:
 .. _emcc-post-js:
 
 ``--post-js <file>``
-  Like `--pre-js``, but emits a file *after* the emitted code.
+  Like ``--pre-js``, but emits a file *after* the emitted code.
+
+``--extern-pre-js <file>``
+  Specify a file whose contents are prepended to the JavaScript output. Unlike
+  ``--pre-js``, this file is external to the optimized code: it is simply
+  prepended, before anything else, to the final optimized JavaScript. It is
+  a convenient way to do so instead of your build system prepending it right
+  after running ``emcc``.
+
+``--extern-post-js <file>``
+  Like ``--extern-pre-js``, but appends to the end.
 
 .. _emcc-embed-file:
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -249,7 +249,7 @@ Options that are modified or new in *emcc* are listed below:
   file is prepended to the final JavaScript output, *after* all other
   work has been done, including optimization, optional ``MODULARIZE``-ation,
   instrumentation like ``SAFE_HEAP``, etc. This is the same as prepending
-  this files after ``emcc`` finishes running, and is just a convenient
+  this file after ``emcc`` finishes running, and is just a convenient
   way to do that. (For comparison, ``--pre-js`` and ``--post-js`` optimize the
   code together with everything else, keep it in the same scope if running
   `MODULARIZE`, etc.).

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -245,11 +245,14 @@ Options that are modified or new in *emcc* are listed below:
   Like ``--pre-js``, but emits a file *after* the emitted code.
 
 ``--extern-pre-js <file>``
-  Specify a file whose contents are prepended to the JavaScript output. Unlike
-  ``--pre-js``, this file is external to the optimized code: it is simply
-  prepended, before anything else, to the final optimized JavaScript. It is
-  a convenient way to do so instead of your build system prepending it right
-  after running ``emcc``.
+  Specify a file whose contents are prepended to the JavaScript output. This
+  file is prepended to the final JavaScript output, *after* all other
+  work has been done, including optimization, optional ``MODULARIZE``-ation,
+  instrumentation like ``SAFE_HEAP``, etc. This is the same as prepending
+  this files after ``emcc`` finishes running, and is just a convenient
+  way to do that. (For comparison, ``--pre-js`` and ``--post-js`` optimize the
+  code together with everything else, keep it in the same scope if running
+  `MODULARIZE`, etc.).
 
 ``--extern-post-js <file>``
   Like ``--extern-pre-js``, but appends to the end.


### PR DESCRIPTION
A request for these has come up now and then, but it's never been
urgent I guess and no one's submitted a PR. This came up again
now so I figured I'd do that.

The new options just prepend/append JS code, after all other
work has been done. A build system could just prepend/append
after emcc runs, but sometimes that's less convenient. For example,
in Binaryen we need something like this now that
`MODULARIZE_INSTANCE` is gone, and the build system there is
CMake, where there isn't an obvious simple way to append text
to a file that I am aware of.

Helps https://github.com/WebAssembly/binaryen/pull/2830