### PR TITLE
Stop testing fastcomp on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,6 @@ executors:
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
       PYTHON_BIN: "python3"
-      EMCC_ALLOW_FASTCOMP: "1"
   mac:
     environment:
       EMSDK_NOTTY: "1"
@@ -311,49 +310,6 @@ commands:
             python3 tests/runner.py sockets
 
 jobs:
-  build-fastcomp:
-    executor: bionic
-    steps:
-      - checkout
-      - run:
-          name: install emsdk
-          command: |
-            curl -# -L -o ~/emsdk-master.tar.gz https://github.com/emscripten-core/emsdk/archive/master.tar.gz
-            tar -C ~ -xf ~/emsdk-master.tar.gz
-            mv ~/emsdk-master ~/emsdk
-            cd ~/emsdk
-            ./emsdk update-tags
-            ./emsdk install tot-fastcomp
-            ./emsdk activate tot-fastcomp
-            # Remove the emsdk version of emscripten to save space in the
-            # persistent workspace and to avoid any confusion with the version
-            # we are trying to test.
-            rm -Rf emscripten
-            # We use an out-of-tree cache directory so it can be part of the
-            # persisted workspace (see below).
-            echo "import os" >> .emscripten
-            echo "CACHE = os.path.expanduser('~/cache')" >> .emscripten
-            cd -
-            echo "final .emscripten:"
-            cat ~/emsdk/.emscripten
-      - emsdk-env
-      - npm-install
-      - run:
-          name: embuilder build ALL
-          command: |
-            python3 ./embuilder.py build ALL
-            python3 tests/runner.py test_hello_world
-      - run:
-          name: freeze cache
-          command: |
-            echo "FROZEN_CACHE=True" >> ~/emsdk/.emscripten
-      - persist_to_workspace:
-          # Must be an absolute path, or relative path from working_directory
-          root: ~/
-          # Must be relative path from root
-          paths:
-            - emsdk/
-            - cache/
   build-docs:
     executor: bionic
     steps:
@@ -372,92 +328,6 @@ jobs:
       - run: pip3 install flake8==3.7.8
       - run: python2 -m flake8 --show-source --statistics
       - run: python3 -m flake8 --show-source --statistics
-  test-fastcomp-other:
-    executor: bionic
-    steps:
-      - run-tests:
-          # some native-dependent tests fail because of the lack of native
-          # headers on emsdk-bundled clang>
-          # CircleCI actively kills memory-over-consuming process skip llvm-lit
-          # tests which need lit, and pip to get lit, but pip has broken on CI
-          test_targets: "other skip:other.test_native_link_error_message skip:other.test_emcc_v"
-  test-fastcomp-browser-firefox:
-    executor: bionic
-    steps:
-      - test-firefox
-  test-fastcomp-browser-chrome:
-    executor: bionic
-    steps:
-      - test-chrome
-  test-fastcomp-ab:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "asm*.test_a* asm*.test_b*"
-  test-fastcomp-c:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "asm*.test_c*"
-  test-fastcomp-d:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "default.test_d* asm1.test_d* asm2.test_d* asm2g.test_d* asm3.test_d*"
-  test-fastcomp-e:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "asm*.test_e*"
-  test-fastcomp-f:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "asm*.test_f*"
-  test-fastcomp-ghi:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "asm*.test_g* asm*.test_h* asm*.test_i*"
-  test-fastcomp-jklmno:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "asm*.test_j* asm*.test_k* asm*.test_l* asm*.test_m* asm*.test_n* asm*.test_o*"
-  test-fastcomp-p:
-    executor: bionic
-    environment:
-      # Without this test_poppler can cause timeouts because it takes more then
-      # 10 minutes without outputing anything.
-      EM_BUILD_VERBOSE: "2"
-    steps:
-      - run-tests:
-          test_targets: "default.test_p* asm1.test_p* asm2.test_p* asm2g.test_p* asm3.test_p*"
-  test-fastcomp-qrst:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "asm*.test_q* asm*.test_r* asm*.test_s* asm*.test_t*"
-  test-fastcomp-uvwxyz:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "asm*.test_u* asm*.test_w* asm*.test_v* asm*.test_x* asm*.test_y* asm*.test_z*"
-  test-fastcomp-wasm0:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "wasm0"
-  test-fastcomp-wasm2:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "wasm2"
-  test-fastcomp-wasm3:
-    executor: bionic
-    steps:
-      - run-tests:
-          test_targets: "wasm3"
   test-sanity:
     executor: bionic
     steps:
@@ -530,7 +400,8 @@ jobs:
     executor: bionic
     steps:
       - run-tests:
-          # see explanations in the fastcomp skips for these, earlier
+          # some native-dependent tests fail because of the lack of native
+          # headers on emsdk-bundled clang
           test_targets: "other skip:other.test_native_link_error_message"
   test-browser-chrome:
     executor: bionic
@@ -606,55 +477,6 @@ workflows:
     jobs:
       - flake8
       - build-docs
-      - build-fastcomp
-      - test-fastcomp-other:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-browser-firefox:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-browser-chrome:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-ab:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-c:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-d:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-e:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-f:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-ghi:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-jklmno:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-p:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-qrst:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-uvwxyz:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-wasm0:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-wasm2:
-          requires:
-            - build-fastcomp
-      - test-fastcomp-wasm3:
-          requires:
-            - build-fastcomp
       - build-linux
       - test-sanity:
           requires:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,15 +18,6 @@ See docs/process.md for how version tagging works.
 Current Trunk
 -------------
 
-2.0.0: ??/??/????
------------------
-- First release that only supports the new upstream wasm backend (which has been
-  the default for a long time) and no longer supports the old fastcomp backend.
-  (#11319)
-- Store exceptions metadata in wasm memory instead of JS. This makes exception
-  handling almost 100% thread-safe. (#11518)
-
-
 1.40.1: 08/01/2020
 ------------------
 - Last release that still has optional support for the old fastcomp backend.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,15 @@ See docs/process.md for how version tagging works.
 Current Trunk
 -------------
 
+2.0.0: ??/??/????
+-----------------
+- First release that only supports the new upstream wasm backend (which has been
+  the default for a long time) and no longer supports the old fastcomp backend.
+  (#11319)
+- Store exceptions metadata in wasm memory instead of JS. This makes exception
+  handling almost 100% thread-safe. (#11518)
+
+
 1.40.1: 08/01/2020
 ------------------
 - Last release that still has optional support for the old fastcomp backend.


### PR DESCRIPTION
Soon the emsdk will disallow tot-fastcomp, and waterfall builds
will not contain fastcomp.

Also prepare the changelog for the eventual 2.0.0