### PR TITLE
Use llvm-objcpy to strip the producers section when not running wasm-opt

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,13 +31,6 @@ Current Trunk
   `EXPORTED_FUNCTIONS` is not relevant in the deciding the type of application
   to build.
 - Allow polymorphic types to be used without RTTI when using embind. (#10914)
-- Only strip the LLVM producer's section in release builds. In `-O0` builds, we
-  try to leave the wasm from LLVM unmodified as much as possible, so if it
-  emitted the producers section, it will be there. Normally that only matters
-  in release builds, which is not changing here. If you want to not have a
-  producer's section in debug builds, you can remove it a tool like
-  `wasm-opt --strip-producers` (which is what Emscripten still does in release
-  builds, as always) or use `llvm-objcopy`.
 - Only strip debug info in release builds + when `-g` is not present. Previously
   even in an `-O0` build without `-g` we would strip it. This was not documented
   behavior, and has no effect on program behavior, but may be noticeable

--- a/emcc.py
+++ b/emcc.py
@@ -2605,6 +2605,7 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       options.binaryen_passes += ['--pass-arg=emscripten-sbrk-ptr@%d' % shared.Settings.DYNAMICTOP_PTR]
       if shared.Settings.STANDALONE_WASM:
         options.binaryen_passes += ['--pass-arg=emscripten-sbrk-val@%d' % shared.Settings.DYNAMIC_BASE]
+    # run wasm-opt if we have work for it
     if options.binaryen_passes:
       # if we need to strip the producers section, and we have wasm-opt passes
       # to run, do it with them.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1147,16 +1147,12 @@ var WASM_ASYNC_COMPILATION = 1;
 var WASM_BIGINT = 0;
 
 // WebAssembly defines a "producers section" which compilers and tools can
-// annotate themselves in, and LLVM emits this by default. In release builds,
+// annotate themselves in, and LLVM emits this by default.
 // Emscripten will strip that out so that it is *not* emitted because it
 // increases code size, and also some users may not want information
 // about their tools to be included in their builds for privacy or security
 // reasons, see
 // https://github.com/WebAssembly/tool-conventions/issues/93.
-// (In debug builds (-O0) we leave the wasm file as it is from LLVM, in which
-// case it may contain this section, if you didn't tell LLVM to not emit it. You
-// can also run wasm-opt --strip-producers manually, which is what Emscripten
-// does in release builds for you automatically.)
 var EMIT_PRODUCERS_SECTION = 0;
 
 // If set then generated WASM files will contain a custom

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7898,17 +7898,14 @@ int main() {
       self.assertIn(b'somewhere.com/hosted.wasm', f.read())
 
   @parameterized({
-    'O0': (True, ['-O0']), # unoptimized builds try not to modify the LLVM wasm.
-    'O1': (False, ['-O1']), # optimized builds strip the producer's section
-    'O2': (False, ['-O2']), # by default.
+    'O0': (['-O0'],),
+    'O1': (['-O1'],),
+    'O2': (['-O2'],),
   })
-  def test_wasm_producers_section(self, expect_producers_by_default, args):
+  def test_wasm_producers_section(self, args):
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c')] + args)
     with open('a.out.wasm', 'rb') as f:
       data = f.read()
-    if expect_producers_by_default:
-      self.assertIn('clang', str(data))
-      return
     # if there is no producers section expected by default, verify that, and
     # see that the flag works to add it.
     self.assertNotIn('clang', str(data))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2031,11 +2031,7 @@ int f() {
       return compile_to_executable(compile_args, [])
 
     no_size, line_size, full_size = test(compile_to_O0_executable)
-    # the difference between these two is due to the producer's section which
-    # LLVM emits, and which we do not strip as this is not a release build.
-    # the specific difference is that LLVM emits language info (C_plus_plus_14)
-    # when emitting debug info, but not otherwise.
-    self.assertLess(no_size, line_size)
+    self.assertEqual(no_size, line_size)
     self.assertEqual(line_size, full_size)
 
   def test_dwarf(self):

--- a/tools/building.py
+++ b/tools/building.py
@@ -1423,6 +1423,14 @@ def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compil
   return js_file
 
 
+def strip_debug(infile, outfile):
+  run_process([LLVM_OBJCOPY, '--remove-section=.debug*', infile, outfile])
+
+
+def strip_producers(infile, outfile):
+  run_process([LLVM_OBJCOPY, '--remove-section=producers', infile, outfile])
+
+
 # extract the DWARF info from the main file, and leave the wasm with
 # debug into as a file on the side
 # TODO: emit only debug sections in the side file, and not the entire
@@ -1435,7 +1443,7 @@ def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   embedded_path = shared.Settings.SEPARATE_DWARF_URL or wasm_file_with_dwarf
 
   shutil.move(wasm_file, wasm_file_with_dwarf)
-  run_process([LLVM_OBJCOPY, '--remove-section=.debug*', wasm_file_with_dwarf, wasm_file])
+  strip_debug(wasm_file_with_dwarf, wasm_file)
 
   # embed a section in the main wasm to point to the file with external DWARF,
   # see https://yurydelendik.github.io/webassembly-dwarf/#external-DWARF


### PR DESCRIPTION
As part of https://github.com/WebAssembly/binaryen/issues/3043 we stopped
stripping the producers section in unoptimized builds in #11996

However there is a way to still strip it with very little overhead, using llvm-objcpy.
This PR makes us strip it using wasm-opt normally if we are running wasm-opt
anyhow, but if we are not (as we hope to get to soon in some builds) then it uses
llvm-objcpy. This does a little more work after link but it's pretty trivial and does
not rewrite code or anything like that.

This does add some complexity, but it is complexity we'll need anyhow for
not running wasm-opt when it isn't needed.

Fixes #12071