### PR TITLE
Followup on proxy_main cleanup

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -185,15 +185,19 @@ function callMain(args) {
     Module.realPrint('main() took ' + (Date.now() - start) + ' milliseconds');
 #endif
 
-    // In PROXY_TO_PTHREAD builds, we should never exit the runtime below, as execution is asynchronously handed
-    // off to a pthread.
-#if !PROXY_TO_PTHREAD
+    // In PROXY_TO_PTHREAD builds, we should never exit the runtime below, as
+    // execution is asynchronously handed off to a pthread.
+#if PROXY_TO_PTHREAD
+#if ASSERTIONS
+    assert(ret == 0, '_emscripten_proxy_main failed to start proxy thread: ' + ret);
+#endif
+#else
 #if ASYNCIFY
     // if we are saving the stack, then do not call exit, we are not
     // really exiting now, just unwinding the JS stack
     if (!noExitRuntime) {
 #endif // ASYNCIFY
-    // if we're not running an evented main loop, it's time to exit
+      // if we're not running an evented main loop, it's time to exit
       exit(ret, /* implicit = */ true);
 #if ASYNCIFY
     }

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -937,14 +937,6 @@ int emscripten_proxy_main(int argc, char** argv) {
   pthread_t thread;
   int rc = pthread_create(&thread, &attr, _main_thread, NULL);
   pthread_attr_destroy(&attr);
-  // TODO(sbc): Remove this fallback.  This is still required today as a or
-  // test_html5_webgl_api which sets OFFSCREENCANVAS_SUPPORT and
-  // PROXY_TO_PTHREAD but does not set OFFSCREEN_FRAMEBUFFER.  In this case
-  // threead creation will fail on firefox (due to lack of OffscreenCanvas
-  // support) and we fall back to running the code directly on the main thread.
-  if (rc) {
-    return __call_main(argc, argv);
-  }
   return rc;
 }
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2626,6 +2626,8 @@ Module["preRun"].push(function () {
     for mode in [['-s', 'OFFSCREENCANVAS_SUPPORT=1', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'],
                  ['-s', 'OFFSCREEN_FRAMEBUFFER=1', '-s', 'USE_PTHREADS=1', '-s', 'PROXY_TO_PTHREAD=1'],
                  []]:
+      if 'OFFSCREENCANVAS_SUPPORT=1' in mode and os.getenv('EMTEST_LACKS_OFFSCREEN_CANVAS'):
+        continue
       self.btest(path_from_root('tests', 'html5_webgl.c'), args=['-s', 'MAX_WEBGL_VERSION=2', '-lGL'] + mode, expected='0')
 
   def test_webgl2_ubos(self):


### PR DESCRIPTION
We had a single browser test that sets `OFFSCREENCANVAS_SUPPORT`
but wasn't decorated with `@requires_offscreen_canvas`.

This test was relying on the behavior emscripten_proxy_main where
it would end up running main directly if pthread_create failed. In this
case pthread_create fails because its tries to setup the offscreen canvas
but that fallback ends up running the code on the main thread.  I seems
to me that having such a fall back confusing.  If USE_PTHREADS is requested
along with  OFFSCREENCANVAS_SUPPORT is seems more reasonable to
simply fail those are available.

This change avoids running that test when offscreen canvas is
not available and removes the fallback from emscripten_proxy_main.