### PR TITLE
Acquire the cache lock before checking for sanity file

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- Fix race condition when running many emcc processes after clearing the cache.
+  The processes would race to run the sanity checks and could interfere with
+  each other (#13299).
 - Emscripten now builds a complete sysroot inside the EM_CACHE directory.
   This includes the system headers which get copied into place there rather
   than adding a sequence of extra include directories.

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -405,7 +405,8 @@ fi
 
   def assertCacheEmpty(self):
     if os.path.exists(Cache.dirname):
-      self.assertEqual(os.listdir(Cache.dirname), [])
+      # The cache is considered empty if it contains no files at all or just the cache.lock
+      self.assertIn(os.listdir(Cache.dirname), ([], ['cache.lock']))
 
   def ensure_cache(self):
     self.do([EMCC, '-O2', path_from_root('tests', 'hello_world.c')])

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -149,7 +149,6 @@ class Cache:
           what = 'system asset'
       message = 'generating ' + what + ': ' + shortname + '... (this will be cached in "' + cachename + '" for subsequent builds)'
       logger.info(message)
-      self.ensure()
       temp = creator()
       if os.path.normcase(temp) != os.path.normcase(cachename):
         utils.safe_ensure_dirs(os.path.dirname(cachename))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -274,47 +274,47 @@ def check_sanity(force=False):
     expected = generate_sanity()
 
     sanity_file = Cache.get_path('sanity.txt')
-    if os.path.exists(sanity_file):
-      sanity_data = open(sanity_file).read()
-      if sanity_data != expected:
-        logger.debug('old sanity: %s' % sanity_data)
-        logger.debug('new sanity: %s' % expected)
-        if config.FROZEN_CACHE:
-          logger.info('(Emscripten: config changed, cache may need to be cleared, but FROZEN_CACHE is set)')
+    with Cache.lock():
+      if os.path.exists(sanity_file):
+        sanity_data = open(sanity_file).read()
+        if sanity_data != expected:
+          logger.info('old sanity: %s' % sanity_data)
+          logger.info('new sanity: %s' % expected)
+          if config.FROZEN_CACHE:
+            logger.info('(Emscripten: config changed, cache may need to be cleared, but FROZEN_CACHE is set)')
+          else:
+            logger.info('(Emscripten: config changed, clearing cache)')
+            Cache.erase()
+            # the check actually failed, so definitely write out the sanity file, to
+            # avoid others later seeing failures too
+            force = False
         else:
-          logger.info('(Emscripten: config changed, clearing cache)')
-          Cache.erase()
-          # the check actually failed, so definitely write out the sanity file, to
-          # avoid others later seeing failures too
-          force = False
+          if force:
+            logger.debug(f'sanity file up-to-date but check forced: {sanity_file}')
+          else:
+            logger.debug(f'sanity file up-to-date: {sanity_file}')
+            return # all is well
       else:
-        if force:
-          logger.debug(f'sanity file up-to-date but check forced: {sanity_file}')
-        else:
-          logger.debug(f'sanity file up-to-date: {sanity_file}')
-          return # all is well
-    else:
-      logger.debug(f'sanity file not found: {sanity_file}')
+        logger.debug(f'sanity file not found: {sanity_file}')
 
-    # some warning, mostly not fatal checks - do them even if EM_IGNORE_SANITY is on
-    check_node_version()
+      # some warning, mostly not fatal checks - do them even if EM_IGNORE_SANITY is on
+      check_node_version()
 
-    llvm_ok = check_llvm()
+      llvm_ok = check_llvm()
 
-    if os.environ.get('EM_IGNORE_SANITY'):
-      logger.info('EM_IGNORE_SANITY set, ignoring sanity checks')
-      return
+      if os.environ.get('EM_IGNORE_SANITY'):
+        logger.info('EM_IGNORE_SANITY set, ignoring sanity checks')
+        return
 
-    if not llvm_ok:
-      exit_with_error('failing sanity checks due to previous llvm failure')
+      if not llvm_ok:
+        exit_with_error('failing sanity checks due to previous llvm failure')
 
-    perform_sanity_checks()
+      perform_sanity_checks()
 
-    if not force:
-      # Only create/update this file if the sanity check succeeded, i.e., we got here
-      Cache.ensure()
-      with open(sanity_file, 'w') as f:
-        f.write(expected)
+      if not force:
+        # Only create/update this file if the sanity check succeeded, i.e., we got here
+        with open(sanity_file, 'w') as f:
+          f.write(expected)
 
 
 # Some distributions ship with multiple llvm versions so they add


### PR DESCRIPTION
Without this check there is a race to create that sanity file when
emscripten if first used.   I noticed this strange behavior when I would
run the test suite just after clearig the cache.

On my machine the test suite would launch many emcc processes and each
of them would notice the sanity file as missing and run the checks.
Some of them would see an empty sanify file that one of the other
processes was in the middle of creating (before they flushed it), and
when this happens that process would try to clear the cache!  This
resulted in the cache being clearing by one process while it was being
populated by another.  Not good.

The fix is the hold the cache lock while we check for the sanity file
and while we run the sanity checks.

This problem has always existed but was recently exacerbated by the fact
that we populate the sysroot headers as soon as we start emcc.

Also remove superfluous ensure() calls.  Since we call this during
 the constructor these days the cache can be assumed to always exist.
