### PR TITLE
Unify usleep and nanosleep implementations

### DIFF
--- a/system/lib/libc/musl/src/unistd/usleep.c
+++ b/system/lib/libc/musl/src/unistd/usleep.c
@@ -1,12 +1,20 @@
 #define _GNU_SOURCE
 #include <unistd.h>
 #include <time.h>
+#ifdef __EMSCRTIPEN__
+#include <emscripten/threading.h>
+#endif
 
 int usleep(unsigned useconds)
 {
+#ifdef __EMSCRTIPEN__
+	emscripten_thread_sleep(usec / 1e3);
+	return 0;
+#else
 	struct timespec tv = {
 		.tv_sec = useconds/1000000,
 		.tv_nsec = (useconds%1000000)*1000
 	};
 	return nanosleep(&tv, &tv);
+#endif
 }

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -154,20 +154,6 @@ void emscripten_thread_sleep(double msecs) {
     EM_THREAD_STATUS_SLEEPING, EM_THREAD_STATUS_RUNNING);
 }
 
-int nanosleep(const struct timespec* req, struct timespec* rem) {
-  if (!req || req->tv_nsec < 0 || req->tv_nsec > 999999999L || req->tv_sec < 0) {
-    errno = EINVAL;
-    return -1;
-  }
-  emscripten_thread_sleep(req->tv_sec * 1000.0 + req->tv_nsec / 1e6);
-  return 0;
-}
-
-int usleep(unsigned usec) {
-  emscripten_thread_sleep(usec / 1e3);
-  return 0;
-}
-
 // Allocator and deallocator for em_queued_call objects.
 static em_queued_call* em_queued_call_malloc() {
   em_queued_call* call = (em_queued_call*)malloc(sizeof(em_queued_call));

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -688,7 +688,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         'inet_addr.c', 'res_query.c', 'res_querydomain.c', 'gai_strerror.c',
         'proto.c', 'gethostbyaddr.c', 'gethostbyaddr_r.c', 'gethostbyname.c',
         'gethostbyname2_r.c', 'gethostbyname_r.c', 'gethostbyname2.c',
-        'usleep.c', 'alarm.c', 'syscall.c', '_exit.c', 'popen.c',
+        'alarm.c', 'syscall.c', '_exit.c', 'popen.c',
         'getgrouplist.c', 'initgroups.c', 'wordexp.c', 'timer_create.c',
         'faccessat.c',
         # 'process' exclusion
@@ -734,7 +734,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
     # Allowed files from ignored modules
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'time'],
-        filenames=['clock_settime.c', 'asctime.c', 'ctime.c', 'gmtime.c', 'localtime.c'])
+        filenames=['clock_settime.c', 'asctime.c', 'ctime.c', 'gmtime.c', 'localtime.c', 'nanosleep.c'])
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'legacy'],
         filenames=['getpagesize.c', 'err.c'])
@@ -1354,7 +1354,6 @@ class libstandalonewasm(MuslInternalLibrary):
                    'gettimeofday.c',
                    'gmtime_r.c',
                    'localtime_r.c',
-                   'nanosleep.c',
                    'mktime.c',
                    'time.c'])
     # It is more efficient to use JS for __assert_fail, as it avoids always


### PR DESCRIPTION
These are now implemented in a single location in terms
of the lower level `emscripten_thread_sleep` in both
theaded and non-threaded builds.