### PR TITLE
GLFW respect GLFW_NO_API flag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -527,3 +527,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Alexey Sokolov <sokolov@google.com> (copyright owned by Google, LLC)
 * Ivan Romanovski <ivan.romanovski@gmail.com>
 * Max Brunsfeld <maxbrunsfeld@gmail.com>
+* Basil Fierz <basil.fierz@hotmail.com>

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1000,7 +1000,7 @@ var LibraryGLFW = {
       for (i = 0; i < GLFW.windows.length && GLFW.windows[i] == null; i++) {
         // no-op
       }
-      var useWebGL = (GLFW.hints[0x00022001] > 0); // Use WebGL when we are told to based on GLFW_CLIENT_API
+      var useWebGL = GLFW.hints[0x00022001] > 0; // Use WebGL when we are told to based on GLFW_CLIENT_API
       if (i == GLFW.windows.length) {
         if (useWebGL) {
           var contextAttributes = {

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -1000,22 +1000,27 @@ var LibraryGLFW = {
       for (i = 0; i < GLFW.windows.length && GLFW.windows[i] == null; i++) {
         // no-op
       }
+      var useWebGL = (GLFW.hints[0x00022001] > 0); // Use WebGL when we are told to based on GLFW_CLIENT_API
       if (i == GLFW.windows.length) {
-        var contextAttributes = {
-          antialias: (GLFW.hints[0x0002100D] > 1), // GLFW_SAMPLES
-          depth: (GLFW.hints[0x00021005] > 0),     // GLFW_DEPTH_BITS
-          stencil: (GLFW.hints[0x00021006] > 0),   // GLFW_STENCIL_BITS
-          alpha: (GLFW.hints[0x00021004] > 0)      // GLFW_ALPHA_BITS
-        }
+        if (useWebGL) {
+          var contextAttributes = {
+            antialias: (GLFW.hints[0x0002100D] > 1), // GLFW_SAMPLES
+            depth: (GLFW.hints[0x00021005] > 0),     // GLFW_DEPTH_BITS
+            stencil: (GLFW.hints[0x00021006] > 0),   // GLFW_STENCIL_BITS
+            alpha: (GLFW.hints[0x00021004] > 0)      // GLFW_ALPHA_BITS
+          }
 #if OFFSCREEN_FRAMEBUFFER
-        // TODO: Make GLFW explicitly aware of whether it is being proxied or not, and set these to true only when proxying is being performed.
-        GL.enableOffscreenFramebufferAttributes(contextAttributes);
+          // TODO: Make GLFW explicitly aware of whether it is being proxied or not, and set these to true only when proxying is being performed.
+          GL.enableOffscreenFramebufferAttributes(contextAttributes);
 #endif
-        Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
+          Module.ctx = Browser.createContext(Module['canvas'], true, true, contextAttributes);
+        } else {
+          Browser.init();
+        }
       }
 
       // If context creation failed, do not return a valid window
-      if (!Module.ctx) return 0;
+      if (!Module.ctx && useWebGL) return 0;
 
       // Get non alive id
       var win = new GLFW_Window(id, width, height, title, monitor, share);

--- a/tests/glfw3.c
+++ b/tests/glfw3.c
@@ -84,7 +84,7 @@ int main()
     {
         int x, y, w, h;
         glfwDefaultWindowHints();
-        glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API);
+        glfwWindowHint(GLFW_CLIENT_API, CLIENT_API);
 
         window = glfwCreateWindow(640, 480, "glfw3.c", NULL, NULL);
         assert(window != NULL);
@@ -142,7 +142,7 @@ int main()
         window = glfwCreateWindow(640, 480, "glfw3.c", NULL, NULL);
         assert(window != NULL);
 
-        assert(glfwGetWindowAttrib(window, GLFW_CLIENT_API) == GLFW_OPENGL_ES_API);
+        assert(glfwGetWindowAttrib(window, GLFW_CLIENT_API) == CLIENT_API);
 
         assert(glfwGetWindowUserPointer(window) == NULL);
         glfwSetWindowUserPointer(window, userptr);
@@ -195,6 +195,7 @@ int main()
         glfwSetTime(0);
     }
 
+#if CLIENT_API == GLFW_OPENGL_ES_API
     {
         glfwMakeContextCurrent(window); // stub
         assert(glfwGetCurrentContext() == window);
@@ -206,6 +207,7 @@ int main()
         assert(glfwExtensionSupported("nonexistant") == 0);
         assert(glfwGetProcAddress("nonexistant") == NULL);
     }
+#endif
 
     glfwTerminate();
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2774,10 +2774,14 @@ Module["preRun"].push(function () {
         in_html('200')
 
   @requires_graphics_hardware
-  def test_glfw3(self):
+  @parameterized({
+    'no_gl': (['-DCLIENT_API=GLFW_NO_API'],),
+    'gl_es': (['-DCLIENT_API=GLFW_OPENGL_ES_API'],)
+  })
+  def test_glfw3(self, args):
     for opts in [[], ['-s', 'LEGACY_GL_EMULATION=1'], ['-Os', '--closure', '1']]:
       print(opts)
-      self.btest(path_from_root('tests', 'glfw3.c'), args=['-s', 'USE_GLFW=3', '-lglfw', '-lGL'] + opts, expected='1')
+      self.btest(path_from_root('tests', 'glfw3.c'), args=['-s', 'USE_GLFW=3', '-lglfw', '-lGL'] + args + opts, expected='1')
 
   @requires_graphics_hardware
   def test_glfw_events(self):


### PR DESCRIPTION
In order to support the combined use of GLFW and WebGPU, GLFW should not assign anything to the Emscripten modules context variable. GLFW supports not creating any OpenGL context using the windows attribute GLFW_CLIENT_API.