### PR TITLE
Clear temp dir before running test_split_module

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9750,6 +9750,7 @@ exec "$@"
     self.do_other_test('test_syslog.c')
 
   def test_split_module(self):
+    self.clear()
     self.set_setting('SPLIT_MODULE')
     self.emcc_args += ['-g', '-Wno-experimental']
     self.emcc_args += ['--post-js', path_from_root('tests', 'other', 'test_split_module.post.js')]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9750,7 +9750,6 @@ exec "$@"
     self.do_other_test('test_syslog.c')
 
   def test_split_module(self):
-    self.clear()
     self.set_setting('SPLIT_MODULE')
     self.emcc_args += ['-g', '-Wno-experimental']
     self.emcc_args += ['--post-js', path_from_root('tests', 'other', 'test_split_module.post.js')]
@@ -9762,5 +9761,6 @@ exec "$@"
     wasm_split = os.path.join(building.get_binaryen_bin(), 'wasm-split')
     self.run_process([wasm_split, '--enable-mutable-globals', '--export-prefix=split@', 'test_split_module.wasm.orig', '-o1', 'primary.wasm', '-o2', 'secondary.wasm', '--profile=profile.data'])
 
+    os.remove('test_split_module.wasm')
     os.rename('primary.wasm', 'test_split_module.wasm')
     self.run_js('test_split_module.js')


### PR DESCRIPTION
`os.rename` over an existing file fails on Windows.