### PR TITLE
Partial revert of #12139

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -444,10 +444,11 @@ def normalize_config_settings():
     PORTS = os.path.join(CACHE, 'ports')
 
   if CLOSURE_COMPILER is None:
-    CLOSURE_COMPILER = get_npm_cmd('google-closure-compiler')
-    if not WINDOWS:
+    if WINDOWS:
+      CLOSURE_COMPILER = [path_from_root('node_modules', '.bin', 'google-closure-compiler.cmd')]
+    else:
       # Work around an issue that Closure compiler can take up a lot of memory and crash in an error
-      # "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory"
+     # "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory"
       CLOSURE_COMPILER = NODE_JS + ['--max_old_space_size=8192', path_from_root('node_modules', '.bin', 'google-closure-compiler')]
 
   if JAVA is None:


### PR DESCRIPTION
This part of the change meant that we would generate an
error if closure-compiler was missing whenever emcc was
run, even if it was never used/needed.

I have a planned followup to clean this up.

Fixes the current emscripten roll into emscripten-releases.