### PR TITLE
Allow caller to override scriptDirectory

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -296,7 +296,9 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 #if MODULARIZE
   // When MODULARIZE, this JS may be executed later, after document.currentScript
   // is gone, so we saved it, and we use it here instead of any other info.
-  if (_scriptDir) {
+  if (Module.scriptDirectory !== undefined) {
+    scriptDirectory = Module.scriptDirectory;
+  } else if (_scriptDir) {
     scriptDirectory = _scriptDir;
   }
 #endif


### PR DESCRIPTION
Depending on the use case, in certain environments which support web-like && worker-like && shell-like experiences blend into one; the heuristics to detect `scriptDirectory` do not suffice. Instead of introducing more complicated code paths to the existing detection mechanics, this patch provides a simple hook to override `scriptDirectory` from the call-site to enable use-cases like:

```js
// in Deno, window is globally defined without document
//
// import DOM API and assign `window.document` as desired
import jsdom from "https://dev.jspm.io/jsdom";
window.document = new jsdom.JSDOM(null, { url: 'http://localhost' }).window.document;

// window.fetch exists, but cannot read from local filesystem (as of Deno `v1.3.3`)
//
// modify the meaning of fetch API for local filesystem reads
// (both before and after are the async methods)
window.fetch = Deno.readFile;

const basePath = './';

// dynamically load the module in order to inject the desired (document and fetch) dependencies
const myModule = await import(basePath + 'myModule.js');

// finally get the instance with the desired `scriptDirectory`
const app = await myModule.default({ scriptDirectory: basePath });
```

---

PS: this is just a nice-to-have change to align the values of `scriptDirectory` with ES6 and ES5 builds during the run time, as my aforementioned use-case is unblocked by providing binary buffer to `wasmBinary` from the call sites:

```js
import jsdom from "https://dev.jspm.io/jsdom";
window.document = new jsdom.JSDOM(null, { url: 'http://localhost' }).window.document;

const myModule = await import('./myModule.js');
const wasmBuffer = await Deno.readFile('./myModule.wasm', 'utf8');
const app = await myModule.default({ wasmBinary: wasmBuffer });
```

so it is maintainers' call to accept/reject this nicety. :)