### PR TITLE
Update test_minimal_runtime_code_size expectations

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -5,6 +5,6 @@
   "a.js.gz": 2375,
   "a.wasm": 10893,
   "a.wasm.gz": 6929,
-  "total": 16427,
+  "total": 16428,
   "total_gz": 9681
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21676,
-  "a.js.gz": 8365,
+  "a.js": 21668,
+  "a.js.gz": 8361,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 25461,
-  "total_gz": 11466
+  "total": 25435,
+  "total_gz": 11462
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -5,6 +5,6 @@
   "a.js.gz": 2196,
   "a.wasm": 10893,
   "a.wasm.gz": 6929,
-  "total": 15912,
+  "total": 15913,
   "total_gz": 9502
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21165,
-  "a.js.gz": 8198,
+  "a.js": 21157,
+  "a.js.gz": 8193,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 24950,
-  "total_gz": 11299
+  "total": 24924,
+  "total_gz": 11294
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13681,
-  "a.html.gz": 7297,
+  "a.html": 13673,
+  "a.html.gz": 7308,
   "total": 13681,
-  "total_gz": 7297
+  "total_gz": 7308
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19250,
-  "a.html.gz": 8021,
-  "total": 19250,
-  "total_gz": 8021
+  "a.html": 19219,
+  "a.html.gz": 8008,
+  "total": 19219,
+  "total_gz": 8008
 }


### PR DESCRIPTION
A binaryen change (https://github.com/WebAssembly/binaryen/pull/3275)
seems to have given us some code size improvements here.