### PR TITLE
Refactor Runner.do_run family of functions to allow compiling from file

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -585,11 +585,10 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     return args
 
   # Build JavaScript code from source code
-  def build(self, filename,
-            libraries=[], includes=[],
+  def build(self, filename, libraries=[], includes=[], force_c=False,
             post_build=None, js_outfile=True):
     suffix = '.js' if js_outfile else '.wasm'
-    if shared.suffix(filename) in ('.cc', '.cxx', '.cpp'):
+    if shared.suffix(filename) in ('.cc', '.cxx', '.cpp') and not force_c:
       compiler = EMXX
     else:
       compiler = EMCC
@@ -1052,11 +1051,21 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     banned = [b[0] for b in self.banned_js_engines if b]
     return [engine for engine in js_engines if engine and engine[0] not in banned]
 
-  def do_run_from_file(self, src, expected_output, *args, **kwargs):
-    if 'force_c' not in kwargs and os.path.splitext(src)[1] == '.c':
-      kwargs['force_c'] = True
-    logger.debug('do_run_from_file: %s' % src)
-    self.do_run(open(src).read(), open(expected_output).read(), *args, **kwargs)
+  def do_run(self, src, expected_output, force_c=False, **kwargs):
+    if 'no_build' in kwargs:
+      filename = src
+    else:
+      if force_c:
+        filename = 'src.c'
+      else:
+        filename = 'src.cpp'
+      with open(filename, 'w') as f:
+        f.write(src)
+    self._build_and_run(filename, expected_output, **kwargs)
+
+  ## Just like `do_run` but with filename of expected output
+  def do_run_from_file(self, filename, expected_output, **kwargs):
+    self._build_and_run(filename, open(expected_output).read(), **kwargs)
 
   def do_run_in_out_file_test(self, *path, **kwargs):
     test_path = path_from_root(*path)
@@ -1074,34 +1083,26 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
                           .format(test_path, ext_list))
       return ret
 
-    src = find_files('.c', '.cpp')
-    output = find_files('.out', '.txt')
-    self.do_run_from_file(src, output, **kwargs)
+    srcfile = find_files('.c', '.cpp')
+    outfile = find_files('.out', '.txt')
+    expected = open(outfile).read()
+    self._build_and_run(srcfile, expected, **kwargs)
 
   ## Does a complete test - builds, runs, checks output, etc.
-  def do_run(self, src, expected_output, args=[], output_nicerizer=None,
-             no_build=False,
-             js_engines=None, post_build=None, libraries=[],
-             includes=[], force_c=False,
-             assert_returncode=0, assert_identical=False, assert_all=False,
-             check_for_error=True):
-    if force_c:
-      basename = 'src.c'
-    else:
-      basename = 'src.cpp'
+  def _build_and_run(self, filename, expected_output, args=[], output_nicerizer=None,
+                     no_build=False,
+                     js_engines=None, post_build=None, libraries=[],
+                     includes=[],
+                     assert_returncode=0, assert_identical=False, assert_all=False,
+                     check_for_error=True, force_c=False):
+    logger.debug('_build_and_run: %s' % filename)
 
     if no_build:
-      if src:
-        js_file = src
-      else:
-        js_file = shared.unsuffixed(basename) + '.js'
+      js_file = filename
     else:
-      dirname = self.get_dir()
-      filename = os.path.join(dirname, basename)
-      with open(filename, 'w') as f:
-        f.write(src)
-      self.build(filename, libraries=libraries, includes=includes, post_build=post_build)
-      js_file = shared.unsuffixed(filename) + '.js'
+      self.build(filename, libraries=libraries, includes=includes, post_build=post_build,
+                 force_c=force_c)
+      js_file = shared.unsuffixed(os.path.basename(filename)) + '.js'
     self.assertExists(js_file)
 
     engines = self.filtered_js_engines(js_engines)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6027,31 +6027,31 @@ return malloc(size);
     shutil.copyfile(path_from_root('tests', 'freetype', 'LiberationSansBold.ttf'), 'font.ttf')
 
     # Main
-    self.do_run(open(path_from_root('tests', 'freetype', 'main.c')).read(),
-                open(path_from_root('tests', 'freetype', 'ref.txt')).read(),
-                ['font.ttf', 'test!', '150', '120', '25'],
-                libraries=self.get_freetype_library(),
-                includes=[path_from_root('tests', 'third_party', 'freetype', 'include')])
+    self.do_run_from_file(path_from_root('tests', 'freetype', 'main.c'),
+                          path_from_root('tests', 'freetype', 'ref.txt'),
+                          args=['font.ttf', 'test!', '150', '120', '25'],
+                          libraries=self.get_freetype_library(),
+                          includes=[path_from_root('tests', 'third_party', 'freetype', 'include')])
 
     # github issue 324
     print('[issue 324]')
-    self.do_run(open(path_from_root('tests', 'freetype', 'main_2.c')).read(),
-                open(path_from_root('tests', 'freetype', 'ref_2.txt')).read(),
-                ['font.ttf', 'w', '32', '32', '25'],
-                libraries=self.get_freetype_library(),
-                includes=[path_from_root('tests', 'third_party', 'freetype', 'include')])
+    self.do_run_from_file(path_from_root('tests', 'freetype', 'main_2.c'),
+                          path_from_root('tests', 'freetype', 'ref_2.txt'),
+                          args=['font.ttf', 'w', '32', '32', '25'],
+                          libraries=self.get_freetype_library(),
+                          includes=[path_from_root('tests', 'third_party', 'freetype', 'include')])
 
     print('[issue 324 case 2]')
-    self.do_run(open(path_from_root('tests', 'freetype', 'main_3.c')).read(),
-                open(path_from_root('tests', 'freetype', 'ref_3.txt')).read(),
-                ['font.ttf', 'W', '32', '32', '0'],
-                libraries=self.get_freetype_library(),
-                includes=[path_from_root('tests', 'third_party', 'freetype', 'include')])
+    self.do_run_from_file(path_from_root('tests', 'freetype', 'main_3.c'),
+                          path_from_root('tests', 'freetype', 'ref_3.txt'),
+                          args=['font.ttf', 'W', '32', '32', '0'],
+                          libraries=self.get_freetype_library(),
+                          includes=[path_from_root('tests', 'third_party', 'freetype', 'include')])
 
     print('[issue 324 case 3]')
-    self.do_run(None,
+    self.do_run('main_3.js',
                 open(path_from_root('tests', 'freetype', 'ref_4.txt')).read(),
-                ['font.ttf', 'ea', '40', '32', '0'],
+                args=['font.ttf', 'ea', '40', '32', '0'],
                 no_build=True)
 
   @no_asan('local count too large for VMs')
@@ -6251,7 +6251,7 @@ return malloc(size);
     def do_test():
       self.do_run(open(path_from_root('tests', 'third_party', 'openjpeg', 'codec', 'j2k_to_image.c')).read(),
                   'Successfully generated', # The real test for valid output is in image_compare
-                  '-i image.j2k -o image.raw'.split(' '),
+                  args='-i image.j2k -o image.raw'.split(),
                   libraries=lib,
                   includes=[path_from_root('tests', 'third_party', 'openjpeg', 'libopenjpeg'),
                             path_from_root('tests', 'third_party', 'openjpeg', 'codec'),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -305,7 +305,7 @@ class TestCoreBase(RunnerCore):
   def test_hello_world(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
     # must not emit this unneeded internal thing
-    self.assertNotContained('EMSCRIPTEN_GENERATED_FUNCTIONS', open('src.js').read())
+    self.assertNotContained('EMSCRIPTEN_GENERATED_FUNCTIONS', open('test_hello_world.js').read())
 
   @sync
   def test_wasm_synchronous_compilation(self):
@@ -467,14 +467,14 @@ class TestCoreBase(RunnerCore):
   @needs_make('make')
   def test_cube2hash(self):
     # A good test of i64 math
-    self.do_run('', 'Usage: hashstring <seed>',
+    self.do_run('// empty file', 'Usage: hashstring <seed>',
                 libraries=self.get_library('cube2hash', ['cube2hash.bc'], configure=None),
                 includes=[path_from_root('tests', 'cube2hash')], assert_returncode=NON_ZERO)
 
     for text, output in [('fleefl', '892BDB6FD3F62E863D63DA55851700FDE3ACF30204798CE9'),
                          ('fleefl2', 'AA2CC5F96FC9D540CA24FDAF1F71E2942753DB83E8A81B61'),
                          ('64bitisslow', '64D8470573635EC354FEE7B7F87C566FCAF1EFB491041670')]:
-      self.do_run('src.js', 'hash value: ' + output, [text], no_build=True)
+      self.do_run('src.js', 'hash value: ' + output, args=[text], no_build=True)
 
   def test_unaligned(self):
     self.skipTest('LLVM marks the reads of s as fully aligned, making this test invalid')
@@ -1262,11 +1262,11 @@ int main(int argc, char **argv)
 '''
 
     print('0')
-    self.do_run(src, 'Caught C string: a c string\nDone.', ['0'])
+    self.do_run(src, 'Caught C string: a c string\nDone.', args=['0'])
     print('1')
-    self.do_run(None, 'Caught exception: std::exception\nDone.', ['1'], no_build=True)
+    self.do_run('src.js', 'Caught exception: std::exception\nDone.', args=['1'], no_build=True)
     print('2')
-    self.do_run(None, 'Caught exception: Hello\nDone.', ['2'], no_build=True)
+    self.do_run('src.js', 'Caught exception: Hello\nDone.', args=['2'], no_build=True)
 
   def test_exceptions_allowed(self):
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 2)
@@ -1279,26 +1279,26 @@ int main(int argc, char **argv)
     test_path = path_from_root('tests', 'core', 'test_exceptions_allowed')
     src, output = (test_path + s for s in ('.cpp', '.out'))
     self.do_run_from_file(src, output)
-    size = len(open('src.js').read())
-    shutil.copyfile('src.js', 'orig.js')
+    size = len(open('test_exceptions_allowed.js').read())
+    shutil.copyfile('test_exceptions_allowed.js', 'orig.js')
 
     # check that an empty whitelist works properly (as in, same as exceptions disabled)
     empty_output = path_from_root('tests', 'core', 'test_exceptions_allowed_empty.out')
 
     self.set_setting('EXCEPTION_CATCHING_ALLOWED', [])
     self.do_run_from_file(src, empty_output, assert_returncode=NON_ZERO)
-    empty_size = len(open('src.js').read())
-    shutil.copyfile('src.js', 'empty.js')
+    empty_size = len(open('test_exceptions_allowed.js').read())
+    shutil.copyfile('test_exceptions_allowed.js', 'empty.js')
 
     self.set_setting('EXCEPTION_CATCHING_ALLOWED', ['fake'])
     self.do_run_from_file(src, empty_output, assert_returncode=NON_ZERO)
-    fake_size = len(open('src.js').read())
-    shutil.copyfile('src.js', 'fake.js')
+    fake_size = len(open('test_exceptions_allowed.js').read())
+    shutil.copyfile('test_exceptions_allowed.js', 'fake.js')
 
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
     self.do_run_from_file(src, empty_output, assert_returncode=NON_ZERO)
-    disabled_size = len(open('src.js').read())
-    shutil.copyfile('src.js', 'disabled.js')
+    disabled_size = len(open('test_exceptions_allowed.js').read())
+    shutil.copyfile('test_exceptions_allowed.js', 'disabled.js')
 
     if not self.is_wasm():
       print(size, empty_size, fake_size, disabled_size)
@@ -3604,7 +3604,7 @@ ok
       # main is just a library
       try_delete('src.js')
       self.run_process([EMCC] + main + self.emcc_args + self.serialize_settings() + ['-o', 'src.js'])
-      self.do_run(None, expected, no_build=True, **kwargs)
+      self.do_run('src.js', expected, no_build=True, **kwargs)
     else:
       self.do_run(main, expected, force_c=force_c, **kwargs)
 
@@ -5709,7 +5709,7 @@ int main(void) {
     self.build(path_from_root('tests', 'fannkuch.cpp'))
     for i, j in results:
       print(i, j)
-      self.do_run('fannkuch.js', 'Pfannkuchen(%d) = %d.' % (i, j), [str(i)], no_build=True)
+      self.do_run('fannkuch.js', 'Pfannkuchen(%d) = %d.' % (i, j), args=[str(i)], no_build=True)
 
   def test_raytrace(self):
     # TODO: Should we remove this test?
@@ -5717,7 +5717,7 @@ int main(void) {
 
     src = open(path_from_root('tests', 'raytrace.cpp')).read().replace('double', 'float')
     output = open(path_from_root('tests', 'raytrace.ppm')).read()
-    self.do_run(src, output, ['3', '16'])
+    self.do_run(src, output, args=['3', '16'])
 
   def test_fasta(self):
     results = [(1, '''GG*ctt**tgagc*'''),
@@ -5736,7 +5736,7 @@ int main(void) {
           f.write(src)
         self.build('fasta.cpp')
         for arg, output in results:
-          self.do_run('fasta.js', output, [str(arg)], lambda x, err: x.replace('\n', '*'), no_build=True)
+          self.do_run('fasta.js', output, args=[str(arg)], output_nicerizer=lambda x, err: x.replace('\n', '*'), no_build=True)
         shutil.copyfile('fasta.js', '%s.js' % t)
 
     test([])
@@ -5755,8 +5755,8 @@ int main(void) {
     self.set_setting('INITIAL_MEMORY', 128 * 1024 * 1024)
 
     src = open(path_from_root('system', 'lib', 'dlmalloc.c')).read() + '\n\n\n' + open(path_from_root('tests', 'dlmalloc_test.c')).read()
-    self.do_run(src, '*1,0*', ['200', '1'], force_c=True)
-    self.do_run(None, '*400,0*', ['400', '400'], force_c=True, no_build=True)
+    self.do_run(src, '*1,0*', args=['200', '1'], force_c=True)
+    self.do_run('src.js', '*400,0*', args=['400', '400'], force_c=True, no_build=True)
 
   def test_dlmalloc(self):
     self.banned_js_engines = [NODE_JS] # slower, and fail on 64-bit
@@ -5765,8 +5765,8 @@ int main(void) {
 
     # Linked version
     src = open(path_from_root('tests', 'dlmalloc_test.c')).read()
-    self.do_run(src, '*1,0*', ['200', '1'])
-    self.do_run(None, '*400,0*', ['400', '400'], no_build=True)
+    self.do_run(src, '*1,0*', args=['200', '1'])
+    self.do_run('src.js', '*400,0*', args=['400', '400'], no_build=True)
 
     # TODO: do this in other passes too, passing their opts into emcc
     if self.emcc_args == []:
@@ -7648,8 +7648,8 @@ Module['onRuntimeInitialized'] = function() {
       self.emcc_args += ['-DCONDITIONAL']
     self.do_run_in_out_file_test('tests', 'core', 'emscripten_lazy_load_code', args=['0'])
 
-    first_size = os.path.getsize('src.wasm')
-    second_size = os.path.getsize('src.wasm.lazy.wasm')
+    first_size = os.path.getsize('emscripten_lazy_load_code.wasm')
+    second_size = os.path.getsize('emscripten_lazy_load_code.wasm.lazy.wasm')
     print('first wasm size', first_size)
     print('second wasm size', second_size)
     if not conditional and is_optimizing(self.emcc_args):
@@ -7657,8 +7657,8 @@ Module['onRuntimeInitialized'] = function() {
       # out more than half
       self.assertLess(first_size, 0.5 * second_size)
 
-    with open('src.wasm', 'rb') as f:
-      with open('src.wasm.lazy.wasm', 'rb') as g:
+    with open('emscripten_lazy_load_code.wasm', 'rb') as f:
+      with open('emscripten_lazy_load_code.wasm.lazy.wasm', 'rb') as g:
         self.assertNotEqual(f.read(), g.read())
 
     # attempts to "break" the wasm by adding an unreachable in $foo_end. returns whether we found it.
@@ -7686,33 +7686,33 @@ Module['onRuntimeInitialized'] = function() {
       return True
 
     def verify_working(args=['0']):
-      self.assertContained('foo_end\n', self.run_js('src.js', args=args))
+      self.assertContained('foo_end\n', self.run_js('emscripten_lazy_load_code.js', args=args))
 
     def verify_broken(args=['0']):
-      self.assertNotContained('foo_end\n', self.run_js('src.js', args=args, assert_returncode=NON_ZERO))
+      self.assertNotContained('foo_end\n', self.run_js('emscripten_lazy_load_code.js', args=args, assert_returncode=NON_ZERO))
 
     # the first-loaded wasm will not reach the second call, since we call it after lazy-loading.
     # verify that by changing the first wasm to throw in that function
-    found_foo_end = break_wasm('src.wasm')
+    found_foo_end = break_wasm('emscripten_lazy_load_code.wasm')
     if not conditional and is_optimizing(self.emcc_args):
       self.assertFalse(found_foo_end, 'should have optimizd out $foo_end')
     verify_working()
     # but breaking the second wasm actually breaks us
-    break_wasm('src.wasm.lazy.wasm')
+    break_wasm('emscripten_lazy_load_code.wasm.lazy.wasm')
     verify_broken()
 
     # restore
-    shutil.copyfile('src.wasm.orig', 'src.wasm')
-    shutil.copyfile('src.wasm.lazy.wasm.orig', 'src.wasm.lazy.wasm')
+    shutil.copyfile('emscripten_lazy_load_code.wasm.orig', 'emscripten_lazy_load_code.wasm')
+    shutil.copyfile('emscripten_lazy_load_code.wasm.lazy.wasm.orig', 'emscripten_lazy_load_code.wasm.lazy.wasm')
     verify_working()
 
     if conditional:
       # if we do not call the lazy load function, then we do not need the lazy wasm,
       # and we do the second call in the first wasm
-      os.remove('src.wasm.lazy.wasm')
+      os.remove('emscripten_lazy_load_code.wasm.lazy.wasm')
       verify_broken()
       verify_working(['42'])
-      break_wasm('src.wasm')
+      break_wasm('emscripten_lazy_load_code.wasm')
       verify_broken()
 
   # Test basic wasm2js functionality in all core compilation modes.
@@ -7724,11 +7724,12 @@ Module['onRuntimeInitialized'] = function() {
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
     # a mem init file is emitted just like with JS
     expect_memory_init_file = self.uses_memory_init_file()
-    see_memory_init_file = os.path.exists('src.js.mem')
-    assert expect_memory_init_file == see_memory_init_file, 'memory init file expectation wrong: %s' % expect_memory_init_file
-    if see_memory_init_file:
-      with open('src.js.mem', 'rb') as f:
+    if expect_memory_init_file:
+      self.assertExists('test_hello_world.js.mem')
+      with open('test_hello_world.js.mem', 'rb') as f:
         self.assertTrue(f.read()[-1] != b'\0')
+    else:
+      self.assertNotExists('test_hello_world.js.mem')
 
   @no_asan('no wasm2js support yet in asan')
   def test_maybe_wasm2js(self):
@@ -7738,12 +7739,12 @@ Module['onRuntimeInitialized'] = function() {
     # see that running as wasm works
     self.do_run_in_out_file_test('tests', 'core', 'test_hello_world')
     # run wasm2js, bundle the code, and use the wasm2js path
-    cmd = [PYTHON, path_from_root('tools', 'maybe_wasm2js.py'), 'src.js', 'src.wasm']
+    cmd = [PYTHON, path_from_root('tools', 'maybe_wasm2js.py'), 'test_hello_world.js', 'test_hello_world.wasm']
     if is_optimizing(self.emcc_args):
       cmd += ['-O2']
     self.run_process(cmd, stdout=open('do_wasm2js.js', 'w')).stdout
     # remove the wasm to make sure we never use it again
-    os.remove('src.wasm')
+    os.remove('test_hello_world.wasm')
     # verify that it runs
     self.assertContained('hello, world!', self.run_js('do_wasm2js.js'))
 
@@ -7909,7 +7910,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
     def test(assert_returncode=0):
       self.do_run_in_out_file_test('tests', 'core', 'test_hello_world', assert_returncode=assert_returncode)
-      js = open('src.js').read()
+      js = open('test_hello_world.js').read()
       assert ('require(' in js) == ('node' in self.get_setting('ENVIRONMENT')), 'we should have require() calls only if node js specified'
 
     for engine in JS_ENGINES:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9670,7 +9670,7 @@ int main() {
     src = path_from_root('tests', 'core', 'test_support_errno.c')
     output = path_from_root('tests', 'core', 'test_support_errno.out')
     self.do_run_from_file(src, output)
-    size_default = os.path.getsize('src.js')
+    size_default = os.path.getsize('test_support_errno.js')
 
     # Run the same test again but with SUPPORT_ERRNO disabled.  This time we don't expect errno
     # to be set after the failing syscall.
@@ -9679,7 +9679,7 @@ int main() {
     self.do_run_from_file(src, output)
 
     # Verify the JS output was smaller
-    self.assertLess(os.path.getsize('src.js'), size_default)
+    self.assertLess(os.path.getsize('test_support_errno.js'), size_default)
 
   def test_assembly(self):
     self.run_process([EMCC, '-c', path_from_root('tests', 'other', 'test_asm.s'), '-o', 'foo.o'])


### PR DESCRIPTION
Previously even do_run_from_file and do_run_in_out_file_test would
read the inputs into a string and then write them back out before
compiling them.

This change inverts the logic such that the underlying implemention
expects as file and the `do_run` helper which accepts string creates
the file before calling it.

This leads to way better error message for tests that do run from
files.