### PR TITLE
Avoid scalarization in _mm_mulhi_*

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -536,9 +536,9 @@ The following table highlights the availability and expected performance of diff
    * - _mm_mul_sd
      - ⚠️ emulated with a shuffle
    * - _mm_mulhi_epi16
-     - ❌ scalarized
+     - ⚠️ emulated with a SIMD four widen+two mul+generic shuffle
    * - _mm_mulhi_epu16
-     - ❌ scalarized
+     - ⚠️ emulated with a SIMD four widen+two mul+generic shuffle
    * - _mm_mullo_epi16
      - ✅ wasm_i16x8_mul
    * - _mm_or_pd

--- a/system/include/SSE/emmintrin.h
+++ b/system/include/SSE/emmintrin.h
@@ -712,31 +712,21 @@ _mm_min_epu8(__m128i __a, __m128i __b)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_mulhi_epi16(__m128i __a, __m128i __b)
 {
-  // TODO: optimize
-  union {
-    signed short x[8];
-    __m128i m;
-  } src, src2, dst;
-  src.m = __a;
-  src2.m = __b;
-  for(int i = 0; i < 8; ++i)
-    dst.x[i] = (signed short)(((int)src.x[i] * (int)src2.x[i]) >> 16);
-  return dst.m;
+  const v128_t lo = wasm_i32x4_mul(wasm_i32x4_widen_low_i16x8((v128_t)__a),
+                                   wasm_i32x4_widen_low_i16x8((v128_t)__b));
+  const v128_t hi = wasm_i32x4_mul(wasm_i32x4_widen_high_i16x8((v128_t)__a),
+                                   wasm_i32x4_widen_high_i16x8((v128_t)__b));
+  return (__m128i)wasm_v16x8_shuffle(lo, hi, 1, 3, 5, 7, 9, 11, 13, 15);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_mulhi_epu16(__m128i __a, __m128i __b)
 {
-  // TODO: optimize
-  union {
-    unsigned short x[8];
-    __m128i m;
-  } src, src2, dst;
-  src.m = __a;
-  src2.m = __b;
-  for(int i = 0; i < 8; ++i)
-    dst.x[i] = (unsigned short)(((int)src.x[i] * (int)src2.x[i]) >> 16);
-  return dst.m;
+  const v128_t lo = wasm_i32x4_mul(wasm_i32x4_widen_low_u16x8((v128_t)__a),
+                                   wasm_i32x4_widen_low_u16x8((v128_t)__b));
+  const v128_t hi = wasm_i32x4_mul(wasm_i32x4_widen_high_u16x8((v128_t)__a),
+                                   wasm_i32x4_widen_high_u16x8((v128_t)__b));
+  return (__m128i)wasm_v16x8_shuffle(lo, hi, 1, 3, 5, 7, 9, 11, 13, 15);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))


### PR DESCRIPTION
Emulate `_mm_mulhi_epi16` and `_mm_mulhi_epu16` with SIMD instructions