### PR TITLE
Fix parsing of JS library pre-processor directives

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -177,7 +177,7 @@ function JSify(data, functionsOnly) {
         return;
       }
       deps.forEach(function(dep) {
-        if (typeof snippet === 'string' && !(dep in LibraryManager.library)) warn('missing library dependency ' + dep + ', make sure you are compiling with the right options (see #ifdefs in src/library*.js)');
+        if (typeof snippet === 'string' && !(dep in LibraryManager.library)) warn('missing library dependency ' + dep + ', make sure you are compiling with the right options (see #if in src/library*.js)');
       });
       var isFunction = false;
 

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -621,7 +621,7 @@ var LibraryDylink = {
 
   $preloadDylibs__deps: ['$loadDynamicLibrary', '$reportUndefinedSymbols'],
   $preloadDylibs: function() {
-#ifdef DYLINK_DEBUG
+#if DYLINK_DEBUG
     err('preloadDylibs');
 #endif
     var libs = {{{ JSON.stringify(RUNTIME_LINKED_LIBS) }}};
@@ -629,7 +629,7 @@ var LibraryDylink = {
       libs = libs.concat(Module['dynamicLibraries'])
     }
     if (!libs.length) {
-#ifdef DYLINK_DEBUG
+#if DYLINK_DEBUG
       err('preloadDylibs: no libraries to preload');
 #endif
       reportUndefinedSymbols();

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1381,7 +1381,7 @@ var LibraryPThread = {
 #endif
   },
 
-  // The profiler setters are defined twice, here in asm.js so that they can be #ifdeffed out
+  // The profiler setters are defined twice, here in asm.js so that they can be #if'ed out
   // without having to pay the impact of a FFI transition for a no-op in non-profiling builds.
   emscripten_conditional_set_current_thread_status__asm: true,
   emscripten_conditional_set_current_thread_status__sig: 'vii',

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -57,9 +57,7 @@ if (wasmMemory) {
 // If the user provides an incorrect length, just use that length instead rather than providing the user to
 // specifically provide the memory length with Module['INITIAL_MEMORY'].
 INITIAL_MEMORY = buffer.byteLength;
-#ifdef ASSERTIONS
+#if ASSERTIONS
 assert(INITIAL_MEMORY % {{{ WASM_PAGE_SIZE }}} === 0);
-#ifdef ALLOW_MEMORY_GROWTH && MAXIMUM_MEMORY != -1
-#endif
 #endif
 updateGlobalBufferAndViews(buffer);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9581,6 +9581,15 @@ exec "$@"
     err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '--js-library=lib.js'])
     self.assertContained('error: Missing library element `foo` for library config `foo__sig`', err)
 
+  def test_jslib_ifdef(self):
+    create_test_file('lib.js', '''
+      #ifdef ASSERTIONS
+      var foo;
+      #endif
+      ''')
+    proc = self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--js-library=lib.js'], stderr=PIPE)
+    self.assertContained('warning: use of #ifdef in js library.  Use #if instead.', proc.stderr)
+
   def test_wasm2js_no_dynamic_linking(self):
     for arg in ['-sMAIN_MODULE', '-sSIDE_MODULE', '-sRELOCATABLE']:
       err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-sMAIN_MODULE', '-sWASM=0'])


### PR DESCRIPTION
Because we were only checking for `#if` at the start of the
line we were accidentally also accepting `#ifdef` and also
`#ifanything`.

For backwards compatibility continue to accept `#ifdef` in
case people are using it in the wild but issue warning.

As a side effect of this refactor we now allow support
preprocessor directives that are not in column 0!