### PR TITLE
Require python3 in test code

### DIFF
--- a/tests/fuzz/creduce_tester.py
+++ b/tests/fuzz/creduce_tester.py
@@ -7,7 +7,6 @@
 """Usage: creduce ./creduce_tester.py newfail1.c
 """
 
-from __future__ import print_function
 import os
 import sys
 from subprocess import Popen, PIPE

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -8,7 +8,6 @@
 
 CSMITH_PATH should be set to something like /usr/local/include/csmith
 """
-from __future__ import print_function
 
 import os
 import sys

--- a/tests/parallel_testsuite.py
+++ b/tests/parallel_testsuite.py
@@ -3,22 +3,15 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import multiprocessing
 import os
-import subprocess
 import sys
 import unittest
 import tempfile
 import time
+import queue
 
 from tools.tempfiles import try_delete
-
-try:
-  import queue
-except ImportError:
-  # Python 2 compatibility
-  import Queue as queue
 
 
 def g_testing_thread(work_queue, result_queue, temp_dir):
@@ -166,11 +159,6 @@ class BufferedTestBase(object):
     self.test = test
     if err:
       exctype, value, tb = err
-      if exctype == subprocess.CalledProcessError:
-        # multiprocess.Queue can't serialize a subprocess.CalledProcessError.
-        # This is a bug in python 2.7 (https://bugs.python.org/issue9400)
-        exctype = Exception
-        value = Exception(str(value))
       self.error = exctype, value, FakeTraceback(tb)
 
   def updateResult(self, result):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -17,7 +17,13 @@ http://kripken.github.io/emscripten-site/docs/getting_started/test-suite.html
 
 # XXX Use EMTEST_ALL_ENGINES=1 in the env to test all engines!
 
-from __future__ import print_function
+import sys
+
+# The emscripten test suite explcitly requires python3.6 or above.
+if sys.version_info < (3, 6):
+  print('error: emscripten requires python 3.6 or above', file=sys.stderr)
+  sys.exit(1)
+
 from subprocess import PIPE, STDOUT
 from functools import wraps
 import argparse
@@ -81,7 +87,7 @@ def delete_contents(pathname):
 
 sys.path.append(path_from_root('third_party/websockify'))
 
-logger = logging.getLogger(__file__)
+logger = logging.getLogger("runner")
 
 # User can specify an environment variable EMTEST_BROWSER to force the browser
 # test suite to run using another browser command line than the default system
@@ -357,14 +363,14 @@ class RunnerMeta(type):
 
     # Add suffix to the function name so that it displays correctly.
     if suffix:
-      resulting_test.__name__ = '%s_%s' % (name, suffix)
+      resulting_test.__name__ = f'{name}_{suffix}'
     else:
       resulting_test.__name__ = name
 
     # On python 3, functions have __qualname__ as well. This is a full dot-separated path to the function.
     # We add the suffix to it as well.
     if hasattr(func, '__qualname__'):
-      resulting_test.__qualname__ = '%s_%s' % (func.__qualname__, suffix)
+      resulting_test.__qualname__ = f'{func.__qualname__}_{suffix}'
 
     return resulting_test.__name__, resulting_test
 
@@ -657,7 +663,7 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
     stderr = self.in_dir('stderr')
     error = None
     if EMTEST_VERBOSE:
-      print("Running '%s' under '%s'" % (filename, engine))
+      print(f"Running '{filename}' under '{engine}'")
     try:
       jsrun.run_js(filename, engine, args,
                    stdout=open(stdout, 'w'),
@@ -814,7 +820,7 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
         generated_libs.append(bc_file)
       return generated_libs
 
-    print('<building and saving %s into cache> ' % cache_name, file=sys.stderr)
+    print(f'<building and saving {cache_name} into cache>', file=sys.stderr)
 
     return build_library(name, build_dir, output_dir, generated_libs, configure,
                          configure_args, make, make_args, self.library_cache,
@@ -1082,7 +1088,7 @@ class RunnerCore(RunnerMeta('TestCase', (unittest.TestCase,), {})):
                      includes=[],
                      assert_returncode=0, assert_identical=False, assert_all=False,
                      check_for_error=True, force_c=False):
-    logger.debug('_build_and_run: %s' % filename)
+    logger.debug(f'_build_and_run: {filename}')
 
     if no_build:
       js_file = filename

--- a/tests/sockets/socket_relay.py
+++ b/tests/sockets/socket_relay.py
@@ -3,8 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
-
 """Listens on 2 ports and relays between them.
 
 Listens to ports A and B. When someone connects to port A, and then

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import math
 import os
 import re

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4,7 +4,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import argparse
 import json
 import multiprocessing
@@ -14,11 +13,12 @@ import re
 import shlex
 import shutil
 import subprocess
-import sys
 import time
 import unittest
 import webbrowser
 import zlib
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from urllib.request import urlopen
 
 from runner import BrowserCore, path_from_root, has_browser, EMTEST_BROWSER
 from runner import no_wasm_backend, create_test_file, parameterized, ensure_dir
@@ -26,17 +26,6 @@ from tools import building
 from tools import system_libs
 from tools.shared import PYTHON, EMCC, WINDOWS, FILE_PACKAGER, PIPE, V8_ENGINE
 from tools.shared import try_delete
-
-try:
-  from http.server import BaseHTTPRequestHandler, HTTPServer
-except ImportError:
-  # Python 2 compatibility
-  from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-
-if sys.version_info.major == 2:
-  from urllib import urlopen
-else:
-  from urllib.request import urlopen
 
 
 def test_chunked_synchronous_xhr_server(support_byte_ranges, chunkSize, data, checksum, port):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import glob
 import hashlib
 import json
@@ -16,7 +15,6 @@ import time
 import unittest
 from functools import wraps
 from textwrap import dedent
-
 
 if __name__ == '__main__':
   raise Exception('do not run this file directly; do something like: tests/runner.py')

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import json
 import os
 import shutil

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6,7 +6,6 @@
 
 # noqa: E241
 
-from __future__ import print_function
 from functools import wraps
 import glob
 import gzip

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import os
 import platform
 import shutil

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import multiprocessing
 import os
 import socket


### PR DESCRIPTION
We alreedy require python3 everywhere but we are holding off breaking
python2 compat in emscripten for a few releases.

I don't see why we should do that for the test code itself so this
change makes the test code start to depend on python3.

And to show that we're serious I thrown in a few f-strings