### PR TITLE
Use __ATPRERUN__ for stack check init code. NFC

### DIFF
--- a/src/library_bootstrap.js
+++ b/src/library_bootstrap.js
@@ -13,5 +13,12 @@ assert(false, "library_bootstrap.js only designed for use with BOOTSTRAPPING_STR
 
 assert(!LibraryManager.library);
 LibraryManager.library = {
-  $callRuntimeCallbacks: function() {}
+  $callRuntimeCallbacks: function(callbacks) {
+    while (callbacks.length > 0) {
+      var callback = callbacks.shift();
+      if (typeof callback == 'function') {
+        callback(Module);
+      }
+    }
+  }
 };

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -232,21 +232,6 @@ function callMain(args) {
 }
 #endif // HAS_MAIN
 
-#if STACK_OVERFLOW_CHECK
-function stackCheckInit() {
-  // This is normally called automatically during __wasm_call_ctors but need to
-  // get these values before even running any of the ctors so we call it redundantly
-  // here.
-  // TODO(sbc): Move writeStackCookie to native to to avoid this.
-#if RELOCATABLE
-  _emscripten_stack_set_limits({{{ getQuoted('STACK_BASE') }}}, {{{ getQuoted('STACK_MAX') }}});
-#else
-  _emscripten_stack_init();
-#endif
-  writeStackCookie();
-}
-#endif
-
 /** @type {function(Array=)} */
 function run(args) {
   args = args || arguments_;
@@ -257,10 +242,6 @@ function run(args) {
 #endif
     return;
   }
-
-#if STACK_OVERFLOW_CHECK
-  stackCheckInit();
-#endif
 
   preRun();
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -578,6 +578,24 @@ addOnPreRun(reportUndefinedSymbols);
 #endif
 #endif
 
+#if STACK_OVERFLOW_CHECK
+function stackCheckInit() {
+  // emscripten_stack_init is normally called automatically during
+  // __wasm_call_ctors.  See system/lib/compiler-rt/stack_limits.S.
+  // However, we need to get these values before even running any of the
+  // ctors so we call it redundantly here.
+  // TODO(sbc): Move writeStackCookie to native to to avoid this.
+#if RELOCATABLE
+  _emscripten_stack_set_limits({{{ getQuoted('STACK_BASE') }}}, {{{ getQuoted('STACK_MAX') }}});
+#else
+  _emscripten_stack_init();
+#endif
+  writeStackCookie();
+}
+
+addOnPreRun(stackCheckInit);
+#endif
+
 /** @param {string|number=} what */
 function abort(what) {
 #if expectToReceiveOnModule('onAbort')


### PR DESCRIPTION
This avoids running this code more than once in the case that
run() is called several times during startup which happens when
run dependencies are injected.

Split out from #13245