### PR TITLE
Remove asserts for using stack functions too early

### DIFF
--- a/src/support.js
+++ b/src/support.js
@@ -8,24 +8,6 @@
 
 var STACK_ALIGN = {{{ STACK_ALIGN }}};
 
-#if ASSERTIONS
-// stack management, and other functionality that is provided by the compiled code,
-// should not be used before it is ready
-
-#if DECLARE_ASM_MODULE_EXPORTS // These functions should not be defined with 'var' if DECLARE_ASM_MODULE_EXPORTS==0 (or the assignments won't be seen)
-/** @suppress{duplicate} */
-var stackSave;
-/** @suppress{duplicate} */
-var stackRestore;
-/** @suppress{duplicate} */
-var stackAlloc;
-#endif
-
-stackSave = stackRestore = stackAlloc = function() {
-  abort('cannot use the stack before compiled code is ready to run, and has provided stack access');
-};
-#endif
-
 function dynamicAlloc(size) {
 #if ASSERTIONS
   assert(DYNAMICTOP_PTR);


### PR DESCRIPTION
These functions come from within the asm/wasm module these days.
Both in the asmjs case and in the wasm case, both the fastcomp
and llvm backend.

Since they come from the asm module they are already protected by the
same mechanism that protects against calling any native code.  For
example compiling hello.c generates the following snippet when compiling
with assertions:

```
/** @type {function(...*):?} */
var stackAlloc = Module["stackAlloc"] = function() {
  assert(runtimeInitialized, 'you need to wait for the runtime to be ready (e.g. wait for main() to be called)');
  assert(!runtimeExited, 'the runtime was exited (use NO_EXIT_RUNTIME to keep it alive after main() exits)');
  return Module["asm"]["stackAlloc"].apply(null, arguments)
};
```

This also avoids the problem of declaring these as var or not.