### PR TITLE
Add libunwind/include to C include path not just C++

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -815,13 +815,13 @@ def emsdk_cflags(user_args, cxx):
     path_from_root('system', 'local', 'include'),
     path_from_root('system', 'include', 'SSE'),
     path_from_root('system', 'lib', 'compiler-rt', 'include'),
+    path_from_root('system', 'lib', 'libunwind', 'include'),
     Cache.get_path('include')
   ]
 
   cxx_include_paths = [
     path_from_root('system', 'include', 'libcxx'),
     path_from_root('system', 'lib', 'libcxxabi', 'include'),
-    path_from_root('system', 'lib', 'libunwind', 'include')
   ]
 
   def include_directive(paths):


### PR DESCRIPTION
This should probably have been this way when it was first added
in #10497 since this is a C header.

A dependency on `unwind.h` was added to compiler-rt (written
in C) in #11634 which means that people without clang unwind.h
in their clang include directory were broken (See #11711)

Fixes: #11711