### PR TITLE
Don't generate a UI event if the page is unloading

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -733,12 +733,16 @@ var LibraryJSEvents = {
         // causing a new scroll, etc..
         return;
       }
+      var b = document.body; // Take document.body to a variable, Closure compiler does not outline access to it on its own.
+      if (!b) {
+        // During a page unload 'body' can be null, with "Cannot read property 'clientWidth' of null" being thrown
+        return;
+      }
 #if USE_PTHREADS
       var uiEvent = targetThread ? _malloc( {{{ C_STRUCTS.EmscriptenUiEvent.__size__ }}} ) : JSEvents.uiEvent;
 #else
       var uiEvent = JSEvents.uiEvent;
 #endif
-      var b = document.body; // Take document.body to a variable, Closure compiler does not outline access to it on its own.
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.detail, 'e.detail', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientWidth, 'b.clientWidth', 'i32') }}};
       {{{ makeSetValue('uiEvent', C_STRUCTS.EmscriptenUiEvent.documentBodyClientHeight, 'b.clientHeight', 'i32') }}};


### PR DESCRIPTION
We see in our (Rollbar) logs many `Cannot read property 'clientWidth' of null` errors, which are caused by resize and other events still firing as the page is unloading. This minor change takes an early-out if `document.body` is `null` (which happens during unload).