### PR TITLE
Re-throw exception on main thread in PROXY_TO_PTHREAD mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1615,7 +1615,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         building.user_requested_exports += ['exit']
 
       if shared.Settings.PROXY_TO_PTHREAD:
-        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_proxy_main']
+        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_proxy_main', '_emscripten_proxy_main_thread_id']
 
       # pthread stack setup and other necessary utilities
       def include_and_export(name):

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -8,6 +8,9 @@ var LibraryPThread = {
   $PThread__postset: 'if (!ENVIRONMENT_IS_PTHREAD) PThread.initMainThreadBlock();',
   $PThread__deps: ['_emscripten_thread_init',
                    'emscripten_register_main_browser_thread_id',
+#if PROXY_TO_PTHREAD
+                   'emscripten_proxy_main_thread_id',
+#endif
                    '$ERRNO_CODES', 'emscripten_futex_wake', '$killThread',
                    '$cancelThread', '$cleanupThread',
 #if USE_ASAN || USE_LSAN
@@ -369,6 +372,14 @@ var LibraryPThread = {
 
       worker.onerror = function(e) {
         err('pthread sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
+#if PROXY_TO_PTHREAD
+        // If the worker running the main thread generates an error, we want
+        // it to take down the main browser thread too.  Especially on node
+        // we want the process to exit in that case.
+        if (worker.pthread && worker.pthread.thread === _emscripten_proxy_main_thread_id()) {
+          throw e;
+        }
+#endif
       };
 
 #if ENVIRONMENT_MAY_BE_NODE

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -363,6 +363,8 @@ void emscripten_current_thread_process_queued_calls(void);
 
 pthread_t emscripten_main_browser_thread_id(void);
 
+pthread_t emscripten_proxy_main_thread_id(void);
+
 // Synchronously sleeps the calling thread for the given number of milliseconds.
 // Note: Calling this on the main browser thread is _very_ _very_ bad for
 // application logic throttling, because it does not save any battery, it will

--- a/tests/core/pthread/test_proxy_to_pthread_exception.c
+++ b/tests/core/pthread/test_proxy_to_pthread_exception.c
@@ -1,0 +1,6 @@
+#include <emscripten.h>
+
+int main() {
+  EM_ASM(missingFunc());
+  return 0;
+}

--- a/tests/core/pthread/test_proxy_to_pthread_exception.out
+++ b/tests/core/pthread/test_proxy_to_pthread_exception.out
@@ -1,0 +1,1 @@
+ReferenceError: missingFunc is not defined

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8117,6 +8117,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['--pre-js', path_from_root('tests', 'core', 'pthread', 'test_pthread_exit_runtime.pre.js')]
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'test_pthread_exit_runtime.c', assert_returncode=43)
 
+  @node_pthreads
+  def test_proxy_to_pthread_exception(self):
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('PTHREAD_POOL_SIZE', '1')
+    self.do_run_in_out_file_test('tests', 'core', 'pthread', 'test_proxy_to_pthread_exception.c', assert_returncode=NON_ZERO)
+
   def test_emscripten_atomics_stub(self):
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'emscripten_atomics.c')
 


### PR DESCRIPTION
Without this, an exception on the proxied main thread will
be swallowed and the browser main (or node main) thread will
just keep running.