### PR TITLE
library_async.js cleanup

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -8,6 +8,10 @@
 // Async support via ASYNCIFY
 //
 
+if (!ASYNCIFY) {
+  throw "To link with the async library you must use -s ASYNCIFY";
+}
+
 mergeInto(LibraryManager.library, {
   // error handling
 
@@ -19,7 +23,6 @@ mergeInto(LibraryManager.library, {
     }
   },
 
-#if ASYNCIFY
   $Asyncify__deps: ['$Browser', '$runAndAbortIfError'],
   $Asyncify: {
     State: {
@@ -489,50 +492,6 @@ mergeInto(LibraryManager.library, {
       Asyncify.currData = null;
     }
   },
-
-  emscripten_coroutine_create: function() {
-    throw 'emscripten_coroutine_create has been removed. Please use the Fibers API';
-  },
-  emscripten_coroutine_next: function() {
-    throw 'emscripten_coroutine_next has been removed. Please use the Fibers API';
-  },
-  emscripten_yield: function() {
-    throw 'emscripten_yield has been removed. Please use the Fibers API';
-  },
-#else // ASYNCIFY
-  emscripten_sleep: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_sleep';
-  },
-  emscripten_coroutine_create: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_coroutine_create';
-  },
-  emscripten_coroutine_next: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_coroutine_next';
-  },
-  emscripten_yield: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_yield';
-  },
-  emscripten_wget: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_wget';
-  },
-  emscripten_wget_data: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_wget_data';
-  },
-  emscripten_scan_registers: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_scan_registers';
-  },
-  emscripten_fiber_init: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_init';
-  },
-  emscripten_fiber_init_from_current_context: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_init_from_current_context';
-  },
-  emscripten_fiber_swap: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_swap';
-  },
-#endif // ASYNCIFY
 });
 
-if (ASYNCIFY) {
-  DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$Asyncify');
-}
+DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$Asyncify');

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -489,28 +489,9 @@ mergeInto(LibraryManager.library, {
       Asyncify.currData = null;
     }
   },
-
-  emscripten_coroutine_create: function() {
-    throw 'emscripten_coroutine_create has been removed. Please use the Fibers API';
-  },
-  emscripten_coroutine_next: function() {
-    throw 'emscripten_coroutine_next has been removed. Please use the Fibers API';
-  },
-  emscripten_yield: function() {
-    throw 'emscripten_yield has been removed. Please use the Fibers API';
-  },
 #else // ASYNCIFY
   emscripten_sleep: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_sleep';
-  },
-  emscripten_coroutine_create: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_coroutine_create';
-  },
-  emscripten_coroutine_next: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_coroutine_next';
-  },
-  emscripten_yield: function() {
-    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_yield';
   },
   emscripten_wget: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_wget';

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -8,10 +8,6 @@
 // Async support via ASYNCIFY
 //
 
-if (!ASYNCIFY) {
-  throw "To link with the async library you must use -s ASYNCIFY";
-}
-
 mergeInto(LibraryManager.library, {
   // error handling
 
@@ -23,6 +19,7 @@ mergeInto(LibraryManager.library, {
     }
   },
 
+#if ASYNCIFY
   $Asyncify__deps: ['$Browser', '$runAndAbortIfError'],
   $Asyncify: {
     State: {
@@ -492,6 +489,50 @@ mergeInto(LibraryManager.library, {
       Asyncify.currData = null;
     }
   },
+
+  emscripten_coroutine_create: function() {
+    throw 'emscripten_coroutine_create has been removed. Please use the Fibers API';
+  },
+  emscripten_coroutine_next: function() {
+    throw 'emscripten_coroutine_next has been removed. Please use the Fibers API';
+  },
+  emscripten_yield: function() {
+    throw 'emscripten_yield has been removed. Please use the Fibers API';
+  },
+#else // ASYNCIFY
+  emscripten_sleep: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_sleep';
+  },
+  emscripten_coroutine_create: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_coroutine_create';
+  },
+  emscripten_coroutine_next: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_coroutine_next';
+  },
+  emscripten_yield: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_yield';
+  },
+  emscripten_wget: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_wget';
+  },
+  emscripten_wget_data: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_wget_data';
+  },
+  emscripten_scan_registers: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_scan_registers';
+  },
+  emscripten_fiber_init: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_init';
+  },
+  emscripten_fiber_init_from_current_context: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_init_from_current_context';
+  },
+  emscripten_fiber_swap: function() {
+    throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_fiber_swap';
+  },
+#endif // ASYNCIFY
 });
 
-DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$Asyncify');
+if (ASYNCIFY) {
+  DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$Asyncify');
+}

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -345,7 +345,9 @@ mergeInto(LibraryManager.library, {
       // We must first unwind, so things are spilled to the stack. We
       // can resume right after unwinding, no need for a timeout.
       Asyncify.afterUnwind = function() {
-        {{{ makeDynCall('vii') }}}(func, Asyncify.currData + 8, HEAP32[Asyncify.currData >> 2]);
+        var stackBegin = Asyncify.currData + {{{ C_STRUCTS.asyncify_data_s.__size__ }}};
+        var stackEnd = HEAP32[Asyncify.currData >> 2];
+        {{{ makeDynCall('vii') }}}(func, stackBegin, stackEnd);
         wakeUp();
       };
     });
@@ -408,7 +410,7 @@ mergeInto(LibraryManager.library, {
         var userData = {{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.user_data, 'i32') }}};
         {{{ makeDynCall('vi') }}}(entryPoint, userData);
       } else {
-        var asyncifyData = newFiber + 20;
+        var asyncifyData = newFiber + {{{ C_STRUCTS.emscripten_fiber_s.asyncify_data }}};
         Asyncify.currData = asyncifyData;
 
 #if ASYNCIFY_DEBUG
@@ -510,13 +512,13 @@ mergeInto(LibraryManager.library, {
   emscripten_yield: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_yield';
   },
-  emscripten_wget: function(url, file) {
+  emscripten_wget: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_wget';
   },
-  emscripten_wget_data: function(url, file) {
+  emscripten_wget_data: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_wget_data';
   },
-  emscripten_scan_registers: function(url, file) {
+  emscripten_scan_registers: function() {
     throw 'Please compile your program with async support in order to use asynchronous operations like emscripten_scan_registers';
   },
   emscripten_fiber_init: function() {

--- a/src/modules.js
+++ b/src/modules.js
@@ -130,18 +130,18 @@ var LibraryManager = {
         'library_uuid.js',
         'library_glew.js',
         'library_idbstore.js',
+        'library_async.js'
       ]);
     } else {
+      if (ASYNCIFY) {
+        libraries.push('library_async.js');
+      }
       if (USE_SDL == 1) {
         libraries.push('library_sdl.js');
       }
       if (USE_SDL == 2) {
         libraries.push('library_egl.js', 'library_webgl.js', 'library_html5_webgl.js');
       }
-    }
-
-    if (ASYNCIFY) {
-      libraries.push('library_async.js');
     }
 
     // Add any explicitly specified system JS libraries to link to, add those to link.

--- a/src/modules.js
+++ b/src/modules.js
@@ -130,18 +130,18 @@ var LibraryManager = {
         'library_uuid.js',
         'library_glew.js',
         'library_idbstore.js',
-        'library_async.js'
       ]);
     } else {
-      if (ASYNCIFY) {
-        libraries.push('library_async.js');
-      }
       if (USE_SDL == 1) {
         libraries.push('library_sdl.js');
       }
       if (USE_SDL == 2) {
         libraries.push('library_egl.js', 'library_webgl.js', 'library_html5_webgl.js');
       }
+    }
+
+    if (ASYNCIFY) {
+      libraries.push('library_async.js');
     }
 
     // Add any explicitly specified system JS libraries to link to, add those to link.


### PR DESCRIPTION
Follow up to #11868 

* Fix subtle regression in `emscripten_scan_registers` introduced by #9859
* Replace some hardcoded offsets with `C_STRUCT` references
* Remove stub functions for the old fastcomp-only coroutines API