### PR TITLE
Load ports dynamically based on directory contents

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1760,7 +1760,7 @@ int f() {
 
   def test_libpng(self):
     shutil.copyfile(path_from_root('tests', 'pngtest.png'), 'pngtest.png')
-    building.emcc(path_from_root('tests', 'pngtest.c'), ['--embed-file', 'pngtest.png', '-s', 'USE_ZLIB=1', '-s', 'USE_LIBPNG=1'], output_filename='a.out.js')
+    building.emcc(path_from_root('tests', 'pngtest.c'), ['--embed-file', 'pngtest.png', '-s', 'USE_LIBPNG=1'], output_filename='a.out.js')
     self.assertContained('TESTS PASSED', run_process(JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).stdout)
 
   def test_libjpeg(self):

--- a/tools/ports/__init__.py
+++ b/tools/ports/__init__.py
@@ -3,42 +3,36 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from . import boost_headers, bullet, cocos2d, freetype, harfbuzz, icu, libjpeg, libpng
-from . import ogg, regal, sdl2, sdl2_gfx, sdl2_image, sdl2_mixer, sdl2_ttf
-from . import sdl2_net, vorbis, zlib, bzip2
+import os
+from tools.shared import exit_with_error
 
-# If port A depends on port B, then A should be _after_ B
-ports = [
-    boost_headers,
-    icu,
-    zlib,
-    bzip2,
-    libjpeg,
-    libpng,
-    sdl2,
-    sdl2_image,
-    sdl2_gfx,
-    ogg, vorbis,
-    sdl2_mixer,
-    bullet,
-    freetype,
-    harfbuzz,
-    sdl2_ttf,
-    sdl2_net,
-    cocos2d,
-    regal
-]
+ports = []
 
 ports_by_name = {}
 
+ports_dir = os.path.dirname(os.path.abspath(__file__))
 
-def init():
+
+def read_ports():
   expected_attrs = ['get', 'clear', 'process_args', 'show', 'needed']
-  for port in ports:
-    name = port.__name__.split('.')[-1]
-    ports_by_name[name] = port
+  for filename in os.listdir(ports_dir):
+    if not filename.endswith('.py') or filename == '__init__.py':
+      continue
+    filename = os.path.splitext(filename)[0]
+    port = __import__(filename, globals(), level=1)
+    ports.append(port)
+    port.name = filename
+    ports_by_name[port.name] = port
     for a in expected_attrs:
       assert hasattr(port, a), 'port %s is missing %s' % (port, a)
+    if not hasattr(port, 'process_dependencies'):
+      port.process_dependencies = lambda x: 0
+    if not hasattr(port, 'deps'):
+      port.deps = []
+
+  for dep in port.deps:
+    if dep not in ports_by_name:
+      exit_with_error('unknown dependency in port: %s' % dep)
 
 
-init()
+read_ports()

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -11,6 +11,8 @@ import re
 TAG = 'version_3_3'
 HASH = 'd7b22660036c684f09754fcbbc7562984f02aa955eef2b76555270c63a717e6672c4fe695afb16280822e8b7c75d4b99ae21975a01a4ed51cad957f7783722cd'
 
+deps = ['libpng', 'zlib']
+
 
 def needed(settings):
   return settings.USE_COCOS2D == 3

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -10,6 +10,8 @@ from tools import building
 TAG = '1.7.5'
 HASH = 'c2c13fc97bb74f0f13092b07804f7087e948bce49793f48b62c2c24a5792523acc0002840bebf21829172bb2e7c3df9f9625250aec6c786a55489667dd04d6a0'
 
+deps = ['freetype']
+
 
 def needed(settings):
   return settings.USE_HARFBUZZ

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -10,6 +10,8 @@ import logging
 TAG = 'version_1'
 HASH = 'a19ede8a4339f2745a490c22f3893899e1a5eae9d2b270e49d88d3a85239fbbaa26c9a352d0e6fb8bb69b4f45bd00c1ae9eff29b60cf03e79c5df45a4409992f'
 
+deps = ['zlib']
+
 
 def needed(settings):
   return settings.USE_LIBPNG

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -63,10 +63,14 @@ def clear(ports, settings, shared):
 
 
 def process_dependencies(settings):
+  global deps
+  deps = ['sdl2']
   settings.USE_SDL = 2
   if 'png' in settings.SDL2_IMAGE_FORMATS:
+    deps.append('libpng')
     settings.USE_LIBPNG = 1
   if 'jpg' in settings.SDL2_IMAGE_FORMATS:
+    deps.append('libjpeg')
     settings.USE_LIBJPEG = 1
 
 

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -10,6 +10,8 @@ import logging
 TAG = 'release-2.0.1'
 HASH = '81fac757bd058adcb3eb5b2cc46addeaa44cee2cd4db653dad5d9666bdc0385cdc21bf5b72872e6dd6dd8eb65812a46d7752298827d6c61ad5ce2b6c963f7ed0'
 
+deps = ['vorbis', 'sdl2']
+
 
 def needed(settings):
   return settings.USE_SDL_MIXER == 2

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -8,6 +8,8 @@ import os
 TAG = 'version_1'
 HASH = '6ce426de0411ba51dd307027c4ef00ff3de4ee396018e524265970039132ab20adb29c2d2e61576c393056374f03fd148dd96f0c4abf8dcee51853dd32f0778f'
 
+deps = ['freetype', 'sdl2']
+
 
 def needed(settings):
   return settings.USE_SDL_TTF == 2

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -10,6 +10,8 @@ import shutil
 TAG = 'version_1'
 HASH = '99bee75beb662f8520bbb18ad6dbf8590d30eb3a7360899f0ac4764ca72fe8013da37c9df21e525f9d2dc5632827d4b4cea558cbc938e7fbed0c41a29a7a2dc5'
 
+deps = ['ogg']
+
 
 def needed(settings):
   return settings.USE_VORBIS


### PR DESCRIPTION
To make this work I had to add explict dependencies to each port so
that the can be built in the correct order.  Previously we were relying
on the ports being listed in a specific order to work around this issue.
    
This paves the way for ports to be maintained out of tree, and for
them to be added/removed by simply adding/removing files from this
directory.