### PR TITLE
Add missing includes into public headers

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -14,6 +14,8 @@
 #include <stdint.h> // uintptr_t
 #include <emscripten/wire.h>
 #include <array>
+#include <string>
+#include <utility>
 #include <vector>
 
 

--- a/system/include/emscripten/wire.h
+++ b/system/include/emscripten/wire.h
@@ -20,8 +20,11 @@
 
 #include <stdio.h>
 #include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <string>
+#include <type_traits>
+#include <utility>
 
 #define EMSCRIPTEN_ALWAYS_INLINE __attribute__((always_inline))
 


### PR DESCRIPTION
Add missing includes into public headers

wire.h:
* cstring - for memcpy;
* type_traits - for std::remove_cv et al.;
* utility - for std::forward;

val.h:
* string - for std::string;
* utility - for std::forward.