### PR TITLE
Fix #10986: webidl_binder.py drops turds

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -494,3 +494,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Mathias Westerdahl <mwesterdahl76@gmail.com>
 * Philip Rideout <prideout@google.com> (copyright owned by Google, LLC)
 * Shrek Shao (shrekshao@google.com) (copyright owned by Google, LLC)
+* Arran Ireland <ion92@protonmail.com>

--- a/third_party/WebIDL.py
+++ b/third_party/WebIDL.py
@@ -4910,11 +4910,12 @@ class Parser(Tokenizer):
 
     def __init__(self, outputdir='', lexer=None):
         Tokenizer.__init__(self, outputdir, lexer)
-        self.parser = yacc.yacc(module=self,
+        self.parser = yacc.yacc(debug=0,
+                                module=self,
                                 outputdir=outputdir,
                                 tabmodule='webidlyacc',
-                                errorlog=yacc.NullLogger(),
-                                picklefile='WebIDLGrammar.pkl')
+                                write_tables=0,
+                                errorlog=yacc.NullLogger())
         self._globalScope = IDLScope(BuiltinLocation("<Global Scope>"), None, None)
         self._installBuiltins(self._globalScope)
         self._productions = []


### PR DESCRIPTION
The WebIDL.Parser() was calling yacc which is in
debug mode by default, causing it to create parser.out.
Furthermore, the pickle filename 'WebIDLGrammar.pkl'
was being passed in, which results in yacc writing its
tables to that filename.

Fixes #10986