### PR TITLE
Fix Wasm2JS polyfill of Promise .catch() handler to work in WASM=2 mode

### DIFF
--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -77,7 +77,7 @@ WebAssembly = {
 #endif
           'instance': new WebAssembly.Instance(module)
         });
-#if ASSERTIONS || WASM == 2
+#if ASSERTIONS || WASM == 2 // see postamble_minimal.js which uses .catch
         // Emulate a simple WebAssembly.instantiate(..).then(()=>{}).catch(()=>{}) syntax.
         return { catch: function() {} };
 #endif

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -77,7 +77,7 @@ WebAssembly = {
 #endif
           'instance': new WebAssembly.Instance(module)
         });
-#if ASSERTIONS
+#if ASSERTIONS || WASM == 2
         // Emulate a simple WebAssembly.instantiate(..).then(()=>{}).catch(()=>{}) syntax.
         return { catch: function() {} };
 #endif


### PR DESCRIPTION
This cleans up a noisy red herring error appearing in -s WASM=2 builds in MINIMAL_RUNTIME=1, when it registers a `.catch()` handler (that is not used when Wasm2JS is already active), and the Promise polyfill did not implement `.catch()`. 

To fix make this #if match the one in https://github.com/emscripten-core/emscripten/blob/b8fd9a06bcd49fbbf1e244cdeb39e0b41f36644b/src/postamble_minimal.js#L210 .