### PR TITLE
tests: switch more tests to btest_exit. NFC.

### DIFF
--- a/tests/asmfs/fopen_write.cpp
+++ b/tests/asmfs/fopen_write.cpp
@@ -38,8 +38,5 @@ int main()
 {
   create_file();
   read_file();
-
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/tests/asmfs/hello_file.cpp
+++ b/tests/asmfs/hello_file.cpp
@@ -29,8 +29,5 @@ int main()
   assert(!strcmp(buffer, "Hello!"));
 
   fclose(file);
-
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/tests/asmfs/read_file_twice.cpp
+++ b/tests/asmfs/read_file_twice.cpp
@@ -35,7 +35,5 @@ int main()
 {
   read_file();
   read_file();
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/tests/asmfs/relative_paths.cpp
+++ b/tests/asmfs/relative_paths.cpp
@@ -32,8 +32,5 @@ int main()
   fread(str, 1, 5, file); assert(errno == 0);
   ret = fclose(file); assert(ret == 0); assert(errno == 0);
   assert(!strcmp(str, "test"));
-
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/tests/binaryen_async.c
+++ b/tests/binaryen_async.c
@@ -14,7 +14,6 @@ int main() {
   int result = EM_ASM_INT({
     return Module.sawAsyncCompilation | 0;
   });
-  REPORT_RESULT(result);
-  return 0;
+  return result;
 }
 

--- a/tests/browser/test_offset_converter.c
+++ b/tests/browser/test_offset_converter.c
@@ -3,7 +3,7 @@
 
 void *get_pc(void) { return __builtin_return_address(0); }
 
-void magic_test_function(void) {
+int magic_test_function(void) {
   int result = EM_ASM_INT({
     function report(x) {
       var xhr = new XMLHttpRequest();
@@ -15,9 +15,9 @@ void magic_test_function(void) {
     report('magic_test_function: converted=' + converted);
     return converted == 'magic_test_function';
   }, get_pc());
-#ifdef REPORT_RESULT
-  REPORT_RESULT(result);
-#endif
+  return result;
 }
 
-int main(void) { magic_test_function(); }
+int main(void) {
+  return magic_test_function();
+}

--- a/tests/core/test_em_asm_signatures.cpp
+++ b/tests/core/test_em_asm_signatures.cpp
@@ -13,8 +13,5 @@ int main()
   ret += MAIN_THREAD_EM_ASM_INT(return $0 + $1 + $2 + $3 + $4 + $5 + $6, 1, 2, 3, 4, 5, 6, 7);
   ret += MAIN_THREAD_EM_ASM_INT(return $0 + $1 + $2 + $3 + $4 + $5 + $6 + $7, 1, 2, 3, 4, 5, 6, 7, 8);
   printf("ret: %d\n", ret);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(ret);
-#endif
   return ret;
 }

--- a/tests/core/test_main_thread_async_em_asm.cpp
+++ b/tests/core/test_main_thread_async_em_asm.cpp
@@ -36,7 +36,5 @@ int main()
     return Module.totalStuffSent == 675;
   })) {}
 #endif
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/tests/core/test_strftime.cpp
+++ b/tests/core/test_strftime.cpp
@@ -12,9 +12,7 @@ void test(int result, const char* comment, const char* parsed = "") {
   printf("%s: %d\n", comment, result);
   if (!result) {
     printf("\nERROR: %s (\"%s\")\n", comment, parsed);
-#ifdef REPORT_RESULT
     abort();
-#endif
   }
 }
 
@@ -254,7 +252,5 @@ int main() {
   size = strftime(s, 10, "%I %M %p", &tm);
   test(!cmp(s, "12 01 PM"), "strftime test #35", s);
 
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  return 0;
 }

--- a/tests/full_es2_sdlproc.c
+++ b/tests/full_es2_sdlproc.c
@@ -731,7 +731,5 @@ main(int argc, char *argv[])
    gears_init();
    gears_draw();
 
-   REPORT_RESULT(1);
-
-   return 0;
+   return 1;
 }

--- a/tests/other/test_mmap_and_munmap.cpp
+++ b/tests/other/test_mmap_and_munmap.cpp
@@ -269,10 +269,6 @@ int main() {
     }
 
     printf("tests_run: %d failures: %d\n", tests_run, failures);
-
-#ifdef REPORT_RESULT
-    REPORT_RESULT(failures);
-#endif
-    return 0;
+    return failures;
 }
 

--- a/tests/other/test_mmap_and_munmap_anonymous.cpp
+++ b/tests/other/test_mmap_and_munmap_anonymous.cpp
@@ -82,10 +82,6 @@ int main() {
 
     printf("tests_run: %d\n", tests_run);
     printf("failures: %d\n", failures);
-
-#ifdef REPORT_RESULT
-    REPORT_RESULT(failures);
-#endif
-    return 0;
+    return failures;
 }
 

--- a/tests/sdl_pumpevents.c
+++ b/tests/sdl_pumpevents.c
@@ -72,6 +72,5 @@ int main(int argc, char *argv[])
    result += loop2();
    emscripten_run_script("keydown(65);"); // A
    result += alphakey();
-   REPORT_RESULT(result);
-   return 0;
+   return result;
 }

--- a/tests/sdl_quit.c
+++ b/tests/sdl_quit.c
@@ -27,8 +27,6 @@ void one() {
   }
 }
 
-void main_2();
-
 int main() {
   SDL_Init(SDL_INIT_VIDEO);
   SDL_Surface *screen = SDL_SetVideoMode(600, 450, 32, SDL_HWSURFACE);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1449,7 +1449,7 @@ keydown(100);keyup(100); // trigger the end
         document.dispatchEvent(event);
       }
     ''')
-    self.btest('sdl_pumpevents.c', expected='7', args=['--pre-js', 'pre.js', '-lSDL', '-lGL'])
+    self.btest_exit('sdl_pumpevents.c', expected='7', args=['--pre-js', 'pre.js', '-lSDL', '-lGL'])
 
   def test_sdl_canvas_size(self):
     self.btest('sdl_canvas_size.c', expected='1',
@@ -1728,7 +1728,7 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_fulles2_sdlproc(self):
-    self.btest('full_es2_sdlproc.c', '1', args=['-s', 'GL_TESTING', '-DHAVE_BUILTIN_SINCOS', '-s', 'FULL_ES2=1', '-lGL', '-lSDL', '-lglut'])
+    self.btest_exit('full_es2_sdlproc.c', '1', args=['-s', 'GL_TESTING', '-DHAVE_BUILTIN_SINCOS', '-s', 'FULL_ES2', '-lGL', '-lSDL', '-lglut'])
 
   @requires_graphics_hardware
   def test_glgears_deriv(self):
@@ -4047,15 +4047,15 @@ window.close = function() {
 
   # Tests MAIN_THREAD_EM_ASM_INT() function call signatures.
   def test_main_thread_em_asm_signatures(self):
-    self.btest(path_from_root('tests', 'core', 'test_em_asm_signatures.cpp'), expected='121', args=[])
+    self.btest_exit(path_from_root('tests', 'core', 'test_em_asm_signatures.cpp'), expected='121', args=[])
 
   @requires_threads
   def test_main_thread_em_asm_signatures_pthreads(self):
-    self.btest(path_from_root('tests', 'core', 'test_em_asm_signatures.cpp'), expected='121', args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'ASSERTIONS'])
+    self.btest_exit(path_from_root('tests', 'core', 'test_em_asm_signatures.cpp'), expected='121', args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'ASSERTIONS'])
 
   @requires_threads
   def test_main_thread_async_em_asm(self):
-    self.btest(path_from_root('tests', 'core', 'test_main_thread_async_em_asm.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'ASSERTIONS'])
+    self.btest_exit(path_from_root('tests', 'core', 'test_main_thread_async_em_asm.cpp'), 0, args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'ASSERTIONS'])
 
   @requires_threads
   def test_main_thread_em_asm_blocking(self):
@@ -4146,11 +4146,11 @@ window.close = function() {
       (['-O1', '-s', 'WASM_ASYNC_COMPILATION=0'], 0), # force it off
     ]:
       print(opts, expect)
-      self.btest('binaryen_async.c', expected=str(expect), args=common_args + opts)
+      self.btest_exit('binaryen_async.c', expected=expect, args=common_args + opts)
     # Ensure that compilation still works and is async without instantiateStreaming available
     no_streaming = ' <script> WebAssembly.instantiateStreaming = undefined;</script>'
     shell_with_script('shell.html', 'shell.html', no_streaming + script)
-    self.btest('binaryen_async.c', expected='1', args=common_args)
+    self.btest_exit('binaryen_async.c', expected=1, args=common_args)
 
   # Test that implementing Module.instantiateWasm() callback works.
   def test_manual_wasm_instantiate(self):
@@ -4446,18 +4446,18 @@ window.close = function() {
     # Test basic file loading and the valid character set for files.
     ensure_dir('dirrey')
     shutil.copyfile(path_from_root('tests', 'asmfs', 'hello_file.txt'), os.path.join(self.get_dir(), 'dirrey', 'hello file !#$%&\'()+,-.;=@[]^_`{}~ %%.txt'))
-    self.btest('asmfs/hello_file.cpp', expected='0', args=['-s', 'ASMFS', '-s', 'WASM=0', '-s', 'USE_PTHREADS', '-s', 'FETCH_DEBUG', '-s', 'PROXY_TO_PTHREAD'])
+    self.btest_exit('asmfs/hello_file.cpp', expected='0', args=['-s', 'ASMFS', '-s', 'WASM=0', '-s', 'USE_PTHREADS', '-s', 'FETCH_DEBUG', '-s', 'PROXY_TO_PTHREAD'])
 
   @requires_asmfs
   @requires_threads
   def test_asmfs_read_file_twice(self):
     shutil.copyfile(path_from_root('tests', 'asmfs', 'hello_file.txt'), 'hello_file.txt')
-    self.btest('asmfs/read_file_twice.cpp', expected='0', args=['-s', 'ASMFS', '-s', 'WASM=0', '-s', 'USE_PTHREADS', '-s', 'FETCH_DEBUG', '-s', 'PROXY_TO_PTHREAD'])
+    self.btest_exit('asmfs/read_file_twice.cpp', expected='0', args=['-s', 'ASMFS', '-s', 'WASM=0', '-s', 'USE_PTHREADS', '-s', 'FETCH_DEBUG', '-s', 'PROXY_TO_PTHREAD'])
 
   @requires_asmfs
   @requires_threads
   def test_asmfs_fopen_write(self):
-    self.btest('asmfs/fopen_write.cpp', expected='0', args=['-s', 'ASMFS', '-s', 'WASM=0', '-s', 'USE_PTHREADS', '-s', 'FETCH_DEBUG'])
+    self.btest_exit('asmfs/fopen_write.cpp', expected='0', args=['-s', 'ASMFS', '-s', 'WASM=0', '-s', 'USE_PTHREADS', '-s', 'FETCH_DEBUG'])
 
   @requires_asmfs
   @requires_threads
@@ -4498,7 +4498,7 @@ window.close = function() {
   @requires_asmfs
   @requires_threads
   def test_asmfs_relative_paths(self):
-    self.btest('asmfs/relative_paths.cpp', expected='0', args=['-s', 'ASMFS', '-s', 'WASM=0', '-s', 'USE_PTHREADS', '-s', 'FETCH_DEBUG'])
+    self.btest_exit('asmfs/relative_paths.cpp', expected='0', args=['-s', 'ASMFS', '-s', 'WASM=0', '-s', 'USE_PTHREADS', '-s', 'FETCH_DEBUG'])
 
   @requires_threads
   def test_pthread_locale(self):
@@ -4869,7 +4869,7 @@ window.close = function() {
   @requires_threads
   def test_offset_converter(self, *args):
     try:
-      self.btest(path_from_root('tests', 'browser', 'test_offset_converter.c'), '1', args=['-s', 'USE_OFFSET_CONVERTER', '-g4', '-s', 'PROXY_TO_PTHREAD', '-s', 'USE_PTHREADS'])
+      self.btest_exit(path_from_root('tests', 'browser', 'test_offset_converter.c'), '1', args=['-s', 'USE_OFFSET_CONVERTER', '-g4', '-s', 'PROXY_TO_PTHREAD', '-s', 'USE_PTHREADS'])
     except Exception as e:
       # dump the wasm file; this is meant to help debug #10539 on the bots
       print(self.run_process([os.path.join(building.get_binaryen_bin(), 'wasm-opt'), 'test.wasm', '-g', '--print', '-all'], stdout=PIPE).stdout)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4055,7 +4055,7 @@ window.close = function() {
 
   @requires_threads
   def test_main_thread_async_em_asm(self):
-    self.btest_exit(path_from_root('tests', 'core', 'test_main_thread_async_em_asm.cpp'), 0, args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'ASSERTIONS'])
+    self.btest_exit(path_from_root('tests', 'core', 'test_main_thread_async_em_asm.cpp'), expected=0, args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'ASSERTIONS'])
 
   @requires_threads
   def test_main_thread_em_asm_blocking(self):


### PR DESCRIPTION
Thus avoiding the need for REPORT_RESULT.