### PR TITLE
Timezone should be set based on standard time

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -494,4 +494,5 @@ a license to everyone to use it as detailed in LICENSE.)
 * Mathias Westerdahl <mwesterdahl76@gmail.com>
 * Philip Rideout <prideout@google.com> (copyright owned by Google, LLC)
 * Shrek Shao (shrekshao@google.com) (copyright owned by Google, LLC)
+* Tristan Griffin <tgriff34@uncc.edu>
 * Arran Ireland <ion92@protonmail.com>

--- a/src/library.js
+++ b/src/library.js
@@ -2028,16 +2028,21 @@ LibraryManager.library = {
     if (_tzset.called) return;
     _tzset.called = true;
 
+    var currentYear = new Date().getFullYear();
+    var winter = new Date(currentYear, 0, 1);
+    var summer = new Date(currentYear, 6, 1);
+
+    Date.prototype.stdTimezoneOffset = function() {
+        return Math.max(winter.getTimezoneOffset(), summer.getTimezoneOffset());
+    }
+
     // timezone is specified as seconds west of UTC ("The external variable
     // `timezone` shall be set to the difference, in seconds, between
     // Coordinated Universal Time (UTC) and local standard time."), the same
     // as returned by getTimezoneOffset().
     // See http://pubs.opengroup.org/onlinepubs/009695399/functions/tzset.html
-    {{{ makeSetValue('__get_timezone()', '0', '(new Date()).getTimezoneOffset() * 60', 'i32') }}};
+    {{{ makeSetValue('__get_timezone()', '0', '(new Date().stdTimezoneOffset()) * 60', 'i32') }}};
 
-    var currentYear = new Date().getFullYear();
-    var winter = new Date(currentYear, 0, 1);
-    var summer = new Date(currentYear, 6, 1);
     {{{ makeSetValue('__get_daylight()', '0', 'Number(winter.getTimezoneOffset() != summer.getTimezoneOffset())', 'i32') }}};
 
     function extractZone(date) {

--- a/src/library.js
+++ b/src/library.js
@@ -2039,7 +2039,7 @@ LibraryManager.library = {
     // timezone is specified as seconds west of UTC ("The external variable
     // `timezone` shall be set to the difference, in seconds, between
     // Coordinated Universal Time (UTC) and local standard time."), the same
-    // as returned by getTimezoneOffset().
+    // as returned by stdTimezoneOffset().
     // See http://pubs.opengroup.org/onlinepubs/009695399/functions/tzset.html
     {{{ makeSetValue('__get_timezone()', '0', '(new Date().stdTimezoneOffset()) * 60', 'i32') }}};
 

--- a/tests/tztest.cpp
+++ b/tests/tztest.cpp
@@ -1,8 +1,0 @@
-#include <time.h>
-#include <stdio.h>
-
-int main() {
-  tzset();
-  printf("timezone=%ld", timezone);
-  return 0;
-}

--- a/tests/tztest.cpp
+++ b/tests/tztest.cpp
@@ -1,0 +1,8 @@
+#include <time.h>
+#include <stdio.h>
+
+int main() {
+  tzset();
+  printf("timezone=%ld", timezone);
+  return 0;
+}


### PR DESCRIPTION
Timezone would return 4 hours instead of the expected 5 hours for the east coast.

Fixes #11572 