### PR TITLE
Remove no-WASM_BACKEND code in emscripten.py. See #11860

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -14,3 +14,4 @@ exclude =
  ./tools/ffdb.py,
  ./system/lib/, # system libraries
  ./cache/, # download/built content
+ .git


### PR DESCRIPTION
The hilarious flake8 errors are apparently because the branch name
ends in `.py`

![and flake8 is confused](https://i.imgflip.com/4bw8is.jpg)