### PR TITLE
By default disable SUPPORT_ERRNO in MINIMAL_RUNTIME builds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -50,6 +50,9 @@ Current Trunk
 - Added support to use a custom set of substitution characters . # and ? to
   ease passing arrays of C symbols on the command line to ASYNCIFY_* settings.
   (#13477)
+- In MINIMAL_RUNTIME build mode, errno support will now be disabled by default
+  due to the code size that it adds. (MINIMAL_RUNTIME=1 implies SUPPORT_ERRNO=0
+  by default) Pass -s SUPPORT_ERRNO=1 to enable errno support if necessary.
 - Using EM_ASM and EM_JS in a side module will now result in an error (since
   this is not implemented yet).  This could effect users were previously
   inadvertently including (but not actually using) EM_ASM or EM_JS functions in

--- a/emcc.py
+++ b/emcc.py
@@ -1355,6 +1355,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # TODO(sbc): Remove this once this becomes the default
       shared.Settings.IGNORE_MISSING_MAIN = 0
 
+    # It is unlikely that developers targeting "native web" APIs with MINIMAL_RUNTIME need
+    # errno support by default.
+    if shared.Settings.MINIMAL_RUNTIME:
+      default_setting('SUPPORT_ERRNO', 0)
+
     if shared.Settings.STRICT:
       default_setting('STRICT_JS', 1)
       default_setting('AUTO_JS_LIBRARIES', 0)

--- a/emcc.py
+++ b/emcc.py
@@ -1359,7 +1359,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # errno support by default.
     if shared.Settings.MINIMAL_RUNTIME:
       default_setting('SUPPORT_ERRNO', 0)
-      logger.debug('In MINIMAL_RUNTIME builds, errno support is disabled by default to save code size. Pass -s SUPPORT_ERRNO=1 to enable support.')
 
     if shared.Settings.STRICT:
       default_setting('STRICT_JS', 1)

--- a/emcc.py
+++ b/emcc.py
@@ -1359,6 +1359,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # errno support by default.
     if shared.Settings.MINIMAL_RUNTIME:
       default_setting('SUPPORT_ERRNO', 0)
+      logger.debug('In MINIMAL_RUNTIME builds, errno support is disabled by default to save code size. Pass -s SUPPORT_ERRNO=1 to enable support.')
 
     if shared.Settings.STRICT:
       default_setting('STRICT_JS', 1)

--- a/src/settings.js
+++ b/src/settings.js
@@ -1698,6 +1698,7 @@ var MIN_CHROME_VERSION = 75;
 // bit of generated code size in applications that do not care about
 // POSIX errno variable. Setting this to 0 also requires using --closure
 // for effective code size optimizations to take place.
+// In MINIMAL_RUNTIME builds, this option defaults to 0.
 // [link]
 var SUPPORT_ERRNO = 1;
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9595,12 +9595,13 @@ int main() {
 
   @parameterized({
     '': ([],),
-    'minimal': (['-s', 'MINIMAL_RUNTIME', '-s', 'SUPPORT_ERRNO=1'],),
+    'minimal': (['-s', 'MINIMAL_RUNTIME', '-s', 'SUPPORT_ERRNO'],),
   })
   def test_support_errno(self, args):
     self.emcc_args += args
     src = test_file('core', 'test_support_errno.c')
     output = test_file('core', 'test_support_errno.out')
+
     self.do_run_from_file(src, output)
     size_default = os.path.getsize('test_support_errno.js')
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9595,7 +9595,7 @@ int main() {
 
   @parameterized({
     '': ([],),
-    'minimal': (['-s', 'MINIMAL_RUNTIME'],),
+    'minimal': (['-s', 'MINIMAL_RUNTIME', '-s', 'SUPPORT_ERRNO=1'],),
   })
   def test_support_errno(self, args):
     self.emcc_args += args

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9607,7 +9607,7 @@ int main() {
 
     # Run the same test again but with SUPPORT_ERRNO disabled.  This time we don't expect errno
     # to be set after the failing syscall.
-    self.set_setting('SUPPORT_ERRNO', 0)
+    self.emcc_args += ['-s', 'SUPPORT_ERRNO=0']
     output = test_file('core', 'test_support_errno_disabled.out')
     self.do_run_from_file(src, output)
 


### PR DESCRIPTION
By default disable SUPPORT_ERRNO in MINIMAL_RUNTIME builds - it is unlikely that developers targeting MINIMAL_RUNTIME would want this. (can override back if desired)