### PR TITLE
Remove redundant selfThreadId and threadInfoStruct JavaScript global

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -295,10 +295,6 @@ var devicePixelRatio;
 // Variables that are present in both output runtime .js file/JS lib files, and worker.js, so cannot be minified because
 // the names need to match:
 /** @suppress {duplicate} */
-var threadInfoStruct;
-/** @suppress {duplicate} */
-var selfThreadId;
-/** @suppress {duplicate} */
 var noExitRuntime;
 
 /** @type {?AudioWorklet} */

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -47,11 +47,6 @@ var wasmMemory;
 #if USE_PTHREADS
 // For sending to workers.
 var wasmModule;
-// Only workers actually use these field, but we refer to them from
-// library_pthread (which exists on all threads) so this definition is useful
-// to avoid accessing the global scope.
-var threadInfoStruct = 0;
-var selfThreadId = 0;
 #endif // USE_PTHREADS
 
 //========================================

--- a/src/worker.js
+++ b/src/worker.js
@@ -9,8 +9,6 @@
 // that executes pthreads on the Emscripten application.
 
 // Thread-local:
-var threadInfoStruct = 0; // Info area for this thread in Emscripten HEAP (shared). If zero, this worker is not currently hosting an executing pthread.
-var selfThreadId = 0; // The ID of this thread. 0 if not hosting a pthread.
 var parentThreadId = 0; // The ID of the parent pthread that launched this thread.
 #if EMBIND
 var initializedJS = false; // Guard variable for one-time init of the JS state (currently only embind types registration)
@@ -30,7 +28,7 @@ function threadPrintErr() {
 }
 function threadAlert() {
   var text = Array.prototype.slice.call(arguments).join(' ');
-  postMessage({cmd: 'alert', text: text, threadId: selfThreadId});
+  postMessage({cmd: 'alert', text: text, threadId: Module['_pthread_self']()});
 }
 #if ASSERTIONS
 // We don't need out() for now, but may need to add it if we want to use it
@@ -152,12 +150,11 @@ this.onmessage = function(e) {
       // threads see a somewhat coherent clock across each of them
       // (+/- 0.1msecs in testing).
       Module['__performance_now_clock_drift'] = performance.now() - e.data.time;
-      threadInfoStruct = e.data.threadInfoStruct;
+      var threadInfoStruct = e.data.threadInfoStruct;
 
       // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
       Module['__emscripten_thread_init'](threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0);
 
-      selfThreadId = e.data.selfThreadId;
       parentThreadId = e.data.parentThreadId;
       // Establish the stack frame for this thread in global scope
       // The stack grows downwards
@@ -165,7 +162,6 @@ this.onmessage = function(e) {
       var top = e.data.stackBase + e.data.stackSize;
 #if ASSERTIONS
       assert(threadInfoStruct);
-      assert(selfThreadId);
       assert(parentThreadId);
       assert(top != 0);
       assert(max != 0);


### PR DESCRIPTION
These globals are duplicates of each other but also redundant in
the face of pthread_self that already stores this pointer in
wasm global.