### PR TITLE
fix emcmake fails with precompiled headers enabled

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1089,11 +1089,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # what is left contains no more |-x OPT| things
     skip = False
     for i in range(len(newargs)):
+      arg = newargs[i]
+
       if skip:
+        if arg == '-Xclang':
+          continue
         skip = False
         continue
 
-      arg = newargs[i]
       if arg in ('-MT', '-MF', '-MQ', '-D', '-U', '-o', '-x',
                  '-Xpreprocessor', '-include', '-imacros', '-idirafter',
                  '-iprefix', '-iwithprefix', '-iwithprefixbefore',


### PR DESCRIPTION
When running emcmake with a cmake project with `target_precompile_headers` it has errors when trying to compile the precompiled header binary.

An example compile commands json 

```{
  "directory": "/Users/peti/proj/_builds/sandbox/wasm32-unknown-emscripten/Debug",
  "command": "/Users/peti/proj/addons/emsdk/upstream/emscripten/em++  -I/Users/peti/proj/packages/ubiqu/src -I/Users/peti/proj/packages/ubiqu/include -g   -g3 -DUBQ_CONTEXT_EGL -Wall -Wextra -Wfatal-errors -Wno-c99-extensions -Wno-gnu-zero-variadic-macro-arguments -pedantic -fms-extensions -fcolor-diagnostics -fno-exceptions -std=gnu++17 -Xclang -emit-pch -Xclang -include -Xclang /Users/peti/proj/_builds/sandbox/wasm32-unknown-emscripten/Debug/ubiqu/CMakeFiles/ubiqu.dir/cmake_pch.hxx -o ubiqu/CMakeFiles/ubiqu.dir/cmake_pch.hxx.pch -c /Users/peti/proj/_builds/sandbox/wasm32-unknown-emscripten/Debug/ubiqu/CMakeFiles/ubiqu.dir/cmake_pch.hxx.cxx",
  "file": "/Users/peti/proj/_builds/sandbox/wasm32-unknown-emscripten/Debug/ubiqu/CMakeFiles/ubiqu.dir/cmake_pch.hxx.cxx"
},
```

The salient compile flags are `-Xclang -emit-pch -Xclang -include -Xclang /Users/peti/proj/_builds/sandbox/wasm32-unknown-emscripten/Debug/ubiqu/CMakeFiles/ubiqu.dir/cmake_pch.hxx`. The emcc.py script tries to skip flags like `-inlucde xyz`. 
But in this case the fact that the pch related flags are prepended with "-Xclang" so the skip does not skip the actual file. In that case it interprets it as an additional import and result in the erro `cannot specify -o with -c/-S and multiple source files`

I'm not 100% sure the -Xclang wrappings are correct, but they are also generated on native clang platforms without emcmake.