### PR TITLE
Don't link in C++ mode by default in STRICT mode

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- In STRICT mode we no longer link in C++ mode by default.  This means if you
+  are building a C++ program in STRICT mode you need to link via `em++` rather
+  than `emcc`.  This matches the behaviour of gcc and clang.
 - IDBFS now persists files whenever their timestamp changes; previously it acted
   on sync only if the timestamp increased and ignored the file changes otherwise.
 - When `-s SUPPORT_LONGJMP=0` is passed to disable longjmp, do not run the LLVM

--- a/emcc.py
+++ b/emcc.py
@@ -2096,8 +2096,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
         extra_files_to_link = system_libs.get_ports(shared.Settings)
         if '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
-          # TODO(sbc): Only set link_as_cxx when run_via_emxx
-          link_as_cxx = '-nostdlib++' not in newargs
+          link_as_cxx = run_via_emxx
+          # Traditionally we always link as C++.  For compatibility we continue to do that,
+          # unless running in strict mode.
+          if not shared.Settings.STRICT and '-nostdlib++' not in newargs:
+            link_as_cxx = True
           extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, link_as_cxx, forced=forced_stdlibs)
         linker_inputs += extra_files_to_link
 

--- a/tests/hello_world.cpp
+++ b/tests/hello_world.cpp
@@ -3,12 +3,11 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
-#include <stdio.h>
-
-class Test {}; // This will fail in C mode
+#include <iostream>
+#include <string>
 
 int main() {
-  printf("hello, world!\n");
+  std::cout << std::string("hello, world!\n");
   return 0;
 }
 

--- a/tests/hello_world.cpp
+++ b/tests/hello_world.cpp
@@ -3,11 +3,12 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
-#include <iostream>
-#include <string>
+#include <stdio.h>
+
+class Test {}; // This will fail in C mode
 
 int main() {
-  std::cout << std::string("hello, world!\n");
+  printf("hello, world!\n");
   return 0;
 }
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -246,6 +246,26 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   @parameterized({
     'c': [EMCC, '.c'],
     'cxx': [EMXX, '.cpp']})
+  def test_emcc_2(self, compiler, suffix):
+    # emcc src.cpp -c    and   emcc src.cpp -o src.[o|bc] ==> should give a .bc file
+    for args in [[], ['-o', 'src.o'], ['-o', 'src.bc'], ['-o', 'src.so']]:
+      print('args:', args)
+      target = args[1] if len(args) == 2 else 'hello_world.o'
+      self.clear()
+      self.run_process([compiler, '-c', path_from_root('tests', 'hello_world' + suffix)] + args)
+      syms = building.llvm_nm(target)
+      self.assertIn('main', syms.defs)
+      # wasm backend will also have '__original_main' or such
+      self.assertEqual(len(syms.defs), 2)
+      if target == 'js': # make sure emcc can recognize the target as a bitcode file
+        shutil.move(target, target + '.bc')
+        target += '.bc'
+      self.run_process([compiler, target, '-o', target + '.js'])
+      self.assertContained('hello, world!', self.run_js(target + '.js'))
+
+  @parameterized({
+    'c': [EMCC, '.c'],
+    'cxx': [EMXX, '.cpp']})
   def test_emcc_3(self, compiler, suffix):
     # handle singleton archives
     self.run_process([compiler, '-c', path_from_root('tests', 'hello_world' + suffix), '-o', 'a.o'])
@@ -6332,7 +6352,7 @@ int main() {
       print(args, expect_names)
       try_delete('a.out.js')
       # we use dlmalloc here, as emmalloc has a bunch of asserts that contain the text "malloc" in them, which makes counting harder
-      self.run_process([EMCC, path_from_root('tests', 'hello_world.c')] + args + ['-s', 'MALLOC="dlmalloc"', '-s', 'EXPORTED_FUNCTIONS=[_main,_malloc]'])
+      self.run_process([EMCC, path_from_root('tests', 'hello_world.cpp')] + args + ['-s', 'MALLOC="dlmalloc"', '-s', 'EXPORTED_FUNCTIONS=[_main,_malloc]'])
       code = open('a.out.wasm', 'rb').read()
       if expect_names:
         # name section adds the name of malloc (there is also another one for the export)
@@ -8300,8 +8320,8 @@ int main () {
 
   def test_strict_mode_link_cxx(self):
     # In strict mode C++ programs fail to link unless run with `em++`.
-    self.run_process([EMXX, '-sSTRICT', path_from_root('tests', 'hello_world.cpp')])
-    err = self.expect_fail([EMCC, '-sSTRICT', path_from_root('tests', 'hello_world.cpp')])
+    self.run_process([EMXX, '-sSTRICT', path_from_root('tests', 'hello_libcxx.cpp')])
+    err = self.expect_fail([EMCC, '-sSTRICT', path_from_root('tests', 'hello_libcxx.cpp')])
     self.assertContained('error: undefined symbol:', err)
 
   def test_safe_heap_log(self):


### PR DESCRIPTION
This makes STRICT mode behave more like gcc and clang
and not link in C++ mode unless run via the C++ driver.