### PR TITLE
Disable wasm2c tests on mac and windows, which fail on chromium ci

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -179,10 +179,12 @@ def also_with_standalone_wasm_and_wasm2c(func):
       self.set_setting('WASM_BIGINT', 1)
       with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
         func(self)
-        print('wasm2c')
-        self.set_setting('WASM2C', 1)
-        with wasm_engines_modify([]):
-          func(self)
+        # wasm2c output is not yet portable on windows and mac
+        if not WINDOWS and not MACOS:
+          print('wasm2c')
+          self.set_setting('WASM2C', 1)
+          with wasm_engines_modify([]):
+            func(self)
 
   return decorated
 
@@ -224,12 +226,14 @@ def also_with_impure_standalone_wasm_and_wasm2c(func):
         self.set_setting('WASM_BIGINT', 1)
         with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
           func(self)
-        print('wasm2c')
-        self.set_setting('STANDALONE_WASM', 1)
-        self.set_setting('WASM2C', 1)
-        # disable js engines too, so we only run the c output
-        with js_engines_modify([]):
-          func(self)
+        # wasm2c output is not yet portable on windows and mac
+        if not WINDOWS and not MACOS:
+          print('wasm2c')
+          self.set_setting('STANDALONE_WASM', 1)
+          self.set_setting('WASM2C', 1)
+          # disable js engines too, so we only run the c output
+          with js_engines_modify([]):
+            func(self)
 
   return decorated
 


### PR DESCRIPTION
This just disables the new testing for now to unbreak CI.

One issue is
```
/b/s/w/ir/tmp/t/tmpba1nk47j/emscripten_test_wasm0_jiaj5par/src.cpp.o.wasm.c:16831:33: error: no member named 'st_atim' in 'struct stat'
  wasm_i32_store(buf + 56, nbuf.st_atim.tv_sec);
                           ~~~~ ^
/b/s/w/ir/tmp/t/tmpba1nk47j/emscripten_test_wasm0_jiaj5par/src.cpp.o.wasm.c:16832:33: error: no member named 'st_atim' in 'struct stat'
  wasm_i32_store(buf + 60, nbuf.st_atim.tv_nsec);
                           ~~~~ ^
/b/s/w/ir/tmp/t/tmpba1nk47j/emscripten_test_wasm0_jiaj5par/src.cpp.o.wasm.c:16833:33: error: no member named 'st_mtim' in 'struct stat'
  wasm_i32_store(buf + 64, nbuf.st_mtim.tv_sec);
                           ~~~~ ^
/b/s/w/ir/tmp/t/tmpba1nk47j/emscripten_test_wasm0_jiaj5par/src.cpp.o.wasm.c:16834:33: error: no member named 'st_mtim' in 'struct stat'
  wasm_i32_store(buf + 68, nbuf.st_mtim.tv_nsec);
                           ~~~~ ^
/b/s/w/ir/tmp/t/tmpba1nk47j/emscripten_test_wasm0_jiaj5par/src.cpp.o.wasm.c:16835:33: error: no member named 'st_ctim' in 'struct stat'
  wasm_i32_store(buf + 72, nbuf.st_ctim.tv_sec);
                           ~~~~ ^
/b/s/w/ir/tmp/t/tmpba1nk47j/emscripten_test_wasm0_jiaj5par/src.cpp.o.wasm.c:16836:33: error: no member named 'st_ctim' in 'struct stat'
  wasm_i32_store(buf + 76, nbuf.st_ctim.tv_nsec);
                           ~~~~ ^
```
which suggests the OS layer is not portable enough yet for mac.

On windows, there is
```
clang: warning: unable to find a Visual Studio installation; try running Clang from a developer command prompt [-Wmsvc-not-found]
C:\b\s\w\ir\tmp\t\tmpk3acajkb\emscripten_test_wasm2_36gr1s8f\src.c.o.wasm.c:197:10: fatal error: 'setjmp.h' file not found
#include <setjmp.h>
         ^~~~~~~~~~
```
That might be a bot-specific issue, as I'm sure setjmp should be supported in general?