### PR TITLE
Warn if emcc if not launched via our launcher scripts

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -47,6 +47,9 @@ Current Trunk
   in any way since wasm-ld ignores unreferenced library files.  Only users
   of the `--whole-archive` linker flag (which is used when `MAIN_MODULE=1` is
   set) should be effected.
+- Emscripten will now warn if it is not run via the shell/bat launcher scripts.
+  Please use `emcc` (or `emcc.bat` on windows) rather then `python emcc.py` to
+  run python.  This warning can be disabled with `-Wno-launcher-script`.
 
 2.0.12: 01/09/2021
 ------------------

--- a/em++
+++ b/em++
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/em++.bat
+++ b/em++.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/em-config
+++ b/em-config
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/em-config.bat
+++ b/em-config.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emar
+++ b/emar
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emar.bat
+++ b/emar.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/embuilder
+++ b/embuilder
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emcc
+++ b/emcc
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emcc.bat
+++ b/emcc.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emcc.py
+++ b/emcc.py
@@ -737,6 +737,7 @@ def run(args):
     if EMCC_CFLAGS:
       cmd += ' + ' + EMCC_CFLAGS
     logger.warning('invocation: ' + cmd + '  (in ' + os.getcwd() + ')')
+    logger.warning('running under python %s: %s' % (sys.version.split()[0], sys.executable))
   if EMCC_CFLAGS:
     args.extend(shlex.split(EMCC_CFLAGS))
 
@@ -868,6 +869,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # This needs to run before other cmdline flags have been parsed, so that
     # warnings are properly printed during arg parse.
     newargs = diagnostics.capture_warnings(newargs)
+
+    if 'EM_LAUNCHER' not in os.environ:
+      diagnostics.warning('launcher-script', 'emscripten python driver (emcc.py) was not run via the emcc launcher script (emcc).  While this may work, launching via any other mechansim is not officially supported.')
 
     if not config.config_file:
       diagnostics.warning('deprecated', 'Specifying EM_CONFIG as a python literal is deprecated. Please use a file instead.')

--- a/emcmake
+++ b/emcmake
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emconfigure
+++ b/emconfigure
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emmake
+++ b/emmake
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emmake.bat
+++ b/emmake.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emranlib
+++ b/emranlib
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emrun
+++ b/emrun
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emrun.bat
+++ b/emrun.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emscons
+++ b/emscons
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emscons.bat
+++ b/emscons.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emsize
+++ b/emsize
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/emsize.bat
+++ b/emsize.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9948,3 +9948,7 @@ exec "$@"
     self.assertGreater(len(exports_linkable), 1000)
     self.assertIn('sendmsg', exports_linkable)
     self.assertNotIn('sendmsg', exports)
+
+  def test_python_launcher_warning(self):
+    err = self.run_process([sys.executable, path_from_root('emcc.py'), path_from_root('tests', 'hello_world.c')], stderr=PIPE).stderr
+    self.assertContained('was not run via the emcc launcher script', err)

--- a/tools/emdump
+++ b/tools/emdump
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/tools/emdump.bat
+++ b/tools/emdump.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/tools/file_packager
+++ b/tools/file_packager
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/tools/run_python.bat
+++ b/tools/run_python.bat
@@ -8,4 +8,5 @@
   set EM_PY=python
 )
 
+@set EM_LAUNCHER=1
 @"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/tools/run_python.sh
+++ b/tools/run_python.sh
@@ -26,4 +26,5 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
+export EM_LAUNCHER=1
 exec "$PYTHON" "$0.py" "$@"

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -57,6 +57,7 @@ diagnostics.add_warning('legacy-settings', enabled=False, part_of_all=False)
 # Catch-all for other emcc warnings
 diagnostics.add_warning('linkflags')
 diagnostics.add_warning('emcc')
+diagnostics.add_warning('launcher-script')
 diagnostics.add_warning('undefined', error=True)
 diagnostics.add_warning('deprecated')
 diagnostics.add_warning('version-check')


### PR DESCRIPTION
For example, if something runs `python emcc.py` rather than just `emcc`
they will see this warning.

Like all warning it can be disabled from the command line (In this case
using `-Wno-launcher-script`).

Ensuring the launcher scripte is narrows the effective abi surface of
the command line driver, making `emcc.py` and internal detail.  This
allows us to, for example, rename or move this file, and maybe even
re-implement `emcc` in a language other than python one day.