### PR TITLE
Add EXTRA_WASM_IMPORTS setting

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1846,7 +1846,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         ('__indirect_function_table', 'wasmTable'),
         # the backend reserves slot 0 for the NULL function pointer
         ('__table_base', '1'),
-        ('__stack_pointer', '__stack_pointer'),
+        '__stack_pointer',
       ]
       if options.use_closure_compiler:
         exit_with_error('cannot use closure compiler on shared modules')

--- a/emcc.py
+++ b/emcc.py
@@ -1347,6 +1347,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if shared.Settings.RELOCATABLE:
       shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$reportUndefinedSymbols', '$relocateExports', '$GOTHandler']
+      shared.Settings.EXTRA_WASM_IMPORTS += [
+        # tell the memory segments where to place themselves
+        ('__memory_base', str(shared.Settings.GLOBAL_BASE)),
+        ('__indirect_function_table', 'wasmTable'),
+        # the backend reserves slot 0 for the NULL function pointer
+        ('__table_base', '1'),
+        ('__stack_pointer', '__stack_pointer'),
+      ]
       if options.use_closure_compiler:
         exit_with_error('cannot use closure compiler on shared modules')
       if shared.Settings.MINIMAL_RUNTIME:

--- a/emcc.py
+++ b/emcc.py
@@ -1300,10 +1300,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.IGNORE_MISSING_MAIN = 0
       shared.Settings.DEFAULT_TO_CXX = 0
 
-    # If set to 1, we will run the autodebugger (the automatic debugging tool, see
-    # tools/autodebugger).  Note that this will disable inclusion of libraries. This
-    # is useful because including dlmalloc makes it hard to compare native and js
-    # builds
     if os.environ.get('EMCC_AUTODEBUG'):
       shared.Settings.AUTODEBUG = 1
 

--- a/emcc.py
+++ b/emcc.py
@@ -1345,26 +1345,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         shared.Settings.EXPORT_ALL = 1
       shared.Settings.RELOCATABLE = 1
 
-    if shared.Settings.RELOCATABLE:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$reportUndefinedSymbols', '$relocateExports', '$GOTHandler']
-      shared.Settings.EXTRA_WASM_IMPORTS += [
-        # tell the memory segments where to place themselves
-        ('__memory_base', str(shared.Settings.GLOBAL_BASE)),
-        ('__indirect_function_table', 'wasmTable'),
-        # the backend reserves slot 0 for the NULL function pointer
-        ('__table_base', '1'),
-        ('__stack_pointer', '__stack_pointer'),
-      ]
-      if options.use_closure_compiler:
-        exit_with_error('cannot use closure compiler on shared modules')
-      if shared.Settings.MINIMAL_RUNTIME:
-        exit_with_error('MINIMAL_RUNTIME is not compatible with relocatable output')
-      if shared.Settings.WASM2JS:
-        exit_with_error('WASM2JS is not compatible with relocatable output')
-      # shared modules need memory utilities to allocate their memory
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['allocate']
-      shared.Settings.ALLOW_TABLE_GROWTH = 1
-
     # various settings require sbrk() access
     if shared.Settings.DETERMINISTIC or \
        shared.Settings.EMSCRIPTEN_TRACING or \
@@ -1857,6 +1837,26 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # a higher global base is useful for optimizing load/store offsets, as it
       # enables the --post-emscripten pass
       shared.Settings.GLOBAL_BASE = 1024
+
+    if shared.Settings.RELOCATABLE:
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$reportUndefinedSymbols', '$relocateExports', '$GOTHandler']
+      shared.Settings.EXTRA_WASM_IMPORTS += [
+        # tell the memory segments where to place themselves
+        ('__memory_base', str(shared.Settings.GLOBAL_BASE)),
+        ('__indirect_function_table', 'wasmTable'),
+        # the backend reserves slot 0 for the NULL function pointer
+        ('__table_base', '1'),
+        ('__stack_pointer', '__stack_pointer'),
+      ]
+      if options.use_closure_compiler:
+        exit_with_error('cannot use closure compiler on shared modules')
+      if shared.Settings.MINIMAL_RUNTIME:
+        exit_with_error('MINIMAL_RUNTIME is not compatible with relocatable output')
+      if shared.Settings.WASM2JS:
+        exit_with_error('WASM2JS is not compatible with relocatable output')
+      # shared modules need memory utilities to allocate their memory
+      shared.Settings.EXPORTED_RUNTIME_METHODS += ['allocate']
+      shared.Settings.ALLOW_TABLE_GROWTH = 1
 
     # various settings require malloc/free support from JS
     if shared.Settings.RELOCATABLE or \

--- a/emscripten.py
+++ b/emscripten.py
@@ -182,6 +182,7 @@ def apply_forwarded_data(forwarded_data):
   StaticCodeHooks.atinits = str(forwarded_json['ATINITS'])
   StaticCodeHooks.atmains = str(forwarded_json['ATMAINS'])
   StaticCodeHooks.atexits = str(forwarded_json['ATEXITS'])
+  # new imports may have been noticed by the JS compiler
   shared.Settings.EXTRA_WASM_IMPORTS = forwarded_json['EXTRA_WASM_IMPORTS']
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -549,28 +549,16 @@ def add_standard_wasm_imports(send_items_map):
       memory_import += " || Module['wasmMemory']"
     send_items_map['memory'] = memory_import
 
-  # With the wasm backend __memory_base and __table_base are only needed for
-  # relocatable output.
-  if shared.Settings.RELOCATABLE:
-    # tell the memory segments where to place themselves
-    send_items_map['__memory_base'] = str(shared.Settings.GLOBAL_BASE)
-    send_items_map['__indirect_function_table'] = 'wasmTable'
-
-    # the wasm backend reserves slot 0 for the NULL function pointer
-    send_items_map['__table_base'] = '1'
-  if shared.Settings.RELOCATABLE:
-    send_items_map['__stack_pointer'] = "__stack_pointer"
-
   if shared.Settings.MAYBE_WASM2JS or shared.Settings.AUTODEBUG or shared.Settings.LINKABLE:
     # legalization of i64 support code may require these in some modes
     send_items_map['setTempRet0'] = 'setTempRet0'
     send_items_map['getTempRet0'] = 'getTempRet0'
 
   for item in shared.Settings.EXTRA_WASM_IMPORTS:
-    if type(item) is list:
-      key, value = item
-    else:
+    if type(item) is str:
       key = value = item
+    else:
+      key, value = item
     send_items_map[key] = value
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -182,6 +182,7 @@ def apply_forwarded_data(forwarded_data):
   StaticCodeHooks.atinits = str(forwarded_json['ATINITS'])
   StaticCodeHooks.atmains = str(forwarded_json['ATMAINS'])
   StaticCodeHooks.atexits = str(forwarded_json['ATEXITS'])
+  shared.Settings.EXTRA_WASM_IMPORTS = forwarded_json['EXTRA_WASM_IMPORTS']
 
 
 def compile_settings(temp_files):
@@ -564,102 +565,12 @@ def add_standard_wasm_imports(send_items_map):
     send_items_map['setTempRet0'] = 'setTempRet0'
     send_items_map['getTempRet0'] = 'getTempRet0'
 
-  if shared.Settings.AUTODEBUG:
-    send_items_map['log_execution'] = '''function(loc) {
-      console.log('log_execution ' + loc);
-    }'''
-    send_items_map['get_i32'] = '''function(loc, index, value) {
-      console.log('get_i32 ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['get_i64'] = '''function(loc, index, low, high) {
-      console.log('get_i64 ' + [loc, index, low, high]);
-      setTempRet0(high);
-      return low;
-    }'''
-    send_items_map['get_f32'] = '''function(loc, index, value) {
-      console.log('get_f32 ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['get_f64'] = '''function(loc, index, value) {
-      console.log('get_f64 ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['get_anyref'] = '''function(loc, index, value) {
-      console.log('get_anyref ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['get_exnref'] = '''function(loc, index, value) {
-      console.log('get_exnref ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['set_i32'] = '''function(loc, index, value) {
-      console.log('set_i32 ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['set_i64'] = '''function(loc, index, low, high) {
-      console.log('set_i64 ' + [loc, index, low, high]);
-      setTempRet0(high);
-      return low;
-    }'''
-    send_items_map['set_f32'] = '''function(loc, index, value) {
-      console.log('set_f32 ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['set_f64'] = '''function(loc, index, value) {
-      console.log('set_f64 ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['set_anyref'] = '''function(loc, index, value) {
-      console.log('set_anyref ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['set_exnref'] = '''function(loc, index, value) {
-      console.log('set_exnref ' + [loc, index, value]);
-      return value;
-    }'''
-    send_items_map['load_ptr'] = '''function(loc, bytes, offset, ptr) {
-      console.log('load_ptr ' + [loc, bytes, offset, ptr]);
-      return ptr;
-    }'''
-    send_items_map['load_val_i32'] = '''function(loc, value) {
-      console.log('load_val_i32 ' + [loc, value]);
-      return value;
-    }'''
-    send_items_map['load_val_i64'] = '''function(loc, low, high) {
-      console.log('load_val_i64 ' + [loc, low, high]);
-      setTempRet0(high);
-      return low;
-    }'''
-    send_items_map['load_val_f32'] = '''function(loc, value) {
-      console.log('load_val_f32 ' + [loc, value]);
-      return value;
-    }'''
-    send_items_map['load_val_f64'] = '''function(loc, value) {
-      console.log('load_val_f64 ' + [loc, value]);
-      return value;
-    }'''
-    send_items_map['store_ptr'] = '''function(loc, bytes, offset, ptr) {
-      console.log('store_ptr ' + [loc, bytes, offset, ptr]);
-      return ptr;
-    }'''
-    send_items_map['store_val_i32'] = '''function(loc, value) {
-      console.log('store_val_i32 ' + [loc, value]);
-      return value;
-    }'''
-    send_items_map['store_val_i64'] = '''function(loc, low, high) {
-      console.log('store_val_i64 ' + [loc, low, high]);
-      setTempRet0(high);
-      return low;
-    }'''
-    send_items_map['store_val_f32'] = '''function(loc, value) {
-      console.log('store_val_f32 ' + [loc, value]);
-      return value;
-    }'''
-    send_items_map['store_val_f64'] = '''function(loc, value) {
-      console.log('store_val_f64 ' + [loc, value]);
-      return value;
-    }'''
+  for item in shared.Settings.EXTRA_WASM_IMPORTS:
+    if type(item) is list:
+      key, value = item
+    else:
+      key = value = item
+    send_items_map[key] = value
 
 
 def create_sending(invoke_funcs, metadata):

--- a/src/autodebug.js
+++ b/src/autodebug.js
@@ -101,7 +101,7 @@ function store_val_f64(loc, value) {
 }
 
 {{{
-EXTRA_WASM_IMPORTS.push([
+EXTRA_WASM_IMPORTS.push(
   'log_execution',
   'get_i32',
   'get_i64',
@@ -125,5 +125,5 @@ EXTRA_WASM_IMPORTS.push([
   'store_val_i64',
   'store_val_f32',
   'store_val_f64'
-]);
+);
 }}}

--- a/src/autodebug.js
+++ b/src/autodebug.js
@@ -1,0 +1,129 @@
+/**
+ * @license
+ * Copyright 2020 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+function log_execution(loc) {
+  console.log('log_execution ' + loc);
+}
+function get_i32(loc, index, value) {
+  console.log('get_i32 ' + [loc, index, value]);
+  return value;
+}
+function get_i64(loc, index, low, high) {
+  console.log('get_i64 ' + [loc, index, low, high]);
+  setTempRet0(high);
+  return low;
+}
+function get_f32(loc, index, value) {
+  console.log('get_f32 ' + [loc, index, value]);
+  return value;
+}
+function get_f64(loc, index, value) {
+  console.log('get_f64 ' + [loc, index, value]);
+  return value;
+}
+function get_anyref(loc, index, value) {
+  console.log('get_anyref ' + [loc, index, value]);
+  return value;
+}
+function get_exnref(loc, index, value) {
+  console.log('get_exnref ' + [loc, index, value]);
+  return value;
+}
+function set_i32(loc, index, value) {
+  console.log('set_i32 ' + [loc, index, value]);
+  return value;
+}
+function set_i64(loc, index, low, high) {
+  console.log('set_i64 ' + [loc, index, low, high]);
+  setTempRet0(high);
+  return low;
+}
+function set_f32(loc, index, value) {
+  console.log('set_f32 ' + [loc, index, value]);
+  return value;
+}
+function set_f64(loc, index, value) {
+  console.log('set_f64 ' + [loc, index, value]);
+  return value;
+}
+function set_anyref(loc, index, value) {
+  console.log('set_anyref ' + [loc, index, value]);
+  return value;
+}
+function set_exnref(loc, index, value) {
+  console.log('set_exnref ' + [loc, index, value]);
+  return value;
+}
+function load_ptr(loc, bytes, offset, ptr) {
+  console.log('load_ptr ' + [loc, bytes, offset, ptr]);
+  return ptr;
+}
+function load_val_i32(loc, value) {
+  console.log('load_val_i32 ' + [loc, value]);
+  return value;
+}
+function load_val_i64(loc, low, high) {
+  console.log('load_val_i64 ' + [loc, low, high]);
+  setTempRet0(high);
+  return low;
+}
+function load_val_f32(loc, value) {
+  console.log('load_val_f32 ' + [loc, value]);
+  return value;
+}
+function load_val_f64(loc, value) {
+  console.log('load_val_f64 ' + [loc, value]);
+  return value;
+}
+function store_ptr(loc, bytes, offset, ptr) {
+  console.log('store_ptr ' + [loc, bytes, offset, ptr]);
+  return ptr;
+}
+function store_val_i32(loc, value) {
+  console.log('store_val_i32 ' + [loc, value]);
+  return value;
+}
+function store_val_i64(loc, low, high) {
+  console.log('store_val_i64 ' + [loc, low, high]);
+  setTempRet0(high);
+  return low;
+}
+function store_val_f32(loc, value) {
+  console.log('store_val_f32 ' + [loc, value]);
+  return value;
+}
+function store_val_f64(loc, value) {
+  console.log('store_val_f64 ' + [loc, value]);
+  return value;
+}
+
+{{{
+EXTRA_WASM_IMPORTS.push([
+  'log_execution',
+  'get_i32',
+  'get_i64',
+  'get_f32',
+  'get_f64',
+  'get_anyref',
+  'get_exnref',
+  'set_i32',
+  'set_i64',
+  'set_f32',
+  'set_f64',
+  'set_anyref',
+  'set_exnref',
+  'load_ptr',
+  'load_val_i32',
+  'load_val_i64',
+  'load_val_f32',
+  'load_val_f64',
+  'store_ptr',
+  'store_val_i32',
+  'store_val_i64',
+  'store_val_f32',
+  'store_val_f64'
+]);
+}}}

--- a/src/modules.js
+++ b/src/modules.js
@@ -516,6 +516,7 @@ var PassManager = {
       ATINITS: ATINITS.join('\n'),
       ATMAINS: ATMAINS.join('\n'),
       ATEXITS: ATEXITS.join('\n'),
+      EXTRA_WASM_IMPORTS: EXTRA_WASM_IMPORTS,
     }));
   },
   load: function(json) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1095,4 +1095,8 @@ function createWasm() {
 var tempDouble;
 var tempI64;
 
+#if AUTODEBUG
+#include "autodebug.js"
+#endif
+
 // === Body ===

--- a/src/settings.js
+++ b/src/settings.js
@@ -1630,6 +1630,12 @@ var ABORT_ON_WASM_EXCEPTIONS = 0;
 // Implies STANDALONE_WASM.
 var PURE_WASI = 0;
 
+// Extra items to provide as imports to the wasm. This is a list of items, each
+// of which can be a string X, in which case we import the global JavaScript
+// name X as "X", or a pair [KEY, VALUE], in which case we import the name
+// VALUE as "KEY".
+var EXTRA_WASM_IMPORTS = [];
+
 //===========================================
 // Internal, used for testing only, from here
 //===========================================


### PR DESCRIPTION
This is an easy way to add something that the JS will send to the wasm as an
import.

Normally this is not needed, as we see the wasm and generate imports for it
automatically. However, if new imports are added to the wasm after the JS compiler
runs (at which time it sees the current imports), then an additional mechanism
is needed.

This new setting can be used to replace some of our existing additional
exports. I did that for autodebug (where it also allows a nice refactor to a
JS file) and relocatable. However, other things may not be easily refactored
as I didn't see an immediately obvious way that would be cleaner than it
is now.

This new setting can also be used by users, allowing custom imports to
be added, see discussion in https://github.com/emscripten-core/emscripten/pull/12764#issuecomment-726361753