### PR TITLE
Fix test_sockets_partial

### DIFF
--- a/tests/sockets/test_sockets_partial_client.c
+++ b/tests/sockets/test_sockets_partial_client.c
@@ -27,7 +27,6 @@ int sum = 0;
 void finish(int result) {
   close(sockfd);
 #ifdef __EMSCRIPTEN__
-  REPORT_RESULT(result);
   emscripten_force_exit(result);
 #else
   exit(result);

--- a/tests/sockets/test_sockets_partial_server.c
+++ b/tests/sockets/test_sockets_partial_server.c
@@ -61,7 +61,7 @@ void do_send(int sockfd) {
   for (i = 0; i < sizeof(buffers) / sizeof(char*); i++) {
     buffer = buffers[i];
 
-    res = send(sockfd, buffer, strlen(buffer), 0);
+    res = send(sockfd, buffer, strlen(buffer), MSG_NOSIGNAL);
     if (res == -1) {
       perror("send failed");
       return;

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -9,7 +9,6 @@ import socket
 import shutil
 import sys
 import time
-import unittest
 from subprocess import Popen, PIPE
 
 if __name__ == '__main__':
@@ -252,14 +251,13 @@ class sockets(BrowserCore):
         self.btest(output, expected='0', args=[sockets_include, '-DSOCKK=%d' % harness.listen_port, '-DTEST_DGRAM=%d' % datagram], force_c=True)
 
   @no_windows('This test is Unix-specific.')
-  @unittest.skip('fails on python3 - ws library may need to be updated')
   def test_sockets_partial(self):
     for harness in [
       WebsockifyServerHarness(os.path.join('sockets', 'test_sockets_partial_server.c'), [], 49180),
       CompiledServerHarness(os.path.join('sockets', 'test_sockets_partial_server.c'), [], 49181)
     ]:
       with harness:
-        self.btest(os.path.join('sockets', 'test_sockets_partial_client.c'), expected='165', args=['-DSOCKK=%d' % harness.listen_port])
+        self.btest_exit(os.path.join('sockets', 'test_sockets_partial_client.c'), expected='165', args=['-DSOCKK=%d' % harness.listen_port])
 
   @no_windows('This test is Unix-specific.')
   def test_sockets_select_server_down(self):


### PR DESCRIPTION
The server process was crashing right after the test code sent its
test for aliveness because after the first send() the client closes
the connection which was generating a SIGPIPE.  My only explanation
is that somehow under python3 the probe connection stayed up long
enough to receive all the sends, preventing the crash.

Also, convert to btest_exit.