### PR TITLE
Move getFuncWrapper to library function

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2966,7 +2966,7 @@ var LibrarySDL = {
     }
     audio['onended'] = function SDL_audio_onended() { // TODO: cache these
       if (channelInfo.audio == this) { channelInfo.audio.paused = true; channelInfo.audio = null; }
-      if (SDL.channelFinished) getFuncWrapper(SDL.channelFinished, 'vi')(channel);
+      if (SDL.channelFinished)  {{{ makeDynCall('vi') }}}(SDL.channelFinished, channel);
     }
     channelInfo.audio = audio;
     // TODO: handle N loops. Behavior matches Mix_PlayMusic
@@ -2991,7 +2991,7 @@ var LibrarySDL = {
         info.audio = null;
       }
       if (SDL.channelFinished) {
-        getFuncWrapper(SDL.channelFinished, 'vi')(channel);
+        {{{ makeDynCall('vi') }}}(SDL.channelFinished, channel);
       }
     }
     if (channel != -1) {

--- a/src/support.js
+++ b/src/support.js
@@ -565,35 +565,6 @@ Module['loadWebAssemblyModule'] = loadWebAssemblyModule;
 
 #include "runtime_functions.js"
 
-var funcWrappers = {};
-
-function getFuncWrapper(func, sig) {
-  if (!func) return; // on null pointer, return undefined
-  assert(sig);
-  if (!funcWrappers[sig]) {
-    funcWrappers[sig] = {};
-  }
-  var sigCache = funcWrappers[sig];
-  if (!sigCache[func]) {
-    // optimize away arguments usage in common cases
-    if (sig.length === 1) {
-      sigCache[func] = function dynCall_wrapper() {
-        return dynCall(sig, func);
-      };
-    } else if (sig.length === 2) {
-      sigCache[func] = function dynCall_wrapper(arg) {
-        return dynCall(sig, func, [arg]);
-      };
-    } else {
-      // general case
-      sigCache[func] = function dynCall_wrapper() {
-        return dynCall(sig, func, Array.prototype.slice.call(arguments));
-      };
-    }
-  }
-  return sigCache[func];
-}
-
 #include "runtime_debug.js"
 
 function makeBigInt(low, high, unsigned) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6614,6 +6614,7 @@ return malloc(size);
     self.do_run_in_out_file_test('tests', 'interop', 'test_add_function.cpp')
 
   def test_getFuncWrapper_sig_alias(self):
+    self.emcc_args += ['-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[$getFuncWrapper]']
     src = r'''
     #include <stdio.h>
     #include <emscripten.h>


### PR DESCRIPTION
Some uses of this function can just be replaced by `makeDynCall`.

The remaining uses only exist in library_browser.js and so this function
can become a library function there.

This is part of #12002