### PR TITLE
Remove only reference to allocate with 'i32'. NFC.

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -919,7 +919,7 @@ var LibraryGLFW = {
       if (x) {
         setValue(x, wx, 'i32');
       }
-      
+
       if (y) {
         setValue(y, wy, 'i32');
       }
@@ -945,7 +945,7 @@ var LibraryGLFW = {
       if (width) {
         setValue(width, ww, 'i32');
       }
-      
+
       if (height) {
         setValue(height, wh, 'i32');
       }
@@ -1228,7 +1228,8 @@ var LibraryGLFW = {
   glfwGetMonitors: function(count) {
     setValue(count, 1, 'i32');
     if (!GLFW.monitors) {
-      GLFW.monitors = allocate([1, 0, 0, 0], 'i32', ALLOC_NORMAL);
+      GLFW.monitors = {{{ makeMalloc('glfwGetMonitors', Runtime.POINTER_SIZE) }}};
+      setValue(GLFW.monitors, 1, 'i32');
     }
     return GLFW.monitors;
   },
@@ -1341,11 +1342,11 @@ var LibraryGLFW = {
       ww = win.width;
       wh = win.height;
     }
-    
+
     if (width) {
       setValue(width, ww, 'i32');
     }
-    
+
     if (height) {
       setValue(height, wh, 'i32');
     }


### PR DESCRIPTION
I'm pretty sure there is a bug in allocate that means it
doesn't work with anything but 'i8', removing this reference
will allow us just to remove support for other types completely.

If you look at the code for allocate it moves through the input
array with `i += typeSize; ` which means for i32 it only reads on it
every 4 values out of the arg0... at least as far as I can tell.

In this case it doesn't matter and I think this is the use of allocate
with anything except 'i8' so maybe this just went unnoticed?