### PR TITLE
Optimize makeDynCall to avoid dynamic dynCall where possible

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1385,7 +1385,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # See: https://github.com/emscripten-core/emscripten/issues/12065
       # See: https://github.com/emscripten-core/emscripten/issues/12066
       shared.Settings.USE_LEGACY_DYNCALLS = 1
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getDynCaller']
       shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_base',
                                              '_emscripten_stack_get_end',
                                              '_emscripten_stack_set_limits']
@@ -1618,17 +1617,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if not shared.Settings.MINIMAL_RUNTIME or shared.Settings.EXIT_RUNTIME:
       # MINIMAL_RUNTIME only needs callRuntimeCallbacks in certain cases, but the normal runtime
       # always does.
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks', '$dynCall']
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks']
 
     if shared.Settings.USE_PTHREADS:
       # memalign is used to ensure allocated thread stacks are aligned.
       shared.Settings.EXPORTED_FUNCTIONS += ['_memalign']
-
-      # dynCall is used to call pthread entry points in worker.js (as
-      # metadce does not consider worker.js, which is external, we must
-      # consider it an export, i.e., one which can never be removed).
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$dynCall']
-      shared.Settings.EXPORTED_FUNCTIONS += ['dynCall']
 
       if shared.Settings.MINIMAL_RUNTIME:
         building.user_requested_exports += ['exit']
@@ -1642,6 +1635,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         shared.Settings.EXPORTED_FUNCTIONS += [name]
 
       include_and_export('establishStackSpace')
+      include_and_export('invokeEntryPoint')
       if not shared.Settings.MINIMAL_RUNTIME:
         # noExitRuntime does not apply to MINIMAL_RUNTIME.
         include_and_export('getNoExitRuntime')

--- a/src/library.js
+++ b/src/library.js
@@ -3727,7 +3727,7 @@ LibraryManager.library = {
   },
 #endif
 
-  $dynCall: function (sig, ptr, args) {
+  $dynCall: function(sig, ptr, args) {
 #if USE_LEGACY_DYNCALLS
     return dynCallLegacy(sig, ptr, args);
 #else

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1105,10 +1105,9 @@ var LibraryBrowser = {
   },
 
   // TODO: currently not callable from a pthread, but immediately calls onerror() if not on main thread.
-  emscripten_async_load_script__deps: ['$getFuncWrapper'],
   emscripten_async_load_script: function(url, onload, onerror) {
-    onload = getFuncWrapper(onload, 'v');
-    onerror = getFuncWrapper(onerror, 'v');
+    onload = {{{ makeDynCall('v', 'onload') }}};
+    onerror = {{{ makeDynCall('v', 'onerror') }}};
 
 #if USE_PTHREADS
     if (ENVIRONMENT_IS_PTHREAD) {
@@ -1197,7 +1196,7 @@ var LibraryBrowser = {
   emscripten_set_main_loop__deps: ['$setMainLoop'],
   emscripten_set_main_loop__docs: '/** @param {number|boolean=} noSetTiming */',
   emscripten_set_main_loop: function(func, fps, simulateInfiniteLoop, arg, noSetTiming) {
-    var browserIterationFunc = function() { {{{ makeDynCall('v', 'func') }}}(); };
+    var browserIterationFunc = {{{ makeDynCall('v', 'func') }}};
     setMainLoop(browserIterationFunc, fps, simulateInfiniteLoop, arg, noSetTiming);
   },
 
@@ -1519,7 +1518,6 @@ var LibraryBrowser = {
     Browser.workers[id] = null;
   },
 
-  emscripten_call_worker__deps: ['$getFuncWrapper'],
   emscripten_call_worker__proxy: 'sync',
   emscripten_call_worker__sig: 'viiiiii',
   emscripten_call_worker: function(id, funcName, data, size, callback, arg) {
@@ -1531,7 +1529,7 @@ var LibraryBrowser = {
     if (callback) {
       callbackId = info.callbacks.length;
       info.callbacks.push({
-        func: getFuncWrapper(callback, 'viii'),
+        func: {{{ makeDynCall('viii', 'callback') }}},
         arg: arg
       });
       info.awaited++;

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1418,6 +1418,10 @@ var LibraryPThread = {
     return noExitRuntime;
   },
 
+  $invokeEntryPoint: function(ptr, arg) {
+    return {{{ makeDynCall('ii', 'ptr') }}}(arg);
+  },
+
   // When using postMessage to send an object, it is processed by the structured clone algorithm.
   // The prototype, and hence methods, on that object is then lost. This function adds back the lost prototype.
   // This does not work with nested objects that has prototypes, but it suffices for WasmSourceMap and WasmOffsetConverter.

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -985,7 +985,17 @@ function makeDynCall(sig, funcPtr) {
     }
   }
   if (USE_LEGACY_DYNCALLS) {
-    return `getDynCaller("${sig}", ${funcPtr})`;
+    let dyncall = exportedAsmFunc(`dynCall_${sig}`)
+    if (sig.length > 1) {
+      let args = [];
+      for (let i = 1; i < sig.length; ++i) {
+        args.push(`a${i}`);
+      }
+      args = args.join(', ');
+      return `(function(${args}) { ${dyncall}.apply(null, [${funcPtr}, ${args}]); })`;
+    } else {
+      return `(function() { ${dyncall}.call(null, ${funcPtr}); })`;
+    }
   } else {
     return `wasmTable.get(${funcPtr})`;
   }

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -61,7 +61,6 @@ function initRuntime(asm) {
   // Export needed variables that worker.js needs to Module.
   Module['_emscripten_tls_init'] = _emscripten_tls_init;
   Module['HEAPU32'] = HEAPU32;
-  Module['dynCall'] = dynCall;
   Module['__emscripten_thread_init'] = __emscripten_thread_init;
   Module['_pthread_self'] = _pthread_self;
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -188,7 +188,7 @@ this.onmessage = function(e) {
         // enable that to work. If you find the following line to crash, either change the signature
         // to "proper" void *ThreadMain(void *arg) form, or try linking with the Emscripten linker
         // flag -s EMULATE_FUNCTION_POINTER_CASTS=1 to add in emulation for this x86 ABI extension.
-        var result = Module['dynCall']('ii', e.data.start_routine, [e.data.arg]);
+        var result = Module['invokeEntryPoint'](e.data.start_routine, e.data.arg);
 
 #if STACK_OVERFLOW_CHECK
         Module['checkStackCookie']();

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -90,7 +90,7 @@ def clear(ports, settings, shared):
 
 
 def process_dependencies(settings):
-  settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$autoResumeAudioContext']
+  settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$autoResumeAudioContext', '$dynCall']
 
 
 def process_args(ports):


### PR DESCRIPTION
Now the runtime `dynCall` is only used in places where the
signature is not known at compile time, such as embind or
(the internally unused) `getFuncWrapper`.

Followup to #12732

See: #12733