### PR TITLE
Move pthread TLS state native code using wasm globals

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1577,9 +1577,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # manually export them
 
       shared.Settings.EXPORTED_FUNCTIONS += [
+        '__emscripten_thread_init',
         '_emscripten_get_global_libc',
         '___pthread_tsd_run_dtors',
-        'registerPthreadPtr', '_pthread_self',
+        '_pthread_self',
         '___emscripten_pthread_data_constructor',
         '_emscripten_futex_wake',
         '_emscripten_stack_set_limits',

--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -179,6 +179,8 @@
   "emscripten_webgl_get_shader_source_utf8": ["malloc", "free"],
   "emscripten_webgl_get_parameter_utf8": ["malloc", "free"],
   "emscripten_webgl_create_context": ["malloc", "free"],
+  "emscripten_start_fetch": ["emscripten_is_main_browser_thread"],
+  "emscripten_fetch": ["emscripten_is_main_browser_thread"],
   "glMapBufferRange": ["malloc", "free"],
   "glGetString": ["malloc", "free"],
   "glGetStringi": ["malloc", "free"],

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -62,7 +62,7 @@ function initRuntime(asm) {
   Module['_emscripten_tls_init'] = _emscripten_tls_init;
   Module['HEAPU32'] = HEAPU32;
   Module['dynCall'] = dynCall;
-  Module['registerPthreadPtr'] = registerPthreadPtr;
+  Module['__emscripten_thread_init'] = __emscripten_thread_init;
   Module['_pthread_self'] = _pthread_self;
 
   if (ENVIRONMENT_IS_PTHREAD) {
@@ -72,7 +72,7 @@ function initRuntime(asm) {
 
   // Pass the thread address inside the asm.js scope to store it for fast access
   // that avoids the need for a FFI out.
-  registerPthreadPtr(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
+  __emscripten_thread_init(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
   _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);
 #endif
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -155,7 +155,7 @@ this.onmessage = function(e) {
       threadInfoStruct = e.data.threadInfoStruct;
 
       // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
-      Module['registerPthreadPtr'](threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0);
+      Module['__emscripten_thread_init'](threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0);
 
       selfThreadId = e.data.selfThreadId;
       parentThreadId = e.data.parentThreadId;

--- a/system/lib/pthread/pthread_self.s
+++ b/system/lib/pthread/pthread_self.s
@@ -1,0 +1,39 @@
+.globaltype thread_id, i32
+thread_id:
+
+.globaltype is_main_thread, i32
+is_main_thread:
+
+.globaltype is_runtime_thread, i32
+is_runtime_thread:
+
+.globl pthread_self
+pthread_self:
+  .functype pthread_self () -> (i32)
+  global.get thread_id
+  end_function
+
+.globl _emscripten_thread_init
+_emscripten_thread_init:
+  .functype _emscripten_thread_init (i32, i32, i32) -> ()
+  local.get 0
+  global.set thread_id
+  local.get 1
+  global.set is_main_thread
+  local.get 2
+  global.set is_runtime_thread
+  end_function
+
+# Semantically the same as testing "!ENVIRONMENT_IS_PTHREAD" in JS
+.globl emscripten_is_main_runtime_thread
+emscripten_is_main_runtime_thread:
+  .functype emscripten_is_main_runtime_thread () -> (i32)
+  global.get is_runtime_thread
+  end_function
+
+# Semantically the same as testing "!ENVIRONMENT_IS_WORKER" in JS
+.globl emscripten_is_main_browser_thread
+emscripten_is_main_browser_thread:
+  .functype emscripten_is_main_browser_thread () -> (i32)
+  global.get is_main_thread
+  end_function

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1200,6 +1200,7 @@ class libpthread(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         filenames=[
           'library_pthread.c',
           'emscripten_tls_init.c',
+          'pthread_self.s',
         ])
     else:
       files += [shared.path_from_root('system', 'lib', 'pthread', 'library_pthread_stub.c')]


### PR DESCRIPTION
This moves pthead_self and other thread state into
native code.