### PR TITLE
Avoid temp files in compile-only mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2028,7 +2028,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     def get_object_filename(input_file):
       if compile_only:
         # In compile-only mode we don't use any temp file.   The object files are written directly
-        # to thier final output locations.
+        # to their final output locations.
         if specified_target:
           assert len(input_files) == 1
           return specified_target

--- a/emcc.py
+++ b/emcc.py
@@ -1150,25 +1150,23 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     final_suffix = get_file_suffix(target)
 
-    if has_dash_c or has_dash_S or has_dash_E:
+    if has_dash_c or has_dash_S or has_dash_E or '-M' in newargs or '-MM' in newargs:
       if has_dash_c:
         if '-emit-llvm' in newargs:
-          final_suffix = '.bc'
-        else:
-          final_suffix = options.default_object_extension
-        target = target_basename + final_suffix
+          options.default_object_extension = '.bc'
       elif has_dash_S:
         if '-emit-llvm' in newargs:
-          final_suffix = '.ll'
+          options.default_object_extension = '.ll'
         else:
-          final_suffix = '.s'
-        target = target_basename + final_suffix
+          options.default_object_extension = '.s'
+      elif '-M' in newargs or '-MM' in newargs:
+        options.default_object_extension = '.mout' # not bitcode, not js; but just dependency rule of the input file
 
-      if len(input_files) > 1 and specified_target:
-        exit_with_error('cannot specify -o with -c/-S/-E and multiple source files')
-
-    if '-M' in newargs or '-MM' in newargs:
-      final_suffix = '.mout' # not bitcode, not js; but just dependency rule of the input file
+      if specified_target:
+        if len(input_files) > 1:
+          exit_with_error('cannot specify -o with -c/-S/-E/-M and multiple source files')
+      else:
+        target = target_basename + options.default_object_extension
 
     # If no output format was sepecific we try to imply the format based on
     # the output filename extension.
@@ -2028,12 +2026,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         return run_process(cmd, check=False).returncode
 
     def get_object_filename(input_file):
-      if compile_only and len(input_files) == 1:
-        # no need for a temp file, just emit to the right place
+      if compile_only:
+        # In compile-only mode we don't use any temp file.   The object files are written directly
+        # to thier final output locations.
         if specified_target:
+          assert len(input_files) == 1
           return specified_target
         else:
-          return unsuffixed_basename(input_files[0][1]) + options.default_object_extension
+          return unsuffixed_basename(input_file) + options.default_object_extension
       else:
         return in_temp(unsuffixed(uniquename(input_file)) + options.default_object_extension)
 
@@ -2074,37 +2074,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
   # exit block 'compile inputs'
   log_time('compile inputs')
-
-  with ToolchainProfiler.profile_block('process inputs'):
-    # If we were just compiling stop here
-    if compile_only:
-      if not specified_target:
-        assert len(temp_files) == len(input_files)
-        for tempf, inputf in zip(temp_files, input_files):
-          safe_move(tempf[1], unsuffixed_basename(inputf[1]) + final_suffix)
-      else:
-        # Specifying -o with multiple input source files is not allowed.
-        # We error out much earlier in this case.
-        assert len(input_files) == 1
-        input_file = input_files[0][1]
-        temp_file = temp_files[0][1]
-        if specified_target != '-':
-          if temp_file != input_file:
-            safe_move(temp_file, specified_target)
-          else:
-            safe_copy(temp_file, specified_target)
-        temp_output_base = unsuffixed(temp_file)
-        if os.path.exists(temp_output_base + '.d'):
-          # There was a .d file generated, from -MD or -MMD and friends, save a copy of it to where the output resides,
-          # adjusting the target name away from the temporary file name to the specified target.
-          # It will be deleted with the rest of the temporary directory.
-          deps = open(temp_output_base + '.d').read()
-          deps = deps.replace(temp_output_base + options.default_object_extension, specified_target)
-          with open(os.path.join(os.path.dirname(specified_target), os.path.basename(unsuffixed(input_file) + '.d')), "w") as out_dep:
-            out_dep.write(deps)
-
-  # exit block 'process inputs'
-  log_time('process inputs')
 
   if compile_only:
     logger.debug('stopping after compile phase')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -397,7 +397,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     self.clear()
     err = self.expect_fail(cmd + ['-o', 'out.o'])
 
-    self.assertContained('cannot specify -o with -c/-S/-E and multiple source files', err)
+    self.assertContained('cannot specify -o with -c/-S/-E/-M and multiple source files', err)
     self.assertNotExists('twopart_main.o')
     self.assertNotExists('twopart_side.o')
     self.assertNotExists(path_from_root('tests', 'twopart_main.o'))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -441,7 +441,7 @@ def generate_sanity():
   return sanity_file_content
 
 
-def perform_sanify_checks():
+def perform_sanity_checks():
   logger.info('(Emscripten: Running sanity checks)')
 
   with ToolchainProfiler.profile_block('sanity compiler_engine'):
@@ -490,8 +490,14 @@ def check_sanity(force=False):
           # the check actually failed, so definitely write out the sanity file, to
           # avoid others later seeing failures too
           force = False
-      elif not force:
-        return # all is well
+      else:
+        if force:
+          logger.debug(f'sanity file up-to-date but check forced: {sanity_file}')
+        else:
+          logger.debug(f'sanity file up-to-date: {sanity_file}')
+          return # all is well
+    else:
+      logger.debug(f'sanity file not found: {sanity_file}')
 
     # some warning, mostly not fatal checks - do them even if EM_IGNORE_SANITY is on
     check_node_version()
@@ -505,7 +511,7 @@ def check_sanity(force=False):
     if not llvm_ok:
       exit_with_error('failing sanity checks due to previous llvm failure')
 
-    perform_sanify_checks()
+    perform_sanity_checks()
 
     if not force:
       # Only create/update this file if the sanity check succeeded, i.e., we got here
@@ -1116,6 +1122,7 @@ def unsuffixed_basename(name):
 
 
 def safe_move(src, dst):
+  logging.debug('move: %s -> %s', src, dst)
   src = os.path.abspath(src)
   dst = os.path.abspath(dst)
   if os.path.isdir(dst):
@@ -1124,11 +1131,11 @@ def safe_move(src, dst):
     return
   if dst == os.devnull:
     return
-  logging.debug('move: %s -> %s', src, dst)
   shutil.move(src, dst)
 
 
 def safe_copy(src, dst):
+  logging.debug('copy: %s -> %s', src, dst)
   src = os.path.abspath(src)
   dst = os.path.abspath(dst)
   if os.path.isdir(dst):


### PR DESCRIPTION
In compile-only mode we can write all object files directly to their
final locations completely avoiding the need for temp files or for
renaming. Also avoid the `.d` file modification that we had in there.

This is a really nice simplification that has become possible as we have
made the emscripten code more precise about exactly which mode it is
running in.

Fixes: #12709