### PR TITLE
library OpenAL JS: prevents crash

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -704,7 +704,9 @@ var LibraryOpenAL = {
 
       var offset = 0.0;
       for (var i = 0; i < src.bufsProcessed; i++) {
-        offset += src.bufQueue[i].audioBuf.duration;
+        if (src.bufQueue[i].audioBuf) {
+          offset += src.bufQueue[i].audioBuf.duration;
+        }
       }
       offset += src.bufOffset;
 
@@ -4886,4 +4888,3 @@ var LibraryOpenAL = {
 
 autoAddDeps(LibraryOpenAL, '$AL');
 mergeInto(LibraryManager.library, LibraryOpenAL);
-


### PR DESCRIPTION
- audioBuf may be null, it's better to silently ignore then crash user application.
- this is the behavior on most desktop implementations of OpenAL, including MojoAL
- feel free to squash my commits into one.