### PR TITLE
Re-enable code size tests after wasm2js change. NFC.

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21688,
-  "a.js.gz": 8372,
+  "a.js": 21380,
+  "a.js.gz": 8269,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 25447,
-  "total_gz": 11473
+  "total": 25139,
+  "total_gz": 11370
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21177,
-  "a.js.gz": 8205,
+  "a.js": 20869,
+  "a.js.gz": 8104,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 24936,
-  "total_gz": 11306
+  "total": 24628,
+  "total_gz": 11205
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 697,
   "a.html.gz": 437,
-  "a.js": 1131,
-  "a.js.gz": 586,
+  "a.js": 861,
+  "a.js.gz": 501,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 1834,
-  "total_gz": 1055
+  "total": 1564,
+  "total_gz": 970
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13673,
-  "a.html.gz": 7308,
-  "total": 13673,
-  "total_gz": 7308
+  "a.html": 13665,
+  "a.html.gz": 7313,
+  "total": 13665,
+  "total_gz": 7313
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 19219,
-  "a.html.gz": 8008,
-  "total": 19219,
-  "total_gz": 8008
+  "a.html": 18933,
+  "a.html.gz": 7914,
+  "total": 18933,
+  "total_gz": 7914
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8220,10 +8220,6 @@ int main () {
       return ' ({:+.2f}%)'.format((actual - expected) * 100.0 / expected)
 
     for js in [False, True]:
-      # TODO(sbc): re-enabled once binaryen side change rolls:
-      # https://github.com/WebAssembly/binaryen/pull/3325
-      if js:
-        continue
       for sources, name in [
           [hello_world_sources, 'hello_world'],
           [random_printf_sources, 'random_printf'],


### PR DESCRIPTION
This gets us some nice code size improvements.

See: https://github.com/WebAssembly/binaryen/pull/3325