### PR TITLE
Add `--oformat` flag to explicitly control output format

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -34,6 +34,7 @@ import stat
 import sys
 import time
 import base64
+from enum import Enum
 from subprocess import PIPE
 
 import emscripten
@@ -71,9 +72,7 @@ SPECIAL_ENDINGLESS_FILENAMES = (os.devnull,)
 SOURCE_ENDINGS = C_ENDINGS + CXX_ENDINGS + OBJC_ENDINGS + OBJCXX_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES + ASSEMBLY_CPP_ENDINGS
 C_ENDINGS = C_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES # consider the special endingless filenames like /dev/null to be C
 
-JS_ENDINGS = ('.js', '.mjs', '.out', '')
-WASM_ENDINGS = ('.wasm',)
-EXECUTABLE_ENDINGS = JS_ENDINGS + WASM_ENDINGS + ('.html',)
+EXECUTABLE_ENDINGS = ('.wasm', '.html', '.js', '.mjs', '.out', '')
 DYNAMICLIB_ENDINGS = ('.dylib', '.so') # Windows .dll suffix is not included in this list, since those are never linked to directly on the command line.
 STATICLIB_ENDINGS = ('.a',)
 ASSEMBLY_ENDINGS = ('.ll', '.s')
@@ -215,8 +214,16 @@ def base64_encode(b):
     return b64
 
 
+class OFormat(Enum):
+  WASM = 1
+  JS = 2
+  MJS = 3
+  HTML = 4
+
+
 class EmccOptions(object):
   def __init__(self):
+    self.oformat = None
     self.requested_debug = ''
     self.profiling = False
     self.profiling_funcs = False
@@ -1142,12 +1149,23 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if '-M' in newargs or '-MM' in newargs:
       final_suffix = '.mout' # not bitcode, not js; but just dependency rule of the input file
 
-    # target is now finalized, can finalize other _target s
-    if final_suffix == '.mjs':
+    # If no output format was sepecific we try to imply the format based on
+    # the output filename extension.
+    if not options.oformat:
+      if shared.Settings.SIDE_MODULE or final_suffix == '.wasm':
+        options.oformat = OFormat.WASM
+      elif final_suffix == '.mjs':
+        options.oformat = OFormat.MJS
+      elif final_suffix == '.html':
+        options.oformat = OFormat.HTML
+      else:
+        options.oformat = OFormat.JS
+
+    if options.oformat == OFormat.MJS:
       shared.Settings.EXPORT_ES6 = 1
       shared.Settings.MODULARIZE = 1
 
-    if shared.Settings.SIDE_MODULE or final_suffix in WASM_ENDINGS:
+    if options.oformat == OFormat.WASM:
       # If the user asks directly for a wasm file then this *is* the target
       wasm_target = target
     else:
@@ -1162,7 +1180,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     shared.verify_settings()
 
-    if final_suffix in WASM_ENDINGS and not shared.Settings.SIDE_MODULE:
+    if options.oformat == OFormat.WASM and not shared.Settings.SIDE_MODULE:
       # if the output is just a wasm file, it will normally be a standalone one,
       # as there is no JS. an exception are side modules, as we can't tell at
       # compile time whether JS will be involved or not - the main module may
@@ -1682,7 +1700,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         not shared.Settings.AUTODEBUG and \
         not shared.Settings.ASSERTIONS and \
         not shared.Settings.RELOCATABLE and \
-        not target.endswith(WASM_ENDINGS) and \
+        not options.oformat == OFormat.WASM and \
         not shared.Settings.ASYNCIFY_LAZY_LOAD_CODE and \
             shared.Settings.MINIFY_ASMJS_EXPORT_NAMES:
       shared.Settings.MINIFY_WASM_IMPORTS_AND_EXPORTS = 1
@@ -2170,8 +2188,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # /dev/null, but that will take some refactoring
       return 0
 
-    wasm_only = shared.Settings.SIDE_MODULE or final_suffix in WASM_ENDINGS
-
     if shared.Settings.MEM_INIT_IN_WASM:
       memfile = None
     else:
@@ -2188,7 +2204,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if embed_memfile():
         shared.Settings.SUPPORT_BASE64_EMBEDDING = 1
 
-      if wasm_only:
+      if options.oformat == OFormat.WASM:
         final_js = None
       else:
         final_js = tmp_wasm + '.js'
@@ -2270,7 +2286,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     log_time('binaryen')
     # If we are not emitting any JS then we are all done now
-    if wasm_only:
+    if options.oformat == OFormat.WASM:
       return
 
     with ToolchainProfiler.profile_block('final emitting'):
@@ -2320,7 +2336,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       shared.JS.handle_license(final_js)
 
-      if final_suffix in JS_ENDINGS:
+      if options.oformat in (OFormat.JS, OFormat.MJS):
         js_target = target
       else:
         js_target = unsuffixed(target) + '.js'
@@ -2332,7 +2348,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         generated_text_files_with_native_eols += [js_target]
 
       # If we were asked to also generate HTML, do that
-      if final_suffix == '.html':
+      if options.oformat == OFormat.HTML:
         generate_html(target, options, js_target, target_basename,
                       wasm_target, memfile)
       else:
@@ -2447,6 +2463,12 @@ def parse_args(newargs):
       options.extern_pre_js += open(consume_arg()).read() + '\n'
     elif check_arg('--extern-post-js'):
       options.extern_post_js += open(consume_arg()).read() + '\n'
+    elif check_arg('--oformat'):
+      formats = [f.lower() for f in OFormat.__members__]
+      fmt = consume_arg()
+      if fmt not in formats:
+        exit_with_error('invalid output format: `%s` (must be one of %s)' % (fmt, formats))
+      options.oformat = getattr(OFormat, fmt.upper())
     elif check_arg('--minify'):
       arg = consume_arg()
       if arg != '0':

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9495,3 +9495,21 @@ exec "$@"
     for arg in ['-sMAIN_MODULE', '-sSIDE_MODULE', '-sRELOCATABLE']:
       err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-sMAIN_MODULE', '-sWASM=0'])
       self.assertContained('WASM2JS is not compatible with relocatable output', err)
+
+  def test_oformat(self):
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--oformat=wasm', '-o', 'out.foo'])
+    self.assertTrue(building.is_wasm('out.foo'))
+    self.clear()
+
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--oformat=html', '-o', 'out.foo'])
+    self.assertFalse(building.is_wasm('out.foo'))
+    self.assertContained('<html ', open('out.foo').read())
+    self.clear()
+
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--oformat=js', '-o', 'out.foo'])
+    self.assertFalse(building.is_wasm('out.foo'))
+    self.assertContained('new ExitStatus', open('out.foo').read())
+    self.clear()
+
+    err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '--oformat=foo'])
+    self.assertContained("error: invalid output format: `foo` (must be one of ['wasm', 'js', 'mjs', 'html']", err)


### PR DESCRIPTION
Without this flag the output format is determined by the name of the
output file.

With this flag the name of the output file is ignored and the format is
determined solely by this flag.

This can be useful in various situation but the motivation for doing
it now that it provides a place to specify a new output format which
will be the raw linker output, which can then be fed into that new
post-link-only mode that we are planning.