### PR TITLE
Don't expect finalize to modify wasm in standalone mode. NFC.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -473,7 +473,6 @@ def finalize_wasm(infile, outfile, memfile, DEBUG):
     modify_wasm = True
   if shared.Settings.STANDALONE_WASM:
     args.append('--standalone-wasm')
-    modify_wasm = True
 
   if shared.Settings.DEBUG_LEVEL >= 3:
     args.append('--dwarf')


### PR DESCRIPTION
I'm not sure why this was ever set.  In standalone mode
is its seems like finalize always does strictly less than
in regular mode.