### PR TITLE
Remove trailing slash from path in PATH.basename

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -498,3 +498,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jia Yuan Lo <jylo06g@gmail.com>
 * Antoine du Hamel <duhamelantoine1995@gmail.com>
 * Alexander Köplinger <alex.koeplinger@outlook.com> (copyright owned by Microsoft, Inc.)
+* Mitchell Hwang <mihw@microsoft.com> (copyright owned by Microsoft, Inc.)

--- a/src/library_path.js
+++ b/src/library_path.js
@@ -67,6 +67,7 @@ mergeInto(LibraryManager.library, {
     basename: function(path) {
       // EMSCRIPTEN return '/'' for '/', not an empty string
       if (path === '/') return '/';
+      path = path.replace(/\/$/, "");
       var lastSlash = path.lastIndexOf('/');
       if (lastSlash === -1) return path;
       return path.substr(lastSlash+1);

--- a/src/library_path.js
+++ b/src/library_path.js
@@ -67,6 +67,7 @@ mergeInto(LibraryManager.library, {
     basename: function(path) {
       // EMSCRIPTEN return '/'' for '/', not an empty string
       if (path === '/') return '/';
+      path = PATH.normalize(path);
       path = path.replace(/\/$/, "");
       var lastSlash = path.lastIndexOf('/');
       if (lastSlash === -1) return path;

--- a/tests/stdio/test_rename.c
+++ b/tests/stdio/test_rename.c
@@ -34,6 +34,7 @@ void setup() {
   mkdir("dir-nonempty", 0777);
   mkdir("dir/subdir3", 0777);
   mkdir("dir/subdir3/subdir3_1", 0777);
+  mkdir("dir/subdir4/", 0777);
   create_file("dir-nonempty/file", "abcdef", 0777);
 }
 
@@ -50,6 +51,8 @@ void cleanup() {
   rmdir("dir/subdir3/subdir3_1/subdir1 renamed");
   rmdir("dir/subdir3/subdir3_1");
   rmdir("dir/subdir3");
+  rmdir("dir/subdir4/");
+  rmdir("dir/subdir5/");
   rmdir("dir");
   rmdir("dir-readonly");
   unlink("dir-nonempty/file");
@@ -111,6 +114,9 @@ void test() {
   err = rename("dir/subdir2", "dir/subdir3/subdir3_1/subdir1 renamed");
   assert(!err);
   err = access("dir/subdir3/subdir3_1/subdir1 renamed", F_OK);
+  assert(!err);
+
+  err = rename("dir/subdir4/", "dir/subdir5/");
   assert(!err);
 
   puts("success");


### PR DESCRIPTION
When calling PATH.basename on paths with a trailing slash (i.e. `/emscripten/`), an empty string will be returned instead of `"emscripten"`. This leads to errors with `rmdir` and `rename` called on paths with a trailing slash.

This PR looks to first normalize the path, leading to at most one trailing slash remaining in the path, and then removing that trailing slash.

## Testing
```
mdhwang:~/emscripten$ python3 tests/runner.py test_rename
tests/runner.py:WARNING: use EMTEST_ALL_ENGINES=1 in the env to run against all JS engines, which is slower but provides more coverage
WARNING: no 'numpy' module, HyBi protocol will be slower
Test suites:
['test_core']
Running test_core: (1 tests)
(checking sanity from test runner)
shared:INFO: (Emscripten: Running sanity checks)
test_rename (test_core.wasm0) ... ok

----------------------------------------------------------------------
Ran 1 test in 0.450s

OK
```

Closes #11897