### PR TITLE
Support emscripten_console.* logging API in standalone mode

### DIFF
--- a/system/lib/standalone_wasm.c
+++ b/system/lib/standalone_wasm.c
@@ -8,7 +8,6 @@
 #include <assert.h>
 #include <emscripten.h>
 #include <errno.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <time.h>

--- a/system/lib/standalone_wasm_stdio.c
+++ b/system/lib/standalone_wasm_stdio.c
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <emscripten.h>
+#include <stdio.h>
+
+void emscripten_console_log(const char *utf8String) {
+  puts(utf8String);
+}
+
+void emscripten_console_warn(const char *utf8String) {
+  fprintf(stderr, "%s\n", utf8String);
+}
+
+void emscripten_console_error(const char *utf8String) {
+  emscripten_console_warn(utf8String);
+}

--- a/tests/other/standalone_syscalls/test.cpp
+++ b/tests/other/standalone_syscalls/test.cpp
@@ -1,4 +1,5 @@
 #include <assert.h>
+#include <emscripten/html5.h>
 #include <fcntl.h>
 #include <sys/ioctl.h>
 #include <sys/stat.h>
@@ -21,4 +22,10 @@ int main() {
   // write to standard streams works.
   write(1, "hello, world!", 5);
   write(1, "\n", 1);
+  // emscripten_log API works
+  emscripten_console_log("log");
+  // warnings/errors go to stderr, and are not noticed in this test
+  emscripten_console_warn("warn");
+  emscripten_console_error("error");
+  emscripten_console_log("log2");
 }

--- a/tests/other/standalone_syscalls/test.out
+++ b/tests/other/standalone_syscalls/test.out
@@ -1,1 +1,3 @@
 hello
+log
+log2

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10655,7 +10655,7 @@ int main() {
     with open(path_from_root('tests', 'other', 'standalone_syscalls', 'test.out')) as f:
       expected = f.read()
       for engine in WASM_ENGINES:
-        self.assertEqual(run_js('test.wasm', engine), expected)
+        self.assertContained(expected, run_js('test.wasm', engine))
 
   @no_fastcomp('wasm2js only')
   def test_promise_polyfill(self):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1398,7 +1398,7 @@ class libstandalonewasm(MuslInternalLibrary):
   def get_files(self):
     base_files = files_in_path(
         path_components=['system', 'lib'],
-        filenames=['standalone_wasm.c'])
+        filenames=['standalone_wasm.c', 'standalone_wasm_stdio.c'])
     # It is more efficient to use JS methods for time, normally.
     time_files = files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'time'],


### PR DESCRIPTION
Added in a new file, so stdio stuff is only brought in if these
are actually used, and not if any of the main `standalone.c` ones
are used (which they almost always are).