### PR TITLE
Only run --low-memory-unused when optimizing

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -603,7 +603,9 @@ def backend_binaryen_passes():
     # even if not optimizing, make an effort to remove all unused imports and
     # exports, to make the wasm as standalone as possible
     passes += ['--remove-unused-module-elements']
-  if shared.Settings.GLOBAL_BASE >= 1024: # hardcoded value in the binaryen pass
+  # when optimizing, use the fact that low memory is never used (1024 is a
+  # hardcoded value in the binaryen pass)
+  if shared.Settings.OPT_LEVEL > 0 and shared.Settings.GLOBAL_BASE >= 1024:
     passes += ['--low-memory-unused']
   if shared.Settings.DEBUG_LEVEL < 3:
     passes += ['--strip-debug']


### PR DESCRIPTION
Helps WebAssembly/binaryen#3043