### PR TITLE
Add option to disable runtime env detection

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -492,3 +492,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Colin Guyon <colin.guyon@insimo.fr> (copyright owned by InSimo, SAS)
 * Philip Rideout <prideout@google.com> (copyright owned by Google, LLC)
 * Shrek Shao (shrekshao@google.com) (copyright owned by Google, LLC)
+* Antoine du Hamel <duhamelantoine1995@gmail.com>

--- a/src/settings.js
+++ b/src/settings.js
@@ -631,6 +631,11 @@ var LEGACY_VM_SUPPORT = 0;
 //    at compile time, there is no runtime behavior change.
 var ENVIRONMENT = '';
 
+// Disables the runtime detection of the environment. Use this option if you
+// want to distribute separate files for each environment, you can use an
+// external tool to define the ENVIRONMENT_IS_* variables as globals.
+var DISABLE_ENVIRONMENT_RUNTIME_DETECTION = 0;
+
 // Enable this to support lz4-compressed file packages. They are stored compressed in memory, and
 // decompressed on the fly, avoiding storing the entire decompressed data in memory at once.
 // If you run the file packager separately, you still need to build the main program with this flag,

--- a/src/shell.js
+++ b/src/shell.js
@@ -83,6 +83,7 @@ var quit_ = function(status, toThrow) {
 // Determine the runtime environment we are in. You can customize this by
 // setting the ENVIRONMENT setting at compile time (see settings.js).
 
+#if !DISABLE_ENVIRONMENT_RUNTIME_DETECTION
 #if ENVIRONMENT && ENVIRONMENT.indexOf(',') < 0
 var ENVIRONMENT_IS_WEB = {{{ ENVIRONMENT === 'web' }}};
 var ENVIRONMENT_IS_WORKER = {{{ ENVIRONMENT === 'worker' }}};
@@ -100,6 +101,7 @@ ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
 ENVIRONMENT_IS_NODE = typeof process === 'object' && typeof process.versions === 'object' && typeof process.versions.node === 'string';
 ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
 #endif // ENVIRONMENT
+#endif // DISABLE_ENVIRONMENT_RUNTIME_DETECTION
 
 #if ASSERTIONS
 if (Module['ENVIRONMENT']) {

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -27,6 +27,7 @@ Module['ready'] = new Promise(function(resolve, reject) {
 #endif
 #endif
 
+#if !DISABLE_ENVIRONMENT_RUNTIME_DETECTION
 #if ENVIRONMENT_MAY_BE_NODE
 var ENVIRONMENT_IS_NODE = typeof process === 'object';
 #endif
@@ -43,6 +44,7 @@ var ENVIRONMENT_IS_WEB = true
 var ENVIRONMENT_IS_WEB = {{{ ENVIRONMENT === 'web' }}};
 #else
 var ENVIRONMENT_IS_WEB = !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_SHELL;
+#endif
 #endif
 #endif
 #endif


### PR DESCRIPTION
To reduce the size of the dist files, I like to distribute different files for each env and remove dead code when I can.

Currently, it's possible to use the `ENVIRONMENT` flag to remove the runtime check, but that only works when specifying one environment. When several envs are passed to the compiler (E.G.: `-s ENVIRONMENT=node,worker`), the compiler injects all the runtime checks, even for the env that are not in the list.

This PR proposes a new option to disable those runtime checks, and leave the burden of defining them to the user.

FWIW here is how I'm intending to use it:
```shell
$ terser --toplevel -d ENVIRONMENT_HAS_NODE=false -d ENVIRONMENT_IS_NODE=false \
		-d ENVIRONMENT_IS_WEB=true -d ENVIRONMENT_IS_WORKER=true \
                build/lib.js > dist/worker.js
$ terser --toplevel -d ENVIRONMENT_HAS_NODE=true -d ENVIRONMENT_IS_NODE=true \
		-d ENVIRONMENT_IS_WEB=false -d ENVIRONMENT_IS_WORKER=false \
                build/lib.js > dist/node.js
```