### PR TITLE
Fix ABORT_ON_WASM_EXCEPTIONS wrapper function caching to work with Safari/Firefox

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -678,47 +678,39 @@ function createExportWrapper(name, fixedasm) {
 // we know to ignore exceptions from there since they're handled by callMain directly.
 var abortWrapperDepth = 0;
 
-// A cache for wrappers based on the original function reference so we don't end up
-// creating the same wrappers over and over again
-var abortWrapperCache = {};
-
 // Creates a wrapper in a closure so that each wrapper gets it's own copy of 'original'
-function makeWrapper(original) {
-  var wrapper = abortWrapperCache[original];
-  if (!wrapper) {
-    wrapper = abortWrapperCache[original] = function() {
-      // Don't allow this function to be called if we're aborted!
-      if (ABORT) {
-        throw "program has already aborted!";
-      }
+function makeAbortWrapper(original) {
+  return function() {
+    // Don't allow this function to be called if we're aborted!
+    if (ABORT) {
+      throw "program has already aborted!";
+    }
 
 #if DISABLE_EXCEPTION_CATCHING != 1
-      abortWrapperDepth += 1;
+    abortWrapperDepth += 1;
 #endif
-      try {
-        return original.apply(null, arguments);
-      }
-      catch (e) {
-        if (
-          ABORT // rethrow exception if abort() was called in the original function call above
-          || abortWrapperDepth > 1 // rethrow exceptions not caught at the top level if exception catching is enabled; rethrow from exceptions from within callMain
+    try {
+      return original.apply(null, arguments);
+    }
+    catch (e) {
+      if (
+        ABORT // rethrow exception if abort() was called in the original function call above
+        || abortWrapperDepth > 1 // rethrow exceptions not caught at the top level if exception catching is enabled; rethrow from exceptions from within callMain
 #if SUPPORT_LONGJMP
-          || e === 'longjmp' // rethrow longjmp if enabled
+        || e === 'longjmp' // rethrow longjmp if enabled
 #endif
-        ) {
-          throw e;
-        }
+      ) {
+        throw e;
+      }
 
-        abort("unhandled exception: " + [e, e.stack]);
-      }
+      abort("unhandled exception: " + [e, e.stack]);
+    }
 #if DISABLE_EXCEPTION_CATCHING != 1
-      finally {
-        abortWrapperDepth -= 1;
-      }
+    finally {
+      abortWrapperDepth -= 1;
+    }
 #endif
-    };
-  }
-  return wrapper;
+    }
 }
 
 // Instrument all the exported functions to:
@@ -726,13 +718,12 @@ function makeWrapper(original) {
 // - throw an exception if someone tries to call them after the program has aborted
 // See settings.ABORT_ON_WASM_EXCEPTIONS for more info.
 function instrumentWasmExportsWithAbort(exports) {
-
   // Override the exported functions with the wrappers and copy over any other symbols
   var instExports = {};
   for (var name in exports) {
       var original = exports[name];
       if (typeof original === 'function') {
-        instExports[name] = makeWrapper(original);
+        instExports[name] = makeAbortWrapper(original);
       } else {
         instExports[name] = original;
       }
@@ -744,8 +735,17 @@ function instrumentWasmExportsWithAbort(exports) {
 function instrumentWasmTableWithAbort() {
   // Override the wasmTable get function to return the wrappers
   var realGet = wasmTable.get;
+  var wrapperCache = {};
   wasmTable.get = function(i) {
-    return makeWrapper(realGet.call(wasmTable, i));
+    var func = realGet.call(wasmTable, i);
+    var cached = wrapperCache[i];
+    if (!cached || cached.func !== func) {
+      cached = wrapperCache[i] = {
+        func: func,
+        wrapper: makeAbortWrapper(func)
+      }
+    }
+    return cached.wrapper;
   };
 }
 #endif


### PR DESCRIPTION
The previous version used function references as cache keys, which works fine in Chrome, but fails in Safari/Firefox when used with WASM functions (from wasmTable) as they all toString() the same.

The cache now uses either the export name or the wasmTable index as the key.