### PR TITLE
Suggest the next multiple of 64KB when the user provides us with a memory value that isn't one

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -529,3 +529,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Max Brunsfeld <maxbrunsfeld@gmail.com>
 * Basil Fierz <basil.fierz@hotmail.com>
 * Rod Hyde <rod@badlydrawngames.com>
+* Amédée d'Aboville <amedee.daboville@gmail.com>

--- a/emcc.py
+++ b/emcc.py
@@ -212,6 +212,9 @@ def base64_encode(b):
   else:
     return b64
 
+def round_up_to_64kb(num):
+    return ((num // 65536) + 1) * 65536
+
 
 class OFormat(Enum):
   WASM = 1
@@ -1646,15 +1649,15 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
 
     if shared.Settings.INITIAL_MEMORY % 65536 != 0:
-      exit_with_error('For wasm, INITIAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.INITIAL_MEMORY))
+      exit_with_error('For wasm, INITIAL_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.INITIAL_MEMORY) + '. The next highest multiple of 64KB is ' + str(round_up_to_64kb(shared.Settings.INITIAL_MEMORY)))
     if shared.Settings.INITIAL_MEMORY >= 2 * 1024 * 1024 * 1024:
       exit_with_error('INITIAL_MEMORY must be less than 2GB due to current spec limitations')
     if shared.Settings.INITIAL_MEMORY < shared.Settings.TOTAL_STACK:
       exit_with_error('INITIAL_MEMORY must be larger than TOTAL_STACK, was ' + str(shared.Settings.INITIAL_MEMORY) + ' (TOTAL_STACK=' + str(shared.Settings.TOTAL_STACK) + ')')
     if shared.Settings.MAXIMUM_MEMORY != -1 and shared.Settings.MAXIMUM_MEMORY % 65536 != 0:
-      exit_with_error('MAXIMUM_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.MAXIMUM_MEMORY))
+      exit_with_error('MAXIMUM_MEMORY must be a multiple of 64KB, was ' + str(shared.Settings.MAXIMUM_MEMORY) + '. The next highest multiple of 64KB is ' + str(round_up_to_64kb(shared.Settings.MAXIMUM_MEMORY)))
     if shared.Settings.MEMORY_GROWTH_LINEAR_STEP != -1 and shared.Settings.MEMORY_GROWTH_LINEAR_STEP % 65536 != 0:
-      exit_with_error('MEMORY_GROWTH_LINEAR_STEP must be a multiple of 64KB, was ' + str(shared.Settings.MEMORY_GROWTH_LINEAR_STEP))
+      exit_with_error('MEMORY_GROWTH_LINEAR_STEP must be a multiple of 64KB, was ' + str(shared.Settings.MEMORY_GROWTH_LINEAR_STEP) + '. The next highest multiple of 64KB is ' + str(round_up_to_64kb(shared.Settings.MEMORY_GROWTH_LINEAR_STEP)))
     if shared.Settings.USE_PTHREADS and shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.MAXIMUM_MEMORY == -1:
       exit_with_error('If pthreads and memory growth are enabled, MAXIMUM_MEMORY must be set')
 


### PR DESCRIPTION
Hi, thanks for Emscripten!

Small quality of life improvement:

This change suggest to the user the next multiple of 64KB to provide when they give a number for `INITIAL_MEMORY`, `MAXIMUM_MEMORY`, or `MEMORY_GROWTH_LINEAR_STEP` that is not a multiple of 64K: 

emcc: error: For wasm, INITIAL_MEMORY must be a multiple of 64KB, was 90507904. The next highest multiple of 64KB is 90570752
