### PR TITLE
Fix clashing racing landing between #11329 and #11277

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2767,7 +2767,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # Run a final regex pass to clean up items that were not possible to optimize by Closure, or unoptimalities that were left behind
       # by processing steps that occurred after Closure.
       if shared.Settings.MINIMAL_RUNTIME == 2 and shared.Settings.USE_CLOSURE_COMPILER and shared.Settings.DEBUG_LEVEL == 0 and not shared.Settings.SINGLE_FILE:
-        # Process .js runtime file
+        # Process .js runtime file. Note that we need to handle the license text
+        # here, so that it will not confuse the hacky script.
+        shared.JS.handle_license(final)
         shared.run_process([shared.PYTHON, shared.path_from_root('tools', 'hacky_postprocess_around_closure_limitations.py'), final])
         # Process .asm.js file
         if not shared.Settings.WASM and shared.Settings.SEPARATE_ASM:

--- a/src/settings.js
+++ b/src/settings.js
@@ -1299,7 +1299,6 @@ var EMIT_PRODUCERS_SECTION = 0;
 var EMIT_EMSCRIPTEN_METADATA = 0;
 
 // Emits emscripten license info in the JS output.
-// [upstream-only]
 var EMIT_EMSCRIPTEN_LICENSE = 0;
 
 // Whether to legalize the JS FFI interfaces (imports/exports) by wrapping them

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -2827,10 +2827,6 @@ class JS(object):
 
   @staticmethod
   def handle_license(js_target):
-    if not Settings.WASM_BACKEND:
-      # EMIT_EMSCRIPTEN_LICENSE is only supported in upstream (it would break
-      # source maps support in fastcomp, and perhaps other things)
-      return
     # ensure we emit the license if and only if we need to, and exactly once
     with open(js_target) as f:
       js = f.read()


### PR DESCRIPTION
One PR added license handling, which ended up hitting a bad
case in the minimal runtime fixup code. We only remove the
license at the very end now, but to let the minimal runtime
fixups work as always, remove it earlier in that code path.