### PR TITLE
Remove fastcomp-only DOUBLE_MODE setting

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -844,8 +844,7 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
     return '{ ' + ret.join(', ') + ' }';
   }
 
-  // In double mode 1, in asmjs-unknown-emscripten we need this code path if we are not fully aligned.
-  if (DOUBLE_MODE == 1 && type == 'double' && (align < 8)) {
+  if (type == 'double' && (align < 8)) {
     return '(' + makeSetTempDouble(0, 'i32', makeGetValue(ptr, pos, 'i32', noNeedFirst, unsigned, ignore, align, noSafe)) + ',' +
                  makeSetTempDouble(1, 'i32', makeGetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'i32', noNeedFirst, unsigned, ignore, align, noSafe)) + ',' +
             makeGetTempDouble(0, 'double') + ')';
@@ -854,7 +853,6 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
   if (align) {
     // Alignment is important here. May need to split this up
     var bytes = Runtime.getNativeTypeSize(type);
-    if (DOUBLE_MODE == 0 && type == 'double') bytes = 4; // we will really only read 4 bytes here
     if (bytes > align) {
       var ret = '(';
       if (isIntImplemented(type)) {
@@ -928,7 +926,7 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
     return ret.join('; ');
   }
 
-  if (DOUBLE_MODE == 1 && type == 'double' && (align < 8)) {
+  if (type == 'double' && (align < 8)) {
     return '(' + makeSetTempDouble(0, 'double', value) + ',' +
             makeSetValue(ptr, pos, makeGetTempDouble(0, 'i32'), 'i32', noNeedFirst, ignore, align, noSafe, ',') + ',' +
             makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), makeGetTempDouble(1, 'i32'), 'i32', noNeedFirst, ignore, align, noSafe, ',') + ')';
@@ -943,7 +941,6 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
   if (align || needSplitting) {
     // Alignment is important here, or we need to split this up for other reasons.
     var bytes = Runtime.getNativeTypeSize(type);
-    if (DOUBLE_MODE == 0 && type == 'double') bytes = 4; // we will really only read 4 bytes here
     if (bytes > align || needSplitting) {
       var ret = '';
       if (isIntImplemented(type)) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -238,27 +238,6 @@ var ALLOW_TABLE_GROWTH = 0;
 // default, any other value will be used as an override
 var GLOBAL_BASE = -1;
 
-// where the stack will begin. -1 means use the default. if the stack cannot
-// start at the value specified here, it may start at a higher location.
-// this is useful when debugging two builds that may differ in their static
-// allocations, by forcing the stack to start in the same place their
-// memory usage patterns would be the same.
-
-// How to load and store 64-bit doubles.  A potential risk is that doubles may
-// be only 32-bit aligned. Forcing 64-bit alignment in Clang itself should be
-// able to solve that, or as a workaround in DOUBLE_MODE 1 we will carefully
-// load in parts, in a way that requires only 32-bit alignment. In DOUBLE_MODE 0
-// we will simply store and load doubles as 32-bit floats, so when they are
-// stored/loaded they will truncate from 64 to 32 bits, and lose precision. This
-// is faster, and might work for some code (but probably that code should just
-// use floats and not doubles anyhow).  Note that a downside of DOUBLE_MODE 1 is
-// that we currently store the double in parts, then load it aligned, and that
-// load-store will make JS engines alter it if it is being stored to a typed
-// array for security reasons. That will 'fix' the number from being a NaN or an
-// infinite number.
-// [fastcomp-only]
-var DOUBLE_MODE = 1;
-
 // Warn at compile time about instructions that LLVM tells us are not fully
 // aligned.  This is useful to find places in your code where you might refactor
 // to ensure proper alignment.  This is currently only supported in asm.js, not

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -829,10 +829,6 @@ class benchmark(runner.RunnerCore):
   def test_fasta_double(self):
     self.fasta('fasta_double', 'double')
 
-  @non_core
-  def test_fasta_double_full(self):
-    self.fasta('fasta_double_full', 'double', emcc_args=['-s', 'DOUBLE_MODE=1'])
-
   def test_skinning(self):
     src = open(path_from_root('tests', 'skinning_test_no_simd.cpp'), 'r').read()
     self.do_benchmark('skinning', src, 'blah=0.000000')


### PR DESCRIPTION
After removing it, things are always in `DOUBLE_MODE == 1`
basically (that is, doubles are normal doubles, no asm.js weirdness).

See #11860 