### PR TITLE
Include legacy/err.c in musl libc build

### DIFF
--- a/tests/other/err/test.cpp
+++ b/tests/other/err/test.cpp
@@ -1,0 +1,6 @@
+#include <err.h>
+
+int main() {
+  warnx("hello warning %d\n", 42);
+  return 0;
+}

--- a/tests/other/err/test.out
+++ b/tests/other/err/test.out
@@ -1,0 +1,1 @@
+(null): hello warning 42

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10520,3 +10520,6 @@ int main () {
     time.sleep(2)
     two = self.run_js('a.out.js')
     self.assertIdentical(one, two)
+
+  def test_err(self):
+    self.do_other_test(os.path.join('other', 'err'))

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -789,7 +789,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         filenames=['clock_settime.c'])
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'legacy'],
-        filenames=['getpagesize.c'])
+        filenames=['getpagesize.c', 'err.c'])
 
     if shared.Settings.WASM_BACKEND:
       # See libc_extras below


### PR DESCRIPTION
This gives access to legecy warn and err functions

Fixes: #11752