### PR TITLE
Check full JS output for hello world

### DIFF
--- a/tests/code_size/hello_world_wasm.js
+++ b/tests/code_size/hello_world_wasm.js
@@ -1,0 +1,27 @@
+var d = Module;
+
+var e = new TextDecoder("utf8");
+
+function f(a) {
+    if (!a) return "";
+    for (var b = a + NaN, c = a; !(c >= b) && g[c]; ) ++c;
+    return e.decode(g.subarray(a, c));
+}
+
+var g, h, k;
+
+WebAssembly.instantiate(d.wasm, {
+    a: {
+        a: function(a) {
+            console.log(f(a));
+        }
+    }
+}).then((function(a) {
+    a = a.instance.exports;
+    k = a.e;
+    h = a.b;
+    var b = h.buffer;
+    g = new Uint8Array(b);
+    a.d();
+    k();
+}));

--- a/tests/code_size/hello_world_wasm2js.js
+++ b/tests/code_size/hello_world_wasm2js.js
@@ -1,0 +1,79 @@
+var b = Module;
+
+var c = new TextDecoder("utf8");
+
+function e(a) {
+    if (!a) return "";
+    for (var m = a + NaN, d = a; !(d >= m) && f[d]; ) ++d;
+    return c.decode(f.subarray(a, d));
+}
+
+var f, g;
+
+g = new function(a) {
+    this.buffer = new ArrayBuffer(65536 * a.initial);
+}({
+    initial: 256,
+    maximum: 256
+});
+
+var h = g.buffer;
+
+f = new Uint8Array(h);
+
+var k = {
+    a: function(a) {
+        console.log(e(a));
+    },
+    memory: g
+}, l, n = (new function() {
+    this.exports = function instantiate(t) {
+        function r(u) {
+            u.set = function(v, w) {
+                this[v] = w;
+            };
+            u.get = function(v) {
+                return this[v];
+            };
+            return u;
+        }
+        function s(x) {
+            var a = Math.imul;
+            var b = Math.fround;
+            var c = Math.abs;
+            var d = Math.clz32;
+            var e = Math.min;
+            var f = Math.max;
+            var g = Math.floor;
+            var h = Math.ceil;
+            var i = Math.trunc;
+            var j = Math.sqrt;
+            var k = x.abort;
+            var l = NaN;
+            var m = Infinity;
+            var n = x.a;
+            function q(a, b) {
+                a = a | 0;
+                b = b | 0;
+                n(1024);
+                return 0;
+            }
+            function p() {}
+            var o = r([]);
+            return {
+                b: o,
+                c: p,
+                d: q
+            };
+        }
+        return s(t);
+    }(k);
+}).exports;
+
+l = n.d;
+
+f.set(new Uint8Array(b.mem), 1024);
+
+n.c();
+
+l();

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8189,8 +8189,8 @@ int main () {
   @no_windows("Code size is slightly different on Windows")
   @no_mac("Code size is slightly different on Mac")
   @parameterized({
-    'hello_world_wasm': ('hello_world', False),
-    'hello_world_wasm2js': ('hello_world', True),
+    'hello_world_wasm': ('hello_world', False, True),
+    'hello_world_wasm2js': ('hello_world', True, True),
     'random_printf_wasm': ('random_printf', False),
     'random_printf_wasm2js': ('random_printf', True),
     'hello_webgl_wasm': ('hello_webgl', False),
@@ -8198,7 +8198,7 @@ int main () {
     'hello_webgl2_wasm': ('hello_webgl2', False),
     'hello_webgl2_wasm2js': ('hello_webgl2', True),
   })
-  def test_minimal_runtime_code_size(self, test_name, js):
+  def test_minimal_runtime_code_size(self, test_name, js, compare_js_output=False):
     smallest_code_size_args = ['-s', 'MINIMAL_RUNTIME=2',
                                '-s', 'ENVIRONMENT=web',
                                '-s', 'TEXTDECODER=2',
@@ -8285,6 +8285,21 @@ int main () {
       size = os.path.getsize(f_gz)
       try_delete(f_gz)
       return size
+
+    # For certain tests, don't just check the output size but check
+    # the full JS output matches the expectations.  That means that
+    # any change that touches those core lines of output will need
+    # to rebaseline this test.  However:
+    # a) such changes deserve extra scrutiny
+    # b) such changes should be few and far between
+    # c) rebaselining is trivial (just run with EMTEST_REBASELINE=1)
+    # Note that we do not compare the full wasm output since that is
+    # even more fragile and can change with LLVM updates.
+    if compare_js_output:
+      js_out = path_from_root('tests', 'code_size', test_name + '.js')
+      terser = shared.get_npm_cmd('terser')
+      self.run_process(terser + ['-b', 'beautify=true', 'a.js', '-o', 'pretty.js'])
+      self.assertFileContents(js_out, open('pretty.js').read())
 
     obtained_results = {}
     total_output_size = 0


### PR DESCRIPTION
For the smallest hello world test, don't just check the output size
but check the full JS output matches the expectations.
That means that any change that touches those core lines of output
will need to rebaseline this test.  However:

a) such changes deserve extra scrutiny
b) such changes should be few and far between
c) rebaselining is trivial (just run with EMTEST_REBASELINE=1)

Note that we do not compare the full wasm output since that is even
more fragile and can change with LLVM updates.