### PR TITLE
Error on bad JS library elements

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -127,7 +127,7 @@ function JSify(data, functionsOnly) {
 
       var noExport = false;
 
-      if (!LibraryManager.library.hasOwnProperty(ident) && !LibraryManager.library.hasOwnProperty(ident + '__inline')) {
+      if (!LibraryManager.library.hasOwnProperty(ident)) {
         if (!(finalName in IMPLEMENTED_FUNCTIONS) && !LINKABLE) {
           var msg = 'undefined symbol: ' + ident;
           if (dependent) msg += ' (referenced by ' + dependent + ')';

--- a/src/library.js
+++ b/src/library.js
@@ -726,16 +726,6 @@ LibraryManager.library = {
     return limit;
   },
 
-  // ==========================================================================
-  // string.h
-  // ==========================================================================
-
-  memcpy__inline: function(dest, src, num, align) {
-    var ret = '';
-    ret += makeCopyValues(dest, src, num, 'null', null, align);
-    return ret;
-  },
-
 #if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101 || STANDALONE_WASM
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin lists browsers that support TypedArray.prototype.copyWithin, but it
   // has outdated information for Safari, saying it would not support it.

--- a/src/modules.js
+++ b/src/modules.js
@@ -216,7 +216,14 @@ var LibraryManager = {
     // (and makes it simpler to switch between SDL versions, fastcomp and non-fastcomp, etc.).
     var lib = LibraryManager.library;
     libloop: for (var x in lib) {
-      if (x.lastIndexOf('__') > 0) continue; // ignore __deps, __*
+      if (isJsLibraryConfigIdentifier(x)) {
+        var index = x.lastIndexOf('__');
+        var basename = x.slice(0, index);
+        if (!(basename in lib)) {
+          error('Missing library element `' + basename + '` for library config `' + x + '`');
+        }
+        continue;
+      }
       if (typeof lib[x] === 'string') {
         var target = x;
         while (typeof lib[target] === 'string') {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9578,6 +9578,17 @@ exec "$@"
                       '--js-library=lib1.js',
                       '--js-library=lib2.js'])
 
+  def test_jslib_bad_config(self):
+    # Regression check for an issue we have where a library clobbering the global `i` variable could
+    # prevent processing of further libraries.
+    create_test_file('lib.js', '''
+      mergeInto(LibraryManager.library, {
+       foo__sig: 'ii',
+      });
+      ''')
+    err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '--js-library=lib.js'])
+    self.assertContained('error: Missing library element `foo` for library config `foo__sig`', err)
+
   def test_wasm2js_no_dynamic_linking(self):
     for arg in ['-sMAIN_MODULE', '-sSIDE_MODULE', '-sRELOCATABLE']:
       err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-sMAIN_MODULE', '-sWASM=0'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9579,8 +9579,6 @@ exec "$@"
                       '--js-library=lib2.js'])
 
   def test_jslib_bad_config(self):
-    # Regression check for an issue we have where a library clobbering the global `i` variable could
-    # prevent processing of further libraries.
     create_test_file('lib.js', '''
       mergeInto(LibraryManager.library, {
        foo__sig: 'ii',


### PR DESCRIPTION
For libary config element such as `foo__sig` error out if
the corresponding library member is not found (in this
case if `foo` is not in the library.

This found `memcpy__inline` which can be removed since
memcpy is no longer part of the JS library.

Also remove `__inline` completely since this was the last
use of it, and its asmjs specific.