### PR TITLE
Split config file handling out of shared.py. NFC.

### DIFF
--- a/em-config.py
+++ b/em-config.py
@@ -16,17 +16,17 @@ is found, or exits with 1 if the variable does not exist.
 
 import sys
 import re
-from tools import shared
+from tools import config
 
 
 def main():
   if len(sys.argv) != 2 or \
     not re.match(r"^[\w\W_][\w\W_\d]*$", sys.argv[1]) or \
-    not hasattr(shared, sys.argv[1]):
+    not hasattr(config, sys.argv[1]):
     print('Usage: em-config VAR_NAME', file=sys.stderr)
     exit(1)
 
-  print(getattr(shared, sys.argv[1]))
+  print(getattr(config, sys.argv[1]))
   return 0
 
 

--- a/emcc.py
+++ b/emcc.py
@@ -49,6 +49,7 @@ from tools.toolchain_profiler import ToolchainProfiler
 from tools import js_manipulation
 from tools import wasm2c
 from tools import webassembly
+from tools import config
 
 if __name__ == '__main__':
   ToolchainProfiler.record_process_start()
@@ -654,8 +655,8 @@ def backend_binaryen_passes():
 
 def make_js_executable(script):
   src = open(script).read()
-  cmd = shared.shlex_join(shared.JS_ENGINE)
-  if not os.path.isabs(shared.JS_ENGINE[0]):
+  cmd = shared.shlex_join(config.JS_ENGINE)
+  if not os.path.isabs(config.JS_ENGINE[0]):
     # TODO: use whereis etc. And how about non-*NIX?
     cmd = '/usr/bin/env -S ' + cmd
   logger.debug('adding `#!` to JavaScript file: %s' % cmd)
@@ -926,7 +927,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # warnings are properly printed during arg parse.
     newargs = diagnostics.capture_warnings(newargs)
 
-    if not shared.CONFIG_FILE:
+    if not config.config_file:
       diagnostics.warning('deprecated', 'Specifying EM_CONFIG as a python literal is deprecated. Please use a file instead.')
 
     for i in range(len(newargs)):
@@ -1947,10 +1948,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     CXX = [shared.CLANG_CXX]
     CC = [shared.CLANG_CC]
-    if shared.COMPILER_WRAPPER:
-      logger.debug('using compiler wrapper: %s', shared.COMPILER_WRAPPER)
-      CXX.insert(0, shared.COMPILER_WRAPPER)
-      CC.insert(0, shared.COMPILER_WRAPPER)
+    if config.COMPILER_WRAPPER:
+      logger.debug('using compiler wrapper: %s', config.COMPILER_WRAPPER)
+      CXX.insert(0, config.COMPILER_WRAPPER)
+      CC.insert(0, config.COMPILER_WRAPPER)
 
     if 'EMMAKEN_COMPILER' in os.environ:
       diagnostics.warning('deprecated', '`EMMAKEN_COMPILER` is deprecated.\n'
@@ -2469,7 +2470,7 @@ def parse_args(newargs):
     elif check_arg('--extern-post-js'):
       options.extern_post_js += open(consume_arg()).read() + '\n'
     elif check_arg('--compiler-wrapper'):
-      shared.COMPILER_WRAPPER = consume_arg()
+      config.COMPILER_WRAPPER = consume_arg()
     elif check_flag('--post-link'):
       options.post_link = True
     elif check_arg('--oformat'):
@@ -2636,7 +2637,7 @@ def parse_args(newargs):
       if os.path.exists(path):
         exit_with_error('File ' + optarg + ' passed to --generate-config already exists!')
       else:
-        shared.generate_config(optarg)
+        config.generate_config(optarg)
       should_exit = True
     # Record USE_PTHREADS setting because it controls whether --shared-memory is passed to lld
     elif arg == '-pthread':

--- a/tests/clang_native.py
+++ b/tests/clang_native.py
@@ -5,7 +5,8 @@
 
 import logging
 import os
-from tools.shared import MACOS, WINDOWS, path_from_root, PIPE, run_process, CLANG_CC, CLANG_CXX
+from tools.shared import PIPE, run_process, CLANG_CC, CLANG_CXX
+from tools.utils import MACOS, WINDOWS, path_from_root
 from tools import building
 
 logger = logging.getLogger('clang_native')

--- a/tests/jsrun.py
+++ b/tests/jsrun.py
@@ -9,6 +9,7 @@ import sys
 from subprocess import Popen, PIPE, CalledProcessError
 
 from tools import shared
+from tools.shared import config
 
 WORKING_ENGINES = {} # Holds all configured engines and whether they work: maps path -> True/False
 
@@ -90,7 +91,7 @@ def run_js(filename, engine=None, args=[],
            stdin=None, stdout=PIPE, stderr=None, cwd=None,
            full_output=False, assert_returncode=0, skip_check=False):
   if not engine:
-    engine = shared.JS_ENGINES[0]
+    engine = config.JS_ENGINES[0]
 
   # We used to support True here but we no longer do.  Assert here just in case.
   assert(type(assert_returncode) == int)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -55,12 +55,13 @@ import clang_native
 import jsrun
 import parallel_testsuite
 from jsrun import NON_ZERO
-from tools.shared import EM_CONFIG, TEMP_DIR, EMCC, EMXX, DEBUG
+from tools.config import EM_CONFIG
+from tools.shared import TEMP_DIR, EMCC, EMXX, DEBUG
 from tools.shared import EMSCRIPTEN_TEMP_DIR
-from tools.shared import MACOS, WINDOWS
 from tools.shared import EM_BUILD_VERBOSE
 from tools.shared import asstr, get_canonical_temp_dir, try_delete
-from tools.shared import asbytes, Settings
+from tools.shared import asbytes, Settings, config
+from tools.utils import MACOS, WINDOWS
 from tools import shared, line_endings, building
 
 
@@ -232,24 +233,24 @@ def chdir(dir):
 
 @contextlib.contextmanager
 def js_engines_modify(replacements):
-  """A context manager that updates shared.JS_ENGINES."""
-  original = shared.JS_ENGINES
-  shared.JS_ENGINES = replacements
+  """A context manager that updates config.JS_ENGINES."""
+  original = config.JS_ENGINES
+  config.JS_ENGINES = replacements
   try:
     yield
   finally:
-    shared.JS_ENGINES = original
+    config.JS_ENGINES = original
 
 
 @contextlib.contextmanager
 def wasm_engines_modify(replacements):
-  """A context manager that updates shared.WASM_ENGINES."""
-  original = shared.WASM_ENGINES
-  shared.WASM_ENGINES = replacements
+  """A context manager that updates config.WASM_ENGINES."""
+  original = config.WASM_ENGINES
+  config.WASM_ENGINES = replacements
   try:
     yield
   finally:
-    shared.WASM_ENGINES = original
+    config.WASM_ENGINES = original
 
 
 def ensure_dir(dirname):
@@ -989,7 +990,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def filtered_js_engines(self, js_engines=None):
     if js_engines is None:
-      js_engines = shared.JS_ENGINES
+      js_engines = config.JS_ENGINES
     for engine in js_engines:
       assert type(engine) == list
     for engine in self.banned_js_engines:
@@ -1046,7 +1047,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if self.get_setting('STANDALONE_WASM'):
       # TODO once standalone wasm support is more stable, apply use_all_engines
       # like with js engines, but for now as we bring it up, test in all of them
-      wasm_engines = shared.WASM_ENGINES
+      wasm_engines = config.WASM_ENGINES
       if len(wasm_engines) == 0:
         logger.warning('no wasm engine was found to run the standalone part of this test')
       engines += wasm_engines
@@ -1656,8 +1657,8 @@ def build_library(name,
 
 
 def check_js_engines():
-  working_engines = list(filter(jsrun.check_engine, shared.JS_ENGINES))
-  if len(working_engines) < len(shared.JS_ENGINES):
+  working_engines = list(filter(jsrun.check_engine, config.JS_ENGINES))
+  if len(working_engines) < len(config.JS_ENGINES):
     print('Not all the JS engines in JS_ENGINES appears to work.')
     exit(1)
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -18,8 +18,8 @@ if __name__ == '__main__':
 import clang_native
 import jsrun
 import runner
-from tools.shared import run_process, path_from_root, SPIDERMONKEY_ENGINE, LLVM_ROOT, V8_ENGINE, PIPE, try_delete, EMCC
-from tools import shared, building
+from tools.shared import run_process, path_from_root, PIPE, try_delete, EMCC, config
+from tools import building
 
 # standard arguments for timing:
 # 0: no runtime, just startup
@@ -188,7 +188,7 @@ class EmscriptenBenchmarker(Benchmarker):
     self.filename = filename
     self.old_env = os.environ
     os.environ = self.env.copy()
-    llvm_root = self.env.get('LLVM') or LLVM_ROOT
+    llvm_root = self.env.get('LLVM') or config.LLVM_ROOT
     if lib_builder:
       env_init = self.env.copy()
       # Note that we need to pass in all the flags here because some build
@@ -356,11 +356,11 @@ benchmarkers = [
   # NativeBenchmarker('gcc',   'gcc',    'g++')
 ]
 
-if V8_ENGINE and V8_ENGINE in shared.JS_ENGINES:
+if config.V8_ENGINE and config.V8_ENGINE in config.JS_ENGINES:
   # avoid the baseline compiler running, because it adds a lot of noise
   # (the nondeterministic time it takes to get to the full compiler ends up
   # mattering as much as the actual benchmark)
-  aot_v8 = V8_ENGINE + ['--no-liftoff']
+  aot_v8 = config.V8_ENGINE + ['--no-liftoff']
   default_v8_name = os.environ.get('EMBENCH_NAME') or 'v8'
   benchmarkers += [
     EmscriptenBenchmarker(default_v8_name, aot_v8),
@@ -372,7 +372,7 @@ if V8_ENGINE and V8_ENGINE in shared.JS_ENGINES:
       # CheerpBenchmarker('cheerp-v8-wasm', aot_v8),
     ]
 
-if SPIDERMONKEY_ENGINE and SPIDERMONKEY_ENGINE in shared.JS_ENGINES:
+if config.SPIDERMONKEY_ENGINE and config.SPIDERMONKEY_ENGINE in config.JS_ENGINES:
   # TODO: ensure no baseline compiler is used, see v8
   benchmarkers += [
     # EmscriptenBenchmarker('sm', SPIDERMONKEY_ENGINE),
@@ -382,7 +382,7 @@ if SPIDERMONKEY_ENGINE and SPIDERMONKEY_ENGINE in shared.JS_ENGINES:
       # CheerpBenchmarker('cheerp-sm-wasm', SPIDERMONKEY_ENGINE),
     ]
 
-if shared.NODE_JS and shared.NODE_JS in shared.JS_ENGINES:
+if config.NODE_JS and config.NODE_JS in config.JS_ENGINES:
   benchmarkers += [
     # EmscriptenBenchmarker('Node.js', shared.NODE_JS),
   ]
@@ -408,7 +408,7 @@ class benchmark(runner.RunnerCore):
         fingerprint.append('sm: ' + [line for line in run_process(['hg', 'tip'], stdout=PIPE).stdout.splitlines() if 'changeset' in line][0])
     except Exception:
       pass
-    fingerprint.append('llvm: ' + LLVM_ROOT)
+    fingerprint.append('llvm: ' + config.LLVM_ROOT)
     print('Running Emscripten benchmarks... [ %s ]' % ' | '.join(fingerprint))
 
   # avoid depending on argument reception from the commandline

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -25,8 +25,8 @@ from runner import no_wasm_backend, create_test_file, parameterized, ensure_dir
 from tools import building
 from tools import shared
 from tools import system_libs
-from tools.shared import PYTHON, EMCC, WINDOWS, FILE_PACKAGER, PIPE, V8_ENGINE
-from tools.shared import try_delete
+from tools.shared import PYTHON, EMCC, WINDOWS, FILE_PACKAGER, PIPE
+from tools.shared import try_delete, config
 
 
 def test_chunked_synchronous_xhr_server(support_byte_ranges, chunkSize, data, checksum, port):
@@ -4887,7 +4887,7 @@ window.close = function() {
     # test that we can allocate in the 2-4GB range, if we enable growth and
     # set the max appropriately
     self.emcc_args += ['-O2', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'MAXIMUM_MEMORY=4GB']
-    self.do_run_in_out_file_test('tests', 'browser', 'test_4GB.cpp', js_engines=[V8_ENGINE])
+    self.do_run_in_out_file_test('tests', 'browser', 'test_4GB.cpp', js_engines=[config.V8_ENGINE])
 
   @no_firefox('no 4GB support yet')
   def test_zzz_zzz_2GB_fail(self):
@@ -4900,7 +4900,7 @@ window.close = function() {
     # test that growth doesn't go beyond 2GB without the max being set for that,
     # and that we can catch an allocation failure exception for that
     self.emcc_args += ['-O2', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'MAXIMUM_MEMORY=2GB']
-    self.do_run_in_out_file_test('tests', 'browser', 'test_2GB_fail.cpp', js_engines=[V8_ENGINE])
+    self.do_run_in_out_file_test('tests', 'browser', 'test_2GB_fail.cpp', js_engines=[config.V8_ENGINE])
 
   @no_firefox('no 4GB support yet')
   def test_zzz_zzz_4GB_fail(self):
@@ -4913,7 +4913,7 @@ window.close = function() {
     # test that we properly report an allocation error that would overflow over
     # 4GB.
     self.emcc_args += ['-O2', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'MAXIMUM_MEMORY=4GB', '-s', 'ABORTING_MALLOC=0']
-    self.do_run_in_out_file_test('tests', 'browser', 'test_4GB_fail.cpp', js_engines=[V8_ENGINE])
+    self.do_run_in_out_file_test('tests', 'browser', 'test_4GB_fail.cpp', js_engines=[config.V8_ENGINE])
 
   @unittest.skip("only run this manually, to test for race conditions")
   @parameterized({

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -13,7 +13,8 @@ if __name__ == '__main__':
 
 from runner import parameterized
 from runner import BrowserCore, path_from_root
-from tools.shared import EMCC, WINDOWS, which
+from tools.shared import EMCC, WINDOWS
+from tools.utils import which
 
 
 class interactive(BrowserCore):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -25,12 +25,12 @@ except Exception:
   pass
 import clang_native
 from runner import BrowserCore, no_windows, chdir
-from tools import shared
-from tools.shared import PYTHON, EMCC, NODE_JS, path_from_root, WINDOWS, run_process, JS_ENGINES, CLANG_CC
+from tools import shared, config
+from tools.shared import PYTHON, EMCC, path_from_root, WINDOWS, run_process, CLANG_CC
 
 npm_checked = False
 
-NPM = os.path.join(os.path.dirname(NODE_JS[0]), 'npm.cmd' if WINDOWS else 'npm')
+NPM = os.path.join(os.path.dirname(config.NODE_JS[0]), 'npm.cmd' if WINDOWS else 'npm')
 
 
 def clean_processes(processes):
@@ -113,7 +113,7 @@ class CompiledServerHarness():
     # the ws module is installed
     global npm_checked
     if not npm_checked:
-      child = run_process(NODE_JS + ['-e', 'require("ws");'], check=False)
+      child = run_process(config.NODE_JS + ['-e', 'require("ws");'], check=False)
       assert child.returncode == 0, '"ws" node module not found.  you may need to run npm install'
       npm_checked = True
 
@@ -121,7 +121,7 @@ class CompiledServerHarness():
     proc = run_process([EMCC, '-Werror', path_from_root('tests', self.filename), '-o', 'server.js', '-DSOCKK=%d' % self.listen_port] + self.args)
     print('Socket server build: out:', proc.stdout or '', '/ err:', proc.stderr or '')
 
-    process = Popen(NODE_JS + ['server.js'])
+    process = Popen(config.NODE_JS + ['server.js'])
     self.processes.append(process)
 
   def __exit__(self, *args, **kwargs):
@@ -148,7 +148,7 @@ class BackgroundServerProcess():
 
 
 def NodeJsWebSocketEchoServerProcess():
-  return BackgroundServerProcess(NODE_JS + [path_from_root('tests', 'websocket', 'nodejs_websocket_echo_server.js')])
+  return BackgroundServerProcess(config.NODE_JS + [path_from_root('tests', 'websocket', 'nodejs_websocket_echo_server.js')])
 
 
 def PythonTcpEchoServerProcess(port):
@@ -403,7 +403,7 @@ class sockets(BrowserCore):
 
     # note: you may need to run this manually yourself, if npm is not in the path, or if you need a version that is not in the path
     self.run_process([NPM, 'install', path_from_root('tests', 'sockets', 'p2p')])
-    broker = Popen(NODE_JS + [path_from_root('tests', 'sockets', 'p2p', 'broker', 'p2p-broker.js')])
+    broker = Popen(config.NODE_JS + [path_from_root('tests', 'sockets', 'p2p', 'broker', 'p2p-broker.js')])
 
     expected = '1'
     self.run_browser(host_outfile, '.', ['/report_result?' + e for e in expected])
@@ -413,7 +413,7 @@ class sockets(BrowserCore):
   def test_nodejs_sockets_echo(self):
     # This test checks that sockets work when the client code is run in Node.js
     # Run with ./runner.py sockets.test_nodejs_sockets_echo
-    if NODE_JS not in JS_ENGINES:
+    if config.NODE_JS not in config.JS_ENGINES:
       self.skipTest('node is not present')
 
     sockets_include = '-I' + path_from_root('tests', 'sockets')

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -6,7 +6,7 @@
 import os
 import shutil
 import logging
-from . import tempfiles, filelock
+from . import tempfiles, filelock, config, utils
 
 logger = logging.getLogger('cache')
 
@@ -74,7 +74,7 @@ class Cache(object):
       logger.debug('PID %s released multiprocess file lock to Emscripten cache at %s' % (str(os.getpid()), self.dirname))
 
   def ensure(self):
-    shared.safe_ensure_dirs(self.dirname)
+    utils.safe_ensure_dirs(self.dirname)
 
   def erase(self):
     self.acquire_cache_lock()
@@ -110,7 +110,7 @@ class Cache(object):
       if os.path.exists(cachename) and not force:
         return cachename
       # it doesn't exist yet, create it
-      if shared.FROZEN_CACHE:
+      if config.FROZEN_CACHE:
         # it's ok to build small .txt marker files like "vanilla"
         if not shortname.endswith('.txt'):
           raise Exception('FROZEN_CACHE disallows building system libs: %s' % shortname)
@@ -124,7 +124,7 @@ class Cache(object):
       self.ensure()
       temp = creator()
       if os.path.normcase(temp) != os.path.normcase(cachename):
-        shared.safe_ensure_dirs(os.path.dirname(cachename))
+        utils.safe_ensure_dirs(os.path.dirname(cachename))
         shutil.copyfile(temp, cachename)
       logger.info(' - ok')
     finally:

--- a/tools/config.py
+++ b/tools/config.py
@@ -1,0 +1,283 @@
+# Copyright 2020 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+import os
+import sys
+import logging
+from .utils import path_from_root, exit_with_error, __rootpath__, which
+
+logger = logging.getLogger('shared')
+
+# The following class can be overridden by the config file and/or
+# environment variables.  Specifically any variable whose name
+# is in ALL_UPPER_CASE is condifered a valid config file key.
+# See parse_config_file below.
+EMSCRIPTEN_ROOT = __rootpath__
+NODE_JS = None
+BINARYEN_ROOT = None
+SPIDERMONKEY_ENGINE = None
+V8_ENGINE = None
+LLVM_ROOT = None
+LLVM_ADD_VERSION = None
+CLANG_ADD_VERSION = None
+CLOSURE_COMPILER = None
+JAVA = None
+JS_ENGINE = None
+JS_ENGINES = None
+WASMER = None
+WASMTIME = None
+WASM_ENGINES = []
+FROZEN_CACHE = None
+CACHE = None
+PORTS = None
+COMPILER_WRAPPER = None
+
+
+def listify(x):
+  if type(x) is not list:
+    return [x]
+  return x
+
+
+def fix_js_engine(old, new):
+  if old is None:
+    return
+  global JS_ENGINES
+  JS_ENGINES = [new if x == old else x for x in JS_ENGINES]
+  return new
+
+
+def root_is_writable():
+  return os.access(__rootpath__, os.W_OK)
+
+
+def normalize_config_settings():
+  global CACHE, PORTS, JAVA, LLVM_ADD_VERSION, CLANG_ADD_VERSION
+  global NODE_JS, V8_ENGINE, JS_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
+
+  # EM_CONFIG stuff
+  if not JS_ENGINES:
+    JS_ENGINES = [NODE_JS]
+  if not JS_ENGINE:
+    JS_ENGINE = JS_ENGINES[0]
+
+  # Engine tweaks
+  if SPIDERMONKEY_ENGINE:
+    new_spidermonkey = SPIDERMONKEY_ENGINE
+    if '-w' not in str(new_spidermonkey):
+      new_spidermonkey += ['-w']
+    SPIDERMONKEY_ENGINE = fix_js_engine(SPIDERMONKEY_ENGINE, new_spidermonkey)
+  NODE_JS = fix_js_engine(NODE_JS, listify(NODE_JS))
+  V8_ENGINE = fix_js_engine(V8_ENGINE, listify(V8_ENGINE))
+  JS_ENGINE = fix_js_engine(JS_ENGINE, listify(JS_ENGINE))
+  JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
+  WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
+  if not CACHE:
+    if root_is_writable():
+      CACHE = path_from_root('cache')
+    else:
+      # Use the legacy method of putting the cache in the user's home directory
+      # if the emscripten root is not writable.
+      # This is useful mostly for read-only installation and perhaps could
+      # be removed in the future since such installations should probably be
+      # setting a specific cache location.
+      logger.debug('Using home-directory for emscripten cache due to read-only root')
+      CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
+  if not PORTS:
+    PORTS = os.path.join(CACHE, 'ports')
+
+  if JAVA is None:
+    logger.debug('JAVA not defined in ' + config_file_location() + ', using "java"')
+    JAVA = 'java'
+
+  # Tools/paths
+  if LLVM_ADD_VERSION is None:
+    LLVM_ADD_VERSION = os.getenv('LLVM_ADD_VERSION')
+
+  if CLANG_ADD_VERSION is None:
+    CLANG_ADD_VERSION = os.getenv('CLANG_ADD_VERSION')
+
+
+def parse_config_file():
+  """Parse the emscripten config file using python's exec.
+
+  Also check EM_<KEY> environment variables to override specific config keys.
+  """
+  config = {}
+  config_text = open(config_file, 'r').read() if config_file else EM_CONFIG
+  try:
+    exec(config_text, config)
+  except Exception as e:
+    exit_with_error('Error in evaluating %s (at %s): %s, text: %s', EM_CONFIG, config_file, str(e), config_text)
+
+  CONFIG_KEYS = (
+    'NODE_JS',
+    'BINARYEN_ROOT',
+    'SPIDERMONKEY_ENGINE',
+    'V8_ENGINE',
+    'LLVM_ROOT',
+    'LLVM_ADD_VERSION',
+    'CLANG_ADD_VERSION',
+    'CLOSURE_COMPILER',
+    'JAVA',
+    'JS_ENGINE',
+    'JS_ENGINES',
+    'WASMER',
+    'WASMTIME',
+    'WASM_ENGINES',
+    'FROZEN_CACHE',
+    'CACHE',
+    'PORTS',
+    'COMPILER_WRAPPER',
+  )
+
+  # Only propagate certain settings from the config file.
+  for key in CONFIG_KEYS:
+    env_var = 'EM_' + key
+    env_value = os.environ.get(env_var)
+    if env_value is not None:
+      globals()[key] = env_value
+    elif key in config:
+      globals()[key] = config[key]
+
+  # Certain keys are mandatory
+  for key in ('LLVM_ROOT', 'NODE_JS', 'BINARYEN_ROOT'):
+    if key not in config:
+      exit_with_error('%s is not defined in %s', key, config_file_location())
+    if not globals()[key]:
+      exit_with_error('%s is set to empty value in %s', key, config_file_location())
+
+  if not NODE_JS:
+    exit_with_error('NODE_JS is not defined in %s', config_file_location())
+
+  normalize_config_settings()
+
+
+# Returns the location of the emscripten config file.
+def config_file_location():
+  # Handle the case where there is no config file at all (i.e. If EM_CONFIG is passed as python code
+  # direclty on the command line).
+  if not config_file:
+    return '<inline config>'
+
+  return config_file
+
+
+def generate_config(path, first_time=False):
+  # Note: repr is used to ensure the paths are escaped correctly on Windows.
+  # The full string is replaced so that the template stays valid Python.
+  config_file = open(path_from_root('tools', 'settings_template.py')).read().splitlines()
+  config_file = config_file[3:] # remove the initial comment
+  config_file = '\n'.join(config_file)
+  # autodetect some default paths
+  config_file = config_file.replace('\'{{{ EMSCRIPTEN_ROOT }}}\'', repr(__rootpath__))
+  llvm_root = os.path.dirname(which('llvm-dis') or '/usr/bin/llvm-dis')
+  config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
+
+  node = which('nodejs') or which('node') or 'node'
+  config_file = config_file.replace('\'{{{ NODE }}}\'', repr(node))
+
+  abspath = os.path.abspath(os.path.expanduser(path))
+  # write
+  with open(abspath, 'w') as f:
+    f.write(config_file)
+
+  if first_time:
+    print('''
+==============================================================================
+Welcome to Emscripten!
+
+This is the first time any of the Emscripten tools has been run.
+
+A settings file has been copied to %s, at absolute path: %s
+
+It contains our best guesses for the important paths, which are:
+
+  LLVM_ROOT       = %s
+  NODE_JS         = %s
+  EMSCRIPTEN_ROOT = %s
+
+Please edit the file if any of those are incorrect.
+
+This command will now exit. When you are done editing those paths, re-run it.
+==============================================================================
+''' % (path, abspath, llvm_root, node, __rootpath__), file=sys.stderr)
+
+
+# Emscripten configuration is done through the --em-config command line option
+# or the EM_CONFIG environment variable. If the specified string value contains
+# newline or semicolon-separated definitions, then these definitions will be
+# used to configure Emscripten.  Otherwise, the string is understood to be a
+# path to a settings file that contains the required definitions.
+# The search order from the config file is as follows:
+# 1. Specified on the command line (--em-config)
+# 2. Specified via EM_CONFIG environment variable
+# 3. Local .emscripten file, if found
+# 4. Local .emscripten file, as used by `emsdk --embedded` (two levels above,
+#    see below)
+# 5. User home directory config (~/.emscripten), if found.
+
+embedded_config = path_from_root('.emscripten')
+# For compatibility with `emsdk --embedded` mode also look two levels up.  The
+# layout of the emsdk puts emcc two levels below emsdk.  For exmaple:
+#  - emsdk/upstream/emscripten/emcc
+#  - emsdk/emscipten/1.38.31/emcc
+# However `emsdk --embedded` stores the config file in the emsdk root.
+# Without this check, when emcc is run from within the emsdk in embedded mode
+# and the user forgets to first run `emsdk_env.sh` (which sets EM_CONFIG) emcc
+# will not see any config file at all and fall back to creating a new/emtpy
+# one.
+# We could remove this special case if emsdk were to write its embedded config
+# file into the emscripten directory itself.
+# See: https://github.com/emscripten-core/emsdk/pull/367
+emsdk_root = os.path.dirname(os.path.dirname(path_from_root()))
+emsdk_embedded_config = os.path.join(emsdk_root, '.emscripten')
+user_home_config = os.path.expanduser('~/.emscripten')
+
+if '--em-config' in sys.argv:
+  EM_CONFIG = sys.argv[sys.argv.index('--em-config') + 1]
+  # And now remove it from sys.argv
+  skip = False
+  newargs = []
+  for arg in sys.argv:
+    if not skip and arg != '--em-config':
+      newargs += [arg]
+    elif arg == '--em-config':
+      skip = True
+    elif skip:
+      skip = False
+  sys.argv = newargs
+  if not os.path.isfile(EM_CONFIG):
+    if EM_CONFIG.startswith('-'):
+      exit_with_error('Passed --em-config without an argument. Usage: --em-config /path/to/.emscripten or --em-config LLVM_ROOT=/path;...')
+    if '=' not in EM_CONFIG:
+      exit_with_error('File ' + EM_CONFIG + ' passed to --em-config does not exist!')
+    else:
+      EM_CONFIG = EM_CONFIG.replace(';', '\n') + '\n'
+elif 'EM_CONFIG' in os.environ:
+  EM_CONFIG = os.environ['EM_CONFIG']
+elif os.path.exists(embedded_config):
+  EM_CONFIG = embedded_config
+elif os.path.exists(emsdk_embedded_config):
+  EM_CONFIG = emsdk_embedded_config
+elif os.path.exists(user_home_config):
+  EM_CONFIG = user_home_config
+else:
+  if root_is_writable():
+    generate_config(embedded_config, first_time=True)
+  else:
+    generate_config(user_home_config, first_time=True)
+  sys.exit(0)
+
+if '\n' in EM_CONFIG:
+  config_file = None
+  logger.debug('config is specified inline without a file')
+else:
+  config_file = os.path.expanduser(EM_CONFIG)
+  logger.debug('emscripten config is located in ' + config_file)
+  if not os.path.exists(config_file):
+    exit_with_error('emscripten config file not found: ' + config_file)
+
+parse_config_file()

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -15,7 +15,7 @@ __rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
 sys.path.insert(1, __rootpath__)
 
 from tools.toolchain_profiler import ToolchainProfiler
-from tools import building
+from tools import building, config
 if __name__ == '__main__':
   ToolchainProfiler.record_process_start()
 
@@ -101,7 +101,7 @@ class Minifier(object):
         f.write('\n')
         f.write('// EXTRA_INFO:' + json.dumps(self.serialize()))
 
-      cmd = shared.NODE_JS + [JS_OPTIMIZER, temp_file, 'minifyGlobals', 'noPrintMetadata']
+      cmd = config.NODE_JS + [JS_OPTIMIZER, temp_file, 'minifyGlobals', 'noPrintMetadata']
       if minify_whitespace:
         cmd.append('minifyWhitespace')
       output = shared.run_process(cmd, stdout=subprocess.PIPE).stdout
@@ -329,7 +329,7 @@ EMSCRIPTEN_FUNCS();
 
   with ToolchainProfiler.profile_block('run_optimizer'):
     if len(filenames):
-      commands = [shared.NODE_JS + [JS_OPTIMIZER, f, 'noPrintMetadata'] + passes for f in filenames]
+      commands = [config.NODE_JS + [JS_OPTIMIZER, f, 'noPrintMetadata'] + passes for f in filenames]
 
       cores = min(cores, len(filenames))
       if len(chunks) > 1 and cores >= 2:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -16,7 +16,7 @@ import tarfile
 import zipfile
 from glob import iglob
 
-from . import shared, building, ports
+from . import shared, building, ports, config
 from tools.shared import mangle_c_symbol_name, demangle_c_symbol_name
 
 stdout = None
@@ -1716,7 +1716,7 @@ class Ports(object):
 
   @staticmethod
   def get_dir():
-    dirname = shared.PORTS
+    dirname = config.PORTS
     shared.safe_ensure_dirs(dirname)
     return dirname
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -1,0 +1,64 @@
+# Copyright 2020 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+import os
+import sys
+
+from . import diagnostics
+
+__rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+WINDOWS = sys.platform.startswith('win')
+MACOS = sys.platform == 'darwin'
+LINUX = sys.platform.startswith('linux')
+
+
+def exit_with_error(msg, *args):
+  diagnostics.error(msg, *args)
+
+
+def path_from_root(*pathelems):
+  return os.path.join(__rootpath__, *pathelems)
+
+
+def safe_ensure_dirs(dirname):
+  try:
+    os.makedirs(dirname)
+  except OSError:
+    # Python 2 compatibility: makedirs does not support exist_ok parameter
+    # Ignore error for already existing dirname as exist_ok does
+    if not os.path.isdir(dirname):
+      raise
+
+
+# Finds the given executable 'program' in PATH. Operates like the Unix tool 'which'.
+def which(program):
+  def is_exe(fpath):
+    return os.path.isfile(fpath) and os.access(fpath, os.X_OK)
+
+  if os.path.isabs(program):
+    if os.path.isfile(program):
+      return program
+
+    if WINDOWS:
+      for suffix in ['.exe', '.cmd', '.bat']:
+        if is_exe(program + suffix):
+          return program + suffix
+
+  fpath, fname = os.path.split(program)
+  if fpath:
+    if is_exe(program):
+      return program
+  else:
+    for path in os.environ["PATH"].split(os.pathsep):
+      path = path.strip('"')
+      exe_file = os.path.join(path, program)
+      if is_exe(exe_file):
+        return exe_file
+      if WINDOWS:
+        for suffix in ('.exe', '.cmd', '.bat'):
+          if is_exe(exe_file + suffix):
+            return exe_file + suffix
+
+  return None

--- a/tools/wasm2c.py
+++ b/tools/wasm2c.py
@@ -6,7 +6,7 @@
 import os
 import re
 
-from tools.shared import Settings, path_from_root, unsuffixed, NODE_JS, check_call, exit_with_error
+from tools.shared import Settings, path_from_root, unsuffixed, config, check_call, exit_with_error
 
 
 # map an emscripten-style signature letter to a wasm2c C type
@@ -75,7 +75,7 @@ def get_func_types(code):
 
 def do_wasm2c(infile):
   assert Settings.STANDALONE_WASM
-  WASM2C = NODE_JS + [path_from_root('node_modules', 'wasm2c', 'wasm2c.js')]
+  WASM2C = config.NODE_JS + [path_from_root('node_modules', 'wasm2c', 'wasm2c.js')]
   WASM2C_DIR = path_from_root('node_modules', 'wasm2c')
   c_file = unsuffixed(infile) + '.wasm.c'
   h_file = unsuffixed(infile) + '.wasm.h'


### PR DESCRIPTION
Move config file handling into its own file.  In order to achieve this
while avoiding a circular bependecy between shared.py and config.py,
move a few small utilities into `utils.py`.

For a while now `shared.py` has been way too big and this is step towards
breaking it up and breaking the existing circular dependencies between
python modules that use, and also also used by, `shared.py` (`cache.py` for
example).