### PR TITLE
Remove builtin primitive concept from jsifier

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -751,8 +751,6 @@ def create_sending(invoke_funcs, metadata):
   send_items = set(basic_funcs + invoke_funcs + em_js_funcs + declared_items)
 
   def fix_import_name(g):
-    if g.startswith('Math_'):
-      return g.split('_')[1]
     # Unlike fastcomp the wasm backend doesn't use the '_' prefix for native
     # symbols.  Emscripten currently expects symbols to start with '_' so we
     # artificially add them to the output of emscripten-wasm-finalize and them

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -15,13 +15,6 @@ var STRUCT_LIST = set('struct', 'list');
 
 var addedLibraryItems = {};
 
-var allExternPrimitives = ['Math_floor', 'Math_abs', 'Math_sqrt', 'Math_pow',
-  'Math_cos', 'Math_sin', 'Math_tan', 'Math_acos', 'Math_asin', 'Math_atan',
-  'Math_atan2', 'Math_exp', 'Math_log', 'Math_ceil', 'Math_imul', 'Math_min',
-  'Math_max', 'Math_clz32', 'Math_fround',
-  'Int8Array', 'Uint8Array', 'Int16Array', 'Uint16Array', 'Int32Array',
-  'Uint32Array', 'Float32Array', 'Float64Array'];
-
 var SETJMP_LABEL = -1;
 
 var INDENTATION = ' ';
@@ -149,9 +142,7 @@ function JSify(data, functionsOnly) {
 
       var noExport = false;
 
-      if (allExternPrimitives.indexOf(ident) != -1) {
-        return;
-      } else if (!LibraryManager.library.hasOwnProperty(ident) && !LibraryManager.library.hasOwnProperty(ident + '__inline')) {
+      if (!LibraryManager.library.hasOwnProperty(ident) && !LibraryManager.library.hasOwnProperty(ident + '__inline')) {
         if (!(finalName in IMPLEMENTED_FUNCTIONS) && !LINKABLE) {
           var msg = 'undefined symbol: ' + ident;
           if (dependent) msg += ' (referenced by ' + dependent + ')';
@@ -229,7 +220,7 @@ function JSify(data, functionsOnly) {
           }
           // In asm, we need to know about library functions. If there is a target, though, then no
           // need to consider this a library function - we will call directly to it anyhow
-          if (!redirectedIdent && (typeof target == 'function' || /Math_\w+/.exec(snippet))) {
+          if (!redirectedIdent && (typeof target == 'function')) {
             Functions.libraryFunctions[finalName] = 1;
           }
         }

--- a/src/library.js
+++ b/src/library.js
@@ -678,9 +678,6 @@ LibraryManager.library = {
   // stdlib.h
   // ==========================================================================
 
-  abs: 'Math_abs',
-  labs: 'Math_abs',
-
   _ZSt9terminatev__deps: ['exit'],
   _ZSt9terminatev: function() {
     _exit(-1234);

--- a/src/modules.js
+++ b/src/modules.js
@@ -223,8 +223,6 @@ var LibraryManager = {
         while (typeof lib[target] === 'string') {
           // ignore code and variable assignments, aliases are just simple names
           if (lib[target].search(/[=({; ]/) >= 0) continue libloop;
-          // ignore trivial pass-throughs to Math.*
-          if (lib[target].indexOf('Math_') == 0) continue libloop;
           target = lib[target];
         }
         if (!isNaN(target)) continue; // This is a number, and so cannot be an alias target.

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -360,9 +360,9 @@ function splitI64(value, floatConversion) {
   // general idea:
   //
   //  $1$0 = ~~$d >>> 0;
-  //  $1$1 = Math_abs($d) >= 1 ? (
-  //     $d > 0 ? Math.min(Math_floor(($d)/ 4294967296.0), 4294967295.0)
-  //            : Math_ceil(Math.min(-4294967296.0, $d - $1$0)/ 4294967296.0)
+  //  $1$1 = Math.abs($d) >= 1 ? (
+  //     $d > 0 ? Math.min(Math.floor(($d)/ 4294967296.0), 4294967295.0)
+  //            : Math.ceil(Math.min(-4294967296.0, $d - $1$0)/ 4294967296.0)
   //  ) : 0;
   //
   // We need to min on positive values here, since our input might be a double, and large values are rounded, so they can
@@ -375,10 +375,10 @@ function splitI64(value, floatConversion) {
   if (floatConversion) lowInput = asmFloatToInt(lowInput);
   var low = lowInput + '>>>0';
   var high = makeInlineCalculation(
-    asmCoercion('Math_abs(VALUE)', 'double') + ' >= ' + asmEnsureFloat('1', 'double') + ' ? ' +
+    asmCoercion('Math.abs(VALUE)', 'double') + ' >= ' + asmEnsureFloat('1', 'double') + ' ? ' +
       '(VALUE > ' + asmEnsureFloat('0', 'double') + ' ? ' +
-               asmCoercion('Math_min(' + asmCoercion('Math_floor((VALUE)/' + asmEnsureFloat(4294967296, 'double') + ')', 'double') + ', ' + asmEnsureFloat(4294967295, 'double') + ')', 'i32') + '>>>0' +
-               ' : ' + asmFloatToInt(asmCoercion('Math_ceil((VALUE - +((' + asmFloatToInt('VALUE') + ')>>>0))/' + asmEnsureFloat(4294967296, 'double') + ')', 'double')) + '>>>0' +
+               asmCoercion('Math.min(' + asmCoercion('Math.floor((VALUE)/' + asmEnsureFloat(4294967296, 'double') + ')', 'double') + ', ' + asmEnsureFloat(4294967295, 'double') + ')', 'i32') + '>>>0' +
+               ' : ' + asmFloatToInt(asmCoercion('Math.ceil((VALUE - +((' + asmFloatToInt('VALUE') + ')>>>0))/' + asmEnsureFloat(4294967296, 'double') + ')', 'double')) + '>>>0' +
       ')' +
     ' : 0',
     value,
@@ -435,10 +435,10 @@ function ensureDot(value) {
 function asmEnsureFloat(value, type) { // ensures that a float type has either 5.5 (clearly a float) or +5 (float due to asm coercion)
   if (!isNumber(value)) return value;
   if (type === 'float') {
-    // normally ok to just emit Math_fround(0), but if the constant is large we may need a .0 (if it can't fit in an int)
-    if (value == 0) return 'Math_fround(0)';
+    // normally ok to just emit Math.fround(0), but if the constant is large we may need a .0 (if it can't fit in an int)
+    if (value == 0) return 'Math.fround(0)';
     value = ensureDot(value);
-    return 'Math_fround(' + value + ')';
+    return 'Math.fround(' + value + ')';
   }
   if (type in Compiletime.FLOAT_TYPES) {
     return ensureDot(value);
@@ -462,7 +462,7 @@ function asmCoercion(value, type, signedness) {
         }
       }
       if (type === 'float') {
-        return 'Math_fround(' + value + ')';
+        return 'Math.fround(' + value + ')';
       } else {
         return '(+(' + value + '))';
       }
@@ -731,7 +731,7 @@ function getFastValue(a, op, b, type) {
     if (a === '2' && isIntImplemented(type)) {
       return '(1 << (' + b + '))';
     }
-    return 'Math_pow(' + a + ', ' + b + ')';
+    return 'Math.pow(' + a + ', ' + b + ')';
   }
   if ((op === '+' || op === '*') && aNumber !== null) { // if one of them is a number, keep it last
     var c = b;
@@ -763,7 +763,7 @@ function getFastValue(a, op, b, type) {
       if ((aNumber !== null && Math.abs(a) < TWO_TWENTY) || (bNumber !== null && Math.abs(b) < TWO_TWENTY)) {
         return '(((' + a + ')*(' + b + '))&' + ((Math.pow(2, bits)-1)|0) + ')'; // keep a non-eliminatable coercion directly on this
       }
-      return '(Math_imul(' + a + ',' + b + ')|0)';
+      return '(Math.imul(' + a + ',' + b + ')|0)';
     }
   } else if (op === '/') {
     if (a === '0' && !(type in Compiletime.FLOAT_TYPES)) { // careful on floats, since 0*NaN is not 0

--- a/src/runtime_math.js
+++ b/src/runtime_math.js
@@ -51,25 +51,3 @@ assert(Math.fround, 'This browser does not support Math.fround(), build with LEG
 assert(Math.clz32, 'This browser does not support Math.clz32(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
 assert(Math.trunc, 'This browser does not support Math.trunc(), build with LEGACY_VM_SUPPORT or POLYFILL_OLD_MATH_FUNCTIONS to add in a polyfill');
 #endif
-
-var Math_abs = Math.abs;
-var Math_cos = Math.cos;
-var Math_sin = Math.sin;
-var Math_tan = Math.tan;
-var Math_acos = Math.acos;
-var Math_asin = Math.asin;
-var Math_atan = Math.atan;
-var Math_atan2 = Math.atan2;
-var Math_exp = Math.exp;
-var Math_log = Math.log;
-var Math_sqrt = Math.sqrt;
-var Math_ceil = Math.ceil;
-var Math_floor = Math.floor;
-var Math_pow = Math.pow;
-var Math_imul = Math.imul;
-var Math_fround = Math.fround;
-var Math_round = Math.round;
-var Math_min = Math.min;
-var Math_max = Math.max;
-var Math_clz32 = Math.clz32;
-var Math_trunc = Math.trunc;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2850,28 +2850,6 @@ int main() {
     self.run_process([EMCC, 'src.cpp', '--js-library', 'lib.js', '-s', 'EXPORTED_FUNCTIONS=["_main", "_jslibfunc"]'])
     self.assertContained('c calling: 12\njs calling: 10.', self.run_js('a.out.js'))
 
-  def test_js_lib_primitive_dep(self):
-    # Verify that primitive dependencies aren't generated in the output JS.
-
-    create_test_file('lib.js', r'''
-mergeInto(LibraryManager.library, {
-  foo__deps: ['Int8Array', 'NonPrimitive'],
-  foo: function() {},
-});
-''')
-    create_test_file('main.c', r'''
-void foo(void);
-
-int main(int argc, char** argv) {
-  foo();
-  return 0;
-}
-''')
-    self.run_process([EMCC, '-O0', 'main.c', '--js-library', 'lib.js', '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
-    generated = open('a.out.js').read()
-    self.assertContained('missing function: NonPrimitive', generated)
-    self.assertNotContained('missing function: Int8Array', generated)
-
   def test_js_lib_using_asm_lib(self):
     create_test_file('lib.js', r'''
 mergeInto(LibraryManager.library, {


### PR DESCRIPTION
I'm pretty sure this was only useful in the asm.js world.