### PR TITLE
Don't follow symlinks passed as inputs

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -257,9 +257,6 @@ class EmccOptions(object):
     # Linux & MacOS)
     self.output_eol = os.linesep
     self.binaryen_passes = []
-    # Whether we will expand the full path of any input files to remove any
-    # symlinks.
-    self.expand_symlinks = True
     self.no_entry = False
 
 
@@ -1158,8 +1155,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # https://bugs.python.org/issue1311
         if not os.path.exists(arg) and arg != os.devnull:
           exit_with_error('%s: No such file or directory ("%s" was expected to be an input file, based on the commandline arguments provided)', arg, arg)
-        if options.expand_symlinks and os.path.islink(arg):
-          arg = os.path.realpath(arg)
         file_suffix = get_file_suffix(arg)
         if file_suffix in SOURCE_ENDINGS + DYNAMICLIB_ENDINGS + ASSEMBLY_ENDINGS + HEADER_ENDINGS or building.is_ar(arg):
           # we already removed -o <target>, so all these should be inputs
@@ -3141,8 +3136,6 @@ def parse_args(newargs):
     elif newargs[i] in ('-fno-diagnostics-color', '-fdiagnostics-color=never'):
       colored_logger.disable()
       diagnostics.color_enabled = False
-    elif newargs[i] == '-no-canonical-prefixes':
-      options.expand_symlinks = False
     elif newargs[i] == '-fno-rtti':
       shared.Settings.USE_RTTI = 0
     elif newargs[i] == '-frtti':

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -996,22 +996,14 @@ int main() {
     os.symlink('foobar.xxx', 'foobar.c')
     self.run_process([EMCC, 'foobar.c', '-c', '-o', 'foobar.o'] + flags)
 
-  @parameterized({
-    'expand_symlinks': ([], True),
-    'no_canonical_prefixes': (['-no-canonical-prefixes'], False),
-  })
   @no_windows('Windows does not support symlinks')
-  def test_symlink_has_bad_suffix(self, flags, expect_success):
-    """Tests compiling a symlink where foobar.xxx points to foobar.c.
-
-    In this case, setting -no-canonical-prefixes will result in a build failure
-    due to the inappropriate file suffix on foobar.xxx."""
+  def test_symlink_has_bad_suffix(self):
+    """Tests that compiling foobar.xxx fails even if it points to foobar.c.
+    """
     create_test_file('foobar.c', 'int main(){ return 0; }')
     os.symlink('foobar.c', 'foobar.xxx')
-    proc = self.run_process([EMCC, 'foobar.xxx', '-o', 'foobar.js'] + flags, check=expect_success, stderr=PIPE)
-    if not expect_success:
-      self.assertNotEqual(proc.returncode, 0)
-      self.assertContained('unknown file type: foobar.xxx', proc.stderr)
+    err = self.expect_fail([EMCC, 'foobar.xxx', '-o', 'foobar.js'])
+    self.assertContained('unknown file type: foobar.xxx', err)
 
   def test_multiply_defined_libsymbols(self):
     lib_name = 'libA.c'


### PR DESCRIPTION
Both gcc and clang don't follow symlink and will fail
if run with `-c foo.xx` even if `foo.xx` links to `foo.c`

```
$ gcc hello.xxx -c
gcc: warning: hello.xxx: linker input file unused because linking not done
$ clang hello.xxx -c
clang: warning: hello.xxx: 'linker' input unused [-Wunused-command-line-argument]
```

This change builds on #9048 but goes further by simply
removing this expansion completely.
    
This symlink following was originally added in
8f4e931b7edb0755252ee23ff2c8f2edeec3aebd but I can't see any reason given.
