### PR TITLE
Extract MainLoop out of Browser

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -287,9 +287,10 @@ mergeInto(LibraryManager.library, {
     },
   },
 
+  emscripten_sleep__deps: ['$SafeTimers'],
   emscripten_sleep: function(ms) {
     Asyncify.handleSleep(function(wakeUp) {
-      MainLoop.safeSetTimeout(wakeUp, ms);
+      SafeTimers.safeSetTimeout(wakeUp, ms);
     });
   },
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -20,7 +20,7 @@ mergeInto(LibraryManager.library, {
   },
 
 #if ASYNCIFY
-  $Asyncify__deps: ['$MainLoop', '$runAndAbortIfError'],
+  $Asyncify__deps: ['$runAndAbortIfError'],
   $Asyncify: {
     State: {
       Normal: 0,
@@ -213,7 +213,7 @@ mergeInto(LibraryManager.library, {
 #endif
           Asyncify.state = Asyncify.State.Rewinding;
           runAndAbortIfError(function() { Module['_asyncify_start_rewind'](Asyncify.currData) });
-          if (MainLoop.func) {
+          if (typeof MainLoop !== 'undefined' && MainLoop.func) {
             MainLoop.resume();
           }
           var start = Asyncify.getDataRewindFunc(Asyncify.currData);
@@ -251,7 +251,7 @@ mergeInto(LibraryManager.library, {
           err('ASYNCIFY: start unwind ' + Asyncify.currData);
 #endif
           runAndAbortIfError(function() { Module['_asyncify_start_unwind'](Asyncify.currData) });
-          if (MainLoop.func) {
+          if (typeof MainLoop !== 'undefined' && MainLoop.func) {
             MainLoop.pause();
           }
         }

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -20,7 +20,7 @@ mergeInto(LibraryManager.library, {
   },
 
 #if ASYNCIFY
-  $Asyncify__deps: ['$Browser', '$runAndAbortIfError'],
+  $Asyncify__deps: ['$MainLoop', '$runAndAbortIfError'],
   $Asyncify: {
     State: {
       Normal: 0,
@@ -213,8 +213,8 @@ mergeInto(LibraryManager.library, {
 #endif
           Asyncify.state = Asyncify.State.Rewinding;
           runAndAbortIfError(function() { Module['_asyncify_start_rewind'](Asyncify.currData) });
-          if (Browser.mainLoop.func) {
-            Browser.mainLoop.resume();
+          if (MainLoop.func) {
+            MainLoop.resume();
           }
           var start = Asyncify.getDataRewindFunc(Asyncify.currData);
 #if ASYNCIFY_DEBUG
@@ -251,8 +251,8 @@ mergeInto(LibraryManager.library, {
           err('ASYNCIFY: start unwind ' + Asyncify.currData);
 #endif
           runAndAbortIfError(function() { Module['_asyncify_start_unwind'](Asyncify.currData) });
-          if (Browser.mainLoop.func) {
-            Browser.mainLoop.pause();
+          if (MainLoop.func) {
+            MainLoop.pause();
           }
         }
       } else if (Asyncify.state === Asyncify.State.Rewinding) {
@@ -289,7 +289,7 @@ mergeInto(LibraryManager.library, {
 
   emscripten_sleep: function(ms) {
     Asyncify.handleSleep(function(wakeUp) {
-      Browser.safeSetTimeout(wakeUp, ms);
+      MainLoop.safeSetTimeout(wakeUp, ms);
     });
   },
 
@@ -316,6 +316,7 @@ mergeInto(LibraryManager.library, {
     });
   },
 
+  emscripten_wget_data__deps: ['$Browser'],
   emscripten_wget_data: function(url, pbuffer, pnum, perror) {
     Asyncify.handleSleep(function(wakeUp) {
       Browser.asyncLoad(UTF8ToString(url), function(byteArray) {

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -6,7 +6,7 @@
 
 // Utilities for browser environments
 var LibraryBrowser = {
-  $Browser__deps: ['$MainLoop'],
+  $Browser__deps: ['$SafeTimers'],
   $Browser__postset: 'Module["requestFullscreen"] = function Module_requestFullscreen(lockPointer, resizeCanvas) { Browser.requestFullscreen(lockPointer, resizeCanvas) };\n' + // exports
 #if ASSERTIONS
                      'Module["requestFullScreen"] = function Module_requestFullScreen() { Browser.requestFullScreen() };\n' +
@@ -156,7 +156,7 @@ var LibraryBrowser = {
           };
           audio.src = url;
           // workaround for chrome bug 124926 - we do not always get oncanplaythrough or onerror
-          MainLoop.safeSetTimeout(function() {
+          SafeTimers.safeSetTimeout(function() {
             finish(audio); // try to use it even though it is not necessarily ready to play
           }, 10000);
         } else {
@@ -940,12 +940,12 @@ var LibraryBrowser = {
   },
 
   // Callable from pthread, executes in pthread context.
-  emscripten_async_run_script__deps: ['emscripten_run_script', '$MainLoop'],
+  emscripten_async_run_script__deps: ['emscripten_run_script', '$SafeTimers'],
   emscripten_async_run_script: function(script, millis) {
     noExitRuntime = true;
 
     // TODO: cache these to avoid generating garbage
-    MainLoop.safeSetTimeout(function() {
+    SafeTimers.safeSetTimeout(function() {
       _emscripten_run_script(script);
     }, millis);
   },

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -6,84 +6,15 @@
 
 // Utilities for browser environments
 var LibraryBrowser = {
-  $Browser__deps: ['$setMainLoop', 'emscripten_set_main_loop_timing'],
+  $Browser__deps: ['$MainLoop'],
   $Browser__postset: 'Module["requestFullscreen"] = function Module_requestFullscreen(lockPointer, resizeCanvas) { Browser.requestFullscreen(lockPointer, resizeCanvas) };\n' + // exports
 #if ASSERTIONS
                      'Module["requestFullScreen"] = function Module_requestFullScreen() { Browser.requestFullScreen() };\n' +
 #endif
-                     'Module["requestAnimationFrame"] = function Module_requestAnimationFrame(func) { Browser.requestAnimationFrame(func) };\n' +
                      'Module["setCanvasSize"] = function Module_setCanvasSize(width, height, noUpdates) { Browser.setCanvasSize(width, height, noUpdates) };\n' +
-                     'Module["pauseMainLoop"] = function Module_pauseMainLoop() { Browser.mainLoop.pause() };\n' +
-                     'Module["resumeMainLoop"] = function Module_resumeMainLoop() { Browser.mainLoop.resume() };\n' +
                      'Module["getUserMedia"] = function Module_getUserMedia() { Browser.getUserMedia() }\n' +
                      'Module["createContext"] = function Module_createContext(canvas, useWebGL, setInModule, webGLContextAttributes) { return Browser.createContext(canvas, useWebGL, setInModule, webGLContextAttributes) }',
   $Browser: {
-    mainLoop: {
-      scheduler: null,
-      method: '',
-      // Each main loop is numbered with a ID in sequence order. Only one main loop can run at a time. This variable stores the ordinal number of the main loop that is currently
-      // allowed to run. All previous main loops will quit themselves. This is incremented whenever a new main loop is created.
-      /** @type{number} */
-      currentlyRunningMainloop: 0,
-      func: null, // The main loop tick function that will be called at each iteration.
-      arg: 0, // The argument that will be passed to the main loop. (of type void*)
-      timingMode: 0,
-      timingValue: 0,
-      currentFrameNumber: 0,
-      queue: [],
-      pause: function() {
-        Browser.mainLoop.scheduler = null;
-        Browser.mainLoop.currentlyRunningMainloop++; // Incrementing this signals the previous main loop that it's now become old, and it must return.
-      },
-      resume: function() {
-        Browser.mainLoop.currentlyRunningMainloop++;
-        var timingMode = Browser.mainLoop.timingMode;
-        var timingValue = Browser.mainLoop.timingValue;
-        var func = Browser.mainLoop.func;
-        Browser.mainLoop.func = null;
-        setMainLoop(func, 0, false, Browser.mainLoop.arg, true /* do not set timing and call scheduler, we will do it on the next lines */);
-        _emscripten_set_main_loop_timing(timingMode, timingValue);
-        Browser.mainLoop.scheduler();
-      },
-      updateStatus: function() {
-        if (Module['setStatus']) {
-          var message = Module['statusMessage'] || 'Please wait...';
-          var remaining = Browser.mainLoop.remainingBlockers;
-          var expected = Browser.mainLoop.expectedBlockers;
-          if (remaining) {
-            if (remaining < expected) {
-              Module['setStatus'](message + ' (' + (expected - remaining) + '/' + expected + ')');
-            } else {
-              Module['setStatus'](message);
-            }
-          } else {
-            Module['setStatus']('');
-          }
-        }
-      },
-      runIter: function(func) {
-        if (ABORT) return;
-        if (Module['preMainLoop']) {
-          var preRet = Module['preMainLoop']();
-          if (preRet === false) {
-            return; // |return false| skips a frame
-          }
-        }
-        try {
-          func();
-        } catch (e) {
-          if (e instanceof ExitStatus) {
-            return;
-          } else if (e == 'unwind') {
-            return;
-          } else {
-            if (e && typeof e === 'object' && e.stack) err('exception thrown: ' + [e, e.stack]);
-            throw e;
-          }
-        }
-        if (Module['postMainLoop']) Module['postMainLoop']();
-      }
-    },
     isFullscreen: false,
     pointerLock: false,
     moduleContextCreatedCallbacks: [],
@@ -225,7 +156,7 @@ var LibraryBrowser = {
           };
           audio.src = url;
           // workaround for chrome bug 124926 - we do not always get oncanplaythrough or onerror
-          Browser.safeSetTimeout(function() {
+          MainLoop.safeSetTimeout(function() {
             finish(audio); // try to use it even though it is not necessarily ready to play
           }, 10000);
         } else {
@@ -444,96 +375,11 @@ var LibraryBrowser = {
       return true;
     },
 
-    nextRAF: 0,
-
-    fakeRequestAnimationFrame: function(func) {
-      // try to keep 60fps between calls to here
-      var now = Date.now();
-      if (Browser.nextRAF === 0) {
-        Browser.nextRAF = now + 1000/60;
-      } else {
-        while (now + 2 >= Browser.nextRAF) { // fudge a little, to avoid timer jitter causing us to do lots of delay:0
-          Browser.nextRAF += 1000/60;
-        }
-      }
-      var delay = Math.max(Browser.nextRAF - now, 0);
-      setTimeout(func, delay);
-    },
-
-    requestAnimationFrame: function(func) {
-      if (typeof requestAnimationFrame === 'function') {
-        requestAnimationFrame(func);
-        return;
-      }
-      var RAF = Browser.fakeRequestAnimationFrame;
-#if LEGACY_VM_SUPPORT
-      if (typeof window !== 'undefined') {
-        RAF = window['requestAnimationFrame'] ||
-              window['mozRequestAnimationFrame'] ||
-              window['webkitRequestAnimationFrame'] ||
-              window['msRequestAnimationFrame'] ||
-              window['oRequestAnimationFrame'] ||
-              RAF;
-      }
-#endif
-      RAF(func);
-    },
-
     // generic abort-aware wrapper for an async callback
     safeCallback: function(func) {
       return function() {
         if (!ABORT) return func.apply(null, arguments);
       };
-    },
-
-    // abort and pause-aware versions TODO: build main loop on top of this?
-
-    allowAsyncCallbacks: true,
-    queuedAsyncCallbacks: [],
-
-    pauseAsyncCallbacks: function() {
-      Browser.allowAsyncCallbacks = false;
-    },
-    resumeAsyncCallbacks: function() { // marks future callbacks as ok to execute, and synchronously runs any remaining ones right now
-      Browser.allowAsyncCallbacks = true;
-      if (Browser.queuedAsyncCallbacks.length > 0) {
-        var callbacks = Browser.queuedAsyncCallbacks;
-        Browser.queuedAsyncCallbacks = [];
-        callbacks.forEach(function(func) {
-          func();
-        });
-      }
-    },
-
-    safeRequestAnimationFrame: function(func) {
-      return Browser.requestAnimationFrame(function() {
-        if (ABORT) return;
-        if (Browser.allowAsyncCallbacks) {
-          func();
-        } else {
-          Browser.queuedAsyncCallbacks.push(func);
-        }
-      });
-    },
-    safeSetTimeout: function(func, timeout) {
-      noExitRuntime = true;
-      return setTimeout(function() {
-        if (ABORT) return;
-        if (Browser.allowAsyncCallbacks) {
-          func();
-        } else {
-          Browser.queuedAsyncCallbacks.push(func);
-        }
-      }, timeout);
-    },
-    safeSetInterval: function(func, timeout) {
-      noExitRuntime = true;
-      return setInterval(function() {
-        if (ABORT) return;
-        if (Browser.allowAsyncCallbacks) {
-          func();
-        } // drop it on the floor otherwise, next interval will kick in
-      }, timeout);
     },
 
     getMimetype: function(name) {
@@ -1094,12 +940,12 @@ var LibraryBrowser = {
   },
 
   // Callable from pthread, executes in pthread context.
-  emscripten_async_run_script__deps: ['emscripten_run_script'],
+  emscripten_async_run_script__deps: ['emscripten_run_script', '$MainLoop'],
   emscripten_async_run_script: function(script, millis) {
     noExitRuntime = true;
 
     // TODO: cache these to avoid generating garbage
-    Browser.safeSetTimeout(function() {
+    MainLoop.safeSetTimeout(function() {
       _emscripten_run_script(script);
     }, millis);
   },
@@ -1132,262 +978,6 @@ var LibraryBrowser = {
     if (onerror) script.onerror = onerror;
     script.src = UTF8ToString(url);
     document.body.appendChild(script);
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_get_main_loop_timing: function(mode, value) {
-    if (mode) {{{ makeSetValue('mode', 0, 'Browser.mainLoop.timingMode', 'i32') }}};
-    if (value) {{{ makeSetValue('value', 0, 'Browser.mainLoop.timingValue', 'i32') }}};
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_set_main_loop_timing: function(mode, value) {
-    Browser.mainLoop.timingMode = mode;
-    Browser.mainLoop.timingValue = value;
-
-    if (!Browser.mainLoop.func) {
-#if ASSERTIONS
-      console.error('emscripten_set_main_loop_timing: Cannot set timing mode for main loop since a main loop does not exist! Call emscripten_set_main_loop first to set one up.');
-#endif
-      return 1; // Return non-zero on failure, can't set timing mode when there is no main loop.
-    }
-
-    if (mode == 0 /*EM_TIMING_SETTIMEOUT*/) {
-      Browser.mainLoop.scheduler = function Browser_mainLoop_scheduler_setTimeout() {
-        var timeUntilNextTick = Math.max(0, Browser.mainLoop.tickStartTime + value - _emscripten_get_now())|0;
-        setTimeout(Browser.mainLoop.runner, timeUntilNextTick); // doing this each time means that on exception, we stop
-      };
-      Browser.mainLoop.method = 'timeout';
-    } else if (mode == 1 /*EM_TIMING_RAF*/) {
-      Browser.mainLoop.scheduler = function Browser_mainLoop_scheduler_rAF() {
-        Browser.requestAnimationFrame(Browser.mainLoop.runner);
-      };
-      Browser.mainLoop.method = 'rAF';
-    } else if (mode == 2 /*EM_TIMING_SETIMMEDIATE*/) {
-      if (typeof setImmediate === 'undefined') {
-        // Emulate setImmediate. (note: not a complete polyfill, we don't emulate clearImmediate() to keep code size to minimum, since not needed)
-        var setImmediates = [];
-        var emscriptenMainLoopMessageId = 'setimmediate';
-        var Browser_setImmediate_messageHandler = function(event) {
-          // When called in current thread or Worker, the main loop ID is structured slightly different to accommodate for --proxy-to-worker runtime listening to Worker events,
-          // so check for both cases.
-          if (event.data === emscriptenMainLoopMessageId || event.data.target === emscriptenMainLoopMessageId) {
-            event.stopPropagation();
-            setImmediates.shift()();
-          }
-        }
-        addEventListener("message", Browser_setImmediate_messageHandler, true);
-        setImmediate = /** @type{function(function(): ?, ...?): number} */(function Browser_emulated_setImmediate(func) {
-          setImmediates.push(func);
-          if (ENVIRONMENT_IS_WORKER) {
-            if (Module['setImmediates'] === undefined) Module['setImmediates'] = [];
-            Module['setImmediates'].push(func);
-            postMessage({target: emscriptenMainLoopMessageId}); // In --proxy-to-worker, route the message via proxyClient.js
-          } else postMessage(emscriptenMainLoopMessageId, "*"); // On the main thread, can just send the message to itself.
-        })
-      }
-      Browser.mainLoop.scheduler = function Browser_mainLoop_scheduler_setImmediate() {
-        setImmediate(Browser.mainLoop.runner);
-      };
-      Browser.mainLoop.method = 'immediate';
-    }
-    return 0;
-  },
-
-  emscripten_set_main_loop__deps: ['$setMainLoop'],
-  emscripten_set_main_loop__docs: '/** @param {number|boolean=} noSetTiming */',
-  emscripten_set_main_loop: function(func, fps, simulateInfiniteLoop, arg, noSetTiming) {
-    var browserIterationFunc = function() { {{{ makeDynCall('v', 'func') }}}(); };
-    setMainLoop(browserIterationFunc, fps, simulateInfiniteLoop, arg, noSetTiming);
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-#if OFFSCREEN_FRAMEBUFFER
-  $setMainLoop__deps: ['emscripten_set_main_loop_timing', 'emscripten_get_now', 'emscripten_webgl_commit_frame'],
-#else
-  $setMainLoop__deps: ['emscripten_set_main_loop_timing', 'emscripten_get_now'],
-#endif
-  $setMainLoop: function(browserIterationFunc, fps, simulateInfiniteLoop, arg, noSetTiming) {
-    noExitRuntime = true;
-
-    assert(!Browser.mainLoop.func, 'emscripten_set_main_loop: there can only be one main loop function at once: call emscripten_cancel_main_loop to cancel the previous one before setting a new one with different parameters.');
-
-    Browser.mainLoop.func = browserIterationFunc;
-    Browser.mainLoop.arg = arg;
-
-#if USE_CLOSURE_COMPILER
-    // Closure compiler bug(?): Closure does not see that the assignment
-    //   var thisMainLoopId = Browser.mainLoop.currentlyRunningMainloop
-    // is a value copy of a number (even with the JSDoc @type annotation)
-    // but optimizeis the code as if the assignment was a reference assignment,
-    // which results in Browser.mainLoop.pause() not working. Hence use a
-    // workaround to make Closure believe this is a value copy that should occur:
-    // (TODO: Minimize this down to a small test case and report - was unable
-    // to reproduce in a small written test case)
-    /** @type{number} */
-    var thisMainLoopId = (function(){return Browser.mainLoop.currentlyRunningMainloop; })();
-#else
-    var thisMainLoopId = Browser.mainLoop.currentlyRunningMainloop;
-#endif
-
-    Browser.mainLoop.runner = function Browser_mainLoop_runner() {
-      if (ABORT) return;
-      if (Browser.mainLoop.queue.length > 0) {
-        var start = Date.now();
-        var blocker = Browser.mainLoop.queue.shift();
-        blocker.func(blocker.arg);
-        if (Browser.mainLoop.remainingBlockers) {
-          var remaining = Browser.mainLoop.remainingBlockers;
-          var next = remaining%1 == 0 ? remaining-1 : Math.floor(remaining);
-          if (blocker.counted) {
-            Browser.mainLoop.remainingBlockers = next;
-          } else {
-            // not counted, but move the progress along a tiny bit
-            next = next + 0.5; // do not steal all the next one's progress
-            Browser.mainLoop.remainingBlockers = (8*remaining + next)/9;
-          }
-        }
-        console.log('main loop blocker "' + blocker.name + '" took ' + (Date.now() - start) + ' ms'); //, left: ' + Browser.mainLoop.remainingBlockers);
-        Browser.mainLoop.updateStatus();
-
-        // catches pause/resume main loop from blocker execution
-        if (thisMainLoopId < Browser.mainLoop.currentlyRunningMainloop) return;
-
-        setTimeout(Browser.mainLoop.runner, 0);
-        return;
-      }
-
-      // catch pauses from non-main loop sources
-      if (thisMainLoopId < Browser.mainLoop.currentlyRunningMainloop) return;
-
-      // Implement very basic swap interval control
-      Browser.mainLoop.currentFrameNumber = Browser.mainLoop.currentFrameNumber + 1 | 0;
-      if (Browser.mainLoop.timingMode == 1/*EM_TIMING_RAF*/ && Browser.mainLoop.timingValue > 1 && Browser.mainLoop.currentFrameNumber % Browser.mainLoop.timingValue != 0) {
-        // Not the scheduled time to render this frame - skip.
-        Browser.mainLoop.scheduler();
-        return;
-      } else if (Browser.mainLoop.timingMode == 0/*EM_TIMING_SETTIMEOUT*/) {
-        Browser.mainLoop.tickStartTime = _emscripten_get_now();
-      }
-
-      // Signal GL rendering layer that processing of a new frame is about to start. This helps it optimize
-      // VBO double-buffering and reduce GPU stalls.
-#if FULL_ES2 || LEGACY_GL_EMULATION
-      GL.newRenderingFrameStarted();
-#endif
-
-#if USE_PTHREADS && OFFSCREEN_FRAMEBUFFER && GL_SUPPORT_EXPLICIT_SWAP_CONTROL
-      // If the current GL context is a proxied regular WebGL context, and was initialized with implicit swap mode on the main thread, and we are on the parent thread,
-      // perform the swap on behalf of the user.
-      if (typeof GL !== 'undefined' && GL.currentContext && GL.currentContextIsProxied) {
-        var explicitSwapControl = {{{ makeGetValue('GL.currentContext', 0, 'i32') }}};
-        if (!explicitSwapControl) _emscripten_webgl_commit_frame();
-      }
-#endif
-
-#if OFFSCREENCANVAS_SUPPORT
-      // If the current GL context is an OffscreenCanvas, but it was initialized with implicit swap mode, perform the swap on behalf of the user.
-      if (typeof GL !== 'undefined' && GL.currentContext && !GL.currentContextIsProxied && !GL.currentContext.attributes.explicitSwapControl && GL.currentContext.GLctx.commit) {
-        GL.currentContext.GLctx.commit();
-      }
-#endif
-
-#if ASSERTIONS
-      if (Browser.mainLoop.method === 'timeout' && Module.ctx) {
-        warnOnce('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
-        Browser.mainLoop.method = ''; // just warn once per call to set main loop
-      }
-#endif
-
-      Browser.mainLoop.runIter(browserIterationFunc);
-
-#if STACK_OVERFLOW_CHECK
-      checkStackCookie();
-#endif
-
-      // catch pauses from the main loop itself
-      if (thisMainLoopId < Browser.mainLoop.currentlyRunningMainloop) return;
-
-      // Queue new audio data. This is important to be right after the main loop invocation, so that we will immediately be able
-      // to queue the newest produced audio samples.
-      // TODO: Consider adding pre- and post- rAF callbacks so that GL.newRenderingFrameStarted() and SDL.audio.queueNewAudioData()
-      //       do not need to be hardcoded into this function, but can be more generic.
-      if (typeof SDL === 'object' && SDL.audio && SDL.audio.queueNewAudioData) SDL.audio.queueNewAudioData();
-
-      Browser.mainLoop.scheduler();
-    }
-
-    if (!noSetTiming) {
-      if (fps && fps > 0) _emscripten_set_main_loop_timing(0/*EM_TIMING_SETTIMEOUT*/, 1000.0 / fps);
-      else _emscripten_set_main_loop_timing(1/*EM_TIMING_RAF*/, 1); // Do rAF by rendering each frame (no decimating)
-
-      Browser.mainLoop.scheduler();
-    }
-
-    if (simulateInfiniteLoop) {
-      throw 'unwind';
-    }
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_set_main_loop_arg__deps: ['$setMainLoop'],
-  emscripten_set_main_loop_arg: function(func, arg, fps, simulateInfiniteLoop) {
-    var browserIterationFunc = function() { {{{ makeDynCall('vi', 'func') }}}(arg); };
-    setMainLoop(browserIterationFunc, fps, simulateInfiniteLoop, arg);
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_cancel_main_loop: function() {
-    Browser.mainLoop.pause();
-    Browser.mainLoop.func = null;
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_pause_main_loop: function() {
-    Browser.mainLoop.pause();
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_resume_main_loop: function() {
-    Browser.mainLoop.resume();
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  _emscripten_push_main_loop_blocker: function(func, arg, name) {
-    Browser.mainLoop.queue.push({ func: function() {
-      {{{ makeDynCall('vi', 'func') }}}(arg);
-    }, name: UTF8ToString(name), counted: true });
-    Browser.mainLoop.updateStatus();
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  _emscripten_push_uncounted_main_loop_blocker: function(func, arg, name) {
-    Browser.mainLoop.queue.push({ func: function() {
-      {{{ makeDynCall('vi', 'func') }}}(arg);
-    }, name: UTF8ToString(name), counted: false });
-    Browser.mainLoop.updateStatus();
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_set_main_loop_expected_blockers: function(num) {
-    Browser.mainLoop.expectedBlockers = num;
-    Browser.mainLoop.remainingBlockers = num;
-    Browser.mainLoop.updateStatus();
-  },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_async_call: function(func, arg, millis) {
-    noExitRuntime = true;
-
-    function wrapper() {
-      {{{ makeDynCall('vi', 'func') }}}(arg);
-    }
-
-    if (millis >= 0) {
-      Browser.safeSetTimeout(wrapper, millis);
-    } else {
-      Browser.safeRequestAnimationFrame(wrapper);
-    }
   },
 
   // Callable in pthread without __proxy needed.

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -633,13 +633,14 @@ var LibraryGLFW = {
 
     joys: {}, // glfw joystick data
     lastGamepadState: null,
-    lastGamepadStateFrame: null, // The integer value of Browser.mainLoop.currentFrameNumber of when the last gamepad state was produced.
+    lastGamepadStateFrame: null, // The integer value of MainLoop.currentFrameNumber of when the last gamepad state was produced.
 
+    refreshJoysticks__deps: ['$MainLoop'],
     refreshJoysticks: function() {
       // Produce a new Gamepad API sample if we are ticking a new game frame, or if not using emscripten_set_main_loop() at all to drive animation.
-      if (Browser.mainLoop.currentFrameNumber !== GLFW.lastGamepadStateFrame || !Browser.mainLoop.currentFrameNumber) {
+      if (MainLoop.currentFrameNumber !== GLFW.lastGamepadStateFrame || !MainLoop.currentFrameNumber) {
         GLFW.lastGamepadState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : null);
-        GLFW.lastGamepadStateFrame = Browser.mainLoop.currentFrameNumber;
+        GLFW.lastGamepadStateFrame = MainLoop.currentFrameNumber;
 
         for (var joy = 0; joy < GLFW.lastGamepadState.length; ++joy) {
           var gamepad = GLFW.lastGamepadState[joy];

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -421,27 +421,27 @@ var LibraryGLUT = {
     }
   },
 
-  glutIdleFunc__deps: ['$MainLoop'],
+  glutIdleFunc__deps: ['$SafeTimers'],
   glutIdleFunc__proxy: 'sync',
   glutIdleFunc__sig: 'vi',
   glutIdleFunc: function(func) {
     function callback() {
       if (GLUT.idleFunc) {
         {{{ makeDynCall('v', 'GLUT.idleFunc') }}}();
-        MainLoop.safeSetTimeout(callback, 4); // HTML spec specifies a 4ms minimum delay on the main thread; workers might get more, but we standardize here
+        SafeTimers.safeSetTimeout(callback, 4); // HTML spec specifies a 4ms minimum delay on the main thread; workers might get more, but we standardize here
       }
     }
     if (!GLUT.idleFunc) {
-      MainLoop.safeSetTimeout(callback, 0);
+      SafeTimers.safeSetTimeout(callback, 0);
     }
     GLUT.idleFunc = func;
   },
 
-  glutTimerFunc__deps: ['$MainLoop'],
+  glutTimerFunc__deps: ['$SafeTimers'],
   glutTimerFunc__proxy: 'sync',
   glutTimerFunc__sig: 'viii',
   glutTimerFunc: function(msec, func, value) {
-    MainLoop.safeSetTimeout(function() { {{{ makeDynCall('vi', 'func') }}}(value); }, msec);
+    SafeTimers.safeSetTimeout(function() { {{{ makeDynCall('vi', 'func') }}}(value); }, msec);
   },
 
   glutDisplayFunc__proxy: 'sync',
@@ -647,13 +647,13 @@ var LibraryGLUT = {
   glutSwapBuffers__sig: 'v',
   glutSwapBuffers: function() {},
 
-  glutPostRedisplay__deps: ['$MainLoop'],
+  glutPostRedisplay__deps: ['$MainLoop', '$SafeTimers'],
   glutPostRedisplay__proxy: 'sync',
   glutPostRedisplay__sig: 'v',
   glutPostRedisplay: function() {
     if (GLUT.displayFunc && !GLUT.requestedAnimationFrame) {
       GLUT.requestedAnimationFrame = true;
-      MainLoop.requestAnimationFrame(function() {
+      SafeTimers.requestAnimationFrame(function() {
         GLUT.requestedAnimationFrame = false;
         MainLoop.runIter(function() {
           {{{ makeDynCall('v', 'GLUT.displayFunc') }}}();

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -421,25 +421,27 @@ var LibraryGLUT = {
     }
   },
 
+  glutIdleFunc__deps: ['$MainLoop'],
   glutIdleFunc__proxy: 'sync',
   glutIdleFunc__sig: 'vi',
   glutIdleFunc: function(func) {
     function callback() {
       if (GLUT.idleFunc) {
         {{{ makeDynCall('v', 'GLUT.idleFunc') }}}();
-        Browser.safeSetTimeout(callback, 4); // HTML spec specifies a 4ms minimum delay on the main thread; workers might get more, but we standardize here
+        MainLoop.safeSetTimeout(callback, 4); // HTML spec specifies a 4ms minimum delay on the main thread; workers might get more, but we standardize here
       }
     }
     if (!GLUT.idleFunc) {
-      Browser.safeSetTimeout(callback, 0);
+      MainLoop.safeSetTimeout(callback, 0);
     }
     GLUT.idleFunc = func;
   },
 
+  glutTimerFunc__deps: ['$MainLoop'],
   glutTimerFunc__proxy: 'sync',
   glutTimerFunc__sig: 'viii',
   glutTimerFunc: function(msec, func, value) {
-    Browser.safeSetTimeout(function() { {{{ makeDynCall('vi', 'func') }}}(value); }, msec);
+    MainLoop.safeSetTimeout(function() { {{{ makeDynCall('vi', 'func') }}}(value); }, msec);
   },
 
   glutDisplayFunc__proxy: 'sync',
@@ -645,14 +647,15 @@ var LibraryGLUT = {
   glutSwapBuffers__sig: 'v',
   glutSwapBuffers: function() {},
 
+  glutPostRedisplay__deps: ['$MainLoop'],
   glutPostRedisplay__proxy: 'sync',
   glutPostRedisplay__sig: 'v',
   glutPostRedisplay: function() {
     if (GLUT.displayFunc && !GLUT.requestedAnimationFrame) {
       GLUT.requestedAnimationFrame = true;
-      Browser.requestAnimationFrame(function() {
+      MainLoop.requestAnimationFrame(function() {
         GLUT.requestedAnimationFrame = false;
-        Browser.mainLoop.runIter(function() {
+        MainLoop.runIter(function() {
           {{{ makeDynCall('v', 'GLUT.displayFunc') }}}();
         });
       });

--- a/src/library_mainloop.js
+++ b/src/library_mainloop.js
@@ -1,0 +1,425 @@
+/**
+ * @license
+ * Copyright 2020 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+// MainLoop system
+var LibraryMainLoop = {
+  $MainLoop__deps: ['$setMainLoop', 'emscripten_set_main_loop_timing'],
+  $MainLoop__postset: 'Module["pauseMainLoop"] = function Module_pauseMainLoop() { MainLoop.pause() };\n' +
+                      'Module["requestAnimationFrame"] = function Module_requestAnimationFrame(func) { MainLoop.requestAnimationFrame(func) };\n' +
+                      'Module["resumeMainLoop"] = function Module_resumeMainLoop() { MainLoop.resume() };\n',
+
+  $MainLoop: {
+    scheduler: null,
+    method: '',
+    // Each main loop is numbered with a ID in sequence order. Only one main loop can run at a time. This variable stores the ordinal number of the main loop that is currently
+    // allowed to run. All previous main loops will quit themselves. This is incremented whenever a new main loop is created.
+    /** @type{number} */
+    currentlyRunningMainloop: 0,
+    func: null, // The main loop tick function that will be called at each iteration.
+    arg: 0, // The argument that will be passed to the main loop. (of type void*)
+    timingMode: 0,
+    timingValue: 0,
+    currentFrameNumber: 0,
+    queue: [],
+    pause: function() {
+      MainLoop.scheduler = null;
+      MainLoop.currentlyRunningMainloop++; // Incrementing this signals the previous main loop that it's now become old, and it must return.
+    },
+    resume: function() {
+      MainLoop.currentlyRunningMainloop++;
+      var timingMode = MainLoop.timingMode;
+      var timingValue = MainLoop.timingValue;
+      var func = MainLoop.func;
+      MainLoop.func = null;
+      setMainLoop(func, 0, false, MainLoop.arg, true /* do not set timing and call scheduler, we will do it on the next lines */);
+      _emscripten_set_main_loop_timing(timingMode, timingValue);
+      MainLoop.scheduler();
+    },
+    updateStatus: function() {
+      if (Module['setStatus']) {
+        var message = Module['statusMessage'] || 'Please wait...';
+        var remaining = MainLoop.remainingBlockers;
+        var expected = MainLoop.expectedBlockers;
+        if (remaining) {
+          if (remaining < expected) {
+            Module['setStatus'](message + ' (' + (expected - remaining) + '/' + expected + ')');
+          } else {
+            Module['setStatus'](message);
+          }
+        } else {
+          Module['setStatus']('');
+        }
+      }
+    },
+    runIter: function(func) {
+      if (ABORT) return;
+      if (Module['preMainLoop']) {
+        var preRet = Module['preMainLoop']();
+        if (preRet === false) {
+          return; // |return false| skips a frame
+        }
+      }
+      try {
+        func();
+      } catch (e) {
+        if (e instanceof ExitStatus) {
+          return;
+        } else if (e == 'unwind') {
+          return;
+        } else {
+          if (e && typeof e === 'object' && e.stack) err('exception thrown: ' + [e, e.stack]);
+          throw e;
+        }
+      }
+      if (Module['postMainLoop']) Module['postMainLoop']();
+    },
+
+    nextRAF: 0,
+
+    fakeRequestAnimationFrame: function(func) {
+      // try to keep 60fps between calls to here
+      var now = Date.now();
+      if (MainLoop.nextRAF === 0) {
+        MainLoop.nextRAF = now + 1000/60;
+      } else {
+        while (now + 2 >= MainLoop.nextRAF) { // fudge a little, to avoid timer jitter causing us to do lots of delay:0
+          MainLoop.nextRAF += 1000/60;
+        }
+      }
+      var delay = Math.max(MainLoop.nextRAF - now, 0);
+      setTimeout(func, delay);
+    },
+
+    requestAnimationFrame: function(func) {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(func);
+        return;
+      }
+      var RAF = MainLoop.fakeRequestAnimationFrame;
+#if LEGACY_VM_SUPPORT
+      if (typeof window !== 'undefined') {
+        RAF = window['requestAnimationFrame'] ||
+              window['mozRequestAnimationFrame'] ||
+              window['webkitRequestAnimationFrame'] ||
+              window['msRequestAnimationFrame'] ||
+              window['oRequestAnimationFrame'] ||
+              RAF;
+      }
+#endif
+      RAF(func);
+    },
+
+    // abort and pause-aware versions TODO: build main loop on top of this?
+
+    allowAsyncCallbacks: true,
+    queuedAsyncCallbacks: [],
+
+    pauseAsyncCallbacks: function() {
+      MainLoop.allowAsyncCallbacks = false;
+    },
+    resumeAsyncCallbacks: function() { // marks future callbacks as ok to execute, and synchronously runs any remaining ones right now
+      MainLoop.allowAsyncCallbacks = true;
+      if (MainLoop.queuedAsyncCallbacks.length > 0) {
+        var callbacks = MainLoop.queuedAsyncCallbacks;
+        MainLoop.queuedAsyncCallbacks = [];
+        callbacks.forEach(function(func) {
+          func();
+        });
+      }
+    },
+
+    safeRequestAnimationFrame: function(func) {
+      return MainLoop.requestAnimationFrame(function() {
+        if (ABORT) return;
+        if (MainLoop.allowAsyncCallbacks) {
+          func();
+        } else {
+          MainLoop.queuedAsyncCallbacks.push(func);
+        }
+      });
+    },
+    safeSetTimeout: function(func, timeout) {
+      noExitRuntime = true;
+      return setTimeout(function() {
+        if (ABORT) return;
+        if (MainLoop.allowAsyncCallbacks) {
+          func();
+        } else {
+          MainLoop.queuedAsyncCallbacks.push(func);
+        }
+      }, timeout);
+    },
+    safeSetInterval: function(func, timeout) {
+      noExitRuntime = true;
+      return setInterval(function() {
+        if (ABORT) return;
+        if (MainLoop.allowAsyncCallbacks) {
+          func();
+        } // drop it on the floor otherwise, next interval will kick in
+      }, timeout);
+    },
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_get_main_loop_timing: function(mode, value) {
+    if (mode) {{{ makeSetValue('mode', 0, 'MainLoop.timingMode', 'i32') }}};
+    if (value) {{{ makeSetValue('value', 0, 'MainLoop.timingValue', 'i32') }}};
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_set_main_loop_timing: function(mode, value) {
+    MainLoop.timingMode = mode;
+    MainLoop.timingValue = value;
+
+    if (!MainLoop.func) {
+#if ASSERTIONS
+      console.error('emscripten_set_main_loop_timing: Cannot set timing mode for main loop since a main loop does not exist! Call   emscripten_set_main_loop first to set one up.');
+#endif
+      return 1; // Return non-zero on failure, can't set timing mode when there is no main loop.
+    }
+
+    if (mode == 0 /*EM_TIMING_SETTIMEOUT*/) {
+      MainLoop.scheduler = function MainLoop_scheduler_setTimeout() {
+        var timeUntilNextTick = Math.max(0, MainLoop.tickStartTime + value - _emscripten_get_now())|0;
+        setTimeout(MainLoop.runner, timeUntilNextTick); // doing this each time means that on exception, we stop
+      };
+      MainLoop.method = 'timeout';
+    } else if (mode == 1 /*EM_TIMING_RAF*/) {
+      MainLoop.scheduler = function MainLoop_scheduler_rAF() {
+        MainLoop.requestAnimationFrame(MainLoop.runner);
+      };
+      MainLoop.method = 'rAF';
+    } else if (mode == 2 /*EM_TIMING_SETIMMEDIATE*/) {
+      if (typeof setImmediate === 'undefined') {
+        // Emulate setImmediate. (note: not a complete polyfill, we don't emulate clearImmediate() to keep code size to minimum, since not needed)
+        var setImmediates = [];
+        var emscriptenMainLoopMessageId = 'setimmediate';
+        var MainLoop_setImmediate_messageHandler = function(event) {
+          // When called in current thread or Worker, the main loop ID is structured slightly different to accommodate for --proxy-to-worker runtime listening to Worker events,
+          // so check for both cases.
+          if (event.data === emscriptenMainLoopMessageId || event.data.target === emscriptenMainLoopMessageId) {
+            event.stopPropagation();
+            setImmediates.shift()();
+          }
+        }
+        addEventListener("message", MainLoop_setImmediate_messageHandler, true);
+        setImmediate = /** @type{function(function(): ?, ...?): number} */(function MainLoop_emulated_setImmediate(func) {
+          setImmediates.push(func);
+          if (ENVIRONMENT_IS_WORKER) {
+            if (Module['setImmediates'] === undefined) Module['setImmediates'] = [];
+            Module['setImmediates'].push(func);
+            postMessage({target: emscriptenMainLoopMessageId}); // In --proxy-to-worker, route the message via proxyClient.js
+          } else postMessage(emscriptenMainLoopMessageId, "*"); // On the main thread, can just send the message to itself.
+        })
+      }
+      MainLoop.scheduler = function MainLoop_scheduler_setImmediate() {
+        setImmediate(MainLoop.runner);
+      };
+      MainLoop.method = 'immediate';
+    }
+    return 0;
+  },
+
+  emscripten_set_main_loop__deps: ['$setMainLoop'],
+  emscripten_set_main_loop__docs: '/** @param {number|boolean=} noSetTiming */',
+  emscripten_set_main_loop: function(func, fps, simulateInfiniteLoop, arg, noSetTiming) {
+    var MainLoopIterationFunc = function() { {{{ makeDynCall('v', 'func') }}}(); };
+    setMainLoop(MainLoopIterationFunc, fps, simulateInfiniteLoop, arg, noSetTiming);
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+#if OFFSCREEN_FRAMEBUFFER
+  $setMainLoop__deps: ['emscripten_set_main_loop_timing', 'emscripten_get_now', 'emscripten_webgl_commit_frame'],
+#else
+  $setMainLoop__deps: ['emscripten_set_main_loop_timing', 'emscripten_get_now'],
+#endif
+  $setMainLoop: function(MainLoopIterationFunc, fps, simulateInfiniteLoop, arg, noSetTiming) {
+    noExitRuntime = true;
+
+    assert(!MainLoop.func, 'emscripten_set_main_loop: there can only be one main loop function at once: call emscripten_cancel_main_loop to cancel the previous one before setting a new one with different parameters.');
+
+    MainLoop.func = MainLoopIterationFunc;
+    MainLoop.arg = arg;
+
+#if USE_CLOSURE_COMPILER
+    // Closure compiler bug(?): Closure does not see that the assignment
+    //   var thisMainLoopId = MainLoop.currentlyRunningMainloop
+    // is a value copy of a number (even with the JSDoc @type annotation)
+    // but optimizeis the code as if the assignment was a reference assignment,
+    // which results in MainLoop.pause() not working. Hence use a
+    // workaround to make Closure believe this is a value copy that should occur:
+    // (TODO: Minimize this down to a small test case and report - was unable
+    // to reproduce in a small written test case)
+    /** @type{number} */
+    var thisMainLoopId = (function(){return MainLoop.currentlyRunningMainloop; })();
+#else
+    var thisMainLoopId = MainLoop.currentlyRunningMainloop;
+#endif
+
+    MainLoop.runner = function MainLoop_runner() {
+      if (ABORT) return;
+      if (MainLoop.queue.length > 0) {
+        var start = Date.now();
+        var blocker = MainLoop.queue.shift();
+        blocker.func(blocker.arg);
+        if (MainLoop.remainingBlockers) {
+          var remaining = MainLoop.remainingBlockers;
+          var next = remaining%1 == 0 ? remaining-1 : Math.floor(remaining);
+          if (blocker.counted) {
+            MainLoop.remainingBlockers = next;
+          } else {
+            // not counted, but move the progress along a tiny bit
+            next = next + 0.5; // do not steal all the next one's progress
+            MainLoop.remainingBlockers = (8*remaining + next)/9;
+          }
+        }
+        console.log('main loop blocker "' + blocker.name + '" took ' + (Date.now() - start) + ' ms'); //, left: ' + MainLoop.remainingBlockers);
+        MainLoop.updateStatus();
+
+        // catches pause/resume main loop from blocker execution
+        if (thisMainLoopId < MainLoop.currentlyRunningMainloop) return;
+
+        setTimeout(MainLoop.runner, 0);
+        return;
+      }
+
+      // catch pauses from non-main loop sources
+      if (thisMainLoopId < MainLoop.currentlyRunningMainloop) return;
+
+      // Implement very basic swap interval control
+      MainLoop.currentFrameNumber = MainLoop.currentFrameNumber + 1 | 0;
+      if (MainLoop.timingMode == 1/*EM_TIMING_RAF*/ && MainLoop.timingValue > 1 && MainLoop.currentFrameNumber % MainLoop.timingValue != 0) {
+        // Not the scheduled time to render this frame - skip.
+        MainLoop.scheduler();
+        return;
+      } else if (MainLoop.timingMode == 0/*EM_TIMING_SETTIMEOUT*/) {
+        MainLoop.tickStartTime = _emscripten_get_now();
+      }
+
+      // Signal GL rendering layer that processing of a new frame is about to start. This helps it optimize
+      // VBO double-buffering and reduce GPU stalls.
+#if FULL_ES2 || LEGACY_GL_EMULATION
+      GL.newRenderingFrameStarted();
+#endif
+
+#if USE_PTHREADS && OFFSCREEN_FRAMEBUFFER && GL_SUPPORT_EXPLICIT_SWAP_CONTROL
+      // If the current GL context is a proxied regular WebGL context, and was initialized with implicit swap mode on the main thread, and we are on the parent thread,
+      // perform the swap on behalf of the user.
+      if (typeof GL !== 'undefined' && GL.currentContext && GL.currentContextIsProxied) {
+        var explicitSwapControl = {{{ makeGetValue('GL.currentContext', 0, 'i32') }}};
+        if (!explicitSwapControl) _emscripten_webgl_commit_frame();
+      }
+#endif
+
+#if OFFSCREENCANVAS_SUPPORT
+      // If the current GL context is an OffscreenCanvas, but it was initialized with implicit swap mode, perform the swap on behalf of the user.
+      if (typeof GL !== 'undefined' && GL.currentContext && !GL.currentContextIsProxied && !GL.currentContext.attributes.explicitSwapControl && GL.currentContext.GLctx.commit) {
+        GL.currentContext.GLctx.commit();
+      }
+#endif
+
+#if ASSERTIONS
+      if (MainLoop.method === 'timeout' && Module.ctx) {
+        warnOnce('Looks like you are rendering without using requestAnimationFrame for the main loop. You should use 0 for the frame rate in emscripten_set_main_loop in order to use requestAnimationFrame, as that can greatly improve your frame rates!');
+        MainLoop.method = ''; // just warn once per call to set main loop
+      }
+#endif
+
+      MainLoop.runIter(MainLoopIterationFunc);
+
+#if STACK_OVERFLOW_CHECK
+      checkStackCookie();
+#endif
+
+      // catch pauses from the main loop itself
+      if (thisMainLoopId < MainLoop.currentlyRunningMainloop) return;
+
+      // Queue new audio data. This is important to be right after the main loop invocation, so that we will immediately be able
+      // to queue the newest produced audio samples.
+      // TODO: Consider adding pre- and post- rAF callbacks so that GL.newRenderingFrameStarted() and SDL.audio.queueNewAudioData()
+      //       do not need to be hardcoded into this function, but can be more generic.
+      if (typeof SDL === 'object' && SDL.audio && SDL.audio.queueNewAudioData) SDL.audio.queueNewAudioData();
+
+      MainLoop.scheduler();
+    }
+
+    if (!noSetTiming) {
+      if (fps && fps > 0) _emscripten_set_main_loop_timing(0/*EM_TIMING_SETTIMEOUT*/, 1000.0 / fps);
+      else _emscripten_set_main_loop_timing(1/*EM_TIMING_RAF*/, 1); // Do rAF by rendering each frame (no decimating)
+
+      MainLoop.scheduler();
+    }
+
+    if (simulateInfiniteLoop) {
+      throw 'unwind';
+    }
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_set_main_loop_arg__deps: ['$setMainLoop'],
+  emscripten_set_main_loop_arg: function(func, arg, fps, simulateInfiniteLoop) {
+    var MainLoopIterationFunc = function() { {{{ makeDynCall('vi', 'func') }}}(arg); };
+    setMainLoop(MainLoopIterationFunc, fps, simulateInfiniteLoop, arg);
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_cancel_main_loop: function() {
+    MainLoop.pause();
+    MainLoop.func = null;
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_pause_main_loop: function() {
+    MainLoop.pause();
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_resume_main_loop: function() {
+    MainLoop.resume();
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  _emscripten_push_main_loop_blocker: function(func, arg, name) {
+    MainLoop.queue.push({ func: function() {
+      {{{ makeDynCall('vi', 'func') }}}(arg);
+    }, name: UTF8ToString(name), counted: true });
+    MainLoop.updateStatus();
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  _emscripten_push_uncounted_main_loop_blocker: function(func, arg, name) {
+    MainLoop.queue.push({ func: function() {
+      {{{ makeDynCall('vi', 'func') }}}(arg);
+    }, name: UTF8ToString(name), counted: false });
+    MainLoop.updateStatus();
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_set_main_loop_expected_blockers: function(num) {
+    MainLoop.expectedBlockers = num;
+    MainLoop.remainingBlockers = num;
+    MainLoop.updateStatus();
+  },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_async_call: function(func, arg, millis) {
+    noExitRuntime = true;
+
+    function wrapper() {
+      {{{ makeDynCall('vi', 'func') }}}(arg);
+    }
+
+    if (millis >= 0) {
+      MainLoop.safeSetTimeout(wrapper, millis);
+    } else {
+      MainLoop.safeRequestAnimationFrame(wrapper);
+    }
+  },
+};
+
+autoAddDeps(LibraryMainLoop, '$MainLoop');
+
+mergeInto(LibraryManager.library, LibraryMainLoop);

--- a/src/library_mainloop.js
+++ b/src/library_mainloop.js
@@ -318,22 +318,6 @@ var LibraryMainLoop = {
     MainLoop.remainingBlockers = num;
     MainLoop.updateStatus();
   },
-
-  // Runs natively in pthread, no __proxy needed.
-  emscripten_async_call__deps: ['$SafeTimers'],
-  emscripten_async_call: function(func, arg, millis) {
-    noExitRuntime = true;
-
-    function wrapper() {
-      {{{ makeDynCall('vi', 'func') }}}(arg);
-    }
-
-    if (millis >= 0) {
-      SafeTimers.safeSetTimeout(wrapper, millis);
-    } else {
-      SafeTimers.safeRequestAnimationFrame(wrapper);
-    }
-  },
 };
 
 autoAddDeps(LibraryMainLoop, '$MainLoop');

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -11,7 +11,7 @@ var LibraryOpenAL = {
   // ** INTERNALS 
   // ************************************************************************
 
-  $AL__deps: ['$Browser'],
+  $AL__deps: ['$Browser', '$MainLoop'],
   $AL: {
     // ------------------------------------------------------
     // -- Constants 
@@ -90,7 +90,7 @@ var LibraryOpenAL = {
       // If we are animating using the requestAnimationFrame method, then the main loop does not run when in the background.
       // To give a perfect glitch-free audio stop when switching from foreground to background, we need to avoid updating
       // audio altogether when in the background, so detect that case and kill audio buffer streaming if so.
-      if (Browser.mainLoop.timingMode === 1 /* EM_TIMING_RAF */ && document['visibilityState'] != 'visible') {
+      if (MainLoop.timingMode === 1 /* EM_TIMING_RAF */ && document['visibilityState'] != 'visible') {
         return;
       }
 
@@ -107,7 +107,7 @@ var LibraryOpenAL = {
     // to OpenAL parameters, such as pitch, may require the web audio queue to be flushed and rescheduled.
     scheduleSourceAudio: function(src, lookahead) {
       // See comment on scheduleContextAudio above.
-      if (Browser.mainLoop.timingMode === 1 /*EM_TIMING_RAF*/ && document['visibilityState'] != 'visible') {
+      if (MainLoop.timingMode === 1 /*EM_TIMING_RAF*/ && document['visibilityState'] != 'visible') {
         return;
       }
       if (src.state !== 0x1012 /* AL_PLAYING */) {

--- a/src/library_safetimers.js
+++ b/src/library_safetimers.js
@@ -96,6 +96,23 @@ var LibrarySafeTimers = {
       RAF(func);
     },
   },
+
+  // Runs natively in pthread, no __proxy needed.
+  emscripten_async_call: function(func, arg, millis) {
+    noExitRuntime = true;
+
+    function wrapper() {
+      {{{ makeDynCall('vi', 'func') }}}(arg);
+    }
+
+    if (millis >= 0) {
+      SafeTimers.safeSetTimeout(wrapper, millis);
+    } else {
+      SafeTimers.safeRequestAnimationFrame(wrapper);
+    }
+  },
 };
+
+autoAddDeps(LibrarySafeTimers, '$SafeTimers');
 
 mergeInto(LibraryManager.library, LibrarySafeTimers);

--- a/src/library_safetimers.js
+++ b/src/library_safetimers.js
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2020 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+// Safe timers
+var LibrarySafeTimers = {
+  $SafeTimers__postset: 'Module["requestAnimationFrame"] = function Module_requestAnimationFrame(func) { SafeTimers.requestAnimationFrame(func) };\n',
+  $SafeTimers: {
+    // abort and pause-aware versions TODO: build main loop on top of this?
+
+    allowAsyncCallbacks: true,
+    queuedAsyncCallbacks: [],
+
+    pauseAsyncCallbacks: function() {
+      SafeTimers.allowAsyncCallbacks = false;
+    },
+
+    resumeAsyncCallbacks: function() { // marks future callbacks as ok to execute, and synchronously runs any remaining ones right now
+      SafeTimers.allowAsyncCallbacks = true;
+      if (SafeTimers.queuedAsyncCallbacks.length > 0) {
+        var callbacks = SafeTimers.queuedAsyncCallbacks;
+        SafeTimers.queuedAsyncCallbacks = [];
+        callbacks.forEach(function(func) {
+          func();
+        });
+      }
+    },
+
+    safeRequestAnimationFrame: function(func) {
+      return SafeTimers.requestAnimationFrame(function() {
+        if (ABORT) return;
+        if (SafeTimers.allowAsyncCallbacks) {
+          func();
+        } else {
+          SafeTimers.queuedAsyncCallbacks.push(func);
+        }
+      });
+    },
+
+    safeSetTimeout: function(func, timeout) {
+      noExitRuntime = true;
+      return setTimeout(function() {
+        if (ABORT) return;
+        if (SafeTimers.allowAsyncCallbacks) {
+          func();
+        } else {
+          SafeTimers.queuedAsyncCallbacks.push(func);
+        }
+      }, timeout);
+    },
+
+    safeSetInterval: function(func, timeout) {
+      noExitRuntime = true;
+      return setInterval(function() {
+        if (ABORT) return;
+        if (SafeTimers.allowAsyncCallbacks) {
+          func();
+        } // drop it on the floor otherwise, next interval will kick in
+      }, timeout);
+    },
+
+    nextRAF: 0,
+
+    fakeRequestAnimationFrame: function(func) {
+      // try to keep 60fps between calls to here
+      var now = Date.now();
+      if (SafeTimers.nextRAF === 0) {
+        SafeTimers.nextRAF = now + 1000/60;
+      } else {
+        while (now + 2 >= SafeTimers.nextRAF) { // fudge a little, to avoid timer jitter causing us to do lots of delay:0
+          SafeTimers.nextRAF += 1000/60;
+        }
+      }
+      var delay = Math.max(SafeTimers.nextRAF - now, 0);
+      setTimeout(func, delay);
+    },
+
+    requestAnimationFrame: function(func) {
+      if (typeof requestAnimationFrame === 'function') {
+        requestAnimationFrame(func);
+        return;
+      }
+      var RAF = SafeTimers.fakeRequestAnimationFrame;
+#if LEGACY_VM_SUPPORT
+      if (typeof window !== 'undefined') {
+        RAF = window['requestAnimationFrame'] ||
+              window['mozRequestAnimationFrame'] ||
+              window['webkitRequestAnimationFrame'] ||
+              window['msRequestAnimationFrame'] ||
+              window['oRequestAnimationFrame'] ||
+              RAF;
+      }
+#endif
+      RAF(func);
+    },
+  },
+};
+
+mergeInto(LibraryManager.library, LibrarySafeTimers);

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -30,7 +30,7 @@ var LibrarySDL = {
     '$FS',
 #endif
     '$PATH', '$Browser', 'SDL_GetTicks', 'SDL_LockSurface',
-    '$SDL_unicode', '$SDL_ttfContext', '$SDL_audio', '$MainLoop'
+    '$SDL_unicode', '$SDL_ttfContext', '$SDL_audio', '$MainLoop', '$SafeTimers'
   ],
   $SDL: {
     defaults: {
@@ -2532,12 +2532,12 @@ var LibrarySDL = {
 
         if (SDL.audio.numAudioTimersPending < SDL.audio.numSimultaneouslyQueuedBuffers) {
           ++SDL.audio.numAudioTimersPending;
-          SDL.audio.timer = MainLoop.safeSetTimeout(SDL.audio.caller, Math.max(0.0, 1000.0*(secsUntilNextPlayStart-preemptBufferFeedSecs)));
+          SDL.audio.timer = SafeTimers.safeSetTimeout(SDL.audio.caller, Math.max(0.0, 1000.0*(secsUntilNextPlayStart-preemptBufferFeedSecs)));
 
           // If we are risking starving, immediately queue an extra buffer.
           if (SDL.audio.numAudioTimersPending < SDL.audio.numSimultaneouslyQueuedBuffers) {
             ++SDL.audio.numAudioTimersPending;
-            MainLoop.safeSetTimeout(SDL.audio.caller, 1.0);
+            SafeTimers.safeSetTimeout(SDL.audio.caller, 1.0);
           }
         }
       };
@@ -2648,7 +2648,7 @@ var LibrarySDL = {
     } else if (!SDL.audio.timer) {
       // Start the audio playback timer callback loop.
       SDL.audio.numAudioTimersPending = 1;
-      SDL.audio.timer = MainLoop.safeSetTimeout(SDL.audio.caller, 1);
+      SDL.audio.timer = SafeTimers.safeSetTimeout(SDL.audio.caller, 1);
     }
     SDL.audio.paused = pauseOn;
   },

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -30,7 +30,7 @@ var LibrarySDL = {
     '$FS',
 #endif
     '$PATH', '$Browser', 'SDL_GetTicks', 'SDL_LockSurface',
-    '$SDL_unicode', '$SDL_ttfContext', '$SDL_audio'
+    '$SDL_unicode', '$SDL_ttfContext', '$SDL_audio', '$MainLoop'
   ],
   $SDL: {
     defaults: {
@@ -783,10 +783,10 @@ var LibrarySDL = {
           event.preventDefault();
           break;
         case 'unload':
-          if (Browser.mainLoop.runner) {
+          if (MainLoop.runner) {
             SDL.events.push(event);
             // Force-run a main event loop, since otherwise this event will never be caught!
-            Browser.mainLoop.runner();
+            MainLoop.runner();
           }
           return;
         case 'resize':
@@ -2532,12 +2532,12 @@ var LibrarySDL = {
 
         if (SDL.audio.numAudioTimersPending < SDL.audio.numSimultaneouslyQueuedBuffers) {
           ++SDL.audio.numAudioTimersPending;
-          SDL.audio.timer = Browser.safeSetTimeout(SDL.audio.caller, Math.max(0.0, 1000.0*(secsUntilNextPlayStart-preemptBufferFeedSecs)));
+          SDL.audio.timer = MainLoop.safeSetTimeout(SDL.audio.caller, Math.max(0.0, 1000.0*(secsUntilNextPlayStart-preemptBufferFeedSecs)));
 
           // If we are risking starving, immediately queue an extra buffer.
           if (SDL.audio.numAudioTimersPending < SDL.audio.numSimultaneouslyQueuedBuffers) {
             ++SDL.audio.numAudioTimersPending;
-            Browser.safeSetTimeout(SDL.audio.caller, 1.0);
+            MainLoop.safeSetTimeout(SDL.audio.caller, 1.0);
           }
         }
       };
@@ -2648,7 +2648,7 @@ var LibrarySDL = {
     } else if (!SDL.audio.timer) {
       // Start the audio playback timer callback loop.
       SDL.audio.numAudioTimersPending = 1;
-      SDL.audio.timer = Browser.safeSetTimeout(SDL.audio.caller, 1);
+      SDL.audio.timer = MainLoop.safeSetTimeout(SDL.audio.caller, 1);
     }
     SDL.audio.paused = pauseOn;
   },
@@ -3488,7 +3488,7 @@ var LibrarySDL = {
   SDL_GL_GetSwapInterval__proxy: 'sync',
   SDL_GL_GetSwapInterval__sig: 'ii',
   SDL_GL_GetSwapInterval: function(state) {
-    if (Browser.mainLoop.timingMode == 1/*EM_TIMING_RAF*/) return Browser.mainLoop.timingValue;
+    if (MainLoop.timingMode == 1/*EM_TIMING_RAF*/) return MainLoop.timingValue;
     else return 0;
   },
 

--- a/src/modules.js
+++ b/src/modules.js
@@ -91,6 +91,7 @@ var LibraryManager = {
       libraries.push('library_strings.js');
     } else {
       libraries.push('library_browser.js');
+      libraries.push('library_mainloop.js');
     }
 
     if (USE_PTHREADS) { // TODO: Currently WebGL proxying makes pthreads library depend on WebGL.

--- a/src/modules.js
+++ b/src/modules.js
@@ -92,6 +92,7 @@ var LibraryManager = {
     } else {
       libraries.push('library_browser.js');
       libraries.push('library_mainloop.js');
+      libraries.push('library_safetimers.js');
     }
 
     if (USE_PTHREADS) { // TODO: Currently WebGL proxying makes pthreads library depend on WebGL.

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -143,7 +143,7 @@ window.scrollX = window.scrollY = 0; // TODO: proxy these
 window.WebGLRenderingContext = WebGLWorker;
 
 window.requestAnimationFrame = (function() {
-  // similar to MainLoop.requestAnimationFrame
+  // similar to SafeTimers.requestAnimationFrame
   var nextRAF = 0;
   return function(func) {
     // try to keep 60fps between calls to here

--- a/src/proxyWorker.js
+++ b/src/proxyWorker.js
@@ -143,7 +143,7 @@ window.scrollX = window.scrollY = 0; // TODO: proxy these
 window.WebGLRenderingContext = WebGLWorker;
 
 window.requestAnimationFrame = (function() {
-  // similar to Browser.requestAnimationFrame
+  // similar to MainLoop.requestAnimationFrame
   var nextRAF = 0;
   return function(func) {
     // try to keep 60fps between calls to here

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4965,14 +4965,14 @@ main(const int argc, const char * const * const argv)
     test(['-O3', '--closure', '1', '-s', 'WASM=0'], 36000)
     test(['-O3', '--closure', '2', '-s', 'WASM=0'], 33000) # might change now and then
 
-  def test_no_browser(self):
-    BROWSER_INIT = 'var Browser'
+  def test_no_mainloop(self):
+    MAINLOOP_INIT = 'var MainLoop'
 
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c')])
-    self.assertNotContained(BROWSER_INIT, open('a.out.js').read())
+    self.assertNotContained(MAINLOOP_INIT, open('a.out.js').read())
 
-    self.run_process([EMCC, path_from_root('tests', 'browser_main_loop.c')]) # uses emscripten_set_main_loop, which needs Browser
-    self.assertContained(BROWSER_INIT, open('a.out.js').read())
+    self.run_process([EMCC, path_from_root('tests', 'browser_main_loop.c')]) # uses emscripten_set_main_loop, which needs MainLoop
+    self.assertContained(MAINLOOP_INIT, open('a.out.js').read())
 
   def test_EXPORTED_RUNTIME_METHODS(self):
     def test(opts, has, not_has):


### PR DESCRIPTION
Fixes #5355

I just noticed that Asyncify mode requires MainLoop, but not because of anything inherent in Asyncify mode, but just because it needs to be aware of it. It would be great if Asyncify could handle MainLoop if it's included, but to not require it. Not too sure how to do that though. Trying a simple `typeof MainLoop !== 'undefined'`

Similarly, `MainLoop.safeSetTimeout` could be split out into an even smaller library, so that if all you use is `emscripten_sleep` it wouldn't have to include all of MainLoop? Edit: This was very easy actually.