### PR TITLE
drop_falsey_fields

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -6,6 +6,10 @@
 
 var LibraryJSEvents = {
   $JSEvents: {
+
+/* We do not depend on the exact initial values of falsey member fields - these fields can be populated on-demand
+   to save code size.
+   (but still documented here to keep track of what is supposed to be present)
     // pointers to structs malloc()ed to Emscripten HEAP for JS->C interop.
     keyEvent: 0,
     mouseEvent: 0,
@@ -31,6 +35,14 @@ var LibraryJSEvents = {
     // When the C runtime exits via exit(), we unregister all event handlers added by this library to be nice and clean.
     // Track in this field whether we have yet registered that __ATEXIT__ handler.
     removeEventListenersRegistered: false, 
+
+#if HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS
+    // If positive, we are currently executing in a JS event handler.
+    inEventHandler: 0,
+    // If we are in an event handler, specifies the event handler object from the eventHandlers array that is currently running.
+    currentEventHandler: null,
+#endif
+*/
 
     removeAllEventListeners: function() {
       for(var i = JSEvents.eventHandlers.length-1; i >= 0; --i) {
@@ -109,11 +121,6 @@ var LibraryJSEvents = {
         call.targetFunction.apply(null, call.argsList);
       }
     },
-
-    // If positive, we are currently executing in a JS event handler.
-    inEventHandler: 0,
-    // If we are in an event handler, specifies the event handler object from the eventHandlers array that is currently running.
-    currentEventHandler: null,
 #endif
 
     // Stores objects representing each currently registered JS event handler.

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -128,10 +128,21 @@ var LibraryGL = {
     debug: true,
 #endif
 
-    counter: 1, // 0 is reserved as 'null' in gl
+/* We do not depend on the exact initial values of falsey member fields - these fields can be populated on-demand
+   to save code size.
+   (but still documented here to keep track of what is supposed to be present)
 #if GL_TRACK_ERRORS
     lastError: 0,
 #endif
+    currentContext: null,
+
+#if FULL_ES2 || LEGACY_GL_EMULATION
+    currArrayBuffer: 0,
+    currElementArrayBuffer: 0,
+#endif
+*/
+
+    counter: 1, // 0 is reserved as 'null' in gl
     buffers: [],
     mappedBuffers: {},
     programs: [],
@@ -146,7 +157,6 @@ var LibraryGL = {
 #else            // without pthreads, it's just an integer ID
     contexts: [],
 #endif
-    currentContext: null,
     offscreenCanvases: {}, // DOM ID -> OffscreenCanvas mappings of <canvas> elements that have their rendering control transferred to offscreen.
     timerQueriesEXT: [],
 #if MAX_WEBGL_VERSION >= 2
@@ -157,8 +167,6 @@ var LibraryGL = {
 #endif
 
 #if FULL_ES2 || LEGACY_GL_EMULATION
-    currArrayBuffer: 0,
-    currElementArrayBuffer: 0,
 
     byteSizeByTypeRoot: 0x1400, // GL_BYTE
     byteSizeByType: [


### PR DESCRIPTION
Member fields that evaluate to falsey values do not need to be initialized, save code size.