### PR TITLE
Better errors for incorrect Module.* setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,7 @@ Current Trunk
 - Remove emterpreter and ``EMTERPRETIFY`` settings.  Emterpreter has largely
   been replaced by asyncify and is fastcomp only so due for removing in
   the near future anyway.
+- Upgrade various musl string functions to 1.2 to fix aliasing issues. (#11215)
 
 1.39.16: 05/15/2020
 -------------------
@@ -459,6 +460,12 @@ v1.38.41: 08/07/2019
    print for parse error reporting. (#9088)
  - Internal API update: one can now specialize embind's (un)marshalling for a
    group of types via SFINAE, instead of a single type. (#9089)
+ - Options passed on the `Module` object during startup, like `Module.arguments`,
+   are now copied to a local (in order to avoid writing `Module.*` everywhere,
+   which wastes space). You can still provide them as always, but you can't
+   modify `Module.arguments` and other things *after* startup (which is now
+   after we've finished processing them). In a build with assertions enabled you
+   will get an error if you access those properties after startup. (#9072)
 
 v1.38.40: 07/24/2019
 --------------------

--- a/site/source/docs/api_reference/module.rst
+++ b/site/source/docs/api_reference/module.rst
@@ -8,6 +8,11 @@ Module object
 
 Developers can provide an implementation of ``Module`` to control the execution of code. For example, to define how notification messages from Emscripten are displayed, developers implement the :js:attr:`Module.print` attribute.
 
+When an Emscripten application starts up it looks at the values on the ``Module``
+object and applies them. Note that changing the values *after* startup will not
+work in general; in a build with ``ASSERTIONS`` enabled you will get an error
+in that case.
+
 .. note:: ``Module`` is also used to provide access to Emscripten API functions (for example :js:func:`ccall`) in a safe way. Any function or runtime method exported (using ``EXPORTED_FUNCTIONS`` for compiled functions, or ``EXTRA_EXPORTED_RUNTIME_METHODS`` for runtime methods like ``ccall``) will be accessible on the ``Module`` object, without minification changing the name, and the optimizer will make sure to keep the function present (and not remove it as unused). See the :ref:`relevant FAQ entry<faq-export-stuff>`.
 
 .. contents:: Table of Contents

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1603,7 +1603,7 @@ function expectToReceiveOnModule(name) {
 function makeRemovedModuleAPIAssert(moduleName, localName) {
   if (!ASSERTIONS) return '';
   if (!localName) localName = moduleName;
-  return "if (!Object.getOwnPropertyDescriptor(Module, '" + moduleName + "')) Object.defineProperty(Module, '" + moduleName + "', { configurable: true, get: function() { abort('Module." + moduleName + " has been replaced with plain " + localName + "') } });";
+  return "if (!Object.getOwnPropertyDescriptor(Module, '" + moduleName + "')) Object.defineProperty(Module, '" + moduleName + "', { configurable: true, get: function() { abort('Module." + moduleName + " has been replaced with plain " + localName + " (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)') } });";
 }
 
 // Make code to receive a value on the incoming Module object.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9967,9 +9967,9 @@ int main(void) {
     ''')
     run_process([PYTHON, EMCC, 'src.cpp', '-s', 'ASSERTIONS'])
     self.assertContained('''
-Module.read has been replaced with plain read_
-Module.wasmBinary has been replaced with plain wasmBinary
-Module.arguments has been replaced with plain arguments_
+Module.read has been replaced with plain read_ (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)
+Module.wasmBinary has been replaced with plain wasmBinary (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)
+Module.arguments has been replaced with plain arguments_ (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)
 ''', run_js('a.out.js', assert_returncode=None, stderr=PIPE))
 
   def test_assertions_on_ready_promise(self):


### PR DESCRIPTION
We look at `Module.arguments` etc. during startup, and setting values
later is not guaranteed to work; an error is thrown in an assertions
build to help avoid confusion. This improves that error and adds more
docs.

helps #11239