### PR TITLE
Fix __sys_fallocate with WASM_BIGINT

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1387,9 +1387,7 @@ var SyscallsLibrary = {
     FS.utime(path, atime, mtime);
     return 0;  
   },
-  __sys_fallocate: function(fd, mode, {{{ defineI64Param('off') }}}, {{{ defineI64Param('len') }}}) {
-    {{{ receiveI64ParamAsI32s('off') }}}
-    {{{ receiveI64ParamAsI32s('len') }}}
+  __sys_fallocate: function(fd, mode, off_low, off_high, len_low, len_high) {
     var stream = SYSCALLS.getStreamFromFD(fd)
     var offset = SYSCALLS.get64(off_low, off_high);
     var len = SYSCALLS.get64(len_low, len_high);

--- a/src/settings.js
+++ b/src/settings.js
@@ -1145,7 +1145,7 @@ var WASM_ASYNC_COMPILATION = 1;
 // WebAssembly integration with JavaScript BigInt. When enabled we don't need
 // to legalize i64s into pairs of i32s, as the wasm VM will use a BigInt where
 // an i64 is used.
-var WASM_BIGINT = 0;
+var WASM_BIGINT = 1;
 
 // WebAssembly defines a "producers section" which compilers and tools can
 // annotate themselves in. Emscripten does not emit this by default, as it

--- a/src/settings.js
+++ b/src/settings.js
@@ -1145,7 +1145,7 @@ var WASM_ASYNC_COMPILATION = 1;
 // WebAssembly integration with JavaScript BigInt. When enabled we don't need
 // to legalize i64s into pairs of i32s, as the wasm VM will use a BigInt where
 // an i64 is used.
-var WASM_BIGINT = 1;
+var WASM_BIGINT = 0;
 
 // WebAssembly defines a "producers section" which compilers and tools can
 // annotate themselves in. Emscripten does not emit this by default, as it

--- a/tests/core/dyncall_specific.c
+++ b/tests/core/dyncall_specific.c
@@ -20,6 +20,8 @@ void waka(int w, long long xy, int z) {
 
 int main() {
   EM_ASM({
+    // Note that these would need to use BigInts if the file were built with
+    // -s WASM_BIGINT
 #if DIRECT
     dynCall_viji($0, 1, 4, 0xffffffff, 9);
     return;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5106,6 +5106,7 @@ main( int argv, char ** argc ) {
   def test_fcntl_open(self):
     self.do_run_in_out_file_test('tests', 'fcntl', 'test_fcntl_open')
 
+  @also_with_wasm_bigint
   def test_fcntl_misc(self):
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
     self.do_run_in_out_file_test('tests', 'fcntl', 'test_fcntl_misc')


### PR DESCRIPTION
I ran the full test suite with `WASM_BIGINT` to look for any issues. It
found just this one. The code assumed that the i64 was an actual i64,
but this uses the musl linux syscall convention, where the i64 is always
in two i32 values.

Add testing for that, and also a comment on another test that
fails with `WASM_BIGINT` but in an expected way.