### PR TITLE
Don't include webgl2.c in regular gl library

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1453,8 +1453,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       exit_with_error('Cannot set GLOBAL_BASE when building SIDE_MODULE')
 
     if shared.Settings.RELOCATABLE:
-      shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
-      shared.Settings.WARN_ON_UNDEFINED_SYMBOLS = 0
+      default_setting('ERROR_ON_UNDEFINED_SYMBOLS', 0)
+      default_setting('WARN_ON_UNDEFINED_SYMBOLS', 0)
 
     if shared.Settings.DISABLE_EXCEPTION_THROWING and not shared.Settings.DISABLE_EXCEPTION_CATCHING:
       exit_with_error("DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0). If you don't want exceptions, set DISABLE_EXCEPTION_CATCHING to 1; if you do want exceptions, don't link with -fno-exceptions")

--- a/tests/core/test_gl_get_proc_address.c
+++ b/tests/core/test_gl_get_proc_address.c
@@ -1,0 +1,10 @@
+#include <emscripten/html5_webgl.h>
+
+// This test just verifies the libgl can be linked with MAIN_MODULE=1.
+// All we do here is reference a symbol libgl to cause it be added to the link
+// line.
+
+int main(int argc, char* argv[]) {
+  emscripten_webgl_get_proc_address("foo");
+  return 0;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8265,6 +8265,11 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args += ['--bind', '--post-js', path_from_root('tests', 'core', 'test_abort_on_exception_post.js')]
     self.do_run_in_out_file_test('tests', 'core', 'test_abort_on_exception.cpp')
 
+  @needs_dlfcn
+  def test_gl_main_module(self):
+    self.set_setting('MAIN_MODULE')
+    self.do_runf(path_from_root('tests', 'core', 'test_gl_get_proc_address.c'))
+
 
 # Generate tests for everything
 def make_run(name, emcc_args, settings=None, env=None):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1073,7 +1073,7 @@ class libgl(MTLibrary):
   name = 'libgl'
 
   src_dir = ['system', 'lib', 'gl']
-  src_glob = '*.c'
+  src_files = ['gl.c', 'webgl1.c']
 
   cflags = ['-Oz']
 
@@ -1082,6 +1082,10 @@ class libgl(MTLibrary):
     self.is_webgl2 = kwargs.pop('is_webgl2')
     self.is_ofb = kwargs.pop('is_ofb')
     self.is_full_es3 = kwargs.pop('is_full_es3')
+    if self.is_webgl2 or self.is_full_es3:
+      # Don't use append or += here, otherwise we end up adding to
+      # the class member.
+      self.src_files = self.src_files + ['webgl2.c']
     super(libgl, self).__init__(**kwargs)
 
   def get_base_name(self):


### PR DESCRIPTION
This fixes big where linking MAIN_MODULE and libgl was bring in
undefined refereces to gl2 symbols.  Normally including this extra
webgl.c file in the library would be harmless since it will be ignored
if no gl2 symbols are used.

However, with MAIN_MODULE mode all objects from all libraries are
included which means that webgl2.o is included which itself references
all webgl2 symbols.

Fixes: #13101