### PR TITLE
Wasm2js: Allow minification of import/export names

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1790,9 +1790,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # Enable minification of wasm imports and exports when appropriate, if we
     # are emitting an optimized JS+wasm combo (then the JS knows how to load the minified names).
     # Things that process the JS after this operation would be done must disable this.
-    # For example, ASYNCIFY_LAZY_LOAD_CODE needs to identify import names, and wasm2js
-    # needs to use the getTempRet0 imports (otherwise, it may create new ones to replace
-    # the old, which would break).
+    # For example, ASYNCIFY_LAZY_LOAD_CODE needs to identify import names.
     if will_metadce(options) and \
         shared.Settings.OPT_LEVEL >= 2 and \
         shared.Settings.DEBUG_LEVEL <= 2 and \
@@ -1803,7 +1801,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         not shared.Settings.RELOCATABLE and \
         not target.endswith(WASM_ENDINGS) and \
         not shared.Settings.ASYNCIFY_LAZY_LOAD_CODE and \
-        not shared.Settings.WASM2JS and \
             shared.Settings.MINIFY_ASMJS_EXPORT_NAMES:
       shared.Settings.MINIFY_WASM_IMPORTS_AND_EXPORTS = 1
       # in fastcomp it's inconvenient to minify module names as there is the

--- a/tests/code_size/hello_webgl2_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl2_fastcomp_asmjs.json
@@ -2,11 +2,11 @@
   "a.html": 580,
   "a.html.gz": 382,
   "a.js": 5321,
-  "a.js.gz": 2509,
+  "a.js.gz": 2510,
   "a.mem": 321,
   "a.mem.gz": 219,
   "a.asm.js": 9814,
   "a.asm.js.gz": 3544,
-  "total": 16041,
-  "total_gz": 6654
+  "total": 16036,
+  "total_gz": 6655
 }

--- a/tests/code_size/hello_webgl2_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl2_fastcomp_wasm.json
@@ -5,6 +5,6 @@
   "a.js.gz": 2535,
   "a.wasm": 8004,
   "a.wasm.gz": 4376,
-  "total": 13860,
+  "total": 13855,
   "total_gz": 7288
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23760,
-  "a.js.gz": 8899,
+  "a.js": 22340,
+  "a.js.gz": 8620,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 27514,
-  "total_gz": 11996
+  "total": 26096,
+  "total_gz": 11717
 }

--- a/tests/code_size/hello_webgl_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl_fastcomp_asmjs.json
@@ -2,11 +2,11 @@
   "a.html": 580,
   "a.html.gz": 382,
   "a.js": 4867,
-  "a.js.gz": 2352,
+  "a.js.gz": 2353,
   "a.mem": 321,
   "a.mem.gz": 219,
   "a.asm.js": 9814,
   "a.asm.js.gz": 3544,
-  "total": 15587,
-  "total_gz": 6497
+  "total": 15582,
+  "total_gz": 6498
 }

--- a/tests/code_size/hello_webgl_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl_fastcomp_wasm.json
@@ -2,9 +2,9 @@
   "a.html": 563,
   "a.html.gz": 377,
   "a.js": 4774,
-  "a.js.gz": 2356,
+  "a.js.gz": 2357,
   "a.wasm": 8004,
   "a.wasm.gz": 4376,
-  "total": 13346,
-  "total_gz": 7109
+  "total": 13341,
+  "total_gz": 7110
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 23250,
-  "a.js.gz": 8735,
+  "a.js": 21827,
+  "a.js.gz": 8454,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 27004,
-  "total_gz": 11832
+  "total": 25583,
+  "total_gz": 11551
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 697,
   "a.html.gz": 437,
-  "a.js": 2021,
-  "a.js.gz": 908,
+  "a.js": 1911,
+  "a.js.gz": 871,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 2724,
-  "total_gz": 1377
+  "total": 2614,
+  "total_gz": 1340
 }

--- a/tests/code_size/random_printf_fastcomp_asmjs.json
+++ b/tests/code_size/random_printf_fastcomp_asmjs.json
@@ -1,6 +1,6 @@
 {
   "a.html": 2898,
   "a.html.gz": 1224,
-  "total": 2907,
+  "total": 2898,
   "total_gz": 1224
 }

--- a/tests/code_size/random_printf_fastcomp_wasm.json
+++ b/tests/code_size/random_printf_fastcomp_wasm.json
@@ -1,6 +1,6 @@
 {
   "a.html": 14026,
   "a.html.gz": 7470,
-  "total": 14059,
+  "total": 14026,
   "total_gz": 7470
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
   "a.html": 13715,
   "a.html.gz": 7366,
-  "total": 13707,
+  "total": 13715,
   "total_gz": 7366
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19732,
-  "a.html.gz": 8241,
-  "total": 19732,
-  "total_gz": 8241
+  "a.html": 19537,
+  "a.html.gz": 8171,
+  "total": 19537,
+  "total_gz": 8171
 }


### PR DESCRIPTION
This was disabled due to some bugs with legalization, but those have been
fixed meanwhile (in https://github.com/WebAssembly/binaryen/pull/2926)
so we can do this.

This helps nicely, e.g. 6% shrinking of `hello_webgl2_wasm2js` in the
minimal runtime size test. cc @juj I think you'll like that :smile: 

In addition to CI, verified with `wasm2js3` locally.