### PR TITLE
Remove zeroes binary from test_archive_non_objects

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7154,14 +7154,11 @@ end
 
   def test_archive_non_objects(self):
     create_test_file('file.txt', 'test file')
-    # llvm-nm has issues with files that start with two or more null bytes since it thinks they
-    # are COFF files.  Ensure that we correctly ignore such files when we process them.
-    create_test_file('zeros.bin', '\0\0\0\0')
     self.run_process([EMCC, '-c', path_from_root('tests', 'hello_world.c')])
     # No index added.
     # --format=darwin (the default on OSX has a strange issue where it add extra
     # newlines to files: https://bugs.llvm.org/show_bug.cgi?id=42562
-    self.run_process([EMAR, 'crS', '--format=gnu', 'libfoo.a', 'file.txt', 'zeros.bin', 'hello_world.o'])
+    self.run_process([EMAR, 'crS', '--format=gnu', 'libfoo.a', 'file.txt', 'hello_world.o'])
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), 'libfoo.a'])
 
   def test_flag_aliases(self):


### PR DESCRIPTION
This test was added in #10300 to check if we can handle non-objects in
archives, especially rust metadata files that start with two leading
zeroes. LLVM's file magic identifier [thinks](https://github.com/llvm/llvm-project/blob/8fb2a235b0f22dedba72b8b559ba33171a8dcd09/llvm/lib/BinaryFormat/Magic.cpp#L58-L60) files with two leading
zeroes are COFF files. But Rust metadata files used to start with two
leading zeroes too, resulting in an error in LLVM tools. So #10300
bypassed use of `llvm-nm` to avoid that.

We were still using `llvm-ranlib`, which also ran the LLVM magic
identifier when trying to create a symbol table for an object, but
`llvm-ranlib` so far has ignored those errors. But recently
https://github.com/llvm/llvm-project/commit/a20168d0307860047ad7c8a2074f98fc25b057c2
made them explicit errors, so we couldn't run `llvm-ranlib` anymore with
archives containing objects that start with two leading zeroes.

But this is not relevant anymore because Rust fixed their object file
format in rust-lang/rust#66235, so their files are not mistaken by LLVM
for COFF files anymore. So this PR fixes this test to not include a
binary with two leading zeros, while still testing archival of
non-object files.