### PR TITLE
Remove llvm_eh_selector and llvm_eh_exception

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -283,21 +283,6 @@ var LibraryExceptions = {
     {{{ makeThrow('ptr') }}}
   },
 
-  llvm_eh_exception__deps: ['$exceptionLast'],
-  llvm_eh_exception: function() {
-    return exceptionLast;
-  },
-
-  llvm_eh_selector__jsargs: true,
-  llvm_eh_selector__deps: ['$exceptionLast'],
-  llvm_eh_selector: function(unused_exception_value, personality/*, varargs*/) {
-    var type = exceptionLast;
-    for (var i = 2; i < arguments.length; i++) {
-      if (arguments[i] == type) return type;
-    }
-    return 0;
-  },
-
   llvm_eh_typeid_for: function(type) {
     return type;
   },

--- a/src/library_exceptions_stub.js
+++ b/src/library_exceptions_stub.js
@@ -13,8 +13,6 @@ var LibraryExceptions = {};
   '__cxa_decrement_exception_refcount',
   '__cxa_throw',
   '__cxa_rethrow',
-  'llvm_eh_exception',
-  'llvm_eh_selector',
   'llvm_eh_typeid_for',
   '__cxa_begin_catch',
   '__cxa_end_catch',


### PR DESCRIPTION
These seems to be legacy symbols.  I don't see any reference
to them in llvm to emscripten anymore.