### PR TITLE
Throw if calls are made into the program after abort() has been called

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -104,6 +104,7 @@ function getCFunc(ident) {
     @param {Arguments|Array=} args
     @param {Object=} opts */
 function ccall(ident, returnType, argTypes, args, opts) {
+  if(ABORT) throw "program has aborted";
   // For fast lookup of conversion functions
   var toC = {
     'string': function(str) {
@@ -191,7 +192,11 @@ function cwrap(ident, returnType, argTypes, opts) {
   var numericArgs = argTypes.every(function(type){ return type === 'number'});
   var numericRet = returnType !== 'string';
   if (numericRet && numericArgs && !opts) {
-    return getCFunc(ident);
+    var func = getCFunc(ident);
+    return function() {
+      if(ABORT) throw "program has aborted";
+      return func.apply(null, arguments);
+    }
   }
 #endif
   return function() {


### PR DESCRIPTION
After abort()-ing the program is left in an undefined state so any calls into it are unsafe, but currently there is no easy way to tell when this happens.

This is a very minor code change that greatly helps in tracking down accidental usage of exported functions and classes by throwing a `program has aborted` exception when attempting to call into the program after abort() has been called in that program.

It guards any calls through `ccall`, `cwrap `and `embind`.

Discussed in https://github.com/emscripten-core/emscripten/issues/11667#issuecomment-661931833