### PR TITLE
Fix browser.sdl_image_must_prepare which became flaky recently

### DIFF
--- a/tests/sdl_image_must_prepare.c
+++ b/tests/sdl_image_must_prepare.c
@@ -36,6 +36,8 @@ void ready(const char *f) {
   testImage("screenshot.jpg", 1);
 
   SDL_Flip(screen);
+
+  EM_ASM({ doReftest() });
 }
 
 int main() {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -689,7 +689,7 @@ If manually bisecting:
   def test_sdl_image_must_prepare(self):
     # load an image file, get pixel data.
     shutil.copyfile(path_from_root('tests', 'screenshot.jpg'), 'screenshot.jpg')
-    self.btest('sdl_image_must_prepare.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.jpg', '-lSDL', '-lGL'])
+    self.btest('sdl_image_must_prepare.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.jpg', '-lSDL', '-lGL'], manually_trigger_reftest=True)
 
   def test_sdl_stb_image(self):
     # load an image file, get pixel data.


### PR DESCRIPTION
The test has always been async (`ready` is called asynchronously) but for
some reason it wasn't noticeable until now, where apparently some firefox
changes make the timing issue happen more often.