### PR TITLE
Fix other.test_system_include_paths on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,7 +444,7 @@ jobs:
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - run-tests:
-          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake*"
+          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths"
   test-mac:
     executor: mac
     steps:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -623,9 +623,13 @@ f.close()
       end = stderr.index('End of search list.')
       includes = stderr[start:end]
       includes = [i.strip() for i in includes.splitlines()[1:]]
+      cachedir = os.path.normpath(shared.Cache.dirname)
+      llvmroot = os.path.normpath(os.path.dirname(config.LLVM_ROOT))
       for i in includes:
-        # we also alow for the cache include directory and llvm's own builtin includes
-        if shared.Cache.dirname in i or os.path.dirname(config.LLVM_ROOT) in i:
+        i = os.path.normpath(i)
+        # we also allow for the cache include directory and llvm's own builtin includes.
+        # all other include paths should be inside the sysroot.
+        if i.startswith(cachedir) or i.startswith(llvmroot):
           continue
         self.assertContained(path_from_root('system'), i)
 


### PR DESCRIPTION
Normalize paths before comparing them.