### PR TITLE
[Dylink] Remove a racy assertion

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -395,22 +395,12 @@ var LibraryDylink = {
         'env': proxy,
         {{{ WASI_MODULE_NAME }}}: proxy,
       };
-#if ASSERTIONS
-      var oldTable = [];
-      for (var i = 0; i < tableBase; i++) {
-        oldTable.push(table.get(i));
-      }
-#endif
 
       function postInstantiation(instance) {
 #if ASSERTIONS
         // the table should be unchanged
         assert(table === originalTable);
         assert(table === wasmTable);
-        // the old part of the table should be unchanged
-        for (var i = 0; i < tableBase; i++) {
-          assert(table.get(i) === oldTable[i], 'old table entries must remain the same');
-        }
         // verify that the new table region was filled in
         for (var i = 0; i < tableSize; i++) {
           assert(table.get(tableBase + i) !== undefined, 'table entry was not filled in');


### PR DESCRIPTION
If 2 side modules are loaded, A and B, and `loadModule` is called on A, then B,
then it is possible that if instantiation is done *async* here then the
`postInstantiation()` callbacks may happen in the reverse order, racily. If that
happens, the extra assertions on the table not changing can fire incorrectly -
the other parts of the table will appear to have changed meanwhile, but for
valid reasons.

Fixes #13054
Fixes #11458