### PR TITLE
Get cache lock before trying to empty it in Cache.clean()

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -439,7 +439,11 @@ fi
 
   def erase_cache(self):
     Cache.erase()
-    assert not os.path.exists(Cache.dirname)
+    self.assertCacheEmpty()
+
+  def assertCacheEmpty(self):
+    if os.path.exists(Cache.dirname):
+      self.assertEqual(os.listdir(Cache.dirname), [])
 
   def ensure_cache(self):
     self.do([PYTHON, EMCC, '-O2', path_from_root('tests', 'hello_world.c')])
@@ -473,9 +477,8 @@ fi
     self.assertTrue(os.path.exists(Cache.root_dirname))
     output = self.do([PYTHON, EMCC, '--clear-cache'])
     self.assertIn(ERASING_MESSAGE, output)
-    self.assertFalse(os.path.exists(Cache.dirname))
-    self.assertFalse(os.path.exists(Cache.root_dirname))
     self.assertIn(SANITY_MESSAGE, output)
+    self.assertCacheEmpty()
 
     # Changing LLVM_ROOT, even without altering .emscripten, clears the cache
     self.ensure_cache()
@@ -485,7 +488,7 @@ fi
       self.assertTrue(os.path.exists(Cache.dirname))
       output = self.do([PYTHON, EMCC])
       self.assertIn(ERASING_MESSAGE, output)
-      self.assertFalse(os.path.exists(Cache.dirname))
+      self.assertCacheEmpty()
 
   # FROZEN_CACHE prevents cache clears, and prevents building
   def test_FROZEN_CACHE(self):


### PR DESCRIPTION
The old implementation seemed to be resulting in some deadlock
issues.  With this method we play a little nicer by acquiring the
lock before cleaning the cache and we avoid re-creating the
lock file itself.

The deadlock was visible when running gen_struct_info right after
a new installation on windows (Noticed as part of #11192). This
change fixed the deadlock present in the testing of that PR.