### PR TITLE
[runner.py] Do not silently ignore incorrect command line skips

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1761,13 +1761,19 @@ def skip_requested_tests(args, modules):
       which = [arg.split('skip:')[1]]
 
       print(','.join(which), file=sys.stderr)
+      skipped = False
       for test in which:
         print('will skip "%s"' % test, file=sys.stderr)
         suite_name, test_name = test.split('.')
         for m in modules:
-          suite = getattr(m, suite_name)
-          setattr(suite, test_name, lambda s: s.skipTest("requested to be skipped"))
-          break
+          try:
+            suite = getattr(m, suite_name)
+            setattr(suite, test_name, lambda s: s.skipTest("requested to be skipped"))
+            skipped = True
+            break
+          except AttributeError:
+            pass
+      assert skipped, "Not able to skip test " + test
       args[i] = None
   return [a for a in args if a is not None]
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1765,12 +1765,9 @@ def skip_requested_tests(args, modules):
         print('will skip "%s"' % test, file=sys.stderr)
         suite_name, test_name = test.split('.')
         for m in modules:
-          try:
-            suite = getattr(m, suite_name)
-            setattr(suite, test_name, lambda s: s.skipTest("requested to be skipped"))
-            break
-          except AttributeError:
-            pass
+          suite = getattr(m, suite_name)
+          setattr(suite, test_name, lambda s: s.skipTest("requested to be skipped"))
+          break
       args[i] = None
   return [a for a in args if a is not None]
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1766,13 +1766,11 @@ def skip_requested_tests(args, modules):
         print('will skip "%s"' % test, file=sys.stderr)
         suite_name, test_name = test.split('.')
         for m in modules:
-          try:
-            suite = getattr(m, suite_name)
+          suite = getattr(m, suite_name, None)
+          if suite:
             setattr(suite, test_name, lambda s: s.skipTest("requested to be skipped"))
             skipped = True
             break
-          except AttributeError:
-            pass
       assert skipped, "Not able to skip test " + test
       args[i] = None
   return [a for a in args if a is not None]


### PR DESCRIPTION
If `skip:some.test_thing` is passed on the command line, do not silently swallow
any errors that occur when trying to set it as skipped. This might help debug an
issue where the Windows roller is not correctly skipping a test that it is
supposed to be skipping.