### PR TITLE
Warn on STANDALONE_WASM without WASM_BIGINT in JS

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -548,3 +548,7 @@ var workerResponded = false, workerCallbackId = -1;
 })();
 
 #endif
+
+#if STANDALONE_WASM && ASSERTIONS && !WASM_BIGINT
+err('warning: running JS from STANDALONE_WASM without WASM_BIGINT will fail if a syscall with i64 is used (in standalone mode we cannot legalize syscalls)');
+#endif

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -422,9 +422,9 @@ if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') 
 
 #include "runtime_sab_polyfill.js"
 
-// In standalone mode, the wasm creates the memory, and the user can't provide it.
 #if STANDALONE_WASM
 #if ASSERTIONS
+// In standalone mode, the wasm creates the memory, and the user can't provide it.
 assert(!Module['wasmMemory']);
 #endif // ASSERTIONS
 #else // !STANDALONE_WASM


### PR DESCRIPTION
Followup to #11254