### PR TITLE
Document and test that PROXY_TO_PTHREAD fixes the pthread_create issue

### DIFF
--- a/site/source/docs/porting/pthreads.rst
+++ b/site/source/docs/porting/pthreads.rst
@@ -35,6 +35,8 @@ Additional flags
   result, your application's ``main()`` is run off the browser main (UI) thread,
   which is good for responsiveness. The browser main thread does still run code
   when things are proxied to it, for example to handle events, rendering, etc.
+  The main thread also does things like create pthreads for you, so that you
+  can depend on them synchronously.
 
 Note that Emscripten has the
 ``--proxy-to-worker`` :ref:`linker flag <proxy-to-worker>` which sounds similar
@@ -117,7 +119,22 @@ Special considerations
 
 The Emscripten implementation for the pthreads API should follow the POSIX standard closely, but some behavioral differences do exist:
 
-- When the linker flag ``-s PTHREAD_POOL_SIZE=<integer>`` is not specified and ``pthread_create()`` is called, the new thread will not start until control is yielded back to the browser's main event loop, because the web worker cannot be created while JS or wasm code is running. This is a violation of POSIX behavior and will break common code which creates a thread and immediately joins it or otherwise synchronously waits to observe an effect such as a memory write. Using a pool creates the web workers before main is called, allowing thread creation to be synchronous.
+- When ``pthread_create()`` is called, if we need to create a new Web Worker,
+  then that requires returning the main event loop. That is, you cannot call
+  ``pthread_create`` and then keep running code synchronously that expects the
+  worker to start running - it will only run after you return to the event loop.
+  This is a violation of POSIX behavior and will break common code which creates
+  a thread and immediately joins it or otherwise synchronously waits to observe
+  an effect such as a memory write. There are several solutions to this:
+
+  1. Return to the main event loop (for example, use
+     ``emscripten_set_main_loop``, or Asyncify).
+  2. Use the linker flag ``-s PTHREAD_POOL_SIZE=<integer>``. Using a pool
+     creates the Web Workers before main is called, so they can just be used
+     when ``pthread_create`` is called.
+  3. Use the linker flag ``-s PROXY_TO_PTHREAD``, which will run ``main()`` on
+     a worker for you. When doing so, ``pthread_create`` is proxied to the
+     main browser thread, where it can return to the main event loop as needed.
 
 - The Emscripten implementation does not support `POSIX signals <http://man7.org/linux/man-pages/man7/signal.7.html>`_, which are sometimes used in conjunction with pthreads. This is because it is not possible to send signals to web workers and pre-empt their execution. The only exception to this is pthread_kill() which can be used as normal to forcibly terminate a running thread.
 

--- a/tests/core/pthread/create.cpp
+++ b/tests/core/pthread/create.cpp
@@ -43,7 +43,7 @@ void mainn() {
   printf("main iter %d : %d\n", main_adds, worker_adds);
   if (worker_adds == NUM_THREADS * TOTAL) {
     printf("done!\n");
-#ifndef POOL
+#ifndef ALLOW_SYNC
   emscripten_cancel_main_loop();
 #else
   exit(0);
@@ -57,8 +57,9 @@ int main() {
     CreateThread(i);
   }
 
-  // Without a pool, the event loop must be reached for the worker to start up.
-#ifndef POOL
+  // if we don't allow sync pthread creation, the event loop must be reached for
+  // the worker to start up.
+#ifndef ALLOW_SYNC
   emscripten_set_main_loop(mainn, 0, 0);
 #else
   while (1) mainn();

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8164,17 +8164,21 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_pthread_create(self):
-    self.set_setting('-lbrowser.js')
+    self.do_run_in_out_file_test('tests', 'core', 'pthread', 'create.cpp')
 
-    def test():
-      self.do_run_in_out_file_test('tests', 'core', 'pthread', 'create.cpp')
-    test()
-
-    print('with pool')
+  @node_pthreads
+  def test_pthread_create_pool(self):
     # with a pool, we can synchronously depend on workers being available
     self.set_setting('PTHREAD_POOL_SIZE', '2')
-    self.emcc_args += ['-DPOOL']
-    test()
+    self.emcc_args += ['-DALLOW_SYNC']
+    self.do_run_in_out_file_test('tests', 'core', 'pthread', 'create.cpp')
+
+  @node_pthreads
+  def test_pthread_create_proxy(self):
+    # with PROXY_TO_PTHREAD, we can synchronously depend on workers being available
+    self.set_setting('PROXY_TO_PTHREAD', '1')
+    self.emcc_args += ['-DALLOW_SYNC']
+    self.do_run_in_out_file_test('tests', 'core', 'pthread', 'create.cpp')
 
   @node_pthreads
   def test_pthread_exceptions(self):


### PR DESCRIPTION
That is, `pthread_create` in that mode works as expected, with the pthread being
synchronously available (since the creation is proxied to the main runtime thread,
which can spin the browser event loop to create the worker).

Related to discussion in #11554