### PR TITLE
Move static allocation for fetch queue from JS to C++ code

### DIFF
--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -12,13 +12,7 @@ var LibraryFetch = {
 #else
   $Fetch__postset: 'Fetch.staticInit();',
 #endif
-  $fetchWorkQueue: '0',
   $Fetch: Fetch,
-  _emscripten_get_fetch_work_queue__deps: ['$fetchWorkQueue'],
-  _emscripten_get_fetch_work_queue: function() {
-    if (!fetchWorkQueue) fetchWorkQueue = _malloc(12);
-    return fetchWorkQueue;
-  },
   _emscripten_fetch_get_response_headers_length: _fetch_get_response_headers_length,
   _emscripten_fetch_get_response_headers: _fetch_get_response_headers,
   _emscripten_fetch_free: _fetch_free,
@@ -35,7 +29,7 @@ var LibraryFetch = {
 #if FETCH_SUPPORT_INDEXEDDB
   '$__emscripten_fetch_cache_data', '$__emscripten_fetch_load_cached_data', '$__emscripten_fetch_delete_cached_data',
 #endif
-  '_emscripten_get_fetch_work_queue', 'emscripten_is_main_browser_thread']
+  'emscripten_is_main_browser_thread']
 };
 
 mergeInto(LibraryManager.library, LibraryFetch);


### PR DESCRIPTION
This moves the function `emscripten_get_fetch_queue` and its static
allocation in the native code avoiding the runtime allocation on the JS side.

See: #12040