### PR TITLE
Array.prototype.fill is slow, avoid it.

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -2028,7 +2028,15 @@ FS.staticInit();` +
     mmapAlloc: function(size) {
       size = alignMemory(size, {{{ POSIX_PAGE_SIZE }}});
       var ptr = _malloc(size);
-      Array.prototype.fill.call(HEAP8, 0, ptr, ptr + size)
+#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 37 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
+      // Typed array fill is not available, and Array.prototype.fill is slow,
+      // so just loop.
+      for (var i = 0; i < size; i++) {
+        HEAPU8[ptr + i] = 0;
+      }
+#else
+      HEAPU8.fill(0, ptr, ptr + size);
+#endif
       return ptr;
     }
   }


### PR DESCRIPTION
Array.prototype.fill is around an order of magnitude slower than
a loop, which in turn is similarly slower than typed array fill (but
sadly that last one is not present on Safari yet, and older browsers).