### PR TITLE
Update docs to recommend -pthread over -sUSE_PTHREADS=1

### DIFF
--- a/site/source/docs/porting/pthreads.rst
+++ b/site/source/docs/porting/pthreads.rst
@@ -17,7 +17,7 @@ Compiling with pthreads enabled
 
 By default, support for pthreads is not enabled. To enable code generation for pthreads, the following command line flags exist:
 
-- Pass the compiler flag ``-s USE_PTHREADS=1`` when compiling any .c/.cpp files, AND when linking to generate the final output .js file.
+- Pass the compiler flag ``-pthread`` when compiling any .c/.cpp files, AND when linking to generate the final output .js file.
 - Optionally, pass the linker flag ``-s PTHREAD_POOL_SIZE=<integer>`` to specify a predefined pool of web workers to populate at page preRun time before application main() is called. This is important because if the workers do not already exist then we may need to wait for the next browser event iteration for certain things, see below.
 
 There should be no other changes required. In C/C++ code, the preprocessor check ``#ifdef __EMSCRIPTEN_PTHREADS__`` can be used to detect whether Emscripten is currently targeting pthreads.

--- a/src/settings.js
+++ b/src/settings.js
@@ -1233,7 +1233,8 @@ var SDL2_MIXER_FORMATS = ["ogg"];
 var IN_TEST_HARNESS = 0;
 
 // If true, enables support for pthreads.
-// [compile+link] - affects user code at compile and system libraries at link
+// [compile+link] - affects user code at compile and system libraries at link.
+// This setting is equivalent to `-pthread`, which should be preferred.
 var USE_PTHREADS = 0;
 
 // In web browsers, Workers cannot be created while the main browser thread


### PR DESCRIPTION
Since we have decided that there is no reason to recommend using the nonstandard
flag when the standard flag does the exact same thing.

Closes #12346.