### PR TITLE
Add defines for webgl2_ext.h

### DIFF
--- a/system/include/webgl/webgl2_ext.h
+++ b/system/include/webgl/webgl2_ext.h
@@ -3,20 +3,29 @@
 #include "webgl2.h"
 
 // 33. https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/
+#ifndef WEBGL2_EXT_disjoint_timer_query_webgl2
+#define WEBGL2_EXT_disjoint_timer_query_webgl2 1
 #define GL_QUERY_COUNTER_BITS_EXT 0x8864
 #define GL_TIME_ELAPSED_EXT 0x88BF
 #define GL_TIMESTAMP_EXT 0x8E28
 #define GL_GPU_DISJOINT_EXT 0x8FBB
 WEBGL_APICALL void GL_APIENTRY emscripten_webgl2_queryCounterEXT(GLuint query, GLenum target);
+#endif /* WEBGL2_EXT_disjoint_timer_query_webgl2 */
 
 // 46. https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/
+#ifndef WEBGL2_WEBGL_draw_instanced_base_vertex_base_instance
+#define WEBGL2_WEBGL_draw_instanced_base_vertex_base_instance 1
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY glDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
+#endif /* WEBGL2_WEBGL_draw_instanced_base_vertex_base_instance */
 
 // 47. https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/
+#ifndef WEBGL2_WEBGL_multi_draw_instanced_base_vertex_base_instance
+#define WEBGL2_WEBGL_multi_draw_instanced_base_vertex_base_instance 1
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, const GLint* baseVertices, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, const GLint* baseVertices, const GLuint* baseinstances, GLsizei drawCount);
+#endif /* WEBGL2_WEBGL_multi_draw_instanced_base_vertex_base_instance */


### PR DESCRIPTION
Reported by Skia, adding these defines could help them check in code using latest feature without waiting which lands in latest.

This should only impact user including `webgl2_ext.h` and should have no side effect.