### PR TITLE
emrun: Don't send response on `^exit^` message

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -693,6 +693,7 @@ class HTTPHandler(SimpleHTTPRequestHandler):
         page_exit_code = int(data[6:])
         logv('Web page has quit with a call to exit() with return code ' + str(page_exit_code) + '. Shutting down web server. Pass --serve_after_exit to keep serving even after the page terminates with exit().')
         self.server.shutdown()
+        return
 
     self.send_response(200)
     self.send_header('Content-type', 'text/plain')


### PR DESCRIPTION
This message means that the browser itself is closing
or has already closed.

Without this change the tests the rely on this all report
exceptions sending the `OK` response.  e.g:

```
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 49430)
Traceback (most recent call last):
  File "/usr/lib/python3.8/socketserver.py", line 650, in process_request_thread
    self.finish_request(request, client_address)
  File "/usr/lib/python3.8/socketserver.py", line 360, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/lib/python3.8/http/server.py", line 647, in __init__
    super().__init__(*args, **kwargs)
  File "/usr/lib/python3.8/socketserver.py", line 720, in __init__
    self.handle()
  File "/usr/lib/python3.8/http/server.py", line 427, in handle
    self.handle_one_request()
  File "/usr/lib/python3.8/http/server.py", line 415, in handle_one_request
    method()
  File "/home/sbc/dev/wasm/emscripten/emrun.py", line 703, in do_POST
    self.wfile.write(b'OK')
  File "/usr/lib/python3.8/socketserver.py", line 799, in write
    self._sock.sendall(b)
BrokenPipeError: [Errno 32] Broken pipe
----------------------------------------
```