### PR TITLE
createContext: Return meaningful error value when failing to get context.

### DIFF
--- a/src/library_egl.js
+++ b/src/library_egl.js
@@ -367,7 +367,7 @@ var LibraryEGL = {
 
     EGL.context = GL.createContext(Module['canvas'], EGL.contextAttributes);
 
-    if (EGL.context != 0) {
+    if (EGL.context > 0) {
       EGL.setErrorCode(0x3000 /* EGL_SUCCESS */);
 
       // Run callbacks so that GL emulation works

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -645,10 +645,10 @@ var LibraryGL = {
       canvas.removeEventListener('webglcontextcreationerror', onContextCreationError, false);
       if (!ctx) {
         err('Could not create canvas: ' + [errorInfo, JSON.stringify(webGLContextAttributes)]);
-        return 0;
+        return {{{ cDefine('EMSCRIPTEN_RESULT_FAILED') }}};
       }
 #else
-      if (!ctx) return 0;
+      if (!ctx) return {{{ cDefine('EMSCRIPTEN_RESULT_FAILED') }}};
 #endif
 
       var handle = GL.registerContext(ctx, webGLContextAttributes);


### PR DESCRIPTION
Instead of returning 0 (EMSCRIPTEN_RESULT_SUCCESS), this will return
a more correct error value.
This revealed a bug in EGL context creation, which I also fixed.