### PR TITLE
Update sphinx to version 2.4.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -359,7 +359,7 @@ jobs:
       - checkout
       # This version is mentioned in `site/source/docs/site/about.rst`.
       # Please keep them in sync.
-      - run: pip3 install sphinx==1.7.9
+      - run: pip3 install sphinx==2.4.4
       - run: make -C site text
       - run: tests/check_emcc_help_text.py
       - run: make -C site html

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -58,19 +58,23 @@ Options that are modified or new in *emcc* are listed below:
    Like "-O1", but enables more optimizations. During link this will
    also enable various JavaScript optimizations.
 
-   Note: These JavaScript optimizations can reduce code size by
-     removing things that the compiler does not see being used, in
-     particular, parts of the runtime may be stripped if they are not
-     exported on the "Module" object. The compiler is aware of code in
-     --pre-js and --post-js, so you can safely use the runtime from
-     there. Alternatively, you can use
-     "EXTRA_EXPORTED_RUNTIME_METHODS", see src/settings.js.
+   Note:
+
+     These JavaScript optimizations can reduce code size by removing
+     things that the compiler does not see being used, in particular,
+     parts of the runtime may be stripped if they are not exported on
+     the "Module" object. The compiler is aware of code in --pre-js
+     and --post-js, so you can safely use the runtime from there.
+     Alternatively, you can use "EXTRA_EXPORTED_RUNTIME_METHODS", see
+     src/settings.js.
 
 "-O3"
    Like "-O2", but with additional optimizations that may take longer
    to run.
 
-   Note: This is a good setting for a release build.
+   Note:
+
+     This is a good setting for a release build.
 
 "-Os"
    Like "-O3", but focuses more on code size (and may make tradeoffs
@@ -80,21 +84,29 @@ Options that are modified or new in *emcc* are listed below:
    Like "-Os", but reduces code size even further, and may take longer
    to run. This can affect both wasm and JavaScript.
 
-   Note: For more tips on optimizing your code, see Optimizing Code.
+   Note:
+
+     For more tips on optimizing your code, see Optimizing Code.
 
 "-s OPTION[=VALUE]"
    Emscripten build options. For the available options, see
    src/settings.js.
 
-   Note: You can prefix boolean options with "NO_" to reverse them.
-     For example, "-s EXIT_RUNTIME=1" is the same as "-s
+   Note:
+
+     You can prefix boolean options with "NO_" to reverse them. For
+     example, "-s EXIT_RUNTIME=1" is the same as "-s
      NO_EXIT_RUNTIME=0".
 
-   Note: If no value is specifed it will default to "1".
+   Note:
 
-   Note: For options that are lists, you need quotation marks (")
-     around the list in most shells (to avoid errors being raised).
-     Two examples are shown below:
+     If no value is specifed it will default to "1".
+
+   Note:
+
+     For options that are lists, you need quotation marks (") around
+     the list in most shells (to avoid errors being raised). Two
+     examples are shown below:
 
         -s RUNTIME_LINKED_LIBS="['liblib.so']"
         -s "RUNTIME_LINKED_LIBS=['liblib.so']"
@@ -113,8 +125,10 @@ Options that are modified or new in *emcc* are listed below:
 
      * The specified file path must be absolute, not relative.
 
-   Note: Options can be specified as a single argument without a
-     space between the "-s" and option name.  e.g. "-sFOO=1".
+   Note:
+
+     Options can be specified as a single argument without a space
+     between the "-s" and option name.  e.g. "-sFOO=1".
 
 "-g"
    Preserve debug information.
@@ -139,8 +153,7 @@ Options that are modified or new in *emcc* are listed below:
 
       * "-g1": When linking, preserve whitespace in JavaScript.
 
-      * "-g2": When linking, preserve function names in compiled
-        code.
+      * "-g2": When linking, preserve function names in compiled code.
 
       * "-g3": When compiling to object files, keep debug info,
         including JS whitespace, function names, and LLVM debug info
@@ -152,8 +165,8 @@ Options that are modified or new in *emcc* are listed below:
 
         Note:
 
-          * Source maps allow you to view and debug the *C/C++
-            source code* in your browser's debugger!
+          * Source maps allow you to view and debug the *C/C++ source
+            code* in your browser's debugger!
 
           * This debugging level may make compilation significantly
             slower (this is why we only do it on "-g4").
@@ -179,7 +192,9 @@ Options that are modified or new in *emcc* are listed below:
    function names. This allows you, for example, to reconstruct
    meaningful stack traces.
 
-   Note: This is only relevant when *minifying* global names, which
+   Note:
+
+     This is only relevant when *minifying* global names, which
      happens in "-O2" and above, and when no "-g" option was specified
      to prevent minification.
 
@@ -194,10 +209,11 @@ Options that are modified or new in *emcc* are listed below:
    You normally don't need to specify this option, as "-O" with an
    optimization level will set a good value.
 
-   Note: Some options might override this flag (e.g.
-     "DEAD_FUNCTIONS", "SAFE_HEAP" and "SPLIT_MEMORY" override the
-     value with "js- opts=1"), because they depend on the js-
-     optimizer.
+   Note:
+
+     Some options might override this flag (e.g. "DEAD_FUNCTIONS",
+     "SAFE_HEAP" and "SPLIT_MEMORY" override the value with "js-
+     opts=1"), because they depend on the js-optimizer.
 
 "--llvm-opts <level>"
    Enables LLVM optimizations, relevant when we call the LLVM
@@ -227,9 +243,9 @@ Options that are modified or new in *emcc* are listed below:
 
       * "1": LLVM LTO is performed.
 
-      * "2": Combine all the bitcode and run LLVM opt on it using
-        the specified "--llvm-opts". This optimizes across modules,
-        but is not the same as normal LTO.
+      * "2": Combine all the bitcode and run LLVM opt on it using the
+        specified "--llvm-opts". This optimizes across modules, but is
+        not the same as normal LTO.
 
       * "3": Does level "2" and then level "1".
 
@@ -273,8 +289,8 @@ Options that are modified or new in *emcc* are listed below:
        "JAVA_HEAP_SIZE" in the environment (for example, to 4096m for
        4GB).
 
-     * Closure is only run if JavaScript opts are being done ("-O2"
-       or above, or "--js-opts 1").
+     * Closure is only run if JavaScript opts are being done ("-O2" or
+       above, or "--js-opts 1").
 
 "--pre-js <file>"
    Specify a file whose contents are added before the emitted code and
@@ -321,9 +337,11 @@ Options that are modified or new in *emcc* are listed below:
    then "dir/file.dat" must exist relative to the directory where you
    run *emcc*.
 
-   Note: Embedding files is much less efficient than preloading
-     them. You should only use it for small files, in small numbers.
-     Instead use "--preload-file", which emits efficient binary data.
+   Note:
+
+     Embedding files is much less efficient than preloading them. You
+     should only use it for small files, in small numbers. Instead use
+     "--preload-file", which emits efficient binary data.
 
    For more information about the "--embed-file" options, see
    Packaging Files.
@@ -338,8 +356,10 @@ Options that are modified or new in *emcc* are listed below:
    **filename.html** is the main file you are compiling to. To run
    your code, you will need both the **.html** and the **.data**.
 
-   Note: This option is similar to --embed-file, except that it is
-     only relevant when generating HTML (it uses asynchronous binary
+   Note:
+
+     This option is similar to --embed-file, except that it is only
+     relevant when generating HTML (it uses asynchronous binary
      *XHRs*), or JavaScript that will be used in a web page.
 
    *emcc* runs tools/file_packager.py to do the actual packaging of
@@ -421,8 +441,10 @@ Options that are modified or new in *emcc* are listed below:
    will also run Emscripten's internal sanity checks on the toolchain,
    etc.
 
-   Tip: "emcc -v" is a useful tool for diagnosing errors. It works
-     with or without other arguments.
+   Tip:
+
+     "emcc -v" is a useful tool for diagnosing errors. It works with
+     or without other arguments.
 
 "--cache"
    Sets the directory to use as the Emscripten cache. The Emscripten
@@ -472,8 +494,10 @@ Options that are modified or new in *emcc* are listed below:
 "--memory-init-file <on>"
    Specifies whether to emit a separate memory initialization file.
 
-      Note: Note that this is only relevant when *not* emitting
-        wasm, as wasm embeds the memory init data in the wasm binary.
+      Note:
+
+        Note that this is only relevant when *not* emitting wasm, as
+        wasm embeds the memory init data in the wasm binary.
 
    Possible "on" values are:
 
@@ -490,11 +514,15 @@ Options that are modified or new in *emcc* are listed below:
         and applied; you cannot call any C functions until it arrives.
         This is the default setting when compiling with -O2 or higher.
 
-        Note: The safest way to ensure that it is safe to call C
-          functions (the initialisation file has loaded) is to call a
-          notifier function from "main()".
+        Note:
 
-        Note: If you assign a network request to
+          The safest way to ensure that it is safe to call C functions
+          (the initialisation file has loaded) is to call a notifier
+          function from "main()".
+
+        Note:
+
+          If you assign a network request to
           "Module.memoryInitializerRequest" (before the script runs),
           then it will use that request instead of automatically
           starting a download for you. This is beneficial in that you
@@ -582,12 +610,13 @@ Options that are modified or new in *emcc* are listed below:
         -flto is used in which case it will be in LLVM bitcode
         format).
 
-      * <name> **.wasm** : WebAssembly without JavaScript support
-        code ("standalone wasm"; this enables "STANDALONE_WASM").
+      * <name> **.wasm** : WebAssembly without JavaScript support code
+        ("standalone wasm"; this enables "STANDALONE_WASM").
 
-   Note: If "--memory-init-file" is used, a **.mem** file will be
-     created in addition to the generated **.js** and/or **.html**
-     file.
+   Note:
+
+     If "--memory-init-file" is used, a **.mem** file will be created
+     in addition to the generated **.js** and/or **.html** file.
 
 "-c"
    Tells *emcc* to generate LLVM bitcode (which can then be linked

--- a/site/source/docs/site/about.rst
+++ b/site/source/docs/site/about.rst
@@ -58,7 +58,7 @@ The version of Sphinx on Ubuntu package repository (apt-get) fails when building
 
 The workaround is to use the *Python package installer* (pip) to get version 1.7.8, and then run an upgrade (note, you may have to uninstall Sphinx first): ::
 
-  pip install sphinx==1.7.9
+  pip install sphinx==2.4.4
 
 
 .. _about-site-builds:


### PR DESCRIPTION
This is that latest in the 2.X series.  Upgrading to 3.X caused
some issues with C type names so that work for a future update.