### PR TITLE
Honor output filename when SIDE_MODULE is set.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1246,7 +1246,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     asm_target = unsuffixed(target) + '.asm.js' # might not be used, but if it is, this is the name
     wasm_text_target = asm_target.replace('.asm.js', '.wat') # ditto, might not be used
-    wasm_binary_target = asm_target.replace('.asm.js', '.wasm') # ditto, might not be used
+    if shared.Settings.SIDE_MODULE or final_suffix in WASM_ENDINGS:
+      wasm_binary_target = target
+    else:
+      wasm_binary_target = asm_target.replace('.asm.js', '.wasm') # ditto, might not be used
     wasm_source_map_target = shared.replace_or_append_suffix(wasm_binary_target, '.map')
 
     # Apply user -jsD settings
@@ -2114,7 +2117,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return 0
 
       # Precompiled headers support
-      if has_header_inputs:
+      if has_header_inputs or 'header' in language_mode:
         headers = [header for _, header in input_files]
         for header in headers:
           if not header.endswith(HEADER_ENDINGS):
@@ -2732,12 +2735,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       shared.JS.handle_license(final)
 
-      if final_suffix in JS_ENDINGS:
-        js_target = target
-      elif final_suffix in WASM_ENDINGS:
+      if final_suffix in WASM_ENDINGS:
         js_target = misc_temp_files.get(suffix='.js').name
-      else:
+      elif final_suffix == '.html':
         js_target = unsuffixed(target) + '.js'
+      else:
+        js_target = target
 
       # The JS is now final. Move it to its final location
       shutil.move(final, js_target)

--- a/emcc.py
+++ b/emcc.py
@@ -1427,7 +1427,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       else:
         link_to_object = True
 
-    if not link_to_object and not compile_only and final_suffix not in EXECUTABLE_ENDINGS:
+    if not link_to_object and not compile_only and final_suffix not in EXECUTABLE_ENDINGS + DYNAMICLIB_ENDINGS:
       # TODO(sbc): Remove this emscripten-specific special case.  We should only generate object
       # file output with an explicit `-c` or `-r`.
       diagnostics.warning('emcc', 'assuming object file output, based on output filename alone.  Add an explict `-c`, `-r` or `-shared` to avoid this warning')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7662,7 +7662,7 @@ int main() {
 
   def test_wasm_targets_side_module(self):
     # side modules do allow a wasm target
-    for opts, target in [([], 'a.out.wasm'), (['-o', 'lib.wasm'], 'lib.wasm')]:
+    for opts, target in [([], 'a.out.wasm'), (['-o', 'lib.wasm'], 'lib.wasm'), (['-o', 'lib.so'], 'lib.so')]:
       # specified target
       print('building: ' + target)
       self.clear()


### PR DESCRIPTION
Previously the wasm output file would always when in `.wasm`
even if some other extensions was requested.

Importantly this mean that `emcc -s SIDE_MODULE -o foo.so` would
not output `foo.so`.