### PR TITLE
Escape strings in JSON generated by binaryen

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -521,3 +521,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dhairya Bahl < dhairyabahl5@gmail.com >
 * Sam Gao <gaoshan274@gmail.com>
 * Sebastian Mayr <me@sam.st>
+* Alexandre Senges <alexandre@senges.ch>

--- a/tools/building.py
+++ b/tools/building.py
@@ -1542,7 +1542,7 @@ def clean_finalized_output(output):
   # Clean JSON, so that [..., "abc"de"", ...] gets escaped properly when compiling with Rust
   if output is None:
     return None
-  regexp = re.compile('"\w+":.+')
+  regexp = re.compile('"\\w+":.+')
   lines = output.split(",")
   cleaned_lines = []
   for line in lines:


### PR DESCRIPTION
When compiling with Rust and C++ together, I get an error: `json.decoder.JSONDecodeError: Extra data: line 1 column 13 (char 12)`

That's because the generated JSON looks like:

```    
    "declares": [
              "__cxa_find_matching_catch_2",
              "getTempRet0",
              "__resumeException",
              "__invoke_void_i32*_i32",
              "__invoke_void",
              "__invoke_void_{}*",
              "__invoke_void_[0xi8]*_i32_{}*_[3xi32]*_%"core::panic::Location"*",
              "__invoke_i32*_i32*",
              "__invoke_void_{}*_[3xi32]*_i32*_%"core::panic::Location"*",
              "__invoke_i1_%"core::fmt::Formatter"*_%"core::fmt::Arguments"*",
              "__invoke_void_%"alloc::vec::Vec<usize>"*_%"alloc::vec::Vec<usize>"*_i32",
              "__invoke_void_%"alloc::vec::Vec<usize>"*_%"alloc::vec::Vec<usize>"*",
              "__invoke_void_%"core::option::Option<core::cell::Cell<externref::Slab>>"*_%"core::option::Option<core::cell::Cell<externref::Slab>>"*_i32",
              "__invoke_void_%"core::option::Option<core::cell::Cell<externref::Slab>>"*_%"core::option::Option<core::cell::Cell<externref::Slab>>"*",
              "__invoke_void_%"externref::Slab"*_%"externref::Slab"*_i32",
              "__invoke_void_%"externref::Slab"*_%"externref::Slab"*",
              "__invoke_void_%"alloc::vec::Vec<usize>"*",
              "__invoke_i32",
              ...
```

This line for instance `"__invoke_void_%"core::option::Option<core::cell::Cell<externref::Slab>>"*_%"core::option::Option<core::cell::Cell<externref::Slab>>"*_i32",` is not valid JSON.

My PR provides a quick hack to fix that