### PR TITLE
Add --experimental-pic wasm-ld flag when linking shared libraries

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -534,6 +534,7 @@ def lld_flags_for_executable(external_symbol_list):
       cmd += ['--export', export]
 
   if Settings.RELOCATABLE:
+    cmd.append('--experimental-pic')
     if Settings.SIDE_MODULE:
       cmd.append('-shared')
     else:


### PR DESCRIPTION
Otherwise wasm-ld will warn that this is an experimental feature.

See https://reviews.llvm.org/D81760