### PR TITLE
Avoid create extra cache objects for top level files

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -90,7 +90,9 @@ class Cache(object):
     finally:
       self.release_cache_lock()
 
-  def get_path(self, shortname):
+  def get_path(self, shortname, root=False):
+    if root:
+      return os.path.join(self.root_dirname, shortname)
     return os.path.join(self.dirname, shortname)
 
   def erase_file(self, shortname):
@@ -101,8 +103,12 @@ class Cache(object):
 
   # Request a cached file. If it isn't in the cache, it will be created with
   # the given creator function
-  def get(self, shortname, creator, what=None, force=False):
-    cachename = os.path.abspath(os.path.join(self.dirname, shortname))
+  def get(self, shortname, creator, what=None, force=False, root=False):
+    if root:
+      cachename = os.path.join(self.root_dirname, shortname)
+    else:
+      cachename = os.path.join(self.dirname, shortname)
+    cachename = os.path.abspath(cachename)
 
     self.acquire_cache_lock()
     try:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1822,6 +1822,7 @@ Settings = SettingsManager()
 verify_settings()
 Cache = cache.Cache(CACHE)
 check_vanilla()
+reconfigure_cache()
 
 PRINT_STAGES = int(os.getenv('EMCC_VERBOSE', '0'))
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -769,6 +769,7 @@ def check_vanilla():
 
   if LLVM_TARGET == WASM_TARGET:
     Settings.WASM_BACKEND = 1
+    reconfigure_cache()
 
 
 def get_llvm_target():
@@ -1822,7 +1823,6 @@ Settings = SettingsManager()
 verify_settings()
 Cache = cache.Cache(CACHE)
 check_vanilla()
-reconfigure_cache()
 
 PRINT_STAGES = int(os.getenv('EMCC_VERBOSE', '0'))
 


### PR DESCRIPTION
This required some re-ordering of the startup code such that
the main case is created earlier on.  This mean settings are
also required to be creating earlier.

This will help with #11670