### PR TITLE
Fix a merge conflict with landed pthreads testing PRs

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8198,10 +8198,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['-DALLOW_SYNC']
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'create.cpp')
 
+  @node_pthreads
+  def test_pthread_create_embind_stack_check(self):
     print('with embind and stack overflow checks (see #12356)')
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.emcc_args += ['--bind']
-    test()
+    self.do_run_in_out_file_test('tests', 'core', 'pthread', 'create.cpp')
 
   @node_pthreads
   def test_pthread_exceptions(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8200,7 +8200,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_pthread_create_embind_stack_check(self):
-    print('with embind and stack overflow checks (see #12356)')
+    # embind should work with stack overflow checks (see #12356)
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.emcc_args += ['--bind']
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'create.cpp')


### PR DESCRIPTION
One PR refactored the `pthread_create` tests, and another appended
to them. To fix it, create a new test for the new mode.