### PR TITLE
Initial support for --post-link on output of wasi-sdk

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ executors:
       EMTEST_DETECT_TEMPFILE_LEAKS: "1"
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
+      EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
       PYTHON_BIN: "python3"
   mac:
     environment:
@@ -61,6 +62,7 @@ commands:
             echo "WASM_ENGINES = []" >> .emscripten
             test -f ~/vms/wasmtime && echo "WASMTIME = os.path.expanduser(os.path.join('~', 'vms', 'wasmtime')) ; WASM_ENGINES.append(WASMTIME)" >> .emscripten || true
             test -f ~/vms/wasmer && echo "WASMER = os.path.expanduser(os.path.join('~', 'vms', 'wasmer')) ; WASM_ENGINES.append(WASMER)" >> .emscripten || true
+            test -d ~/wasi-sdk && cp -ar ~/wasi-sdk/lib/ ~/emsdk/upstream/lib/clang/12.0.0/
             cd -
             echo "final .emscripten:"
             cat ~/emsdk/.emscripten
@@ -107,8 +109,9 @@ commands:
           paths:
             - emsdk/
             - cache/
-            - vms
-            - .jsvu
+            - vms/
+            - wasi-sdk/
+            - .jsvu/
   run-tests:
     description: "Runs emscripten tests"
     parameters:
@@ -351,6 +354,14 @@ jobs:
             wget https://github.com/bytecodealliance/wasmtime/releases/download/v0.8.0/wasmtime-$VERSION-x86_64-linux.tar.xz
             tar -xf wasmtime-$VERSION-x86_64-linux.tar.xz
             cp wasmtime-$VERSION-x86_64-linux/wasmtime ~/vms
+      - run:
+          name: get wasi-sdk-sysroot
+          command: |
+            wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-11/libclang_rt.builtins-wasm32-wasi-11.0.tar.gz
+            wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-11/wasi-sysroot-11.0.tar.gz
+            mkdir ~/wasi-sdk
+            tar xvf libclang_rt.builtins-wasm32-wasi-11.0.tar.gz -C ~/wasi-sdk
+            tar xvf wasi-sysroot-11.0.tar.gz -C ~/wasi-sdk/
       - run:
           name: get v8
           command: |

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -42,6 +42,12 @@ Current Trunk
   async compilation turned off, so that startup is synchronous, now returns the
   Module object from the factory function (as it would not make sense to return
   a Promise without async startup). See #12647
+- Added experimental support for using emscripten as a post link tool.  In this
+  case the input to emscripten is a single wasm file (for example the output of
+  `wasm-ld`).  When emcc is run with `--post-link` it will take a wasm file as
+  input that perform all the normal post link steps such as finalizing and
+  optimizing the wasm file and generating the JavaScript and/of html that will
+  run it.
 
 2.0.8: 10/24/2020
 -----------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -46,7 +46,7 @@ Current Trunk
   case the input to emscripten is a single wasm file (for example the output of
   `wasm-ld`).  When emcc is run with `--post-link` it will take a wasm file as
   input that perform all the normal post link steps such as finalizing and
-  optimizing the wasm file and generating the JavaScript and/of html that will
+  optimizing the wasm file and generating the JavaScript and/or html that will
   run it.
 
 2.0.8: 10/24/2020

--- a/emcc.py
+++ b/emcc.py
@@ -1199,7 +1199,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     shared.verify_settings()
 
-    if options.oformat == OFormat.WASM and not shared.Settings.SIDE_MODULE:
+    if (options.oformat == OFormat.WASM or shared.Settings.PURE_WASI) and not shared.Settings.SIDE_MODULE:
       # if the output is just a wasm file, it will normally be a standalone one,
       # as there is no JS. an exception are side modules, as we can't tell at
       # compile time whether JS will be involved or not - the main module may
@@ -1414,7 +1414,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.STACK_OVERFLOW_CHECK:
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$abortStackOverflow']
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
       shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_end', '_emscripten_stack_get_free']
       if shared.Settings.RELOCATABLE:
         shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_set_limits']

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -835,7 +835,7 @@ function createWasm() {
 
 #if !RELOCATABLE
     wasmTable = Module['asm']['__indirect_function_table'];
-#if ASSERTIONS
+#if ASSERTIONS && !PURE_WASI
     assert(wasmTable, "table not found in wasm exports");
 #endif
 #endif
@@ -858,7 +858,7 @@ function createWasm() {
     assert(wasmMemory, "memory not found in wasm exports");
 #endif
     updateGlobalBufferAndViews(wasmMemory.buffer);
-#if ASSERTIONS
+#if STACK_OVERFLOW_CHECK
     writeStackCookie();
 #endif
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -1622,6 +1622,13 @@ var ERROR_ON_WASM_CHANGES_AFTER_LINK = 0;
 // cost of a few bytes extra.
 var ABORT_ON_WASM_EXCEPTIONS = 0;
 
+// Build binaries that use as many WASI APIs as possible, and include additional
+// JS support libraries for those APIs.  This allows emscripten produce binaries
+// are more WASI compilant and also allows it to process and execute WASI
+// binaries built with other SDKs (e.g.  wasi-sdk).
+// Implies STANDALONE_WASM.
+var PURE_WASI = 0;
+
 //===========================================
 // Internal, used for testing only, from here
 //===========================================

--- a/src/settings.js
+++ b/src/settings.js
@@ -1623,9 +1623,10 @@ var ERROR_ON_WASM_CHANGES_AFTER_LINK = 0;
 var ABORT_ON_WASM_EXCEPTIONS = 0;
 
 // Build binaries that use as many WASI APIs as possible, and include additional
-// JS support libraries for those APIs.  This allows emscripten produce binaries
+// JS support libraries for those APIs.  This allows emscripten to produce binaries
 // are more WASI compilant and also allows it to process and execute WASI
 // binaries built with other SDKs (e.g.  wasi-sdk).
+// This setting is experimental and subject to change or removal.
 // Implies STANDALONE_WASM.
 var PURE_WASI = 0;
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9610,3 +9610,15 @@ exec "$@"
     err = self.run_process([EMCC, '--post-link', 'bare.wasm'], stderr=PIPE).stderr
     self.assertContained('--oformat=base/--post-link are experimental and subject to change', err)
     err = self.assertContained('hello, world!', self.run_js('a.out.js'))
+
+  def compile_with_wasi_sdk(self, filename, output):
+    sysroot = os.environ.get('EMTEST_WASI_SYSROOT')
+    if not sysroot:
+      self.skipTest('EMTEST_WASI_SYSROOT not found in environment')
+    sysroot = os.path.expanduser(sysroot)
+    self.run_process([CLANG_CC, '--sysroot=' + sysroot, '--target=wasm32-wasi', filename, '-o', output])
+
+  def test_run_wasi_sdk_output(self):
+    self.compile_with_wasi_sdk(path_from_root('tests', 'hello_world.c'), 'hello.wasm')
+    self.run_process([EMCC, '--post-link', '-sPURE_WASI', 'hello.wasm'])
+    self.assertContained('hello, world!', self.run_js('a.out.js'))


### PR DESCRIPTION
This is an initial PR that only supports the most basic of
wasi-sdk-produced programs.  Most ones that just use stdout and argv.

Adds a simple test which uses the official wasi-sdk sysroot
to build the wasm binary and then uses emscripten to post-process
this to turn this into a runnable JS file.

See #12341

