### PR TITLE
more POSIXish MEMFS: update timestamp in parent on file create/deletion/rename

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -530,3 +530,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Basil Fierz <basil.fierz@hotmail.com>
 * Rod Hyde <rod@badlydrawngames.com>
 * Aleksey Kliger <aleksey@lambdageek.org> (copyright owned by Microsoft, Inc.)
+* Nicolas Ollinger <nopid@free.fr>

--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -89,6 +89,7 @@ mergeInto(LibraryManager.library, {
       // add the new node to the parent
       if (parent) {
         parent.contents[name] = node;
+        parent.timestamp = node.timestamp;
       }
       return node;
     },
@@ -220,12 +221,15 @@ mergeInto(LibraryManager.library, {
         }
         // do the internal rewiring
         delete old_node.parent.contents[old_node.name];
+        old_node.parent.timestamp = Date.now()
         old_node.name = new_name;
         new_dir.contents[new_name] = old_node;
+        new_dir.timestamp = old_node.parent.timestamp;
         old_node.parent = new_dir;
       },
       unlink: function(parent, name) {
         delete parent.contents[name];
+        parent.timestamp = Date.now();
       },
       rmdir: function(parent, name) {
         var node = FS.lookupNode(parent, name);
@@ -233,6 +237,7 @@ mergeInto(LibraryManager.library, {
           throw new FS.ErrnoError({{{ cDefine('ENOTEMPTY') }}});
         }
         delete parent.contents[name];
+        parent.timestamp = Date.now();
       },
       readdir: function(node) {
         var entries = ['.', '..'];

--- a/tests/stat/test_stat.c
+++ b/tests/stat/test_stat.c
@@ -30,11 +30,6 @@ void create_file(const char *path, const char *buffer, int mode) {
   close(fd);
 }
 
-void active_sleep(int delta) {
-    time_t end = time(NULL) + delta;
-    while (time(NULL) < end);
-}
-
 void setup() {
   struct utimbuf t = {1200000000, 1200000000};
   
@@ -56,7 +51,7 @@ void cleanup() {
 void test() {
   int err;
   struct stat s;
-  time_t t[5];
+  struct utimbuf t = {1200000000, 1200000000};
 
   // stat a folder
   memset(&s, 0, sizeof(s));
@@ -171,21 +166,14 @@ void test() {
 
   // create and unlink files inside a directory and check that mtime updates
   mkdir("folder/subdir", 0777);
-  err = stat("folder/subdir", &s);
-  t[0] = s.st_mtime;
-  active_sleep(2);
+  utime("folder/subdir", &t);
   create_file("folder/subdir/file", "abcdef", 0777);
   err = stat("folder/subdir", &s);
-  t[1] = s.st_mtime;
-  err = stat("folder/subdir/file", &s);
-  t[2] = s.st_mtime;
-  assert(t[1] > t[0]);
-  assert(t[2] == t[1]);
-  active_sleep(2);
+  assert(s.st_mtime != 1200000000);
+  utime("folder/subdir", &t);
   unlink("folder/subdir/file");
   err = stat("folder/subdir", &s);
-  t[3] = s.st_mtime;
-  assert(t[3] > t[1]);
+  assert(s.st_mtime != 1200000000);
 
   puts("success");
 }


### PR DESCRIPTION
tl;dr Modify MEMFS behavior to look more POSIXish: the timestamp of a directory is modified each time a file is created or deleted inside the directory.

This PR comes from the resolution of [caching behavior issues in pyodide](https://github.com/iodide-project/pyodide/issues/737).

On a modern Unix-like system, each file (including directories) has up to 4 timestamps: creation, change, modification and access date and time. Three of them are available through the standard POSIX stat() function call:
```C
    time_t    st_atime;   /* time of last access */
    time_t    st_mtime;   /* time of last modification */
    time_t    st_ctime;   /* time of last status change */
```

In MEMFS there is a single timestamp attribute per node:
```javascript
      node.timestamp = Date.now();
```

In its sourcecode it is accessed only during the following operations:
 1. [`createNode`](https://github.com/emscripten-core/emscripten/blob/af9a5a703464e93e2ae9182e28305c42fef97377/src/library_memfs.js#L88) when it is initialized with `Date.now()`
 2. [`getattr`](https://github.com/emscripten-core/emscripten/blob/af9a5a703464e93e2ae9182e28305c42fef97377/src/library_memfs.js#L181-L183) where the value is read to fill the fields `attr.atime`, `attr.mtime` and `attr.ctime`
 3. [`setattr`](https://github.com/emscripten-core/emscripten/blob/af9a5a703464e93e2ae9182e28305c42fef97377/src/library_memfs.js#L194-L195) where the value is replaced by the field `attr.timestamp` if filled
 4. [`write`](https://github.com/emscripten-core/emscripten/blob/af9a5a703464e93e2ae9182e28305c42fef97377/src/library_memfs.js#L298) where it is updated to `Date.now()` each time some data is written to a file (excluding directories and links that do not support the write operation)

Thus the current semantics of `timestamp` in MEMFS is more like a last modification timestamp for files and a creation timestamp for directories.

My proposal is to modify `createNode` to also update the `timestamp` of the parent directory so that the virtual filesystem behaves like the modification timestamp of a POSIX.1 ([open](https://pubs.opengroup.org/onlinepubs/9699919799/functions/open.html), [unlink](https://pubs.opengroup.org/onlinepubs/9699919799/functions/unlink.html)) compatible filesystem:

> If O_CREAT is set and the file did not previously exist, upon successful completion, open() shall mark for update the last data access, last data modification, and last file status change timestamps of the file and the last data modification and last file status change timestamps of the parent directory.

> Upon successful completion, unlink() shall mark for update the last data modification and last file status change timestamps of the parent directory. Also, if the file's link count is not 0, the last file status change timestamp of the file shall be marked for update.

The change is very minimal, no space overhead and very little time overhead.

Please notice that this is very different from implementing a full POSIX filesystem (space and time overhead) or implementing a separation of access and modification timestamps as discussed in #11454.
