### PR TITLE
Combine check_call and print_compiler_stack. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1995,10 +1995,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         # output the dependency rule. Warning: clang and gcc behave differently
         # with -MF! (clang seems to not recognize it)
         logger.debug(('just preprocessor ' if has_dash_E else 'just dependencies: ') + ' '.join(cmd))
-        shared.print_compiler_stage(cmd)
-        rtn = run_process(cmd, check=False).returncode
-        if rtn:
-          return rtn
+        shared.check_call(cmd)
       return 0
 
     # Precompiled headers support
@@ -2011,8 +2008,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if specified_target:
           cmd += ['-o', specified_target]
         logger.debug("running (for precompiled headers): " + cmd[0] + ' ' + ' '.join(cmd[1:]))
-        shared.print_compiler_stage(cmd)
-        return run_process(cmd, check=False).returncode
+        shared.check_call(cmd)
+        return 0
 
     def get_object_filename(input_file):
       if compile_only:
@@ -2037,7 +2034,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if not has_dash_c:
         cmd += ['-c']
       cmd += ['-o', output_file]
-      shared.print_compiler_stage(cmd)
       shared.check_call(cmd)
       if output_file not in ('-', os.devnull):
         assert os.path.exists(output_file)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1593,7 +1593,7 @@ keydown(100);keyup(100); // trigger the end
     for file_data in [1, 0]:
       cmd = [EMCC, path_from_root('tests', 'hello_world_worker.cpp'), '-o', 'worker.js'] + (['--preload-file', 'file.dat'] if file_data else [])
       print(cmd)
-      subprocess.check_call(cmd)
+      self.run_process(cmd)
       self.assertExists('worker.js')
       self.run_browser('main.html', '', '/report_result?hello from worker, and :' + ('data for w' if file_data else '') + ':')
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -28,7 +28,7 @@ from .shared import LLVM_LINK, LLVM_OBJCOPY
 from .shared import try_delete, run_process, check_call, exit_with_error
 from .shared import configuration, path_from_root, EXPECTED_BINARYEN_VERSION
 from .shared import asmjs_mangle, DEBUG
-from .shared import EM_BUILD_VERBOSE, TEMP_DIR, print_compiler_stage
+from .shared import EM_BUILD_VERBOSE, TEMP_DIR
 from .shared import CANONICAL_TEMP_DIR, LLVM_DWARFDUMP, demangle_c_symbol_name, asbytes
 from .shared import get_emscripten_temp_dir, exe_suffix, is_c_symbol
 from .utils import which, WINDOWS
@@ -464,7 +464,6 @@ def link_llvm(linker_inputs, target):
   # runs llvm-link to link things.
   cmd = [LLVM_LINK] + linker_inputs + ['-o', target]
   cmd = get_command_with_possible_response_file(cmd)
-  print_compiler_stage(cmd)
   check_call(cmd)
 
 
@@ -577,7 +576,6 @@ def link_lld(args, target, external_symbol_list=None):
   if '--relocatable' not in args and '-r' not in args:
     cmd += lld_flags_for_executable(external_symbol_list)
 
-  print_compiler_stage(cmd)
   cmd = get_command_with_possible_response_file(cmd)
   check_call(cmd)
 
@@ -895,7 +893,6 @@ def eval_ctors(js_file, binary_file, debug_info=False): # noqa
   # cmd = [PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, binary_file, str(Settings.INITIAL_MEMORY), str(Settings.TOTAL_STACK), str(Settings.GLOBAL_BASE), binaryen_bin, str(int(debug_info))]
   # if binaryen_bin:
   #   cmd += get_binaryen_feature_flags()
-  # print_compiler_stage(cmd)
   # check_call(cmd)
 
 
@@ -1620,7 +1617,6 @@ def run_binaryen_command(tool, infile, outfile=None, args=[], debug=False, stdou
   # if the features are not already handled, handle them
   if '--detect-features' not in cmd:
     cmd += get_binaryen_feature_flags()
-  print_compiler_stage(cmd)
   # if we are emitting a source map, every time we load and save the wasm
   # we must tell binaryen to update it
   if Settings.GENERATE_SOURCE_MAP and outfile:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -99,6 +99,7 @@ def run_process(cmd, check=True, input=None, *args, **kw):
 
 def check_call(cmd, *args, **kw):
   """Like `run_process` above but treat failures as fatal and exit_with_error."""
+  print_compiler_stage(cmd)
   try:
     return run_process(cmd, *args, **kw)
   except subprocess.CalledProcessError as e:
@@ -114,7 +115,6 @@ def run_js_tool(filename, jsargs=[], *args, **kw):
   implemented in javascript.
   """
   command = config.NODE_JS + [filename] + jsargs
-  print_compiler_stage(command)
   return check_call(command, *args, **kw).stdout
 
 


### PR DESCRIPTION
This means that `emcc -v` will consistently print all sub-commands that
run via `check_call`.