### PR TITLE
Allow disabling tests that require native clang

### DIFF
--- a/tests/clang_native.py
+++ b/tests/clang_native.py
@@ -84,7 +84,7 @@ def get_clang_native_env():
     # Guess where Windows 8.1 SDK is located
     if 'WindowsSdkDir' in env:
       windows8_sdk_dir = env['WindowsSdkDir']
-    elif os.path.isdir(os.path.join(prog_files_x86, 'Windows Kits', '8.1')):
+    else:
       windows8_sdk_dir = os.path.join(prog_files_x86, 'Windows Kits', '8.1')
     if not os.path.isdir(windows8_sdk_dir):
       raise Exception('Windows 8.1 SDK was not found in "' + windows8_sdk_dir + '"! Run in Visual Studio command prompt to avoid the need to autoguess this location (or set WindowsSdkDir env var).')

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -100,6 +100,8 @@ EMTEST_ALL_ENGINES = os.getenv('EMTEST_ALL_ENGINES')
 
 EMTEST_SKIP_SLOW = os.getenv('EMTEST_SKIP_SLOW')
 
+EMTEST_NO_NATIVE_CLANG = os.getenv('EMTEST_NO_NATIVE_CLANG')
+
 EMTEST_VERBOSE = int(os.getenv('EMTEST_VERBOSE', '0'))
 
 if EMTEST_VERBOSE:
@@ -180,6 +182,17 @@ def no_asmjs(note=''):
 
   def decorated(f):
     return skip_if(f, 'is_wasm', note, negate=True)
+  return decorated
+
+
+def requires_native_clang(func):
+  assert callable(func)
+
+  def decorated(self, *args, **kwargs):
+    if EMTEST_NO_NATIVE_CLANG:
+      return self.skipTest('native clang tests are disabled')
+    return func(self, *args, **kwargs)
+
   return decorated
 
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -100,7 +100,7 @@ EMTEST_ALL_ENGINES = os.getenv('EMTEST_ALL_ENGINES')
 
 EMTEST_SKIP_SLOW = os.getenv('EMTEST_SKIP_SLOW')
 
-EMTEST_NO_NATIVE_CLANG = os.getenv('EMTEST_NO_NATIVE_CLANG')
+EMTEST_LACKS_NATIVE_CLANG = os.getenv('EMTEST_LACKS_NATIVE_CLANG')
 
 EMTEST_VERBOSE = int(os.getenv('EMTEST_VERBOSE', '0'))
 
@@ -189,7 +189,7 @@ def requires_native_clang(func):
   assert callable(func)
 
   def decorated(self, *args, **kwargs):
-    if EMTEST_NO_NATIVE_CLANG:
+    if EMTEST_LACKS_NATIVE_CLANG:
       return self.skipTest('native clang tests are disabled')
     return func(self, *args, **kwargs)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
 from tools.shared import run_js, run_process, try_delete
 from tools.shared import NODE_JS, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, PYTHON, EMCC, EMAR, WINDOWS, MACOS, AUTODEBUGGER, LLVM_ROOT
 from tools import jsrun, shared, building
-from runner import RunnerCore, path_from_root
+from runner import RunnerCore, path_from_root, requires_native_clang
 from runner import skip_if, no_wasm_backend, no_fastcomp, needs_dlfcn, no_windows, no_asmjs, is_slow_test, create_test_file, parameterized
 from runner import js_engines_modify, wasm_engines_modify, env_modify, with_env_modify
 import clang_native
@@ -6000,6 +6000,7 @@ return malloc(size);
 
   # Tests invoking the SIMD API via x86 SSE1 xmmintrin.h header (_mm_x() functions)
   @wasm_simd
+  @requires_native_clang
   def test_sse1(self):
     src = path_from_root('tests', 'sse', 'test_sse1.cpp')
     run_process([shared.CLANG_CXX, src, '-msse', '-o', 'test_sse1', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
@@ -6013,6 +6014,7 @@ return malloc(size);
 
   # Tests invoking the SIMD API via x86 SSE2 emmintrin.h header (_mm_x() functions)
   @wasm_simd
+  @requires_native_clang
   def test_sse2(self):
     src = path_from_root('tests', 'sse', 'test_sse2.cpp')
     run_process([shared.CLANG_CXX, src, '-msse2', '-Wno-argument-outside-range', '-o', 'test_sse2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
@@ -6025,6 +6027,7 @@ return malloc(size);
 
   # Tests invoking the SIMD API via x86 SSE3 pmmintrin.h header (_mm_x() functions)
   @wasm_simd
+  @requires_native_clang
   def test_sse3(self):
     src = path_from_root('tests', 'sse', 'test_sse3.cpp')
     run_process([shared.CLANG_CXX, src, '-msse3', '-Wno-argument-outside-range', '-o', 'test_sse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
@@ -6037,6 +6040,7 @@ return malloc(size);
 
   # Tests invoking the SIMD API via x86 SSSE3 tmmintrin.h header (_mm_x() functions)
   @wasm_simd
+  @requires_native_clang
   def test_ssse3(self):
     src = path_from_root('tests', 'sse', 'test_ssse3.cpp')
     run_process([shared.CLANG_CXX, src, '-mssse3', '-Wno-argument-outside-range', '-o', 'test_ssse3', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
@@ -6049,6 +6053,7 @@ return malloc(size);
 
   # Tests invoking the SIMD API via x86 SSE4.1 smmintrin.h header (_mm_x() functions)
   @wasm_simd
+  @requires_native_clang
   def test_sse4_1(self):
     src = path_from_root('tests', 'sse', 'test_sse4_1.cpp')
     run_process([shared.CLANG_CXX, src, '-msse4.1', '-Wno-argument-outside-range', '-o', 'test_sse4_1', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
@@ -6061,6 +6066,7 @@ return malloc(size);
 
   # Tests invoking the SIMD API via x86 SSE4.2 nmmintrin.h header (_mm_x() functions)
   @wasm_simd
+  @requires_native_clang
   def test_sse4_2(self):
     src = path_from_root('tests', 'sse', 'test_sse4_2.cpp')
     run_process([shared.CLANG_CXX, src, '-msse4.2', '-Wno-argument-outside-range', '-o', 'test_sse4_2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
@@ -6073,6 +6079,7 @@ return malloc(size);
 
   # Tests invoking the SIMD API via x86 AVX avxintrin.h header (_mm_x() functions)
   @wasm_simd
+  @requires_native_clang
   def test_avx(self):
     src = path_from_root('tests', 'sse', 'test_avx.cpp')
     run_process([shared.CLANG_CXX, src, '-mavx', '-Wno-argument-outside-range', '-o', 'test_avx', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -35,7 +35,7 @@ from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WIND
 from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP
 from tools.shared import NODE_JS, SPIDERMONKEY_ENGINE, JS_ENGINES, WASM_ENGINES, V8_ENGINE
 from runner import RunnerCore, path_from_root, no_wasm_backend, no_fastcomp, is_slow_test, ensure_dir
-from runner import needs_dlfcn, env_modify, no_windows, chdir, with_env_modify, create_test_file, parameterized
+from runner import needs_dlfcn, env_modify, no_windows, requires_native_clang, chdir, with_env_modify, create_test_file, parameterized
 from tools import jsrun, shared, building
 import clang_native
 import tools.line_endings
@@ -3775,6 +3775,7 @@ int main()
     print(cmd)
     run_process(cmd)
 
+  @requires_native_clang
   def test_bad_triple(self):
     # compile a minimal program, with as few dependencies as possible, as
     # native building on CI may not always work well


### PR DESCRIPTION
Add EMTEST_NO_NATIVE_CLANG and a decorator that can apply to test functions.