### PR TITLE
tools/ports: supports embuilder --pic build harfbuzz

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -501,3 +501,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Alexander Köplinger <alex.koeplinger@outlook.com> (copyright owned by Microsoft, Inc.)
 * Kenneth Pouncey <kepounce@microsoft.com> (copyright owned by Microsoft, Inc.)
 * Mitchell Hwang <mihw@microsoft.com> (copyright owned by Microsoft, Inc.)
+* Paul Peny <pmpp.pub@gmail.com>

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -44,8 +44,16 @@ def get(ports, settings, shared):
       '-DHB_HAVE_FREETYPE=ON'
     ]
 
+    extra_cxx_flags = []
+
+    if TAG.find('pic')>=0:
+      extra_cxx_flags.append('-fPIC')
+
     if settings.USE_PTHREADS:
-      configure_args += ['-DCMAKE_CXX_FLAGS="-pthread"']
+      extra_cxx_flags.append('-pthread')
+
+    if len(extra_cxx_flags):
+      configure_args += ['-DCMAKE_CXX_FLAGS="{}"'.format(' '.join(extra_cxx_flags))]
 
     building.configure(configure_args)
     building.make(['make', '-j%d' % building.get_num_cores(), '-C' + dest_path, 'install'])

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -46,7 +46,7 @@ def get(ports, settings, shared):
 
     extra_cxx_flags = []
 
-    if TAG.find('pic')>=0:
+    if settings.RELOCATABLE:
       extra_cxx_flags.append('-fPIC')
 
     if settings.USE_PTHREADS:


### PR DESCRIPTION
quick fix for embuilder --pic build harfbuzz could fail without -fpic in compiler flags
could close https://github.com/emscripten-core/emsdk/issues/479