### PR TITLE
Use warning for binaryen version check

### DIFF
--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -401,6 +401,9 @@ def inspect_code(headers, cpp_opts, structs, defines):
                                     '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0',
                                     '-s', 'STRICT=1',
                                     '-s', 'SINGLE_FILE=1']
+  # Default behavior for emcc is to warn for binaryen version check mismatches
+  # so we should try to match that behavior.
+  cmd += ['-Wno-error=version-check']
 
   # TODO(sbc): Remove this one we remove the test_em_config_env_var test
   cmd += ['-Wno-deprecated']


### PR DESCRIPTION
This is in line with the default emcc behavior. The problem is that otherwise we'd see this:

```
cache:INFO: generating system asset: generated_struct_info.json... (this will be cached in "/home/svenstaro/.emscripten_cache/wasm/generated_struct_info.json" for subsequent builds)
emcc: error: unexpected binaryen version: 95 (expected 93) [-Wversion-check] [-Werror]
FAIL: Compilation failed!: ['/usr/lib/emscripten/emcc', '-D_GNU_SOURCE', '-o', '/tmp/tmp4qoem2az.js', '/tmp/tmpkmdni3d6.c', '-O0', '--js-opts', '0', '--memory-init-file', '0', '-Werror', '-Wno-format', '-s', 'BOOTSTRAPPING_STRUCT_INFO=1', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0', '-s', 'STRICT=1', '-s', 'SINGLE_FILE=1']
```

However, this is unexpected as this only occur when the cache is rebuilt. If the cache already exists, then only a warning is emitted. This patch makes sure the general emscripten behavior is to emit a warning only.