### PR TITLE
Allow `-sFOO=1` as well as `-s FOO=1` on the command line

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Settings on the command line no longer require a space between the `-s` and
+  the name of the setting.   For example, `-sEXPORT_ALL` is now equivalent to
+  `-s EXPORT_ALL`.
 - Rename `EXCEPTION_CATCHING_WHITELIST` to `EXCEPTION_CATCHING_ALLOWED`. The
   functionality is unchanged, and the old name will be allowed as an alias
   for a few releases to give users time to migrate.

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -83,8 +83,8 @@ Options that are modified or new in *emcc* are listed below:
    Note: For more tips on optimizing your code, see Optimizing Code.
 
 "-s OPTION[=VALUE]"
-   JavaScript code generation option passed into the Emscripten
-   compiler. For the available options, see src/settings.js.
+   Emscripten build options. For the available options, see
+   src/settings.js.
 
    Note: You can prefix boolean options with "NO_" to reverse them.
      For example, "-s EXIT_RUNTIME=1" is the same as "-s
@@ -112,6 +112,9 @@ Options that are modified or new in *emcc* are listed below:
        functions: "["_func1", "func2"]".
 
      * The specified file path must be absolute, not relative.
+
+   Note: Options can be specified as a single argument without a
+     space between the "-s" and option name.  .e.g "-sFOO=1".
 
 "-g"
    Preserve debug information.

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -114,7 +114,7 @@ Options that are modified or new in *emcc* are listed below:
      * The specified file path must be absolute, not relative.
 
    Note: Options can be specified as a single argument without a
-     space between the "-s" and option name.  .e.g "-sFOO=1".
+     space between the "-s" and option name.  e.g. "-sFOO=1".
 
 "-g"
    Preserve debug information.

--- a/emcc.py
+++ b/emcc.py
@@ -1039,10 +1039,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if not is_dash_s_for_emcc(newargs, i):
             continue
           key = newargs[i + 1]
-          newargs[i + 1] = None
+          newargs[i + 1] = ''
         else:
           key = newargs[i][2:]
-        newargs[i] = None
+        newargs[i] = ''
 
         # If not = is specified default to 1
         if '=' not in key:

--- a/emcc.py
+++ b/emcc.py
@@ -842,9 +842,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # -s OPT=VALUE or -s OPT or -sOPT are all interpreted as emscripten flags.
     # -s by itself is a linker option (alias for --strip-all)
     if args[i] == '-s':
-      if len(args) <= i:
+      if len(args) <= i + 1:
         return False
-      arg = args[i+1]
+      arg = args[i + 1]
     else:
       arg = args[i][2:]
     return arg.split('=')[0].isupper()

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -107,7 +107,7 @@ Options that are modified or new in *emcc* are listed below:
     - The specified file path must be absolute, not relative.
 
   .. note:: Options can be specified as a single argument without a space
-            between the ``-s`` and option name.  .e.g ``-sFOO=1``.
+            between the ``-s`` and option name.  e.g. ``-sFOO=1``.
 
 .. _emcc-g:
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -82,7 +82,7 @@ Options that are modified or new in *emcc* are listed below:
 .. _emcc-s-option-value:
 
 ``-s OPTION[=VALUE]``
-  JavaScript code generation option passed into the Emscripten compiler. For the available options, see `src/settings.js <https://github.com/emscripten-core/emscripten/blob/master/src/settings.js>`_.
+  Emscripten build options. For the available options, see `src/settings.js <https://github.com/emscripten-core/emscripten/blob/master/src/settings.js>`_.
 
   .. note:: You can prefix boolean options with ``NO_`` to reverse them. For example, ``-s EXIT_RUNTIME=1`` is the same as ``-s NO_EXIT_RUNTIME=0``.
 
@@ -105,6 +105,9 @@ Options that are modified or new in *emcc* are listed below:
 
     - In this case the file might contain a JSON-formatted list of functions: ``["_func1", "func2"]``.
     - The specified file path must be absolute, not relative.
+
+  .. note:: Options can be specified as a single argument without a space
+            between the ``-s`` and option name.  .e.g ``-sFOO=1``.
 
 .. _emcc-g:
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6842,7 +6842,7 @@ high = 1234
     self.assertContained("Attempt to set a non-existent setting: 'ZBINARYEN_ASYNC_COMPILATION'", stderr)
     self.assertNotContained(' BINARYEN_ASYNC_COMPILATION', stderr)
 
-  def test_dash_no_space(self):
+  def test_dash_s_no_space(self):
     run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-sEXPORT_ALL=1'])
     err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.cpp'), '-sEXPORTED_FUNCTIONS=["foo"]'])
     self.assertContained('error: undefined exported function: "foo"', err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6842,6 +6842,11 @@ high = 1234
     self.assertContained("Attempt to set a non-existent setting: 'ZBINARYEN_ASYNC_COMPILATION'", stderr)
     self.assertNotContained(' BINARYEN_ASYNC_COMPILATION', stderr)
 
+  def test_dash_no_space(self):
+    run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-sEXPORT_ALL=1'])
+    err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.cpp'), '-sEXPORTED_FUNCTIONS=["foo"]'])
+    self.assertContained('error: undefined exported function: "foo"', err)
+
   def test_python_2_3(self):
     # check emcc/em++ can be called by any python
     def trim_py_suffix(filename):


### PR DESCRIPTION
Fixes: #11463