### PR TITLE
Remove excess headers from report_result.h

### DIFF
--- a/tests/emscripten_set_timeout.c
+++ b/tests/emscripten_set_timeout.c
@@ -1,4 +1,5 @@
 #include <emscripten/html5.h>
+#include <emscripten/em_asm.h>
 #include <assert.h>
 
 int func1Executed = 0;

--- a/tests/emscripten_set_timeout_loop.c
+++ b/tests/emscripten_set_timeout_loop.c
@@ -1,4 +1,5 @@
 #include <emscripten/html5.h>
+#include <emscripten/em_asm.h>
 #include <assert.h>
 
 double previousSetTimeouTime = 0;

--- a/tests/pthread/emscripten_thread_sleep.c
+++ b/tests/pthread/emscripten_thread_sleep.c
@@ -2,6 +2,7 @@
 #include <emscripten.h>
 #include <emscripten/threading.h>
 #include <assert.h>
+#include <stdio.h>
 
 void Sleep(double msecs)
 {

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -7,6 +7,7 @@
 #include <emscripten.h>
 #include <emscripten/threading.h>
 #include <assert.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 volatile int result = 0;

--- a/tests/pthread/test_pthread_volatile.cpp
+++ b/tests/pthread/test_pthread_volatile.cpp
@@ -4,6 +4,7 @@
 // found in the LICENSE file.
 
 #include <pthread.h>
+#include <stdio.h>
 #include <errno.h>
 #include <emscripten.h>
 #include <emscripten/threading.h>

--- a/tests/report_result.h
+++ b/tests/report_result.h
@@ -10,17 +10,15 @@
 #ifndef REPORT_RESULT_H_
 #define REPORT_RESULT_H_
 
-#include <stdio.h>
-
 #ifdef __EMSCRIPTEN__
-
-#include <emscripten.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
+
 void _ReportResult(int result, int sync);
 void _MaybeReportResult(int result, int sync);
+
 #ifdef __cplusplus
 }
 #endif
@@ -40,7 +38,9 @@ void _MaybeReportResult(int result, int sync);
 
 #else
 
+#include <stdio.h>
 #include <stdlib.h>
+
 #define REPORT_RESULT(result)       \
   do {                              \
     printf("result: %d\n", result); \

--- a/tests/request_animation_frame.cpp
+++ b/tests/request_animation_frame.cpp
@@ -7,6 +7,7 @@
 
 // Test RAF is actually used (and not setTimeout etc.)
 
+#include <stdio.h>
 #include <emscripten.h>
 
 EMSCRIPTEN_KEEPALIVE extern "C" void good() {

--- a/tests/sdl2_net_client.c
+++ b/tests/sdl2_net_client.c
@@ -23,6 +23,10 @@
 
 #include "SDL_net.h"
 
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
+
 typedef enum {
   MSG_READ,
   MSG_WRITE

--- a/tests/sdl_stb_image_cleanup.c
+++ b/tests/sdl_stb_image_cleanup.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <SDL/SDL_image.h>
 #include <emscripten.h>
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3499,6 +3499,7 @@ window.close = function() {
           };
         ''')
       src += r'''
+        #include <emscripten/em_asm.h>
         int main() {
           test_main();
           EM_ASM({


### PR DESCRIPTION
Because this header is force-included into all browser tests it should
be as un-intrusive as possible.

This also involved adding includes to a few tests that were indirectly
relying on these includes.  Better to IWYN.

Split out from #12928