### PR TITLE
Ignore a new clang warning that breaks on sqlite

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6220,9 +6220,14 @@ return malloc(size);
     # newer clang has a warning for implicit conversions that lose information,
     # which happens in sqlite (see #9138)
     self.emcc_args += ['-Wno-implicit-int-float-conversion']
-    # temporarily ignore unknown flags, which lets the above flag be used on our CI which doesn't
-    # yet have the new clang with that flag
+    # newer clang warns about "suspicious concatenation of string literals in an
+    # array initialization; did you mean to separate the elements with a comma?"
+    self.emcc_args += ['-Wno-string-concatenation']
+    # ignore unknown flags, which lets the above flags be used on github CI
+    # before the LLVM change rolls in (the same LLVM change that adds the
+    # warning also starts to warn on it)
     self.emcc_args += ['-Wno-unknown-warning-option']
+
     self.emcc_args += ['-I' + path_from_root('tests', 'third_party', 'sqlite')]
 
     src = '''


### PR DESCRIPTION
This should unbreak the LLVM roll.