### PR TITLE
Support import(...) in ESTree->Terser conversion

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -187,6 +187,13 @@ class other(RunnerCore):
     # any tests for EXPORT_ES6 but once we do this should be enabled.
     # self.assertContained('hello, world!', self.run_js('hello_world.mjs'))
 
+  def test_emcc_output_worker_mjs(self):
+    self.run_process([EMCC, '-o', 'hello_world.mjs', '-pthread', '-O1', path_from_root('tests', 'hello_world.c')])
+    with open('hello_world.mjs') as f:
+      self.assertContained('export default Module;', f.read())
+    with open('hello_world.worker.js') as f:
+      self.assertContained('import(', f.read())
+
   def test_emcc_out_file(self):
     # Verify that "-ofile" works in addition to "-o" "file"
     self.run_process([EMCC, '-c', '-ofoo.o', path_from_root('tests', 'hello_world.c')])

--- a/third_party/terser/terser.js
+++ b/third_party/terser/terser.js
@@ -7611,7 +7611,7 @@ function OutputStream(options) {
                 definitions : M.declarations.map(from_moz)
             });
         },
-        
+
         ImportDeclaration: function(M) {
             var imported_name = null;
             var imported_names = null;
@@ -7738,6 +7738,19 @@ function OutputStream(options) {
                             end   : my_end_token(M),
                             name  : M.name
                         });
+        },
+        ImportExpression: function(M) {
+          let import_token = my_start_token(M);
+          return new AST_Call({
+            start      : import_token,
+            end        : my_end_token(M),
+            expression : new AST_SymbolRef({
+              start    : import_token,
+              end      : import_token,
+              name     : "import"
+            }),
+            args       : [from_moz(M.source)]
+          });
         }
     };
 


### PR DESCRIPTION

A bit crude, since Terser doesn't have a dedicated dynamic import AST node type, but verified that it works.

Fixes #11303 (now for real).