### PR TITLE
Honor EMCC_CORES in test runner's `build_library`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,6 +367,8 @@ jobs:
     executor: bionic
     steps:
       - checkout
+      - run: pip2 install flake8==3.7.8
+      - run: pip3 install flake8==3.7.8
       - run: python2 -m flake8 --show-source --statistics
       - run: python3 -m flake8 --show-source --statistics
   test-fastcomp-other:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -940,7 +940,7 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
                   configure_args=[], make=['make'], make_args=None,
                   env_init={}, cache_name_extra='', native=False):
     if make_args is None:
-      make_args = ['-j', str(multiprocessing.cpu_count())]
+      make_args = ['-j', str(building.get_num_cores())]
 
     build_dir = self.get_build_dir()
     output_dir = self.get_dir()


### PR DESCRIPTION
This is important on circleci where the machines report a lot of
cores but we don't want to actually use that many (we force the
core count 4 there)..