### PR TITLE
Adding Big Endian support

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -522,3 +522,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Sam Gao <gaoshan274@gmail.com>
 * Sebastian Mayr <me@sam.st>
 * Vladimir Gamalyan <vladimir.gamalyan@gmail.com>
+* Milad Fa <mfarazma@redhat.com>

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -268,13 +268,13 @@ var HEAP,
 
 function updateGlobalBufferAndViews(buf) {
   // Using Data Views to force little-endian ordering on all architectures.
-  function _generateProxyObj(byteCount, getter, setter) {
+  function _generateProxyObj(viewObj, byteCount, getter, setter) {
     return {
       get: function (target, key) {
-        return new DataView(target.buffer)[getter](byteCount * (key), true);
-      },
+        return viewObj[getter](byteCount * (key), true);
+      }, 
       set: function (target, key, value) {
-        new DataView(target.buffer)[setter](byteCount * (key), value, true);
+        return viewObj[setter](byteCount * (key), value, true);
       }
     }
   }
@@ -289,12 +289,19 @@ function updateGlobalBufferAndViews(buf) {
   var _HEAPF32 = new Float32Array(buf);
   var _HEAPF64 = new Float64Array(buf);
 
-  Module['HEAP16'] = HEAP16 = new Proxy(_HEAP16, _generateProxyObj(2, 'getInt16', 'setInt16'));
-  Module['HEAP32'] = HEAP32 = new Proxy(_HEAP32, _generateProxyObj(4, 'getInt32', 'setInt32'));
-  Module['HEAPU16'] = HEAPU16 = new Proxy(_HEAPU16, _generateProxyObj(2, 'getUint16', 'setUint16'));
-  Module['HEAPU32'] = HEAPU32 = new Proxy(_HEAPU32, _generateProxyObj(4, 'getUint32', 'setUint32'));
-  Module['HEAPF32'] = HEAPF32 = new Proxy(_HEAPF32, _generateProxyObj(4, 'getFloat32', 'setFloat32'));
-  Module['HEAPF64'] = HEAPF64 = new Proxy(_HEAPF64, _generateProxyObj(8, 'getFloat64', 'setFloat64'));
+  var _HEAP16View = new DataView(_HEAP16.buffer);
+  var _HEAP32View = new DataView(_HEAP32.buffer);
+  var _HEAPU16View = new DataView(_HEAPU16.buffer);
+  var _HEAPU32View = new DataView(_HEAPU32.buffer);
+  var _HEAPF32View = new DataView(_HEAPF32.buffer);
+  var _HEAPF64View = new DataView(_HEAPF64.buffer);
+
+  Module['HEAP16'] = HEAP16 = new Proxy(_HEAP16, _generateProxyObj(_HEAP16View, 2, 'getInt16', 'setInt16'));
+  Module['HEAP32'] = HEAP32 = new Proxy(_HEAP32, _generateProxyObj(_HEAP32View, 4, 'getInt32', 'setInt32'));
+  Module['HEAPU16'] = HEAPU16 = new Proxy(_HEAPU16, _generateProxyObj(_HEAPU16View, 2, 'getUint16', 'setUint16'));
+  Module['HEAPU32'] = HEAPU32 = new Proxy(_HEAPU32, _generateProxyObj(_HEAPU32View, 4, 'getUint32', 'setUint32'));
+  Module['HEAPF32'] = HEAPF32 = new Proxy(_HEAPF32, _generateProxyObj(_HEAPF32View, 4, 'getFloat32', 'setFloat32'));
+  Module['HEAPF64'] = HEAPF64 = new Proxy(_HEAPF64, _generateProxyObj(_HEAPF64View, 8, 'getFloat64', 'setFloat64'));
 }
 
 #if RELOCATABLE

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -267,14 +267,27 @@ var HEAP,
   HEAPF64;
 
 function updateGlobalBufferAndViews(buf) {
-  // Using Data Views to force little-endian ordering on all architectures.
-  function _generateProxyObj(viewObj, byteCount, getter, setter) {
+  function _withinBounds(bufferByteLength, byteCount, index){
+     var indexCount = bufferByteLength / byteCount;
+     if (index < 0 || index >= indexCount){
+        return false;
+     }
+     return true;
+  }
+  function _generateProxyObj(buffer, viewObj, byteCount, getter, setter) {
     return {
-      get: function (target, key) {
-        return viewObj[getter](byteCount * (key), true);
-      }, 
-      set: function (target, key, value) {
-        viewObj[setter](byteCount * (key), value, true);
+      get: function (target, index) {
+        if (isNaN(index)) return target[index];
+        if (!_withinBounds(buffer.byteLength, byteCount, index)){
+           return undefined;
+        }
+        return viewObj[getter](byteCount * index, true);
+      },
+      set: function (target, index, value) {
+        if (!_withinBounds(buffer.byteLength, byteCount, index)){
+           return false;
+        }
+        viewObj[setter](byteCount * index, value, true);
         return true;
       }
     }
@@ -290,19 +303,15 @@ function updateGlobalBufferAndViews(buf) {
   var _HEAPF32 = new Float32Array(buf);
   var _HEAPF64 = new Float64Array(buf);
 
-  var _HEAP16View = new DataView(_HEAP16.buffer);
-  var _HEAP32View = new DataView(_HEAP32.buffer);
-  var _HEAPU16View = new DataView(_HEAPU16.buffer);
-  var _HEAPU32View = new DataView(_HEAPU32.buffer);
-  var _HEAPF32View = new DataView(_HEAPF32.buffer);
-  var _HEAPF64View = new DataView(_HEAPF64.buffer);
+  // Using Data Views to force little-endian ordering on all architectures.
+  var HEAPDataView = new DataView(buf);
 
-  Module['HEAP16'] = HEAP16 = new Proxy(_HEAP16, _generateProxyObj(_HEAP16View, 2, 'getInt16', 'setInt16'));
-  Module['HEAP32'] = HEAP32 = new Proxy(_HEAP32, _generateProxyObj(_HEAP32View, 4, 'getInt32', 'setInt32'));
-  Module['HEAPU16'] = HEAPU16 = new Proxy(_HEAPU16, _generateProxyObj(_HEAPU16View, 2, 'getUint16', 'setUint16'));
-  Module['HEAPU32'] = HEAPU32 = new Proxy(_HEAPU32, _generateProxyObj(_HEAPU32View, 4, 'getUint32', 'setUint32'));
-  Module['HEAPF32'] = HEAPF32 = new Proxy(_HEAPF32, _generateProxyObj(_HEAPF32View, 4, 'getFloat32', 'setFloat32'));
-  Module['HEAPF64'] = HEAPF64 = new Proxy(_HEAPF64, _generateProxyObj(_HEAPF64View, 8, 'getFloat64', 'setFloat64'));
+  Module['HEAP16'] = HEAP16 = new Proxy(_HEAP16, _generateProxyObj(buf, HEAPDataView, _HEAP16.BYTES_PER_ELEMENT, 'getInt16', 'setInt16'));
+  Module['HEAP32'] = HEAP32 = new Proxy(_HEAP32, _generateProxyObj(buf, HEAPDataView, _HEAP32.BYTES_PER_ELEMENT, 'getInt32', 'setInt32'));
+  Module['HEAPU16'] = HEAPU16 = new Proxy(_HEAPU16, _generateProxyObj(buf, HEAPDataView, _HEAPU16.BYTES_PER_ELEMENT, 'getUint16', 'setUint16'));
+  Module['HEAPU32'] = HEAPU32 = new Proxy(_HEAPU32, _generateProxyObj(buf, HEAPDataView, _HEAPU32.BYTES_PER_ELEMENT, 'getUint32', 'setUint32'));
+  Module['HEAPF32'] = HEAPF32 = new Proxy(_HEAPF32, _generateProxyObj(buf, HEAPDataView, _HEAPF32.BYTES_PER_ELEMENT, 'getFloat32', 'setFloat32'));
+  Module['HEAPF64'] = HEAPF64 = new Proxy(_HEAPF64, _generateProxyObj(buf, HEAPDataView, _HEAPF64.BYTES_PER_ELEMENT, 'getFloat64', 'setFloat64'));
 }
 
 #if RELOCATABLE

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -274,7 +274,8 @@ function updateGlobalBufferAndViews(buf) {
         return viewObj[getter](byteCount * (key), true);
       }, 
       set: function (target, key, value) {
-        return viewObj[setter](byteCount * (key), value, true);
+        viewObj[setter](byteCount * (key), value, true);
+        return true;
       }
     }
   }

--- a/src/runtime_assertions.js
+++ b/src/runtime_assertions.js
@@ -5,14 +5,6 @@
  */
 
 #if ASSERTIONS
-// Endianness check (note: assumes compiler arch was little-endian)
-(function() {
-  var h16 = new Int16Array(1);
-  var h8 = new Int8Array(h16.buffer);
-  h16[0] = 0x6373;
-  if (h8[0] !== 0x73 || h8[1] !== 0x63) throw 'Runtime error: expected the system to be little-endian!';
-})();
-
 function abortFnPtrError(ptr, sig) {
 #if ASSERTIONS >= 2
 	var possibleSig = '';


### PR DESCRIPTION
This PR modifies the getter/setters of the global HEAP objects. It adds a Proxy to the `multi byte` arrays as an intercepter and forces Little Endian ordering when reading/writing to the buffer by using `Data Views`. We force little endian as WASM itself  is LE enforced on all architectures.