### PR TITLE
Allow preprocessing of multiple files at once to stdout

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2170,7 +2170,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         for input_file in [x[1] for x in input_files]:
           cmd = get_clang_command(input_file)
           if specified_target:
-            assert(len(input_files) == 1)
             cmd += ['-o', specified_target]
           # Do not compile, but just output the result from preprocessing stage or
           # output the dependency rule. Warning: clang and gcc behave differently

--- a/emcc.py
+++ b/emcc.py
@@ -2176,7 +2176,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           # output the dependency rule. Warning: clang and gcc behave differently
           # with -MF! (clang seems to not recognize it)
           logger.debug(('just preprocessor ' if has_dash_E else 'just dependencies: ') + ' '.join(cmd))
-          run_process(cmd, check=False).returncode
+          shared.print_compiler_stage(cmd)
+          rtn = run_process(cmd, check=False).returncode
+          if rtn:
+            return rtn
         return 0
 
       # Precompiled headers support
@@ -2193,6 +2196,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
             cmd += ['-o', specified_target]
           cmd = system_libs.process_args(cmd, shared.Settings)
           logger.debug("running (for precompiled headers): " + cmd[0] + ' ' + ' '.join(cmd[1:]))
+          shared.print_compiler_stage(cmd)
           return run_process(cmd, check=False).returncode
 
       def get_object_filename(input_file):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -476,7 +476,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     self.clear()
     err = self.expect_fail(cmd + ['-o', 'out.o'])
 
-    self.assertContained('cannot specify -o with -c/-S and multiple source files', err)
+    self.assertContained('cannot specify -o with -c/-S/-E and multiple source files', err)
     self.assertNotExists('twopart_main.o')
     self.assertNotExists('twopart_side.o')
     self.assertNotExists(path_from_root('tests', 'twopart_main.o'))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2610,6 +2610,10 @@ done.
     self.assertContained('hello_world.c"', out)
     self.assertContained('printf("hello, world!', out)
 
+  def test_preprocess_multi(self):
+    out = run_process([EMCC, path_from_root('tests', 'hello_world.c'), path_from_root('tests', 'hello_world.c'), '-E'], stdout=PIPE).stdout
+    self.assertEqual(out.count('printf("hello, world!'), 2)
+
   def test_syntax_only_valid(self):
     result = run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-fsyntax-only'], stdout=PIPE, stderr=STDOUT)
     self.assertEqual(result.stdout, '')


### PR DESCRIPTION
Also, move -E handling before precompiled header handling otherwise
we can't use -E on headers.

Fixes #9466