### PR TITLE
Avoid the implicit skipping of SIMD tests

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -566,3 +566,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Albert Vaca Cintora <albertvaka@gmail.com>
 * Zhi An Ng <zhin@google.com> (copyright owned by Google, Inc.)
 * Ian Jackson <ijackson@chiark.greenend.org.uk>
+* Antetokounpo <antor.232@outlook.com>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,9 +38,9 @@ logger = logging.getLogger("test_core")
 
 def wasm_simd(f):
   def decorated(self):
-    if os.getenv('EMTEST_NO_D8'):
-      unittest.skip('Skipped because EMTEST_NO_D8 is set')
-    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
+    if not V8_ENGINE or V8_ENGINE not in JS_ENGINES:
+      if os.getenv('EMTEST_NO_D8') is None:
+        raise Exception('d8 is needed to run SIMD tests, set EMTEST_NO_D8 if you want to skip them')
       self.skipTest('wasm simd only supported in d8 for now')
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')
@@ -56,11 +56,7 @@ def wasm_simd(f):
 
 def bleeding_edge_wasm_backend(f):
   def decorated(self):
-    if os.getenv('EMTEST_NO_D8'):
-      unittest.skip('Skipped because EMTEST_NO_D8 is set')
-    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
-      self.skipTest('only works in d8 for now')
-    if not self.is_wasm():
+    if not V8_ENGINE or V8_ENGINE not in JS_ENGINES:
       self.skipTest('wasm2js only supports MVP for now')
     self.js_engines = [config.V8_ENGINE]
     f(self)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -39,6 +39,8 @@ logger = logging.getLogger("test_core")
 def wasm_simd(f):
   def decorated(self):
     if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
+      if os.getenv('EMTEST_NO_D8') is None:
+        raise Exception('d8 is needed to run SIMD tests, set EMTEST_NO_D8 if you want to skip them')
       self.skipTest('wasm simd only supported in d8 for now')
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')
@@ -55,6 +57,8 @@ def wasm_simd(f):
 def bleeding_edge_wasm_backend(f):
   def decorated(self):
     if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
+      if os.getenv('EMTEST_NO_D8') is None:
+        raise Exception('d8 is needed to run SIMD tests, set EMTEST_NO_D8 if you want to skip them')
       self.skipTest('only works in d8 for now')
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,10 +38,10 @@ logger = logging.getLogger("test_core")
 
 def wasm_simd(f):
   def decorated(self):
-    if not V8_ENGINE or V8_ENGINE not in JS_ENGINES:
-      if os.getenv('EMTEST_NO_D8') is None:
-        raise Exception('d8 is needed to run SIMD tests, set EMTEST_NO_D8 if you want to skip them')
-      self.skipTest('wasm simd only supported in d8 for now')
+    if os.getenv('EMTEST_NO_D8'):
+      self.skipTest('Skipped because EMTEST_NO_D8 is set')
+    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
+      self.fail('wasm simd only supported in d8 but d8 is not found (set EMTEST_NO_D8 to skip these tests)')
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')
     if '-O3' in self.emcc_args:
@@ -56,6 +56,10 @@ def wasm_simd(f):
 
 def bleeding_edge_wasm_backend(f):
   def decorated(self):
+    if os.getenv('EMTEST_NO_D8'):
+      self.skipTest('Skipped because EMTEST_NO_D8 is set')
+    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
+      self.fail('only works in d8 for now but d8 is not found (set EMTEST_NO_D8 to skip these tests)')
     if not V8_ENGINE or V8_ENGINE not in JS_ENGINES:
       self.skipTest('wasm2js only supports MVP for now')
     self.js_engines = [config.V8_ENGINE]
@@ -64,8 +68,6 @@ def bleeding_edge_wasm_backend(f):
 
 
 def also_with_wasm_bigint(f):
-  def decorated(self):
-    self.set_setting('WASM_BIGINT', 0)
     f(self)
     if self.is_wasm():
       self.set_setting('WASM_BIGINT')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,9 +38,9 @@ logger = logging.getLogger("test_core")
 
 def wasm_simd(f):
   def decorated(self):
+    if os.getenv('EMTEST_NO_D8'):
+      unittest.skip('Skipped because EMTEST_NO_D8 is set')
     if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
-      if os.getenv('EMTEST_NO_D8') is None:
-        raise Exception('d8 is needed to run SIMD tests, set EMTEST_NO_D8 if you want to skip them')
       self.skipTest('wasm simd only supported in d8 for now')
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')
@@ -56,9 +56,9 @@ def wasm_simd(f):
 
 def bleeding_edge_wasm_backend(f):
   def decorated(self):
+    if os.getenv('EMTEST_NO_D8'):
+      unittest.skip('Skipped because EMTEST_NO_D8 is set')
     if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
-      if os.getenv('EMTEST_NO_D8') is None:
-        raise Exception('d8 is needed to run SIMD tests, set EMTEST_NO_D8 if you want to skip them')
       self.skipTest('only works in d8 for now')
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')


### PR DESCRIPTION
This makes that the tests throws errors if we try to run SIMD  tests while d8 is not installed. It also adds the environment variable `EMTEST_NO_D8`, which when set makes the code silently skip these tests and not throw errors.

Let me know if anything is wrong or could be improved.

Fixes #12369 