### PR TITLE
Allow cache directory to be configured via config file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Honor `CACHE` setting in config file as an alternative to `EM_CACHE`
+  environment variable or `--cache` commandline flag.
 
 1.39.15: 05/06/2020
 -------------------

--- a/emcc.py
+++ b/emcc.py
@@ -2959,7 +2959,7 @@ def parse_args(newargs):
       logger.error('jcache is no longer supported')
       newargs[i] = ''
     elif check_arg('--cache'):
-      os.environ['EM_CACHE'] = os.path.normpath(consume_arg())
+      shared.CACHE = os.path.normpath(consume_arg())
       shared.reconfigure_cache()
     elif newargs[i] == '--clear-cache':
       logger.info('clearing cache as requested by --clear-cache')

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -574,7 +574,7 @@ fi
     temp_dir = tempfile.mkdtemp(prefix='emscripten_temp_')
 
     with chdir(temp_dir):
-      self.do([PYTHON, EMCC, '--em-config', custom_config_filename] + MINIMAL_HELLO_WORLD + ['-O2'])
+      run_process([PYTHON, EMCC, '--em-config', custom_config_filename] + MINIMAL_HELLO_WORLD + ['-O2'])
       result = run_js('a.out.js')
 
     self.assertContained('hello, world!', result)

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -25,13 +25,9 @@ class Cache(object):
   # acquired.
   EM_EXCLUSIVE_CACHE_ACCESS = int(os.environ.get('EM_EXCLUSIVE_CACHE_ACCESS', '0'))
 
-  def __init__(self, use_subdir=True):
+  def __init__(self, dirname, use_subdir=True):
     # figure out the root directory for all caching
-    dirname = os.environ.get('EM_CACHE')
-    if dirname:
-      dirname = os.path.normpath(dirname)
-    if not dirname:
-      dirname = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
+    dirname = os.path.normpath(dirname)
     self.root_dirname = dirname
 
     def try_remove_ending(thestring, ending):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3411,10 +3411,7 @@ V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
 JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
 WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
 if not CACHE:
-  if CONFIG_FILE:
-    CACHE = CONFIG_FILE + '_cache'
-  else:
-    CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
+  CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
 
 # Install our replacement Popen handler if we are running on Windows to avoid
 # python spawn process function.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -642,7 +642,7 @@ def check_vanilla():
     # if we are using vanilla LLVM, i.e. we don't have our asm.js backend, then we
     # must use wasm (or at least try to). to know that, we have to run llc to
     # see which backends it has. we cache this result.
-    temp_cache = cache.Cache(use_subdir=False)
+    temp_cache = cache.Cache(CACHE, use_subdir=False)
 
     def has_vanilla_targets():
       logger.debug('testing for asm.js target, because if not present (i.e. this is plain vanilla llvm, not emscripten fastcomp), we will use the wasm target instead (set EMCC_WASM_BACKEND to skip this check)')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -284,6 +284,7 @@ def parse_config_file():
     'WASMTIME',
     'WASM_ENGINES',
     'FROZEN_CACHE',
+    'CACHE',
   )
 
   # Only propagate certain settings from the config file.
@@ -2791,7 +2792,7 @@ class Building(object):
 
 def reconfigure_cache():
   global Cache
-  Cache = cache.Cache()
+  Cache = cache.Cache(CACHE)
 
 
 # Placeholder strings used for SINGLE_FILE
@@ -3385,6 +3386,7 @@ JS_ENGINES = []
 WASMER = None
 WASMTIME = None
 WASM_ENGINES = []
+CACHE = None
 FROZEN_CACHE = False
 
 # Emscripten compiler spawns other processes, which can reimport shared.py, so
@@ -3408,6 +3410,11 @@ NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
 V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
 JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
 WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
+if not CACHE:
+  if CONFIG_FILE:
+    CACHE = CONFIG_FILE + '_cache'
+  else:
+    CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
 
 # Install our replacement Popen handler if we are running on Windows to avoid
 # python spawn process function.
@@ -3503,5 +3510,5 @@ verify_settings()
 PRINT_STAGES = int(os.getenv('EMCC_VERBOSE', '0'))
 
 # compatibility with existing emcc, etc. scripts
-Cache = cache.Cache()
+Cache = cache.Cache(CACHE)
 chunkify = cache.chunkify


### PR DESCRIPTION
Honor `CACHE` setting in config file as an alternative to `EM_CACHE`
environment variable or `--cache` commandline flag.

Specifically this is useful for emsdk which wants to set the cache directory
and currently has has to export both EM_CONFIG and EM_CACHE whereas
it should be enough to do just the one.

Hopefully we can remove the command line flag if it has no more
users. 