### PR TITLE
SDL2_mixer: fix unconditional dependence on mpg123 and vorbis

### DIFF
--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -85,7 +85,7 @@ def clear(ports, settings, shared):
 
 def process_dependencies(settings):
   global deps
-  deps = ['vorbis', 'mpg123', 'sdl2']
+  deps = ['sdl2']
   settings.USE_SDL = 2
   if "ogg" in settings.SDL2_MIXER_FORMATS:
     deps.append('vorbis')


### PR DESCRIPTION
Make SDL2_mixer only depend on libmpg123 and libvorbis if support is
requested through SDL2_MIXER_FORMATS.