### PR TITLE
Allow --argument=foo as well as --argument foo

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,9 @@ See docs/process.md for how version tagging works.
 Current Trunk
 -------------
 
+- emcc now accepts `--arg=foo` as well as `--arg foo`.  For example
+  `--js-library=file.js`.
+
 2.0.7: 10/13/2020
 -----------------
 - Don't run Binaryen postprocessing for Emscripten EH/SjLj. This lets us avoid

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9460,5 +9460,5 @@ exec "$@"
       ''')
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'),
                       '-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[foo]',
-                      '--js-library', 'lib1.js',
-                      '--js-library', 'lib2.js'])
+                      '--js-library=lib1.js',
+                      '--js-library=lib2.js'])


### PR DESCRIPTION
This is useful in general but specifically for cmake
which links to re-order compiler flags.