### PR TITLE
Implement _mm_shuffle_epi8 with wasm_v8x16_swizzle

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -807,7 +807,7 @@ The following table highlights the availability and expected performance of diff
    * - _mm_mulhrs_epi16
      - 💣 scalarized (TODO: emulatable in SIMD?)
    * - _mm_shuffle_epi8
-     - 💣 scalarized (TODO: use wasm_v8x16_swizzle when available)
+     - ⚠️ emulated with a SIMD swizzle+and+const
    * - _mm_sign_epi8
      - ⚠️ emulated with a SIMD complex shuffle+cmp+xor+andnot
    * - _mm_sign_epi16

--- a/system/include/SSE/tmmintrin.h
+++ b/system/include/SSE/tmmintrin.h
@@ -141,16 +141,7 @@ _mm_mulhrs_epi16(__m128i __a, __m128i __b)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_shuffle_epi8(__m128i __a, __m128i __b)
 {
-  // TODO: use wasm_v8x16_swizzle() when it becomes available.
-  union {
-    unsigned char __x[16];
-    __m128i __m;
-  } __src, __src2, __dst;
-  __src.__m = __a;
-  __src2.__m = __b;
-  for(int __i = 0; __i < 16; ++__i)
-      __dst.__x[__i] = (__src2.__x[__i] & 0x80) ? 0 : __src.__x[__src2.__x[__i]&15];
-  return __dst.__m;
+  return (__m128i)wasm_v8x16_swizzle((v128_t)__a, (v128_t)_mm_and_si128(__b, _mm_set1_epi8(0x8F)));
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))


### PR DESCRIPTION
Use `wasm_v8x16_swizzle` to avoid scalarization