### PR TITLE
Avoid using EM_IGNORE_SANITY in test code. NFC.

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -58,13 +58,16 @@ NODE_JS = %s
 ''' % (config.LLVM_ROOT, config.BINARYEN_ROOT, config.NODE_JS)
 
 
-def make_fake_wasm_opt(filename, version):
-  print('make_fake_wasm_opt: %s' % filename)
+def make_fake_tool(filename, version, report_name=None):
+  if not report_name:
+    report_name = os.path.basename(filename)
+  print('make_fake_tool: %s' % filename)
   ensure_dir(os.path.dirname(filename))
   with open(filename, 'w') as f:
     f.write('#!/bin/sh\n')
-    f.write('echo "wasm-opt version %s"\n' % version)
+    f.write('echo "%s version %s"\n' % (report_name, version))
     f.write('echo "..."\n')
+    f.write('exit 0\n')
   make_executable(filename)
 
 
@@ -72,15 +75,8 @@ def make_fake_clang(filename, version):
   """Create a fake clang that only handles --version
   --version writes to stdout (unlike -v which writes to stderr)
   """
-  print('make_fake_clang: %s' % filename)
-  ensure_dir(os.path.dirname(filename))
-  with open(filename, 'w') as f:
-    f.write('#!/bin/sh\n')
-    f.write('echo "clang version %s"\n' % version)
-    f.write('echo "..."\n')
-  shutil.copyfile(filename, filename + '++')
-  make_executable(filename)
-  make_executable(filename + '++')
+  make_fake_tool(filename, version)
+  make_fake_tool(filename + '++', version)
 
 
 def make_fake_llc(filename, targets):
@@ -92,14 +88,6 @@ def make_fake_llc(filename, targets):
   with open(filename, 'w') as f:
     f.write('#!/bin/sh\n')
     f.write('echo "llc fake output\nRegistered Targets:\n%s"' % targets)
-  make_executable(filename)
-
-
-def make_fake_lld(filename):
-  print('make_fake_lld: %s' % filename)
-  with open(filename, 'w') as f:
-    f.write('#!/bin/sh\n')
-    f.write('exit 0\n')
   make_executable(filename)
 
 
@@ -261,23 +249,25 @@ class sanity(RunnerCore):
 
     real_version_x, real_version_y = (int(x) for x in EXPECTED_LLVM_VERSION.split('.'))
     make_fake_llc(self.in_dir('fake', 'llc'), 'wasm32 - WebAssembly 32-bit')
-    make_fake_lld(self.in_dir('fake', 'wasm-ld'))
+    make_fake_tool(self.in_dir('fake', 'wasm-ld'), EXPECTED_LLVM_VERSION)
 
-    with env_modify({'EM_IGNORE_SANITY': '1'}):
-      for inc_x in range(-2, 3):
-        for inc_y in range(-2, 3):
-          expected_x = real_version_x + inc_x
-          expected_y = real_version_y + inc_y
-          if expected_x < 0 or expected_y < 0:
-            continue # must be a valid llvm version
-          print("mod LLVM version: %d %d -> %d %d" % (real_version_x, real_version_x, expected_x, expected_y))
-          make_fake_clang(self.in_dir('fake', 'clang'), '%s.%s' % (expected_x, expected_y))
-          did_modify = inc_x != 0 or inc_y != 0
-          if did_modify:
-            output = self.check_working(EMCC, LLVM_WARNING)
-          else:
-            output = self.check_working(EMCC)
-            self.assertNotContained(LLVM_WARNING, output)
+    for inc_x in range(-2, 3):
+      for inc_y in range(-2, 3):
+        try_delete(SANITY_FILE)
+        expected_x = real_version_x + inc_x
+        expected_y = real_version_y + inc_y
+        if expected_x < 0 or expected_y < 0:
+          continue # must be a valid llvm version
+        print("mod LLVM version: %d %d -> %d %d" % (real_version_x, real_version_y, expected_x, expected_y))
+        make_fake_clang(self.in_dir('fake', 'clang'), '%s.%s' % (expected_x, expected_y))
+        make_fake_tool(self.in_dir('fake', 'llvm-ar'), '%s.%s' % (expected_x, expected_y))
+        make_fake_tool(self.in_dir('fake', 'llvm-nm'), '%s.%s' % (expected_x, expected_y))
+        did_modify = inc_x != 0 or inc_y != 0
+        if did_modify:
+          output = self.check_working(EMCC, LLVM_WARNING)
+        else:
+          output = self.check_working(EMCC)
+          self.assertNotContained(LLVM_WARNING, output)
 
   def test_emscripten_root(self):
     # The correct path
@@ -299,7 +289,7 @@ class sanity(RunnerCore):
     # Clang should report the version number we expect, and emcc should not warn
     assert shared.check_node_version()
     output = self.check_working(EMCC)
-    self.assertNotIn(NODE_WARNING, output)
+    self.assertNotContained(NODE_WARNING, output)
 
     # Fake a different node version
     restore_and_set_up()
@@ -308,31 +298,31 @@ class sanity(RunnerCore):
 
     ensure_dir('fake')
 
-    with env_modify({'EM_IGNORE_SANITY': '1'}):
-      for version, succeed in [('v0.8.0', False),
-                               ('v4.1.0', False),
-                               ('v4.1.1', True),
-                               ('v4.2.3-pre', True),
-                               ('cheez', False)]:
-        print(version, succeed)
-        f = open(self.in_dir('fake', 'nodejs'), 'w')
-        f.write('#!/bin/sh\n')
-        f.write('''if [ $1 = "--version" ]; then
+    for version, succeed in [('v0.8.0', False),
+                             ('v4.1.0', False),
+                             ('v4.1.1', True),
+                             ('v4.2.3-pre', True),
+                             ('cheez', False)]:
+      print(version, succeed)
+      try_delete(SANITY_FILE)
+      f = open(self.in_dir('fake', 'nodejs'), 'w')
+      f.write('#!/bin/sh\n')
+      f.write('''if [ $1 = "--version" ]; then
 echo "%s"
 else
 %s $@
 fi
-''' % (version, config.NODE_JS))
-        f.close()
-        make_executable(self.in_dir('fake', 'nodejs'))
-        if not succeed:
-          if version[0] == 'v':
-            self.check_working(EMCC, NODE_WARNING)
-          else:
-            self.check_working(EMCC, NODE_WARNING_2)
+''' % (version, ' '.join(config.NODE_JS)))
+      f.close()
+      make_executable(self.in_dir('fake', 'nodejs'))
+      if not succeed:
+        if version[0] == 'v':
+          self.check_working(EMCC, NODE_WARNING)
         else:
-          output = self.check_working(EMCC)
-          assert NODE_WARNING not in output, output
+          self.check_working(EMCC, NODE_WARNING_2)
+      else:
+        output = self.check_working(EMCC)
+        self.assertNotContained(NODE_WARNING, output)
 
   def test_emcc(self):
     SANITY_FAIL_MESSAGE = 'sanity check failed to run'
@@ -598,30 +588,30 @@ fi
     test_path = self.in_dir('fake', 'abcd8765')
     ensure_dir(test_path)
 
-    with env_modify({'EM_IGNORE_SANITY': '1'}):
-      jsengines = [('d8',     config.V8_ENGINE),
-                   ('d8_g',   config.V8_ENGINE),
-                   ('js',     config.SPIDERMONKEY_ENGINE),
-                   ('node',   config.NODE_JS),
-                   ('nodejs', config.NODE_JS)]
-      for filename, engine in jsengines:
-        if type(engine) is list:
-          engine = engine[0]
-        if not engine:
-          print('WARNING: Not testing engine %s, not configured.' % (filename))
-          continue
+    jsengines = [('d8',     config.V8_ENGINE),
+                 ('d8_g',   config.V8_ENGINE),
+                 ('js',     config.SPIDERMONKEY_ENGINE),
+                 ('node',   config.NODE_JS),
+                 ('nodejs', config.NODE_JS)]
+    for filename, engine in jsengines:
+      try_delete(SANITY_FILE)
+      if type(engine) is list:
+        engine = engine[0]
+      if not engine:
+        print('WARNING: Not testing engine %s, not configured.' % (filename))
+        continue
 
-        print(filename, engine)
+      print(filename, engine)
 
-        test_engine_path = os.path.join(test_path, filename)
-        with open(test_engine_path, 'w') as f:
-          f.write('#!/bin/sh\n')
-          f.write('exec %s $@\n' % (engine))
-        make_executable(test_engine_path)
+      test_engine_path = os.path.join(test_path, filename)
+      with open(test_engine_path, 'w') as f:
+        f.write('#!/bin/sh\n')
+        f.write('exec %s $@\n' % (engine))
+      make_executable(test_engine_path)
 
-        out = self.run_js(sample_script, engine=test_engine_path, args=['--foo'])
+      out = self.run_js(sample_script, engine=test_engine_path, args=['--foo'])
 
-        self.assertEqual('0: --foo', out.strip())
+      self.assertEqual('0: --foo', out.strip())
 
   def test_wacky_env(self):
     restore_and_set_up()
@@ -657,7 +647,7 @@ fi
 
       make_fake_clang(self.in_dir('fake', 'bin', 'clang'), EXPECTED_LLVM_VERSION)
       make_fake_llc(self.in_dir('fake', 'bin', 'llc'), report)
-      make_fake_lld(self.in_dir('fake', 'bin', 'wasm-ld'))
+      make_fake_tool(self.in_dir('fake', 'bin', 'wasm-ld'), EXPECTED_LLVM_VERSION)
 
     # fake llc output
 
@@ -702,8 +692,8 @@ fi
     with open(config_file, 'a') as f:
       f.write('\nBINARYEN_ROOT = "' + self.in_dir('fake') + '"')
 
-    make_fake_wasm_opt(self.in_dir('fake', 'bin', 'wasm-opt'), 'foo')
+    make_fake_tool(self.in_dir('fake', 'bin', 'wasm-opt'), 'foo')
     self.check_working([EMCC, path_from_root('tests', 'hello_world.c')], 'error parsing binaryen version (wasm-opt version foo). Please check your binaryen installation')
 
-    make_fake_wasm_opt(self.in_dir('fake', 'bin', 'wasm-opt'), '70')
+    make_fake_tool(self.in_dir('fake', 'bin', 'wasm-opt'), '70')
     self.check_working([EMCC, path_from_root('tests', 'hello_world.c')], 'unexpected binaryen version: 70 (expected ')


### PR DESCRIPTION
This isn't needed provided:
a. the fake tools were good enough to fool our checks
b. we clear the sanity file explicitly between each test iteration.