### PR TITLE
Remove the use of the native JS optimizer: part 1

### DIFF
--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -449,6 +449,7 @@ EMSCRIPTEN_FUNCS();
         commands = [shared.NODE_JS + [JS_OPTIMIZER, f, 'noPrintMetadata'] +
                     (['--debug'] if source_map else []) + passes for f in filenames]
       else:
+        assert False
         # use the native optimizer
         shared.logging.debug('js optimizer using native')
         assert not source_map # XXX need to use js optimizer


### PR DESCRIPTION
This change simply asserts that the native optimizer is not
being used for anything anymore.

As far as I can't tell use_native only has a single call site
and always returns False since its never passed `asm` as one
of the passes anymore.

Once this lands we can actually remove it.