### PR TITLE
Fix EMCC_FORCE_STDLIBS and re-enable tests for it

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -113,9 +113,9 @@ def needs_dylink(func):
   assert callable(func)
 
   @wraps(func)
-  def decorated(self):
+  def decorated(self, *args, **kwargs):
     self.check_dylink()
-    return func(self)
+    return func(self, *args, **kwargs)
 
   return decorated
 


### PR DESCRIPTION
Refactored the existing test and re-enabled it.  This had
bit rotted in the mean time which meant that EMCC_FORCE_STDLIBS=1
was getting duplicate symbols.

Fixes: #10571
Fixes: #11703