### PR TITLE
Refacotor ports so they can be built regardless of the settings.

### DIFF
--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -33,7 +33,7 @@ ports_by_name = {}
 
 
 def init():
-  expected_attrs = ['get', 'clear', 'process_args', 'show']
+  expected_attrs = ['get', 'clear', 'process_args', 'show', 'needed']
   for port in ports:
     name = port.__name__.split('.')[-1]
     ports_by_name[name] = port

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -11,10 +11,11 @@ TAG = '1.70.0'
 HASH = '3ba0180a4a3c20d64727750a3233c82aadba95f265a45052297b955902741edac1befd963400958d6915e5b8d9ade48195eeaf8524f06fdb4cfe43b98677f196'
 
 
-def get(ports, settings, shared):
-  if settings.USE_BOOST_HEADERS != 1:
-    return []
+def needed(settings):
+  return settings.USE_BOOST_HEADERS == 1
 
+
+def get(ports, settings, shared):
   ports.fetch_project('boost_headers', 'https://github.com/emscripten-ports/boost/releases/download/boost-1.70.0/boost-headers-' + TAG + '.zip',
                       'boost', sha512hash=HASH)
   libname = ports.get_lib_name('libboost_headers')
@@ -55,10 +56,9 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_BOOST_HEADERS == 1:
-    get(ports, settings, shared)
-    args += ['-DBOOST_ALL_NO_LIB']
-  return args
+  assert(needed(settings))
+  get(ports, settings, shared)
+  return args + ['-DBOOST_ALL_NO_LIB']
 
 
 def show():

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -51,12 +51,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libboost_headers'))
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args + ['-DBOOST_ALL_NO_LIB']
 

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -51,7 +51,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libboost_headers'))
 
 

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -11,10 +11,11 @@ TAG = 'version_1'
 HASH = '3922486816cf7d99ee02c3c1ef63d94290e8ed304016dd9927137d04206e7674d9df8773a4abb7bb57783d0a5107ad0f893aa87acfb34f7b316eec22ca55a536'
 
 
-def get(ports, settings, shared):
-  if settings.USE_BULLET != 1:
-    return []
+def needed(settings):
+  return settings.USE_BULLET == 1
 
+
+def get(ports, settings, shared):
   ports.fetch_project('bullet', 'https://github.com/emscripten-ports/bullet/archive/' + TAG + '.zip', 'Bullet-' + TAG, sha512hash=HASH)
   libname = ports.get_lib_name('libbullet')
 
@@ -57,10 +58,9 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_BULLET == 1:
-    get(ports, settings, shared)
-    args += ['-I' + os.path.join(ports.get_include_dir(), 'bullet')]
-  return args
+  assert(needed(settings))
+  get(ports, settings, shared)
+  return args + ['-I' + os.path.join(ports.get_include_dir(), 'bullet')]
 
 
 def show():

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -53,7 +53,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libbullet'))
 
 

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -53,12 +53,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libbullet'))
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args + ['-I' + os.path.join(ports.get_include_dir(), 'bullet')]
 

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -50,7 +50,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libbz2.a', create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file('libbz2.a')
 
 

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -50,12 +50,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libbz2.a', create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file('libbz2.a')
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -10,10 +10,11 @@ VERSION = '1.0.6'
 HASH = '512cbfde5144067f677496452f3335e9368fd5d7564899cb49e77847b9ae7dca598218276637cbf5ec524523be1e8ace4ad36a148ef7f4badf3f6d5a002a4bb2'
 
 
-def get(ports, settings, shared):
-  if settings.USE_BZIP2 != 1:
-    return []
+def needed(settings):
+  return settings.USE_BZIP2
 
+
+def get(ports, settings, shared):
   ports.fetch_project('bzip2', 'https://github.com/emscripten-ports/bzip2/archive/' + VERSION + '.zip', 'bzip2-' + VERSION, sha512hash=HASH)
 
   def create():
@@ -54,8 +55,8 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_BZIP2 == 1:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -75,7 +75,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libcocos2d'))
 
 

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -75,18 +75,16 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libcocos2d'))
 
 
 def process_dependencies(settings):
-  assert(needed(settings))
   settings.USE_LIBPNG = 1
   settings.USE_ZLIB = 1
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   for include in make_includes(os.path.join(ports.get_include_dir(), 'cocos2d')):
     args.append('-I' + include)

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -12,10 +12,11 @@ TAG = 'version_3_3'
 HASH = 'd7b22660036c684f09754fcbbc7562984f02aa955eef2b76555270c63a717e6672c4fe695afb16280822e8b7c75d4b99ae21975a01a4ed51cad957f7783722cd'
 
 
-def get(ports, settings, shared):
-  if settings.USE_COCOS2D != 3:
-    return []
+def needed(settings):
+  return settings.USE_COCOS2D == 3
 
+
+def get(ports, settings, shared):
   ports.fetch_project(
     'cocos2d', 'https://github.com/emscripten-ports/Cocos2d/archive/' + TAG + '.zip', 'Cocos2d-' + TAG, sha512hash=HASH)
   libname = ports.get_lib_name('libcocos2d')
@@ -79,16 +80,16 @@ def clear(ports, shared):
 
 
 def process_dependencies(settings):
-  if settings.USE_COCOS2D == 3:
-    settings.USE_LIBPNG = 1
-    settings.USE_ZLIB = 1
+  assert(needed(settings))
+  settings.USE_LIBPNG = 1
+  settings.USE_ZLIB = 1
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_COCOS2D == 3:
-    get(ports, settings, shared)
-    for include in make_includes(os.path.join(ports.get_include_dir(), 'cocos2d')):
-      args.append('-I' + include)
+  assert(needed(settings))
+  get(ports, settings, shared)
+  for include in make_includes(os.path.join(ports.get_include_dir(), 'cocos2d')):
+    args.append('-I' + include)
   return args
 
 

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -112,12 +112,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libfreetype.a', create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file('libfreetype.a')
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   return args + ['-I' + os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')]
 
 

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -112,7 +112,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libfreetype.a', create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file('libfreetype.a')
 
 

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -10,10 +10,11 @@ TAG = 'version_1'
 HASH = '0d0b1280ba0501ad0a23cf1daa1f86821c722218b59432734d3087a89acd22aabd5c3e5e1269700dcd41e87073046e906060f167c032eb91a3ac8c5808a02783'
 
 
-def get(ports, settings, shared):
-  if settings.USE_FREETYPE != 1:
-    return []
+def needed(settings):
+  return settings.USE_FREETYPE
 
+
+def get(ports, settings, shared):
   ports.fetch_project('freetype', 'https://github.com/emscripten-ports/FreeType/archive/' + TAG + '.zip', 'FreeType-' + TAG, sha512hash=HASH)
 
   def create():
@@ -116,11 +117,8 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_FREETYPE == 1:
-    get(ports, settings, shared)
-    args += ['-I' + os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')]
-
-  return args
+  assert(needed(settings))
+  return args + ['-I' + os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')]
 
 
 def show():

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -55,17 +55,15 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libharfbuzz' + ('-mt' if settings.USE_PTHREADS else '') + '.a', create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file('libharfbuzz.a')
 
 
 def process_dependencies(settings):
-  assert(needed(settings))
   settings.USE_FREETYPE = 1
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args + ['-I' + os.path.join(ports.get_build_dir(), 'harfbuzz', 'include', 'harfbuzz')]
 

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -55,7 +55,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libharfbuzz' + ('-mt' if settings.USE_PTHREADS else '') + '.a', create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file('libharfbuzz.a')
 
 

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -11,10 +11,11 @@ TAG = '1.7.5'
 HASH = 'c2c13fc97bb74f0f13092b07804f7087e948bce49793f48b62c2c24a5792523acc0002840bebf21829172bb2e7c3df9f9625250aec6c786a55489667dd04d6a0'
 
 
-def get(ports, settings, shared):
-  if settings.USE_HARFBUZZ != 1:
-    return []
+def needed(settings):
+  return settings.USE_HARFBUZZ
 
+
+def get(ports, settings, shared):
   ports.fetch_project('harfbuzz', 'https://github.com/harfbuzz/harfbuzz/releases/download/' +
                       TAG + '/harfbuzz-' + TAG + '.tar.bz2', 'harfbuzz-' + TAG, is_tarbz2=True, sha512hash=HASH)
 
@@ -59,15 +60,14 @@ def clear(ports, shared):
 
 
 def process_dependencies(settings):
-  if settings.USE_HARFBUZZ == 1:
-    settings.USE_FREETYPE = 1
+  assert(needed(settings))
+  settings.USE_FREETYPE = 1
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_HARFBUZZ == 1:
-    get(ports, settings, shared)
-    args += ['-I' + os.path.join(ports.get_build_dir(), 'harfbuzz', 'include', 'harfbuzz')]
-  return args
+  assert(needed(settings))
+  get(ports, settings, shared)
+  return args + ['-I' + os.path.join(ports.get_build_dir(), 'harfbuzz', 'include', 'harfbuzz')]
 
 
 def show():

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -39,7 +39,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libicuuc'))
 
 

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -12,10 +12,11 @@ VERSION = '62_1'
 HASH = 'd3fa42da9aa9c2fc749fff4a31a9e57e826903681d9f4e5b4474649bf3efe271fec10f214a027d542123b85ad3f6fcfc9b6208ad3f8e4c24fe4a0cbab4024e2d'
 
 
-def get(ports, settings, shared):
-  if settings.USE_ICU != 1:
-    return []
+def needed(settings):
+  return settings.USE_ICU
 
+
+def get(ports, settings, shared):
   url = 'https://github.com/unicode-org/icu/releases/download/%s/icu4c-%s-src.zip' % (TAG, VERSION)
   ports.fetch_project('icu', url, 'icu', sha512hash=HASH)
   libname = ports.get_lib_name('libicuuc')
@@ -43,8 +44,7 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_ICU == 1:
-    get(ports, settings, shared)
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -39,7 +39,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libicuuc'))
 
 

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -11,10 +11,11 @@ VERSION = '9c'
 HASH = '2b581c60ae401a79bbbe748ff2deeda5acd50bfd2ea22e5926e36d34b9ebcffb6580b0ff48e972c1441583e30e21e1ea821ca0423f9c67ce08a31dffabdbe6b7'
 
 
-def get(ports, settings, shared):
-  if settings.USE_LIBJPEG != 1:
-    return []
+def needed(settings):
+  return settings.USE_LIBJPEG
 
+
+def get(ports, settings, shared):
   ports.fetch_project('libjpeg', 'https://dl.bintray.com/homebrew/mirror/jpeg-9c.tar.gz', 'jpeg-9c', sha512hash=HASH)
 
   libname = ports.get_lib_name('libjpeg')
@@ -50,8 +51,8 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_LIBJPEG == 1:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -46,12 +46,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libjpeg'))
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -46,7 +46,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libjpeg'))
 
 

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -11,10 +11,11 @@ TAG = 'version_1'
 HASH = 'a19ede8a4339f2745a490c22f3893899e1a5eae9d2b270e49d88d3a85239fbbaa26c9a352d0e6fb8bb69b4f45bd00c1ae9eff29b60cf03e79c5df45a4409992f'
 
 
-def get(ports, settings, shared):
-  if settings.USE_LIBPNG != 1:
-    return []
+def needed(settings):
+  return settings.USE_LIBPNG
 
+
+def get(ports, settings, shared):
   ports.fetch_project('libpng', 'https://github.com/emscripten-ports/libpng/archive/' + TAG + '.zip', 'libpng-' + TAG, sha512hash=HASH)
 
   libname = ports.get_lib_name('libpng')
@@ -43,13 +44,13 @@ def clear(ports, shared):
 
 
 def process_dependencies(settings):
-  if settings.USE_LIBPNG == 1:
-    settings.USE_ZLIB = 1
+  assert(needed(settings))
+  settings.USE_ZLIB = 1
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_LIBPNG == 1:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -39,17 +39,15 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libpng'))
 
 
 def process_dependencies(settings):
-  assert(needed(settings))
   settings.USE_ZLIB = 1
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -39,7 +39,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libpng'))
 
 

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -42,12 +42,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libogg'))
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -42,7 +42,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libogg'))
 
 

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -11,10 +11,11 @@ TAG = 'version_1'
 HASH = '929e8d6003c06ae09593021b83323c8f1f54532b67b8ba189f4aedce52c25dc182bac474de5392c46ad5b0dea5a24928e4ede1492d52f4dd5cd58eea9be4dba7'
 
 
-def get(ports, settings, shared):
-  if settings.USE_OGG != 1:
-    return []
+def needed(settings):
+  return settings.USE_OGG
 
+
+def get(ports, settings, shared):
   ports.fetch_project('ogg', 'https://github.com/emscripten-ports/ogg/archive/' + TAG + '.zip', 'Ogg-' + TAG, sha512hash=HASH)
   libname = ports.get_lib_name('libogg')
 
@@ -46,8 +47,8 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_OGG == 1:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -11,14 +11,15 @@ TAG = 'version_7'
 HASH = 'a921dab254f21cf5d397581c5efe58faf147c31527228b4fb34aed75164c736af4b3347092a8d9ec1249160230fa163309a87a20c2b9ceef8554566cc215de9d'
 
 
+def needed(settings):
+  return settings.USE_REGAL
+
+
 def get_lib_name(ports, settings):
   return ports.get_lib_name('libregal' + ('-mt' if settings.USE_PTHREADS else ''))
 
 
 def get(ports, settings, shared):
-  if settings.USE_REGAL != 1:
-    return []
-
   ports.fetch_project('regal', 'https://github.com/emscripten-ports/regal/archive/' + TAG + '.zip',
                       'regal-' + TAG, sha512hash=HASH)
 
@@ -141,17 +142,17 @@ def get(ports, settings, shared):
 
 
 def clear(ports, shared):
-  shared.Cache.erase_file(get_lib_name(ports, shared.Settings))
+  shared.Cache.erase_file(get_lib_name(ports))
 
 
 def process_dependencies(settings):
-  if settings.USE_REGAL == 1:
-    settings.FULL_ES2 = 1
+  assert(needed(settings))
+  settings.FULL_ES2 = 1
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_REGAL == 1:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -141,17 +141,15 @@ def get(ports, settings, shared):
   return [shared.Cache.get(get_lib_name(ports, settings), create, what='port')]
 
 
-def clear(ports, shared):
-  shared.Cache.erase_file(get_lib_name(ports))
+def clear(ports, settings, shared):
+  shared.Cache.erase_file(get_lib_name(ports, settings))
 
 
 def process_dependencies(settings):
-  assert(needed(settings))
   settings.FULL_ES2 = 1
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -85,12 +85,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2'))
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   # TODO(sbc): remove this
   get(ports, settings, shared)
   return args + ['-Xclang', '-isystem' + os.path.join(ports.get_include_dir(), 'SDL2')]

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -85,7 +85,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2'))
 
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -10,10 +10,11 @@ HASH = '0ea4ab13b8715b9f8b41096f47dc03cad17f35e19c945156b2bb0f3c16b261a4b0c6d576
 SUBDIR = 'SDL2-' + TAG
 
 
-def get(ports, settings, shared):
-  if settings.USE_SDL != 2:
-    return []
+def needed(settings):
+  return settings.USE_SDL == 2
 
+
+def get(ports, settings, shared):
   # get the port
   ports.fetch_project('sdl2', 'https://github.com/emscripten-ports/SDL2/archive/' + TAG + '.zip', SUBDIR, sha512hash=HASH)
   libname = ports.get_lib_name('libSDL2' + ('-mt' if settings.USE_PTHREADS else ''))
@@ -89,14 +90,10 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_SDL == 1:
-    # TODO(sbc): remove this
-    args += ['-Xclang', '-isystem' + shared.path_from_root('system', 'include', 'SDL')]
-  elif settings.USE_SDL == 2:
-    # TODO(sbc): remove this
-    args += ['-Xclang', '-isystem' + os.path.join(ports.get_include_dir(), 'SDL2')]
-    get(ports, settings, shared)
-  return args
+  assert(needed(settings))
+  # TODO(sbc): remove this
+  get(ports, settings, shared)
+  return args + ['-Xclang', '-isystem' + os.path.join(ports.get_include_dir(), 'SDL2')]
 
 
 def show():

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -38,7 +38,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_gfx'))
 
 

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -11,10 +11,11 @@ TAG = '2b147ffef10ec541d3eace326eafe11a54e635f8'
 HASH = 'f39f1f50a039a1667fe92b87d28548d32adcf0eb8526008656de5315039aa21f29d230707caa47f80f6b3a412a577698cd4bbfb9458bb92ac47e6ba993b8efe6'
 
 
-def get(ports, settings, shared):
-  if settings.USE_SDL_GFX != 2:
-    return []
+def needed(settings):
+  return settings.USE_SDL_GFX == 2
 
+
+def get(ports, settings, shared):
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_gfx'
   ports.fetch_project('sdl2_gfx', 'https://github.com/svn2github/sdl2_gfx/archive/' + TAG + '.zip', 'sdl2_gfx-' + TAG, sha512hash=HASH)
@@ -42,8 +43,8 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_SDL_GFX == 2:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -38,12 +38,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_gfx'))
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -9,10 +9,11 @@ TAG = 'version_4'
 HASH = '30a7b04652239bccff3cb1fa7cd8ae602791b5f502a96df39585c13ebc4bb2b64ba1598c0d1f5382028d94e04a5ca02185ea06bf7f4b3520f6df4cc253f9dd24'
 
 
-def get(ports, settings, shared):
-  if settings.USE_SDL_IMAGE != 2:
-    return []
+def needed(settings):
+  return settings.USE_SDL_IMAGE == 2
 
+
+def get(ports, settings, shared):
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_image'
   ports.fetch_project('sdl2_image', 'https://github.com/emscripten-ports/SDL2_image/archive/' + TAG + '.zip', 'SDL2_image-' + TAG, sha512hash=HASH)
@@ -62,8 +63,8 @@ def clear(ports, shared):
 
 
 def process_dependencies(settings):
-  if settings.USE_SDL_IMAGE == 2:
-    settings.USE_SDL = 2
+  assert(needed(settings))
+  settings.USE_SDL = 2
   if 'png' in settings.SDL2_IMAGE_FORMATS:
     settings.USE_LIBPNG = 1
   if 'jpg' in settings.SDL2_IMAGE_FORMATS:
@@ -71,8 +72,8 @@ def process_dependencies(settings):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_SDL_IMAGE == 2:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -58,7 +58,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.get_path(ports.get_lib_name('libSDL2_image'))
 
 

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -58,12 +58,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.get_path(ports.get_lib_name('libSDL2_image'))
 
 
 def process_dependencies(settings):
-  assert(needed(settings))
   settings.USE_SDL = 2
   if 'png' in settings.SDL2_IMAGE_FORMATS:
     settings.USE_LIBPNG = 1
@@ -72,7 +71,6 @@ def process_dependencies(settings):
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -44,7 +44,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_mixer'))
 
 

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -11,10 +11,11 @@ TAG = 'release-2.0.1'
 HASH = '81fac757bd058adcb3eb5b2cc46addeaa44cee2cd4db653dad5d9666bdc0385cdc21bf5b72872e6dd6dd8eb65812a46d7752298827d6c61ad5ce2b6c963f7ed0'
 
 
-def get(ports, settings, shared):
-  if settings.USE_SDL_MIXER != 2:
-    return []
+def needed(settings):
+  return settings.USE_SDL_MIXER == 2
 
+
+def get(ports, settings, shared):
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_mixer'
   ports.fetch_project('sdl2_mixer', 'https://github.com/emscripten-ports/SDL2_mixer/archive/' + TAG + '.zip', 'SDL2_mixer-' + TAG, sha512hash=HASH)
@@ -48,14 +49,14 @@ def clear(ports, shared):
 
 
 def process_dependencies(settings):
-  if settings.USE_SDL_MIXER == 2:
-    settings.USE_SDL = 2
-    settings.USE_VORBIS = 1
+  assert(needed(settings))
+  settings.USE_SDL = 2
+  settings.USE_VORBIS = 1
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_SDL_MIXER == 2:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -44,18 +44,16 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_mixer'))
 
 
 def process_dependencies(settings):
-  assert(needed(settings))
   settings.USE_SDL = 2
   settings.USE_VORBIS = 1
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -10,10 +10,11 @@ TAG = 'version_2'
 HASH = '317b22ad9b6b2f7b40fac7b7c426da2fa2da1803bbe58d480631f1e5b190d730763f2768c77c72affa806c69a1e703f401b15a1be3ec611cd259950d5ebc3711'
 
 
-def get(ports, settings, shared):
-  if settings.USE_SDL_NET != 2:
-    return []
+def needed(settings):
+  return settings.USE_SDL_NET == 2
 
+
+def get(ports, settings, shared):
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_net'
   ports.fetch_project('sdl2_net', 'https://github.com/emscripten-ports/SDL2_net/archive/' + TAG + '.zip', 'SDL2_net-' + TAG, sha512hash=HASH)
@@ -45,8 +46,8 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_SDL_NET == 2:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -41,7 +41,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_net'))
 
 

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -41,12 +41,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_net'))
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -42,7 +42,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_ttf'))
 
 

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -42,18 +42,16 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_ttf'))
 
 
 def process_dependencies(settings):
-  assert(needed(settings))
   settings.USE_SDL = 2
   settings.USE_FREETYPE = 1
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -9,10 +9,11 @@ TAG = 'version_1'
 HASH = '6ce426de0411ba51dd307027c4ef00ff3de4ee396018e524265970039132ab20adb29c2d2e61576c393056374f03fd148dd96f0c4abf8dcee51853dd32f0778f'
 
 
-def get(ports, settings, shared):
-  if settings.USE_SDL_TTF != 2:
-    return []
+def needed(settings):
+  return settings.USE_SDL_TTF == 2
 
+
+def get(ports, settings, shared):
   ports.fetch_project('sdl2_ttf', 'https://github.com/emscripten-ports/SDL2_ttf/archive/' + TAG + '.zip', 'SDL2_ttf-' + TAG, sha512hash=HASH)
   libname = ports.get_lib_name('libSDL2_ttf')
 
@@ -46,14 +47,14 @@ def clear(ports, shared):
 
 
 def process_dependencies(settings):
-  if settings.USE_SDL_TTF == 2:
-    settings.USE_SDL = 2
-    settings.USE_FREETYPE = 1
+  assert(needed(settings))
+  settings.USE_SDL = 2
+  settings.USE_FREETYPE = 1
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_SDL_TTF == 2:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -37,7 +37,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libvorbis'))
 
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -11,10 +11,11 @@ TAG = 'version_1'
 HASH = '99bee75beb662f8520bbb18ad6dbf8590d30eb3a7360899f0ac4764ca72fe8013da37c9df21e525f9d2dc5632827d4b4cea558cbc938e7fbed0c41a29a7a2dc5'
 
 
-def get(ports, settings, shared):
-  if settings.USE_VORBIS != 1:
-    return []
+def needed(settings):
+  return settings.USE_VORBIS
 
+
+def get(ports, settings, shared):
   ports.fetch_project('vorbis', 'https://github.com/emscripten-ports/vorbis/archive/' + TAG + '.zip', 'Vorbis-' + TAG, sha512hash=HASH)
   libname = ports.get_lib_name('libvorbis')
 
@@ -41,13 +42,13 @@ def clear(ports, shared):
 
 
 def process_dependencies(settings):
-  if settings.USE_VORBIS == 1:
-    settings.USE_OGG = 1
+  assert(needed(settings))
+  settings.USE_OGG = 1
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_VORBIS == 1:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -37,17 +37,15 @@ def get(ports, settings, shared):
   return [shared.Cache.get(libname, create)]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file(ports.get_lib_name('libvorbis'))
 
 
 def process_dependencies(settings):
-  assert(needed(settings))
   settings.USE_OGG = 1
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -47,12 +47,11 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libz.a', create, what='port')]
 
 
-def clear(ports, shared):
+def clear(ports, shared, settings):
   shared.Cache.erase_file('libz.a')
 
 
 def process_args(ports, args, settings, shared):
-  assert(needed(settings))
   get(ports, settings, shared)
   return args
 

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -10,10 +10,11 @@ TAG = 'version_1'
 HASH = '77f7d8f18fe11bb66a57e358325b7422d721f7b506bd63293cfde74079f958864db66ead5a36c311a76dd8c2b089b7659641a5522de650de0f9e6865782a60dd'
 
 
-def get(ports, settings, shared):
-  if settings.USE_ZLIB != 1:
-    return []
+def needed(settings):
+  return settings.USE_ZLIB
 
+
+def get(ports, settings, shared):
   ports.fetch_project('zlib', 'https://github.com/emscripten-ports/zlib/archive/' + TAG + '.zip', 'zlib-' + TAG, sha512hash=HASH)
 
   def create():
@@ -51,8 +52,8 @@ def clear(ports, shared):
 
 
 def process_args(ports, args, settings, shared):
-  if settings.USE_ZLIB == 1:
-    get(ports, settings, shared)
+  assert(needed(settings))
+  get(ports, settings, shared)
   return args
 
 

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -47,7 +47,7 @@ def get(ports, settings, shared):
   return [shared.Cache.get('libz.a', create, what='port')]
 
 
-def clear(ports, shared, settings):
+def clear(ports, settings, shared):
   shared.Cache.erase_file('libz.a')
 
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1969,7 +1969,7 @@ class Ports(object):
   @staticmethod
   def clear_project_build(name):
     port = ports.ports_by_name[name]
-    port.clear(Ports, shared, shared.Settings)
+    port.clear(Ports, shared.Settings, shared)
     shared.try_delete(os.path.join(Ports.get_build_dir(), name))
 
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1969,7 +1969,7 @@ class Ports(object):
   @staticmethod
   def clear_project_build(name):
     port = ports.ports_by_name[name]
-    port.clear(Ports, shared)
+    port.clear(Ports, shared, shared.Settings)
     shared.try_delete(os.path.join(Ports.get_build_dir(), name))
 
 


### PR DESCRIPTION
This change splits the concept of `needed()` from `get()` and is
needed for implementing: #11580