### PR TITLE
Document embind library files limitations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -525,3 +525,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jean-Sébastien Nadeau <mundusnine@gmail.com> (copyright owned by Foundry Interactive Inc.)
 * Wouter van Oortmerssen <wvo@google.com> (copyright owned by Google, LLC)
 * Alexey Sokolov <sokolov@google.com> (copyright owned by Google, LLC)
+* Ivan Romanovski <ivan.romanovski@gmail.com>

--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -96,7 +96,14 @@ object.
    use whatever name you like for the module by assigning it to a new
    variable: ``var MyModuleName = Module;``.
 
+Binding libraries
+=================
 
+Binding code is run as a static constructor and static constructors only get run if the object file is included in the link, therefore when generating bindings for library files compiler must be explicitly instructed to include the object file.
+
+For example, to generate bindings for a hypothetical **library.a** compiled with Emscripten run *emcc* with ``whole-archive`` compiler flag::
+
+   emcc --bind -o library.js -Wl,--whole-archive library.a -Wl,--no-whole-archive
 
 Classes
 =======

--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -105,7 +105,7 @@ bindings for library files compiler must be explicitly instructed to include
 the object file.
 
 For example, to generate bindings for a hypothetical **library.a** compiled
-with Emscripten run *emcc* with ``whole-archive`` compiler flag::
+with Emscripten run *emcc* with ``--whole-archive`` compiler flag::
 
    emcc --bind -o library.js -Wl,--whole-archive library.a -Wl,--no-whole-archive
 

--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -99,9 +99,13 @@ object.
 Binding libraries
 =================
 
-Binding code is run as a static constructor and static constructors only get run if the object file is included in the link, therefore when generating bindings for library files compiler must be explicitly instructed to include the object file.
+Binding code is run as a static constructor and static constructors only get
+run if the object file is included in the link, therefore when generating
+bindings for library files compiler must be explicitly instructed to include
+the object file.
 
-For example, to generate bindings for a hypothetical **library.a** compiled with Emscripten run *emcc* with ``whole-archive`` compiler flag::
+For example, to generate bindings for a hypothetical **library.a** compiled
+with Emscripten run *emcc* with ``whole-archive`` compiler flag::
 
    emcc --bind -o library.js -Wl,--whole-archive library.a -Wl,--no-whole-archive
 

--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -101,7 +101,7 @@ Binding libraries
 
 Binding code is run as a static constructor and static constructors only get
 run if the object file is included in the link, therefore when generating
-bindings for library files compiler must be explicitly instructed to include
+bindings for library files the compiler must be explicitly instructed to include
 the object file.
 
 For example, to generate bindings for a hypothetical **library.a** compiled


### PR DESCRIPTION
References https://github.com/emscripten-core/emscripten/issues/11973

Embind has certain limitations regarding library (.a) files which are not immediately obvious to first time users. This updates the documentation with more information on how to successfully add bindings to library files compiled with Emscipten.

I am not an expert in C++ so I am not sure this explanation is correct and it is mostly based on explanation from @sbc100 in the response to the issue above.