### PR TITLE
Don't pass C/C++ flags when compiling assembly files

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1956,7 +1956,7 @@ def build_port(port_name, settings):
     port.get(Ports, settings, shared)
 
 
-def process_args(args, settings):
+def add_ports_cflags(args, settings):
   # Legacy SDL1 port is not actually a port at all but builtin
   if settings.USE_SDL == 1:
     args += ['-Xclang', '-isystem' + shared.path_from_root('system', 'include', 'SDL')]


### PR DESCRIPTION
With #12698, I mistakenly started passing cflags to all
compile steps includes assembly file builds, which started
generating unused argument warnings.

This is another refactor which fixes that issue and also avoids calling
get_ports_cflags for each input file.