### PR TITLE
Remove old reference to _llvm_global_ctors. NFC.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -458,11 +458,6 @@ def emscript(infile, outfile_js, memfile, temp_files, DEBUG):
     pre = None
 
     invoke_funcs = metadata['invokeFuncs']
-    try:
-      del forwarded_json['Variables']['globals']['_llvm_global_ctors'] # not a true variable
-    except KeyError:
-      pass
-
     sending = create_sending(invoke_funcs, metadata)
     receiving = create_receiving(exports, metadata['initializers'])
 


### PR DESCRIPTION
I assume this was some kind of fastcomp thing.  I can't find
any reference to it anymore.