### PR TITLE
Remove asm-specific exports such as `global.Math`

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -390,11 +390,6 @@ var LibraryDylink = {
       };
       var proxy = new Proxy(env, proxyHandler);
       var info = {
-        'global': {
-          'NaN': NaN,
-          'Infinity': Infinity,
-        },
-        'global.Math': Math,
         'GOT.mem': new Proxy(asmLibraryArg, GOTHandler),
         'GOT.func': new Proxy(asmLibraryArg, GOTHandler),
         'env': proxy,


### PR DESCRIPTION
These stopped being exported form JS in #11887 but
the exports used in the dylink case still included
them.