### PR TITLE
Followup on addition of emscripten_stack_get_free

### DIFF
--- a/src/library_stack.js
+++ b/src/library_stack.js
@@ -54,11 +54,15 @@ mergeInto(LibraryManager.library, {
 
   // With the wasm backend, these functions are implemented as native
   // functions in compiler-rt/stack_ops.s
+  emscripten_stack_init__sig: 'v',
+  emscripten_stack_init: function() { },
+
   emscripten_stack_get_current__asm: true,
   emscripten_stack_get_current__sig: 'i',
   emscripten_stack_get_current: function() {
     return STACKTOP|0;
   },
+
   emscripten_stack_get_free__asm: true,
   emscripten_stack_get_free__sig: 'i',
   emscripten_stack_get_free: function() {

--- a/system/include/emscripten/stack.h
+++ b/system/include/emscripten/stack.h
@@ -29,7 +29,15 @@ uintptr_t emscripten_stack_get_end(void);
 // Returns the current stack pointer.
 uintptr_t emscripten_stack_get_current(void);
 
-// Returns the number of free bytes left on the stack.
+// Setup internal state such that emscripten_stack_get_free can be used.
+// This needed until we can fix:
+// https://github.com/emscripten-core/emscripten/issues/11773
+void emscripten_stack_init(void);
+
+// Returns the number of free bytes left on the stack. This is required to be
+// fast so that it can be called frequetly. To enable it to the fewest wasm
+// instructions possible this function currently relies on
+// `emscripten_stack_init` being called because it returns meaningful vaules.
 size_t emscripten_stack_get_free(void);
 
 #ifdef __cplusplus

--- a/system/include/emscripten/stack.h
+++ b/system/include/emscripten/stack.h
@@ -34,10 +34,9 @@ uintptr_t emscripten_stack_get_current(void);
 // https://github.com/emscripten-core/emscripten/issues/11773
 void emscripten_stack_init(void);
 
-// Returns the number of free bytes left on the stack. This is required to be
-// fast so that it can be called frequetly. To enable it to the fewest wasm
-// instructions possible this function currently relies on
-// `emscripten_stack_init` being called because it returns meaningful vaules.
+// Returns the number of free bytes left on the stack.  This is required to be
+// fast so that it can be called frequently and requires `emscripten_stack_init`
+// to be called before it will return accurate values.
 size_t emscripten_stack_get_free(void);
 
 #ifdef __cplusplus

--- a/system/lib/compiler-rt/stack_ops.s
+++ b/system/lib/compiler-rt/stack_ops.s
@@ -1,6 +1,7 @@
 .globl stackSave
 .globl stackRestore
 .globl stackAlloc
+.globl emscripten_stack_init
 .globl emscripten_stack_get_current
 .globl emscripten_stack_get_free
 
@@ -43,15 +44,16 @@ emscripten_stack_get_current:
 .globaltype __stack_end, i32
 __stack_end:
 
+emscripten_stack_init:
+  # initialize __stack_end such that future calls to emscripten_stack_get_free
+  # use the correct value.
+  .functype emscripten_stack_init () -> ()
+  call emscripten_stack_get_end
+  global.set __stack_end
+  end_function
+
 emscripten_stack_get_free:
-  # set __stack_base/__stack_end on first call
   .functype emscripten_stack_get_free () -> (i32)
-  global.get __stack_end
-  i32.eqz
-  if
-    call emscripten_stack_get_end
-    global.set __stack_end
-  end_if
   global.get __stack_pointer
   global.get __stack_end
   i32.sub

--- a/tests/core/test_stack_get_free.c
+++ b/tests/core/test_stack_get_free.c
@@ -25,6 +25,7 @@ void TestStackValidity() {
 int increment = 256 * 1024;
 
 int main() {
+  emscripten_stack_init();
   TestStackValidity();
 
   uintptr_t origFree = emscripten_stack_get_free();


### PR DESCRIPTION
This is a followup on #11437 which added this API.  Sadly, as of today,
the linker doesn't know the final memory layout so until we fix #11773
this extra `init` function is needed.

The alternative, which is to modify binaryen and emscripten to inject
the stack end value post-link is IMHO way to much complexity to justify
the convenience of not having the call this init function.

Once we fix #11773 the init function can become uneeded/no-op.