### PR TITLE
Fixes #13146

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -532,3 +532,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Aleksey Kliger <aleksey@lambdageek.org> (copyright owned by Microsoft, Inc.)
 * Nicolas Ollinger <nopid@free.fr>
 * Michael R. Crusoe <crusoe@debian.org>
+* Thomas Ballinger <thomasballinger@gmail.com>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2229,11 +2229,12 @@ int f() {
     create_test_file(full, 'data')
     proc = self.run_process([FILE_PACKAGER, 'test.data', '--preload', full], stdout=PIPE, stderr=PIPE)
     assert len(proc.stdout), proc.stderr
-    assert unicode_name in proc.stdout, proc.stdout
+    assert json.dumps(unicode_name) in proc.stdout, proc.stdout
     print(len(proc.stderr))
 
   def test_file_packager_directory_with_single_quote(self):
     single_quote_name = "direc'tory"
+    ensure_dir(single_quote_name)
     full = os.path.join(single_quote_name, 'data.txt')
     create_test_file(full, 'data')
     proc = self.run_process([FILE_PACKAGER, 'test.data', '--preload', full], stdout=PIPE, stderr=PIPE)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2232,6 +2232,16 @@ int f() {
     assert unicode_name in proc.stdout, proc.stdout
     print(len(proc.stderr))
 
+  def test_file_packager_directory_with_single_quote(self):
+    single_quote_name = "direc'tory"
+    full = os.path.join(single_quote_name, 'data.txt')
+    create_test_file(full, 'data')
+    proc = self.run_process([FILE_PACKAGER, 'test.data', '--preload', full], stdout=PIPE, stderr=PIPE)
+    assert len(proc.stdout), proc.stderr
+    # ensure not invalid JavaScript
+    assert "'direc'tory'" not in proc.stdout
+    assert json.dumps("direc'tory") in proc.stdout
+
   def test_file_packager_mention_FORCE_FILESYSTEM(self):
     MESSAGE = 'Remember to build the main file with  -s FORCE_FILESYSTEM=1  so that it includes support for loading this file package'
     create_test_file('data.txt', 'data1')

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -378,7 +378,7 @@ def main():
         partial = '/'.join(parts[:i + 1])
         if partial not in partial_dirs:
           code += ('''Module['FS_createPath'](%s, %s, true, true);\n'''
-                   % (json.dumps('/'+'/'.join(parts[:i])), json.dumps(parts[i])))
+                   % (json.dumps('/' + '/'.join(parts[:i])), json.dumps(parts[i])))
           partial_dirs.append(partial)
 
   if has_preloaded:

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -377,8 +377,8 @@ def main():
       for i in range(len(parts)):
         partial = '/'.join(parts[:i + 1])
         if partial not in partial_dirs:
-          code += ('''Module['FS_createPath']('/%s', '%s', true, true);\n'''
-                   % ('/'.join(parts[:i]), parts[i]))
+          code += ('''Module['FS_createPath'](%s, %s, true, true);\n'''
+                   % (json.dumps('/'+'/'.join(parts[:i])), json.dumps(parts[i])))
           partial_dirs.append(partial)
 
   if has_preloaded:


### PR DESCRIPTION
Escape directory and file names when creating filesystem with file_packager, as in the `--preload` flag for `emcc`.

Fixes #13146