### PR TITLE
Remove i64x2_{any,all}_true tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5710,7 +5710,6 @@ return malloc(size);
 
   @wasm_simd
   @is_slow_test
-  @disabled('https://github.com/WebAssembly/binaryen/issues/3468')
   def test_wasm_builtin_simd(self):
     # Improves test readability
     self.emcc_args += ['-Wno-c++11-narrowing', '-Wno-format']
@@ -5720,7 +5719,6 @@ return malloc(size);
 
   @wasm_simd
   @is_slow_test
-  @disabled('https://github.com/WebAssembly/binaryen/issues/3468')
   def test_wasm_intrinsics_simd(self):
     def run():
       self.do_runf(path_from_root('tests', 'test_wasm_intrinsics_simd.c'), 'Success!')

--- a/tests/test_wasm_builtin_simd.cpp
+++ b/tests/test_wasm_builtin_simd.cpp
@@ -441,14 +441,6 @@ i32x4 TESTFN i32x4_mul(i32x4 x, i32x4 y) {
 i64x2 TESTFN i64x2_neg(i64x2 vec) {
   return -vec;
 }
-#ifdef __wasm_unimplemented_simd128__
-int32_t TESTFN i64x2_any_true(i64x2 vec) {
-  return __builtin_wasm_any_true_i64x2(vec);
-}
-int32_t TESTFN i64x2_all_true(i64x2 vec) {
-  return __builtin_wasm_all_true_i64x2(vec);
-}
-#endif // __wasm_unimplemented_simd128__
 i64x2 TESTFN i64x2_shl(i64x2 vec, int32_t shift) {
   return vec << shift;
 }
@@ -1253,14 +1245,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
 
   // i64x2 arithmetic
   expect_vec(i64x2_neg((i64x2){0x8000000000000000, 42}), ((i64x2){0x8000000000000000, -42}));
-#ifdef __wasm_unimplemented_simd128__
-  expect_eq(i64x2_any_true((i64x2){0, 0}), 0);
-  expect_eq(i64x2_any_true((i64x2){1, 0}), 1);
-  expect_eq(i64x2_any_true((i64x2){1, 1}), 1);
-  expect_eq(i64x2_all_true((i64x2){0, 0}), 0);
-  expect_eq(i64x2_all_true((i64x2){1, 0}), 0);
-  expect_eq(i64x2_all_true((i64x2){1, 1}), 1);
-#endif // __wasm_unimplemented_simd128__
   expect_vec(i64x2_shl((i64x2){1, 0x8000000000000000}, 1), ((i64x2){2, 0}));
   expect_vec(i64x2_shl((i64x2){1, 0x8000000000000000}, 64), ((i64x2){1, 0x8000000000000000}));
   expect_vec(i64x2_shr_s((i64x2){1, 0x8000000000000000}, 1), ((i64x2){0, 0xc000000000000000}));

--- a/tests/test_wasm_intrinsics_simd.c
+++ b/tests/test_wasm_intrinsics_simd.c
@@ -518,18 +518,6 @@ v128_t TESTFN i32x4_mul(v128_t x, v128_t y) {
 v128_t TESTFN i64x2_neg(v128_t vec) {
   return wasm_i64x2_neg(vec);
 }
-
-#ifdef __wasm_unimplemented_simd128__
-
-bool TESTFN i64x2_any_true(v128_t vec) {
-  return wasm_i64x2_any_true(vec);
-}
-bool TESTFN i64x2_all_true(v128_t vec) {
-  return wasm_i64x2_all_true(vec);
-}
-
-#endif // __wasm_unimplemented_simd128__
-
 v128_t TESTFN i64x2_shl(v128_t vec, int32_t shift) {
   return wasm_i64x2_shl(vec, shift);
 }
@@ -1576,12 +1564,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
 
   // i64x2 arithmetic
   expect_vec(i64x2_neg((v128_t)i64x2(0x8000000000000000, 42)), i64x2(0x8000000000000000, -42));
-  /* expect_eq(i64x2_any_true((v128_t)i64x2(0, 0)), 0); */
-  /* expect_eq(i64x2_any_true((v128_t)i64x2(1, 0)), 1); */
-  /* expect_eq(i64x2_any_true((v128_t)i64x2(1, 1)), 1); */
-  /* expect_eq(i64x2_all_true((v128_t)i64x2(0, 0)), 0); */
-  /* expect_eq(i64x2_all_true((v128_t)i64x2(1, 0)), 0); */
-  /* expect_eq(i64x2_all_true((v128_t)i64x2(1, 1)), 1); */
 
   expect_vec(i64x2_shl((v128_t)i64x2(1, 0x8000000000000000), 1), i64x2(2, 0));
   expect_vec(i64x2_shl((v128_t)i64x2(1, 0x8000000000000000), 64), i64x2(1, 0x8000000000000000));


### PR DESCRIPTION
These instructions are no longer in the SIMD proposal and were removed from
Binaryen, so their presence was causing the SIMD tests to fail.