### PR TITLE
Remove duplicate `makeDynCall` function in parseTools.js. NFC

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1459,6 +1459,8 @@ function asmFFICoercion(value, type) {
 }
 
 function makeDynCall(sig) {
+  // TODO(sbc): Should this be: exportedAsmFunc('dynCall_' + sig);
+  // See https://github.com/emscripten-core/emscripten/pull/11991;
   return 'dynCall_' + sig;
 }
 


### PR DESCRIPTION
The first one was declared as:

```
function makeDynCall(sig) {
  return exportedAsmFunc('dynCall_' + sig);
}
```

The second one was declared as:

```
function makeDynCall(sig) {
  return 'dynCall_' + sig;
}
```

Since the second declaration overides the first one I can only
conclude the the first one has never been active and there is
not needed.