### PR TITLE
Fix node example in docs. fixes #11314

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -196,18 +196,18 @@ Require the library and call its procedures from node:
 
 .. code:: javascript
 
-    var moduleFactory = require('./a.out.js');
+    var factory = require('./a.out.js');
 
-    moduleFactory().then((module) => {
-      module._sayHi(); // direct calling works
-      module.ccall("sayHi"); // using ccall etc. also work
-      console.log(module._daysInWeek()); // values can be returned, etc.
+    factory().then((instance) => {
+      instance._sayHi(); // direct calling works
+      instance.ccall("sayHi"); // using ccall etc. also work
+      console.log(instance._daysInWeek()); // values can be returned, etc.
     });
 
 The ``MODULARIZE`` option makes ``emcc`` emit code in a modular format that is
 easy to import and use with ``require()``: ``require()`` of the module returns
 a factory function that can instantiate the compiled code, returning a
-``Promise`` to tell us when it is ready, and giving us the instantiated
+``Promise`` to tell us when it is ready, and giving us the instance of the
 module as a parameter.
 
 (Note that we use ``call`` here, so we need to add it to the exported runtime

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -70,9 +70,12 @@ to prevent C++ name mangling.
 To compile this code run the following command in the Emscripten
 home directory::
 
-    ./emcc tests/hello_function.cpp -o function.html -s EXPORTED_FUNCTIONS='["_int_sqrt"]' -s EXTRA_EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
+    ./emcc tests/hello_function.cpp -o function.html -s EXPORTED_FUNCTIONS='["_int_sqrt"]' -s EXPORTED_RUNTIME_METHODS='["ccall", "cwrap"]'
 
-``EXPORTED_FUNCTIONS`` tells the compiler what we want to be accessible from the compiled code (everything else might be removed if it is not used), and ``EXTRA_EXPORTED_RUNTIME_METHODS`` tells the compiler that we want to use the runtime functions ``ccall`` and ``cwrap`` (otherwise, it will remove them if it does not see they are used).
+``EXPORTED_FUNCTIONS`` tells the compiler what we want to be accessible from the
+compiled code (everything else might be removed if it is not used), and
+``EXPORTED_RUNTIME_METHODS`` tells the compiler that we want to use the runtime
+functions ``ccall`` and ``cwrap`` (otherwise, it will not include them).
 
 .. note::
 
@@ -155,8 +158,8 @@ parameters to pass to the function:
      didn't see, like another script tag on the HTML or in the JS console like
      we did in this tutorial, then because of optimizations
      and minification you should export ccall from the runtime, using
-     ``EXTRA_EXPORTED_RUNTIME_METHODS``, for example using
-     ``-s 'EXTRA_EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]'``,
+     ``EXPORTED_RUNTIME_METHODS``, for example using
+     ``-s 'EXPORTED_RUNTIME_METHODS=["ccall", "cwrap"]'``,
      and call it on ``Module`` (which contains
      everything exported, in a safe way that is not influenced by minification
      or optimizations).
@@ -187,18 +190,28 @@ Compile the library with emcc:
 
 .. code:: bash
 
-    emcc api_example.c -o api_example.js
+    emcc api_example.c -o api_example.js -s MODULARIZE -s EXPORTED_RUNTIME_METHODS=['ccall']
 
 Require the library and call its procedures from node:
 
 .. code:: javascript
 
-    var em_module = require('./api_example.js');
+    var moduleFactory = require('./a.out.js');
 
-    em_module._sayHi(); // direct calling works
-    em_module.ccall("sayHi"); // using ccall etc. also work
-    console.log(em_module._daysInWeek()); // values can be returned, etc.
+    moduleFactory().then((module) => {
+      module._sayHi(); // direct calling works
+      module.ccall("sayHi"); // using ccall etc. also work
+      console.log(module._daysInWeek()); // values can be returned, etc.
+    });
 
+The ``MODULARIZE`` option makes ``emcc`` emit code in a modular format that is
+easy to import and use with ``require()``: ``require()`` of the module returns
+a factory function that can instantiate the compiled code, returning a
+``Promise`` to tell us when it is ready, and giving us the instantiated
+module as a parameter.
+
+(Note that we use ``call`` here, so we need to add it to the exported runtime
+methods, as before.)
 
 .. _interacting-with-code-direct-function-calls:
 

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -210,7 +210,7 @@ a factory function that can instantiate the compiled code, returning a
 ``Promise`` to tell us when it is ready, and giving us the instance of the
 module as a parameter.
 
-(Note that we use ``call`` here, so we need to add it to the exported runtime
+(Note that we use ``ccall`` here, so we need to add it to the exported runtime
 methods, as before.)
 
 .. _interacting-with-code-direct-function-calls:


### PR DESCRIPTION
The example didn't wait for the runtime to be ready - I guess it
was from back when synchronous startup was the default?

I rewrote the example to use `MODULARIZE`. Also it was
missing an export of `ccall`.

Also rename `EXTRA_EXPORTED_RUNTIME_METHODS` to
`EXPORTED_RUNTIME_METHODS` as the "extra_" is no longer
needed.