### PR TITLE
Default to TEXTDECODER=2 in -Oz builds

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1244,6 +1244,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       default_setting('IGNORE_MISSING_MAIN', 0)
       default_setting('DEFAULT_TO_CXX', 0)
 
+    # Default to TEXTDECODER=2 (always use TextDecoder to decode UTF-8 strings)
+    # in -Oz builds, since custom decoder for UTF-8 takes up space.
+    if shared.Settings.SHRINK_LEVEL >= 2 and not shared.Settings.USE_PTHREADS:
+      default_setting('TEXTDECODER', 2)
+
     # If set to 1, we will run the autodebugger (the automatic debugging tool, see
     # tools/autodebugger).  Note that this will disable inclusion of libraries. This
     # is useful because including dlmalloc makes it hard to compare native and js

--- a/emcc.py
+++ b/emcc.py
@@ -1246,6 +1246,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     # Default to TEXTDECODER=2 (always use TextDecoder to decode UTF-8 strings)
     # in -Oz builds, since custom decoder for UTF-8 takes up space.
+    # In pthreads enabled builds, TEXTDECODER==2 may not work, see
+    # https://github.com/whatwg/encoding/issues/172
     if shared.Settings.SHRINK_LEVEL >= 2 and not shared.Settings.USE_PTHREADS:
       default_setting('TEXTDECODER', 2)
 
@@ -1512,7 +1514,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         exit_with_error('USE_PTHREADS=2 is not longer supported')
       if shared.Settings.ALLOW_MEMORY_GROWTH:
         diagnostics.warning('pthreads-mem-growth', 'USE_PTHREADS + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271')
-      # UTF8Decoder.decode doesn't work with a view of a SharedArrayBuffer
+      # UTF8Decoder.decode may not work with a view of a SharedArrayBuffer, see https://github.com/whatwg/encoding/issues/172
       shared.Settings.TEXTDECODER = 0
       shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_pthread.js')))
       newargs += ['-pthread']

--- a/src/settings.js
+++ b/src/settings.js
@@ -1534,7 +1534,8 @@ var EVAL_CTORS = 0;
 // Is enabled, use the JavaScript TextDecoder API for string marshalling.
 // Enabled by default, set this to 0 to disable.
 // If set to 2, we assume TextDecoder is present and usable, and do not emit
-// any JS code to fall back if it is missing.
+// any JS code to fall back if it is missing. In single threaded -Oz build modes,
+// TEXTDECODER defaults to value == 2 to save code size.
 // [link]
 var TEXTDECODER = 1;
 


### PR DESCRIPTION
Default to TEXTDECODER=2 in -Oz builds to save 0.5KB-1KB of build output size.