### PR TITLE
Fix strange/broken syntax in __resumeException__deps

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -429,8 +429,7 @@ var LibraryExceptions = {
     {{{ makeStructuralReturn(['catchInfo.ptr', 'thrownType']) }}};
   },
 
-  __resumeException__deps: [function() { '$exceptionLast', '$CatchInfo',
-                                        Functions.libraryFunctions['___resumeException'] = 1 }], // will be called directly from compiled code
+  __resumeException__deps: ['$exceptionLast', '$CatchInfo'],
   __resumeException: function(catchInfoPtr) {
     var catchInfo = new CatchInfo(catchInfoPtr);
     var ptr = catchInfo.get_base_ptr();


### PR DESCRIPTION
Its hard for me to tell exactly what this was originally trying
to express, but right now it looks broken.

Prior to bcf60cea I think it might
have made more sense when the function was just one element of the
list, but then with bcf60cea it became a function with the list inside
it as expressions that do nothing.