### PR TITLE
Fix default setting of EXIT_RUNTIME in standalone mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1292,9 +1292,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # See https://github.com/WebAssembly/WASI/blob/master/design/application-abi.md
       # For a command we always want EXIT_RUNTIME=1
       # For a reactor we always want EXIT_RUNTIME=0
-      if 'EXIT_RUNTIME' in settings_changes:
+      if 'EXIT_RUNTIME' in settings_key_changes:
         exit_with_error('Explictly setting EXIT_RUNTIME not compatible with STANDALONE_WASM.  EXIT_RUNTIME will always be True for programs (with a main function) and False for reactors (not main function).')
-      shared.Settings.EXIT_RUNTIME = not shared.Settings.EXPECT_MAIN
+      shared.Settings.EXIT_RUNTIME = shared.Settings.EXPECT_MAIN
 
     def filter_out_dynamic_libs(inputs):
       # If not compiling to JS, then we are compiling to an intermediate bitcode

--- a/tests/other/metadce/libcxxabi_message_O3_STANDALONE_WASM.funcs
+++ b/tests/other/metadce/libcxxabi_message_O3_STANDALONE_WASM.funcs
@@ -1,1 +1,2 @@
+$__wasm_call_ctors
 $_start

--- a/tests/other/metadce/mem_O3_ALLOW_MEMORY_GROWTH_STANDALONE_WASM.funcs
+++ b/tests/other/metadce/mem_O3_ALLOW_MEMORY_GROWTH_STANDALONE_WASM.funcs
@@ -1,4 +1,5 @@
 $__main_void
+$__wasm_call_ctors
 $_start
 $dlmalloc
 $emscripten_resize_heap

--- a/tests/other/metadce/mem_O3_STANDALONE_WASM.funcs
+++ b/tests/other/metadce/mem_O3_STANDALONE_WASM.funcs
@@ -1,4 +1,5 @@
 $__main_void
+$__wasm_call_ctors
 $_start
 $dlmalloc
 $sbrk

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM.funcs
@@ -1,3 +1,4 @@
+$__wasm_call_ctors
 $_start
 $dlmalloc
 $sbrk

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
@@ -1,2 +1,3 @@
+$__wasm_call_ctors
 $_start
 $dlmalloc

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2458,7 +2458,9 @@ The current type of b is: 9
   @also_with_standalone_wasm()
   def test_atexit(self):
     # Confirms they are called in the proper reverse order
-    self.set_setting('EXIT_RUNTIME', 1)
+    if not self.get_setting('STANDALONE_WASM'):
+      # STANDALONE_WASM mode always sets EXIT_RUNTIME if main exists
+      self.set_setting('EXIT_RUNTIME', 1)
     self.do_run_in_out_file_test('tests', 'core', 'test_atexit')
 
   def test_atexit_threads(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7936,7 +7936,7 @@ int main() {
                            [], [], 128), # noqa
     # argc/argv support code etc. is in the wasm
     'O3_standalone':      ('libcxxabi_message.cpp', ['-O3', '-s', 'STANDALONE_WASM'],
-                           [], [], 174), # noqa
+                           [], [], 198), # noqa
   })
   @no_fastcomp()
   def test_metadce_libcxxabi_message(self, filename, *args):


### PR DESCRIPTION
EXIT_RUNTIME should be true if there is a main function and
false if now.  The logic here was inverted.