### PR TITLE
In standalone mode make `main` mandatory by default

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1206,9 +1206,9 @@ var USE_GLFW = 2;
 // the page will be reloaded in Wasm2JS mode.
 var WASM = 1;
 
-// STANDALONE_WASM indicates that we want to emit a wasm file that can run without
-// JavaScript. The file will use standard APIs such as wasi as much as possible
-// to achieve that.
+// STANDALONE_WASM indicates that we want to emit a wasm file that can run
+// without JavaScript. The file will use standard APIs such as wasi as much as
+// possible to achieve that.
 //
 // This option does not guarantee that the wasm can be used by itself - if you
 // use APIs with no non-JS alternative, we will still use those (e.g., OpenGL
@@ -1237,6 +1237,10 @@ var WASM = 1;
 // the WASM_BIGINT option to avoid that problem by using BigInts for i64s which
 // means we don't need to legalize for JS (but this requires a new enough JS
 // VM).
+//
+// Standlone builds by default require a `main` entry point.  If you want to
+// build a library (also known as a reactor) instead you can pass `--no-entry`
+// or specify a list of EXPORTED_FUNCTIONS that does not include `main`.
 var STANDALONE_WASM = 0;
 
 // Whether to use the WebAssembly backend that is in development in LLVM.  You

--- a/system/lib/standalone/__main_argc_argv.c
+++ b/system/lib/standalone/__main_argc_argv.c
@@ -13,13 +13,9 @@
 
 #include <assert.h>
 
-// Main has to be weak here because in emscripten we allow standalone
-// applications that don't contain a main at all.
-int main(int argc, char *argv[]) __attribute__((weak));
+int main(int argc, char *argv[]);
 
 __attribute__((weak))
 int __main_argc_argv(int argc, char *argv[]) {
-  if (!main)
-    return 0;
   return main(argc, argv);
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8697,12 +8697,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @also_with_standalone_wasm(impure=True)
   def test_undefined_main(self):
     if self.get_setting('STANDALONE_WASM'):
-      # In standalone mode we the user to explicly opt out if they don't have a main function
+      # In standalone we don't support implicitly building without main.  The user has to explicitly
+      # opt out (see below).
       err = self.expect_fail([EMCC, path_from_root('tests', 'core', 'test_ctors_no_main.cpp')] + self.get_emcc_args())
       self.assertContained('error: undefined symbol: main (referenced by top-level compiled C/C++ code)', err)
     elif not self.get_setting('LLD_REPORT_UNDEFINED') and not self.get_setting('STRICT'):
-      # Traditionally in emscripten we allow main to be undefined.  This allows programs with a main
-      # and libraries without a main to be compiled identically.
+      # Traditionally in emscripten we allow main to be implicitly undefined.  This allows programs
+      # with a main and libraries without a main to be compiled identically.
       # However we are trying to move away from that model to a more explicit opt-out model. See:
       # https://github.com/emscripten-core/emscripten/issues/9640
       self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8696,11 +8696,15 @@ NODEFS is no longer included by default; build with -lnodefs.js
   # are not yet suppored by the wasm engines we test against.
   @also_with_standalone_wasm(impure=True)
   def test_undefined_main(self):
-    # Traditionally in emscripten we allow main to be undefined.  This allows programs with a main
-    # and libraries without a main to be compiled identically.
-    # However we are trying to move away from that model to a more explicit opt-out model. See:
-    # https://github.com/emscripten-core/emscripten/issues/9640
-    if not self.get_setting('LLD_REPORT_UNDEFINED') and not self.get_setting('STRICT') and not self.get_setting('STANDALONE_WASM'):
+    if self.get_setting('STANDALONE_WASM'):
+      # In standalone mode we the user to explicly opt out if they don't have a main function
+      err = self.expect_fail([EMCC, path_from_root('tests', 'core', 'test_ctors_no_main.cpp')] + self.get_emcc_args())
+      self.assertContained('error: undefined symbol: main (referenced by top-level compiled C/C++ code)', err)
+    elif not self.get_setting('LLD_REPORT_UNDEFINED') and not self.get_setting('STRICT'):
+      # Traditionally in emscripten we allow main to be undefined.  This allows programs with a main
+      # and libraries without a main to be compiled identically.
+      # However we are trying to move away from that model to a more explicit opt-out model. See:
+      # https://github.com/emscripten-core/emscripten/issues/9640
       self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main')
 
       # Disabling IGNORE_MISSING_MAIN should cause link to fail due to missing main


### PR DESCRIPTION
Building with `--no-entry` or with `EXPORTED_FUNCTIONS` that doesn't
include main still works fine.

Fixes #11535