### PR TITLE
Give a friendlier error when misusing tools/file_packager.py

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4660,7 +4660,7 @@ window.close = function() {
     self.run_browser('page.html', 'hello from file', '/report_result?15')
 
     # with separate file packager invocation
-    self.run_process([PYTHON, FILE_PACKAGER, 'data.js', '--preload', 'test.txt', '--js-output=' + 'data.js'])
+    self.run_process([PYTHON, FILE_PACKAGER, 'data.data', '--preload', 'test.txt', '--js-output=' + 'data.js'])
     self.compile_btest(['page.c', '-s', 'ALLOW_MEMORY_GROWTH=1', '--pre-js', 'data.js', '-o', 'page.html', '-s', 'FORCE_FILESYSTEM=1'])
     self.run_browser('page.html', 'hello from file', '/report_result?15')
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2196,6 +2196,12 @@ int f() {
     err = self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--preload-file', 'data.txt'], stdout=PIPE, stderr=PIPE).stderr
     self.assertEqual(len(err), 0)
 
+  def test_file_packager_returns_error_if_target_equal_to_jsoutput(self):
+    MESSAGE = 'error: TARGET should not be the same value of --js-output'
+    result = self.run_process([PYTHON, FILE_PACKAGER, 'test.data', '--js-output=test.data'], check=False, stdout=PIPE, stderr=PIPE)
+    self.assertEqual(result.returncode, 1)
+    self.assertContained(MESSAGE, result.stderr)
+
   def test_headless(self):
     shutil.copyfile(path_from_root('tests', 'screenshot.png'), 'example.png')
     self.run_process([EMCC, path_from_root('tests', 'sdl_headless.c'), '-s', 'HEADLESS=1'])

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -264,6 +264,11 @@ def main():
           'so that it includes support for loading this file package',
           file=sys.stderr)
 
+  if jsoutput and os.path.abspath(jsoutput) == os.path.abspath(data_target):
+    print('error: TARGET should not be the same value of --js-output',
+          file=sys.stderr)
+    return 1
+
   ret = ''
   # emcc.py will add this to the output itself, so it is only needed for
   # standalone calls


### PR DESCRIPTION
Catch the case when you are using the very same path as target and
js output.

Fixes #12326