### PR TITLE
Fix definition of mtx_t and cond_t

### DIFF
--- a/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
@@ -95,14 +95,22 @@ typedef struct { union { int __i[10]; volatile int __vi[10]; unsigned __s[10]; }
 
 #if defined(__NEED_pthread_mutex_t) && !defined(__DEFINED_pthread_mutex_t)
 typedef struct { union { int __i[7]; volatile int __vi[7]; volatile void *__p[7]; } __u; } pthread_mutex_t;
-typedef pthread_mutex_t mtx_t;
 #define __DEFINED_pthread_mutex_t
+#endif
+
+#if defined(__NEED_mtx_t) && !defined(__DEFINED_mtx_t)
+typedef struct { union { int __i[7]; volatile int __vi[7]; volatile void *__p[7]; } __u; } mtx_t;
+#define __DEFINED_mtx_t
 #endif
 
 #if defined(__NEED_pthread_cond_t) && !defined(__DEFINED_pthread_cond_t)
 typedef struct { union { int __i[12]; volatile int __vi[12]; void *__p[12]; } __u; } pthread_cond_t;
-typedef pthread_cond_t cnd_t;
 #define __DEFINED_pthread_cond_t
+#endif
+
+#if defined(__NEED_cnd_t) && !defined(__DEFINED_cnd_t)
+typedef struct { union { int __i[12]; volatile int __vi[12]; void *__p[12]; } __u; } cnd_t;
+#define __DEFINED_cnd_t
 #endif
 
 #if defined(__NEED_pthread_rwlock_t) && !defined(__DEFINED_pthread_rwlock_t)

--- a/system/lib/libc/musl/include/threads.h
+++ b/system/lib/libc/musl/include/threads.h
@@ -20,11 +20,6 @@ typedef void (*tss_dtor_t)(void *);
 #define __NEED_cnd_t
 #define __NEED_mtx_t
 
-// XXX Emscripten: Fix musl libc issue, where the above defines are wrong, but instead should be the following: (https://github.com/emscripten-core/emscripten/issues/5343)
-#define __NEED_pthread_cond_t
-#define __NEED_pthread_mutex_t
-// XXX
-
 #include <bits/alltypes.h>
 
 #define TSS_DTOR_ITERATIONS 4


### PR DESCRIPTION
The convention in musl is to duplicate these types rather than
typedef them.

Fixes: #5343