### PR TITLE
Add remaining compiler-rt builtin sources. NFC.

### DIFF
--- a/system/lib/compiler-rt/lib/builtins/absvdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/absvdi2.c
@@ -1,0 +1,25 @@
+//===-- absvdi2.c - Implement __absvdi2 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __absvdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: absolute value
+
+// Effects: aborts if abs(x) < 0
+
+COMPILER_RT_ABI di_int __absvdi2(di_int a) {
+  const int N = (int)(sizeof(di_int) * CHAR_BIT);
+  if (a == ((di_int)1 << (N - 1)))
+    compilerrt_abort();
+  const di_int t = a >> (N - 1);
+  return (a ^ t) - t;
+}

--- a/system/lib/compiler-rt/lib/builtins/absvsi2.c
+++ b/system/lib/compiler-rt/lib/builtins/absvsi2.c
@@ -1,0 +1,25 @@
+//===-- absvsi2.c - Implement __absvsi2 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __absvsi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: absolute value
+
+// Effects: aborts if abs(x) < 0
+
+COMPILER_RT_ABI si_int __absvsi2(si_int a) {
+  const int N = (int)(sizeof(si_int) * CHAR_BIT);
+  if (a == (1 << (N - 1)))
+    compilerrt_abort();
+  const si_int t = a >> (N - 1);
+  return (a ^ t) - t;
+}

--- a/system/lib/compiler-rt/lib/builtins/absvti2.c
+++ b/system/lib/compiler-rt/lib/builtins/absvti2.c
@@ -1,0 +1,29 @@
+//===-- absvti2.c - Implement __absvdi2 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __absvti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: absolute value
+
+// Effects: aborts if abs(x) < 0
+
+COMPILER_RT_ABI ti_int __absvti2(ti_int a) {
+  const int N = (int)(sizeof(ti_int) * CHAR_BIT);
+  if (a == ((ti_int)1 << (N - 1)))
+    compilerrt_abort();
+  const ti_int s = a >> (N - 1);
+  return (a ^ s) - s;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/adddf3.c
+++ b/system/lib/compiler-rt/lib/builtins/adddf3.c
@@ -1,0 +1,25 @@
+//===-- lib/adddf3.c - Double-precision addition ------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements double-precision soft-float addition with the IEEE-754
+// default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_add_impl.inc"
+
+COMPILER_RT_ABI double __adddf3(double a, double b) { return __addXf3__(a, b); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI double __aeabi_dadd(double a, double b) { return __adddf3(a, b); }
+#else
+COMPILER_RT_ALIAS(__adddf3, __aeabi_dadd)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/addsf3.c
+++ b/system/lib/compiler-rt/lib/builtins/addsf3.c
@@ -1,0 +1,25 @@
+//===-- lib/addsf3.c - Single-precision addition ------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements single-precision soft-float addition with the IEEE-754
+// default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_add_impl.inc"
+
+COMPILER_RT_ABI float __addsf3(float a, float b) { return __addXf3__(a, b); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI float __aeabi_fadd(float a, float b) { return __addsf3(a, b); }
+#else
+COMPILER_RT_ALIAS(__addsf3, __aeabi_fadd)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/addvdi3.c
+++ b/system/lib/compiler-rt/lib/builtins/addvdi3.c
@@ -1,0 +1,29 @@
+//===-- addvdi3.c - Implement __addvdi3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __addvdi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a + b
+
+// Effects: aborts if a + b overflows
+
+COMPILER_RT_ABI di_int __addvdi3(di_int a, di_int b) {
+  di_int s = (du_int)a + (du_int)b;
+  if (b >= 0) {
+    if (s < a)
+      compilerrt_abort();
+  } else {
+    if (s >= a)
+      compilerrt_abort();
+  }
+  return s;
+}

--- a/system/lib/compiler-rt/lib/builtins/addvsi3.c
+++ b/system/lib/compiler-rt/lib/builtins/addvsi3.c
@@ -1,0 +1,29 @@
+//===-- addvsi3.c - Implement __addvsi3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __addvsi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a + b
+
+// Effects: aborts if a + b overflows
+
+COMPILER_RT_ABI si_int __addvsi3(si_int a, si_int b) {
+  si_int s = (su_int)a + (su_int)b;
+  if (b >= 0) {
+    if (s < a)
+      compilerrt_abort();
+  } else {
+    if (s >= a)
+      compilerrt_abort();
+  }
+  return s;
+}

--- a/system/lib/compiler-rt/lib/builtins/addvti3.c
+++ b/system/lib/compiler-rt/lib/builtins/addvti3.c
@@ -1,0 +1,33 @@
+//===-- addvti3.c - Implement __addvti3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __addvti3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: a + b
+
+// Effects: aborts if a + b overflows
+
+COMPILER_RT_ABI ti_int __addvti3(ti_int a, ti_int b) {
+  ti_int s = (tu_int)a + (tu_int)b;
+  if (b >= 0) {
+    if (s < a)
+      compilerrt_abort();
+  } else {
+    if (s >= a)
+      compilerrt_abort();
+  }
+  return s;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/apple_versioning.c
+++ b/system/lib/compiler-rt/lib/builtins/apple_versioning.c
@@ -1,0 +1,339 @@
+//===-- apple_versioning.c - Adds versioning symbols for ld ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#if __APPLE__
+#include <Availability.h>
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED
+#define NOT_HERE_BEFORE_10_6(sym)
+#define NOT_HERE_IN_10_8_AND_EARLIER(sym)                                      \
+  extern const char sym##_tmp61 __asm("$ld$hide$os6.1$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp61 = 0;           \
+  extern const char sym##_tmp60 __asm("$ld$hide$os6.0$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp60 = 0;           \
+  extern const char sym##_tmp51 __asm("$ld$hide$os5.1$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp51 = 0;           \
+  extern const char sym##_tmp50 __asm("$ld$hide$os5.0$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp50 = 0;
+#else
+#define NOT_HERE_BEFORE_10_6(sym)                                              \
+  extern const char sym##_tmp4 __asm("$ld$hide$os10.4$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp4 = 0;            \
+  extern const char sym##_tmp5 __asm("$ld$hide$os10.5$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp5 = 0;
+#define NOT_HERE_IN_10_8_AND_EARLIER(sym)                                      \
+  extern const char sym##_tmp8 __asm("$ld$hide$os10.8$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp8 = 0;            \
+  extern const char sym##_tmp7 __asm("$ld$hide$os10.7$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp7 = 0;            \
+  extern const char sym##_tmp6 __asm("$ld$hide$os10.6$_" #sym);                \
+  __attribute__((visibility("default"))) const char sym##_tmp6 = 0;
+#endif
+
+// Symbols in libSystem.dylib in 10.6 and later,
+//  but are in libgcc_s.dylib in earlier versions
+
+NOT_HERE_BEFORE_10_6(__absvdi2)
+NOT_HERE_BEFORE_10_6(__absvsi2)
+NOT_HERE_BEFORE_10_6(__absvti2)
+NOT_HERE_BEFORE_10_6(__addvdi3)
+NOT_HERE_BEFORE_10_6(__addvsi3)
+NOT_HERE_BEFORE_10_6(__addvti3)
+NOT_HERE_BEFORE_10_6(__ashldi3)
+NOT_HERE_BEFORE_10_6(__ashlti3)
+NOT_HERE_BEFORE_10_6(__ashrdi3)
+NOT_HERE_BEFORE_10_6(__ashrti3)
+NOT_HERE_BEFORE_10_6(__clear_cache)
+NOT_HERE_BEFORE_10_6(__clzdi2)
+NOT_HERE_BEFORE_10_6(__clzsi2)
+NOT_HERE_BEFORE_10_6(__clzti2)
+NOT_HERE_BEFORE_10_6(__cmpdi2)
+NOT_HERE_BEFORE_10_6(__cmpti2)
+NOT_HERE_BEFORE_10_6(__ctzdi2)
+NOT_HERE_BEFORE_10_6(__ctzsi2)
+NOT_HERE_BEFORE_10_6(__ctzti2)
+NOT_HERE_BEFORE_10_6(__divdc3)
+NOT_HERE_BEFORE_10_6(__divdi3)
+NOT_HERE_BEFORE_10_6(__divsc3)
+NOT_HERE_BEFORE_10_6(__divtc3)
+NOT_HERE_BEFORE_10_6(__divti3)
+NOT_HERE_BEFORE_10_6(__divxc3)
+NOT_HERE_BEFORE_10_6(__enable_execute_stack)
+NOT_HERE_BEFORE_10_6(__ffsdi2)
+NOT_HERE_BEFORE_10_6(__ffsti2)
+NOT_HERE_BEFORE_10_6(__fixdfdi)
+NOT_HERE_BEFORE_10_6(__fixdfti)
+NOT_HERE_BEFORE_10_6(__fixsfdi)
+NOT_HERE_BEFORE_10_6(__fixsfti)
+NOT_HERE_BEFORE_10_6(__fixtfdi)
+NOT_HERE_BEFORE_10_6(__fixunsdfdi)
+NOT_HERE_BEFORE_10_6(__fixunsdfsi)
+NOT_HERE_BEFORE_10_6(__fixunsdfti)
+NOT_HERE_BEFORE_10_6(__fixunssfdi)
+NOT_HERE_BEFORE_10_6(__fixunssfsi)
+NOT_HERE_BEFORE_10_6(__fixunssfti)
+NOT_HERE_BEFORE_10_6(__fixunstfdi)
+NOT_HERE_BEFORE_10_6(__fixunsxfdi)
+NOT_HERE_BEFORE_10_6(__fixunsxfsi)
+NOT_HERE_BEFORE_10_6(__fixunsxfti)
+NOT_HERE_BEFORE_10_6(__fixxfdi)
+NOT_HERE_BEFORE_10_6(__fixxfti)
+NOT_HERE_BEFORE_10_6(__floatdidf)
+NOT_HERE_BEFORE_10_6(__floatdisf)
+NOT_HERE_BEFORE_10_6(__floatditf)
+NOT_HERE_BEFORE_10_6(__floatdixf)
+NOT_HERE_BEFORE_10_6(__floattidf)
+NOT_HERE_BEFORE_10_6(__floattisf)
+NOT_HERE_BEFORE_10_6(__floattixf)
+NOT_HERE_BEFORE_10_6(__floatundidf)
+NOT_HERE_BEFORE_10_6(__floatundisf)
+NOT_HERE_BEFORE_10_6(__floatunditf)
+NOT_HERE_BEFORE_10_6(__floatundixf)
+NOT_HERE_BEFORE_10_6(__floatuntidf)
+NOT_HERE_BEFORE_10_6(__floatuntisf)
+NOT_HERE_BEFORE_10_6(__floatuntixf)
+NOT_HERE_BEFORE_10_6(__gcc_personality_v0)
+NOT_HERE_BEFORE_10_6(__lshrdi3)
+NOT_HERE_BEFORE_10_6(__lshrti3)
+NOT_HERE_BEFORE_10_6(__moddi3)
+NOT_HERE_BEFORE_10_6(__modti3)
+NOT_HERE_BEFORE_10_6(__muldc3)
+NOT_HERE_BEFORE_10_6(__muldi3)
+NOT_HERE_BEFORE_10_6(__mulsc3)
+NOT_HERE_BEFORE_10_6(__multc3)
+NOT_HERE_BEFORE_10_6(__multi3)
+NOT_HERE_BEFORE_10_6(__mulvdi3)
+NOT_HERE_BEFORE_10_6(__mulvsi3)
+NOT_HERE_BEFORE_10_6(__mulvti3)
+NOT_HERE_BEFORE_10_6(__mulxc3)
+NOT_HERE_BEFORE_10_6(__negdi2)
+NOT_HERE_BEFORE_10_6(__negti2)
+NOT_HERE_BEFORE_10_6(__negvdi2)
+NOT_HERE_BEFORE_10_6(__negvsi2)
+NOT_HERE_BEFORE_10_6(__negvti2)
+NOT_HERE_BEFORE_10_6(__paritydi2)
+NOT_HERE_BEFORE_10_6(__paritysi2)
+NOT_HERE_BEFORE_10_6(__parityti2)
+NOT_HERE_BEFORE_10_6(__popcountdi2)
+NOT_HERE_BEFORE_10_6(__popcountsi2)
+NOT_HERE_BEFORE_10_6(__popcountti2)
+NOT_HERE_BEFORE_10_6(__powidf2)
+NOT_HERE_BEFORE_10_6(__powisf2)
+NOT_HERE_BEFORE_10_6(__powitf2)
+NOT_HERE_BEFORE_10_6(__powixf2)
+NOT_HERE_BEFORE_10_6(__subvdi3)
+NOT_HERE_BEFORE_10_6(__subvsi3)
+NOT_HERE_BEFORE_10_6(__subvti3)
+NOT_HERE_BEFORE_10_6(__ucmpdi2)
+NOT_HERE_BEFORE_10_6(__ucmpti2)
+NOT_HERE_BEFORE_10_6(__udivdi3)
+NOT_HERE_BEFORE_10_6(__udivmoddi4)
+NOT_HERE_BEFORE_10_6(__udivmodti4)
+NOT_HERE_BEFORE_10_6(__udivti3)
+NOT_HERE_BEFORE_10_6(__umoddi3)
+NOT_HERE_BEFORE_10_6(__umodti3)
+
+#if __ppc__
+NOT_HERE_BEFORE_10_6(__gcc_qadd)
+NOT_HERE_BEFORE_10_6(__gcc_qdiv)
+NOT_HERE_BEFORE_10_6(__gcc_qmul)
+NOT_HERE_BEFORE_10_6(__gcc_qsub)
+NOT_HERE_BEFORE_10_6(__trampoline_setup)
+#endif // __ppc__
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_compare_exchange)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_compare_exchange_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_compare_exchange_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_compare_exchange_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_compare_exchange_8)
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_exchange)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_exchange_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_exchange_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_exchange_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_exchange_8)
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_add_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_add_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_add_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_add_8)
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_and_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_and_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_and_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_and_8)
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_or_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_or_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_or_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_or_8)
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_sub_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_sub_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_sub_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_sub_8)
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_xor_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_xor_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_xor_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_fetch_xor_8)
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_load)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_load_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_load_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_load_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_load_8)
+
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_store)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_store_1)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_store_2)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_store_4)
+NOT_HERE_IN_10_8_AND_EARLIER(__atomic_store_8)
+
+#if __arm__ && __DYNAMIC__
+#define NOT_HERE_UNTIL_AFTER_4_3(sym)                                          \
+  extern const char sym##_tmp1 __asm("$ld$hide$os3.0$_" #sym);                 \
+  __attribute__((visibility("default"))) const char sym##_tmp1 = 0;            \
+  extern const char sym##_tmp2 __asm("$ld$hide$os3.1$_" #sym);                 \
+  __attribute__((visibility("default"))) const char sym##_tmp2 = 0;            \
+  extern const char sym##_tmp3 __asm("$ld$hide$os3.2$_" #sym);                 \
+  __attribute__((visibility("default"))) const char sym##_tmp3 = 0;            \
+  extern const char sym##_tmp4 __asm("$ld$hide$os4.0$_" #sym);                 \
+  __attribute__((visibility("default"))) const char sym##_tmp4 = 0;            \
+  extern const char sym##_tmp5 __asm("$ld$hide$os4.1$_" #sym);                 \
+  __attribute__((visibility("default"))) const char sym##_tmp5 = 0;            \
+  extern const char sym##_tmp6 __asm("$ld$hide$os4.2$_" #sym);                 \
+  __attribute__((visibility("default"))) const char sym##_tmp6 = 0;            \
+  extern const char sym##_tmp7 __asm("$ld$hide$os4.3$_" #sym);                 \
+  __attribute__((visibility("default"))) const char sym##_tmp7 = 0;
+
+NOT_HERE_UNTIL_AFTER_4_3(__absvdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__absvsi2)
+NOT_HERE_UNTIL_AFTER_4_3(__adddf3)
+NOT_HERE_UNTIL_AFTER_4_3(__adddf3vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__addsf3)
+NOT_HERE_UNTIL_AFTER_4_3(__addsf3vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__addvdi3)
+NOT_HERE_UNTIL_AFTER_4_3(__addvsi3)
+NOT_HERE_UNTIL_AFTER_4_3(__ashldi3)
+NOT_HERE_UNTIL_AFTER_4_3(__ashrdi3)
+NOT_HERE_UNTIL_AFTER_4_3(__bswapdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__bswapsi2)
+NOT_HERE_UNTIL_AFTER_4_3(__clzdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__clzsi2)
+NOT_HERE_UNTIL_AFTER_4_3(__cmpdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__ctzdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__ctzsi2)
+NOT_HERE_UNTIL_AFTER_4_3(__divdc3)
+NOT_HERE_UNTIL_AFTER_4_3(__divdf3)
+NOT_HERE_UNTIL_AFTER_4_3(__divdf3vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__divdi3)
+NOT_HERE_UNTIL_AFTER_4_3(__divsc3)
+NOT_HERE_UNTIL_AFTER_4_3(__divsf3)
+NOT_HERE_UNTIL_AFTER_4_3(__divsf3vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__divsi3)
+NOT_HERE_UNTIL_AFTER_4_3(__eqdf2)
+NOT_HERE_UNTIL_AFTER_4_3(__eqdf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__eqsf2)
+NOT_HERE_UNTIL_AFTER_4_3(__eqsf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__extendsfdf2)
+NOT_HERE_UNTIL_AFTER_4_3(__extendsfdf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__ffsdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__fixdfdi)
+NOT_HERE_UNTIL_AFTER_4_3(__fixdfsi)
+NOT_HERE_UNTIL_AFTER_4_3(__fixdfsivfp)
+NOT_HERE_UNTIL_AFTER_4_3(__fixsfdi)
+NOT_HERE_UNTIL_AFTER_4_3(__fixsfsi)
+NOT_HERE_UNTIL_AFTER_4_3(__fixsfsivfp)
+NOT_HERE_UNTIL_AFTER_4_3(__fixunsdfdi)
+NOT_HERE_UNTIL_AFTER_4_3(__fixunsdfsi)
+NOT_HERE_UNTIL_AFTER_4_3(__fixunsdfsivfp)
+NOT_HERE_UNTIL_AFTER_4_3(__fixunssfdi)
+NOT_HERE_UNTIL_AFTER_4_3(__fixunssfsi)
+NOT_HERE_UNTIL_AFTER_4_3(__fixunssfsivfp)
+NOT_HERE_UNTIL_AFTER_4_3(__floatdidf)
+NOT_HERE_UNTIL_AFTER_4_3(__floatdisf)
+NOT_HERE_UNTIL_AFTER_4_3(__floatsidf)
+NOT_HERE_UNTIL_AFTER_4_3(__floatsidfvfp)
+NOT_HERE_UNTIL_AFTER_4_3(__floatsisf)
+NOT_HERE_UNTIL_AFTER_4_3(__floatsisfvfp)
+NOT_HERE_UNTIL_AFTER_4_3(__floatundidf)
+NOT_HERE_UNTIL_AFTER_4_3(__floatundisf)
+NOT_HERE_UNTIL_AFTER_4_3(__floatunsidf)
+NOT_HERE_UNTIL_AFTER_4_3(__floatunsisf)
+NOT_HERE_UNTIL_AFTER_4_3(__floatunssidfvfp)
+NOT_HERE_UNTIL_AFTER_4_3(__floatunssisfvfp)
+NOT_HERE_UNTIL_AFTER_4_3(__gedf2)
+NOT_HERE_UNTIL_AFTER_4_3(__gedf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__gesf2)
+NOT_HERE_UNTIL_AFTER_4_3(__gesf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__gtdf2)
+NOT_HERE_UNTIL_AFTER_4_3(__gtdf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__gtsf2)
+NOT_HERE_UNTIL_AFTER_4_3(__gtsf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__ledf2)
+NOT_HERE_UNTIL_AFTER_4_3(__ledf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__lesf2)
+NOT_HERE_UNTIL_AFTER_4_3(__lesf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__lshrdi3)
+NOT_HERE_UNTIL_AFTER_4_3(__ltdf2)
+NOT_HERE_UNTIL_AFTER_4_3(__ltdf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__ltsf2)
+NOT_HERE_UNTIL_AFTER_4_3(__ltsf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__moddi3)
+NOT_HERE_UNTIL_AFTER_4_3(__modsi3)
+NOT_HERE_UNTIL_AFTER_4_3(__muldc3)
+NOT_HERE_UNTIL_AFTER_4_3(__muldf3)
+NOT_HERE_UNTIL_AFTER_4_3(__muldf3vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__muldi3)
+NOT_HERE_UNTIL_AFTER_4_3(__mulsc3)
+NOT_HERE_UNTIL_AFTER_4_3(__mulsf3)
+NOT_HERE_UNTIL_AFTER_4_3(__mulsf3vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__mulvdi3)
+NOT_HERE_UNTIL_AFTER_4_3(__mulvsi3)
+NOT_HERE_UNTIL_AFTER_4_3(__nedf2)
+NOT_HERE_UNTIL_AFTER_4_3(__nedf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__negdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__negvdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__negvsi2)
+NOT_HERE_UNTIL_AFTER_4_3(__nesf2)
+NOT_HERE_UNTIL_AFTER_4_3(__nesf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__paritydi2)
+NOT_HERE_UNTIL_AFTER_4_3(__paritysi2)
+NOT_HERE_UNTIL_AFTER_4_3(__popcountdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__popcountsi2)
+NOT_HERE_UNTIL_AFTER_4_3(__powidf2)
+NOT_HERE_UNTIL_AFTER_4_3(__powisf2)
+NOT_HERE_UNTIL_AFTER_4_3(__subdf3)
+NOT_HERE_UNTIL_AFTER_4_3(__subdf3vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__subsf3)
+NOT_HERE_UNTIL_AFTER_4_3(__subsf3vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__subvdi3)
+NOT_HERE_UNTIL_AFTER_4_3(__subvsi3)
+NOT_HERE_UNTIL_AFTER_4_3(__truncdfsf2)
+NOT_HERE_UNTIL_AFTER_4_3(__truncdfsf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__ucmpdi2)
+NOT_HERE_UNTIL_AFTER_4_3(__udivdi3)
+NOT_HERE_UNTIL_AFTER_4_3(__udivmoddi4)
+NOT_HERE_UNTIL_AFTER_4_3(__udivsi3)
+NOT_HERE_UNTIL_AFTER_4_3(__umoddi3)
+NOT_HERE_UNTIL_AFTER_4_3(__umodsi3)
+NOT_HERE_UNTIL_AFTER_4_3(__unorddf2)
+NOT_HERE_UNTIL_AFTER_4_3(__unorddf2vfp)
+NOT_HERE_UNTIL_AFTER_4_3(__unordsf2)
+NOT_HERE_UNTIL_AFTER_4_3(__unordsf2vfp)
+
+NOT_HERE_UNTIL_AFTER_4_3(__divmodsi4)
+NOT_HERE_UNTIL_AFTER_4_3(__udivmodsi4)
+#endif // __arm__ && __DYNAMIC__
+
+#else // !__APPLE__
+
+extern int avoid_empty_file;
+
+#endif // !__APPLE__

--- a/system/lib/compiler-rt/lib/builtins/atomic_flag_clear.c
+++ b/system/lib/compiler-rt/lib/builtins/atomic_flag_clear.c
@@ -1,0 +1,25 @@
+//===-- atomic_flag_clear.c -----------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements atomic_flag_clear from C11's stdatomic.h.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __has_include
+#define __has_include(inc) 0
+#endif
+
+#if __has_include(<stdatomic.h>)
+
+#include <stdatomic.h>
+#undef atomic_flag_clear
+void atomic_flag_clear(volatile atomic_flag *object) {
+  __c11_atomic_store(&(object)->_Value, 0, __ATOMIC_SEQ_CST);
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/atomic_flag_clear_explicit.c
+++ b/system/lib/compiler-rt/lib/builtins/atomic_flag_clear_explicit.c
@@ -1,0 +1,26 @@
+//===-- atomic_flag_clear_explicit.c --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements atomic_flag_clear_explicit from C11's stdatomic.h.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __has_include
+#define __has_include(inc) 0
+#endif
+
+#if __has_include(<stdatomic.h>)
+
+#include <stdatomic.h>
+#undef atomic_flag_clear_explicit
+void atomic_flag_clear_explicit(volatile atomic_flag *object,
+                                memory_order order) {
+  __c11_atomic_store(&(object)->_Value, 0, order);
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/atomic_flag_test_and_set.c
+++ b/system/lib/compiler-rt/lib/builtins/atomic_flag_test_and_set.c
@@ -1,0 +1,25 @@
+//===-- atomic_flag_test_and_set.c ----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements atomic_flag_test_and_set from C11's stdatomic.h.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __has_include
+#define __has_include(inc) 0
+#endif
+
+#if __has_include(<stdatomic.h>)
+
+#include <stdatomic.h>
+#undef atomic_flag_test_and_set
+_Bool atomic_flag_test_and_set(volatile atomic_flag *object) {
+  return __c11_atomic_exchange(&(object)->_Value, 1, __ATOMIC_SEQ_CST);
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/atomic_flag_test_and_set_explicit.c
+++ b/system/lib/compiler-rt/lib/builtins/atomic_flag_test_and_set_explicit.c
@@ -1,0 +1,26 @@
+//===-- atomic_flag_test_and_set_explicit.c -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements atomic_flag_test_and_set_explicit from C11's stdatomic.h
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __has_include
+#define __has_include(inc) 0
+#endif
+
+#if __has_include(<stdatomic.h>)
+
+#include <stdatomic.h>
+#undef atomic_flag_test_and_set_explicit
+_Bool atomic_flag_test_and_set_explicit(volatile atomic_flag *object,
+                                        memory_order order) {
+  return __c11_atomic_exchange(&(object)->_Value, 1, order);
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/atomic_signal_fence.c
+++ b/system/lib/compiler-rt/lib/builtins/atomic_signal_fence.c
@@ -1,0 +1,25 @@
+//===-- atomic_signal_fence.c ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements atomic_signal_fence from C11's stdatomic.h.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __has_include
+#define __has_include(inc) 0
+#endif
+
+#if __has_include(<stdatomic.h>)
+
+#include <stdatomic.h>
+#undef atomic_signal_fence
+void atomic_signal_fence(memory_order order) {
+  __c11_atomic_signal_fence(order);
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/atomic_thread_fence.c
+++ b/system/lib/compiler-rt/lib/builtins/atomic_thread_fence.c
@@ -1,0 +1,25 @@
+//===-- atomic_thread_fence.c ---------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements atomic_thread_fence from C11's stdatomic.h.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __has_include
+#define __has_include(inc) 0
+#endif
+
+#if __has_include(<stdatomic.h>)
+
+#include <stdatomic.h>
+#undef atomic_thread_fence
+void atomic_thread_fence(memory_order order) {
+  __c11_atomic_thread_fence(order);
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/bswapdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/bswapdi2.c
@@ -1,0 +1,25 @@
+//===-- bswapdi2.c - Implement __bswapdi2 ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __bswapdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI uint64_t __bswapdi2(uint64_t u) {
+  return (
+      (((u)&0xff00000000000000ULL) >> 56) |
+      (((u)&0x00ff000000000000ULL) >> 40) |
+      (((u)&0x0000ff0000000000ULL) >> 24) |
+      (((u)&0x000000ff00000000ULL) >> 8)  |
+      (((u)&0x00000000ff000000ULL) << 8)  |
+      (((u)&0x0000000000ff0000ULL) << 24) |
+      (((u)&0x000000000000ff00ULL) << 40) |
+      (((u)&0x00000000000000ffULL) << 56));
+}

--- a/system/lib/compiler-rt/lib/builtins/bswapsi2.c
+++ b/system/lib/compiler-rt/lib/builtins/bswapsi2.c
@@ -1,0 +1,20 @@
+//===-- bswapsi2.c - Implement __bswapsi2 ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __bswapsi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI uint32_t __bswapsi2(uint32_t u) {
+  return ((((u)&0xff000000) >> 24) |
+          (((u)&0x00ff0000) >> 8)  |
+          (((u)&0x0000ff00) << 8)  |
+          (((u)&0x000000ff) << 24));
+}

--- a/system/lib/compiler-rt/lib/builtins/clear_cache.c
+++ b/system/lib/compiler-rt/lib/builtins/clear_cache.c
@@ -1,0 +1,184 @@
+//===-- clear_cache.c - Implement __clear_cache ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+#include <assert.h>
+#include <stddef.h>
+
+#if __APPLE__
+#include <libkern/OSCacheControl.h>
+#endif
+
+#if defined(_WIN32)
+// Forward declare Win32 APIs since the GCC mode driver does not handle the
+// newer SDKs as well as needed.
+uint32_t FlushInstructionCache(uintptr_t hProcess, void *lpBaseAddress,
+                               uintptr_t dwSize);
+uintptr_t GetCurrentProcess(void);
+#endif
+
+#if defined(__FreeBSD__) && defined(__arm__)
+#include <machine/sysarch.h>
+#include <sys/types.h>
+#endif
+
+#if defined(__NetBSD__) && defined(__arm__)
+#include <machine/sysarch.h>
+#endif
+
+#if defined(__OpenBSD__) && defined(__mips__)
+#include <machine/sysarch.h>
+#include <sys/types.h>
+#endif
+
+#if defined(__linux__) && defined(__mips__)
+#include <sys/cachectl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#if defined(__ANDROID__) && defined(__LP64__)
+// clear_mips_cache - Invalidates instruction cache for Mips.
+static void clear_mips_cache(const void *Addr, size_t Size) {
+  __asm__ volatile(
+      ".set push\n"
+      ".set noreorder\n"
+      ".set noat\n"
+      "beq %[Size], $zero, 20f\n" // If size == 0, branch around.
+      "nop\n"
+      "daddu %[Size], %[Addr], %[Size]\n" // Calculate end address + 1
+      "rdhwr $v0, $1\n"                   // Get step size for SYNCI.
+                                          // $1 is $HW_SYNCI_Step
+      "beq $v0, $zero, 20f\n"             // If no caches require
+                                          // synchronization, branch
+                                          // around.
+      "nop\n"
+      "10:\n"
+      "synci 0(%[Addr])\n"            // Synchronize all caches around
+                                      // address.
+      "daddu %[Addr], %[Addr], $v0\n" // Add step size.
+      "sltu $at, %[Addr], %[Size]\n"  // Compare current with end
+                                      // address.
+      "bne $at, $zero, 10b\n"         // Branch if more to do.
+      "nop\n"
+      "sync\n" // Clear memory hazards.
+      "20:\n"
+      "bal 30f\n"
+      "nop\n"
+      "30:\n"
+      "daddiu $ra, $ra, 12\n" // $ra has a value of $pc here.
+                              // Add offset of 12 to point to the
+                              // instruction after the last nop.
+                              //
+      "jr.hb $ra\n"           // Return, clearing instruction
+                              // hazards.
+      "nop\n"
+      ".set pop\n"
+      : [ Addr ] "+r"(Addr), [ Size ] "+r"(Size)::"at", "ra", "v0", "memory");
+}
+#endif
+#endif
+
+// The compiler generates calls to __clear_cache() when creating
+// trampoline functions on the stack for use with nested functions.
+// It is expected to invalidate the instruction cache for the
+// specified range.
+
+void __clear_cache(void *start, void *end) {
+#if __i386__ || __x86_64__ || defined(_M_IX86) || defined(_M_X64)
+// Intel processors have a unified instruction and data cache
+// so there is nothing to do
+#elif defined(_WIN32) && (defined(__arm__) || defined(__aarch64__))
+  FlushInstructionCache(GetCurrentProcess(), start, end - start);
+#elif defined(__arm__) && !defined(__APPLE__)
+#if defined(__FreeBSD__) || defined(__NetBSD__)
+  struct arm_sync_icache_args arg;
+
+  arg.addr = (uintptr_t)start;
+  arg.len = (uintptr_t)end - (uintptr_t)start;
+
+  sysarch(ARM_SYNC_ICACHE, &arg);
+#elif defined(__linux__)
+// We used to include asm/unistd.h for the __ARM_NR_cacheflush define, but
+// it also brought many other unused defines, as well as a dependency on
+// kernel headers to be installed.
+//
+// This value is stable at least since Linux 3.13 and should remain so for
+// compatibility reasons, warranting it's re-definition here.
+#define __ARM_NR_cacheflush 0x0f0002
+  register int start_reg __asm("r0") = (int)(intptr_t)start;
+  const register int end_reg __asm("r1") = (int)(intptr_t)end;
+  const register int flags __asm("r2") = 0;
+  const register int syscall_nr __asm("r7") = __ARM_NR_cacheflush;
+  __asm __volatile("svc 0x0"
+                   : "=r"(start_reg)
+                   : "r"(syscall_nr), "r"(start_reg), "r"(end_reg), "r"(flags));
+  assert(start_reg == 0 && "Cache flush syscall failed.");
+#else
+  compilerrt_abort();
+#endif
+#elif defined(__linux__) && defined(__mips__)
+  const uintptr_t start_int = (uintptr_t)start;
+  const uintptr_t end_int = (uintptr_t)end;
+#if defined(__ANDROID__) && defined(__LP64__)
+  // Call synci implementation for short address range.
+  const uintptr_t address_range_limit = 256;
+  if ((end_int - start_int) <= address_range_limit) {
+    clear_mips_cache(start, (end_int - start_int));
+  } else {
+    syscall(__NR_cacheflush, start, (end_int - start_int), BCACHE);
+  }
+#else
+  syscall(__NR_cacheflush, start, (end_int - start_int), BCACHE);
+#endif
+#elif defined(__mips__) && defined(__OpenBSD__)
+  cacheflush(start, (uintptr_t)end - (uintptr_t)start, BCACHE);
+#elif defined(__aarch64__) && !defined(__APPLE__)
+  uint64_t xstart = (uint64_t)(uintptr_t)start;
+  uint64_t xend = (uint64_t)(uintptr_t)end;
+  uint64_t addr;
+
+  // Get Cache Type Info
+  uint64_t ctr_el0;
+  __asm __volatile("mrs %0, ctr_el0" : "=r"(ctr_el0));
+
+  // dc & ic instructions must use 64bit registers so we don't use
+  // uintptr_t in case this runs in an IPL32 environment.
+  const size_t dcache_line_size = 4 << ((ctr_el0 >> 16) & 15);
+  for (addr = xstart & ~(dcache_line_size - 1); addr < xend;
+       addr += dcache_line_size)
+    __asm __volatile("dc cvau, %0" ::"r"(addr));
+  __asm __volatile("dsb ish");
+
+  const size_t icache_line_size = 4 << ((ctr_el0 >> 0) & 15);
+  for (addr = xstart & ~(icache_line_size - 1); addr < xend;
+       addr += icache_line_size)
+    __asm __volatile("ic ivau, %0" ::"r"(addr));
+  __asm __volatile("isb sy");
+#elif defined(__powerpc64__)
+  const size_t line_size = 32;
+  const size_t len = (uintptr_t)end - (uintptr_t)start;
+
+  const uintptr_t mask = ~(line_size - 1);
+  const uintptr_t start_line = ((uintptr_t)start) & mask;
+  const uintptr_t end_line = ((uintptr_t)start + len + line_size - 1) & mask;
+
+  for (uintptr_t line = start_line; line < end_line; line += line_size)
+    __asm__ volatile("dcbf 0, %0" : : "r"(line));
+  __asm__ volatile("sync");
+
+  for (uintptr_t line = start_line; line < end_line; line += line_size)
+    __asm__ volatile("icbi 0, %0" : : "r"(line));
+  __asm__ volatile("isync");
+#else
+#if __APPLE__
+  // On Darwin, sys_icache_invalidate() provides this functionality
+  sys_icache_invalidate(start, end - start);
+#else
+  compilerrt_abort();
+#endif
+#endif
+}

--- a/system/lib/compiler-rt/lib/builtins/clzdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/clzdi2.c
@@ -1,0 +1,35 @@
+//===-- clzdi2.c - Implement __clzdi2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __clzdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: the number of leading 0-bits
+
+#if !defined(__clang__) &&                                                     \
+    ((defined(__sparc__) && defined(__arch64__)) || defined(__mips64) ||       \
+     (defined(__riscv) && __SIZEOF_POINTER__ >= 8))
+// On 64-bit architectures with neither a native clz instruction nor a native
+// ctz instruction, gcc resolves __builtin_clz to __clzdi2 rather than
+// __clzsi2, leading to infinite recursion.
+#define __builtin_clz(a) __clzsi2(a)
+extern si_int __clzsi2(si_int);
+#endif
+
+// Precondition: a != 0
+
+COMPILER_RT_ABI si_int __clzdi2(di_int a) {
+  dwords x;
+  x.all = a;
+  const si_int f = -(x.s.high == 0);
+  return __builtin_clz((x.s.high & ~f) | (x.s.low & f)) +
+         (f & ((si_int)(sizeof(si_int) * CHAR_BIT)));
+}

--- a/system/lib/compiler-rt/lib/builtins/clzsi2.c
+++ b/system/lib/compiler-rt/lib/builtins/clzsi2.c
@@ -1,0 +1,48 @@
+//===-- clzsi2.c - Implement __clzsi2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __clzsi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: the number of leading 0-bits
+
+// Precondition: a != 0
+
+COMPILER_RT_ABI si_int __clzsi2(si_int a) {
+  su_int x = (su_int)a;
+  si_int t = ((x & 0xFFFF0000) == 0) << 4; // if (x is small) t = 16 else 0
+  x >>= 16 - t;                            // x = [0 - 0xFFFF]
+  su_int r = t;                            // r = [0, 16]
+  // return r + clz(x)
+  t = ((x & 0xFF00) == 0) << 3;
+  x >>= 8 - t; // x = [0 - 0xFF]
+  r += t;      // r = [0, 8, 16, 24]
+  // return r + clz(x)
+  t = ((x & 0xF0) == 0) << 2;
+  x >>= 4 - t; // x = [0 - 0xF]
+  r += t;      // r = [0, 4, 8, 12, 16, 20, 24, 28]
+  // return r + clz(x)
+  t = ((x & 0xC) == 0) << 1;
+  x >>= 2 - t; // x = [0 - 3]
+  r += t;      // r = [0 - 30] and is even
+  // return r + clz(x)
+  //     switch (x)
+  //     {
+  //     case 0:
+  //         return r + 2;
+  //     case 1:
+  //         return r + 1;
+  //     case 2:
+  //     case 3:
+  //         return r;
+  //     }
+  return r + ((2 - x) & -((x & 2) == 0));
+}

--- a/system/lib/compiler-rt/lib/builtins/cmpdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/cmpdi2.c
@@ -1,0 +1,42 @@
+//===-- cmpdi2.c - Implement __cmpdi2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __cmpdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: if (a <  b) returns 0
+//           if (a == b) returns 1
+//           if (a >  b) returns 2
+
+COMPILER_RT_ABI si_int __cmpdi2(di_int a, di_int b) {
+  dwords x;
+  x.all = a;
+  dwords y;
+  y.all = b;
+  if (x.s.high < y.s.high)
+    return 0;
+  if (x.s.high > y.s.high)
+    return 2;
+  if (x.s.low < y.s.low)
+    return 0;
+  if (x.s.low > y.s.low)
+    return 2;
+  return 1;
+}
+
+#ifdef __ARM_EABI__
+// Returns: if (a <  b) returns -1
+//           if (a == b) returns  0
+//           if (a >  b) returns  1
+COMPILER_RT_ABI si_int __aeabi_lcmp(di_int a, di_int b) {
+  return __cmpdi2(a, b) - 1;
+}
+#endif

--- a/system/lib/compiler-rt/lib/builtins/cmpti2.c
+++ b/system/lib/compiler-rt/lib/builtins/cmpti2.c
@@ -1,0 +1,37 @@
+//===-- cmpti2.c - Implement __cmpti2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __cmpti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns:  if (a <  b) returns 0
+//           if (a == b) returns 1
+//           if (a >  b) returns 2
+
+COMPILER_RT_ABI si_int __cmpti2(ti_int a, ti_int b) {
+  twords x;
+  x.all = a;
+  twords y;
+  y.all = b;
+  if (x.s.high < y.s.high)
+    return 0;
+  if (x.s.high > y.s.high)
+    return 2;
+  if (x.s.low < y.s.low)
+    return 0;
+  if (x.s.low > y.s.low)
+    return 2;
+  return 1;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/comparedf2.c
+++ b/system/lib/compiler-rt/lib/builtins/comparedf2.c
@@ -1,0 +1,151 @@
+//===-- lib/comparedf2.c - Double-precision comparisons -----------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// // This file implements the following soft-float comparison routines:
+//
+//   __eqdf2   __gedf2   __unorddf2
+//   __ledf2   __gtdf2
+//   __ltdf2
+//   __nedf2
+//
+// The semantics of the routines grouped in each column are identical, so there
+// is a single implementation for each, and wrappers to provide the other names.
+//
+// The main routines behave as follows:
+//
+//   __ledf2(a,b) returns -1 if a < b
+//                         0 if a == b
+//                         1 if a > b
+//                         1 if either a or b is NaN
+//
+//   __gedf2(a,b) returns -1 if a < b
+//                         0 if a == b
+//                         1 if a > b
+//                        -1 if either a or b is NaN
+//
+//   __unorddf2(a,b) returns 0 if both a and b are numbers
+//                           1 if either a or b is NaN
+//
+// Note that __ledf2( ) and __gedf2( ) are identical except in their handling of
+// NaN values.
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+
+enum LE_RESULT { LE_LESS = -1, LE_EQUAL = 0, LE_GREATER = 1, LE_UNORDERED = 1 };
+
+COMPILER_RT_ABI enum LE_RESULT __ledf2(fp_t a, fp_t b) {
+
+  const srep_t aInt = toRep(a);
+  const srep_t bInt = toRep(b);
+  const rep_t aAbs = aInt & absMask;
+  const rep_t bAbs = bInt & absMask;
+
+  // If either a or b is NaN, they are unordered.
+  if (aAbs > infRep || bAbs > infRep)
+    return LE_UNORDERED;
+
+  // If a and b are both zeros, they are equal.
+  if ((aAbs | bAbs) == 0)
+    return LE_EQUAL;
+
+  // If at least one of a and b is positive, we get the same result comparing
+  // a and b as signed integers as we would with a floating-point compare.
+  if ((aInt & bInt) >= 0) {
+    if (aInt < bInt)
+      return LE_LESS;
+    else if (aInt == bInt)
+      return LE_EQUAL;
+    else
+      return LE_GREATER;
+  }
+
+  // Otherwise, both are negative, so we need to flip the sense of the
+  // comparison to get the correct result.  (This assumes a twos- or ones-
+  // complement integer representation; if integers are represented in a
+  // sign-magnitude representation, then this flip is incorrect).
+  else {
+    if (aInt > bInt)
+      return LE_LESS;
+    else if (aInt == bInt)
+      return LE_EQUAL;
+    else
+      return LE_GREATER;
+  }
+}
+
+#if defined(__ELF__)
+// Alias for libgcc compatibility
+COMPILER_RT_ALIAS(__ledf2, __cmpdf2)
+#endif
+COMPILER_RT_ALIAS(__ledf2, __eqdf2)
+COMPILER_RT_ALIAS(__ledf2, __ltdf2)
+COMPILER_RT_ALIAS(__ledf2, __nedf2)
+
+enum GE_RESULT {
+  GE_LESS = -1,
+  GE_EQUAL = 0,
+  GE_GREATER = 1,
+  GE_UNORDERED = -1 // Note: different from LE_UNORDERED
+};
+
+COMPILER_RT_ABI enum GE_RESULT __gedf2(fp_t a, fp_t b) {
+
+  const srep_t aInt = toRep(a);
+  const srep_t bInt = toRep(b);
+  const rep_t aAbs = aInt & absMask;
+  const rep_t bAbs = bInt & absMask;
+
+  if (aAbs > infRep || bAbs > infRep)
+    return GE_UNORDERED;
+  if ((aAbs | bAbs) == 0)
+    return GE_EQUAL;
+  if ((aInt & bInt) >= 0) {
+    if (aInt < bInt)
+      return GE_LESS;
+    else if (aInt == bInt)
+      return GE_EQUAL;
+    else
+      return GE_GREATER;
+  } else {
+    if (aInt > bInt)
+      return GE_LESS;
+    else if (aInt == bInt)
+      return GE_EQUAL;
+    else
+      return GE_GREATER;
+  }
+}
+
+COMPILER_RT_ALIAS(__gedf2, __gtdf2)
+
+COMPILER_RT_ABI int
+__unorddf2(fp_t a, fp_t b) {
+    const rep_t aAbs = toRep(a) & absMask;
+    const rep_t bAbs = toRep(b) & absMask;
+    return aAbs > infRep || bAbs > infRep;
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI int __aeabi_dcmpun(fp_t a, fp_t b) { return __unorddf2(a, b); }
+#else
+COMPILER_RT_ALIAS(__unorddf2, __aeabi_dcmpun)
+#endif
+#endif
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+// The alias mechanism doesn't work on Windows except for MinGW, so emit
+// wrapper functions.
+int __eqdf2(fp_t a, fp_t b) { return __ledf2(a, b); }
+int __ltdf2(fp_t a, fp_t b) { return __ledf2(a, b); }
+int __nedf2(fp_t a, fp_t b) { return __ledf2(a, b); }
+int __gtdf2(fp_t a, fp_t b) { return __gedf2(a, b); }
+#endif

--- a/system/lib/compiler-rt/lib/builtins/comparesf2.c
+++ b/system/lib/compiler-rt/lib/builtins/comparesf2.c
@@ -1,0 +1,151 @@
+//===-- lib/comparesf2.c - Single-precision comparisons -----------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the following soft-fp_t comparison routines:
+//
+//   __eqsf2   __gesf2   __unordsf2
+//   __lesf2   __gtsf2
+//   __ltsf2
+//   __nesf2
+//
+// The semantics of the routines grouped in each column are identical, so there
+// is a single implementation for each, and wrappers to provide the other names.
+//
+// The main routines behave as follows:
+//
+//   __lesf2(a,b) returns -1 if a < b
+//                         0 if a == b
+//                         1 if a > b
+//                         1 if either a or b is NaN
+//
+//   __gesf2(a,b) returns -1 if a < b
+//                         0 if a == b
+//                         1 if a > b
+//                        -1 if either a or b is NaN
+//
+//   __unordsf2(a,b) returns 0 if both a and b are numbers
+//                           1 if either a or b is NaN
+//
+// Note that __lesf2( ) and __gesf2( ) are identical except in their handling of
+// NaN values.
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+
+enum LE_RESULT { LE_LESS = -1, LE_EQUAL = 0, LE_GREATER = 1, LE_UNORDERED = 1 };
+
+COMPILER_RT_ABI enum LE_RESULT __lesf2(fp_t a, fp_t b) {
+
+  const srep_t aInt = toRep(a);
+  const srep_t bInt = toRep(b);
+  const rep_t aAbs = aInt & absMask;
+  const rep_t bAbs = bInt & absMask;
+
+  // If either a or b is NaN, they are unordered.
+  if (aAbs > infRep || bAbs > infRep)
+    return LE_UNORDERED;
+
+  // If a and b are both zeros, they are equal.
+  if ((aAbs | bAbs) == 0)
+    return LE_EQUAL;
+
+  // If at least one of a and b is positive, we get the same result comparing
+  // a and b as signed integers as we would with a fp_ting-point compare.
+  if ((aInt & bInt) >= 0) {
+    if (aInt < bInt)
+      return LE_LESS;
+    else if (aInt == bInt)
+      return LE_EQUAL;
+    else
+      return LE_GREATER;
+  }
+
+  // Otherwise, both are negative, so we need to flip the sense of the
+  // comparison to get the correct result.  (This assumes a twos- or ones-
+  // complement integer representation; if integers are represented in a
+  // sign-magnitude representation, then this flip is incorrect).
+  else {
+    if (aInt > bInt)
+      return LE_LESS;
+    else if (aInt == bInt)
+      return LE_EQUAL;
+    else
+      return LE_GREATER;
+  }
+}
+
+#if defined(__ELF__)
+// Alias for libgcc compatibility
+COMPILER_RT_ALIAS(__lesf2, __cmpsf2)
+#endif
+COMPILER_RT_ALIAS(__lesf2, __eqsf2)
+COMPILER_RT_ALIAS(__lesf2, __ltsf2)
+COMPILER_RT_ALIAS(__lesf2, __nesf2)
+
+enum GE_RESULT {
+  GE_LESS = -1,
+  GE_EQUAL = 0,
+  GE_GREATER = 1,
+  GE_UNORDERED = -1 // Note: different from LE_UNORDERED
+};
+
+COMPILER_RT_ABI enum GE_RESULT __gesf2(fp_t a, fp_t b) {
+
+  const srep_t aInt = toRep(a);
+  const srep_t bInt = toRep(b);
+  const rep_t aAbs = aInt & absMask;
+  const rep_t bAbs = bInt & absMask;
+
+  if (aAbs > infRep || bAbs > infRep)
+    return GE_UNORDERED;
+  if ((aAbs | bAbs) == 0)
+    return GE_EQUAL;
+  if ((aInt & bInt) >= 0) {
+    if (aInt < bInt)
+      return GE_LESS;
+    else if (aInt == bInt)
+      return GE_EQUAL;
+    else
+      return GE_GREATER;
+  } else {
+    if (aInt > bInt)
+      return GE_LESS;
+    else if (aInt == bInt)
+      return GE_EQUAL;
+    else
+      return GE_GREATER;
+  }
+}
+
+COMPILER_RT_ALIAS(__gesf2, __gtsf2)
+
+COMPILER_RT_ABI int
+__unordsf2(fp_t a, fp_t b) {
+    const rep_t aAbs = toRep(a) & absMask;
+    const rep_t bAbs = toRep(b) & absMask;
+    return aAbs > infRep || bAbs > infRep;
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI int __aeabi_fcmpun(fp_t a, fp_t b) { return __unordsf2(a, b); }
+#else
+COMPILER_RT_ALIAS(__unordsf2, __aeabi_fcmpun)
+#endif
+#endif
+
+#if defined(_WIN32) && !defined(__MINGW32__)
+// The alias mechanism doesn't work on Windows except for MinGW, so emit
+// wrapper functions.
+int __eqsf2(fp_t a, fp_t b) { return __lesf2(a, b); }
+int __ltsf2(fp_t a, fp_t b) { return __lesf2(a, b); }
+int __nesf2(fp_t a, fp_t b) { return __lesf2(a, b); }
+int __gtsf2(fp_t a, fp_t b) { return __gesf2(a, b); }
+#endif

--- a/system/lib/compiler-rt/lib/builtins/cpu_model.c
+++ b/system/lib/compiler-rt/lib/builtins/cpu_model.c
@@ -1,0 +1,689 @@
+//===-- cpu_model.c - Support for __cpu_model builtin  ------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+//  This file is based on LLVM's lib/Support/Host.cpp.
+//  It implements the operating system Host concept and builtin
+//  __cpu_model for the compiler_rt library, for x86 only.
+//
+//===----------------------------------------------------------------------===//
+
+#if (defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) ||           \
+     defined(_M_X64)) &&                                                       \
+    (defined(__GNUC__) || defined(__clang__) || defined(_MSC_VER))
+
+#include <assert.h>
+
+#define bool int
+#define true 1
+#define false 0
+
+#ifdef _MSC_VER
+#include <intrin.h>
+#endif
+
+#ifndef __has_attribute
+#define __has_attribute(attr) 0
+#endif
+
+enum VendorSignatures {
+  SIG_INTEL = 0x756e6547, // Genu
+  SIG_AMD = 0x68747541,   // Auth
+};
+
+enum ProcessorVendors {
+  VENDOR_INTEL = 1,
+  VENDOR_AMD,
+  VENDOR_OTHER,
+  VENDOR_MAX
+};
+
+enum ProcessorTypes {
+  INTEL_BONNELL = 1,
+  INTEL_CORE2,
+  INTEL_COREI7,
+  AMDFAM10H,
+  AMDFAM15H,
+  INTEL_SILVERMONT,
+  INTEL_KNL,
+  AMD_BTVER1,
+  AMD_BTVER2,
+  AMDFAM17H,
+  INTEL_KNM,
+  INTEL_GOLDMONT,
+  INTEL_GOLDMONT_PLUS,
+  INTEL_TREMONT,
+  CPU_TYPE_MAX
+};
+
+enum ProcessorSubtypes {
+  INTEL_COREI7_NEHALEM = 1,
+  INTEL_COREI7_WESTMERE,
+  INTEL_COREI7_SANDYBRIDGE,
+  AMDFAM10H_BARCELONA,
+  AMDFAM10H_SHANGHAI,
+  AMDFAM10H_ISTANBUL,
+  AMDFAM15H_BDVER1,
+  AMDFAM15H_BDVER2,
+  AMDFAM15H_BDVER3,
+  AMDFAM15H_BDVER4,
+  AMDFAM17H_ZNVER1,
+  INTEL_COREI7_IVYBRIDGE,
+  INTEL_COREI7_HASWELL,
+  INTEL_COREI7_BROADWELL,
+  INTEL_COREI7_SKYLAKE,
+  INTEL_COREI7_SKYLAKE_AVX512,
+  INTEL_COREI7_CANNONLAKE,
+  INTEL_COREI7_ICELAKE_CLIENT,
+  INTEL_COREI7_ICELAKE_SERVER,
+  AMDFAM17H_ZNVER2,
+  INTEL_COREI7_CASCADELAKE,
+  CPU_SUBTYPE_MAX
+};
+
+enum ProcessorFeatures {
+  FEATURE_CMOV = 0,
+  FEATURE_MMX,
+  FEATURE_POPCNT,
+  FEATURE_SSE,
+  FEATURE_SSE2,
+  FEATURE_SSE3,
+  FEATURE_SSSE3,
+  FEATURE_SSE4_1,
+  FEATURE_SSE4_2,
+  FEATURE_AVX,
+  FEATURE_AVX2,
+  FEATURE_SSE4_A,
+  FEATURE_FMA4,
+  FEATURE_XOP,
+  FEATURE_FMA,
+  FEATURE_AVX512F,
+  FEATURE_BMI,
+  FEATURE_BMI2,
+  FEATURE_AES,
+  FEATURE_PCLMUL,
+  FEATURE_AVX512VL,
+  FEATURE_AVX512BW,
+  FEATURE_AVX512DQ,
+  FEATURE_AVX512CD,
+  FEATURE_AVX512ER,
+  FEATURE_AVX512PF,
+  FEATURE_AVX512VBMI,
+  FEATURE_AVX512IFMA,
+  FEATURE_AVX5124VNNIW,
+  FEATURE_AVX5124FMAPS,
+  FEATURE_AVX512VPOPCNTDQ,
+  FEATURE_AVX512VBMI2,
+  FEATURE_GFNI,
+  FEATURE_VPCLMULQDQ,
+  FEATURE_AVX512VNNI,
+  FEATURE_AVX512BITALG
+};
+
+// The check below for i386 was copied from clang's cpuid.h (__get_cpuid_max).
+// Check motivated by bug reports for OpenSSL crashing on CPUs without CPUID
+// support. Consequently, for i386, the presence of CPUID is checked first
+// via the corresponding eflags bit.
+static bool isCpuIdSupported() {
+#if defined(__GNUC__) || defined(__clang__)
+#if defined(__i386__)
+  int __cpuid_supported;
+  __asm__("  pushfl\n"
+          "  popl   %%eax\n"
+          "  movl   %%eax,%%ecx\n"
+          "  xorl   $0x00200000,%%eax\n"
+          "  pushl  %%eax\n"
+          "  popfl\n"
+          "  pushfl\n"
+          "  popl   %%eax\n"
+          "  movl   $0,%0\n"
+          "  cmpl   %%eax,%%ecx\n"
+          "  je     1f\n"
+          "  movl   $1,%0\n"
+          "1:"
+          : "=r"(__cpuid_supported)
+          :
+          : "eax", "ecx");
+  if (!__cpuid_supported)
+    return false;
+#endif
+  return true;
+#endif
+  return true;
+}
+
+// This code is copied from lib/Support/Host.cpp.
+// Changes to either file should be mirrored in the other.
+
+/// getX86CpuIDAndInfo - Execute the specified cpuid and return the 4 values in
+/// the specified arguments.  If we can't run cpuid on the host, return true.
+static bool getX86CpuIDAndInfo(unsigned value, unsigned *rEAX, unsigned *rEBX,
+                               unsigned *rECX, unsigned *rEDX) {
+#if defined(__GNUC__) || defined(__clang__)
+#if defined(__x86_64__)
+  // gcc doesn't know cpuid would clobber ebx/rbx. Preserve it manually.
+  // FIXME: should we save this for Clang?
+  __asm__("movq\t%%rbx, %%rsi\n\t"
+          "cpuid\n\t"
+          "xchgq\t%%rbx, %%rsi\n\t"
+          : "=a"(*rEAX), "=S"(*rEBX), "=c"(*rECX), "=d"(*rEDX)
+          : "a"(value));
+  return false;
+#elif defined(__i386__)
+  __asm__("movl\t%%ebx, %%esi\n\t"
+          "cpuid\n\t"
+          "xchgl\t%%ebx, %%esi\n\t"
+          : "=a"(*rEAX), "=S"(*rEBX), "=c"(*rECX), "=d"(*rEDX)
+          : "a"(value));
+  return false;
+#else
+  return true;
+#endif
+#elif defined(_MSC_VER)
+  // The MSVC intrinsic is portable across x86 and x64.
+  int registers[4];
+  __cpuid(registers, value);
+  *rEAX = registers[0];
+  *rEBX = registers[1];
+  *rECX = registers[2];
+  *rEDX = registers[3];
+  return false;
+#else
+  return true;
+#endif
+}
+
+/// getX86CpuIDAndInfoEx - Execute the specified cpuid with subleaf and return
+/// the 4 values in the specified arguments.  If we can't run cpuid on the host,
+/// return true.
+static bool getX86CpuIDAndInfoEx(unsigned value, unsigned subleaf,
+                                 unsigned *rEAX, unsigned *rEBX, unsigned *rECX,
+                                 unsigned *rEDX) {
+#if defined(__GNUC__) || defined(__clang__)
+#if defined(__x86_64__)
+  // gcc doesn't know cpuid would clobber ebx/rbx. Preserve it manually.
+  // FIXME: should we save this for Clang?
+  __asm__("movq\t%%rbx, %%rsi\n\t"
+          "cpuid\n\t"
+          "xchgq\t%%rbx, %%rsi\n\t"
+          : "=a"(*rEAX), "=S"(*rEBX), "=c"(*rECX), "=d"(*rEDX)
+          : "a"(value), "c"(subleaf));
+  return false;
+#elif defined(__i386__)
+  __asm__("movl\t%%ebx, %%esi\n\t"
+          "cpuid\n\t"
+          "xchgl\t%%ebx, %%esi\n\t"
+          : "=a"(*rEAX), "=S"(*rEBX), "=c"(*rECX), "=d"(*rEDX)
+          : "a"(value), "c"(subleaf));
+  return false;
+#else
+  return true;
+#endif
+#elif defined(_MSC_VER)
+  int registers[4];
+  __cpuidex(registers, value, subleaf);
+  *rEAX = registers[0];
+  *rEBX = registers[1];
+  *rECX = registers[2];
+  *rEDX = registers[3];
+  return false;
+#else
+  return true;
+#endif
+}
+
+// Read control register 0 (XCR0). Used to detect features such as AVX.
+static bool getX86XCR0(unsigned *rEAX, unsigned *rEDX) {
+#if defined(__GNUC__) || defined(__clang__)
+  // Check xgetbv; this uses a .byte sequence instead of the instruction
+  // directly because older assemblers do not include support for xgetbv and
+  // there is no easy way to conditionally compile based on the assembler used.
+  __asm__(".byte 0x0f, 0x01, 0xd0" : "=a"(*rEAX), "=d"(*rEDX) : "c"(0));
+  return false;
+#elif defined(_MSC_FULL_VER) && defined(_XCR_XFEATURE_ENABLED_MASK)
+  unsigned long long Result = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+  *rEAX = Result;
+  *rEDX = Result >> 32;
+  return false;
+#else
+  return true;
+#endif
+}
+
+static void detectX86FamilyModel(unsigned EAX, unsigned *Family,
+                                 unsigned *Model) {
+  *Family = (EAX >> 8) & 0xf; // Bits 8 - 11
+  *Model = (EAX >> 4) & 0xf;  // Bits 4 - 7
+  if (*Family == 6 || *Family == 0xf) {
+    if (*Family == 0xf)
+      // Examine extended family ID if family ID is F.
+      *Family += (EAX >> 20) & 0xff; // Bits 20 - 27
+    // Examine extended model ID if family ID is 6 or F.
+    *Model += ((EAX >> 16) & 0xf) << 4; // Bits 16 - 19
+  }
+}
+
+static void getIntelProcessorTypeAndSubtype(unsigned Family, unsigned Model,
+                                            unsigned Brand_id,
+                                            unsigned Features,
+                                            unsigned Features2, unsigned *Type,
+                                            unsigned *Subtype) {
+  if (Brand_id != 0)
+    return;
+  switch (Family) {
+  case 6:
+    switch (Model) {
+    case 0x0f: // Intel Core 2 Duo processor, Intel Core 2 Duo mobile
+               // processor, Intel Core 2 Quad processor, Intel Core 2 Quad
+               // mobile processor, Intel Core 2 Extreme processor, Intel
+               // Pentium Dual-Core processor, Intel Xeon processor, model
+               // 0Fh. All processors are manufactured using the 65 nm process.
+    case 0x16: // Intel Celeron processor model 16h. All processors are
+               // manufactured using the 65 nm process
+    case 0x17: // Intel Core 2 Extreme processor, Intel Xeon processor, model
+               // 17h. All processors are manufactured using the 45 nm process.
+               //
+               // 45nm: Penryn , Wolfdale, Yorkfield (XE)
+    case 0x1d: // Intel Xeon processor MP. All processors are manufactured using
+               // the 45 nm process.
+      *Type = INTEL_CORE2; // "penryn"
+      break;
+    case 0x1a: // Intel Core i7 processor and Intel Xeon processor. All
+               // processors are manufactured using the 45 nm process.
+    case 0x1e: // Intel(R) Core(TM) i7 CPU         870  @ 2.93GHz.
+               // As found in a Summer 2010 model iMac.
+    case 0x1f:
+    case 0x2e:              // Nehalem EX
+      *Type = INTEL_COREI7; // "nehalem"
+      *Subtype = INTEL_COREI7_NEHALEM;
+      break;
+    case 0x25: // Intel Core i7, laptop version.
+    case 0x2c: // Intel Core i7 processor and Intel Xeon processor. All
+               // processors are manufactured using the 32 nm process.
+    case 0x2f: // Westmere EX
+      *Type = INTEL_COREI7; // "westmere"
+      *Subtype = INTEL_COREI7_WESTMERE;
+      break;
+    case 0x2a: // Intel Core i7 processor. All processors are manufactured
+               // using the 32 nm process.
+    case 0x2d:
+      *Type = INTEL_COREI7; //"sandybridge"
+      *Subtype = INTEL_COREI7_SANDYBRIDGE;
+      break;
+    case 0x3a:
+    case 0x3e:              // Ivy Bridge EP
+      *Type = INTEL_COREI7; // "ivybridge"
+      *Subtype = INTEL_COREI7_IVYBRIDGE;
+      break;
+
+    // Haswell:
+    case 0x3c:
+    case 0x3f:
+    case 0x45:
+    case 0x46:
+      *Type = INTEL_COREI7; // "haswell"
+      *Subtype = INTEL_COREI7_HASWELL;
+      break;
+
+    // Broadwell:
+    case 0x3d:
+    case 0x47:
+    case 0x4f:
+    case 0x56:
+      *Type = INTEL_COREI7; // "broadwell"
+      *Subtype = INTEL_COREI7_BROADWELL;
+      break;
+
+    // Skylake:
+    case 0x4e:              // Skylake mobile
+    case 0x5e:              // Skylake desktop
+    case 0x8e:              // Kaby Lake mobile
+    case 0x9e:              // Kaby Lake desktop
+      *Type = INTEL_COREI7; // "skylake"
+      *Subtype = INTEL_COREI7_SKYLAKE;
+      break;
+
+    // Skylake Xeon:
+    case 0x55:
+      *Type = INTEL_COREI7;
+      if (Features2 & (1 << (FEATURE_AVX512VNNI - 32)))
+        *Subtype = INTEL_COREI7_CASCADELAKE; // "cascadelake"
+      else
+        *Subtype = INTEL_COREI7_SKYLAKE_AVX512; // "skylake-avx512"
+      break;
+
+    // Cannonlake:
+    case 0x66:
+      *Type = INTEL_COREI7;
+      *Subtype = INTEL_COREI7_CANNONLAKE; // "cannonlake"
+      break;
+
+    // Icelake:
+    case 0x7d:
+    case 0x7e:
+      *Type = INTEL_COREI7;
+      *Subtype = INTEL_COREI7_ICELAKE_CLIENT; // "icelake-client"
+      break;
+
+    // Icelake Xeon:
+    case 0x6a:
+    case 0x6c:
+      *Type = INTEL_COREI7;
+      *Subtype = INTEL_COREI7_ICELAKE_SERVER; // "icelake-server"
+      break;
+
+    case 0x1c: // Most 45 nm Intel Atom processors
+    case 0x26: // 45 nm Atom Lincroft
+    case 0x27: // 32 nm Atom Medfield
+    case 0x35: // 32 nm Atom Midview
+    case 0x36: // 32 nm Atom Midview
+      *Type = INTEL_BONNELL;
+      break; // "bonnell"
+
+    // Atom Silvermont codes from the Intel software optimization guide.
+    case 0x37:
+    case 0x4a:
+    case 0x4d:
+    case 0x5a:
+    case 0x5d:
+    case 0x4c: // really airmont
+      *Type = INTEL_SILVERMONT;
+      break; // "silvermont"
+    // Goldmont:
+    case 0x5c: // Apollo Lake
+    case 0x5f: // Denverton
+      *Type = INTEL_GOLDMONT;
+      break; // "goldmont"
+    case 0x7a:
+      *Type = INTEL_GOLDMONT_PLUS;
+      break;
+    case 0x86:
+      *Type = INTEL_TREMONT;
+      break;
+
+    case 0x57:
+      *Type = INTEL_KNL; // knl
+      break;
+
+    case 0x85:
+      *Type = INTEL_KNM; // knm
+      break;
+
+    default: // Unknown family 6 CPU.
+      break;
+      break;
+    }
+  default:
+    break; // Unknown.
+  }
+}
+
+static void getAMDProcessorTypeAndSubtype(unsigned Family, unsigned Model,
+                                          unsigned Features, unsigned Features2,
+                                          unsigned *Type, unsigned *Subtype) {
+  // FIXME: this poorly matches the generated SubtargetFeatureKV table.  There
+  // appears to be no way to generate the wide variety of AMD-specific targets
+  // from the information returned from CPUID.
+  switch (Family) {
+  case 16:
+    *Type = AMDFAM10H; // "amdfam10"
+    switch (Model) {
+    case 2:
+      *Subtype = AMDFAM10H_BARCELONA;
+      break;
+    case 4:
+      *Subtype = AMDFAM10H_SHANGHAI;
+      break;
+    case 8:
+      *Subtype = AMDFAM10H_ISTANBUL;
+      break;
+    }
+    break;
+  case 20:
+    *Type = AMD_BTVER1;
+    break; // "btver1";
+  case 21:
+    *Type = AMDFAM15H;
+    if (Model >= 0x60 && Model <= 0x7f) {
+      *Subtype = AMDFAM15H_BDVER4;
+      break; // "bdver4"; 60h-7Fh: Excavator
+    }
+    if (Model >= 0x30 && Model <= 0x3f) {
+      *Subtype = AMDFAM15H_BDVER3;
+      break; // "bdver3"; 30h-3Fh: Steamroller
+    }
+    if ((Model >= 0x10 && Model <= 0x1f) || Model == 0x02) {
+      *Subtype = AMDFAM15H_BDVER2;
+      break; // "bdver2"; 02h, 10h-1Fh: Piledriver
+    }
+    if (Model <= 0x0f) {
+      *Subtype = AMDFAM15H_BDVER1;
+      break; // "bdver1"; 00h-0Fh: Bulldozer
+    }
+    break;
+  case 22:
+    *Type = AMD_BTVER2;
+    break; // "btver2"
+  case 23:
+    *Type = AMDFAM17H;
+    if (Model >= 0x30 && Model <= 0x3f) {
+      *Subtype = AMDFAM17H_ZNVER2;
+      break; // "znver2"; 30h-3fh: Zen2
+    }
+    if (Model <= 0x0f) {
+      *Subtype = AMDFAM17H_ZNVER1;
+      break; // "znver1"; 00h-0Fh: Zen1
+    }
+    break;
+  default:
+    break; // "generic"
+  }
+}
+
+static void getAvailableFeatures(unsigned ECX, unsigned EDX, unsigned MaxLeaf,
+                                 unsigned *FeaturesOut,
+                                 unsigned *Features2Out) {
+  unsigned Features = 0;
+  unsigned Features2 = 0;
+  unsigned EAX, EBX;
+
+#define setFeature(F)                                                          \
+  do {                                                                         \
+    if (F < 32)                                                                \
+      Features |= 1U << (F & 0x1f);                                            \
+    else if (F < 64)                                                           \
+      Features2 |= 1U << ((F - 32) & 0x1f);                                    \
+  } while (0)
+
+  if ((EDX >> 15) & 1)
+    setFeature(FEATURE_CMOV);
+  if ((EDX >> 23) & 1)
+    setFeature(FEATURE_MMX);
+  if ((EDX >> 25) & 1)
+    setFeature(FEATURE_SSE);
+  if ((EDX >> 26) & 1)
+    setFeature(FEATURE_SSE2);
+
+  if ((ECX >> 0) & 1)
+    setFeature(FEATURE_SSE3);
+  if ((ECX >> 1) & 1)
+    setFeature(FEATURE_PCLMUL);
+  if ((ECX >> 9) & 1)
+    setFeature(FEATURE_SSSE3);
+  if ((ECX >> 12) & 1)
+    setFeature(FEATURE_FMA);
+  if ((ECX >> 19) & 1)
+    setFeature(FEATURE_SSE4_1);
+  if ((ECX >> 20) & 1)
+    setFeature(FEATURE_SSE4_2);
+  if ((ECX >> 23) & 1)
+    setFeature(FEATURE_POPCNT);
+  if ((ECX >> 25) & 1)
+    setFeature(FEATURE_AES);
+
+  // If CPUID indicates support for XSAVE, XRESTORE and AVX, and XGETBV
+  // indicates that the AVX registers will be saved and restored on context
+  // switch, then we have full AVX support.
+  const unsigned AVXBits = (1 << 27) | (1 << 28);
+  bool HasAVX = ((ECX & AVXBits) == AVXBits) && !getX86XCR0(&EAX, &EDX) &&
+                ((EAX & 0x6) == 0x6);
+  bool HasAVX512Save = HasAVX && ((EAX & 0xe0) == 0xe0);
+
+  if (HasAVX)
+    setFeature(FEATURE_AVX);
+
+  bool HasLeaf7 =
+      MaxLeaf >= 0x7 && !getX86CpuIDAndInfoEx(0x7, 0x0, &EAX, &EBX, &ECX, &EDX);
+
+  if (HasLeaf7 && ((EBX >> 3) & 1))
+    setFeature(FEATURE_BMI);
+  if (HasLeaf7 && ((EBX >> 5) & 1) && HasAVX)
+    setFeature(FEATURE_AVX2);
+  if (HasLeaf7 && ((EBX >> 8) & 1))
+    setFeature(FEATURE_BMI2);
+  if (HasLeaf7 && ((EBX >> 16) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512F);
+  if (HasLeaf7 && ((EBX >> 17) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512DQ);
+  if (HasLeaf7 && ((EBX >> 21) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512IFMA);
+  if (HasLeaf7 && ((EBX >> 26) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512PF);
+  if (HasLeaf7 && ((EBX >> 27) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512ER);
+  if (HasLeaf7 && ((EBX >> 28) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512CD);
+  if (HasLeaf7 && ((EBX >> 30) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512BW);
+  if (HasLeaf7 && ((EBX >> 31) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512VL);
+
+  if (HasLeaf7 && ((ECX >> 1) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512VBMI);
+  if (HasLeaf7 && ((ECX >> 6) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512VBMI2);
+  if (HasLeaf7 && ((ECX >> 8) & 1))
+    setFeature(FEATURE_GFNI);
+  if (HasLeaf7 && ((ECX >> 10) & 1) && HasAVX)
+    setFeature(FEATURE_VPCLMULQDQ);
+  if (HasLeaf7 && ((ECX >> 11) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512VNNI);
+  if (HasLeaf7 && ((ECX >> 12) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512BITALG);
+  if (HasLeaf7 && ((ECX >> 14) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX512VPOPCNTDQ);
+
+  if (HasLeaf7 && ((EDX >> 2) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX5124VNNIW);
+  if (HasLeaf7 && ((EDX >> 3) & 1) && HasAVX512Save)
+    setFeature(FEATURE_AVX5124FMAPS);
+
+  unsigned MaxExtLevel;
+  getX86CpuIDAndInfo(0x80000000, &MaxExtLevel, &EBX, &ECX, &EDX);
+
+  bool HasExtLeaf1 = MaxExtLevel >= 0x80000001 &&
+                     !getX86CpuIDAndInfo(0x80000001, &EAX, &EBX, &ECX, &EDX);
+  if (HasExtLeaf1 && ((ECX >> 6) & 1))
+    setFeature(FEATURE_SSE4_A);
+  if (HasExtLeaf1 && ((ECX >> 11) & 1))
+    setFeature(FEATURE_XOP);
+  if (HasExtLeaf1 && ((ECX >> 16) & 1))
+    setFeature(FEATURE_FMA4);
+
+  *FeaturesOut = Features;
+  *Features2Out = Features2;
+#undef setFeature
+}
+
+#if defined(HAVE_INIT_PRIORITY)
+#define CONSTRUCTOR_ATTRIBUTE __attribute__((__constructor__ 101))
+#elif __has_attribute(__constructor__)
+#define CONSTRUCTOR_ATTRIBUTE __attribute__((__constructor__))
+#else
+// FIXME: For MSVC, we should make a function pointer global in .CRT$X?? so that
+// this runs during initialization.
+#define CONSTRUCTOR_ATTRIBUTE
+#endif
+
+#ifndef _WIN32
+__attribute__((visibility("hidden")))
+#endif
+int __cpu_indicator_init(void) CONSTRUCTOR_ATTRIBUTE;
+
+#ifndef _WIN32
+__attribute__((visibility("hidden")))
+#endif
+struct __processor_model {
+  unsigned int __cpu_vendor;
+  unsigned int __cpu_type;
+  unsigned int __cpu_subtype;
+  unsigned int __cpu_features[1];
+} __cpu_model = {0, 0, 0, {0}};
+
+#ifndef _WIN32
+__attribute__((visibility("hidden")))
+#endif
+unsigned int __cpu_features2;
+
+// A constructor function that is sets __cpu_model and __cpu_features2 with
+// the right values.  This needs to run only once.  This constructor is
+// given the highest priority and it should run before constructors without
+// the priority set.  However, it still runs after ifunc initializers and
+// needs to be called explicitly there.
+
+int CONSTRUCTOR_ATTRIBUTE __cpu_indicator_init(void) {
+  unsigned EAX, EBX, ECX, EDX;
+  unsigned MaxLeaf = 5;
+  unsigned Vendor;
+  unsigned Model, Family, Brand_id;
+  unsigned Features = 0;
+  unsigned Features2 = 0;
+
+  // This function needs to run just once.
+  if (__cpu_model.__cpu_vendor)
+    return 0;
+
+  if (!isCpuIdSupported())
+    return -1;
+
+  // Assume cpuid insn present. Run in level 0 to get vendor id.
+  if (getX86CpuIDAndInfo(0, &MaxLeaf, &Vendor, &ECX, &EDX) || MaxLeaf < 1) {
+    __cpu_model.__cpu_vendor = VENDOR_OTHER;
+    return -1;
+  }
+  getX86CpuIDAndInfo(1, &EAX, &EBX, &ECX, &EDX);
+  detectX86FamilyModel(EAX, &Family, &Model);
+  Brand_id = EBX & 0xff;
+
+  // Find available features.
+  getAvailableFeatures(ECX, EDX, MaxLeaf, &Features, &Features2);
+  __cpu_model.__cpu_features[0] = Features;
+  __cpu_features2 = Features2;
+
+  if (Vendor == SIG_INTEL) {
+    // Get CPU type.
+    getIntelProcessorTypeAndSubtype(Family, Model, Brand_id, Features,
+                                    Features2, &(__cpu_model.__cpu_type),
+                                    &(__cpu_model.__cpu_subtype));
+    __cpu_model.__cpu_vendor = VENDOR_INTEL;
+  } else if (Vendor == SIG_AMD) {
+    // Get CPU type.
+    getAMDProcessorTypeAndSubtype(Family, Model, Features, Features2,
+                                  &(__cpu_model.__cpu_type),
+                                  &(__cpu_model.__cpu_subtype));
+    __cpu_model.__cpu_vendor = VENDOR_AMD;
+  } else
+    __cpu_model.__cpu_vendor = VENDOR_OTHER;
+
+  assert(__cpu_model.__cpu_vendor < VENDOR_MAX);
+  assert(__cpu_model.__cpu_type < CPU_TYPE_MAX);
+  assert(__cpu_model.__cpu_subtype < CPU_SUBTYPE_MAX);
+
+  return 0;
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/ctzdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/ctzdi2.c
@@ -1,0 +1,35 @@
+//===-- ctzdi2.c - Implement __ctzdi2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __ctzdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: the number of trailing 0-bits
+
+#if !defined(__clang__) &&                                                     \
+    ((defined(__sparc__) && defined(__arch64__)) || defined(__mips64) ||       \
+     (defined(__riscv) && __SIZEOF_POINTER__ >= 8))
+// On 64-bit architectures with neither a native clz instruction nor a native
+// ctz instruction, gcc resolves __builtin_ctz to __ctzdi2 rather than
+// __ctzsi2, leading to infinite recursion.
+#define __builtin_ctz(a) __ctzsi2(a)
+extern si_int __ctzsi2(si_int);
+#endif
+
+// Precondition: a != 0
+
+COMPILER_RT_ABI si_int __ctzdi2(di_int a) {
+  dwords x;
+  x.all = a;
+  const si_int f = -(x.s.low == 0);
+  return __builtin_ctz((x.s.high & f) | (x.s.low & ~f)) +
+         (f & ((si_int)(sizeof(si_int) * CHAR_BIT)));
+}

--- a/system/lib/compiler-rt/lib/builtins/ctzsi2.c
+++ b/system/lib/compiler-rt/lib/builtins/ctzsi2.c
@@ -1,0 +1,53 @@
+//===-- ctzsi2.c - Implement __ctzsi2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __ctzsi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: the number of trailing 0-bits
+
+// Precondition: a != 0
+
+COMPILER_RT_ABI si_int __ctzsi2(si_int a) {
+  su_int x = (su_int)a;
+  si_int t = ((x & 0x0000FFFF) == 0)
+             << 4; // if (x has no small bits) t = 16 else 0
+  x >>= t;         // x = [0 - 0xFFFF] + higher garbage bits
+  su_int r = t;    // r = [0, 16]
+  // return r + ctz(x)
+  t = ((x & 0x00FF) == 0) << 3;
+  x >>= t; // x = [0 - 0xFF] + higher garbage bits
+  r += t;  // r = [0, 8, 16, 24]
+  // return r + ctz(x)
+  t = ((x & 0x0F) == 0) << 2;
+  x >>= t; // x = [0 - 0xF] + higher garbage bits
+  r += t;  // r = [0, 4, 8, 12, 16, 20, 24, 28]
+  // return r + ctz(x)
+  t = ((x & 0x3) == 0) << 1;
+  x >>= t;
+  x &= 3; // x = [0 - 3]
+  r += t; // r = [0 - 30] and is even
+  // return r + ctz(x)
+
+  //  The branch-less return statement below is equivalent
+  //  to the following switch statement:
+  //     switch (x)
+  //    {
+  //     case 0:
+  //         return r + 2;
+  //     case 2:
+  //         return r + 1;
+  //     case 1:
+  //     case 3:
+  //         return r;
+  //     }
+  return r + ((2 - (x >> 1)) & -((x & 1) == 0));
+}

--- a/system/lib/compiler-rt/lib/builtins/ctzti2.c
+++ b/system/lib/compiler-rt/lib/builtins/ctzti2.c
@@ -1,0 +1,29 @@
+//===-- ctzti2.c - Implement __ctzti2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __ctzti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: the number of trailing 0-bits
+
+// Precondition: a != 0
+
+COMPILER_RT_ABI si_int __ctzti2(ti_int a) {
+  twords x;
+  x.all = a;
+  const di_int f = -(x.s.low == 0);
+  return __builtin_ctzll((x.s.high & f) | (x.s.low & ~f)) +
+         ((si_int)f & ((si_int)(sizeof(di_int) * CHAR_BIT)));
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/divdf3.c
+++ b/system/lib/compiler-rt/lib/builtins/divdf3.c
@@ -1,0 +1,210 @@
+//===-- lib/divdf3.c - Double-precision division ------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements double-precision soft-float division
+// with the IEEE-754 default rounding (to nearest, ties to even).
+//
+// For simplicity, this implementation currently flushes denormals to zero.
+// It should be a fairly straightforward exercise to implement gradual
+// underflow with correct rounding.
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+
+COMPILER_RT_ABI fp_t __divdf3(fp_t a, fp_t b) {
+
+  const unsigned int aExponent = toRep(a) >> significandBits & maxExponent;
+  const unsigned int bExponent = toRep(b) >> significandBits & maxExponent;
+  const rep_t quotientSign = (toRep(a) ^ toRep(b)) & signBit;
+
+  rep_t aSignificand = toRep(a) & significandMask;
+  rep_t bSignificand = toRep(b) & significandMask;
+  int scale = 0;
+
+  // Detect if a or b is zero, denormal, infinity, or NaN.
+  if (aExponent - 1U >= maxExponent - 1U ||
+      bExponent - 1U >= maxExponent - 1U) {
+
+    const rep_t aAbs = toRep(a) & absMask;
+    const rep_t bAbs = toRep(b) & absMask;
+
+    // NaN / anything = qNaN
+    if (aAbs > infRep)
+      return fromRep(toRep(a) | quietBit);
+    // anything / NaN = qNaN
+    if (bAbs > infRep)
+      return fromRep(toRep(b) | quietBit);
+
+    if (aAbs == infRep) {
+      // infinity / infinity = NaN
+      if (bAbs == infRep)
+        return fromRep(qnanRep);
+      // infinity / anything else = +/- infinity
+      else
+        return fromRep(aAbs | quotientSign);
+    }
+
+    // anything else / infinity = +/- 0
+    if (bAbs == infRep)
+      return fromRep(quotientSign);
+
+    if (!aAbs) {
+      // zero / zero = NaN
+      if (!bAbs)
+        return fromRep(qnanRep);
+      // zero / anything else = +/- zero
+      else
+        return fromRep(quotientSign);
+    }
+    // anything else / zero = +/- infinity
+    if (!bAbs)
+      return fromRep(infRep | quotientSign);
+
+    // One or both of a or b is denormal.  The other (if applicable) is a
+    // normal number.  Renormalize one or both of a and b, and set scale to
+    // include the necessary exponent adjustment.
+    if (aAbs < implicitBit)
+      scale += normalize(&aSignificand);
+    if (bAbs < implicitBit)
+      scale -= normalize(&bSignificand);
+  }
+
+  // Set the implicit significand bit.  If we fell through from the
+  // denormal path it was already set by normalize( ), but setting it twice
+  // won't hurt anything.
+  aSignificand |= implicitBit;
+  bSignificand |= implicitBit;
+  int quotientExponent = aExponent - bExponent + scale;
+
+  // Align the significand of b as a Q31 fixed-point number in the range
+  // [1, 2.0) and get a Q32 approximate reciprocal using a small minimax
+  // polynomial approximation: reciprocal = 3/4 + 1/sqrt(2) - b/2.  This
+  // is accurate to about 3.5 binary digits.
+  const uint32_t q31b = bSignificand >> 21;
+  uint32_t recip32 = UINT32_C(0x7504f333) - q31b;
+  // 0x7504F333 / 2^32 + 1 = 3/4 + 1/sqrt(2)
+
+  // Now refine the reciprocal estimate using a Newton-Raphson iteration:
+  //
+  //     x1 = x0 * (2 - x0 * b)
+  //
+  // This doubles the number of correct binary digits in the approximation
+  // with each iteration.
+  uint32_t correction32;
+  correction32 = -((uint64_t)recip32 * q31b >> 32);
+  recip32 = (uint64_t)recip32 * correction32 >> 31;
+  correction32 = -((uint64_t)recip32 * q31b >> 32);
+  recip32 = (uint64_t)recip32 * correction32 >> 31;
+  correction32 = -((uint64_t)recip32 * q31b >> 32);
+  recip32 = (uint64_t)recip32 * correction32 >> 31;
+
+  // The reciprocal may have overflowed to zero if the upper half of b is
+  // exactly 1.0.  This would sabatoge the full-width final stage of the
+  // computation that follows, so we adjust the reciprocal down by one bit.
+  recip32--;
+
+  // We need to perform one more iteration to get us to 56 binary digits.
+  // The last iteration needs to happen with extra precision.
+  const uint32_t q63blo = bSignificand << 11;
+  uint64_t correction, reciprocal;
+  correction = -((uint64_t)recip32 * q31b + ((uint64_t)recip32 * q63blo >> 32));
+  uint32_t cHi = correction >> 32;
+  uint32_t cLo = correction;
+  reciprocal = (uint64_t)recip32 * cHi + ((uint64_t)recip32 * cLo >> 32);
+
+  // Adjust the final 64-bit reciprocal estimate downward to ensure that it is
+  // strictly smaller than the infinitely precise exact reciprocal.  Because
+  // the computation of the Newton-Raphson step is truncating at every step,
+  // this adjustment is small; most of the work is already done.
+  reciprocal -= 2;
+
+  // The numerical reciprocal is accurate to within 2^-56, lies in the
+  // interval [0.5, 1.0), and is strictly smaller than the true reciprocal
+  // of b.  Multiplying a by this reciprocal thus gives a numerical q = a/b
+  // in Q53 with the following properties:
+  //
+  //    1. q < a/b
+  //    2. q is in the interval [0.5, 2.0)
+  //    3. The error in q is bounded away from 2^-53 (actually, we have a
+  //       couple of bits to spare, but this is all we need).
+
+  // We need a 64 x 64 multiply high to compute q, which isn't a basic
+  // operation in C, so we need to be a little bit fussy.
+  rep_t quotient, quotientLo;
+  wideMultiply(aSignificand << 2, reciprocal, &quotient, &quotientLo);
+
+  // Two cases: quotient is in [0.5, 1.0) or quotient is in [1.0, 2.0).
+  // In either case, we are going to compute a residual of the form
+  //
+  //     r = a - q*b
+  //
+  // We know from the construction of q that r satisfies:
+  //
+  //     0 <= r < ulp(q)*b
+  //
+  // If r is greater than 1/2 ulp(q)*b, then q rounds up.  Otherwise, we
+  // already have the correct result.  The exact halfway case cannot occur.
+  // We also take this time to right shift quotient if it falls in the [1,2)
+  // range and adjust the exponent accordingly.
+  rep_t residual;
+  if (quotient < (implicitBit << 1)) {
+    residual = (aSignificand << 53) - quotient * bSignificand;
+    quotientExponent--;
+  } else {
+    quotient >>= 1;
+    residual = (aSignificand << 52) - quotient * bSignificand;
+  }
+
+  const int writtenExponent = quotientExponent + exponentBias;
+
+  if (writtenExponent >= maxExponent) {
+    // If we have overflowed the exponent, return infinity.
+    return fromRep(infRep | quotientSign);
+  }
+
+  else if (writtenExponent < 1) {
+    if (writtenExponent == 0) {
+      // Check whether the rounded result is normal.
+      const bool round = (residual << 1) > bSignificand;
+      // Clear the implicit bit.
+      rep_t absResult = quotient & significandMask;
+      // Round.
+      absResult += round;
+      if (absResult & ~significandMask) {
+        // The rounded result is normal; return it.
+        return fromRep(absResult | quotientSign);
+      }
+    }
+    // Flush denormals to zero.  In the future, it would be nice to add
+    // code to round them correctly.
+    return fromRep(quotientSign);
+  }
+
+  else {
+    const bool round = (residual << 1) > bSignificand;
+    // Clear the implicit bit.
+    rep_t absResult = quotient & significandMask;
+    // Insert the exponent.
+    absResult |= (rep_t)writtenExponent << significandBits;
+    // Round.
+    absResult += round;
+    // Insert the sign and return.
+    const double result = fromRep(absResult | quotientSign);
+    return result;
+  }
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_ddiv(fp_t a, fp_t b) { return __divdf3(a, b); }
+#else
+COMPILER_RT_ALIAS(__divdf3, __aeabi_ddiv)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/divmodsi4.c
+++ b/system/lib/compiler-rt/lib/builtins/divmodsi4.c
@@ -1,0 +1,22 @@
+//===-- divmodsi4.c - Implement __divmodsi4
+//--------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __divmodsi4 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a / b, *rem = a % b
+
+COMPILER_RT_ABI si_int __divmodsi4(si_int a, si_int b, si_int *rem) {
+  si_int d = __divsi3(a, b);
+  *rem = a - (d * b);
+  return d;
+}

--- a/system/lib/compiler-rt/lib/builtins/divsf3.c
+++ b/system/lib/compiler-rt/lib/builtins/divsf3.c
@@ -1,0 +1,194 @@
+//===-- lib/divsf3.c - Single-precision division ------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements single-precision soft-float division
+// with the IEEE-754 default rounding (to nearest, ties to even).
+//
+// For simplicity, this implementation currently flushes denormals to zero.
+// It should be a fairly straightforward exercise to implement gradual
+// underflow with correct rounding.
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+
+COMPILER_RT_ABI fp_t __divsf3(fp_t a, fp_t b) {
+
+  const unsigned int aExponent = toRep(a) >> significandBits & maxExponent;
+  const unsigned int bExponent = toRep(b) >> significandBits & maxExponent;
+  const rep_t quotientSign = (toRep(a) ^ toRep(b)) & signBit;
+
+  rep_t aSignificand = toRep(a) & significandMask;
+  rep_t bSignificand = toRep(b) & significandMask;
+  int scale = 0;
+
+  // Detect if a or b is zero, denormal, infinity, or NaN.
+  if (aExponent - 1U >= maxExponent - 1U ||
+      bExponent - 1U >= maxExponent - 1U) {
+
+    const rep_t aAbs = toRep(a) & absMask;
+    const rep_t bAbs = toRep(b) & absMask;
+
+    // NaN / anything = qNaN
+    if (aAbs > infRep)
+      return fromRep(toRep(a) | quietBit);
+    // anything / NaN = qNaN
+    if (bAbs > infRep)
+      return fromRep(toRep(b) | quietBit);
+
+    if (aAbs == infRep) {
+      // infinity / infinity = NaN
+      if (bAbs == infRep)
+        return fromRep(qnanRep);
+      // infinity / anything else = +/- infinity
+      else
+        return fromRep(aAbs | quotientSign);
+    }
+
+    // anything else / infinity = +/- 0
+    if (bAbs == infRep)
+      return fromRep(quotientSign);
+
+    if (!aAbs) {
+      // zero / zero = NaN
+      if (!bAbs)
+        return fromRep(qnanRep);
+      // zero / anything else = +/- zero
+      else
+        return fromRep(quotientSign);
+    }
+    // anything else / zero = +/- infinity
+    if (!bAbs)
+      return fromRep(infRep | quotientSign);
+
+    // One or both of a or b is denormal.  The other (if applicable) is a
+    // normal number.  Renormalize one or both of a and b, and set scale to
+    // include the necessary exponent adjustment.
+    if (aAbs < implicitBit)
+      scale += normalize(&aSignificand);
+    if (bAbs < implicitBit)
+      scale -= normalize(&bSignificand);
+  }
+
+  // Set the implicit significand bit.  If we fell through from the
+  // denormal path it was already set by normalize( ), but setting it twice
+  // won't hurt anything.
+  aSignificand |= implicitBit;
+  bSignificand |= implicitBit;
+  int quotientExponent = aExponent - bExponent + scale;
+  // 0x7504F333 / 2^32 + 1 = 3/4 + 1/sqrt(2)
+
+  // Align the significand of b as a Q31 fixed-point number in the range
+  // [1, 2.0) and get a Q32 approximate reciprocal using a small minimax
+  // polynomial approximation: reciprocal = 3/4 + 1/sqrt(2) - b/2.  This
+  // is accurate to about 3.5 binary digits.
+  uint32_t q31b = bSignificand << 8;
+  uint32_t reciprocal = UINT32_C(0x7504f333) - q31b;
+
+  // Now refine the reciprocal estimate using a Newton-Raphson iteration:
+  //
+  //     x1 = x0 * (2 - x0 * b)
+  //
+  // This doubles the number of correct binary digits in the approximation
+  // with each iteration.
+  uint32_t correction;
+  correction = -((uint64_t)reciprocal * q31b >> 32);
+  reciprocal = (uint64_t)reciprocal * correction >> 31;
+  correction = -((uint64_t)reciprocal * q31b >> 32);
+  reciprocal = (uint64_t)reciprocal * correction >> 31;
+  correction = -((uint64_t)reciprocal * q31b >> 32);
+  reciprocal = (uint64_t)reciprocal * correction >> 31;
+
+  // Adust the final 32-bit reciprocal estimate downward to ensure that it is
+  // strictly smaller than the infinitely precise exact reciprocal.  Because
+  // the computation of the Newton-Raphson step is truncating at every step,
+  // this adjustment is small; most of the work is already done.
+  reciprocal -= 2;
+
+  // The numerical reciprocal is accurate to within 2^-28, lies in the
+  // interval [0x1.000000eep-1, 0x1.fffffffcp-1], and is strictly smaller
+  // than the true reciprocal of b.  Multiplying a by this reciprocal thus
+  // gives a numerical q = a/b in Q24 with the following properties:
+  //
+  //    1. q < a/b
+  //    2. q is in the interval [0x1.000000eep-1, 0x1.fffffffcp0)
+  //    3. The error in q is at most 2^-24 + 2^-27 -- the 2^24 term comes
+  //       from the fact that we truncate the product, and the 2^27 term
+  //       is the error in the reciprocal of b scaled by the maximum
+  //       possible value of a.  As a consequence of this error bound,
+  //       either q or nextafter(q) is the correctly rounded.
+  rep_t quotient = (uint64_t)reciprocal * (aSignificand << 1) >> 32;
+
+  // Two cases: quotient is in [0.5, 1.0) or quotient is in [1.0, 2.0).
+  // In either case, we are going to compute a residual of the form
+  //
+  //     r = a - q*b
+  //
+  // We know from the construction of q that r satisfies:
+  //
+  //     0 <= r < ulp(q)*b
+  //
+  // If r is greater than 1/2 ulp(q)*b, then q rounds up.  Otherwise, we
+  // already have the correct result.  The exact halfway case cannot occur.
+  // We also take this time to right shift quotient if it falls in the [1,2)
+  // range and adjust the exponent accordingly.
+  rep_t residual;
+  if (quotient < (implicitBit << 1)) {
+    residual = (aSignificand << 24) - quotient * bSignificand;
+    quotientExponent--;
+  } else {
+    quotient >>= 1;
+    residual = (aSignificand << 23) - quotient * bSignificand;
+  }
+
+  const int writtenExponent = quotientExponent + exponentBias;
+
+  if (writtenExponent >= maxExponent) {
+    // If we have overflowed the exponent, return infinity.
+    return fromRep(infRep | quotientSign);
+  }
+
+  else if (writtenExponent < 1) {
+    if (writtenExponent == 0) {
+      // Check whether the rounded result is normal.
+      const bool round = (residual << 1) > bSignificand;
+      // Clear the implicit bit.
+      rep_t absResult = quotient & significandMask;
+      // Round.
+      absResult += round;
+      if (absResult & ~significandMask) {
+        // The rounded result is normal; return it.
+        return fromRep(absResult | quotientSign);
+      }
+    }
+    // Flush denormals to zero.  In the future, it would be nice to add
+    // code to round them correctly.
+    return fromRep(quotientSign);
+  }
+
+  else {
+    const bool round = (residual << 1) > bSignificand;
+    // Clear the implicit bit.
+    rep_t absResult = quotient & significandMask;
+    // Insert the exponent.
+    absResult |= (rep_t)writtenExponent << significandBits;
+    // Round.
+    absResult += round;
+    // Insert the sign and return.
+    return fromRep(absResult | quotientSign);
+  }
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_fdiv(fp_t a, fp_t b) { return __divsf3(a, b); }
+#else
+COMPILER_RT_ALIAS(__divsf3, __aeabi_fdiv)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/divsi3.c
+++ b/system/lib/compiler-rt/lib/builtins/divsi3.c
@@ -1,0 +1,35 @@
+//===-- divsi3.c - Implement __divsi3 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __divsi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a / b
+
+COMPILER_RT_ABI si_int __divsi3(si_int a, si_int b) {
+  const int bits_in_word_m1 = (int)(sizeof(si_int) * CHAR_BIT) - 1;
+  si_int s_a = a >> bits_in_word_m1; // s_a = a < 0 ? -1 : 0
+  si_int s_b = b >> bits_in_word_m1; // s_b = b < 0 ? -1 : 0
+  a = (a ^ s_a) - s_a;               // negate if s_a == -1
+  b = (b ^ s_b) - s_b;               // negate if s_b == -1
+  s_a ^= s_b;                        // sign of quotient
+  //
+  // On CPUs without unsigned hardware division support,
+  //  this calls __udivsi3 (notice the cast to su_int).
+  // On CPUs with unsigned hardware division support,
+  //  this uses the unsigned division instruction.
+  //
+  return ((su_int)a / (su_int)b ^ s_a) - s_a; // negate if s_a == -1
+}
+
+#if defined(__ARM_EABI__)
+COMPILER_RT_ALIAS(__divsi3, __aeabi_idiv)
+#endif

--- a/system/lib/compiler-rt/lib/builtins/divtc3.c
+++ b/system/lib/compiler-rt/lib/builtins/divtc3.c
@@ -1,0 +1,54 @@
+//===-- divtc3.c - Implement __divtc3 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __divtc3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+#include "int_lib.h"
+#include "int_math.h"
+
+// Returns: the quotient of (a + ib) / (c + id)
+
+COMPILER_RT_ABI Lcomplex __divtc3(long double __a, long double __b,
+                                  long double __c, long double __d) {
+  int __ilogbw = 0;
+  long double __logbw =
+      __compiler_rt_logbl(crt_fmaxl(crt_fabsl(__c), crt_fabsl(__d)));
+  if (crt_isfinite(__logbw)) {
+    __ilogbw = (int)__logbw;
+    __c = crt_scalbnl(__c, -__ilogbw);
+    __d = crt_scalbnl(__d, -__ilogbw);
+  }
+  long double __denom = __c * __c + __d * __d;
+  Lcomplex z;
+  COMPLEX_REAL(z) = crt_scalbnl((__a * __c + __b * __d) / __denom, -__ilogbw);
+  COMPLEX_IMAGINARY(z) =
+      crt_scalbnl((__b * __c - __a * __d) / __denom, -__ilogbw);
+  if (crt_isnan(COMPLEX_REAL(z)) && crt_isnan(COMPLEX_IMAGINARY(z))) {
+    if ((__denom == 0.0) && (!crt_isnan(__a) || !crt_isnan(__b))) {
+      COMPLEX_REAL(z) = crt_copysignl(CRT_INFINITY, __c) * __a;
+      COMPLEX_IMAGINARY(z) = crt_copysignl(CRT_INFINITY, __c) * __b;
+    } else if ((crt_isinf(__a) || crt_isinf(__b)) && crt_isfinite(__c) &&
+               crt_isfinite(__d)) {
+      __a = crt_copysignl(crt_isinf(__a) ? 1.0 : 0.0, __a);
+      __b = crt_copysignl(crt_isinf(__b) ? 1.0 : 0.0, __b);
+      COMPLEX_REAL(z) = CRT_INFINITY * (__a * __c + __b * __d);
+      COMPLEX_IMAGINARY(z) = CRT_INFINITY * (__b * __c - __a * __d);
+    } else if (crt_isinf(__logbw) && __logbw > 0.0 && crt_isfinite(__a) &&
+               crt_isfinite(__b)) {
+      __c = crt_copysignl(crt_isinf(__c) ? 1.0 : 0.0, __c);
+      __d = crt_copysignl(crt_isinf(__d) ? 1.0 : 0.0, __d);
+      COMPLEX_REAL(z) = 0.0 * (__a * __c + __b * __d);
+      COMPLEX_IMAGINARY(z) = 0.0 * (__b * __c - __a * __d);
+    }
+  }
+  return z;
+}

--- a/system/lib/compiler-rt/lib/builtins/divxc3.c
+++ b/system/lib/compiler-rt/lib/builtins/divxc3.c
@@ -1,0 +1,55 @@
+//===-- divxc3.c - Implement __divxc3 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __divxc3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#if !_ARCH_PPC
+
+#include "int_lib.h"
+#include "int_math.h"
+
+// Returns: the quotient of (a + ib) / (c + id)
+
+COMPILER_RT_ABI Lcomplex __divxc3(long double __a, long double __b,
+                                  long double __c, long double __d) {
+  int __ilogbw = 0;
+  long double __logbw = crt_logbl(crt_fmaxl(crt_fabsl(__c), crt_fabsl(__d)));
+  if (crt_isfinite(__logbw)) {
+    __ilogbw = (int)__logbw;
+    __c = crt_scalbnl(__c, -__ilogbw);
+    __d = crt_scalbnl(__d, -__ilogbw);
+  }
+  long double __denom = __c * __c + __d * __d;
+  Lcomplex z;
+  COMPLEX_REAL(z) = crt_scalbnl((__a * __c + __b * __d) / __denom, -__ilogbw);
+  COMPLEX_IMAGINARY(z) =
+      crt_scalbnl((__b * __c - __a * __d) / __denom, -__ilogbw);
+  if (crt_isnan(COMPLEX_REAL(z)) && crt_isnan(COMPLEX_IMAGINARY(z))) {
+    if ((__denom == 0) && (!crt_isnan(__a) || !crt_isnan(__b))) {
+      COMPLEX_REAL(z) = crt_copysignl(CRT_INFINITY, __c) * __a;
+      COMPLEX_IMAGINARY(z) = crt_copysignl(CRT_INFINITY, __c) * __b;
+    } else if ((crt_isinf(__a) || crt_isinf(__b)) && crt_isfinite(__c) &&
+               crt_isfinite(__d)) {
+      __a = crt_copysignl(crt_isinf(__a) ? 1 : 0, __a);
+      __b = crt_copysignl(crt_isinf(__b) ? 1 : 0, __b);
+      COMPLEX_REAL(z) = CRT_INFINITY * (__a * __c + __b * __d);
+      COMPLEX_IMAGINARY(z) = CRT_INFINITY * (__b * __c - __a * __d);
+    } else if (crt_isinf(__logbw) && __logbw > 0 && crt_isfinite(__a) &&
+               crt_isfinite(__b)) {
+      __c = crt_copysignl(crt_isinf(__c) ? 1 : 0, __c);
+      __d = crt_copysignl(crt_isinf(__d) ? 1 : 0, __d);
+      COMPLEX_REAL(z) = 0 * (__a * __c + __b * __d);
+      COMPLEX_IMAGINARY(z) = 0 * (__b * __c - __a * __d);
+    }
+  }
+  return z;
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/emutls.c
+++ b/system/lib/compiler-rt/lib/builtins/emutls.c
@@ -1,0 +1,383 @@
+//===---------- emutls.c - Implements __emutls_get_address ---------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "int_lib.h"
+
+#ifdef __BIONIC__
+// There are 4 pthread key cleanup rounds on Bionic. Delay emutls deallocation
+// to round 2. We need to delay deallocation because:
+//  - Android versions older than M lack __cxa_thread_atexit_impl, so apps
+//    use a pthread key destructor to call C++ destructors.
+//  - Apps might use __thread/thread_local variables in pthread destructors.
+// We can't wait until the final two rounds, because jemalloc needs two rounds
+// after the final malloc/free call to free its thread-specific data (see
+// https://reviews.llvm.org/D46978#1107507).
+#define EMUTLS_SKIP_DESTRUCTOR_ROUNDS 1
+#else
+#define EMUTLS_SKIP_DESTRUCTOR_ROUNDS 0
+#endif
+
+typedef struct emutls_address_array {
+  uintptr_t skip_destructor_rounds;
+  uintptr_t size; // number of elements in the 'data' array
+  void *data[];
+} emutls_address_array;
+
+static void emutls_shutdown(emutls_address_array *array);
+
+#ifndef _WIN32
+
+#include <pthread.h>
+
+static pthread_mutex_t emutls_mutex = PTHREAD_MUTEX_INITIALIZER;
+static pthread_key_t emutls_pthread_key;
+static bool emutls_key_created = false;
+
+typedef unsigned int gcc_word __attribute__((mode(word)));
+typedef unsigned int gcc_pointer __attribute__((mode(pointer)));
+
+// Default is not to use posix_memalign, so systems like Android
+// can use thread local data without heavier POSIX memory allocators.
+#ifndef EMUTLS_USE_POSIX_MEMALIGN
+#define EMUTLS_USE_POSIX_MEMALIGN 0
+#endif
+
+static __inline void *emutls_memalign_alloc(size_t align, size_t size) {
+  void *base;
+#if EMUTLS_USE_POSIX_MEMALIGN
+  if (posix_memalign(&base, align, size) != 0)
+    abort();
+#else
+#define EXTRA_ALIGN_PTR_BYTES (align - 1 + sizeof(void *))
+  char *object;
+  if ((object = (char *)malloc(EXTRA_ALIGN_PTR_BYTES + size)) == NULL)
+    abort();
+  base = (void *)(((uintptr_t)(object + EXTRA_ALIGN_PTR_BYTES)) &
+                  ~(uintptr_t)(align - 1));
+
+  ((void **)base)[-1] = object;
+#endif
+  return base;
+}
+
+static __inline void emutls_memalign_free(void *base) {
+#if EMUTLS_USE_POSIX_MEMALIGN
+  free(base);
+#else
+  // The mallocated address is in ((void**)base)[-1]
+  free(((void **)base)[-1]);
+#endif
+}
+
+static __inline void emutls_setspecific(emutls_address_array *value) {
+  pthread_setspecific(emutls_pthread_key, (void *)value);
+}
+
+static __inline emutls_address_array *emutls_getspecific() {
+  return (emutls_address_array *)pthread_getspecific(emutls_pthread_key);
+}
+
+static void emutls_key_destructor(void *ptr) {
+  emutls_address_array *array = (emutls_address_array *)ptr;
+  if (array->skip_destructor_rounds > 0) {
+    // emutls is deallocated using a pthread key destructor. These
+    // destructors are called in several rounds to accommodate destructor
+    // functions that (re)initialize key values with pthread_setspecific.
+    // Delay the emutls deallocation to accommodate other end-of-thread
+    // cleanup tasks like calling thread_local destructors (e.g. the
+    // __cxa_thread_atexit fallback in libc++abi).
+    array->skip_destructor_rounds--;
+    emutls_setspecific(array);
+  } else {
+    emutls_shutdown(array);
+    free(ptr);
+  }
+}
+
+static __inline void emutls_init(void) {
+  if (pthread_key_create(&emutls_pthread_key, emutls_key_destructor) != 0)
+    abort();
+  emutls_key_created = true;
+}
+
+static __inline void emutls_init_once(void) {
+  static pthread_once_t once = PTHREAD_ONCE_INIT;
+  pthread_once(&once, emutls_init);
+}
+
+static __inline void emutls_lock() { pthread_mutex_lock(&emutls_mutex); }
+
+static __inline void emutls_unlock() { pthread_mutex_unlock(&emutls_mutex); }
+
+#else // _WIN32
+
+#include <assert.h>
+#include <malloc.h>
+#include <stdio.h>
+#include <windows.h>
+
+static LPCRITICAL_SECTION emutls_mutex;
+static DWORD emutls_tls_index = TLS_OUT_OF_INDEXES;
+
+typedef uintptr_t gcc_word;
+typedef void *gcc_pointer;
+
+static void win_error(DWORD last_err, const char *hint) {
+  char *buffer = NULL;
+  if (FormatMessageA(FORMAT_MESSAGE_ALLOCATE_BUFFER |
+                         FORMAT_MESSAGE_FROM_SYSTEM |
+                         FORMAT_MESSAGE_MAX_WIDTH_MASK,
+                     NULL, last_err, 0, (LPSTR)&buffer, 1, NULL)) {
+    fprintf(stderr, "Windows error: %s\n", buffer);
+  } else {
+    fprintf(stderr, "Unkown Windows error: %s\n", hint);
+  }
+  LocalFree(buffer);
+}
+
+static __inline void win_abort(DWORD last_err, const char *hint) {
+  win_error(last_err, hint);
+  abort();
+}
+
+static __inline void *emutls_memalign_alloc(size_t align, size_t size) {
+  void *base = _aligned_malloc(size, align);
+  if (!base)
+    win_abort(GetLastError(), "_aligned_malloc");
+  return base;
+}
+
+static __inline void emutls_memalign_free(void *base) { _aligned_free(base); }
+
+static void emutls_exit(void) {
+  if (emutls_mutex) {
+    DeleteCriticalSection(emutls_mutex);
+    _aligned_free(emutls_mutex);
+    emutls_mutex = NULL;
+  }
+  if (emutls_tls_index != TLS_OUT_OF_INDEXES) {
+    emutls_shutdown((emutls_address_array *)TlsGetValue(emutls_tls_index));
+    TlsFree(emutls_tls_index);
+    emutls_tls_index = TLS_OUT_OF_INDEXES;
+  }
+}
+
+#pragma warning(push)
+#pragma warning(disable : 4100)
+static BOOL CALLBACK emutls_init(PINIT_ONCE p0, PVOID p1, PVOID *p2) {
+  emutls_mutex =
+      (LPCRITICAL_SECTION)_aligned_malloc(sizeof(CRITICAL_SECTION), 16);
+  if (!emutls_mutex) {
+    win_error(GetLastError(), "_aligned_malloc");
+    return FALSE;
+  }
+  InitializeCriticalSection(emutls_mutex);
+
+  emutls_tls_index = TlsAlloc();
+  if (emutls_tls_index == TLS_OUT_OF_INDEXES) {
+    emutls_exit();
+    win_error(GetLastError(), "TlsAlloc");
+    return FALSE;
+  }
+  atexit(&emutls_exit);
+  return TRUE;
+}
+
+static __inline void emutls_init_once(void) {
+  static INIT_ONCE once;
+  InitOnceExecuteOnce(&once, emutls_init, NULL, NULL);
+}
+
+static __inline void emutls_lock() { EnterCriticalSection(emutls_mutex); }
+
+static __inline void emutls_unlock() { LeaveCriticalSection(emutls_mutex); }
+
+static __inline void emutls_setspecific(emutls_address_array *value) {
+  if (TlsSetValue(emutls_tls_index, (LPVOID)value) == 0)
+    win_abort(GetLastError(), "TlsSetValue");
+}
+
+static __inline emutls_address_array *emutls_getspecific() {
+  LPVOID value = TlsGetValue(emutls_tls_index);
+  if (value == NULL) {
+    const DWORD err = GetLastError();
+    if (err != ERROR_SUCCESS)
+      win_abort(err, "TlsGetValue");
+  }
+  return (emutls_address_array *)value;
+}
+
+// Provide atomic load/store functions for emutls_get_index if built with MSVC.
+#if !defined(__ATOMIC_RELEASE)
+#include <intrin.h>
+
+enum { __ATOMIC_ACQUIRE = 2, __ATOMIC_RELEASE = 3 };
+
+static __inline uintptr_t __atomic_load_n(void *ptr, unsigned type) {
+  assert(type == __ATOMIC_ACQUIRE);
+  // These return the previous value - but since we do an OR with 0,
+  // it's equivalent to a plain load.
+#ifdef _WIN64
+  return InterlockedOr64(ptr, 0);
+#else
+  return InterlockedOr(ptr, 0);
+#endif
+}
+
+static __inline void __atomic_store_n(void *ptr, uintptr_t val, unsigned type) {
+  assert(type == __ATOMIC_RELEASE);
+  InterlockedExchangePointer((void *volatile *)ptr, (void *)val);
+}
+
+#endif // __ATOMIC_RELEASE
+
+#pragma warning(pop)
+
+#endif // _WIN32
+
+static size_t emutls_num_object = 0; // number of allocated TLS objects
+
+// Free the allocated TLS data
+static void emutls_shutdown(emutls_address_array *array) {
+  if (array) {
+    uintptr_t i;
+    for (i = 0; i < array->size; ++i) {
+      if (array->data[i])
+        emutls_memalign_free(array->data[i]);
+    }
+  }
+}
+
+// For every TLS variable xyz,
+// there is one __emutls_control variable named __emutls_v.xyz.
+// If xyz has non-zero initial value, __emutls_v.xyz's "value"
+// will point to __emutls_t.xyz, which has the initial value.
+typedef struct __emutls_control {
+  // Must use gcc_word here, instead of size_t, to match GCC.  When
+  // gcc_word is larger than size_t, the upper extra bits are all
+  // zeros.  We can use variables of size_t to operate on size and
+  // align.
+  gcc_word size;  // size of the object in bytes
+  gcc_word align; // alignment of the object in bytes
+  union {
+    uintptr_t index; // data[index-1] is the object address
+    void *address;   // object address, when in single thread env
+  } object;
+  void *value; // null or non-zero initial value for the object
+} __emutls_control;
+
+// Emulated TLS objects are always allocated at run-time.
+static __inline void *emutls_allocate_object(__emutls_control *control) {
+  // Use standard C types, check with gcc's emutls.o.
+  COMPILE_TIME_ASSERT(sizeof(uintptr_t) == sizeof(gcc_pointer));
+  COMPILE_TIME_ASSERT(sizeof(uintptr_t) == sizeof(void *));
+
+  size_t size = control->size;
+  size_t align = control->align;
+  void *base;
+  if (align < sizeof(void *))
+    align = sizeof(void *);
+  // Make sure that align is power of 2.
+  if ((align & (align - 1)) != 0)
+    abort();
+
+  base = emutls_memalign_alloc(align, size);
+  if (control->value)
+    memcpy(base, control->value, size);
+  else
+    memset(base, 0, size);
+  return base;
+}
+
+// Returns control->object.index; set index if not allocated yet.
+static __inline uintptr_t emutls_get_index(__emutls_control *control) {
+  uintptr_t index = __atomic_load_n(&control->object.index, __ATOMIC_ACQUIRE);
+  if (!index) {
+    emutls_init_once();
+    emutls_lock();
+    index = control->object.index;
+    if (!index) {
+      index = ++emutls_num_object;
+      __atomic_store_n(&control->object.index, index, __ATOMIC_RELEASE);
+    }
+    emutls_unlock();
+  }
+  return index;
+}
+
+// Updates newly allocated thread local emutls_address_array.
+static __inline void emutls_check_array_set_size(emutls_address_array *array,
+                                                 uintptr_t size) {
+  if (array == NULL)
+    abort();
+  array->size = size;
+  emutls_setspecific(array);
+}
+
+// Returns the new 'data' array size, number of elements,
+// which must be no smaller than the given index.
+static __inline uintptr_t emutls_new_data_array_size(uintptr_t index) {
+  // Need to allocate emutls_address_array with extra slots
+  // to store the header.
+  // Round up the emutls_address_array size to multiple of 16.
+  uintptr_t header_words = sizeof(emutls_address_array) / sizeof(void *);
+  return ((index + header_words + 15) & ~((uintptr_t)15)) - header_words;
+}
+
+// Returns the size in bytes required for an emutls_address_array with
+// N number of elements for data field.
+static __inline uintptr_t emutls_asize(uintptr_t N) {
+  return N * sizeof(void *) + sizeof(emutls_address_array);
+}
+
+// Returns the thread local emutls_address_array.
+// Extends its size if necessary to hold address at index.
+static __inline emutls_address_array *
+emutls_get_address_array(uintptr_t index) {
+  emutls_address_array *array = emutls_getspecific();
+  if (array == NULL) {
+    uintptr_t new_size = emutls_new_data_array_size(index);
+    array = (emutls_address_array *)malloc(emutls_asize(new_size));
+    if (array) {
+      memset(array->data, 0, new_size * sizeof(void *));
+      array->skip_destructor_rounds = EMUTLS_SKIP_DESTRUCTOR_ROUNDS;
+    }
+    emutls_check_array_set_size(array, new_size);
+  } else if (index > array->size) {
+    uintptr_t orig_size = array->size;
+    uintptr_t new_size = emutls_new_data_array_size(index);
+    array = (emutls_address_array *)realloc(array, emutls_asize(new_size));
+    if (array)
+      memset(array->data + orig_size, 0,
+             (new_size - orig_size) * sizeof(void *));
+    emutls_check_array_set_size(array, new_size);
+  }
+  return array;
+}
+
+void *__emutls_get_address(__emutls_control *control) {
+  uintptr_t index = emutls_get_index(control);
+  emutls_address_array *array = emutls_get_address_array(index--);
+  if (array->data[index] == NULL)
+    array->data[index] = emutls_allocate_object(control);
+  return array->data[index];
+}
+
+#ifdef __BIONIC__
+// Called by Bionic on dlclose to delete the emutls pthread key.
+__attribute__((visibility("hidden"))) void __emutls_unregister_key(void) {
+  if (emutls_key_created) {
+    pthread_key_delete(emutls_pthread_key);
+    emutls_key_created = false;
+  }
+}
+#endif

--- a/system/lib/compiler-rt/lib/builtins/enable_execute_stack.c
+++ b/system/lib/compiler-rt/lib/builtins/enable_execute_stack.c
@@ -1,0 +1,67 @@
+//===-- enable_execute_stack.c - Implement __enable_execute_stack ---------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifndef _WIN32
+#include <sys/mman.h>
+#endif
+
+// #include "config.h"
+// FIXME: CMake - include when cmake system is ready.
+// Remove #define HAVE_SYSCONF 1 line.
+#define HAVE_SYSCONF 1
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#else
+#ifndef __APPLE__
+#include <unistd.h>
+#endif // __APPLE__
+#endif // _WIN32
+
+#if __LP64__
+#define TRAMPOLINE_SIZE 48
+#else
+#define TRAMPOLINE_SIZE 40
+#endif
+
+// The compiler generates calls to __enable_execute_stack() when creating
+// trampoline functions on the stack for use with nested functions.
+// It is expected to mark the page(s) containing the address
+// and the next 48 bytes as executable.  Since the stack is normally rw-
+// that means changing the protection on those page(s) to rwx.
+
+COMPILER_RT_ABI void __enable_execute_stack(void *addr) {
+
+#if _WIN32
+  MEMORY_BASIC_INFORMATION mbi;
+  if (!VirtualQuery(addr, &mbi, sizeof(mbi)))
+    return; // We should probably assert here because there is no return value
+  VirtualProtect(mbi.BaseAddress, mbi.RegionSize, PAGE_EXECUTE_READWRITE,
+                 &mbi.Protect);
+#else
+#if __APPLE__
+  // On Darwin, pagesize is always 4096 bytes
+  const uintptr_t pageSize = 4096;
+#elif !defined(HAVE_SYSCONF)
+#error "HAVE_SYSCONF not defined! See enable_execute_stack.c"
+#else
+  const uintptr_t pageSize = sysconf(_SC_PAGESIZE);
+#endif // __APPLE__
+
+  const uintptr_t pageAlignMask = ~(pageSize - 1);
+  uintptr_t p = (uintptr_t)addr;
+  unsigned char *startPage = (unsigned char *)(p & pageAlignMask);
+  unsigned char *endPage =
+      (unsigned char *)((p + TRAMPOLINE_SIZE + pageSize) & pageAlignMask);
+  size_t length = endPage - startPage;
+  (void)mprotect((void *)startPage, length, PROT_READ | PROT_WRITE | PROT_EXEC);
+#endif
+}

--- a/system/lib/compiler-rt/lib/builtins/eprintf.c
+++ b/system/lib/compiler-rt/lib/builtins/eprintf.c
@@ -1,0 +1,27 @@
+//===---------- eprintf.c - Implements __eprintf --------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+#include <stdio.h>
+
+// __eprintf() was used in an old version of <assert.h>.
+// It can eventually go away, but it is needed when linking
+// .o files built with the old <assert.h>.
+//
+// It should never be exported from a dylib, so it is marked
+// visibility hidden.
+#ifndef _WIN32
+__attribute__((visibility("hidden")))
+#endif
+COMPILER_RT_ABI void
+__eprintf(const char *format, const char *assertion_expression,
+          const char *line, const char *file) {
+  fprintf(stderr, format, assertion_expression, line, file);
+  fflush(stderr);
+  compilerrt_abort();
+}

--- a/system/lib/compiler-rt/lib/builtins/extendhfsf2.c
+++ b/system/lib/compiler-rt/lib/builtins/extendhfsf2.c
@@ -1,0 +1,27 @@
+//===-- lib/extendhfsf2.c - half -> single conversion -------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SRC_HALF
+#define DST_SINGLE
+#include "fp_extend_impl.inc"
+
+// Use a forwarding definition and noinline to implement a poor man's alias,
+// as there isn't a good cross-platform way of defining one.
+COMPILER_RT_ABI NOINLINE float __extendhfsf2(uint16_t a) {
+  return __extendXfYf2__(a);
+}
+
+COMPILER_RT_ABI float __gnu_h2f_ieee(uint16_t a) { return __extendhfsf2(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI float __aeabi_h2f(uint16_t a) { return __extendhfsf2(a); }
+#else
+COMPILER_RT_ALIAS(__extendhfsf2, __aeabi_h2f)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/extendsfdf2.c
+++ b/system/lib/compiler-rt/lib/builtins/extendsfdf2.c
@@ -1,0 +1,21 @@
+//===-- lib/extendsfdf2.c - single -> double conversion -----------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SRC_SINGLE
+#define DST_DOUBLE
+#include "fp_extend_impl.inc"
+
+COMPILER_RT_ABI double __extendsfdf2(float a) { return __extendXfYf2__(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI double __aeabi_f2d(float a) { return __extendsfdf2(a); }
+#else
+COMPILER_RT_ALIAS(__extendsfdf2, __aeabi_f2d)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/ffsdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/ffsdi2.c
@@ -1,0 +1,27 @@
+//===-- ffsdi2.c - Implement __ffsdi2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __ffsdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: the index of the least significant 1-bit in a, or
+// the value zero if a is zero. The least significant bit is index one.
+
+COMPILER_RT_ABI si_int __ffsdi2(di_int a) {
+  dwords x;
+  x.all = a;
+  if (x.s.low == 0) {
+    if (x.s.high == 0)
+      return 0;
+    return __builtin_ctz(x.s.high) + (1 + sizeof(si_int) * CHAR_BIT);
+  }
+  return __builtin_ctz(x.s.low) + 1;
+}

--- a/system/lib/compiler-rt/lib/builtins/ffssi2.c
+++ b/system/lib/compiler-rt/lib/builtins/ffssi2.c
@@ -1,0 +1,23 @@
+//===-- ffssi2.c - Implement __ffssi2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __ffssi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: the index of the least significant 1-bit in a, or
+// the value zero if a is zero. The least significant bit is index one.
+
+COMPILER_RT_ABI si_int __ffssi2(si_int a) {
+  if (a == 0) {
+    return 0;
+  }
+  return __builtin_ctz(a) + 1;
+}

--- a/system/lib/compiler-rt/lib/builtins/ffsti2.c
+++ b/system/lib/compiler-rt/lib/builtins/ffsti2.c
@@ -1,0 +1,31 @@
+//===-- ffsti2.c - Implement __ffsti2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __ffsti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: the index of the least significant 1-bit in a, or
+// the value zero if a is zero. The least significant bit is index one.
+
+COMPILER_RT_ABI si_int __ffsti2(ti_int a) {
+  twords x;
+  x.all = a;
+  if (x.s.low == 0) {
+    if (x.s.high == 0)
+      return 0;
+    return __builtin_ctzll(x.s.high) + (1 + sizeof(di_int) * CHAR_BIT);
+  }
+  return __builtin_ctzll(x.s.low) + 1;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/fixdfsi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixdfsi.c
@@ -1,0 +1,23 @@
+//===-- fixdfsi.c - Implement __fixdfsi -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+typedef si_int fixint_t;
+typedef su_int fixuint_t;
+#include "fp_fixint_impl.inc"
+
+COMPILER_RT_ABI si_int __fixdfsi(fp_t a) { return __fixint(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI si_int __aeabi_d2iz(fp_t a) { return __fixdfsi(a); }
+#else
+COMPILER_RT_ALIAS(__fixdfsi, __aeabi_d2iz)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/fixsfdi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixsfdi.c
@@ -1,0 +1,44 @@
+//===-- fixsfdi.c - Implement __fixsfdi -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+
+#ifndef __SOFT_FP__
+// Support for systems that have hardware floating-point; can set the invalid
+// flag as a side-effect of computation.
+
+COMPILER_RT_ABI du_int __fixunssfdi(float a);
+
+COMPILER_RT_ABI di_int __fixsfdi(float a) {
+  if (a < 0.0f) {
+    return -__fixunssfdi(-a);
+  }
+  return __fixunssfdi(a);
+}
+
+#else
+// Support for systems that don't have hardware floating-point; there are no
+// flags to set, and we don't want to code-gen to an unknown soft-float
+// implementation.
+
+typedef di_int fixint_t;
+typedef du_int fixuint_t;
+#include "fp_fixint_impl.inc"
+
+COMPILER_RT_ABI di_int __fixsfdi(fp_t a) { return __fixint(a); }
+
+#endif
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI di_int __aeabi_f2lz(fp_t a) { return __fixsfdi(a); }
+#else
+COMPILER_RT_ALIAS(__fixsfdi, __aeabi_f2lz)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/fixsfsi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixsfsi.c
@@ -1,0 +1,23 @@
+//===-- fixsfsi.c - Implement __fixsfsi -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+typedef si_int fixint_t;
+typedef su_int fixuint_t;
+#include "fp_fixint_impl.inc"
+
+COMPILER_RT_ABI si_int __fixsfsi(fp_t a) { return __fixint(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI si_int __aeabi_f2iz(fp_t a) { return __fixsfsi(a); }
+#else
+COMPILER_RT_ALIAS(__fixsfsi, __aeabi_f2iz)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/fixunsdfsi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixunsdfsi.c
@@ -1,0 +1,22 @@
+//===-- fixunsdfsi.c - Implement __fixunsdfsi -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+typedef su_int fixuint_t;
+#include "fp_fixuint_impl.inc"
+
+COMPILER_RT_ABI su_int __fixunsdfsi(fp_t a) { return __fixuint(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI su_int __aeabi_d2uiz(fp_t a) { return __fixunsdfsi(a); }
+#else
+COMPILER_RT_ALIAS(__fixunsdfsi, __aeabi_d2uiz)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/fixunssfdi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixunssfdi.c
@@ -1,0 +1,43 @@
+//===-- fixunssfdi.c - Implement __fixunssfdi -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+
+#ifndef __SOFT_FP__
+// Support for systems that have hardware floating-point; can set the invalid
+// flag as a side-effect of computation.
+
+COMPILER_RT_ABI du_int __fixunssfdi(float a) {
+  if (a <= 0.0f)
+    return 0;
+  double da = a;
+  su_int high = da / 4294967296.f;               // da / 0x1p32f;
+  su_int low = da - (double)high * 4294967296.f; // high * 0x1p32f;
+  return ((du_int)high << 32) | low;
+}
+
+#else
+// Support for systems that don't have hardware floating-point; there are no
+// flags to set, and we don't want to code-gen to an unknown soft-float
+// implementation.
+
+typedef du_int fixuint_t;
+#include "fp_fixuint_impl.inc"
+
+COMPILER_RT_ABI du_int __fixunssfdi(fp_t a) { return __fixuint(a); }
+
+#endif
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI du_int __aeabi_f2ulz(fp_t a) { return __fixunssfdi(a); }
+#else
+COMPILER_RT_ALIAS(__fixunssfdi, __aeabi_f2ulz)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/fixunssfsi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixunssfsi.c
@@ -1,0 +1,26 @@
+//===-- fixunssfsi.c - Implement __fixunssfsi -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __fixunssfsi for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+typedef su_int fixuint_t;
+#include "fp_fixuint_impl.inc"
+
+COMPILER_RT_ABI su_int __fixunssfsi(fp_t a) { return __fixuint(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI su_int __aeabi_f2uiz(fp_t a) { return __fixunssfsi(a); }
+#else
+COMPILER_RT_ALIAS(__fixunssfsi, __aeabi_f2uiz)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/fixunsxfdi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixunsxfdi.c
@@ -1,0 +1,39 @@
+//===-- fixunsxfdi.c - Implement __fixunsxfdi -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __fixunsxfdi for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#if !_ARCH_PPC
+
+#include "int_lib.h"
+
+// Returns: convert a to a unsigned long long, rounding toward zero.
+//          Negative values all become zero.
+
+// Assumption: long double is an intel 80 bit floating point type padded with 6
+// bytes du_int is a 64 bit integral type value in long double is representable
+// in du_int or is negative (no range checking performed)
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+COMPILER_RT_ABI du_int __fixunsxfdi(long double a) {
+  long_double_bits fb;
+  fb.f = a;
+  int e = (fb.u.high.s.low & 0x00007FFF) - 16383;
+  if (e < 0 || (fb.u.high.s.low & 0x00008000))
+    return 0;
+  if ((unsigned)e > sizeof(du_int) * CHAR_BIT)
+    return ~(du_int)0;
+  return fb.u.low.all >> (63 - e);
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/fixunsxfsi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixunsxfsi.c
@@ -1,0 +1,39 @@
+//===-- fixunsxfsi.c - Implement __fixunsxfsi -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __fixunsxfsi for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#if !_ARCH_PPC
+
+#include "int_lib.h"
+
+// Returns: convert a to a unsigned int, rounding toward zero.
+//          Negative values all become zero.
+
+// Assumption: long double is an intel 80 bit floating point type padded with 6
+// bytes su_int is a 32 bit integral type value in long double is representable
+// in su_int or is negative
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+COMPILER_RT_ABI su_int __fixunsxfsi(long double a) {
+  long_double_bits fb;
+  fb.f = a;
+  int e = (fb.u.high.s.low & 0x00007FFF) - 16383;
+  if (e < 0 || (fb.u.high.s.low & 0x00008000))
+    return 0;
+  if ((unsigned)e > sizeof(su_int) * CHAR_BIT)
+    return ~(su_int)0;
+  return fb.u.low.s.high >> (31 - e);
+}
+
+#endif // !_ARCH_PPC

--- a/system/lib/compiler-rt/lib/builtins/fixunsxfti.c
+++ b/system/lib/compiler-rt/lib/builtins/fixunsxfti.c
@@ -1,0 +1,44 @@
+//===-- fixunsxfti.c - Implement __fixunsxfti -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __fixunsxfti for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: convert a to a unsigned long long, rounding toward zero.
+//          Negative values all become zero.
+
+// Assumption: long double is an intel 80 bit floating point type padded with 6
+// bytes tu_int is a 128 bit integral type value in long double is representable
+// in tu_int or is negative
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+COMPILER_RT_ABI tu_int __fixunsxfti(long double a) {
+  long_double_bits fb;
+  fb.f = a;
+  int e = (fb.u.high.s.low & 0x00007FFF) - 16383;
+  if (e < 0 || (fb.u.high.s.low & 0x00008000))
+    return 0;
+  if ((unsigned)e > sizeof(tu_int) * CHAR_BIT)
+    return ~(tu_int)0;
+  tu_int r = fb.u.low.all;
+  if (e > 63)
+    r <<= (e - 63);
+  else
+    r >>= (63 - e);
+  return r;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/fixxfdi.c
+++ b/system/lib/compiler-rt/lib/builtins/fixxfdi.c
@@ -1,0 +1,43 @@
+//===-- fixxfdi.c - Implement __fixxfdi -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __fixxfdi for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#if !_ARCH_PPC
+
+#include "int_lib.h"
+
+// Returns: convert a to a signed long long, rounding toward zero.
+
+// Assumption: long double is an intel 80 bit floating point type padded with 6
+// bytes di_int is a 64 bit integral type value in long double is representable
+// in di_int (no range checking performed)
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+COMPILER_RT_ABI di_int __fixxfdi(long double a) {
+  const di_int di_max = (di_int)((~(du_int)0) / 2);
+  const di_int di_min = -di_max - 1;
+  long_double_bits fb;
+  fb.f = a;
+  int e = (fb.u.high.s.low & 0x00007FFF) - 16383;
+  if (e < 0)
+    return 0;
+  if ((unsigned)e >= sizeof(di_int) * CHAR_BIT)
+    return a > 0 ? di_max : di_min;
+  di_int s = -(si_int)((fb.u.high.s.low & 0x00008000) >> 15);
+  di_int r = fb.u.low.all;
+  r = (du_int)r >> (63 - e);
+  return (r ^ s) - s;
+}
+
+#endif // !_ARCH_PPC

--- a/system/lib/compiler-rt/lib/builtins/fixxfti.c
+++ b/system/lib/compiler-rt/lib/builtins/fixxfti.c
@@ -1,0 +1,46 @@
+//===-- fixxfti.c - Implement __fixxfti -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __fixxfti for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: convert a to a signed long long, rounding toward zero.
+
+// Assumption: long double is an intel 80 bit floating point type padded with 6
+// bytes ti_int is a 128 bit integral type value in long double is representable
+// in ti_int
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+COMPILER_RT_ABI ti_int __fixxfti(long double a) {
+  const ti_int ti_max = (ti_int)((~(tu_int)0) / 2);
+  const ti_int ti_min = -ti_max - 1;
+  long_double_bits fb;
+  fb.f = a;
+  int e = (fb.u.high.s.low & 0x00007FFF) - 16383;
+  if (e < 0)
+    return 0;
+  ti_int s = -(si_int)((fb.u.high.s.low & 0x00008000) >> 15);
+  ti_int r = fb.u.low.all;
+  if ((unsigned)e >= sizeof(ti_int) * CHAR_BIT)
+    return a > 0 ? ti_max : ti_min;
+  if (e > 63)
+    r <<= (e - 63);
+  else
+    r >>= (63 - e);
+  return (r ^ s) - s;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/floatdisf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatdisf.c
@@ -1,0 +1,75 @@
+//===-- floatdisf.c - Implement __floatdisf -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __floatdisf for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+// Returns: convert a to a float, rounding toward even.
+
+// Assumption: float is a IEEE 32 bit floating point type
+//             di_int is a 64 bit integral type
+
+// seee eeee emmm mmmm mmmm mmmm mmmm mmmm
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI float __floatdisf(di_int a) {
+  if (a == 0)
+    return 0.0F;
+  const unsigned N = sizeof(di_int) * CHAR_BIT;
+  const di_int s = a >> (N - 1);
+  a = (a ^ s) - s;
+  int sd = N - __builtin_clzll(a); // number of significant digits
+  int e = sd - 1;                  // exponent
+  if (sd > FLT_MANT_DIG) {
+    //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx
+    //  finish: 000000000000000000000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQR
+    //                                                12345678901234567890123456
+    //  1 = msb 1 bit
+    //  P = bit FLT_MANT_DIG-1 bits to the right of 1
+    //  Q = bit FLT_MANT_DIG bits to the right of 1
+    //  R = "or" of all bits to the right of Q
+    switch (sd) {
+    case FLT_MANT_DIG + 1:
+      a <<= 1;
+      break;
+    case FLT_MANT_DIG + 2:
+      break;
+    default:
+      a = ((du_int)a >> (sd - (FLT_MANT_DIG + 2))) |
+          ((a & ((du_int)(-1) >> ((N + FLT_MANT_DIG + 2) - sd))) != 0);
+    };
+    // finish:
+    a |= (a & 4) != 0; // Or P into R
+    ++a;               // round - this step may add a significant bit
+    a >>= 2;           // dump Q and R
+    // a is now rounded to FLT_MANT_DIG or FLT_MANT_DIG+1 bits
+    if (a & ((du_int)1 << FLT_MANT_DIG)) {
+      a >>= 1;
+      ++e;
+    }
+    // a is now rounded to FLT_MANT_DIG bits
+  } else {
+    a <<= (FLT_MANT_DIG - sd);
+    // a is now rounded to FLT_MANT_DIG bits
+  }
+  float_bits fb;
+  fb.u = ((su_int)s & 0x80000000) | // sign
+         ((e + 127) << 23) |        // exponent
+         ((su_int)a & 0x007FFFFF);  // mantissa
+  return fb.f;
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI float __aeabi_l2f(di_int a) { return __floatdisf(a); }
+#else
+COMPILER_RT_ALIAS(__floatdisf, __aeabi_l2f)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/floatdixf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatdixf.c
@@ -1,0 +1,41 @@
+//===-- floatdixf.c - Implement __floatdixf -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __floatdixf for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#if !_ARCH_PPC
+
+#include "int_lib.h"
+
+// Returns: convert a to a long double, rounding toward even.
+
+// Assumption: long double is a IEEE 80 bit floating point type padded to 128
+// bits di_int is a 64 bit integral type
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+COMPILER_RT_ABI long double __floatdixf(di_int a) {
+  if (a == 0)
+    return 0.0;
+  const unsigned N = sizeof(di_int) * CHAR_BIT;
+  const di_int s = a >> (N - 1);
+  a = (a ^ s) - s;
+  int clz = __builtin_clzll(a);
+  int e = (N - 1) - clz; // exponent
+  long_double_bits fb;
+  fb.u.high.s.low = ((su_int)s & 0x00008000) | // sign
+                    (e + 16383);               // exponent
+  fb.u.low.all = a << clz;                     // mantissa
+  return fb.f;
+}
+
+#endif // !_ARCH_PPC

--- a/system/lib/compiler-rt/lib/builtins/floatsidf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatsidf.c
@@ -1,0 +1,57 @@
+//===-- lib/floatsidf.c - integer -> double-precision conversion --*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements integer to double-precision conversion for the
+// compiler-rt library in the IEEE-754 default round-to-nearest, ties-to-even
+// mode.
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI fp_t __floatsidf(int a) {
+
+  const int aWidth = sizeof a * CHAR_BIT;
+
+  // Handle zero as a special case to protect clz
+  if (a == 0)
+    return fromRep(0);
+
+  // All other cases begin by extracting the sign and absolute value of a
+  rep_t sign = 0;
+  if (a < 0) {
+    sign = signBit;
+    a = -a;
+  }
+
+  // Exponent of (fp_t)a is the width of abs(a).
+  const int exponent = (aWidth - 1) - __builtin_clz(a);
+  rep_t result;
+
+  // Shift a into the significand field and clear the implicit bit.  Extra
+  // cast to unsigned int is necessary to get the correct behavior for
+  // the input INT_MIN.
+  const int shift = significandBits - exponent;
+  result = (rep_t)(unsigned int)a << shift ^ implicitBit;
+
+  // Insert the exponent
+  result += (rep_t)(exponent + exponentBias) << significandBits;
+  // Insert the sign bit and return
+  return fromRep(result | sign);
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_i2d(int a) { return __floatsidf(a); }
+#else
+COMPILER_RT_ALIAS(__floatsidf, __aeabi_i2d)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/floatsisf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatsisf.c
@@ -1,0 +1,65 @@
+//===-- lib/floatsisf.c - integer -> single-precision conversion --*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements integer to single-precision conversion for the
+// compiler-rt library in the IEEE-754 default round-to-nearest, ties-to-even
+// mode.
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI fp_t __floatsisf(int a) {
+
+  const int aWidth = sizeof a * CHAR_BIT;
+
+  // Handle zero as a special case to protect clz
+  if (a == 0)
+    return fromRep(0);
+
+  // All other cases begin by extracting the sign and absolute value of a
+  rep_t sign = 0;
+  if (a < 0) {
+    sign = signBit;
+    a = -a;
+  }
+
+  // Exponent of (fp_t)a is the width of abs(a).
+  const int exponent = (aWidth - 1) - __builtin_clz(a);
+  rep_t result;
+
+  // Shift a into the significand field, rounding if it is a right-shift
+  if (exponent <= significandBits) {
+    const int shift = significandBits - exponent;
+    result = (rep_t)a << shift ^ implicitBit;
+  } else {
+    const int shift = exponent - significandBits;
+    result = (rep_t)a >> shift ^ implicitBit;
+    rep_t round = (rep_t)a << (typeWidth - shift);
+    if (round > signBit)
+      result++;
+    if (round == signBit)
+      result += result & 1;
+  }
+
+  // Insert the exponent
+  result += (rep_t)(exponent + exponentBias) << significandBits;
+  // Insert the sign bit and return
+  return fromRep(result | sign);
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_i2f(int a) { return __floatsisf(a); }
+#else
+COMPILER_RT_ALIAS(__floatsisf, __aeabi_i2f)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/floattixf.c
+++ b/system/lib/compiler-rt/lib/builtins/floattixf.c
@@ -1,0 +1,73 @@
+//===-- floattixf.c - Implement __floattixf -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __floattixf for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: convert a to a long double, rounding toward even.
+
+// Assumption: long double is a IEEE 80 bit floating point type padded to 128
+// bits ti_int is a 128 bit integral type
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+COMPILER_RT_ABI long double __floattixf(ti_int a) {
+  if (a == 0)
+    return 0.0;
+  const unsigned N = sizeof(ti_int) * CHAR_BIT;
+  const ti_int s = a >> (N - 1);
+  a = (a ^ s) - s;
+  int sd = N - __clzti2(a); // number of significant digits
+  int e = sd - 1;           // exponent
+  if (sd > LDBL_MANT_DIG) {
+    //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx
+    //  finish: 000000000000000000000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQR
+    //                                                12345678901234567890123456
+    //  1 = msb 1 bit
+    //  P = bit LDBL_MANT_DIG-1 bits to the right of 1
+    //  Q = bit LDBL_MANT_DIG bits to the right of 1
+    //  R = "or" of all bits to the right of Q
+    switch (sd) {
+    case LDBL_MANT_DIG + 1:
+      a <<= 1;
+      break;
+    case LDBL_MANT_DIG + 2:
+      break;
+    default:
+      a = ((tu_int)a >> (sd - (LDBL_MANT_DIG + 2))) |
+          ((a & ((tu_int)(-1) >> ((N + LDBL_MANT_DIG + 2) - sd))) != 0);
+    };
+    // finish:
+    a |= (a & 4) != 0; // Or P into R
+    ++a;               // round - this step may add a significant bit
+    a >>= 2;           // dump Q and R
+    // a is now rounded to LDBL_MANT_DIG or LDBL_MANT_DIG+1 bits
+    if (a & ((tu_int)1 << LDBL_MANT_DIG)) {
+      a >>= 1;
+      ++e;
+    }
+    // a is now rounded to LDBL_MANT_DIG bits
+  } else {
+    a <<= (LDBL_MANT_DIG - sd);
+    // a is now rounded to LDBL_MANT_DIG bits
+  }
+  long_double_bits fb;
+  fb.u.high.s.low = ((su_int)s & 0x8000) | // sign
+                    (e + 16383);           // exponent
+  fb.u.low.all = (du_int)a;                // mantissa
+  return fb.f;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/floatundidf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatundidf.c
@@ -1,0 +1,106 @@
+//===-- floatundidf.c - Implement __floatundidf ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __floatundidf for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+// Returns: convert a to a double, rounding toward even.
+
+// Assumption: double is a IEEE 64 bit floating point type
+//             du_int is a 64 bit integral type
+
+// seee eeee eeee mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm
+// mmmm
+
+#include "int_lib.h"
+
+#ifndef __SOFT_FP__
+// Support for systems that have hardware floating-point; we'll set the inexact
+// flag as a side-effect of this computation.
+
+COMPILER_RT_ABI double __floatundidf(du_int a) {
+  static const double twop52 = 4503599627370496.0;           // 0x1.0p52
+  static const double twop84 = 19342813113834066795298816.0; // 0x1.0p84
+  static const double twop84_plus_twop52 =
+      19342813118337666422669312.0; // 0x1.00000001p84
+
+  union {
+    uint64_t x;
+    double d;
+  } high = {.d = twop84};
+  union {
+    uint64_t x;
+    double d;
+  } low = {.d = twop52};
+
+  high.x |= a >> 32;
+  low.x |= a & UINT64_C(0x00000000ffffffff);
+
+  const double result = (high.d - twop84_plus_twop52) + low.d;
+  return result;
+}
+
+#else
+// Support for systems that don't have hardware floating-point; there are no
+// flags to set, and we don't want to code-gen to an unknown soft-float
+// implementation.
+
+COMPILER_RT_ABI double __floatundidf(du_int a) {
+  if (a == 0)
+    return 0.0;
+  const unsigned N = sizeof(du_int) * CHAR_BIT;
+  int sd = N - __builtin_clzll(a); // number of significant digits
+  int e = sd - 1;                  // exponent
+  if (sd > DBL_MANT_DIG) {
+    //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx
+    //  finish: 000000000000000000000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQR
+    //                                                12345678901234567890123456
+    //  1 = msb 1 bit
+    //  P = bit DBL_MANT_DIG-1 bits to the right of 1
+    //  Q = bit DBL_MANT_DIG bits to the right of 1
+    //  R = "or" of all bits to the right of Q
+    switch (sd) {
+    case DBL_MANT_DIG + 1:
+      a <<= 1;
+      break;
+    case DBL_MANT_DIG + 2:
+      break;
+    default:
+      a = (a >> (sd - (DBL_MANT_DIG + 2))) |
+          ((a & ((du_int)(-1) >> ((N + DBL_MANT_DIG + 2) - sd))) != 0);
+    };
+    // finish:
+    a |= (a & 4) != 0; // Or P into R
+    ++a;               // round - this step may add a significant bit
+    a >>= 2;           // dump Q and R
+    // a is now rounded to DBL_MANT_DIG or DBL_MANT_DIG+1 bits
+    if (a & ((du_int)1 << DBL_MANT_DIG)) {
+      a >>= 1;
+      ++e;
+    }
+    // a is now rounded to DBL_MANT_DIG bits
+  } else {
+    a <<= (DBL_MANT_DIG - sd);
+    // a is now rounded to DBL_MANT_DIG bits
+  }
+  double_bits fb;
+  fb.u.s.high = ((e + 1023) << 20) |              // exponent
+                ((su_int)(a >> 32) & 0x000FFFFF); // mantissa-high
+  fb.u.s.low = (su_int)a;                         // mantissa-low
+  return fb.f;
+}
+#endif
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI double __aeabi_ul2d(du_int a) { return __floatundidf(a); }
+#else
+COMPILER_RT_ALIAS(__floatundidf, __aeabi_ul2d)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/floatundisf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatundisf.c
@@ -1,0 +1,72 @@
+//===-- floatundisf.c - Implement __floatundisf ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __floatundisf for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+// Returns: convert a to a float, rounding toward even.
+
+// Assumption: float is a IEEE 32 bit floating point type
+//            du_int is a 64 bit integral type
+
+// seee eeee emmm mmmm mmmm mmmm mmmm mmmm
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI float __floatundisf(du_int a) {
+  if (a == 0)
+    return 0.0F;
+  const unsigned N = sizeof(du_int) * CHAR_BIT;
+  int sd = N - __builtin_clzll(a); // number of significant digits
+  int e = sd - 1;                  // 8 exponent
+  if (sd > FLT_MANT_DIG) {
+    //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx
+    //  finish: 000000000000000000000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQR
+    //                                                12345678901234567890123456
+    //  1 = msb 1 bit
+    //  P = bit FLT_MANT_DIG-1 bits to the right of 1
+    //  Q = bit FLT_MANT_DIG bits to the right of 1
+    //  R = "or" of all bits to the right of Q
+    switch (sd) {
+    case FLT_MANT_DIG + 1:
+      a <<= 1;
+      break;
+    case FLT_MANT_DIG + 2:
+      break;
+    default:
+      a = (a >> (sd - (FLT_MANT_DIG + 2))) |
+          ((a & ((du_int)(-1) >> ((N + FLT_MANT_DIG + 2) - sd))) != 0);
+    };
+    // finish:
+    a |= (a & 4) != 0; // Or P into R
+    ++a;               // round - this step may add a significant bit
+    a >>= 2;           // dump Q and R
+    // a is now rounded to FLT_MANT_DIG or FLT_MANT_DIG+1 bits
+    if (a & ((du_int)1 << FLT_MANT_DIG)) {
+      a >>= 1;
+      ++e;
+    }
+    // a is now rounded to FLT_MANT_DIG bits
+  } else {
+    a <<= (FLT_MANT_DIG - sd);
+    // a is now rounded to FLT_MANT_DIG bits
+  }
+  float_bits fb;
+  fb.u = ((e + 127) << 23) |       // exponent
+         ((su_int)a & 0x007FFFFF); // mantissa
+  return fb.f;
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI float __aeabi_ul2f(du_int a) { return __floatundisf(a); }
+#else
+COMPILER_RT_ALIAS(__floatundisf, __aeabi_ul2f)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/floatundixf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatundixf.c
@@ -1,0 +1,37 @@
+//===-- floatundixf.c - Implement __floatundixf ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __floatundixf for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#if !_ARCH_PPC
+
+#include "int_lib.h"
+
+// Returns: convert a to a long double, rounding toward even.
+
+// Assumption: long double is a IEEE 80 bit floating point type padded to 128
+// bits du_int is a 64 bit integral type
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+COMPILER_RT_ABI long double __floatundixf(du_int a) {
+  if (a == 0)
+    return 0.0;
+  const unsigned N = sizeof(du_int) * CHAR_BIT;
+  int clz = __builtin_clzll(a);
+  int e = (N - 1) - clz; // exponent
+  long_double_bits fb;
+  fb.u.high.s.low = (e + 16383); // exponent
+  fb.u.low.all = a << clz;       // mantissa
+  return fb.f;
+}
+
+#endif // _ARCH_PPC

--- a/system/lib/compiler-rt/lib/builtins/floatunsidf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatunsidf.c
@@ -1,0 +1,47 @@
+//===-- lib/floatunsidf.c - uint -> double-precision conversion ---*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements unsigned integer to double-precision conversion for the
+// compiler-rt library in the IEEE-754 default round-to-nearest, ties-to-even
+// mode.
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI fp_t __floatunsidf(unsigned int a) {
+
+  const int aWidth = sizeof a * CHAR_BIT;
+
+  // Handle zero as a special case to protect clz
+  if (a == 0)
+    return fromRep(0);
+
+  // Exponent of (fp_t)a is the width of abs(a).
+  const int exponent = (aWidth - 1) - __builtin_clz(a);
+  rep_t result;
+
+  // Shift a into the significand field and clear the implicit bit.
+  const int shift = significandBits - exponent;
+  result = (rep_t)a << shift ^ implicitBit;
+
+  // Insert the exponent
+  result += (rep_t)(exponent + exponentBias) << significandBits;
+  return fromRep(result);
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_ui2d(unsigned int a) { return __floatunsidf(a); }
+#else
+COMPILER_RT_ALIAS(__floatunsidf, __aeabi_ui2d)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/floatunsisf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatunsisf.c
@@ -1,0 +1,57 @@
+//===-- lib/floatunsisf.c - uint -> single-precision conversion ---*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements unsigned integer to single-precision conversion for the
+// compiler-rt library in the IEEE-754 default round-to-nearest, ties-to-even
+// mode.
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI fp_t __floatunsisf(unsigned int a) {
+
+  const int aWidth = sizeof a * CHAR_BIT;
+
+  // Handle zero as a special case to protect clz
+  if (a == 0)
+    return fromRep(0);
+
+  // Exponent of (fp_t)a is the width of abs(a).
+  const int exponent = (aWidth - 1) - __builtin_clz(a);
+  rep_t result;
+
+  // Shift a into the significand field, rounding if it is a right-shift
+  if (exponent <= significandBits) {
+    const int shift = significandBits - exponent;
+    result = (rep_t)a << shift ^ implicitBit;
+  } else {
+    const int shift = exponent - significandBits;
+    result = (rep_t)a >> shift ^ implicitBit;
+    rep_t round = (rep_t)a << (typeWidth - shift);
+    if (round > signBit)
+      result++;
+    if (round == signBit)
+      result += result & 1;
+  }
+
+  // Insert the exponent
+  result += (rep_t)(exponent + exponentBias) << significandBits;
+  return fromRep(result);
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_ui2f(unsigned int a) { return __floatunsisf(a); }
+#else
+COMPILER_RT_ALIAS(__floatunsisf, __aeabi_ui2f)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/floatuntitf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatuntitf.c
@@ -1,0 +1,75 @@
+//===-- lib/floatuntitf.c - uint128 -> quad-precision conversion --*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements tu_int to quad-precision conversion for the
+// compiler-rt library in the IEEE-754 default round-to-nearest, ties-to-even
+// mode.
+//
+//===----------------------------------------------------------------------===//
+
+#define QUAD_PRECISION
+#include "fp_lib.h"
+#include "int_lib.h"
+
+// Returns: convert a tu_int to a fp_t, rounding toward even.
+
+// Assumption: fp_t is a IEEE 128 bit floating point type
+//             tu_int is a 128 bit integral type
+
+// seee eeee eeee eeee mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm
+// mmmm | mmmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+#if defined(CRT_HAS_128BIT) && defined(CRT_LDBL_128BIT)
+COMPILER_RT_ABI fp_t __floatuntitf(tu_int a) {
+  if (a == 0)
+    return 0.0;
+  const unsigned N = sizeof(tu_int) * CHAR_BIT;
+  int sd = N - __clzti2(a); // number of significant digits
+  int e = sd - 1;           // exponent
+  if (sd > LDBL_MANT_DIG) {
+    //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx
+    //  finish: 000000000000000000000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQR
+    //                                                12345678901234567890123456
+    //  1 = msb 1 bit
+    //  P = bit LDBL_MANT_DIG-1 bits to the right of 1
+    //  Q = bit LDBL_MANT_DIG bits to the right of 1
+    //  R = "or" of all bits to the right of Q
+    switch (sd) {
+    case LDBL_MANT_DIG + 1:
+      a <<= 1;
+      break;
+    case LDBL_MANT_DIG + 2:
+      break;
+    default:
+      a = (a >> (sd - (LDBL_MANT_DIG + 2))) |
+          ((a & ((tu_int)(-1) >> ((N + LDBL_MANT_DIG + 2) - sd))) != 0);
+    };
+    // finish:
+    a |= (a & 4) != 0; // Or P into R
+    ++a;               // round - this step may add a significant bit
+    a >>= 2;           // dump Q and R
+    // a is now rounded to LDBL_MANT_DIG or LDBL_MANT_DIG+1 bits
+    if (a & ((tu_int)1 << LDBL_MANT_DIG)) {
+      a >>= 1;
+      ++e;
+    }
+    // a is now rounded to LDBL_MANT_DIG bits
+  } else {
+    a <<= (LDBL_MANT_DIG - sd);
+    // a is now rounded to LDBL_MANT_DIG bits
+  }
+
+  long_double_bits fb;
+  fb.u.high.all = (du_int)(e + 16383) << 48             // exponent
+                  | ((a >> 64) & 0x0000ffffffffffffLL); // significand
+  fb.u.low.all = (du_int)(a);
+  return fb.f;
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/floatuntixf.c
+++ b/system/lib/compiler-rt/lib/builtins/floatuntixf.c
@@ -1,0 +1,70 @@
+//===-- floatuntixf.c - Implement __floatuntixf ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __floatuntixf for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: convert a to a long double, rounding toward even.
+
+// Assumption: long double is a IEEE 80 bit floating point type padded to 128
+// bits tu_int is a 128 bit integral type
+
+// gggg gggg gggg gggg gggg gggg gggg gggg | gggg gggg gggg gggg seee eeee eeee
+// eeee | 1mmm mmmm mmmm mmmm mmmm mmmm mmmm mmmm | mmmm mmmm mmmm mmmm mmmm
+// mmmm mmmm mmmm
+
+COMPILER_RT_ABI long double __floatuntixf(tu_int a) {
+  if (a == 0)
+    return 0.0;
+  const unsigned N = sizeof(tu_int) * CHAR_BIT;
+  int sd = N - __clzti2(a); // number of significant digits
+  int e = sd - 1;           // exponent
+  if (sd > LDBL_MANT_DIG) {
+    //  start:  0000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQxxxxxxxxxxxxxxxxxx
+    //  finish: 000000000000000000000000000000000000001xxxxxxxxxxxxxxxxxxxxxxPQR
+    //                                                12345678901234567890123456
+    //  1 = msb 1 bit
+    //  P = bit LDBL_MANT_DIG-1 bits to the right of 1
+    //  Q = bit LDBL_MANT_DIG bits to the right of 1
+    //  R = "or" of all bits to the right of Q
+    switch (sd) {
+    case LDBL_MANT_DIG + 1:
+      a <<= 1;
+      break;
+    case LDBL_MANT_DIG + 2:
+      break;
+    default:
+      a = (a >> (sd - (LDBL_MANT_DIG + 2))) |
+          ((a & ((tu_int)(-1) >> ((N + LDBL_MANT_DIG + 2) - sd))) != 0);
+    };
+    // finish:
+    a |= (a & 4) != 0; // Or P into R
+    ++a;               // round - this step may add a significant bit
+    a >>= 2;           // dump Q and R
+    // a is now rounded to LDBL_MANT_DIG or LDBL_MANT_DIG+1 bits
+    if (a & ((tu_int)1 << LDBL_MANT_DIG)) {
+      a >>= 1;
+      ++e;
+    }
+    // a is now rounded to LDBL_MANT_DIG bits
+  } else {
+    a <<= (LDBL_MANT_DIG - sd);
+    // a is now rounded to LDBL_MANT_DIG bits
+  }
+  long_double_bits fb;
+  fb.u.high.s.low = (e + 16383); // exponent
+  fb.u.low.all = (du_int)a;      // mantissa
+  return fb.f;
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/gcc_personality_v0.c
+++ b/system/lib/compiler-rt/lib/builtins/gcc_personality_v0.c
@@ -1,0 +1,234 @@
+//===-- gcc_personality_v0.c - Implement __gcc_personality_v0 -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#include <unwind.h>
+#if defined(__arm__) && !defined(__ARM_DWARF_EH__) &&                          \
+    !defined(__USING_SJLJ_EXCEPTIONS__)
+// When building with older compilers (e.g. clang <3.9), it is possible that we
+// have a version of unwind.h which does not provide the EHABI declarations
+// which are quired for the C personality to conform to the specification.  In
+// order to provide forward compatibility for such compilers, we re-declare the
+// necessary interfaces in the helper to permit a standalone compilation of the
+// builtins (which contains the C unwinding personality for historical reasons).
+#include "unwind-ehabi-helpers.h"
+#endif
+
+// Pointer encodings documented at:
+//   http://refspecs.freestandards.org/LSB_1.3.0/gLSB/gLSB/ehframehdr.html
+
+#define DW_EH_PE_omit 0xff // no data follows
+
+#define DW_EH_PE_absptr 0x00
+#define DW_EH_PE_uleb128 0x01
+#define DW_EH_PE_udata2 0x02
+#define DW_EH_PE_udata4 0x03
+#define DW_EH_PE_udata8 0x04
+#define DW_EH_PE_sleb128 0x09
+#define DW_EH_PE_sdata2 0x0A
+#define DW_EH_PE_sdata4 0x0B
+#define DW_EH_PE_sdata8 0x0C
+
+#define DW_EH_PE_pcrel 0x10
+#define DW_EH_PE_textrel 0x20
+#define DW_EH_PE_datarel 0x30
+#define DW_EH_PE_funcrel 0x40
+#define DW_EH_PE_aligned 0x50
+#define DW_EH_PE_indirect 0x80 // gcc extension
+
+// read a uleb128 encoded value and advance pointer
+static uintptr_t readULEB128(const uint8_t **data) {
+  uintptr_t result = 0;
+  uintptr_t shift = 0;
+  unsigned char byte;
+  const uint8_t *p = *data;
+  do {
+    byte = *p++;
+    result |= (byte & 0x7f) << shift;
+    shift += 7;
+  } while (byte & 0x80);
+  *data = p;
+  return result;
+}
+
+// read a pointer encoded value and advance pointer
+static uintptr_t readEncodedPointer(const uint8_t **data, uint8_t encoding) {
+  const uint8_t *p = *data;
+  uintptr_t result = 0;
+
+  if (encoding == DW_EH_PE_omit)
+    return 0;
+
+  // first get value
+  switch (encoding & 0x0F) {
+  case DW_EH_PE_absptr:
+    result = *((const uintptr_t *)p);
+    p += sizeof(uintptr_t);
+    break;
+  case DW_EH_PE_uleb128:
+    result = readULEB128(&p);
+    break;
+  case DW_EH_PE_udata2:
+    result = *((const uint16_t *)p);
+    p += sizeof(uint16_t);
+    break;
+  case DW_EH_PE_udata4:
+    result = *((const uint32_t *)p);
+    p += sizeof(uint32_t);
+    break;
+  case DW_EH_PE_udata8:
+    result = *((const uint64_t *)p);
+    p += sizeof(uint64_t);
+    break;
+  case DW_EH_PE_sdata2:
+    result = *((const int16_t *)p);
+    p += sizeof(int16_t);
+    break;
+  case DW_EH_PE_sdata4:
+    result = *((const int32_t *)p);
+    p += sizeof(int32_t);
+    break;
+  case DW_EH_PE_sdata8:
+    result = *((const int64_t *)p);
+    p += sizeof(int64_t);
+    break;
+  case DW_EH_PE_sleb128:
+  default:
+    // not supported
+    compilerrt_abort();
+    break;
+  }
+
+  // then add relative offset
+  switch (encoding & 0x70) {
+  case DW_EH_PE_absptr:
+    // do nothing
+    break;
+  case DW_EH_PE_pcrel:
+    result += (uintptr_t)(*data);
+    break;
+  case DW_EH_PE_textrel:
+  case DW_EH_PE_datarel:
+  case DW_EH_PE_funcrel:
+  case DW_EH_PE_aligned:
+  default:
+    // not supported
+    compilerrt_abort();
+    break;
+  }
+
+  // then apply indirection
+  if (encoding & DW_EH_PE_indirect) {
+    result = *((const uintptr_t *)result);
+  }
+
+  *data = p;
+  return result;
+}
+
+#if defined(__arm__) && !defined(__USING_SJLJ_EXCEPTIONS__) &&                 \
+    !defined(__ARM_DWARF_EH__)
+#define USING_ARM_EHABI 1
+_Unwind_Reason_Code __gnu_unwind_frame(struct _Unwind_Exception *,
+                                       struct _Unwind_Context *);
+#endif
+
+static inline _Unwind_Reason_Code
+continueUnwind(struct _Unwind_Exception *exceptionObject,
+               struct _Unwind_Context *context) {
+#if USING_ARM_EHABI
+  // On ARM EHABI the personality routine is responsible for actually
+  // unwinding a single stack frame before returning (ARM EHABI Sec. 6.1).
+  if (__gnu_unwind_frame(exceptionObject, context) != _URC_OK)
+    return _URC_FAILURE;
+#endif
+  return _URC_CONTINUE_UNWIND;
+}
+
+// The C compiler makes references to __gcc_personality_v0 in
+// the dwarf unwind information for translation units that use
+// __attribute__((cleanup(xx))) on local variables.
+// This personality routine is called by the system unwinder
+// on each frame as the stack is unwound during a C++ exception
+// throw through a C function compiled with -fexceptions.
+#if __USING_SJLJ_EXCEPTIONS__
+// the setjump-longjump based exceptions personality routine has a
+// different name
+COMPILER_RT_ABI _Unwind_Reason_Code __gcc_personality_sj0(
+    int version, _Unwind_Action actions, uint64_t exceptionClass,
+    struct _Unwind_Exception *exceptionObject, struct _Unwind_Context *context)
+#elif USING_ARM_EHABI
+// The ARM EHABI personality routine has a different signature.
+COMPILER_RT_ABI _Unwind_Reason_Code __gcc_personality_v0(
+    _Unwind_State state, struct _Unwind_Exception *exceptionObject,
+    struct _Unwind_Context *context)
+#else
+COMPILER_RT_ABI _Unwind_Reason_Code __gcc_personality_v0(
+    int version, _Unwind_Action actions, uint64_t exceptionClass,
+    struct _Unwind_Exception *exceptionObject, struct _Unwind_Context *context)
+#endif
+{
+  // Since C does not have catch clauses, there is nothing to do during
+  // phase 1 (the search phase).
+#if USING_ARM_EHABI
+  // After resuming from a cleanup we should also continue on to the next
+  // frame straight away.
+  if ((state & _US_ACTION_MASK) != _US_UNWIND_FRAME_STARTING)
+#else
+  if (actions & _UA_SEARCH_PHASE)
+#endif
+    return continueUnwind(exceptionObject, context);
+
+  // There is nothing to do if there is no LSDA for this frame.
+  const uint8_t *lsda = (uint8_t *)_Unwind_GetLanguageSpecificData(context);
+  if (lsda == (uint8_t *)0)
+    return continueUnwind(exceptionObject, context);
+
+  uintptr_t pc = (uintptr_t)_Unwind_GetIP(context) - 1;
+  uintptr_t funcStart = (uintptr_t)_Unwind_GetRegionStart(context);
+  uintptr_t pcOffset = pc - funcStart;
+
+  // Parse LSDA header.
+  uint8_t lpStartEncoding = *lsda++;
+  if (lpStartEncoding != DW_EH_PE_omit) {
+    readEncodedPointer(&lsda, lpStartEncoding);
+  }
+  uint8_t ttypeEncoding = *lsda++;
+  if (ttypeEncoding != DW_EH_PE_omit) {
+    readULEB128(&lsda);
+  }
+  // Walk call-site table looking for range that includes current PC.
+  uint8_t callSiteEncoding = *lsda++;
+  uint32_t callSiteTableLength = readULEB128(&lsda);
+  const uint8_t *callSiteTableStart = lsda;
+  const uint8_t *callSiteTableEnd = callSiteTableStart + callSiteTableLength;
+  const uint8_t *p = callSiteTableStart;
+  while (p < callSiteTableEnd) {
+    uintptr_t start = readEncodedPointer(&p, callSiteEncoding);
+    uintptr_t length = readEncodedPointer(&p, callSiteEncoding);
+    uintptr_t landingPad = readEncodedPointer(&p, callSiteEncoding);
+    readULEB128(&p); // action value not used for C code
+    if (landingPad == 0)
+      continue; // no landing pad for this entry
+    if ((start <= pcOffset) && (pcOffset < (start + length))) {
+      // Found landing pad for the PC.
+      // Set Instruction Pointer to so we re-enter function
+      // at landing pad. The landing pad is created by the compiler
+      // to take two parameters in registers.
+      _Unwind_SetGR(context, __builtin_eh_return_data_regno(0),
+                    (uintptr_t)exceptionObject);
+      _Unwind_SetGR(context, __builtin_eh_return_data_regno(1), 0);
+      _Unwind_SetIP(context, (funcStart + landingPad));
+      return _URC_INSTALL_CONTEXT;
+    }
+  }
+
+  // No landing pad found, continue unwinding.
+  return continueUnwind(exceptionObject, context);
+}

--- a/system/lib/compiler-rt/lib/builtins/int_util.c
+++ b/system/lib/compiler-rt/lib/builtins/int_util.c
@@ -1,0 +1,67 @@
+//===-- int_util.c - Implement internal utilities -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// NOTE: The definitions in this file are declared weak because we clients to be
+// able to arbitrarily package individual functions into separate .a files. If
+// we did not declare these weak, some link situations might end up seeing
+// duplicate strong definitions of the same symbol.
+//
+// We can't use this solution for kernel use (which may not support weak), but
+// currently expect that when built for kernel use all the functionality is
+// packaged into a single library.
+
+#ifdef KERNEL_USE
+
+NORETURN extern void panic(const char *, ...);
+#ifndef _WIN32
+__attribute__((visibility("hidden")))
+#endif
+void __compilerrt_abort_impl(const char *file, int line, const char *function) {
+  panic("%s:%d: abort in %s", file, line, function);
+}
+
+#elif __APPLE__
+
+// from libSystem.dylib
+NORETURN extern void __assert_rtn(const char *func, const char *file, int line,
+                                  const char *message);
+
+#ifndef _WIN32
+__attribute__((weak))
+__attribute__((visibility("hidden")))
+#endif
+void __compilerrt_abort_impl(const char *file, int line, const char *function) {
+  __assert_rtn(function, file, line, "libcompiler_rt abort");
+}
+
+#elif __Fuchsia__
+
+#ifndef _WIN32
+__attribute__((weak))
+__attribute__((visibility("hidden")))
+#endif
+void __compilerrt_abort_impl(const char *file, int line, const char *function) {
+  __builtin_trap();
+}
+
+#else
+
+// Get the system definition of abort()
+#include <stdlib.h>
+
+#ifndef _WIN32
+__attribute__((weak))
+__attribute__((visibility("hidden")))
+#endif
+void __compilerrt_abort_impl(const char *file, int line, const char *function) {
+  abort();
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/mingw_fixfloat.c
+++ b/system/lib/compiler-rt/lib/builtins/mingw_fixfloat.c
@@ -1,0 +1,34 @@
+//===-- mingw_fixfloat.c - Wrap int/float conversions for arm/windows -----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+COMPILER_RT_ABI di_int __fixdfdi(double a);
+COMPILER_RT_ABI di_int __fixsfdi(float a);
+COMPILER_RT_ABI du_int __fixunsdfdi(double a);
+COMPILER_RT_ABI du_int __fixunssfdi(float a);
+COMPILER_RT_ABI double __floatdidf(di_int a);
+COMPILER_RT_ABI float __floatdisf(di_int a);
+COMPILER_RT_ABI double __floatundidf(du_int a);
+COMPILER_RT_ABI float __floatundisf(du_int a);
+
+COMPILER_RT_ABI di_int __dtoi64(double a) { return __fixdfdi(a); }
+
+COMPILER_RT_ABI di_int __stoi64(float a) { return __fixsfdi(a); }
+
+COMPILER_RT_ABI du_int __dtou64(double a) { return __fixunsdfdi(a); }
+
+COMPILER_RT_ABI du_int __stou64(float a) { return __fixunssfdi(a); }
+
+COMPILER_RT_ABI double __i64tod(di_int a) { return __floatdidf(a); }
+
+COMPILER_RT_ABI float __i64tos(di_int a) { return __floatdisf(a); }
+
+COMPILER_RT_ABI double __u64tod(du_int a) { return __floatundidf(a); }
+
+COMPILER_RT_ABI float __u64tos(du_int a) { return __floatundisf(a); }

--- a/system/lib/compiler-rt/lib/builtins/modsi3.c
+++ b/system/lib/compiler-rt/lib/builtins/modsi3.c
@@ -1,0 +1,19 @@
+//===-- modsi3.c - Implement __modsi3 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __modsi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a % b
+
+COMPILER_RT_ABI si_int __modsi3(si_int a, si_int b) {
+  return a - __divsi3(a, b) * b;
+}

--- a/system/lib/compiler-rt/lib/builtins/muldf3.c
+++ b/system/lib/compiler-rt/lib/builtins/muldf3.c
@@ -1,0 +1,25 @@
+//===-- lib/muldf3.c - Double-precision multiplication ------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements double-precision soft-float multiplication
+// with the IEEE-754 default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_mul_impl.inc"
+
+COMPILER_RT_ABI fp_t __muldf3(fp_t a, fp_t b) { return __mulXf3__(a, b); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_dmul(fp_t a, fp_t b) { return __muldf3(a, b); }
+#else
+COMPILER_RT_ALIAS(__muldf3, __aeabi_dmul)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/mulodi4.c
+++ b/system/lib/compiler-rt/lib/builtins/mulodi4.c
@@ -1,0 +1,49 @@
+//===-- mulodi4.c - Implement __mulodi4 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __mulodi4 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a * b
+
+// Effects: sets *overflow to 1  if a * b overflows
+
+COMPILER_RT_ABI di_int __mulodi4(di_int a, di_int b, int *overflow) {
+  const int N = (int)(sizeof(di_int) * CHAR_BIT);
+  const di_int MIN = (di_int)1 << (N - 1);
+  const di_int MAX = ~MIN;
+  *overflow = 0;
+  di_int result = a * b;
+  if (a == MIN) {
+    if (b != 0 && b != 1)
+      *overflow = 1;
+    return result;
+  }
+  if (b == MIN) {
+    if (a != 0 && a != 1)
+      *overflow = 1;
+    return result;
+  }
+  di_int sa = a >> (N - 1);
+  di_int abs_a = (a ^ sa) - sa;
+  di_int sb = b >> (N - 1);
+  di_int abs_b = (b ^ sb) - sb;
+  if (abs_a < 2 || abs_b < 2)
+    return result;
+  if (sa == sb) {
+    if (abs_a > MAX / abs_b)
+      *overflow = 1;
+  } else {
+    if (abs_a > MIN / -abs_b)
+      *overflow = 1;
+  }
+  return result;
+}

--- a/system/lib/compiler-rt/lib/builtins/mulosi4.c
+++ b/system/lib/compiler-rt/lib/builtins/mulosi4.c
@@ -1,0 +1,49 @@
+//===-- mulosi4.c - Implement __mulosi4 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __mulosi4 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a * b
+
+// Effects: sets *overflow to 1  if a * b overflows
+
+COMPILER_RT_ABI si_int __mulosi4(si_int a, si_int b, int *overflow) {
+  const int N = (int)(sizeof(si_int) * CHAR_BIT);
+  const si_int MIN = (si_int)1 << (N - 1);
+  const si_int MAX = ~MIN;
+  *overflow = 0;
+  si_int result = a * b;
+  if (a == MIN) {
+    if (b != 0 && b != 1)
+      *overflow = 1;
+    return result;
+  }
+  if (b == MIN) {
+    if (a != 0 && a != 1)
+      *overflow = 1;
+    return result;
+  }
+  si_int sa = a >> (N - 1);
+  si_int abs_a = (a ^ sa) - sa;
+  si_int sb = b >> (N - 1);
+  si_int abs_b = (b ^ sb) - sb;
+  if (abs_a < 2 || abs_b < 2)
+    return result;
+  if (sa == sb) {
+    if (abs_a > MAX / abs_b)
+      *overflow = 1;
+  } else {
+    if (abs_a > MIN / -abs_b)
+      *overflow = 1;
+  }
+  return result;
+}

--- a/system/lib/compiler-rt/lib/builtins/muloti4.c
+++ b/system/lib/compiler-rt/lib/builtins/muloti4.c
@@ -1,0 +1,53 @@
+//===-- muloti4.c - Implement __muloti4 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __muloti4 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: a * b
+
+// Effects: sets *overflow to 1  if a * b overflows
+
+COMPILER_RT_ABI ti_int __muloti4(ti_int a, ti_int b, int *overflow) {
+  const int N = (int)(sizeof(ti_int) * CHAR_BIT);
+  const ti_int MIN = (ti_int)1 << (N - 1);
+  const ti_int MAX = ~MIN;
+  *overflow = 0;
+  ti_int result = a * b;
+  if (a == MIN) {
+    if (b != 0 && b != 1)
+      *overflow = 1;
+    return result;
+  }
+  if (b == MIN) {
+    if (a != 0 && a != 1)
+      *overflow = 1;
+    return result;
+  }
+  ti_int sa = a >> (N - 1);
+  ti_int abs_a = (a ^ sa) - sa;
+  ti_int sb = b >> (N - 1);
+  ti_int abs_b = (b ^ sb) - sb;
+  if (abs_a < 2 || abs_b < 2)
+    return result;
+  if (sa == sb) {
+    if (abs_a > MAX / abs_b)
+      *overflow = 1;
+  } else {
+    if (abs_a > MIN / -abs_b)
+      *overflow = 1;
+  }
+  return result;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/mulsf3.c
+++ b/system/lib/compiler-rt/lib/builtins/mulsf3.c
@@ -1,0 +1,25 @@
+//===-- lib/mulsf3.c - Single-precision multiplication ------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements single-precision soft-float multiplication
+// with the IEEE-754 default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_mul_impl.inc"
+
+COMPILER_RT_ABI fp_t __mulsf3(fp_t a, fp_t b) { return __mulXf3__(a, b); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_fmul(fp_t a, fp_t b) { return __mulsf3(a, b); }
+#else
+COMPILER_RT_ALIAS(__mulsf3, __aeabi_fmul)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/mulvdi3.c
+++ b/system/lib/compiler-rt/lib/builtins/mulvdi3.c
@@ -1,0 +1,47 @@
+//===-- mulvdi3.c - Implement __mulvdi3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __mulvdi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a * b
+
+// Effects: aborts if a * b overflows
+
+COMPILER_RT_ABI di_int __mulvdi3(di_int a, di_int b) {
+  const int N = (int)(sizeof(di_int) * CHAR_BIT);
+  const di_int MIN = (di_int)1 << (N - 1);
+  const di_int MAX = ~MIN;
+  if (a == MIN) {
+    if (b == 0 || b == 1)
+      return a * b;
+    compilerrt_abort();
+  }
+  if (b == MIN) {
+    if (a == 0 || a == 1)
+      return a * b;
+    compilerrt_abort();
+  }
+  di_int sa = a >> (N - 1);
+  di_int abs_a = (a ^ sa) - sa;
+  di_int sb = b >> (N - 1);
+  di_int abs_b = (b ^ sb) - sb;
+  if (abs_a < 2 || abs_b < 2)
+    return a * b;
+  if (sa == sb) {
+    if (abs_a > MAX / abs_b)
+      compilerrt_abort();
+  } else {
+    if (abs_a > MIN / -abs_b)
+      compilerrt_abort();
+  }
+  return a * b;
+}

--- a/system/lib/compiler-rt/lib/builtins/mulvsi3.c
+++ b/system/lib/compiler-rt/lib/builtins/mulvsi3.c
@@ -1,0 +1,47 @@
+//===-- mulvsi3.c - Implement __mulvsi3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __mulvsi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a * b
+
+// Effects: aborts if a * b overflows
+
+COMPILER_RT_ABI si_int __mulvsi3(si_int a, si_int b) {
+  const int N = (int)(sizeof(si_int) * CHAR_BIT);
+  const si_int MIN = (si_int)1 << (N - 1);
+  const si_int MAX = ~MIN;
+  if (a == MIN) {
+    if (b == 0 || b == 1)
+      return a * b;
+    compilerrt_abort();
+  }
+  if (b == MIN) {
+    if (a == 0 || a == 1)
+      return a * b;
+    compilerrt_abort();
+  }
+  si_int sa = a >> (N - 1);
+  si_int abs_a = (a ^ sa) - sa;
+  si_int sb = b >> (N - 1);
+  si_int abs_b = (b ^ sb) - sb;
+  if (abs_a < 2 || abs_b < 2)
+    return a * b;
+  if (sa == sb) {
+    if (abs_a > MAX / abs_b)
+      compilerrt_abort();
+  } else {
+    if (abs_a > MIN / -abs_b)
+      compilerrt_abort();
+  }
+  return a * b;
+}

--- a/system/lib/compiler-rt/lib/builtins/mulvti3.c
+++ b/system/lib/compiler-rt/lib/builtins/mulvti3.c
@@ -1,0 +1,51 @@
+//===-- mulvti3.c - Implement __mulvti3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __mulvti3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: a * b
+
+// Effects: aborts if a * b overflows
+
+COMPILER_RT_ABI ti_int __mulvti3(ti_int a, ti_int b) {
+  const int N = (int)(sizeof(ti_int) * CHAR_BIT);
+  const ti_int MIN = (ti_int)1 << (N - 1);
+  const ti_int MAX = ~MIN;
+  if (a == MIN) {
+    if (b == 0 || b == 1)
+      return a * b;
+    compilerrt_abort();
+  }
+  if (b == MIN) {
+    if (a == 0 || a == 1)
+      return a * b;
+    compilerrt_abort();
+  }
+  ti_int sa = a >> (N - 1);
+  ti_int abs_a = (a ^ sa) - sa;
+  ti_int sb = b >> (N - 1);
+  ti_int abs_b = (b ^ sb) - sb;
+  if (abs_a < 2 || abs_b < 2)
+    return a * b;
+  if (sa == sb) {
+    if (abs_a > MAX / abs_b)
+      compilerrt_abort();
+  } else {
+    if (abs_a > MIN / -abs_b)
+      compilerrt_abort();
+  }
+  return a * b;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/mulxc3.c
+++ b/system/lib/compiler-rt/lib/builtins/mulxc3.c
@@ -1,0 +1,69 @@
+//===-- mulxc3.c - Implement __mulxc3 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __mulxc3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#if !_ARCH_PPC
+
+#include "int_lib.h"
+#include "int_math.h"
+
+// Returns: the product of a + ib and c + id
+
+COMPILER_RT_ABI Lcomplex __mulxc3(long double __a, long double __b,
+                                  long double __c, long double __d) {
+  long double __ac = __a * __c;
+  long double __bd = __b * __d;
+  long double __ad = __a * __d;
+  long double __bc = __b * __c;
+  Lcomplex z;
+  COMPLEX_REAL(z) = __ac - __bd;
+  COMPLEX_IMAGINARY(z) = __ad + __bc;
+  if (crt_isnan(COMPLEX_REAL(z)) && crt_isnan(COMPLEX_IMAGINARY(z))) {
+    int __recalc = 0;
+    if (crt_isinf(__a) || crt_isinf(__b)) {
+      __a = crt_copysignl(crt_isinf(__a) ? 1 : 0, __a);
+      __b = crt_copysignl(crt_isinf(__b) ? 1 : 0, __b);
+      if (crt_isnan(__c))
+        __c = crt_copysignl(0, __c);
+      if (crt_isnan(__d))
+        __d = crt_copysignl(0, __d);
+      __recalc = 1;
+    }
+    if (crt_isinf(__c) || crt_isinf(__d)) {
+      __c = crt_copysignl(crt_isinf(__c) ? 1 : 0, __c);
+      __d = crt_copysignl(crt_isinf(__d) ? 1 : 0, __d);
+      if (crt_isnan(__a))
+        __a = crt_copysignl(0, __a);
+      if (crt_isnan(__b))
+        __b = crt_copysignl(0, __b);
+      __recalc = 1;
+    }
+    if (!__recalc && (crt_isinf(__ac) || crt_isinf(__bd) || crt_isinf(__ad) ||
+                      crt_isinf(__bc))) {
+      if (crt_isnan(__a))
+        __a = crt_copysignl(0, __a);
+      if (crt_isnan(__b))
+        __b = crt_copysignl(0, __b);
+      if (crt_isnan(__c))
+        __c = crt_copysignl(0, __c);
+      if (crt_isnan(__d))
+        __d = crt_copysignl(0, __d);
+      __recalc = 1;
+    }
+    if (__recalc) {
+      COMPLEX_REAL(z) = CRT_INFINITY * (__a * __c - __b * __d);
+      COMPLEX_IMAGINARY(z) = CRT_INFINITY * (__a * __d + __b * __c);
+    }
+  }
+  return z;
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/negdf2.c
+++ b/system/lib/compiler-rt/lib/builtins/negdf2.c
@@ -1,0 +1,24 @@
+//===-- lib/negdf2.c - double-precision negation ------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements double-precision soft-float negation.
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+
+COMPILER_RT_ABI fp_t __negdf2(fp_t a) { return fromRep(toRep(a) ^ signBit); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_dneg(fp_t a) { return __negdf2(a); }
+#else
+COMPILER_RT_ALIAS(__negdf2, __aeabi_dneg)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/negdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/negdi2.c
@@ -1,0 +1,21 @@
+//===-- negdi2.c - Implement __negdi2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __negdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: -a
+
+COMPILER_RT_ABI di_int __negdi2(di_int a) {
+  // Note: this routine is here for API compatibility; any sane compiler
+  // should expand it inline.
+  return -a;
+}

--- a/system/lib/compiler-rt/lib/builtins/negsf2.c
+++ b/system/lib/compiler-rt/lib/builtins/negsf2.c
@@ -1,0 +1,24 @@
+//===-- lib/negsf2.c - single-precision negation ------------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements single-precision soft-float negation.
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+
+COMPILER_RT_ABI fp_t __negsf2(fp_t a) { return fromRep(toRep(a) ^ signBit); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_fneg(fp_t a) { return __negsf2(a); }
+#else
+COMPILER_RT_ALIAS(__negsf2, __aeabi_fneg)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/negti2.c
+++ b/system/lib/compiler-rt/lib/builtins/negti2.c
@@ -1,0 +1,25 @@
+//===-- negti2.c - Implement __negti2 -------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __negti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: -a
+
+COMPILER_RT_ABI ti_int __negti2(ti_int a) {
+  // Note: this routine is here for API compatibility; any sane compiler
+  // should expand it inline.
+  return -a;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/negvdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/negvdi2.c
@@ -1,0 +1,24 @@
+//===-- negvdi2.c - Implement __negvdi2 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __negvdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: -a
+
+// Effects: aborts if -a overflows
+
+COMPILER_RT_ABI di_int __negvdi2(di_int a) {
+  const di_int MIN = (di_int)1 << ((int)(sizeof(di_int) * CHAR_BIT) - 1);
+  if (a == MIN)
+    compilerrt_abort();
+  return -a;
+}

--- a/system/lib/compiler-rt/lib/builtins/negvsi2.c
+++ b/system/lib/compiler-rt/lib/builtins/negvsi2.c
@@ -1,0 +1,24 @@
+//===-- negvsi2.c - Implement __negvsi2 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __negvsi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: -a
+
+// Effects: aborts if -a overflows
+
+COMPILER_RT_ABI si_int __negvsi2(si_int a) {
+  const si_int MIN = (si_int)1 << ((int)(sizeof(si_int) * CHAR_BIT) - 1);
+  if (a == MIN)
+    compilerrt_abort();
+  return -a;
+}

--- a/system/lib/compiler-rt/lib/builtins/negvti2.c
+++ b/system/lib/compiler-rt/lib/builtins/negvti2.c
@@ -1,0 +1,28 @@
+//===-- negvti2.c - Implement __negvti2 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __negvti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: -a
+
+// Effects: aborts if -a overflows
+
+COMPILER_RT_ABI ti_int __negvti2(ti_int a) {
+  const ti_int MIN = (ti_int)1 << ((int)(sizeof(ti_int) * CHAR_BIT) - 1);
+  if (a == MIN)
+    compilerrt_abort();
+  return -a;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/os_version_check.c
+++ b/system/lib/compiler-rt/lib/builtins/os_version_check.c
@@ -1,0 +1,224 @@
+//===-- os_version_check.c - OS version checking  -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the function __isOSVersionAtLeast, used by
+// Objective-C's @available
+//
+//===----------------------------------------------------------------------===//
+
+#ifdef __APPLE__
+
+#include <TargetConditionals.h>
+#include <dispatch/dispatch.h>
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+// These three variables hold the host's OS version.
+static int32_t GlobalMajor, GlobalMinor, GlobalSubminor;
+static dispatch_once_t DispatchOnceCounter;
+
+// We can't include <CoreFoundation/CoreFoundation.h> directly from here, so
+// just forward declare everything that we need from it.
+
+typedef const void *CFDataRef, *CFAllocatorRef, *CFPropertyListRef,
+    *CFStringRef, *CFDictionaryRef, *CFTypeRef, *CFErrorRef;
+
+#if __LLP64__
+typedef unsigned long long CFTypeID;
+typedef unsigned long long CFOptionFlags;
+typedef signed long long CFIndex;
+#else
+typedef unsigned long CFTypeID;
+typedef unsigned long CFOptionFlags;
+typedef signed long CFIndex;
+#endif
+
+typedef unsigned char UInt8;
+typedef _Bool Boolean;
+typedef CFIndex CFPropertyListFormat;
+typedef uint32_t CFStringEncoding;
+
+// kCFStringEncodingASCII analog.
+#define CF_STRING_ENCODING_ASCII 0x0600
+// kCFStringEncodingUTF8 analog.
+#define CF_STRING_ENCODING_UTF8 0x08000100
+#define CF_PROPERTY_LIST_IMMUTABLE 0
+
+typedef CFDataRef (*CFDataCreateWithBytesNoCopyFuncTy)(CFAllocatorRef,
+                                                       const UInt8 *, CFIndex,
+                                                       CFAllocatorRef);
+typedef CFPropertyListRef (*CFPropertyListCreateWithDataFuncTy)(
+    CFAllocatorRef, CFDataRef, CFOptionFlags, CFPropertyListFormat *,
+    CFErrorRef *);
+typedef CFPropertyListRef (*CFPropertyListCreateFromXMLDataFuncTy)(
+    CFAllocatorRef, CFDataRef, CFOptionFlags, CFStringRef *);
+typedef CFStringRef (*CFStringCreateWithCStringNoCopyFuncTy)(CFAllocatorRef,
+                                                             const char *,
+                                                             CFStringEncoding,
+                                                             CFAllocatorRef);
+typedef const void *(*CFDictionaryGetValueFuncTy)(CFDictionaryRef,
+                                                  const void *);
+typedef CFTypeID (*CFGetTypeIDFuncTy)(CFTypeRef);
+typedef CFTypeID (*CFStringGetTypeIDFuncTy)(void);
+typedef Boolean (*CFStringGetCStringFuncTy)(CFStringRef, char *, CFIndex,
+                                            CFStringEncoding);
+typedef void (*CFReleaseFuncTy)(CFTypeRef);
+
+// Find and parse the SystemVersion.plist file.
+static void parseSystemVersionPList(void *Unused) {
+  (void)Unused;
+  // Load CoreFoundation dynamically
+  const void *NullAllocator = dlsym(RTLD_DEFAULT, "kCFAllocatorNull");
+  if (!NullAllocator)
+    return;
+  const CFAllocatorRef AllocatorNull = *(const CFAllocatorRef *)NullAllocator;
+  CFDataCreateWithBytesNoCopyFuncTy CFDataCreateWithBytesNoCopyFunc =
+      (CFDataCreateWithBytesNoCopyFuncTy)dlsym(RTLD_DEFAULT,
+                                               "CFDataCreateWithBytesNoCopy");
+  if (!CFDataCreateWithBytesNoCopyFunc)
+    return;
+  CFPropertyListCreateWithDataFuncTy CFPropertyListCreateWithDataFunc =
+      (CFPropertyListCreateWithDataFuncTy)dlsym(RTLD_DEFAULT,
+                                                "CFPropertyListCreateWithData");
+// CFPropertyListCreateWithData was introduced only in macOS 10.6+, so it
+// will be NULL on earlier OS versions.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+  CFPropertyListCreateFromXMLDataFuncTy CFPropertyListCreateFromXMLDataFunc =
+      (CFPropertyListCreateFromXMLDataFuncTy)dlsym(
+          RTLD_DEFAULT, "CFPropertyListCreateFromXMLData");
+#pragma clang diagnostic pop
+  // CFPropertyListCreateFromXMLDataFunc is deprecated in macOS 10.10, so it
+  // might be NULL in future OS versions.
+  if (!CFPropertyListCreateWithDataFunc && !CFPropertyListCreateFromXMLDataFunc)
+    return;
+  CFStringCreateWithCStringNoCopyFuncTy CFStringCreateWithCStringNoCopyFunc =
+      (CFStringCreateWithCStringNoCopyFuncTy)dlsym(
+          RTLD_DEFAULT, "CFStringCreateWithCStringNoCopy");
+  if (!CFStringCreateWithCStringNoCopyFunc)
+    return;
+  CFDictionaryGetValueFuncTy CFDictionaryGetValueFunc =
+      (CFDictionaryGetValueFuncTy)dlsym(RTLD_DEFAULT, "CFDictionaryGetValue");
+  if (!CFDictionaryGetValueFunc)
+    return;
+  CFGetTypeIDFuncTy CFGetTypeIDFunc =
+      (CFGetTypeIDFuncTy)dlsym(RTLD_DEFAULT, "CFGetTypeID");
+  if (!CFGetTypeIDFunc)
+    return;
+  CFStringGetTypeIDFuncTy CFStringGetTypeIDFunc =
+      (CFStringGetTypeIDFuncTy)dlsym(RTLD_DEFAULT, "CFStringGetTypeID");
+  if (!CFStringGetTypeIDFunc)
+    return;
+  CFStringGetCStringFuncTy CFStringGetCStringFunc =
+      (CFStringGetCStringFuncTy)dlsym(RTLD_DEFAULT, "CFStringGetCString");
+  if (!CFStringGetCStringFunc)
+    return;
+  CFReleaseFuncTy CFReleaseFunc =
+      (CFReleaseFuncTy)dlsym(RTLD_DEFAULT, "CFRelease");
+  if (!CFReleaseFunc)
+    return;
+
+  char *PListPath = "/System/Library/CoreServices/SystemVersion.plist";
+
+#if TARGET_OS_SIMULATOR
+  char *PListPathPrefix = getenv("IPHONE_SIMULATOR_ROOT");
+  if (!PListPathPrefix)
+    return;
+  char FullPath[strlen(PListPathPrefix) + strlen(PListPath) + 1];
+  strcpy(FullPath, PListPathPrefix);
+  strcat(FullPath, PListPath);
+  PListPath = FullPath;
+#endif
+  FILE *PropertyList = fopen(PListPath, "r");
+  if (!PropertyList)
+    return;
+
+  // Dynamically allocated stuff.
+  CFDictionaryRef PListRef = NULL;
+  CFDataRef FileContentsRef = NULL;
+  UInt8 *PListBuf = NULL;
+
+  fseek(PropertyList, 0, SEEK_END);
+  long PListFileSize = ftell(PropertyList);
+  if (PListFileSize < 0)
+    goto Fail;
+  rewind(PropertyList);
+
+  PListBuf = malloc((size_t)PListFileSize);
+  if (!PListBuf)
+    goto Fail;
+
+  size_t NumRead = fread(PListBuf, 1, (size_t)PListFileSize, PropertyList);
+  if (NumRead != (size_t)PListFileSize)
+    goto Fail;
+
+  // Get the file buffer into CF's format. We pass in a null allocator here *
+  // because we free PListBuf ourselves
+  FileContentsRef = (*CFDataCreateWithBytesNoCopyFunc)(
+      NULL, PListBuf, (CFIndex)NumRead, AllocatorNull);
+  if (!FileContentsRef)
+    goto Fail;
+
+  if (CFPropertyListCreateWithDataFunc)
+    PListRef = (*CFPropertyListCreateWithDataFunc)(
+        NULL, FileContentsRef, CF_PROPERTY_LIST_IMMUTABLE, NULL, NULL);
+  else
+    PListRef = (*CFPropertyListCreateFromXMLDataFunc)(
+        NULL, FileContentsRef, CF_PROPERTY_LIST_IMMUTABLE, NULL);
+  if (!PListRef)
+    goto Fail;
+
+  CFStringRef ProductVersion = (*CFStringCreateWithCStringNoCopyFunc)(
+      NULL, "ProductVersion", CF_STRING_ENCODING_ASCII, AllocatorNull);
+  if (!ProductVersion)
+    goto Fail;
+  CFTypeRef OpaqueValue = (*CFDictionaryGetValueFunc)(PListRef, ProductVersion);
+  (*CFReleaseFunc)(ProductVersion);
+  if (!OpaqueValue ||
+      (*CFGetTypeIDFunc)(OpaqueValue) != (*CFStringGetTypeIDFunc)())
+    goto Fail;
+
+  char VersionStr[32];
+  if (!(*CFStringGetCStringFunc)((CFStringRef)OpaqueValue, VersionStr,
+                                 sizeof(VersionStr), CF_STRING_ENCODING_UTF8))
+    goto Fail;
+  sscanf(VersionStr, "%d.%d.%d", &GlobalMajor, &GlobalMinor, &GlobalSubminor);
+
+Fail:
+  if (PListRef)
+    (*CFReleaseFunc)(PListRef);
+  if (FileContentsRef)
+    (*CFReleaseFunc)(FileContentsRef);
+  free(PListBuf);
+  fclose(PropertyList);
+}
+
+int32_t __isOSVersionAtLeast(int32_t Major, int32_t Minor, int32_t Subminor) {
+  // Populate the global version variables, if they haven't already.
+  dispatch_once_f(&DispatchOnceCounter, NULL, parseSystemVersionPList);
+
+  if (Major < GlobalMajor)
+    return 1;
+  if (Major > GlobalMajor)
+    return 0;
+  if (Minor < GlobalMinor)
+    return 1;
+  if (Minor > GlobalMinor)
+    return 0;
+  return Subminor <= GlobalSubminor;
+}
+
+#else
+
+// Silence an empty translation unit warning.
+typedef int unused;
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/paritydi2.c
+++ b/system/lib/compiler-rt/lib/builtins/paritydi2.c
@@ -1,0 +1,21 @@
+//===-- paritydi2.c - Implement __paritydi2 -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __paritydi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: 1 if number of bits is odd else returns 0
+
+COMPILER_RT_ABI si_int __paritydi2(di_int a) {
+  dwords x;
+  x.all = a;
+  return __paritysi2(x.s.high ^ x.s.low);
+}

--- a/system/lib/compiler-rt/lib/builtins/paritysi2.c
+++ b/system/lib/compiler-rt/lib/builtins/paritysi2.c
@@ -1,0 +1,23 @@
+//===-- paritysi2.c - Implement __paritysi2 -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __paritysi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: 1 if number of bits is odd else returns 0
+
+COMPILER_RT_ABI si_int __paritysi2(si_int a) {
+  su_int x = (su_int)a;
+  x ^= x >> 16;
+  x ^= x >> 8;
+  x ^= x >> 4;
+  return (0x6996 >> (x & 0xF)) & 1;
+}

--- a/system/lib/compiler-rt/lib/builtins/parityti2.c
+++ b/system/lib/compiler-rt/lib/builtins/parityti2.c
@@ -1,0 +1,25 @@
+//===-- parityti2.c - Implement __parityti2 -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __parityti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: 1 if number of bits is odd else returns 0
+
+COMPILER_RT_ABI si_int __parityti2(ti_int a) {
+  twords x;
+  x.all = a;
+  return __paritydi2(x.s.high ^ x.s.low);
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/popcountdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/popcountdi2.c
@@ -1,0 +1,32 @@
+//===-- popcountdi2.c - Implement __popcountdi2 ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __popcountdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: count of 1 bits
+
+COMPILER_RT_ABI si_int __popcountdi2(di_int a) {
+  du_int x2 = (du_int)a;
+  x2 = x2 - ((x2 >> 1) & 0x5555555555555555uLL);
+  // Every 2 bits holds the sum of every pair of bits (32)
+  x2 = ((x2 >> 2) & 0x3333333333333333uLL) + (x2 & 0x3333333333333333uLL);
+  // Every 4 bits holds the sum of every 4-set of bits (3 significant bits) (16)
+  x2 = (x2 + (x2 >> 4)) & 0x0F0F0F0F0F0F0F0FuLL;
+  // Every 8 bits holds the sum of every 8-set of bits (4 significant bits) (8)
+  su_int x = (su_int)(x2 + (x2 >> 32));
+  // The lower 32 bits hold four 16 bit sums (5 significant bits).
+  //   Upper 32 bits are garbage
+  x = x + (x >> 16);
+  // The lower 16 bits hold two 32 bit sums (6 significant bits).
+  //   Upper 16 bits are garbage
+  return (x + (x >> 8)) & 0x0000007F; // (7 significant bits)
+}

--- a/system/lib/compiler-rt/lib/builtins/popcountsi2.c
+++ b/system/lib/compiler-rt/lib/builtins/popcountsi2.c
@@ -1,0 +1,29 @@
+//===-- popcountsi2.c - Implement __popcountsi2 ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __popcountsi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: count of 1 bits
+
+COMPILER_RT_ABI si_int __popcountsi2(si_int a) {
+  su_int x = (su_int)a;
+  x = x - ((x >> 1) & 0x55555555);
+  // Every 2 bits holds the sum of every pair of bits
+  x = ((x >> 2) & 0x33333333) + (x & 0x33333333);
+  // Every 4 bits holds the sum of every 4-set of bits (3 significant bits)
+  x = (x + (x >> 4)) & 0x0F0F0F0F;
+  // Every 8 bits holds the sum of every 8-set of bits (4 significant bits)
+  x = (x + (x >> 16));
+  // The lower 16 bits hold two 8 bit sums (5 significant bits).
+  //    Upper 16 bits are garbage
+  return (x + (x >> 8)) & 0x0000003F; // (6 significant bits)
+}

--- a/system/lib/compiler-rt/lib/builtins/popcountti2.c
+++ b/system/lib/compiler-rt/lib/builtins/popcountti2.c
@@ -1,0 +1,43 @@
+//===-- popcountti2.c - Implement __popcountti2
+//----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __popcountti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: count of 1 bits
+
+COMPILER_RT_ABI si_int __popcountti2(ti_int a) {
+  tu_int x3 = (tu_int)a;
+  x3 = x3 - ((x3 >> 1) &
+             (((tu_int)0x5555555555555555uLL << 64) | 0x5555555555555555uLL));
+  // Every 2 bits holds the sum of every pair of bits (64)
+  x3 = ((x3 >> 2) &
+        (((tu_int)0x3333333333333333uLL << 64) | 0x3333333333333333uLL)) +
+       (x3 & (((tu_int)0x3333333333333333uLL << 64) | 0x3333333333333333uLL));
+  // Every 4 bits holds the sum of every 4-set of bits (3 significant bits) (32)
+  x3 = (x3 + (x3 >> 4)) &
+       (((tu_int)0x0F0F0F0F0F0F0F0FuLL << 64) | 0x0F0F0F0F0F0F0F0FuLL);
+  // Every 8 bits holds the sum of every 8-set of bits (4 significant bits) (16)
+  du_int x2 = (du_int)(x3 + (x3 >> 64));
+  // Every 8 bits holds the sum of every 8-set of bits (5 significant bits) (8)
+  su_int x = (su_int)(x2 + (x2 >> 32));
+  // Every 8 bits holds the sum of every 8-set of bits (6 significant bits) (4)
+  x = x + (x >> 16);
+  // Every 8 bits holds the sum of every 8-set of bits (7 significant bits) (2)
+  //
+  // Upper 16 bits are garbage
+  return (x + (x >> 8)) & 0xFF; // (8 significant bits)
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/powixf2.c
+++ b/system/lib/compiler-rt/lib/builtins/powixf2.c
@@ -1,0 +1,33 @@
+//===-- powixf2.cpp - Implement __powixf2 ---------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __powixf2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#if !_ARCH_PPC
+
+#include "int_lib.h"
+
+// Returns: a ^ b
+
+COMPILER_RT_ABI long double __powixf2(long double a, si_int b) {
+  const int recip = b < 0;
+  long double r = 1;
+  while (1) {
+    if (b & 1)
+      r *= a;
+    b /= 2;
+    if (b == 0)
+      break;
+    a *= a;
+  }
+  return recip ? 1 / r : r;
+}
+
+#endif

--- a/system/lib/compiler-rt/lib/builtins/subdf3.c
+++ b/system/lib/compiler-rt/lib/builtins/subdf3.c
@@ -1,0 +1,28 @@
+//===-- lib/adddf3.c - Double-precision subtraction ---------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements double-precision soft-float subtraction with the
+// IEEE-754 default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define DOUBLE_PRECISION
+#include "fp_lib.h"
+
+// Subtraction; flip the sign bit of b and add.
+COMPILER_RT_ABI fp_t __subdf3(fp_t a, fp_t b) {
+  return __adddf3(a, fromRep(toRep(b) ^ signBit));
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_dsub(fp_t a, fp_t b) { return __subdf3(a, b); }
+#else
+COMPILER_RT_ALIAS(__subdf3, __aeabi_dsub)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/subsf3.c
+++ b/system/lib/compiler-rt/lib/builtins/subsf3.c
@@ -1,0 +1,28 @@
+//===-- lib/subsf3.c - Single-precision subtraction ---------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements single-precision soft-float subtraction with the
+// IEEE-754 default rounding (to nearest, ties to even).
+//
+//===----------------------------------------------------------------------===//
+
+#define SINGLE_PRECISION
+#include "fp_lib.h"
+
+// Subtraction; flip the sign bit of b and add.
+COMPILER_RT_ABI fp_t __subsf3(fp_t a, fp_t b) {
+  return __addsf3(a, fromRep(toRep(b) ^ signBit));
+}
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI fp_t __aeabi_fsub(fp_t a, fp_t b) { return __subsf3(a, b); }
+#else
+COMPILER_RT_ALIAS(__subsf3, __aeabi_fsub)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/subvdi3.c
+++ b/system/lib/compiler-rt/lib/builtins/subvdi3.c
@@ -1,0 +1,29 @@
+//===-- subvdi3.c - Implement __subvdi3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __subvdi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a - b
+
+// Effects: aborts if a - b overflows
+
+COMPILER_RT_ABI di_int __subvdi3(di_int a, di_int b) {
+  di_int s = (du_int)a - (du_int)b;
+  if (b >= 0) {
+    if (s > a)
+      compilerrt_abort();
+  } else {
+    if (s <= a)
+      compilerrt_abort();
+  }
+  return s;
+}

--- a/system/lib/compiler-rt/lib/builtins/subvsi3.c
+++ b/system/lib/compiler-rt/lib/builtins/subvsi3.c
@@ -1,0 +1,29 @@
+//===-- subvsi3.c - Implement __subvsi3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __subvsi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a - b
+
+// Effects: aborts if a - b overflows
+
+COMPILER_RT_ABI si_int __subvsi3(si_int a, si_int b) {
+  si_int s = (su_int)a - (su_int)b;
+  if (b >= 0) {
+    if (s > a)
+      compilerrt_abort();
+  } else {
+    if (s <= a)
+      compilerrt_abort();
+  }
+  return s;
+}

--- a/system/lib/compiler-rt/lib/builtins/subvti3.c
+++ b/system/lib/compiler-rt/lib/builtins/subvti3.c
@@ -1,0 +1,33 @@
+//===-- subvti3.c - Implement __subvti3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __subvti3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns: a - b
+
+// Effects: aborts if a - b overflows
+
+COMPILER_RT_ABI ti_int __subvti3(ti_int a, ti_int b) {
+  ti_int s = (tu_int)a - (tu_int)b;
+  if (b >= 0) {
+    if (s > a)
+      compilerrt_abort();
+  } else {
+    if (s <= a)
+      compilerrt_abort();
+  }
+  return s;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/trampoline_setup.c
+++ b/system/lib/compiler-rt/lib/builtins/trampoline_setup.c
@@ -1,0 +1,43 @@
+//===----- trampoline_setup.c - Implement __trampoline_setup -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+extern void __clear_cache(void *start, void *end);
+
+// The ppc compiler generates calls to __trampoline_setup() when creating
+// trampoline functions on the stack for use with nested functions.
+// This function creates a custom 40-byte trampoline function on the stack
+// which loads r11 with a pointer to the outer function's locals
+// and then jumps to the target nested function.
+
+#if __ppc__ && !defined(__powerpc64__)
+COMPILER_RT_ABI void __trampoline_setup(uint32_t *trampOnStack,
+                                        int trampSizeAllocated,
+                                        const void *realFunc, void *localsPtr) {
+  // should never happen, but if compiler did not allocate
+  // enough space on stack for the trampoline, abort
+  if (trampSizeAllocated < 40)
+    compilerrt_abort();
+
+  // create trampoline
+  trampOnStack[0] = 0x7c0802a6; // mflr r0
+  trampOnStack[1] = 0x4800000d; // bl Lbase
+  trampOnStack[2] = (uint32_t)realFunc;
+  trampOnStack[3] = (uint32_t)localsPtr;
+  trampOnStack[4] = 0x7d6802a6; // Lbase: mflr r11
+  trampOnStack[5] = 0x818b0000; // lwz    r12,0(r11)
+  trampOnStack[6] = 0x7c0803a6; // mtlr r0
+  trampOnStack[7] = 0x7d8903a6; // mtctr r12
+  trampOnStack[8] = 0x816b0004; // lwz    r11,4(r11)
+  trampOnStack[9] = 0x4e800420; // bctr
+
+  // clear instruction cache
+  __clear_cache(trampOnStack, &trampOnStack[10]);
+}
+#endif // __ppc__ && !defined(__powerpc64__)

--- a/system/lib/compiler-rt/lib/builtins/truncdfhf2.c
+++ b/system/lib/compiler-rt/lib/builtins/truncdfhf2.c
@@ -1,0 +1,21 @@
+//===-- lib/truncdfhf2.c - double -> half conversion --------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SRC_DOUBLE
+#define DST_HALF
+#include "fp_trunc_impl.inc"
+
+COMPILER_RT_ABI uint16_t __truncdfhf2(double a) { return __truncXfYf2__(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI uint16_t __aeabi_d2h(double a) { return __truncdfhf2(a); }
+#else
+COMPILER_RT_ALIAS(__truncdfhf2, __aeabi_d2h)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/truncdfsf2.c
+++ b/system/lib/compiler-rt/lib/builtins/truncdfsf2.c
@@ -1,0 +1,21 @@
+//===-- lib/truncdfsf2.c - double -> single conversion ------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SRC_DOUBLE
+#define DST_SINGLE
+#include "fp_trunc_impl.inc"
+
+COMPILER_RT_ABI float __truncdfsf2(double a) { return __truncXfYf2__(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI float __aeabi_d2f(double a) { return __truncdfsf2(a); }
+#else
+COMPILER_RT_ALIAS(__truncdfsf2, __aeabi_d2f)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/truncsfhf2.c
+++ b/system/lib/compiler-rt/lib/builtins/truncsfhf2.c
@@ -1,0 +1,27 @@
+//===-- lib/truncsfhf2.c - single -> half conversion --------------*- C -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#define SRC_SINGLE
+#define DST_HALF
+#include "fp_trunc_impl.inc"
+
+// Use a forwarding definition and noinline to implement a poor man's alias,
+// as there isn't a good cross-platform way of defining one.
+COMPILER_RT_ABI NOINLINE uint16_t __truncsfhf2(float a) {
+  return __truncXfYf2__(a);
+}
+
+COMPILER_RT_ABI uint16_t __gnu_f2h_ieee(float a) { return __truncsfhf2(a); }
+
+#if defined(__ARM_EABI__)
+#if defined(COMPILER_RT_ARMHF_TARGET)
+AEABI_RTABI uint16_t __aeabi_f2h(float a) { return __truncsfhf2(a); }
+#else
+COMPILER_RT_ALIAS(__truncsfhf2, __aeabi_f2h)
+#endif
+#endif

--- a/system/lib/compiler-rt/lib/builtins/ucmpdi2.c
+++ b/system/lib/compiler-rt/lib/builtins/ucmpdi2.c
@@ -1,0 +1,42 @@
+//===-- ucmpdi2.c - Implement __ucmpdi2 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __ucmpdi2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns:  if (a <  b) returns 0
+//           if (a == b) returns 1
+//           if (a >  b) returns 2
+
+COMPILER_RT_ABI si_int __ucmpdi2(du_int a, du_int b) {
+  udwords x;
+  x.all = a;
+  udwords y;
+  y.all = b;
+  if (x.s.high < y.s.high)
+    return 0;
+  if (x.s.high > y.s.high)
+    return 2;
+  if (x.s.low < y.s.low)
+    return 0;
+  if (x.s.low > y.s.low)
+    return 2;
+  return 1;
+}
+
+#ifdef __ARM_EABI__
+// Returns: if (a <  b) returns -1
+//           if (a == b) returns  0
+//           if (a >  b) returns  1
+COMPILER_RT_ABI si_int __aeabi_ulcmp(di_int a, di_int b) {
+  return __ucmpdi2(a, b) - 1;
+}
+#endif

--- a/system/lib/compiler-rt/lib/builtins/ucmpti2.c
+++ b/system/lib/compiler-rt/lib/builtins/ucmpti2.c
@@ -1,0 +1,37 @@
+//===-- ucmpti2.c - Implement __ucmpti2 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __ucmpti2 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+#ifdef CRT_HAS_128BIT
+
+// Returns:  if (a <  b) returns 0
+//           if (a == b) returns 1
+//           if (a >  b) returns 2
+
+COMPILER_RT_ABI si_int __ucmpti2(tu_int a, tu_int b) {
+  utwords x;
+  x.all = a;
+  utwords y;
+  y.all = b;
+  if (x.s.high < y.s.high)
+    return 0;
+  if (x.s.high > y.s.high)
+    return 2;
+  if (x.s.low < y.s.low)
+    return 0;
+  if (x.s.low > y.s.low)
+    return 2;
+  return 1;
+}
+
+#endif // CRT_HAS_128BIT

--- a/system/lib/compiler-rt/lib/builtins/udivmodsi4.c
+++ b/system/lib/compiler-rt/lib/builtins/udivmodsi4.c
@@ -1,0 +1,21 @@
+//===-- udivmodsi4.c - Implement __udivmodsi4 -----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __udivmodsi4 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a / b, *rem = a % b
+
+COMPILER_RT_ABI su_int __udivmodsi4(su_int a, su_int b, su_int *rem) {
+  si_int d = __udivsi3(a, b);
+  *rem = a - (d * b);
+  return d;
+}

--- a/system/lib/compiler-rt/lib/builtins/udivsi3.c
+++ b/system/lib/compiler-rt/lib/builtins/udivsi3.c
@@ -1,0 +1,62 @@
+//===-- udivsi3.c - Implement __udivsi3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __udivsi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a / b
+
+// Translated from Figure 3-40 of The PowerPC Compiler Writer's Guide
+
+// This function should not call __divsi3!
+COMPILER_RT_ABI su_int __udivsi3(su_int n, su_int d) {
+  const unsigned n_uword_bits = sizeof(su_int) * CHAR_BIT;
+  su_int q;
+  su_int r;
+  unsigned sr;
+  // special cases
+  if (d == 0)
+    return 0; // ?!
+  if (n == 0)
+    return 0;
+  sr = __builtin_clz(d) - __builtin_clz(n);
+  // 0 <= sr <= n_uword_bits - 1 or sr large
+  if (sr > n_uword_bits - 1) // d > r
+    return 0;
+  if (sr == n_uword_bits - 1) // d == 1
+    return n;
+  ++sr;
+  // 1 <= sr <= n_uword_bits - 1
+  // Not a special case
+  q = n << (n_uword_bits - sr);
+  r = n >> sr;
+  su_int carry = 0;
+  for (; sr > 0; --sr) {
+    // r:q = ((r:q)  << 1) | carry
+    r = (r << 1) | (q >> (n_uword_bits - 1));
+    q = (q << 1) | carry;
+    // carry = 0;
+    // if (r.all >= d.all)
+    // {
+    //      r.all -= d.all;
+    //      carry = 1;
+    // }
+    const si_int s = (si_int)(d - r - 1) >> (n_uword_bits - 1);
+    carry = s & 1;
+    r -= d & s;
+  }
+  q = (q << 1) | carry;
+  return q;
+}
+
+#if defined(__ARM_EABI__)
+COMPILER_RT_ALIAS(__udivsi3, __aeabi_uidiv)
+#endif

--- a/system/lib/compiler-rt/lib/builtins/umodsi3.c
+++ b/system/lib/compiler-rt/lib/builtins/umodsi3.c
@@ -1,0 +1,19 @@
+//===-- umodsi3.c - Implement __umodsi3 -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements __umodsi3 for the compiler_rt library.
+//
+//===----------------------------------------------------------------------===//
+
+#include "int_lib.h"
+
+// Returns: a % b
+
+COMPILER_RT_ABI su_int __umodsi3(su_int a, su_int b) {
+  return a - __udivsi3(a, b) * b;
+}

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -33,11 +33,9 @@ def main():
   clear(local_builtins)
   clear(local_include)
 
-  listfile = os.path.join(script_dir, 'compiler-rt', 'filelist.txt')
-  for name in open(listfile).read().splitlines():
-    src = os.path.join(upstream_src, name);
-    target = os.path.join(local_builtins, name);
-    shutil.copy2(src, target)
+  for pattern in ('*.c', '*.h', '*.inc'):
+    for src in glob.glob(os.path.join(upstream_src, pattern)):
+      shutil.copy2(src, local_builtins)
 
   for pattern in ('*.h', '*.inc'):
     for name in glob.glob(os.path.join(upstream_src, pattern)):

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -34,10 +34,6 @@ def main():
   clear(local_include)
 
   for pattern in ('*.c', '*.h', '*.inc'):
-    for src in glob.glob(os.path.join(upstream_src, pattern)):
-      shutil.copy2(src, local_builtins)
-
-  for pattern in ('*.h', '*.inc'):
     for name in glob.glob(os.path.join(upstream_src, pattern)):
       shutil.copy2(name, local_builtins)
     for name in glob.glob(os.path.join(upstream_include, pattern)):


### PR DESCRIPTION
This change doesn't actually compile any of them which is
why its NFC.  It just paves the way for compiling them and makes
updating from upstream simple since we just copy everything.