### PR TITLE
Optimize _mm_sign_epi* intrinsics

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -809,11 +809,11 @@ The following table highlights the availability and expected performance of diff
    * - _mm_shuffle_epi8
      - 💣 scalarized (TODO: use wasm_v8x16_swizzle when available)
    * - _mm_sign_epi8
-     - ⚠️ emulated with a SIMD complex shuffle+cmp+xor+andnot
+     - ⚠️ emulated with SIMD two cmp+two logical+add
    * - _mm_sign_epi16
-     - ⚠️ emulated with a SIMD shr+cmp+xor+andnot
+     - ⚠️ emulated with SIMD two cmp+two logical+add
    * - _mm_sign_epi32
-     - ⚠️ emulated with a SIMD shr+cmp+xor+andnot
+     - ⚠️ emulated with SIMD two cmp+two logical+add
 
 ⚫ The SSSE3 functions that deal with 64-bit wide MMX registers are not available:
  -  _mm_abs_pi8, _mm_abs_pi16, _mm_abs_pi32, _mm_alignr_pi8, _mm_hadd_pi16, _mm_hadd_pi32, _mm_hadds_pi16, _mm_hsub_pi16, _mm_hsub_pi32, _mm_hsubs_pi16, _mm_maddubs_pi16, _mm_mulhrs_pi16, _mm_shuffle_pi8, _mm_sign_pi8, _mm_sign_pi16 and _mm_sign_pi32

--- a/system/include/SSE/tmmintrin.h
+++ b/system/include/SSE/tmmintrin.h
@@ -156,25 +156,28 @@ _mm_shuffle_epi8(__m128i __a, __m128i __b)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_sign_epi8(__m128i __a, __m128i __b)
 {
-  __m128i __mask = (__m128i)wasm_i8x16_shr((v128_t)__b, 7);
-  __m128i __zeromask = _mm_cmpeq_epi8(__b, _mm_setzero_si128());
-  return _mm_andnot_si128(__zeromask, _mm_xor_si128(_mm_add_epi8(__a, __mask), __mask));
+  const __m128i __zero = _mm_setzero_si128();
+  __a = _mm_andnot_si128(_mm_cmpeq_epi8(__b, __zero), __a);
+  const __m128i __mask = _mm_cmpgt_epi8(__zero, __b);
+  return _mm_xor_si128(_mm_add_epi8(__a, __mask), __mask);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_sign_epi16(__m128i __a, __m128i __b)
 {
-  __m128i __mask = _mm_srai_epi16(__b, 15);
-  __m128i __zeromask = _mm_cmpeq_epi16(__b, _mm_setzero_si128());
-  return _mm_andnot_si128(__zeromask, _mm_xor_si128(_mm_add_epi16(__a, __mask), __mask));
+  const __m128i __zero = _mm_setzero_si128();
+  __a = _mm_andnot_si128(_mm_cmpeq_epi16(__b, __zero), __a);
+  const __m128i __mask = _mm_cmpgt_epi16(__zero, __b);
+  return _mm_xor_si128(_mm_add_epi16(__a, __mask), __mask);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_sign_epi32(__m128i __a, __m128i __b)
 {
-  __m128i __mask = _mm_srai_epi32(__b, 31);
-  __m128i __zeromask = _mm_cmpeq_epi32(__b, _mm_setzero_si128());
-  return _mm_andnot_si128(__zeromask, _mm_xor_si128(_mm_add_epi32(__a, __mask), __mask));
+  const __m128i __zero = _mm_setzero_si128();
+  __a = _mm_andnot_si128(_mm_cmpeq_epi32(__b, __zero), __a);
+  const __m128i __mask = _mm_cmpgt_epi32(__zero, __b);
+  return _mm_xor_si128(_mm_add_epi32(__a, __mask), __mask);
 }
 
 // Unavailable functions:


### PR DESCRIPTION
Replace arithmetic shift with compare for less than:
- SSE4-level x86 doesn't include right shift for 8-bit integers
- CPUs commonly have more SIMD ALUs than SIMD Shift units, so compare is cheaper than shift