### PR TITLE
Fix wasm2c/os.c on MacOS and NetBSD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -568,7 +568,7 @@ jobs:
     executor: mac
     steps:
       - run-tests-mac:
-          test_targets: "other wasm0.test_lua skip:other.test_native_link_error_message skip:other.test_emcc_v"
+          test_targets: "other wasm0.test_lua wasm0.test_longjmp skip:other.test_native_link_error_message skip:other.test_emcc_v"
 
 workflows:
   build-test:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1235,7 +1235,9 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
       if len(wasm_engines) == 0:
         logger.warning('no wasm engine was found to run the standalone part of this test')
       js_engines += wasm_engines
-      if self.get_setting('WASM2C'):
+      # wasm2c requires a working clang install which is missing on CI, or to
+      # use msvc which wasm2c doesn't support yet
+      if self.get_setting('WASM2C') and not WINDOWS:
         # the "engine" to run wasm2c builds is clang that compiles the c
         js_engines += [[CLANG_CC]]
     if len(js_engines) == 0:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -179,12 +179,10 @@ def also_with_standalone_wasm_and_wasm2c(func):
       self.set_setting('WASM_BIGINT', 1)
       with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
         func(self)
-        # wasm2c output is not yet portable on windows and mac
-        if not WINDOWS and not MACOS:
-          print('wasm2c')
-          self.set_setting('WASM2C', 1)
-          with wasm_engines_modify([]):
-            func(self)
+        print('wasm2c')
+        self.set_setting('WASM2C', 1)
+        with wasm_engines_modify([]):
+          func(self)
 
   return decorated
 
@@ -226,14 +224,12 @@ def also_with_impure_standalone_wasm_and_wasm2c(func):
         self.set_setting('WASM_BIGINT', 1)
         with js_engines_modify([NODE_JS + ['--experimental-wasm-bigint']]):
           func(self)
-        # wasm2c output is not yet portable on windows and mac
-        if not WINDOWS and not MACOS:
-          print('wasm2c')
-          self.set_setting('STANDALONE_WASM', 1)
-          self.set_setting('WASM2C', 1)
-          # disable js engines too, so we only run the c output
-          with js_engines_modify([]):
-            func(self)
+        print('wasm2c')
+        self.set_setting('STANDALONE_WASM', 1)
+        self.set_setting('WASM2C', 1)
+        # disable js engines too, so we only run the c output
+        with js_engines_modify([]):
+          func(self)
 
   return decorated
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10248,6 +10248,7 @@ int main() {
       for engine in WASM_ENGINES:
         self.assertContained(expected, run_js('test.wasm', engine))
 
+  @no_windows('TODO: fix setjmp.h on clang on windows on ci')
   @no_fastcomp("uses standalone mode")
   def test_wasm2c_reactor(self):
     # test compiling an unsafe library using wasm2c, then using it from a

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10248,7 +10248,6 @@ int main() {
       for engine in WASM_ENGINES:
         self.assertContained(expected, run_js('test.wasm', engine))
 
-  @no_windows('TODO: fix setjmp.h on clang on windows on ci')
   @no_fastcomp("uses standalone mode")
   def test_wasm2c_reactor(self):
     # test compiling an unsafe library using wasm2c, then using it from a

--- a/tools/wasm2c/os.c
+++ b/tools/wasm2c/os.c
@@ -192,12 +192,21 @@ static u32 do_stat(int nfd, u32 buf) {
   wasm_i64_store(buf + 40, nbuf.st_size);
   wasm_i32_store(buf + 48, nbuf.st_blksize);
   wasm_i32_store(buf + 52, nbuf.st_blocks);
+#if defined(__APPLE__) || defined(__NetBSD__)
+  wasm_i32_store(buf + 56, nbuf.st_atimespec.tv_sec);
+  wasm_i32_store(buf + 60, nbuf.st_atimespec.tv_nsec);
+  wasm_i32_store(buf + 64, nbuf.st_mtimespec.tv_sec);
+  wasm_i32_store(buf + 68, nbuf.st_mtimespec.tv_nsec);
+  wasm_i32_store(buf + 72, nbuf.st_ctimespec.tv_sec);
+  wasm_i32_store(buf + 76, nbuf.st_ctimespec.tv_nsec);
+#else
   wasm_i32_store(buf + 56, nbuf.st_atim.tv_sec);
   wasm_i32_store(buf + 60, nbuf.st_atim.tv_nsec);
   wasm_i32_store(buf + 64, nbuf.st_mtim.tv_sec);
   wasm_i32_store(buf + 68, nbuf.st_mtim.tv_nsec);
   wasm_i32_store(buf + 72, nbuf.st_ctim.tv_sec);
   wasm_i32_store(buf + 76, nbuf.st_ctim.tv_nsec);
+#endif
   wasm_i64_store(buf + 80, nbuf.st_ino);
   return 0;
 }


### PR DESCRIPTION
Also add a test on the mac bot for wasm2c. (This will
conflict with #11364 which renames that test.)

Also simplify the disabling of wasm2c tests on windows - do it
in a single central place.

Re: windows, from reading online it sounds hard to get clang
working by itself on windows, and we have not done that on
our CI apparently as all our tests that would run clang to
build native executables are instead disabled there. So probably not
worth trying to do that just for this. Instead, maybe once wasm2c
works with msvc we can use that.
