### PR TITLE
Remove GLOBAL_BASE runtime variable

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -205,10 +205,9 @@ class Memory():
 
     # Memory layout:
     #  * first the static globals
-    self.global_base = shared.Settings.GLOBAL_BASE
     self.static_bump = metadata['staticBump']
     #  * then the stack (up on fastcomp, down on upstream)
-    self.stack_low = align_memory(self.global_base + self.static_bump)
+    self.stack_low = align_memory(shared.Settings.GLOBAL_BASE + self.static_bump)
     self.stack_high = align_memory(self.stack_low + shared.Settings.TOTAL_STACK)
     self.stack_base = self.stack_high
     self.stack_max = self.stack_low
@@ -226,7 +225,7 @@ def apply_memory(js, metadata):
   if shared.Settings.RELOCATABLE:
     js = js.replace('{{{ HEAP_BASE }}}', str(memory.dynamic_base))
 
-  logger.debug('global_base: %d stack_base: %d, stack_max: %d, dynamic_base: %d, static bump: %d', memory.global_base, memory.stack_base, memory.stack_max, memory.dynamic_base, memory.static_bump)
+  logger.debug('stack_base: %d, stack_max: %d, dynamic_base: %d, static bump: %d', memory.stack_base, memory.stack_max, memory.dynamic_base, memory.static_bump)
 
   shared.Settings.LEGACY_DYNAMIC_BASE = memory.dynamic_base
 

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -19,17 +19,17 @@ if (memoryInitializer) {
   }
   if (ENVIRONMENT_IS_NODE || ENVIRONMENT_IS_SHELL) {
     var data = readBinary(memoryInitializer);
-    HEAPU8.set(data, GLOBAL_BASE);
+    HEAPU8.set(data, {{{ GLOBAL_BASE }}});
   } else {
     addRunDependency('memory initializer');
     var applyMemoryInitializer = function(data) {
       if (data.byteLength) data = new Uint8Array(data);
 #if ASSERTIONS
       for (var i = 0; i < data.length; i++) {
-        assert(HEAPU8[GLOBAL_BASE + i] === 0, "area for memory initializer should not have been touched before it's loaded");
+        assert(HEAPU8[{{{ GLOBAL_BASE }}} + i] === 0, "area for memory initializer should not have been touched before it's loaded");
       }
 #endif
-      HEAPU8.set(data, GLOBAL_BASE);
+      HEAPU8.set(data, {{{ GLOBAL_BASE }}});
       // Delete the typed array that contains the large blob of the memory initializer request response so that
       // we won't keep unnecessary memory lying around. However, keep the XHR object itself alive so that e.g.
       // its .status field can still be accessed later.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -834,7 +834,7 @@ function createWasm() {
     var exports = instance.exports;
 
 #if RELOCATABLE
-    exports = relocateExports(exports, GLOBAL_BASE);
+    exports = relocateExports(exports, {{{ GLOBAL_BASE }}});
 #endif
 
 #if ASYNCIFY

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -59,8 +59,7 @@ Module['wasm'] = base64Decode('{{{ getQuoted("WASM_BINARY_DATA") }}}');
 if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
 
-var GLOBAL_BASE = {{{ GLOBAL_BASE }}},
-    TOTAL_STACK = {{{ TOTAL_STACK }}},
+var TOTAL_STACK = {{{ TOTAL_STACK }}},
     STACK_BASE = {{{ getQuoted('STACK_BASE') }}},
     STACKTOP = STACK_BASE,
     STACK_MAX = {{{ getQuoted('STACK_MAX') }}}
@@ -148,7 +147,7 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 #if ASSERTIONS
 if (!Module['mem']) throw 'Must load memory initializer as an ArrayBuffer in to variable Module.mem before adding compiled output .js script to the DOM';
 #endif
-HEAPU8.set(new Uint8Array(Module['mem']), GLOBAL_BASE);
+HEAPU8.set(new Uint8Array(Module['mem']), {{{ GLOBAL_BASE }}});
 
 #endif
 

--- a/src/support.js
+++ b/src/support.js
@@ -53,12 +53,6 @@ function getCompilerSetting(name) {
 #endif // ASSERTIONS
 #endif // RETAIN_COMPILER_SETTINGS
 
-// The address globals begin at. Very low in memory, for code size and optimization opportunities.
-// Above 0 is static memory, starting with globals.
-// Then the stack.
-// Then 'dynamic' memory for sbrk.
-var GLOBAL_BASE = {{{ GLOBAL_BASE }}};
-
 #if USE_PTHREADS
 // JS library code refers to Atomics in the manner used from asm.js, provide
 // the same API here.


### PR DESCRIPTION
This still exists in the form of a setting but it is constant
and baked into the wasm module so it doesn't need to be a runtime
variable.