### PR TITLE
Update to latest xcode version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ executors:
       EMSDK_NOTTY: "1"
       PYTHON_BIN: "python3"
     macos:
-      xcode: "9.0"
+      xcode: "12.2.0"
 
 commands:
   emsdk-env:


### PR DESCRIPTION
The xcode version is only really used when we want to do native
clang build, and we recent ran into issues of compatiblity between
our clang-12 binary and linker that is part of xcode 9.0.0.

We were seeing clang pass `-platform_version` to the linker which
is not a supported linker flag in xcode 9.0.0.

I'm not sure exactly how this ever worked to why it broke in the last
couple of days.

Fixes: #12331