### PR TITLE
Rebaseline test_minimal_runtime_code_size test results. NFC

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21364,
+  "a.js": 21297,
   "a.js.gz": 8265,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 25123,
+  "total": 25056,
   "total_gz": 11366
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 20852,
-  "a.js.gz": 8105,
+  "a.js": 20785,
+  "a.js.gz": 8104,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 24611,
-  "total_gz": 11206
+  "total": 24544,
+  "total_gz": 11205
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 18933,
-  "a.html.gz": 7914,
-  "total": 18933,
-  "total_gz": 7914
+  "a.html": 18857,
+  "a.html.gz": 7904,
+  "total": 18857,
+  "total_gz": 7904
 }


### PR DESCRIPTION
This captures some minor code size win from (I belive)
https://github.com/WebAssembly/binaryen/pull/3323