### PR TITLE
Fix syscall proxying of _newselect

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -66,11 +66,6 @@ function demangleCSymbolName(f) {
   return f[0] == '_' ? f.substr(1) : '$' + f;
 }
 
-function isJsLibraryConfigIdentifier(ident) {
-  return ident.endsWith('__sig') || ident.endsWith('__proxy') || ident.endsWith('__asm') || ident.endsWith('__inline')
-   || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs') || ident.endsWith('__import');
-}
-
 // JSifier
 function JSify(data, functionsOnly) {
   var mainPass = !functionsOnly;

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1838,12 +1838,8 @@ for (var x in SyscallsLibrary) {
   var wasi = false;
   if (x in WASI_SYSCALLS) {
     wasi = true;
-  } else {
-    // A syscall is __sys_X (but at least one syscall has an extra _ prefix)
-    var match = /^__sys__?[^_]*$/.exec(x);
-    if (!match) {
-      continue;
-    }
+  } else if (!x.startsWith('__sys_') || isJsLibraryConfigIdentifier(x)) {
+    continue;
   }
   var t = SyscallsLibrary[x];
   if (typeof t === 'string') continue;

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1839,7 +1839,8 @@ for (var x in SyscallsLibrary) {
   if (x in WASI_SYSCALLS) {
     wasi = true;
   } else {
-    var match = /^__sys_[^_]*$/.exec(x);
+    // A syscall is __sys_X (but at least one syscall has an extra _ prefix)
+    var match = /^__sys__?[^_]*$/.exec(x);
     if (!match) {
       continue;
     }

--- a/src/utility.js
+++ b/src/utility.js
@@ -213,7 +213,8 @@ function isJsOnlyIdentifier(ident) {
 
 function isJsLibraryConfigIdentifier(ident) {
   return ident.endsWith('__sig') || ident.endsWith('__proxy') || ident.endsWith('__asm') || ident.endsWith('__inline')
-   || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs') || ident.endsWith('__import');
+   || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs') || ident.endsWith('__import')
+   || ident.endsWith('__nothrow');
 }
 
 // Flattens something like [5, 6, 'hi', [1, 'bye'], 44] into

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -170,7 +170,7 @@ class sockets(BrowserCore):
     print('Setting NODE_PATH=' + path_from_root('node_modules'))
     os.environ['NODE_PATH'] = path_from_root('node_modules')
 
-  def test_sockets_echo(self):
+  def test_sockets_echo(self, extra_args=[]):
     sockets_include = '-I' + path_from_root('tests', 'sockets')
 
     # Note: in the WebsockifyServerHarness and CompiledServerHarness tests below, explicitly use consecutive server listen ports,
@@ -193,6 +193,9 @@ class sockets(BrowserCore):
     for harness, datagram in harnesses:
       with harness:
         self.btest(os.path.join('sockets', 'test_sockets_echo_client.c'), expected='0', args=['-DSOCKK=%d' % harness.listen_port, '-DTEST_DGRAM=%d' % datagram, sockets_include])
+
+  def test_sockets_echo_pthreads(self, extra_args=[]):
+    self.test_sockets_echo(['-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
   def test_sdl2_sockets_echo(self):
     harness = CompiledServerHarness('sdl2_net_server.c', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'], 49164)


### PR DESCRIPTION
This does not fully allow this test to run:
```diff
diff --git a/tests/test_sockets.py b/tests/test_sockets.py
index 88f928699..08cd570cd 100644
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -193,6 +193,7 @@ class sockets(BrowserCore):
     for harness, datagram in harnesses:
       with harness:
         self.btest(os.path.join('sockets', 'test_sockets_echo_client.c'), expected='0', args=['-DSOCKK=%d' % harness.listen_port, '-DTEST_DGRAM=%d' % datagram, sockets_include])
+        self.btest(os.path.join('sockets', 'test_sockets_echo_client.c'), expected='0', args=['-DSOCKK=%d' % harness.listen_port, '-DTEST_DGRAM=%d' % datagram, sockets_include, '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
   def test_sdl2_sockets_echo(self):
     harness = CompiledServerHarness('sdl2_net_server.c', ['-s', 'USE_SDL=2', '-s', 'USE_SDL_NET=2'], 49164)
```

Not sure what the other issues are.