### PR TITLE
embind: fix asan violation in std::string and std::wstring

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -486,3 +486,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * popomen <nz_nuaa@163.com>
 * Sebastián Gurin (cancerberoSgx) <sebastigurin@gmail.com>
 * Benedikt Meurer <bmeurer@google.com> (copyright owned by Google, LLC)
+* Jiulong Wang <jiulongw@gmail.com>

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -639,7 +639,7 @@ var LibraryEmbind = {
                 // Looping here to support possible embedded '0' bytes
                 for (var i = 0; i <= length; ++i) {
                     var currentBytePtr = value + 4 + i;
-                    if (HEAPU8[currentBytePtr] == 0 || i == length) {
+                    if (i == length || HEAPU8[currentBytePtr] == 0) {
                         var maxRead = currentBytePtr - decodeStartPtr;
                         var stringSegment = UTF8ToString(decodeStartPtr, maxRead);
                         if (str === undefined) {
@@ -748,7 +748,7 @@ var LibraryEmbind = {
             // Looping here to support possible embedded '0' bytes
             for (var i = 0; i <= length; ++i) {
                 var currentBytePtr = value + 4 + i * charSize;
-                if (HEAP[currentBytePtr >> shift] == 0 || i == length) {
+                if (i == length || HEAP[currentBytePtr >> shift] == 0) {
                     var maxReadBytes = currentBytePtr - decodeStartPtr;
                     var stringSegment = decodeString(decodeStartPtr, maxReadBytes);
                     if (str === undefined) {


### PR DESCRIPTION
ASAN strictly forbids read over allocated boundary, so length checking
should go before `\0` testing.

Fixes #11598.