### PR TITLE
Add compiler-rt sanitizer includes from upstream llvm

### DIFF
--- a/system/lib/compiler-rt/include/sanitizer/allocator_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/allocator_interface.h
@@ -1,0 +1,88 @@
+//===-- allocator_interface.h ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Public interface header for allocator used in sanitizers (ASan/TSan/MSan).
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_ALLOCATOR_INTERFACE_H
+#define SANITIZER_ALLOCATOR_INTERFACE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  /* Returns the estimated number of bytes that will be reserved by allocator
+     for request of "size" bytes. If allocator can't allocate that much
+     memory, returns the maximal possible allocation size, otherwise returns
+     "size". */
+  size_t __sanitizer_get_estimated_allocated_size(size_t size);
+
+  /* Returns true if p was returned by the allocator and
+     is not yet freed. */
+  int __sanitizer_get_ownership(const volatile void *p);
+
+  /* Returns the number of bytes reserved for the pointer p.
+     Requires (get_ownership(p) == true) or (p == 0). */
+  size_t __sanitizer_get_allocated_size(const volatile void *p);
+
+  /* Number of bytes, allocated and not yet freed by the application. */
+  size_t __sanitizer_get_current_allocated_bytes(void);
+
+  /* Number of bytes, mmaped by the allocator to fulfill allocation requests.
+     Generally, for request of X bytes, allocator can reserve and add to free
+     lists a large number of chunks of size X to use them for future requests.
+     All these chunks count toward the heap size. Currently, allocator never
+     releases memory to OS (instead, it just puts freed chunks to free
+     lists). */
+  size_t __sanitizer_get_heap_size(void);
+
+  /* Number of bytes, mmaped by the allocator, which can be used to fulfill
+     allocation requests. When a user program frees memory chunk, it can first
+     fall into quarantine and will count toward __sanitizer_get_free_bytes()
+     later. */
+  size_t __sanitizer_get_free_bytes(void);
+
+  /* Number of bytes in unmapped pages, that are released to OS. Currently,
+     always returns 0. */
+  size_t __sanitizer_get_unmapped_bytes(void);
+
+  /* Malloc hooks that may be optionally provided by user.
+     __sanitizer_malloc_hook(ptr, size) is called immediately after
+       allocation of "size" bytes, which returned "ptr".
+     __sanitizer_free_hook(ptr) is called immediately before
+       deallocation of "ptr". */
+  void __sanitizer_malloc_hook(const volatile void *ptr, size_t size);
+  void __sanitizer_free_hook(const volatile void *ptr);
+
+  /* Installs a pair of hooks for malloc/free.
+     Several (currently, 5) hook pairs may be installed, they are executed
+     in the order they were installed and after calling
+     __sanitizer_malloc_hook/__sanitizer_free_hook.
+     Unlike __sanitizer_malloc_hook/__sanitizer_free_hook these hooks can be
+     chained and do not rely on weak symbols working on the platform, but
+     require __sanitizer_install_malloc_and_free_hooks to be called at startup
+     and thus will not be called on malloc/free very early in the process.
+     Returns the number of hooks currently installed or 0 on failure.
+     Not thread-safe, should be called in the main thread before starting
+     other threads.
+  */
+  int __sanitizer_install_malloc_and_free_hooks(
+      void (*malloc_hook)(const volatile void *, size_t),
+      void (*free_hook)(const volatile void *));
+
+  /* Drains allocator quarantines (calling thread's and global ones), returns
+     freed memory back to OS and releases other non-essential internal allocator
+     resources in attempt to reduce process RSS.
+     Currently available with ASan only.
+  */
+  void __sanitizer_purge_allocator(void);
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif

--- a/system/lib/compiler-rt/include/sanitizer/asan_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/asan_interface.h
@@ -1,0 +1,322 @@
+//===-- sanitizer/asan_interface.h ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of AddressSanitizer (ASan).
+//
+// Public interface header.
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_ASAN_INTERFACE_H
+#define SANITIZER_ASAN_INTERFACE_H
+
+#include <sanitizer/common_interface_defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/// Marks a memory region (<c>[addr, addr+size)</c>) as unaddressable.
+///
+/// This memory must be previously allocated by your program. Instrumented
+/// code is forbidden from accessing addresses in this region until it is
+/// unpoisoned. This function is not guaranteed to poison the entire region -
+/// it could poison only a subregion of <c>[addr, addr+size)</c> due to ASan
+/// alignment restrictions.
+///
+/// \note This function is not thread-safe because no two threads can poison or
+/// unpoison memory in the same memory region simultaneously.
+///
+/// \param addr Start of memory region.
+/// \param size Size of memory region.
+void __asan_poison_memory_region(void const volatile *addr, size_t size);
+
+/// Marks a memory region (<c>[addr, addr+size)</c>) as addressable.
+///
+/// This memory must be previously allocated by your program. Accessing
+/// addresses in this region is allowed until this region is poisoned again.
+/// This function could unpoison a super-region of <c>[addr, addr+size)</c> due
+/// to ASan alignment restrictions.
+///
+/// \note This function is not thread-safe because no two threads can
+/// poison or unpoison memory in the same memory region simultaneously.
+///
+/// \param addr Start of memory region.
+/// \param size Size of memory region.
+void __asan_unpoison_memory_region(void const volatile *addr, size_t size);
+
+// Macros provided for convenience.
+#if __has_feature(address_sanitizer) || defined(__SANITIZE_ADDRESS__)
+/// Marks a memory region as unaddressable.
+///
+/// \note Macro provided for convenience; defined as a no-op if ASan is not
+/// enabled.
+///
+/// \param addr Start of memory region.
+/// \param size Size of memory region.
+#define ASAN_POISON_MEMORY_REGION(addr, size) \
+  __asan_poison_memory_region((addr), (size))
+
+/// Marks a memory region as addressable.
+///
+/// \note Macro provided for convenience; defined as a no-op if ASan is not
+/// enabled.
+///
+/// \param addr Start of memory region.
+/// \param size Size of memory region.
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+  __asan_unpoison_memory_region((addr), (size))
+#else
+#define ASAN_POISON_MEMORY_REGION(addr, size) \
+  ((void)(addr), (void)(size))
+#define ASAN_UNPOISON_MEMORY_REGION(addr, size) \
+  ((void)(addr), (void)(size))
+#endif
+
+/// Checks if an address is poisoned.
+///
+/// Returns 1 if <c><i>addr</i></c> is poisoned (that is, 1-byte read/write
+/// access to this address would result in an error report from ASan).
+/// Otherwise returns 0.
+///
+/// \param addr Address to check.
+///
+/// \retval 1 Address is poisoned.
+/// \retval 0 Address is not poisoned.
+int __asan_address_is_poisoned(void const volatile *addr);
+
+/// Checks if a region is poisoned.
+///
+/// If at least one byte in <c>[beg, beg+size)</c> is poisoned, returns the
+/// address of the first such byte. Otherwise returns 0.
+///
+/// \param beg Start of memory region.
+/// \param size Start of memory region.
+/// \returns Address of first poisoned byte.
+void *__asan_region_is_poisoned(void *beg, size_t size);
+
+/// Describes an address (useful for calling from the debugger).
+///
+/// Prints the description of <c><i>addr</i></c>.
+///
+/// \param addr Address to describe.
+void __asan_describe_address(void *addr);
+
+/// Checks if an error has been or is being reported (useful for calling from
+/// the debugger to get information about an ASan error).
+///
+/// Returns 1 if an error has been (or is being) reported. Otherwise returns 0.
+///
+/// \returns 1 if an error has been (or is being) reported. Otherwise returns
+/// 0.
+int __asan_report_present(void);
+
+/// Gets the PC (program counter) register value of an ASan error (useful for
+/// calling from the debugger).
+///
+/// Returns PC if an error has been (or is being) reported.
+/// Otherwise returns 0.
+///
+/// \returns PC value.
+void *__asan_get_report_pc(void);
+
+/// Gets the BP (base pointer) register value of an ASan error (useful for
+/// calling from the debugger).
+///
+/// Returns BP if an error has been (or is being) reported.
+/// Otherwise returns 0.
+///
+/// \returns BP value.
+void *__asan_get_report_bp(void);
+
+/// Gets the SP (stack pointer) register value of an ASan error (useful for
+/// calling from the debugger).
+///
+/// If an error has been (or is being) reported, returns SP.
+/// Otherwise returns 0.
+///
+/// \returns SP value.
+void *__asan_get_report_sp(void);
+
+/// Gets the address of the report buffer of an ASan error (useful for calling
+/// from the debugger).
+///
+/// Returns the address of the report buffer if an error has been (or is being)
+/// reported. Otherwise returns 0.
+///
+/// \returns Address of report buffer.
+void *__asan_get_report_address(void);
+
+/// Gets access type of an ASan error (useful for calling from the debugger).
+///
+/// Returns access type (read or write) if an error has been (or is being)
+/// reported. Otherwise returns 0.
+///
+/// \returns Access type (0 = read, 1 = write).
+int __asan_get_report_access_type(void);
+
+/// Gets access size of an ASan error (useful for calling from the debugger).
+///
+/// Returns access size if an error has been (or is being) reported. Otherwise
+/// returns 0.
+///
+/// \returns Access size in bytes.
+size_t __asan_get_report_access_size(void);
+
+/// Gets the bug description of an ASan error (useful for calling from a
+/// debugger).
+///
+/// \returns Returns a bug description if an error has been (or is being)
+/// reported - for example, "heap-use-after-free". Otherwise returns an empty
+/// string.
+const char *__asan_get_report_description(void);
+
+/// Gets information about a pointer (useful for calling from the debugger).
+///
+/// Returns the category of the given pointer as a constant string.
+/// Possible return values are <c>global</c>, <c>stack</c>, <c>stack-fake</c>,
+/// <c>heap</c>, <c>heap-invalid</c>, <c>shadow-low</c>, <c>shadow-gap</c>,
+/// <c>shadow-high</c>, and <c>unknown</c>.
+///
+/// If the return value is <c>global</c> or <c>stack</c>, tries to also return
+/// the variable name, address, and size. If the return value is <c>heap</c>,
+/// tries to return the chunk address and size. <c><i>name</i></c> should point
+/// to an allocated buffer of size <c><i>name_size</i></c>.
+///
+/// \param addr Address to locate.
+/// \param name Buffer to store the variable's name.
+/// \param name_size Size in bytes of the variable's name buffer.
+/// \param region_address [out] Address of the region.
+/// \param region_size [out] Size of the region in bytes.
+///
+/// \returns Returns the category of the given pointer as a constant string.
+const char *__asan_locate_address(void *addr, char *name, size_t name_size,
+                                  void **region_address, size_t *region_size);
+
+/// Gets the allocation stack trace and thread ID for a heap address (useful
+/// for calling from the debugger).
+///
+/// Stores up to <c><i>size</i></c> frames in <c><i>trace</i></c>. Returns
+/// the number of stored frames or 0 on error.
+///
+/// \param addr A heap address.
+/// \param trace A buffer to store the stack trace.
+/// \param size Size in bytes of the trace buffer.
+/// \param thread_id [out] The thread ID of the address.
+///
+/// \returns Returns the number of stored frames or 0 on error.
+size_t __asan_get_alloc_stack(void *addr, void **trace, size_t size,
+                              int *thread_id);
+
+/// Gets the free stack trace and thread ID for a heap address (useful for
+/// calling from the debugger).
+///
+/// Stores up to <c><i>size</i></c> frames in <c><i>trace</i></c>. Returns
+/// the number of stored frames or 0 on error.
+///
+/// \param addr A heap address.
+/// \param trace A buffer to store the stack trace.
+/// \param size Size in bytes of the trace buffer.
+/// \param thread_id [out] The thread ID of the address.
+///
+/// \returns Returns the number of stored frames or 0 on error.
+size_t __asan_get_free_stack(void *addr, void **trace, size_t size,
+                             int *thread_id);
+
+/// Gets the current shadow memory mapping (useful for calling from the
+/// debugger).
+///
+/// \param shadow_scale [out] Shadow scale value.
+/// \param shadow_offset [out] Offset value.
+void __asan_get_shadow_mapping(size_t *shadow_scale, size_t *shadow_offset);
+
+/// This is an internal function that is called to report an error. However,
+/// it is still a part of the interface because you might want to set a
+/// breakpoint on this function in the debugger.
+///
+/// \param pc <c><i>pc</i></c> value of the ASan error.
+/// \param bp <c><i>bp</i></c> value of the ASan error.
+/// \param sp <c><i>sp</i></c> value of the ASan error.
+/// \param addr Address of the ASan error.
+/// \param is_write True if the error is a write error; false otherwise.
+/// \param access_size Size of the memory access of the ASan error.
+void __asan_report_error(void *pc, void *bp, void *sp,
+                         void *addr, int is_write, size_t access_size);
+
+// Deprecated. Call __sanitizer_set_death_callback instead.
+void __asan_set_death_callback(void (*callback)(void));
+
+/// Sets the callback function to be called during ASan error reporting.
+///
+/// The callback provides a string pointer to the report.
+///
+/// \param callback User-provided function.
+void __asan_set_error_report_callback(void (*callback)(const char *));
+
+/// User-provided callback on ASan errors.
+///
+/// You can provide a function that would be called immediately when ASan
+/// detects an error. This is useful in cases when ASan detects an error but
+/// your program crashes before the ASan report is printed.
+void __asan_on_error(void);
+
+/// Prints accumulated statistics to <c>stderr</c> (useful for calling from the
+/// debugger).
+void __asan_print_accumulated_stats(void);
+
+/// User-provided default option settings.
+///
+/// You can provide your own implementation of this function to return a string
+/// containing ASan runtime options (for example,
+/// <c>verbosity=1:halt_on_error=0</c>).
+///
+/// \returns Default options string.
+const char* __asan_default_options(void);
+
+// The following two functions facilitate garbage collection in presence of
+// ASan's fake stack.
+
+/// Gets an opaque handler to the current thread's fake stack.
+///
+/// Returns an opaque handler to be used by
+/// <c>__asan_addr_is_in_fake_stack()</c>. Returns NULL if the current thread
+/// does not have a fake stack.
+///
+/// \returns An opaque handler to the fake stack or NULL.
+void *__asan_get_current_fake_stack(void);
+
+/// Checks if an address belongs to a given fake stack.
+///
+/// If <c><i>fake_stack</i></c> is non-NULL and <c><i>addr</i></c> belongs to a
+/// fake frame in <c><i>fake_stack</i></c>, returns the address of the real
+/// stack that corresponds to the fake frame and sets <c><i>beg</i></c> and
+/// <c><i>end</i></c> to the boundaries of this fake frame. Otherwise returns
+/// NULL and does not touch <c><i>beg</i></c> and <c><i>end</i></c>.
+///
+/// If <c><i>beg</i></c> or <c><i>end</i></c> are NULL, they are not touched.
+///
+/// \note This function can be called from a thread other than the owner of
+/// <c><i>fake_stack</i></c>, but the owner thread needs to be alive.
+///
+/// \param fake_stack An opaque handler to a fake stack.
+/// \param addr Address to test.
+/// \param beg [out] Beginning of fake frame.
+/// \param end [out] End of fake frame.
+/// \returns Stack address or NULL.
+void *__asan_addr_is_in_fake_stack(void *fake_stack, void *addr, void **beg,
+                                   void **end);
+
+/// Performs shadow memory cleanup of the current thread's stack before a
+/// function marked with the <c>[[noreturn]]</c> attribute is called.
+///
+/// To avoid false positives on the stack, must be called before no-return
+/// functions like <c>_exit()</c> and <c>execl()</c>.
+void __asan_handle_no_return(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SANITIZER_ASAN_INTERFACE_H

--- a/system/lib/compiler-rt/include/sanitizer/common_interface_defs.h
+++ b/system/lib/compiler-rt/include/sanitizer/common_interface_defs.h
@@ -1,0 +1,354 @@
+//===-- sanitizer/common_interface_defs.h -----------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Common part of the public sanitizer interface.
+//===----------------------------------------------------------------------===//
+
+#ifndef SANITIZER_COMMON_INTERFACE_DEFS_H
+#define SANITIZER_COMMON_INTERFACE_DEFS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+// GCC does not understand __has_feature.
+#if !defined(__has_feature)
+#define __has_feature(x) 0
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+// Arguments for __sanitizer_sandbox_on_notify() below.
+typedef struct {
+  // Enable sandbox support in sanitizer coverage.
+  int coverage_sandboxed;
+  // File descriptor to write coverage data to. If -1 is passed, a file will
+  // be pre-opened by __sanitizer_sandobx_on_notify(). This field has no
+  // effect if coverage_sandboxed == 0.
+  intptr_t coverage_fd;
+  // If non-zero, split the coverage data into well-formed blocks. This is
+  // useful when coverage_fd is a socket descriptor. Each block will contain
+  // a header, allowing data from multiple processes to be sent over the same
+  // socket.
+  unsigned int coverage_max_block_size;
+} __sanitizer_sandbox_arguments;
+
+// Tell the tools to write their reports to "path.<pid>" instead of stderr.
+void __sanitizer_set_report_path(const char *path);
+// Tell the tools to write their reports to the provided file descriptor
+// (casted to void *).
+void __sanitizer_set_report_fd(void *fd);
+
+// Notify the tools that the sandbox is going to be turned on. The reserved
+// parameter will be used in the future to hold a structure with functions
+// that the tools may call to bypass the sandbox.
+void __sanitizer_sandbox_on_notify(__sanitizer_sandbox_arguments *args);
+
+// This function is called by the tool when it has just finished reporting
+// an error. 'error_summary' is a one-line string that summarizes
+// the error message. This function can be overridden by the client.
+void __sanitizer_report_error_summary(const char *error_summary);
+
+// Some of the sanitizers (for example ASan/TSan) could miss bugs that happen
+// in unaligned loads/stores. To find such bugs reliably, you need to replace
+// plain unaligned loads/stores with these calls.
+
+/// Loads a 16-bit unaligned value.
+///
+/// \param p Pointer to unaligned memory.
+///
+/// \returns Loaded value.
+uint16_t __sanitizer_unaligned_load16(const void *p);
+
+/// Loads a 32-bit unaligned value.
+///
+/// \param p Pointer to unaligned memory.
+///
+/// \returns Loaded value.
+uint32_t __sanitizer_unaligned_load32(const void *p);
+
+/// Loads a 64-bit unaligned value.
+///
+/// \param p Pointer to unaligned memory.
+///
+/// \returns Loaded value.
+uint64_t __sanitizer_unaligned_load64(const void *p);
+
+/// Stores a 16-bit unaligned value.
+///
+/// \param p Pointer to unaligned memory.
+/// \param x 16-bit value to store.
+void __sanitizer_unaligned_store16(void *p, uint16_t x);
+
+/// Stores a 32-bit unaligned value.
+///
+/// \param p Pointer to unaligned memory.
+/// \param x 32-bit value to store.
+void __sanitizer_unaligned_store32(void *p, uint32_t x);
+
+/// Stores a 64-bit unaligned value.
+///
+/// \param p Pointer to unaligned memory.
+/// \param x 64-bit value to store.
+void __sanitizer_unaligned_store64(void *p, uint64_t x);
+
+// Returns 1 on the first call, then returns 0 thereafter.  Called by the tool
+// to ensure only one report is printed when multiple errors occur
+// simultaneously.
+int __sanitizer_acquire_crash_state();
+
+/// Annotates the current state of a contiguous container, such as
+/// <c>std::vector</c>, <c>std::string</c>, or similar.
+///
+/// A contiguous container is a container that keeps all of its elements
+/// in a contiguous region of memory. The container owns the region of memory
+/// <c>[beg, end)</c>; the memory <c>[beg, mid)</c> is used to store the
+/// current elements, and the memory <c>[mid, end)</c> is reserved for future
+/// elements (<c>beg <= mid <= end</c>). For example, in
+/// <c>std::vector<> v</c>:
+///
+/// \code
+///   beg = &v[0];
+///   end = beg + v.capacity() * sizeof(v[0]);
+///   mid = beg + v.size()     * sizeof(v[0]);
+/// \endcode
+///
+/// This annotation tells the Sanitizer tool about the current state of the
+/// container so that the tool can report errors when memory from
+/// <c>[mid, end)</c> is accessed. Insert this annotation into methods like
+/// <c>push_back()</c> or <c>pop_back()</c>. Supply the old and new values of
+/// <c>mid</c>(<c><i>old_mid</i></c> and <c><i>new_mid</i></c>). In the initial
+/// state <c>mid == end</c>, so that should be the final state when the
+/// container is destroyed or when the container reallocates the storage.
+///
+/// For ASan, <c><i>beg</i></c> should be 8-aligned and <c><i>end</i></c>
+/// should be either 8-aligned or it should point to the end of a separate
+/// heap-, stack-, or global-allocated buffer. So the following example will
+/// not work:
+///
+/// \code
+///   int64_t x[2]; // 16 bytes, 8-aligned
+///   char *beg = (char *)&x[0];
+///   char *end = beg + 12; // Not 8-aligned, not the end of the buffer
+/// \endcode
+///
+/// The following, however, will work:
+/// \code
+///   int32_t x[3]; // 12 bytes, but 8-aligned under ASan.
+///   char *beg = (char*)&x[0];
+///   char *end = beg + 12; // Not 8-aligned, but is the end of the buffer
+/// \endcode
+///
+/// \note  Use this function with caution and do not use for anything other
+/// than vector-like classes.
+///
+/// \param beg Beginning of memory region.
+/// \param end End of memory region.
+/// \param old_mid Old middle of memory region.
+/// \param new_mid New middle of memory region.
+void __sanitizer_annotate_contiguous_container(const void *beg,
+                                               const void *end,
+                                               const void *old_mid,
+                                               const void *new_mid);
+
+/// Returns true if the contiguous container <c>[beg, end)</c> is properly
+/// poisoned.
+///
+/// Proper poisoning could occur, for example, with
+/// <c>__sanitizer_annotate_contiguous_container</c>), that is, if
+/// <c>[beg, mid)</c> is addressable and <c>[mid, end)</c> is unaddressable.
+/// Full verification requires O (<c>end - beg</c>) time; this function tries
+/// to avoid such complexity by touching only parts of the container around
+/// <c><i>beg</i></c>, <c><i>mid</i></c>, and <c><i>end</i></c>.
+///
+/// \param beg Beginning of memory region.
+/// \param mid Middle of memory region.
+/// \param end Old end of memory region.
+///
+/// \returns True if the contiguous container <c>[beg, end)</c> is properly
+///  poisoned.
+int __sanitizer_verify_contiguous_container(const void *beg, const void *mid,
+                                            const void *end);
+
+/// Similar to <c>__sanitizer_verify_contiguous_container()</c> but also
+/// returns the address of the first improperly poisoned byte.
+///
+/// Returns NULL if the area is poisoned properly.
+///
+/// \param beg Beginning of memory region.
+/// \param mid Middle of memory region.
+/// \param end Old end of memory region.
+///
+/// \returns The bad address or NULL.
+const void *__sanitizer_contiguous_container_find_bad_address(const void *beg,
+                                                              const void *mid,
+                                                              const void *end);
+
+/// Prints the stack trace leading to this call (useful for calling from the
+/// debugger).
+void __sanitizer_print_stack_trace(void);
+
+// Symbolizes the supplied 'pc' using the format string 'fmt'.
+// Outputs at most 'out_buf_size' bytes into 'out_buf'.
+// If 'out_buf' is not empty then output is zero or more non empty C strings
+// followed by single empty C string. Multiple strings can be returned if PC
+// corresponds to inlined function. Inlined frames are printed in the order
+// from "most-inlined" to the "least-inlined", so the last frame should be the
+// not inlined function.
+// Inlined frames can be removed with 'symbolize_inline_frames=0'.
+// The format syntax is described in
+// lib/sanitizer_common/sanitizer_stacktrace_printer.h.
+void __sanitizer_symbolize_pc(void *pc, const char *fmt, char *out_buf,
+                              size_t out_buf_size);
+// Same as __sanitizer_symbolize_pc, but for data section (i.e. globals).
+void __sanitizer_symbolize_global(void *data_ptr, const char *fmt,
+                                  char *out_buf, size_t out_buf_size);
+
+/// Sets the callback to be called immediately before death on error.
+///
+/// Passing 0 will unset the callback.
+///
+/// \param callback User-provided callback.
+void __sanitizer_set_death_callback(void (*callback)(void));
+
+
+// Interceptor hooks.
+// Whenever a libc function interceptor is called, it checks if the
+// corresponding weak hook is defined, and calls it if it is indeed defined.
+// The primary use-case is data-flow-guided fuzzing, where the fuzzer needs
+// to know what is being passed to libc functions (for example memcmp).
+// FIXME: implement more hooks.
+
+/// Interceptor hook for <c>memcmp()</c>.
+///
+/// \param called_pc PC (program counter) address of the original call.
+/// \param s1 Pointer to block of memory.
+/// \param s2 Pointer to block of memory.
+/// \param n Number of bytes to compare.
+/// \param result Value returned by the intercepted function.
+void __sanitizer_weak_hook_memcmp(void *called_pc, const void *s1,
+                                  const void *s2, size_t n, int result);
+
+/// Interceptor hook for <c>strncmp()</c>.
+///
+/// \param called_pc PC (program counter) address of the original call.
+/// \param s1 Pointer to block of memory.
+/// \param s2 Pointer to block of memory.
+/// \param n Number of bytes to compare.
+/// \param result Value returned by the intercepted function.
+void __sanitizer_weak_hook_strncmp(void *called_pc, const char *s1,
+                                  const char *s2, size_t n, int result);
+
+/// Interceptor hook for <c>strncasecmp()</c>.
+///
+/// \param called_pc PC (program counter) address of the original call.
+/// \param s1 Pointer to block of memory.
+/// \param s2 Pointer to block of memory.
+/// \param n Number of bytes to compare.
+/// \param result Value returned by the intercepted function.
+void __sanitizer_weak_hook_strncasecmp(void *called_pc, const char *s1,
+                                       const char *s2, size_t n, int result);
+
+/// Interceptor hook for <c>strcmp()</c>.
+///
+/// \param called_pc PC (program counter) address of the original call.
+/// \param s1 Pointer to block of memory.
+/// \param s2 Pointer to block of memory.
+/// \param result Value returned by the intercepted function.
+void __sanitizer_weak_hook_strcmp(void *called_pc, const char *s1,
+                                  const char *s2, int result);
+
+/// Interceptor hook for <c>strcasecmp()</c>.
+///
+/// \param called_pc PC (program counter) address of the original call.
+/// \param s1 Pointer to block of memory.
+/// \param s2 Pointer to block of memory.
+/// \param result Value returned by the intercepted function.
+void __sanitizer_weak_hook_strcasecmp(void *called_pc, const char *s1,
+                                      const char *s2, int result);
+
+/// Interceptor hook for <c>strstr()</c>.
+///
+/// \param called_pc PC (program counter) address of the original call.
+/// \param s1 Pointer to block of memory.
+/// \param s2 Pointer to block of memory.
+/// \param result Value returned by the intercepted function.
+void __sanitizer_weak_hook_strstr(void *called_pc, const char *s1,
+                                  const char *s2, char *result);
+
+void __sanitizer_weak_hook_strcasestr(void *called_pc, const char *s1,
+                                      const char *s2, char *result);
+
+void __sanitizer_weak_hook_memmem(void *called_pc,
+                                  const void *s1, size_t len1,
+                                  const void *s2, size_t len2, void *result);
+
+// Prints stack traces for all live heap allocations ordered by total
+// allocation size until top_percent of total live heap is shown. top_percent
+// should be between 1 and 100. At most max_number_of_contexts contexts
+// (stack traces) are printed.
+// Experimental feature currently available only with ASan on Linux/x86_64.
+void __sanitizer_print_memory_profile(size_t top_percent,
+                                      size_t max_number_of_contexts);
+
+/// Notify ASan that a fiber switch has started (required only if implementing
+/// your own fiber library).
+///
+/// Before switching to a different stack, you must call
+/// <c>__sanitizer_start_switch_fiber()</c> with a pointer to the bottom of the
+/// destination stack and with its size. When code starts running on the new
+/// stack, it must call <c>__sanitizer_finish_switch_fiber()</c> to finalize
+/// the switch. The <c>__sanitizer_start_switch_fiber()</c> function takes a
+/// <c>void**</c> pointer argument to store the current fake stack if there is
+/// one (it is necessary when the runtime option
+/// <c>detect_stack_use_after_return</c> is enabled).
+///
+/// When restoring a stack, this <c>void**</c> pointer must be given to the
+/// <c>__sanitizer_finish_switch_fiber()</c> function. In most cases, this
+/// pointer can be stored on the stack immediately before switching. When
+/// leaving a fiber definitely, NULL must be passed as the first argument to
+/// the <c>__sanitizer_start_switch_fiber()</c> function so that the fake stack
+/// is destroyed. If your program does not need stack use-after-return
+/// detection, you can always pass NULL to these two functions.
+///
+/// \note The fake stack mechanism is disabled during fiber switch, so if a
+/// signal callback runs during the switch, it will not benefit from stack
+/// use-after-return detection.
+///
+/// \param fake_stack_save [out] Fake stack save location.
+/// \param bottom Bottom address of stack.
+/// \param size Size of stack in bytes.
+void __sanitizer_start_switch_fiber(void **fake_stack_save,
+                                    const void *bottom, size_t size);
+
+/// Notify ASan that a fiber switch has completed (required only if
+/// implementing your own fiber library).
+///
+/// When code starts running on the new stack, it must call
+/// <c>__sanitizer_finish_switch_fiber()</c> to finalize
+/// the switch. For usage details, see the description of
+/// <c>__sanitizer_start_switch_fiber()</c>.
+///
+/// \param fake_stack_save Fake stack save location.
+/// \param bottom_old [out] Bottom address of old stack.
+/// \param size_old [out] Size of old stack in bytes.
+void __sanitizer_finish_switch_fiber(void *fake_stack_save,
+                                     const void **bottom_old,
+                                     size_t *size_old);
+
+// Get full module name and calculate pc offset within it.
+// Returns 1 if pc belongs to some module, 0 if module was not found.
+int __sanitizer_get_module_and_offset_for_pc(void *pc, char *module_path,
+                                             size_t module_path_len,
+                                             void **pc_offset);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SANITIZER_COMMON_INTERFACE_DEFS_H

--- a/system/lib/compiler-rt/include/sanitizer/coverage_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/coverage_interface.h
@@ -1,0 +1,35 @@
+//===-- sanitizer/coverage_interface.h --------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Public interface for sanitizer coverage.
+//===----------------------------------------------------------------------===//
+
+#ifndef SANITIZER_COVERAG_INTERFACE_H
+#define SANITIZER_COVERAG_INTERFACE_H
+
+#include <sanitizer/common_interface_defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+  // Record and dump coverage info.
+  void __sanitizer_cov_dump(void);
+
+  // Clear collected coverage info.
+  void __sanitizer_cov_reset(void);
+
+  // Dump collected coverage info. Sorts pcs by module into individual .sancov
+  // files.
+  void __sanitizer_dump_coverage(const uintptr_t *pcs, uintptr_t len);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SANITIZER_COVERAG_INTERFACE_H

--- a/system/lib/compiler-rt/include/sanitizer/dfsan_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/dfsan_interface.h
@@ -1,0 +1,121 @@
+//===-- dfsan_interface.h -------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of DataFlowSanitizer.
+//
+// Public interface header.
+//===----------------------------------------------------------------------===//
+#ifndef DFSAN_INTERFACE_H
+#define DFSAN_INTERFACE_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <sanitizer/common_interface_defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint16_t dfsan_label;
+
+/// Stores information associated with a specific label identifier.  A label
+/// may be a base label created using dfsan_create_label, with associated
+/// text description and user data, or an automatically created union label,
+/// which represents the union of two label identifiers (which may themselves
+/// be base or union labels).
+struct dfsan_label_info {
+  // Fields for union labels, set to 0 for base labels.
+  dfsan_label l1;
+  dfsan_label l2;
+
+  // Fields for base labels.
+  const char *desc;
+  void *userdata;
+};
+
+/// Signature of the callback argument to dfsan_set_write_callback().
+typedef void (*dfsan_write_callback_t)(int fd, const void *buf, size_t count);
+
+/// Computes the union of \c l1 and \c l2, possibly creating a union label in
+/// the process.
+dfsan_label dfsan_union(dfsan_label l1, dfsan_label l2);
+
+/// Creates and returns a base label with the given description and user data.
+dfsan_label dfsan_create_label(const char *desc, void *userdata);
+
+/// Sets the label for each address in [addr,addr+size) to \c label.
+void dfsan_set_label(dfsan_label label, void *addr, size_t size);
+
+/// Sets the label for each address in [addr,addr+size) to the union of the
+/// current label for that address and \c label.
+void dfsan_add_label(dfsan_label label, void *addr, size_t size);
+
+/// Retrieves the label associated with the given data.
+///
+/// The type of 'data' is arbitrary.  The function accepts a value of any type,
+/// which can be truncated or extended (implicitly or explicitly) as necessary.
+/// The truncation/extension operations will preserve the label of the original
+/// value.
+dfsan_label dfsan_get_label(long data);
+
+/// Retrieves the label associated with the data at the given address.
+dfsan_label dfsan_read_label(const void *addr, size_t size);
+
+/// Retrieves a pointer to the dfsan_label_info struct for the given label.
+const struct dfsan_label_info *dfsan_get_label_info(dfsan_label label);
+
+/// Returns whether the given label label contains the label elem.
+int dfsan_has_label(dfsan_label label, dfsan_label elem);
+
+/// If the given label label contains a label with the description desc, returns
+/// that label, else returns 0.
+dfsan_label dfsan_has_label_with_desc(dfsan_label label, const char *desc);
+
+/// Returns the number of labels allocated.
+size_t dfsan_get_label_count(void);
+
+/// Flushes the DFSan shadow, i.e. forgets about all labels currently associated
+/// with the application memory. Will work only if there are no other
+/// threads executing DFSan-instrumented code concurrently.
+/// Use this call to start over the taint tracking within the same procces.
+void dfsan_flush(void);
+
+/// Sets a callback to be invoked on calls to write().  The callback is invoked
+/// before the write is done.  The write is not guaranteed to succeed when the
+/// callback executes.  Pass in NULL to remove any callback.
+void dfsan_set_write_callback(dfsan_write_callback_t labeled_write_callback);
+
+/// Writes the labels currently used by the program to the given file
+/// descriptor. The lines of the output have the following format:
+///
+/// <label> <parent label 1> <parent label 2> <label description if any>
+void dfsan_dump_labels(int fd);
+
+/// Interceptor hooks.
+/// Whenever a dfsan's custom function is called the corresponding
+/// hook is called it non-zero. The hooks should be defined by the user.
+/// The primary use case is taint-guided fuzzing, where the fuzzer
+/// needs to see the parameters of the function and the labels.
+/// FIXME: implement more hooks.
+void dfsan_weak_hook_memcmp(void *caller_pc, const void *s1, const void *s2,
+                            size_t n, dfsan_label s1_label,
+                            dfsan_label s2_label, dfsan_label n_label);
+void dfsan_weak_hook_strncmp(void *caller_pc, const char *s1, const char *s2,
+                             size_t n, dfsan_label s1_label,
+                             dfsan_label s2_label, dfsan_label n_label);
+#ifdef __cplusplus
+}  // extern "C"
+
+template <typename T>
+void dfsan_set_label(dfsan_label label, T &data) {  // NOLINT
+  dfsan_set_label(label, (void *)&data, sizeof(T));
+}
+
+#endif
+
+#endif  // DFSAN_INTERFACE_H

--- a/system/lib/compiler-rt/include/sanitizer/hwasan_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/hwasan_interface.h
@@ -1,0 +1,96 @@
+//===-- sanitizer/asan_interface.h ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of HWAddressSanitizer.
+//
+// Public interface header.
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_HWASAN_INTERFACE_H
+#define SANITIZER_HWASAN_INTERFACE_H
+
+#include <sanitizer/common_interface_defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  // Libc hook for program startup in statically linked executables.
+  // Initializes enough of the runtime to run instrumented code. This function
+  // should only be called in statically linked executables because it modifies
+  // the GOT, which won't work in regular binaries because RELRO will already
+  // have been applied by the time the function is called. This also means that
+  // the function should be called before libc applies RELRO.
+  // Does not call libc unless there is an error.
+  // Can be called multiple times.
+  void __hwasan_init_static(void);
+
+  // This function may be optionally provided by user and should return
+  // a string containing HWASan runtime options. See asan_flags.h for details.
+  const char* __hwasan_default_options(void);
+
+  void __hwasan_enable_allocator_tagging(void);
+  void __hwasan_disable_allocator_tagging(void);
+
+  // Mark region of memory with the given tag. Both address and size need to be
+  // 16-byte aligned.
+  void __hwasan_tag_memory(const volatile void *p, unsigned char tag,
+                           size_t size);
+
+  /// Set pointer tag. Previous tag is lost.
+  void *__hwasan_tag_pointer(const volatile void *p, unsigned char tag);
+
+  // Set memory tag from the current SP address to the given address to zero.
+  // This is meant to annotate longjmp and other non-local jumps.
+  // This function needs to know the (almost) exact destination frame address;
+  // clearing shadow for the entire thread stack like __asan_handle_no_return
+  // does would cause false reports.
+  void __hwasan_handle_longjmp(const void *sp_dst);
+
+  // Set memory tag for the part of the current thread stack below sp_dst to
+  // zero. Call this in vfork() before returning in the parent process.
+  void __hwasan_handle_vfork(const void *sp_dst);
+
+  // Libc hook for thread creation. Should be called in the child thread before
+  // any instrumented code.
+  void __hwasan_thread_enter();
+
+  // Libc hook for thread destruction. No instrumented code should run after
+  // this call.
+  void __hwasan_thread_exit();
+
+  // Print shadow and origin for the memory range to stderr in a human-readable
+  // format.
+  void __hwasan_print_shadow(const volatile void *x, size_t size);
+
+  // Print one-line report about the memory usage of the current process.
+  void __hwasan_print_memory_usage();
+
+  /* Returns the offset of the first byte in the memory range that can not be
+   * accessed through the pointer in x, or -1 if the whole range is good. */
+  intptr_t __hwasan_test_shadow(const volatile void *x, size_t size);
+
+  int __sanitizer_posix_memalign(void **memptr, size_t alignment, size_t size);
+  void * __sanitizer_memalign(size_t alignment, size_t size);
+  void * __sanitizer_aligned_alloc(size_t alignment, size_t size);
+  void * __sanitizer___libc_memalign(size_t alignment, size_t size);
+  void * __sanitizer_valloc(size_t size);
+  void * __sanitizer_pvalloc(size_t size);
+  void __sanitizer_free(void *ptr);
+  void __sanitizer_cfree(void *ptr);
+  size_t __sanitizer_malloc_usable_size(const void *ptr);
+  struct mallinfo __sanitizer_mallinfo();
+  int __sanitizer_mallopt(int cmd, int value);
+  void __sanitizer_malloc_stats(void);
+  void * __sanitizer_calloc(size_t nmemb, size_t size);
+  void * __sanitizer_realloc(void *ptr, size_t size);
+  void * __sanitizer_reallocarray(void *ptr, size_t nmemb, size_t size);
+  void * __sanitizer_malloc(size_t size);
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SANITIZER_HWASAN_INTERFACE_H

--- a/system/lib/compiler-rt/include/sanitizer/linux_syscall_hooks.h
+++ b/system/lib/compiler-rt/include/sanitizer/linux_syscall_hooks.h
@@ -1,0 +1,3082 @@
+//===-- linux_syscall_hooks.h ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of public sanitizer interface.
+//
+// System call handlers.
+//
+// Interface methods declared in this header implement pre- and post- syscall
+// actions for the active sanitizer.
+// Usage:
+//   __sanitizer_syscall_pre_getfoo(...args...);
+//   long res = syscall(__NR_getfoo, ...args...);
+//   __sanitizer_syscall_post_getfoo(res, ...args...);
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_LINUX_SYSCALL_HOOKS_H
+#define SANITIZER_LINUX_SYSCALL_HOOKS_H
+
+#define __sanitizer_syscall_pre_time(tloc) \
+  __sanitizer_syscall_pre_impl_time((long)(tloc))
+#define __sanitizer_syscall_post_time(res, tloc) \
+  __sanitizer_syscall_post_impl_time(res, (long)(tloc))
+#define __sanitizer_syscall_pre_stime(tptr) \
+  __sanitizer_syscall_pre_impl_stime((long)(tptr))
+#define __sanitizer_syscall_post_stime(res, tptr) \
+  __sanitizer_syscall_post_impl_stime(res, (long)(tptr))
+#define __sanitizer_syscall_pre_gettimeofday(tv, tz) \
+  __sanitizer_syscall_pre_impl_gettimeofday((long)(tv), (long)(tz))
+#define __sanitizer_syscall_post_gettimeofday(res, tv, tz) \
+  __sanitizer_syscall_post_impl_gettimeofday(res, (long)(tv), (long)(tz))
+#define __sanitizer_syscall_pre_settimeofday(tv, tz) \
+  __sanitizer_syscall_pre_impl_settimeofday((long)(tv), (long)(tz))
+#define __sanitizer_syscall_post_settimeofday(res, tv, tz) \
+  __sanitizer_syscall_post_impl_settimeofday(res, (long)(tv), (long)(tz))
+#define __sanitizer_syscall_pre_adjtimex(txc_p) \
+  __sanitizer_syscall_pre_impl_adjtimex((long)(txc_p))
+#define __sanitizer_syscall_post_adjtimex(res, txc_p) \
+  __sanitizer_syscall_post_impl_adjtimex(res, (long)(txc_p))
+#define __sanitizer_syscall_pre_times(tbuf) \
+  __sanitizer_syscall_pre_impl_times((long)(tbuf))
+#define __sanitizer_syscall_post_times(res, tbuf) \
+  __sanitizer_syscall_post_impl_times(res, (long)(tbuf))
+#define __sanitizer_syscall_pre_gettid() __sanitizer_syscall_pre_impl_gettid()
+#define __sanitizer_syscall_post_gettid(res) \
+  __sanitizer_syscall_post_impl_gettid(res)
+#define __sanitizer_syscall_pre_nanosleep(rqtp, rmtp) \
+  __sanitizer_syscall_pre_impl_nanosleep((long)(rqtp), (long)(rmtp))
+#define __sanitizer_syscall_post_nanosleep(res, rqtp, rmtp) \
+  __sanitizer_syscall_post_impl_nanosleep(res, (long)(rqtp), (long)(rmtp))
+#define __sanitizer_syscall_pre_alarm(seconds) \
+  __sanitizer_syscall_pre_impl_alarm((long)(seconds))
+#define __sanitizer_syscall_post_alarm(res, seconds) \
+  __sanitizer_syscall_post_impl_alarm(res, (long)(seconds))
+#define __sanitizer_syscall_pre_getpid() __sanitizer_syscall_pre_impl_getpid()
+#define __sanitizer_syscall_post_getpid(res) \
+  __sanitizer_syscall_post_impl_getpid(res)
+#define __sanitizer_syscall_pre_getppid() __sanitizer_syscall_pre_impl_getppid()
+#define __sanitizer_syscall_post_getppid(res) \
+  __sanitizer_syscall_post_impl_getppid(res)
+#define __sanitizer_syscall_pre_getuid() __sanitizer_syscall_pre_impl_getuid()
+#define __sanitizer_syscall_post_getuid(res) \
+  __sanitizer_syscall_post_impl_getuid(res)
+#define __sanitizer_syscall_pre_geteuid() __sanitizer_syscall_pre_impl_geteuid()
+#define __sanitizer_syscall_post_geteuid(res) \
+  __sanitizer_syscall_post_impl_geteuid(res)
+#define __sanitizer_syscall_pre_getgid() __sanitizer_syscall_pre_impl_getgid()
+#define __sanitizer_syscall_post_getgid(res) \
+  __sanitizer_syscall_post_impl_getgid(res)
+#define __sanitizer_syscall_pre_getegid() __sanitizer_syscall_pre_impl_getegid()
+#define __sanitizer_syscall_post_getegid(res) \
+  __sanitizer_syscall_post_impl_getegid(res)
+#define __sanitizer_syscall_pre_getresuid(ruid, euid, suid)          \
+  __sanitizer_syscall_pre_impl_getresuid((long)(ruid), (long)(euid), \
+                                         (long)(suid))
+#define __sanitizer_syscall_post_getresuid(res, ruid, euid, suid)          \
+  __sanitizer_syscall_post_impl_getresuid(res, (long)(ruid), (long)(euid), \
+                                          (long)(suid))
+#define __sanitizer_syscall_pre_getresgid(rgid, egid, sgid)          \
+  __sanitizer_syscall_pre_impl_getresgid((long)(rgid), (long)(egid), \
+                                         (long)(sgid))
+#define __sanitizer_syscall_post_getresgid(res, rgid, egid, sgid)          \
+  __sanitizer_syscall_post_impl_getresgid(res, (long)(rgid), (long)(egid), \
+                                          (long)(sgid))
+#define __sanitizer_syscall_pre_getpgid(pid) \
+  __sanitizer_syscall_pre_impl_getpgid((long)(pid))
+#define __sanitizer_syscall_post_getpgid(res, pid) \
+  __sanitizer_syscall_post_impl_getpgid(res, (long)(pid))
+#define __sanitizer_syscall_pre_getpgrp() __sanitizer_syscall_pre_impl_getpgrp()
+#define __sanitizer_syscall_post_getpgrp(res) \
+  __sanitizer_syscall_post_impl_getpgrp(res)
+#define __sanitizer_syscall_pre_getsid(pid) \
+  __sanitizer_syscall_pre_impl_getsid((long)(pid))
+#define __sanitizer_syscall_post_getsid(res, pid) \
+  __sanitizer_syscall_post_impl_getsid(res, (long)(pid))
+#define __sanitizer_syscall_pre_getgroups(gidsetsize, grouplist) \
+  __sanitizer_syscall_pre_impl_getgroups((long)(gidsetsize), (long)(grouplist))
+#define __sanitizer_syscall_post_getgroups(res, gidsetsize, grouplist) \
+  __sanitizer_syscall_post_impl_getgroups(res, (long)(gidsetsize),     \
+                                          (long)(grouplist))
+#define __sanitizer_syscall_pre_setregid(rgid, egid) \
+  __sanitizer_syscall_pre_impl_setregid((long)(rgid), (long)(egid))
+#define __sanitizer_syscall_post_setregid(res, rgid, egid) \
+  __sanitizer_syscall_post_impl_setregid(res, (long)(rgid), (long)(egid))
+#define __sanitizer_syscall_pre_setgid(gid) \
+  __sanitizer_syscall_pre_impl_setgid((long)(gid))
+#define __sanitizer_syscall_post_setgid(res, gid) \
+  __sanitizer_syscall_post_impl_setgid(res, (long)(gid))
+#define __sanitizer_syscall_pre_setreuid(ruid, euid) \
+  __sanitizer_syscall_pre_impl_setreuid((long)(ruid), (long)(euid))
+#define __sanitizer_syscall_post_setreuid(res, ruid, euid) \
+  __sanitizer_syscall_post_impl_setreuid(res, (long)(ruid), (long)(euid))
+#define __sanitizer_syscall_pre_setuid(uid) \
+  __sanitizer_syscall_pre_impl_setuid((long)(uid))
+#define __sanitizer_syscall_post_setuid(res, uid) \
+  __sanitizer_syscall_post_impl_setuid(res, (long)(uid))
+#define __sanitizer_syscall_pre_setresuid(ruid, euid, suid)          \
+  __sanitizer_syscall_pre_impl_setresuid((long)(ruid), (long)(euid), \
+                                         (long)(suid))
+#define __sanitizer_syscall_post_setresuid(res, ruid, euid, suid)          \
+  __sanitizer_syscall_post_impl_setresuid(res, (long)(ruid), (long)(euid), \
+                                          (long)(suid))
+#define __sanitizer_syscall_pre_setresgid(rgid, egid, sgid)          \
+  __sanitizer_syscall_pre_impl_setresgid((long)(rgid), (long)(egid), \
+                                         (long)(sgid))
+#define __sanitizer_syscall_post_setresgid(res, rgid, egid, sgid)          \
+  __sanitizer_syscall_post_impl_setresgid(res, (long)(rgid), (long)(egid), \
+                                          (long)(sgid))
+#define __sanitizer_syscall_pre_setfsuid(uid) \
+  __sanitizer_syscall_pre_impl_setfsuid((long)(uid))
+#define __sanitizer_syscall_post_setfsuid(res, uid) \
+  __sanitizer_syscall_post_impl_setfsuid(res, (long)(uid))
+#define __sanitizer_syscall_pre_setfsgid(gid) \
+  __sanitizer_syscall_pre_impl_setfsgid((long)(gid))
+#define __sanitizer_syscall_post_setfsgid(res, gid) \
+  __sanitizer_syscall_post_impl_setfsgid(res, (long)(gid))
+#define __sanitizer_syscall_pre_setpgid(pid, pgid) \
+  __sanitizer_syscall_pre_impl_setpgid((long)(pid), (long)(pgid))
+#define __sanitizer_syscall_post_setpgid(res, pid, pgid) \
+  __sanitizer_syscall_post_impl_setpgid(res, (long)(pid), (long)(pgid))
+#define __sanitizer_syscall_pre_setsid() __sanitizer_syscall_pre_impl_setsid()
+#define __sanitizer_syscall_post_setsid(res) \
+  __sanitizer_syscall_post_impl_setsid(res)
+#define __sanitizer_syscall_pre_setgroups(gidsetsize, grouplist) \
+  __sanitizer_syscall_pre_impl_setgroups((long)(gidsetsize), (long)(grouplist))
+#define __sanitizer_syscall_post_setgroups(res, gidsetsize, grouplist) \
+  __sanitizer_syscall_post_impl_setgroups(res, (long)(gidsetsize),     \
+                                          (long)(grouplist))
+#define __sanitizer_syscall_pre_acct(name) \
+  __sanitizer_syscall_pre_impl_acct((long)(name))
+#define __sanitizer_syscall_post_acct(res, name) \
+  __sanitizer_syscall_post_impl_acct(res, (long)(name))
+#define __sanitizer_syscall_pre_capget(header, dataptr) \
+  __sanitizer_syscall_pre_impl_capget((long)(header), (long)(dataptr))
+#define __sanitizer_syscall_post_capget(res, header, dataptr) \
+  __sanitizer_syscall_post_impl_capget(res, (long)(header), (long)(dataptr))
+#define __sanitizer_syscall_pre_capset(header, data) \
+  __sanitizer_syscall_pre_impl_capset((long)(header), (long)(data))
+#define __sanitizer_syscall_post_capset(res, header, data) \
+  __sanitizer_syscall_post_impl_capset(res, (long)(header), (long)(data))
+#define __sanitizer_syscall_pre_personality(personality) \
+  __sanitizer_syscall_pre_impl_personality((long)(personality))
+#define __sanitizer_syscall_post_personality(res, personality) \
+  __sanitizer_syscall_post_impl_personality(res, (long)(personality))
+#define __sanitizer_syscall_pre_sigpending(set) \
+  __sanitizer_syscall_pre_impl_sigpending((long)(set))
+#define __sanitizer_syscall_post_sigpending(res, set) \
+  __sanitizer_syscall_post_impl_sigpending(res, (long)(set))
+#define __sanitizer_syscall_pre_sigprocmask(how, set, oset)          \
+  __sanitizer_syscall_pre_impl_sigprocmask((long)(how), (long)(set), \
+                                           (long)(oset))
+#define __sanitizer_syscall_post_sigprocmask(res, how, set, oset)          \
+  __sanitizer_syscall_post_impl_sigprocmask(res, (long)(how), (long)(set), \
+                                            (long)(oset))
+#define __sanitizer_syscall_pre_getitimer(which, value) \
+  __sanitizer_syscall_pre_impl_getitimer((long)(which), (long)(value))
+#define __sanitizer_syscall_post_getitimer(res, which, value) \
+  __sanitizer_syscall_post_impl_getitimer(res, (long)(which), (long)(value))
+#define __sanitizer_syscall_pre_setitimer(which, value, ovalue)        \
+  __sanitizer_syscall_pre_impl_setitimer((long)(which), (long)(value), \
+                                         (long)(ovalue))
+#define __sanitizer_syscall_post_setitimer(res, which, value, ovalue)        \
+  __sanitizer_syscall_post_impl_setitimer(res, (long)(which), (long)(value), \
+                                          (long)(ovalue))
+#define __sanitizer_syscall_pre_timer_create(which_clock, timer_event_spec, \
+                                             created_timer_id)              \
+  __sanitizer_syscall_pre_impl_timer_create(                                \
+      (long)(which_clock), (long)(timer_event_spec), (long)(created_timer_id))
+#define __sanitizer_syscall_post_timer_create(                         \
+    res, which_clock, timer_event_spec, created_timer_id)              \
+  __sanitizer_syscall_post_impl_timer_create(res, (long)(which_clock), \
+                                             (long)(timer_event_spec), \
+                                             (long)(created_timer_id))
+#define __sanitizer_syscall_pre_timer_gettime(timer_id, setting) \
+  __sanitizer_syscall_pre_impl_timer_gettime((long)(timer_id), (long)(setting))
+#define __sanitizer_syscall_post_timer_gettime(res, timer_id, setting) \
+  __sanitizer_syscall_post_impl_timer_gettime(res, (long)(timer_id),   \
+                                              (long)(setting))
+#define __sanitizer_syscall_pre_timer_getoverrun(timer_id) \
+  __sanitizer_syscall_pre_impl_timer_getoverrun((long)(timer_id))
+#define __sanitizer_syscall_post_timer_getoverrun(res, timer_id) \
+  __sanitizer_syscall_post_impl_timer_getoverrun(res, (long)(timer_id))
+#define __sanitizer_syscall_pre_timer_settime(timer_id, flags, new_setting,   \
+                                              old_setting)                    \
+  __sanitizer_syscall_pre_impl_timer_settime((long)(timer_id), (long)(flags), \
+                                             (long)(new_setting),             \
+                                             (long)(old_setting))
+#define __sanitizer_syscall_post_timer_settime(res, timer_id, flags,     \
+                                               new_setting, old_setting) \
+  __sanitizer_syscall_post_impl_timer_settime(                           \
+      res, (long)(timer_id), (long)(flags), (long)(new_setting),         \
+      (long)(old_setting))
+#define __sanitizer_syscall_pre_timer_delete(timer_id) \
+  __sanitizer_syscall_pre_impl_timer_delete((long)(timer_id))
+#define __sanitizer_syscall_post_timer_delete(res, timer_id) \
+  __sanitizer_syscall_post_impl_timer_delete(res, (long)(timer_id))
+#define __sanitizer_syscall_pre_clock_settime(which_clock, tp) \
+  __sanitizer_syscall_pre_impl_clock_settime((long)(which_clock), (long)(tp))
+#define __sanitizer_syscall_post_clock_settime(res, which_clock, tp)    \
+  __sanitizer_syscall_post_impl_clock_settime(res, (long)(which_clock), \
+                                              (long)(tp))
+#define __sanitizer_syscall_pre_clock_gettime(which_clock, tp) \
+  __sanitizer_syscall_pre_impl_clock_gettime((long)(which_clock), (long)(tp))
+#define __sanitizer_syscall_post_clock_gettime(res, which_clock, tp)    \
+  __sanitizer_syscall_post_impl_clock_gettime(res, (long)(which_clock), \
+                                              (long)(tp))
+#define __sanitizer_syscall_pre_clock_adjtime(which_clock, tx) \
+  __sanitizer_syscall_pre_impl_clock_adjtime((long)(which_clock), (long)(tx))
+#define __sanitizer_syscall_post_clock_adjtime(res, which_clock, tx)    \
+  __sanitizer_syscall_post_impl_clock_adjtime(res, (long)(which_clock), \
+                                              (long)(tx))
+#define __sanitizer_syscall_pre_clock_getres(which_clock, tp) \
+  __sanitizer_syscall_pre_impl_clock_getres((long)(which_clock), (long)(tp))
+#define __sanitizer_syscall_post_clock_getres(res, which_clock, tp)    \
+  __sanitizer_syscall_post_impl_clock_getres(res, (long)(which_clock), \
+                                             (long)(tp))
+#define __sanitizer_syscall_pre_clock_nanosleep(which_clock, flags, rqtp, \
+                                                rmtp)                     \
+  __sanitizer_syscall_pre_impl_clock_nanosleep(                           \
+      (long)(which_clock), (long)(flags), (long)(rqtp), (long)(rmtp))
+#define __sanitizer_syscall_post_clock_nanosleep(res, which_clock, flags, \
+                                                 rqtp, rmtp)              \
+  __sanitizer_syscall_post_impl_clock_nanosleep(                          \
+      res, (long)(which_clock), (long)(flags), (long)(rqtp), (long)(rmtp))
+#define __sanitizer_syscall_pre_nice(increment) \
+  __sanitizer_syscall_pre_impl_nice((long)(increment))
+#define __sanitizer_syscall_post_nice(res, increment) \
+  __sanitizer_syscall_post_impl_nice(res, (long)(increment))
+#define __sanitizer_syscall_pre_sched_setscheduler(pid, policy, param)         \
+  __sanitizer_syscall_pre_impl_sched_setscheduler((long)(pid), (long)(policy), \
+                                                  (long)(param))
+#define __sanitizer_syscall_post_sched_setscheduler(res, pid, policy, param) \
+  __sanitizer_syscall_post_impl_sched_setscheduler(                          \
+      res, (long)(pid), (long)(policy), (long)(param))
+#define __sanitizer_syscall_pre_sched_setparam(pid, param) \
+  __sanitizer_syscall_pre_impl_sched_setparam((long)(pid), (long)(param))
+#define __sanitizer_syscall_post_sched_setparam(res, pid, param) \
+  __sanitizer_syscall_post_impl_sched_setparam(res, (long)(pid), (long)(param))
+#define __sanitizer_syscall_pre_sched_getscheduler(pid) \
+  __sanitizer_syscall_pre_impl_sched_getscheduler((long)(pid))
+#define __sanitizer_syscall_post_sched_getscheduler(res, pid) \
+  __sanitizer_syscall_post_impl_sched_getscheduler(res, (long)(pid))
+#define __sanitizer_syscall_pre_sched_getparam(pid, param) \
+  __sanitizer_syscall_pre_impl_sched_getparam((long)(pid), (long)(param))
+#define __sanitizer_syscall_post_sched_getparam(res, pid, param) \
+  __sanitizer_syscall_post_impl_sched_getparam(res, (long)(pid), (long)(param))
+#define __sanitizer_syscall_pre_sched_setaffinity(pid, len, user_mask_ptr) \
+  __sanitizer_syscall_pre_impl_sched_setaffinity((long)(pid), (long)(len), \
+                                                 (long)(user_mask_ptr))
+#define __sanitizer_syscall_post_sched_setaffinity(res, pid, len, \
+                                                   user_mask_ptr) \
+  __sanitizer_syscall_post_impl_sched_setaffinity(                \
+      res, (long)(pid), (long)(len), (long)(user_mask_ptr))
+#define __sanitizer_syscall_pre_sched_getaffinity(pid, len, user_mask_ptr) \
+  __sanitizer_syscall_pre_impl_sched_getaffinity((long)(pid), (long)(len), \
+                                                 (long)(user_mask_ptr))
+#define __sanitizer_syscall_post_sched_getaffinity(res, pid, len, \
+                                                   user_mask_ptr) \
+  __sanitizer_syscall_post_impl_sched_getaffinity(                \
+      res, (long)(pid), (long)(len), (long)(user_mask_ptr))
+#define __sanitizer_syscall_pre_sched_yield() \
+  __sanitizer_syscall_pre_impl_sched_yield()
+#define __sanitizer_syscall_post_sched_yield(res) \
+  __sanitizer_syscall_post_impl_sched_yield(res)
+#define __sanitizer_syscall_pre_sched_get_priority_max(policy) \
+  __sanitizer_syscall_pre_impl_sched_get_priority_max((long)(policy))
+#define __sanitizer_syscall_post_sched_get_priority_max(res, policy) \
+  __sanitizer_syscall_post_impl_sched_get_priority_max(res, (long)(policy))
+#define __sanitizer_syscall_pre_sched_get_priority_min(policy) \
+  __sanitizer_syscall_pre_impl_sched_get_priority_min((long)(policy))
+#define __sanitizer_syscall_post_sched_get_priority_min(res, policy) \
+  __sanitizer_syscall_post_impl_sched_get_priority_min(res, (long)(policy))
+#define __sanitizer_syscall_pre_sched_rr_get_interval(pid, interval) \
+  __sanitizer_syscall_pre_impl_sched_rr_get_interval((long)(pid),    \
+                                                     (long)(interval))
+#define __sanitizer_syscall_post_sched_rr_get_interval(res, pid, interval) \
+  __sanitizer_syscall_post_impl_sched_rr_get_interval(res, (long)(pid),    \
+                                                      (long)(interval))
+#define __sanitizer_syscall_pre_setpriority(which, who, niceval)       \
+  __sanitizer_syscall_pre_impl_setpriority((long)(which), (long)(who), \
+                                           (long)(niceval))
+#define __sanitizer_syscall_post_setpriority(res, which, who, niceval)       \
+  __sanitizer_syscall_post_impl_setpriority(res, (long)(which), (long)(who), \
+                                            (long)(niceval))
+#define __sanitizer_syscall_pre_getpriority(which, who) \
+  __sanitizer_syscall_pre_impl_getpriority((long)(which), (long)(who))
+#define __sanitizer_syscall_post_getpriority(res, which, who) \
+  __sanitizer_syscall_post_impl_getpriority(res, (long)(which), (long)(who))
+#define __sanitizer_syscall_pre_shutdown(arg0, arg1) \
+  __sanitizer_syscall_pre_impl_shutdown((long)(arg0), (long)(arg1))
+#define __sanitizer_syscall_post_shutdown(res, arg0, arg1) \
+  __sanitizer_syscall_post_impl_shutdown(res, (long)(arg0), (long)(arg1))
+#define __sanitizer_syscall_pre_reboot(magic1, magic2, cmd, arg)      \
+  __sanitizer_syscall_pre_impl_reboot((long)(magic1), (long)(magic2), \
+                                      (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_post_reboot(res, magic1, magic2, cmd, arg)      \
+  __sanitizer_syscall_post_impl_reboot(res, (long)(magic1), (long)(magic2), \
+                                       (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_pre_restart_syscall() \
+  __sanitizer_syscall_pre_impl_restart_syscall()
+#define __sanitizer_syscall_post_restart_syscall(res) \
+  __sanitizer_syscall_post_impl_restart_syscall(res)
+#define __sanitizer_syscall_pre_kexec_load(entry, nr_segments, segments,      \
+                                           flags)                             \
+  __sanitizer_syscall_pre_impl_kexec_load((long)(entry), (long)(nr_segments), \
+                                          (long)(segments), (long)(flags))
+#define __sanitizer_syscall_post_kexec_load(res, entry, nr_segments, segments, \
+                                            flags)                             \
+  __sanitizer_syscall_post_impl_kexec_load(res, (long)(entry),                 \
+                                           (long)(nr_segments),                \
+                                           (long)(segments), (long)(flags))
+#define __sanitizer_syscall_pre_exit(error_code) \
+  __sanitizer_syscall_pre_impl_exit((long)(error_code))
+#define __sanitizer_syscall_post_exit(res, error_code) \
+  __sanitizer_syscall_post_impl_exit(res, (long)(error_code))
+#define __sanitizer_syscall_pre_exit_group(error_code) \
+  __sanitizer_syscall_pre_impl_exit_group((long)(error_code))
+#define __sanitizer_syscall_post_exit_group(res, error_code) \
+  __sanitizer_syscall_post_impl_exit_group(res, (long)(error_code))
+#define __sanitizer_syscall_pre_wait4(pid, stat_addr, options, ru)   \
+  __sanitizer_syscall_pre_impl_wait4((long)(pid), (long)(stat_addr), \
+                                     (long)(options), (long)(ru))
+#define __sanitizer_syscall_post_wait4(res, pid, stat_addr, options, ru)   \
+  __sanitizer_syscall_post_impl_wait4(res, (long)(pid), (long)(stat_addr), \
+                                      (long)(options), (long)(ru))
+#define __sanitizer_syscall_pre_waitid(which, pid, infop, options, ru) \
+  __sanitizer_syscall_pre_impl_waitid(                                 \
+      (long)(which), (long)(pid), (long)(infop), (long)(options), (long)(ru))
+#define __sanitizer_syscall_post_waitid(res, which, pid, infop, options, ru) \
+  __sanitizer_syscall_post_impl_waitid(res, (long)(which), (long)(pid),      \
+                                       (long)(infop), (long)(options),       \
+                                       (long)(ru))
+#define __sanitizer_syscall_pre_waitpid(pid, stat_addr, options)       \
+  __sanitizer_syscall_pre_impl_waitpid((long)(pid), (long)(stat_addr), \
+                                       (long)(options))
+#define __sanitizer_syscall_post_waitpid(res, pid, stat_addr, options)       \
+  __sanitizer_syscall_post_impl_waitpid(res, (long)(pid), (long)(stat_addr), \
+                                        (long)(options))
+#define __sanitizer_syscall_pre_set_tid_address(tidptr) \
+  __sanitizer_syscall_pre_impl_set_tid_address((long)(tidptr))
+#define __sanitizer_syscall_post_set_tid_address(res, tidptr) \
+  __sanitizer_syscall_post_impl_set_tid_address(res, (long)(tidptr))
+#define __sanitizer_syscall_pre_init_module(umod, len, uargs)         \
+  __sanitizer_syscall_pre_impl_init_module((long)(umod), (long)(len), \
+                                           (long)(uargs))
+#define __sanitizer_syscall_post_init_module(res, umod, len, uargs)         \
+  __sanitizer_syscall_post_impl_init_module(res, (long)(umod), (long)(len), \
+                                            (long)(uargs))
+#define __sanitizer_syscall_pre_delete_module(name_user, flags) \
+  __sanitizer_syscall_pre_impl_delete_module((long)(name_user), (long)(flags))
+#define __sanitizer_syscall_post_delete_module(res, name_user, flags) \
+  __sanitizer_syscall_post_impl_delete_module(res, (long)(name_user), \
+                                              (long)(flags))
+#define __sanitizer_syscall_pre_rt_sigprocmask(how, set, oset, sigsetsize) \
+  __sanitizer_syscall_pre_impl_rt_sigprocmask(                             \
+      (long)(how), (long)(set), (long)(oset), (long)(sigsetsize))
+#define __sanitizer_syscall_post_rt_sigprocmask(res, how, set, oset, \
+                                                sigsetsize)          \
+  __sanitizer_syscall_post_impl_rt_sigprocmask(                      \
+      res, (long)(how), (long)(set), (long)(oset), (long)(sigsetsize))
+#define __sanitizer_syscall_pre_rt_sigpending(set, sigsetsize) \
+  __sanitizer_syscall_pre_impl_rt_sigpending((long)(set), (long)(sigsetsize))
+#define __sanitizer_syscall_post_rt_sigpending(res, set, sigsetsize) \
+  __sanitizer_syscall_post_impl_rt_sigpending(res, (long)(set),      \
+                                              (long)(sigsetsize))
+#define __sanitizer_syscall_pre_rt_sigtimedwait(uthese, uinfo, uts, \
+                                                sigsetsize)         \
+  __sanitizer_syscall_pre_impl_rt_sigtimedwait(                     \
+      (long)(uthese), (long)(uinfo), (long)(uts), (long)(sigsetsize))
+#define __sanitizer_syscall_post_rt_sigtimedwait(res, uthese, uinfo, uts, \
+                                                 sigsetsize)              \
+  __sanitizer_syscall_post_impl_rt_sigtimedwait(                          \
+      res, (long)(uthese), (long)(uinfo), (long)(uts), (long)(sigsetsize))
+#define __sanitizer_syscall_pre_rt_tgsigqueueinfo(tgid, pid, sig, uinfo)    \
+  __sanitizer_syscall_pre_impl_rt_tgsigqueueinfo((long)(tgid), (long)(pid), \
+                                                 (long)(sig), (long)(uinfo))
+#define __sanitizer_syscall_post_rt_tgsigqueueinfo(res, tgid, pid, sig, uinfo) \
+  __sanitizer_syscall_post_impl_rt_tgsigqueueinfo(                             \
+      res, (long)(tgid), (long)(pid), (long)(sig), (long)(uinfo))
+#define __sanitizer_syscall_pre_kill(pid, sig) \
+  __sanitizer_syscall_pre_impl_kill((long)(pid), (long)(sig))
+#define __sanitizer_syscall_post_kill(res, pid, sig) \
+  __sanitizer_syscall_post_impl_kill(res, (long)(pid), (long)(sig))
+#define __sanitizer_syscall_pre_tgkill(tgid, pid, sig) \
+  __sanitizer_syscall_pre_impl_tgkill((long)(tgid), (long)(pid), (long)(sig))
+#define __sanitizer_syscall_post_tgkill(res, tgid, pid, sig)           \
+  __sanitizer_syscall_post_impl_tgkill(res, (long)(tgid), (long)(pid), \
+                                       (long)(sig))
+#define __sanitizer_syscall_pre_tkill(pid, sig) \
+  __sanitizer_syscall_pre_impl_tkill((long)(pid), (long)(sig))
+#define __sanitizer_syscall_post_tkill(res, pid, sig) \
+  __sanitizer_syscall_post_impl_tkill(res, (long)(pid), (long)(sig))
+#define __sanitizer_syscall_pre_rt_sigqueueinfo(pid, sig, uinfo)         \
+  __sanitizer_syscall_pre_impl_rt_sigqueueinfo((long)(pid), (long)(sig), \
+                                               (long)(uinfo))
+#define __sanitizer_syscall_post_rt_sigqueueinfo(res, pid, sig, uinfo)         \
+  __sanitizer_syscall_post_impl_rt_sigqueueinfo(res, (long)(pid), (long)(sig), \
+                                                (long)(uinfo))
+#define __sanitizer_syscall_pre_sgetmask() \
+  __sanitizer_syscall_pre_impl_sgetmask()
+#define __sanitizer_syscall_post_sgetmask(res) \
+  __sanitizer_syscall_post_impl_sgetmask(res)
+#define __sanitizer_syscall_pre_ssetmask(newmask) \
+  __sanitizer_syscall_pre_impl_ssetmask((long)(newmask))
+#define __sanitizer_syscall_post_ssetmask(res, newmask) \
+  __sanitizer_syscall_post_impl_ssetmask(res, (long)(newmask))
+#define __sanitizer_syscall_pre_signal(sig, handler) \
+  __sanitizer_syscall_pre_impl_signal((long)(sig), (long)(handler))
+#define __sanitizer_syscall_post_signal(res, sig, handler) \
+  __sanitizer_syscall_post_impl_signal(res, (long)(sig), (long)(handler))
+#define __sanitizer_syscall_pre_pause() __sanitizer_syscall_pre_impl_pause()
+#define __sanitizer_syscall_post_pause(res) \
+  __sanitizer_syscall_post_impl_pause(res)
+#define __sanitizer_syscall_pre_sync() __sanitizer_syscall_pre_impl_sync()
+#define __sanitizer_syscall_post_sync(res) \
+  __sanitizer_syscall_post_impl_sync(res)
+#define __sanitizer_syscall_pre_fsync(fd) \
+  __sanitizer_syscall_pre_impl_fsync((long)(fd))
+#define __sanitizer_syscall_post_fsync(res, fd) \
+  __sanitizer_syscall_post_impl_fsync(res, (long)(fd))
+#define __sanitizer_syscall_pre_fdatasync(fd) \
+  __sanitizer_syscall_pre_impl_fdatasync((long)(fd))
+#define __sanitizer_syscall_post_fdatasync(res, fd) \
+  __sanitizer_syscall_post_impl_fdatasync(res, (long)(fd))
+#define __sanitizer_syscall_pre_bdflush(func, data) \
+  __sanitizer_syscall_pre_impl_bdflush((long)(func), (long)(data))
+#define __sanitizer_syscall_post_bdflush(res, func, data) \
+  __sanitizer_syscall_post_impl_bdflush(res, (long)(func), (long)(data))
+#define __sanitizer_syscall_pre_mount(dev_name, dir_name, type, flags, data) \
+  __sanitizer_syscall_pre_impl_mount((long)(dev_name), (long)(dir_name),     \
+                                     (long)(type), (long)(flags),            \
+                                     (long)(data))
+#define __sanitizer_syscall_post_mount(res, dev_name, dir_name, type, flags,   \
+                                       data)                                   \
+  __sanitizer_syscall_post_impl_mount(res, (long)(dev_name), (long)(dir_name), \
+                                      (long)(type), (long)(flags),             \
+                                      (long)(data))
+#define __sanitizer_syscall_pre_umount(name, flags) \
+  __sanitizer_syscall_pre_impl_umount((long)(name), (long)(flags))
+#define __sanitizer_syscall_post_umount(res, name, flags) \
+  __sanitizer_syscall_post_impl_umount(res, (long)(name), (long)(flags))
+#define __sanitizer_syscall_pre_oldumount(name) \
+  __sanitizer_syscall_pre_impl_oldumount((long)(name))
+#define __sanitizer_syscall_post_oldumount(res, name) \
+  __sanitizer_syscall_post_impl_oldumount(res, (long)(name))
+#define __sanitizer_syscall_pre_truncate(path, length) \
+  __sanitizer_syscall_pre_impl_truncate((long)(path), (long)(length))
+#define __sanitizer_syscall_post_truncate(res, path, length) \
+  __sanitizer_syscall_post_impl_truncate(res, (long)(path), (long)(length))
+#define __sanitizer_syscall_pre_ftruncate(fd, length) \
+  __sanitizer_syscall_pre_impl_ftruncate((long)(fd), (long)(length))
+#define __sanitizer_syscall_post_ftruncate(res, fd, length) \
+  __sanitizer_syscall_post_impl_ftruncate(res, (long)(fd), (long)(length))
+#define __sanitizer_syscall_pre_stat(filename, statbuf) \
+  __sanitizer_syscall_pre_impl_stat((long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_post_stat(res, filename, statbuf) \
+  __sanitizer_syscall_post_impl_stat(res, (long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_pre_statfs(path, buf) \
+  __sanitizer_syscall_pre_impl_statfs((long)(path), (long)(buf))
+#define __sanitizer_syscall_post_statfs(res, path, buf) \
+  __sanitizer_syscall_post_impl_statfs(res, (long)(path), (long)(buf))
+#define __sanitizer_syscall_pre_statfs64(path, sz, buf) \
+  __sanitizer_syscall_pre_impl_statfs64((long)(path), (long)(sz), (long)(buf))
+#define __sanitizer_syscall_post_statfs64(res, path, sz, buf)           \
+  __sanitizer_syscall_post_impl_statfs64(res, (long)(path), (long)(sz), \
+                                         (long)(buf))
+#define __sanitizer_syscall_pre_fstatfs(fd, buf) \
+  __sanitizer_syscall_pre_impl_fstatfs((long)(fd), (long)(buf))
+#define __sanitizer_syscall_post_fstatfs(res, fd, buf) \
+  __sanitizer_syscall_post_impl_fstatfs(res, (long)(fd), (long)(buf))
+#define __sanitizer_syscall_pre_fstatfs64(fd, sz, buf) \
+  __sanitizer_syscall_pre_impl_fstatfs64((long)(fd), (long)(sz), (long)(buf))
+#define __sanitizer_syscall_post_fstatfs64(res, fd, sz, buf)           \
+  __sanitizer_syscall_post_impl_fstatfs64(res, (long)(fd), (long)(sz), \
+                                          (long)(buf))
+#define __sanitizer_syscall_pre_lstat(filename, statbuf) \
+  __sanitizer_syscall_pre_impl_lstat((long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_post_lstat(res, filename, statbuf) \
+  __sanitizer_syscall_post_impl_lstat(res, (long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_pre_fstat(fd, statbuf) \
+  __sanitizer_syscall_pre_impl_fstat((long)(fd), (long)(statbuf))
+#define __sanitizer_syscall_post_fstat(res, fd, statbuf) \
+  __sanitizer_syscall_post_impl_fstat(res, (long)(fd), (long)(statbuf))
+#define __sanitizer_syscall_pre_newstat(filename, statbuf) \
+  __sanitizer_syscall_pre_impl_newstat((long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_post_newstat(res, filename, statbuf) \
+  __sanitizer_syscall_post_impl_newstat(res, (long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_pre_newlstat(filename, statbuf) \
+  __sanitizer_syscall_pre_impl_newlstat((long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_post_newlstat(res, filename, statbuf) \
+  __sanitizer_syscall_post_impl_newlstat(res, (long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_pre_newfstat(fd, statbuf) \
+  __sanitizer_syscall_pre_impl_newfstat((long)(fd), (long)(statbuf))
+#define __sanitizer_syscall_post_newfstat(res, fd, statbuf) \
+  __sanitizer_syscall_post_impl_newfstat(res, (long)(fd), (long)(statbuf))
+#define __sanitizer_syscall_pre_ustat(dev, ubuf) \
+  __sanitizer_syscall_pre_impl_ustat((long)(dev), (long)(ubuf))
+#define __sanitizer_syscall_post_ustat(res, dev, ubuf) \
+  __sanitizer_syscall_post_impl_ustat(res, (long)(dev), (long)(ubuf))
+#define __sanitizer_syscall_pre_stat64(filename, statbuf) \
+  __sanitizer_syscall_pre_impl_stat64((long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_post_stat64(res, filename, statbuf) \
+  __sanitizer_syscall_post_impl_stat64(res, (long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_pre_fstat64(fd, statbuf) \
+  __sanitizer_syscall_pre_impl_fstat64((long)(fd), (long)(statbuf))
+#define __sanitizer_syscall_post_fstat64(res, fd, statbuf) \
+  __sanitizer_syscall_post_impl_fstat64(res, (long)(fd), (long)(statbuf))
+#define __sanitizer_syscall_pre_lstat64(filename, statbuf) \
+  __sanitizer_syscall_pre_impl_lstat64((long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_post_lstat64(res, filename, statbuf) \
+  __sanitizer_syscall_post_impl_lstat64(res, (long)(filename), (long)(statbuf))
+#define __sanitizer_syscall_pre_setxattr(path, name, value, size, flags) \
+  __sanitizer_syscall_pre_impl_setxattr(                                 \
+      (long)(path), (long)(name), (long)(value), (long)(size), (long)(flags))
+#define __sanitizer_syscall_post_setxattr(res, path, name, value, size, flags) \
+  __sanitizer_syscall_post_impl_setxattr(res, (long)(path), (long)(name),      \
+                                         (long)(value), (long)(size),          \
+                                         (long)(flags))
+#define __sanitizer_syscall_pre_lsetxattr(path, name, value, size, flags) \
+  __sanitizer_syscall_pre_impl_lsetxattr(                                 \
+      (long)(path), (long)(name), (long)(value), (long)(size), (long)(flags))
+#define __sanitizer_syscall_post_lsetxattr(res, path, name, value, size,   \
+                                           flags)                          \
+  __sanitizer_syscall_post_impl_lsetxattr(res, (long)(path), (long)(name), \
+                                          (long)(value), (long)(size),     \
+                                          (long)(flags))
+#define __sanitizer_syscall_pre_fsetxattr(fd, name, value, size, flags) \
+  __sanitizer_syscall_pre_impl_fsetxattr(                               \
+      (long)(fd), (long)(name), (long)(value), (long)(size), (long)(flags))
+#define __sanitizer_syscall_post_fsetxattr(res, fd, name, value, size, flags) \
+  __sanitizer_syscall_post_impl_fsetxattr(res, (long)(fd), (long)(name),      \
+                                          (long)(value), (long)(size),        \
+                                          (long)(flags))
+#define __sanitizer_syscall_pre_getxattr(path, name, value, size)   \
+  __sanitizer_syscall_pre_impl_getxattr((long)(path), (long)(name), \
+                                        (long)(value), (long)(size))
+#define __sanitizer_syscall_post_getxattr(res, path, name, value, size)   \
+  __sanitizer_syscall_post_impl_getxattr(res, (long)(path), (long)(name), \
+                                         (long)(value), (long)(size))
+#define __sanitizer_syscall_pre_lgetxattr(path, name, value, size)   \
+  __sanitizer_syscall_pre_impl_lgetxattr((long)(path), (long)(name), \
+                                         (long)(value), (long)(size))
+#define __sanitizer_syscall_post_lgetxattr(res, path, name, value, size)   \
+  __sanitizer_syscall_post_impl_lgetxattr(res, (long)(path), (long)(name), \
+                                          (long)(value), (long)(size))
+#define __sanitizer_syscall_pre_fgetxattr(fd, name, value, size)   \
+  __sanitizer_syscall_pre_impl_fgetxattr((long)(fd), (long)(name), \
+                                         (long)(value), (long)(size))
+#define __sanitizer_syscall_post_fgetxattr(res, fd, name, value, size)   \
+  __sanitizer_syscall_post_impl_fgetxattr(res, (long)(fd), (long)(name), \
+                                          (long)(value), (long)(size))
+#define __sanitizer_syscall_pre_listxattr(path, list, size)          \
+  __sanitizer_syscall_pre_impl_listxattr((long)(path), (long)(list), \
+                                         (long)(size))
+#define __sanitizer_syscall_post_listxattr(res, path, list, size)          \
+  __sanitizer_syscall_post_impl_listxattr(res, (long)(path), (long)(list), \
+                                          (long)(size))
+#define __sanitizer_syscall_pre_llistxattr(path, list, size)          \
+  __sanitizer_syscall_pre_impl_llistxattr((long)(path), (long)(list), \
+                                          (long)(size))
+#define __sanitizer_syscall_post_llistxattr(res, path, list, size)          \
+  __sanitizer_syscall_post_impl_llistxattr(res, (long)(path), (long)(list), \
+                                           (long)(size))
+#define __sanitizer_syscall_pre_flistxattr(fd, list, size)          \
+  __sanitizer_syscall_pre_impl_flistxattr((long)(fd), (long)(list), \
+                                          (long)(size))
+#define __sanitizer_syscall_post_flistxattr(res, fd, list, size)          \
+  __sanitizer_syscall_post_impl_flistxattr(res, (long)(fd), (long)(list), \
+                                           (long)(size))
+#define __sanitizer_syscall_pre_removexattr(path, name) \
+  __sanitizer_syscall_pre_impl_removexattr((long)(path), (long)(name))
+#define __sanitizer_syscall_post_removexattr(res, path, name) \
+  __sanitizer_syscall_post_impl_removexattr(res, (long)(path), (long)(name))
+#define __sanitizer_syscall_pre_lremovexattr(path, name) \
+  __sanitizer_syscall_pre_impl_lremovexattr((long)(path), (long)(name))
+#define __sanitizer_syscall_post_lremovexattr(res, path, name) \
+  __sanitizer_syscall_post_impl_lremovexattr(res, (long)(path), (long)(name))
+#define __sanitizer_syscall_pre_fremovexattr(fd, name) \
+  __sanitizer_syscall_pre_impl_fremovexattr((long)(fd), (long)(name))
+#define __sanitizer_syscall_post_fremovexattr(res, fd, name) \
+  __sanitizer_syscall_post_impl_fremovexattr(res, (long)(fd), (long)(name))
+#define __sanitizer_syscall_pre_brk(brk) \
+  __sanitizer_syscall_pre_impl_brk((long)(brk))
+#define __sanitizer_syscall_post_brk(res, brk) \
+  __sanitizer_syscall_post_impl_brk(res, (long)(brk))
+#define __sanitizer_syscall_pre_mprotect(start, len, prot)          \
+  __sanitizer_syscall_pre_impl_mprotect((long)(start), (long)(len), \
+                                        (long)(prot))
+#define __sanitizer_syscall_post_mprotect(res, start, len, prot)          \
+  __sanitizer_syscall_post_impl_mprotect(res, (long)(start), (long)(len), \
+                                         (long)(prot))
+#define __sanitizer_syscall_pre_mremap(addr, old_len, new_len, flags, \
+                                       new_addr)                      \
+  __sanitizer_syscall_pre_impl_mremap((long)(addr), (long)(old_len),  \
+                                      (long)(new_len), (long)(flags), \
+                                      (long)(new_addr))
+#define __sanitizer_syscall_post_mremap(res, addr, old_len, new_len, flags, \
+                                        new_addr)                           \
+  __sanitizer_syscall_post_impl_mremap(res, (long)(addr), (long)(old_len),  \
+                                       (long)(new_len), (long)(flags),      \
+                                       (long)(new_addr))
+#define __sanitizer_syscall_pre_remap_file_pages(start, size, prot, pgoff, \
+                                                 flags)                    \
+  __sanitizer_syscall_pre_impl_remap_file_pages(                           \
+      (long)(start), (long)(size), (long)(prot), (long)(pgoff), (long)(flags))
+#define __sanitizer_syscall_post_remap_file_pages(res, start, size, prot,    \
+                                                  pgoff, flags)              \
+  __sanitizer_syscall_post_impl_remap_file_pages(res, (long)(start),         \
+                                                 (long)(size), (long)(prot), \
+                                                 (long)(pgoff), (long)(flags))
+#define __sanitizer_syscall_pre_msync(start, len, flags) \
+  __sanitizer_syscall_pre_impl_msync((long)(start), (long)(len), (long)(flags))
+#define __sanitizer_syscall_post_msync(res, start, len, flags)         \
+  __sanitizer_syscall_post_impl_msync(res, (long)(start), (long)(len), \
+                                      (long)(flags))
+#define __sanitizer_syscall_pre_munmap(addr, len) \
+  __sanitizer_syscall_pre_impl_munmap((long)(addr), (long)(len))
+#define __sanitizer_syscall_post_munmap(res, addr, len) \
+  __sanitizer_syscall_post_impl_munmap(res, (long)(addr), (long)(len))
+#define __sanitizer_syscall_pre_mlock(start, len) \
+  __sanitizer_syscall_pre_impl_mlock((long)(start), (long)(len))
+#define __sanitizer_syscall_post_mlock(res, start, len) \
+  __sanitizer_syscall_post_impl_mlock(res, (long)(start), (long)(len))
+#define __sanitizer_syscall_pre_munlock(start, len) \
+  __sanitizer_syscall_pre_impl_munlock((long)(start), (long)(len))
+#define __sanitizer_syscall_post_munlock(res, start, len) \
+  __sanitizer_syscall_post_impl_munlock(res, (long)(start), (long)(len))
+#define __sanitizer_syscall_pre_mlockall(flags) \
+  __sanitizer_syscall_pre_impl_mlockall((long)(flags))
+#define __sanitizer_syscall_post_mlockall(res, flags) \
+  __sanitizer_syscall_post_impl_mlockall(res, (long)(flags))
+#define __sanitizer_syscall_pre_munlockall() \
+  __sanitizer_syscall_pre_impl_munlockall()
+#define __sanitizer_syscall_post_munlockall(res) \
+  __sanitizer_syscall_post_impl_munlockall(res)
+#define __sanitizer_syscall_pre_madvise(start, len, behavior)      \
+  __sanitizer_syscall_pre_impl_madvise((long)(start), (long)(len), \
+                                       (long)(behavior))
+#define __sanitizer_syscall_post_madvise(res, start, len, behavior)      \
+  __sanitizer_syscall_post_impl_madvise(res, (long)(start), (long)(len), \
+                                        (long)(behavior))
+#define __sanitizer_syscall_pre_mincore(start, len, vec) \
+  __sanitizer_syscall_pre_impl_mincore((long)(start), (long)(len), (long)(vec))
+#define __sanitizer_syscall_post_mincore(res, start, len, vec)           \
+  __sanitizer_syscall_post_impl_mincore(res, (long)(start), (long)(len), \
+                                        (long)(vec))
+#define __sanitizer_syscall_pre_pivot_root(new_root, put_old) \
+  __sanitizer_syscall_pre_impl_pivot_root((long)(new_root), (long)(put_old))
+#define __sanitizer_syscall_post_pivot_root(res, new_root, put_old) \
+  __sanitizer_syscall_post_impl_pivot_root(res, (long)(new_root),   \
+                                           (long)(put_old))
+#define __sanitizer_syscall_pre_chroot(filename) \
+  __sanitizer_syscall_pre_impl_chroot((long)(filename))
+#define __sanitizer_syscall_post_chroot(res, filename) \
+  __sanitizer_syscall_post_impl_chroot(res, (long)(filename))
+#define __sanitizer_syscall_pre_mknod(filename, mode, dev)           \
+  __sanitizer_syscall_pre_impl_mknod((long)(filename), (long)(mode), \
+                                     (long)(dev))
+#define __sanitizer_syscall_post_mknod(res, filename, mode, dev)           \
+  __sanitizer_syscall_post_impl_mknod(res, (long)(filename), (long)(mode), \
+                                      (long)(dev))
+#define __sanitizer_syscall_pre_link(oldname, newname) \
+  __sanitizer_syscall_pre_impl_link((long)(oldname), (long)(newname))
+#define __sanitizer_syscall_post_link(res, oldname, newname) \
+  __sanitizer_syscall_post_impl_link(res, (long)(oldname), (long)(newname))
+#define __sanitizer_syscall_pre_symlink(old, new_) \
+  __sanitizer_syscall_pre_impl_symlink((long)(old), (long)(new_))
+#define __sanitizer_syscall_post_symlink(res, old, new_) \
+  __sanitizer_syscall_post_impl_symlink(res, (long)(old), (long)(new_))
+#define __sanitizer_syscall_pre_unlink(pathname) \
+  __sanitizer_syscall_pre_impl_unlink((long)(pathname))
+#define __sanitizer_syscall_post_unlink(res, pathname) \
+  __sanitizer_syscall_post_impl_unlink(res, (long)(pathname))
+#define __sanitizer_syscall_pre_rename(oldname, newname) \
+  __sanitizer_syscall_pre_impl_rename((long)(oldname), (long)(newname))
+#define __sanitizer_syscall_post_rename(res, oldname, newname) \
+  __sanitizer_syscall_post_impl_rename(res, (long)(oldname), (long)(newname))
+#define __sanitizer_syscall_pre_chmod(filename, mode) \
+  __sanitizer_syscall_pre_impl_chmod((long)(filename), (long)(mode))
+#define __sanitizer_syscall_post_chmod(res, filename, mode) \
+  __sanitizer_syscall_post_impl_chmod(res, (long)(filename), (long)(mode))
+#define __sanitizer_syscall_pre_fchmod(fd, mode) \
+  __sanitizer_syscall_pre_impl_fchmod((long)(fd), (long)(mode))
+#define __sanitizer_syscall_post_fchmod(res, fd, mode) \
+  __sanitizer_syscall_post_impl_fchmod(res, (long)(fd), (long)(mode))
+#define __sanitizer_syscall_pre_fcntl(fd, cmd, arg) \
+  __sanitizer_syscall_pre_impl_fcntl((long)(fd), (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_post_fcntl(res, fd, cmd, arg) \
+  __sanitizer_syscall_post_impl_fcntl(res, (long)(fd), (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_pre_fcntl64(fd, cmd, arg) \
+  __sanitizer_syscall_pre_impl_fcntl64((long)(fd), (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_post_fcntl64(res, fd, cmd, arg)           \
+  __sanitizer_syscall_post_impl_fcntl64(res, (long)(fd), (long)(cmd), \
+                                        (long)(arg))
+#define __sanitizer_syscall_pre_pipe(fildes) \
+  __sanitizer_syscall_pre_impl_pipe((long)(fildes))
+#define __sanitizer_syscall_post_pipe(res, fildes) \
+  __sanitizer_syscall_post_impl_pipe(res, (long)(fildes))
+#define __sanitizer_syscall_pre_pipe2(fildes, flags) \
+  __sanitizer_syscall_pre_impl_pipe2((long)(fildes), (long)(flags))
+#define __sanitizer_syscall_post_pipe2(res, fildes, flags) \
+  __sanitizer_syscall_post_impl_pipe2(res, (long)(fildes), (long)(flags))
+#define __sanitizer_syscall_pre_dup(fildes) \
+  __sanitizer_syscall_pre_impl_dup((long)(fildes))
+#define __sanitizer_syscall_post_dup(res, fildes) \
+  __sanitizer_syscall_post_impl_dup(res, (long)(fildes))
+#define __sanitizer_syscall_pre_dup2(oldfd, newfd) \
+  __sanitizer_syscall_pre_impl_dup2((long)(oldfd), (long)(newfd))
+#define __sanitizer_syscall_post_dup2(res, oldfd, newfd) \
+  __sanitizer_syscall_post_impl_dup2(res, (long)(oldfd), (long)(newfd))
+#define __sanitizer_syscall_pre_dup3(oldfd, newfd, flags) \
+  __sanitizer_syscall_pre_impl_dup3((long)(oldfd), (long)(newfd), (long)(flags))
+#define __sanitizer_syscall_post_dup3(res, oldfd, newfd, flags)         \
+  __sanitizer_syscall_post_impl_dup3(res, (long)(oldfd), (long)(newfd), \
+                                     (long)(flags))
+#define __sanitizer_syscall_pre_ioperm(from, num, on) \
+  __sanitizer_syscall_pre_impl_ioperm((long)(from), (long)(num), (long)(on))
+#define __sanitizer_syscall_post_ioperm(res, from, num, on)            \
+  __sanitizer_syscall_post_impl_ioperm(res, (long)(from), (long)(num), \
+                                       (long)(on))
+#define __sanitizer_syscall_pre_ioctl(fd, cmd, arg) \
+  __sanitizer_syscall_pre_impl_ioctl((long)(fd), (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_post_ioctl(res, fd, cmd, arg) \
+  __sanitizer_syscall_post_impl_ioctl(res, (long)(fd), (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_pre_flock(fd, cmd) \
+  __sanitizer_syscall_pre_impl_flock((long)(fd), (long)(cmd))
+#define __sanitizer_syscall_post_flock(res, fd, cmd) \
+  __sanitizer_syscall_post_impl_flock(res, (long)(fd), (long)(cmd))
+#define __sanitizer_syscall_pre_io_setup(nr_reqs, ctx) \
+  __sanitizer_syscall_pre_impl_io_setup((long)(nr_reqs), (long)(ctx))
+#define __sanitizer_syscall_post_io_setup(res, nr_reqs, ctx) \
+  __sanitizer_syscall_post_impl_io_setup(res, (long)(nr_reqs), (long)(ctx))
+#define __sanitizer_syscall_pre_io_destroy(ctx) \
+  __sanitizer_syscall_pre_impl_io_destroy((long)(ctx))
+#define __sanitizer_syscall_post_io_destroy(res, ctx) \
+  __sanitizer_syscall_post_impl_io_destroy(res, (long)(ctx))
+#define __sanitizer_syscall_pre_io_getevents(ctx_id, min_nr, nr, events,    \
+                                             timeout)                       \
+  __sanitizer_syscall_pre_impl_io_getevents((long)(ctx_id), (long)(min_nr), \
+                                            (long)(nr), (long)(events),     \
+                                            (long)(timeout))
+#define __sanitizer_syscall_post_io_getevents(res, ctx_id, min_nr, nr, events, \
+                                              timeout)                         \
+  __sanitizer_syscall_post_impl_io_getevents(res, (long)(ctx_id),              \
+                                             (long)(min_nr), (long)(nr),       \
+                                             (long)(events), (long)(timeout))
+#define __sanitizer_syscall_pre_io_submit(ctx_id, arg1, arg2)          \
+  __sanitizer_syscall_pre_impl_io_submit((long)(ctx_id), (long)(arg1), \
+                                         (long)(arg2))
+#define __sanitizer_syscall_post_io_submit(res, ctx_id, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_io_submit(res, (long)(ctx_id), (long)(arg1), \
+                                          (long)(arg2))
+#define __sanitizer_syscall_pre_io_cancel(ctx_id, iocb, result)        \
+  __sanitizer_syscall_pre_impl_io_cancel((long)(ctx_id), (long)(iocb), \
+                                         (long)(result))
+#define __sanitizer_syscall_post_io_cancel(res, ctx_id, iocb, result)        \
+  __sanitizer_syscall_post_impl_io_cancel(res, (long)(ctx_id), (long)(iocb), \
+                                          (long)(result))
+#define __sanitizer_syscall_pre_sendfile(out_fd, in_fd, offset, count) \
+  __sanitizer_syscall_pre_impl_sendfile((long)(out_fd), (long)(in_fd), \
+                                        (long)(offset), (long)(count))
+#define __sanitizer_syscall_post_sendfile(res, out_fd, in_fd, offset, count) \
+  __sanitizer_syscall_post_impl_sendfile(res, (long)(out_fd), (long)(in_fd), \
+                                         (long)(offset), (long)(count))
+#define __sanitizer_syscall_pre_sendfile64(out_fd, in_fd, offset, count) \
+  __sanitizer_syscall_pre_impl_sendfile64((long)(out_fd), (long)(in_fd), \
+                                          (long)(offset), (long)(count))
+#define __sanitizer_syscall_post_sendfile64(res, out_fd, in_fd, offset, count) \
+  __sanitizer_syscall_post_impl_sendfile64(res, (long)(out_fd), (long)(in_fd), \
+                                           (long)(offset), (long)(count))
+#define __sanitizer_syscall_pre_readlink(path, buf, bufsiz)        \
+  __sanitizer_syscall_pre_impl_readlink((long)(path), (long)(buf), \
+                                        (long)(bufsiz))
+#define __sanitizer_syscall_post_readlink(res, path, buf, bufsiz)        \
+  __sanitizer_syscall_post_impl_readlink(res, (long)(path), (long)(buf), \
+                                         (long)(bufsiz))
+#define __sanitizer_syscall_pre_creat(pathname, mode) \
+  __sanitizer_syscall_pre_impl_creat((long)(pathname), (long)(mode))
+#define __sanitizer_syscall_post_creat(res, pathname, mode) \
+  __sanitizer_syscall_post_impl_creat(res, (long)(pathname), (long)(mode))
+#define __sanitizer_syscall_pre_open(filename, flags, mode)          \
+  __sanitizer_syscall_pre_impl_open((long)(filename), (long)(flags), \
+                                    (long)(mode))
+#define __sanitizer_syscall_post_open(res, filename, flags, mode)          \
+  __sanitizer_syscall_post_impl_open(res, (long)(filename), (long)(flags), \
+                                     (long)(mode))
+#define __sanitizer_syscall_pre_close(fd) \
+  __sanitizer_syscall_pre_impl_close((long)(fd))
+#define __sanitizer_syscall_post_close(res, fd) \
+  __sanitizer_syscall_post_impl_close(res, (long)(fd))
+#define __sanitizer_syscall_pre_access(filename, mode) \
+  __sanitizer_syscall_pre_impl_access((long)(filename), (long)(mode))
+#define __sanitizer_syscall_post_access(res, filename, mode) \
+  __sanitizer_syscall_post_impl_access(res, (long)(filename), (long)(mode))
+#define __sanitizer_syscall_pre_vhangup() __sanitizer_syscall_pre_impl_vhangup()
+#define __sanitizer_syscall_post_vhangup(res) \
+  __sanitizer_syscall_post_impl_vhangup(res)
+#define __sanitizer_syscall_pre_chown(filename, user, group)         \
+  __sanitizer_syscall_pre_impl_chown((long)(filename), (long)(user), \
+                                     (long)(group))
+#define __sanitizer_syscall_post_chown(res, filename, user, group)         \
+  __sanitizer_syscall_post_impl_chown(res, (long)(filename), (long)(user), \
+                                      (long)(group))
+#define __sanitizer_syscall_pre_lchown(filename, user, group)         \
+  __sanitizer_syscall_pre_impl_lchown((long)(filename), (long)(user), \
+                                      (long)(group))
+#define __sanitizer_syscall_post_lchown(res, filename, user, group)         \
+  __sanitizer_syscall_post_impl_lchown(res, (long)(filename), (long)(user), \
+                                       (long)(group))
+#define __sanitizer_syscall_pre_fchown(fd, user, group) \
+  __sanitizer_syscall_pre_impl_fchown((long)(fd), (long)(user), (long)(group))
+#define __sanitizer_syscall_post_fchown(res, fd, user, group)         \
+  __sanitizer_syscall_post_impl_fchown(res, (long)(fd), (long)(user), \
+                                       (long)(group))
+#define __sanitizer_syscall_pre_chown16(filename, user, group)       \
+  __sanitizer_syscall_pre_impl_chown16((long)(filename), (long)user, \
+                                       (long)group)
+#define __sanitizer_syscall_post_chown16(res, filename, user, group)       \
+  __sanitizer_syscall_post_impl_chown16(res, (long)(filename), (long)user, \
+                                        (long)group)
+#define __sanitizer_syscall_pre_lchown16(filename, user, group)       \
+  __sanitizer_syscall_pre_impl_lchown16((long)(filename), (long)user, \
+                                        (long)group)
+#define __sanitizer_syscall_post_lchown16(res, filename, user, group)       \
+  __sanitizer_syscall_post_impl_lchown16(res, (long)(filename), (long)user, \
+                                         (long)group)
+#define __sanitizer_syscall_pre_fchown16(fd, user, group) \
+  __sanitizer_syscall_pre_impl_fchown16((long)(fd), (long)user, (long)group)
+#define __sanitizer_syscall_post_fchown16(res, fd, user, group)       \
+  __sanitizer_syscall_post_impl_fchown16(res, (long)(fd), (long)user, \
+                                         (long)group)
+#define __sanitizer_syscall_pre_setregid16(rgid, egid) \
+  __sanitizer_syscall_pre_impl_setregid16((long)rgid, (long)egid)
+#define __sanitizer_syscall_post_setregid16(res, rgid, egid) \
+  __sanitizer_syscall_post_impl_setregid16(res, (long)rgid, (long)egid)
+#define __sanitizer_syscall_pre_setgid16(gid) \
+  __sanitizer_syscall_pre_impl_setgid16((long)gid)
+#define __sanitizer_syscall_post_setgid16(res, gid) \
+  __sanitizer_syscall_post_impl_setgid16(res, (long)gid)
+#define __sanitizer_syscall_pre_setreuid16(ruid, euid) \
+  __sanitizer_syscall_pre_impl_setreuid16((long)ruid, (long)euid)
+#define __sanitizer_syscall_post_setreuid16(res, ruid, euid) \
+  __sanitizer_syscall_post_impl_setreuid16(res, (long)ruid, (long)euid)
+#define __sanitizer_syscall_pre_setuid16(uid) \
+  __sanitizer_syscall_pre_impl_setuid16((long)uid)
+#define __sanitizer_syscall_post_setuid16(res, uid) \
+  __sanitizer_syscall_post_impl_setuid16(res, (long)uid)
+#define __sanitizer_syscall_pre_setresuid16(ruid, euid, suid) \
+  __sanitizer_syscall_pre_impl_setresuid16((long)ruid, (long)euid, (long)suid)
+#define __sanitizer_syscall_post_setresuid16(res, ruid, euid, suid)      \
+  __sanitizer_syscall_post_impl_setresuid16(res, (long)ruid, (long)euid, \
+                                            (long)suid)
+#define __sanitizer_syscall_pre_getresuid16(ruid, euid, suid)          \
+  __sanitizer_syscall_pre_impl_getresuid16((long)(ruid), (long)(euid), \
+                                           (long)(suid))
+#define __sanitizer_syscall_post_getresuid16(res, ruid, euid, suid)          \
+  __sanitizer_syscall_post_impl_getresuid16(res, (long)(ruid), (long)(euid), \
+                                            (long)(suid))
+#define __sanitizer_syscall_pre_setresgid16(rgid, egid, sgid) \
+  __sanitizer_syscall_pre_impl_setresgid16((long)rgid, (long)egid, (long)sgid)
+#define __sanitizer_syscall_post_setresgid16(res, rgid, egid, sgid)      \
+  __sanitizer_syscall_post_impl_setresgid16(res, (long)rgid, (long)egid, \
+                                            (long)sgid)
+#define __sanitizer_syscall_pre_getresgid16(rgid, egid, sgid)          \
+  __sanitizer_syscall_pre_impl_getresgid16((long)(rgid), (long)(egid), \
+                                           (long)(sgid))
+#define __sanitizer_syscall_post_getresgid16(res, rgid, egid, sgid)          \
+  __sanitizer_syscall_post_impl_getresgid16(res, (long)(rgid), (long)(egid), \
+                                            (long)(sgid))
+#define __sanitizer_syscall_pre_setfsuid16(uid) \
+  __sanitizer_syscall_pre_impl_setfsuid16((long)uid)
+#define __sanitizer_syscall_post_setfsuid16(res, uid) \
+  __sanitizer_syscall_post_impl_setfsuid16(res, (long)uid)
+#define __sanitizer_syscall_pre_setfsgid16(gid) \
+  __sanitizer_syscall_pre_impl_setfsgid16((long)gid)
+#define __sanitizer_syscall_post_setfsgid16(res, gid) \
+  __sanitizer_syscall_post_impl_setfsgid16(res, (long)gid)
+#define __sanitizer_syscall_pre_getgroups16(gidsetsize, grouplist) \
+  __sanitizer_syscall_pre_impl_getgroups16((long)(gidsetsize),     \
+                                           (long)(grouplist))
+#define __sanitizer_syscall_post_getgroups16(res, gidsetsize, grouplist) \
+  __sanitizer_syscall_post_impl_getgroups16(res, (long)(gidsetsize),     \
+                                            (long)(grouplist))
+#define __sanitizer_syscall_pre_setgroups16(gidsetsize, grouplist) \
+  __sanitizer_syscall_pre_impl_setgroups16((long)(gidsetsize),     \
+                                           (long)(grouplist))
+#define __sanitizer_syscall_post_setgroups16(res, gidsetsize, grouplist) \
+  __sanitizer_syscall_post_impl_setgroups16(res, (long)(gidsetsize),     \
+                                            (long)(grouplist))
+#define __sanitizer_syscall_pre_getuid16() \
+  __sanitizer_syscall_pre_impl_getuid16()
+#define __sanitizer_syscall_post_getuid16(res) \
+  __sanitizer_syscall_post_impl_getuid16(res)
+#define __sanitizer_syscall_pre_geteuid16() \
+  __sanitizer_syscall_pre_impl_geteuid16()
+#define __sanitizer_syscall_post_geteuid16(res) \
+  __sanitizer_syscall_post_impl_geteuid16(res)
+#define __sanitizer_syscall_pre_getgid16() \
+  __sanitizer_syscall_pre_impl_getgid16()
+#define __sanitizer_syscall_post_getgid16(res) \
+  __sanitizer_syscall_post_impl_getgid16(res)
+#define __sanitizer_syscall_pre_getegid16() \
+  __sanitizer_syscall_pre_impl_getegid16()
+#define __sanitizer_syscall_post_getegid16(res) \
+  __sanitizer_syscall_post_impl_getegid16(res)
+#define __sanitizer_syscall_pre_utime(filename, times) \
+  __sanitizer_syscall_pre_impl_utime((long)(filename), (long)(times))
+#define __sanitizer_syscall_post_utime(res, filename, times) \
+  __sanitizer_syscall_post_impl_utime(res, (long)(filename), (long)(times))
+#define __sanitizer_syscall_pre_utimes(filename, utimes) \
+  __sanitizer_syscall_pre_impl_utimes((long)(filename), (long)(utimes))
+#define __sanitizer_syscall_post_utimes(res, filename, utimes) \
+  __sanitizer_syscall_post_impl_utimes(res, (long)(filename), (long)(utimes))
+#define __sanitizer_syscall_pre_lseek(fd, offset, origin) \
+  __sanitizer_syscall_pre_impl_lseek((long)(fd), (long)(offset), (long)(origin))
+#define __sanitizer_syscall_post_lseek(res, fd, offset, origin)        \
+  __sanitizer_syscall_post_impl_lseek(res, (long)(fd), (long)(offset), \
+                                      (long)(origin))
+#define __sanitizer_syscall_pre_llseek(fd, offset_high, offset_low, result, \
+                                       origin)                              \
+  __sanitizer_syscall_pre_impl_llseek((long)(fd), (long)(offset_high),      \
+                                      (long)(offset_low), (long)(result),   \
+                                      (long)(origin))
+#define __sanitizer_syscall_post_llseek(res, fd, offset_high, offset_low,    \
+                                        result, origin)                      \
+  __sanitizer_syscall_post_impl_llseek(res, (long)(fd), (long)(offset_high), \
+                                       (long)(offset_low), (long)(result),   \
+                                       (long)(origin))
+#define __sanitizer_syscall_pre_read(fd, buf, count) \
+  __sanitizer_syscall_pre_impl_read((long)(fd), (long)(buf), (long)(count))
+#define __sanitizer_syscall_post_read(res, fd, buf, count)         \
+  __sanitizer_syscall_post_impl_read(res, (long)(fd), (long)(buf), \
+                                     (long)(count))
+#define __sanitizer_syscall_pre_readv(fd, vec, vlen) \
+  __sanitizer_syscall_pre_impl_readv((long)(fd), (long)(vec), (long)(vlen))
+#define __sanitizer_syscall_post_readv(res, fd, vec, vlen)          \
+  __sanitizer_syscall_post_impl_readv(res, (long)(fd), (long)(vec), \
+                                      (long)(vlen))
+#define __sanitizer_syscall_pre_write(fd, buf, count) \
+  __sanitizer_syscall_pre_impl_write((long)(fd), (long)(buf), (long)(count))
+#define __sanitizer_syscall_post_write(res, fd, buf, count)         \
+  __sanitizer_syscall_post_impl_write(res, (long)(fd), (long)(buf), \
+                                      (long)(count))
+#define __sanitizer_syscall_pre_writev(fd, vec, vlen) \
+  __sanitizer_syscall_pre_impl_writev((long)(fd), (long)(vec), (long)(vlen))
+#define __sanitizer_syscall_post_writev(res, fd, vec, vlen)          \
+  __sanitizer_syscall_post_impl_writev(res, (long)(fd), (long)(vec), \
+                                       (long)(vlen))
+
+#ifdef _LP64
+#define __sanitizer_syscall_pre_pread64(fd, buf, count, pos)                   \
+  __sanitizer_syscall_pre_impl_pread64((long)(fd), (long)(buf), (long)(count), \
+                                       (long)(pos))
+#define __sanitizer_syscall_post_pread64(res, fd, buf, count, pos)    \
+  __sanitizer_syscall_post_impl_pread64(res, (long)(fd), (long)(buf), \
+                                        (long)(count), (long)(pos))
+#define __sanitizer_syscall_pre_pwrite64(fd, buf, count, pos)    \
+  __sanitizer_syscall_pre_impl_pwrite64((long)(fd), (long)(buf), \
+                                        (long)(count), (long)(pos))
+#define __sanitizer_syscall_post_pwrite64(res, fd, buf, count, pos)    \
+  __sanitizer_syscall_post_impl_pwrite64(res, (long)(fd), (long)(buf), \
+                                         (long)(count), (long)(pos))
+#else
+#define __sanitizer_syscall_pre_pread64(fd, buf, count, pos0, pos1)            \
+  __sanitizer_syscall_pre_impl_pread64((long)(fd), (long)(buf), (long)(count), \
+                                       (long)(pos0), (long)(pos1))
+#define __sanitizer_syscall_post_pread64(res, fd, buf, count, pos0, pos1) \
+  __sanitizer_syscall_post_impl_pread64(res, (long)(fd), (long)(buf),     \
+                                        (long)(count), (long)(pos0), \
+                                        (long)(pos1))
+#define __sanitizer_syscall_pre_pwrite64(fd, buf, count, pos0, pos1) \
+  __sanitizer_syscall_pre_impl_pwrite64(                             \
+      (long)(fd), (long)(buf), (long)(count), (long)(pos0), (long)(pos1))
+#define __sanitizer_syscall_post_pwrite64(res, fd, buf, count, pos0, pos1) \
+  __sanitizer_syscall_post_impl_pwrite64(                                  \
+      res, (long)(fd), (long)(buf), (long)(count), (long)(pos0), (long)(pos1))
+#endif
+
+#define __sanitizer_syscall_pre_preadv(fd, vec, vlen, pos_l, pos_h)          \
+  __sanitizer_syscall_pre_impl_preadv((long)(fd), (long)(vec), (long)(vlen), \
+                                      (long)(pos_l), (long)(pos_h))
+#define __sanitizer_syscall_post_preadv(res, fd, vec, vlen, pos_l, pos_h) \
+  __sanitizer_syscall_post_impl_preadv(res, (long)(fd), (long)(vec),      \
+                                       (long)(vlen), (long)(pos_l),       \
+                                       (long)(pos_h))
+#define __sanitizer_syscall_pre_pwritev(fd, vec, vlen, pos_l, pos_h)          \
+  __sanitizer_syscall_pre_impl_pwritev((long)(fd), (long)(vec), (long)(vlen), \
+                                       (long)(pos_l), (long)(pos_h))
+#define __sanitizer_syscall_post_pwritev(res, fd, vec, vlen, pos_l, pos_h) \
+  __sanitizer_syscall_post_impl_pwritev(res, (long)(fd), (long)(vec),      \
+                                        (long)(vlen), (long)(pos_l),       \
+                                        (long)(pos_h))
+#define __sanitizer_syscall_pre_getcwd(buf, size) \
+  __sanitizer_syscall_pre_impl_getcwd((long)(buf), (long)(size))
+#define __sanitizer_syscall_post_getcwd(res, buf, size) \
+  __sanitizer_syscall_post_impl_getcwd(res, (long)(buf), (long)(size))
+#define __sanitizer_syscall_pre_mkdir(pathname, mode) \
+  __sanitizer_syscall_pre_impl_mkdir((long)(pathname), (long)(mode))
+#define __sanitizer_syscall_post_mkdir(res, pathname, mode) \
+  __sanitizer_syscall_post_impl_mkdir(res, (long)(pathname), (long)(mode))
+#define __sanitizer_syscall_pre_chdir(filename) \
+  __sanitizer_syscall_pre_impl_chdir((long)(filename))
+#define __sanitizer_syscall_post_chdir(res, filename) \
+  __sanitizer_syscall_post_impl_chdir(res, (long)(filename))
+#define __sanitizer_syscall_pre_fchdir(fd) \
+  __sanitizer_syscall_pre_impl_fchdir((long)(fd))
+#define __sanitizer_syscall_post_fchdir(res, fd) \
+  __sanitizer_syscall_post_impl_fchdir(res, (long)(fd))
+#define __sanitizer_syscall_pre_rmdir(pathname) \
+  __sanitizer_syscall_pre_impl_rmdir((long)(pathname))
+#define __sanitizer_syscall_post_rmdir(res, pathname) \
+  __sanitizer_syscall_post_impl_rmdir(res, (long)(pathname))
+#define __sanitizer_syscall_pre_lookup_dcookie(cookie64, buf, len)           \
+  __sanitizer_syscall_pre_impl_lookup_dcookie((long)(cookie64), (long)(buf), \
+                                              (long)(len))
+#define __sanitizer_syscall_post_lookup_dcookie(res, cookie64, buf, len) \
+  __sanitizer_syscall_post_impl_lookup_dcookie(res, (long)(cookie64),    \
+                                               (long)(buf), (long)(len))
+#define __sanitizer_syscall_pre_quotactl(cmd, special, id, addr)      \
+  __sanitizer_syscall_pre_impl_quotactl((long)(cmd), (long)(special), \
+                                        (long)(id), (long)(addr))
+#define __sanitizer_syscall_post_quotactl(res, cmd, special, id, addr)      \
+  __sanitizer_syscall_post_impl_quotactl(res, (long)(cmd), (long)(special), \
+                                         (long)(id), (long)(addr))
+#define __sanitizer_syscall_pre_getdents(fd, dirent, count)         \
+  __sanitizer_syscall_pre_impl_getdents((long)(fd), (long)(dirent), \
+                                        (long)(count))
+#define __sanitizer_syscall_post_getdents(res, fd, dirent, count)         \
+  __sanitizer_syscall_post_impl_getdents(res, (long)(fd), (long)(dirent), \
+                                         (long)(count))
+#define __sanitizer_syscall_pre_getdents64(fd, dirent, count)         \
+  __sanitizer_syscall_pre_impl_getdents64((long)(fd), (long)(dirent), \
+                                          (long)(count))
+#define __sanitizer_syscall_post_getdents64(res, fd, dirent, count)         \
+  __sanitizer_syscall_post_impl_getdents64(res, (long)(fd), (long)(dirent), \
+                                           (long)(count))
+#define __sanitizer_syscall_pre_setsockopt(fd, level, optname, optval, optlen) \
+  __sanitizer_syscall_pre_impl_setsockopt((long)(fd), (long)(level),           \
+                                          (long)(optname), (long)(optval),     \
+                                          (long)(optlen))
+#define __sanitizer_syscall_post_setsockopt(res, fd, level, optname, optval, \
+                                            optlen)                          \
+  __sanitizer_syscall_post_impl_setsockopt(res, (long)(fd), (long)(level),   \
+                                           (long)(optname), (long)(optval),  \
+                                           (long)(optlen))
+#define __sanitizer_syscall_pre_getsockopt(fd, level, optname, optval, optlen) \
+  __sanitizer_syscall_pre_impl_getsockopt((long)(fd), (long)(level),           \
+                                          (long)(optname), (long)(optval),     \
+                                          (long)(optlen))
+#define __sanitizer_syscall_post_getsockopt(res, fd, level, optname, optval, \
+                                            optlen)                          \
+  __sanitizer_syscall_post_impl_getsockopt(res, (long)(fd), (long)(level),   \
+                                           (long)(optname), (long)(optval),  \
+                                           (long)(optlen))
+#define __sanitizer_syscall_pre_bind(arg0, arg1, arg2) \
+  __sanitizer_syscall_pre_impl_bind((long)(arg0), (long)(arg1), (long)(arg2))
+#define __sanitizer_syscall_post_bind(res, arg0, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_bind(res, (long)(arg0), (long)(arg1), \
+                                     (long)(arg2))
+#define __sanitizer_syscall_pre_connect(arg0, arg1, arg2) \
+  __sanitizer_syscall_pre_impl_connect((long)(arg0), (long)(arg1), (long)(arg2))
+#define __sanitizer_syscall_post_connect(res, arg0, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_connect(res, (long)(arg0), (long)(arg1), \
+                                        (long)(arg2))
+#define __sanitizer_syscall_pre_accept(arg0, arg1, arg2) \
+  __sanitizer_syscall_pre_impl_accept((long)(arg0), (long)(arg1), (long)(arg2))
+#define __sanitizer_syscall_post_accept(res, arg0, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_accept(res, (long)(arg0), (long)(arg1), \
+                                       (long)(arg2))
+#define __sanitizer_syscall_pre_accept4(arg0, arg1, arg2, arg3)    \
+  __sanitizer_syscall_pre_impl_accept4((long)(arg0), (long)(arg1), \
+                                       (long)(arg2), (long)(arg3))
+#define __sanitizer_syscall_post_accept4(res, arg0, arg1, arg2, arg3)    \
+  __sanitizer_syscall_post_impl_accept4(res, (long)(arg0), (long)(arg1), \
+                                        (long)(arg2), (long)(arg3))
+#define __sanitizer_syscall_pre_getsockname(arg0, arg1, arg2)          \
+  __sanitizer_syscall_pre_impl_getsockname((long)(arg0), (long)(arg1), \
+                                           (long)(arg2))
+#define __sanitizer_syscall_post_getsockname(res, arg0, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_getsockname(res, (long)(arg0), (long)(arg1), \
+                                            (long)(arg2))
+#define __sanitizer_syscall_pre_getpeername(arg0, arg1, arg2)          \
+  __sanitizer_syscall_pre_impl_getpeername((long)(arg0), (long)(arg1), \
+                                           (long)(arg2))
+#define __sanitizer_syscall_post_getpeername(res, arg0, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_getpeername(res, (long)(arg0), (long)(arg1), \
+                                            (long)(arg2))
+#define __sanitizer_syscall_pre_send(arg0, arg1, arg2, arg3)                  \
+  __sanitizer_syscall_pre_impl_send((long)(arg0), (long)(arg1), (long)(arg2), \
+                                    (long)(arg3))
+#define __sanitizer_syscall_post_send(res, arg0, arg1, arg2, arg3)    \
+  __sanitizer_syscall_post_impl_send(res, (long)(arg0), (long)(arg1), \
+                                     (long)(arg2), (long)(arg3))
+#define __sanitizer_syscall_pre_sendto(arg0, arg1, arg2, arg3, arg4, arg5) \
+  __sanitizer_syscall_pre_impl_sendto((long)(arg0), (long)(arg1),          \
+                                      (long)(arg2), (long)(arg3),          \
+                                      (long)(arg4), (long)(arg5))
+#define __sanitizer_syscall_post_sendto(res, arg0, arg1, arg2, arg3, arg4, \
+                                        arg5)                              \
+  __sanitizer_syscall_post_impl_sendto(res, (long)(arg0), (long)(arg1),    \
+                                       (long)(arg2), (long)(arg3),         \
+                                       (long)(arg4), (long)(arg5))
+#define __sanitizer_syscall_pre_sendmsg(fd, msg, flags) \
+  __sanitizer_syscall_pre_impl_sendmsg((long)(fd), (long)(msg), (long)(flags))
+#define __sanitizer_syscall_post_sendmsg(res, fd, msg, flags)         \
+  __sanitizer_syscall_post_impl_sendmsg(res, (long)(fd), (long)(msg), \
+                                        (long)(flags))
+#define __sanitizer_syscall_pre_sendmmsg(fd, msg, vlen, flags)                 \
+  __sanitizer_syscall_pre_impl_sendmmsg((long)(fd), (long)(msg), (long)(vlen), \
+                                        (long)(flags))
+#define __sanitizer_syscall_post_sendmmsg(res, fd, msg, vlen, flags)   \
+  __sanitizer_syscall_post_impl_sendmmsg(res, (long)(fd), (long)(msg), \
+                                         (long)(vlen), (long)(flags))
+#define __sanitizer_syscall_pre_recv(arg0, arg1, arg2, arg3)                  \
+  __sanitizer_syscall_pre_impl_recv((long)(arg0), (long)(arg1), (long)(arg2), \
+                                    (long)(arg3))
+#define __sanitizer_syscall_post_recv(res, arg0, arg1, arg2, arg3)    \
+  __sanitizer_syscall_post_impl_recv(res, (long)(arg0), (long)(arg1), \
+                                     (long)(arg2), (long)(arg3))
+#define __sanitizer_syscall_pre_recvfrom(arg0, arg1, arg2, arg3, arg4, arg5) \
+  __sanitizer_syscall_pre_impl_recvfrom((long)(arg0), (long)(arg1),          \
+                                        (long)(arg2), (long)(arg3),          \
+                                        (long)(arg4), (long)(arg5))
+#define __sanitizer_syscall_post_recvfrom(res, arg0, arg1, arg2, arg3, arg4, \
+                                          arg5)                              \
+  __sanitizer_syscall_post_impl_recvfrom(res, (long)(arg0), (long)(arg1),    \
+                                         (long)(arg2), (long)(arg3),         \
+                                         (long)(arg4), (long)(arg5))
+#define __sanitizer_syscall_pre_recvmsg(fd, msg, flags) \
+  __sanitizer_syscall_pre_impl_recvmsg((long)(fd), (long)(msg), (long)(flags))
+#define __sanitizer_syscall_post_recvmsg(res, fd, msg, flags)         \
+  __sanitizer_syscall_post_impl_recvmsg(res, (long)(fd), (long)(msg), \
+                                        (long)(flags))
+#define __sanitizer_syscall_pre_recvmmsg(fd, msg, vlen, flags, timeout)        \
+  __sanitizer_syscall_pre_impl_recvmmsg((long)(fd), (long)(msg), (long)(vlen), \
+                                        (long)(flags), (long)(timeout))
+#define __sanitizer_syscall_post_recvmmsg(res, fd, msg, vlen, flags, timeout) \
+  __sanitizer_syscall_post_impl_recvmmsg(res, (long)(fd), (long)(msg),        \
+                                         (long)(vlen), (long)(flags),         \
+                                         (long)(timeout))
+#define __sanitizer_syscall_pre_socket(arg0, arg1, arg2) \
+  __sanitizer_syscall_pre_impl_socket((long)(arg0), (long)(arg1), (long)(arg2))
+#define __sanitizer_syscall_post_socket(res, arg0, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_socket(res, (long)(arg0), (long)(arg1), \
+                                       (long)(arg2))
+#define __sanitizer_syscall_pre_socketpair(arg0, arg1, arg2, arg3)    \
+  __sanitizer_syscall_pre_impl_socketpair((long)(arg0), (long)(arg1), \
+                                          (long)(arg2), (long)(arg3))
+#define __sanitizer_syscall_post_socketpair(res, arg0, arg1, arg2, arg3)    \
+  __sanitizer_syscall_post_impl_socketpair(res, (long)(arg0), (long)(arg1), \
+                                           (long)(arg2), (long)(arg3))
+#define __sanitizer_syscall_pre_socketcall(call, args) \
+  __sanitizer_syscall_pre_impl_socketcall((long)(call), (long)(args))
+#define __sanitizer_syscall_post_socketcall(res, call, args) \
+  __sanitizer_syscall_post_impl_socketcall(res, (long)(call), (long)(args))
+#define __sanitizer_syscall_pre_listen(arg0, arg1) \
+  __sanitizer_syscall_pre_impl_listen((long)(arg0), (long)(arg1))
+#define __sanitizer_syscall_post_listen(res, arg0, arg1) \
+  __sanitizer_syscall_post_impl_listen(res, (long)(arg0), (long)(arg1))
+#define __sanitizer_syscall_pre_poll(ufds, nfds, timeout) \
+  __sanitizer_syscall_pre_impl_poll((long)(ufds), (long)(nfds), (long)(timeout))
+#define __sanitizer_syscall_post_poll(res, ufds, nfds, timeout)       \
+  __sanitizer_syscall_post_impl_poll(res, (long)(ufds), (long)(nfds), \
+                                     (long)(timeout))
+#define __sanitizer_syscall_pre_select(n, inp, outp, exp, tvp)              \
+  __sanitizer_syscall_pre_impl_select((long)(n), (long)(inp), (long)(outp), \
+                                      (long)(exp), (long)(tvp))
+#define __sanitizer_syscall_post_select(res, n, inp, outp, exp, tvp) \
+  __sanitizer_syscall_post_impl_select(res, (long)(n), (long)(inp),  \
+                                       (long)(outp), (long)(exp), (long)(tvp))
+#define __sanitizer_syscall_pre_old_select(arg) \
+  __sanitizer_syscall_pre_impl_old_select((long)(arg))
+#define __sanitizer_syscall_post_old_select(res, arg) \
+  __sanitizer_syscall_post_impl_old_select(res, (long)(arg))
+#define __sanitizer_syscall_pre_epoll_create(size) \
+  __sanitizer_syscall_pre_impl_epoll_create((long)(size))
+#define __sanitizer_syscall_post_epoll_create(res, size) \
+  __sanitizer_syscall_post_impl_epoll_create(res, (long)(size))
+#define __sanitizer_syscall_pre_epoll_create1(flags) \
+  __sanitizer_syscall_pre_impl_epoll_create1((long)(flags))
+#define __sanitizer_syscall_post_epoll_create1(res, flags) \
+  __sanitizer_syscall_post_impl_epoll_create1(res, (long)(flags))
+#define __sanitizer_syscall_pre_epoll_ctl(epfd, op, fd, event)                 \
+  __sanitizer_syscall_pre_impl_epoll_ctl((long)(epfd), (long)(op), (long)(fd), \
+                                         (long)(event))
+#define __sanitizer_syscall_post_epoll_ctl(res, epfd, op, fd, event)     \
+  __sanitizer_syscall_post_impl_epoll_ctl(res, (long)(epfd), (long)(op), \
+                                          (long)(fd), (long)(event))
+#define __sanitizer_syscall_pre_epoll_wait(epfd, events, maxevents, timeout) \
+  __sanitizer_syscall_pre_impl_epoll_wait((long)(epfd), (long)(events),      \
+                                          (long)(maxevents), (long)(timeout))
+#define __sanitizer_syscall_post_epoll_wait(res, epfd, events, maxevents,     \
+                                            timeout)                          \
+  __sanitizer_syscall_post_impl_epoll_wait(res, (long)(epfd), (long)(events), \
+                                           (long)(maxevents), (long)(timeout))
+#define __sanitizer_syscall_pre_epoll_pwait(epfd, events, maxevents, timeout, \
+                                            sigmask, sigsetsize)              \
+  __sanitizer_syscall_pre_impl_epoll_pwait(                                   \
+      (long)(epfd), (long)(events), (long)(maxevents), (long)(timeout),       \
+      (long)(sigmask), (long)(sigsetsize))
+#define __sanitizer_syscall_post_epoll_pwait(res, epfd, events, maxevents,   \
+                                             timeout, sigmask, sigsetsize)   \
+  __sanitizer_syscall_post_impl_epoll_pwait(                                 \
+      res, (long)(epfd), (long)(events), (long)(maxevents), (long)(timeout), \
+      (long)(sigmask), (long)(sigsetsize))
+#define __sanitizer_syscall_pre_gethostname(name, len) \
+  __sanitizer_syscall_pre_impl_gethostname((long)(name), (long)(len))
+#define __sanitizer_syscall_post_gethostname(res, name, len) \
+  __sanitizer_syscall_post_impl_gethostname(res, (long)(name), (long)(len))
+#define __sanitizer_syscall_pre_sethostname(name, len) \
+  __sanitizer_syscall_pre_impl_sethostname((long)(name), (long)(len))
+#define __sanitizer_syscall_post_sethostname(res, name, len) \
+  __sanitizer_syscall_post_impl_sethostname(res, (long)(name), (long)(len))
+#define __sanitizer_syscall_pre_setdomainname(name, len) \
+  __sanitizer_syscall_pre_impl_setdomainname((long)(name), (long)(len))
+#define __sanitizer_syscall_post_setdomainname(res, name, len) \
+  __sanitizer_syscall_post_impl_setdomainname(res, (long)(name), (long)(len))
+#define __sanitizer_syscall_pre_newuname(name) \
+  __sanitizer_syscall_pre_impl_newuname((long)(name))
+#define __sanitizer_syscall_post_newuname(res, name) \
+  __sanitizer_syscall_post_impl_newuname(res, (long)(name))
+#define __sanitizer_syscall_pre_uname(arg0) \
+  __sanitizer_syscall_pre_impl_uname((long)(arg0))
+#define __sanitizer_syscall_post_uname(res, arg0) \
+  __sanitizer_syscall_post_impl_uname(res, (long)(arg0))
+#define __sanitizer_syscall_pre_olduname(arg0) \
+  __sanitizer_syscall_pre_impl_olduname((long)(arg0))
+#define __sanitizer_syscall_post_olduname(res, arg0) \
+  __sanitizer_syscall_post_impl_olduname(res, (long)(arg0))
+#define __sanitizer_syscall_pre_getrlimit(resource, rlim) \
+  __sanitizer_syscall_pre_impl_getrlimit((long)(resource), (long)(rlim))
+#define __sanitizer_syscall_post_getrlimit(res, resource, rlim) \
+  __sanitizer_syscall_post_impl_getrlimit(res, (long)(resource), (long)(rlim))
+#define __sanitizer_syscall_pre_old_getrlimit(resource, rlim) \
+  __sanitizer_syscall_pre_impl_old_getrlimit((long)(resource), (long)(rlim))
+#define __sanitizer_syscall_post_old_getrlimit(res, resource, rlim)  \
+  __sanitizer_syscall_post_impl_old_getrlimit(res, (long)(resource), \
+                                              (long)(rlim))
+#define __sanitizer_syscall_pre_setrlimit(resource, rlim) \
+  __sanitizer_syscall_pre_impl_setrlimit((long)(resource), (long)(rlim))
+#define __sanitizer_syscall_post_setrlimit(res, resource, rlim) \
+  __sanitizer_syscall_post_impl_setrlimit(res, (long)(resource), (long)(rlim))
+#define __sanitizer_syscall_pre_prlimit64(pid, resource, new_rlim, old_rlim) \
+  __sanitizer_syscall_pre_impl_prlimit64((long)(pid), (long)(resource),      \
+                                         (long)(new_rlim), (long)(old_rlim))
+#define __sanitizer_syscall_post_prlimit64(res, pid, resource, new_rlim,      \
+                                           old_rlim)                          \
+  __sanitizer_syscall_post_impl_prlimit64(res, (long)(pid), (long)(resource), \
+                                          (long)(new_rlim), (long)(old_rlim))
+#define __sanitizer_syscall_pre_getrusage(who, ru) \
+  __sanitizer_syscall_pre_impl_getrusage((long)(who), (long)(ru))
+#define __sanitizer_syscall_post_getrusage(res, who, ru) \
+  __sanitizer_syscall_post_impl_getrusage(res, (long)(who), (long)(ru))
+#define __sanitizer_syscall_pre_umask(mask) \
+  __sanitizer_syscall_pre_impl_umask((long)(mask))
+#define __sanitizer_syscall_post_umask(res, mask) \
+  __sanitizer_syscall_post_impl_umask(res, (long)(mask))
+#define __sanitizer_syscall_pre_msgget(key, msgflg) \
+  __sanitizer_syscall_pre_impl_msgget((long)(key), (long)(msgflg))
+#define __sanitizer_syscall_post_msgget(res, key, msgflg) \
+  __sanitizer_syscall_post_impl_msgget(res, (long)(key), (long)(msgflg))
+#define __sanitizer_syscall_pre_msgsnd(msqid, msgp, msgsz, msgflg) \
+  __sanitizer_syscall_pre_impl_msgsnd((long)(msqid), (long)(msgp), \
+                                      (long)(msgsz), (long)(msgflg))
+#define __sanitizer_syscall_post_msgsnd(res, msqid, msgp, msgsz, msgflg) \
+  __sanitizer_syscall_post_impl_msgsnd(res, (long)(msqid), (long)(msgp), \
+                                       (long)(msgsz), (long)(msgflg))
+#define __sanitizer_syscall_pre_msgrcv(msqid, msgp, msgsz, msgtyp, msgflg) \
+  __sanitizer_syscall_pre_impl_msgrcv((long)(msqid), (long)(msgp),         \
+                                      (long)(msgsz), (long)(msgtyp),       \
+                                      (long)(msgflg))
+#define __sanitizer_syscall_post_msgrcv(res, msqid, msgp, msgsz, msgtyp, \
+                                        msgflg)                          \
+  __sanitizer_syscall_post_impl_msgrcv(res, (long)(msqid), (long)(msgp), \
+                                       (long)(msgsz), (long)(msgtyp),    \
+                                       (long)(msgflg))
+#define __sanitizer_syscall_pre_msgctl(msqid, cmd, buf) \
+  __sanitizer_syscall_pre_impl_msgctl((long)(msqid), (long)(cmd), (long)(buf))
+#define __sanitizer_syscall_post_msgctl(res, msqid, cmd, buf)           \
+  __sanitizer_syscall_post_impl_msgctl(res, (long)(msqid), (long)(cmd), \
+                                       (long)(buf))
+#define __sanitizer_syscall_pre_semget(key, nsems, semflg)        \
+  __sanitizer_syscall_pre_impl_semget((long)(key), (long)(nsems), \
+                                      (long)(semflg))
+#define __sanitizer_syscall_post_semget(res, key, nsems, semflg)        \
+  __sanitizer_syscall_post_impl_semget(res, (long)(key), (long)(nsems), \
+                                       (long)(semflg))
+#define __sanitizer_syscall_pre_semop(semid, sops, nsops) \
+  __sanitizer_syscall_pre_impl_semop((long)(semid), (long)(sops), (long)(nsops))
+#define __sanitizer_syscall_post_semop(res, semid, sops, nsops)         \
+  __sanitizer_syscall_post_impl_semop(res, (long)(semid), (long)(sops), \
+                                      (long)(nsops))
+#define __sanitizer_syscall_pre_semctl(semid, semnum, cmd, arg)      \
+  __sanitizer_syscall_pre_impl_semctl((long)(semid), (long)(semnum), \
+                                      (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_post_semctl(res, semid, semnum, cmd, arg)      \
+  __sanitizer_syscall_post_impl_semctl(res, (long)(semid), (long)(semnum), \
+                                       (long)(cmd), (long)(arg))
+#define __sanitizer_syscall_pre_semtimedop(semid, sops, nsops, timeout) \
+  __sanitizer_syscall_pre_impl_semtimedop((long)(semid), (long)(sops),  \
+                                          (long)(nsops), (long)(timeout))
+#define __sanitizer_syscall_post_semtimedop(res, semid, sops, nsops, timeout) \
+  __sanitizer_syscall_post_impl_semtimedop(res, (long)(semid), (long)(sops),  \
+                                           (long)(nsops), (long)(timeout))
+#define __sanitizer_syscall_pre_shmat(shmid, shmaddr, shmflg)        \
+  __sanitizer_syscall_pre_impl_shmat((long)(shmid), (long)(shmaddr), \
+                                     (long)(shmflg))
+#define __sanitizer_syscall_post_shmat(res, shmid, shmaddr, shmflg)        \
+  __sanitizer_syscall_post_impl_shmat(res, (long)(shmid), (long)(shmaddr), \
+                                      (long)(shmflg))
+#define __sanitizer_syscall_pre_shmget(key, size, flag) \
+  __sanitizer_syscall_pre_impl_shmget((long)(key), (long)(size), (long)(flag))
+#define __sanitizer_syscall_post_shmget(res, key, size, flag)          \
+  __sanitizer_syscall_post_impl_shmget(res, (long)(key), (long)(size), \
+                                       (long)(flag))
+#define __sanitizer_syscall_pre_shmdt(shmaddr) \
+  __sanitizer_syscall_pre_impl_shmdt((long)(shmaddr))
+#define __sanitizer_syscall_post_shmdt(res, shmaddr) \
+  __sanitizer_syscall_post_impl_shmdt(res, (long)(shmaddr))
+#define __sanitizer_syscall_pre_shmctl(shmid, cmd, buf) \
+  __sanitizer_syscall_pre_impl_shmctl((long)(shmid), (long)(cmd), (long)(buf))
+#define __sanitizer_syscall_post_shmctl(res, shmid, cmd, buf)           \
+  __sanitizer_syscall_post_impl_shmctl(res, (long)(shmid), (long)(cmd), \
+                                       (long)(buf))
+#define __sanitizer_syscall_pre_ipc(call, first, second, third, ptr, fifth)    \
+  __sanitizer_syscall_pre_impl_ipc((long)(call), (long)(first),                \
+                                   (long)(second), (long)(third), (long)(ptr), \
+                                   (long)(fifth))
+#define __sanitizer_syscall_post_ipc(res, call, first, second, third, ptr, \
+                                     fifth)                                \
+  __sanitizer_syscall_post_impl_ipc(res, (long)(call), (long)(first),      \
+                                    (long)(second), (long)(third),         \
+                                    (long)(ptr), (long)(fifth))
+#define __sanitizer_syscall_pre_mq_open(name, oflag, mode, attr)    \
+  __sanitizer_syscall_pre_impl_mq_open((long)(name), (long)(oflag), \
+                                       (long)(mode), (long)(attr))
+#define __sanitizer_syscall_post_mq_open(res, name, oflag, mode, attr)    \
+  __sanitizer_syscall_post_impl_mq_open(res, (long)(name), (long)(oflag), \
+                                        (long)(mode), (long)(attr))
+#define __sanitizer_syscall_pre_mq_unlink(name) \
+  __sanitizer_syscall_pre_impl_mq_unlink((long)(name))
+#define __sanitizer_syscall_post_mq_unlink(res, name) \
+  __sanitizer_syscall_post_impl_mq_unlink(res, (long)(name))
+#define __sanitizer_syscall_pre_mq_timedsend(mqdes, msg_ptr, msg_len,          \
+                                             msg_prio, abs_timeout)            \
+  __sanitizer_syscall_pre_impl_mq_timedsend((long)(mqdes), (long)(msg_ptr),    \
+                                            (long)(msg_len), (long)(msg_prio), \
+                                            (long)(abs_timeout))
+#define __sanitizer_syscall_post_mq_timedsend(res, mqdes, msg_ptr, msg_len,   \
+                                              msg_prio, abs_timeout)          \
+  __sanitizer_syscall_post_impl_mq_timedsend(                                 \
+      res, (long)(mqdes), (long)(msg_ptr), (long)(msg_len), (long)(msg_prio), \
+      (long)(abs_timeout))
+#define __sanitizer_syscall_pre_mq_timedreceive(mqdes, msg_ptr, msg_len, \
+                                                msg_prio, abs_timeout)   \
+  __sanitizer_syscall_pre_impl_mq_timedreceive(                          \
+      (long)(mqdes), (long)(msg_ptr), (long)(msg_len), (long)(msg_prio), \
+      (long)(abs_timeout))
+#define __sanitizer_syscall_post_mq_timedreceive(res, mqdes, msg_ptr, msg_len, \
+                                                 msg_prio, abs_timeout)        \
+  __sanitizer_syscall_post_impl_mq_timedreceive(                               \
+      res, (long)(mqdes), (long)(msg_ptr), (long)(msg_len), (long)(msg_prio),  \
+      (long)(abs_timeout))
+#define __sanitizer_syscall_pre_mq_notify(mqdes, notification) \
+  __sanitizer_syscall_pre_impl_mq_notify((long)(mqdes), (long)(notification))
+#define __sanitizer_syscall_post_mq_notify(res, mqdes, notification) \
+  __sanitizer_syscall_post_impl_mq_notify(res, (long)(mqdes),        \
+                                          (long)(notification))
+#define __sanitizer_syscall_pre_mq_getsetattr(mqdes, mqstat, omqstat)       \
+  __sanitizer_syscall_pre_impl_mq_getsetattr((long)(mqdes), (long)(mqstat), \
+                                             (long)(omqstat))
+#define __sanitizer_syscall_post_mq_getsetattr(res, mqdes, mqstat, omqstat) \
+  __sanitizer_syscall_post_impl_mq_getsetattr(res, (long)(mqdes),           \
+                                              (long)(mqstat), (long)(omqstat))
+#define __sanitizer_syscall_pre_pciconfig_iobase(which, bus, devfn)         \
+  __sanitizer_syscall_pre_impl_pciconfig_iobase((long)(which), (long)(bus), \
+                                                (long)(devfn))
+#define __sanitizer_syscall_post_pciconfig_iobase(res, which, bus, devfn) \
+  __sanitizer_syscall_post_impl_pciconfig_iobase(res, (long)(which),      \
+                                                 (long)(bus), (long)(devfn))
+#define __sanitizer_syscall_pre_pciconfig_read(bus, dfn, off, len, buf) \
+  __sanitizer_syscall_pre_impl_pciconfig_read(                          \
+      (long)(bus), (long)(dfn), (long)(off), (long)(len), (long)(buf))
+#define __sanitizer_syscall_post_pciconfig_read(res, bus, dfn, off, len, buf) \
+  __sanitizer_syscall_post_impl_pciconfig_read(                               \
+      res, (long)(bus), (long)(dfn), (long)(off), (long)(len), (long)(buf))
+#define __sanitizer_syscall_pre_pciconfig_write(bus, dfn, off, len, buf) \
+  __sanitizer_syscall_pre_impl_pciconfig_write(                          \
+      (long)(bus), (long)(dfn), (long)(off), (long)(len), (long)(buf))
+#define __sanitizer_syscall_post_pciconfig_write(res, bus, dfn, off, len, buf) \
+  __sanitizer_syscall_post_impl_pciconfig_write(                               \
+      res, (long)(bus), (long)(dfn), (long)(off), (long)(len), (long)(buf))
+#define __sanitizer_syscall_pre_swapon(specialfile, swap_flags) \
+  __sanitizer_syscall_pre_impl_swapon((long)(specialfile), (long)(swap_flags))
+#define __sanitizer_syscall_post_swapon(res, specialfile, swap_flags) \
+  __sanitizer_syscall_post_impl_swapon(res, (long)(specialfile),      \
+                                       (long)(swap_flags))
+#define __sanitizer_syscall_pre_swapoff(specialfile) \
+  __sanitizer_syscall_pre_impl_swapoff((long)(specialfile))
+#define __sanitizer_syscall_post_swapoff(res, specialfile) \
+  __sanitizer_syscall_post_impl_swapoff(res, (long)(specialfile))
+#define __sanitizer_syscall_pre_sysctl(args) \
+  __sanitizer_syscall_pre_impl_sysctl((long)(args))
+#define __sanitizer_syscall_post_sysctl(res, args) \
+  __sanitizer_syscall_post_impl_sysctl(res, (long)(args))
+#define __sanitizer_syscall_pre_sysinfo(info) \
+  __sanitizer_syscall_pre_impl_sysinfo((long)(info))
+#define __sanitizer_syscall_post_sysinfo(res, info) \
+  __sanitizer_syscall_post_impl_sysinfo(res, (long)(info))
+#define __sanitizer_syscall_pre_sysfs(option, arg1, arg2) \
+  __sanitizer_syscall_pre_impl_sysfs((long)(option), (long)(arg1), (long)(arg2))
+#define __sanitizer_syscall_post_sysfs(res, option, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_sysfs(res, (long)(option), (long)(arg1), \
+                                      (long)(arg2))
+#define __sanitizer_syscall_pre_syslog(type, buf, len) \
+  __sanitizer_syscall_pre_impl_syslog((long)(type), (long)(buf), (long)(len))
+#define __sanitizer_syscall_post_syslog(res, type, buf, len)           \
+  __sanitizer_syscall_post_impl_syslog(res, (long)(type), (long)(buf), \
+                                       (long)(len))
+#define __sanitizer_syscall_pre_uselib(library) \
+  __sanitizer_syscall_pre_impl_uselib((long)(library))
+#define __sanitizer_syscall_post_uselib(res, library) \
+  __sanitizer_syscall_post_impl_uselib(res, (long)(library))
+#define __sanitizer_syscall_pre_ni_syscall() \
+  __sanitizer_syscall_pre_impl_ni_syscall()
+#define __sanitizer_syscall_post_ni_syscall(res) \
+  __sanitizer_syscall_post_impl_ni_syscall(res)
+#define __sanitizer_syscall_pre_ptrace(request, pid, addr, data)    \
+  __sanitizer_syscall_pre_impl_ptrace((long)(request), (long)(pid), \
+                                      (long)(addr), (long)(data))
+#define __sanitizer_syscall_post_ptrace(res, request, pid, addr, data)    \
+  __sanitizer_syscall_post_impl_ptrace(res, (long)(request), (long)(pid), \
+                                       (long)(addr), (long)(data))
+#define __sanitizer_syscall_pre_add_key(_type, _description, _payload, plen, \
+                                        destringid)                          \
+  __sanitizer_syscall_pre_impl_add_key((long)(_type), (long)(_description),  \
+                                       (long)(_payload), (long)(plen),       \
+                                       (long)(destringid))
+#define __sanitizer_syscall_post_add_key(res, _type, _description, _payload, \
+                                         plen, destringid)                   \
+  __sanitizer_syscall_post_impl_add_key(                                     \
+      res, (long)(_type), (long)(_description), (long)(_payload),            \
+      (long)(plen), (long)(destringid))
+#define __sanitizer_syscall_pre_request_key(_type, _description,       \
+                                            _callout_info, destringid) \
+  __sanitizer_syscall_pre_impl_request_key(                            \
+      (long)(_type), (long)(_description), (long)(_callout_info),      \
+      (long)(destringid))
+#define __sanitizer_syscall_post_request_key(res, _type, _description,  \
+                                             _callout_info, destringid) \
+  __sanitizer_syscall_post_impl_request_key(                            \
+      res, (long)(_type), (long)(_description), (long)(_callout_info),  \
+      (long)(destringid))
+#define __sanitizer_syscall_pre_keyctl(cmd, arg2, arg3, arg4, arg5)            \
+  __sanitizer_syscall_pre_impl_keyctl((long)(cmd), (long)(arg2), (long)(arg3), \
+                                      (long)(arg4), (long)(arg5))
+#define __sanitizer_syscall_post_keyctl(res, cmd, arg2, arg3, arg4, arg5) \
+  __sanitizer_syscall_post_impl_keyctl(res, (long)(cmd), (long)(arg2),    \
+                                       (long)(arg3), (long)(arg4),        \
+                                       (long)(arg5))
+#define __sanitizer_syscall_pre_ioprio_set(which, who, ioprio)        \
+  __sanitizer_syscall_pre_impl_ioprio_set((long)(which), (long)(who), \
+                                          (long)(ioprio))
+#define __sanitizer_syscall_post_ioprio_set(res, which, who, ioprio)        \
+  __sanitizer_syscall_post_impl_ioprio_set(res, (long)(which), (long)(who), \
+                                           (long)(ioprio))
+#define __sanitizer_syscall_pre_ioprio_get(which, who) \
+  __sanitizer_syscall_pre_impl_ioprio_get((long)(which), (long)(who))
+#define __sanitizer_syscall_post_ioprio_get(res, which, who) \
+  __sanitizer_syscall_post_impl_ioprio_get(res, (long)(which), (long)(who))
+#define __sanitizer_syscall_pre_set_mempolicy(mode, nmask, maxnode)       \
+  __sanitizer_syscall_pre_impl_set_mempolicy((long)(mode), (long)(nmask), \
+                                             (long)(maxnode))
+#define __sanitizer_syscall_post_set_mempolicy(res, mode, nmask, maxnode) \
+  __sanitizer_syscall_post_impl_set_mempolicy(res, (long)(mode),          \
+                                              (long)(nmask), (long)(maxnode))
+#define __sanitizer_syscall_pre_migrate_pages(pid, maxnode, from, to)      \
+  __sanitizer_syscall_pre_impl_migrate_pages((long)(pid), (long)(maxnode), \
+                                             (long)(from), (long)(to))
+#define __sanitizer_syscall_post_migrate_pages(res, pid, maxnode, from, to) \
+  __sanitizer_syscall_post_impl_migrate_pages(                              \
+      res, (long)(pid), (long)(maxnode), (long)(from), (long)(to))
+#define __sanitizer_syscall_pre_move_pages(pid, nr_pages, pages, nodes,  \
+                                           status, flags)                \
+  __sanitizer_syscall_pre_impl_move_pages((long)(pid), (long)(nr_pages), \
+                                          (long)(pages), (long)(nodes),  \
+                                          (long)(status), (long)(flags))
+#define __sanitizer_syscall_post_move_pages(res, pid, nr_pages, pages, nodes,  \
+                                            status, flags)                     \
+  __sanitizer_syscall_post_impl_move_pages(res, (long)(pid), (long)(nr_pages), \
+                                           (long)(pages), (long)(nodes),       \
+                                           (long)(status), (long)(flags))
+#define __sanitizer_syscall_pre_mbind(start, len, mode, nmask, maxnode, flags) \
+  __sanitizer_syscall_pre_impl_mbind((long)(start), (long)(len), (long)(mode), \
+                                     (long)(nmask), (long)(maxnode),           \
+                                     (long)(flags))
+#define __sanitizer_syscall_post_mbind(res, start, len, mode, nmask, maxnode, \
+                                       flags)                                 \
+  __sanitizer_syscall_post_impl_mbind(res, (long)(start), (long)(len),        \
+                                      (long)(mode), (long)(nmask),            \
+                                      (long)(maxnode), (long)(flags))
+#define __sanitizer_syscall_pre_get_mempolicy(policy, nmask, maxnode, addr, \
+                                              flags)                        \
+  __sanitizer_syscall_pre_impl_get_mempolicy((long)(policy), (long)(nmask), \
+                                             (long)(maxnode), (long)(addr), \
+                                             (long)(flags))
+#define __sanitizer_syscall_post_get_mempolicy(res, policy, nmask, maxnode,   \
+                                               addr, flags)                   \
+  __sanitizer_syscall_post_impl_get_mempolicy(res, (long)(policy),            \
+                                              (long)(nmask), (long)(maxnode), \
+                                              (long)(addr), (long)(flags))
+#define __sanitizer_syscall_pre_inotify_init() \
+  __sanitizer_syscall_pre_impl_inotify_init()
+#define __sanitizer_syscall_post_inotify_init(res) \
+  __sanitizer_syscall_post_impl_inotify_init(res)
+#define __sanitizer_syscall_pre_inotify_init1(flags) \
+  __sanitizer_syscall_pre_impl_inotify_init1((long)(flags))
+#define __sanitizer_syscall_post_inotify_init1(res, flags) \
+  __sanitizer_syscall_post_impl_inotify_init1(res, (long)(flags))
+#define __sanitizer_syscall_pre_inotify_add_watch(fd, path, mask)          \
+  __sanitizer_syscall_pre_impl_inotify_add_watch((long)(fd), (long)(path), \
+                                                 (long)(mask))
+#define __sanitizer_syscall_post_inotify_add_watch(res, fd, path, mask) \
+  __sanitizer_syscall_post_impl_inotify_add_watch(res, (long)(fd),      \
+                                                  (long)(path), (long)(mask))
+#define __sanitizer_syscall_pre_inotify_rm_watch(fd, wd) \
+  __sanitizer_syscall_pre_impl_inotify_rm_watch((long)(fd), (long)(wd))
+#define __sanitizer_syscall_post_inotify_rm_watch(res, fd, wd) \
+  __sanitizer_syscall_post_impl_inotify_rm_watch(res, (long)(fd), (long)(wd))
+#define __sanitizer_syscall_pre_spu_run(fd, unpc, ustatus)       \
+  __sanitizer_syscall_pre_impl_spu_run((long)(fd), (long)(unpc), \
+                                       (long)(ustatus))
+#define __sanitizer_syscall_post_spu_run(res, fd, unpc, ustatus)       \
+  __sanitizer_syscall_post_impl_spu_run(res, (long)(fd), (long)(unpc), \
+                                        (long)(ustatus))
+#define __sanitizer_syscall_pre_spu_create(name, flags, mode, fd)      \
+  __sanitizer_syscall_pre_impl_spu_create((long)(name), (long)(flags), \
+                                          (long)(mode), (long)(fd))
+#define __sanitizer_syscall_post_spu_create(res, name, flags, mode, fd)      \
+  __sanitizer_syscall_post_impl_spu_create(res, (long)(name), (long)(flags), \
+                                           (long)(mode), (long)(fd))
+#define __sanitizer_syscall_pre_mknodat(dfd, filename, mode, dev)     \
+  __sanitizer_syscall_pre_impl_mknodat((long)(dfd), (long)(filename), \
+                                       (long)(mode), (long)(dev))
+#define __sanitizer_syscall_post_mknodat(res, dfd, filename, mode, dev)     \
+  __sanitizer_syscall_post_impl_mknodat(res, (long)(dfd), (long)(filename), \
+                                        (long)(mode), (long)(dev))
+#define __sanitizer_syscall_pre_mkdirat(dfd, pathname, mode)          \
+  __sanitizer_syscall_pre_impl_mkdirat((long)(dfd), (long)(pathname), \
+                                       (long)(mode))
+#define __sanitizer_syscall_post_mkdirat(res, dfd, pathname, mode)          \
+  __sanitizer_syscall_post_impl_mkdirat(res, (long)(dfd), (long)(pathname), \
+                                        (long)(mode))
+#define __sanitizer_syscall_pre_unlinkat(dfd, pathname, flag)          \
+  __sanitizer_syscall_pre_impl_unlinkat((long)(dfd), (long)(pathname), \
+                                        (long)(flag))
+#define __sanitizer_syscall_post_unlinkat(res, dfd, pathname, flag)          \
+  __sanitizer_syscall_post_impl_unlinkat(res, (long)(dfd), (long)(pathname), \
+                                         (long)(flag))
+#define __sanitizer_syscall_pre_symlinkat(oldname, newdfd, newname)       \
+  __sanitizer_syscall_pre_impl_symlinkat((long)(oldname), (long)(newdfd), \
+                                         (long)(newname))
+#define __sanitizer_syscall_post_symlinkat(res, oldname, newdfd, newname) \
+  __sanitizer_syscall_post_impl_symlinkat(res, (long)(oldname),           \
+                                          (long)(newdfd), (long)(newname))
+#define __sanitizer_syscall_pre_linkat(olddfd, oldname, newdfd, newname, \
+                                       flags)                            \
+  __sanitizer_syscall_pre_impl_linkat((long)(olddfd), (long)(oldname),   \
+                                      (long)(newdfd), (long)(newname),   \
+                                      (long)(flags))
+#define __sanitizer_syscall_post_linkat(res, olddfd, oldname, newdfd, newname, \
+                                        flags)                                 \
+  __sanitizer_syscall_post_impl_linkat(res, (long)(olddfd), (long)(oldname),   \
+                                       (long)(newdfd), (long)(newname),        \
+                                       (long)(flags))
+#define __sanitizer_syscall_pre_renameat(olddfd, oldname, newdfd, newname) \
+  __sanitizer_syscall_pre_impl_renameat((long)(olddfd), (long)(oldname),   \
+                                        (long)(newdfd), (long)(newname))
+#define __sanitizer_syscall_post_renameat(res, olddfd, oldname, newdfd,        \
+                                          newname)                             \
+  __sanitizer_syscall_post_impl_renameat(res, (long)(olddfd), (long)(oldname), \
+                                         (long)(newdfd), (long)(newname))
+#define __sanitizer_syscall_pre_futimesat(dfd, filename, utimes)        \
+  __sanitizer_syscall_pre_impl_futimesat((long)(dfd), (long)(filename), \
+                                         (long)(utimes))
+#define __sanitizer_syscall_post_futimesat(res, dfd, filename, utimes)        \
+  __sanitizer_syscall_post_impl_futimesat(res, (long)(dfd), (long)(filename), \
+                                          (long)(utimes))
+#define __sanitizer_syscall_pre_faccessat(dfd, filename, mode)          \
+  __sanitizer_syscall_pre_impl_faccessat((long)(dfd), (long)(filename), \
+                                         (long)(mode))
+#define __sanitizer_syscall_post_faccessat(res, dfd, filename, mode)          \
+  __sanitizer_syscall_post_impl_faccessat(res, (long)(dfd), (long)(filename), \
+                                          (long)(mode))
+#define __sanitizer_syscall_pre_fchmodat(dfd, filename, mode)          \
+  __sanitizer_syscall_pre_impl_fchmodat((long)(dfd), (long)(filename), \
+                                        (long)(mode))
+#define __sanitizer_syscall_post_fchmodat(res, dfd, filename, mode)          \
+  __sanitizer_syscall_post_impl_fchmodat(res, (long)(dfd), (long)(filename), \
+                                         (long)(mode))
+#define __sanitizer_syscall_pre_fchownat(dfd, filename, user, group, flag) \
+  __sanitizer_syscall_pre_impl_fchownat((long)(dfd), (long)(filename),     \
+                                        (long)(user), (long)(group),       \
+                                        (long)(flag))
+#define __sanitizer_syscall_post_fchownat(res, dfd, filename, user, group,   \
+                                          flag)                              \
+  __sanitizer_syscall_post_impl_fchownat(res, (long)(dfd), (long)(filename), \
+                                         (long)(user), (long)(group),        \
+                                         (long)(flag))
+#define __sanitizer_syscall_pre_openat(dfd, filename, flags, mode)   \
+  __sanitizer_syscall_pre_impl_openat((long)(dfd), (long)(filename), \
+                                      (long)(flags), (long)(mode))
+#define __sanitizer_syscall_post_openat(res, dfd, filename, flags, mode)   \
+  __sanitizer_syscall_post_impl_openat(res, (long)(dfd), (long)(filename), \
+                                       (long)(flags), (long)(mode))
+#define __sanitizer_syscall_pre_newfstatat(dfd, filename, statbuf, flag) \
+  __sanitizer_syscall_pre_impl_newfstatat((long)(dfd), (long)(filename), \
+                                          (long)(statbuf), (long)(flag))
+#define __sanitizer_syscall_post_newfstatat(res, dfd, filename, statbuf, flag) \
+  __sanitizer_syscall_post_impl_newfstatat(res, (long)(dfd), (long)(filename), \
+                                           (long)(statbuf), (long)(flag))
+#define __sanitizer_syscall_pre_fstatat64(dfd, filename, statbuf, flag) \
+  __sanitizer_syscall_pre_impl_fstatat64((long)(dfd), (long)(filename), \
+                                         (long)(statbuf), (long)(flag))
+#define __sanitizer_syscall_post_fstatat64(res, dfd, filename, statbuf, flag) \
+  __sanitizer_syscall_post_impl_fstatat64(res, (long)(dfd), (long)(filename), \
+                                          (long)(statbuf), (long)(flag))
+#define __sanitizer_syscall_pre_readlinkat(dfd, path, buf, bufsiz)   \
+  __sanitizer_syscall_pre_impl_readlinkat((long)(dfd), (long)(path), \
+                                          (long)(buf), (long)(bufsiz))
+#define __sanitizer_syscall_post_readlinkat(res, dfd, path, buf, bufsiz)   \
+  __sanitizer_syscall_post_impl_readlinkat(res, (long)(dfd), (long)(path), \
+                                           (long)(buf), (long)(bufsiz))
+#define __sanitizer_syscall_pre_utimensat(dfd, filename, utimes, flags) \
+  __sanitizer_syscall_pre_impl_utimensat((long)(dfd), (long)(filename), \
+                                         (long)(utimes), (long)(flags))
+#define __sanitizer_syscall_post_utimensat(res, dfd, filename, utimes, flags) \
+  __sanitizer_syscall_post_impl_utimensat(res, (long)(dfd), (long)(filename), \
+                                          (long)(utimes), (long)(flags))
+#define __sanitizer_syscall_pre_unshare(unshare_flags) \
+  __sanitizer_syscall_pre_impl_unshare((long)(unshare_flags))
+#define __sanitizer_syscall_post_unshare(res, unshare_flags) \
+  __sanitizer_syscall_post_impl_unshare(res, (long)(unshare_flags))
+#define __sanitizer_syscall_pre_splice(fd_in, off_in, fd_out, off_out, len, \
+                                       flags)                               \
+  __sanitizer_syscall_pre_impl_splice((long)(fd_in), (long)(off_in),        \
+                                      (long)(fd_out), (long)(off_out),      \
+                                      (long)(len), (long)(flags))
+#define __sanitizer_syscall_post_splice(res, fd_in, off_in, fd_out, off_out, \
+                                        len, flags)                          \
+  __sanitizer_syscall_post_impl_splice(res, (long)(fd_in), (long)(off_in),   \
+                                       (long)(fd_out), (long)(off_out),      \
+                                       (long)(len), (long)(flags))
+#define __sanitizer_syscall_pre_vmsplice(fd, iov, nr_segs, flags) \
+  __sanitizer_syscall_pre_impl_vmsplice((long)(fd), (long)(iov),  \
+                                        (long)(nr_segs), (long)(flags))
+#define __sanitizer_syscall_post_vmsplice(res, fd, iov, nr_segs, flags) \
+  __sanitizer_syscall_post_impl_vmsplice(res, (long)(fd), (long)(iov),  \
+                                         (long)(nr_segs), (long)(flags))
+#define __sanitizer_syscall_pre_tee(fdin, fdout, len, flags)                 \
+  __sanitizer_syscall_pre_impl_tee((long)(fdin), (long)(fdout), (long)(len), \
+                                   (long)(flags))
+#define __sanitizer_syscall_post_tee(res, fdin, fdout, len, flags)    \
+  __sanitizer_syscall_post_impl_tee(res, (long)(fdin), (long)(fdout), \
+                                    (long)(len), (long)(flags))
+#define __sanitizer_syscall_pre_get_robust_list(pid, head_ptr, len_ptr)       \
+  __sanitizer_syscall_pre_impl_get_robust_list((long)(pid), (long)(head_ptr), \
+                                               (long)(len_ptr))
+#define __sanitizer_syscall_post_get_robust_list(res, pid, head_ptr, len_ptr) \
+  __sanitizer_syscall_post_impl_get_robust_list(                              \
+      res, (long)(pid), (long)(head_ptr), (long)(len_ptr))
+#define __sanitizer_syscall_pre_set_robust_list(head, len) \
+  __sanitizer_syscall_pre_impl_set_robust_list((long)(head), (long)(len))
+#define __sanitizer_syscall_post_set_robust_list(res, head, len) \
+  __sanitizer_syscall_post_impl_set_robust_list(res, (long)(head), (long)(len))
+#define __sanitizer_syscall_pre_getcpu(cpu, node, cache) \
+  __sanitizer_syscall_pre_impl_getcpu((long)(cpu), (long)(node), (long)(cache))
+#define __sanitizer_syscall_post_getcpu(res, cpu, node, cache)         \
+  __sanitizer_syscall_post_impl_getcpu(res, (long)(cpu), (long)(node), \
+                                       (long)(cache))
+#define __sanitizer_syscall_pre_signalfd(ufd, user_mask, sizemask)      \
+  __sanitizer_syscall_pre_impl_signalfd((long)(ufd), (long)(user_mask), \
+                                        (long)(sizemask))
+#define __sanitizer_syscall_post_signalfd(res, ufd, user_mask, sizemask)      \
+  __sanitizer_syscall_post_impl_signalfd(res, (long)(ufd), (long)(user_mask), \
+                                         (long)(sizemask))
+#define __sanitizer_syscall_pre_signalfd4(ufd, user_mask, sizemask, flags) \
+  __sanitizer_syscall_pre_impl_signalfd4((long)(ufd), (long)(user_mask),   \
+                                         (long)(sizemask), (long)(flags))
+#define __sanitizer_syscall_post_signalfd4(res, ufd, user_mask, sizemask,      \
+                                           flags)                              \
+  __sanitizer_syscall_post_impl_signalfd4(res, (long)(ufd), (long)(user_mask), \
+                                          (long)(sizemask), (long)(flags))
+#define __sanitizer_syscall_pre_timerfd_create(clockid, flags) \
+  __sanitizer_syscall_pre_impl_timerfd_create((long)(clockid), (long)(flags))
+#define __sanitizer_syscall_post_timerfd_create(res, clockid, flags) \
+  __sanitizer_syscall_post_impl_timerfd_create(res, (long)(clockid), \
+                                               (long)(flags))
+#define __sanitizer_syscall_pre_timerfd_settime(ufd, flags, utmr, otmr)    \
+  __sanitizer_syscall_pre_impl_timerfd_settime((long)(ufd), (long)(flags), \
+                                               (long)(utmr), (long)(otmr))
+#define __sanitizer_syscall_post_timerfd_settime(res, ufd, flags, utmr, otmr) \
+  __sanitizer_syscall_post_impl_timerfd_settime(                              \
+      res, (long)(ufd), (long)(flags), (long)(utmr), (long)(otmr))
+#define __sanitizer_syscall_pre_timerfd_gettime(ufd, otmr) \
+  __sanitizer_syscall_pre_impl_timerfd_gettime((long)(ufd), (long)(otmr))
+#define __sanitizer_syscall_post_timerfd_gettime(res, ufd, otmr) \
+  __sanitizer_syscall_post_impl_timerfd_gettime(res, (long)(ufd), (long)(otmr))
+#define __sanitizer_syscall_pre_eventfd(count) \
+  __sanitizer_syscall_pre_impl_eventfd((long)(count))
+#define __sanitizer_syscall_post_eventfd(res, count) \
+  __sanitizer_syscall_post_impl_eventfd(res, (long)(count))
+#define __sanitizer_syscall_pre_eventfd2(count, flags) \
+  __sanitizer_syscall_pre_impl_eventfd2((long)(count), (long)(flags))
+#define __sanitizer_syscall_post_eventfd2(res, count, flags) \
+  __sanitizer_syscall_post_impl_eventfd2(res, (long)(count), (long)(flags))
+#define __sanitizer_syscall_pre_old_readdir(arg0, arg1, arg2)          \
+  __sanitizer_syscall_pre_impl_old_readdir((long)(arg0), (long)(arg1), \
+                                           (long)(arg2))
+#define __sanitizer_syscall_post_old_readdir(res, arg0, arg1, arg2)          \
+  __sanitizer_syscall_post_impl_old_readdir(res, (long)(arg0), (long)(arg1), \
+                                            (long)(arg2))
+#define __sanitizer_syscall_pre_pselect6(arg0, arg1, arg2, arg3, arg4, arg5) \
+  __sanitizer_syscall_pre_impl_pselect6((long)(arg0), (long)(arg1),          \
+                                        (long)(arg2), (long)(arg3),          \
+                                        (long)(arg4), (long)(arg5))
+#define __sanitizer_syscall_post_pselect6(res, arg0, arg1, arg2, arg3, arg4, \
+                                          arg5)                              \
+  __sanitizer_syscall_post_impl_pselect6(res, (long)(arg0), (long)(arg1),    \
+                                         (long)(arg2), (long)(arg3),         \
+                                         (long)(arg4), (long)(arg5))
+#define __sanitizer_syscall_pre_ppoll(arg0, arg1, arg2, arg3, arg4)            \
+  __sanitizer_syscall_pre_impl_ppoll((long)(arg0), (long)(arg1), (long)(arg2), \
+                                     (long)(arg3), (long)(arg4))
+#define __sanitizer_syscall_post_ppoll(res, arg0, arg1, arg2, arg3, arg4) \
+  __sanitizer_syscall_post_impl_ppoll(res, (long)(arg0), (long)(arg1),    \
+                                      (long)(arg2), (long)(arg3),         \
+                                      (long)(arg4))
+#define __sanitizer_syscall_pre_syncfs(fd) \
+  __sanitizer_syscall_pre_impl_syncfs((long)(fd))
+#define __sanitizer_syscall_post_syncfs(res, fd) \
+  __sanitizer_syscall_post_impl_syncfs(res, (long)(fd))
+#define __sanitizer_syscall_pre_perf_event_open(attr_uptr, pid, cpu, group_fd, \
+                                                flags)                         \
+  __sanitizer_syscall_pre_impl_perf_event_open((long)(attr_uptr), (long)(pid), \
+                                               (long)(cpu), (long)(group_fd),  \
+                                               (long)(flags))
+#define __sanitizer_syscall_post_perf_event_open(res, attr_uptr, pid, cpu, \
+                                                 group_fd, flags)          \
+  __sanitizer_syscall_post_impl_perf_event_open(                           \
+      res, (long)(attr_uptr), (long)(pid), (long)(cpu), (long)(group_fd),  \
+      (long)(flags))
+#define __sanitizer_syscall_pre_mmap_pgoff(addr, len, prot, flags, fd, pgoff) \
+  __sanitizer_syscall_pre_impl_mmap_pgoff((long)(addr), (long)(len),          \
+                                          (long)(prot), (long)(flags),        \
+                                          (long)(fd), (long)(pgoff))
+#define __sanitizer_syscall_post_mmap_pgoff(res, addr, len, prot, flags, fd, \
+                                            pgoff)                           \
+  __sanitizer_syscall_post_impl_mmap_pgoff(res, (long)(addr), (long)(len),   \
+                                           (long)(prot), (long)(flags),      \
+                                           (long)(fd), (long)(pgoff))
+#define __sanitizer_syscall_pre_old_mmap(arg) \
+  __sanitizer_syscall_pre_impl_old_mmap((long)(arg))
+#define __sanitizer_syscall_post_old_mmap(res, arg) \
+  __sanitizer_syscall_post_impl_old_mmap(res, (long)(arg))
+#define __sanitizer_syscall_pre_name_to_handle_at(dfd, name, handle, mnt_id, \
+                                                  flag)                      \
+  __sanitizer_syscall_pre_impl_name_to_handle_at(                            \
+      (long)(dfd), (long)(name), (long)(handle), (long)(mnt_id), (long)(flag))
+#define __sanitizer_syscall_post_name_to_handle_at(res, dfd, name, handle, \
+                                                   mnt_id, flag)           \
+  __sanitizer_syscall_post_impl_name_to_handle_at(                         \
+      res, (long)(dfd), (long)(name), (long)(handle), (long)(mnt_id),      \
+      (long)(flag))
+#define __sanitizer_syscall_pre_open_by_handle_at(mountdirfd, handle, flags) \
+  __sanitizer_syscall_pre_impl_open_by_handle_at(                            \
+      (long)(mountdirfd), (long)(handle), (long)(flags))
+#define __sanitizer_syscall_post_open_by_handle_at(res, mountdirfd, handle, \
+                                                   flags)                   \
+  __sanitizer_syscall_post_impl_open_by_handle_at(                          \
+      res, (long)(mountdirfd), (long)(handle), (long)(flags))
+#define __sanitizer_syscall_pre_setns(fd, nstype) \
+  __sanitizer_syscall_pre_impl_setns((long)(fd), (long)(nstype))
+#define __sanitizer_syscall_post_setns(res, fd, nstype) \
+  __sanitizer_syscall_post_impl_setns(res, (long)(fd), (long)(nstype))
+#define __sanitizer_syscall_pre_process_vm_readv(pid, lvec, liovcnt, rvec, \
+                                                 riovcnt, flags)           \
+  __sanitizer_syscall_pre_impl_process_vm_readv(                           \
+      (long)(pid), (long)(lvec), (long)(liovcnt), (long)(rvec),            \
+      (long)(riovcnt), (long)(flags))
+#define __sanitizer_syscall_post_process_vm_readv(res, pid, lvec, liovcnt, \
+                                                  rvec, riovcnt, flags)    \
+  __sanitizer_syscall_post_impl_process_vm_readv(                          \
+      res, (long)(pid), (long)(lvec), (long)(liovcnt), (long)(rvec),       \
+      (long)(riovcnt), (long)(flags))
+#define __sanitizer_syscall_pre_process_vm_writev(pid, lvec, liovcnt, rvec, \
+                                                  riovcnt, flags)           \
+  __sanitizer_syscall_pre_impl_process_vm_writev(                           \
+      (long)(pid), (long)(lvec), (long)(liovcnt), (long)(rvec),             \
+      (long)(riovcnt), (long)(flags))
+#define __sanitizer_syscall_post_process_vm_writev(res, pid, lvec, liovcnt, \
+                                                   rvec, riovcnt, flags)    \
+  __sanitizer_syscall_post_impl_process_vm_writev(                          \
+      res, (long)(pid), (long)(lvec), (long)(liovcnt), (long)(rvec),        \
+      (long)(riovcnt), (long)(flags))
+#define __sanitizer_syscall_pre_fork() \
+  __sanitizer_syscall_pre_impl_fork()
+#define __sanitizer_syscall_post_fork(res) \
+  __sanitizer_syscall_post_impl_fork(res)
+#define __sanitizer_syscall_pre_vfork() \
+  __sanitizer_syscall_pre_impl_vfork()
+#define __sanitizer_syscall_post_vfork(res) \
+  __sanitizer_syscall_post_impl_vfork(res)
+#define __sanitizer_syscall_pre_sigaction(signum, act, oldact)                 \
+  __sanitizer_syscall_pre_impl_sigaction((long)signum, (long)act, (long)oldact)
+#define __sanitizer_syscall_post_sigaction(res, signum, act, oldact)           \
+  __sanitizer_syscall_post_impl_sigaction(res, (long)signum, (long)act,        \
+                                          (long)oldact)
+#define __sanitizer_syscall_pre_rt_sigaction(signum, act, oldact, sz)          \
+  __sanitizer_syscall_pre_impl_rt_sigaction((long)signum, (long)act,           \
+                                            (long)oldact, (long)sz)
+#define __sanitizer_syscall_post_rt_sigaction(res, signum, act, oldact, sz)    \
+  __sanitizer_syscall_post_impl_rt_sigaction(res, (long)signum, (long)act,     \
+                                             (long)oldact, (long)sz)
+
+// And now a few syscalls we don't handle yet.
+#define __sanitizer_syscall_pre_afs_syscall(...)
+#define __sanitizer_syscall_pre_arch_prctl(...)
+#define __sanitizer_syscall_pre_break(...)
+#define __sanitizer_syscall_pre_chown32(...)
+#define __sanitizer_syscall_pre_clone(...)
+#define __sanitizer_syscall_pre_create_module(...)
+#define __sanitizer_syscall_pre_epoll_ctl_old(...)
+#define __sanitizer_syscall_pre_epoll_wait_old(...)
+#define __sanitizer_syscall_pre_execve(...)
+#define __sanitizer_syscall_pre_fadvise64(...)
+#define __sanitizer_syscall_pre_fadvise64_64(...)
+#define __sanitizer_syscall_pre_fallocate(...)
+#define __sanitizer_syscall_pre_fanotify_init(...)
+#define __sanitizer_syscall_pre_fanotify_mark(...)
+#define __sanitizer_syscall_pre_fchown32(...)
+#define __sanitizer_syscall_pre_ftime(...)
+#define __sanitizer_syscall_pre_ftruncate64(...)
+#define __sanitizer_syscall_pre_futex(...)
+#define __sanitizer_syscall_pre_getegid32(...)
+#define __sanitizer_syscall_pre_geteuid32(...)
+#define __sanitizer_syscall_pre_getgid32(...)
+#define __sanitizer_syscall_pre_getgroups32(...)
+#define __sanitizer_syscall_pre_get_kernel_syms(...)
+#define __sanitizer_syscall_pre_getpmsg(...)
+#define __sanitizer_syscall_pre_getresgid32(...)
+#define __sanitizer_syscall_pre_getresuid32(...)
+#define __sanitizer_syscall_pre_get_thread_area(...)
+#define __sanitizer_syscall_pre_getuid32(...)
+#define __sanitizer_syscall_pre_gtty(...)
+#define __sanitizer_syscall_pre_idle(...)
+#define __sanitizer_syscall_pre_iopl(...)
+#define __sanitizer_syscall_pre_lchown32(...)
+#define __sanitizer_syscall_pre__llseek(...)
+#define __sanitizer_syscall_pre_lock(...)
+#define __sanitizer_syscall_pre_madvise1(...)
+#define __sanitizer_syscall_pre_mmap(...)
+#define __sanitizer_syscall_pre_mmap2(...)
+#define __sanitizer_syscall_pre_modify_ldt(...)
+#define __sanitizer_syscall_pre_mpx(...)
+#define __sanitizer_syscall_pre__newselect(...)
+#define __sanitizer_syscall_pre_nfsservctl(...)
+#define __sanitizer_syscall_pre_oldfstat(...)
+#define __sanitizer_syscall_pre_oldlstat(...)
+#define __sanitizer_syscall_pre_oldolduname(...)
+#define __sanitizer_syscall_pre_oldstat(...)
+#define __sanitizer_syscall_pre_prctl(...)
+#define __sanitizer_syscall_pre_prof(...)
+#define __sanitizer_syscall_pre_profil(...)
+#define __sanitizer_syscall_pre_putpmsg(...)
+#define __sanitizer_syscall_pre_query_module(...)
+#define __sanitizer_syscall_pre_readahead(...)
+#define __sanitizer_syscall_pre_readdir(...)
+#define __sanitizer_syscall_pre_rt_sigreturn(...)
+#define __sanitizer_syscall_pre_rt_sigsuspend(...)
+#define __sanitizer_syscall_pre_security(...)
+#define __sanitizer_syscall_pre_setfsgid32(...)
+#define __sanitizer_syscall_pre_setfsuid32(...)
+#define __sanitizer_syscall_pre_setgid32(...)
+#define __sanitizer_syscall_pre_setgroups32(...)
+#define __sanitizer_syscall_pre_setregid32(...)
+#define __sanitizer_syscall_pre_setresgid32(...)
+#define __sanitizer_syscall_pre_setresuid32(...)
+#define __sanitizer_syscall_pre_setreuid32(...)
+#define __sanitizer_syscall_pre_set_thread_area(...)
+#define __sanitizer_syscall_pre_setuid32(...)
+#define __sanitizer_syscall_pre_sigaltstack(...)
+#define __sanitizer_syscall_pre_sigreturn(...)
+#define __sanitizer_syscall_pre_sigsuspend(...)
+#define __sanitizer_syscall_pre_stty(...)
+#define __sanitizer_syscall_pre_sync_file_range(...)
+#define __sanitizer_syscall_pre__sysctl(...)
+#define __sanitizer_syscall_pre_truncate64(...)
+#define __sanitizer_syscall_pre_tuxcall(...)
+#define __sanitizer_syscall_pre_ugetrlimit(...)
+#define __sanitizer_syscall_pre_ulimit(...)
+#define __sanitizer_syscall_pre_umount2(...)
+#define __sanitizer_syscall_pre_vm86(...)
+#define __sanitizer_syscall_pre_vm86old(...)
+#define __sanitizer_syscall_pre_vserver(...)
+
+#define __sanitizer_syscall_post_afs_syscall(res, ...)
+#define __sanitizer_syscall_post_arch_prctl(res, ...)
+#define __sanitizer_syscall_post_break(res, ...)
+#define __sanitizer_syscall_post_chown32(res, ...)
+#define __sanitizer_syscall_post_clone(res, ...)
+#define __sanitizer_syscall_post_create_module(res, ...)
+#define __sanitizer_syscall_post_epoll_ctl_old(res, ...)
+#define __sanitizer_syscall_post_epoll_wait_old(res, ...)
+#define __sanitizer_syscall_post_execve(res, ...)
+#define __sanitizer_syscall_post_fadvise64(res, ...)
+#define __sanitizer_syscall_post_fadvise64_64(res, ...)
+#define __sanitizer_syscall_post_fallocate(res, ...)
+#define __sanitizer_syscall_post_fanotify_init(res, ...)
+#define __sanitizer_syscall_post_fanotify_mark(res, ...)
+#define __sanitizer_syscall_post_fchown32(res, ...)
+#define __sanitizer_syscall_post_ftime(res, ...)
+#define __sanitizer_syscall_post_ftruncate64(res, ...)
+#define __sanitizer_syscall_post_futex(res, ...)
+#define __sanitizer_syscall_post_getegid32(res, ...)
+#define __sanitizer_syscall_post_geteuid32(res, ...)
+#define __sanitizer_syscall_post_getgid32(res, ...)
+#define __sanitizer_syscall_post_getgroups32(res, ...)
+#define __sanitizer_syscall_post_get_kernel_syms(res, ...)
+#define __sanitizer_syscall_post_getpmsg(res, ...)
+#define __sanitizer_syscall_post_getresgid32(res, ...)
+#define __sanitizer_syscall_post_getresuid32(res, ...)
+#define __sanitizer_syscall_post_get_thread_area(res, ...)
+#define __sanitizer_syscall_post_getuid32(res, ...)
+#define __sanitizer_syscall_post_gtty(res, ...)
+#define __sanitizer_syscall_post_idle(res, ...)
+#define __sanitizer_syscall_post_iopl(res, ...)
+#define __sanitizer_syscall_post_lchown32(res, ...)
+#define __sanitizer_syscall_post__llseek(res, ...)
+#define __sanitizer_syscall_post_lock(res, ...)
+#define __sanitizer_syscall_post_madvise1(res, ...)
+#define __sanitizer_syscall_post_mmap2(res, ...)
+#define __sanitizer_syscall_post_mmap(res, ...)
+#define __sanitizer_syscall_post_modify_ldt(res, ...)
+#define __sanitizer_syscall_post_mpx(res, ...)
+#define __sanitizer_syscall_post__newselect(res, ...)
+#define __sanitizer_syscall_post_nfsservctl(res, ...)
+#define __sanitizer_syscall_post_oldfstat(res, ...)
+#define __sanitizer_syscall_post_oldlstat(res, ...)
+#define __sanitizer_syscall_post_oldolduname(res, ...)
+#define __sanitizer_syscall_post_oldstat(res, ...)
+#define __sanitizer_syscall_post_prctl(res, ...)
+#define __sanitizer_syscall_post_profil(res, ...)
+#define __sanitizer_syscall_post_prof(res, ...)
+#define __sanitizer_syscall_post_putpmsg(res, ...)
+#define __sanitizer_syscall_post_query_module(res, ...)
+#define __sanitizer_syscall_post_readahead(res, ...)
+#define __sanitizer_syscall_post_readdir(res, ...)
+#define __sanitizer_syscall_post_rt_sigreturn(res, ...)
+#define __sanitizer_syscall_post_rt_sigsuspend(res, ...)
+#define __sanitizer_syscall_post_security(res, ...)
+#define __sanitizer_syscall_post_setfsgid32(res, ...)
+#define __sanitizer_syscall_post_setfsuid32(res, ...)
+#define __sanitizer_syscall_post_setgid32(res, ...)
+#define __sanitizer_syscall_post_setgroups32(res, ...)
+#define __sanitizer_syscall_post_setregid32(res, ...)
+#define __sanitizer_syscall_post_setresgid32(res, ...)
+#define __sanitizer_syscall_post_setresuid32(res, ...)
+#define __sanitizer_syscall_post_setreuid32(res, ...)
+#define __sanitizer_syscall_post_set_thread_area(res, ...)
+#define __sanitizer_syscall_post_setuid32(res, ...)
+#define __sanitizer_syscall_post_sigaltstack(res, ...)
+#define __sanitizer_syscall_post_sigreturn(res, ...)
+#define __sanitizer_syscall_post_sigsuspend(res, ...)
+#define __sanitizer_syscall_post_stty(res, ...)
+#define __sanitizer_syscall_post_sync_file_range(res, ...)
+#define __sanitizer_syscall_post__sysctl(res, ...)
+#define __sanitizer_syscall_post_truncate64(res, ...)
+#define __sanitizer_syscall_post_tuxcall(res, ...)
+#define __sanitizer_syscall_post_ugetrlimit(res, ...)
+#define __sanitizer_syscall_post_ulimit(res, ...)
+#define __sanitizer_syscall_post_umount2(res, ...)
+#define __sanitizer_syscall_post_vm86old(res, ...)
+#define __sanitizer_syscall_post_vm86(res, ...)
+#define __sanitizer_syscall_post_vserver(res, ...)
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Private declarations. Do not call directly from user code. Use macros above.
+void __sanitizer_syscall_pre_impl_time(long tloc);
+void __sanitizer_syscall_post_impl_time(long res, long tloc);
+void __sanitizer_syscall_pre_impl_stime(long tptr);
+void __sanitizer_syscall_post_impl_stime(long res, long tptr);
+void __sanitizer_syscall_pre_impl_gettimeofday(long tv, long tz);
+void __sanitizer_syscall_post_impl_gettimeofday(long res, long tv, long tz);
+void __sanitizer_syscall_pre_impl_settimeofday(long tv, long tz);
+void __sanitizer_syscall_post_impl_settimeofday(long res, long tv, long tz);
+void __sanitizer_syscall_pre_impl_adjtimex(long txc_p);
+void __sanitizer_syscall_post_impl_adjtimex(long res, long txc_p);
+void __sanitizer_syscall_pre_impl_times(long tbuf);
+void __sanitizer_syscall_post_impl_times(long res, long tbuf);
+void __sanitizer_syscall_pre_impl_gettid();
+void __sanitizer_syscall_post_impl_gettid(long res);
+void __sanitizer_syscall_pre_impl_nanosleep(long rqtp, long rmtp);
+void __sanitizer_syscall_post_impl_nanosleep(long res, long rqtp, long rmtp);
+void __sanitizer_syscall_pre_impl_alarm(long seconds);
+void __sanitizer_syscall_post_impl_alarm(long res, long seconds);
+void __sanitizer_syscall_pre_impl_getpid();
+void __sanitizer_syscall_post_impl_getpid(long res);
+void __sanitizer_syscall_pre_impl_getppid();
+void __sanitizer_syscall_post_impl_getppid(long res);
+void __sanitizer_syscall_pre_impl_getuid();
+void __sanitizer_syscall_post_impl_getuid(long res);
+void __sanitizer_syscall_pre_impl_geteuid();
+void __sanitizer_syscall_post_impl_geteuid(long res);
+void __sanitizer_syscall_pre_impl_getgid();
+void __sanitizer_syscall_post_impl_getgid(long res);
+void __sanitizer_syscall_pre_impl_getegid();
+void __sanitizer_syscall_post_impl_getegid(long res);
+void __sanitizer_syscall_pre_impl_getresuid(long ruid, long euid, long suid);
+void __sanitizer_syscall_post_impl_getresuid(long res, long ruid, long euid,
+                                             long suid);
+void __sanitizer_syscall_pre_impl_getresgid(long rgid, long egid, long sgid);
+void __sanitizer_syscall_post_impl_getresgid(long res, long rgid, long egid,
+                                             long sgid);
+void __sanitizer_syscall_pre_impl_getpgid(long pid);
+void __sanitizer_syscall_post_impl_getpgid(long res, long pid);
+void __sanitizer_syscall_pre_impl_getpgrp();
+void __sanitizer_syscall_post_impl_getpgrp(long res);
+void __sanitizer_syscall_pre_impl_getsid(long pid);
+void __sanitizer_syscall_post_impl_getsid(long res, long pid);
+void __sanitizer_syscall_pre_impl_getgroups(long gidsetsize, long grouplist);
+void __sanitizer_syscall_post_impl_getgroups(long res, long gidsetsize,
+                                             long grouplist);
+void __sanitizer_syscall_pre_impl_setregid(long rgid, long egid);
+void __sanitizer_syscall_post_impl_setregid(long res, long rgid, long egid);
+void __sanitizer_syscall_pre_impl_setgid(long gid);
+void __sanitizer_syscall_post_impl_setgid(long res, long gid);
+void __sanitizer_syscall_pre_impl_setreuid(long ruid, long euid);
+void __sanitizer_syscall_post_impl_setreuid(long res, long ruid, long euid);
+void __sanitizer_syscall_pre_impl_setuid(long uid);
+void __sanitizer_syscall_post_impl_setuid(long res, long uid);
+void __sanitizer_syscall_pre_impl_setresuid(long ruid, long euid, long suid);
+void __sanitizer_syscall_post_impl_setresuid(long res, long ruid, long euid,
+                                             long suid);
+void __sanitizer_syscall_pre_impl_setresgid(long rgid, long egid, long sgid);
+void __sanitizer_syscall_post_impl_setresgid(long res, long rgid, long egid,
+                                             long sgid);
+void __sanitizer_syscall_pre_impl_setfsuid(long uid);
+void __sanitizer_syscall_post_impl_setfsuid(long res, long uid);
+void __sanitizer_syscall_pre_impl_setfsgid(long gid);
+void __sanitizer_syscall_post_impl_setfsgid(long res, long gid);
+void __sanitizer_syscall_pre_impl_setpgid(long pid, long pgid);
+void __sanitizer_syscall_post_impl_setpgid(long res, long pid, long pgid);
+void __sanitizer_syscall_pre_impl_setsid();
+void __sanitizer_syscall_post_impl_setsid(long res);
+void __sanitizer_syscall_pre_impl_setgroups(long gidsetsize, long grouplist);
+void __sanitizer_syscall_post_impl_setgroups(long res, long gidsetsize,
+                                             long grouplist);
+void __sanitizer_syscall_pre_impl_acct(long name);
+void __sanitizer_syscall_post_impl_acct(long res, long name);
+void __sanitizer_syscall_pre_impl_capget(long header, long dataptr);
+void __sanitizer_syscall_post_impl_capget(long res, long header, long dataptr);
+void __sanitizer_syscall_pre_impl_capset(long header, long data);
+void __sanitizer_syscall_post_impl_capset(long res, long header, long data);
+void __sanitizer_syscall_pre_impl_personality(long personality);
+void __sanitizer_syscall_post_impl_personality(long res, long personality);
+void __sanitizer_syscall_pre_impl_sigpending(long set);
+void __sanitizer_syscall_post_impl_sigpending(long res, long set);
+void __sanitizer_syscall_pre_impl_sigprocmask(long how, long set, long oset);
+void __sanitizer_syscall_post_impl_sigprocmask(long res, long how, long set,
+                                               long oset);
+void __sanitizer_syscall_pre_impl_getitimer(long which, long value);
+void __sanitizer_syscall_post_impl_getitimer(long res, long which, long value);
+void __sanitizer_syscall_pre_impl_setitimer(long which, long value,
+                                            long ovalue);
+void __sanitizer_syscall_post_impl_setitimer(long res, long which, long value,
+                                             long ovalue);
+void __sanitizer_syscall_pre_impl_timer_create(long which_clock,
+                                               long timer_event_spec,
+                                               long created_timer_id);
+void __sanitizer_syscall_post_impl_timer_create(long res, long which_clock,
+                                                long timer_event_spec,
+                                                long created_timer_id);
+void __sanitizer_syscall_pre_impl_timer_gettime(long timer_id, long setting);
+void __sanitizer_syscall_post_impl_timer_gettime(long res, long timer_id,
+                                                 long setting);
+void __sanitizer_syscall_pre_impl_timer_getoverrun(long timer_id);
+void __sanitizer_syscall_post_impl_timer_getoverrun(long res, long timer_id);
+void __sanitizer_syscall_pre_impl_timer_settime(long timer_id, long flags,
+                                                long new_setting,
+                                                long old_setting);
+void __sanitizer_syscall_post_impl_timer_settime(long res, long timer_id,
+                                                 long flags, long new_setting,
+                                                 long old_setting);
+void __sanitizer_syscall_pre_impl_timer_delete(long timer_id);
+void __sanitizer_syscall_post_impl_timer_delete(long res, long timer_id);
+void __sanitizer_syscall_pre_impl_clock_settime(long which_clock, long tp);
+void __sanitizer_syscall_post_impl_clock_settime(long res, long which_clock,
+                                                 long tp);
+void __sanitizer_syscall_pre_impl_clock_gettime(long which_clock, long tp);
+void __sanitizer_syscall_post_impl_clock_gettime(long res, long which_clock,
+                                                 long tp);
+void __sanitizer_syscall_pre_impl_clock_adjtime(long which_clock, long tx);
+void __sanitizer_syscall_post_impl_clock_adjtime(long res, long which_clock,
+                                                 long tx);
+void __sanitizer_syscall_pre_impl_clock_getres(long which_clock, long tp);
+void __sanitizer_syscall_post_impl_clock_getres(long res, long which_clock,
+                                                long tp);
+void __sanitizer_syscall_pre_impl_clock_nanosleep(long which_clock, long flags,
+                                                  long rqtp, long rmtp);
+void __sanitizer_syscall_post_impl_clock_nanosleep(long res, long which_clock,
+                                                   long flags, long rqtp,
+                                                   long rmtp);
+void __sanitizer_syscall_pre_impl_nice(long increment);
+void __sanitizer_syscall_post_impl_nice(long res, long increment);
+void __sanitizer_syscall_pre_impl_sched_setscheduler(long pid, long policy,
+                                                     long param);
+void __sanitizer_syscall_post_impl_sched_setscheduler(long res, long pid,
+                                                      long policy, long param);
+void __sanitizer_syscall_pre_impl_sched_setparam(long pid, long param);
+void __sanitizer_syscall_post_impl_sched_setparam(long res, long pid,
+                                                  long param);
+void __sanitizer_syscall_pre_impl_sched_getscheduler(long pid);
+void __sanitizer_syscall_post_impl_sched_getscheduler(long res, long pid);
+void __sanitizer_syscall_pre_impl_sched_getparam(long pid, long param);
+void __sanitizer_syscall_post_impl_sched_getparam(long res, long pid,
+                                                  long param);
+void __sanitizer_syscall_pre_impl_sched_setaffinity(long pid, long len,
+                                                    long user_mask_ptr);
+void __sanitizer_syscall_post_impl_sched_setaffinity(long res, long pid,
+                                                     long len,
+                                                     long user_mask_ptr);
+void __sanitizer_syscall_pre_impl_sched_getaffinity(long pid, long len,
+                                                    long user_mask_ptr);
+void __sanitizer_syscall_post_impl_sched_getaffinity(long res, long pid,
+                                                     long len,
+                                                     long user_mask_ptr);
+void __sanitizer_syscall_pre_impl_sched_yield();
+void __sanitizer_syscall_post_impl_sched_yield(long res);
+void __sanitizer_syscall_pre_impl_sched_get_priority_max(long policy);
+void __sanitizer_syscall_post_impl_sched_get_priority_max(long res,
+                                                          long policy);
+void __sanitizer_syscall_pre_impl_sched_get_priority_min(long policy);
+void __sanitizer_syscall_post_impl_sched_get_priority_min(long res,
+                                                          long policy);
+void __sanitizer_syscall_pre_impl_sched_rr_get_interval(long pid,
+                                                        long interval);
+void __sanitizer_syscall_post_impl_sched_rr_get_interval(long res, long pid,
+                                                         long interval);
+void __sanitizer_syscall_pre_impl_setpriority(long which, long who,
+                                              long niceval);
+void __sanitizer_syscall_post_impl_setpriority(long res, long which, long who,
+                                               long niceval);
+void __sanitizer_syscall_pre_impl_getpriority(long which, long who);
+void __sanitizer_syscall_post_impl_getpriority(long res, long which, long who);
+void __sanitizer_syscall_pre_impl_shutdown(long arg0, long arg1);
+void __sanitizer_syscall_post_impl_shutdown(long res, long arg0, long arg1);
+void __sanitizer_syscall_pre_impl_reboot(long magic1, long magic2, long cmd,
+                                         long arg);
+void __sanitizer_syscall_post_impl_reboot(long res, long magic1, long magic2,
+                                          long cmd, long arg);
+void __sanitizer_syscall_pre_impl_restart_syscall();
+void __sanitizer_syscall_post_impl_restart_syscall(long res);
+void __sanitizer_syscall_pre_impl_kexec_load(long entry, long nr_segments,
+                                             long segments, long flags);
+void __sanitizer_syscall_post_impl_kexec_load(long res, long entry,
+                                              long nr_segments, long segments,
+                                              long flags);
+void __sanitizer_syscall_pre_impl_exit(long error_code);
+void __sanitizer_syscall_post_impl_exit(long res, long error_code);
+void __sanitizer_syscall_pre_impl_exit_group(long error_code);
+void __sanitizer_syscall_post_impl_exit_group(long res, long error_code);
+void __sanitizer_syscall_pre_impl_wait4(long pid, long stat_addr, long options,
+                                        long ru);
+void __sanitizer_syscall_post_impl_wait4(long res, long pid, long stat_addr,
+                                         long options, long ru);
+void __sanitizer_syscall_pre_impl_waitid(long which, long pid, long infop,
+                                         long options, long ru);
+void __sanitizer_syscall_post_impl_waitid(long res, long which, long pid,
+                                          long infop, long options, long ru);
+void __sanitizer_syscall_pre_impl_waitpid(long pid, long stat_addr,
+                                          long options);
+void __sanitizer_syscall_post_impl_waitpid(long res, long pid, long stat_addr,
+                                           long options);
+void __sanitizer_syscall_pre_impl_set_tid_address(long tidptr);
+void __sanitizer_syscall_post_impl_set_tid_address(long res, long tidptr);
+void __sanitizer_syscall_pre_impl_init_module(long umod, long len, long uargs);
+void __sanitizer_syscall_post_impl_init_module(long res, long umod, long len,
+                                               long uargs);
+void __sanitizer_syscall_pre_impl_delete_module(long name_user, long flags);
+void __sanitizer_syscall_post_impl_delete_module(long res, long name_user,
+                                                 long flags);
+void __sanitizer_syscall_pre_impl_rt_sigprocmask(long how, long set, long oset,
+                                                 long sigsetsize);
+void __sanitizer_syscall_post_impl_rt_sigprocmask(long res, long how, long set,
+                                                  long oset, long sigsetsize);
+void __sanitizer_syscall_pre_impl_rt_sigpending(long set, long sigsetsize);
+void __sanitizer_syscall_post_impl_rt_sigpending(long res, long set,
+                                                 long sigsetsize);
+void __sanitizer_syscall_pre_impl_rt_sigtimedwait(long uthese, long uinfo,
+                                                  long uts, long sigsetsize);
+void __sanitizer_syscall_post_impl_rt_sigtimedwait(long res, long uthese,
+                                                   long uinfo, long uts,
+                                                   long sigsetsize);
+void __sanitizer_syscall_pre_impl_rt_tgsigqueueinfo(long tgid, long pid,
+                                                    long sig, long uinfo);
+void __sanitizer_syscall_post_impl_rt_tgsigqueueinfo(long res, long tgid,
+                                                     long pid, long sig,
+                                                     long uinfo);
+void __sanitizer_syscall_pre_impl_kill(long pid, long sig);
+void __sanitizer_syscall_post_impl_kill(long res, long pid, long sig);
+void __sanitizer_syscall_pre_impl_tgkill(long tgid, long pid, long sig);
+void __sanitizer_syscall_post_impl_tgkill(long res, long tgid, long pid,
+                                          long sig);
+void __sanitizer_syscall_pre_impl_tkill(long pid, long sig);
+void __sanitizer_syscall_post_impl_tkill(long res, long pid, long sig);
+void __sanitizer_syscall_pre_impl_rt_sigqueueinfo(long pid, long sig,
+                                                  long uinfo);
+void __sanitizer_syscall_post_impl_rt_sigqueueinfo(long res, long pid, long sig,
+                                                   long uinfo);
+void __sanitizer_syscall_pre_impl_sgetmask();
+void __sanitizer_syscall_post_impl_sgetmask(long res);
+void __sanitizer_syscall_pre_impl_ssetmask(long newmask);
+void __sanitizer_syscall_post_impl_ssetmask(long res, long newmask);
+void __sanitizer_syscall_pre_impl_signal(long sig, long handler);
+void __sanitizer_syscall_post_impl_signal(long res, long sig, long handler);
+void __sanitizer_syscall_pre_impl_pause();
+void __sanitizer_syscall_post_impl_pause(long res);
+void __sanitizer_syscall_pre_impl_sync();
+void __sanitizer_syscall_post_impl_sync(long res);
+void __sanitizer_syscall_pre_impl_fsync(long fd);
+void __sanitizer_syscall_post_impl_fsync(long res, long fd);
+void __sanitizer_syscall_pre_impl_fdatasync(long fd);
+void __sanitizer_syscall_post_impl_fdatasync(long res, long fd);
+void __sanitizer_syscall_pre_impl_bdflush(long func, long data);
+void __sanitizer_syscall_post_impl_bdflush(long res, long func, long data);
+void __sanitizer_syscall_pre_impl_mount(long dev_name, long dir_name, long type,
+                                        long flags, long data);
+void __sanitizer_syscall_post_impl_mount(long res, long dev_name, long dir_name,
+                                         long type, long flags, long data);
+void __sanitizer_syscall_pre_impl_umount(long name, long flags);
+void __sanitizer_syscall_post_impl_umount(long res, long name, long flags);
+void __sanitizer_syscall_pre_impl_oldumount(long name);
+void __sanitizer_syscall_post_impl_oldumount(long res, long name);
+void __sanitizer_syscall_pre_impl_truncate(long path, long length);
+void __sanitizer_syscall_post_impl_truncate(long res, long path, long length);
+void __sanitizer_syscall_pre_impl_ftruncate(long fd, long length);
+void __sanitizer_syscall_post_impl_ftruncate(long res, long fd, long length);
+void __sanitizer_syscall_pre_impl_stat(long filename, long statbuf);
+void __sanitizer_syscall_post_impl_stat(long res, long filename, long statbuf);
+void __sanitizer_syscall_pre_impl_statfs(long path, long buf);
+void __sanitizer_syscall_post_impl_statfs(long res, long path, long buf);
+void __sanitizer_syscall_pre_impl_statfs64(long path, long sz, long buf);
+void __sanitizer_syscall_post_impl_statfs64(long res, long path, long sz,
+                                            long buf);
+void __sanitizer_syscall_pre_impl_fstatfs(long fd, long buf);
+void __sanitizer_syscall_post_impl_fstatfs(long res, long fd, long buf);
+void __sanitizer_syscall_pre_impl_fstatfs64(long fd, long sz, long buf);
+void __sanitizer_syscall_post_impl_fstatfs64(long res, long fd, long sz,
+                                             long buf);
+void __sanitizer_syscall_pre_impl_lstat(long filename, long statbuf);
+void __sanitizer_syscall_post_impl_lstat(long res, long filename, long statbuf);
+void __sanitizer_syscall_pre_impl_fstat(long fd, long statbuf);
+void __sanitizer_syscall_post_impl_fstat(long res, long fd, long statbuf);
+void __sanitizer_syscall_pre_impl_newstat(long filename, long statbuf);
+void __sanitizer_syscall_post_impl_newstat(long res, long filename,
+                                           long statbuf);
+void __sanitizer_syscall_pre_impl_newlstat(long filename, long statbuf);
+void __sanitizer_syscall_post_impl_newlstat(long res, long filename,
+                                            long statbuf);
+void __sanitizer_syscall_pre_impl_newfstat(long fd, long statbuf);
+void __sanitizer_syscall_post_impl_newfstat(long res, long fd, long statbuf);
+void __sanitizer_syscall_pre_impl_ustat(long dev, long ubuf);
+void __sanitizer_syscall_post_impl_ustat(long res, long dev, long ubuf);
+void __sanitizer_syscall_pre_impl_stat64(long filename, long statbuf);
+void __sanitizer_syscall_post_impl_stat64(long res, long filename,
+                                          long statbuf);
+void __sanitizer_syscall_pre_impl_fstat64(long fd, long statbuf);
+void __sanitizer_syscall_post_impl_fstat64(long res, long fd, long statbuf);
+void __sanitizer_syscall_pre_impl_lstat64(long filename, long statbuf);
+void __sanitizer_syscall_post_impl_lstat64(long res, long filename,
+                                           long statbuf);
+void __sanitizer_syscall_pre_impl_setxattr(long path, long name, long value,
+                                           long size, long flags);
+void __sanitizer_syscall_post_impl_setxattr(long res, long path, long name,
+                                            long value, long size, long flags);
+void __sanitizer_syscall_pre_impl_lsetxattr(long path, long name, long value,
+                                            long size, long flags);
+void __sanitizer_syscall_post_impl_lsetxattr(long res, long path, long name,
+                                             long value, long size, long flags);
+void __sanitizer_syscall_pre_impl_fsetxattr(long fd, long name, long value,
+                                            long size, long flags);
+void __sanitizer_syscall_post_impl_fsetxattr(long res, long fd, long name,
+                                             long value, long size, long flags);
+void __sanitizer_syscall_pre_impl_getxattr(long path, long name, long value,
+                                           long size);
+void __sanitizer_syscall_post_impl_getxattr(long res, long path, long name,
+                                            long value, long size);
+void __sanitizer_syscall_pre_impl_lgetxattr(long path, long name, long value,
+                                            long size);
+void __sanitizer_syscall_post_impl_lgetxattr(long res, long path, long name,
+                                             long value, long size);
+void __sanitizer_syscall_pre_impl_fgetxattr(long fd, long name, long value,
+                                            long size);
+void __sanitizer_syscall_post_impl_fgetxattr(long res, long fd, long name,
+                                             long value, long size);
+void __sanitizer_syscall_pre_impl_listxattr(long path, long list, long size);
+void __sanitizer_syscall_post_impl_listxattr(long res, long path, long list,
+                                             long size);
+void __sanitizer_syscall_pre_impl_llistxattr(long path, long list, long size);
+void __sanitizer_syscall_post_impl_llistxattr(long res, long path, long list,
+                                              long size);
+void __sanitizer_syscall_pre_impl_flistxattr(long fd, long list, long size);
+void __sanitizer_syscall_post_impl_flistxattr(long res, long fd, long list,
+                                              long size);
+void __sanitizer_syscall_pre_impl_removexattr(long path, long name);
+void __sanitizer_syscall_post_impl_removexattr(long res, long path, long name);
+void __sanitizer_syscall_pre_impl_lremovexattr(long path, long name);
+void __sanitizer_syscall_post_impl_lremovexattr(long res, long path, long name);
+void __sanitizer_syscall_pre_impl_fremovexattr(long fd, long name);
+void __sanitizer_syscall_post_impl_fremovexattr(long res, long fd, long name);
+void __sanitizer_syscall_pre_impl_brk(long brk);
+void __sanitizer_syscall_post_impl_brk(long res, long brk);
+void __sanitizer_syscall_pre_impl_mprotect(long start, long len, long prot);
+void __sanitizer_syscall_post_impl_mprotect(long res, long start, long len,
+                                            long prot);
+void __sanitizer_syscall_pre_impl_mremap(long addr, long old_len, long new_len,
+                                         long flags, long new_addr);
+void __sanitizer_syscall_post_impl_mremap(long res, long addr, long old_len,
+                                          long new_len, long flags,
+                                          long new_addr);
+void __sanitizer_syscall_pre_impl_remap_file_pages(long start, long size,
+                                                   long prot, long pgoff,
+                                                   long flags);
+void __sanitizer_syscall_post_impl_remap_file_pages(long res, long start,
+                                                    long size, long prot,
+                                                    long pgoff, long flags);
+void __sanitizer_syscall_pre_impl_msync(long start, long len, long flags);
+void __sanitizer_syscall_post_impl_msync(long res, long start, long len,
+                                         long flags);
+void __sanitizer_syscall_pre_impl_munmap(long addr, long len);
+void __sanitizer_syscall_post_impl_munmap(long res, long addr, long len);
+void __sanitizer_syscall_pre_impl_mlock(long start, long len);
+void __sanitizer_syscall_post_impl_mlock(long res, long start, long len);
+void __sanitizer_syscall_pre_impl_munlock(long start, long len);
+void __sanitizer_syscall_post_impl_munlock(long res, long start, long len);
+void __sanitizer_syscall_pre_impl_mlockall(long flags);
+void __sanitizer_syscall_post_impl_mlockall(long res, long flags);
+void __sanitizer_syscall_pre_impl_munlockall();
+void __sanitizer_syscall_post_impl_munlockall(long res);
+void __sanitizer_syscall_pre_impl_madvise(long start, long len, long behavior);
+void __sanitizer_syscall_post_impl_madvise(long res, long start, long len,
+                                           long behavior);
+void __sanitizer_syscall_pre_impl_mincore(long start, long len, long vec);
+void __sanitizer_syscall_post_impl_mincore(long res, long start, long len,
+                                           long vec);
+void __sanitizer_syscall_pre_impl_pivot_root(long new_root, long put_old);
+void __sanitizer_syscall_post_impl_pivot_root(long res, long new_root,
+                                              long put_old);
+void __sanitizer_syscall_pre_impl_chroot(long filename);
+void __sanitizer_syscall_post_impl_chroot(long res, long filename);
+void __sanitizer_syscall_pre_impl_mknod(long filename, long mode, long dev);
+void __sanitizer_syscall_post_impl_mknod(long res, long filename, long mode,
+                                         long dev);
+void __sanitizer_syscall_pre_impl_link(long oldname, long newname);
+void __sanitizer_syscall_post_impl_link(long res, long oldname, long newname);
+void __sanitizer_syscall_pre_impl_symlink(long old, long new_);
+void __sanitizer_syscall_post_impl_symlink(long res, long old, long new_);
+void __sanitizer_syscall_pre_impl_unlink(long pathname);
+void __sanitizer_syscall_post_impl_unlink(long res, long pathname);
+void __sanitizer_syscall_pre_impl_rename(long oldname, long newname);
+void __sanitizer_syscall_post_impl_rename(long res, long oldname, long newname);
+void __sanitizer_syscall_pre_impl_chmod(long filename, long mode);
+void __sanitizer_syscall_post_impl_chmod(long res, long filename, long mode);
+void __sanitizer_syscall_pre_impl_fchmod(long fd, long mode);
+void __sanitizer_syscall_post_impl_fchmod(long res, long fd, long mode);
+void __sanitizer_syscall_pre_impl_fcntl(long fd, long cmd, long arg);
+void __sanitizer_syscall_post_impl_fcntl(long res, long fd, long cmd, long arg);
+void __sanitizer_syscall_pre_impl_fcntl64(long fd, long cmd, long arg);
+void __sanitizer_syscall_post_impl_fcntl64(long res, long fd, long cmd,
+                                           long arg);
+void __sanitizer_syscall_pre_impl_pipe(long fildes);
+void __sanitizer_syscall_post_impl_pipe(long res, long fildes);
+void __sanitizer_syscall_pre_impl_pipe2(long fildes, long flags);
+void __sanitizer_syscall_post_impl_pipe2(long res, long fildes, long flags);
+void __sanitizer_syscall_pre_impl_dup(long fildes);
+void __sanitizer_syscall_post_impl_dup(long res, long fildes);
+void __sanitizer_syscall_pre_impl_dup2(long oldfd, long newfd);
+void __sanitizer_syscall_post_impl_dup2(long res, long oldfd, long newfd);
+void __sanitizer_syscall_pre_impl_dup3(long oldfd, long newfd, long flags);
+void __sanitizer_syscall_post_impl_dup3(long res, long oldfd, long newfd,
+                                        long flags);
+void __sanitizer_syscall_pre_impl_ioperm(long from, long num, long on);
+void __sanitizer_syscall_post_impl_ioperm(long res, long from, long num,
+                                          long on);
+void __sanitizer_syscall_pre_impl_ioctl(long fd, long cmd, long arg);
+void __sanitizer_syscall_post_impl_ioctl(long res, long fd, long cmd, long arg);
+void __sanitizer_syscall_pre_impl_flock(long fd, long cmd);
+void __sanitizer_syscall_post_impl_flock(long res, long fd, long cmd);
+void __sanitizer_syscall_pre_impl_io_setup(long nr_reqs, long ctx);
+void __sanitizer_syscall_post_impl_io_setup(long res, long nr_reqs, long ctx);
+void __sanitizer_syscall_pre_impl_io_destroy(long ctx);
+void __sanitizer_syscall_post_impl_io_destroy(long res, long ctx);
+void __sanitizer_syscall_pre_impl_io_getevents(long ctx_id, long min_nr,
+                                               long nr, long events,
+                                               long timeout);
+void __sanitizer_syscall_post_impl_io_getevents(long res, long ctx_id,
+                                                long min_nr, long nr,
+                                                long events, long timeout);
+void __sanitizer_syscall_pre_impl_io_submit(long ctx_id, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_io_submit(long res, long ctx_id, long arg1,
+                                             long arg2);
+void __sanitizer_syscall_pre_impl_io_cancel(long ctx_id, long iocb,
+                                            long result);
+void __sanitizer_syscall_post_impl_io_cancel(long res, long ctx_id, long iocb,
+                                             long result);
+void __sanitizer_syscall_pre_impl_sendfile(long out_fd, long in_fd, long offset,
+                                           long count);
+void __sanitizer_syscall_post_impl_sendfile(long res, long out_fd, long in_fd,
+                                            long offset, long count);
+void __sanitizer_syscall_pre_impl_sendfile64(long out_fd, long in_fd,
+                                             long offset, long count);
+void __sanitizer_syscall_post_impl_sendfile64(long res, long out_fd, long in_fd,
+                                              long offset, long count);
+void __sanitizer_syscall_pre_impl_readlink(long path, long buf, long bufsiz);
+void __sanitizer_syscall_post_impl_readlink(long res, long path, long buf,
+                                            long bufsiz);
+void __sanitizer_syscall_pre_impl_creat(long pathname, long mode);
+void __sanitizer_syscall_post_impl_creat(long res, long pathname, long mode);
+void __sanitizer_syscall_pre_impl_open(long filename, long flags, long mode);
+void __sanitizer_syscall_post_impl_open(long res, long filename, long flags,
+                                        long mode);
+void __sanitizer_syscall_pre_impl_close(long fd);
+void __sanitizer_syscall_post_impl_close(long res, long fd);
+void __sanitizer_syscall_pre_impl_access(long filename, long mode);
+void __sanitizer_syscall_post_impl_access(long res, long filename, long mode);
+void __sanitizer_syscall_pre_impl_vhangup();
+void __sanitizer_syscall_post_impl_vhangup(long res);
+void __sanitizer_syscall_pre_impl_chown(long filename, long user, long group);
+void __sanitizer_syscall_post_impl_chown(long res, long filename, long user,
+                                         long group);
+void __sanitizer_syscall_pre_impl_lchown(long filename, long user, long group);
+void __sanitizer_syscall_post_impl_lchown(long res, long filename, long user,
+                                          long group);
+void __sanitizer_syscall_pre_impl_fchown(long fd, long user, long group);
+void __sanitizer_syscall_post_impl_fchown(long res, long fd, long user,
+                                          long group);
+void __sanitizer_syscall_pre_impl_chown16(long filename, long user, long group);
+void __sanitizer_syscall_post_impl_chown16(long res, long filename, long user,
+                                           long group);
+void __sanitizer_syscall_pre_impl_lchown16(long filename, long user,
+                                           long group);
+void __sanitizer_syscall_post_impl_lchown16(long res, long filename, long user,
+                                            long group);
+void __sanitizer_syscall_pre_impl_fchown16(long fd, long user, long group);
+void __sanitizer_syscall_post_impl_fchown16(long res, long fd, long user,
+                                            long group);
+void __sanitizer_syscall_pre_impl_setregid16(long rgid, long egid);
+void __sanitizer_syscall_post_impl_setregid16(long res, long rgid, long egid);
+void __sanitizer_syscall_pre_impl_setgid16(long gid);
+void __sanitizer_syscall_post_impl_setgid16(long res, long gid);
+void __sanitizer_syscall_pre_impl_setreuid16(long ruid, long euid);
+void __sanitizer_syscall_post_impl_setreuid16(long res, long ruid, long euid);
+void __sanitizer_syscall_pre_impl_setuid16(long uid);
+void __sanitizer_syscall_post_impl_setuid16(long res, long uid);
+void __sanitizer_syscall_pre_impl_setresuid16(long ruid, long euid, long suid);
+void __sanitizer_syscall_post_impl_setresuid16(long res, long ruid, long euid,
+                                               long suid);
+void __sanitizer_syscall_pre_impl_getresuid16(long ruid, long euid, long suid);
+void __sanitizer_syscall_post_impl_getresuid16(long res, long ruid, long euid,
+                                               long suid);
+void __sanitizer_syscall_pre_impl_setresgid16(long rgid, long egid, long sgid);
+void __sanitizer_syscall_post_impl_setresgid16(long res, long rgid, long egid,
+                                               long sgid);
+void __sanitizer_syscall_pre_impl_getresgid16(long rgid, long egid, long sgid);
+void __sanitizer_syscall_post_impl_getresgid16(long res, long rgid, long egid,
+                                               long sgid);
+void __sanitizer_syscall_pre_impl_setfsuid16(long uid);
+void __sanitizer_syscall_post_impl_setfsuid16(long res, long uid);
+void __sanitizer_syscall_pre_impl_setfsgid16(long gid);
+void __sanitizer_syscall_post_impl_setfsgid16(long res, long gid);
+void __sanitizer_syscall_pre_impl_getgroups16(long gidsetsize, long grouplist);
+void __sanitizer_syscall_post_impl_getgroups16(long res, long gidsetsize,
+                                               long grouplist);
+void __sanitizer_syscall_pre_impl_setgroups16(long gidsetsize, long grouplist);
+void __sanitizer_syscall_post_impl_setgroups16(long res, long gidsetsize,
+                                               long grouplist);
+void __sanitizer_syscall_pre_impl_getuid16();
+void __sanitizer_syscall_post_impl_getuid16(long res);
+void __sanitizer_syscall_pre_impl_geteuid16();
+void __sanitizer_syscall_post_impl_geteuid16(long res);
+void __sanitizer_syscall_pre_impl_getgid16();
+void __sanitizer_syscall_post_impl_getgid16(long res);
+void __sanitizer_syscall_pre_impl_getegid16();
+void __sanitizer_syscall_post_impl_getegid16(long res);
+void __sanitizer_syscall_pre_impl_utime(long filename, long times);
+void __sanitizer_syscall_post_impl_utime(long res, long filename, long times);
+void __sanitizer_syscall_pre_impl_utimes(long filename, long utimes);
+void __sanitizer_syscall_post_impl_utimes(long res, long filename, long utimes);
+void __sanitizer_syscall_pre_impl_lseek(long fd, long offset, long origin);
+void __sanitizer_syscall_post_impl_lseek(long res, long fd, long offset,
+                                         long origin);
+void __sanitizer_syscall_pre_impl_llseek(long fd, long offset_high,
+                                         long offset_low, long result,
+                                         long origin);
+void __sanitizer_syscall_post_impl_llseek(long res, long fd, long offset_high,
+                                          long offset_low, long result,
+                                          long origin);
+void __sanitizer_syscall_pre_impl_read(long fd, long buf, long count);
+void __sanitizer_syscall_post_impl_read(long res, long fd, long buf,
+                                        long count);
+void __sanitizer_syscall_pre_impl_readv(long fd, long vec, long vlen);
+void __sanitizer_syscall_post_impl_readv(long res, long fd, long vec,
+                                         long vlen);
+void __sanitizer_syscall_pre_impl_write(long fd, long buf, long count);
+void __sanitizer_syscall_post_impl_write(long res, long fd, long buf,
+                                         long count);
+void __sanitizer_syscall_pre_impl_writev(long fd, long vec, long vlen);
+void __sanitizer_syscall_post_impl_writev(long res, long fd, long vec,
+                                          long vlen);
+
+#ifdef _LP64
+void __sanitizer_syscall_pre_impl_pread64(long fd, long buf, long count,
+                                          long pos);
+void __sanitizer_syscall_post_impl_pread64(long res, long fd, long buf,
+                                           long count, long pos);
+void __sanitizer_syscall_pre_impl_pwrite64(long fd, long buf, long count,
+                                           long pos);
+void __sanitizer_syscall_post_impl_pwrite64(long res, long fd, long buf,
+                                            long count, long pos);
+#else
+void __sanitizer_syscall_pre_impl_pread64(long fd, long buf, long count,
+                                          long pos0, long pos1);
+void __sanitizer_syscall_post_impl_pread64(long res, long fd, long buf,
+                                           long count, long pos0, long pos1);
+void __sanitizer_syscall_pre_impl_pwrite64(long fd, long buf, long count,
+                                           long pos0, long pos1);
+void __sanitizer_syscall_post_impl_pwrite64(long res, long fd, long buf,
+                                            long count, long pos0, long pos1);
+#endif
+
+void __sanitizer_syscall_pre_impl_preadv(long fd, long vec, long vlen,
+                                         long pos_l, long pos_h);
+void __sanitizer_syscall_post_impl_preadv(long res, long fd, long vec,
+                                          long vlen, long pos_l, long pos_h);
+void __sanitizer_syscall_pre_impl_pwritev(long fd, long vec, long vlen,
+                                          long pos_l, long pos_h);
+void __sanitizer_syscall_post_impl_pwritev(long res, long fd, long vec,
+                                           long vlen, long pos_l, long pos_h);
+void __sanitizer_syscall_pre_impl_getcwd(long buf, long size);
+void __sanitizer_syscall_post_impl_getcwd(long res, long buf, long size);
+void __sanitizer_syscall_pre_impl_mkdir(long pathname, long mode);
+void __sanitizer_syscall_post_impl_mkdir(long res, long pathname, long mode);
+void __sanitizer_syscall_pre_impl_chdir(long filename);
+void __sanitizer_syscall_post_impl_chdir(long res, long filename);
+void __sanitizer_syscall_pre_impl_fchdir(long fd);
+void __sanitizer_syscall_post_impl_fchdir(long res, long fd);
+void __sanitizer_syscall_pre_impl_rmdir(long pathname);
+void __sanitizer_syscall_post_impl_rmdir(long res, long pathname);
+void __sanitizer_syscall_pre_impl_lookup_dcookie(long cookie64, long buf,
+                                                 long len);
+void __sanitizer_syscall_post_impl_lookup_dcookie(long res, long cookie64,
+                                                  long buf, long len);
+void __sanitizer_syscall_pre_impl_quotactl(long cmd, long special, long id,
+                                           long addr);
+void __sanitizer_syscall_post_impl_quotactl(long res, long cmd, long special,
+                                            long id, long addr);
+void __sanitizer_syscall_pre_impl_getdents(long fd, long dirent, long count);
+void __sanitizer_syscall_post_impl_getdents(long res, long fd, long dirent,
+                                            long count);
+void __sanitizer_syscall_pre_impl_getdents64(long fd, long dirent, long count);
+void __sanitizer_syscall_post_impl_getdents64(long res, long fd, long dirent,
+                                              long count);
+void __sanitizer_syscall_pre_impl_setsockopt(long fd, long level, long optname,
+                                             long optval, long optlen);
+void __sanitizer_syscall_post_impl_setsockopt(long res, long fd, long level,
+                                              long optname, long optval,
+                                              long optlen);
+void __sanitizer_syscall_pre_impl_getsockopt(long fd, long level, long optname,
+                                             long optval, long optlen);
+void __sanitizer_syscall_post_impl_getsockopt(long res, long fd, long level,
+                                              long optname, long optval,
+                                              long optlen);
+void __sanitizer_syscall_pre_impl_bind(long arg0, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_bind(long res, long arg0, long arg1,
+                                        long arg2);
+void __sanitizer_syscall_pre_impl_connect(long arg0, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_connect(long res, long arg0, long arg1,
+                                           long arg2);
+void __sanitizer_syscall_pre_impl_accept(long arg0, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_accept(long res, long arg0, long arg1,
+                                          long arg2);
+void __sanitizer_syscall_pre_impl_accept4(long arg0, long arg1, long arg2,
+                                          long arg3);
+void __sanitizer_syscall_post_impl_accept4(long res, long arg0, long arg1,
+                                           long arg2, long arg3);
+void __sanitizer_syscall_pre_impl_getsockname(long arg0, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_getsockname(long res, long arg0, long arg1,
+                                               long arg2);
+void __sanitizer_syscall_pre_impl_getpeername(long arg0, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_getpeername(long res, long arg0, long arg1,
+                                               long arg2);
+void __sanitizer_syscall_pre_impl_send(long arg0, long arg1, long arg2,
+                                       long arg3);
+void __sanitizer_syscall_post_impl_send(long res, long arg0, long arg1,
+                                        long arg2, long arg3);
+void __sanitizer_syscall_pre_impl_sendto(long arg0, long arg1, long arg2,
+                                         long arg3, long arg4, long arg5);
+void __sanitizer_syscall_post_impl_sendto(long res, long arg0, long arg1,
+                                          long arg2, long arg3, long arg4,
+                                          long arg5);
+void __sanitizer_syscall_pre_impl_sendmsg(long fd, long msg, long flags);
+void __sanitizer_syscall_post_impl_sendmsg(long res, long fd, long msg,
+                                           long flags);
+void __sanitizer_syscall_pre_impl_sendmmsg(long fd, long msg, long vlen,
+                                           long flags);
+void __sanitizer_syscall_post_impl_sendmmsg(long res, long fd, long msg,
+                                            long vlen, long flags);
+void __sanitizer_syscall_pre_impl_recv(long arg0, long arg1, long arg2,
+                                       long arg3);
+void __sanitizer_syscall_post_impl_recv(long res, long arg0, long arg1,
+                                        long arg2, long arg3);
+void __sanitizer_syscall_pre_impl_recvfrom(long arg0, long arg1, long arg2,
+                                           long arg3, long arg4, long arg5);
+void __sanitizer_syscall_post_impl_recvfrom(long res, long arg0, long arg1,
+                                            long arg2, long arg3, long arg4,
+                                            long arg5);
+void __sanitizer_syscall_pre_impl_recvmsg(long fd, long msg, long flags);
+void __sanitizer_syscall_post_impl_recvmsg(long res, long fd, long msg,
+                                           long flags);
+void __sanitizer_syscall_pre_impl_recvmmsg(long fd, long msg, long vlen,
+                                           long flags, long timeout);
+void __sanitizer_syscall_post_impl_recvmmsg(long res, long fd, long msg,
+                                            long vlen, long flags,
+                                            long timeout);
+void __sanitizer_syscall_pre_impl_socket(long arg0, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_socket(long res, long arg0, long arg1,
+                                          long arg2);
+void __sanitizer_syscall_pre_impl_socketpair(long arg0, long arg1, long arg2,
+                                             long arg3);
+void __sanitizer_syscall_post_impl_socketpair(long res, long arg0, long arg1,
+                                              long arg2, long arg3);
+void __sanitizer_syscall_pre_impl_socketcall(long call, long args);
+void __sanitizer_syscall_post_impl_socketcall(long res, long call, long args);
+void __sanitizer_syscall_pre_impl_listen(long arg0, long arg1);
+void __sanitizer_syscall_post_impl_listen(long res, long arg0, long arg1);
+void __sanitizer_syscall_pre_impl_poll(long ufds, long nfds, long timeout);
+void __sanitizer_syscall_post_impl_poll(long res, long ufds, long nfds,
+                                        long timeout);
+void __sanitizer_syscall_pre_impl_select(long n, long inp, long outp, long exp,
+                                         long tvp);
+void __sanitizer_syscall_post_impl_select(long res, long n, long inp, long outp,
+                                          long exp, long tvp);
+void __sanitizer_syscall_pre_impl_old_select(long arg);
+void __sanitizer_syscall_post_impl_old_select(long res, long arg);
+void __sanitizer_syscall_pre_impl_epoll_create(long size);
+void __sanitizer_syscall_post_impl_epoll_create(long res, long size);
+void __sanitizer_syscall_pre_impl_epoll_create1(long flags);
+void __sanitizer_syscall_post_impl_epoll_create1(long res, long flags);
+void __sanitizer_syscall_pre_impl_epoll_ctl(long epfd, long op, long fd,
+                                            long event);
+void __sanitizer_syscall_post_impl_epoll_ctl(long res, long epfd, long op,
+                                             long fd, long event);
+void __sanitizer_syscall_pre_impl_epoll_wait(long epfd, long events,
+                                             long maxevents, long timeout);
+void __sanitizer_syscall_post_impl_epoll_wait(long res, long epfd, long events,
+                                              long maxevents, long timeout);
+void __sanitizer_syscall_pre_impl_epoll_pwait(long epfd, long events,
+                                              long maxevents, long timeout,
+                                              long sigmask, long sigsetsize);
+void __sanitizer_syscall_post_impl_epoll_pwait(long res, long epfd, long events,
+                                               long maxevents, long timeout,
+                                               long sigmask, long sigsetsize);
+void __sanitizer_syscall_pre_impl_gethostname(long name, long len);
+void __sanitizer_syscall_post_impl_gethostname(long res, long name, long len);
+void __sanitizer_syscall_pre_impl_sethostname(long name, long len);
+void __sanitizer_syscall_post_impl_sethostname(long res, long name, long len);
+void __sanitizer_syscall_pre_impl_setdomainname(long name, long len);
+void __sanitizer_syscall_post_impl_setdomainname(long res, long name, long len);
+void __sanitizer_syscall_pre_impl_newuname(long name);
+void __sanitizer_syscall_post_impl_newuname(long res, long name);
+void __sanitizer_syscall_pre_impl_uname(long arg0);
+void __sanitizer_syscall_post_impl_uname(long res, long arg0);
+void __sanitizer_syscall_pre_impl_olduname(long arg0);
+void __sanitizer_syscall_post_impl_olduname(long res, long arg0);
+void __sanitizer_syscall_pre_impl_getrlimit(long resource, long rlim);
+void __sanitizer_syscall_post_impl_getrlimit(long res, long resource,
+                                             long rlim);
+void __sanitizer_syscall_pre_impl_old_getrlimit(long resource, long rlim);
+void __sanitizer_syscall_post_impl_old_getrlimit(long res, long resource,
+                                                 long rlim);
+void __sanitizer_syscall_pre_impl_setrlimit(long resource, long rlim);
+void __sanitizer_syscall_post_impl_setrlimit(long res, long resource,
+                                             long rlim);
+void __sanitizer_syscall_pre_impl_prlimit64(long pid, long resource,
+                                            long new_rlim, long old_rlim);
+void __sanitizer_syscall_post_impl_prlimit64(long res, long pid, long resource,
+                                             long new_rlim, long old_rlim);
+void __sanitizer_syscall_pre_impl_getrusage(long who, long ru);
+void __sanitizer_syscall_post_impl_getrusage(long res, long who, long ru);
+void __sanitizer_syscall_pre_impl_umask(long mask);
+void __sanitizer_syscall_post_impl_umask(long res, long mask);
+void __sanitizer_syscall_pre_impl_msgget(long key, long msgflg);
+void __sanitizer_syscall_post_impl_msgget(long res, long key, long msgflg);
+void __sanitizer_syscall_pre_impl_msgsnd(long msqid, long msgp, long msgsz,
+                                         long msgflg);
+void __sanitizer_syscall_post_impl_msgsnd(long res, long msqid, long msgp,
+                                          long msgsz, long msgflg);
+void __sanitizer_syscall_pre_impl_msgrcv(long msqid, long msgp, long msgsz,
+                                         long msgtyp, long msgflg);
+void __sanitizer_syscall_post_impl_msgrcv(long res, long msqid, long msgp,
+                                          long msgsz, long msgtyp, long msgflg);
+void __sanitizer_syscall_pre_impl_msgctl(long msqid, long cmd, long buf);
+void __sanitizer_syscall_post_impl_msgctl(long res, long msqid, long cmd,
+                                          long buf);
+void __sanitizer_syscall_pre_impl_semget(long key, long nsems, long semflg);
+void __sanitizer_syscall_post_impl_semget(long res, long key, long nsems,
+                                          long semflg);
+void __sanitizer_syscall_pre_impl_semop(long semid, long sops, long nsops);
+void __sanitizer_syscall_post_impl_semop(long res, long semid, long sops,
+                                         long nsops);
+void __sanitizer_syscall_pre_impl_semctl(long semid, long semnum, long cmd,
+                                         long arg);
+void __sanitizer_syscall_post_impl_semctl(long res, long semid, long semnum,
+                                          long cmd, long arg);
+void __sanitizer_syscall_pre_impl_semtimedop(long semid, long sops, long nsops,
+                                             long timeout);
+void __sanitizer_syscall_post_impl_semtimedop(long res, long semid, long sops,
+                                              long nsops, long timeout);
+void __sanitizer_syscall_pre_impl_shmat(long shmid, long shmaddr, long shmflg);
+void __sanitizer_syscall_post_impl_shmat(long res, long shmid, long shmaddr,
+                                         long shmflg);
+void __sanitizer_syscall_pre_impl_shmget(long key, long size, long flag);
+void __sanitizer_syscall_post_impl_shmget(long res, long key, long size,
+                                          long flag);
+void __sanitizer_syscall_pre_impl_shmdt(long shmaddr);
+void __sanitizer_syscall_post_impl_shmdt(long res, long shmaddr);
+void __sanitizer_syscall_pre_impl_shmctl(long shmid, long cmd, long buf);
+void __sanitizer_syscall_post_impl_shmctl(long res, long shmid, long cmd,
+                                          long buf);
+void __sanitizer_syscall_pre_impl_ipc(long call, long first, long second,
+                                      long third, long ptr, long fifth);
+void __sanitizer_syscall_post_impl_ipc(long res, long call, long first,
+                                       long second, long third, long ptr,
+                                       long fifth);
+void __sanitizer_syscall_pre_impl_mq_open(long name, long oflag, long mode,
+                                          long attr);
+void __sanitizer_syscall_post_impl_mq_open(long res, long name, long oflag,
+                                           long mode, long attr);
+void __sanitizer_syscall_pre_impl_mq_unlink(long name);
+void __sanitizer_syscall_post_impl_mq_unlink(long res, long name);
+void __sanitizer_syscall_pre_impl_mq_timedsend(long mqdes, long msg_ptr,
+                                               long msg_len, long msg_prio,
+                                               long abs_timeout);
+void __sanitizer_syscall_post_impl_mq_timedsend(long res, long mqdes,
+                                                long msg_ptr, long msg_len,
+                                                long msg_prio,
+                                                long abs_timeout);
+void __sanitizer_syscall_pre_impl_mq_timedreceive(long mqdes, long msg_ptr,
+                                                  long msg_len, long msg_prio,
+                                                  long abs_timeout);
+void __sanitizer_syscall_post_impl_mq_timedreceive(long res, long mqdes,
+                                                   long msg_ptr, long msg_len,
+                                                   long msg_prio,
+                                                   long abs_timeout);
+void __sanitizer_syscall_pre_impl_mq_notify(long mqdes, long notification);
+void __sanitizer_syscall_post_impl_mq_notify(long res, long mqdes,
+                                             long notification);
+void __sanitizer_syscall_pre_impl_mq_getsetattr(long mqdes, long mqstat,
+                                                long omqstat);
+void __sanitizer_syscall_post_impl_mq_getsetattr(long res, long mqdes,
+                                                 long mqstat, long omqstat);
+void __sanitizer_syscall_pre_impl_pciconfig_iobase(long which, long bus,
+                                                   long devfn);
+void __sanitizer_syscall_post_impl_pciconfig_iobase(long res, long which,
+                                                    long bus, long devfn);
+void __sanitizer_syscall_pre_impl_pciconfig_read(long bus, long dfn, long off,
+                                                 long len, long buf);
+void __sanitizer_syscall_post_impl_pciconfig_read(long res, long bus, long dfn,
+                                                  long off, long len, long buf);
+void __sanitizer_syscall_pre_impl_pciconfig_write(long bus, long dfn, long off,
+                                                  long len, long buf);
+void __sanitizer_syscall_post_impl_pciconfig_write(long res, long bus, long dfn,
+                                                   long off, long len,
+                                                   long buf);
+void __sanitizer_syscall_pre_impl_swapon(long specialfile, long swap_flags);
+void __sanitizer_syscall_post_impl_swapon(long res, long specialfile,
+                                          long swap_flags);
+void __sanitizer_syscall_pre_impl_swapoff(long specialfile);
+void __sanitizer_syscall_post_impl_swapoff(long res, long specialfile);
+void __sanitizer_syscall_pre_impl_sysctl(long args);
+void __sanitizer_syscall_post_impl_sysctl(long res, long args);
+void __sanitizer_syscall_pre_impl_sysinfo(long info);
+void __sanitizer_syscall_post_impl_sysinfo(long res, long info);
+void __sanitizer_syscall_pre_impl_sysfs(long option, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_sysfs(long res, long option, long arg1,
+                                         long arg2);
+void __sanitizer_syscall_pre_impl_syslog(long type, long buf, long len);
+void __sanitizer_syscall_post_impl_syslog(long res, long type, long buf,
+                                          long len);
+void __sanitizer_syscall_pre_impl_uselib(long library);
+void __sanitizer_syscall_post_impl_uselib(long res, long library);
+void __sanitizer_syscall_pre_impl_ni_syscall();
+void __sanitizer_syscall_post_impl_ni_syscall(long res);
+void __sanitizer_syscall_pre_impl_ptrace(long request, long pid, long addr,
+                                         long data);
+void __sanitizer_syscall_post_impl_ptrace(long res, long request, long pid,
+                                          long addr, long data);
+void __sanitizer_syscall_pre_impl_add_key(long _type, long _description,
+                                          long _payload, long plen,
+                                          long destringid);
+void __sanitizer_syscall_post_impl_add_key(long res, long _type,
+                                           long _description, long _payload,
+                                           long plen, long destringid);
+void __sanitizer_syscall_pre_impl_request_key(long _type, long _description,
+                                              long _callout_info,
+                                              long destringid);
+void __sanitizer_syscall_post_impl_request_key(long res, long _type,
+                                               long _description,
+                                               long _callout_info,
+                                               long destringid);
+void __sanitizer_syscall_pre_impl_keyctl(long cmd, long arg2, long arg3,
+                                         long arg4, long arg5);
+void __sanitizer_syscall_post_impl_keyctl(long res, long cmd, long arg2,
+                                          long arg3, long arg4, long arg5);
+void __sanitizer_syscall_pre_impl_ioprio_set(long which, long who, long ioprio);
+void __sanitizer_syscall_post_impl_ioprio_set(long res, long which, long who,
+                                              long ioprio);
+void __sanitizer_syscall_pre_impl_ioprio_get(long which, long who);
+void __sanitizer_syscall_post_impl_ioprio_get(long res, long which, long who);
+void __sanitizer_syscall_pre_impl_set_mempolicy(long mode, long nmask,
+                                                long maxnode);
+void __sanitizer_syscall_post_impl_set_mempolicy(long res, long mode,
+                                                 long nmask, long maxnode);
+void __sanitizer_syscall_pre_impl_migrate_pages(long pid, long maxnode,
+                                                long from, long to);
+void __sanitizer_syscall_post_impl_migrate_pages(long res, long pid,
+                                                 long maxnode, long from,
+                                                 long to);
+void __sanitizer_syscall_pre_impl_move_pages(long pid, long nr_pages,
+                                             long pages, long nodes,
+                                             long status, long flags);
+void __sanitizer_syscall_post_impl_move_pages(long res, long pid, long nr_pages,
+                                              long pages, long nodes,
+                                              long status, long flags);
+void __sanitizer_syscall_pre_impl_mbind(long start, long len, long mode,
+                                        long nmask, long maxnode, long flags);
+void __sanitizer_syscall_post_impl_mbind(long res, long start, long len,
+                                         long mode, long nmask, long maxnode,
+                                         long flags);
+void __sanitizer_syscall_pre_impl_get_mempolicy(long policy, long nmask,
+                                                long maxnode, long addr,
+                                                long flags);
+void __sanitizer_syscall_post_impl_get_mempolicy(long res, long policy,
+                                                 long nmask, long maxnode,
+                                                 long addr, long flags);
+void __sanitizer_syscall_pre_impl_inotify_init();
+void __sanitizer_syscall_post_impl_inotify_init(long res);
+void __sanitizer_syscall_pre_impl_inotify_init1(long flags);
+void __sanitizer_syscall_post_impl_inotify_init1(long res, long flags);
+void __sanitizer_syscall_pre_impl_inotify_add_watch(long fd, long path,
+                                                    long mask);
+void __sanitizer_syscall_post_impl_inotify_add_watch(long res, long fd,
+                                                     long path, long mask);
+void __sanitizer_syscall_pre_impl_inotify_rm_watch(long fd, long wd);
+void __sanitizer_syscall_post_impl_inotify_rm_watch(long res, long fd, long wd);
+void __sanitizer_syscall_pre_impl_spu_run(long fd, long unpc, long ustatus);
+void __sanitizer_syscall_post_impl_spu_run(long res, long fd, long unpc,
+                                           long ustatus);
+void __sanitizer_syscall_pre_impl_spu_create(long name, long flags, long mode,
+                                             long fd);
+void __sanitizer_syscall_post_impl_spu_create(long res, long name, long flags,
+                                              long mode, long fd);
+void __sanitizer_syscall_pre_impl_mknodat(long dfd, long filename, long mode,
+                                          long dev);
+void __sanitizer_syscall_post_impl_mknodat(long res, long dfd, long filename,
+                                           long mode, long dev);
+void __sanitizer_syscall_pre_impl_mkdirat(long dfd, long pathname, long mode);
+void __sanitizer_syscall_post_impl_mkdirat(long res, long dfd, long pathname,
+                                           long mode);
+void __sanitizer_syscall_pre_impl_unlinkat(long dfd, long pathname, long flag);
+void __sanitizer_syscall_post_impl_unlinkat(long res, long dfd, long pathname,
+                                            long flag);
+void __sanitizer_syscall_pre_impl_symlinkat(long oldname, long newdfd,
+                                            long newname);
+void __sanitizer_syscall_post_impl_symlinkat(long res, long oldname,
+                                             long newdfd, long newname);
+void __sanitizer_syscall_pre_impl_linkat(long olddfd, long oldname, long newdfd,
+                                         long newname, long flags);
+void __sanitizer_syscall_post_impl_linkat(long res, long olddfd, long oldname,
+                                          long newdfd, long newname,
+                                          long flags);
+void __sanitizer_syscall_pre_impl_renameat(long olddfd, long oldname,
+                                           long newdfd, long newname);
+void __sanitizer_syscall_post_impl_renameat(long res, long olddfd, long oldname,
+                                            long newdfd, long newname);
+void __sanitizer_syscall_pre_impl_futimesat(long dfd, long filename,
+                                            long utimes);
+void __sanitizer_syscall_post_impl_futimesat(long res, long dfd, long filename,
+                                             long utimes);
+void __sanitizer_syscall_pre_impl_faccessat(long dfd, long filename, long mode);
+void __sanitizer_syscall_post_impl_faccessat(long res, long dfd, long filename,
+                                             long mode);
+void __sanitizer_syscall_pre_impl_fchmodat(long dfd, long filename, long mode);
+void __sanitizer_syscall_post_impl_fchmodat(long res, long dfd, long filename,
+                                            long mode);
+void __sanitizer_syscall_pre_impl_fchownat(long dfd, long filename, long user,
+                                           long group, long flag);
+void __sanitizer_syscall_post_impl_fchownat(long res, long dfd, long filename,
+                                            long user, long group, long flag);
+void __sanitizer_syscall_pre_impl_openat(long dfd, long filename, long flags,
+                                         long mode);
+void __sanitizer_syscall_post_impl_openat(long res, long dfd, long filename,
+                                          long flags, long mode);
+void __sanitizer_syscall_pre_impl_newfstatat(long dfd, long filename,
+                                             long statbuf, long flag);
+void __sanitizer_syscall_post_impl_newfstatat(long res, long dfd, long filename,
+                                              long statbuf, long flag);
+void __sanitizer_syscall_pre_impl_fstatat64(long dfd, long filename,
+                                            long statbuf, long flag);
+void __sanitizer_syscall_post_impl_fstatat64(long res, long dfd, long filename,
+                                             long statbuf, long flag);
+void __sanitizer_syscall_pre_impl_readlinkat(long dfd, long path, long buf,
+                                             long bufsiz);
+void __sanitizer_syscall_post_impl_readlinkat(long res, long dfd, long path,
+                                              long buf, long bufsiz);
+void __sanitizer_syscall_pre_impl_utimensat(long dfd, long filename,
+                                            long utimes, long flags);
+void __sanitizer_syscall_post_impl_utimensat(long res, long dfd, long filename,
+                                             long utimes, long flags);
+void __sanitizer_syscall_pre_impl_unshare(long unshare_flags);
+void __sanitizer_syscall_post_impl_unshare(long res, long unshare_flags);
+void __sanitizer_syscall_pre_impl_splice(long fd_in, long off_in, long fd_out,
+                                         long off_out, long len, long flags);
+void __sanitizer_syscall_post_impl_splice(long res, long fd_in, long off_in,
+                                          long fd_out, long off_out, long len,
+                                          long flags);
+void __sanitizer_syscall_pre_impl_vmsplice(long fd, long iov, long nr_segs,
+                                           long flags);
+void __sanitizer_syscall_post_impl_vmsplice(long res, long fd, long iov,
+                                            long nr_segs, long flags);
+void __sanitizer_syscall_pre_impl_tee(long fdin, long fdout, long len,
+                                      long flags);
+void __sanitizer_syscall_post_impl_tee(long res, long fdin, long fdout,
+                                       long len, long flags);
+void __sanitizer_syscall_pre_impl_get_robust_list(long pid, long head_ptr,
+                                                  long len_ptr);
+void __sanitizer_syscall_post_impl_get_robust_list(long res, long pid,
+                                                   long head_ptr, long len_ptr);
+void __sanitizer_syscall_pre_impl_set_robust_list(long head, long len);
+void __sanitizer_syscall_post_impl_set_robust_list(long res, long head,
+                                                   long len);
+void __sanitizer_syscall_pre_impl_getcpu(long cpu, long node, long cache);
+void __sanitizer_syscall_post_impl_getcpu(long res, long cpu, long node,
+                                          long cache);
+void __sanitizer_syscall_pre_impl_signalfd(long ufd, long user_mask,
+                                           long sizemask);
+void __sanitizer_syscall_post_impl_signalfd(long res, long ufd, long user_mask,
+                                            long sizemask);
+void __sanitizer_syscall_pre_impl_signalfd4(long ufd, long user_mask,
+                                            long sizemask, long flags);
+void __sanitizer_syscall_post_impl_signalfd4(long res, long ufd, long user_mask,
+                                             long sizemask, long flags);
+void __sanitizer_syscall_pre_impl_timerfd_create(long clockid, long flags);
+void __sanitizer_syscall_post_impl_timerfd_create(long res, long clockid,
+                                                  long flags);
+void __sanitizer_syscall_pre_impl_timerfd_settime(long ufd, long flags,
+                                                  long utmr, long otmr);
+void __sanitizer_syscall_post_impl_timerfd_settime(long res, long ufd,
+                                                   long flags, long utmr,
+                                                   long otmr);
+void __sanitizer_syscall_pre_impl_timerfd_gettime(long ufd, long otmr);
+void __sanitizer_syscall_post_impl_timerfd_gettime(long res, long ufd,
+                                                   long otmr);
+void __sanitizer_syscall_pre_impl_eventfd(long count);
+void __sanitizer_syscall_post_impl_eventfd(long res, long count);
+void __sanitizer_syscall_pre_impl_eventfd2(long count, long flags);
+void __sanitizer_syscall_post_impl_eventfd2(long res, long count, long flags);
+void __sanitizer_syscall_pre_impl_old_readdir(long arg0, long arg1, long arg2);
+void __sanitizer_syscall_post_impl_old_readdir(long res, long arg0, long arg1,
+                                               long arg2);
+void __sanitizer_syscall_pre_impl_pselect6(long arg0, long arg1, long arg2,
+                                           long arg3, long arg4, long arg5);
+void __sanitizer_syscall_post_impl_pselect6(long res, long arg0, long arg1,
+                                            long arg2, long arg3, long arg4,
+                                            long arg5);
+void __sanitizer_syscall_pre_impl_ppoll(long arg0, long arg1, long arg2,
+                                        long arg3, long arg4);
+void __sanitizer_syscall_post_impl_ppoll(long res, long arg0, long arg1,
+                                         long arg2, long arg3, long arg4);
+void __sanitizer_syscall_pre_impl_fanotify_init(long flags, long event_f_flags);
+void __sanitizer_syscall_post_impl_fanotify_init(long res, long flags,
+                                                 long event_f_flags);
+void __sanitizer_syscall_pre_impl_fanotify_mark(long fanotify_fd, long flags,
+                                                long mask, long fd,
+                                                long pathname);
+void __sanitizer_syscall_post_impl_fanotify_mark(long res, long fanotify_fd,
+                                                 long flags, long mask, long fd,
+                                                 long pathname);
+void __sanitizer_syscall_pre_impl_syncfs(long fd);
+void __sanitizer_syscall_post_impl_syncfs(long res, long fd);
+void __sanitizer_syscall_pre_impl_perf_event_open(long attr_uptr, long pid,
+                                                  long cpu, long group_fd,
+                                                  long flags);
+void __sanitizer_syscall_post_impl_perf_event_open(long res, long attr_uptr,
+                                                   long pid, long cpu,
+                                                   long group_fd, long flags);
+void __sanitizer_syscall_pre_impl_mmap_pgoff(long addr, long len, long prot,
+                                             long flags, long fd, long pgoff);
+void __sanitizer_syscall_post_impl_mmap_pgoff(long res, long addr, long len,
+                                              long prot, long flags, long fd,
+                                              long pgoff);
+void __sanitizer_syscall_pre_impl_old_mmap(long arg);
+void __sanitizer_syscall_post_impl_old_mmap(long res, long arg);
+void __sanitizer_syscall_pre_impl_name_to_handle_at(long dfd, long name,
+                                                    long handle, long mnt_id,
+                                                    long flag);
+void __sanitizer_syscall_post_impl_name_to_handle_at(long res, long dfd,
+                                                     long name, long handle,
+                                                     long mnt_id, long flag);
+void __sanitizer_syscall_pre_impl_open_by_handle_at(long mountdirfd,
+                                                    long handle, long flags);
+void __sanitizer_syscall_post_impl_open_by_handle_at(long res, long mountdirfd,
+                                                     long handle, long flags);
+void __sanitizer_syscall_pre_impl_setns(long fd, long nstype);
+void __sanitizer_syscall_post_impl_setns(long res, long fd, long nstype);
+void __sanitizer_syscall_pre_impl_process_vm_readv(long pid, long lvec,
+                                                   long liovcnt, long rvec,
+                                                   long riovcnt, long flags);
+void __sanitizer_syscall_post_impl_process_vm_readv(long res, long pid,
+                                                    long lvec, long liovcnt,
+                                                    long rvec, long riovcnt,
+                                                    long flags);
+void __sanitizer_syscall_pre_impl_process_vm_writev(long pid, long lvec,
+                                                    long liovcnt, long rvec,
+                                                    long riovcnt, long flags);
+void __sanitizer_syscall_post_impl_process_vm_writev(long res, long pid,
+                                                     long lvec, long liovcnt,
+                                                     long rvec, long riovcnt,
+                                                     long flags);
+void __sanitizer_syscall_pre_impl_fork();
+void __sanitizer_syscall_post_impl_fork(long res);
+void __sanitizer_syscall_pre_impl_vfork();
+void __sanitizer_syscall_post_impl_vfork(long res);
+void __sanitizer_syscall_pre_impl_sigaction(long signum, long act, long oldact);
+void __sanitizer_syscall_post_impl_sigaction(long res, long signum, long act,
+                                             long oldact);
+void __sanitizer_syscall_pre_impl_rt_sigaction(long signum, long act,
+                                               long oldact, long sz);
+void __sanitizer_syscall_post_impl_rt_sigaction(long res, long signum, long act,
+                                                long oldact, long sz);
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SANITIZER_LINUX_SYSCALL_HOOKS_H

--- a/system/lib/compiler-rt/include/sanitizer/lsan_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/lsan_interface.h
@@ -1,0 +1,89 @@
+//===-- sanitizer/lsan_interface.h ------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of LeakSanitizer.
+//
+// Public interface header.
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_LSAN_INTERFACE_H
+#define SANITIZER_LSAN_INTERFACE_H
+
+#include <sanitizer/common_interface_defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  // Allocations made between calls to __lsan_disable() and __lsan_enable() will
+  // be treated as non-leaks. Disable/enable pairs may be nested.
+  void __lsan_disable(void);
+  void __lsan_enable(void);
+
+  // The heap object into which p points will be treated as a non-leak.
+  void __lsan_ignore_object(const void *p);
+
+  // Memory regions registered through this interface will be treated as sources
+  // of live pointers during leak checking. Useful if you store pointers in
+  // mapped memory.
+  // Points of note:
+  // - __lsan_unregister_root_region() must be called with the same pointer and
+  // size that have earlier been passed to __lsan_register_root_region()
+  // - LSan will skip any inaccessible memory when scanning a root region. E.g.,
+  // if you map memory within a larger region that you have mprotect'ed, you can
+  // register the entire large region.
+  // - the implementation is not optimized for performance. This interface is
+  // intended to be used for a small number of relatively static regions.
+  void __lsan_register_root_region(const void *p, size_t size);
+  void __lsan_unregister_root_region(const void *p, size_t size);
+
+  // Check for leaks now. This function behaves identically to the default
+  // end-of-process leak check. In particular, it will terminate the process if
+  // leaks are found and the exitcode runtime flag is non-zero.
+  // Subsequent calls to this function will have no effect and end-of-process
+  // leak check will not run. Effectively, end-of-process leak check is moved to
+  // the time of first invocation of this function.
+  // By calling this function early during process shutdown, you can instruct
+  // LSan to ignore shutdown-only leaks which happen later on.
+  void __lsan_do_leak_check(void);
+
+  // Check for leaks now. Returns zero if no leaks have been found or if leak
+  // detection is disabled, non-zero otherwise.
+  // This function may be called repeatedly, e.g. to periodically check a
+  // long-running process. It prints a leak report if appropriate, but does not
+  // terminate the process. It does not affect the behavior of
+  // __lsan_do_leak_check() or the end-of-process leak check, and is not
+  // affected by them.
+  int __lsan_do_recoverable_leak_check(void);
+
+  // The user may optionally provide this function to disallow leak checking
+  // for the program it is linked into (if the return value is non-zero). This
+  // function must be defined as returning a constant value; any behavior beyond
+  // that is unsupported.
+  // To avoid dead stripping, you may need to define this function with
+  // __attribute__((used))
+  int __lsan_is_turned_off(void);
+
+  // This function may be optionally provided by user and should return
+  // a string containing LSan runtime options. See lsan_flags.inc for details.
+  const char *__lsan_default_options(void);
+
+  // This function may be optionally provided by the user and should return
+  // a string containing LSan suppressions.
+  const char *__lsan_default_suppressions(void);
+#ifdef __cplusplus
+}  // extern "C"
+
+namespace __lsan {
+class ScopedDisabler {
+ public:
+  ScopedDisabler() { __lsan_disable(); }
+  ~ScopedDisabler() { __lsan_enable(); }
+};
+}  // namespace __lsan
+#endif
+
+#endif  // SANITIZER_LSAN_INTERFACE_H

--- a/system/lib/compiler-rt/include/sanitizer/msan_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/msan_interface.h
@@ -1,0 +1,121 @@
+//===-- msan_interface.h --------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of MemorySanitizer.
+//
+// Public interface header.
+//===----------------------------------------------------------------------===//
+#ifndef MSAN_INTERFACE_H
+#define MSAN_INTERFACE_H
+
+#include <sanitizer/common_interface_defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  /* Set raw origin for the memory range. */
+  void __msan_set_origin(const volatile void *a, size_t size, uint32_t origin);
+
+  /* Get raw origin for an address. */
+  uint32_t __msan_get_origin(const volatile void *a);
+
+  /* Test that this_id is a descendant of prev_id (or they are simply equal).
+   * "descendant" here means they are part of the same chain, created with
+   * __msan_chain_origin. */
+  int __msan_origin_is_descendant_or_same(uint32_t this_id, uint32_t prev_id);
+
+  /* Returns non-zero if tracking origins. */
+  int __msan_get_track_origins(void);
+
+  /* Returns the origin id of the latest UMR in the calling thread. */
+  uint32_t __msan_get_umr_origin(void);
+
+  /* Make memory region fully initialized (without changing its contents). */
+  void __msan_unpoison(const volatile void *a, size_t size);
+
+  /* Make a null-terminated string fully initialized (without changing its
+     contents). */
+  void __msan_unpoison_string(const volatile char *a);
+
+  /* Make first n parameters of the next function call fully initialized. */
+  void __msan_unpoison_param(size_t n);
+
+  /* Make memory region fully uninitialized (without changing its contents).
+     This is a legacy interface that does not update origin information. Use
+     __msan_allocated_memory() instead. */
+  void __msan_poison(const volatile void *a, size_t size);
+
+  /* Make memory region partially uninitialized (without changing its contents).
+   */
+  void __msan_partial_poison(const volatile void *data, void *shadow,
+                             size_t size);
+
+  /* Returns the offset of the first (at least partially) poisoned byte in the
+     memory range, or -1 if the whole range is good. */
+  intptr_t __msan_test_shadow(const volatile void *x, size_t size);
+
+  /* Checks that memory range is fully initialized, and reports an error if it
+   * is not. */
+  void __msan_check_mem_is_initialized(const volatile void *x, size_t size);
+
+  /* For testing:
+     __msan_set_expect_umr(1);
+     ... some buggy code ...
+     __msan_set_expect_umr(0);
+     The last line will verify that a UMR happened. */
+  void __msan_set_expect_umr(int expect_umr);
+
+  /* Change the value of keep_going flag. Non-zero value means don't terminate
+     program execution when an error is detected. This will not affect error in
+     modules that were compiled without the corresponding compiler flag. */
+  void __msan_set_keep_going(int keep_going);
+
+  /* Print shadow and origin for the memory range to stderr in a human-readable
+     format. */
+  void __msan_print_shadow(const volatile void *x, size_t size);
+
+  /* Print shadow for the memory range to stderr in a minimalistic
+     human-readable format. */
+  void __msan_dump_shadow(const volatile void *x, size_t size);
+
+  /* Returns true if running under a dynamic tool (DynamoRio-based). */
+  int  __msan_has_dynamic_component(void);
+
+  /* Tell MSan about newly allocated memory (ex.: custom allocator).
+     Memory will be marked uninitialized, with origin at the call site. */
+  void __msan_allocated_memory(const volatile void* data, size_t size);
+
+  /* Tell MSan about newly destroyed memory. Mark memory as uninitialized. */
+  void __sanitizer_dtor_callback(const volatile void* data, size_t size);
+
+  /* This function may be optionally provided by user and should return
+     a string containing Msan runtime options. See msan_flags.h for details. */
+  const char* __msan_default_options(void);
+
+  /* Deprecated. Call __sanitizer_set_death_callback instead. */
+  void __msan_set_death_callback(void (*callback)(void));
+
+  /* Update shadow for the application copy of size bytes from src to dst.
+     Src and dst are application addresses. This function does not copy the
+     actual application memory, it only updates shadow and origin for such
+     copy. Source and destination regions can overlap. */
+  void __msan_copy_shadow(const volatile void *dst, const volatile void *src,
+                          size_t size);
+
+  /* Disables uninitialized memory checks in interceptors. */
+  void __msan_scoped_disable_interceptor_checks(void);
+
+  /* Re-enables uninitialized memory checks in interceptors after a previous
+     call to __msan_scoped_disable_interceptor_checks. */
+  void __msan_scoped_enable_interceptor_checks(void);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif

--- a/system/lib/compiler-rt/include/sanitizer/netbsd_syscall_hooks.h
+++ b/system/lib/compiler-rt/include/sanitizer/netbsd_syscall_hooks.h
@@ -1,0 +1,4731 @@
+//===-- netbsd_syscall_hooks.h --------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of public sanitizer interface.
+//
+// System call handlers.
+//
+// Interface methods declared in this header implement pre- and post- syscall
+// actions for the active sanitizer.
+// Usage:
+//   __sanitizer_syscall_pre_getfoo(...args...);
+//   long long res = syscall(SYS_getfoo, ...args...);
+//   __sanitizer_syscall_post_getfoo(res, ...args...);
+//
+// DO NOT EDIT! THIS FILE HAS BEEN GENERATED!
+//
+// Generated with: generate_netbsd_syscalls.awk
+// Generated date: 2018-10-30
+// Generated from: syscalls.master,v 1.293 2018/07/31 13:00:13 rjs Exp
+//
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_NETBSD_SYSCALL_HOOKS_H
+#define SANITIZER_NETBSD_SYSCALL_HOOKS_H
+
+#define __sanitizer_syscall_pre_syscall(code, arg0, arg1, arg2, arg3, arg4,    \
+                                        arg5, arg6, arg7)                      \
+  __sanitizer_syscall_pre_impl_syscall(                                        \
+      (long long)(code), (long long)(arg0), (long long)(arg1),                 \
+      (long long)(arg2), (long long)(arg3), (long long)(arg4),                 \
+      (long long)(arg5), (long long)(arg6), (long long)(arg7))
+#define __sanitizer_syscall_post_syscall(res, code, arg0, arg1, arg2, arg3,    \
+                                         arg4, arg5, arg6, arg7)               \
+  __sanitizer_syscall_post_impl_syscall(                                       \
+      res, (long long)(code), (long long)(arg0), (long long)(arg1),            \
+      (long long)(arg2), (long long)(arg3), (long long)(arg4),                 \
+      (long long)(arg5), (long long)(arg6), (long long)(arg7))
+#define __sanitizer_syscall_pre_exit(rval)                                     \
+  __sanitizer_syscall_pre_impl_exit((long long)(rval))
+#define __sanitizer_syscall_post_exit(res, rval)                               \
+  __sanitizer_syscall_post_impl_exit(res, (long long)(rval))
+#define __sanitizer_syscall_pre_fork() __sanitizer_syscall_pre_impl_fork()
+#define __sanitizer_syscall_post_fork(res)                                     \
+  __sanitizer_syscall_post_impl_fork(res)
+#define __sanitizer_syscall_pre_read(fd, buf, nbyte)                           \
+  __sanitizer_syscall_pre_impl_read((long long)(fd), (long long)(buf),         \
+                                    (long long)(nbyte))
+#define __sanitizer_syscall_post_read(res, fd, buf, nbyte)                     \
+  __sanitizer_syscall_post_impl_read(res, (long long)(fd), (long long)(buf),   \
+                                     (long long)(nbyte))
+#define __sanitizer_syscall_pre_write(fd, buf, nbyte)                          \
+  __sanitizer_syscall_pre_impl_write((long long)(fd), (long long)(buf),        \
+                                     (long long)(nbyte))
+#define __sanitizer_syscall_post_write(res, fd, buf, nbyte)                    \
+  __sanitizer_syscall_post_impl_write(res, (long long)(fd), (long long)(buf),  \
+                                      (long long)(nbyte))
+#define __sanitizer_syscall_pre_open(path, flags, mode)                        \
+  __sanitizer_syscall_pre_impl_open((long long)(path), (long long)(flags),     \
+                                    (long long)(mode))
+#define __sanitizer_syscall_post_open(res, path, flags, mode)                  \
+  __sanitizer_syscall_post_impl_open(res, (long long)(path),                   \
+                                     (long long)(flags), (long long)(mode))
+#define __sanitizer_syscall_pre_close(fd)                                      \
+  __sanitizer_syscall_pre_impl_close((long long)(fd))
+#define __sanitizer_syscall_post_close(res, fd)                                \
+  __sanitizer_syscall_post_impl_close(res, (long long)(fd))
+#define __sanitizer_syscall_pre_compat_50_wait4(pid, status, options, rusage)  \
+  __sanitizer_syscall_pre_impl_compat_50_wait4(                                \
+      (long long)(pid), (long long)(status), (long long)(options),             \
+      (long long)(rusage))
+#define __sanitizer_syscall_post_compat_50_wait4(res, pid, status, options,    \
+                                                 rusage)                       \
+  __sanitizer_syscall_post_impl_compat_50_wait4(                               \
+      res, (long long)(pid), (long long)(status), (long long)(options),        \
+      (long long)(rusage))
+#define __sanitizer_syscall_pre_compat_43_ocreat(path, mode)                   \
+  __sanitizer_syscall_pre_impl_compat_43_ocreat((long long)(path),             \
+                                                (long long)(mode))
+#define __sanitizer_syscall_post_compat_43_ocreat(res, path, mode)             \
+  __sanitizer_syscall_post_impl_compat_43_ocreat(res, (long long)(path),       \
+                                                 (long long)(mode))
+#define __sanitizer_syscall_pre_link(path, link)                               \
+  __sanitizer_syscall_pre_impl_link((long long)(path), (long long)(link))
+#define __sanitizer_syscall_post_link(res, path, link)                         \
+  __sanitizer_syscall_post_impl_link(res, (long long)(path), (long long)(link))
+#define __sanitizer_syscall_pre_unlink(path)                                   \
+  __sanitizer_syscall_pre_impl_unlink((long long)(path))
+#define __sanitizer_syscall_post_unlink(res, path)                             \
+  __sanitizer_syscall_post_impl_unlink(res, (long long)(path))
+/* syscall 11 has been skipped */
+#define __sanitizer_syscall_pre_chdir(path)                                    \
+  __sanitizer_syscall_pre_impl_chdir((long long)(path))
+#define __sanitizer_syscall_post_chdir(res, path)                              \
+  __sanitizer_syscall_post_impl_chdir(res, (long long)(path))
+#define __sanitizer_syscall_pre_fchdir(fd)                                     \
+  __sanitizer_syscall_pre_impl_fchdir((long long)(fd))
+#define __sanitizer_syscall_post_fchdir(res, fd)                               \
+  __sanitizer_syscall_post_impl_fchdir(res, (long long)(fd))
+#define __sanitizer_syscall_pre_compat_50_mknod(path, mode, dev)               \
+  __sanitizer_syscall_pre_impl_compat_50_mknod(                                \
+      (long long)(path), (long long)(mode), (long long)(dev))
+#define __sanitizer_syscall_post_compat_50_mknod(res, path, mode, dev)         \
+  __sanitizer_syscall_post_impl_compat_50_mknod(                               \
+      res, (long long)(path), (long long)(mode), (long long)(dev))
+#define __sanitizer_syscall_pre_chmod(path, mode)                              \
+  __sanitizer_syscall_pre_impl_chmod((long long)(path), (long long)(mode))
+#define __sanitizer_syscall_post_chmod(res, path, mode)                        \
+  __sanitizer_syscall_post_impl_chmod(res, (long long)(path), (long long)(mode))
+#define __sanitizer_syscall_pre_chown(path, uid, gid)                          \
+  __sanitizer_syscall_pre_impl_chown((long long)(path), (long long)(uid),      \
+                                     (long long)(gid))
+#define __sanitizer_syscall_post_chown(res, path, uid, gid)                    \
+  __sanitizer_syscall_post_impl_chown(res, (long long)(path),                  \
+                                      (long long)(uid), (long long)(gid))
+#define __sanitizer_syscall_pre_break(nsize)                                   \
+  __sanitizer_syscall_pre_impl_break((long long)(nsize))
+#define __sanitizer_syscall_post_break(res, nsize)                             \
+  __sanitizer_syscall_post_impl_break(res, (long long)(nsize))
+#define __sanitizer_syscall_pre_compat_20_getfsstat(buf, bufsize, flags)       \
+  __sanitizer_syscall_pre_impl_compat_20_getfsstat(                            \
+      (long long)(buf), (long long)(bufsize), (long long)(flags))
+#define __sanitizer_syscall_post_compat_20_getfsstat(res, buf, bufsize, flags) \
+  __sanitizer_syscall_post_impl_compat_20_getfsstat(                           \
+      res, (long long)(buf), (long long)(bufsize), (long long)(flags))
+#define __sanitizer_syscall_pre_compat_43_olseek(fd, offset, whence)           \
+  __sanitizer_syscall_pre_impl_compat_43_olseek(                               \
+      (long long)(fd), (long long)(offset), (long long)(whence))
+#define __sanitizer_syscall_post_compat_43_olseek(res, fd, offset, whence)     \
+  __sanitizer_syscall_post_impl_compat_43_olseek(                              \
+      res, (long long)(fd), (long long)(offset), (long long)(whence))
+#define __sanitizer_syscall_pre_getpid() __sanitizer_syscall_pre_impl_getpid()
+#define __sanitizer_syscall_post_getpid(res)                                   \
+  __sanitizer_syscall_post_impl_getpid(res)
+#define __sanitizer_syscall_pre_compat_40_mount(type, path, flags, data)       \
+  __sanitizer_syscall_pre_impl_compat_40_mount(                                \
+      (long long)(type), (long long)(path), (long long)(flags),                \
+      (long long)(data))
+#define __sanitizer_syscall_post_compat_40_mount(res, type, path, flags, data) \
+  __sanitizer_syscall_post_impl_compat_40_mount(                               \
+      res, (long long)(type), (long long)(path), (long long)(flags),           \
+      (long long)(data))
+#define __sanitizer_syscall_pre_unmount(path, flags)                           \
+  __sanitizer_syscall_pre_impl_unmount((long long)(path), (long long)(flags))
+#define __sanitizer_syscall_post_unmount(res, path, flags)                     \
+  __sanitizer_syscall_post_impl_unmount(res, (long long)(path),                \
+                                        (long long)(flags))
+#define __sanitizer_syscall_pre_setuid(uid)                                    \
+  __sanitizer_syscall_pre_impl_setuid((long long)(uid))
+#define __sanitizer_syscall_post_setuid(res, uid)                              \
+  __sanitizer_syscall_post_impl_setuid(res, (long long)(uid))
+#define __sanitizer_syscall_pre_getuid() __sanitizer_syscall_pre_impl_getuid()
+#define __sanitizer_syscall_post_getuid(res)                                   \
+  __sanitizer_syscall_post_impl_getuid(res)
+#define __sanitizer_syscall_pre_geteuid() __sanitizer_syscall_pre_impl_geteuid()
+#define __sanitizer_syscall_post_geteuid(res)                                  \
+  __sanitizer_syscall_post_impl_geteuid(res)
+#define __sanitizer_syscall_pre_ptrace(req, pid, addr, data)                   \
+  __sanitizer_syscall_pre_impl_ptrace((long long)(req), (long long)(pid),      \
+                                      (long long)(addr), (long long)(data))
+#define __sanitizer_syscall_post_ptrace(res, req, pid, addr, data)             \
+  __sanitizer_syscall_post_impl_ptrace(res, (long long)(req),                  \
+                                       (long long)(pid), (long long)(addr),    \
+                                       (long long)(data))
+#define __sanitizer_syscall_pre_recvmsg(s, msg, flags)                         \
+  __sanitizer_syscall_pre_impl_recvmsg((long long)(s), (long long)(msg),       \
+                                       (long long)(flags))
+#define __sanitizer_syscall_post_recvmsg(res, s, msg, flags)                   \
+  __sanitizer_syscall_post_impl_recvmsg(res, (long long)(s), (long long)(msg), \
+                                        (long long)(flags))
+#define __sanitizer_syscall_pre_sendmsg(s, msg, flags)                         \
+  __sanitizer_syscall_pre_impl_sendmsg((long long)(s), (long long)(msg),       \
+                                       (long long)(flags))
+#define __sanitizer_syscall_post_sendmsg(res, s, msg, flags)                   \
+  __sanitizer_syscall_post_impl_sendmsg(res, (long long)(s), (long long)(msg), \
+                                        (long long)(flags))
+#define __sanitizer_syscall_pre_recvfrom(s, buf, len, flags, from,             \
+                                         fromlenaddr)                          \
+  __sanitizer_syscall_pre_impl_recvfrom(                                       \
+      (long long)(s), (long long)(buf), (long long)(len), (long long)(flags),  \
+      (long long)(from), (long long)(fromlenaddr))
+#define __sanitizer_syscall_post_recvfrom(res, s, buf, len, flags, from,       \
+                                          fromlenaddr)                         \
+  __sanitizer_syscall_post_impl_recvfrom(                                      \
+      res, (long long)(s), (long long)(buf), (long long)(len),                 \
+      (long long)(flags), (long long)(from), (long long)(fromlenaddr))
+#define __sanitizer_syscall_pre_accept(s, name, anamelen)                      \
+  __sanitizer_syscall_pre_impl_accept((long long)(s), (long long)(name),       \
+                                      (long long)(anamelen))
+#define __sanitizer_syscall_post_accept(res, s, name, anamelen)                \
+  __sanitizer_syscall_post_impl_accept(res, (long long)(s), (long long)(name), \
+                                       (long long)(anamelen))
+#define __sanitizer_syscall_pre_getpeername(fdes, asa, alen)                   \
+  __sanitizer_syscall_pre_impl_getpeername(                                    \
+      (long long)(fdes), (long long)(asa), (long long)(alen))
+#define __sanitizer_syscall_post_getpeername(res, fdes, asa, alen)             \
+  __sanitizer_syscall_post_impl_getpeername(                                   \
+      res, (long long)(fdes), (long long)(asa), (long long)(alen))
+#define __sanitizer_syscall_pre_getsockname(fdes, asa, alen)                   \
+  __sanitizer_syscall_pre_impl_getsockname(                                    \
+      (long long)(fdes), (long long)(asa), (long long)(alen))
+#define __sanitizer_syscall_post_getsockname(res, fdes, asa, alen)             \
+  __sanitizer_syscall_post_impl_getsockname(                                   \
+      res, (long long)(fdes), (long long)(asa), (long long)(alen))
+#define __sanitizer_syscall_pre_access(path, flags)                            \
+  __sanitizer_syscall_pre_impl_access((long long)(path), (long long)(flags))
+#define __sanitizer_syscall_post_access(res, path, flags)                      \
+  __sanitizer_syscall_post_impl_access(res, (long long)(path),                 \
+                                       (long long)(flags))
+#define __sanitizer_syscall_pre_chflags(path, flags)                           \
+  __sanitizer_syscall_pre_impl_chflags((long long)(path), (long long)(flags))
+#define __sanitizer_syscall_post_chflags(res, path, flags)                     \
+  __sanitizer_syscall_post_impl_chflags(res, (long long)(path),                \
+                                        (long long)(flags))
+#define __sanitizer_syscall_pre_fchflags(fd, flags)                            \
+  __sanitizer_syscall_pre_impl_fchflags((long long)(fd), (long long)(flags))
+#define __sanitizer_syscall_post_fchflags(res, fd, flags)                      \
+  __sanitizer_syscall_post_impl_fchflags(res, (long long)(fd),                 \
+                                         (long long)(flags))
+#define __sanitizer_syscall_pre_sync() __sanitizer_syscall_pre_impl_sync()
+#define __sanitizer_syscall_post_sync(res)                                     \
+  __sanitizer_syscall_post_impl_sync(res)
+#define __sanitizer_syscall_pre_kill(pid, signum)                              \
+  __sanitizer_syscall_pre_impl_kill((long long)(pid), (long long)(signum))
+#define __sanitizer_syscall_post_kill(res, pid, signum)                        \
+  __sanitizer_syscall_post_impl_kill(res, (long long)(pid), (long long)(signum))
+#define __sanitizer_syscall_pre_compat_43_stat43(path, ub)                     \
+  __sanitizer_syscall_pre_impl_compat_43_stat43((long long)(path),             \
+                                                (long long)(ub))
+#define __sanitizer_syscall_post_compat_43_stat43(res, path, ub)               \
+  __sanitizer_syscall_post_impl_compat_43_stat43(res, (long long)(path),       \
+                                                 (long long)(ub))
+#define __sanitizer_syscall_pre_getppid() __sanitizer_syscall_pre_impl_getppid()
+#define __sanitizer_syscall_post_getppid(res)                                  \
+  __sanitizer_syscall_post_impl_getppid(res)
+#define __sanitizer_syscall_pre_compat_43_lstat43(path, ub)                    \
+  __sanitizer_syscall_pre_impl_compat_43_lstat43((long long)(path),            \
+                                                 (long long)(ub))
+#define __sanitizer_syscall_post_compat_43_lstat43(res, path, ub)              \
+  __sanitizer_syscall_post_impl_compat_43_lstat43(res, (long long)(path),      \
+                                                  (long long)(ub))
+#define __sanitizer_syscall_pre_dup(fd)                                        \
+  __sanitizer_syscall_pre_impl_dup((long long)(fd))
+#define __sanitizer_syscall_post_dup(res, fd)                                  \
+  __sanitizer_syscall_post_impl_dup(res, (long long)(fd))
+#define __sanitizer_syscall_pre_pipe() __sanitizer_syscall_pre_impl_pipe()
+#define __sanitizer_syscall_post_pipe(res)                                     \
+  __sanitizer_syscall_post_impl_pipe(res)
+#define __sanitizer_syscall_pre_getegid() __sanitizer_syscall_pre_impl_getegid()
+#define __sanitizer_syscall_post_getegid(res)                                  \
+  __sanitizer_syscall_post_impl_getegid(res)
+#define __sanitizer_syscall_pre_profil(samples, size, offset, scale)           \
+  __sanitizer_syscall_pre_impl_profil((long long)(samples), (long long)(size), \
+                                      (long long)(offset), (long long)(scale))
+#define __sanitizer_syscall_post_profil(res, samples, size, offset, scale)     \
+  __sanitizer_syscall_post_impl_profil(res, (long long)(samples),              \
+                                       (long long)(size), (long long)(offset), \
+                                       (long long)(scale))
+#define __sanitizer_syscall_pre_ktrace(fname, ops, facs, pid)                  \
+  __sanitizer_syscall_pre_impl_ktrace((long long)(fname), (long long)(ops),    \
+                                      (long long)(facs), (long long)(pid))
+#define __sanitizer_syscall_post_ktrace(res, fname, ops, facs, pid)            \
+  __sanitizer_syscall_post_impl_ktrace(res, (long long)(fname),                \
+                                       (long long)(ops), (long long)(facs),    \
+                                       (long long)(pid))
+#define __sanitizer_syscall_pre_compat_13_sigaction13(signum, nsa, osa)        \
+  __sanitizer_syscall_pre_impl_compat_13_sigaction13(                          \
+      (long long)(signum), (long long)(nsa), (long long)(osa))
+#define __sanitizer_syscall_post_compat_13_sigaction13(res, signum, nsa, osa)  \
+  __sanitizer_syscall_post_impl_compat_13_sigaction13(                         \
+      res, (long long)(signum), (long long)(nsa), (long long)(osa))
+#define __sanitizer_syscall_pre_getgid() __sanitizer_syscall_pre_impl_getgid()
+#define __sanitizer_syscall_post_getgid(res)                                   \
+  __sanitizer_syscall_post_impl_getgid(res)
+#define __sanitizer_syscall_pre_compat_13_sigprocmask13(how, mask)             \
+  __sanitizer_syscall_pre_impl_compat_13_sigprocmask13((long long)(how),       \
+                                                       (long long)(mask))
+#define __sanitizer_syscall_post_compat_13_sigprocmask13(res, how, mask)       \
+  __sanitizer_syscall_post_impl_compat_13_sigprocmask13(res, (long long)(how), \
+                                                        (long long)(mask))
+#define __sanitizer_syscall_pre___getlogin(namebuf, namelen)                   \
+  __sanitizer_syscall_pre_impl___getlogin((long long)(namebuf),                \
+                                          (long long)(namelen))
+#define __sanitizer_syscall_post___getlogin(res, namebuf, namelen)             \
+  __sanitizer_syscall_post_impl___getlogin(res, (long long)(namebuf),          \
+                                           (long long)(namelen))
+#define __sanitizer_syscall_pre___setlogin(namebuf)                            \
+  __sanitizer_syscall_pre_impl___setlogin((long long)(namebuf))
+#define __sanitizer_syscall_post___setlogin(res, namebuf)                      \
+  __sanitizer_syscall_post_impl___setlogin(res, (long long)(namebuf))
+#define __sanitizer_syscall_pre_acct(path)                                     \
+  __sanitizer_syscall_pre_impl_acct((long long)(path))
+#define __sanitizer_syscall_post_acct(res, path)                               \
+  __sanitizer_syscall_post_impl_acct(res, (long long)(path))
+#define __sanitizer_syscall_pre_compat_13_sigpending13()                       \
+  __sanitizer_syscall_pre_impl_compat_13_sigpending13()
+#define __sanitizer_syscall_post_compat_13_sigpending13(res)                   \
+  __sanitizer_syscall_post_impl_compat_13_sigpending13(res)
+#define __sanitizer_syscall_pre_compat_13_sigaltstack13(nss, oss)              \
+  __sanitizer_syscall_pre_impl_compat_13_sigaltstack13((long long)(nss),       \
+                                                       (long long)(oss))
+#define __sanitizer_syscall_post_compat_13_sigaltstack13(res, nss, oss)        \
+  __sanitizer_syscall_post_impl_compat_13_sigaltstack13(res, (long long)(nss), \
+                                                        (long long)(oss))
+#define __sanitizer_syscall_pre_ioctl(fd, com, data)                           \
+  __sanitizer_syscall_pre_impl_ioctl((long long)(fd), (long long)(com),        \
+                                     (long long)(data))
+#define __sanitizer_syscall_post_ioctl(res, fd, com, data)                     \
+  __sanitizer_syscall_post_impl_ioctl(res, (long long)(fd), (long long)(com),  \
+                                      (long long)(data))
+#define __sanitizer_syscall_pre_compat_12_oreboot(opt)                         \
+  __sanitizer_syscall_pre_impl_compat_12_oreboot((long long)(opt))
+#define __sanitizer_syscall_post_compat_12_oreboot(res, opt)                   \
+  __sanitizer_syscall_post_impl_compat_12_oreboot(res, (long long)(opt))
+#define __sanitizer_syscall_pre_revoke(path)                                   \
+  __sanitizer_syscall_pre_impl_revoke((long long)(path))
+#define __sanitizer_syscall_post_revoke(res, path)                             \
+  __sanitizer_syscall_post_impl_revoke(res, (long long)(path))
+#define __sanitizer_syscall_pre_symlink(path, link)                            \
+  __sanitizer_syscall_pre_impl_symlink((long long)(path), (long long)(link))
+#define __sanitizer_syscall_post_symlink(res, path, link)                      \
+  __sanitizer_syscall_post_impl_symlink(res, (long long)(path),                \
+                                        (long long)(link))
+#define __sanitizer_syscall_pre_readlink(path, buf, count)                     \
+  __sanitizer_syscall_pre_impl_readlink((long long)(path), (long long)(buf),   \
+                                        (long long)(count))
+#define __sanitizer_syscall_post_readlink(res, path, buf, count)               \
+  __sanitizer_syscall_post_impl_readlink(res, (long long)(path),               \
+                                         (long long)(buf), (long long)(count))
+#define __sanitizer_syscall_pre_execve(path, argp, envp)                       \
+  __sanitizer_syscall_pre_impl_execve((long long)(path), (long long)(argp),    \
+                                      (long long)(envp))
+#define __sanitizer_syscall_post_execve(res, path, argp, envp)                 \
+  __sanitizer_syscall_post_impl_execve(res, (long long)(path),                 \
+                                       (long long)(argp), (long long)(envp))
+#define __sanitizer_syscall_pre_umask(newmask)                                 \
+  __sanitizer_syscall_pre_impl_umask((long long)(newmask))
+#define __sanitizer_syscall_post_umask(res, newmask)                           \
+  __sanitizer_syscall_post_impl_umask(res, (long long)(newmask))
+#define __sanitizer_syscall_pre_chroot(path)                                   \
+  __sanitizer_syscall_pre_impl_chroot((long long)(path))
+#define __sanitizer_syscall_post_chroot(res, path)                             \
+  __sanitizer_syscall_post_impl_chroot(res, (long long)(path))
+#define __sanitizer_syscall_pre_compat_43_fstat43(fd, sb)                      \
+  __sanitizer_syscall_pre_impl_compat_43_fstat43((long long)(fd),              \
+                                                 (long long)(sb))
+#define __sanitizer_syscall_post_compat_43_fstat43(res, fd, sb)                \
+  __sanitizer_syscall_post_impl_compat_43_fstat43(res, (long long)(fd),        \
+                                                  (long long)(sb))
+#define __sanitizer_syscall_pre_compat_43_ogetkerninfo(op, where, size, arg)   \
+  __sanitizer_syscall_pre_impl_compat_43_ogetkerninfo(                         \
+      (long long)(op), (long long)(where), (long long)(size),                  \
+      (long long)(arg))
+#define __sanitizer_syscall_post_compat_43_ogetkerninfo(res, op, where, size,  \
+                                                        arg)                   \
+  __sanitizer_syscall_post_impl_compat_43_ogetkerninfo(                        \
+      res, (long long)(op), (long long)(where), (long long)(size),             \
+      (long long)(arg))
+#define __sanitizer_syscall_pre_compat_43_ogetpagesize()                       \
+  __sanitizer_syscall_pre_impl_compat_43_ogetpagesize()
+#define __sanitizer_syscall_post_compat_43_ogetpagesize(res)                   \
+  __sanitizer_syscall_post_impl_compat_43_ogetpagesize(res)
+#define __sanitizer_syscall_pre_compat_12_msync(addr, len)                     \
+  __sanitizer_syscall_pre_impl_compat_12_msync((long long)(addr),              \
+                                               (long long)(len))
+#define __sanitizer_syscall_post_compat_12_msync(res, addr, len)               \
+  __sanitizer_syscall_post_impl_compat_12_msync(res, (long long)(addr),        \
+                                                (long long)(len))
+#define __sanitizer_syscall_pre_vfork() __sanitizer_syscall_pre_impl_vfork()
+#define __sanitizer_syscall_post_vfork(res)                                    \
+  __sanitizer_syscall_post_impl_vfork(res)
+/* syscall 67 has been skipped */
+/* syscall 68 has been skipped */
+/* syscall 69 has been skipped */
+/* syscall 70 has been skipped */
+#define __sanitizer_syscall_pre_compat_43_ommap(addr, len, prot, flags, fd,    \
+                                                pos)                           \
+  __sanitizer_syscall_pre_impl_compat_43_ommap(                                \
+      (long long)(addr), (long long)(len), (long long)(prot),                  \
+      (long long)(flags), (long long)(fd), (long long)(pos))
+#define __sanitizer_syscall_post_compat_43_ommap(res, addr, len, prot, flags,  \
+                                                 fd, pos)                      \
+  __sanitizer_syscall_post_impl_compat_43_ommap(                               \
+      res, (long long)(addr), (long long)(len), (long long)(prot),             \
+      (long long)(flags), (long long)(fd), (long long)(pos))
+#define __sanitizer_syscall_pre_vadvise(anom)                                  \
+  __sanitizer_syscall_pre_impl_vadvise((long long)(anom))
+#define __sanitizer_syscall_post_vadvise(res, anom)                            \
+  __sanitizer_syscall_post_impl_vadvise(res, (long long)(anom))
+#define __sanitizer_syscall_pre_munmap(addr, len)                              \
+  __sanitizer_syscall_pre_impl_munmap((long long)(addr), (long long)(len))
+#define __sanitizer_syscall_post_munmap(res, addr, len)                        \
+  __sanitizer_syscall_post_impl_munmap(res, (long long)(addr), (long long)(len))
+#define __sanitizer_syscall_pre_mprotect(addr, len, prot)                      \
+  __sanitizer_syscall_pre_impl_mprotect((long long)(addr), (long long)(len),   \
+                                        (long long)(prot))
+#define __sanitizer_syscall_post_mprotect(res, addr, len, prot)                \
+  __sanitizer_syscall_post_impl_mprotect(res, (long long)(addr),               \
+                                         (long long)(len), (long long)(prot))
+#define __sanitizer_syscall_pre_madvise(addr, len, behav)                      \
+  __sanitizer_syscall_pre_impl_madvise((long long)(addr), (long long)(len),    \
+                                       (long long)(behav))
+#define __sanitizer_syscall_post_madvise(res, addr, len, behav)                \
+  __sanitizer_syscall_post_impl_madvise(res, (long long)(addr),                \
+                                        (long long)(len), (long long)(behav))
+/* syscall 76 has been skipped */
+/* syscall 77 has been skipped */
+#define __sanitizer_syscall_pre_mincore(addr, len, vec)                        \
+  __sanitizer_syscall_pre_impl_mincore((long long)(addr), (long long)(len),    \
+                                       (long long)(vec))
+#define __sanitizer_syscall_post_mincore(res, addr, len, vec)                  \
+  __sanitizer_syscall_post_impl_mincore(res, (long long)(addr),                \
+                                        (long long)(len), (long long)(vec))
+#define __sanitizer_syscall_pre_getgroups(gidsetsize, gidset)                  \
+  __sanitizer_syscall_pre_impl_getgroups((long long)(gidsetsize),              \
+                                         (long long)(gidset))
+#define __sanitizer_syscall_post_getgroups(res, gidsetsize, gidset)            \
+  __sanitizer_syscall_post_impl_getgroups(res, (long long)(gidsetsize),        \
+                                          (long long)(gidset))
+#define __sanitizer_syscall_pre_setgroups(gidsetsize, gidset)                  \
+  __sanitizer_syscall_pre_impl_setgroups((long long)(gidsetsize),              \
+                                         (long long)(gidset))
+#define __sanitizer_syscall_post_setgroups(res, gidsetsize, gidset)            \
+  __sanitizer_syscall_post_impl_setgroups(res, (long long)(gidsetsize),        \
+                                          (long long)(gidset))
+#define __sanitizer_syscall_pre_getpgrp() __sanitizer_syscall_pre_impl_getpgrp()
+#define __sanitizer_syscall_post_getpgrp(res)                                  \
+  __sanitizer_syscall_post_impl_getpgrp(res)
+#define __sanitizer_syscall_pre_setpgid(pid, pgid)                             \
+  __sanitizer_syscall_pre_impl_setpgid((long long)(pid), (long long)(pgid))
+#define __sanitizer_syscall_post_setpgid(res, pid, pgid)                       \
+  __sanitizer_syscall_post_impl_setpgid(res, (long long)(pid),                 \
+                                        (long long)(pgid))
+#define __sanitizer_syscall_pre_compat_50_setitimer(which, itv, oitv)          \
+  __sanitizer_syscall_pre_impl_compat_50_setitimer(                            \
+      (long long)(which), (long long)(itv), (long long)(oitv))
+#define __sanitizer_syscall_post_compat_50_setitimer(res, which, itv, oitv)    \
+  __sanitizer_syscall_post_impl_compat_50_setitimer(                           \
+      res, (long long)(which), (long long)(itv), (long long)(oitv))
+#define __sanitizer_syscall_pre_compat_43_owait()                              \
+  __sanitizer_syscall_pre_impl_compat_43_owait()
+#define __sanitizer_syscall_post_compat_43_owait(res)                          \
+  __sanitizer_syscall_post_impl_compat_43_owait(res)
+#define __sanitizer_syscall_pre_compat_12_oswapon(name)                        \
+  __sanitizer_syscall_pre_impl_compat_12_oswapon((long long)(name))
+#define __sanitizer_syscall_post_compat_12_oswapon(res, name)                  \
+  __sanitizer_syscall_post_impl_compat_12_oswapon(res, (long long)(name))
+#define __sanitizer_syscall_pre_compat_50_getitimer(which, itv)                \
+  __sanitizer_syscall_pre_impl_compat_50_getitimer((long long)(which),         \
+                                                   (long long)(itv))
+#define __sanitizer_syscall_post_compat_50_getitimer(res, which, itv)          \
+  __sanitizer_syscall_post_impl_compat_50_getitimer(res, (long long)(which),   \
+                                                    (long long)(itv))
+#define __sanitizer_syscall_pre_compat_43_ogethostname(hostname, len)          \
+  __sanitizer_syscall_pre_impl_compat_43_ogethostname((long long)(hostname),   \
+                                                      (long long)(len))
+#define __sanitizer_syscall_post_compat_43_ogethostname(res, hostname, len)    \
+  __sanitizer_syscall_post_impl_compat_43_ogethostname(                        \
+      res, (long long)(hostname), (long long)(len))
+#define __sanitizer_syscall_pre_compat_43_osethostname(hostname, len)          \
+  __sanitizer_syscall_pre_impl_compat_43_osethostname((long long)(hostname),   \
+                                                      (long long)(len))
+#define __sanitizer_syscall_post_compat_43_osethostname(res, hostname, len)    \
+  __sanitizer_syscall_post_impl_compat_43_osethostname(                        \
+      res, (long long)(hostname), (long long)(len))
+#define __sanitizer_syscall_pre_compat_43_ogetdtablesize()                     \
+  __sanitizer_syscall_pre_impl_compat_43_ogetdtablesize()
+#define __sanitizer_syscall_post_compat_43_ogetdtablesize(res)                 \
+  __sanitizer_syscall_post_impl_compat_43_ogetdtablesize(res)
+#define __sanitizer_syscall_pre_dup2(from, to)                                 \
+  __sanitizer_syscall_pre_impl_dup2((long long)(from), (long long)(to))
+#define __sanitizer_syscall_post_dup2(res, from, to)                           \
+  __sanitizer_syscall_post_impl_dup2(res, (long long)(from), (long long)(to))
+/* syscall 91 has been skipped */
+#define __sanitizer_syscall_pre_fcntl(fd, cmd, arg)                            \
+  __sanitizer_syscall_pre_impl_fcntl((long long)(fd), (long long)(cmd),        \
+                                     (long long)(arg))
+#define __sanitizer_syscall_post_fcntl(res, fd, cmd, arg)                      \
+  __sanitizer_syscall_post_impl_fcntl(res, (long long)(fd), (long long)(cmd),  \
+                                      (long long)(arg))
+#define __sanitizer_syscall_pre_compat_50_select(nd, in, ou, ex, tv)           \
+  __sanitizer_syscall_pre_impl_compat_50_select(                               \
+      (long long)(nd), (long long)(in), (long long)(ou), (long long)(ex),      \
+      (long long)(tv))
+#define __sanitizer_syscall_post_compat_50_select(res, nd, in, ou, ex, tv)     \
+  __sanitizer_syscall_post_impl_compat_50_select(                              \
+      res, (long long)(nd), (long long)(in), (long long)(ou), (long long)(ex), \
+      (long long)(tv))
+/* syscall 94 has been skipped */
+#define __sanitizer_syscall_pre_fsync(fd)                                      \
+  __sanitizer_syscall_pre_impl_fsync((long long)(fd))
+#define __sanitizer_syscall_post_fsync(res, fd)                                \
+  __sanitizer_syscall_post_impl_fsync(res, (long long)(fd))
+#define __sanitizer_syscall_pre_setpriority(which, who, prio)                  \
+  __sanitizer_syscall_pre_impl_setpriority(                                    \
+      (long long)(which), (long long)(who), (long long)(prio))
+#define __sanitizer_syscall_post_setpriority(res, which, who, prio)            \
+  __sanitizer_syscall_post_impl_setpriority(                                   \
+      res, (long long)(which), (long long)(who), (long long)(prio))
+#define __sanitizer_syscall_pre_compat_30_socket(domain, type, protocol)       \
+  __sanitizer_syscall_pre_impl_compat_30_socket(                               \
+      (long long)(domain), (long long)(type), (long long)(protocol))
+#define __sanitizer_syscall_post_compat_30_socket(res, domain, type, protocol) \
+  __sanitizer_syscall_post_impl_compat_30_socket(                              \
+      res, (long long)(domain), (long long)(type), (long long)(protocol))
+#define __sanitizer_syscall_pre_connect(s, name, namelen)                      \
+  __sanitizer_syscall_pre_impl_connect((long long)(s), (long long)(name),      \
+                                       (long long)(namelen))
+#define __sanitizer_syscall_post_connect(res, s, name, namelen)                \
+  __sanitizer_syscall_post_impl_connect(                                       \
+      res, (long long)(s), (long long)(name), (long long)(namelen))
+#define __sanitizer_syscall_pre_compat_43_oaccept(s, name, anamelen)           \
+  __sanitizer_syscall_pre_impl_compat_43_oaccept(                              \
+      (long long)(s), (long long)(name), (long long)(anamelen))
+#define __sanitizer_syscall_post_compat_43_oaccept(res, s, name, anamelen)     \
+  __sanitizer_syscall_post_impl_compat_43_oaccept(                             \
+      res, (long long)(s), (long long)(name), (long long)(anamelen))
+#define __sanitizer_syscall_pre_getpriority(which, who)                        \
+  __sanitizer_syscall_pre_impl_getpriority((long long)(which), (long long)(who))
+#define __sanitizer_syscall_post_getpriority(res, which, who)                  \
+  __sanitizer_syscall_post_impl_getpriority(res, (long long)(which),           \
+                                            (long long)(who))
+#define __sanitizer_syscall_pre_compat_43_osend(s, buf, len, flags)            \
+  __sanitizer_syscall_pre_impl_compat_43_osend(                                \
+      (long long)(s), (long long)(buf), (long long)(len), (long long)(flags))
+#define __sanitizer_syscall_post_compat_43_osend(res, s, buf, len, flags)      \
+  __sanitizer_syscall_post_impl_compat_43_osend(                               \
+      res, (long long)(s), (long long)(buf), (long long)(len),                 \
+      (long long)(flags))
+#define __sanitizer_syscall_pre_compat_43_orecv(s, buf, len, flags)            \
+  __sanitizer_syscall_pre_impl_compat_43_orecv(                                \
+      (long long)(s), (long long)(buf), (long long)(len), (long long)(flags))
+#define __sanitizer_syscall_post_compat_43_orecv(res, s, buf, len, flags)      \
+  __sanitizer_syscall_post_impl_compat_43_orecv(                               \
+      res, (long long)(s), (long long)(buf), (long long)(len),                 \
+      (long long)(flags))
+#define __sanitizer_syscall_pre_compat_13_sigreturn13(sigcntxp)                \
+  __sanitizer_syscall_pre_impl_compat_13_sigreturn13((long long)(sigcntxp))
+#define __sanitizer_syscall_post_compat_13_sigreturn13(res, sigcntxp)          \
+  __sanitizer_syscall_post_impl_compat_13_sigreturn13(res,                     \
+                                                      (long long)(sigcntxp))
+#define __sanitizer_syscall_pre_bind(s, name, namelen)                         \
+  __sanitizer_syscall_pre_impl_bind((long long)(s), (long long)(name),         \
+                                    (long long)(namelen))
+#define __sanitizer_syscall_post_bind(res, s, name, namelen)                   \
+  __sanitizer_syscall_post_impl_bind(res, (long long)(s), (long long)(name),   \
+                                     (long long)(namelen))
+#define __sanitizer_syscall_pre_setsockopt(s, level, name, val, valsize)       \
+  __sanitizer_syscall_pre_impl_setsockopt((long long)(s), (long long)(level),  \
+                                          (long long)(name), (long long)(val), \
+                                          (long long)(valsize))
+#define __sanitizer_syscall_post_setsockopt(res, s, level, name, val, valsize) \
+  __sanitizer_syscall_post_impl_setsockopt(                                    \
+      res, (long long)(s), (long long)(level), (long long)(name),              \
+      (long long)(val), (long long)(valsize))
+#define __sanitizer_syscall_pre_listen(s, backlog)                             \
+  __sanitizer_syscall_pre_impl_listen((long long)(s), (long long)(backlog))
+#define __sanitizer_syscall_post_listen(res, s, backlog)                       \
+  __sanitizer_syscall_post_impl_listen(res, (long long)(s),                    \
+                                       (long long)(backlog))
+/* syscall 107 has been skipped */
+#define __sanitizer_syscall_pre_compat_43_osigvec(signum, nsv, osv)            \
+  __sanitizer_syscall_pre_impl_compat_43_osigvec(                              \
+      (long long)(signum), (long long)(nsv), (long long)(osv))
+#define __sanitizer_syscall_post_compat_43_osigvec(res, signum, nsv, osv)      \
+  __sanitizer_syscall_post_impl_compat_43_osigvec(                             \
+      res, (long long)(signum), (long long)(nsv), (long long)(osv))
+#define __sanitizer_syscall_pre_compat_43_osigblock(mask)                      \
+  __sanitizer_syscall_pre_impl_compat_43_osigblock((long long)(mask))
+#define __sanitizer_syscall_post_compat_43_osigblock(res, mask)                \
+  __sanitizer_syscall_post_impl_compat_43_osigblock(res, (long long)(mask))
+#define __sanitizer_syscall_pre_compat_43_osigsetmask(mask)                    \
+  __sanitizer_syscall_pre_impl_compat_43_osigsetmask((long long)(mask))
+#define __sanitizer_syscall_post_compat_43_osigsetmask(res, mask)              \
+  __sanitizer_syscall_post_impl_compat_43_osigsetmask(res, (long long)(mask))
+#define __sanitizer_syscall_pre_compat_13_sigsuspend13(mask)                   \
+  __sanitizer_syscall_pre_impl_compat_13_sigsuspend13((long long)(mask))
+#define __sanitizer_syscall_post_compat_13_sigsuspend13(res, mask)             \
+  __sanitizer_syscall_post_impl_compat_13_sigsuspend13(res, (long long)(mask))
+#define __sanitizer_syscall_pre_compat_43_osigstack(nss, oss)                  \
+  __sanitizer_syscall_pre_impl_compat_43_osigstack((long long)(nss),           \
+                                                   (long long)(oss))
+#define __sanitizer_syscall_post_compat_43_osigstack(res, nss, oss)            \
+  __sanitizer_syscall_post_impl_compat_43_osigstack(res, (long long)(nss),     \
+                                                    (long long)(oss))
+#define __sanitizer_syscall_pre_compat_43_orecvmsg(s, msg, flags)              \
+  __sanitizer_syscall_pre_impl_compat_43_orecvmsg(                             \
+      (long long)(s), (long long)(msg), (long long)(flags))
+#define __sanitizer_syscall_post_compat_43_orecvmsg(res, s, msg, flags)        \
+  __sanitizer_syscall_post_impl_compat_43_orecvmsg(                            \
+      res, (long long)(s), (long long)(msg), (long long)(flags))
+#define __sanitizer_syscall_pre_compat_43_osendmsg(s, msg, flags)              \
+  __sanitizer_syscall_pre_impl_compat_43_osendmsg(                             \
+      (long long)(s), (long long)(msg), (long long)(flags))
+#define __sanitizer_syscall_post_compat_43_osendmsg(res, s, msg, flags)        \
+  __sanitizer_syscall_post_impl_compat_43_osendmsg(                            \
+      res, (long long)(s), (long long)(msg), (long long)(flags))
+/* syscall 115 has been skipped */
+#define __sanitizer_syscall_pre_compat_50_gettimeofday(tp, tzp)                \
+  __sanitizer_syscall_pre_impl_compat_50_gettimeofday((long long)(tp),         \
+                                                      (long long)(tzp))
+#define __sanitizer_syscall_post_compat_50_gettimeofday(res, tp, tzp)          \
+  __sanitizer_syscall_post_impl_compat_50_gettimeofday(res, (long long)(tp),   \
+                                                       (long long)(tzp))
+#define __sanitizer_syscall_pre_compat_50_getrusage(who, rusage)               \
+  __sanitizer_syscall_pre_impl_compat_50_getrusage((long long)(who),           \
+                                                   (long long)(rusage))
+#define __sanitizer_syscall_post_compat_50_getrusage(res, who, rusage)         \
+  __sanitizer_syscall_post_impl_compat_50_getrusage(res, (long long)(who),     \
+                                                    (long long)(rusage))
+#define __sanitizer_syscall_pre_getsockopt(s, level, name, val, avalsize)      \
+  __sanitizer_syscall_pre_impl_getsockopt((long long)(s), (long long)(level),  \
+                                          (long long)(name), (long long)(val), \
+                                          (long long)(avalsize))
+#define __sanitizer_syscall_post_getsockopt(res, s, level, name, val,          \
+                                            avalsize)                          \
+  __sanitizer_syscall_post_impl_getsockopt(                                    \
+      res, (long long)(s), (long long)(level), (long long)(name),              \
+      (long long)(val), (long long)(avalsize))
+/* syscall 119 has been skipped */
+#define __sanitizer_syscall_pre_readv(fd, iovp, iovcnt)                        \
+  __sanitizer_syscall_pre_impl_readv((long long)(fd), (long long)(iovp),       \
+                                     (long long)(iovcnt))
+#define __sanitizer_syscall_post_readv(res, fd, iovp, iovcnt)                  \
+  __sanitizer_syscall_post_impl_readv(res, (long long)(fd), (long long)(iovp), \
+                                      (long long)(iovcnt))
+#define __sanitizer_syscall_pre_writev(fd, iovp, iovcnt)                       \
+  __sanitizer_syscall_pre_impl_writev((long long)(fd), (long long)(iovp),      \
+                                      (long long)(iovcnt))
+#define __sanitizer_syscall_post_writev(res, fd, iovp, iovcnt)                 \
+  __sanitizer_syscall_post_impl_writev(res, (long long)(fd),                   \
+                                       (long long)(iovp), (long long)(iovcnt))
+#define __sanitizer_syscall_pre_compat_50_settimeofday(tv, tzp)                \
+  __sanitizer_syscall_pre_impl_compat_50_settimeofday((long long)(tv),         \
+                                                      (long long)(tzp))
+#define __sanitizer_syscall_post_compat_50_settimeofday(res, tv, tzp)          \
+  __sanitizer_syscall_post_impl_compat_50_settimeofday(res, (long long)(tv),   \
+                                                       (long long)(tzp))
+#define __sanitizer_syscall_pre_fchown(fd, uid, gid)                           \
+  __sanitizer_syscall_pre_impl_fchown((long long)(fd), (long long)(uid),       \
+                                      (long long)(gid))
+#define __sanitizer_syscall_post_fchown(res, fd, uid, gid)                     \
+  __sanitizer_syscall_post_impl_fchown(res, (long long)(fd), (long long)(uid), \
+                                       (long long)(gid))
+#define __sanitizer_syscall_pre_fchmod(fd, mode)                               \
+  __sanitizer_syscall_pre_impl_fchmod((long long)(fd), (long long)(mode))
+#define __sanitizer_syscall_post_fchmod(res, fd, mode)                         \
+  __sanitizer_syscall_post_impl_fchmod(res, (long long)(fd), (long long)(mode))
+#define __sanitizer_syscall_pre_compat_43_orecvfrom(s, buf, len, flags, from,  \
+                                                    fromlenaddr)               \
+  __sanitizer_syscall_pre_impl_compat_43_orecvfrom(                            \
+      (long long)(s), (long long)(buf), (long long)(len), (long long)(flags),  \
+      (long long)(from), (long long)(fromlenaddr))
+#define __sanitizer_syscall_post_compat_43_orecvfrom(res, s, buf, len, flags,  \
+                                                     from, fromlenaddr)        \
+  __sanitizer_syscall_post_impl_compat_43_orecvfrom(                           \
+      res, (long long)(s), (long long)(buf), (long long)(len),                 \
+      (long long)(flags), (long long)(from), (long long)(fromlenaddr))
+#define __sanitizer_syscall_pre_setreuid(ruid, euid)                           \
+  __sanitizer_syscall_pre_impl_setreuid((long long)(ruid), (long long)(euid))
+#define __sanitizer_syscall_post_setreuid(res, ruid, euid)                     \
+  __sanitizer_syscall_post_impl_setreuid(res, (long long)(ruid),               \
+                                         (long long)(euid))
+#define __sanitizer_syscall_pre_setregid(rgid, egid)                           \
+  __sanitizer_syscall_pre_impl_setregid((long long)(rgid), (long long)(egid))
+#define __sanitizer_syscall_post_setregid(res, rgid, egid)                     \
+  __sanitizer_syscall_post_impl_setregid(res, (long long)(rgid),               \
+                                         (long long)(egid))
+#define __sanitizer_syscall_pre_rename(from, to)                               \
+  __sanitizer_syscall_pre_impl_rename((long long)(from), (long long)(to))
+#define __sanitizer_syscall_post_rename(res, from, to)                         \
+  __sanitizer_syscall_post_impl_rename(res, (long long)(from), (long long)(to))
+#define __sanitizer_syscall_pre_compat_43_otruncate(path, length)              \
+  __sanitizer_syscall_pre_impl_compat_43_otruncate((long long)(path),          \
+                                                   (long long)(length))
+#define __sanitizer_syscall_post_compat_43_otruncate(res, path, length)        \
+  __sanitizer_syscall_post_impl_compat_43_otruncate(res, (long long)(path),    \
+                                                    (long long)(length))
+#define __sanitizer_syscall_pre_compat_43_oftruncate(fd, length)               \
+  __sanitizer_syscall_pre_impl_compat_43_oftruncate((long long)(fd),           \
+                                                    (long long)(length))
+#define __sanitizer_syscall_post_compat_43_oftruncate(res, fd, length)         \
+  __sanitizer_syscall_post_impl_compat_43_oftruncate(res, (long long)(fd),     \
+                                                     (long long)(length))
+#define __sanitizer_syscall_pre_flock(fd, how)                                 \
+  __sanitizer_syscall_pre_impl_flock((long long)(fd), (long long)(how))
+#define __sanitizer_syscall_post_flock(res, fd, how)                           \
+  __sanitizer_syscall_post_impl_flock(res, (long long)(fd), (long long)(how))
+#define __sanitizer_syscall_pre_mkfifo(path, mode)                             \
+  __sanitizer_syscall_pre_impl_mkfifo((long long)(path), (long long)(mode))
+#define __sanitizer_syscall_post_mkfifo(res, path, mode)                       \
+  __sanitizer_syscall_post_impl_mkfifo(res, (long long)(path),                 \
+                                       (long long)(mode))
+#define __sanitizer_syscall_pre_sendto(s, buf, len, flags, to, tolen)          \
+  __sanitizer_syscall_pre_impl_sendto((long long)(s), (long long)(buf),        \
+                                      (long long)(len), (long long)(flags),    \
+                                      (long long)(to), (long long)(tolen))
+#define __sanitizer_syscall_post_sendto(res, s, buf, len, flags, to, tolen)    \
+  __sanitizer_syscall_post_impl_sendto(res, (long long)(s), (long long)(buf),  \
+                                       (long long)(len), (long long)(flags),   \
+                                       (long long)(to), (long long)(tolen))
+#define __sanitizer_syscall_pre_shutdown(s, how)                               \
+  __sanitizer_syscall_pre_impl_shutdown((long long)(s), (long long)(how))
+#define __sanitizer_syscall_post_shutdown(res, s, how)                         \
+  __sanitizer_syscall_post_impl_shutdown(res, (long long)(s), (long long)(how))
+#define __sanitizer_syscall_pre_socketpair(domain, type, protocol, rsv)        \
+  __sanitizer_syscall_pre_impl_socketpair(                                     \
+      (long long)(domain), (long long)(type), (long long)(protocol),           \
+      (long long)(rsv))
+#define __sanitizer_syscall_post_socketpair(res, domain, type, protocol, rsv)  \
+  __sanitizer_syscall_post_impl_socketpair(                                    \
+      res, (long long)(domain), (long long)(type), (long long)(protocol),      \
+      (long long)(rsv))
+#define __sanitizer_syscall_pre_mkdir(path, mode)                              \
+  __sanitizer_syscall_pre_impl_mkdir((long long)(path), (long long)(mode))
+#define __sanitizer_syscall_post_mkdir(res, path, mode)                        \
+  __sanitizer_syscall_post_impl_mkdir(res, (long long)(path), (long long)(mode))
+#define __sanitizer_syscall_pre_rmdir(path)                                    \
+  __sanitizer_syscall_pre_impl_rmdir((long long)(path))
+#define __sanitizer_syscall_post_rmdir(res, path)                              \
+  __sanitizer_syscall_post_impl_rmdir(res, (long long)(path))
+#define __sanitizer_syscall_pre_compat_50_utimes(path, tptr)                   \
+  __sanitizer_syscall_pre_impl_compat_50_utimes((long long)(path),             \
+                                                (long long)(tptr))
+#define __sanitizer_syscall_post_compat_50_utimes(res, path, tptr)             \
+  __sanitizer_syscall_post_impl_compat_50_utimes(res, (long long)(path),       \
+                                                 (long long)(tptr))
+/* syscall 139 has been skipped */
+#define __sanitizer_syscall_pre_compat_50_adjtime(delta, olddelta)             \
+  __sanitizer_syscall_pre_impl_compat_50_adjtime((long long)(delta),           \
+                                                 (long long)(olddelta))
+#define __sanitizer_syscall_post_compat_50_adjtime(res, delta, olddelta)       \
+  __sanitizer_syscall_post_impl_compat_50_adjtime(res, (long long)(delta),     \
+                                                  (long long)(olddelta))
+#define __sanitizer_syscall_pre_compat_43_ogetpeername(fdes, asa, alen)        \
+  __sanitizer_syscall_pre_impl_compat_43_ogetpeername(                         \
+      (long long)(fdes), (long long)(asa), (long long)(alen))
+#define __sanitizer_syscall_post_compat_43_ogetpeername(res, fdes, asa, alen)  \
+  __sanitizer_syscall_post_impl_compat_43_ogetpeername(                        \
+      res, (long long)(fdes), (long long)(asa), (long long)(alen))
+#define __sanitizer_syscall_pre_compat_43_ogethostid()                         \
+  __sanitizer_syscall_pre_impl_compat_43_ogethostid()
+#define __sanitizer_syscall_post_compat_43_ogethostid(res)                     \
+  __sanitizer_syscall_post_impl_compat_43_ogethostid(res)
+#define __sanitizer_syscall_pre_compat_43_osethostid(hostid)                   \
+  __sanitizer_syscall_pre_impl_compat_43_osethostid((long long)(hostid))
+#define __sanitizer_syscall_post_compat_43_osethostid(res, hostid)             \
+  __sanitizer_syscall_post_impl_compat_43_osethostid(res, (long long)(hostid))
+#define __sanitizer_syscall_pre_compat_43_ogetrlimit(which, rlp)               \
+  __sanitizer_syscall_pre_impl_compat_43_ogetrlimit((long long)(which),        \
+                                                    (long long)(rlp))
+#define __sanitizer_syscall_post_compat_43_ogetrlimit(res, which, rlp)         \
+  __sanitizer_syscall_post_impl_compat_43_ogetrlimit(res, (long long)(which),  \
+                                                     (long long)(rlp))
+#define __sanitizer_syscall_pre_compat_43_osetrlimit(which, rlp)               \
+  __sanitizer_syscall_pre_impl_compat_43_osetrlimit((long long)(which),        \
+                                                    (long long)(rlp))
+#define __sanitizer_syscall_post_compat_43_osetrlimit(res, which, rlp)         \
+  __sanitizer_syscall_post_impl_compat_43_osetrlimit(res, (long long)(which),  \
+                                                     (long long)(rlp))
+#define __sanitizer_syscall_pre_compat_43_okillpg(pgid, signum)                \
+  __sanitizer_syscall_pre_impl_compat_43_okillpg((long long)(pgid),            \
+                                                 (long long)(signum))
+#define __sanitizer_syscall_post_compat_43_okillpg(res, pgid, signum)          \
+  __sanitizer_syscall_post_impl_compat_43_okillpg(res, (long long)(pgid),      \
+                                                  (long long)(signum))
+#define __sanitizer_syscall_pre_setsid() __sanitizer_syscall_pre_impl_setsid()
+#define __sanitizer_syscall_post_setsid(res)                                   \
+  __sanitizer_syscall_post_impl_setsid(res)
+#define __sanitizer_syscall_pre_compat_50_quotactl(path, cmd, uid, arg)        \
+  __sanitizer_syscall_pre_impl_compat_50_quotactl(                             \
+      (long long)(path), (long long)(cmd), (long long)(uid), (long long)(arg))
+#define __sanitizer_syscall_post_compat_50_quotactl(res, path, cmd, uid, arg)  \
+  __sanitizer_syscall_post_impl_compat_50_quotactl(                            \
+      res, (long long)(path), (long long)(cmd), (long long)(uid),              \
+      (long long)(arg))
+#define __sanitizer_syscall_pre_compat_43_oquota()                             \
+  __sanitizer_syscall_pre_impl_compat_43_oquota()
+#define __sanitizer_syscall_post_compat_43_oquota(res)                         \
+  __sanitizer_syscall_post_impl_compat_43_oquota(res)
+#define __sanitizer_syscall_pre_compat_43_ogetsockname(fdec, asa, alen)        \
+  __sanitizer_syscall_pre_impl_compat_43_ogetsockname(                         \
+      (long long)(fdec), (long long)(asa), (long long)(alen))
+#define __sanitizer_syscall_post_compat_43_ogetsockname(res, fdec, asa, alen)  \
+  __sanitizer_syscall_post_impl_compat_43_ogetsockname(                        \
+      res, (long long)(fdec), (long long)(asa), (long long)(alen))
+/* syscall 151 has been skipped */
+/* syscall 152 has been skipped */
+/* syscall 153 has been skipped */
+/* syscall 154 has been skipped */
+#define __sanitizer_syscall_pre_nfssvc(flag, argp)                             \
+  __sanitizer_syscall_pre_impl_nfssvc((long long)(flag), (long long)(argp))
+#define __sanitizer_syscall_post_nfssvc(res, flag, argp)                       \
+  __sanitizer_syscall_post_impl_nfssvc(res, (long long)(flag),                 \
+                                       (long long)(argp))
+#define __sanitizer_syscall_pre_compat_43_ogetdirentries(fd, buf, count,       \
+                                                         basep)                \
+  __sanitizer_syscall_pre_impl_compat_43_ogetdirentries(                       \
+      (long long)(fd), (long long)(buf), (long long)(count),                   \
+      (long long)(basep))
+#define __sanitizer_syscall_post_compat_43_ogetdirentries(res, fd, buf, count, \
+                                                          basep)               \
+  __sanitizer_syscall_post_impl_compat_43_ogetdirentries(                      \
+      res, (long long)(fd), (long long)(buf), (long long)(count),              \
+      (long long)(basep))
+#define __sanitizer_syscall_pre_compat_20_statfs(path, buf)                    \
+  __sanitizer_syscall_pre_impl_compat_20_statfs((long long)(path),             \
+                                                (long long)(buf))
+#define __sanitizer_syscall_post_compat_20_statfs(res, path, buf)              \
+  __sanitizer_syscall_post_impl_compat_20_statfs(res, (long long)(path),       \
+                                                 (long long)(buf))
+#define __sanitizer_syscall_pre_compat_20_fstatfs(fd, buf)                     \
+  __sanitizer_syscall_pre_impl_compat_20_fstatfs((long long)(fd),              \
+                                                 (long long)(buf))
+#define __sanitizer_syscall_post_compat_20_fstatfs(res, fd, buf)               \
+  __sanitizer_syscall_post_impl_compat_20_fstatfs(res, (long long)(fd),        \
+                                                  (long long)(buf))
+/* syscall 159 has been skipped */
+/* syscall 160 has been skipped */
+#define __sanitizer_syscall_pre_compat_30_getfh(fname, fhp)                    \
+  __sanitizer_syscall_pre_impl_compat_30_getfh((long long)(fname),             \
+                                               (long long)(fhp))
+#define __sanitizer_syscall_post_compat_30_getfh(res, fname, fhp)              \
+  __sanitizer_syscall_post_impl_compat_30_getfh(res, (long long)(fname),       \
+                                                (long long)(fhp))
+#define __sanitizer_syscall_pre_compat_09_ogetdomainname(domainname, len)      \
+  __sanitizer_syscall_pre_impl_compat_09_ogetdomainname(                       \
+      (long long)(domainname), (long long)(len))
+#define __sanitizer_syscall_post_compat_09_ogetdomainname(res, domainname,     \
+                                                          len)                 \
+  __sanitizer_syscall_post_impl_compat_09_ogetdomainname(                      \
+      res, (long long)(domainname), (long long)(len))
+#define __sanitizer_syscall_pre_compat_09_osetdomainname(domainname, len)      \
+  __sanitizer_syscall_pre_impl_compat_09_osetdomainname(                       \
+      (long long)(domainname), (long long)(len))
+#define __sanitizer_syscall_post_compat_09_osetdomainname(res, domainname,     \
+                                                          len)                 \
+  __sanitizer_syscall_post_impl_compat_09_osetdomainname(                      \
+      res, (long long)(domainname), (long long)(len))
+#define __sanitizer_syscall_pre_compat_09_ouname(name)                         \
+  __sanitizer_syscall_pre_impl_compat_09_ouname((long long)(name))
+#define __sanitizer_syscall_post_compat_09_ouname(res, name)                   \
+  __sanitizer_syscall_post_impl_compat_09_ouname(res, (long long)(name))
+#define __sanitizer_syscall_pre_sysarch(op, parms)                             \
+  __sanitizer_syscall_pre_impl_sysarch((long long)(op), (long long)(parms))
+#define __sanitizer_syscall_post_sysarch(res, op, parms)                       \
+  __sanitizer_syscall_post_impl_sysarch(res, (long long)(op),                  \
+                                        (long long)(parms))
+/* syscall 166 has been skipped */
+/* syscall 167 has been skipped */
+/* syscall 168 has been skipped */
+#if !defined(_LP64)
+#define __sanitizer_syscall_pre_compat_10_osemsys(which, a2, a3, a4, a5)       \
+  __sanitizer_syscall_pre_impl_compat_10_osemsys(                              \
+      (long long)(which), (long long)(a2), (long long)(a3), (long long)(a4),   \
+      (long long)(a5))
+#define __sanitizer_syscall_post_compat_10_osemsys(res, which, a2, a3, a4, a5) \
+  __sanitizer_syscall_post_impl_compat_10_osemsys(                             \
+      res, (long long)(which), (long long)(a2), (long long)(a3),               \
+      (long long)(a4), (long long)(a5))
+#else
+/* syscall 169 has been skipped */
+#endif
+#if !defined(_LP64)
+#define __sanitizer_syscall_pre_compat_10_omsgsys(which, a2, a3, a4, a5, a6)   \
+  __sanitizer_syscall_pre_impl_compat_10_omsgsys(                              \
+      (long long)(which), (long long)(a2), (long long)(a3), (long long)(a4),   \
+      (long long)(a5), (long long)(a6))
+#define __sanitizer_syscall_post_compat_10_omsgsys(res, which, a2, a3, a4, a5, \
+                                                   a6)                         \
+  __sanitizer_syscall_post_impl_compat_10_omsgsys(                             \
+      res, (long long)(which), (long long)(a2), (long long)(a3),               \
+      (long long)(a4), (long long)(a5), (long long)(a6))
+#else
+/* syscall 170 has been skipped */
+#endif
+#if !defined(_LP64)
+#define __sanitizer_syscall_pre_compat_10_oshmsys(which, a2, a3, a4)           \
+  __sanitizer_syscall_pre_impl_compat_10_oshmsys(                              \
+      (long long)(which), (long long)(a2), (long long)(a3), (long long)(a4))
+#define __sanitizer_syscall_post_compat_10_oshmsys(res, which, a2, a3, a4)     \
+  __sanitizer_syscall_post_impl_compat_10_oshmsys(                             \
+      res, (long long)(which), (long long)(a2), (long long)(a3),               \
+      (long long)(a4))
+#else
+/* syscall 171 has been skipped */
+#endif
+/* syscall 172 has been skipped */
+#define __sanitizer_syscall_pre_pread(fd, buf, nbyte, PAD, offset)             \
+  __sanitizer_syscall_pre_impl_pread((long long)(fd), (long long)(buf),        \
+                                     (long long)(nbyte), (long long)(PAD),     \
+                                     (long long)(offset))
+#define __sanitizer_syscall_post_pread(res, fd, buf, nbyte, PAD, offset)       \
+  __sanitizer_syscall_post_impl_pread(res, (long long)(fd), (long long)(buf),  \
+                                      (long long)(nbyte), (long long)(PAD),    \
+                                      (long long)(offset))
+#define __sanitizer_syscall_pre_pwrite(fd, buf, nbyte, PAD, offset)            \
+  __sanitizer_syscall_pre_impl_pwrite((long long)(fd), (long long)(buf),       \
+                                      (long long)(nbyte), (long long)(PAD),    \
+                                      (long long)(offset))
+#define __sanitizer_syscall_post_pwrite(res, fd, buf, nbyte, PAD, offset)      \
+  __sanitizer_syscall_post_impl_pwrite(res, (long long)(fd), (long long)(buf), \
+                                       (long long)(nbyte), (long long)(PAD),   \
+                                       (long long)(offset))
+#define __sanitizer_syscall_pre_compat_30_ntp_gettime(ntvp)                    \
+  __sanitizer_syscall_pre_impl_compat_30_ntp_gettime((long long)(ntvp))
+#define __sanitizer_syscall_post_compat_30_ntp_gettime(res, ntvp)              \
+  __sanitizer_syscall_post_impl_compat_30_ntp_gettime(res, (long long)(ntvp))
+#if defined(NTP) || !defined(_KERNEL_OPT)
+#define __sanitizer_syscall_pre_ntp_adjtime(tp)                                \
+  __sanitizer_syscall_pre_impl_ntp_adjtime((long long)(tp))
+#define __sanitizer_syscall_post_ntp_adjtime(res, tp)                          \
+  __sanitizer_syscall_post_impl_ntp_adjtime(res, (long long)(tp))
+#else
+/* syscall 176 has been skipped */
+#endif
+/* syscall 177 has been skipped */
+/* syscall 178 has been skipped */
+/* syscall 179 has been skipped */
+/* syscall 180 has been skipped */
+#define __sanitizer_syscall_pre_setgid(gid)                                    \
+  __sanitizer_syscall_pre_impl_setgid((long long)(gid))
+#define __sanitizer_syscall_post_setgid(res, gid)                              \
+  __sanitizer_syscall_post_impl_setgid(res, (long long)(gid))
+#define __sanitizer_syscall_pre_setegid(egid)                                  \
+  __sanitizer_syscall_pre_impl_setegid((long long)(egid))
+#define __sanitizer_syscall_post_setegid(res, egid)                            \
+  __sanitizer_syscall_post_impl_setegid(res, (long long)(egid))
+#define __sanitizer_syscall_pre_seteuid(euid)                                  \
+  __sanitizer_syscall_pre_impl_seteuid((long long)(euid))
+#define __sanitizer_syscall_post_seteuid(res, euid)                            \
+  __sanitizer_syscall_post_impl_seteuid(res, (long long)(euid))
+#define __sanitizer_syscall_pre_lfs_bmapv(fsidp, blkiov, blkcnt)               \
+  __sanitizer_syscall_pre_impl_lfs_bmapv(                                      \
+      (long long)(fsidp), (long long)(blkiov), (long long)(blkcnt))
+#define __sanitizer_syscall_post_lfs_bmapv(res, fsidp, blkiov, blkcnt)         \
+  __sanitizer_syscall_post_impl_lfs_bmapv(                                     \
+      res, (long long)(fsidp), (long long)(blkiov), (long long)(blkcnt))
+#define __sanitizer_syscall_pre_lfs_markv(fsidp, blkiov, blkcnt)               \
+  __sanitizer_syscall_pre_impl_lfs_markv(                                      \
+      (long long)(fsidp), (long long)(blkiov), (long long)(blkcnt))
+#define __sanitizer_syscall_post_lfs_markv(res, fsidp, blkiov, blkcnt)         \
+  __sanitizer_syscall_post_impl_lfs_markv(                                     \
+      res, (long long)(fsidp), (long long)(blkiov), (long long)(blkcnt))
+#define __sanitizer_syscall_pre_lfs_segclean(fsidp, segment)                   \
+  __sanitizer_syscall_pre_impl_lfs_segclean((long long)(fsidp),                \
+                                            (long long)(segment))
+#define __sanitizer_syscall_post_lfs_segclean(res, fsidp, segment)             \
+  __sanitizer_syscall_post_impl_lfs_segclean(res, (long long)(fsidp),          \
+                                             (long long)(segment))
+#define __sanitizer_syscall_pre_compat_50_lfs_segwait(fsidp, tv)               \
+  __sanitizer_syscall_pre_impl_compat_50_lfs_segwait((long long)(fsidp),       \
+                                                     (long long)(tv))
+#define __sanitizer_syscall_post_compat_50_lfs_segwait(res, fsidp, tv)         \
+  __sanitizer_syscall_post_impl_compat_50_lfs_segwait(res, (long long)(fsidp), \
+                                                      (long long)(tv))
+#define __sanitizer_syscall_pre_compat_12_stat12(path, ub)                     \
+  __sanitizer_syscall_pre_impl_compat_12_stat12((long long)(path),             \
+                                                (long long)(ub))
+#define __sanitizer_syscall_post_compat_12_stat12(res, path, ub)               \
+  __sanitizer_syscall_post_impl_compat_12_stat12(res, (long long)(path),       \
+                                                 (long long)(ub))
+#define __sanitizer_syscall_pre_compat_12_fstat12(fd, sb)                      \
+  __sanitizer_syscall_pre_impl_compat_12_fstat12((long long)(fd),              \
+                                                 (long long)(sb))
+#define __sanitizer_syscall_post_compat_12_fstat12(res, fd, sb)                \
+  __sanitizer_syscall_post_impl_compat_12_fstat12(res, (long long)(fd),        \
+                                                  (long long)(sb))
+#define __sanitizer_syscall_pre_compat_12_lstat12(path, ub)                    \
+  __sanitizer_syscall_pre_impl_compat_12_lstat12((long long)(path),            \
+                                                 (long long)(ub))
+#define __sanitizer_syscall_post_compat_12_lstat12(res, path, ub)              \
+  __sanitizer_syscall_post_impl_compat_12_lstat12(res, (long long)(path),      \
+                                                  (long long)(ub))
+#define __sanitizer_syscall_pre_pathconf(path, name)                           \
+  __sanitizer_syscall_pre_impl_pathconf((long long)(path), (long long)(name))
+#define __sanitizer_syscall_post_pathconf(res, path, name)                     \
+  __sanitizer_syscall_post_impl_pathconf(res, (long long)(path),               \
+                                         (long long)(name))
+#define __sanitizer_syscall_pre_fpathconf(fd, name)                            \
+  __sanitizer_syscall_pre_impl_fpathconf((long long)(fd), (long long)(name))
+#define __sanitizer_syscall_post_fpathconf(res, fd, name)                      \
+  __sanitizer_syscall_post_impl_fpathconf(res, (long long)(fd),                \
+                                          (long long)(name))
+#define __sanitizer_syscall_pre_getsockopt2(s, level, name, val, avalsize)     \
+  __sanitizer_syscall_pre_impl_getsockopt2(                                    \
+      (long long)(s), (long long)(level), (long long)(name), (long long)(val), \
+      (long long)(avalsize))
+#define __sanitizer_syscall_post_getsockopt2(res, s, level, name, val,         \
+                                             avalsize)                         \
+  __sanitizer_syscall_post_impl_getsockopt2(                                   \
+      res, (long long)(s), (long long)(level), (long long)(name),              \
+      (long long)(val), (long long)(avalsize))
+#define __sanitizer_syscall_pre_getrlimit(which, rlp)                          \
+  __sanitizer_syscall_pre_impl_getrlimit((long long)(which), (long long)(rlp))
+#define __sanitizer_syscall_post_getrlimit(res, which, rlp)                    \
+  __sanitizer_syscall_post_impl_getrlimit(res, (long long)(which),             \
+                                          (long long)(rlp))
+#define __sanitizer_syscall_pre_setrlimit(which, rlp)                          \
+  __sanitizer_syscall_pre_impl_setrlimit((long long)(which), (long long)(rlp))
+#define __sanitizer_syscall_post_setrlimit(res, which, rlp)                    \
+  __sanitizer_syscall_post_impl_setrlimit(res, (long long)(which),             \
+                                          (long long)(rlp))
+#define __sanitizer_syscall_pre_compat_12_getdirentries(fd, buf, count, basep) \
+  __sanitizer_syscall_pre_impl_compat_12_getdirentries(                        \
+      (long long)(fd), (long long)(buf), (long long)(count),                   \
+      (long long)(basep))
+#define __sanitizer_syscall_post_compat_12_getdirentries(res, fd, buf, count,  \
+                                                         basep)                \
+  __sanitizer_syscall_post_impl_compat_12_getdirentries(                       \
+      res, (long long)(fd), (long long)(buf), (long long)(count),              \
+      (long long)(basep))
+#define __sanitizer_syscall_pre_mmap(addr, len, prot, flags, fd, PAD, pos)     \
+  __sanitizer_syscall_pre_impl_mmap(                                           \
+      (long long)(addr), (long long)(len), (long long)(prot),                  \
+      (long long)(flags), (long long)(fd), (long long)(PAD), (long long)(pos))
+#define __sanitizer_syscall_post_mmap(res, addr, len, prot, flags, fd, PAD,    \
+                                      pos)                                     \
+  __sanitizer_syscall_post_impl_mmap(                                          \
+      res, (long long)(addr), (long long)(len), (long long)(prot),             \
+      (long long)(flags), (long long)(fd), (long long)(PAD), (long long)(pos))
+#define __sanitizer_syscall_pre___syscall(code, arg0, arg1, arg2, arg3, arg4,  \
+                                          arg5, arg6, arg7)                    \
+  __sanitizer_syscall_pre_impl___syscall(                                      \
+      (long long)(code), (long long)(arg0), (long long)(arg1),                 \
+      (long long)(arg2), (long long)(arg3), (long long)(arg4),                 \
+      (long long)(arg5), (long long)(arg6), (long long)(arg7))
+#define __sanitizer_syscall_post___syscall(res, code, arg0, arg1, arg2, arg3,  \
+                                           arg4, arg5, arg6, arg7)             \
+  __sanitizer_syscall_post_impl___syscall(                                     \
+      res, (long long)(code), (long long)(arg0), (long long)(arg1),            \
+      (long long)(arg2), (long long)(arg3), (long long)(arg4),                 \
+      (long long)(arg5), (long long)(arg6), (long long)(arg7))
+#define __sanitizer_syscall_pre_lseek(fd, PAD, offset, whence)                 \
+  __sanitizer_syscall_pre_impl_lseek((long long)(fd), (long long)(PAD),        \
+                                     (long long)(offset), (long long)(whence))
+#define __sanitizer_syscall_post_lseek(res, fd, PAD, offset, whence)           \
+  __sanitizer_syscall_post_impl_lseek(res, (long long)(fd), (long long)(PAD),  \
+                                      (long long)(offset),                     \
+                                      (long long)(whence))
+#define __sanitizer_syscall_pre_truncate(path, PAD, length)                    \
+  __sanitizer_syscall_pre_impl_truncate((long long)(path), (long long)(PAD),   \
+                                        (long long)(length))
+#define __sanitizer_syscall_post_truncate(res, path, PAD, length)              \
+  __sanitizer_syscall_post_impl_truncate(                                      \
+      res, (long long)(path), (long long)(PAD), (long long)(length))
+#define __sanitizer_syscall_pre_ftruncate(fd, PAD, length)                     \
+  __sanitizer_syscall_pre_impl_ftruncate((long long)(fd), (long long)(PAD),    \
+                                         (long long)(length))
+#define __sanitizer_syscall_post_ftruncate(res, fd, PAD, length)               \
+  __sanitizer_syscall_post_impl_ftruncate(                                     \
+      res, (long long)(fd), (long long)(PAD), (long long)(length))
+#define __sanitizer_syscall_pre___sysctl(name, namelen, oldv, oldlenp, newv,   \
+                                         newlen)                               \
+  __sanitizer_syscall_pre_impl___sysctl(                                       \
+      (long long)(name), (long long)(namelen), (long long)(oldv),              \
+      (long long)(oldlenp), (long long)(newv), (long long)(newlen))
+#define __sanitizer_syscall_post___sysctl(res, name, namelen, oldv, oldlenp,   \
+                                          newv, newlen)                        \
+  __sanitizer_syscall_post_impl___sysctl(                                      \
+      res, (long long)(name), (long long)(namelen), (long long)(oldv),         \
+      (long long)(oldlenp), (long long)(newv), (long long)(newlen))
+#define __sanitizer_syscall_pre_mlock(addr, len)                               \
+  __sanitizer_syscall_pre_impl_mlock((long long)(addr), (long long)(len))
+#define __sanitizer_syscall_post_mlock(res, addr, len)                         \
+  __sanitizer_syscall_post_impl_mlock(res, (long long)(addr), (long long)(len))
+#define __sanitizer_syscall_pre_munlock(addr, len)                             \
+  __sanitizer_syscall_pre_impl_munlock((long long)(addr), (long long)(len))
+#define __sanitizer_syscall_post_munlock(res, addr, len)                       \
+  __sanitizer_syscall_post_impl_munlock(res, (long long)(addr),                \
+                                        (long long)(len))
+#define __sanitizer_syscall_pre_undelete(path)                                 \
+  __sanitizer_syscall_pre_impl_undelete((long long)(path))
+#define __sanitizer_syscall_post_undelete(res, path)                           \
+  __sanitizer_syscall_post_impl_undelete(res, (long long)(path))
+#define __sanitizer_syscall_pre_compat_50_futimes(fd, tptr)                    \
+  __sanitizer_syscall_pre_impl_compat_50_futimes((long long)(fd),              \
+                                                 (long long)(tptr))
+#define __sanitizer_syscall_post_compat_50_futimes(res, fd, tptr)              \
+  __sanitizer_syscall_post_impl_compat_50_futimes(res, (long long)(fd),        \
+                                                  (long long)(tptr))
+#define __sanitizer_syscall_pre_getpgid(pid)                                   \
+  __sanitizer_syscall_pre_impl_getpgid((long long)(pid))
+#define __sanitizer_syscall_post_getpgid(res, pid)                             \
+  __sanitizer_syscall_post_impl_getpgid(res, (long long)(pid))
+#define __sanitizer_syscall_pre_reboot(opt, bootstr)                           \
+  __sanitizer_syscall_pre_impl_reboot((long long)(opt), (long long)(bootstr))
+#define __sanitizer_syscall_post_reboot(res, opt, bootstr)                     \
+  __sanitizer_syscall_post_impl_reboot(res, (long long)(opt),                  \
+                                       (long long)(bootstr))
+#define __sanitizer_syscall_pre_poll(fds, nfds, timeout)                       \
+  __sanitizer_syscall_pre_impl_poll((long long)(fds), (long long)(nfds),       \
+                                    (long long)(timeout))
+#define __sanitizer_syscall_post_poll(res, fds, nfds, timeout)                 \
+  __sanitizer_syscall_post_impl_poll(res, (long long)(fds), (long long)(nfds), \
+                                     (long long)(timeout))
+#define __sanitizer_syscall_pre_afssys(id, a1, a2, a3, a4, a5, a6)             \
+  __sanitizer_syscall_pre_impl_afssys(                                         \
+      (long long)(id), (long long)(a1), (long long)(a2), (long long)(a3),      \
+      (long long)(a4), (long long)(a5), (long long)(a6))
+#define __sanitizer_syscall_post_afssys(res, id, a1, a2, a3, a4, a5, a6)       \
+  __sanitizer_syscall_post_impl_afssys(                                        \
+      res, (long long)(id), (long long)(a1), (long long)(a2), (long long)(a3), \
+      (long long)(a4), (long long)(a5), (long long)(a6))
+/* syscall 211 has been skipped */
+/* syscall 212 has been skipped */
+/* syscall 213 has been skipped */
+/* syscall 214 has been skipped */
+/* syscall 215 has been skipped */
+/* syscall 216 has been skipped */
+/* syscall 217 has been skipped */
+/* syscall 218 has been skipped */
+/* syscall 219 has been skipped */
+#define __sanitizer_syscall_pre_compat_14___semctl(semid, semnum, cmd, arg)    \
+  __sanitizer_syscall_pre_impl_compat_14___semctl(                             \
+      (long long)(semid), (long long)(semnum), (long long)(cmd),               \
+      (long long)(arg))
+#define __sanitizer_syscall_post_compat_14___semctl(res, semid, semnum, cmd,   \
+                                                    arg)                       \
+  __sanitizer_syscall_post_impl_compat_14___semctl(                            \
+      res, (long long)(semid), (long long)(semnum), (long long)(cmd),          \
+      (long long)(arg))
+#define __sanitizer_syscall_pre_semget(key, nsems, semflg)                     \
+  __sanitizer_syscall_pre_impl_semget((long long)(key), (long long)(nsems),    \
+                                      (long long)(semflg))
+#define __sanitizer_syscall_post_semget(res, key, nsems, semflg)               \
+  __sanitizer_syscall_post_impl_semget(                                        \
+      res, (long long)(key), (long long)(nsems), (long long)(semflg))
+#define __sanitizer_syscall_pre_semop(semid, sops, nsops)                      \
+  __sanitizer_syscall_pre_impl_semop((long long)(semid), (long long)(sops),    \
+                                     (long long)(nsops))
+#define __sanitizer_syscall_post_semop(res, semid, sops, nsops)                \
+  __sanitizer_syscall_post_impl_semop(res, (long long)(semid),                 \
+                                      (long long)(sops), (long long)(nsops))
+#define __sanitizer_syscall_pre_semconfig(flag)                                \
+  __sanitizer_syscall_pre_impl_semconfig((long long)(flag))
+#define __sanitizer_syscall_post_semconfig(res, flag)                          \
+  __sanitizer_syscall_post_impl_semconfig(res, (long long)(flag))
+#define __sanitizer_syscall_pre_compat_14_msgctl(msqid, cmd, buf)              \
+  __sanitizer_syscall_pre_impl_compat_14_msgctl(                               \
+      (long long)(msqid), (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_post_compat_14_msgctl(res, msqid, cmd, buf)        \
+  __sanitizer_syscall_post_impl_compat_14_msgctl(                              \
+      res, (long long)(msqid), (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_pre_msgget(key, msgflg)                            \
+  __sanitizer_syscall_pre_impl_msgget((long long)(key), (long long)(msgflg))
+#define __sanitizer_syscall_post_msgget(res, key, msgflg)                      \
+  __sanitizer_syscall_post_impl_msgget(res, (long long)(key),                  \
+                                       (long long)(msgflg))
+#define __sanitizer_syscall_pre_msgsnd(msqid, msgp, msgsz, msgflg)             \
+  __sanitizer_syscall_pre_impl_msgsnd((long long)(msqid), (long long)(msgp),   \
+                                      (long long)(msgsz), (long long)(msgflg))
+#define __sanitizer_syscall_post_msgsnd(res, msqid, msgp, msgsz, msgflg)       \
+  __sanitizer_syscall_post_impl_msgsnd(res, (long long)(msqid),                \
+                                       (long long)(msgp), (long long)(msgsz),  \
+                                       (long long)(msgflg))
+#define __sanitizer_syscall_pre_msgrcv(msqid, msgp, msgsz, msgtyp, msgflg)     \
+  __sanitizer_syscall_pre_impl_msgrcv((long long)(msqid), (long long)(msgp),   \
+                                      (long long)(msgsz), (long long)(msgtyp), \
+                                      (long long)(msgflg))
+#define __sanitizer_syscall_post_msgrcv(res, msqid, msgp, msgsz, msgtyp,       \
+                                        msgflg)                                \
+  __sanitizer_syscall_post_impl_msgrcv(                                        \
+      res, (long long)(msqid), (long long)(msgp), (long long)(msgsz),          \
+      (long long)(msgtyp), (long long)(msgflg))
+#define __sanitizer_syscall_pre_shmat(shmid, shmaddr, shmflg)                  \
+  __sanitizer_syscall_pre_impl_shmat((long long)(shmid), (long long)(shmaddr), \
+                                     (long long)(shmflg))
+#define __sanitizer_syscall_post_shmat(res, shmid, shmaddr, shmflg)            \
+  __sanitizer_syscall_post_impl_shmat(                                         \
+      res, (long long)(shmid), (long long)(shmaddr), (long long)(shmflg))
+#define __sanitizer_syscall_pre_compat_14_shmctl(shmid, cmd, buf)              \
+  __sanitizer_syscall_pre_impl_compat_14_shmctl(                               \
+      (long long)(shmid), (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_post_compat_14_shmctl(res, shmid, cmd, buf)        \
+  __sanitizer_syscall_post_impl_compat_14_shmctl(                              \
+      res, (long long)(shmid), (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_pre_shmdt(shmaddr)                                 \
+  __sanitizer_syscall_pre_impl_shmdt((long long)(shmaddr))
+#define __sanitizer_syscall_post_shmdt(res, shmaddr)                           \
+  __sanitizer_syscall_post_impl_shmdt(res, (long long)(shmaddr))
+#define __sanitizer_syscall_pre_shmget(key, size, shmflg)                      \
+  __sanitizer_syscall_pre_impl_shmget((long long)(key), (long long)(size),     \
+                                      (long long)(shmflg))
+#define __sanitizer_syscall_post_shmget(res, key, size, shmflg)                \
+  __sanitizer_syscall_post_impl_shmget(res, (long long)(key),                  \
+                                       (long long)(size), (long long)(shmflg))
+#define __sanitizer_syscall_pre_compat_50_clock_gettime(clock_id, tp)          \
+  __sanitizer_syscall_pre_impl_compat_50_clock_gettime((long long)(clock_id),  \
+                                                       (long long)(tp))
+#define __sanitizer_syscall_post_compat_50_clock_gettime(res, clock_id, tp)    \
+  __sanitizer_syscall_post_impl_compat_50_clock_gettime(                       \
+      res, (long long)(clock_id), (long long)(tp))
+#define __sanitizer_syscall_pre_compat_50_clock_settime(clock_id, tp)          \
+  __sanitizer_syscall_pre_impl_compat_50_clock_settime((long long)(clock_id),  \
+                                                       (long long)(tp))
+#define __sanitizer_syscall_post_compat_50_clock_settime(res, clock_id, tp)    \
+  __sanitizer_syscall_post_impl_compat_50_clock_settime(                       \
+      res, (long long)(clock_id), (long long)(tp))
+#define __sanitizer_syscall_pre_compat_50_clock_getres(clock_id, tp)           \
+  __sanitizer_syscall_pre_impl_compat_50_clock_getres((long long)(clock_id),   \
+                                                      (long long)(tp))
+#define __sanitizer_syscall_post_compat_50_clock_getres(res, clock_id, tp)     \
+  __sanitizer_syscall_post_impl_compat_50_clock_getres(                        \
+      res, (long long)(clock_id), (long long)(tp))
+#define __sanitizer_syscall_pre_timer_create(clock_id, evp, timerid)           \
+  __sanitizer_syscall_pre_impl_timer_create(                                   \
+      (long long)(clock_id), (long long)(evp), (long long)(timerid))
+#define __sanitizer_syscall_post_timer_create(res, clock_id, evp, timerid)     \
+  __sanitizer_syscall_post_impl_timer_create(                                  \
+      res, (long long)(clock_id), (long long)(evp), (long long)(timerid))
+#define __sanitizer_syscall_pre_timer_delete(timerid)                          \
+  __sanitizer_syscall_pre_impl_timer_delete((long long)(timerid))
+#define __sanitizer_syscall_post_timer_delete(res, timerid)                    \
+  __sanitizer_syscall_post_impl_timer_delete(res, (long long)(timerid))
+#define __sanitizer_syscall_pre_compat_50_timer_settime(timerid, flags, value, \
+                                                        ovalue)                \
+  __sanitizer_syscall_pre_impl_compat_50_timer_settime(                        \
+      (long long)(timerid), (long long)(flags), (long long)(value),            \
+      (long long)(ovalue))
+#define __sanitizer_syscall_post_compat_50_timer_settime(res, timerid, flags,  \
+                                                         value, ovalue)        \
+  __sanitizer_syscall_post_impl_compat_50_timer_settime(                       \
+      res, (long long)(timerid), (long long)(flags), (long long)(value),       \
+      (long long)(ovalue))
+#define __sanitizer_syscall_pre_compat_50_timer_gettime(timerid, value)        \
+  __sanitizer_syscall_pre_impl_compat_50_timer_gettime((long long)(timerid),   \
+                                                       (long long)(value))
+#define __sanitizer_syscall_post_compat_50_timer_gettime(res, timerid, value)  \
+  __sanitizer_syscall_post_impl_compat_50_timer_gettime(                       \
+      res, (long long)(timerid), (long long)(value))
+#define __sanitizer_syscall_pre_timer_getoverrun(timerid)                      \
+  __sanitizer_syscall_pre_impl_timer_getoverrun((long long)(timerid))
+#define __sanitizer_syscall_post_timer_getoverrun(res, timerid)                \
+  __sanitizer_syscall_post_impl_timer_getoverrun(res, (long long)(timerid))
+#define __sanitizer_syscall_pre_compat_50_nanosleep(rqtp, rmtp)                \
+  __sanitizer_syscall_pre_impl_compat_50_nanosleep((long long)(rqtp),          \
+                                                   (long long)(rmtp))
+#define __sanitizer_syscall_post_compat_50_nanosleep(res, rqtp, rmtp)          \
+  __sanitizer_syscall_post_impl_compat_50_nanosleep(res, (long long)(rqtp),    \
+                                                    (long long)(rmtp))
+#define __sanitizer_syscall_pre_fdatasync(fd)                                  \
+  __sanitizer_syscall_pre_impl_fdatasync((long long)(fd))
+#define __sanitizer_syscall_post_fdatasync(res, fd)                            \
+  __sanitizer_syscall_post_impl_fdatasync(res, (long long)(fd))
+#define __sanitizer_syscall_pre_mlockall(flags)                                \
+  __sanitizer_syscall_pre_impl_mlockall((long long)(flags))
+#define __sanitizer_syscall_post_mlockall(res, flags)                          \
+  __sanitizer_syscall_post_impl_mlockall(res, (long long)(flags))
+#define __sanitizer_syscall_pre_munlockall()                                   \
+  __sanitizer_syscall_pre_impl_munlockall()
+#define __sanitizer_syscall_post_munlockall(res)                               \
+  __sanitizer_syscall_post_impl_munlockall(res)
+#define __sanitizer_syscall_pre_compat_50___sigtimedwait(set, info, timeout)   \
+  __sanitizer_syscall_pre_impl_compat_50___sigtimedwait(                       \
+      (long long)(set), (long long)(info), (long long)(timeout))
+#define __sanitizer_syscall_post_compat_50___sigtimedwait(res, set, info,      \
+                                                          timeout)             \
+  __sanitizer_syscall_post_impl_compat_50___sigtimedwait(                      \
+      res, (long long)(set), (long long)(info), (long long)(timeout))
+#define __sanitizer_syscall_pre_sigqueueinfo(pid, info)                        \
+  __sanitizer_syscall_pre_impl_sigqueueinfo((long long)(pid), (long long)(info))
+#define __sanitizer_syscall_post_sigqueueinfo(res, pid, info)                  \
+  __sanitizer_syscall_post_impl_sigqueueinfo(res, (long long)(pid),            \
+                                             (long long)(info))
+#define __sanitizer_syscall_pre_modctl(cmd, arg)                               \
+  __sanitizer_syscall_pre_impl_modctl((long long)(cmd), (long long)(arg))
+#define __sanitizer_syscall_post_modctl(res, cmd, arg)                         \
+  __sanitizer_syscall_post_impl_modctl(res, (long long)(cmd), (long long)(arg))
+#define __sanitizer_syscall_pre__ksem_init(value, idp)                         \
+  __sanitizer_syscall_pre_impl__ksem_init((long long)(value), (long long)(idp))
+#define __sanitizer_syscall_post__ksem_init(res, value, idp)                   \
+  __sanitizer_syscall_post_impl__ksem_init(res, (long long)(value),            \
+                                           (long long)(idp))
+#define __sanitizer_syscall_pre__ksem_open(name, oflag, mode, value, idp)      \
+  __sanitizer_syscall_pre_impl__ksem_open(                                     \
+      (long long)(name), (long long)(oflag), (long long)(mode),                \
+      (long long)(value), (long long)(idp))
+#define __sanitizer_syscall_post__ksem_open(res, name, oflag, mode, value,     \
+                                            idp)                               \
+  __sanitizer_syscall_post_impl__ksem_open(                                    \
+      res, (long long)(name), (long long)(oflag), (long long)(mode),           \
+      (long long)(value), (long long)(idp))
+#define __sanitizer_syscall_pre__ksem_unlink(name)                             \
+  __sanitizer_syscall_pre_impl__ksem_unlink((long long)(name))
+#define __sanitizer_syscall_post__ksem_unlink(res, name)                       \
+  __sanitizer_syscall_post_impl__ksem_unlink(res, (long long)(name))
+#define __sanitizer_syscall_pre__ksem_close(id)                                \
+  __sanitizer_syscall_pre_impl__ksem_close((long long)(id))
+#define __sanitizer_syscall_post__ksem_close(res, id)                          \
+  __sanitizer_syscall_post_impl__ksem_close(res, (long long)(id))
+#define __sanitizer_syscall_pre__ksem_post(id)                                 \
+  __sanitizer_syscall_pre_impl__ksem_post((long long)(id))
+#define __sanitizer_syscall_post__ksem_post(res, id)                           \
+  __sanitizer_syscall_post_impl__ksem_post(res, (long long)(id))
+#define __sanitizer_syscall_pre__ksem_wait(id)                                 \
+  __sanitizer_syscall_pre_impl__ksem_wait((long long)(id))
+#define __sanitizer_syscall_post__ksem_wait(res, id)                           \
+  __sanitizer_syscall_post_impl__ksem_wait(res, (long long)(id))
+#define __sanitizer_syscall_pre__ksem_trywait(id)                              \
+  __sanitizer_syscall_pre_impl__ksem_trywait((long long)(id))
+#define __sanitizer_syscall_post__ksem_trywait(res, id)                        \
+  __sanitizer_syscall_post_impl__ksem_trywait(res, (long long)(id))
+#define __sanitizer_syscall_pre__ksem_getvalue(id, value)                      \
+  __sanitizer_syscall_pre_impl__ksem_getvalue((long long)(id),                 \
+                                              (long long)(value))
+#define __sanitizer_syscall_post__ksem_getvalue(res, id, value)                \
+  __sanitizer_syscall_post_impl__ksem_getvalue(res, (long long)(id),           \
+                                               (long long)(value))
+#define __sanitizer_syscall_pre__ksem_destroy(id)                              \
+  __sanitizer_syscall_pre_impl__ksem_destroy((long long)(id))
+#define __sanitizer_syscall_post__ksem_destroy(res, id)                        \
+  __sanitizer_syscall_post_impl__ksem_destroy(res, (long long)(id))
+#define __sanitizer_syscall_pre__ksem_timedwait(id, abstime)                   \
+  __sanitizer_syscall_pre_impl__ksem_timedwait((long long)(id),                \
+                                               (long long)(abstime))
+#define __sanitizer_syscall_post__ksem_timedwait(res, id, abstime)             \
+  __sanitizer_syscall_post_impl__ksem_timedwait(res, (long long)(id),          \
+                                                (long long)(abstime))
+#define __sanitizer_syscall_pre_mq_open(name, oflag, mode, attr)               \
+  __sanitizer_syscall_pre_impl_mq_open((long long)(name), (long long)(oflag),  \
+                                       (long long)(mode), (long long)(attr))
+#define __sanitizer_syscall_post_mq_open(res, name, oflag, mode, attr)         \
+  __sanitizer_syscall_post_impl_mq_open(res, (long long)(name),                \
+                                        (long long)(oflag), (long long)(mode), \
+                                        (long long)(attr))
+#define __sanitizer_syscall_pre_mq_close(mqdes)                                \
+  __sanitizer_syscall_pre_impl_mq_close((long long)(mqdes))
+#define __sanitizer_syscall_post_mq_close(res, mqdes)                          \
+  __sanitizer_syscall_post_impl_mq_close(res, (long long)(mqdes))
+#define __sanitizer_syscall_pre_mq_unlink(name)                                \
+  __sanitizer_syscall_pre_impl_mq_unlink((long long)(name))
+#define __sanitizer_syscall_post_mq_unlink(res, name)                          \
+  __sanitizer_syscall_post_impl_mq_unlink(res, (long long)(name))
+#define __sanitizer_syscall_pre_mq_getattr(mqdes, mqstat)                      \
+  __sanitizer_syscall_pre_impl_mq_getattr((long long)(mqdes),                  \
+                                          (long long)(mqstat))
+#define __sanitizer_syscall_post_mq_getattr(res, mqdes, mqstat)                \
+  __sanitizer_syscall_post_impl_mq_getattr(res, (long long)(mqdes),            \
+                                           (long long)(mqstat))
+#define __sanitizer_syscall_pre_mq_setattr(mqdes, mqstat, omqstat)             \
+  __sanitizer_syscall_pre_impl_mq_setattr(                                     \
+      (long long)(mqdes), (long long)(mqstat), (long long)(omqstat))
+#define __sanitizer_syscall_post_mq_setattr(res, mqdes, mqstat, omqstat)       \
+  __sanitizer_syscall_post_impl_mq_setattr(                                    \
+      res, (long long)(mqdes), (long long)(mqstat), (long long)(omqstat))
+#define __sanitizer_syscall_pre_mq_notify(mqdes, notification)                 \
+  __sanitizer_syscall_pre_impl_mq_notify((long long)(mqdes),                   \
+                                         (long long)(notification))
+#define __sanitizer_syscall_post_mq_notify(res, mqdes, notification)           \
+  __sanitizer_syscall_post_impl_mq_notify(res, (long long)(mqdes),             \
+                                          (long long)(notification))
+#define __sanitizer_syscall_pre_mq_send(mqdes, msg_ptr, msg_len, msg_prio)     \
+  __sanitizer_syscall_pre_impl_mq_send(                                        \
+      (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),          \
+      (long long)(msg_prio))
+#define __sanitizer_syscall_post_mq_send(res, mqdes, msg_ptr, msg_len,         \
+                                         msg_prio)                             \
+  __sanitizer_syscall_post_impl_mq_send(                                       \
+      res, (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),     \
+      (long long)(msg_prio))
+#define __sanitizer_syscall_pre_mq_receive(mqdes, msg_ptr, msg_len, msg_prio)  \
+  __sanitizer_syscall_pre_impl_mq_receive(                                     \
+      (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),          \
+      (long long)(msg_prio))
+#define __sanitizer_syscall_post_mq_receive(res, mqdes, msg_ptr, msg_len,      \
+                                            msg_prio)                          \
+  __sanitizer_syscall_post_impl_mq_receive(                                    \
+      res, (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),     \
+      (long long)(msg_prio))
+#define __sanitizer_syscall_pre_compat_50_mq_timedsend(                        \
+    mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)                            \
+  __sanitizer_syscall_pre_impl_compat_50_mq_timedsend(                         \
+      (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),          \
+      (long long)(msg_prio), (long long)(abs_timeout))
+#define __sanitizer_syscall_post_compat_50_mq_timedsend(                       \
+    res, mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)                       \
+  __sanitizer_syscall_post_impl_compat_50_mq_timedsend(                        \
+      res, (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),     \
+      (long long)(msg_prio), (long long)(abs_timeout))
+#define __sanitizer_syscall_pre_compat_50_mq_timedreceive(                     \
+    mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)                            \
+  __sanitizer_syscall_pre_impl_compat_50_mq_timedreceive(                      \
+      (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),          \
+      (long long)(msg_prio), (long long)(abs_timeout))
+#define __sanitizer_syscall_post_compat_50_mq_timedreceive(                    \
+    res, mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)                       \
+  __sanitizer_syscall_post_impl_compat_50_mq_timedreceive(                     \
+      res, (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),     \
+      (long long)(msg_prio), (long long)(abs_timeout))
+/* syscall 267 has been skipped */
+/* syscall 268 has been skipped */
+/* syscall 269 has been skipped */
+#define __sanitizer_syscall_pre___posix_rename(from, to)                       \
+  __sanitizer_syscall_pre_impl___posix_rename((long long)(from),               \
+                                              (long long)(to))
+#define __sanitizer_syscall_post___posix_rename(res, from, to)                 \
+  __sanitizer_syscall_post_impl___posix_rename(res, (long long)(from),         \
+                                               (long long)(to))
+#define __sanitizer_syscall_pre_swapctl(cmd, arg, misc)                        \
+  __sanitizer_syscall_pre_impl_swapctl((long long)(cmd), (long long)(arg),     \
+                                       (long long)(misc))
+#define __sanitizer_syscall_post_swapctl(res, cmd, arg, misc)                  \
+  __sanitizer_syscall_post_impl_swapctl(res, (long long)(cmd),                 \
+                                        (long long)(arg), (long long)(misc))
+#define __sanitizer_syscall_pre_compat_30_getdents(fd, buf, count)             \
+  __sanitizer_syscall_pre_impl_compat_30_getdents(                             \
+      (long long)(fd), (long long)(buf), (long long)(count))
+#define __sanitizer_syscall_post_compat_30_getdents(res, fd, buf, count)       \
+  __sanitizer_syscall_post_impl_compat_30_getdents(                            \
+      res, (long long)(fd), (long long)(buf), (long long)(count))
+#define __sanitizer_syscall_pre_minherit(addr, len, inherit)                   \
+  __sanitizer_syscall_pre_impl_minherit((long long)(addr), (long long)(len),   \
+                                        (long long)(inherit))
+#define __sanitizer_syscall_post_minherit(res, addr, len, inherit)             \
+  __sanitizer_syscall_post_impl_minherit(                                      \
+      res, (long long)(addr), (long long)(len), (long long)(inherit))
+#define __sanitizer_syscall_pre_lchmod(path, mode)                             \
+  __sanitizer_syscall_pre_impl_lchmod((long long)(path), (long long)(mode))
+#define __sanitizer_syscall_post_lchmod(res, path, mode)                       \
+  __sanitizer_syscall_post_impl_lchmod(res, (long long)(path),                 \
+                                       (long long)(mode))
+#define __sanitizer_syscall_pre_lchown(path, uid, gid)                         \
+  __sanitizer_syscall_pre_impl_lchown((long long)(path), (long long)(uid),     \
+                                      (long long)(gid))
+#define __sanitizer_syscall_post_lchown(res, path, uid, gid)                   \
+  __sanitizer_syscall_post_impl_lchown(res, (long long)(path),                 \
+                                       (long long)(uid), (long long)(gid))
+#define __sanitizer_syscall_pre_compat_50_lutimes(path, tptr)                  \
+  __sanitizer_syscall_pre_impl_compat_50_lutimes((long long)(path),            \
+                                                 (long long)(tptr))
+#define __sanitizer_syscall_post_compat_50_lutimes(res, path, tptr)            \
+  __sanitizer_syscall_post_impl_compat_50_lutimes(res, (long long)(path),      \
+                                                  (long long)(tptr))
+#define __sanitizer_syscall_pre___msync13(addr, len, flags)                    \
+  __sanitizer_syscall_pre_impl___msync13((long long)(addr), (long long)(len),  \
+                                         (long long)(flags))
+#define __sanitizer_syscall_post___msync13(res, addr, len, flags)              \
+  __sanitizer_syscall_post_impl___msync13(                                     \
+      res, (long long)(addr), (long long)(len), (long long)(flags))
+#define __sanitizer_syscall_pre_compat_30___stat13(path, ub)                   \
+  __sanitizer_syscall_pre_impl_compat_30___stat13((long long)(path),           \
+                                                  (long long)(ub))
+#define __sanitizer_syscall_post_compat_30___stat13(res, path, ub)             \
+  __sanitizer_syscall_post_impl_compat_30___stat13(res, (long long)(path),     \
+                                                   (long long)(ub))
+#define __sanitizer_syscall_pre_compat_30___fstat13(fd, sb)                    \
+  __sanitizer_syscall_pre_impl_compat_30___fstat13((long long)(fd),            \
+                                                   (long long)(sb))
+#define __sanitizer_syscall_post_compat_30___fstat13(res, fd, sb)              \
+  __sanitizer_syscall_post_impl_compat_30___fstat13(res, (long long)(fd),      \
+                                                    (long long)(sb))
+#define __sanitizer_syscall_pre_compat_30___lstat13(path, ub)                  \
+  __sanitizer_syscall_pre_impl_compat_30___lstat13((long long)(path),          \
+                                                   (long long)(ub))
+#define __sanitizer_syscall_post_compat_30___lstat13(res, path, ub)            \
+  __sanitizer_syscall_post_impl_compat_30___lstat13(res, (long long)(path),    \
+                                                    (long long)(ub))
+#define __sanitizer_syscall_pre___sigaltstack14(nss, oss)                      \
+  __sanitizer_syscall_pre_impl___sigaltstack14((long long)(nss),               \
+                                               (long long)(oss))
+#define __sanitizer_syscall_post___sigaltstack14(res, nss, oss)                \
+  __sanitizer_syscall_post_impl___sigaltstack14(res, (long long)(nss),         \
+                                                (long long)(oss))
+#define __sanitizer_syscall_pre___vfork14()                                    \
+  __sanitizer_syscall_pre_impl___vfork14()
+#define __sanitizer_syscall_post___vfork14(res)                                \
+  __sanitizer_syscall_post_impl___vfork14(res)
+#define __sanitizer_syscall_pre___posix_chown(path, uid, gid)                  \
+  __sanitizer_syscall_pre_impl___posix_chown(                                  \
+      (long long)(path), (long long)(uid), (long long)(gid))
+#define __sanitizer_syscall_post___posix_chown(res, path, uid, gid)            \
+  __sanitizer_syscall_post_impl___posix_chown(                                 \
+      res, (long long)(path), (long long)(uid), (long long)(gid))
+#define __sanitizer_syscall_pre___posix_fchown(fd, uid, gid)                   \
+  __sanitizer_syscall_pre_impl___posix_fchown(                                 \
+      (long long)(fd), (long long)(uid), (long long)(gid))
+#define __sanitizer_syscall_post___posix_fchown(res, fd, uid, gid)             \
+  __sanitizer_syscall_post_impl___posix_fchown(                                \
+      res, (long long)(fd), (long long)(uid), (long long)(gid))
+#define __sanitizer_syscall_pre___posix_lchown(path, uid, gid)                 \
+  __sanitizer_syscall_pre_impl___posix_lchown(                                 \
+      (long long)(path), (long long)(uid), (long long)(gid))
+#define __sanitizer_syscall_post___posix_lchown(res, path, uid, gid)           \
+  __sanitizer_syscall_post_impl___posix_lchown(                                \
+      res, (long long)(path), (long long)(uid), (long long)(gid))
+#define __sanitizer_syscall_pre_getsid(pid)                                    \
+  __sanitizer_syscall_pre_impl_getsid((long long)(pid))
+#define __sanitizer_syscall_post_getsid(res, pid)                              \
+  __sanitizer_syscall_post_impl_getsid(res, (long long)(pid))
+#define __sanitizer_syscall_pre___clone(flags, stack)                          \
+  __sanitizer_syscall_pre_impl___clone((long long)(flags), (long long)(stack))
+#define __sanitizer_syscall_post___clone(res, flags, stack)                    \
+  __sanitizer_syscall_post_impl___clone(res, (long long)(flags),               \
+                                        (long long)(stack))
+#define __sanitizer_syscall_pre_fktrace(fd, ops, facs, pid)                    \
+  __sanitizer_syscall_pre_impl_fktrace((long long)(fd), (long long)(ops),      \
+                                       (long long)(facs), (long long)(pid))
+#define __sanitizer_syscall_post_fktrace(res, fd, ops, facs, pid)              \
+  __sanitizer_syscall_post_impl_fktrace(res, (long long)(fd),                  \
+                                        (long long)(ops), (long long)(facs),   \
+                                        (long long)(pid))
+#define __sanitizer_syscall_pre_preadv(fd, iovp, iovcnt, PAD, offset)          \
+  __sanitizer_syscall_pre_impl_preadv((long long)(fd), (long long)(iovp),      \
+                                      (long long)(iovcnt), (long long)(PAD),   \
+                                      (long long)(offset))
+#define __sanitizer_syscall_post_preadv(res, fd, iovp, iovcnt, PAD, offset)    \
+  __sanitizer_syscall_post_impl_preadv(res, (long long)(fd),                   \
+                                       (long long)(iovp), (long long)(iovcnt), \
+                                       (long long)(PAD), (long long)(offset))
+#define __sanitizer_syscall_pre_pwritev(fd, iovp, iovcnt, PAD, offset)         \
+  __sanitizer_syscall_pre_impl_pwritev((long long)(fd), (long long)(iovp),     \
+                                       (long long)(iovcnt), (long long)(PAD),  \
+                                       (long long)(offset))
+#define __sanitizer_syscall_post_pwritev(res, fd, iovp, iovcnt, PAD, offset)   \
+  __sanitizer_syscall_post_impl_pwritev(                                       \
+      res, (long long)(fd), (long long)(iovp), (long long)(iovcnt),            \
+      (long long)(PAD), (long long)(offset))
+#define __sanitizer_syscall_pre_compat_16___sigaction14(signum, nsa, osa)      \
+  __sanitizer_syscall_pre_impl_compat_16___sigaction14(                        \
+      (long long)(signum), (long long)(nsa), (long long)(osa))
+#define __sanitizer_syscall_post_compat_16___sigaction14(res, signum, nsa,     \
+                                                         osa)                  \
+  __sanitizer_syscall_post_impl_compat_16___sigaction14(                       \
+      res, (long long)(signum), (long long)(nsa), (long long)(osa))
+#define __sanitizer_syscall_pre___sigpending14(set)                            \
+  __sanitizer_syscall_pre_impl___sigpending14((long long)(set))
+#define __sanitizer_syscall_post___sigpending14(res, set)                      \
+  __sanitizer_syscall_post_impl___sigpending14(res, (long long)(set))
+#define __sanitizer_syscall_pre___sigprocmask14(how, set, oset)                \
+  __sanitizer_syscall_pre_impl___sigprocmask14(                                \
+      (long long)(how), (long long)(set), (long long)(oset))
+#define __sanitizer_syscall_post___sigprocmask14(res, how, set, oset)          \
+  __sanitizer_syscall_post_impl___sigprocmask14(                               \
+      res, (long long)(how), (long long)(set), (long long)(oset))
+#define __sanitizer_syscall_pre___sigsuspend14(set)                            \
+  __sanitizer_syscall_pre_impl___sigsuspend14((long long)(set))
+#define __sanitizer_syscall_post___sigsuspend14(res, set)                      \
+  __sanitizer_syscall_post_impl___sigsuspend14(res, (long long)(set))
+#define __sanitizer_syscall_pre_compat_16___sigreturn14(sigcntxp)              \
+  __sanitizer_syscall_pre_impl_compat_16___sigreturn14((long long)(sigcntxp))
+#define __sanitizer_syscall_post_compat_16___sigreturn14(res, sigcntxp)        \
+  __sanitizer_syscall_post_impl_compat_16___sigreturn14(res,                   \
+                                                        (long long)(sigcntxp))
+#define __sanitizer_syscall_pre___getcwd(bufp, length)                         \
+  __sanitizer_syscall_pre_impl___getcwd((long long)(bufp), (long long)(length))
+#define __sanitizer_syscall_post___getcwd(res, bufp, length)                   \
+  __sanitizer_syscall_post_impl___getcwd(res, (long long)(bufp),               \
+                                         (long long)(length))
+#define __sanitizer_syscall_pre_fchroot(fd)                                    \
+  __sanitizer_syscall_pre_impl_fchroot((long long)(fd))
+#define __sanitizer_syscall_post_fchroot(res, fd)                              \
+  __sanitizer_syscall_post_impl_fchroot(res, (long long)(fd))
+#define __sanitizer_syscall_pre_compat_30_fhopen(fhp, flags)                   \
+  __sanitizer_syscall_pre_impl_compat_30_fhopen((long long)(fhp),              \
+                                                (long long)(flags))
+#define __sanitizer_syscall_post_compat_30_fhopen(res, fhp, flags)             \
+  __sanitizer_syscall_post_impl_compat_30_fhopen(res, (long long)(fhp),        \
+                                                 (long long)(flags))
+#define __sanitizer_syscall_pre_compat_30_fhstat(fhp, sb)                      \
+  __sanitizer_syscall_pre_impl_compat_30_fhstat((long long)(fhp),              \
+                                                (long long)(sb))
+#define __sanitizer_syscall_post_compat_30_fhstat(res, fhp, sb)                \
+  __sanitizer_syscall_post_impl_compat_30_fhstat(res, (long long)(fhp),        \
+                                                 (long long)(sb))
+#define __sanitizer_syscall_pre_compat_20_fhstatfs(fhp, buf)                   \
+  __sanitizer_syscall_pre_impl_compat_20_fhstatfs((long long)(fhp),            \
+                                                  (long long)(buf))
+#define __sanitizer_syscall_post_compat_20_fhstatfs(res, fhp, buf)             \
+  __sanitizer_syscall_post_impl_compat_20_fhstatfs(res, (long long)(fhp),      \
+                                                   (long long)(buf))
+#define __sanitizer_syscall_pre_compat_50_____semctl13(semid, semnum, cmd,     \
+                                                       arg)                    \
+  __sanitizer_syscall_pre_impl_compat_50_____semctl13(                         \
+      (long long)(semid), (long long)(semnum), (long long)(cmd),               \
+      (long long)(arg))
+#define __sanitizer_syscall_post_compat_50_____semctl13(res, semid, semnum,    \
+                                                        cmd, arg)              \
+  __sanitizer_syscall_post_impl_compat_50_____semctl13(                        \
+      res, (long long)(semid), (long long)(semnum), (long long)(cmd),          \
+      (long long)(arg))
+#define __sanitizer_syscall_pre_compat_50___msgctl13(msqid, cmd, buf)          \
+  __sanitizer_syscall_pre_impl_compat_50___msgctl13(                           \
+      (long long)(msqid), (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_post_compat_50___msgctl13(res, msqid, cmd, buf)    \
+  __sanitizer_syscall_post_impl_compat_50___msgctl13(                          \
+      res, (long long)(msqid), (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_pre_compat_50___shmctl13(shmid, cmd, buf)          \
+  __sanitizer_syscall_pre_impl_compat_50___shmctl13(                           \
+      (long long)(shmid), (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_post_compat_50___shmctl13(res, shmid, cmd, buf)    \
+  __sanitizer_syscall_post_impl_compat_50___shmctl13(                          \
+      res, (long long)(shmid), (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_pre_lchflags(path, flags)                          \
+  __sanitizer_syscall_pre_impl_lchflags((long long)(path), (long long)(flags))
+#define __sanitizer_syscall_post_lchflags(res, path, flags)                    \
+  __sanitizer_syscall_post_impl_lchflags(res, (long long)(path),               \
+                                         (long long)(flags))
+#define __sanitizer_syscall_pre_issetugid()                                    \
+  __sanitizer_syscall_pre_impl_issetugid()
+#define __sanitizer_syscall_post_issetugid(res)                                \
+  __sanitizer_syscall_post_impl_issetugid(res)
+#define __sanitizer_syscall_pre_utrace(label, addr, len)                       \
+  __sanitizer_syscall_pre_impl_utrace((long long)(label), (long long)(addr),   \
+                                      (long long)(len))
+#define __sanitizer_syscall_post_utrace(res, label, addr, len)                 \
+  __sanitizer_syscall_post_impl_utrace(res, (long long)(label),                \
+                                       (long long)(addr), (long long)(len))
+#define __sanitizer_syscall_pre_getcontext(ucp)                                \
+  __sanitizer_syscall_pre_impl_getcontext((long long)(ucp))
+#define __sanitizer_syscall_post_getcontext(res, ucp)                          \
+  __sanitizer_syscall_post_impl_getcontext(res, (long long)(ucp))
+#define __sanitizer_syscall_pre_setcontext(ucp)                                \
+  __sanitizer_syscall_pre_impl_setcontext((long long)(ucp))
+#define __sanitizer_syscall_post_setcontext(res, ucp)                          \
+  __sanitizer_syscall_post_impl_setcontext(res, (long long)(ucp))
+#define __sanitizer_syscall_pre__lwp_create(ucp, flags, new_lwp)               \
+  __sanitizer_syscall_pre_impl__lwp_create(                                    \
+      (long long)(ucp), (long long)(flags), (long long)(new_lwp))
+#define __sanitizer_syscall_post__lwp_create(res, ucp, flags, new_lwp)         \
+  __sanitizer_syscall_post_impl__lwp_create(                                   \
+      res, (long long)(ucp), (long long)(flags), (long long)(new_lwp))
+#define __sanitizer_syscall_pre__lwp_exit()                                    \
+  __sanitizer_syscall_pre_impl__lwp_exit()
+#define __sanitizer_syscall_post__lwp_exit(res)                                \
+  __sanitizer_syscall_post_impl__lwp_exit(res)
+#define __sanitizer_syscall_pre__lwp_self()                                    \
+  __sanitizer_syscall_pre_impl__lwp_self()
+#define __sanitizer_syscall_post__lwp_self(res)                                \
+  __sanitizer_syscall_post_impl__lwp_self(res)
+#define __sanitizer_syscall_pre__lwp_wait(wait_for, departed)                  \
+  __sanitizer_syscall_pre_impl__lwp_wait((long long)(wait_for),                \
+                                         (long long)(departed))
+#define __sanitizer_syscall_post__lwp_wait(res, wait_for, departed)            \
+  __sanitizer_syscall_post_impl__lwp_wait(res, (long long)(wait_for),          \
+                                          (long long)(departed))
+#define __sanitizer_syscall_pre__lwp_suspend(target)                           \
+  __sanitizer_syscall_pre_impl__lwp_suspend((long long)(target))
+#define __sanitizer_syscall_post__lwp_suspend(res, target)                     \
+  __sanitizer_syscall_post_impl__lwp_suspend(res, (long long)(target))
+#define __sanitizer_syscall_pre__lwp_continue(target)                          \
+  __sanitizer_syscall_pre_impl__lwp_continue((long long)(target))
+#define __sanitizer_syscall_post__lwp_continue(res, target)                    \
+  __sanitizer_syscall_post_impl__lwp_continue(res, (long long)(target))
+#define __sanitizer_syscall_pre__lwp_wakeup(target)                            \
+  __sanitizer_syscall_pre_impl__lwp_wakeup((long long)(target))
+#define __sanitizer_syscall_post__lwp_wakeup(res, target)                      \
+  __sanitizer_syscall_post_impl__lwp_wakeup(res, (long long)(target))
+#define __sanitizer_syscall_pre__lwp_getprivate()                              \
+  __sanitizer_syscall_pre_impl__lwp_getprivate()
+#define __sanitizer_syscall_post__lwp_getprivate(res)                          \
+  __sanitizer_syscall_post_impl__lwp_getprivate(res)
+#define __sanitizer_syscall_pre__lwp_setprivate(ptr)                           \
+  __sanitizer_syscall_pre_impl__lwp_setprivate((long long)(ptr))
+#define __sanitizer_syscall_post__lwp_setprivate(res, ptr)                     \
+  __sanitizer_syscall_post_impl__lwp_setprivate(res, (long long)(ptr))
+#define __sanitizer_syscall_pre__lwp_kill(target, signo)                       \
+  __sanitizer_syscall_pre_impl__lwp_kill((long long)(target),                  \
+                                         (long long)(signo))
+#define __sanitizer_syscall_post__lwp_kill(res, target, signo)                 \
+  __sanitizer_syscall_post_impl__lwp_kill(res, (long long)(target),            \
+                                          (long long)(signo))
+#define __sanitizer_syscall_pre__lwp_detach(target)                            \
+  __sanitizer_syscall_pre_impl__lwp_detach((long long)(target))
+#define __sanitizer_syscall_post__lwp_detach(res, target)                      \
+  __sanitizer_syscall_post_impl__lwp_detach(res, (long long)(target))
+#define __sanitizer_syscall_pre_compat_50__lwp_park(ts, unpark, hint,          \
+                                                    unparkhint)                \
+  __sanitizer_syscall_pre_impl_compat_50__lwp_park(                            \
+      (long long)(ts), (long long)(unpark), (long long)(hint),                 \
+      (long long)(unparkhint))
+#define __sanitizer_syscall_post_compat_50__lwp_park(res, ts, unpark, hint,    \
+                                                     unparkhint)               \
+  __sanitizer_syscall_post_impl_compat_50__lwp_park(                           \
+      res, (long long)(ts), (long long)(unpark), (long long)(hint),            \
+      (long long)(unparkhint))
+#define __sanitizer_syscall_pre__lwp_unpark(target, hint)                      \
+  __sanitizer_syscall_pre_impl__lwp_unpark((long long)(target),                \
+                                           (long long)(hint))
+#define __sanitizer_syscall_post__lwp_unpark(res, target, hint)                \
+  __sanitizer_syscall_post_impl__lwp_unpark(res, (long long)(target),          \
+                                            (long long)(hint))
+#define __sanitizer_syscall_pre__lwp_unpark_all(targets, ntargets, hint)       \
+  __sanitizer_syscall_pre_impl__lwp_unpark_all(                                \
+      (long long)(targets), (long long)(ntargets), (long long)(hint))
+#define __sanitizer_syscall_post__lwp_unpark_all(res, targets, ntargets, hint) \
+  __sanitizer_syscall_post_impl__lwp_unpark_all(                               \
+      res, (long long)(targets), (long long)(ntargets), (long long)(hint))
+#define __sanitizer_syscall_pre__lwp_setname(target, name)                     \
+  __sanitizer_syscall_pre_impl__lwp_setname((long long)(target),               \
+                                            (long long)(name))
+#define __sanitizer_syscall_post__lwp_setname(res, target, name)               \
+  __sanitizer_syscall_post_impl__lwp_setname(res, (long long)(target),         \
+                                             (long long)(name))
+#define __sanitizer_syscall_pre__lwp_getname(target, name, len)                \
+  __sanitizer_syscall_pre_impl__lwp_getname(                                   \
+      (long long)(target), (long long)(name), (long long)(len))
+#define __sanitizer_syscall_post__lwp_getname(res, target, name, len)          \
+  __sanitizer_syscall_post_impl__lwp_getname(                                  \
+      res, (long long)(target), (long long)(name), (long long)(len))
+#define __sanitizer_syscall_pre__lwp_ctl(features, address)                    \
+  __sanitizer_syscall_pre_impl__lwp_ctl((long long)(features),                 \
+                                        (long long)(address))
+#define __sanitizer_syscall_post__lwp_ctl(res, features, address)              \
+  __sanitizer_syscall_post_impl__lwp_ctl(res, (long long)(features),           \
+                                         (long long)(address))
+/* syscall 326 has been skipped */
+/* syscall 327 has been skipped */
+/* syscall 328 has been skipped */
+/* syscall 329 has been skipped */
+#define __sanitizer_syscall_pre_compat_60_sa_register(newv, oldv, flags,       \
+                                                      stackinfo_offset)        \
+  __sanitizer_syscall_pre_impl_compat_60_sa_register(                          \
+      (long long)(newv), (long long)(oldv), (long long)(flags),                \
+      (long long)(stackinfo_offset))
+#define __sanitizer_syscall_post_compat_60_sa_register(res, newv, oldv, flags, \
+                                                       stackinfo_offset)       \
+  __sanitizer_syscall_post_impl_compat_60_sa_register(                         \
+      res, (long long)(newv), (long long)(oldv), (long long)(flags),           \
+      (long long)(stackinfo_offset))
+#define __sanitizer_syscall_pre_compat_60_sa_stacks(num, stacks)               \
+  __sanitizer_syscall_pre_impl_compat_60_sa_stacks((long long)(num),           \
+                                                   (long long)(stacks))
+#define __sanitizer_syscall_post_compat_60_sa_stacks(res, num, stacks)         \
+  __sanitizer_syscall_post_impl_compat_60_sa_stacks(res, (long long)(num),     \
+                                                    (long long)(stacks))
+#define __sanitizer_syscall_pre_compat_60_sa_enable()                          \
+  __sanitizer_syscall_pre_impl_compat_60_sa_enable()
+#define __sanitizer_syscall_post_compat_60_sa_enable(res)                      \
+  __sanitizer_syscall_post_impl_compat_60_sa_enable(res)
+#define __sanitizer_syscall_pre_compat_60_sa_setconcurrency(concurrency)       \
+  __sanitizer_syscall_pre_impl_compat_60_sa_setconcurrency(                    \
+      (long long)(concurrency))
+#define __sanitizer_syscall_post_compat_60_sa_setconcurrency(res, concurrency) \
+  __sanitizer_syscall_post_impl_compat_60_sa_setconcurrency(                   \
+      res, (long long)(concurrency))
+#define __sanitizer_syscall_pre_compat_60_sa_yield()                           \
+  __sanitizer_syscall_pre_impl_compat_60_sa_yield()
+#define __sanitizer_syscall_post_compat_60_sa_yield(res)                       \
+  __sanitizer_syscall_post_impl_compat_60_sa_yield(res)
+#define __sanitizer_syscall_pre_compat_60_sa_preempt(sa_id)                    \
+  __sanitizer_syscall_pre_impl_compat_60_sa_preempt((long long)(sa_id))
+#define __sanitizer_syscall_post_compat_60_sa_preempt(res, sa_id)              \
+  __sanitizer_syscall_post_impl_compat_60_sa_preempt(res, (long long)(sa_id))
+/* syscall 336 has been skipped */
+/* syscall 337 has been skipped */
+/* syscall 338 has been skipped */
+/* syscall 339 has been skipped */
+#define __sanitizer_syscall_pre___sigaction_sigtramp(signum, nsa, osa, tramp,  \
+                                                     vers)                     \
+  __sanitizer_syscall_pre_impl___sigaction_sigtramp(                           \
+      (long long)(signum), (long long)(nsa), (long long)(osa),                 \
+      (long long)(tramp), (long long)(vers))
+#define __sanitizer_syscall_post___sigaction_sigtramp(res, signum, nsa, osa,   \
+                                                      tramp, vers)             \
+  __sanitizer_syscall_post_impl___sigaction_sigtramp(                          \
+      res, (long long)(signum), (long long)(nsa), (long long)(osa),            \
+      (long long)(tramp), (long long)(vers))
+/* syscall 341 has been skipped */
+/* syscall 342 has been skipped */
+#define __sanitizer_syscall_pre_rasctl(addr, len, op)                          \
+  __sanitizer_syscall_pre_impl_rasctl((long long)(addr), (long long)(len),     \
+                                      (long long)(op))
+#define __sanitizer_syscall_post_rasctl(res, addr, len, op)                    \
+  __sanitizer_syscall_post_impl_rasctl(res, (long long)(addr),                 \
+                                       (long long)(len), (long long)(op))
+#define __sanitizer_syscall_pre_kqueue() __sanitizer_syscall_pre_impl_kqueue()
+#define __sanitizer_syscall_post_kqueue(res)                                   \
+  __sanitizer_syscall_post_impl_kqueue(res)
+#define __sanitizer_syscall_pre_compat_50_kevent(fd, changelist, nchanges,     \
+                                                 eventlist, nevents, timeout)  \
+  __sanitizer_syscall_pre_impl_compat_50_kevent(                               \
+      (long long)(fd), (long long)(changelist), (long long)(nchanges),         \
+      (long long)(eventlist), (long long)(nevents), (long long)(timeout))
+#define __sanitizer_syscall_post_compat_50_kevent(                             \
+    res, fd, changelist, nchanges, eventlist, nevents, timeout)                \
+  __sanitizer_syscall_post_impl_compat_50_kevent(                              \
+      res, (long long)(fd), (long long)(changelist), (long long)(nchanges),    \
+      (long long)(eventlist), (long long)(nevents), (long long)(timeout))
+#define __sanitizer_syscall_pre__sched_setparam(pid, lid, policy, params)      \
+  __sanitizer_syscall_pre_impl__sched_setparam(                                \
+      (long long)(pid), (long long)(lid), (long long)(policy),                 \
+      (long long)(params))
+#define __sanitizer_syscall_post__sched_setparam(res, pid, lid, policy,        \
+                                                 params)                       \
+  __sanitizer_syscall_post_impl__sched_setparam(                               \
+      res, (long long)(pid), (long long)(lid), (long long)(policy),            \
+      (long long)(params))
+#define __sanitizer_syscall_pre__sched_getparam(pid, lid, policy, params)      \
+  __sanitizer_syscall_pre_impl__sched_getparam(                                \
+      (long long)(pid), (long long)(lid), (long long)(policy),                 \
+      (long long)(params))
+#define __sanitizer_syscall_post__sched_getparam(res, pid, lid, policy,        \
+                                                 params)                       \
+  __sanitizer_syscall_post_impl__sched_getparam(                               \
+      res, (long long)(pid), (long long)(lid), (long long)(policy),            \
+      (long long)(params))
+#define __sanitizer_syscall_pre__sched_setaffinity(pid, lid, size, cpuset)     \
+  __sanitizer_syscall_pre_impl__sched_setaffinity(                             \
+      (long long)(pid), (long long)(lid), (long long)(size),                   \
+      (long long)(cpuset))
+#define __sanitizer_syscall_post__sched_setaffinity(res, pid, lid, size,       \
+                                                    cpuset)                    \
+  __sanitizer_syscall_post_impl__sched_setaffinity(                            \
+      res, (long long)(pid), (long long)(lid), (long long)(size),              \
+      (long long)(cpuset))
+#define __sanitizer_syscall_pre__sched_getaffinity(pid, lid, size, cpuset)     \
+  __sanitizer_syscall_pre_impl__sched_getaffinity(                             \
+      (long long)(pid), (long long)(lid), (long long)(size),                   \
+      (long long)(cpuset))
+#define __sanitizer_syscall_post__sched_getaffinity(res, pid, lid, size,       \
+                                                    cpuset)                    \
+  __sanitizer_syscall_post_impl__sched_getaffinity(                            \
+      res, (long long)(pid), (long long)(lid), (long long)(size),              \
+      (long long)(cpuset))
+#define __sanitizer_syscall_pre_sched_yield()                                  \
+  __sanitizer_syscall_pre_impl_sched_yield()
+#define __sanitizer_syscall_post_sched_yield(res)                              \
+  __sanitizer_syscall_post_impl_sched_yield(res)
+#define __sanitizer_syscall_pre__sched_protect(priority)                       \
+  __sanitizer_syscall_pre_impl__sched_protect((long long)(priority))
+#define __sanitizer_syscall_post__sched_protect(res, priority)                 \
+  __sanitizer_syscall_post_impl__sched_protect(res, (long long)(priority))
+/* syscall 352 has been skipped */
+/* syscall 353 has been skipped */
+#define __sanitizer_syscall_pre_fsync_range(fd, flags, start, length)          \
+  __sanitizer_syscall_pre_impl_fsync_range(                                    \
+      (long long)(fd), (long long)(flags), (long long)(start),                 \
+      (long long)(length))
+#define __sanitizer_syscall_post_fsync_range(res, fd, flags, start, length)    \
+  __sanitizer_syscall_post_impl_fsync_range(                                   \
+      res, (long long)(fd), (long long)(flags), (long long)(start),            \
+      (long long)(length))
+#define __sanitizer_syscall_pre_uuidgen(store, count)                          \
+  __sanitizer_syscall_pre_impl_uuidgen((long long)(store), (long long)(count))
+#define __sanitizer_syscall_post_uuidgen(res, store, count)                    \
+  __sanitizer_syscall_post_impl_uuidgen(res, (long long)(store),               \
+                                        (long long)(count))
+#define __sanitizer_syscall_pre_getvfsstat(buf, bufsize, flags)                \
+  __sanitizer_syscall_pre_impl_getvfsstat(                                     \
+      (long long)(buf), (long long)(bufsize), (long long)(flags))
+#define __sanitizer_syscall_post_getvfsstat(res, buf, bufsize, flags)          \
+  __sanitizer_syscall_post_impl_getvfsstat(                                    \
+      res, (long long)(buf), (long long)(bufsize), (long long)(flags))
+#define __sanitizer_syscall_pre_statvfs1(path, buf, flags)                     \
+  __sanitizer_syscall_pre_impl_statvfs1((long long)(path), (long long)(buf),   \
+                                        (long long)(flags))
+#define __sanitizer_syscall_post_statvfs1(res, path, buf, flags)               \
+  __sanitizer_syscall_post_impl_statvfs1(res, (long long)(path),               \
+                                         (long long)(buf), (long long)(flags))
+#define __sanitizer_syscall_pre_fstatvfs1(fd, buf, flags)                      \
+  __sanitizer_syscall_pre_impl_fstatvfs1((long long)(fd), (long long)(buf),    \
+                                         (long long)(flags))
+#define __sanitizer_syscall_post_fstatvfs1(res, fd, buf, flags)                \
+  __sanitizer_syscall_post_impl_fstatvfs1(                                     \
+      res, (long long)(fd), (long long)(buf), (long long)(flags))
+#define __sanitizer_syscall_pre_compat_30_fhstatvfs1(fhp, buf, flags)          \
+  __sanitizer_syscall_pre_impl_compat_30_fhstatvfs1(                           \
+      (long long)(fhp), (long long)(buf), (long long)(flags))
+#define __sanitizer_syscall_post_compat_30_fhstatvfs1(res, fhp, buf, flags)    \
+  __sanitizer_syscall_post_impl_compat_30_fhstatvfs1(                          \
+      res, (long long)(fhp), (long long)(buf), (long long)(flags))
+#define __sanitizer_syscall_pre_extattrctl(path, cmd, filename, attrnamespace, \
+                                           attrname)                           \
+  __sanitizer_syscall_pre_impl_extattrctl(                                     \
+      (long long)(path), (long long)(cmd), (long long)(filename),              \
+      (long long)(attrnamespace), (long long)(attrname))
+#define __sanitizer_syscall_post_extattrctl(res, path, cmd, filename,          \
+                                            attrnamespace, attrname)           \
+  __sanitizer_syscall_post_impl_extattrctl(                                    \
+      res, (long long)(path), (long long)(cmd), (long long)(filename),         \
+      (long long)(attrnamespace), (long long)(attrname))
+#define __sanitizer_syscall_pre_extattr_set_file(path, attrnamespace,          \
+                                                 attrname, data, nbytes)       \
+  __sanitizer_syscall_pre_impl_extattr_set_file(                               \
+      (long long)(path), (long long)(attrnamespace), (long long)(attrname),    \
+      (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_set_file(res, path, attrnamespace,    \
+                                                  attrname, data, nbytes)      \
+  __sanitizer_syscall_post_impl_extattr_set_file(                              \
+      res, (long long)(path), (long long)(attrnamespace),                      \
+      (long long)(attrname), (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_pre_extattr_get_file(path, attrnamespace,          \
+                                                 attrname, data, nbytes)       \
+  __sanitizer_syscall_pre_impl_extattr_get_file(                               \
+      (long long)(path), (long long)(attrnamespace), (long long)(attrname),    \
+      (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_get_file(res, path, attrnamespace,    \
+                                                  attrname, data, nbytes)      \
+  __sanitizer_syscall_post_impl_extattr_get_file(                              \
+      res, (long long)(path), (long long)(attrnamespace),                      \
+      (long long)(attrname), (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_pre_extattr_delete_file(path, attrnamespace,       \
+                                                    attrname)                  \
+  __sanitizer_syscall_pre_impl_extattr_delete_file(                            \
+      (long long)(path), (long long)(attrnamespace), (long long)(attrname))
+#define __sanitizer_syscall_post_extattr_delete_file(res, path, attrnamespace, \
+                                                     attrname)                 \
+  __sanitizer_syscall_post_impl_extattr_delete_file(                           \
+      res, (long long)(path), (long long)(attrnamespace),                      \
+      (long long)(attrname))
+#define __sanitizer_syscall_pre_extattr_set_fd(fd, attrnamespace, attrname,    \
+                                               data, nbytes)                   \
+  __sanitizer_syscall_pre_impl_extattr_set_fd(                                 \
+      (long long)(fd), (long long)(attrnamespace), (long long)(attrname),      \
+      (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_set_fd(res, fd, attrnamespace,        \
+                                                attrname, data, nbytes)        \
+  __sanitizer_syscall_post_impl_extattr_set_fd(                                \
+      res, (long long)(fd), (long long)(attrnamespace), (long long)(attrname), \
+      (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_pre_extattr_get_fd(fd, attrnamespace, attrname,    \
+                                               data, nbytes)                   \
+  __sanitizer_syscall_pre_impl_extattr_get_fd(                                 \
+      (long long)(fd), (long long)(attrnamespace), (long long)(attrname),      \
+      (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_get_fd(res, fd, attrnamespace,        \
+                                                attrname, data, nbytes)        \
+  __sanitizer_syscall_post_impl_extattr_get_fd(                                \
+      res, (long long)(fd), (long long)(attrnamespace), (long long)(attrname), \
+      (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_pre_extattr_delete_fd(fd, attrnamespace, attrname) \
+  __sanitizer_syscall_pre_impl_extattr_delete_fd(                              \
+      (long long)(fd), (long long)(attrnamespace), (long long)(attrname))
+#define __sanitizer_syscall_post_extattr_delete_fd(res, fd, attrnamespace,     \
+                                                   attrname)                   \
+  __sanitizer_syscall_post_impl_extattr_delete_fd(                             \
+      res, (long long)(fd), (long long)(attrnamespace), (long long)(attrname))
+#define __sanitizer_syscall_pre_extattr_set_link(path, attrnamespace,          \
+                                                 attrname, data, nbytes)       \
+  __sanitizer_syscall_pre_impl_extattr_set_link(                               \
+      (long long)(path), (long long)(attrnamespace), (long long)(attrname),    \
+      (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_set_link(res, path, attrnamespace,    \
+                                                  attrname, data, nbytes)      \
+  __sanitizer_syscall_post_impl_extattr_set_link(                              \
+      res, (long long)(path), (long long)(attrnamespace),                      \
+      (long long)(attrname), (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_pre_extattr_get_link(path, attrnamespace,          \
+                                                 attrname, data, nbytes)       \
+  __sanitizer_syscall_pre_impl_extattr_get_link(                               \
+      (long long)(path), (long long)(attrnamespace), (long long)(attrname),    \
+      (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_get_link(res, path, attrnamespace,    \
+                                                  attrname, data, nbytes)      \
+  __sanitizer_syscall_post_impl_extattr_get_link(                              \
+      res, (long long)(path), (long long)(attrnamespace),                      \
+      (long long)(attrname), (long long)(data), (long long)(nbytes))
+#define __sanitizer_syscall_pre_extattr_delete_link(path, attrnamespace,       \
+                                                    attrname)                  \
+  __sanitizer_syscall_pre_impl_extattr_delete_link(                            \
+      (long long)(path), (long long)(attrnamespace), (long long)(attrname))
+#define __sanitizer_syscall_post_extattr_delete_link(res, path, attrnamespace, \
+                                                     attrname)                 \
+  __sanitizer_syscall_post_impl_extattr_delete_link(                           \
+      res, (long long)(path), (long long)(attrnamespace),                      \
+      (long long)(attrname))
+#define __sanitizer_syscall_pre_extattr_list_fd(fd, attrnamespace, data,       \
+                                                nbytes)                        \
+  __sanitizer_syscall_pre_impl_extattr_list_fd(                                \
+      (long long)(fd), (long long)(attrnamespace), (long long)(data),          \
+      (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_list_fd(res, fd, attrnamespace, data, \
+                                                 nbytes)                       \
+  __sanitizer_syscall_post_impl_extattr_list_fd(                               \
+      res, (long long)(fd), (long long)(attrnamespace), (long long)(data),     \
+      (long long)(nbytes))
+#define __sanitizer_syscall_pre_extattr_list_file(path, attrnamespace, data,   \
+                                                  nbytes)                      \
+  __sanitizer_syscall_pre_impl_extattr_list_file(                              \
+      (long long)(path), (long long)(attrnamespace), (long long)(data),        \
+      (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_list_file(res, path, attrnamespace,   \
+                                                   data, nbytes)               \
+  __sanitizer_syscall_post_impl_extattr_list_file(                             \
+      res, (long long)(path), (long long)(attrnamespace), (long long)(data),   \
+      (long long)(nbytes))
+#define __sanitizer_syscall_pre_extattr_list_link(path, attrnamespace, data,   \
+                                                  nbytes)                      \
+  __sanitizer_syscall_pre_impl_extattr_list_link(                              \
+      (long long)(path), (long long)(attrnamespace), (long long)(data),        \
+      (long long)(nbytes))
+#define __sanitizer_syscall_post_extattr_list_link(res, path, attrnamespace,   \
+                                                   data, nbytes)               \
+  __sanitizer_syscall_post_impl_extattr_list_link(                             \
+      res, (long long)(path), (long long)(attrnamespace), (long long)(data),   \
+      (long long)(nbytes))
+#define __sanitizer_syscall_pre_compat_50_pselect(nd, in, ou, ex, ts, mask)    \
+  __sanitizer_syscall_pre_impl_compat_50_pselect(                              \
+      (long long)(nd), (long long)(in), (long long)(ou), (long long)(ex),      \
+      (long long)(ts), (long long)(mask))
+#define __sanitizer_syscall_post_compat_50_pselect(res, nd, in, ou, ex, ts,    \
+                                                   mask)                       \
+  __sanitizer_syscall_post_impl_compat_50_pselect(                             \
+      res, (long long)(nd), (long long)(in), (long long)(ou), (long long)(ex), \
+      (long long)(ts), (long long)(mask))
+#define __sanitizer_syscall_pre_compat_50_pollts(fds, nfds, ts, mask)          \
+  __sanitizer_syscall_pre_impl_compat_50_pollts(                               \
+      (long long)(fds), (long long)(nfds), (long long)(ts), (long long)(mask))
+#define __sanitizer_syscall_post_compat_50_pollts(res, fds, nfds, ts, mask)    \
+  __sanitizer_syscall_post_impl_compat_50_pollts(                              \
+      res, (long long)(fds), (long long)(nfds), (long long)(ts),               \
+      (long long)(mask))
+#define __sanitizer_syscall_pre_setxattr(path, name, value, size, flags)       \
+  __sanitizer_syscall_pre_impl_setxattr((long long)(path), (long long)(name),  \
+                                        (long long)(value), (long long)(size), \
+                                        (long long)(flags))
+#define __sanitizer_syscall_post_setxattr(res, path, name, value, size, flags) \
+  __sanitizer_syscall_post_impl_setxattr(                                      \
+      res, (long long)(path), (long long)(name), (long long)(value),           \
+      (long long)(size), (long long)(flags))
+#define __sanitizer_syscall_pre_lsetxattr(path, name, value, size, flags)      \
+  __sanitizer_syscall_pre_impl_lsetxattr(                                      \
+      (long long)(path), (long long)(name), (long long)(value),                \
+      (long long)(size), (long long)(flags))
+#define __sanitizer_syscall_post_lsetxattr(res, path, name, value, size,       \
+                                           flags)                              \
+  __sanitizer_syscall_post_impl_lsetxattr(                                     \
+      res, (long long)(path), (long long)(name), (long long)(value),           \
+      (long long)(size), (long long)(flags))
+#define __sanitizer_syscall_pre_fsetxattr(fd, name, value, size, flags)        \
+  __sanitizer_syscall_pre_impl_fsetxattr(                                      \
+      (long long)(fd), (long long)(name), (long long)(value),                  \
+      (long long)(size), (long long)(flags))
+#define __sanitizer_syscall_post_fsetxattr(res, fd, name, value, size, flags)  \
+  __sanitizer_syscall_post_impl_fsetxattr(                                     \
+      res, (long long)(fd), (long long)(name), (long long)(value),             \
+      (long long)(size), (long long)(flags))
+#define __sanitizer_syscall_pre_getxattr(path, name, value, size)              \
+  __sanitizer_syscall_pre_impl_getxattr((long long)(path), (long long)(name),  \
+                                        (long long)(value), (long long)(size))
+#define __sanitizer_syscall_post_getxattr(res, path, name, value, size)        \
+  __sanitizer_syscall_post_impl_getxattr(                                      \
+      res, (long long)(path), (long long)(name), (long long)(value),           \
+      (long long)(size))
+#define __sanitizer_syscall_pre_lgetxattr(path, name, value, size)             \
+  __sanitizer_syscall_pre_impl_lgetxattr((long long)(path), (long long)(name), \
+                                         (long long)(value),                   \
+                                         (long long)(size))
+#define __sanitizer_syscall_post_lgetxattr(res, path, name, value, size)       \
+  __sanitizer_syscall_post_impl_lgetxattr(                                     \
+      res, (long long)(path), (long long)(name), (long long)(value),           \
+      (long long)(size))
+#define __sanitizer_syscall_pre_fgetxattr(fd, name, value, size)               \
+  __sanitizer_syscall_pre_impl_fgetxattr((long long)(fd), (long long)(name),   \
+                                         (long long)(value),                   \
+                                         (long long)(size))
+#define __sanitizer_syscall_post_fgetxattr(res, fd, name, value, size)         \
+  __sanitizer_syscall_post_impl_fgetxattr(                                     \
+      res, (long long)(fd), (long long)(name), (long long)(value),             \
+      (long long)(size))
+#define __sanitizer_syscall_pre_listxattr(path, list, size)                    \
+  __sanitizer_syscall_pre_impl_listxattr((long long)(path), (long long)(list), \
+                                         (long long)(size))
+#define __sanitizer_syscall_post_listxattr(res, path, list, size)              \
+  __sanitizer_syscall_post_impl_listxattr(                                     \
+      res, (long long)(path), (long long)(list), (long long)(size))
+#define __sanitizer_syscall_pre_llistxattr(path, list, size)                   \
+  __sanitizer_syscall_pre_impl_llistxattr(                                     \
+      (long long)(path), (long long)(list), (long long)(size))
+#define __sanitizer_syscall_post_llistxattr(res, path, list, size)             \
+  __sanitizer_syscall_post_impl_llistxattr(                                    \
+      res, (long long)(path), (long long)(list), (long long)(size))
+#define __sanitizer_syscall_pre_flistxattr(fd, list, size)                     \
+  __sanitizer_syscall_pre_impl_flistxattr((long long)(fd), (long long)(list),  \
+                                          (long long)(size))
+#define __sanitizer_syscall_post_flistxattr(res, fd, list, size)               \
+  __sanitizer_syscall_post_impl_flistxattr(                                    \
+      res, (long long)(fd), (long long)(list), (long long)(size))
+#define __sanitizer_syscall_pre_removexattr(path, name)                        \
+  __sanitizer_syscall_pre_impl_removexattr((long long)(path), (long long)(name))
+#define __sanitizer_syscall_post_removexattr(res, path, name)                  \
+  __sanitizer_syscall_post_impl_removexattr(res, (long long)(path),            \
+                                            (long long)(name))
+#define __sanitizer_syscall_pre_lremovexattr(path, name)                       \
+  __sanitizer_syscall_pre_impl_lremovexattr((long long)(path),                 \
+                                            (long long)(name))
+#define __sanitizer_syscall_post_lremovexattr(res, path, name)                 \
+  __sanitizer_syscall_post_impl_lremovexattr(res, (long long)(path),           \
+                                             (long long)(name))
+#define __sanitizer_syscall_pre_fremovexattr(fd, name)                         \
+  __sanitizer_syscall_pre_impl_fremovexattr((long long)(fd), (long long)(name))
+#define __sanitizer_syscall_post_fremovexattr(res, fd, name)                   \
+  __sanitizer_syscall_post_impl_fremovexattr(res, (long long)(fd),             \
+                                             (long long)(name))
+#define __sanitizer_syscall_pre_compat_50___stat30(path, ub)                   \
+  __sanitizer_syscall_pre_impl_compat_50___stat30((long long)(path),           \
+                                                  (long long)(ub))
+#define __sanitizer_syscall_post_compat_50___stat30(res, path, ub)             \
+  __sanitizer_syscall_post_impl_compat_50___stat30(res, (long long)(path),     \
+                                                   (long long)(ub))
+#define __sanitizer_syscall_pre_compat_50___fstat30(fd, sb)                    \
+  __sanitizer_syscall_pre_impl_compat_50___fstat30((long long)(fd),            \
+                                                   (long long)(sb))
+#define __sanitizer_syscall_post_compat_50___fstat30(res, fd, sb)              \
+  __sanitizer_syscall_post_impl_compat_50___fstat30(res, (long long)(fd),      \
+                                                    (long long)(sb))
+#define __sanitizer_syscall_pre_compat_50___lstat30(path, ub)                  \
+  __sanitizer_syscall_pre_impl_compat_50___lstat30((long long)(path),          \
+                                                   (long long)(ub))
+#define __sanitizer_syscall_post_compat_50___lstat30(res, path, ub)            \
+  __sanitizer_syscall_post_impl_compat_50___lstat30(res, (long long)(path),    \
+                                                    (long long)(ub))
+#define __sanitizer_syscall_pre___getdents30(fd, buf, count)                   \
+  __sanitizer_syscall_pre_impl___getdents30((long long)(fd), (long long)(buf), \
+                                            (long long)(count))
+#define __sanitizer_syscall_post___getdents30(res, fd, buf, count)             \
+  __sanitizer_syscall_post_impl___getdents30(                                  \
+      res, (long long)(fd), (long long)(buf), (long long)(count))
+#define __sanitizer_syscall_pre_posix_fadvise()                                \
+  __sanitizer_syscall_pre_impl_posix_fadvise((long long)())
+#define __sanitizer_syscall_post_posix_fadvise(res)                            \
+  __sanitizer_syscall_post_impl_posix_fadvise(res, (long long)())
+#define __sanitizer_syscall_pre_compat_30___fhstat30(fhp, sb)                  \
+  __sanitizer_syscall_pre_impl_compat_30___fhstat30((long long)(fhp),          \
+                                                    (long long)(sb))
+#define __sanitizer_syscall_post_compat_30___fhstat30(res, fhp, sb)            \
+  __sanitizer_syscall_post_impl_compat_30___fhstat30(res, (long long)(fhp),    \
+                                                     (long long)(sb))
+#define __sanitizer_syscall_pre_compat_50___ntp_gettime30(ntvp)                \
+  __sanitizer_syscall_pre_impl_compat_50___ntp_gettime30((long long)(ntvp))
+#define __sanitizer_syscall_post_compat_50___ntp_gettime30(res, ntvp)          \
+  __sanitizer_syscall_post_impl_compat_50___ntp_gettime30(res,                 \
+                                                          (long long)(ntvp))
+#define __sanitizer_syscall_pre___socket30(domain, type, protocol)             \
+  __sanitizer_syscall_pre_impl___socket30(                                     \
+      (long long)(domain), (long long)(type), (long long)(protocol))
+#define __sanitizer_syscall_post___socket30(res, domain, type, protocol)       \
+  __sanitizer_syscall_post_impl___socket30(                                    \
+      res, (long long)(domain), (long long)(type), (long long)(protocol))
+#define __sanitizer_syscall_pre___getfh30(fname, fhp, fh_size)                 \
+  __sanitizer_syscall_pre_impl___getfh30((long long)(fname), (long long)(fhp), \
+                                         (long long)(fh_size))
+#define __sanitizer_syscall_post___getfh30(res, fname, fhp, fh_size)           \
+  __sanitizer_syscall_post_impl___getfh30(                                     \
+      res, (long long)(fname), (long long)(fhp), (long long)(fh_size))
+#define __sanitizer_syscall_pre___fhopen40(fhp, fh_size, flags)                \
+  __sanitizer_syscall_pre_impl___fhopen40(                                     \
+      (long long)(fhp), (long long)(fh_size), (long long)(flags))
+#define __sanitizer_syscall_post___fhopen40(res, fhp, fh_size, flags)          \
+  __sanitizer_syscall_post_impl___fhopen40(                                    \
+      res, (long long)(fhp), (long long)(fh_size), (long long)(flags))
+#define __sanitizer_syscall_pre___fhstatvfs140(fhp, fh_size, buf, flags)       \
+  __sanitizer_syscall_pre_impl___fhstatvfs140(                                 \
+      (long long)(fhp), (long long)(fh_size), (long long)(buf),                \
+      (long long)(flags))
+#define __sanitizer_syscall_post___fhstatvfs140(res, fhp, fh_size, buf, flags) \
+  __sanitizer_syscall_post_impl___fhstatvfs140(                                \
+      res, (long long)(fhp), (long long)(fh_size), (long long)(buf),           \
+      (long long)(flags))
+#define __sanitizer_syscall_pre_compat_50___fhstat40(fhp, fh_size, sb)         \
+  __sanitizer_syscall_pre_impl_compat_50___fhstat40(                           \
+      (long long)(fhp), (long long)(fh_size), (long long)(sb))
+#define __sanitizer_syscall_post_compat_50___fhstat40(res, fhp, fh_size, sb)   \
+  __sanitizer_syscall_post_impl_compat_50___fhstat40(                          \
+      res, (long long)(fhp), (long long)(fh_size), (long long)(sb))
+#define __sanitizer_syscall_pre_aio_cancel(fildes, aiocbp)                     \
+  __sanitizer_syscall_pre_impl_aio_cancel((long long)(fildes),                 \
+                                          (long long)(aiocbp))
+#define __sanitizer_syscall_post_aio_cancel(res, fildes, aiocbp)               \
+  __sanitizer_syscall_post_impl_aio_cancel(res, (long long)(fildes),           \
+                                           (long long)(aiocbp))
+#define __sanitizer_syscall_pre_aio_error(aiocbp)                              \
+  __sanitizer_syscall_pre_impl_aio_error((long long)(aiocbp))
+#define __sanitizer_syscall_post_aio_error(res, aiocbp)                        \
+  __sanitizer_syscall_post_impl_aio_error(res, (long long)(aiocbp))
+#define __sanitizer_syscall_pre_aio_fsync(op, aiocbp)                          \
+  __sanitizer_syscall_pre_impl_aio_fsync((long long)(op), (long long)(aiocbp))
+#define __sanitizer_syscall_post_aio_fsync(res, op, aiocbp)                    \
+  __sanitizer_syscall_post_impl_aio_fsync(res, (long long)(op),                \
+                                          (long long)(aiocbp))
+#define __sanitizer_syscall_pre_aio_read(aiocbp)                               \
+  __sanitizer_syscall_pre_impl_aio_read((long long)(aiocbp))
+#define __sanitizer_syscall_post_aio_read(res, aiocbp)                         \
+  __sanitizer_syscall_post_impl_aio_read(res, (long long)(aiocbp))
+#define __sanitizer_syscall_pre_aio_return(aiocbp)                             \
+  __sanitizer_syscall_pre_impl_aio_return((long long)(aiocbp))
+#define __sanitizer_syscall_post_aio_return(res, aiocbp)                       \
+  __sanitizer_syscall_post_impl_aio_return(res, (long long)(aiocbp))
+#define __sanitizer_syscall_pre_compat_50_aio_suspend(list, nent, timeout)     \
+  __sanitizer_syscall_pre_impl_compat_50_aio_suspend(                          \
+      (long long)(list), (long long)(nent), (long long)(timeout))
+#define __sanitizer_syscall_post_compat_50_aio_suspend(res, list, nent,        \
+                                                       timeout)                \
+  __sanitizer_syscall_post_impl_compat_50_aio_suspend(                         \
+      res, (long long)(list), (long long)(nent), (long long)(timeout))
+#define __sanitizer_syscall_pre_aio_write(aiocbp)                              \
+  __sanitizer_syscall_pre_impl_aio_write((long long)(aiocbp))
+#define __sanitizer_syscall_post_aio_write(res, aiocbp)                        \
+  __sanitizer_syscall_post_impl_aio_write(res, (long long)(aiocbp))
+#define __sanitizer_syscall_pre_lio_listio(mode, list, nent, sig)              \
+  __sanitizer_syscall_pre_impl_lio_listio((long long)(mode),                   \
+                                          (long long)(list),                   \
+                                          (long long)(nent), (long long)(sig))
+#define __sanitizer_syscall_post_lio_listio(res, mode, list, nent, sig)        \
+  __sanitizer_syscall_post_impl_lio_listio(                                    \
+      res, (long long)(mode), (long long)(list), (long long)(nent),            \
+      (long long)(sig))
+/* syscall 407 has been skipped */
+/* syscall 408 has been skipped */
+/* syscall 409 has been skipped */
+#define __sanitizer_syscall_pre___mount50(type, path, flags, data, data_len)   \
+  __sanitizer_syscall_pre_impl___mount50(                                      \
+      (long long)(type), (long long)(path), (long long)(flags),                \
+      (long long)(data), (long long)(data_len))
+#define __sanitizer_syscall_post___mount50(res, type, path, flags, data,       \
+                                           data_len)                           \
+  __sanitizer_syscall_post_impl___mount50(                                     \
+      res, (long long)(type), (long long)(path), (long long)(flags),           \
+      (long long)(data), (long long)(data_len))
+#define __sanitizer_syscall_pre_mremap(old_address, old_size, new_address,     \
+                                       new_size, flags)                        \
+  __sanitizer_syscall_pre_impl_mremap(                                         \
+      (long long)(old_address), (long long)(old_size),                         \
+      (long long)(new_address), (long long)(new_size), (long long)(flags))
+#define __sanitizer_syscall_post_mremap(res, old_address, old_size,            \
+                                        new_address, new_size, flags)          \
+  __sanitizer_syscall_post_impl_mremap(                                        \
+      res, (long long)(old_address), (long long)(old_size),                    \
+      (long long)(new_address), (long long)(new_size), (long long)(flags))
+#define __sanitizer_syscall_pre_pset_create(psid)                              \
+  __sanitizer_syscall_pre_impl_pset_create((long long)(psid))
+#define __sanitizer_syscall_post_pset_create(res, psid)                        \
+  __sanitizer_syscall_post_impl_pset_create(res, (long long)(psid))
+#define __sanitizer_syscall_pre_pset_destroy(psid)                             \
+  __sanitizer_syscall_pre_impl_pset_destroy((long long)(psid))
+#define __sanitizer_syscall_post_pset_destroy(res, psid)                       \
+  __sanitizer_syscall_post_impl_pset_destroy(res, (long long)(psid))
+#define __sanitizer_syscall_pre_pset_assign(psid, cpuid, opsid)                \
+  __sanitizer_syscall_pre_impl_pset_assign(                                    \
+      (long long)(psid), (long long)(cpuid), (long long)(opsid))
+#define __sanitizer_syscall_post_pset_assign(res, psid, cpuid, opsid)          \
+  __sanitizer_syscall_post_impl_pset_assign(                                   \
+      res, (long long)(psid), (long long)(cpuid), (long long)(opsid))
+#define __sanitizer_syscall_pre__pset_bind(idtype, first_id, second_id, psid,  \
+                                           opsid)                              \
+  __sanitizer_syscall_pre_impl__pset_bind(                                     \
+      (long long)(idtype), (long long)(first_id), (long long)(second_id),      \
+      (long long)(psid), (long long)(opsid))
+#define __sanitizer_syscall_post__pset_bind(res, idtype, first_id, second_id,  \
+                                            psid, opsid)                       \
+  __sanitizer_syscall_post_impl__pset_bind(                                    \
+      res, (long long)(idtype), (long long)(first_id), (long long)(second_id), \
+      (long long)(psid), (long long)(opsid))
+#define __sanitizer_syscall_pre___posix_fadvise50(fd, PAD, offset, len,        \
+                                                  advice)                      \
+  __sanitizer_syscall_pre_impl___posix_fadvise50(                              \
+      (long long)(fd), (long long)(PAD), (long long)(offset),                  \
+      (long long)(len), (long long)(advice))
+#define __sanitizer_syscall_post___posix_fadvise50(res, fd, PAD, offset, len,  \
+                                                   advice)                     \
+  __sanitizer_syscall_post_impl___posix_fadvise50(                             \
+      res, (long long)(fd), (long long)(PAD), (long long)(offset),             \
+      (long long)(len), (long long)(advice))
+#define __sanitizer_syscall_pre___select50(nd, in, ou, ex, tv)                 \
+  __sanitizer_syscall_pre_impl___select50((long long)(nd), (long long)(in),    \
+                                          (long long)(ou), (long long)(ex),    \
+                                          (long long)(tv))
+#define __sanitizer_syscall_post___select50(res, nd, in, ou, ex, tv)           \
+  __sanitizer_syscall_post_impl___select50(res, (long long)(nd),               \
+                                           (long long)(in), (long long)(ou),   \
+                                           (long long)(ex), (long long)(tv))
+#define __sanitizer_syscall_pre___gettimeofday50(tp, tzp)                      \
+  __sanitizer_syscall_pre_impl___gettimeofday50((long long)(tp),               \
+                                                (long long)(tzp))
+#define __sanitizer_syscall_post___gettimeofday50(res, tp, tzp)                \
+  __sanitizer_syscall_post_impl___gettimeofday50(res, (long long)(tp),         \
+                                                 (long long)(tzp))
+#define __sanitizer_syscall_pre___settimeofday50(tv, tzp)                      \
+  __sanitizer_syscall_pre_impl___settimeofday50((long long)(tv),               \
+                                                (long long)(tzp))
+#define __sanitizer_syscall_post___settimeofday50(res, tv, tzp)                \
+  __sanitizer_syscall_post_impl___settimeofday50(res, (long long)(tv),         \
+                                                 (long long)(tzp))
+#define __sanitizer_syscall_pre___utimes50(path, tptr)                         \
+  __sanitizer_syscall_pre_impl___utimes50((long long)(path), (long long)(tptr))
+#define __sanitizer_syscall_post___utimes50(res, path, tptr)                   \
+  __sanitizer_syscall_post_impl___utimes50(res, (long long)(path),             \
+                                           (long long)(tptr))
+#define __sanitizer_syscall_pre___adjtime50(delta, olddelta)                   \
+  __sanitizer_syscall_pre_impl___adjtime50((long long)(delta),                 \
+                                           (long long)(olddelta))
+#define __sanitizer_syscall_post___adjtime50(res, delta, olddelta)             \
+  __sanitizer_syscall_post_impl___adjtime50(res, (long long)(delta),           \
+                                            (long long)(olddelta))
+#define __sanitizer_syscall_pre___lfs_segwait50(fsidp, tv)                     \
+  __sanitizer_syscall_pre_impl___lfs_segwait50((long long)(fsidp),             \
+                                               (long long)(tv))
+#define __sanitizer_syscall_post___lfs_segwait50(res, fsidp, tv)               \
+  __sanitizer_syscall_post_impl___lfs_segwait50(res, (long long)(fsidp),       \
+                                                (long long)(tv))
+#define __sanitizer_syscall_pre___futimes50(fd, tptr)                          \
+  __sanitizer_syscall_pre_impl___futimes50((long long)(fd), (long long)(tptr))
+#define __sanitizer_syscall_post___futimes50(res, fd, tptr)                    \
+  __sanitizer_syscall_post_impl___futimes50(res, (long long)(fd),              \
+                                            (long long)(tptr))
+#define __sanitizer_syscall_pre___lutimes50(path, tptr)                        \
+  __sanitizer_syscall_pre_impl___lutimes50((long long)(path), (long long)(tptr))
+#define __sanitizer_syscall_post___lutimes50(res, path, tptr)                  \
+  __sanitizer_syscall_post_impl___lutimes50(res, (long long)(path),            \
+                                            (long long)(tptr))
+#define __sanitizer_syscall_pre___setitimer50(which, itv, oitv)                \
+  __sanitizer_syscall_pre_impl___setitimer50(                                  \
+      (long long)(which), (long long)(itv), (long long)(oitv))
+#define __sanitizer_syscall_post___setitimer50(res, which, itv, oitv)          \
+  __sanitizer_syscall_post_impl___setitimer50(                                 \
+      res, (long long)(which), (long long)(itv), (long long)(oitv))
+#define __sanitizer_syscall_pre___getitimer50(which, itv)                      \
+  __sanitizer_syscall_pre_impl___getitimer50((long long)(which),               \
+                                             (long long)(itv))
+#define __sanitizer_syscall_post___getitimer50(res, which, itv)                \
+  __sanitizer_syscall_post_impl___getitimer50(res, (long long)(which),         \
+                                              (long long)(itv))
+#define __sanitizer_syscall_pre___clock_gettime50(clock_id, tp)                \
+  __sanitizer_syscall_pre_impl___clock_gettime50((long long)(clock_id),        \
+                                                 (long long)(tp))
+#define __sanitizer_syscall_post___clock_gettime50(res, clock_id, tp)          \
+  __sanitizer_syscall_post_impl___clock_gettime50(res, (long long)(clock_id),  \
+                                                  (long long)(tp))
+#define __sanitizer_syscall_pre___clock_settime50(clock_id, tp)                \
+  __sanitizer_syscall_pre_impl___clock_settime50((long long)(clock_id),        \
+                                                 (long long)(tp))
+#define __sanitizer_syscall_post___clock_settime50(res, clock_id, tp)          \
+  __sanitizer_syscall_post_impl___clock_settime50(res, (long long)(clock_id),  \
+                                                  (long long)(tp))
+#define __sanitizer_syscall_pre___clock_getres50(clock_id, tp)                 \
+  __sanitizer_syscall_pre_impl___clock_getres50((long long)(clock_id),         \
+                                                (long long)(tp))
+#define __sanitizer_syscall_post___clock_getres50(res, clock_id, tp)           \
+  __sanitizer_syscall_post_impl___clock_getres50(res, (long long)(clock_id),   \
+                                                 (long long)(tp))
+#define __sanitizer_syscall_pre___nanosleep50(rqtp, rmtp)                      \
+  __sanitizer_syscall_pre_impl___nanosleep50((long long)(rqtp),                \
+                                             (long long)(rmtp))
+#define __sanitizer_syscall_post___nanosleep50(res, rqtp, rmtp)                \
+  __sanitizer_syscall_post_impl___nanosleep50(res, (long long)(rqtp),          \
+                                              (long long)(rmtp))
+#define __sanitizer_syscall_pre_____sigtimedwait50(set, info, timeout)         \
+  __sanitizer_syscall_pre_impl_____sigtimedwait50(                             \
+      (long long)(set), (long long)(info), (long long)(timeout))
+#define __sanitizer_syscall_post_____sigtimedwait50(res, set, info, timeout)   \
+  __sanitizer_syscall_post_impl_____sigtimedwait50(                            \
+      res, (long long)(set), (long long)(info), (long long)(timeout))
+#define __sanitizer_syscall_pre___mq_timedsend50(mqdes, msg_ptr, msg_len,      \
+                                                 msg_prio, abs_timeout)        \
+  __sanitizer_syscall_pre_impl___mq_timedsend50(                               \
+      (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),          \
+      (long long)(msg_prio), (long long)(abs_timeout))
+#define __sanitizer_syscall_post___mq_timedsend50(                             \
+    res, mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)                       \
+  __sanitizer_syscall_post_impl___mq_timedsend50(                              \
+      res, (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),     \
+      (long long)(msg_prio), (long long)(abs_timeout))
+#define __sanitizer_syscall_pre___mq_timedreceive50(mqdes, msg_ptr, msg_len,   \
+                                                    msg_prio, abs_timeout)     \
+  __sanitizer_syscall_pre_impl___mq_timedreceive50(                            \
+      (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),          \
+      (long long)(msg_prio), (long long)(abs_timeout))
+#define __sanitizer_syscall_post___mq_timedreceive50(                          \
+    res, mqdes, msg_ptr, msg_len, msg_prio, abs_timeout)                       \
+  __sanitizer_syscall_post_impl___mq_timedreceive50(                           \
+      res, (long long)(mqdes), (long long)(msg_ptr), (long long)(msg_len),     \
+      (long long)(msg_prio), (long long)(abs_timeout))
+#define __sanitizer_syscall_pre_compat_60__lwp_park(ts, unpark, hint,          \
+                                                    unparkhint)                \
+  __sanitizer_syscall_pre_impl_compat_60__lwp_park(                            \
+      (long long)(ts), (long long)(unpark), (long long)(hint),                 \
+      (long long)(unparkhint))
+#define __sanitizer_syscall_post_compat_60__lwp_park(res, ts, unpark, hint,    \
+                                                     unparkhint)               \
+  __sanitizer_syscall_post_impl_compat_60__lwp_park(                           \
+      res, (long long)(ts), (long long)(unpark), (long long)(hint),            \
+      (long long)(unparkhint))
+#define __sanitizer_syscall_pre___kevent50(fd, changelist, nchanges,           \
+                                           eventlist, nevents, timeout)        \
+  __sanitizer_syscall_pre_impl___kevent50(                                     \
+      (long long)(fd), (long long)(changelist), (long long)(nchanges),         \
+      (long long)(eventlist), (long long)(nevents), (long long)(timeout))
+#define __sanitizer_syscall_post___kevent50(res, fd, changelist, nchanges,     \
+                                            eventlist, nevents, timeout)       \
+  __sanitizer_syscall_post_impl___kevent50(                                    \
+      res, (long long)(fd), (long long)(changelist), (long long)(nchanges),    \
+      (long long)(eventlist), (long long)(nevents), (long long)(timeout))
+#define __sanitizer_syscall_pre___pselect50(nd, in, ou, ex, ts, mask)          \
+  __sanitizer_syscall_pre_impl___pselect50((long long)(nd), (long long)(in),   \
+                                           (long long)(ou), (long long)(ex),   \
+                                           (long long)(ts), (long long)(mask))
+#define __sanitizer_syscall_post___pselect50(res, nd, in, ou, ex, ts, mask)    \
+  __sanitizer_syscall_post_impl___pselect50(                                   \
+      res, (long long)(nd), (long long)(in), (long long)(ou), (long long)(ex), \
+      (long long)(ts), (long long)(mask))
+#define __sanitizer_syscall_pre___pollts50(fds, nfds, ts, mask)                \
+  __sanitizer_syscall_pre_impl___pollts50((long long)(fds), (long long)(nfds), \
+                                          (long long)(ts), (long long)(mask))
+#define __sanitizer_syscall_post___pollts50(res, fds, nfds, ts, mask)          \
+  __sanitizer_syscall_post_impl___pollts50(res, (long long)(fds),              \
+                                           (long long)(nfds), (long long)(ts), \
+                                           (long long)(mask))
+#define __sanitizer_syscall_pre___aio_suspend50(list, nent, timeout)           \
+  __sanitizer_syscall_pre_impl___aio_suspend50(                                \
+      (long long)(list), (long long)(nent), (long long)(timeout))
+#define __sanitizer_syscall_post___aio_suspend50(res, list, nent, timeout)     \
+  __sanitizer_syscall_post_impl___aio_suspend50(                               \
+      res, (long long)(list), (long long)(nent), (long long)(timeout))
+#define __sanitizer_syscall_pre___stat50(path, ub)                             \
+  __sanitizer_syscall_pre_impl___stat50((long long)(path), (long long)(ub))
+#define __sanitizer_syscall_post___stat50(res, path, ub)                       \
+  __sanitizer_syscall_post_impl___stat50(res, (long long)(path),               \
+                                         (long long)(ub))
+#define __sanitizer_syscall_pre___fstat50(fd, sb)                              \
+  __sanitizer_syscall_pre_impl___fstat50((long long)(fd), (long long)(sb))
+#define __sanitizer_syscall_post___fstat50(res, fd, sb)                        \
+  __sanitizer_syscall_post_impl___fstat50(res, (long long)(fd), (long long)(sb))
+#define __sanitizer_syscall_pre___lstat50(path, ub)                            \
+  __sanitizer_syscall_pre_impl___lstat50((long long)(path), (long long)(ub))
+#define __sanitizer_syscall_post___lstat50(res, path, ub)                      \
+  __sanitizer_syscall_post_impl___lstat50(res, (long long)(path),              \
+                                          (long long)(ub))
+#define __sanitizer_syscall_pre_____semctl50(semid, semnum, cmd, arg)          \
+  __sanitizer_syscall_pre_impl_____semctl50(                                   \
+      (long long)(semid), (long long)(semnum), (long long)(cmd),               \
+      (long long)(arg))
+#define __sanitizer_syscall_post_____semctl50(res, semid, semnum, cmd, arg)    \
+  __sanitizer_syscall_post_impl_____semctl50(                                  \
+      res, (long long)(semid), (long long)(semnum), (long long)(cmd),          \
+      (long long)(arg))
+#define __sanitizer_syscall_pre___shmctl50(shmid, cmd, buf)                    \
+  __sanitizer_syscall_pre_impl___shmctl50((long long)(shmid),                  \
+                                          (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_post___shmctl50(res, shmid, cmd, buf)              \
+  __sanitizer_syscall_post_impl___shmctl50(res, (long long)(shmid),            \
+                                           (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_pre___msgctl50(msqid, cmd, buf)                    \
+  __sanitizer_syscall_pre_impl___msgctl50((long long)(msqid),                  \
+                                          (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_post___msgctl50(res, msqid, cmd, buf)              \
+  __sanitizer_syscall_post_impl___msgctl50(res, (long long)(msqid),            \
+                                           (long long)(cmd), (long long)(buf))
+#define __sanitizer_syscall_pre___getrusage50(who, rusage)                     \
+  __sanitizer_syscall_pre_impl___getrusage50((long long)(who),                 \
+                                             (long long)(rusage))
+#define __sanitizer_syscall_post___getrusage50(res, who, rusage)               \
+  __sanitizer_syscall_post_impl___getrusage50(res, (long long)(who),           \
+                                              (long long)(rusage))
+#define __sanitizer_syscall_pre___timer_settime50(timerid, flags, value,       \
+                                                  ovalue)                      \
+  __sanitizer_syscall_pre_impl___timer_settime50(                              \
+      (long long)(timerid), (long long)(flags), (long long)(value),            \
+      (long long)(ovalue))
+#define __sanitizer_syscall_post___timer_settime50(res, timerid, flags, value, \
+                                                   ovalue)                     \
+  __sanitizer_syscall_post_impl___timer_settime50(                             \
+      res, (long long)(timerid), (long long)(flags), (long long)(value),       \
+      (long long)(ovalue))
+#define __sanitizer_syscall_pre___timer_gettime50(timerid, value)              \
+  __sanitizer_syscall_pre_impl___timer_gettime50((long long)(timerid),         \
+                                                 (long long)(value))
+#define __sanitizer_syscall_post___timer_gettime50(res, timerid, value)        \
+  __sanitizer_syscall_post_impl___timer_gettime50(res, (long long)(timerid),   \
+                                                  (long long)(value))
+#if defined(NTP) || !defined(_KERNEL_OPT)
+#define __sanitizer_syscall_pre___ntp_gettime50(ntvp)                          \
+  __sanitizer_syscall_pre_impl___ntp_gettime50((long long)(ntvp))
+#define __sanitizer_syscall_post___ntp_gettime50(res, ntvp)                    \
+  __sanitizer_syscall_post_impl___ntp_gettime50(res, (long long)(ntvp))
+#else
+/* syscall 448 has been skipped */
+#endif
+#define __sanitizer_syscall_pre___wait450(pid, status, options, rusage)        \
+  __sanitizer_syscall_pre_impl___wait450(                                      \
+      (long long)(pid), (long long)(status), (long long)(options),             \
+      (long long)(rusage))
+#define __sanitizer_syscall_post___wait450(res, pid, status, options, rusage)  \
+  __sanitizer_syscall_post_impl___wait450(                                     \
+      res, (long long)(pid), (long long)(status), (long long)(options),        \
+      (long long)(rusage))
+#define __sanitizer_syscall_pre___mknod50(path, mode, dev)                     \
+  __sanitizer_syscall_pre_impl___mknod50((long long)(path), (long long)(mode), \
+                                         (long long)(dev))
+#define __sanitizer_syscall_post___mknod50(res, path, mode, dev)               \
+  __sanitizer_syscall_post_impl___mknod50(res, (long long)(path),              \
+                                          (long long)(mode), (long long)(dev))
+#define __sanitizer_syscall_pre___fhstat50(fhp, fh_size, sb)                   \
+  __sanitizer_syscall_pre_impl___fhstat50(                                     \
+      (long long)(fhp), (long long)(fh_size), (long long)(sb))
+#define __sanitizer_syscall_post___fhstat50(res, fhp, fh_size, sb)             \
+  __sanitizer_syscall_post_impl___fhstat50(                                    \
+      res, (long long)(fhp), (long long)(fh_size), (long long)(sb))
+/* syscall 452 has been skipped */
+#define __sanitizer_syscall_pre_pipe2(fildes, flags)                           \
+  __sanitizer_syscall_pre_impl_pipe2((long long)(fildes), (long long)(flags))
+#define __sanitizer_syscall_post_pipe2(res, fildes, flags)                     \
+  __sanitizer_syscall_post_impl_pipe2(res, (long long)(fildes),                \
+                                      (long long)(flags))
+#define __sanitizer_syscall_pre_dup3(from, to, flags)                          \
+  __sanitizer_syscall_pre_impl_dup3((long long)(from), (long long)(to),        \
+                                    (long long)(flags))
+#define __sanitizer_syscall_post_dup3(res, from, to, flags)                    \
+  __sanitizer_syscall_post_impl_dup3(res, (long long)(from), (long long)(to),  \
+                                     (long long)(flags))
+#define __sanitizer_syscall_pre_kqueue1(flags)                                 \
+  __sanitizer_syscall_pre_impl_kqueue1((long long)(flags))
+#define __sanitizer_syscall_post_kqueue1(res, flags)                           \
+  __sanitizer_syscall_post_impl_kqueue1(res, (long long)(flags))
+#define __sanitizer_syscall_pre_paccept(s, name, anamelen, mask, flags)        \
+  __sanitizer_syscall_pre_impl_paccept((long long)(s), (long long)(name),      \
+                                       (long long)(anamelen),                  \
+                                       (long long)(mask), (long long)(flags))
+#define __sanitizer_syscall_post_paccept(res, s, name, anamelen, mask, flags)  \
+  __sanitizer_syscall_post_impl_paccept(                                       \
+      res, (long long)(s), (long long)(name), (long long)(anamelen),           \
+      (long long)(mask), (long long)(flags))
+#define __sanitizer_syscall_pre_linkat(fd1, name1, fd2, name2, flags)          \
+  __sanitizer_syscall_pre_impl_linkat((long long)(fd1), (long long)(name1),    \
+                                      (long long)(fd2), (long long)(name2),    \
+                                      (long long)(flags))
+#define __sanitizer_syscall_post_linkat(res, fd1, name1, fd2, name2, flags)    \
+  __sanitizer_syscall_post_impl_linkat(res, (long long)(fd1),                  \
+                                       (long long)(name1), (long long)(fd2),   \
+                                       (long long)(name2), (long long)(flags))
+#define __sanitizer_syscall_pre_renameat(fromfd, from, tofd, to)               \
+  __sanitizer_syscall_pre_impl_renameat((long long)(fromfd),                   \
+                                        (long long)(from), (long long)(tofd),  \
+                                        (long long)(to))
+#define __sanitizer_syscall_post_renameat(res, fromfd, from, tofd, to)         \
+  __sanitizer_syscall_post_impl_renameat(res, (long long)(fromfd),             \
+                                         (long long)(from), (long long)(tofd), \
+                                         (long long)(to))
+#define __sanitizer_syscall_pre_mkfifoat(fd, path, mode)                       \
+  __sanitizer_syscall_pre_impl_mkfifoat((long long)(fd), (long long)(path),    \
+                                        (long long)(mode))
+#define __sanitizer_syscall_post_mkfifoat(res, fd, path, mode)                 \
+  __sanitizer_syscall_post_impl_mkfifoat(res, (long long)(fd),                 \
+                                         (long long)(path), (long long)(mode))
+#define __sanitizer_syscall_pre_mknodat(fd, path, mode, PAD, dev)              \
+  __sanitizer_syscall_pre_impl_mknodat((long long)(fd), (long long)(path),     \
+                                       (long long)(mode), (long long)(PAD),    \
+                                       (long long)(dev))
+#define __sanitizer_syscall_post_mknodat(res, fd, path, mode, PAD, dev)        \
+  __sanitizer_syscall_post_impl_mknodat(res, (long long)(fd),                  \
+                                        (long long)(path), (long long)(mode),  \
+                                        (long long)(PAD), (long long)(dev))
+#define __sanitizer_syscall_pre_mkdirat(fd, path, mode)                        \
+  __sanitizer_syscall_pre_impl_mkdirat((long long)(fd), (long long)(path),     \
+                                       (long long)(mode))
+#define __sanitizer_syscall_post_mkdirat(res, fd, path, mode)                  \
+  __sanitizer_syscall_post_impl_mkdirat(res, (long long)(fd),                  \
+                                        (long long)(path), (long long)(mode))
+#define __sanitizer_syscall_pre_faccessat(fd, path, amode, flag)               \
+  __sanitizer_syscall_pre_impl_faccessat((long long)(fd), (long long)(path),   \
+                                         (long long)(amode),                   \
+                                         (long long)(flag))
+#define __sanitizer_syscall_post_faccessat(res, fd, path, amode, flag)         \
+  __sanitizer_syscall_post_impl_faccessat(                                     \
+      res, (long long)(fd), (long long)(path), (long long)(amode),             \
+      (long long)(flag))
+#define __sanitizer_syscall_pre_fchmodat(fd, path, mode, flag)                 \
+  __sanitizer_syscall_pre_impl_fchmodat((long long)(fd), (long long)(path),    \
+                                        (long long)(mode), (long long)(flag))
+#define __sanitizer_syscall_post_fchmodat(res, fd, path, mode, flag)           \
+  __sanitizer_syscall_post_impl_fchmodat(res, (long long)(fd),                 \
+                                         (long long)(path), (long long)(mode), \
+                                         (long long)(flag))
+#define __sanitizer_syscall_pre_fchownat(fd, path, owner, group, flag)         \
+  __sanitizer_syscall_pre_impl_fchownat((long long)(fd), (long long)(path),    \
+                                        (long long)(owner),                    \
+                                        (long long)(group), (long long)(flag))
+#define __sanitizer_syscall_post_fchownat(res, fd, path, owner, group, flag)   \
+  __sanitizer_syscall_post_impl_fchownat(                                      \
+      res, (long long)(fd), (long long)(path), (long long)(owner),             \
+      (long long)(group), (long long)(flag))
+#define __sanitizer_syscall_pre_fexecve(fd, argp, envp)                        \
+  __sanitizer_syscall_pre_impl_fexecve((long long)(fd), (long long)(argp),     \
+                                       (long long)(envp))
+#define __sanitizer_syscall_post_fexecve(res, fd, argp, envp)                  \
+  __sanitizer_syscall_post_impl_fexecve(res, (long long)(fd),                  \
+                                        (long long)(argp), (long long)(envp))
+#define __sanitizer_syscall_pre_fstatat(fd, path, buf, flag)                   \
+  __sanitizer_syscall_pre_impl_fstatat((long long)(fd), (long long)(path),     \
+                                       (long long)(buf), (long long)(flag))
+#define __sanitizer_syscall_post_fstatat(res, fd, path, buf, flag)             \
+  __sanitizer_syscall_post_impl_fstatat(res, (long long)(fd),                  \
+                                        (long long)(path), (long long)(buf),   \
+                                        (long long)(flag))
+#define __sanitizer_syscall_pre_utimensat(fd, path, tptr, flag)                \
+  __sanitizer_syscall_pre_impl_utimensat((long long)(fd), (long long)(path),   \
+                                         (long long)(tptr), (long long)(flag))
+#define __sanitizer_syscall_post_utimensat(res, fd, path, tptr, flag)          \
+  __sanitizer_syscall_post_impl_utimensat(                                     \
+      res, (long long)(fd), (long long)(path), (long long)(tptr),              \
+      (long long)(flag))
+#define __sanitizer_syscall_pre_openat(fd, path, oflags, mode)                 \
+  __sanitizer_syscall_pre_impl_openat((long long)(fd), (long long)(path),      \
+                                      (long long)(oflags), (long long)(mode))
+#define __sanitizer_syscall_post_openat(res, fd, path, oflags, mode)           \
+  __sanitizer_syscall_post_impl_openat(res, (long long)(fd),                   \
+                                       (long long)(path), (long long)(oflags), \
+                                       (long long)(mode))
+#define __sanitizer_syscall_pre_readlinkat(fd, path, buf, bufsize)             \
+  __sanitizer_syscall_pre_impl_readlinkat((long long)(fd), (long long)(path),  \
+                                          (long long)(buf),                    \
+                                          (long long)(bufsize))
+#define __sanitizer_syscall_post_readlinkat(res, fd, path, buf, bufsize)       \
+  __sanitizer_syscall_post_impl_readlinkat(                                    \
+      res, (long long)(fd), (long long)(path), (long long)(buf),               \
+      (long long)(bufsize))
+#define __sanitizer_syscall_pre_symlinkat(path1, fd, path2)                    \
+  __sanitizer_syscall_pre_impl_symlinkat((long long)(path1), (long long)(fd),  \
+                                         (long long)(path2))
+#define __sanitizer_syscall_post_symlinkat(res, path1, fd, path2)              \
+  __sanitizer_syscall_post_impl_symlinkat(res, (long long)(path1),             \
+                                          (long long)(fd), (long long)(path2))
+#define __sanitizer_syscall_pre_unlinkat(fd, path, flag)                       \
+  __sanitizer_syscall_pre_impl_unlinkat((long long)(fd), (long long)(path),    \
+                                        (long long)(flag))
+#define __sanitizer_syscall_post_unlinkat(res, fd, path, flag)                 \
+  __sanitizer_syscall_post_impl_unlinkat(res, (long long)(fd),                 \
+                                         (long long)(path), (long long)(flag))
+#define __sanitizer_syscall_pre_futimens(fd, tptr)                             \
+  __sanitizer_syscall_pre_impl_futimens((long long)(fd), (long long)(tptr))
+#define __sanitizer_syscall_post_futimens(res, fd, tptr)                       \
+  __sanitizer_syscall_post_impl_futimens(res, (long long)(fd),                 \
+                                         (long long)(tptr))
+#define __sanitizer_syscall_pre___quotactl(path, args)                         \
+  __sanitizer_syscall_pre_impl___quotactl((long long)(path), (long long)(args))
+#define __sanitizer_syscall_post___quotactl(res, path, args)                   \
+  __sanitizer_syscall_post_impl___quotactl(res, (long long)(path),             \
+                                           (long long)(args))
+#define __sanitizer_syscall_pre_posix_spawn(pid, path, file_actions, attrp,    \
+                                            argv, envp)                        \
+  __sanitizer_syscall_pre_impl_posix_spawn(                                    \
+      (long long)(pid), (long long)(path), (long long)(file_actions),          \
+      (long long)(attrp), (long long)(argv), (long long)(envp))
+#define __sanitizer_syscall_post_posix_spawn(res, pid, path, file_actions,     \
+                                             attrp, argv, envp)                \
+  __sanitizer_syscall_post_impl_posix_spawn(                                   \
+      res, (long long)(pid), (long long)(path), (long long)(file_actions),     \
+      (long long)(attrp), (long long)(argv), (long long)(envp))
+#define __sanitizer_syscall_pre_recvmmsg(s, mmsg, vlen, flags, timeout)        \
+  __sanitizer_syscall_pre_impl_recvmmsg((long long)(s), (long long)(mmsg),     \
+                                        (long long)(vlen), (long long)(flags), \
+                                        (long long)(timeout))
+#define __sanitizer_syscall_post_recvmmsg(res, s, mmsg, vlen, flags, timeout)  \
+  __sanitizer_syscall_post_impl_recvmmsg(                                      \
+      res, (long long)(s), (long long)(mmsg), (long long)(vlen),               \
+      (long long)(flags), (long long)(timeout))
+#define __sanitizer_syscall_pre_sendmmsg(s, mmsg, vlen, flags)                 \
+  __sanitizer_syscall_pre_impl_sendmmsg((long long)(s), (long long)(mmsg),     \
+                                        (long long)(vlen), (long long)(flags))
+#define __sanitizer_syscall_post_sendmmsg(res, s, mmsg, vlen, flags)           \
+  __sanitizer_syscall_post_impl_sendmmsg(res, (long long)(s),                  \
+                                         (long long)(mmsg), (long long)(vlen), \
+                                         (long long)(flags))
+#define __sanitizer_syscall_pre_clock_nanosleep(clock_id, flags, rqtp, rmtp)   \
+  __sanitizer_syscall_pre_impl_clock_nanosleep(                                \
+      (long long)(clock_id), (long long)(flags), (long long)(rqtp),            \
+      (long long)(rmtp))
+#define __sanitizer_syscall_post_clock_nanosleep(res, clock_id, flags, rqtp,   \
+                                                 rmtp)                         \
+  __sanitizer_syscall_post_impl_clock_nanosleep(                               \
+      res, (long long)(clock_id), (long long)(flags), (long long)(rqtp),       \
+      (long long)(rmtp))
+#define __sanitizer_syscall_pre____lwp_park60(clock_id, flags, ts, unpark,     \
+                                              hint, unparkhint)                \
+  __sanitizer_syscall_pre_impl____lwp_park60(                                  \
+      (long long)(clock_id), (long long)(flags), (long long)(ts),              \
+      (long long)(unpark), (long long)(hint), (long long)(unparkhint))
+#define __sanitizer_syscall_post____lwp_park60(res, clock_id, flags, ts,       \
+                                               unpark, hint, unparkhint)       \
+  __sanitizer_syscall_post_impl____lwp_park60(                                 \
+      res, (long long)(clock_id), (long long)(flags), (long long)(ts),         \
+      (long long)(unpark), (long long)(hint), (long long)(unparkhint))
+#define __sanitizer_syscall_pre_posix_fallocate(fd, PAD, pos, len)             \
+  __sanitizer_syscall_pre_impl_posix_fallocate(                                \
+      (long long)(fd), (long long)(PAD), (long long)(pos), (long long)(len))
+#define __sanitizer_syscall_post_posix_fallocate(res, fd, PAD, pos, len)       \
+  __sanitizer_syscall_post_impl_posix_fallocate(                               \
+      res, (long long)(fd), (long long)(PAD), (long long)(pos),                \
+      (long long)(len))
+#define __sanitizer_syscall_pre_fdiscard(fd, PAD, pos, len)                    \
+  __sanitizer_syscall_pre_impl_fdiscard((long long)(fd), (long long)(PAD),     \
+                                        (long long)(pos), (long long)(len))
+#define __sanitizer_syscall_post_fdiscard(res, fd, PAD, pos, len)              \
+  __sanitizer_syscall_post_impl_fdiscard(res, (long long)(fd),                 \
+                                         (long long)(PAD), (long long)(pos),   \
+                                         (long long)(len))
+#define __sanitizer_syscall_pre_wait6(idtype, id, status, options, wru, info)  \
+  __sanitizer_syscall_pre_impl_wait6(                                          \
+      (long long)(idtype), (long long)(id), (long long)(status),               \
+      (long long)(options), (long long)(wru), (long long)(info))
+#define __sanitizer_syscall_post_wait6(res, idtype, id, status, options, wru,  \
+                                       info)                                   \
+  __sanitizer_syscall_post_impl_wait6(                                         \
+      res, (long long)(idtype), (long long)(id), (long long)(status),          \
+      (long long)(options), (long long)(wru), (long long)(info))
+#define __sanitizer_syscall_pre_clock_getcpuclockid2(idtype, id, clock_id)     \
+  __sanitizer_syscall_pre_impl_clock_getcpuclockid2(                           \
+      (long long)(idtype), (long long)(id), (long long)(clock_id))
+#define __sanitizer_syscall_post_clock_getcpuclockid2(res, idtype, id,         \
+                                                      clock_id)                \
+  __sanitizer_syscall_post_impl_clock_getcpuclockid2(                          \
+      res, (long long)(idtype), (long long)(id), (long long)(clock_id))
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Private declarations. Do not call directly from user code. Use macros above.
+
+// DO NOT EDIT! THIS FILE HAS BEEN GENERATED!
+
+void __sanitizer_syscall_pre_impl_syscall(long long code, long long arg0,
+                                          long long arg1, long long arg2,
+                                          long long arg3, long long arg4,
+                                          long long arg5, long long arg6,
+                                          long long arg7);
+void __sanitizer_syscall_post_impl_syscall(long long res, long long code,
+                                           long long arg0, long long arg1,
+                                           long long arg2, long long arg3,
+                                           long long arg4, long long arg5,
+                                           long long arg6, long long arg7);
+void __sanitizer_syscall_pre_impl_exit(long long rval);
+void __sanitizer_syscall_post_impl_exit(long long res, long long rval);
+void __sanitizer_syscall_pre_impl_fork(void);
+void __sanitizer_syscall_post_impl_fork(long long res);
+void __sanitizer_syscall_pre_impl_read(long long fd, long long buf,
+                                       long long nbyte);
+void __sanitizer_syscall_post_impl_read(long long res, long long fd,
+                                        long long buf, long long nbyte);
+void __sanitizer_syscall_pre_impl_write(long long fd, long long buf,
+                                        long long nbyte);
+void __sanitizer_syscall_post_impl_write(long long res, long long fd,
+                                         long long buf, long long nbyte);
+void __sanitizer_syscall_pre_impl_open(long long path, long long flags,
+                                       long long mode);
+void __sanitizer_syscall_post_impl_open(long long res, long long path,
+                                        long long flags, long long mode);
+void __sanitizer_syscall_pre_impl_close(long long fd);
+void __sanitizer_syscall_post_impl_close(long long res, long long fd);
+void __sanitizer_syscall_pre_impl_compat_50_wait4(long long pid,
+                                                  long long status,
+                                                  long long options,
+                                                  long long rusage);
+void __sanitizer_syscall_post_impl_compat_50_wait4(long long res, long long pid,
+                                                   long long status,
+                                                   long long options,
+                                                   long long rusage);
+void __sanitizer_syscall_pre_impl_compat_43_ocreat(long long path,
+                                                   long long mode);
+void __sanitizer_syscall_post_impl_compat_43_ocreat(long long res,
+                                                    long long path,
+                                                    long long mode);
+void __sanitizer_syscall_pre_impl_link(long long path, long long link);
+void __sanitizer_syscall_post_impl_link(long long res, long long path,
+                                        long long link);
+void __sanitizer_syscall_pre_impl_unlink(long long path);
+void __sanitizer_syscall_post_impl_unlink(long long res, long long path);
+/* syscall 11 has been skipped */
+void __sanitizer_syscall_pre_impl_chdir(long long path);
+void __sanitizer_syscall_post_impl_chdir(long long res, long long path);
+void __sanitizer_syscall_pre_impl_fchdir(long long fd);
+void __sanitizer_syscall_post_impl_fchdir(long long res, long long fd);
+void __sanitizer_syscall_pre_impl_compat_50_mknod(long long path,
+                                                  long long mode,
+                                                  long long dev);
+void __sanitizer_syscall_post_impl_compat_50_mknod(long long res,
+                                                   long long path,
+                                                   long long mode,
+                                                   long long dev);
+void __sanitizer_syscall_pre_impl_chmod(long long path, long long mode);
+void __sanitizer_syscall_post_impl_chmod(long long res, long long path,
+                                         long long mode);
+void __sanitizer_syscall_pre_impl_chown(long long path, long long uid,
+                                        long long gid);
+void __sanitizer_syscall_post_impl_chown(long long res, long long path,
+                                         long long uid, long long gid);
+void __sanitizer_syscall_pre_impl_break(long long nsize);
+void __sanitizer_syscall_post_impl_break(long long res, long long nsize);
+void __sanitizer_syscall_pre_impl_compat_20_getfsstat(long long buf,
+                                                      long long bufsize,
+                                                      long long flags);
+void __sanitizer_syscall_post_impl_compat_20_getfsstat(long long res,
+                                                       long long buf,
+                                                       long long bufsize,
+                                                       long long flags);
+void __sanitizer_syscall_pre_impl_compat_43_olseek(long long fd,
+                                                   long long offset,
+                                                   long long whence);
+void __sanitizer_syscall_post_impl_compat_43_olseek(long long res, long long fd,
+                                                    long long offset,
+                                                    long long whence);
+void __sanitizer_syscall_pre_impl_getpid(void);
+void __sanitizer_syscall_post_impl_getpid(long long res);
+void __sanitizer_syscall_pre_impl_compat_40_mount(long long type,
+                                                  long long path,
+                                                  long long flags,
+                                                  long long data);
+void __sanitizer_syscall_post_impl_compat_40_mount(long long res,
+                                                   long long type,
+                                                   long long path,
+                                                   long long flags,
+                                                   long long data);
+void __sanitizer_syscall_pre_impl_unmount(long long path, long long flags);
+void __sanitizer_syscall_post_impl_unmount(long long res, long long path,
+                                           long long flags);
+void __sanitizer_syscall_pre_impl_setuid(long long uid);
+void __sanitizer_syscall_post_impl_setuid(long long res, long long uid);
+void __sanitizer_syscall_pre_impl_getuid(void);
+void __sanitizer_syscall_post_impl_getuid(long long res);
+void __sanitizer_syscall_pre_impl_geteuid(void);
+void __sanitizer_syscall_post_impl_geteuid(long long res);
+void __sanitizer_syscall_pre_impl_ptrace(long long req, long long pid,
+                                         long long addr, long long data);
+void __sanitizer_syscall_post_impl_ptrace(long long res, long long req,
+                                          long long pid, long long addr,
+                                          long long data);
+void __sanitizer_syscall_pre_impl_recvmsg(long long s, long long msg,
+                                          long long flags);
+void __sanitizer_syscall_post_impl_recvmsg(long long res, long long s,
+                                           long long msg, long long flags);
+void __sanitizer_syscall_pre_impl_sendmsg(long long s, long long msg,
+                                          long long flags);
+void __sanitizer_syscall_post_impl_sendmsg(long long res, long long s,
+                                           long long msg, long long flags);
+void __sanitizer_syscall_pre_impl_recvfrom(long long s, long long buf,
+                                           long long len, long long flags,
+                                           long long from,
+                                           long long fromlenaddr);
+void __sanitizer_syscall_post_impl_recvfrom(long long res, long long s,
+                                            long long buf, long long len,
+                                            long long flags, long long from,
+                                            long long fromlenaddr);
+void __sanitizer_syscall_pre_impl_accept(long long s, long long name,
+                                         long long anamelen);
+void __sanitizer_syscall_post_impl_accept(long long res, long long s,
+                                          long long name, long long anamelen);
+void __sanitizer_syscall_pre_impl_getpeername(long long fdes, long long asa,
+                                              long long alen);
+void __sanitizer_syscall_post_impl_getpeername(long long res, long long fdes,
+                                               long long asa, long long alen);
+void __sanitizer_syscall_pre_impl_getsockname(long long fdes, long long asa,
+                                              long long alen);
+void __sanitizer_syscall_post_impl_getsockname(long long res, long long fdes,
+                                               long long asa, long long alen);
+void __sanitizer_syscall_pre_impl_access(long long path, long long flags);
+void __sanitizer_syscall_post_impl_access(long long res, long long path,
+                                          long long flags);
+void __sanitizer_syscall_pre_impl_chflags(long long path, long long flags);
+void __sanitizer_syscall_post_impl_chflags(long long res, long long path,
+                                           long long flags);
+void __sanitizer_syscall_pre_impl_fchflags(long long fd, long long flags);
+void __sanitizer_syscall_post_impl_fchflags(long long res, long long fd,
+                                            long long flags);
+void __sanitizer_syscall_pre_impl_sync(void);
+void __sanitizer_syscall_post_impl_sync(long long res);
+void __sanitizer_syscall_pre_impl_kill(long long pid, long long signum);
+void __sanitizer_syscall_post_impl_kill(long long res, long long pid,
+                                        long long signum);
+void __sanitizer_syscall_pre_impl_compat_43_stat43(long long path,
+                                                   long long ub);
+void __sanitizer_syscall_post_impl_compat_43_stat43(long long res,
+                                                    long long path,
+                                                    long long ub);
+void __sanitizer_syscall_pre_impl_getppid(void);
+void __sanitizer_syscall_post_impl_getppid(long long res);
+void __sanitizer_syscall_pre_impl_compat_43_lstat43(long long path,
+                                                    long long ub);
+void __sanitizer_syscall_post_impl_compat_43_lstat43(long long res,
+                                                     long long path,
+                                                     long long ub);
+void __sanitizer_syscall_pre_impl_dup(long long fd);
+void __sanitizer_syscall_post_impl_dup(long long res, long long fd);
+void __sanitizer_syscall_pre_impl_pipe(void);
+void __sanitizer_syscall_post_impl_pipe(long long res);
+void __sanitizer_syscall_pre_impl_getegid(void);
+void __sanitizer_syscall_post_impl_getegid(long long res);
+void __sanitizer_syscall_pre_impl_profil(long long samples, long long size,
+                                         long long offset, long long scale);
+void __sanitizer_syscall_post_impl_profil(long long res, long long samples,
+                                          long long size, long long offset,
+                                          long long scale);
+void __sanitizer_syscall_pre_impl_ktrace(long long fname, long long ops,
+                                         long long facs, long long pid);
+void __sanitizer_syscall_post_impl_ktrace(long long res, long long fname,
+                                          long long ops, long long facs,
+                                          long long pid);
+void __sanitizer_syscall_pre_impl_compat_13_sigaction13(long long signum,
+                                                        long long nsa,
+                                                        long long osa);
+void __sanitizer_syscall_post_impl_compat_13_sigaction13(long long res,
+                                                         long long signum,
+                                                         long long nsa,
+                                                         long long osa);
+void __sanitizer_syscall_pre_impl_getgid(void);
+void __sanitizer_syscall_post_impl_getgid(long long res);
+void __sanitizer_syscall_pre_impl_compat_13_sigprocmask13(long long how,
+                                                          long long mask);
+void __sanitizer_syscall_post_impl_compat_13_sigprocmask13(long long res,
+                                                           long long how,
+                                                           long long mask);
+void __sanitizer_syscall_pre_impl___getlogin(long long namebuf,
+                                             long long namelen);
+void __sanitizer_syscall_post_impl___getlogin(long long res, long long namebuf,
+                                              long long namelen);
+void __sanitizer_syscall_pre_impl___setlogin(long long namebuf);
+void __sanitizer_syscall_post_impl___setlogin(long long res, long long namebuf);
+void __sanitizer_syscall_pre_impl_acct(long long path);
+void __sanitizer_syscall_post_impl_acct(long long res, long long path);
+void __sanitizer_syscall_pre_impl_compat_13_sigpending13(void);
+void __sanitizer_syscall_post_impl_compat_13_sigpending13(long long res);
+void __sanitizer_syscall_pre_impl_compat_13_sigaltstack13(long long nss,
+                                                          long long oss);
+void __sanitizer_syscall_post_impl_compat_13_sigaltstack13(long long res,
+                                                           long long nss,
+                                                           long long oss);
+void __sanitizer_syscall_pre_impl_ioctl(long long fd, long long com,
+                                        long long data);
+void __sanitizer_syscall_post_impl_ioctl(long long res, long long fd,
+                                         long long com, long long data);
+void __sanitizer_syscall_pre_impl_compat_12_oreboot(long long opt);
+void __sanitizer_syscall_post_impl_compat_12_oreboot(long long res,
+                                                     long long opt);
+void __sanitizer_syscall_pre_impl_revoke(long long path);
+void __sanitizer_syscall_post_impl_revoke(long long res, long long path);
+void __sanitizer_syscall_pre_impl_symlink(long long path, long long link);
+void __sanitizer_syscall_post_impl_symlink(long long res, long long path,
+                                           long long link);
+void __sanitizer_syscall_pre_impl_readlink(long long path, long long buf,
+                                           long long count);
+void __sanitizer_syscall_post_impl_readlink(long long res, long long path,
+                                            long long buf, long long count);
+void __sanitizer_syscall_pre_impl_execve(long long path, long long argp,
+                                         long long envp);
+void __sanitizer_syscall_post_impl_execve(long long res, long long path,
+                                          long long argp, long long envp);
+void __sanitizer_syscall_pre_impl_umask(long long newmask);
+void __sanitizer_syscall_post_impl_umask(long long res, long long newmask);
+void __sanitizer_syscall_pre_impl_chroot(long long path);
+void __sanitizer_syscall_post_impl_chroot(long long res, long long path);
+void __sanitizer_syscall_pre_impl_compat_43_fstat43(long long fd, long long sb);
+void __sanitizer_syscall_post_impl_compat_43_fstat43(long long res,
+                                                     long long fd,
+                                                     long long sb);
+void __sanitizer_syscall_pre_impl_compat_43_ogetkerninfo(long long op,
+                                                         long long where,
+                                                         long long size,
+                                                         long long arg);
+void __sanitizer_syscall_post_impl_compat_43_ogetkerninfo(long long res,
+                                                          long long op,
+                                                          long long where,
+                                                          long long size,
+                                                          long long arg);
+void __sanitizer_syscall_pre_impl_compat_43_ogetpagesize(void);
+void __sanitizer_syscall_post_impl_compat_43_ogetpagesize(long long res);
+void __sanitizer_syscall_pre_impl_compat_12_msync(long long addr,
+                                                  long long len);
+void __sanitizer_syscall_post_impl_compat_12_msync(long long res,
+                                                   long long addr,
+                                                   long long len);
+void __sanitizer_syscall_pre_impl_vfork(void);
+void __sanitizer_syscall_post_impl_vfork(long long res);
+/* syscall 67 has been skipped */
+/* syscall 68 has been skipped */
+/* syscall 69 has been skipped */
+/* syscall 70 has been skipped */
+void __sanitizer_syscall_pre_impl_compat_43_ommap(long long addr, long long len,
+                                                  long long prot,
+                                                  long long flags, long long fd,
+                                                  long long pos);
+void __sanitizer_syscall_post_impl_compat_43_ommap(
+    long long res, long long addr, long long len, long long prot,
+    long long flags, long long fd, long long pos);
+void __sanitizer_syscall_pre_impl_vadvise(long long anom);
+void __sanitizer_syscall_post_impl_vadvise(long long res, long long anom);
+void __sanitizer_syscall_pre_impl_munmap(long long addr, long long len);
+void __sanitizer_syscall_post_impl_munmap(long long res, long long addr,
+                                          long long len);
+void __sanitizer_syscall_pre_impl_mprotect(long long addr, long long len,
+                                           long long prot);
+void __sanitizer_syscall_post_impl_mprotect(long long res, long long addr,
+                                            long long len, long long prot);
+void __sanitizer_syscall_pre_impl_madvise(long long addr, long long len,
+                                          long long behav);
+void __sanitizer_syscall_post_impl_madvise(long long res, long long addr,
+                                           long long len, long long behav);
+/* syscall 76 has been skipped */
+/* syscall 77 has been skipped */
+void __sanitizer_syscall_pre_impl_mincore(long long addr, long long len,
+                                          long long vec);
+void __sanitizer_syscall_post_impl_mincore(long long res, long long addr,
+                                           long long len, long long vec);
+void __sanitizer_syscall_pre_impl_getgroups(long long gidsetsize,
+                                            long long gidset);
+void __sanitizer_syscall_post_impl_getgroups(long long res,
+                                             long long gidsetsize,
+                                             long long gidset);
+void __sanitizer_syscall_pre_impl_setgroups(long long gidsetsize,
+                                            long long gidset);
+void __sanitizer_syscall_post_impl_setgroups(long long res,
+                                             long long gidsetsize,
+                                             long long gidset);
+void __sanitizer_syscall_pre_impl_getpgrp(void);
+void __sanitizer_syscall_post_impl_getpgrp(long long res);
+void __sanitizer_syscall_pre_impl_setpgid(long long pid, long long pgid);
+void __sanitizer_syscall_post_impl_setpgid(long long res, long long pid,
+                                           long long pgid);
+void __sanitizer_syscall_pre_impl_compat_50_setitimer(long long which,
+                                                      long long itv,
+                                                      long long oitv);
+void __sanitizer_syscall_post_impl_compat_50_setitimer(long long res,
+                                                       long long which,
+                                                       long long itv,
+                                                       long long oitv);
+void __sanitizer_syscall_pre_impl_compat_43_owait(void);
+void __sanitizer_syscall_post_impl_compat_43_owait(long long res);
+void __sanitizer_syscall_pre_impl_compat_12_oswapon(long long name);
+void __sanitizer_syscall_post_impl_compat_12_oswapon(long long res,
+                                                     long long name);
+void __sanitizer_syscall_pre_impl_compat_50_getitimer(long long which,
+                                                      long long itv);
+void __sanitizer_syscall_post_impl_compat_50_getitimer(long long res,
+                                                       long long which,
+                                                       long long itv);
+void __sanitizer_syscall_pre_impl_compat_43_ogethostname(long long hostname,
+                                                         long long len);
+void __sanitizer_syscall_post_impl_compat_43_ogethostname(long long res,
+                                                          long long hostname,
+                                                          long long len);
+void __sanitizer_syscall_pre_impl_compat_43_osethostname(long long hostname,
+                                                         long long len);
+void __sanitizer_syscall_post_impl_compat_43_osethostname(long long res,
+                                                          long long hostname,
+                                                          long long len);
+void __sanitizer_syscall_pre_impl_compat_43_ogetdtablesize(void);
+void __sanitizer_syscall_post_impl_compat_43_ogetdtablesize(long long res);
+void __sanitizer_syscall_pre_impl_dup2(long long from, long long to);
+void __sanitizer_syscall_post_impl_dup2(long long res, long long from,
+                                        long long to);
+/* syscall 91 has been skipped */
+void __sanitizer_syscall_pre_impl_fcntl(long long fd, long long cmd,
+                                        long long arg);
+void __sanitizer_syscall_post_impl_fcntl(long long res, long long fd,
+                                         long long cmd, long long arg);
+void __sanitizer_syscall_pre_impl_compat_50_select(long long nd, long long in,
+                                                   long long ou, long long ex,
+                                                   long long tv);
+void __sanitizer_syscall_post_impl_compat_50_select(long long res, long long nd,
+                                                    long long in, long long ou,
+                                                    long long ex, long long tv);
+/* syscall 94 has been skipped */
+void __sanitizer_syscall_pre_impl_fsync(long long fd);
+void __sanitizer_syscall_post_impl_fsync(long long res, long long fd);
+void __sanitizer_syscall_pre_impl_setpriority(long long which, long long who,
+                                              long long prio);
+void __sanitizer_syscall_post_impl_setpriority(long long res, long long which,
+                                               long long who, long long prio);
+void __sanitizer_syscall_pre_impl_compat_30_socket(long long domain,
+                                                   long long type,
+                                                   long long protocol);
+void __sanitizer_syscall_post_impl_compat_30_socket(long long res,
+                                                    long long domain,
+                                                    long long type,
+                                                    long long protocol);
+void __sanitizer_syscall_pre_impl_connect(long long s, long long name,
+                                          long long namelen);
+void __sanitizer_syscall_post_impl_connect(long long res, long long s,
+                                           long long name, long long namelen);
+void __sanitizer_syscall_pre_impl_compat_43_oaccept(long long s, long long name,
+                                                    long long anamelen);
+void __sanitizer_syscall_post_impl_compat_43_oaccept(long long res, long long s,
+                                                     long long name,
+                                                     long long anamelen);
+void __sanitizer_syscall_pre_impl_getpriority(long long which, long long who);
+void __sanitizer_syscall_post_impl_getpriority(long long res, long long which,
+                                               long long who);
+void __sanitizer_syscall_pre_impl_compat_43_osend(long long s, long long buf,
+                                                  long long len,
+                                                  long long flags);
+void __sanitizer_syscall_post_impl_compat_43_osend(long long res, long long s,
+                                                   long long buf, long long len,
+                                                   long long flags);
+void __sanitizer_syscall_pre_impl_compat_43_orecv(long long s, long long buf,
+                                                  long long len,
+                                                  long long flags);
+void __sanitizer_syscall_post_impl_compat_43_orecv(long long res, long long s,
+                                                   long long buf, long long len,
+                                                   long long flags);
+void __sanitizer_syscall_pre_impl_compat_13_sigreturn13(long long sigcntxp);
+void __sanitizer_syscall_post_impl_compat_13_sigreturn13(long long res,
+                                                         long long sigcntxp);
+void __sanitizer_syscall_pre_impl_bind(long long s, long long name,
+                                       long long namelen);
+void __sanitizer_syscall_post_impl_bind(long long res, long long s,
+                                        long long name, long long namelen);
+void __sanitizer_syscall_pre_impl_setsockopt(long long s, long long level,
+                                             long long name, long long val,
+                                             long long valsize);
+void __sanitizer_syscall_post_impl_setsockopt(long long res, long long s,
+                                              long long level, long long name,
+                                              long long val, long long valsize);
+void __sanitizer_syscall_pre_impl_listen(long long s, long long backlog);
+void __sanitizer_syscall_post_impl_listen(long long res, long long s,
+                                          long long backlog);
+/* syscall 107 has been skipped */
+void __sanitizer_syscall_pre_impl_compat_43_osigvec(long long signum,
+                                                    long long nsv,
+                                                    long long osv);
+void __sanitizer_syscall_post_impl_compat_43_osigvec(long long res,
+                                                     long long signum,
+                                                     long long nsv,
+                                                     long long osv);
+void __sanitizer_syscall_pre_impl_compat_43_osigblock(long long mask);
+void __sanitizer_syscall_post_impl_compat_43_osigblock(long long res,
+                                                       long long mask);
+void __sanitizer_syscall_pre_impl_compat_43_osigsetmask(long long mask);
+void __sanitizer_syscall_post_impl_compat_43_osigsetmask(long long res,
+                                                         long long mask);
+void __sanitizer_syscall_pre_impl_compat_13_sigsuspend13(long long mask);
+void __sanitizer_syscall_post_impl_compat_13_sigsuspend13(long long res,
+                                                          long long mask);
+void __sanitizer_syscall_pre_impl_compat_43_osigstack(long long nss,
+                                                      long long oss);
+void __sanitizer_syscall_post_impl_compat_43_osigstack(long long res,
+                                                       long long nss,
+                                                       long long oss);
+void __sanitizer_syscall_pre_impl_compat_43_orecvmsg(long long s, long long msg,
+                                                     long long flags);
+void __sanitizer_syscall_post_impl_compat_43_orecvmsg(long long res,
+                                                      long long s,
+                                                      long long msg,
+                                                      long long flags);
+void __sanitizer_syscall_pre_impl_compat_43_osendmsg(long long s, long long msg,
+                                                     long long flags);
+void __sanitizer_syscall_post_impl_compat_43_osendmsg(long long res,
+                                                      long long s,
+                                                      long long msg,
+                                                      long long flags);
+/* syscall 115 has been skipped */
+void __sanitizer_syscall_pre_impl_compat_50_gettimeofday(long long tp,
+                                                         long long tzp);
+void __sanitizer_syscall_post_impl_compat_50_gettimeofday(long long res,
+                                                          long long tp,
+                                                          long long tzp);
+void __sanitizer_syscall_pre_impl_compat_50_getrusage(long long who,
+                                                      long long rusage);
+void __sanitizer_syscall_post_impl_compat_50_getrusage(long long res,
+                                                       long long who,
+                                                       long long rusage);
+void __sanitizer_syscall_pre_impl_getsockopt(long long s, long long level,
+                                             long long name, long long val,
+                                             long long avalsize);
+void __sanitizer_syscall_post_impl_getsockopt(long long res, long long s,
+                                              long long level, long long name,
+                                              long long val,
+                                              long long avalsize);
+/* syscall 119 has been skipped */
+void __sanitizer_syscall_pre_impl_readv(long long fd, long long iovp,
+                                        long long iovcnt);
+void __sanitizer_syscall_post_impl_readv(long long res, long long fd,
+                                         long long iovp, long long iovcnt);
+void __sanitizer_syscall_pre_impl_writev(long long fd, long long iovp,
+                                         long long iovcnt);
+void __sanitizer_syscall_post_impl_writev(long long res, long long fd,
+                                          long long iovp, long long iovcnt);
+void __sanitizer_syscall_pre_impl_compat_50_settimeofday(long long tv,
+                                                         long long tzp);
+void __sanitizer_syscall_post_impl_compat_50_settimeofday(long long res,
+                                                          long long tv,
+                                                          long long tzp);
+void __sanitizer_syscall_pre_impl_fchown(long long fd, long long uid,
+                                         long long gid);
+void __sanitizer_syscall_post_impl_fchown(long long res, long long fd,
+                                          long long uid, long long gid);
+void __sanitizer_syscall_pre_impl_fchmod(long long fd, long long mode);
+void __sanitizer_syscall_post_impl_fchmod(long long res, long long fd,
+                                          long long mode);
+void __sanitizer_syscall_pre_impl_compat_43_orecvfrom(
+    long long s, long long buf, long long len, long long flags, long long from,
+    long long fromlenaddr);
+void __sanitizer_syscall_post_impl_compat_43_orecvfrom(
+    long long res, long long s, long long buf, long long len, long long flags,
+    long long from, long long fromlenaddr);
+void __sanitizer_syscall_pre_impl_setreuid(long long ruid, long long euid);
+void __sanitizer_syscall_post_impl_setreuid(long long res, long long ruid,
+                                            long long euid);
+void __sanitizer_syscall_pre_impl_setregid(long long rgid, long long egid);
+void __sanitizer_syscall_post_impl_setregid(long long res, long long rgid,
+                                            long long egid);
+void __sanitizer_syscall_pre_impl_rename(long long from, long long to);
+void __sanitizer_syscall_post_impl_rename(long long res, long long from,
+                                          long long to);
+void __sanitizer_syscall_pre_impl_compat_43_otruncate(long long path,
+                                                      long long length);
+void __sanitizer_syscall_post_impl_compat_43_otruncate(long long res,
+                                                       long long path,
+                                                       long long length);
+void __sanitizer_syscall_pre_impl_compat_43_oftruncate(long long fd,
+                                                       long long length);
+void __sanitizer_syscall_post_impl_compat_43_oftruncate(long long res,
+                                                        long long fd,
+                                                        long long length);
+void __sanitizer_syscall_pre_impl_flock(long long fd, long long how);
+void __sanitizer_syscall_post_impl_flock(long long res, long long fd,
+                                         long long how);
+void __sanitizer_syscall_pre_impl_mkfifo(long long path, long long mode);
+void __sanitizer_syscall_post_impl_mkfifo(long long res, long long path,
+                                          long long mode);
+void __sanitizer_syscall_pre_impl_sendto(long long s, long long buf,
+                                         long long len, long long flags,
+                                         long long to, long long tolen);
+void __sanitizer_syscall_post_impl_sendto(long long res, long long s,
+                                          long long buf, long long len,
+                                          long long flags, long long to,
+                                          long long tolen);
+void __sanitizer_syscall_pre_impl_shutdown(long long s, long long how);
+void __sanitizer_syscall_post_impl_shutdown(long long res, long long s,
+                                            long long how);
+void __sanitizer_syscall_pre_impl_socketpair(long long domain, long long type,
+                                             long long protocol, long long rsv);
+void __sanitizer_syscall_post_impl_socketpair(long long res, long long domain,
+                                              long long type,
+                                              long long protocol,
+                                              long long rsv);
+void __sanitizer_syscall_pre_impl_mkdir(long long path, long long mode);
+void __sanitizer_syscall_post_impl_mkdir(long long res, long long path,
+                                         long long mode);
+void __sanitizer_syscall_pre_impl_rmdir(long long path);
+void __sanitizer_syscall_post_impl_rmdir(long long res, long long path);
+void __sanitizer_syscall_pre_impl_compat_50_utimes(long long path,
+                                                   long long tptr);
+void __sanitizer_syscall_post_impl_compat_50_utimes(long long res,
+                                                    long long path,
+                                                    long long tptr);
+/* syscall 139 has been skipped */
+void __sanitizer_syscall_pre_impl_compat_50_adjtime(long long delta,
+                                                    long long olddelta);
+void __sanitizer_syscall_post_impl_compat_50_adjtime(long long res,
+                                                     long long delta,
+                                                     long long olddelta);
+void __sanitizer_syscall_pre_impl_compat_43_ogetpeername(long long fdes,
+                                                         long long asa,
+                                                         long long alen);
+void __sanitizer_syscall_post_impl_compat_43_ogetpeername(long long res,
+                                                          long long fdes,
+                                                          long long asa,
+                                                          long long alen);
+void __sanitizer_syscall_pre_impl_compat_43_ogethostid(void);
+void __sanitizer_syscall_post_impl_compat_43_ogethostid(long long res);
+void __sanitizer_syscall_pre_impl_compat_43_osethostid(long long hostid);
+void __sanitizer_syscall_post_impl_compat_43_osethostid(long long res,
+                                                        long long hostid);
+void __sanitizer_syscall_pre_impl_compat_43_ogetrlimit(long long which,
+                                                       long long rlp);
+void __sanitizer_syscall_post_impl_compat_43_ogetrlimit(long long res,
+                                                        long long which,
+                                                        long long rlp);
+void __sanitizer_syscall_pre_impl_compat_43_osetrlimit(long long which,
+                                                       long long rlp);
+void __sanitizer_syscall_post_impl_compat_43_osetrlimit(long long res,
+                                                        long long which,
+                                                        long long rlp);
+void __sanitizer_syscall_pre_impl_compat_43_okillpg(long long pgid,
+                                                    long long signum);
+void __sanitizer_syscall_post_impl_compat_43_okillpg(long long res,
+                                                     long long pgid,
+                                                     long long signum);
+void __sanitizer_syscall_pre_impl_setsid(void);
+void __sanitizer_syscall_post_impl_setsid(long long res);
+void __sanitizer_syscall_pre_impl_compat_50_quotactl(long long path,
+                                                     long long cmd,
+                                                     long long uid,
+                                                     long long arg);
+void __sanitizer_syscall_post_impl_compat_50_quotactl(
+    long long res, long long path, long long cmd, long long uid, long long arg);
+void __sanitizer_syscall_pre_impl_compat_43_oquota(void);
+void __sanitizer_syscall_post_impl_compat_43_oquota(long long res);
+void __sanitizer_syscall_pre_impl_compat_43_ogetsockname(long long fdec,
+                                                         long long asa,
+                                                         long long alen);
+void __sanitizer_syscall_post_impl_compat_43_ogetsockname(long long res,
+                                                          long long fdec,
+                                                          long long asa,
+                                                          long long alen);
+/* syscall 151 has been skipped */
+/* syscall 152 has been skipped */
+/* syscall 153 has been skipped */
+/* syscall 154 has been skipped */
+void __sanitizer_syscall_pre_impl_nfssvc(long long flag, long long argp);
+void __sanitizer_syscall_post_impl_nfssvc(long long res, long long flag,
+                                          long long argp);
+void __sanitizer_syscall_pre_impl_compat_43_ogetdirentries(long long fd,
+                                                           long long buf,
+                                                           long long count,
+                                                           long long basep);
+void __sanitizer_syscall_post_impl_compat_43_ogetdirentries(long long res,
+                                                            long long fd,
+                                                            long long buf,
+                                                            long long count,
+                                                            long long basep);
+void __sanitizer_syscall_pre_impl_compat_20_statfs(long long path,
+                                                   long long buf);
+void __sanitizer_syscall_post_impl_compat_20_statfs(long long res,
+                                                    long long path,
+                                                    long long buf);
+void __sanitizer_syscall_pre_impl_compat_20_fstatfs(long long fd,
+                                                    long long buf);
+void __sanitizer_syscall_post_impl_compat_20_fstatfs(long long res,
+                                                     long long fd,
+                                                     long long buf);
+/* syscall 159 has been skipped */
+/* syscall 160 has been skipped */
+void __sanitizer_syscall_pre_impl_compat_30_getfh(long long fname,
+                                                  long long fhp);
+void __sanitizer_syscall_post_impl_compat_30_getfh(long long res,
+                                                   long long fname,
+                                                   long long fhp);
+void __sanitizer_syscall_pre_impl_compat_09_ogetdomainname(long long domainname,
+                                                           long long len);
+void __sanitizer_syscall_post_impl_compat_09_ogetdomainname(
+    long long res, long long domainname, long long len);
+void __sanitizer_syscall_pre_impl_compat_09_osetdomainname(long long domainname,
+                                                           long long len);
+void __sanitizer_syscall_post_impl_compat_09_osetdomainname(
+    long long res, long long domainname, long long len);
+void __sanitizer_syscall_pre_impl_compat_09_ouname(long long name);
+void __sanitizer_syscall_post_impl_compat_09_ouname(long long res,
+                                                    long long name);
+void __sanitizer_syscall_pre_impl_sysarch(long long op, long long parms);
+void __sanitizer_syscall_post_impl_sysarch(long long res, long long op,
+                                           long long parms);
+/* syscall 166 has been skipped */
+/* syscall 167 has been skipped */
+/* syscall 168 has been skipped */
+#if !defined(_LP64)
+void __sanitizer_syscall_pre_impl_compat_10_osemsys(long long which,
+                                                    long long a2, long long a3,
+                                                    long long a4, long long a5);
+void __sanitizer_syscall_post_impl_compat_10_osemsys(long long res,
+                                                     long long which,
+                                                     long long a2, long long a3,
+                                                     long long a4,
+                                                     long long a5);
+#else
+/* syscall 169 has been skipped */
+#endif
+#if !defined(_LP64)
+void __sanitizer_syscall_pre_impl_compat_10_omsgsys(long long which,
+                                                    long long a2, long long a3,
+                                                    long long a4, long long a5,
+                                                    long long a6);
+void __sanitizer_syscall_post_impl_compat_10_omsgsys(long long res,
+                                                     long long which,
+                                                     long long a2, long long a3,
+                                                     long long a4, long long a5,
+                                                     long long a6);
+#else
+/* syscall 170 has been skipped */
+#endif
+#if !defined(_LP64)
+void __sanitizer_syscall_pre_impl_compat_10_oshmsys(long long which,
+                                                    long long a2, long long a3,
+                                                    long long a4);
+void __sanitizer_syscall_post_impl_compat_10_oshmsys(long long res,
+                                                     long long which,
+                                                     long long a2, long long a3,
+                                                     long long a4);
+#else
+/* syscall 171 has been skipped */
+#endif
+/* syscall 172 has been skipped */
+void __sanitizer_syscall_pre_impl_pread(long long fd, long long buf,
+                                        long long nbyte, long long PAD,
+                                        long long offset);
+void __sanitizer_syscall_post_impl_pread(long long res, long long fd,
+                                         long long buf, long long nbyte,
+                                         long long PAD, long long offset);
+void __sanitizer_syscall_pre_impl_pwrite(long long fd, long long buf,
+                                         long long nbyte, long long PAD,
+                                         long long offset);
+void __sanitizer_syscall_post_impl_pwrite(long long res, long long fd,
+                                          long long buf, long long nbyte,
+                                          long long PAD, long long offset);
+void __sanitizer_syscall_pre_impl_compat_30_ntp_gettime(long long ntvp);
+void __sanitizer_syscall_post_impl_compat_30_ntp_gettime(long long res,
+                                                         long long ntvp);
+#if defined(NTP) || !defined(_KERNEL_OPT)
+void __sanitizer_syscall_pre_impl_ntp_adjtime(long long tp);
+void __sanitizer_syscall_post_impl_ntp_adjtime(long long res, long long tp);
+#else
+/* syscall 176 has been skipped */
+#endif
+/* syscall 177 has been skipped */
+/* syscall 178 has been skipped */
+/* syscall 179 has been skipped */
+/* syscall 180 has been skipped */
+void __sanitizer_syscall_pre_impl_setgid(long long gid);
+void __sanitizer_syscall_post_impl_setgid(long long res, long long gid);
+void __sanitizer_syscall_pre_impl_setegid(long long egid);
+void __sanitizer_syscall_post_impl_setegid(long long res, long long egid);
+void __sanitizer_syscall_pre_impl_seteuid(long long euid);
+void __sanitizer_syscall_post_impl_seteuid(long long res, long long euid);
+void __sanitizer_syscall_pre_impl_lfs_bmapv(long long fsidp, long long blkiov,
+                                            long long blkcnt);
+void __sanitizer_syscall_post_impl_lfs_bmapv(long long res, long long fsidp,
+                                             long long blkiov,
+                                             long long blkcnt);
+void __sanitizer_syscall_pre_impl_lfs_markv(long long fsidp, long long blkiov,
+                                            long long blkcnt);
+void __sanitizer_syscall_post_impl_lfs_markv(long long res, long long fsidp,
+                                             long long blkiov,
+                                             long long blkcnt);
+void __sanitizer_syscall_pre_impl_lfs_segclean(long long fsidp,
+                                               long long segment);
+void __sanitizer_syscall_post_impl_lfs_segclean(long long res, long long fsidp,
+                                                long long segment);
+void __sanitizer_syscall_pre_impl_compat_50_lfs_segwait(long long fsidp,
+                                                        long long tv);
+void __sanitizer_syscall_post_impl_compat_50_lfs_segwait(long long res,
+                                                         long long fsidp,
+                                                         long long tv);
+void __sanitizer_syscall_pre_impl_compat_12_stat12(long long path,
+                                                   long long ub);
+void __sanitizer_syscall_post_impl_compat_12_stat12(long long res,
+                                                    long long path,
+                                                    long long ub);
+void __sanitizer_syscall_pre_impl_compat_12_fstat12(long long fd, long long sb);
+void __sanitizer_syscall_post_impl_compat_12_fstat12(long long res,
+                                                     long long fd,
+                                                     long long sb);
+void __sanitizer_syscall_pre_impl_compat_12_lstat12(long long path,
+                                                    long long ub);
+void __sanitizer_syscall_post_impl_compat_12_lstat12(long long res,
+                                                     long long path,
+                                                     long long ub);
+void __sanitizer_syscall_pre_impl_pathconf(long long path, long long name);
+void __sanitizer_syscall_post_impl_pathconf(long long res, long long path,
+                                            long long name);
+void __sanitizer_syscall_pre_impl_fpathconf(long long fd, long long name);
+void __sanitizer_syscall_post_impl_fpathconf(long long res, long long fd,
+                                             long long name);
+void __sanitizer_syscall_pre_impl_getsockopt2(long long s, long long level,
+                                              long long name, long long val,
+                                              long long avalsize);
+void __sanitizer_syscall_post_impl_getsockopt2(long long res, long long s,
+                                               long long level, long long name,
+                                               long long val,
+                                               long long avalsize);
+void __sanitizer_syscall_pre_impl_getrlimit(long long which, long long rlp);
+void __sanitizer_syscall_post_impl_getrlimit(long long res, long long which,
+                                             long long rlp);
+void __sanitizer_syscall_pre_impl_setrlimit(long long which, long long rlp);
+void __sanitizer_syscall_post_impl_setrlimit(long long res, long long which,
+                                             long long rlp);
+void __sanitizer_syscall_pre_impl_compat_12_getdirentries(long long fd,
+                                                          long long buf,
+                                                          long long count,
+                                                          long long basep);
+void __sanitizer_syscall_post_impl_compat_12_getdirentries(long long res,
+                                                           long long fd,
+                                                           long long buf,
+                                                           long long count,
+                                                           long long basep);
+void __sanitizer_syscall_pre_impl_mmap(long long addr, long long len,
+                                       long long prot, long long flags,
+                                       long long fd, long long PAD,
+                                       long long pos);
+void __sanitizer_syscall_post_impl_mmap(long long res, long long addr,
+                                        long long len, long long prot,
+                                        long long flags, long long fd,
+                                        long long PAD, long long pos);
+void __sanitizer_syscall_pre_impl___syscall(long long code, long long arg0,
+                                            long long arg1, long long arg2,
+                                            long long arg3, long long arg4,
+                                            long long arg5, long long arg6,
+                                            long long arg7);
+void __sanitizer_syscall_post_impl___syscall(long long res, long long code,
+                                             long long arg0, long long arg1,
+                                             long long arg2, long long arg3,
+                                             long long arg4, long long arg5,
+                                             long long arg6, long long arg7);
+void __sanitizer_syscall_pre_impl_lseek(long long fd, long long PAD,
+                                        long long offset, long long whence);
+void __sanitizer_syscall_post_impl_lseek(long long res, long long fd,
+                                         long long PAD, long long offset,
+                                         long long whence);
+void __sanitizer_syscall_pre_impl_truncate(long long path, long long PAD,
+                                           long long length);
+void __sanitizer_syscall_post_impl_truncate(long long res, long long path,
+                                            long long PAD, long long length);
+void __sanitizer_syscall_pre_impl_ftruncate(long long fd, long long PAD,
+                                            long long length);
+void __sanitizer_syscall_post_impl_ftruncate(long long res, long long fd,
+                                             long long PAD, long long length);
+void __sanitizer_syscall_pre_impl___sysctl(long long name, long long namelen,
+                                           long long oldv, long long oldlenp,
+                                           long long newv, long long newlen);
+void __sanitizer_syscall_post_impl___sysctl(long long res, long long name,
+                                            long long namelen, long long oldv,
+                                            long long oldlenp, long long newv,
+                                            long long newlen);
+void __sanitizer_syscall_pre_impl_mlock(long long addr, long long len);
+void __sanitizer_syscall_post_impl_mlock(long long res, long long addr,
+                                         long long len);
+void __sanitizer_syscall_pre_impl_munlock(long long addr, long long len);
+void __sanitizer_syscall_post_impl_munlock(long long res, long long addr,
+                                           long long len);
+void __sanitizer_syscall_pre_impl_undelete(long long path);
+void __sanitizer_syscall_post_impl_undelete(long long res, long long path);
+void __sanitizer_syscall_pre_impl_compat_50_futimes(long long fd,
+                                                    long long tptr);
+void __sanitizer_syscall_post_impl_compat_50_futimes(long long res,
+                                                     long long fd,
+                                                     long long tptr);
+void __sanitizer_syscall_pre_impl_getpgid(long long pid);
+void __sanitizer_syscall_post_impl_getpgid(long long res, long long pid);
+void __sanitizer_syscall_pre_impl_reboot(long long opt, long long bootstr);
+void __sanitizer_syscall_post_impl_reboot(long long res, long long opt,
+                                          long long bootstr);
+void __sanitizer_syscall_pre_impl_poll(long long fds, long long nfds,
+                                       long long timeout);
+void __sanitizer_syscall_post_impl_poll(long long res, long long fds,
+                                        long long nfds, long long timeout);
+void __sanitizer_syscall_pre_impl_afssys(long long id, long long a1,
+                                         long long a2, long long a3,
+                                         long long a4, long long a5,
+                                         long long a6);
+void __sanitizer_syscall_post_impl_afssys(long long res, long long id,
+                                          long long a1, long long a2,
+                                          long long a3, long long a4,
+                                          long long a5, long long a6);
+/* syscall 211 has been skipped */
+/* syscall 212 has been skipped */
+/* syscall 213 has been skipped */
+/* syscall 214 has been skipped */
+/* syscall 215 has been skipped */
+/* syscall 216 has been skipped */
+/* syscall 217 has been skipped */
+/* syscall 218 has been skipped */
+/* syscall 219 has been skipped */
+void __sanitizer_syscall_pre_impl_compat_14___semctl(long long semid,
+                                                     long long semnum,
+                                                     long long cmd,
+                                                     long long arg);
+void __sanitizer_syscall_post_impl_compat_14___semctl(long long res,
+                                                      long long semid,
+                                                      long long semnum,
+                                                      long long cmd,
+                                                      long long arg);
+void __sanitizer_syscall_pre_impl_semget(long long key, long long nsems,
+                                         long long semflg);
+void __sanitizer_syscall_post_impl_semget(long long res, long long key,
+                                          long long nsems, long long semflg);
+void __sanitizer_syscall_pre_impl_semop(long long semid, long long sops,
+                                        long long nsops);
+void __sanitizer_syscall_post_impl_semop(long long res, long long semid,
+                                         long long sops, long long nsops);
+void __sanitizer_syscall_pre_impl_semconfig(long long flag);
+void __sanitizer_syscall_post_impl_semconfig(long long res, long long flag);
+void __sanitizer_syscall_pre_impl_compat_14_msgctl(long long msqid,
+                                                   long long cmd,
+                                                   long long buf);
+void __sanitizer_syscall_post_impl_compat_14_msgctl(long long res,
+                                                    long long msqid,
+                                                    long long cmd,
+                                                    long long buf);
+void __sanitizer_syscall_pre_impl_msgget(long long key, long long msgflg);
+void __sanitizer_syscall_post_impl_msgget(long long res, long long key,
+                                          long long msgflg);
+void __sanitizer_syscall_pre_impl_msgsnd(long long msqid, long long msgp,
+                                         long long msgsz, long long msgflg);
+void __sanitizer_syscall_post_impl_msgsnd(long long res, long long msqid,
+                                          long long msgp, long long msgsz,
+                                          long long msgflg);
+void __sanitizer_syscall_pre_impl_msgrcv(long long msqid, long long msgp,
+                                         long long msgsz, long long msgtyp,
+                                         long long msgflg);
+void __sanitizer_syscall_post_impl_msgrcv(long long res, long long msqid,
+                                          long long msgp, long long msgsz,
+                                          long long msgtyp, long long msgflg);
+void __sanitizer_syscall_pre_impl_shmat(long long shmid, long long shmaddr,
+                                        long long shmflg);
+void __sanitizer_syscall_post_impl_shmat(long long res, long long shmid,
+                                         long long shmaddr, long long shmflg);
+void __sanitizer_syscall_pre_impl_compat_14_shmctl(long long shmid,
+                                                   long long cmd,
+                                                   long long buf);
+void __sanitizer_syscall_post_impl_compat_14_shmctl(long long res,
+                                                    long long shmid,
+                                                    long long cmd,
+                                                    long long buf);
+void __sanitizer_syscall_pre_impl_shmdt(long long shmaddr);
+void __sanitizer_syscall_post_impl_shmdt(long long res, long long shmaddr);
+void __sanitizer_syscall_pre_impl_shmget(long long key, long long size,
+                                         long long shmflg);
+void __sanitizer_syscall_post_impl_shmget(long long res, long long key,
+                                          long long size, long long shmflg);
+void __sanitizer_syscall_pre_impl_compat_50_clock_gettime(long long clock_id,
+                                                          long long tp);
+void __sanitizer_syscall_post_impl_compat_50_clock_gettime(long long res,
+                                                           long long clock_id,
+                                                           long long tp);
+void __sanitizer_syscall_pre_impl_compat_50_clock_settime(long long clock_id,
+                                                          long long tp);
+void __sanitizer_syscall_post_impl_compat_50_clock_settime(long long res,
+                                                           long long clock_id,
+                                                           long long tp);
+void __sanitizer_syscall_pre_impl_compat_50_clock_getres(long long clock_id,
+                                                         long long tp);
+void __sanitizer_syscall_post_impl_compat_50_clock_getres(long long res,
+                                                          long long clock_id,
+                                                          long long tp);
+void __sanitizer_syscall_pre_impl_timer_create(long long clock_id,
+                                               long long evp,
+                                               long long timerid);
+void __sanitizer_syscall_post_impl_timer_create(long long res,
+                                                long long clock_id,
+                                                long long evp,
+                                                long long timerid);
+void __sanitizer_syscall_pre_impl_timer_delete(long long timerid);
+void __sanitizer_syscall_post_impl_timer_delete(long long res,
+                                                long long timerid);
+void __sanitizer_syscall_pre_impl_compat_50_timer_settime(long long timerid,
+                                                          long long flags,
+                                                          long long value,
+                                                          long long ovalue);
+void __sanitizer_syscall_post_impl_compat_50_timer_settime(long long res,
+                                                           long long timerid,
+                                                           long long flags,
+                                                           long long value,
+                                                           long long ovalue);
+void __sanitizer_syscall_pre_impl_compat_50_timer_gettime(long long timerid,
+                                                          long long value);
+void __sanitizer_syscall_post_impl_compat_50_timer_gettime(long long res,
+                                                           long long timerid,
+                                                           long long value);
+void __sanitizer_syscall_pre_impl_timer_getoverrun(long long timerid);
+void __sanitizer_syscall_post_impl_timer_getoverrun(long long res,
+                                                    long long timerid);
+void __sanitizer_syscall_pre_impl_compat_50_nanosleep(long long rqtp,
+                                                      long long rmtp);
+void __sanitizer_syscall_post_impl_compat_50_nanosleep(long long res,
+                                                       long long rqtp,
+                                                       long long rmtp);
+void __sanitizer_syscall_pre_impl_fdatasync(long long fd);
+void __sanitizer_syscall_post_impl_fdatasync(long long res, long long fd);
+void __sanitizer_syscall_pre_impl_mlockall(long long flags);
+void __sanitizer_syscall_post_impl_mlockall(long long res, long long flags);
+void __sanitizer_syscall_pre_impl_munlockall(void);
+void __sanitizer_syscall_post_impl_munlockall(long long res);
+void __sanitizer_syscall_pre_impl_compat_50___sigtimedwait(long long set,
+                                                           long long info,
+                                                           long long timeout);
+void __sanitizer_syscall_post_impl_compat_50___sigtimedwait(long long res,
+                                                            long long set,
+                                                            long long info,
+                                                            long long timeout);
+void __sanitizer_syscall_pre_impl_sigqueueinfo(long long pid, long long info);
+void __sanitizer_syscall_post_impl_sigqueueinfo(long long res, long long pid,
+                                                long long info);
+void __sanitizer_syscall_pre_impl_modctl(long long cmd, long long arg);
+void __sanitizer_syscall_post_impl_modctl(long long res, long long cmd,
+                                          long long arg);
+void __sanitizer_syscall_pre_impl__ksem_init(long long value, long long idp);
+void __sanitizer_syscall_post_impl__ksem_init(long long res, long long value,
+                                              long long idp);
+void __sanitizer_syscall_pre_impl__ksem_open(long long name, long long oflag,
+                                             long long mode, long long value,
+                                             long long idp);
+void __sanitizer_syscall_post_impl__ksem_open(long long res, long long name,
+                                              long long oflag, long long mode,
+                                              long long value, long long idp);
+void __sanitizer_syscall_pre_impl__ksem_unlink(long long name);
+void __sanitizer_syscall_post_impl__ksem_unlink(long long res, long long name);
+void __sanitizer_syscall_pre_impl__ksem_close(long long id);
+void __sanitizer_syscall_post_impl__ksem_close(long long res, long long id);
+void __sanitizer_syscall_pre_impl__ksem_post(long long id);
+void __sanitizer_syscall_post_impl__ksem_post(long long res, long long id);
+void __sanitizer_syscall_pre_impl__ksem_wait(long long id);
+void __sanitizer_syscall_post_impl__ksem_wait(long long res, long long id);
+void __sanitizer_syscall_pre_impl__ksem_trywait(long long id);
+void __sanitizer_syscall_post_impl__ksem_trywait(long long res, long long id);
+void __sanitizer_syscall_pre_impl__ksem_getvalue(long long id, long long value);
+void __sanitizer_syscall_post_impl__ksem_getvalue(long long res, long long id,
+                                                  long long value);
+void __sanitizer_syscall_pre_impl__ksem_destroy(long long id);
+void __sanitizer_syscall_post_impl__ksem_destroy(long long res, long long id);
+void __sanitizer_syscall_pre_impl__ksem_timedwait(long long id,
+                                                  long long abstime);
+void __sanitizer_syscall_post_impl__ksem_timedwait(long long res, long long id,
+                                                   long long abstime);
+void __sanitizer_syscall_pre_impl_mq_open(long long name, long long oflag,
+                                          long long mode, long long attr);
+void __sanitizer_syscall_post_impl_mq_open(long long res, long long name,
+                                           long long oflag, long long mode,
+                                           long long attr);
+void __sanitizer_syscall_pre_impl_mq_close(long long mqdes);
+void __sanitizer_syscall_post_impl_mq_close(long long res, long long mqdes);
+void __sanitizer_syscall_pre_impl_mq_unlink(long long name);
+void __sanitizer_syscall_post_impl_mq_unlink(long long res, long long name);
+void __sanitizer_syscall_pre_impl_mq_getattr(long long mqdes, long long mqstat);
+void __sanitizer_syscall_post_impl_mq_getattr(long long res, long long mqdes,
+                                              long long mqstat);
+void __sanitizer_syscall_pre_impl_mq_setattr(long long mqdes, long long mqstat,
+                                             long long omqstat);
+void __sanitizer_syscall_post_impl_mq_setattr(long long res, long long mqdes,
+                                              long long mqstat,
+                                              long long omqstat);
+void __sanitizer_syscall_pre_impl_mq_notify(long long mqdes,
+                                            long long notification);
+void __sanitizer_syscall_post_impl_mq_notify(long long res, long long mqdes,
+                                             long long notification);
+void __sanitizer_syscall_pre_impl_mq_send(long long mqdes, long long msg_ptr,
+                                          long long msg_len,
+                                          long long msg_prio);
+void __sanitizer_syscall_post_impl_mq_send(long long res, long long mqdes,
+                                           long long msg_ptr, long long msg_len,
+                                           long long msg_prio);
+void __sanitizer_syscall_pre_impl_mq_receive(long long mqdes, long long msg_ptr,
+                                             long long msg_len,
+                                             long long msg_prio);
+void __sanitizer_syscall_post_impl_mq_receive(long long res, long long mqdes,
+                                              long long msg_ptr,
+                                              long long msg_len,
+                                              long long msg_prio);
+void __sanitizer_syscall_pre_impl_compat_50_mq_timedsend(long long mqdes,
+                                                         long long msg_ptr,
+                                                         long long msg_len,
+                                                         long long msg_prio,
+                                                         long long abs_timeout);
+void __sanitizer_syscall_post_impl_compat_50_mq_timedsend(
+    long long res, long long mqdes, long long msg_ptr, long long msg_len,
+    long long msg_prio, long long abs_timeout);
+void __sanitizer_syscall_pre_impl_compat_50_mq_timedreceive(
+    long long mqdes, long long msg_ptr, long long msg_len, long long msg_prio,
+    long long abs_timeout);
+void __sanitizer_syscall_post_impl_compat_50_mq_timedreceive(
+    long long res, long long mqdes, long long msg_ptr, long long msg_len,
+    long long msg_prio, long long abs_timeout);
+/* syscall 267 has been skipped */
+/* syscall 268 has been skipped */
+/* syscall 269 has been skipped */
+void __sanitizer_syscall_pre_impl___posix_rename(long long from, long long to);
+void __sanitizer_syscall_post_impl___posix_rename(long long res, long long from,
+                                                  long long to);
+void __sanitizer_syscall_pre_impl_swapctl(long long cmd, long long arg,
+                                          long long misc);
+void __sanitizer_syscall_post_impl_swapctl(long long res, long long cmd,
+                                           long long arg, long long misc);
+void __sanitizer_syscall_pre_impl_compat_30_getdents(long long fd,
+                                                     long long buf,
+                                                     long long count);
+void __sanitizer_syscall_post_impl_compat_30_getdents(long long res,
+                                                      long long fd,
+                                                      long long buf,
+                                                      long long count);
+void __sanitizer_syscall_pre_impl_minherit(long long addr, long long len,
+                                           long long inherit);
+void __sanitizer_syscall_post_impl_minherit(long long res, long long addr,
+                                            long long len, long long inherit);
+void __sanitizer_syscall_pre_impl_lchmod(long long path, long long mode);
+void __sanitizer_syscall_post_impl_lchmod(long long res, long long path,
+                                          long long mode);
+void __sanitizer_syscall_pre_impl_lchown(long long path, long long uid,
+                                         long long gid);
+void __sanitizer_syscall_post_impl_lchown(long long res, long long path,
+                                          long long uid, long long gid);
+void __sanitizer_syscall_pre_impl_compat_50_lutimes(long long path,
+                                                    long long tptr);
+void __sanitizer_syscall_post_impl_compat_50_lutimes(long long res,
+                                                     long long path,
+                                                     long long tptr);
+void __sanitizer_syscall_pre_impl___msync13(long long addr, long long len,
+                                            long long flags);
+void __sanitizer_syscall_post_impl___msync13(long long res, long long addr,
+                                             long long len, long long flags);
+void __sanitizer_syscall_pre_impl_compat_30___stat13(long long path,
+                                                     long long ub);
+void __sanitizer_syscall_post_impl_compat_30___stat13(long long res,
+                                                      long long path,
+                                                      long long ub);
+void __sanitizer_syscall_pre_impl_compat_30___fstat13(long long fd,
+                                                      long long sb);
+void __sanitizer_syscall_post_impl_compat_30___fstat13(long long res,
+                                                       long long fd,
+                                                       long long sb);
+void __sanitizer_syscall_pre_impl_compat_30___lstat13(long long path,
+                                                      long long ub);
+void __sanitizer_syscall_post_impl_compat_30___lstat13(long long res,
+                                                       long long path,
+                                                       long long ub);
+void __sanitizer_syscall_pre_impl___sigaltstack14(long long nss, long long oss);
+void __sanitizer_syscall_post_impl___sigaltstack14(long long res, long long nss,
+                                                   long long oss);
+void __sanitizer_syscall_pre_impl___vfork14(void);
+void __sanitizer_syscall_post_impl___vfork14(long long res);
+void __sanitizer_syscall_pre_impl___posix_chown(long long path, long long uid,
+                                                long long gid);
+void __sanitizer_syscall_post_impl___posix_chown(long long res, long long path,
+                                                 long long uid, long long gid);
+void __sanitizer_syscall_pre_impl___posix_fchown(long long fd, long long uid,
+                                                 long long gid);
+void __sanitizer_syscall_post_impl___posix_fchown(long long res, long long fd,
+                                                  long long uid, long long gid);
+void __sanitizer_syscall_pre_impl___posix_lchown(long long path, long long uid,
+                                                 long long gid);
+void __sanitizer_syscall_post_impl___posix_lchown(long long res, long long path,
+                                                  long long uid, long long gid);
+void __sanitizer_syscall_pre_impl_getsid(long long pid);
+void __sanitizer_syscall_post_impl_getsid(long long res, long long pid);
+void __sanitizer_syscall_pre_impl___clone(long long flags, long long stack);
+void __sanitizer_syscall_post_impl___clone(long long res, long long flags,
+                                           long long stack);
+void __sanitizer_syscall_pre_impl_fktrace(long long fd, long long ops,
+                                          long long facs, long long pid);
+void __sanitizer_syscall_post_impl_fktrace(long long res, long long fd,
+                                           long long ops, long long facs,
+                                           long long pid);
+void __sanitizer_syscall_pre_impl_preadv(long long fd, long long iovp,
+                                         long long iovcnt, long long PAD,
+                                         long long offset);
+void __sanitizer_syscall_post_impl_preadv(long long res, long long fd,
+                                          long long iovp, long long iovcnt,
+                                          long long PAD, long long offset);
+void __sanitizer_syscall_pre_impl_pwritev(long long fd, long long iovp,
+                                          long long iovcnt, long long PAD,
+                                          long long offset);
+void __sanitizer_syscall_post_impl_pwritev(long long res, long long fd,
+                                           long long iovp, long long iovcnt,
+                                           long long PAD, long long offset);
+void __sanitizer_syscall_pre_impl_compat_16___sigaction14(long long signum,
+                                                          long long nsa,
+                                                          long long osa);
+void __sanitizer_syscall_post_impl_compat_16___sigaction14(long long res,
+                                                           long long signum,
+                                                           long long nsa,
+                                                           long long osa);
+void __sanitizer_syscall_pre_impl___sigpending14(long long set);
+void __sanitizer_syscall_post_impl___sigpending14(long long res, long long set);
+void __sanitizer_syscall_pre_impl___sigprocmask14(long long how, long long set,
+                                                  long long oset);
+void __sanitizer_syscall_post_impl___sigprocmask14(long long res, long long how,
+                                                   long long set,
+                                                   long long oset);
+void __sanitizer_syscall_pre_impl___sigsuspend14(long long set);
+void __sanitizer_syscall_post_impl___sigsuspend14(long long res, long long set);
+void __sanitizer_syscall_pre_impl_compat_16___sigreturn14(long long sigcntxp);
+void __sanitizer_syscall_post_impl_compat_16___sigreturn14(long long res,
+                                                           long long sigcntxp);
+void __sanitizer_syscall_pre_impl___getcwd(long long bufp, long long length);
+void __sanitizer_syscall_post_impl___getcwd(long long res, long long bufp,
+                                            long long length);
+void __sanitizer_syscall_pre_impl_fchroot(long long fd);
+void __sanitizer_syscall_post_impl_fchroot(long long res, long long fd);
+void __sanitizer_syscall_pre_impl_compat_30_fhopen(long long fhp,
+                                                   long long flags);
+void __sanitizer_syscall_post_impl_compat_30_fhopen(long long res,
+                                                    long long fhp,
+                                                    long long flags);
+void __sanitizer_syscall_pre_impl_compat_30_fhstat(long long fhp, long long sb);
+void __sanitizer_syscall_post_impl_compat_30_fhstat(long long res,
+                                                    long long fhp,
+                                                    long long sb);
+void __sanitizer_syscall_pre_impl_compat_20_fhstatfs(long long fhp,
+                                                     long long buf);
+void __sanitizer_syscall_post_impl_compat_20_fhstatfs(long long res,
+                                                      long long fhp,
+                                                      long long buf);
+void __sanitizer_syscall_pre_impl_compat_50_____semctl13(long long semid,
+                                                         long long semnum,
+                                                         long long cmd,
+                                                         long long arg);
+void __sanitizer_syscall_post_impl_compat_50_____semctl13(long long res,
+                                                          long long semid,
+                                                          long long semnum,
+                                                          long long cmd,
+                                                          long long arg);
+void __sanitizer_syscall_pre_impl_compat_50___msgctl13(long long msqid,
+                                                       long long cmd,
+                                                       long long buf);
+void __sanitizer_syscall_post_impl_compat_50___msgctl13(long long res,
+                                                        long long msqid,
+                                                        long long cmd,
+                                                        long long buf);
+void __sanitizer_syscall_pre_impl_compat_50___shmctl13(long long shmid,
+                                                       long long cmd,
+                                                       long long buf);
+void __sanitizer_syscall_post_impl_compat_50___shmctl13(long long res,
+                                                        long long shmid,
+                                                        long long cmd,
+                                                        long long buf);
+void __sanitizer_syscall_pre_impl_lchflags(long long path, long long flags);
+void __sanitizer_syscall_post_impl_lchflags(long long res, long long path,
+                                            long long flags);
+void __sanitizer_syscall_pre_impl_issetugid(void);
+void __sanitizer_syscall_post_impl_issetugid(long long res);
+void __sanitizer_syscall_pre_impl_utrace(long long label, long long addr,
+                                         long long len);
+void __sanitizer_syscall_post_impl_utrace(long long res, long long label,
+                                          long long addr, long long len);
+void __sanitizer_syscall_pre_impl_getcontext(long long ucp);
+void __sanitizer_syscall_post_impl_getcontext(long long res, long long ucp);
+void __sanitizer_syscall_pre_impl_setcontext(long long ucp);
+void __sanitizer_syscall_post_impl_setcontext(long long res, long long ucp);
+void __sanitizer_syscall_pre_impl__lwp_create(long long ucp, long long flags,
+                                              long long new_lwp);
+void __sanitizer_syscall_post_impl__lwp_create(long long res, long long ucp,
+                                               long long flags,
+                                               long long new_lwp);
+void __sanitizer_syscall_pre_impl__lwp_exit(void);
+void __sanitizer_syscall_post_impl__lwp_exit(long long res);
+void __sanitizer_syscall_pre_impl__lwp_self(void);
+void __sanitizer_syscall_post_impl__lwp_self(long long res);
+void __sanitizer_syscall_pre_impl__lwp_wait(long long wait_for,
+                                            long long departed);
+void __sanitizer_syscall_post_impl__lwp_wait(long long res, long long wait_for,
+                                             long long departed);
+void __sanitizer_syscall_pre_impl__lwp_suspend(long long target);
+void __sanitizer_syscall_post_impl__lwp_suspend(long long res,
+                                                long long target);
+void __sanitizer_syscall_pre_impl__lwp_continue(long long target);
+void __sanitizer_syscall_post_impl__lwp_continue(long long res,
+                                                 long long target);
+void __sanitizer_syscall_pre_impl__lwp_wakeup(long long target);
+void __sanitizer_syscall_post_impl__lwp_wakeup(long long res, long long target);
+void __sanitizer_syscall_pre_impl__lwp_getprivate(void);
+void __sanitizer_syscall_post_impl__lwp_getprivate(long long res);
+void __sanitizer_syscall_pre_impl__lwp_setprivate(long long ptr);
+void __sanitizer_syscall_post_impl__lwp_setprivate(long long res,
+                                                   long long ptr);
+void __sanitizer_syscall_pre_impl__lwp_kill(long long target, long long signo);
+void __sanitizer_syscall_post_impl__lwp_kill(long long res, long long target,
+                                             long long signo);
+void __sanitizer_syscall_pre_impl__lwp_detach(long long target);
+void __sanitizer_syscall_post_impl__lwp_detach(long long res, long long target);
+void __sanitizer_syscall_pre_impl_compat_50__lwp_park(long long ts,
+                                                      long long unpark,
+                                                      long long hint,
+                                                      long long unparkhint);
+void __sanitizer_syscall_post_impl_compat_50__lwp_park(long long res,
+                                                       long long ts,
+                                                       long long unpark,
+                                                       long long hint,
+                                                       long long unparkhint);
+void __sanitizer_syscall_pre_impl__lwp_unpark(long long target, long long hint);
+void __sanitizer_syscall_post_impl__lwp_unpark(long long res, long long target,
+                                               long long hint);
+void __sanitizer_syscall_pre_impl__lwp_unpark_all(long long targets,
+                                                  long long ntargets,
+                                                  long long hint);
+void __sanitizer_syscall_post_impl__lwp_unpark_all(long long res,
+                                                   long long targets,
+                                                   long long ntargets,
+                                                   long long hint);
+void __sanitizer_syscall_pre_impl__lwp_setname(long long target,
+                                               long long name);
+void __sanitizer_syscall_post_impl__lwp_setname(long long res, long long target,
+                                                long long name);
+void __sanitizer_syscall_pre_impl__lwp_getname(long long target, long long name,
+                                               long long len);
+void __sanitizer_syscall_post_impl__lwp_getname(long long res, long long target,
+                                                long long name, long long len);
+void __sanitizer_syscall_pre_impl__lwp_ctl(long long features,
+                                           long long address);
+void __sanitizer_syscall_post_impl__lwp_ctl(long long res, long long features,
+                                            long long address);
+/* syscall 326 has been skipped */
+/* syscall 327 has been skipped */
+/* syscall 328 has been skipped */
+/* syscall 329 has been skipped */
+void __sanitizer_syscall_pre_impl_compat_60_sa_register(
+    long long newv, long long oldv, long long flags,
+    long long stackinfo_offset);
+void __sanitizer_syscall_post_impl_compat_60_sa_register(
+    long long res, long long newv, long long oldv, long long flags,
+    long long stackinfo_offset);
+void __sanitizer_syscall_pre_impl_compat_60_sa_stacks(long long num,
+                                                      long long stacks);
+void __sanitizer_syscall_post_impl_compat_60_sa_stacks(long long res,
+                                                       long long num,
+                                                       long long stacks);
+void __sanitizer_syscall_pre_impl_compat_60_sa_enable(void);
+void __sanitizer_syscall_post_impl_compat_60_sa_enable(long long res);
+void __sanitizer_syscall_pre_impl_compat_60_sa_setconcurrency(
+    long long concurrency);
+void __sanitizer_syscall_post_impl_compat_60_sa_setconcurrency(
+    long long res, long long concurrency);
+void __sanitizer_syscall_pre_impl_compat_60_sa_yield(void);
+void __sanitizer_syscall_post_impl_compat_60_sa_yield(long long res);
+void __sanitizer_syscall_pre_impl_compat_60_sa_preempt(long long sa_id);
+void __sanitizer_syscall_post_impl_compat_60_sa_preempt(long long res,
+                                                        long long sa_id);
+/* syscall 336 has been skipped */
+/* syscall 337 has been skipped */
+/* syscall 338 has been skipped */
+/* syscall 339 has been skipped */
+void __sanitizer_syscall_pre_impl___sigaction_sigtramp(long long signum,
+                                                       long long nsa,
+                                                       long long osa,
+                                                       long long tramp,
+                                                       long long vers);
+void __sanitizer_syscall_post_impl___sigaction_sigtramp(
+    long long res, long long signum, long long nsa, long long osa,
+    long long tramp, long long vers);
+/* syscall 341 has been skipped */
+/* syscall 342 has been skipped */
+void __sanitizer_syscall_pre_impl_rasctl(long long addr, long long len,
+                                         long long op);
+void __sanitizer_syscall_post_impl_rasctl(long long res, long long addr,
+                                          long long len, long long op);
+void __sanitizer_syscall_pre_impl_kqueue(void);
+void __sanitizer_syscall_post_impl_kqueue(long long res);
+void __sanitizer_syscall_pre_impl_compat_50_kevent(
+    long long fd, long long changelist, long long nchanges, long long eventlist,
+    long long nevents, long long timeout);
+void __sanitizer_syscall_post_impl_compat_50_kevent(
+    long long res, long long fd, long long changelist, long long nchanges,
+    long long eventlist, long long nevents, long long timeout);
+void __sanitizer_syscall_pre_impl__sched_setparam(long long pid, long long lid,
+                                                  long long policy,
+                                                  long long params);
+void __sanitizer_syscall_post_impl__sched_setparam(long long res, long long pid,
+                                                   long long lid,
+                                                   long long policy,
+                                                   long long params);
+void __sanitizer_syscall_pre_impl__sched_getparam(long long pid, long long lid,
+                                                  long long policy,
+                                                  long long params);
+void __sanitizer_syscall_post_impl__sched_getparam(long long res, long long pid,
+                                                   long long lid,
+                                                   long long policy,
+                                                   long long params);
+void __sanitizer_syscall_pre_impl__sched_setaffinity(long long pid,
+                                                     long long lid,
+                                                     long long size,
+                                                     long long cpuset);
+void __sanitizer_syscall_post_impl__sched_setaffinity(long long res,
+                                                      long long pid,
+                                                      long long lid,
+                                                      long long size,
+                                                      long long cpuset);
+void __sanitizer_syscall_pre_impl__sched_getaffinity(long long pid,
+                                                     long long lid,
+                                                     long long size,
+                                                     long long cpuset);
+void __sanitizer_syscall_post_impl__sched_getaffinity(long long res,
+                                                      long long pid,
+                                                      long long lid,
+                                                      long long size,
+                                                      long long cpuset);
+void __sanitizer_syscall_pre_impl_sched_yield(void);
+void __sanitizer_syscall_post_impl_sched_yield(long long res);
+void __sanitizer_syscall_pre_impl__sched_protect(long long priority);
+void __sanitizer_syscall_post_impl__sched_protect(long long res,
+                                                  long long priority);
+/* syscall 352 has been skipped */
+/* syscall 353 has been skipped */
+void __sanitizer_syscall_pre_impl_fsync_range(long long fd, long long flags,
+                                              long long start,
+                                              long long length);
+void __sanitizer_syscall_post_impl_fsync_range(long long res, long long fd,
+                                               long long flags, long long start,
+                                               long long length);
+void __sanitizer_syscall_pre_impl_uuidgen(long long store, long long count);
+void __sanitizer_syscall_post_impl_uuidgen(long long res, long long store,
+                                           long long count);
+void __sanitizer_syscall_pre_impl_getvfsstat(long long buf, long long bufsize,
+                                             long long flags);
+void __sanitizer_syscall_post_impl_getvfsstat(long long res, long long buf,
+                                              long long bufsize,
+                                              long long flags);
+void __sanitizer_syscall_pre_impl_statvfs1(long long path, long long buf,
+                                           long long flags);
+void __sanitizer_syscall_post_impl_statvfs1(long long res, long long path,
+                                            long long buf, long long flags);
+void __sanitizer_syscall_pre_impl_fstatvfs1(long long fd, long long buf,
+                                            long long flags);
+void __sanitizer_syscall_post_impl_fstatvfs1(long long res, long long fd,
+                                             long long buf, long long flags);
+void __sanitizer_syscall_pre_impl_compat_30_fhstatvfs1(long long fhp,
+                                                       long long buf,
+                                                       long long flags);
+void __sanitizer_syscall_post_impl_compat_30_fhstatvfs1(long long res,
+                                                        long long fhp,
+                                                        long long buf,
+                                                        long long flags);
+void __sanitizer_syscall_pre_impl_extattrctl(long long path, long long cmd,
+                                             long long filename,
+                                             long long attrnamespace,
+                                             long long attrname);
+void __sanitizer_syscall_post_impl_extattrctl(long long res, long long path,
+                                              long long cmd, long long filename,
+                                              long long attrnamespace,
+                                              long long attrname);
+void __sanitizer_syscall_pre_impl_extattr_set_file(long long path,
+                                                   long long attrnamespace,
+                                                   long long attrname,
+                                                   long long data,
+                                                   long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_set_file(
+    long long res, long long path, long long attrnamespace, long long attrname,
+    long long data, long long nbytes);
+void __sanitizer_syscall_pre_impl_extattr_get_file(long long path,
+                                                   long long attrnamespace,
+                                                   long long attrname,
+                                                   long long data,
+                                                   long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_get_file(
+    long long res, long long path, long long attrnamespace, long long attrname,
+    long long data, long long nbytes);
+void __sanitizer_syscall_pre_impl_extattr_delete_file(long long path,
+                                                      long long attrnamespace,
+                                                      long long attrname);
+void __sanitizer_syscall_post_impl_extattr_delete_file(long long res,
+                                                       long long path,
+                                                       long long attrnamespace,
+                                                       long long attrname);
+void __sanitizer_syscall_pre_impl_extattr_set_fd(long long fd,
+                                                 long long attrnamespace,
+                                                 long long attrname,
+                                                 long long data,
+                                                 long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_set_fd(long long res, long long fd,
+                                                  long long attrnamespace,
+                                                  long long attrname,
+                                                  long long data,
+                                                  long long nbytes);
+void __sanitizer_syscall_pre_impl_extattr_get_fd(long long fd,
+                                                 long long attrnamespace,
+                                                 long long attrname,
+                                                 long long data,
+                                                 long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_get_fd(long long res, long long fd,
+                                                  long long attrnamespace,
+                                                  long long attrname,
+                                                  long long data,
+                                                  long long nbytes);
+void __sanitizer_syscall_pre_impl_extattr_delete_fd(long long fd,
+                                                    long long attrnamespace,
+                                                    long long attrname);
+void __sanitizer_syscall_post_impl_extattr_delete_fd(long long res,
+                                                     long long fd,
+                                                     long long attrnamespace,
+                                                     long long attrname);
+void __sanitizer_syscall_pre_impl_extattr_set_link(long long path,
+                                                   long long attrnamespace,
+                                                   long long attrname,
+                                                   long long data,
+                                                   long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_set_link(
+    long long res, long long path, long long attrnamespace, long long attrname,
+    long long data, long long nbytes);
+void __sanitizer_syscall_pre_impl_extattr_get_link(long long path,
+                                                   long long attrnamespace,
+                                                   long long attrname,
+                                                   long long data,
+                                                   long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_get_link(
+    long long res, long long path, long long attrnamespace, long long attrname,
+    long long data, long long nbytes);
+void __sanitizer_syscall_pre_impl_extattr_delete_link(long long path,
+                                                      long long attrnamespace,
+                                                      long long attrname);
+void __sanitizer_syscall_post_impl_extattr_delete_link(long long res,
+                                                       long long path,
+                                                       long long attrnamespace,
+                                                       long long attrname);
+void __sanitizer_syscall_pre_impl_extattr_list_fd(long long fd,
+                                                  long long attrnamespace,
+                                                  long long data,
+                                                  long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_list_fd(long long res, long long fd,
+                                                   long long attrnamespace,
+                                                   long long data,
+                                                   long long nbytes);
+void __sanitizer_syscall_pre_impl_extattr_list_file(long long path,
+                                                    long long attrnamespace,
+                                                    long long data,
+                                                    long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_list_file(long long res,
+                                                     long long path,
+                                                     long long attrnamespace,
+                                                     long long data,
+                                                     long long nbytes);
+void __sanitizer_syscall_pre_impl_extattr_list_link(long long path,
+                                                    long long attrnamespace,
+                                                    long long data,
+                                                    long long nbytes);
+void __sanitizer_syscall_post_impl_extattr_list_link(long long res,
+                                                     long long path,
+                                                     long long attrnamespace,
+                                                     long long data,
+                                                     long long nbytes);
+void __sanitizer_syscall_pre_impl_compat_50_pselect(long long nd, long long in,
+                                                    long long ou, long long ex,
+                                                    long long ts,
+                                                    long long mask);
+void __sanitizer_syscall_post_impl_compat_50_pselect(long long res,
+                                                     long long nd, long long in,
+                                                     long long ou, long long ex,
+                                                     long long ts,
+                                                     long long mask);
+void __sanitizer_syscall_pre_impl_compat_50_pollts(long long fds,
+                                                   long long nfds, long long ts,
+                                                   long long mask);
+void __sanitizer_syscall_post_impl_compat_50_pollts(
+    long long res, long long fds, long long nfds, long long ts, long long mask);
+void __sanitizer_syscall_pre_impl_setxattr(long long path, long long name,
+                                           long long value, long long size,
+                                           long long flags);
+void __sanitizer_syscall_post_impl_setxattr(long long res, long long path,
+                                            long long name, long long value,
+                                            long long size, long long flags);
+void __sanitizer_syscall_pre_impl_lsetxattr(long long path, long long name,
+                                            long long value, long long size,
+                                            long long flags);
+void __sanitizer_syscall_post_impl_lsetxattr(long long res, long long path,
+                                             long long name, long long value,
+                                             long long size, long long flags);
+void __sanitizer_syscall_pre_impl_fsetxattr(long long fd, long long name,
+                                            long long value, long long size,
+                                            long long flags);
+void __sanitizer_syscall_post_impl_fsetxattr(long long res, long long fd,
+                                             long long name, long long value,
+                                             long long size, long long flags);
+void __sanitizer_syscall_pre_impl_getxattr(long long path, long long name,
+                                           long long value, long long size);
+void __sanitizer_syscall_post_impl_getxattr(long long res, long long path,
+                                            long long name, long long value,
+                                            long long size);
+void __sanitizer_syscall_pre_impl_lgetxattr(long long path, long long name,
+                                            long long value, long long size);
+void __sanitizer_syscall_post_impl_lgetxattr(long long res, long long path,
+                                             long long name, long long value,
+                                             long long size);
+void __sanitizer_syscall_pre_impl_fgetxattr(long long fd, long long name,
+                                            long long value, long long size);
+void __sanitizer_syscall_post_impl_fgetxattr(long long res, long long fd,
+                                             long long name, long long value,
+                                             long long size);
+void __sanitizer_syscall_pre_impl_listxattr(long long path, long long list,
+                                            long long size);
+void __sanitizer_syscall_post_impl_listxattr(long long res, long long path,
+                                             long long list, long long size);
+void __sanitizer_syscall_pre_impl_llistxattr(long long path, long long list,
+                                             long long size);
+void __sanitizer_syscall_post_impl_llistxattr(long long res, long long path,
+                                              long long list, long long size);
+void __sanitizer_syscall_pre_impl_flistxattr(long long fd, long long list,
+                                             long long size);
+void __sanitizer_syscall_post_impl_flistxattr(long long res, long long fd,
+                                              long long list, long long size);
+void __sanitizer_syscall_pre_impl_removexattr(long long path, long long name);
+void __sanitizer_syscall_post_impl_removexattr(long long res, long long path,
+                                               long long name);
+void __sanitizer_syscall_pre_impl_lremovexattr(long long path, long long name);
+void __sanitizer_syscall_post_impl_lremovexattr(long long res, long long path,
+                                                long long name);
+void __sanitizer_syscall_pre_impl_fremovexattr(long long fd, long long name);
+void __sanitizer_syscall_post_impl_fremovexattr(long long res, long long fd,
+                                                long long name);
+void __sanitizer_syscall_pre_impl_compat_50___stat30(long long path,
+                                                     long long ub);
+void __sanitizer_syscall_post_impl_compat_50___stat30(long long res,
+                                                      long long path,
+                                                      long long ub);
+void __sanitizer_syscall_pre_impl_compat_50___fstat30(long long fd,
+                                                      long long sb);
+void __sanitizer_syscall_post_impl_compat_50___fstat30(long long res,
+                                                       long long fd,
+                                                       long long sb);
+void __sanitizer_syscall_pre_impl_compat_50___lstat30(long long path,
+                                                      long long ub);
+void __sanitizer_syscall_post_impl_compat_50___lstat30(long long res,
+                                                       long long path,
+                                                       long long ub);
+void __sanitizer_syscall_pre_impl___getdents30(long long fd, long long buf,
+                                               long long count);
+void __sanitizer_syscall_post_impl___getdents30(long long res, long long fd,
+                                                long long buf, long long count);
+void __sanitizer_syscall_pre_impl_posix_fadvise(long long);
+void __sanitizer_syscall_post_impl_posix_fadvise(long long res, long long);
+void __sanitizer_syscall_pre_impl_compat_30___fhstat30(long long fhp,
+                                                       long long sb);
+void __sanitizer_syscall_post_impl_compat_30___fhstat30(long long res,
+                                                        long long fhp,
+                                                        long long sb);
+void __sanitizer_syscall_pre_impl_compat_50___ntp_gettime30(long long ntvp);
+void __sanitizer_syscall_post_impl_compat_50___ntp_gettime30(long long res,
+                                                             long long ntvp);
+void __sanitizer_syscall_pre_impl___socket30(long long domain, long long type,
+                                             long long protocol);
+void __sanitizer_syscall_post_impl___socket30(long long res, long long domain,
+                                              long long type,
+                                              long long protocol);
+void __sanitizer_syscall_pre_impl___getfh30(long long fname, long long fhp,
+                                            long long fh_size);
+void __sanitizer_syscall_post_impl___getfh30(long long res, long long fname,
+                                             long long fhp, long long fh_size);
+void __sanitizer_syscall_pre_impl___fhopen40(long long fhp, long long fh_size,
+                                             long long flags);
+void __sanitizer_syscall_post_impl___fhopen40(long long res, long long fhp,
+                                              long long fh_size,
+                                              long long flags);
+void __sanitizer_syscall_pre_impl___fhstatvfs140(long long fhp,
+                                                 long long fh_size,
+                                                 long long buf,
+                                                 long long flags);
+void __sanitizer_syscall_post_impl___fhstatvfs140(long long res, long long fhp,
+                                                  long long fh_size,
+                                                  long long buf,
+                                                  long long flags);
+void __sanitizer_syscall_pre_impl_compat_50___fhstat40(long long fhp,
+                                                       long long fh_size,
+                                                       long long sb);
+void __sanitizer_syscall_post_impl_compat_50___fhstat40(long long res,
+                                                        long long fhp,
+                                                        long long fh_size,
+                                                        long long sb);
+void __sanitizer_syscall_pre_impl_aio_cancel(long long fildes,
+                                             long long aiocbp);
+void __sanitizer_syscall_post_impl_aio_cancel(long long res, long long fildes,
+                                              long long aiocbp);
+void __sanitizer_syscall_pre_impl_aio_error(long long aiocbp);
+void __sanitizer_syscall_post_impl_aio_error(long long res, long long aiocbp);
+void __sanitizer_syscall_pre_impl_aio_fsync(long long op, long long aiocbp);
+void __sanitizer_syscall_post_impl_aio_fsync(long long res, long long op,
+                                             long long aiocbp);
+void __sanitizer_syscall_pre_impl_aio_read(long long aiocbp);
+void __sanitizer_syscall_post_impl_aio_read(long long res, long long aiocbp);
+void __sanitizer_syscall_pre_impl_aio_return(long long aiocbp);
+void __sanitizer_syscall_post_impl_aio_return(long long res, long long aiocbp);
+void __sanitizer_syscall_pre_impl_compat_50_aio_suspend(long long list,
+                                                        long long nent,
+                                                        long long timeout);
+void __sanitizer_syscall_post_impl_compat_50_aio_suspend(long long res,
+                                                         long long list,
+                                                         long long nent,
+                                                         long long timeout);
+void __sanitizer_syscall_pre_impl_aio_write(long long aiocbp);
+void __sanitizer_syscall_post_impl_aio_write(long long res, long long aiocbp);
+void __sanitizer_syscall_pre_impl_lio_listio(long long mode, long long list,
+                                             long long nent, long long sig);
+void __sanitizer_syscall_post_impl_lio_listio(long long res, long long mode,
+                                              long long list, long long nent,
+                                              long long sig);
+/* syscall 407 has been skipped */
+/* syscall 408 has been skipped */
+/* syscall 409 has been skipped */
+void __sanitizer_syscall_pre_impl___mount50(long long type, long long path,
+                                            long long flags, long long data,
+                                            long long data_len);
+void __sanitizer_syscall_post_impl___mount50(long long res, long long type,
+                                             long long path, long long flags,
+                                             long long data,
+                                             long long data_len);
+void __sanitizer_syscall_pre_impl_mremap(long long old_address,
+                                         long long old_size,
+                                         long long new_address,
+                                         long long new_size, long long flags);
+void __sanitizer_syscall_post_impl_mremap(long long res, long long old_address,
+                                          long long old_size,
+                                          long long new_address,
+                                          long long new_size, long long flags);
+void __sanitizer_syscall_pre_impl_pset_create(long long psid);
+void __sanitizer_syscall_post_impl_pset_create(long long res, long long psid);
+void __sanitizer_syscall_pre_impl_pset_destroy(long long psid);
+void __sanitizer_syscall_post_impl_pset_destroy(long long res, long long psid);
+void __sanitizer_syscall_pre_impl_pset_assign(long long psid, long long cpuid,
+                                              long long opsid);
+void __sanitizer_syscall_post_impl_pset_assign(long long res, long long psid,
+                                               long long cpuid,
+                                               long long opsid);
+void __sanitizer_syscall_pre_impl__pset_bind(long long idtype,
+                                             long long first_id,
+                                             long long second_id,
+                                             long long psid, long long opsid);
+void __sanitizer_syscall_post_impl__pset_bind(long long res, long long idtype,
+                                              long long first_id,
+                                              long long second_id,
+                                              long long psid, long long opsid);
+void __sanitizer_syscall_pre_impl___posix_fadvise50(long long fd, long long PAD,
+                                                    long long offset,
+                                                    long long len,
+                                                    long long advice);
+void __sanitizer_syscall_post_impl___posix_fadvise50(
+    long long res, long long fd, long long PAD, long long offset, long long len,
+    long long advice);
+void __sanitizer_syscall_pre_impl___select50(long long nd, long long in,
+                                             long long ou, long long ex,
+                                             long long tv);
+void __sanitizer_syscall_post_impl___select50(long long res, long long nd,
+                                              long long in, long long ou,
+                                              long long ex, long long tv);
+void __sanitizer_syscall_pre_impl___gettimeofday50(long long tp, long long tzp);
+void __sanitizer_syscall_post_impl___gettimeofday50(long long res, long long tp,
+                                                    long long tzp);
+void __sanitizer_syscall_pre_impl___settimeofday50(long long tv, long long tzp);
+void __sanitizer_syscall_post_impl___settimeofday50(long long res, long long tv,
+                                                    long long tzp);
+void __sanitizer_syscall_pre_impl___utimes50(long long path, long long tptr);
+void __sanitizer_syscall_post_impl___utimes50(long long res, long long path,
+                                              long long tptr);
+void __sanitizer_syscall_pre_impl___adjtime50(long long delta,
+                                              long long olddelta);
+void __sanitizer_syscall_post_impl___adjtime50(long long res, long long delta,
+                                               long long olddelta);
+void __sanitizer_syscall_pre_impl___lfs_segwait50(long long fsidp,
+                                                  long long tv);
+void __sanitizer_syscall_post_impl___lfs_segwait50(long long res,
+                                                   long long fsidp,
+                                                   long long tv);
+void __sanitizer_syscall_pre_impl___futimes50(long long fd, long long tptr);
+void __sanitizer_syscall_post_impl___futimes50(long long res, long long fd,
+                                               long long tptr);
+void __sanitizer_syscall_pre_impl___lutimes50(long long path, long long tptr);
+void __sanitizer_syscall_post_impl___lutimes50(long long res, long long path,
+                                               long long tptr);
+void __sanitizer_syscall_pre_impl___setitimer50(long long which, long long itv,
+                                                long long oitv);
+void __sanitizer_syscall_post_impl___setitimer50(long long res, long long which,
+                                                 long long itv, long long oitv);
+void __sanitizer_syscall_pre_impl___getitimer50(long long which, long long itv);
+void __sanitizer_syscall_post_impl___getitimer50(long long res, long long which,
+                                                 long long itv);
+void __sanitizer_syscall_pre_impl___clock_gettime50(long long clock_id,
+                                                    long long tp);
+void __sanitizer_syscall_post_impl___clock_gettime50(long long res,
+                                                     long long clock_id,
+                                                     long long tp);
+void __sanitizer_syscall_pre_impl___clock_settime50(long long clock_id,
+                                                    long long tp);
+void __sanitizer_syscall_post_impl___clock_settime50(long long res,
+                                                     long long clock_id,
+                                                     long long tp);
+void __sanitizer_syscall_pre_impl___clock_getres50(long long clock_id,
+                                                   long long tp);
+void __sanitizer_syscall_post_impl___clock_getres50(long long res,
+                                                    long long clock_id,
+                                                    long long tp);
+void __sanitizer_syscall_pre_impl___nanosleep50(long long rqtp, long long rmtp);
+void __sanitizer_syscall_post_impl___nanosleep50(long long res, long long rqtp,
+                                                 long long rmtp);
+void __sanitizer_syscall_pre_impl_____sigtimedwait50(long long set,
+                                                     long long info,
+                                                     long long timeout);
+void __sanitizer_syscall_post_impl_____sigtimedwait50(long long res,
+                                                      long long set,
+                                                      long long info,
+                                                      long long timeout);
+void __sanitizer_syscall_pre_impl___mq_timedsend50(long long mqdes,
+                                                   long long msg_ptr,
+                                                   long long msg_len,
+                                                   long long msg_prio,
+                                                   long long abs_timeout);
+void __sanitizer_syscall_post_impl___mq_timedsend50(
+    long long res, long long mqdes, long long msg_ptr, long long msg_len,
+    long long msg_prio, long long abs_timeout);
+void __sanitizer_syscall_pre_impl___mq_timedreceive50(long long mqdes,
+                                                      long long msg_ptr,
+                                                      long long msg_len,
+                                                      long long msg_prio,
+                                                      long long abs_timeout);
+void __sanitizer_syscall_post_impl___mq_timedreceive50(
+    long long res, long long mqdes, long long msg_ptr, long long msg_len,
+    long long msg_prio, long long abs_timeout);
+void __sanitizer_syscall_pre_impl_compat_60__lwp_park(long long ts,
+                                                      long long unpark,
+                                                      long long hint,
+                                                      long long unparkhint);
+void __sanitizer_syscall_post_impl_compat_60__lwp_park(long long res,
+                                                       long long ts,
+                                                       long long unpark,
+                                                       long long hint,
+                                                       long long unparkhint);
+void __sanitizer_syscall_pre_impl___kevent50(long long fd, long long changelist,
+                                             long long nchanges,
+                                             long long eventlist,
+                                             long long nevents,
+                                             long long timeout);
+void __sanitizer_syscall_post_impl___kevent50(
+    long long res, long long fd, long long changelist, long long nchanges,
+    long long eventlist, long long nevents, long long timeout);
+void __sanitizer_syscall_pre_impl___pselect50(long long nd, long long in,
+                                              long long ou, long long ex,
+                                              long long ts, long long mask);
+void __sanitizer_syscall_post_impl___pselect50(long long res, long long nd,
+                                               long long in, long long ou,
+                                               long long ex, long long ts,
+                                               long long mask);
+void __sanitizer_syscall_pre_impl___pollts50(long long fds, long long nfds,
+                                             long long ts, long long mask);
+void __sanitizer_syscall_post_impl___pollts50(long long res, long long fds,
+                                              long long nfds, long long ts,
+                                              long long mask);
+void __sanitizer_syscall_pre_impl___aio_suspend50(long long list,
+                                                  long long nent,
+                                                  long long timeout);
+void __sanitizer_syscall_post_impl___aio_suspend50(long long res,
+                                                   long long list,
+                                                   long long nent,
+                                                   long long timeout);
+void __sanitizer_syscall_pre_impl___stat50(long long path, long long ub);
+void __sanitizer_syscall_post_impl___stat50(long long res, long long path,
+                                            long long ub);
+void __sanitizer_syscall_pre_impl___fstat50(long long fd, long long sb);
+void __sanitizer_syscall_post_impl___fstat50(long long res, long long fd,
+                                             long long sb);
+void __sanitizer_syscall_pre_impl___lstat50(long long path, long long ub);
+void __sanitizer_syscall_post_impl___lstat50(long long res, long long path,
+                                             long long ub);
+void __sanitizer_syscall_pre_impl_____semctl50(long long semid,
+                                               long long semnum, long long cmd,
+                                               long long arg);
+void __sanitizer_syscall_post_impl_____semctl50(long long res, long long semid,
+                                                long long semnum, long long cmd,
+                                                long long arg);
+void __sanitizer_syscall_pre_impl___shmctl50(long long shmid, long long cmd,
+                                             long long buf);
+void __sanitizer_syscall_post_impl___shmctl50(long long res, long long shmid,
+                                              long long cmd, long long buf);
+void __sanitizer_syscall_pre_impl___msgctl50(long long msqid, long long cmd,
+                                             long long buf);
+void __sanitizer_syscall_post_impl___msgctl50(long long res, long long msqid,
+                                              long long cmd, long long buf);
+void __sanitizer_syscall_pre_impl___getrusage50(long long who,
+                                                long long rusage);
+void __sanitizer_syscall_post_impl___getrusage50(long long res, long long who,
+                                                 long long rusage);
+void __sanitizer_syscall_pre_impl___timer_settime50(long long timerid,
+                                                    long long flags,
+                                                    long long value,
+                                                    long long ovalue);
+void __sanitizer_syscall_post_impl___timer_settime50(long long res,
+                                                     long long timerid,
+                                                     long long flags,
+                                                     long long value,
+                                                     long long ovalue);
+void __sanitizer_syscall_pre_impl___timer_gettime50(long long timerid,
+                                                    long long value);
+void __sanitizer_syscall_post_impl___timer_gettime50(long long res,
+                                                     long long timerid,
+                                                     long long value);
+#if defined(NTP) || !defined(_KERNEL_OPT)
+void __sanitizer_syscall_pre_impl___ntp_gettime50(long long ntvp);
+void __sanitizer_syscall_post_impl___ntp_gettime50(long long res,
+                                                   long long ntvp);
+#else
+/* syscall 448 has been skipped */
+#endif
+void __sanitizer_syscall_pre_impl___wait450(long long pid, long long status,
+                                            long long options,
+                                            long long rusage);
+void __sanitizer_syscall_post_impl___wait450(long long res, long long pid,
+                                             long long status,
+                                             long long options,
+                                             long long rusage);
+void __sanitizer_syscall_pre_impl___mknod50(long long path, long long mode,
+                                            long long dev);
+void __sanitizer_syscall_post_impl___mknod50(long long res, long long path,
+                                             long long mode, long long dev);
+void __sanitizer_syscall_pre_impl___fhstat50(long long fhp, long long fh_size,
+                                             long long sb);
+void __sanitizer_syscall_post_impl___fhstat50(long long res, long long fhp,
+                                              long long fh_size, long long sb);
+/* syscall 452 has been skipped */
+void __sanitizer_syscall_pre_impl_pipe2(long long fildes, long long flags);
+void __sanitizer_syscall_post_impl_pipe2(long long res, long long fildes,
+                                         long long flags);
+void __sanitizer_syscall_pre_impl_dup3(long long from, long long to,
+                                       long long flags);
+void __sanitizer_syscall_post_impl_dup3(long long res, long long from,
+                                        long long to, long long flags);
+void __sanitizer_syscall_pre_impl_kqueue1(long long flags);
+void __sanitizer_syscall_post_impl_kqueue1(long long res, long long flags);
+void __sanitizer_syscall_pre_impl_paccept(long long s, long long name,
+                                          long long anamelen, long long mask,
+                                          long long flags);
+void __sanitizer_syscall_post_impl_paccept(long long res, long long s,
+                                           long long name, long long anamelen,
+                                           long long mask, long long flags);
+void __sanitizer_syscall_pre_impl_linkat(long long fd1, long long name1,
+                                         long long fd2, long long name2,
+                                         long long flags);
+void __sanitizer_syscall_post_impl_linkat(long long res, long long fd1,
+                                          long long name1, long long fd2,
+                                          long long name2, long long flags);
+void __sanitizer_syscall_pre_impl_renameat(long long fromfd, long long from,
+                                           long long tofd, long long to);
+void __sanitizer_syscall_post_impl_renameat(long long res, long long fromfd,
+                                            long long from, long long tofd,
+                                            long long to);
+void __sanitizer_syscall_pre_impl_mkfifoat(long long fd, long long path,
+                                           long long mode);
+void __sanitizer_syscall_post_impl_mkfifoat(long long res, long long fd,
+                                            long long path, long long mode);
+void __sanitizer_syscall_pre_impl_mknodat(long long fd, long long path,
+                                          long long mode, long long PAD,
+                                          long long dev);
+void __sanitizer_syscall_post_impl_mknodat(long long res, long long fd,
+                                           long long path, long long mode,
+                                           long long PAD, long long dev);
+void __sanitizer_syscall_pre_impl_mkdirat(long long fd, long long path,
+                                          long long mode);
+void __sanitizer_syscall_post_impl_mkdirat(long long res, long long fd,
+                                           long long path, long long mode);
+void __sanitizer_syscall_pre_impl_faccessat(long long fd, long long path,
+                                            long long amode, long long flag);
+void __sanitizer_syscall_post_impl_faccessat(long long res, long long fd,
+                                             long long path, long long amode,
+                                             long long flag);
+void __sanitizer_syscall_pre_impl_fchmodat(long long fd, long long path,
+                                           long long mode, long long flag);
+void __sanitizer_syscall_post_impl_fchmodat(long long res, long long fd,
+                                            long long path, long long mode,
+                                            long long flag);
+void __sanitizer_syscall_pre_impl_fchownat(long long fd, long long path,
+                                           long long owner, long long group,
+                                           long long flag);
+void __sanitizer_syscall_post_impl_fchownat(long long res, long long fd,
+                                            long long path, long long owner,
+                                            long long group, long long flag);
+void __sanitizer_syscall_pre_impl_fexecve(long long fd, long long argp,
+                                          long long envp);
+void __sanitizer_syscall_post_impl_fexecve(long long res, long long fd,
+                                           long long argp, long long envp);
+void __sanitizer_syscall_pre_impl_fstatat(long long fd, long long path,
+                                          long long buf, long long flag);
+void __sanitizer_syscall_post_impl_fstatat(long long res, long long fd,
+                                           long long path, long long buf,
+                                           long long flag);
+void __sanitizer_syscall_pre_impl_utimensat(long long fd, long long path,
+                                            long long tptr, long long flag);
+void __sanitizer_syscall_post_impl_utimensat(long long res, long long fd,
+                                             long long path, long long tptr,
+                                             long long flag);
+void __sanitizer_syscall_pre_impl_openat(long long fd, long long path,
+                                         long long oflags, long long mode);
+void __sanitizer_syscall_post_impl_openat(long long res, long long fd,
+                                          long long path, long long oflags,
+                                          long long mode);
+void __sanitizer_syscall_pre_impl_readlinkat(long long fd, long long path,
+                                             long long buf, long long bufsize);
+void __sanitizer_syscall_post_impl_readlinkat(long long res, long long fd,
+                                              long long path, long long buf,
+                                              long long bufsize);
+void __sanitizer_syscall_pre_impl_symlinkat(long long path1, long long fd,
+                                            long long path2);
+void __sanitizer_syscall_post_impl_symlinkat(long long res, long long path1,
+                                             long long fd, long long path2);
+void __sanitizer_syscall_pre_impl_unlinkat(long long fd, long long path,
+                                           long long flag);
+void __sanitizer_syscall_post_impl_unlinkat(long long res, long long fd,
+                                            long long path, long long flag);
+void __sanitizer_syscall_pre_impl_futimens(long long fd, long long tptr);
+void __sanitizer_syscall_post_impl_futimens(long long res, long long fd,
+                                            long long tptr);
+void __sanitizer_syscall_pre_impl___quotactl(long long path, long long args);
+void __sanitizer_syscall_post_impl___quotactl(long long res, long long path,
+                                              long long args);
+void __sanitizer_syscall_pre_impl_posix_spawn(long long pid, long long path,
+                                              long long file_actions,
+                                              long long attrp, long long argv,
+                                              long long envp);
+void __sanitizer_syscall_post_impl_posix_spawn(long long res, long long pid,
+                                               long long path,
+                                               long long file_actions,
+                                               long long attrp, long long argv,
+                                               long long envp);
+void __sanitizer_syscall_pre_impl_recvmmsg(long long s, long long mmsg,
+                                           long long vlen, long long flags,
+                                           long long timeout);
+void __sanitizer_syscall_post_impl_recvmmsg(long long res, long long s,
+                                            long long mmsg, long long vlen,
+                                            long long flags, long long timeout);
+void __sanitizer_syscall_pre_impl_sendmmsg(long long s, long long mmsg,
+                                           long long vlen, long long flags);
+void __sanitizer_syscall_post_impl_sendmmsg(long long res, long long s,
+                                            long long mmsg, long long vlen,
+                                            long long flags);
+void __sanitizer_syscall_pre_impl_clock_nanosleep(long long clock_id,
+                                                  long long flags,
+                                                  long long rqtp,
+                                                  long long rmtp);
+void __sanitizer_syscall_post_impl_clock_nanosleep(long long res,
+                                                   long long clock_id,
+                                                   long long flags,
+                                                   long long rqtp,
+                                                   long long rmtp);
+void __sanitizer_syscall_pre_impl____lwp_park60(long long clock_id,
+                                                long long flags, long long ts,
+                                                long long unpark,
+                                                long long hint,
+                                                long long unparkhint);
+void __sanitizer_syscall_post_impl____lwp_park60(
+    long long res, long long clock_id, long long flags, long long ts,
+    long long unpark, long long hint, long long unparkhint);
+void __sanitizer_syscall_pre_impl_posix_fallocate(long long fd, long long PAD,
+                                                  long long pos, long long len);
+void __sanitizer_syscall_post_impl_posix_fallocate(long long res, long long fd,
+                                                   long long PAD, long long pos,
+                                                   long long len);
+void __sanitizer_syscall_pre_impl_fdiscard(long long fd, long long PAD,
+                                           long long pos, long long len);
+void __sanitizer_syscall_post_impl_fdiscard(long long res, long long fd,
+                                            long long PAD, long long pos,
+                                            long long len);
+void __sanitizer_syscall_pre_impl_wait6(long long idtype, long long id,
+                                        long long status, long long options,
+                                        long long wru, long long info);
+void __sanitizer_syscall_post_impl_wait6(long long res, long long idtype,
+                                         long long id, long long status,
+                                         long long options, long long wru,
+                                         long long info);
+void __sanitizer_syscall_pre_impl_clock_getcpuclockid2(long long idtype,
+                                                       long long id,
+                                                       long long clock_id);
+void __sanitizer_syscall_post_impl_clock_getcpuclockid2(long long res,
+                                                        long long idtype,
+                                                        long long id,
+                                                        long long clock_id);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+// DO NOT EDIT! THIS FILE HAS BEEN GENERATED!
+
+#endif // SANITIZER_NETBSD_SYSCALL_HOOKS_H

--- a/system/lib/compiler-rt/include/sanitizer/scudo_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/scudo_interface.h
@@ -1,0 +1,38 @@
+//===-- sanitizer/scudo_interface.h -----------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+/// Public Scudo interface header.
+//
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_SCUDO_INTERFACE_H_
+#define SANITIZER_SCUDO_INTERFACE_H_
+
+#include <sanitizer/common_interface_defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+  // This function may be optionally provided by a user and should return
+  // a string containing Scudo runtime options. See scudo_flags.h for details.
+  const char* __scudo_default_options(void);
+
+  // This function allows to set the RSS limit at runtime. This can be either
+  // the hard limit (HardLimit=1) or the soft limit (HardLimit=0). The limit
+  // can be removed by setting LimitMb to 0. This function's parameters should
+  // be fully trusted to avoid security mishaps.
+  void __scudo_set_rss_limit(size_t LimitMb, int HardLimit);
+
+  // This function outputs various allocator statistics for both the Primary
+  // and Secondary allocators, including memory usage, number of allocations
+  // and deallocations.
+  void __scudo_print_stats(void);
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SANITIZER_SCUDO_INTERFACE_H_

--- a/system/lib/compiler-rt/include/sanitizer/tsan_interface.h
+++ b/system/lib/compiler-rt/include/sanitizer/tsan_interface.h
@@ -1,0 +1,161 @@
+//===-- tsan_interface.h ----------------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of ThreadSanitizer (TSan), a race detector.
+//
+// Public interface header for TSan.
+//===----------------------------------------------------------------------===//
+#ifndef SANITIZER_TSAN_INTERFACE_H
+#define SANITIZER_TSAN_INTERFACE_H
+
+#include <sanitizer/common_interface_defs.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// __tsan_release establishes a happens-before relation with a preceding
+// __tsan_acquire on the same address.
+void __tsan_acquire(void *addr);
+void __tsan_release(void *addr);
+
+// Annotations for custom mutexes.
+// The annotations allow to get better reports (with sets of locked mutexes),
+// detect more types of bugs (e.g. mutex misuses, races between lock/unlock and
+// destruction and potential deadlocks) and improve precision and performance
+// (by ignoring individual atomic operations in mutex code). However, the
+// downside is that annotated mutex code itself is not checked for correctness.
+
+// Mutex creation flags are passed to __tsan_mutex_create annotation.
+// If mutex has no constructor and __tsan_mutex_create is not called,
+// the flags may be passed to __tsan_mutex_pre_lock/__tsan_mutex_post_lock
+// annotations.
+
+// Mutex has static storage duration and no-op constructor and destructor.
+// This effectively makes tsan ignore destroy annotation.
+const unsigned __tsan_mutex_linker_init      = 1 << 0;
+// Mutex is write reentrant.
+const unsigned __tsan_mutex_write_reentrant  = 1 << 1;
+// Mutex is read reentrant.
+const unsigned __tsan_mutex_read_reentrant   = 1 << 2;
+// Mutex does not have static storage duration, and must not be used after
+// its destructor runs.  The opposite of __tsan_mutex_linker_init.
+// If this flag is passed to __tsan_mutex_destroy, then the destruction
+// is ignored unless this flag was previously set on the mutex.
+const unsigned __tsan_mutex_not_static       = 1 << 8;
+
+// Mutex operation flags:
+
+// Denotes read lock operation.
+const unsigned __tsan_mutex_read_lock        = 1 << 3;
+// Denotes try lock operation.
+const unsigned __tsan_mutex_try_lock         = 1 << 4;
+// Denotes that a try lock operation has failed to acquire the mutex.
+const unsigned __tsan_mutex_try_lock_failed  = 1 << 5;
+// Denotes that the lock operation acquires multiple recursion levels.
+// Number of levels is passed in recursion parameter.
+// This is useful for annotation of e.g. Java builtin monitors,
+// for which wait operation releases all recursive acquisitions of the mutex.
+const unsigned __tsan_mutex_recursive_lock   = 1 << 6;
+// Denotes that the unlock operation releases all recursion levels.
+// Number of released levels is returned and later must be passed to
+// the corresponding __tsan_mutex_post_lock annotation.
+const unsigned __tsan_mutex_recursive_unlock = 1 << 7;
+
+// Annotate creation of a mutex.
+// Supported flags: mutex creation flags.
+void __tsan_mutex_create(void *addr, unsigned flags);
+
+// Annotate destruction of a mutex.
+// Supported flags:
+//   - __tsan_mutex_linker_init
+//   - __tsan_mutex_not_static
+void __tsan_mutex_destroy(void *addr, unsigned flags);
+
+// Annotate start of lock operation.
+// Supported flags:
+//   - __tsan_mutex_read_lock
+//   - __tsan_mutex_try_lock
+//   - all mutex creation flags
+void __tsan_mutex_pre_lock(void *addr, unsigned flags);
+
+// Annotate end of lock operation.
+// Supported flags:
+//   - __tsan_mutex_read_lock (must match __tsan_mutex_pre_lock)
+//   - __tsan_mutex_try_lock (must match __tsan_mutex_pre_lock)
+//   - __tsan_mutex_try_lock_failed
+//   - __tsan_mutex_recursive_lock
+//   - all mutex creation flags
+void __tsan_mutex_post_lock(void *addr, unsigned flags, int recursion);
+
+// Annotate start of unlock operation.
+// Supported flags:
+//   - __tsan_mutex_read_lock
+//   - __tsan_mutex_recursive_unlock
+int __tsan_mutex_pre_unlock(void *addr, unsigned flags);
+
+// Annotate end of unlock operation.
+// Supported flags:
+//   - __tsan_mutex_read_lock (must match __tsan_mutex_pre_unlock)
+void __tsan_mutex_post_unlock(void *addr, unsigned flags);
+
+// Annotate start/end of notify/signal/broadcast operation.
+// Supported flags: none.
+void __tsan_mutex_pre_signal(void *addr, unsigned flags);
+void __tsan_mutex_post_signal(void *addr, unsigned flags);
+
+// Annotate start/end of a region of code where lock/unlock/signal operation
+// diverts to do something else unrelated to the mutex. This can be used to
+// annotate, for example, calls into cooperative scheduler or contention
+// profiling code.
+// These annotations must be called only from within
+// __tsan_mutex_pre/post_lock, __tsan_mutex_pre/post_unlock,
+// __tsan_mutex_pre/post_signal regions.
+// Supported flags: none.
+void __tsan_mutex_pre_divert(void *addr, unsigned flags);
+void __tsan_mutex_post_divert(void *addr, unsigned flags);
+
+// External race detection API.
+// Can be used by non-instrumented libraries to detect when their objects are
+// being used in an unsafe manner.
+//   - __tsan_external_read/__tsan_external_write annotates the logical reads
+//       and writes of the object at the specified address. 'caller_pc' should
+//       be the PC of the library user, which the library can obtain with e.g.
+//       `__builtin_return_address(0)`.
+//   - __tsan_external_register_tag registers a 'tag' with the specified name,
+//       which is later used in read/write annotations to denote the object type
+//   - __tsan_external_assign_tag can optionally mark a heap object with a tag
+void *__tsan_external_register_tag(const char *object_type);
+void __tsan_external_register_header(void *tag, const char *header);
+void __tsan_external_assign_tag(void *addr, void *tag);
+void __tsan_external_read(void *addr, void *caller_pc, void *tag);
+void __tsan_external_write(void *addr, void *caller_pc, void *tag);
+
+// Fiber switching API.
+//   - TSAN context for fiber can be created by __tsan_create_fiber
+//     and freed by __tsan_destroy_fiber.
+//   - TSAN context of current fiber or thread can be obtained
+//     by calling __tsan_get_current_fiber.
+//   - __tsan_switch_to_fiber should be called immediatly before switch
+//     to fiber, such as call of swapcontext.
+//   - Fiber name can be set by __tsan_set_fiber_name.
+void *__tsan_get_current_fiber(void);
+void *__tsan_create_fiber(unsigned flags);
+void __tsan_destroy_fiber(void *fiber);
+void __tsan_switch_to_fiber(void *fiber, unsigned flags);
+void __tsan_set_fiber_name(void *fiber, const char *name);
+
+// Flags for __tsan_switch_to_fiber:
+// Do not establish a happens-before relation between fibers
+const unsigned __tsan_switch_to_fiber_no_sync = 1 << 0;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // SANITIZER_TSAN_INTERFACE_H

--- a/system/lib/compiler-rt/include/sanitizer/tsan_interface_atomic.h
+++ b/system/lib/compiler-rt/include/sanitizer/tsan_interface_atomic.h
@@ -1,0 +1,221 @@
+//===-- tsan_interface_atomic.h ---------------------------------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file is a part of ThreadSanitizer (TSan), a race detector.
+//
+// Public interface header for TSan atomics.
+//===----------------------------------------------------------------------===//
+#ifndef TSAN_INTERFACE_ATOMIC_H
+#define TSAN_INTERFACE_ATOMIC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef char     __tsan_atomic8;
+typedef short    __tsan_atomic16;  // NOLINT
+typedef int      __tsan_atomic32;
+typedef long     __tsan_atomic64;  // NOLINT
+#if defined(__SIZEOF_INT128__) \
+    || (__clang_major__ * 100 + __clang_minor__ >= 302)
+__extension__ typedef __int128 __tsan_atomic128;
+# define __TSAN_HAS_INT128 1
+#else
+# define __TSAN_HAS_INT128 0
+#endif
+
+// Part of ABI, do not change.
+// https://github.com/llvm/llvm-project/blob/master/libcxx/include/atomic
+typedef enum {
+  __tsan_memory_order_relaxed,
+  __tsan_memory_order_consume,
+  __tsan_memory_order_acquire,
+  __tsan_memory_order_release,
+  __tsan_memory_order_acq_rel,
+  __tsan_memory_order_seq_cst
+} __tsan_memory_order;
+
+__tsan_atomic8 __tsan_atomic8_load(const volatile __tsan_atomic8 *a,
+    __tsan_memory_order mo);
+__tsan_atomic16 __tsan_atomic16_load(const volatile __tsan_atomic16 *a,
+    __tsan_memory_order mo);
+__tsan_atomic32 __tsan_atomic32_load(const volatile __tsan_atomic32 *a,
+    __tsan_memory_order mo);
+__tsan_atomic64 __tsan_atomic64_load(const volatile __tsan_atomic64 *a,
+    __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_load(const volatile __tsan_atomic128 *a,
+    __tsan_memory_order mo);
+#endif
+
+void __tsan_atomic8_store(volatile __tsan_atomic8 *a, __tsan_atomic8 v,
+    __tsan_memory_order mo);
+void __tsan_atomic16_store(volatile __tsan_atomic16 *a, __tsan_atomic16 v,
+    __tsan_memory_order mo);
+void __tsan_atomic32_store(volatile __tsan_atomic32 *a, __tsan_atomic32 v,
+    __tsan_memory_order mo);
+void __tsan_atomic64_store(volatile __tsan_atomic64 *a, __tsan_atomic64 v,
+    __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+void __tsan_atomic128_store(volatile __tsan_atomic128 *a, __tsan_atomic128 v,
+    __tsan_memory_order mo);
+#endif
+
+__tsan_atomic8 __tsan_atomic8_exchange(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __tsan_atomic16_exchange(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __tsan_atomic32_exchange(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __tsan_atomic64_exchange(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 v, __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_exchange(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 v, __tsan_memory_order mo);
+#endif
+
+__tsan_atomic8 __tsan_atomic8_fetch_add(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __tsan_atomic16_fetch_add(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __tsan_atomic32_fetch_add(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __tsan_atomic64_fetch_add(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 v, __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_fetch_add(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 v, __tsan_memory_order mo);
+#endif
+
+__tsan_atomic8 __tsan_atomic8_fetch_sub(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __tsan_atomic16_fetch_sub(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __tsan_atomic32_fetch_sub(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __tsan_atomic64_fetch_sub(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 v, __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_fetch_sub(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 v, __tsan_memory_order mo);
+#endif
+
+__tsan_atomic8 __tsan_atomic8_fetch_and(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __tsan_atomic16_fetch_and(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __tsan_atomic32_fetch_and(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __tsan_atomic64_fetch_and(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 v, __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_fetch_and(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 v, __tsan_memory_order mo);
+#endif
+
+__tsan_atomic8 __tsan_atomic8_fetch_or(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __tsan_atomic16_fetch_or(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __tsan_atomic32_fetch_or(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __tsan_atomic64_fetch_or(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 v, __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_fetch_or(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 v, __tsan_memory_order mo);
+#endif
+
+__tsan_atomic8 __tsan_atomic8_fetch_xor(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __tsan_atomic16_fetch_xor(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __tsan_atomic32_fetch_xor(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __tsan_atomic64_fetch_xor(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 v, __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_fetch_xor(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 v, __tsan_memory_order mo);
+#endif
+
+__tsan_atomic8 __tsan_atomic8_fetch_nand(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 v, __tsan_memory_order mo);
+__tsan_atomic16 __tsan_atomic16_fetch_nand(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 v, __tsan_memory_order mo);
+__tsan_atomic32 __tsan_atomic32_fetch_nand(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 v, __tsan_memory_order mo);
+__tsan_atomic64 __tsan_atomic64_fetch_nand(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 v, __tsan_memory_order mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_fetch_nand(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 v, __tsan_memory_order mo);
+#endif
+
+int __tsan_atomic8_compare_exchange_weak(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 *c, __tsan_atomic8 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+int __tsan_atomic16_compare_exchange_weak(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 *c, __tsan_atomic16 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+int __tsan_atomic32_compare_exchange_weak(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 *c, __tsan_atomic32 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+int __tsan_atomic64_compare_exchange_weak(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 *c, __tsan_atomic64 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+#if __TSAN_HAS_INT128
+int __tsan_atomic128_compare_exchange_weak(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 *c, __tsan_atomic128 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+#endif
+
+int __tsan_atomic8_compare_exchange_strong(volatile __tsan_atomic8 *a,
+    __tsan_atomic8 *c, __tsan_atomic8 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+int __tsan_atomic16_compare_exchange_strong(volatile __tsan_atomic16 *a,
+    __tsan_atomic16 *c, __tsan_atomic16 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+int __tsan_atomic32_compare_exchange_strong(volatile __tsan_atomic32 *a,
+    __tsan_atomic32 *c, __tsan_atomic32 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+int __tsan_atomic64_compare_exchange_strong(volatile __tsan_atomic64 *a,
+    __tsan_atomic64 *c, __tsan_atomic64 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+#if __TSAN_HAS_INT128
+int __tsan_atomic128_compare_exchange_strong(volatile __tsan_atomic128 *a,
+    __tsan_atomic128 *c, __tsan_atomic128 v, __tsan_memory_order mo,
+    __tsan_memory_order fail_mo);
+#endif
+
+__tsan_atomic8 __tsan_atomic8_compare_exchange_val(
+    volatile __tsan_atomic8 *a, __tsan_atomic8 c, __tsan_atomic8 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+__tsan_atomic16 __tsan_atomic16_compare_exchange_val(
+    volatile __tsan_atomic16 *a, __tsan_atomic16 c, __tsan_atomic16 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+__tsan_atomic32 __tsan_atomic32_compare_exchange_val(
+    volatile __tsan_atomic32 *a, __tsan_atomic32 c, __tsan_atomic32 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+__tsan_atomic64 __tsan_atomic64_compare_exchange_val(
+    volatile __tsan_atomic64 *a, __tsan_atomic64 c, __tsan_atomic64 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+#if __TSAN_HAS_INT128
+__tsan_atomic128 __tsan_atomic128_compare_exchange_val(
+    volatile __tsan_atomic128 *a, __tsan_atomic128 c, __tsan_atomic128 v,
+    __tsan_memory_order mo, __tsan_memory_order fail_mo);
+#endif
+
+void __tsan_atomic_thread_fence(__tsan_memory_order mo);
+void __tsan_atomic_signal_fence(__tsan_memory_order mo);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // TSAN_INTERFACE_ATOMIC_H

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -12,17 +12,26 @@ import shutil
 script_dir = os.path.abspath(os.path.dirname(__file__))
 local_src = os.path.join(script_dir, 'compiler-rt')
 local_builtins = os.path.join(local_src, 'lib', 'builtins')
+local_include = os.path.join(local_src, 'include', 'sanitizer')
+
+
+def clear(dirname):
+  if os.path.exists(dirname):
+    shutil.rmtree(dirname)
+  os.makedirs(dirname)
 
 
 def main():
   upstream_dir = os.path.abspath(sys.argv[1])
   assert os.path.exists(upstream_dir)
   upstream_src = os.path.join(upstream_dir, 'lib', 'builtins')
+  upstream_include = os.path.join(upstream_dir, 'include', 'sanitizer')
   assert os.path.exists(upstream_src)
+  assert os.path.exists(upstream_include)
 
   # Remove old version
-  shutil.rmtree(local_builtins)
-  os.mkdir(local_builtins)
+  clear(local_builtins)
+  clear(local_include)
 
   listfile = os.path.join(script_dir, 'compiler-rt', 'filelist.txt')
   for name in open(listfile).read().splitlines():
@@ -33,6 +42,8 @@ def main():
   for pattern in ('*.h', '*.inc'):
     for name in glob.glob(os.path.join(upstream_src, pattern)):
       shutil.copy2(name, local_builtins)
+    for name in glob.glob(os.path.join(upstream_include, pattern)):
+      shutil.copy2(name, local_include)
 
   shutil.copy2(os.path.join(upstream_dir, 'CREDITS.TXT'), local_src)
   shutil.copy2(os.path.join(upstream_dir, 'LICENSE.TXT'), local_src)

--- a/tests/core/test_asan_api.c
+++ b/tests/core/test_asan_api.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sanitizer/asan_interface.h>
+
+int main() {
+  char *x = malloc(10);
+  memset(x, 0, 10);
+  printf("poisoned: %d\n", __asan_address_is_poisoned(x));
+  free(x);
+  printf("poisoned: %d\n", __asan_address_is_poisoned(x));
+  __asan_unpoison_memory_region(x, 10);
+  printf("poisoned: %d\n", __asan_address_is_poisoned(x));
+  return 0;
+}

--- a/tests/core/test_asan_api.out
+++ b/tests/core/test_asan_api.out
@@ -1,0 +1,3 @@
+poisoned: 0
+poisoned: 1
+poisoned: 0

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8666,6 +8666,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_run(open(path_from_root('tests', 'core', 'test_asan_js_stack_op.c')).read(),
                 basename='src.c', expected_output='Hello, World!')
 
+  @no_wasm2js('TODO: ASAN in wasm2js')
+  @no_fastcomp('asan not supported on fastcomp')
+  def test_asan_api(self):
+    self.emcc_args.append('-fsanitize=address')
+    self.set_setting('ALLOW_MEMORY_GROWTH')
+    self.do_run_in_out_file_test('tests', 'core', 'test_asan_api')
+
   @no_fastcomp('WASM backend stack protection')
   def test_safe_stack(self):
     self.set_setting('STACK_OVERFLOW_CHECK', 2)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -797,6 +797,7 @@ def emsdk_cflags(user_args, cxx):
     path_from_root('system', 'lib', 'libc', 'musl', 'arch', 'emscripten'),
     path_from_root('system', 'local', 'include'),
     path_from_root('system', 'include', 'SSE'),
+    path_from_root('system', 'lib', 'compiler-rt', 'include'),
     Cache.get_path('include')
   ]
 


### PR DESCRIPTION
New headers included by running `system/lib/update_compiler_rt.py`
against llvm 9.0.0 tree.

Fixes: #10929