### PR TITLE
Deterministic dynamic libs order

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -540,3 +540,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Raffaele Pertile <raffarti@zoho.com>
 * Patric Stout <github@truebrain.nl>
 * Jinoh Kang <jinoh.kang.kr@gmail.com>
+* Jorge Prendes <jorge.prendes@gmail.com>

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -46,7 +46,7 @@ var LibraryDylink = {
 
   $GOT: {},
 
-  // Greate globals to each imported symbol.  These are all initialized to zero
+  // Create globals to each imported symbol.  These are all initialized to zero
   // and get assigned later in `updateGOT`
   $GOTHandler__deps: ['$GOT'],
   $GOTHandler: {
@@ -217,7 +217,7 @@ var LibraryDylink = {
     loadedLibNames: {},
   },
 
-  // Dynmamic version of shared.py:make_invoke.  This is needed for invokes
+  // Dynamic version of shared.py:make_invoke.  This is needed for invokes
   // that originate from side modules since these are not known at JS
   // generation time.
   $createInvokeFunction: function(sig) {
@@ -258,7 +258,7 @@ var LibraryDylink = {
     return ret;
   },
 
-  // fetchBinary fetches binaray data @ url. (async)
+  // fetchBinary fetches binary data @ url. (async)
   $fetchBinary: function(url) {
     return fetch(url, { credentials: 'same-origin' }).then(function(response) {
       if (!response['ok']) {
@@ -271,7 +271,7 @@ var LibraryDylink = {
   },
 
   // Loads a side module from binary data. Returns the module's exports or a
-  // progise that resolves to its exports if the loadAsync flag is set.
+  // promise that resolves to its exports if the loadAsync flag is set.
   $loadWebAssemblyModule__deps: ['$loadDynamicLibrary', '$createInvokeFunction', '$getMemory', '$relocateExports', '$resolveGlobalSymbol', '$GOTHandler'],
   $loadWebAssemblyModule: function(binary, flags) {
     var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3556,6 +3556,41 @@ window.close = function() {
     self.btest_exit(self.in_dir('main.c'), '3',
                     args=['-s', 'MAIN_MODULE', '--pre-js', 'pre.js'])
 
+  def test_dynamic_link_pthread_many(self):
+    # test asynchronously loading two side modules during startup
+    # they should always load in the same order
+    create_test_file('main.cpp', r'''
+      #include <assert.h>
+      #include <thread>
+      extern "C" int side1();
+      extern "C" int side2();
+      int main() {
+        auto side1_ptr = &side1;
+        auto side2_ptr = &side2;
+        std::thread([=]{
+          REPORT_RESULT(int(
+            side1_ptr() == 1 &&
+            side2_ptr() == 2
+          ));
+        }).detach();
+        return 0;
+      }
+    ''')
+    # Use a big payload in side1 so that it takes longer to load than side2
+    create_test_file('side1.cpp', r'''
+      char const * payload1 = "''' + str(list(range(1, int(1e5)))) + r'''";
+      extern "C" int side1() { return 1; }
+    ''')
+    create_test_file('side2.cpp', r'''
+      char const * payload2 = "0";
+      extern "C" int side2() { return 2; }
+    ''')
+    self.run_process([EMCC, 'side1.cpp', '-Wno-experimental', '-pthread', '-s', 'SIDE_MODULE', '-o', 'side1.wasm'])
+    self.run_process([EMCC, 'side2.cpp', '-Wno-experimental', '-pthread', '-s', 'SIDE_MODULE', '-o', 'side2.wasm'])
+    self.btest(self.in_dir('main.cpp'), '1',
+               args=['-Wno-experimental', '-pthread', '-s', 'MAIN_MODULE',
+                     '-s', 'RUNTIME_LINKED_LIBS=["side1.wasm","side2.wasm"]'])
+
   def test_memory_growth_during_startup(self):
     create_test_file('data.dat', 'X' * (30 * 1024 * 1024))
     self.btest('browser_test_hello_world.c', '0', args=['-s', 'ASSERTIONS', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'INITIAL_MEMORY=16MB', '-s', 'TOTAL_STACK=16384', '--preload-file', 'data.dat'])


### PR DESCRIPTION
When using pthread with more than one dynamic library the order in which the libraries are linked when the module is loaded in the browser's main thread is non deterministic. This makes the function pointers between the main thread and the workers not compatible.

With this change the main thread links the dynamic libraries in the same deterministic order as in the workers.
This fix only applies to libraries linked when the module is loaded and adds a test to lock down this behavior.
Libraries linked only through dlopen remains unsupported.

Fix #13303