### PR TITLE
Generate port settings in ports

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1143,6 +1143,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if options.no_entry:
       shared.Settings.EXPORTED_FUNCTIONS.remove('_main')
 
+    # set up the settings for ports (i.e., add USE_ZLIB for the zlib port, etc.
+    # before applying the user settings)
+    system_libs.apply_ports_settings()
+
     # Apply -s settings in newargs here (after optimization levels, so they can override them)
     apply_settings(settings_changes)
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1338,13 +1338,6 @@ var EMIT_EMSCRIPTEN_LICENSE = 0;
 // LEGALIZE_JS_FFI=0 is incompatible with RUNNING_JS_OPTS.
 var LEGALIZE_JS_FFI = 1;
 
-// Ports-related flags.
-
-// Specify the SDL version that is being linked against.
-// 1, the default, is 1.3, which is implemented in JS
-// 2 is a port of the SDL C code on emscripten-ports
-var USE_SDL = 1;
-
 // The list of defines (C_DEFINES) was moved into struct_info.json in the same
 // directory.  That file is automatically parsed by tools/gen_struct_info.py.
 // If you modify the headers, just clear your cache and emscripten libc should

--- a/src/settings.js
+++ b/src/settings.js
@@ -1338,70 +1338,12 @@ var EMIT_EMSCRIPTEN_LICENSE = 0;
 // LEGALIZE_JS_FFI=0 is incompatible with RUNNING_JS_OPTS.
 var LEGALIZE_JS_FFI = 1;
 
-// Ports
+// Ports-related flags.
 
 // Specify the SDL version that is being linked against.
 // 1, the default, is 1.3, which is implemented in JS
 // 2 is a port of the SDL C code on emscripten-ports
 var USE_SDL = 1;
-
-// Specify the SDL_gfx version that is being linked against. Must match USE_SDL
-var USE_SDL_GFX = 0;
-
-// Specify the SDL_image version that is being linked against. Must match USE_SDL
-var USE_SDL_IMAGE = 1;
-
-// Specify the SDL_ttf version that is being linked against. Must match USE_SDL
-var USE_SDL_TTF = 1;
-
-// Specify the SDL_net version that is being linked against. Must match USE_SDL
-var USE_SDL_NET = 1;
-
-// 1 = use icu from emscripten-ports
-var USE_ICU = 0;
-
-// 1 = use zlib from emscripten-ports
-var USE_ZLIB = 0;
-
-// 1 = use bzip2 from emscripten-ports
-var USE_BZIP2 = 0;
-
-// 1 = use libjpeg from emscripten-ports
-var USE_LIBJPEG = 0;
-
-// 1 = use libpng from emscripten-ports
-var USE_LIBPNG = 0;
-
-// 1 = use Regal from emscripten-ports
-var USE_REGAL = 0;
-
-// 1 = use Boost headers from emscripten-ports
-var USE_BOOST_HEADERS = 0;
-
-// 1 = use bullet from emscripten-ports
-var USE_BULLET = 0;
-
-// 1 = use vorbis from emscripten-ports
-var USE_VORBIS = 0;
-
-// 1 = use ogg from emscripten-ports
-var USE_OGG = 0;
-
-// 1 = use freetype from emscripten-ports
-var USE_FREETYPE = 0;
-
-// Specify the SDL_mixer version that is being linked against.
-// Doesn't *have* to match USE_SDL, but a good idea.
-var USE_SDL_MIXER = 1;
-
-// 1 = use harfbuzz from harfbuzz upstream
-var USE_HARFBUZZ = 0;
-
-// 3 = use cocos2d v3 from emscripten-ports
-var USE_COCOS2D = 0;
-
-// Formats to support in SDL2_image. Valid values: bmp, gif, lbm, pcx, png, pnm, tga, xcf, xpm, xv
-var SDL2_IMAGE_FORMATS = [];
 
 // The list of defines (C_DEFINES) was moved into struct_info.json in the same
 // directory.  That file is automatically parsed by tools/gen_struct_info.py.

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -63,3 +63,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'Boost headers v1.70.0 (USE_BOOST_HEADERS=1; Boost license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_BOOST_HEADERS', 0)

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -65,3 +65,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'bullet (USE_BULLET=1; zlib license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_BULLET', 0)

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -61,3 +61,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'bzip2 (USE_BZIP2=1; BSD license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_BZIP2', 0)

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -97,6 +97,10 @@ def show():
   return 'cocos2d'
 
 
+def add_settings(settings):
+  settings.add_new_setting('USE_COCOS2D', 0)
+
+
 def make_source_list(cocos2d_root, cocos2dx_root):
   sources = []
 

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -127,6 +127,10 @@ def show():
   return 'freetype (USE_FREETYPE=1; freetype license)'
 
 
+def add_settings(settings):
+  settings.add_new_setting('USE_FREETYPE', 0)
+
+
 ftconf_h = r'''/***************************************************************************/
 /*                                                                         */
 /*  ftconfig.in                                                            */

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -70,3 +70,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'harfbuzz (USE_HARFBUZZ=1; MIT license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_HARFBUZZ', 0)

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -48,3 +48,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'icu (USE_ICU=1; Unicode License)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_ICU', 0)

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -59,6 +59,10 @@ def show():
   return 'libjpeg (USE_LIBJPEG=1; BSD license)'
 
 
+def add_settings(settings):
+  settings.add_new_setting('USE_LIBJPEG', 0)
+
+
 jconfig_h = '''/* jconfig.h.  Generated from jconfig.cfg by configure.  */
 /* jconfig.cfg --- source file edited by configure script */
 /* see jconfig.txt for explanations */

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -57,6 +57,10 @@ def show():
   return 'libpng (USE_LIBPNG=1; zlib license)'
 
 
+def add_settings(settings):
+  settings.add_new_setting('USE_LIBPNG', 0)
+
+
 pnglibconf_h = r'''/* libpng 1.6.17 STANDARD API DEFINITION */
 
 /* pnglibconf.h - library build configuration */

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -55,6 +55,10 @@ def show():
   return 'ogg (USE_OGG=1; zlib license)'
 
 
+def add_settings(settings):
+  settings.add_new_setting('USE_OGG', 0)
+
+
 config_types_h = '''\
 #ifndef __CONFIG_TYPES_H__
 #define __CONFIG_TYPES_H__

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -157,3 +157,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'regal (USE_REGAL=1; Regal license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_REGAL', 0)

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -103,6 +103,11 @@ def show():
   return 'SDL2 (USE_SDL=2; zlib license)'
 
 
+def add_settings(settings):
+  settings.add_new_setting('USE_SDL', 1)
+  settings.add_new_setting('SDL2_IMAGE_FORMATS', [])
+
+
 sdl_config_h = r'''/* include/SDL_config.h.  Generated from SDL_config.h.in by configure.  */
 /*
   Simple DirectMedia Layer

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -104,8 +104,8 @@ def show():
 
 
 def add_settings(settings):
+  # the default value is to use SDL1; to use the port, set to 2
   settings.add_new_setting('USE_SDL', 1)
-  settings.add_new_setting('SDL2_IMAGE_FORMATS', [])
 
 
 sdl_config_h = r'''/* include/SDL_config.h.  Generated from SDL_config.h.in by configure.  */

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -49,3 +49,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'SDL2_gfx (zlib license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_SDL_GFX', 0)

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -78,3 +78,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'SDL2_image (USE_SDL_IMAGE=2; zlib license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_SDL_MIXER', 1)

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -81,4 +81,8 @@ def show():
 
 
 def add_settings(settings):
+  # the default value is to use SDL1; to use the port, set to 2
+  # this should normally match USE_SDL (i.e., don't mix SDL1 and 2)
   settings.add_new_setting('USE_SDL_IMAGE', 1)
+  # formats to support in SDL2_image. Valid values: bmp, gif, lbm, pcx, png, pnm, tga, xcf, xpm, xv
+  settings.add_new_setting('SDL2_IMAGE_FORMATS', [])

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -81,4 +81,4 @@ def show():
 
 
 def add_settings(settings):
-  settings.add_new_setting('USE_SDL_MIXER', 1)
+  settings.add_new_setting('USE_SDL_IMAGE', 1)

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -64,4 +64,6 @@ def show():
 
 
 def add_settings(settings):
+  # the default value is to use SDL1; to use the port, set to 2
+  # this should normally match USE_SDL (i.e., don't mix SDL1 and 2)
   settings.add_new_setting('USE_SDL_MIXER', 1)

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -61,3 +61,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'SDL2_mixer (USE_SDL_MIXER=2; zlib license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_SDL_MIXER', 1)

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -52,3 +52,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'SDL2_net (zlib license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_SDL_NET', 1)

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -55,4 +55,6 @@ def show():
 
 
 def add_settings(settings):
+  # the default value is to use SDL1; to use the port, set to 2
+  # this should normally match USE_SDL (i.e., don't mix SDL1 and 2)
   settings.add_new_setting('USE_SDL_NET', 1)

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -62,4 +62,6 @@ def show():
 
 
 def add_settings(settings):
+  # the default value is to use SDL1; to use the port, set to 2
+  # this should normally match USE_SDL (i.e., don't mix SDL1 and 2)
   settings.add_new_setting('USE_SDL_TTF', 1)

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -59,3 +59,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'SDL2_ttf (USE_SDL_TTF=2; zlib license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_SDL_TTF', 1)

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -53,3 +53,7 @@ def process_args(ports, args, settings, shared):
 
 def show():
   return 'vorbis (USE_VORBIS=1; zlib license)'
+
+
+def add_settings(settings):
+  settings.add_new_setting('USE_VORBIS', 0)

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -60,6 +60,10 @@ def show():
   return 'zlib (USE_ZLIB=1; zlib license)'
 
 
+def add_settings(settings):
+  settings.add_new_setting('USE_ZLIB', 0)
+
+
 zconf_h = r'''/* zconf.h -- configuration of the zlib compression library
  * Copyright (C) 1995-2013 Jean-loup Gailly.
  * For conditions of distribution and use, see copyright notice in zlib.h

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -944,6 +944,13 @@ class SettingsManager(object):
     def __getitem__(cls, key):
       return cls.attrs[key]
 
+    # Add a new setting and set its value. Normally setting a value will only
+    # work if the setting already exists; this actually adds a new setting.
+    @classmethod
+    def add_new_setting(cls, key, value):
+      assert key not in cls.attrs
+      cls.attrs[key] = value
+
     @classmethod
     def target_environment_may_be(self, environment):
       return self.attrs['ENVIRONMENT'] == '' or environment in self.attrs['ENVIRONMENT'].split(',')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -948,7 +948,7 @@ class SettingsManager(object):
     # work if the setting already exists; this actually adds a new setting.
     @classmethod
     def add_new_setting(cls, key, value):
-      assert key not in cls.attrs
+      assert key not in cls.attrs, key
       cls.attrs[key] = value
 
     @classmethod

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1973,3 +1973,12 @@ def show_ports():
   print('Available ports:')
   for port in ports.ports:
     print('   ', port.show())
+
+
+# each port can add new settings, like USE_ZLIB for zlib. The setting is how
+# a user would ask for the port to be used.
+# a port might have more than one setting, if it has sub-settings that affect
+# how it works.
+def apply_ports_settings():
+  for port in ports.ports:
+    port.add_settings(shared.Settings)


### PR DESCRIPTION
Instead of a port having to modify `settings.js`, give them a hook to
add new settings.

See discussion in #11066 