### PR TITLE
Simplify/refactor handling of `main`/`_start`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,10 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- `--no-entry` is now required in `STANDALONE_WASM` mode when building a reactor
+  (application without a main function).  Previouly exporting a list of
+  functions that didn't include `_main` would imply this.  Now the list of
+  `EXPORTED_FUNCTIONS` is not relevant in the command/reactor selection.
 - Allow polymorphic types to be used without RTTI when using embind. (#10914)
 - Only strip the LLVM producer's section in release builds. In `-O0` builds, we
   try to leave the wasm from LLVM unmodified as much as possible, so if it

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,9 +18,10 @@ See docs/process.md for how version tagging works.
 Current Trunk
 -------------
 - `--no-entry` is now required in `STANDALONE_WASM` mode when building a reactor
-  (application without a main function).  Previouly exporting a list of
+  (application without a main function).  Previously exporting a list of
   functions that didn't include `_main` would imply this.  Now the list of
-  `EXPORTED_FUNCTIONS` is not relevant in the command/reactor selection.
+  `EXPORTED_FUNCTIONS` is not relevant in the deciding the type of application
+  to build.
 - Allow polymorphic types to be used without RTTI when using embind. (#10914)
 - Only strip the LLVM producer's section in release builds. In `-O0` builds, we
   try to leave the wasm from LLVM unmodified as much as possible, so if it

--- a/emcc.py
+++ b/emcc.py
@@ -1141,7 +1141,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     elif shared.Settings.STANDALONE_WASM:
       if '_main' in shared.Settings.EXPORTED_FUNCTIONS:
         # TODO(sbc): Make this into a warning?
-        loffer.debug('including `_main` in EXPORTED_FUNCTIONS is not necessary in standalone mode')
+        logger.debug('including `_main` in EXPORTED_FUNCTIONS is not necessary in standalone mode')
     else:
       # In normal non-standalone mode we have special handling of `_main` in EXPORTED_FUNCTIONS.
       # 1. If the user specifies exports, but doesn't include `_main` we assume they want to build a

--- a/emcc.py
+++ b/emcc.py
@@ -906,10 +906,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     newargs = [arg for arg in newargs if arg]
 
-    settings_key_changes = set()
+    settings_key_changes = {}
     for s in settings_changes:
       key, value = s.split('=', 1)
-      settings_key_changes.add(key)
+      settings_key_changes[key] = value
 
     # Find input files
 
@@ -1037,12 +1037,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # Libraries are searched before settings_changes are applied, so apply the
     # value for STRICT from command line already now.
 
-    def get_last_setting_change(setting):
-      return ([None] + [x for x in settings_changes if x.startswith(setting + '=')])[-1]
-
-    strict_cmdline = get_last_setting_change('STRICT')
+    strict_cmdline = settings_key_changes.get('STRICT')
     if strict_cmdline:
-      shared.Settings.STRICT = int(strict_cmdline.split('=', 1)[1])
+      shared.Settings.STRICT = int(strict_cmdline)
 
     # Apply optimization level settings
     shared.Settings.apply_opt_level(opt_level=shared.Settings.OPT_LEVEL, shrink_level=shared.Settings.SHRINK_LEVEL, noisy=True)
@@ -1055,12 +1052,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.MINIMAL_RUNTIME or 'MINIMAL_RUNTIME=1' in settings_changes or 'MINIMAL_RUNTIME=2' in settings_changes:
       # Remove the default exported functions 'malloc', 'free', etc. those should only be linked in if used
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
-
-    # Remove the default _main function from shared.Settings.EXPORTED_FUNCTIONS.
-    # We do this before the user settings are applied so it affects the default value only and a
-    # user could use `--no-entry` and still export main too.
-    if options.no_entry:
-      shared.Settings.EXPORTED_FUNCTIONS.remove('_main')
 
     # Apply -s settings in newargs here (after optimization levels, so they can override them)
     apply_settings(settings_changes)
@@ -1145,9 +1136,24 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # we also do not support standalone mode in fastcomp.
       shared.Settings.STANDALONE_WASM = 1
 
-    if options.no_entry or ('_main' not in shared.Settings.EXPORTED_FUNCTIONS and
-                            '__start' not in shared.Settings.EXPORTED_FUNCTIONS):
+    if options.no_entry:
       shared.Settings.EXPECT_MAIN = 0
+    elif shared.Settings.STANDALONE_WASM:
+      if '_main' in shared.Settings.EXPORTED_FUNCTIONS:
+        # TODO(sbc): Make this into a warning?
+        loffer.debug('including `_main` in EXPORTED_FUNCTIONS is not necessary in standalone mode')
+    else:
+      # In normal non-standalone mode we have special handling of `_main` in EXPORTED_FUNCTIONS.
+      # 1. If the user specifies exports, but doesn't include `_main` we assume they want to build a
+      #    reactor.
+      # 2. If the user doesn't export anything we default to exporting `_main` (unless `--no-entry`
+      #    is specified (see above).
+      if 'EXPORTED_FUNCTIONS' in settings_key_changes:
+        if '_main' not in shared.Settings.USER_EXPORTED_FUNCTIONS:
+          shared.Settings.EXPECT_MAIN = 0
+      else:
+        assert(not shared.Settings.EXPORTED_FUNCTIONS)
+        shared.Settings.EXPORTED_FUNCTIONS = ['_main']
 
     if shared.Settings.STANDALONE_WASM:
       # In STANDALONE_WASM mode we either build a command or a reactor.

--- a/emscripten.py
+++ b/emscripten.py
@@ -265,15 +265,9 @@ def apply_table(js):
 
 
 def report_missing_symbols(all_implemented, pre):
-  required_symbols = set(shared.Settings.USER_EXPORTED_FUNCTIONS)
-  # In standalone mode a request for `_main` is interpreted as a request for `_start`
-  # so don't warn about mossing main.
-  if shared.Settings.STANDALONE_WASM and '_main' in required_symbols:
-    required_symbols.discard('_main')
-
   # the initial list of missing functions are that the user explicitly exported
   # but were not implemented in compiled code
-  missing = list(required_symbols - all_implemented)
+  missing = list(set(shared.Settings.USER_EXPORTED_FUNCTIONS) - all_implemented)
 
   for requested in missing:
     if ('function ' + asstr(requested)) in pre:

--- a/src/settings.js
+++ b/src/settings.js
@@ -762,14 +762,13 @@ var NODE_CODE_CACHING = 0;
 
 // Functions that are explicitly exported. These functions are kept alive
 // through LLVM dead code elimination, and also made accessible outside of the
-// generated code even after running closure compiler (on "Module").  Note the
-// necessary prefix of "_".
+// generated code even after running closure compiler (on "Module").  The
+// symbols listed here require an `_` prefix.
 //
-// Note also that this is the full list of exported functions - if you have a
-// main() function and want it to run, you must include it in this list (as
-// _main is by default in this value, and if you override it without keeping it
-// there, you are in effect removing it).
-var EXPORTED_FUNCTIONS = ['_main'];
+// By default if this setting is not specified on the command line the
+// `_main` function will be implicitly exported.  In STANDALONE_WASM mode the
+// default export is `__start` (or `__initialize` if --no-entry is specified).
+var EXPORTED_FUNCTIONS = [];
 
 // If true, we export all the symbols that are present in JS onto the Module
 // object. This does not affect which symbols will be present - it does not

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8292,12 +8292,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
       err = self.expect_fail([EMCC, path_from_root('tests', 'core', 'test_ctors_no_main.cpp')] + self.get_emcc_args())
       self.assertContained('error: entry symbol not defined (pass --no-entry to suppress): main', err)
 
+      # In non-standalone mode exporting an empty list of functions signal that we don't
+      # have a main and so should not generate an error.
+      self.set_setting('EXPORTED_FUNCTIONS', [])
+      self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main.cpp')
+      self.clear_setting('EXPORTED_FUNCTIONS')
+
     # If we pass --no-entry or set EXPORTED_FUNCTIONS to empty should never see any errors
     self.emcc_args.append('--no-entry')
-    self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main.cpp')
-
-    self.emcc_args.remove('--no-entry')
-    self.set_setting('EXPORTED_FUNCTIONS', [])
     self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main.cpp')
 
   def test_export_start(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9664,11 +9664,7 @@ int main () {
     self.assertContained('hello, world!', output)
 
   def test_standalone_export_main(self):
-    # Tests that explicitly exported `_main` does not fail, but does generate a
-    # warning.  This is because `_start` is the entry point used in standalone mode
-    # so exporting `_main` doesn't normally make sense.
+    # Tests that explicitly exported `_main` does not fail, even though `_start` is the entry
+    # point.
+    # We should consider making this a warning since the `_main` export is redundant.
     self.run_process([EMCC, '-sEXPORTED_FUNCTIONS=[_main]', '-sSTANDALONE_WASM', '-c', path_from_root('tests', 'core', 'test_hello_world.c')])
-
-    # Expect failure with `-Werror`
-    err = self.expect_fail([EMCC, '-sEXPORTED_FUNCTIONS=[_main]', '-sSTANDALONE_WASM', '-Werror', '-c', path_from_root('tests', 'core', 'test_hello_world.c')])
-    self.assertContained('including `_main` in EXPORTED_FUNCTIONS is not necessary in standalone mode', err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9664,10 +9664,11 @@ int main () {
     self.assertContained('hello, world!', output)
 
   def test_standalone_export_main(self):
-    # Tests that explictly exported `_main` does not fail.   Since we interpret an
-    # export of `_main` to be be an export of `__start` in standalone mode the
-    # actual main function is not exported, but we also don't want to report an
-    # error
-    self.set_setting('STANDALONE_WASM')
-    self.set_setting('EXPORTED_FUNCTIONS', ['_main'])
-    self.do_run_in_out_file_test('tests', 'core', 'test_hello_world.c')
+    # Tests that explicitly exported `_main` does not fail, but does generate a
+    # warning.  This is because `_start` is the entry point used in standalone mode
+    # so exporting `_main` doesn't normally make sense.
+    self.run_process([EMCC, '-sEXPORTED_FUNCTIONS=[_main]', '-sSTANDALONE_WASM', '-c', path_from_root('tests', 'core', 'test_hello_world.c')])
+
+    # Expect failure with `-Werror`
+    err = self.expect_fail([EMCC, '-sEXPORTED_FUNCTIONS=[_main]', '-sSTANDALONE_WASM', '-Werror', '-c', path_from_root('tests', 'core', 'test_hello_world.c')])
+    self.assertContained('including `_main` in EXPORTED_FUNCTIONS is not necessary in standalone mode', err)

--- a/tools/building.py
+++ b/tools/building.py
@@ -511,8 +511,6 @@ def lld_flags_for_executable(external_symbol_list):
     if external_symbol_list:
       # Filter out symbols external/JS symbols
       c_exports = [e for e in c_exports if e not in external_symbol_list]
-    if Settings.STANDALONE_WASM and Settings.EXPECT_MAIN and 'main' in c_exports:
-      c_exports.remove('main')
     for export in c_exports:
       cmd += ['--export', export]
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -63,6 +63,7 @@ diagnostics.add_warning('emcc')
 diagnostics.add_warning('undefined', error=True)
 diagnostics.add_warning('deprecated')
 diagnostics.add_warning('version-check')
+diagnostics.add_warning('export-main')
 diagnostics.add_warning('unused-command-line-argument', shared=True)
 
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1365,6 +1365,9 @@ class libjsmath(Library):
 # If main() is not in EXPORTED_FUNCTIONS, it may be dce'd out. This can be
 # confusing, so issue a warning.
 def warn_on_unexported_main(symbolses):
+  # In STANDALONE_WASM we don't expect main to be explictly exported
+  if shared.Settings.STANDALONE_WASM:
+    return
   if '_main' not in shared.Settings.EXPORTED_FUNCTIONS:
     for symbols in symbolses:
       if 'main' in symbols.defs:


### PR DESCRIPTION
This change is NFC for non-standalone mode.

For standalone mode we no longer have any special handling for `main`.
This is because `_start` is the entry symbol for standalone mode.  We no
longer include `_main` in EXPORTED_FUNCTIONS by default.  With this
change `--no-entry` is only way build a reactor.  EXPORTED_FUNCTIONS
no longer effects whether we build a reactor or a command.

This makes things more explicit and less magical, and also means the
user is not exposed to directly to name of the entry point which gets exported
(so the fact that we use `_start` becomes and implementation detail).
