### PR TITLE
Fix MODULARIZE with sync compilation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -35,6 +35,10 @@ Current Trunk
   modules.  As one side effect of this change it is now required that JavaScript
   functions that are imported by address are now required to have a `__sig`
   specified in the library JavaScript file.
+- `MODULARIZE` + `WASM_ASYNC_COMPILATION=0`, that is, modularize mode but with
+  async compilation turned off, so that startup is synchronous, now returns the
+  Module object from the factory function (as it would not make sense to return
+  a Promise without async startup). See #12647
 
 2.0.8: 10/24/2020
 -----------------

--- a/emcc.py
+++ b/emcc.py
@@ -2841,7 +2841,9 @@ def modularize():
   logger.debug('Modularizing, assigning to var ' + shared.Settings.EXPORT_NAME)
   src = open(final_js).read()
 
-  return_value = shared.Settings.EXPORT_NAME + '.ready'
+  return_value = shared.Settings.EXPORT_NAME
+  if shared.Settings.WASM_ASYNC_COMPILATION:
+    return_value += '.ready'
   if not shared.Settings.EXPORT_READY_PROMISE:
     return_value = '{}'
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -954,6 +954,10 @@ var DETERMINISTIC = 0;
 // resolved with the module instance when it is safe to run the compiled code,
 // similar to the `onRuntimeInitialized` callback. You do not need to use the
 // `onRuntimeInitialized` callback when using `MODULARIZE`.
+//
+// (If WASM_ASYNC_COMPILATION is off, that is, if compilation is
+// *synchronous*, then it would not make sense to return a Promise, and instead
+// the Module object itself is returned, which is ready to be used.)
 // 
 // The default name of the function is `Module`, but can be changed using the
 // `EXPORT_NAME` option. We recommend renaming it to a more typical name for a

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3274,7 +3274,7 @@ window.close = function() {
         src = open(path_from_root('tests', 'browser_test_hello_world.c')).read()
         create_test_file('test.c', self.with_report_result(src))
         # this test is synchronous, so avoid async startup due to wasm features
-        self.compile_btest(['test.c', '-s', 'MODULARIZE=1', '-s', 'WASM_ASYNC_COMPILATION=0', '-s', 'SINGLE_FILE=1'] + args + opts)
+        self.compile_btest(['test.c', '-s', 'MODULARIZE=1', '-s', 'SINGLE_FILE=1'] + args + opts)
         create_test_file('a.html', '''
           <script src="a.out.js"></script>
           <script>


### PR DESCRIPTION
`MODULARIZE` + `WASM_ASYNC_COMPILATION=0`, that is, modularize mode but with
async compilation turned off, so that startup is synchronous, should return the
Module object from the factory function (as it would not make sense to return
a Promise without async startup). 

Fixes #12647