### PR TITLE
Don't error on recently-removed fastcomp settings that were silently accepted before

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1779,5 +1779,4 @@ var LEGACY_SETTINGS = [
   ['FAST_UNROLLED_MEMCPY_AND_MEMSET', [0, 1], 'The wasm backend implements memcpy/memset in C'],
   ['DOUBLE_MODE', [0, 1], 'The wasm backend always implements doubles normally'],
   ['PRECISE_F32', [0, 1, 2], 'The wasm backend always implements floats normally'],
-  ['EMULATED_FUNCTION_POINTERS', [0, 1], 'The wasm backend always implements function pointers using a Table'],
 ];

--- a/src/settings.js
+++ b/src/settings.js
@@ -1776,4 +1776,8 @@ var LEGACY_SETTINGS = [
   ['ASYNCIFY_WHITELIST', 'ASYNCIFY_ONLY'],
   ['ASYNCIFY_BLACKLIST', 'ASYNCIFY_REMOVE'],
   ['EXCEPTION_CATCHING_WHITELIST', 'EXCEPTION_CATCHING_ALLOWED'],
+  ['FAST_UNROLLED_MEMCPY_AND_MEMSET', [0, 1], 'The wasm backend implements memcpy/memset in C'],
+  ['DOUBLE_MODE', [0, 1], 'The wasm backend always implements doubles normally'],
+  ['PRECISE_F32', [0, 1, 2], 'The wasm backend always implements floats normally'],
+  ['EMULATED_FUNCTION_POINTERS', [0, 1], 'The wasm backend always implements function pointers using a Table'],
 ];


### PR DESCRIPTION
This keeps our behavior identical to what it was earlier, accepting all
(valid) values of those removed settings.