### PR TITLE
Set noExitRuntime also on pthreads

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -435,17 +435,14 @@ if (Module['noInitialRun']) shouldRunNow = false;
 #endif // HAS_MAIN
 
 #if EXIT_RUNTIME == 0
-#if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) // EXIT_RUNTIME=0 only applies to default behavior of the main browser thread
-#endif
-  noExitRuntime = true;
+noExitRuntime = true;
 #endif
 
 #if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) {
-  run();
-} else {
+if (ENVIRONMENT_IS_PTHREAD) {
   PThread.initWorker();
+} else {
+  run();
 }
 #else
 run();

--- a/src/shell_pthreads.js
+++ b/src/shell_pthreads.js
@@ -5,9 +5,14 @@
  */
 
 // Three configurations we can be running in:
-// 1) We could be the application main() thread running in the main JS UI thread. (ENVIRONMENT_IS_WORKER == false and ENVIRONMENT_IS_PTHREAD == false)
-// 2) We could be the application main() thread proxied to worker. (with Emscripten -s PROXY_TO_WORKER=1) (ENVIRONMENT_IS_WORKER == true, ENVIRONMENT_IS_PTHREAD == false)
-// 3) We could be an application pthread running in a worker. (ENVIRONMENT_IS_WORKER == true and ENVIRONMENT_IS_PTHREAD == true)
+// 1) We could be the application main() thread running in the main JS UI
+//    thread.
+//    (ENVIRONMENT_IS_WORKER == false and ENVIRONMENT_IS_PTHREAD == false)
+// 2) We could be the application main() thread proxied to worker. (with
+//    Emscripten -s PROXY_TO_WORKER=1)
+//    (ENVIRONMENT_IS_WORKER == true  and ENVIRONMENT_IS_PTHREAD == false)
+// 3) We could be an application pthread running in a worker.
+//    (ENVIRONMENT_IS_WORKER == true  and ENVIRONMENT_IS_PTHREAD == true)
 
 // ENVIRONMENT_IS_PTHREAD=true will have been preset in worker.js. Make it false in the main runtime thread.
 var ENVIRONMENT_IS_PTHREAD = Module['ENVIRONMENT_IS_PTHREAD'] || false;


### PR DESCRIPTION
If we don't set this then calls to exit() from pthread will
trigger `onExit` bring down the program.

As it stands noExitRuntime is left `undefined` threads which is falsey
which means that threads will behave as if EXIT_RUNTIME=1 was set.