### PR TITLE
Fix use of old __set_stack_limit function

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -385,7 +385,7 @@ mergeInto(LibraryManager.library, {
       STACK_MAX =  {{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.stack_limit, 'i32') }}};
 
 #if STACK_OVERFLOW_CHECK >= 2
-      Module['___set_stack_limit'](STACK_MAX);
+      Module['___set_stack_limits'](STACK_BASE, STACK_MAX);
 #endif
 
       stackRestore({{{ makeGetValue('newFiber', C_STRUCTS.emscripten_fiber_s.stack_ptr,   'i32') }}});


### PR DESCRIPTION
This was renamed to `__set_stack_limits` and the old version
removed completely from binaryen.

I guess that means we don't have testing for this path?