### PR TITLE
Simplify handling of exported native globals (namedGlobals)

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -112,7 +112,7 @@ var LibraryPThread = {
 #endif
     },
     initShared: function() {
-      PThread.mainThreadFutex = Module['_main_thread_futex'];
+      PThread.mainThreadFutex = _main_thread_futex;
 #if ASSERTIONS
       assert(PThread.mainThreadFutex > 0);
 #endif

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -154,7 +154,7 @@ var TARGET_NOT_SUPPORTED = 0x7FFFFFFF;
 // Wasm backend symbols that are considered system symbols and don't
 // have the normal C symbol name mangled applied (== prefix with an underscore)
 // (Also implicily on this list is any function that starts with string "dynCall_")
-var WASM_SYSTEM_EXPORTS = ['setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore', '__growWasmMemory', '__heap_base', '__data_end'];
+var WASM_SYSTEM_EXPORTS = ['setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore', '__growWasmMemory'];
 
 // Internal: value of -flto argument (either full or thin)
 var LTO = 0;

--- a/tests/other/test_export_global_address.c
+++ b/tests/other/test_export_global_address.c
@@ -5,8 +5,8 @@
 EMSCRIPTEN_KEEPALIVE int g_foo = 4;
 
 EM_JS(int*, get_foo_from_js, (void), {
-  assert(Module['_g_foo'] !== undefined, "g_foo not exported to JS");
-  return Module['_g_foo'];
+  assert(_g_foo !== undefined, "g_foo not exported to JS");
+  return _g_foo;
 });
 
 int main() {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9247,7 +9247,12 @@ int main() {
     self.emcc_args.append('foo.o')
     self.do_run_from_file(src, output)
 
-  def test_export_global_address(self):
+  @parameterized({
+    '': ([],),
+    'minimal': (['-s', 'MINIMAL_RUNTIME'],),
+  })
+  def test_export_global_address(self, args):
+    self.emcc_args += args
     src = path_from_root('tests', 'other', 'test_export_global_address.c')
     output = path_from_root('tests', 'other', 'test_export_global_address.out')
     self.do_run_from_file(src, output)


### PR DESCRIPTION
And make them work with MINIMAL_RUNTIME.

This removes the need for a NAMED_GLOBALS variable and is
precursor to transitioning to the new PIC ABI