### PR TITLE
Write sanity.txt at top level of cache.

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -22,7 +22,7 @@ from tools.shared import run_process, try_delete
 from tools.shared import expected_llvm_version, Cache, Settings
 from tools import shared, system_libs
 
-SANITY_FILE = shared.Cache.get_path('sanity.txt')
+SANITY_FILE = shared.Cache.get_path('sanity.txt', root=True)
 commands = [[EMCC], [PYTHON, path_from_root('tests', 'runner.py'), 'blahblah']]
 
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -577,7 +577,7 @@ def check_sanity(force=False):
       return # config stored directly in EM_CONFIG => skip sanity checks
     expected = generate_sanity()
 
-    sanity_file = Cache.get_path('sanity.txt')
+    sanity_file = Cache.get_path('sanity.txt', root=True)
     if os.path.exists(sanity_file):
       sanity_data = open(sanity_file).read()
       if sanity_data != expected:


### PR DESCRIPTION
Like is_vanilla.txt this file doesn't belong in the arch-specific
subdirectory.