### PR TITLE
Move table creation to a separate js file, and don't do it unnecessarily in standalone

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -48,17 +48,7 @@ var wasmMemory;
 // In the wasm backend, we polyfill the WebAssembly object,
 // so this creates a (non-native-wasm) table for us.
 #if WASM_BACKEND || WASM
-var wasmTable = new WebAssembly.Table({
-  'initial': {{{ getQuoted('WASM_TABLE_SIZE') }}},
-#if !ALLOW_TABLE_GROWTH
-#if WASM_BACKEND
-  'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}} + {{{ RESERVED_FUNCTION_POINTERS }}},
-#else
-  'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}},
-#endif
-#endif // WASM_BACKEND
-  'element': 'anyfunc'
-});
+#include "runtime_init_table.js"
 #endif // WASM_BACKEND || WASM
 
 #if USE_PTHREADS

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -106,17 +106,7 @@ assert(buffer instanceof SharedArrayBuffer, 'requested a shared WebAssembly.Memo
 #endif
 #endif
 
-var wasmTable = new WebAssembly.Table({
-  'initial': {{{ getQuoted('WASM_TABLE_SIZE') }}},
-#if !ALLOW_TABLE_GROWTH
-#if WASM_BACKEND
-  'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}} + {{{ RESERVED_FUNCTION_POINTERS }}},
-#else
-  'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}},
-#endif
-#endif // WASM_BACKEND
-  'element': 'anyfunc'
-});
+#include "runtime_init_table.js"
 
 #else
 

--- a/src/runtime_init_table.js
+++ b/src/runtime_init_table.js
@@ -1,0 +1,13 @@
+#if !STANDALONE_WASM // standalone wasm creates the table in the wasm
+var wasmTable = new WebAssembly.Table({
+  'initial': {{{ getQuoted('WASM_TABLE_SIZE') }}},
+#if !ALLOW_TABLE_GROWTH
+#if WASM_BACKEND
+  'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}} + {{{ RESERVED_FUNCTION_POINTERS }}},
+#else
+  'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}},
+#endif
+#endif // WASM_BACKEND
+  'element': 'anyfunc'
+});
+#endif


### PR DESCRIPTION
In standalone mode the table is created in the wasm.