### PR TITLE
Prefer `node` over `nodejs` in PATH.

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -176,7 +176,7 @@ def generate_config(path, first_time=False):
   llvm_root = os.path.dirname(which('llvm-dis') or '/usr/bin/llvm-dis')
   config_file = config_file.replace('\'{{{ LLVM_ROOT }}}\'', repr(llvm_root))
 
-  node = which('nodejs') or which('node') or 'node'
+  node = which('node') or which('nodejs') or 'node'
   config_file = config_file.replace('\'{{{ NODE }}}\'', repr(node))
 
   abspath = os.path.abspath(os.path.expanduser(path))


### PR DESCRIPTION
Older debian/ubuntu systems used to use `nodejs` to avoid conflict
with another package containing a node binary.   However, if we
search for nodejs first we always end up finding the system package
even if the user explictly has a downloaded version of node in their
path.

This change continues to support the old `nodejs` name for users of
older debian/ubuntu systems but also prefers `node` since it not
uncommon to use official node binaries.

See https://github.com/WebAssembly/binaryen/pull/3164