### PR TITLE
Document embind requirements for array fields

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -205,6 +205,11 @@ Consider the example below:
         int age;
     };
 
+	// Array fields are treated as if they were std::array<type,size>
+	struct ArrayInStruct {
+		int field[2];
+	};
+
     PersonRecord findPersonAtLocation(Point2f);
 
     EMSCRIPTEN_BINDINGS(my_value_example) {
@@ -217,6 +222,16 @@ Consider the example below:
             .field("name", &PersonRecord::name)
             .field("age", &PersonRecord::age)
             ;
+
+		value_object<ArrayInStruct>("ArrayInStruct")
+			.field("field", &ArrayInStruct::field) // Need to register the array type
+			;
+
+		// Register std::array<int, 2> because ArrayInStruct::field is interpreted as such
+		value_array<std::array<int, 2>>("array_int_2")
+			.element(index<0>())
+			.element(index<1>())
+			;
 
         function("findPersonAtLocation", &findPersonAtLocation);
     }


### PR DESCRIPTION
#4510 Added support for raw array fields by interpreting them as a std::array.
However, while mentioned in the pull request, it was not documented that you still have to register the std::array type.