### PR TITLE
Add a testcase for pthreads race conditions

### DIFF
--- a/tests/pthread/test_pthread_proxy_hammer.cpp
+++ b/tests/pthread/test_pthread_proxy_hammer.cpp
@@ -1,0 +1,71 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <emscripten.h>
+#include <stdio.h>
+
+class random_device
+{
+    int __f_;
+public:
+    // constructors
+    explicit random_device();
+    ~random_device();
+
+    // generating functions
+    unsigned operator()();
+};
+
+random_device::random_device()
+    : __f_(open("/dev/urandom", O_RDONLY))
+{
+    if (__f_ < 0) abort();
+}
+
+random_device::~random_device()
+{
+    close(__f_);
+}
+
+unsigned
+random_device::operator()()
+{
+    unsigned r;
+    size_t n = sizeof(r);
+    char* p = reinterpret_cast<char*>(&r);
+    while (n > 0)
+    {
+        ssize_t s = read(__f_, p, 1);
+        if (s == 0) abort();
+        if (s == -1)
+        {
+            if (errno != EINTR) abort();
+            continue;
+        }
+        n -= static_cast<size_t>(s);
+        p += static_cast<size_t>(s);
+    }
+    return r;
+}
+
+void* ptr;
+
+int main() {
+  int total = 0;
+  for (int i = 0; i < 128; i++) {
+    EM_ASM({ out($0, $1) }, i, total);
+    for (int j = 0; j < 128; j++) {
+      auto* rd = new random_device;
+      total += (*rd)();
+      ptr = (void*)rd; // make sure the optimizer doesn't remove the allocation
+      delete rd;
+    }
+  }
+  EM_ASM({ out("done") });
+#ifdef REPORT_RESULT
+	REPORT_RESULT(0);
+#endif
+  return 0;
+}
+

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1364,12 +1364,12 @@ class BrowserCore(RunnerCore):
         self.harness_out_queue.get()
       raise Exception('excessive responses from %s' % who)
 
-  # @param tries_left: how many more times to try this test, if it fails. browser tests have
-  #                    many more causes of flakiness (in particular, they do not run
-  #                    synchronously, so we have a timeout, which can be hit if the VM
-  #                    we run on stalls temporarily), so we let each test try more than
-  #                    once by default
-  def run_browser(self, html_file, message, expectedResult=None, timeout=None, tries_left=1):
+  # @param extra_tries: how many more times to try this test, if it fails. browser tests have
+  #                     many more causes of flakiness (in particular, they do not run
+  #                     synchronously, so we have a timeout, which can be hit if the VM
+  #                     we run on stalls temporarily), so we let each test try more than
+  #                     once by default
+  def run_browser(self, html_file, message, expectedResult=None, timeout=None, extra_tries=1):
     if not has_browser():
       return
     if BrowserCore.unresponsive_tests >= BrowserCore.MAX_UNRESPONSIVE_TESTS:
@@ -1408,10 +1408,10 @@ class BrowserCore(RunnerCore):
           try:
             self.assertIdenticalUrlEncoded(expectedResult, output)
           except Exception as e:
-            if tries_left > 0:
+            if extra_tries > 0:
               print('[test error (see below), automatically retrying]')
               print(e)
-              return self.run_browser(html_file, message, expectedResult, timeout, tries_left - 1)
+              return self.run_browser(html_file, message, expectedResult, timeout, extra_tries - 1)
             else:
               raise e
       finally:
@@ -1549,7 +1549,7 @@ class BrowserCore(RunnerCore):
             reference_slack=0, manual_reference=False, post_build=None,
             args=[], outfile='test.html', message='.', also_proxied=False,
             url_suffix='', timeout=None, also_asmjs=False,
-            manually_trigger_reftest=False):
+            manually_trigger_reftest=False, extra_tries=1):
     assert expected or reference, 'a btest must either expect an output, or have a reference image'
     # if we are provided the source and not a path, use that
     filename_is_src = '\n' in filename
@@ -1583,7 +1583,7 @@ class BrowserCore(RunnerCore):
       post_build()
     if not isinstance(expected, list):
       expected = [expected]
-    self.run_browser(outfile + url_suffix, message, ['/report_result?' + e for e in expected], timeout=timeout)
+    self.run_browser(outfile + url_suffix, message, ['/report_result?' + e for e in expected], timeout=timeout, extra_tries=extra_tries)
 
     # Tests can opt into being run under asmjs as well
     if 'WASM=0' not in args and (also_asmjs or self.also_asmjs):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4915,8 +4915,6 @@ window.close = function() {
   @unittest.skip("only run this manually, to test for race conditions")
   @requires_threads
   def test_manual_pthread_proxy_hammer(self):
-    # don't run this with the default extra_tries value, as this is *meant* to
-    # notice flakes. that is, this looks for a race condition.
     # the specific symptom of the hangs that were fixed is that the test hangs
     # at some point, using 0% CPU. often that occured in 0-200 iterations out
     # of the 1024 the test runs by default, but this can vary by machine and
@@ -4925,4 +4923,6 @@ window.close = function() {
                expected='0',
                args=['-s', 'USE_PTHREADS=1', '-O2', '-s', 'PROXY_TO_PTHREAD'],
                timeout=10000,
+               # don't run this with the default extra_tries value, as this is
+               # *meant* to notice something random, a race condition.
                extra_tries=0)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4509,6 +4509,10 @@ window.close = function() {
   def test_pthread_reltime(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_reltime.cpp'), expected='3', args=['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'])
 
+  @requires_threads
+  def test_pthread_proxy_hammer(self):
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_proxy_hammer.cpp'), expected='0', args=['-s', 'USE_PTHREADS=1', '-O2', '-s', 'PROXY_TO_PTHREAD'])
+
   # Tests that it is possible to load the main .js file of the application manually via a Blob URL, and still use pthreads.
   @requires_threads
   @no_wasm_backend("WASM2JS does not yet support pthreads")

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4509,10 +4509,6 @@ window.close = function() {
   def test_pthread_reltime(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_reltime.cpp'), expected='3', args=['-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=1'])
 
-  @requires_threads
-  def test_pthread_proxy_hammer(self):
-    self.btest(path_from_root('tests', 'pthread', 'test_pthread_proxy_hammer.cpp'), expected='0', args=['-s', 'USE_PTHREADS=1', '-O2', '-s', 'PROXY_TO_PTHREAD'])
-
   # Tests that it is possible to load the main .js file of the application manually via a Blob URL, and still use pthreads.
   @requires_threads
   @no_wasm_backend("WASM2JS does not yet support pthreads")
@@ -4915,3 +4911,18 @@ window.close = function() {
     # 4GB.
     self.emcc_args += ['-O2', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'MAXIMUM_MEMORY=4GB', '-s', 'ABORTING_MALLOC=0']
     self.do_run_in_out_file_test('tests', 'browser', 'test_4GB_fail.cpp', js_engines=[V8_ENGINE])
+
+  #@unittest.skip("only run this manually, to test for race conditions")
+  @requires_threads
+  def test_manual_pthread_proxy_hammer(self):
+    # don't run this with the default extra_tries value, as this is *meant* to
+    # notice flakes. that is, this looks for a race condition.
+    # the specific symptom of the hangs that were fixed is that the test hangs
+    # at some point, using 0% CPU. often that occured in 0-200 iterations out
+    # of the 1024 the test runs by default, but this can vary by machine and
+    # browser...
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_proxy_hammer.cpp'),
+               expected='0',
+               args=['-s', 'USE_PTHREADS=1', '-O2', '-s', 'PROXY_TO_PTHREAD'],
+               timeout=10000,
+               extra_tries=0)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4912,7 +4912,7 @@ window.close = function() {
     self.emcc_args += ['-O2', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'MAXIMUM_MEMORY=4GB', '-s', 'ABORTING_MALLOC=0']
     self.do_run_in_out_file_test('tests', 'browser', 'test_4GB_fail.cpp', js_engines=[V8_ENGINE])
 
-  #@unittest.skip("only run this manually, to test for race conditions")
+  @unittest.skip("only run this manually, to test for race conditions")
   @requires_threads
   def test_manual_pthread_proxy_hammer(self):
     # don't run this with the default extra_tries value, as this is *meant* to


### PR DESCRIPTION
This is a manual test for race conditions (disabled by default as it is
very long, and checks for a race condition so it is inherently flakey)
that are fixed in #12243 #12244 #12245

It passes after the fixes in those PRs. Without them, it tends to fail
after 100 iterations out of 1000, so at least for me locally it fails
pretty consistently before the fixes.

Note that that was with chrome. I saw the test fail on firefox too
but far more rarely. On node I never saw it fail. So it definitely is
sensitive to timing somehow.