### PR TITLE
Remove support for EM_PYTHON environment variable

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3370,7 +3370,7 @@ elif os.path.exists(emsdk_embedded_config):
 else:
   EM_CONFIG = '~/.emscripten'
 
-PYTHON = os.getenv('EM_PYTHON', sys.executable)
+PYTHON = sys.executable
 EMSCRIPTEN_ROOT = __rootpath__
 
 # The following globals can be overridden by the config file.


### PR DESCRIPTION
It doesn't make sense for emscripten to be running under one python
version and then launch sub-processes under a different one.

I had thought that emsdk used this it sets EMSDK_PYTHON which can be
used to launch emscripten, but once launched we want to continue to use
the version of python we started out with.

I first added support for this in #9175 supposedly for the benefit
of #9166, but that change didn't end up using it anyway.