### PR TITLE
Fix null pointer read in realpath

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -303,7 +303,7 @@ var SyscallsLibrary = {
   },
   __sys_open: function(path, flags, varargs) {
     var pathname = SYSCALLS.getStr(path);
-    var mode = SYSCALLS.get();
+    var mode = varargs ? SYSCALLS.get() : 0;
     var stream = FS.open(pathname, flags, mode);
     return stream.fd;
   },

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5796,24 +5796,21 @@ mergeInto(LibraryManager.library, {
 #include <stdio.h>
 #include <errno.h>
 
-#define TEST_PATH "/boot/README.txt"
-
 int main(int argc, char **argv) {
-  errno = 0;
-  char *t_realpath_buf = realpath(TEST_PATH, NULL);
-  if (NULL == t_realpath_buf) {
+  char *t_realpath_buf = realpath("/boot/README.txt", NULL);
+  if (!t_realpath_buf) {
     perror("Resolve failed");
     return 1;
-  } else {
-    printf("Resolved: %s\n", t_realpath_buf);
-    free(t_realpath_buf);
-    return 0;
   }
+
+  printf("Resolved: %s\n", t_realpath_buf);
+  free(t_realpath_buf);
+  return 0;
 }
 ''')
     ensure_dir('boot')
     create_test_file(os.path.join('boot', 'README.txt'), ' ')
-    self.run_process([EMCC, 'src.c', '--embed-file', 'boot'])
+    self.run_process([EMCC, 'src.c', '-s', 'SAFE_HEAP', '--embed-file', 'boot'])
     self.assertContained('Resolved: /boot/README.txt', self.run_js('a.out.js'))
 
   def test_realpath_nodefs(self):


### PR DESCRIPTION
Calling realpath with SAFE_HEAP enabled was causing a read of
address zero because realpath calls sys_open with a third argument
and therefor without any varargs at all

Fixes: #12999