### PR TITLE
Remove some superfluous exports in STANDALONE_WASM mode

### DIFF
--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -118,7 +118,7 @@ var WasiLibrary = {
   // this is needed. To get this code to be usable as a JS shim we need to
   // either wait for BigInt support or to legalize on the client.
   clock_time_get__sig: 'iiiii',
-  clock_time_get__deps: ['emscripten_get_now', 'emscripten_get_now_is_monotonic', '$setErrNo', '$checkWasiClock'],
+  clock_time_get__deps: ['emscripten_get_now', 'emscripten_get_now_is_monotonic', '$checkWasiClock'],
   clock_time_get: function(clk_id, {{{ defineI64Param('precision') }}}, ptime) {
     {{{ receiveI64ParamAsI32s('precision') }}}
     if (!checkWasiClock(clk_id)) {
@@ -141,7 +141,7 @@ var WasiLibrary = {
   },
 
   clock_res_get__sig: 'iii',
-  clock_res_get__deps: ['emscripten_get_now', 'emscripten_get_now_res', 'emscripten_get_now_is_monotonic', '$setErrNo', '$checkWasiClock'],
+  clock_res_get__deps: ['emscripten_get_now', 'emscripten_get_now_res', 'emscripten_get_now_is_monotonic', '$checkWasiClock'],
   clock_res_get: function(clk_id, pres) {
     if (!checkWasiClock(clk_id)) {
       return {{{ cDefine('EINVAL') }}};

--- a/tests/other/metadce/libcxxabi_message_O3_STANDALONE_WASM.funcs
+++ b/tests/other/metadce/libcxxabi_message_O3_STANDALONE_WASM.funcs
@@ -1,2 +1,1 @@
-$__wasm_call_ctors
 $_start

--- a/tests/other/metadce/mem_O3_ALLOW_MEMORY_GROWTH_STANDALONE_WASM.funcs
+++ b/tests/other/metadce/mem_O3_ALLOW_MEMORY_GROWTH_STANDALONE_WASM.funcs
@@ -1,5 +1,4 @@
 $__main_void
-$__wasm_call_ctors
 $_start
 $dlmalloc
 $emscripten_resize_heap

--- a/tests/other/metadce/mem_O3_STANDALONE_WASM.funcs
+++ b/tests/other/metadce/mem_O3_STANDALONE_WASM.funcs
@@ -1,5 +1,4 @@
 $__main_void
-$__wasm_call_ctors
 $_start
 $dlmalloc
 $sbrk

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM.funcs
@@ -1,4 +1,3 @@
-$__wasm_call_ctors
 $_start
 $dlmalloc
 $sbrk

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
@@ -1,3 +1,2 @@
-$__wasm_call_ctors
 $_start
 $dlmalloc

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7493,7 +7493,7 @@ int main() {
                            [], [], 128), # noqa
     # argc/argv support code etc. is in the wasm
     'O3_standalone':      ('libcxxabi_message.cpp', ['-O3', '-s', 'STANDALONE_WASM'],
-                           [], [], 198), # noqa
+                           [], [], 174), # noqa
   })
   def test_metadce_libcxxabi_message(self, filename, *args):
     self.run_metadce_test(filename, *args)


### PR DESCRIPTION
Many of these exports such as __errno_location and malloc/free
are exported only for the benefit of the JS support code which
not used in standalone mode.