### PR TITLE
Enable and update other.test_minimal_runtime_code_size after LLVM roll

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -5,6 +5,6 @@
   "a.js.gz": 2422,
   "a.wasm": 10935,
   "a.wasm.gz": 6954,
-  "total": 16571,
+  "total": 16566,
   "total_gz": 9753
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -5,6 +5,6 @@
   "a.js.gz": 2244,
   "a.wasm": 10935,
   "a.wasm.gz": 6954,
-  "total": 16056,
+  "total": 16051,
   "total_gz": 9575
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9285,7 +9285,6 @@ int main () {
         test(['-s', 'WASM=0'], closure, opt)
         test(['-s', 'WASM=1', '-s', 'WASM_ASYNC_COMPILATION=0'], closure, opt)
 
-  @unittest.skip('disable for llvm roll')
   def test_minimal_runtime_code_size(self):
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'AGGRESSIVE_VARIABLE_ELIMINATION=1',


### PR DESCRIPTION
I must be doing something wrong here, as I don't see the code size
win we were expecting...

@tlively what is the pattern that should have changed? I'm not sure
how to look for it. Here is the output after the roll - does that look like
it has the optimization?

https://gist.github.com/kripken/9506f1d58f839ceab1919df7c5b09350