### PR TITLE
Fix Embind + Asyncify

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -1071,12 +1071,16 @@ var LibraryEmbind = {
     signature = readLatin1String(signature);
 
     function makeDynCaller() {
-#if USE_LEGACY_DYNCALLS || !WASM_BIGINT
+#if USE_LEGACY_DYNCALLS
+      return getDynCaller(signature, rawFunction);
+#else
+#if !WASM_BIGINT
       if (signature.indexOf('j') != -1) {
         return getDynCaller(signature, rawFunction);
       }
 #endif
       return wasmTable.get(rawFunction);
+#endif
     }
 
     var fp = makeDynCaller();


### PR DESCRIPTION
PR #12150 assumed that we could always fallback to direct wasm table
calls, but this is not yet compatible for Asyncify.

Resolves: #12239.