### PR TITLE
Fix MAIN_THREAD_ASYNC_EM_ASM stack allocation

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -2179,16 +2179,21 @@ def create_asm_consts_wasm(forwarded_json, metadata):
         # ... over to the negative integers starting at -1.
         preamble += ('\n  if (ENVIRONMENT_IS_PTHREAD) { ' +
                      proxy_debug_print(sync_proxy) +
-                     'return _emscripten_proxy_to_main_thread_js(-1 - code, ' +
-                     str(int(sync_proxy)) +
-                     ', code, sigPtr, argbuf); }')
+                     'return _emscripten_proxy_to_main_thread_js.apply(null, ' +
+                     '[-1 - code, ' + str(int(sync_proxy)) + '].concat(args)) }')
 
     if shared.Settings.RELOCATABLE:
       preamble += '\n  code -= %s;\n' % shared.Settings.GLOBAL_BASE
 
+    # EM_ASM functions are variadic, receiving the actual arguments as a buffer
+    # in memory. the last parameter (argBuf) points to that data. We need to
+    # alwayd un-variadify that, as in the async case this is a stack allocation
+    # that LLVM made, which may go away before the main thread gets the message.
+    # the readAsmConstArgs helper does so.
     asm_const_funcs.append(r'''
-function %s(code, sigPtr, argbuf) {%s
+function %s(code, sigPtr, argbuf) {
   var args = readAsmConstArgs(sigPtr, argbuf);
+%s
   return ASM_CONSTS[code].apply(null, args);
 }''' % (const_name, preamble))
   asm_consts = [(key, value) for key, value in asm_consts.items()]

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1305,17 +1305,6 @@ var LibraryPThread = {
     // EM_ASMs as negative values (see include_asm_consts)
     var isEmAsmConst = index < 0;
     var func = !isEmAsmConst ? proxiedFunctionTable[index] : ASM_CONSTS[-index - 1];
-#if WASM_BACKEND
-    if (isEmAsmConst) {
-      // EM_ASM arguments are stored in their own buffer in memory, that we need
-      // to unpack in order to call. The proxied arguments are the code index,
-      // signature pointer, and vararg buffer pointer, in that order.
-      var sigPtr = _emscripten_receive_on_main_thread_js_callArgs[1];
-      var varargPtr = _emscripten_receive_on_main_thread_js_callArgs[2];
-      var constArgs = readAsmConstArgs(sigPtr, varargPtr);
-      return func.apply(null, constArgs);
-    }
-#endif
 #if ASSERTIONS
     assert(func.length == numCallArgs, 'Call args mismatch in emscripten_receive_on_main_thread_js');
 #endif

--- a/tests/core/test_main_thread_async_em_asm.cpp
+++ b/tests/core/test_main_thread_async_em_asm.cpp
@@ -8,9 +8,35 @@
 
 int main()
 {
-	// Test that on main browser thread, MAIN_THREAD_ASYNC_EM_ASM() will get
-	// synchronously executed.
-	printf("Before MAIN_THREAD_ASYNC_EM_ASM\n");
-	MAIN_THREAD_ASYNC_EM_ASM(out('Inside MAIN_THREAD_ASYNC_EM_ASM: ' + $0 + ' ' + $1), 42, 3.5);
-	printf("After MAIN_THREAD_ASYNC_EM_ASM\n");
+  // Test that on main browser thread, MAIN_THREAD_ASYNC_EM_ASM() will get
+  // synchronously executed.
+  printf("Before MAIN_THREAD_ASYNC_EM_ASM\n");
+  MAIN_THREAD_ASYNC_EM_ASM({
+    out('Inside MAIN_THREAD_ASYNC_EM_ASM: ' + $0 + ' ' + $1)
+  }, 42, 3.5);
+  printf("After MAIN_THREAD_ASYNC_EM_ASM\n");
+#if __EMSCRIPTEN_PTHREADS__
+  // Test sending a bunch of async messages, and seeing that they arrive ok
+  // on the main thread (this runs in PROXY_TO_PTHREAD, so we are not the
+  // main thread).
+  MAIN_THREAD_EM_ASM({
+    Module.totalStuffSent = 0;
+  });
+  for (int i = 0; i < 10; i++) {
+    // Use a bunch of arguments, to ensure they arrive ok.
+    MAIN_THREAD_ASYNC_EM_ASM({
+      Module.totalStuffSent += $0 + $1 + $2 + $3 + $4;
+    }, 1 * i, 2 * i, 3 * i, 4 * i, 5 * i);
+  }
+  // Poll for them all arriving - we just need to wait, but their arrival is
+  // guaranteed.
+  while (!MAIN_THREAD_EM_ASM_INT({
+    // We only add, so this should never exceed the target.
+    assert(Module.totalStuffSent <= 675);
+    return Module.totalStuffSent == 675;
+  })) {}
+#endif
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3992,6 +3992,10 @@ window.close = function() {
     self.btest(path_from_root('tests', 'core', 'test_em_asm_signatures.cpp'), expected='121', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'ASSERTIONS=1'])
 
   @requires_threads
+  def test_main_thread_async_em_asm(self):
+    self.btest(path_from_root('tests', 'core', 'test_main_thread_async_em_asm.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1', '-s', 'ASSERTIONS=1'])
+
+  @requires_threads
   def test_main_thread_em_asm_blocking(self):
     create_test_file('page.html',
                      open(path_from_root('tests', 'browser', 'test_em_asm_blocking.html')).read())


### PR DESCRIPTION
EM_ASM are all variadic, so the params are on the C stack. The proxying
just naively proxies over arguments, including the parameter LLVM gave us
with the stack pointer - but that stack allocation may have been released and
the memory reused by the time the main thread gets the async message.

Instead, just unpack the varargs arguments immediately, which this PR
does by just moving the call to `readAsmConstArgs` to be first. This
this actually ends up simplifying the code - removing an ifdef on
the receiving side where we no longer need anything special.

Fixes #11350