### PR TITLE
Fix an off-by-one error when converting UTF16 strings to JavaScript strings

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -519,3 +519,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Pawel Czarnecki <pawel@8thwall.com> (copyright owned by 8th Wall, Inc.)
 * Dhairya Bahl < dhairyabahl5@gmail.com >
 * Sam Gao <gaoshan274@gmail.com>
+* Sebastian Mayr <me@sam.st>

--- a/src/runtime_strings_extra.js
+++ b/src/runtime_strings_extra.js
@@ -62,16 +62,18 @@ function UTF16ToString(ptr, maxBytesToRead) {
   } else {
 #endif // TEXTDECODER != 2
 #endif // TEXTDECODER
-    var i = 0;
-
     var str = '';
-    while (1) {
+
+    // If maxBytesToRead is not passed explicitly, it will be undefined, and the for-loop's condition
+    // will always evaluate to true. The loop is then terminated on the first null char.
+    for (var i = 0; !(i >= maxBytesToRead / 2); ++i) {
       var codeUnit = {{{ makeGetValue('ptr', 'i*2', 'i16') }}};
-      if (codeUnit == 0 || i == maxBytesToRead / 2) return str;
-      ++i;
+      if (codeUnit == 0) break;
       // fromCharCode constructs a character from a UTF-16 code unit, so we can pass the UTF16 string right through.
       str += String.fromCharCode(codeUnit);
     }
+
+    return str;
 #if TEXTDECODER && TEXTDECODER != 2
   }
 #endif // TEXTDECODER

--- a/tests/core/test_utf16.cpp
+++ b/tests/core/test_utf16.cpp
@@ -1,0 +1,60 @@
+// Copyright 2020 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <cassert>
+#include <emscripten.h>
+#include <stdio.h>
+#include <string>
+#include <vector>
+#include <wchar.h>
+
+// Roundtrip a (non-)null-terminated string between C++ and JS.
+EM_JS(void, roundtripString, (const char16_t* str, int strBytes, char16_t* result, int resultBytes), {
+  var jsStr = UTF16ToString(str, strBytes >= 0 ? strBytes : undefined);
+  out(jsStr);
+  var bytesWritten = stringToUTF16(jsStr, result, resultBytes);
+  if (bytesWritten != resultBytes - 2) throw 'stringToUTF16 wrote an invalid length: ' + numBytesWritten;
+});
+
+static void testString(const char16_t* arg) {
+  // Test with null-terminated string.
+  std::u16string strz(arg);
+  char16_t* result = new char16_t[strz.size() + 1]();
+  int resultBytes = (strz.size() + 1) * sizeof(char16_t);
+
+  roundtripString(strz.data(), -1, result, resultBytes);
+  // Compare strings after taking a route through JS side.
+  assert(std::equal(result, result + strz.size() + 1, strz.data()));
+
+  // Same test with non-null-terminated string and explicit length.
+  std::vector<char16_t> str(strz.begin(), strz.end());
+  std::fill_n(result, str.size() + 1, 0);
+
+  roundtripString(str.data(), str.size() * sizeof(char16_t), result, resultBytes);
+  assert(std::equal(result, result + str.size(), str.data()));
+
+  // Test again with some garbage at the end of the string.
+  std::vector<char16_t> strx(str);
+  strx.insert(strx.end(), 10, 'x');
+  std::fill_n(result, str.size() + 1, 0);
+
+  roundtripString(strx.data(), str.size() * sizeof(char16_t), result, resultBytes);
+  assert(std::equal(result, result + str.size(), str.data()));
+
+  delete[] result;
+}
+
+// This code tests that UTF16 strings can be marshalled between C++ and JS.
+int main() {
+  // For the conversion of long strings (more than 32 bytes), TextDecoder can be used.
+  testString(u"abc\u2603\u20AC\U0002007C123 --- abc\u2603\u20AC\U0002007C123");
+
+  // But for shorter strings it's never used.
+  testString(u"short\u2603\u20AC\U0002007C123");
+  testString(u"a");
+  testString(u"");
+
+  printf("OK.\n");
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5019,6 +5019,9 @@ main( int argv, char ** argc ) {
     self.do_runf(path_from_root('tests', 'utf32.cpp'), 'OK.')
     self.do_runf(path_from_root('tests', 'utf32.cpp'), 'OK.', args=['-fshort-wchar'])
 
+  def test_utf16(self):
+    self.do_runf(path_from_root('tests', 'core', 'test_utf16.cpp'), 'OK.')
+
   def test_utf8(self):
     if self.get_setting('MINIMAL_RUNTIME'):
       self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$AsciiToString', '$stringToAscii', '$writeAsciiToMemory'])


### PR DESCRIPTION
This issue can be triggered with the added test case. But it also occurs when returning a short (less than 32 byte) `std::u16string` from C++ to JS through embind. In this case, address sanitizer complains as following:

```==42==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x12301df4 at pc 0x0020a4e6 bp 0x109b8d60 sp 0x109b8d6c

test.js:3098 READ of size 2 at 0x12301df4 thread T0
test.js:3098     #0 0x20a4e6 in asan_c_load_2+0x20a4e6 (http://0.0.0.0:8000/build/test.wasm+0x20a4e6)

_asan_js_load_2 @ test.js:1579
UTF16ToString @ test.js:1859
fromWireType @ test.js:7348
simpleReadValueFromPointer @ test.js:5932
__emval_take_value @ test.js:7560
emscripten::val::val<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > const&>(std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > const&) @ val.h:347
emscripten::internal::VectorAccess<std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > >::get(std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > const&, unsigned long) @ bind.h:1716
emscripten::internal::FunctionInvoker<emscripten::val (*)(std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > const&, unsigned long), emscripten::val, std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > const&, unsigned long>::invoke(emscripten::val (**)(std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > const&, unsigned long), std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > >*, unsigned long) @ bind.h:499
vector$std$$u16string$$get @ VM1712:9
onRuntimeInitialized @ test.html:40
doRun @ test.js:9492
run @ test.js:9505
runCaller @ test.js:9473
removeRunDependency @ test.js:2221
processPackageData @ test.js:132
(anonymous) @ test.js:82
xhr.onload @ test.js:68
load (async)
fetchRemotePackage @ test.js:65
loadPackage @ test.js:80
(anonymous) @ test.js:153
(anonymous) @ test.js:1023

test.js:3098 
test.js:3098 0x12301df4 is located 0 bytes to the right of 20-byte region [0x12301de0,0x12301df4)
test.js:3098 allocated by thread T0 here:
test.js:3098     #0 0x1f6096 in malloc+0x1f6096 (http://0.0.0.0:8000/build/test.wasm+0x1f6096)
test.js:3098     #1 0x2dbbc in emscripten::internal::BindingType<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, void>::toWireType(std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > const&) ../../../../../../usr/lib/emscripten/system/include/emscripten/wire.h:296:41
test.js:3098     #2 0x2dab9 in emscripten::internal::WireTypePack<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > const&>::WireTypePack(std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > const&) ../../../../../../usr/lib/emscripten/system/include/emscripten/val.h:231:42
test.js:3098     #3 0x2a746 in emscripten::val::val<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > const&>(std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > const&) ../../../../../../usr/lib/emscripten/system/include/emscripten/val.h:346:29
test.js:3098     #4 0xcd63 in emscripten::internal::VectorAccess<std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > >::get(std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > const&, unsigned long) ../../../../../../usr/lib/emscripten/system/include/emscripten/bind.h:1716:28
test.js:3098     #5 0x2d62b in emscripten::internal::FunctionInvoker<emscripten::val (*)(std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > const&, unsigned long), emscripten::val, std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > const&, unsigned long>::invoke(emscripten::val (**)(std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > > const&, unsigned long), std::__2::vector<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> >, std::__2::allocator<std::__2::basic_string<char16_t, std::__2::char_traits<char16_t>, std::__2::allocator<char16_t> > > >*, unsigned long) ../../../../../../usr/lib/emscripten/system/include/emscripten/bind.h:499:21
test.js:3098     #6 0x80001ae9 in vector$std$$u16string$$get [as get] (eval at new_ eval at new_ (http://0.0.0.0:8000/build/test.js:6889:22), <anonymous>:9:10
test.js:3098     #7 0x80000028 in Object.onRuntimeInitialized http://0.0.0.0:8000/test.html:40:54
test.js:3098 
test.js:3098 SUMMARY: AddressSanitizer: heap-buffer-overflow (http://0.0.0.0:8000/build/test.wasm+0x20a4e5) in asan_c_load_2+0x20a4e5
```
It looks like embind passes `std::u16string`s to JS without null-terminator, which triggers the off-by-one.