### PR TITLE
Disable LIBCXX_ABI_OPTIMIZED_FUNCTION

### DIFF
--- a/system/include/libcxx/__config
+++ b/system/include/libcxx/__config
@@ -99,7 +99,8 @@
 // Previously libc++ used "unsigned int" exclusively.
 #  define _LIBCPP_ABI_VARIANT_INDEX_TYPE_OPTIMIZATION
 // Unstable attempt to provide a more optimized std::function
-#  define _LIBCPP_ABI_OPTIMIZED_FUNCTION
+// XXX EMSCRIPTEN https://github.com/emscripten-core/emscripten/issues/11022
+//#  define _LIBCPP_ABI_OPTIMIZED_FUNCTION
 // All the regex constants must be distinct and nonzero.
 #  define _LIBCPP_ABI_REGEX_CONSTANTS_NONZERO
 #elif _LIBCPP_ABI_VERSION == 1

--- a/tests/core/test_std_function_incomplete_return.cpp
+++ b/tests/core/test_std_function_incomplete_return.cpp
@@ -1,0 +1,15 @@
+#include <iostream>
+#include <functional>
+struct foo;
+using fnc = std::function<foo(int)>;
+struct bar {
+    bar() {
+        std::cout << "construct me" << std::endl;
+    }
+    fnc _f{nullptr};
+};
+int main(int argc, const char * argv[]) {
+    std::cout << "Hello, World!\n";
+    bar b{};
+    return 0;
+}

--- a/tests/core/test_std_function_incomplete_return.out
+++ b/tests/core/test_std_function_incomplete_return.out
@@ -1,0 +1,2 @@
+Hello, World!
+construct me

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5261,6 +5261,9 @@ main( int argv, char ** argc ) {
   def test_std_cout_new(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_std_cout_new')
 
+  def test_std_function_incomplete_return(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_std_function_incomplete_return')
+
   def test_istream(self):
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME', 1)


### PR DESCRIPTION
Workaround for #11022

Disables one particular libcxx ABI change while leaving the other LIBCXX ABIv2 changes for now.