### PR TITLE
Consistent use of `ports.get_build_dir()`. NFC.

### DIFF
--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -23,7 +23,7 @@ def get(ports, settings, shared):
     logging.info('building port: bullet')
 
     source_path = os.path.join(ports.get_dir(), 'bullet', 'Bullet-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'bullet')
+    dest_path = os.path.join(ports.get_build_dir(), 'bullet')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -21,7 +21,7 @@ def get(ports, settings, shared):
     ports.clear_project_build('bzip2')
 
     source_path = os.path.join(ports.get_dir(), 'bzip2', 'bzip2-' + VERSION)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'bzip2')
+    dest_path = os.path.join(ports.get_build_dir(), 'bzip2')
     shared.try_delete(dest_path)
     os.makedirs(dest_path)
     shutil.rmtree(dest_path, ignore_errors=True)

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -21,7 +21,7 @@ def get(ports, settings, shared):
     ports.clear_project_build('freetype')
 
     source_path = os.path.join(ports.get_dir(), 'freetype', 'FreeType-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'freetype')
+    dest_path = os.path.join(ports.get_build_dir(), 'freetype')
     shared.try_delete(dest_path)
     os.makedirs(dest_path)
     shutil.rmtree(dest_path, ignore_errors=True)

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -25,7 +25,7 @@ def get(ports, settings, shared):
     logging.info('building port: icu')
 
     source_path = os.path.join(ports.get_dir(), 'icu', 'icu')
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'icu')
+    dest_path = os.path.join(ports.get_build_dir(), 'icu')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -24,7 +24,7 @@ def get(ports, settings, shared):
     logging.info('building port: libjpeg')
 
     source_path = os.path.join(ports.get_dir(), 'libjpeg', 'jpeg-9c')
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'libjpeg')
+    dest_path = os.path.join(ports.get_build_dir(), 'libjpeg')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -26,7 +26,7 @@ def get(ports, settings, shared):
     logging.info('building port: libpng')
 
     source_path = os.path.join(ports.get_dir(), 'libpng', 'libpng-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'libpng')
+    dest_path = os.path.join(ports.get_build_dir(), 'libpng')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -23,7 +23,7 @@ def get(ports, settings, shared):
     logging.info('building port: mpg123')
 
     source_path = os.path.join(ports.get_dir(), 'mpg123', 'mpg123-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'mpg123')
+    dest_path = os.path.join(ports.get_build_dir(), 'mpg123')
 
     sauce_path = os.path.join(dest_path, 'src')
     libmpg123_path = os.path.join(sauce_path, 'libmpg123')

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -24,7 +24,7 @@ def get(ports, settings, shared):
     ports.clear_project_build('vorbis')
 
     source_path = os.path.join(ports.get_dir(), 'ogg', 'Ogg-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'ogg')
+    dest_path = os.path.join(ports.get_build_dir(), 'ogg')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -25,7 +25,7 @@ def get(ports, settings, shared):
     logging.info('building port: sdl2_gfx')
 
     source_path = os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_gfx')
+    dest_path = os.path.join(ports.get_build_dir(), 'sdl2_gfx')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -32,7 +32,7 @@ def get(ports, settings, shared):
     logging.info('building port: sdl2_mixer')
 
     source_path = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL2_mixer-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'sdl2_mixer')
+    dest_path = os.path.join(ports.get_build_dir(), 'sdl2_mixer')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -25,7 +25,7 @@ def get(ports, settings, shared):
     logging.info('building port: vorbis')
 
     source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'vorbis')
+    dest_path = os.path.join(ports.get_build_dir(), 'vorbis')
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -21,7 +21,7 @@ def get(ports, settings, shared):
     ports.clear_project_build('zlib')
 
     source_path = os.path.join(ports.get_dir(), 'zlib', 'zlib-' + TAG)
-    dest_path = os.path.join(shared.Cache.get_path('ports-builds'), 'zlib')
+    dest_path = os.path.join(ports.get_build_dir(), 'zlib')
     shared.try_delete(dest_path)
     os.makedirs(dest_path)
     shutil.rmtree(dest_path, ignore_errors=True)


### PR DESCRIPTION
Some ports were already using this and other were using
`shared.Cache.get_path('ports-builds')` directly.

This allows us to centrally control the ports build directory and
potentially change it in the future.