### PR TITLE
Remove checks for Settings.WASM since it is now always true

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -40,20 +40,17 @@ def compute_minimal_runtime_initializer_and_exports(post, initializers, exports,
   # Generate invocations for all global initializers directly off the asm export object, e.g. asm['__GLOBAL__INIT']();
   post = post.replace('/*** RUN_GLOBAL_INITIALIZERS(); ***/', '\n'.join(["asm['" + x + "']();" for x in global_initializer_funcs(initializers)]))
 
-  if shared.Settings.WASM:
-    # Declare all exports out to global JS scope so that JS library functions can access them in a
-    # way that minifies well with Closure
-    # e.g. var a,b,c,d,e,f;
-    exports_that_are_not_initializers = [x for x in exports if x not in initializers]
-    # In Wasm backend the exports are still unmangled at this point, so mangle the names here
-    exports_that_are_not_initializers = [asmjs_mangle(x) for x in exports_that_are_not_initializers]
-    post = post.replace('/*** ASM_MODULE_EXPORTS_DECLARES ***/', 'var ' + ','.join(exports_that_are_not_initializers) + ';')
+  # Declare all exports out to global JS scope so that JS library functions can access them in a
+  # way that minifies well with Closure
+  # e.g. var a,b,c,d,e,f;
+  exports_that_are_not_initializers = [x for x in exports if x not in initializers]
+  # In Wasm backend the exports are still unmangled at this point, so mangle the names here
+  exports_that_are_not_initializers = [asmjs_mangle(x) for x in exports_that_are_not_initializers]
+  post = post.replace('/*** ASM_MODULE_EXPORTS_DECLARES ***/', 'var ' + ','.join(exports_that_are_not_initializers) + ';')
 
-    # Generate assignments from all asm.js/wasm exports out to the JS variables above: e.g. a = asm['a']; b = asm['b'];
-    post = post.replace('/*** ASM_MODULE_EXPORTS ***/', receiving)
-    receiving = ''
-
-  return post, receiving
+  # Generate assignments from all asm.js/wasm exports out to the JS variables above: e.g. a = asm['a']; b = asm['b'];
+  post = post.replace('/*** ASM_MODULE_EXPORTS ***/', receiving)
+  return post
 
 
 def global_initializer_funcs(initializers):
@@ -399,12 +396,11 @@ for (var named in NAMED_GLOBALS) {
 Module['NAMED_GLOBALS'] = NAMED_GLOBALS;
 ''' % ',\n  '.join('"' + k + '": ' + str(v) for k, v in metadata['namedGlobals'].items())
 
-  if shared.Settings.WASM:
-    # wasm side modules are pure wasm, and cannot create their g$..() methods, so we help them out
-    # TODO: this works if we are the main module, but if the supplying module is later, it won't, so
-    #       we'll need another solution for that. one option is to scan the module imports, if/when
-    #       wasm supports that, then the loader can do this.
-    named_globals += '''
+  # wasm side modules are pure wasm, and cannot create their g$..() methods, so we help them out
+  # TODO: this works if we are the main module, but if the supplying module is later, it won't, so
+  #       we'll need another solution for that. one option is to scan the module imports, if/when
+  #       wasm supports that, then the loader can do this.
+  named_globals += '''
 for (var named in NAMED_GLOBALS) {
   (function(named) {
     var addr = Module['_' + named];
@@ -509,7 +505,8 @@ def emscript(infile, outfile, memfile, temp_files, DEBUG):
   receiving = create_receiving_wasm(exports, metadata['initializers'])
 
   if shared.Settings.MINIMAL_RUNTIME:
-    post, receiving = compute_minimal_runtime_initializer_and_exports(post, metadata['initializers'], exports, receiving)
+    post = compute_minimal_runtime_initializer_and_exports(post, metadata['initializers'], exports, receiving)
+    receiving = ''
 
   module = create_module_wasm(sending, receiving, invoke_funcs, metadata)
 
@@ -851,9 +848,9 @@ def create_receiving_wasm(exports, initializers):
 
   # with WASM_ASYNC_COMPILATION that asm object may not exist at this point in time
   # so we need to support delayed assignment.
-  delay_assignment = (shared.Settings.WASM and shared.Settings.WASM_ASYNC_COMPILATION) and not shared.Settings.MINIMAL_RUNTIME
+  delay_assignment = shared.Settings.WASM_ASYNC_COMPILATION and not shared.Settings.MINIMAL_RUNTIME
   if not delay_assignment:
-    if shared.Settings.WASM and shared.Settings.MINIMAL_RUNTIME:
+    if shared.Settings.MINIMAL_RUNTIME:
       # In Wasm exports are assigned inside a function to variables existing in top level JS scope, i.e.
       # var _main;
       # WebAssembly.instantiate(Module["wasm"], imports).then((function(output) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -783,10 +783,6 @@ var EXPORTED_FUNCTIONS = [];
 // library functions on Module, for things like dynamic linking.
 var EXPORT_ALL = 0;
 
-// If true, export all the functions appearing in a function table, and the
-// tables themselves.
-var EXPORT_FUNCTION_TABLES = 0;
-
 // Remembers the values of these settings, and makes them accessible
 // through Runtime.getCompilerSetting and emscripten_get_compiler_setting.
 // To see what is retained, look for compilerSettings in the generated code.
@@ -1685,4 +1681,5 @@ var LEGACY_SETTINGS = [
   ['DEAD_FUNCTIONS', [[]], 'The wasm backend does not support dead function removal'],
   ['WASM_BACKEND', [-1], 'Only the wasm backend is now supported (note that setting it as -s has never been allowed anyhow)'],
   ['EXPORT_BINDINGS', [0, 1], 'No longer needed'],
+  ['EXPORT_FUNCTION_TABLES', [0], 'No longer needed'],
 ];

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1006,9 +1006,6 @@ def verify_settings():
   if Settings.SAFE_HEAP not in [0, 1]:
     exit_with_error('emcc: SAFE_HEAP must be 0 or 1 in fastcomp')
 
-  if Settings.WASM and Settings.EXPORT_FUNCTION_TABLES:
-      exit_with_error('emcc: EXPORT_FUNCTION_TABLES incompatible with WASM')
-
   if not Settings.WASM:
     # When the user requests non-wasm output, we enable wasm2js. that is,
     # we still compile to wasm normally, but we compile the final output

--- a/tools/update_symbols.py
+++ b/tools/update_symbols.py
@@ -103,10 +103,6 @@ def main():
                       help='symbol files to regenerate (default: all)')
   args = parser.parse_args()
 
-  if not shared.Settings.WASM:
-    sys.stderr.write('This script only runs in WASM mode\n')
-    sys.exit(1)
-
   shared.safe_ensure_dirs(get_symbols_dir())
   if args.files:
     for symbol_file in args.files:


### PR DESCRIPTION
Even when `WASM=0` is specified on the command line this gettings
re-written early on as `WASM=1` + `WASM2JS=1`.

See: #11860