### PR TITLE
Run clang with `--sysroot`. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,10 @@ Current Trunk
   `IMPORTED_MEMORY` setting can be used to revert to the old behaviour.
   Breaking change: This new setting is required if you provide a runtime
   value for `wasmMemory` or `INITIAL_MEMORY` on the Module object.
+- Internally, emscripten now uses the `--sysroot` argument to point clang at
+  it headers.  This should not effect most projects but has a minor effect the
+  order of the system include paths: The root include path
+  (`<emscritpen_root>/system/include`) is now always last in the include path.
 
 2.0.9: 11/16/2020
 -----------------

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -33,7 +33,7 @@
         }
     },
     {
-        "file": "libc/sys/stat.h",
+        "file": "sys/stat.h",
         "defines": [
             "S_IFDIR",
             "S_IFREG",
@@ -893,7 +893,7 @@
         "structs": {}
     },
     {
-        "file": "compat/sys/stat.h",
+        "file": "sys/stat.h",
         "defines": [
             "S_IALLUGO",
             "S_IWUGO",


### PR DESCRIPTION
This means we don't need to pass -nostdsysteminc and also means we can
use shorter sysroot-relative paths when specifying include directories.

This is a step toawrds a real emscripten sysroot which is alos needed
for goma integration (IIUC).

See: #9353