### PR TITLE
test_minimal_runtime_code_size: Don't use slop in EMTEST_REBASELINE mode

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21668,
-  "a.js.gz": 8361,
+  "a.js": 21688,
+  "a.js.gz": 8372,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 25435,
-  "total_gz": 11462
+  "total": 25447,
+  "total_gz": 11473
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21157,
-  "a.js.gz": 8193,
+  "a.js": 21177,
+  "a.js.gz": 8205,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 24924,
-  "total_gz": 11294
+  "total": 24936,
+  "total_gz": 11306
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
   "a.html": 13673,
   "a.html.gz": 7308,
-  "total": 13681,
+  "total": 13673,
   "total_gz": 7308
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8273,12 +8273,13 @@ int main () {
           # happens in wasm2js, so it may be platform-nondeterminism in closure
           # compiler).
           # TODO: identify what is causing this. meanwhile allow some amount of slop
-          if js:
-            slop = 30
-          else:
-            slop = 20
-          if size <= expected_size + slop and size >= expected_size - slop:
-            size = expected_size
+          if not os.environ.get('EMTEST_REBASELINE'):
+            if js:
+              slop = 30
+            else:
+              slop = 20
+            if size <= expected_size + slop and size >= expected_size - slop:
+              size = expected_size
 
           # N.B. even though the test code above prints out gzip compressed sizes, regression testing is done against uncompressed sizes
           # this is because optimizing for compressed sizes can be unpredictable and sometimes counterproductive


### PR DESCRIPTION
This was leading to some odd results in the expectations files there the
totals didn't add up.  As pointed out by @tlively in #12646.