### PR TITLE
Deprecate EMMAKEN_COMPILER environment variable

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -603,8 +603,6 @@ Environment variables
 
    * "EMMAKEN_JUST_CONFIGURE"
 
-   * "EMMAKEN_COMPILER"
-
    * "EMMAKEN_CFLAGS"
 
    * "EMCC_DEBUG"

--- a/emcc.py
+++ b/emcc.py
@@ -21,8 +21,6 @@ emcc can be influenced by a few environment variables:
 
   EMMAKEN_NO_SDK - Will tell emcc *not* to use the emscripten headers. Instead
                    your system headers will be used.
-
-  EMMAKEN_COMPILER - The compiler to be used, if you don't want the default clang.
 """
 
 from __future__ import print_function
@@ -771,9 +769,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       arg = args[i][2:]
     return arg.split('=')[0].isupper()
 
-  CXX = os.environ.get('EMMAKEN_COMPILER', shared.CLANG_CXX)
-  CC = cxx_to_c_compiler(CXX)
-
   EMMAKEN_CFLAGS = os.environ.get('EMMAKEN_CFLAGS')
   if EMMAKEN_CFLAGS:
     args += shlex.split(EMMAKEN_CFLAGS)
@@ -835,6 +830,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         newargs[i + 1] = ''
 
     options, settings_changes, user_js_defines, newargs = parse_args(newargs)
+
+    CXX = shared.CLANG_CXX
+    CC = shared.CLANG_CC
+    if 'EMMAKEN_COMPILER' in os.environ:
+      diagnostics.warning('deprecated', 'EMMAKEN_COMPILER is deprecated.  Please set LLVM_ROOT in config file or EM_LLVM_ROOT in the environment')
+      CXX = os.environ['EMMAKEN_COMPILER']
+      CC = cxx_to_c_compiler(CXX)
 
     if '-print-search-dirs' in newargs:
       return run_process([CC, '-print-search-dirs'], check=False).returncode

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -465,7 +465,6 @@ Environment variables
 *emcc* is affected by several environment variables, as listed below:
 
   - ``EMMAKEN_JUST_CONFIGURE``
-  - ``EMMAKEN_COMPILER``
   - ``EMMAKEN_CFLAGS``
   - ``EMCC_DEBUG``
   - ``EMCC_CLOSURE_ARGS`` : arguments to be passed to *Closure Compiler*

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9678,3 +9678,8 @@ int main () {
 
   def test_getrusage(self):
     self.do_runf(path_from_root('tests', 'other', 'test_getrusage.c'))
+
+  @with_env_modify({'EMMAKEN_COMPILER': shared.CLANG_CC})
+  def test_emmaken_compiler(self):
+    stderr = self.run_process([EMCC, '-c', path_from_root('tests', 'core', 'test_hello_world.c')], stderr=PIPE).stderr
+    self.assertContained('warning: EMMAKEN_COMPILER is deprecated', stderr)


### PR DESCRIPTION
For users that want to override the LLVM/clang version used by
emscripten we already have the `LLVM_ROOT` config setting and
the corresponding `EM_LLVM_ROOT` environment variable.