### PR TITLE
CMake toolchain file should cache CMAKE_*_COMPILER

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -86,10 +86,10 @@ endif()
 
 # Specify the compilers to use for C and C++
 if ("${CMAKE_C_COMPILER}" STREQUAL "")
-  set(CMAKE_C_COMPILER "${EMSCRIPTEN_ROOT_PATH}/emcc${EMCC_SUFFIX}")
+  set(CMAKE_C_COMPILER "${EMSCRIPTEN_ROOT_PATH}/emcc${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten emcc")
 endif()
 if ("${CMAKE_CXX_COMPILER}" STREQUAL "")
-  set(CMAKE_CXX_COMPILER "${EMSCRIPTEN_ROOT_PATH}/em++${EMCC_SUFFIX}")
+  set(CMAKE_CXX_COMPILER "${EMSCRIPTEN_ROOT_PATH}/em++${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten em++")
 endif()
 
 if ("${CMAKE_AR}" STREQUAL "")


### PR DESCRIPTION
Similarly to other `CMAKE_*_COMPILER_*` variables, cache `CMAKE_C_COMPILER` and `CMAKE_CXX_COMPILER`.

Noticed this while trying to build with VSCode and the CMake extension which seems to rely on it.
I think this is needed only because we are forcing compilers with `EMSCRIPTEN_FORCE_COMPILERS`?
