### PR TITLE
Simplify windows and mac builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ commands:
             # For some reason this seems to deadlock while accessing the
             # cache direcotry on windows.  Adding EMCC_DEBUG makes it work so
             # debugging the issue is tricky.
-            [ "$CIRCLE_JOB" != "build-windows" ] && $PYTHON_BIN ./tools/gen_struct_info.py > out.json
+            [ "$CIRCLE_JOB" != "test-windows" ] && $PYTHON_BIN ./tools/gen_struct_info.py > out.json
             $PYTHON_BIN ./emcc.py --clear-cache
   build-libs-and-freeze:
     description: "Build all libraries, and freeze the cache"
@@ -409,7 +409,9 @@ jobs:
     executor: bionic
     steps:
       - test-sockets-chrome
-  build-windows:
+  # windows and mac do not have separate build and test jobs, as they only run
+  # a limited set of tests; it is simpler and faster to do it all in one job.
+  test-windows:
     executor:
       name: win/vs2019
       shell: bash.exe -eo pipefail
@@ -419,6 +421,9 @@ jobs:
       PYTHON_BIN: "python"
       PYTHONUNBUFFERED: "1"
       EMSDK_NOTTY: "1"
+      # clang can compile but not link in the current setup, see
+      # https://github.com/emscripten-core/emscripten/pull/11382#pullrequestreview-428902638
+      EMTEST_LACKS_NATIVE_CLANG: "1"
     steps:
       - checkout
       - run:
@@ -432,33 +437,9 @@ jobs:
       - build
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
-      - persist
-  test-minimal-windows:
-    environment:
-      # on windows the python binary is always called python.exe and never
-      # python3.exe
-      PYTHON_BIN: "python"
-      PYTHONUNBUFFERED: "1"
-      EMSDK_NOTTY: "1"
-      # clang can compile but not link in the current setup, see
-      # https://github.com/emscripten-core/emscripten/pull/11382#pullrequestreview-428902638
-      EMTEST_LACKS_NATIVE_CLANG: "1"
-    executor:
-      name: win/vs2019
-      shell: bash.exe -eo pipefail
-    steps:
-      # while these two steps are also done in build-windows, they are needed
-      - run:
-          name: Install packages
-          command: |
-            choco install make cmake.portable
-            choco install python --version 3.8.0
-      - run:
-          name: Add python to bash path
-          command: echo "export PATH=\"$PATH:/c/python38/\"" >> $BASH_ENV
       - run-tests:
           test_targets: "other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null"
-  build-mac:
+  test-mac:
     executor: mac
     steps:
       - run:
@@ -470,10 +451,6 @@ jobs:
       - build
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
-      - persist
-  test-other-mac:
-    executor: mac
-    steps:
       - run-tests-mac:
           test_targets: "other wasm0.test_lua wasm0.test_longjmp_standalone wasm2.test_sse1 skip:other.test_native_link_error_message"
 
@@ -510,11 +487,5 @@ workflows:
       - test-sockets-chrome:
           requires:
             - build-linux
-      - build-windows
-      - test-minimal-windows:
-          requires:
-            - build-windows
-      - build-mac
-      - test-other-mac:
-          requires:
-            - build-mac
+      - test-windows
+      - test-mac

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,8 @@ commands:
       - emsdk-env
       - npm-install
       - run:
-          name: gen_struct_info
+          name: clear cache
           command: |
-            # We've had issues in the past with building struct info when the
-            # cache is completely empty.  So specific test creating struct
-            # info first.
-            # For some reason this seems to deadlock while accessing the
-            # cache direcotry on windows.  Adding EMCC_DEBUG makes it work so
-            # debugging the issue is tricky.
-            [ "$CIRCLE_JOB" != "test-windows" ] && $PYTHON_BIN ./tools/gen_struct_info.py > out.json
             $PYTHON_BIN ./emcc.py --clear-cache
   build-libs-and-freeze:
     description: "Build all libraries, and freeze the cache"


### PR DESCRIPTION
They each had a single test job. Merge the build+test jobs into a single job,
which is simpler (less code in the circleci config) and also faster (avoids
the overhead of starting a second job, a second install of `choco` packages,
and persisting and unpersisting data).

This would be a bad idea if we intend to have multiple test jobs for
those OSes. Is there any reason to expect that?