### PR TITLE
Update special handling of autoconf

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -808,9 +808,6 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     # use files, as PIPE can get too full and hang us
     stdout = self.in_dir('stdout')
     stderr = self.in_dir('stderr')
-    # Make sure that we produced proper line endings to the .js file we are about to run.
-    if not filename.endswith('.wasm'):
-      self.assertEqual(line_endings.check_line_endings(filename), 0)
     error = None
     if EMTEST_VERBOSE:
       print("Running '%s' under '%s'" % (filename, engine))
@@ -821,6 +818,10 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
                    assert_returncode=assert_returncode)
     except subprocess.CalledProcessError as e:
       error = e
+
+    # Make sure that we produced proper line endings to the .js file we are about to run.
+    if not filename.endswith('.wasm'):
+      self.assertEqual(line_endings.check_line_endings(filename), 0)
 
     out = open(stdout, 'r').read()
     err = open(stderr, 'r').read()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10524,3 +10524,11 @@ int main () {
     # Test that `-shared` forces object file output regardless of output filename
     self.run_process([EMCC, '-shared', path_from_root('tests', 'hello_world.c'), '-o', 'out.js'])
     self.assertIsObjectFile('out.js')
+
+  @no_windows('windows does not support shbang syntax')
+  @with_env_modify({'EMMAKEN_JUST_CONFIGURE': '1'})
+  def test_autoconf_mode(self):
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c')])
+    # Test that output name is just `a.out` and that it is directly executable
+    output = self.run_process([os.path.abspath('a.out')], stdout=PIPE).stdout
+    self.assertContained('hello, world!', output)

--- a/tools/scons/site_scons/site_tools/emscripten/emscripten.py
+++ b/tools/scons/site_scons/site_tools/emscripten/emscripten.py
@@ -22,7 +22,7 @@ def generate(env, emscripten_path=None, **kw):
   # by Emscripten to the child.
   for var in ['EM_CACHE', 'EMCC_DEBUG', 'EMSCRIPTEN_NATIVE_OPTIMIZER', 'EMTEST_BROWSER',
               'EMMAKEN_JUST_CONFIGURE', 'EMCC_CFLAGS', 'EMCC_TEMP_DIR',
-              'EMCC_AUTODEBUG', 'EMMAKEN_JUST_CONFIGURE_RECURSE',
+              'EMCC_AUTODEBUG',
               'EMMAKEN_COMPILER', 'EMMAKEN_CFLAGS', 'EMCC_JSOPT_BLACKLIST',
               'MOZ_DISABLE_AUTO_SAFE_MODE', 'EMCC_STDERR_FILE',
               'EMSCRIPTEN_SUPPRESS_USAGE_WARNING', 'NODE_PATH', 'EMCC_JSOPT_MIN_CHUNK_SIZE',

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -356,6 +356,7 @@ def parse_config_file():
     'CLANG_ADD_VERSION',
     'CLOSURE_COMPILER',
     'JAVA',
+    'JS_ENGINE',
     'JS_ENGINES',
     'WASMER',
     'WASMTIME',
@@ -401,11 +402,13 @@ def fix_js_engine(old, new):
 
 def normalize_config_settings():
   global CACHE, PORTS, JAVA, CLOSURE_COMPILER
-  global NODE_JS, V8_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
+  global NODE_JS, V8_ENGINE, JS_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
 
   # EM_CONFIG stuff
   if not JS_ENGINES:
     JS_ENGINES = [NODE_JS]
+  if not JS_ENGINE:
+    JS_ENGINE = JS_ENGINES[0]
 
   # Engine tweaks
   if SPIDERMONKEY_ENGINE:
@@ -415,6 +418,7 @@ def normalize_config_settings():
     SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, new_spidermonkey)
   NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
   V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
+  JS_ENGINE = fix_js_engine(JS_ENGINE, listify(JS_ENGINE))
   JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
   WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
   if not CACHE:
@@ -1726,6 +1730,7 @@ CLANG_ADD_VERSION = None
 CLOSURE_COMPILER = None
 EMSCRIPTEN_NATIVE_OPTIMIZER = None
 JAVA = None
+JS_ENGINE = None
 JS_ENGINES = []
 WASMER = None
 WASMTIME = None

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -72,7 +72,7 @@ def run_one_command(cmd):
   # building system libraries and ports should be hermetic in that it is not
   # affected by things like EMMAKEN_CFLAGS which the user may have set
   safe_env = os.environ.copy()
-  for opt in ['EMMAKEN_CFLAGS']:
+  for opt in ['EMMAKEN_CFLAGS', 'EMMAKEN_JUST_CONFIGURE']:
     if opt in safe_env:
       del safe_env[opt]
   # Disable certain warnings when we build ports/system libraries we don't want to


### PR DESCRIPTION
- Avoid running an inner emcc process.

- Separate out function for adding `#!` line.  We could add a user
  option for this if there is demand.

- Allow `#!` line to be configured via new JS_ENGINE setting.
  This is different from the plural JS_ENGINES used by test
  code since it never makes sense to have more than one.
  It also makes it easier to set vai the command line. For
  example to build something that is runnable under d8 you
  can just do:
    `EM_JS_ENGINE=d8 emcc hello.c -o out.js -sEXECUTABLE`
  This setting defaults to JS_ENGINES[0] which itself defaults
  to NODE_JS so it should be very rare that anyone actually
  needs to set this.