### PR TITLE
Fix WebGL emscripten_webgl_get_context_attributes() proxying

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -3240,7 +3240,7 @@ var LibraryJSEvents = {
 function handleWebGLProxying(funcs) {
   if (!USE_PTHREADS) return; // No proxying needed in singlethreaded builds
 
-  function funcArgs(func) {
+  function listOfNFunctionArgs(func) {
     var args = [];
     for(var i = 0; i < func.length; ++i) {
       args.push('p' + i);
@@ -3258,13 +3258,14 @@ function handleWebGLProxying(funcs) {
       funcs[i + '_main_thread'] = i + '_calling_thread';
       funcs[i + '_main_thread__proxy'] = 'sync';
       funcs[i + '_main_thread__sig'] = funcs[i + '__sig'];
+      if (!funcs[i + '__deps']) funcs[i + '__deps'] = [];
       funcs[i + '__deps'].push(i + '_calling_thread');
       funcs[i + '__deps'].push(i + '_main_thread');
       delete funcs[i + '__proxy'];
-      var funcArgs = funcArgs(funcs[i]);
+      var funcArgs = listOfNFunctionArgs(funcs[i]);
       var funcArgsString = funcArgs.join(',');
       var funcBody = `return GL.contexts[p0] ? _${i}_calling_thread(${funcArgsString}) : _${i}_main_thread(${funcArgsString});`;
-      if (funcs[i + '_before_on_calling_thread') {
+      if (funcs[i + '_before_on_calling_thread']) {
         funcs[i + '__deps'].push(i + '_before_on_calling_thread');
         funcBody = `_${i}_before_on_calling_thread(${funcArgsString}); ` + funcBody;
       }

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -3275,6 +3275,11 @@ function handleWebGLProxying(funcs) {
       // When building with OFFSCREEN_FRAMEBUFFER but without OFFSCREENCANVAS_SUPPORT,
       // only main thread creates WebGL contexts, so all calls are unconditionally proxied.
       funcs[i + '__proxy'] = 'sync';
+#else
+      // Building without OFFSCREENCANVAS_SUPPORT or OFFSCREEN_FRAMEBUFFER: the application
+      // will only utilize WebGL in the main browser thread. Remove any WebGL proxying
+      // directives.
+      delete funcs[i + '__proxy'];
 #endif
 #endif
     }

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -3237,6 +3237,8 @@ var LibraryJSEvents = {
   }
 };
 
+// Process 'sync_on_webgl_context_handle_thread' pseudo-proxying mode (used only in this file) to
+// appropriate proxying mechanism, either proxying on-demand, unconditionally, or never, depending on build modes.
 function handleWebGLProxying(funcs) {
   if (!USE_PTHREADS) return; // No proxying needed in singlethreaded builds
 
@@ -3278,8 +3280,8 @@ function handleWebGLProxying(funcs) {
       funcs[i + '__proxy'] = 'sync';
 #else
       // Building without OFFSCREENCANVAS_SUPPORT or OFFSCREEN_FRAMEBUFFER: the application
-      // will only utilize WebGL in the main browser thread. Remove any WebGL proxying
-      // directives.
+      // will only utilize WebGL in the main browser thread. Remove the WebGL proxying
+      // directive.
       delete funcs[i + '__proxy'];
 #endif
 #endif

--- a/tests/webgl2.cpp
+++ b/tests/webgl2.cpp
@@ -35,6 +35,7 @@ int main()
     memset(&attrs, -1, sizeof(attrs));
     EMSCRIPTEN_RESULT res = emscripten_webgl_get_context_attributes(context, &attrs);
     assert(res == EMSCRIPTEN_RESULT_SUCCESS);
+    assert(attrs.majorVersion == 2);
     assert(attrs.powerPreference == EM_WEBGL_POWER_PREFERENCE_DEFAULT || attrs.powerPreference == EM_WEBGL_POWER_PREFERENCE_LOW_POWER || attrs.powerPreference == EM_WEBGL_POWER_PREFERENCE_HIGH_PERFORMANCE);
     res = emscripten_webgl_make_context_current(context);
     assert(res == EMSCRIPTEN_RESULT_SUCCESS);


### PR DESCRIPTION
Fix WebGL emscripten_webgl_get_context_attributes() proxying in OffscreenCanvas and Offscreen Framebuffer builds. Autogenerate the simplest pattern of proxying mechanism to clean up the code to avoid repeating the proxy boilerplate each time.