### PR TITLE
wasm preamble: use Promise.resolve rather than new Promise

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -496,3 +496,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Shrek Shao (shrekshao@google.com) (copyright owned by Google, LLC)
 * Arran Ireland <ion92@protonmail.com>
 * Jia Yuan Lo <jylo06g@gmail.com>
+* Antoine du Hamel <duhamelantoine1995@gmail.com>

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -861,9 +861,7 @@ function getBinaryPromise() {
     });
   }
   // Otherwise, getBinary should be able to get it synchronously
-  return new Promise(function(resolve, reject) {
-    resolve(getBinary());
-  });
+  return Promise.resolve().then(getBinary);
 }
 
 #if LOAD_SOURCE_MAP


### PR DESCRIPTION
Using `Promise.resolve` is more concise than using `Promise` constructor and produces the same result.