### PR TITLE
Don't remove EM_CONFIG environment variable

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -62,11 +62,6 @@ from tools.shared import EM_CONFIG, TEMP_DIR, EMCC, EMXX, DEBUG, LLVM_TARGET, AS
 from tools.shared import asstr, get_canonical_temp_dir, Building, run_process, try_delete, asbytes, safe_copy, Settings
 from tools import jsrun, shared, line_endings
 
-# tools/shared.py sets EM_CONFIG in the environment, but we want to run the test suite
-# in an unmodified environment.
-if 'EM_CONFIG' in os.environ:
-  del os.environ['EM_CONFIG']
-
 
 def path_from_root(*pathelems):
   return os.path.join(__rootpath__, *pathelems)


### PR DESCRIPTION
This was added as part of #11307 but it broke the waterfall
which was expecting to be able to run the test suite with
a custom config set