### PR TITLE
Show a clear compile error on pthreads+MODULARIZE without EXPORT_NAME

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1595,9 +1595,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         include_and_export('getNoExitRuntime')
 
       if shared.Settings.MODULARIZE:
-        # MODULARIZE+USE_PTHREADS mode requires EXPORT_NAME to be customized
-        # becauase of how the external worker.js file communicates with the
-        # Module.
         if shared.Settings.EXPORT_NAME == 'Module':
           exit_with_error('pthreads + MODULARIZE currently require you to set -s EXPORT_NAME=Something (see settings.js) to Something != Module, so that the .worker.js file can work')
 

--- a/emcc.py
+++ b/emcc.py
@@ -1595,6 +1595,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         include_and_export('getNoExitRuntime')
 
       if shared.Settings.MODULARIZE:
+        # MODULARIZE+USE_PTHREADS mode requires EXPORT_NAME to be customized
+        # becauase of how the external worker.js file communicates with the
+        # Module.
+        if shared.Settings.EXPORT_NAME == 'Module':
+          exit_with_error('pthreads + MODULARIZE currently require you to set -s EXPORT_NAME=Something (see settings.js) to Something != Module, so that the .worker.js file can work')
+
         # MODULARIZE+USE_PTHREADS mode requires extra exports out to Module so that worker.js
         # can access them:
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -189,9 +189,11 @@ class other(RunnerCore):
     # self.assertContained('hello, world!', self.run_js('hello_world.mjs'))
 
   def test_emcc_output_worker_mjs(self):
-    self.run_process([EMCC, '-o', 'hello_world.mjs', '-pthread', '-O1', path_from_root('tests', 'hello_world.c')])
+    self.run_process([EMCC, '-o', 'hello_world.mjs', '-pthread', '-O1',
+                      path_from_root('tests', 'hello_world.c'),
+                      '-s', 'EXPORT_NAME=FooModule'])
     with open('hello_world.mjs') as f:
-      self.assertContained('export default Module;', f.read())
+      self.assertContained('export default FooModule;', f.read())
     with open('hello_world.worker.js') as f:
       self.assertContained('import(', f.read())
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9441,3 +9441,8 @@ exec "$@"
     stderr = self.run_process([EMCC, 'a.o', '-s', 'SUPPORT_LONGJMP=0'], stderr=PIPE, check=False).stderr
     self.assertContained('error: longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)',
                          stderr)
+
+  def test_pthread_MODULARIZE(self):
+    stderr = self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-pthread', '-sMODULARIZE'], stderr=PIPE, check=False).stderr
+    self.assertContained('pthreads + MODULARIZE currently require you to set -s EXPORT_NAME=Something (see settings.js) to Something != Module, so that the .worker.js file can work',
+                         stderr)


### PR DESCRIPTION
This is better than a cryptic error at runtime.