### PR TITLE
Fix docs on newer versions of sphinx. Fixes #12918

### DIFF
--- a/site/source/_themes/emscripten_sphinx_rtd_theme/layout.html
+++ b/site/source/_themes/emscripten_sphinx_rtd_theme/layout.html
@@ -180,7 +180,8 @@
             VERSION:'{{ release|e }}',
             COLLAPSE_INDEX:false,
             FILE_SUFFIX:'{{ '' if no_search_suffix else file_suffix }}',
-            HAS_SOURCE:  {{ has_source|lower }}
+            HAS_SOURCE:  {{ has_source|lower }},
+            LINK_SUFFIX: '.html'
         };
     </script>
     {%- for scriptfile in script_files %}


### PR DESCRIPTION
`LINK_SUFFIX` must be defined or else the files are given no
suffix, and instead a JS `undefined` appears, which breaks search
results.
