### PR TITLE
Error on "no input files" rather than just warning. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -796,8 +796,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   # This check comes after check_sanity because test_sanity expects this.
   if not args:
-    logger.warning('no input files')
-    return 1
+    exit_with_error('no input files')
 
   if '-dumpmachine' in args:
     print(shared.get_llvm_target())

--- a/site/source/docs/building_from_source/verify_emscripten_environment.rst
+++ b/site/source/docs/building_from_source/verify_emscripten_environment.rst
@@ -31,9 +31,9 @@ For example, the following output reports an installation where Java is missing:
   INFO     root: (Emscripten: Running sanity checks)
   WARNING  root: java does not seem to exist, required for closure compiler. -O2 and above will fail. You need to define JAVA in .emscripten
 
-At this point you need to :ref:`Install and activate <fixing-missing-components-emcc>` any missing components. When everything is set up properly, ``emcc -v`` should give no warnings, and if you just enter ``emcc`` (without any input files), it should only give the following warning: ::
+At this point you need to :ref:`Install and activate <fixing-missing-components-emcc>` any missing components. When everything is set up properly, ``emcc -v`` should give no warnings, and if you just enter ``emcc`` (without any input files), it will give an error ::
 
-  WARNING  root: no input files
+  emcc: error: no input files
 
 
 Build a basic example


### PR DESCRIPTION
We were already treating like an error and returning non-zero but
we were reporting it as a warning for some reason.