### PR TITLE
SIDE_MODULE is completely unnecessary in the JS compiler

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -71,6 +71,9 @@ INCOMING_MODULE_JS_API = set(INCOMING_MODULE_JS_API);
 
 RUNTIME_DEBUG = LIBRARY_DEBUG || GL_DEBUG;
 
+// Side modules are pure wasm and have no JS
+assert(!SIDE_MODULE);
+
 // Output some info and warnings based on settings
 
 if (VERBOSE) {

--- a/src/modules.js
+++ b/src/modules.js
@@ -303,7 +303,6 @@ var LibraryManager = {
   },
 
   isStubFunction: function(ident) {
-    if (SIDE_MODULE == 1) return false; // cannot eliminate these, as may be implement in the main module and imported by us
     var libCall = LibraryManager.library[ident.substr(1)];
     return typeof libCall === 'function' && libCall.toString().replace(/\s/g, '') === 'function(){}'
                                          && !(ident in Functions.implementedFunctions);

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -377,7 +377,6 @@ function makeGlobalUse(ident) {
       return ident;
     }
     var ret = (Runtime.GLOBAL_BASE + index).toString();
-    if (SIDE_MODULE) ret = '(H_BASE+' + ret + ')';
     return ret;
   }
   return ident;
@@ -1056,7 +1055,7 @@ function makeHEAPView(which, start, end) {
 // When dynamically linking, some things like dynCalls may not exist in one module and
 // be provided by a linked module, so they must be accessed indirectly using Module
 function exportedAsmFunc(func) {
-  if (!MAIN_MODULE && !SIDE_MODULE) {
+  if (!MAIN_MODULE) {
     return func;
   } else {
     return "Module['" + func + "']";
@@ -1257,9 +1256,6 @@ function makePointer(slab, pos, allocator, type, ptr, finalMemoryInitialization)
       // writing out into memory, without a normal allocation. We put all of these into a single big chunk.
       assert(typeof slab == 'object');
       assert(slab.length % QUANTUM_SIZE == 0, slab.length); // must be aligned already
-      if (SIDE_MODULE && typeof ptr == 'string') {
-        ptr = parseInt(ptr.substring(ptr.indexOf('+'), ptr.length-1)); // parse into (H_BASE+X)
-      }
       var offset = ptr - Runtime.GLOBAL_BASE;
       for (var i = 0; i < slab.length; i++) {
         memoryInitialization[offset + i] = slab[i];

--- a/src/shell.js
+++ b/src/shell.js
@@ -8,7 +8,6 @@
 "use strict";
 
 #endif
-#if SIDE_MODULE == 0
 // The Module object: Our interface to the outside world. We import
 // and export values on it. There are various ways Module can be used:
 // 1. Not defined. We create it here
@@ -36,7 +35,6 @@ if (!Module) /** @suppress{checkTypes}*/Module = {"__EMSCRIPTEN_PRIVATE_MODULE_E
 #else
 var Module = typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : {};
 #endif // USE_CLOSURE_COMPILER
-#endif // SIDE_MODULE
 
 #if ((MAYBE_WASM2JS && WASM != 2) || MODULARIZE) && (MIN_CHROME_VERSION < 33 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 29 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 80000) // https://caniuse.com/#feat=promises
 // Include a Promise polyfill for legacy browsers. This is needed either for

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -5,7 +5,6 @@ d
  * SPDX-License-Identifier: MIT
  */
 
-#if SIDE_MODULE == 0
 #if USE_CLOSURE_COMPILER
 // if (!Module)` is crucial for Closure Compiler here as it will otherwise replace every `Module` occurrence with the object below
 var /** @type{Object} */ Module;
@@ -13,7 +12,6 @@ if (!Module) /** @suppress{checkTypes}*/Module = {"__EMSCRIPTEN_PRIVATE_MODULE_E
 #else
 var Module = {{{ EXPORT_NAME }}};
 #endif // USE_CLOSURE_COMPILER
-#endif // SIDE_MODULE
 
 #if MODULARIZE && EXPORT_READY_PROMISE
 // Set up the promise that indicates the Module is initialized


### PR DESCRIPTION
asm.js emitted JS for side modules, but wasm side modules are just
pure wasm. The JS compiler will now error if invoked on a side module,
and all the code for that can be removed.

See https://github.com/emscripten-core/emscripten/issues/11860