### PR TITLE
Add #include to Sanitizers doc

### DIFF
--- a/site/source/docs/debugging/Sanitizers.rst
+++ b/site/source/docs/debugging/Sanitizers.rst
@@ -274,6 +274,8 @@ by doing:
 
 .. code-block:: c
 
+  #include <sanitizer/lsan_interface.h>
+
   #if defined(__has_feature)
   #if __has_feature(address_sanitizer)
     // code for ASan-enabled builds


### PR DESCRIPTION
A follow-up to #11644 - I've noticed we updated the tests and documented the public API, but didn't document the extra `#include` that API is coming from.