### PR TITLE
Remove references to __growWasmMemory

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3545,7 +3545,7 @@ LibraryManager.library = {
   // at runtime rather than statically in JS code.
   $exportAsmFunctions: function(asm) {
     var asmjsMangle = function(x) {
-      var unmangledSymbols = {{{ buildStringArray(WASM_FUNCTIONS_THAT_ARE_NOT_NAME_MANGLED) }}};
+      var unmangledSymbols = {{{ buildStringArray(WASM_SYSTEM_EXPORTS) }}};
       return x.indexOf('dynCall_') == 0 || unmangledSymbols.indexOf(x) != -1 ? x : '_' + x;
     };
 

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -110,7 +110,7 @@ var LibraryDylink = {
   },
 
   $asmjsMangle: function(x) {
-    var unmangledSymbols = {{{ buildStringArray(WASM_FUNCTIONS_THAT_ARE_NOT_NAME_MANGLED) }}};
+    var unmangledSymbols = {{{ buildStringArray(WASM_SYSTEM_EXPORTS) }}};
     return x.indexOf('dynCall_') == 0 || unmangledSymbols.indexOf(x) != -1 ? x : '_' + x;
   },
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -151,10 +151,10 @@ var MINIFY_ASMJS_EXPORT_NAMES = 1;
 // Internal: represents a browser version that is not supported at all.
 var TARGET_NOT_SUPPORTED = 0x7FFFFFFF;
 
-// Wasm backend does not apply C name mangling (== prefix with an underscore) to
-// the following functions. (it also does not mangle any function that starts with
-// string "dynCall_")
-var WASM_FUNCTIONS_THAT_ARE_NOT_NAME_MANGLED = ['setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore', '__growWasmMemory', '__heap_base', '__data_end'];
+// Wasm backend symbols that are considered system symbols and don't
+// have the normal C symbol name mangled applied (== prefix with an underscore)
+// (Also implicily on this list is any function that starts with string "dynCall_")
+var WASM_SYSTEM_EXPORTS = ['setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore', '__growWasmMemory', '__heap_base', '__data_end'];
 
 // Internal: value of -flto argument (either full or thin)
 var LTO = 0;

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -23,16 +23,6 @@ WebAssembly = {
 #else
     this.buffer = new ArrayBuffer(opts['initial'] * {{{ WASM_PAGE_SIZE }}});
 #endif
-    this.grow = function(amount) {
-#if ASSERTIONS
-      var oldBuffer = this.buffer;
-#endif
-      var ret = __growWasmMemory(amount);
-#if ASSERTIONS
-      assert(this.buffer !== oldBuffer); // the call should have updated us
-#endif
-      return ret;
-    };
   },
 
 #if RELOCATABLE

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21782,
-  "a.js.gz": 8414,
+  "a.js": 21702,
+  "a.js.gz": 8369,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 25545,
-  "total_gz": 11515
+  "total": 25461,
+  "total_gz": 11470
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21271,
-  "a.js.gz": 8252,
+  "a.js": 21191,
+  "a.js.gz": 8202,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 25034,
-  "total_gz": 11353
+  "total": 24950,
+  "total_gz": 11303
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 697,
   "a.html.gz": 437,
-  "a.js": 1474,
-  "a.js.gz": 699,
+  "a.js": 1131,
+  "a.js.gz": 586,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 2181,
-  "total_gz": 1168
+  "total": 1834,
+  "total_gz": 1055
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19254,
-  "a.html.gz": 8041,
+  "a.html": 19198,
+  "a.html.gz": 8017,
   "total": 19254,
-  "total_gz": 8041
+  "total_gz": 8017
 }

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -1042,7 +1042,7 @@ def is_c_symbol(name):
 def treat_as_user_function(name):
   if name.startswith('dynCall_'):
     return False
-  if name in Settings.WASM_FUNCTIONS_THAT_ARE_NOT_NAME_MANGLED:
+  if name in Settings.WASM_SYSTEM_EXPORTS:
     return False
   return True
 


### PR DESCRIPTION
This is no longer needed since wasm2js will not
inject a grow function into the memory that it
imports (if needed).

See: https://github.com/WebAssembly/binaryen/pull/3185