### PR TITLE
Remove handling of `--llvm-lto`

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -239,27 +239,8 @@ Options that are modified or new in *emcc* are listed below:
    You normally don't need to specify this option, as "-O" with an
    optimization level will set a good value.
 
-"--llvm-lto <level>"
-   Enables LLVM link-time optimizations (LTO). Possible "level" values
-   are:
-
-      * "0": No LLVM LTO (default).
-
-      * "1": LLVM LTO is performed.
-
-      * "2": Combine all the bitcode and run LLVM opt on it using the
-        specified "--llvm-opts". This optimizes across modules, but is
-        not the same as normal LTO.
-
-      * "3": Does level "2" and then level "1".
-
-   Note:
-
-     * If LLVM optimizations are not run (see "--llvm-opts"), this
-       setting has no effect.
-
-     * LLVM LTO is not perfectly stable yet, and can cause code to
-       behave incorrectly.
+"-flto"
+   Enables link-time optimizations (LTO).
 
 "--closure <on>"
    Runs the *Closure Compiler*. Possible "on" values are:

--- a/site/source/docs/compiling/WebAssembly.rst
+++ b/site/source/docs/compiling/WebAssembly.rst
@@ -63,10 +63,6 @@ upgrade from fastcomp to upstream:
     (``-flto``, ``-flto=full``, ``-flto=thin``, at both compile and link times).
     These flags will make the wasm backend behave more like fastcomp.
 
-  * With fastcomp LTO optimization passes will not be run by default;
-    for that you must pass ``--llvm-lto 1``.  With the llvm backend
-    LTO passes will be run on any object files that are in bitcode format.
-
   * Another thing you might notice is that fastcomp's link stage is able to
     perform some minor types of link time optimization even without LTO being
     set. The LLVM backend requires actually setting LTO for those things.

--- a/site/source/docs/compiling/WebAssembly.rst
+++ b/site/source/docs/compiling/WebAssembly.rst
@@ -63,6 +63,10 @@ upgrade from fastcomp to upstream:
     (``-flto``, ``-flto=full``, ``-flto=thin``, at both compile and link times).
     These flags will make the wasm backend behave more like fastcomp.
 
+  * With fastcomp, LTO optimization passes were not be run by default; for that
+    it was necessry to pass ``--llvm-lto 1``.  With the llvm backend LTO passes
+    will be run on any object files that are in bitcode format.
+
   * Another thing you might notice is that fastcomp's link stage is able to
     perform some minor types of link time optimization even without LTO being
     set. The LLVM backend requires actually setting LTO for those things.

--- a/site/source/docs/optimizing/Optimizing-Code.rst
+++ b/site/source/docs/optimizing/Optimizing-Code.rst
@@ -27,7 +27,7 @@ The optimization level you should use depends mostly on the current stage of dev
 - Building with ``-O3`` or ``-Os`` can produce an ever better build than ``-O2``, and are worth considering for release builds. ``-O3`` builds are even more optimized than ``-O2``, but at the cost of significantly longer compilation time and potentially larger code size. ``-Os`` is similar in increasing compile times, but focuses on reducing code size while doing additional optimization. It's worth trying these different optimization options to see what works best for your application.
 - Other optimizations are discussed in the following sections.
 
-In addition to the ``-Ox`` options, there are separate compiler options that can be used to control the JavaScript optimizer (:ref:`js-opts <emcc-js-opts>`), LLVM optimizations (:ref:`llvm-opts <emcc-llvm-opts>`) and LLVM link-time optimizations (:ref:`llvm-lto <emcc-llvm-lto>`).
+In addition to the ``-Ox`` options, there are separate compiler options that can be used to control the JavaScript optimizer (:ref:`js-opts <emcc-js-opts>`), LLVM optimizations (:ref:`llvm-opts <emcc-llvm-opts>`) and LLVM link-time optimizations (:ref:`lto <emcc-lto>`).
 
 .. note::
 
@@ -91,21 +91,14 @@ LTO
 ===
 
 Link Time Optimization (LTO) lets the compiler do more optimizations, as it can
-inline across separate compilation units, and even with system libraries. For
-fastcomp the :ref:`main relevant flag <emcc-llvm-lto>` is ``--llvm-lto 1`` at
-link time.
-
-With the LLVM wasm backend, LTO triggered by compiling objects files with
-``-flto``.  The effect of this flag is to emit LTO object files (technically
-this means emitting bitcode).  The linker can handle a mix wasm object files
-and LTO object files.  Passing ``-flto`` at link time will also trigger LTO
-system libraries to be used.
+inline across separate compilation units, and even with system libraries.
+LTO is enabled by compiling objects files with ``-flto``.  The effect of this
+flag is to emit LTO object files (technically this means emitting bitcode).  The
+linker can handle a mix wasm object files and LTO object files.  Passing
+``-flto`` at link time will also trigger LTO system libraries to be used.
 
 Thus, to allow maximal LTO opportunities with the LLVM wasm backend, build all
 source files with ``-flto`` and also link with ``flto``.
-
-Note that older versions of LLVM had bugs in this area. With the older fastcomp
-backend LTO should be used carefully.
 
 Very large codebases
 ====================
@@ -182,7 +175,6 @@ Unsafe optimizations
 A few **UNSAFE** optimizations you might want to try are:
 
 - ``--closure 1``: This can help with reducing the size of the non-generated (support/glue) JS code, and with startup. However it can break if you do not do proper :term:`Closure Compiler` annotations and exports. But it's worth it!
-- ``--llvm-lto 1``: This enables LLVM's link-time optimizations, which can help in some cases. However there are known issues with these optimizations, so code must be extensively tested. See :ref:`llvm-lto <emcc-llvm-lto>` for information about the other modes.
 
 .. _optimizing-code-profiling:
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -207,20 +207,10 @@ Options that are modified or new in *emcc* are listed below:
 
   You normally don't need to specify this option, as ``-O`` with an optimization level will set a good value.
 
-.. _emcc-llvm-lto:
+.. _emcc-lto:
 
-``--llvm-lto <level>``
-  Enables LLVM link-time optimizations (LTO). Possible ``level`` values are:
-
-    - ``0``: No LLVM LTO (default).
-    - ``1``: LLVM LTO is performed.
-    - ``2``: Combine all the bitcode and run LLVM opt on it using the specified ``--llvm-opts``. This optimizes across modules, but is not the same as normal LTO.
-    - ``3``: Does level ``2`` and then level ``1``.
-
-  .. note::
-
-    - If LLVM optimizations are not run (see ``--llvm-opts``), this setting has no effect.
-    - LLVM LTO is not perfectly stable yet, and can cause code to behave incorrectly.
+``-flto``
+  Enables link-time optimizations (LTO).
 
 .. _emcc-closure:
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -943,7 +943,7 @@ class benchmark(runner.RunnerCore):
     args = [path_from_root('tests', 'nbody-java', x) for x in os.listdir(path_from_root('tests', 'nbody-java')) if x.endswith('.c')] + \
            ['-I' + path_from_root('tests', 'nbody-java')]
     self.do_benchmark('nbody_java', '', '''Time(s)''',
-                      force_c=True, emcc_args=args + ['--llvm-lto', '2'], native_args=args + ['-lgc', '-std=c99', '-target', 'x86_64-pc-linux-gnu', '-lm'])
+                      force_c=True, emcc_args=args + ['-flto'], native_args=args + ['-lgc', '-std=c99', '-target', 'x86_64-pc-linux-gnu', '-lm'])
 
   def lua(self, benchmark, expected, output_parser=None, args_processor=None):
     self.emcc_args.remove('-Werror')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6309,8 +6309,8 @@ return malloc(size);
 
     for lto in [0, 1]:
       print('lto:', lto)
-      if lto == 1:
-        self.emcc_args += ['--llvm-lto', '1']
+      if lto:
+        self.emcc_args += ['-flto']
       self.do_run_object(bitcode, pyoutput, args=['-S', '-c', pyscript])
 
   @no_asan('call stack exceeded on some versions of node')
@@ -6352,7 +6352,7 @@ return malloc(size);
 
     run_all('normal')
 
-    self.emcc_args += ['--llvm-lto', '1']
+    self.emcc_args += ['-flto']
 
     run_all('lto')
 
@@ -8464,12 +8464,12 @@ wasm3 = make_run('wasm3', emcc_args=['-O3'])
 wasms = make_run('wasms', emcc_args=['-Os'])
 wasmz = make_run('wasmz', emcc_args=['-Oz'])
 
-wasmlto0 = make_run('wasmlto0', emcc_args=['-flto', '-O0', '--llvm-lto', '1'])
-wasmlto1 = make_run('wasmlto1', emcc_args=['-flto', '-O1', '--llvm-lto', '1'])
-wasmlto2 = make_run('wasmlto2', emcc_args=['-flto', '-O2', '--llvm-lto', '1'])
-wasmlto3 = make_run('wasmlto3', emcc_args=['-flto', '-O3', '--llvm-lto', '1'])
-wasmltos = make_run('wasmltos', emcc_args=['-flto', '-Os', '--llvm-lto', '1'])
-wasmltoz = make_run('wasmltoz', emcc_args=['-flto', '-Oz', '--llvm-lto', '1'])
+wasmlto0 = make_run('wasmlto0', emcc_args=['-flto', '-O0'])
+wasmlto1 = make_run('wasmlto1', emcc_args=['-flto', '-O1'])
+wasmlto2 = make_run('wasmlto2', emcc_args=['-flto', '-O2'])
+wasmlto3 = make_run('wasmlto3', emcc_args=['-flto', '-O3'])
+wasmltos = make_run('wasmltos', emcc_args=['-flto', '-Os'])
+wasmltoz = make_run('wasmltoz', emcc_args=['-flto', '-Oz'])
 
 if shared.Settings.WASM_BACKEND:
   wasm2js0 = make_run('wasm2js0', emcc_args=['-O0'], settings={'WASM': 0})

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3254,7 +3254,7 @@ int main(int argc, char **argv) {
 
     for wasm in [0, 1]:
       for no_exit in [1, 0]:
-        for opts in [[], ['-O1'], ['-O2', '-g2'], ['-O2', '-g2', '--llvm-lto', '1']]:
+        for opts in [[], ['-O1'], ['-O2', '-g2'], ['-O2', '-g2', '-flto']]:
           print(wasm, no_exit, opts)
           cmd = [EMCC] + opts + ['code.cpp', '-s', 'EXIT_RUNTIME=' + str(1 - no_exit), '-s', 'WASM=' + str(wasm)]
           if wasm:
@@ -3411,8 +3411,8 @@ Waste<3> *getMore() {
       (['-O2', '-g'], False),
       (['-Os', '-g', '-s', 'EXIT_RUNTIME=1'], True),
       (['-Os', '-g'], False),
-      (['-O2', '-g', '--llvm-lto', '1', '-s', 'EXIT_RUNTIME=1'], True),
-      (['-O2', '-g', '--llvm-lto', '1'], False),
+      (['-O2', '-g', '-flto', '-s', 'EXIT_RUNTIME=1'], True),
+      (['-O2', '-g', '-flto'], False),
     ]:
       print(opts, has_global)
       self.run_process([EMCC, 'main.cpp', '-c'] + opts)

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -432,7 +432,7 @@ fi
     for i in range(3):
       print(i)
       self.clear()
-      output = self.do([EMCC, '-O' + str(i), '-s', '--llvm-lto', '0', path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
+      output = self.do([EMCC, '-O' + str(i), path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'DISABLE_EXCEPTION_CATCHING=0'])
       print('\n\n\n', output)
       self.assertContainedIf(BUILDING_MESSAGE.replace('X', libname), output, i == 0)
       self.assertContained('hello, world!', self.run_js('a.out.js'))


### PR DESCRIPTION
We still accept this flag with a warning but continue to ignore
it under the llvm backend.