### PR TITLE
Remove fastcomp-specific SIMPLIFY_IFS setting. See #11860

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2635,15 +2635,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
           optimizer.queue += ['simplifyExpressions']
 
-      if shared.Settings.OPT_LEVEL >= 1 and options.js_opts:
-        if shared.Settings.OPT_LEVEL >= 2:
-          # simplify ifs if it is ok to make the code somewhat unreadable,
-          # with commaified code breaks late aggressive variable elimination)
-          # do not do this with binaryen, as commaifying confuses binaryen call type detection (FIXME, in theory, but unimportant)
-          debugging = shared.Settings.DEBUG_LEVEL == 0 or options.profiling
-          if shared.Settings.SIMPLIFY_IFS and debugging and not shared.Settings.WASM:
-            optimizer.queue += ['simplifyIfs']
-
       if options.js_opts:
         if shared.Settings.SAFE_HEAP and not building.is_wasm_only():
           optimizer.queue += ['safeHeap']

--- a/src/settings.js
+++ b/src/settings.js
@@ -269,10 +269,6 @@ var IGNORE_CLOSURE_COMPILER_ERRORS = 0;
 // [compile+link]
 var INLINING_LIMIT = 0;
 
-// Whether to simplify ifs in js-optimizer.js
-// [fastcomp-only]
-var SIMPLIFY_IFS = 1;
-
 // Check each write to the heap, for example, this will give a clear
 // error on what would be segfaults in a native build (like dereferencing
 // 0). See runtime_safe_heap.js for the actual checks performed.
@@ -1736,4 +1732,5 @@ var LEGACY_SETTINGS = [
   ['PRECISE_F32', [0, 1, 2], 'The wasm backend always implements floats normally'],
   ['ALIASING_FUNCTION_POINTERS', [0, 1], 'The wasm backend always uses a single index space for function pointers, in a single Table'],
   ['AGGRESSIVE_VARIABLE_ELIMINATION', [0, 1], 'Wasm ignores asm.js-specific optimization flags'],
+  ['SIMPLIFY_IFS', [1], 'Wasm ignores asm.js-specific optimization flags'],
 ];


### PR DESCRIPTION
 Note that the pass is not removed, as it is a TODO for wasm2js