### PR TITLE
Consistent use of makeDynCall in JS library code

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -208,6 +208,14 @@ var dynCall_v;
  * @suppress {duplicate, undefinedVars}
  */
 var dynCall_vi;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
+var dynCall_vii;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
+var dynCall_iii;
 
 // Module loaders externs, for AMD etc.
 
@@ -332,7 +340,7 @@ function AudioWorkletProcessor() {}
 /** @type {!MessagePort} */
 AudioWorkletProcessor.prototype.port;
 
-// AudioWorkletNodeOptions 
+// AudioWorkletNodeOptions
 /**
  * @constructor
  */

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -194,7 +194,7 @@ var LibraryExceptions = {
       var destructor = info.get_destructor();
       if (destructor) {
         // In Wasm, destructors return 'this' as in ARM
-        Module['dynCall_ii'](destructor, info.excPtr);
+        {{{ makeDynCall('ii') }}}(destructor, info.excPtr);
       }
       ___cxa_free_exception(info.excPtr);
 #if EXCEPTION_DEBUG

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1750,11 +1750,7 @@ var LibraryGLFW = {
   },
 
   glfwCreateThread: function(fun, arg) {
-    var str = 'v';
-    for (var i in arg) {
-      str += 'i';
-    }
-    dynCall(str, fun, arg);
+    {{{ makeDynCall('vi') }}}(str, fun, arg);
     // One single thread
     return 0;
   },

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -873,7 +873,7 @@ var LibrarySDL = {
       if (!SDL.eventHandler) return;
 
       while (SDL.pollEvent(SDL.eventHandlerTemp)) {
-        Module['dynCall_iii'](SDL.eventHandler, SDL.eventHandlerContext, SDL.eventHandlerTemp);
+        {{{ makeDynCall('iii') }}}(SDL.eventHandler, SDL.eventHandlerContext, SDL.eventHandlerTemp);
       }
     },
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1018,7 +1018,7 @@ var LibraryWebGPU = {
       if (ev.error instanceof GPUValidationError) type = Validation;
       else if (ev.error instanceof GPUOutOfMemoryError) type = OutOfMemory;
       var messagePtr = allocateUTF8(ev.error.message);
-      dynCall_viii(callback, type, messagePtr, userdata);
+      {{{ makeDynCall('viii') }}}(callback, type, messagePtr, userdata);
       _free(messagePtr);
     };
   },
@@ -1031,9 +1031,9 @@ var LibraryWebGPU = {
     var completionValue = {{{ gpu.makeU64ToNumber('completionValue_low', 'completionValue_high') }}};
 
     fence.onCompletion(completionValue).then(function() {
-      dynCall_vii(callback, 0 /* WEBGPU_FENCE_COMPLETION_STATUS_SUCCESS */, userdata);
+      {{{ makeDynCall('vii') }}}(callback, 0 /* WEBGPU_FENCE_COMPLETION_STATUS_SUCCESS */, userdata);
     }, function() {
-      dynCall_vii(callback, 1 /* WEBGPU_FENCE_COMPLETION_STATUS_ERROR */, userdata);
+      {{{ makeDynCall('vii') }}}(callback, 1 /* WEBGPU_FENCE_COMPLETION_STATUS_ERROR */, userdata);
     });
   },
 
@@ -1374,10 +1374,10 @@ var LibraryWebGPU = {
     // `callback` takes (WGPUBufferMapAsyncStatus status, void * userdata)
 
     buffer["mapAsync"](mode, offset, size).then(function() {
-      dynCall_vii(callback, 0 /* WGPUBufferMapAsyncStatus_Success */, userdata);
+      {{{ makeDynCall('vii') }}}(callback, 0 /* WGPUBufferMapAsyncStatus_Success */, userdata);
     }, function() {
       // TODO(kainino0x): Figure out how to pick other error status values.
-      dynCall_vii(callback, 1 /* WGPUBufferMapAsyncStatus_Error */, userdata);
+      {{{ makeDynCall('vii') }}}(callback, 1 /* WGPUBufferMapAsyncStatus_Error */, userdata);
     });
   },
 


### PR DESCRIPTION
makeDynCall today doesn't really do anything, it just returns
dynCall_sig.  For being consistent here makes it easier to reason
about and easier to change in central location.

The alternative of course would be instead remove the makeDynCall
functions, but I have changes planed that might start using it
for somthing useful again.