### PR TITLE
Remove unnecessary use of PTHREAD_CREATE_JOINABLE in test code. NFC.

### DIFF
--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -938,7 +938,6 @@ int proxy_main(int argc, char** argv) {
   if (emscripten_has_threading_support()) {
     pthread_attr_t attr;
     pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
     // Use TOTAL_STACK for the stack size, which is the normal size of the stack
     // that main() would have without PROXY_TO_PTHREAD.
     pthread_attr_setstacksize(&attr, EM_ASM_INT({ return TOTAL_STACK }));

--- a/tests/core/pthread/create.cpp
+++ b/tests/core/pthread/create.cpp
@@ -30,13 +30,9 @@ pthread_t thread[NUM_THREADS];
 
 void CreateThread(int i)
 {
-  pthread_attr_t attr;
-  pthread_attr_init(&attr);
-  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   static int counter = 1;
-  int rc = pthread_create(&thread[i], &attr, ThreadMain, (void*)i);
+  int rc = pthread_create(&thread[i], nullptr, ThreadMain, (void*)i);
   assert(rc == 0);
-  pthread_attr_destroy(&attr);
 }
 
 void mainn() {

--- a/tests/gl_in_pthread.cpp
+++ b/tests/gl_in_pthread.cpp
@@ -67,7 +67,6 @@ void CreateThread()
   pthread_attr_t attr;
   pthread_attr_init(&attr);
   emscripten_pthread_attr_settransferredcanvases(&attr, "#canvas");
-  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   int rc = pthread_create(&thread, &attr, ThreadMain, 0);
   if (rc == ENOSYS)
   {

--- a/tests/gl_in_two_pthreads.cpp
+++ b/tests/gl_in_two_pthreads.cpp
@@ -51,7 +51,6 @@ void run_thread(int param)
   pthread_attr_t attr;
   pthread_attr_init(&attr);
   emscripten_pthread_attr_settransferredcanvases(&attr, "#canvas");
-  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
   pthread_t thread;
   int rc = pthread_create(&thread, &attr, thread_main, (void*)param);
   assert(rc == 0);

--- a/tests/pthread/test_pthread_64bit_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_atomics.cpp
@@ -91,7 +91,6 @@ void RunTest(int test)
 {	
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	pthread_attr_setstacksize(&attr, 4*1024);
 
 	printf("Main thread has thread ID %d\n", (int)pthread_self());

--- a/tests/pthread/test_pthread_atomics.cpp
+++ b/tests/pthread/test_pthread_atomics.cpp
@@ -103,7 +103,6 @@ void RunTest(int test)
 {	
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	pthread_attr_setstacksize(&attr, 4*1024);
 
 	printf("Main thread has thread ID %d\n", (int)pthread_self());

--- a/tests/pthread/test_pthread_attr_getstack.cpp
+++ b/tests/pthread/test_pthread_attr_getstack.cpp
@@ -52,14 +52,10 @@ int main()
 	}
 
 	pthread_t thread;
-	pthread_attr_t attr;
 	int rc, result;
 
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-	rc = pthread_create(&thread, &attr, ThreadMain, NULL);
+	rc = pthread_create(&thread, NULL, ThreadMain, NULL);
 	assert(rc == 0);
-	pthread_attr_destroy(&attr);
 
 	rc = pthread_join(thread, (void**)&result);
 	assert(rc == 0);

--- a/tests/pthread/test_pthread_condition_variable.cpp
+++ b/tests/pthread/test_pthread_condition_variable.cpp
@@ -80,18 +80,15 @@ int main (int argc, char *argv[])
   int i, rc;
   long t1=1, t2=2, t3=3;
   pthread_t threads[3];
-  pthread_attr_t attr;
 
   /* Initialize mutex and condition variable objects */
   pthread_mutex_init(&count_mutex, NULL);
   pthread_cond_init (&count_threshold_cv, NULL);
 
   /* For portability, explicitly create threads in a joinable state */
-  pthread_attr_init(&attr);
-  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-  pthread_create(&threads[0], &attr, watch_count, (void *)t1);
-  pthread_create(&threads[1], &attr, inc_count, (void *)t2);
-  pthread_create(&threads[2], &attr, inc_count, (void *)t3);
+  pthread_create(&threads[0], NULL, watch_count, (void *)t1);
+  pthread_create(&threads[1], NULL, inc_count, (void *)t2);
+  pthread_create(&threads[2], NULL, inc_count, (void *)t3);
 
   if (emscripten_has_threading_support())
   {
@@ -103,7 +100,6 @@ int main (int argc, char *argv[])
   }
 
   /* Clean up and exit */
-  pthread_attr_destroy(&attr);
   pthread_mutex_destroy(&count_mutex);
   pthread_cond_destroy(&count_threshold_cv);
 #ifdef REPORT_RESULT

--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -61,15 +61,11 @@ int numThreadsToCreate = 1000;
 
 void CreateThread(int i)
 {
-	pthread_attr_t attr;
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	static int counter = 1;
 	global_shared_data[i] = (counter++ * 12141231) & 0x7FFFFFFF; // Arbitrary random'ish data for perturbing the sort for this thread task.
 //	EM_ASM(out('Main: Creating thread idx ' + $0 + ' (param ' + $1 + ')'), i, global_shared_data[i]);
-	int rc = pthread_create(&thread[i], &attr, ThreadMain, (void*)i);
+	int rc = pthread_create(&thread[i], NULL, ThreadMain, (void*)i);
 	assert(rc == 0);
-	pthread_attr_destroy(&attr);
 }
 
 int main()

--- a/tests/pthread/test_pthread_gcc_spinlock.cpp
+++ b/tests/pthread/test_pthread_gcc_spinlock.cpp
@@ -60,13 +60,9 @@ int main()
 
 	for(int i = 0; i < NUM_THREADS; ++i)
 	{
-		pthread_attr_t attr;
-		pthread_attr_init(&attr);
-		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-		int rc = pthread_create(&thread[i], &attr, ThreadMain, 0);
+		int rc = pthread_create(&thread[i], NULL, ThreadMain, 0);
 		if (rc != 0 || thread[i] == 0)
 			printf("Failed to create thread!\n");
-		pthread_attr_destroy(&attr);
 	}
 
 	for(int i = 0; i < NUM_THREADS; ++i)

--- a/tests/pthread/test_pthread_hardware_concurrency.cpp
+++ b/tests/pthread/test_pthread_hardware_concurrency.cpp
@@ -36,7 +36,6 @@ void RunTest(int test)
 
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	pthread_attr_setstacksize(&attr, 4*1024);
 
 	printf("Main thread has thread ID %d\n", (int)pthread_self());

--- a/tests/pthread/test_pthread_mandelbrot.cpp
+++ b/tests/pthread/test_pthread_mandelbrot.cpp
@@ -585,12 +585,8 @@ int main(int argc, char** argv)
   maxThreadsRunning = emscripten_num_logical_cores() < MAX_NUM_THREADS ? emscripten_num_logical_cores() : MAX_NUM_THREADS;
   for(int i = 0; i < maxThreadsRunning; ++i)
   {
-    pthread_attr_t attr;
-    pthread_attr_init(&attr);
-    pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-    int rc = pthread_create(&thread[i], &attr, mandelbrot_thread, (void*)i);
+    int rc = pthread_create(&thread[i], NULL, mandelbrot_thread, (void*)i);
     assert(rc == 0);
-    pthread_attr_destroy(&attr);
   }
 #endif
 

--- a/tests/pthread/test_pthread_mutex.cpp
+++ b/tests/pthread/test_pthread_mutex.cpp
@@ -47,7 +47,6 @@ void CreateThread(int i, int n)
 {
 	pthread_attr_t attr;
 	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 	pthread_attr_setstacksize(&attr, 4*1024);
 	int rc = pthread_create(&thread[i], &attr, ThreadMain, 0);
 	if (rc != 0 || thread[i] == 0)

--- a/tests/pthread/test_pthread_proxying_in_futex_wait.cpp
+++ b/tests/pthread/test_pthread_proxying_in_futex_wait.cpp
@@ -42,10 +42,7 @@ int main()
 	}
 
 	pthread_t thread;
-	pthread_attr_t attr;
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-	int rc = pthread_create(&thread, &attr, ThreadMain, 0);
+	int rc = pthread_create(&thread, NULL, ThreadMain, 0);
 	assert(rc == 0);
 	rc = emscripten_futex_wait(&main_thread_wait_val, 1, 15 * 1000);
 	// An rc of 0 means no error, and of EWOULDBLOCK means that the value is
@@ -60,7 +57,6 @@ int main()
 #endif
 		exit(1);
 	}
-	pthread_attr_destroy(&attr);
 	pthread_join(thread, 0);		
 
 #ifdef REPORT_RESULT

--- a/tests/pthread/test_pthread_run_on_main_thread.cpp
+++ b/tests/pthread/test_pthread_run_on_main_thread.cpp
@@ -147,11 +147,8 @@ int main()
 		test_sync();
 		test_async_waitable();
 
-		pthread_attr_t attr;
-		pthread_attr_init(&attr);
-		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 		pthread_t thread;
-		int rc = pthread_create(&thread, &attr, thread_main, 0);
+		int rc = pthread_create(&thread, NULL, thread_main, NULL);
 		assert(rc == 0);
 		rc = pthread_join(thread, 0);
 		assert(rc == 0);

--- a/tests/pthread/test_pthread_run_on_main_thread_flood.cpp
+++ b/tests/pthread/test_pthread_run_on_main_thread_flood.cpp
@@ -71,11 +71,8 @@ int main()
 		test_sync();
 		test_async_waitable();
 
-		pthread_attr_t attr;
-		pthread_attr_init(&attr);
-		pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
 		pthread_t thread;
-		int rc = pthread_create(&thread, &attr, thread_main, 0);
+		int rc = pthread_create(&thread, NULL, thread_main, NULL);
 		assert(rc == 0);
 		rc = pthread_join(thread, 0);
 		assert(rc == 0);

--- a/tests/pthread/test_pthread_supported.cpp
+++ b/tests/pthread/test_pthread_supported.cpp
@@ -13,18 +13,14 @@
 
 void *ThreadMain(void *arg)
 {
-	pthread_exit(0);
+	pthread_exit(NULL);
 }
 
 int main()
 {
 	pthread_t thread;
-	pthread_attr_t attr;
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-	int rc = pthread_create(&thread, &attr, ThreadMain, 0);
-	pthread_attr_destroy(&attr);
-	pthread_join(thread, 0);
+	int rc = pthread_create(&thread, NULL, ThreadMain, NULL);
+	pthread_join(thread, NULL);
 
 	if (emscripten_has_threading_support()) assert(rc == 0);
 	else assert(rc == EAGAIN);

--- a/tests/pthread/test_pthread_thread_local_storage.cpp
+++ b/tests/pthread/test_pthread_thread_local_storage.cpp
@@ -51,13 +51,9 @@ int numThreadsToCreate = 32;
 
 void CreateThread(int i)
 {
-	pthread_attr_t attr;
-	pthread_attr_init(&attr);
-	pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_JOINABLE);
-	int rc = pthread_create(&thread[i], &attr, ThreadMain, (void*)i);
+	int rc = pthread_create(&thread[i], NULL, ThreadMain, (void*)i);
 	if (emscripten_has_threading_support()) assert(rc == 0);
 	else assert(rc == EAGAIN);
-	pthread_attr_destroy(&attr);
 }
 
 int main()


### PR DESCRIPTION
Threads are joinable by default, there is no need to set
this attribute.