### PR TITLE
Add eslint for JS linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,9 @@ orbs:
   win: circleci/windows@1.0.0
 
 executors:
+  linux-node:
+    docker:
+      - image: circleci/node:stretch
   bionic:
     docker:
       - image: emscripten/emscripten-ci
@@ -339,6 +342,12 @@ jobs:
       - checkout
       - run: pip3 install -r requirements-dev.txt
       - run: python3 -m flake8 --show-source --statistics
+  eslint:
+    executor: linux-node
+    steps:
+      - checkout
+      - npm-install
+      - run: npm run lint
   test-sanity:
     executor: bionic
     steps:
@@ -479,6 +488,7 @@ workflows:
   build-test:
     jobs:
       - flake8
+      - eslint
       - build-docs
       - build-linux
       - test-sanity:

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,16 @@
+env:
+  browser: true
+  es2020: true
+  node: true
+extends:
+  - google
+parserOptions:
+  ecmaVersion: 12
+ignorePatterns: "library_*.js"
+rules:
+  #max-len: ["error", 100]
+  max-len: "off"
+  require-jsdoc: "off"
+  no-unused-vars: "off"
+  space-infix-ops: "error"
+  quotes: ["error", "single", {"avoidEscape": true}]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,15 +2,100 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.11.tgz",
+      "integrity": "sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.10.4"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.12.11",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
+      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "dev": true
+    },
+    "@babel/highlight": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+      "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "@eslint/eslintrc": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.3.0.tgz",
+      "integrity": "sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.12.4",
+        "debug": "^4.1.1",
+        "espree": "^7.3.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^3.13.1",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "strip-json-comments": "^3.1.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        }
+      }
+    },
     "acorn": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
       "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
     },
+    "acorn-jsx": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
+      "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
     "ansi": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
       "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+      "dev": true
+    },
+    "ansi-colors": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+      "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true
     },
     "ansi-escapes": {
@@ -42,6 +127,21 @@
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
     },
     "async": {
       "version": "1.0.0",
@@ -75,6 +175,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
       "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+    },
+    "callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true
     },
     "camel-case": {
       "version": "3.0.0",
@@ -238,6 +344,17 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
+    "cross-spawn": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
+      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "dev": true,
+      "requires": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      }
+    },
     "cycle": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
@@ -253,11 +370,41 @@
         "ms": "2.0.0"
       }
     },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
       "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "enquirer": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
+      "integrity": "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==",
+      "dev": true,
+      "requires": {
+        "ansi-colors": "^4.1.1"
+      }
     },
     "es-check": {
       "version": "5.1.0",
@@ -282,6 +429,248 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+    },
+    "eslint": {
+      "version": "7.18.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.18.0.tgz",
+      "integrity": "sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@eslint/eslintrc": "^0.3.0",
+        "ajv": "^6.10.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "enquirer": "^2.3.5",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^2.1.0",
+        "eslint-visitor-keys": "^2.0.0",
+        "espree": "^7.3.1",
+        "esquery": "^1.2.0",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^6.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "glob-parent": "^5.0.0",
+        "globals": "^12.1.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "js-yaml": "^3.13.1",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash": "^4.17.20",
+        "minimatch": "^3.0.4",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.1",
+        "progress": "^2.0.0",
+        "regexpp": "^3.1.0",
+        "semver": "^7.2.1",
+        "strip-ansi": "^6.0.0",
+        "strip-json-comments": "^3.1.0",
+        "table": "^6.0.4",
+        "text-table": "^0.2.0",
+        "v8-compile-cache": "^2.0.3"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+          "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
+    "eslint-config-google": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-google/-/eslint-config-google-0.14.0.tgz",
+      "integrity": "sha512-WsbX4WbjuMvTdeVL6+J3rK1RGhCTqjsFjX7UMSMgZiyxxaNLkoJENbrGExzERFeoTpGw3F3FypTiWAP9ZXzkEw==",
+      "dev": true
+    },
+    "eslint-scope": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+      "dev": true,
+      "requires": {
+        "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "eslint-visitor-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.1.tgz",
+      "integrity": "sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==",
+      "dev": true,
+      "requires": {
+        "acorn": "^7.4.0",
+        "acorn-jsx": "^5.3.1",
+        "eslint-visitor-keys": "^1.3.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "7.4.1",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
+          "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
+          "dev": true
+        },
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.3.1.tgz",
+      "integrity": "sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.1.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^5.2.0"
+      },
+      "dependencies": {
+        "estraverse": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+          "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+          "dev": true
+        }
+      }
+    },
+    "estraverse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -312,6 +701,18 @@
       "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=",
       "dev": true
     },
+    "fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
     "fast-levenshtein": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
@@ -328,10 +729,41 @@
         "object-assign": "^4.1.0"
       }
     },
+    "file-entry-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
+      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^3.0.4"
+      }
+    },
+    "flat-cache": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
+      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "dev": true,
+      "requires": {
+        "flatted": "^3.1.0",
+        "rimraf": "^3.0.2"
+      }
+    },
+    "flatted": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
+      "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
     "gauge": {
@@ -359,6 +791,24 @@
         "minimatch": "^3.0.4",
         "once": "^1.3.0",
         "path-is-absolute": "^1.0.0"
+      }
+    },
+    "glob-parent": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "dev": true,
+      "requires": {
+        "is-glob": "^4.0.1"
+      }
+    },
+    "globals": {
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
+      "integrity": "sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==",
+      "dev": true,
+      "requires": {
+        "type-fest": "^0.8.1"
       }
     },
     "google-closure-compiler": {
@@ -452,6 +902,28 @@
           "integrity": "sha512-NIQrwvv9V39FHgGFm36+U9SMQzbiHvU79k+iADraJTpmrFFfx7Ds0IvDoAdZsDrknlkRk14OYoWXb57uTh7/sw=="
         }
       }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
+      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "inflight": {
       "version": "1.0.6",
@@ -552,22 +1024,81 @@
         }
       }
     },
+    "is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+      "dev": true
+    },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-glob": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "dev": true,
+      "requires": {
+        "is-extglob": "^2.1.1"
+      }
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
       "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      }
     },
     "lodash": {
       "version": "4.17.20",
@@ -615,6 +1146,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.4.tgz",
       "integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "micromist": {
       "version": "1.1.0",
@@ -666,6 +1206,12 @@
       "integrity": "sha1-riT4hQgY1mL8q1rPfzuVv6oszzg=",
       "dev": true
     },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
     "no-case": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/no-case/-/no-case-2.3.2.tgz",
@@ -712,6 +1258,20 @@
       "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
       "dev": true
     },
+    "optionator": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+      "integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
+      "dev": true,
+      "requires": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.3"
+      }
+    },
     "options": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
@@ -738,10 +1298,25 @@
         "no-case": "^2.2.0"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
     "pinkie": {
@@ -759,6 +1334,12 @@
         "pinkie": "^2.0.0"
       }
     },
+    "prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true
+    },
     "prettyjson": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.2.1.tgz",
@@ -774,6 +1355,18 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
     "readable-stream": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
@@ -787,6 +1380,12 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
+    },
+    "regexpp": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
+      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "dev": true
     },
     "relateurl": {
       "version": "0.2.7",
@@ -803,6 +1402,18 @@
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.1.tgz",
       "integrity": "sha512-yD5BHCe7quCgBph4rMQ+0KkIRKwWCrHDOX1p1Gp6HwjPM5kVoCdKGNhN7ydqqsX6lJEnQDKZ/tFMiEdQ1dvPEw=="
     },
+    "require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
@@ -811,6 +1422,15 @@
       "requires": {
         "exit-hook": "^1.0.0",
         "onetime": "^1.0.0"
+      }
+    },
+    "rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
       }
     },
     "run-async": {
@@ -829,6 +1449,73 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "semver": {
+      "version": "7.3.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+      "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^3.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        }
+      }
     },
     "source-map": {
       "version": "0.5.6",
@@ -860,6 +1547,12 @@
         "concat-stream": "^1.4.7",
         "os-shim": "^0.1.2"
       }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -894,12 +1587,82 @@
         "ansi-regex": "^3.0.0"
       }
     },
+    "strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.0.7.tgz",
+      "integrity": "sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==",
+      "dev": true,
+      "requires": {
+        "ajv": "^7.0.2",
+        "lodash": "^4.17.20",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "7.0.3",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-7.0.3.tgz",
+          "integrity": "sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "ansi-regex": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
+        }
       }
     },
     "tabtab": {
@@ -940,6 +1703,12 @@
         }
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -961,6 +1730,21 @@
         "os-tmpdir": "~1.0.1"
       }
     },
+    "type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "^1.2.1"
+      }
+    },
+    "type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true
+    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -972,10 +1756,25 @@
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
     },
+    "uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+    },
+    "v8-compile-cache": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
+      "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
+      "dev": true
     },
     "vinyl": {
       "version": "2.2.1",
@@ -1003,6 +1802,15 @@
       "resolved": "https://registry.npmjs.org/wasm2c/-/wasm2c-1.0.0.tgz",
       "integrity": "sha512-4SIESF2JNxrry6XFa/UQcsQibn+bxPkQ/oqixiXz2o8fsMl8J4vtvhH/evgbi8vZajAlaukuihEcQTWb9tVLUA=="
     },
+    "which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
     "winston": {
       "version": "2.4.5",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.5.tgz",
@@ -1025,6 +1833,12 @@
         }
       }
     },
+    "word-wrap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+      "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+      "dev": true
+    },
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -1042,6 +1856,12 @@
         "options": ">=0.0.5",
         "tinycolor": "0.x"
       }
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,6 +2,8 @@
   "private": true,
   "devDependencies": {
     "es-check": "^5.1.0",
+    "eslint": "^7.18.0",
+    "eslint-config-google": "^0.14.0",
     "ws": "~0.4.28"
   },
   "dependencies": {
@@ -10,5 +12,8 @@
     "html-minifier-terser": "5.0.2",
     "source-map": "0.5.6",
     "wasm2c": "1.0.0"
+  },
+  "scripts": {
+    "lint": "eslint src/parseTools.js"
   }
 }

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -7,21 +7,21 @@
 // Various tools for parsing LLVM. Utilities of various sorts, that are
 // specific to Emscripten (and hence not in utility.js).
 
-var currentlyParsedFilename = '';
+let currentlyParsedFilename = '';
 
 // Does simple 'macro' substitution, using Django-like syntax,
 // {{{ code }}} will be replaced with |eval(code)|.
 // NOTE: Be careful with that ret check. If ret is |0|, |ret ? ret.toString() : ''| would result in ''!
 function processMacros(text) {
   return text.replace(/{{{([^}]|}(?!}))+}}}/g, function(str) {
-    str = str.substr(3, str.length-6);
+    str = str.substr(3, str.length - 6);
     try {
-      var ret = eval(str);
+      const ret = eval(str);
+      return ret !== null ? ret.toString() : '';
     } catch (ex) {
       ex.stack = 'In the following macro:\n\n' + str + '\n\n' + ex.stack;
       throw ex;
     }
-    return ret !== null ? ret.toString() : '';
   });
 }
 
@@ -33,18 +33,18 @@ function processMacros(text) {
 function preprocess(text, filenameHint) {
   currentlyParsedFilename = filenameHint;
   try {
-    var fileExt = (filenameHint) ? filenameHint.split('.').pop().toLowerCase() : "";
-    var isHtml = (fileExt === 'html' || fileExt === 'htm') ? true : false;
-    var inStyle = false;
-    var lines = text.split('\n');
-    var ret = '';
-    var showStack = [];
-    var emptyLine = false;
-    for (var i = 0; i < lines.length; i++) {
-      var line = lines[i];
+    const fileExt = (filenameHint) ? filenameHint.split('.').pop().toLowerCase() : '';
+    const isHtml = (fileExt === 'html' || fileExt === 'htm') ? true : false;
+    let inStyle = false;
+    const lines = text.split('\n');
+    let ret = '';
+    const showStack = [];
+    let emptyLine = false;
+    for (let i = 0; i < lines.length; i++) {
+      let line = lines[i];
       try {
-        if (line[line.length-1] === '\r') {
-          line = line.substr(0, line.length-1); // Windows will have '\r' left over from splitting over '\r\n'
+        if (line[line.length - 1] === '\r') {
+          line = line.substr(0, line.length - 1); // Windows will have '\r' left over from splitting over '\r\n'
         }
         if (isHtml && line.indexOf('<style') !== -1 && !inStyle) {
           inStyle = true;
@@ -54,28 +54,28 @@ function preprocess(text, filenameHint) {
         }
 
         if (!inStyle) {
-          var trimmed = line.trim()
+          const trimmed = line.trim();
           if (trimmed[0] === '#') {
-            var first = trimmed.split(' ', 1)[0]
+            const first = trimmed.split(' ', 1)[0];
             if (first == '#if' || first == '#ifdef') {
               if (first == '#ifdef') {
                 warn('warning: use of #ifdef in js library.  Use #if instead.');
               }
-              var after = trimmed.substring(trimmed.indexOf(' '));
-              var truthy = !!eval(after);
+              const after = trimmed.substring(trimmed.indexOf(' '));
+              const truthy = !!eval(after);
               showStack.push(truthy);
             } else if (first === '#include') {
               if (showStack.indexOf(false) === -1) {
-                var filename = line.substr(line.indexOf(' ')+1);
+                let filename = line.substr(line.indexOf(' ') + 1);
                 if (filename.indexOf('"') === 0) {
                   filename = filename.substr(1, filename.length - 2);
                 }
-                var included = read(filename);
-                var result = preprocess(included, filename);
+                const included = read(filename);
+                const result = preprocess(included, filename);
                 if (result) {
-                  ret += "// include: " + filename + "\n";
+                  ret += `// include: ${filename}\n`;
                   ret += result;
-                  ret += "// end include: " + filename + "\n";
+                  ret += `// end include: ${filename}\n`;
                 }
               }
             } else if (first === '#else') {
@@ -85,7 +85,7 @@ function preprocess(text, filenameHint) {
               assert(showStack.length > 0);
               showStack.pop();
             } else {
-              throw "Unknown preprocessor directive on line " + i + ': `' + line + '`';
+              throw new Error(`Unknown preprocessor directive on line ${i}: ``${line}```);
             }
           } else {
             if (showStack.indexOf(false) === -1) {
@@ -106,12 +106,13 @@ function preprocess(text, filenameHint) {
             ret += line + '\n';
           }
         }
-      } catch(e) {
-        printErr('parseTools.js preprocessor error in ' + filenameHint + ':' + (i+1) + ': \"' + line + '\"!');
+      } catch (e) {
+        printErr('parseTools.js preprocessor error in ' + filenameHint + ':' + (i + 1) + ': \"' + line + '\"!');
         throw e;
       }
     }
-    assert(showStack.length == 0, 'preprocessing error in file '+ filenameHint + ', no matching #endif found (' + showStack.length + ' unmatched preprocessing directives on stack)');
+    assert(showStack.length == 0, `preprocessing error in file ${filenameHint}, \
+no matching #endif found (${showStack.length$}' unmatched preprocessing directives on stack)`);
     return ret;
   } finally {
     currentlyParsedFilename = null;
@@ -120,15 +121,16 @@ function preprocess(text, filenameHint) {
 
 function removePointing(type, num) {
   if (num === 0) return type;
-  assert(type.substr(type.length-(num ? num : 1)).replace(/\*/g, '') === ''); //, 'Error in removePointing with ' + [type, num, type.substr(type.length-(num ? num : 1))]);
-  return type.substr(0, type.length-(num ? num : 1));
+  assert(type.substr(type.length - (num ? num : 1)).replace(/\*/g, '') === '');
+  // , 'Error in removePointing with ' + [type, num, type.substr(type.length-(num ? num : 1))]);
+  return type.substr(0, type.length - (num ? num : 1));
 }
 
 function pointingLevels(type) {
   if (!type) return 0;
-  var ret = 0;
-  var len1 = type.length - 1;
-  while (type[len1-ret] && type[len1-ret] === '*') {
+  let ret = 0;
+  const len1 = type.length - 1;
+  while (type[len1 - ret] && type[len1 - ret] === '*') {
     ret++;
   }
   return ret;
@@ -146,7 +148,7 @@ function isNiceIdent(ident, loose) {
 // Simple variables or numbers, or things already quoted, do not need to be quoted
 function needsQuoting(ident) {
   if (/^[-+]?[$_]?[\w$_\d]*$/.test(ident)) return false; // number or variable
-  if (ident[0] === '(' && ident[ident.length-1] === ')' && ident.indexOf('(', 1) < 0) return false; // already fully quoted
+  if (ident[0] === '(' && ident[ident.length - 1] === ')' && ident.indexOf('(', 1) < 0) return false; // already fully quoted
   return true;
 }
 
@@ -163,7 +165,7 @@ function isStructPointerType(type) {
 }
 
 function isPointerType(type) {
-  return type[type.length-1] == '*';
+  return type[type.length - 1] == '*';
 }
 
 function isArrayType(type) {
@@ -179,7 +181,7 @@ function isStructType(type) {
 }
 
 function isVectorType(type) {
-  return type[type.length-1] === '>';
+  return type[type.length - 1] === '>';
 }
 
 function isStructuralType(type) {
@@ -191,7 +193,7 @@ function getStructuralTypeParts(type) { // split { i32, i8 } etc. into parts
 }
 
 function getStructuralTypePartBits(part) {
-  return Math.ceil((getBits(part) || 32)/32)*32; // simple 32-bit alignment. || 32 is for pointers
+  return Math.ceil((getBits(part) || 32) / 32) * 32; // simple 32-bit alignment. || 32 is for pointers
 }
 
 function isIntImplemented(type) {
@@ -203,7 +205,7 @@ function getBits(type, allowPointers) {
   if (allowPointers && isPointerType(type)) return 32;
   if (!type) return 0;
   if (type[0] == 'i') {
-    var left = type.substr(1);
+    const left = type.substr(1);
     if (!isNumber(left)) return 0;
     return parseInt(left);
   }
@@ -211,9 +213,9 @@ function getBits(type, allowPointers) {
     return sum(getStructuralTypeParts(type).map(getStructuralTypePartBits));
   }
   if (isStructType(type)) {
-    var typeData = Types.types[type];
+    const typeData = Types.types[type];
     if (typeData === undefined) return 0;
-    return typeData.flatSize*8;
+    return typeData.flatSize * 8;
   }
   return 0;
 }
@@ -224,16 +226,17 @@ function isVoidType(type) {
 
 // Detects a function definition, ([...|type,[type,...]])
 function isFunctionDef(token, out) {
-  var text = token.text;
-  var nonPointing = removeAllPointing(text);
-  if (nonPointing[0] != '(' || nonPointing.substr(-1) != ')')
+  const text = token.text;
+  const nonPointing = removeAllPointing(text);
+  if (nonPointing[0] != '(' || nonPointing.substr(-1) != ')') {
     return false;
+  }
   if (nonPointing === '()') return true;
   if (!token.tokens) return false;
-  var fail = false;
-  var segments = splitTokenList(token.tokens);
+  let fail = false;
+  const segments = splitTokenList(token.tokens);
   segments.forEach(function(segment) {
-    var subtext = segment[0].text;
+    const subtext = segment[0].text;
     fail = fail || segment.length > 1 || !(isType(subtext) || subtext == '...');
   });
   if (out) {
@@ -245,18 +248,18 @@ function isFunctionDef(token, out) {
 
 function isPossiblyFunctionType(type) {
   // A quick but unreliable way to see if something is a function type. Yes is just 'maybe', no is definite.
-  var len = type.length;
-  return type[len-2] == ')' && type[len-1] == '*';
+  const len = type.length;
+  return type[len - 2] == ')' && type[len - 1] == '*';
 }
 
 function isFunctionType(type, out) {
   if (!isPossiblyFunctionType(type)) return false;
-  type = type.substr(0, type.length-1); // remove final '*'
-  var firstOpen = type.indexOf('(');
+  type = type.substr(0, type.length - 1); // remove final '*'
+  const firstOpen = type.indexOf('(');
   if (firstOpen <= 0) return false;
   type = type.replace(/"[^"]+"/g, '".."');
-  var lastOpen = type.lastIndexOf('(');
-  var returnType;
+  const lastOpen = type.lastIndexOf('(');
+  let returnType;
   if (firstOpen == lastOpen) {
     returnType = getReturnType(type);
     if (!isType(returnType)) return false;
@@ -265,9 +268,11 @@ function isFunctionType(type, out) {
   }
   if (out) out.returnType = returnType;
   // find ( that starts the arguments
-  var depth = 0, i = type.length-1, argText = null;
+  let depth = 0;
+  let i = type.length - 1;
+  let argText = null;
   while (i >= 0) {
-    var curr = type[i];
+    const curr = type[i];
     if (curr == ')') depth++;
     else if (curr == '(') {
       depth--;
@@ -279,40 +284,41 @@ function isFunctionType(type, out) {
     i--;
   }
   assert(argText);
-  return isFunctionDef({ text: argText, tokens: tokenize(argText.substr(1, argText.length-2)) }, out);
+  return isFunctionDef({text: argText, tokens: tokenize(argText.substr(1, argText.length - 2))}, out);
 }
 
 function getReturnType(type) {
-  if (pointingLevels(type) > 1) return '*'; // the type of a call can be either the return value, or the entire function. ** or more means it is a return value
-  var lastOpen = type.lastIndexOf('(');
+  // the type of a call can be either the return value, or the entire function. ** or more means it is a return value
+  if (pointingLevels(type) > 1) return '*';
+  const lastOpen = type.lastIndexOf('(');
   if (lastOpen > 0) {
     // handle things like   void (i32)* (i32, void (i32)*)*
-    var closeStar = type.indexOf(')*');
-    if (closeStar > 0 && closeStar < type.length-2) lastOpen = closeStar+3;
-    return type.substr(0, lastOpen-1);
+    const closeStar = type.indexOf(')*');
+    if (closeStar > 0 && closeStar < type.length - 2) lastOpen = closeStar + 3;
+    return type.substr(0, lastOpen - 1);
   }
   return type;
 }
 
-var isTypeCache = {}; // quite hot, optimize as much as possible
+const isTypeCache = {}; // quite hot, optimize as much as possible
 
 function isType(type) {
   if (type in isTypeCache) return isTypeCache[type];
-  var ret = isPointerType(type) || isVoidType(type) || Compiletime.isNumberType(type) || isStructType(type) || isFunctionType(type);
+  const ret = isPointerType(type) || isVoidType(type) || Compiletime.isNumberType(type) || isStructType(type) || isFunctionType(type);
   isTypeCache[type] = ret;
   return ret;
 }
 
-var SPLIT_TOKEN_LIST_SPLITTERS = set(',', 'to'); // 'to' can separate parameters as well...
+const SPLIT_TOKEN_LIST_SPLITTERS = set(',', 'to'); // 'to' can separate parameters as well...
 
 // Splits a list of tokens separated by commas. For example, a list of arguments in a function call
 function splitTokenList(tokens) {
   if (tokens.length == 0) return [];
   if (!tokens.slice) tokens = tokens.tokens;
-  var ret = [];
-  var seg = [];
-  for (var i = 0; i < tokens.length; i++) {
-    var token = tokens[i];
+  const ret = [];
+  const seg = [];
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
     if (token.text in SPLIT_TOKEN_LIST_SPLITTERS) {
       ret.push(seg);
       seg = [];
@@ -331,9 +337,8 @@ function _IntToHex(x) {
   assert(x >= 0 && x <= 15);
   if (x <= 9) {
     return String.fromCharCode('0'.charCodeAt(0) + x);
-  } else {
-    return String.fromCharCode('A'.charCodeAt(0) + x - 10);
   }
+  return String.fromCharCode('A'.charCodeAt(0) + x - 10);
 }
 
 function IEEEUnHex(stringy) {
@@ -341,24 +346,23 @@ function IEEEUnHex(stringy) {
   if (stringy.replace(/0/g, '') === '') return 0;
   while (stringy.length < 16) stringy = '0' + stringy;
   assert(stringy.length === 16, 'Can only unhex 16-digit double numbers, nothing platform-specific'); // |long double| might cause this
-  var top = eval('0x' + stringy[0]);
-  var neg = !!(top & 8); // sign
+  const top = eval('0x' + stringy[0]);
+  const neg = !!(top & 8); // sign
   if (neg) {
     stringy = _IntToHex(top & ~8) + stringy.substr(1);
   }
-  var a = eval('0x' + stringy.substr(0, 8)); // top half
-  var b = eval('0x' + stringy.substr(8)); // bottom half
-  var e = a >> ((52 - 32) & 0x7ff); // exponent
+  let a = eval('0x' + stringy.substr(0, 8)); // top half
+  const b = eval('0x' + stringy.substr(8)); // bottom half
+  let e = a >> ((52 - 32) & 0x7ff); // exponent
   a = a & 0xfffff;
   if (e === 0x7ff) {
     if (a == 0 && b == 0) {
       return neg ? '-Infinity' : 'Infinity';
-    } else {
-      return 'NaN';
     }
+    return 'NaN';
   }
   e -= 1023; // offset
-  var absolute = ((((a | 0x100000) * 1.0) / Math.pow(2,52-32)) * Math.pow(2, e)) + (((b * 1.0) / Math.pow(2, 52)) * Math.pow(2, e));
+  const absolute = ((((a | 0x100000) * 1.0) / Math.pow(2, 52 - 32)) * Math.pow(2, e)) + (((b * 1.0) / Math.pow(2, 52)) * Math.pow(2, e));
   return (absolute * (neg ? -1 : 1)).toString();
 }
 
@@ -398,34 +402,40 @@ function splitI64(value, floatConversion) {
   //
   // For negatives, we need to ensure a -1 if the value is overall negative, even if not significant negative component
 
-  var lowInput = legalizedI64s ? value : 'VALUE';
+  const lowInput = legalizedI64s ? value : 'VALUE';
   if (floatConversion) lowInput = asmFloatToInt(lowInput);
-  var low = lowInput + '>>>0';
-  var high = makeInlineCalculation(
-    asmCoercion('Math.abs(VALUE)', 'double') + ' >= ' + asmEnsureFloat('1', 'double') + ' ? ' +
-      '(VALUE > ' + asmEnsureFloat('0', 'double') + ' ? ' +
-               asmCoercion('Math.min(' + asmCoercion('Math.floor((VALUE)/' + asmEnsureFloat(4294967296, 'double') + ')', 'double') + ', ' + asmEnsureFloat(4294967295, 'double') + ')', 'i32') + '>>>0' +
-               ' : ' + asmFloatToInt(asmCoercion('Math.ceil((VALUE - +((' + asmFloatToInt('VALUE') + ')>>>0))/' + asmEnsureFloat(4294967296, 'double') + ')', 'double')) + '>>>0' +
-      ')' +
-    ' : 0',
-    value,
-    'tempDouble'
+  const low = lowInput + '>>>0';
+  const high = makeInlineCalculation(
+      asmCoercion('Math.abs(VALUE)', 'double') + ' >= ' + asmEnsureFloat('1', 'double') + ' ? ' +
+        '(VALUE > ' + asmEnsureFloat('0', 'double') + ' ? ' +
+        asmCoercion('Math.min(' + asmCoercion('Math.floor((VALUE)/' +
+        asmEnsureFloat(4294967296, 'double') + ')', 'double') + ', ' +
+        asmEnsureFloat(4294967295, 'double') + ')', 'i32') + '>>>0' +
+        ' : ' +
+        asmFloatToInt(asmCoercion('Math.ceil((VALUE - +((' + asmFloatToInt('VALUE') + ')>>>0))/' +
+        asmEnsureFloat(4294967296, 'double') + ')', 'double')) + '>>>0' +
+        ')' +
+      ' : 0',
+      value,
+      'tempDouble',
   );
   if (legalizedI64s) {
     return [low, high];
-  } else {
-    return makeI64(low, high);
   }
+  return makeI64(low, high);
 }
 
 // Misc
 
 function indentify(text, indent) {
-  if (text.length > 1024*1024) return text; // Don't try to indentify huge strings - we may run out of memory
+  // Don't try to indentify huge strings - we may run out of memory
+  if (text.length > 1024 * 1024) return text;
   if (typeof indent === 'number') {
-    var len = indent;
+    const len = indent;
     indent = '';
-    for (var i = 0; i < len; i++) indent += ' ';
+    for (let i = 0; i < len; i++) {
+      indent += ' ';
+    }
   }
   return text.replace(/\n/g, '\n' + indent);
 }
@@ -437,41 +447,41 @@ function checkSafeHeap() {
 }
 
 function getHeapOffset(offset, type) {
-  if (Runtime.getNativeFieldSize(type) > 4) {
-    if (type == 'i64') {
-      type = 'i32'; // we emulate 64-bit integer values as 32 in asmjs-unknown-emscripten, but not double
-    }
+  if (Runtime.getNativeFieldSize(type) > 4 && type == 'i64') {
+    // we emulate 64-bit integer values as 32 in asmjs-unknown-emscripten, but not double
+    type = 'i32';
   }
 
-  var sz = Runtime.getNativeTypeSize(type);
-  var shifts = Math.log(sz)/Math.LN2;
-  offset = '(' + offset + ')';
-  return '(' + offset + '>>' + shifts + ')';
+  const sz = Runtime.getNativeTypeSize(type);
+  const shifts = Math.log(sz) / Math.LN2;
+  return `((${offset})>>${shifts})`;
 }
 
 function ensureDot(value) {
   value = value.toString();
   // if already dotted, or Infinity or NaN, nothing to do here
-  // if smaller than 1 and running js opts, we always need to force a coercion (0.001 will turn into 1e-3, which has no .)
+  // if smaller than 1 and running js opts, we always need to force a coercion
+  // (0.001 will turn into 1e-3, which has no .)
   if ((value.indexOf('.') >= 0 || /[IN]/.test(value))) return value;
-  var e = value.indexOf('e');
+  const e = value.indexOf('e');
   if (e < 0) return value + '.0';
   return value.substr(0, e) + '.0' + value.substr(e);
 }
 
-function asmEnsureFloat(value, type) { // ensures that a float type has either 5.5 (clearly a float) or +5 (float due to asm coercion)
+// ensures that a float type has either 5.5 (clearly a float) or +5 (float due to asm coercion)
+function asmEnsureFloat(value, type) {
   if (!isNumber(value)) return value;
   if (type === 'float') {
-    // normally ok to just emit Math.fround(0), but if the constant is large we may need a .0 (if it can't fit in an int)
+    // normally ok to just emit Math.fround(0), but if the constant is large we
+    // may need a .0 (if it can't fit in an int)
     if (value == 0) return 'Math.fround(0)';
     value = ensureDot(value);
     return 'Math.fround(' + value + ')';
   }
   if (type in Compiletime.FLOAT_TYPES) {
     return ensureDot(value);
-  } else {
-    return value;
   }
+  return value;
 }
 
 function asmCoercion(value, type, signedness) {
@@ -509,15 +519,15 @@ function asmFloatToInt(x) {
 function makeGetTempDouble(i, type, forSet) { // get an aliased part of the tempDouble temporary storage
   // Cannot use makeGetValue because it uses us
   // this is a unique case where we *can* use HEAPF64
-  var heap = getHeapForType(type);
-  var ptr = getFastValue('tempDoublePtr', '+', Runtime.getNativeTypeSize(type)*i);
-  var offset;
+  const heap = getHeapForType(type);
+  const ptr = getFastValue('tempDoublePtr', '+', Runtime.getNativeTypeSize(type) * i);
+  let offset;
   if (type == 'double') {
     offset = '(' + ptr + ')>>3';
   } else {
     offset = getHeapOffset(ptr, type);
   }
-  var ret = heap + '[' + offset + ']';
+  let ret = heap + '[' + offset + ']';
   if (!forSet) ret = asmCoercion(ret, type);
   return ret;
 }
@@ -526,31 +536,29 @@ function makeSetTempDouble(i, type, value) {
   return makeGetTempDouble(i, type, true) + '=' + asmEnsureFloat(value, type);
 }
 
-var asmPrintCounter = 0;
-
 // See makeSetValue
 function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSafe, forceAsm) {
-  assert(!forceAsm, "forceAsm is no longer supported");
+  assert(!forceAsm, 'forceAsm is no longer supported');
   if (isStructType(type)) {
-    var typeData = Types.types[type];
-    var ret = [];
-    for (var i = 0; i < typeData.fields.length; i++) {
+    const typeData = Types.types[type];
+    const ret = [];
+    for (let i = 0; i < typeData.fields.length; i++) {
       ret.push('f' + i + ': ' + makeGetValue(ptr, pos + typeData.flatIndexes[i], typeData.fields[i], noNeedFirst, unsigned, 0, 0, noSafe));
     }
     return '{ ' + ret.join(', ') + ' }';
   }
 
   if (type == 'double' && (align < 8)) {
-    return '(' + makeSetTempDouble(0, 'i32', makeGetValue(ptr, pos, 'i32', noNeedFirst, unsigned, ignore, align, noSafe)) + ',' +
-                 makeSetTempDouble(1, 'i32', makeGetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'i32', noNeedFirst, unsigned, ignore, align, noSafe)) + ',' +
-            makeGetTempDouble(0, 'double') + ')';
+    const setdouble1 = makeSetTempDouble(0, 'i32', makeGetValue(ptr, pos, 'i32', noNeedFirst, unsigned, ignore, align, noSafe));
+    const setdouble2 = makeSetTempDouble(1, 'i32', makeGetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'i32', noNeedFirst, unsigned, ignore, align, noSafe));
+    return '(' + setdouble1 + ',' + setdouble2 + ',' + makeGetTempDouble(0, 'double') + ')';
   }
 
   if (align) {
     // Alignment is important here. May need to split this up
-    var bytes = Runtime.getNativeTypeSize(type);
+    const bytes = Runtime.getNativeTypeSize(type);
     if (bytes > align) {
-      var ret = '(';
+      let ret = '(';
       if (isIntImplemented(type)) {
         if (bytes == 4 && align == 2) {
           // Special case that we can optimize
@@ -558,9 +566,9 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
                  '(' + makeGetValue(ptr, getFastValue(pos, '+', 2), 'i16', noNeedFirst, 2, ignore, 2, noSafe) + '<<16)';
         } else { // XXX we cannot truly handle > 4... (in x86)
           ret = '';
-          for (var i = 0; i < bytes; i++) {
-            ret += '(' + makeGetValue(ptr, getFastValue(pos, '+', i), 'i8', noNeedFirst, 1, ignore, 1, noSafe) + (i > 0 ? '<<' + (8*i) : '') + ')';
-            if (i < bytes-1) ret += '|';
+          for (let i = 0; i < bytes; i++) {
+            ret += '(' + makeGetValue(ptr, getFastValue(pos, '+', i), 'i8', noNeedFirst, 1, ignore, 1, noSafe) + (i > 0 ? '<<' + (8 * i) : '') + ')';
+            if (i < bytes - 1) ret += '|';
           }
           ret = '(' + makeSignOp(ret, type, unsigned ? 'un' : 're', true);
         }
@@ -576,37 +584,45 @@ function makeGetValue(ptr, pos, type, noNeedFirst, unsigned, ignore, align, noSa
     }
   }
 
-  var offset = calcFastOffset(ptr, pos, noNeedFirst);
+  const offset = calcFastOffset(ptr, pos, noNeedFirst);
   if (SAFE_HEAP && !noSafe) {
     if (!ignore) {
-      return asmCoercion('SAFE_HEAP_LOAD' + ((type in Compiletime.FLOAT_TYPES) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + Runtime.getNativeTypeSize(type) + ', ' + (!!unsigned+0) + ')', type, unsigned ? 'u' : undefined);
+      return asmCoercion('SAFE_HEAP_LOAD' + ((type in Compiletime.FLOAT_TYPES) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + Runtime.getNativeTypeSize(type) + ', ' + (!!unsigned + 0) + ')', type, unsigned ? 'u' : undefined);
     }
   }
   return getHeapForType(type, unsigned) + '[' + getHeapOffset(offset, type) + ']';
 }
 
-//! @param ptr The pointer. Used to find both the slab and the offset in that slab. If the pointer
-//!            is just an integer, then this is almost redundant, but in general the pointer type
-//!            may in the future include information about which slab as well. So, for now it is
-//!            possible to put |0| here, but if a pointer is available, that is more future-proof.
-//! @param pos The position in that slab - the offset. Added to any offset in the pointer itself.
-//! @param value The value to set.
-//! @param type A string defining the type. Used to find the slab (HEAPU8, HEAP16, HEAPU32, etc.).
-//!             'null' means, in the context of SAFE_HEAP, that we should accept all types;
-//!             which means we should write to all slabs, ignore type differences if any on reads, etc.
-//! @param noNeedFirst Whether to ignore the offset in the pointer itself.
+/**
+ * @param {nunber} ptr The pointer. Used to find both the slab and the offset in that slab. If the pointer
+ *            is just an integer, then this is almost redundant, but in general the pointer type
+ *            may in the future include information about which slab as well. So, for now it is
+ *            possible to put |0| here, but if a pointer is available, that is more future-proof.
+ * @param {nunber} pos The position in that slab - the offset. Added to any offset in the pointer itself.
+ * @param {number} value The value to set.
+ * @param {string} type A string defining the type. Used to find the slab (HEAPU8, HEAP16, HEAPU32, etc.).
+ *             'null' means, in the context of SAFE_HEAP, that we should accept all types;
+ *             which means we should write to all slabs, ignore type differences if any on reads, etc.
+ * @param {bool} noNeedFirst Whether to ignore the offset in the pointer itself.
+ * @param {bool} ignore: legacy, ignored.
+ * @param {number} align: TODO
+ * @param {bool} noSafe: TODO
+ * @param {string} sep: TODO
+ * @param {bool} forcedAlign: legacy, ignored.
+ * @return {TODO}
+ */
 function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe, sep, forcedAlign) {
-  assert(!forcedAlign, "forcedAlign is no longer supported");
+  assert(!forcedAlign, 'forcedAlign is no longer supported');
   sep = sep || ';';
   if (isStructType(type)) {
-    var typeData = Types.types[type];
-    var ret = [];
+    const typeData = Types.types[type];
+    const ret = [];
     // We can receive either an object - an object literal that was in the .ll - or a string,
     // which is the ident of an aggregate struct
     if (typeof value === 'string') {
-      value = range(typeData.fields.length).map(function(i) { return value + '.f' + i });
+      value = range(typeData.fields.length).map((i) => value + '.f' + i);
     }
-    for (var i = 0; i < typeData.fields.length; i++) {
+    for (let i = 0; i < typeData.fields.length; i++) {
       ret.push(makeSetValue(ptr, getFastValue(pos, '+', typeData.flatIndexes[i]), value[i], typeData.fields[i], noNeedFirst, 0, 0, noSafe));
     }
     return ret.join('; ');
@@ -622,13 +638,13 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
             makeSetValue(ptr, getFastValue(pos, '+', Runtime.getNativeTypeSize('i32')), 'tempI64[1]', 'i32', noNeedFirst, ignore, align, noSafe, ',') + ')';
   }
 
-  var bits = getBits(type);
-  var needSplitting = bits > 0 && !isPowerOfTwo(bits); // an unnatural type like i24
+  const bits = getBits(type);
+  const needSplitting = bits > 0 && !isPowerOfTwo(bits); // an unnatural type like i24
   if (align || needSplitting) {
     // Alignment is important here, or we need to split this up for other reasons.
-    var bytes = Runtime.getNativeTypeSize(type);
+    const bytes = Runtime.getNativeTypeSize(type);
     if (bytes > align || needSplitting) {
-      var ret = '';
+      let ret = '';
       if (isIntImplemented(type)) {
         if (bytes == 4 && align == 2) {
           // Special case that we can optimize
@@ -637,9 +653,9 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
           ret += makeSetValue(ptr, getFastValue(pos, '+', 2), 'tempBigInt>>16', 'i16', noNeedFirst, ignore, 2, noSafe);
         } else {
           ret += 'tempBigInt=' + value + sep;
-          for (var i = 0; i < bytes; i++) {
+          for (let i = 0; i < bytes; i++) {
             ret += makeSetValue(ptr, getFastValue(pos, '+', i), 'tempBigInt&0xff', 'i8', noNeedFirst, ignore, 1, noSafe);
-            if (i < bytes-1) ret += sep + 'tempBigInt = tempBigInt>>8' + sep;
+            if (i < bytes - 1) ret += sep + 'tempBigInt = tempBigInt>>8' + sep;
           }
         }
       } else {
@@ -650,7 +666,7 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
     }
   }
 
-  var offset = calcFastOffset(ptr, pos, noNeedFirst);
+  const offset = calcFastOffset(ptr, pos, noNeedFirst);
   if (SAFE_HEAP && !noSafe) {
     if (!ignore) {
       return 'SAFE_HEAP_STORE' + ((type in Compiletime.FLOAT_TYPES) ? '_D' : '') + '(' + asmCoercion(offset, 'i32') + ', ' + asmCoercion(value, type) + ', ' + Runtime.getNativeTypeSize(type) + ')';
@@ -659,32 +675,35 @@ function makeSetValue(ptr, pos, value, type, noNeedFirst, ignore, align, noSafe,
   return getHeapForType(type) + '[' + getHeapOffset(offset, type) + '] = ' + value;
 }
 
-var UNROLL_LOOP_MAX = 8;
+const UNROLL_LOOP_MAX = 8;
 
 function makeCopyValues(dest, src, num, type, modifier, align, sep) {
   sep = sep || ';';
   function unroll(type, num, jump) {
     jump = jump || 1;
     return range(num).map(function(i) {
-      return makeSetValue(dest, i*jump, makeGetValue(src, i*jump, type), type);
+      return makeSetValue(dest, i * jump, makeGetValue(src, i * jump, type), type);
     }).join(sep);
   }
-  // If we don't know how to handle this at compile-time, or handling it is best done in a large amount of code, call memcpy
+  // If we don't know how to handle this at compile-time, or handling it is best
+  // done in a large amount of code, call memcpy
   if (!isNumber(num)) num = stripCorrections(num);
   if (!isNumber(align)) align = stripCorrections(align);
-  if (!isNumber(num) || (parseInt(num)/align >= UNROLL_LOOP_MAX)) {
+  if (!isNumber(num) || (parseInt(num) / align >= UNROLL_LOOP_MAX)) {
     return '(_memcpy(' + dest + ', ' + src + ', ' + num + ')|0)';
   }
   num = parseInt(num);
-  dest = stripCorrections(dest); // remove corrections, since we will be correcting after we add anyhow,
-  src = stripCorrections(src);   // and in the heap assignment expression
-  var ret = [];
+  // remove corrections, since we will be correcting after we add anyhow,
+  dest = stripCorrections(dest);
+  src = stripCorrections(src);
+  // and in the heap assignment expression
+  const ret = [];
   [4, 2, 1].forEach(function(possibleAlign) {
     if (num == 0) return;
     if (align >= possibleAlign) {
-      ret.push(unroll('i' + (possibleAlign*8), Math.floor(num/possibleAlign), possibleAlign));
-      src = getFastValue(src, '+', Math.floor(num/possibleAlign)*possibleAlign);
-      dest = getFastValue(dest, '+', Math.floor(num/possibleAlign)*possibleAlign);
+      ret.push(unroll('i' + (possibleAlign * 8), Math.floor(num / possibleAlign), possibleAlign));
+      src = getFastValue(src, '+', Math.floor(num / possibleAlign) * possibleAlign);
+      dest = getFastValue(dest, '+', Math.floor(num / possibleAlign) * possibleAlign);
       num %= possibleAlign;
     }
   });
@@ -692,9 +711,9 @@ function makeCopyValues(dest, src, num, type, modifier, align, sep) {
 }
 
 function makeHEAPView(which, start, end) {
-  var size = parseInt(which.replace('U', '').replace('F', ''))/8;
-  var mod = size == 1 ? '' : ('>>' + Math.log2(size));
-  return 'HEAP' + which + '.subarray((' + start + ')' + mod + ',(' + end + ')' + mod + ')';
+  const size = parseInt(which.replace('U', '').replace('F', '')) / 8;
+  const mod = size == 1 ? '' : ('>>' + Math.log2(size));
+  return `HEAP${which}.subarray((${start})${mod}, (${end})${mod})`;
 }
 
 // When dynamically linking, some things like dynCalls may not exist in one module and
@@ -702,12 +721,11 @@ function makeHEAPView(which, start, end) {
 function exportedAsmFunc(func) {
   if (!MAIN_MODULE) {
     return func;
-  } else {
-    return "Module['" + func + "']";
   }
+  return `Module['${func}']`;
 }
 
-var TWO_TWENTY = Math.pow(2, 20);
+const TWO_TWENTY = Math.pow(2, 20);
 
 // Given two values and an operation, returns the result of that operation.
 // Tries to do as much as possible at compile time.
@@ -716,7 +734,8 @@ function getFastValue(a, op, b, type) {
   a = a === 'true' ? '1' : (a === 'false' ? '0' : a);
   b = b === 'true' ? '1' : (b === 'false' ? '0' : b);
 
-  var aNumber = null, bNumber = null;
+  let aNumber = null;
+  let bNumber = null;
   if (typeof a === 'number') {
     aNumber = a;
     a = a.toString();
@@ -733,7 +752,7 @@ function getFastValue(a, op, b, type) {
       case '*': return (aNumber * bNumber).toString();
       case '/': {
         if (type[0] === 'i') {
-          return ((aNumber / bNumber)|0).toString();
+          return ((aNumber / bNumber) | 0).toString();
         } else {
           return (aNumber / bNumber).toString();
         }
@@ -743,20 +762,20 @@ function getFastValue(a, op, b, type) {
       case '>>>': return (aNumber >>> bNumber).toString();
       case '&': return (aNumber & bNumber).toString();
       case 'pow': return Math.pow(aNumber, bNumber).toString();
-      default: throw 'need to implement getFastValue pn ' + op;
+      default: assert(false, 'need to implement getFastValue pn ' + op);
     }
   }
   if (op === 'pow') {
     if (a === '2' && isIntImplemented(type)) {
-      return '(1 << (' + b + '))';
+      return `(1 << (${b}))`;
     }
-    return 'Math.pow(' + a + ', ' + b + ')';
+    return `Math.pow(${a}, ${b})`;
   }
   if ((op === '+' || op === '*') && aNumber !== null) { // if one of them is a number, keep it last
-    var c = b;
+    const c = b;
     b = a;
     a = c;
-    var cNumber = bNumber;
+    const cNumber = bNumber;
     bNumber = aNumber;
     aNumber = cNumber;
   }
@@ -770,22 +789,26 @@ function getFastValue(a, op, b, type) {
     } else if (bNumber === 1) {
       return a;
     } else if (bNumber !== null && type && isIntImplemented(type) && Runtime.getNativeTypeSize(type) <= 32) {
-      var shifts = Math.log(bNumber)/Math.LN2;
+      const shifts = Math.log(bNumber) / Math.LN2;
       if (shifts % 1 === 0) {
-        return '(' + a + '<<' + shifts + ')';
+        return `(${a}<<${shifts})`;
       }
     }
     if (!(type in Compiletime.FLOAT_TYPES)) {
       // if guaranteed small enough to not overflow into a double, do a normal multiply
-      var bits = getBits(type) || 32; // default is 32-bit multiply for things like getelementptr indexes
-      // Note that we can emit simple multiple in non-asm.js mode, but asm.js will not parse "16-bit" multiple, so must do imul there
+      // default is 32-bit multiply for things like getelementptr indexes
+      const bits = getBits(type) || 32;
+      // Note that we can emit simple multiple in non-asm.js mode, but asm.js
+      // will not parse "16-bit" multiple, so must do imul there
       if ((aNumber !== null && Math.abs(a) < TWO_TWENTY) || (bNumber !== null && Math.abs(b) < TWO_TWENTY)) {
-        return '(((' + a + ')*(' + b + '))&' + ((Math.pow(2, bits)-1)|0) + ')'; // keep a non-eliminatable coercion directly on this
+        // keep a non-eliminatable coercion directly on this
+        return `(((${a})*(${b}))&${(Math.pow(2, bits) - 1) | 0})`;
       }
-      return '(Math.imul(' + a + ',' + b + ')|0)';
+      return `(Math.imul(${a}, ${b})|0)`;
     }
   } else if (op === '/') {
-    if (a === '0' && !(type in Compiletime.FLOAT_TYPES)) { // careful on floats, since 0*NaN is not 0
+    // careful on floats, since 0*NaN is not 0
+    if (a === '0' && !(type in Compiletime.FLOAT_TYPES)) {
       return '0';
     } else if (b === 1) {
       return a;
@@ -796,12 +819,12 @@ function getFastValue(a, op, b, type) {
       b = b.substr(1);
     }
     if (aNumber === 0) {
-      return op === '+' ? b : '(-' + b + ')';
+      return op === '+' ? b : `(-${b})`;
     } else if (bNumber === 0) {
       return a;
     }
   }
-  return '(' + a + ')' + op + '(' + b + ')';
+  return `(${a})${op}(${b})`;
 }
 
 function calcFastOffset(ptr, pos, noNeedFirst) {
@@ -834,11 +857,11 @@ function getHeapForType(type, unsigned) {
 }
 
 function makeGetTempRet0() {
-  return "(getTempRet0() | 0)";
+  return '(getTempRet0() | 0)';
 }
 
 function makeSetTempRet0(value) {
-  return "setTempRet0((" + value + ") | 0)";
+  return 'setTempRet0((' + value + ') | 0)';
 }
 
 // Takes a pair of return values, stashes one in tempRet0 and returns the other.
@@ -856,7 +879,7 @@ function makeThrow(what) {
       what += ' + " (note: in dynamic linking, if a side module wants exceptions, the main module must be built with that support)"';
     }
   }
-  return 'throw ' + what + ';';
+  return `throw ${what};`;
 }
 
 function makeSignOp(value, type, op, force, ignore) {
@@ -865,7 +888,8 @@ function makeSignOp(value, type, op, force, ignore) {
   }
   if (isPointerType(type)) type = 'i32'; // Pointers are treated as 32-bit ints
   if (!value) return value;
-  var bits, full;
+  let bits;
+  let full;
   if (type[0] === 'i') {
     bits = parseInt(type.substr(1));
     full = op + 'Sign(' + value + ', ' + bits + ', ' + Math.floor(ignore) + ')';
@@ -888,17 +912,17 @@ function makeSignOp(value, type, op, force, ignore) {
         if (op === 're') {
           return '(' + value + '|0)';
         } else {
-          return '(' + value +  '>>>0)';
+          return '(' + value + '>>>0)';
         }
       } else if (bits < 32) {
         if (op === 're') {
-          return '((' + value + '<<' + (32-bits) + ')>>' + (32-bits) + ')';
+          return '((' + value + '<<' + (32 - bits) + ')>>' + (32 - bits) + ')';
         } else {
-          return '(' + value + '&' + (Math.pow(2, bits)-1) + ')';
+          return '(' + value + '&' + (Math.pow(2, bits) - 1) + ')';
         }
       } else { // bits > 32
         if (op === 're') {
-          return makeInlineCalculation('VALUE >= ' + Math.pow(2, bits-1) + ' ? VALUE-' + Math.pow(2, bits) + ' : VALUE', value, 'tempBigIntS');
+          return makeInlineCalculation('VALUE >= ' + Math.pow(2, bits - 1) + ' ? VALUE-' + Math.pow(2, bits) + ' : VALUE', value, 'tempBigIntS');
         } else {
           return makeInlineCalculation('VALUE >= 0 ? VALUE : ' + Math.pow(2, bits) + '+VALUE', value, 'tempBigIntS');
         }
@@ -909,10 +933,12 @@ function makeSignOp(value, type, op, force, ignore) {
   return value;
 }
 
-var legalizedI64s = true; // We do not legalize globals, but do legalize function lines. This will be true in the latter case
+// We do not legalize globals, but do legalize function lines. This will be true in the latter case
+// eslint-disable-next-line prefer-const
+global.legalizedI64s = true;
 
 function stripCorrections(param) {
-  var m;
+  let m;
   while (true) {
     if (m = /^\((.*)\)$/.exec(param)) {
       param = m[1];
@@ -950,8 +976,8 @@ function getTypeFromHeap(suffix) {
     case '32': return 'i32';
     case 'F32': return 'float';
     case 'F64': return 'double';
-    default: throw 'getTypeFromHeap? ' + suffix;
   }
+  assert(false, 'bad type suffix: ' + suffix);
 }
 
 function ensureValidFFIType(type) {
@@ -968,10 +994,14 @@ function asmFFICoercion(value, type) {
 function makeDynCall(sig, funcPtr) {
   assert(sig.indexOf('j') == -1);
   if (funcPtr === undefined) {
-    printErr(`warning: ${currentlyParsedFilename}: Legacy use of {{{ makeDynCall("${sig}") }}}(funcPtr, arg1, arg2, ...). Starting from Emscripten 2.0.2 (Aug 31st 2020), syntax for makeDynCall has changed. New syntax is {{{ makeDynCall("${sig}", "funcPtr") }}}(arg1, arg2, ...). Please update to new syntax.`);
-    var ret = (sig[0] == 'v') ? 'return ' : '';
-    var args = [];
-    for(var i = 1; i < sig.length; ++i) {
+    printErr(`warning: ${currentlyParsedFilename}: \
+Legacy use of {{{ makeDynCall("${sig}") }}}(funcPtr, arg1, arg2, ...). \
+Starting from Emscripten 2.0.2 (Aug 31st 2020), syntax for makeDynCall has changed. \
+New syntax is {{{ makeDynCall("${sig}", "funcPtr") }}}(arg1, arg2, ...). \
+Please update to new syntax.`);
+    const ret = (sig[0] == 'v') ? 'return ' : '';
+    let args = [];
+    for (let i = 1; i < sig.length; ++i) {
       args.push(`a${i}`);
     }
     args = args.join(', ');
@@ -983,7 +1013,7 @@ function makeDynCall(sig, funcPtr) {
     }
   }
   if (USE_LEGACY_DYNCALLS) {
-    let dyncall = exportedAsmFunc(`dynCall_${sig}`)
+    const dyncall = exportedAsmFunc(`dynCall_${sig}`);
     if (sig.length > 1) {
       let args = [];
       for (let i = 1; i < sig.length; ++i) {
@@ -1008,29 +1038,29 @@ function makeEval(code) {
     // Treat eval as error.
     return "abort('DYNAMIC_EXECUTION=0 was set, cannot eval');";
   }
-  var ret = '';
+  let ret = '';
   if (DYNAMIC_EXECUTION == 2) {
     // Warn on evals, but proceed.
     ret += "err('Warning: DYNAMIC_EXECUTION=2 was set, but calling eval in the following location:');\n";
-    ret += "err(stackTrace());\n";
+    ret += 'err(stackTrace());\n';
   }
   ret += code;
   return ret;
 }
 
-var ATINITS = [];
+global.ATINITS = [];
 
 function addAtInit(code) {
   ATINITS.push(code);
 }
 
-var ATMAINS = [];
+global.ATMAINS = [];
 
 function addAtMain(code) {
   ATMAINS.push(code);
 }
 
-var ATEXITS = [];
+global.ATEXITS = [];
 
 function addAtExit(code) {
   if (EXIT_RUNTIME) {
@@ -1039,40 +1069,46 @@ function addAtExit(code) {
 }
 
 function makeRetainedCompilerSettings() {
-  var ignore = set('STRUCT_INFO');
+  const ignore = set('STRUCT_INFO');
   if (STRICT) {
-    for (var i in LEGACY_SETTINGS) {
-      var name = LEGACY_SETTINGS[i][0];
+    for (const setting of LEGACY_SETTINGS) {
+      const name = setting[0];
       ignore[name] = 0;
     }
   }
 
-  var ret = {};
-  for (var x in this) {
-    try {
-      if (x[0] !== '_' && !(x in ignore) && x == x.toUpperCase() && (typeof this[x] === 'number' || typeof this[x] === 'string' || this.isArray())) ret[x] = this[x];
-    } catch(e){}
+  const ret = {};
+  for (const x in global) {
+    if (!(x in ignore) && x[0] !== '_' && x == x.toUpperCase()) {
+      try {
+        if (typeof global[x] === 'number' || typeof global[x] === 'string' || this.isArray()) {
+          ret[x] = global[x];
+        }
+      } catch (e) {}
+    }
   }
   return ret;
 }
 
 // In wasm, the heap size must be a multiple of 64KiB.
-var WASM_PAGE_SIZE = 65536;
+const WASM_PAGE_SIZE = 65536;
 
 // Page size reported by some POSIX calls, mostly filesystem. This does not
 // depend on the memory page size which differs between wasm and asm.js, and
 // makes us report a consistent value despite the compile target. However,
 // perhaps we should unify all the page sizes (especially after fastcomp is
 // gone TODO).
-var POSIX_PAGE_SIZE = 16384;
+const POSIX_PAGE_SIZE = 16384;
 
 // Receives a function as text, and a function that constructs a modified
 // function, to which we pass the parsed-out name, arguments, and body of the
 // function. Returns the output of that function.
 function modifyFunction(text, func) {
   // Match a function with a name.
-  var match = text.match(/^\s*function\s+([^(]*)?\s*\(([^)]*)\)/);
-  var name, args, rest;
+  let match = text.match(/^\s*function\s+([^(]*)?\s*\(([^)]*)\)/);
+  let names;
+  let args;
+  let rest;
   if (match) {
     name = match[1];
     args = match[2];
@@ -1086,9 +1122,9 @@ function modifyFunction(text, func) {
     args = match[1];
     rest = text.substr(match[0].length);
   }
-  var bodyStart = rest.indexOf('{');
+  const bodyStart = rest.indexOf('{');
   assert(bodyStart >= 0);
-  var bodyEnd = rest.lastIndexOf('}');
+  const bodyEnd = rest.lastIndexOf('}');
   assert(bodyEnd > 0);
   return func(name, args, rest.substring(bodyStart + 1, bodyEnd));
 }
@@ -1108,13 +1144,22 @@ function expectToReceiveOnModule(name) {
 function makeRemovedModuleAPIAssert(moduleName, localName) {
   if (!ASSERTIONS) return '';
   if (!localName) localName = moduleName;
-  return "if (!Object.getOwnPropertyDescriptor(Module, '" + moduleName + "')) Object.defineProperty(Module, '" + moduleName + "', { configurable: true, get: function() { abort('Module." + moduleName + " has been replaced with plain " + localName + " (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)') } });";
+  return `if (!Object.getOwnPropertyDescriptor(Module, '${moduleName}')) {
+  Object.defineProperty(Module, '${moduleName}', {
+    configurable: true,
+    get: function() {
+      abort('Module.${moduleName} has been replaced with plain ${localName}\
+ (the initial value can be provided on Module,\
+ but after startup the value is only looked for on a local variable of that name)')
+    }
+  });
+}`;
 }
 
 // Make code to receive a value on the incoming Module object.
 function makeModuleReceive(localName, moduleName) {
   if (!moduleName) moduleName = localName;
-  var ret = '';
+  let ret = '';
   if (expectToReceiveOnModule(moduleName)) {
     // Usually the local we use is the same as the Module property name,
     // but sometimes they must differ.
@@ -1126,7 +1171,7 @@ function makeModuleReceive(localName, moduleName) {
 
 function makeModuleReceiveWithVar(localName, moduleName, defaultValue, noAssert) {
   if (!moduleName) moduleName = localName;
-  var ret = 'var ' + localName;
+  let ret = 'var ' + localName;
   if (!expectToReceiveOnModule(moduleName)) {
     if (defaultValue) {
       ret += ' = ' + defaultValue;
@@ -1134,10 +1179,9 @@ function makeModuleReceiveWithVar(localName, moduleName, defaultValue, noAssert)
     ret += ';';
   } else {
     if (defaultValue) {
-      ret += " = Module['" + moduleName + "'] || " + defaultValue + ";";
+      ret += ` = Module['${moduleName}'] || ${defaultValue};`;
     } else {
-      ret += ';' +
-             makeModuleReceive(localName, moduleName);
+      ret += ';' + makeModuleReceive(localName, moduleName);
       return ret;
     }
   }
@@ -1149,9 +1193,9 @@ function makeModuleReceiveWithVar(localName, moduleName, defaultValue, noAssert)
 
 function makeRemovedFSAssert(fsName) {
   if (!ASSERTIONS) return;
-  var lower = fsName.toLowerCase();
+  const lower = fsName.toLowerCase();
   if (SYSTEM_JS_LIBRARIES.indexOf('library_' + lower + '.js') >= 0) return '';
-  return "var " + fsName + " = '" + fsName + " is no longer included by default; build with -l" + lower + ".js';";
+  return `var ${fsName} = '${fsName} is no longer included by default; build with -l${lower}.js';`;
 }
 
 // Given an array of elements [elem1,elem2,elem3], returns a string "['elem1','elem2','elem3']"
@@ -1168,15 +1212,14 @@ function buildStringArray(array) {
 function makeAsmImportsAccessInPthread(variable) {
   if (!MINIMAL_RUNTIME) {
     // Regular runtime uses the name "Module" for both imports and exports.
-    return "Module['" + variable + "']";
+    return `Module['${variable}']`;
   }
   if (MODULARIZE) {
     // MINIMAL_RUNTIME uses 'imports' as the name for the imports object in MODULARIZE builds.
-    return "imports['" + variable + "']";
-  } else {
-    // In non-MODULARIZE builds, can access the imports from global scope.
-    return variable;
+    return `imports['${variable}']`;
   }
+  // In non-MODULARIZE builds, can access the imports from global scope.
+  return variable;
 }
 
 function hasExportedFunction(func) {
@@ -1188,9 +1231,8 @@ function hasExportedFunction(func) {
 function defineI64Param(name) {
   if (WASM_BIGINT) {
     return name + '_bigint';
-  } else {
-    return name + '_low, ' + name + '_high';
   }
+  return name + '_low, ' + name + '_high';
 }
 
 function receiveI64ParamAsI32s(name) {
@@ -1200,18 +1242,16 @@ function receiveI64ParamAsI32s(name) {
     //    https://github.com/google/closure-compiler/issues/3167
     //  * acorn needs to be upgraded, and to set ecmascript version >= 11
     //  * terser needs to be upgraded
-    return 'var ' + name + '_low = Number(' + name + '_bigint & BigInt(0xffffffff)) | 0, ' + name + '_high = Number(' + name + '_bigint >> BigInt(32)) | 0;';
-  } else {
-    return '';
+    return `var ${name}_low = Number(${name}_bigint & BigInt(0xffffffff)) | 0, ${name}_high = Number(${name}_bigint >> BigInt(32)) | 0;`;
   }
+  return '';
 }
 
 function sendI64Argument(low, high) {
   if (WASM_BIGINT) {
     return 'BigInt(low) | (BigInt(high) << BigInt(32))';
-  } else {
-    return low + ', ' + high;
   }
+  return low + ', ' + high;
 }
 
 // Add assertions to catch common errors when using the Promise object we
@@ -1222,7 +1262,7 @@ function addReadyPromiseAssertions(promise) {
   //  var instance = Module();
   //  ...
   //  instance._main();
-  var properties = keys(EXPORTED_FUNCTIONS);
+  const properties = keys(EXPORTED_FUNCTIONS);
   // Also warn on onRuntimeInitialized which might be a common pattern with
   // older MODULARIZE-using codebases.
   properties.push('onRuntimeInitialized');
@@ -1239,7 +1279,7 @@ function addReadyPromiseAssertions(promise) {
 
 function makeMalloc(source, param) {
   if ('_malloc' in IMPLEMENTED_FUNCTIONS) {
-    return '_malloc(' + param + ')';
+    return `_malloc(${param})`;
   }
   // It should be impossible to call some functions without malloc being
   // included, unless we have a deps_info.json bug. To let closure not error
@@ -1247,7 +1287,7 @@ function makeMalloc(source, param) {
   // with an error at runtime.
   // TODO: A more comprehensive deps system could catch this at compile time.
   if (!ASSERTIONS) {
-    return "abort();";
+    return 'abort();';
   }
-  return `abort('malloc was not included, but is needed in ${source}. Adding "_malloc" to EXPORTED_FUNCTIONS should fix that. This may be a bug in the compiler, please file an issue.');`
+  return `abort('malloc was not included, but is needed in ${source}. Adding "_malloc" to EXPORTED_FUNCTIONS should fix that. This may be a bug in the compiler, please file an issue.');`;
 }


### PR DESCRIPTION
I chose a single one of the compiler JS files and made it conform
to the style.

We use JS is strange ways (use use eval to import modules into
the global scope!) so we can't apply some rules.

Also we can't lint library.js files because they use the preprocessor.
