### PR TITLE
Remove DYNAMIC_BASE setting and JavaScript global

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2651,7 +2651,7 @@ def do_binaryen(target, options, memfile, wasm_target,
   #   webassembly.add_dylink_section(wasm_target, shared.Settings.RUNTIME_LINKED_LIBS)
 
   if shared.Settings.EMIT_EMSCRIPTEN_METADATA:
-    webassembly.add_emscripten_metadata(final_js, wasm_target)
+    webassembly.add_emscripten_metadata(wasm_target)
 
   if final_js:
     # pthreads memory growth requires some additional JS fixups

--- a/emscripten.py
+++ b/emscripten.py
@@ -224,11 +224,12 @@ def apply_memory(js, metadata):
   # Write it all out
   js = js.replace('{{{ STACK_BASE }}}', str(memory.stack_base))
   js = js.replace('{{{ STACK_MAX }}}', str(memory.stack_max))
-  js = js.replace('{{{ DYNAMIC_BASE }}}', str(memory.dynamic_base))
+  if shared.Settings.RELOCATABLE:
+    js = js.replace('{{{ HEAP_BASE }}}', str(memory.dynamic_base))
 
   logger.debug('global_base: %d stack_base: %d, stack_max: %d, dynamic_base: %d, static bump: %d', memory.global_base, memory.stack_base, memory.stack_max, memory.dynamic_base, memory.static_bump)
 
-  shared.Settings.DYNAMIC_BASE = memory.dynamic_base
+  shared.Settings.LEGACY_DYNAMIC_BASE = memory.dynamic_base
 
   return js
 

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -409,9 +409,6 @@ var LibraryPThread = {
 #if USE_OFFSET_CONVERTER
         'wasmOffsetConverter': wasmOffsetConverter,
 #endif
-#if !MINIMAL_RUNTIME
-        'DYNAMIC_BASE': DYNAMIC_BASE
-#endif
       });
     },
 

--- a/src/library_trace.js
+++ b/src/library_trace.js
@@ -266,9 +266,6 @@ var LibraryTracing = {
         'stack_base':   STACK_BASE,
         'stack_top':    STACKTOP,
         'stack_max':    STACK_MAX,
-#if !MINIMAL_RUNTIME
-        'dynamic_base': DYNAMIC_BASE,
-#endif
         'dynamic_top':  _sbrk(),
         'total_memory': HEAP8.length
       };

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -347,12 +347,10 @@ function updateGlobalBufferAndViews(buf) {
 
 var STACK_BASE = {{{ getQuoted('STACK_BASE') }}},
     STACKTOP = STACK_BASE,
-    STACK_MAX = {{{ getQuoted('STACK_MAX') }}},
-    DYNAMIC_BASE = {{{ getQuoted('DYNAMIC_BASE') }}};
+    STACK_MAX = {{{ getQuoted('STACK_MAX') }}};
 
 #if ASSERTIONS
 assert(STACK_BASE % 16 === 0, 'stack must start aligned');
-assert(DYNAMIC_BASE % 16 === 0, 'heap must start aligned');
 #endif
 
 #if RELOCATABLE
@@ -361,7 +359,7 @@ assert(DYNAMIC_BASE % 16 === 0, 'heap must start aligned');
 // initialize sbrk (the main module is relocatable itself, and so it does not
 // have __heap_base hardcoded into it - it receives it from JS as an extern
 // global, basically).
-Module['___heap_base'] = DYNAMIC_BASE;
+Module['___heap_base'] = {{{ getQuoted('HEAP_BASE') }}};
 #endif // RELOCATABLE
 
 #if USE_PTHREADS
@@ -373,7 +371,6 @@ if (ENVIRONMENT_IS_PTHREAD) {
 #if ASSERTIONS || STACK_OVERFLOW_CHECK >= 2
   STACK_MAX = STACKTOP = STACK_MAX = 0x7FFFFFFF;
 #endif
-  // TODO DYNAMIC_BASE = Module['DYNAMIC_BASE'];
 }
 #endif
 

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -99,7 +99,6 @@ var WASM_PAGE_SIZE = {{{ WASM_PAGE_SIZE }}};
 if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
 assert(STACK_BASE % 16 === 0, 'stack must start aligned to 16 bytes, STACK_BASE==' + STACK_BASE);
-assert(({{{ getQuoted('DYNAMIC_BASE') }}}) % 16 === 0, 'heap must start aligned to 16 bytes, DYNAMIC_BASE==' + {{{ getQuoted('DYNAMIC_BASE') }}});
 assert({{{ INITIAL_MEMORY }}} >= TOTAL_STACK, 'INITIAL_MEMORY should be larger than TOTAL_STACK, was ' + {{{ INITIAL_MEMORY }}} + '! (TOTAL_STACK=' + TOTAL_STACK + ')');
 assert({{{ INITIAL_MEMORY }}} % WASM_PAGE_SIZE === 0);
 #if MAXIMUM_MEMORY != -1

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -62,9 +62,12 @@ var EMBIND = 0;
 // Whether the main() function reads the argc/argv parameters.
 var MAIN_READS_PARAMS = 1;
 
-// The computed initial value of the program break (the sbrk position), which
-// is called DYNAMIC_BASE as it is the start of dynamically-allocated memory.
-var DYNAMIC_BASE = -1;
+// Computed during emscripten for the purpose of writing to emscripten_metadata
+// section.
+// TODO(sbc): Remove this.  If emscripten doesn't need it then neither should
+// any other loader.
+// See https://github.com/emscripten-core/emscripten/issues/12231
+var LEGACY_DYNAMIC_BASE = -1;
 
 // List of functions implemented in compiled code; received from the backend.
 var IMPLEMENTED_FUNCTIONS = [];

--- a/src/shell_pthreads.js
+++ b/src/shell_pthreads.js
@@ -14,7 +14,6 @@ var ENVIRONMENT_IS_PTHREAD = Module['ENVIRONMENT_IS_PTHREAD'] || false;
 if (ENVIRONMENT_IS_PTHREAD) {
   // Grab imports from the pthread to local scope.
   buffer = Module['buffer'];
-  DYNAMIC_BASE = Module['DYNAMIC_BASE'];
   // Note that not all runtime fields are imported above. Values for STACK_BASE, STACKTOP and STACK_MAX are not yet known at worker.js load time.
   // These will be filled in at pthread startup time (the 'run' message for a pthread - pthread start establishes the stack frame)
 }

--- a/src/worker.js
+++ b/src/worker.js
@@ -72,11 +72,6 @@ this.onmessage = function(e) {
       var imports = {};
 #endif
 
-      // Initialize the global "process"-wide fields:
-#if !MINIMAL_RUNTIME
-      Module['DYNAMIC_BASE'] = e.data.DYNAMIC_BASE;
-#endif
-
       // Module and memory were sent from main thread
 #if MINIMAL_RUNTIME
 #if MODULARIZE

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -6,7 +6,6 @@
 """Utilties for manipulating WebAssembly binaries from python.
 """
 
-import re
 import math
 import logging
 
@@ -59,16 +58,13 @@ def readLEB(buf, offset):
   return (result, offset)
 
 
-def add_emscripten_metadata(js_file, wasm_file):
+def add_emscripten_metadata(wasm_file):
   WASM_PAGE_SIZE = 65536
 
   mem_size = shared.Settings.INITIAL_MEMORY // WASM_PAGE_SIZE
   table_size = shared.Settings.WASM_TABLE_SIZE
   global_base = shared.Settings.GLOBAL_BASE
-
-  js = open(js_file).read()
-  m = re.search(r"(^|\s)DYNAMIC_BASE\s+=\s+(\d+)", js)
-  dynamic_base = int(m.group(2))
+  dynamic_base = shared.Settings.LEGACY_DYNAMIC_BASE
 
   logger.debug('creating wasm emscripten metadata section with mem size %d, table size %d' % (mem_size, table_size,))
   name = b'\x13emscripten_metadata' # section name, including prefixed size


### PR DESCRIPTION
Users who really need to access this can export `__heap_base`
if they wish but normally this is not a detail that we export.