### PR TITLE
Remove `__asm` library function tagging mechanism

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3932,7 +3932,6 @@ function copyLibEntry(lib, a, b) {
   lib[a + '__postset'] = lib[b + '__postset'];
   lib[a + '__proxy'] = lib[b + '__proxy'];
   lib[a + '__sig'] = lib[b + '__sig'];
-  lib[a + '__asm'] = lib[b + '__asm'];
   lib[a + '__deps'] = (lib[b + '__deps'] || []).slice(0);
 }
 

--- a/src/modules.js
+++ b/src/modules.js
@@ -218,7 +218,6 @@ var LibraryManager = {
     var lib = LibraryManager.library;
     libloop: for (var x in lib) {
       if (x.lastIndexOf('__') > 0) continue; // ignore __deps, __*
-      if (lib[x + '__asm']) continue; // ignore asm library functions, those need to be fully optimized
       if (typeof lib[x] === 'string') {
         var target = x;
         while (typeof lib[target] === 'string') {
@@ -258,33 +257,6 @@ var LibraryManager = {
         }
       }
     }
-
-    // all asm.js methods should just be run in JS. We should optimize them eventually into wasm. TODO
-    for (var x in lib) {
-      if (lib[x + '__asm']) {
-        lib[x + '__asm'] = undefined;
-      }
-    }
-
-    /*
-    // export code for CallHandlers.h
-    printErr('============================');
-    for (var x in this.library) {
-      var y = this.library[x];
-      if (typeof y === 'string' && x.indexOf('__sig') < 0 && x.indexOf('__postset') < 0 && y.indexOf(' ') < 0) {
-        printErr('DEF_REDIRECT_HANDLER(' + x + ', ' + y + ');');
-      }
-    }
-    printErr('============================');
-    for (var x in this.library) {
-      var y = this.library[x];
-      if (typeof y === 'string' && x.indexOf('__sig') < 0 && x.indexOf('__postset') < 0 && y.indexOf(' ') < 0) {
-        printErr('  SETUP_CALL_HANDLER(' + x + ');');
-      }
-    }
-    printErr('============================');
-    // end export code for CallHandlers.h
-    */
 
     this.loaded = true;
   },
@@ -442,11 +414,6 @@ function exportRuntime() {
     'callMain',
     'abort',
   ];
-
-  function isJsLibraryConfigIdentifier(ident) {
-    return ident.endsWith('__sig') || ident.endsWith('__proxy') || ident.endsWith('__asm') || ident.endsWith('__inline')
-     || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs') || ident.endsWith('__import');
-  }
 
   // Add JS library elements such as FS, GL, ENV, etc. These are prefixed with
   // '$ which indicates they are JS methods.


### PR DESCRIPTION
We no longer suppoer asmjs so these tags don't mean anything
anymore.

To support user-supplied libraries we continue to ignore them
in isJsLibraryConfigIdentifier

Also remove duplicate copy of `isJsLibraryConfigIdentifier`
function that existed both in modules.js and utility.js (they
were already out of sync).