### PR TITLE
If async preparing wasm fails, abort() to reject the module promise

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,9 @@ Current Trunk
   (#12536)
 - emcc now accepts `--arg=foo` as well as `--arg foo`.  For example
   `--js-library=file.js`.
+- Reject promises returned from the factory function created by using the
+  MODULARIZE build option if initialization of the module instance fails
+  (#12396).
 
 2.0.7: 10/13/2020
 -----------------

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -985,7 +985,7 @@ function createWasm() {
         !isFileURI(wasmBinaryFile) &&
 #endif
         typeof fetch === 'function') {
-      fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
+      return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
         var result = WebAssembly.instantiateStreaming(response, info);
 #if USE_OFFSET_CONVERTER
         // This doesn't actually do another request, it only copies the Response object.
@@ -1091,7 +1091,12 @@ function createWasm() {
 #if RUNTIME_LOGGING
   err('asynchronously preparing wasm');
 #endif
+#if MODULARIZE
+  // If instantiation fails, reject the module ready promise.
+  instantiateAsync().catch(readyPromiseReject);
+#else
   instantiateAsync();
+#endif
 #if LOAD_SOURCE_MAP
   getSourceMapPromise().then(receiveSourceMapJSON);
 #endif

--- a/tests/browser/test_modularize_init_error.cpp
+++ b/tests/browser/test_modularize_init_error.cpp
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2020 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <emscripten.h>
+
+class ThrowsOnConstruction {
+ public:
+  ThrowsOnConstruction() {
+    EM_ASM({
+      throw "intentional error to test rejection";
+    });
+  }
+} throws_;
+
+int main() {
+  return 0;
+}


### PR DESCRIPTION
For example, if a global constructor performs an invalid memory access,
an exception will be thrown that bubbles up to receiveInstantiatedSource.
That causes a rejection of the promise returned from instantiateAsync,
which we should handle.

Fixes #12396