### PR TITLE
Remove MAX_GLOBAL_ALIGN and corresponding maxGlobalAlign metadata fie…

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -129,8 +129,6 @@ def update_settings_glue(metadata, DEBUG):
   shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = sorted(set(all_funcs).difference(implemented_funcs))
 
   shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [x[1:] for x in metadata['externs']]
-
-  shared.Settings.MAX_GLOBAL_ALIGN = metadata['maxGlobalAlign']
   shared.Settings.IMPLEMENTED_FUNCTIONS = metadata['implementedFunctions']
 
   if metadata['asmConsts']:
@@ -899,7 +897,6 @@ def load_metadata_wasm(metadata_raw, DEBUG):
     'implementedFunctions': [],
     'externs': [],
     'simd': False, # Obsolete, always False
-    'maxGlobalAlign': 0,
     'staticBump': 0,
     'tableSize': 0,
     'initializers': [],

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -66,9 +66,6 @@ var MAIN_READS_PARAMS = 1;
 // is called DYNAMIC_BASE as it is the start of dynamically-allocated memory.
 var DYNAMIC_BASE = -1;
 
-// Maximum seen global alignment; received from the backend.
-var MAX_GLOBAL_ALIGN = -1;
-
 // List of functions implemented in compiled code; received from the backend.
 var IMPLEMENTED_FUNCTIONS = [];
 

--- a/src/support.js
+++ b/src/support.js
@@ -111,10 +111,6 @@ function getCompilerSetting(name) {
 // Then 'dynamic' memory for sbrk.
 var GLOBAL_BASE = {{{ GLOBAL_BASE }}};
 
-#if RELOCATABLE
-GLOBAL_BASE = alignMemory(GLOBAL_BASE, {{{ MAX_GLOBAL_ALIGN || 1 }}});
-#endif
-
 #if USE_PTHREADS
 // JS library code refers to Atomics in the manner used from asm.js, provide
 // the same API here.

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -119,7 +119,8 @@ def add_dylink_section(wasm_file, needed_dynlibs):
   # a wasm shared library has a special "dylink" section, see tools-conventions repo
   # TODO: use this in the wasm backend
   assert False
-  mem_align = shared.Settings.MAX_GLOBAL_ALIGN
+  # TODO read mem_align from existing "dylink" section.
+  mem_align = 1
   mem_size = shared.Settings.STATIC_BUMP
   table_size = shared.Settings.WASM_TABLE_SIZE
   mem_align = int(math.log(mem_align, 2))


### PR DESCRIPTION
…ld.  NFC

The `maxGlobalAlign` metadata field as never been produced
by wasm-emscripten-finalize which means the default value
of `0` has always been assigned to MAX_GLOBAL_ALIGN under
the wasm backend.