### PR TITLE
Use Promise polyfill for MODULARIZE too

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -38,6 +38,13 @@ var Module = typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : 
 #endif // USE_CLOSURE_COMPILER
 #endif // SIDE_MODULE
 
+#if ((MAYBE_WASM2JS && WASM != 2) || MODULARIZE) && (MIN_CHROME_VERSION < 33 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 29 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000) // https://caniuse.com/#feat=promises
+// Include a Promise polyfill for legacy browsers. This is needed either for
+// wasm2js, where we polyfill the wasm API which needs Promises, or when using
+// modularize which creates a Promise for when the module is ready.
+#include "promise_polyfill.js"
+#endif
+
 #if MODULARIZE
 // Set up the promise that indicates the Module is initialized
 var readyPromiseResolve, readyPromiseReject;

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -7,11 +7,6 @@
 // wasm2js.js - enough of a polyfill for the WebAssembly object so that we can load
 // wasm2js code that way.
 
-#if MIN_CHROME_VERSION < 33 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 29 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000 // https://caniuse.com/#feat=promises
-// Include a Promise polyfill for legacy browsers.
-#include "promise_polyfill.js"
-#endif
-
 // Emit "var WebAssembly" if definitely using wasm2js. Otherwise, in MAYBE_WASM2JS
 // mode, we can't use a "var" since it would prevent normal wasm from working.
 /** @suppress{const} */

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10238,12 +10238,17 @@ int main() {
       for engine in WASM_ENGINES:
         self.assertContained(expected, run_js('test.wasm', engine))
 
+  @parameterized({
+    'wasm2js': (['-s', 'WASM=0'], ''),
+    'modularize': (['-s', 'MODULARIZE'], 'Module()'),
+  })
   @no_fastcomp('wasm2js only')
-  def test_promise_polyfill(self):
+  def test_promise_polyfill(self, constant_args, extern_post_js):
     def test(args):
       # legacy browsers may lack Promise, which wasm2js depends on. see what
       # happens when we kill the global Promise function.
-      run_process([EMCC, path_from_root('tests', 'hello_world.cpp'), '-s', 'WASM=0'] + args)
+      create_test_file('extern-post.js', extern_post_js)
+      run_process([EMCC, path_from_root('tests', 'hello_world.cpp')] + constant_args + args + ['--extern-post-js', 'extern-post.js'])
       with open('a.out.js') as f:
         js = f.read()
       with open('a.out.js', 'w') as f:


### PR DESCRIPTION
In legacy browsers we need to polyfill Promise if we ever use it. We
already handled the wasm2js case before. This moves that code into
`shell.js` and also adds support for MODULARIZE which also needs
Promise support.

Fixes #11271