### PR TITLE
Ensure EH does not change code after linking

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9011,8 +9011,6 @@ int main() {
     ok(required_flags + ['-O1'])
     # Exception support shouldn't require changes after linking
     ok(required_flags + ['-fexceptions'])
-    # longjmp support shouldn't require changes after linking
-    ok(required_flags + ['-sSUPPORT_LONGJMP=1'])
 
     # other builds fail with a standard message + extra details
     def fail(args, details):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9009,6 +9009,10 @@ int main() {
     ok(required_flags, filename='hello_world_main_loop.cpp')
     # -O1 is ok as we don't run wasm-opt there (but no higher, see below)
     ok(required_flags + ['-O1'])
+    # exception support shouldn't require change after linking
+    ok(required_flags + ['-fexceptions'])
+    # longjmp support shouldn't require change after linking
+    ok(required_flags + ['-sSUPPORT_LONGJMP=1'])
 
     # other builds fail with a standard message + extra details
     def fail(args, details):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9009,9 +9009,9 @@ int main() {
     ok(required_flags, filename='hello_world_main_loop.cpp')
     # -O1 is ok as we don't run wasm-opt there (but no higher, see below)
     ok(required_flags + ['-O1'])
-    # exception support shouldn't require change after linking
+    # Exception support shouldn't require changes after linking
     ok(required_flags + ['-fexceptions'])
-    # longjmp support shouldn't require change after linking
+    # longjmp support shouldn't require changes after linking
     ok(required_flags + ['-sSUPPORT_LONGJMP=1'])
 
     # other builds fail with a standard message + extra details


### PR DESCRIPTION
We used to require Binaryen postprocessing for EH and have a `fail`
requirement for it in `other.test_immutable_after_link`. I deleted the
requirement in #12399, but it could have been better if I didn't just
delete it but changed it to an `ok` requirement. This PR adds that.