### PR TITLE
Use hash to detect if sanity is out-of-date

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -18,7 +18,7 @@ from runner import create_test_file, no_wasm_backend, ensure_dir
 from tools.shared import NODE_JS, PYTHON, EMCC, SPIDERMONKEY_ENGINE, V8_ENGINE
 from tools.shared import CONFIG_FILE, PIPE, STDOUT, EM_CONFIG, LLVM_ROOT, CANONICAL_TEMP_DIR
 from tools.shared import run_process, try_delete, run_js, safe_ensure_dirs
-from tools.shared import expected_llvm_version, generate_sanity, Cache, Settings
+from tools.shared import expected_llvm_version, Cache, Settings
 from tools import jsrun, shared, system_libs
 
 SANITY_FILE = CONFIG_FILE + '_sanity'

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -492,7 +492,6 @@ def check_sanity(force=False):
       return # config stored directly in EM_CONFIG => skip sanity checks
     expected = generate_sanity()
 
-    settings_mtime = os.path.getmtime(CONFIG_FILE)
     sanity_file = CONFIG_FILE + '_sanity'
     if os.path.exists(sanity_file):
       sanity_data = open(sanity_file).read()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -7,6 +7,7 @@ from __future__ import print_function
 
 from subprocess import PIPE, STDOUT
 import atexit
+import binascii
 import base64
 import difflib
 import json
@@ -455,7 +456,7 @@ def generate_sanity():
     config = open(CONFIG_FILE).read()
   else:
     config = EM_CONFIG
-  sanity_file_content += '|%s\n' % hex(abs(hash(config)))
+  sanity_file_content += '|%#x\n' % binascii.crc32(config.encode())
   return sanity_file_content
 
 


### PR DESCRIPTION
We've had issues with using the config file timestamp in the
past and there continues to a race condition here between the
creation of the sanity and update of the config file.

Switch instead to hashing the config and including that in
the sanity data.