### PR TITLE
emrun: use argparse in more conventional way

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,12 @@ Current Trunk
 - Reject promises returned from the factory function created by using the
   MODULARIZE build option if initialization of the module instance fails
   (#12396).
+- emrun: Passing command line flags (arguments that start with `-`) to the
+  program bring run now requires a `--` on the command line to signal the
+  end of `emrun` arguments. e.g:
+    `emrun filename.html -- --arg-for-page`
+  This is standard behaviour for command line parsing and simplifies the
+  emrun logic.
 
 2.0.7: 10/13/2020
 -----------------

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2488,7 +2488,7 @@ void *getBindBuffer() {
         args_base,
         args_base + ['--private_browsing', '--port', '6941']
     ]:
-      args += [self.in_dir('hello_world.html'), '1', '2', '--3']
+      args += [self.in_dir('hello_world.html'), '--', '1', '2', '--3']
       print(shared.shlex_join(args))
       proc = self.run_process(args, check=False)
       self.assertEqual(proc.returncode, 100)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2467,6 +2467,13 @@ void *getBindBuffer() {
                  '--kill_exit', '--port', '6939', '--verbose',
                  '--log_stdout', self.in_dir('stdout.txt'),
                  '--log_stderr', self.in_dir('stderr.txt')]
+
+    # Verify that trying to pass argument to the page without the `--` separator will
+    # generate an actionable error message
+    err = self.expect_fail(args_base + ['--foo'])
+    self.assertContained('error: unrecognized arguments: --foo', err)
+    self.assertContained('remember to add `--` between arguments', err)
+
     if EMTEST_BROWSER is not None:
       # If EMTEST_BROWSER carried command line arguments to pass to the browser,
       # (e.g. "firefox -profile /path/to/foo") those can't be passed via emrun,
@@ -2484,6 +2491,7 @@ void *getBindBuffer() {
           browser_args = parser.parse_known_args(browser_args)[1]
         if browser_args:
           args_base += ['--browser_args', ' ' + ' '.join(browser_args)]
+
     for args in [
         args_base,
         args_base + ['--private_browsing', '--port', '6941']


### PR DESCRIPTION
This is not quite NFC since passing command line arguments
to the page that start with `-` now requires a separator.

This used to work:

./emrun filename.html --foo --bar

Where as now one needs to add `--` to signal the end of emrun's
argument parsing.

So either:

```emrun filename.html -- --foo --bar```

or:

```emrun -- filename.html --foo --bar```