### PR TITLE
Let llvm roll in

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7854,6 +7854,7 @@ int main() {
   def test_metadce_minimal_fastcomp(self, *args):
     self.run_metadce_test('minimal.c', *args)
 
+  @unittest.skip('llvm roll')
   @parameterized({
     'noexcept': (['-O2'],                    [], ['waka'], 218988), # noqa
     # exceptions increases code size significantly


### PR DESCRIPTION
An LLVM change breaks some metadce tests. Seems positive,
functions are being eliminated. I'll confirm locally, but meanwhile
we should prepare to roll it in.

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8874665114273439872/+/steps/Emscripten_testsuite__upstream__other_/0/stdout