### PR TITLE
Revert the behaviour of the `-shared` flag if an executable suffix is…

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1435,7 +1435,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # object files linked with `wasm-ld --relocatable` or `llvm-link` in the case
       # of LTO.
       if final_suffix in executable_endings:
-        diagnostics.warning('emcc', '-shared/-r used with executable output suffix. This behaviour is deprecated.  Please remove -shared/-r to build an exectuable or avoid the executable suffset (%s) when building object files.' % final_suffix)
+        diagnostics.warning('emcc', '-shared/-r used with executable output suffix. This behaviour is deprecated.  Please remove -shared/-r to build an executable or avoid the executable suffix (%s) when building object files.' % final_suffix)
       else:
         link_to_object = True
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10521,9 +10521,14 @@ int main () {
     self.do_other_test(os.path.join('other', 'err'))
 
   def test_shared_flag(self):
-    # Test that `-shared` forces object file output regardless of output filename
-    self.run_process([EMCC, '-shared', path_from_root('tests', 'hello_world.c'), '-o', 'out.js'])
-    self.assertIsObjectFile('out.js')
+    self.run_process([EMCC, '-shared', path_from_root('tests', 'hello_world.c'), '-o', 'out.foo'])
+    self.assertIsObjectFile('out.foo')
+
+    # Test that using an exectuable output name overides the `-shared` flag, but produces a warning.
+    err = self.run_process([EMCC, '-shared', path_from_root('tests', 'hello_world.c'), '-o', 'out.js'],
+                           stderr=PIPE).stderr
+    self.assertContained('warning: -shared/-r used with executable output suffix', err)
+    self.run_js('out.js')
 
   @no_windows('windows does not support shbang syntax')
   @with_env_modify({'EMMAKEN_JUST_CONFIGURE': '1'})


### PR DESCRIPTION
… provided

We recently started to honor the `-shared` flag in #11798.  This
meant outputing an object file rather than an executable in this
case.

However, we had at least one user who was using `-shared` in combination
with `.js` output file and was expecting an executable to
be produced.