### PR TITLE
Use getentropy from std::random_device, avoiding FS usage of /dev/urandom

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,8 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- Add `getentropy` in `sys/random.h`, and use that from libc++'s
+  `random_device`. This is more efficient, see #12240.
 
 2.0.4: 09/16/2020
 -----------------

--- a/src/library.js
+++ b/src/library.js
@@ -2845,6 +2845,47 @@ LibraryManager.library = {
   endgrent: function() { throw 'endgrent: TODO' },
   setgrent: function() { throw 'setgrent: TODO' },
 
+  // random.h
+
+  // TODO: consider allowing the API to get a parameter for the number of
+  // bytes.
+  $getRandomDevice: function() {
+    if (typeof crypto === 'object' && typeof crypto['getRandomValues'] === 'function') {
+      // for modern web browsers
+      var randomBuffer = new Uint8Array(1);
+      return function() { crypto.getRandomValues(randomBuffer); return randomBuffer[0]; };
+    } else
+#if ENVIRONMENT_MAY_BE_NODE
+    if (ENVIRONMENT_IS_NODE) {
+      // for nodejs with or without crypto support included
+      try {
+        var crypto_module = require('crypto');
+        // nodejs has crypto support
+        return function() { return crypto_module['randomBytes'](1)[0]; };
+      } catch (e) {
+        // nodejs doesn't have crypto support
+      }
+    }
+#endif // ENVIRONMENT_MAY_BE_NODE
+    // we couldn't find a proper implementation, as Math.random() is not suitable for /dev/random, see emscripten-core/emscripten/pull/7096
+#if ASSERTIONS
+    return function() { abort("no cryptographic support found for randomDevice. consider polyfilling it if you want to use something insecure like Math.random(), e.g. put this in a --pre-js: var crypto = { getRandomValues: function(array) { for (var i = 0; i < array.length; i++) array[i] = (Math.random()*256)|0 } };"); };
+#else
+    return function() { abort("randomDevice"); };
+#endif
+  },
+
+  getentropy__deps: ['$getRandomDevice'],
+  getentropy: function(buffer, size) {
+    if (!_getentropy.randomDevice) {
+      _getentropy.randomDevice = getRandomDevice();
+    }
+    for (var i = 0; i < size; i++) {
+      {{{ makeSetValue('buffer', 'i', '_getentropy.randomDevice()', 'i8') }}}
+    }
+    return 0;
+  },
+
   // ==========================================================================
   // emscripten.h
   // ==========================================================================

--- a/system/include/compat/sys/random.h
+++ b/system/include/compat/sys/random.h
@@ -1,0 +1,9 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int getentropy(void *buffer, size_t length);
+
+#ifdef __cplusplus
+}
+#endif

--- a/system/include/compat/sys/random.h
+++ b/system/include/compat/sys/random.h
@@ -2,6 +2,11 @@
 extern "C" {
 #endif
 
+// This is used by libc++ as an efficient way to get high-quality random data
+// (more efficiently than via the filesystem using /dev/urandom).
+// Upstream musl added support for this, so we can switch to that, but it isn't
+// where libc++ looks for it (which is here and not unistd.h), and it uses a
+// syscall which is unnecessary indirection for us.
 int getentropy(void *buffer, size_t length);
 
 #ifdef __cplusplus

--- a/system/include/compat/sys/unistd.h
+++ b/system/include/compat/sys/unistd.h
@@ -1,2 +1,1 @@
 #include <unistd.h>
-#include <random.h> // for getentropy()

--- a/system/include/compat/sys/unistd.h
+++ b/system/include/compat/sys/unistd.h
@@ -1,1 +1,2 @@
 #include <unistd.h>
+#include <random.h> // for getentropy()

--- a/system/include/libcxx/__config
+++ b/system/include/libcxx/__config
@@ -308,7 +308,7 @@
    // random data even when using sandboxing mechanisms such as chroots,
    // Capsicum, etc.
 #  define _LIBCPP_USING_ARC4_RANDOM
-#elif defined(__Fuchsia__) || defined(__wasi__)
+#elif defined(__Fuchsia__) || defined(__wasi__) || defined(__EMSCRIPTEN__)
 #  define _LIBCPP_USING_GETENTROPY
 #elif defined(__native_client__)
    // NaCl's sandbox (which PNaCl also runs in) doesn't allow filesystem access,

--- a/system/lib/libcxx/readme.txt
+++ b/system/lib/libcxx/readme.txt
@@ -20,3 +20,5 @@ Local modifications are marked with the comment: 'XXX EMSCRIPTEN'
 3. Define _LIBCPP_ELAST in libcxx/include/config_elast.h
 
 4. Set init_priority of __start_std_streams in libcxx/iostream.cpp
+
+5. Use _LIBCPP_USING_GETENTROPY (like wasi)

--- a/tests/core/test_random_device.cpp
+++ b/tests/core/test_random_device.cpp
@@ -12,7 +12,7 @@ auto main()
 try
 {
   std::random_device rd;
-  std::cout << "random was read" << "\n";
+  std::cout << rd() << ", a random was read\n";
 }
 catch( const std::exception& e )
 {


### PR DESCRIPTION
This does *not* change the random number mechanism, it just avoids going through the FS
in order to get random values. `getRandomDevice` is refactored out of the FS code without
change into a global helper.

By avoiding the FS this is faster, in particular in pthreads builds all FS operations are
proxied, so this PR avoids that overhead.

As a benefit this makes us do the same as WASI, so it removes a difference.

Also make the test for this actually get a random number, and not just set up the device
(that used to open the FD, so the test wasn't useless before).

Fixes #10068.
