### PR TITLE
ports: Refactor process_args sub-command. NFC.

### DIFF
--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -55,9 +55,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libboost_headers'))
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args + ['-DBOOST_ALL_NO_LIB']
+def process_args(ports):
+  return ['-DBOOST_ALL_NO_LIB']
 
 
 def show():

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -57,9 +57,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libbullet'))
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args + ['-I' + os.path.join(ports.get_include_dir(), 'bullet')]
+def process_args(ports):
+  return ['-I' + os.path.join(ports.get_include_dir(), 'bullet')]
 
 
 def show():

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -54,9 +54,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file('libbz2.a')
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -84,8 +84,8 @@ def process_dependencies(settings):
   settings.USE_ZLIB = 1
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
+def process_args(ports):
+  args = []
   for include in make_includes(os.path.join(ports.get_include_dir(), 'cocos2d')):
     args.append('-I' + include)
   return args

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -116,9 +116,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file('libfreetype.a')
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args + ['-I' + os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')]
+def process_args(ports):
+  return ['-I' + os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')]
 
 
 def show():

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -63,9 +63,8 @@ def process_dependencies(settings):
   settings.USE_FREETYPE = 1
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args + ['-I' + os.path.join(ports.get_build_dir(), 'harfbuzz', 'include', 'harfbuzz')]
+def process_args(ports):
+  return ['-I' + os.path.join(ports.get_build_dir(), 'harfbuzz', 'include', 'harfbuzz')]
 
 
 def show():

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -43,9 +43,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libicuuc'))
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -50,9 +50,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libjpeg'))
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -47,9 +47,8 @@ def process_dependencies(settings):
   settings.USE_ZLIB = 1
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -46,9 +46,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libogg'))
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -149,9 +149,8 @@ def process_dependencies(settings):
   settings.FULL_ES2 = 1
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -89,10 +89,9 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2'))
 
 
-def process_args(ports, args, settings, shared):
+def process_args(ports):
   # TODO(sbc): remove this
-  get(ports, settings, shared)
-  return args + ['-Xclang', '-isystem' + os.path.join(ports.get_include_dir(), 'SDL2')]
+  return ['-Xclang', '-isystem' + os.path.join(ports.get_include_dir(), 'SDL2')]
 
 
 def show():

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -42,9 +42,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_gfx'))
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -70,9 +70,8 @@ def process_dependencies(settings):
     settings.USE_LIBJPEG = 1
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -53,9 +53,8 @@ def process_dependencies(settings):
   settings.USE_VORBIS = 1
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -45,9 +45,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file(ports.get_lib_name('libSDL2_net'))
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -51,9 +51,8 @@ def process_dependencies(settings):
   settings.USE_FREETYPE = 1
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -45,9 +45,8 @@ def process_dependencies(settings):
   settings.USE_OGG = 1
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -51,9 +51,8 @@ def clear(ports, settings, shared):
   shared.Cache.erase_file('libz.a')
 
 
-def process_args(ports, args, settings, shared):
-  get(ports, settings, shared)
-  return args
+def process_args(ports):
+  return []
 
 
 def show():

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -2005,7 +2005,8 @@ def process_args(args, settings):
   process_dependencies(settings)
   for port in ports.ports:
     if port.needed(settings):
-      args = port.process_args(Ports, args, settings, shared)
+      port.get(Ports, settings, shared)
+      args += port.process_args(Ports)
   return args
 
 


### PR DESCRIPTION
Now we just return needed flags and the `get()` can be done
at the outer level once we know a port is needed.