### PR TITLE
Give a clear message about when to use --no-entry

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -182,6 +182,9 @@ function JSify(data, functionsOnly) {
           } else if (VERBOSE || WARN_ON_UNDEFINED_SYMBOLS) {
             warn(msg);
           }
+          if (ident === 'main' && STANDALONE_WASM) {
+            warn('To build in STANDALONE_WASM mode without a main(), use emcc --no-entry');
+          }
         }
         if (!RELOCATABLE) {
           // emit a stub that will fail at runtime

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8701,6 +8701,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
       # opt out (see below).
       err = self.expect_fail([EMCC, path_from_root('tests', 'core', 'test_ctors_no_main.cpp')] + self.get_emcc_args())
       self.assertContained('error: undefined symbol: main (referenced by top-level compiled C/C++ code)', err)
+      self.assertContained('warning: To build in STANDALONE_WASM mode without a main(), use emcc --no-entry', err)
     elif not self.get_setting('LLD_REPORT_UNDEFINED') and not self.get_setting('STRICT'):
       # Traditionally in emscripten we allow main to be implicitly undefined.  This allows programs
       # with a main and libraries without a main to be compiled identically.


### PR DESCRIPTION
This should make it completely obvious how to build a library
in standalone mode - the compiler output now says exactly
what to do.