### PR TITLE
Allow dlsym() to looking JavaScript symbols in RTLD_DEFAULT mode

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -302,6 +302,9 @@ function JSify(data, functionsOnly) {
       if ((EXPORT_ALL || (finalName in EXPORTED_FUNCTIONS)) && !noExport) {
         contentText += '\nModule["' + finalName + '"] = ' + finalName + ';';
       }
+      if (MAIN_MODULE && sig) {
+        contentText += '\n' + finalName + '.sig = \'' + sig + '\';';
+      }
 
       var commentText = '';
       if (LibraryManager.library[ident + '__docs']) {

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -694,10 +694,11 @@ var LibraryDylink = {
 #endif // ASSERTIONS
     return result;
 #else // EMULATE_FUNCTION_POINTER_CASTS
-    // Insert the function into the wasm table.  Since we know the function
-    // comes directly from the loaded wasm module we can insert it directly
-    // into the table, avoiding any JS interaction.
-    return addFunctionWasm(result);
+    // Insert the function into the wasm table.  If its a direct wasm function
+    // the second argument will not be needed.  If its a JS function we rely
+    // on the `sig` attribute being set based on the `<func>__sig` specified
+    // in library JS file.
+    return addFunctionWasm(result, result.sig);
 #endif // EMULATE_FUNCTION_POINTER_CASTS
   },
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5430,10 +5430,11 @@ int main(int argc, char** argv) {
   return 0;
 }
 ''')
-    self.run_process([EMCC, 'main.c', '-sMAIN_MODULE=2',
-      '--js-library=lib.js',
-      '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[foo,bar]',
-      '-sEXPORTED_FUNCTIONS=[_main,_foo,_bar]'])
+    self.run_process([EMCC, 'main.c',
+                      '--js-library=lib.js',
+                      '-sMAIN_MODULE=2',
+                      '-sDEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[foo,bar]',
+                      '-sEXPORTED_FUNCTIONS=[_main,_foo,_bar]'])
 
     # Fist test the successful use of a JS function with dlsym
     out = self.run_js('a.out.js', args=['foo'])


### PR DESCRIPTION
In this mode dlsym is supposed to be able to looking all symbols
in default library search path which should include JS symbols.

Unfortunately if the symbol being looked up is not already in the
table then its signature needs to be known at this point.  To
handle this case we keep the signatures around at runtime by
attaching them to the JS library functions.  This a small extra
overhead that only applies to dynamic linking.

This change is needed for and split out from #12461