### PR TITLE
When no output suffix is specified assume executable output

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,9 @@ Current Trunk
   environment variable or `--cache` commandline flag.
 - Remove `--cache` command line arg.  The `CACHE` config setting and the
   `EM_CACHE` environment variable can be used to control this.
+- Compiling to a file with no suffix will now generate an executable (JS) rather
+  than an object file.  This means simple cases like `emcc -o foo foo.c` so the
+  expected thing and generate an executable.
 
 1.39.15: 05/06/2020
 -------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,7 +22,7 @@ Current Trunk
 - Remove `--cache` command line arg.  The `CACHE` config setting and the
   `EM_CACHE` environment variable can be used to control this.
 - Compiling to a file with no suffix will now generate an executable (JS) rather
-  than an object file.  This means simple cases like `emcc -o foo foo.c` so the
+  than an object file.  This means simple cases like `emcc -o foo foo.c` do the
   expected thing and generate an executable.
 
 1.39.15: 05/06/2020

--- a/emcc.py
+++ b/emcc.py
@@ -464,6 +464,8 @@ def find_output_arg(args):
       specified_target = arg[2:]
     else:
       outargs.append(arg)
+  if specified_target and specified_target.startswith('-'):
+    exit_with_error('invalid output name: `%s`' % specified_target)
   return specified_target, outargs
 
 

--- a/emcc.py
+++ b/emcc.py
@@ -954,7 +954,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     has_dash_S = '-S' in newargs
     has_dash_E = '-E' in newargs
     link_to_object = False
-    executable_endings = JS_CONTAINING_ENDINGS + ('.wasm',)
     compile_only = has_dash_c or has_dash_S or has_dash_E
 
     def add_link_flag(i, f):
@@ -1091,6 +1090,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if final_suffix == '.mjs':
       shared.Settings.EXPORT_ES6 = 1
       shared.Settings.MODULARIZE = 1
+
+    if final_suffix in ('.mjs', '.js', ''):
       js_target = target
     else:
       js_target = unsuffixed(target) + '.js'
@@ -1306,8 +1307,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
       cflags.append('-DEMSCRIPTEN')
 
+    # Treat the empty extension as an executable, to handle the commond case of `emcc -o foo foo.c`
+    executable_endings = JS_CONTAINING_ENDINGS + WASM_ENDINGS + ('',)
     if not link_to_object and not compile_only and final_suffix not in executable_endings:
-      # TODO(sbc): Remove this emscripten-specific special case.
+      # TODO(sbc): Remove this emscripten-specific special case.  We should only generate object
+      # file output with an explicit `-c` or `-r`.
       diagnostics.warning('emcc', 'Assuming object file output in the absence of `-c`, based on output filename. Add with `-c` or `-r` to avoid this warning')
       link_to_object = True
 

--- a/emcc.py
+++ b/emcc.py
@@ -57,13 +57,15 @@ except ImportError:
 
 logger = logging.getLogger('emcc')
 
+DEV_NULL = '/dev/null' if not WINDOWS else 'NUL'
+
 # endings = dot + a suffix, safe to test by  filename.endswith(endings)
 C_ENDINGS = ('.c', '.i')
 CXX_ENDINGS = ('.cpp', '.cxx', '.cc', '.c++', '.CPP', '.CXX', '.C', '.CC', '.C++', '.ii')
 OBJC_ENDINGS = ('.m', '.mi')
 OBJCXX_ENDINGS = ('.mm', '.mii')
 ASSEMBLY_CPP_ENDINGS = ('.S',)
-SPECIAL_ENDINGLESS_FILENAMES = ('/dev/null' if not WINDOWS else 'NUL',)
+SPECIAL_ENDINGLESS_FILENAMES = (DEV_NULL,)
 
 SOURCE_ENDINGS = C_ENDINGS + CXX_ENDINGS + OBJC_ENDINGS + OBJCXX_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES + ASSEMBLY_CPP_ENDINGS
 C_ENDINGS = C_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES # consider the special endingless filenames like /dev/null to be C
@@ -464,8 +466,6 @@ def find_output_arg(args):
       specified_target = arg[2:]
     else:
       outargs.append(arg)
-  if specified_target and specified_target.startswith('-'):
-    exit_with_error('invalid output name: `%s`' % specified_target)
   return specified_target, outargs
 
 
@@ -2259,6 +2259,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         diagnostics.warning('unused-command-line-argument', "argument unused during compilation: '%s'" % flag[1])
       return 0
 
+    if specified_target and specified_target.startswith('-'):
+      exit_with_error('invalid output filename: `%s`' % specified_target)
+
     using_lld = shared.Settings.WASM_BACKEND and not (link_to_object and shared.Settings.LTO)
     link_flags = filter_link_flags(link_flags, using_lld)
 
@@ -2440,6 +2443,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # exit block 'post-link'
       log_time('post-link')
+
+    if target == DEV_NULL:
+      # TODO(sbc): In theory we should really run the whole pipeline even if the output is
+      # /dev/null, but that will take some refactoring
+      return 0
 
     with ToolchainProfiler.profile_block('emscript'):
       # Emscripten

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -841,6 +841,7 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     return self.assertContained(text1, text2)
 
   def assertContained(self, values, string, additional_info=''):
+    print('assertContained %s %s' % (values, string))
     if type(values) not in [list, tuple]:
       values = [values]
     values = list(map(asstr, values))

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -841,7 +841,6 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     return self.assertContained(text1, text2)
 
   def assertContained(self, values, string, additional_info=''):
-    print('assertContained %s %s' % (values, string))
     if type(values) not in [list, tuple]:
       values = [values]
     values = list(map(asstr, values))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -282,8 +282,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     'cxx': [EMXX, '.cpp']})
   def test_emcc_2(self, compiler, suffix):
     # emcc src.cpp -c    and   emcc src.cpp -o src.[o|bc] ==> should give a .bc file
-    #      regression check: -o js should create "js", with bitcode content
-    for args in [['-c'], ['-o', 'src.o'], ['-o', 'src.bc'], ['-o', 'src.so'], ['-o', 'js'], ['-O1', '-c', '-o', '/dev/null'], ['-O1', '-o', '/dev/null']]:
+    for args in [['-c'], ['-o', 'src.o'], ['-o', 'src.bc'], ['-o', 'src.so'], ['-O1', '-c', '-o', '/dev/null'], ['-O1', '-o', '/dev/null']]:
       print('args:', args)
       if '/dev/null' in args and WINDOWS:
         print('skip because windows')
@@ -295,7 +294,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         print('(no output)')
         continue
       syms = Building.llvm_nm(target)
-      self.assertContained('main', syms.defs)
+      self.assertIn('main', syms.defs)
       if self.is_wasm_backend():
         # wasm backend will also have '__original_main' or such
         self.assertEqual(len(syms.defs), 2)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10474,6 +10474,11 @@ Module.arguments has been replaced with plain arguments_
     self.assertContained('warning: Assuming object file output in the absence of `-c`', err)
     self.assertBinaryEqual('hello1.o', 'hello2.o')
 
+  def test_empty_output_extension(self):
+    # Default to JS output when no extension is present
+    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Werror', '-o', 'hello'])
+    self.assertContained('hello, world!', run_js('hello'))
+
   def test_backwards_deps_in_archive(self):
     # Test that JS dependencies from deps_info.json work for code linked via
     # static archives using -l<name>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10578,9 +10578,15 @@ int main() {
       return shared.Building.is_bitcode('-')
 
   def test_stdout_link(self):
-    # linking to stdout `-` doesn't work, and just produces a file on disk called `-`
-    run_process([PYTHON, EMCC, '-o', '-', path_from_root('tests', 'hello_world.cpp')])
-    self.assertTrue(self.is_object_file('-'))
+    # linking to stdout `-` doesn't work, we have no way to pass such an output filename
+    # through post-link tools such as binaryen.
+    err = self.expect_fail([PYTHON, EMCC, '-o', '-', path_from_root('tests', 'hello_world.cpp')])
+    self.assertContained('invalid output name: `-`', err)
+    self.assertNotExists('-')
+
+    err = self.expect_fail([PYTHON, EMCC, '-o', '-foo', path_from_root('tests', 'hello_world.cpp')])
+    self.assertContained('invalid output name: `-foo`', err)
+    self.assertNotExists('-foo')
 
   def test_output_to_nowhere(self):
     nowhere = 'NULL' if WINDOWS else '/dev/null'

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10581,11 +10581,11 @@ int main() {
     # linking to stdout `-` doesn't work, we have no way to pass such an output filename
     # through post-link tools such as binaryen.
     err = self.expect_fail([PYTHON, EMCC, '-o', '-', path_from_root('tests', 'hello_world.cpp')])
-    self.assertContained('invalid output name: `-`', err)
+    self.assertContained('invalid output filename: `-`', err)
     self.assertNotExists('-')
 
     err = self.expect_fail([PYTHON, EMCC, '-o', '-foo', path_from_root('tests', 'hello_world.cpp')])
-    self.assertContained('invalid output name: `-foo`', err)
+    self.assertContained('invalid output filename: `-foo`', err)
     self.assertNotExists('-foo')
 
   def test_output_to_nowhere(self):


### PR DESCRIPTION
We were previously assembly object file output for simple cases
like `emcc -c foo.c -o foo`.   Previously this would attempt to build
a relocatable object file, now it build a JavaScript executable.

This caused the behavior of `emcc -o -` to change. Previously
we silently accepted this because we could create an object
file called `-`.  However, with this change we try to link `-.wasm`
and passing a filename to binaryen that starts with `-` is not
possible, because it thinks its a option.  This seems like reasonable
behaviour the part of binaryen.  Indeed neither gcc or clang support
compiling files that start with `-`.

```
$ clang -c -- -foo.c
error: unknown argument: '-foo.c'
$ gcc -c  -foo.c
gcc: error: unrecognized command line option ‘-foo.c’
```