### PR TITLE
Update docs for _mm_load1_pd and _mm_loaddup_pd

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -480,7 +480,7 @@ The following table highlights the availability and expected performance of diff
    * - _mm_load_pd
      - 🟡 wasm_v128_load. VM must guess type. :raw-html:`<br />` Unaligned load on x86 CPUs.
    * - _mm_load1_pd (_mm_load_pd1)
-     - 🟡 Virtual. v64x2.load_splat, VM must guess type.
+     - 🟡 Virtual. wasm_v64x2_load_splat, VM must guess type.
    * - _mm_load_sd
      - ❌ emulated with wasm_f64x2_make
    * - _mm_load_si128
@@ -762,7 +762,7 @@ The following table highlights the availability and expected performance of diff
    * - _mm_hsub_pd
      - ⚠️ emulated with a SIMD add+two shuffles
    * - _mm_loaddup_pd
-     - 🟡 Scalar load + splat.
+     - 🟡 Virtual. wasm_v64x2_load_splat, VM must guess type.
    * - _mm_movedup_pd
      - 💡 emulated with a general shuffle
    * - _MM_GET_DENORMALS_ZERO_MODE


### PR DESCRIPTION
- Refer to the name of WAsm SIMD intrinsic rather than instruction for
consistency with documentation for other SSE intrinsics
- Document that `_mm_loaddup_pd` maps to a single WAsm SIMD instruction