### PR TITLE
Make the DOM codes reproducible

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -521,3 +521,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Dhairya Bahl < dhairyabahl5@gmail.com >
 * Sam Gao <gaoshan274@gmail.com>
 * Sebastian Mayr <me@sam.st>
+* Chris Lamb <chris@chris-lamb.co.uk>

--- a/tools/create_dom_pk_codes.py
+++ b/tools/create_dom_pk_codes.py
@@ -31,7 +31,7 @@
 
 # Use #include <emscripten/dom_pk_codes.h> in your code to access these IDs.
 
-import sys, random
+import sys, random, os
 
 input_strings = [
   (0x0, 'Unidentified',          'DOM_PK_UNKNOWN'),
@@ -241,6 +241,7 @@ def hash_all(k1, k2):
 # value at step i, k_1 and k_2 are the constants we are searching, and s_i is the i'th input
 # character
 perfect_hash_table = None
+random.seed(os.environ.get('SOURCE_DATE_EPOCH'))
 while perfect_hash_table == None:
   # The search space is super-narrow, but since there are so few items to hash, practically
   # almost any choice gives a collision free hash.


### PR DESCRIPTION
Whilst working on the [Reproducible Builds effort](https://reproducible-builds.org/) I noticed that emscripten could not be built reproducibly. This is because it generates a switch/case statement using Python's `random.randint`/`random.uniform` functionality.

This patch seeds this random component using the [`SOURCE_DATE_EPOCH`](https://reproducible-builds.org/specs/source-date-epoch/) environment variable so that, *iff* this variable is present, it will deterministically generate the same output.

(I originally filed this bug in Debian as [#973595](https://bugs.debian.org/973595).)
