### PR TITLE
Avoid scalarization in _mm_cmpeq_epi64

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -849,7 +849,7 @@ The following table highlights the availability and expected performance of diff
    * - _mm_ceil_ss
      - ❌ scalarized
    * - _mm_cmpeq_epi64
-     - ❌ scalarized
+     - ⚠️ emulated with a SIMD cmp+and+shuffle
    * - _mm_cvtepi16_epi32
      - ✅ wasm_i32x4_widen_low_i16x8
    * - _mm_cvtepi16_epi64

--- a/system/include/SSE/smmintrin.h
+++ b/system/include/SSE/smmintrin.h
@@ -379,7 +379,8 @@ _mm_test_mix_ones_zeros(__m128i __a, __m128i __mask)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cmpeq_epi64(__m128i __a, __m128i __b)
 {
-  return (__m128i)((__i64x2)__a == (__i64x2)__b);
+  const __m128i __mask = _mm_cmpeq_epi32(__a, __b);
+  return _mm_and_si128(__mask, _mm_shuffle_epi32(__mask, _MM_SHUFFLE(2, 3, 0, 1)));
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))


### PR DESCRIPTION
Replace scalarized implementation of `_mm_cmpeq_epi64` with a SIMD version