### PR TITLE
Fix a dependency between libc++ and malloc/free

### DIFF
--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -182,5 +182,6 @@
   "glMapBufferRange": ["malloc", "free"],
   "glGetString": ["malloc", "free"],
   "glGetStringi": ["malloc", "free"],
-  "syslog": ["malloc", "free"]
+  "syslog": ["malloc", "free"],
+  "_ZNKSt3__28ios_base6getlocEv": ["malloc", "free"]
 }

--- a/tests/other/metadce/hello_libcxx_O2.exports
+++ b/tests/other/metadce/hello_libcxx_O2.exports
@@ -7,7 +7,9 @@ dynCall_iiiiij
 dynCall_iiiiijj
 dynCall_jiji
 dynCall_viijii
+free
 main
+malloc
 stackAlloc
 stackRestore
 stackSave

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5551,6 +5551,7 @@ PORT: 3979
     self.do_run_in_out_file_test('tests', 'core', 'test_stdvec.cpp')
 
   def test_random_device(self):
+    self.maybe_closure()
     self.do_run_in_out_file_test('tests', 'core', 'test_random_device.cpp')
 
   def test_reinterpreted_ptrs(self):


### PR DESCRIPTION
Using any locale stuff (`std::__2::ios_base::getloc() const` is what is used
in practice) ends up including a lot of various code, including mmap/munmap
which indirectly call malloc/free from JS. This broke when we stopped
including malloc/free by default in #12213. It broke closure, which errors on
this - I'm not sure it's possible to actually get mmap/munmap to actually be
used in that code path.

Adds a test that breaks without the fix.

Sadly this shows the fragility of this approach - we have lots of malloc/free
uses in our JS, and quite a lot of code paths from system libs to there,
which is how this one was missed. OTOH, in practice any non-trivial
program tends to include malloc/free anyhow, which is why we haven't
gotten bug reports I think (I noticed this particular issue by chance when
looking at random_device).



