### PR TITLE
wasm2js: Use normal constructors for Module, Instance, Memory

### DIFF
--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -33,7 +33,8 @@ WebAssembly = {
 
   // Table is not a normal constructor and instead returns the array object.
   // That lets us use the length property automatically, which is simpler and
-  // smaller (but instanceof will fail).
+  // smaller (but instanceof will not report that an instance of Table is an
+  // instance of this function).
   Table: /** @constructor */ function(opts) {
     var ret = new Array(opts['initial']);
     ret.grow = function(by) {

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23759,
-  "a.js.gz": 8909,
+  "a.js": 23758,
+  "a.js.gz": 8898,
   "a.mem": 3168,
   "a.mem.gz": 2711,
   "total": 27515,
-  "total_gz": 12006
+  "total_gz": 11995
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23249,
-  "a.js.gz": 8745,
+  "a.js": 23248,
+  "a.js.gz": 8734,
   "a.mem": 3168,
   "a.mem.gz": 2711,
   "total": 27005,
-  "total_gz": 11842
+  "total_gz": 11831
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 697,
   "a.html.gz": 437,
-  "a.js": 2022,
-  "a.js.gz": 912,
+  "a.js": 2021,
+  "a.js.gz": 908,
   "a.mem": 6,
   "a.mem.gz": 32,
   "total": 2725,
-  "total_gz": 1381
+  "total_gz": 1377
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19708,
-  "a.html.gz": 8238,
+  "a.html": 19707,
+  "a.html.gz": 8241,
   "total": 19708,
-  "total_gz": 8238
+  "total_gz": 8241
 }


### PR DESCRIPTION
Before we returned a new object. That means that `instanceof` does not
report the instances are proper instances of the functions, which I noticed
while working on wasm2js+pthreads. This fixes that and also shrinks code
size a little bit.

However, for Table I left it as it was before, since that has the `.length`
property which we'd need to use `.defineProperty()` or other fanciness,
which would also increase code size.