### PR TITLE
Fix wasm0.test_emscripten_scan_registers

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1398,6 +1398,12 @@ Functions
     the stack - the wasm VM has spilled them, but none of that is observable to
     user code).
 
+    Note that this function scans wasm locals. Depending on the LLVM
+    optimization level, this may not scan the original locals in your source
+    code. For example in ``-O0`` locals may be stored on the stack. To make
+    sure you scan everything necessary, you can also do
+    ``emscripten_scan_stack``.
+
     This function requires Asyncify - it relies on that option to spill the
     local state all the way up the stack. As a result, it will add overhead
     to your program.

--- a/tests/core/emscripten_scan_registers.cpp
+++ b/tests/core/emscripten_scan_registers.cpp
@@ -7,6 +7,8 @@ std::set<int> seenInts;
 
 static int scans = 0;
 
+#define DO_SCAN { emscripten_scan_registers(scan); emscripten_scan_stack(scan); }
+
 void scan(void* x, void* y) {
   printf("scan\n");
   int* p = (int*)x;
@@ -21,7 +23,7 @@ void scan(void* x, void* y) {
 __attribute__((noinline))
 void inner(int x, int y) {
   if (x == y) inner(x + 1, y - 1); // avoid inlining in binaryen
-  emscripten_scan_registers(scan);
+  DO_SCAN
   printf("a %d, %d\n", x, y);
   assert(seenInts.count(314159));
   assert(seenInts.count(21828));
@@ -31,12 +33,12 @@ void inner(int x, int y) {
   if (x < y) {
     printf("left..\n");
     z = x + 100;
-    emscripten_scan_registers(scan);
+    DO_SCAN
     printf("..left\n");
   } else {
     printf("right..\n");
     z = y + 200;
-    emscripten_scan_registers(scan);
+    DO_SCAN
     printf("..right\n");
   }
   printf("b %d, %d, %d\n", x, y, z);
@@ -53,11 +55,11 @@ int main() {
   inner(x, y);
   x = EM_ASM_INT({ return $0 + 1 }, x);
   y = EM_ASM_INT({ return $0 - 1 }, y);
-  emscripten_scan_registers(scan);
+  DO_SCAN
   printf("c %d, %d\n", x, y);
   assert(seenInts.count(314160));
   assert(seenInts.count(21827));
   assert(seenInts.size() < 1000);
-  assert(scans == 3);
+  assert(scans == 6);
   puts("ok");
 }

--- a/tests/core/emscripten_scan_registers.txt
+++ b/tests/core/emscripten_scan_registers.txt
@@ -1,9 +1,12 @@
 scan
+scan
 a 314159, 21828
 right..
 scan
+scan
 ..right
 b 314159, 21828, 22028
+scan
 scan
 c 314160, 21827
 ok


### PR DESCRIPTION
That test assumed C locals were in wasm registers, but that is not
true in LLVM -O0 - they are on the stack. We didn't notice this because
they are *also* in wasm locals, temp locals that have short lifetimes.
With the new lives