### PR TITLE
Ignore --llvm-lto argument

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2761,6 +2761,7 @@ def parse_args(newargs):
         shared.Settings.LTO = "full"
     elif check_arg('--llvm-lto'):
       logger.warning('--llvm-lto ignored when using llvm backend')
+      consume_arg()
     elif check_arg('--closure-args'):
       args = consume_arg()
       options.closure_args += shlex.split(args)


### PR DESCRIPTION
Folowup on #11918.

Even though we are generating a warning when this argument is used
we also need to ignore the integer argument that follows.