### PR TITLE
Remove redundant USE_THREADS macro in system_libs.py. NFC

### DIFF
--- a/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
@@ -105,7 +105,7 @@ INTERCEPTOR(int, pthread_create, void *thread,
 
 namespace __lsan {
 
-#ifndef USE_THREADS
+#ifndef __EMSCRIPTEN_PTHREADS__
 // XXX HACK: Emscripten treats thread_local variables the same as globals in
 // non-threaded builds, so a hack was introduced where we skip the allocator
 // cache in the common module. Now we have to define this symbol to keep that

--- a/system/lib/compiler-rt/lib/lsan/lsan_common.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan_common.cpp
@@ -170,7 +170,7 @@ void ScanRangeForPointers(uptr begin, uptr end,
   // Emscripten in non-threaded mode stores thread_local variables in the
   // same place as normal globals. This means allocator_cache must be skipped
   // when scanning globals instead of when scanning thread-locals.
-#if SANITIZER_EMSCRIPTEN && !defined(USE_THREADS)
+#if SANITIZER_EMSCRIPTEN && !defined(__EMSCRIPTEN_PTHREADS__)
   uptr cache_begin, cache_end;
   GetAllocatorCacheRange(&cache_begin, &cache_end);
 #endif
@@ -194,7 +194,7 @@ void ScanRangeForPointers(uptr begin, uptr end,
       continue;
     }
 
-#if SANITIZER_EMSCRIPTEN && !defined(USE_THREADS)
+#if SANITIZER_EMSCRIPTEN && !defined(__EMSCRIPTEN_PTHREADS__)
     if (cache_begin <= pp && pp < cache_end) {
       LOG_POINTERS("%p: skipping because it overlaps the cache %p-%p.\n",
           pp, cache_begin, cache_end);

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cpp
@@ -116,7 +116,7 @@ void GetThreadStackAndTls(bool main, uptr *stk_addr, uptr *stk_size,
   uptr stk_top;
   GetThreadStackTopAndBottom(true, &stk_top, stk_addr);
   *stk_size = stk_top - *stk_addr;
-#ifdef USE_THREADS
+#ifdef __EMSCRIPTEN_PTHREADS__
   *tls_addr = (uptr) __builtin_wasm_tls_base();
   *tls_size = __builtin_wasm_tls_size();
 #else

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -528,7 +528,7 @@ class MTLibrary(Library):
   def get_cflags(self):
     cflags = super(MTLibrary, self).get_cflags()
     if self.is_mt:
-      cflags += ['-s', 'USE_PTHREADS=1', '-DUSE_THREADS']
+      cflags += ['-s', 'USE_PTHREADS']
     return cflags
 
   def get_base_name(self):


### PR DESCRIPTION
We already automatically define `__EMSCRIPTEN_THREADS__` in emcc.py
whenever `-s USE_PTHREADS` is enabled.