### PR TITLE
Put python requirements in requirements.txt

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
     executor: bionic
     steps:
       - checkout
-      - run: pip3 install flake8==3.7.8 flake8-unused-arguments==0.0.6
+      - run: pip3 install -r requirements.txt
       - run: python3 -m flake8 --show-source --statistics
   test-sanity:
     executor: bionic

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -330,7 +330,7 @@ jobs:
     executor: bionic
     steps:
       - checkout
-      - run: pip3 install -r requirements.txt
+      - run: pip3 install -r requirements-dev.txt
       - run: python3 -m flake8 --show-source --statistics
   test-sanity:
     executor: bionic

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,8 @@
+# TODO(sbc): switch to using Pipenv since it seems like that way to go
+# these day managing python deps.
+# These requirements are only needed for developers who want to run # flake8 on
+# the codebase, not for users of emscripten.
+# Install with `pip3 install -r requirements-dev.txt`
+
+flake8==3.7.8
+flake8-unused-arguments==0.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+# Currently these requirements only needed by emscripten developers
+# and are not needed by users of the toolchian.
+# Install with `pip3 install -r requirements.txt`
+flake8==3.7.8
+flake8-unused-arguments==0.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-# Currently these requirements only needed by emscripten developers
-# and are not needed by users of the toolchian.
-# Install with `pip3 install -r requirements.txt`
-flake8==3.7.8
-flake8-unused-arguments==0.0.6


### PR DESCRIPTION
Currently the only requirements we have are for flake8 which is not
required by users of emscripten, only developers who want to run flake8
while working on emscripen.

If we get most advanced or what/need our users to have speicfic pip
packages installed we should probably switch to
https://pipenv.pypa.io/en/latest/ but for now this is enough.