### PR TITLE
test: remove two unneeded include paths. NFC.

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -569,8 +569,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     dirname, basename = os.path.split(filename)
     output = shared.unsuffixed(basename) + suffix
-    cmd = compiler + [filename, '-o', output] + self.get_emcc_args(main_file=True) + \
-        ['-I.', '-I' + dirname, '-I' + os.path.join(dirname, 'include')] + \
+    cmd = compiler + [filename, '-o', output, '-I.'] + self.get_emcc_args(main_file=True) + \
         ['-I' + include for include in includes] + \
         libraries
 


### PR DESCRIPTION
These just added needless extra flag to every test build command.  If individual tests
need extra include paths they can add them themselves, but it looks like none of 
our tests currently do.