### PR TITLE
Remove post-link memory size check based on dynamic_base

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -226,9 +226,6 @@ class Memory():
     #  * then dynamic memory begins
     self.dynamic_base = align_memory(self.stack_high)
 
-    if self.dynamic_base >= shared.Settings.INITIAL_MEMORY:
-     exit_with_error('Memory is not large enough for static data (%d) plus the stack (%d), please increase INITIAL_MEMORY (%d) to at least %d' % (self.static_bump, shared.Settings.TOTAL_STACK, shared.Settings.INITIAL_MEMORY, self.dynamic_base))
-
 
 def apply_memory(js, metadata):
   # Apply the statically-at-compile-time computed memory locations.


### PR DESCRIPTION
Now that the memory layout is determined statically by wasm-ld
it is no longer possible to get this error message since the
wasm-ld itself will already have failed with:

  `wasm-ld: error: initial memory too small`

See `other.test_clear_error_on_massive_static_data` which was
the only test we had for this error message and it got removed
with #11911.

This is part of an effort to completely remove DYNAMIC_BASE.