### PR TITLE
Add ABORT_ON_WASM_EXCEPTIONS

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -360,7 +360,7 @@ var LibraryExceptions = {
   __cxa_call_unexpected: function(exception) {
     err('Unexpected exception thrown, this is not properly supported - aborting');
 #if !MINIMAL_RUNTIME
-    ABORT = true;
+    ABORT = 1;
 #endif
     throw exception;
   },

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -416,7 +416,7 @@ function exit(status, implicit) {
     PThread.terminateAllThreads();
 #endif
 
-    ABORT = true;
+    ABORT = 2;
     EXITSTATUS = status;
 
     exitRuntime();

--- a/src/settings.js
+++ b/src/settings.js
@@ -1664,6 +1664,19 @@ var WASM2C = 0;
 // in a custom location.
 var SEPARATE_DWARF_URL = '';
 
+// Whether the program should abort when an unhandled WASM exception is encountered.
+// This makes the Emscripten program behave more like a native program where the OS
+// would terminate the process and no further code can be executed when an unhanled
+// exception (e.g. out-of-bounds memory access) happens.
+// This will instrument all exported functions to catch thrown exceptions and
+// call abort() when they happen. Once the program aborts any exported function calls
+// will fail with a "program has already aborted" exception to prevent calls into
+// code with a potentially corrupted program state.
+// This adds ~250 bytes to the code size in optimized builds and a slight overhead
+// for the extra instrumented function indirection.
+// Disable this if you want to handle the exceptions yourself or save some bytes.
+var ABORT_ON_WASM_EXCEPTIONS = 1;
+
 //===========================================
 // Internal, used for testing only, from here
 //===========================================

--- a/tests/core/test_abort_on_exception.c
+++ b/tests/core/test_abort_on_exception.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2016 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <stdio.h>
+#include <emscripten.h>
+
+volatile int* addr = (int*)0xfffffff;
+
+EMSCRIPTEN_KEEPALIVE void crash() {
+  printf("crashing\n");
+  *addr = 1337;
+}
+
+EM_JS(void, unhandled_exception_wrapper, (void), {
+  try {
+	// Crash the program
+	_crash();
+  }
+  catch(e) {
+	// Catch the abort
+	out(true);
+  }
+  
+  out("again");
+  
+  try {
+    // Try executing some function again
+	_crash();
+  }
+  catch(e) {
+	// Make sure it failed with the expected exception
+	out(e === "program has already aborted!" || e === "DEAD");
+  }
+});
+
+int main() {
+  unhandled_exception_wrapper();
+  return 0;
+} 
+

--- a/tests/core/test_abort_on_exception.out
+++ b/tests/core/test_abort_on_exception.out
@@ -1,0 +1,4 @@
+crashing
+true
+again
+true

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2316,7 +2316,7 @@ void *getBindBuffer() {
       } catch(e) {
         out('expected fail 1');
         assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
-        ABORT = false; // hackish
+        ABORT = 0; // hackish
       }
       assert(ok === expected_ok);
 
@@ -2327,7 +2327,7 @@ void *getBindBuffer() {
       } catch(e) {
         out('expected fail 2');
         assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
-        ABORT = false; // hackish
+        ABORT = 0; // hackish
       }
       assert(ok === expected_ok);
 
@@ -2338,7 +2338,7 @@ void *getBindBuffer() {
       } catch(e) {
         out('expected fail 3');
         assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
-        ABORT = false; // hackish
+        ABORT = 0; // hackish
       }
       assert(ok === expected_ok);
     '''

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7010,6 +7010,7 @@ someweirdtext
 
   def test_embind_val(self):
     self.emcc_args += ['--bind']
+    self.set_setting('ABORT_ON_WASM_EXCEPTIONS', 0); # The test handles exceptions itself
     self.do_run_from_file(path_from_root('tests', 'embind', 'test_val.cpp'), path_from_root('tests', 'embind', 'test_val.out'))
 
   def test_embind_no_rtti(self):
@@ -8402,6 +8403,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('TOTAL_STACK', 4 * 1024 * 1024)
     self.do_run_in_out_file_test('tests', 'core', 'test_stack_get_free')
 
+  def test_abort_on_exception(self):
+    self.do_run_in_out_file_test('tests', 'core', 'test_abort_on_exception')
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None):


### PR DESCRIPTION
Putting this up for discussion - this PR adds `Module['onException']` as discussed here:
https://github.com/emscripten-core/emscripten/issues/11667

It can be used as a catch-all notification for unhandled exceptions that occur within the execution frame of Emscripten compiled code.

`onException` fires when an exception occurs:
- in main function
- in the registered mainloop function
- in any code invoked via ccall/cwrap/embind

The exception is still passed on, because we need the execution of the JS task to get interrupted.