### PR TITLE
Fix CMake compilation for static libraries with IPO (#11143)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -470,3 +470,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * rssqian <rssqian@gmail.com>
 * Shachar Langbeheim <nihohit@gmail.com>
 * David Carlier <devnexen@gmail.com>
+* Paul Du <du.paul136@gmail.com> (copyright owned by ARSKAN)

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -100,6 +100,19 @@ if ("${CMAKE_RANLIB}" STREQUAL "")
   set(CMAKE_RANLIB "${EMSCRIPTEN_ROOT_PATH}/emranlib${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten ranlib")
 endif()
 
+if ("${CMAKE_C_COMPILER_AR}" STREQUAL "")
+  set(CMAKE_C_COMPILER_AR "${CMAKE_AR}" CACHE FILEPATH "Emscripten ar")
+endif()
+if ("${CMAKE_CXX_COMPILER_AR}" STREQUAL "")
+  set(CMAKE_CXX_COMPILER_AR "${CMAKE_AR}" CACHE FILEPATH "Emscripten ar")
+endif()
+if ("${CMAKE_C_COMPILER_RANLIB}" STREQUAL "")
+  set(CMAKE_C_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranlib")
+endif()
+if ("${CMAKE_CXX_COMPILER_RANLIB}" STREQUAL "")
+  set(CMAKE_CXX_COMPILER_RANLIB "${CMAKE_RANLIB}" CACHE FILEPATH "Emscripten ranlib")
+endif()
+
 # Don't allow CMake to autodetect the compiler, since it does not understand
 # Emscripten.
 # Pass -DEMSCRIPTEN_FORCE_COMPILERS=OFF to disable (sensible mostly only for


### PR DESCRIPTION
`CMAKE_INTERPROCEDURAL_OPTIMIZATION` uses `CMAKE_C_COMPILER_AR` and `CMAKE_CXX_COMPILER_AR` instead of `CMAKE_AR` for linking static libraries. It's the same for `RANLIB`.

This PR defines thoses variables to the right emscripten tools instead of CMake default autodetection which points to system llvm tools.