### PR TITLE
Implement _mm_abs_epi* with wasm_*_abs

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -783,11 +783,11 @@ The following table highlights the availability and expected performance of diff
    * - Intrinsic name
      - WebAssembly SIMD support
    * - _mm_abs_epi8
-     - ⚠️ emulated with a SIMD shift+xor+add
+     - ✅ wasm_i8x16_abs
    * - _mm_abs_epi16
-     - ⚠️ emulated with a SIMD shift+xor+add
+     - ✅ wasm_i16x8_abs
    * - _mm_abs_epi32
-     - ⚠️ emulated with a SIMD shift+xor+add
+     - ✅ wasm_i32x4_abs
    * - _mm_alignr_epi8
      - ⚠️ emulated with a SIMD or+two shifts
    * - _mm_hadd_epi16

--- a/system/include/SSE/tmmintrin.h
+++ b/system/include/SSE/tmmintrin.h
@@ -16,22 +16,19 @@
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_abs_epi8(__m128i __a)
 {
-  __m128i __mask = (__m128i)wasm_i8x16_shr((v128_t)__a, 7);
-  return _mm_xor_si128(_mm_add_epi8(__a, __mask), __mask);
+  return (__m128i)wasm_i8x16_abs((v128_t)__a);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_abs_epi16(__m128i __a)
 {
-  __m128i __mask = _mm_srai_epi16(__a, 15);
-  return _mm_xor_si128(_mm_add_epi16(__a, __mask), __mask);
+  return (__m128i)wasm_i16x8_abs((v128_t)__a);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_abs_epi32(__m128i __a)
 {
-  __m128i __mask = _mm_srai_epi32(__a, 31);
-  return _mm_xor_si128(_mm_add_epi32(__a, __mask), __mask);
+  return (__m128i)wasm_i32x4_abs((v128_t)__a);
 }
 
 #define _mm_alignr_epi8(__a, __b, __count) \


### PR DESCRIPTION
Switch implementation of `_mm_abs_epi8`/`_mm_abs_epi16`/`_mm_abs_epi32` from emulation to using native `wasm_i8x16_abs`/`wasm_i16x8_abs`/`wasm_i32x4_abs` instructions from WebAssembly/simd#128