### PR TITLE
Fix `-s EMSCRIPTEN_METADATA` in standalone mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2728,6 +2728,7 @@ def do_binaryen(target, options, wasm_target):
     webassembly.add_dylink_section(wasm_target, shared.Settings.RUNTIME_LINKED_LIBS)
 
   if shared.Settings.EMIT_EMSCRIPTEN_METADATA:
+    diagnostics.warning('deprecated', 'We hope to remove support for EMIT_EMSCRIPTEN_METADATA. See https://github.com/emscripten-core/emscripten/issues/12231')
     webassembly.add_emscripten_metadata(wasm_target)
 
   if final_js:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8071,13 +8071,19 @@ int main () {
   def test_emscripten_metadata(self):
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c')])
     self.assertNotIn(b'emscripten_metadata', open('a.out.wasm', 'rb').read())
+
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'),
                       '-s', 'EMIT_EMSCRIPTEN_METADATA'])
     self.assertIn(b'emscripten_metadata', open('a.out.wasm', 'rb').read())
 
+    # Test is standalone mode too.
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-o', 'out.wasm',
+                      '-s', 'EMIT_EMSCRIPTEN_METADATA'])
+    self.assertIn(b'emscripten_metadata', open('out.wasm', 'rb').read())
+
     # make sure wasm executes correctly
     ret = self.run_process(NODE_JS + ['a.out.js'], stdout=PIPE).stdout
-    self.assertTextDataIdentical('hello, world!\n', ret)
+    self.assertContained('hello, world!\n', ret)
 
   @parameterized({
     'O0': (False, ['-O0']), # noqa


### PR DESCRIPTION
The problem is that apply_memory is only called in modes where
JS is being generated.

Fixes: #12552