### PR TITLE
Run preRun callbacks on new pthreads

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -356,10 +356,6 @@ if (ENVIRONMENT_IS_PTHREAD) runtimeInitialized = true; // The runtime is hosted 
 #endif
 
 function preRun() {
-#if USE_PTHREADS
-  if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
-#endif
-
 #if expectToReceiveOnModule('preRun')
   if (Module['preRun']) {
     if (typeof Module['preRun'] == 'function') Module['preRun'] = [Module['preRun']];


### PR DESCRIPTION
This is useful for my ongoing work to get dynamic linking working on
threads.  We use addOnPreRun to load side modules before any main module
code is run.  I imagine that other uses would probably also involve
setting up JS-side state before native code runs in which case I think
it makes sense to run these callback on each thread as it starts.

If it turns out that is not desirable we can design an alternative
mechanism for threads, but using this existing one makes the most sense
to me.

To implement this we delay the sending of the "loaded" reply from a new
thread until all the preRun callbacks have completed.