### PR TITLE
Remove EM_LOG_DEMANGLE

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,9 @@ See docs/process.md for how version tagging works.
 
 Current Trunk
 -------------
+- EM_LOG_DEMANGLE is now deprecated.  Function names shown in wasm backtraces
+  are never mangled (they are either missing or demangled already) so demangled
+  is not possible anymore.
 - In STRICT mode we no longer link in C++ mode by default.  This means if you
   are building a C++ program in STRICT mode you need to link via `em++` rather
   than `emcc`.  This matches the behaviour of gcc and clang.

--- a/site/source/api_items.py
+++ b/site/source/api_items.py
@@ -66,7 +66,6 @@ def get_mapped_items():
     mapped_wiki_inline_code['EM_JS'] = ':c:macro:`EM_JS`'
     mapped_wiki_inline_code['EM_LOG_CONSOLE'] = ':c:macro:`EM_LOG_CONSOLE`'
     mapped_wiki_inline_code['EM_LOG_C_STACK'] = ':c:macro:`EM_LOG_C_STACK`'
-    mapped_wiki_inline_code['EM_LOG_DEMANGLE'] = ':c:macro:`EM_LOG_DEMANGLE`'
     mapped_wiki_inline_code['EM_LOG_ERROR'] = ':c:macro:`EM_LOG_ERROR`'
     mapped_wiki_inline_code['EM_LOG_FUNC_PARAMS'] = ':c:macro:`EM_LOG_FUNC_PARAMS`'
     mapped_wiki_inline_code['EM_LOG_JS_STACK'] = ':c:macro:`EM_LOG_JS_STACK`'

--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1011,10 +1011,6 @@ Defines
 
   If specified, prints a call stack that contains file names referring to lines in the built .js/.html file along with the message. The flags :c:data:`EM_LOG_C_STACK` and :c:data:`EM_LOG_JS_STACK` can be combined to output both untranslated and translated file and line information.
 
-.. c:macro:: EM_LOG_DEMANGLE
-
-  If specified, C/C++ function names are de-mangled before printing. Otherwise, the mangled post-compilation JavaScript function names are displayed.
-
 .. c:macro:: EM_LOG_NO_PATHS
 
   If specified, the pathnames of the file information in the call stack will be omitted.

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -243,7 +243,7 @@ char *emscripten_get_preloaded_image_data_from_FILE(FILE *file, int *w, int *h);
 #define EM_LOG_ERROR     4
 #define EM_LOG_C_STACK   8
 #define EM_LOG_JS_STACK 16
-#define EM_LOG_DEMANGLE 32
+#define EM_LOG_DEMANGLE 32  // deprecated
 #define EM_LOG_NO_PATHS 64
 #define EM_LOG_FUNC_PARAMS 128
 #define EM_LOG_DEBUG    256

--- a/tests/emscripten_log/emscripten_log.cpp
+++ b/tests/emscripten_log/emscripten_log.cpp
@@ -37,13 +37,13 @@ void __attribute__((noinline)) kitten()
 	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_CONSOLE | EM_LOG_DEBUG, "Debug message to console.");
 
 	// Log to with full callstack information (both original C source and JS callstacks):
-	emscripten_log(EM_LOG_C_STACK | EM_LOG_JS_STACK | EM_LOG_DEMANGLE, "A message with as full call stack information as possible:");
+	emscripten_log(EM_LOG_C_STACK | EM_LOG_JS_STACK, "A message with as full call stack information as possible:");
 
 	// Log with just mangled JS callstacks:
 	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_JS_STACK, "This is a message with a mangled JS callstack:");
 
 	// Log only clean C callstack:
-	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_C_STACK | EM_LOG_DEMANGLE, "This message should have a clean C callstack:");
+	emscripten_log(EM_LOG_NO_PATHS | EM_LOG_C_STACK, "This message should have a clean C callstack:");
 }
 
 void __attribute__((noinline)) bar(int = 0, char * = 0, double = 0) // Arbitrary function signature to add some content to callstack.
@@ -53,7 +53,7 @@ void __attribute__((noinline)) bar(int = 0, char * = 0, double = 0) // Arbitrary
 	else
 		MYASSERT(1 == 1, "");
 
-	int flags = EM_LOG_NO_PATHS | EM_LOG_JS_STACK | EM_LOG_DEMANGLE | EM_LOG_FUNC_PARAMS;
+	int flags = EM_LOG_NO_PATHS | EM_LOG_JS_STACK | EM_LOG_FUNC_PARAMS;
 #ifndef RUN_FROM_JS_SHELL
 	flags |= EM_LOG_C_STACK;
 #endif
@@ -97,7 +97,7 @@ void __attribute__((noinline)) bar(int = 0, char * = 0, double = 0) // Arbitrary
 	// Test that obtaining a truncated callstack works. (https://github.com/emscripten-core/emscripten/issues/2171)
 	char *buffer = new char[21];
 	buffer[20] = 0x01; // Magic sentinel that should not change its value.
-	emscripten_get_callstack(EM_LOG_C_STACK | EM_LOG_DEMANGLE | EM_LOG_NO_PATHS | EM_LOG_FUNC_PARAMS, buffer, 20);
+	emscripten_get_callstack(EM_LOG_C_STACK | EM_LOG_NO_PATHS | EM_LOG_FUNC_PARAMS, buffer, 20);
 	MYASSERT(!!strstr(buffer, "at bar(int,"), "Truncated callstack was %s!", buffer);
 	MYASSERT(buffer[20] == 0x01, "");
 	delete[] buffer;
@@ -157,7 +157,7 @@ void DoubleTest() {
 int main()
 {
 	int test = 123;
-	emscripten_log(EM_LOG_FUNC_PARAMS | EM_LOG_DEMANGLE | EM_LOG_CONSOLE, "test print %d\n", test);
+	emscripten_log(EM_LOG_FUNC_PARAMS | EM_LOG_CONSOLE, "test print %d\n", test);
 
 	Foo<int>();
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -196,7 +196,7 @@ If manually bisecting:
 
   def test_emscripten_log(self):
     create_test_file('src.cpp', self.with_report_result(open(path_from_root('tests', 'emscripten_log', 'emscripten_log.cpp')).read()))
-    self.compile_btest(['src.cpp', '--pre-js', path_from_root('src', 'emscripten-source-map.min.js'), '-g4', '-o', 'page.html', '-s', 'DEMANGLE_SUPPORT=1'])
+    self.compile_btest(['src.cpp', '--pre-js', path_from_root('src', 'emscripten-source-map.min.js'), '-g4', '-o', 'page.html'])
     self.run_browser('page.html', None, '/report_result?1')
 
   def test_preload_file(self):


### PR DESCRIPTION
When displaying a callstack from a wasm module names will either
not appear at all or they will be populated from the wasm names
section which never contains managled names.

As far as I can tell mangled names no longer appear in backtraces
so demanagling is no longer a useful feature.