### PR TITLE
Do not process main thread queued calls while returning a worker to the pool

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1523,6 +1523,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         '__emscripten_main_thread_futex',
         '__emscripten_thread_init',
         '_emscripten_current_thread_process_queued_calls',
+        '__emscripten_allow_main_runtime_queued_calls',
         '_emscripten_futex_wake',
         '_emscripten_get_global_libc',
         '_emscripten_main_browser_thread_id',

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -293,6 +293,9 @@ var LibraryPThread = {
     // the case when doing something like free(), which just needs the malloc
     // lock to be released.
     runWithoutMainThreadQueuedCalls: function(func) {
+#if ASSERTIONS
+      assert(PThread.mainThreadBlock, 'runWithoutMainThreadQueuedCalls must be done on the main thread');
+#endif
       // Re-register the main thread block as if we not the main thread. That
       // makes emscripten_main_thread_process_queued_calls() not process queued
       // calls for that thread.

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -74,7 +74,9 @@ var LibraryPThread = {
       // to access this value will read the wrong value, but that is UB anyway.
       __emscripten_thread_init(tb, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
       _emscripten_register_main_browser_thread_id(tb);
+#if ASSERTIONS
       PThread.mainRuntimeThread = true;
+#endif
 
 #if USE_ASAN || USE_LSAN
       });

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -72,6 +72,7 @@ var LibraryPThread = {
       // Pass the thread address to the native code where they stored in wasm
       // globals which act as a form of TLS. Global constructors trying
       // to access this value will read the wrong value, but that is UB anyway.
+      PThread.mainThreadBlock = tb;
       __emscripten_thread_init(tb, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
       _emscripten_register_main_browser_thread_id(tb);
 
@@ -266,13 +267,45 @@ var LibraryPThread = {
       if (pthread.worker) pthread.worker.pthread = null;
     },
     returnWorkerToPool: function(worker) {
-      delete PThread.pthreads[worker.pthread.threadInfoStruct];
-      //Note: worker is intentionally not terminated so the pool can dynamically grow.
-      PThread.unusedWorkers.push(worker);
-      PThread.runningWorkers.splice(PThread.runningWorkers.indexOf(worker), 1); // Not a running Worker anymore
-      PThread.freeThreadData(worker.pthread);
-      // Detach the worker from the pthread object, and return it to the worker pool as an unused worker.
-      worker.pthread = undefined;
+      // We don't want to run main thread queued calls here, since we are doing
+      // some operations that leave the worker queue in an invalid state until
+      // we are completely done (it would be bad if free() ends up calling a
+      // queued pthread_create which looks at the global data structures we are
+      // modifying).
+      PThread.runWithoutMainThreadQueuedCalls(function() {
+        delete PThread.pthreads[worker.pthread.threadInfoStruct];
+        //Note: worker is intentionally not terminated so the pool can dynamically grow.
+        PThread.unusedWorkers.push(worker);
+        PThread.runningWorkers.splice(PThread.runningWorkers.indexOf(worker), 1); // Not a running Worker anymore
+        PThread.freeThreadData(worker.pthread);
+        // Detach the worker from the pthread object, and return it to the worker pool as an unused worker.
+        worker.pthread = undefined;
+      });
+    },
+    // Runs a function with processing of queued calls to the main thread
+    // disabled. This is useful to avoid something like free() ending up waiting
+    // for a lock, then running processing events, and those events can end up
+    // doing things that interfere with what we were doing before (for example,
+    // if we are tearing down a thread, calling free to erase its data could
+    // end up calling a proxied pthread_create, which gets a free worker, and
+    // can interfere).
+    // This is only safe to call if we do not need queued calls to run. That is
+    // the case when doing something like free(), which just needs the malloc
+    // lock to be released.
+    runWithoutMainThreadQueuedCalls: function(func) {
+      // Re-register the main thread block as if we not the main thread. That
+      // makes emscripten_main_thread_process_queued_calls() not process queued
+      // calls for that thread.
+      var isMainBrowserThread = !ENVIRONMENT_IS_WORKER;
+      var isMainRuntimeThread = 0;
+      __emscripten_thread_init(PThread.mainThreadBlock, isMainBrowserThread, isMainRuntimeThread);
+      try {
+        func();
+      } finally {
+        // Re-register ourselves normally again.
+        isMainRuntimeThread = 1;
+        __emscripten_thread_init(PThread.mainThreadBlock, isMainBrowserThread, isMainRuntimeThread);
+      }
     },
     receiveObjectTransfer: function(data) {
 #if OFFSCREENCANVAS_SUPPORT

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -709,8 +709,13 @@ void emscripten_current_thread_process_queued_calls() {
     bool_main_thread_inside_nested_process_queued_calls = 0;
 }
 
+// At times when we disallow the main thread to process queued calls, this will
+// be set to 0.
+int _emscripten_allow_main_runtime_queued_calls = 1;
+
 void emscripten_main_thread_process_queued_calls() {
-  if (!emscripten_is_main_runtime_thread())
+  if (!emscripten_is_main_runtime_thread() ||
+      !_emscripten_allow_main_runtime_queued_calls)
     return;
 
   emscripten_current_thread_process_queued_calls();


### PR DESCRIPTION
This adds a utility function for not running queued calls in a scope. The method
of avoiding them is slightly hackish, by temporarily re-registering the main
thread as if it were not the main runtime thread, but as it's limited to that
utility function, I think it's reasonable, and simpler than adding a new
mechanism. But open to ideas.

Fixes #12970