### PR TITLE
Formatting cleanups for MINIMAL_RUNTIME output. NFC.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -45,7 +45,7 @@ def compute_minimal_runtime_initializer_and_exports(post, initializers, exports,
   exports_that_are_not_initializers = [x for x in exports if x not in initializers]
   # In Wasm backend the exports are still unmangled at this point, so mangle the names here
   exports_that_are_not_initializers = [asmjs_mangle(x) for x in exports_that_are_not_initializers]
-  post = post.replace('/*** ASM_MODULE_EXPORTS_DECLARES ***/', 'var ' + ','.join(exports_that_are_not_initializers) + ';')
+  post = post.replace('/*** ASM_MODULE_EXPORTS_DECLARES ***/', 'var ' + ',\n  '.join(exports_that_are_not_initializers) + ';')
 
   # Generate assignments from all asm.js/wasm exports out to the JS variables above: e.g. a = asm['a']; b = asm['b'];
   post = post.replace('/*** ASM_MODULE_EXPORTS ***/', receiving)
@@ -844,7 +844,10 @@ def create_receiving(exports, initializers):
   else:
     receiving += make_export_wrappers(exports, delay_assignment)
 
-  return '\n'.join(receiving) + '\n'
+  if shared.Settings.MINIMAL_RUNTIME:
+    return '\n  '.join(receiving) + '\n'
+  else:
+    return '\n'.join(receiving) + '\n'
 
 
 def create_module(sending, receiving, invoke_funcs, metadata):

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -15,34 +15,36 @@ function run() {
 #endif
 
 #if STACK_OVERFLOW_CHECK >= 2
-    ___set_stack_limits(STACK_BASE, STACK_MAX);
+  ___set_stack_limits(STACK_BASE, STACK_MAX);
 #endif
 
 #if PROXY_TO_PTHREAD
-    // User requested the PROXY_TO_PTHREAD option, so call a stub main which pthread_create()s a new thread
-    // that will call the user's real main() for the application.
-    var ret = _proxy_main();
+  // User requested the PROXY_TO_PTHREAD option, so call a stub main which
+  // pthread_create()s a new thread that will call the user's real main() for
+  // the application.
+  var ret = _proxy_main();
 #else
-    var ret = _main();
+  var ret = _main();
 
 #if EXIT_RUNTIME
-    callRuntimeCallbacks(__ATEXIT__);
-    {{{ getQuoted('ATEXITS') }}}
+  callRuntimeCallbacks(__ATEXIT__);
+  {{{ getQuoted('ATEXITS') }}}
 #if USE_PTHREADS
-    PThread.runExitHandlers();
+  PThread.runExitHandlers();
 #endif
 #endif
 
 #if IN_TEST_HARNESS
-    // fflush() filesystem stdio for test harness, since there are existing tests that depend on this behavior.
-    // For production use, instead print full lines to avoid this kind of lazy behavior.
-    if (typeof _fflush !== 'undefined') _fflush();
+  // fflush() filesystem stdio for test harness, since there are existing
+  // tests that depend on this behavior.
+  // For production use, instead print full lines to avoid this kind of lazy
+  // behavior.
+  if (typeof _fflush !== 'undefined') _fflush();
 #endif
 
 #if ASSERTIONS
-    runtimeExited = true;
+  runtimeExited = true;
 #endif
-
 #endif
 
 #if STACK_OVERFLOW_CHECK
@@ -69,7 +71,8 @@ function initRuntime(asm) {
     return;
   }
 
-  // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
+  // Pass the thread address inside the asm.js scope to store it for fast access
+  // that avoids the need for a FFI out.
   registerPthreadPtr(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
   _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);
 #endif
@@ -109,8 +112,9 @@ function loadWasmModuleToWorkers() {
 #else
   var numWorkersToLoad = PThread.unusedWorkers.length;
   PThread.unusedWorkers.forEach(function(w) { PThread.loadWasmModuleToWorker(w, function() {
-    // PTHREAD_POOL_DELAY_LOAD==0: we wanted to synchronously wait until the Worker pool
-    // has loaded up. If all Workers have finished loading up the Wasm Module, proceed with main()
+    // PTHREAD_POOL_DELAY_LOAD==0: we wanted to synchronously wait until the
+    // Worker pool has loaded up. If all Workers have finished loading up the
+    // Wasm Module, proceed with main()
     if (!--numWorkersToLoad) ready();
   })});
 #endif
@@ -130,7 +134,8 @@ function loadWasmModuleToWorkers() {
 // Node.js and Safari do not support instantiateStreaming.
 #if MIN_FIREFOX_VERSION < 58 || MIN_CHROME_VERSION < 61 || ENVIRONMENT_MAY_BE_NODE || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED
 #if ASSERTIONS && !WASM2JS
-// Module['wasm'] should contain a typed array of the Wasm object data, or a precompiled WebAssembly Module.
+// Module['wasm'] should contain a typed array of the Wasm object data, or a
+// precompiled WebAssembly Module.
 if (!WebAssembly.instantiateStreaming && !Module['wasm']) throw 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM';
 #endif
 (WebAssembly.instantiateStreaming
@@ -142,9 +147,11 @@ WebAssembly.instantiateStreaming(fetch('{{{ TARGET_BASENAME }}}.wasm'), imports)
 
 #else // Non-streaming instantiation
 #if ASSERTIONS && !WASM2JS
-// Module['wasm'] should contain a typed array of the Wasm object data, or a precompiled WebAssembly Module.
+// Module['wasm'] should contain a typed array of the Wasm object data, or a
+// precompiled WebAssembly Module.
 if (!Module['wasm']) throw 'Must load WebAssembly Module in to variable Module.wasm before adding compiled output .js script to the DOM';
 #endif
+
 WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
 #endif
 
@@ -152,26 +159,29 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
   // Export Wasm module for pthread creation to access.
   wasmModule = output.module || Module['wasm'];
 #endif
-
 #if !LibraryManager.has('library_exports.js') && !EMBIND
-  // If not using the emscripten_get_exported_function() API or embind, keep the 'asm'
-  // exports variable in local scope to this instantiate function to save code size.
-  // (otherwise access it without to export it to outer scope)
+  // If not using the emscripten_get_exported_function() API or embind, keep the
+  // 'asm' exports variable in local scope to this instantiate function to save
+  // code size.  (otherwise access it without to export it to outer scope)
   var
 #endif
-
-// WebAssembly instantiation API gotcha: if Module['wasm'] above was a typed array, then the
-// output object will have an output.instance and output.module objects. But if Module['wasm']
-// is an already compiled WebAssembly module, then output is the WebAssembly instance itself.
-// Depending on the build mode, Module['wasm'] can mean a different thing.
+  // WebAssembly instantiation API gotcha: if Module['wasm'] above was a typed
+  // array, then the output object will have an output.instance and
+  // output.module objects. But if Module['wasm'] is an already compiled
+  // WebAssembly module, then output is the WebAssembly instance itself.
+  // Depending on the build mode, Module['wasm'] can mean a different thing.
 #if MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION || MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION || USE_PTHREADS
-// https://caniuse.com/#feat=wasm and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
-// Firefox 52 added Wasm support, but only Firefox 58 added compileStreaming & instantiateStreaming.
-// Chrome 57 added Wasm support, but only Chrome 61 added compileStreaming & instantiateStreaming.
-// Node.js and Safari do not support compileStreaming or instantiateStreaming.
+  // https://caniuse.com/#feat=wasm and https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WebAssembly/instantiateStreaming
+  // Firefox 52 added Wasm support, but only Firefox 58 added compileStreaming &
+  // instantiateStreaming.
+  // Chrome 57 added Wasm support, but only Chrome 61 added compileStreaming &
+  // instantiateStreaming.
+  // Node.js and Safari do not support compileStreaming or instantiateStreaming.
 #if MIN_FIREFOX_VERSION < 58 || MIN_CHROME_VERSION < 61 || ENVIRONMENT_MAY_BE_NODE || MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED || USE_PTHREADS
-  // In pthreads, Module['wasm'] is an already compiled WebAssembly.Module. In that case, 'output' is a WebAssembly.Instance.
-  // In main thread, Module['wasm'] is either a typed array or a fetch stream. In that case, 'output.instance' is the WebAssembly.Instance.
+  // In pthreads, Module['wasm'] is an already compiled WebAssembly.Module. In
+  // that case, 'output' is a WebAssembly.Instance.
+  // In main thread, Module['wasm'] is either a typed array or a fetch stream.
+  // In that case, 'output.instance' is the WebAssembly.Instance.
   asm = (output.instance || output).exports;
 #else
   asm = output.exports;
@@ -213,9 +223,8 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
   }
 #endif
 
-})
 #if ASSERTIONS || WASM == 2
-.catch(function(error) {
+}).catch(function(error) {
 #if ASSERTIONS
   console.error(error);
 #endif
@@ -233,6 +242,5 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
   }
 #endif
 #endif // WASM == 2
-})
 #endif // ASSERTIONS || WASM == 2
-;
+});


### PR DESCRIPTION
Largely whitespace changes to make the output file more readable
without running it through a formatter.