### PR TITLE
Add control over JS version used in input and output of emscripten

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,13 @@ Current Trunk
   - STACK_MAX
   - STACKTOP
   - TOTAL_STACK
+- Support added for INPUT_JS_VERSION and OUTPUT_JS_VERSION settings.  These
+  control is/when we use the closure compiler to transpile the resulting
+  output.  If you use `--closure` compiler today we no longer default to
+  accepting `EMCASCRIPT_2020`.  If you want to use any langueage features
+  more recent than `ECMASCRIPT5` in your JS library code or inline JS assembly
+  code then you now need to pass a more recent version on the command line.
+  e.g. `-sINPUT_JS_VERSION=ECMASCRIPT2015`.  See #
 
 2.0.8: 10/24/2020
 -----------------

--- a/src/settings.js
+++ b/src/settings.js
@@ -1625,6 +1625,45 @@ var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = 0;
 // Internal (testing only): Forces memory growing to fail.
 var TEST_MEMORY_GROWTH_FAILS = 0;
 
+// The version of the JS standard that is used our JS library code (and
+// also any user JS library code) is expected to be written in.
+//
+// If this differs from OUTPUT_JS_VERSION then closure-compiler will be
+// run to transpile emscripten's output JS.
+//
+// In order to avoid transpiling in the command case we keep both these
+// settings in sync with the requires of the default set of browsers
+// versions  See MIN_FIREFOX_VERSION, etc.
+//
+// Value values to this setting are the same the values accepted by
+// closure compiler: ECMASCRIPT3, ECMASCRIPT5, ECMASCRIPT5_STRICT,
+// ECMASCRIPT_2015, ECMASCRIPT_2016, ECMASCRIPT_2017, ECMASCRIPT_2018,
+// ECMASCRIPT_2019
+//
+// See: https://github.com/google/closure-compiler/wiki/Flags-and-Options
+//
+// If you want to write libray code in some higher version that this
+// then you can use this option, but the output will be transpiled unless
+// you also increase the MIN browser versions (or OUTPUT_JS_VERSION).
+//
+// TODO(sbc): Update to ECMASCRIPT_2016 since I believe all the minimum
+// set of browsers all support this.
+//
+// TODO(sbc): Attempt to derive this, by default, from the minimum browser
+// versions.
+var INPUT_JS_VERSION = 'ECMASCRIPT5';
+
+// The version of the JS standard used in emscripten output.  If this differes
+// from INPUT_JS_VERSION then closure-compiler will be used to transpile the
+// output.
+var OUTPUT_JS_VERSION = 'ECMASCRIPT5';
+
+// Set to 0 to disable automatic traspilation of JS output from INPUT_JS_VERSION
+// to OUTPUT_JS_VERSION.  Does nothing if INPUT_JS_VERSION and OUTPUT_JS_VERSION
+// match.
+var TRANSPILE = 1;
+
+// Legacy settings that have been removed or renamed.
 // For renamed settings the format is:
 // [OLD_NAME, NEW_NAME]
 // For removed settings (which now effectively have a fixed value and can no

--- a/tools/building.py
+++ b/tools/building.py
@@ -893,7 +893,7 @@ def check_closure_compiler(cmd, args, env, allowed_to_fail):
   return True
 
 
-def closure_compiler(filename, pretty=True, advanced=True, extra_closure_args=None):
+def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   with ToolchainProfiler.profile_block('closure_compiler'):
     env = shared.env_with_node_in_path()
     user_args = []
@@ -967,12 +967,11 @@ def closure_compiler(filename, pretty=True, advanced=True, extra_closure_args=No
     configuration.get_temp_files().note(outfile)
 
     args = ['--compilation_level', 'ADVANCED_OPTIMIZATIONS' if advanced else 'SIMPLE_OPTIMIZATIONS']
-    # Keep in sync with ecmaVersion in tools/acorn-optimizer.js
-    args += ['--language_in', 'ECMASCRIPT_2020']
+    args += ['--language_in', Settings.INPUT_JS_VERSION]
     # Tell closure not to do any transpiling or inject any polyfills.
     # At some point we may want to look into using this as way to convert to ES5 but
     # babel is perhaps a better tool for that.
-    args += ['--language_out', 'NO_TRANSPILE']
+    args += ['--language_out', Settings.OUTPUT_JS_VERSION]
     # Tell closure never to inject the 'use strict' directive.
     args += ['--emit_use_strict=false']
 


### PR DESCRIPTION
This allows users more control of the version of JS they want
to produce and the version they want to use in their input.

It also fixes a bug where we were introducing non-ES5 features into our
output files by using closure with --language_out set to NO_TRANSPILE and
--language_in set to ECMASCRIPT_2020.

Fixes: #12628