### PR TITLE
Run llvm-objcopy via check-call

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -1359,7 +1359,7 @@ def strip(infile, outfile, debug=False, producers=False):
     cmd += ['--remove-section=.debug*']
   if producers:
     cmd += ['--remove-section=producers']
-  run_process(cmd)
+  check_call(cmd)
 
 
 # extract the DWARF info from the main file, and leave the wasm with


### PR DESCRIPTION
This means that when it fails we print a nice error message
rather than showing an exception.

See #13158