### PR TITLE
Report undefined symbols when only producing a wasm file

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8184,9 +8184,16 @@ NODEFS is no longer included by default; build with -lnodefs.js
       self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main.cpp')
       self.clear_setting('EXPORTED_FUNCTIONS')
 
-    # If we pass --no-entry or set EXPORTED_FUNCTIONS to empty should never see any errors
+  def test_undefined_main_explict(self):
+    # If we pass --no-entry this test should compile without issue
     self.emcc_args.append('--no-entry')
     self.do_run_in_out_file_test('tests', 'core', 'test_ctors_no_main.cpp')
+
+  def test_undefined_main_wasm_output(self):
+    if not can_do_standalone(self):
+      self.skipTest('standalone mode only')
+    err = self.expect_fail([EMCC, '-o', 'out.wasm', path_from_root('tests', 'core', 'test_ctors_no_main.cpp')] + self.get_emcc_args())
+    self.assertContained('undefined symbol: main', err)
 
   def test_export_start(self):
     if not can_do_standalone(self):


### PR DESCRIPTION
When building direclty to wasm (e.g. with `-o <out>.wasm`
or with `--oformat=wasm`) we were not reporting undefined
symbols since we were not running the js compiler at all.

Fixed: #12725