### PR TITLE
Ignore --gc-sections for lld

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -95,9 +95,6 @@ UNSUPPORTED_LLD_FLAGS = {
     # wasm-ld doesn't support soname or other dynamic linking flags (yet).   Ignore them
     # in order to aid build systems that want to pass these flags.
     '-soname': True,
-    # there is no need to specify --gc-sections: we add it automatically when
-    # it is possible, and not when it would be an error
-    '--gc-sections': False,
     '--allow-shlib-undefined',
     '-rpath': True,
     '-rpath-link': True

--- a/emcc.py
+++ b/emcc.py
@@ -95,7 +95,7 @@ UNSUPPORTED_LLD_FLAGS = {
     # wasm-ld doesn't support soname or other dynamic linking flags (yet).   Ignore them
     # in order to aid build systems that want to pass these flags.
     '-soname': True,
-    '--allow-shlib-undefined',
+    '--allow-shlib-undefined': False,
     '-rpath': True,
     '-rpath-link': True
 }

--- a/emcc.py
+++ b/emcc.py
@@ -76,6 +76,7 @@ ASSEMBLY_ENDINGS = ('.ll', '.s')
 HEADER_ENDINGS = ('.h', '.hxx', '.hpp', '.hh', '.H', '.HXX', '.HPP', '.HH')
 WASM_ENDINGS = ('.wasm',)
 
+# Supported LLD flags which we will pass through to the linker.
 SUPPORTED_LINKER_FLAGS = (
     '--start-group', '--end-group',
     '-(', '-)',
@@ -83,7 +84,8 @@ SUPPORTED_LINKER_FLAGS = (
     '-whole-archive', '-no-whole-archive'
 )
 
-# Maps to true if the flag takes an argument
+# Unsupported LLD flags which we will ignore.
+# Maps to true if the flag takes an argument.
 UNSUPPORTED_LLD_FLAGS = {
     # macOS-specific linker flag that libtool (ltmain.sh) will if macOS is detected.
     '-bind_at_load': False,
@@ -93,6 +95,10 @@ UNSUPPORTED_LLD_FLAGS = {
     # wasm-ld doesn't support soname or other dynamic linking flags (yet).   Ignore them
     # in order to aid build systems that want to pass these flags.
     '-soname': True,
+    # there is no need to specify --gc-sections: we add it automatically when
+    # it is possible, and not when it would be an error
+    '--gc-sections': False,
+    '--allow-shlib-undefined',
     '-rpath': True,
     '-rpath-link': True
 }


### PR DESCRIPTION
We apply it ourselves when possible, and we know when it is ok to
do so. If a build system passes it in, it's possible they'd get it wrong
(which happens on LLVM), so just ignore it.

Also ignore `--allow-shlib-undefined` which LLVM passes in - I am
less sure about this one, as it's a weird gnu thing apparently? But
LLVM won't link without ignoring this.