### PR TITLE
Remove fastcomp-specific WEAK_DECLARES internal setting. see #11860

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -479,7 +479,6 @@ def update_settings_glue(metadata, DEBUG):
 
   shared.Settings.MAX_GLOBAL_ALIGN = metadata['maxGlobalAlign']
   shared.Settings.IMPLEMENTED_FUNCTIONS = metadata['implementedFunctions']
-  shared.Settings.WEAK_DECLARES = metadata.get('weakDeclares', [])
 
   if metadata['asmConsts']:
     # emit the EM_ASM signature-reading helper function only if we have any EM_ASM

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -49,8 +49,6 @@ var proxiedFunctionInvokers = {};
 // static ctors, even if there is no user main.
 var HAS_MAIN = ('_main' in IMPLEMENTED_FUNCTIONS) || MAIN_MODULE || SIDE_MODULE || STANDALONE_WASM;
 
-WEAK_DECLARES = set(WEAK_DECLARES);
-
 // Mangles the given C/JS side function name to assembly level function name (adds an underscore)
 function mangleCSymbolName(f) {
   return f[0] == '$' ? f.substr(1) : '_' + f;
@@ -164,7 +162,7 @@ function JSify(data, functionsOnly) {
         usedExternPrimitives[ident] = 1;
         return;
       } else if ((!LibraryManager.library.hasOwnProperty(ident) && !LibraryManager.library.hasOwnProperty(ident + '__inline')) || SIDE_MODULE) {
-        if (!(finalName in IMPLEMENTED_FUNCTIONS) && !(finalName in WEAK_DECLARES) && !LINKABLE) {
+        if (!(finalName in IMPLEMENTED_FUNCTIONS) && !LINKABLE) {
           var msg = 'undefined symbol: ' + ident;
           if (dependent) msg += ' (referenced by ' + dependent + ')';
           if (ERROR_ON_UNDEFINED_SYMBOLS) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -501,7 +501,6 @@ var GL_DISABLE_HALF_FLOAT_EXTENSION_IF_BROKEN = 0;
 // compiled musl code. However, it can be significantly slower as it calls out to JS. It
 // also may give different results as JS math is specced somewhat differently than libc, and
 // can also vary between browsers.
-// [upstream-only]
 var JS_MATH = 0;
 
 // If set, enables polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround.
@@ -1086,10 +1085,6 @@ var USE_GLFW = 2;
 
 // Whether to use compile code to WebAssembly. Set this to 0 to compile to JS
 // instead of wasm.
-//
-// Note that in upstream, WASM=0 behaves very similarly to WASM=1, in particular
-// startup can be either async or sync, so flags like WASM_ASYNC_COMPILATION
-// still make sense there, see that option for more details.
 //
 // Specify -s WASM=2 to target both WebAssembly and JavaScript at the same time.
 // In that build mode, two files a.wasm and a.wasm.js are produced, and at runtime

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -75,10 +75,6 @@ var MAX_GLOBAL_ALIGN = -1;
 // List of functions implemented in compiled code; received from the backend.
 var IMPLEMENTED_FUNCTIONS = [];
 
-// List of weakly undefined externals; received from the backend
-// fastcomp-only
-var WEAK_DECLARES = [];
-
 // Name of the file containing the Fetch *.fetch.js, if relevant
 var FETCH_WORKER_FILE = '';
 


### PR DESCRIPTION
Once this and #11942 are landed, we are rid of all fastcomp-specific settings.