### PR TITLE
Disable browser.test_pthread_create in minimal runtime for now, and make the test stricter

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3655,11 +3655,16 @@ window.close = function() {
   def test_pthread_create(self):
     def test(args):
       print(args)
-      self.btest(path_from_root('tests', 'pthread', 'test_pthread_create.cpp'), expected='0', args=['-s', 'INITIAL_MEMORY=64MB', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'] + args)
+      self.btest(path_from_root('tests', 'pthread', 'test_pthread_create.cpp'),
+                 expected='0',
+                 args=['-s', 'INITIAL_MEMORY=64MB', '-s', 'USE_PTHREADS=1', '-s', 'PTHREAD_POOL_SIZE=8'] + args,
+                 extra_tries=0) # this should be 100% deterministic
     print() # new line
     test([])
     test(['-O3'])
-    test(['-s', 'MINIMAL_RUNTIME=1'])
+    # TODO: re-enable minimal runtime once the flakiness is figure out,
+    # https://github.com/emscripten-core/emscripten/issues/12368
+    # test(['-s', 'MINIMAL_RUNTIME=1'])
 
   # Test that preallocating worker threads work.
   @requires_threads


### PR DESCRIPTION
See #12368 - the flakiness in the test appears to be 100% due to the minimal runtime
part, so something specific is racy there. After spending a little time I saw nothing
obvious, but maybe I'm not familiar enough with minimal runtime to know where to
look, that is, where the differences between the runtimes would be regarding pthreads.

For now this disables that test on minimal runtime, and also makes the test stricter -
it's 100% deterministic so there's no need to retry once after a failure (which actually
made the flakiness here harder to notice).

Note that this does not remove all minimal runtime + pthreads tests, as there is still
`test_minimal_runtime_hello_pthread` (which is simpler, and shows no flakiness).

@juj what is the status of minimal runtime + pthreads?