### PR TITLE
Remove non-atomic musl helpers. NFC.

### DIFF
--- a/system/lib/libc/musl/arch/emscripten/atomic_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/atomic_arch.h
@@ -22,7 +22,6 @@ static inline void a_or_64(volatile uint64_t *p, uint64_t v)
 	*p |= v;
 }
 
-#ifdef __EMSCRIPTEN_PTHREADS__
 #define a_store_l a_store_l
 static inline void a_store_l(volatile void *p, long x)
 {
@@ -99,88 +98,6 @@ static inline void a_store(volatile int *p, int x)
 {
 	__c11_atomic_store((_Atomic int*)p, x, __ATOMIC_SEQ_CST);
 }
-#else // __EMSCRIPTEN_PTHREADS__
-#define a_store_l a_store_l
-static inline void a_store_l(volatile void *p, long x)
-{
-	*(long*)p = x;
-}
-
-#define a_or_l a_or_l
-static inline void a_or_l(volatile void *p, long v)
-{
-	*(long*)p |= v;
-}
-
-#define a_cas_p a_cas_p
-static inline void *a_cas_p(volatile void *p, void *t, void *s)
-{
-	if (*(long*)p == t)
-		*(long*)p = s;
-	return t;
-}
-
-#define a_cas_l a_cas_l
-static inline long a_cas_l(volatile void *p, long t, long s)
-{
-	if (*(long*)p == t)
-		*(long*)p = s;
-	return t;
-}
-
-#define a_cas a_cas
-static inline int a_cas(volatile int *p, int t, int s)
-{
-	if (*p == t)
-		*p = s;
-	return t;
-}
-
-#define a_or a_or
-static inline void a_or(volatile void *p, int v)
-{
-	*(int*)p |= v;
-}
-
-#define a_and a_and
-static inline void a_and(volatile void *p, int v)
-{
-	*(int*)p &= v;
-}
-
-#define a_inc a_inc
-static inline void a_inc(volatile int *x)
-{
-	++*x;
-}
-
-#define a_dec a_dec
-static inline void a_dec(volatile int *x)
-{
-	--*x;
-}
-
-#define a_store a_store
-static inline void a_store(volatile int *p, int x)
-{
-	*p = x;
-}
-
-#define a_swap a_swap
-static inline int a_swap(volatile int *x, int v)
-{
-	int old;
-	do old = *x;
-	while (!__sync_bool_compare_and_swap(x, old, v));
-	return old;
-}
-
-#define a_fetch_add a_fetch_add
-static inline int a_fetch_add(volatile int *x, int v)
-{
-  return __sync_fetch_and_add(x, v);
-}
-#endif
 
 #define a_spin a_spin
 static inline void a_spin()


### PR DESCRIPTION
Instead we can just rely on LLVM to lower these away when
building the single threaded version of libc.