### PR TITLE
Stop passing --minimize-wasm-changes to wasm-emscripten-finalize

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -578,7 +578,6 @@ def finalize_wasm(temp_files, infile, outfile, memfile, DEBUG):
     args.append('--pass-arg=legalize-js-interface-export-originals')
   if shared.Settings.DEBUG_LEVEL >= 3:
     args.append('--dwarf')
-  args.append('--minimize-wasm-changes')
   stdout = building.run_binaryen_command('wasm-emscripten-finalize',
                                          infile=base_wasm,
                                          outfile=wasm,


### PR DESCRIPTION
Binaryen no longer needs that flag, and we can probably remove it from
there entirely since we added other flags for dynCalls, and I'm not sure
we have anything else left that could use such a flag?