### PR TITLE
WIP: Add clang-format to github actions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,4 +4,10 @@ IndentCaseLabels: true
 ColumnLimit: 100
 ContinuationIndentWidth: 2
 ConstructorInitializerIndentWidth: 2
-AlignAfterOpenBracket: DontAlign
+SpaceAfterTemplateKeyword: false
+BinPackArguments: false
+BinPackParameters: false
+---
+Language: JavaScript
+DisableFormat: true
+---

--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,0 +1,4 @@
+# ignore third_party code from clang-format checks
+third_party/*
+tests/third_party/*
+tests/*

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -1,4 +1,4 @@
-name: CI
+name: archive
 
 on:
   create:

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,17 @@
+name: clang-format
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      # Fetch all history for all tags and branches
+      with:
+        fetch-depth: 0
+    - name: Install clang-format
+      run: |
+        sudo apt-get install clang-format-10
+        sudo update-alternatives --install /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-10 100
+    - run: tests/clang-format-diff.sh origin/$GITHUB_BASE_REF

--- a/tests/clang-format-diff.sh
+++ b/tests/clang-format-diff.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Based on binaryen/scripts/clang-format-diff.sh
+# TODO(sbc): Switch to pre-packaged github actions once we find one that
+# is mature enough for our needs.
+
+set -o errexit
+
+if [ "$#" -gt 0 ]; then
+  BRANCH=$1
+else
+  BRANCH=origin/master
+fi
+
+MERGE_BASE=$(git merge-base $BRANCH HEAD)
+FORMAT_MSG=$(git clang-format $MERGE_BASE -q --diff)
+if [ -n "$FORMAT_MSG" -a "$FORMAT_MSG" != "no modified files to format" ]
+then
+  echo "Please run git clang-format before committing, or apply this diff:"
+  echo
+  # Run git clang-format again, this time without capruting stdout.  This way
+  # clang-format format the message nicely and add color.
+  git clang-format $MERGE_BASE -q --diff
+  exit 1
+fi


### PR DESCRIPTION
I would have prefered to use an actual pre-packaged github
action for this.  There seem to be very many of these but
none of them seems to have the most important feature here
which is the ability to run just on the diff and not on the
entire repo.

This probably shouldn't land until we figure out exactly
what parts of the tree we want to run this on.

I'm thinking probably `tests` but also any part of `system`
that are emscripten-local.

We also might want to do a quick first pass at formatting
these things before landing this.