### PR TITLE
Implement emscripten builtin stack functions in assembly

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1430,6 +1430,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
 
     if shared.Settings.WASM_BACKEND:
+      shared.Settings.EXPORTED_FUNCTIONS += ['_stackSave', '_stackRestore', '_stackAlloc']
       # We need to preserve the __data_end symbol so that wasm-emscripten-finalize can determine
       # the STATIC_BUMP value.
       shared.Settings.EXPORTED_FUNCTIONS += ['___data_end']
@@ -2323,8 +2324,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     with ToolchainProfiler.profile_block('calculate system libraries'):
       # link in ports and system libraries, if necessary
-      if not shared.Settings.BOOTSTRAPPING_STRUCT_INFO and \
-         not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
+      if not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
         extra_files_to_link = system_libs.get_ports(shared.Settings)
         if '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
           # TODO(sbc): Only set link_as_cxx if use_cxx

--- a/system/lib/compiler-rt/stack_ops.s
+++ b/system/lib/compiler-rt/stack_ops.s
@@ -1,0 +1,32 @@
+.globl stackSave
+.globl stackRestore
+.globl stackAlloc
+
+.globaltype __stack_pointer, i32
+
+stackSave:
+  .functype stackSave() -> (i32)
+  global.get __stack_pointer
+  end_function
+
+stackRestore:
+  .functype stackRestore(i32) -> ()
+  local.get 0
+  global.set __stack_pointer
+  end_function
+
+stackAlloc:
+  .functype stackAlloc(i32) -> (i32)
+  .local i32, i32
+  global.get __stack_pointer
+  # Get arg 0 -> number of bytes to allocate
+  local.get 0
+  # Stack grows down.  Subtract arg0 from __stack_pointer
+  i32.sub
+  # Align result by anding with ~15
+  i32.const 0xfffffff0
+  i32.and
+  local.tee 1
+  global.set __stack_pointer
+  local.get 1
+  end_function

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -401,7 +401,8 @@ def inspect_code(headers, cpp_opts, structs, defines):
                                                    '-s', 'BOOTSTRAPPING_STRUCT_INFO=1',
                                                    '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0',
                                                    '-s', 'STRICT=1',
-                                                   '-s', 'SINGLE_FILE=1']
+                                                   '-s', 'SINGLE_FILE=1',
+                                                   '-nostdlib', '-lcompiler_rt']
   if not shared.Settings.WASM_BACKEND:
     # Avoid the binaryen dependency if we are only using fastcomp
     cmd += ['-s', 'WASM=0']

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -255,9 +255,6 @@ class Library(object):
   # Set to true to prevent EMCC_FORCE_STDLIBS from linking this library.
   never_force = False
 
-  # The C compile executable to use. You can override this to shared.EMXX for C++.
-  emcc = shared.EMCC
-
   # A list of flags to pass to emcc.
   # The flags for the parent class is automatically inherited.
   cflags = ['-Werror']
@@ -382,7 +379,14 @@ class Library(object):
     cflags = self.get_cflags()
     for src in self.get_files():
       o = self.in_temp(shared.unsuffixed_basename(src) + '.o')
-      commands.append([shared.PYTHON, self.emcc, '-c', src, '-o', o] + cflags)
+      ext = os.path.splitext(src)[1]
+      if ext in ('.s', '.c'):
+        cmd = [shared.PYTHON, shared.EMCC]
+      else:
+        cmd = [shared.PYTHON, shared.EMXX]
+      if ext != '.s':
+        cmd += cflags
+      commands.append(cmd + ['-c', src, '-o', o])
       objects.append(o)
     run_build_commands(commands)
     return objects
@@ -661,10 +665,6 @@ class AsanInstrumentedLibrary(Library):
     return super(AsanInstrumentedLibrary, cls).get_default_variation(is_asan=shared.Settings.USE_ASAN, **kwargs)
 
 
-class CXXLibrary(Library):
-  emcc = shared.EMXX
-
-
 class NoBCLibrary(Library):
   # Some libraries cannot be compiled as .bc files. This is because .bc files will link in every
   # object in the library.  While the optimizer will readily optimize out most of the unused
@@ -688,6 +688,7 @@ class libcompiler_rt(Library):
     filelist = shared.path_from_root('system', 'lib', 'compiler-rt', 'filelist.txt')
     src_files = open(filelist).read().splitlines()
     src_files.append(shared.path_from_root('system', 'lib', 'compiler-rt', 'extras.c'))
+    src_files.append(shared.path_from_root('system', 'lib', 'compiler-rt', 'stack_ops.s'))
   else:
     src_files = ['divdc3.c', 'divsc3.c', 'muldc3.c', 'mulsc3.c']
 
@@ -897,7 +898,7 @@ class libc_extras(NoBCLibrary, MuslInternalLibrary):
     return super(libc_extras, self).can_build() and not shared.Settings.WASM_BACKEND
 
 
-class libcxxabi(CXXLibrary, NoExceptLibrary, MTLibrary):
+class libcxxabi(NoExceptLibrary, MTLibrary):
   name = 'libc++abi'
   cflags = [
       '-Oz',
@@ -950,7 +951,7 @@ class libcxxabi(CXXLibrary, NoExceptLibrary, MTLibrary):
         filenames=filenames)
 
 
-class libcxx(NoBCLibrary, CXXLibrary, NoExceptLibrary, MTLibrary):
+class libcxx(NoBCLibrary, NoExceptLibrary, MTLibrary):
   name = 'libc++'
 
   cflags = ['-DLIBCXX_BUILDING_LIBCXXABI=1', '-D_LIBCPP_BUILDING_LIBRARY', '-Oz',
@@ -998,7 +999,7 @@ class libcxx(NoBCLibrary, CXXLibrary, NoExceptLibrary, MTLibrary):
   ]
 
 
-class libunwind(CXXLibrary, NoExceptLibrary, MTLibrary):
+class libunwind(NoExceptLibrary, MTLibrary):
   name = 'libunwind'
   cflags = ['-Oz', '-D_LIBUNWIND_DISABLE_VISIBILITY_ANNOTATIONS']
   src_dir = ['system', 'lib', 'libunwind', 'src']
@@ -1169,7 +1170,7 @@ class libgl(MTLibrary):
     )
 
 
-class libembind(CXXLibrary):
+class libembind(Library):
   name = 'libembind'
   never_force = True
 
@@ -1201,7 +1202,7 @@ class libembind(CXXLibrary):
     return super(libembind, cls).get_default_variation(with_rtti=shared.Settings.USE_RTTI, **kwargs)
 
 
-class libfetch(CXXLibrary, MTLibrary):
+class libfetch(MTLibrary):
   name = 'libfetch'
   never_force = True
 
@@ -1209,7 +1210,7 @@ class libfetch(CXXLibrary, MTLibrary):
     return [shared.path_from_root('system', 'lib', 'fetch', 'emscripten_fetch.cpp')]
 
 
-class libasmfs(CXXLibrary, MTLibrary):
+class libasmfs(MTLibrary):
   name = 'libasmfs'
   never_force = True
 


### PR DESCRIPTION
Previously these were bring generated by binaryen during
wasm-emscripten-finalize.