### PR TITLE
Fix emscripten CI after recent emsdk change

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ commands:
             cd ~/emsdk-master
             ./emsdk update-tags
             ./emsdk install tot-upstream
-            ./emsdk activate tot-upstream
+            ./emsdk activate --no-embedded tot-upstream
             # Remove the emsdk version of emscripten to save space in the
             # persistent workspace and to avoid any confusion with the version
             # we are trying to test.
@@ -315,7 +315,7 @@ jobs:
             cd ~/emsdk-master
             ./emsdk update-tags
             ./emsdk install tot-fastcomp
-            ./emsdk activate tot-fastcomp
+            ./emsdk activate --no-embedded tot-fastcomp
             # Remove the emsdk version of emscripten to save space in the
             # persistent workspace and to avoid any confusion with the version
             # we are trying to test.


### PR DESCRIPTION
See https://github.com/emscripten-core/emsdk/pull/472

Turns out we were actually depending on the non-embedded
config!
