### PR TITLE
Minor fix for run_python.sh to work with POSIX sh on FreeBSD.

### DIFF
--- a/em++
+++ b/em++
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/em-config
+++ b/em-config
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emar
+++ b/emar
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/embuilder
+++ b/embuilder
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emcc
+++ b/emcc
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emcmake
+++ b/emcmake
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emconfigure
+++ b/emconfigure
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emmake
+++ b/emmake
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emranlib
+++ b/emranlib
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emrun
+++ b/emrun
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emscons
+++ b/emscons
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/emsize
+++ b/emsize
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 

--- a/tools/run_python.sh
+++ b/tools/run_python.sh
@@ -22,7 +22,7 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  print 'unable to find python in $PATH'
+  echo 'unable to find python in $PATH'
   exit 1
 fi
 


### PR DESCRIPTION
This is a very small fix to replace 'print' with 'echo' in the run_python.sh.

/bin/sh on FreeBSD doesn't support print. It is possibly a bash extension.