### PR TITLE
Remove pthread_self from EXPORTED_RUNTIME_METHODS_SET

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -464,8 +464,7 @@ function exportRuntime() {
     // In pthreads mode, the following functions always need to be exported to
     // Module for closure compiler, and also for MODULARIZE (so worker.js can
     // access them).
-    var threadExports = ['PThread', '_pthread_self'];
-    threadExports.push('wasmMemory');
+    var threadExports = ['PThread', 'wasmMemory'];
     if (!MINIMAL_RUNTIME) {
       threadExports.push('ExitStatus');
     }


### PR DESCRIPTION
This function was moved to native code so it doesn't
make sense anymore to add it to the list of runtime
methods.