### PR TITLE
Rename "blacklist" to clearer things

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -281,7 +281,6 @@ class JSOptimizer(object):
     self.queue = []
     self.extra_info = {}
     self.queue_history = []
-    self.blacklist = os.environ.get('EMCC_JSOPT_BLACKLIST', '').split(',')
     self.minify_whitespace = False
     self.cleanup_shell = False
 
@@ -295,8 +294,6 @@ class JSOptimizer(object):
     self.in_temp = in_temp
 
   def flush(self, title='js_opts'):
-    self.queue = [p for p in self.queue if p not in self.blacklist]
-
     assert not shared.Settings.WASM_BACKEND, 'JSOptimizer should not run with pure wasm output'
 
     if self.extra_info is not None and len(self.extra_info) == 0:
@@ -653,7 +650,7 @@ def backend_binaryen_passes():
   if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
     # note that this pass must run before asyncify, as if it runs afterwards we only
     # generate the  byn$fpcast_emu  functions after asyncify runs, and so we wouldn't
-    # be able to whitelist them etc.
+    # be able to further process them.
     passes += ['--fpcast-emu']
   if shared.Settings.ASYNCIFY:
     passes += ['--asyncify']

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1528,18 +1528,18 @@ function getQuoted(str) {
 }
 
 function makeRetainedCompilerSettings() {
-  var blacklist = set('STRUCT_INFO');
+  var ignore = set('STRUCT_INFO');
   if (STRICT) {
     for (var i in LEGACY_SETTINGS) {
       var name = LEGACY_SETTINGS[i][0];
-      blacklist[name] = 0;
+      ignore[name] = 0;
     }
   }
 
   var ret = {};
   for (var x in this) {
     try {
-      if (x[0] !== '_' && !(x in blacklist) && x == x.toUpperCase() && (typeof this[x] === 'number' || typeof this[x] === 'string' || this.isArray())) ret[x] = this[x];
+      if (x[0] !== '_' && !(x in ignore) && x == x.toUpperCase() && (typeof this[x] === 'number' || typeof this[x] === 'string' || this.isArray())) ret[x] = this[x];
     } catch(e){}
   }
   return ret;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1583,8 +1583,8 @@ var ASMFS = 0;
 //
 // When using code that depends on this option, your Content Security Policy may
 // need to be updated. Specifically, embedding asm.js requires the script-src
-// directive to whitelist 'unsafe-inline', and using a Worker requires the
-// child-src directive to whitelist blob:. If you aren't using Content Security
+// directive to allow 'unsafe-inline', and using a Worker requires the
+// child-src directive to allow blob:. If you aren't using Content Security
 // Policy, or your CSP header doesn't include either script-src or child-src,
 // then you can safely ignore this warning.
 var SINGLE_FILE = 0;

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -724,14 +724,14 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
     musl_srcdir = shared.path_from_root('system', 'lib', 'libc', 'musl', 'src')
 
     # musl modules
-    blacklist = [
+    ignore = [
         'ipc', 'passwd', 'thread', 'signal', 'sched', 'ipc', 'time', 'linux',
         'aio', 'exit', 'legacy', 'mq', 'process', 'search', 'setjmp', 'env',
         'ldso', 'conf'
     ]
 
     # individual files
-    blacklist += [
+    ignore += [
         'memcpy.c', 'memset.c', 'memmove.c', 'getaddrinfo.c', 'getnameinfo.c',
         'inet_addr.c', 'res_query.c', 'res_querydomain.c', 'gai_strerror.c',
         'proto.c', 'gethostbyaddr.c', 'gethostbyaddr_r.c', 'gethostbyname.c',
@@ -741,10 +741,10 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         'faccessat.c',
     ]
 
-    blacklist += LIBC_SOCKETS
+    ignore += LIBC_SOCKETS
 
     # individual math files
-    blacklist += [
+    ignore += [
         'abs.c', 'cos.c', 'cosf.c', 'cosl.c', 'sin.c', 'sinf.c', 'sinl.c',
         'tan.c', 'tanf.c', 'tanl.c', 'acos.c', 'acosf.c', 'acosl.c', 'asin.c',
         'asinf.c', 'asinl.c', 'atan.c', 'atanf.c', 'atanl.c', 'atan2.c',
@@ -758,7 +758,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
       # functions that do not rely on undefined behavior, for example, reading
       # multiple bytes at once as an int and overflowing a buffer.
       # Otherwise, ASan will catch these errors and terminate the program.
-      blacklist += ['strcpy.c', 'memchr.c', 'strchrnul.c', 'strlen.c',
+      ignore += ['strcpy.c', 'memchr.c', 'strchrnul.c', 'strlen.c',
                     'aligned_alloc.c', 'fcntl.c']
       libc_files += [
         shared.path_from_root('system', 'lib', 'libc', 'emscripten_asan_strcpy.c'),
@@ -770,28 +770,28 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
 
     if shared.Settings.WASM_BACKEND:
       # With the wasm backend these are included in wasm_libc_rt instead
-      blacklist += [os.path.basename(f) for f in get_wasm_libc_rt_files()]
+      ignore += [os.path.basename(f) for f in get_wasm_libc_rt_files()]
     else:
-      blacklist += ['rintf.c', 'ceil.c', 'ceilf.c', 'floor.c', 'floorf.c',
+      ignore += ['rintf.c', 'ceil.c', 'ceilf.c', 'floor.c', 'floorf.c',
                     'fabs.c', 'fabsf.c', 'sqrt.c', 'sqrtf.c']
 
-    blacklist = set(blacklist)
+    ignore = set(ignore)
     # TODO: consider using more math code from musl, doing so makes box2d faster
     for dirpath, dirnames, filenames in os.walk(musl_srcdir):
       for f in filenames:
         if f.endswith('.c'):
-          if f in blacklist:
+          if f in ignore:
             continue
           dir_parts = os.path.split(dirpath)
           cancel = False
           for part in dir_parts:
-            if part in blacklist:
+            if part in ignore:
               cancel = True
               break
           if not cancel:
             libc_files.append(os.path.join(musl_srcdir, dirpath, f))
 
-    # Allowed files from blacklisted modules
+    # Allowed files from ignored modules
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'time'],
         filenames=['clock_settime.c'])

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -759,7 +759,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
       # multiple bytes at once as an int and overflowing a buffer.
       # Otherwise, ASan will catch these errors and terminate the program.
       ignore += ['strcpy.c', 'memchr.c', 'strchrnul.c', 'strlen.c',
-                    'aligned_alloc.c', 'fcntl.c']
+                 'aligned_alloc.c', 'fcntl.c']
       libc_files += [
         shared.path_from_root('system', 'lib', 'libc', 'emscripten_asan_strcpy.c'),
         shared.path_from_root('system', 'lib', 'libc', 'emscripten_asan_memchr.c'),
@@ -773,7 +773,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
       ignore += [os.path.basename(f) for f in get_wasm_libc_rt_files()]
     else:
       ignore += ['rintf.c', 'ceil.c', 'ceilf.c', 'floor.c', 'floorf.c',
-                    'fabs.c', 'fabsf.c', 'sqrt.c', 'sqrtf.c']
+                 'fabs.c', 'fabsf.c', 'sqrt.c', 'sqrtf.c']
 
     ignore = set(ignore)
     # TODO: consider using more math code from musl, doing so makes box2d faster


### PR DESCRIPTION
It's shorter and clearer anyhow to use the term "ignore" in those
contexts, especially as in some of them it's actually a set and not
a list, so it was confusing before.

`EMCC_JSOPT_BLACKLIST` is the only theoretically-noticeable
part of this, but it was for internal use by devs (no docs, no tests;
also not relevant for wasm anyhow), so just remove it.