### PR TITLE
Set memfile in single location. NFC.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -514,7 +514,7 @@ def finalize_wasm(infile, memfile, DEBUG):
     args.append('--no-legalize-javascript-ffi')
   else:
     modify_wasm = True
-  if not shared.Settings.MEM_INIT_IN_WASM:
+  if memfile:
     args.append('--separate-data-segments=' + memfile)
     modify_wasm = True
   if shared.Settings.SIDE_MODULE:
@@ -556,7 +556,7 @@ def finalize_wasm(infile, memfile, DEBUG):
   if write_source_map:
     building.save_intermediate(infile + '.map', 'post_finalize.map')
 
-  if not shared.Settings.MEM_INIT_IN_WASM:
+  if memfile:
     # we have a separate .mem file. binaryen did not strip any trailing zeros,
     # because it's an ABI question as to whether it is valid to do so or not.
     # we can do so here, since we make sure to zero out that memory (even in

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -624,7 +624,7 @@ function abort(what) {
   throw e;
 }
 
-var memoryInitializer = null;
+// {{MEM_INITIALIZER}}
 
 #include "memoryprofiler.js"
 

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -180,9 +180,6 @@ var runtimeExited = false;
 #endif
 
 #include "runtime_math.js"
-
-var memoryInitializer = null;
-
 #include "memoryprofiler.js"
 #include "runtime_debug.js"
 


### PR DESCRIPTION
This cleans up the handling the `memfile` a little and uses its presence
to absence to drive behaviour rather than check the various settings
in multiple places.