### PR TITLE
Fix reverse dependency between getrusage and memset

### DIFF
--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -94,7 +94,7 @@
   "_embind_register_std_wstring": ["malloc", "free"],
   "pthread_create": ["malloc", "free", "emscripten_main_thread_process_queued_calls"],
   "$getTypeName": ["free"],
-  "__sys_getrusage": ["memset"],
+  "getrusage": ["memset"],
   "_embind_register_std_string": ["free"],
   "_embind_register_std_wstring": ["free"],
   "_embind_register_function": ["free"],

--- a/tests/other/test_getrusage.c
+++ b/tests/other/test_getrusage.c
@@ -1,0 +1,8 @@
+#include <sys/time.h>
+#include <sys/resource.h>
+
+int main() {
+  struct rusage u;
+  getrusage(0, &u);
+  return 0;
+}

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1054,7 +1054,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         f.write(src)
     self._build_and_run(filename, expected_output, **kwargs)
 
-  def do_runf(self, filename, expected_output, **kwargs):
+  def do_runf(self, filename, expected_output=None, **kwargs):
     self._build_and_run(filename, expected_output, **kwargs)
 
   ## Just like `do_run` but with filename of expected output

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9655,3 +9655,6 @@ int main () {
     # point.
     # We should consider making this a warning since the `_main` export is redundant.
     self.run_process([EMCC, '-sEXPORTED_FUNCTIONS=[_main]', '-sSTANDALONE_WASM', '-c', path_from_root('tests', 'core', 'test_hello_world.c')])
+
+  def test_getrusage(self):
+    self.do_runf(path_from_root('tests', 'other', 'test_getrusage.c'))


### PR DESCRIPTION
The dependencies in `src/deps_info.json` only apply to symbols
that exist in user object code.  Since __sys_getrusage is a symbol
that is only references by the libc system library is never
considered "used" by the system that processes these dependencies
since this process necessarily happens *before* the linker runs.

Fixes: #12204