### PR TITLE
Convert sample batch of browser tests to avoid REPORT_RESULT

### DIFF
--- a/tests/benchmark_utf16.cpp
+++ b/tests/benchmark_utf16.cpp
@@ -63,8 +63,5 @@ int main() {
   }
   double t3 = emscripten_get_now();
   printf("OK. Time: %f (%f).\n", t, t3-t2);
-
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/tests/benchmark_utf8.cpp
+++ b/tests/benchmark_utf8.cpp
@@ -64,8 +64,5 @@ int main() {
   }
   double t3 = emscripten_get_now();
   printf("OK. Time: %f (%f).\n", t, t3-t2);
-
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/tests/unistd/access.c
+++ b/tests/unistd/access.c
@@ -75,9 +75,5 @@ int main() {
   );
 #endif
 
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
-
   return 0;
 }

--- a/tests/unistd/close.c
+++ b/tests/unistd/close.c
@@ -42,8 +42,5 @@ int main() {
   assert(errno == EBADF);
   errno = 0;
 
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
   return 0;
 }

--- a/tests/unistd/unlink.c
+++ b/tests/unistd/unlink.c
@@ -187,8 +187,5 @@ int main() {
   setup();
   test();
 
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
   return EXIT_SUCCESS;
 }

--- a/tests/write_file.c
+++ b/tests/write_file.c
@@ -9,8 +9,5 @@ int main() {
 	char str[256] = {};
 	fgets(str, 255, handle);
 	printf("%s\n", str);
-#ifdef REPORT_RESULT
-	REPORT_RESULT(strcmp(str, "hello from file!"));
-#endif
-	return 0;
+	return strcmp(str, "hello from file!");
 }


### PR DESCRIPTION
For simple browser tests we can just rely on the process
exit code being reported.  I've added a new btest_exit
method so that tests can opt into this new behavior.

This allows test code to be identical whether running
in the browser or outside.