### PR TITLE
CI: Don't build all libraries and freeze the cache on Windows and Mac

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,6 +106,7 @@ commands:
             echo "FROZEN_CACHE=True" >> ~/emsdk/.emscripten
   persist:
     description: "Persist the emsdk, libraries, and engines"
+    steps:
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory
           root: ~/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
     steps:
       - run: npm ci
   build:
-    description: "Install emsdk build all libraries using embuilder"
+    description: "Install emsdk"
     steps:
       - run:
           name: install emsdk
@@ -77,6 +77,9 @@ commands:
             # debugging the issue is tricky.
             [ "$CIRCLE_JOB" != "build-windows" ] && $PYTHON_BIN ./tools/gen_struct_info.py > out.json
             $PYTHON_BIN ./emcc.py --clear-cache
+  build-libs-and-freeze:
+    description: "Build all libraries, and freeze the cache"
+    steps:
       - run:
           name: embuilder build ALL
           command: |
@@ -101,6 +104,8 @@ commands:
           name: freeze cache
           command: |
             echo "FROZEN_CACHE=True" >> ~/emsdk/.emscripten
+  persist:
+    description: "Persist the emsdk, libraries, and engines"
       - persist_to_workspace:
           # Must be an absolute path, or relative path from working_directory
           root: ~/
@@ -360,6 +365,8 @@ jobs:
             export PATH="${HOME}/.jsvu:${PATH}"
             jsvu --os=default --engines=v8
       - build
+      - build-libs-and-freeze
+      - persist
   test-wasm0:
     executor: bionic
     steps:
@@ -419,6 +426,9 @@ jobs:
           name: Add python to bash path
           command: echo "export PATH=\"$PATH:/c/python38/\"" >> $BASH_ENV
       - build
+      # note we do *not* build all libraries and freeze the cache; as we run
+      # only limited tests here, it's more efficient to build on demand
+      - persist
   test-minimal-windows:
     environment:
       # on windows the python binary is always called python.exe and never
@@ -451,6 +461,9 @@ jobs:
           command: brew install python3 cmake
       - checkout
       - build
+      # note we do *not* build all libraries and freeze the cache; as we run
+      # only limited tests here, it's more efficient to build on demand
+      - persist
   test-other-mac:
     executor: mac
     steps:


### PR DESCRIPTION
On those platforms we just run a subset of tests, which don't need most
of those libraries, so it's not helpful to build everything up front (which it
is on Linux, where we run the great majority of our tests in multiple jobs).

Before this window took 39 minutes to build and 5 to test, and with this
it takes 6 and 6 (so the test time increases very little, and most of the
build time is gone).

On mac the win is less extreme, it was 23 to build and 13 to test, and
with this it takes 2 to build and 20 to test (so test increases significantly,
but still worth it given the big build speedup).

A downside is that we don't test building libraries on those OSes. As
it's done mostly in pure python anyhow, this is probably not a big
deal (e.g. harfbuzz is an exception and uses cmake, but we hope to
change that too eventually).

Fixes #11840