### PR TITLE
Replace RESERVED_FUNCTION_POINTERS with ALLOW_TABLE_GROWTH

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,14 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Remove the `RESERVED_FUNCTION_POINTERS` setting, which is no longer needed as
+  we have `ALLOW_TABLE_GROWTH`. The old option allowed a fixed number of
+  functions to be added to the table, while the new one allows an unlimited
+  number. (We needed the old option for fastcomp, which could not support
+  growth.) The old setting is mapped to the new one, so that building with
+  `-s RESERVED_FUNCTION_POINTERS=K` for any `K > 0` will simply turn on
+  table growth. The only noticeable effect of this is that you will be able to
+  add an unlimited amount of functions and not just `K`.
 
 2.0.0: 08/10/2020
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -3181,8 +3181,6 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
     # We do not currently have a setup to preprocess {{{ }}} settings in user scripts, so manually
     # expand the settings that wasm2js.js actually uses.
     wasm2js = wasm2js.replace('{{{ WASM_PAGE_SIZE }}}', '65536')
-    for opt in ['RESERVED_FUNCTION_POINTERS']:
-      wasm2js = wasm2js.replace('{{{ %s }}}' % opt, str(shared.Settings.get(opt)))
     for opt in ['WASM_TABLE_SIZE']:
       wasm2js = wasm2js.replace("{{{ getQuoted('%s') }}}" % opt, str(shared.Settings.get(opt)))
     return wasm2js

--- a/emscripten.py
+++ b/emscripten.py
@@ -984,10 +984,6 @@ def make_function_tables_defs(implemented_functions, all_implemented, function_t
     start = raw.index('[')
     end = raw.rindex(']')
     body = raw[start + 1:end].split(',')
-    for j in range(shared.Settings.RESERVED_FUNCTION_POINTERS):
-      curr = 'jsCall_%s_%s' % (sig, j)
-      body[1 + j] = curr
-      implemented_functions.add(curr)
     Counter.next_item = 0
 
     def fix_item(item):
@@ -1092,15 +1088,6 @@ function dynCall_%s(index%s%s) {
 ''' % (sig, ',' if len(sig) > 1 else '', args, arg_coercions, ret))
 
     ffi_args = ','.join([shared.JS.make_coercion('a' + str(i), sig[i], ffi_arg=True) for i in range(1, len(sig))])
-    for i in range(shared.Settings.RESERVED_FUNCTION_POINTERS):
-      jsret = ('return ' if sig[0] != 'v' else '') + shared.JS.make_coercion('jsCall_%s(%d%s%s)' % (sig, i, ',' if ffi_args else '', ffi_args), sig[0], ffi_result=True)
-      function_tables_impls.append('''
-function jsCall_%s_%s(%s) {
-  %s
-  %s;
-}
-
-''' % (sig, i, args, arg_coercions, jsret))
   return function_tables_impls
 
 
@@ -1223,16 +1210,7 @@ def create_asm_setup(debug_tables, function_table_data, invoke_function_names, m
     ''' % (fullname, key, check(barename), side, barename, barename, sig, key, key)
 
   asm_setup += create_invoke_wrappers(invoke_function_names)
-  asm_setup += setup_function_pointers(function_table_sigs)
 
-  return asm_setup
-
-
-def setup_function_pointers(function_table_sigs):
-  asm_setup = ''
-  for sig in function_table_sigs:
-    if shared.Settings.RESERVED_FUNCTION_POINTERS:
-      asm_setup += '\n' + shared.JS.make_jscall(sig) + '\n'
   return asm_setup
 
 
@@ -1255,9 +1233,6 @@ def create_basic_funcs(function_table_sigs, invoke_function_names):
 
   basic_funcs += invoke_function_names
 
-  for sig in function_table_sigs:
-    if shared.Settings.RESERVED_FUNCTION_POINTERS:
-      basic_funcs.append('jsCall_%s' % sig)
   return basic_funcs
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -1087,7 +1087,6 @@ function dynCall_%s(index%s%s) {
 }
 ''' % (sig, ',' if len(sig) > 1 else '', args, arg_coercions, ret))
 
-    ffi_args = ','.join([shared.JS.make_coercion('a' + str(i), sig[i], ffi_arg=True) for i in range(1, len(sig))])
   return function_tables_impls
 
 

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -616,12 +616,8 @@ be called.
 
 See `test_add_function in tests/test_core.py`_ for an example.
 
-When using ``addFunction``, there is a backing array where these functions are
-stored. This array must be explicitly sized, which can be done via a
-compile-time setting, ``RESERVED_FUNCTION_POINTERS``. For example, to reserve
-space for 20 functions to be added::
-
-    emcc ... -s RESERVED_FUNCTION_POINTERS=20 ...
+You should build with ``-s ALLOW_TABLE_GROWTH`` to allow new functions to be
+added to the table. Otherwise by default the table has a fixed size.
 
 .. note:: When using ``addFunction`` on LLVM wasm backend, you need to provide
    an additional second argument, a Wasm function signature string. Each

--- a/src/runtime_init_table.js
+++ b/src/runtime_init_table.js
@@ -2,7 +2,7 @@
 var wasmTable = new WebAssembly.Table({
   'initial': {{{ getQuoted('WASM_TABLE_SIZE') }}},
 #if !ALLOW_TABLE_GROWTH
-  'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}} + {{{ RESERVED_FUNCTION_POINTERS }}},
+  'maximum': {{{ getQuoted('WASM_TABLE_SIZE') }}},
 #endif
   'element': 'anyfunc'
 });

--- a/src/settings.js
+++ b/src/settings.js
@@ -285,11 +285,6 @@ var SAFE_HEAP = 0;
 // Log out all SAFE_HEAP operations
 var SAFE_HEAP_LOG = 0;
 
-// In asm.js mode, we cannot simply add function pointers to function tables, so
-// we reserve some slots for them.
-// [fastcomp-only]
-var RESERVED_FUNCTION_POINTERS = 0;
-
 // Allows function pointers to be cast, wraps each call of an incorrect type
 // with a runtime correction.  This adds overhead and should not be used
 // normally.  It also forces ALIASING_FUNCTION_POINTERS to 0.  Aside from making
@@ -1707,6 +1702,8 @@ var LEGACY_SETTINGS = [
   ['PGO', [0], 'pgo no longer supported'],
   ['QUANTUM_SIZE', [4], 'altering the QUANTUM_SIZE is not supported'],
   ['FUNCTION_POINTER_ALIGNMENT', [2], 'Starting from Emscripten 1.37.29, no longer available (https://github.com/emscripten-core/emscripten/pull/6091)'],
+  // Reserving function pointers is not needed - allowing table growth allows any number of new functions to be added.
+  ['RESERVED_FUNCTION_POINTERS', 'ALLOW_TABLE_GROWTH'],
   ['BUILD_AS_SHARED_LIB', [0], 'Starting from Emscripten 1.38.16, no longer available (https://github.com/emscripten-core/emscripten/pull/7433)'],
   ['SAFE_SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SAFE_SPLIT_MEMORY codegen is no longer available (https://github.com/emscripten-core/emscripten/pull/7465)'],
   ['SPLIT_MEMORY', [0], 'Starting from Emscripten 1.38.19, SPLIT_MEMORY codegen is no longer available (https://github.com/emscripten-core/emscripten/pull/7465)'],

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -48,7 +48,7 @@ WebAssembly = {
 #else
 #if ASSERTIONS // without assertions we'll throw on calling the missing function
     ret.grow = function(by) {
-      abort('Build with ALLOW_TABLE_GROWTH to allow table growth.')
+      abort('Unable to grow wasm table. Build with ALLOW_TABLE_GROWTH.')
     };
 #endif // ASSERTIONS
 #endif // ALLOW_TABLE_GROWTH

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -41,14 +41,17 @@ WebAssembly = {
   // instance of this function).
   Table: /** @constructor */ function(opts) {
     var ret = new Array(opts['initial']);
+#if ALLOW_TABLE_GROWTH
     ret.grow = function(by) {
-#if !ALLOW_TABLE_GROWTH
-      if (ret.length >= {{{ getQuoted('WASM_TABLE_SIZE') }}}) {
-        abort('Unable to grow wasm table. Build with ALLOW_TABLE_GROWTH.')
-      }
-#endif
       ret.push(null);
     };
+#else
+#if ASSERTIONS // without assertions we'll throw on calling the missing function
+    ret.grow = function(by) {
+      abort('Build with ALLOW_TABLE_GROWTH to allow table growth.')
+    };
+#endif // ASSERTIONS
+#endif // ALLOW_TABLE_GROWTH
     ret.set = function(i, func) {
       ret[i] = func;
     };

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -43,8 +43,8 @@ WebAssembly = {
     var ret = new Array(opts['initial']);
     ret.grow = function(by) {
 #if !ALLOW_TABLE_GROWTH
-      if (ret.length >= {{{ getQuoted('WASM_TABLE_SIZE') }}} + {{{ RESERVED_FUNCTION_POINTERS }}}) {
-        abort('Unable to grow wasm table. Use a higher value for RESERVED_FUNCTION_POINTERS or set ALLOW_TABLE_GROWTH.')
+      if (ret.length >= {{{ getQuoted('WASM_TABLE_SIZE') }}}) {
+        abort('Unable to grow wasm table. Build with ALLOW_TABLE_GROWTH.')
       }
 #endif
       ret.push(null);

--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 5068,
-  "a.js.gz": 2422,
-  "a.wasm": 10925,
-  "a.wasm.gz": 6948,
+  "a.js": 5064,
+  "a.js.gz": 2417,
+  "a.wasm": 10917,
+  "a.wasm.gz": 6932,
   "total": 16556,
-  "total_gz": 9747
+  "total_gz": 9726
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 22339,
-  "a.js.gz": 8620,
+  "a.js": 22182,
+  "a.js.gz": 8483,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 26088,
-  "total_gz": 11717
+  "total": 25938,
+  "total_gz": 11580
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 4553,
-  "a.js.gz": 2244,
-  "a.wasm": 10925,
-  "a.wasm.gz": 6948,
+  "a.js": 4549,
+  "a.js.gz": 2240,
+  "a.wasm": 10917,
+  "a.wasm.gz": 6932,
   "total": 16041,
-  "total_gz": 9569
+  "total_gz": 9549
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21826,
-  "a.js.gz": 8453,
+  "a.js": 21671,
+  "a.js.gz": 8323,
   "a.mem": 3168,
   "a.mem.gz": 2711,
-  "total": 25575,
-  "total_gz": 11550
+  "total": 25427,
+  "total_gz": 11420
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 697,
   "a.html.gz": 437,
-  "a.js": 1911,
-  "a.js.gz": 871,
+  "a.js": 1753,
+  "a.js.gz": 753,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 2614,
-  "total_gz": 1340
+  "total": 2456,
+  "total_gz": 1222
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13711,
-  "a.html.gz": 7321,
-  "total": 13715,
-  "total_gz": 7321
+  "a.html": 13727,
+  "a.html.gz": 7361,
+  "total": 13711,
+  "total_gz": 7361
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19526,
-  "a.html.gz": 8162,
-  "total": 19537,
-  "total_gz": 8162
+  "a.html": 19387,
+  "a.html.gz": 8068,
+  "total": 19387,
+  "total_gz": 8068
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6689,8 +6689,15 @@ return malloc(size);
 
     print('with RESERVED_FUNCTION_POINTERS=0')
     self.set_setting('RESERVED_FUNCTION_POINTERS', 0)
+    expected = 'Unable to grow wasm table'
+    if self.is_wasm2js() and is_optimizing(self.emcc_args):
+      # in wasm2js the error message doesn't come from the VM, but from our
+      # emulation code. when ASSERTIONS are enabled we show a clear message, but
+      # in optimized builds we don't waste code size on that, and the JS engine
+      # shows a generic error.
+      expected = 'table.grow is not a function'
+    self.do_run(open(src).read(), expected, assert_returncode=NON_ZERO)
 
-    self.do_run(open(src).read(), 'Unable to grow wasm table', assert_returncode=NON_ZERO)
     print('- with table growth')
     self.set_setting('ALLOW_TABLE_GROWTH', 1)
     self.emcc_args += ['-DGROWTH']


### PR DESCRIPTION
Related to #11860 but this is NOT an NFC change. It has a very minor
noticeable effect.

The old `RESERVED_FUNCTION_POINTERS` let you add a fixed number
of slots for `addFunction`. We needed that in fastcomp where arbitrary
growth wasn't possible. As fastcomp is gone, we don't need the option
any more, and people can just use `ALLOW_TABLE_GROWTH` which
does the same but without a fixed limit.

Concretely this just maps `RESERVED_FUNCTION_POINTERS` to
`ALLOW_TABLE_GROWTH`. This has slightly different semantics, in
that it allows unlimited growth now. But that should be a strict
improvement, preventing previous error cases. Still, I added a mention
to the changelog.

The improvement to the code size tests is because of the simplification
in `src/wasm2js.js`. It basically makes release builds not contain extra
error logging which apparently we had earlier, and became obvious
while removing the old option's support.