### PR TITLE
Remove dead functions from src/utility.js

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -701,7 +701,7 @@ function makeCopyValues(dest, src, num, type, modifier, align, sep) {
 
 function makeHEAPView(which, start, end) {
   var size = parseInt(which.replace('U', '').replace('F', ''))/8;
-  var mod = size == 1 ? '' : ('>>' + log2(size));
+  var mod = size == 1 ? '' : ('>>' + Math.log2(size));
   return 'HEAP' + which + '.subarray((' + start + ')' + mod + ',(' + end + ')' + mod + ')';
 }
 


### PR DESCRIPTION
This should be NFC unless some external library JS file happens
to depend on these functions existing at build time.

Aside from clearly dead code this change also includes:

- Use Math.log2 rather than polyfill
- Use Array.isArray rather than polyfill
- Move 4 functions to jsifier.py