### PR TITLE
Remove dead code in src/jsifier.js. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2876,7 +2876,7 @@ def module_export_name_substitution():
     # For Node.js and other shell environments, create an unminified Module object so that
     # loading external .asm.js file that assigns to Module['asm'] works even when Closure is used.
     if shared.Settings.MINIMAL_RUNTIME and (shared.Settings.target_environment_may_be('node') or shared.Settings.target_environment_may_be('shell')):
-      src = 'if(typeof Module==="undefined"){var Module={};}' + src
+      src = 'if(typeof Module==="undefined"){var Module={};}\n' + src
     f.write(src)
   save_intermediate('module_export_name_substitution')
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -767,7 +767,7 @@ def create_sending(invoke_funcs, metadata):
   add_standard_wasm_imports(send_items_map)
 
   sorted_keys = sorted(send_items_map.keys())
-  return '{ ' + ', '.join('"' + k + '": ' + send_items_map[k] for k in sorted_keys) + ' }'
+  return '{\n  ' + ',\n  '.join('"' + k + '": ' + send_items_map[k] for k in sorted_keys) + '\n}'
 
 
 def make_export_wrappers(exports, delay_assignment):

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -9,26 +9,11 @@
 // Convert analyzed data to javascript. Everything has already been calculated
 // before this stage, which just does the final conversion to JavaScript.
 
-// Handy sets
-
-var STRUCT_LIST = set('struct', 'list');
-
 var addedLibraryItems = {};
-
-var SETJMP_LABEL = -1;
-
-var INDENTATION = ' ';
-
-var functionStubSigs = {};
 
 // Some JS-implemented library functions are proxied to be called on the main browser thread, if the Emscripten runtime is executing in a Web Worker.
 // Each such proxied function is identified via an ordinal number (this is not the same namespace as function pointers in general).
 var proxiedFunctionTable = ["null" /* Reserve index 0 for an undefined function*/];
-
-// proxiedFunctionInvokers contains bodies of the functions that will perform the proxying. These
-// are generated in a map to keep track which ones have already been emitted, to avoid outputting duplicates.
-// map: pair(sig, syncOrAsync) -> function body
-var proxiedFunctionInvokers = {};
 
 // Used internally. set when there is a main() function.
 // Also set when in a linkable module, as the main() function might
@@ -360,7 +345,6 @@ function JSify(data, functionsOnly) {
     if (!mainPass) {
       var generated = itemsDict.function.concat(itemsDict.type).concat(itemsDict.GlobalVariableStub).concat(itemsDict.GlobalVariable);
       print(generated.map(function(item) { return item.JS; }).join('\n'));
-      print('// {{PRE_LIBRARY}}\n'); // safe to put stuff here that statically allocates
       return;
     }
 

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -5,8 +5,9 @@
  */
 
 var SyscallsLibrary = {
-  $SYSCALLS__deps: ['$PATH',
+  $SYSCALLS__deps: [
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
+                   '$PATH',
                    '$FS',
 #endif
 #if SYSCALL_DEBUG

--- a/src/modules.js
+++ b/src/modules.js
@@ -489,11 +489,10 @@ function exportRuntime() {
       }
     }
   }
-  return runtimeElements.map(function(name) {
-    return maybeExport(name);
-  }).join('\n') + runtimeNumbers.map(function(name) {
-    return maybeExportNumber(name);
-  }).join('\n');
+  var exports = runtimeElements.map(function(name) { return maybeExport(name); });
+  exports = exports.concat(runtimeNumbers.map(function(name) { return maybeExportNumber(name); }));
+  exports = exports.filter(function(name) { return name != '' });
+  return exports.join('\n');
 }
 
 var PassManager = {

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -5,7 +5,6 @@
  */
 
 // === Auto-generated postamble setup entry stuff ===
-
 {{{ exportRuntime() }}}
 
 #if hasExportedFunction('_main') // Only if user is exporting a C main(), we will generate a run() function that can be used to launch main.

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -143,12 +143,10 @@ if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
 
 #if MEM_INIT_METHOD == 1 && !MEM_INIT_IN_WASM && !SINGLE_FILE
-
 #if ASSERTIONS
 if (!Module['mem']) throw 'Must load memory initializer as an ArrayBuffer in to variable Module.mem before adding compiled output .js script to the DOM';
 #endif
 HEAPU8.set(new Uint8Array(Module['mem']), {{{ GLOBAL_BASE }}});
-
 #endif
 
 #if USE_PTHREADS && ((MEM_INIT_METHOD == 1 && !MEM_INIT_IN_WASM && !SINGLE_FILE) || USES_DYNAMIC_ALLOC)
@@ -175,7 +173,9 @@ var __ATEXIT__    = []; // functions called during shutdown
 #if ASSERTIONS || SAFE_HEAP
 var runtimeInitialized = false;
 
-// This is always false in minimal_runtime - the runtime does not have a concept of exiting (keeping this variable here for now since it is referenced from generated code)
+// This is always false in minimal_runtime - the runtime does not have a concept
+// of exiting (keeping this variable here for now since it is referenced from
+// generated code)
 var runtimeExited = false;
 #endif
 
@@ -184,7 +184,6 @@ var runtimeExited = false;
 var memoryInitializer = null;
 
 #include "memoryprofiler.js"
-
 #include "runtime_debug.js"
 
 // === Body ===

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -1,5 +1,4 @@
 /**
-d
  * @license
  * Copyright 2010 The Emscripten Authors
  * SPDX-License-Identifier: MIT


### PR DESCRIPTION
Also more cleanup on MINIMAL_RUNTIME output, including
formatting of asmLibraryArg and removal of large number
of empty lines due to runtime elements.

Avoid including $PATH when filesystem access is not needed.