### PR TITLE
Initial support for pthreads + dynamic linking

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -153,16 +153,9 @@ def main():
     tasks = SYSTEM_TASKS + USER_TASKS
     auto_tasks = True
   if auto_tasks:
-    skip_tasks = []
-    if shared.Settings.RELOCATABLE:
-      # we don't support PIC + pthreads yet
-      for task in SYSTEM_TASKS + USER_TASKS:
-        if '-mt' in task:
-          skip_tasks.append(task)
-      print('Skipping building of %s, because we don\'t support threads and PIC code.' % ', '.join(skip_tasks))
     # cocos2d: must be ported, errors on
     # "Cannot recognize the target platform; are you targeting an unsupported platform?"
-    skip_tasks += ['cocos2d']
+    skip_tasks = ['cocos2d']
     tasks = [x for x in tasks if x not in skip_tasks]
     print('Building targets: %s' % ' '.join(tasks))
   for what in tasks:

--- a/emcc.py
+++ b/emcc.py
@@ -1611,12 +1611,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         if not shared.Settings.MINIMAL_RUNTIME:
           shared.Settings.EXPORTED_RUNTIME_METHODS += ['ExitStatus']
 
-      if shared.Settings.LINKABLE:
-        exit_with_error('-s LINKABLE=1 is not supported with -s USE_PTHREADS>0!')
       if shared.Settings.SIDE_MODULE:
-        exit_with_error('-s SIDE_MODULE=1 is not supported with -s USE_PTHREADS>0!')
-      if shared.Settings.MAIN_MODULE:
-        exit_with_error('-s MAIN_MODULE=1 is not supported with -s USE_PTHREADS>0!')
+        diagnostics.warning('experimental', '-s SIDE_MODULE + pthreads is experimental')
+      elif shared.Settings.MAIN_MODULE:
+        diagnostics.warning('experimental', '-s MAIN_MODULE + pthreads is experimental')
+      elif shared.Settings.LINKABLE:
+        diagnostics.warning('experimental', '-s LINKABLE + pthreads is experimental')
+
       if shared.Settings.PROXY_TO_WORKER:
         exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
     else:

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -83,14 +83,6 @@ var LibraryPThread = {
 #endif
     },
     initWorker: function() {
-#if MODULARIZE
-      // The promise resolve function typically gets called as part of the execution
-      // of the Module `run`. The workers/pthreads don't execute `run` here, they
-      // call `run` in response to a message at a later time, so the creation
-      // promise can be resolved, marking the pthread-Module as initialized.
-      readyPromiseResolve(Module);
-#endif // MODULARIZE
-
 #if USE_CLOSURE_COMPILER
       // worker.js is not compiled together with us, and must access certain
       // things.
@@ -1186,7 +1178,7 @@ var LibraryPThread = {
   },
 
   __call_main: function(argc, argv) {
-    var returnCode = _main(argc, argv);
+    var returnCode = {{{ exportedAsmFunc('_main') }}}(argc, argv);
 #if EXIT_RUNTIME
     if (!noExitRuntime) {
       // exitRuntime enabled, proxied main() finished in a pthread, shut down the process.

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -234,6 +234,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
   // This Worker is now ready to host pthreads, tell the main thread we can proceed.
   if (ENVIRONMENT_IS_PTHREAD) {
     moduleLoaded();
+    postMessage({ 'cmd': 'loaded' });
   }
 #endif
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -571,11 +571,6 @@ Module["preloadedImages"] = {}; // maps url to image data
 Module["preloadedAudios"] = {}; // maps url to audio data
 #if MAIN_MODULE
 Module["preloadedWasm"] = {}; // maps url to wasm instance exports
-addOnPreRun(preloadDylibs);
-#else
-#if RELOCATABLE
-addOnPreRun(reportUndefinedSymbols);
-#endif
 #endif
 
 /** @param {string|number=} what */

--- a/src/worker.js
+++ b/src/worker.js
@@ -81,7 +81,6 @@ function moduleLoaded() {
 #if USE_OFFSET_CONVERTER
   wasmOffsetConverter = resetPrototype(Module['WasmOffsetConverter'], wasmOffsetData);
 #endif
-  postMessage({ 'cmd': 'loaded' });
 }
 
 this.onmessage = function(e) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8163,6 +8163,14 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('USE_PTHREADS')
     self.do_run_in_out_file_test('tests', 'core', 'pthread', 'emscripten_futexes.c')
 
+  @needs_dlfcn
+  @node_pthreads
+  def test_pthread_dynamic_linking(self):
+    self.emcc_args.append('-Wno-experimental')
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    self.do_basic_dylink_test()
+
   # Tests the emscripten_get_exported_function() API.
   def test_emscripten_get_exported_function(self):
     # Could also test with -s ALLOW_TABLE_GROWTH=1


### PR DESCRIPTION
This support is still experimental and has some major
caveats:

- Only supports load-time dynamic linking
- No support for sharing TLS data between dylibs.

The major change is that workers now also call the module `run` function
although they exit early once dynamic libraries have all been loaded.
    
 Another change is the dynamic library loading (which needs to run on
 each new worker) is now seperated from `__ATPRERUN__` (which only wants
 to run once on the main thread).
