### PR TITLE
Handle both emscripten_longjmp and emscripten_longjmp_jmpbuf

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1788,14 +1788,13 @@ LibraryManager.library = {
   // ==========================================================================
 
 #if SUPPORT_LONGJMP
+  longjmp__sig: 'vii',
   longjmp: function(env, value) {
     _setThrew(env, value || 1);
     throw 'longjmp';
   },
-  emscripten_longjmp__deps: ['longjmp'],
-  emscripten_longjmp: function(env, value) {
-    _longjmp(env, value);
-  },
+  emscripten_longjmp: 'longjmp',
+  emscripten_longjmp_jmpbuf: 'longjmp',
 #endif
 
   // ==========================================================================

--- a/tools/wasm2c/base.c
+++ b/tools/wasm2c/base.c
@@ -131,6 +131,10 @@ IMPORT_IMPL(void, Z_envZ_emscripten_longjmpZ_vii, (u32 buf, u32 value), {
   longjmp(setjmp_stack[next_setjmp - 1], 1);
 });
 
+IMPORT_IMPL(void, Z_envZ_emscripten_longjmp_jmpbufZ_vii, (u32 buf, u32 value), {
+  return Z_envZ_emscripten_longjmpZ_vii(buf, value);
+});
+
 IMPORT_IMPL(void, Z_envZ_emscripten_notify_memory_growthZ_vi, (u32 size), {});
 
 static u32 tempRet0 = 0;


### PR DESCRIPTION
The longer name appears from the wasm backend, and wasm-emscripten-finalize renames
it. Instead, support both, and then we can remove the long name either in LLVM or in
binaryen.

See https://github.com/WebAssembly/binaryen/issues/3043