### PR TITLE
Move all wasi syscalls to library_wasi.js. NFC.

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1454,156 +1454,15 @@ var SyscallsLibrary = {
 #endif
     return 0;
   },
-
-  // WASI (WebAssembly System Interface) I/O support.
-  // This is the set of syscalls that use the FS etc. APIs. The rest is in
-  // library_wasi.js.
-
-#if SYSCALLS_REQUIRE_FILESYSTEM == 0 && (!MINIMAL_RUNTIME || EXIT_RUNTIME)
-  $flush_NO_FILESYSTEM: function() {
-    // flush anything remaining in the buffers during shutdown
-    if (typeof _fflush !== 'undefined') _fflush(0);
-    var buffers = SYSCALLS.buffers;
-    if (buffers[1].length) SYSCALLS.printChar(1, {{{ charCode("\n") }}});
-    if (buffers[2].length) SYSCALLS.printChar(2, {{{ charCode("\n") }}});
-  },
-  fd_write__deps: ['$flush_NO_FILESYSTEM'],
-#if EXIT_RUNTIME == 1
-  fd_write__postset: '__ATEXIT__.push(flush_NO_FILESYSTEM);',
-#endif
-#endif
-  fd_write__sig: 'iiiii',
-  fd_write: function(fd, iov, iovcnt, pnum) {
-#if SYSCALLS_REQUIRE_FILESYSTEM
-    var stream = SYSCALLS.getStreamFromFD(fd);
-    var num = SYSCALLS.doWritev(stream, iov, iovcnt);
-#else
-    // hack to support printf in SYSCALLS_REQUIRE_FILESYSTEM=0
-    var num = 0;
-    for (var i = 0; i < iovcnt; i++) {
-      var ptr = {{{ makeGetValue('iov', 'i*8', 'i32') }}};
-      var len = {{{ makeGetValue('iov', 'i*8 + 4', 'i32') }}};
-      for (var j = 0; j < len; j++) {
-        SYSCALLS.printChar(fd, HEAPU8[ptr+j]);
-      }
-      num += len;
-    }
-#endif // SYSCALLS_REQUIRE_FILESYSTEM
-    {{{ makeSetValue('pnum', 0, 'num', 'i32') }}}
-    return 0;
-  },
-  fd_close__sig: 'ii',
-  fd_close: function(fd) {
-#if SYSCALLS_REQUIRE_FILESYSTEM
-    var stream = SYSCALLS.getStreamFromFD(fd);
-    FS.close(stream);
-#else
-#if PROXY_POSIX_SOCKETS
-    // close() is a tricky function because it can be used to close both regular file descriptors
-    // and POSIX network socket handles, hence an implementation would need to track for each
-    // file descriptor which kind of item it is. To simplify, when using PROXY_POSIX_SOCKETS
-    // option, use shutdown() to close a socket, and this function should behave like a no-op.
-    warnOnce('To close sockets with PROXY_POSIX_SOCKETS bridge, prefer to use the function shutdown() that is proxied, instead of close()')
-#else
-#if ASSERTIONS
-    abort('it should not be possible to operate on streams when !SYSCALLS_REQUIRE_FILESYSTEM');
-#endif
-#endif
-#endif
-    return 0;
-  },
-  fd_read__sig: 'iiiii',
-  fd_read: function(fd, iov, iovcnt, pnum) {
-    var stream = SYSCALLS.getStreamFromFD(fd);
-    var num = SYSCALLS.doReadv(stream, iov, iovcnt);
-    {{{ makeSetValue('pnum', 0, 'num', 'i32') }}}
-    return 0;
-  },
-  fd_seek__sig: 'iiiiii',
-  fd_seek: function(fd, {{{ defineI64Param('offset') }}}, whence, newOffset) {
-    {{{ receiveI64ParamAsI32s('offset') }}}
-    var stream = SYSCALLS.getStreamFromFD(fd);
-    var HIGH_OFFSET = 0x100000000; // 2^32
-    // use an unsigned operator on low and shift high by 32-bits
-    var offset = offset_high * HIGH_OFFSET + (offset_low >>> 0);
-
-    var DOUBLE_LIMIT = 0x20000000000000; // 2^53
-    // we also check for equality since DOUBLE_LIMIT + 1 == DOUBLE_LIMIT
-    if (offset <= -DOUBLE_LIMIT || offset >= DOUBLE_LIMIT) {
-      return -{{{ cDefine('EOVERFLOW') }}};
-    }
-
-    FS.llseek(stream, offset, whence);
-    {{{ makeSetValue('newOffset', '0', 'stream.position', 'i64') }}};
-    if (stream.getdents && offset === 0 && whence === {{{ cDefine('SEEK_SET') }}}) stream.getdents = null; // reset readdir state
-    return 0;
-  },
-  fd_fdstat_get__sig: 'iii',
-  fd_fdstat_get: function(fd, pbuf) {
-#if SYSCALLS_REQUIRE_FILESYSTEM
-    var stream = SYSCALLS.getStreamFromFD(fd);
-    // All character devices are terminals (other things a Linux system would
-    // assume is a character device, like the mouse, we have special APIs for).
-    var type = stream.tty ? {{{ cDefine('__WASI_FILETYPE_CHARACTER_DEVICE') }}} :
-               FS.isDir(stream.mode) ? {{{ cDefine('__WASI_FILETYPE_DIRECTORY') }}} :
-               FS.isLink(stream.mode) ? {{{ cDefine('__WASI_FILETYPE_SYMBOLIC_LINK') }}} :
-               {{{ cDefine('__WASI_FILETYPE_REGULAR_FILE') }}};
-#else
-    // hack to support printf in SYSCALLS_REQUIRE_FILESYSTEM=0
-    var type = fd == 1 || fd == 2 ? {{{ cDefine('__WASI_FILETYPE_CHARACTER_DEVICE') }}} : abort();
-#endif
-    {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_filetype, 'type', 'i8') }}};
-    // TODO {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_flags, '?', 'i16') }}};
-    // TODO {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_rights_base, '?', 'i64') }}};
-    // TODO {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_rights_inheriting, '?', 'i64') }}};
-    return 0;
-  },
-  fd_sync__sig: 'ii',
-  fd_sync: function(fd) {
-    var stream = SYSCALLS.getStreamFromFD(fd);
-#if ASYNCIFY
-    return Asyncify.handleSleep(function(wakeUp) {
-      var mount = stream.node.mount;
-      if (!mount.type.syncfs) {
-        // We write directly to the file system, so there's nothing to do here.
-        wakeUp(0);
-        return;
-      }
-      mount.type.syncfs(mount, false, function(err) {
-        if (err) {
-          wakeUp(function() { return {{{ cDefine('EIO') }}} });
-          return;
-        }
-        wakeUp(0);
-      });
-    });
-#else
-    if (stream.stream_ops && stream.stream_ops.fsync) {
-      return -stream.stream_ops.fsync(stream);
-    }
-    return 0; // we can't do anything synchronously; the in-memory FS is already synced to
-#endif // ASYNCIFY
-  },
-
 };
 
-var WASI_SYSCALLS = set([
-  'fd_write',
-  'fd_close',
-  'fd_read',
-  'fd_seek',
-  'fd_fdstat_get',
-  'fd_sync',
-]);
-
-for (var x in SyscallsLibrary) {
+function wrapSyscallFunction(x, library, isWasi) {
   if (x[0] === '$' || isJsLibraryConfigIdentifier(x)) {
-    continue;
+    return;
   }
 
-  var wasi = x in WASI_SYSCALLS;
-  var t = SyscallsLibrary[x];
-  if (typeof t === 'string') continue;
+  var t = library[x];
+  if (typeof t === 'string') return;
   t = t.toString();
 
   // If a syscall uses FS, but !SYSCALLS_REQUIRE_FILESYSTEM, then the user
@@ -1617,11 +1476,11 @@ for (var x in SyscallsLibrary) {
     });
   }
 
-  var isVariadic = !wasi && t.indexOf(', varargs') != -1;
+  var isVariadic = !isWasi && t.indexOf(', varargs') != -1;
 #if SYSCALLS_REQUIRE_FILESYSTEM == 0
   var canThrow = false;
 #else
-  var canThrow = SyscallsLibrary[x + '__nothrow'] !== true;
+  var canThrow = library[x + '__nothrow'] !== true;
 #endif
 
   var pre = '', post = '';
@@ -1647,7 +1506,7 @@ for (var x in SyscallsLibrary) {
   post += "err('syscall return: ' + ret);\n";
   post += "return ret;\n";
 #endif
-  delete SyscallsLibrary[x + '__nothrow'];
+  delete library[x + '__nothrow'];
   var handler = '';
   if (canThrow) {
     pre += 'try {\n';
@@ -1659,14 +1518,14 @@ for (var x in SyscallsLibrary) {
     "  err('error: syscall failed with ' + e.errno + ' (' + ERRNO_MESSAGES[e.errno] + ')');\n" +
     "  canWarn = false;\n";
 #endif
-    if (wasi) {
+    // Musl syscalls are negated.
+    if (isWasi) {
       handler += "  return e.errno;\n";
     } else {
       // Musl syscalls are negated.
       handler += "  return -e.errno;\n";
     }
-    handler +=
-    "}\n";
+    handler += "}\n";
   }
   post = handler + post;
 
@@ -1678,9 +1537,9 @@ for (var x in SyscallsLibrary) {
     var bodyEnd = t.lastIndexOf('}');
     t = t.substring(0, bodyEnd) + post + t.substring(bodyEnd);
   }
-  SyscallsLibrary[x] = eval('(' + t + ')');
-  if (!SyscallsLibrary[x + '__deps']) SyscallsLibrary[x + '__deps'] = [];
-  SyscallsLibrary[x + '__deps'].push('$SYSCALLS');
+  library[x] = eval('(' + t + ')');
+  if (!library[x + '__deps']) library[x + '__deps'] = [];
+  library[x + '__deps'].push('$SYSCALLS');
 #if USE_PTHREADS
   // Most syscalls need to happen on the main JS thread (e.g. because the
   // filesystem is in JS and on that thread). Proxy synchronously to there.
@@ -1691,10 +1550,14 @@ for (var x in SyscallsLibrary) {
   // instead of synchronously, and marked with
   //  __proxy: 'async'
   // (but essentially all syscalls do have return values).
-  if (SyscallsLibrary[x + '__proxy'] === undefined) {
-    SyscallsLibrary[x + '__proxy'] = 'sync';
+  if (library[x + '__proxy'] === undefined) {
+    library[x + '__proxy'] = 'sync';
   }
 #endif
+}
+
+for (var x in SyscallsLibrary) {
+  wrapSyscallFunction(x, SyscallsLibrary, false);
 }
 
 mergeInto(LibraryManager.library, SyscallsLibrary);

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -159,6 +159,140 @@ var WasiLibrary = {
     {{{ makeSetValue('pres', 4, '(nsec / Math.pow(2, 32)) >>> 0', 'i32') }}};
     return 0;
   },
+
+#if SYSCALLS_REQUIRE_FILESYSTEM == 0 && (!MINIMAL_RUNTIME || EXIT_RUNTIME)
+  $flush_NO_FILESYSTEM: function() {
+    // flush anything remaining in the buffers during shutdown
+    if (typeof _fflush !== 'undefined') _fflush(0);
+    var buffers = SYSCALLS.buffers;
+    if (buffers[1].length) SYSCALLS.printChar(1, {{{ charCode("\n") }}});
+    if (buffers[2].length) SYSCALLS.printChar(2, {{{ charCode("\n") }}});
+  },
+  fd_write__deps: ['$flush_NO_FILESYSTEM'],
+#if EXIT_RUNTIME == 1
+  fd_write__postset: '__ATEXIT__.push(flush_NO_FILESYSTEM);',
+#endif
+#endif
+  fd_write__sig: 'iiiii',
+  fd_write: function(fd, iov, iovcnt, pnum) {
+#if SYSCALLS_REQUIRE_FILESYSTEM
+    var stream = SYSCALLS.getStreamFromFD(fd);
+    var num = SYSCALLS.doWritev(stream, iov, iovcnt);
+#else
+    // hack to support printf in SYSCALLS_REQUIRE_FILESYSTEM=0
+    var num = 0;
+    for (var i = 0; i < iovcnt; i++) {
+      var ptr = {{{ makeGetValue('iov', 'i*8', 'i32') }}};
+      var len = {{{ makeGetValue('iov', 'i*8 + 4', 'i32') }}};
+      for (var j = 0; j < len; j++) {
+        SYSCALLS.printChar(fd, HEAPU8[ptr+j]);
+      }
+      num += len;
+    }
+#endif // SYSCALLS_REQUIRE_FILESYSTEM
+    {{{ makeSetValue('pnum', 0, 'num', 'i32') }}}
+    return 0;
+  },
+
+  fd_close__sig: 'ii',
+  fd_close: function(fd) {
+#if SYSCALLS_REQUIRE_FILESYSTEM
+    var stream = SYSCALLS.getStreamFromFD(fd);
+    FS.close(stream);
+#else
+#if PROXY_POSIX_SOCKETS
+    // close() is a tricky function because it can be used to close both regular file descriptors
+    // and POSIX network socket handles, hence an implementation would need to track for each
+    // file descriptor which kind of item it is. To simplify, when using PROXY_POSIX_SOCKETS
+    // option, use shutdown() to close a socket, and this function should behave like a no-op.
+    warnOnce('To close sockets with PROXY_POSIX_SOCKETS bridge, prefer to use the function shutdown() that is proxied, instead of close()')
+#else
+#if ASSERTIONS
+    abort('it should not be possible to operate on streams when !SYSCALLS_REQUIRE_FILESYSTEM');
+#endif
+#endif
+#endif
+    return 0;
+  },
+
+  fd_read__sig: 'iiiii',
+  fd_read: function(fd, iov, iovcnt, pnum) {
+    var stream = SYSCALLS.getStreamFromFD(fd);
+    var num = SYSCALLS.doReadv(stream, iov, iovcnt);
+    {{{ makeSetValue('pnum', 0, 'num', 'i32') }}}
+    return 0;
+  },
+
+  fd_seek__sig: 'iiiiii',
+  fd_seek: function(fd, {{{ defineI64Param('offset') }}}, whence, newOffset) {
+    {{{ receiveI64ParamAsI32s('offset') }}}
+    var stream = SYSCALLS.getStreamFromFD(fd);
+    var HIGH_OFFSET = 0x100000000; // 2^32
+    // use an unsigned operator on low and shift high by 32-bits
+    var offset = offset_high * HIGH_OFFSET + (offset_low >>> 0);
+
+    var DOUBLE_LIMIT = 0x20000000000000; // 2^53
+    // we also check for equality since DOUBLE_LIMIT + 1 == DOUBLE_LIMIT
+    if (offset <= -DOUBLE_LIMIT || offset >= DOUBLE_LIMIT) {
+      return -{{{ cDefine('EOVERFLOW') }}};
+    }
+
+    FS.llseek(stream, offset, whence);
+    {{{ makeSetValue('newOffset', '0', 'stream.position', 'i64') }}};
+    if (stream.getdents && offset === 0 && whence === {{{ cDefine('SEEK_SET') }}}) stream.getdents = null; // reset readdir state
+    return 0;
+  },
+  fd_fdstat_get__sig: 'iii',
+  fd_fdstat_get: function(fd, pbuf) {
+#if SYSCALLS_REQUIRE_FILESYSTEM
+    var stream = SYSCALLS.getStreamFromFD(fd);
+    // All character devices are terminals (other things a Linux system would
+    // assume is a character device, like the mouse, we have special APIs for).
+    var type = stream.tty ? {{{ cDefine('__WASI_FILETYPE_CHARACTER_DEVICE') }}} :
+               FS.isDir(stream.mode) ? {{{ cDefine('__WASI_FILETYPE_DIRECTORY') }}} :
+               FS.isLink(stream.mode) ? {{{ cDefine('__WASI_FILETYPE_SYMBOLIC_LINK') }}} :
+               {{{ cDefine('__WASI_FILETYPE_REGULAR_FILE') }}};
+#else
+    // hack to support printf in SYSCALLS_REQUIRE_FILESYSTEM=0
+    var type = fd == 1 || fd == 2 ? {{{ cDefine('__WASI_FILETYPE_CHARACTER_DEVICE') }}} : abort();
+#endif
+    {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_filetype, 'type', 'i8') }}};
+    // TODO {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_flags, '?', 'i16') }}};
+    // TODO {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_rights_base, '?', 'i64') }}};
+    // TODO {{{ makeSetValue('pbuf', C_STRUCTS.__wasi_fdstat_t.fs_rights_inheriting, '?', 'i64') }}};
+    return 0;
+  },
+
+  fd_sync__sig: 'ii',
+  fd_sync: function(fd) {
+    var stream = SYSCALLS.getStreamFromFD(fd);
+#if ASYNCIFY
+    return Asyncify.handleSleep(function(wakeUp) {
+      var mount = stream.node.mount;
+      if (!mount.type.syncfs) {
+        // We write directly to the file system, so there's nothing to do here.
+        wakeUp(0);
+        return;
+      }
+      mount.type.syncfs(mount, false, function(err) {
+        if (err) {
+          wakeUp(function() { return {{{ cDefine('EIO') }}} });
+          return;
+        }
+        wakeUp(0);
+      });
+    });
+#else
+    if (stream.stream_ops && stream.stream_ops.fsync) {
+      return -stream.stream_ops.fsync(stream);
+    }
+    return 0; // we can't do anything synchronously; the in-memory FS is already synced to
+#endif // ASYNCIFY
+  },
 };
+
+for (var x in WasiLibrary) {
+  wrapSyscallFunction(x, WasiLibrary, true);
+}
 
 mergeInto(LibraryManager.library, WasiLibrary);


### PR DESCRIPTION
To make this possible I factored out the `wrapSyscallFunction`
function to make it callable from two different locations.