### PR TITLE
Check whether scriptDir is defined.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -524,3 +524,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Vladimir Gamalyan <vladimir.gamalyan@gmail.com>
 * Jean-Sébastien Nadeau <mundusnine@gmail.com> (copyright owned by Foundry Interactive Inc.)
 * Wouter van Oortmerssen <wvo@google.com> (copyright owned by Google, LLC)
+* Ann Yuan <annyuan@google.com> (copyright owned by Google, LLC)

--- a/src/shell.js
+++ b/src/shell.js
@@ -296,7 +296,7 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
 #if MODULARIZE
   // When MODULARIZE, this JS may be executed later, after document.currentScript
   // is gone, so we saved it, and we use it here instead of any other info.
-  if (_scriptDir) {
+  if (typeof _scriptDir !== 'undefined') {
     scriptDirectory = _scriptDir;
   }
 #endif


### PR DESCRIPTION
Adding the type check avoids triggering a ReferenceError if _scriptDir has not been defined.