### PR TITLE
Some minor cleanups split out from #12461

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3759,7 +3759,9 @@ LibraryManager.library = {
       return dynCallLegacy(sig, ptr, args);
     }
 #endif
-
+#if ASSERTIONS
+    assert(wasmTable.get(ptr), 'missing table entry in dynCall: ' + ptr);
+#endif
     return wasmTable.get(ptr).apply(null, args)
 #endif
   },

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -43,7 +43,6 @@ if (typeof WebAssembly !== 'object') {
 // Wasm globals
 
 var wasmMemory;
-var wasmTable;
 
 #if USE_PTHREADS
 // For sending to workers.
@@ -355,9 +354,9 @@ assert(!Module['wasmMemory']);
 #else // !STANDALONE_WASM
 // In non-standalone/normal mode, we create the memory here.
 #include "runtime_init_memory.js"
-#include "runtime_init_table.js"
 #endif // !STANDALONE_WASM
 
+#include "runtime_init_table.js"
 #include "runtime_stack_check.js"
 #include "runtime_assertions.js"
 

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -154,7 +154,7 @@ function addFunctionWasm(func, sig) {
       throw err;
     }
 #if ASSERTIONS
-    assert(typeof sig !== 'undefined', 'Missing signature argument to addFunction');
+    assert(typeof sig !== 'undefined', 'Missing signature argument to addFunction: ' + func);
 #endif
     var wrapped = convertJsFunctionToWasm(func, sig);
     wasmTable.set(ret, wrapped);

--- a/src/runtime_init_table.js
+++ b/src/runtime_init_table.js
@@ -1,4 +1,5 @@
-#if RELOCATABLE // normal static binaries export the table
+#if RELOCATABLE
+// In RELOCATABLE mode we create the table in JS.
 var wasmTable = new WebAssembly.Table({
   'initial': {{{ WASM_TABLE_SIZE }}},
 #if !ALLOW_TABLE_GROWTH
@@ -6,4 +7,9 @@ var wasmTable = new WebAssembly.Table({
 #endif
   'element': 'anyfunc'
 });
+#else
+// In regular non-RELOCATABLE mode the table is exported
+// from the wasm module and this will be assigned once
+// the exports are available.
+var wasmTable;
 #endif

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3354,7 +3354,7 @@ ok
     self.build_dlfcn_lib('liblib.c')
 
     self.prep_dlfcn_main()
-    src = r'''
+    create_test_file('main.c', r'''
       #include <assert.h>
       #include <stdio.h>
       #include <dlfcn.h>
@@ -3382,9 +3382,9 @@ ok
 
         return 0;
       }
-      '''
+      ''')
     self.set_setting('EXPORTED_FUNCTIONS', ['_main', '_malloc', '_free'])
-    self.do_run(src, '''go!
+    self.do_runf('main.c', '''go!
 pre 1
 pre 2
 pre 3


### PR DESCRIPTION
- Use C over C++ in test_dlfcn_longjmp since the test
  doesn't use C++ and it makes debugging simpler.
- Add/improve a couple of assertions
- Remove duplicate `var` in declaration wasmTable.