### PR TITLE
Remove minification from struct_info.json

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -878,7 +878,7 @@ def generate_struct_info():
   def generate_struct_info():
     with ToolchainProfiler.profile_block('gen_struct_info'):
       out = shared.Cache.get_path(generated_struct_info_name)
-      gen_struct_info.main(['-q', '-c', '-o', out])
+      gen_struct_info.main(['-q', '-o', out])
       return out
 
   shared.Settings.STRUCT_INFO = shared.Cache.get(generated_struct_info_name, generate_struct_info)

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -459,16 +459,13 @@ def parse_json(path, header_files, structs, defines):
       defines[part[1]] = part[0]
 
 
-def output_json(obj, compressed=True, stream=None):
+def output_json(obj, stream=None):
   if stream is None:
     stream = sys.stdout
   elif isinstance(stream, str):
     stream = open(stream, 'w')
 
-  if compressed:
-    json.dump(obj, stream, separators=(',', ':'))
-  else:
-    json.dump(obj, stream, indent=4, sort_keys=True)
+  json.dump(obj, stream, indent=4, sort_keys=True)
 
   stream.write('\n')
   stream.close()
@@ -497,8 +494,6 @@ def main(args):
                       help='Don\'t output anything besides error messages.')
   parser.add_argument('-f', dest='list_fields', action='store_true', default=False,
                       help='Output a list of structs and fields for the given headers.')
-  parser.add_argument('-c', dest='pretty_print', action='store_false', default=True,
-                      help="Compress JSON output (don't pretty print)")
   parser.add_argument('-o', dest='output', metavar='path', default=None,
                       help='Path to the JSON file that will be written. If omitted, the generated data will be printed to stdout.')
   parser.add_argument('-I', dest='includes', metavar='dir', action='append', default=[],
@@ -533,7 +528,7 @@ def main(args):
       else:
         data.append(parse_header(path, cpp_opts))
 
-    output_json(data, not args.pretty_print, args.output)
+    output_json(data, args.output)
     return 0
 
   # Look for structs in all passed headers.
@@ -554,7 +549,7 @@ def main(args):
 
   # Inspect all collected structs.
   struct_info = inspect_code(header_files, cpp_opts, structs, defines)
-  output_json(struct_info, not args.pretty_print, args.output)
+  output_json(struct_info, args.output)
   return 0
 
 


### PR DESCRIPTION
This is extra option that seems to just add complexity
and make the output file hard to read.  This file is
read only at link time and the cost of reading in
those extra spaces surly can't be significant.