### PR TITLE
Move more of library_pthread_stub.js to native code.

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1108,12 +1108,6 @@ var LibraryPThread = {
     if (execute) routine();
   },
 
-  // pthread_sigmask - examine and change mask of blocked signals
-  pthread_sigmask: function(how, set, oldset) {
-    err('pthread_sigmask() is not supported: this is a no-op.');
-    return 0;
-  },
-
   pthread_atfork: function(prepare, parent, child) {
     err('fork() is not supported: pthread_atfork is a no-op.');
     return 0;

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -17,16 +17,6 @@ var LibraryPThreadStub = {
 #endif
   },
 
-  pthread_attr_getstack: function(attr, stackaddr, stacksize) {
-    /* int pthread_attr_getstack(const pthread_attr_t *restrict attr,
-       void **restrict stackaddr, size_t *restrict stacksize); */
-    /*FIXME: assumes that there is only one thread, and that attr is the
-      current thread*/
-    {{{ makeSetValue('stackaddr', '0', '_emscripten_stack_get_base()', 'i8*') }}};
-    {{{ makeSetValue('stacksize', '0', TOTAL_STACK, 'i32') }}};
-    return 0;
-  },
-
   pthread_cleanup_push__sig: 'vii',
   pthread_cleanup_push: function(routine, arg) {
     __ATEXIT__.push({ func: routine, arg: arg });
@@ -43,17 +33,13 @@ var LibraryPThreadStub = {
     _pthread_cleanup_push.level = __ATEXIT__.length;
   },
 
-  // pthread_sigmask - examine and change mask of blocked signals
-  pthread_sigmask: function(how, set, oldset) {
-    err('pthread_sigmask() is not supported: this is a no-op.');
-    return 0;
-  },
-
   {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create: function() {
     return {{{ cDefine('EAGAIN') }}};
   },
 
-  {{{ USE_LSAN ? 'emscripten_builtin_' : '' }}}pthread_join: function() {},
+  {{{ USE_LSAN ? 'emscripten_builtin_' : '' }}}pthread_join: function() {
+    return {{{ cDefine('EINVAL') }}};
+  },
 
   // When pthreads is not enabled, we can't use the Atomics futex api to do
   // proper sleeps, so simulate a busy spin wait loop instead.

--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -53,6 +53,11 @@ var funs = {
 #endif
     return 0;
   },
+  // pthread_sigmask - examine and change mask of blocked signals
+  pthread_sigmask: function(how, set, oldset) {
+    err('pthread_sigmask() is not supported: this is a no-op.');
+    return 0;
+  },
   __libc_current_sigrtmin: function() {
 #if ASSERTIONS
     err('Calling stub instead of __libc_current_sigrtmin');

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -4,6 +4,9 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "pthread_impl.h"
+#include <emscripten/stack.h>
+#include <emscripten/threading.h>
+#include <emscripten/emscripten.h>
 
 int emscripten_has_threading_support() { return 0; }
 
@@ -256,6 +259,14 @@ int pthread_attr_destroy(pthread_attr_t *attr) {
 }
 
 int pthread_attr_getdetachstate(const pthread_attr_t *attr, int *detachstate) {
+  return 0;
+}
+
+int pthread_attr_getstack(const pthread_attr_t *attr, void **stackaddr, size_t *stacksize) {
+  /*FIXME: assumes that there is only one thread, and that attr is the
+    current thread*/
+  *stackaddr = (void*)emscripten_stack_get_base();
+  *stacksize = emscripten_stack_get_base() - emscripten_stack_get_end();
   return 0;
 }
 


### PR DESCRIPTION
Move generic pthread sleep code into a common system/lib/pthread/sleep.c
which is compiled into both threaded and non-threaded builds.
    
Implement lower level emscripten_thread_sleep in library_pthread_stub.c.

Followup to #12840