### PR TITLE
Fix python3 string warning.

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1091,7 +1091,7 @@ class JS(object):
   #   Copyright 2017 The Emscripten Authors
   #   SPDX-License-Identifier: MIT
   #  */
-  emscripten_license_regex = '''\/\*\*?(\s*\*?\s*@license)?(\s*\*?\s*Copyright \d+ The Emscripten Authors\s*\*?\s*SPDX-License-Identifier: MIT)+\s*\*\/''' # noqa
+  emscripten_license_regex = r'\/\*\*?(\s*\*?\s*@license)?(\s*\*?\s*Copyright \d+ The Emscripten Authors\s*\*?\s*SPDX-License-Identifier: MIT)+\s*\*\/'
 
   @staticmethod
   def handle_license(js_target):


### PR DESCRIPTION
This code was generated a warning in python3:
  `shared.py:1094: SyntaxWarning: invalid escape sequence`

It only shows up the first time the code is run but youn can reproduce
it by `rm -rf tools/__pycache__/`