### PR TITLE
Fix Embind + WASM_BIGINT

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -1062,17 +1062,21 @@ var LibraryEmbind = {
 #endif
   },
 
-  $embind__requireFunction__deps: ['$readLatin1String', '$throwBindingError', '$getDynCaller'],
+  $embind__requireFunction__deps: ['$readLatin1String', '$throwBindingError'
+#if USE_LEGACY_DYNCALLS || !WASM_BIGINT
+    , '$getDynCaller'
+#endif
+  ],
   $embind__requireFunction: function(signature, rawFunction) {
     signature = readLatin1String(signature);
 
     function makeDynCaller() {
-#if !USE_LEGACY_DYNCALLS
-      if (signature.indexOf('j') == -1) {
-        return wasmTable.get(rawFunction);
+#if USE_LEGACY_DYNCALLS || !WASM_BIGINT
+      if (signature.indexOf('j') != -1) {
+        return getDynCaller(signature, rawFunction);
       }
 #endif
-      return getDynCaller(signature, rawFunction);
+      return wasmTable.get(rawFunction);
     }
 
     var fp = makeDynCaller();

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6903,6 +6903,7 @@ someweirdtext
     self.do_run_from_file(path_from_root('tests', 'embind', 'test_negative_constants.cpp'),
                           path_from_root('tests', 'embind', 'test_negative_constants.out'))
 
+  @also_with_wasm_bigint
   def test_embind_unsigned(self):
     self.emcc_args += ['--bind']
     self.do_run_from_file(path_from_root('tests', 'embind', 'test_unsigned.cpp'), path_from_root('tests', 'embind', 'test_unsigned.out'))


### PR DESCRIPTION
Avoid dependency on the `getDynCaller` function when compiling with
`-s WASM_BIGINT=1`. Also extend a test case to support this combination.

<details>
  <summary>Details</summary>
  
```
test_embind_unsigned (test_core.wasm0) ... error: undefined symbol: $getDynCaller (referenced by $embind__requireFunction__deps: ['$readLatin1String','$throwBindingError','$getDynCaller'], referenced by _embind_register_function__deps: ['$craftInvokerFunction','$exposePublicSymbol','$heap32VectorToArray','$readLatin1String','$replacePublicSymbol','$embind__requireFunction','$throwUnboundTypeError','$whenDependentTypesAreResolved'], referenced by top-level compiled C/C++ code)
warning: Link with `-s LLD_REPORT_UNDEFINED` to get more information on undefined symbols
warning: To disable errors for undefined symbols use `-s ERROR_ON_UNDEFINED_SYMBOLS=0`
warning: getDynCaller may need to be added to EXPORTED_FUNCTIONS if it arrives from a system library
Error: Aborting compilation due to previous errors
```
</details>