### PR TITLE
Finish LLVM roll

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -4,7 +4,7 @@
   "a.js": 5068,
   "a.js.gz": 2422,
   "a.wasm": 10925,
-  "a.wasm.gz": 6947,
+  "a.wasm.gz": 6946,
   "total": 16556,
-  "total_gz": 9746
+  "total_gz": 9745
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23758,
-  "a.js.gz": 8898,
+  "a.js": 23760,
+  "a.js.gz": 8899,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 27515,
-  "total_gz": 11995
+  "total": 27514,
+  "total_gz": 11996
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -4,7 +4,7 @@
   "a.js": 4553,
   "a.js.gz": 2244,
   "a.wasm": 10925,
-  "a.wasm.gz": 6947,
+  "a.wasm.gz": 6946,
   "total": 16041,
-  "total_gz": 9568
+  "total_gz": 9567
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23248,
-  "a.js.gz": 8734,
+  "a.js": 23250,
+  "a.js.gz": 8735,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 27005,
-  "total_gz": 11831
+  "total": 27004,
+  "total_gz": 11832
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -5,6 +5,6 @@
   "a.js.gz": 908,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 2725,
+  "total": 2724,
   "total_gz": 1377
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,5 +1,5 @@
 {
-  "a.html": 13707,
+  "a.html": 13715,
   "a.html.gz": 7366,
   "total": 13707,
   "total_gz": 7366

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19707,
-  "a.html.gz": 8241,
-  "total": 19708,
-  "total_gz": 8241
+  "a.html": 19731,
+  "a.html.gz": 8242,
+  "total": 19731,
+  "total_gz": 8242
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9282,7 +9282,6 @@ int main () {
         test(['-s', 'WASM=0'], closure, opt)
         test(['-s', 'WASM=1', '-s', 'WASM_ASYNC_COMPILATION=0'], closure, opt)
 
-  @unittest.skip('let llvm roll in')
   def test_minimal_runtime_code_size(self):
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'AGGRESSIVE_VARIABLE_ELIMINATION=1',


### PR DESCRIPTION
A very minor regression in `other.test_minimal_runtime_code_size`. Looking
at the builds, nothing obvious pops out - just some minor differences here and
there, that seem to add up badly.