### PR TITLE
Remove redundant setting of noExitRuntime in test code. NFC

### DIFF
--- a/tests/canvas_focus.c
+++ b/tests/canvas_focus.c
@@ -30,6 +30,7 @@ int main()
     // Focus, then send an event, same as if the user clicked on it for focus.
     Module.canvas.focus();
     document.activeElement.dispatchEvent(event);
-    noExitRuntime = true;
   });
+  emscripten_exit_with_live_runtime();
+  return 0;
 }

--- a/tests/emscripten_hide_mouse.c
+++ b/tests/emscripten_hide_mouse.c
@@ -18,5 +18,6 @@ int main()
 	emscripten_hide_mouse();
 	EMSCRIPTEN_RESULT ret = emscripten_set_click_callback("#canvas", 0, 1, mouse_callback);
 	assert(ret == 0);
-	EM_ASM(noExitRuntime = true);
+	emscripten_exit_with_live_runtime();
+	return 0;
 }

--- a/tests/emscripten_set_interval.c
+++ b/tests/emscripten_set_interval.c
@@ -32,5 +32,6 @@ void tick(void *userData)
 int main()
 {
 	intervalId = emscripten_set_interval(tick, 100, (void*)1);
-	EM_ASM(noExitRuntime = 1);
+	emscripten_exit_with_live_runtime();
+	return 0;
 }

--- a/tests/emscripten_set_timeout.c
+++ b/tests/emscripten_set_timeout.c
@@ -1,3 +1,4 @@
+#include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
 #include <emscripten/em_asm.h>
 #include <assert.h>
@@ -44,5 +45,5 @@ void func1(void *userData)
 int main()
 {
 	emscripten_set_timeout(func1, 100, (void*)1);
-	EM_ASM(noExitRuntime = 1);
+	emscripten_exit_with_live_runtime();
 }

--- a/tests/emscripten_set_timeout_loop.c
+++ b/tests/emscripten_set_timeout_loop.c
@@ -1,3 +1,4 @@
+#include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
 #include <emscripten/em_asm.h>
 #include <assert.h>
@@ -30,5 +31,6 @@ EM_BOOL tick(double time, void *userData)
 int main()
 {
 	emscripten_set_timeout_loop(tick, 100, (void*)1);
-	EM_ASM(noExitRuntime = 1);
+	emscripten_exit_with_live_runtime();
+	return 0;
 }

--- a/tests/gl_in_mainthread_after_pthread.cpp
+++ b/tests/gl_in_mainthread_after_pthread.cpp
@@ -116,7 +116,6 @@ void PollThreadExit(void *)
 
 int main()
 {
-  EM_ASM(noExitRuntime = true;);
   CreateThread();
   emscripten_async_call(PollThreadExit, 0, 1000);
   return 0;

--- a/tests/gl_in_pthread.cpp
+++ b/tests/gl_in_pthread.cpp
@@ -109,7 +109,6 @@ void *mymain(void*)
 int main()
 {
 #ifdef TEST_CHAINED_WEBGL_CONTEXT_PASSING
-  EM_ASM(noExitRuntime = true;);
   pthread_attr_t attr;
   pthread_attr_init(&attr);
 #ifndef TRANSFER_TO_CHAINED_THREAD_FROM_MAIN_THREAD
@@ -124,6 +123,7 @@ int main()
 #endif
     exit(0);
   }
+  emscripten_exit_with_live_runtime();
 #else
   mymain(0);
 #endif

--- a/tests/gl_only_in_pthread.cpp
+++ b/tests/gl_only_in_pthread.cpp
@@ -98,7 +98,6 @@ int main()
 #endif
     return 0;
   }
-  EM_ASM(noExitRuntime = true;);
   CreateThread();
   emscripten_async_call(PollThreadExit, 0, 100);
   return 0;

--- a/tests/html5_callbacks_on_calling_thread.c
+++ b/tests/html5_callbacks_on_calling_thread.c
@@ -53,7 +53,7 @@ void *threadMain(void *arg)
     emscripten_current_thread_process_queued_calls();
   }
 #else
-  EM_ASM(noExitRuntime = true);
+  emscripten_exit_with_live_runtime();
 #endif
   return 0;
 }
@@ -66,5 +66,5 @@ int main()
   int rc = pthread_create(&thread, NULL, threadMain, 0);
   assert(rc == 0);
 
-  EM_ASM(noExitRuntime = true);
+  emscripten_exit_with_live_runtime();
 }

--- a/tests/html5_event_callback_in_two_threads.c
+++ b/tests/html5_event_callback_in_two_threads.c
@@ -112,5 +112,5 @@ int main()
 
   printf("Please press the Enter key.\n");
 
-  EM_ASM(noExitRuntime = true);
+  emscripten_exit_with_live_runtime();
 }

--- a/tests/pthread/emscripten_thread_sleep.c
+++ b/tests/pthread/emscripten_thread_sleep.c
@@ -40,5 +40,6 @@ int main()
 	Sleep(5000);
 	pthread_t thread;
 	pthread_create(&thread, NULL, thread_main, NULL);
-	EM_ASM(noExitRuntime=true);
+	emscripten_exit_with_live_runtime();
+	return 0;
 }

--- a/tests/pthread/test_pthread_clock_drift.cpp
+++ b/tests/pthread/test_pthread_clock_drift.cpp
@@ -57,5 +57,5 @@ int main()
 	mainThreadTime = emscripten_get_now();
 	wake(&timeReceived);
 
-	EM_ASM(noExitRuntime=true);
+	emscripten_exit_with_live_runtime();
 }

--- a/tests/resize_offscreencanvas_from_main_thread.cpp
+++ b/tests/resize_offscreencanvas_from_main_thread.cpp
@@ -29,8 +29,7 @@ void thread_local_main_loop()
     emscripten_cancel_main_loop();
 #endif
 
-    EM_ASM(noExitRuntime=false);
-    exit(0);
+    emscripten_force_exit(0);
   }
   printf("%dx%d\n", w, h);
 }
@@ -59,7 +58,6 @@ void *thread_main(void *arg)
   emscripten_set_main_loop(thread_local_main_loop, 1, 0);
 #endif
 
-  EM_ASM(noExitRuntime=true);
   return 0;
 }
 
@@ -106,7 +104,6 @@ int main()
   printf("Creating thread.\n");
   pthread_create(&thread, &attr, thread_main, NULL);
   pthread_detach(thread);
-  EM_ASM(noExitRuntime=true);
 
   // Wait for a while, then change the canvas size on the main thread.
   printf("Waiting for 5 seconds for good measure.\n");

--- a/tests/test_gamepad.c
+++ b/tests/test_gamepad.c
@@ -114,10 +114,6 @@ int main()
 
   emscripten_set_main_loop(mainloop, 10, 0);
 
-  /* For the events to function, one must either call emscripten_set_main_loop or enable Module.noExitRuntime by some other means. 
-     Otherwise the application will exit after leaving main(), and the atexit handlers will clean up all event hooks (by design). */
-  EM_ASM(noExitRuntime = true);
-
 #ifdef REPORT_RESULT
   // Keep the page running for a moment.
   emscripten_async_call(report_result, 0, 5000);

--- a/tests/test_html5_core.c
+++ b/tests/test_html5_core.c
@@ -425,13 +425,11 @@ int main()
   ret = (width && height) ? EMSCRIPTEN_RESULT_SUCCESS : EMSCRIPTEN_RESULT_FAILED;
   TEST_RESULT(emscripten_get_screen_size);
 
-  /* For the events to function, one must either call emscripten_set_main_loop or enable Module.noExitRuntime by some other means.
-     Otherwise the application will exit after leaving main(), and the atexit handlers will clean up all event hooks (by design). */
-  EM_ASM(noExitRuntime = true);
-
 #ifdef REPORT_RESULT
   // Keep the page running for a moment.
   emscripten_async_call(report_result, 0, 5000);
+#else
+  emscripten_exit_with_live_runtime();
 #endif
   return 0;
 }

--- a/tests/test_html5_mouse.c
+++ b/tests/test_html5_mouse.c
@@ -173,8 +173,5 @@ int main()
   );
 #endif
 
-  /* For the events to function, one must either call emscripten_set_main_loop or enable Module.noExitRuntime by some other means. 
-     Otherwise the application will exit after leaving main(), and the atexit handlers will clean up all event hooks (by design). */
-  EM_ASM(noExitRuntime = true);
   return 0;
 }

--- a/tests/test_html5_pointerlockerror.c
+++ b/tests/test_html5_pointerlockerror.c
@@ -94,8 +94,6 @@ int main()
   ret = emscripten_set_pointerlockerror_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, 1, pointerlockerror_callback);
   TEST_RESULT(emscripten_set_pointerlockerror_callback);
 
-  /* For the events to function, one must either call emscripten_set_main_loop or enable Module.noExitRuntime by some other means. 
-     Otherwise the application will exit after leaving main(), and the atexit handlers will clean up all event hooks (by design). */
-  EM_ASM(noExitRuntime = true);
+  emscripten_exit_with_live_runtime();
   return 0;
 }

--- a/tests/test_keyboard_codes.c
+++ b/tests/test_keyboard_codes.c
@@ -79,5 +79,6 @@ int main()
   emscripten_set_keydown_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, 1, key_callback);
   emscripten_set_keyup_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, 1, key_callback);
   emscripten_set_keypress_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, 1, key_callback);
-  EM_ASM(noExitRuntime = true);
+  emscripten_exit_with_live_runtime();
+  return 0;
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2656,7 +2656,7 @@ m0.ccall('myread0','number',[],[]);
     create_test_file('proxyfs_pre.js', r'''
 if (typeof Module === 'undefined') Module = {};
 Module["noInitialRun"]=true;
-noExitRuntime=true;
+Module["noExitRuntime"]=true;
 ''')
 
     create_test_file('proxyfs_embed.txt', 'test\n')


### PR DESCRIPTION
Tests that set a main loop to make an async call don't need to
set this explicitly.

Also, prefer `emscripten_exit_with_live_runtime()` when it is actually
needed.