### PR TITLE
Remove memory/table information from emscripten_metadata

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -229,8 +229,6 @@ def apply_memory(js, metadata):
 
   logger.debug('global_base: %d stack_base: %d, stack_max: %d, dynamic_base: %d, static bump: %d', memory.global_base, memory.stack_base, memory.stack_max, memory.dynamic_base, memory.static_bump)
 
-  shared.Settings.LEGACY_DYNAMIC_BASE = memory.dynamic_base
-
   return js
 
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -62,13 +62,6 @@ var EMBIND = 0;
 // Whether the main() function reads the argc/argv parameters.
 var MAIN_READS_PARAMS = 1;
 
-// Computed during emscripten for the purpose of writing to emscripten_metadata
-// section.
-// TODO(sbc): Remove this.  If emscripten doesn't need it then neither should
-// any other loader.
-// See https://github.com/emscripten-core/emscripten/issues/12231
-var LEGACY_DYNAMIC_BASE = -1;
-
 // List of functions implemented in compiled code; received from the backend.
 var IMPLEMENTED_FUNCTIONS = [];
 

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -18,7 +18,7 @@ logger = logging.getLogger('shared')
 # NB: major version 0 implies no compatibility
 # NB: when changing the metadata format, we should only append new fields, not
 #     reorder, modify, or remove existing ones.
-EMSCRIPTEN_METADATA_MAJOR, EMSCRIPTEN_METADATA_MINOR = (0, 3)
+EMSCRIPTEN_METADATA_MAJOR, EMSCRIPTEN_METADATA_MINOR = (1, 0)
 # For the JS/WASM ABI, specifies the minimum ABI version required of
 # the WASM runtime implementation by the generated WASM binary. It follows
 # semver and changes whenever C types change size/signedness or
@@ -59,14 +59,7 @@ def readLEB(buf, offset):
 
 
 def add_emscripten_metadata(wasm_file):
-  WASM_PAGE_SIZE = 65536
-
-  mem_size = shared.Settings.INITIAL_MEMORY // WASM_PAGE_SIZE
-  table_size = shared.Settings.WASM_TABLE_SIZE
-  global_base = shared.Settings.GLOBAL_BASE
-  dynamic_base = shared.Settings.LEGACY_DYNAMIC_BASE
-
-  logger.debug('creating wasm emscripten metadata section with mem size %d, table size %d' % (mem_size, table_size,))
+  logger.debug('creating wasm emscripten metadata section')
   name = b'\x13emscripten_metadata' # section name, including prefixed size
   contents = (
     # metadata section version
@@ -78,19 +71,6 @@ def add_emscripten_metadata(wasm_file):
     # Minimum ABI version
     toLEB(EMSCRIPTEN_ABI_MAJOR) +
     toLEB(EMSCRIPTEN_ABI_MINOR) +
-
-    # Wasm backend, always 1 now
-    toLEB(1) +
-
-    toLEB(mem_size) +
-    toLEB(table_size) +
-    toLEB(global_base) +
-    toLEB(dynamic_base) +
-    # dynamictopPtr, always 0 now
-    toLEB(0) +
-
-    # tempDoublePtr, always 0 in wasm backend
-    toLEB(0) +
 
     toLEB(int(shared.Settings.STANDALONE_WASM))
 


### PR DESCRIPTION
We are moving away from the world where the memory layout is
determined by the python driver code and towards a world where
the wasm-ld decides the final layout.

For relocatable module (SIDE_MODULE and MAIN_MODULE) the size
and alignment of memory and table segments is already encoded
in the `dylink` sections.

For non-relocatable modules I don't think this information is
needed by the embedder anymore.

Symbols like `__global_base` or `__data_end` and `__heap_base` are
details we don't export by default but can be explicitly exported if needed.

This is part of an effort to completely remove DYNAMIC_BASE.