### PR TITLE
Remove old leftover MEMFS code

### DIFF
--- a/tests/core/FS_exports.cpp
+++ b/tests/core/FS_exports.cpp
@@ -24,7 +24,7 @@ int main() {
 #endif
   EM_ASM({
     // use eval, so that the compiler can't see FS usage statically
-    eval('out("Data: " + JSON.stringify(MEMFS.getFileDataAsTypedArray(FS.root.contents["file.txt"])))');
+    eval('out("Data: " + JSON.stringify(Array.from(MEMFS.getFileDataAsTypedArray(FS.root.contents["file.txt"]))))');
   });
 }
 

--- a/tests/core/FS_exports.cpp
+++ b/tests/core/FS_exports.cpp
@@ -24,7 +24,7 @@ int main() {
 #endif
   EM_ASM({
     // use eval, so that the compiler can't see FS usage statically
-    eval('out("Data: " + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.root.contents["file.txt"])))');
+    eval('out("Data: " + JSON.stringify(MEMFS.getFileDataAsTypedArray(FS.root.contents["file.txt"])))');
   });
 }
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1061,7 +1061,7 @@ class benchmark(runner.RunnerCore):
             var hash = 5381;
             var totalSize = 0;
             files.forEach(function(file) {
-              var data = MEMFS.getFileDataAsRegularArray(FS.root.contents[file]);
+              var data = MEMFS.getFileDataAsTypedArray(FS.root.contents[file]);
               for (var i = 0; i < data.length; i++) {
                 hash = ((hash << 5) + hash) ^ (data[i] & 0xff);
               }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1061,7 +1061,7 @@ class benchmark(runner.RunnerCore):
             var hash = 5381;
             var totalSize = 0;
             files.forEach(function(file) {
-              var data = MEMFS.getFileDataAsTypedArray(FS.root.contents[file]);
+              var data = Array.from(MEMFS.getFileDataAsTypedArray(FS.root.contents[file]));
               for (var i = 0; i < data.length; i++) {
                 hash = ((hash << 5) + hash) ^ (data[i] & 0xff);
               }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6001,7 +6001,7 @@ return malloc(size);
       FS.createDataFile('/', 'paper.pdf', eval(read_('paper.pdf.js')), true, false, false);
     };
     Module.postRun = function() {
-      var FileData = MEMFS.getFileDataAsRegularArray(FS.root.contents['filename-1.ppm']);
+      var FileData = MEMFS.getFileDataAsTypedArray(FS.root.contents['filename-1.ppm']);
       out("Data: " + JSON.stringify(FileData.map(function(x) { return unSign(x, 8) })));
     };
     ''')
@@ -6038,7 +6038,7 @@ return malloc(size);
       create_test_file('pre.js', """
         Module.preRun = function() { FS.createDataFile('/', 'image.j2k', %s, true, false, false); };
         Module.postRun = function() {
-          out('Data: ' + JSON.stringify(MEMFS.getFileDataAsRegularArray(FS.analyzePath('image.raw').object)));
+          out('Data: ' + JSON.stringify(MEMFS.getFileDataAsTypedArray(FS.analyzePath('image.raw').object)));
         };
         """ % line_splitter(str(image_bytes)))
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6001,7 +6001,7 @@ return malloc(size);
       FS.createDataFile('/', 'paper.pdf', eval(read_('paper.pdf.js')), true, false, false);
     };
     Module.postRun = function() {
-      var FileData = MEMFS.getFileDataAsTypedArray(FS.root.contents['filename-1.ppm']);
+      var FileData = Array.from(MEMFS.getFileDataAsTypedArray(FS.root.contents['filename-1.ppm']));
       out("Data: " + JSON.stringify(FileData.map(function(x) { return unSign(x, 8) })));
     };
     ''')
@@ -6038,7 +6038,7 @@ return malloc(size);
       create_test_file('pre.js', """
         Module.preRun = function() { FS.createDataFile('/', 'image.j2k', %s, true, false, false); };
         Module.postRun = function() {
-          out('Data: ' + JSON.stringify(MEMFS.getFileDataAsTypedArray(FS.analyzePath('image.raw').object)));
+          out('Data: ' + JSON.stringify(Array.from(MEMFS.getFileDataAsTypedArray(FS.analyzePath('image.raw').object))));
         };
         """ % line_splitter(str(image_bytes)))
 


### PR DESCRIPTION
In PR #7918, the option MEMFS_APPEND_TO_TYPED_ARRAYS=0 was removed, dropping the support for using regular JS Arrays to back MEMFS file storage. In this PR, complete the removal of old code that related to JS Array backing, since all files are now always typed array backed.