### PR TITLE
Initial commit to log functions in Wasm.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -632,6 +632,9 @@ def backend_binaryen_passes():
     extras = shared.Settings.BINARYEN_EXTRA_PASSES.split(',')
     passes += [('--' + p) if p[0] != '-' else p for p in extras if p]
 
+  if shared.Settings.INSTRUMENT:
+    passes += ['--log-function']
+
   return passes
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -737,6 +737,9 @@ def add_standard_wasm_imports(send_items_map):
       return value;
     }'''
 
+  if shared.Settings.INSTRUMENT:
+    send_items_map['log_function'] = '''log_function'''
+
 
 def create_sending(invoke_funcs, metadata):
   basic_funcs = []

--- a/src/settings.js
+++ b/src/settings.js
@@ -1614,6 +1614,10 @@ var ERROR_ON_WASM_CHANGES_AFTER_LINK = 0;
 // cost of a few bytes extra.
 var ABORT_ON_WASM_EXCEPTIONS = 0;
 
+// Logs all Wasm functions that are executed. The user will have to provide a log_function
+// in Javascript to choose how the functions should be logged.
+var INSTRUMENT = 0;
+
 //===========================================
 // Internal, used for testing only, from here
 //===========================================


### PR DESCRIPTION
Initial code to allow the user to log functions in Wasm. He will have to set `-s INSTRUMENT=1` and provide a Javascript  `log_function` to implement the logging. FYI @sbc100 and @tlively .