### PR TITLE
[idbfs] Properly check date equivalence

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -515,3 +515,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * kamenokonyokonyoko <kamenokonokotan@gmail.com>
 * Lectem <lectem@gmail.com>
 * Henrik Algestam <henrik@algestam.se>
+* Pawel Czarnecki <pawel@8thwall.com> (copyright owned by 8th Wall, Inc.)

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -231,7 +231,7 @@ mergeInto(LibraryManager.library, {
       Object.keys(src.entries).forEach(function (key) {
         var e = src.entries[key];
         var e2 = dst.entries[key];
-        if (!e2 || e['timestamp'] != e2['timestamp']) {
+        if (!e2 || e['timestamp'].getTime() != e2['timestamp'].getTime()) {
           create.push(key);
           total++;
         }


### PR DESCRIPTION
#12409 introduced a bug.

The PR was merged with the assumption that `!=` on Date objects compares the date values just like the greater than operator does. Unfortunately, this checks for object reference equivalence and will always evaluate to false in this case since each timestamp is a separate Date object.

https://github.com/emscripten-core/emscripten/pull/12409#issuecomment-713191241