### PR TITLE
Cleanup proxy_main

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1605,7 +1605,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         building.user_requested_exports += ['exit']
 
       if shared.Settings.PROXY_TO_PTHREAD:
-        shared.Settings.EXPORTED_FUNCTIONS += ['_proxy_main']
+        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_proxy_main']
 
       # pthread stack setup and other necessary utilities
       def include_and_export(name):

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -21,7 +21,7 @@ function run() {
   // User requested the PROXY_TO_PTHREAD option, so call a stub main which
   // pthread_create()s a new thread that will call the user's real main() for
   // the application.
-  var ret = _proxy_main();
+  var ret = _emscripten_proxy_main();
 #else
   var ret = _main();
 


### PR DESCRIPTION
- rename the non-static proxy_main to emscripten_proxy_main.

- Remove emscripten prefix from internal thread main function
  and mark it as static.

- Avoid pointless pthread arguments.  The arguments are being passed via
  a fixed global variable anyway, so its simpler to just refer to those
  globals directly.

- Remove the fallback path for when threads are not available.  If a
  program is compiled with PROXY_TO_PTHREADS (and USE_PTHREADS) its 
  very unlikely to work if threads are not available at runtime (i.e. if
  SharedArrayBuffer is not present).  We don't support building a programs
  for threads and then running it in a non-threaded environment.  We could
  add such support to emscripten but today we just assert at runtime if
  you try do this.   We still have a fallback for when pthread_create
  itself fails, but I hope we can remove that in a followup.