### PR TITLE
Fix a race condition in pthread call targets not waking up.

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -152,6 +152,9 @@ typedef struct em_queued_call
   // after it has been executed. If false, the caller is in control of the
   // memory.
   int calleeDelete;
+
+  // The thread on which to perform the call.
+  void* targetThread;
 } em_queued_call;
 
 void emscripten_sync_run_in_main_thread(em_queued_call *call);


### PR DESCRIPTION
A thread may happen to have finished handling its events right before we add
another one. If it is idle, it may never handle it. To avoid that, if we wait on a call
then notify it to wake up.

To allow that, track the target thread of each proxied call, so we know who to
notify.