### PR TITLE
Skip other.test_minimal_runtime_code_size

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9295,6 +9295,7 @@ int main () {
         test(['-s', 'WASM=0'], closure, opt)
         test(['-s', 'WASM=1', '-s', 'WASM_ASYNC_COMPILATION=0'], closure, opt)
 
+  @unittest.skip('allow binaryen improvements to roll')
   def test_minimal_runtime_code_size(self):
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'AGGRESSIVE_VARIABLE_ELIMINATION=1',


### PR DESCRIPTION
To allow binaryen improvements to roll in.