### PR TITLE
Use musl's pthread_self.c. NFC.

### DIFF
--- a/system/lib/libc/musl/arch/emscripten/pthread_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/pthread_arch.h
@@ -1,4 +1,4 @@
-static inline struct pthread *__pthread_self(void) { return pthread_self(); }
+struct pthread *__pthread_self(void);
 
 #define TP_ADJ(p) (p)
 

--- a/system/lib/libc/musl/src/misc/emscripten_pthread.c
+++ b/system/lib/libc/musl/src/misc/emscripten_pthread.c
@@ -4,13 +4,13 @@
 
 #if !__EMSCRIPTEN_PTHREADS__
 static struct pthread __main_pthread;
-pthread_t pthread_self(void) {
+pthread_t __pthread_self(void) {
   return &__main_pthread;
 }
 
 __attribute__((constructor))
 void __emscripten_pthread_data_constructor(void) {
-  pthread_self()->locale = &libc.global_locale;
+  __pthread_self()->locale = &libc.global_locale;
 }
 #endif // !__EMSCRIPTEN_PTHREADS__
 

--- a/system/lib/pthread/emscripten_thread_state.s
+++ b/system/lib/pthread/emscripten_thread_state.s
@@ -7,9 +7,9 @@ is_main_thread:
 .globaltype is_runtime_thread, i32
 is_runtime_thread:
 
-.globl pthread_self
-pthread_self:
-  .functype pthread_self () -> (i32)
+.globl __pthread_self
+__pthread_self:
+  .functype __pthread_self () -> (i32)
   global.get thread_id
   end_function
 

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -3,6 +3,7 @@
 #include <semaphore.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include "pthread_impl.h"
 
 int emscripten_has_threading_support() { return 0; }
 
@@ -183,8 +184,8 @@ int pthread_detach(pthread_t t) {
   return 0;
 }
 
-int emscripten_main_browser_thread_id() {
-  return (int)pthread_self();
+pthread_t emscripten_main_browser_thread_id() {
+  return __pthread_self();
 }
 
 // pthread_equal is defined as a macro in C, as a function for C++; undef it

--- a/tests/other/metadce/hello_world.funcs
+++ b/tests/other/metadce/hello_world.funcs
@@ -43,7 +43,6 @@ $pop_arg
 $pop_arg_long_double
 $printf
 $printf_core
-$pthread_self
 $stackAlloc
 $stackRestore
 $stackSave

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1158,6 +1158,9 @@ class libpthread(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
 
   def get_files(self):
     files = [shared.path_from_root('system', 'lib', 'pthread', 'emscripten_atomic.c')]
+    files += files_in_path(
+        path_components=['system', 'lib', 'libc', 'musl', 'src', 'thread'],
+        filenames=['pthread_self.c'])
     if self.is_mt:
       files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'thread'],
@@ -1193,14 +1196,14 @@ class libpthread(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
           'pthread_rwlock_wrlock.c', 'pthread_condattr_init.c',
           'pthread_mutex_getprioceiling.c', 'pthread_setcanceltype.c',
           'pthread_condattr_setclock.c', 'pthread_mutex_init.c',
-          'pthread_setspecific.c', 'pthread_setcancelstate.c'
+          'pthread_setspecific.c', 'pthread_setcancelstate.c',
         ])
       files += files_in_path(
         path_components=['system', 'lib', 'pthread'],
         filenames=[
           'library_pthread.c',
           'emscripten_tls_init.c',
-          'pthread_self.s',
+          'emscripten_thread_state.s',
         ])
     else:
       files += [shared.path_from_root('system', 'lib', 'pthread', 'library_pthread_stub.c')]


### PR DESCRIPTION
This change make emscripten more like other platforms in that
the internal function  `__pthread_self` is used to implement
the public `pthread_self`.

Previously we had it kind of backwards where the low level
`__pthread_self` was calling into the higher level `pthread_self`.
