### PR TITLE
Fix config checksum under python2 vs python3

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -491,7 +491,9 @@ def generate_sanity():
     config = open(CONFIG_FILE).read()
   else:
     config = EM_CONFIG
-  sanity_file_content += '|%#x\n' % binascii.crc32(config.encode())
+  # Convert to unsigned for python2 and python3 compat
+  checksum = binascii.crc32(config.encode()) & 0xffffffff
+  sanity_file_content += '|%#x\n' % checksum
   return sanity_file_content
 
 


### PR DESCRIPTION
This solves an issue we were seeing on the emsdk CI where python2 was initially
being used to activate the SDK but then future commands were run under the
embedded python3.

See: https://docs.python.org/3/library/binascii.html#binascii.crc32