### PR TITLE
Rename ubsan_minimal_handlers.cpp -> ubsan_minimal_handlers.cc

### DIFF
--- a/system/lib/compiler-rt/lib/ubsan_minimal/readme.txt
+++ b/system/lib/compiler-rt/lib/ubsan_minimal/readme.txt
@@ -5,7 +5,7 @@ Last Changed Date: 2019-01-19
 
 ===========================================================================
 
-* `ubsan_minimal_handlers.cpp` -- changed to use
+* `ubsan_minimal_handlers.cc` -- changed to use
   `emscripten_return_address` as `__builtin_return_address` is not yet
   available in clang target `wasm-unknown-emscripten`.
 * `sanitizer_atomic.h` -- based on `sanitizer_atomic.h`,

--- a/system/lib/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cc
+++ b/system/lib/compiler-rt/lib/ubsan_minimal/ubsan_minimal_handlers.cc
@@ -1,12 +1,3 @@
-/**
- * Copied from compiler-rt.
- * Last changed revision: 351178
- * Last changed date: 2019-01-15.
- *
- * Changes:
- *   * switched to using emscripten_return_address instead of
-       __builtin_return_address. clang currently rejects the latter on wasm.
- */
 #include "sanitizer_common/sanitizer_atomic.h"
 
 #include <stdlib.h>

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1322,7 +1322,7 @@ class libubsan_minimal_rt_wasm(CompilerRTWasmLibrary, MTLibrary):
 
   includes = [['system', 'lib', 'compiler-rt', 'lib']]
   src_dir = ['system', 'lib', 'compiler-rt', 'lib', 'ubsan_minimal']
-  src_files = ['ubsan_minimal_handlers.cpp']
+  src_files = ['ubsan_minimal_handlers.cc']
 
 
 class libsanitizer_common_rt_wasm(CompilerRTWasmLibrary, MTLibrary):


### PR DESCRIPTION
The upstream filename is `.cc` so I think it was simply imported
with the wrong name.

Also remove leading comment because it seems to be both redundant
(duplicates information in the readme.txt) and inaccurate (the change
in question does not seem to appear in this file.. it contains no changes
at all from upstream AFAICT).