### PR TITLE
Handle read-only emscripten root

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3413,10 +3413,10 @@ if not CACHE:
   if root_is_writable():
     CACHE = path_from_root('cache')
   else:
-    # Use the legacy method ot putting the cache in the user's home directory
+    # Use the legacy method of putting the cache in the user's home directory
     # if the emscripten root is not writable.
-    # TODO(sbc): Remove this once write-only installations and transitioned to
-    # shipping CACHE in thier embedded config files.
+    # TODO(sbc): Remove this once write-only installations are transitioned to
+    # settings CACHE as part of thier embedded config files.
     CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
 if not PORTS:
   PORTS = os.path.join(CACHE, 'ports')

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3415,8 +3415,10 @@ if not CACHE:
   else:
     # Use the legacy method of putting the cache in the user's home directory
     # if the emscripten root is not writable.
-    # TODO(sbc): Remove this once write-only installations are transitioned to
-    # settings CACHE as part of thier embedded config files.
+    # This is useful mostly for read-only installation and perhaps could
+    # be removed in the future since such installations should probably be
+    # setting a specific cache location.
+    logger.debug('Using home-directory for emscripten cache due to read-only root')
     CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
 if not PORTS:
   PORTS = os.path.join(CACHE, 'ports')


### PR DESCRIPTION
Followup on #11270.

This means that users with a read-only emscripten root will continue
to default to having their cache live in $HOME.

In the long term such installations should configure the cache
specifically, but for now this restores the previous cache location.