### PR TITLE
Mt deadlock issue

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -509,3 +509,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Julien Jorge <julien.jorge@gmx.fr>
 * Attila Oláh <atl@google.com> (copyright owned by Google, LLC)
 * Marat Dukhan <maratek@google.com> (copyright owned by Google, LLC)
+* Alexander Jährling <alexander.jaehrling@isis-papyrus.com>

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -361,6 +361,8 @@ void emscripten_main_thread_process_queued_calls(void);
 
 void emscripten_current_thread_process_queued_calls(void);
 
+void emscripten_current_thread_process_proxied_queued_calls(void);
+
 pthread_t emscripten_main_browser_thread_id(void);
 
 // Synchronously sleeps the calling thread for the given number of milliseconds.

--- a/system/lib/libc/musl/src/thread/__timedwait.c
+++ b/system/lib/libc/musl/src/thread/__timedwait.c
@@ -52,7 +52,7 @@ int __timedwait_cp(volatile int *addr, int val,
 				return ECANCELED;
 			}
 			// Assist other threads by executing proxied operations that are effectively singlethreaded.
-			if (is_main_thread) emscripten_main_thread_process_queued_calls();
+			if (is_main_thread) emscripten_current_thread_process_proxied_queued_calls();
 			// Must wait in slices in case this thread is cancelled in between.
 			double waitMsecs = sleepUntilTime - emscripten_get_now();
 			if (waitMsecs <= 0) {

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -258,6 +258,10 @@ void emscripten_main_thread_process_queued_calls() {
   // nop
 }
 
+void emscripten_current_thread_process_proxied_queued_calls() {
+  // nop
+}
+
 void emscripten_current_thread_process_queued_calls() {
   // nop
 }


### PR DESCRIPTION
Hi,

we have had massive problems with deadlocks with emscripten due to proxy to main thread calls.

For example if a worker-thread holding a mutex tries to allocate/deallocate memory and the main thread is then executing additional functionality, because other calls were queued on the main thread as well, trying to obtain the same mutex. This happens a lot in our Qt based application by signal/slot or invokeMethod calls.

To avoid this I introduced a new function emscripten_current_thread_process_proxied_queued_calls which replaces emscripten_current_thread_process_queued_calls and emscripten_sync_run_in_main_runtime_thread_ in situations were it would be dangerous to execute something else than proxied calls.

For us this worked very well.

Regarding a test case I'm unsure, I should be able to come up with something which reproduces the original issue, but I first seek feedback whether the solution might have unwanted side effects I just don't see yet.

Kind regards,
Alex