### PR TITLE
Fix file packager preload-cache feature not working in a Worker

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -489,3 +489,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jiulong Wang <jiulongw@gmail.com>
 * pudinha <rogi@skylittlesystem.org>
 * Nicholas Phillips <nwp2@illinois.edu>
+* Colin Guyon <colin.guyon@insimo.fr> (copyright owned by InSimo, SAS)

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -566,7 +566,15 @@ def main():
 
     if use_preload_cache:
       code += r'''
-        var indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
+        var indexedDB;
+        if (typeof window === 'object') {
+          indexedDB = window.indexedDB || window.mozIndexedDB || window.webkitIndexedDB || window.msIndexedDB;
+        } else if (typeof location !== 'undefined') {
+          // worker
+          indexedDB = self.indexedDB;
+        } else {
+          throw 'using IndexedDB to cache data can only be done on a web page or in a web worker';
+        }
         var IDB_RO = "readonly";
         var IDB_RW = "readwrite";
         var DB_NAME = "''' + indexeddb_name + '''";


### PR DESCRIPTION
Fix file packager preload-cache feature not working in a Worker
    
An exception was thrown when loading the data JS loader script, `window` being unavailable in a Worker.
Tested on recent versions of Chrome, Firefox and Safari.

(To test whether we are in a Worker, I used the same technique that exists elsewhere in the file).

Thanks