### PR TITLE
tests: Removal of @no_wasm_backend, part 1

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1204,7 +1204,22 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return [f for f in inputs if check(f[1])]
       return inputs
 
+    def filter_out_duplicate_dynamic_libs(inputs):
+      # Filter out duplicate shared libraries.
+      # See test_core.py:test_redundant_link
+      seen = set()
+      rtn = []
+      for i in inputs:
+        if get_file_suffix(i[1]) in DYNAMICLIB_ENDINGS and os.path.exists(i[1]):
+          abspath = os.path.abspath(i[1])
+          if abspath in seen:
+            continue
+          seen.add(abspath)
+        rtn.append(i)
+      return rtn
+
     input_files = filter_out_dynamic_libs(input_files)
+    input_files = filter_out_duplicate_dynamic_libs(input_files)
 
     if not input_files and not link_flags:
       exit_with_error('no input files')

--- a/src/settings.js
+++ b/src/settings.js
@@ -222,12 +222,6 @@ var ALLOW_TABLE_GROWTH = 0;
 // default, any other value will be used as an override
 var GLOBAL_BASE = -1;
 
-// Warn at compile time about instructions that LLVM tells us are not fully
-// aligned.  This is useful to find places in your code where you might refactor
-// to ensure proper alignment.  This is currently only supported in asm.js, not
-// wasm.
-var WARN_UNALIGNED = 0;
-
 // Whether closure compiling is being run on this output
 var USE_CLOSURE_COMPILER = 0;
 
@@ -1698,4 +1692,5 @@ var LEGACY_SETTINGS = [
   ['RUNNING_JS_OPTS', [0], 'Fastcomp cared about running JS which could alter asm.js validation, but not upstream'],
   ['EXPORT_FUNCTION_TABLES', [0], 'No longer needed'],
   ['BINARYEN_SCRIPTS', [""], 'No longer needed'],
+  ['WARN_UNALIGNED', [0, 1], 'No longer needed'],
 ];

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -164,6 +164,11 @@ def no_wasm_backend(note=''):
   return unittest.skip(note)
 
 
+def disabled(note=''):
+  assert not callable(note)
+  return unittest.skip(note)
+
+
 def no_windows(note=''):
   assert not callable(note)
   if WINDOWS:

--- a/tests/sillyfuncast2_noasm.ll
+++ b/tests/sillyfuncast2_noasm.ll
@@ -1,6 +1,5 @@
 ; ModuleID = 'tests/hello_world.bc'
 target datalayout = "e-p:32:32-i64:64-v128:32:128-n32-S128"
-target triple = "asmjs-unknown-emscripten"
 
 @.str = private unnamed_addr constant [15 x i8] c"hello, world!\0A\00", align 1 ; [#uses=1 type=[15 x i8]*]
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -32,8 +32,8 @@ from tools.shared import try_delete
 from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WINDOWS, LLVM_ROOT, EM_BUILD_VERBOSE
 from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP
 from tools.shared import NODE_JS, JS_ENGINES, WASM_ENGINES, V8_ENGINE
-from runner import RunnerCore, path_from_root, no_wasm_backend, is_slow_test, ensure_dir
-from runner import needs_dlfcn, env_modify, no_windows, requires_native_clang, chdir, with_env_modify, create_test_file, parameterized
+from runner import RunnerCore, path_from_root, is_slow_test, ensure_dir, disabled
+from runner import env_modify, no_windows, requires_native_clang, chdir, with_env_modify, create_test_file, parameterized
 from runner import js_engines_modify, NON_ZERO
 from tools import shared, building
 import jsrun
@@ -47,6 +47,7 @@ emcmake = shared.bat_suffix(path_from_root('emcmake'))
 emconfigure = shared.bat_suffix(path_from_root('emconfigure'))
 emconfig = shared.bat_suffix(path_from_root('em-config'))
 emsize = shared.bat_suffix(path_from_root('emsize'))
+wasm_dis = os.path.join(building.get_binaryen_bin(), 'wasm-dis')
 
 
 class temp_directory():
@@ -90,7 +91,7 @@ def uses_canonical_tmp(func):
 
 
 def parse_wasm(filename):
-  wat = shared.run_process([os.path.join(building.get_binaryen_bin(), 'wasm-dis'), filename], stdout=PIPE).stdout
+  wat = shared.run_process([wasm_dis, filename], stdout=PIPE).stdout
   imports = []
   exports = []
   funcs = []
@@ -426,7 +427,6 @@ f.close()
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--js-transform', '%s t.py' % (PYTHON)])
     self.assertIn('transformed!', open('a.out.js').read())
 
-  @no_wasm_backend("wasm backend alwasy embedds memory")
   def test_js_mem_file(self):
     for opts in [0, 1, 2, 3]:
       print('mem init in', opts)
@@ -829,7 +829,6 @@ int main() {
 
     self.assertContained('result: 62', self.run_js('a.out.js'))
 
-  @no_wasm_backend('not relevent with lld')
   def test_link_group(self):
     lib_src_name = 'lib.c'
     create_test_file(lib_src_name, 'int x() { return 42; }')
@@ -859,8 +858,6 @@ int main() {
         self.assertExists(out_js, output.stdout + '\n' + output.stderr)
         self.assertContained('result: 42', self.run_js(out_js))
 
-    test(['-Wl,--start-group', lib_name, '-Wl,--start-group'], 'Nested --start-group, missing --end-group?')
-    test(['-Wl,--end-group', lib_name, '-Wl,--start-group'], '--end-group without --start-group')
     test(['-Wl,--start-group', lib_name, '-Wl,--end-group'], None)
     test(['-Wl,--start-group', lib_name], None)
 
@@ -921,75 +918,21 @@ int f() {
     self.run_process([EMCC, 'out.bc'])
     self.assertContained('Hello', self.run_js('a.out.js'))
 
-  @no_wasm_backend('lld resolves circular lib dependencies')
-  def test_circular_libs(self):
-    def tmp_source(name, code):
-      with open(name, 'w') as f:
-        f.write(code)
-
-    tmp_source('a.c', 'int z(); int x() { return z(); }')
-    tmp_source('b.c', 'int x(); int y() { return x(); } int z() { return 42; }')
-    tmp_source('c.c', 'int q() { return 0; }')
-    tmp_source('main.c', r'''
-      #include <stdio.h>
-      int y();
-      int main() {
-        printf("result: %d\n", y());
-        return 0;
-      }
-    ''')
-
-    building.emcc('a.c', ['-c']) # a.c.o
-    building.emcc('b.c', ['-c']) # b.c.o
-    building.emcc('c.c', ['-c'])
-    building.emar('cr', 'libA.a', ['a.c.o', 'c.c.o'])
-    building.emar('cr', 'libB.a', ['b.c.o', 'c.c.o'])
-
-    args = ['main.c', '-o', 'a.out.js']
-    libs_list = ['libA.a', 'libB.a']
-
-    # 'libA.a' does not satisfy any symbols from main, so it will not be included,
-    # and there will be an undefined symbol.
-    err = self.expect_fail([EMCC] + args + libs_list)
-    self.assertContained('error: undefined symbol: x', err)
-
-    # -Wl,--start-group and -Wl,--end-group around the libs will cause a rescan
-    # of 'libA.a' after 'libB.a' adds undefined symbol "x", so a.c.o will now be
-    # included (and the link will succeed).
-    libs = ['-Wl,--start-group'] + libs_list + ['-Wl,--end-group']
-    self.run_process([EMCC] + args + libs)
-    self.assertContained('result: 42', self.run_js('a.out.js'))
-
-    # -( and -) should also work.
-    args = ['main.c', '-o', 'a2.out.js']
-    libs = ['-Wl,-('] + libs_list + ['-Wl,-)']
-    self.run_process([EMCC] + args + libs)
-    self.assertContained('result: 42', self.run_js('a2.out.js'))
-
-  # The fastcomp path will deliberately ignore duplicate input files in order
-  # to allow "libA.so" on the command line twice. The is not really .so support
-  # and the .so files are really bitcode.
-  @no_wasm_backend('tests legacy .so linking behviour')
-  @needs_dlfcn
+  # We deliberately ignore duplicate input files in order to allow
+  # "libA.so" on the command line twice. This is not really .so support
+  # and the .so files are really object files.
   def test_redundant_link(self):
-    lib = "int mult() { return 1; }"
-    lib_name = 'libA.c'
-    create_test_file(lib_name, lib)
-    main = r'''
+    create_test_file('libA.c', 'int mult() { return 1; }')
+    create_test_file('main.c', r'''
       #include <stdio.h>
       int mult();
       int main() {
         printf("result: %d\n", mult());
         return 0;
       }
-    '''
-    main_name = 'main.c'
-    create_test_file(main_name, main)
-
-    building.emcc(lib_name, ['-shared'], output_filename='libA.so')
-
-    building.emcc(main_name, ['libA.so', 'libA.so'], output_filename='a.out.js')
-
+    ''')
+    building.emcc('libA.c', ['-shared'], output_filename='libA.so')
+    building.emcc('main.c', ['libA.so', 'libA.so'], output_filename='a.out.js')
     self.assertContained('result: 1', self.run_js('a.out.js'))
 
   def test_dot_a_all_contents_invalid(self):
@@ -3076,28 +3019,6 @@ int main() {
       output = self.run_js('a.out.js')
       self.assertContained('|5|', output)
 
-  @no_wasm_backend('tests extra fastcomp warnings on unaligned loads/stores, which matter a lot more in asm.js')
-  def test_warn_unaligned(self):
-    create_test_file('src.cpp', r'''
-#include <stdio.h>
-struct packey {
-  char x;
-  int y;
-  double z;
-} __attribute__((__packed__));
-int main() {
-  volatile packey p;
-  p.x = 0;
-  p.y = 1;
-  p.z = 2;
-  return 0;
-}
-''')
-    output = self.run_process([EMCC, 'src.cpp', '-s', 'WASM=0', '-s', 'WARN_UNALIGNED=1', '-g'], stderr=PIPE)
-    self.assertContained('emcc: warning: unaligned store', output.stderr)
-    self.assertContained('emcc: warning: unaligned store', output.stderr)
-    self.assertContained('@line 11 "src.cpp"', output.stderr)
-
   def test_LEGACY_VM_SUPPORT(self):
     # when modern features are lacking, we can polyfill them or at least warn
     create_test_file('pre.js', 'Math.imul = undefined;')
@@ -3279,18 +3200,11 @@ int main() {
       self.run_process([EMCC, path_from_root('tests', 'fs_after_main.cpp')])
       self.assertContained('Test passed.', self.run_js('a.out.js'))
 
-  @no_wasm_backend('tests fastcomp compiler flags')
   def test_os_oz(self):
-    for arg, expect in [
-        ('-O1', '-O1'),
-        ('-O2', '-O3'),
-        ('-Os', '-Os'),
-        ('-Oz', '-Oz'),
-        ('-O3', '-O3'),
-      ]:
-      print(arg, expect)
-      proc = self.run_process([EMCC, '-v', path_from_root('tests', 'hello_world.cpp'), arg], stderr=PIPE)
-      self.assertContained(expect, proc.stderr)
+    for opt in ['-O1', '-O2', '-Os', '-Oz', '-O3']:
+      print(opt)
+      proc = self.run_process([EMCC, '-v', path_from_root('tests', 'hello_world.cpp'), opt], stderr=PIPE)
+      self.assertContained(opt, proc.stderr)
       self.assertContained('hello, world!', self.run_js('a.out.js'))
 
   def test_oz_size(self):
@@ -3315,7 +3229,7 @@ int main() {
     # unopt build is quite larger'
     self.assertGreater(sizes['0'], (1.20 * opt_max))
 
-  @no_wasm_backend('relies on ctor evaluation and dtor elimination')
+  @disabled('relies on fastcomp EXIT_RUNTIME=0 optimization not implemented/disabled')
   def test_global_inits(self):
     create_test_file('inc.h', r'''
 #include <stdio.h>
@@ -3381,29 +3295,6 @@ Waste<3> *getMore() {
       self.assertContained('argc: 1\n16\n17\n10\n', self.run_js('a.out.js'))
       self.assertContainedIf('globalCtors', src, has_global)
 
-  # Tests that when there are only 0 or 1 global initializers, that a grouped global initializer function will not be generated
-  # (that would just consume excess code size)
-  def test_no_global_inits(self):
-    create_test_file('one_global_initializer.cpp', r'''
-#include <emscripten.h>
-#include <stdio.h>
-double t = emscripten_get_now();
-int main() { printf("t:%d\n", (int)(t>0)); }
-''')
-    self.run_process([EMCC, 'one_global_initializer.cpp'])
-    # Above file has one global initializer, should not generate a redundant grouped globalCtors function
-    self.assertNotContained('globalCtors', open('a.out.js').read())
-    self.assertContained('t:1', self.run_js('a.out.js'))
-
-    create_test_file('zero_global_initializers.cpp', r'''
-#include <stdio.h>
-int main() { printf("t:1\n"); }
-''')
-    self.run_process([EMCC, 'zero_global_initializers.cpp'])
-    # Above file should have zero global initializers, should not generate any global initializer functions
-    self.assertNotContained('__GLOBAL__sub_', open('a.out.js').read())
-    self.assertContained('t:1', self.run_js('a.out.js'))
-
   def test_implicit_func(self):
     create_test_file('src.c', r'''
 #include <stdio.h>
@@ -3437,7 +3328,7 @@ int main()
         for e in expected:
           self.assertContained(e, output)
 
-  @no_wasm_backend('uses prebuilt .ll file')
+  @disabled('upstream llvm produces invalid wasm for sillyfuncast2_noasm.ll')
   def test_incorrect_static_call(self):
     for wasm in [0, 1]:
       for opts in [0, 1]:
@@ -3450,8 +3341,12 @@ int main()
           # Should not need to pipe stdout here but binaryen writes to stdout
           # when it really should write to stderr.
           stderr = self.run_process(cmd, stdout=PIPE, stderr=PIPE, check=False).stderr
-          assert ('unexpected' in stderr) == asserts, stderr
-          assert ("to 'doit'" in stderr) == asserts, stderr
+          if asserts:
+            self.assertContained('unexpected', stderr)
+            self.assertContained("to 'doit'", stderr)
+          else:
+            self.assertNotContained('unexpected', stderr)
+            self.assertNotContained("to 'doit'", stderr)
 
   @requires_native_clang
   def test_bad_triple(self):
@@ -3504,96 +3399,6 @@ int main()
       warning = 'linking a library with `-shared` will emit a static object file'
       self.assertContainedIf(warning, err, suffix in shared_suffixes)
 
-  @no_wasm_backend('asm.js optimizations')
-  def test_simplify_ifs(self):
-    def test(src, nums):
-      create_test_file('src.c', src)
-      for opts, ifs in [
-        [['-g2'], nums[0]],
-        [['--profiling'], nums[1]],
-        [['--profiling', '-g2'], nums[2]]
-      ]:
-        print(opts, ifs)
-        if type(ifs) == int:
-          ifs = [ifs]
-        try_delete('a.out.js')
-        self.run_process([EMCC, 'src.c', '-O2', '-s', 'WASM=0'] + opts, stdout=PIPE)
-        src = open('a.out.js').read()
-        main = src[src.find('function _main'):src.find('\n}', src.find('function _main'))]
-        actual_ifs = main.count('if (')
-        assert actual_ifs in ifs, main + ' : ' + str([ifs, actual_ifs])
-
-    test(r'''
-      #include <stdio.h>
-      #include <string.h>
-      int main(int argc, char **argv) {
-        if (argc > 5 && strlen(argv[0]) > 1 && strlen(argv[1]) > 2) printf("halp");
-        return 0;
-      }
-    ''', [3, 1, 1])
-
-    test(r'''
-      #include <stdio.h>
-      #include <string.h>
-      int main(int argc, char **argv) {
-        while (argc % 3 == 0) {
-          if (argc > 5 && strlen(argv[0]) > 1 && strlen(argv[1]) > 2) {
-            printf("halp");
-            argc++;
-          } else {
-            while (argc > 0) {
-              printf("%d\n", argc--);
-            }
-          }
-        }
-        return 0;
-      }
-    ''', [8, [5, 7], [5, 7]])
-
-    test(r'''
-      #include <stdio.h>
-      #include <string.h>
-      int main(int argc, char **argv) {
-        while (argc % 17 == 0) argc *= 2;
-        if (argc > 5 && strlen(argv[0]) > 10 && strlen(argv[1]) > 20) {
-          printf("halp");
-          argc++;
-        } else {
-          printf("%d\n", argc--);
-        }
-        while (argc % 17 == 0) argc *= 2;
-        return argc;
-      }
-    ''', [6, 3, 3])
-
-    test(r'''
-      #include <stdio.h>
-      #include <stdlib.h>
-
-      int main(int argc, char *argv[]) {
-        if (getenv("A") && getenv("B")) {
-            printf("hello world\n");
-        } else {
-            printf("goodnight moon\n");
-        }
-        printf("and that's that\n");
-        return 0;
-      }
-    ''', [[3, 2], 1, 1])
-
-    test(r'''
-      #include <stdio.h>
-      #include <stdlib.h>
-
-      int main(int argc, char *argv[]) {
-        if (getenv("A") || getenv("B")) {
-            printf("hello world\n");
-        }
-        printf("and that's that\n");
-        return 0;
-      }
-    ''', [[3, 2], 1, 1])
-
   def test_symbol_map(self):
     UNMINIFIED_HEAP8 = 'var HEAP8 = new global.Int8Array'
     UNMINIFIED_MIDDLE = 'function middle'
@@ -3643,7 +3448,7 @@ EM_ASM({ _middle() });
           out = self.run_js('a.out.js')
           self.assertContained(stack_trace_reference, out)
           # make sure there are no symbols in the wasm itself
-          wat = self.run_process([os.path.join(building.get_binaryen_bin(), 'wasm-dis'), 'a.out.wasm'], stdout=PIPE).stdout
+          wat = self.run_process([wasm_dis, 'a.out.wasm'], stdout=PIPE).stdout
           for func_start in ('(func $middle', '(func $_middle'):
             self.assertNotContained(func_start, wat)
         # check we don't keep unnecessary debug info with wasm2js when emitting
@@ -4852,43 +4657,6 @@ main(const int argc, const char * const * const argv)
     test(['-o', 'c.html'], True)
     test(['-c'], False)
 
-  @no_wasm_backend('asm.js debug info')
-  def test_js_dash_g(self):
-    create_test_file('src.c', '''
-      #include <stdio.h>
-      #include <assert.h>
-
-      void checker(int x) {
-        x += 20;
-        assert(x < 15); // this is line 7!
-      }
-
-      int main() {
-        checker(10);
-        return 0;
-      }
-    ''')
-
-    def check(has):
-      print(has)
-      lines = open('a.out.js').readlines()
-      lines = [line for line in lines if '___assert_fail(' in line or '___assert_func(' in line]
-      found_line_num = any(('//@line 7 "' in line) for line in lines)
-      found_filename = any(('src.c"\n' in line) for line in lines)
-      assert found_line_num == has, 'Must have debug info with the line number'
-      assert found_filename == has, 'Must have debug info with the filename'
-
-    self.run_process([EMCC, '-s', 'WASM=0', 'src.c', '-g'])
-    check(True)
-    self.run_process([EMCC, '-s', 'WASM=0', 'src.c'])
-    check(False)
-    self.run_process([EMCC, '-s', 'WASM=0', 'src.c', '-g0'])
-    check(False)
-    self.run_process([EMCC, '-s', 'WASM=0', 'src.c', '-g0', '-g']) # later one overrides
-    check(True)
-    self.run_process([EMCC, '-s', 'WASM=0', 'src.c', '-g', '-g0']) # later one overrides
-    check(False)
-
   def test_dash_g_bc(self):
     def test(opts):
       print(opts)
@@ -5154,47 +4922,6 @@ int main(void) {
     result = self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'a.html', '-s', 'EXPORT_NAME=Other'], stdout=PIPE, check=False, stderr=STDOUT)
     self.assertNotEqual(result.returncode, 0)
     self.assertContained('Customizing EXPORT_NAME requires that the HTML be customized to use that name', result.stdout)
-
-  @no_wasm_backend('tests fastcomp specific passes')
-  def test_emcc_c_multi(self):
-    def test(args, llvm_opts=None):
-      print(args)
-      lib = r'''
-        int mult() { return 1; }
-      '''
-
-      lib_name = 'libA.c'
-      create_test_file(lib_name, lib)
-      main = r'''
-        #include <stdio.h>
-        int mult();
-        int main() {
-          printf("result: %d\n", mult());
-          return 0;
-        }
-      '''
-      main_name = 'main.c'
-      create_test_file(main_name, main)
-
-      err = self.run_process([EMCC, '-v', '-c', main_name, lib_name] + args, stderr=PIPE).stderr
-
-      VECTORIZE = '-disable-loop-vectorization'
-
-      if args:
-        assert err.count(VECTORIZE) == 2, err # specified twice, once per file
-        # corresponding to exactly once per invocation of optimizer
-        assert err.count(os.path.sep + 'opt') == 2, err
-      else:
-        assert err.count(VECTORIZE) == 0, err # no optimizations
-
-      self.run_process([EMCC, main_name.replace('.c', '.o'), lib_name.replace('.c', '.o')])
-
-      self.assertContained('result: 1', self.run_js('a.out.js'))
-
-    test([])
-    test(['-O2'], '-O3')
-    test(['-Oz'], '-Oz')
-    test(['-Os'], '-Os')
 
   def test_export_all_3142(self):
     create_test_file('src.cpp', r'''
@@ -6372,7 +6099,7 @@ int main() {
       create_test_file('src.cpp', src)
       self.run_process([EMCC, 'src.cpp', '-O2', '-s', 'EVAL_CTORS=1', '-profiling-funcs', '-s', 'WASM=%d' % wasm])
 
-  @no_wasm_backend('EVAL_CTORS is monolithic with the wasm backend')
+  @disabled('EVAL_CTORS is currently disabled')
   def test_eval_ctors(self):
     for wasm in (1, 0):
       print('wasm', wasm)
@@ -6733,7 +6460,7 @@ int main() {
       cmd = [EMCC, path_from_root('tests', 'hello_world.c'), '-s', 'WASM=1', '-O2'] + args
       print(' '.join(cmd))
       self.run_process(cmd)
-      wat = self.run_process([os.path.join(building.get_binaryen_bin(), 'wasm-dis'), 'a.out.wasm'], stdout=PIPE).stdout
+      wat = self.run_process([wasm_dis, 'a.out.wasm'], stdout=PIPE).stdout
       for line in wat:
         if '(import "env" "memory" (memory ' in line:
           parts = line.strip().replace('(', '').replace(')', '').split(' ')
@@ -7041,7 +6768,6 @@ int main() {
 
   def test_legalize_js_ffi(self):
     # test disabling of JS FFI legalization
-    wasm_dis = os.path.join(building.get_binaryen_bin(), 'wasm-dis')
     for (args, js_ffi) in [
         (['-s', 'LEGALIZE_JS_FFI=1', '-s', 'SIDE_MODULE=1', '-O1', '-s', 'EXPORT_ALL=1'], True),
         (['-s', 'LEGALIZE_JS_FFI=0', '-s', 'SIDE_MODULE=1', '-O1', '-s', 'EXPORT_ALL=1'], False),
@@ -7090,10 +6816,8 @@ int main() {
         assert not e_f32_f64, 'f32 converted to f64 in exports'
         assert e_i64_i64,     'i64 converted to i64 in exports'
 
-  @no_wasm_backend('not testing legalize with main module and wasm backend')
   def test_no_legalize_js_ffi(self):
     # test minimal JS FFI legalization for invoke and dyncalls
-    wasm_dis = os.path.join(building.get_binaryen_bin(), 'wasm-dis')
     for (args, js_ffi) in [
         (['-s', 'LEGALIZE_JS_FFI=0', '-s', 'MAIN_MODULE=2', '-O3', '-s', 'DISABLE_EXCEPTION_CATCHING=0'], False),
       ]:
@@ -7168,7 +6892,7 @@ int main() {
         if target.endswith('.wasm'):
           # only wasm requested
           self.assertNotExists('out.js')
-        wat = self.run_process([os.path.join(building.get_binaryen_bin(), 'wasm-dis'), 'out.wasm'], stdout=PIPE).stdout
+        wat = self.run_process([wasm_dis, 'out.wasm'], stdout=PIPE).stdout
         wat_lines = wat.split('\n')
         exports = [line.strip().split(' ')[1].replace('"', '') for line in wat_lines if "(export " in line]
         imports = [line.strip().split(' ')[2].replace('"', '') for line in wat_lines if "(import " in line]

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -14,7 +14,7 @@ import zipfile
 from subprocess import PIPE, STDOUT
 
 from runner import RunnerCore, path_from_root, env_modify, chdir
-from runner import create_test_file, no_wasm_backend, ensure_dir
+from runner import create_test_file, ensure_dir
 from tools.shared import NODE_JS, PYTHON, EMCC, SPIDERMONKEY_ENGINE, V8_ENGINE
 from tools.shared import CONFIG_FILE, EM_CONFIG, LLVM_ROOT, CANONICAL_TEMP_DIR
 from tools.shared import try_delete
@@ -533,7 +533,6 @@ fi
     os.remove(custom_config_filename)
     shutil.rmtree(temp_dir)
 
-  @no_wasm_backend('depends on WASM=0 working')
   def test_emcc_ports(self):
     restore_and_set_up()
 
@@ -568,7 +567,7 @@ fi
       assert not os.path.exists(PORTS_DIR)
 
       def first_use():
-        output = self.do([EMCC, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'WASM=0', '-s', 'USE_SDL=2'])
+        output = self.do([EMCC, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'USE_SDL=2'])
         assert RETRIEVING_MESSAGE in output, output
         assert BUILDING_MESSAGE in output, output
         self.assertExists(PORTS_DIR)
@@ -576,7 +575,7 @@ fi
 
       def second_use():
         # Using it again avoids retrieve and build
-        output = self.do([EMCC, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'WASM=0', '-s', 'USE_SDL=2'])
+        output = self.do([EMCC, path_from_root('tests', 'hello_world_sdl.cpp'), '-s', 'USE_SDL=2'])
         assert RETRIEVING_MESSAGE not in output, output
         assert BUILDING_MESSAGE not in output, output
 


### PR DESCRIPTION
This change removes the use of this decorator from the other
and sanity test suites.

Some tests simply worked, some make no sense with wasm backend and
a couple are tests we would like revive once day (related to ctor
evaluation and ctor elimiation).

See: #12335