### PR TITLE
Fix USE_OFFSET_CONVERTER + pthreads + O2

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -569,7 +569,7 @@ var LibraryPThread = {
     return navigator['hardwareConcurrency'];
   },
 
-  {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create__deps: ['$spawnThread', 'pthread_getschedparam', 'pthread_self', 'memalign', '$resetPrototype', 'emscripten_sync_run_in_main_thread_4'],
+  {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create__deps: ['$spawnThread', 'pthread_getschedparam', 'pthread_self', 'memalign', 'emscripten_sync_run_in_main_thread_4'],
   {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create: function(pthread_ptr, attr, start_routine, arg) {
     if (typeof SharedArrayBuffer === 'undefined') {
       err('Current environment does not support SharedArrayBuffer, pthreads are not available!');
@@ -1445,19 +1445,6 @@ var LibraryPThread = {
 
   $invokeEntryPoint: function(ptr, arg) {
     return {{{ makeDynCall('ii', 'ptr') }}}(arg);
-  },
-
-  // When using postMessage to send an object, it is processed by the structured clone algorithm.
-  // The prototype, and hence methods, on that object is then lost. This function adds back the lost prototype.
-  // This does not work with nested objects that has prototypes, but it suffices for WasmSourceMap and WasmOffsetConverter.
-  $resetPrototype: function(constructor, attrs) {
-    var object = Object.create(constructor.prototype);
-    for (var key in attrs) {
-      if (attrs.hasOwnProperty(key)) {
-        object[key] = attrs[key];
-      }
-    }
-    return object;
   },
 
   // This function is called internally to notify target thread ID that it has messages it needs to

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -185,11 +185,10 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
 #endif
 
 #if USE_OFFSET_CONVERTER
-  wasmOffsetConverter =
 #if USE_PTHREADS
-    ENVIRONMENT_IS_PTHREAD ? resetPrototype(WasmOffsetConverter, wasmOffsetData) :
+  if (!ENVIRONMENT_IS_PTHREAD)
 #endif
-    new WasmOffsetConverter(Module['wasm'], output.module);
+    wasmOffsetConverter = new WasmOffsetConverter(Module['wasm'], output.module);
 #endif
 
 #if !DECLARE_ASM_MODULE_EXPORTS
@@ -232,7 +231,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
 #if USE_PTHREADS
   // This Worker is now ready to host pthreads, tell the main thread we can proceed.
   if (ENVIRONMENT_IS_PTHREAD) {
-    postMessage({ 'cmd': 'loaded' });
+    moduleLoaded();
   }
 #endif
 

--- a/tests/core/test_return_address.c
+++ b/tests/core/test_return_address.c
@@ -5,12 +5,12 @@
  * found in the LICENSE file.
  */
 
-#include <cassert>
-#include <cstdio>
+#include <assert.h>
+#include <stdio.h>
 
-extern "C" void *emscripten_return_address(int level);
+void *emscripten_return_address(int level);
 
-void func(void) {
+void func() {
   assert(emscripten_return_address(0) != 0);
   assert(emscripten_return_address(50) == 0);
 }
@@ -21,5 +21,5 @@ void func(void) {
 int main(int argc, char **argv) {
   assert(emscripten_return_address(50) == 0);
   func();
-  std::puts("passed");
+  puts("passed");
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7753,11 +7753,10 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.maybe_closure()
     self.do_runf(path_from_root('tests', 'test_global_initializer.cpp'), 't1 > t0: 1')
 
-  @no_wasm2js('wasm2js wasm emulation does not include custom sections')
-  @no_optimize('return address test cannot work with optimizations')
+  @no_wasm2js('wasm2js does not support PROXY_TO_PTHREAD (custom section support)')
   def test_return_address(self):
-    self.emcc_args += ['-s', 'USE_OFFSET_CONVERTER']
-    self.do_runf(path_from_root('tests', 'core', 'test_return_address.cpp'), 'passed')
+    self.set_setting('USE_OFFSET_CONVERTER')
+    self.do_runf(path_from_root('tests', 'core', 'test_return_address.c'), 'passed')
 
   @no_wasm2js('TODO: sanitizers in wasm2js')
   @no_asan('-fsanitize-minimal-runtime cannot be used with ASan')
@@ -8106,6 +8105,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('PTHREAD_POOL_SIZE', '2')
     self.emcc_args += ['--pre-js', path_from_root('tests', 'core', 'pthread', 'test_pthread_exit_runtime.pre.js')]
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'test_pthread_exit_runtime.c', assert_returncode=43)
+
+  @node_pthreads
+  @no_wasm2js('wasm2js does not support PROXY_TO_PTHREAD (custom section support)')
+  def test_pthread_offset_converter(self):
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('USE_OFFSET_CONVERTER')
+    self.do_runf(path_from_root('tests', 'core', 'test_return_address.c'), 'passed')
 
   def test_emscripten_atomics_stub(self):
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'emscripten_atomics.c')


### PR DESCRIPTION
This change is required in order to fully enable asan+pthreads.

Move resetPrototype back to worker.js which is really the only place it
should be needed.  Calling resetPrototype must happen after the main
script is loaded (so that the WasmOffsetConverter class/function is
available).

Defining `resetPrototype` as a library function was problematic as it is
required by the worker script so would need to survive minification and
closure.  I think its simpler to define it right where its needed and
hooks into all code paths that signaled the that module is loaded.

It seems like we didn't have any tests for this so added one.