### PR TITLE
Remove use of `initializer` metadata produced by finalize

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -35,14 +35,11 @@ if STDERR_FILE:
   STDERR_FILE = open(STDERR_FILE, 'w')
 
 
-def compute_minimal_runtime_initializer_and_exports(post, initializers, exports, receiving):
-  # Generate invocations for all global initializers directly off the asm export object, e.g. asm['__GLOBAL__INIT']();
-  post = post.replace('/*** RUN_GLOBAL_INITIALIZERS(); ***/', '\n'.join(["asm['" + x + "']();" for x in initializers]))
-
+def compute_minimal_runtime_initializer_and_exports(post, exports, receiving):
   # Declare all exports out to global JS scope so that JS library functions can access them in a
   # way that minifies well with Closure
   # e.g. var a,b,c,d,e,f;
-  exports_that_are_not_initializers = [x for x in exports if x not in initializers]
+  exports_that_are_not_initializers = [x for x in exports if x not in '__wasm_call_ctors']
   # In Wasm backend the exports are still unmangled at this point, so mangle the names here
   exports_that_are_not_initializers = [asmjs_mangle(x) for x in exports_that_are_not_initializers]
   post = post.replace('/*** ASM_MODULE_EXPORTS_DECLARES ***/', 'var ' + ',\n  '.join(exports_that_are_not_initializers) + ';')
@@ -359,16 +356,6 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, temp_files, DEBUG):
 
   # memory and global initializers
 
-  # In minimal runtime, global initializers are run after the Wasm Module instantiation has finished.
-  if not shared.Settings.MINIMAL_RUNTIME:
-    global_initializers = ', '.join('{ func: function() { %s() } }' % i for i in metadata['initializers'])
-    # In regular runtime, global initializers are recorded in an __ATINIT__ array.
-    global_initializers = '__ATINIT__.push(%s);' % global_initializers
-    if shared.Settings.USE_PTHREADS:
-      global_initializers = 'if (!ENVIRONMENT_IS_PTHREAD) ' + global_initializers
-
-    pre += '\n' + global_initializers + '\n'
-
   if shared.Settings.RELOCATABLE:
     static_bump = align_memory(webassembly.parse_dylink_section(in_wasm)[0])
     memory = Memory(static_bump)
@@ -398,10 +385,10 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, temp_files, DEBUG):
 
     invoke_funcs = metadata['invokeFuncs']
     sending = create_sending(invoke_funcs, metadata)
-    receiving = create_receiving(exports, metadata['initializers'])
+    receiving = create_receiving(exports)
 
     if shared.Settings.MINIMAL_RUNTIME:
-      post = compute_minimal_runtime_initializer_and_exports(post, metadata['initializers'], exports, receiving)
+      post = compute_minimal_runtime_initializer_and_exports(post, exports, receiving)
       receiving = ''
 
     module = create_module(sending, receiving, invoke_funcs, metadata)
@@ -731,13 +718,13 @@ var %(mangled)s = Module["%(mangled)s"] = asm["%(name)s"]
   return wrappers
 
 
-def create_receiving(exports, initializers):
+def create_receiving(exports):
   # When not declaring asm exports this section is empty and we instead programatically export
   # symbols on the global object by calling exportAsmFunctions after initialization
   if not shared.Settings.DECLARE_ASM_MODULE_EXPORTS:
     return ''
 
-  exports_that_are_not_initializers = [x for x in exports if x not in initializers]
+  exports_that_are_not_initializers = [x for x in exports if x != '__wasm_call_ctors']
 
   receiving = []
 
@@ -803,12 +790,9 @@ def load_metadata_wasm(metadata_raw, DEBUG):
 
   metadata = {
     'declares': [],
-    'implementedFunctions': [],
     'externs': [],
-    'simd': False, # Obsolete, always False
     'staticBump': 0,
     'tableSize': 0,
-    'initializers': [],
     'exports': [],
     'namedGlobals': {},
     'emJsFuncs': {},
@@ -817,9 +801,12 @@ def load_metadata_wasm(metadata_raw, DEBUG):
     'features': [],
     'mainReadsParams': 1,
   }
+  legacy_keys = set(['implementedFunctions', 'initializers', 'simd'])
 
   assert 'tableSize' in metadata_json.keys()
   for key, value in metadata_json.items():
+    if key in legacy_keys:
+      continue
     # json.loads returns `unicode` for strings but other code in this file
     # generally works with utf8 encoded `str` objects, and they don't alwasy
     # mix well.  e.g. s.replace(x, y) will blow up is `s` a uts8 str containing
@@ -831,11 +818,6 @@ def load_metadata_wasm(metadata_raw, DEBUG):
     if key not in metadata:
       exit_with_error('unexpected metadata key received from wasm-emscripten-finalize: %s', key)
     metadata[key] = value
-
-  if not shared.Settings.MINIMAL_RUNTIME:
-    # In regular runtime initializers call the global var version of the export, so they get the mangled name.
-    # In MINIMAL_RUNTIME, the initializers are called directly off the export object for minimal code size.
-    metadata['initializers'] = [asmjs_mangle(i) for i in metadata['initializers']]
 
   if DEBUG:
     logger.debug("Metadata parsed: " + pprint.pformat(metadata))

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -75,7 +75,9 @@ function initRuntime(asm) {
   writeStackCookie();
 #endif
 
-  /*** RUN_GLOBAL_INITIALIZERS(); ***/
+#if '___wasm_call_ctors' in IMPLEMENTED_FUNCTIONS
+  asm['__wasm_call_ctors']();
+#endif
 
   {{{ getQuoted('ATINITS') }}}
 }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -351,6 +351,13 @@ var __ATPOSTRUN__ = []; // functions called after the main() is called
 var runtimeInitialized = false;
 var runtimeExited = false;
 
+#if '___wasm_call_ctors' in IMPLEMENTED_FUNCTIONS
+#if USE_PTHREADS
+if (!ENVIRONMENT_IS_PTHREAD)
+#endif
+__ATINIT__.push({ func: function() { ___wasm_call_ctors() } });
+#endif
+
 #if USE_PTHREADS
 if (ENVIRONMENT_IS_PTHREAD) runtimeInitialized = true; // The runtime is hosted in the main thread, and bits shared to pthreads via SharedArrayBuffer. No need to init again in pthread.
 #endif


### PR DESCRIPTION
With the wasm backend there is only ever at most one initializer
function do we don't need complex handling, we can do it all in
the pre/postable.

Also ignore two other unused metadata fields: `simd` and
`implementedFunctions`.  Both of these are not longer output by
binaryen.