### PR TITLE
Simplify makeStructuralReturn

### DIFF
--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -194,7 +194,7 @@ var LibraryPThreadStub = {
     var l = 0, h = 0;
     l = (a + c)>>>0;
     h = (b + d + (((l>>>0) < (a>>>0))|0))>>>0; // Add carry from low word to high word on overflow.
-    {{{ makeStructuralReturn(['l|0', 'h'], true) }}};
+    {{{ makeStructuralReturn(['l|0', 'h']) }}};
   },
 
   i64Subtract__asm: true,
@@ -205,7 +205,7 @@ var LibraryPThreadStub = {
     l = (a - c)>>>0;
     h = (b - d)>>>0;
     h = (b - d - (((c>>>0) > (a>>>0))|0))>>>0; // Borrow one from high word to low word on underflow.
-    {{{ makeStructuralReturn(['l|0', 'h'], true) }}};
+    {{{ makeStructuralReturn(['l|0', 'h']) }}};
   },
 
   // gnu atomics

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -836,7 +836,7 @@ function makeSetTempRet0(value) {
   return "setTempRet0((" + value + ") | 0)";
 }
 
-// Takes a pair of return values, stashes on in tempRet0 and returns the other
+// Takes a pair of return values, stashes one in tempRet0 and returns the other.
 // Should probably be renamed to `makeReturn64` but keeping this old name in
 // case external JS library code uses this name.
 function makeStructuralReturn(values) {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -836,19 +836,12 @@ function makeSetTempRet0(value) {
   return "setTempRet0((" + value + ") | 0)";
 }
 
-function makeStructuralReturn(values, inAsm) {
-  var i = -1;
-  return 'return ' + asmCoercion(values.slice(1).map(function(value) {
-    i++;
-    if (!inAsm) {
-      return 'setTempRet' + i + '(' + value + ')';
-    }
-    if (i === 0) {
-      return makeSetTempRet0(value)
-    } else {
-      return 'tempRet' + i + ' = ' + value;
-    }
-  }).concat([values[0]]).join(','), 'i32');
+// Takes a pair of return values, stashes on in tempRet0 and returns the other
+// Should probably be renamed to `makeReturn64` but keeping this old name in
+// case external JS library code uses this name.
+function makeStructuralReturn(values) {
+  assert(values.length == 2);
+  return makeSetTempRet0(values[1]) + '; return ' + asmCoercion(values[0], 'i32');
 }
 
 function makeThrow(what) {


### PR DESCRIPTION
We don't support more than two values here so we can significantly
simplify.