### PR TITLE
Enable fsync() support in src/library_tty.js

### DIFF
--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -50,10 +50,10 @@ mergeInto(LibraryManager.library, {
       },
       close: function(stream) {
         // flush any pending line data
-        stream.tty.ops.flush(stream.tty);
+        stream.tty.ops.fsync(stream.tty);
       },
-      flush: function(stream) {
-        stream.tty.ops.flush(stream.tty);
+      fsync: function(stream) {
+        stream.tty.ops.fsync(stream.tty);
       },
       read: function(stream, buffer, offset, length, pos /* ignored */) {
         if (!stream.tty || !stream.tty.ops.get_char) {
@@ -156,7 +156,7 @@ mergeInto(LibraryManager.library, {
           if (val != 0) tty.output.push(val); // val == 0 would cut text output off in the middle.
         }
       },
-      flush: function(tty) {
+      fsync: function(tty) {
         if (tty.output && tty.output.length > 0) {
           out(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
@@ -172,7 +172,7 @@ mergeInto(LibraryManager.library, {
           if (val != 0) tty.output.push(val);
         }
       },
-      flush: function(tty) {
+      fsync: function(tty) {
         if (tty.output && tty.output.length > 0) {
           err(UTF8ArrayToString(tty.output, 0));
           tty.output = [];

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -417,7 +417,7 @@ var WasiLibrary = {
     });
 #else
     if (stream.stream_ops && stream.stream_ops.fsync) {
-      return -stream.stream_ops.fsync(stream);
+      return stream.stream_ops.fsync(stream);
     }
     return 0; // we can't do anything synchronously; the in-memory FS is already synced to
 #endif // ASYNCIFY

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5962,6 +5962,9 @@ Module['onRuntimeInitialized'] = function() {
   def test_unistd_close(self):
     self.do_run_in_out_file_test('unistd/close.c')
 
+  def test_unistd_fsync_stdout(self):
+    self.do_run_in_out_file_test(test_file('unistd/fsync_stdout.c'))
+
   @also_with_noderawfs
   def test_unistd_pipe(self):
     self.do_runf(test_file('unistd/pipe.c'), 'success')

--- a/test/unistd/fsync_stdout.c
+++ b/test/unistd/fsync_stdout.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2011 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+
+int main() {
+  write(STDOUT_FILENO, "a", 1);
+  write(STDOUT_FILENO, "b", 1);
+  write(STDOUT_FILENO, "c", 1);
+  write(STDOUT_FILENO, "end\n", 4);
+
+  write(STDOUT_FILENO, "d", 1);
+  fsync(STDOUT_FILENO);
+  write(STDOUT_FILENO, "e", 1);
+  fsync(STDOUT_FILENO);
+  write(STDOUT_FILENO, "f", 1);
+  fsync(STDOUT_FILENO);
+  return 0;
+}

--- a/test/unistd/fsync_stdout.out
+++ b/test/unistd/fsync_stdout.out
@@ -1,0 +1,4 @@
+abcend
+d
+e
+f


### PR DESCRIPTION
The fd_sync syscall looks for fsync in the fd opts and as far
as I cant tell there are no uses of flush (fflush ia libc call whereas
fsync is the syscall equivalent).