### PR TITLE
Allow ES2018 as input when running closure compiler

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2977,6 +2977,9 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
 
 
 def minify_html(filename, options):
+  if shared.Settings.DEBUG_LEVEL >= 2:
+    return
+
   opts = []
   # -g1 and greater retain whitespace and comments in source
   if shared.Settings.DEBUG_LEVEL == 0:
@@ -3006,13 +3009,10 @@ def minify_html(filename, options):
   # '--remove-empty-elements': removes all elements with empty contents.
   #                            (Breaks at least browser.test_asm_swapping)
 
-  if shared.Settings.DEBUG_LEVEL >= 2:
-    return
-
   logger.debug('minifying HTML file ' + filename)
   size_before = os.path.getsize(filename)
   start_time = time.time()
-  run_process(shared.get_npm_cmd('html-minifier-terser') + [filename, '-o', filename] + opts, env=shared.env_with_node_in_path())
+  shared.check_call(shared.get_npm_cmd('html-minifier-terser') + [filename, '-o', filename] + opts, env=shared.env_with_node_in_path())
 
   elapsed_time = time.time() - start_time
   size_after = os.path.getsize(filename)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7760,18 +7760,25 @@ var ASM_CONSTS = [function() { var x = !<->5.; }];
     self.assertIdentical(normal, tiny)
     self.assertIdentical(normal, huge)
 
-  def test_EM_ASM_ES6(self):
+  @parameterized({
+    '': ([],), # noqa
+    'O3': (['-O3'],), # noqa
+    'closure': (['--closure', '1'],), # noqa
+    'closure_O3': (['--closure', '1', '-O3'],), # noqa
+  })
+  def test_EM_ASM_ES6(self, args):
     create_test_file('src.cpp', r'''
 #include <emscripten.h>
 int main() {
   EM_ASM({
-    var x = (a, b) => 5; // valid ES6
+    let x = (a, b) => 5; // valid ES6
     async function y() {} // valid ES2017
     out('hello!');
+    return x;
   });
 }
 ''')
-    self.run_process([EMCC, 'src.cpp', '-O2'])
+    self.run_process([EMCC, 'src.cpp'] + args)
     self.assertContained('hello!', self.run_js('a.out.js'))
 
   def test_check_sourcemapurl(self):

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1301,6 +1301,7 @@ var sourceComments = [];
 var ast;
 try {
   ast = acorn.parse(input, {
+    // Keep in sync with --language_in that we pass to closure in building.py
     ecmaVersion: 2018,
     preserveParens: closureFriendly,
     onComment: closureFriendly ? sourceComments : undefined

--- a/tools/building.py
+++ b/tools/building.py
@@ -1089,8 +1089,16 @@ def closure_compiler(filename, pretty=True, advanced=True, extra_closure_args=No
     outfile = filename + '.cc.js'
     configuration.get_temp_files().note(outfile)
 
-    args = ['--compilation_level', 'ADVANCED_OPTIMIZATIONS' if advanced else 'SIMPLE_OPTIMIZATIONS',
-            '--language_in', 'ECMASCRIPT5']
+    args = ['--compilation_level', 'ADVANCED_OPTIMIZATIONS' if advanced else 'SIMPLE_OPTIMIZATIONS']
+    # Keep in sync with ecmaVersion in tools/acorn-optimizer.js
+    args += ['--language_in', 'ECMASCRIPT_2018']
+    # Tell closure not to do any transpiling or inject any polyfills.
+    # At some point we may want to look into using this as way to convert to ES5 but
+    # babel is perhaps a better tool for that.
+    args += ['--language_out', 'NO_TRANSPILE']
+    # Tell closure never to inject the 'use strict' directive.
+    args += ['--emit_use_strict=false']
+
     for e in CLOSURE_EXTERNS:
       args += ['--externs', e]
     args += ['--js_output_file', outfile]


### PR DESCRIPTION
This matches the input we accept when running the acorn compiler.

See https://github.com/emscripten-core/emscripten/issues/11984