### PR TITLE
SDL2_mixer: add support for WAV music (fix #11655)

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3206,19 +3206,20 @@ window.close = function() {
     self.btest('sdl2_mixer_wav.c', expected='1', args=['--preload-file', 'sound.wav', '-s', 'USE_SDL=2', '-s', 'USE_SDL_MIXER=2', '-s', 'INITIAL_MEMORY=33554432'])
 
   @parameterized({
-    'ogg': ('ogg', 'alarmvictory_1.ogg'),
-    'mp3': ('mp3', 'pudinha.mp3'),
+    'wav': ([],         '0',            'the_entertainer.wav'),
+    'ogg': (['ogg'],    'MIX_INIT_OGG', 'alarmvictory_1.ogg'),
+    'mp3': (['mp3'],    'MIX_INIT_MP3', 'pudinha.mp3'),
   })
   @requires_sound_hardware
-  def test_sdl2_mixer_music(self, fmt, music_name):
+  def test_sdl2_mixer_music(self, formats, flags, music_name):
     shutil.copyfile(path_from_root('tests', 'sounds', music_name), music_name)
     self.btest('sdl2_mixer_music.c', expected='1', args=[
       '--preload-file', music_name,
       '-DSOUND_PATH=' + json.dumps(music_name),
-      '-DFLAGS=' + ('MIX_INIT_' + fmt.upper() if fmt else '0'),
+      '-DFLAGS=' + flags,
       '-s', 'USE_SDL=2',
       '-s', 'USE_SDL_MIXER=2',
-      '-s', 'SDL2_MIXER_FORMATS=' + json.dumps([fmt] if fmt else []),
+      '-s', 'SDL2_MIXER_FORMATS=' + json.dumps(formats),
       '-s', 'INITIAL_MEMORY=33554432'
     ])
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -117,20 +117,21 @@ class interactive(BrowserCore):
     ])
 
   @parameterized({
-    'ogg': ('ogg', 'alarmvictory_1.ogg'),
-    'mp3': ('mp3', 'pudinha.mp3'),
+    'wav': ([],         '0',            'the_entertainer.wav'),
+    'ogg': (['ogg'],    'MIX_INIT_OGG', 'alarmvictory_1.ogg'),
+    'mp3': (['mp3'],    'MIX_INIT_MP3', 'pudinha.mp3'),
   })
-  def test_sdl2_mixer_music(self, fmt, music_name):
+  def test_sdl2_mixer_music(self, formats, flags, music_name):
     shutil.copyfile(path_from_root('tests', 'sounds', music_name), music_name)
     self.btest('sdl2_mixer_music.c', expected='1', args=[
       '-O2',
       '--minify', '0',
       '--preload-file', music_name,
       '-DSOUND_PATH=' + json.dumps(music_name),
-      '-DFLAGS=' + ('MIX_INIT_' + fmt.upper() if fmt else '0'),
+      '-DFLAGS=' + flags,
       '-s', 'USE_SDL=2',
       '-s', 'USE_SDL_MIXER=2',
-      '-s', 'SDL2_MIXER_FORMATS=' + json.dumps([fmt] if fmt else []),
+      '-s', 'SDL2_MIXER_FORMATS=' + json.dumps(formats),
       '-s', 'INITIAL_MEMORY=33554432'
     ])
 

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -39,7 +39,8 @@ def get(ports, settings, shared):
 
     flags = [
       '-s', 'USE_SDL=2',
-      '-O2'
+      '-O2',
+      '-DMUSIC_WAV',
     ]
 
     if "ogg" in settings.SDL2_MIXER_FORMATS:


### PR DESCRIPTION
Unintuitivelly, SDL2_mixer allow builds that support WAV samples on
Mix_LoadWAV() ~ which, despite the name, may also support formats such
mp3 and ogg ~, but not on Mix_LoadMUS().

Add a "wav" option to SDL2_MIXER_FORMATS to allow building with support
for WAV music.