### PR TITLE
Use a mutable global as __stack_pointer in dynamic linking

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -18,6 +18,9 @@ See docs/process.md for how version tagging works.
 Current Trunk
 -------------
 
+- Dynamic linking (MAIN_MODULE + SIDE_MODULE) now produces wasm binaries that
+  depend on mutable globals.  Specifically the stack pointer global is mutable
+  and shared between the modules (#12536).
 - emcc now accepts `--arg=foo` as well as `--arg foo`.  For example
   `--js-library=file.js`.
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -479,7 +479,7 @@ def remove_trailing_zeros(memfile):
 
 def finalize_wasm(infile, memfile, DEBUG):
   building.save_intermediate(infile, 'base.wasm')
-  args = ['--detect-features', '--minimize-wasm-changes']
+  args = ['--mutable-sp', '--detect-features', '--minimize-wasm-changes']
 
   # if we don't need to modify the wasm, don't tell finalize to emit a wasm file
   modify_wasm = False
@@ -631,7 +631,7 @@ def add_standard_wasm_imports(send_items_map):
     # the wasm backend reserves slot 0 for the NULL function pointer
     send_items_map['__table_base'] = '1'
   if shared.Settings.RELOCATABLE:
-    send_items_map['__stack_pointer'] = 'STACK_BASE'
+    send_items_map['__stack_pointer'] = "__stack_pointer"
 
   if shared.Settings.MAYBE_WASM2JS or shared.Settings.AUTODEBUG or shared.Settings.LINKABLE:
     # legalization of i64 support code may require these in some modes

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -285,11 +285,14 @@ var STACK_BASE = {{{ getQuoted('STACK_BASE') }}},
     STACKTOP = STACK_BASE,
     STACK_MAX = {{{ getQuoted('STACK_MAX') }}};
 
+
 #if ASSERTIONS
 assert(STACK_BASE % 16 === 0, 'stack must start aligned');
 #endif
 
 #if RELOCATABLE
+__stack_pointer = new WebAssembly.Global({value: 'i32', mutable: true}, STACK_BASE);
+
 // To support such allocations during startup, track them on __heap_base and
 // then when the main module is loaded it reads that value and uses it to
 // initialize sbrk (the main module is relocatable itself, and so it does not

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6577,7 +6577,7 @@ int main() {
 
     if expected_size is not None:
       # measure the wasm size without the name section
-      self.run_process([wasm_opt, 'a.out.wasm', '--strip-debug', '-o', 'a.out.nodebug.wasm'])
+      self.run_process([wasm_opt, 'a.out.wasm', '--strip-debug', '--all-features', '-o', 'a.out.nodebug.wasm'])
       wasm_size = os.path.getsize('a.out.nodebug.wasm')
       ratio = abs(wasm_size - expected_size) / float(expected_size)
       print('  seen wasm size: %d (expected: %d), ratio to expected: %f' % (wasm_size, expected_size, ratio))


### PR DESCRIPTION
Without this change we were using a normal Number and then
wasm-emscripten-finalize would use that value to set an
internal mutable global.

This change means that users emscripten's dynamic linking
now depends on the mutable globals proposal.  However this
is already available in all major browsers:

  https://webassembly.org/roadmap/

This is small step towards #12461 which can be landing
in isolation without otherwise changing the ABI.

Once this lands we can remove internalizeStackPointerGloba
from wasm-emscripten-finalize.
