### PR TITLE
WASM2JS is currently not compatible with STANDALONE_WASM

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1736,6 +1736,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         exit_with_error('STANDALONE_WASM does not support pthreads yet')
       if shared.Settings.MINIMAL_RUNTIME:
         exit_with_error('MINIMAL_RUNTIME reduces JS size, and is incompatible with STANDALONE_WASM which focuses on ignoring JS anyhow and being 100% wasm')
+      if shared.Settings.WASM2JS:
+        exit_with_error('WASM2JS is not compatible with STANDALONE_WASM output')
       # the wasm must be runnable without the JS, so there cannot be anything that
       # requires JS legalization
       shared.Settings.LEGALIZE_JS_FFI = 0

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9586,6 +9586,10 @@ exec "$@"
       err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-sMAIN_MODULE', '-sWASM=0'])
       self.assertContained('WASM2JS is not compatible with relocatable output', err)
 
+  def test_wasm2js_standalone(self):
+    err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-sSTANDALONE_WASM', '-sWASM=0'])
+    self.assertContained('WASM2JS is not compatible with STANDALONE_WASM output', err)
+
   def test_oformat(self):
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--oformat=wasm', '-o', 'out.foo'])
     self.assertTrue(building.is_wasm('out.foo'))


### PR DESCRIPTION
wasm2js doesn't yet support memories exported from the wasm module.
I'm working fixed that but for now add an error message.