### PR TITLE
Remove `extern` declarations from emscripten headers. NFC.

### DIFF
--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -59,25 +59,25 @@ typedef void (*em_callback_func)(void);
 typedef void (*em_arg_callback_func)(void*);
 typedef void (*em_str_callback_func)(const char *);
 
-extern void emscripten_run_script(const char *script);
-extern int emscripten_run_script_int(const char *script);
-extern char *emscripten_run_script_string(const char *script);
-extern void emscripten_async_run_script(const char *script, int millis);
-extern void emscripten_async_load_script(const char *script, em_callback_func onload, em_callback_func onerror);
+void emscripten_run_script(const char *script);
+int emscripten_run_script_int(const char *script);
+char *emscripten_run_script_string(const char *script);
+void emscripten_async_run_script(const char *script, int millis);
+void emscripten_async_load_script(const char *script, em_callback_func onload, em_callback_func onerror);
 
 #if __EMSCRIPTEN__
-extern void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infinite_loop);
+void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infinite_loop);
 
 #define EM_TIMING_SETTIMEOUT 0
 #define EM_TIMING_RAF 1
 #define EM_TIMING_SETIMMEDIATE 2
 
-extern int emscripten_set_main_loop_timing(int mode, int value);
-extern void emscripten_get_main_loop_timing(int *mode, int *value);
-extern void emscripten_set_main_loop_arg(em_arg_callback_func func, void *arg, int fps, int simulate_infinite_loop);
-extern void emscripten_pause_main_loop(void);
-extern void emscripten_resume_main_loop(void);
-extern void emscripten_cancel_main_loop(void);
+int emscripten_set_main_loop_timing(int mode, int value);
+void emscripten_get_main_loop_timing(int *mode, int *value);
+void emscripten_set_main_loop_arg(em_arg_callback_func func, void *arg, int fps, int simulate_infinite_loop);
+void emscripten_pause_main_loop(void);
+void emscripten_resume_main_loop(void);
+void emscripten_cancel_main_loop(void);
 #else
 #define emscripten_set_main_loop(func, fps, simulateInfiniteLoop) \
   while (1) { func(); usleep(1000000/fps); }
@@ -88,17 +88,17 @@ extern void emscripten_cancel_main_loop(void);
 typedef void (*em_socket_callback)(int fd, void *userData);
 typedef void (*em_socket_error_callback)(int fd, int err, const char* msg, void *userData);
 
-extern void emscripten_set_socket_error_callback(void *userData, em_socket_error_callback callback);
-extern void emscripten_set_socket_open_callback(void *userData, em_socket_callback callback);
-extern void emscripten_set_socket_listen_callback(void *userData, em_socket_callback callback);
-extern void emscripten_set_socket_connection_callback(void *userData, em_socket_callback callback);
-extern void emscripten_set_socket_message_callback(void *userData, em_socket_callback callback);
-extern void emscripten_set_socket_close_callback(void *userData, em_socket_callback callback);
+void emscripten_set_socket_error_callback(void *userData, em_socket_error_callback callback);
+void emscripten_set_socket_open_callback(void *userData, em_socket_callback callback);
+void emscripten_set_socket_listen_callback(void *userData, em_socket_callback callback);
+void emscripten_set_socket_connection_callback(void *userData, em_socket_callback callback);
+void emscripten_set_socket_message_callback(void *userData, em_socket_callback callback);
+void emscripten_set_socket_close_callback(void *userData, em_socket_callback callback);
 
 
 #if __EMSCRIPTEN__
-extern void _emscripten_push_main_loop_blocker(em_arg_callback_func func, void *arg, const char *name);
-extern void _emscripten_push_uncounted_main_loop_blocker(em_arg_callback_func func, void *arg, const char *name);
+void _emscripten_push_main_loop_blocker(em_arg_callback_func func, void *arg, const char *name);
+void _emscripten_push_uncounted_main_loop_blocker(em_arg_callback_func func, void *arg, const char *name);
 #else
 inline void _emscripten_push_main_loop_blocker(em_arg_callback_func func, void *arg, const char *name) {
   func(arg);
@@ -113,14 +113,14 @@ inline void _emscripten_push_uncounted_main_loop_blocker(em_arg_callback_func fu
   _emscripten_push_uncounted_main_loop_blocker(func, arg, #func)
 
 #if __EMSCRIPTEN__
-extern void emscripten_set_main_loop_expected_blockers(int num);
+void emscripten_set_main_loop_expected_blockers(int num);
 #else
 inline void emscripten_set_main_loop_expected_blockers(int num) {}
 #endif
 
 
 #if __EMSCRIPTEN__
-extern void emscripten_async_call(em_arg_callback_func func, void *arg, int millis);
+void emscripten_async_call(em_arg_callback_func func, void *arg, int millis);
 #else
 inline void emscripten_async_call(em_arg_callback_func func, void *arg, int millis) {
   if (millis) SDL_Delay(millis);
@@ -129,8 +129,8 @@ inline void emscripten_async_call(em_arg_callback_func func, void *arg, int mill
 #endif
 
 
-extern void emscripten_exit_with_live_runtime(void);
-extern void emscripten_force_exit(int status);
+void emscripten_exit_with_live_runtime(void);
+void emscripten_force_exit(int status);
 
 double emscripten_get_device_pixel_ratio(void);
 

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -124,9 +124,9 @@ typedef struct EmscriptenKeyboardEvent {
 
 
 typedef EM_BOOL (*em_key_callback_func)(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_keypress_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_keydown_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_keyup_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_keypress_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_keydown_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_keyup_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenMouseEvent {
   long screenX;
@@ -151,17 +151,17 @@ typedef struct EmscriptenMouseEvent {
 
 
 typedef EM_BOOL (*em_mouse_callback_func)(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_click_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_mousedown_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_mouseup_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_dblclick_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_mousemove_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_mouseenter_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_mouseleave_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_mouseover_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_mouseout_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_click_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mousedown_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseup_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_dblclick_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mousemove_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseenter_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseleave_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseover_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseout_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_get_mouse_status(EmscriptenMouseEvent *mouseState);
+EMSCRIPTEN_RESULT emscripten_get_mouse_status(EmscriptenMouseEvent *mouseState);
 
 #define DOM_DELTA_PIXEL 0x00
 #define DOM_DELTA_LINE  0x01
@@ -177,7 +177,7 @@ typedef struct EmscriptenWheelEvent {
 
 
 typedef EM_BOOL (*em_wheel_callback_func)(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_wheel_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_wheel_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_wheel_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_wheel_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenUiEvent {
   long detail;
@@ -193,8 +193,8 @@ typedef struct EmscriptenUiEvent {
 
 
 typedef EM_BOOL (*em_ui_callback_func)(int eventType, const EmscriptenUiEvent *uiEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_resize_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_ui_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_scroll_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_ui_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_resize_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_ui_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_scroll_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_ui_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenFocusEvent {
   EM_UTF8 nodeName[EM_HTML5_LONG_STRING_LEN_BYTES];
@@ -202,10 +202,10 @@ typedef struct EmscriptenFocusEvent {
 } EmscriptenFocusEvent;
 
 typedef EM_BOOL (*em_focus_callback_func)(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_blur_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_focus_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_focusin_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_focusout_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_blur_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focus_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focusin_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focusout_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenDeviceOrientationEvent {
   double alpha;
@@ -216,9 +216,9 @@ typedef struct EmscriptenDeviceOrientationEvent {
 
 
 typedef EM_BOOL (*em_deviceorientation_callback_func)(int eventType, const EmscriptenDeviceOrientationEvent *deviceOrientationEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_deviceorientation_callback_on_thread(void *userData, EM_BOOL useCapture, em_deviceorientation_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_deviceorientation_callback_on_thread(void *userData, EM_BOOL useCapture, em_deviceorientation_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_get_deviceorientation_status(EmscriptenDeviceOrientationEvent *orientationState);
+EMSCRIPTEN_RESULT emscripten_get_deviceorientation_status(EmscriptenDeviceOrientationEvent *orientationState);
 
 #define EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION                   0x01
 #define EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION_INCLUDING_GRAVITY 0x02
@@ -239,9 +239,9 @@ typedef struct EmscriptenDeviceMotionEvent {
 
 
 typedef EM_BOOL (*em_devicemotion_callback_func)(int eventType, const EmscriptenDeviceMotionEvent *deviceMotionEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_devicemotion_callback_on_thread(void *userData, EM_BOOL useCapture, em_devicemotion_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_devicemotion_callback_on_thread(void *userData, EM_BOOL useCapture, em_devicemotion_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_get_devicemotion_status(EmscriptenDeviceMotionEvent *motionState);
+EMSCRIPTEN_RESULT emscripten_get_devicemotion_status(EmscriptenDeviceMotionEvent *motionState);
 
 #define EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY    1
 #define EMSCRIPTEN_ORIENTATION_PORTRAIT_SECONDARY  2
@@ -255,11 +255,11 @@ typedef struct EmscriptenOrientationChangeEvent {
 
 
 typedef EM_BOOL (*em_orientationchange_callback_func)(int eventType, const EmscriptenOrientationChangeEvent *orientationChangeEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_orientationchange_callback_on_thread(void *userData, EM_BOOL useCapture, em_orientationchange_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_orientationchange_callback_on_thread(void *userData, EM_BOOL useCapture, em_orientationchange_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_get_orientation_status(EmscriptenOrientationChangeEvent *orientationStatus);
-extern EMSCRIPTEN_RESULT emscripten_lock_orientation(int allowedOrientations);
-extern EMSCRIPTEN_RESULT emscripten_unlock_orientation(void);
+EMSCRIPTEN_RESULT emscripten_get_orientation_status(EmscriptenOrientationChangeEvent *orientationStatus);
+EMSCRIPTEN_RESULT emscripten_lock_orientation(int allowedOrientations);
+EMSCRIPTEN_RESULT emscripten_unlock_orientation(void);
 
 typedef struct EmscriptenFullscreenChangeEvent {
   EM_BOOL isFullscreen;
@@ -274,9 +274,9 @@ typedef struct EmscriptenFullscreenChangeEvent {
 
 
 typedef EM_BOOL (*em_fullscreenchange_callback_func)(int eventType, const EmscriptenFullscreenChangeEvent *fullscreenChangeEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_fullscreenchange_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_fullscreenchange_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_fullscreenchange_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_fullscreenchange_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_get_fullscreen_status(EmscriptenFullscreenChangeEvent *fullscreenStatus);
+EMSCRIPTEN_RESULT emscripten_get_fullscreen_status(EmscriptenFullscreenChangeEvent *fullscreenStatus);
 
 #define EMSCRIPTEN_FULLSCREEN_SCALE int
 #define EMSCRIPTEN_FULLSCREEN_SCALE_DEFAULT 0
@@ -305,14 +305,14 @@ typedef struct EmscriptenFullscreenStrategy {
   pthread_t canvasResizedCallbackTargetThread;
 } EmscriptenFullscreenStrategy;
 
-extern EMSCRIPTEN_RESULT emscripten_request_fullscreen(const char *target, EM_BOOL deferUntilInEventHandler);
-extern EMSCRIPTEN_RESULT emscripten_request_fullscreen_strategy(const char *target, EM_BOOL deferUntilInEventHandler, const EmscriptenFullscreenStrategy *fullscreenStrategy);
+EMSCRIPTEN_RESULT emscripten_request_fullscreen(const char *target, EM_BOOL deferUntilInEventHandler);
+EMSCRIPTEN_RESULT emscripten_request_fullscreen_strategy(const char *target, EM_BOOL deferUntilInEventHandler, const EmscriptenFullscreenStrategy *fullscreenStrategy);
 
-extern EMSCRIPTEN_RESULT emscripten_exit_fullscreen(void);
+EMSCRIPTEN_RESULT emscripten_exit_fullscreen(void);
 
-extern EMSCRIPTEN_RESULT emscripten_enter_soft_fullscreen(const char *target, const EmscriptenFullscreenStrategy *fullscreenStrategy);
+EMSCRIPTEN_RESULT emscripten_enter_soft_fullscreen(const char *target, const EmscriptenFullscreenStrategy *fullscreenStrategy);
 
-extern EMSCRIPTEN_RESULT emscripten_exit_soft_fullscreen(void);
+EMSCRIPTEN_RESULT emscripten_exit_soft_fullscreen(void);
 
 typedef struct EmscriptenPointerlockChangeEvent {
   EM_BOOL isActive;
@@ -322,16 +322,16 @@ typedef struct EmscriptenPointerlockChangeEvent {
 
 
 typedef EM_BOOL (*em_pointerlockchange_callback_func)(int eventType, const EmscriptenPointerlockChangeEvent *pointerlockChangeEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_pointerlockchange_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_pointerlockchange_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_pointerlockchange_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_pointerlockchange_callback_func callback, pthread_t targetThread);
 
 typedef EM_BOOL (*em_pointerlockerror_callback_func)(int eventType, const void *reserved, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_pointerlockerror_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_pointerlockerror_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_pointerlockerror_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_pointerlockerror_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_get_pointerlock_status(EmscriptenPointerlockChangeEvent *pointerlockStatus);
+EMSCRIPTEN_RESULT emscripten_get_pointerlock_status(EmscriptenPointerlockChangeEvent *pointerlockStatus);
 
-extern EMSCRIPTEN_RESULT emscripten_request_pointerlock(const char *target, EM_BOOL deferUntilInEventHandler);
+EMSCRIPTEN_RESULT emscripten_request_pointerlock(const char *target, EM_BOOL deferUntilInEventHandler);
 
-extern EMSCRIPTEN_RESULT emscripten_exit_pointerlock(void);
+EMSCRIPTEN_RESULT emscripten_exit_pointerlock(void);
 
 #define EMSCRIPTEN_VISIBILITY_HIDDEN    0
 #define EMSCRIPTEN_VISIBILITY_VISIBLE   1
@@ -344,9 +344,9 @@ typedef struct EmscriptenVisibilityChangeEvent {
 } EmscriptenVisibilityChangeEvent;
 
 typedef EM_BOOL (*em_visibilitychange_callback_func)(int eventType, const EmscriptenVisibilityChangeEvent *visibilityChangeEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_visibilitychange_callback_on_thread(void *userData, EM_BOOL useCapture, em_visibilitychange_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_visibilitychange_callback_on_thread(void *userData, EM_BOOL useCapture, em_visibilitychange_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_get_visibility_status(EmscriptenVisibilityChangeEvent *visibilityStatus);
+EMSCRIPTEN_RESULT emscripten_get_visibility_status(EmscriptenVisibilityChangeEvent *visibilityStatus);
 
 
 typedef struct EmscriptenTouchPoint
@@ -378,10 +378,10 @@ typedef struct EmscriptenTouchEvent {
 
 
 typedef EM_BOOL (*em_touch_callback_func)(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_touchstart_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_touchend_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_touchmove_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_touchcancel_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchstart_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchend_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchmove_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchcancel_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
 
 
 typedef struct EmscriptenGamepadEvent {
@@ -399,12 +399,12 @@ typedef struct EmscriptenGamepadEvent {
 
 
 typedef EM_BOOL (*em_gamepad_callback_func)(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_gamepadconnected_callback_on_thread(void *userData, EM_BOOL useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_gamepaddisconnected_callback_on_thread(void *userData, EM_BOOL useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_gamepadconnected_callback_on_thread(void *userData, EM_BOOL useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_gamepaddisconnected_callback_on_thread(void *userData, EM_BOOL useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_sample_gamepad_data(void);
-extern int emscripten_get_num_gamepads(void);
-extern EMSCRIPTEN_RESULT emscripten_get_gamepad_status(int index, EmscriptenGamepadEvent *gamepadState);
+EMSCRIPTEN_RESULT emscripten_sample_gamepad_data(void);
+int emscripten_get_num_gamepads(void);
+EMSCRIPTEN_RESULT emscripten_get_gamepad_status(int index, EmscriptenGamepadEvent *gamepadState);
 
 typedef struct EmscriptenBatteryEvent {
   double chargingTime;
@@ -414,28 +414,28 @@ typedef struct EmscriptenBatteryEvent {
 } EmscriptenBatteryEvent;
 
 typedef EM_BOOL (*em_battery_callback_func)(int eventType, const EmscriptenBatteryEvent *batteryEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_batterychargingchange_callback_on_thread(void *userData, em_battery_callback_func callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_batterylevelchange_callback_on_thread(void *userData, em_battery_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_batterychargingchange_callback_on_thread(void *userData, em_battery_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_batterylevelchange_callback_on_thread(void *userData, em_battery_callback_func callback, pthread_t targetThread);
 
-extern EMSCRIPTEN_RESULT emscripten_get_battery_status(EmscriptenBatteryEvent *batteryState);
+EMSCRIPTEN_RESULT emscripten_get_battery_status(EmscriptenBatteryEvent *batteryState);
 
 
-extern EMSCRIPTEN_RESULT emscripten_vibrate(int msecs);
-extern EMSCRIPTEN_RESULT emscripten_vibrate_pattern(int *msecsArray, int numEntries);
+EMSCRIPTEN_RESULT emscripten_vibrate(int msecs);
+EMSCRIPTEN_RESULT emscripten_vibrate_pattern(int *msecsArray, int numEntries);
 
 typedef const char *(*em_beforeunload_callback)(int eventType, const void *reserved, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_beforeunload_callback_on_thread(void *userData, em_beforeunload_callback callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_beforeunload_callback_on_thread(void *userData, em_beforeunload_callback callback, pthread_t targetThread);
 
 // Sets the canvas.width & canvas.height properties.
-extern EMSCRIPTEN_RESULT emscripten_set_canvas_element_size(const char *target, int width, int height);
+EMSCRIPTEN_RESULT emscripten_set_canvas_element_size(const char *target, int width, int height);
 
 // Returns the canvas.width & canvas.height properties.
-extern EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char *target, int *width, int *height);
+EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char *target, int *width, int *height);
 
-extern EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target, double width, double height);
-extern EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target, double *width, double *height);
+EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target, double width, double height);
+EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target, double *width, double *height);
 
-extern void emscripten_html5_remove_all_event_listeners(void);
+void emscripten_html5_remove_all_event_listeners(void);
 
 #define EM_CALLBACK_THREAD_CONTEXT_MAIN_BROWSER_THREAD ((pthread_t)0x1)
 #define EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD ((pthread_t)0x2)
@@ -476,32 +476,32 @@ extern void emscripten_html5_remove_all_event_listeners(void);
 #define emscripten_set_batterylevelchange_callback(userData, callback)                        emscripten_set_batterylevelchange_callback_on_thread(             (userData),               (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 #define emscripten_set_beforeunload_callback(userData, callback)                              emscripten_set_beforeunload_callback_on_thread(                   (userData),               (callback), EM_CALLBACK_THREAD_CONTEXT_MAIN_BROWSER_THREAD)
 
-extern long emscripten_set_timeout(void (*cb)(void *userData), double msecs, void *userData);
-extern void emscripten_clear_timeout(long setTimeoutId);
-extern void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *userData), double intervalMsecs, void *userData);
+long emscripten_set_timeout(void (*cb)(void *userData), double msecs, void *userData);
+void emscripten_clear_timeout(long setTimeoutId);
+void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *userData), double intervalMsecs, void *userData);
 
-extern long emscripten_request_animation_frame(EM_BOOL (*cb)(double time, void *userData), void *userData);
-extern void emscripten_cancel_animation_frame(long requestAnimationFrameId);
-extern void emscripten_request_animation_frame_loop(EM_BOOL (*cb)(double time, void *userData), void *userData);
+long emscripten_request_animation_frame(EM_BOOL (*cb)(double time, void *userData), void *userData);
+void emscripten_cancel_animation_frame(long requestAnimationFrameId);
+void emscripten_request_animation_frame_loop(EM_BOOL (*cb)(double time, void *userData), void *userData);
 
-extern long emscripten_set_immediate(void (*cb)(void *userData), void *userData);
-extern void emscripten_clear_immediate(long setImmediateId);
-extern void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *userData), void *userData);
+long emscripten_set_immediate(void (*cb)(void *userData), void *userData);
+void emscripten_clear_immediate(long setImmediateId);
+void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *userData), void *userData);
 
-extern long emscripten_set_interval(void (*cb)(void *userData), double intervalMsecs, void *userData);
-extern void emscripten_clear_interval(long setIntervalId);
+long emscripten_set_interval(void (*cb)(void *userData), double intervalMsecs, void *userData);
+void emscripten_clear_interval(long setIntervalId);
 
-extern double emscripten_date_now(void);
-extern double emscripten_performance_now(void);
+double emscripten_date_now(void);
+double emscripten_performance_now(void);
 
-extern void emscripten_console_log(const char *utf8String);
-extern void emscripten_console_warn(const char *utf8String);
-extern void emscripten_console_error(const char *utf8String);
+void emscripten_console_log(const char *utf8String);
+void emscripten_console_warn(const char *utf8String);
+void emscripten_console_error(const char *utf8String);
 
-extern void emscripten_throw_number(double number);
-extern void emscripten_throw_string(const char *utf8String);
+void emscripten_throw_number(double number);
+void emscripten_throw_string(const char *utf8String);
 
-extern void emscripten_unwind_to_js_event_loop(void) __attribute__((noreturn));
+void emscripten_unwind_to_js_event_loop(void) __attribute__((noreturn));
 
 #ifdef __cplusplus
 } // ~extern "C"

--- a/system/include/emscripten/html5_webgl.h
+++ b/system/include/emscripten/html5_webgl.h
@@ -44,56 +44,56 @@ typedef struct EmscriptenWebGLContextAttributes {
   EM_BOOL renderViaOffscreenBackBuffer;
 } EmscriptenWebGLContextAttributes;
 
-extern void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttributes *attributes);
+void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttributes *attributes);
 
-extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target, const EmscriptenWebGLContextAttributes *attributes);
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target, const EmscriptenWebGLContextAttributes *attributes);
 
-extern EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context(void);
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context(void);
 
-extern EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height);
+EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height);
 
-extern EMSCRIPTEN_RESULT emscripten_webgl_get_context_attributes(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, EmscriptenWebGLContextAttributes *outAttributes);
+EMSCRIPTEN_RESULT emscripten_webgl_get_context_attributes(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, EmscriptenWebGLContextAttributes *outAttributes);
 
-extern EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EM_BOOL emscripten_webgl_enable_extension(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, const char *extension);
+EM_BOOL emscripten_webgl_enable_extension(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, const char *extension);
 
-extern EM_BOOL emscripten_webgl_enable_ANGLE_instanced_arrays(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EM_BOOL emscripten_webgl_enable_ANGLE_instanced_arrays(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EM_BOOL emscripten_webgl_enable_OES_vertex_array_object(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EM_BOOL emscripten_webgl_enable_OES_vertex_array_object(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EM_BOOL emscripten_webgl_enable_WEBGL_draw_buffers(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EM_BOOL emscripten_webgl_enable_WEBGL_draw_buffers(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EM_BOOL emscripten_webgl_enable_WEBGL_draw_instanced_base_vertex_base_instance(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EM_BOOL emscripten_webgl_enable_WEBGL_draw_instanced_base_vertex_base_instance(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EM_BOOL emscripten_webgl_enable_WEBGL_multi_draw(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EM_BOOL emscripten_webgl_enable_WEBGL_multi_draw(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EM_BOOL emscripten_webgl_enable_WEBGL_multi_draw_instanced_base_vertex_base_instance(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EM_BOOL emscripten_webgl_enable_WEBGL_multi_draw_instanced_base_vertex_base_instance(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
 typedef EM_BOOL (*em_webgl_context_callback)(int eventType, const void *reserved, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_set_webglcontextlost_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
-extern EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_webglcontextlost_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
 
-extern EM_BOOL emscripten_is_webgl_context_lost(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
+EM_BOOL emscripten_is_webgl_context_lost(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-extern EMSCRIPTEN_RESULT emscripten_webgl_commit_frame(void);
+EMSCRIPTEN_RESULT emscripten_webgl_commit_frame(void);
 
-extern EM_BOOL emscripten_supports_offscreencanvas(void);
+EM_BOOL emscripten_supports_offscreencanvas(void);
 
 // Returns function pointers to WebGL 1 functions. Please avoid using this function ever - all WebGL1/GLES2 functions, even those for WebGL1 extensions, are available to user code via static linking. Calling GL functions
 // via function pointers obtained here is slow, and using this function can greatly increase resulting compiled program size. This functionality is available only for easier program code porting purposes, but be aware
 // that calling this is causing a noticeable performance and compiled code size hit.
-extern void *emscripten_webgl1_get_proc_address(const char *name);
+void *emscripten_webgl1_get_proc_address(const char *name);
 
 // Returns function pointers to WebGL 2 functions. Please avoid using this function ever - all WebGL2/GLES3 functions, even those for WebGL2 extensions, are available to user code via static linking. Calling GL functions
 // via function pointers obtained here is slow, and using this function can greatly increase resulting compiled program size. This functionality is available only for easier program code porting purposes, but be aware
 // that calling this is causing a noticeable performance and compiled code size hit.
-extern void *emscripten_webgl2_get_proc_address(const char *name);
+void *emscripten_webgl2_get_proc_address(const char *name);
 
 // Combines emscripten_webgl1_get_proc_address() and emscripten_webgl2_get_proc_address() to return function pointers to both WebGL1 and WebGL2 functions. Same drawbacks apply.
-extern void *emscripten_webgl_get_proc_address(const char *name);
+void *emscripten_webgl_get_proc_address(const char *name);
 
 #define emscripten_set_webglcontextlost_callback(target, userData, useCapture, callback)      emscripten_set_webglcontextlost_callback_on_thread(     (target), (userData), (useCapture), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 #define emscripten_set_webglcontextrestored_callback(target, userData, useCapture, callback)  emscripten_set_webglcontextrestored_callback_on_thread( (target), (userData), (useCapture), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)

--- a/system/include/emscripten/key_codes.h
+++ b/system/include/emscripten/key_codes.h
@@ -204,7 +204,7 @@
 extern "C" {
 #endif
 
-extern const char *emscripten_dom_vk_to_string(int dom_vk_code);
+const char *emscripten_dom_vk_to_string(int dom_vk_code);
 
 #ifdef __cplusplus
 } // ~extern "C"

--- a/system/include/emscripten/posix_socket.h
+++ b/system/include/emscripten/posix_socket.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-extern EMSCRIPTEN_RESULT emscripten_init_websocket_to_posix_socket_bridge(const char *bridgeUrl);
+EMSCRIPTEN_RESULT emscripten_init_websocket_to_posix_socket_bridge(const char *bridgeUrl);
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/vr.h
+++ b/system/include/emscripten/vr.h
@@ -123,30 +123,30 @@ typedef struct VRFrameData {
     VRPose pose;
 } VRFrameData;
 
-extern int emscripten_vr_ready(void);
-extern int emscripten_vr_init(em_vr_arg_callback_func callback, void* userData);
-extern int emscripten_vr_deinit(void);
+int emscripten_vr_ready(void);
+int emscripten_vr_init(em_vr_arg_callback_func callback, void* userData);
+int emscripten_vr_deinit(void);
 
-extern int emscripten_vr_version_major(void);
-extern int emscripten_vr_version_minor(void);
+int emscripten_vr_version_major(void);
+int emscripten_vr_version_minor(void);
 
-extern int emscripten_vr_count_displays(void);
-extern VRDisplayHandle emscripten_vr_get_display_handle(int displayIndex);
+int emscripten_vr_count_displays(void);
+VRDisplayHandle emscripten_vr_get_display_handle(int displayIndex);
 
-extern int emscripten_vr_set_display_render_loop(VRDisplayHandle handle, em_vr_callback_func callback);
-extern int emscripten_vr_set_display_render_loop_arg(VRDisplayHandle handle, em_vr_arg_callback_func callback, void* arg);
-extern int emscripten_vr_cancel_display_render_loop(VRDisplayHandle handle);
+int emscripten_vr_set_display_render_loop(VRDisplayHandle handle, em_vr_callback_func callback);
+int emscripten_vr_set_display_render_loop_arg(VRDisplayHandle handle, em_vr_arg_callback_func callback, void* arg);
+int emscripten_vr_cancel_display_render_loop(VRDisplayHandle handle);
 
-extern int emscripten_vr_request_present(VRDisplayHandle handle, VRLayerInit* layerInit, int layerCount, em_vr_arg_callback_func callback, void* userData);
-extern int emscripten_vr_get_frame_data(VRDisplayHandle handle, VRFrameData* frameData);
-extern int emscripten_vr_submit_frame(VRDisplayHandle handle);
-extern int emscripten_vr_exit_present(VRDisplayHandle handle);
+int emscripten_vr_request_present(VRDisplayHandle handle, VRLayerInit* layerInit, int layerCount, em_vr_arg_callback_func callback, void* userData);
+int emscripten_vr_get_frame_data(VRDisplayHandle handle, VRFrameData* frameData);
+int emscripten_vr_submit_frame(VRDisplayHandle handle);
+int emscripten_vr_exit_present(VRDisplayHandle handle);
 
-extern const char *emscripten_vr_get_display_name(VRDisplayHandle handle);
-extern int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichEye, VREyeParameters* eyeParams);
-extern int emscripten_vr_get_display_capabilities(VRDisplayHandle handle, VRDisplayCapabilities* displayCaps);
-extern bool emscripten_vr_display_connected(VRDisplayHandle handle);
-extern bool emscripten_vr_display_presenting(VRDisplayHandle handle);
+const char *emscripten_vr_get_display_name(VRDisplayHandle handle);
+int emscripten_vr_get_eye_parameters(VRDisplayHandle handle, VREye whichEye, VREyeParameters* eyeParams);
+int emscripten_vr_get_display_capabilities(VRDisplayHandle handle, VRDisplayCapabilities* displayCaps);
+bool emscripten_vr_display_connected(VRDisplayHandle handle);
+bool emscripten_vr_display_presenting(VRDisplayHandle handle);
 
 #ifdef __cplusplus
 } // ~extern "C"

--- a/system/include/emscripten/websocket.h
+++ b/system/include/emscripten/websocket.h
@@ -19,21 +19,21 @@ extern "C" {
 
 #define EMSCRIPTEN_WEBSOCKET_T int
 
-extern EMSCRIPTEN_RESULT emscripten_websocket_get_ready_state(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short *readyState);
-extern EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, unsigned long long *bufferedAmount);
-extern EMSCRIPTEN_RESULT emscripten_websocket_get_extensions(EMSCRIPTEN_WEBSOCKET_T socket, char *extensions, int extensionsLength);
-extern EMSCRIPTEN_RESULT emscripten_websocket_get_extensions_length(EMSCRIPTEN_WEBSOCKET_T socket, int *extensionsLength);
-extern EMSCRIPTEN_RESULT emscripten_websocket_get_protocol(EMSCRIPTEN_WEBSOCKET_T socket, char *protocol, int protocolLength);
-extern EMSCRIPTEN_RESULT emscripten_websocket_get_protocol_length(EMSCRIPTEN_WEBSOCKET_T socket, int *protocolLength);
-extern EMSCRIPTEN_RESULT emscripten_websocket_get_url(EMSCRIPTEN_WEBSOCKET_T socket, char *url, int urlLength);
-extern EMSCRIPTEN_RESULT emscripten_websocket_get_url_length(EMSCRIPTEN_WEBSOCKET_T socket, int *urlLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_ready_state(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short *readyState);
+EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, unsigned long long *bufferedAmount);
+EMSCRIPTEN_RESULT emscripten_websocket_get_extensions(EMSCRIPTEN_WEBSOCKET_T socket, char *extensions, int extensionsLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_extensions_length(EMSCRIPTEN_WEBSOCKET_T socket, int *extensionsLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_protocol(EMSCRIPTEN_WEBSOCKET_T socket, char *protocol, int protocolLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_protocol_length(EMSCRIPTEN_WEBSOCKET_T socket, int *protocolLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_url(EMSCRIPTEN_WEBSOCKET_T socket, char *url, int urlLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_url_length(EMSCRIPTEN_WEBSOCKET_T socket, int *urlLength);
 
 typedef struct EmscriptenWebSocketOpenEvent {
   EMSCRIPTEN_WEBSOCKET_T socket;
 } EmscriptenWebSocketOpenEvent;
 
 typedef EM_BOOL (*em_websocket_open_callback_func)(int eventType, const EmscriptenWebSocketOpenEvent *websocketEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_websocket_set_onopen_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_open_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_websocket_set_onopen_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_open_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketMessageEvent {
   EMSCRIPTEN_WEBSOCKET_T socket;
@@ -43,14 +43,14 @@ typedef struct EmscriptenWebSocketMessageEvent {
 } EmscriptenWebSocketMessageEvent;
 
 typedef EM_BOOL (*em_websocket_message_callback_func)(int eventType, const EmscriptenWebSocketMessageEvent *websocketEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_websocket_set_onmessage_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_message_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_websocket_set_onmessage_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_message_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketErrorEvent {
   EMSCRIPTEN_WEBSOCKET_T socket;
 } EmscriptenWebSocketErrorEvent;
 
 typedef EM_BOOL (*em_websocket_error_callback_func)(int eventType, const EmscriptenWebSocketErrorEvent *websocketEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_websocket_set_onerror_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_error_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_websocket_set_onerror_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_error_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketCloseEvent {
   EMSCRIPTEN_WEBSOCKET_T socket;
@@ -60,7 +60,7 @@ typedef struct EmscriptenWebSocketCloseEvent {
 } EmscriptenWebSocketCloseEvent;
 
 typedef EM_BOOL (*em_websocket_close_callback_func)(int eventType, const EmscriptenWebSocketCloseEvent *websocketEvent, void *userData);
-extern EMSCRIPTEN_RESULT emscripten_websocket_set_onclose_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_close_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_websocket_set_onclose_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_close_callback_func callback, pthread_t targetThread);
 
 #define emscripten_websocket_set_onopen_callback(socket, userData, callback)    emscripten_websocket_set_onopen_callback_on_thread(   (socket), (userData), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 #define emscripten_websocket_set_onerror_callback(socket, userData, callback)   emscripten_websocket_set_onerror_callback_on_thread(  (socket), (userData), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)


### PR DESCRIPTION
These are rendundant in function declartions and just add
visual noise.  For example, musl headers don't use them.