### PR TITLE
Handle exit() from pthread by posting exitProcess back to main thread

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -351,17 +351,17 @@ var LibraryPThread = {
           if (detached) {
             PThread.returnWorkerToPool(worker);
           }
-#if EXIT_RUNTIME // If building with -s EXIT_RUNTIME=0, no thread will post this message, so don't even compile it in.
         } else if (cmd === 'exitProcess') {
           // A pthread has requested to exit the whole application process (runtime).
-          noExitRuntime = false;
+#if ASSERTIONS
+          err("exitProcess requested by worker");
+#endif
           try {
             exit(d['returnCode']);
           } catch (e) {
             if (e instanceof ExitStatus) return;
             throw e;
           }
-#endif
         } else if (cmd === 'cancelDone') {
           PThread.returnWorkerToPool(worker);
         } else if (cmd === 'objectTransfer') {

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -377,6 +377,18 @@ function exit(status, implicit) {
     return;
   }
 
+#if USE_PTHREADS
+  if (ENVIRONMENT_IS_PTHREAD && !implicit) {
+#if ASSERTIONS
+    err('Pthread 0x' + _pthread_self().toString(16) + ' called exit(), posting exitProcess.');
+#endif
+    // When running in a pthread we propagate the exit back to the main thread
+    // where it can decide if the whole process should be shut down or not.
+    postMessage({ 'cmd': 'exitProcess', 'returnCode': status });
+    throw new ExitStatus(status);
+  }
+#endif
+
   if (noExitRuntime) {
 #if ASSERTIONS
     // if exit() was called, we may warn the user if the runtime isn't actually being shut down
@@ -436,9 +448,16 @@ if (Module['noInitialRun']) shouldRunNow = false;
 
 #if EXIT_RUNTIME == 0
 #if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD) // EXIT_RUNTIME=0 only applies to default behavior of the main browser thread
+// EXIT_RUNTIME=0 only applies to default behavior of the main browser thread.
+// Otherwise EXIT_RUNTIME=0 (the default) would mean that pthreads would never
+// exit by defualt wich would break a lot of existing code.
+// However, pthreads can still choose to set noExitRuntime explictly, or
+// call emscripten_unwind_to_js_event_loop to extend their lifetime beyond
+// thier main function.  See comment in src/worker.js for more.
+noExitRuntime = false;
+#else
+noExitRuntime = true;
 #endif
-  noExitRuntime = true;
 #endif
 
 #if USE_PTHREADS

--- a/tests/core/pthread/test_pthread_exit_runtime.c
+++ b/tests/core/pthread/test_pthread_exit_runtime.c
@@ -1,0 +1,21 @@
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+pthread_t t;
+
+void* thread_main_exit(void* arg) {
+  printf("calling exit\n");
+  exit(42);
+}
+
+int main() {
+  printf("main\n");
+  pthread_create(&t, NULL, thread_main_exit, NULL);
+  pthread_join(t, NULL);
+  printf("done join\n");
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+  return 0;
+}

--- a/tests/core/pthread/test_pthread_exit_runtime.c
+++ b/tests/core/pthread/test_pthread_exit_runtime.c
@@ -1,3 +1,4 @@
+#include <assert.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -11,11 +12,21 @@ void* thread_main_exit(void* arg) {
 
 int main() {
   printf("main\n");
-  pthread_create(&t, NULL, thread_main_exit, NULL);
-  pthread_join(t, NULL);
-  printf("done join\n");
+  int rc = pthread_create(&t, NULL, thread_main_exit, NULL);
+  assert(rc == 0);
+  void* thread_rtn = 0;
+  rc = pthread_join(t, &thread_rtn);
+  assert(rc == 0);
+#if EXIT_RUNTIME
+  printf("done join -- should never get here\n");
+  return 1;
+#else
+  // Since EXIT_RUNTIME is not set the exit() in the thread is not expected to
+  // bring down the whole process, only itself.
+  printf("done join -- thread exited with %ld\n", (intptr_t)thread_rtn);
 #ifdef REPORT_RESULT
-  REPORT_RESULT(0);
+  REPORT_RESULT(43);
 #endif
-  return 0;
+  return 43;
+#endif
 }

--- a/tests/core/pthread/test_pthread_exit_runtime.out
+++ b/tests/core/pthread/test_pthread_exit_runtime.out
@@ -1,0 +1,1 @@
+onExit status: 42

--- a/tests/core/pthread/test_pthread_exit_runtime.pre.js
+++ b/tests/core/pthread/test_pthread_exit_runtime.pre.js
@@ -1,0 +1,8 @@
+Module.preRun = function() {
+  Module['onExit'] = function(status) {
+    out('onExit status: ' + status);
+    if (typeof reportResultToServer !== 'undefined') {
+      reportResultToServer('onExit status: ' + status);
+    }
+  };
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3963,6 +3963,28 @@ window.close = function() {
   def test_pthread_asan_use_after_free(self):
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_asan_use_after_free.cpp'), expected='1', args=['-fsanitize=address', '-s', 'INITIAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '--pre-js', path_from_root('tests', 'pthread', 'test_pthread_asan_use_after_free.js')])
 
+  @requires_threads
+  def test_pthread_exit_process(self):
+    args = ['-s', 'USE_PTHREADS=1',
+            '-s', 'PROXY_TO_PTHREAD',
+            '-s', 'PTHREAD_POOL_SIZE=2',
+            '-s', 'EXIT_RUNTIME',
+            '-DEXIT_RUNTIME',
+            '-O0']
+    args += ['--pre-js', path_from_root('tests', 'core', 'pthread', 'test_pthread_exit_runtime.pre.js')]
+    self.btest(path_from_root('tests', 'core', 'pthread', 'test_pthread_exit_runtime.c'), expected='onExit status: 42', args=args)
+
+  @requires_threads
+  def test_pthread_no_exit_process(self):
+    # Same as above but without EXIT_RUNTIME.  In this case we don't expect onExit to
+    # ever be called.
+    args = ['-s', 'USE_PTHREADS=1',
+            '-s', 'PROXY_TO_PTHREAD',
+            '-s', 'PTHREAD_POOL_SIZE=2',
+            '-O0']
+    args += ['--pre-js', path_from_root('tests', 'core', 'pthread', 'test_pthread_exit_runtime.pre.js')]
+    self.btest(path_from_root('tests', 'core', 'pthread', 'test_pthread_exit_runtime.c'), expected='43', args=args)
+
   # Tests MAIN_THREAD_EM_ASM_INT() function call signatures.
   def test_main_thread_em_asm_signatures(self):
     self.btest(path_from_root('tests', 'core', 'test_em_asm_signatures.cpp'), expected='121', args=[])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8092,11 +8092,20 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_pthread_exit_process(self):
-    self.add_pre_run("Module['onExit'] = function(status) { out('onExit status: ' + status); };")
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('PTHREAD_POOL_SIZE', '2')
     self.set_setting('EXIT_RUNTIME')
+    self.emcc_args += ['--pre-js', path_from_root('tests', 'core', 'pthread', 'test_pthread_exit_runtime.pre.js')]
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'test_pthread_exit_runtime.c', assert_returncode=42)
+
+  @node_pthreads
+  @disabled('https://github.com/emscripten-core/emscripten/issues/12945')
+  def test_pthread_no_exit_process(self):
+    # Same as above but without EXIT_RUNTIME
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('PTHREAD_POOL_SIZE', '2')
+    self.emcc_args += ['--pre-js', path_from_root('tests', 'core', 'pthread', 'test_pthread_exit_runtime.pre.js')]
+    self.do_run_in_out_file_test('tests', 'core', 'pthread', 'test_pthread_exit_runtime.c', assert_returncode=43)
 
   def test_emscripten_atomics_stub(self):
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'emscripten_atomics.c')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8090,6 +8090,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['-fexceptions']
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'exceptions.cpp')
 
+  @node_pthreads
+  def test_pthread_exit_process(self):
+    self.add_pre_run("Module['onExit'] = function(status) { out('onExit status: ' + status); };")
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('PTHREAD_POOL_SIZE', '2')
+    self.set_setting('EXIT_RUNTIME')
+    self.do_run_in_out_file_test('tests', 'core', 'pthread', 'test_pthread_exit_runtime.c', assert_returncode=42)
+
   def test_emscripten_atomics_stub(self):
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'emscripten_atomics.c')
 


### PR DESCRIPTION
We have pthread_exit() for users who only want to exit from the one thread (this
is the same as returning from the thread entry point).

The C exit function on the other hand is supposed to bring down the whole process. 