### PR TITLE
Use DESTDIR instead of uncommon DISTDIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,17 @@
 VERSION=$(shell cat emscripten-version.txt | sed s/\"//g)
-DISTDIR=../emscripten-$(VERSION)
+DESTDIR=../emscripten-$(VERSION)
 DISTFILE=emscripten-$(VERSION).tar.bz2
 
 dist: $(DISTFILE)
 
 install:
-	@rm -rf $(DISTDIR)
-	./tools/install.py $(DISTDIR)
+	@rm -rf $(DESTDIR)
+	./tools/install.py $(DESTDIR)
 
 # Create an distributable archive of emscripten suitable for use
 # by end users.  This archive excludes parts of the codebase that
 # are you only used by emscripten developers.
 $(DISTFILE): install
-	tar cf $@ $(EXCLUDE_PATTERN) -C `dirname $(DISTDIR)` `basename $(DISTDIR)`
+	tar cf $@ $(EXCLUDE_PATTERN) -C `dirname $(DESTDIR)` `basename $(DESTDIR)`
 
 .PHONY: dist install


### PR DESCRIPTION
It's quite common to see DESTDIR being used with Makefiles but DISTDIR is very uncommon.