### PR TITLE
Enable WASM2JS + STANDALONE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1735,8 +1735,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         exit_with_error('STANDALONE_WASM does not support pthreads yet')
       if shared.Settings.MINIMAL_RUNTIME:
         exit_with_error('MINIMAL_RUNTIME reduces JS size, and is incompatible with STANDALONE_WASM which focuses on ignoring JS anyhow and being 100% wasm')
-      if shared.Settings.WASM2JS:
-        exit_with_error('WASM2JS is not compatible with STANDALONE_WASM output')
       # the wasm must be runnable without the JS, so there cannot be anything that
       # requires JS legalization
       shared.Settings.LEGALIZE_JS_FFI = 0

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -64,7 +64,7 @@ WebAssembly = {
     // TODO: use the module and info somehow - right now the wasm2js output is embedded in
     // the main JS
     // This will be replaced by the actual wasm2js code.
-    this.exports = Module['__wasm2jsInstantiate__'](asmLibraryArg, wasmMemory);
+    this.exports = Module['__wasm2jsInstantiate__'](asmLibraryArg);
   },
 
   instantiate: /** @suppress{checkTypes} */ function(binary, info) {

--- a/tools/maybe_wasm2js.py
+++ b/tools/maybe_wasm2js.py
@@ -43,7 +43,8 @@ cmd = [os.path.join(building.get_binaryen_bin(), 'wasm2js'), '--emscripten', was
 cmd += opts
 js = shared.run_process(cmd, stdout=subprocess.PIPE).stdout
 # assign the instantiate function to where it will be used
-# TODO:remove second case once wasm2js (binaryen) changes roll
+# TODO(sbc): From the seond patterns here that represents the output of
+# older versions of wasm2js
 if 'function instantiate(asmLibraryArg)' in js:
   js = js.replace('function instantiate(asmLibraryArg) {',
                   "Module['__wasm2jsInstantiate__'] = function(asmLibraryArg) {")


### PR DESCRIPTION
Now that wasm2js supports memories defined on the wasm side
this seems to just work.

See: https://github.com/WebAssembly/binaryen/pull/3323