### PR TITLE
Deprecate passing EM_CONFIG without a file

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -859,6 +859,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # warnings are properly printed during arg parse.
     newargs = diagnostics.capture_warnings(newargs)
 
+    if not shared.CONFIG_FILE:
+      diagnostics.warning('deprected', 'Specifying EM_CONFIG as a python literal is deprected. Please you a file instead.')
+
     for i in range(len(newargs)):
       if newargs[i] in ('-l', '-L', '-I'):
         # Scan for individual -l/-L/-I arguments and concatenate the next arg on

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -412,6 +412,7 @@ fi
     self.assertContained(SANITY_MESSAGE, output)
     self.assertNotContained(SANITY_FAIL_MESSAGE, output)
 
+  def test_emconfig_literal(self):
     # emcc should be configurable directly from EM_CONFIG without any config file
     restore_and_set_up()
     config = open(CONFIG_FILE, 'r').read()
@@ -423,7 +424,6 @@ fi
       }
     ''')
 
-    wipe()
     with env_modify({'EM_CONFIG': config}):
       run_process([PYTHON, EMCC, 'main.cpp', '-o', 'a.out.js'])
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -66,6 +66,7 @@ diagnostics.add_warning('legacy-settings', enabled=False, part_of_all=False)
 diagnostics.add_warning('linkflags')
 diagnostics.add_warning('emcc')
 diagnostics.add_warning('undefined')
+diagnostics.add_warning('deprected')
 diagnostics.add_warning('version-check')
 diagnostics.add_warning('unused-command-line-argument', shared=True)
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -86,6 +86,7 @@ def run_one_command(cmd):
   for opt in ['EMMAKEN_CFLAGS']:
     if opt in safe_env:
       del safe_env[opt]
+  cmd.append('-Wno-deprecated')
   shared.run_process(cmd, stdout=stdout, stderr=stderr, env=safe_env)
 
 


### PR DESCRIPTION
This is feature that I don't think has any users and removing
can simplify out code and testing matrix.

It was originally added back 2012 when it seems that per-project
configuration was a desirable feature:
99c46475c1944c1e62e04f30bd0db3233639515d

I think these days this should not be necessary, and even if it
if we still support `--em-config` on the command line.