### PR TITLE
Remove use of MEM_INIT_METHOD == 2

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -9,34 +9,6 @@
 {{{ exportRuntime() }}}
 
 #if MEM_INIT_IN_WASM == 0
-#if MEM_INIT_METHOD == 2
-#if USE_PTHREADS
-if (memoryInitializer && !ENVIRONMENT_IS_PTHREAD) (function(s) {
-#else
-if (memoryInitializer) (function(s) {
-#endif
-  var i, n = s.length;
-#if ASSERTIONS
-  n -= 4;
-  var crc, bit, table = new Int32Array(256);
-  for (i = 0; i < 256; ++i) {
-    for (crc = i, bit = 0; bit < 8; ++bit)
-      crc = (crc >>> 1) ^ ((crc & 1) * 0xedb88320);
-    table[i] = crc >>> 0;
-  }
-  crc = -1;
-  crc = table[(crc ^ n) & 0xff] ^ (crc >>> 8);
-  crc = table[(crc ^ (n >>> 8)) & 0xff] ^ (crc >>> 8);
-  for (i = 0; i < s.length; ++i) {
-    crc = table[(crc ^ s.charCodeAt(i)) & 0xff] ^ (crc >>> 8);
-  }
-  assert(crc === 0, "memory initializer checksum");
-#endif
-  for (i = 0; i < n; ++i) {
-    HEAPU8[GLOBAL_BASE + i] = s.charCodeAt(i);
-  }
-})(memoryInitializer);
-#else
 #if USE_PTHREADS
 if (memoryInitializer && !ENVIRONMENT_IS_PTHREAD) {
 #else
@@ -115,7 +87,6 @@ if (memoryInitializer) {
     }
   }
 }
-#endif
 #endif // MEM_INIT_IN_WASM == 0
 
 var calledRun;

--- a/src/settings.js
+++ b/src/settings.js
@@ -97,7 +97,6 @@ var EXIT_RUNTIME = 0;
 // 1: create a *.mem file containing the binary data of the initial memory;
 
 //    use the --memory-init-file command line switch to select this method
-// 2: embed a string literal representing that initial memory data
 var MEM_INIT_METHOD = 0;
 
 // The total stack size. There is no way to enlarge the stack, so this

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -152,8 +152,6 @@ while 1:
     if random.random() < 0.25:
       js_args += ['-s', 'INLINING_LIMIT=1'] # inline nothing, for more call interaction
     if random.random() < 0.5:
-      js_args += ["--memory-init-file", "0", "-s", "MEM_INIT_METHOD=2"]
-    if random.random() < 0.5:
       js_args += ['-s', 'ASSERTIONS=1']
     print('(compile)', ' '.join(js_args))
     short_args = [shared.EMCC, fail_output_name] + js_args[5:]

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3998,31 +3998,6 @@ window.close = function() {
   def test_sigalrm(self):
     self.btest(path_from_root('tests', 'sigalrm.cpp'), expected='0', args=['-O3'])
 
-  @no_wasm_backend('mem init file')
-  def test_meminit_pairs(self):
-    d = 'const char *data[] = {\n  "'
-    d += '",\n  "'.join(''.join('\\x{:02x}\\x{:02x}'.format(i, j)
-                                for j in range(256)) for i in range(256))
-    with open(path_from_root('tests', 'meminit_pairs.c')) as f:
-      d += '"\n};\n' + f.read()
-    args = ["-O2", "--memory-init-file", "0", "-s", "MEM_INIT_METHOD=2", "-s", "ASSERTIONS=1", '-s', 'WASM=0']
-    self.btest(d, expected='0', args=args + ["--closure", "0"])
-    self.btest(d, expected='0', args=args + ["--closure", "0", "-g"])
-    self.btest(d, expected='0', args=args + ["--closure", "1"])
-
-  @no_wasm_backend('mem init file')
-  def test_meminit_big(self):
-    d = 'const char *data[] = {\n  "'
-    d += '",\n  "'.join([''.join('\\x{:02x}\\x{:02x}'.format(i, j)
-                                 for j in range(256)) for i in range(256)] * 256)
-    with open(path_from_root('tests', 'meminit_pairs.c')) as f:
-      d += '"\n};\n' + f.read()
-    assert len(d) > (1 << 27) # more than 32M memory initializer
-    args = ["-O2", "--memory-init-file", "0", "-s", "MEM_INIT_METHOD=2", "-s", "ASSERTIONS=1", '-s', 'WASM=0']
-    self.btest(d, expected='0', args=args + ["--closure", "0"])
-    self.btest(d, expected='0', args=args + ["--closure", "0", "-g"])
-    self.btest(d, expected='0', args=args + ["--closure", "1"])
-
   def test_canvas_style_proxy(self):
     self.btest('canvas_style_proxy.c', expected='1', args=['--proxy-to-worker', '--shell-file', path_from_root('tests/canvas_style_proxy_shell.html'), '--pre-js', path_from_root('tests/canvas_style_proxy_pre.js')])
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5801,23 +5801,6 @@ int main() {
     self.run_process([EMCC, 'src.c', '-s', 'EXPORTED_FUNCTIONS=["_main", "_treecount"]', '--minify', '0', '-g4', '-Oz'])
     self.assertContained('hello, world!', self.run_js('a.out.js'))
 
-  @no_wasm_backend('MEM_INIT_METHOD not supported under wasm')
-  def test_meminit_crc(self):
-    create_test_file('src.c', r'''
-#include <stdio.h>
-int main() { printf("Mary had a little lamb.\n"); }
-''')
-
-    self.run_process([EMCC, 'src.c', '--memory-init-file', '0', '-s', 'MEM_INIT_METHOD=2', '-s', 'ASSERTIONS=1', '-s', 'WASM=0'])
-    with open('a.out.js') as f:
-      d = f.read()
-    return
-    self.assertContained('Mary had', d)
-    d = d.replace('Mary had', 'Paul had')
-    create_test_file('a.out.js', d)
-    out = self.run_js('a.out.js', assert_returncode=NON_ZERO)
-    self.assertContained('Assertion failed: memory initializer checksum', out)
-
   def test_emscripten_print_double(self):
     create_test_file('src.c', r'''
 #include <stdio.h>


### PR DESCRIPTION
These is no way to set MEM_INIT_METHOD to 2 these days.  It cannot
be used on the command line (we error out if it is), and the only place
it gets set in the source code we set it to 1.