### PR TITLE
Remove setErrNo dependency from library_fs.js. NFC.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -50,7 +50,13 @@ LibraryManager.library = {
   // utime.h
   // ==========================================================================
 
-  utime__deps: ['$FS', '$setErrNo'],
+  $handleFSError__deps: ['$setErrNo'],
+  $handleFSError: function(e) {
+    if (!(e instanceof FS.ErrnoError)) throw e + ' : ' + stackTrace();
+    return setErrNo(e.errno);
+  },
+
+  utime__deps: ['$FS', '$handleFSError'],
   utime__proxy: 'sync',
   utime__sig: 'iii',
   utime: function(path, times) {
@@ -70,12 +76,12 @@ LibraryManager.library = {
       FS.utime(path, time, time);
       return 0;
     } catch (e) {
-      FS.handleFSError(e);
+      handleFSError(e);
       return -1;
     }
   },
 
-  utimes__deps: ['$FS', '$setErrNo'],
+  utimes__deps: ['$FS', '$handleFSError'],
   utimes__proxy: 'sync',
   utimes__sig: 'iii',
   utimes: function(path, times) {
@@ -93,7 +99,7 @@ LibraryManager.library = {
       FS.utime(path, time, time);
       return 0;
     } catch (e) {
-      FS.handleFSError(e);
+      handleFSError(e);
       return -1;
     }
   },

--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.exports
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.exports
@@ -1,4 +1,3 @@
-__errno_location
 __wasm_call_ctors
 dynCall_jiji
 main

--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.funcs
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.funcs
@@ -1,6 +1,5 @@
 $__emscripten_stdout_close
 $__emscripten_stdout_seek
-$__errno_location
 $__fwritex
 $__overflow
 $__stdio_write


### PR DESCRIPTION
The filesystem library generally reports errors by throwing
`FS.ErrnoError` exceptions so it should not need ever need
to set errno directly.

Errno gets set in library_syscalls were each syscall is
is wrapped in a try/catch that returns errno back to libs.

In order to remove this dependency I had to remove the three
different uses of `setErrNo` in library_fs.js:

1. `handleFSErro`r.  This only had two caller, both in
   library.js so moved this there and added a seperate
   dependency on setErrNo.

2. `findObject`: Only has a single caller in src/library_dylink.js
   which only cared about a binary result and certainly
   doesn't check the errno location.

3. `forceLoadFile`: Had exactly two internal callers that both
   turned the error into an exception anyway, so just throw
   the exception directly.