### PR TITLE
Generate missing invoke_xx functions at runtime

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2044,9 +2044,6 @@ def emscript_wasm_backend(infile, outfile, memfile, temp_files, DEBUG):
   pre = None
 
   invoke_funcs = metadata['invokeFuncs']
-  if shared.Settings.RELOCATABLE:
-    invoke_funcs.append('invoke_X')
-
   try:
     del forwarded_json['Variables']['globals']['_llvm_global_ctors'] # not a true variable
   except KeyError:

--- a/src/support.js
+++ b/src/support.js
@@ -103,6 +103,15 @@ function fetchBinary(url) {
   });
 }
 
+function asmjsMangle(x) {
+#if WASM_BACKEND
+  var unmangledSymbols = {{{ buildStringArray(WASM_FUNCTIONS_THAT_ARE_NOT_NAME_MANGLED) }}};
+  return x.indexOf('dynCall_') == 0 || unmangledSymbols.indexOf(x) != -1 ? x : '_' + x;
+#else
+  return x;
+#endif
+}
+
 // loadDynamicLibrary loads dynamic library @ lib URL / path and returns handle for loaded DSO.
 //
 // Several flags affect the loading:
@@ -250,10 +259,8 @@ function loadDynamicLibrary(lib, flags) {
       //
       // We should copy the symbols (which include methods and variables) from SIDE_MODULE to MAIN_MODULE.
 
-      var module_sym = sym;
-#if WASM_BACKEND
-      module_sym = '_' + sym;
-#else
+      var module_sym = asmjsMangle(sym);
+#if !WASM_BACKEND
       // Module of SIDE_MODULE has not only the symbols (which should be copied)
       // but also others (print*, asmGlobal*, FUNCTION_TABLE_**, NAMED_GLOBALS, and so on).
       //
@@ -261,7 +268,7 @@ function loadDynamicLibrary(lib, flags) {
       // When the symbol (which should be copied) is variable, Module.* 's type becomes number.
       // Except for the symbol prefix (_), there is no difference in the symbols (which should be copied) and others.
       // So this just copies over compiled symbols (which start with _).
-      if (sym[0] !== '_') {
+      if (!sym.startsWith('dynCall_') && sym[0] !== '_') {
         continue;
       }
 #endif
@@ -336,6 +343,24 @@ function relocateExports(exports, memoryBase, tableBase, moduleLocal) {
   }
   return relocated;
 }
+
+#if RELOCATABLE
+// Dynmamic version of shared.py:make_invoke.  This is needed for invokes
+// that originate from side modules since these are not known at JS
+// generation time.
+function createInvokeFunction(sig) {
+  return function() {
+    var sp = stackSave();
+    try {
+      return Module['dynCall_' + sig].apply(null, arguments);
+    } catch(e) {
+      stackRestore(sp);
+      if (e !== e+0 && e !== 'longjmp') throw e;
+      _setThrew(1, 0);
+    }
+  }
+}
+#endif
 
 // Loads a side module from binary data
 function loadWebAssemblyModule(binary, flags) {
@@ -432,13 +457,16 @@ function loadWebAssemblyModule(binary, flags) {
 
       var resolved = Module["asm"][sym];
       if (!resolved) {
-#if WASM_BACKEND
-        sym = '_' + sym;
-#endif
-        resolved = Module[sym];
+        var mangled = asmjsMangle(sym);
+        resolved = Module[mangled];
         if (!resolved) {
-          resolved = moduleLocal[sym];
+          resolved = moduleLocal[mangled];
         }
+#if RELOCATABLE
+        if (!resolved && sym.startsWith('invoke_')) {
+          resolved = createInvokeFunction(sym.split('_')[1]);
+        }
+#endif
 #if ASSERTIONS
         assert(resolved, 'missing linked ' + type + ' `' + sym + '`. perhaps a side module was not linked in? if this global was expected to arrive from a system library, try to build the MAIN_MODULE with EMCC_FORCE_STDLIBS=1 in the environment');
 #endif
@@ -505,13 +533,6 @@ function loadWebAssemblyModule(binary, flags) {
             }
             return fp;
           };
-        }
-        if (prop.startsWith('invoke_')) {
-          // A missing invoke, i.e., an invoke for a function type
-          // present in the dynamic library but not in the main JS,
-          // and the dynamic library cannot provide JS for it. Use
-          // the generic "X" invoke for it.
-          return obj[prop] = invoke_X;
         }
         // otherwise this is regular function import - call it indirectly
         return obj[prop] = function() {

--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.exports
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.exports
@@ -2,6 +2,9 @@ __assign_got_enties
 __errno_location
 __stdio_write
 __wasm_call_ctors
+dynCall_ii
+dynCall_iiii
+dynCall_jiji
 main
 malloc
 stackAlloc

--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.imports
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.imports
@@ -5,4 +5,5 @@ emscripten_memcpy_big
 emscripten_resize_heap
 fd_write
 memory
+setTempRet0
 table

--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.sent
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.sent
@@ -5,4 +5,5 @@ emscripten_memcpy_big
 emscripten_resize_heap
 fd_write
 memory
+setTempRet0
 table

--- a/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE_2.exports
+++ b/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE_2.exports
@@ -7,3 +7,5 @@ dynCall_ii
 dynCall_iiii
 dynCall_iiiii
 stackAlloc
+stackRestore
+stackSave

--- a/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE_2.funcs
+++ b/tests/other/metadce/hello_world_fastcomp_O3_MAIN_MODULE_2.funcs
@@ -18,3 +18,5 @@ $dynCall_ii
 $dynCall_iiii
 $dynCall_iiiii
 $stackAlloc
+$stackRestore
+$stackSave

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1267,27 +1267,11 @@ function jsCall_%s(index%s) {
 
   @staticmethod
   def make_invoke(sig, named=True):
-    if sig == 'X':
-      # 'X' means the generic unknown signature, used in wasm dynamic linking
-      # to indicate an invoke that the main JS may not have defined, so we
-      # go through this (which may be slower, as we don't declare the
-      # arguments explicitly). In non-wasm dynamic linking, the other modules
-      # have JS and so can define their own invokes to be linked in.
-      # This only makes sense in function pointer emulation mode, where we
-      # can do a direct table call.
-      assert Settings.WASM
-      assert Settings.WASM_BACKEND or Settings.EMULATED_FUNCTION_POINTERS
-      args = ''
-      body = '''
-        var args = Array.prototype.slice.call(arguments);
-        return wasmTable.get(args[0]).apply(null, args.slice(1));
-      '''
-    else:
-      legal_sig = JS.legalize_sig(sig) # TODO: do this in extcall, jscall?
-      args = ','.join(['a' + str(i) for i in range(1, len(legal_sig))])
-      args = 'index' + (',' if args else '') + args
-      ret = 'return ' if sig[0] != 'v' else ''
-      body = '%s%s(%s);' % (ret, JS.make_dynCall(sig), args)
+    legal_sig = JS.legalize_sig(sig) # TODO: do this in extcall, jscall?
+    args = ','.join(['a' + str(i) for i in range(1, len(legal_sig))])
+    args = 'index' + (',' if args else '') + args
+    ret = 'return ' if sig[0] != 'v' else ''
+    body = '%s%s(%s);' % (ret, JS.make_dynCall(sig), args)
     # C++ exceptions are numbers, and longjmp is a string 'longjmp'
     if Settings.SUPPORT_LONGJMP:
       rethrow = "if (e !== e+0 && e !== 'longjmp') throw e;"


### PR DESCRIPTION
In the dynamic linking case we don't know the full list of invoke_xx
functions that are needed when the JS is output since the side modules
can contains invoke_xx imports that are not known at main module link
time.

Previously we could use a single invoke_X function that worked for all
signatures, and accessed that wasm table directly rather then relying
on dynCall_xx functions.  While in throey this is better, it doesn't
handle type legalization that JS boundary and will fail if the
signature contains an i64.

Once we have bigint support available everywhere we can potentially
eliminate dynCall functions completely but for now we need to use them
everywhere.