### PR TITLE
Emit a relative path in -gseparate-dwarf

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7480,10 +7480,11 @@ int main() {
     os.mkdir('subdir')
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'),
                       '-o', os.path.join('subdir', 'output.js'),
-                      '-gseparate-dwarf=with_dwarf.wasm'])
+                      '-gseparate-dwarf=with_dwarf2.wasm'])
+    self.assertExists('with_dwarf2.wasm')
     with open(os.path.join('subdir', 'output.wasm'), 'rb') as f:
       wasm = f.read()
-      self.assertIn(b'../with_dwarf.wasm', wasm)
+      self.assertIn(b'../with_dwarf2.wasm', wasm)
 
   def test_separate_dwarf_with_filename_and_path(self):
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-gseparate-dwarf=with_dwarf.wasm'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7456,8 +7456,8 @@ int main() {
     # assumes the debug file is alongside the main one
     os.mkdir('subdir')
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'),
-                     '-gseparate-dwarf',
-                     '-o', os.path.join('subdir', 'output.js')])
+                      '-gseparate-dwarf',
+                      '-o', os.path.join('subdir', 'output.js')])
     with open(os.path.join('subdir', 'output.wasm'), 'rb') as f:
       wasm = f.read()
       self.assertIn(b'output.wasm.debug.wasm', wasm)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7475,6 +7475,16 @@ int main() {
       stderr = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), invalid])
       self.assertContained('invalid -gseparate-dwarf=FILENAME notation', stderr)
 
+    # building to a subdirectory, but with the debug file in another place,
+    # should leave a relative path to the debug wasm
+    os.mkdir('subdir')
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'),
+                      '-o', os.path.join('subdir', 'output.js'),
+                      '-gseparate-dwarf=with_dwarf.wasm'])
+    with open(os.path.join('subdir', 'output.wasm'), 'rb') as f:
+      wasm = f.read()
+      self.assertIn(b'../with_dwarf.wasm', wasm)
+
   def test_separate_dwarf_with_filename_and_path(self):
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-gseparate-dwarf=with_dwarf.wasm'])
     with open('a.out.wasm', 'rb') as f:

--- a/tools/building.py
+++ b/tools/building.py
@@ -1361,16 +1361,10 @@ def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   embedded_path = shared.Settings.SEPARATE_DWARF_URL
   if wasm_file_with_dwarf is True:
     wasm_file_with_dwarf = wasm_file + '.debug.wasm'
-    # assume by default that the debug file is adjacent to the main one; to
-    # override that SEPARATE_DWARF_URL can be used
-    wasm_file_with_dwarf = os.path.basename(wasm_file_with_dwarf)
-    if not embedded_path:
-      embedded_path = wasm_file_with_dwarf
-  else:
+  if not embedded_path:
     # a path was provided - make it relative to the wasm.
-    if not embedded_path:
-      embedded_path = os.path.relpath(wasm_file_with_dwarf,
-                                      os.path.dirname(wasm_file))
+    embedded_path = os.path.relpath(wasm_file_with_dwarf,
+                                    os.path.dirname(wasm_file))
 
   shutil.move(wasm_file, wasm_file_with_dwarf)
   strip(wasm_file_with_dwarf, wasm_file, debug=True)

--- a/tools/building.py
+++ b/tools/building.py
@@ -1358,16 +1358,19 @@ def strip(infile, outfile, debug=False, producers=False):
 def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   # if the dwarf filename wasn't provided, use the default target + a suffix
   wasm_file_with_dwarf = shared.Settings.SEPARATE_DWARF
+  embedded_path = shared.Settings.SEPARATE_DWARF_URL
   if wasm_file_with_dwarf is True:
     wasm_file_with_dwarf = wasm_file + '.debug.wasm'
     # assume by default that the debug file is adjacent to the main one; to
     # override that SEPARATE_DWARF_URL can be used
     wasm_file_with_dwarf = os.path.basename(wasm_file_with_dwarf)
+    if not embedded_path:
+      embedded_path = wasm_file_with_dwarf
   else:
     # a path was provided - make it relative to the wasm.
-    wasm_file_with_dwarf = os.path.relpath(wasm_file_with_dwarf,
-                                           os.path.dirname(wasm_file))
-  embedded_path = shared.Settings.SEPARATE_DWARF_URL or wasm_file_with_dwarf
+    if not embedded_path:
+      embedded_path = os.path.relpath(wasm_file_with_dwarf,
+                                      os.path.dirname(wasm_file))
 
   shutil.move(wasm_file, wasm_file_with_dwarf)
   strip(wasm_file_with_dwarf, wasm_file, debug=True)

--- a/tools/building.py
+++ b/tools/building.py
@@ -1363,6 +1363,10 @@ def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
     # assume by default that the debug file is adjacent to the main one; to
     # override that SEPARATE_DWARF_URL can be used
     wasm_file_with_dwarf = os.path.basename(wasm_file_with_dwarf)
+  else:
+    # a path was provided - make it relative to the wasm.
+    wasm_file_with_dwarf = os.path.relpath(wasm_file_with_dwarf,
+                                           os.path.dirname(wasm_file))
   embedded_path = shared.Settings.SEPARATE_DWARF_URL or wasm_file_with_dwarf
 
   shutil.move(wasm_file, wasm_file_with_dwarf)

--- a/tools/building.py
+++ b/tools/building.py
@@ -1360,6 +1360,9 @@ def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   wasm_file_with_dwarf = shared.Settings.SEPARATE_DWARF
   if wasm_file_with_dwarf is True:
     wasm_file_with_dwarf = wasm_file + '.debug.wasm'
+    # assume by default that the debug file is adjacent to the main one; to
+    # override that SEPARATE_DWARF_URL can be used
+    wasm_file_with_dwarf = os.path.basename(wasm_file_with_dwarf)
   embedded_path = shared.Settings.SEPARATE_DWARF_URL or wasm_file_with_dwarf
 
   shutil.move(wasm_file, wasm_file_with_dwarf)


### PR DESCRIPTION
Emit only the basename in the wasm to point to the debug wasm. This assumes
the files are alongside each other. (For more complex things, we already have
`SEPARATE_DWARF_URL`).

cc @RReverser @pfaffe @dschuff 

fixes #12526