### PR TITLE
Make ASSERTIONS=2 imply STACK_OVERFLOW_CHECK=2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- `-s ASSERTIONS=2` now implies `-s STACK_OVERFLOW_CHECK=2`. Previously only
+  `-s ASSERTIONS=1` implied `-s STACK_OVERFLOW_CHECK=1`.
 - Dynamic linking (MAIN_MODULE + SIDE_MODULE) now produces wasm binaries that
   depend on mutable globals.  Specifically the stack pointer global is mutable
   and shared between the modules. This is an ABI change for dynamic linking.

--- a/emcc.py
+++ b/emcc.py
@@ -1236,9 +1236,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # Note the exports the user requested
     building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
 
-    # -s ASSERTIONS=1 implies basic stack overflow checks.
+    # -s ASSERTIONS=1 implies basic stack overflow checks, and ASSERTIONS=2
+    # implies full stack overflow checks
     if shared.Settings.ASSERTIONS:
-      shared.Settings.STACK_OVERFLOW_CHECK = max(1, shared.Settings.STACK_OVERFLOW_CHECK)
+      shared.Settings.STACK_OVERFLOW_CHECK = max(shared.Settings.ASSERTIONS, shared.Settings.STACK_OVERFLOW_CHECK)
 
     if shared.Settings.LLD_REPORT_UNDEFINED or shared.Settings.STANDALONE_WASM:
       # Reporting undefined symbols at wasm-ld time requires us to know if we have a `main` function

--- a/emcc.py
+++ b/emcc.py
@@ -1237,8 +1237,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS[:]
 
     # -s ASSERTIONS=1 implies basic stack overflow checks, and ASSERTIONS=2
-    # implies full stack overflow checks
-    if shared.Settings.ASSERTIONS:
+    # implies full stack overflow checks (unless the user specifically set
+    # something else)
+    if shared.Settings.ASSERTIONS and 'STACK_OVERFLOW_CHECK' not in settings_key_changes:
       shared.Settings.STACK_OVERFLOW_CHECK = max(shared.Settings.ASSERTIONS, shared.Settings.STACK_OVERFLOW_CHECK)
 
     if shared.Settings.LLD_REPORT_UNDEFINED or shared.Settings.STANDALONE_WASM:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7688,7 +7688,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf(path_from_root('tests', 'stack_overflow.cpp'), 'stack overflow', assert_returncode=NON_ZERO)
 
     # ASSERTIONS=2 implies STACK_OVERFLOW_CHECK=2
-    self.set_setting('STACK_OVERFLOW_CHECK', 0)
+    self.clear_setting('STACK_OVERFLOW_CHECK')
     self.set_setting('ASSERTIONS', 2)
     self.do_runf(path_from_root('tests', 'stack_overflow.cpp'), 'stack overflow', assert_returncode=NON_ZERO)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7687,6 +7687,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['-DONE_BIG_STRING']
     self.do_runf(path_from_root('tests', 'stack_overflow.cpp'), 'stack overflow', assert_returncode=NON_ZERO)
 
+    # ASSERTIONS=2 implies STACK_OVERFLOW_CHECK=2
+    self.set_setting('STACK_OVERFLOW_CHECK', 0)
+    self.set_setting('ASSERTIONS', 2)
+    self.do_runf(path_from_root('tests', 'stack_overflow.cpp'), 'stack overflow', assert_returncode=NON_ZERO)
+
   @node_pthreads
   def test_binaryen_2170_emscripten_atomic_cas_u8(self):
     self.emcc_args += ['-s', 'USE_PTHREADS=1']


### PR DESCRIPTION
This is in addition to the existing 1 implying 1.

The goal is to make it easier to use `-s ASSERTIONS=2` and have it check
as many things as possible.