### PR TITLE
Remove is_wasm_only() which only made sense on fastcomp

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1771,9 +1771,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if shared.Settings.USE_PTHREADS:
       newargs.append('-pthread')
 
-    if not shared.Settings.LEGALIZE_JS_FFI:
-      assert building.is_wasm_only(), 'LEGALIZE_JS_FFI incompatible with RUNNING_JS_OPTS.'
-
     # check if we can address the 2GB mark and higher: either if we start at
     # 2GB, or if we allow growth to either any amount or to 2GB or more.
     if shared.Settings.INITIAL_MEMORY > 2 * 1024 * 1024 * 1024 or \

--- a/tools/building.py
+++ b/tools/building.py
@@ -856,14 +856,6 @@ def can_inline():
   return Settings.INLINING_LIMIT == 0
 
 
-def is_wasm_only():
-  # not even wasm, much less wasm-only
-  if not Settings.WASM:
-    return False
-  # llvm backend can only ever produce wasm
-  return True
-
-
 def get_safe_internalize():
   if Settings.LINKABLE:
     return [] # do not internalize anything


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/issues/11860