### PR TITLE
[IDBFS] Do not fail when syncing existing directories.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -515,3 +515,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * kamenokonyokonyoko <kamenokonokotan@gmail.com>
 * Lectem <lectem@gmail.com>
 * Henrik Algestam <henrik@algestam.se>
+* Pawel Czarnecki <pawel@8thwall.com> (copyright owned by 8th Wall, Inc.)

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -169,11 +169,7 @@ mergeInto(LibraryManager.library, {
     storeLocalEntry: function(path, entry, callback) {
       try {
         if (FS.isDir(entry['mode'])) {
-          try {
-            FS.mkdir(path, entry['mode']);
-          } catch (e) {
-            if (e.errno != {{{ cDefine('EEXIST') }}}) throw e;
-          }
+          FS.mkdirTree(path, entry['mode']);
         } else if (FS.isFile(entry['mode'])) {
           FS.writeFile(path, entry['contents'], { canOwn: true });
         } else {

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -173,8 +173,6 @@ mergeInto(LibraryManager.library, {
             FS.mkdir(path, entry['mode']);
           } catch (e) {
             if (e.errno != {{{ cDefine('EEXIST') }}}) throw e;
-            FS.rmdir(path);
-            FS.mkdir(path, entry['mode']);
           }
         } else if (FS.isFile(entry['mode'])) {
           FS.writeFile(path, entry['contents'], { canOwn: true });

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -169,10 +169,12 @@ mergeInto(LibraryManager.library, {
     storeLocalEntry: function(path, entry, callback) {
       try {
         if (FS.isDir(entry['mode'])) {
-          try{
+          try {
             FS.mkdir(path, entry['mode']);
           } catch (e) {
             if (e.errno != {{{ cDefine('EEXIST') }}}) throw e
+            FS.rmdir(path)
+            FS.mkdir(path, entry['mode']);
           }
         } else if (FS.isFile(entry['mode'])) {
           FS.writeFile(path, entry['contents'], { canOwn: true });

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -169,7 +169,11 @@ mergeInto(LibraryManager.library, {
     storeLocalEntry: function(path, entry, callback) {
       try {
         if (FS.isDir(entry['mode'])) {
-          FS.mkdir(path, entry['mode']);
+          try{
+            FS.mkdir(path, entry['mode']);
+          } catch (e) {
+            if (e.errno != {{{ cDefine('EEXIST') }}}) throw e
+          }
         } else if (FS.isFile(entry['mode'])) {
           FS.writeFile(path, entry['contents'], { canOwn: true });
         } else {

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -172,8 +172,8 @@ mergeInto(LibraryManager.library, {
           try {
             FS.mkdir(path, entry['mode']);
           } catch (e) {
-            if (e.errno != {{{ cDefine('EEXIST') }}}) throw e
-            FS.rmdir(path)
+            if (e.errno != {{{ cDefine('EEXIST') }}}) throw e;
+            FS.rmdir(path);
             FS.mkdir(path, entry['mode']);
           }
         } else if (FS.isFile(entry['mode'])) {

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -231,7 +231,7 @@ mergeInto(LibraryManager.library, {
       Object.keys(src.entries).forEach(function (key) {
         var e = src.entries[key];
         var e2 = dst.entries[key];
-        if (!e2 || e['timestamp'] != e2['timestamp']) {
+        if (!e2 || e['timestamp'].getTime() != e2['timestamp'].getTime()) {
           create.push(key);
           total++;
         }


### PR DESCRIPTION
When a directory with a different timestamp exists in IDB and we sync back to memfs an `EEXIST` error is thrown.

This is not the case when syncing files and is incorrect behavior. There is no reason why the directory should not be updated.

Following the spirit of `mkdirTree` https://github.com/emscripten-core/emscripten/blob/eabd82cb1d5890b3c1ed545997a94c460488a6ee/src/library_fs.js#L688

I suggest we catch the case of an existing directory, remove it and recreate it in order to update it.

EDIT: we can't `rmdir` an non-empty directory. Since my understanding is the `mode` doesn't do much then perhaps we can just ignore this `EEXIST` all together and not worry about re-creating (as is the case in `mkdirTree`)? 