### PR TITLE
fastcomp: Always use stack helper functions from library js

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1421,11 +1421,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       link_to_object = True
 
     if shared.Settings.STACK_OVERFLOW_CHECK:
-      if shared.Settings.MINIMAL_RUNTIME:
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$abortStackOverflow']
-        shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
-      else:
-        shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie', 'abortStackOverflow']
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$abortStackOverflow']
+      shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
 
     if shared.Settings.MODULARIZE:
       assert not options.proxy_to_worker, '-s MODULARIZE=1 is not compatible with --proxy-to-worker (if you want to run in a worker with -s MODULARIZE=1, you likely want to do the worker side setup manually)'

--- a/emscripten.py
+++ b/emscripten.py
@@ -497,9 +497,9 @@ def create_global_initializer(initializers):
   if 'globalCtors' not in global_initializer_funcs(initializers):
     return ''
 
-  global_initializer = '''  function globalCtors() {
-    %s
-  }''' % '\n    '.join(i + '();' for i in initializers)
+  global_initializer = '''function globalCtors() {
+  %s
+}''' % '\n    '.join(i + '();' for i in initializers)
 
   return global_initializer
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -170,13 +170,18 @@ def parse_fastcomp_output(backend_output, DEBUG):
   # functions marked llvm.used in the code are exports requested by the user
   shared.Building.user_requested_exports += metadata['exports']
 
-  # In MINIMAL_RUNTIME stackSave() and stackRestore are JS library functions. If LLVM backend generated
+  # stackSave() and stackRestore() are JS library functions. If fastcomp generated
   # calls to invoke_*() functions that save and restore the stack, we must include the stack functions
-  # explicitly into the build. (In traditional runtime the stack functions are always present, so this
-  # tracking is not needed)
-  if shared.Settings.MINIMAL_RUNTIME and (len(metadata['invokeFuncs']) > 0 or shared.Settings.LINKABLE):
-    shared.Settings.EXPORTED_FUNCTIONS += ['stackSave', 'stackRestore']
-    shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$stackSave', '$stackRestore']
+  # explicitly into the build.
+  # In traditional runtime we alwasy require these functions.  For example stackAlloc is used
+  # allocate argv on the stack before calling main>
+  if shared.Settings.MINIMAL_RUNTIME:
+    if len(metadata['invokeFuncs']) > 0 or shared.Settings.LINKABLE:
+      shared.Settings.EXPORTED_FUNCTIONS += ['stackSave', 'stackRestore']
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$stackSave', '$stackRestore']
+  else:
+    shared.Settings.EXPORTED_FUNCTIONS += ['stackSave', 'stackRestore', 'stackAlloc']
+    shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$stackSave', '$stackRestore', '$stackAlloc']
 
   return funcs, metadata, mem_init
 
@@ -948,8 +953,6 @@ def get_exported_implemented_functions(all_exported_functions, all_implemented, 
 
   if shared.Settings.ALLOW_MEMORY_GROWTH:
     funcs.append('_emscripten_replace_memory')
-  if not shared.Settings.SIDE_MODULE and not shared.Settings.MINIMAL_RUNTIME:
-    funcs += ['stackAlloc', 'stackSave', 'stackRestore']
   if shared.Settings.USE_PTHREADS:
     funcs += ['asmJsEstablishStackFrame']
 
@@ -1597,7 +1600,7 @@ def setup_function_pointers(function_table_sigs):
 
 def create_basic_funcs(function_table_sigs, invoke_function_names):
   basic_funcs = shared.Settings.RUNTIME_FUNCS_TO_IMPORT
-  if shared.Settings.STACK_OVERFLOW_CHECK and not shared.Settings.MINIMAL_RUNTIME:
+  if shared.Settings.STACK_OVERFLOW_CHECK and not shared.Settings.MINIMAL_RUNTIME and shared.Settings.SIDE_MODULE:
     basic_funcs += ['abortStackOverflow']
   if shared.Settings.SAFE_HEAP:
     if asm_safe_heap():
@@ -1638,8 +1641,7 @@ def create_basic_vars(exported_implemented_functions, forwarded_json, metadata):
 
 
 def create_exports(exported_implemented_functions, in_table, function_table_data, metadata):
-  asm_runtime_funcs = create_asm_runtime_funcs()
-  all_exported = exported_implemented_functions + asm_runtime_funcs + function_tables(function_table_data)
+  all_exported = exported_implemented_functions + function_tables(function_table_data)
   # In asm.js + emulated function pointers, export all the table because we use
   # JS to add the asm.js module's functions to the table (which is external
   # in this mode). In wasm, we don't need that since wasm modules can
@@ -1662,13 +1664,6 @@ def create_exports(exported_implemented_functions, in_table, function_table_data
     for k, v in metadata['functionPointers'].items():
       exports.append(quote('fp$' + str(k)) + ': ' + str(v))
   return '{ ' + ', '.join(exports) + ' }'
-
-
-def create_asm_runtime_funcs():
-  funcs = []
-  if not (shared.Settings.WASM and shared.Settings.SIDE_MODULE) and not shared.Settings.MINIMAL_RUNTIME:
-    funcs += ['stackAlloc', 'stackSave', 'stackRestore']
-  return funcs
 
 
 def function_tables(function_table_data):
@@ -1834,33 +1829,7 @@ for (var named in NAMED_GLOBALS) {
 
 
 def create_runtime_funcs_asmjs(exports, metadata):
-  if shared.Settings.ASSERTIONS or shared.Settings.STACK_OVERFLOW_CHECK >= 2:
-    stack_check = '  if ((STACKTOP|0) >= (STACK_MAX|0)) abortStackOverflow(size|0);\n'
-  else:
-    stack_check = ''
-
-  funcs = ['''
-function stackAlloc(size) {
-  size = size|0;
-  var ret = 0;
-  ret = STACKTOP;
-  STACKTOP = (STACKTOP + size)|0;
-  STACKTOP = (STACKTOP + 15)&-16;
-  %s
-  return ret|0;
-}
-function stackSave() {
-  return STACKTOP|0;
-}
-function stackRestore(top) {
-  top = top|0;
-  STACKTOP = top;
-}
-''' % stack_check]
-
-  if shared.Settings.MINIMAL_RUNTIME:
-    # MINIMAL_RUNTIME moves stack functions to library.
-    funcs = []
+  funcs = []
 
   if shared.Settings.USE_PTHREADS:
     funcs.append('''

--- a/emscripten.py
+++ b/emscripten.py
@@ -173,8 +173,8 @@ def parse_fastcomp_output(backend_output, DEBUG):
   # stackSave() and stackRestore() are JS library functions. If fastcomp generated
   # calls to invoke_*() functions that save and restore the stack, we must include the stack functions
   # explicitly into the build.
-  # In traditional runtime we alwasy require these functions.  For example stackAlloc is used
-  # allocate argv on the stack before calling main>
+  # In traditional runtime we always require these functions.  For example stackAlloc is used
+  # allocate argv on the stack before calling main.
   if shared.Settings.MINIMAL_RUNTIME:
     if len(metadata['invokeFuncs']) > 0 or shared.Settings.LINKABLE:
       shared.Settings.EXPORTED_FUNCTIONS += ['stackSave', 'stackRestore']

--- a/src/library.js
+++ b/src/library.js
@@ -1346,46 +1346,6 @@ LibraryManager.library = {
     stackRestore(ret);
   },
 
-#if MINIMAL_RUNTIME
-#if WASM_BACKEND == 0
-  $abortStackOverflow__deps: ['$stackSave'],
-#endif
-  $abortStackOverflow__import: true,
-  $abortStackOverflow: function(allocSize) {
-    abort('Stack overflow! Attempted to allocate ' + allocSize + ' bytes on the stack, but stack has only ' + (STACK_MAX - stackSave() + allocSize) + ' bytes available!');
-  },
-
-#if WASM_BACKEND == 0
-  $stackAlloc__asm: true,
-  $stackAlloc__sig: 'ii',
-  $stackAlloc__deps: ['$abortStackOverflow'],
-  $stackAlloc: function(size) {
-    size = size|0;
-    var ret = 0;
-    ret = STACKTOP;
-    STACKTOP = (STACKTOP + size)|0;
-    STACKTOP = (STACKTOP + 15)&-16;
-#if ASSERTIONS || STACK_OVERFLOW_CHECK >= 2
-    if ((STACKTOP|0) >= (STACK_MAX|0)) abortStackOverflow(size|0);
-#endif
-    return ret|0;
-  },
-
-  $stackSave__asm: true,
-  $stackSave__sig: 'i',
-  $stackSave: function() {
-    return STACKTOP|0;
-  },
-
-  $stackRestore__asm: true,
-  $stackRestore__sig: 'vi',
-  $stackRestore: function(top) {
-    top = top|0;
-    STACKTOP = top;
-  },
-#endif
-#endif
-
   llvm_flt_rounds: function() {
     return -1; // 'indeterminable' for FLT_ROUNDS
   },
@@ -2083,7 +2043,7 @@ LibraryManager.library = {
   },
 
   ctime_r__deps: ['localtime_r', 'asctime_r'
-#if MINIMAL_RUNTIME && !WASM_BACKEND
+#if !WASM_BACKEND
     , '$stackSave', '$stackAlloc', '$stackRestore'
 #endif
   ],

--- a/src/library_bootstrap.js
+++ b/src/library_bootstrap.js
@@ -4,11 +4,11 @@
  * SPDX-License-Identifier: MIT
  */
 
-// When bootstrapping struct info, we can't use the full libray because
+// When bootstrapping struct info, we can't use the full library because
 // it itself depends on the struct info information.
 
 #if !BOOTSTRAPPING_STRUCT_INFO
-assert(false)
+assert(false, "library_bootstrap.js only designed for use with BOOTSTRAPPING_STRUCT_INFO")
 #endif
 
 assert(!LibraryManager.library);

--- a/src/library_bootstrap.js
+++ b/src/library_bootstrap.js
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2015 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+// When bootstrapping struct info, we can't use the full libray because
+// it itself depends on the struct info information.
+
+#if !BOOTSTRAPPING_STRUCT_INFO
+assert(false)
+#endif
+
+assert(!LibraryManager.library);
+LibraryManager.library = {};

--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -4,14 +4,6 @@
  * SPDX-License-Identifier: MIT
  */
 
-#if BOOTSTRAPPING_STRUCT_INFO
-// When bootstrapping struct info, this is the entire library.  It is literally
-// just enough to run the bootstrap program that prints out C constants for us,
-// we obviously need to run without any such constants ourselves...
-assert(!LibraryManager.library);
-LibraryManager.library = {};
-#endif
-
 mergeInto(LibraryManager.library, {
   $reallyNegative: function(x) {
     return x < 0 || (x === 0 && (1/x) === -Infinity);

--- a/src/library_stack.js
+++ b/src/library_stack.js
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2015 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+mergeInto(LibraryManager.library, {
+#if WASM_BACKEND == 0
+  $abortStackOverflow__deps: ['$stackSave'],
+#endif
+  $abortStackOverflow__import: true,
+  $abortStackOverflow: function(allocSize) {
+    abort('Stack overflow! Attempted to allocate ' + allocSize + ' bytes on the stack, but stack has only ' + (STACK_MAX - stackSave() + allocSize) + ' bytes available!');
+  },
+
+#if WASM_BACKEND == 0
+  $stackAlloc__asm: true,
+  $stackAlloc__sig: 'ii',
+#if ASSERTIONS || STACK_OVERFLOW_CHECK >= 2
+  $stackAlloc__deps: ['$abortStackOverflow'],
+#endif
+  $stackAlloc: function(size) {
+    size = size|0;
+    var ret = 0;
+    ret = STACKTOP;
+    STACKTOP = (STACKTOP + size)|0;
+    STACKTOP = (STACKTOP + 15)&-16;
+#if ASSERTIONS || STACK_OVERFLOW_CHECK >= 2
+    if ((STACKTOP|0) >= (STACK_MAX|0)) abortStackOverflow(size|0);
+#endif
+    return ret|0;
+  },
+
+  $stackSave__asm: true,
+  $stackSave__sig: 'i',
+  $stackSave: function() {
+    return STACKTOP|0;
+  },
+
+  $stackRestore__asm: true,
+  $stackRestore__sig: 'vi',
+  $stackRestore: function(top) {
+    top = top|0;
+    STACKTOP = top;
+  },
+#endif
+});

--- a/src/modules.js
+++ b/src/modules.js
@@ -62,6 +62,7 @@ var LibraryManager = {
     // Core system libraries (always linked against)
     var libraries = [
       'library.js',
+      'library_stack.js',
       'library_formatString.js',
       'library_math.js',
       'library_path.js',
@@ -161,7 +162,12 @@ var LibraryManager = {
     }
 
     if (BOOTSTRAPPING_STRUCT_INFO) {
-      libraries = ['library_formatString.js', 'library_stack_trace.js'];
+      libraries = [
+        'library_bootstrap.js',
+        'library_stack.js',
+        'library_formatString.js',
+        'library_stack_trace.js'
+      ];
     }
 
     // Deduplicate libraries to avoid processing any library file multiple times
@@ -480,9 +486,6 @@ function exportRuntime() {
   if (STACK_OVERFLOW_CHECK) {
     runtimeElements.push('writeStackCookie');
     runtimeElements.push('checkStackCookie');
-    if (!MINIMAL_RUNTIME) {
-      runtimeElements.push('abortStackOverflow');
-    }
   }
 
   if (USE_PTHREADS) {

--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -42,11 +42,4 @@ function checkStackCookie() {
   if (HEAP32[0] !== 0x63736d65 /* 'emsc' */) abort('Runtime error: The application has corrupted its heap memory area (address zero)!');
 #endif
 }
-
-#if !MINIMAL_RUNTIME // MINIMAL_RUNTIME moves this to a JS library function
-function abortStackOverflow(allocSize) {
-  abort('Stack overflow! Attempted to allocate ' + allocSize + ' bytes on the stack, but stack has only ' + (STACK_MAX - stackSave() + allocSize) + ' bytes available!');
-}
-#endif
-
 #endif

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5636,38 +5636,46 @@ Descriptor desc;
     assert ' = f0;' in src or ' = f0,' in src
 
   @no_wasm_backend('depends on merging asmjs')
-  def test_merge_pair(self):
-    def test(filename, full):
-      print('----', filename, full)
-      run_process([PYTHON, EMCC, path_from_root('tests', filename), '-O1', '-profiling', '-o', 'left.js', '-s', 'WASM=0'])
-      src = open('left.js').read()
-      create_test_file('right.js', src.replace('function _main() {', 'function _main() { out("replaced"); '))
+  @parameterized({
+    '': (['hello_world.cpp', True]),
+    'full': (['hello_libcxx.cpp', False]),
+  })
+  def test_merge_pair(self, filename, full):
+    run_process([PYTHON, EMCC, path_from_root('tests', filename), '-O1', '-profiling', '-o', 'left.js', '-s', 'WASM=0'])
+    src = open('left.js').read()
+    create_test_file('right.js', src.replace('function _main() {', 'function _main() { out("replaced"); '))
 
-      self.assertContained('hello, world!', run_js('left.js'))
-      self.assertContained('hello, world!', run_js('right.js'))
-      self.assertNotContained('replaced', run_js('left.js'))
-      self.assertContained('replaced', run_js('right.js'))
+    self.assertContained('hello, world!', run_js('left.js'))
+    self.assertContained('hello, world!', run_js('right.js'))
+    self.assertNotContained('replaced', run_js('left.js'))
+    self.assertContained('replaced', run_js('right.js'))
 
-      n = src.count('function _')
+    n = src.count('function _')
 
-      def has(i):
-        run_process([PYTHON, path_from_root('tools', 'merge_pair.py'), 'left.js', 'right.js', str(i), 'out.js'])
-        return 'replaced' in run_js('out.js')
+    def has(i, check=None):
+      print('merge_pair.py : %d' % i)
+      run_process([PYTHON, path_from_root('tools', 'merge_pair.py'), 'left.js', 'right.js', str(i), 'out.js'])
+      out = run_js('out.js')
+      if check is True:
+        self.assertContained('replaced', out)
+      if check is False:
+        self.assertNotContained('replaced', out)
+      return 'replaced' in run_js('out.js')
 
-      assert not has(0), 'same as left'
-      assert has(n), 'same as right'
-      assert has(n + 5), 'same as right, big number is still ok'
+    # same as left
+    has(0, check=False)
+    # same as right
+    has(n, check=True)
+    # same as right, big number is still ok
+    has(n + 5, check=True)
 
-      if full:
-        change = -1
-        for i in range(n):
-          if has(i):
-            change = i
-            break
-        assert change > 0 and change <= n
-
-    test('hello_world.cpp', True)
-    test('hello_libcxx.cpp', False)
+    if full:
+      change = -1
+      for i in range(n):
+        if has(i):
+          change = i
+          break
+      assert change > 0 and change <= n
 
   def test_emmake_emconfigure(self):
     def check(what, args, fail=True, expect=''):


### PR DESCRIPTION
Previously we only did this for MIMIMAL_RUNTIME.  This change
unifies around this approach to avoid having two different ways of
doing things.