### PR TITLE
Add support for `--preload-file` and under node

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -539,14 +539,12 @@ def main():
     remote_package_size = os.path.getsize(package_name)
     remote_package_name = os.path.basename(package_name)
     ret += r'''
-      var PACKAGE_PATH;
+      var PACKAGE_PATH = '';
       if (typeof window === 'object') {
         PACKAGE_PATH = window['encodeURIComponent'](window.location.pathname.toString().substring(0, window.location.pathname.toString().lastIndexOf('/')) + '/');
       } else if (typeof location !== 'undefined') {
         // worker
         PACKAGE_PATH = encodeURIComponent(location.pathname.toString().substring(0, location.pathname.toString().lastIndexOf('/')) + '/');
-      } else {
-        throw 'using preloaded data can only be done on a web page or in a web worker';
       }
       var PACKAGE_NAME = '%s';
       var REMOTE_PACKAGE_BASE = '%s';
@@ -730,6 +728,19 @@ def main():
 
     ret += r'''
       function fetchRemotePackage(packageName, packageSize, callback, errback) {
+        if (typeof process === 'object') {
+          fs = require('fs');
+          fs.readFile(packageName, function(err, contents) {
+            if (err) {
+              errback(err);
+            } else {
+              console.log('got data');
+              console.log(typeof contents.buffer);
+              callback(contents.buffer);
+            }
+          });
+          return;
+        }
         var xhr = new XMLHttpRequest();
         xhr.open('GET', packageName, true);
         xhr.responseType = 'arraybuffer';


### PR DESCRIPTION
I did this to all me to test the pre-load plugins which don't run
with `--embed-file`.  Is it worth landing this for testing reasons
alone.  Shoudl the preload plugins work under node?