### PR TITLE
Move trivial pthread stubs to native code

### DIFF
--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -17,43 +17,6 @@ var LibraryPThreadStub = {
 #endif
   },
 
-  pthread_mutexattr_init: function() {},
-  pthread_mutexattr_setschedparam: function() {},
-  pthread_mutexattr_setprotocol: function() {},
-  pthread_mutexattr_settype: function() {},
-  pthread_mutexattr_destroy: function() {},
-
-  pthread_mutexattr_setpshared: function(attr, pshared) {
-    // XXX implement if/when getpshared is required
-    return 0;
-  },
-
-  pthread_cond_init: function() { return 0; },
-  pthread_cond_destroy: function() { return 0; },
-  pthread_cond_timedwait: function() { return 0; },
-
-  pthread_condattr_init: function() { return 0; },
-  pthread_condattr_destroy: function() { return 0; },
-  pthread_condattr_setclock: function() { return 0; },
-  pthread_condattr_setpshared: function() { return 0; },
-  pthread_condattr_getclock: function() { return 0; },
-  pthread_condattr_getpshared: function() { return 0; },
-
-  pthread_attr_init: function(attr) {
-    /* int pthread_attr_init(pthread_attr_t *attr); */
-    //FIXME: should allocate a pthread_attr_t
-    return 0;
-  },
-  pthread_getattr_np: function(thread, attr) {
-    /* int pthread_getattr_np(pthread_t thread, pthread_attr_t *attr); */
-    //FIXME: should fill in attributes of the given thread in pthread_attr_t
-    return 0;
-  },
-  pthread_attr_destroy: function(attr) {
-    /* int pthread_attr_destroy(pthread_attr_t *attr); */
-    //FIXME: should destroy the pthread_attr_t struct
-    return 0;
-  },
   pthread_attr_getstack: function(attr, stackaddr, stacksize) {
     /* int pthread_attr_getstack(const pthread_attr_t *restrict attr,
        void **restrict stackaddr, size_t *restrict stacksize); */
@@ -63,13 +26,6 @@ var LibraryPThreadStub = {
     {{{ makeSetValue('stacksize', '0', TOTAL_STACK, 'i32') }}};
     return 0;
   },
-  pthread_attr_getdetachstate: function(attr, detachstate) {
-    /* int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate); */
-    return 0;
-  },
-
-  pthread_setcancelstate: function() { return 0; },
-  pthread_setcanceltype: function() { return 0; },
 
   pthread_cleanup_push__sig: 'vii',
   pthread_cleanup_push: function(routine, arg) {
@@ -93,52 +49,11 @@ var LibraryPThreadStub = {
     return 0;
   },
 
-  pthread_rwlock_init: function() { return 0; },
-  pthread_rwlock_destroy: function() { return 0; },
-  pthread_rwlock_rdlock: function() { return 0; },
-  pthread_rwlock_tryrdlock: function() { return 0; },
-  pthread_rwlock_timedrdlock: function() { return 0; },
-  pthread_rwlock_wrlock: function() { return 0; },
-  pthread_rwlock_trywrlock: function() { return 0; },
-  pthread_rwlock_timedwrlock: function() { return 0; },
-  pthread_rwlock_unlock: function() { return 0; },
-
-  pthread_rwlockattr_init: function() { return 0; },
-  pthread_rwlockattr_destroy: function() { return 0; },
-  pthread_rwlockattr_setpshared: function() { return 0; },
-  pthread_rwlockattr_getpshared: function() { return 0; },
-
-  pthread_spin_init: function() { return 0; },
-  pthread_spin_destroy: function() { return 0; },
-  pthread_spin_lock: function() { return 0; },
-  pthread_spin_trylock: function() { return 0; },
-  pthread_spin_unlock: function() { return 0; },
-
-  pthread_attr_setdetachstate: function() {},
-  pthread_attr_setschedparam: function() {},
-  pthread_attr_setstacksize: function() {},
-
   {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create: function() {
     return {{{ cDefine('EAGAIN') }}};
   },
-  pthread_cancel: function() {},
-  pthread_exit__deps: ['exit'],
-  pthread_exit: function(status) {
-    _exit(status);
-  },
 
-  pthread_equal: function(x, y) { return x == y },
   {{{ USE_LSAN ? 'emscripten_builtin_' : '' }}}pthread_join: function() {},
-  pthread_detach: function() {},
-
-  sem_init: function() {},
-  sem_post: function() {},
-  sem_wait: function() {},
-  sem_trywait: function() {},
-  sem_destroy: function() {},
-
-  emscripten_main_browser_thread_id__deps: ['pthread_self'],
-  emscripten_main_browser_thread_id: function() { return _pthread_self(); },
 
   // When pthreads is not enabled, we can't use the Atomics futex api to do proper sleeps, so simulate a busy spin wait loop instead.
   usleep__deps: ['emscripten_get_now'],
@@ -171,8 +86,6 @@ var LibraryPThreadStub = {
     }
     return _usleep((seconds * 1e6) + (nanoseconds / 1000));
   },
-
-  __wait: function() {},
 };
 
 mergeInto(LibraryManager.library, LibraryPThreadStub);

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -1,5 +1,6 @@
 #include <errno.h>
 #include <pthread.h>
+#include <semaphore.h>
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -37,11 +38,9 @@ int pthread_mutex_init(
   return 0;
 }
 
-#ifndef EMSCRIPTEN_ASAN_OVERRIDE
 int pthread_mutex_lock(pthread_mutex_t* mutex) { return 0; }
 
 int pthread_mutex_unlock(pthread_mutex_t* mutex) { return 0; }
-#endif
 
 int pthread_mutex_trylock(pthread_mutex_t* mutex) { return 0; }
 
@@ -172,10 +171,203 @@ int pthread_atfork(void (*prepare)(void), void (*parent)(void), void (*child)(vo
   return 0;
 }
 
+int pthread_cancel(pthread_t thread) {
+  return 0;
+}
+
+_Noreturn void pthread_exit(void* status) {
+   exit((int)status);
+}
+
+int pthread_detach(pthread_t t) {
+  return 0;
+}
+
+int emscripten_main_browser_thread_id() {
+  return (int)pthread_self();
+}
+
 // pthread_equal is defined as a macro in C, as a function for C++; undef it
 // here so we define the function for C++ that links to us.
+#ifdef pthread_equal
 #undef pthread_equal
+#endif
 
 int pthread_equal(pthread_t t1, pthread_t t2) {
   return t1 == t2;
 }
+
+int pthread_mutexattr_init(pthread_mutexattr_t *attr) {
+  return 0;
+}
+
+int pthread_mutexattr_setprotocol(pthread_mutexattr_t *attr, int protocol) {
+  return 0;
+}
+
+int pthread_mutexattr_settype(pthread_mutexattr_t *attr, int type) {
+  return 0;
+}
+
+int pthread_mutexattr_destroy(pthread_mutexattr_t *attr) {
+  return 0;
+}
+
+int pthread_mutexattr_setpshared(pthread_mutexattr_t *attr, int pshared) {
+  // XXX implement if/when getpshared is required
+  return 0;
+}
+
+int pthread_condattr_init(pthread_condattr_t * attr) {
+  return 0;
+}
+
+int pthread_condattr_destroy(pthread_condattr_t *attr) {
+  return 0;
+}
+
+int pthread_condattr_setclock(pthread_condattr_t *attr, clockid_t clk) {
+  return 0;
+}
+
+int pthread_condattr_setpshared(pthread_condattr_t *attr, int shared) {
+  return 0;
+}
+
+int pthread_condattr_getclock(const pthread_condattr_t *attr, clockid_t* clk) {
+  return 0;
+}
+
+int pthread_condattr_getpshared(const pthread_condattr_t *attr, int *shared) {
+  return 0;
+}
+
+int pthread_attr_init(pthread_attr_t *attr) {
+  return 0;
+}
+
+int pthread_getattr_np(pthread_t thread, pthread_attr_t *attr) {
+  return 0;
+}
+
+int pthread_attr_destroy(pthread_attr_t *attr) {
+  return 0;
+}
+
+int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate) {
+  return 0;
+}
+
+int pthread_setcancelstate() {
+  return 0;
+}
+
+int pthread_setcanceltype() {
+  return 0;
+}
+
+int pthread_rwlock_init(pthread_rwlock_t* rwlock, const pthread_rwlockattr_t* attr) {
+  return 0;
+}
+
+int pthread_rwlock_destroy(pthread_rwlock_t *rwlock) {
+  return 0;
+}
+
+int pthread_rwlock_rdlock(pthread_rwlock_t *rwlock) {
+  return 0;
+}
+
+int pthread_rwlock_tryrdlock(pthread_rwlock_t* rwlock) {
+  return 0;
+}
+
+int pthread_rwlock_timedrdlock(pthread_rwlock_t* rwlock, const struct timespec* abs_timeout) {
+  return 0;
+}
+
+int pthread_rwlock_wrlock(pthread_rwlock_t *rwlock) {
+  return 0;
+}
+
+int pthread_rwlock_trywrlock(pthread_rwlock_t *rwlock) {
+  return 0;
+}
+
+int pthread_rwlock_timedwrlock(pthread_rwlock_t* rwlock, const struct timespec* abs_timeout) {
+  return 0;
+}
+
+int pthread_rwlock_unlock(pthread_rwlock_t *rwlock) {
+  return 0;
+}
+
+int pthread_rwlockattr_init(pthread_rwlockattr_t *attr) {
+  return 0;
+}
+
+int pthread_rwlockattr_destroy(pthread_rwlockattr_t *attr) {
+  return 0;
+}
+
+int pthread_rwlockattr_setpshared(pthread_rwlockattr_t* attr, int pshared) {
+  return 0;
+}
+
+int pthread_rwlockattr_getpshared(const pthread_rwlockattr_t* attr, int *pshared) {
+  return 0;
+}
+
+int pthread_spin_init(pthread_spinlock_t *lock, int pshared) {
+  return 0;
+}
+
+int pthread_spin_destroy(pthread_spinlock_t *lock) {
+  return 0;
+}
+
+int pthread_spin_lock(pthread_spinlock_t *lock) {
+  return 0;
+}
+
+int pthread_spin_trylock(pthread_spinlock_t *lock) {
+  return 0;
+}
+
+int pthread_spin_unlock(pthread_spinlock_t *lock) {
+  return 0;
+}
+
+int pthread_attr_setdetachstate(pthread_attr_t* attr, int detachstate) {
+  return 0;
+}
+
+int pthread_attr_setschedparam(pthread_attr_t* attr, const struct sched_param* param) {
+  return 0;
+}
+
+int pthread_attr_setstacksize(pthread_attr_t *attr, size_t stacksize) {
+  return 0;
+}
+
+int sem_init(sem_t *sem, int pshared, unsigned int value) {
+  return 0;
+}
+
+int sem_post(sem_t *sem) {
+  return 0;
+}
+
+int sem_wait(sem_t *sem) {
+  return 0;
+}
+
+int sem_trywait(sem_t *sem) {
+  return 0;
+}
+
+int sem_destroy(sem_t *sem) {
+  return 0;
+}
+
+void __wait(volatile int *addr, volatile int *waiters, int val, int priv) {}


### PR DESCRIPTION
This has the advantage of making binaries that use the stubs smaller and
more portable.  In many cases these function can be completely removed
by binaryen or LTO.

I will porobably followup with another PR to move all the rest.