### PR TITLE
Repair broken glVertexAttribIPointer in WebGL 2.

### DIFF
--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -946,7 +946,7 @@ var LibraryWebGL2 = {
 #if GL_ASSERTIONS
     assert(cb, index);
 #endif
-    if (!GL.currArrayBuffer) {
+    if (!GLctx.currentArrayBufferBinding) {
       cb.size = size;
       cb.type = type;
       cb.normalized = false;


### PR DESCRIPTION
This regressed when some state tracking was renamed and moved on May 26 via PR #11225, and the integer variant of glVertexAttribPointer was overlooked.

https://github.com/google/filament/issues/2856