### PR TITLE
Bump Acorn JS version to ES2018

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8628,12 +8628,12 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
     self.assertIdentical(normal, huge)
 
   def test_EM_ASM_ES6(self):
-    # check we show a proper understandable error for JS parse problems
     create_test_file('src.cpp', r'''
 #include <emscripten.h>
 int main() {
   EM_ASM({
-    var x = (a, b) => 5; // valid ES6!
+    var x = (a, b) => 5; // valid ES6
+    async function y() {} // valid ES2017
     out('hello!');
   });
 }

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1299,7 +1299,7 @@ if (extraInfoStart > 0) {
 // Collect all JS code comments to this array so that we can retain them in the outputted code
 // if --closureFriendly was requested.
 var sourceComments = [];
-var ast = acorn.parse(input, { ecmaVersion: 9, preserveParens: closureFriendly, onComment: closureFriendly ? sourceComments : undefined });
+var ast = acorn.parse(input, { ecmaVersion: 2018, preserveParens: closureFriendly, onComment: closureFriendly ? sourceComments : undefined });
 
 var minifyWhitespace = false;
 var noPrint = false;
@@ -1337,4 +1337,3 @@ if (!noPrint) {
   });
   print(output);
 }
-

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1299,7 +1299,7 @@ if (extraInfoStart > 0) {
 // Collect all JS code comments to this array so that we can retain them in the outputted code
 // if --closureFriendly was requested.
 var sourceComments = [];
-var ast = acorn.parse(input, { ecmaVersion: 6, preserveParens: closureFriendly, onComment: closureFriendly ? sourceComments : undefined });
+var ast = acorn.parse(input, { ecmaVersion: 9, preserveParens: closureFriendly, onComment: closureFriendly ? sourceComments : undefined });
 
 var minifyWhitespace = false;
 var noPrint = false;


### PR DESCRIPTION
The acorn code says
```javascript
  // `ecmaVersion` indicates the ECMAScript version to parse. Must be
  // either 3, 5, 6 (2015), 7 (2016), 8 (2017), 9 (2018), or 10
  // (2019). This influences support for strict mode, the set of
  // reserved words, and support for new syntax features. The default
  // is 9.
```
We set the version to 6 (2015) when we added Acorn, probably to
keep it as close as possible to the old pre-Acorn parser. But the
default in our version is 9 (2018) so we may as well switch to that,
and that fixes #11431 (8 - 2017 - would have been enough for
that specific bug).