### PR TITLE
Avoid mangling + demangling in jsifier.js

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -429,8 +429,7 @@ var LibraryExceptions = {
     {{{ makeStructuralReturn(['catchInfo.ptr', 'thrownType']) }}};
   },
 
-  __resumeException__deps: [function() { '$exceptionLast', '$CatchInfo',
-                                        Functions.libraryFunctions['___resumeException'] = 1 }], // will be called directly from compiled code
+  __resumeException__deps: ['$exceptionLast', '$CatchInfo'],
   __resumeException: function(catchInfoPtr) {
     var catchInfo = new CatchInfo(catchInfoPtr);
     var ptr = catchInfo.get_base_ptr();

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9713,6 +9713,14 @@ exec "$@"
     proc = self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--js-library=lib.js'], stderr=PIPE)
     self.assertContained('warning: use of #ifdef in js library.  Use #if instead.', proc.stderr)
 
+  def test_jslib_mangling(self):
+    create_test_file('lib.js', '''
+      mergeInto(LibraryManager.library, {
+       $__foo: function() { return 43; },
+      });
+      ''')
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '--js-library=lib.js', '-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[$__foo]'])
+
   def test_wasm2js_no_dynamic_linking(self):
     for arg in ['-sMAIN_MODULE', '-sSIDE_MODULE', '-sRELOCATABLE']:
       err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-sMAIN_MODULE', '-sWASM=0'])


### PR DESCRIPTION
We had a bug that only showed up with symbols that start with `$_`.
These happen to exist in `library_fetch.js` e.g:
`$__emscripten_fetch_xhr`.  In this case, when we mangle, we remove the
leading `$` giving `__emscripten_fetch_xhr`, and then if we demangle we
do that wrong thing and end up removing the `_` instead of re-adding the
  `$`.

This change avoids the round trip by always storing both the mangled
and demangled version of a given symbol.

See #12268