### PR TITLE
Disable other.test_minimal_runtime_code_size on Mac

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -171,7 +171,7 @@ def disabled(note=''):
 
 def no_mac(note=''):
   assert not callable(note)
-  if MAC:
+  if MACOS:
     return unittest.skip(note)
   return lambda f: f
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -63,7 +63,7 @@ import parallel_testsuite
 from jsrun import NON_ZERO
 from tools.shared import EM_CONFIG, TEMP_DIR, EMCC, EMXX, DEBUG
 from tools.shared import EMSCRIPTEN_TEMP_DIR
-from tools.shared import WINDOWS
+from tools.shared import MACOS, WINDOWS
 from tools.shared import EM_BUILD_VERBOSE
 from tools.shared import asstr, get_canonical_temp_dir, try_delete
 from tools.shared import asbytes, Settings

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -169,6 +169,13 @@ def disabled(note=''):
   return unittest.skip(note)
 
 
+def no_mac(note=''):
+  assert not callable(note)
+  if MAC:
+    return unittest.skip(note)
+  return lambda f: f
+
+
 def no_windows(note=''):
   assert not callable(note)
   if WINDOWS:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -33,7 +33,7 @@ from tools.shared import EMCC, EMXX, EMAR, EMRANLIB, PYTHON, FILE_PACKAGER, WIND
 from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP
 from tools.shared import NODE_JS, JS_ENGINES, WASM_ENGINES, V8_ENGINE
 from runner import RunnerCore, path_from_root, is_slow_test, ensure_dir, disabled, make_executable
-from runner import env_modify, no_windows, requires_native_clang, chdir, with_env_modify, create_test_file, parameterized
+from runner import env_modify, no_mac, no_windows, requires_native_clang, chdir, with_env_modify, create_test_file, parameterized
 from runner import js_engines_modify, NON_ZERO
 from tools import shared, building
 import jsrun

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8051,11 +8051,12 @@ int main () {
         test(['-s', 'WASM=0'], closure, opt)
         test(['-s', 'WASM_ASYNC_COMPILATION=0'], closure, opt)
 
-  # TODO: Debug why the code size is different on Windows. Also, for some
-  # unknown reason (at time of writing), this test is not skipped on the Windows
-  # autoroller, despite the bot being correctly configured to skip this test.
-  # The no_windows decorator also solves that problem.
+  # TODO: Debug why the code size is different on Windows and Mac. Also, for
+  # some unknown reason (at time of writing), this test is not skipped on the
+  # Windows autoroller, despite the bot being correctly configured to skip this
+  # test. The no_windows decorator also solves that problem.
   @no_windows("Code size is slightly different on Windows")
+  @no_mac("Code size is slightly different on Mac")
   def test_minimal_runtime_code_size(self):
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'ENVIRONMENT=web',

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8053,8 +8053,9 @@ int main () {
 
   # TODO: Debug why the code size is different on Windows and Mac. Also, for
   # some unknown reason (at time of writing), this test is not skipped on the
-  # autoroller, despite the bot being correctly configured to skip this test.
-  # The no_windows decorator also solves that problem.
+  # Windows and Mac autorollers, despite the bot being correctly configured to
+  # skip this test in all three platforms (Linux, Mac, and Windows).
+  # The no_windows/no_mac decorators also solve that problem.
   @no_windows("Code size is slightly different on Windows")
   @no_mac("Code size is slightly different on Mac")
   def test_minimal_runtime_code_size(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8053,8 +8053,8 @@ int main () {
 
   # TODO: Debug why the code size is different on Windows and Mac. Also, for
   # some unknown reason (at time of writing), this test is not skipped on the
-  # Windows autoroller, despite the bot being correctly configured to skip this
-  # test. The no_windows decorator also solves that problem.
+  # autoroller, despite the bot being correctly configured to skip this test.
+  # The no_windows decorator also solves that problem.
   @no_windows("Code size is slightly different on Windows")
   @no_mac("Code size is slightly different on Mac")
   def test_minimal_runtime_code_size(self):


### PR DESCRIPTION
After #12464, small code size regression also happened on Mac. Not sure
what the exact reason is, but this just disables it to make the
autoroller work again.

Failure log: https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket.appspot.com/8866979228011064752/+/steps/Emscripten_testsuite__upstream__other_/0/stdout