### PR TITLE
Handle memory growth in `NODEFS` mmap

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -298,10 +298,15 @@ mergeInto(LibraryManager.library, {
         if (!FS.isFile(stream.node.mode)) {
           throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }
+
+        // malloc() can lead to growing the heap. If targeting the heap, we need to
+        // re-acquire the heap buffer object in case growth had occurred.
+        var fromHeap = (buffer == HEAPU8);
+
         var ptr = _malloc(length);
 
         assert(offset === 0);
-        NODEFS.stream_ops.read(stream, buffer, ptr + offset, length, position);
+        NODEFS.stream_ops.read(stream, fromHeap ? HEAP8 : buffer, ptr + offset, length, position);
         
         return { ptr: ptr, allocated: true };
       },


### PR DESCRIPTION
This is the same as we have in `MEMFS`, but for `NODEFS`: when
we grow, the old buffer would be invalidated, so we have to check
for that. We couldn't find a nicer way there, and I can't think of a better
way now. Luckily this is a rare pattern (pass around a buffer reference
around a malloc).

Found by asan, but this is not an asan bug but due to how much
memory asan needs.