### PR TITLE
Remove --save-bc command line option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,9 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- Remove the --save-bc command line option.  This was specific to fastcomp,
-  which is deprecated, and for debugging purposes we already have EMCC_DEBUG
-  which saves all intermediante files.
+- Remove the `--save-bc` command line option.  This was specific to fastcomp,
+  which is deprecated, and for debugging purposes we already have `EMCC_DEBUG`
+  which saves all intermediate files.
 - It is now an error if a function listed in the `EXPORTED_FUNCTIONS` list is
   missing from the build (can be disabled via `-Wno-undefined`)
   (ERROR_ON_UNDEFINED_SYMBOLS and WARN_ON_UNDEFINED_SYMBOLS no longer apply

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Remove the --save-bc command line option.  This was specific to fastcomp,
+  which is deprecated, and for debugging purposes we already have EMCC_DEBUG
+  which saves all intermediante files.
 - It is now an error if a function listed in the `EXPORTED_FUNCTIONS` list is
   missing from the build (can be disabled via `-Wno-undefined`)
   (ERROR_ON_UNDEFINED_SYMBOLS and WARN_ON_UNDEFINED_SYMBOLS no longer apply

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -463,12 +463,6 @@ Options that are modified or new in *emcc* are listed below:
    Shows the list of available projects in the Emscripten Ports repos.
    After this operation is complete, this process will exit.
 
-"--save-bc PATH"
-   When compiling to JavaScript or HTML, this option will save a copy
-   of the bitcode to the specified path. The bitcode will include all
-   files being linked after link-time optimizations have been
-   performed (if any), including standard libraries.
-
 "--memory-init-file <on>"
    Specifies whether to emit a separate memory initialization file.
 

--- a/emcc.py
+++ b/emcc.py
@@ -241,7 +241,6 @@ class EmccOptions(object):
     self.cpu_profiler = False
     self.thread_profiler = False
     self.memory_profiler = False
-    self.save_bc = False
     self.memory_init_file = None
     self.use_preload_cache = False
     self.no_heap_copy = False
@@ -2488,12 +2487,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           if len(link_opts) > 0:
             final = building.llvm_opt(final, link_opts, DEFAULT_FINAL)
             save_intermediate('linktime', 'bc')
-          if options.save_bc:
-            shutil.copyfile(final, options.save_bc)
-
-        # Prepare .ll for Emscripten
-        if options.save_bc:
-          save_intermediate('ll', 'll')
 
         if shared.Settings.AUTODEBUG:
           logger.debug('autodebug')
@@ -3044,8 +3037,6 @@ def parse_args(newargs):
     elif newargs[i] == '--show-ports':
       system_libs.show_ports()
       should_exit = True
-    elif check_arg('--save-bc'):
-      options.save_bc = consume_arg()
     elif check_arg('--memory-init-file'):
       options.memory_init_file = int(consume_arg())
     elif newargs[i] == '--proxy-to-worker':

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -388,11 +388,6 @@ Options that are modified or new in *emcc* are listed below:
 ``--show-ports``
   Shows the list of available projects in the Emscripten Ports repos. After this operation is complete, this process will exit.
 
-.. _emcc-save-bc:
-
-``--save-bc PATH``
-  When compiling to JavaScript or HTML, this option will save a copy of the bitcode to the specified path. The bitcode will include all files being linked after link-time optimizations have been performed (if any), including standard libraries.
-
 .. _emcc-memory-init-file:
 
 ``--memory-init-file <on>``

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2037,17 +2037,6 @@ int f() {
       # make sure the slack is tiny compared to the whole program
       self.assertGreater(len(js), 100 * SLACK)
 
-  @no_wasm_backend('depends on bc output')
-  def test_save_bc(self):
-    cmd = [EMCC, path_from_root('tests', 'hello_world_loop_malloc.cpp'), '--save-bc', 'my_bitcode.bc']
-    run_process(cmd)
-    assert 'hello, world!' in run_js('a.out.js')
-    self.assertExists('my_bitcode.bc')
-    try_delete('a.out.js')
-    building.llvm_dis('my_bitcode.bc', 'my_ll.ll')
-    run_process([EMCC, 'my_ll.ll', '-nostdlib', '-o', 'two.js'])
-    assert 'hello, world!' in run_js('two.js')
-
   def test_js_optimizer(self):
     ACORN_PASSES = ['JSDCE', 'AJSDCE', 'applyImportAndExportNameChanges', 'emitDCEGraph', 'applyDCEGraphRemovals', 'growableHeap', 'unsignPointers', 'asanify']
     for input, expected, passes in [

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -464,7 +464,7 @@ fi
     for i in range(3):
       print(i)
       self.clear()
-      output = self.do([EMCC, '-O' + str(i), '-s', '--llvm-lto', '0', path_from_root('tests', 'hello_libcxx.cpp'), '--save-bc', 'a.bc', '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
+      output = self.do([EMCC, '-O' + str(i), '-s', '--llvm-lto', '0', path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
       print('\n\n\n', output)
       assert (BUILDING_MESSAGE.replace('X', libname) in output) == (i == 0), 'Must only build the first time'
       self.assertContained('hello, world!', run_js('a.out.js'))


### PR DESCRIPTION
This was specific to fastcomp, which is deprecated and for debugging
purposes we already have EMCC_DEBUG which saves all files.