### PR TITLE
Fix closure error messages

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2732,7 +2732,7 @@ def do_binaryen(target, options, wasm_target):
       final_js = building.minify_wasm_js(js_file=final_js,
                                          wasm_file=wasm_target,
                                          expensive_optimizations=will_metadce(),
-                                         minify_whitespace=minify_whitespace(),
+                                         minify_whitespace=minify_whitespace() and not options.use_closure_compiler,
                                          debug_info=intermediate_debug_info)
       save_intermediate_with_wasm('postclean', wasm_target)
 

--- a/emcc.py
+++ b/emcc.py
@@ -2727,7 +2727,9 @@ def do_binaryen(target, options, wasm_target):
       final_js = building.instrument_js_for_safe_heap(final_js)
 
     if shared.Settings.OPT_LEVEL >= 2 and shared.Settings.DEBUG_LEVEL <= 2:
-      # minify the JS
+      # minify the JS. Do not minify whitespace if Closure is used, so that
+      # Closure can print out readable error messages (Closure will then
+      # minify whitespace afterwards)
       save_intermediate_with_wasm('preclean', wasm_target)
       final_js = building.minify_wasm_js(js_file=final_js,
                                          wasm_file=wasm_target,

--- a/src/cpuprofiler.js
+++ b/src/cpuprofiler.js
@@ -13,7 +13,7 @@
 if (!performance.realNow) {
   var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
   if (isSafari) {
-    realPerformance = performance;
+    var realPerformance = performance;
     performance = {
       realNow: function() { return realPerformance.now(); },
       now: function() { return realPerformance.now(); }
@@ -297,7 +297,7 @@ var emscriptenCpuProfiler = {
 
     // Create the UI display if it doesn't yet exist. If you want to customize the location/style of the cpuprofiler UI,
     // you can manually create this beforehand.
-    cpuprofiler = document.getElementById('cpuprofiler');
+    var cpuprofiler = document.getElementById('cpuprofiler');
     if (!cpuprofiler) {
       var css = '.colorbox { border: solid 1px black; margin-left: 10px; margin-right: 3px; display: inline-block; width: 20px; height: 10px; }  .hastooltip:hover .tooltip { display: block; } .tooltip { display: none; background: #FFFFFF; margin-left: 28px; padding: 5px; position: absolute; z-index: 1000; width:200px; } .hastooltip { margin:0px; }';
       var style = document.createElement('style');
@@ -431,12 +431,12 @@ var emscriptenCpuProfiler = {
     for(var i = 0; i < this.sections.length; ++i) {
       var sect = this.sections[i];
       if (!sect) continue;
-      var h = (sect.frametimesInsideMainLoop[x] + sect.frametimesOutsideMainLoop[x]) * scale;
+      h = (sect.frametimesInsideMainLoop[x] + sect.frametimesOutsideMainLoop[x]) * scale;
       y -= h;
       this.drawContext.fillStyle = sect.drawColor;
       this.drawContext.fillRect(x, y, 1, h);
     }
-    var h = this.timeSpentOutsideMainloop[x] * scale;
+    h = this.timeSpentOutsideMainloop[x] * scale;
     y -= h;
     var fps60Limit = this.canvas.height - (16.666666666 + 1.0) * this.canvas.height / this.verticalTimeScale; // Be very lax, allow 1msec extra jitter.
     var fps30Limit = this.canvas.height - (33.333333333 + 1.0) * this.canvas.height / this.verticalTimeScale; // Be very lax, allow 1msec extra jitter.
@@ -645,7 +645,7 @@ var emscriptenCpuProfiler = {
 
 // Hook into setInterval to be able to capture the time spent executing them.
 emscriptenCpuProfiler.createSection(2, 'setInterval', emscriptenCpuProfiler.colorSetIntervalSection, /*traceable=*/true);
-realSetInterval = setInterval;
+var realSetInterval = setInterval;
 setInterval = function(fn, delay) {
   function wrappedSetInterval() {
     emscriptenCpuProfiler.enterSection(2);
@@ -657,7 +657,7 @@ setInterval = function(fn, delay) {
 
 // Hook into setTimeout to be able to capture the time spent executing them.
 emscriptenCpuProfiler.createSection(3, 'setTimeout', emscriptenCpuProfiler.colorSetTimeoutSection, /*traceable=*/true);
-realSetTimeout = setTimeout;
+var realSetTimeout = setTimeout;
 setTimeout = function(fn, delay) {
   function wrappedSetTimeout() {
     emscriptenCpuProfiler.enterSection(3);

--- a/src/memoryprofiler.js
+++ b/src/memoryprofiler.js
@@ -161,7 +161,7 @@ var emscriptenMemoryProfiler = {
   },
 
   recordStackWatermark: function() {
-    if (runtimeInitialized) {
+    if (typeof runtimeInitialized === 'undefined' || runtimeInitialized) {
       var self = emscriptenMemoryProfiler;
       self.stackTopWatermark = Math.min(self.stackTopWatermark, _emscripten_stack_get_current());
     }
@@ -487,7 +487,7 @@ var emscriptenMemoryProfiler = {
       self.canvas.width = document.documentElement.clientWidth - 32;
     }
 
-    if (!runtimeInitialized) {
+    if (typeof runtimeInitialized !== 'undefined' && !runtimeInitialized) {
       return;
     }
     var stackBase = _emscripten_stack_get_base();
@@ -513,7 +513,7 @@ var emscriptenMemoryProfiler = {
     html += "<br />Free memory: " + colorBar("#70FF70") + "DYNAMIC: " + self.formatBytes(heap_end - heap_base - self.totalMemoryAllocated) + ", " + colorBar('#FFFFFF') + 'Unallocated HEAP: ' + self.formatBytes(HEAP8.length - heap_end) + " (" + ((HEAP8.length - heap_base - self.totalMemoryAllocated) * 100 / (HEAP8.length - heap_base)).toFixed(2) + "% of all dynamic memory and unallocated heap)";
 
     var preloadedMemoryUsed = 0;
-    for (i in self.sizeOfPreRunAllocatedPtr) preloadedMemoryUsed += self.sizeOfPreRunAllocatedPtr[i]|0;
+    for (var i in self.sizeOfPreRunAllocatedPtr) preloadedMemoryUsed += self.sizeOfPreRunAllocatedPtr[i]|0;
     html += '<br />' + colorBar('#FF9900') + colorBar('#FFDD33') + 'Preloaded memory used, most likely memory reserved by files in the virtual filesystem : ' + self.formatBytes(preloadedMemoryUsed);
 
     html += '<br />OpenAL audio data: ' + self.formatBytes(self.countOpenALAudioDataSize()) + ' (outside HEAP)';
@@ -588,7 +588,7 @@ var emscriptenMemoryProfiler = {
     var sort = document.getElementById('memoryProfilerSort');
     var sortOrder = sort.options[sort.selectedIndex].value;
 
-    var html = '';
+    html = '';
 
     // Print out sbrk() and memory resize subdivisions:
     if (document.getElementById('showHeapResizes').checked) {

--- a/tests/closure_error.c
+++ b/tests/closure_error.c
@@ -1,6 +1,9 @@
-extern void foo(void);
+#include <emscripten.h>
 
 int main()
 {
-	foo();
+	EM_ASM({
+		thisVarDoesNotExist++;
+		thisVarDoesNotExistEither++;
+	});
 }

--- a/tests/closure_error.c
+++ b/tests/closure_error.c
@@ -1,0 +1,6 @@
+extern void foo(void);
+
+int main()
+{
+	foo();
+}

--- a/tests/library_closure_error.js
+++ b/tests/library_closure_error.js
@@ -1,0 +1,6 @@
+mergeInto(LibraryManager.library, {
+	foo: function() {
+		thisVarDoesNotExist++;
+		thisVarDoesNotExistEither++;
+	}
+});

--- a/tests/library_closure_error.js
+++ b/tests/library_closure_error.js
@@ -1,6 +1,0 @@
-mergeInto(LibraryManager.library, {
-	foo: function() {
-		thisVarDoesNotExist++;
-		thisVarDoesNotExistEither++;
-	}
-});

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9656,3 +9656,18 @@ exec "$@"
     assert idx2 != -1
     # The errors must be present on distinct lines.
     assert idx1 != idx2
+
+  # Make sure that --cpuprofiler compiles with --closure 1
+  def test_cpuprofiler_closure(self):
+    # TODO: Enable '-s', 'CLOSURE_WARNINGS=error' in the following, but that has currently regressed.
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', , '--cpuprofiler'])
+
+  # Make sure that --memoryprofiler compiles with --closure 1
+  def test_memoryprofiler_closure(self):
+    # TODO: Enable '-s', 'CLOSURE_WARNINGS=error' in the following, but that has currently regressed.
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '--memoryprofiler'])
+
+  # Make sure that --threadprofiler compiles with --closure 1
+  def test_threadprofiler_closure(self):
+    # TODO: Enable '-s', 'CLOSURE_WARNINGS=error' in the following, but that has currently regressed.
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-s', 'USE_PTHREADS=1', '--closure', '1', '--threadprofiler'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9642,21 +9642,21 @@ exec "$@"
 
   # Test that Closure prints out clear readable error messages when there are errors.
   def test_closure_errors(self):
-    err = self.expect_fail([EMCC, path_from_root('tests', 'closure_error.c'), '-O2', '--closure', '1', '--js-library', path_from_root('tests', 'library_closure_error.js')])
+    err = self.expect_fail([EMCC, path_from_root('tests', 'closure_error.c'), '-O2', '--closure', '1'])
     lines = err.split('\n')
 
     def find_substr_index(s):
-      for i in range(len(lines)):
-        if s in lines[i]:
+      for i, line in enumerate(lines):
+        if s in line:
           return i
       return -1
 
     idx1 = find_substr_index('[JSC_UNDEFINED_VARIABLE] variable thisVarDoesNotExist is undeclared')
     idx2 = find_substr_index('[JSC_UNDEFINED_VARIABLE] variable thisVarDoesNotExistEither is undeclared')
-    assert idx1 != -1
-    assert idx2 != -1
+    self.assertNotEqual(idx1, -1)
+    self.assertNotEqual(idx2, -1)
     # The errors must be present on distinct lines.
-    assert idx1 != idx2
+    self.assertNotEqual(idx1, idx2)
 
   # Make sure that --cpuprofiler compiles with --closure 1
   def test_cpuprofiler_closure(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9639,3 +9639,20 @@ exec "$@"
     self.compile_with_wasi_sdk(path_from_root('tests', 'hello_world.c'), 'hello.wasm')
     self.run_process([EMCC, '--post-link', '-sPURE_WASI', 'hello.wasm'])
     self.assertContained('hello, world!', self.run_js('a.out.js'))
+
+  # Test that Closure prints out clear readable error messages when there are errors.
+  def test_closure_errors(self):
+    err = self.expect_fail([EMCC, path_from_root('tests', 'closure_error.c'), '-O2', '--closure', '1', '--js-library', path_from_root('tests', 'library_closure_error.js')])
+    lines = err.split('\n')
+    def find_substr_index(s):
+      for i in range(len(lines)):
+        if s in lines[i]:
+          return i
+      return -1
+
+    idx1 = find_substr_index('[JSC_UNDEFINED_VARIABLE] variable thisVarDoesNotExist is undeclared')
+    idx2 = find_substr_index('[JSC_UNDEFINED_VARIABLE] variable thisVarDoesNotExistEither is undeclared')
+    assert idx1 != -1
+    assert idx2 != -1
+    # The errors must be present on distinct lines.
+    assert idx1 != idx2

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9644,6 +9644,7 @@ exec "$@"
   def test_closure_errors(self):
     err = self.expect_fail([EMCC, path_from_root('tests', 'closure_error.c'), '-O2', '--closure', '1', '--js-library', path_from_root('tests', 'library_closure_error.js')])
     lines = err.split('\n')
+
     def find_substr_index(s):
       for i in range(len(lines)):
         if s in lines[i]:
@@ -9660,7 +9661,7 @@ exec "$@"
   # Make sure that --cpuprofiler compiles with --closure 1
   def test_cpuprofiler_closure(self):
     # TODO: Enable '-s', 'CLOSURE_WARNINGS=error' in the following, but that has currently regressed.
-    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', , '--cpuprofiler'])
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '--closure', '1', '--cpuprofiler'])
 
   # Make sure that --memoryprofiler compiles with --closure 1
   def test_memoryprofiler_closure(self):


### PR DESCRIPTION
Fix Closure to print clear readable error messages, instead of a single wall of minified text.

Fix --cpuprofiler and --memoryprofiler to work with --closure 1, and add testing for --cpuprofiler, --memoryprofiler and --threadprofiler with Closure.