### PR TITLE
Remove use of shared.timeout_run from the test suite

### DIFF
--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -268,7 +268,7 @@ console.log(JSON.stringify([numSuccessful, Array.prototype.slice.call(heap.subar
     err_file_handle = open(err_file, 'w')
     proc = subprocess.Popen(shared.NODE_JS + [temp_file], stdout=out_file_handle, stderr=err_file_handle, universal_newlines=True)
     try:
-      shared.timeout_run(proc, timeout=10, full_output=True, throw_on_failure=False)
+      shared.timeout_run(proc, timeout=10, full_output=True, check=False)
     except Exception as e:
       if 'Timed out' not in str(e):
         raise
@@ -315,7 +315,7 @@ def eval_ctors_wasm(js, wasm_file, num):
   logger.debug('wasm ctor cmd: ' + str(cmd))
   proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
   try:
-    err = shared.timeout_run(proc, timeout=10, full_output=True, throw_on_failure=False)
+    err = shared.timeout_run(proc, timeout=10, full_output=True, check=False)
   except Exception as e:
     if 'Timed out' not in str(e):
       raise

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -259,7 +259,7 @@ def which(program):
 
 # Only used by tests and by ctor_evaller.py.   Once fastcomp is removed
 # this can most likely be moved into the tests/jsrun.py.
-def timeout_run(proc, timeout=None, full_output=False, throw_on_failure=True):
+def timeout_run(proc, timeout=None, full_output=False, check=True):
   start = time.time()
   if timeout is not None:
     while time.time() - start < timeout and proc.poll() is None:
@@ -269,7 +269,7 @@ def timeout_run(proc, timeout=None, full_output=False, throw_on_failure=True):
       raise Exception("Timed out")
   stdout, stderr = proc.communicate()
   out = ['' if o is None else o for o in (stdout, stderr)]
-  if throw_on_failure and proc.returncode != 0:
+  if check and proc.returncode != 0:
     raise subprocess.CalledProcessError(proc.returncode, '', stdout, stderr)
   if TRACK_PROCESS_SPAWNS:
     logging.info('Process ' + str(proc.pid) + ' finished after ' + str(time.time() - start) + ' seconds. Exit code: ' + str(proc.returncode))


### PR DESCRIPTION
This is follow up to #11571.  The only remaining user of the timeout
code is now the ctor evaller.