### PR TITLE
Allow `emcc -Wl,--version`

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2348,7 +2348,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             log_time('JS symbol generation')
           final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, external_symbol_list=js_funcs)
           # Special handling for when the user passed '-Wl,--version'.  In this case the linker
-          # does not create the output file, but just prints its vesion and exits with 0..
+          # does not create the output file, but just prints its version and exits with 0.
           if '--version' in linker_inputs:
             return 0
         else:

--- a/emcc.py
+++ b/emcc.py
@@ -1180,7 +1180,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     input_files = filter_out_dynamic_libs(input_files)
 
-    if len(input_files) == 0:
+    if not input_files and not link_flags:
       exit_with_error('no input files\nnote that input files without a known suffix are ignored, make sure your input files end with one of: ' + str(SOURCE_ENDINGS + OBJECT_FILE_ENDINGS + DYNAMICLIB_ENDINGS + STATICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS))
 
     # Note the exports the user requested
@@ -2347,6 +2347,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             js_funcs = get_all_js_syms(misc_temp_files)
             log_time('JS symbol generation')
           final = shared.Building.link_lld(linker_inputs, DEFAULT_FINAL, external_symbol_list=js_funcs)
+          # Special handling for when the user passed '-Wl,--version'.  In this case the linker
+          # does not create the output file, but just prints its vesion and exits with 0..
+          if '--version' in linker_inputs:
+            return 0
         else:
           final = shared.Building.link(linker_inputs, DEFAULT_FINAL, force_archive_contents=force_archive_contents, just_calculate=just_calculate)
       else:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10761,3 +10761,8 @@ int main() {
     src = path_from_root('tests', 'other', 'test_export_global_address.c')
     output = path_from_root('tests', 'other', 'test_export_global_address.out')
     self.do_run_from_file(src, output)
+
+  @no_fastcomp('wasm-ld only')
+  def test_linker_version(self):
+    out = run_process([PYTHON, EMCC, '-Wl,--version'], stdout=PIPE).stdout
+    self.assertContained('LLD ', out)


### PR DESCRIPTION
This change firstly allows the linker to run when no input files
are specified but at least one linker flag was specified.

Secondly we specially handle the `--version` linker flag and exit
early without running any post-link steps.

Fixes: #11092