### PR TITLE
Fix typo in loadDynamicLibrary

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -526,3 +526,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Wouter van Oortmerssen <wvo@google.com> (copyright owned by Google, LLC)
 * Alexey Sokolov <sokolov@google.com> (copyright owned by Google, LLC)
 * Ivan Romanovski <ivan.romanovski@gmail.com>
+* Max Brunsfeld <maxbrunsfeld@gmail.com>

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -533,7 +533,7 @@ var LibraryDylink = {
       if (flags.fs) {
         var libData = flags.fs.readFile(libFile, {encoding: 'binary'});
         if (!(libData instanceof Uint8Array)) {
-          libData = new Uint8Array(lib_data);
+          libData = new Uint8Array(libData);
         }
         return flags.loadAsync ? Promise.resolve(libData) : libData;
       }


### PR DESCRIPTION
This fixes an error that would occur when calling `loadDynamicLibrary` with an `fs` option where `readFile` did not return a typed array:

```
ReferenceError: lib_data is not defined
```

See https://github.com/emscripten-core/emscripten/pull/12574#issuecomment-738959320