### PR TITLE
Disable other.test_minimal_runtime_code_size on Windows

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8036,6 +8036,11 @@ int main () {
         test(['-s', 'WASM=0'], closure, opt)
         test(['-s', 'WASM_ASYNC_COMPILATION=0'], closure, opt)
 
+  # TODO: Debug why the code size is different on Windows. Also, for some
+  # unknown reason (at time of writing), this test is not skipped on the Windows
+  # autoroller, despite the bot being correctly configured to skip this test.
+  # The no_windows decorator also solves that problem.
+  @no_windows("Code size is slightly different on Windows")
   def test_minimal_runtime_code_size(self):
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'ENVIRONMENT=web',


### PR DESCRIPTION
Code size is slightly different on Windows for unknown reasons and the Windows
autoroller is not skipping this test even though it is configured to do so. As a
result, the autoroller is currently failing to roll in LLVM. We don't know why
either of these issues occur, so although it would be nice to figure them out,
this PR simply disables the problematic test on Windows as a workaround.