### PR TITLE
Error on ASan + MINIMAL_RUNTIME

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1784,6 +1784,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if shared.Settings.GLOBAL_BASE != -1:
         exit_with_error("ASan does not support custom GLOBAL_BASE")
 
+      if shared.Settings.MINIMAL_RUNTIME:
+        exit_with_error("MINIMAL_RUNTIME does not support ASan")
+
       max_mem = shared.Settings.INITIAL_MEMORY
       if shared.Settings.ALLOW_MEMORY_GROWTH:
         max_mem = shared.Settings.MAXIMUM_MEMORY

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6997,7 +6997,7 @@ someweirdtext
     'minimal_runtime': (['-s', 'MINIMAL_RUNTIME'],),
   })
   def test_source_map(self, args):
-    if args and '-fsanitize=address' in self.emcc_args:
+    if 'MINIMAL_RUNTIME' in args and '-fsanitize=address' in self.emcc_args:
       self.skipTest('MINIMAL_RUNTIME does not support ASan')
     if '-g' not in self.emcc_args:
       self.emcc_args.append('-g')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5133,6 +5133,7 @@ main( int argv, char ** argc ) {
       self.do_runf(path_from_root('tests', 'utf8_invalid.cpp'), 'OK.')
 
   # Test that invalid character in UTF8 does not cause decoding to crash.
+  @no_asan('MINIMAL_RUNTIME does not support ASan')
   def test_minimal_runtime_utf8_invalid(self):
     self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['UTF8ToString', 'stringToUTF8'])
     for decoder_mode in [[], ['-s', 'TEXTDECODER=1']]:
@@ -5685,6 +5686,7 @@ int main(void) {
   def test_whets(self):
     self.do_runf(path_from_root('tests', 'whets.cpp'), 'Single Precision C Whetstone Benchmark')
 
+  @no_asan("ASan changes allocator behavior")
   def test_dlmalloc_inline(self):
     self.banned_js_engines = [NODE_JS] # slower, and fail on 64-bit
     # needed with typed arrays
@@ -5694,6 +5696,7 @@ int main(void) {
     self.do_run(src, '*1,0*', args=['200', '1'], force_c=True)
     self.do_run('src.js', '*400,0*', args=['400', '400'], force_c=True, no_build=True)
 
+  @no_asan("ASan changes allocator behavior")
   def test_dlmalloc(self):
     self.banned_js_engines = [NODE_JS] # slower, and fail on 64-bit
     # needed with typed arrays
@@ -6112,9 +6115,6 @@ return malloc(size);
   @needs_make('make')
   @is_slow_test
   def test_openjpeg(self):
-    if '-fsanitize=address' in self.emcc_args:
-      self.set_setting('INITIAL_MEMORY', 128 * 1024 * 1024)
-
     def line_splitter(data):
       out = ''
       counter = 0
@@ -6997,6 +6997,8 @@ someweirdtext
     'minimal_runtime': (['-s', 'MINIMAL_RUNTIME'],),
   })
   def test_source_map(self, args):
+    if args and '-fsanitize=address' in self.emcc_args:
+      self.skipTest('MINIMAL_RUNTIME does not support ASan')
     if '-g' not in self.emcc_args:
       self.emcc_args.append('-g')
 
@@ -7833,6 +7835,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
       print(occurances)
 
   # Tests that building with -s DECLARE_ASM_MODULE_EXPORTS=0 works
+  @no_asan('MINIMAL_RUNTIME does not support ASan')
   def test_minimal_runtime_no_declare_asm_module_exports(self):
     self.set_setting('DECLARE_ASM_MODULE_EXPORTS', 0)
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
@@ -7872,6 +7875,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf(path_from_root('tests', 'small_hello_world.c'), 'hello')
 
   # Tests global initializer with -s MINIMAL_RUNTIME=1
+  @no_asan('MINIMAL_RUNTIME does not support ASan')
   def test_minimal_runtime_global_initializer(self):
     self.set_setting('MINIMAL_RUNTIME', 1)
     self.maybe_closure()
@@ -8208,6 +8212,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_run_in_out_file_test('tests', 'core', 'test_get_exported_function.cpp')
 
   # Tests the emscripten_get_exported_function() API.
+  @no_asan('MINIMAL_RUNTIME does not support ASan')
   def test_minimal_runtime_emscripten_get_exported_function(self):
     # Could also test with -s ALLOW_TABLE_GROWTH=1
     self.set_setting('RESERVED_FUNCTION_POINTERS', 2)


### PR DESCRIPTION
Also skip all the minimal runtime core tests when ASan is enabled and get
test_openjpeg passing again. Closes #12248.