### PR TITLE
Add O_NOCTTY flag to nodefs flags

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -514,3 +514,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Stephan Reiter <reste@google.com> (copyright owned by Google, LLC)
 * kamenokonyokonyoko <kamenokonokotan@gmail.com>
 * Lectem <lectem@gmail.com>
+* Henrik Algestam <henrik@algestam.se>

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -20,6 +20,7 @@ mergeInto(LibraryManager.library, {
         "{{{ cDefine('O_APPEND') }}}": flags["O_APPEND"],
         "{{{ cDefine('O_CREAT') }}}": flags["O_CREAT"],
         "{{{ cDefine('O_EXCL') }}}": flags["O_EXCL"],
+        "{{{ cDefine('O_NOCTTY') }}}": flags["O_NOCTTY"],
         "{{{ cDefine('O_RDONLY') }}}": flags["O_RDONLY"],
         "{{{ cDefine('O_RDWR') }}}": flags["O_RDWR"],
         "{{{ cDefine('O_DSYNC') }}}": flags["O_SYNC"],

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -473,7 +473,8 @@
             "F_SETFD",
             "O_EXCL",
             "F_GETFL",
-            "O_LARGEFILE"
+            "O_LARGEFILE",
+            "O_NOCTTY"
         ],
         "structs": {}
     },

--- a/tests/fcntl/test_fcntl_open.out
+++ b/tests/fcntl/test_fcntl_open.out
@@ -238,6 +238,246 @@ success: 1
 errno: 0
 st_mode: 0100000
 
+EXISTING FILE 0,16
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,16
+success: 1
+errno: 0
+st_mode: 040000
+
+NON-EXISTING 0,16
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 0,17
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,17
+success: 1
+errno: 0
+st_mode: 040000
+
+NON-EXISTING 0,17
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 0,18
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,18
+success: 1
+errno: 0
+st_mode: 040000
+
+NON-EXISTING 0,18
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 0,19
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 0,19
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 0,19
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 0,20
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,20
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 0,20
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 0,21
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,21
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 0,21
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 0,22
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,22
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 0,22
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 0,23
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 0,23
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 0,23
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 0,24
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,24
+success: 1
+errno: 0
+st_mode: 040000
+
+NON-EXISTING 0,24
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 0,25
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,25
+success: 1
+errno: 0
+st_mode: 040000
+
+NON-EXISTING 0,25
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 0,26
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,26
+success: 1
+errno: 0
+st_mode: 040000
+
+NON-EXISTING 0,26
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 0,27
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 0,27
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 0,27
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 0,28
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,28
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 0,28
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 0,29
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,29
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 0,29
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 0,30
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 0,30
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 0,30
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 0,31
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 0,31
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 0,31
+success: 1
+errno: 0
+st_mode: 0100000
+
 EXISTING FILE 1,0
 success: 1
 errno: 0
@@ -478,6 +718,246 @@ success: 1
 errno: 0
 st_mode: 0100000
 
+EXISTING FILE 1,16
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,16
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,16
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 1,17
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,17
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,17
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 1,18
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,18
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,18
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 1,19
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 1,19
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 1,19
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 1,20
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,20
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,20
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 1,21
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,21
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,21
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 1,22
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,22
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,22
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 1,23
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 1,23
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 1,23
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 1,24
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,24
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,24
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 1,25
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,25
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,25
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 1,26
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,26
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,26
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 1,27
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 1,27
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 1,27
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 1,28
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,28
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,28
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 1,29
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,29
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,29
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 1,30
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 1,30
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 1,30
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 1,31
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 1,31
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 1,31
+success: 1
+errno: 0
+st_mode: 0100000
+
 EXISTING FILE 2,0
 success: 1
 errno: 0
@@ -714,6 +1194,246 @@ errno: 20
 st_mode: 040000
 
 NON-EXISTING 2,15
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 2,16
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,16
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,16
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 2,17
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,17
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,17
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 2,18
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,18
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,18
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 2,19
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 2,19
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 2,19
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 2,20
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,20
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,20
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 2,21
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,21
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,21
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 2,22
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,22
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,22
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 2,23
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 2,23
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 2,23
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 2,24
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,24
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,24
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 2,25
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,25
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,25
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 2,26
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,26
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,26
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 2,27
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 2,27
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 2,27
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 2,28
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,28
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,28
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 2,29
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,29
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,29
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FILE 2,30
+success: 1
+errno: 0
+st_mode: 0100000
+
+EXISTING FOLDER 2,30
+success: 0
+errno: 31
+st_mode: 040000
+
+NON-EXISTING 2,30
+success: 0
+errno: 44
+st_mode: 00
+
+EXISTING FILE 2,31
+success: 0
+errno: 20
+st_mode: 0100000
+
+EXISTING FOLDER 2,31
+success: 0
+errno: 20
+st_mode: 040000
+
+NON-EXISTING 2,31
 success: 1
 errno: 0
 st_mode: 0100000


### PR DESCRIPTION
This PR adds the `O_NOCTTY` flag mentioned in issue #11927.

This resolves the original problem where gzip did not compress the file but instead exited with an error (`Invalid argument`).

With this change, gzip compresses the file but reports another error (`testfile.gz: Not a directory`) which seems to be caused by the function `futimens` reporting an error when updating the timestamps of the compressed file. I'm not sure if this problem is related to the `O_NOCTTY` change or if this is a separate issue. 