### PR TITLE
Honor `-shared` flag

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1193,6 +1193,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         else:
           newargs[i] = ''
           input_files.append((i, arg))
+      elif arg == '-shared':
+        # Until we have a better story for actually producing runtime shared libraries
+        # we support a compatibility mode where shared libraries are actually just
+        # object files linked with `wasm-ld --reloctable` or `llvm-link` in the case
+        # of LTO.
+        link_to_object = True
+        newargs[i] = ''
       elif arg == '-r':
         link_to_object = True
         newargs[i] = ''
@@ -1464,7 +1471,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if not link_to_object and not compile_only and final_suffix not in executable_endings:
       # TODO(sbc): Remove this emscripten-specific special case.  We should only generate object
       # file output with an explicit `-c` or `-r`.
-      diagnostics.warning('emcc', 'Assuming object file output in the absence of `-c`, based on output filename. Add with `-c` or `-r` to avoid this warning')
+      diagnostics.warning('emcc', 'assuming object file output, based on output filename alone.  Add an explict `-c`, `-r` or `-shared` to avoid this warning')
       link_to_object = True
 
     if shared.Settings.STACK_OVERFLOW_CHECK:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -505,7 +505,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # We also support building without the `-r` flag but expect a warning
     err = self.run_process([EMCC, 'twopart_main.o', 'twopart_side.o', '-o', 'combined2.o'], stderr=PIPE).stderr
     self.assertBinaryEqual('combined.o', 'combined2.o')
-    self.assertContained('warning: Assuming object file output in the absence of `-c`', err)
+    self.assertContained('warning: assuming object file output', err)
 
     # Should be two symbols (and in the wasm backend, also __original_main)
     syms = building.llvm_nm('combined.o')
@@ -10114,7 +10114,7 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     # Most compilers require the `-c` to be explicit.
     self.run_process([EMCC, path_from_root('tests', 'hello_world.cpp'), '-c', '-o', 'hello1.o'])
     err = self.run_process([EMCC, path_from_root('tests', 'hello_world.cpp'), '-o', 'hello2.o'], stderr=PIPE).stderr
-    self.assertContained('warning: Assuming object file output in the absence of `-c`', err)
+    self.assertContained('warning: assuming object file output', err)
     self.assertBinaryEqual('hello1.o', 'hello2.o')
 
   def test_empty_output_extension(self):


### PR DESCRIPTION
Today in emscripten "shared libraries" are just object files
and we assume we are linking a shared library wheneven the
file extension doesn't look like an exectuable.

Honoring this flag means that we can force this behavior
regardless of file extension.

This is the first in the chain of changes that seeks to make
emscripten less magical around linking shared libraries.

See #11796