### PR TITLE
Update code size tests and allow a little more slop

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 22332,
-  "a.js.gz": 8615,
+  "a.js": 22339,
+  "a.js.gz": 8620,
   "a.mem": 3168,
   "a.mem.gz": 2711,
   "total": 26088,
-  "total_gz": 11712
+  "total_gz": 11717
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21819,
-  "a.js.gz": 8448,
+  "a.js": 21826,
+  "a.js.gz": 8453,
   "a.mem": 3168,
   "a.mem.gz": 2711,
   "total": 25575,
-  "total_gz": 11545
+  "total_gz": 11550
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13715,
-  "a.html.gz": 7366,
+  "a.html": 13711,
+  "a.html.gz": 7321,
   "total": 13715,
-  "total_gz": 7366
+  "total_gz": 7321
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19537,
-  "a.html.gz": 8171,
+  "a.html": 19526,
+  "a.html.gz": 8162,
   "total": 19537,
-  "total_gz": 8171
+  "total_gz": 8162
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9417,7 +9417,7 @@ int main () {
             if js:
               slop = 30
             else:
-              slop = 10
+              slop = 20
           else:
             slop = 50
           if size <= expected_size + slop and size >= expected_size - slop:


### PR DESCRIPTION
More slop is now needed due to newer LLVM, just on Mac and Windows
for whatever reason...

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8873415336766169216/+/steps/Emscripten_testsuite__upstream__other_/0/stdout

https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8873415336766169232/+/steps/Emscripten_testsuite__upstream__other_/0/stdout