### PR TITLE
C environ constructor cleanup

### DIFF
--- a/system/lib/libc/musl/src/env/__environ.c
+++ b/system/lib/libc/musl/src/env/__environ.c
@@ -26,7 +26,7 @@ void __emscripten_environ_constructor(void) {
         return;
     }
     char *environ_buf = malloc(sizeof(char) * environ_buf_size);
-    if (__environ == 0 || environ_buf == 0) {
+    if (environ_buf == 0) {
         __environ = 0;
         return;
     }

--- a/tests/env/src-mini.c
+++ b/tests/env/src-mini.c
@@ -13,6 +13,10 @@ extern char **environ;
 int main(int argc, char *argv[])
 {
   int i;
+  if (!environ) {
+    puts("environ is NULL - not enough memory?");
+    return 1;
+  }
   for(i=0; environ[i] != NULL; i ++ ) {
     printf("%s\n", environ[i]);
   }


### PR DESCRIPTION
We had a redundant check there.

Also improve the test to handle the case where malloc failed in the constructor. This might help debug the `asan` failure on the bot on this test (which does not fail locally for me).