### PR TITLE
Internalize a bunch of JS libraries functions

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -4399,7 +4399,7 @@ LibraryManager.library = {
   },
 
   // Look up the function name from our stack frame cache with our PC representation.
-  emscripten_pc_get_function__deps: ['$UNWIND_CACHE', 'emscripten_with_builtin_malloc'
+  emscripten_pc_get_function__deps: ['$UNWIND_CACHE', '$withBuiltinMalloc'
 #if MINIMAL_RUNTIME
     , '$allocateUTF8'
 #endif
@@ -4425,7 +4425,7 @@ LibraryManager.library = {
     } else {
       name = wasmOffsetConverter.getName(pc);
     }
-    _emscripten_with_builtin_malloc(function () {
+    withBuiltinMalloc(function () {
       if (_emscripten_pc_get_function.ret) _free(_emscripten_pc_get_function.ret);
       _emscripten_pc_get_function.ret = allocateUTF8(name);
     });
@@ -4464,7 +4464,7 @@ LibraryManager.library = {
   },
 
   // Look up the file name from our stack frame cache with our PC representation.
-  emscripten_pc_get_file__deps: ['emscripten_pc_get_source_js', 'emscripten_with_builtin_malloc',
+  emscripten_pc_get_file__deps: ['emscripten_pc_get_source_js', '$withBuiltinMalloc',
 #if MINIMAL_RUNTIME
     '$allocateUTF8',
 #endif
@@ -4473,7 +4473,7 @@ LibraryManager.library = {
     var result = _emscripten_pc_get_source_js(pc);
     if (!result) return 0;
 
-    _emscripten_with_builtin_malloc(function () {
+    withBuiltinMalloc(function () {
       if (_emscripten_pc_get_file.ret) _free(_emscripten_pc_get_file.ret);
       _emscripten_pc_get_file.ret = allocateUTF8(result.file);
     });
@@ -4502,9 +4502,9 @@ LibraryManager.library = {
 #endif
   },
 
-  emscripten_with_builtin_malloc__deps: ['emscripten_builtin_malloc', 'emscripten_builtin_free', 'emscripten_builtin_memalign'],
-  emscripten_with_builtin_malloc__docs: '/** @suppress{checkTypes} */',
-  emscripten_with_builtin_malloc: function (func) {
+  $withBuiltinMalloc__deps: ['emscripten_builtin_malloc', 'emscripten_builtin_free', 'emscripten_builtin_memalign'],
+  $withBuiltinMalloc__docs: '/** @suppress{checkTypes} */',
+  $withBuiltinMalloc: function (func) {
     var prev_malloc = typeof _malloc !== 'undefined' ? _malloc : undefined;
     var prev_memalign = typeof _memalign !== 'undefined' ? _memalign : undefined;
     var prev_free = typeof _free !== 'undefined' ? _free : undefined;
@@ -4520,30 +4520,30 @@ LibraryManager.library = {
     }
   },
 
-  emscripten_builtin_mmap2__deps: ['emscripten_with_builtin_malloc', '$syscallMmap2'],
+  emscripten_builtin_mmap2__deps: ['$withBuiltinMalloc', '$syscallMmap2'],
   emscripten_builtin_mmap2: function (addr, len, prot, flags, fd, off) {
-    return _emscripten_with_builtin_malloc(function () {
+    return withBuiltinMalloc(function () {
       return syscallMmap2(addr, len, prot, flags, fd, off);
     });
   },
 
-  emscripten_builtin_munmap__deps: ['emscripten_with_builtin_malloc', '$syscallMunmap'],
+  emscripten_builtin_munmap__deps: ['$withBuiltinMalloc', '$syscallMunmap'],
   emscripten_builtin_munmap: function (addr, len) {
-    return _emscripten_with_builtin_malloc(function () {
+    return withBuiltinMalloc(function () {
       return syscallMunmap(addr, len);
     });
   },
 
-  _readAsmConstArgsArray: '=[]',
-  $readAsmConstArgs__deps: ['_readAsmConstArgsArray'],
+  $readAsmConstArgsArray: '=[]',
+  $readAsmConstArgs__deps: ['$readAsmConstArgsArray'],
   $readAsmConstArgs: function(sigPtr, buf) {
 #if ASSERTIONS
     // Nobody should have mutated _readAsmConstArgsArray underneath us to be something else than an array.
-    assert(Array.isArray( __readAsmConstArgsArray));
+    assert(Array.isArray(readAsmConstArgsArray));
     // The input buffer is allocated on the stack, so it must be stack-aligned.
     assert(buf % {{{ STACK_ALIGN }}} == 0);
 #endif
-    __readAsmConstArgsArray.length = 0;
+    readAsmConstArgsArray.length = 0;
     var ch;
     // Most arguments are i32s, so shift the buffer pointer so it is a plain
     // index into HEAP32.
@@ -4556,10 +4556,10 @@ LibraryManager.library = {
       // will emit padding to avoid that.
       var double = ch < 105;
       if (double && (buf & 1)) buf++;
-      __readAsmConstArgsArray.push(double ? HEAPF64[buf++ >> 1] : HEAP32[buf]);
+      readAsmConstArgsArray.push(double ? HEAPF64[buf++ >> 1] : HEAP32[buf]);
       ++buf;
     }
-    return __readAsmConstArgsArray;
+    return readAsmConstArgsArray;
   },
 
 #if !DECLARE_ASM_MODULE_EXPORTS

--- a/src/library.js
+++ b/src/library.js
@@ -761,7 +761,7 @@ LibraryManager.library = {
   // to limitations in the system libraries (we can't easily add a global
   // ctor to create the environment without it always being linked in with
   // libc).
-  __buildEnvironment__deps: ['__environ', '$ENV', '_getExecutableName'
+  __buildEnvironment__deps: ['__environ', '$ENV', '$getExecutableName'
 #if MINIMAL_RUNTIME
     , '$writeAsciiToMemory'
 #endif
@@ -783,7 +783,7 @@ LibraryManager.library = {
       ENV['HOME'] = '/home/web_user';
       // Browser language detection #8751
       ENV['LANG'] = ((typeof navigator === 'object' && navigator.languages && navigator.languages[0]) || 'C').replace('-', '_') + '.UTF-8';
-      ENV['_'] = __getExecutableName();
+      ENV['_'] = getExecutableName();
       // Allocate memory.
 #if !MINIMAL_RUNTIME // TODO: environment support in MINIMAL_RUNTIME
       poolPtr = getMemory(TOTAL_ENV_SIZE);
@@ -1838,12 +1838,12 @@ LibraryManager.library = {
     }
   },
 
-  dladdr__deps: ['$stringToNewUTF8', '_getExecutableName'],
+  dladdr__deps: ['$stringToNewUTF8', '$getExecutableName'],
   dladdr__proxy: 'sync',
   dladdr__sig: 'iii',
   dladdr: function(addr, info) {
     // report all function pointers as coming from this program itself XXX not really correct in any way
-    var fname = stringToNewUTF8(__getExecutableName()); // XXX leak
+    var fname = stringToNewUTF8(getExecutableName()); // XXX leak
     {{{ makeSetValue('info', 0, 'fname', 'i32') }}};
     {{{ makeSetValue('info', Runtime.QUANTUM_SIZE, '0', 'i32') }}};
     {{{ makeSetValue('info', Runtime.QUANTUM_SIZE*2, '0', 'i32') }}};
@@ -4063,7 +4063,7 @@ LibraryManager.library = {
 #endif
 
   // Returns [parentFuncArguments, functionName, paramListName]
-  _emscripten_traverse_stack: function(args) {
+  $traverseStack: function(args) {
     if (!args || !args.callee || !args.callee.name) {
       return [null, '', ''];
     }
@@ -4092,7 +4092,7 @@ LibraryManager.library = {
     return [args, funcname, str];
   },
 
-  emscripten_get_callstack_js__deps: ['_emscripten_traverse_stack', '$jsStackTrace', '$demangle'
+  emscripten_get_callstack_js__deps: ['$traverseStack', '$jsStackTrace', '$demangle'
 #if MINIMAL_RUNTIME
     , '$warnOnce'
 #endif
@@ -4117,9 +4117,9 @@ LibraryManager.library = {
     var stack_args = null;
     if (flags & 128 /*EM_LOG_FUNC_PARAMS*/) {
       // To get the actual parameters to the functions, traverse the stack via the unfortunately deprecated 'arguments.callee' method, if it works:
-      stack_args = __emscripten_traverse_stack(arguments);
+      stack_args = traverseStack(arguments);
       while (stack_args[1].indexOf('_emscripten_') >= 0)
-        stack_args = __emscripten_traverse_stack(stack_args[0]);
+        stack_args = traverseStack(stack_args[0]);
     }
 
     // Process all lines:
@@ -4189,7 +4189,7 @@ LibraryManager.library = {
           callstack = callstack.replace(/\s+$/, '');
           callstack += ' with values: ' + stack_args[1] + stack_args[2] + '\n';
         }
-        stack_args = __emscripten_traverse_stack(stack_args[0]);
+        stack_args = traverseStack(stack_args[0]);
       }
     }
     // Trim extra whitespace at the end of the output.
@@ -5109,7 +5109,7 @@ LibraryManager.library = {
     abort('stack overflow')
   },
 
-  _getExecutableName: function() {
+  $getExecutableName: function() {
 #if MINIMAL_RUNTIME // MINIMAL_RUNTIME does not have a global runtime variable thisProgram
 #if ENVIRONMENT_MAY_BE_NODE
     if (ENVIRONMENT_IS_NODE && process['argv'].length > 1) {

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -237,7 +237,7 @@ var LibraryJSEvents = {
     },
   },
 
-  _registerKeyEventCallback__deps: ['$JSEvents', '_findEventTarget'],
+  _registerKeyEventCallback__deps: ['$JSEvents', '$findEventTarget'],
   _registerKeyEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -278,7 +278,7 @@ var LibraryJSEvents = {
     };
 
     var eventHandler = {
-      target: __findEventTarget(target),
+      target: findEventTarget(target),
 #if HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS
 #if MIN_IE_VERSION != TARGET_NOT_SUPPORTED
       allowsDeferredCalls: JSEvents.isInternetExplorer() ? false : true, // MSIE doesn't allow fullscreen and pointerlock requests from key handlers, others do.
@@ -309,7 +309,7 @@ var LibraryJSEvents = {
 #endif
 
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
-  _maybeCStringToJsString: function(cString) {
+  $maybeCStringToJsString: function(cString) {
     // "cString > 2" checks if the input is a number, and isn't of the special
     // values we accept here, EMSCRIPTEN_EVENT_TARGET_* (which map to 0, 1, 2).
     // In other words, if cString > 2 then it's a pointer to a valid place in
@@ -317,9 +317,9 @@ var LibraryJSEvents = {
     return cString > 2 ? UTF8ToString(cString) : cString;
   },
 
-  _findEventTarget__deps: ['_maybeCStringToJsString', '$specialHTMLTargets'],
-  _findEventTarget: function(target) {
-    target = __maybeCStringToJsString(target);
+  $findEventTarget__deps: ['$maybeCStringToJsString', '$specialHTMLTargets'],
+  $findEventTarget: function(target) {
+    target = maybeCStringToJsString(target);
 #if ENVIRONMENT_MAY_BE_WORKER || ENVIRONMENT_MAY_BE_NODE
     var domElement = specialHTMLTargets[target] || (typeof document !== 'undefined' ? document.querySelector(target) : undefined);
 #else
@@ -329,9 +329,9 @@ var LibraryJSEvents = {
   },
 
 #if OFFSCREENCANVAS_SUPPORT
-  _findCanvasEventTarget__deps: ['$GL', '_maybeCStringToJsString'],
-  _findCanvasEventTarget: function(target) {
-    target = __maybeCStringToJsString(target);
+  $findCanvasEventTarget__deps: ['$GL', '$maybeCStringToJsString'],
+  $findCanvasEventTarget: function(target) {
+    target = maybeCStringToJsString(target);
 
     // When compiling with OffscreenCanvas support and looking up a canvas to target,
     // we first look up if the target Canvas has been transferred to OffscreenCanvas use.
@@ -356,14 +356,14 @@ var LibraryJSEvents = {
 #endif
   },
 #else
-  _findCanvasEventTarget__deps: ['_findEventTarget'],
-  _findCanvasEventTarget: function(target) { return __findEventTarget(target); },
+  $findCanvasEventTarget__deps: ['$findEventTarget'],
+  $findCanvasEventTarget: function(target) { return findEventTarget(target); },
 #endif
 
 #else
   // Find a DOM element with the given ID.
-  _findEventTarget__deps: ['$specialHTMLTargets'],
-  _findEventTarget: function(target) {
+  $findEventTarget__deps: ['$specialHTMLTargets'],
+  $findEventTarget: function(target) {
 #if ASSERTIONS
     warnOnce('Rules for selecting event targets in HTML5 API are changing: instead of using document.getElementById() that only can refer to elements by their DOM ID, new event target selection mechanism uses the more flexible function document.querySelector() that can look up element names, classes, and complex CSS selectors. Build with -s DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR=1 to change to the new lookup rules. See https://github.com/emscripten-core/emscripten/pull/7977 for more details.');
 #endif
@@ -386,15 +386,15 @@ var LibraryJSEvents = {
   },
 
   // Like findEventTarget, but looks for OffscreenCanvas elements first
-  _findCanvasEventTarget__deps: ['_findEventTarget'],
-  _findCanvasEventTarget: function(target) {
+  $findCanvasEventTarget__deps: ['$findEventTarget'],
+  $findCanvasEventTarget: function(target) {
     if (typeof target === 'number') target = UTF8ToString(target);
     if (!target || target === '#canvas') {
       if (typeof GL !== 'undefined' && GL.offscreenCanvases['canvas']) return GL.offscreenCanvases['canvas']; // TODO: Remove this line, target '#canvas' should refer only to Module['canvas'], not to GL.offscreenCanvases['canvas'] - but need stricter tests to be able to remove this line.
       return Module['canvas'];
     }
     if (typeof GL !== 'undefined' && GL.offscreenCanvases[target]) return GL.offscreenCanvases[target];
-    return __findEventTarget(target);
+    return findEventTarget(target);
   },
 #endif
 
@@ -505,13 +505,13 @@ var LibraryJSEvents = {
 #endif
   },
 
-  _registerMouseEventCallback__deps: ['$JSEvents', '_fillMouseEventData', '_findEventTarget'],
+  _registerMouseEventCallback__deps: ['$JSEvents', '_fillMouseEventData', '$findEventTarget'],
   _registerMouseEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
 #endif
     if (!JSEvents.mouseEvent) JSEvents.mouseEvent = _malloc( {{{ C_STRUCTS.EmscriptenMouseEvent.__size__ }}} );
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
 
     var mouseEventHandlerFunc = function(ev) {
       var e = ev || event;
@@ -630,7 +630,7 @@ var LibraryJSEvents = {
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 
-  _registerWheelEventCallback__deps: ['$JSEvents', '_fillMouseEventData', '_findEventTarget'],
+  _registerWheelEventCallback__deps: ['$JSEvents', '_fillMouseEventData', '$findEventTarget'],
   _registerWheelEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -693,9 +693,9 @@ var LibraryJSEvents = {
 
   emscripten_set_wheel_callback_on_thread__proxy: 'sync',
   emscripten_set_wheel_callback_on_thread__sig: 'iiiiii',
-  emscripten_set_wheel_callback_on_thread__deps: ['$JSEvents', '_registerWheelEventCallback', '_findEventTarget'],
+  emscripten_set_wheel_callback_on_thread__deps: ['$JSEvents', '_registerWheelEventCallback', '$findEventTarget'],
   emscripten_set_wheel_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
     if (typeof target.onwheel !== 'undefined') {
       __registerWheelEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_WHEEL') }}}, "wheel", targetThread);
       return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
@@ -709,7 +709,7 @@ var LibraryJSEvents = {
     }
   },
 
-  _registerUiEventCallback__deps: ['$JSEvents', '_findEventTarget'],
+  _registerUiEventCallback__deps: ['$JSEvents', '$findEventTarget'],
   _registerUiEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -717,12 +717,12 @@ var LibraryJSEvents = {
     if (!JSEvents.uiEvent) JSEvents.uiEvent = _malloc( {{{ C_STRUCTS.EmscriptenUiEvent.__size__ }}} );
 
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
 #else
     if (eventTypeString == "scroll" && !target) {
       target = document; // By default read scroll events on document rather than window.
     } else {
-      target = __findEventTarget(target);
+      target = findEventTarget(target);
     }
 #else
 #endif
@@ -784,7 +784,7 @@ var LibraryJSEvents = {
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 
-  _registerFocusEventCallback__deps: ['$JSEvents', '_findEventTarget'],
+  _registerFocusEventCallback__deps: ['$JSEvents', '$findEventTarget'],
   _registerFocusEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -813,7 +813,7 @@ var LibraryJSEvents = {
     };
 
     var eventHandler = {
-      target: __findEventTarget(target),
+      target: findEventTarget(target),
       eventTypeString: eventTypeString,
       callbackfunc: callbackfunc,
       handlerFunc: focusEventHandlerFunc,
@@ -862,7 +862,7 @@ var LibraryJSEvents = {
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceOrientationEvent.absolute, 'e.absolute', 'i32') }}};
   },
 
-  _registerDeviceOrientationEventCallback__deps: ['$JSEvents', '_fillDeviceOrientationEventData', '_findEventTarget'],
+  _registerDeviceOrientationEventCallback__deps: ['$JSEvents', '_fillDeviceOrientationEventData', '$findEventTarget'],
   _registerDeviceOrientationEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -885,7 +885,7 @@ var LibraryJSEvents = {
     };
 
     var eventHandler = {
-      target: __findEventTarget(target),
+      target: findEventTarget(target),
       eventTypeString: eventTypeString,
       callbackfunc: callbackfunc,
       handlerFunc: deviceOrientationEventHandlerFunc,
@@ -937,7 +937,7 @@ var LibraryJSEvents = {
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenDeviceMotionEvent.rotationRateGamma, 'rr["gamma"]', 'double') }}};
   },
 
-  _registerDeviceMotionEventCallback__deps: ['$JSEvents', '_fillDeviceMotionEventData', '_findEventTarget'],
+  _registerDeviceMotionEventCallback__deps: ['$JSEvents', '_fillDeviceMotionEventData', '$findEventTarget'],
   _registerDeviceMotionEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -960,7 +960,7 @@ var LibraryJSEvents = {
     };
 
     var eventHandler = {
-      target: __findEventTarget(target),
+      target: findEventTarget(target),
       eventTypeString: eventTypeString,
       callbackfunc: callbackfunc,
       handlerFunc: deviceMotionEventHandlerFunc,
@@ -1009,7 +1009,7 @@ var LibraryJSEvents = {
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenOrientationChangeEvent.orientationAngle, 'orientation', 'i32') }}};
   },
 
-  _registerOrientationChangeEventCallback__deps: ['$JSEvents', '_fillOrientationChangeEventData', '_findEventTarget'],
+  _registerOrientationChangeEventCallback__deps: ['$JSEvents', '_fillOrientationChangeEventData', '$findEventTarget'],
   _registerOrientationChangeEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -1133,7 +1133,7 @@ var LibraryJSEvents = {
     }
   },
 
-  _registerFullscreenChangeEventCallback__deps: ['$JSEvents', '_fillFullscreenChangeEventData', '_findEventTarget'],
+  _registerFullscreenChangeEventCallback__deps: ['$JSEvents', '_fillFullscreenChangeEventData', '$findEventTarget'],
   _registerFullscreenChangeEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -1170,13 +1170,13 @@ var LibraryJSEvents = {
 
   emscripten_set_fullscreenchange_callback_on_thread__proxy: 'sync',
   emscripten_set_fullscreenchange_callback_on_thread__sig: 'iiiiii',
-  emscripten_set_fullscreenchange_callback_on_thread__deps: ['$JSEvents', '_registerFullscreenChangeEventCallback', '_findEventTarget', '$specialHTMLTargets'],
+  emscripten_set_fullscreenchange_callback_on_thread__deps: ['$JSEvents', '_registerFullscreenChangeEventCallback', '$findEventTarget', '$specialHTMLTargets'],
   emscripten_set_fullscreenchange_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
 #else
-    target = target ? __findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}];
+    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}];
 #endif
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
     __registerFullscreenChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_FULLSCREENCHANGE') }}}, "fullscreenchange", targetThread);
@@ -1525,13 +1525,13 @@ var LibraryJSEvents = {
   },
 
   // https://developer.mozilla.org/en-US/docs/Web/Guide/API/DOM/Using_full_screen_mode  
-  _emscripten_do_request_fullscreen__deps: ['$JSEvents', '_setLetterbox', 'emscripten_set_canvas_element_size', 'emscripten_get_canvas_element_size', '_get_canvas_element_size', '_set_canvas_element_size', 'JSEvents_requestFullscreen', '_findEventTarget'],
+  _emscripten_do_request_fullscreen__deps: ['$JSEvents', '_setLetterbox', 'emscripten_set_canvas_element_size', 'emscripten_get_canvas_element_size', '_get_canvas_element_size', '_set_canvas_element_size', 'JSEvents_requestFullscreen', '$findEventTarget'],
   _emscripten_do_request_fullscreen: function(target, strategy) {
     if (!JSEvents.fullscreenEnabled()) return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
 #if !DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     if (!target) target = '#canvas';
 #endif
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
 
     if (!target.requestFullscreen
@@ -1604,14 +1604,14 @@ var LibraryJSEvents = {
     return __emscripten_do_request_fullscreen(target, strategy);
   },
 
-  emscripten_enter_soft_fullscreen__deps: ['$JSEvents', '_setLetterbox', '_hideEverythingExceptGivenElement', '_restoreOldWindowedStyle', '_registerRestoreOldStyle', '_restoreHiddenElements', '_currentFullscreenStrategy', '_softFullscreenResizeWebGLRenderTarget', '_get_canvas_element_size', '_set_canvas_element_size', 'JSEvents_resizeCanvasForFullscreen', '_findEventTarget'],
+  emscripten_enter_soft_fullscreen__deps: ['$JSEvents', '_setLetterbox', '_hideEverythingExceptGivenElement', '_restoreOldWindowedStyle', '_registerRestoreOldStyle', '_restoreHiddenElements', '_currentFullscreenStrategy', '_softFullscreenResizeWebGLRenderTarget', '_get_canvas_element_size', '_set_canvas_element_size', 'JSEvents_resizeCanvasForFullscreen', '$findEventTarget'],
   emscripten_enter_soft_fullscreen__proxy: 'sync',
   emscripten_enter_soft_fullscreen__sig: 'iii',
   emscripten_enter_soft_fullscreen: function(target, fullscreenStrategy) {
 #if !DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     if (!target) target = '#canvas';
 #endif
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
 
     var strategy = {
@@ -1718,7 +1718,7 @@ var LibraryJSEvents = {
     stringToUTF8(id, eventStruct + {{{ C_STRUCTS.EmscriptenPointerlockChangeEvent.id }}}, {{{ cDefine('EM_HTML5_LONG_STRING_LEN_BYTES') }}});
   },
 
-  _registerPointerlockChangeEventCallback__deps: ['$JSEvents', '_fillPointerlockChangeEventData', '_findEventTarget'],
+  _registerPointerlockChangeEventCallback__deps: ['$JSEvents', '_fillPointerlockChangeEventData', '$findEventTarget'],
   _registerPointerlockChangeEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -1754,7 +1754,7 @@ var LibraryJSEvents = {
 
   emscripten_set_pointerlockchange_callback_on_thread__proxy: 'sync',
   emscripten_set_pointerlockchange_callback_on_thread__sig: 'iiiiii',
-  emscripten_set_pointerlockchange_callback_on_thread__deps: ['$JSEvents', '_registerPointerlockChangeEventCallback', '_findEventTarget', '$specialHTMLTargets'],
+  emscripten_set_pointerlockchange_callback_on_thread__deps: ['$JSEvents', '_registerPointerlockChangeEventCallback', '$findEventTarget', '$specialHTMLTargets'],
   emscripten_set_pointerlockchange_callback_on_thread__docs: '/** @suppress {missingProperties} */', // Closure does not see document.body.mozRequestPointerLock etc.
   emscripten_set_pointerlockchange_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     // TODO: Currently not supported in pthreads or in --proxy-to-worker mode. (In pthreads mode, document object is not defined)
@@ -1763,9 +1763,9 @@ var LibraryJSEvents = {
     }
 
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
 #else
-    target = target ? __findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
+    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
 #endif
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
     __registerPointerlockChangeEventCallback(target, userData, useCapture, callbackfunc, {{{ cDefine('EMSCRIPTEN_EVENT_POINTERLOCKCHANGE') }}}, "pointerlockchange", targetThread);
@@ -1775,7 +1775,7 @@ var LibraryJSEvents = {
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 
-  _registerPointerlockErrorEventCallback__deps: ['$JSEvents', '_findEventTarget', '$specialHTMLTargets'],
+  _registerPointerlockErrorEventCallback__deps: ['$JSEvents', '$findEventTarget', '$specialHTMLTargets'],
   _registerPointerlockErrorEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -1803,7 +1803,7 @@ var LibraryJSEvents = {
 
   emscripten_set_pointerlockerror_callback_on_thread__proxy: 'sync',
   emscripten_set_pointerlockerror_callback_on_thread__sig: 'iiiiii',
-  emscripten_set_pointerlockerror_callback_on_thread__deps: ['$JSEvents', '_registerPointerlockErrorEventCallback', '_findEventTarget', '$specialHTMLTargets'],
+  emscripten_set_pointerlockerror_callback_on_thread__deps: ['$JSEvents', '_registerPointerlockErrorEventCallback', '$findEventTarget', '$specialHTMLTargets'],
   emscripten_set_pointerlockerror_callback_on_thread__docs: '/** @suppress {missingProperties} */', // Closure does not see document.body.mozRequestPointerLock etc.
   emscripten_set_pointerlockerror_callback_on_thread: function(target, userData, useCapture, callbackfunc, targetThread) {
     // TODO: Currently not supported in pthreads or in --proxy-to-worker mode. (In pthreads mode, document object is not defined)
@@ -1812,9 +1812,9 @@ var LibraryJSEvents = {
     }
 
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
 #else
-    target = target ? __findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
+    target = target ? findEventTarget(target) : specialHTMLTargets[{{{ cDefine('EMSCRIPTEN_EVENT_TARGET_DOCUMENT') }}}]; // Pointer lock change events need to be captured from 'document' by default instead of 'window'
 #endif
 
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
@@ -1876,12 +1876,12 @@ var LibraryJSEvents = {
 
   emscripten_request_pointerlock__proxy: 'sync',
   emscripten_request_pointerlock__sig: 'iii',
-  emscripten_request_pointerlock__deps: ['$JSEvents', '_requestPointerLock', '_findEventTarget'],
+  emscripten_request_pointerlock__deps: ['$JSEvents', '_requestPointerLock', '$findEventTarget'],
   emscripten_request_pointerlock: function(target, deferUntilInEventHandler) {
 #if !DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
     if (!target) target = '#canvas';
 #endif
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
     if (!target.requestPointerLock
 #if MIN_FIREFOX_VERSION <= 40 // https://caniuse.com/#feat=pointerlock
@@ -1975,7 +1975,7 @@ var LibraryJSEvents = {
     {{{ makeSetValue('eventStruct', C_STRUCTS.EmscriptenVisibilityChangeEvent.visibilityState, 'visibilityState', 'i32') }}};
   },
 
-  _registerVisibilityChangeEventCallback__deps: ['$JSEvents', '_fillVisibilityChangeEventData', '_findEventTarget'],
+  _registerVisibilityChangeEventCallback__deps: ['$JSEvents', '_fillVisibilityChangeEventData', '$findEventTarget'],
   _registerVisibilityChangeEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -2034,14 +2034,14 @@ var LibraryJSEvents = {
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
 
-  _registerTouchEventCallback__deps: ['$JSEvents', '_findEventTarget', '_getBoundingClientRect'],
+  _registerTouchEventCallback__deps: ['$JSEvents', '$findEventTarget', '_getBoundingClientRect'],
   _registerTouchEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
 #endif
     if (!JSEvents.touchEvent) JSEvents.touchEvent = _malloc( {{{ C_STRUCTS.EmscriptenTouchEvent.__size__ }}} );
 
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
 
     var touchEventHandlerFunc = function(e) {
 #if ASSERTIONS
@@ -2196,7 +2196,7 @@ var LibraryJSEvents = {
     stringToUTF8(e.mapping, eventStruct + {{{ C_STRUCTS.EmscriptenGamepadEvent.mapping }}}, {{{ cDefine('EM_HTML5_MEDIUM_STRING_LEN_BYTES') }}});
   },
 
-  _registerGamepadEventCallback__deps: ['$JSEvents', '_fillGamepadEventData', '_findEventTarget'],
+  _registerGamepadEventCallback__deps: ['$JSEvents', '_fillGamepadEventData', '$findEventTarget'],
   _registerGamepadEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -2221,7 +2221,7 @@ var LibraryJSEvents = {
     };
 
     var eventHandler = {
-      target: __findEventTarget(target),
+      target: findEventTarget(target),
 #if HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS
       allowsDeferredCalls: true,
 #endif
@@ -2292,7 +2292,7 @@ var LibraryJSEvents = {
     return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
   },
   
-  _registerBeforeUnloadEventCallback__deps: ['$JSEvents', '_findEventTarget'],
+  _registerBeforeUnloadEventCallback__deps: ['$JSEvents', '$findEventTarget'],
   _registerBeforeUnloadEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString) {
     var beforeUnloadEventHandlerFunc = function(ev) {
       var e = ev || event;
@@ -2311,7 +2311,7 @@ var LibraryJSEvents = {
     };
 
     var eventHandler = {
-      target: __findEventTarget(target),
+      target: findEventTarget(target),
       eventTypeString: eventTypeString,
       callbackfunc: callbackfunc,
       handlerFunc: beforeUnloadEventHandlerFunc,
@@ -2341,7 +2341,7 @@ var LibraryJSEvents = {
 
   _battery: function() { return navigator.battery || navigator.mozBattery || navigator.webkitBattery; },
 
-  _registerBatteryEventCallback__deps: ['$JSEvents', '_fillBatteryEventData', '_battery', '_findEventTarget'],
+  _registerBatteryEventCallback__deps: ['$JSEvents', '_fillBatteryEventData', '_battery', '$findEventTarget'],
   _registerBatteryEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -2366,7 +2366,7 @@ var LibraryJSEvents = {
     };
 
     var eventHandler = {
-      target: __findEventTarget(target),
+      target: findEventTarget(target),
       eventTypeString: eventTypeString,
       callbackfunc: callbackfunc,
       handlerFunc: batteryEventHandlerFunc,
@@ -2403,9 +2403,9 @@ var LibraryJSEvents = {
   },
 
 #if USE_PTHREADS
-  emscripten_set_canvas_element_size_calling_thread__deps: ['$JSEvents', 'emscripten_set_offscreencanvas_size_on_target_thread', '_findCanvasEventTarget'],
+  emscripten_set_canvas_element_size_calling_thread__deps: ['$JSEvents', 'emscripten_set_offscreencanvas_size_on_target_thread', '$findCanvasEventTarget'],
   emscripten_set_canvas_element_size_calling_thread: function(target, width, height) {
-    var canvas = __findCanvasEventTarget(target);
+    var canvas = findCanvasEventTarget(target);
     if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
 
     if (canvas.canvasSharedPtr) {
@@ -2490,12 +2490,12 @@ var LibraryJSEvents = {
   emscripten_set_canvas_element_size_main_thread__deps: ['emscripten_set_canvas_element_size_calling_thread'],
   emscripten_set_canvas_element_size_main_thread: function(target, width, height) { return _emscripten_set_canvas_element_size_calling_thread(target, width, height); },
 
-  emscripten_set_canvas_element_size__deps: ['$JSEvents', 'emscripten_set_canvas_element_size_calling_thread', 'emscripten_set_canvas_element_size_main_thread', '_findCanvasEventTarget'],
+  emscripten_set_canvas_element_size__deps: ['$JSEvents', 'emscripten_set_canvas_element_size_calling_thread', 'emscripten_set_canvas_element_size_main_thread', '$findCanvasEventTarget'],
   emscripten_set_canvas_element_size: function(target, width, height) {
 #if GL_DEBUG
     console.error('emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
 #endif
-    var canvas = __findCanvasEventTarget(target);
+    var canvas = findCanvasEventTarget(target);
     if (canvas) {
       return _emscripten_set_canvas_element_size_calling_thread(target, width, height);
     } else {
@@ -2503,12 +2503,12 @@ var LibraryJSEvents = {
     }
   }, 
 #else
-  emscripten_set_canvas_element_size__deps: ['$JSEvents', '_findCanvasEventTarget'],
+  emscripten_set_canvas_element_size__deps: ['$JSEvents', '$findCanvasEventTarget'],
   emscripten_set_canvas_element_size: function(target, width, height) {
 #if GL_DEBUG
     console.error('emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
 #endif
-    var canvas = __findCanvasEventTarget(target);
+    var canvas = findCanvasEventTarget(target);
     if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
     canvas.width = width;
     canvas.height = height;
@@ -2543,9 +2543,9 @@ var LibraryJSEvents = {
   }, 
 
 #if USE_PTHREADS
-  emscripten_get_canvas_element_size_calling_thread__deps: ['$JSEvents', '_findCanvasEventTarget'],
+  emscripten_get_canvas_element_size_calling_thread__deps: ['$JSEvents', '$findCanvasEventTarget'],
   emscripten_get_canvas_element_size_calling_thread: function(target, width, height) {
-    var canvas = __findCanvasEventTarget(target);
+    var canvas = findCanvasEventTarget(target);
     if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
 
     if (canvas.canvasSharedPtr) {
@@ -2576,9 +2576,9 @@ var LibraryJSEvents = {
   emscripten_get_canvas_element_size_main_thread__deps: ['emscripten_get_canvas_element_size_calling_thread'],
   emscripten_get_canvas_element_size_main_thread: function(target, width, height) { return _emscripten_get_canvas_element_size_calling_thread(target, width, height); },
 
-  emscripten_get_canvas_element_size__deps: ['$JSEvents', 'emscripten_get_canvas_element_size_calling_thread', 'emscripten_get_canvas_element_size_main_thread', '_findCanvasEventTarget'],
+  emscripten_get_canvas_element_size__deps: ['$JSEvents', 'emscripten_get_canvas_element_size_calling_thread', 'emscripten_get_canvas_element_size_main_thread', '$findCanvasEventTarget'],
   emscripten_get_canvas_element_size: function(target, width, height) {
-    var canvas = __findCanvasEventTarget(target);
+    var canvas = findCanvasEventTarget(target);
     if (canvas) {
       return _emscripten_get_canvas_element_size_calling_thread(target, width, height);
     } else {
@@ -2586,9 +2586,9 @@ var LibraryJSEvents = {
     }
   }, 
 #else
-  emscripten_get_canvas_element_size__deps: ['$JSEvents', '_findCanvasEventTarget'],
+  emscripten_get_canvas_element_size__deps: ['$JSEvents', '$findCanvasEventTarget'],
   emscripten_get_canvas_element_size: function(target, width, height) {
-    var canvas = __findCanvasEventTarget(target);
+    var canvas = findCanvasEventTarget(target);
     if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
     {{{ makeSetValue('width', '0', 'canvas.width', 'i32') }}};
     {{{ makeSetValue('height', '0', 'canvas.height', 'i32') }}};
@@ -2616,12 +2616,12 @@ var LibraryJSEvents = {
 
   emscripten_set_element_css_size__proxy: 'sync',
   emscripten_set_element_css_size__sig: 'iiii',
-  emscripten_set_element_css_size__deps: ['$JSEvents', '_findEventTarget'],
+  emscripten_set_element_css_size__deps: ['$JSEvents', '$findEventTarget'],
   emscripten_set_element_css_size: function(target, width, height) {
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
 #else
-    target = target ? __findEventTarget(target) : Module['canvas'];
+    target = target ? findEventTarget(target) : Module['canvas'];
 #endif
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
 
@@ -2633,12 +2633,12 @@ var LibraryJSEvents = {
 
   emscripten_get_element_css_size__proxy: 'sync',
   emscripten_get_element_css_size__sig: 'iiii',
-  emscripten_get_element_css_size__deps: ['$JSEvents', '_findEventTarget', '_getBoundingClientRect'],
+  emscripten_get_element_css_size__deps: ['$JSEvents', '$findEventTarget', '_getBoundingClientRect'],
   emscripten_get_element_css_size: function(target, width, height) {
 #if DISABLE_DEPRECATED_FIND_EVENT_TARGET_BEHAVIOR
-    target = __findEventTarget(target);
+    target = findEventTarget(target);
 #else
-    target = target ? __findEventTarget(target) : Module['canvas'];
+    target = target ? findEventTarget(target) : Module['canvas'];
 #endif
     if (!target) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
 
@@ -2680,7 +2680,7 @@ var LibraryJSEvents = {
     return requestAnimationFrame(tick);
   },
 
-  _polyfill_set_immediate__postset:
+  $polyfillSetImmediate__postset:
     'var __setImmediate_id_counter = 0;\n' +
     'var __setImmediate_queue = [];\n' +
     'var __setImmediate_message_id = "_si";\n' +
@@ -2703,11 +2703,11 @@ var LibraryJSEvents = {
       '})\n' +
     '}',
 
-  _polyfill_set_immediate: function() { /* nop, used for its postset to ensure setImmediate() polyfill is not duplicated between emscripten_set_immediate() and emscripten_set_immediate_loop() if application links to both of them.*/ },
+  $polyfillSetImmediate: function() { /* nop, used for its postset to ensure setImmediate() polyfill is not duplicated between emscripten_set_immediate() and emscripten_set_immediate_loop() if application links to both of them.*/ },
 
-  emscripten_set_immediate__deps: ['_polyfill_set_immediate'],
+  emscripten_set_immediate__deps: ['$polyfillSetImmediate'],
   emscripten_set_immediate: function(cb, userData) {
-    __polyfill_set_immediate();
+    polyfillSetImmediate();
     return setImmediate(function() {
       {{{ makeDynCall('vi') }}}(cb, userData);
     });
@@ -2717,9 +2717,9 @@ var LibraryJSEvents = {
     clearImmediate(id);
   },
 
-  emscripten_set_immediate_loop__deps: ['_polyfill_set_immediate'],
+  emscripten_set_immediate_loop__deps: ['$polyfillSetImmediate'],
   emscripten_set_immediate_loop: function(cb, userData) {
-    __polyfill_set_immediate();
+    polyfillSetImmediate();
     function tick() {
       if ({{{ makeDynCall('ii') }}}(cb, userData)) {
         setImmediate(tick);

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -68,7 +68,7 @@ var LibraryHtml5WebGL = {
 #if LibraryManager.has('library_webgl.js')
   '$GL',
 #endif
-  '$JSEvents', '_emscripten_webgl_power_preferences', '_findEventTarget', '_findCanvasEventTarget'],
+  '$JSEvents', '_emscripten_webgl_power_preferences', '$findEventTarget', '$findCanvasEventTarget'],
   // This function performs proxying manually, depending on the style of context that is to be created.
   emscripten_webgl_do_create_context: function(target, attributes) {
 #if ASSERTIONS
@@ -92,7 +92,7 @@ var LibraryHtml5WebGL = {
     contextAttributes.proxyContextToMainThread = HEAP32[a + ({{{ C_STRUCTS.EmscriptenWebGLContextAttributes.proxyContextToMainThread }}}>>2)];
     contextAttributes.renderViaOffscreenBackBuffer = HEAP32[a + ({{{ C_STRUCTS.EmscriptenWebGLContextAttributes.renderViaOffscreenBackBuffer }}}>>2)];
 
-    var canvas = __findCanvasEventTarget(target);
+    var canvas = findCanvasEventTarget(target);
 
 #if GL_DEBUG
     var targetStr = UTF8ToString(target);
@@ -376,7 +376,7 @@ var LibraryHtml5WebGL = {
 #endif
   },
 
-  _registerWebGlEventCallback__deps: ['$JSEvents', '_findEventTarget'],
+  _registerWebGlEventCallback__deps: ['$JSEvents', '$findEventTarget'],
   _registerWebGlEventCallback: function(target, userData, useCapture, callbackfunc, eventTypeId, eventTypeString, targetThread) {
 #if USE_PTHREADS
     targetThread = JSEvents.getTargetThreadForEventCallback(targetThread);
@@ -397,7 +397,7 @@ var LibraryHtml5WebGL = {
     };
 
     var eventHandler = {
-      target: __findEventTarget(target),
+      target: findEventTarget(target),
       eventTypeString: eventTypeString,
       callbackfunc: callbackfunc,
       handlerFunc: webGlEventHandlerFunc,

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -11,7 +11,7 @@ var WasiLibrary = {
     _exit(code);
   },
 
-  $getEnvStrings__deps: ['$ENV', '_getExecutableName'],
+  $getEnvStrings__deps: ['$ENV', '$getExecutableName'],
   $getEnvStrings: function() {
     if (!getEnvStrings.strings) {
       // Default values.
@@ -29,7 +29,7 @@ var WasiLibrary = {
         'PWD': '/',
         'HOME': '/home/web_user',
         'LANG': lang,
-        '_': __getExecutableName()
+        '_': getExecutableName()
       };
       // Apply the user-provided values, if any.
       for (var x in ENV) {

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -12,14 +12,14 @@ var LibraryGL = {
 
   // For functions such as glDrawBuffers, glInvalidateFramebuffer and glInvalidateSubFramebuffer that need to pass a short array to the WebGL API,
   // create a set of short fixed-length arrays to avoid having to generate any garbage when calling those functions.
-  _tempFixedLengthArray__postset: 'for (var i = 0; i < 32; ++i) __tempFixedLengthArray.push(new Array(i));',
-  _tempFixedLengthArray: [],
+  $tempFixedLengthArray__postset: 'for (var i = 0; i < 32; ++i) tempFixedLengthArray.push(new Array(i));',
+  $tempFixedLengthArray: [],
 
-  _miniTempWebGLFloatBuffers: [],
-  _miniTempWebGLFloatBuffers__postset:
-      'var __miniTempWebGLFloatBuffersStorage = new Float32Array(' + {{{ GL_POOL_TEMP_BUFFERS_SIZE }}} + ');\n'
+  $miniTempWebGLFloatBuffers: [],
+  $miniTempWebGLFloatBuffers__postset:
+      'var miniTempWebGLFloatBuffersStorage = new Float32Array(' + {{{ GL_POOL_TEMP_BUFFERS_SIZE }}} + ');\n'
     + 'for (/**@suppress{duplicate}*/var i = 0; i < ' + {{{ GL_POOL_TEMP_BUFFERS_SIZE }}} + '; ++i) {\n'
-    + '__miniTempWebGLFloatBuffers[i] = __miniTempWebGLFloatBuffersStorage.subarray(0, i+1);\n'
+    + 'miniTempWebGLFloatBuffers[i] = miniTempWebGLFloatBuffersStorage.subarray(0, i+1);\n'
     + '}\n',
 
   _miniTempWebGLIntBuffers: [],
@@ -29,7 +29,7 @@ var LibraryGL = {
     + '__miniTempWebGLIntBuffers[i] = __miniTempWebGLIntBuffersStorage.subarray(0, i+1);\n'
     + '}\n',
 
-  _heapObjectForWebGLType: function(type) {
+  $heapObjectForWebGLType: function(type) {
     // Micro-optimization for size: Subtract lowest GL enum number (0x1400/* GL_BYTE */) from type to compare
     // smaller values for the heap, for shorter generated code size.
     // Also the type HEAPU16 is not tested for explicitly, but any unrecognized type will return out HEAPU16.
@@ -68,13 +68,13 @@ var LibraryGL = {
         && type != {{{ 0x8034 - 0x1400 /* GL_UNSIGNED_SHORT_5_5_5_1 */ }}}
         && type != {{{ 0x8363 - 0x1400 /* GL_UNSIGNED_SHORT_5_6_5 */ }}}
         && type != {{{ 0x8D61 - 0x1400 /* GL_HALF_FLOAT_OES */ }}}) {
-        err('Invalid WebGL type 0x' + (type+0x1400).toString() + ' passed to _heapObjectForWebGLType!');
+        err('Invalid WebGL type 0x' + (type+0x1400).toString() + ' passed to $heapObjectForWebGLType!');
       }
 #endif
     return HEAPU16;
   },
 
-  _heapAccessShiftForWebGLHeap: function(heap) {
+  $heapAccessShiftForWebGLHeap: function(heap) {
     return 31 - Math.clz32(heap.BYTES_PER_ELEMENT);
   },
 
@@ -1475,7 +1475,7 @@ var LibraryGL = {
     GLctx['compressedTexSubImage2D'](target, level, xoffset, yoffset, width, height, format, data ? {{{ makeHEAPView('U8', 'data', 'data+imageSize') }}} : null);
   },
 
-  _computeUnpackAlignedImageSize: function(width, height, sizePerPixel, alignment) {
+  $computeUnpackAlignedImageSize: function(width, height, sizePerPixel, alignment) {
     function roundedToNextMultipleOf(x, y) {
 #if GL_ASSERTIONS
       assert((y & (y-1)) === 0, 'Unpack alignment must be a power of 2! (Allowed values per WebGL spec are 1, 2, 4 or 8)');
@@ -1521,13 +1521,13 @@ var LibraryGL = {
     return colorChannels[format - 0x1902]||1;
   },
 
-  $emscriptenWebGLGetTexPixelData__deps: ['_computeUnpackAlignedImageSize', '_colorChannelsInGlTextureFormat', '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'],
+  $emscriptenWebGLGetTexPixelData__deps: ['$computeUnpackAlignedImageSize', '_colorChannelsInGlTextureFormat', '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'],
   $emscriptenWebGLGetTexPixelData: function(type, format, width, height, pixels, internalFormat) {
-    var heap = __heapObjectForWebGLType(type);
-    var shift = __heapAccessShiftForWebGLHeap(heap);
+    var heap = heapObjectForWebGLType(type);
+    var shift = heapAccessShiftForWebGLHeap(heap);
     var byteSize = 1<<shift;
     var sizePerPixel = __colorChannelsInGlTextureFormat(format) * byteSize;
-    var bytes = __computeUnpackAlignedImageSize(width, height, sizePerPixel, GL.unpackAlignment);
+    var bytes = computeUnpackAlignedImageSize(width, height, sizePerPixel, GL.unpackAlignment);
 #if GL_ASSERTIONS
     assert((pixels >> shift) << shift == pixels, 'Pointer to texture data passed to texture get function must be aligned to the byte size of the pixel type!');
 #endif
@@ -1537,7 +1537,7 @@ var LibraryGL = {
   glTexImage2D__sig: 'viiiiiiiii',
   glTexImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
-                       , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
+                       , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
 #endif
   ],
   glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
@@ -1565,8 +1565,8 @@ var LibraryGL = {
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
       } else if (pixels) {
-        var heap = __heapObjectForWebGLType(type);
-        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, heap, pixels >> __heapAccessShiftForWebGLHeap(heap));
+        var heap = heapObjectForWebGLType(type);
+        GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, heap, pixels >> heapAccessShiftForWebGLHeap(heap));
       } else {
         GLctx.texImage2D(target, level, internalFormat, width, height, border, format, type, null);
       }
@@ -1579,7 +1579,7 @@ var LibraryGL = {
   glTexSubImage2D__sig: 'viiiiiiiii',
   glTexSubImage2D__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
-                          , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
+                          , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
 #endif
   ],
   glTexSubImage2D: function(target, level, xoffset, yoffset, width, height, format, type, pixels) {
@@ -1597,8 +1597,8 @@ var LibraryGL = {
       if (GLctx.currentPixelUnpackBufferBinding) {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, pixels);
       } else if (pixels) {
-        var heap = __heapObjectForWebGLType(type);
-        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, heap, pixels >> __heapAccessShiftForWebGLHeap(heap));
+        var heap = heapObjectForWebGLType(type);
+        GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, heap, pixels >> heapAccessShiftForWebGLHeap(heap));
       } else {
         GLctx.texSubImage2D(target, level, xoffset, yoffset, width, height, format, type, null);
       }
@@ -1613,7 +1613,7 @@ var LibraryGL = {
   glReadPixels__sig: 'viiiiiii',
   glReadPixels__deps: ['$emscriptenWebGLGetTexPixelData'
 #if MAX_WEBGL_VERSION >= 2
-                       , '_heapObjectForWebGLType', '_heapAccessShiftForWebGLHeap'
+                       , '$heapObjectForWebGLType', '$heapAccessShiftForWebGLHeap'
 #endif
   ],
   glReadPixels: function(x, y, width, height, format, type, pixels) {
@@ -1622,8 +1622,8 @@ var LibraryGL = {
       if (GLctx.currentPixelPackBufferBinding) {
         GLctx.readPixels(x, y, width, height, format, type, pixels);
       } else {
-        var heap = __heapObjectForWebGLType(type);
-        GLctx.readPixels(x, y, width, height, format, type, heap, pixels >> __heapAccessShiftForWebGLHeap(heap));
+        var heap = heapObjectForWebGLType(type);
+        GLctx.readPixels(x, y, width, height, format, type, heap, pixels >> heapAccessShiftForWebGLHeap(heap));
       }
       return;
     }
@@ -2392,7 +2392,7 @@ var LibraryGL = {
 
   glUniform1fv__sig: 'viii',
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
-  glUniform1fv__deps: ['_miniTempWebGLFloatBuffers'],
+  glUniform1fv__deps: ['$miniTempWebGLFloatBuffers'],
 #endif
   glUniform1fv: function(location, count, value) {
 #if GL_ASSERTIONS
@@ -2414,7 +2414,7 @@ var LibraryGL = {
 #if GL_POOL_TEMP_BUFFERS
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE }}}) {
       // avoid allocation when uploading few enough uniforms
-      var view = __miniTempWebGLFloatBuffers[count-1];
+      var view = miniTempWebGLFloatBuffers[count-1];
       for (var i = 0; i < count; ++i) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
       }
@@ -2432,7 +2432,7 @@ var LibraryGL = {
 
   glUniform2fv__sig: 'viii',
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
-  glUniform2fv__deps: ['_miniTempWebGLFloatBuffers'],
+  glUniform2fv__deps: ['$miniTempWebGLFloatBuffers'],
 #endif
   glUniform2fv: function(location, count, value) {
 #if GL_ASSERTIONS
@@ -2454,7 +2454,7 @@ var LibraryGL = {
 #if GL_POOL_TEMP_BUFFERS
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 2 }}}) {
       // avoid allocation when uploading few enough uniforms
-      var view = __miniTempWebGLFloatBuffers[2*count-1];
+      var view = miniTempWebGLFloatBuffers[2*count-1];
       for (var i = 0; i < 2*count; i += 2) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
@@ -2473,7 +2473,7 @@ var LibraryGL = {
 
   glUniform3fv__sig: 'viii',
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
-  glUniform3fv__deps: ['_miniTempWebGLFloatBuffers'],
+  glUniform3fv__deps: ['$miniTempWebGLFloatBuffers'],
 #endif
   glUniform3fv: function(location, count, value) {
 #if GL_ASSERTIONS
@@ -2495,7 +2495,7 @@ var LibraryGL = {
 #if GL_POOL_TEMP_BUFFERS
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 3 }}}) {
       // avoid allocation when uploading few enough uniforms
-      var view = __miniTempWebGLFloatBuffers[3*count-1];
+      var view = miniTempWebGLFloatBuffers[3*count-1];
       for (var i = 0; i < 3*count; i += 3) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
@@ -2515,7 +2515,7 @@ var LibraryGL = {
 
   glUniform4fv__sig: 'viii',
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
-  glUniform4fv__deps: ['_miniTempWebGLFloatBuffers'],
+  glUniform4fv__deps: ['$miniTempWebGLFloatBuffers'],
 #endif
   glUniform4fv: function(location, count, value) {
 #if GL_ASSERTIONS
@@ -2537,7 +2537,7 @@ var LibraryGL = {
 #if GL_POOL_TEMP_BUFFERS
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 4 }}}) {
       // avoid allocation when uploading few enough uniforms
-      var view = __miniTempWebGLFloatBuffers[4*count-1];
+      var view = miniTempWebGLFloatBuffers[4*count-1];
       // hoist the heap out of the loop for size and for pthreads+growth.
       var heap = HEAPF32;
       value >>= 2;
@@ -2562,7 +2562,7 @@ var LibraryGL = {
 
   glUniformMatrix2fv__sig: 'viiii',
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
-  glUniformMatrix2fv__deps: ['_miniTempWebGLFloatBuffers'],
+  glUniformMatrix2fv__deps: ['$miniTempWebGLFloatBuffers'],
 #endif
   glUniformMatrix2fv: function(location, count, transpose, value) {
 #if GL_ASSERTIONS
@@ -2584,7 +2584,7 @@ var LibraryGL = {
 #if GL_POOL_TEMP_BUFFERS
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 4 }}}) {
       // avoid allocation when uploading few enough uniforms
-      var view = __miniTempWebGLFloatBuffers[4*count-1];
+      var view = miniTempWebGLFloatBuffers[4*count-1];
       for (var i = 0; i < 4*count; i += 4) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
@@ -2605,7 +2605,7 @@ var LibraryGL = {
 
   glUniformMatrix3fv__sig: 'viiii',
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
-  glUniformMatrix3fv__deps: ['_miniTempWebGLFloatBuffers'],
+  glUniformMatrix3fv__deps: ['$miniTempWebGLFloatBuffers'],
 #endif
   glUniformMatrix3fv: function(location, count, transpose, value) {
 #if GL_ASSERTIONS
@@ -2627,7 +2627,7 @@ var LibraryGL = {
 #if GL_POOL_TEMP_BUFFERS
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 9 }}}) {
       // avoid allocation when uploading few enough uniforms
-      var view = __miniTempWebGLFloatBuffers[9*count-1];
+      var view = miniTempWebGLFloatBuffers[9*count-1];
       for (var i = 0; i < 9*count; i += 9) {
         view[i] = {{{ makeGetValue('value', '4*i', 'float') }}};
         view[i+1] = {{{ makeGetValue('value', '4*i+4', 'float') }}};
@@ -2653,7 +2653,7 @@ var LibraryGL = {
 
   glUniformMatrix4fv__sig: 'viiii',
 #if GL_POOL_TEMP_BUFFERS && MIN_WEBGL_VERSION == 1
-  glUniformMatrix4fv__deps: ['_miniTempWebGLFloatBuffers'],
+  glUniformMatrix4fv__deps: ['$miniTempWebGLFloatBuffers'],
 #endif
   glUniformMatrix4fv: function(location, count, transpose, value) {
 #if GL_ASSERTIONS
@@ -2675,7 +2675,7 @@ var LibraryGL = {
 #if GL_POOL_TEMP_BUFFERS
     if (count <= {{{ GL_POOL_TEMP_BUFFERS_SIZE / 16 }}}) {
       // avoid allocation when uploading few enough uniforms
-      var view = __miniTempWebGLFloatBuffers[16*count-1];
+      var view = miniTempWebGLFloatBuffers[16*count-1];
       // hoist the heap out of the loop for size and for pthreads+growth.
       var heap = HEAPF32;
       value >>= 2;
@@ -3561,17 +3561,17 @@ var LibraryGL = {
   glDrawElementsInstancedANGLE: 'glDrawElementsInstanced',
 
 
-  glDrawBuffers__deps: ['_tempFixedLengthArray'],
+  glDrawBuffers__deps: ['$tempFixedLengthArray'],
   glDrawBuffers__sig: 'vii',
   glDrawBuffers: function(n, bufs) {
 #if GL_ASSERTIONS
     assert(GLctx['drawBuffers'], 'Must have WebGL2 or WEBGL_draw_buffers extension to use drawBuffers');
 #endif
 #if GL_ASSERTIONS
-    assert(n < __tempFixedLengthArray.length, 'Invalid count of numBuffers=' + n + ' passed to glDrawBuffers (that many draw buffer points do not exist in GL)');
+    assert(n < tempFixedLengthArray.length, 'Invalid count of numBuffers=' + n + ' passed to glDrawBuffers (that many draw buffer points do not exist in GL)');
 #endif
 
-    var bufArray = __tempFixedLengthArray[n];
+    var bufArray = tempFixedLengthArray[n];
     for (var i = 0; i < n; i++) {
       bufArray[i] = {{{ makeGetValue('bufs', 'i*4', 'i32') }}};
     }

--- a/system/lib/compiler-rt/lib/asan/asan_flags.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_flags.cpp
@@ -134,7 +134,7 @@ void InitializeFlags() {
   // Override from Emscripten Module.
 #define MAKE_OPTION_LOAD(parser, name) \
     options = (char*) EM_ASM_INT({ \
-      return _emscripten_with_builtin_malloc(function () { \
+      return withBuiltinMalloc(function () { \
         return allocateUTF8(Module[name] || 0); \
       }); \
     }); \

--- a/system/lib/compiler-rt/lib/lsan/lsan.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan.cpp
@@ -87,7 +87,7 @@ static void InitializeFlags() {
   parser.ParseString(lsan_default_options);
 #if SANITIZER_EMSCRIPTEN
   char *options = (char*) EM_ASM_INT({
-    return _emscripten_with_builtin_malloc(function () {
+    return withBuiltinMalloc(function () {
       return allocateUTF8(Module['LSAN_OPTIONS'] || 0);
     });
   });

--- a/system/lib/compiler-rt/lib/ubsan/ubsan_flags.cpp
+++ b/system/lib/compiler-rt/lib/ubsan/ubsan_flags.cpp
@@ -81,7 +81,7 @@ void InitializeFlags() {
   // Override from environment variable.
 #if SANITIZER_EMSCRIPTEN
   char *options = (char*) EM_ASM_INT({
-    return _emscripten_with_builtin_malloc(function () {
+    return withBuiltinMalloc(function () {
       return allocateUTF8(Module['UBSAN_OPTIONS'] || 0);
     });
   });

--- a/tests/code_size/hello_webgl2_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl2_fastcomp_asmjs.json
@@ -1,12 +1,12 @@
 {
   "a.html": 580,
   "a.html.gz": 382,
-  "a.js": 5321,
-  "a.js.gz": 2510,
+  "a.js": 5204,
+  "a.js.gz": 2465,
   "a.mem": 321,
   "a.mem.gz": 219,
-  "a.asm.js": 9814,
-  "a.asm.js.gz": 3544,
-  "total": 16036,
-  "total_gz": 6655
+  "a.asm.js": 9750,
+  "a.asm.js.gz": 3517,
+  "total": 15855,
+  "total_gz": 6583
 }

--- a/tests/code_size/hello_webgl2_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl2_fastcomp_wasm.json
@@ -4,7 +4,7 @@
   "a.js": 5288,
   "a.js.gz": 2535,
   "a.wasm": 8004,
-  "a.wasm.gz": 4376,
+  "a.wasm.gz": 4373,
   "total": 13855,
-  "total_gz": 7288
+  "total_gz": 7285
 }

--- a/tests/code_size/hello_webgl_fastcomp_asmjs.json
+++ b/tests/code_size/hello_webgl_fastcomp_asmjs.json
@@ -1,12 +1,12 @@
 {
   "a.html": 580,
   "a.html.gz": 382,
-  "a.js": 4867,
-  "a.js.gz": 2353,
+  "a.js": 4696,
+  "a.js.gz": 2288,
   "a.mem": 321,
   "a.mem.gz": 219,
-  "a.asm.js": 9814,
-  "a.asm.js.gz": 3544,
-  "total": 15582,
-  "total_gz": 6498
+  "a.asm.js": 9750,
+  "a.asm.js.gz": 3517,
+  "total": 15347,
+  "total_gz": 6406
 }

--- a/tests/code_size/hello_webgl_fastcomp_wasm.json
+++ b/tests/code_size/hello_webgl_fastcomp_wasm.json
@@ -4,7 +4,7 @@
   "a.js": 4774,
   "a.js.gz": 2357,
   "a.wasm": 8004,
-  "a.wasm.gz": 4376,
+  "a.wasm.gz": 4373,
   "total": 13341,
-  "total_gz": 7110
+  "total_gz": 7107
 }

--- a/tests/code_size/random_printf_fastcomp_asmjs.json
+++ b/tests/code_size/random_printf_fastcomp_asmjs.json
@@ -1,6 +1,6 @@
 {
   "a.html": 2898,
-  "a.html.gz": 1224,
+  "a.html.gz": 1225,
   "total": 2898,
-  "total_gz": 1224
+  "total_gz": 1225
 }

--- a/tests/code_size/random_printf_fastcomp_wasm.json
+++ b/tests/code_size/random_printf_fastcomp_wasm.json
@@ -1,6 +1,6 @@
 {
   "a.html": 14026,
-  "a.html.gz": 7470,
+  "a.html.gz": 7484,
   "total": 14026,
-  "total_gz": 7470
+  "total_gz": 7484
 }


### PR DESCRIPTION
These functions are not reachable by native code and the
convension is that we prefix such functions with `$` (which means
don't mangle) and use camelCase.