### PR TITLE
Remove duplicate abort message printing

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -689,7 +689,6 @@ function abort(what) {
   if (ENVIRONMENT_IS_PTHREAD) console.error('Pthread aborting at ' + new Error().stack);
 #endif
   what += '';
-  out(what);
   err(what);
 
   ABORT = true;
@@ -702,10 +701,10 @@ function abort(what) {
   what = output;
 #endif // ASSERTIONS
 
+#if WASM
   // Throw a wasm runtime error, because a JS error might be seen as a foreign
   // exception, which means we'd run destructors on it. We need the error to
   // simply make the program stop.
-#if WASM
   throw new WebAssembly.RuntimeError(what);
 #else
   throw what;

--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -105,9 +105,9 @@ struct_ptr_array[0]->attr2 == 101
 4 : 0.25
 9 : 0.01
 10 : -20.42
-Assertion failed: [CHECK FAILED] Parent::Parent(val:val): Expecting <integer>
 Parent:42
-Assertion failed: [CHECK FAILED] Parent::voidStar(something:something): Expecting <pointer>
-Assertion failed: [CHECK FAILED] StringUser::Print(anotherString:anotherString): Expecting <string>
 
 done.
+Assertion failed: [CHECK FAILED] Parent::Parent(val:val): Expecting <integer>
+Assertion failed: [CHECK FAILED] Parent::voidStar(something:something): Expecting <pointer>
+Assertion failed: [CHECK FAILED] StringUser::Print(anotherString:anotherString): Expecting <string>


### PR DESCRIPTION
Previously we were printing this to both stdout and stderr.