### PR TITLE
Fix duplicate `dylink` section in side modules

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6881,7 +6881,8 @@ int main() {
       for x in os.listdir('.'):
         self.assertFalse(x.endswith('.js'))
       self.assertTrue(building.is_wasm(target))
-      self.assertIn(b'dylink', open(target, 'rb').read())
+      wasm_data = open(target, 'rb').read()
+      self.assertEqual(wasm_data.count(b'dylink'), 1)
 
   def test_wasm_backend_lto(self):
     # test building of non-wasm-object-files libraries, building with them, and running them

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -122,7 +122,8 @@ def add_dylink_section(wasm_file, needed_dynlibs):
   assert wasm[offset] == 0
   offset += 1
   size, offset = readLEB(wasm, offset)
-  section = wasm[offset:offset + size]
+  section_end = offset + size
+  section = wasm[offset:section_end]
   # section name
   assert section.startswith(section_name)
   offset = len(section_name)
@@ -173,4 +174,4 @@ def add_dylink_section(wasm_file, needed_dynlibs):
     f.write(section_name)
     f.write(contents)
     # copy rest of binary
-    f.write(wasm[8:])
+    f.write(wasm[section_end:])


### PR DESCRIPTION
We were adding a second dylink section before the first
which is relatively harmless but certainly wrong.