### PR TITLE
Fix onAbort not triggered when Wasm not supported.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -482,3 +482,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Elías Serrano <feserr3@gmail.com>
 * Philip Pfaffe <pfaffe@google.com> (copyright owned by Google, LLC)
 * Troy Tae <tjy970721@gmail.com>
+* Sky Wang <sky-wang@qq.com>

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -34,11 +34,7 @@ if (Module['doWasm2JS']) {
 
 #if WASM == 1
 if (typeof WebAssembly !== 'object') {
-#if ASSERTIONS
-  abort('No WebAssembly support found. Build with -s WASM=0 to target JavaScript instead.');
-#else
-  err('no native wasm support detected');
-#endif
+  abort('no native wasm support detected');
 }
 #endif
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8206,10 +8206,7 @@ int main() {
       create_test_file('pre.js', 'WebAssembly = undefined;\n')
       run_process([EMCC, path_from_root('tests', 'hello_world.cpp'), '--pre-js', 'pre.js'] + opts)
       out = run_js('a.out.js', stderr=STDOUT, assert_returncode=None)
-      if opts == []:
-        self.assertContained('No WebAssembly support found. Build with -s WASM=0 to target JavaScript instead.', out)
-      else:
-        self.assertContained('no native wasm support detected', out)
+      self.assertContained('no native wasm support detected', out)
 
   def test_jsrun(self):
     print(NODE_JS)


### PR DESCRIPTION
As mentioned in #11459

In some browsers that does not support WebAssembly, when compiled with -O3,  It just print the error message and exit, the caller can't get error callback to handle this situation.

This pr should can help.