### PR TITLE
set location as program name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -532,3 +532,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Aleksey Kliger <aleksey@lambdageek.org> (copyright owned by Microsoft, Inc.)
 * Nicolas Ollinger <nopid@free.fr>
 * Michael R. Crusoe <crusoe@debian.org>
+* Stefan Neubert <stefan-neubert@gmx.net>

--- a/src/shell.js
+++ b/src/shell.js
@@ -73,7 +73,7 @@ for (key in Module) {
 }
 
 var arguments_ = [];
-var thisProgram = './this.program';
+var thisProgram = document.URL;
 var quit_ = function(status, toThrow) {
   throw toThrow;
 };


### PR DESCRIPTION
Not only for the use case in the comment but in general it's a convention to have the filename, of a program being run, in the first element of argv. For WebAssembly this could be the URL, the client is requesting.

I tried a pull request yesterday, but it failed in the checks, so this pull request will fail to. But actually I'm not able to figure out why.
I tested the change with emscipten-core/emscripten:master locally. AFAIK shell.js get processed by jsifier.js from compiler.js invoked by emscripten.py, which is working fine and I'm not able to run the checks locally.

So feel free to reject and or discuss this suggestion and it's implementation.