### PR TITLE
Implement emscripten_num_logical_cores for Node

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -561,6 +561,9 @@ var LibraryPThread = {
   },
 
   emscripten_num_logical_cores: function() {
+#if ENVIRONMENT_MAY_BE_NODE
+    if (ENVIRONMENT_IS_NODE) return require('os').cpus().length;
+#endif
     return navigator['hardwareConcurrency'];
   },
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2547,9 +2547,6 @@ int main()
 
   def test_node_emscripten_num_logical_cores(self):
     # Test with node.js that the emscripten_num_logical_cores method is working
-    if NODE_JS not in JS_ENGINES:
-      self.skipTest("node engine required for this test")
-
     create_test_file('src.cpp', r'''
 #include <emscripten/threading.h>
 #include <stdio.h>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2545,6 +2545,27 @@ int main()
       out = self.run_js('a.out.js', engine=engine)
       self.assertContained('File size: 724', out)
 
+  def test_node_emscripten_num_logical_cores(self):
+    # Test with node.js that the emscripten_num_logical_cores method is working
+    if NODE_JS not in JS_ENGINES:
+      self.skipTest("node engine required for this test")
+
+    create_test_file('src.cpp', r'''
+#include <emscripten/threading.h>
+#include <stdio.h>
+#include <assert.h>
+
+int main() {
+  int num = emscripten_num_logical_cores();
+  assert(num != 0);
+  puts("ok");
+}
+''')
+    # Pass -s USE_PTHREADS=1 to ensure we don't link against libpthread_stub.a
+    self.run_process([EMCC, 'src.cpp', '-s', 'USE_PTHREADS=1', '-s', 'ENVIRONMENT=node'])
+    ret = self.run_process(NODE_JS + ['--experimental-wasm-threads', 'a.out.js'], stdout=PIPE).stdout
+    self.assertContained('ok', ret)
+
   def test_proxyfs(self):
     # This test supposes that 3 different programs share the same directory and files.
     # The same JS object is not used for each of them


### PR DESCRIPTION
Since `navigator['hardwareConcurrency']` can't be used on Node.js.