### PR TITLE
Stop running --inline-main

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,7 +17,7 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
-- Do not remove `__original_main` using `--no-inline-main`. We used to do this
+- Do not remove `__original_main` using `--inline-main`. We used to do this
   so that it didn't show up in stack traces (which could be confusing because
   it is added by the linker - it's not in the source code). But this has had
   several downsides, so we are stopping that now. This does not affect program

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,16 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Do not remove `__original_main` using `--no-inline-main`. We used to do this
+  so that it didn't show up in stack traces (which could be confusing because
+  it is added by the linker - it's not in the source code). But this has had
+  several downsides, so we are stopping that now. This does not affect program
+  behavior, unless you look at the wasm internals. However, one noticeable
+  effect is that if you use `ASYNCIFY_ADD` or `ASYNCIFY_ONLY` then you may need
+  to add `__original_main` to there (since you are doing manual fine-tuning of
+  the list of functions, which depends on the wasm's internals). Note that this
+  should not matter in `-O2+` anyhow as normal inlining generally removes
+  `__original_main`.
 
 2.0.1: 08/21/2020
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -589,12 +589,6 @@ def backend_binaryen_passes():
   if shared.Settings.SAFE_HEAP:
     passes += ['--safe-heap']
   passes += ['--post-emscripten']
-  # always inline __original_main into main, as otherwise it makes debugging confusing,
-  # and doing so is never bad for code size
-  # FIXME however, don't do it with DWARF for now, as inlining is not
-  #       fully handled in DWARF updating yet
-  if shared.Settings.DEBUG_LEVEL < 3:
-    passes += ['--inline-main']
   if not shared.Settings.EXIT_RUNTIME:
     passes += ['--no-exit-runtime']
   if shared.Settings.OPT_LEVEL > 0 or shared.Settings.SHRINK_LEVEL > 0:

--- a/tests/other/metadce/hello_world_O1.funcs
+++ b/tests/other/metadce/hello_world_O1.funcs
@@ -4,6 +4,7 @@ $__errno_location
 $__fwritex
 $__growWasmMemory
 $__lockfile
+$__original_main
 $__overflow
 $__stdio_write
 $__towrite

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7570,7 +7570,7 @@ Module['onRuntimeInitialized'] = function() {
   @parameterized({
     'normal': ([], True),
     'ignoreindirect': (['-s', 'ASYNCIFY_IGNORE_INDIRECT'], False),
-    'add': (['-s', 'ASYNCIFY_IGNORE_INDIRECT', '-s', 'ASYNCIFY_ADD=["main","virt()"]'], True),
+    'add': (['-s', 'ASYNCIFY_IGNORE_INDIRECT', '-s', 'ASYNCIFY_ADD=["__original_main","main","virt()"]'], True),
   })
   @no_asan('asan is not compatible with asyncify stack operations; may also need to not instrument asan_c_load_4, TODO')
   def test_asyncify_indirect_lists(self, args, should_pass):


### PR DESCRIPTION
LLVM adding `__original_main` can be confusing for users, as it shows up in
stack traces, and they don't expect it. So we added a pass to inline that into
`main`, and we ran it on all builds, debug and release. However, this has some
downsides:

* As a comment that this PR removes shows, we actually stopped doing
  this in debug builds because it can mess with DWARF. So the place we need
  it most is no longer relevant anyhow, and it wasn't actually helping us with
  debugging - @dschuff unless I'm missing something?
* It is more work and complexity during link, which we are trying to reduce,
  see WebAssembly/binaryen#3043 
* There are some planned changes to these functions and `_start` and all
  that anyhow (see discussion on the PR) so this will become irrelevant soon.

This does not affect behavior, unless you look at the wasm internals. But a noticeable
effect is that if you use `ASYNCIFY_ADD` or `ASYNCIFY_ONLY` then you may need
to add `__original_main` to there (since you are doing manual fine-tuning of
the list of functions, which depends on the wasm's internals) - see the test change
here.

Note that this should not matter in `-O2+` anyhow as normal inlining generally removes
`__original_main`.
