### PR TITLE
Remove unnecessary internal BINARYEN_SIMD setting

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3080,9 +3080,6 @@ def parse_args(newargs):
       else:
         shared.generate_config(optarg)
       should_exit = True
-    # Record SIMD setting for Binaryen
-    elif newargs[i] == '-msimd128' or newargs[i] in shared.SIMD_FEATURE_TOWER:
-      shared.Settings.BINARYEN_SIMD = 1
     # Record USE_PTHREADS setting because it controls whether --shared-memory is passed to lld
     elif newargs[i] == '-pthread':
       settings_changes.append('USE_PTHREADS=1')

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -28,9 +28,6 @@ var SYSCALLS_REQUIRE_FILESYSTEM = 1;
 // the features section.
 var BINARYEN_FEATURES = [];
 
-// Tracks whether to enable Wasm SIMD support in Binaryen.
-var BINARYEN_SIMD = 0;
-
 // Whether EMCC_AUTODEBUG is on, which automatically instruments code for
 // runtime logging that can help in debugging.
 var AUTODEBUG = 0;
@@ -206,7 +203,7 @@ var ONLY_CALC_JS_SYMBOLS = 0;
 var STACK_BASE = 0;
 
 // Set to true if the program has a main function.  By default this is
-// enabled, but if `--no-entry` is passed, or if `_main` is not part of 
+// enabled, but if `--no-entry` is passed, or if `_main` is not part of
 // EXPORTED_FUNCTIONS then this gets set to 0.
 var EXPECT_MAIN = 1;
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -1654,8 +1654,6 @@ def get_binaryen_feature_flags():
   ret = ['--mvp-features']
   if Settings.USE_PTHREADS:
     ret += ['--enable-threads']
-  if Settings.BINARYEN_SIMD:
-    ret += ['--enable-simd']
   ret += Settings.BINARYEN_FEATURES
   return ret
 


### PR DESCRIPTION
The target features section and the BINARYEN_FEATURES setting are
sufficient to inform Binaryen to use the SIMD feature.