### PR TITLE
Create embedded config on first use

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Config file
 .emscripten
+.emscripten_backup
 .emscripten_sanity
 .emscripten_sanity_wasm
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,7 +18,7 @@ See docs/process.md for how version tagging works.
 Current Trunk
 -------------
 - On first use, emscripten creates a sample config file.  This config file
-  is now created in the emscripten directory by deafult.  The traditional
+  is now created in the emscripten directory by default.  The traditional
   `~/.emscripten` config file in the `$HOME` directory is still supported and
   the sample config will still be written there in the case that the emscripten
   root is read-only.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,11 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- On first use, emscripten creates a sample config file.  This config file
+  is now created in the emscripten directory by deafult.  The traditional
+  `~/.emscripten` config file in the `$HOME` directory is still supported and
+  the sample config will still be written there in the case that the emscripten
+  root is read-only.
 - The default location for downloaded ports is now a directory called "ports"
   within the cache directory.  In practice these means by default they live
   in `cache/ports` inside the emscripten source directory.  This can be

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -429,9 +429,9 @@ Options that are modified or new in *emcc* are listed below:
    If using this in combination with "--clear-cache", be sure to
    specify this argument first.
 
-   The Emscripten cache defaults "emscripten/cache" but can be
-   overridden use "EM_CACHE" environment variable or "CACHE" config
-   setting.
+   The Emscripten cache defaults to "emscripten/cache" but can be
+   overridden using the "EM_CACHE" environment variable or "CACHE"
+   config setting.
 
 "--clear-cache"
    Manually clears the cache of compiled Emscripten system libraries
@@ -539,7 +539,7 @@ Options that are modified or new in *emcc* are listed below:
 "--em-config"
    Specifies the location of the **.emscripten** configuration file.
    If not specified emscripten will search for ".emscripten" first in
-   the emscripten dirctory itself, and then in the users home
+   the emscripten directory itself, and then in the user's home
    directory ("~/.emscripten"). This can be overridden using the
    "EM_CONFIG" environment variable.
 

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -429,9 +429,9 @@ Options that are modified or new in *emcc* are listed below:
    If using this in combination with "--clear-cache", be sure to
    specify this argument first.
 
-   The Emscripten cache defaults to being located in the path name
-   stored in the "EM_CACHE" environment variable or
-   "~/.emscripten_cache".
+   The Emscripten cache defaults "emscripten/cache" but can be
+   overridden use "EM_CACHE" environment variable or "CACHE" config
+   setting.
 
 "--clear-cache"
    Manually clears the cache of compiled Emscripten system libraries
@@ -537,10 +537,11 @@ Options that are modified or new in *emcc* are listed below:
    multithreaded builds (-s USE_PTHREADS=1/2).
 
 "--em-config"
-   Specifies the location of the **.emscripten** configuration file
-   for the current compiler run. If not specified, the environment
-   variable "EM_CONFIG" is first read for this location. If neither
-   are specified, the default location **~/.emscripten** is used.
+   Specifies the location of the **.emscripten** configuration file.
+   If not specified emscripten will search for ".emscripten" first in
+   the emscripten dirctory itself, and then in the users home
+   directory ("~/.emscripten"). This can be overridden using the
+   "EM_CONFIG" environment variable.
 
 "--default-obj-ext .ext"
    Specifies the file suffix to generate if the location of a

--- a/docs/process.md
+++ b/docs/process.md
@@ -213,7 +213,7 @@ key values in that file include:
 
 Shipping this config file inside the emscripten directory is the simplest
 way to ensure it won't interfere with any config file that user might have
-in thier home directory.
+in their home directory.
 
 ## Ports
 

--- a/docs/process.md
+++ b/docs/process.md
@@ -199,17 +199,21 @@ the wasm backend):
 (If you are packaging the older fastcomp backend instead of the wasm backend,
 you don't need wasm-ld or wasm2js, and you do need llvm-link and opt.)
 
-You also need to set up the `~/.emscripten` file for your users. Emscripten
+You also need to set up a `.emscripten` config file for your users. Emscripten
 will try to do so on first run if such a file does not exist; the simplest
 thing is to look at those contents, edit the paths as needed if anything is
 wrong, and then use that file. (You can also look at how the emsdk generates
-the `.emscripten` file, which it does at the `activate step.) Some of the
+the `.emscripten` file, which it does at the `activate` step.) Some of the
 key values in that file include:
 
  * `LLVM_ROOT`: The path to the LLVM binaries.
  * `BINARYEN_ROOT`: The path to binaryen (the binaries are expected in `/bin` under there; note that
     despite the name this differs from `LLVM_ROOT` which points directly to the binaries).
  * `NODE_JS`: The path to Node.js, which is needed internally.
+
+Shipping this config file inside the emscripten directory is the simplest
+way to ensure it won't interfere with any config file that user might have
+in thier home directory.
 
 ## Ports
 

--- a/docs/upgrading-bundled-libs.Markdown
+++ b/docs/upgrading-bundled-libs.Markdown
@@ -18,7 +18,7 @@ To update them,
    `system/lib`/ and have the suffix `.symbol`. To generate the new contents,
    build the system library with the new files, and do something like this
    for musl:
-   `~/Dev/fastcomp/build/bin/llvm-nm ~/.emscripten_cache/asmjs/libc.bc | sort`
+   `~/Dev/fastcomp/build/bin/llvm-nm cache/asmjs/libc.bc | sort`
    and write that to the `.symbol` file. Take a look at the git diff to see
    if anything looks odd.
  * Run the test suite to make sure everything works. You can open a PR and let

--- a/embuilder.py
+++ b/embuilder.py
@@ -105,7 +105,7 @@ do that, run
    2. cmake . -DCMAKE_BUILD_TYPE=Release
    3. make (or mingw32-make/vcbuild/msbuild on Windows)
 
-and set up the location to the native optimizer in ~/.emscripten
+and set up the location to the native optimizer in .emscripten
 ''' % '\n        '.join(all_tasks)
 
 

--- a/site/source/docs/building_from_source/building_fastcomp_manually_from_source.rst
+++ b/site/source/docs/building_from_source/building_fastcomp_manually_from_source.rst
@@ -24,7 +24,7 @@ Building Fastcomp
 
 To build the Fastcomp code from source:
 
--  Create a directory to store the build. It doesn't matter where, because Emscripten gets the information from the :ref:`compiler configuration file (~/.emscripten) <compiler-configuration-file>`. We show how to update this file later in these instructions:
+-  Create a directory to store the build. It doesn't matter where, because Emscripten gets the information from the :ref:`compiler configuration file (.emscripten) <compiler-configuration-file>`. We show how to update this file later in these instructions:
 
   ::
 
@@ -83,7 +83,7 @@ To build the Fastcomp code from source:
 
 -
 
-  The final step is to update the :ref:`~/.emscripten <compiler-configuration-file>` file, specifying the location of *fastcomp* in the ``LLVM_ROOT`` variable.
+  The final step is to update the :ref:`.emscripten <compiler-configuration-file>` file, specifying the location of *fastcomp* in the ``LLVM_ROOT`` variable.
 
   .. note:: If you're building the **whole** of Emscripten from source, following the platform-specific instructions in :ref:`installing-from-source`, you won't yet have Emscripten installed. In this case, skip this step and return to those instructions.
 

--- a/site/source/docs/building_from_source/configuring_emscripten_settings.rst
+++ b/site/source/docs/building_from_source/configuring_emscripten_settings.rst
@@ -4,7 +4,10 @@
 Configuring Emscripten Settings when Manually Building from Source
 ==================================================================
 
-The compiler settings used by Emscripten are defined in the :ref:`compiler configuration file (~/.emscripten) <compiler-configuration-file>`. These settings include paths to the tools (LLVM, Clang, Java, etc.) and the compiler's temporary directory for intermediate build files.
+The compiler settings used by Emscripten are defined in the :ref:`compiler
+configuration file (.emscripten) <compiler-configuration-file>`. These settings
+include paths to the tools (LLVM, Clang, Java, etc.) and the compiler's
+temporary directory for intermediate build files.
 
 This article explains how to create and update the file when you are building Emscripten :ref:`manually <installing-from-source>` from source.
 
@@ -31,14 +34,17 @@ The file will probably not include the link to :term:`Fastcomp` (``LLVM_ROOT``) 
 Locating the compiler configuration file (.emscripten)
 =======================================================
 
-The settings file is created in the user's home directory: 
+The settings file (``.emscripten``) is created by default within the emscripten directory:
 
-	- On Linux and macOS this file is named **~/.emscripten**, where ~ is the user's home directory.
+In cases where the emscripten directory is read-only the users home directoy
+will be used:
 
-		.. note:: Files with the "." prefix are hidden by default. You may need to change your view settings to find the file.
+  - On Linux and macOS this file is named **~/.emscripten**, where ~ is the
+    user's home directory.
 
+    .. note:: Files with the "." prefix are hidden by default. You may need to change your view settings to find the file.
 
-	- On Windows the file can be found at a path like: **C:/Users/yourusername_000/.emscripten**.
+  - On Windows the file can be found at a path like: **C:/Users/yourusername_000/.emscripten**.
 
 
 Compiler configuration file-format

--- a/site/source/docs/building_from_source/verify_emscripten_environment.rst
+++ b/site/source/docs/building_from_source/verify_emscripten_environment.rst
@@ -29,7 +29,7 @@ For example, the following output reports an installation where Java is missing:
   Target: x86_64-pc-win32
   Thread model: posix
   INFO     root: (Emscripten: Running sanity checks)
-  WARNING  root: java does not seem to exist, required for closure compiler. -O2 and above will fail. You need to define JAVA in ~/.emscripten
+  WARNING  root: java does not seem to exist, required for closure compiler. -O2 and above will fail. You need to define JAVA in .emscripten
 
 At this point you need to :ref:`Install and activate <fixing-missing-components-emcc>` any missing components. When everything is set up properly, ``emcc -v`` should give no warnings, and if you just enter ``emcc`` (without any input files), it should only give the following warning: ::
 

--- a/site/source/docs/getting_started/downloads.rst
+++ b/site/source/docs/getting_started/downloads.rst
@@ -49,7 +49,7 @@ Run the following :ref:`emsdk <emsdk>` commands to get the latest tools from Git
     # Download and install the latest SDK tools.
     ./emsdk install latest
 
-    # Make the "latest" SDK "active" for the current user. (writes ~/.emscripten file)
+    # Make the "latest" SDK "active" for the current user. (writes .emscripten file)
     ./emsdk activate latest
 
     # Activate PATH and other environment variables in the current terminal
@@ -154,7 +154,7 @@ Linux
 
 .. note:: You need Python 2.7.12 or newer because older versions may not work due to `a GitHub change with SSL <https://github.com/emscripten-core/emscripten/issues/6275>`_).
 
-.. note:: If you want to use your system's Node.js instead of the emsdk's, it may be ``node`` instead of ``nodejs``, and you can adjust the ``NODE_JS`` attribute of your ``~/.emscripten`` file to point to it.
+.. note:: If you want to use your system's Node.js instead of the emsdk's, it may be ``node`` instead of ``nodejs``, and you can adjust the ``NODE_JS`` attribute of your ``.emscripten`` file to point to it.
 
 - *Git* is not installed automatically. Git is only needed if you want to use tools from one of the development branches **emscripten-incoming** or **emscripten-master**:
 

--- a/site/source/docs/site/glossary.rst
+++ b/site/source/docs/site/glossary.rst
@@ -117,7 +117,11 @@ The following terms are used when referring to the SDK and :ref:`emsdk`:
     There are a number of different Emscripten SDK packages. These can be downloaded from :ref:`here <sdk-download-and-install>`.
 
   Active Tool/SDK
-    The :term:`emsdk` can store multiple versions of :term:`tools <Tool>` and :term:`SDKs <SDK>`. The active tools/SDK is the set of tools that are used by default on the *Emscripten Command Prompt*. This compiler configuration is stored in a user-specific persistent file (**~/.emscripten**) and can be changed using *emsdk*.
+    The :term:`emsdk` can store multiple versions of :term:`tools <Tool>` and
+    :term:`SDKs <SDK>`. The active tools/SDK is the set of tools that are used
+    by default on the *Emscripten Command Prompt*. This compiler configuration
+    is stored in an emsdk-specific config file (**.emscripten**) and can be
+    changed using *emsdk*.
 
   emsdk root directory
     The :term:`emsdk` can manage any number of :term:`tools <Tool>` and :term:`SDKs <SDK>`, and these are stored in :term:`subdirectories <SDK root directory>` of the *emsdk root directory*. The **emsdk root** is the directory specified when you first installed an SDK.

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -351,8 +351,8 @@ Options that are modified or new in *emcc* are listed below:
   If using this in combination with ``--clear-cache``, be sure to specify
   this argument first.
 
-  The Emscripten cache defaults to being located in the path name stored
-  in the ``EM_CACHE`` environment variable or ``~/.emscripten_cache``.
+  The Emscripten cache defaults ``emscripten/cache`` but can be overridden
+  use ``EM_CACHE`` environment variable or ``CACHE`` config setting.
 
 .. _emcc-clear-cache:
 
@@ -432,7 +432,10 @@ Options that are modified or new in *emcc* are listed below:
 .. _emcc-config:
 
 ``--em-config``
-  Specifies the location of the **.emscripten** configuration file for the current compiler run. If not specified, the environment variable ``EM_CONFIG`` is first read for this location. If neither are specified, the default location **~/.emscripten** is used.
+  Specifies the location of the **.emscripten** configuration file.  If not
+  specified emscripten will search for ``.emscripten`` first in the emscripten
+  dirctory itself, and then in the users home directory (``~/.emscripten``).
+  This can be overridden using the ``EM_CONFIG`` environment variable.
 
 ``--default-obj-ext .ext``
   Specifies the file suffix to generate if the location of a directory name is passed to the ``-o`` directive.

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -351,8 +351,8 @@ Options that are modified or new in *emcc* are listed below:
   If using this in combination with ``--clear-cache``, be sure to specify
   this argument first.
 
-  The Emscripten cache defaults ``emscripten/cache`` but can be overridden
-  use ``EM_CACHE`` environment variable or ``CACHE`` config setting.
+  The Emscripten cache defaults to ``emscripten/cache`` but can be overridden
+  using the ``EM_CACHE`` environment variable or ``CACHE`` config setting.
 
 .. _emcc-clear-cache:
 
@@ -434,7 +434,7 @@ Options that are modified or new in *emcc* are listed below:
 ``--em-config``
   Specifies the location of the **.emscripten** configuration file.  If not
   specified emscripten will search for ``.emscripten`` first in the emscripten
-  dirctory itself, and then in the users home directory (``~/.emscripten``).
+  directory itself, and then in the user's home directory (``~/.emscripten``).
   This can be overridden using the ``EM_CONFIG`` environment variable.
 
 ``--default-obj-ext .ext``

--- a/site/source/docs/tools_reference/emsdk.rst
+++ b/site/source/docs/tools_reference/emsdk.rst
@@ -85,7 +85,7 @@ Emscripten Compiler Configuration File (.emscripten)
 The *Compiler Configuration File* stores the :term:`active <Active Tool/SDK>` configuration on behalf of the *emsdk*. The active configuration defines the specific set of tools that are used by default if Emscripten in called on the :ref:`Emscripten Command Prompt <emcmdprompt>`.
 
 The configuration file is named **.emscripten**. It is emsdk-specific, so it
-wont conflict with any config file the user might have in thier home directory.
+won't conflict with any config file the user might have in their home directory.
 
 The file should generally not be updated directly unless you're :ref:`building Emscripten from source <installing-from-source>`. Instead use the *emsdk* to activate specific SDKs and tools as needed (``emsdk activate <tool/SDK>``).
 

--- a/site/source/docs/tools_reference/emsdk.rst
+++ b/site/source/docs/tools_reference/emsdk.rst
@@ -69,7 +69,10 @@ The :term:`SDK` targets are a convenience mechanism for specifying the full set 
   ./emsdk install sdk-incoming-64bit
   ./emsdk install git-1.8.3 clang-incoming-64bit node-0.10.17-64bit python-2.7.5.3-64bit java-7.45-64bit emscripten-incoming
 
-A particular installed SDK (or tool) can then be set as :term:`active <Active Tool/SDK>`, meaning that it will be used when Emscripten is run. The active "compiler configuration" is stored in a user-specific file (*~/.emscripten*), which is discussed in the next section.
+A particular installed SDK (or tool) can then be set as :term:`active <Active
+Tool/SDK>`, meaning that it will be used when Emscripten is run. The active
+"compiler configuration" is stored is a config file (*.emscripten*) within
+the emsdk directory.
 
 .. note:: The different tools and SDKs managed by *emsdk* are stored in different directories under the root folder you specified when you first installed an SDK, grouped by tool and version.
 
@@ -81,7 +84,8 @@ Emscripten Compiler Configuration File (.emscripten)
 
 The *Compiler Configuration File* stores the :term:`active <Active Tool/SDK>` configuration on behalf of the *emsdk*. The active configuration defines the specific set of tools that are used by default if Emscripten in called on the :ref:`Emscripten Command Prompt <emcmdprompt>`.
 
-The configuration file is named **.emscripten**. It is user-specific, and is located in the user's home directory (**~/.emscripten** on Linux).
+The configuration file is named **.emscripten**. It is emsdk-specific, so it
+wont conflict with any config file the user might have in thier home directory.
 
 The file should generally not be updated directly unless you're :ref:`building Emscripten from source <installing-from-source>`. Instead use the *emsdk* to activate specific SDKs and tools as needed (``emsdk activate <tool/SDK>``).
 
@@ -189,7 +193,9 @@ First use the ``update`` command to fetch package information for all new tools 
 How do I change the currently active SDK version?
 ----------------------------------------------------------------
 
-Toggle between different tools and SDK versions using the :term:`activate <Active Tool/SDK>` command. This will set up ``~/.emscripten`` to point to that particular tool: ::
+Toggle between different tools and SDK versions using the :term:`activate
+<Active Tool/SDK>` command. This will set up ``.emscripten`` to point to that
+particular tool: ::
 
   ./emsdk activate <tool/sdk name>
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -62,6 +62,10 @@ from tools.shared import EM_CONFIG, TEMP_DIR, EMCC, EMXX, DEBUG, LLVM_TARGET, AS
 from tools.shared import asstr, get_canonical_temp_dir, Building, run_process, try_delete, asbytes, safe_copy, Settings
 from tools import jsrun, shared, line_endings
 
+# tools/shared.py sets EM_CONFIG in the environment, but we want to run the test suite
+# in an unmodified environment.
+if 'EM_CONFIG' in os.environ:
+  del os.environ['EM_CONFIG']
 
 def path_from_root(*pathelems):
   return os.path.join(__rootpath__, *pathelems)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -67,6 +67,7 @@ from tools import jsrun, shared, line_endings
 if 'EM_CONFIG' in os.environ:
   del os.environ['EM_CONFIG']
 
+
 def path_from_root(*pathelems):
   return os.path.join(__rootpath__, *pathelems)
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -125,7 +125,7 @@ class sanity(RunnerCore):
     print('WARNING: This will modify %s, and in theory can break it although it should be restored properly. A backup will be saved in %s_backup' % (EM_CONFIG, EM_CONFIG))
     print()
     print('>>> the original settings file is:')
-    print(open(os.path.expanduser('~/.emscripten')).read())
+    print(open(path_from_root('.emscripten')).read())
     print('<<<')
     print()
 
@@ -212,8 +212,6 @@ class sanity(RunnerCore):
       assert output.split()[-1].endswith('===='), 'We should have stopped: ' + output
       config_file = open(CONFIG_FILE).read()
       template_file = open(path_from_root('tools', 'settings_template.py')).read()
-      self.assertNotContained('~/.emscripten', config_file)
-      self.assertContained('~/.emscripten', template_file)
       self.assertNotContained('{{{', config_file)
       self.assertNotContained('}}}', config_file)
       self.assertContained('{{{', template_file)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -118,18 +118,19 @@ class sanity(RunnerCore):
     # Unlike the other test suites we explicitly don't want to be skipping
     # the sanity checks here
     del os.environ['EMCC_SKIP_SANITY_CHECK']
+
+    assert os.path.exists(CONFIG_FILE), 'To run these tests, we need a (working!) %s file to already exist' % EM_CONFIG
     shutil.copyfile(CONFIG_FILE, CONFIG_FILE + '_backup')
 
     print()
     print('Running sanity checks.')
-    print('WARNING: This will modify %s, and in theory can break it although it should be restored properly. A backup will be saved in %s_backup' % (EM_CONFIG, EM_CONFIG))
+    print('WARNING: This will modify %s, and in theory can break it although it should be restored properly. A backup will be saved in %s_backup' % (CONFIG_FILE, CONFIG_FILE))
     print()
     print('>>> the original settings file is:')
-    print(open(path_from_root('.emscripten')).read())
+    print(open(CONFIG_FILE)).read())
     print('<<<')
     print()
 
-    assert os.path.exists(CONFIG_FILE), 'To run these tests, we need a (working!) %s file to already exist' % EM_CONFIG
     assert 'EMCC_DEBUG' not in os.environ, 'do not run sanity checks in debug mode!'
     assert 'EMCC_WASM_BACKEND' not in os.environ, 'do not force wasm backend either way in sanity checks!'
 

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -195,9 +195,11 @@ class sanity(RunnerCore):
         os.environ['PATH'] = old_environ_path
         shutil.rmtree(temp_bin)
 
+      default_config = shared.embedded_config
       self.assertContained('Welcome to Emscripten!', output)
       self.assertContained('This is the first time any of the Emscripten tools has been run.', output)
-      self.assertContained('A settings file has been copied to %s, at absolute path: %s' % (EM_CONFIG, CONFIG_FILE), output)
+      self.assertContained('A settings file has been copied to %s, at absolute path: %s' %
+          (default_config, default_config), output)
       self.assertContained('It contains our best guesses for the important paths, which are:', output)
       self.assertContained('LLVM_ROOT', output)
       self.assertContained('NODE_JS', output)
@@ -211,7 +213,7 @@ class sanity(RunnerCore):
       self.assertContained('Please edit the file if any of those are incorrect', output)
       self.assertContained('This command will now exit. When you are done editing those paths, re-run it.', output)
       assert output.split()[-1].endswith('===='), 'We should have stopped: ' + output
-      config_file = open(CONFIG_FILE).read()
+      config_file = open(default_config).read()
       template_file = open(path_from_root('tools', 'settings_template.py')).read()
       self.assertNotContained('{{{', config_file)
       self.assertNotContained('}}}', config_file)
@@ -228,15 +230,16 @@ class sanity(RunnerCore):
 
       # Second run, with bad EM_CONFIG
       for settings in ['blah', 'LLVM_ROOT="blarg"; JS_ENGINES=[]; NODE_JS=[]; SPIDERMONKEY_ENGINE=[]']:
-        f = open(CONFIG_FILE, 'w')
+        f = open(default_config, 'w')
         f.write(settings)
         f.close()
         output = self.do(command)
 
         if 'LLVM_ROOT' not in settings:
-          self.assertContained('Error in evaluating %s' % EM_CONFIG, output)
+          self.assertContained('Error in evaluating %s' % default_config, output)
         elif 'runner.py' not in ' '.join(command):
           self.assertContained('error:', output) # sanity check should fail
+      try_delete(default_config)
 
   def test_llvm(self):
     LLVM_WARNING = 'LLVM version appears incorrect'

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -198,8 +198,7 @@ class sanity(RunnerCore):
       default_config = shared.embedded_config
       self.assertContained('Welcome to Emscripten!', output)
       self.assertContained('This is the first time any of the Emscripten tools has been run.', output)
-      self.assertContained('A settings file has been copied to %s, at absolute path: %s' %
-          (default_config, default_config), output)
+      self.assertContained('A settings file has been copied to %s, at absolute path: %s' % (default_config, default_config), output)
       self.assertContained('It contains our best guesses for the important paths, which are:', output)
       self.assertContained('LLVM_ROOT', output)
       self.assertContained('NODE_JS', output)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -127,7 +127,7 @@ class sanity(RunnerCore):
     print('WARNING: This will modify %s, and in theory can break it although it should be restored properly. A backup will be saved in %s_backup' % (CONFIG_FILE, CONFIG_FILE))
     print()
     print('>>> the original settings file is:')
-    print(open(CONFIG_FILE)).read())
+    print(open(CONFIG_FILE).read())
     print('<<<')
     print()
 

--- a/tools/settings_template.py
+++ b/tools/settings_template.py
@@ -1,5 +1,5 @@
 # This file will be edited (the {{{ }}} things), and written to `.emscripten`
-# when emscripten is direct uses and no config file is found.
+# when emscripten is first used and no config file is found.
 
 # Note: If you put paths relative to the home directory, do not forget
 # os.path.expanduser

--- a/tools/settings_template.py
+++ b/tools/settings_template.py
@@ -1,5 +1,5 @@
-# This file will be edited (the {{{ }}} things), and then ~/.emscripten created
-# with the result, if ~/.emscripten doesn't exist.
+# This file will be edited (the {{{ }}} things), and written to `.emscripten`
+# when emscripten is direct uses and no config file is found.
 
 # Note: If you put paths relative to the home directory, do not forget
 # os.path.expanduser

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3298,9 +3298,9 @@ def make_fetch_worker(source_file, output_file):
   open(output_file, 'w').write(fetch_worker_src)
 
 
-# =================================================================================================
+# ============================================================================
 # End declarations.
-# =================================================================================================
+# ============================================================================
 
 # Everything below this point is top level code that get run when importing this
 # file.  TODO(sbc): We should try to reduce that amount we do here and instead
@@ -3317,7 +3317,7 @@ def make_fetch_worker(source_file, output_file):
 # 3. Local .emscripten file, if found
 # 4. Local .emscripten file, as used by `emsdk --embedded` (two levels above,
 #    see below)
-# 5. Fall back users home directory (~/.emscripten).
+# 5. User home directory config (~/.emscripten), if found.
 
 embedded_config = path_from_root('.emscripten')
 # For compatibility with `emsdk --embedded` mode also look two levels up.  The
@@ -3334,6 +3334,7 @@ embedded_config = path_from_root('.emscripten')
 # See: https://github.com/emscripten-core/emsdk/pull/367
 emsdk_root = os.path.dirname(os.path.dirname(__rootpath__))
 emsdk_embedded_config = os.path.join(emsdk_root, '.emscripten')
+user_home_config = os.path.expanduser('~/.emscripten')
 
 if '--em-config' in sys.argv:
   EM_CONFIG = sys.argv[sys.argv.index('--em-config') + 1]
@@ -3361,8 +3362,14 @@ elif os.path.exists(embedded_config):
   EM_CONFIG = embedded_config
 elif os.path.exists(emsdk_embedded_config):
   EM_CONFIG = emsdk_embedded_config
+elif os.path.exists(user_home_config):
+  EM_CONFIG = user_home_config
 else:
-  EM_CONFIG = '~/.emscripten'
+  if root_is_writable():
+    generate_config(embedded_config, first_time=True)
+  else:
+    generate_config(user_home_config, first_time=True)
+  sys.exit(0)
 
 PYTHON = sys.executable
 EMSCRIPTEN_ROOT = __rootpath__
@@ -3400,8 +3407,7 @@ else:
   CONFIG_FILE = os.path.expanduser(EM_CONFIG)
   logger.debug('EM_CONFIG is located in ' + CONFIG_FILE)
   if not os.path.exists(CONFIG_FILE):
-    generate_config(EM_CONFIG, first_time=True)
-    sys.exit(0)
+    exit_with_error('emscripten config file not found: ' + CONFIG_FILE)
 
 parse_config_file()
 SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, listify(SPIDERMONKEY_ENGINE))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3336,6 +3336,8 @@ emsdk_root = os.path.dirname(os.path.dirname(__rootpath__))
 emsdk_embedded_config = os.path.join(emsdk_root, '.emscripten')
 user_home_config = os.path.expanduser('~/.emscripten')
 
+EMSCRIPTEN_ROOT = __rootpath__
+
 if '--em-config' in sys.argv:
   EM_CONFIG = sys.argv[sys.argv.index('--em-config') + 1]
   # And now remove it from sys.argv
@@ -3372,7 +3374,6 @@ else:
   sys.exit(0)
 
 PYTHON = sys.executable
-EMSCRIPTEN_ROOT = __rootpath__
 
 # The following globals can be overridden by the config file.
 # See parse_config_file below.


### PR DESCRIPTION
When emscripten is first used and we create the default config file,
create it in the emscripten directory if we can.