### PR TITLE
Add missing `-fPIC` to dylink test

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4480,8 +4480,8 @@ res64 - external 64\n''', header='''
     create_test_file('third.cpp', 'extern "C" int sidef() { return 36; }')
     create_test_file('fourth.cpp', 'extern "C" int sideg() { return 17; }')
 
-    self.run_process([EMCC, '-c', 'third.cpp', '-o', 'third.o'] + self.get_emcc_args())
-    self.run_process([EMCC, '-c', 'fourth.cpp', '-o', 'fourth.o'] + self.get_emcc_args())
+    self.run_process([EMCC, '-fPIC', '-c', 'third.cpp', '-o', 'third.o'] + self.get_emcc_args())
+    self.run_process([EMCC, '-fPIC', '-c', 'fourth.cpp', '-o', 'fourth.o'] + self.get_emcc_args())
     self.run_process([EMAR, 'rc', 'libfourth.a', 'fourth.o'])
 
     self.dylink_test(main=r'''


### PR DESCRIPTION
This should always have been here but was previously not a 
fatal problem because the code in these object files happens
to not generate any non-PIC-compatible relocations.

However, since https://reviews.llvm.org/D87537 landed in llvm
all `-pie/-shared` linked binaries now require the mutable-globals
feature in at least one object otherwise the link will fail with

`wasm-ld: error: mutable global imported but 'mutable-globals' feature
not present in inputs: '__stack_pointer'. Use --no-check-features to
suppress.`

Passing `-fPIC` when compiling shared library code not only
produces compatible relocations but now also injects this feature
into the features section.