### PR TITLE
Fix package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,8 +5,7 @@
     "acorn": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
-      "dev": true
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
     },
     "ansi-styles": {
       "version": "3.2.1",


### PR DESCRIPTION
Acorn is not a dev-dependency in package.json, but sneaked in as a `"dev"` in package-lock.json, making Emscripten fail for end users. Most likely an artifact from temporary hacking on #11480 that wasn't fixed up in the final PR.