### PR TITLE
Make -msse explicitly require -msimd128

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,7 +26,6 @@ Current Trunk
 - Removed obsolete SIMD.js support (-s SIMD=1). Use -msimd128 to target Wasm
   SIMD. (#11180)
 - Add warning about fastcomp deprecation (can be disabled via `-Wno-fastcomp`).
-- Removed obsolete SIMD.js support (-s SIMD=1). Use -msimd128 to target Wasm SIMD. (#11180)
 - The mmap method of JavaScript filesystem drivers (based on library_fs.js) no
   longer takes a target memory.  It's safer/cleaner/smaller to assume the target
   is the global memory buffer.

--- a/tests/benchmark_sse1.py
+++ b/tests/benchmark_sse1.py
@@ -43,7 +43,7 @@ print native_results[0]
 
 # Run emscripten build
 out_file = os.path.join(temp_dir, 'benchmark_sse1_html.js')
-cmd = [EMCC, path_from_root('tests', 'sse', 'benchmark_sse1.cpp'), '-O3', '-msse', '-s', 'SIMD=1', '-s', 'TOTAL_MEMORY=536870912', '-o', out_file]
+cmd = [EMCC, path_from_root('tests', 'sse', 'benchmark_sse1.cpp'), '-O3', '-msse', '-msimd128', '-s', 'TOTAL_MEMORY=536870912', '-o', out_file]
 print 'Building Emscripten version of the benchmark:'
 print ' '.join(cmd)
 build = Popen(cmd)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -745,6 +745,9 @@ def emsdk_cflags(user_args=[]):
     return result
 
   if '-msse' in user_args:
+    if not Settings.BINARYEN_SIMD:
+      exit_with_error('-msse requires -msimd128')
+
     c_opts += ['-D__SSE__=1'] + include_directive([path_from_root('system', 'include', 'SSE')])
 
   # libcxx include paths must be defined before libc's include paths otherwise libcxx will not build


### PR DESCRIPTION
Passing -msse without -msimd128 doesn't make sense anyway, because the SSE intrinsics glue will fail to compile when trying to call the WASM SIMD intrinsics.

More importantly, this unbreaks projects that test for -msse in a configure check, not expecting it to A) target an unstable version of the WASM spec; and B) fail to actually compile the SSE code.