### PR TITLE
Clarify what the failure case is in test_asan_modularized_with_closure

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8591,7 +8591,9 @@ NODEFS is no longer included by default; build with -lnodefs.js
     def post(filename):
       with open(filename, 'a') as f:
         f.write('\n\n')
-        f.write('createModule().then();\n')
+        # the bug is that createModule() returns undefined, instead of the
+        # proper Promise object.
+        f.write('if (!(createModule() instanceof Promise)) throw "Promise was not returned :(";\n')
 
     self.do_run(open(path_from_root('tests', 'hello_world.c')).read(),
                 post_build=post,


### PR DESCRIPTION
I was surprised that `.then()` was needed to show the crash, since it should
be doing nothing... turns out that the bug was that `Module()` was returning
undefined, so it's a call that should do nothing, but it throws on calling a
method on something that is not an object.

This PR modifies the test to clarify what is being tested - check explicitly
that a proper Promise object is returned. I verified that this fails without
the fix in #11889 and passes with it.