### PR TITLE
Remove fb and gb dynamic linking globals

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -248,10 +248,8 @@ var LibraryDylink = {
           // symbols that should be local to this module
           switch (prop) {
             case '__memory_base':
-            case 'gb':
               return memoryBase;
             case '__table_base':
-            case 'fb':
               return tableBase;
           }
 


### PR DESCRIPTION
In fact we don't need runtime variables for these since they
are fixed at build time for the main module can calculated on
the fly for side modules.

Also remove the `fb` and `gb` aliases we had for imports of
these things.. I think they must have been a fastcomp thing.