### PR TITLE
Ensure EM_CONFIG is set before config parsing

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -280,4 +280,9 @@ else:
   if not os.path.exists(config_file):
     exit_with_error('emscripten config file not found: ' + config_file)
 
+# Emscripten compiler spawns other processes, which can reimport shared.py, so
+# make sure that those child processes get the same configuration file by
+# setting it to the currently active environment.
+os.environ['EM_CONFIG'] = EM_CONFIG
+
 parse_config_file()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -970,11 +970,6 @@ def read_and_preprocess(filename, expand_macros=False):
 # file.  TODO(sbc): We should try to reduce that amount we do here and instead
 # have consumers explicitly call initialization functions.
 
-# Emscripten compiler spawns other processes, which can reimport shared.py, so
-# make sure that those child processes get the same configuration file by
-# setting it to the currently active environment.
-os.environ['EM_CONFIG'] = config.EM_CONFIG
-
 # Verbosity level control for any intermediate subprocess spawns from the compiler. Useful for internal debugging.
 # 0: disabled.
 # 1: Log stderr of subprocess spawns.


### PR DESCRIPTION
emsdk was broken by #12699 because it was assuming that
EM_CONFIG is available in the environment at the point
when the config was bring parsed.