### PR TITLE
Improve support for the wasm preloadPlugin

### DIFF
--- a/site/source/docs/api_reference/advanced-apis.rst
+++ b/site/source/docs/api_reference/advanced-apis.rst
@@ -91,7 +91,7 @@ Advanced File System API
 
 .. js:function:: FS.getMode(canRead, canWrite)
   FS.joinPath(parts, forceRelative)
-  FS.absolutePath(relative, base)
+  FS.absolutePath(relative)
   FS.standardizePath(path)
   FS.findObject(path, dontResolveLastLink)
   FS.createFolder(parent, name, canRead, canWrite)

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -238,7 +238,7 @@ var LibraryBrowser = {
       wasmPlugin['asyncWasmLoadPromise'] = new Promise(
         function(resolve, reject) { return resolve(); });
       wasmPlugin['canHandle'] = function(name) {
-        return !Module.noWasmDecoding && name.endsWith('.so');
+        return !Module.noWasmDecoding && (name.endsWith('.so') || name.endsWith('.wasm'));
       };
       wasmPlugin['handle'] = function(byteArray, name, onload, onerror) {
         // loadWebAssemblyModule can not load modules out-of-order, so rather

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1548,8 +1548,8 @@ FS.staticInit();` +
       if (forceRelative && path[0] == '/') path = path.substr(1);
       return path;
     },
-    absolutePath: function(relative, base) {
-      return PATH_FS.resolve(base, relative);
+    absolutePath: function(relative) {
+      return PATH_FS.resolve(relative);
     },
     standardizePath: function(path) {
       return PATH.normalize(path);

--- a/src/support.js
+++ b/src/support.js
@@ -159,6 +159,10 @@ function loadDynamicLibrary(lib, flags) {
     return flags.loadAsync ? Promise.resolve(handle) : handle;
   }
 
+  if (flags.fs) {
+    lib = flags.fs.absolutePath(lib);
+  }
+
   // allocate new DSO & handle
   handle = LDSO.nextHandle++;
   dso = {


### PR DESCRIPTION
- Add support for `.wasm` as well as `.so`.
- Make paths absolute since preload paths are albsolute.  Without this
  a preload of "/side.so" won't match a `dlopen` of "side.so".