### PR TITLE
Cleanup test_size.cpp. NFC.

### DIFF
--- a/tests/core/test_sizeof.cpp
+++ b/tests/core/test_sizeof.cpp
@@ -30,5 +30,8 @@ int main(int argc, const char *argv[]) {
   printf("*%d,%d,%d,%d,%d,%d*\n", as[0].x, as[0].y, as[1].x, as[1].y, as[2].x,
          as[2].y);
 
+  delete[] a;
+  delete[] b;
+  delete[] c;
   return 0;
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1703,10 +1703,7 @@ int main() {
     self.do_run_in_out_file_test('tests', 'core', 'test_mod_globalstruct.c')
 
   def test_sizeof(self):
-      # Has invalid writes between printouts
-      self.set_setting('SAFE_HEAP', 0)
-
-      self.do_run_in_out_file_test('tests', 'core', 'test_sizeof.cpp')
+    self.do_run_in_out_file_test('tests', 'core', 'test_sizeof.cpp')
 
   def test_llvm_used(self):
     self.do_run_in_out_file_test('tests', 'core', 'test_llvm_used.c')


### PR DESCRIPTION
- Fix memory leak
- Re-enable in safe heap mode (seems to pass just fine).
- Fix indentation.