### PR TITLE
Clarify exception command-line flag renaming

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,8 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- Following the upstream LLVM backend, rename `EXCEPTION_CATCHING_WHITELIST` to
-  `EXCEPTION_CATCHING_ALLOWED`.
+- Rename `EXCEPTION_CATCHING_WHITELIST` to `EXCEPTION_CATCHING_ALLOWED`. The
+  functionality is unchanged, and the old name will be allowed as an alias
+  for a few releases to give users time to migrate.
 - Add support for the new `ASYNCIFY_ADD_LIST`, and update existing list names
   following the updates in Binaryen, so that now we have `ASYNCIFY_ADD_LIST` to
   add a function, `ASYNCIFY_REMOVE_LIST` to remove one (previously this was


### PR DESCRIPTION
* Make the statement a bit stronger (we're doing this because we want to, not just because we did it upstream)
* Mention that the old name is still available for now for compatibility