### PR TITLE
Remove a static allocation in C++ exceptions support code in JS

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -417,11 +417,10 @@ var LibraryExceptions = {
 #if EXCEPTION_DEBUG
     out("can_catch on " + [thrown]);
 #endif
-    if (!exceptionThrowBuf.thrownBuf) {
-      exceptionThrowBuf.thrownBuf = _malloc(4);
+    if (!exceptionThrowBuf) {
+      exceptionThrowBuf = _malloc(4);
     }
-    var thrownBuf = exceptionThrowBuf.thrownBuf;
-    {{{ makeSetValue('thrownBuf', '0', 'thrown', '*') }}};
+    {{{ makeSetValue('exceptionThrowBuf', '0', 'thrown', '*') }}};
     // The different catch blocks are denoted by different types.
     // Due to inheritance, those types may not precisely match the
     // type of the thrown object. Find one which matches, and
@@ -432,8 +431,8 @@ var LibraryExceptions = {
         // Catch all clause matched or exactly the same type is caught
         break;
       }
-      if ({{{ exportedAsmFunc('___cxa_can_catch') }}}(caughtType, thrownType, thrownBuf)) {
-        var adjusted = {{{ makeGetValue('thrownBuf', '0', '*') }}};
+      if ({{{ exportedAsmFunc('___cxa_can_catch') }}}(caughtType, thrownType, exceptionThrowBuf)) {
+        var adjusted = {{{ makeGetValue('exceptionThrowBuf', '0', '*') }}};
         if (thrown !== adjusted) {
           catchInfo.set_adjusted_ptr(adjusted);
         }

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -416,11 +416,9 @@ var LibraryExceptions = {
 #if EXCEPTION_DEBUG
     out("can_catch on " + [thrown]);
 #endif
-#if DISABLE_EXCEPTION_CATCHING == 1
-    var thrownBuf = 0;
-#else
-    var thrownBuf = {{{ makeStaticAlloc(4) }}};
-#endif
+    if (!__cxa_find_matching_catch.thrownBuf) {
+      __cxa_find_matching_catch.thrownBuf = _malloc(4);
+    }
     {{{ makeSetValue('thrownBuf', '0', 'thrown', '*') }}};
     // The different catch blocks are denoted by different types.
     // Due to inheritance, those types may not precisely match the

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -416,8 +416,8 @@ var LibraryExceptions = {
 #if EXCEPTION_DEBUG
     out("can_catch on " + [thrown]);
 #endif
-    if (!__cxa_find_matching_catch.thrownBuf) {
-      __cxa_find_matching_catch.thrownBuf = _malloc(4);
+    if (!___cxa_find_matching_catch.thrownBuf) {
+      ___cxa_find_matching_catch.thrownBuf = _malloc(4);
     }
     {{{ makeSetValue('thrownBuf', '0', 'thrown', '*') }}};
     // The different catch blocks are denoted by different types.

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -7,6 +7,7 @@
 var LibraryExceptions = {
   $exceptionLast: '0',
   $exceptionCaught: ' []',
+  $exceptionThrowBuf: '0',
 
   // Static fields for ExceptionInfo class.
   $ExceptionInfoAttrs: {
@@ -395,7 +396,7 @@ var LibraryExceptions = {
   // unwinding using 'if' blocks around each function, so the remaining
   // functionality boils down to picking a suitable 'catch' block.
   // We'll do that here, instead, to keep things simpler.
-  __cxa_find_matching_catch__deps: ['$exceptionLast', '$ExceptionInfo', '$CatchInfo', '__resumeException'],
+  __cxa_find_matching_catch__deps: ['$exceptionLast', '$ExceptionInfo', '$CatchInfo', '__resumeException', '$exceptionThrowBuf'],
   __cxa_find_matching_catch: function() {
     var thrown = exceptionLast;
     if (!thrown) {
@@ -416,9 +417,10 @@ var LibraryExceptions = {
 #if EXCEPTION_DEBUG
     out("can_catch on " + [thrown]);
 #endif
-    if (!___cxa_find_matching_catch.thrownBuf) {
-      ___cxa_find_matching_catch.thrownBuf = _malloc(4);
+    if (!exceptionThrowBuf.thrownBuf) {
+      exceptionThrowBuf.thrownBuf = _malloc(4);
     }
+    var thrownBuf = exceptionThrowBuf.thrownBuf;
     {{{ makeSetValue('thrownBuf', '0', 'thrown', '*') }}};
     // The different catch blocks are denoted by different types.
     // Due to inheritance, those types may not precisely match the


### PR DESCRIPTION
This also fixes a potential issue with thread-safety (as all threads used
to use that same location, previously).