### PR TITLE
Adjust stalebot from 1 year + 7 days to 1 year + 30 days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 365
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 7
+daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned


### PR DESCRIPTION
1 year is a good base time I think. But maybe 1 week between "this will be closed"
and closing it is a little too fast, since someone on vacation from work might miss it.
There seems little harm in bumping that to 30 days?

cc @RReverser 