### PR TITLE
Fix other.test_js_optimizer_parse_error on windows after #11480

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -553,7 +553,7 @@ jobs:
           name: Add python to bash path
           command: echo "export PATH=\"$PATH:/c/python38/\"" >> $BASH_ENV
       - run-tests:
-          test_targets: "other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug"
+          test_targets: "other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error"
   build-mac:
     executor: mac
     steps:

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1307,7 +1307,7 @@ try {
   });
 } catch (err) {
   err.message += (function() {
-    var errorMessage = '\n' + input.split('\n')[err.loc.line - 1] + '\n';
+    var errorMessage = '\n' + input.split(acorn.lineBreak)[err.loc.line - 1] + '\n';
     var column = err.loc.column;
     while (column--) {
       errorMessage += ' ';


### PR DESCRIPTION
The breakage looks like it might be a `\r\n` vs `\n` difference,

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8876394376783305232/+/steps/Emscripten_testsuite__upstream__other_/0/stdout

Added the test here to find out.