### PR TITLE
Avoid scalarization in SSE4 widening intrinsics

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -853,27 +853,27 @@ The following table highlights the availability and expected performance of diff
    * - _mm_cvtepi16_epi32
      - ✅ wasm_i32x4_widen_low_i16x8
    * - _mm_cvtepi16_epi64
-     - ❌ scalarized
+     - ⚠️ emulated with a SIMD widen+const+cmp+shuffle
    * - _mm_cvtepi32_epi64
-     - ❌ scalarized
+     - ⚠️ emulated with SIMD const+cmp+shuffle
    * - _mm_cvtepi8_epi16
      - ✅ wasm_i16x8_widen_low_i8x16
    * - _mm_cvtepi8_epi32
-     - ❌ scalarized
+     - ⚠️ emulated with two SIMD widens
    * - _mm_cvtepi8_epi64
-     - ❌ scalarized
+     - ⚠️ emulated with two SIMD widens+const+cmp+shuffle
    * - _mm_cvtepu16_epi32
      - ✅ wasm_i32x4_widen_low_u16x8
    * - _mm_cvtepu16_epi64
-     - ❌ scalarized
+     - ⚠️ emulated with SIMD const+two shuffles
    * - _mm_cvtepu32_epi64
-     - ❌ scalarized
+     - ⚠️ emulated with SIMD const+shuffle
    * - _mm_cvtepu8_epi16
      - ✅ wasm_i16x8_widen_low_u8x16
    * - _mm_cvtepu8_epi32
-     - ❌ scalarized
+     - ⚠️ emulated with two SIMD widens
    * - _mm_cvtepu8_epi64
-     - ❌ scalarized
+     - ⚠️ emulated with SIMD const+three shuffles
    * - _mm_dp_pd
      - ⚠️ emulated with SIMD mul+add+setzero+2xblend
    * - _mm_dp_ps

--- a/system/include/SSE/smmintrin.h
+++ b/system/include/SSE/smmintrin.h
@@ -385,73 +385,81 @@ _mm_cmpeq_epi64(__m128i __a, __m128i __b)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepi8_epi16(__m128i __a)
 {
-  return (__m128i)wasm_i16x8_widen_low_i8x16(__a);
+  return (__m128i)wasm_i16x8_widen_low_i8x16((v128_t)__a);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepi8_epi32(__m128i __a)
 {
-  return (__m128i)__builtin_convertvector(__builtin_shufflevector((__i8x16)__a, (__i8x16)__a, 0, 1, 2, 3), __i32x4);
+  return (__m128i)wasm_i32x4_widen_low_i16x8(wasm_i16x8_widen_low_i8x16((v128_t)__a));
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepi8_epi64(__m128i __a)
 {
-  return (__m128i)__builtin_convertvector(__builtin_shufflevector((__i8x16)__a, (__i8x16)__a, 0, 1), __i64x2);
+  const __m128i __exta = _mm_cvtepi8_epi32(__a);
+  const __m128i __sign = _mm_cmpgt_epi32(_mm_setzero_si128(), __exta);
+  return _mm_unpacklo_epi32(__exta, __sign);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepi16_epi32(__m128i __a)
 {
-  return (__m128i)wasm_i32x4_widen_low_i16x8(__a);
+  return (__m128i)wasm_i32x4_widen_low_i16x8((v128_t)__a);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepi16_epi64(__m128i __a)
 {
-  return (__m128i)__builtin_convertvector(__builtin_shufflevector((__i16x8)__a, (__i16x8)__a, 0, 1), __i64x2);
+  const __m128i __exta = _mm_cvtepi16_epi32(__a);
+  const __m128i __sign = _mm_cmpgt_epi32(_mm_setzero_si128(), __exta);
+  return _mm_unpacklo_epi32(__exta, __sign);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepi32_epi64(__m128i __a)
 {
-  return (__m128i)__builtin_convertvector(__builtin_shufflevector((__i32x4)__a, (__i32x4)__a, 0, 1), __i64x2);
+  const __m128i __sign = _mm_cmpgt_epi32(_mm_setzero_si128(), __a);
+  return _mm_unpacklo_epi32(__a, __sign);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepu8_epi16(__m128i __a)
 {
-  return (__m128i)wasm_i16x8_widen_low_u8x16(__a);
+  return (__m128i)wasm_i16x8_widen_low_u8x16((v128_t)__a);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepu8_epi32(__m128i __a)
 {
-  return (__m128i)__builtin_convertvector(__builtin_shufflevector((__u8x16)__a, (__u8x16)__a, 0, 1, 2, 3), __i32x4);
+  return (__m128i)wasm_i32x4_widen_low_u16x8(wasm_i16x8_widen_low_u8x16((v128_t)__a));
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepu8_epi64(__m128i __a)
 {
-  return (__m128i)__builtin_convertvector(__builtin_shufflevector((__u8x16)__a, (__u8x16)__a, 0, 1), __i64x2);
+  const __m128i __zero = _mm_setzero_si128();
+  return _mm_unpacklo_epi32(_mm_unpacklo_epi16(_mm_unpacklo_epi8(__a, __zero), __zero), __zero);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepu16_epi32(__m128i __a)
 {
-  return (__m128i)wasm_i32x4_widen_low_u16x8(__a);
+  return (__m128i)wasm_i32x4_widen_low_u16x8((v128_t)__a);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepu16_epi64(__m128i __a)
 {
-  return (__m128i)__builtin_convertvector(__builtin_shufflevector((__u16x8)__a, (__u16x8)__a, 0, 1), __i64x2);
+  const __m128i __zero = _mm_setzero_si128();
+  return _mm_unpacklo_epi32(_mm_unpacklo_epi16(__a, __zero), __zero);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cvtepu32_epi64(__m128i __a)
 {
-  return (__m128i)__builtin_convertvector(__builtin_shufflevector((__u32x4)__a, (__u32x4)__a, 0, 1), __i64x2);
+  const __m128i __zero = _mm_setzero_si128();
+  return _mm_unpacklo_epi32(__a, __zero);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))


### PR DESCRIPTION
Replace scalarized implementations with SIMD