### PR TITLE
Update SDL Mix_PlayMusic according SDL docs

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -3060,7 +3060,7 @@ var LibrarySDL = {
       audio = info.audio;
     }
     audio['onended'] = function() { if (SDL.music.audio == this) _Mix_HaltMusic(); } // will send callback
-    audio.loop = loops != 0; // TODO: handle N loops for finite N
+    audio.loop = loops != 0 && loops != 1; // TODO: handle N loops for finite N
     audio.volume = SDL.music.volume;
     SDL.music.audio = audio;
     audio.play();


### PR DESCRIPTION
Hi. I found a little mistake in `Mix_PlayMusic`:
```
audio.loop = loops != 0;
```
Music will be looped if `loops == -1`, or `loops > 0`, but docs [says](https://www.libsdl.org/projects/SDL_mixer/docs/SDL_mixer_57.html):
```
 int Mix_PlayMusic(Mix_Music *music, int loops)

music
    Pointer to Mix_Music to play. 
loops
    number of times to play through the music.
    0 plays the music zero times...
    -1 plays the music forever (or as close as it can get to that) 
```
Little bit wired, that `loops == 0` means that music should not play. However I checked on linux host and native build plays music 1 time even if `loops == 0`.
Real problem is that when `loops == 1` emscripten plays music forever, SDL not behave in that way. For `loops == 1` music should play 1 times, so this fix helps to achieve this.

P.S. Is it good to use `!==` instead of `!=`?