### PR TITLE
Fixes format specifier warning

### DIFF
--- a/tests/webgl2_ubos.cpp
+++ b/tests/webgl2_ubos.cpp
@@ -166,7 +166,7 @@ int main()
     DUMPUNIFORMBLOCKSTATUS(GL_UNIFORM_BLOCK_ACTIVE_UNIFORMS);
     GLint indices[16] = {};
     glGetActiveUniformBlockiv(program, i, GL_UNIFORM_BLOCK_ACTIVE_UNIFORM_INDICES, indices);
-    for(size_t i = 0; i < param; ++i)
+    for(GLint i = 0; i < param; ++i)
       printf("offset for index %d: %d\n", i, indices[i]);
   }
 


### PR DESCRIPTION
Fixes this warning that came up when looking at #12118
```
webgl2_ubos.cpp:170:43: warning: format specifies type 'int' but the argument has type 'size_t'
      (aka 'unsigned long') [-Wformat]
      printf("offset for index %d: %d\n", i, indices[i]);
                               ~~         ^
                               %zu
```