### PR TITLE
Fix name of file in `erase` method of harfbuzz and sdl2 ports

### DIFF
--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -17,6 +17,10 @@ def needed(settings):
   return settings.USE_HARFBUZZ
 
 
+def get_lib_name(ports, settings):
+  return ports.get_lib_name('libharfbuzz' + ('-mt' if settings.USE_PTHREADS else ''))
+
+
 def get(ports, settings, shared):
   ports.fetch_project('harfbuzz', 'https://github.com/harfbuzz/harfbuzz/releases/download/' +
                       TAG + '/harfbuzz-' + TAG + '.tar.bz2', 'harfbuzz-' + TAG, is_tarbz2=True, sha512hash=HASH)
@@ -63,11 +67,11 @@ def get(ports, settings, shared):
 
     return os.path.join(dest_path, 'libharfbuzz.a')
 
-  return [shared.Cache.get('libharfbuzz' + ('-mt' if settings.USE_PTHREADS else '') + '.a', create, what='port')]
+  return [shared.Cache.get(get_lib_name(ports, settings), create, what='port')]
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libharfbuzz.a')
+  shared.Cache.erase_file(get_lib_name(ports, settings))
 
 
 def process_dependencies(settings):

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -14,10 +14,14 @@ def needed(settings):
   return settings.USE_SDL == 2
 
 
+def get_lib_name(ports, settings):
+  return ports.get_lib_name('libSDL2' + ('-mt' if settings.USE_PTHREADS else ''))
+
+
 def get(ports, settings, shared):
   # get the port
   ports.fetch_project('sdl2', 'https://github.com/emscripten-ports/SDL2/archive/' + TAG + '.zip', SUBDIR, sha512hash=HASH)
-  libname = ports.get_lib_name('libSDL2' + ('-mt' if settings.USE_PTHREADS else ''))
+  libname = get_lib_name(ports, settings)
 
   def create():
     # copy includes to a location so they can be used as 'SDL2/'
@@ -86,7 +90,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file(ports.get_lib_name('libSDL2'))
+  shared.Cache.erase_file(get_lib_name(ports, settings))
 
 
 def process_dependencies(settings):


### PR DESCRIPTION
In practice this is not really a problem since this method is only
used when cleaning a port before building it, so that only side effect
would be that the old library continues to exist if the new build fails
for some reason.

The pattern of using a `get_lib_name` helper function is copied from the
regal port.