### PR TITLE
Remove doublequote_commands option from get_building_env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,7 +553,7 @@ jobs:
           name: Add python to bash path
           command: echo "export PATH=\"$PATH:/c/python38/\"" >> $BASH_ENV
       - run-tests:
-          test_targets: "other wasm2"
+          test_targets: "other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug"
   build-upstream-mac:
     executor: mac
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,7 +553,7 @@ jobs:
           name: Add python to bash path
           command: echo "export PATH=\"$PATH:/c/python38/\"" >> $BASH_ENV
       - run-tests:
-          test_targets: "other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug"
+          test_targets: "other wasm2"
   build-upstream-mac:
     executor: mac
     steps:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1784,7 +1784,7 @@ def build_library(name,
   if native:
     env = clang_native.get_clang_native_env()
   else:
-    env = building.get_building_env(True, cflags=cflags)
+    env = building.get_building_env(cflags=cflags)
   for k, v in env_init.items():
     env[k] = v
   if configure:

--- a/tools/building.py
+++ b/tools/building.py
@@ -264,27 +264,21 @@ def remove_quotes(arg):
     return arg
 
 
-def get_building_env(doublequote_commands=False, cflags=[]):
-  def quote(arg):
-    if WINDOWS and doublequote_commands:
-      return doublequote_spaces(arg)
-    else:
-      return arg
-
+def get_building_env(cflags=[]):
   env = os.environ.copy()
   # point CC etc. to the em* tools.
-  env['CC'] = quote(EMCC)
-  env['CXX'] = quote(EMXX)
-  env['AR'] = quote(EMAR)
-  env['LD'] = quote(EMCC)
-  env['NM'] = quote(LLVM_NM)
-  env['LDSHARED'] = quote(EMCC)
-  env['RANLIB'] = quote(EMRANLIB)
+  env['CC'] = EMCC
+  env['CXX'] = EMXX
+  env['AR'] = EMAR
+  env['LD'] = EMCC
+  env['NM'] = LLVM_NM
+  env['LDSHARED'] = EMCC
+  env['RANLIB'] = EMRANLIB
   env['EMSCRIPTEN_TOOLS'] = path_from_root('tools')
   if cflags:
     env['CFLAGS'] = env['EMMAKEN_CFLAGS'] = ' '.join(cflags)
-  env['HOST_CC'] = quote(CLANG_CC)
-  env['HOST_CXX'] = quote(CLANG_CXX)
+  env['HOST_CC'] = CLANG_CC
+  env['HOST_CXX'] = CLANG_CXX
   env['HOST_CFLAGS'] = "-W" # if set to nothing, CFLAGS is used, which we don't want
   env['HOST_CXXFLAGS'] = "-W" # if set to nothing, CXXFLAGS is used, which we don't want
   env['PKG_CONFIG_LIBDIR'] = path_from_root('system', 'local', 'lib', 'pkgconfig') + os.path.pathsep + path_from_root('system', 'lib', 'pkgconfig')


### PR DESCRIPTION
This argument was only used in a single place: in tests/runner.py
when constructing the environment to pass to `building.configure`
or `building.make`.

However the primary users of `building.configure` and `building.make`
that our users use are in `emconfigure` and `emmake` and here we
don't pass this option.

If this (windows-only) is actually needed then it should be used
in the production environment too, not just during testing.  Assuming
all the tests pass I think this is not needed.