### PR TITLE
Temporarily disable test_metadce_hello_main_module_2

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6791,7 +6791,8 @@ int main() {
     # we don't metadce with linkable code! other modules may want stuff
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [],  10297), # noqa
+    # TODO(sbc): Rename once llvm change rolls
+    #'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [],  10297), # noqa
   })
   def test_metadce_hello(self, *args):
     self.run_metadce_test('hello_world.cpp', *args)


### PR DESCRIPTION
This test needs to be disaled so that a recent llvm change
can roll: https://reviews.llvm.org/D93066

It causes the following diff/failure:

```
AssertionError: Unexpected difference:
--- /b/s/w/ir/k/install/emscripten/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.funcs
+++ /b/s/w/ir/k/install/emscripten/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.funcs.new
@@ -4,7 +4,8 @@
 $__overflow
 $__stdio_write
 $__towrite
-$__wasm_apply_relocs
+$__wasm_apply_data_relocs
+$__wasm_apply_global_relocs
 $__wasm_call_ctors
 $dlmalloc
 $fwrite
```