### PR TITLE
Fix regression that broke calls to makeDynCall in JS library code.

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -32,86 +32,90 @@ function processMacros(text) {
 // to locate errors for reporting and for html files to stop expansion between <style> and </style>.
 function preprocess(text, filenameHint) {
   currentlyParsedFilename = filenameHint;
-  var fileExt = (filenameHint) ? filenameHint.split('.').pop().toLowerCase() : "";
-  var isHtml = (fileExt === 'html' || fileExt === 'htm') ? true : false;
-  var inStyle = false;
-  var lines = text.split('\n');
-  var ret = '';
-  var showStack = [];
-  var emptyLine = false;
-  for (var i = 0; i < lines.length; i++) {
-    var line = lines[i];
-    try {
-      if (line[line.length-1] === '\r') {
-        line = line.substr(0, line.length-1); // Windows will have '\r' left over from splitting over '\r\n'
-      }
-      if (isHtml && line.indexOf('<style') !== -1 && !inStyle) {
-        inStyle = true;
-      }
-      if (isHtml && line.indexOf('</style') !== -1 && inStyle) {
-        inStyle = false;
-      }
+  try {
+    var fileExt = (filenameHint) ? filenameHint.split('.').pop().toLowerCase() : "";
+    var isHtml = (fileExt === 'html' || fileExt === 'htm') ? true : false;
+    var inStyle = false;
+    var lines = text.split('\n');
+    var ret = '';
+    var showStack = [];
+    var emptyLine = false;
+    for (var i = 0; i < lines.length; i++) {
+      var line = lines[i];
+      try {
+        if (line[line.length-1] === '\r') {
+          line = line.substr(0, line.length-1); // Windows will have '\r' left over from splitting over '\r\n'
+        }
+        if (isHtml && line.indexOf('<style') !== -1 && !inStyle) {
+          inStyle = true;
+        }
+        if (isHtml && line.indexOf('</style') !== -1 && inStyle) {
+          inStyle = false;
+        }
 
-      if (!inStyle) {
-        var trimmed = line.trim()
-        if (trimmed[0] === '#') {
-          var first = trimmed.split(' ', 1)[0]
-          if (first == '#if' || first == '#ifdef') {
-            if (first == '#ifdef') {
-              warn('warning: use of #ifdef in js library.  Use #if instead.');
-            }
-            var after = trimmed.substring(trimmed.indexOf(' '));
-            var truthy = !!eval(after);
-            showStack.push(truthy);
-          } else if (first === '#include') {
-            if (showStack.indexOf(false) === -1) {
-              var filename = line.substr(line.indexOf(' ')+1);
-              if (filename.indexOf('"') === 0) {
-                filename = filename.substr(1, filename.length - 2);
+        if (!inStyle) {
+          var trimmed = line.trim()
+          if (trimmed[0] === '#') {
+            var first = trimmed.split(' ', 1)[0]
+            if (first == '#if' || first == '#ifdef') {
+              if (first == '#ifdef') {
+                warn('warning: use of #ifdef in js library.  Use #if instead.');
               }
-              var included = read(filename);
-              var result = preprocess(included, filename);
-              if (result) {
-                ret += "// include: " + filename + "\n";
-                ret += result;
-                ret += "// end include: " + filename + "\n";
+              var after = trimmed.substring(trimmed.indexOf(' '));
+              var truthy = !!eval(after);
+              showStack.push(truthy);
+            } else if (first === '#include') {
+              if (showStack.indexOf(false) === -1) {
+                var filename = line.substr(line.indexOf(' ')+1);
+                if (filename.indexOf('"') === 0) {
+                  filename = filename.substr(1, filename.length - 2);
+                }
+                var included = read(filename);
+                var result = preprocess(included, filename);
+                if (result) {
+                  ret += "// include: " + filename + "\n";
+                  ret += result;
+                  ret += "// end include: " + filename + "\n";
+                }
               }
-            }
-          } else if (first === '#else') {
-            assert(showStack.length > 0);
-            showStack.push(!showStack.pop());
-          } else if (first === '#endif') {
-            assert(showStack.length > 0);
-            showStack.pop();
-          } else {
-            throw "Unknown preprocessor directive on line " + i + ': `' + line + '`';
-          }
-        } else {
-          if (showStack.indexOf(false) === -1) {
-            // Never emit more than one empty line at a time.
-            if (emptyLine && !line) {
-              continue;
-            }
-            ret += line + '\n';
-            if (!line) {
-              emptyLine = true;
+            } else if (first === '#else') {
+              assert(showStack.length > 0);
+              showStack.push(!showStack.pop());
+            } else if (first === '#endif') {
+              assert(showStack.length > 0);
+              showStack.pop();
             } else {
-              emptyLine = false;
+              throw "Unknown preprocessor directive on line " + i + ': `' + line + '`';
+            }
+          } else {
+            if (showStack.indexOf(false) === -1) {
+              // Never emit more than one empty line at a time.
+              if (emptyLine && !line) {
+                continue;
+              }
+              ret += line + '\n';
+              if (!line) {
+                emptyLine = true;
+              } else {
+                emptyLine = false;
+              }
             }
           }
+        } else { // !inStyle
+          if (showStack.indexOf(false) === -1) {
+            ret += line + '\n';
+          }
         }
-      } else { // !inStyle
-        if (showStack.indexOf(false) === -1) {
-          ret += line + '\n';
-        }
+      } catch(e) {
+        printErr('parseTools.js preprocessor error in ' + filenameHint + ':' + (i+1) + ': \"' + line + '\"!');
+        throw e;
       }
-    } catch(e) {
-      printErr('parseTools.js preprocessor error in ' + filenameHint + ':' + (i+1) + ': \"' + line + '\"!');
-      throw e;
     }
+    assert(showStack.length == 0, 'preprocessing error in file '+ filenameHint + ', no matching #endif found (' + showStack.length + ' unmatched preprocessing directives on stack)');
+    return ret;
+  } finally {
+    currentlyParsedFilename = null;
   }
-  assert(showStack.length == 0, 'preprocessing error in file '+ filenameHint + ', no matching #endif found (' + showStack.length + ' unmatched preprocessing directives on stack)');
-  return ret;
 }
 
 function removePointing(type, num) {

--- a/tests/library_test_old_dyncall_format.js
+++ b/tests/library_test_old_dyncall_format.js
@@ -1,0 +1,5 @@
+mergeInto(LibraryManager.library, {
+	callFunc: function(func, param1, param2) {
+		{{{ makeDynCall('vii') }}} (func, param1, param2);
+	}
+});

--- a/tests/test_old_dyncall_format.c
+++ b/tests/test_old_dyncall_format.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+void foo(int param1, int param2)
+{
+	if (param1 == 42 && param2 == 100) printf("Test passed!\n");
+}
+
+extern void callFunc(void (*foo)(int, int), int param1, int param2);
+
+int main()
+{
+	callFunc(foo, 42, 100);
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9617,6 +9617,11 @@ exec "$@"
     err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '--oformat=foo'])
     self.assertContained("error: invalid output format: `foo` (must be one of ['wasm', 'js', 'mjs', 'html', 'bare']", err)
 
+  # Tests that the old format of {{{ makeDynCall('sig') }}}(func, param1) works
+  def test_old_makeDynCall_syntax(self):
+    err = self.run_process([EMCC, path_from_root('tests', 'test_old_dyncall_format.c'), '--js-library', path_from_root('tests', 'library_test_old_dyncall_format.js')], stderr=PIPE).stderr
+    self.assertContained('syntax for makeDynCall has changed', err)
+
   def test_post_link(self):
     err = self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--oformat=bare', '-o', 'bare.wasm'], stderr=PIPE).stderr
     self.assertContained('--oformat=base/--post-link are experimental and subject to change', err)


### PR DESCRIPTION
Fix regression that broke calls to makeDynCall in JS library code. Old syntax is {{{ makeDynCall('sig') }}}(funcPtr, arg1, arg2);. New syntax is {{{ makeDynCall('sig', 'funcPtr') }}}(arg1, arg2). With this change, both old and new syntax work, with a compile time warning issued for old syntax to migrate to new one. Add ChangeLog entry about broken static dynCall invocation outside JS library files.