### PR TITLE
Remove some old runtime stubs

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -743,19 +743,12 @@ LibraryManager.library = {
 #endif
 
   // ==========================================================================
-  // GCC/LLVM specifics
+  // assert.h
   // ==========================================================================
-  __builtin_prefetch: function(){},
 
   __assert_fail__sig: 'viiii',
   __assert_fail: function(condition, filename, line, func) {
     abort('Assertion failed: ' + UTF8ToString(condition) + ', at: ' + [filename ? UTF8ToString(filename) : 'unknown filename', line, func ? UTF8ToString(func) : 'unknown function']);
-  },
-
-  __gxx_personality_v0: function() {
-  },
-
-  __gcc_personality_v0: function() {
   },
 
   // ==========================================================================


### PR DESCRIPTION
__builtin_prefetch is handled by clang/llvm.

__gxx_personality_v0/__gxx_personality_v0 are defined in
cxa_personality.cpp when building with wasm exceptions and
don't seem to be needed at all with emscripten-style
exceptions.