### PR TITLE
Fix SAFE_HEAP handling of sbrk

### DIFF
--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -172,7 +172,7 @@ var wasmOffsetConverter;
 var __ATEXIT__    = []; // functions called during shutdown
 #endif
 
-#if ASSERTIONS
+#if ASSERTIONS || SAFE_HEAP
 var runtimeInitialized = false;
 
 // This is always false in minimal_runtime - the runtime does not have a concept of exiting (keeping this variable here for now since it is referenced from generated code)

--- a/src/runtime_safe_heap.js
+++ b/src/runtime_safe_heap.js
@@ -106,16 +106,19 @@ function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
 #if SAFE_HEAP_LOG
   out('SAFE_HEAP store: ' + [dest, value, bytes, isFloat, SAFE_HEAP_COUNTER++]);
 #endif
-  var brk = _sbrk() >>> 0;
   if (dest <= 0) abort('segmentation fault storing ' + bytes + ' bytes to address ' + dest);
   if (dest % bytes !== 0) abort('alignment error storing to address ' + dest + ', which was expected to be aligned to a multiple of ' + bytes);
-  if (dest + bytes > brk) abort('segmentation fault, exceeded the top of the available dynamic heap when storing ' + bytes + ' bytes to address ' + dest + '. DYNAMICTOP=' + brk);
-  assert(brk >= STACK_BASE); // sbrk-managed memory must be above the stack
-  assert(brk <= HEAP8.length);
+  if (runtimeInitialized) {
+    var brk = _sbrk() >>> 0;
+    if (dest + bytes > brk) abort('segmentation fault, exceeded the top of the available dynamic heap when storing ' + bytes + ' bytes to address ' + dest + '. DYNAMICTOP=' + brk);
+    assert(brk >= STACK_BASE); // sbrk-managed memory must be above the stack
+    assert(brk <= HEAP8.length);
+  }
   setValue(dest, value, getSafeHeapType(bytes, isFloat), 1);
+  return value;
 }
 function SAFE_HEAP_STORE_D(dest, value, bytes) {
-  SAFE_HEAP_STORE(dest, value, bytes, true);
+  return SAFE_HEAP_STORE(dest, value, bytes, true);
 }
 
 /** @param {number|boolean=} isFloat */
@@ -123,12 +126,14 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned, isFloat) {
 #if CAN_ADDRESS_2GB
   dest >>>= 0;
 #endif
-  var brk = _sbrk() >>> 0;
   if (dest <= 0) abort('segmentation fault loading ' + bytes + ' bytes from address ' + dest);
   if (dest % bytes !== 0) abort('alignment error loading from address ' + dest + ', which was expected to be aligned to a multiple of ' + bytes);
-  if (dest + bytes > brk) abort('segmentation fault, exceeded the top of the available dynamic heap when loading ' + bytes + ' bytes from address ' + dest + '. DYNAMICTOP=' + brk);
-  assert(brk >= STACK_BASE); // sbrk-managed memory must be above the stack
-  assert(brk <= HEAP8.length);
+  if (runtimeInitialized) {
+    var brk = _sbrk() >>> 0;
+    if (dest + bytes > brk) abort('segmentation fault, exceeded the top of the available dynamic heap when loading ' + bytes + ' bytes from address ' + dest + '. DYNAMICTOP=' + brk);
+    assert(brk >= STACK_BASE); // sbrk-managed memory must be above the stack
+    assert(brk <= HEAP8.length);
+  }
   var type = getSafeHeapType(bytes, isFloat);
   var ret = getValue(dest, type, 1);
   if (unsigned) ret = unSign(ret, parseInt(type.substr(1), 10));


### PR DESCRIPTION
It can only be called if the runtime is initialized.

Make minimal runtime track whether the runtime was initialized, which it
only does in special modes.