### PR TITLE
Reload the page with Wasm2JS build if Wasm compilation fails

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3622,7 +3622,7 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
           function loadMainJs() {
 %s
           }
-          if (!window.WebAssembly) {
+          if (!window.WebAssembly || location.search.indexOf('_rwasm=0') > 0) {
             // Current browser does not support WebAssembly, load the .wasm.js JavaScript fallback
             // before the main JS runtime.
             var wasm2js = document.createElement('script');

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1010,6 +1010,21 @@ function createWasm() {
 #endif // USE_OFFSET_CONVERTER
     }).then(receiver, function(reason) {
       err('failed to asynchronously prepare wasm: ' + reason);
+
+#if WASM == 2
+#if ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
+      if (typeof location !== 'undefined') {
+#endif
+        // WebAssembly compilation failed, try running the JS fallback instead.
+        var search = location.search;
+        if (search.indexOf('_rwasm=0') < 0) {
+          location.href += (search ? search + '&' : '?') + '_rwasm=0';
+        }
+#if ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
+      }
+#endif
+#endif // WASM == 2
+
       abort(reason);
     });
   }

--- a/src/settings.js
+++ b/src/settings.js
@@ -1193,9 +1193,8 @@ var USE_GLFW = 2;
 // the WebAssembly file is loaded if browser/shell supports it. Otherwise the
 // .wasm.js fallback will be used.
 //
-// Additionally in MINIMAL_RUNTIME mode, if WASM=2 is enabled and the browser
-// fails to compile the WebAssembly module, the page will be reloaded in Wasm2JS
-// mode.
+// If WASM=2 is enabled and the browser fails to compile the WebAssembly module,
+// the page will be reloaded in Wasm2JS mode.
 var WASM = 1;
 
 // STANDALONE_WASM indicates that we want to emit a wasm file that can run without

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4917,14 +4917,20 @@ window.close = function() {
       self.run_browser('test.html', 'hello!', '/report_result?0')
 
   @no_fastcomp('wasm-backend specific feature')
-  def test_minimal_runtime_wasm2js_fallback(self):
-    src = 'src.cpp'
-    create_test_file(src, self.with_report_result(open(path_from_root('tests', 'small_hello_world.c')).read()))
-    self.compile_btest([src, '-s', 'WASM=2', '-s', 'MINIMAL_RUNTIME=1', '-o', 'test.html'])
+  def test_wasm2js_fallback_on_wasm_compilation_failure(self):
+    for args in [[], ['-s', 'MINIMAL_RUNTIME=1']]:
+      src = 'src.cpp'
+      create_test_file(src, self.with_report_result(open(path_from_root('tests', 'small_hello_world.c')).read()))
+      self.compile_btest([src, '-s', 'WASM=2', '-o', 'test.html'] + args)
 
-    # Corrupt the .wasm file, that should trigger the Wasm2js fallback to run
-    shutil.copyfile('test.js', 'test.wasm')
-    self.run_browser('test.html', 'hello!', '/report_result?0')
+      # Run without the .wasm.js file present: with Wasm support, the page should still run
+      os.rename('test.wasm.js', 'test.wasm.js.unused')
+      self.run_browser('test.html', 'hello!', '/report_result?0')
+
+      # Restore the .wasm.js file, then corrupt the .wasm file, that should trigger the Wasm2js fallback to run
+      os.rename('test.wasm.js.unused', 'test.wasm.js')
+      shutil.copyfile('test.js', 'test.wasm')
+      self.run_browser('test.html', 'hello!', '/report_result?0')
 
   def test_system(self):
     self.btest(path_from_root('tests', 'system.c'), '0')


### PR DESCRIPTION
Reload the page with Wasm2JS build if Wasm compilation fails in WASM==2 build mode in classic runtime.