### PR TITLE
Cleanup pthread tests. NFC.

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -393,21 +393,21 @@ void emscripten_thread_sleep(double msecs);
 // Sets the profiler status of the calling thread. This is a no-op if thread
 // profiling is not active.
 // This is an internal function and generally not intended for user code.
-// When thread profiler is not enabled (not building with --threadprofiling),
+// When thread profiler is not enabled (not building with --threadprofiler),
 // this is a no-op.
 void emscripten_set_current_thread_status(EM_THREAD_STATUS newStatus);
 
 // Sets the profiler status of the calling thread, but only if it was in the
 // expected status beforehand.
 // This is an internal function and generally not intended for user code.
-// When thread profiler is not enabled (not building with --threadprofiling),
+// When thread profiler is not enabled (not building with --threadprofiler),
 // this is a no-op.
 void emscripten_conditional_set_current_thread_status(EM_THREAD_STATUS expectedStatus, EM_THREAD_STATUS newStatus);
 
 // Sets the name of the given thread. Pass pthread_self() as the thread ID to
 // set the name of the calling thread.
 // The name parameter is a UTF-8 encoded string which is truncated to 32 bytes.
-// When thread profiler is not enabled (not building with --threadprofiling),
+// When thread profiler is not enabled (not building with --threadprofiler),
 // this is a no-op.
 void emscripten_set_thread_name(pthread_t threadId, const char *name);
 

--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -22,7 +22,7 @@ struct pthread {
 	// by direct pointer arithmetic in worker.js.
 	int threadStatus; // 0: thread not exited, 1: exited.
 	int threadExitCode; // Thread exit code.
-	void *profilerBlock; // If --threadprofiling is enabled, this pointer is allocated to contain internal information about the thread state for profiling purposes.
+	void *profilerBlock; // If --threadprofiler is enabled, this pointer is allocated to contain internal information about the thread state for profiling purposes.
 #endif
 
 	struct pthread *self;

--- a/tests/core/pthread/exceptions.cpp
+++ b/tests/core/pthread/exceptions.cpp
@@ -31,9 +31,8 @@ void *ThreadMain(void *arg) {
     } catch (int x) {
       total += x;
     } catch (float f) {
-      sum++;
       // wait for a change, so we see interleaved processing.
-      int last = sum.load();
+      int last = ++sum;
       while (sum.load() == last) {}
     }
   }
@@ -50,9 +49,7 @@ void CreateThread(int i)
 
 void loop() {
   static int main_adds = 0;
-  int worker_adds = sum.load() - main_adds;
-  sum++;
-  main_adds++;
+  int worker_adds = sum++ - main_adds++;
   printf("main iter %d : %d\n", main_adds, worker_adds);
   if (worker_adds == NUM_THREADS * THREAD_ADDS &&
       main_adds >= MAIN_ADDS) {
@@ -65,9 +62,10 @@ void loop() {
 int main() {
   // Create initial threads.
   for(int i = 0; i < NUM_THREADS; ++i) {
-    printf("maek\n");
+    printf("make\n");
     CreateThread(i);
   }
 
   emscripten_set_main_loop(loop, 0, 0);
+  return 0;
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8069,6 +8069,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @node_pthreads
   def test_pthread_create(self):
+    self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'create.cpp')
 
   @node_pthreads


### PR DESCRIPTION
This PR cleanups the `tests/core/pthread/{create,exceptions}.cpp` tests by:
- using the [operator arithmetic from `std::atomic<T>`](http://en.cppreference.com/w/cpp/atomic/atomic/operator_arith), were possible;
- calling `exit(0);` after canceling the main loop;
- ensuring it's build with `-sEXIT_RUNTIME` for a true shutdown;
- removing a redundant variable.

Commit https://github.com/kleisauke/emscripten/commit/4defe14d907dbd6b025b6427680b6fa6fcd59e80 is unrelated to the above changes, but I thought I could include within this PR as well (since it's a small typo fix).

(this was split from https://github.com/emscripten-core/emscripten/pull/12963, as requested in https://github.com/emscripten-core/emscripten/pull/12963#commitcomment-45765729)