### PR TITLE
library_pthread_stub: Fix pthread_key_create memory issues

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -529,3 +529,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Max Brunsfeld <maxbrunsfeld@gmail.com>
 * Basil Fierz <basil.fierz@hotmail.com>
 * Rod Hyde <rod@badlydrawngames.com>
+* Aleksey Kliger <aleksey@lambdageek.org> (copyright owned by Microsoft, Inc.)

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -81,7 +81,7 @@ int pthread_key_create(pthread_key_t* key, void (*destructor)(void*)) {
   if (!max_tls_entries) {
     // First time we're called, allocate entry table.
     max_tls_entries = 4;
-    tls_entries = (struct entry_t*)malloc(max_tls_entries * sizeof(void *));
+    tls_entries = (struct entry_t*)malloc(max_tls_entries * sizeof(struct entry_t));
   }
   // Find empty spot.
   size_t entry = 0;
@@ -92,7 +92,7 @@ int pthread_key_create(pthread_key_t* key, void (*destructor)(void*)) {
     // No empty spots, table full: double the table.
     max_tls_entries *= 2;
     tls_entries =
-      (struct entry_t*)realloc(tls_entries, num_tls_entries * sizeof(void *));
+      (struct entry_t*)realloc(tls_entries, max_tls_entries * sizeof(struct entry_t));
   }
   if (entry == num_tls_entries) {
     // No empty spots, but table not full.

--- a/tests/pthread/specific.c
+++ b/tests/pthread/specific.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>
@@ -70,6 +71,28 @@ int main(void)
     rv = pthread_key_delete(key);
     printf("pthread_key_delete just after created = %d\n", rv);
     assert(rv == 0);
+
+    {
+        /* Test creating multiple keys and overflowing the tls_entries array*/
+        const int n = 5;
+        int i;
+
+        pthread_key_t *keys = malloc(sizeof (pthread_key_t) * n);
+        for (i = 0; i < n; ++i) {
+            rv = pthread_key_create(&keys[i], NULL);
+            assert(rv == 0);
+            rv = pthread_setspecific(keys[i], (void*)(intptr_t)(i + 1));
+            assert(rv == 0);
+        }
+
+        for (i = 0; i < n; ++i) {
+            void *d = pthread_getspecific(keys[i]);
+            assert (i+1 == (intptr_t)d);
+            rv = pthread_key_delete(keys[i]);
+            assert(rv == 0);
+        }
+	free (keys);
+    }
 
     return 0;
 }


### PR DESCRIPTION
Allocate `sizeof (struct entry_t)` memory per TLS entry, and when resizing allocate `max_num_entries` for the new buffer.
   Fixes #13012 
