### PR TITLE
mmap: Reintroduce `mmapAlloc` helper, zeroing only the padding

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -485,3 +485,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Sky Wang <sky-wang@qq.com>
 * popomen <nz_nuaa@163.com>
 * Sebastián Gurin (cancerberoSgx) <sebastigurin@gmail.com>
+* Benedikt Meurer <bmeurer@google.com> (copyright owned by Google, LLC)

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -2021,6 +2021,15 @@ FS.staticInit();` +
         transaction.onerror = onerror;
       };
       openRequest.onerror = onerror;
+    },
+
+    // Allocate memory for an mmap operation. This allocates space of the right
+    // page-aligned size, and clears the padding.
+    mmapAlloc: function(size) {
+      var alignedSize = alignMemory(size, {{{ POSIX_PAGE_SIZE }}});
+      var ptr = _malloc(alignedSize);
+      while (size < alignedSize) HEAP8[ptr + size++] = 0;
+      return ptr;
     }
   }
 });

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -382,8 +382,7 @@ mergeInto(LibraryManager.library, {
             }
           }
           allocated = true;
-          var allocatedSize = alignMemory(length, {{{ POSIX_PAGE_SIZE }}});
-          ptr = _malloc(allocatedSize);
+          ptr = FS.mmapAlloc(length);
           if (!ptr) {
             throw new FS.ErrnoError({{{ cDefine('ENOMEM') }}});
           }
@@ -391,10 +390,6 @@ mergeInto(LibraryManager.library, {
           ptr >>>= 0;
 #endif
           HEAP8.set(contents, ptr);
-          // The extra space allocated due to alignment must be zeroed out.
-          for (var i = length; i < allocatedSize; i++) {
-            HEAP8[ptr + i] = 0;
-          }
         }
         return { ptr: ptr, allocated: allocated };
       },

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -302,16 +302,9 @@ mergeInto(LibraryManager.library, {
           throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }
 
-        var allocatedSize = alignMemory(length, {{{ POSIX_PAGE_SIZE }}});
-        var ptr = _malloc(allocatedSize);
+        var ptr = FS.mmapAlloc(length);
 
         NODEFS.stream_ops.read(stream, HEAP8, ptr, length, position);
-
-        // The extra space allocated due to alignment must be zeroed out.
-        for (var i = length; i < allocatedSize; i++) {
-          HEAP8[ptr + i] = 0;
-        }
-
         return { ptr: ptr, allocated: true };
       },
       msync: function(stream, buffer, offset, length, mmapFlags) {


### PR DESCRIPTION
This partially reverts commit 50f266c4202e72304ebe1d658e447e4e73081261,
and puts back the `mmapAlloc` helper, using a loop to clear only the
padding bytes before having the FS code copy in the file contents.

Refs #11565