### PR TITLE
Remove hard dependency on Browser from Asyncify

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -20,7 +20,7 @@ mergeInto(LibraryManager.library, {
   },
 
 #if ASYNCIFY
-  $Asyncify__deps: ['$Browser', '$runAndAbortIfError'],
+  $Asyncify__deps: ['$runAndAbortIfError'],
   $Asyncify: {
     State: {
       Normal: 0,
@@ -213,7 +213,7 @@ mergeInto(LibraryManager.library, {
 #endif
           Asyncify.state = Asyncify.State.Rewinding;
           runAndAbortIfError(function() { Module['_asyncify_start_rewind'](Asyncify.currData) });
-          if (Browser.mainLoop.func) {
+          if (typeof Browser !== 'undefined' && Browser.mainLoop.func) {
             Browser.mainLoop.resume();
           }
           var start = Asyncify.getDataRewindFunc(Asyncify.currData);
@@ -251,7 +251,7 @@ mergeInto(LibraryManager.library, {
           err('ASYNCIFY: start unwind ' + Asyncify.currData);
 #endif
           runAndAbortIfError(function() { Module['_asyncify_start_unwind'](Asyncify.currData) });
-          if (Browser.mainLoop.func) {
+          if (typeof Browser !== 'undefined' && Browser.mainLoop.func) {
             Browser.mainLoop.pause();
           }
         }
@@ -287,6 +287,7 @@ mergeInto(LibraryManager.library, {
     },
   },
 
+  emscripten_sleep__deps: ['$Browser'],
   emscripten_sleep: function(ms) {
     Asyncify.handleSleep(function(wakeUp) {
       Browser.safeSetTimeout(wakeUp, ms);
@@ -316,6 +317,7 @@ mergeInto(LibraryManager.library, {
     });
   },
 
+  emscripten_wget_data__deps: ['$Browser'],
   emscripten_wget_data: function(url, pbuffer, pnum, perror) {
     Asyncify.handleSleep(function(wakeUp) {
       Browser.asyncLoad(UTF8ToString(url), function(byteArray) {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -294,7 +294,7 @@ mergeInto(LibraryManager.library, {
     });
   },
 
-  emscripten_wget__deps: ['$PATH_FS', '$FS'],
+  emscripten_wget__deps: ['$Browser', '$PATH_FS', '$FS'],
   emscripten_wget: function(url, file) {
     Asyncify.handleSleep(function(wakeUp) {
       var _url = UTF8ToString(url);


### PR DESCRIPTION
Split out from #12165 

Remove the hard dependency on Browser from Asyncify. Could save 13KB from a minified build.