### PR TITLE
fix: GL_INFO_LOG_LENGTH returns 0 if there is no information log

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -488,3 +488,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Benedikt Meurer <bmeurer@google.com> (copyright owned by Google, LLC)
 * Jiulong Wang <jiulongw@gmail.com>
 * pudinha <rogi@skylittlesystem.org>
+* Nicholas Phillips <nwp2@illinois.edu>

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -2961,7 +2961,7 @@ var LibraryGL = {
 #if GL_ASSERTIONS || GL_TRACK_ERRORS
       if (log === null) log = '(unknown error)';
 #endif
-      if (log.length === 0){
+      if (log.length === 0) {
         // GLES2 specification says that if the shader has no information log, a value of 0 is returned.
         {{{ makeSetValue('p', '0', '0', 'i32') }}};
       } else {

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -2961,7 +2961,12 @@ var LibraryGL = {
 #if GL_ASSERTIONS || GL_TRACK_ERRORS
       if (log === null) log = '(unknown error)';
 #endif
-      {{{ makeSetValue('p', '0', 'log.length + 1', 'i32') }}};
+      if (log.length === 0){
+        // GLES2 specification says that if the shader has no information log, a value of 0 is returned.
+        {{{ makeSetValue('p', '0', '0', 'i32') }}};
+      } else {
+        {{{ makeSetValue('p', '0', 'log.length + 1', 'i32') }}};
+      }
     } else if (pname == 0x8B88) { // GL_SHADER_SOURCE_LENGTH
       var source = GLctx.getShaderSource(GL.shaders[shader]);
       var sourceLength = (source === null || source.length == 0) ? 0 : source.length + 1;


### PR DESCRIPTION
Fix for this issue: #11673 

The webgl port of glGetShaderiv(..., GL_INFO_LOG_LENGTH) incorrectly returned 1 when there was no information log. The GLES 2 standard says that it should return 0 in this case. This change will make it correctly return 0.