### PR TITLE
tests: Explicitly include stdio.h in test_pthread_clock_drift

### DIFF
--- a/tests/pthread/test_pthread_clock_drift.cpp
+++ b/tests/pthread/test_pthread_clock_drift.cpp
@@ -7,6 +7,7 @@
 #include <emscripten.h>
 #include <emscripten/threading.h>
 #include <math.h>
+#include <stdio.h>
 
 volatile int threadStarted = 0;
 volatile int timeReceived = 0;


### PR DESCRIPTION
For `printf()` which is used in this test.