### PR TITLE
Fix a couple of issues with `--threadprofiler`

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -108,7 +108,7 @@ var LibraryPThread = {
 
       // Zero fill contents at startup.
       for (var i = 0; i < {{{ C_STRUCTS.thread_profiler_block.__size__ }}}; i += 4) Atomics.store(HEAPU32, (profilerBlock + i) >> 2, 0);
-      Atomics.store(HEAPU32, (pthreadPtr + {{{ C_STRUCTS.thread_profiler_block.currentStatusStartTime }}} ) >> 2, performance.now());
+      Atomics.store(HEAPU32, (profilerBlock + {{{ C_STRUCTS.thread_profiler_block.currentStatusStartTime }}} ) >> 2, performance.now());
     },
 
     // Sets the current thread status, but only if it was in the given expected state before. This is used

--- a/src/threadprofiler.js
+++ b/src/threadprofiler.js
@@ -24,24 +24,34 @@ var emscriptenThreadProfiler = {
   },
 
   updateUi: function updateUi() {
-    if (typeof PThread === 'undefined') return; // Likely running threadprofiler on a singlethreaded build, or not initialized yet, ignore updating.
+    if (typeof PThread === 'undefined') {
+      // Likely running threadprofiler on a singlethreaded build, or not
+      // initialized yet, ignore updating.
+      return;
+    }
     var str = '';
     var mainThread = _emscripten_main_browser_thread_id();
 
     var threads = [mainThread];
-    for(var t in PThread.pthreads) threads.push(PThread.pthreads[t].threadInfoStruct);
+    for (var i in PThread.pthreads) {
+      threads.push(PThread.pthreads[i].threadInfoStruct);
+    }
 
-    for(var i = 0; i < threads.length; ++i) {
-      var threadPtr = threads[i];//(t == mainThread ? mainThread : maiPThread.pthreads[t].threadInfoStruct;
-      var profilerBlock = Atomics.load(HEAPU32, (threadPtr + 20 /*C_STRUCTS.pthread.profilerBlock*/ ) >> 2);
+    for (var i = 0; i < threads.length; ++i) {
+      var threadPtr = threads[i];
+      var profilerBlock = Atomics.load(HEAPU32, (threadPtr + 8 /* {{{ C_STRUCTS.pthread.profilerBlock }}}*/) >> 2);
       var threadName = PThread.getThreadName(threadPtr);
-      if (threadName) threadName = '"' + threadName + '" (0x' + threadPtr.toString(16) + ')';
-      else threadName = '(0x' + threadPtr.toString(16) + ')';
+      if (threadName) {
+        threadName = '"' + threadName + '" (0x' + threadPtr.toString(16) + ')';
+      } else {
+        threadName = '(0x' + threadPtr.toString(16) + ')';
+      }
 
       str += 'Thread ' + threadName + ' now: ' + PThread.threadStatusAsString(threadPtr) + '. ';
+
       var threadTimesInStatus = [];
       var totalTime = 0;
-      for(var j = 0; j < 7/*EM_THREAD_STATUS_NUMFIELDS*/; ++j) {
+      for (var j = 0; j < 7/*EM_THREAD_STATUS_NUMFIELDS*/; ++j) {
         threadTimesInStatus.push(HEAPF64[((profilerBlock + 16/*C_STRUCTS.thread_profiler_block.timeSpentInStatus*/) >> 3) + j]);
         totalTime += threadTimesInStatus[j];
         HEAPF64[((profilerBlock + 16/*C_STRUCTS.thread_profiler_block.timeSpentInStatus*/) >> 3) + j] = 0;

--- a/tests/pthread/test_pthread_mandelbrot.cpp
+++ b/tests/pthread/test_pthread_mandelbrot.cpp
@@ -405,9 +405,11 @@ void main_tick()
   numItersDoneOnCanvas += numItersPerFrame;
 
 #if defined(TEST_THREAD_PROFILING) && defined(REPORT_RESULT)
-  if (numItersDoneOnCanvas > 50000)
+  static bool reported = false;
+  if (!reported && numItersDoneOnCanvas > 50000)
   {
     REPORT_RESULT(0);
+    reported = true;
   }
 #endif
 
@@ -501,7 +503,7 @@ void main_tick()
       var updatesPerFrame = (new RegExp("[\\?&]updates=([^&#]*)")).exec(location.href);
       if (updatesPerFrame) return updatesPerFrame[1];
     }
-    if (typeof Module !== 'undefined' && Module.arguments && Module.arguments.length >= 1) return parseInt(Module.arguments[0]);
+    if (arguments_ && arguments_.length >= 1) return parseInt(arguments_[0]);
     if (typeof document !== 'undefined' && document.getElementById('updates_per_frame')) return parseInt(document.getElementById('updates_per_frame').value);
     return 50;
   });
@@ -602,7 +604,7 @@ int main(int argc, char** argv)
   if (ENVIRONMENT_IS_WEB) {
     emscripten_set_main_loop(main_tick, 0, 0);
   } else {
-    int numTotalFrames = EM_ASM_INT(return (typeof Module !== 'undefined' && Module.arguments && Module.arguments.length >= 2) ? parseInt(Module.arguments[1]) : 1000);
+    int numTotalFrames = EM_ASM_INT(return (arguments_ && arguments_.length >= 2) ? parseInt(arguments_[1]) : 1000);
     printf("Rendering %d frames of Mandelbrot. Invoke \"node|js mandelbrot.js numItersPerFrame numFrames\" to configure.\n", numTotalFrames);
     double t0 = emscripten_get_now();
     for(int i = 0; i < numTotalFrames; ++i) {

--- a/tests/pthread/test_pthread_mandelbrot_shell.html
+++ b/tests/pthread/test_pthread_mandelbrot_shell.html
@@ -1212,7 +1212,7 @@
     </div>
 
     Updates per frame:<input type="number" id="updates_per_frame" value=50 min=10 max=50000> <br />
-    # of threads:<input type="number" id="num_threads" value=4 min=1 max=16> <br />
+    Threads: <input type="number" id="num_threads" value=4 min=1 max=16> <br />
     Use SSE: <input type="checkbox" id='use_sse' checked> <br />
     Performance: <span id='performance'>-</span><br />
 

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -221,7 +221,13 @@ class interactive(BrowserCore):
     self.btest('hello_world_gles.c', expected='0', args=['-DLONGTEST=1', '-DTEST_MEMORYPROFILER_ALLOCATIONS_MAP=1', '-O2', '--cpuprofiler', '--memoryprofiler'])
 
   def test_threadprofiler(self):
-    self.btest('pthread/test_pthread_mandelbrot.cpp', expected='0', args=['-O2', '--threadprofiler', '-s', 'USE_PTHREADS', '-DTEST_THREAD_PROFILING=1', '-s', 'PTHREAD_POOL_SIZE=16', '--shell-file', path_from_root('tests', 'pthread', 'test_pthread_mandelbrot_shell.html')])
+    args = ['-O2', '--threadprofiler',
+            '-s', 'USE_PTHREADS',
+            '-DTEST_THREAD_PROFILING=1',
+            '-s', 'PTHREAD_POOL_SIZE=16',
+            '-s', 'INITIAL_MEMORY=64mb',
+            '--shell-file', path_from_root('tests', 'pthread', 'test_pthread_mandelbrot_shell.html')]
+    self.btest('pthread/test_pthread_mandelbrot.cpp', expected='0', args=args)
 
   # Test that event backproxying works.
   def test_html5_callbacks_on_calling_thread(self):


### PR DESCRIPTION
Firstly, there was an error in `createProfilerBlock` where
`currentStatusStartTime` was being used as an offset into the thread
object rather than the profile block of the thread.

Secondly, threadprofiler.js has to hardcode the value of
`C_STRUCTS.pthread.profilerBlock` which is now 12 and not 20.

These issues were causing memory corruption.  I manually verified that
the thread names and profile information now show up correctly in the
mandelbrot test where they didn't before.

I discovered these issue while investigating #13157.