### PR TITLE
Fix dlsym for 64-bit functions

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -111,7 +111,7 @@ var LibraryDylink = {
     return x.indexOf('dynCall_') == 0 || unmangledSymbols.indexOf(x) != -1 ? x : '_' + x;
   },
 
-  // Resolve a symbol first agsint Module["asm"] and then failing that
+  // Resolve a symbol first against Module["asm"] and then failing that
   // resolve it directly against the global Module object.
   $resolveGlobalSymbol: function(sym, legalized) {
 #if !WASM_BIGINT

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -111,14 +111,36 @@ var LibraryDylink = {
     return x.indexOf('dynCall_') == 0 || unmangledSymbols.indexOf(x) != -1 ? x : '_' + x;
   },
 
-  $resolveGlobalSymbol: function(sym) {
-    var resolved = Module["asm"][sym];
-    if (!resolved) {
-      var mangled = asmjsMangle(sym);
-      resolved = Module[mangled];
-      if (!resolved && sym.startsWith('invoke_')) {
-        resolved = createInvokeFunction(sym.split('_')[1]);
+  // Resolve a symbol first agsint Module["asm"] and then failing that
+  // resolve it directly against the global Module object.
+  $resolveGlobalSymbol: function(sym, legalized) {
+#if !WASM_BIGINT
+    // In case the function was legalized, look for the original export first.
+    // We always want to return the original wasm function here since this
+    // function is used in the internal linking only.
+    if (!legalized) {
+      var orig = Module['asm']['orig$' + sym];
+      if (orig) {
+        return orig;
       }
+    }
+#endif
+
+    var resolved = Module['asm'][sym];
+    if (!resolved) {
+#if !WASM_BIGINT
+      if (!legalized) {
+        orig = Module['_orig$' + sym];
+        if (orig) {
+          return orig;
+        }
+     }
+#endif
+      resolved = Module[asmjsMangle(sym)];
+    }
+
+    if (!resolved && sym.startsWith('invoke_')) {
+      resolved = createInvokeFunction(sym.split('_')[1]);
     }
     return resolved;
   },
@@ -211,8 +233,14 @@ var LibraryDylink = {
       // b) Symbols from side modules are not always added to the global namespace.
       var moduleExports;
 
-      function resolveSymbol(sym, type) {
-        var resolved = resolveGlobalSymbol(sym);
+      function resolveSymbol(sym, type, legalized) {
+        var resolved = resolveGlobalSymbol(sym, legalized);
+#if !WASM_BIGINT
+        if (!resolved && !legalized) {
+          // In case the function was legalized, look for the original export first.
+          resolved = moduleExports['orig$' + sym];
+        }
+#endif
         if (!resolved) {
           resolved = moduleExports[sym];
         }
@@ -266,13 +294,6 @@ var LibraryDylink = {
             assert(parts.length == 3)
             var name = parts[1];
             var sig = parts[2];
-#if !WASM_BIGINT
-            // If the export was legalized we look for the original
-            // function when adding it ot the table
-            if (sig.indexOf('j') >= 0) {
-              name = 'orig$' + name;
-            }
-#endif
             var fp = 0;
             return obj[prop] = function() {
               if (!fp) {
@@ -284,7 +305,7 @@ var LibraryDylink = {
           }
           // otherwise this is regular function import - call it indirectly
           return obj[prop] = function() {
-            return resolveSymbol(prop, 'function').apply(null, arguments);
+            return resolveSymbol(prop, 'function', true).apply(null, arguments);
           };
         }
       };
@@ -638,6 +659,10 @@ var LibraryDylink = {
         DLFCN.errorMsg = 'Tried to lookup unknown symbol "' + symbol + '" in dynamic lib: ' + lib.name;
         return 0;
       }
+#if !WASM_BIGINT
+      result = lib.module['orig$' + symbol];
+      if (!result)
+#endif
       result = lib.module[symbol];
     }
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5405,6 +5405,10 @@ EMSCRIPTEN_KEEPALIVE int foo() {
   return 42;
 }
 
+EMSCRIPTEN_KEEPALIVE int64_t foo64() {
+  return 64;
+}
+
 int main(int argc, char** argv) {
   int (*f)();
   f = dlsym(RTLD_DEFAULT, "foo");
@@ -5413,14 +5417,24 @@ int main(int argc, char** argv) {
     return 1;
   }
   printf("foo -> %d\n", f());
+
+  int64_t (*f64)();
+  f64 = dlsym(RTLD_DEFAULT, "foo64");
+  if (!f64) {
+    printf("dlsym failed: %s\n", dlerror());
+    return 1;
+  }
+  printf("foo64 -> %lld\n", f64());
+
   f = dlsym(RTLD_DEFAULT, "bar");
   printf("bar -> %p\n", f);
   return 0;
 }
 ''')
-    self.run_process([EMCC, 'main.c', '-s', 'MAIN_MODULE'])
+    self.run_process([EMCC, 'main.c', '-s', 'MAIN_MODULE=2'])
     out = self.run_js('a.out.js')
     self.assertContained('foo -> 42', out)
+    self.assertContained('foo64 -> 64', out)
     self.assertContained('bar -> 0', out)
 
   def test_main_module_without_exceptions_message(self):


### PR DESCRIPTION
This basically involved looking the `orig$` functions whenever we
want a native WebAssembly function.

Regarding test_dlfcn_i64: It seems that this test wasn't actually
testing functions that have i64 in thier signature but some kind of i64
handling from back in the asm.js days.  See  #2060.  This change
repurposes it to and makes it more useful.