### PR TITLE
Fix the return value of __stdio_seek

### DIFF
--- a/system/lib/libc/musl/src/stdio/__stdio_seek.c
+++ b/system/lib/libc/musl/src/stdio/__stdio_seek.c
@@ -5,6 +5,7 @@ off_t __stdio_seek(FILE *f, off_t off, int whence)
 	off_t ret;
 #ifdef __EMSCRIPTEN__
 	if (__wasi_syscall_ret(__wasi_fd_seek(f->fd, off, whence, &ret)))
+		ret = -1;
 #else
 #ifdef SYS__llseek
 	if (syscall(SYS__llseek, f->fd, off>>32, off, &ret, whence)<0)


### PR DESCRIPTION
The ifdefs here were confusing, and in effect we had
```
#if emscripten
  if (..)
#else
  if (..)
    return -1;
#endif
  return 0;
```
So we ended up with
```
  if (..)
  return 0;
```
and no return otherwise. That can end up with the wrong value
when the seek fails.

Found by asan, but this is not an asan bug but due to how much
memory asan needs - for some reason the bug only occurs on
a failing seek with a large enough address.