### PR TITLE
Remove unneeded --minify 0 in a test

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7834,7 +7834,6 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('ASYNCIFY', 1)
     self.set_setting('ASYNCIFY_IMPORTS', ['suspend'])
     self.set_setting('ASSERTIONS', 1)
-    self.emcc_args += ['--minify', '0']
     self.do_run_in_out_file_test('tests', 'core', 'asyncify_assertions')
 
   @no_asan('asyncify stack operations confuse asan')


### PR DESCRIPTION
This was added in #11048 but I think it was just for debugging?