### PR TITLE
Fix non-ascii content garbled in log

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4250,7 +4250,7 @@ LibraryManager.library = {
   emscripten_log__deps: ['$formatString', 'emscripten_log_js'],
   emscripten_log: function(flags, format, varargs) {
     var result = formatString(format, varargs);
-    var str = UTF8ArrayToString(result, 0, result.length);
+    var str = UTF8ArrayToString(result, 0);
     _emscripten_log_js(flags, str);
   },
 

--- a/src/library.js
+++ b/src/library.js
@@ -4249,12 +4249,8 @@ LibraryManager.library = {
 
   emscripten_log__deps: ['$formatString', 'emscripten_log_js'],
   emscripten_log: function(flags, format, varargs) {
-    var str = '';
     var result = formatString(format, varargs);
-    for (var i = 0 ; i < result.length; ++i) {
-      str += '%' + ('0' + result[i].toString(16)).slice(-2);
-    }
-    str = decodeURIComponent(str);
+    var str = UTF8ArrayToString(result, 0, result.length);
     _emscripten_log_js(flags, str);
   },
 

--- a/src/library.js
+++ b/src/library.js
@@ -4252,8 +4252,9 @@ LibraryManager.library = {
     var str = '';
     var result = formatString(format, varargs);
     for (var i = 0 ; i < result.length; ++i) {
-      str += String.fromCharCode(result[i]);
+      str += '%' + ('0' + result[i].toString(16)).slice(-2);
     }
+    str = decodeURIComponent(str);
     _emscripten_log_js(flags, str);
   },
 


### PR DESCRIPTION
I think decodeURIComponent is the right way to deal with encoding here. The \<result\> here is every byte of the utf-8 string but String.fromCharCode() regard the input as UTF-16 
