### PR TITLE
Avoid obfuscation of transfered data fields from main thread

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -478,3 +478,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Robert Aboukhalil <robert.aboukhalil@gmail.com>
 * Jonathan Poelen <jonathan.poelen@gmail.com>
 * Ashley Hauck <github@khyperia.com>
+* Junyue Cao <junyuecao@gmail.com>

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -534,12 +534,12 @@ var LibraryPThread = {
         'selfThreadId': threadParams.pthread_ptr, // TODO: Remove this since thread ID is now the same as the thread address.
         'parentThreadId': threadParams.parent_pthread_ptr,
         'stackBase': threadParams.stackBase,
-        'stackSize': threadParams.stackSize,
+        'stackSize': threadParams.stackSize
+    };
 #if OFFSCREENCANVAS_SUPPORT
-        'moduleCanvasId': threadParams.moduleCanvasId,
-        'offscreenCanvases': threadParams.offscreenCanvases,
+    msg.moduleCanvasId = threadParams.moduleCanvasId;
+    msg.offscreenCanvases = threadParams.offscreenCanvases;
 #endif
-      };
     worker.runPthread = function() {
       // Ask the worker to start executing its pthread entry point function.
       msg.time = performance.now();


### PR DESCRIPTION
In the original code, the offscreen canvas cannot be passed after the code is obfuscated