### PR TITLE
Only legalize as part of autodebug if we should do so

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1899,7 +1899,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           passes += ['--instrument-locals']
           passes += ['--log-execution']
           passes += ['--instrument-memory']
-          passes += ['--legalize-js-interface']
+          if shared.Settings.LEGALIZE_JS_FFI:
+            # legalize it again now, as the instrumentation may need it
+            passes += ['--legalize-js-interface']
         if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
           # note that this pass must run before asyncify, as if it runs afterwards we only
           # generate the  byn$fpcast_emu  functions after asyncify runs, and so we wouldn't

--- a/emcc.py
+++ b/emcc.py
@@ -1758,6 +1758,18 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         shared.Settings.STANDALONE_WASM = 1
       js_target = misc_temp_files.get(suffix='.js').name
 
+    if shared.Settings.STANDALONE_WASM:
+      if not shared.Settings.WASM_BACKEND:
+        exit_with_error('STANDALONE_WASM is only available in the upstream wasm backend path')
+      if shared.Settings.USE_PTHREADS:
+        exit_with_error('STANDALONE_WASM does not support pthreads yet')
+      # the wasm must be runnable without the JS, so there cannot be anything that
+      # requires JS legalization
+      shared.Settings.LEGALIZE_JS_FFI = 0
+
+    if shared.Settings.WASM_BIGINT:
+      shared.Settings.LEGALIZE_JS_FFI = 0
+
     if shared.Settings.WASM:
       if shared.Settings.SINGLE_FILE:
         # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
@@ -2035,18 +2047,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       cflags.append('-D__EMSCRIPTEN_TRACING__=1')
       if shared.Settings.ALLOW_MEMORY_GROWTH:
         shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
-
-    if shared.Settings.STANDALONE_WASM:
-      if not shared.Settings.WASM_BACKEND:
-        exit_with_error('STANDALONE_WASM is only available in the upstream wasm backend path')
-      if shared.Settings.USE_PTHREADS:
-        exit_with_error('STANDALONE_WASM does not support pthreads yet')
-      # the wasm must be runnable without the JS, so there cannot be anything that
-      # requires JS legalization
-      shared.Settings.LEGALIZE_JS_FFI = 0
-
-    if shared.Settings.WASM_BIGINT:
-      shared.Settings.LEGALIZE_JS_FFI = 0
 
     if shared.Settings.WASM_BACKEND:
       if shared.Settings.SIMD:

--- a/tests/core/test_autodebug.c
+++ b/tests/core/test_autodebug.c
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2020 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdint.h>
+#include <stdio.h>
+
+int main() {
+  // Do some printing, and make sure to use doubles and i64s too, so we test
+  // their logging.
+  double d = printf("some numbers: %d %f\n", 42, 2.18281828);
+  uint64_t j = printf("some  more: %lld %lf\n", 1337, 3.14159);
+  printf("counts: %lld %lf\n", d, j);
+  puts("success");
+  return 0;
+}


### PR DESCRIPTION
Doing so unconditionally breaks standalone + autodebug.

This has to move some `emcc.py` code to decide if we need to legalize
to an earlier place, so we know that when we do the autodebug stuff
as part of the binaryen passes.

`also_with_impure_standalone_wasm` has to use BigInt support
while doing the "impure" part. In that mode we test standalone but
*not* in a wasm vm, rather in a JS VM. So we don't legalize, but we
do connect to JS. Without BigInt, we would trap on i64s.
