### PR TITLE
Remove PThread.mainThreadBlock. NFC.

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -22,9 +22,6 @@ var LibraryPThread = {
     unusedWorkers: [],
     // Contains all Workers that are currently hosting an active pthread.
     runningWorkers: [],
-    // Points to a pthread_t structure in the Emscripten main heap, allocated on
-    // demand if/when first needed.
-    // mainThreadBlock: undefined,
     initMainThreadBlock: function() {
 #if ASSERTIONS
       assert(!ENVIRONMENT_IS_PTHREAD);
@@ -47,41 +44,41 @@ var LibraryPThread = {
       withBuiltinMalloc(function () {
 #endif
 
-      PThread.mainThreadBlock = _malloc({{{ C_STRUCTS.pthread.__size__ }}});
+      var tb = _malloc({{{ C_STRUCTS.pthread.__size__ }}});
 
-      for (var i = 0; i < {{{ C_STRUCTS.pthread.__size__ }}}/4; ++i) HEAPU32[PThread.mainThreadBlock/4+i] = 0;
+      for (var i = 0; i < {{{ C_STRUCTS.pthread.__size__ }}}/4; ++i) HEAPU32[tb/4+i] = 0;
 
       // The pthread struct has a field that points to itself - this is used as
         // a magic ID to detect whether the pthread_t structure is 'alive'.
-      {{{ makeSetValue('PThread.mainThreadBlock', C_STRUCTS.pthread.self, 'PThread.mainThreadBlock', 'i32') }}};
+      {{{ makeSetValue('tb', C_STRUCTS.pthread.self, 'tb', 'i32') }}};
 
       // pthread struct robust_list head should point to itself.
-      var headPtr = PThread.mainThreadBlock + {{{ C_STRUCTS.pthread.robust_list }}};
+      var headPtr = tb + {{{ C_STRUCTS.pthread.robust_list }}};
       {{{ makeSetValue('headPtr', 0, 'headPtr', 'i32') }}};
 
       // Allocate memory for thread-local storage.
       var tlsMemory = _malloc({{{ cDefine('PTHREAD_KEYS_MAX') * 4 }}});
       for (var i = 0; i < {{{ cDefine('PTHREAD_KEYS_MAX') }}}; ++i) HEAPU32[tlsMemory/4+i] = 0;
-      Atomics.store(HEAPU32, (PThread.mainThreadBlock + {{{ C_STRUCTS.pthread.tsd }}} ) >> 2, tlsMemory); // Init thread-local-storage memory array.
-      Atomics.store(HEAPU32, (PThread.mainThreadBlock + {{{ C_STRUCTS.pthread.tid }}} ) >> 2, PThread.mainThreadBlock); // Main thread ID.
+      Atomics.store(HEAPU32, (tb + {{{ C_STRUCTS.pthread.tsd }}} ) >> 2, tlsMemory); // Init thread-local-storage memory array.
+      Atomics.store(HEAPU32, (tb + {{{ C_STRUCTS.pthread.tid }}} ) >> 2, tb); // Main thread ID.
 
       PThread.initShared();
 
 #if PTHREADS_PROFILING
-      PThread.createProfilerBlock(PThread.mainThreadBlock);
-      PThread.setThreadName(PThread.mainThreadBlock, "Browser main thread");
-      PThread.setThreadStatus(PThread.mainThreadBlock, {{{ cDefine('EM_THREAD_STATUS_RUNNING') }}});
-#endif
-
-#if USE_ASAN || USE_LSAN
-      });
+      PThread.createProfilerBlock(tb);
+      PThread.setThreadName(tb, "Browser main thread");
+      PThread.setThreadStatus(tb, {{{ cDefine('EM_THREAD_STATUS_RUNNING') }}});
 #endif
 
       // Pass the thread address to the native code where they stored in wasm
       // globals which act as a form of TLS. Global constructors trying
       // to access this value will read the wrong value, but that is UB anyway.
-      __emscripten_thread_init(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
-      _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);
+      __emscripten_thread_init(tb, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
+      _emscripten_register_main_browser_thread_id(tb);
+
+#if USE_ASAN || USE_LSAN
+      });
+#endif
     },
     initWorker: function() {
       PThread.initShared();
@@ -848,7 +845,7 @@ var LibraryPThread = {
 #endif
   },
 
-  _emscripten_do_pthread_join__deps: ['$cleanupThread', '_pthread_testcancel_js', 'emscripten_main_thread_process_queued_calls', 'emscripten_futex_wait', 'pthread_self',
+  _emscripten_do_pthread_join__deps: ['$cleanupThread', '_pthread_testcancel_js', 'emscripten_main_thread_process_queued_calls', 'emscripten_futex_wait', 'pthread_self', 'emscripten_main_browser_thread_id',
 #if ASSERTIONS || IN_TEST_HARNESS || !MINIMAL_RUNTIME || !ALLOW_BLOCKING_ON_MAIN_THREAD
   'emscripten_check_blocking_allowed'
 #endif
@@ -862,7 +859,7 @@ var LibraryPThread = {
       err('PThread ' + thread + ' is attempting to join to itself!');
       return ERRNO_CODES.EDEADLK;
     }
-    else if (!ENVIRONMENT_IS_PTHREAD && PThread.mainThreadBlock == thread) {
+    else if (!ENVIRONMENT_IS_PTHREAD && _emscripten_main_browser_thread_id() == thread) {
       err('Main thread ' + thread + ' is attempting to join to itself!');
       return ERRNO_CODES.EDEADLK;
     }

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -69,11 +69,6 @@ function initRuntime(asm) {
     PThread.initWorker();
     return;
   }
-
-  // Pass the thread address inside the asm.js scope to store it for fast access
-  // that avoids the need for a FFI out.
-  __emscripten_thread_init(PThread.mainThreadBlock, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
-  _emscripten_register_main_browser_thread_id(PThread.mainThreadBlock);
 #endif
 
 #if STACK_OVERFLOW_CHECK

--- a/src/threadprofiler.js
+++ b/src/threadprofiler.js
@@ -26,13 +26,13 @@ var emscriptenThreadProfiler = {
   updateUi: function updateUi() {
     if (typeof PThread === 'undefined') return; // Likely running threadprofiler on a singlethreaded build, or not initialized yet, ignore updating.
     var str = '';
-    var mainThread = PThread.mainThreadBlock;
+    var mainThread = _emscripten_main_browser_thread_id();
 
-    var threads = [PThread.mainThreadBlock];
+    var threads = [mainThread];
     for(var t in PThread.pthreads) threads.push(PThread.pthreads[t].threadInfoStruct);
 
     for(var i = 0; i < threads.length; ++i) {
-      var threadPtr = threads[i];//(t == PThread.mainThreadBlock ? PThread.mainThreadBlock : maiPThread.pthreads[t].threadInfoStruct;
+      var threadPtr = threads[i];//(t == mainThread ? mainThread : maiPThread.pthreads[t].threadInfoStruct;
       var profilerBlock = Atomics.load(HEAPU32, (threadPtr + 20 /*C_STRUCTS.pthread.profilerBlock*/ ) >> 2);
       var threadName = PThread.getThreadName(threadPtr);
       if (threadName) threadName = '"' + threadName + '" (0x' + threadPtr.toString(16) + ')';


### PR DESCRIPTION
The main thread pointer is already available via the
`_emscripten_main_browser_thread_id` native
function.

There is no point in also storing it in JS.

While making this change I noticed that postamble_minimal.js
was also redundantly calling `__emscripten_thread_init` and
`_emscripten_register_main_browser_thread_id`.