### PR TITLE
Pass blindly all -mllvm options to the compiler.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -506,3 +506,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Prashanth Nethi <prashant@adobe.com>
 * Max Weisel <max@maxweisel.com>
 * Georg Rottensteiner <georg@georg-rottensteiner.de>
+* Julien Jorge <julien.jorge@gmx.fr>

--- a/emcc.py
+++ b/emcc.py
@@ -394,18 +394,35 @@ def find_output_arg(args):
   """
   outargs = []
   specified_target = None
-  use_next = False
-  for arg in args:
-    if use_next:
-      specified_target = arg
-      use_next = False
-      continue
+
+  arg_count = len(args)
+  i = 0
+
+  while i < arg_count:
+    arg = args[i]
+
     if arg == '-o':
-      use_next = True
-    elif arg.startswith('-o'):
+      if i != arg_count - 1:
+        specified_target = args[i + 1]
+      i += 2
+      continue
+
+    if arg.startswith('-o'):
       specified_target = arg[2:]
+      i += 1
+      continue
+
+    outargs.append(arg)
+
+    if arg == '-mllvm' and i != arg_count - 1:
+      # Explicitly skip over -mllvm arguments and their values because their
+      # values could potentially start with -o and be confused for output file
+      # specifiers.
+      outargs.append(arg[i + 1])
+      i += 2
     else:
-      outargs.append(arg)
+      i += 1
+
   return specified_target, outargs
 
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9700,3 +9700,9 @@ int main () {
   def test_emmaken_compiler(self):
     stderr = self.run_process([EMCC, '-c', path_from_root('tests', 'core', 'test_hello_world.c')], stderr=PIPE).stderr
     self.assertContained('warning: EMMAKEN_COMPILER is deprecated', stderr)
+
+  def test_llvm_option_dash_o(self):
+    # emcc used to interpret -mllvm's option value as the output file if it began with -o
+    self.run_process([EMCC, '-o', 'llvm_option_dash_o_output', '-mllvm', '-opt-bisect-limit=1', path_from_root('tests', 'hello_world.c')])
+    self.assertExists('llvm_option_dash_o_output')
+    self.assertNotExists('pt-bisect-limit=1')


### PR DESCRIPTION
Use case: given an hypothetical clang-like compiler `custom-clang` accepting an option `-order-pizza`, the following command

```
EMMAKEN_COMPILER=custom-clang emcc test.c -o test -mllvm -order-pizza
```

Will produce an output file named `rder-pizza` instead of `test`. This is because `find_output_arg(args)` does not skip `-mllvm` options.

This PR fixes this issue.