### PR TITLE
Flush standard streams before running sub-process

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -161,9 +161,13 @@ class other(RunnerCore):
     for compiler in [EMCC, EMXX]:
       # -v, without input files
       proc = self.run_process([compiler, '-v'], stdout=PIPE, stderr=PIPE)
+      self.assertEqual(proc.stdout, '')
+      # assert that the emcc message comes first.  We had a bug where the sub-process output
+      # from clang would be flushed to stderr first.
+      self.assertContained('emcc (Emscripten gcc/clang-like replacement', proc.stderr)
+      self.assertTrue(proc.stderr.startswith('emcc (Emscripten gcc/clang-like replacement'))
       self.assertContained('clang version %s' % shared.EXPECTED_LLVM_VERSION, proc.stderr)
       self.assertContained('GNU', proc.stderr)
-      self.assertNotContained('this is dangerous', proc.stdout)
       self.assertNotContained('this is dangerous', proc.stderr)
 
   def test_emcc_generate_config(self):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -98,6 +98,10 @@ def run_process(cmd, check=True, input=None, *args, **kw):
   and should be fatal.  In those cases the `check_call` wrapper should be preferred.
   """
 
+  # Flush standard streams otherwise the output of the subprocess may appear in the
+  # output before messages that we have already written.
+  sys.stdout.flush()
+  sys.stderr.flush()
   kw.setdefault('universal_newlines', True)
   ret = subprocess.run(cmd, check=check, input=input, *args, **kw)
   debug_text = '%sexecuted %s' % ('successfully ' if check else '', shlex_join(cmd))


### PR DESCRIPTION
Without this, the subprocess output (which will be flushed
on sub-process exit) may appear in the output before message
that we have written.

This particular effects python3 which changed the default
buffering of std streams when in non-interative mode:
https://stackoverflow.com/questions/22471023/python-sys-stderr-flush-frequency

Fixes: #12654