### PR TITLE
Fix broken promise when loading wasm from array buffer

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -473,3 +473,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * David Carlier <devnexen@gmail.com>
 * Paul Du <du.paul136@gmail.com> (copyright owned by ARSKAN)
 * Piotr Doan <doanpiotr@gmail.com>
+* Stuart Schechter <stuart.schechter@gmail.com>

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1040,7 +1040,7 @@ function createWasm() {
             // in which case falling back to ArrayBuffer instantiation should work.
             err('wasm streaming compile failed: ' + reason);
             err('falling back to ArrayBuffer instantiation');
-            instantiateArrayBuffer(receiveInstantiatedSource);
+            return instantiateArrayBuffer(receiveInstantiatedSource);
           });
       });
     } else {


### PR DESCRIPTION
When  loading wasm from an array buffer, then() was being called BEFORE the module was fully loaded.

I traced the error back to this line, where there's a missing return.  With the return, the result will be a promise that resolves AFTER the module is instantiated.  Without that return statement, then() may be called prematurely, as the promise returned is for the completion of this function without awaiting the instantiation. 

For those curious, to reproduce this bug, I was compiling with these options and running on node 10.  However, it's hard to reproduce precisely because it's a race condition.
```
    -s MODULARIZE=1
    -s ASSERTIONS=2
    -s WASM_MEM_MAX=4GB
    -s ALLOW_MEMORY_GROWTH=1
    -s SINGLE_FILE=1
    -g4
```