### PR TITLE
cache.py: Check for existence of file before acquiring the lock. NFC

### DIFF
--- a/tools/cache.py
+++ b/tools/cache.py
@@ -106,6 +106,10 @@ class Cache(object):
     else:
       cachename = os.path.join(self.dirname, shortname)
     cachename = os.path.abspath(cachename)
+    # Check for existence before taking the lock in case we can avoid the
+    # lock completely.
+    if os.path.exists(cachename) and not force:
+      return cachename
 
     self.acquire_cache_lock()
     try:


### PR DESCRIPTION
This seems like a all around win since once the cache is
populated we avoid that lock completely.

It also help to mitigate and issue with EM_EXCLUSIVE_CACHE_ACCESS
that I recently found (See #12949).