### PR TITLE
Don't error out if `_main` is in user exported functions in standalon…

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -750,9 +750,15 @@ def get_all_implemented(forwarded_json, metadata):
 
 
 def report_missing_symbols(all_implemented, pre):
+  required_symbols = set(shared.Settings.USER_EXPORTED_FUNCTIONS)
+  # In standalone mode a request for `_main` is interpreted as a request for `_start`
+  # so don't warn about mossing main.
+  if shared.Settings.STANDALONE_WASM and '_main' in required_symbols:
+    required_symbols.discard('_main')
+
   # the initial list of missing functions are that the user explicitly exported
   # but were not implemented in compiled code
-  missing = list(set(shared.Settings.USER_EXPORTED_FUNCTIONS) - all_implemented)
+  missing = list(required_symbols - all_implemented)
 
   for requested in missing:
     if ('function ' + asstr(requested)) in pre:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9820,3 +9820,12 @@ int main () {
     # Test that output name is just `a.out` and that it is directly executable
     output = self.run_process([os.path.abspath('a.out')], stdout=PIPE).stdout
     self.assertContained('hello, world!', output)
+
+  def test_standalone_export_main(self):
+    # Tests that explictly exported `_main` does not fail.   Since we interpret an
+    # export of `_main` to be be an export of `__start` in standalone mode the
+    # actual main function is not exported, but we also don't want to report an
+    # error
+    self.set_setting('STANDALONE_WASM')
+    self.set_setting('EXPORTED_FUNCTIONS', ['_main'])
+    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')


### PR DESCRIPTION
…e mode.

Fixes #11939