### PR TITLE
Make wasm2c always use the simplest FFI, with no JS limitations

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1135,6 +1135,15 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # we also do not support standalone mode in fastcomp.
       shared.Settings.STANDALONE_WASM = 1
 
+    if shared.Settings.WASM2C:
+      # wasm2c only makes sense with standalone wasm - there will be no JS,
+      # just wasm and then C
+      shared.Settings.STANDALONE_WASM = 1
+      # wasm2c doesn't need any special handling of i64, we have proper i64
+      # handling on the FFI boundary, which is exactly like the case of JS with
+      # BigInt support
+      shared.Settings.WASM_BIGINT = 1
+
     if options.no_entry:
       shared.Settings.EXPECT_MAIN = 0
     elif shared.Settings.STANDALONE_WASM:


### PR DESCRIPTION
We have no problem with i64s on the FFI boundary, which is effectively
the same as `WASM_BIGINT` for JS.

Also, we always want to be in standalone mode, as in wasm2c there is
no JS, just wasm and then C.

As suggested by @sbc100 in #12065