### PR TITLE
Update code size tests for recent improvements

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21786,
-  "a.js.gz": 8416,
+  "a.js": 21782,
+  "a.js.gz": 8414,
   "a.mem": 3171,
   "a.mem.gz": 2715,
   "total": 25545,
-  "total_gz": 11517
+  "total_gz": 11515
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21275,
-  "a.js.gz": 8254,
+  "a.js": 21271,
+  "a.js.gz": 8252,
   "a.mem": 3171,
   "a.mem.gz": 2715,
   "total": 25034,
-  "total_gz": 11355
+  "total_gz": 11353
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 697,
   "a.html.gz": 437,
-  "a.js": 1478,
-  "a.js.gz": 700,
+  "a.js": 1474,
+  "a.js.gz": 699,
   "a.mem": 6,
   "a.mem.gz": 32,
   "total": 2181,
-  "total_gz": 1169
+  "total_gz": 1168
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13633,
-  "a.html.gz": 7310,
+  "a.html": 13625,
+  "a.html.gz": 7293,
   "total": 13633,
-  "total_gz": 7310
+  "total_gz": 7293
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19300,
-  "a.html.gz": 8033,
-  "total": 19301,
-  "total_gz": 8033
+  "a.html": 19254,
+  "a.html.gz": 8041,
+  "total": 19254,
+  "total_gz": 8041
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8220,7 +8220,7 @@ int main () {
           # TODO: identify what is causing this. meanwhile allow some amount of slop
           if js:
             # TODO: restore this to 30 after roll
-            slop = 40
+            slop = 60
           else:
             slop = 20
           if size <= expected_size + slop and size >= expected_size - slop:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8219,7 +8219,8 @@ int main () {
           # compiler).
           # TODO: identify what is causing this. meanwhile allow some amount of slop
           if js:
-            slop = 30
+            # TODO: restore this to 30 after roll
+            slop = 40
           else:
             slop = 20
           if size <= expected_size + slop and size >= expected_size - slop:


### PR DESCRIPTION
https://github.com/WebAssembly/binaryen/pull/3163 removed some code and this was enough to break one
of the rollers, where we were on the edge apparently. But most of the recent
wins have just accumulated without causing an error.

This updates to the new expectations including that PR, which shows the nice improvements.
It also increases the slop for now just so we can pass on CI before and after. Will remove
that after.