### PR TITLE
Improve release notes page

### DIFF
--- a/site/source/docs/introducing_emscripten/release_notes.rst
+++ b/site/source/docs/introducing_emscripten/release_notes.rst
@@ -4,17 +4,13 @@
 Release Notes
 =============
 
-Changes between tagged Emscripten versions are recorded in the :ref:`ChangeLog`.
+Changes between tagged Emscripten versions are recorded in the :ref:`ChangeLog`
+(``ChangeLog.md`` in the source repo).
 This log includes high-level information about new features, user-oriented
 fixes, options, command-line parameters, usage changes, deprecations,
 significant internal modifications, optimizations, etc. The log for each version
 links to a detailed diff report, which lists all the incremental changes since
 the previous release.
-
-In addition, the mailing list is used to announce each new :term:`SDK` release;
-these announcements include additional informal release notes and "highlights"
-information. The easiest way to find these posts is to use `this search
-<https://groups.google.com/forum/#!searchin/emscripten-discuss/%22Emscripten$20SDK%22$20$20AND$20(released$20OR$20out$20OR$20available)>`_.
 
 .. _ChangeLog:
 


### PR DESCRIPTION
Mention where the changelog is, and remove a mention of the mailing list
since we don't consistently mention releases there.