### PR TITLE
Refactor 16-/32-/64-bit load/store intrinsics

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -497,8 +497,12 @@ The following table highlights the availability and expected performance of diff
      - 🟡 wasm_v128_load. VM must guess type.
    * - _mm_loadu_si128
      - 🟡 wasm_v128_load. VM must guess type.
+   * - _mm_loadu_si64
+     - ❌ emulated with const+scalar load+replace lane
    * - _mm_loadu_si32
-     - ❌ emulated with wasm_i32x4_make
+     - ❌ emulated with const+scalar load+replace lane
+   * - _mm_loadu_si16
+     - ❌ emulated with const+scalar load+replace lane
    * - _mm_madd_epi16
      - ❌ scalarized
    * - _mm_maskmoveu_si128
@@ -659,8 +663,12 @@ The following table highlights the availability and expected performance of diff
      - 🟡 wasm_v128_store. VM must guess type.
    * - _mm_storeu_si128
      - 🟡 wasm_v128_store. VM must guess type.
+   * - _mm_storeu_si64
+     - 💡 emulated with extract lane+scalar store
    * - _mm_storeu_si32
-     - 💡 emulated with scalar store
+     - 💡 emulated with extract lane+scalar store
+   * - _mm_storeu_si16
+     - 💡 emulated with extract lane+scalar store
    * - _mm_stream_pd
      - 🟡 wasm_v128_store. VM must guess type. :raw-html:`<br />` No cache control in Wasm SIMD.
    * - _mm_stream_si128

--- a/system/include/compat/emmintrin.h
+++ b/system/include/compat/emmintrin.h
@@ -1145,25 +1145,50 @@ _mm_load_si128(__m128i const *__p)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_loadu_si128(__m128i const *__p)
 {
-  struct __loadu_si128 {
+  // UB-free unaligned access copied from wasm_simd128.h
+  struct __mm_loadu_si128_struct {
     __m128i __v;
   } __attribute__((__packed__, __may_alias__));
-  return ((struct __loadu_si128*)__p)->__v;
+  return ((struct __mm_loadu_si128_struct*)__p)->__v;
+}
+
+static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
+_mm_loadu_si16(void const *__p)
+{
+  // UB-free unaligned access copied from wasm_simd128.h
+  struct __mm_loadu_si16_struct {
+    unsigned short __v;
+  } __attribute__((__packed__, __may_alias__));
+  return (__m128i)wasm_i16x8_replace_lane(wasm_i64x2_const(0, 0), 0,
+    ((const struct __mm_loadu_si16_struct *)__p)->__v);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_loadu_si32(void const *__p)
 {
-  return (__m128i)wasm_i32x4_make(*(unsigned int*)__p, 0, 0, 0);
+  // UB-free unaligned access copied from wasm_simd128.h
+  struct __mm_loadu_si32_struct {
+    float __v;
+  } __attribute__((__packed__, __may_alias__));
+  return (__m128i)wasm_f32x4_replace_lane(wasm_f64x2_const(0.0, 0.0), 0,
+    ((const struct __mm_loadu_si32_struct *)__p)->__v);
+}
+
+static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
+_mm_loadu_si64(void const *__p)
+{
+  // UB-free unaligned access copied from wasm_simd128.h
+  struct __mm_loadu_si64_struct {
+    double __v;
+  } __attribute__((__packed__, __may_alias__));
+  return (__m128i)wasm_f64x2_replace_lane(wasm_f64x2_const(0.0, 0.0), 0,
+    ((const struct __mm_loadu_si64_struct *)__p)->__v);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_loadl_epi64(__m128i const *__p)
 {
-  struct __mm_loadl_epi64_struct {
-    int __u[2];
-  } __attribute__((__packed__, __may_alias__));
-  return (__m128i) { ((struct __mm_loadl_epi64_struct*)__p)->__u[0], ((struct __mm_loadl_epi64_struct*)__p)->__u[1], 0, 0};
+  return _mm_loadu_si64(__p);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
@@ -1245,18 +1270,43 @@ _mm_store_si128(__m128i *__p, __m128i __b)
 }
 
 static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_mm_storeu_si32(void *__p, __m128i __a)
+_mm_storeu_si16(void *__p, __m128i __a)
 {
-  *(unsigned int *)__p = wasm_i32x4_extract_lane((v128_t)__a, 0);
+  // UB-free unaligned access copied from wasm_simd128.h
+  struct __mm_storeu_si16_struct {
+    unsigned short __v;
+  } __attribute__((__packed__, __may_alias__));
+  ((struct __mm_storeu_si16_struct *)__p)->__v = wasm_i16x8_extract_lane((v128_t)__a, 0);
 }
 
 static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_mm_storeu_si128(__m128i *__p, __m128i __b)
+_mm_storeu_si32(void *__p, __m128i __a)
 {
-  struct __unaligned {
+  // UB-free unaligned access copied from wasm_simd128.h
+  struct __mm_storeu_si32_struct {
+    float __v;
+  } __attribute__((__packed__, __may_alias__));
+  ((struct __mm_storeu_si32_struct *)__p)->__v = wasm_f32x4_extract_lane((v128_t)__a, 0);
+}
+
+static __inline__ void __attribute__((__always_inline__, __nodebug__))
+_mm_storeu_si64(void *__p, __m128i __a)
+{
+  // UB-free unaligned access copied from wasm_simd128.h
+  struct __mm_storeu_si64_struct {
+    double __v;
+  } __attribute__((__packed__, __may_alias__));
+  ((struct __mm_storeu_si64_struct *)__p)->__v = wasm_f64x2_extract_lane((v128_t)__a, 0);
+}
+
+static __inline__ void __attribute__((__always_inline__, __nodebug__))
+_mm_storeu_si128(__m128i *__p, __m128i __a)
+{
+  // UB-free unaligned access copied from wasm_simd128.h
+  struct __mm_storeu_si128_struct {
     __m128i __v;
   } __attribute__((__packed__, __may_alias__));
-  ((struct __unaligned *)__p)->__v = __b;
+  ((struct __mm_storeu_si128_struct *)__p)->__v = __a;
 }
 
 static __inline__ void __attribute__((__always_inline__, __nodebug__))
@@ -1277,7 +1327,7 @@ _mm_maskmoveu_si128(__m128i __d, __m128i __n, char *__p)
 static __inline__ void __attribute__((__always_inline__, __nodebug__))
 _mm_storel_epi64(__m128i *__p, __m128i __a)
 {
-  *(long long *)__p = wasm_i64x2_extract_lane((v128_t)__a, 0);
+  _mm_storeu_si64(__p, __a);
 }
 
 static __inline__ void __attribute__((__always_inline__, __nodebug__))

--- a/system/include/compat/xmmintrin.h
+++ b/system/include/compat/xmmintrin.h
@@ -188,24 +188,6 @@ _mm_storeu_ps(float *__p, __m128 __a)
   ((struct __unaligned *)__p)->__v = __a;
 }
 
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_mm_storeu_si16(void *__p, __m128i __a)
-{
-  struct __unaligned {
-    unsigned short __u;
-  } __attribute__((__packed__, __may_alias__));
-  ((struct __unaligned *)__p)->__u = ((__u16x8)__a)[0];
-}
-
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
-_mm_storeu_si64(void *__p, __m128i __a)
-{
-  struct __unaligned {
-    unsigned long long __u;
-  } __attribute__((__packed__, __may_alias__));
-  ((struct __unaligned *)__p)->__u = ((__u64x2)__a)[0];
-}
-
 static __inline__ int __attribute__((__always_inline__, __nodebug__))
 _mm_movemask_ps(__m128 __a)
 {

--- a/tests/sse/test_sse1.cpp
+++ b/tests/sse/test_sse1.cpp
@@ -147,8 +147,6 @@ int main()
 	void_OutFloatPtr_M128(_mm_storel_pi, __m64*, 8, 1);
 	void_OutFloatPtr_M128(_mm_storer_ps, float*, 16, 16);
 	void_OutFloatPtr_M128(_mm_storeu_ps, float*, 16, 1);
-	void_OutIntPtr_M128i(_mm_storeu_si16, unsigned short*, 2, 1);
-	void_OutIntPtr_M128i(_mm_storeu_si64, __m64*, 8, 1);
 	void_OutFloatPtr_M128(_mm_stream_ps, float*, 16, 16);
 
 	// SSE1 Swizzle instructions:

--- a/tests/sse/test_sse2.cpp
+++ b/tests/sse/test_sse2.cpp
@@ -291,7 +291,9 @@ void test_store()
 	void_OutDoublePtr_M128d(_mm_storel_pd, double*, 8, 1);
 	void_OutDoublePtr_M128d(_mm_storer_pd, double*, 16, 16);
 	void_OutDoublePtr_M128d(_mm_storeu_pd, double*, 16, 1);
+	void_OutIntPtr_M128i(_mm_storeu_si16, unsigned short*, 2, 1);
 	void_OutIntPtr_M128i(_mm_storeu_si32, __m128i*, 4, 1);
+	void_OutIntPtr_M128i(_mm_storeu_si64, __m64*, 8, 1);
 	void_OutIntPtr_M128i(_mm_storeu_si128, __m128i*, 16, 1);
 	void_OutDoublePtr_M128d(_mm_stream_pd, double*, 16, 16);
 	void_OutIntPtr_M128i(_mm_stream_si128, __m128i*, 16, 16);


### PR DESCRIPTION
- Load/store 32-bit quantities as `float` rather than `int`. This avoid transfer between general-purpose and FP/SIMD registers in native code.
- Add missing `_mm_loadu_si64` and `_mm_loadu_si16`
- Use UB-free load/store snippets for existing load/store intrinsics