### PR TITLE
Header and stubs for LLVM

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4809,6 +4809,18 @@ LibraryManager.library = {
     err('TODO: Unwind_DeleteException');
   },
 
+  // execinfo.h
+
+  backtrace: function() {
+    abort('TODO: backtrace support');
+  },
+  backtrace_symbols: function() {
+    abort('TODO: backtrace support');
+  },
+  backtrace_symbols_fd: function() {
+    abort('TODO: backtrace support');
+  },
+
   // autodebugging
 
   emscripten_autodebug_i64: function(line, valuel, valueh) {

--- a/system/include/compat/execinfo.h
+++ b/system/include/compat/execinfo.h
@@ -1,0 +1,10 @@
+#ifndef  _COMPAT_EXECINFO_H_
+#define  _COMPAT_EXECINFO_H_
+
+int backtrace(void **buffer, int size);
+
+char **backtrace_symbols(void *const *buffer, int size);
+
+void backtrace_symbols_fd(void *const *buffer, int size, int fd);
+
+#endif  _COMPAT_EXECINFO_H_

--- a/system/include/compat/machine/endian.h
+++ b/system/include/compat/machine/endian.h
@@ -1,0 +1,6 @@
+#ifndef  _COMPAT_ENDIAN_H_
+#define  _COMPAT_ENDIAN_H_
+
+#include <bits/endian.h>
+
+#endif  _COMPAT_ENDIAN_H_


### PR DESCRIPTION
LLVM includes `machine/endian.h` which apparently we need
to redirect to `bits/endian.h`.

Also add `execinfo.h` (also necessary for LLVM) with stubs that
abort, but we could expand them if necessary.