### PR TITLE
parseTools: remove unused variables

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -577,9 +577,6 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
 
   var offset = calcFastOffset(ptr, pos, noNeedFirst);
   if (SAFE_HEAP && !noSafe) {
-    var printType = type;
-    if (printType !== 'null' && printType[0] !== '#') printType = '"' + safeQuote(printType) + '"';
-    if (printType[0] === '#') printType = printType.substr(1);
     if (!ignore) {
       return asmCoercion('SAFE_HEAP_LOAD' + ((type in Compiletime.FLOAT_TYPES) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + Runtime.getNativeTypeSize(type) + ', ' + (!!unsigned+0) + ')', type, unsigned ? 'u' : undefined);
     }
@@ -657,9 +654,6 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
 
   var offset = calcFastOffset(ptr, pos, noNeedFirst);
   if (SAFE_HEAP && !noSafe) {
-    var printType = type;
-    if (printType !== 'null' && printType[0] !== '#') printType = '"' + safeQuote(printType) + '"';
-    if (printType[0] === '#') printType = printType.substr(1);
     if (!ignore) {
       return 'SAFE_HEAP_STORE' + ((type in Compiletime.FLOAT_TYPES) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + asmCoercion(value, type) + ', ' + Runtime.getNativeTypeSize(type) + ')';
     }


### PR DESCRIPTION
Looks like the actual usage of printType was removed back in
66bd874d9bcc3a0ef2b9892253ee8359525ce48d.