### PR TITLE
Fix out of bound access when skipping over -mllvm args in find_output_arg()

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -418,7 +418,7 @@ def find_output_arg(args):
       # Explicitly skip over -mllvm arguments and their values because their
       # values could potentially start with -o and be confused for output file
       # specifiers.
-      outargs.append(arg[i + 1])
+      outargs.append(args[i + 1])
       i += 2
     else:
       i += 1

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9707,7 +9707,21 @@ int main () {
     self.assertContained('warning: EMMAKEN_COMPILER is deprecated', stderr)
 
   def test_llvm_option_dash_o(self):
-    # emcc used to interpret -mllvm's option value as the output file if it began with -o
-    self.run_process([EMCC, '-o', 'llvm_option_dash_o_output', '-mllvm', '-opt-bisect-limit=1', path_from_root('tests', 'hello_world.c')])
+    # emcc used to interpret -mllvm's option value as the output file if it
+    # began with -o
+    stderr = self.run_process(
+      [EMCC, '-v', '-o', 'llvm_option_dash_o_output', '-mllvm',
+       '-opt-bisect-limit=1', path_from_root('tests', 'hello_world.c')],
+      stderr=PIPE).stderr
+
     self.assertExists('llvm_option_dash_o_output')
     self.assertNotExists('pt-bisect-limit=1')
+    self.assertContained(' -mllvm -opt-bisect-limit=1 ', stderr)
+
+    # Regression test for #12236: the '-mllvm' argument was indexed instead of
+    # its value, and the index was out of bounds if the argument was sixth or
+    # further on the command line
+    self.run_process(
+      [EMCC, '-DFOO', '-DBAR', '-DFOOBAR', '-DBARFOO',
+       '-o', 'llvm_option_dash_o_output', '-mllvm', '-opt-bisect-limit=1',
+       path_from_root('tests', 'hello_world.c')])


### PR DESCRIPTION
Here's a PR to fix a problem I have introduced yesterday, because I still can't get that I should test every change I do :(

Instead of keeping the next argument when encountering an `-mllvm` option, `find_output_arg()` used to replace it with a substring of `"-mllvm"` starting from the index of the next argument.