### PR TITLE
Factor out compiler commands in test_other.py

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: tests/runner.py other')
 
 from tools.shared import Building, PIPE, run_js, run_process, STDOUT, try_delete, listify
-from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS, LLVM_ROOT, EMCONFIG, EM_BUILD_VERBOSE
+from tools.shared import EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS, LLVM_ROOT, EMCONFIG, EM_BUILD_VERBOSE
 from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP
 from tools.shared import NODE_JS, SPIDERMONKEY_ENGINE, JS_ENGINES, WASM_ENGINES, V8_ENGINE
 from runner import RunnerCore, path_from_root, no_wasm_backend, no_fastcomp, is_slow_test, ensure_dir
@@ -157,13 +157,21 @@ def parse_wasm(filename):
 
 
 class other(RunnerCore):
+  # Define the compiler command in a single location.  This allows is to add flags, etc, that
+  # effect all tests.
+  # TODO(sbc): In future integrate with RunnerCore emcc_args and settings system.
+  # TODO(sbc): Use emcc (the sheell script) and emcc.bat rather than assuming emcc.py is a
+  # python script.
+  emcc = [PYTHON, shared.EMCC]
+  emxx = [PYTHON, shared.EMXX]
+
   # Utility to run a simple test in this suite. This receives a directory which
   # should contain a test.cpp and test.out files, compiles the cpp, and runs it
   # to verify the output, with optional compile and run arguments.
   # TODO: use in more places
   def do_other_test(self, dirname, emcc_args=[], run_args=[]):
     shutil.copyfile(path_from_root('tests', dirname, 'test.cpp'), 'test.cpp')
-    run_process([PYTHON, EMCC, 'test.cpp'] + emcc_args)
+    run_process(self.emcc + ['test.cpp'] + emcc_args)
     expected = open(path_from_root('tests', dirname, 'test.out')).read()
     seen = run_js('a.out.js', args=run_args, stderr=PIPE, full_output=True) + '\n'
     self.assertContained(expected, seen)
@@ -174,7 +182,7 @@ class other(RunnerCore):
   # of regexes match. The return code can also be checked.
   def do_smart_test(self, source, literals=[], regexes=[],
                     emcc_args=[], run_args=[], assert_returncode=0):
-    run_process([PYTHON, EMCC, source] + emcc_args)
+    run_process(self.emcc + [source] + emcc_args)
     seen = run_js('a.out.js', args=run_args, stderr=PIPE, full_output=True,
                   assert_returncode=assert_returncode) + '\n'
 
@@ -202,18 +210,18 @@ class other(RunnerCore):
       os.close(slave)
 
   def test_emcc_v(self):
-    for compiler in [EMCC, EMXX]:
+    for compiler in [self.emcc, self.emxx]:
       # -v, without input files
-      proc = run_process([PYTHON, compiler, '-v'], stdout=PIPE, stderr=PIPE)
+      proc = run_process(compiler + ['-v'], stdout=PIPE, stderr=PIPE)
       self.assertContained('clang version %s' % shared.expected_llvm_version(), proc.stderr)
       self.assertContained('GNU', proc.stderr)
       self.assertNotContained('this is dangerous', proc.stdout)
       self.assertNotContained('this is dangerous', proc.stderr)
 
   def test_emcc_generate_config(self):
-    for compiler in [EMCC, EMXX]:
+    for compiler in [self.emcc, self.emxx]:
       config_path = './emscripten_config'
-      run_process([PYTHON, compiler, '--generate-config', config_path])
+      run_process(compiler + ['--generate-config', config_path])
       self.assertExists(config_path, 'A config file should have been created at %s' % config_path)
       config_contents = open(config_path).read()
       self.assertContained('EMSCRIPTEN_ROOT', config_contents)
@@ -221,7 +229,7 @@ class other(RunnerCore):
       os.remove(config_path)
 
   def test_emcc_output_mjs(self):
-    run_process([PYTHON, EMCC, '-o', 'hello_world.mjs', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-o', 'hello_world.mjs', path_from_root('tests', 'hello_world.c')])
     with open('hello_world.mjs') as f:
       output = f.read()
     self.assertContained('export default Module;', output)
@@ -231,23 +239,23 @@ class other(RunnerCore):
 
   def test_emcc_out_file(self):
     # Verify that "-ofile" works in addition to "-o" "file"
-    run_process([PYTHON, EMCC, '-c', '-ofoo.o', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-c', '-ofoo.o', path_from_root('tests', 'hello_world.c')])
     self.assertExists('foo.o')
-    run_process([PYTHON, EMCC, '-ofoo.js', 'foo.o'])
+    run_process(self.emcc + ['-ofoo.js', 'foo.o'])
     self.assertExists('foo.js')
 
   @parameterized({
-    'c': [EMCC, '.c'],
-    'cxx': [EMXX, '.cpp']})
+    'c': [self.emcc, '.c'],
+    'cxx': [self.emxx, '.cpp']})
   def test_emcc_basics(self, compiler, suffix):
     # emcc src.cpp ==> writes a.out.js and a.out.wasm
-    run_process([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix)])
+    run_process(compiler + [path_from_root('tests', 'hello_world' + suffix)])
     self.assertExists('a.out.js')
     self.assertExists('a.out.wasm')
     self.assertContained('hello, world!', run_js('a.out.js'))
 
     # --version
-    output = run_process([PYTHON, compiler, '--version'], stdout=PIPE, stderr=PIPE)
+    output = run_process(compiler + ['--version'], stdout=PIPE, stderr=PIPE)
     output = output.stdout.replace('\r', '')
     self.assertContained('emcc (Emscripten gcc/clang-like replacement)', output)
     self.assertContained('''Copyright (C) 2014 the Emscripten authors (see AUTHORS.txt)
@@ -256,21 +264,21 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 ''', output)
 
     # --help
-    output = run_process([PYTHON, compiler, '--help'], stdout=PIPE, stderr=PIPE)
+    output = run_process(compiler + ['--help'], stdout=PIPE, stderr=PIPE)
     self.assertContained('Display this information', output.stdout)
     self.assertContained('Most clang options will work', output.stdout)
 
     # -dumpmachine
-    output = run_process([PYTHON, compiler, '-dumpmachine'], stdout=PIPE, stderr=PIPE)
+    output = run_process(compiler + ['-dumpmachine'], stdout=PIPE, stderr=PIPE)
     self.assertContained(shared.get_llvm_target(), output.stdout)
 
     # -dumpversion
-    output = run_process([PYTHON, compiler, '-dumpversion'], stdout=PIPE, stderr=PIPE)
+    output = run_process(compiler + ['-dumpversion'], stdout=PIPE, stderr=PIPE)
     self.assertEqual(shared.EMSCRIPTEN_VERSION, output.stdout.strip())
 
     # properly report source code errors, and stop there
     self.clear()
-    stderr = self.expect_fail([PYTHON, compiler, path_from_root('tests', 'hello_world_error' + suffix)])
+    stderr = self.expect_fail(compiler + [path_from_root('tests', 'hello_world_error' + suffix)])
     self.assertNotContained('IOError', stderr) # no python stack
     self.assertNotContained('Traceback', stderr) # no python stack
     self.assertContained('error: invalid preprocessing directive', stderr)
@@ -278,8 +286,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     self.assertContained('errors generated.', stderr.splitlines()[-2])
 
   @parameterized({
-    'c': [EMCC, '.c'],
-    'cxx': [EMXX, '.cpp']})
+    'c': [self.emcc, '.c'],
+    'cxx': [self.emxx, '.cpp']})
   def test_emcc_2(self, compiler, suffix):
     # emcc src.cpp -c    and   emcc src.cpp -o src.[o|bc] ==> should give a .bc file
     for args in [['-c'], ['-o', 'src.o'], ['-o', 'src.bc'], ['-o', 'src.so'], ['-O1', '-c', '-o', '/dev/null'], ['-O1', '-o', '/dev/null']]:
@@ -289,7 +297,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         continue
       target = args[1] if len(args) == 2 else 'hello_world.o'
       self.clear()
-      run_process([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix)] + args)
+      run_process(compiler + [path_from_root('tests', 'hello_world' + suffix)] + args)
       if args[-1] == '/dev/null':
         print('(no output)')
         continue
@@ -303,23 +311,23 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if target == 'js': # make sure emcc can recognize the target as a bitcode file
         shutil.move(target, target + '.bc')
         target += '.bc'
-      run_process([PYTHON, compiler, target, '-o', target + '.js'])
+      run_process(compiler + [target, '-o', target + '.js'])
       self.assertContained('hello, world!', run_js(target + '.js'))
 
   @parameterized({
-    'c': [EMCC, '.c'],
-    'cxx': [EMXX, '.cpp']})
+    'c': [self.emcc, '.c'],
+    'cxx': [self.emxx, '.cpp']})
   def test_emcc_3(self, compiler, suffix):
     # handle singleton archives
-    run_process([PYTHON, compiler, '-c', path_from_root('tests', 'hello_world' + suffix), '-o', 'a.o'])
+    run_process(compiler + ['-c', path_from_root('tests', 'hello_world' + suffix), '-o', 'a.o'])
     run_process([LLVM_AR, 'r', 'a.a', 'a.o'], stdout=PIPE, stderr=PIPE)
-    run_process([PYTHON, compiler, 'a.a'])
+    run_process(compiler + ['a.a'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
     if not self.is_wasm_backend():
       # emcc src.ll ==> generates .js
       self.clear()
-      run_process([PYTHON, compiler, path_from_root('tests', 'hello_world.ll')])
+      run_process(compiler + [path_from_root('tests', 'hello_world.ll')])
       self.assertContained('hello, world!', run_js('a.out.js'))
 
     # emcc [..] -o [path] ==> should work with absolute paths
@@ -331,7 +339,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       ensure_dir(os.path.join('a_dir', 'b_dir'))
       os.chdir('a_dir')
       # use single file so we don't have more files to clean up
-      run_process([PYTHON, compiler, path_from_root('tests', 'hello_world' + suffix), '-o', path, '-s', 'SINGLE_FILE=1'])
+      run_process(compiler + [path_from_root('tests', 'hello_world' + suffix), '-o', path, '-s', 'SINGLE_FILE=1'])
       last = os.getcwd()
       os.chdir(os.path.dirname(path))
       self.assertContained('hello, world!', run_js(os.path.basename(path)))
@@ -339,8 +347,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       try_delete(path)
 
   @parameterized({
-    'c': [EMCC],
-    'cxx': [EMXX]})
+    'c': [self.emcc],
+    'cxx': [self.emxx]})
   def test_emcc_4(self, compiler):
     # Optimization: emcc src.cpp -o something.js [-Ox]. -O0 is the same as not specifying any optimization setting
     for params, opt_level, bc_params, closure, has_malloc in [ # bc params are used after compiling to bitcode
@@ -381,13 +389,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       print(params, opt_level, bc_params, closure, has_malloc)
       self.clear()
       keep_debug = '-g' in params
-      args = [PYTHON, compiler, path_from_root('tests', 'hello_world_loop' + ('_malloc' if has_malloc else '') + '.cpp')] + params
+      args = compiler + [path_from_root('tests', 'hello_world_loop' + ('_malloc' if has_malloc else '') + '.cpp')] + params
       print('..', args)
       output = run_process(args, stdout=PIPE, stderr=PIPE)
       assert len(output.stdout) == 0, output.stdout
       if bc_params is not None:
         self.assertExists('something.bc', output.stderr)
-        bc_args = [PYTHON, compiler, 'something.bc', '-o', 'something.js'] + bc_params
+        bc_args = compiler + ['something.bc', '-o', 'something.js'] + bc_params
         print('....', bc_args)
         output = run_process(bc_args, stdout=PIPE, stderr=PIPE)
       self.assertExists('something.js', output.stderr)
@@ -424,8 +432,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   @no_wasm_backend('tests for asmjs optimzer')
   @parameterized({
-    'c': [EMCC],
-    'cxx': [EMXX]})
+    'c': [self.emcc],
+    'cxx': [self.emxx]})
   def test_emcc_5(self, compiler):
     # asm.js optimization levels
     for params, test, text in [
@@ -457,13 +465,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     ]:
       print(params, text)
       self.clear()
-      run_process([PYTHON, compiler, path_from_root('tests', 'hello_world_loop.cpp'), '-o', 'a.out.js', '-s', 'WASM=0'] + params)
+      run_process(compiler + [path_from_root('tests', 'hello_world_loop.cpp'), '-o', 'a.out.js', '-s', 'WASM=0'] + params)
       self.assertContained('hello, world!', run_js('a.out.js'))
       assert test(open('a.out.js').read()), text
 
   def test_multiple_sources(self):
     # Compiling two sources at a time should work.
-    cmd = [PYTHON, EMCC, '-c', path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.cpp')]
+    cmd = self.emcc + ['-c', path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.cpp')]
     run_process(cmd)
 
     # Object files should be generated by default in the current working
@@ -485,22 +493,22 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   def test_combining_object_files(self):
     # Compiling two files with -c will generate separate object files
-    run_process([PYTHON, EMCC, path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.cpp'), '-c'])
+    run_process(self.emcc + [path_from_root('tests', 'twopart_main.cpp'), path_from_root('tests', 'twopart_side.cpp'), '-c'])
     self.assertExists('twopart_main.o')
     self.assertExists('twopart_side.o')
 
     # Linking with just one of them is expected to fail
-    err = self.expect_fail([PYTHON, EMCC, 'twopart_main.o'])
+    err = self.expect_fail(self.emcc + ['twopart_main.o'])
     self.assertContained('undefined symbol: _Z7theFuncPKc', err)
 
     # Linking with both should work
-    run_process([PYTHON, EMCC, 'twopart_main.o', 'twopart_side.o'])
+    run_process(self.emcc + ['twopart_main.o', 'twopart_side.o'])
     self.assertContained('side got: hello from main, over', run_js('a.out.js'))
 
     # Combining object files into another object should also work, using the `-r` flag
-    run_process([PYTHON, EMCC, '-r', 'twopart_main.o', 'twopart_side.o', '-o', 'combined.o'])
+    run_process(self.emcc + ['-r', 'twopart_main.o', 'twopart_side.o', '-o', 'combined.o'])
     # We also support building without the `-r` flag but expect a warning
-    err = run_process([PYTHON, EMCC, 'twopart_main.o', 'twopart_side.o', '-o', 'combined2.o'], stderr=PIPE).stderr
+    err = run_process(self.emcc + ['twopart_main.o', 'twopart_side.o', '-o', 'combined2.o'], stderr=PIPE).stderr
     self.assertBinaryEqual('combined.o', 'combined2.o')
     self.assertContained('warning: Assuming object file output in the absence of `-c`', err)
 
@@ -512,7 +520,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     else:
       self.assertEqual(len(syms.defs), 2)
 
-    run_process([PYTHON, EMCC, 'combined.o', '-o', 'combined.o.js'])
+    run_process(self.emcc + ['combined.o', '-o', 'combined.o.js'])
     self.assertContained('side got: hello from main, over', run_js('combined.o.js'))
 
   def test_js_transform(self):
@@ -524,7 +532,7 @@ f.write('transformed!')
 f.close()
 ''')
 
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-transform', '%s t.py' % (PYTHON)])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '--js-transform', '%s t.py' % (PYTHON)])
     self.assertIn('transformed!', open('a.out.js').read())
 
   @no_wasm_backend("wasm backend alwasy embedds memory")
@@ -532,7 +540,7 @@ f.close()
     for opts in [0, 1, 2, 3]:
       print('mem init in', opts)
       self.clear()
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-O' + str(opts)])
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-O' + str(opts)])
       if opts >= 2:
         self.assertExists('a.out.js.mem')
       else:
@@ -545,7 +553,7 @@ f.close()
         self.clear()
         wasm = '=0' not in str(mode)
         print('  mode', mode, 'wasm?', wasm)
-        run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')] + opts + mode)
+        run_process(self.emcc + [path_from_root('tests', 'hello_world.c')] + opts + mode)
         self.assertExists('a.out.js')
         if wasm:
           self.assertExists('a.out.wasm')
@@ -563,17 +571,17 @@ f.close()
             self.assertContained('use asm', src)
 
   def test_emcc_cflags(self):
-    output = run_process([PYTHON, EMCC, '--cflags'], stdout=PIPE)
+    output = run_process(self.emcc + ['--cflags'], stdout=PIPE)
     flags = output.stdout.strip()
     self.assertContained(' '.join(Building.doublequote_spaces(shared.emsdk_cflags())), flags)
     # check they work
     cmd = [CLANG_CXX, path_from_root('tests', 'hello_world.cpp')] + shlex.split(flags.replace('\\', '\\\\')) + ['-c', '-emit-llvm', '-o', 'a.bc']
     run_process(cmd)
-    run_process([PYTHON, EMCC, 'a.bc'])
+    run_process(self.emcc + ['a.bc'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_emcc_print_search_dirs(self):
-    result = run_process([PYTHON, EMCC, '-print-search-dirs'], stdout=PIPE, stderr=PIPE)
+    result = run_process(self.emcc + ['-print-search-dirs'], stdout=PIPE, stderr=PIPE)
     self.assertContained('programs: =', result.stdout)
     self.assertContained('libraries: =', result.stdout)
 
@@ -762,36 +770,36 @@ f.close()
         else:
           self.assertContained(path_from_root('system'), i)
 
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-v'], stderr=PIPE).stderr
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-v'], stderr=PIPE).stderr
     verify_includes(err)
-    err = run_process([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-v'], stderr=PIPE).stderr
+    err = run_process(self.emxx + [path_from_root('tests', 'hello_world.cpp'), '-v'], stderr=PIPE).stderr
     verify_includes(err)
 
   def test_failure_error_code(self):
-    for compiler in [EMCC, EMXX]:
+    for compiler in [self.emcc, self.emxx]:
       # Test that if one file is missing from the build, then emcc shouldn't succeed, and shouldn't produce an output file.
-      self.expect_fail([PYTHON, compiler, path_from_root('tests', 'hello_world.c'), 'this_file_is_missing.c', '-o', 'out.js'])
+      self.expect_fail(compiler + [path_from_root('tests', 'hello_world.c'), 'this_file_is_missing.c', '-o', 'out.js'])
       self.assertFalse(os.path.exists('out.js'))
 
   def test_use_cxx(self):
     create_test_file('empty_file', ' ')
-    dash_xc = run_process([PYTHON, EMCC, '-v', '-xc', 'empty_file'], stderr=PIPE).stderr
+    dash_xc = run_process(self.emcc + ['-v', '-xc', 'empty_file'], stderr=PIPE).stderr
     self.assertNotContained('-x c++', dash_xc)
-    dash_xcpp = run_process([PYTHON, EMCC, '-v', '-xc++', 'empty_file'], stderr=PIPE).stderr
+    dash_xcpp = run_process(self.emcc + ['-v', '-xc++', 'empty_file'], stderr=PIPE).stderr
     self.assertContained('-x c++', dash_xcpp)
 
   def test_cxx11(self):
     for std in ['-std=c++11', '--std=c++11']:
-      for compiler in [EMCC, EMXX]:
-        run_process([PYTHON, compiler, std, path_from_root('tests', 'hello_cxx11.cpp')])
+      for compiler in [self.emcc, self.emxx]:
+        run_process(compiler + [std, path_from_root('tests', 'hello_cxx11.cpp')])
 
   # Regression test for issue #4522: Incorrect CC vs CXX detection
   def test_incorrect_c_detection(self):
     # This auto-detection only works for the compile phase.
     # For linking you need to use `em++` or pass `-x c++`
     create_test_file('test.c', 'foo\n')
-    for compiler in [EMCC, EMXX]:
-      run_process([PYTHON, compiler, '-c', '--bind', '--embed-file', 'test.c', path_from_root('tests', 'hello_world.cpp')])
+    for compiler in [self.emcc, self.emxx]:
+      run_process(compiler + ['-c', '--bind', '--embed-file', 'test.c', path_from_root('tests', 'hello_world.cpp')])
 
   def test_odd_suffixes(self):
     for suffix in ['CPP', 'c++', 'C++', 'cxx', 'CXX', 'cc', 'CC', 'i', 'ii']:
@@ -804,20 +812,20 @@ f.close()
       self.clear()
       print(suffix)
       shutil.copyfile(path_from_root('tests', 'hello_world.c'), 'test.' + suffix)
-      run_process([PYTHON, EMCC, self.in_dir('test.' + suffix)])
+      run_process(self.emcc + [self.in_dir('test.' + suffix)])
       self.assertContained('hello, world!', run_js('a.out.js'))
 
     for suffix in ['lo']:
       self.clear()
       print(suffix)
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'binary.' + suffix])
-      run_process([PYTHON, EMCC, 'binary.' + suffix])
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', 'binary.' + suffix])
+      run_process(self.emcc + ['binary.' + suffix])
       self.assertContained('hello, world!', run_js('a.out.js'))
 
   @no_wasm_backend('asm.js minification')
   def test_asm_minify(self):
     def test(args):
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world_loop_malloc.cpp'), '-s', 'WASM=0'] + args)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world_loop_malloc.cpp'), '-s', 'WASM=0'] + args)
       self.assertContained('hello, world!', run_js('a.out.js'))
       return open('a.out.js').read()
 
@@ -862,16 +870,16 @@ f.close()
 
     def test(args, expected):
       print(args, expected)
-      run_process([PYTHON, EMCC, 'src.c'] + args, stderr=PIPE)
+      run_process(self.emcc + ['src.c'] + args, stderr=PIPE)
       self.assertContained(expected, run_js('a.out.js', stderr=PIPE, full_output=True, assert_returncode=None))
       if self.is_wasm_backend():
         return
       print('in asm.js')
-      run_process([PYTHON, EMCC, 'src.c', '-s', 'WASM=0'] + args, stderr=PIPE)
+      run_process(self.emcc + ['src.c', '-s', 'WASM=0'] + args, stderr=PIPE)
       self.assertContained(expected, run_js('a.out.js', stderr=PIPE, full_output=True, assert_returncode=None))
       # TODO: emulation function support in wasm is imperfect
       print('with emulated function pointers in asm.js')
-      run_process([PYTHON, EMCC, '-s', 'WASM=0', 'src.c', '-s', 'ASSERTIONS=1'] + args + ['-s', 'EMULATED_FUNCTION_POINTERS=1'], stderr=PIPE)
+      run_process(self.emcc + ['-s', 'WASM=0', 'src.c', '-s', 'ASSERTIONS=1'] + args + ['-s', 'EMULATED_FUNCTION_POINTERS=1'], stderr=PIPE)
       out = run_js('a.out.js', stderr=PIPE, full_output=True, assert_returncode=None)
       self.assertContained(expected, out)
 
@@ -901,7 +909,7 @@ f.close()
   @no_wasm_backend('uses EMULATED_FUNCTION_POINTERS')
   def test_emulate_function_pointer_casts_assertions_2(self):
     # check empty tables work with assertions 2 in this mode (#6554)
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EMULATED_FUNCTION_POINTERS=1', '-s', 'ASSERTIONS=2'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'EMULATED_FUNCTION_POINTERS=1', '-s', 'ASSERTIONS=2'])
 
   def test_wl_linkflags(self):
     # Test path -L and -l via -Wl, arguments and -Wl, response files
@@ -922,11 +930,11 @@ f.close()
     -L.
     -lfoo
     ''')
-    run_process([PYTHON, EMCC, '-o', 'libfile.o', 'libfile.cpp'])
+    run_process(self.emcc + ['-o', 'libfile.o', 'libfile.cpp'])
     run_process([PYTHON, EMAR, 'cr', 'libfoo.a', 'libfile.o'])
-    run_process([PYTHON, EMCC, 'main.cpp', '-L.', '-lfoo'])
-    run_process([PYTHON, EMCC, 'main.cpp', '-Wl,-L.', '-Wl,-lfoo'])
-    run_process([PYTHON, EMCC, 'main.cpp', '-Wl,@linkflags.txt'])
+    run_process(self.emcc + ['main.cpp', '-L.', '-lfoo'])
+    run_process(self.emcc + ['main.cpp', '-Wl,-L.', '-Wl,-lfoo'])
+    run_process(self.emcc + ['main.cpp', '-Wl,@linkflags.txt'])
 
   def test_l_link(self):
     # Linking with -lLIBNAME and -L/DIRNAME should work, also should work with spaces
@@ -949,7 +957,7 @@ f.close()
     aout = 'a.out.js'
 
     def build(path, args):
-      run_process([PYTHON, EMCC, path] + args)
+      run_process(self.emcc + [path] + args)
 
     # Test linking the library built here by emcc
     build('libfile.cpp', ['-c'])
@@ -991,10 +999,10 @@ int main() {
 }
 ''')
 
-    run_process([PYTHON, EMCC, '-o', 'a.o', 'a.c'])
+    run_process(self.emcc + ['-o', 'a.o', 'a.c'])
     run_process([PYTHON, EMAR, 'rv', 'library.a', 'a.o'])
-    run_process([PYTHON, EMCC, '-o', 'main.o', 'main.c'])
-    run_process([PYTHON, EMCC, '-o', 'a.js', 'main.o', 'library.a'])
+    run_process(self.emcc + ['-o', 'main.o', 'main.c'])
+    run_process(self.emcc + ['-o', 'a.js', 'main.o', 'library.a'])
     self.assertContained('|0|', run_js('a.js'))
 
   @parameterized({
@@ -1008,7 +1016,7 @@ int main() {
     In this case, we should always successfully compile the code."""
     create_test_file('foobar.xxx', 'int main(){ return 0; }')
     os.symlink('foobar.xxx', 'foobar.c')
-    run_process([PYTHON, EMCC, 'foobar.c', '-o', 'foobar.bc'] + flags)
+    run_process(self.emcc + ['foobar.c', '-o', 'foobar.bc'] + flags)
 
   @parameterized({
     'expand_symlinks': ([], True),
@@ -1022,7 +1030,7 @@ int main() {
     due to the inappropriate file suffix on foobar.xxx."""
     create_test_file('foobar.c', 'int main(){ return 0; }')
     os.symlink('foobar.c', 'foobar.xxx')
-    proc = run_process([PYTHON, EMCC, 'foobar.xxx', '-o', 'foobar.bc'] + flags, check=expect_success, stderr=PIPE)
+    proc = run_process(self.emcc + ['foobar.xxx', '-o', 'foobar.bc'] + flags, check=expect_success, stderr=PIPE)
     if not expect_success:
       self.assertNotEqual(proc.returncode, 0)
       self.assertContained("unknown suffix", proc.stderr)
@@ -1108,7 +1116,7 @@ int main() {
 
     def test(lib_args, err_expected):
       print(err_expected)
-      output = run_process([PYTHON, EMCC, main_name, '-o', 'a.out.js'] + lib_args, stdout=PIPE, stderr=PIPE, check=not err_expected)
+      output = run_process(self.emcc + [main_name, '-o', 'a.out.js'] + lib_args, stdout=PIPE, stderr=PIPE, check=not err_expected)
       if err_expected:
         self.assertContained(err_expected, output.stderr)
       else:
@@ -1142,18 +1150,18 @@ int main() {
   def test_whole_archive(self):
     # Verify that -Wl,--whole-archive includes the static constructor from the
     # otherwise unreferenced library.
-    run_process([PYTHON, EMCC, '-c', '-o', 'main.o', path_from_root('tests', 'test_whole_archive', 'main.c')])
-    run_process([PYTHON, EMCC, '-c', '-o', 'testlib.o', path_from_root('tests', 'test_whole_archive', 'testlib.c')])
+    run_process(self.emcc + ['-c', '-o', 'main.o', path_from_root('tests', 'test_whole_archive', 'main.c')])
+    run_process(self.emcc + ['-c', '-o', 'testlib.o', path_from_root('tests', 'test_whole_archive', 'testlib.c')])
     run_process([PYTHON, EMAR, 'crs', 'libtest.a', 'testlib.o'])
 
-    run_process([PYTHON, EMCC, '-Wl,--whole-archive', 'libtest.a', '-Wl,--no-whole-archive', 'main.o'])
+    run_process(self.emcc + ['-Wl,--whole-archive', 'libtest.a', '-Wl,--no-whole-archive', 'main.o'])
     self.assertContained('foo is: 42\n', run_js('a.out.js'))
 
-    run_process([PYTHON, EMCC, '-Wl,-whole-archive', 'libtest.a', '-Wl,-no-whole-archive', 'main.o'])
+    run_process(self.emcc + ['-Wl,-whole-archive', 'libtest.a', '-Wl,-no-whole-archive', 'main.o'])
     self.assertContained('foo is: 42\n', run_js('a.out.js'))
 
     # Verify the --no-whole-archive prevents the inclusion of the ctor
-    run_process([PYTHON, EMCC, '-Wl,-whole-archive', '-Wl,--no-whole-archive', 'libtest.a', 'main.o'])
+    run_process(self.emcc + ['-Wl,-whole-archive', '-Wl,--no-whole-archive', 'libtest.a', 'main.o'])
     self.assertContained('foo is: 0\n', run_js('a.out.js'))
 
   def test_link_group_bitcode(self):
@@ -1172,11 +1180,11 @@ int f() {
 }
 ''')
 
-    run_process([PYTHON, EMCC, '-o', '1.o', '1.c'])
-    run_process([PYTHON, EMCC, '-o', '2.o', '2.c'])
+    run_process(self.emcc + ['-o', '1.o', '1.c'])
+    run_process(self.emcc + ['-o', '2.o', '2.c'])
     run_process([PYTHON, EMAR, 'crs', '2.a', '2.o'])
-    run_process([PYTHON, EMCC, '-o', 'out.bc', '-Wl,--start-group', '2.a', '1.o', '-Wl,--end-group'])
-    run_process([PYTHON, EMCC, 'out.bc'])
+    run_process(self.emcc + ['-o', 'out.bc', '-Wl,--start-group', '2.a', '1.o', '-Wl,--end-group'])
+    run_process(self.emcc + ['out.bc'])
     self.assertContained('Hello', run_js('a.out.js'))
 
   @no_wasm_backend('lld resolves circular lib dependencies')
@@ -1208,20 +1216,20 @@ int f() {
 
     # 'libA.a' does not satisfy any symbols from main, so it will not be included,
     # and there will be an undefined symbol.
-    err = self.expect_fail([PYTHON, EMCC] + args + libs_list)
+    err = self.expect_fail(self.emcc + args + libs_list)
     self.assertContained('error: undefined symbol: x', err)
 
     # -Wl,--start-group and -Wl,--end-group around the libs will cause a rescan
     # of 'libA.a' after 'libB.a' adds undefined symbol "x", so a.c.o will now be
     # included (and the link will succeed).
     libs = ['-Wl,--start-group'] + libs_list + ['-Wl,--end-group']
-    run_process([PYTHON, EMCC] + args + libs)
+    run_process(self.emcc + args + libs)
     self.assertContained('result: 42', run_js('a.out.js'))
 
     # -( and -) should also work.
     args = ['main.c', '-o', 'a2.out.js']
     libs = ['-Wl,-('] + libs_list + ['-Wl,-)']
-    run_process([PYTHON, EMCC] + args + libs)
+    run_process(self.emcc + args + libs)
     self.assertContained('result: 42', run_js('a2.out.js'))
 
   # The fastcomp path will deliberately ignore duplicate input files in order
@@ -1258,7 +1266,7 @@ int f() {
     create_test_file('main.c', 'extern int native(); int main() { return native(); }')
     run_process([CLANG_CC, 'native.c', '-target', 'x86_64-linux', '-c', '-o', 'native.o'])
     run_process([PYTHON, EMAR, 'crs', 'libfoo.a', 'native.o'])
-    stderr = self.expect_fail([PYTHON, EMCC, 'main.c', 'libfoo.a'])
+    stderr = self.expect_fail(self.emcc + ['main.c', 'libfoo.a'])
     self.assertContained('unknown file type', stderr)
 
   def test_export_all(self):
@@ -1377,7 +1385,7 @@ int f() {
                            (['-Lsubdir/something', '-Wwarn-absolute-paths'], False),
                            ([], False)]:
       print(args, expected)
-      proc = run_process([PYTHON, EMCC, 'main.c'] + args, stderr=PIPE)
+      proc = run_process(self.emcc + ['main.c'] + args, stderr=PIPE)
       WARNING = 'encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript)'
       self.assertContainedIf(WARNING, proc.stderr, expected)
 
@@ -1403,8 +1411,8 @@ int f() {
       }
     ''')
 
-    run_process([PYTHON, EMCC, 'libfile.cpp', '-o', 'libfile.so'], stderr=PIPE)
-    run_process([PYTHON, EMCC, 'main.cpp', os.path.join('subdir', 'libfile.so'), '-L.'])
+    run_process(self.emcc + ['libfile.cpp', '-o', 'libfile.so'], stderr=PIPE)
+    run_process(self.emcc + ['main.cpp', os.path.join('subdir', 'libfile.so'), '-L.'])
     self.assertContained('hello from lib', run_js('a.out.js'))
 
   def test_identical_basenames(self):
@@ -1424,14 +1432,14 @@ int f() {
       void printey() { printf("hello there\\n"); }
     ''')
 
-    run_process([PYTHON, EMCC, os.path.join('foo', 'main.cpp'), os.path.join('bar', 'main.cpp')])
+    run_process(self.emcc + [os.path.join('foo', 'main.cpp'), os.path.join('bar', 'main.cpp')])
     self.assertContained('hello there', run_js('a.out.js'))
 
     # ditto with first creating .o files
     try_delete('a.out.js')
-    run_process([PYTHON, EMCC, os.path.join('foo', 'main.cpp'), '-o', os.path.join('foo', 'main.o')])
-    run_process([PYTHON, EMCC, os.path.join('bar', 'main.cpp'), '-o', os.path.join('bar', 'main.o')])
-    run_process([PYTHON, EMCC, os.path.join('foo', 'main.o'), os.path.join('bar', 'main.o')])
+    run_process(self.emcc + [os.path.join('foo', 'main.cpp'), '-o', os.path.join('foo', 'main.o')])
+    run_process(self.emcc + [os.path.join('bar', 'main.cpp'), '-o', os.path.join('bar', 'main.o')])
+    run_process(self.emcc + [os.path.join('foo', 'main.o'), os.path.join('bar', 'main.o')])
     self.assertContained('hello there', run_js('a.out.js'))
 
   def test_main_a(self):
@@ -1453,12 +1461,12 @@ int f() {
       int f() { return 12346; }
     ''')
 
-    run_process([PYTHON, EMCC, main_name, '-c', '-o', main_name + '.bc'])
-    run_process([PYTHON, EMCC, other_name, '-c', '-o', other_name + '.bc'])
+    run_process(self.emcc + [main_name, '-c', '-o', main_name + '.bc'])
+    run_process(self.emcc + [other_name, '-c', '-o', other_name + '.bc'])
 
     run_process([PYTHON, EMAR, 'cr', main_name + '.a', main_name + '.bc'])
 
-    run_process([PYTHON, EMCC, other_name + '.bc', main_name + '.a'])
+    run_process(self.emcc + [other_name + '.bc', main_name + '.a'])
 
     self.assertContained('result: 12346.', run_js('a.out.js'))
 
@@ -1469,7 +1477,7 @@ int f() {
         printf("a\n");
       }
     ''')
-    run_process([PYTHON, EMCC, 'common.c', '-c', '-o', 'common.o'])
+    run_process(self.emcc + ['common.c', '-c', '-o', 'common.o'])
     try_delete('liba.a')
     run_process([PYTHON, EMAR, 'rc', 'liba.a', 'common.o'])
 
@@ -1479,7 +1487,7 @@ int f() {
         printf("b\n");
       }
     ''')
-    run_process([PYTHON, EMCC, 'common.c', '-c', '-o', 'common.o'])
+    run_process(self.emcc + ['common.c', '-c', '-o', 'common.o'])
     try_delete('libb.a')
     run_process([PYTHON, EMAR, 'rc', 'libb.a', 'common.o'])
 
@@ -1492,7 +1500,7 @@ int f() {
       }
     ''')
 
-    run_process([PYTHON, EMCC, 'main.c', '-L.', '-la', '-lb'])
+    run_process(self.emcc + ['main.c', '-L.', '-la', '-lb'])
     self.assertContained('a\nb\n', run_js('a.out.js'))
 
   def test_archive_duplicate_basenames(self):
@@ -1503,7 +1511,7 @@ int f() {
         printf("a\n");
       }
     ''')
-    run_process([PYTHON, EMCC, os.path.join('a', 'common.c'), '-c', '-o', os.path.join('a', 'common.o')])
+    run_process(self.emcc + [os.path.join('a', 'common.c'), '-c', '-o', os.path.join('a', 'common.o')])
 
     ensure_dir('b')
     create_test_file(os.path.join('b', 'common.c'), r'''
@@ -1512,7 +1520,7 @@ int f() {
         printf("b...\n");
       }
     ''')
-    run_process([PYTHON, EMCC, os.path.join('b', 'common.c'), '-c', '-o', os.path.join('b', 'common.o')])
+    run_process(self.emcc + [os.path.join('b', 'common.c'), '-c', '-o', os.path.join('b', 'common.o')])
 
     try_delete('liba.a')
     run_process([PYTHON, EMAR, 'rc', 'liba.a', os.path.join('a', 'common.o'), os.path.join('b', 'common.o')])
@@ -1532,7 +1540,7 @@ int f() {
         b();
       }
     ''')
-    err = run_process([PYTHON, EMCC, 'main.c', '-L.', '-la'], stderr=PIPE).stderr
+    err = run_process(self.emcc + ['main.c', '-L.', '-la'], stderr=PIPE).stderr
     self.assertNotIn('archive file contains duplicate entries', err)
     self.assertContained('a\nb...\n', run_js('a.out.js'))
 
@@ -1544,7 +1552,7 @@ int f() {
 
     # With fastcomp we don't support duplicate members so this should generate
     # a warning.  With the wasm backend (lld) this is fully supported.
-    cmd = [PYTHON, EMCC, 'main.c', '-L.', '-ldup']
+    cmd = self.emcc + ['main.c', '-L.', '-ldup']
     if self.is_wasm_backend():
       run_process(cmd)
       self.assertContained('a\nb...\n', run_js('a.out.js'))
@@ -1572,7 +1580,7 @@ int f() {
         printf("Hello, world!\n");
       }
     ''' % export_name)
-    run_process([PYTHON, EMCC, 'export.c', '-c', '-o', 'export.o'])
+    run_process(self.emcc + ['export.c', '-c', '-o', 'export.o'])
     run_process([PYTHON, EMAR, 'rc', 'libexport.a', 'export.o'])
 
     create_test_file('main.c', r'''
@@ -1582,16 +1590,16 @@ int f() {
     ''')
 
     # Sanity check: the symbol should not be linked in if not requested.
-    run_process([PYTHON, EMCC, 'main.c', '-L.', '-lexport'])
+    run_process(self.emcc + ['main.c', '-L.', '-lexport'])
     self.assertFalse(self.is_exported_in_wasm(expect_export, 'a.out.wasm'))
 
     # Sanity check: exporting without a definition does not cause it to appear.
     # Note: exporting main prevents emcc from warning that it generated no code.
-    run_process([PYTHON, EMCC, 'main.c', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0', '-s', "EXPORTED_FUNCTIONS=['_main', '%s']" % full_export_name])
+    run_process(self.emcc + ['main.c', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0', '-s', "EXPORTED_FUNCTIONS=['_main', '%s']" % full_export_name])
     self.assertFalse(self.is_exported_in_wasm(expect_export, 'a.out.wasm'))
 
     # Actual test: defining symbol in library and exporting it causes it to appear in the output.
-    run_process([PYTHON, EMCC, 'main.c', '-L.', '-lexport', '-s', "EXPORTED_FUNCTIONS=['%s']" % full_export_name])
+    run_process(self.emcc + ['main.c', '-L.', '-lexport', '-s', "EXPORTED_FUNCTIONS=['%s']" % full_export_name])
     self.assertTrue(self.is_exported_in_wasm(expect_export, 'a.out.wasm'))
 
   def test_embed_file(self):
@@ -1609,11 +1617,11 @@ int f() {
       }
     ''')
 
-    run_process([PYTHON, EMCC, 'main.cpp', '--embed-file', 'somefile.txt'])
+    run_process(self.emcc + ['main.cpp', '--embed-file', 'somefile.txt'])
     self.assertContained('|hello from a file wi|', run_js('a.out.js'))
 
     # preload twice, should not err
-    run_process([PYTHON, EMCC, 'main.cpp', '--embed-file', 'somefile.txt', '--embed-file', 'somefile.txt'])
+    run_process(self.emcc + ['main.cpp', '--embed-file', 'somefile.txt', '--embed-file', 'somefile.txt'])
     self.assertContained('|hello from a file wi|', run_js('a.out.js'))
 
   def test_embed_file_dup(self):
@@ -1643,7 +1651,7 @@ int f() {
       }
     ''')
 
-    run_process([PYTHON, EMCC, 'main.cpp', '--embed-file', 'tst'])
+    run_process(self.emcc + ['main.cpp', '--embed-file', 'tst'])
     self.assertContained('|frist|\n|sacond|\n|thard|\n', run_js('a.out.js'))
 
   def test_exclude_file(self):
@@ -1666,7 +1674,7 @@ int f() {
       }
     ''')
 
-    run_process([PYTHON, EMCC, 'main.cpp', '--embed-file', 'tst', '--exclude-file', '*.exe'])
+    run_process(self.emcc + ['main.cpp', '--embed-file', 'tst', '--exclude-file', '*.exe'])
     self.assertEqual(run_js('a.out.js').strip(), '')
 
   def test_multidynamic_link(self):
@@ -1710,7 +1718,7 @@ int f() {
         }
       ''')
 
-      compiler = [PYTHON, EMCC]
+      compiler = self.emcc
 
       # Build libfile normally into an .so
       run_process(compiler + [os.path.join('libdir', 'libfile.cpp'), '-o', os.path.join('libdir', 'libfile.so' + lib_suffix)])
@@ -1720,7 +1728,7 @@ int f() {
       run_process(compiler + [os.path.join('main.cpp')] + link_cmd + ['-lother', '-c'])
       print('...')
       # The normal build system is over. We need to do an additional step to link in the dynamic libraries, since we ignored them before
-      run_process([PYTHON, EMCC, 'main.o'] + link_cmd + ['-lother', '-s', 'EXIT_RUNTIME=1'])
+      run_process(self.emcc + ['main.o'] + link_cmd + ['-lother', '-s', 'EXIT_RUNTIME=1'])
 
       self.assertContained('*hello from lib\n|hello from lib|\n*', run_js('a.out.js'))
 
@@ -1744,7 +1752,7 @@ int f() {
       out(MESSAGE);
     ''')
 
-    run_process([PYTHON, EMCC, 'main.cpp', '--pre-js', 'before.js', '--post-js', 'after.js', '-s', 'WASM_ASYNC_COMPILATION=0'])
+    run_process(self.emcc + ['main.cpp', '--pre-js', 'before.js', '--post-js', 'after.js', '-s', 'WASM_ASYNC_COMPILATION=0'])
     self.assertContained('hello from main\nhello from js\n', run_js('a.out.js'))
 
   def test_sdl_endianness(self):
@@ -1757,7 +1765,7 @@ int f() {
         return 0;
       }
     ''')
-    run_process([PYTHON, EMCC, 'main.cpp'])
+    run_process(self.emcc + ['main.cpp'])
     self.assertContained('1234, 1234, 4321\n', run_js('a.out.js'))
 
   def test_sdl2_mixer(self):
@@ -1838,7 +1846,7 @@ int f() {
         return 0;
       }
     ''')
-    run_process([PYTHON, EMCC, '-O2', 'main.cpp'])
+    run_process(self.emcc + ['-O2', 'main.cpp'])
     output = run_js('a.out.js', full_output=True, stderr=PIPE)
     self.assertContained('''0:0
 1:1
@@ -1855,7 +1863,7 @@ int f() {
     self.assertNotContained('warning: library.js memcpy should not be running, it is only for testing!', output)
 
   def test_undefined_function(self):
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')]
+    cmd = self.emcc + [path_from_root('tests', 'hello_world.cpp')]
     run_process(cmd)
 
     # adding a missing symbol to EXPORTED_FUNCTIONS should cause failure
@@ -1892,7 +1900,7 @@ int f() {
           try_delete('a.out.js')
           print('checking "%s" %s=%s' % (args, action, value))
           extra = ['-s', action + '_ON_UNDEFINED_SYMBOLS=%d' % value] if action else []
-          proc = run_process([PYTHON, EMCC, 'main.cpp'] + extra + args, stderr=PIPE, check=False)
+          proc = run_process(self.emcc + ['main.cpp'] + extra + args, stderr=PIPE, check=False)
           print(proc.stderr)
           if value or action is None:
             # The default is that we error in undefined symbols
@@ -1938,14 +1946,14 @@ int f() {
       };
       ''')
 
-    run_process([PYTHON, EMCC, 'main.cpp', '--pre-js', 'pre.js', '-s', 'WASM_ASYNC_COMPILATION=0'])
+    run_process(self.emcc + ['main.cpp', '--pre-js', 'pre.js', '-s', 'WASM_ASYNC_COMPILATION=0'])
     self.assertContained('pre-run\nhello from main\npost-run\n', run_js('a.out.js'))
 
     # addRunDependency during preRun should prevent main, and post-run from
     # running.
     with open('pre.js', 'a') as f:
       f.write('Module.preRun = function() { out("add-dep"); addRunDependency(); }\n')
-    run_process([PYTHON, EMCC, 'main.cpp', '--pre-js', 'pre.js', '-s', 'WASM_ASYNC_COMPILATION=0'])
+    run_process(self.emcc + ['main.cpp', '--pre-js', 'pre.js', '-s', 'WASM_ASYNC_COMPILATION=0'])
     output = run_js('a.out.js')
     self.assertContained('add-dep\n', output)
     self.assertNotContained('hello from main\n', output)
@@ -1962,7 +1970,7 @@ int f() {
         create_test_file('post.js', 'removeRunDependency("test");')
         args += ['--pre-js', 'pre.js', '--post-js', 'post.js']
 
-      run_process([PYTHON, EMCC, 'main.cpp'] + args)
+      run_process(self.emcc + ['main.cpp'] + args)
       output = run_js('a.out.js')
       self.assertContainedIf('hello from main', output, not no_initial_run)
 
@@ -1982,7 +1990,7 @@ int f() {
         preInit: function() { out('pre-init') }
       };
     ''')
-    run_process([PYTHON, EMCC, 'main.cpp', '--pre-js', 'pre.js'])
+    run_process(self.emcc + ['main.cpp', '--pre-js', 'pre.js'])
     self.assertContained('pre-init\npre-run\nhello from main\npost-run\n', run_js('a.out.js'))
 
   def test_prepost2(self):
@@ -2001,7 +2009,7 @@ int f() {
     create_test_file('pre2.js', '''
       Module.postRun = function() { out('post-run') };
     ''')
-    run_process([PYTHON, EMCC, 'main.cpp', '--pre-js', 'pre.js', '--pre-js', 'pre2.js'])
+    run_process(self.emcc + ['main.cpp', '--pre-js', 'pre.js', '--pre-js', 'pre2.js'])
     self.assertContained('pre-run\nhello from main\npost-run\n', run_js('a.out.js'))
 
   def test_prepre(self):
@@ -2020,7 +2028,7 @@ int f() {
     create_test_file('pre2.js', '''
       Module.preRun.push(function() { out('prepre') });
     ''')
-    run_process([PYTHON, EMCC, 'main.cpp', '--pre-js', 'pre.js', '--pre-js', 'pre2.js'])
+    run_process(self.emcc + ['main.cpp', '--pre-js', 'pre.js', '--pre-js', 'pre2.js'])
     self.assertContained('prepre\npre-run\nhello from main\n', run_js('a.out.js'))
 
   def test_extern_prepost(self):
@@ -2030,7 +2038,7 @@ int f() {
     create_test_file('extern-post.js', '''
       // I am an external post.
     ''')
-    run_process([PYTHON, EMCC, '-O2', path_from_root('tests', 'hello_world.c'), '--extern-pre-js', 'extern-pre.js', '--extern-post-js', 'extern-post.js'])
+    run_process(self.emcc + ['-O2', path_from_root('tests', 'hello_world.c'), '--extern-pre-js', 'extern-pre.js', '--extern-post-js', 'extern-post.js'])
     # the files should be included, and externally - not as part of optimized
     # code, so they are the very first and last things, and they are not
     # minified.
@@ -2049,13 +2057,13 @@ int f() {
 
   @no_wasm_backend('depends on bc output')
   def test_save_bc(self):
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world_loop_malloc.cpp'), '--save-bc', 'my_bitcode.bc']
+    cmd = self.emcc + [path_from_root('tests', 'hello_world_loop_malloc.cpp'), '--save-bc', 'my_bitcode.bc']
     run_process(cmd)
     assert 'hello, world!' in run_js('a.out.js')
     self.assertExists('my_bitcode.bc')
     try_delete('a.out.js')
     Building.llvm_dis('my_bitcode.bc', 'my_ll.ll')
-    run_process([PYTHON, EMCC, 'my_ll.ll', '-nostdlib', '-o', 'two.js'])
+    run_process(self.emcc + ['my_ll.ll', '-nostdlib', '-o', 'two.js'])
     assert 'hello, world!' in run_js('two.js')
 
   def test_js_optimizer(self):
@@ -2262,7 +2270,7 @@ int f() {
   def test_m_mm(self):
     create_test_file('foo.c', '#include <emscripten.h>')
     for opt in ['M', 'MM']:
-      proc = run_process([PYTHON, EMCC, 'foo.c', '-' + opt], stdout=PIPE, stderr=PIPE)
+      proc = run_process(self.emcc + ['foo.c', '-' + opt], stdout=PIPE, stderr=PIPE)
       assert 'foo.o: ' in proc.stdout, '-%s failed to produce the right output: %s' % (opt, proc.stdout)
       assert 'error' not in proc.stderr, 'Unexpected stderr: ' + proc.stderr
 
@@ -2279,7 +2287,7 @@ int f() {
           env.pop('EMCC_DEBUG', None)
         else:
           env['EMCC_DEBUG'] = debug
-        run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-O' + str(opts)], stderr=PIPE, env=env)
+        run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-O' + str(opts)], stderr=PIPE, env=env)
         if debug is None:
           self.assertFalse(os.path.exists(self.canonical_temp_dir))
         elif debug == '1':
@@ -2307,7 +2315,7 @@ int f() {
         (['-O2', '-g'], True),
       ]:
       print(args, expect_debug)
-      err = run_process([PYTHON, EMCC, '-v', path_from_root('tests', 'hello_world.cpp')] + args, stdout=PIPE, stderr=PIPE).stderr
+      err = run_process(self.emcc + ['-v', path_from_root('tests', 'hello_world.cpp')] + args, stdout=PIPE, stderr=PIPE).stderr
       lines = err.splitlines()
       if self.is_wasm_backend():
         finalize = [l for l in lines if 'wasm-emscripten-finalize' in l][0]
@@ -2333,7 +2341,7 @@ int f() {
       return (no_size, line_size, full_size)
 
     def compile_to_object(compile_args):
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'a.out.wasm'] + compile_args)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'a.out.wasm'] + compile_args)
 
     no_size, line_size, full_size = test(compile_to_object)
     self.assertLess(no_size, line_size)
@@ -2341,9 +2349,9 @@ int f() {
 
     def compile_to_executable(compile_args, link_args):
       # compile with the specified args
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'a.o'] + compile_args)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'a.o'] + compile_args)
       # link with debug info
-      run_process([PYTHON, EMCC, 'a.o'] + link_args)
+      run_process(self.emcc + ['a.o'] + link_args)
 
     def compile_to_debug_executable(compile_args):
       return compile_to_executable(compile_args, ['-g'])
@@ -2363,7 +2371,7 @@ int f() {
   def test_dwarf(self):
     def compile_with_dwarf(args, output):
       # Test that -g enables dwarf info in object files and linked wasm
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', output, '-g'] + args)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-o', output, '-g'] + args)
 
     def verify(output):
       info = run_process([LLVM_DWARFDUMP, '--all', output], stdout=PIPE).stdout
@@ -2399,7 +2407,7 @@ int f() {
     self.assertContained('If you see this - the world is all right!', output)
 
   def test_embind_fail(self):
-    out = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'embind', 'test_unsigned.cpp')])
+    out = self.expect_fail(self.emcc + [path_from_root('tests', 'embind', 'test_unsigned.cpp')])
     self.assertContained("undefined symbol: _embind_register_function", out)
 
   @is_slow_test
@@ -2431,7 +2439,7 @@ int f() {
       ]
 
       run_process(
-        [PYTHON, EMCC, path_from_root('tests', 'embind', 'embind_test.cpp'),
+        self.emcc + [path_from_root('tests', 'embind', 'embind_test.cpp'),
          '--pre-js', path_from_root('tests', 'embind', 'test.pre.js'),
          '--post-js', path_from_root('tests', 'embind', 'test.post.js'),
          '-s', 'WASM_ASYNC_COMPILATION=0',
@@ -2493,10 +2501,10 @@ int f() {
         }
       }
     ''')
-    run_process([PYTHON, EMCC, 'main.cpp', '-o', 'main.o'])
-    run_process([PYTHON, EMCC, 'supp.cpp', '-o', 'supp.o'])
+    run_process(self.emcc + ['main.cpp', '-o', 'main.o'])
+    run_process(self.emcc + ['supp.cpp', '-o', 'supp.o'])
 
-    run_process([PYTHON, EMCC, 'main.o', '-s', 'supp.o', '-s', 'SAFE_HEAP=1'])
+    run_process(self.emcc + ['main.o', '-s', 'supp.o', '-s', 'SAFE_HEAP=1'])
     self.assertContained('yello', run_js('a.out.js'))
     # Check that valid -s option had an effect'
     self.assertContained('SAFE_HEAP', open('a.out.js').read())
@@ -2508,7 +2516,7 @@ int f() {
       }
     ''')
     with env_modify({'EMMAKEN_JUST_CONFIGURE': '1'}):
-      cmd = [PYTHON, EMCC, '-s', 'ASSERTIONS=1', 'conftest.c', '-o', 'conftest']
+      cmd = self.emcc + ['-s', 'ASSERTIONS=1', 'conftest.c', '-o', 'conftest']
     output = run_process(cmd, stderr=PIPE)
     self.assertNotContained('emcc: warning: treating -s as linker option', output.stderr)
     self.assertExists('conftest')
@@ -2588,12 +2596,12 @@ int f() {
     err = run_process([PYTHON, FILE_PACKAGER, 'test.data', '--preload', 'data.txt'], stdout=PIPE, stderr=PIPE).stderr
     self.assertContained(MESSAGE, err)
     # do not mention from emcc
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--preload-file', 'data.txt'], stdout=PIPE, stderr=PIPE).stderr
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '--preload-file', 'data.txt'], stdout=PIPE, stderr=PIPE).stderr
     self.assertEqual(len(err), 0)
 
   def test_headless(self):
     shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'example.png')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'sdl_headless.c'), '-s', 'HEADLESS=1'])
+    run_process(self.emcc + [path_from_root('tests', 'sdl_headless.c'), '-s', 'HEADLESS=1'])
     output = run_js('a.out.js', stderr=PIPE)
     assert '''Init: 0
 Font: 0x1
@@ -2605,7 +2613,7 @@ done.
 
   def test_preprocess(self):
     # Pass -Werror to prevent regressions such as https://github.com/emscripten-core/emscripten/pull/9661
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-E', '-Werror'], stdout=PIPE).stdout
+    out = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-E', '-Werror'], stdout=PIPE).stdout
     self.assertNotExists('a.out.js')
     self.assertNotExists('a.out')
     # Test explicitly that the output contains a line typically written by the preprocessor.
@@ -2614,13 +2622,13 @@ done.
     self.assertContained('printf("hello, world!', out)
 
   def test_syntax_only_valid(self):
-    result = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-fsyntax-only'], stdout=PIPE, stderr=STDOUT)
+    result = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-fsyntax-only'], stdout=PIPE, stderr=STDOUT)
     self.assertEqual(result.stdout, '')
     self.assertNotExists('a.out.js')
 
   def test_syntax_only_invalid(self):
     create_test_file('src.c', 'int main() {')
-    result = run_process([PYTHON, EMCC, 'src.c', '-fsyntax-only'], stdout=PIPE, check=False, stderr=STDOUT)
+    result = run_process(self.emcc + ['src.c', '-fsyntax-only'], stdout=PIPE, check=False, stderr=STDOUT)
     self.assertNotEqual(result.returncode, 0)
     self.assertContained("src.c:1:13: error: expected '}'", result.stdout)
     self.assertNotExists('a.out.js')
@@ -2660,7 +2668,7 @@ done.
 
     # full demangle support
 
-    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'DEMANGLE_SUPPORT=1'])
+    run_process(self.emcc + ['src.cpp', '-s', 'DEMANGLE_SUPPORT=1'])
     output = run_js('a.out.js')
     self.assertContained('''operator new(unsigned long)
 _main
@@ -2681,7 +2689,7 @@ FWakaGLXFleeflsMarfoo::FWakaGLXFleeflsMarfoo(unsigned int, unsigned int, unsigne
 void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::OR>(unsigned int const*, unsigned int)
 ''', output)
     # test for multiple functions in one stack trace
-    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'DEMANGLE_SUPPORT=1', '-g'])
+    run_process(self.emcc + ['src.cpp', '-s', 'DEMANGLE_SUPPORT=1', '-g'])
     output = run_js('a.out.js')
     self.assertIn('one(int)', output)
     self.assertIn('two(char)', output)
@@ -2704,14 +2712,14 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
       }
     ''')
 
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     output = run_js('a.out.js')
     self.assertContained('Waka::f::a23412341234::point()', output)
 
   # Test that malloc() -> OOM -> abort() -> stackTrace() -> jsStackTrace() -> demangleAll() -> demangle() -> malloc()
   # cycle will not produce an infinite loop.
   def test_demangle_malloc_infinite_loop_crash(self):
-    run_process([PYTHON, EMXX, path_from_root('tests', 'malloc_demangle_infinite_loop.cpp'), '-g', '-s', 'ABORTING_MALLOC=1', '-s', 'DEMANGLE_SUPPORT=1'])
+    run_process(self.emxx + [path_from_root('tests', 'malloc_demangle_infinite_loop.cpp'), '-g', '-s', 'ABORTING_MALLOC=1', '-s', 'DEMANGLE_SUPPORT=1'])
     output = run_js('a.out.js', assert_returncode=None, stderr=PIPE)
     if output.count('Cannot enlarge memory arrays') > 2:
       print(output)
@@ -2726,7 +2734,7 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     self.clear()
 
     # compile with -O2 --closure 0
-    run_process([PYTHON, EMCC, path_from_root('tests', 'Module-exports', 'test.c'),
+    run_process(self.emcc + [path_from_root('tests', 'Module-exports', 'test.c'),
                  '-o', 'test.js', '-O2', '--closure', '0',
                  '--pre-js', path_from_root('tests', 'Module-exports', 'setup.js'),
                  '-s', 'EXPORTED_FUNCTIONS=["_bufferTest"]',
@@ -2751,7 +2759,7 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     self.assertNotExists('test.js')
 
     # compile with -O2 --closure 1
-    run_process([PYTHON, EMCC, path_from_root('tests', 'Module-exports', 'test.c'),
+    run_process(self.emcc + [path_from_root('tests', 'Module-exports', 'test.c'),
                  '-o', 'test.js', '-O2', '--closure', '1',
                  '--pre-js', path_from_root('tests', 'Module-exports', 'setup.js'),
                  '-s', 'EXPORTED_FUNCTIONS=["_bufferTest"]',
@@ -2791,13 +2799,13 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
 
     reference_error_text = 'console.log(xxx); //< here is the ReferenceError'
 
-    run_process([PYTHON, EMCC, 'count.c', '-o', 'count.js'])
+    run_process(self.emcc + ['count.c', '-o', 'count.js'])
 
     # Check that the ReferenceError is caught and rethrown and thus the original error line is masked
     self.assertNotContained(reference_error_text,
                             run_js('index.js', engine=NODE_JS, stderr=STDOUT, assert_returncode=None))
 
-    run_process([PYTHON, EMCC, 'count.c', '-o', 'count.js', '-s', 'NODEJS_CATCH_EXIT=0'])
+    run_process(self.emcc + ['count.c', '-o', 'count.js', '-s', 'NODEJS_CATCH_EXIT=0'])
 
     # Check that the ReferenceError is not caught, so we see the error properly
     self.assertContained(reference_error_text,
@@ -2823,14 +2831,14 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
 
     reference_error_text = 'undefined'
 
-    run_process([PYTHON, EMCC, 'count.c', '-s', 'FORCE_FILESYSTEM=1', '-s',
+    run_process(self.emcc + ['count.c', '-s', 'FORCE_FILESYSTEM=1', '-s',
                  'EXTRA_EXPORTED_RUNTIME_METHODS=["FS_writeFile"]', '-o', 'count.js'])
 
     # Check that the Module.FS_writeFile exists
     self.assertNotContained(reference_error_text,
                             run_js('index.js', engine=NODE_JS, stderr=STDOUT, assert_returncode=None))
 
-    run_process([PYTHON, EMCC, 'count.c', '-s', 'FORCE_FILESYSTEM=1', '-o', 'count.js'])
+    run_process(self.emcc + ['count.c', '-s', 'FORCE_FILESYSTEM=1', '-o', 'count.js'])
 
     # Check that the Module.FS_writeFile is not exported
     self.assertContained(reference_error_text,
@@ -2874,7 +2882,7 @@ int main()
     return 0;
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '--embed-file', 'src.cpp'])
+    run_process(self.emcc + ['src.cpp', '--embed-file', 'src.cpp'])
     for engine in JS_ENGINES:
       out = run_js('a.out.js', engine=engine, stderr=PIPE, full_output=True)
       self.assertContained('File size: 724', out)
@@ -3131,7 +3139,7 @@ myreade(){
   @unittest.skip("autovectorization of this stopped in LLVM 6.0")
   def test_autovectorize_linpack(self):
     # TODO: investigate when SIMD arrives in wasm
-    run_process([PYTHON, EMCC, path_from_root('tests', 'linpack.c'), '-O2', '-msimd128', '-DSP', '--profiling'])
+    run_process(self.emcc + [path_from_root('tests', 'linpack.c'), '-O2', '-msimd128', '-DSP', '--profiling'])
 
   def test_dependency_file(self):
     # Issue 1732: -MMD (and friends) create dependency files that need to be
@@ -3148,7 +3156,7 @@ myreade(){
       void my_function();
     ''')
 
-    run_process([PYTHON, EMCC, '-MMD', '-c', 'test.cpp', '-o', 'test.o'])
+    run_process(self.emcc + ['-MMD', '-c', 'test.cpp', '-o', 'test.o'])
 
     self.assertExists('test.d')
     deps = open('test.d').read()
@@ -3159,16 +3167,16 @@ myreade(){
 
   def test_dependency_file_2(self):
     shutil.copyfile(path_from_root('tests', 'hello_world.c'), 'a.c')
-    run_process([PYTHON, EMCC, 'a.c', '-MMD', '-MF', 'test.d', '-c'])
+    run_process(self.emcc + ['a.c', '-MMD', '-MF', 'test.d', '-c'])
     self.assertContained(open('test.d').read(), 'a.o: a.c\n')
 
     shutil.copyfile(path_from_root('tests', 'hello_world.c'), 'a.c')
-    run_process([PYTHON, EMCC, 'a.c', '-MMD', '-MF', 'test2.d', '-c', '-o', 'test.o'])
+    run_process(self.emcc + ['a.c', '-MMD', '-MF', 'test2.d', '-c', '-o', 'test.o'])
     self.assertContained(open('test2.d').read(), 'test.o: a.c\n')
 
     shutil.copyfile(path_from_root('tests', 'hello_world.c'), 'a.c')
     ensure_dir('obj')
-    run_process([PYTHON, EMCC, 'a.c', '-MMD', '-MF', 'test3.d', '-c', '-o', 'obj/test.o'])
+    run_process(self.emcc + ['a.c', '-MMD', '-MF', 'test3.d', '-c', '-o', 'obj/test.o'])
     self.assertContained(open('test3.d').read(), 'obj/test.o: a.c\n')
 
   def test_js_lib_quoted_key(self):
@@ -3182,7 +3190,7 @@ mergeInto(LibraryManager.library, {
 });
 ''')
 
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '--js-library', 'lib.js'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '--js-library', 'lib.js'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_js_lib_exported(self):
@@ -3202,7 +3210,7 @@ int main() {
   });
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '--js-library', 'lib.js', '-s', 'EXPORTED_FUNCTIONS=["_main", "_jslibfunc"]'])
+    run_process(self.emcc + ['src.cpp', '--js-library', 'lib.js', '-s', 'EXPORTED_FUNCTIONS=["_main", "_jslibfunc"]'])
     self.assertContained('c calling: 12\njs calling: 10.', run_js('a.out.js'))
 
   def test_js_lib_primitive_dep(self):
@@ -3222,7 +3230,7 @@ int main(int argc, char** argv) {
   return 0;
 }
 ''')
-    run_process([PYTHON, EMCC, '-O0', 'main.c', '--js-library', 'lib.js', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
+    run_process(self.emcc + ['-O0', 'main.c', '--js-library', 'lib.js', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
     generated = open('a.out.js').read()
     self.assertContained('missing function: NonPrimitive', generated)
     self.assertNotContained('missing function: Int8Array', generated)
@@ -3250,7 +3258,7 @@ int main() {
   printf("c calling: %d\n", jslibfunc(6));
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '--js-library', 'lib.js'])
+    run_process(self.emcc + ['src.cpp', '--js-library', 'lib.js'])
     self.assertContained('c calling: 14\n', run_js('a.out.js'))
 
   def test_EMCC_BUILD_DIR(self):
@@ -3260,23 +3268,23 @@ int main() {
     create_test_file('lib.js', r'''
 printErr('dir was ' + process.env.EMCC_BUILD_DIR);
 ''')
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '--js-library', 'lib.js'], stderr=PIPE).stderr
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '--js-library', 'lib.js'], stderr=PIPE).stderr
     self.assertContained('dir was ' + os.path.realpath(os.path.normpath(self.get_dir())), err)
 
   def test_float_h(self):
-    process = run_process([PYTHON, EMCC, path_from_root('tests', 'float+.c')], stdout=PIPE, stderr=PIPE)
+    process = run_process(self.emcc + [path_from_root('tests', 'float+.c')], stdout=PIPE, stderr=PIPE)
     assert process.returncode == 0, 'float.h should agree with our system: ' + process.stdout + '\n\n\n' + process.stderr
 
   def test_output_is_dir(self):
     ensure_dir('out_dir')
-    err = self.expect_fail([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', 'out_dir/'])
+    err = self.expect_fail(self.emcc + ['-c', path_from_root('tests', 'hello_world.c'), '-o', 'out_dir/'])
     self.assertContained('error: unable to open output file', err)
 
   def test_default_obj_ext(self):
-    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-c', path_from_root('tests', 'hello_world.c')])
     self.assertExists('hello_world.o')
 
-    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '--default-obj-ext', 'obj'])
+    run_process(self.emcc + ['-c', path_from_root('tests', 'hello_world.c'), '--default-obj-ext', 'obj'])
     self.assertExists('hello_world.obj')
 
   def test_doublestart_bug(self):
@@ -3304,7 +3312,7 @@ Module["preRun"].push(function () {
 });
 ''')
 
-    run_process([PYTHON, EMCC, 'code.cpp', '--pre-js', 'pre.js'])
+    run_process(self.emcc + ['code.cpp', '--pre-js', 'pre.js'])
     output = run_js('a.out.js', engine=NODE_JS)
 
     assert output.count('This should only appear once.') == 1, output
@@ -3322,7 +3330,7 @@ int main(void) {
 var Module = { print: function(x) { throw '<{(' + x + ')}>' } };
 ''')
 
-    run_process([PYTHON, EMCC, 'code.cpp', '--pre-js', 'pre.js'])
+    run_process(self.emcc + ['code.cpp', '--pre-js', 'pre.js'])
     output = run_js('a.out.js', stderr=PIPE, full_output=True, engine=NODE_JS, assert_returncode=None)
     assert r'<{(123456789)}>' in output, output
 
@@ -3330,17 +3338,17 @@ var Module = { print: function(x) { throw '<{(' + x + ')}>' } };
     # Check that we don't have any underlying warnings from clang, this can happen if we
     # pass any link flags to when building a pch.
     create_test_file('header.h', '#define X 5\n')
-    run_process([PYTHON, EMCC, '-Werror', '-xc++-header', 'header.h'])
+    run_process(self.emcc + ['-Werror', '-xc++-header', 'header.h'])
 
   def test_precompiled_headers(self):
     for suffix in ['gch', 'pch']:
       print(suffix)
       self.clear()
       create_test_file('header.h', '#define X 5\n')
-      run_process([PYTHON, EMCC, '-xc++-header', 'header.h', '-c'])
+      run_process(self.emcc + ['-xc++-header', 'header.h', '-c'])
       self.assertExists('header.h.gch') # default output is gch
       if suffix != 'gch':
-        run_process([PYTHON, EMCC, '-xc++-header', 'header.h', '-o', 'header.h.' + suffix])
+        run_process(self.emcc + ['-xc++-header', 'header.h', '-o', 'header.h.' + suffix])
         self.assertBinaryEqual('header.h.gch', 'header.h.' + suffix)
 
       create_test_file('src.cpp', r'''
@@ -3350,27 +3358,27 @@ int main() {
   return 0;
 }
 ''')
-      run_process([PYTHON, EMCC, 'src.cpp', '-include', 'header.h'])
+      run_process(self.emcc + ['src.cpp', '-include', 'header.h'])
 
       output = run_js('a.out.js', stderr=PIPE, full_output=True, engine=NODE_JS)
       self.assertContained('|5|', output)
 
       # also verify that the gch is actually used
-      err = run_process([PYTHON, EMCC, 'src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE).stderr
+      err = run_process(self.emcc + ['src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE).stderr
       self.assertTextDataContained('*** PCH/Modules Loaded:\nModule: header.h.' + suffix, err)
       # and sanity check it is not mentioned when not
       try_delete('header.h.' + suffix)
-      err = run_process([PYTHON, EMCC, 'src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE).stderr
+      err = run_process(self.emcc + ['src.cpp', '-include', 'header.h', '-Xclang', '-print-stats'], stderr=PIPE).stderr
       self.assertNotContained('*** PCH/Modules Loaded:\nModule: header.h.' + suffix, err.replace('\r\n', '\n'))
 
       # with specified target via -o
       try_delete('header.h.' + suffix)
-      run_process([PYTHON, EMCC, '-xc++-header', 'header.h', '-o', 'my.' + suffix])
+      run_process(self.emcc + ['-xc++-header', 'header.h', '-o', 'my.' + suffix])
       self.assertExists('my.' + suffix)
 
       # -include-pch flag
-      run_process([PYTHON, EMCC, '-xc++-header', 'header.h', '-o', 'header.h.' + suffix])
-      run_process([PYTHON, EMCC, 'src.cpp', '-include-pch', 'header.h.' + suffix])
+      run_process(self.emcc + ['-xc++-header', 'header.h', '-o', 'header.h.' + suffix])
+      run_process(self.emcc + ['src.cpp', '-include-pch', 'header.h.' + suffix])
       output = run_js('a.out.js')
       self.assertContained('|5|', output)
 
@@ -3391,7 +3399,7 @@ int main() {
   return 0;
 }
 ''')
-    output = run_process([PYTHON, EMCC, 'src.cpp', '-s', 'WASM=0', '-s', 'WARN_UNALIGNED=1', '-g'], stderr=PIPE)
+    output = run_process(self.emcc + ['src.cpp', '-s', 'WASM=0', '-s', 'WARN_UNALIGNED=1', '-g'], stderr=PIPE)
     self.assertContained('emcc: warning: unaligned store', output.stderr)
     self.assertContained('emcc: warning: unaligned store', output.stderr)
     self.assertContained('@line 11 "src.cpp"', output.stderr)
@@ -3402,7 +3410,7 @@ int main() {
 
     def test(expected, opts=[]):
       print(opts)
-      result = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--pre-js', 'pre.js'] + opts, stderr=PIPE, check=False)
+      result = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '--pre-js', 'pre.js'] + opts, stderr=PIPE, check=False)
       if result.returncode == 0:
         self.assertContained(expected, run_js('a.out.js', stderr=PIPE, full_output=True, engine=NODE_JS, assert_returncode=None))
       else:
@@ -3435,7 +3443,7 @@ int main() {
           abort();
         }
       ''')
-    run_process([PYTHON, EMCC, 'src.c', '-s', 'WASM_ASYNC_COMPILATION=0'])
+    run_process(self.emcc + ['src.c', '-s', 'WASM_ASYNC_COMPILATION=0'])
     add_on_abort_and_verify()
 
     # test direct abort() JS call
@@ -3446,7 +3454,7 @@ int main() {
           EM_ASM({ abort() });
         }
       ''')
-    run_process([PYTHON, EMCC, 'src.c', '-s', 'WASM_ASYNC_COMPILATION=0'])
+    run_process(self.emcc + ['src.c', '-s', 'WASM_ASYNC_COMPILATION=0'])
     add_on_abort_and_verify()
 
     # test throwing in an abort handler, and catching that
@@ -3466,7 +3474,7 @@ int main() {
           });
         }
       ''')
-    run_process([PYTHON, EMCC, 'src.c', '-s', 'WASM_ASYNC_COMPILATION=0'])
+    run_process(self.emcc + ['src.c', '-s', 'WASM_ASYNC_COMPILATION=0'])
     with open('a.out.js') as f:
       js = f.read()
     with open('a.out.js', 'w') as f:
@@ -3481,7 +3489,7 @@ int main() {
     self.assertEqual(out.count(expected_output), 2)
 
     # test an abort during startup
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')])
     os.remove('a.out.wasm') # trigger onAbort by intentionally causing startup to fail
     add_on_abort_and_verify()
 
@@ -3516,7 +3524,7 @@ int main(int argc, char **argv) {
           if self.is_wasm_backend() and not wasm:
             continue
           print(wasm, no_exit, opts)
-          cmd = [PYTHON, EMCC] + opts + ['code.cpp', '-s', 'EXIT_RUNTIME=' + str(1 - no_exit), '-s', 'WASM=' + str(wasm)]
+          cmd = self.emcc + opts + ['code.cpp', '-s', 'EXIT_RUNTIME=' + str(1 - no_exit), '-s', 'WASM=' + str(wasm)]
           if wasm:
             cmd += ['--profiling-funcs'] # for function names
           run_process(cmd)
@@ -3564,7 +3572,7 @@ int main() {
           for flush in [0, 1]:
             # TODO: also check FILESYSTEM=0 here. it never worked though, buffered output was not emitted at shutdown
             print(src, no_exit, assertions, flush)
-            cmd = [PYTHON, EMCC, src, '-s', 'EXIT_RUNTIME=%d' % (1 - no_exit), '-s', 'ASSERTIONS=%d' % assertions]
+            cmd = self.emcc + [src, '-s', 'EXIT_RUNTIME=%d' % (1 - no_exit), '-s', 'ASSERTIONS=%d' % assertions]
             if flush:
               cmd += ['-DFLUSH']
             run_process(cmd)
@@ -3577,7 +3585,7 @@ int main() {
   def test_fs_after_main(self):
     for args in [[], ['-O1']]:
       print(args)
-      run_process([PYTHON, EMCC, path_from_root('tests', 'fs_after_main.cpp')])
+      run_process(self.emcc + [path_from_root('tests', 'fs_after_main.cpp')])
       self.assertContained('Test passed.', run_js('a.out.js', engine=NODE_JS))
 
   @no_wasm_backend('tests fastcomp compiler flags')
@@ -3590,7 +3598,7 @@ int main() {
         ('-O3', '-O3'),
       ]:
       print(arg, expect)
-      proc = run_process([PYTHON, EMCC, '-v', path_from_root('tests', 'hello_world.cpp'), arg], stderr=PIPE)
+      proc = run_process(self.emcc + ['-v', path_from_root('tests', 'hello_world.cpp'), arg], stderr=PIPE)
       self.assertContained(expect, proc.stderr)
       self.assertContained('hello, world!', run_js('a.out.js'))
 
@@ -3606,7 +3614,7 @@ int main() {
       ]:
       print(name, args)
       self.clear()
-      run_process([PYTHON, EMCC, '-c', path_from_root('system', 'lib', 'dlmalloc.c')] + args)
+      run_process(self.emcc + ['-c', path_from_root('system', 'lib', 'dlmalloc.c')] + args)
       sizes[name] = os.path.getsize('dlmalloc.o')
     print(sizes)
     opt_min = min(sizes['1'], sizes['2'], sizes['3'], sizes['s'], sizes['z'])
@@ -3674,9 +3682,9 @@ Waste<3> *getMore() {
       (['-O2', '-g', '--llvm-lto', '1'], False),
     ]:
       print(opts, has_global)
-      run_process([PYTHON, EMCC, 'main.cpp', '-c'] + opts)
-      run_process([PYTHON, EMCC, 'side.cpp', '-c'] + opts)
-      run_process([PYTHON, EMCC, 'main.o', 'side.o'] + opts)
+      run_process(self.emcc + ['main.cpp', '-c'] + opts)
+      run_process(self.emcc + ['side.cpp', '-c'] + opts)
+      run_process(self.emcc + ['main.o', 'side.o'] + opts)
       run_js('a.out.js', stderr=PIPE, full_output=True, engine=NODE_JS)
       src = open('a.out.js').read()
       self.assertContained('argc: 1\n16\n17\n10\n', run_js('a.out.js'))
@@ -3691,7 +3699,7 @@ Waste<3> *getMore() {
 double t = emscripten_get_now();
 int main() { printf("t:%d\n", (int)(t>0)); }
 ''')
-    run_process([PYTHON, EMCC, 'one_global_initializer.cpp'])
+    run_process(self.emcc + ['one_global_initializer.cpp'])
     # Above file has one global initializer, should not generate a redundant grouped globalCtors function
     self.assertNotContained('globalCtors', open('a.out.js').read())
     self.assertContained('t:1', run_js('a.out.js'))
@@ -3700,7 +3708,7 @@ int main() { printf("t:%d\n", (int)(t>0)); }
 #include <stdio.h>
 int main() { printf("t:1\n"); }
 ''')
-    run_process([PYTHON, EMCC, 'zero_global_initializers.cpp'])
+    run_process(self.emcc + ['zero_global_initializers.cpp'])
     # Above file should have zero global initializers, should not generate any global initializer functions
     self.assertNotContained('__GLOBAL__sub_', open('a.out.js').read())
     self.assertContained('t:1', run_js('a.out.js'))
@@ -3728,7 +3736,7 @@ int main()
     ]:
       print(opts, expected)
       try_delete('a.out.js')
-      stderr = run_process([PYTHON, EMCC, 'src.c'] + opts, stderr=PIPE, check=False).stderr
+      stderr = run_process(self.emcc + ['src.c'] + opts, stderr=PIPE, check=False).stderr
       for ce in compile_expected + [INCOMPATIBLE_WARNINGS]:
         self.assertContained(ce, stderr)
       if expected is None:
@@ -3746,7 +3754,7 @@ int main()
           extra = []
           if opts != 1 - asserts:
             extra = ['-s', 'ASSERTIONS=' + str(asserts)]
-          cmd = [PYTHON, EMCC, path_from_root('tests', 'sillyfuncast2_noasm.ll'), '-O' + str(opts), '-s', 'WASM=' + str(wasm)] + extra
+          cmd = self.emcc + [path_from_root('tests', 'sillyfuncast2_noasm.ll'), '-O' + str(opts), '-s', 'WASM=' + str(wasm)] + extra
           print(opts, asserts, wasm, cmd)
           # Should not need to pipe stdout here but binaryen writes to stdout
           # when it really should write to stderr.
@@ -3780,7 +3788,7 @@ int main()
     except Exception:
       self.skipTest('Native clang env not found')
     run_process([CLANG_CXX, 'minimal.cpp', '-target', 'x86_64-linux', '-c', '-emit-llvm', '-o', 'a.bc'] + clang_native.get_clang_native_args(), env=vs_env)
-    err = run_process([PYTHON, EMCC, 'a.bc'], stdout=PIPE, stderr=PIPE, check=False).stderr
+    err = run_process(self.emcc + ['a.bc'], stdout=PIPE, stderr=PIPE, check=False).stderr
     if self.is_wasm_backend():
       self.assertContained('machine type must be wasm32', err)
     else:
@@ -3790,18 +3798,18 @@ int main()
   def test_valid_abspath(self):
     # Test whether abspath warning appears
     abs_include_path = os.path.abspath(self.get_dir())
-    err = run_process([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
+    err = run_process(self.emcc + ['-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
     warning = '-I or -L of an absolute path "-I%s" encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript).' % abs_include_path
     self.assertContained(warning, err)
 
     # Passing an absolute path to a directory inside the emscripten tree is always ok and should not issue a warning.
     abs_include_path = path_from_root('tests')
-    err = run_process([PYTHON, EMCC, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
+    err = run_process(self.emcc + ['-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
     warning = '-I or -L of an absolute path "-I%s" encountered. If this is to a local system header/library, it may cause problems (local system files make sense for compiling natively on your system, but not necessarily to JavaScript).' % abs_include_path
     self.assertNotContained(warning, err)
 
     # Hide warning for this include path
-    err = run_process([PYTHON, EMCC, '--valid-abspath', abs_include_path, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
+    err = run_process(self.emcc + ['--valid-abspath', abs_include_path, '-I%s' % abs_include_path, '-Wwarn-absolute-paths', path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
     self.assertNotContained(warning, err)
 
   def test_valid_abspath_2(self):
@@ -3809,7 +3817,7 @@ int main()
       abs_include_path = 'C:\\nowhere\\at\\all'
     else:
       abs_include_path = '/nowhere/at/all'
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--valid-abspath', abs_include_path, '-I%s' % abs_include_path]
+    cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '--valid-abspath', abs_include_path, '-I%s' % abs_include_path]
     print(' '.join(cmd))
     run_process(cmd)
     self.assertContained('hello, world!', run_js('a.out.js'))
@@ -3819,7 +3827,7 @@ int main()
 
     for suffix in ['.o', '.a', '.bc', '.so', '.lib', '.dylib', '.js', '.html']:
       print(suffix)
-      err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'out' + suffix], stderr=PIPE).stderr
+      err = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', 'out' + suffix], stderr=PIPE).stderr
       warning = 'When Emscripten compiles to a typical native suffix for shared libraries (.so, .dylib, .dll) then it emits an object file. You should then compile that to an emscripten SIDE_MODULE (using that flag) with suffix .wasm (for wasm) or .js (for asm.js).'
       self.assertContainedIf(warning, err, suffix in shared_suffixes)
 
@@ -3830,7 +3838,7 @@ int main()
       if self.is_wasm_backend() and not wasm:
         continue
       print(wasm)
-      stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'SIDE_MODULE=1', '-o', 'a.so', '-s', 'WASM=%d' % wasm])
+      stderr = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'SIDE_MODULE=1', '-o', 'a.so', '-s', 'WASM=%d' % wasm])
       self.assertContained('SIDE_MODULE must only be used when compiling to an executable shared library, and not when emitting an object file', stderr)
 
   @no_wasm_backend('asm.js optimizations')
@@ -3846,7 +3854,7 @@ int main()
         if type(ifs) == int:
           ifs = [ifs]
         try_delete('a.out.js')
-        run_process([PYTHON, EMCC, 'src.c', '-O2', '-s', 'WASM=0'] + opts, stdout=PIPE)
+        run_process(self.emcc + ['src.c', '-O2', '-s', 'WASM=0'] + opts, stdout=PIPE)
         src = open('a.out.js').read()
         main = src[src.find('function _main'):src.find('\n}', src.find('function _main'))]
         actual_ifs = main.count('if (')
@@ -3948,7 +3956,7 @@ int main() {
 EM_ASM({ _middle() });
 }
 ''')
-        cmd = [PYTHON, EMCC, 'src.c', '--emit-symbol-map'] + opts
+        cmd = self.emcc + ['src.c', '--emit-symbol-map'] + opts
         cmd += ['-s', 'WASM=%d' % wasm]
         run_process(cmd)
         # check that the map is correct
@@ -3978,9 +3986,9 @@ EM_ASM({ _middle() });
     # e.g. they assume our 'executable' extension is bc, and compile an .o to a .bc
     # (the user would then need to build bc to js of course, but we need to actually
     # emit the bc)
-    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-c', path_from_root('tests', 'hello_world.c')])
     self.assertExists('hello_world.o')
-    run_process([PYTHON, EMCC, 'hello_world.o', '-o', 'hello_world.bc'])
+    run_process(self.emcc + ['hello_world.o', '-o', 'hello_world.bc'])
     self.assertExists('hello_world.o')
     self.assertExists('hello_world.bc')
 
@@ -4013,7 +4021,7 @@ int main() {
                 if emulate_casts and self.is_wasm_backend() and relocatable:
                   # TODO('https://github.com/emscripten-core/emscripten/issues/8507')
                   continue
-                cmd = [PYTHON, EMCC, 'src.cpp', '-O' + str(opts)]
+                cmd = self.emcc + ['src.cpp', '-O' + str(opts)]
                 if not wasm:
                   cmd += ['-s', 'WASM=0']
                 if safe:
@@ -4074,7 +4082,7 @@ int main(int argc, char **argv) {
     sizes_dd = {}
 
     for alias in [None, 0, 1]:
-      cmd = [PYTHON, EMCC, 'src.cpp', '-O1', '-s', 'WASM=0']
+      cmd = self.emcc + ['src.cpp', '-O1', '-s', 'WASM=0']
       if alias is not None:
         cmd += ['-s', 'ALIASING_FUNCTION_POINTERS=' + str(alias)]
       else:
@@ -4098,7 +4106,7 @@ int main(int argc, char **argv) {
   def test_bad_export(self):
     for m in ['', ' ']:
       self.clear()
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=["' + m + '_main"]']
+      cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=["' + m + '_main"]']
       print(cmd)
       stderr = run_process(cmd, stderr=PIPE, check=False).stderr
       if m:
@@ -4107,7 +4115,7 @@ int main(int argc, char **argv) {
         self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_no_dynamic_execution(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'DYNAMIC_EXECUTION=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-O1', '-s', 'DYNAMIC_EXECUTION=0'])
     self.assertContained('hello, world!', run_js('a.out.js'))
     src = open('a.out.js').read()
     self.assertNotContained('eval(', src)
@@ -4117,7 +4125,7 @@ int main(int argc, char **argv) {
 
     # Test that --preload-file doesn't add an use of eval().
     create_test_file('temp.txt', "foo\n")
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1',
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-O1',
                  '-s', 'DYNAMIC_EXECUTION=0', '--preload-file', 'temp.txt'])
     src = open('a.out.js').read()
     assert 'eval(' not in src
@@ -4126,7 +4134,7 @@ int main(int argc, char **argv) {
     try_delete('a.out.js')
 
     # Test that -s DYNAMIC_EXECUTION=1 and -s RELOCATABLE=1 are not allowed together.
-    self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1',
+    self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-O1',
                       '-s', 'DYNAMIC_EXECUTION=0', '-s', 'RELOCATABLE=1'])
     try_delete('a.out.js')
 
@@ -4139,12 +4147,12 @@ int main(int argc, char **argv) {
       ''')
 
     # Test that emscripten_run_script() aborts when -s DYNAMIC_EXECUTION=0
-    run_process([PYTHON, EMCC, 'test.c', '-O1', '-s', 'DYNAMIC_EXECUTION=0'])
+    run_process(self.emcc + ['test.c', '-O1', '-s', 'DYNAMIC_EXECUTION=0'])
     self.assertContained('DYNAMIC_EXECUTION=0 was set, cannot eval', run_js('a.out.js', assert_returncode=None, full_output=True, stderr=PIPE))
     try_delete('a.out.js')
 
     # Test that emscripten_run_script() posts a warning when -s DYNAMIC_EXECUTION=2
-    run_process([PYTHON, EMCC, 'test.c', '-O1', '-s', 'DYNAMIC_EXECUTION=2'])
+    run_process(self.emcc + ['test.c', '-O1', '-s', 'DYNAMIC_EXECUTION=2'])
     self.assertContained('Warning: DYNAMIC_EXECUTION=2 was set, but calling eval in the following location:', run_js('a.out.js', assert_returncode=None, full_output=True, stderr=PIPE))
     self.assertContained('hello from script', run_js('a.out.js', assert_returncode=None, full_output=True, stderr=PIPE))
     try_delete('a.out.js')
@@ -4169,7 +4177,7 @@ int main(int argc, char **argv) {
         printf("file size is %ld\n", size);
       }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained('read: 0\nfile size is 104\n', run_js('a.out.js'))
 
   def test_unlink(self):
@@ -4184,7 +4192,7 @@ int main(int argc, char **argv) {
 }
 ''')
 
-    run_process([PYTHON, EMCC, 'code.cpp'])
+    run_process(self.emcc + ['code.cpp'])
     self.assertContained('I am ' + os.path.realpath(self.get_dir()).replace('\\', '/') + '/a.out.js', run_js('a.out.js', engine=NODE_JS).replace('\\', '/'))
 
   def test_returncode(self):
@@ -4203,7 +4211,7 @@ int main(int argc, char **argv) {
       for no_exit in [0, 1]:
         for call_exit in [0, 1]:
           for async_compile in [0, 1]:
-            run_process([PYTHON, EMCC, 'src.cpp', '-DCODE=%d' % code, '-s', 'EXIT_RUNTIME=%d' % (1 - no_exit), '-DCALL_EXIT=%d' % call_exit, '-s', 'WASM_ASYNC_COMPILATION=%d' % async_compile])
+            run_process(self.emcc + ['src.cpp', '-DCODE=%d' % code, '-s', 'EXIT_RUNTIME=%d' % (1 - no_exit), '-DCALL_EXIT=%d' % call_exit, '-s', 'WASM_ASYNC_COMPILATION=%d' % async_compile])
             for engine in JS_ENGINES:
               # async compilation can't return a code in d8
               if async_compile and engine == V8_ENGINE:
@@ -4229,7 +4237,7 @@ int main(int argc, char **argv) {
     ''')
     for no_exit in [0, 1]:
       for call_exit in [0, 1]:
-        run_process([PYTHON, EMCC, 'src.cpp', '-s', 'EXIT_RUNTIME=%d' % (1 - no_exit), '-DCALL_EXIT=%d' % call_exit])
+        run_process(self.emcc + ['src.cpp', '-s', 'EXIT_RUNTIME=%d' % (1 - no_exit), '-DCALL_EXIT=%d' % call_exit])
         print(no_exit, call_exit)
         out = run_js('a.out.js', stdout=PIPE, stderr=PIPE, full_output=True)
         assert ('emscripten_force_exit cannot actually shut down the runtime, as the build does not have EXIT_RUNTIME set' in out) == (no_exit and call_exit), out
@@ -4260,7 +4268,7 @@ int main(int argc, char **argv) {
   }
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
 
     # cannot create /, can open
     self.assertContained(r'''
@@ -4320,7 +4328,7 @@ int main(int argc, char **argv) {
   }
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
 
     # cannot stat ""
     self.assertContained(r'''Failed to stat path: /a; errno=44
@@ -4344,7 +4352,7 @@ int main(int argc, char **argv) {
   }
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
 
     # cannot symlink nonexistents
     self.assertContained(r'Failed to symlink paths: , abc; errno=44', run_js('a.out.js', args=['', 'abc']))
@@ -4365,7 +4373,7 @@ int main(int argc, char **argv) {
   }
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
 
     # cannot symlink nonexistents
     self.assertContained(r'Failed to rename paths: , abc; errno=44', run_js('a.out.js', args=['', 'abc']))
@@ -4486,7 +4494,7 @@ int main()
   return 0;
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
 
     # cannot symlink nonexistents
     self.assertContained(r'''Before:
@@ -4515,7 +4523,7 @@ dir
         printf("tiny: %d\n", __EMSCRIPTEN_tiny__);
       }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     expected = '''\
 major: %d
 minor: %d
@@ -4532,7 +4540,7 @@ tiny: %d
 int main() {
     return utimes(NULL, NULL);
 }''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
 
   def test_syscall_without_filesystem(self):
     # a program which includes a non-trivial syscall, but disables the filesystem.
@@ -4543,14 +4551,14 @@ extern int __sys_openat(int);
 int main() {
   return __sys_openat(0);
 }''')
-    run_process([PYTHON, EMCC, 'src.c', '-s', 'NO_FILESYSTEM=1'])
+    run_process(self.emcc + ['src.c', '-s', 'NO_FILESYSTEM=1'])
 
   def test_dashS(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-S'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-S'])
     self.assertExists('hello_world.s')
 
   def test_dashS_stdout(self):
-    stdout = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-S', '-o', '-'], stdout=PIPE).stdout
+    stdout = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-S', '-o', '-'], stdout=PIPE).stdout
     self.assertEqual(os.listdir('.'), [])
     self.assertContained('hello_world.c', stdout)
 
@@ -4559,12 +4567,12 @@ int main() {
     # We shouldn't need to copy the file here but if we don't then emcc will
     # internally clobber the hello_world.ll in tests.
     shutil.copyfile(path_from_root('tests', 'hello_world.c'), 'hello_world.c')
-    run_process([PYTHON, EMCC, 'hello_world.c', '-S', '-emit-llvm'])
+    run_process(self.emcc + ['hello_world.c', '-S', '-emit-llvm'])
     self.assertExists('hello_world.ll')
     bitcode = open('hello_world.ll').read()
     self.assertContained('target triple = "', bitcode)
 
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-c', '-emit-llvm'])
     self.assertTrue(Building.is_bitcode('hello_world.bc'))
 
   def test_dashE(self):
@@ -4574,7 +4582,7 @@ __EMSCRIPTEN_major__ __EMSCRIPTEN_minor__ __EMSCRIPTEN_tiny__ EMSCRIPTEN_KEEPALI
 
     def test(args=[]):
       print(args)
-      out = run_process([PYTHON, EMCC, 'src.cpp', '-E'] + args, stdout=PIPE).stdout
+      out = run_process(self.emcc + ['src.cpp', '-E'] + args, stdout=PIPE).stdout
       self.assertContained('%d %d %d __attribute__((used))' % (shared.EMSCRIPTEN_VERSION_MAJOR, shared.EMSCRIPTEN_VERSION_MINOR, shared.EMSCRIPTEN_VERSION_TINY), out)
 
     test()
@@ -4582,19 +4590,19 @@ __EMSCRIPTEN_major__ __EMSCRIPTEN_minor__ __EMSCRIPTEN_tiny__ EMSCRIPTEN_KEEPALI
 
   def test_dashE_respect_dashO(self):
     # issue #3365
-    with_dash_o = run_process([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-E', '-o', 'ignored.js'], stdout=PIPE, stderr=PIPE).stdout
-    without_dash_o = run_process([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-E'], stdout=PIPE, stderr=PIPE).stdout
+    with_dash_o = run_process(self.emxx + [path_from_root('tests', 'hello_world.cpp'), '-E', '-o', 'ignored.js'], stdout=PIPE, stderr=PIPE).stdout
+    without_dash_o = run_process(self.emxx + [path_from_root('tests', 'hello_world.cpp'), '-E'], stdout=PIPE, stderr=PIPE).stdout
     self.assertEqual(len(with_dash_o), 0)
     self.assertNotEqual(len(without_dash_o), 0)
 
   def test_dashM(self):
-    out = run_process([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE).stdout
+    out = run_process(self.emxx + [path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE).stdout
     self.assertContained('hello_world.o:', out) # Verify output is just a dependency rule instead of bitcode or js
 
   def test_dashM_respect_dashO(self):
     # issue #3365
-    with_dash_o = run_process([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M', '-o', 'ignored.js'], stdout=PIPE).stdout
-    without_dash_o = run_process([PYTHON, EMXX, path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE).stdout
+    with_dash_o = run_process(self.emxx + [path_from_root('tests', 'hello_world.cpp'), '-M', '-o', 'ignored.js'], stdout=PIPE).stdout
+    without_dash_o = run_process(self.emxx + [path_from_root('tests', 'hello_world.cpp'), '-M'], stdout=PIPE).stdout
     self.assertEqual(len(with_dash_o), 0)
     self.assertNotEqual(len(without_dash_o), 0)
 
@@ -4730,7 +4738,7 @@ main()
   iterate_backward(answer1, int_adapter());
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '-O2', '-s', 'SAFE_HEAP=1'])
+    run_process(self.emcc + ['src.cpp', '-O2', '-s', 'SAFE_HEAP=1'])
 
   @parameterized({
     'none': [{'EMCC_FORCE_STDLIBS': None}, False],
@@ -4745,7 +4753,7 @@ main()
   })
   def test_only_force_stdlibs(self, env, fail):
     with env_modify(env):
-      run_process([PYTHON, EMXX, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
+      run_process(self.emxx + [path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
       if fail:
         output = self.expect_fail(NODE_JS + ['a.out.js'], stdout=PIPE)
         self.assertContained('missing function', output)
@@ -4769,7 +4777,7 @@ int main()
 }
 ''')
     with env_modify({'EMCC_FORCE_STDLIBS': 'libc,libc++abi,libc++,libmalloc,libpthread', 'EMCC_ONLY_FORCED_STDLIBS': '1'}):
-      run_process([PYTHON, EMXX, 'src.cpp', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
+      run_process(self.emxx + ['src.cpp', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     self.assertContained('Caught exception: std::exception', run_js('a.out.js', stderr=PIPE))
 
   def test_strftime_zZ(self):
@@ -4846,7 +4854,7 @@ int main()
   std::cout << "ok!\n";
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained('ok!', run_js('a.out.js'))
 
   def test_strptime_symmetry(self):
@@ -4956,7 +4964,7 @@ int main()
   return 0;
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained(r'''Creating file: /tmp/file with content=This is some content
 Size of file is: 20
 Truncating file=/tmp/file to length=32
@@ -5039,7 +5047,7 @@ int main()
                      "exists and is read-only.\n\n");
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained(r'''Creating file: /tmp/file with content of size=292
 Data written to file=/tmp/file; successfully wrote 292 bytes
 Creating file: /tmp/file with content of size=79
@@ -5067,7 +5075,7 @@ Failed to open file for writing: /tmp/file; errno=2; Permission denied
           return 0;
       }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '--embed-file', 'large.txt'])
+    run_process(self.emcc + ['src.cpp', '--embed-file', 'large.txt'])
     for engine in JS_ENGINES:
       if engine == V8_ENGINE:
         continue # ooms
@@ -5098,7 +5106,7 @@ main()
   return 123;
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     output = run_js('a.out.js', engine=NODE_JS, assert_returncode=42)
     assert 'callback pre()' in output
     assert 'callback post()' not in output
@@ -5124,7 +5132,7 @@ main(const int argc, const char * const * const argv)
 }
 
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
 
     self.assertContained('locale set to C: C;C;C;C;C;C',
                          run_js('a.out.js', args=['C']))
@@ -5140,14 +5148,14 @@ main(const int argc, const char * const * const argv)
     # Accept-Language: fr,fr-FR;q=0.8,en-US;q=0.5,en;q=0.3
     create_test_file('preamble.js', r'''navigator = {};
       navigator.languages = [ "fr", "fr-FR", "en-US", "en" ];''')
-    run_process([PYTHON, EMCC, '--pre-js', 'preamble.js',
+    run_process(self.emcc + ['--pre-js', 'preamble.js',
                  path_from_root('tests', 'test_browser_language_detection.c')])
     self.assertContained('fr.UTF-8', run_js('a.out.js'))
 
     # Accept-Language: fr-FR,fr;q=0.8,en-US;q=0.5,en;q=0.3
     create_test_file('preamble.js', r'''navigator = {};
       navigator.languages = [ "fr-FR", "fr", "en-US", "en" ];''')
-    run_process([PYTHON, EMCC, '--pre-js', 'preamble.js',
+    run_process(self.emcc + ['--pre-js', 'preamble.js',
                  path_from_root('tests', 'test_browser_language_detection.c')])
     self.assertContained('fr_FR.UTF-8', run_js('a.out.js'))
 
@@ -5161,7 +5169,7 @@ main(const int argc, const char * const * const argv)
       };
     ''')
     create_test_file('src.cpp', '')
-    run_process([PYTHON, EMCC, 'src.cpp', '--pre-js', 'pre_main.js'])
+    run_process(self.emcc + ['src.cpp', '--pre-js', 'pre_main.js'])
     self.assertContained('compiled without a main, but one is present. if you added it from JS, use Module["onRuntimeInitialized"]',
                          run_js('a.out.js', assert_returncode=None, stderr=PIPE))
 
@@ -5180,7 +5188,7 @@ int main() {
   printf("ok.\n");
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained('ok.', run_js('a.out.js', args=['C']))
 
   def test_locale_wrong(self):
@@ -5218,7 +5226,7 @@ main(const int argc, const char * const * const argv)
   }
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'EXIT_RUNTIME=1', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
+    run_process(self.emcc + ['src.cpp', '-s', 'EXIT_RUNTIME=1', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     self.assertContained('Constructed locale "C"\nThis locale is the global locale.\nThis locale is the C locale.', run_js('a.out.js', args=['C']))
     self.assertContained('''Can't construct locale "waka": collate_byname<char>::collate_byname failed to construct for waka''', run_js('a.out.js', args=['waka'], assert_returncode=1))
 
@@ -5229,7 +5237,7 @@ main(const int argc, const char * const * const argv)
       self.clear()
       shutil.copyfile(path_from_root('tests', 'hello_world.c'), 'a.c')
       create_test_file('b.c', ' ')
-      run_process([PYTHON, EMCC, 'a.c', 'b.c'] + args)
+      run_process(self.emcc + ['a.c', 'b.c'] + args)
       clutter = glob.glob('*.o')
       if be_clean:
         assert len(clutter) == 0, 'should not leave clutter ' + str(clutter)
@@ -5266,26 +5274,26 @@ main(const int argc, const char * const * const argv)
       assert found_line_num == has, 'Must have debug info with the line number'
       assert found_filename == has, 'Must have debug info with the filename'
 
-    run_process([PYTHON, EMCC, '-s', 'WASM=0', 'src.c', '-g'])
+    run_process(self.emcc + ['-s', 'WASM=0', 'src.c', '-g'])
     check(True)
-    run_process([PYTHON, EMCC, '-s', 'WASM=0', 'src.c'])
+    run_process(self.emcc + ['-s', 'WASM=0', 'src.c'])
     check(False)
-    run_process([PYTHON, EMCC, '-s', 'WASM=0', 'src.c', '-g0'])
+    run_process(self.emcc + ['-s', 'WASM=0', 'src.c', '-g0'])
     check(False)
-    run_process([PYTHON, EMCC, '-s', 'WASM=0', 'src.c', '-g0', '-g']) # later one overrides
+    run_process(self.emcc + ['-s', 'WASM=0', 'src.c', '-g0', '-g']) # later one overrides
     check(True)
-    run_process([PYTHON, EMCC, '-s', 'WASM=0', 'src.c', '-g', '-g0']) # later one overrides
+    run_process(self.emcc + ['-s', 'WASM=0', 'src.c', '-g', '-g0']) # later one overrides
     check(False)
 
   def test_dash_g_bc(self):
     def test(opts):
       print(opts)
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'a_.bc'] + opts)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', 'a_.bc'] + opts)
       sizes = {'_': os.path.getsize('a_.bc')}
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-g', '-o', 'ag.bc'] + opts)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-g', '-o', 'ag.bc'] + opts)
       sizes['g'] = os.path.getsize('ag.bc')
       for i in range(0, 5):
-        run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-g' + str(i), '-o', 'a' + str(i) + '.bc'] + opts)
+        run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-g' + str(i), '-o', 'a' + str(i) + '.bc'] + opts)
         sizes[i] = os.path.getsize('a' + str(i) + '.bc')
       print('  ', sizes)
       assert sizes['_'] == sizes[0] == sizes[1] == sizes[2], 'no debug means no llvm debug info ' + str(sizes)
@@ -5297,11 +5305,11 @@ main(const int argc, const char * const * const argv)
   def test_no_filesystem(self):
     FS_MARKER = 'var FS'
     # fopen forces full filesystem support
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world_fopen.c'), '-s', 'ASSERTIONS=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world_fopen.c'), '-s', 'ASSERTIONS=0'])
     yes_size = os.path.getsize('a.out.js')
     self.assertContained('hello, world!', run_js('a.out.js'))
     self.assertContained(FS_MARKER, open('a.out.js').read())
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'ASSERTIONS=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'ASSERTIONS=0'])
     no_size = os.path.getsize('a.out.js')
     self.assertContained('hello, world!', run_js('a.out.js'))
     self.assertNotContained(FS_MARKER, open('a.out.js').read())
@@ -5311,7 +5319,7 @@ main(const int argc, const char * const * const argv)
     self.assertLess(no_size, 360000)
 
   def test_no_filesystem_libcxx(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'FILESYSTEM=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'FILESYSTEM=0'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_no_nuthin(self):
@@ -5326,7 +5334,7 @@ main(const int argc, const char * const * const argv)
         # pad the name to a common length so that doesn't effect the size of the
         # output
         padded_name = name + '_' * (20 - len(name))
-        run_process([PYTHON, EMCC, path_from_root('tests', source), '-o', padded_name + '.js'] + opts + moar_opts)
+        run_process(self.emcc + [path_from_root('tests', source), '-o', padded_name + '.js'] + opts + moar_opts)
         sizes[name] = os.path.getsize(padded_name + '.js')
         if os.path.exists(padded_name + '.wasm'):
           sizes[name] += os.path.getsize(padded_name + '.wasm')
@@ -5353,10 +5361,10 @@ main(const int argc, const char * const * const argv)
   def test_no_browser(self):
     BROWSER_INIT = 'var Browser'
 
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')])
     self.assertNotContained(BROWSER_INIT, open('a.out.js').read())
 
-    run_process([PYTHON, EMCC, path_from_root('tests', 'browser_main_loop.c')]) # uses emscripten_set_main_loop, which needs Browser
+    run_process(self.emcc + [path_from_root('tests', 'browser_main_loop.c')]) # uses emscripten_set_main_loop, which needs Browser
     self.assertContained(BROWSER_INIT, open('a.out.js').read())
 
   def test_EXPORTED_RUNTIME_METHODS(self):
@@ -5365,7 +5373,7 @@ main(const int argc, const char * const * const argv)
       self.clear()
       # check without assertions, as with assertions we add stubs for the things we remove (which
       # print nice error messages)
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'ASSERTIONS=0'] + opts)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'ASSERTIONS=0'] + opts)
       self.assertContained('hello, world!', run_js('a.out.js'))
       src = open('a.out.js').read()
       self.assertContained(has, src)
@@ -5434,7 +5442,7 @@ main()
   return fail;
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained(r'''pass: mkdir("path", 0777) == 0
 pass: close(open("path/file", O_CREAT | O_WRONLY, 0644)) == 0
 pass: stat("path", &st) == 0
@@ -5475,9 +5483,9 @@ int main(void) {
   return testy() + init_weakref(5, 6);
 }
 ''')
-    run_process([PYTHON, EMCC, 'x.c', '-o', 'x.o'])
-    run_process([PYTHON, EMCC, 'y.c', '-o', 'y.o'])
-    run_process([PYTHON, EMCC, 'z.c', '-o', 'z.o'])
+    run_process(self.emcc + ['x.c', '-o', 'x.o'])
+    run_process(self.emcc + ['y.c', '-o', 'y.o'])
+    run_process(self.emcc + ['z.c', '-o', 'z.o'])
     try_delete('libtest.a')
     run_process([PYTHON, EMAR, 'rc', 'libtest.a', 'y.o'])
     run_process([PYTHON, EMAR, 'rc', 'libtest.a', 'x.o'])
@@ -5485,17 +5493,17 @@ int main(void) {
 
     for args in [[], ['-O2']]:
       print('args:', args)
-      run_process([PYTHON, EMCC, 'z.o', 'libtest.a', '-s', 'EXIT_RUNTIME=1'] + args)
+      run_process(self.emcc + ['z.o', 'libtest.a', '-s', 'EXIT_RUNTIME=1'] + args)
       run_js('a.out.js', assert_returncode=161)
 
   def test_link_with_bad_o_in_a(self):
     # when building a .a, we force-include all the objects inside it. but, some
     # may not be valid bitcode, e.g. if it contains metadata or something else
     # weird. we should just ignore those
-    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', 'hello_world.o'])
+    run_process(self.emcc + ['-c', path_from_root('tests', 'hello_world.c'), '-o', 'hello_world.o'])
     create_test_file('bad.obj', 'this is not a good file, it should be ignored!')
     run_process([LLVM_AR, 'cr', 'libfoo.a', 'hello_world.o', 'bad.obj'])
-    run_process([PYTHON, EMCC, 'libfoo.a'])
+    run_process(self.emcc + ['libfoo.a'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_require(self):
@@ -5505,33 +5513,33 @@ int main(void) {
     assert output.stdout == 'hello, world!\n' and output.stderr == '', 'expected no output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % (output.stdout, output.stderr)
 
   def test_require_modularize(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'ASSERTIONS=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'ASSERTIONS=0'])
     src = open('a.out.js').read()
     self.assertContained('module.exports = Module;', src)
     output = run_process(NODE_JS + ['-e', 'var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE)
     self.assertFalse(output.stderr)
     self.assertEqual(output.stdout, 'hello, world!\n')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="NotModule"', '-s', 'ASSERTIONS=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="NotModule"', '-s', 'ASSERTIONS=0'])
     src = open('a.out.js').read()
     self.assertContained('module.exports = NotModule;', src)
     output = run_process(NODE_JS + ['-e', 'var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE)
     self.assertFalse(output.stderr)
     self.assertEqual(output.stdout, 'hello, world!\n')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1'])
     # We call require() twice to ensure it returns wrapper function each time
     output = run_process(NODE_JS + ['-e', 'require("./a.out.js")();var m = require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE)
     self.assertFalse(output.stderr)
     self.assertEqual(output.stdout, 'hello, world!\nhello, world!\n')
 
   def test_define_modularize(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'ASSERTIONS=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'ASSERTIONS=0'])
     with open('a.out.js') as f:
       src = 'var module = 0; ' + f.read()
     create_test_file('a.out.js', src)
     assert "define([], function() { return Module; });" in src
     output = run_process(NODE_JS + ['-e', 'var m; (global.define = function(deps, factory) { m = factory(); }).amd = true; require("./a.out.js"); m();'], stdout=PIPE, stderr=PIPE)
     assert output.stdout == 'hello, world!\n' and output.stderr == '', 'expected output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % (output.stdout, output.stderr)
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="NotModule"', '-s', 'ASSERTIONS=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME="NotModule"', '-s', 'ASSERTIONS=0'])
     with open('a.out.js') as f:
       src = 'var module = 0; ' + f.read()
     create_test_file('a.out.js', src)
@@ -5540,7 +5548,7 @@ int main(void) {
     assert output.stdout == 'hello, world!\n' and output.stderr == '', 'expected output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % (output.stdout, output.stderr)
 
   def test_EXPORT_NAME_with_html(self):
-    result = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'a.html', '-s', 'EXPORT_NAME=Other'], stdout=PIPE, check=False, stderr=STDOUT)
+    result = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', 'a.html', '-s', 'EXPORT_NAME=Other'], stdout=PIPE, check=False, stderr=STDOUT)
     self.assertNotEqual(result.returncode, 0)
     self.assertContained('Customizing EXPORT_NAME requires that the HTML be customized to use that name', result.stdout)
 
@@ -5565,7 +5573,7 @@ int main(void) {
       main_name = 'main.c'
       create_test_file(main_name, main)
 
-      err = run_process([PYTHON, EMCC, '-v', '-c', main_name, lib_name] + args, stderr=PIPE).stderr
+      err = run_process(self.emcc + ['-v', '-c', main_name, lib_name] + args, stderr=PIPE).stderr
 
       VECTORIZE = '-disable-loop-vectorization'
 
@@ -5576,7 +5584,7 @@ int main(void) {
       else:
         assert err.count(VECTORIZE) == 0, err # no optimizations
 
-      run_process([PYTHON, EMCC, main_name.replace('.c', '.o'), lib_name.replace('.c', '.o')])
+      run_process(self.emcc + [main_name.replace('.c', '.o'), lib_name.replace('.c', '.o')])
 
       self.assertContained('result: 1', run_js('a.out.js'))
 
@@ -5608,12 +5616,12 @@ public:
 Descriptor desc;
     ''')
     try_delete('a.out.js')
-    run_process([PYTHON, EMCC, 'src.cpp', '-O2', '-s', 'EXPORT_ALL'])
+    run_process(self.emcc + ['src.cpp', '-O2', '-s', 'EXPORT_ALL'])
     self.assertExists('a.out.js')
 
   @no_wasm_backend('tests PRECISE_F32=1')
   def test_f0(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'fasta.cpp'), '-O2', '-s', 'PRECISE_F32=1', '-profiling', '-s', 'WASM=0'])
+    run_process(self.emcc + [path_from_root('tests', 'fasta.cpp'), '-O2', '-s', 'PRECISE_F32=1', '-profiling', '-s', 'WASM=0'])
     src = open('a.out.js').read()
     assert ' = f0;' in src or ' = f0,' in src
 
@@ -5680,16 +5688,16 @@ int main() {
 }
 ''')
     try_delete('a.out.js')
-    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'EXIT_RUNTIME=1'])
+    run_process(self.emcc + ['src.cpp', '-s', 'EXIT_RUNTIME=1'])
     self.assertContained('exiting now, status 14', run_js('a.out.js', assert_returncode=14))
 
   def test_NO_aliasing(self):
     # the NO_ prefix flips boolean options
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EXIT_RUNTIME=1'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'EXIT_RUNTIME=1'])
     exit_1 = open('a.out.js').read()
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'NO_EXIT_RUNTIME=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'NO_EXIT_RUNTIME=0'])
     no_exit_0 = open('a.out.js').read()
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EXIT_RUNTIME=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'EXIT_RUNTIME=0'])
     exit_0 = open('a.out.js').read()
 
     assert exit_1 == no_exit_0
@@ -5702,7 +5710,7 @@ int main() {
   _exit(0); // should not end up in an infinite loop with non-underscore exit
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained('', run_js('a.out.js', assert_returncode=0))
 
   def test_file_packager_huge(self):
@@ -5725,7 +5733,7 @@ int main() {
   return x == 0; // can't alloc it, but don't fail catastrophically, expect null
 }
     ''')
-    run_process([PYTHON, EMCC, 'main.cpp', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'WASM=0'])
+    run_process(self.emcc + ['main.cpp', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'WASM=0'])
     # just care about message regarding allocating over 1GB of memory
     output = run_js('a.out.js', stderr=PIPE, full_output=True)
     if self.is_wasm_backend():
@@ -5733,7 +5741,7 @@ int main() {
     else:
       self.assertContained('''Warning: Enlarging memory arrays, this is not fast! 16777216,1476395008\n''', output)
     print('wasm')
-    run_process([PYTHON, EMCC, 'main.cpp', '-s', 'ALLOW_MEMORY_GROWTH=1'])
+    run_process(self.emcc + ['main.cpp', '-s', 'ALLOW_MEMORY_GROWTH=1'])
     # no message about growth, just check return code
     run_js('a.out.js', stderr=PIPE, full_output=True)
 
@@ -5787,7 +5795,7 @@ int main() {
   printf("managed another malloc!\n");
 }
 ''' % (pre_fail, post_fail))
-          args = [PYTHON, EMCC, 'main.cpp'] + opts + aborting_args
+          args = self.emcc + ['main.cpp'] + opts + aborting_args
           args += ['-s', 'TEST_MEMORY_GROWTH_FAILS=1'] # In this test, force memory growing to fail
           if growth:
             args += ['-s', 'ALLOW_MEMORY_GROWTH=1']
@@ -5838,7 +5846,7 @@ int main() {
 }
 ''')
 
-    run_process([PYTHON, EMCC, '-O1', 'test.cpp', '-s', 'ALLOW_MEMORY_GROWTH'])
+    run_process(self.emcc + ['-O1', 'test.cpp', '-s', 'ALLOW_MEMORY_GROWTH'])
     self.assertContained('done', run_js('a.out.js'))
 
   def test_libcxx_minimal(self):
@@ -5853,8 +5861,8 @@ int main(int argc, char** argv) {
 }
 ''')
 
-    run_process([PYTHON, EMCC, '-O2', 'vector.cpp', '-o', 'vector.js'])
-    run_process([PYTHON, EMCC, '-O2', path_from_root('tests', 'hello_libcxx.cpp'), '-o', 'iostream.js'])
+    run_process(self.emcc + ['-O2', 'vector.cpp', '-o', 'vector.js'])
+    run_process(self.emcc + ['-O2', path_from_root('tests', 'hello_libcxx.cpp'), '-o', 'iostream.js'])
 
     vector = os.path.getsize('vector.js')
     iostream = os.path.getsize('iostream.js')
@@ -5885,7 +5893,7 @@ int main(int argc, char** argv) {
 
     def test(args, expected):
       print(args, expected)
-      run_process([PYTHON, EMCC, 'src.c', '-s', 'WASM=0'] + args, stderr=PIPE)
+      run_process(self.emcc + ['src.c', '-s', 'WASM=0'] + args, stderr=PIPE)
       self.assertContained(expected, run_js('a.out.js'))
 
     for opts in [0, 1, 2, 3]:
@@ -5930,7 +5938,7 @@ int main(int argc, char** argv) {
 
     def test(args, expected):
       print(args, expected.replace('\n', ' '))
-      run_process([PYTHON, EMCC, 'src.c', '-s', 'WASM=0'] + args)
+      run_process(self.emcc + ['src.c', '-s', 'WASM=0'] + args)
       self.assertContained(expected, run_js('a.out.js'))
 
     for opts in [0, 1, 2]:
@@ -5962,7 +5970,7 @@ int main(int argc, char** argv) {
           }
         ''')
         # -fno-builtin to prevent printf -> iprintf optimization
-        run_process([PYTHON, EMCC, 'library.c', '-fno-builtin', '-s', 'SIDE_MODULE=1', '-O2', '-o', library_file, '-s', 'WASM=' + str(wasm), '-s', 'EXPORT_ALL'] + library_args)
+        run_process(self.emcc + ['library.c', '-fno-builtin', '-s', 'SIDE_MODULE=1', '-O2', '-o', library_file, '-s', 'WASM=' + str(wasm), '-s', 'EXPORT_ALL'] + library_args)
         create_test_file('main.c', r'''
           #include <dlfcn.h>
           #include <stdio.h>
@@ -5979,7 +5987,7 @@ int main(int argc, char** argv) {
             else x();
           }
         ''' % library_file)
-        run_process([PYTHON, EMCC, 'main.c', '--embed-file', library_file, '-O2', '-s', 'WASM=' + str(wasm)] + main_args)
+        run_process(self.emcc + ['main.c', '--embed-file', library_file, '-O2', '-s', 'WASM=' + str(wasm)] + main_args)
         self.assertContained(expected, run_js('a.out.js', assert_returncode=None, stderr=STDOUT))
         size = os.path.getsize('a.out.js')
         if wasm:
@@ -6118,11 +6126,11 @@ main()
 
 ''')
 
-    run_process([PYTHON, EMCC, '-o', 'libhello1.wasm', 'hello1.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
-    run_process([PYTHON, EMCC, '-o', 'libhello2.wasm', 'hello2.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
-    run_process([PYTHON, EMCC, '-o', 'libhello3.wasm', 'hello3.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
-    run_process([PYTHON, EMCC, '-o', 'libhello4.wasm', 'hello4.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
-    run_process([PYTHON, EMCC, '-o', 'main.js', 'main.c', '-s', 'MAIN_MODULE=1', '-s', 'INITIAL_MEMORY=' + str(32 * 1024 * 1024),
+    run_process(self.emcc + ['-o', 'libhello1.wasm', 'hello1.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
+    run_process(self.emcc + ['-o', 'libhello2.wasm', 'hello2.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
+    run_process(self.emcc + ['-o', 'libhello3.wasm', 'hello3.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
+    run_process(self.emcc + ['-o', 'libhello4.wasm', 'hello4.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
+    run_process(self.emcc + ['-o', 'main.js', 'main.c', '-s', 'MAIN_MODULE=1', '-s', 'INITIAL_MEMORY=' + str(32 * 1024 * 1024),
                  '--embed-file', 'libhello1.wasm@/lib/libhello1.wasm',
                  '--embed-file', 'libhello2.wasm@/usr/lib/libhello2.wasm',
                  '--embed-file', 'libhello3.wasm@/libhello3.wasm',
@@ -6193,9 +6201,9 @@ main(int argc,char** argv)
 }
 ''')
 
-    run_process([PYTHON, EMCC, '-o', 'libhello1.js', 'hello1.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
-    run_process([PYTHON, EMCC, '-o', 'libhello2.js', 'hello2.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
-    run_process([PYTHON, EMCC, '-o', 'main.js', 'main.c', '-s', 'MAIN_MODULE=1',
+    run_process(self.emcc + ['-o', 'libhello1.js', 'hello1.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
+    run_process(self.emcc + ['-o', 'libhello2.js', 'hello2.c', '-s', 'SIDE_MODULE=1', '-s', 'EXPORT_ALL=1'])
+    run_process(self.emcc + ['-o', 'main.js', 'main.c', '-s', 'MAIN_MODULE=1',
                  '--embed-file', 'libhello1.wasm',
                  '--embed-file', 'libhello2.wasm'])
     out = run_js('main.js')
@@ -6240,12 +6248,12 @@ main(int argc,char** argv)
         return 0;
       }
       ''')
-    run_process([PYTHON, EMCC, '-o', 'libside.wasm', 'side.cpp', '-s', 'SIDE_MODULE=1', '-fexceptions'])
+    run_process(self.emcc + ['-o', 'libside.wasm', 'side.cpp', '-s', 'SIDE_MODULE=1', '-fexceptions'])
 
     def build_main(args):
       print(args)
       with env_modify({'EMCC_FORCE_STDLIBS': 'libc++abi'}):
-        run_process([PYTHON, EMCC, 'main.cpp', '-s', 'MAIN_MODULE=1',
+        run_process(self.emcc + ['main.cpp', '-s', 'MAIN_MODULE=1',
                      '--embed-file', 'libside.wasm'] + args)
 
     build_main([])
@@ -6275,7 +6283,7 @@ int main() {
   printf("hello, world!\n");
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.c', '-s', 'EXPORTED_FUNCTIONS=["_main", "_treecount"]', '--minify', '0', '-g4', '-Oz'])
+    run_process(self.emcc + ['src.c', '-s', 'EXPORTED_FUNCTIONS=["_main", "_treecount"]', '--minify', '0', '-g4', '-Oz'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   @no_wasm_backend('MEM_INIT_METHOD not supported under wasm')
@@ -6285,7 +6293,7 @@ int main() {
 int main() { printf("Mary had a little lamb.\n"); }
 ''')
 
-    run_process([PYTHON, EMCC, 'src.c', '--memory-init-file', '0', '-s', 'MEM_INIT_METHOD=2', '-s', 'ASSERTIONS=1', '-s', 'WASM=0'])
+    run_process(self.emcc + ['src.c', '--memory-init-file', '0', '-s', 'MEM_INIT_METHOD=2', '-s', 'ASSERTIONS=1', '-s', 'WASM=0'])
     with open('a.out.js') as f:
       d = f.read()
     return
@@ -6326,7 +6334,7 @@ int main() {
   test(-1.0/0.0);
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.c'])
+    run_process(self.emcc + ['src.c'])
     out = run_js('a.out.js')
     self.assertContained('''
 |0 : 1 : 0 : 0 : 1|
@@ -6374,11 +6382,11 @@ int main() {
   puts("ok");
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained('ok', run_js('a.out.js'))
 
   def test_no_warn_exported_jslibfunc(self):
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'),
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'),
                        '-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=["alGetError"]',
                        '-s', 'EXPORTED_FUNCTIONS=["_main", "_alGetError"]'], stderr=PIPE).stderr
     self.assertNotContained('function requested to be exported, but not implemented: "_alGetError"', err)
@@ -6387,7 +6395,7 @@ int main() {
   def test_almost_asm_warning(self):
     def run(args, expected):
       print(args, expected)
-      err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0'] + args, stderr=PIPE).stderr
+      err = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0'] + args, stderr=PIPE).stderr
       if expected:
         self.assertContained('[-Walmost-asm]', err)
       else:
@@ -6400,14 +6408,14 @@ int main() {
     run(['-O1', '-s', 'ALLOW_MEMORY_GROWTH=1', '-Wno-almost-asm', '-Walmost-asm'], True)
 
   def test_musl_syscalls(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')])
     src = open('a.out.js').read()
     # there should be no musl syscalls in hello world output
     self.assertNotContained('__syscall', src)
 
   @no_windows('posix-only')
   def test_emcc_dev_null(self):
-    out = run_process([PYTHON, EMCC, '-dM', '-E', '-x', 'c', '/dev/null'], stdout=PIPE).stdout
+    out = run_process(self.emcc + ['-dM', '-E', '-x', 'c', '/dev/null'], stdout=PIPE).stdout
     self.assertContained('#define __EMSCRIPTEN__ 1', out) # all our defines should show up
 
   def test_umask_0(self):
@@ -6418,11 +6426,11 @@ int main() {
   umask(0);
   printf("hello, world!\n");
 }''')
-    run_process([PYTHON, EMCC, 'src.c'])
+    run_process(self.emcc + ['src.c'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_no_missing_symbols(self): # simple hello world should not show any missing symbols
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')])
 
     # main() is implemented in C, and even if requested from JS, we should not warn
     create_test_file('library_foo.js', '''
@@ -6448,7 +6456,7 @@ int main() {
   return EXIT_SUCCESS;
 }
 ''')
-    run_process([PYTHON, EMCC, 'test.cpp', '--js-library', 'library_foo.js'])
+    run_process(self.emcc + ['test.cpp', '--js-library', 'library_foo.js'])
 
     # but we do error on a missing js var
     create_test_file('library_foo_missing.js', '''
@@ -6461,11 +6469,11 @@ mergeInto(LibraryManager.library, {
   }()),
 });
 ''')
-    err = self.expect_fail([PYTHON, EMCC, 'test.cpp', '--js-library', 'library_foo_missing.js'])
+    err = self.expect_fail(self.emcc + ['test.cpp', '--js-library', 'library_foo_missing.js'])
     self.assertContained('undefined symbol: nonexistingvariable', err)
 
     # and also for missing C code, of course (without the --js-library, it's just a missing C method)
-    err = self.expect_fail([PYTHON, EMCC, 'test.cpp'])
+    err = self.expect_fail(self.emcc + ['test.cpp'])
     self.assertContained('undefined symbol: my_js', err)
 
   @no_fastcomp('fastcomp links in memset in JS in a hackish way')
@@ -6499,7 +6507,7 @@ int main(int argc, char** argv) {
 }
 ''')
 
-    err = self.expect_fail([PYTHON, EMCC, 'test.cpp', '--js-library', 'lib.js'])
+    err = self.expect_fail(self.emcc + ['test.cpp', '--js-library', 'lib.js'])
     self.assertContained('_memset may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library', err)
 
     # without the dep, and with EXPORTED_FUNCTIONS, it works ok
@@ -6510,7 +6518,7 @@ mergeInto(LibraryManager.library, {
   },
 });
 ''')
-    run_process([PYTHON, EMCC, 'test.cpp', '--js-library', 'lib.js', '-s', 'EXPORTED_FUNCTIONS=[_main,_memset]'])
+    run_process(self.emcc + ['test.cpp', '--js-library', 'lib.js', '-s', 'EXPORTED_FUNCTIONS=[_main,_memset]'])
     self.assertContained('dddddddddd', run_js('a.out.js'))
 
   def test_realpath(self):
@@ -6538,7 +6546,7 @@ main(int argc, char **argv)
 ''')
     ensure_dir('boot')
     create_test_file(os.path.join('boot', 'README.txt'), ' ')
-    run_process([PYTHON, EMCC, 'src.c', '--embed-file', 'boot'])
+    run_process(self.emcc + ['src.c', '--embed-file', 'boot'])
     self.assertContained('Resolved: /boot/README.txt', run_js('a.out.js'))
 
   def test_realpath_nodefs(self):
@@ -6570,7 +6578,7 @@ main(int argc, char **argv)
 }
 ''')
     create_test_file('TEST_NODEFS.txt', ' ')
-    run_process([PYTHON, EMCC, 'src.c', '-lnodefs.js'])
+    run_process(self.emcc + ['src.c', '-lnodefs.js'])
     self.assertContained('Resolved: /working/TEST_NODEFS.txt', run_js('a.out.js'))
 
   def test_realpath_2(self):
@@ -6610,7 +6618,7 @@ int main(int argc, char **argv)
 ''')
     create_test_file('testfile.txt', '')
     create_test_file(os.path.join('Folder', 'testfile.txt'), '')
-    run_process([PYTHON, EMCC, 'src.c', '--embed-file', 'testfile.txt', '--embed-file', 'Folder'])
+    run_process(self.emcc + ['src.c', '--embed-file', 'testfile.txt', '--embed-file', 'Folder'])
     self.assertContained('''Resolved: "testfile.txt" => "/testfile.txt"
 Resolved: "Folder/testfile.txt" => "/Folder/testfile.txt"
 Resolve failed: "testnonexistentfile.txt"
@@ -6623,9 +6631,9 @@ Resolved: "/" => "/"
 
   def test_no_warnings(self):
     # build once before to make sure system libs etc. exist
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp')])
+    run_process(self.emcc + [path_from_root('tests', 'hello_libcxx.cpp')])
     # check that there is nothing in stderr for a regular compile
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp')], stderr=PIPE).stderr
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_libcxx.cpp')], stderr=PIPE).stderr
     self.assertEqual(err, '')
 
   @no_wasm_backend("llvm-lto is fastcomp only flag")
@@ -6633,7 +6641,7 @@ Resolved: "/" => "/"
     sizes = {}
     lto_levels = [0, 1, 2, 3]
     for lto in lto_levels:
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-O2', '--llvm-lto', str(lto)]
+      cmd = self.emcc + [path_from_root('tests', 'hello_libcxx.cpp'), '-O2', '--llvm-lto', str(lto)]
       if self.is_wasm_backend():
         cmd += ['-flto']
       print(cmd)
@@ -6663,10 +6671,10 @@ Resolved: "/" => "/"
         printf("double-freed\n");
       }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained('double-freed', run_js('a.out.js'))
     # in debug mode, the double-free is caught
-    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'ASSERTIONS=2'])
+    run_process(self.emcc + ['src.cpp', '-s', 'ASSERTIONS=2'])
     seen_error = False
     out = '?'
     try:
@@ -6685,7 +6693,7 @@ Resolved: "/" => "/"
         ('emmalloc', 'emmalloc')
       ):
         print(malloc, name)
-        cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-o', 'a.out.js'] + opts
+        cmd = self.emcc + [path_from_root('tests', 'hello_libcxx.cpp'), '-o', 'a.out.js'] + opts
         if malloc:
           cmd += ['-s', 'MALLOC="%s"' % malloc]
         print(cmd)
@@ -6703,10 +6711,10 @@ Resolved: "/" => "/"
   def test_emmalloc_2GB(self):
     def test(args, text=None):
       if text:
-        stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MALLOC=emmalloc'] + args)
+        stderr = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MALLOC=emmalloc'] + args)
         self.assertContained(text, stderr)
       else:
-        run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MALLOC=emmalloc'] + args)
+        run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MALLOC=emmalloc'] + args)
 
     test(['-s', 'INITIAL_MEMORY=2GB'], 'INITIAL_MEMORY must be less than 2GB due to current spec limitations')
     # emmalloc allows growth by default (as the max size is fine), but not if
@@ -6719,7 +6727,7 @@ Resolved: "/" => "/"
   def test_2GB_plus(self):
     # when the heap size can be over 2GB, we rewrite pointers to be unsigned
     def test(page_diff):
-      args = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-s', 'ALLOW_MEMORY_GROWTH']
+      args = self.emcc + [path_from_root('tests', 'hello_world.c'), '-O2', '-s', 'ALLOW_MEMORY_GROWTH']
       if page_diff is not None:
         args += ['-s', 'MAXIMUM_MEMORY=%d' % (2**31 + page_diff * 64 * 1024)]
       print(args)
@@ -6750,7 +6758,7 @@ Resolved: "/" => "/"
     # The MS 32 bits should be available in Runtime.getTempRet0() even when compiled with -O2 --closure 1
 
     # Compile test.c and wrap it in a native JavaScript binding so we can call our compiled function from JS.
-    run_process([PYTHON, EMCC, path_from_root('tests', 'return64bit', 'test.c'),
+    run_process(self.emcc + [path_from_root('tests', 'return64bit', 'test.c'),
                  '--pre-js', path_from_root('tests', 'return64bit', 'testbindstart.js'),
                  '--pre-js', path_from_root('tests', 'return64bit', bind_js),
                  '--post-js', path_from_root('tests', 'return64bit', 'testbindend.js'),
@@ -6776,59 +6784,59 @@ high = 1234
 ''', out)
 
   def test_lib_include_flags(self):
-    run_process([PYTHON, EMCC] + '-l m -l c -I'.split() + [path_from_root('tests', 'include_test'), path_from_root('tests', 'lib_include_flags.c')])
+    run_process(self.emcc + '-l m -l c -I'.split() + [path_from_root('tests', 'include_test'), path_from_root('tests', 'lib_include_flags.c')])
 
   def test_dash_s(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def test_dash_s_response_file_string(self):
     create_test_file('response_file', '"MyModule"\n')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORT_NAME=@response_file'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORT_NAME=@response_file'])
 
   def test_dash_s_response_file_list(self):
     create_test_file('response_file', '["_main", "_malloc"]\n')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=@response_file'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=@response_file'])
 
   def test_dash_s_response_file_misssing(self):
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=@foo'])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=@foo'])
     self.assertContained('error: foo: file not found parsing argument: EXPORTED_FUNCTIONS=@foo', err)
 
   def test_dash_s_unclosed_quote(self):
     # Unclosed quote
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY='MISSING_QUOTE"], stderr=PIPE, check=False).stderr
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY='MISSING_QUOTE"], stderr=PIPE, check=False).stderr
     self.assertNotContained('AssertionError', err) # Do not mention that it is an assertion error
     self.assertContained('unclosed opened quoted string. expected final character to be "\'"', err)
 
   def test_dash_s_single_quote(self):
     # Only one quote
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY='"], stderr=PIPE, check=False).stderr
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY='"], stderr=PIPE, check=False).stderr
     self.assertNotContained('AssertionError', err) # Do not mention that it is an assertion error
     self.assertContained('unclosed opened quoted string.', err)
 
   def test_dash_s_unclosed_list(self):
     # Unclosed list
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY=[Value1, Value2"])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY=[Value1, Value2"])
     self.assertNotContained('AssertionError', err) # Do not mention that it is an assertion error
     self.assertContained('unclosed opened string list. expected final character to be "]"', err)
 
   def test_dash_s_valid_list(self):
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY=[Value1, \"Value2\"]"])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), "-s", "TEST_KEY=[Value1, \"Value2\"]"])
     self.assertNotContained('a problem occurred in evaluating the content after a "-s", specifically', err)
 
   def test_dash_s_wrong_type(self):
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=foo'])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=foo'])
     self.assertContained("error: setting `EXPORTED_FUNCTIONS` expects `<class 'list'>` but got `<class 'str'>`", err)
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'EXIT_RUNTIME=[foo,bar]'])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'EXIT_RUNTIME=[foo,bar]'])
     self.assertContained("error: setting `EXIT_RUNTIME` expects `<class 'int'>` but got `<class 'list'>`", err)
 
   def test_dash_s_typo(self):
     # with suggestions
-    stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'DISABLE_EXCEPTION_CATCH=1'])
+    stderr = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'DISABLE_EXCEPTION_CATCH=1'])
     self.assertContained("Attempt to set a non-existent setting: 'DISABLE_EXCEPTION_CATCH'", stderr)
     self.assertContained('did you mean one of DISABLE_EXCEPTION_CATCHING', stderr)
     # no suggestions
-    stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'CHEEZ=1'])
+    stderr = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'CHEEZ=1'])
     self.assertContained("perhaps a typo in emcc\'s  -s X=Y  notation?", stderr)
     self.assertContained('(see src/settings.js for valid values)', stderr)
 
@@ -6846,9 +6854,9 @@ high = 1234
       print(python, has)
       if has:
         print('  checking emcc.py...')
-        run_process([python, EMCC, '--version'], stdout=PIPE)
+        run_process([python, shared.EMCC, '--version'], stdout=PIPE)
         print('  checking em++.py...')
-        run_process([python, EMXX, '--version'], stdout=PIPE)
+        run_process([python, shared.EMXX, '--version'], stdout=PIPE)
 
     run('python')
     run('python2')
@@ -6863,7 +6871,7 @@ int main() {
   return 0;
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.c', '-O2', '-g'])
+    run_process(self.emcc + ['src.c', '-O2', '-g'])
     size = os.path.getsize('a.out.wasm')
     # size should be much smaller than the size of that zero-initialized buffer
     self.assertLess(size, 123456 / 2)
@@ -6871,26 +6879,26 @@ int main() {
   @no_wasm_backend('asm.js')
   def test_separate_asm_warning(self):
     # Test that -s PRECISE_F32=2 raises a warning that --separate-asm is implied.
-    stderr = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-s', 'PRECISE_F32=2', '-o', 'a.html'], stderr=PIPE).stderr
+    stderr = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-s', 'PRECISE_F32=2', '-o', 'a.html'], stderr=PIPE).stderr
     self.assertContained('forcing separate asm output', stderr)
 
     # Test that -s PRECISE_F32=2 --separate-asm should not post a warning.
-    stderr = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-s', 'PRECISE_F32=2', '-o', 'a.html', '--separate-asm'], stderr=PIPE).stderr
+    stderr = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-s', 'PRECISE_F32=2', '-o', 'a.html', '--separate-asm'], stderr=PIPE).stderr
     self.assertNotContained('forcing separate asm output', stderr)
 
     # Test that -s PRECISE_F32=1 should not post a warning.
-    stderr = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-s', 'PRECISE_F32=1', '-o', 'a.html'], stderr=PIPE).stderr
+    stderr = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-s', 'PRECISE_F32=1', '-o', 'a.html'], stderr=PIPE).stderr
     self.assertNotContained('forcing separate asm output', stderr)
 
     # Manually doing separate asm should show a warning, if not targeting html
     warning = '--separate-asm works best when compiling to HTML'
-    stderr = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '--separate-asm'], stderr=PIPE).stderr
+    stderr = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '--separate-asm'], stderr=PIPE).stderr
     self.assertContained(warning, stderr)
-    stderr = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '--separate-asm', '-o', 'a.html'], stderr=PIPE).stderr
+    stderr = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '--separate-asm', '-o', 'a.html'], stderr=PIPE).stderr
     self.assertNotContained(warning, stderr)
 
     # test that the warning can be suppressed
-    stderr = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '--separate-asm', '-Wno-separate-asm'], stderr=PIPE).stderr
+    stderr = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '--separate-asm', '-Wno-separate-asm'], stderr=PIPE).stderr
     self.assertNotContained(warning, stderr)
 
   def test_canonicalize_nan_warning(self):
@@ -6911,10 +6919,10 @@ int main() {
 }
 ''')
 
-    stderr = run_process([PYTHON, EMCC, 'src.cpp', '-O1'], stderr=PIPE).stderr
+    stderr = run_process(self.emcc + ['src.cpp', '-O1'], stderr=PIPE).stderr
     if not self.is_wasm_backend():
       self.assertContained("emcc: warning: cannot represent a NaN literal", stderr)
-      stderr = run_process([PYTHON, EMCC, 'src.cpp', '-O1', '-g'], stderr=PIPE).stderr
+      stderr = run_process(self.emcc + ['src.cpp', '-O1', '-g'], stderr=PIPE).stderr
       self.assertContained("emcc: warning: cannot represent a NaN literal", stderr)
       self.assertContained('//@line 12 "src.cpp"', stderr)
     else:
@@ -6949,7 +6957,7 @@ int main() {
       self.assertItemsEqual(link_args, ['main.cpp.o'])
 
   def test_memory_growth_noasm(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-s', 'ALLOW_MEMORY_GROWTH=1'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-O2', '-s', 'ALLOW_MEMORY_GROWTH=1'])
     src = open('a.out.js').read()
     assert 'use asm' not in src
 
@@ -6964,7 +6972,7 @@ int main() {
   }, int64_t(0x12345678ABCDEF1FLL));
 }
 ''')
-    stderr = self.expect_fail([PYTHON, EMCC, 'src.cpp', '-Oz'])
+    stderr = self.expect_fail(self.emcc + ['src.cpp', '-Oz'])
     if not self.is_wasm_backend():
       self.assertContained('EM_ASM should not receive i64s as inputs, they are not valid in JS', stderr)
 
@@ -6984,7 +6992,7 @@ int main() {
         int main() {}
       '''
       create_test_file('src.cpp', src)
-      run_process([PYTHON, EMCC, 'src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs', '-s', 'WASM=%d' % wasm])
+      run_process(self.emcc + ['src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs', '-s', 'WASM=%d' % wasm])
 
   @no_wasm_backend('EVAL_CTORS is monolithic with the wasm backend')
   def test_eval_ctors(self):
@@ -6998,7 +7006,7 @@ int main() {
 
       def get_size(args):
         print('get_size', args)
-        run_process([PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WASM=%d' % wasm] + args)
+        run_process(self.emcc + [path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WASM=%d' % wasm] + args)
         self.assertContained('hello, world!', run_js('a.out.js'))
         if wasm:
           codesize = self.count_wasm_contents('a.out.wasm', 'funcs')
@@ -7056,7 +7064,7 @@ int main() {
           }
         ''' % (p1, p2, p3, last)
         create_test_file('src.cpp', src)
-        run_process([PYTHON, EMCC, 'src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs', '-s', 'WASM=%d' % wasm])
+        run_process(self.emcc + ['src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs', '-s', 'WASM=%d' % wasm])
         self.assertContained('total is %s.' % hex(expected), run_js('a.out.js'))
         shutil.copyfile('a.out.js', 'x' + hex(expected) + '.js')
         if wasm:
@@ -7096,7 +7104,7 @@ mergeInto(LibraryManager.library, {
   C c;
   int main() {}
       ''')
-      err = run_process([PYTHON, EMCC, 'src.cpp', '--js-library', 'lib.js', '-Oz', '-s', 'WASM=%d' % wasm], stderr=PIPE).stderr
+      err = run_process(self.emcc + ['src.cpp', '--js-library', 'lib.js', '-Oz', '-s', 'WASM=%d' % wasm], stderr=PIPE).stderr
       if self.is_wasm_backend():
         # disabled in the wasm backend
         self.assertContained('Ctor evalling in the wasm backend is disabled', err)
@@ -7121,7 +7129,7 @@ mergeInto(LibraryManager.library, {
 ''')
     # use SINGLE_FILE since we don't want to depend on loading a side .wasm file on the environment in this test;
     # with the wrong env we have very odd failures
-    run_process([PYTHON, EMCC, 'main.cpp', '-s', 'SINGLE_FILE=1'])
+    run_process(self.emcc + ['main.cpp', '-s', 'SINGLE_FILE=1'])
     src = open('a.out.js').read()
     envs = ['web', 'worker', 'node', 'shell']
     for env in envs:
@@ -7153,7 +7161,7 @@ mergeInto(LibraryManager.library, {
         printf("|%s|\n", getenv("hello"));
       }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '--pre-js', 'pre.js'])
+    run_process(self.emcc + ['src.cpp', '--pre-js', 'pre.js'])
     self.assertContained('|world|', run_js('a.out.js'))
 
     create_test_file('pre.js', r'''
@@ -7161,17 +7169,17 @@ mergeInto(LibraryManager.library, {
         preRun: [function(module) { module.ENV.hello = 'world' }]
       };
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '--pre-js', 'pre.js', '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["ENV"]'])
+    run_process(self.emcc + ['src.cpp', '--pre-js', 'pre.js', '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["ENV"]'])
     self.assertContained('|world|', run_js('a.out.js'))
 
-    run_process([PYTHON, EMCC, 'src.cpp', '--pre-js', 'pre.js', '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["ENV"]', '-s', 'MODULARIZE=1'])
+    run_process(self.emcc + ['src.cpp', '--pre-js', 'pre.js', '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=["ENV"]', '-s', 'MODULARIZE=1'])
     output = run_process(NODE_JS + ['-e', 'require("./a.out.js")();'], stdout=PIPE, stderr=PIPE)
     self.assertContained('|world|', output.stdout)
 
   def test_warn_no_filesystem(self):
     WARNING = 'Filesystem support (FS) was not included. The problem is that you are using files from JS, but files were not used from C/C++, so filesystem support was not auto-included. You can force-include filesystem support with  -s FORCE_FILESYSTEM=1'
 
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')])
     seen = run_js('a.out.js', stderr=PIPE)
     assert WARNING not in seen
 
@@ -7185,7 +7193,7 @@ mergeInto(LibraryManager.library, {
     return 0;
   }
   ''' % contents)
-      run_process([PYTHON, EMCC, 'src.cpp'])
+      run_process(self.emcc + ['src.cpp'])
       self.assertContained(WARNING, run_js('a.out.js', stderr=PIPE, assert_returncode=None))
 
     # might appear in handwritten code
@@ -7199,13 +7207,13 @@ mergeInto(LibraryManager.library, {
     test("Module['FS_createPreloadedFile']('waka waka, just warning check')")
 
     # text is in the source when needed, but when forcing FS, it isn't there
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     self.assertContained(WARNING, open('a.out.js').read())
-    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'FORCE_FILESYSTEM=1']) # forcing FS means no need
+    run_process(self.emcc + ['src.cpp', '-s', 'FORCE_FILESYSTEM=1']) # forcing FS means no need
     self.assertNotContained(WARNING, open('a.out.js').read())
-    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'ASSERTIONS=0']) # no assertions, no need
+    run_process(self.emcc + ['src.cpp', '-s', 'ASSERTIONS=0']) # no assertions, no need
     self.assertNotContained(WARNING, open('a.out.js').read())
-    run_process([PYTHON, EMCC, 'src.cpp', '-O2']) # optimized, so no assertions
+    run_process(self.emcc + ['src.cpp', '-O2']) # optimized, so no assertions
     self.assertNotContained(WARNING, open('a.out.js').read())
 
   def test_warn_module_print_err(self):
@@ -7219,7 +7227,7 @@ mergeInto(LibraryManager.library, {
     return 0;
   }
   ''' % contents)
-      run_process([PYTHON, EMCC, 'src.cpp'] + args)
+      run_process(self.emcc + ['src.cpp'] + args)
       self.assertContained(expected, run_js('a.out.js', stderr=STDOUT, assert_returncode=None))
 
     # error shown (when assertions are on)
@@ -7234,7 +7242,7 @@ mergeInto(LibraryManager.library, {
   def test_warn_unexported_main(self):
     WARNING = 'main() is in the input files, but "_main" is not in EXPORTED_FUNCTIONS, which means it may be eliminated as dead code. Export it if you want main() to run.'
 
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=[]'], stderr=PIPE)
+    proc = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'EXPORTED_FUNCTIONS=[]'], stderr=PIPE)
     self.assertContained(WARNING, proc.stderr)
 
   ############################################################
@@ -7363,13 +7371,13 @@ mergeInto(LibraryManager.library, {
 
   @no_wasm_backend('uses CYBERDWARF')
   def test_cyberdwarf_pointers(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'debugger', 'test_pointers.cpp'), '-Oz', '-s', 'CYBERDWARF=1',
+    run_process(self.emcc + [path_from_root('tests', 'debugger', 'test_pointers.cpp'), '-Oz', '-s', 'CYBERDWARF=1',
                  '--pre-js', path_from_root('tests', 'debugger', 'test_preamble.js'), '-o', 'test_pointers.js'])
     run_js('test_pointers.js', engine=NODE_JS)
 
   @no_wasm_backend('uses CYBERDWARF')
   def test_cyberdwarf_union(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'debugger', 'test_union.cpp'), '-Oz', '-s', 'CYBERDWARF=1',
+    run_process(self.emcc + [path_from_root('tests', 'debugger', 'test_union.cpp'), '-Oz', '-s', 'CYBERDWARF=1',
                  '--pre-js', path_from_root('tests', 'debugger', 'test_preamble.js'), '-o', 'test_union.js'])
     run_js('test_union.js', engine=NODE_JS)
 
@@ -7383,10 +7391,10 @@ int main() {
   return 0;
 }
     ''')
-    run_process([PYTHON, EMCC, '-Wall', '-x', 'c++', 'src_tmp_fixed_lang'])
+    run_process(self.emcc + ['-Wall', '-x', 'c++', 'src_tmp_fixed_lang'])
     self.assertContained("Test_source_fixed_lang_hello", run_js('a.out.js'))
 
-    stderr = self.expect_fail([PYTHON, EMCC, '-Wall', 'src_tmp_fixed_lang'])
+    stderr = self.expect_fail(self.emcc + ['-Wall', 'src_tmp_fixed_lang'])
     self.assertContained("Input file has an unknown suffix, don't know what to do with it!", stderr)
 
   def test_disable_inlining(self):
@@ -7403,7 +7411,7 @@ int main() {
 }
 ''')
     # Without the 'INLINING_LIMIT=1', -O2 inlines foo()
-    cmd = [PYTHON, EMCC, 'test.c', '-O2', '-o', 'test.bc', '-s', 'INLINING_LIMIT=1']
+    cmd = self.emcc + ['test.c', '-O2', '-o', 'test.bc', '-s', 'INLINING_LIMIT=1']
     if self.is_wasm_backend():
       cmd += ['-flto']
     run_process(cmd)
@@ -7427,7 +7435,7 @@ int main() {
             files += ['a.asm.js']
           if output_suffix == 'html':
             files += ['a.html']
-          cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'a.' + output_suffix, '--output_eol', eol] + params
+          cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', 'a.' + output_suffix, '--output_eol', eol] + params
           run_process(cmd)
           for f in files:
             print(str(cmd) + ' ' + str(params) + ' ' + eol + ' ' + f)
@@ -7461,7 +7469,7 @@ int main() {
         try_delete('a.out.js')
         try_delete('a.out.wasm')
         try_delete('a.out.wat')
-        cmd = [PYTHON, EMCC, path_from_root('tests', 'core', 'test_i64.c')] + args
+        cmd = self.emcc + [path_from_root('tests', 'core', 'test_i64.c')] + args
         print(args, 'js opts:', expect_js_opts, 'only-wasm:', expect_only_wasm, '   ', ' '.join(cmd))
         err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
         assert expect_js_opts == ('applying js optimization passes:' in err), err
@@ -7500,7 +7508,7 @@ int main() {
       ]:
       print(args, expect)
       try_delete('a.out.js')
-      err = run_process([PYTHON, EMCC, '-v', path_from_root('tests', 'hello_world.cpp'), '-s', 'BINARYEN=1'] + args, stderr=PIPE).stderr
+      err = run_process(self.emcc + ['-v', path_from_root('tests', 'hello_world.cpp'), '-s', 'BINARYEN=1'] + args, stderr=PIPE).stderr
       assert expect == (' -emscripten-precise-f32' in err), err
       self.assertContained('hello, world!', run_js('a.out.js'))
 
@@ -7520,7 +7528,7 @@ int main() {
       print(args, expect_names)
       try_delete('a.out.js')
       # we use dlmalloc here, as emmalloc has a bunch of asserts that contain the text "malloc" in them, which makes counting harder
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + args + ['-s', 'MALLOC="dlmalloc"'])
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp')] + args + ['-s', 'MALLOC="dlmalloc"'])
       code = open('a.out.wasm', 'rb').read()
       if expect_names:
         # name section adds the name of malloc (there is also another one for the export)
@@ -7535,13 +7543,13 @@ int main() {
   def test_binaryen_warn_mem(self):
     # if user changes INITIAL_MEMORY at runtime, the wasm module may not accept the memory import if it is too big/small
     create_test_file('pre.js', 'var Module = { INITIAL_MEMORY: 50 * 1024 * 1024 };\n')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'INITIAL_MEMORY=' + str(16 * 1024 * 1024), '--pre-js', 'pre.js', '-s', 'WASM_ASYNC_COMPILATION=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'INITIAL_MEMORY=' + str(16 * 1024 * 1024), '--pre-js', 'pre.js', '-s', 'WASM_ASYNC_COMPILATION=0'])
     out = run_js('a.out.js', full_output=True, stderr=PIPE, assert_returncode=None)
     self.assertContained('LinkError', out)
     self.assertContained('Memory size incompatibility issues may be due to changing INITIAL_MEMORY at runtime to something too large. Use ALLOW_MEMORY_GROWTH to allow any size memory (and also make sure not to set INITIAL_MEMORY at runtime to something smaller than it was at compile time).', out)
     self.assertNotContained('hello, world!', out)
     # and with memory growth, all should be good
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'INITIAL_MEMORY=' + str(16 * 1024 * 1024), '--pre-js', 'pre.js', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'WASM_ASYNC_COMPILATION=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'INITIAL_MEMORY=' + str(16 * 1024 * 1024), '--pre-js', 'pre.js', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'WASM_ASYNC_COMPILATION=0'])
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   @no_wasm_backend('asm.js specific')
@@ -7552,7 +7560,7 @@ int main() {
       (['-s', 'MAIN_MODULE=2'], False),
     ]:
       with temp_directory(self.get_dir()) as temp_dir:
-        cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join(temp_dir, 'a.js')] + args
+        cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', os.path.join(temp_dir, 'a.js')] + args
         print(' '.join(cmd))
         run_process(cmd)
         if output_asmjs:
@@ -7562,12 +7570,12 @@ int main() {
     # Test that outputting to .wasm does not nuke an existing .asm.js file, if
     # user wants to manually dual-deploy both to same directory.
     with temp_directory(self.get_dir()) as temp_dir:
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-o', os.path.join(temp_dir, 'a.js'), '--separate-asm']
+      cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=0', '-o', os.path.join(temp_dir, 'a.js'), '--separate-asm']
       print(' '.join(cmd))
       run_process(cmd)
       self.assertExists(os.path.join(temp_dir, 'a.asm.js'))
 
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join(temp_dir, 'a.js')]
+      cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', os.path.join(temp_dir, 'a.js')]
       print(' '.join(cmd))
       run_process(cmd)
       self.assertExists(os.path.join(temp_dir, 'a.asm.js'))
@@ -7582,7 +7590,7 @@ int main() {
         (['-s', 'INITIAL_MEMORY=20971520',                                '-s', 'MAXIMUM_MEMORY=41943040'], 320, 640),
         (['-s', 'INITIAL_MEMORY=20971520', '-s', 'ALLOW_MEMORY_GROWTH=1', '-s', 'MAXIMUM_MEMORY=41943040'], 320, 640),
       ]:
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-O2'] + args
+      cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-O2'] + args
       print(' '.join(cmd))
       run_process(cmd)
       wat = run_process([os.path.join(Building.get_binaryen_bin(), 'wasm-dis'), 'a.out.wasm'], stdout=PIPE).stdout
@@ -7598,35 +7606,35 @@ int main() {
 
   def test_invalid_mem(self):
     # A large amount is fine, multiple of 16MB or not
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=33MB'])
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=32MB'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=33MB'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=32MB'])
 
     # But not in asm.js
     if not self.is_wasm_backend():
-      ret = self.expect_fail([PYTHON, EMCC, '-s', 'WASM=0', path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=33MB'])
+      ret = self.expect_fail(self.emcc + ['-s', 'WASM=0', path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=33MB'])
       self.assertContained('INITIAL_MEMORY must be a multiple of 16MB', ret)
 
     # A tiny amount is fine in wasm
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=65536', '-s', 'TOTAL_STACK=1024'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=65536', '-s', 'TOTAL_STACK=1024'])
     # And the program works!
     self.assertContained('hello, world!', run_js('a.out.js'))
 
     # But not in asm.js
     if not self.is_wasm_backend():
-      ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=65536', '-s', 'WASM=0'])
+      ret = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=65536', '-s', 'WASM=0'])
       self.assertContained('INITIAL_MEMORY must be at least 16MB', ret)
 
     # Must be a multiple of 64KB
-    ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=33554433']) # 32MB + 1 byte
+    ret = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=33554433']) # 32MB + 1 byte
     self.assertContained('INITIAL_MEMORY must be a multiple of 64KB', ret)
 
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MAXIMUM_MEMORY=33MB'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MAXIMUM_MEMORY=33MB'])
 
-    ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MAXIMUM_MEMORY=34603009']) # 33MB + 1 byte
+    ret = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MAXIMUM_MEMORY=34603009']) # 33MB + 1 byte
     self.assertContained('MAXIMUM_MEMORY must be a multiple of 64KB', ret)
 
   def test_invalid_output_dir(self):
-    ret = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('NONEXISTING_DIRECTORY', 'out.js')])
+    ret = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', os.path.join('NONEXISTING_DIRECTORY', 'out.js')])
     self.assertContained('specified output file (NONEXISTING_DIRECTORY%sout.js) is in a directory that does not exist' % os.path.sep, ret)
 
   def test_binaryen_ctors(self):
@@ -7643,11 +7651,11 @@ int main() {
       B b;
       int main() {}
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'])
+    run_process(self.emcc + ['src.cpp'])
     correct = run_js('a.out.js')
     for args in [[], ['-s', 'RELOCATABLE=1']]:
       print(args)
-      run_process([PYTHON, EMCC, 'src.cpp', '-s', 'WASM=1', '-o', 'b.out.js'] + args)
+      run_process(self.emcc + ['src.cpp', '-s', 'WASM=1', '-o', 'b.out.js'] + args)
       seen = run_js('b.out.js')
       assert correct == seen, correct + '\n vs \n' + seen
 
@@ -7671,7 +7679,7 @@ int main() {
         ]:
         print(args, expect_dash_g, expect_emit_text)
         try_delete('a.out.wat')
-        cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1'] + args
+        cmd = self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1'] + args
         print(' '.join(cmd))
         err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
         if not self.is_wasm_backend():
@@ -7698,7 +7706,7 @@ int main() {
           (['-s', 'BINARYEN_IGNORE_IMPLICIT_TRAPS=1'], True),
         ]:
         print(args, expect)
-        cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WASM=1', '-O3'] + args
+        cmd = self.emcc + [path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WASM=1', '-O3'] + args
         print(' '.join(cmd))
         err = run_process(cmd, stdout=PIPE, stderr=PIPE).stderr
         self.assertContainedIf('--ignore-implicit-traps ', err, expect)
@@ -7710,7 +7718,7 @@ int main() {
   @no_fastcomp('BINARYEN_EXTRA_PASSES is used to optimize only in the wasm backend (fastcomp uses flags to asm2wasm)')
   def test_binaryen_passes_extra(self):
     def build(args=[]):
-      return run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-O3'] + args, stdout=PIPE).stdout
+      return run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-O3'] + args, stdout=PIPE).stdout
 
     build()
     base_size = os.path.getsize('a.out.wasm')
@@ -7767,7 +7775,7 @@ int main() {
       expected_basename += '_fastcomp'
     expected_basename += args_to_filename(args)
 
-    run_process([PYTHON, EMCC, filename, '-g2'] + args)
+    run_process(self.emcc + [filename, '-g2'] + args)
     # find the imports we send from JS
     js = open('a.out.js').read()
     start = js.find('asmLibraryArg = ')
@@ -7956,7 +7964,7 @@ int main() {
   # ensures runtime exports work, even with metadce
   def test_extra_runtime_exports(self):
     exports = ['stackSave', 'stackRestore', 'stackAlloc', 'FS']
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1', '-Os', '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=%s' % str(exports)])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=1', '-Os', '-s', 'EXTRA_EXPORTED_RUNTIME_METHODS=%s' % str(exports)])
     js = open('a.out.js').read()
     for export in exports:
       assert ('Module["%s"]' % export) in js, export
@@ -7975,7 +7983,7 @@ int main() {
       print(args)
       try_delete('a.out.wasm')
       try_delete('a.out.wat')
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'ffi.c'), '-g', '-o', 'a.out.js'] + args
+      cmd = self.emcc + [path_from_root('tests', 'other', 'ffi.c'), '-g', '-o', 'a.out.js'] + args
       print(' '.join(cmd))
       run_process(cmd)
       run_process([wasm_dis, 'a.out.wasm', '-o', 'a.out.wat'])
@@ -8024,7 +8032,7 @@ int main() {
       try_delete('a.out.wasm')
       try_delete('a.out.wat')
       with env_modify({'EMCC_FORCE_STDLIBS': 'libc++'}):
-        cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'noffi.cpp'), '-g', '-o', 'a.out.js'] + args
+        cmd = self.emcc + [path_from_root('tests', 'other', 'noffi.cpp'), '-g', '-o', 'a.out.js'] + args
       print(' '.join(cmd))
       run_process(cmd)
       run_process([wasm_dis, 'a.out.wasm', '-o', 'a.out.wat'])
@@ -8043,13 +8051,13 @@ int main() {
   def test_export_aliasee(self):
     # build side module
     args = ['-s', 'SIDE_MODULE=1']
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'alias', 'side.c'), '-g', '-o', 'side.wasm'] + args
+    cmd = self.emcc + [path_from_root('tests', 'other', 'alias', 'side.c'), '-g', '-o', 'side.wasm'] + args
     print(' '.join(cmd))
     run_process(cmd)
 
     # build main module
     args = ['-s', 'EXPORTED_FUNCTIONS=["_main", "_foo"]', '-s', 'MAIN_MODULE=2', '-s', 'EXIT_RUNTIME=1', '-lnodefs.js']
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'alias', 'main.c'), '-o', 'main.js'] + args
+    cmd = self.emcc + [path_from_root('tests', 'other', 'alias', 'main.c'), '-o', 'main.js'] + args
     print(' '.join(cmd))
     run_process(cmd)
 
@@ -8060,7 +8068,7 @@ int main() {
     def run(args, expected):
       if self.is_wasm_backend() and 'WASM=0' in args:
         return
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'unistd', 'sysconf_phys_pages.c')] + args
+      cmd = self.emcc + [path_from_root('tests', 'unistd', 'sysconf_phys_pages.c')] + args
       print(str(cmd))
       run_process(cmd)
       result = run_js('a.out.js').strip()
@@ -8090,7 +8098,7 @@ int main() {
         print(opts, potentially_expect_minified_exports_and_imports, target, ' => ', expect_minified_exports_and_imports, standalone)
 
         self.clear()
-        run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', target] + opts)
+        run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-o', target] + opts)
         self.assertExists('out.wasm')
         if target.endswith('.wasm'):
           # only wasm requested
@@ -8122,7 +8130,7 @@ int main() {
       # specified target
       print('building: ' + target)
       self.clear()
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'SIDE_MODULE=1'] + opts)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'SIDE_MODULE=1'] + opts)
       for x in os.listdir('.'):
         assert not x.endswith('.js'), 'we should not emit js when making a wasm side module: ' + x
       self.assertIn(b'dylink', open(target, 'rb').read())
@@ -8137,27 +8145,27 @@ int main() {
       print(args)
 
       print('wasm in object')
-      run_process([PYTHON, EMXX, src] + args + ['-c', '-o', 'hello_obj.o'])
+      run_process(self.emxx + [src] + args + ['-c', '-o', 'hello_obj.o'])
       self.assertTrue(shared.Building.is_wasm('hello_obj.o'))
       self.assertFalse(shared.Building.is_bitcode('hello_obj.o'))
 
       print('bitcode in object')
-      run_process([PYTHON, EMXX, src] + args + ['-c', '-o', 'hello_bitcode.o', '-flto'])
+      run_process(self.emxx + [src] + args + ['-c', '-o', 'hello_bitcode.o', '-flto'])
       self.assertFalse(shared.Building.is_wasm('hello_bitcode.o'))
       self.assertTrue(shared.Building.is_bitcode('hello_bitcode.o'))
 
       print('use bitcode object (LTO)')
-      run_process([PYTHON, EMXX, 'hello_bitcode.o'] + args + ['-flto'])
+      run_process(self.emxx + ['hello_bitcode.o'] + args + ['-flto'])
       self.assertContained('hello, world!', run_js('a.out.js'))
       print('use bitcode object (non-LTO)')
-      run_process([PYTHON, EMXX, 'hello_bitcode.o'] + args)
+      run_process(self.emxx + ['hello_bitcode.o'] + args)
       self.assertContained('hello, world!', run_js('a.out.js'))
 
       print('use native object (LTO)')
-      run_process([PYTHON, EMXX, 'hello_obj.o'] + args + ['-flto'])
+      run_process(self.emxx + ['hello_obj.o'] + args + ['-flto'])
       self.assertContained('hello, world!', run_js('a.out.js'))
       print('use native object (non-LTO)')
-      run_process([PYTHON, EMXX, 'hello_obj.o'] + args)
+      run_process(self.emxx + ['hello_obj.o'] + args)
       self.assertContained('hello, world!', run_js('a.out.js'))
 
   @parameterized({
@@ -8166,7 +8174,7 @@ int main() {
   })
   @no_fastcomp('test wasm object files')
   def test_wasm_backend_lto_libcxx(self, *args):
-    run_process([PYTHON, EMXX, path_from_root('tests', 'hello_libcxx.cpp'), '-flto'] + list(args))
+    run_process(self.emxx + [path_from_root('tests', 'hello_libcxx.cpp'), '-flto'] + list(args))
 
   @no_fastcomp('wasm backend lto specific')
   def test_lto_flags(self):
@@ -8177,7 +8185,7 @@ int main() {
       (['-s', 'WASM_OBJECT_FILES=0'], True),
       (['-s', 'WASM_OBJECT_FILES=1'], False),
     ]:
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp')] + flags + ['-c', '-o', 'a.o'])
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp')] + flags + ['-c', '-o', 'a.o'])
       seen_bitcode = Building.is_bitcode('a.o')
       self.assertEqual(expect_bitcode, seen_bitcode, 'must emit LTO-capable bitcode when flags indicate so (%s)' % str(flags))
 
@@ -8186,7 +8194,7 @@ int main() {
       print(opts)
       # check we show a good error message if there is no wasm support
       create_test_file('pre.js', 'WebAssembly = undefined;\n')
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '--pre-js', 'pre.js'] + opts)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '--pre-js', 'pre.js'] + opts)
       out = run_js('a.out.js', stderr=STDOUT, assert_returncode=None)
       if opts == []:
         self.assertContained('No WebAssembly support found. Build with -s WASM=0 to target JavaScript instead.', out)
@@ -8224,7 +8232,7 @@ int main() {
 
   def test_error_on_missing_libraries(self):
     # -llsomenonexistingfile is an error by default
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile'])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-lsomenonexistingfile'])
     if self.is_wasm_backend():
       self.assertContained('wasm-ld: error: unable to find library -lsomenonexistingfile', err)
     else:
@@ -8233,7 +8241,7 @@ int main() {
   # Tests that if user accidentally attempts to link native object code, we show an error
   def test_native_link_error_message(self):
     run_process([CLANG_CC, '-c', path_from_root('tests', 'hello_123.c'), '-o', 'hello_123.o'])
-    err = self.expect_fail([PYTHON, EMCC, 'hello_123.o', '-o', 'hello_123.js'])
+    err = self.expect_fail(self.emcc + ['hello_123.o', '-o', 'hello_123.js'])
     self.assertContained('hello_123.o is not a valid input', err)
 
   # Tests that we should give a clear error on INITIAL_MEMORY not being enough for static initialization + stack
@@ -8245,7 +8253,7 @@ int main() {
           return (int)&muchData;
         }
       ''')
-    err = self.expect_fail([PYTHON, EMCC, 'src.cpp', '-s', 'TOTAL_STACK=1KB', '-s', 'INITIAL_MEMORY=64KB'])
+    err = self.expect_fail(self.emcc + ['src.cpp', '-s', 'TOTAL_STACK=1KB', '-s', 'INITIAL_MEMORY=64KB'])
     if self.is_wasm_backend():
       self.assertContained('wasm-ld: error: initial memory too small', err)
     else:
@@ -8253,12 +8261,12 @@ int main() {
 
   def test_o_level_clamp(self):
     for level in [3, 4, 20]:
-      err = run_process([PYTHON, EMCC, '-O' + str(level), path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
+      err = run_process(self.emcc + ['-O' + str(level), path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
       self.assertContainedIf("optimization level '-O" + str(level) + "' is not supported; using '-O3' instead", err, level > 3)
 
   # Tests that if user specifies multiple -o output directives, then the last one will take precedence
   def test_multiple_o_files(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'a.js', '-o', 'b.js'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', 'a.js', '-o', 'b.js'])
     assert os.path.isfile('b.js')
     assert not os.path.isfile('a.js')
 
@@ -8280,7 +8288,7 @@ int main() {
           print(inc)
           create_test_file('a.c', inc)
           create_test_file('b.c', inc)
-          run_process([PYTHON, EMCC] + std + ['a.c', 'b.c'])
+          run_process(self.emcc + std + ['a.c', 'b.c'])
 
   @is_slow_test
   def test_single_file(self):
@@ -8299,7 +8307,7 @@ int main() {
       expect_meminit = meminit1_enabled and not wasm_enabled
       expect_wat = debug_enabled and wasm_enabled and not self.is_wasm_backend()
 
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c')]
+      cmd = self.emcc + [path_from_root('tests', 'hello_world.c')]
 
       if single_file_enabled:
         expect_meminit = False
@@ -8373,22 +8381,22 @@ end
     # This test added because we had an issue with the AUTO_ARCHIVE_INDEXES failing on empty
     # archives (which inherently don't have indexes).
     run_process([PYTHON, EMAR, 'crS', 'libfoo.a'])
-    run_process([PYTHON, EMCC, '-Werror', 'libfoo.a', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-Werror', 'libfoo.a', path_from_root('tests', 'hello_world.c')])
 
   def test_archive_no_index(self):
     create_test_file('foo.c', 'int foo = 1;')
-    run_process([PYTHON, EMCC, '-c', 'foo.c'])
-    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-c', 'foo.c'])
+    run_process(self.emcc + ['-c', path_from_root('tests', 'hello_world.c')])
     # The `S` flag means don't add an archive index
     run_process([PYTHON, EMAR, 'crS', 'libfoo.a', 'foo.o'])
     # The llvm backend (link GNU ld and lld) doesn't support linking archives with no index.
     # However we have logic that will automatically add indexes (unless running with
     # NO_AUTO_ARCHIVE_INDEXES).
     if self.is_wasm_backend():
-      stderr = self.expect_fail([PYTHON, EMCC, '-s', 'NO_AUTO_ARCHIVE_INDEXES', 'libfoo.a', 'hello_world.o'])
+      stderr = self.expect_fail(self.emcc + ['-s', 'NO_AUTO_ARCHIVE_INDEXES', 'libfoo.a', 'hello_world.o'])
       self.assertContained('libfoo.a: archive has no index; run ranlib to add one', stderr)
     # The default behavior is to add archive indexes automatically.
-    run_process([PYTHON, EMCC, 'libfoo.a', 'hello_world.o'])
+    run_process(self.emcc + ['libfoo.a', 'hello_world.o'])
 
   @no_fastcomp('AUTO_ARCHIVE_INDEXES only applies to wasm backend')
   def test_archive_non_objects(self):
@@ -8396,18 +8404,18 @@ end
     # llvm-nm has issues with files that start with two or more null bytes since it thinks they
     # are COFF files.  Ensure that we correctly ignore such files when we process them.
     create_test_file('zeros.bin', '\0\0\0\0')
-    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-c', path_from_root('tests', 'hello_world.c')])
     # No index added.
     # --format=darwin (the default on OSX has a strange issue where it add extra
     # newlines to files: https://bugs.llvm.org/show_bug.cgi?id=42562
     run_process([PYTHON, EMAR, 'crS', '--format=gnu', 'libfoo.a', 'file.txt', 'zeros.bin', 'hello_world.o'])
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), 'libfoo.a'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), 'libfoo.a'])
 
   def test_flag_aliases(self):
     def assert_aliases_match(flag1, flag2, flagarg, extra_args=[]):
       results = {}
       for f in (flag1, flag2):
-        run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', f + '=' + flagarg] + extra_args)
+        run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', f + '=' + flagarg] + extra_args)
         with open('a.out.js') as out:
           results[f + '.js'] = out.read()
         with open('a.out.wasm', 'rb') as out:
@@ -8434,7 +8442,7 @@ end
     ''')
 
     def test(check, extra=[]):
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '--pre-js', 'pre.js'] + extra
+      cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '--pre-js', 'pre.js'] + extra
       proc = run_process(cmd, check=check, stderr=PIPE)
       if not check:
         self.assertNotEqual(proc.returncode, 0)
@@ -8453,22 +8461,22 @@ end
     # are including a lot of JS without corresponding compiled code for it. This still
     # lets us catch all other errors.
     with env_modify({'EMCC_CLOSURE_ARGS': '--jscomp_off undefinedVars'}):
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-O1', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
 
   # Tests --closure-args command line flag
   def test_closure_externs(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--closure', '1', '--pre-js', path_from_root('tests', 'test_closure_externs_pre_js.js'), '--closure-args', '--externs "' + path_from_root('tests', 'test_closure_externs.js') + '"'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '--closure', '1', '--pre-js', path_from_root('tests', 'test_closure_externs_pre_js.js'), '--closure-args', '--externs "' + path_from_root('tests', 'test_closure_externs.js') + '"'])
 
   def test_toolchain_profiler(self):
     environ = os.environ.copy()
     environ['EM_PROFILE_TOOLCHAIN'] = '1'
     # replaced subprocess functions should not cause errors
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')], env=environ)
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')], env=environ)
 
   def test_noderawfs(self):
     fopen_write = open(path_from_root('tests', 'asmfs', 'fopen_write.cpp')).read()
     create_test_file('main.cpp', fopen_write)
-    run_process([PYTHON, EMCC, 'main.cpp', '-s', 'NODERAWFS=1'])
+    run_process(self.emcc + ['main.cpp', '-s', 'NODERAWFS=1'])
     self.assertContained("read 11 bytes. Result: Hello data!", run_js('a.out.js'))
 
     # NODERAWFS should directly write on OS file system
@@ -8476,14 +8484,14 @@ end
 
   def test_noderawfs_disables_embedding(self):
     expected = '--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem'
-    base = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'NODERAWFS=1']
+    base = self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'NODERAWFS=1']
     err = self.expect_fail(base + ['--preload-file', 'somefile'])
     self.assertContained(expected, err)
     err = self.expect_fail(base + ['--embed-file', 'somefile'])
     self.assertContained(expected, err)
 
   def test_node_code_caching(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'),
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'),
                  '-s', 'NODE_CODE_CACHING',
                  '-s', 'WASM_ASYNC_COMPILATION=0'])
 
@@ -8560,7 +8568,7 @@ EMSCRIPTEN_KEEPALIVE void foo() {
   EM_ASM({ console.log("bar") });
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.c', '--pre-js', 'pre.js', '-s', 'MAIN_MODULE=2'])
+    run_process(self.emcc + ['src.c', '--pre-js', 'pre.js', '-s', 'MAIN_MODULE=2'])
     self.assertContained('bar', run_js('a.out.js'))
 
   def test_js_optimizer_parse_error(self):
@@ -8573,7 +8581,7 @@ int main() {
   });
 }
 ''')
-    stderr = self.expect_fail([PYTHON, EMCC, 'src.cpp', '-O2'])
+    stderr = self.expect_fail(self.emcc + ['src.cpp', '-O2'])
     # wasm backend output doesn't have spaces in the EM_ASM function bodies
     # TODO(sbc): remove second option once binaryen#2408 rolls
     self.assertContained(('''
@@ -8590,7 +8598,7 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
   @no_fastcomp('wasm2js only')
   def test_js_optimizer_chunk_size_determinism(self):
     def build():
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O3', '-s', 'WASM=0'])
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-O3', '-s', 'WASM=0'])
       with open('a.out.js') as f:
         # FIXME: newline differences can exist, ignore for now
         return f.read().replace('\n', '')
@@ -8623,13 +8631,13 @@ int main() {
   });
 }
 ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '-O2'])
+    run_process(self.emcc + ['src.cpp', '-O2'])
     self.assertContained('hello!', run_js('a.out.js'))
 
   def test_check_sourcemapurl(self):
     if not self.is_wasm():
       self.skipTest('only supported with wasm')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_123.c'), '-g4', '-o', 'a.js', '--source-map-base', 'dir/'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_123.c'), '-g4', '-o', 'a.js', '--source-map-base', 'dir/'])
     output = open('a.wasm', 'rb').read()
     # has sourceMappingURL section content and points to 'dir/a.wasm.map' file
     source_mapping_url_content = encode_leb(len('sourceMappingURL')) + b'sourceMappingURL' + encode_leb(len('dir/a.wasm.map')) + b'dir/a.wasm.map'
@@ -8639,9 +8647,9 @@ int main() {
 
   def test_check_source_map_args(self):
     # -g4 is needed for source maps; -g is not enough
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-g'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-g'])
     self.assertNotExists('a.out.wasm.map')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-g4'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-g4'])
     self.assertExists('a.out.wasm.map')
 
   @parameterized({
@@ -8654,7 +8662,7 @@ int main() {
       self.skipTest('only supported with wasm')
 
     try_delete('a.wasm.map')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_123.c'), '-g4', '-o', 'a.js'] + list(args))
+    run_process(self.emcc + [path_from_root('tests', 'hello_123.c'), '-g4', '-o', 'a.js'] + list(args))
     output = open('a.wasm', 'rb').read()
     # has sourceMappingURL section content and points to 'a.wasm.map' file
     source_mapping_url_content = encode_leb(len('sourceMappingURL')) + b'sourceMappingURL' + encode_leb(len('a.wasm.map')) + b'a.wasm.map'
@@ -8707,7 +8715,7 @@ int main() {
       ]
       for curr in infiles:
         print('  ', curr)
-        run_process([PYTHON, EMCC, curr, '-g4'])
+        run_process(self.emcc + [curr, '-g4'])
         with open('a.out.wasm.map', 'r') as f:
           self.assertIn('"%s"' % expected_source_map_path, str(f.read()))
 
@@ -8718,10 +8726,10 @@ int main() {
 
   @no_fastcomp('dwarf')
   def test_separate_dwarf(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-g'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-g'])
     self.assertExists('a.out.wasm')
     self.assertNotExists('a.out.wasm.debug.wasm')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-gseparate-dwarf'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-gseparate-dwarf'])
     self.assertExists('a.out.wasm')
     self.assertExists('a.out.wasm.debug.wasm')
     self.assertLess(os.path.getsize('a.out.wasm'), os.path.getsize('a.out.wasm.debug.wasm'))
@@ -8733,22 +8741,22 @@ int main() {
 
   @no_fastcomp('dwarf')
   def test_separate_dwarf_with_filename(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-gseparate-dwarf=with_dwarf.wasm'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-gseparate-dwarf=with_dwarf.wasm'])
     self.assertNotExists('a.out.wasm.debug.wasm')
     self.assertExists('with_dwarf.wasm')
     # the correct notation is to have exactly one '=' and in the right place
     for invalid in ('-gseparate-dwarf=x=', '-gseparate-dwarfy=', '-gseparate-dwarf-hmm'):
-      stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), invalid])
+      stderr = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), invalid])
       self.assertContained('invalid -gseparate-dwarf=FILENAME notation', stderr)
 
   def test_wasm_producers_section(self):
     # no producers section by default
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')])
     with open('a.out.wasm', 'rb') as f:
       self.assertNotIn('clang', str(f.read()))
     size = os.path.getsize('a.out.wasm')
     if self.is_wasm_backend():
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'EMIT_PRODUCERS_SECTION=1'])
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'EMIT_PRODUCERS_SECTION=1'])
       with open('a.out.wasm', 'rb') as f:
         self.assertIn('clang', str(f.read()))
       size_with_section = os.path.getsize('a.out.wasm')
@@ -8759,7 +8767,7 @@ int main() {
     output_file = 'test_stdin.html'
     shell_file = path_from_root('tests', 'module', 'test_html_preprocess.html')
 
-    run_process([PYTHON, EMCC, '-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=0'], stdout=PIPE, stderr=PIPE)
+    run_process(self.emcc + ['-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=0'], stdout=PIPE, stderr=PIPE)
     output = open(output_file).read()
     self.assertContained("""<style>
 /* Disable preprocessing inside style block as syntax is ambiguous with CSS */
@@ -8776,7 +8784,7 @@ T4:(else) ASSERTIONS <= 1
 T5:(else) ASSERTIONS
 T6:!ASSERTIONS""", output)
 
-    run_process([PYTHON, EMCC, '-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=1'], stdout=PIPE, stderr=PIPE)
+    run_process(self.emcc + ['-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=1'], stdout=PIPE, stderr=PIPE)
     output = open(output_file).read()
     self.assertContained("""<style>
 /* Disable preprocessing inside style block as syntax is ambiguous with CSS */
@@ -8793,7 +8801,7 @@ T4:(else) ASSERTIONS <= 1
 T5:ASSERTIONS
 T6:(else) !ASSERTIONS""", output)
 
-    run_process([PYTHON, EMCC, '-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=2'], stdout=PIPE, stderr=PIPE)
+    run_process(self.emcc + ['-o', output_file, test_file, '--shell-file', shell_file, '-s', 'ASSERTIONS=2'], stdout=PIPE, stderr=PIPE)
     output = open(output_file).read()
     self.assertContained("""<style>
 /* Disable preprocessing inside style block as syntax is ambiguous with CSS */
@@ -8813,7 +8821,7 @@ T6:(else) !ASSERTIONS""", output)
   # Tests that Emscripten-compiled applications can be run from a relative path with node command line that is different than the current working directory.
   def test_node_js_run_from_different_directory(self):
     ensure_dir('subdir')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'a.js'), '-O3'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'a.js'), '-O3'])
     ret = run_process(NODE_JS + [os.path.join('subdir', 'a.js')], stdout=PIPE).stdout
     self.assertContained('hello, world!', ret)
 
@@ -8833,7 +8841,7 @@ test_module().then((test_module_instance) => {
     create_test_file(os.path.join('subdir', moduleLoader), moduleLoaderContents)
 
     # build hello_world.c
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=test_module', '-s', 'ENVIRONMENT=worker,node'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', os.path.join('subdir', 'module.js'), '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'MODULARIZE=1', '-s', 'EXPORT_NAME=test_module', '-s', 'ENVIRONMENT=worker,node'])
 
     # run the module
     ret = run_process(NODE_JS + ['--experimental-wasm-threads'] + [os.path.join('subdir', moduleLoader)], stdout=PIPE).stdout
@@ -8841,7 +8849,7 @@ test_module().then((test_module_instance) => {
 
   @no_windows('node system() does not seem to work, see https://github.com/emscripten-core/emscripten/pull/10547')
   def test_node_js_system(self):
-    run_process([PYTHON, EMCC, '-DENV_NODE', path_from_root('tests', 'system.c'), '-o', 'a.js', '-O3'])
+    run_process(self.emcc + ['-DENV_NODE', path_from_root('tests', 'system.c'), '-o', 'a.js', '-O3'])
     ret = run_process(NODE_JS + ['a.js'], stdout=PIPE).stdout
     self.assertContained('OK', ret)
 
@@ -8906,7 +8914,7 @@ test_module().then((test_module_instance) => {
       ('EXPORTED_FUNCTIONS=["_a", "_b" "_c", "_d"]', 'undefined exported function: "_b" "_c"'),
     ]:
       print(export_arg)
-      proc = run_process([PYTHON, EMCC, 'src.c', '-s', export_arg], stdout=PIPE, stderr=PIPE, check=not expected)
+      proc = run_process(self.emcc + ['src.c', '-s', export_arg], stdout=PIPE, stderr=PIPE, check=not expected)
       print(proc.stderr)
       if not expected:
         self.assertFalse(proc.stderr)
@@ -8916,7 +8924,7 @@ test_module().then((test_module_instance) => {
 
   @no_fastcomp('uses new ASYNCIFY')
   def test_asyncify_escaping(self):
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'ASYNCIFY=1', '-s', "ASYNCIFY_WHITELIST=[DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)]"], stdout=PIPE, stderr=PIPE)
+    proc = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'ASYNCIFY=1', '-s', "ASYNCIFY_WHITELIST=[DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)]"], stdout=PIPE, stderr=PIPE)
     self.assertContained('emcc: ASYNCIFY list contains an item without balanced parentheses', proc.stderr)
     self.assertContained('   DOS_ReadFile(unsigned short', proc.stderr)
     self.assertContained('Try to quote the entire argument', proc.stderr)
@@ -8928,7 +8936,7 @@ test_module().then((test_module_instance) => {
   "DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)"
 ]
 ''')
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'ASYNCIFY=1', '-s', "ASYNCIFY_WHITELIST=@a.txt"], stdout=PIPE, stderr=PIPE)
+    proc = run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'ASYNCIFY=1', '-s', "ASYNCIFY_WHITELIST=@a.txt"], stdout=PIPE, stderr=PIPE)
     # we should parse the response file properly, and then issue a proper warning for the missing function
     self.assertContained(
         'Asyncify whitelist contained a non-matching pattern: DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)',
@@ -9189,7 +9197,7 @@ int main () {
       # Currently we rely on Closure for full minification of every appearance of JS function names.
       # TODO: Add minification also for non-Closure users and add [] to this list to test minification without Closure.
       for closure in [['--closure', '1']]:
-        args = [PYTHON, EMCC, '-O3', '--js-library', 'library_long.js', 'main_long.c', '-o', 'a.html'] + wasm + closure
+        args = self.emcc + ['-O3', '--js-library', 'library_long.js', 'main_long.c', '-o', 'a.html'] + wasm + closure
         print(' '.join(args))
         run_process(args)
 
@@ -9203,7 +9211,7 @@ int main () {
   def test_no_invoke_functions_are_generated_if_exception_catching_is_disabled(self):
     self.skipTest('Skipping other.test_no_invoke_functions_are_generated_if_exception_catching_is_disabled: Enable after new version of fastcomp has been tagged')
     for args in [[], ['-s', 'WASM=0']]:
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=1', '-o', 'a.html'] + args)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=1', '-o', 'a.html'] + args)
       output = open('a.js').read()
       self.assertContained('_main', output) # Smoke test that we actually compiled
       self.assertNotContained('invoke_', output)
@@ -9212,16 +9220,16 @@ int main () {
   def test_no_excessive_invoke_functions_are_generated_when_exceptions_are_enabled(self):
     self.skipTest('Skipping other.test_no_excessive_invoke_functions_are_generated_when_exceptions_are_enabled: Enable after new version of fastcomp has been tagged')
     for args in [[], ['-s', 'WASM=0']]:
-      run_process([PYTHON, EMCC, path_from_root('tests', 'invoke_i.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0', '-o', 'a.html'] + args)
+      run_process(self.emcc + [path_from_root('tests', 'invoke_i.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0', '-o', 'a.html'] + args)
       output = open('a.js').read()
       self.assertContained('invoke_i', output)
       self.assertNotContained('invoke_ii', output)
       self.assertNotContained('invoke_v', output)
 
   def test_emscripten_metadata(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')])
     self.assertNotIn(b'emscripten_metadata', open('a.out.wasm', 'rb').read())
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'),
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'),
                  '-s', 'EMIT_EMSCRIPTEN_METADATA'])
     self.assertIn(b'emscripten_metadata', open('a.out.wasm', 'rb').read())
 
@@ -9240,7 +9248,7 @@ int main () {
     # fastcomp does not support the new license flag
     if not self.is_wasm_backend():
       expect_license = False
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c')] + args)
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c')] + args)
     with open('a.out.js') as f:
       js = f.read()
     self.assertContainedIf('Copyright 2010 Emscripten authors', js, expect_license)
@@ -9256,7 +9264,7 @@ int main () {
     def test(wasm, closure, opt):
       extra_args = wasm + opt + closure
       print(extra_args)
-      args = [PYTHON, EMCC, path_from_root('tests', 'long_function_name_in_export.c'), '-o', 'a.html', '-s', 'ENVIRONMENT=web', '-s', 'DECLARE_ASM_MODULE_EXPORTS=0', '-Werror'] + extra_args
+      args = self.emcc + [path_from_root('tests', 'long_function_name_in_export.c'), '-o', 'a.html', '-s', 'ENVIRONMENT=web', '-s', 'DECLARE_ASM_MODULE_EXPORTS=0', '-Werror'] + extra_args
       run_process(args)
 
       output = open('a.js', 'r').read()
@@ -9369,7 +9377,7 @@ int main () {
           if not os.environ.get('EMTEST_REBASELINE'):
             raise
 
-        args = [PYTHON, EMCC, '-o', 'a.html'] + args + sources
+        args = self.emcc + ['-o', 'a.html'] + args + sources
         print('\n' + ' '.join(args))
         run_process(args)
         print('\n')
@@ -9439,18 +9447,18 @@ int main () {
 
   # Test that legacy settings that have been fixed to a specific value and their value can no longer be changed,
   def test_legacy_settings_forbidden_to_change(self):
-    stderr = self.expect_fail([PYTHON, EMCC, '-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=0', path_from_root('tests', 'hello_world.c')])
+    stderr = self.expect_fail(self.emcc + ['-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=0', path_from_root('tests', 'hello_world.c')])
     self.assertContained('MEMFS_APPEND_TO_TYPED_ARRAYS=0 is no longer supported', stderr)
 
-    run_process([PYTHON, EMCC, '-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1', path_from_root('tests', 'hello_world.c')])
-    run_process([PYTHON, EMCC, '-s', 'PRECISE_I64_MATH=2', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-s', 'MEMFS_APPEND_TO_TYPED_ARRAYS=1', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-s', 'PRECISE_I64_MATH=2', path_from_root('tests', 'hello_world.c')])
 
   @no_fastcomp('depends on wasm backend .a linking')
   def test_jsmath(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'other', 'jsmath.cpp'), '-Os', '-o', 'normal.js', '--closure', '0'])
+    run_process(self.emcc + [path_from_root('tests', 'other', 'jsmath.cpp'), '-Os', '-o', 'normal.js', '--closure', '0'])
     normal_js_size = os.path.getsize('normal.js')
     normal_wasm_size = os.path.getsize('normal.wasm')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'other', 'jsmath.cpp'), '-Os', '-o', 'jsmath.js', '-s', 'JS_MATH', '--closure', '0'])
+    run_process(self.emcc + [path_from_root('tests', 'other', 'jsmath.cpp'), '-Os', '-o', 'jsmath.js', '-s', 'JS_MATH', '--closure', '0'])
     jsmath_js_size = os.path.getsize('jsmath.js')
     jsmath_wasm_size = os.path.getsize('jsmath.wasm')
     # js math increases JS size, but decreases wasm, and wins overall
@@ -9471,13 +9479,13 @@ int main () {
   def test_strict_mode_hello_world(self):
     # Verify that strict mode can be used for simple hello world program both
     # via the environment EMCC_STRICT=1 and from the command line `-s STRICT`
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'STRICT=1']
+    cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'STRICT=1']
     run_process(cmd)
     with env_modify({'EMCC_STRICT': '1'}):
       self.do_run(open(path_from_root('tests', 'hello_world.c')).read(), 'hello, world!')
 
   def test_legacy_settings(self):
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'SPLIT_MEMORY=0']
+    cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'SPLIT_MEMORY=0']
 
     # By default warnings are not shown
     stderr = run_process(cmd, stderr=PIPE).stderr
@@ -9489,7 +9497,7 @@ int main () {
     self.assertContained('[-Wlegacy-settings]', stderr)
 
   def test_strict_mode_legacy_settings(self):
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'SPLIT_MEMORY=0']
+    cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'SPLIT_MEMORY=0']
     run_process(cmd)
 
     stderr = self.expect_fail(cmd + ['-s', 'STRICT=1'])
@@ -9552,7 +9560,7 @@ int main () {
 #if SPLIT_MEMORY
 #endif
 ''')
-    cmd = [PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'out.js', '--js-library', 'lib.js']
+    cmd = self.emcc + [path_from_root('tests', 'hello_world.c'), '-o', 'out.js', '--js-library', 'lib.js']
     run_process(cmd)
     self.assertContained('ReferenceError: SPLIT_MEMORY is not defined', self.expect_fail(cmd + ['-s', 'STRICT=1']))
     with env_modify({'EMCC_STRICT': '1'}):
@@ -9580,7 +9588,7 @@ int main () {
             %s
           }
         ''' % code)
-      run_process([PYTHON, EMCC, 'src.c', '-O1'])
+      run_process(self.emcc + ['src.c', '-O1'])
       return os.path.getsize('a.out.wasm')
 
     i = test('printf("%d", *(int*)unknown_value);')
@@ -9625,12 +9633,12 @@ int main(void) {
     printf("%Lf => %.30Le\n", ld, ld / (ld - 1));
 }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp'] + args)
+    run_process(self.emcc + ['src.cpp'] + args)
     self.assertContained(expected, run_js('a.out.js'))
 
   # Tests that passing -s MALLOC=none will not include system malloc() to the build.
   def test_malloc_none(self):
-    stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'malloc_none.c'), '-s', 'MALLOC=none'])
+    stderr = self.expect_fail(self.emcc + [path_from_root('tests', 'malloc_none.c'), '-s', 'MALLOC=none'])
     self.assertContained('undefined symbol: malloc', stderr)
 
   @parameterized({
@@ -9726,7 +9734,7 @@ int main(void) {
   @no_fastcomp('fastcomp clang detects colors differently')
   def test_build_error_color(self):
     create_test_file('src.c', 'int main() {')
-    returncode, output = self.run_on_pty([PYTHON, EMCC, 'src.c'])
+    returncode, output = self.run_on_pty(self.emcc + ['src.c'])
     self.assertNotEqual(returncode, 0)
     self.assertIn(b"\x1b[1msrc.c:1:13: \x1b[0m\x1b[0;1;31merror: \x1b[0m\x1b[1mexpected '}'\x1b[0m", output)
     self.assertIn(b"\x1b[31merror: ", output)
@@ -9740,7 +9748,7 @@ int main(void) {
     with open('src.c', 'w') as f:
       f.write('int main() {')
 
-    returncode, output = self.run_on_pty([PYTHON, EMCC, flag, 'src.c'])
+    returncode, output = self.run_on_pty(self.emcc + [flag, 'src.c'])
     self.assertNotEqual(returncode, 0)
     self.assertNotIn(b'\x1b', output)
 
@@ -9754,7 +9762,7 @@ int main(void) {
         q = *p;
       }
     ''')
-    run_process([PYTHON, EMCC, '-fsanitize=null', 'src.c'])
+    run_process(self.emcc + ['-fsanitize=null', 'src.c'])
     output = run_js('a.out.js', stderr=PIPE, full_output=True)
     self.assertIn('\x1b[1msrc.c', output)
 
@@ -9765,14 +9773,14 @@ int main(void) {
         return 42;
       }
     ''')
-    run_process([PYTHON, EMCC, 'no.c', '-O3', '-o', 'no.js'])
+    run_process(self.emcc + ['no.c', '-O3', '-o', 'no.js'])
     no = os.path.getsize('no.js')
     create_test_file('yes.c', '''
       int main(int argc, char **argv) {
         return argc;
       }
     ''')
-    run_process([PYTHON, EMCC, 'yes.c', '-O3', '-o', 'yes.js'])
+    run_process(self.emcc + ['yes.c', '-O3', '-o', 'yes.js'])
     yes = os.path.getsize('yes.js')
     # not having to set up argc/argv allows us to avoid including a
     # significant amount of JS for string support (which is not needed
@@ -9782,7 +9790,7 @@ int main(void) {
   @no_fastcomp('not optimized in fastcomp')
   def test_INCOMING_MODULE_JS_API(self):
     def test(args):
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-O3', '--closure', '1'] + args)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-O3', '--closure', '1'] + args)
       for engine in JS_ENGINES:
         self.assertContained('hello, world!', run_js('a.out.js', engine=engine))
       with open('a.out.js') as f:
@@ -9821,12 +9829,12 @@ int main(void) {
       #error "not defined"
       #endif
     ''')
-    run_process([PYTHON, EMCC, 'src.c', '-c'])
-    self.expect_fail([PYTHON, EMCC, 'src.c', '-s', 'STRICT', '-c'])
+    run_process(self.emcc + ['src.c', '-c'])
+    self.expect_fail(self.emcc + ['src.c', '-s', 'STRICT', '-c'])
 
   def test_exception_settings(self):
     for catching, throwing, opts in itertools.product([0, 1], repeat=3):
-      cmd = [PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_THROWING=%d' % (1 - throwing), '-s', 'DISABLE_EXCEPTION_CATCHING=%d' % (1 - catching), '-O%d' % opts]
+      cmd = self.emcc + [path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_THROWING=%d' % (1 - throwing), '-s', 'DISABLE_EXCEPTION_CATCHING=%d' % (1 - catching), '-O%d' % opts]
       print(cmd)
       if not throwing and not catching:
         self.assertContained('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required', self.expect_fail(cmd))
@@ -9839,11 +9847,11 @@ int main(void) {
   def test_fignore_exceptions(self):
     # the new clang flag -fignore-exceptions basically is the same as -s DISABLE_EXCEPTION_CATCHING=1,
     # that is, it allows throwing, but emits no support code for catching.
-    run_process([PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
+    run_process(self.emcc + [path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
     enable_size = os.path.getsize('a.out.wasm')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=1'])
+    run_process(self.emcc + [path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=1'])
     disable_size = os.path.getsize('a.out.wasm')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', '-fignore-exceptions'])
+    run_process(self.emcc + [path_from_root('tests', 'other', 'exceptions_modes_symbols_defined.cpp'), '-s', '-fignore-exceptions'])
     ignore_size = os.path.getsize('a.out.wasm')
     self.assertGreater(enable_size, disable_size)
     self.assertEqual(disable_size, ignore_size)
@@ -9872,8 +9880,8 @@ int main(void) {
       ([], ['-fexceptions'], False),
     ]:
       print(compile_flags, link_flags, expect_caught)
-      run_process([PYTHON, EMCC, 'src.cpp', '-c', '-o', 'src.o'] + compile_flags)
-      run_process([PYTHON, EMCC, 'src.o'] + link_flags)
+      run_process(self.emcc + ['src.cpp', '-c', '-o', 'src.o'] + compile_flags)
+      run_process(self.emcc + ['src.o'] + link_flags)
       result = run_js('a.out.js', assert_returncode=None, stderr=PIPE)
       self.assertContainedIf('CAUGHT', result, expect_caught)
 
@@ -9891,7 +9899,7 @@ int main(void) {
         });
       }
     ''')
-    run_process([PYTHON, EMCC, 'src.c', '-s', 'ASSERTIONS'])
+    run_process(self.emcc + ['src.c', '-s', 'ASSERTIONS'])
     self.assertContained('Module.read has been replaced with plain read', run_js('a.out.js'))
 
   def test_assertions_on_incoming_module_api_changes(self):
@@ -9900,7 +9908,7 @@ int main(void) {
         read: function() {}
       }
     ''')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'ASSERTIONS', '--pre-js', 'pre.js'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'ASSERTIONS', '--pre-js', 'pre.js'])
     self.assertContained('Module.read option was removed', run_js('a.out.js', assert_returncode=None, stderr=PIPE))
 
   def test_assertions_on_outgoing_module_api_changes(self):
@@ -9923,7 +9931,7 @@ int main(void) {
         });
       }
     ''')
-    run_process([PYTHON, EMCC, 'src.cpp', '-s', 'ASSERTIONS'])
+    run_process(self.emcc + ['src.cpp', '-s', 'ASSERTIONS'])
     self.assertContained('''
 Module.read has been replaced with plain read_ (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)
 Module.wasmBinary has been replaced with plain wasmBinary (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)
@@ -9948,7 +9956,7 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
         console.log(e);
       }
     ''')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE', '-s', 'ASSERTIONS', '--extern-post-js', 'test.js'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'MODULARIZE', '-s', 'ASSERTIONS', '--extern-post-js', 'test.js'])
     out = run_js('a.out.js')
     self.assertContained('You are getting _main on the Promise object, instead of the instance. Use .then() to get called back with the instance, see the MODULARIZE docs in src/settings.js', out)
     self.assertContained('You are setting onRuntimeInitialized on the Promise object, instead of the instance. Use .then() to get called back with the instance, see the MODULARIZE docs in src/settings.js', out)
@@ -9976,9 +9984,9 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
         return 0;
       }
     ''')
-    run_process([PYTHON, EMCC, '-c', 'foo.c'])
-    run_process([PYTHON, EMCC, '-c', 'main.c'])
-    run_process([PYTHON, EMCC, 'foo.o', 'main.o'])
+    run_process(self.emcc + ['-c', 'foo.c'])
+    run_process(self.emcc + ['-c', 'main.c'])
+    run_process(self.emcc + ['foo.o', 'main.o'])
     self.assertContained('Hello, world!\nHello, world!\n', run_js('a.out.js'))
 
   def test_em_asm_strict_c(self):
@@ -9988,7 +9996,7 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
         EM_ASM({ console.log('Hello, world!'); });
       }
     ''')
-    result = run_process([PYTHON, EMCC, '-std=c11', 'src.c'], stderr=PIPE, check=False)
+    result = run_process(self.emcc + ['-std=c11', 'src.c'], stderr=PIPE, check=False)
     self.assertNotEqual(result.returncode, 0)
     self.assertIn('EM_ASM does not work in -std=c* modes, use -std=gnu* modes instead', result.stderr)
 
@@ -10011,7 +10019,7 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
         });
       }
     ''')
-    result = run_process([PYTHON, EMCC, 'src.c'], stderr=PIPE, check=False)
+    result = run_process(self.emcc + ['src.c'], stderr=PIPE, check=False)
     self.assertNotEqual(result.returncode, 0)
     self.assertIn('Cannot use EM_ASM* alongside setjmp/longjmp', result.stderr)
     self.assertIn('Please consider using EM_JS, or move the EM_ASM into another function.', result.stderr)
@@ -10020,47 +10028,47 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     # Certain standard libraries are expected to be useable via -l flags but
     # don't actually exist in our standard library path.  Make sure we don't
     # error out when linking with these flags.
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-lm', '-ldl', '-lrt', '-lpthread'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-lm', '-ldl', '-lrt', '-lpthread'])
 
   @no_fastcomp('lld-specific')
   def test_supported_linker_flags(self):
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,--print-map'], stderr=PIPE).stderr
+    out = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Wl,--print-map'], stderr=PIPE).stderr
     self.assertContained('warning: ignoring unsupported linker flag: `--print-map`', out)
 
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Xlinker', '--print-map'], stderr=PIPE).stderr
+    out = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Xlinker', '--print-map'], stderr=PIPE).stderr
     self.assertContained('warning: ignoring unsupported linker flag: `--print-map`', out)
 
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,-rpath=foo'], stderr=PIPE).stderr
+    out = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Wl,-rpath=foo'], stderr=PIPE).stderr
     self.assertContained('warning: ignoring unsupported linker flag: `-rpath=foo`', out)
 
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,-rpath-link,foo'], stderr=PIPE).stderr
+    out = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Wl,-rpath-link,foo'], stderr=PIPE).stderr
     self.assertContained('warning: ignoring unsupported linker flag: `-rpath-link`', out)
 
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'),
+    out = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'),
                        '-Wl,--no-check-features,-mllvm,-debug'], stderr=PIPE).stderr
     self.assertNotContained('warning: ignoring unsupported linker flag', out)
 
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,-allow-shlib-undefined'], stderr=PIPE).stderr
+    out = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Wl,-allow-shlib-undefined'], stderr=PIPE).stderr
     self.assertContained('warning: ignoring unsupported linker flag: `-allow-shlib-undefined`', out)
 
-    out = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,--allow-shlib-undefined'], stderr=PIPE).stderr
+    out = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Wl,--allow-shlib-undefined'], stderr=PIPE).stderr
     self.assertContained('warning: ignoring unsupported linker flag: `--allow-shlib-undefined`', out)
 
   @no_fastcomp('lld-specific')
   def test_linker_flags_pass_through(self):
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,--waka'])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Wl,--waka'])
     self.assertContained('wasm-ld: error: unknown argument: --waka', err)
 
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Xlinker', '--waka'])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Xlinker', '--waka'])
     self.assertContained('wasm-ld: error: unknown argument: --waka', err)
 
   def test_linker_flags_unused(self):
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-lbar'], stderr=PIPE).stderr
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-c', '-lbar'], stderr=PIPE).stderr
     self.assertContained("warning: argument unused during compilation: '-lbar' [-Wunused-command-line-argument]", err)
 
   def test_non_wasm_without_wasm_in_vm(self):
     # Test that our non-wasm output does not depend on wasm support in the vm.
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=0'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=0'])
     with open('a.out.js') as f:
       js = f.read()
     with open('a.out.js', 'w') as f:
@@ -10072,29 +10080,29 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     # Emscripten supports compiling to an object file when the output has an
     # object extension.
     # Most compilers require the `-c` to be explicit.
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'hello1.o'])
-    err = run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'hello2.o'], stderr=PIPE).stderr
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'hello1.o'])
+    err = run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-o', 'hello2.o'], stderr=PIPE).stderr
     self.assertContained('warning: Assuming object file output in the absence of `-c`', err)
     self.assertBinaryEqual('hello1.o', 'hello2.o')
 
   def test_empty_output_extension(self):
     # Default to JS output when no extension is present
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-Werror', '-o', 'hello'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-Werror', '-o', 'hello'])
     self.assertContained('hello, world!', run_js('hello'))
 
   def test_backwards_deps_in_archive(self):
     # Test that JS dependencies from deps_info.json work for code linked via
     # static archives using -l<name>
-    run_process([PYTHON, EMCC, path_from_root('tests', 'sockets', 'test_gethostbyname.c'), '-o', 'a.o'])
+    run_process(self.emcc + [path_from_root('tests', 'sockets', 'test_gethostbyname.c'), '-o', 'a.o'])
     run_process([LLVM_AR, 'cr', 'liba.a', 'a.o'])
     create_test_file('empty.c', 'static int foo = 0;')
-    run_process([PYTHON, EMCC, 'empty.c', '-la', '-L.'])
+    run_process(self.emcc + ['empty.c', '-la', '-L.'])
     self.assertContained('success', run_js('a.out.js'))
 
   def test_warning_flags(self):
     create_test_file('not_object.bc', 'some text')
-    run_process([PYTHON, EMCC, '-c', '-o', 'hello.o', path_from_root('tests', 'hello_world.c')])
-    cmd = [PYTHON, EMCC, 'hello.o', 'not_object.bc', '-o', 'a.wasm']
+    run_process(self.emcc + ['-c', '-o', 'hello.o', path_from_root('tests', 'hello_world.c')])
+    cmd = self.emcc + ['hello.o', 'not_object.bc', '-o', 'a.wasm']
 
     # warning that is enabled by default
     stderr = run_process(cmd, stderr=PIPE).stderr
@@ -10123,7 +10131,7 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
   def test_emranlib(self):
     create_test_file('foo.c', 'int foo = 1;')
     create_test_file('bar.c', 'int bar = 2;')
-    run_process([PYTHON, EMCC, '-c', 'foo.c', 'bar.c'])
+    run_process(self.emcc + ['-c', 'foo.c', 'bar.c'])
 
     # Create a library with no archive map
     run_process([PYTHON, EMAR, 'crS', 'liba.a', 'foo.o', 'bar.o'])
@@ -10147,32 +10155,32 @@ int main() {
   return 0;
 }
 ''')
-    run_process([PYTHON, EMCC, 'pthread.c'])
+    run_process(self.emcc + ['pthread.c'])
 
   def test_stdin_preprocess(self):
     create_test_file('temp.h', '#include <string>')
-    outputStdin = run_process([PYTHON, EMCC, '-x', 'c++', '-dM', '-E', '-'], input="#include <string>", stdout=PIPE).stdout
-    outputFile = run_process([PYTHON, EMCC, '-x', 'c++', '-dM', '-E', 'temp.h'], stdout=PIPE).stdout
+    outputStdin = run_process(self.emcc + ['-x', 'c++', '-dM', '-E', '-'], input="#include <string>", stdout=PIPE).stdout
+    outputFile = run_process(self.emcc + ['-x', 'c++', '-dM', '-E', 'temp.h'], stdout=PIPE).stdout
     self.assertTextDataIdentical(outputStdin, outputFile)
 
   def test_stdin_compile_only(self):
     # Should fail without -x lang specifier
     with open(path_from_root('tests', 'hello_world.cpp')) as f:
-      err = self.expect_fail([PYTHON, EMCC, '-c', '-'], input=f.read())
+      err = self.expect_fail(self.emcc + ['-c', '-'], input=f.read())
     self.assertContained('error: -E or -x required when input is from standard input', err)
 
     with open(path_from_root('tests', 'hello_world.cpp')) as f:
-      run_process([PYTHON, EMCC, '-c', '-o', 'out.o', '-x', 'c++', '-'], input=f.read())
+      run_process(self.emcc + ['-c', '-o', 'out.o', '-x', 'c++', '-'], input=f.read())
     self.assertExists('out.o')
 
     # Same again but without an explicit output filename
     with open(path_from_root('tests', 'hello_world.cpp')) as f:
-      run_process([PYTHON, EMCC, '-c', '-x', 'c++', '-'], input=f.read())
+      run_process(self.emcc + ['-c', '-x', 'c++', '-'], input=f.read())
     self.assertExists('-.o')
 
   def test_stdin_compile_and_link(self):
     with open(path_from_root('tests', 'hello_world.cpp')) as f:
-      run_process([PYTHON, EMCC, '-x', 'c++', '-'], input=f.read())
+      run_process(self.emcc + ['-x', 'c++', '-'], input=f.read())
     self.assertContained('hello, world!', run_js('a.out.js'))
 
   def is_object_file(self, filename):
@@ -10184,23 +10192,23 @@ int main() {
   def test_stdout_link(self):
     # linking to stdout `-` doesn't work, we have no way to pass such an output filename
     # through post-link tools such as binaryen.
-    err = self.expect_fail([PYTHON, EMCC, '-o', '-', path_from_root('tests', 'hello_world.cpp')])
+    err = self.expect_fail(self.emcc + ['-o', '-', path_from_root('tests', 'hello_world.cpp')])
     self.assertContained('invalid output filename: `-`', err)
     self.assertNotExists('-')
 
-    err = self.expect_fail([PYTHON, EMCC, '-o', '-foo', path_from_root('tests', 'hello_world.cpp')])
+    err = self.expect_fail(self.emcc + ['-o', '-foo', path_from_root('tests', 'hello_world.cpp')])
     self.assertContained('invalid output filename: `-foo`', err)
     self.assertNotExists('-foo')
 
   def test_output_to_nowhere(self):
     nowhere = 'NULL' if WINDOWS else '/dev/null'
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', nowhere, '-c'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-o', nowhere, '-c'])
 
   # Test that passing -s MIN_X_VERSION=-1 on the command line will result in browser X being not supported at all.
   # I.e. -s MIN_X_VERSION=-1 is equal to -s MIN_X_VERSION=Infinity
   def test_drop_support_for_browser(self):
     # Test that -1 means "not supported"
-    run_process([PYTHON, EMCC, path_from_root('tests', 'test_html5.c'), '-s', 'MIN_IE_VERSION=-1'])
+    run_process(self.emcc + [path_from_root('tests', 'test_html5.c'), '-s', 'MIN_IE_VERSION=-1'])
     self.assertContained('allowsDeferredCalls: true', open('a.out.js').read())
     self.assertNotContained('allowsDeferredCalls: JSEvents.isInternetExplorer()', open('a.out.js').read())
 
@@ -10215,11 +10223,11 @@ int main() {
 #define DAV1D_ERR(e) (e)
 #endif
 ''')
-    run_process([PYTHON, EMCC, 'errno_type.c'])
+    run_process(self.emcc + ['errno_type.c'])
 
   @no_fastcomp("uses standalone mode")
   def test_standalone_syscalls(self):
-    run_process([PYTHON, EMCC, path_from_root('tests', 'other', 'standalone_syscalls', 'test.cpp'), '-o', 'test.wasm'])
+    run_process(self.emcc + [path_from_root('tests', 'other', 'standalone_syscalls', 'test.cpp'), '-o', 'test.wasm'])
     with open(path_from_root('tests', 'other', 'standalone_syscalls', 'test.out')) as f:
       expected = f.read()
       for engine in WASM_ENGINES:
@@ -10230,7 +10238,7 @@ int main() {
     def test(args):
       # legacy browsers may lack Promise, which wasm2js depends on. see what
       # happens when we kill the global Promise function.
-      run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=0'] + args)
+      run_process(self.emcc + [path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=0'] + args)
       with open('a.out.js') as f:
         js = f.read()
       with open('a.out.js', 'w') as f:
@@ -10245,71 +10253,71 @@ int main() {
   # Compile-test for -s USE_WEBGPU=1 and library_webgpu.js.
   def test_webgpu_compiletest(self):
     for args in [[], ['-s', 'ASSERTIONS=1']]:
-      run_process([PYTHON, EMCC, path_from_root('tests', 'webgpu_dummy.cpp'), '-s', 'USE_WEBGPU=1'] + args)
+      run_process(self.emcc + [path_from_root('tests', 'webgpu_dummy.cpp'), '-s', 'USE_WEBGPU=1'] + args)
 
   @no_fastcomp('lld only')
   def test_signature_mismatch(self):
     create_test_file('a.c', 'void foo(); int main() { foo(); return 0; }')
     create_test_file('b.c', 'int foo() { return 1; }')
-    stderr = run_process([PYTHON, EMCC, 'a.c', 'b.c'], stderr=PIPE).stderr
+    stderr = run_process(self.emcc + ['a.c', 'b.c'], stderr=PIPE).stderr
     self.assertContained('function signature mismatch: foo', stderr)
-    self.expect_fail([PYTHON, EMCC, '-Wl,--fatal-warnings', 'a.c', 'b.c'])
-    self.expect_fail([PYTHON, EMCC, '-s', 'STRICT', 'a.c', 'b.c'])
+    self.expect_fail(self.emcc + ['-Wl,--fatal-warnings', 'a.c', 'b.c'])
+    self.expect_fail(self.emcc + ['-s', 'STRICT', 'a.c', 'b.c'])
 
   @no_fastcomp('lld only')
   def test_lld_report_undefined(self):
     create_test_file('main.c', 'void foo(); int main() { foo(); return 0; }')
-    stderr = self.expect_fail([PYTHON, EMCC, '-s', 'LLD_REPORT_UNDEFINED', 'main.c'])
+    stderr = self.expect_fail(self.emcc + ['-s', 'LLD_REPORT_UNDEFINED', 'main.c'])
     self.assertContained('wasm-ld: error:', stderr)
     self.assertContained('main_0.o: undefined symbol: foo', stderr)
 
   @no_fastcomp('wasm backend only')
   def test_4GB(self):
-    stderr = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=2GB'])
+    stderr = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '-s', 'INITIAL_MEMORY=2GB'])
     self.assertContained('INITIAL_MEMORY must be less than 2GB due to current spec limitations', stderr)
 
   # Verifies that warning messages that Closure outputs are recorded to console
   def test_closure_warnings(self):
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=quiet'], stderr=PIPE)
+    proc = run_process(self.emcc + [path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=quiet'], stderr=PIPE)
     self.assertNotContained('WARNING', proc.stderr)
 
-    proc = run_process([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=warn'], stderr=PIPE)
+    proc = run_process(self.emcc + [path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=warn'], stderr=PIPE)
     self.assertContained('WARNING - [JSC_REFERENCE_BEFORE_DECLARE] Variable referenced before declaration', proc.stderr)
 
-    self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=error'])
+    self.expect_fail(self.emcc + [path_from_root('tests', 'test_closure_warning.c'), '-O3', '--closure', '1', '-s', 'CLOSURE_WARNINGS=error'])
 
   @no_fastcomp('test wasm object files')
   def test_bitcode_input(self):
     # Verify that bitcode files are accepted as input
     create_test_file('main.c', 'void foo(); int main() { return 0; }')
-    run_process([PYTHON, EMCC, '-emit-llvm', '-c', '-o', 'main.bc', 'main.c'])
+    run_process(self.emcc + ['-emit-llvm', '-c', '-o', 'main.bc', 'main.c'])
     self.assertTrue(shared.Building.is_bitcode('main.bc'))
-    run_process([PYTHON, EMCC, '-c', '-o', 'main.o', 'main.bc'])
+    run_process(self.emcc + ['-c', '-o', 'main.o', 'main.bc'])
     self.assertTrue(shared.Building.is_wasm('main.o'))
 
   def test_nostdlib(self):
     # First ensure all the system libs are built
-    run_process([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c')])
+    run_process(self.emcc + [path_from_root('tests', 'unistd', 'close.c')])
 
-    self.assertContained('undefined symbol:', self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nostdlib']))
-    self.assertContained('undefined symbol:', self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nodefaultlibs']))
+    self.assertContained('undefined symbol:', self.expect_fail(self.emcc + [path_from_root('tests', 'unistd', 'close.c'), '-nostdlib']))
+    self.assertContained('undefined symbol:', self.expect_fail(self.emcc + [path_from_root('tests', 'unistd', 'close.c'), '-nodefaultlibs']))
 
     # Build again but with explit system libraries
     libs = ['-lc', '-lcompiler_rt']
     if self.is_wasm_backend():
       libs.append('-lc_rt_wasm')
-    run_process([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nostdlib'] + libs)
-    run_process([PYTHON, EMCC, path_from_root('tests', 'unistd', 'close.c'), '-nodefaultlibs'] + libs)
+    run_process(self.emcc + [path_from_root('tests', 'unistd', 'close.c'), '-nostdlib'] + libs)
+    run_process(self.emcc + [path_from_root('tests', 'unistd', 'close.c'), '-nodefaultlibs'] + libs)
 
   def test_argument_match(self):
     # Verify that emcc arguments match precisely.  We had a bug where only the prefix
     # was matched
-    run_process([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-opts', '10'])
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-optsXX'])
+    run_process(self.emcc + [path_from_root('tests', 'hello_world.c'), '--js-opts', '10'])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '--js-optsXX'])
     self.assertContained("error: unsupported option '--js-optsXX'", err)
 
   def test_missing_argument(self):
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'hello_world.c'), '--js-opts'])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'hello_world.c'), '--js-opts'])
     self.assertContained("error: option '--js-opts' requires an argument", err)
 
   def test_default_to_cxx(self):
@@ -10318,22 +10326,22 @@ int main() {
 
     # The default bahviour is to default to C++, which means the C++ header can be compiled even
     # with emcc.
-    run_process([PYTHON, EMCC, '-c', 'cxxfoo.h'])
+    run_process(self.emcc + ['-c', 'cxxfoo.h'])
 
     # But this means that C flags can't be passed (since we are assuming C++)
-    err = self.expect_fail([PYTHON, EMCC, '-std=gnu11', '-c', 'foo.h'])
+    err = self.expect_fail(self.emcc + ['-std=gnu11', '-c', 'foo.h'])
     self.assertContained("'-std=gnu11' not allowed with 'C++'", err)
 
     # If we disable DEFAULT_TO_CXX the emcc can be used with cflags, but can't be used to build
     # C++ headers
-    run_process([PYTHON, EMCC, '-std=gnu11', '-c', 'foo.h', '-s', 'DEFAULT_TO_CXX=0'])
-    err = self.expect_fail([PYTHON, EMCC, '-c', 'cxxfoo.h', '-s', 'DEFAULT_TO_CXX=0'])
+    run_process(self.emcc + ['-std=gnu11', '-c', 'foo.h', '-s', 'DEFAULT_TO_CXX=0'])
+    err = self.expect_fail(self.emcc + ['-c', 'cxxfoo.h', '-s', 'DEFAULT_TO_CXX=0'])
     self.assertContained("'string' file not found", err)
 
     # Using em++ should alwasy work for C++ headers
-    run_process([PYTHON, EMXX, '-c', 'cxxfoo.h', '-s', 'DEFAULT_TO_CXX=0'])
+    run_process(self.emxx + ['-c', 'cxxfoo.h', '-s', 'DEFAULT_TO_CXX=0'])
     # Or using emcc with `-x c++`
-    run_process([PYTHON, EMCC, '-c', 'cxxfoo.h', '-s', 'DEFAULT_TO_CXX=0', '-x', 'c++-header'])
+    run_process(self.emcc + ['-c', 'cxxfoo.h', '-s', 'DEFAULT_TO_CXX=0', '-x', 'c++-header'])
 
   @parameterized({
     '': ([],),
@@ -10357,7 +10365,7 @@ int main() {
 
   @no_fastcomp('no .s file support')
   def test_assembly(self):
-    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'other', 'test_asm.s'), '-o', 'foo.o'])
+    run_process(self.emcc + ['-c', path_from_root('tests', 'other', 'test_asm.s'), '-o', 'foo.o'])
     src = path_from_root('tests', 'other', 'test_asm.c')
     output = path_from_root('tests', 'other', 'test_asm.out')
     self.emcc_args.append('foo.o')
@@ -10365,7 +10373,7 @@ int main() {
 
   @no_fastcomp('no .s file support')
   def test_assembly_preprocessed(self):
-    run_process([PYTHON, EMCC, '-c', path_from_root('tests', 'other', 'test_asm_cpp.S'), '-o', 'foo.o'])
+    run_process(self.emcc + ['-c', path_from_root('tests', 'other', 'test_asm_cpp.S'), '-o', 'foo.o'])
     src = path_from_root('tests', 'other', 'test_asm.c')
     output = path_from_root('tests', 'other', 'test_asm.out')
     self.emcc_args.append('foo.o')
@@ -10378,18 +10386,18 @@ int main() {
 
   @no_fastcomp('wasm-ld only')
   def test_linker_version(self):
-    out = run_process([PYTHON, EMCC, '-Wl,--version'], stdout=PIPE).stdout
+    out = run_process(self.emcc + ['-Wl,--version'], stdout=PIPE).stdout
     self.assertContained('LLD ', out)
 
   # Tests that if a JS library function is missing, the linker will print out which function
   # depended on the missing function.
   def test_chained_js_error_diagnostics(self):
-    err = self.expect_fail([PYTHON, EMCC, path_from_root('tests', 'test_chained_js_error_diagnostics.c'), '--js-library', path_from_root('tests', 'test_chained_js_error_diagnostics.js')])
+    err = self.expect_fail(self.emcc + [path_from_root('tests', 'test_chained_js_error_diagnostics.c'), '--js-library', path_from_root('tests', 'test_chained_js_error_diagnostics.js')])
     self.assertContained("error: undefined symbol: nonexistent_function (referenced by bar__deps: ['nonexistent_function'], referenced by foo__deps: ['bar'], referenced by top-level compiled C/C++ code)", err)
 
   def test_xclang_flag(self):
     create_test_file('foo.h', ' ')
-    run_process([PYTHON, EMCC, '-c', '-o', 'out.o', '-Xclang', '-include', '-Xclang', 'foo.h', path_from_root('tests', 'hello_world.c')])
+    run_process(self.emcc + ['-c', '-o', 'out.o', '-Xclang', '-include', '-Xclang', 'foo.h', path_from_root('tests', 'hello_world.c')])
 
   def test_native_call_before_init(self):
     self.set_setting('ASSERTIONS')


### PR DESCRIPTION
This allows for various future improvements, but more more
immediately allows for #11280 to land (because I want to be able
to add `-Wno-fastcomp` across the board).