### PR TITLE
Remove `BINARYEN_SCRIPTS` settings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -31,6 +31,7 @@ Current Trunk
   corrupted program state.
 - Use `__indirect_function_table` as the import name for the table, which is
   what LLVM does.
+- Remove `BINARYEN_SCRIPTS` setting.
 
 2.0.2: 09/02/2020
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -358,7 +358,7 @@ def apply_settings(changes):
                'GL_MAX_TEMP_BUFFER_SIZE', 'MAXIMUM_MEMORY', 'DEFAULT_PTHREAD_STACK_SIZE'):
       value = str(expand_byte_size_suffixes(value))
 
-    if value[0] == '@':
+    if value and value[0] == '@':
       filename = value[1:]
       if not os.path.exists(filename):
         exit_with_error('%s: file not found parsing argument: %s' % (filename, change))
@@ -2632,17 +2632,6 @@ def do_binaryen(target, asm_target, options, memfile, wasm_binary_target,
       building.strip(wasm_binary_target, wasm_binary_target,
                      debug=strip_debug, producers=strip_producers)
 
-  if shared.Settings.BINARYEN_SCRIPTS:
-    binaryen_scripts = os.path.join(shared.BINARYEN_ROOT, 'scripts')
-    script_env = os.environ.copy()
-    root_dir = os.path.abspath(os.path.dirname(__file__))
-    if script_env.get('PYTHONPATH'):
-      script_env['PYTHONPATH'] += ':' + root_dir
-    else:
-      script_env['PYTHONPATH'] = root_dir
-    for script in shared.Settings.BINARYEN_SCRIPTS.split(','):
-      logger.debug('running binaryen script: ' + script)
-      shared.check_call([shared.PYTHON, os.path.join(binaryen_scripts, script), final, wasm_text_target], env=script_env)
   if shared.Settings.EVAL_CTORS:
     building.save_intermediate(wasm_binary_target, 'pre-ctors.wasm')
     building.eval_ctors(final, wasm_binary_target, binaryen_bin, debug_info=intermediate_debug_info)
@@ -3156,6 +3145,9 @@ def is_valid_abspath(options, path_name):
 
 
 def parse_value(text):
+  if not text:
+    return text
+
   # Note that using response files can introduce whitespace, if the file
   # has a newline at the end. For that reason, we rstrip() in relevant
   # places here.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1105,10 +1105,6 @@ var WASM = 1;
 // or specify a list of EXPORTED_FUNCTIONS that does not include `main`.
 var STANDALONE_WASM = 0;
 
-// An optional comma-separated list of script hooks to run after binaryen,
-// in binaryen's /scripts dir.
-var BINARYEN_SCRIPTS = "";
-
 // Whether to ignore implicit traps when optimizing in binaryen.  Implicit
 // traps are the traps that happen in a load that is out of bounds, or
 // div/rem of 0, etc. With this option set, the optimizer assumes that loads
@@ -1690,4 +1686,5 @@ var LEGACY_SETTINGS = [
   ['EXPORT_BINDINGS', [0, 1], 'No longer needed'],
   ['RUNNING_JS_OPTS', [0], 'Fastcomp cared about running JS which could alter asm.js validation, but not upstream'],
   ['EXPORT_FUNCTION_TABLES', [0], 'No longer needed'],
+  ['BINARYEN_SCRIPTS', [""], 'No longer needed'],
 ];


### PR DESCRIPTION
This was designed for running scripts in `binaryen/scripts` but
I don't think there are any scripts there there are useful these
days.