### PR TITLE
Fixed issue #12112 caused by fetch using relative paths to retrieve wasm files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ third_party/lzma.js/lzma-native
 third_party/lzma.js/lzma-native.exe
 
 .DS_Store
+
+*.out
+*.geany

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1018,6 +1018,16 @@ function createWasm() {
         !isFileURI(wasmBinaryFile) &&
 #endif
         typeof fetch === 'function') {
+
+      // Ensure the fetch path is absolute.
+      if(!wasmBinaryFile.startsWith('http')){
+        let prefix = self.location.href.match(/http[s]*:\/\/[^\/]+/)[0];
+        if(!prefix.endsWith('/')){
+          prefix += '/';
+        }
+        wasmBinaryFile = prefix + wasmBinaryFile;
+      }
+
       fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
         var result = WebAssembly.instantiateStreaming(response, info);
 #if USE_OFFSET_CONVERTER


### PR DESCRIPTION
This fixes issue #12112 by patching instantiateAsync() to use an absolute URI when given just a filename.