### PR TITLE
Rename loadSideModule back to loadWebAssemblyModule

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -242,12 +242,12 @@ var LibraryBrowser = {
         return !Module.noWasmDecoding && name.endsWith('.so');
       };
       wasmPlugin['handle'] = function(byteArray, name, onload, onerror) {
-        // loadSideModule can not load modules out-of-order, so rather
+        // loadWebAssemblyModule can not load modules out-of-order, so rather
         // than just running the promises in parallel, this makes a chain of
         // promises to run in series.
         this['asyncWasmLoadPromise'] = this['asyncWasmLoadPromise'].then(
           function() {
-            return loadSideModule(byteArray, {loadAsync: true, nodelete: true});
+            return loadWebAssemblyModule(byteArray, {loadAsync: true, nodelete: true});
           }).then(
             function(module) {
               Module['preloadedWasm'][name] = module;

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -250,8 +250,8 @@ var LibraryDylink = {
 
   // Loads a side module from binary data. Returns the module's exports or a
   // progise that resolves to its exports if the loadAsync flag is set.
-  $loadSideModule__deps: ['$loadDynamicLibrary', '$createInvokeFunction', '$getMemory', '$relocateExports', '$resolveGlobalSymbol', '$GOTHandler'],
-  $loadSideModule: function(binary, flags) {
+  $loadWebAssemblyModule__deps: ['$loadDynamicLibrary', '$createInvokeFunction', '$getMemory', '$relocateExports', '$resolveGlobalSymbol', '$GOTHandler'],
+  $loadWebAssemblyModule: function(binary, flags) {
     var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
     assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0asm
     // we should see the dylink section right after the magic number and wasm version
@@ -478,7 +478,7 @@ var LibraryDylink = {
   // If a library was already loaded, it is not loaded a second time. However
   // flags.global and flags.nodelete are handled every time a load request is made.
   // Once a library becomes "global" or "nodelete", it cannot be removed or unloaded.
-  $loadDynamicLibrary__deps: ['$LDSO', '$loadSideModule', '$asmjsMangle', '$fetchBinary'],
+  $loadDynamicLibrary__deps: ['$LDSO', '$loadWebAssemblyModule', '$asmjsMangle', '$fetchBinary'],
   $loadDynamicLibrary: function(lib, flags) {
     if (lib == '__main__' && !LDSO.loadedLibNames[lib]) {
       LDSO.loadedLibs[-1] = {
@@ -557,11 +557,11 @@ var LibraryDylink = {
       // module not preloaded - load lib data and create new module from it
       if (flags.loadAsync) {
         return loadLibData(lib).then(function(libData) {
-          return loadSideModule(libData, flags);
+          return loadWebAssemblyModule(libData, flags);
         });
       }
 
-      return loadSideModule(loadLibData(lib), flags);
+      return loadWebAssemblyModule(loadLibData(lib), flags);
     }
 
     // Module.symbols <- libModule.symbols (flags.global handler)


### PR DESCRIPTION
References https://github.com/emscripten-core/emscripten/pull/12574

In Emscripten 2.0.9, this function was renamed to `loadSideModule`. But one of the wiki pages still [mentions](https://github.com/emscripten-core/emscripten/wiki/WebAssembly-Standalone) `loadWebAssemblyModule`. I think it is useful to consider this function as public, because AFAICT, it is the only way to load a side module and get raw access to the `exports` object of the resulting `WebAssembly.Instance`.

This PR restores the old name for the function.