### PR TITLE
Embind + Asyncify

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -115,7 +115,7 @@ DEFAULT_ASYNCIFY_IMPORTS = [
   'emscripten_idb_load_blob', 'emscripten_idb_store_blob', 'SDL_Delay',
   'emscripten_scan_registers', 'emscripten_lazy_load_code',
   'emscripten_fiber_swap',
-  'wasi_snapshot_preview1.fd_sync', '__wasi_fd_sync']
+  'wasi_snapshot_preview1.fd_sync', '__wasi_fd_sync', '_emval_await']
 
 # Mapping of emcc opt levels to llvm opt levels. We use llvm opt level 3 in emcc
 # opt levels 2 and 3 (emcc 3 is unsafe opts, so unsuitable for the only level to

--- a/site/source/docs/api_reference/val.h.rst
+++ b/site/source/docs/api_reference/val.h.rst
@@ -256,6 +256,15 @@ Guide material for this class can be found in :ref:`embind-val-guide`.
     :returns: **HamishW**-Replace with description.
 
 
+  .. cpp:function:: val await() const
+
+    Pauses the C++ to ``await`` the ``Promise`` / thenable.
+
+    :returns: The fulfilled value.
+
+    This method requires :ref:`Asyncify` to be enabled.
+
+
 .. cpp:type: EMSCRIPTEN_SYMBOL(name)
 
   **HamishW**-Replace with description.

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -114,7 +114,30 @@ function; another is to use ``EM_JS``, which we'll use in this next example:
     #include <stdio.h>
 
     EM_JS(void, do_fetch, (), {
-      Asyncify.handleSleep(function(wakeUp) {
+      Asyncify.handleAsync(async () => {
+        out("waiting for a fetch");
+        const response = await fetch("a.html");
+        out("got the fetch response");
+        // (normally you would do something with the fetch here)
+      });
+    });
+
+    int main() {
+      puts("before");
+      do_fetch();
+      puts("after");
+    }
+
+If you can't use the modern ``async``-``await`` syntax, there is a variant with an explicit ``wakeUp`` callback too:
+
+.. code-block:: cpp
+
+    // example.c
+    #include <emscripten.h>
+    #include <stdio.h>
+
+    EM_JS(void, do_fetch, (), {
+      Asyncify.handleSleep(wakeUp => {
         out("waiting for a fetch");
         fetch("a.html").then(response => {
           out("got the fetch response");
@@ -130,11 +153,11 @@ function; another is to use ``EM_JS``, which we'll use in this next example:
       puts("after");
     }
 
-
 The async operation happens in the ``EM_JS`` function ``do_fetch()``, which
-calls ``Asyncify.handleSleep``. It gives that function the code to be run, and
-gets a ``wakeUp`` function that it calls in the asynchronous future at the right
-time. After we call ``wakeUp()`` the compiled C code resumes normally.
+calls ``Asyncify.handleAsync`` or ``Asyncify.handleSleep``. It gives that
+function the code to be run, and gets a ``wakeUp`` function that it calls in the
+asynchronous future at the right time. After we call ``wakeUp()`` the compiled C
+code resumes normally.
 
 In this example the async operation is a ``fetch``, which means we need to wait
 for a Promise. While that is async, note how the C code in ``main()`` is
@@ -187,18 +210,16 @@ You can also return values from async JS functions. Here is an example:
     #include <stdio.h>
 
     EM_JS(int, get_digest_size, (const char* str), {
-      // Note how we return the output of handleSleep() here.
-      return Asyncify.handleSleep(function(wakeUp) {
+      // Note how we return the output of handleAsync() here.
+      return Asyncify.handleAsync(async () => {
         const text = UTF8ToString(str);
         const encoder = new TextEncoder();
         const data = encoder.encode(text);
         out("ask for digest for " + text);
-        window.crypto.subtle.digest("SHA-256", data).then(digestValue => {
-          out("got digest of length " + digestValue.byteLength);
-          // Return the value by sending it to wakeUp(). It will then be returned
-          // from handleSleep() on the outside.
-          wakeUp(digestValue.byteLength);
-        });
+        const digestValue = await window.crypto.subtle.digest("SHA-256", data);
+        out("got digest of length " + digestValue.byteLength);
+        // Return the value as you normally would.
+        return digestValue.byteLength;
       });
     });
 
@@ -217,9 +238,45 @@ You can build this with
 This example calls the Promise-returning ``window.crypto.subtle()`` API (the
 example is based off of
 `this MDN example <https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#Basic_example>`_
-). Note how we pass the value to be returned into ``wakeUp()``. We must also
-return the value returned from ``handleSleep()``. The calling C code then
+).
+
+Note that we must propagate the value returned from ``handleSleep()``. The calling C code then
 gets it normally, after the Promise completes.
+
+If you're using ``handleSleep`` API, the value needs to be also passed to the ``wakeUp`` callback, instead of being returned from our handler:
+
+.. code-block:: cpp
+
+    // ...
+    return Asyncify.handleSleep(wakeUp => {
+      const text = UTF8ToString(str);
+      const encoder = new TextEncoder();
+      const data = encoder.encode(text);
+      out("ask for digest for " + text);
+      window.crypto.subtle.digest("SHA-256", data).then(digestValue => {
+        out("got digest of length " + digestValue.byteLength);
+        // Return the value by sending it to wakeUp(). It will then be returned
+        // from handleSleep() on the outside.
+        wakeUp(digestValue.byteLength);
+      });
+    });
+    // ...
+
+Usage with Embind
+#################
+
+If you're using :ref:`Embind<embind-val-guide>` for interaction with JavaScript
+and want to ``await`` a dynamically retrieved ``Promise``, you can call an
+``await()`` method directly on the ``val`` instance:
+
+.. code-block:: cpp
+
+    val my_object = /* ... */;
+    val result = my_object.call("someAsyncMethod").await();
+
+In this case you don't need to worry about ``ASYNCIFY_IMPORTS``, since it's an
+internal implementation detail of ``val::await`` and Emscripten takes care of it
+automatically.
 
 Optimizing
 ##########

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -243,7 +243,7 @@ example is based off of
 Note that we must propagate the value returned from ``handleSleep()``. The calling C code then
 gets it normally, after the Promise completes.
 
-If you're using ``handleSleep`` API, the value needs to be also passed to the ``wakeUp`` callback, instead of being returned from our handler:
+If you're using the ``handleSleep`` API, the value needs to be also passed to the ``wakeUp`` callback, instead of being returned from our handler:
 
 .. code-block:: cpp
 

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -454,7 +454,7 @@ var LibraryEmVal = {
     constructor = requireHandle(constructor);
     return object instanceof constructor;
   },
-  
+
   _emval_is_number__deps: ['$requireHandle'],
   _emval_is_number: function(handle) {
     handle = requireHandle(handle);
@@ -487,6 +487,14 @@ var LibraryEmVal = {
     throw object;
   },
 
+#if ASYNCIFY
+  _emval_await__deps: ['$requireHandle', '_emval_register', '$Asyncify'],
+  _emval_await: function(promise) {
+    promise = requireHandle(promise);
+    promise = promise.then(__emval_register);
+    return Asyncify.handlePromise(promise);
+  },
+#endif
 };
 
 mergeInto(LibraryManager.library, LibraryEmVal);

--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -490,9 +490,10 @@ var LibraryEmVal = {
 #if ASYNCIFY
   _emval_await__deps: ['$requireHandle', '_emval_register', '$Asyncify'],
   _emval_await: function(promise) {
-    promise = requireHandle(promise);
-    promise = promise.then(__emval_register);
-    return Asyncify.handlePromise(promise);
+    return Asyncify.handleAsync(function () {
+      promise = requireHandle(promise);
+      return promise.then(__emval_register);
+    });
   },
 #endif
 };

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -503,6 +503,11 @@ mergeInto(LibraryManager.library, {
       return Asyncify.handleSleepReturnValue;
     },
 
+    // Unlike `handleSleep`, accepts a function returning a `Promise`
+    // and uses the fulfilled value instead of passing in a separate callback.
+    //
+    // This is particularly useful for native JS `async` functions where the
+    // returned value will "just work" and be passed back to C++.
     handleAsync: function(startAsync) {
       return Asyncify.handleSleep(function(wakeUp) {
         // TODO: add error handling as a second param when handleSleep implements it.
@@ -752,4 +757,3 @@ mergeInto(LibraryManager.library, {
 if (WASM_BACKEND && ASYNCIFY) {
   DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$Asyncify');
 }
-

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -503,12 +503,12 @@ mergeInto(LibraryManager.library, {
       return Asyncify.handleSleepReturnValue;
     },
 
-    handlePromise: function(promise) {
+    handleAsync: function(startAsync) {
       return Asyncify.handleSleep(function(wakeUp) {
         // TODO: add error handling as a second param when handleSleep implements it.
-        promise.then(wakeUp);
+        startAsync().then(wakeUp);
       });
-    }
+    },
   },
 
   emscripten_sleep: function(ms) {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -501,6 +501,13 @@ mergeInto(LibraryManager.library, {
         abort('invalid state: ' + Asyncify.state);
       }
       return Asyncify.handleSleepReturnValue;
+    },
+
+    handlePromise: function(promise) {
+      return Asyncify.handleSleep(function(wakeUp) {
+        // TODO: add error handling as a second param when handleSleep implements it.
+        promise.then(wakeUp);
+      });
     }
   },
 

--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -101,6 +101,7 @@ namespace emscripten {
             bool _emval_in(EM_VAL item, EM_VAL object);
             bool _emval_delete(EM_VAL object, EM_VAL property);
             bool _emval_throw(EM_VAL object);
+            EM_VAL _emval_await(EM_VAL promise);
         }
 
         template<const char* address>
@@ -527,6 +528,10 @@ namespace emscripten {
 
         void throw_() const {
             internal::_emval_throw(handle);
+        }
+
+        val await() const {
+            return val(internal::_emval_await(handle));
         }
 
     private:

--- a/tests/embind_with_asyncify.cpp
+++ b/tests/embind_with_asyncify.cpp
@@ -1,0 +1,18 @@
+#include <assert.h>
+
+#include <string>
+
+#include <emscripten.h>
+#include <emscripten/val.h>
+
+using namespace emscripten;
+
+int main() {
+  val fetch = val::global("fetch");
+  std::string url = "data:text/plain,foo";
+  val async_response = fetch(url);
+  val response = async_response.await();
+  val async_text = response.call<val>("text");
+  std::string text = async_text.await().as<std::string>();
+  REPORT_RESULT(text == "foo");
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4817,6 +4817,7 @@ window.close = function() {
   def test_embind_with_pthreads(self):
     self.btest('embind_with_pthreads.cpp', '1', args=['--bind', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
+  @no_fastcomp("no asyncify support")
   def test_embind_with_asyncify(self):
     self.btest('embind_with_asyncify.cpp', '1', args=['--bind'] + self.get_async_args())
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4817,6 +4817,9 @@ window.close = function() {
   def test_embind_with_pthreads(self):
     self.btest('embind_with_pthreads.cpp', '1', args=['--bind', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'])
 
+  def test_embind_with_asyncify(self):
+    self.btest('embind_with_asyncify.cpp', '1', args=['--bind'] + self.get_async_args())
+
   # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
   def test_emscripten_console_log(self):
     self.btest(path_from_root('tests', 'emscripten_console_log.c'), '0', args=['--pre-js', path_from_root('tests', 'emscripten_console_log_pre.js')])


### PR DESCRIPTION
This adds a `val::await()` method to Embind API, which allows to await
dynamically retrieved `Promise`s from JavaScript.

This commit also adds an underlying `Asyncify.handleAsync` helper,
which is currently a thin wrapper around `Asyncify.handleSleep`
but might be extended over time, and useful anyway due to ubiquity
of `Promise`-based APIs and `async`-`await` on the modern Web.