### PR TITLE
Re-enable tests

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 5073,
-  "a.js.gz": 2423,
-  "a.wasm": 10912,
-  "a.wasm.gz": 6940,
-  "total": 16549,
-  "total_gz": 9740
+  "a.js": 5068,
+  "a.js.gz": 2422,
+  "a.wasm": 10935,
+  "a.wasm.gz": 6954,
+  "total": 16571,
+  "total_gz": 9753
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23705,
-  "a.js.gz": 8895,
+  "a.js": 23742,
+  "a.js.gz": 8902,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 27462,
-  "total_gz": 11992
+  "total": 27498,
+  "total_gz": 11999
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 4558,
-  "a.js.gz": 2247,
-  "a.wasm": 10912,
-  "a.wasm.gz": 6940,
-  "total": 16034,
-  "total_gz": 9564
+  "a.js": 4553,
+  "a.js.gz": 2244,
+  "a.wasm": 10935,
+  "a.wasm.gz": 6954,
+  "total": 16056,
+  "total_gz": 9575
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23195,
-  "a.js.gz": 8733,
+  "a.js": 23232,
+  "a.js.gz": 8739,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 26952,
-  "total_gz": 11830
+  "total": 26988,
+  "total_gz": 11836
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13724,
-  "a.html.gz": 7322,
-  "total": 13724,
-  "total_gz": 7322
+  "a.html": 13800,
+  "a.html.gz": 7422,
+  "total": 13800,
+  "total_gz": 7422
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19899,
-  "a.html.gz": 8344,
-  "total": 19899,
-  "total_gz": 8344
+  "a.html": 19982,
+  "a.html.gz": 8376,
+  "total": 19982,
+  "total_gz": 8376
 }

--- a/tests/other/metadce/hello_libcxx_O2.funcs
+++ b/tests/other/metadce/hello_libcxx_O2.funcs
@@ -476,7 +476,6 @@ $std::__2::ctype<wchar_t>\20const&\20std::__2::use_facet<std::__2::ctype<wchar_t
 $std::__2::enable_if<\28\28std::__2::integral_constant<bool\2c\20false>::value\29\20||\20\28!\28__has_construct<std::__2::__sso_allocator<std::__2::locale::facet*\2c\2028ul>\2c\20bool*\2c\20bool>::value\29\29\29\20&&\20\28is_trivially_move_constructible<bool>::value\29\2c\20void>::type\20std::__2::allocator_traits<std::__2::__sso_allocator<std::__2::locale::facet*\2c\2028ul>\20>::__construct_backward_with_exception_guarantees<std::__2::locale::facet*>\28std::__2::__sso_allocator<std::__2::locale::facet*\2c\2028ul>&\2c\20bool*\2c\20bool*\2c\20bool*&\29
 $std::__2::enable_if<\28is_move_constructible<char>::value\29\20&&\20\28is_move_assignable<char>::value\29\2c\20void>::type\20std::__2::swap<char>\28char&\2c\20char&\29
 $std::__2::enable_if<\28is_move_constructible<unsigned\20int>::value\29\20&&\20\28is_move_assignable<unsigned\20int>::value\29\2c\20void>::type\20std::__2::swap<unsigned\20int>\28unsigned\20int&\2c\20unsigned\20int&\29
-$std::__2::enable_if<\28is_same<std::__2::remove_const<wchar_t\20const>::type\2c\20wchar_t>::value\29\20&&\20\28is_trivially_copy_assignable<wchar_t>::value\29\2c\20wchar_t*>::type\20std::__2::__copy<wchar_t\20const\2c\20wchar_t>\28wchar_t\20const*\2c\20wchar_t\20const*\2c\20wchar_t*\29
 $std::__2::enable_if<__is_cpp17_forward_iterator<char\20const*>::value\2c\20void>::type\20std::__2::basic_string<char\2c\20std::__2::char_traits<char>\2c\20std::__2::allocator<char>\20>::__init<char\20const*>\28char\20const*\2c\20char\20const*\29
 $std::__2::enable_if<__is_cpp17_forward_iterator<wchar_t\20const*>::value\2c\20void>::type\20std::__2::basic_string<wchar_t\2c\20std::__2::char_traits<wchar_t>\2c\20std::__2::allocator<wchar_t>\20>::__init<wchar_t\20const*>\28wchar_t\20const*\2c\20wchar_t\20const*\29
 $std::__2::enable_if<is_trivially_copy_assignable<char>::value\2c\20char\20const*>::type\20std::__2::__unwrap_iter<char>\28std::__2::__wrap_iter<char\20const*>\29
@@ -743,7 +742,6 @@ $void\20std::__2::reverse<char*>\28char*\2c\20char*\29
 $void\20std::__2::reverse<wchar_t*>\28wchar_t*\2c\20wchar_t*\29
 $vsnprintf
 $vsscanf
-$wchar_t*\20std::__2::copy<std::__2::__wrap_iter<wchar_t\20const*>\2c\20wchar_t*>\28std::__2::__wrap_iter<wchar_t\20const*>\2c\20std::__2::__wrap_iter<wchar_t\20const*>\2c\20wchar_t*\29
 $wchar_t\20const*\20std::__2::__num_get<wchar_t>::__do_widen_p<wchar_t>\28std::__2::ios_base&\2c\20wchar_t*\29\20const
 $wchar_t\20const*\20std::__2::find<wchar_t\20const*\2c\20wchar_t>\28wchar_t\20const*\2c\20wchar_t\20const*\2c\20wchar_t\20const&\29
 $wcrtomb

--- a/tests/other/metadce/hello_libcxx_O2_fexceptions.funcs
+++ b/tests/other/metadce/hello_libcxx_O2_fexceptions.funcs
@@ -553,7 +553,6 @@ $std::__2::enable_if<\28__is_cpp17_forward_iterator<char*>::value\29\20&&\20\28_
 $std::__2::enable_if<\28__is_cpp17_forward_iterator<wchar_t*>::value\29\20&&\20\28__libcpp_string_gets_noexcept_iterator<wchar_t*>::value\29\2c\20std::__2::basic_string<wchar_t\2c\20std::__2::char_traits<wchar_t>\2c\20std::__2::allocator<wchar_t>\20>&>::type\20std::__2::basic_string<wchar_t\2c\20std::__2::char_traits<wchar_t>\2c\20std::__2::allocator<wchar_t>\20>::append<wchar_t*>\28wchar_t*\2c\20wchar_t*\29
 $std::__2::enable_if<\28is_move_constructible<char>::value\29\20&&\20\28is_move_assignable<char>::value\29\2c\20void>::type\20std::__2::swap<char>\28char&\2c\20char&\29
 $std::__2::enable_if<\28is_move_constructible<unsigned\20int>::value\29\20&&\20\28is_move_assignable<unsigned\20int>::value\29\2c\20void>::type\20std::__2::swap<unsigned\20int>\28unsigned\20int&\2c\20unsigned\20int&\29
-$std::__2::enable_if<\28is_same<std::__2::remove_const<wchar_t\20const>::type\2c\20wchar_t>::value\29\20&&\20\28is_trivially_copy_assignable<wchar_t>::value\29\2c\20wchar_t*>::type\20std::__2::__copy<wchar_t\20const\2c\20wchar_t>\28wchar_t\20const*\2c\20wchar_t\20const*\2c\20wchar_t*\29
 $std::__2::enable_if<__is_cpp17_forward_iterator<char\20const*>::value\2c\20void>::type\20std::__2::basic_string<char\2c\20std::__2::char_traits<char>\2c\20std::__2::allocator<char>\20>::__init<char\20const*>\28char\20const*\2c\20char\20const*\29
 $std::__2::enable_if<__is_cpp17_forward_iterator<wchar_t\20const*>::value\2c\20void>::type\20std::__2::basic_string<wchar_t\2c\20std::__2::char_traits<wchar_t>\2c\20std::__2::allocator<wchar_t>\20>::__init<wchar_t\20const*>\28wchar_t\20const*\2c\20wchar_t\20const*\29
 $std::__2::enable_if<is_trivially_copy_assignable<char>::value\2c\20char\20const*>::type\20std::__2::__unwrap_iter<char>\28std::__2::__wrap_iter<char\20const*>\29
@@ -917,7 +916,6 @@ $void\20std::__2::reverse<char*>\28char*\2c\20char*\29
 $void\20std::__2::reverse<wchar_t*>\28wchar_t*\2c\20wchar_t*\29
 $vsnprintf
 $vsscanf
-$wchar_t*\20std::__2::copy<std::__2::__wrap_iter<wchar_t\20const*>\2c\20wchar_t*>\28std::__2::__wrap_iter<wchar_t\20const*>\2c\20std::__2::__wrap_iter<wchar_t\20const*>\2c\20wchar_t*\29
 $wchar_t\20const*\20std::__2::__num_get<wchar_t>::__do_widen_p<wchar_t>\28std::__2::ios_base&\2c\20wchar_t*\29\20const
 $wchar_t\20const*\20std::__2::find<wchar_t\20const*\2c\20wchar_t>\28wchar_t\20const*\2c\20wchar_t\20const*\2c\20wchar_t\20const&\29
 $wcrtomb

--- a/tests/other/metadce/hello_libcxx_O2_fexceptions_DEMANGLE_SUPPORT.funcs
+++ b/tests/other/metadce/hello_libcxx_O2_fexceptions_DEMANGLE_SUPPORT.funcs
@@ -911,7 +911,6 @@ $std::__2::enable_if<\28__is_cpp17_forward_iterator<wchar_t*>::value\29\20&&\20\
 $std::__2::enable_if<\28is_move_constructible<\28anonymous\20namespace\29::itanium_demangle::Node*>::value\29\20&&\20\28is_move_assignable<\28anonymous\20namespace\29::itanium_demangle::Node*>::value\29\2c\20void>::type\20std::__2::swap<\28anonymous\20namespace\29::itanium_demangle::Node*>\28\28anonymous\20namespace\29::itanium_demangle::Node*&\2c\20\28anonymous\20namespace\29::itanium_demangle::Node*&\29
 $std::__2::enable_if<\28is_move_constructible<char>::value\29\20&&\20\28is_move_assignable<char>::value\29\2c\20void>::type\20std::__2::swap<char>\28char&\2c\20char&\29
 $std::__2::enable_if<\28is_move_constructible<unsigned\20int>::value\29\20&&\20\28is_move_assignable<unsigned\20int>::value\29\2c\20void>::type\20std::__2::swap<unsigned\20int>\28unsigned\20int&\2c\20unsigned\20int&\29
-$std::__2::enable_if<\28is_same<std::__2::remove_const<wchar_t\20const>::type\2c\20wchar_t>::value\29\20&&\20\28is_trivially_copy_assignable<wchar_t>::value\29\2c\20wchar_t*>::type\20std::__2::__copy<wchar_t\20const\2c\20wchar_t>\28wchar_t\20const*\2c\20wchar_t\20const*\2c\20wchar_t*\29
 $std::__2::enable_if<__is_cpp17_forward_iterator<char\20const*>::value\2c\20void>::type\20std::__2::basic_string<char\2c\20std::__2::char_traits<char>\2c\20std::__2::allocator<char>\20>::__init<char\20const*>\28char\20const*\2c\20char\20const*\29
 $std::__2::enable_if<__is_cpp17_forward_iterator<wchar_t\20const*>::value\2c\20void>::type\20std::__2::basic_string<wchar_t\2c\20std::__2::char_traits<wchar_t>\2c\20std::__2::allocator<wchar_t>\20>::__init<wchar_t\20const*>\28wchar_t\20const*\2c\20wchar_t\20const*\29
 $std::__2::enable_if<is_trivially_copy_assignable<char>::value\2c\20char\20const*>::type\20std::__2::__unwrap_iter<char>\28std::__2::__wrap_iter<char\20const*>\29
@@ -1275,7 +1274,6 @@ $void\20std::__2::reverse<char*>\28char*\2c\20char*\29
 $void\20std::__2::reverse<wchar_t*>\28wchar_t*\2c\20wchar_t*\29
 $vsnprintf
 $vsscanf
-$wchar_t*\20std::__2::copy<std::__2::__wrap_iter<wchar_t\20const*>\2c\20wchar_t*>\28std::__2::__wrap_iter<wchar_t\20const*>\2c\20std::__2::__wrap_iter<wchar_t\20const*>\2c\20wchar_t*\29
 $wchar_t\20const*\20std::__2::__num_get<wchar_t>::__do_widen_p<wchar_t>\28std::__2::ios_base&\2c\20wchar_t*\29\20const
 $wchar_t\20const*\20std::__2::find<wchar_t\20const*\2c\20wchar_t>\28wchar_t\20const*\2c\20wchar_t\20const*\2c\20wchar_t\20const&\29
 $wcrtomb

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7855,8 +7855,7 @@ int main() {
     self.run_metadce_test('minimal.c', *args)
 
   @parameterized({
-    # 'noexcept' disabled to allow LLVM to roll
-    # 'noexcept': (['-O2'],                    [], ['waka'], 218988), # noqa
+    'noexcept': (['-O2'],                    [], ['waka'], 218988), # noqa
     # exceptions increases code size significantly
     'except':   (['-O2', '-fexceptions'],    [], ['waka'], 279827), # noqa
     # exceptions does not pull in demangling by default, which increases code size
@@ -9274,7 +9273,6 @@ int main () {
         test(['-s', 'WASM=0'], closure, opt)
         test(['-s', 'WASM=1', '-s', 'WASM_ASYNC_COMPILATION=0'], closure, opt)
 
-  @unittest.skip("Disabled to allow LLVM to roll")
   def test_minimal_runtime_code_size(self):
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'AGGRESSIVE_VARIABLE_ELIMINATION=1',

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7855,7 +7855,8 @@ int main() {
     self.run_metadce_test('minimal.c', *args)
 
   @parameterized({
-    'noexcept': (['-O2'],                    [], ['waka'], 218988), # noqa
+    # 'noexcept' disabled to allow LLVM to roll
+    # 'noexcept': (['-O2'],                    [], ['waka'], 218988), # noqa
     # exceptions increases code size significantly
     'except':   (['-O2', '-fexceptions'],    [], ['waka'], 279827), # noqa
     # exceptions does not pull in demangling by default, which increases code size
@@ -7863,7 +7864,6 @@ int main() {
                   '-s', 'DEMANGLE_SUPPORT'], [], ['waka'], 408028), # noqa
   })
   @no_fastcomp()
-  @unittest.skip("Temporarily disabled to allow LLVM to roll")
   def test_metadce_cxx(self, *args):
     self.run_metadce_test('hello_libcxx.cpp', *args)
 


### PR DESCRIPTION
These tests were disabled to allow LLVM to roll. The code size increases were introduced in https://github.com/llvm/llvm-project/commit/6438ea45e053378a3c461a879805174eaa864bdb, and it doesn't look like there is much to be done about that.