### PR TITLE
Remove use of set-env in github actions

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -17,7 +17,7 @@ jobs:
       run: |
         make dist
         version=`cat emscripten-version.txt | sed s/\"//g`
-        echo "::set-env name=VERSION::$version"
+        echo "VERSION=$version" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v1
       with:
         name: emscripten-${{ env.VERSION }}


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/