### PR TITLE
Add my overlay to packages

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -524,3 +524,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Vladimir Gamalyan <vladimir.gamalyan@gmail.com>
 * Jean-Sébastien Nadeau <mundusnine@gmail.com> (copyright owned by Foundry Interactive Inc.)
 * Wouter van Oortmerssen <wvo@google.com> (copyright owned by Google, LLC)
+* Alexey Sokolov <sokolov@google.com> (copyright owned by Google, LLC)

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -153,3 +153,7 @@ work with downstream packagers to ensure everything works as expected.
 **Arch Linux**
  - package info: https://github.com/archlinux/svntogit-community/tree/packages/emscripten/trunk
  - maintainer: Sven-Hendrik Haase <svenstaro@gmail.com>
+
+**Gentoo Linux** (custom overlay)
+ - package info: `dev-util/emscripten` in [darthgandalf-overlay](https://github.com/DarthGandalf/gentoo-overlay)
+ - maintainer: @DarthGandalf


### PR DESCRIPTION
As requested at #12646 

There are some blockers to add it to Gentoo properly:
* Incompatibility with stable LLVM and binaryen
* Dependency on npm which we can't yet handle cleanly