### PR TITLE
Add tests for preload-file and locateFile

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -473,3 +473,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * David Carlier <devnexen@gmail.com>
 * Paul Du <du.paul136@gmail.com> (copyright owned by ARSKAN)
 * Piotr Doan <doanpiotr@gmail.com>
+* Martin Weber <enwi2@t-online.de>

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -268,12 +268,6 @@ If manually bisecting:
       <html lang="en">
         <head>
           <script src="sub2/page.js"></script>
-          <script>
-            Module['onRuntimeInitialized'] = function() {
-              //new Module.page();
-            };
-            console.log("tested")
-          </script>
         </head>
         <body></bod>
       </html>


### PR DESCRIPTION
For preload-file:
Test that putting .js, .wasm and .data files in a sub-directory
below the .html file still works. As stated in the reference,
emscripten should expect to find .data and .wasm files next to
the .js file.

For locateFile:
Test locateFile when using preload-file instead of manually
running the file packager.

See issue #9637