### PR TITLE
Avoid special replacements for STACK_BASE/STACK_MAX/HEAP_BASE

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -433,8 +433,7 @@ var LibraryDylink = {
           reportUndefinedSymbols();
         }
 #if STACK_OVERFLOW_CHECK >= 2
-
-        moduleExports['__set_stack_limits'](_emscripten_stack_get_base(), _emscripten_stack_get_end());
+        moduleExports['__set_stack_limits']({{{ STACK_BASE }}} , {{{ STACK_MAX }}});
 #endif
         // initialize the module
         var init = moduleExports['__post_instantiate'];

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -239,7 +239,7 @@ function stackCheckInit() {
   // here.
   // TODO(sbc): Move writeStackCookie to native to to avoid this.
 #if RELOCATABLE
-  _emscripten_stack_set_limits({{{ getQuoted('STACK_BASE') }}}, {{{ getQuoted('STACK_MAX') }}});
+  _emscripten_stack_set_limits({{{ STACK_BASE }}}, {{{ STACK_MAX }}});
 #else
   _emscripten_stack_init();
 #endif

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -281,14 +281,14 @@ function updateGlobalBufferAndViews(buf) {
 }
 
 #if RELOCATABLE
-var __stack_pointer = new WebAssembly.Global({value: 'i32', mutable: true}, {{{ getQuoted('STACK_BASE') }}});
+var __stack_pointer = new WebAssembly.Global({value: 'i32', mutable: true}, {{{ STACK_BASE }}});
 
 // To support such allocations during startup, track them on __heap_base and
 // then when the main module is loaded it reads that value and uses it to
 // initialize sbrk (the main module is relocatable itself, and so it does not
 // have __heap_base hardcoded into it - it receives it from JS as an extern
 // global, basically).
-Module['___heap_base'] = {{{ getQuoted('HEAP_BASE') }}};
+Module['___heap_base'] = {{{ HEAP_BASE }}};
 #endif // RELOCATABLE
 
 var TOTAL_STACK = {{{ TOTAL_STACK }}};
@@ -388,6 +388,9 @@ function initRuntime() {
 #endif
   runtimeInitialized = true;
 #if STACK_OVERFLOW_CHECK >= 2
+#if RUNTIME_LOGGING
+  err('__set_stack_limits: ' + _emscripten_stack_get_base() + ', ' + _emscripten_stack_get_end());
+#endif
   ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
 #endif
   {{{ getQuoted('ATINITS') }}}

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -184,3 +184,9 @@ var STRUCT_INFO = '';
 var MEMORYPROFILER = 0;
 
 var GENERATE_SOURCE_MAP = 0;
+
+// Memory layout.  These are only used/set in RELOCATABLE builds.  Otherwise
+// memory layout is fixed in the wasm binary at link time.
+var STACK_BASE = 0;
+var STACK_MAX = 0;
+var HEAP_BASE = 0;


### PR DESCRIPTION
Rather then using `getQuoted` and then special-case replacements for
pre/post we can just use internal settings.

This has the advantage that these settings can be included in library
code as we as the pre/post js.

After this change getQuoted now only has a couple of remainging
uses for ATINITS, ATEXITS, ATMAINS and WASM_BINARY_DATA