### PR TITLE
Enable test_asyncify_unused in wasm backend

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7853,7 +7853,6 @@ Module['onRuntimeInitialized'] = function() {
     src = open(path_from_root('tests', 'test_fibers.cpp')).read()
     self.do_run(src, '*leaf-0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*')
 
-  @no_wasm_backend('ASYNCIFY is not supported in the LLVM wasm backend')
   @no_fastcomp('ASYNCIFY has been removed from fastcomp')
   def test_asyncify_unused(self):
     # test a program not using asyncify, but the pref is set


### PR DESCRIPTION
The test ran in no backend previously... noticed by @RReverser 