### PR TITLE
Stop using dynCalls in wasm2c

### DIFF
--- a/tools/wasm2c/base.c
+++ b/tools/wasm2c/base.c
@@ -81,11 +81,6 @@ DEFINE_STORE(wasm_i64_store8, u8, u64);
 DEFINE_STORE(wasm_i64_store16, u16, u64);
 DEFINE_STORE(wasm_i64_store32, u32, u64);
 
-#define CALL_INDIRECT_NOTYPE(table, type, fptr, ...)    \
-  (LIKELY((fptr) < table.size && table.data[fptr].func) \
-        ? ((type)table.data[fptr].func)(__VA_ARGS__)    \
-        : TRAP(CALL_INDIRECT))
-
 // Imports
 
 #ifdef VERBOSE_LOGGING


### PR DESCRIPTION
Instead, this calls the Table directly.

This takes a little more effort at compile time because we need to find
the index of the function type for the signature we are calling with
(so that we trap if the target function has the wrong type). To do that,
scan the wasm2c output - which is at risk of breaking if that output
changes, sadly (another option might be to disassemble the wasm
and scan that, which would at least be a stable format - but this
seems fine for now).

Helps https://github.com/emscripten-core/emscripten/pull/12059

Fixes https://github.com/emscripten-core/emscripten/issues/12065