### PR TITLE
Fix bad interaction between MODULARIZE, ASan, O0, and Closure

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3425,7 +3425,7 @@ def module_export_name_substitution():
   else:
     replacement = "typeof %(EXPORT_NAME)s !== 'undefined' ? %(EXPORT_NAME)s : {}" % {"EXPORT_NAME": shared.Settings.EXPORT_NAME}
   with open(final, 'w') as f:
-    src = re.sub(r'{[\'"]?__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__[\'"]?:1}', replacement, src)
+    src = re.sub(r'{\s*[\'"]?__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__[\'"]?:\s*1\s*}', replacement, src)
     # For Node.js and other shell environments, create an unminified Module object so that
     # loading external .asm.js file that assigns to Module['asm'] works even when Closure is used.
     if shared.Settings.MINIMAL_RUNTIME and (shared.Settings.target_environment_may_be('node') or shared.Settings.target_environment_may_be('shell')):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8579,6 +8579,24 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('ALLOW_MEMORY_GROWTH')
     self.do_run_in_out_file_test('tests', 'core', 'test_asan_api')
 
+  @no_wasm2js('TODO: ASAN in wasm2js')
+  @no_fastcomp('asan not supported on fastcomp')
+  def test_asan_modularized_with_closure(self):
+    self.emcc_args.append('-sMODULARIZE=1')
+    self.emcc_args.append('-sEXPORT_NAME="createModule"')
+    self.emcc_args.append('-sUSE_CLOSURE_COMPILER=1')
+    self.emcc_args.append('-fsanitize=address')
+    self.emcc_args.append('-sALLOW_MEMORY_GROWTH=1')
+
+    def post(filename):
+      with open(filename, 'a') as f:
+        f.write('\n\n')
+        f.write('createModule().then();\n')
+
+    self.do_run(open(path_from_root('tests', 'hello_world.c')).read(),
+                post_build=post,
+                expected_output='hello, world!')
+
   @no_fastcomp('WASM backend stack protection')
   def test_safe_stack(self):
     self.set_setting('STACK_OVERFLOW_CHECK', 2)


### PR DESCRIPTION
MODULARIZE with a non-default export name combined with ASan, -O0, and
closure compiler had a bug where
`__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__` would fail to
be replaced properly with the module name. This was because ASan
causes the asanify JS transformation to be run, which changes the code
formatting and breaks the regex that did the substitution. This PR
fixes the problem by making the regex robust to the presence of
whitespace.