### PR TITLE
Remove unused JS var from pthread_detach. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -983,7 +983,6 @@ var LibraryPThread = {
       err('pthread_detach attempted on thread ' + thread + ', which does not point to a valid thread, or does not exist anymore!');
       return ERRNO_CODES.ESRCH;
     }
-    var threadStatus = Atomics.load(HEAPU32, (thread + {{{ C_STRUCTS.pthread.threadStatus }}} ) >> 2);
     // Follow musl convention: detached:0 means not detached, 1 means the thread
     // was created as detached, and 2 means that the thread was detached via
     // pthread_detach.


### PR DESCRIPTION
Shame we don't have linters to help is catch this stuff.