### PR TITLE
Update documentation to call out benefits of using extern-post-js fla…

### DIFF
--- a/site/source/docs/getting_started/FAQ.rst
+++ b/site/source/docs/getting_started/FAQ.rst
@@ -274,6 +274,12 @@ Another option is to use the ``MODULARIZE`` option, using ``-s MODULARIZE=1``. T
 
 Note that in ``MODULARIZE`` mode we do not look for a global Module object for default values. Default values must be passed as a parameter to the factory function.  (see details in settings.js)
 
+Why is Module['onRuntimeInitialized'] not called when my JavaScript file is loaded?
+===================================================================================
+
+When you are compiling your application to a ``.js`` file, you normally use ``emcc`` or ``em++`` flag ``--post-js`` to load the file. Then, your next ``<script>`` tag will likely have a ``src`` attribute pointing to your client or appliciation code, such as ``index.js``, ``main.js``, or ``app.js``.
+
+Rather than loading them in two separate script tags, you can use the ``--extern-post-js`` :ref:`compiler flag <emcc-extern-post-js>` to append your client code to the same file. Doing so will ensure your callback is registered before the Module is loaded.
 
 .. _faq-NO_EXIT_RUNTIME:
 

--- a/site/source/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.rst
@@ -131,6 +131,9 @@ You can use the `EXPORT_NAME` option to change `Module` to something else. This 
 good practice for libraries, as then they don't include unnecessary things in the
 global scope, and in some cases you want to create more than one.
 
+You can also consider using the ``--extern-post-js`` :ref:`compiler flag <emcc-extern-post-js>` to append your client code to the compiled file. 
+Doing so will ensure your callback is registered before the Module is loaded and the ``onRuntimeInitialized`` promised is resolved.
+
 
 Using C++ classes in JavaScript
 ================================

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -239,6 +239,8 @@ Options that are modified or new in *emcc* are listed below:
   code together with everything else, keep it in the same scope if running
   `MODULARIZE`, etc.).
 
+.. _emcc-extern-post-js:
+
 ``--extern-post-js <file>``
   Like ``--extern-pre-js``, but appends to the end.
 


### PR DESCRIPTION
…g for onRuntimeInitialized

* add reference to extern-post-js compiler flag on emcc page
* add insight into FAQ section about a potential misfire between generated JS and your scripts which load later
* add similar information in WebIDL binder documentation on Modular output, which is what I followed to discover this issue

@kripken refs https://github.com/emscripten-core/emscripten/issues/12637