### PR TITLE
By default, store ports inside the cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,6 @@ commands:
           paths:
             - emsdk-master/
             - cache/
-            - .emscripten_ports/
             - .emscripten
             - vms
             - .jsvu
@@ -345,7 +344,6 @@ jobs:
           paths:
             - emsdk-master/
             - cache/
-            - .emscripten_ports/
             - .emscripten
   build-docs:
     executor: bionic

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,11 +17,18 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- Removed obsolete SIMD.js support (-s SIMD=1). Use -msimd128 to target Wasm SIMD. (#11180)
+- The default location for downloaded ports is now a directory called "ports"
+  within the cache directory.  In practice these means by default they live
+  in `cache/ports` inside the emscripten source directory.  This can be
+  controlled by setting the location of the cache directory, or for even more
+  fine grained control the `EM_PORTS` environment variable and the `PORTS`
+  config setting can be used.
+- Removed obsolete SIMD.js support (-s SIMD=1). Use -msimd128 to target Wasm
+  SIMD. (#11180)
 - The mmap method of JavaScript filesystem drivers (based on library_fs.js) no
   longer takes a target memory.  It's safer/cleaner/smaller to assume the target
   is the global memory buffer.
-- Remove emterpreter and ``EMTERPRETIFY`` settings.  Emterpreter has largely
+- Remove emterpreter and `EMTERPRETIFY` settings.  Emterpreter has largely
   been replaced by asyncify and is fastcomp only so due for removing in
   the near future anyway.
 - Upgrade various musl string functions to 1.2 to fix aliasing issues. (#11215)

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -444,6 +444,9 @@ Options that are modified or new in *emcc* are listed below:
    failing to link with library files. This also clears other cached
    data. After the cache is cleared, this process will exit.
 
+   By default this will also clear any download ports since the ports
+   directory is usually within the cache directory.
+
 "--clear-ports"
    Manually clears the local copies of ports from the Emscripten Ports
    repos (sdl2, etc.). This also clears the cache, to remove their

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -357,16 +357,28 @@ Options that are modified or new in *emcc* are listed below:
 .. _emcc-clear-cache:
 
 ``--clear-cache``
-  Manually clears the cache of compiled Emscripten system libraries (libc++, libc++abi, libc).
+  Manually clears the cache of compiled Emscripten system libraries (libc++,
+  libc++abi, libc).
 
-  This is normally handled automatically, but if you update LLVM in-place (instead of having a different directory for a new version), the caching mechanism can get confused. Clearing the cache can fix weird problems related to cache incompatibilities, like *Clang* failing to link with library files. This also clears other cached data. After the cache is cleared, this process will exit.
+  This is normally handled automatically, but if you update LLVM in-place
+  (instead of having a different directory for a new version), the caching
+  mechanism can get confused. Clearing the cache can fix weird problems related
+  to cache incompatibilities, like *Clang* failing to link with library files.
+  This also clears other cached data. After the cache is cleared, this process
+  will exit.
+
+  By default this will also clear any download ports since the ports directory
+  is usually within the cache directory.
 
 .. _emcc-clear-ports:
 
 ``--clear-ports``
-  Manually clears the local copies of ports from the Emscripten Ports repos (sdl2, etc.). This also clears the cache, to remove their builds.
+  Manually clears the local copies of ports from the Emscripten Ports repos
+  (sdl2, etc.). This also clears the cache, to remove their builds.
 
-  You should only need to do this if a problem happens and you want all ports that you use to be downloaded and built from scratch. After this operation is complete, this process will exit.
+  You should only need to do this if a problem happens and you want all ports
+  that you use to be downloaded and built from scratch. After this operation is
+  complete, this process will exit.
 
 .. _emcc-show-ports:
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -285,6 +285,7 @@ def parse_config_file():
     'WASM_ENGINES',
     'FROZEN_CACHE',
     'CACHE',
+    'PORTS',
   )
 
   # Only propagate certain settings from the config file.
@@ -3377,6 +3378,7 @@ WASMER = None
 WASMTIME = None
 WASM_ENGINES = []
 CACHE = None
+PORTS = None
 FROZEN_CACHE = False
 
 # Emscripten compiler spawns other processes, which can reimport shared.py, so
@@ -3402,6 +3404,8 @@ JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
 WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
 if not CACHE:
   CACHE = path_from_root('cache')
+if not PORTS:
+  PORTS = os.path.join(CACHE, 'ports')
 
 # Install our replacement Popen handler if we are running on Windows to avoid
 # python spawn process function.

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1796,7 +1796,7 @@ class Ports(object):
 
   @staticmethod
   def get_dir():
-    dirname = os.environ.get('EM_PORTS') or os.path.expanduser(os.path.join('~', '.emscripten_ports'))
+    dirname = shared.PORTS
     shared.safe_ensure_dirs(dirname)
     return dirname
 


### PR DESCRIPTION
This means we no longer default to `~/.emscripten_ports` and ports
now live in the cache by default.

This also means that `--clear-ports` is less meaningful since
`--clear-cache` normally handles that already.

Also enable `PORTS` to be set in the config file as well as the
existing `EM_PORTS` enviroment variable.  This mirrors recent changes
to `CACHE/EM_CACHE` handling.

This is part of move away from using $HOME by default.  In particular
I think this means the emsdk users who use --embedded will have nothing
added to their $HOME directory.

See #9543