### PR TITLE
library_webgpu.js: Fix syntax

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1292,14 +1292,14 @@ var LibraryWebGPU = {
 
   // wgpuComputePipeline
 
-  wgpuComputePipelineGetBindGroupLayout(pipelineId, groupIndex) {
+  wgpuComputePipelineGetBindGroupLayout: function(pipelineId, groupIndex) {
     var pipeline = WebGPU.mgrComputePipeline.get(pipelineId);
     return WebGPU.mgrBindGroupLayout.create(pipeline["getBindGroupLayout"](groupIndex));
   },
 
   // wgpuRenderPipeline
 
-  wgpuRenderPipelineGetBindGroupLayout(pipelineId, groupIndex) {
+  wgpuRenderPipelineGetBindGroupLayout: function(pipelineId, groupIndex) {
     var pipeline = WebGPU.mgrRenderPipeline.get(pipelineId);
     return WebGPU.mgrBindGroupLayout.create(pipeline["getBindGroupLayout"](groupIndex));
   },

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7263,7 +7263,9 @@ end
     # are including a lot of JS without corresponding compiled code for it. This still
     # lets us catch all other errors.
     with env_modify({'EMCC_CLOSURE_ARGS': '--jscomp_off undefinedVars'}):
-      self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
+      # USE_WEBGPU is specified here to make sure that it's closure-safe.
+      # It can be removed if USE_WEBGPU is later included in INCLUDE_FULL_LIBRARY.
+      self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O1', '--closure', '1', '-g1', '-s', 'INCLUDE_FULL_LIBRARY=1', '-s', 'USE_WEBGPU=1', '-s', 'ERROR_ON_UNDEFINED_SYMBOLS=0'])
 
   # Tests --closure-args command line flag
   def test_closure_externs(self):


### PR DESCRIPTION
This file accidentally used some modern JS syntax; this fixes it.

Fixes #12621