### PR TITLE
Fix pthreads stack check code

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1320,7 +1320,7 @@ var LibraryPThread = {
     STACK_MAX = stackMax;
 
 #if STACK_OVERFLOW_CHECK >= 2
-    ___set_stack_limit(STACK_MAX);
+    ___set_stack_limits(STACK_BASE, STACK_MAX);
 #endif
 
     // Call inside wasm module to set up the stack frame for this pthread in asm.js/wasm module scope


### PR DESCRIPTION
Followup to #12095, a trivial fix for pthreads as well, which fixes
current breakage on master.

I'm not sure how the test passed on that PR. Must have interacted
with something else, as it should have failed...