### PR TITLE
Remove SIMD builtin tests for widening ops

### DIFF
--- a/tests/test_wasm_builtin_simd.cpp
+++ b/tests/test_wasm_builtin_simd.cpp
@@ -560,30 +560,6 @@ i16x8 TESTFN i16x8_narrow_i32x4_s(i32x4 a, i32x4 b) {
 i16x8 TESTFN i16x8_narrow_i32x4_u(i32x4 a, i32x4 b) {
   return __builtin_wasm_narrow_u_i16x8_i32x4(a, b);
 }
-i16x8 TESTFN i16x8_widen_low_i8x16_s(i8x16 a) {
-  return __builtin_wasm_widen_low_s_i16x8_i8x16(a);
-}
-i16x8 TESTFN i16x8_widen_high_i8x16_s(i8x16 a) {
-  return __builtin_wasm_widen_high_s_i16x8_i8x16(a);
-}
-i16x8 TESTFN i16x8_widen_low_i8x16_u(i8x16 a) {
-  return __builtin_wasm_widen_low_u_i16x8_i8x16(a);
-}
-i16x8 TESTFN i16x8_widen_high_i8x16_u(i8x16 a) {
-  return __builtin_wasm_widen_high_u_i16x8_i8x16(a);
-}
-i32x4 TESTFN i32x4_widen_low_i16x8_s(i16x8 a) {
-  return __builtin_wasm_widen_low_s_i32x4_i16x8(a);
-}
-i32x4 TESTFN i32x4_widen_high_i16x8_s(i16x8 a) {
-  return __builtin_wasm_widen_high_s_i32x4_i16x8(a);
-}
-i32x4 TESTFN i32x4_widen_low_i16x8_u(i16x8 a) {
-  return __builtin_wasm_widen_low_u_i32x4_i16x8(a);
-}
-i32x4 TESTFN i32x4_widen_high_i16x8_u(i16x8 a) {
-  return __builtin_wasm_widen_high_u_i32x4_i16x8(a);
-}
 
 static int failures = 0;
 
@@ -1361,35 +1337,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ),
     ((i16x8){-32767, 32767, 0, -1, 0, 1, 0, 0})
   );
-  expect_vec(
-    i16x8_widen_low_i8x16_s(
-      (i8x16){0, 1, -1, -128, 127, 129, 64, -64, -64, 64, 129, 127, -128, -1, 1, 0}
-    ),
-    ((i16x8){0, 1, -1, -128, 127, -127, 64, -64})
-  );
-  expect_vec(
-    i16x8_widen_high_i8x16_s(
-      (i8x16){0, 1, -1, -128, 127, 129, 64, -64, -64, 64, 129, 127, -128, -1, 1, 0}
-    ),
-    ((i16x8){-64, 64, -127, 127, -128, -1, 1, 0})
-  );
-  expect_vec(
-    i16x8_widen_low_i8x16_u(
-      (i8x16){0, 1, -1, -128, 127, 129, 64, -64, -64, 64, 129, 127, -128, -1, 1, 0}
-    ),
-    ((i16x8){0, 1, 255, 128, 127, 129, 64, 192})
-  );
-  expect_vec(
-    i16x8_widen_high_i8x16_u(
-      (i8x16){0, 1, -1, -128, 127, 129, 64, -64, -64, 64, 129, 127, -128, -1, 1, 0}
-    ),
-    ((i16x8){192, 64, 129, 127, 128, 255, 1, 0})
-  );
-  expect_vec(i32x4_widen_low_i16x8_s((i16x8){0, 1, -1, -32768, 32767, -32767, 16384, -16384}), ((i32x4){0, 1, -1, -32768}));
-  expect_vec(i32x4_widen_high_i16x8_s((i16x8){0, 1, -1, -32768, 32767, -32767, 16384, -16384}), ((i32x4){32767, -32767, 16384, -16384}));
-  expect_vec(i32x4_widen_low_i16x8_u((i16x8){0, 1, -1, -32768, 32767, -32767, 16384, -16384}), ((i32x4){0, 1, 65535, 32768}));
-  expect_vec(i32x4_widen_high_i16x8_u((i16x8){0, 1, -1, -32768, 32767, -32767, 16384, -16384}), ((i32x4){32767, 32769, 16384, 49152}));
-
 
   if (failures == 0) {
     printf("Success!\n");


### PR DESCRIPTION
The builtin function that was previously being tested has been removed
in upstream clang and the portable code patterns that replaced it are
uninteresting to test here because they are long and already tested
via the intrinsics header.

This will unbreak CI.