### PR TITLE
Fix time measurement in parallel_testsuite.py on python 2

### DIFF
--- a/tests/parallel_testsuite.py
+++ b/tests/parallel_testsuite.py
@@ -131,15 +131,18 @@ class BufferedParallelTestResult(object):
     result.stopTest(self.test)
 
   def startTest(self, test):
-    self.start_time = time.perf_counter()
+    if hasattr(time, 'perf_counter'):
+      self.start_time = time.perf_counter()
 
   def stopTest(self, test):
     # TODO(sbc): figure out a way to display this duration information again when
     # these results get passed back to the TextTestRunner/TextTestResult.
-    self.buffered_result.duration = time.perf_counter() - self.start_time
+    if hasattr(time, 'perf_counter'):
+      self.buffered_result.duration = time.perf_counter() - self.start_time
 
   def addSuccess(self, test):
-    print(test, '... ok (%.2fs)' % (time.perf_counter() - self.start_time), file=sys.stderr)
+    if hasattr(time, 'perf_counter'):
+      print(test, '... ok (%.2fs)' % (time.perf_counter() - self.start_time), file=sys.stderr)
     self.buffered_result = BufferedTestSuccess(test)
 
   def addSkip(self, test, reason):

--- a/tests/parallel_testsuite.py
+++ b/tests/parallel_testsuite.py
@@ -131,6 +131,8 @@ class BufferedParallelTestResult(object):
     result.stopTest(self.test)
 
   def startTest(self, test):
+    # Python 2 does not have perf_counter()
+    # TODO: remove when we remove Python 2 support
     if hasattr(time, 'perf_counter'):
       self.start_time = time.perf_counter()
 


### PR DESCRIPTION
Looks like python 2 doesn't support the new timing stuff
that we recently added.