### PR TITLE
Fix segfaults in some pthread_stub methods

### DIFF
--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -309,6 +309,8 @@ int pthread_key_create(pthread_key_t* key, void (*destructor)(void*)) {
 }
 
 int pthread_key_delete(pthread_key_t key) {
+  if (key == 0)
+    return EINVAL;
   uintptr_t* tls = (uintptr_t*)key;
   if (tls[1] != PTHREAD_TLS_MAGIC_ID)
     return EINVAL;
@@ -318,6 +320,8 @@ int pthread_key_delete(pthread_key_t key) {
 }
 
 void* pthread_getspecific(pthread_key_t key) {
+  if (key == 0)
+    return NULL;
   uintptr_t* tls = (uintptr_t*)key;
   if (tls[1] != PTHREAD_TLS_MAGIC_ID)
     return NULL;
@@ -325,6 +329,8 @@ void* pthread_getspecific(pthread_key_t key) {
 }
 
 int pthread_setspecific(pthread_key_t key, const void* value) {
+  if (key == 0)
+    return EINVAL;
   uintptr_t* tls = (uintptr_t*)key;
   if (tls[1] != PTHREAD_TLS_MAGIC_ID)
     return EINVAL;


### PR DESCRIPTION
Noticed by `SAFE_HEAP`. It's ok to pass a null pointer to these, and they
should ignore it.