### PR TITLE
Fix aliasing-based undefined behavior in string functions.

### DIFF
--- a/system/include/libc/features.h
+++ b/system/include/libc/features.h
@@ -33,4 +33,7 @@
 #define _Noreturn
 #endif
 
+#define weak_alias(old, new) \
+	extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
+
 #endif

--- a/system/lib/libc/README.md
+++ b/system/lib/libc/README.md
@@ -10,3 +10,4 @@ Some changes have been made to the version that was taken from upstream, includi
  * Setting `_POSIX_REALTIME_SIGNALS` and `_POSIX_SPAWN` macros to -1, to exclude unsupported functions.
 
 Backported src/stdio/vswprintf.c from 1.1.23 to fix #9305.
+Backported src/string/{memccpy,memchr,memmove,stpcpy,stpncpy,strchrnul,strlcpy,strlen}.c from 1.2.0 to fix #7279.

--- a/system/lib/libc/musl/src/string/memccpy.c
+++ b/system/lib/libc/musl/src/string/memccpy.c
@@ -11,19 +11,22 @@ void *memccpy(void *restrict dest, const void *restrict src, int c, size_t n)
 {
 	unsigned char *d = dest;
 	const unsigned char *s = src;
-	size_t *wd, k;
-	const size_t *ws;
 
 	c = (unsigned char)c;
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	word *wd;
+	const word *ws;
 	if (((uintptr_t)s & ALIGN) == ((uintptr_t)d & ALIGN)) {
 		for (; ((uintptr_t)s & ALIGN) && n && (*d=*s)!=c; n--, s++, d++);
 		if ((uintptr_t)s & ALIGN) goto tail;
-		k = ONES * c;
+		size_t k = ONES * c;
 		wd=(void *)d; ws=(const void *)s;
 		for (; n>=sizeof(size_t) && !HASZERO(*ws^k);
 		       n-=sizeof(size_t), ws++, wd++) *wd = *ws;
 		d=(void *)wd; s=(const void *)ws;
 	}
+#endif
 	for (; n && (*d=*s)!=c; n--, s++, d++);
 tail:
 	if (*s==c) return d+1;

--- a/system/lib/libc/musl/src/string/memchr.c
+++ b/system/lib/libc/musl/src/string/memchr.c
@@ -12,12 +12,16 @@ void *memchr(const void *src, int c, size_t n)
 {
 	const unsigned char *s = src;
 	c = (unsigned char)c;
+#ifdef __GNUC__
 	for (; ((uintptr_t)s & ALIGN) && n && *s != c; s++, n--);
 	if (n && *s != c) {
-		const size_t *w;
+		typedef size_t __attribute__((__may_alias__)) word;
+		const word *w;
 		size_t k = ONES * c;
 		for (w = (const void *)s; n>=SS && !HASZERO(*w^k); w++, n-=SS);
-		for (s = (const void *)w; n && *s != c; s++, n--);
+		s = (const void *)w;
 	}
+#endif
+	for (; n && *s != c; s++, n--);
 	return n ? (void *)s : 0;
 }

--- a/system/lib/libc/musl/src/string/memmove.c
+++ b/system/lib/libc/musl/src/string/memmove.c
@@ -1,8 +1,10 @@
 #include <string.h>
 #include <stdint.h>
 
-#define WT size_t
+#ifdef __GNUC__
+typedef __attribute__((__may_alias__)) size_t WT;
 #define WS (sizeof(WT))
+#endif
 
 void *memmove(void *dest, const void *src, size_t n)
 {
@@ -10,9 +12,10 @@ void *memmove(void *dest, const void *src, size_t n)
 	const char *s = src;
 
 	if (d==s) return d;
-	if (s+n <= d || d+n <= s) return memcpy(d, s, n);
+	if ((uintptr_t)s-(uintptr_t)d-n <= -2*n) return memcpy(d, s, n);
 
 	if (d<s) {
+#ifdef __GNUC__
 		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
 			while ((uintptr_t)d % WS) {
 				if (!n--) return dest;
@@ -20,8 +23,10 @@ void *memmove(void *dest, const void *src, size_t n)
 			}
 			for (; n>=WS; n-=WS, d+=WS, s+=WS) *(WT *)d = *(WT *)s;
 		}
+#endif
 		for (; n; n--) *d++ = *s++;
 	} else {
+#ifdef __GNUC__
 		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
 			while ((uintptr_t)(d+n) % WS) {
 				if (!n--) return dest;
@@ -29,6 +34,7 @@ void *memmove(void *dest, const void *src, size_t n)
 			}
 			while (n>=WS) n-=WS, *(WT *)(d+n) = *(WT *)(s+n);
 		}
+#endif
 		while (n) n--, d[n] = s[n];
 	}
 

--- a/system/lib/libc/musl/src/string/stpcpy.c
+++ b/system/lib/libc/musl/src/string/stpcpy.c
@@ -1,7 +1,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
-#include "libc.h"
 
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)
@@ -10,9 +9,10 @@
 
 char *__stpcpy(char *restrict d, const char *restrict s)
 {
-	size_t *wd;
-	const size_t *ws;
-
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	word *wd;
+	const word *ws;
 	if ((uintptr_t)s % ALIGN == (uintptr_t)d % ALIGN) {
 		for (; (uintptr_t)s % ALIGN; s++, d++)
 			if (!(*d=*s)) return d;
@@ -20,6 +20,7 @@ char *__stpcpy(char *restrict d, const char *restrict s)
 		for (; !HASZERO(*ws); *wd++ = *ws++);
 		d=(void *)wd; s=(const void *)ws;
 	}
+#endif
 	for (; (*d=*s); s++, d++);
 
 	return d;

--- a/system/lib/libc/musl/src/string/stpncpy.c
+++ b/system/lib/libc/musl/src/string/stpncpy.c
@@ -1,7 +1,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
-#include "libc.h"
 
 #define ALIGN (sizeof(size_t)-1)
 #define ONES ((size_t)-1/UCHAR_MAX)
@@ -10,9 +9,10 @@
 
 char *__stpncpy(char *restrict d, const char *restrict s, size_t n)
 {
-	size_t *wd;
-	const size_t *ws;
-
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	word *wd;
+	const word *ws;
 	if (((uintptr_t)s & ALIGN) == ((uintptr_t)d & ALIGN)) {
 		for (; ((uintptr_t)s & ALIGN) && n && (*d=*s); n--, s++, d++);
 		if (!n || !*s) goto tail;
@@ -21,6 +21,7 @@ char *__stpncpy(char *restrict d, const char *restrict s, size_t n)
 		       n-=sizeof(size_t), ws++, wd++) *wd = *ws;
 		d=(void *)wd; s=(const void *)ws;
 	}
+#endif
 	for (; n && (*d=*s); n--, s++, d++);
 tail:
 	memset(d, 0, n);
@@ -28,4 +29,3 @@ tail:
 }
 
 weak_alias(__stpncpy, stpncpy);
-

--- a/system/lib/libc/musl/src/string/strchrnul.c
+++ b/system/lib/libc/musl/src/string/strchrnul.c
@@ -1,7 +1,6 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
-#include "libc.h"
 
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)
@@ -10,16 +9,19 @@
 
 char *__strchrnul(const char *s, int c)
 {
-	size_t *w, k;
-
 	c = (unsigned char)c;
 	if (!c) return (char *)s + strlen(s);
 
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	const word *w;
 	for (; (uintptr_t)s % ALIGN; s++)
 		if (!*s || *(unsigned char *)s == c) return (char *)s;
-	k = ONES * c;
+	size_t k = ONES * c;
 	for (w = (void *)s; !HASZERO(*w) && !HASZERO(*w^k); w++);
-	for (s = (void *)w; *s && *(unsigned char *)s != c; s++);
+	s = (void *)w;
+#endif
+	for (; *s && *(unsigned char *)s != c; s++);
 	return (char *)s;
 }
 

--- a/system/lib/libc/musl/src/string/strlen.c
+++ b/system/lib/libc/musl/src/string/strlen.c
@@ -10,9 +10,13 @@
 size_t strlen(const char *s)
 {
 	const char *a = s;
-	const size_t *w;
+#ifdef __GNUC__
+	typedef size_t __attribute__((__may_alias__)) word;
+	const word *w;
 	for (; (uintptr_t)s % ALIGN; s++) if (!*s) return s-a;
 	for (w = (const void *)s; !HASZERO(*w); w++);
-	for (s = (const void *)w; *s; s++);
+	s = (const void *)w;
+#endif
+	for (; *s; s++);
 	return s-a;
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19929,
+  "a.html": 19899,
   "a.html.gz": 8344,
-  "total": 19929,
+  "total": 19899,
   "total_gz": 8344
 }


### PR DESCRIPTION
Copies these functions verbatim from musl v1.2.0. #10910  #7279 