### PR TITLE
Use more musl code for time to avoid static allocations in JS

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1062,8 +1062,6 @@ LibraryManager.library = {
 
   // Statically allocated copy of the string "GMT" for gmtime() to point to
   __tm_timezone: '{{{ makeStaticString("GMT") }}}',
-  // Statically allocated time strings.
-  __tm_formatted: '{{{ makeStaticAlloc(C_STRUCTS.tm.__size__) }}}',
   mktime__deps: ['tzset'],
   mktime__sig: 'ii',
   mktime: function(tmPtr) {
@@ -1176,12 +1174,8 @@ LibraryManager.library = {
   },
   __localtime_r: 'localtime_r',
 
-  asctime__deps: ['__tm_formatted', 'asctime_r'],
-  asctime: function(tmPtr) {
-    return _asctime_r(tmPtr, ___tm_formatted);
-  },
-
-  asctime_r__deps: ['__tm_formatted', 'mktime'],
+  asctime_r__deps: ['mktime'],
+  asctime_r__sig: 'iii',
   asctime_r: function(tmPtr, buf) {
     var date = {
       tm_sec: {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'i32') }}},
@@ -1209,6 +1203,7 @@ LibraryManager.library = {
     stringToUTF8(s, buf, 26);
     return buf;
   },
+  __asctime_r: 'asctime_r',
 
   ctime_r__deps: ['localtime_r', 'asctime_r'],
   ctime_r__sig: 'iii',

--- a/src/library.js
+++ b/src/library.js
@@ -1104,6 +1104,7 @@ LibraryManager.library = {
   timelocal: 'mktime',
 
   gmtime_r__deps: ['__tm_timezone'],
+  gmtime_r__sig: 'iii',
   gmtime_r: function(time, tmPtr) {
     var date = new Date({{{ makeGetValue('time', 0, 'i32') }}}*1000);
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'date.getUTCSeconds()', 'i32') }}};
@@ -1122,6 +1123,8 @@ LibraryManager.library = {
 
     return tmPtr;
   },
+  __gmtime_r: 'gmtime_r',
+
   timegm__deps: ['tzset'],
   timegm: function(tmPtr) {
     _tzset();
@@ -1143,6 +1146,7 @@ LibraryManager.library = {
   },
 
   localtime_r__deps: ['__tm_timezone', 'tzset'],
+  localtime_r__sig: 'iii',
   localtime_r: function(time, tmPtr) {
     _tzset();
     var date = new Date({{{ makeGetValue('time', 0, 'i32') }}}*1000);
@@ -1170,6 +1174,7 @@ LibraryManager.library = {
 
     return tmPtr;
   },
+  __localtime_r: 'localtime_r',
 
   asctime__deps: ['__tm_formatted', 'asctime_r'],
   asctime: function(tmPtr) {
@@ -1206,12 +1211,14 @@ LibraryManager.library = {
   },
 
   ctime_r__deps: ['localtime_r', 'asctime_r'],
+  ctime_r__sig: 'iii',
   ctime_r: function(time, buf) {
     var stack = stackSave();
     var rv = _asctime_r(_localtime_r(time, stackAlloc({{{ C_STRUCTS.tm.__size__ }}})), buf);
     stackRestore(stack);
     return rv;
   },
+  __ctime_r: 'ctime_r',
 
   dysize: function(year) {
     var leap = ((year % 4 == 0) && ((year % 100 != 0) || (year % 400 == 0)));

--- a/src/library.js
+++ b/src/library.js
@@ -1060,8 +1060,6 @@ LibraryManager.library = {
     return time1 - time0;
   },
 
-  // Statically allocated time struct.
-  __tm_current: '{{{ makeStaticAlloc(C_STRUCTS.tm.__size__) }}}',
   // Statically allocated copy of the string "GMT" for gmtime() to point to
   __tm_timezone: '{{{ makeStaticString("GMT") }}}',
   // Statically allocated time strings.
@@ -1105,11 +1103,6 @@ LibraryManager.library = {
   },
   timelocal: 'mktime',
 
-  gmtime__deps: ['__tm_current', 'gmtime_r'],
-  gmtime: function(time) {
-    return _gmtime_r(time, ___tm_current);
-  },
-
   gmtime_r__deps: ['__tm_timezone'],
   gmtime_r: function(time, tmPtr) {
     var date = new Date({{{ makeGetValue('time', 0, 'i32') }}}*1000);
@@ -1147,11 +1140,6 @@ LibraryManager.library = {
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_yday, 'yday', 'i32') }}};
 
     return (date.getTime() / 1000)|0;
-  },
-
-  localtime__deps: ['__tm_current', 'localtime_r'],
-  localtime: function(time) {
-    return _localtime_r(time, ___tm_current);
   },
 
   localtime_r__deps: ['__tm_timezone', 'tzset'],
@@ -1215,11 +1203,6 @@ LibraryManager.library = {
     // Our undefined behavior is to truncate the write to at most 26 bytes, including null terminator.
     stringToUTF8(s, buf, 26);
     return buf;
-  },
-
-  ctime__deps: ['__tm_current', 'ctime_r'],
-  ctime: function(timer) {
-    return _ctime_r(timer, ___tm_current);
   },
 
   ctime_r__deps: ['localtime_r', 'asctime_r'],

--- a/system/lib/libc/musl/src/time/asctime.c
+++ b/system/lib/libc/musl/src/time/asctime.c
@@ -1,9 +1,9 @@
 #include <time.h>
 
-char *__asctime(const struct tm *, char *);
+char *__asctime_r(const struct tm *, char *);
 
 char *asctime(const struct tm *tm)
 {
 	static char buf[26];
-	return __asctime(tm, buf);
+	return __asctime_r(tm, buf);
 }

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -727,7 +727,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
     # Allowed files from ignored modules
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'time'],
-        filenames=['clock_settime.c'])
+        filenames=['clock_settime.c', 'ctime.c', 'gmtime.c', 'localtime.c'])
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'legacy'],
         filenames=['getpagesize.c', 'err.c'])
@@ -1332,12 +1332,11 @@ class libstandalonewasm(MuslInternalLibrary):
                    '__year_to_secs.c',
                    'clock.c',
                    'clock_gettime.c',
+                   'ctime_r.c',
                    'difftime.c',
                    'gettimeofday.c',
-                   'localtime.c',
-                   'localtime_r.c',
-                   'gmtime.c',
                    'gmtime_r.c',
+                   'localtime_r.c',
                    'nanosleep.c',
                    'mktime.c',
                    'time.c'])

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -727,7 +727,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
     # Allowed files from ignored modules
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'time'],
-        filenames=['clock_settime.c', 'ctime.c', 'gmtime.c', 'localtime.c'])
+        filenames=['clock_settime.c', 'asctime.c', 'ctime.c', 'gmtime.c', 'localtime.c'])
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'legacy'],
         filenames=['getpagesize.c', 'err.c'])
@@ -1330,6 +1330,7 @@ class libstandalonewasm(MuslInternalLibrary):
                    '__tm_to_secs.c',
                    '__tz.c',
                    '__year_to_secs.c',
+                   'asctime_r.c',
                    'clock.c',
                    'clock_gettime.c',
                    'ctime_r.c',


### PR DESCRIPTION
Use musl code for non-reentrant time functions to avoid a static allocation in
JS. Instead, C does the allocation and sends the buffer to the `_r`
versions of the time functions. This is better for code size too.

Musl calls `__` prefixed versions, so add aliases for them.

Add a fix from upstream musl to `asctime.c`.

Add `ctime_r` and `asctime_r` to libstandalone, which were missing.

Helps https://github.com/WebAssembly/binaryen/issues/3043