### PR TITLE
Fix usage or threadInfoStruct JS variable that was removed in #12853 

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1526,6 +1526,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         '__emscripten_do_dispatch_to_thread',
         '__emscripten_main_thread_futex',
         '__emscripten_thread_init',
+        '_emscripten_current_thread_process_queued_calls',
         '_emscripten_futex_wake',
         '_emscripten_get_global_libc',
         '_emscripten_main_browser_thread_id',
@@ -1538,6 +1539,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         '_emscripten_tls_init',
         '_pthread_self',
       ]
+      # Some of these symbols are using by worker.js but otherwise unreferenced.
+      # Because emitDCEGraph only considered the main js file, and not worker.js
+      # we have explictly mark these symbols as user-exported so that they will
+      # kept alive through DCE.
+      # TODO: Find a less hacky way to do this, perhaps by also scanning worker.js
+      # for roots.
+      building.user_requested_exports.append('_emscripten_tls_init')
+      building.user_requested_exports.append('_emscripten_current_thread_process_queued_calls')
 
       # set location of worker.js
       shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'

--- a/tests/browser_reporting.js
+++ b/tests/browser_reporting.js
@@ -10,7 +10,9 @@ function reportResultToServer(result, sync, port) {
   }
   reportResultToServer.reported = true;
   var xhr = new XMLHttpRequest();
-  if (hasModule && Module['pageThrewException']) result = 12345;
+  if (hasModule && Module['pageThrewException']) {
+    result = 'pageThrewException';
+  }
   xhr.open('GET', 'http://localhost:' + port + '/report_result?' + result, !sync);
   xhr.send();
   if (typeof window === 'object' && window && hasModule && !Module['pageThrewException'] /* for easy debugging, don't close window on failure */) setTimeout(function() { window.close() }, 1000);

--- a/tests/other/metadce/minimal_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.exports
+++ b/tests/other/metadce/minimal_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.exports
@@ -10,6 +10,7 @@ I
 J
 K
 L
+M
 r
 s
 t

--- a/tests/pthread/test_pthread_dispatch_after_exit.c
+++ b/tests/pthread/test_pthread_dispatch_after_exit.c
@@ -1,0 +1,45 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+#include "emscripten/threading.h"
+#include "emscripten.h"
+
+static _Atomic int doneShutdown;
+static _Atomic int doneEntry;
+static pthread_t mythread;
+
+void *ThreadMain(void *threadid) {
+  puts("hello world");
+  doneEntry = 1;
+  emscripten_exit_with_live_runtime();
+  return NULL;
+}
+
+void Shutdown() {
+  puts("got Shutdown");
+  doneShutdown = 1;
+}
+
+void looper() {
+  static int framecount = 0;
+  framecount++;
+  if (doneEntry) {
+    puts("looper() : running Shutdown on thread");
+    int rc = emscripten_dispatch_to_thread(mythread, EM_FUNC_SIG_V, Shutdown, NULL);
+    assert(rc == 0);
+    doneEntry = 0;
+  }
+  if (doneShutdown) {
+    puts("looper() : done Shutdown exiting");
+    emscripten_force_exit(0);
+  }
+}
+
+int main(int argc, char* argv[]) {
+  int rc = pthread_create(&mythread, NULL, ThreadMain, (void *)0);
+  assert(rc == 0);
+  emscripten_set_main_loop(looper, 10, 0);
+  return 0;
+}

--- a/tests/pthread/test_pthread_dispatch_after_exit.out
+++ b/tests/pthread/test_pthread_dispatch_after_exit.out
@@ -1,0 +1,4 @@
+hello world
+looper() : running Shutdown on thread
+got Shutdown
+looper() : done Shutdown exiting

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3848,6 +3848,10 @@ window.close = function() {
     for args in [[], ['-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE=8']]:
       self.btest(path_from_root('tests', 'pthread', 'test_pthread_supported.cpp'), expected='0', args=['-O3'] + args)
 
+  @requires_threads
+  def test_pthread_dispatch_after_exit(self):
+    self.btest_exit(path_from_root('tests', 'pthread', 'test_pthread_dispatch_after_exit.c'), 0, args=['-s', 'USE_PTHREADS'])
+
   # Test the operation of Module.pthreadMainPrefixURL variable
   @no_wasm_backend('uses js')
   @requires_threads

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2369,6 +2369,10 @@ The current type of b is: 9
   def test_pthread_equal(self):
     self.do_run_in_out_file_test('tests', 'pthread', 'test_pthread_equal.cpp')
 
+  @node_pthreads
+  def test_pthread_dispatch_after_exit(self):
+    self.do_run_in_out_file_test('tests', 'pthread', 'test_pthread_dispatch_after_exit.c')
+
   def test_tcgetattr(self):
     self.do_runf(path_from_root('tests', 'termios', 'test_tcgetattr.c'), 'success')
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -1132,13 +1132,6 @@ def metadce(js_file, wasm_file, minify_whitespace, debug_info):
           'name': 'emcc$export$' + export,
           'reaches': []
         })
-  # Because emitDCEGraph only looks at the main js file, and not the worker
-  # we have to explictly add module exported here that are accessed from the
-  # worker, in order to keep them alive through this DCE.
-  # TODO: Find a more robust way to do this, perhaps by also scanning worker.js
-  # for roots.
-  if Settings.USE_PTHREADS:
-    user_requested_exports.append('_emscripten_tls_init')
   # ensure that functions expected to be exported to the outside are roots
   for item in graph:
     if 'export' in item:


### PR DESCRIPTION
This was supposed to be removed in #12853 but it was still
be used in the 'cencel' and 'processThreadQueue' message
handlers.  Because of the way JS `var` is hoisted to function
scope a stale version of this variable was bring read.