### PR TITLE
Cleanup --memory-init-file handling

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -94,10 +94,10 @@ var EXIT_RUNTIME = 0;
 
 // How to represent the initial memory content.
 // 0: embed a base64 string literal representing the initial memory data
-// 1: create a *.mem file containing the binary data of the initial memory;
+// 1: memory init done inside wasm of via a *.mem binary data file
 
 //    use the --memory-init-file command line switch to select this method
-var MEM_INIT_METHOD = 0;
+var MEM_INIT_METHOD = 1;
 
 // The total stack size. There is no way to enlarge the stack, so this
 // value must be large enough for the program's requirements. If

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -113,7 +113,7 @@ var PTHREAD_WORKER_FILE = '';
 // Base URL the source mapfile, if relevant
 var SOURCE_MAP_BASE = '';
 
-var MEM_INIT_IN_WASM = 0;
+var MEM_INIT_IN_WASM = 1;
 
 // If set to 1, src/base64Utils.js will be included in the bundle.
 // This is set internally when needed (SINGLE_FILE)


### PR DESCRIPTION
- Bring all the handling of this option into a single location
- Don't override the option itself (that signifies the actual user command
  line option).

This change is not-quite-NFC because it does generate more errors
in cases where `--memory-init-file` is specified but was previously
ignored.  For example if this option is used without WASM=0 (i.e.
with WebAssembly output) this is now an error.