### PR TITLE
Fix pthread_cleanup_push stub function

### DIFF
--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -71,10 +71,9 @@ var LibraryPThreadStub = {
   pthread_setcancelstate: function() { return 0; },
   pthread_setcanceltype: function() { return 0; },
 
-  pthread_cleanup_push__deps: ['$makeDynCaller'],
   pthread_cleanup_push__sig: 'vii',
   pthread_cleanup_push: function(routine, arg) {
-    __ATEXIT__.push(function() { {{{ makeDynCall('vi', 'routine') }}}(arg) })
+    __ATEXIT__.push({ func: routine, arg: arg });
     _pthread_cleanup_push.level = __ATEXIT__.length;
   },
 
@@ -83,12 +82,6 @@ var LibraryPThreadStub = {
     __ATEXIT__.pop();
     _pthread_cleanup_push.level = __ATEXIT__.length;
   },
-
-  _pthread_cleanup_push__sig: 'vii',
-  _pthread_cleanup_push: 'pthread_cleanup_push',
-
-  _pthread_cleanup_pop__sig: 'v',
-  _pthread_cleanup_pop: 'pthread_cleanup_pop',
 
   // pthread_sigmask - examine and change mask of blocked signals
   pthread_sigmask: function(how, set, oldset) {

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -77,9 +77,13 @@ var LibraryPThreadStub = {
     _pthread_cleanup_push.level = __ATEXIT__.length;
   },
 
-  pthread_cleanup_pop: function() {
+  pthread_cleanup_pop__sig: 'vi',
+  pthread_cleanup_pop: function(execute) {
     assert(_pthread_cleanup_push.level == __ATEXIT__.length, 'cannot pop if something else added meanwhile!');
-    __ATEXIT__.pop();
+    callback = __ATEXIT__.pop();
+    if (execute) {
+      {{{ makeDynCall('vi', 'callback.func') }}}(callback.arg)
+    }
     _pthread_cleanup_push.level = __ATEXIT__.length;
   },
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9277,18 +9277,26 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     self.assertContained('Archive map', output)
 
   def test_pthread_stub(self):
-    # Verify that programs containing pthread code can still be compiled even
+    # Verify that programs containing pthread code can still work even
     # without enabling threads.  This is possible becase we link in
     # libpthread_stub.a
-    create_test_file('pthread.c', '''
+    create_test_file('pthread.c', r'''
+#include <stdint.h>
+#include <stdio.h>
 #include <pthread.h>
+
+static void cleanup (void* arg) {
+  printf("cleanup: %ld\n", (intptr_t)arg);
+}
 
 int main() {
   pthread_atfork(NULL, NULL, NULL);
+  pthread_cleanup_push(cleanup, (void*)42);
+  pthread_cleanup_pop(1);
   return 0;
 }
 ''')
-    self.run_process([EMCC, 'pthread.c'])
+    self.do_runf('pthread.c', 'cleanup: 42')
 
   def test_stdin_preprocess(self):
     create_test_file('temp.h', '#include <string>')


### PR DESCRIPTION
A typo was introduced to the dependencies of pthread_cleanup_push
in #1205.  However, we can do better by simply avoiding the dynCall
here.

Fixes: https://github.com/emscripten-core/emsdk/issues/614