### PR TITLE
Remove `info` logging from filelock.py

### DIFF
--- a/tools/filelock.py
+++ b/tools/filelock.py
@@ -25,6 +25,10 @@
 
 # This software package was obtained from
 # https://github.com/benediktschmitt/py-filelock
+#
+# Local changes:
+# - Changed logger.info to logger.warn to avoid displaying logging
+#   information under normal emscripten usage.
 
 """
 A platform independent file lock that supports the with-statement.
@@ -274,7 +278,7 @@ class BaseFileLock(object):
                         self._acquire()
 
                 if self.is_locked:
-                    logger().info('Lock %s acquired on %s', lock_id, lock_filename)
+                    logger().debug('Lock %s acquired on %s', lock_id, lock_filename)
                     break
                 elif timeout >= 0 and time.time() - start_time > timeout:
                     logger().debug('Timeout on acquiring lock %s on %s', lock_id, lock_filename)
@@ -318,7 +322,7 @@ class BaseFileLock(object):
                     logger().debug('Attempting to release lock %s on %s', lock_id, lock_filename)
                     self._release()
                     self._lock_counter = 0
-                    logger().info('Lock %s released on %s', lock_id, lock_filename)
+                    logger().debug('Lock %s released on %s', lock_id, lock_filename)
 
         return None
 


### PR DESCRIPTION
This was inadvertently added as part of #13093.