### PR TITLE
Bump binaryen version to 97

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -507,3 +507,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Max Weisel <max@maxweisel.com>
 * Georg Rottensteiner <georg@georg-rottensteiner.de>
 * Julien Jorge <julien.jorge@gmx.fr>
+* Attila Oláh <atl@google.com> (copyright owned by Google, LLC)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -36,7 +36,7 @@ MACOS = sys.platform == 'darwin'
 LINUX = sys.platform.startswith('linux')
 DEBUG = int(os.environ.get('EMCC_DEBUG', '0'))
 EXPECTED_NODE_VERSION = (4, 1, 1)
-EXPECTED_BINARYEN_VERSION = 96
+EXPECTED_BINARYEN_VERSION = 97
 EXPECTED_LLVM_VERSION = "12.0"
 SIMD_INTEL_FEATURE_TOWER = ['-msse', '-msse2', '-msse3', '-mssse3', '-msse4.1', '-msse4.2', '-mavx']
 SIMD_NEON_FLAGS = ['-mfpu=neon']


### PR DESCRIPTION
Version 97 has just been released (https://github.com/WebAssembly/binaryen/pull/3140).