### PR TITLE
Remove redundant zero'ing of pthread fields. NFC.

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -533,12 +533,10 @@ var LibraryPThread = {
       threadInfoStruct: threadParams.pthread_ptr
     };
     var tis = pthread.threadInfoStruct >> 2;
-    Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.threadStatus }}} >> 2), 0); // threadStatus <- 0, meaning not yet exited.
-    Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.threadExitCode }}} >> 2), 0); // threadExitCode <- 0.
-    Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.profilerBlock }}} >> 2), 0); // profilerBlock <- 0.
+    // spawnThread is always called with a zero-initialized thread struct so
+    // no need to set any valudes to zero here.
     Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.detached }}} >> 2), threadParams.detached);
     Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.tsd }}} >> 2), tlsMemory); // Init thread-local-storage memory array.
-    Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.tsd_used }}} >> 2), 0); // Mark initial status to unused.
     Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.tid }}} >> 2), pthread.threadInfoStruct); // Main thread ID.
     Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.stack_size }}} >> 2), threadParams.stackSize);
     Atomics.store(HEAPU32, tis + ({{{ C_STRUCTS.pthread.stack }}} >> 2), stackHigh);

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1462,7 +1462,6 @@
               "profilerBlock",
               "self",
               "tsd",
-              "tsd_used",
               "detached",
               "stack",
               "stack_size",


### PR DESCRIPTION
The spawnThread function is only even called with struct that
have already been zero-initialized in pthread_create.

This is preemptive change to handle the upcoming musl upgrade
that makes `tsd_used` into a bitfield (which gen_struct_info can't
handle).