### PR TITLE
Let ASan libs supersede UBSan and LSan

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -520,6 +520,16 @@ jobs:
       - run-tests:
           # TODO: test wasms
           test_targets: "wasm3"
+  test-asan: # Temporary
+    executor: bionic
+    steps:
+      - run-tests:
+          test_targets: "asan"
+  test-lsan: # Temporary
+    executor: bionic
+    steps:
+      - run-tests:
+          test_targets: "lsan"
   test-wasm2js1:
     executor: bionic
     steps:
@@ -665,6 +675,12 @@ workflows:
           requires:
             - build-linux
       - test-wasm3:
+          requires:
+            - build-linux
+      - test-asan: # Temporary
+          requires:
+            - build-linux
+      - test-lsan: # Temporary
           requires:
             - build-linux
       - test-wasm2js1:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1661,20 +1661,21 @@ def calculate(temp_files, in_temp, cxx, forced, stdout_=None, stderr_=None):
     if shared.Settings.WASM_BACKEND:
       add_library(system_libs_map['libc_rt_wasm'])
 
-    if shared.Settings.UBSAN_RUNTIME == 1:
-      add_library(system_libs_map['libubsan_minimal_rt_wasm'])
-    elif shared.Settings.UBSAN_RUNTIME == 2:
-      add_library(system_libs_map['libubsan_rt_wasm'])
-
-    if shared.Settings.USE_LSAN:
-      force_include.add('liblsan_rt_wasm')
-      add_library(system_libs_map['liblsan_rt_wasm'])
-
     if shared.Settings.USE_ASAN:
       force_include.add('libasan_rt_wasm')
       add_library(system_libs_map['libasan_rt_wasm'])
       add_library(system_libs_map['libubsan_rt_wasm'])
       add_library(system_libs_map['libasan_js'])
+    else:
+      # The only need to be included if ASan was not already included
+      if shared.Settings.UBSAN_RUNTIME == 1:
+        add_library(system_libs_map['libubsan_minimal_rt_wasm'])
+      elif shared.Settings.UBSAN_RUNTIME == 2:
+        add_library(system_libs_map['libubsan_rt_wasm'])
+
+      if shared.Settings.USE_LSAN:
+        force_include.add('liblsan_rt_wasm')
+        add_library(system_libs_map['liblsan_rt_wasm'])
 
     if shared.Settings.USE_LSAN or shared.Settings.USE_ASAN:
       add_library(system_libs_map['liblsan_common_rt_wasm'])

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1666,19 +1666,20 @@ def calculate(temp_files, in_temp, cxx, forced, stdout_=None, stderr_=None):
       add_library(system_libs_map['libasan_rt_wasm'])
       add_library(system_libs_map['libubsan_rt_wasm'])
       add_library(system_libs_map['libasan_js'])
+
+    if shared.Settings.USE_LSAN:
+      force_include.add('liblsan_rt_wasm')
+      add_library(system_libs_map['liblsan_rt_wasm'])
+      add_library(system_libs_map['libubsan_rt_wasm'])
+
+    if shared.Settings.USE_LSAN or shared.Settings.USE_ASAN:
+      add_library(system_libs_map['liblsan_common_rt_wasm'])
     else:
-      # The only need to be included if ASan was not already included
+      # UBSan is already included in ASan and LSan
       if shared.Settings.UBSAN_RUNTIME == 1:
         add_library(system_libs_map['libubsan_minimal_rt_wasm'])
       elif shared.Settings.UBSAN_RUNTIME == 2:
         add_library(system_libs_map['libubsan_rt_wasm'])
-
-      if shared.Settings.USE_LSAN:
-        force_include.add('liblsan_rt_wasm')
-        add_library(system_libs_map['liblsan_rt_wasm'])
-
-    if shared.Settings.USE_LSAN or shared.Settings.USE_ASAN:
-      add_library(system_libs_map['liblsan_common_rt_wasm'])
 
     if sanitize:
       add_library(system_libs_map['libsanitizer_common_rt_wasm'])


### PR DESCRIPTION
The trybots that run the "asan" testsuite have been failing the ubsan tests because the asan and ubsan runtime libraries are exporting duplicate symbols. This PR changes the lsan and ubsan runtime libraries to only be pulled in if the asan libraries are not already pulled in to avoid duplicate symbols. This change is meant to be consistent with how the runtime libraries are linked when using the native sanitizers.