### PR TITLE
Don't print backtrace when file_packager fails

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2585,7 +2585,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           file_args.append('--lz4')
         if options.use_preload_plugins:
           file_args.append('--use-preload-plugins')
-        file_code = run_process([shared.PYTHON, shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE).stdout
+        file_code = shared.check_call([shared.PYTHON, shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE).stdout
         options.pre_js = js_manipulation.add_files_pre_js(options.pre_js, file_code)
 
       # Apply pre and postjs files

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -254,12 +254,13 @@ def main():
         data_files.append({'srcpath': srcpath, 'dstpath': dstpath, 'mode': mode,
                            'explicit_dst_path': uses_at_notation})
       else:
-        print('Warning: ' + arg + ' does not exist, ignoring.', file=sys.stderr)
+        print('error: ' + arg + ' does not exist', file=sys.stderr)
+        return 1
     elif leading == 'exclude':
       excluded_patterns.append(arg)
     else:
       print('Unknown parameter:', arg, file=sys.stderr)
-      sys.exit(1)
+      return 1
 
   if (not force) and not data_files:
     has_preloaded = False


### PR DESCRIPTION
Use check_call rather than run_process to print a nice failure
message and exit cleanly.

Also error out if the input files are missing rather than just
warning.  Seems like passing non-existent files should be fatal.