### PR TITLE
Force use of Ninja generator in test_cmake_with_embind_cpp11_mode

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -422,7 +422,7 @@ jobs:
       - run:
           name: Install packages
           command: |
-            choco install make cmake.portable
+            choco install make cmake.portable ninja
             choco install python --version 3.8.0
       - run:
           name: Add python to bash path
@@ -431,7 +431,7 @@ jobs:
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - run-tests:
-          test_targets: "other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null"
+          test_targets: "other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake*"
   test-mac:
     executor: mac
     steps:

--- a/tests/cmake/cmake_with_emval/CMakeLists.txt
+++ b/tests/cmake/cmake_with_emval/CMakeLists.txt
@@ -1,12 +1,12 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(cpp_with_emscripten_val)
+project(cmake_with_emval)
 
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 if (NO_GNU_EXTENSIONS)
-	set(CMAKE_CXX_EXTENSIONS OFF)
+  set(CMAKE_CXX_EXTENSIONS OFF)
 endif()
 
-add_executable(cpp_with_emscripten_val main.cpp)
+add_executable(cmake_with_emval main.cpp)

--- a/tests/cmake/cmake_with_emval/main.cpp
+++ b/tests/cmake/cmake_with_emval/main.cpp
@@ -9,12 +9,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int main()
-{
+int main() {
 #if __STRICT_ANSI__
-	int strict_ansi = 1;
+  int strict_ansi = 1;
 #else
-	int strict_ansi = 0;
+  int strict_ansi = 0;
 #endif
-	printf("Hello! __STRICT_ANSI__: %d, __cplusplus: %ld\n", strict_ansi, __cplusplus);
+  printf("Hello! __STRICT_ANSI__: %d, __cplusplus: %ld\n", strict_ansi, __cplusplus);
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -580,22 +580,28 @@ f.close()
     emscripten_features = '\n'.join([x for x in emscripten_features.split('\n') if '***' in x])
     self.assertTextDataIdentical(native_features, emscripten_features)
 
-  # Tests that it's possible to pass C++11 or GNU++11 build modes to CMake by building code that needs C++11 (embind)
+  # Tests that it's possible to pass C++11 or GNU++11 build modes to CMake by building code that
+  # needs C++11 (embind)
   def test_cmake_with_embind_cpp11_mode(self):
+    if WINDOWS and not shared.which('ninja'):
+      self.skipTest('Skipping cmake test on windows since ninja not found')
     for args in [[], ['-DNO_GNU_EXTENSIONS=1']]:
-      with temp_directory(self.get_dir()) as tempdirname:
-        configure = [emcmake, 'cmake', path_from_root('tests', 'cmake', 'cmake_with_emval')] + args
-        print(str(configure))
-        self.run_process(configure)
-        build = ['cmake', '--build', '.']
-        print(str(build))
-        self.run_process(build)
+      self.clear()
+      # Use ninja generator here since we assume its always installed on our build/test machines.
+      configure = [emcmake, 'cmake', path_from_root('tests', 'cmake', 'cmake_with_emval')] + args
+      if WINDOWS:
+        configure += ['-G', 'Ninja']
+      print(str(configure))
+      self.run_process(configure)
+      build = ['cmake', '--build', '.']
+      print(str(build))
+      self.run_process(build)
 
-        ret = self.run_process(NODE_JS + [os.path.join(tempdirname, 'cpp_with_emscripten_val.js')], stdout=PIPE).stdout.strip()
-        if '-DNO_GNU_EXTENSIONS=1' in args:
-          self.assertTextDataIdentical('Hello! __STRICT_ANSI__: 1, __cplusplus: 201103', ret)
-        else:
-          self.assertTextDataIdentical('Hello! __STRICT_ANSI__: 0, __cplusplus: 201103', ret)
+      out = self.run_process(NODE_JS + ['cmake_with_emval.js'], stdout=PIPE).stdout
+      if '-DNO_GNU_EXTENSIONS=1' in args:
+        self.assertContained('Hello! __STRICT_ANSI__: 1, __cplusplus: 201103', out)
+      else:
+        self.assertContained('Hello! __STRICT_ANSI__: 0, __cplusplus: 201103', out)
 
   # Tests that the Emscripten CMake toolchain option
   def test_cmake_bitcode_static_libraries(self):


### PR DESCRIPTION
This change includes a bunch of cleanups but the main change
here is to force the use of the Ninja generator.  Without
this this test will try to VS or nmake on windows which both
fail on emscripten-releases CI
    
This change is needed since we stopped forcing the default
generator on windows in #12595.
