### PR TITLE
Delete EH specification in test_dlmalloc_partial

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5897,6 +5897,9 @@ int main(void) {
 
   @no_asan('asan also changes malloc, and that ends up linking in new twice')
   def test_dlmalloc_partial(self):
+    # Wasm backend warns when exception specifications with types are used, so
+    # suppress it
+    self.emcc_args += ['-Wno-wasm-exception-spec']
     # present part of the symbols of dlmalloc, not all
     src = open(path_from_root('tests', 'new.cpp')).read().replace('{{{ NEW }}}', 'new int').replace('{{{ DELETE }}}', 'delete') + '''
 #include <new>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5897,15 +5897,12 @@ int main(void) {
 
   @no_asan('asan also changes malloc, and that ends up linking in new twice')
   def test_dlmalloc_partial(self):
-    # Wasm backend warns when exception specifications with types are used, so
-    # suppress it
-    self.emcc_args += ['-Wno-wasm-exception-spec']
     # present part of the symbols of dlmalloc, not all
     src = open(path_from_root('tests', 'new.cpp')).read().replace('{{{ NEW }}}', 'new int').replace('{{{ DELETE }}}', 'delete') + '''
 #include <new>
 
 void *
-operator new(size_t size) throw(std::bad_alloc)
+operator new(size_t size)
 {
 printf("new %d!\\n", size);
 return malloc(size);


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/d94bacbcf87a06abc0c1fc3405406399460debc3
emits a warning for exception specification with types, while all tests
are running with `-Werror`. This removes `throw(std::bad_alloc)` from
the function signature to remove the warning. This fixes the current
[waterfall breakage](https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8879843178252913584/+/steps/Emscripten_testsuite__upstream__wasms_/0/stdout).