### PR TITLE
Remove need to `getQuoted` by using separate template pattern

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2829,7 +2829,7 @@ def do_binaryen(target, options, wasm_target):
     js = open(final_js).read()
 
     if shared.Settings.MINIMAL_RUNTIME:
-      js = do_replace(js, '{{{ WASM_BINARY_DATA }}}', base64_encode(open(wasm_target, 'rb').read()))
+      js = do_replace(js, '<<< WASM_BINARY_DATA >>>', base64_encode(open(wasm_target, 'rb').read()))
     else:
       js = do_replace(js, '<<< WASM_BINARY_FILE >>>', shared.JS.get_subresource_location(wasm_target))
     shared.try_delete(wasm_target)

--- a/emscripten.py
+++ b/emscripten.py
@@ -163,9 +163,9 @@ def update_settings_glue(metadata, DEBUG):
 
 
 def apply_static_code_hooks(forwarded_json, code):
-  code = code.replace('{{{ ATINITS }}}', str(forwarded_json['ATINITS']))
-  code = code.replace('{{{ ATMAINS }}}', str(forwarded_json['ATMAINS']))
-  code = code.replace('{{{ ATEXITS }}}', str(forwarded_json['ATEXITS']))
+  code = code.replace('<<< ATINITS >>>', str(forwarded_json['ATINITS']))
+  code = code.replace('<<< ATMAINS >>>', str(forwarded_json['ATMAINS']))
+  code = code.replace('<<< ATEXITS >>>', str(forwarded_json['ATEXITS']))
   return code
 
 

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1040,13 +1040,6 @@ function addAtExit(code) {
   }
 }
 
-// Some things, like the dynamic and stack bases, will be computed later and
-// applied. Return them as {{{ STR }}} for that replacing later.
-
-function getQuoted(str) {
-  return '{{{ ' + str + ' }}}';
-}
-
 function makeRetainedCompilerSettings() {
   var ignore = set('STRUCT_INFO');
   if (STRICT) {

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -27,7 +27,7 @@ function run() {
 
 #if EXIT_RUNTIME
   callRuntimeCallbacks(__ATEXIT__);
-  {{{ getQuoted('ATEXITS') }}}
+  <<< ATEXITS >>>
 #if USE_PTHREADS
   PThread.runExitHandlers();
 #endif
@@ -79,7 +79,7 @@ function initRuntime(asm) {
   asm['__wasm_call_ctors']();
 #endif
 
-  {{{ getQuoted('ATINITS') }}}
+  <<< ATINITS >>>
 }
 
 // Initialize wasm (asynchronous)

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -393,7 +393,7 @@ function initRuntime() {
 #endif
   ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
 #endif
-  {{{ getQuoted('ATINITS') }}}
+  <<< ATINITS >>>
   callRuntimeCallbacks(__ATINIT__);
 }
 
@@ -404,7 +404,7 @@ function preMain() {
 #if USE_PTHREADS
   if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
 #endif
-  {{{ getQuoted('ATMAINS') }}}
+  <<< ATMAINS >>>
   callRuntimeCallbacks(__ATMAIN__);
 }
 
@@ -417,7 +417,7 @@ function exitRuntime() {
 #endif
 #if EXIT_RUNTIME
   callRuntimeCallbacks(__ATEXIT__);
-  {{{ getQuoted('ATEXITS') }}}
+  <<< ATEXITS >>>
 #if USE_PTHREADS
   PThread.runExitHandlers();
 #endif

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -55,7 +55,7 @@ if (Module['doWasm2JS']) {
 
 #if SINGLE_FILE && WASM == 1 && !WASM2JS
 #include "base64Decode.js"
-Module['wasm'] = base64Decode('{{{ getQuoted("WASM_BINARY_DATA") }}}');
+Module['wasm'] = base64Decode('<<< WASM_BINARY_DATA >>>');
 #endif
 
 #include "runtime_functions.js"


### PR DESCRIPTION
Use `<<<` and `>>>` for late-substitution replacements as opposed to `{{{` and
`}}}` which is used to by the JS compiler.

This avoids the somewhat confusing `getQuoted` function which worked as
an escape hatch.