### PR TITLE
Zero sin_zero when writing a sockaddr_in

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -538,3 +538,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Amin Yahyaabadi <aminyahyaabadi74@gmail.com>
 * Adam Leskis <leskis@gmail.com>
 * Raffaele Pertile <raffarti@zoho.com>
+* Patric Stout <github@truebrain.nl>

--- a/src/library.js
+++ b/src/library.js
@@ -2304,6 +2304,9 @@ LibraryManager.library = {
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_family, 'family', 'i16') }}};
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_addr.s_addr, 'addr', 'i32') }}};
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_port, '_htons(port)', 'i16') }}};
+        /* Use makeSetValue instead of memset to avoid adding memset dependency for all users of _write_sockaddr. */
+        {{{ assert(C_STRUCTS.sockaddr_in.__size__ - C_STRUCTS.sockaddr_in.sin_zero == 8), '' }}}
+        {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_zero, '0', 'i64') }}};
         break;
       case {{{ cDefine('AF_INET6') }}}:
         addr = __inet_pton6_raw(addr);

--- a/tests/sockets/test_sin_zero.c
+++ b/tests/sockets/test_sin_zero.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <netdb.h>
+#include <assert.h>
+
+int main() {
+  struct sockaddr_in addr;
+
+  int s = socket(PF_INET, SOCK_STREAM, IPPROTO_TCP);
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(12345);
+  inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr);
+
+  connect(s, (struct sockaddr *)&addr, sizeof(addr));
+
+  struct sockaddr_storage adr_inet;
+  socklen_t len_inet = sizeof adr_inet;
+  memset(&adr_inet, 1, sizeof(adr_inet));
+  getsockname(s, (struct sockaddr *)&adr_inet, &len_inet);
+
+  struct sockaddr_in *adr_inet4 = (struct sockaddr_in *)&adr_inet;
+  for (int i = 0; i < 8; i++) {
+    assert(adr_inet4->sin_zero[i] == 0);
+  }
+
+  puts("success");
+
+  return EXIT_SUCCESS;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8079,6 +8079,9 @@ ok.
   def test_getsockname_addrlen(self):
     self.do_runf(path_from_root('tests', 'sockets', 'test_getsockname_addrlen.c'), 'success')
 
+  def test_sin_zero(self):
+    self.do_runf(path_from_root('tests', 'sockets', 'test_sin_zero.c'), 'success')
+
   def test_getaddrinfo(self):
     self.do_runf(path_from_root('tests', 'sockets', 'test_getaddrinfo.c'), 'success')
 


### PR DESCRIPTION
Although not strictly defined by POSIX, it is done by most (all?)
other implementations, most often in patches over the years as
places got forgotten.
This is mostly useful to allow quick comparing between sockaddr_in
to see if they are the same address.

Fixes #12998

----

I made the change for `write_sockaddr`, as this is basically what the linux kernel is doing too: when ever `sin_family`/`sin_addr`/`sin_port` is written, also write `sin_zero`. But this is open for preference, I guess.

Examples of this can be found throughout libc and the kernel. It is fun to run a `git blame` on those lines, just to see how often this got fixed over time again and again in :)
https://github.com/torvalds/linux/blob/9ff9b0d392ea08090cd1780fb196f36dbb586529/net/ipv4/raw.c#L789