### PR TITLE
Remove --cache commandline arg

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -19,6 +19,8 @@ Current Trunk
 -------------
 - Honor `CACHE` setting in config file as an alternative to `EM_CACHE`
   environment variable or `--cache` commandline flag.
+- Remove `--cache` command line arg.  The `CACHE` config setting and the
+  `EM_CACHE` environment variable can be used to control this.
 
 1.39.15: 05/06/2020
 -------------------

--- a/emcc.py
+++ b/emcc.py
@@ -2958,9 +2958,6 @@ def parse_args(newargs):
     elif newargs[i] == '--jcache':
       logger.error('jcache is no longer supported')
       newargs[i] = ''
-    elif check_arg('--cache'):
-      shared.CACHE = os.path.normpath(consume_arg())
-      shared.reconfigure_cache()
     elif newargs[i] == '--clear-cache':
       logger.info('clearing cache as requested by --clear-cache')
       shared.Cache.erase()

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -516,16 +516,18 @@ fi
         return 0;
       }
       ''')
-    cache_dir_name = self.in_dir('emscripten_cache')
-    tasks = []
-    num_times_libc_was_built = 0
-    for i in range(3):
-      p = run_process([PYTHON, EMCC, 'test.c', '--cache', cache_dir_name, '-o', '%d.js' % i], stderr=STDOUT, stdout=PIPE)
-      tasks += [p]
-    for p in tasks:
-      print('stdout:\n', p.stdout)
-      if 'generating system library: libc' in p.stdout:
-        num_times_libc_was_built += 1
+    cache_dir_name = self.in_dir('test_cache')
+    with env_modify({'EM_CACHE': cache_dir_name}):
+      tasks = []
+      num_times_libc_was_built = 0
+      for i in range(3):
+        p = run_process([PYTHON, EMCC, 'test.c', '-o', '%d.js' % i], stderr=STDOUT, stdout=PIPE)
+        tasks += [p]
+      for p in tasks:
+        print('stdout:\n', p.stdout)
+        if 'generating system library: libc' in p.stdout:
+          num_times_libc_was_built += 1
+
     # The cache directory must exist after the build
     self.assertTrue(os.path.exists(cache_dir_name))
     # The cache directory must contain a built libc
@@ -535,27 +537,6 @@ fi
       self.assertTrue(os.path.exists(os.path.join(cache_dir_name, 'asmjs', 'libc.bc')))
     # Exactly one child process should have triggered libc build!
     self.assertEqual(num_times_libc_was_built, 1)
-
-  def test_emcc_cache_flag(self):
-    restore_and_set_up()
-
-    cache_dir_name = self.in_dir('emscripten_cache')
-    self.assertFalse(os.path.exists(cache_dir_name))
-    create_test_file('test.c', r'''
-      #include <stdio.h>
-      int main() {
-        printf("hello, world!\n");
-        return 0;
-      }
-      ''')
-    run_process([PYTHON, EMCC, 'test.c', '--cache', cache_dir_name], stderr=PIPE)
-    # The cache directory must exist after the build
-    self.assertTrue(os.path.exists(cache_dir_name))
-    # The cache directory must contain a built libc'
-    if self.is_wasm_backend():
-      self.assertTrue(os.path.exists(os.path.join(cache_dir_name, 'wasm-obj', 'libc.a')))
-    else:
-      self.assertTrue(os.path.exists(os.path.join(cache_dir_name, 'asmjs', 'libc.bc')))
 
   def test_emconfig(self):
     restore_and_set_up()


### PR DESCRIPTION
As discussed in #11091 it seems pretty safe for remove.  We have `CACHE` config
file setting as well as EM_CACHE environment variable.