### PR TITLE
Refactor emscripten_set_main_loop.

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1304,7 +1304,7 @@ var LibraryBrowser = {
   emscripten_set_main_loop_arg__deps: ['$setMainLoop'],
   emscripten_set_main_loop_arg: function(func, arg, fps, simulateInfiniteLoop) {
     var browserIterationFunc = function() { {{{ makeDynCall('vi') }}}(func, arg); };
-    setMainLoop(func, fps, simulateInfiniteLoop, arg);
+    setMainLoop(browserIterationFunc, fps, simulateInfiniteLoop, arg);
   },
 
   // Runs natively in pthread, no __proxy needed.


### PR DESCRIPTION
This creates an internal `setMainLoop` which is called by both
`emscripten_set_main_loop` and `emscripten_set_main_loop_arg` once
the `browserInteratorFunction` has been created.

This avoids depending on both dynCall_v and dynCall_vi in
emscripten_set_main_loop (which might not both exists in a given
program).

This allows us to switch to use makeDynCall rather than
Module['dynCall_xx'], which is more consistent with other library
code and better for MINIMAL_RUNTIME.

Split off from #12010