### PR TITLE
Allow setting of individual config settings via `-s` flags

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9432,6 +9432,10 @@ exec "$@"
     self.assertContained('wrapping compiler call: ', stdout)
     self.assertExists('test_hello_world.o')
 
+    stdout = self.run_process([EMCC, '-c', path_from_root('tests', 'core', 'test_hello_world.c'), '-s', 'COMPILER_WRAPPER=./wrapper.sh'], stdout=PIPE).stdout
+    self.assertContained('wrapping compiler call: ', stdout)
+    self.assertExists('test_hello_world.o')
+
   def test_llvm_option_dash_o(self):
     # emcc used to interpret -mllvm's option value as the output file if it
     # began with -o

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -279,27 +279,6 @@ def parse_config_file():
   except Exception as e:
     exit_with_error('Error in evaluating %s (at %s): %s, text: %s', EM_CONFIG, CONFIG_FILE, str(e), config_text)
 
-  CONFIG_KEYS = (
-    'NODE_JS',
-    'BINARYEN_ROOT',
-    'SPIDERMONKEY_ENGINE',
-    'V8_ENGINE',
-    'LLVM_ROOT',
-    'LLVM_ADD_VERSION',
-    'CLANG_ADD_VERSION',
-    'CLOSURE_COMPILER',
-    'JAVA',
-    'JS_ENGINE',
-    'JS_ENGINES',
-    'WASMER',
-    'WASMTIME',
-    'WASM_ENGINES',
-    'FROZEN_CACHE',
-    'CACHE',
-    'PORTS',
-    'COMPILER_WRAPPER',
-  )
-
   # Only propagate certain settings from the config file.
   for key in CONFIG_KEYS:
     env_var = 'EM_' + key
@@ -1306,10 +1285,31 @@ JS_ENGINES = []
 WASMER = None
 WASMTIME = None
 WASM_ENGINES = []
+FROZEN_CACHE = False
 CACHE = None
 PORTS = None
-FROZEN_CACHE = False
 COMPILER_WRAPPER = None
+
+CONFIG_KEYS = (
+  'NODE_JS',
+  'BINARYEN_ROOT',
+  'SPIDERMONKEY_ENGINE',
+  'V8_ENGINE',
+  'LLVM_ROOT',
+  'LLVM_ADD_VERSION',
+  'CLANG_ADD_VERSION',
+  'CLOSURE_COMPILER',
+  'JAVA',
+  'JS_ENGINE',
+  'JS_ENGINES',
+  'WASMER',
+  'WASMTIME',
+  'WASM_ENGINES',
+  'FROZEN_CACHE',
+  'CACHE',
+  'PORTS',
+  'COMPILER_WRAPPER',
+)
 
 # Emscripten compiler spawns other processes, which can reimport shared.py, so
 # make sure that those child processes get the same configuration file by


### PR DESCRIPTION
This means that the config setting `COMPILER_WRAPPER` can
also be set on the command line via `-s COMPILER_WRAPPER='foo'`.

Caveat: Using this feature ends up overriding he config setting
fairly late in the process which is too late for certain settings
to be overridden (for example -sLLVM_ROOT won't work because its
value is mostly used during startup when shared.py is first
imported.  I'm have some factors planning to make this less
of a problem).

Fixes: #12340