### PR TITLE
Store cache lock inside cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@
 
 # Default emscripten cache
 /cache
-/cache.lock
 
 # Ignore only the root node_modules, but not any further down the path
 /node_modules/

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -19,7 +19,7 @@ from runner import RunnerCore, path_from_root, env_modify, chdir
 from runner import create_test_file, no_wasm_backend, ensure_dir
 from tools.shared import NODE_JS, PYTHON, EMCC, SPIDERMONKEY_ENGINE, V8_ENGINE
 from tools.shared import CONFIG_FILE, EM_CONFIG, LLVM_ROOT, CANONICAL_TEMP_DIR
-from tools.shared import run_process, try_delete, safe_ensure_dirs
+from tools.shared import run_process, try_delete
 from tools.shared import expected_llvm_version, Cache, Settings
 from tools import shared, system_libs
 
@@ -758,14 +758,14 @@ fi
     f.write('LLVM_ROOT = "' + self.in_dir('fake1', 'bin') + '"\n')
     f.close()
 
-    safe_ensure_dirs(self.in_dir('fake1', 'bin'))
+    ensure_dir(self.in_dir('fake1', 'bin'))
     f = open(self.in_dir('fake1', 'bin', 'llc'), 'w')
     f.write('#!/bin/sh\n')
     f.write('echo "llc fake1 output\nRegistered Targets:\n%s"' % 'got js backend! JavaScript (asm.js, emscripten) backend')
     f.close()
     os.chmod(self.in_dir('fake1', 'bin', 'llc'), stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC)
 
-    safe_ensure_dirs(self.in_dir('fake2', 'bin'))
+    ensure_dir(self.in_dir('fake2', 'bin'))
     f = open(self.in_dir('fake2', 'bin', 'llc'), 'w')
     f.write('#!/bin/sh\n')
     f.write('echo "llc fake2 output\nRegistered Targets:\n%s"' % 'got wasm32 backend! WebAssembly 32-bit')

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -30,9 +30,6 @@ class Cache(object):
     dirname = os.path.normpath(dirname)
     self.root_dirname = dirname
 
-    self.filelock_name = dirname.rstrip('/\\') + '.lock'
-    self.filelock = filelock.FileLock(self.filelock_name)
-
     # if relevant, use a subdir of the cache
     if use_subdir:
       if shared.Settings.WASM_BACKEND:
@@ -47,6 +44,12 @@ class Cache(object):
 
     self.dirname = dirname
     self.acquired_count = 0
+
+    # since the lock itself lives inside the cache directory we need to ensure it
+    # exists.
+    self.ensure()
+    self.filelock_name = os.path.join(dirname, 'cache.lock')
+    self.filelock = filelock.FileLock(self.filelock_name)
 
   def acquire_cache_lock(self):
     if not self.EM_EXCLUSIVE_CACHE_ACCESS and self.acquired_count == 0:
@@ -76,11 +79,7 @@ class Cache(object):
       logger.debug('PID %s released multiprocess file lock to Emscripten cache at %s' % (str(os.getpid()), self.dirname))
 
   def ensure(self):
-    self.acquire_cache_lock()
-    try:
-      shared.safe_ensure_dirs(self.dirname)
-    finally:
-      self.release_cache_lock()
+    shared.safe_ensure_dirs(self.dirname)
 
   def erase(self):
     self.acquire_cache_lock()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -651,7 +651,7 @@ def safe_ensure_dirs(dirname):
 
 
 # Temp dir. Create a random one, unless EMCC_DEBUG is set, in which case use the canonical
-# temp direcotyr (TEMP_DIR/emscripten_temp).
+# temp directory (TEMP_DIR/emscripten_temp).
 def get_emscripten_temp_dir():
   """Returns a path to EMSCRIPTEN_TEMP_DIR, creating one if it didn't exist."""
   global configuration, EMSCRIPTEN_TEMP_DIR

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -632,14 +632,14 @@ def replace_suffix(filename, new_suffix):
   return os.path.splitext(filename)[0] + new_suffix
 
 
-# In MINIMAL_RUNTIME mode, keep suffixes of generated files simple ('.mem' instead of '.js.mem'; .'symbols' instead of '.js.symbols' etc)
+# In MINIMAL_RUNTIME mode, keep suffixes of generated files simple
+# ('.mem' instead of '.js.mem'; .'symbols' instead of '.js.symbols' etc)
 # Retain the original naming scheme in traditional runtime.
 def replace_or_append_suffix(filename, new_suffix):
   assert new_suffix[0] == '.'
   return replace_suffix(filename, new_suffix) if Settings.MINIMAL_RUNTIME else filename + new_suffix
 
 
-# Temp dir. Create a random one, unless EMCC_DEBUG is set, in which case use TEMP_DIR/emscripten_temp
 def safe_ensure_dirs(dirname):
   try:
     os.makedirs(dirname)
@@ -650,8 +650,10 @@ def safe_ensure_dirs(dirname):
       raise
 
 
-# Returns a path to EMSCRIPTEN_TEMP_DIR, creating one if it didn't exist.
+# Temp dir. Create a random one, unless EMCC_DEBUG is set, in which case use the canonical
+# temp direcotyr (TEMP_DIR/emscripten_temp).
 def get_emscripten_temp_dir():
+  """Returns a path to EMSCRIPTEN_TEMP_DIR, creating one if it didn't exist."""
   global configuration, EMSCRIPTEN_TEMP_DIR
   if not EMSCRIPTEN_TEMP_DIR:
     EMSCRIPTEN_TEMP_DIR = tempfile.mkdtemp(prefix='emscripten_temp_', dir=configuration.TEMP_DIR)


### PR DESCRIPTION
In the case of root install it is useful to be able to allow write
access only to cache directory.  By keeping the lock inside the
directory we avoid needing write access to that parent directory.

See: #535