### PR TITLE
Add EMSCRIPTEN_ defines around webgl extensions

### DIFF
--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -161,13 +161,11 @@ WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint d
 #define GL_MAX_EXT 0x8008
 #endif /* EMSCRIPTEN_EXT_blend_minmax */
 
-// 12. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/
-#ifndef EMSCRIPTEN_WEBGL_compressed_texture_atc
-#define EMSCRIPTEN_WEBGL_compressed_texture_atc 1
-#define GL_COMPRESSED_RGB_ATC_WEBGL 0x8C92
-#define GL_COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL 0x8C93
-#define GL_COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL 0x87EE
-#endif /* EMSCRIPTEN_WEBGL_compressed_texture_atc */
+// 27. https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/
+// <no symbols exposed>
+#ifndef EMSCRIPTEN_EXT_shader_texture_lod
+#define EMSCRIPTEN_EXT_shader_texture_lod 1
+#endif /* EMSCRIPTEN_EXT_shader_texture_lod */
 
 // 13. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/
 #ifndef EMSCRIPTEN_WEBGL_compressed_texture_pvrtc
@@ -243,7 +241,6 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectuivEXT(GLuint id, GLenum pname, G
 WEBGL_APICALL void GL_APIENTRY glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params);
 WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params);
 #endif /* EMSCRIPTEN_EXT_disjoint_timer_query */
-
 
 // 29. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/
 #ifndef EMSCRIPTEN_WEBGL_compressed_texture_etc

--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -5,18 +5,32 @@
 
 // 1. https://www.khronos.org/registry/webgl/extensions/OES_texture_float/
 // <no symbols exposed>
+#ifndef EMSCRIPTEN_OES_texture_float
+#define EMSCRIPTEN_OES_texture_float 1
+#endif /* EMSCRIPTEN_OES_texture_float */
 
 // 2. https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/
+#ifndef EMSCRIPTEN_OES_texture_half_float
+#define EMSCRIPTEN_OES_texture_half_float 1
 #define GL_HALF_FLOAT_OES 0x8D61
+#endif /* EMSCRIPTEN_OES_texture_half_float */
 
 // 3. https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/
+#ifndef EMSCRIPTEN_WEBGL_lose_context
+#define EMSCRIPTEN_WEBGL_lose_context 1
 WEBGL_APICALL EMSCRIPTEN_RESULT GL_APIENTRY emscripten_webgl_loseContext(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE contextHandle);
 WEBGL_APICALL EMSCRIPTEN_RESULT GL_APIENTRY emscripten_webgl_restoreContext(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE contextHandle);
+#endif /* EMSCRIPTEN_WEBGL_lose_context */
 
 // 4. https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/
+#ifndef EMSCRIPTEN_OES_standard_derivatives
+#define EMSCRIPTEN_OES_standard_derivatives 1
 #define GL_FRAGMENT_SHADER_DERIVATIVE_HINT_OES 0x8B8B
+#endif /* EMSCRIPTEN_OES_standard_derivatives */
 
 // 5. https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/
+#ifndef EMSCRIPTEN_OES_vertex_array_object
+#define EMSCRIPTEN_OES_vertex_array_object 1
 #define GL_VERTEX_ARRAY_BINDING_OES 0x85B5
 WEBGL_APICALL void GL_APIENTRY emscripten_glBindVertexArrayOES(GLuint array);
 WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays);
@@ -26,34 +40,58 @@ WEBGL_APICALL void GL_APIENTRY glBindVertexArrayOES(GLuint array);
 WEBGL_APICALL void GL_APIENTRY glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays);
 WEBGL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint *arrays);
 WEBGL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES(GLuint array);
+#endif /* EMSCRIPTEN_OES_vertex_array_object */
 
 // 6. https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_renderer_info/
+#ifndef EMSCRIPTEN_WEBGL_debug_renderer_info
+#define EMSCRIPTEN_WEBGL_debug_renderer_info 1
 #define GL_UNMASKED_VENDOR_WEBGL 0x9245
 #define GL_UNMASKED_RENDERER_WEBGL 0x9246
+#endif /* EMSCRIPTEN_WEBGL_debug_renderer_info */
 
 // 7. https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/
+#ifndef EMSCRIPTEN_WEBGL_debug_shaders
+#define EMSCRIPTEN_WEBGL_debug_shaders 1
 WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *source);
+#endif /* EMSCRIPTEN_WEBGL_debug_shaders */
 
 // 8. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
+#ifndef EMSCRIPTEN_WEBGL_compressed_texture_s3tc
+#define EMSCRIPTEN_WEBGL_compressed_texture_s3tc 1
 #define GL_COMPRESSED_RGB_S3TC_DXT1_EXT 0x83F0
 #define GL_COMPRESSED_RGBA_S3TC_DXT1_EXT 0x83F1
 #define GL_COMPRESSED_RGBA_S3TC_DXT3_EXT 0x83F2
 #define GL_COMPRESSED_RGBA_S3TC_DXT5_EXT 0x83F3
+#endif /* EMSCRIPTEN_WEBGL_compressed_texture_s3tc */
 
 // 9. https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/
+#ifndef EMSCRIPTEN_WEBGL_depth_texture
+#define EMSCRIPTEN_WEBGL_depth_texture 1
 #define GL_UNSIGNED_INT_24_8_WEBGL 0x84FA
+#endif /* EMSCRIPTEN_WEBGL_depth_texture */
 
 // 10. https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/
 // <no symbols exposed>
+#ifndef EMSCRIPTEN_OES_element_index_uint
+#define EMSCRIPTEN_OES_element_index_uint 1
+#endif /* EMSCRIPTEN_OES_element_index_uint */
 
 // 11. https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/
+#ifndef EMSCRIPTEN_EXT_texture_filter_anisotropic
+#define EMSCRIPTEN_EXT_texture_filter_anisotropic 1
 #define GL_TEXTURE_MAX_ANISOTROPY_EXT 0x84FE
 #define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
+#endif /* EMSCRIPTEN_EXT_texture_filter_anisotropic */
 
 // 16. https://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/
 // <no symbols exposed>
+#ifndef EMSCRIPTEN_EXT_frag_depth
+#define EMSCRIPTEN_EXT_frag_depth 1
+#endif /* EMSCRIPTEN_EXT_frag_depth */
 
 // 18. https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/
+#ifndef EMSCRIPTEN_WEBGL_draw_buffers
+#define EMSCRIPTEN_WEBGL_draw_buffers 1
 #define GL_COLOR_ATTACHMENT0_WEBGL 0x8CE0
 #define GL_COLOR_ATTACHMENT1_WEBGL 0x8CE1
 #define GL_COLOR_ATTACHMENT2_WEBGL 0x8CE2
@@ -90,8 +128,11 @@ WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint
 #define GL_MAX_DRAW_BUFFERS_WEBGL 0x8824
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawBuffersWEBGL(GLsizei n, const GLenum *buffers);
 WEBGL_APICALL void GL_APIENTRY glDrawBuffersWEBGL(GLsizei n, const GLenum *buffers);
+#endif /* EMSCRIPTEN_WEBGL_draw_buffers */
 
 // 19. https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
+#ifndef EMSCRIPTEN_ANGLE_instanced_arrays
+#define EMSCRIPTEN_ANGLE_instanced_arrays 1
 #define GL_VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE 0x88FE
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
@@ -99,52 +140,85 @@ WEBGL_APICALL void GL_APIENTRY emscripten_glVertexAttribDivisorANGLE(GLuint inde
 WEBGL_APICALL void GL_APIENTRY glDrawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
 WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
 WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint divisor);
+#endif /* EMSCRIPTEN_ANGLE_instanced_arrays */
 
 // 20. https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/
 // <no symbols exposed>
+#ifndef EMSCRIPTEN_OES_texture_float_linear
+#define EMSCRIPTEN_OES_texture_float_linear 1
+#endif /* EMSCRIPTEN_OES_texture_float_linear */
 
 // 21. https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/
 // <no symbols exposed>
+#ifndef EMSCRIPTEN_OES_texture_half_float_linear
+#define EMSCRIPTEN_OES_texture_half_float_linear 1
+#endif /* EMSCRIPTEN_OES_texture_half_float_linear */
 
 // 25. https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/
+#ifndef EMSCRIPTEN_EXT_blend_minmax
+#define EMSCRIPTEN_EXT_blend_minmax 1
 #define GL_MIN_EXT 0x8007
 #define GL_MAX_EXT 0x8008
+#endif /* EMSCRIPTEN_EXT_blend_minmax */
 
 // 27. https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/
 // <no symbols exposed>
+#ifndef EMSCRIPTEN_EXT_shader_texture_lod
+#define EMSCRIPTEN_EXT_shader_texture_lod 1
+#endif /* EMSCRIPTEN_EXT_shader_texture_lod */
 
 // 12. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/
+#ifndef EMSCRIPTEN_WEBGL_compressed_texture_atc
+#define EMSCRIPTEN_WEBGL_compressed_texture_atc 1
 #define GL_COMPRESSED_RGB_ATC_WEBGL 0x8C92
 #define GL_COMPRESSED_RGBA_ATC_EXPLICIT_ALPHA_WEBGL 0x8C93
 #define GL_COMPRESSED_RGBA_ATC_INTERPOLATED_ALPHA_WEBGL 0x87EE
+#endif /* EMSCRIPTEN_WEBGL_compressed_texture_atc */
 
 // 13. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/
+#ifndef EMSCRIPTEN_WEBGL_compressed_texture_pvrtc
+#define EMSCRIPTEN_WEBGL_compressed_texture_pvrtc 1
 #define GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG 0x8C00
 #define GL_COMPRESSED_RGB_PVRTC_2BPPV1_IMG 0x8C01
 #define GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG 0x8C02
 #define GL_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG 0x8C03
+#endif /* EMSCRIPTEN_WEBGL_compressed_texture_pvrtc */
 
 // 14. https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/
+#ifndef EMSCRIPTEN_EXT_color_buffer_half_float
+#define EMSCRIPTEN_EXT_color_buffer_half_float 1
 #define GL_RGBA16F_EXT 0x881A
 #define GL_RGB16F_EXT 0x881B
 #define GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT 0x8211
 #define GL_UNSIGNED_NORMALIZED_EXT 0x8C17
+#endif /* EMSCRIPTEN_EXT_color_buffer_half_float */
 
 // 15. https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/
+#ifndef EMSCRIPTEN_WEBGL_color_buffer_float
+#define EMSCRIPTEN_WEBGL_color_buffer_float 1
 #define GL_RGBA32F_EXT 0x8814
 #define GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT 0x8211
 #define GL_UNSIGNED_NORMALIZED_EXT 0x8C17
+#endif /* EMSCRIPTEN_WEBGL_color_buffer_float */
 
 // 17. https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/
+#ifndef EMSCRIPTEN_EXT_sRGB
+#define EMSCRIPTEN_EXT_sRGB 1
 #define GL_SRGB_EXT 0x8C40
 #define GL_SRGB_ALPHA_EXT 0x8C42
 #define GL_SRGB8_ALPHA8_EXT 0x8C43
 #define GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT 0x8210
+#endif /* EMSCRIPTEN_EXT_sRGB */
 
 // 24. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/
+#ifndef EMSCRIPTEN_WEBGL_compressed_texture_etc1
+#define EMSCRIPTEN_WEBGL_compressed_texture_etc1 1
 #define GL_COMPRESSED_RGB_ETC1_WEBGL 0x8D64
+#endif /* EMSCRIPTEN_WEBGL_compressed_texture_etc1 */
 
 // 26. https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/
+#ifndef EMSCRIPTEN_EXT_disjoint_timer_query
+#define EMSCRIPTEN_EXT_disjoint_timer_query 1
 #define GL_QUERY_COUNTER_BITS_EXT 0x8864
 #define GL_CURRENT_QUERY_EXT 0x8865
 #define GL_QUERY_RESULT_EXT 0x8866
@@ -174,9 +248,12 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectivEXT(GLuint id, GLenum pname, GL
 WEBGL_APICALL void GL_APIENTRY glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint *params);
 WEBGL_APICALL void GL_APIENTRY glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params);
 WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params);
+#endif /* EMSCRIPTEN_EXT_disjoint_timer_query */
 
 
 // 29. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/
+#ifndef EMSCRIPTEN_WEBGL_compressed_texture_etc
+#define EMSCRIPTEN_WEBGL_compressed_texture_etc 1
 #define GL_COMPRESSED_R11_EAC 0x9270
 #define GL_COMPRESSED_SIGNED_R11_EAC 0x9271
 #define GL_COMPRESSED_RG11_EAC 0x9272
@@ -187,8 +264,11 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname,
 #define GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 0x9277
 #define GL_COMPRESSED_RGBA8_ETC2_EAC 0x9278
 #define GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC 0x9279
+#endif /* EMSCRIPTEN_WEBGL_compressed_texture_etc */
 
 // 30. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/
+#ifndef EMSCRIPTEN_WEBGL_compressed_texture_astc
+#define EMSCRIPTEN_WEBGL_compressed_texture_astc 1
 #define GL_COMPRESSED_RGBA_ASTC_4x4_KHR 0x93B0
 #define GL_COMPRESSED_RGBA_ASTC_5x4_KHR 0x93B1
 #define GL_COMPRESSED_RGBA_ASTC_5x5_KHR 0x93B2
@@ -218,17 +298,26 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname,
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR 0x93DC
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR 0x93DD
 WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getSupportedAstcProfiles(GLsizei bufSize, GLsizei *length, GLchar *buf);
+#endif /* EMSCRIPTEN_WEBGL_compressed_texture_astc */
 
 // 31. https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/
 // <no symbols exposed>
+#ifndef EMSCRIPTEN_EXT_color_buffer_float
+#define EMSCRIPTEN_EXT_color_buffer_float 1
+#endif /* EMSCRIPTEN_EXT_color_buffer_float */
 
 // 32. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/
+#ifndef EMSCRIPTEN_WEBGL_compressed_texture_s3tc_srgb
+#define EMSCRIPTEN_WEBGL_compressed_texture_s3tc_srgb 1
 #define GL_COMPRESSED_SRGB_S3TC_DXT1_EXT 0x8C4C
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT 0x8C4D
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT 0x8C4E
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT 0x8C4F
+#endif /* EMSCRIPTEN_WEBGL_compressed_texture_s3tc_srgb */
 
 // 40. https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/
+#ifndef EMSCRIPTEN_WEBGL_multi_draw
+#define EMSCRIPTEN_WEBGL_multi_draw 1
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, GLsizei drawcount);
@@ -237,8 +326,11 @@ WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysWEBGL(GLenum mode, const GLint* 
 WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, GLsizei drawcount);
+#endif /* EMSCRIPTEN_WEBGL_multi_draw */
 
 // 44. https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/
+#ifndef EMSCRIPTEN_EXT_texture_norm16
+#define EMSCRIPTEN_EXT_texture_norm16 1
 #define GL_R16_EXT 0x822A
 #define GL_RG16_EXT 0x822C
 #define GL_RGB16_EXT 0x8054
@@ -247,3 +339,4 @@ WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedWEBGL(GLenum mode, co
 #define GL_RG16_SNORM_EXT 0x8F99
 #define GL_RGB16_SNORM_EXT 0x8F9A
 #define GL_RGBA16_SNORM_EXT 0x8F9B
+#endif /* EMSCRIPTEN_EXT_texture_norm16 */

--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -4,9 +4,9 @@
 #include <emscripten/html5.h>
 
 // 1. https://www.khronos.org/registry/webgl/extensions/OES_texture_float/
-// <no symbols exposed>
 #ifndef EMSCRIPTEN_OES_texture_float
 #define EMSCRIPTEN_OES_texture_float 1
+// <no symbols exposed>
 #endif /* EMSCRIPTEN_OES_texture_float */
 
 // 2. https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/
@@ -71,9 +71,9 @@ WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint
 #endif /* EMSCRIPTEN_WEBGL_depth_texture */
 
 // 10. https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/
-// <no symbols exposed>
 #ifndef EMSCRIPTEN_OES_element_index_uint
 #define EMSCRIPTEN_OES_element_index_uint 1
+// <no symbols exposed>
 #endif /* EMSCRIPTEN_OES_element_index_uint */
 
 // 11. https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/
@@ -84,9 +84,9 @@ WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint
 #endif /* EMSCRIPTEN_EXT_texture_filter_anisotropic */
 
 // 16. https://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/
-// <no symbols exposed>
 #ifndef EMSCRIPTEN_EXT_frag_depth
 #define EMSCRIPTEN_EXT_frag_depth 1
+// <no symbols exposed>
 #endif /* EMSCRIPTEN_EXT_frag_depth */
 
 // 18. https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/
@@ -143,15 +143,15 @@ WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint d
 #endif /* EMSCRIPTEN_ANGLE_instanced_arrays */
 
 // 20. https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/
-// <no symbols exposed>
 #ifndef EMSCRIPTEN_OES_texture_float_linear
 #define EMSCRIPTEN_OES_texture_float_linear 1
+// <no symbols exposed>
 #endif /* EMSCRIPTEN_OES_texture_float_linear */
 
 // 21. https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/
-// <no symbols exposed>
 #ifndef EMSCRIPTEN_OES_texture_half_float_linear
 #define EMSCRIPTEN_OES_texture_half_float_linear 1
+// <no symbols exposed>
 #endif /* EMSCRIPTEN_OES_texture_half_float_linear */
 
 // 25. https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/
@@ -160,12 +160,6 @@ WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint d
 #define GL_MIN_EXT 0x8007
 #define GL_MAX_EXT 0x8008
 #endif /* EMSCRIPTEN_EXT_blend_minmax */
-
-// 27. https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/
-// <no symbols exposed>
-#ifndef EMSCRIPTEN_EXT_shader_texture_lod
-#define EMSCRIPTEN_EXT_shader_texture_lod 1
-#endif /* EMSCRIPTEN_EXT_shader_texture_lod */
 
 // 12. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_atc/
 #ifndef EMSCRIPTEN_WEBGL_compressed_texture_atc
@@ -301,9 +295,9 @@ WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getSupportedAstcProfiles(GLsizei
 #endif /* EMSCRIPTEN_WEBGL_compressed_texture_astc */
 
 // 31. https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/
-// <no symbols exposed>
 #ifndef EMSCRIPTEN_EXT_color_buffer_float
 #define EMSCRIPTEN_EXT_color_buffer_float 1
+// <no symbols exposed>
 #endif /* EMSCRIPTEN_EXT_color_buffer_float */
 
 // 32. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/

--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -162,9 +162,9 @@ WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint d
 #endif /* EMSCRIPTEN_GL_EXT_blend_minmax */
 
 // 27. https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/
-// <no symbols exposed>
 #ifndef EMSCRIPTEN_GL_EXT_shader_texture_lod
 #define EMSCRIPTEN_GL_EXT_shader_texture_lod 1
+// <no symbols exposed>
 #endif /* EMSCRIPTEN_GL_EXT_shader_texture_lod */
 
 // 13. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/

--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -4,33 +4,33 @@
 #include <emscripten/html5.h>
 
 // 1. https://www.khronos.org/registry/webgl/extensions/OES_texture_float/
-#ifndef EMSCRIPTEN_OES_texture_float
-#define EMSCRIPTEN_OES_texture_float 1
+#ifndef EMSCRIPTEN_GL_OES_texture_float
+#define EMSCRIPTEN_GL_OES_texture_float 1
 // <no symbols exposed>
-#endif /* EMSCRIPTEN_OES_texture_float */
+#endif /* EMSCRIPTEN_GL_OES_texture_float */
 
 // 2. https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float/
-#ifndef EMSCRIPTEN_OES_texture_half_float
-#define EMSCRIPTEN_OES_texture_half_float 1
+#ifndef EMSCRIPTEN_GL_OES_texture_half_float
+#define EMSCRIPTEN_GL_OES_texture_half_float 1
 #define GL_HALF_FLOAT_OES 0x8D61
-#endif /* EMSCRIPTEN_OES_texture_half_float */
+#endif /* EMSCRIPTEN_GL_OES_texture_half_float */
 
 // 3. https://www.khronos.org/registry/webgl/extensions/WEBGL_lose_context/
-#ifndef EMSCRIPTEN_WEBGL_lose_context
-#define EMSCRIPTEN_WEBGL_lose_context 1
+#ifndef EMSCRIPTEN_GL_WEBGL_lose_context
+#define EMSCRIPTEN_GL_WEBGL_lose_context 1
 WEBGL_APICALL EMSCRIPTEN_RESULT GL_APIENTRY emscripten_webgl_loseContext(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE contextHandle);
 WEBGL_APICALL EMSCRIPTEN_RESULT GL_APIENTRY emscripten_webgl_restoreContext(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE contextHandle);
-#endif /* EMSCRIPTEN_WEBGL_lose_context */
+#endif /* EMSCRIPTEN_GL_WEBGL_lose_context */
 
 // 4. https://www.khronos.org/registry/webgl/extensions/OES_standard_derivatives/
-#ifndef EMSCRIPTEN_OES_standard_derivatives
-#define EMSCRIPTEN_OES_standard_derivatives 1
+#ifndef EMSCRIPTEN_GL_OES_standard_derivatives
+#define EMSCRIPTEN_GL_OES_standard_derivatives 1
 #define GL_FRAGMENT_SHADER_DERIVATIVE_HINT_OES 0x8B8B
-#endif /* EMSCRIPTEN_OES_standard_derivatives */
+#endif /* EMSCRIPTEN_GL_OES_standard_derivatives */
 
 // 5. https://www.khronos.org/registry/webgl/extensions/OES_vertex_array_object/
-#ifndef EMSCRIPTEN_OES_vertex_array_object
-#define EMSCRIPTEN_OES_vertex_array_object 1
+#ifndef EMSCRIPTEN_GL_OES_vertex_array_object
+#define EMSCRIPTEN_GL_OES_vertex_array_object 1
 #define GL_VERTEX_ARRAY_BINDING_OES 0x85B5
 WEBGL_APICALL void GL_APIENTRY emscripten_glBindVertexArrayOES(GLuint array);
 WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays);
@@ -40,58 +40,58 @@ WEBGL_APICALL void GL_APIENTRY glBindVertexArrayOES(GLuint array);
 WEBGL_APICALL void GL_APIENTRY glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays);
 WEBGL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint *arrays);
 WEBGL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES(GLuint array);
-#endif /* EMSCRIPTEN_OES_vertex_array_object */
+#endif /* EMSCRIPTEN_GL_OES_vertex_array_object */
 
 // 6. https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_renderer_info/
-#ifndef EMSCRIPTEN_WEBGL_debug_renderer_info
-#define EMSCRIPTEN_WEBGL_debug_renderer_info 1
+#ifndef EMSCRIPTEN_GL_WEBGL_debug_renderer_info
+#define EMSCRIPTEN_GL_WEBGL_debug_renderer_info 1
 #define GL_UNMASKED_VENDOR_WEBGL 0x9245
 #define GL_UNMASKED_RENDERER_WEBGL 0x9246
-#endif /* EMSCRIPTEN_WEBGL_debug_renderer_info */
+#endif /* EMSCRIPTEN_GL_WEBGL_debug_renderer_info */
 
 // 7. https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/
-#ifndef EMSCRIPTEN_WEBGL_debug_shaders
-#define EMSCRIPTEN_WEBGL_debug_shaders 1
+#ifndef EMSCRIPTEN_GL_WEBGL_debug_shaders
+#define EMSCRIPTEN_GL_WEBGL_debug_shaders 1
 WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *source);
-#endif /* EMSCRIPTEN_WEBGL_debug_shaders */
+#endif /* EMSCRIPTEN_GL_WEBGL_debug_shaders */
 
 // 8. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
-#ifndef EMSCRIPTEN_WEBGL_compressed_texture_s3tc
-#define EMSCRIPTEN_WEBGL_compressed_texture_s3tc 1
+#ifndef EMSCRIPTEN_GL_WEBGL_compressed_texture_s3tc
+#define EMSCRIPTEN_GL_WEBGL_compressed_texture_s3tc 1
 #define GL_COMPRESSED_RGB_S3TC_DXT1_EXT 0x83F0
 #define GL_COMPRESSED_RGBA_S3TC_DXT1_EXT 0x83F1
 #define GL_COMPRESSED_RGBA_S3TC_DXT3_EXT 0x83F2
 #define GL_COMPRESSED_RGBA_S3TC_DXT5_EXT 0x83F3
-#endif /* EMSCRIPTEN_WEBGL_compressed_texture_s3tc */
+#endif /* EMSCRIPTEN_GL_WEBGL_compressed_texture_s3tc */
 
 // 9. https://www.khronos.org/registry/webgl/extensions/WEBGL_depth_texture/
-#ifndef EMSCRIPTEN_WEBGL_depth_texture
-#define EMSCRIPTEN_WEBGL_depth_texture 1
+#ifndef EMSCRIPTEN_GL_WEBGL_depth_texture
+#define EMSCRIPTEN_GL_WEBGL_depth_texture 1
 #define GL_UNSIGNED_INT_24_8_WEBGL 0x84FA
-#endif /* EMSCRIPTEN_WEBGL_depth_texture */
+#endif /* EMSCRIPTEN_GL_WEBGL_depth_texture */
 
 // 10. https://www.khronos.org/registry/webgl/extensions/OES_element_index_uint/
-#ifndef EMSCRIPTEN_OES_element_index_uint
-#define EMSCRIPTEN_OES_element_index_uint 1
+#ifndef EMSCRIPTEN_GL_OES_element_index_uint
+#define EMSCRIPTEN_GL_OES_element_index_uint 1
 // <no symbols exposed>
-#endif /* EMSCRIPTEN_OES_element_index_uint */
+#endif /* EMSCRIPTEN_GL_OES_element_index_uint */
 
 // 11. https://www.khronos.org/registry/webgl/extensions/EXT_texture_filter_anisotropic/
-#ifndef EMSCRIPTEN_EXT_texture_filter_anisotropic
-#define EMSCRIPTEN_EXT_texture_filter_anisotropic 1
+#ifndef EMSCRIPTEN_GL_EXT_texture_filter_anisotropic
+#define EMSCRIPTEN_GL_EXT_texture_filter_anisotropic 1
 #define GL_TEXTURE_MAX_ANISOTROPY_EXT 0x84FE
 #define GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
-#endif /* EMSCRIPTEN_EXT_texture_filter_anisotropic */
+#endif /* EMSCRIPTEN_GL_EXT_texture_filter_anisotropic */
 
 // 16. https://www.khronos.org/registry/webgl/extensions/EXT_frag_depth/
-#ifndef EMSCRIPTEN_EXT_frag_depth
-#define EMSCRIPTEN_EXT_frag_depth 1
+#ifndef EMSCRIPTEN_GL_EXT_frag_depth
+#define EMSCRIPTEN_GL_EXT_frag_depth 1
 // <no symbols exposed>
-#endif /* EMSCRIPTEN_EXT_frag_depth */
+#endif /* EMSCRIPTEN_GL_EXT_frag_depth */
 
 // 18. https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_buffers/
-#ifndef EMSCRIPTEN_WEBGL_draw_buffers
-#define EMSCRIPTEN_WEBGL_draw_buffers 1
+#ifndef EMSCRIPTEN_GL_WEBGL_draw_buffers
+#define EMSCRIPTEN_GL_WEBGL_draw_buffers 1
 #define GL_COLOR_ATTACHMENT0_WEBGL 0x8CE0
 #define GL_COLOR_ATTACHMENT1_WEBGL 0x8CE1
 #define GL_COLOR_ATTACHMENT2_WEBGL 0x8CE2
@@ -128,11 +128,11 @@ WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint
 #define GL_MAX_DRAW_BUFFERS_WEBGL 0x8824
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawBuffersWEBGL(GLsizei n, const GLenum *buffers);
 WEBGL_APICALL void GL_APIENTRY glDrawBuffersWEBGL(GLsizei n, const GLenum *buffers);
-#endif /* EMSCRIPTEN_WEBGL_draw_buffers */
+#endif /* EMSCRIPTEN_GL_WEBGL_draw_buffers */
 
 // 19. https://www.khronos.org/registry/webgl/extensions/ANGLE_instanced_arrays/
-#ifndef EMSCRIPTEN_ANGLE_instanced_arrays
-#define EMSCRIPTEN_ANGLE_instanced_arrays 1
+#ifndef EMSCRIPTEN_GL_ANGLE_instanced_arrays
+#define EMSCRIPTEN_GL_ANGLE_instanced_arrays 1
 #define GL_VERTEX_ATTRIB_ARRAY_DIVISOR_ANGLE 0x88FE
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
@@ -140,77 +140,77 @@ WEBGL_APICALL void GL_APIENTRY emscripten_glVertexAttribDivisorANGLE(GLuint inde
 WEBGL_APICALL void GL_APIENTRY glDrawArraysInstancedANGLE(GLenum mode, GLint first, GLsizei count, GLsizei primcount);
 WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedANGLE(GLenum mode, GLsizei count, GLenum type, GLintptr offset, GLsizei primcount);
 WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint divisor);
-#endif /* EMSCRIPTEN_ANGLE_instanced_arrays */
+#endif /* EMSCRIPTEN_GL_ANGLE_instanced_arrays */
 
 // 20. https://www.khronos.org/registry/webgl/extensions/OES_texture_float_linear/
-#ifndef EMSCRIPTEN_OES_texture_float_linear
-#define EMSCRIPTEN_OES_texture_float_linear 1
+#ifndef EMSCRIPTEN_GL_OES_texture_float_linear
+#define EMSCRIPTEN_GL_OES_texture_float_linear 1
 // <no symbols exposed>
-#endif /* EMSCRIPTEN_OES_texture_float_linear */
+#endif /* EMSCRIPTEN_GL_OES_texture_float_linear */
 
 // 21. https://www.khronos.org/registry/webgl/extensions/OES_texture_half_float_linear/
-#ifndef EMSCRIPTEN_OES_texture_half_float_linear
-#define EMSCRIPTEN_OES_texture_half_float_linear 1
+#ifndef EMSCRIPTEN_GL_OES_texture_half_float_linear
+#define EMSCRIPTEN_GL_OES_texture_half_float_linear 1
 // <no symbols exposed>
-#endif /* EMSCRIPTEN_OES_texture_half_float_linear */
+#endif /* EMSCRIPTEN_GL_OES_texture_half_float_linear */
 
 // 25. https://www.khronos.org/registry/webgl/extensions/EXT_blend_minmax/
-#ifndef EMSCRIPTEN_EXT_blend_minmax
-#define EMSCRIPTEN_EXT_blend_minmax 1
+#ifndef EMSCRIPTEN_GL_EXT_blend_minmax
+#define EMSCRIPTEN_GL_EXT_blend_minmax 1
 #define GL_MIN_EXT 0x8007
 #define GL_MAX_EXT 0x8008
-#endif /* EMSCRIPTEN_EXT_blend_minmax */
+#endif /* EMSCRIPTEN_GL_EXT_blend_minmax */
 
 // 27. https://www.khronos.org/registry/webgl/extensions/EXT_shader_texture_lod/
 // <no symbols exposed>
-#ifndef EMSCRIPTEN_EXT_shader_texture_lod
-#define EMSCRIPTEN_EXT_shader_texture_lod 1
-#endif /* EMSCRIPTEN_EXT_shader_texture_lod */
+#ifndef EMSCRIPTEN_GL_EXT_shader_texture_lod
+#define EMSCRIPTEN_GL_EXT_shader_texture_lod 1
+#endif /* EMSCRIPTEN_GL_EXT_shader_texture_lod */
 
 // 13. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_pvrtc/
-#ifndef EMSCRIPTEN_WEBGL_compressed_texture_pvrtc
-#define EMSCRIPTEN_WEBGL_compressed_texture_pvrtc 1
+#ifndef EMSCRIPTEN_GL_WEBGL_compressed_texture_pvrtc
+#define EMSCRIPTEN_GL_WEBGL_compressed_texture_pvrtc 1
 #define GL_COMPRESSED_RGB_PVRTC_4BPPV1_IMG 0x8C00
 #define GL_COMPRESSED_RGB_PVRTC_2BPPV1_IMG 0x8C01
 #define GL_COMPRESSED_RGBA_PVRTC_4BPPV1_IMG 0x8C02
 #define GL_COMPRESSED_RGBA_PVRTC_2BPPV1_IMG 0x8C03
-#endif /* EMSCRIPTEN_WEBGL_compressed_texture_pvrtc */
+#endif /* EMSCRIPTEN_GL_WEBGL_compressed_texture_pvrtc */
 
 // 14. https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_half_float/
-#ifndef EMSCRIPTEN_EXT_color_buffer_half_float
-#define EMSCRIPTEN_EXT_color_buffer_half_float 1
+#ifndef EMSCRIPTEN_GL_EXT_color_buffer_half_float
+#define EMSCRIPTEN_GL_EXT_color_buffer_half_float 1
 #define GL_RGBA16F_EXT 0x881A
 #define GL_RGB16F_EXT 0x881B
 #define GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT 0x8211
 #define GL_UNSIGNED_NORMALIZED_EXT 0x8C17
-#endif /* EMSCRIPTEN_EXT_color_buffer_half_float */
+#endif /* EMSCRIPTEN_GL_EXT_color_buffer_half_float */
 
 // 15. https://www.khronos.org/registry/webgl/extensions/WEBGL_color_buffer_float/
-#ifndef EMSCRIPTEN_WEBGL_color_buffer_float
-#define EMSCRIPTEN_WEBGL_color_buffer_float 1
+#ifndef EMSCRIPTEN_GL_WEBGL_color_buffer_float
+#define EMSCRIPTEN_GL_WEBGL_color_buffer_float 1
 #define GL_RGBA32F_EXT 0x8814
 #define GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT 0x8211
 #define GL_UNSIGNED_NORMALIZED_EXT 0x8C17
-#endif /* EMSCRIPTEN_WEBGL_color_buffer_float */
+#endif /* EMSCRIPTEN_GL_WEBGL_color_buffer_float */
 
 // 17. https://www.khronos.org/registry/webgl/extensions/EXT_sRGB/
-#ifndef EMSCRIPTEN_EXT_sRGB
-#define EMSCRIPTEN_EXT_sRGB 1
+#ifndef EMSCRIPTEN_GL_EXT_sRGB
+#define EMSCRIPTEN_GL_EXT_sRGB 1
 #define GL_SRGB_EXT 0x8C40
 #define GL_SRGB_ALPHA_EXT 0x8C42
 #define GL_SRGB8_ALPHA8_EXT 0x8C43
 #define GL_FRAMEBUFFER_ATTACHMENT_COLOR_ENCODING_EXT 0x8210
-#endif /* EMSCRIPTEN_EXT_sRGB */
+#endif /* EMSCRIPTEN_GL_EXT_sRGB */
 
 // 24. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc1/
-#ifndef EMSCRIPTEN_WEBGL_compressed_texture_etc1
-#define EMSCRIPTEN_WEBGL_compressed_texture_etc1 1
+#ifndef EMSCRIPTEN_GL_WEBGL_compressed_texture_etc1
+#define EMSCRIPTEN_GL_WEBGL_compressed_texture_etc1 1
 #define GL_COMPRESSED_RGB_ETC1_WEBGL 0x8D64
-#endif /* EMSCRIPTEN_WEBGL_compressed_texture_etc1 */
+#endif /* EMSCRIPTEN_GL_WEBGL_compressed_texture_etc1 */
 
 // 26. https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query/
-#ifndef EMSCRIPTEN_EXT_disjoint_timer_query
-#define EMSCRIPTEN_EXT_disjoint_timer_query 1
+#ifndef EMSCRIPTEN_GL_EXT_disjoint_timer_query
+#define EMSCRIPTEN_GL_EXT_disjoint_timer_query 1
 #define GL_QUERY_COUNTER_BITS_EXT 0x8864
 #define GL_CURRENT_QUERY_EXT 0x8865
 #define GL_QUERY_RESULT_EXT 0x8866
@@ -240,11 +240,11 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectivEXT(GLuint id, GLenum pname, GL
 WEBGL_APICALL void GL_APIENTRY glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint *params);
 WEBGL_APICALL void GL_APIENTRY glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params);
 WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params);
-#endif /* EMSCRIPTEN_EXT_disjoint_timer_query */
+#endif /* EMSCRIPTEN_GL_EXT_disjoint_timer_query */
 
 // 29. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/
-#ifndef EMSCRIPTEN_WEBGL_compressed_texture_etc
-#define EMSCRIPTEN_WEBGL_compressed_texture_etc 1
+#ifndef EMSCRIPTEN_GL_WEBGL_compressed_texture_etc
+#define EMSCRIPTEN_GL_WEBGL_compressed_texture_etc 1
 #define GL_COMPRESSED_R11_EAC 0x9270
 #define GL_COMPRESSED_SIGNED_R11_EAC 0x9271
 #define GL_COMPRESSED_RG11_EAC 0x9272
@@ -255,11 +255,11 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname,
 #define GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 0x9277
 #define GL_COMPRESSED_RGBA8_ETC2_EAC 0x9278
 #define GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC 0x9279
-#endif /* EMSCRIPTEN_WEBGL_compressed_texture_etc */
+#endif /* EMSCRIPTEN_GL_WEBGL_compressed_texture_etc */
 
 // 30. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_astc/
-#ifndef EMSCRIPTEN_WEBGL_compressed_texture_astc
-#define EMSCRIPTEN_WEBGL_compressed_texture_astc 1
+#ifndef EMSCRIPTEN_GL_WEBGL_compressed_texture_astc
+#define EMSCRIPTEN_GL_WEBGL_compressed_texture_astc 1
 #define GL_COMPRESSED_RGBA_ASTC_4x4_KHR 0x93B0
 #define GL_COMPRESSED_RGBA_ASTC_5x4_KHR 0x93B1
 #define GL_COMPRESSED_RGBA_ASTC_5x5_KHR 0x93B2
@@ -289,26 +289,26 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname,
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR 0x93DC
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR 0x93DD
 WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getSupportedAstcProfiles(GLsizei bufSize, GLsizei *length, GLchar *buf);
-#endif /* EMSCRIPTEN_WEBGL_compressed_texture_astc */
+#endif /* EMSCRIPTEN_GL_WEBGL_compressed_texture_astc */
 
 // 31. https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/
-#ifndef EMSCRIPTEN_EXT_color_buffer_float
-#define EMSCRIPTEN_EXT_color_buffer_float 1
+#ifndef EMSCRIPTEN_GL_EXT_color_buffer_float
+#define EMSCRIPTEN_GL_EXT_color_buffer_float 1
 // <no symbols exposed>
-#endif /* EMSCRIPTEN_EXT_color_buffer_float */
+#endif /* EMSCRIPTEN_GL_EXT_color_buffer_float */
 
 // 32. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc_srgb/
-#ifndef EMSCRIPTEN_WEBGL_compressed_texture_s3tc_srgb
-#define EMSCRIPTEN_WEBGL_compressed_texture_s3tc_srgb 1
+#ifndef EMSCRIPTEN_GL_WEBGL_compressed_texture_s3tc_srgb
+#define EMSCRIPTEN_GL_WEBGL_compressed_texture_s3tc_srgb 1
 #define GL_COMPRESSED_SRGB_S3TC_DXT1_EXT 0x8C4C
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT1_EXT 0x8C4D
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT3_EXT 0x8C4E
 #define GL_COMPRESSED_SRGB_ALPHA_S3TC_DXT5_EXT 0x8C4F
-#endif /* EMSCRIPTEN_WEBGL_compressed_texture_s3tc_srgb */
+#endif /* EMSCRIPTEN_GL_WEBGL_compressed_texture_s3tc_srgb */
 
 // 40. https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/
-#ifndef EMSCRIPTEN_WEBGL_multi_draw
-#define EMSCRIPTEN_WEBGL_multi_draw 1
+#ifndef EMSCRIPTEN_GL_WEBGL_multi_draw
+#define EMSCRIPTEN_GL_WEBGL_multi_draw 1
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, GLsizei drawcount);
@@ -317,11 +317,11 @@ WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysWEBGL(GLenum mode, const GLint* 
 WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, GLsizei drawcount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, GLsizei drawcount);
-#endif /* EMSCRIPTEN_WEBGL_multi_draw */
+#endif /* EMSCRIPTEN_GL_WEBGL_multi_draw */
 
 // 44. https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/
-#ifndef EMSCRIPTEN_EXT_texture_norm16
-#define EMSCRIPTEN_EXT_texture_norm16 1
+#ifndef EMSCRIPTEN_GL_EXT_texture_norm16
+#define EMSCRIPTEN_GL_EXT_texture_norm16 1
 #define GL_R16_EXT 0x822A
 #define GL_RG16_EXT 0x822C
 #define GL_RGB16_EXT 0x8054
@@ -330,4 +330,4 @@ WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedWEBGL(GLenum mode, co
 #define GL_RG16_SNORM_EXT 0x8F99
 #define GL_RGB16_SNORM_EXT 0x8F9A
 #define GL_RGBA16_SNORM_EXT 0x8F9B
-#endif /* EMSCRIPTEN_EXT_texture_norm16 */
+#endif /* EMSCRIPTEN_GL_EXT_texture_norm16 */

--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -181,6 +181,8 @@ WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint d
 #define EMSCRIPTEN_GL_EXT_color_buffer_half_float 1
 #define GL_RGBA16F_EXT 0x881A
 #define GL_RGB16F_EXT 0x881B
+#define GL_RG16F_EXT 0x822F
+#define GL_R16F_EXT 0x822D
 #define GL_FRAMEBUFFER_ATTACHMENT_COMPONENT_TYPE_EXT 0x8211
 #define GL_UNSIGNED_NORMALIZED_EXT 0x8C17
 #endif /* EMSCRIPTEN_GL_EXT_color_buffer_half_float */

--- a/system/include/webgl/webgl2_ext.h
+++ b/system/include/webgl/webgl2_ext.h
@@ -3,29 +3,29 @@
 #include "webgl2.h"
 
 // 33. https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/
-#ifndef EMSCRIPTEN_EXT_disjoint_timer_query_webgl2
-#define EMSCRIPTEN_EXT_disjoint_timer_query_webgl2 1
+#ifndef EMSCRIPTEN_GL_EXT_disjoint_timer_query_webgl2
+#define EMSCRIPTEN_GL_EXT_disjoint_timer_query_webgl2 1
 #define GL_QUERY_COUNTER_BITS_EXT 0x8864
 #define GL_TIME_ELAPSED_EXT 0x88BF
 #define GL_TIMESTAMP_EXT 0x8E28
 #define GL_GPU_DISJOINT_EXT 0x8FBB
 WEBGL_APICALL void GL_APIENTRY emscripten_webgl2_queryCounterEXT(GLuint query, GLenum target);
-#endif /* EMSCRIPTEN_EXT_disjoint_timer_query_webgl2 */
+#endif /* EMSCRIPTEN_GL_EXT_disjoint_timer_query_webgl2 */
 
 // 46. https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/
-#ifndef EMSCRIPTEN_WEBGL_draw_instanced_base_vertex_base_instance
-#define EMSCRIPTEN_WEBGL_draw_instanced_base_vertex_base_instance 1
+#ifndef EMSCRIPTEN_GL_WEBGL_draw_instanced_base_vertex_base_instance
+#define EMSCRIPTEN_GL_WEBGL_draw_instanced_base_vertex_base_instance 1
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY glDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
-#endif /* EMSCRIPTEN_WEBGL_draw_instanced_base_vertex_base_instance */
+#endif /* EMSCRIPTEN_GL_WEBGL_draw_instanced_base_vertex_base_instance */
 
 // 47. https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/
-#ifndef EMSCRIPTEN_WEBGL_multi_draw_instanced_base_vertex_base_instance
-#define EMSCRIPTEN_WEBGL_multi_draw_instanced_base_vertex_base_instance 1
+#ifndef EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance
+#define EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance 1
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, const GLint* baseVertices, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, const GLint* baseVertices, const GLuint* baseinstances, GLsizei drawCount);
-#endif /* EMSCRIPTEN_WEBGL_multi_draw_instanced_base_vertex_base_instance */
+#endif /* EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance */

--- a/system/include/webgl/webgl2_ext.h
+++ b/system/include/webgl/webgl2_ext.h
@@ -3,29 +3,29 @@
 #include "webgl2.h"
 
 // 33. https://www.khronos.org/registry/webgl/extensions/EXT_disjoint_timer_query_webgl2/
-#ifndef WEBGL2_EXT_disjoint_timer_query_webgl2
-#define WEBGL2_EXT_disjoint_timer_query_webgl2 1
+#ifndef EMSCRIPTEN_EXT_disjoint_timer_query_webgl2
+#define EMSCRIPTEN_EXT_disjoint_timer_query_webgl2 1
 #define GL_QUERY_COUNTER_BITS_EXT 0x8864
 #define GL_TIME_ELAPSED_EXT 0x88BF
 #define GL_TIMESTAMP_EXT 0x8E28
 #define GL_GPU_DISJOINT_EXT 0x8FBB
 WEBGL_APICALL void GL_APIENTRY emscripten_webgl2_queryCounterEXT(GLuint query, GLenum target);
-#endif /* WEBGL2_EXT_disjoint_timer_query_webgl2 */
+#endif /* EMSCRIPTEN_EXT_disjoint_timer_query_webgl2 */
 
 // 46. https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/
-#ifndef WEBGL2_WEBGL_draw_instanced_base_vertex_base_instance
-#define WEBGL2_WEBGL_draw_instanced_base_vertex_base_instance 1
+#ifndef EMSCRIPTEN_WEBGL_draw_instanced_base_vertex_base_instance
+#define EMSCRIPTEN_WEBGL_draw_instanced_base_vertex_base_instance 1
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY emscripten_glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY glDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
 WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
-#endif /* WEBGL2_WEBGL_draw_instanced_base_vertex_base_instance */
+#endif /* EMSCRIPTEN_WEBGL_draw_instanced_base_vertex_base_instance */
 
 // 47. https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/
-#ifndef WEBGL2_WEBGL_multi_draw_instanced_base_vertex_base_instance
-#define WEBGL2_WEBGL_multi_draw_instanced_base_vertex_base_instance 1
+#ifndef EMSCRIPTEN_WEBGL_multi_draw_instanced_base_vertex_base_instance
+#define EMSCRIPTEN_WEBGL_multi_draw_instanced_base_vertex_base_instance 1
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, const GLint* baseVertices, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, const GLuint* baseInstances, GLsizei drawCount);
 WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, const GLint* baseVertices, const GLuint* baseinstances, GLsizei drawCount);
-#endif /* WEBGL2_WEBGL_multi_draw_instanced_base_vertex_base_instance */
+#endif /* EMSCRIPTEN_WEBGL_multi_draw_instanced_base_vertex_base_instance */


### PR DESCRIPTION
Follow up of #12373

Add defines around webgl extensions in the same style as other GL headers.
Using `EMSCRIPTEN_` as the prefix to avoid conflict with GLES extensions and meanwhile ease of auto code generation (without need of version detection of webgl1/2)

CC'ing @kainino0x for review.
CC'ing @csmartdalton86