### PR TITLE
Refactor also_with_standalone_wasm* to use parametrized

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,7 +568,7 @@ jobs:
     executor: mac
     steps:
       - run-tests-mac:
-          test_targets: "other wasm0.test_lua wasm0.test_longjmp skip:other.test_native_link_error_message skip:other.test_emcc_v"
+          test_targets: "other wasm0.test_lua wasm0.test_longjmp_standalone skip:other.test_native_link_error_message skip:other.test_emcc_v"
 
 workflows:
   build-test:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6579,10 +6579,10 @@ return malloc(size);
       '''
     self.do_run(src, 'AD:-1,1', build_ll_hook=do_autodebug)
 
+  @also_with_standalone_wasm(wasm2c=True, impure=True)
   @no_asan('autodebug logging interferes with asan')
   @no_fastcomp('autodebugging wasm is only supported in the wasm backend')
   @with_env_modify({'EMCC_AUTODEBUG': '1'})
-  @also_with_standalone_wasm(wasm2c=True, impure=True)
   def test_autodebug_wasm(self):
     # Autodebug does not work with too much shadow memory.
     # Memory consumed by autodebug depends on the size of the WASM linear memory.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -145,108 +145,34 @@ def can_do_standalone(self):
       '-fsanitize=address' not in self.emcc_args
 
 
-# Also run the test with -s STANDALONE. If we have wasm runtimes, also run in
-# them (regardless we also check that the js+wasm combo works in js vms).
-def also_with_standalone_wasm(func):
-  def decorated(self):
-    func(self)
-    # Standalone mode is only supported in the wasm backend, and not in all
-    # modes there.
-    if can_do_standalone(self):
-      print('standalone')
-      self.set_setting('STANDALONE_WASM', 1)
-      # we will not legalize the JS ffi interface, so we must use BigInt
-      # support in order for JS to have a chance to run this without trapping
-      # when it sees an i64 on the ffi.
-      self.set_setting('WASM_BIGINT', 1)
-      with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
+# Impure means a test that cannot run in a wasm VM yet, as it is not 100%
+# standalone. We can still run them with the JS code though.
+def also_with_standalone_wasm(wasm2c=False, impure=False):
+  def decorated(func):
+    def metafunc(self, standalone):
+      if not standalone:
         func(self)
+      else:
+        if can_do_standalone(self):
+          self.set_setting('STANDALONE_WASM', 1)
+          # we will not legalize the JS ffi interface, so we must use BigInt
+          # support in order for JS to have a chance to run this without trapping
+          # when it sees an i64 on the ffi.
+          self.set_setting('WASM_BIGINT', 1)
+          # if we are impure, disallow all wasm engines
+          with wasm_engines_modify([] if impure else shared.WASM_ENGINES):
+            with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
+              func(self)
+              if wasm2c:
+                print('wasm2c')
+                self.set_setting('WASM2C', 1)
+                with wasm_engines_modify([]):
+                  func(self)
 
-  return decorated
+    metafunc._parameterize = {'': (False,),
+                              'standalone': (True,)}
+    return metafunc
 
-
-def also_with_standalone_wasm_and_wasm2c(func):
-  def decorated(self):
-    func(self)
-    # Standalone mode is only supported in the wasm backend, and not in all
-    # modes there.
-    if can_do_standalone(self):
-      print('standalone')
-      self.set_setting('STANDALONE_WASM', 1)
-      # we will not legalize the JS ffi interface, so we must use BigInt
-      # support in order for JS to have a chance to run this without trapping
-      # when it sees an i64 on the ffi.
-      self.set_setting('WASM_BIGINT', 1)
-      with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
-        func(self)
-        print('wasm2c')
-        self.set_setting('WASM2C', 1)
-        with wasm_engines_modify([]):
-          func(self)
-
-  return decorated
-
-
-# Similar to also_with_standalone_wasm, but suitable for tests that cannot
-# run in a wasm VM yet, as they are not 100% standalone. We can still
-# run them with the JS code though.
-def also_with_impure_standalone_wasm(func):
-  def decorated(self):
-    func(self)
-    # Standalone mode is only supported in the wasm backend, and not in all
-    # modes there.
-    if can_do_standalone(self):
-      print('standalone (impure; no wasm runtimes)')
-      self.set_setting('STANDALONE_WASM', 1)
-      # we will not legalize the JS ffi interface, so we must use BigInt
-      # support in order for JS to have a chance to run this without trapping
-      # when it sees an i64 on the ffi.
-      self.set_setting('WASM_BIGINT', 1)
-      with wasm_engines_modify([]):
-        with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
-          func(self)
-
-  return decorated
-
-
-def also_with_impure_standalone_wasm_and_wasm2c(func):
-  def decorated(self):
-    func(self)
-    # Standalone mode is only supported in the wasm backend, and not in all
-    # modes there.
-    if can_do_standalone(self):
-      print('standalone (impure; no wasm runtimes)')
-      with wasm_engines_modify([]):
-        self.set_setting('STANDALONE_WASM', 1)
-        # we will not legalize the JS ffi interface, so we must use BigInt
-        # support in order for JS to have a chance to run this without trapping
-        # when it sees an i64 on the ffi.
-        self.set_setting('WASM_BIGINT', 1)
-        with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
-          func(self)
-        print('wasm2c')
-        self.set_setting('STANDALONE_WASM', 1)
-        self.set_setting('WASM2C', 1)
-        # disable js engines too, so we only run the c output
-        with js_engines_modify([]):
-          func(self)
-
-  return decorated
-
-
-# Similar to also_with_standalone_wasm, but suitable for tests that can *only*
-# run in a wasm VM, or in non-standalone mode, but not in standalone mode with
-# our JS.
-def also_with_only_standalone_wasm(func):
-  def decorated(self):
-    func(self)
-    # Standalone mode is only supported in the wasm backend, and not in all
-    # modes there.
-    if can_do_standalone(self):
-      print('standalone (only; no js runtimes)')
-      self.set_setting('STANDALONE_WASM', 1)
-      with js_engines_modify([]):
-        func(self)
   return decorated
 
 
@@ -392,7 +318,7 @@ class TestCoreBase(RunnerCore):
                             configure_args=configure_args,
                             cache_name_extra=configure_commands[0])
 
-  @also_with_standalone_wasm
+  @also_with_standalone_wasm()
   def test_hello_world(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
     # must not emit this unneeded internal thing
@@ -445,7 +371,7 @@ class TestCoreBase(RunnerCore):
   def test_i64_umul(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_i64_umul')
 
-  @also_with_standalone_wasm
+  @also_with_standalone_wasm()
   def test_i64_precise(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_i64_precise')
 
@@ -541,7 +467,7 @@ class TestCoreBase(RunnerCore):
     js = open('src.c.o.js').read()
     assert ('llvm_' not in js) == is_optimizing(self.emcc_args) or not self.is_wasm(), 'intrinsics must be lowered when optimizing'
 
-  @also_with_standalone_wasm
+  @also_with_standalone_wasm()
   def test_bswap64(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_bswap64')
 
@@ -568,7 +494,7 @@ class TestCoreBase(RunnerCore):
     shutil.copyfile(path_from_root('tests', 'cube2md5.txt'), 'cube2md5.txt')
     self.do_run(open(path_from_root('tests', 'cube2md5.cpp')).read(), open(path_from_root('tests', 'cube2md5.ok')).read(), assert_returncode=None)
 
-  @also_with_standalone_wasm_and_wasm2c
+  @also_with_standalone_wasm(wasm2c=True)
   @needs_make('make')
   def test_cube2hash(self):
     # A good test of i64 math
@@ -1113,7 +1039,7 @@ base align: 0, 0, 0, 0'''])
       '''
       self.do_run(src, 'sizeofs:6,8\n*C___: 0,6,12,20<24*\n*Carr: 0,6,12,20<24*\n*C__w: 0,6,12,20<24*\n*Cp1_: 4,6,12,20<24*\n*Cp2_: 0,6,12,20<24*\n*Cint: 0,8,12,20<24*\n*C4__: 0,8,12,20<24*\n*C4_2: 0,6,10,16<20*\n*C__z: 0,8,16,24<28*')
 
-  @also_with_standalone_wasm
+  @also_with_standalone_wasm()
   def test_assert(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_assert', assert_returncode=None)
 
@@ -1123,7 +1049,7 @@ base align: 0, 0, 0, 0'''])
   def test_regex(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_regex')
 
-  @also_with_impure_standalone_wasm_and_wasm2c
+  @also_with_standalone_wasm(wasm2c=True, impure=True)
   def test_longjmp(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_longjmp')
 
@@ -1633,7 +1559,7 @@ int main() {
 
   # Marked as impure since the WASI reactor modules (modules without main)
   # are not yet suppored by the wasm engines we test against.
-  @also_with_impure_standalone_wasm
+  @also_with_standalone_wasm(impure=True)
   def test_ctors_no_main(self):
     self.emcc_args.append('--no-entry')
     self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main')
@@ -2178,7 +2104,7 @@ int main(int argc, char **argv) {
     self.emcc_args += ['-s', 'ALLOW_MEMORY_GROWTH=0', '-s', 'ABORTING_MALLOC=0', '-s', 'SAFE_HEAP']
     self.do_run_in_out_file_test('tests', 'core', 'test_memorygrowth_3')
 
-  @also_with_impure_standalone_wasm
+  @also_with_standalone_wasm(impure=True)
   def test_memorygrowth_MAXIMUM_MEMORY(self):
     if self.has_changed_setting('ALLOW_MEMORY_GROWTH'):
       self.skipTest('test needs to modify memory growth')
@@ -2512,7 +2438,7 @@ The current type of b is: 9
     # tests strtoll for decimal strings (0x...)
     self.do_run_in_out_file_test('tests', 'core', 'test_strtol_oct')
 
-  @also_with_standalone_wasm
+  @also_with_standalone_wasm()
   def test_atexit(self):
     # Confirms they are called in the proper reverse order
     self.set_setting('EXIT_RUNTIME', 1)
@@ -2605,7 +2531,7 @@ The current type of b is: 9
   def test_memcpy3(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_memcpy3', assert_returncode=None)
 
-  @also_with_standalone_wasm
+  @also_with_standalone_wasm()
   def test_memcpy_alignment(self):
     self.do_run(open(path_from_root('tests', 'test_memcpy_alignment.cpp')).read(), 'OK.')
 
@@ -5531,7 +5457,7 @@ main( int argv, char ** argc ) {
     src = open(path_from_root('tests', 'unistd', 'isatty.c')).read()
     self.do_run(src, 'success', force_c=True)
 
-  @also_with_standalone_wasm
+  @also_with_standalone_wasm()
   def test_unistd_sysconf(self):
     self.do_run_in_out_file_test('tests', 'unistd', 'sysconf')
 
@@ -5628,7 +5554,7 @@ main( int argv, char ** argc ) {
 
   # i64s in the API, which we'd need to legalize for JS, so in standalone mode
   # all we can test is wasm VMs
-  @also_with_standalone_wasm_and_wasm2c
+  @also_with_standalone_wasm(wasm2c=True)
   def test_posixtime(self):
     test_path = path_from_root('tests', 'core', 'test_posixtime')
     src, output = (test_path + s for s in ('.c', '.out'))
@@ -6656,7 +6582,7 @@ return malloc(size);
   @no_asan('autodebug logging interferes with asan')
   @no_fastcomp('autodebugging wasm is only supported in the wasm backend')
   @with_env_modify({'EMCC_AUTODEBUG': '1'})
-  @also_with_impure_standalone_wasm_and_wasm2c
+  @also_with_standalone_wasm(wasm2c=True, impure=True)
   def test_autodebug_wasm(self):
     # Autodebug does not work with too much shadow memory.
     # Memory consumed by autodebug depends on the size of the WASM linear memory.
@@ -8243,7 +8169,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
           'allow': TRAP_OUTPUTS
         }[mode], assert_returncode=None)
 
-  @also_with_standalone_wasm
+  @also_with_standalone_wasm()
   def test_sbrk(self):
     self.do_run(open(path_from_root('tests', 'sbrk_brk.cpp')).read(), 'OK.')
 
@@ -8689,7 +8615,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   # Marked as impure since the WASI reactor modules (modules without main)
   # are not yet suppored by the wasm engines we test against.
-  @also_with_impure_standalone_wasm
+  @also_with_standalone_wasm(impure=True)
   def test_undefined_main(self):
     # Traditionally in emscripten we allow main to be undefined.  This allows programs with a main
     # and libraries without a main to be compiled identically.


### PR DESCRIPTION
This also makes it easy to consolidate the variations on that
decorator into a single function.