### PR TITLE
Start removing some of the old v1 FS functions

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1532,12 +1532,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # separately, and they need emcc's output to contain the support they need)
       if not shared.Settings.ASMFS:
         shared.Settings.EXPORTED_RUNTIME_METHODS += [
-          'FS_createFolder',
           'FS_createPath',
           'FS_createDataFile',
           'FS_createPreloadedFile',
           'FS_createLazyFile',
-          'FS_createLink',
           'FS_createDevice',
           'FS_unlink'
         ]

--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -634,7 +634,7 @@ File system API
     FS.createLazyFile('/', 'bar', '/get_file.php?name=baz', true, true);
 
 
-  :param parent: The parent folder, either as a path (e.g. `'/usr/lib'`) or an object previously returned from a `FS.createFolder()` or `FS.createPath()` call.
+  :param parent: The parent folder, either as a path (e.g. `'/usr/lib'`) or an object previously returned from a `FS.mkdir()` or `FS.createPath()` call.
   :type parent: string/object
   :param string name: The name of the new file.
   :param string url: In the browser, this is the URL whose contents will be returned when this file is accessed. In a command line engine like *node.js*, this will be the local (real) file system path from where the contents will be loaded. Note that writes to this file are virtual.
@@ -648,7 +648,7 @@ File system API
 
   Preloads a file asynchronously, and uses preload plugins to prepare its content. You should call this in ``preRun``, ``run()`` will be delayed until all preloaded files are ready. This is how the :ref:`preload-file <emcc-preload-file>` option works in *emcc* when ``--use-preload-plugins`` has been specified (if you use this method by itself, you will need to build the program with that option).
 
-  :param parent: The parent folder, either as a path (e.g. **'/usr/lib'**) or an object previously returned from a `FS.createFolder()` or `FS.createPath()` call.
+  :param parent: The parent folder, either as a path (e.g. **'/usr/lib'**) or an object previously returned from a `FS.mkdir()` or `FS.createPath()` call.
   :type parent: string/object
   :param string name: The name of the new file.
   :param string url: In the browser, this is the URL whose contents will be returned when the file is accessed. In a command line engine, this will be the local (real) file system path the contents will be loaded from. Note that writes to this file are virtual.

--- a/site/source/docs/api_reference/advanced-apis.rst
+++ b/site/source/docs/api_reference/advanced-apis.rst
@@ -90,16 +90,11 @@ Advanced File System API
 
 
 .. js:function:: FS.getMode(canRead, canWrite)
-  FS.joinPath(parts, forceRelative)
-  FS.absolutePath(relative, base)
-  FS.standardizePath(path)
   FS.findObject(path, dontResolveLastLink)
-  FS.createFolder(parent, name, canRead, canWrite)
   FS.createPath(parent, path, canRead, canWrite)
   FS.createFile(parent, name, properties, canRead, canWrite)
   FS.createDataFile(parent, name, data, canRead, canWrite, canOwn)
   FS.createDevice(parent, name, input, output)
-  FS.createLink(parent, name, target, canRead, canWrite)
   FS.forceLoadFile(obj)
 
   Legacy v1 compatibility functions.

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1979,22 +1979,22 @@ FS.staticInit();` +
     // Removed v1 functions
 #if ASSERTIONS
     absolutePath: function() {
-      abort('FS.absolutePath has been removed');
+      abort('FS.absolutePath has been removed; use PATH_FS.resolve instead');
     },
     createFolder: function() {
-      abort('FS.createFolder has been removed');
+      abort('FS.createFolder has been removed; use FS.mkdir instead');
     },
     createLink: function() {
-      abort('FS.createLink has been removed');
+      abort('FS.createLink has been removed; use FS.symlink instead');
     },
     joinPath: function() {
-      abort('FS.joinPath has been removed');
+      abort('FS.joinPath has been removed; use PATH.join instead');
     },
     mmapAlloc: function() {
       abort('FS.mmapAlloc has been replaced by the top level function mmapAlloc');
     },
     standardizePath: function() {
-      abort('FS.standardizePath has been removed');
+      abort('FS.standardizePath has been removed; use PATH.normalize instead');
     },
 #endif
   },

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1516,17 +1516,6 @@ FS.staticInit();` +
       if (canWrite) mode |= {{{ cDefine('S_IWUGO') }}};
       return mode;
     },
-    joinPath: function(parts, forceRelative) {
-      var path = PATH.join.apply(null, parts);
-      if (forceRelative && path[0] == '/') path = path.substr(1);
-      return path;
-    },
-    absolutePath: function(relative, base) {
-      return PATH_FS.resolve(base, relative);
-    },
-    standardizePath: function(path) {
-      return PATH.normalize(path);
-    },
     findObject: function(path, dontResolveLastLink) {
       var ret = FS.analyzePath(path, dontResolveLastLink);
       if (ret.exists) {
@@ -1563,11 +1552,6 @@ FS.staticInit();` +
         ret.error = e.errno;
       };
       return ret;
-    },
-    createFolder: function(parent, name, canRead, canWrite) {
-      var path = PATH.join2(typeof parent === 'string' ? parent : FS.getPath(parent), name);
-      var mode = FS.getMode(canRead, canWrite);
-      return FS.mkdir(path, mode);
     },
     createPath: function(parent, path, canRead, canWrite) {
       parent = typeof parent === 'string' ? parent : FS.getPath(parent);
@@ -1662,10 +1646,6 @@ FS.staticInit();` +
         }
       });
       return FS.mkdev(path, mode, dev);
-    },
-    createLink: function(parent, name, target, canRead, canWrite) {
-      var path = PATH.join2(typeof parent === 'string' ? parent : FS.getPath(parent), name);
-      return FS.symlink(target, path);
     },
     // Makes sure a file's contents are loaded. Returns whether the file has
     // been loaded successfully. No-op for files that have been loaded already.
@@ -1996,15 +1976,37 @@ FS.staticInit();` +
       openRequest.onerror = onerror;
     },
 
-    // Allocate memory for an mmap operation. This allocates space of the right
-    // page-aligned size, and clears the padding.
-    mmapAlloc: function(size) {
-      var alignedSize = alignMemory(size, {{{ POSIX_PAGE_SIZE }}});
-      var ptr = {{{ makeMalloc('mmapAlloc', 'alignedSize') }}};
-      while (size < alignedSize) HEAP8[ptr + size++] = 0;
-      return ptr;
-    }
-  }
+    // Removed v1 functions
+#if ASSERTIONS
+    absolutePath: function() {
+      abort('FS.absolutePath has been removed');
+    },
+    createFolder: function() {
+      abort('FS.createFolder has been removed');
+    },
+    createLink: function() {
+      abort('FS.createLink has been removed');
+    },
+    joinPath: function() {
+      abort('FS.joinPath has been removed');
+    },
+    mmapAlloc: function() {
+      abort('FS.mmapAlloc has been replaced by the top level function mmapAlloc');
+    },
+    standardizePath: function() {
+      abort('FS.standardizePath has been removed');
+    },
+#endif
+  },
+
+  // Allocate memory for an mmap operation. This allocates space of the right
+  // page-aligned size, and clears the padding.
+  $mmapAlloc: function(size) {
+    var alignedSize = alignMemory(size, {{{ POSIX_PAGE_SIZE }}});
+    var ptr = {{{ makeMalloc('mmapAlloc', 'alignedSize') }}};
+    while (size < alignedSize) HEAP8[ptr + size++] = 0;
+    return ptr;
+  },
 });
 
 if (FORCE_FILESYSTEM) {

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -5,7 +5,7 @@
  */
 
 mergeInto(LibraryManager.library, {
-  $MEMFS__deps: ['$FS'],
+  $MEMFS__deps: ['$FS', '$mmapAlloc'],
   $MEMFS: {
     ops_table: null,
     mount: function(mount) {
@@ -373,7 +373,7 @@ mergeInto(LibraryManager.library, {
             }
           }
           allocated = true;
-          ptr = FS.mmapAlloc(length);
+          ptr = mmapAlloc(length);
           if (!ptr) {
             throw new FS.ErrnoError({{{ cDefine('ENOMEM') }}});
           }

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -5,7 +5,7 @@
  */
 
 mergeInto(LibraryManager.library, {
-  $NODEFS__deps: ['$FS', '$PATH', '$ERRNO_CODES'],
+  $NODEFS__deps: ['$FS', '$PATH', '$ERRNO_CODES', '$mmapAlloc'],
   $NODEFS__postset: 'if (ENVIRONMENT_IS_NODE) { var fs = require("fs"); var NODEJS_PATH = require("path"); NODEFS.staticInit(); }',
   $NODEFS: {
     isWindows: false,
@@ -302,7 +302,7 @@ mergeInto(LibraryManager.library, {
           throw new FS.ErrnoError({{{ cDefine('ENODEV') }}});
         }
 
-        var ptr = FS.mmapAlloc(length);
+        var ptr = mmapAlloc(length);
 
         NODEFS.stream_ops.read(stream, HEAP8, ptr, length, position);
         return { ptr: ptr, allocated: true };

--- a/src/modules.js
+++ b/src/modules.js
@@ -336,12 +336,10 @@ function isFSPrefixed(name) {
 
 // forcing the filesystem exports a few things by default
 function isExportedByForceFilesystem(name) {
-  return name === 'FS_createFolder' ||
-         name === 'FS_createPath' ||
+  return name === 'FS_createPath' ||
          name === 'FS_createDataFile' ||
          name === 'FS_createPreloadedFile' ||
          name === 'FS_createLazyFile' ||
-         name === 'FS_createLink' ||
          name === 'FS_createDevice' ||
          name === 'FS_unlink' ||
          name === 'addRunDependency' ||


### PR DESCRIPTION
Started working on #12185 

I removed the functions that weren't being used anywhere else (leaving abort calls in ASSERTIONS), and also turned one function that was being used elsewhere, `mmapAlloc`, into a top level function. Does that seem like a good strategy for the other functions which are more commonly used in the code? And are functions like `createPreloadedFile` actually old?