### PR TITLE
wasm-sourcemap.py: fix handling of paths on different drives

### DIFF
--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -279,11 +279,10 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, bas
     if prefixes.provided():
       source_name = prefixes.sources.resolve(file_name)
     else:
-      file_name = os.path.abspath(file_name)
       try:
         file_name = os.path.relpath(file_name, base_path)
-      except Exception:
-        pass      
+      except ValueError:
+        file_name = os.path.abspath(file_name)
       file_name = normalize_path(file_name)
       source_name = file_name
     if source_name not in sources_map:

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -279,7 +279,11 @@ def build_sourcemap(entries, code_section_offset, prefixes, collect_sources, bas
     if prefixes.provided():
       source_name = prefixes.sources.resolve(file_name)
     else:
-      file_name = os.path.relpath(os.path.abspath(file_name), base_path)
+      file_name = os.path.abspath(file_name)
+      try:
+        file_name = os.path.relpath(file_name, base_path)
+      except Exception:
+        pass      
       file_name = normalize_path(file_name)
       source_name = file_name
     if source_name not in sources_map:


### PR DESCRIPTION
Fixed issue with code files included from different drives (Windows), where wasm-sourcemap.py would bail out with an error

Fixes: https://github.com/emscripten-core/emscripten/issues/12111