### PR TITLE
Use C atomics in library_pthread.c

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -9,6 +9,7 @@
 
 #include <inttypes.h>
 #include <pthread.h>
+
 #include <emscripten/html5.h>
 
 #ifdef __cplusplus
@@ -139,7 +140,7 @@ typedef struct em_queued_call
 {
   int functionEnum;
   void *functionPtr;
-  int operationDone;
+  _Atomic int operationDone;
   em_variant_val args[EM_QUEUED_JS_CALL_MAX_ARGS];
   em_variant_val returnValue;
 

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -15,6 +15,7 @@
 #include <math.h>
 #include <poll.h>
 #include <pthread.h>
+#include <stdatomic.h>
 #include <stdarg.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -165,6 +166,7 @@ static em_queued_call* em_queued_call_malloc() {
   }
   return call;
 }
+
 static void em_queued_call_free(em_queued_call* call) {
   if (call)
     free(call->satelliteData);
@@ -355,8 +357,8 @@ static void _do_call(em_queued_call* q) {
 typedef struct CallQueue {
   void* target_thread;
   em_queued_call** call_queue;
-  int call_queue_head; // Shared data synchronized by call_queue_lock.
-  int call_queue_tail;
+  atomic_int call_queue_head; // Shared data synchronized by call_queue_lock.
+  atomic_int call_queue_tail;
   struct CallQueue* next;
 } CallQueue;
 
@@ -366,9 +368,8 @@ typedef struct CallQueue {
 static pthread_mutex_t call_queue_lock = PTHREAD_MUTEX_INITIALIZER;
 static CallQueue* callQueue_head = 0;
 
-static CallQueue* GetQueue(
-  void* target) // Not thread safe, call while having call_queue_lock obtained.
-{
+// Not thread safe, call while having call_queue_lock obtained.
+static CallQueue* GetQueue(void* target) {
   assert(target);
   CallQueue* q = callQueue_head;
   while (q && q->target_thread != target)
@@ -376,9 +377,8 @@ static CallQueue* GetQueue(
   return q;
 }
 
-static CallQueue* GetOrAllocateQueue(
-  void* target) // Not thread safe, call while having call_queue_lock obtained.
-{
+// Not thread safe, call while having call_queue_lock obtained.
+static CallQueue* GetOrAllocateQueue(void* target) {
   CallQueue* q = GetQueue(target);
   if (q)
     return q;
@@ -403,14 +403,14 @@ static CallQueue* GetOrAllocateQueue(
 EMSCRIPTEN_RESULT emscripten_wait_for_call_v(em_queued_call* call, double timeoutMSecs) {
   int r;
 
-  int done = emscripten_atomic_load_u32(&call->operationDone);
+  int done = atomic_load(&call->operationDone);
   if (!done) {
     double now = emscripten_get_now();
     double waitEndTime = now + timeoutMSecs;
     emscripten_set_current_thread_status(EM_THREAD_STATUS_WAITPROXY);
     while (!done && now < waitEndTime) {
       r = emscripten_futex_wait(&call->operationDone, 0, waitEndTime - now);
-      done = emscripten_atomic_load_u32(&call->operationDone);
+      done = atomic_load(&call->operationDone);
       now = emscripten_get_now();
     }
     emscripten_set_current_thread_status(EM_THREAD_STATUS_RUNNING);
@@ -470,8 +470,8 @@ int _emscripten_do_dispatch_to_thread(
     q->call_queue = malloc(
       sizeof(em_queued_call*) * CALL_QUEUE_SIZE); // Shared data synchronized by call_queue_lock.
 
-  int head = emscripten_atomic_load_u32((void*)&q->call_queue_head);
-  int tail = emscripten_atomic_load_u32((void*)&q->call_queue_tail);
+  int head = atomic_load(&q->call_queue_head);
+  int tail = atomic_load(&q->call_queue_tail);
   int new_tail = (tail + 1) % CALL_QUEUE_SIZE;
 
   while (new_tail == head) { // Queue is full?
@@ -482,8 +482,8 @@ int _emscripten_do_dispatch_to_thread(
     if (target_thread == emscripten_main_browser_thread_id()) {
       emscripten_futex_wait((void*)&q->call_queue_head, head, INFINITY);
       pthread_mutex_lock(&call_queue_lock);
-      head = emscripten_atomic_load_u32((void*)&q->call_queue_head);
-      tail = emscripten_atomic_load_u32((void*)&q->call_queue_tail);
+      head = atomic_load(&q->call_queue_head);
+      tail = atomic_load(&q->call_queue_tail);
       new_tail = (tail + 1) % CALL_QUEUE_SIZE;
     } else {
       // For the queues of other threads, just drop the message.
@@ -511,7 +511,7 @@ int _emscripten_do_dispatch_to_thread(
     }
   }
 
-  emscripten_atomic_store_u32((void*)&q->call_queue_tail, new_tail);
+  atomic_store(&q->call_queue_tail, new_tail);
 
   pthread_mutex_unlock(&call_queue_lock);
 
@@ -674,8 +674,8 @@ void emscripten_current_thread_process_queued_calls() {
     return;
   }
 
-  int head = emscripten_atomic_load_u32((void*)&q->call_queue_head);
-  int tail = emscripten_atomic_load_u32((void*)&q->call_queue_tail);
+  int head = atomic_load(&q->call_queue_head);
+  int tail = atomic_load(&q->call_queue_tail);
   while (head != tail) {
     // Assume that the call is heavy, so unlock access to the call queue while it is being
     // performed.
@@ -684,8 +684,8 @@ void emscripten_current_thread_process_queued_calls() {
     pthread_mutex_lock(&call_queue_lock);
 
     head = (head + 1) % CALL_QUEUE_SIZE;
-    emscripten_atomic_store_u32((void*)&q->call_queue_head, head);
-    tail = emscripten_atomic_load_u32((void*)&q->call_queue_tail);
+    atomic_store(&q->call_queue_head, head);
+    tail = atomic_load(&q->call_queue_tail);
   }
   pthread_mutex_unlock(&call_queue_lock);
 


### PR DESCRIPTION
Avoids including emscripten_atomic_store_u32 in all threaded
programs.

We could even drop the explicit load/store calls in favor of just
using builtin operators but i'll leave that as a potential followup.