### PR TITLE
Do not consider embind contexts to be leaked

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -479,7 +479,7 @@ if (!ENVIRONMENT_IS_PTHREAD) {
   Module['___embind_register_native_and_builtin_types']();
 #endif // EMBIND
 #if MODULARIZE
-  // The promise resolve function typically gets called as part of the execution
+  // The promise resolve function typically gets called as part of the execution 
   // of the Module `run`. The workers/pthreads don't execute `run` here, they
   // call `run` in response to a message at a later time, so the creation
   // promise can be resolved, marking the pthread-Module as initialized.

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -397,7 +397,7 @@ function exit(status, implicit) {
   // don't need to do anything here and can just leave. if the status is
   // non-zero, though, then we need to report it.
   // (we may have warned about this earlier, if a situation justifies doing so)
-  if (implicit && noExitRuntime && status === 0) {
+  if (implicit && status === 0) {
     return;
   }
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -397,7 +397,7 @@ function exit(status, implicit) {
   // don't need to do anything here and can just leave. if the status is
   // non-zero, though, then we need to report it.
   // (we may have warned about this earlier, if a situation justifies doing so)
-  if (implicit && status === 0) {
+  if (implicit && noExitRuntime && status === 0) {
     return;
   }
 
@@ -479,7 +479,7 @@ if (!ENVIRONMENT_IS_PTHREAD) {
   Module['___embind_register_native_and_builtin_types']();
 #endif // EMBIND
 #if MODULARIZE
-  // The promise resolve function typically gets called as part of the execution 
+  // The promise resolve function typically gets called as part of the execution
   // of the Module `run`. The workers/pthreads don't execute `run` here, they
   // call `run` in response to a message at a later time, so the creation
   // promise can be resolved, marking the pthread-Module as initialized.

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -20,7 +20,10 @@
 #include <type_traits>
 #include <emscripten/val.h>
 #include <emscripten/wire.h>
+
+#if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer)
 #include <sanitizer/lsan_interface.h>
+#endif
 
 namespace emscripten {
     enum class sharing_policy {
@@ -589,7 +592,9 @@ namespace emscripten {
         inline T* getContext(const T& t) {
             // not a leak because this is called once per binding
             auto* ret = new T(t);
+#if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer)
             __lsan_ignore_object(ret);
+#endif
             return ret;
         }
 

--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -20,6 +20,7 @@
 #include <type_traits>
 #include <emscripten/val.h>
 #include <emscripten/wire.h>
+#include <sanitizer/lsan_interface.h>
 
 namespace emscripten {
     enum class sharing_policy {
@@ -587,7 +588,9 @@ namespace emscripten {
         template<typename T>
         inline T* getContext(const T& t) {
             // not a leak because this is called once per binding
-            return new T(t);
+            auto* ret = new T(t);
+            __lsan_ignore_object(ret);
+            return ret;
         }
 
         template<typename Accessor, typename ValueType>

--- a/tests/core/test_embind_5.cpp
+++ b/tests/core/test_embind_5.cpp
@@ -17,6 +17,9 @@ public:
   virtual void doit() {
     EM_ASM({out("doing it");});
   }
+  virtual ~MyFoo() {
+    EM_ASM({out("destructing my foo");});
+  }
 };
 
 class MyBar : public MyFoo {
@@ -26,6 +29,9 @@ public:
   }
   void doit() override {
     EM_ASM({out("doing something else");});
+  }
+  virtual ~MyBar() override {
+    EM_ASM({out("destructing my bar");});
   }
 };
 
@@ -50,6 +56,9 @@ int main(int argc, char **argv) {
       bar.doit();
     } catch(e) {
       out(e);
+    } finally {
+      foo.delete();
+      bar.delete();
     }
   );
   return 0;

--- a/tests/core/test_embind_5.out
+++ b/tests/core/test_embind_5.out
@@ -3,3 +3,6 @@ doing it
 constructing my foo
 constructing my bar
 doing something else
+destructing my foo
+destructing my bar
+destructing my foo

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7356,19 +7356,19 @@ someweirdtext
     self.do_run_from_file(path_from_root('tests', 'embind', 'test_val.cpp'), path_from_root('tests', 'embind', 'test_val.out'))
 
   def test_embind_no_rtti(self):
-    create_test_file('pre.js', '''
-      Module = {};
-      Module['postRun'] = function() {
-        out("dotest retured: " + Module.dotest());
-      };
-    ''')
     src = r'''
+      #include <emscripten.h>
       #include <emscripten/bind.h>
       #include <emscripten/val.h>
       #include <stdio.h>
 
+      EM_JS(void, calltest, (), {
+        console.log("dotest returned: " + Module.dotest());
+      });
+
       int main(int argc, char** argv){
         printf("418\n");
+        calltest();
         return 0;
       }
 
@@ -7380,23 +7380,23 @@ someweirdtext
         emscripten::function("dotest", &test);
       }
     '''
-    self.emcc_args += ['--bind', '-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0', '--pre-js', 'pre.js']
-    self.do_run(src, '418\ndotest retured: 42\n')
+    self.emcc_args += ['--bind', '-fno-rtti', '-DEMSCRIPTEN_HAS_UNBOUND_TYPE_NAMES=0']
+    self.do_run(src, '418\ndotest returned: 42\n')
 
   def test_embind_no_rtti_followed_by_rtti(self):
-    create_test_file('pre.js', '''
-      Module = {};
-      Module['postRun'] = function() {
-        out("dotest retured: " + Module.dotest());
-      };
-    ''')
     src = r'''
+      #include <emscripten.h>
       #include <emscripten/bind.h>
       #include <emscripten/val.h>
       #include <stdio.h>
 
+      EM_JS(void, calltest, (), {
+        console.log("dotest returned: " + Module.dotest());
+      });
+
       int main(int argc, char** argv){
         printf("418\n");
+        calltest();
         return 0;
       }
 
@@ -7408,8 +7408,8 @@ someweirdtext
         emscripten::function("dotest", &test);
       }
     '''
-    self.emcc_args += ['--bind', '-fno-rtti', '-frtti', '--pre-js', 'pre.js']
-    self.do_run(src, '418\ndotest retured: 42\n')
+    self.emcc_args += ['--bind', '-fno-rtti', '-frtti']
+    self.do_run(src, '418\ndotest returned: 42\n')
 
   @parameterized({
     'all': ('ALL', False),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7330,7 +7330,7 @@ someweirdtext
     self.do_run(src, '107')
 
   def test_embind_5(self):
-    self.emcc_args += ['--bind']
+    self.emcc_args += ['--bind', '-s', 'EXIT_RUNTIME=1']
     self.do_run_in_out_file_test('tests', 'core', 'test_embind_5')
 
   def test_embind_custom_marshal(self):


### PR DESCRIPTION
LeakSanitizer was previously reporting leaks of embind contexts, but
the reports were not actionable for users because the allocations were
inside the embind library. The context leaks are intentional because
they are allocated only once and live for the lifetime of the program,
so this patch uses the lsan public interface to tell lsan to ignore
the leaked contexts.

Testing this change also uncovered a bug that postRun hooks were
skipped when EXIT_RUNTIME was enabled, so this patch contains a
drive-by fix for that as well.

Fixes #11533.