### PR TITLE
Enable asan pthread tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -399,7 +399,7 @@ jobs:
     steps:
       - run-tests:
           # also add a few asan tests
-          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer"
+          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread*"
   test-wasm3:
     executor: bionic
     steps:

--- a/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
@@ -8,6 +8,8 @@
 #if SANITIZER_EMSCRIPTEN
 #include <emscripten.h>
 #include <cstddef>
+#include <cstdint>
+#define __ATTRP_C11_THREAD ((void*)(uintptr_t)-1)
 
 namespace __asan {
 
@@ -74,7 +76,7 @@ INTERCEPTOR(int, pthread_create, void *thread,
     StopInitOrderChecking();
   GET_STACK_TRACE_THREAD;
   int detached = 0;
-  if (attr)
+  if (attr && attr != __ATTRP_C11_THREAD)
     pthread_attr_getdetachstate(attr, &detached);
   atomic_uintptr_t *param = (atomic_uintptr_t *)
       emscripten_builtin_malloc(sizeof(atomic_uintptr_t));

--- a/tests/pthread/test_pthread_c11_threads.c
+++ b/tests/pthread/test_pthread_c11_threads.c
@@ -17,12 +17,12 @@ int thread_main(void* arg) {
   return 42;
 }
 
-int run_with_exit() {
+int run_with_exit(void* arg) {
   thrd_yield();
   thrd_exit(43);
 }
 
-int main() {
+int main(int argc, char* argv[]) {
   int result = 0;
   printf("thrd_current: %p\n", thrd_current());
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -185,8 +185,7 @@ def requires_native_clang(func):
 def node_pthreads(f):
   def decorated(self):
     self.set_setting('USE_PTHREADS')
-    if '-fsanitize=address' in self.emcc_args:
-      self.skipTest('asan ends up using atomics that are not yet supported in node 12')
+    self.emcc_args += ['-Wno-pthreads-mem-growth']
     if self.get_setting('MINIMAL_RUNTIME'):
       self.skipTest('node pthreads not yet supported with MINIMAL_RUNTIME')
     self.js_engines = [config.NODE_JS]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8064,7 +8064,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_c11_threads(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
-    self.set_setting('TOTAL_MEMORY', '64mb')
+    if not self.has_changed_setting('INITIAL_MEMORY'):
+      self.set_setting('INITIAL_MEMORY', '64mb')
     self.do_run_in_out_file_test('tests', 'pthread', 'test_pthread_c11_threads.c')
 
   @node_pthreads
@@ -8302,9 +8303,9 @@ wasm2ss = make_run('wasm2ss', emcc_args=['-O2'], settings={'STACK_OVERFLOW_CHECK
 strict = make_run('strict', emcc_args=[], settings={'STRICT': 1})
 
 lsan = make_run('lsan', emcc_args=['-fsanitize=leak', '-O2'], settings={'ALLOW_MEMORY_GROWTH': 1})
-asan = make_run('asan', emcc_args=['-fsanitize=address', '-O2'], settings={'ALLOW_MEMORY_GROWTH': 1, 'INITIAL_MEMORY': '300mb'})
+asan = make_run('asan', emcc_args=['-fsanitize=address', '-O2'], settings={'ALLOW_MEMORY_GROWTH': 1, 'INITIAL_MEMORY': '500mb'})
 asani = make_run('asani', emcc_args=['-fsanitize=address', '-O2', '--pre-js', os.path.join(os.path.dirname(__file__), 'asan-no-leak.js')],
-                 settings={'ALLOW_MEMORY_GROWTH': 1, 'INITIAL_MEMORY': '300mb'})
+                 settings={'ALLOW_MEMORY_GROWTH': 1, 'INITIAL_MEMORY': '500mb'})
 
 # Experimental modes (not tested by CI)
 lld = make_run('lld', emcc_args=[], settings={'LLD_REPORT_UNDEFINED': 1})


### PR DESCRIPTION
The comment marking these tests as disabled said "asan ends up using
atomics that are not yet supported in node 12", but I ran them
with the emsdk version of node (12.18.1) and they ran just fine.