### PR TITLE
Remove memory buffer param from mmap

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- The mmap method of JavaScript filesysem drivers (based on library_fs.js) no
+  longer takes a target memory.  Its safer/cleaner/smaller to assume the target
+  is the global memory buffer.
 
 1.39.16: 05/15/2020
 -------------------

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1225,9 +1225,9 @@ FS.staticInit();` +
       }
       stream.stream_ops.allocate(stream, offset, length);
     },
-    mmap: function(stream, buffer, offset, length, position, prot, flags) {
+    mmap: function(stream, address, length, position, prot, flags) {
 #if CAN_ADDRESS_2GB
-      offset >>>= 0;
+      address >>>= 0;
 #endif
       // User requests writing to file (prot & PROT_WRITE != 0).
       // Checking if we have permissions to write to the file unless
@@ -1246,7 +1246,7 @@ FS.staticInit();` +
       if (!stream.stream_ops.mmap) {
         throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
       }
-      return stream.stream_ops.mmap(stream, buffer, offset, length, position, prot, flags);
+      return stream.stream_ops.mmap(stream, address, length, position, prot, flags);
     },
     msync: function(stream, buffer, offset, length, mmapFlags) {
 #if CAN_ADDRESS_2GB

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -355,6 +355,7 @@ mergeInto(LibraryManager.library, {
         stream.node.usedBytes = Math.max(stream.node.usedBytes, offset + length);
       },
       mmap: function(stream, address, length, position, prot, flags) {
+        // We don't currently support location hints for the address of the mapping
         assert(address === 0);
 
         if (!FS.isFile(stream.node.mode)) {
@@ -364,7 +365,7 @@ mergeInto(LibraryManager.library, {
         var allocated;
         var contents = stream.node.contents;
         // Only make a new copy when MAP_PRIVATE is specified.
-        if ( !(flags & {{{ cDefine('MAP_PRIVATE') }}}) && contents.buffer === HEAP8.buffer ) {
+        if (!(flags & {{{ cDefine('MAP_PRIVATE') }}}) && contents.buffer === buffer) {
           // We can't emulate MAP_SHARED when the file is not backed by the buffer
           // we're mapping to (e.g. the HEAP buffer).
           allocated = false;

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -294,20 +294,16 @@ mergeInto(LibraryManager.library, {
 
         return position;
       },
-      mmap: function(stream, buffer, offset, length, position, prot, flags) {
+      mmap: function(stream, address, length, position, prot, flags) {
+        assert(address === 0);
+
         if (!FS.isFile(stream.node.mode)) {
           throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }
 
-        // malloc() can lead to growing the heap. If targeting the heap, we need to
-        // re-acquire the heap buffer object in case growth had occurred.
-        var fromHeap = (buffer == HEAPU8);
-
         var ptr = _malloc(length);
 
-        assert(offset === 0);
-        NODEFS.stream_ops.read(stream, fromHeap ? HEAP8 : buffer, ptr + offset, length, position);
-        
+        NODEFS.stream_ops.read(stream, HEAP8, ptr, length, position);
         return { ptr: ptr, allocated: true };
       },
       msync: function(stream, buffer, offset, length, mmapFlags) {

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -295,6 +295,7 @@ mergeInto(LibraryManager.library, {
         return position;
       },
       mmap: function(stream, address, length, position, prot, flags) {
+        // We don't currently support location hints for the address of the mapping
         assert(address === 0);
 
         if (!FS.isFile(stream.node.mode)) {

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -249,7 +249,7 @@ var SyscallsLibrary = {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
       var info = FS.getStream(fd);
       if (!info) return -{{{ cDefine('EBADF') }}};
-      var res = FS.mmap(info, HEAPU8, addr, len, off, prot, flags);
+      var res = FS.mmap(info, addr, len, off, prot, flags);
       ptr = res.ptr;
       allocated = res.allocated;
 #else // no filesystem support; report lack of support


### PR DESCRIPTION
mmap always operates on the HEAP8 buffer, so this parameter wasn't
useful as far as I can tell.  It also caused special case handling code
to check for the buffer being HEAP8 (which it always is).