### PR TITLE
Default to storing emscripten cache locally

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,7 @@ commands:
             # as a "bleeding edge" shell here, basically, with node being the
             # primary shell (which we run without any special flags)
             echo "V8_ENGINE = [os.path.expanduser('~/.jsvu/v8'), '--wasm-staging']" >> ~/.emscripten
+            echo "CACHE = os.path.expanduser('~/cache')" >> ~/.emscripten
             echo "JS_ENGINES = [NODE_JS]" >> ~/.emscripten
             echo "if os.path.exists(V8_ENGINE[0]): JS_ENGINES.append(V8_ENGINE)" >> ~/.emscripten
             echo "WASM_ENGINES = []" >> ~/.emscripten
@@ -59,9 +60,6 @@ commands:
             cd -
             echo "final .emscripten:"
             cat ~/.emscripten
-            # Remove any system libs the emsdk installed: we want to rebuild
-            # them all from source here, to check whether new changes work.
-            rm -Rf ~/.emscripten_cache
       - run:
           name: embuilder build ALL
           command: |
@@ -94,7 +92,7 @@ commands:
           # Must be relative path from root
           paths:
             - emsdk-master/
-            - .emscripten_cache/
+            - cache/
             - .emscripten_ports/
             - .emscripten
             - vms
@@ -314,9 +312,6 @@ jobs:
             cd -
             echo "final .emscripten:"
             cat ~/.emscripten
-            # Remove any system libs the emsdk installed: we want to rebuild
-            # them all from source here, to check whether new changes work.
-            rm -Rf ~/.emscripten_cache
       - run:
           name: embuilder build ALL
           command: |
@@ -333,7 +328,7 @@ jobs:
           # Must be relative path from root
           paths:
             - emsdk-master/
-            - .emscripten_cache/
+            - cache/
             - .emscripten_ports/
             - .emscripten
   build-docs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,8 @@ commands:
             # we are trying to test.
             rm -Rf emscripten
             echo "import os" >> ~/.emscripten
+            # We use an out-of-tree cache directory so it can be part of the
+            # persisted workspace (see below).
             echo "CACHE = os.path.expanduser('~/cache')" >> ~/.emscripten
             # test v8 with --wasm-staging which enables new features. we use v8
             # as a "bleeding edge" shell here, basically, with node being the
@@ -310,6 +312,8 @@ jobs:
             # we are trying to test.
             rm -Rf emscripten
             cd -
+            # We use an out-of-tree cache directory so it can be part of the
+            # persisted workspace (see below).
             echo "import os" >> ~/.emscripten
             echo "CACHE = os.path.expanduser('~/cache')" >> ~/.emscripten
             echo "final .emscripten:"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,11 @@ commands:
             # we are trying to test.
             rm -Rf emscripten
             echo "import os" >> ~/.emscripten
+            echo "CACHE = os.path.expanduser('~/cache')" >> ~/.emscripten
             # test v8 with --wasm-staging which enables new features. we use v8
             # as a "bleeding edge" shell here, basically, with node being the
             # primary shell (which we run without any special flags)
             echo "V8_ENGINE = [os.path.expanduser('~/.jsvu/v8'), '--wasm-staging']" >> ~/.emscripten
-            echo "CACHE = os.path.expanduser('~/cache')" >> ~/.emscripten
             echo "JS_ENGINES = [NODE_JS]" >> ~/.emscripten
             echo "if os.path.exists(V8_ENGINE[0]): JS_ENGINES.append(V8_ENGINE)" >> ~/.emscripten
             echo "WASM_ENGINES = []" >> ~/.emscripten
@@ -310,6 +310,8 @@ jobs:
             # we are trying to test.
             rm -Rf emscripten
             cd -
+            echo "import os" >> ~/.emscripten
+            echo "CACHE = os.path.expanduser('~/cache')" >> ~/.emscripten
             echo "final .emscripten:"
             cat ~/.emscripten
       - run:

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # Compiled python files
 *.pyc
 
+# Default emscripten cache
+/cache
+/cache.lock
+
 # Ignore only the root node_modules, but not any further down the path
 /node_modules/
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,9 @@ Current Trunk
   the operation is in fact only async if it is sent to another thread, while it
   is sync if on the same one. A new `emscripten_dispatch_to_thread_async`
   function is added which is always async.
+- The emscripten cache now lives in a directory called `cache` at the root
+  of the emscripten tree by default.  The `CACHE` config setting and the
+  `EM_CACHE` environment variable can be used to override this (#11126).
 - Honor `CACHE` setting in config file as an alternative to `EM_CACHE`
   environment variable.
 - Remove `--cache` command line arg.  The `CACHE` config setting and the

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3412,7 +3412,7 @@ V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
 JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
 WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
 if not CACHE:
-  CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
+  CACHE = path_from_root('cache')
 
 # Install our replacement Popen handler if we are running on Windows to avoid
 # python spawn process function.


### PR DESCRIPTION
The cache is something that can't really be shared between emscripten
versions.  In fact having a single location for the cache often means
that developers with more then one version of emscripten have the
cache cleared whenever they switch version.

With this method the cache it always local the to emscripten directory.
If distro what to install emscripten in a read-only or shared location
then can still use the CACHE config file setting, or set EM_CACHE
in the environment.

This is part of a wider push to stop using $HOME where we can and
move towards an embedded mode where it makes sense.

See: #9543