### PR TITLE
Remove last references to handleFSError

### DIFF
--- a/site/source/api_items.py
+++ b/site/source/api_items.py
@@ -113,8 +113,6 @@ def get_mapped_items():
     mapped_wiki_inline_code['FS.getMode()'] = ':js:func:`FS.getMode`'
     mapped_wiki_inline_code['FS.getPath'] = ':js:func:`FS.getPath`'
     mapped_wiki_inline_code['FS.getPath()'] = ':js:func:`FS.getPath`'
-    mapped_wiki_inline_code['FS.handleFSError'] = ':js:func:`FS.handleFSError`'
-    mapped_wiki_inline_code['FS.handleFSError()'] = ':js:func:`FS.handleFSError`'
     mapped_wiki_inline_code['FS.init'] = ':js:func:`FS.init`'
     mapped_wiki_inline_code['FS.init()'] = ':js:func:`FS.init`'
     mapped_wiki_inline_code['FS.isBlkdev'] = ':js:func:`FS.isBlkdev`'

--- a/site/source/docs/api_reference/advanced-apis.rst
+++ b/site/source/docs/api_reference/advanced-apis.rst
@@ -51,7 +51,7 @@ Advanced File System API
 
 :ref:`Filesystem-API` covers the public API that will be relevant to most developers. The following functions are only needed for advanced use-cases (for example, writing a new local file system) or legacy file system compatibility.
 
-.. js:function:: FS.handleFSError(e)
+.. js:function::
   FS.hashName(parentid, name)
   FS.hashAddNode(node)
   FS.hashRemoveNode(node)

--- a/src/library.js
+++ b/src/library.js
@@ -50,13 +50,20 @@ LibraryManager.library = {
   // utime.h
   // ==========================================================================
 
-  $handleFSError__deps: ['$setErrNo'],
-  $handleFSError: function(e) {
-    if (!(e instanceof FS.ErrnoError)) throw e + ' : ' + stackTrace();
-    return setErrNo(e.errno);
+  $setFileTime__deps: ['$setErrNo'],
+  $setFileTime: function(path, time) {
+    path = UTF8ToString(path);
+    try {
+      FS.utime(path, time, time);
+      return 0;
+    } catch (e) {
+      if (!(e instanceof FS.ErrnoError)) throw e + ' : ' + stackTrace();
+      setErrNo(e.errno);
+      return -1;
+    }
   },
 
-  utime__deps: ['$FS', '$handleFSError'],
+  utime__deps: ['$FS', '$setFileTime'],
   utime__proxy: 'sync',
   utime__sig: 'iii',
   utime: function(path, times) {
@@ -65,43 +72,29 @@ LibraryManager.library = {
     var time;
     if (times) {
       // NOTE: We don't keep track of access timestamps.
-      var offset = {{{ C_STRUCTS.utimbuf.modtime }}};
-      time = {{{ makeGetValue('times', 'offset', 'i32') }}};
-      time *= 1000;
+      time = {{{ makeGetValue('times', C_STRUCTS.utimbuf.modtime, 'i32') }}} * 1000;
     } else {
       time = Date.now();
     }
-    path = UTF8ToString(path);
-    try {
-      FS.utime(path, time, time);
-      return 0;
-    } catch (e) {
-      handleFSError(e);
-      return -1;
-    }
+    return setFileTime(path, time);
   },
 
-  utimes__deps: ['$FS', '$handleFSError'],
+  utimes__deps: ['$FS', '$setFileTime'],
   utimes__proxy: 'sync',
   utimes__sig: 'iii',
   utimes: function(path, times) {
+    // utimes is just like utime but take an array of 2 times: `struct timeval times[2]`
+    // times[0] is the new access time (which we currently ignore)
+    // times[1] is the new modification time.
     var time;
     if (times) {
-      var offset = {{{ C_STRUCTS.timeval.__size__ }}} + {{{ C_STRUCTS.timeval.tv_sec }}};
-      time = {{{ makeGetValue('times', 'offset', 'i32') }}} * 1000;
-      offset = {{{ C_STRUCTS.timeval.__size__ }}} + {{{ C_STRUCTS.timeval.tv_usec }}};
-      time += {{{ makeGetValue('times', 'offset', 'i32') }}} / 1000;
+      var mtime = times + {{{ C_STRUCTS.timeval.__size__ }}};
+      time = {{{ makeGetValue('mtime', C_STRUCTS.timeval.tv_sec, 'i32') }}} * 1000;
+      time += {{{ makeGetValue('mtime', C_STRUCTS.timeval.tv_usec, 'i32') }}} / 1000;
     } else {
       time = Date.now();
     }
-    path = UTF8ToString(path);
-    try {
-      FS.utime(path, time, time);
-      return 0;
-    } catch (e) {
-      handleFSError(e);
-      return -1;
-    }
+    return setFileTime(path, time);
   },
 
   // ==========================================================================


### PR DESCRIPTION
Refactor utime syscalls to share more code eliminating
the need for the free-floating handleFSError function.

See #12668