### PR TITLE
Remove python2 support. NFC.

### DIFF
--- a/em-config.py
+++ b/em-config.py
@@ -14,7 +14,6 @@ This tool prints the value of the variable to stdout if one
 is found, or exits with 1 if the variable does not exist.
 """
 
-from __future__ import print_function
 import sys
 import re
 from tools import shared

--- a/emar.py
+++ b/emar.py
@@ -16,7 +16,6 @@ other in this case.
 # TODO(sbc): Implement `ar x` within emscripten, in python, to avoid this issue
 # and delete this file.
 
-from __future__ import print_function
 import sys
 
 from tools.toolchain_profiler import ToolchainProfiler

--- a/embuilder.py
+++ b/embuilder.py
@@ -12,7 +12,6 @@ process (in particular, if emcc does this automatically, and you are
 running multiple build commands in parallel, confusion can occur).
 """
 
-from __future__ import print_function
 import argparse
 import logging
 import sys

--- a/emcc.py
+++ b/emcc.py
@@ -23,8 +23,6 @@ emcc can be influenced by a few environment variables:
                    your system headers will be used.
 """
 
-from __future__ import print_function
-
 import json
 import logging
 import os
@@ -879,9 +877,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if not shared.CONFIG_FILE:
       diagnostics.warning('deprecated', 'Specifying EM_CONFIG as a python literal is deprecated. Please use a file instead.')
-
-    if sys.version_info < (3, 0, 0) and 'EMCC_ALLOW_PYTHON2' not in os.environ:
-      diagnostics.warning('deprecated', 'Support for running emscripten with python2 is deprecated.  Please update to python3 as soon as possible (See https://github.com/emscripten-core/emscripten/issues/7198')
 
     for i in range(len(newargs)):
       if newargs[i] in ('-l', '-L', '-I'):

--- a/emcmake.py
+++ b/emcmake.py
@@ -4,7 +4,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import sys
 from tools import building
 from subprocess import CalledProcessError

--- a/emconfigure.py
+++ b/emconfigure.py
@@ -4,8 +4,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-'''
-This is a helper script. It runs ./configure (or cmake,
+"""This is a helper script. It runs ./configure (or cmake,
 etc.) for you, setting the environment variables to use
 emcc and so forth. Usage:
 
@@ -15,9 +14,8 @@ You can also use this for cmake and other configure-like
 stages. What happens is that all compilations done during
 this command are to native code, not JS, so that configure
 tests will work properly.
-'''
+"""
 
-from __future__ import print_function
 import sys
 from tools import building
 from subprocess import CalledProcessError

--- a/emmake.py
+++ b/emmake.py
@@ -21,7 +21,6 @@ that configure tests pass. emmake uses Emscripten to
 generate JavaScript.
 """
 
-from __future__ import print_function
 import sys
 from tools import building
 from subprocess import CalledProcessError

--- a/emranlib.py
+++ b/emranlib.py
@@ -4,14 +4,12 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-
 """emranlib - ranlib helper script
 
 This script acts as a frontend replacement for ranlib, and simply invokes
 llvm-ranlib internally.
 """
 
-from __future__ import print_function
 import sys
 from tools import shared
 

--- a/emrun.py
+++ b/emrun.py
@@ -12,7 +12,6 @@ Usage: emrun <options> filename.html <args to program>
 See emrun --help for more information
 """
 
-from __future__ import print_function
 import argparse
 import atexit
 import cgi
@@ -101,12 +100,7 @@ LINUX = False
 MACOS = False
 if os.name == 'nt':
   WINDOWS = True
-  try:
-    import winreg
-  except ImportError:
-    # In python2 this is called _winreg. Remove once we fully drop python2 support.
-    # See https://docs.python.org/2/library/_winreg.html
-    import _winreg as winreg
+  import winreg
 elif platform.system() == 'Linux':
   LINUX = True
 elif platform.mac_ver()[0] != '':

--- a/emscripten.py
+++ b/emscripten.py
@@ -9,8 +9,6 @@ header files (so that the JS compiler can see the constants in those
 headers, for the libc implementation in JS).
 """
 
-from __future__ import print_function
-
 import os
 import json
 import subprocess

--- a/emsize.py
+++ b/emsize.py
@@ -21,8 +21,6 @@ input file, which is expected to be a JS file. The wasm file is expected to be
 in the same directory, and have the same basename with a '.wasm' extension.
 """
 
-from __future__ import print_function
-
 import argparse
 import os
 import subprocess

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -7,7 +7,7 @@
 """This is the Emscripten test runner. To run some tests, specify which tests
 you want, for example
 
-  python tests/runner.py asm1.test_hello_world
+  python3 tests/runner.py asm1.test_hello_world
 
 There are many options for which tests to run and how to run them. For details,
 see
@@ -16,13 +16,6 @@ http://kripken.github.io/emscripten-site/docs/getting_started/test-suite.html
 """
 
 # XXX Use EMTEST_ALL_ENGINES=1 in the env to test all engines!
-
-import sys
-
-# The emscripten test suite explcitly requires python3.6 or above.
-if sys.version_info < (3, 6):
-  print('error: emscripten requires python 3.6 or above', file=sys.stderr)
-  sys.exit(1)
 
 from subprocess import PIPE, STDOUT
 from functools import wraps
@@ -45,6 +38,7 @@ import shutil
 import string
 import subprocess
 import stat
+import sys
 import tempfile
 import time
 import unittest

--- a/tools/building.py
+++ b/tools/building.py
@@ -3,8 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
-
 import atexit
 import json
 import logging

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import os
 import shutil
 import logging
@@ -134,8 +133,4 @@ class Cache(object):
     return cachename
 
 
-try:
-  from . import shared
-except ImportError:
-  # Python 2 circular import compatibility
-  import shared
+from . import shared

--- a/tools/clean_webconsole.py
+++ b/tools/clean_webconsole.py
@@ -6,7 +6,6 @@
 """Removes timestamp and line info from a webgl log
 """
 
-from __future__ import print_function
 import os
 import re
 import sys

--- a/tools/create_dom_pk_codes.py
+++ b/tools/create_dom_pk_codes.py
@@ -31,7 +31,6 @@
 
 # Use #include <emscripten/dom_pk_codes.h> in your code to access these IDs.
 
-from __future__ import print_function
 import sys, random
 
 input_strings = [

--- a/tools/emdump.py
+++ b/tools/emdump.py
@@ -9,8 +9,6 @@
 """emdump.py prints out statistics about compiled code sizes
 """
 
-from __future__ import print_function
-
 import argparse
 import os
 import re

--- a/tools/emprofile.py
+++ b/tools/emprofile.py
@@ -4,7 +4,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import json
 import os
 import shutil

--- a/tools/ffdb.py
+++ b/tools/ffdb.py
@@ -4,7 +4,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import socket, json, sys, uuid, datetime, time, logging, cgi, zipfile, os, tempfile, atexit, subprocess, re, base64, struct, imghdr
 
 WINDOWS = sys.platform == 'win32'

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -4,8 +4,7 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-'''
-A tool that generates FS API calls to generate a filesystem, and packages the files
+"""A tool that generates FS API calls to generate a filesystem, and packages the files
 to work with that.
 
 This is called by emcc. You can also call it yourself.
@@ -54,9 +53,8 @@ Notes:
 
   * The file packager generates unix-style file paths. So if you are on windows and a file is accessed at
     subdir\file, in JS it will be subdir/file. For simplicity we treat the web platform as a *NIX.
-'''
+"""
 
-from __future__ import print_function
 import os
 import sys
 import shutil

--- a/tools/find_bigfuncs.py
+++ b/tools/find_bigfuncs.py
@@ -6,7 +6,6 @@
 """Tool to find or compare big functions in a js or ll file
 """
 
-from __future__ import print_function
 import sys
 
 

--- a/tools/find_bigvars.py
+++ b/tools/find_bigvars.py
@@ -6,7 +6,6 @@
 """Simple tool to find functions with lots of vars.
 """
 
-from __future__ import print_function
 import sys
 
 filename = sys.argv[1]

--- a/tools/install.py
+++ b/tools/install.py
@@ -9,8 +9,6 @@ a traditional `make dist` target but is written in python so it can be portable
 and run on non-unix platforms (basically windows).
 """
 
-from __future__ import print_function
-
 import argparse
 import fnmatch
 import logging

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -4,7 +4,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import os
 import sys
 import subprocess

--- a/tools/line_endings.py
+++ b/tools/line_endings.py
@@ -1,10 +1,9 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2014 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import os
 import sys
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -3,8 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
-
 from subprocess import PIPE
 import atexit
 import binascii
@@ -17,11 +15,13 @@ import re
 import shutil
 import subprocess
 import time
+import shlex
 import sys
 import tempfile
 
-if sys.version_info < (3, 5):
-  print('error: emscripten requires python 3.5 or above', file=sys.stderr)
+# We depend on python 3.6 for fstring support
+if sys.version_info < (3, 6):
+  print('error: emscripten requires python 3.6 or above', file=sys.stderr)
   sys.exit(1)
 
 from .toolchain_profiler import ToolchainProfiler
@@ -46,9 +46,6 @@ logging.basicConfig(format='%(name)s:%(levelname)s: %(message)s',
                     level=logging.DEBUG if DEBUG else logging.INFO)
 colored_logger.enable()
 logger = logging.getLogger('shared')
-
-if sys.version_info < (2, 7, 12):
-  logger.debug('python versions older than 2.7.12 are known to run into outdated SSL certificate related issues, https://github.com/emscripten-core/emscripten/issues/6275')
 
 # warning about absolute-paths is disabled by default, and not enabled by -Wall
 diagnostics.add_warning('absolute-paths', enabled=False, part_of_all=False)
@@ -80,49 +77,14 @@ def root_is_writable():
   return os.access(__rootpath__, os.W_OK)
 
 
-# Switch to shlex.quote once we can depend on python 3
 def shlex_quote(arg):
-  if ' ' in arg and (not (arg.startswith('"') and arg.endswith('"'))) and (not (arg.startswith("'") and arg.endswith("'"))):
-    return '"' + arg.replace('"', '\\"') + '"'
-
-  return arg
+  return shlex.quote(arg)
 
 
 # Switch to shlex.join once we can depend on python 3.8:
 # https://docs.python.org/3/library/shlex.html#shlex.join
 def shlex_join(cmd):
   return ' '.join(shlex_quote(x) for x in cmd)
-
-
-# This is a workaround for https://bugs.python.org/issue9400
-class Py2CalledProcessError(subprocess.CalledProcessError):
-  def __init__(self, returncode, cmd, output=None, stderr=None):
-    super(Exception, self).__init__(returncode, cmd, output, stderr)
-    self.returncode = returncode
-    self.cmd = cmd
-    self.output = output
-    self.stderr = stderr
-
-
-# https://docs.python.org/3/library/subprocess.html#subprocess.CompletedProcess
-class Py2CompletedProcess:
-  def __init__(self, args, returncode, stdout, stderr):
-    self.args = args
-    self.returncode = returncode
-    self.stdout = stdout
-    self.stderr = stderr
-
-  def __repr__(self):
-    _repr = ['args=%s' % repr(self.args), 'returncode=%s' % self.returncode]
-    if self.stdout is not None:
-      _repr.append('stdout=' + repr(self.stdout))
-    if self.stderr is not None:
-      _repr.append('stderr=' + repr(self.stderr))
-    return 'CompletedProcess(%s)' % ', '.join(_repr)
-
-  def check_returncode(self):
-    if self.returncode != 0:
-      raise Py2CalledProcessError(returncode=self.returncode, cmd=self.args, output=self.stdout, stderr=self.stderr)
 
 
 def run_process(cmd, check=True, input=None, *args, **kw):
@@ -134,24 +96,10 @@ def run_process(cmd, check=True, input=None, *args, **kw):
   """
 
   kw.setdefault('universal_newlines', True)
-
+  ret = subprocess.run(cmd, check=check, input=input, *args, **kw)
   debug_text = '%sexecuted %s' % ('successfully ' if check else '', shlex_join(cmd))
-
-  if hasattr(subprocess, "run"):
-    ret = subprocess.run(cmd, check=check, input=input, *args, **kw)
-    logger.debug(debug_text)
-    return ret
-
-  # Python 2 compatibility: Introduce Python 3 subprocess.run-like behavior
-  if input is not None:
-    kw['stdin'] = subprocess.PIPE
-  proc = subprocess.Popen(cmd, *args, **kw)
-  stdout, stderr = proc.communicate(input)
-  result = Py2CompletedProcess(cmd, proc.returncode, stdout, stderr)
-  if check:
-    result.check_returncode()
   logger.debug(debug_text)
-  return result
+  return ret
 
 
 def check_call(cmd, *args, **kw):
@@ -246,25 +194,25 @@ def generate_config(path, first_time=False):
     f.write(config_file)
 
   if first_time:
-    print('''
+    print(f'''
 ==============================================================================
 Welcome to Emscripten!
 
 This is the first time any of the Emscripten tools has been run.
 
-A settings file has been copied to %s, at absolute path: %s
+A settings file has been copied to {path}, at absolute path: {abspath}
 
 It contains our best guesses for the important paths, which are:
 
-  LLVM_ROOT       = %s
-  NODE_JS         = %s
-  EMSCRIPTEN_ROOT = %s
+  LLVM_ROOT       = {llvm_root}
+  NODE_JS         = {node}
+  EMSCRIPTEN_ROOT = {EMSCRIPTEN_ROOT}
 
 Please edit the file if any of those are incorrect.
 
 This command will now exit. When you are done editing those paths, re-run it.
 ==============================================================================
-''' % (path, abspath, llvm_root, node, EMSCRIPTEN_ROOT), file=sys.stderr)
+''', file=sys.stderr)
 
 
 def parse_config_file():
@@ -480,8 +428,7 @@ def generate_sanity():
     config = open(CONFIG_FILE).read()
   else:
     config = EM_CONFIG
-  # Convert to unsigned for python2 and python3 compat
-  checksum = binascii.crc32(config.encode()) & 0xffffffff
+  checksum = binascii.crc32(config.encode())
   sanity_file_content += '|%#x\n' % checksum
   return sanity_file_content
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import glob
 import hashlib
 import itertools

--- a/tools/tempfiles.py
+++ b/tools/tempfiles.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from __future__ import print_function
 import os
 import shutil
 import tempfile

--- a/tools/update_js.py
+++ b/tools/update_js.py
@@ -7,7 +7,6 @@
 Performs a search-replace in all of js/
 '''
 
-from __future__ import print_function
 import os
 
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -9,7 +9,6 @@ WebIDL binder
 http://kripken.github.io/emscripten-site/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.html
 '''
 
-from __future__ import print_function
 import os, sys
 
 sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))


### PR DESCRIPTION
We have been error'ing out python3 usage for a while now.
This change finally removes the python2 support so there
is no way back.

And to show we mean it, include an f-string in there
for good measure.

Fixes: #7198
