### PR TITLE
Remove unnecessary extra assignments to Module.asm

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -1582,7 +1582,6 @@ def create_receiving(function_table_data, function_tables_defs, exported_impleme
         else:
           receiving += '\n'.join(make_export_wrappers(module_exports, delay_assignment))
     else:
-      receiving += 'Module["asm"] = asm;\n'
       receiving += '\n'.join(make_export_wrappers(module_exports, delay_assignment))
 
   if shared.Settings.EXPORT_FUNCTION_TABLES and not shared.Settings.WASM:

--- a/emscripten.py
+++ b/emscripten.py
@@ -2457,7 +2457,6 @@ def create_receiving_wasm(exports, initializers):
       else:
         receiving += make_export_wrappers(exports, delay_assignment)
   else:
-    receiving.append('Module["asm"] = asm;')
     receiving += make_export_wrappers(exports, delay_assignment)
 
   return '\n'.join(receiving) + '\n'

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -6,6 +6,11 @@
 
 // === Auto-generated postamble setup entry stuff ===
 
+#if !WASM_BACKEND && !WASM
+// asm.js startup is synchronous
+Module['asm'] = asm;
+#endif
+
 {{{ exportRuntime() }}}
 
 #if MEM_INIT_IN_WASM == 0

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -6,8 +6,6 @@
 
 // === Auto-generated postamble setup entry stuff ===
 
-Module['asm'] = asm;
-
 {{{ exportRuntime() }}}
 
 #if MEM_INIT_IN_WASM == 0


### PR DESCRIPTION
We have the proper assignment in receiveInstance, so all these
are uneeded (except for asm.js in one place).