### PR TITLE
Fix test_lua to depend on liblua.a

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -665,10 +665,6 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     else:
       # "fast", new path: just call emcc and go straight to JS
       all_files = all_sources + libraries
-      for i in range(len(all_files)):
-        if '.' not in all_files[i]:
-          shutil.move(all_files[i], all_files[i] + '.bc')
-          all_files[i] += '.bc'
       args = [PYTHON, compiler] + self.get_emcc_args(main_file=True) + \
           ['-I' + dirname, '-I' + os.path.join(dirname, 'include')] + \
           ['-I' + include for include in includes] + \
@@ -918,9 +914,10 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
 
     print('<building and saving %s into cache> ' % cache_name, file=sys.stderr)
 
-    return build_library(name, build_dir, output_dir, generated_libs, configure,
+    rtn = build_library(name, build_dir, output_dir, generated_libs, configure,
                          configure_args, make, make_args, self.library_cache,
                          cache_name, env_init=env_init, native=native, cflags=self.get_emcc_args())
+    return rtn
 
   def clear(self):
     for name in os.listdir(self.get_dir()):
@@ -1724,11 +1721,11 @@ def build_library(name,
                   env_init={},
                   native=False,
                   cflags=[]):
-  """Build a library into a .bc file. We build the .bc file once and cache it
-  for all our tests. (We cache in memory since the test directory is destroyed
-  and recreated for each test. Note that we cache separately for different
-  compilers).  This cache is just during the test runner. There is a different
-  concept of caching as well, see |Cache|.
+  """Build a library and cache the result.  We build the library file
+  once and cache it for all our tests. (We cache in memory since the test
+  directory is destroyed and recreated for each test. Note that we cache
+  separately for different compilers).  This cache is just during the test
+  runner. There is a different concept of caching as well, see |Cache|.
   """
 
   if type(generated_libs) is not list:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -914,10 +914,9 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
 
     print('<building and saving %s into cache> ' % cache_name, file=sys.stderr)
 
-    rtn = build_library(name, build_dir, output_dir, generated_libs, configure,
+    return build_library(name, build_dir, output_dir, generated_libs, configure,
                          configure_args, make, make_args, self.library_cache,
                          cache_name, env_init=env_init, native=native, cflags=self.get_emcc_args())
-    return rtn
 
   def clear(self):
     for name in os.listdir(self.get_dir()):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6096,7 +6096,7 @@ return malloc(size);
     self.do_run('',
                 'hello lua world!\n17\n1\n2\n3\n4\n7',
                 args=['-e', '''print("hello lua world!");print(17);for x = 1,4 do print(x) end;print(10-3)'''],
-                libraries=self.get_library(os.path.join('third_party', 'lua'), [os.path.join('src', 'lua'), os.path.join('src', 'liblua.a')], make=['make', 'generic'], configure=None),
+                libraries=self.get_library(os.path.join('third_party', 'lua'), [os.path.join('src', 'lua.o'), os.path.join('src', 'liblua.a')], make=['make', 'generic'], configure=None),
                 includes=[path_from_root('tests', 'lua')],
                 output_nicerizer=lambda string, err: (string + err).replace('\n\n', '\n').replace('\n\n', '\n'))
 


### PR DESCRIPTION
We were previously linking against `lua` which is the fully linked
lua program.  Instead link againt liblua.a and loa.o the main entry
point.

This change is needed before we can land #11108