### PR TITLE
tests: avoid modifying global JS_ENGINES

### DIFF
--- a/tests/jsrun.py
+++ b/tests/jsrun.py
@@ -9,7 +9,6 @@ import sys
 from subprocess import Popen, PIPE, CalledProcessError
 
 from tools import shared
-from tools.shared import config
 
 WORKING_ENGINES = {} # Holds all configured engines and whether they work: maps path -> True/False
 
@@ -87,12 +86,9 @@ def require_engine(engine):
     sys.exit(1)
 
 
-def run_js(filename, engine=None, args=[],
+def run_js(filename, engine, args=[],
            stdin=None, stdout=PIPE, stderr=None, cwd=None,
            full_output=False, assert_returncode=0, skip_check=False):
-  if not engine:
-    engine = config.JS_ENGINES[0]
-
   # We used to support True here but we no longer do.  Assert here just in case.
   assert(type(assert_returncode) == int)
 


### PR DESCRIPTION
Modifying this global state seems wrong. Its probably safe because when
we run tests in parallel we use seperate processes, but it wouldn't work
if we switched to using threads.

Instead maintain test-local list of JS engines, and also a seperate list
of extra arguments for node and/v8.