### PR TITLE
ASan testing fixes

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6054,6 +6054,9 @@ return malloc(size);
   @is_slow_test
   def test_openjpeg(self):
     if '-fsanitize=address' in self.emcc_args:
+      # In ASan mode we need a large initial memory (or else wasm-ld fails).
+      # The OpenJPEG CMake will build several executables, so we must enable
+      # the flag for them all.
       os.environ['EMMAKEN_CFLAGS'] = '-sINITIAL_MEMORY=300MB'
 
     def line_splitter(data):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1158,6 +1158,7 @@ int main() {
       self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
       self.do_run_from_file(path_from_root('tests', 'core', 'test_exceptions.cpp'), path_from_root('tests', 'core', 'test_exceptions_uncaught.out'), assert_returncode=NON_ZERO)
 
+  @no_asan('TODO: ASan support in minimal runtime')
   def test_exceptions_minimal_runtime(self):
     self.set_setting('EXCEPTION_DEBUG', 1)
     self.set_setting('EXIT_RUNTIME', 1)
@@ -5068,6 +5069,7 @@ main( int argv, char ** argc ) {
       self.do_runf(path_from_root('tests', 'utf8_invalid.cpp'), 'OK.')
 
   # Test that invalid character in UTF8 does not cause decoding to crash.
+  @no_asan('TODO: ASan support in minimal runtime')
   def test_minimal_runtime_utf8_invalid(self):
     self.set_setting('EXTRA_EXPORTED_RUNTIME_METHODS', ['UTF8ToString', 'stringToUTF8'])
     for decoder_mode in [[], ['-s', 'TEXTDECODER=1']]:
@@ -5620,6 +5622,7 @@ int main(void) {
   def test_whets(self):
     self.do_runf(path_from_root('tests', 'whets.cpp'), 'Single Precision C Whetstone Benchmark')
 
+  @no_asan('depends on the specifics of memory size, which for asan we are forced to increase')
   def test_dlmalloc_inline(self):
     self.banned_js_engines = [NODE_JS] # slower, and fail on 64-bit
     # needed with typed arrays
@@ -5629,6 +5632,7 @@ int main(void) {
     self.do_run(src, '*1,0*', args=['200', '1'], force_c=True)
     self.do_run('src.js', '*400,0*', args=['400', '400'], force_c=True, no_build=True)
 
+  @no_asan('depends on the specifics of memory size, which for asan we are forced to increase')
   def test_dlmalloc(self):
     self.banned_js_engines = [NODE_JS] # slower, and fail on 64-bit
     # needed with typed arrays
@@ -6050,7 +6054,7 @@ return malloc(size);
   @is_slow_test
   def test_openjpeg(self):
     if '-fsanitize=address' in self.emcc_args:
-      self.set_setting('INITIAL_MEMORY', 128 * 1024 * 1024)
+      os.environ['EMMAKEN_CFLAGS'] = '-sINITIAL_MEMORY=300MB'
 
     def line_splitter(data):
       out = ''
@@ -7765,6 +7769,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
       print(occurances)
 
   # Tests that building with -s DECLARE_ASM_MODULE_EXPORTS=0 works
+  @no_asan('TODO: ASan support in minimal runtime')
   def test_minimal_runtime_no_declare_asm_module_exports(self):
     self.set_setting('DECLARE_ASM_MODULE_EXPORTS', 0)
     self.set_setting('WASM_ASYNC_COMPILATION', 0)
@@ -7804,6 +7809,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf(path_from_root('tests', 'small_hello_world.c'), 'hello')
 
   # Tests global initializer with -s MINIMAL_RUNTIME=1
+  @no_asan('TODO: ASan support in minimal runtime')
   def test_minimal_runtime_global_initializer(self):
     self.set_setting('MINIMAL_RUNTIME', 1)
     self.maybe_closure()
@@ -8061,6 +8067,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
                  post_build=post,
                  expected_output='hello, world!')
 
+  @no_asan('SAFE_HEAP cannot be used with ASan')
   def test_safe_heap_user_js(self):
     self.set_setting('SAFE_HEAP', 1)
     self.do_runf(path_from_root('tests', 'core', 'test_safe_heap_user_js.c'),
@@ -8161,6 +8168,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_run_in_out_file_test('tests', 'core', 'test_get_exported_function.cpp')
 
   # Tests the emscripten_get_exported_function() API.
+  @no_asan('TODO: ASan support in minimal runtime')
   def test_minimal_runtime_emscripten_get_exported_function(self):
     # Could also test with -s ALLOW_TABLE_GROWTH=1
     self.set_setting('RESERVED_FUNCTION_POINTERS', 2)


### PR DESCRIPTION
Open to ideas for a better solution for OpenJPEG, see comment there.

This should fix all current errors on the waterfall for `asan`, except for
the one I can't reproduce locally (`environ`).