### PR TITLE
Add simple syslog test.

### DIFF
--- a/src/deps_info.json
+++ b/src/deps_info.json
@@ -182,5 +182,5 @@
   "glMapBufferRange": ["malloc", "free"],
   "glGetString": ["malloc", "free"],
   "glGetStringi": ["malloc", "free"],
-  "syslog": ["malloc", "free"]
+  "syslog": ["malloc", "htons", "ntohs"]
 }

--- a/tests/other/test_syslog.c
+++ b/tests/other/test_syslog.c
@@ -1,0 +1,11 @@
+#include <syslog.h>
+#include <stddef.h>
+
+int main() {
+  // The current implementation of syslog that we use comes
+  // from musl and doesn't do anything useful under emscripten.
+  // This test exists simply to ensure that it compile and link.
+  syslog(LOG_CRIT, "%s", "log1");
+  openlog(NULL, LOG_CONS, LOG_USER);
+  syslog(LOG_CRIT, "%s", "log2");
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9709,3 +9709,6 @@ exec "$@"
   def test_threadprofiler_closure(self):
     # TODO: Enable '-s', 'CLOSURE_WARNINGS=error' in the following, but that has currently regressed.
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-s', 'USE_PTHREADS=1', '--closure', '1', '--threadprofiler'])
+
+  def test_syslog(self):
+    self.do_other_test('test_syslog.c')


### PR DESCRIPTION
This doesn't actaully work right now because musl's syslog
depends on all kinds of things like sockets and being
able to open "/dev/console".

So this is really just a compile and link test.

The indirect dependency on malloc comes from that fact
that it calls gmtime_r which can allocate in JS.