### PR TITLE
Add CI testing for -O3 + memory growth + wasm2js

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -382,8 +382,8 @@ jobs:
     executor: bionic
     steps:
       - run-tests:
-          # TODO: test wasms
-          test_targets: "wasm3"
+          # also add a little select testing for wasm2js in -O3
+          test_targets: "wasm3 wasm2js3.test_memorygrowth_2"
   test-wasm2js1:
     executor: bionic
     steps:


### PR DESCRIPTION
That should pass after https://github.com/WebAssembly/binaryen/pull/3113, and prevent regressions there.