### PR TITLE
sdl2-config: bump version

### DIFF
--- a/system/bin/sdl2-config
+++ b/system/bin/sdl2-config
@@ -10,5 +10,5 @@ args = sys.argv[1:]
 if '--cflags' in args or '--libs' in args:
   print('-s USE_SDL=2')
 elif '--version' in args:
-  print('2.0.0')
+  print('2.0.10')
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4929,7 +4929,7 @@ print(os.environ.get('NM'))
 
   def test_sdl2_config(self):
     for args, expected in [
-      [['--version'], '2.0.0'],
+      [['--version'], '2.0.10'],
       [['--cflags'], '-s USE_SDL=2'],
       [['--libs'], '-s USE_SDL=2'],
       [['--cflags', '--libs'], '-s USE_SDL=2'],


### PR DESCRIPTION
Third-party SDL modules query require a recent-ish version of SDL2 (e.g. standard SDL2_image requires SDL2 >= 2.0.8).
Emscripten currently ships SDL2 tag version_22, that is 2.0.10.