### PR TITLE
Make `wasmBinaryFile` a parameter to `createWasm`

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -785,7 +785,7 @@ def create_module(sending, receiving, invoke_funcs, metadata):
     module.append('Asyncify.instrumentWasmImports(asmLibraryArg);\n')
 
   if not shared.Settings.MINIMAL_RUNTIME:
-    module.append("var asm = createWasm();\n")
+    module.append(f"var asm = createWasm('{shared.Settings.WASM_BINARY_FILE}');\n")
 
   module.append(receiving)
   module.append(invoke_wrappers)

--- a/src/library.js
+++ b/src/library.js
@@ -3427,7 +3427,7 @@ LibraryManager.library = {
 #if MINIMAL_RUNTIME
     return stringToUTF8('{{{ TARGET_BASENAME }}}.wasm', buf, length);
 #else
-    return stringToUTF8(wasmBinaryFile, buf, length);
+    return stringToUTF8('{{{ WASM_BINARY_FILE }}}', buf, length);
 #endif
   },
 

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -350,12 +350,10 @@ mergeInto(LibraryManager.library, {
 
   emscripten_lazy_load_code: function() {
     Asyncify.handleSleep(function(wakeUp) {
-      // Update the expected wasm binary file to be the lazy one.
-      wasmBinaryFile += '.lazy.wasm';
       // Add a callback for when all run dependencies are fulfilled, which happens when async wasm loading is done.
       dependenciesFulfilled = wakeUp;
       // Load the new wasm.
-      asm = createWasm();
+      asm = createWasm('{{{ WASM_BINARY_FILE }}}' + '.lazy.wasm');
     });
   },
 

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -96,7 +96,7 @@ WasmSourceMap.prototype.normalizeOffset = function (offset) {
 }
 
 var wasmSourceMapFile = '{{{ WASM_BINARY_FILE }}}.map';
-if (!isDataURI(wasmBinaryFile)) {
+if (!isDataURI(wasmSourceMapFile)) {
   wasmSourceMapFile = locateFile(wasmSourceMapFile);
 }
 


### PR DESCRIPTION
Upcoming wasm-split integration work will have to do most of the work of
`createWasm` twice for different modules. This preparatory PR makes it cleaner
to call `createWasm` multiple times.