### PR TITLE
Cleanup JavaScript compiler tools. NFC.

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /**
  * @license
  * Copyright 2010 The Emscripten Authors
@@ -9,10 +10,6 @@
 var nodeFS = require('fs');
 var nodePath = require('path');
 
-// *** Environment setup code ***
-
-// Expose functionality in the same simple way that the shells work
-// Note that we pollute the global namespace here, otherwise we break in node
 print = function(x) {
   process['stdout'].write(x + '\n');
 };
@@ -34,31 +31,25 @@ function find(filename) {
 
 read = function(filename) {
   var absolute = find(filename);
-  return nodeFS['readFileSync'](absolute).toString();
+  return nodeFS.readFileSync(absolute).toString();
 };
 
-load = function(f) {
-  globalEval(read(f));
+function load(f) {
+  eval.call(null, read(f));
 };
-
-function globalEval(x) {
-  eval.call(null, x);
-}
 
 // Basic utilities
-
 load('utility.js');
 
 // Load settings, can be overridden by commandline
-
-load('settings.js');
-load('settings_internal.js');
+load('./settings.js');
+load('./settings_internal.js');
 
 var arguments_ = process['argv'].slice(2);
-var settings_file = arguments_[0];
+var settingsFile = arguments_[0];
 
-if (settings_file) {
-  var settings = JSON.parse(read(settings_file));
+if (settingsFile) {
+  var settings = JSON.parse(read(settingsFile));
   for (var key in settings) {
     var value = settings[key];
     if (value[0] == '@') {
@@ -69,7 +60,7 @@ if (settings_file) {
         // continue normally; assume it is not a response file
       }
     }
-    eval(key + ' = ' + JSON.stringify(value));
+    global[key] = eval(JSON.stringify(value));
   }
 }
 

--- a/tools/js-optimizer.js
+++ b/tools/js-optimizer.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 // Copyright 2011 The Emscripten Authors.  All rights reserved.
 // Emscripten is available under two separate licenses, the MIT license and the
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
@@ -15,127 +16,32 @@
 //       instead of returning it to the previous call frame where we check?
 // TODO: Share EMPTY_NODE instead of emptyNode that constructs?
 
-if (!Math.fround) {
-  var froundBuffer = new Float32Array(1);
-  Math.fround = function(x) { froundBuffer[0] = x; return froundBuffer[0] };
-}
-
-// *** Environment setup code ***
-var arguments_ = [];
-var debug = false;
-
-var ENVIRONMENT_IS_NODE = typeof process === 'object';
-var ENVIRONMENT_IS_WEB = typeof window === 'object';
-var ENVIRONMENT_IS_WORKER = typeof importScripts === 'function';
-var ENVIRONMENT_IS_SHELL = !ENVIRONMENT_IS_WEB && !ENVIRONMENT_IS_NODE && !ENVIRONMENT_IS_WORKER;
-
-if (ENVIRONMENT_IS_NODE) {
-  // Expose functionality in the same simple way that the shells work
-  // Note that we pollute the global namespace here, otherwise we break in node
-  print = function(x) {
-    process['stdout'].write(x + '\n');
-  };
-  printErr = function(x) {
-    process['stderr'].write(x + '\n');
-  };
-
-  var nodeFS = require('fs');
-  var nodePath = require('path');
-
-  if (!nodeFS.existsSync) {
-    nodeFS.existsSync = function(path) {
-      try {
-        return !!nodeFS.readFileSync(path);
-      } catch(e) {
-        return false;
-      }
-    }
-  }
-
-  function find(filename) {
-    var prefixes = [nodePath.join(__dirname, '..', 'src'), process.cwd()];
-    for (var i = 0; i < prefixes.length; ++i) {
-      var combined = nodePath.join(prefixes[i], filename);
-      if (nodeFS.existsSync(combined)) {
-        return combined;
-      }
-    }
-    return filename;
-  }
-
-  read = function(filename) {
-    var absolute = find(filename);
-    return nodeFS['readFileSync'](absolute).toString();
-  };
-
-  load = function(f) {
-    globalEval(read(f));
-  };
-
-  arguments_ = process['argv'].slice(2);
-
-} else if (ENVIRONMENT_IS_SHELL) {
-  // Polyfill over SpiderMonkey/V8 differences
-  if (!this['read']) {
-    this['read'] = function(f) { snarf(f) };
-  }
-
-  if (typeof scriptArgs != 'undefined') {
-    arguments_ = scriptArgs;
-  } else if (typeof arguments != 'undefined') {
-    arguments_ = arguments;
-  }
-
-} else if (ENVIRONMENT_IS_WEB) {
-  this['print'] = printErr = function(x) {
-    console.log(x);
-  };
-
-  this['read'] = function(url) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, false);
-    xhr.send(null);
-    return xhr.responseText;
-  };
-
-  if (this['arguments']) {
-    arguments_ = arguments;
-  }
-} else if (ENVIRONMENT_IS_WORKER) {
-  // We can do very little here...
-
-  this['load'] = importScripts;
-
-} else {
-  throw 'Unknown runtime environment. Where are we?';
-}
-
-function globalEval(x) {
-  eval.call(null, x);
-}
-
-if (typeof load === 'undefined' && typeof read != 'undefined') {
-  this['load'] = function(f) {
-    globalEval(read(f));
-  };
-}
-
-if (typeof printErr === 'undefined') {
-  this['printErr'] = function(){};
-}
-
-if (typeof print === 'undefined') {
-  this['print'] = printErr;
-}
-// *** Environment setup code ***
-
 var uglify = require('../third_party/uglify-js');
 var fs = require('fs');
 var path = require('path');
+var fs = require('fs');
 
-// Load some modules
+var arguments_ = process['argv'].slice(2);
+var debug = false;
 
-load('utility.js');
+function printErr(x) {
+  process.stderr.write(x + '\n');
+}
+
+function print(x) {
+  process.stdout.write(x + '\n');
+}
+
+function read(filename) {
+  return fs.readFileSync(filename).toString();
+}
+
+function load(f) {
+  f = path.join(__dirname, f)
+  eval.call(null, read(f));
+};
+
+load('../src/utility.js');
 
 // Utilities
 

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright 2012 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -233,6 +233,7 @@ def run_js_tool(filename, jsargs=[], *args, **kw):
   implemented in javascript.
   """
   command = NODE_JS + [filename] + jsargs
+  print_compiler_stage(command)
   return check_call(command, *args, **kw).stdout
 
 


### PR DESCRIPTION
This change makes are 3 primary JavaScript compiler tools more like
normal node programs:

 tools/js-optimizer.js
 tools/preprocessor.js
 src/compiler.js

1. Make them executable and add #! lines
2. Remove compatibility boilerplate that makes them runnable outside
   of node.
2. Experiment with using node's `require` rether then `eval` in the
   global scope.  For no I only coverted `utility.js` to node module.