### PR TITLE
Disabling flaky test_pthread_cond_signal_1_1

### DIFF
--- a/tests/test_posixtest.py
+++ b/tests/test_posixtest.py
@@ -135,9 +135,16 @@ unsupported = {
   'test_pthread_spin_lock_3_1': 'signals are not supported',
 }
 
+# Mark certain tests as flaky, which may sometimes fail.
+# TODO invesigate these tests.
+flaky = {
+  'test_pthread_cond_signal_1_1': 'flaky: https://github.com/emscripten-core/emscripten/issues/13283',
+}
+
 # Mark certain tests as not passing
 disabled = {
   **unsupported,
+  **flaky,
   'test_pthread_create_11_1': 'never returns',
   'test_pthread_barrier_wait_2_1': 'never returns',
   'test_pthread_cond_timedwait_2_6': 'never returns',


### PR DESCRIPTION
test_pthread_cond_signal_1_1 has very tight timing requirements, and
expects that side threads will be woken and do some action in very short
time. This causes occasional spurious fail of this test not because side
thread(s) hasn't been woken by pthread_cond_signal, but because this
threads hasn't been scheduled and hasn't get CPU on time.