### PR TITLE
Fix Blocking on the main thread warnning message.

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -792,7 +792,7 @@ var LibraryPThread = {
     if (ENVIRONMENT_IS_NODE) return;
 #endif
 
-    if (ENVIRONMENT_IS_PTHREAD) return; // Blocking in a pthread is fine.
+    if (ENVIRONMENT_IS_WORKER) return; // Blocking in a worker/pthread is fine.
 
     warnOnce('Blocking on the main thread is very dangerous, see https://emscripten.org/docs/porting/pthreads.html#blocking-on-the-main-browser-thread');
 #if !ALLOW_BLOCKING_ON_MAIN_THREAD


### PR DESCRIPTION
Fix #11680 

pthread always runs in worker, so use `ENVIRONMENT_IS_WORKER` instead.