### PR TITLE
Remove emscripten copyright from third_party headers

### DIFF
--- a/tests/third_party/box2d/glui/glui_bitmap_img_data.cpp
+++ b/tests/third_party/box2d/glui/glui_bitmap_img_data.cpp
@@ -1,8 +1,3 @@
-// Copyright 2013 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 /**
  Bitmaps for all GLUI images.
  

--- a/tests/third_party/box2d/glui/glui_treepanel.cpp
+++ b/tests/third_party/box2d/glui/glui_treepanel.cpp
@@ -1,8 +1,3 @@
-// Copyright 2013 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include "glui.h"
 
 

--- a/tests/third_party/bullet/Demos/HelloWorld/parse.py
+++ b/tests/third_party/bullet/Demos/HelloWorld/parse.py
@@ -1,8 +1,3 @@
-# Copyright 2014 The Emscripten Authors.  All rights reserved.
-# Emscripten is available under two separate licenses, the MIT license and the
-# University of Illinois/NCSA Open Source License.  Both these licenses can be
-# found in the LICENSE file.
-
 from __future__ import print_function
 import math
 

--- a/tests/third_party/bullet/Demos/HelloWorld/setup.js
+++ b/tests/third_party/bullet/Demos/HelloWorld/setup.js
@@ -1,8 +1,3 @@
-// Copyright 2014 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 function startSimulation() {
   var i = 0;
   var interval = setInterval(function() {

--- a/tests/third_party/bullet/Extras/ConvexDecomposition/ConvexBuilder.cpp
+++ b/tests/third_party/bullet/Extras/ConvexDecomposition/ConvexBuilder.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include "float_math.h"
 #include "ConvexBuilder.h"
 #include "meshvolume.h"

--- a/tests/third_party/bullet/Extras/glui/glui_bitmap_img_data.cpp
+++ b/tests/third_party/bullet/Extras/glui/glui_bitmap_img_data.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 /**
  Bitmaps for all GLUI images.
  

--- a/tests/third_party/bullet/Extras/glui/glui_treepanel.cpp
+++ b/tests/third_party/bullet/Extras/glui/glui_treepanel.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include "GL/glui.h"
 
 

--- a/tests/third_party/enet/callbacks.c
+++ b/tests/third_party/enet/callbacks.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file callbacks.c
  @brief ENet callback functions

--- a/tests/third_party/enet/compress.c
+++ b/tests/third_party/enet/compress.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file compress.c
  @brief An adaptive order-2 PPM range coder

--- a/tests/third_party/enet/host.c
+++ b/tests/third_party/enet/host.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file host.c
  @brief ENet host management functions

--- a/tests/third_party/enet/list.c
+++ b/tests/third_party/enet/list.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file list.c
  @brief ENet linked list functions

--- a/tests/third_party/enet/packet.c
+++ b/tests/third_party/enet/packet.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file  packet.c
  @brief ENet packet management functions

--- a/tests/third_party/enet/peer.c
+++ b/tests/third_party/enet/peer.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file  peer.c
  @brief ENet peer management functions

--- a/tests/third_party/enet/protocol.c
+++ b/tests/third_party/enet/protocol.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file  protocol.c
  @brief ENet protocol functions

--- a/tests/third_party/enet/unix.c
+++ b/tests/third_party/enet/unix.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file  unix.c
  @brief ENet Unix system specific functions

--- a/tests/third_party/enet/win32.c
+++ b/tests/third_party/enet/win32.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2012 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /** 
  @file  win32.c
  @brief ENet Win32 system specific functions

--- a/tests/third_party/freealut/examples/hello_world.c
+++ b/tests/third_party/freealut/examples/hello_world.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <stdlib.h>
 #include <AL/alut.h>
 

--- a/tests/third_party/freealut/examples/playfile.c
+++ b/tests/third_party/freealut/examples/playfile.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>

--- a/tests/third_party/freealut/src/alutBufferData.c
+++ b/tests/third_party/freealut/src/alutBufferData.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 
 struct BufferData_struct

--- a/tests/third_party/freealut/src/alutCodec.c
+++ b/tests/third_party/freealut/src/alutCodec.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 
 ALvoid *_alutCodecLinear(ALvoid * data, size_t length, ALint numChannels, ALint bitsPerSample, ALfloat sampleFrequency)

--- a/tests/third_party/freealut/src/alutError.c
+++ b/tests/third_party/freealut/src/alutError.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 #include <stdio.h>
 

--- a/tests/third_party/freealut/src/alutInit.c
+++ b/tests/third_party/freealut/src/alutInit.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 
 static enum

--- a/tests/third_party/freealut/src/alutInputStream.c
+++ b/tests/third_party/freealut/src/alutInputStream.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 #include <stdio.h>
 #include <string.h>

--- a/tests/third_party/freealut/src/alutLoader.c
+++ b/tests/third_party/freealut/src/alutLoader.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 #include <ctype.h>
 

--- a/tests/third_party/freealut/src/alutOutputStream.c
+++ b/tests/third_party/freealut/src/alutOutputStream.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 #include <string.h>
 

--- a/tests/third_party/freealut/src/alutUtil.c
+++ b/tests/third_party/freealut/src/alutUtil.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 
 #if HAVE_NANOSLEEP && HAVE_TIME_H

--- a/tests/third_party/freealut/src/alutVersion.c
+++ b/tests/third_party/freealut/src/alutVersion.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 
 ALint alutGetMajorVersion(void)

--- a/tests/third_party/freealut/src/alutWaveform.c
+++ b/tests/third_party/freealut/src/alutWaveform.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include "alutInternal.h"
 #include <math.h>
 #include <string.h>

--- a/tests/third_party/freealut/test_suite/test_errorstuff.c
+++ b/tests/third_party/freealut/test_suite/test_errorstuff.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <AL/alut.h>

--- a/tests/third_party/freealut/test_suite/test_fileloader.c
+++ b/tests/third_party/freealut/test_suite/test_fileloader.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <AL/alut.h>

--- a/tests/third_party/freealut/test_suite/test_memoryloader.c
+++ b/tests/third_party/freealut/test_suite/test_memoryloader.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <stdio.h>
 #include <stdlib.h>
 #include <AL/alut.h>

--- a/tests/third_party/freealut/test_suite/test_retrostuff.c
+++ b/tests/third_party/freealut/test_suite/test_retrostuff.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <AL/alut.h>

--- a/tests/third_party/freealut/test_suite/test_version.c
+++ b/tests/third_party/freealut/test_suite/test_version.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <stdlib.h>
 #include <stdio.h>
 #include <AL/alut.h>

--- a/tests/third_party/freealut/test_suite/test_waveforms.c
+++ b/tests/third_party/freealut/test_suite/test_waveforms.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2013 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <stdlib.h>
 #include <AL/alut.h>
 

--- a/tests/third_party/freetype/src/tools/apinames.c
+++ b/tests/third_party/freetype/src/tools/apinames.c
@@ -1,11 +1,4 @@
 /*
- * Copyright 2011 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
-/*
  * This little program is used to parse the FreeType headers and
  * find the declaration of all public APIs.  This is easy, because
  * they all look like the following:

--- a/tests/third_party/freetype/src/tools/test_afm.c
+++ b/tests/third_party/freetype/src/tools/test_afm.c
@@ -1,11 +1,4 @@
 /*
- * Copyright 2011 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
-/*
  * gcc -DFT2_BUILD_LIBRARY -I../../include -o test_afm test_afm.c \
  *     -L../../objs/.libs -lfreetype -lz -static
  */

--- a/tests/third_party/freetype/src/tools/test_bbox.c
+++ b/tests/third_party/freetype/src/tools/test_bbox.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2011 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_BBOX_H

--- a/tests/third_party/freetype/src/tools/test_trig.c
+++ b/tests/third_party/freetype/src/tools/test_trig.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2011 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_TRIGONOMETRY_H

--- a/tests/third_party/lzma/Alloc.c
+++ b/tests/third_party/lzma/Alloc.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2016 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /* Alloc.c -- Memory allocation functions
 2013-11-12 : Igor Pavlov : Public domain */
 

--- a/tests/third_party/lzma/LzFind.c
+++ b/tests/third_party/lzma/LzFind.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2016 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /* LzFind.c -- Match finder for LZ algorithms
 2009-04-22 : Igor Pavlov : Public domain */
 

--- a/tests/third_party/lzma/LzmaDec.c
+++ b/tests/third_party/lzma/LzmaDec.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2016 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /* LzmaDec.c -- LZMA Decoder
 2015-01-01 : Igor Pavlov : Public domain */
 

--- a/tests/third_party/lzma/LzmaEnc.c
+++ b/tests/third_party/lzma/LzmaEnc.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2016 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /* LzmaEnc.c -- LZMA Encoder
 2014-12-29 : Igor Pavlov : Public domain */
 

--- a/tests/third_party/poppler/glib/poppler-enums.c
+++ b/tests/third_party/poppler/glib/poppler-enums.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2011 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 /* Generated data (by glib-mkenums) */
 
 #include <config.h>

--- a/tests/third_party/poppler/poppler/gen-unicode-tables.py
+++ b/tests/third_party/poppler/poppler/gen-unicode-tables.py
@@ -1,9 +1,4 @@
 #!/usr/bin/python
-# Copyright 2011 The Emscripten Authors.  All rights reserved.
-# Emscripten is available under two separate licenses, the MIT license and the
-# University of Illinois/NCSA Open Source License.  Both these licenses can be
-# found in the LICENSE file.
-
 from __future__ import print_function
 import unicodedata
 

--- a/tests/third_party/poppler/qt/test-poppler-qt.cpp
+++ b/tests/third_party/poppler/qt/test-poppler-qt.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <qapplication.h>
 #include <qpainter.h>
 #include <qpixmap.h>

--- a/tests/third_party/poppler/qt4/tests/check_actualtext.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_actualtext.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_attachments.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_attachments.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_dateConversion.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_dateConversion.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 Q_DECLARE_METATYPE(QDate)

--- a/tests/third_party/poppler/qt4/tests/check_fonts.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_fonts.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_links.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_links.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_metadata.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_metadata.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_optcontent.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_optcontent.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include "PDFDoc.h"

--- a/tests/third_party/poppler/qt4/tests/check_pagelayout.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_pagelayout.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_pagemode.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_pagemode.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_password.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_password.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_permissions.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_permissions.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/check_search.cpp
+++ b/tests/third_party/poppler/qt4/tests/check_search.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtTest/QtTest>
 
 #include <poppler-qt4.h>

--- a/tests/third_party/poppler/qt4/tests/poppler-attachments.cpp
+++ b/tests/third_party/poppler/qt4/tests/poppler-attachments.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDebug>
 

--- a/tests/third_party/poppler/qt4/tests/poppler-fonts.cpp
+++ b/tests/third_party/poppler/qt4/tests/poppler-fonts.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDebug>
 

--- a/tests/third_party/poppler/qt4/tests/poppler-texts.cpp
+++ b/tests/third_party/poppler/qt4/tests/poppler-texts.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtCore/QCoreApplication>
 #include <QtCore/QDebug>
 

--- a/tests/third_party/poppler/qt4/tests/stress-poppler-dir.cpp
+++ b/tests/third_party/poppler/qt4/tests/stress-poppler-dir.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtCore/QDebug>
 #include <QtCore/QDir>
 #include <QtCore/QTime>

--- a/tests/third_party/poppler/qt4/tests/stress-poppler-qt4.cpp
+++ b/tests/third_party/poppler/qt4/tests/stress-poppler-qt4.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtCore/QDebug>
 #include <QtCore/QDir>
 #include <QtCore/QTime>

--- a/tests/third_party/poppler/qt4/tests/test-password-qt4.cpp
+++ b/tests/third_party/poppler/qt4/tests/test-password-qt4.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtCore/QDebug>
 #include <QtGui/QApplication>
 #include <QtGui/QImage>

--- a/tests/third_party/poppler/qt4/tests/test-poppler-qt4.cpp
+++ b/tests/third_party/poppler/qt4/tests/test-poppler-qt4.cpp
@@ -1,8 +1,3 @@
-// Copyright 2011 The Emscripten Authors.  All rights reserved.
-// Emscripten is available under two separate licenses, the MIT license and the
-// University of Illinois/NCSA Open Source License.  Both these licenses can be
-// found in the LICENSE file.
-
 #include <QtCore/QDebug>
 #include <QtCore/QFile>
 #include <QtGui/QApplication>

--- a/tests/third_party/poppler/test/pdf-operators.c
+++ b/tests/third_party/poppler/test/pdf-operators.c
@@ -1,10 +1,3 @@
-/*
- * Copyright 2011 The Emscripten Authors.  All rights reserved.
- * Emscripten is available under two separate licenses, the MIT license and the
- * University of Illinois/NCSA Open Source License.  Both these licenses can be
- * found in the LICENSE file.
- */
-
 typedef struct
 {
   char *op;


### PR DESCRIPTION
Its seems we painted with too broad a brush in #7116.

This change was generated programmatically using this type of thing:

```
for f in `git grep --name-only "//.*The Emscripten Authors" tests/third_party`; do tail -n +6 $f > tmp && /bin/mv tmp $f; done
```

Fixes: #12711