### PR TITLE
tests: Require a source file on disc in btest. NFC.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -936,10 +936,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self.set_setting('MAIN_MODULE')
     self.set_setting('RUNTIME_LINKED_LIBS', ['libb' + so, 'libc' + so])
     do_run(r'''
+      #ifdef __cplusplus
       extern "C" {
+      #endif
       void bfunc();
       void cfunc();
+      #ifdef __cplusplus
       }
+      #endif
 
       int test_main() {
         bfunc();
@@ -1530,16 +1534,9 @@ class BrowserCore(RunnerCore):
     assert expected or reference, 'a btest must either expect an output, or have a reference image'
     if args is None:
       args = []
-    # if we are provided the source and not a path, use that
-    filename_is_src = '\n' in filename
-    src = filename if filename_is_src else ''
     original_args = args[:]
-    if filename_is_src:
-      filepath = os.path.join(self.get_dir(), 'main.c' if force_c else 'main.cpp')
-      with open(filepath, 'w') as f:
-       f.write(src)
-    else:
-      filepath = path_from_root('tests', filename)
+    if not os.path.exists(filename):
+      filename = path_from_root('tests', filename)
     if reference:
       self.reference = reference
       expected = [str(i) for i in range(0, reference_slack + 1)]
@@ -1547,7 +1544,7 @@ class BrowserCore(RunnerCore):
       if not manual_reference:
         args += ['--pre-js', 'reftest.js', '-s', 'GL_TESTING']
     outfile = 'test.html'
-    args = [filepath, '-o', outfile] + args
+    args += [filename, '-o', outfile]
     # print('all args:', args)
     try_delete(outfile)
     self.compile_btest(args, reporting=reporting)

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -232,12 +232,12 @@ class sockets(BrowserCore):
     # generate a large string literal to use as our message
     message = ''
     for i in range(256 * 256 * 2):
-        message += str(chr(ord('a') + (i % 26)))
+      message += str(chr(ord('a') + (i % 26)))
 
     # re-write the client test with this literal (it's too big to pass via command line)
     input_filename = path_from_root('tests', 'sockets', 'test_sockets_echo_client.c')
     input = open(input_filename).read()
-    output = input.replace('#define MESSAGE "pingtothepong"', '#define MESSAGE "%s"' % message)
+    create_test_file('test_sockets_echo_bigdata.c', input.replace('#define MESSAGE "pingtothepong"', '#define MESSAGE "%s"' % message))
 
     harnesses = [
       (CompiledServerHarness(os.path.join('sockets', 'test_sockets_echo_server.c'), [sockets_include, '-DTEST_DGRAM=0'], 49172), 0),
@@ -249,7 +249,7 @@ class sockets(BrowserCore):
 
     for harness, datagram in harnesses:
       with harness:
-        self.btest(output, expected='0', args=[sockets_include, '-DSOCKK=%d' % harness.listen_port, '-DTEST_DGRAM=%d' % datagram], force_c=True)
+        self.btest('test_sockets_echo_bigdata.c', expected='0', args=[sockets_include, '-DSOCKK=%d' % harness.listen_port, '-DTEST_DGRAM=%d' % datagram], force_c=True)
 
   @no_windows('This test is Unix-specific.')
   @unittest.skip('fails on python3 - ws library may need to be updated')


### PR DESCRIPTION
This change drops support for compiling from a string, which was only
used in one or two places.   This matches recent changes to the
regular test runner that makes it easier to debug tests (since the
full sources always exists on disk).