### PR TITLE
Fix minification of wasm2js output when using --emit-symbol-map

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3309,7 +3309,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
                                       opt_level=shared.Settings.OPT_LEVEL,
                                       minify_whitespace=optimizer.minify_whitespace,
                                       use_closure_compiler=options.use_closure_compiler,
-                                      debug_info=intermediate_debug_info,
+                                      debug_info=debug_info,
                                       symbols_file=symbols_file)
     if shared.Settings.WASM == 2:
       shutil.copyfile(wasm2js, wasm2js_template)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3975,8 +3975,8 @@ EM_ASM({ _middle() });
           wat = run_process([os.path.join(Building.get_binaryen_bin(), 'wasm-dis'), 'a.out.wasm'], stdout=PIPE).stdout
           for func_start in ('(func $middle', '(func $_middle'):
             self.assertNotContained(func_start, wat)
-        # check we don't minify unnecessarily with wasm2js when emitting a
-        # symbol map
+        # check we don't keep unnecessary debug info with wasm2js when emitting
+        # a symbol map
         if self.is_wasm_backend() and wasm == 0 and '-O' in str(opts):
           with open('a.out.js') as f:
             js = f.read()


### PR DESCRIPTION
We avoided minification of function names and other global things when
we needed intermediate debug info, but that was wrong, wasm2js is a
final emitting step and should only care about if there is final debug info
(where there is not with a symbol map).

Makes hello world 10% smaller and hello world libc++ 60% smaller
(since the names there are very big!)

fixes #11273