### PR TITLE
Avoid writing even sanity.txt if FROZEN_CACHE is enabled

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -75,7 +75,7 @@ def normalize_config_settings():
   JS_ENGINES = [listify(engine) for engine in JS_ENGINES]
   WASM_ENGINES = [listify(engine) for engine in WASM_ENGINES]
   if not CACHE:
-    if root_is_writable():
+    if FROZEN_CACHE or root_is_writable():
       CACHE = path_from_root('cache')
     else:
       # Use the legacy method of putting the cache in the user's home directory


### PR DESCRIPTION
These improvements to the FROZE_CACHE setting allow for a
pre-populated read-only cache.  In thie senario the cache
is cannot ever be locked, and that we don't even write
the sanity file.

Users can still forece a sanity check with `emcc --check`
but no sanity file will ever be written.