### PR TITLE
Ensure that gen_struct_info can be built against compiler-rt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
           command: |
             # We've had issues in the past with building struct info when the
             # cache is completely empty.  So make sure it works.
-            $PYTHON_BIN ./tools/gen_struct_info.py > out.json
+            EMCC_DEBUG=1 $PYTHON_BIN ./tools/gen_struct_info.py > out.json
             $PYTHON_BIN ./emcc.py --clear-cache
       - run:
           name: embuilder build ALL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ commands:
           command: |
             # We've had issues in the past with building struct info when the
             # cache is completely empty.  So make sure it works.
-            EMCC_DEBUG=1 $PYTHON_BIN ./tools/gen_struct_info.py > out.json
+            $PYTHON_BIN ./tools/gen_struct_info.py > out.json
             $PYTHON_BIN ./emcc.py --clear-cache
       - run:
           name: embuilder build ALL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,12 @@ commands:
           name: gen_struct_info
           command: |
             # We've had issues in the past with building struct info when the
-            # cache is completely empty.  So make sure it works.
-            $PYTHON_BIN ./tools/gen_struct_info.py > out.json
+            # cache is completely empty.  So specific test creating struct
+            # info first.
+            # For some reason this seems to deadlock while accessing the
+            # cache direcotry on windows.  Adding EMCC_DEBUG makes it work so
+            # debugging the issue is tricky.
+            [ "CIRCLE_JOB" != "build-upstream-windows" ] && $PYTHON_BIN ./tools/gen_struct_info.py > out.json
             $PYTHON_BIN ./emcc.py --clear-cache
       - run:
           name: embuilder build ALL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,13 @@ commands:
             echo "final .emscripten:"
             cat ~/.emscripten
       - run:
+          name: gen_struct_info
+          command: |
+            # We've had issues in the past with building struct info when the
+            # cache is completely empty.  So make sure it works.
+            $PYTHON_BIN ./tools/gen_struct_info.py > out.json
+            $PYTHON_BIN ./emcc.py --clear-cache
+      - run:
           name: embuilder build ALL
           command: |
             $PYTHON_BIN ./embuilder.py build ALL

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ commands:
             # For some reason this seems to deadlock while accessing the
             # cache direcotry on windows.  Adding EMCC_DEBUG makes it work so
             # debugging the issue is tricky.
-            [ "CIRCLE_JOB" != "build-upstream-windows" ] && $PYTHON_BIN ./tools/gen_struct_info.py > out.json
+            [ "$CIRCLE_JOB" != "build-upstream-windows" ] && $PYTHON_BIN ./tools/gen_struct_info.py > out.json
             $PYTHON_BIN ./emcc.py --clear-cache
       - run:
           name: embuilder build ALL

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -386,10 +386,9 @@ def inspect_code(headers, cpp_opts, structs, defines):
   os.close(js_file[0])
 
   # Remove dangerous env modifications
-  safe_env = os.environ.copy()
-  for opt in ['EMCC_FORCE_STDLIBS', 'EMCC_ONLY_FORCED_STDLIBS']:
-    if opt in safe_env:
-      del safe_env[opt]
+  env = os.environ.copy()
+  env['EMCC_FORCE_STDLIBS'] = 'libcompiler_rt'
+  env['EMCC_ONLY_FORCED_STDLIBS'] = '1'
 
   info = []
   # Compile the program.
@@ -401,8 +400,8 @@ def inspect_code(headers, cpp_opts, structs, defines):
                                                    '-s', 'BOOTSTRAPPING_STRUCT_INFO=1',
                                                    '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0',
                                                    '-s', 'STRICT=1',
-                                                   '-s', 'SINGLE_FILE=1',
-                                                   '-nostdlib', '-lcompiler_rt']
+                                                   '-s', 'SINGLE_FILE=1']
+
   if not shared.Settings.WASM_BACKEND:
     # Avoid the binaryen dependency if we are only using fastcomp
     cmd += ['-s', 'WASM=0']
@@ -411,7 +410,7 @@ def inspect_code(headers, cpp_opts, structs, defines):
 
   show(cmd)
   try:
-    subprocess.check_call(cmd, env=safe_env)
+    subprocess.check_call(cmd, env=env)
   except subprocess.CalledProcessError as e:
     sys.stderr.write('FAIL: Compilation failed!: %s\n' % e.cmd)
     sys.exit(1)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1590,7 +1590,7 @@ def calculate(temp_files, in_temp, cxx, forced, stdout_=None, stderr_=None):
     add_library(system_libs_map[forced])
 
   if only_forced:
-    if shared.Settings.WASM_BACKEND:
+    if shared.Settings.WASM_BACKEND and not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
       add_library(system_libs_map['libc_rt_wasm'])
     add_library(system_libs_map['libcompiler_rt'])
   else:


### PR DESCRIPTION
As part of #11166, the stackAlloc function now lives in compiler-rt
and even the most basic program such as gen_struct_info needs to
be able to call stackAlloc to allocate space for argv.

This change ensure that compiler-rt is built in demand whenever
gen_struct_info is built.

Fixes #11189