### PR TITLE
Remove mmap dependency from musl's locale code

### DIFF
--- a/system/lib/libc/musl/src/locale/locale_map.c
+++ b/system/lib/libc/musl/src/locale/locale_map.c
@@ -65,6 +65,7 @@ const struct __locale_map *__get_locale(int cat, const char *val)
 			return p;
 		}
 
+#ifndef __EMSCRIPTEN__ // don't support MUSL_LOCPATH which uses mmap
 	if (!libc.secure) path = getenv("MUSL_LOCPATH");
 	/* FIXME: add a default path? */
 
@@ -93,6 +94,7 @@ const struct __locale_map *__get_locale(int cat, const char *val)
 			break;
 		}
 	}
+#endif
 
 	/* If no locale definition was found, make a locale map
 	 * object anyway to store the name, which is kept for the

--- a/tests/other/metadce/hello_libcxx_O2.imports
+++ b/tests/other/metadce/hello_libcxx_O2.imports
@@ -1,6 +1,4 @@
 __indirect_function_table
-__map_file
-__sys_munmap
 abort
 emscripten_memcpy_big
 emscripten_resize_heap

--- a/tests/other/metadce/hello_libcxx_O2.sent
+++ b/tests/other/metadce/hello_libcxx_O2.sent
@@ -1,7 +1,5 @@
 __cxa_atexit
 __indirect_function_table
-__map_file
-__sys_munmap
 abort
 emscripten_memcpy_big
 emscripten_resize_heap

--- a/tests/other/metadce/hello_libcxx_O2_fexceptions.imports
+++ b/tests/other/metadce/hello_libcxx_O2_fexceptions.imports
@@ -8,9 +8,7 @@ __cxa_rethrow
 __cxa_throw
 __cxa_uncaught_exceptions
 __indirect_function_table
-__map_file
 __resumeException
-__sys_munmap
 abort
 emscripten_memcpy_big
 emscripten_resize_heap

--- a/tests/other/metadce/hello_libcxx_O2_fexceptions.sent
+++ b/tests/other/metadce/hello_libcxx_O2_fexceptions.sent
@@ -9,9 +9,7 @@ __cxa_rethrow
 __cxa_throw
 __cxa_uncaught_exceptions
 __indirect_function_table
-__map_file
 __resumeException
-__sys_munmap
 abort
 emscripten_memcpy_big
 emscripten_resize_heap

--- a/tests/other/metadce/hello_libcxx_O2_fexceptions_DEMANGLE_SUPPORT.imports
+++ b/tests/other/metadce/hello_libcxx_O2_fexceptions_DEMANGLE_SUPPORT.imports
@@ -8,9 +8,7 @@ __cxa_rethrow
 __cxa_throw
 __cxa_uncaught_exceptions
 __indirect_function_table
-__map_file
 __resumeException
-__sys_munmap
 abort
 emscripten_memcpy_big
 emscripten_resize_heap

--- a/tests/other/metadce/hello_libcxx_O2_fexceptions_DEMANGLE_SUPPORT.sent
+++ b/tests/other/metadce/hello_libcxx_O2_fexceptions_DEMANGLE_SUPPORT.sent
@@ -9,9 +9,7 @@ __cxa_rethrow
 __cxa_throw
 __cxa_uncaught_exceptions
 __indirect_function_table
-__map_file
 __resumeException
-__sys_munmap
 abort
 emscripten_memcpy_big
 emscripten_resize_heap

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5551,6 +5551,7 @@ PORT: 3979
     self.do_run_in_out_file_test('tests', 'core', 'test_stdvec.cpp')
 
   def test_random_device(self):
+    self.maybe_closure()
     self.do_run_in_out_file_test('tests', 'core', 'test_random_device.cpp')
 
   def test_reinterpreted_ptrs(self):


### PR DESCRIPTION
Alternative to #12259 - this removes the mmap dependency from musl's
locale code, and by doing that fixes a dependency bug with libc++ using
locale code that causes mmap to be included, and mmap from JS needs
malloc/free which we no longer include since #12213 

That seems nicer anyhow, as mmap was only used there when the user
provided `MUSL_LOCPATH` - I don't think it's worth it for us to support
that nonstandard option.