### PR TITLE
Remove WASM=0 code in emcc.py

### DIFF
--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -156,11 +156,6 @@ var MINIFY_WASM_IMPORTS_AND_EXPORTS = 0;
 // Whether to minify imported module names.
 var MINIFY_WASM_IMPORTED_MODULES = 0;
 
-// passes information to emscripten.py about whether to minify
-// JS -> asm.js import names. Controlled by optimization level, enabled
-// at -O1 and higher, but disabled at -g2 and higher.
-var MINIFY_ASMJS_IMPORT_NAMES = 0;
-
 // Whether to minify functions exported from Asm.js/Wasm module.
 var MINIFY_ASMJS_EXPORT_NAMES = 1;
 


### PR DESCRIPTION
Any code behind `WASM=0` is not used, as we convert `-s WASM=0` into
`WASM=1` and `WASM2JS=1` internally. That is, we always compile to wasm
even if we emit JS in the end.

Best viewed without whitespace differences.
