### PR TITLE
Cleanup argument handling in emcc. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2359,6 +2359,13 @@ def parse_args(newargs):
     newargs[i] = newargs[i].strip()
     arg = newargs[i]
 
+    def check_flag(value):
+      # Check for and consume a flag
+      if arg == value:
+        newargs[i] = ''
+        return True
+      return False
+
     def check_arg(value):
       if arg.startswith(value) and '=' in arg:
         exit_with_error('Invalid parameter (do not use "=" with "--" options)')
@@ -2454,10 +2461,10 @@ def parse_args(newargs):
         # debug info during link (during compile, this does not make a
         # difference).
         shared.Settings.DEBUG_LEVEL = 3
-    elif check_arg('-profiling') or check_arg('--profiling'):
+    elif check_flag('-profiling') or check_flag('--profiling'):
       shared.Settings.DEBUG_LEVEL = max(shared.Settings.DEBUG_LEVEL, 2)
       options.profiling = True
-    elif check_arg('-profiling-funcs') or check_arg('--profiling-funcs'):
+    elif check_flag('-profiling-funcs') or check_flag('--profiling-funcs'):
       options.profiling_funcs = True
     elif newargs[i] == '--tracing' or newargs[i] == '--memoryprofiler':
       if newargs[i] == '--memoryprofiler':
@@ -2466,10 +2473,10 @@ def parse_args(newargs):
       newargs[i] = ''
       settings_changes.append("EMSCRIPTEN_TRACING=1")
       shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_trace.js')))
-    elif check_arg('--emit-symbol-map'):
+    elif check_flag('--emit-symbol-map'):
       options.emit_symbol_map = True
       shared.Settings.EMIT_SYMBOL_MAP = 1
-    elif check_arg('--bind'):
+    elif check_flag('--bind'):
       shared.Settings.EMBIND = 1
       shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'embind', 'emval.js')))
       shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'embind', 'embind.js')))
@@ -2479,13 +2486,13 @@ def parse_args(newargs):
       options.preload_files.append(consume_arg())
     elif check_arg('--exclude-file'):
       options.exclude_files.append(consume_arg())
-    elif check_arg('--use-preload-cache'):
+    elif check_flag('--use-preload-cache'):
       options.use_preload_cache = True
-    elif check_arg('--no-heap-copy'):
+    elif check_flag('--no-heap-copy'):
       diagnostics.warning('legacy-settings', 'ignoring legacy flag --no-heap-copy (that is the only mode supported now)')
-    elif check_arg('--use-preload-plugins'):
+    elif check_flag('--use-preload-plugins'):
       options.use_preload_plugins = True
-    elif check_arg('--ignore-dynamic-linking'):
+    elif check_flag('--ignore-dynamic-linking'):
       options.ignore_dynamic_linking = True
     elif arg == '-v':
       shared.PRINT_STAGES = True
@@ -2494,35 +2501,35 @@ def parse_args(newargs):
       options.shell_path = consume_arg()
     elif check_arg('--source-map-base'):
       options.source_map_base = consume_arg()
-    elif check_arg('--no-entry'):
+    elif check_flag('--no-entry'):
       options.no_entry = True
     elif check_arg('--js-library'):
       shared.Settings.SYSTEM_JS_LIBRARIES.append((i + 1, os.path.abspath(consume_arg())))
-    elif check_arg('--remove-duplicates'):
+    elif check_flag('--remove-duplicates'):
       diagnostics.warning('legacy-settings', '--remove-duplicates is deprecated as it is no longer needed. If you cannot link without it, file a bug with a testcase')
-    elif check_arg('--jcache'):
+    elif check_flag('--jcache'):
       logger.error('jcache is no longer supported')
-    elif check_arg('--clear-cache'):
+    elif check_flag('--clear-cache'):
       logger.info('clearing cache as requested by --clear-cache')
       shared.Cache.erase()
       shared.check_sanity(force=True) # this is a good time for a sanity check
       should_exit = True
-    elif check_arg('--clear-ports'):
+    elif check_flag('--clear-ports'):
       logger.info('clearing ports and cache as requested by --clear-ports')
       system_libs.Ports.erase()
       shared.Cache.erase()
       shared.check_sanity(force=True) # this is a good time for a sanity check
       should_exit = True
-    elif check_arg('--show-ports'):
+    elif check_flag('--show-ports'):
       system_libs.show_ports()
       should_exit = True
     elif check_arg('--memory-init-file'):
       options.memory_init_file = int(consume_arg())
-    elif check_arg('--proxy-to-worker'):
+    elif check_flag('--proxy-to-worker'):
       options.proxy_to_worker = True
     elif check_arg('--valid-abspath'):
       options.valid_abspaths.append(consume_arg())
-    elif check_arg('--separate-asm'):
+    elif check_flag('--separate-asm'):
       exit_with_error('cannot --separate-asm with the wasm backend, since not emitting asm.js')
     elif arg.startswith(('-I', '-L')):
       path_name = arg[2:]
@@ -2536,11 +2543,11 @@ def parse_args(newargs):
             '" encountered. If this is to a local system header/library, it may '
             'cause problems (local system files make sense for compiling natively '
             'on your system, but not necessarily to JavaScript).')
-    elif check_arg('--emrun'):
+    elif check_flag('--emrun'):
       options.emrun = True
-    elif check_arg('--cpuprofiler'):
+    elif check_flag('--cpuprofiler'):
       options.cpu_profiler = True
-    elif check_arg('--threadprofiler'):
+    elif check_flag('--threadprofiler'):
       options.thread_profiler = True
       settings_changes.append('PTHREADS_PROFILING=1')
     elif arg == '-fno-exceptions':
@@ -2595,9 +2602,9 @@ def parse_args(newargs):
         exit_with_error(arg + ': cannot change built-in settings values with a -jsD directive. Pass -s ' + key + '=' + value + ' instead!')
       user_js_defines += [(key, value)]
       newargs[i] = ''
-    elif check_arg('-shared'):
+    elif check_flag('-shared'):
       options.shared = True
-    elif check_arg('-r'):
+    elif check_flag('-r'):
       options.relocatable = True
 
   if should_exit:

--- a/emcc.py
+++ b/emcc.py
@@ -2373,9 +2373,9 @@ def parse_args(newargs):
       newargs[i + 1] = ''
       return ret
 
-    if newargs[i].startswith('-O'):
+    if arg.startswith('-O'):
       # Let -O default to -O2, which is what gcc does.
-      options.requested_level = newargs[i][2:] or '2'
+      options.requested_level = arg[2:] or '2'
       if options.requested_level == 's':
         options.llvm_opts = ['-Os']
         options.requested_level = 2
@@ -2386,15 +2386,15 @@ def parse_args(newargs):
         options.requested_level = 2
         shared.Settings.SHRINK_LEVEL = 2
         settings_changes.append('INLINING_LIMIT=25')
-      shared.Settings.OPT_LEVEL = validate_arg_level(options.requested_level, 3, 'Invalid optimization level: ' + newargs[i], clamp=True)
+      shared.Settings.OPT_LEVEL = validate_arg_level(options.requested_level, 3, 'Invalid optimization level: ' + arg, clamp=True)
     elif check_arg('--js-opts'):
       logger.warning('--js-opts ignored when using llvm backend')
       consume_arg()
     elif check_arg('--llvm-opts'):
       options.llvm_opts = parse_value(consume_arg())
-    elif newargs[i].startswith('-flto'):
-      if '=' in newargs[i]:
-        shared.Settings.LTO = newargs[i].split('=')[1]
+    elif arg.startswith('-flto'):
+      if '=' in arg:
+        shared.Settings.LTO = arg.split('=')[1]
       else:
         shared.Settings.LTO = "full"
     elif check_arg('--llvm-lto'):
@@ -2420,12 +2420,12 @@ def parse_args(newargs):
       if arg != '0':
         exit_with_error('0 is the only supported option for --minify; 1 has been deprecated')
       shared.Settings.DEBUG_LEVEL = max(1, shared.Settings.DEBUG_LEVEL)
-    elif newargs[i].startswith('-g'):
-      options.requested_debug = newargs[i]
-      requested_level = newargs[i][2:] or '3'
+    elif arg.startswith('-g'):
+      options.requested_debug = arg
+      requested_level = arg[2:] or '3'
       if is_int(requested_level):
         # the -gX value is the debug level (-g1, -g2, etc.)
-        shared.Settings.DEBUG_LEVEL = validate_arg_level(requested_level, 4, 'Invalid debug level: ' + newargs[i])
+        shared.Settings.DEBUG_LEVEL = validate_arg_level(requested_level, 4, 'Invalid debug level: ' + arg)
         # if we don't need to preserve LLVM debug info, do not keep this flag
         # for clang
         if shared.Settings.DEBUG_LEVEL < 3:
@@ -2454,13 +2454,11 @@ def parse_args(newargs):
         # debug info during link (during compile, this does not make a
         # difference).
         shared.Settings.DEBUG_LEVEL = 3
-    elif newargs[i] == '-profiling' or newargs[i] == '--profiling':
+    elif check_arg('-profiling') or check_arg('--profiling'):
       shared.Settings.DEBUG_LEVEL = max(shared.Settings.DEBUG_LEVEL, 2)
       options.profiling = True
-      newargs[i] = ''
-    elif newargs[i] == '-profiling-funcs' or newargs[i] == '--profiling-funcs':
+    elif check_arg('-profiling-funcs') or check_arg('--profiling-funcs'):
       options.profiling_funcs = True
-      newargs[i] = ''
     elif newargs[i] == '--tracing' or newargs[i] == '--memoryprofiler':
       if newargs[i] == '--memoryprofiler':
         options.memory_profiler = True
@@ -2468,13 +2466,11 @@ def parse_args(newargs):
       newargs[i] = ''
       settings_changes.append("EMSCRIPTEN_TRACING=1")
       shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_trace.js')))
-    elif newargs[i] == '--emit-symbol-map':
+    elif check_arg('--emit-symbol-map'):
       options.emit_symbol_map = True
       shared.Settings.EMIT_SYMBOL_MAP = 1
-      newargs[i] = ''
-    elif newargs[i] == '--bind':
+    elif check_arg('--bind'):
       shared.Settings.EMBIND = 1
-      newargs[i] = ''
       shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'embind', 'emval.js')))
       shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'embind', 'embind.js')))
     elif check_arg('--embed-file'):
@@ -2483,112 +2479,96 @@ def parse_args(newargs):
       options.preload_files.append(consume_arg())
     elif check_arg('--exclude-file'):
       options.exclude_files.append(consume_arg())
-    elif newargs[i].startswith('--use-preload-cache'):
+    elif check_arg('--use-preload-cache'):
       options.use_preload_cache = True
-      newargs[i] = ''
-    elif newargs[i].startswith('--no-heap-copy'):
+    elif check_arg('--no-heap-copy'):
       diagnostics.warning('legacy-settings', 'ignoring legacy flag --no-heap-copy (that is the only mode supported now)')
-      newargs[i] = ''
-    elif newargs[i].startswith('--use-preload-plugins'):
+    elif check_arg('--use-preload-plugins'):
       options.use_preload_plugins = True
-      newargs[i] = ''
-    elif newargs[i] == '--ignore-dynamic-linking':
+    elif check_arg('--ignore-dynamic-linking'):
       options.ignore_dynamic_linking = True
-      newargs[i] = ''
-    elif newargs[i] == '-v':
+    elif arg == '-v':
       shared.PRINT_STAGES = True
       shared.check_sanity(force=True)
     elif check_arg('--shell-file'):
       options.shell_path = consume_arg()
     elif check_arg('--source-map-base'):
       options.source_map_base = consume_arg()
-    elif newargs[i] == '--no-entry':
+    elif check_arg('--no-entry'):
       options.no_entry = True
-      newargs[i] = ''
     elif check_arg('--js-library'):
       shared.Settings.SYSTEM_JS_LIBRARIES.append((i + 1, os.path.abspath(consume_arg())))
-    elif newargs[i] == '--remove-duplicates':
+    elif check_arg('--remove-duplicates'):
       diagnostics.warning('legacy-settings', '--remove-duplicates is deprecated as it is no longer needed. If you cannot link without it, file a bug with a testcase')
-      newargs[i] = ''
-    elif newargs[i] == '--jcache':
+    elif check_arg('--jcache'):
       logger.error('jcache is no longer supported')
-      newargs[i] = ''
-    elif newargs[i] == '--clear-cache':
+    elif check_arg('--clear-cache'):
       logger.info('clearing cache as requested by --clear-cache')
       shared.Cache.erase()
       shared.check_sanity(force=True) # this is a good time for a sanity check
       should_exit = True
-    elif newargs[i] == '--clear-ports':
+    elif check_arg('--clear-ports'):
       logger.info('clearing ports and cache as requested by --clear-ports')
       system_libs.Ports.erase()
       shared.Cache.erase()
       shared.check_sanity(force=True) # this is a good time for a sanity check
       should_exit = True
-    elif newargs[i] == '--show-ports':
+    elif check_arg('--show-ports'):
       system_libs.show_ports()
       should_exit = True
     elif check_arg('--memory-init-file'):
       options.memory_init_file = int(consume_arg())
-    elif newargs[i] == '--proxy-to-worker':
+    elif check_arg('--proxy-to-worker'):
       options.proxy_to_worker = True
-      newargs[i] = ''
-    elif newargs[i] == '--valid-abspath':
-      options.valid_abspaths.append(newargs[i + 1])
-      newargs[i] = ''
-      newargs[i + 1] = ''
-    elif newargs[i] == '--separate-asm':
+    elif check_arg('--valid-abspath'):
+      options.valid_abspaths.append(consume_arg())
+    elif check_arg('--separate-asm'):
       exit_with_error('cannot --separate-asm with the wasm backend, since not emitting asm.js')
-    elif newargs[i].startswith(('-I', '-L')):
-      path_name = newargs[i][2:]
+    elif arg.startswith(('-I', '-L')):
+      path_name = arg[2:]
       if os.path.isabs(path_name) and not is_valid_abspath(options, path_name):
         # Of course an absolute path to a non-system-specific library or header
         # is fine, and you can ignore this warning. The danger are system headers
         # that are e.g. x86 specific and nonportable. The emscripten bundled
         # headers are modified to be portable, local system ones are generally not.
         diagnostics.warning(
-            'absolute-paths', '-I or -L of an absolute path "' + newargs[i] +
+            'absolute-paths', '-I or -L of an absolute path "' + arg +
             '" encountered. If this is to a local system header/library, it may '
             'cause problems (local system files make sense for compiling natively '
             'on your system, but not necessarily to JavaScript).')
-    elif newargs[i] == '--emrun':
+    elif check_arg('--emrun'):
       options.emrun = True
-      newargs[i] = ''
-    elif newargs[i] == '--cpuprofiler':
+    elif check_arg('--cpuprofiler'):
       options.cpu_profiler = True
-      newargs[i] = ''
-    elif newargs[i] == '--threadprofiler':
+    elif check_arg('--threadprofiler'):
       options.thread_profiler = True
       settings_changes.append('PTHREADS_PROFILING=1')
-      newargs[i] = ''
-    elif newargs[i] == '-fno-exceptions':
+    elif arg == '-fno-exceptions':
       shared.Settings.DISABLE_EXCEPTION_CATCHING = 1
       shared.Settings.DISABLE_EXCEPTION_THROWING = 1
       shared.Settings.EXCEPTION_HANDLING = 0
-    elif newargs[i] == '-fexceptions':
+    elif arg == '-fexceptions':
       eh_enabled = True
-    elif newargs[i] == '-fwasm-exceptions':
+    elif arg == '-fwasm-exceptions':
       wasm_eh_enabled = True
-    elif newargs[i] == '-fignore-exceptions':
+    elif arg == '-fignore-exceptions':
       shared.Settings.DISABLE_EXCEPTION_CATCHING = 1
-    elif newargs[i] == '--default-obj-ext':
-      newargs[i] = ''
-      options.default_object_extension = newargs[i + 1]
+    elif check_arg('--default-obj-ext'):
+      options.default_object_extension = consume_arg()
       if not options.default_object_extension.startswith('.'):
         options.default_object_extension = '.' + options.default_object_extension
-      newargs[i + 1] = ''
-    elif newargs[i].startswith("-fsanitize=cfi"):
+    elif arg == '-fsanitize=cfi':
       options.cfi = True
-    elif newargs[i] == "--output_eol":
-      if newargs[i + 1].lower() == 'windows':
+    elif check_arg('--output_eol'):
+      style = consume_arg()
+      if style.lower() == 'windows':
         options.output_eol = '\r\n'
-      elif newargs[i + 1].lower() == 'linux':
+      elif style.lower() == 'linux':
         options.output_eol = '\n'
       else:
-        exit_with_error('Invalid value "' + newargs[i + 1] + '" to --output_eol!')
-      newargs[i] = ''
-      newargs[i + 1] = ''
-    elif newargs[i] == '--generate-config':
-      optarg = newargs[i + 1]
+        exit_with_error('Invalid value "' + style + '" to --output_eol!')
+    elif check_arg('--generate-config'):
+      optarg = consume_arg()
       path = os.path.expanduser(optarg)
       if os.path.exists(path):
         exit_with_error('File ' + optarg + ' passed to --generate-config already exists!')
@@ -2596,46 +2576,44 @@ def parse_args(newargs):
         shared.generate_config(optarg)
       should_exit = True
     # Record USE_PTHREADS setting because it controls whether --shared-memory is passed to lld
-    elif newargs[i] == '-pthread':
+    elif arg == '-pthread':
       settings_changes.append('USE_PTHREADS=1')
-    elif newargs[i] in ('-fno-diagnostics-color', '-fdiagnostics-color=never'):
+    elif arg in ('-fno-diagnostics-color', '-fdiagnostics-color=never'):
       colored_logger.disable()
       diagnostics.color_enabled = False
-    elif newargs[i] == '-fno-rtti':
+    elif arg == '-fno-rtti':
       shared.Settings.USE_RTTI = 0
-    elif newargs[i] == '-frtti':
+    elif arg == '-frtti':
       shared.Settings.USE_RTTI = 1
-
-    # TODO Currently -fexceptions only means Emscripten EH. Switch to wasm
-    # exception handling by default when -fexceptions is given when wasm
-    # exception handling becomes stable.
-    if wasm_eh_enabled:
-      shared.Settings.EXCEPTION_HANDLING = 1
-      shared.Settings.DISABLE_EXCEPTION_THROWING = 1
-      shared.Settings.DISABLE_EXCEPTION_CATCHING = 1
-    elif eh_enabled:
-      shared.Settings.EXCEPTION_HANDLING = 0
-      shared.Settings.DISABLE_EXCEPTION_THROWING = 0
-      shared.Settings.DISABLE_EXCEPTION_CATCHING = 0
-    elif newargs[i].startswith('-jsD'):
-      key = newargs[i][4:]
+    elif arg.startswith('-jsD'):
+      key = arg[4:]
       if '=' in key:
         key, value = key.split('=')
       else:
         value = '1'
       if key in shared.Settings.attrs:
-        exit_with_error(newargs[i] + ': cannot change built-in settings values with a -jsD directive. Pass -s ' + key + '=' + value + ' instead!')
+        exit_with_error(arg + ': cannot change built-in settings values with a -jsD directive. Pass -s ' + key + '=' + value + ' instead!')
       user_js_defines += [(key, value)]
       newargs[i] = ''
-    elif newargs[i] == '-shared':
+    elif check_arg('-shared'):
       options.shared = True
-      newargs[i] = ''
-    elif newargs[i] == '-r':
+    elif check_arg('-r'):
       options.relocatable = True
-      newargs[i] = ''
 
   if should_exit:
     sys.exit(0)
+
+  # TODO Currently -fexceptions only means Emscripten EH. Switch to wasm
+  # exception handling by default when -fexceptions is given when wasm
+  # exception handling becomes stable.
+  if wasm_eh_enabled:
+    shared.Settings.EXCEPTION_HANDLING = 1
+    shared.Settings.DISABLE_EXCEPTION_THROWING = 1
+    shared.Settings.DISABLE_EXCEPTION_CATCHING = 1
+  elif eh_enabled:
+    shared.Settings.EXCEPTION_HANDLING = 0
+    shared.Settings.DISABLE_EXCEPTION_THROWING = 0
+    shared.Settings.DISABLE_EXCEPTION_CATCHING = 0
 
   newargs = [a for a in newargs if a]
   return options, settings_changes, user_js_defines, newargs


### PR DESCRIPTION
It seems to tried to improve this but never finished the job
until now.

- use `arg` to refer to the current argument throughout the loop
- use new `check_flag` to conditionally consume a flag
- use `consume_arg` to unconditionally consume the next argument

Move the exception handling post-processing to after the loop.