### PR TITLE
Clean up pthread startup code (NFC)

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -470,17 +470,7 @@ if (!ENVIRONMENT_IS_PTHREAD) // EXIT_RUNTIME=0 only applies to default behavior 
 if (!ENVIRONMENT_IS_PTHREAD) {
   run();
 } else {
-#if EMBIND
-  // Embind must initialize itself on all threads, as it generates support JS.
-  Module['___embind_register_native_and_builtin_types']();
-#endif // EMBIND
-#if MODULARIZE
-  // The promise resolve function typically gets called as part of the execution 
-  // of the Module `run`. The workers/pthreads don't execute `run` here, they
-  // call `run` in response to a message at a later time, so the creation
-  // promise can be resolved, marking the pthread-Module as initialized.
-  readyPromiseResolve(Module);
-#endif // MODULARIZE
+  PThread.initWorker();
 }
 #else
 run();

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -64,7 +64,11 @@ function initRuntime(asm) {
   Module['registerPthreadPtr'] = registerPthreadPtr;
   Module['_pthread_self'] = _pthread_self;
 
-  if (ENVIRONMENT_IS_PTHREAD) return;
+  if (ENVIRONMENT_IS_PTHREAD) {
+    PThread.initWorker();
+    return;
+  }
+
   // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
   registerPthreadPtr(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
   _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);


### PR DESCRIPTION
There were two places that pthread workers were initialized, one in a postSet,
and one at the end of postamble. This joins the two into a single `initWorker`
method, and moves code to there, which is simpler.

(Also add a missing `initWorker` for minimal runtime, so this is technically
not NFC for that runtime. Note that there may be more fixes needed there,
this just does the obvious thing for this PR to improve things.)

This will make fixing a race condition in a subsequent PR easier.