### PR TITLE
Update documented python version dependency

### DIFF
--- a/site/source/docs/building_from_source/toolchain_what_is_needed.rst
+++ b/site/source/docs/building_from_source/toolchain_what_is_needed.rst
@@ -22,9 +22,10 @@ Emscripten tools and dependencies
 
 In general a complete Emscripten environment requires the following tools. First test to see if they are already installed using the :ref:`instructions below <toolchain-test-which-dependencies-are-installed>`.
 
-  - :term:`Node.js` (0.8 or above; 0.10.17 or above to run websocket-using servers in node):
-  - :term:`Python` 2.7.12 or above, or Python 3.5 or above (Python 2.7.0 or newer may also work, but is known to have SSL related issues, https://github.com/emscripten-core/emscripten/issues/6275)
-  - :term:`Java` (1.6.0_31 or later).  Java is optional. It is required to use the :term:`Closure Compiler` (in order to minify your code).
+  - :term:`Node.js` (0.8 or above; 0.10.17 or above to run websocket-using servers in node)
+  - :term:`Python` (3.6 or above)
+    site/source/docs/building_from_source/toolchain_what_is_needed.rst
+  - :term:`Java` (1.6.0_31 or later). Java is optional. It can be used to run the java version of term:`Closure Compiler`.
   - :term:`Git` client. Git is required if building tools from source.
   - :term:`LLVM` (LLVM, including clang and wasm-ld)
   - :term:`Binaryen` (Binaryen, including wasm-opt, wasm-emscripten-finalize, etc.)

--- a/site/source/docs/getting_started/downloads.rst
+++ b/site/source/docs/getting_started/downloads.rst
@@ -103,7 +103,7 @@ macOS
 +++++
 
 If you use the Emscripten SDK it includes a bundled version of Python 3.  Otherwise
-you will need to manually install and use Python 3.5 or newer.
+you will need to manually install and use Python 3.6 or newer.
 
 These instructions explain how to install **all** the :ref:`required tools <toolchain-what-you-need>`. You can :ref:`test whether some of these are already installed <toolchain-test-which-dependencies-are-installed>` on the platform and skip those steps.
 
@@ -127,18 +127,15 @@ Linux
 
 .. note:: *Emsdk* does not install any tools to the system, or otherwise interact with Linux package managers. All file changes are done inside the **emsdk/** directory.
 
-- *Python*, *CMake*, and *Java* are not provided by *emsdk*. The user is expected to install these beforehand with the *system package manager*:
+- *Python* is not provided by *emsdk*. The user is expected to install this beforehand with the *system package manager*:
 
   ::
 
     # Install Python
     sudo apt-get install python3
 
-    # Install CMake (optional, only needed for tests and building Binaryen)
+    # Install CMake (optional, only needed for tests and building Binaryen or LLVM)
     sudo apt-get install cmake
-
-    # Install Java (optional, only needed for Closure Compiler minification)
-    sudo apt-get install default-jre
 
 .. note:: If you want to use your system's Node.js instead of the emsdk's, it may be ``node`` instead of ``nodejs``, and you can adjust the ``NODE_JS`` attribute of your ``.emscripten`` file to point to it.
 
@@ -147,7 +144,7 @@ Linux
   ::
 
     # Install git
-    sudo apt-get install git-core
+    sudo apt-get install git
 
 
 Verifying the installation


### PR DESCRIPTION
We require pythno 3.6 (for python's f-strings).

Also remove mentions Java in linux documentation since we always
use the native version of closure compiler on linux.

FIxes: #12852