### PR TITLE
Disable asan.test_emscripten_stack

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8743,6 +8743,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.assertContained('cannot change built-in settings values with a -jsD directive', self.expect_fail([EMCC, '-jsDWASM=0']))
 
   # Tests <emscripten/stack.h> API
+  @no_asan('stack allocation sizes are no longer predictable')
   def test_emscripten_stack(self):
     self.emcc_args += ['-lstack.js']
     self.set_setting('TOTAL_STACK', 4 * 1024 * 1024)


### PR DESCRIPTION
`asan` is only run on the side, so this wasn't noticed when the test
was added.

Looks like the issue is that asan adds more to the size of each
stack allocation (red zones or such?) while the test assumes it can
predict the exact position of the stack pointer.