### PR TITLE
Build cached items directly to expected locations. NFC.

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -250,6 +250,8 @@ def main():
       shared.Settings.USE_PTHREADS = 0
     elif what == 'boost_headers':
       build_port('boost_headers', 'libboost_headers.a')
+    elif what == 'mpg123':
+      build_port('mpg123', 'libmpg123.a')
     else:
       logger.error('unfamiliar build target: ' + what)
       return 1

--- a/emscripten.py
+++ b/emscripten.py
@@ -827,11 +827,9 @@ def normalize_line_endings(text):
 def generate_struct_info():
   generated_struct_info_name = 'generated_struct_info.json'
 
-  def generate_struct_info():
+  def generate_struct_info(out):
     with ToolchainProfiler.profile_block('gen_struct_info'):
-      out = shared.Cache.get_path(generated_struct_info_name)
       gen_struct_info.main(['-q', '-o', out])
-      return out
 
   shared.Settings.STRUCT_INFO = shared.Cache.get(generated_struct_info_name, generate_struct_info)
 

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -6,7 +6,6 @@
 import contextlib
 import logging
 import os
-import shutil
 from . import tempfiles, filelock, config, utils
 
 logger = logging.getLogger('cache')
@@ -149,10 +148,9 @@ class Cache:
           what = 'system asset'
       message = 'generating ' + what + ': ' + shortname + '... (this will be cached in "' + cachename + '" for subsequent builds)'
       logger.info(message)
-      temp = creator()
-      if os.path.normcase(temp) != os.path.normcase(cachename):
-        utils.safe_ensure_dirs(os.path.dirname(cachename))
-        shutil.copyfile(temp, cachename)
+      utils.safe_ensure_dirs(os.path.dirname(cachename))
+      creator(cachename)
+      assert os.path.exists(cachename)
       logger.info(' - ok')
 
     return cachename

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -18,9 +18,8 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('boost_headers', 'https://github.com/emscripten-ports/boost/releases/download/boost-1.70.0/boost-headers-' + TAG + '.zip',
                       'boost', sha512hash=HASH)
-  libname = 'libboost_headers.a'
 
-  def create():
+  def create(final):
     logging.info('building port: boost_headers')
     ports.clear_project_build('boost_headers')
 
@@ -43,12 +42,10 @@ def get(ports, settings, shared):
     command = [shared.EMCC, '-c', dummy_file, '-o', obj]
     commands.append(command)
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'boost_headers', libname)
     o_s.append(obj)
     ports.create_lib(final, o_s)
-    return final
 
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib('libboost_headers.a', create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -17,9 +17,8 @@ def needed(settings):
 
 def get(ports, settings, shared):
   ports.fetch_project('bullet', 'https://github.com/emscripten-ports/bullet/archive/' + TAG + '.zip', 'Bullet-' + TAG, sha512hash=HASH)
-  libname = 'libbullet.a'
 
-  def create():
+  def create(final):
     logging.info('building port: bullet')
 
     source_path = os.path.join(ports.get_dir(), 'bullet', 'Bullet-' + TAG)
@@ -46,11 +45,9 @@ def get(ports, settings, shared):
       for dir in dirs:
         includes.append(os.path.join(root, dir))
 
-    final = os.path.join(ports.get_build_dir(), 'bullet', libname)
     ports.build_port(src_path, final, includes=includes, exclude_dirs=['MiniCL'])
-    return final
 
-  return [shared.Cache.get_lib(libname, create)]
+  return [shared.Cache.get_lib('libbullet.a', create)]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -17,7 +17,7 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('bzip2', 'https://github.com/emscripten-ports/bzip2/archive/' + VERSION + '.zip', 'bzip2-' + VERSION, sha512hash=HASH)
 
-  def create():
+  def create(final):
     ports.clear_project_build('bzip2')
 
     source_path = os.path.join(ports.get_dir(), 'bzip2', 'bzip2-' + VERSION)
@@ -42,10 +42,8 @@ def get(ports, settings, shared):
       o_s.append(o)
     ports.run_commands(commands)
 
-    final = os.path.join(ports.get_build_dir(), 'bzip2', 'libbz2.a')
     ports.create_lib(final, o_s)
     ports.install_headers(source_path)
-    return final
 
   return [shared.Cache.get_lib('libbz2.a', create, what='port')]
 

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -21,9 +21,8 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project(
     'cocos2d', 'https://github.com/emscripten-ports/Cocos2d/archive/' + TAG + '.zip', 'Cocos2d-' + TAG, sha512hash=HASH)
-  libname = 'libcocos2d.a'
 
-  def create():
+  def create(final):
     logging.info('building port: cocos2d v3')
     logging.warn('cocos2d: library is experimental, do not expect that it will work out of the box')
 
@@ -65,16 +64,13 @@ def get(ports, settings, shared):
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
-    final = os.path.join(cocos2d_build, libname)
     ports.create_lib(final, o_s)
 
     for dirname in cocos2dx_includes:
       target = os.path.join('cocos2d', os.path.relpath(dirname, cocos2d_root))
       ports.install_header_dir(dirname, target=target)
 
-    return final
-
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib('libcocos2d.a', create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -17,7 +17,7 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('freetype', 'https://github.com/emscripten-ports/FreeType/archive/' + TAG + '.zip', 'FreeType-' + TAG, sha512hash=HASH)
 
-  def create():
+  def create(final):
     ports.clear_project_build('freetype')
 
     source_path = os.path.join(ports.get_dir(), 'freetype', 'FreeType-' + TAG)
@@ -101,13 +101,11 @@ def get(ports, settings, shared):
       o_s.append(o)
 
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'freetype', 'libfreetype.a')
     shared.try_delete(final)
     shared.run_process([shared.LLVM_AR, 'rc', final] + o_s)
 
     ports.install_header_dir(os.path.join(dest_path, 'include'),
                              target=os.path.join('freetype2', 'freetype'))
-    return final
 
   return [shared.Cache.get_lib('libfreetype.a', create, what='port')]
 

--- a/tools/ports/giflib.py
+++ b/tools/ports/giflib.py
@@ -18,9 +18,7 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('giflib', f'https://vorboss.dl.sourceforge.net/project/giflib/giflib-{VERSION}.tar.gz', f'giflib-{VERSION}', sha512hash=HASH)
 
-  libname = 'libgif.a'
-
-  def create():
+  def create(final):
     logging.info('building port: giflib')
 
     source_path = os.path.join(ports.get_dir(), 'giflib', f'giflib-{VERSION}')
@@ -31,11 +29,9 @@ def get(ports, settings, shared):
 
     ports.install_headers(dest_path)
 
-    final = os.path.join(ports.get_build_dir(), 'giflib', libname)
     ports.build_port(dest_path, final)
-    return final
 
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib('libgif.a', create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -4,6 +4,7 @@
 # found in the LICENSE file.
 
 import os
+import shutil
 import logging
 from tools import building
 
@@ -25,7 +26,7 @@ def get(ports, settings, shared):
   ports.fetch_project('harfbuzz', 'https://github.com/harfbuzz/harfbuzz/releases/download/' +
                       TAG + '/harfbuzz-' + TAG + '.tar.bz2', 'harfbuzz-' + TAG, is_tarbz2=True, sha512hash=HASH)
 
-  def create():
+  def create(final):
     logging.info('building port: harfbuzz')
     ports.clear_project_build('harfbuzz')
 
@@ -65,7 +66,7 @@ def get(ports, settings, shared):
 
     ports.install_header_dir(os.path.join(dest_path, 'include', 'harfbuzz'))
 
-    return os.path.join(dest_path, 'libharfbuzz.a')
+    shutil.copyfile(os.path.join(dest_path, 'libharfbuzz.a'), final)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -19,9 +19,8 @@ def needed(settings):
 def get(ports, settings, shared):
   url = 'https://github.com/unicode-org/icu/releases/download/%s/icu4c-%s-src.zip' % (TAG, VERSION)
   ports.fetch_project('icu', url, 'icu', sha512hash=HASH)
-  libname = 'libicuuc.a'
 
-  def create():
+  def create(final):
     logging.info('building port: icu')
 
     source_path = os.path.join(ports.get_dir(), 'icu', 'icu')
@@ -30,13 +29,11 @@ def get(ports, settings, shared):
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
-    final = os.path.join(dest_path, libname)
     ports.build_port(os.path.join(dest_path, 'source', 'common'), final, [os.path.join(dest_path, 'source', 'common')], ['-DU_COMMON_IMPLEMENTATION=1'])
 
     ports.install_header_dir(os.path.join(dest_path, 'source', 'common', 'unicode'))
-    return final
 
-  return [shared.Cache.get_lib(libname, create)]
+  return [shared.Cache.get_lib('libicuuc.a', create)]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -18,9 +18,7 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('libjpeg', 'https://dl.bintray.com/homebrew/mirror/jpeg-9c.tar.gz', 'jpeg-9c', sha512hash=HASH)
 
-  libname = 'libjpeg.a'
-
-  def create():
+  def create(final):
     logging.info('building port: libjpeg')
 
     source_path = os.path.join(ports.get_dir(), 'libjpeg', 'jpeg-9c')
@@ -32,7 +30,6 @@ def get(ports, settings, shared):
     open(os.path.join(dest_path, 'jconfig.h'), 'w').write(jconfig_h)
     ports.install_headers(dest_path)
 
-    final = os.path.join(ports.get_build_dir(), 'libjpeg', libname)
     ports.build_port(
       dest_path, final,
       exclude_files=[
@@ -41,9 +38,8 @@ def get(ports, settings, shared):
         'jpegtran.c', 'rdjpgcom.c', 'wrjpgcom.c',
       ]
     )
-    return final
 
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib('libjpeg.a', create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -20,9 +20,7 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('libpng', 'https://github.com/emscripten-ports/libpng/archive/' + TAG + '.zip', 'libpng-' + TAG, sha512hash=HASH)
 
-  libname = 'libpng.a'
-
-  def create():
+  def create(final):
     logging.info('building port: libpng')
 
     source_path = os.path.join(ports.get_dir(), 'libpng', 'libpng-' + TAG)
@@ -34,11 +32,9 @@ def get(ports, settings, shared):
     open(os.path.join(dest_path, 'pnglibconf.h'), 'w').write(pnglibconf_h)
     ports.install_headers(dest_path)
 
-    final = os.path.join(ports.get_build_dir(), 'libpng', libname)
     ports.build_port(dest_path, final, flags=['-s', 'USE_ZLIB=1'], exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
-    return final
 
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib('libpng.a', create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -17,9 +17,8 @@ def needed(settings):
 
 def get(ports, settings, shared):
   ports.fetch_project('mpg123', 'https://www.mpg123.de/download/mpg123-1.26.2.tar.bz2', 'mpg123-' + TAG, is_tarbz2=True, sha512hash=HASH)
-  libname = 'libmpg123.a'
 
-  def create():
+  def create(output_path):
     logging.info('building port: mpg123')
 
     source_path = os.path.join(ports.get_dir(), 'mpg123', 'mpg123-' + TAG)
@@ -34,7 +33,6 @@ def get(ports, settings, shared):
     open(os.path.join(sauce_path, 'config.h'), 'w').write(config_h)
     open(os.path.join(libmpg123_path, 'mpg123.h'), 'w').write(mpg123_h)
 
-    output_path = os.path.join(dest_path, libname)
     flags = [
       '-DOPT_GENERIC',
       '-DREAL_IS_FLOAT',
@@ -91,9 +89,8 @@ def get(ports, settings, shared):
 
     # copy header to a location so it can be used as 'MPG123/'
     ports.install_headers(libmpg123_path, pattern="*123.h", target='')
-    return output_path
 
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib('libmpg123.a', create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -17,9 +17,8 @@ def needed(settings):
 
 def get(ports, settings, shared):
   ports.fetch_project('ogg', 'https://github.com/emscripten-ports/ogg/archive/' + TAG + '.zip', 'Ogg-' + TAG, sha512hash=HASH)
-  libname = 'libogg.a'
 
-  def create():
+  def create(final):
     logging.info('building port: ogg')
     ports.clear_project_build('vorbis')
 
@@ -35,11 +34,9 @@ def get(ports, settings, shared):
     shutil.rmtree(header_dir, ignore_errors=True)
     shutil.copytree(os.path.join(dest_path, 'include', 'ogg'), header_dir)
 
-    final = os.path.join(dest_path, libname)
     ports.build_port(os.path.join(dest_path, 'src'), final)
-    return final
 
-  return [shared.Cache.get_lib(libname, create)]
+  return [shared.Cache.get_lib('libogg.a', create)]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -23,7 +23,7 @@ def get(ports, settings, shared):
   ports.fetch_project('regal', 'https://github.com/emscripten-ports/regal/archive/' + TAG + '.zip',
                       'regal-' + TAG, sha512hash=HASH)
 
-  def create():
+  def create(final):
     logging.info('building port: regal')
     ports.clear_project_build('regal')
 
@@ -134,9 +134,7 @@ def get(ports, settings, shared):
       o_s.append(o)
 
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'regal', get_lib_name(settings))
     ports.create_lib(final, o_s)
-    return final
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 

--- a/tools/ports/sdl2.py
+++ b/tools/ports/sdl2.py
@@ -21,9 +21,8 @@ def get_lib_name(settings):
 def get(ports, settings, shared):
   # get the port
   ports.fetch_project('sdl2', 'https://github.com/emscripten-ports/SDL2/archive/' + TAG + '.zip', SUBDIR, sha512hash=HASH)
-  libname = get_lib_name(settings)
 
-  def create():
+  def create(final):
     # copy includes to a location so they can be used as 'SDL2/'
     source_include_path = os.path.join(ports.get_dir(), 'sdl2', SUBDIR, 'include')
     ports.install_headers(source_include_path, target='SDL2')
@@ -82,11 +81,9 @@ def get(ports, settings, shared):
       commands.append(command)
       o_s.append(o)
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'sdl2', libname)
     ports.create_lib(final, o_s)
-    return final
 
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -19,9 +19,8 @@ def get(ports, settings, shared):
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_gfx'
   ports.fetch_project('sdl2_gfx', 'https://github.com/svn2github/sdl2_gfx/archive/' + TAG + '.zip', 'sdl2_gfx-' + TAG, sha512hash=HASH)
-  libname = 'libSDL2_gfx.a'
 
-  def create():
+  def create(final):
     logging.info('building port: sdl2_gfx')
 
     source_path = os.path.join(ports.get_dir(), 'sdl2_gfx', 'sdl2_gfx-' + TAG)
@@ -29,13 +28,11 @@ def get(ports, settings, shared):
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
-    final = os.path.join(dest_path, libname)
     ports.build_port(dest_path, final, [dest_path], exclude_dirs=['test'])
 
     ports.install_headers(source_path, target='SDL2')
-    return final
 
-  return [shared.Cache.get_lib(libname, create)]
+  return [shared.Cache.get_lib('libSDL2_gfx.a', create)]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -26,7 +26,7 @@ def get(ports, settings, shared):
     libname += '_' + formats
   libname += '.a'
 
-  def create():
+  def create(final):
     src_dir = os.path.join(ports.get_dir(), 'sdl2_image', 'SDL2_image-' + TAG)
     ports.install_headers(src_dir, target='SDL2')
     srcs = '''IMG.c IMG_bmp.c IMG_gif.c IMG_jpg.c IMG_lbm.c IMG_pcx.c IMG_png.c IMG_pnm.c IMG_tga.c
@@ -51,9 +51,7 @@ def get(ports, settings, shared):
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'sdl2_image', libname)
     ports.create_lib(final, o_s)
-    return final
 
   return [shared.Cache.get_lib(libname, create, what='port')]
 

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -28,7 +28,7 @@ def get(ports, settings, shared):
     libname += '_' + formats
   libname += '.a'
 
-  def create():
+  def create(final):
     logging.info('building port: sdl2_mixer')
 
     source_path = os.path.join(ports.get_dir(), 'sdl2_mixer', 'SDL2_mixer-' + TAG)
@@ -55,7 +55,6 @@ def get(ports, settings, shared):
         '-DMUSIC_MP3_MPG123',
       ]
 
-    final = os.path.join(dest_path, libname)
     ports.build_port(
       dest_path,
       final,
@@ -74,7 +73,6 @@ def get(ports, settings, shared):
 
     # copy header to a location so it can be used as 'SDL2/'
     ports.install_headers(source_path, pattern='SDL_*.h', target='SDL2')
-    return final
 
   return [shared.Cache.get_lib(libname, create, what='port')]
 

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -18,9 +18,8 @@ def get(ports, settings, shared):
   sdl_build = os.path.join(ports.get_build_dir(), 'sdl2')
   assert os.path.exists(sdl_build), 'You must use SDL2 to use SDL2_net'
   ports.fetch_project('sdl2_net', 'https://github.com/emscripten-ports/SDL2_net/archive/' + TAG + '.zip', 'SDL2_net-' + TAG, sha512hash=HASH)
-  libname = 'libSDL2_net.a'
 
-  def create():
+  def create(final):
     logging.info('building port: sdl2_net')
     src_dir = os.path.join(ports.get_dir(), 'sdl2_net', 'SDL2_net-' + TAG)
     ports.install_headers(src_dir, target='SDL2')
@@ -34,11 +33,9 @@ def get(ports, settings, shared):
       o_s.append(o)
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'sdl2_net', libname)
     ports.create_lib(final, o_s)
-    return final
 
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib('libSDL2_net.a', create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -17,9 +17,8 @@ def needed(settings):
 
 def get(ports, settings, shared):
   ports.fetch_project('sdl2_ttf', 'https://hg.libsdl.org/SDL_ttf/archive/' + TAG + '.zip', 'SDL_ttf-' + TAG, sha512hash=HASH)
-  libname = 'libSDL2_ttf.a'
 
-  def create():
+  def create(final):
     src_root = os.path.join(ports.get_dir(), 'sdl2_ttf', 'SDL_ttf-' + TAG)
     ports.install_headers(src_root, target='SDL2')
 
@@ -37,11 +36,9 @@ def get(ports, settings, shared):
 
     shared.safe_ensure_dirs(os.path.dirname(o_s[0]))
     ports.run_commands(commands)
-    final = os.path.join(ports.get_build_dir(), 'sdl2_ttf', libname)
     ports.create_lib(final, o_s)
-    return final
 
-  return [shared.Cache.get_lib(libname, create, what='port')]
+  return [shared.Cache.get_lib('libSDL2_ttf.a', create, what='port')]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -19,9 +19,8 @@ def needed(settings):
 
 def get(ports, settings, shared):
   ports.fetch_project('vorbis', 'https://github.com/emscripten-ports/vorbis/archive/' + TAG + '.zip', 'Vorbis-' + TAG, sha512hash=HASH)
-  libname = 'libvorbis.a'
 
-  def create():
+  def create(final):
     logging.info('building port: vorbis')
 
     source_path = os.path.join(ports.get_dir(), 'vorbis', 'Vorbis-' + TAG)
@@ -30,13 +29,11 @@ def get(ports, settings, shared):
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
 
-    final = os.path.join(dest_path, libname)
     ports.build_port(os.path.join(dest_path, 'lib'), final, [os.path.join(dest_path, 'include')],
                      ['-s', 'USE_OGG=1'], ['psytune', 'barkmel', 'tone', 'misc'])
     ports.install_header_dir(os.path.join(source_path, 'include', 'vorbis'))
-    return final
 
-  return [shared.Cache.get_lib(libname, create)]
+  return [shared.Cache.get_lib('libvorbis.a', create)]
 
 
 def clear(ports, settings, shared):

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -17,7 +17,7 @@ def needed(settings):
 def get(ports, settings, shared):
   ports.fetch_project('zlib', 'https://github.com/emscripten-ports/zlib/archive/' + TAG + '.zip', 'zlib-' + TAG, sha512hash=HASH)
 
-  def create():
+  def create(final):
     ports.clear_project_build('zlib')
 
     source_path = os.path.join(ports.get_dir(), 'zlib', 'zlib-' + TAG)
@@ -40,9 +40,7 @@ def get(ports, settings, shared):
       o_s.append(o)
     ports.run_commands(commands)
 
-    final = os.path.join(ports.get_build_dir(), 'zlib', 'libz.a')
     ports.create_lib(final, o_s)
-    return final
 
   return [shared.Cache.get_lib('libz.a', create, what='port')]
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -371,11 +371,9 @@ class Library(object):
     run_build_commands(commands)
     return objects
 
-  def build(self):
+  def build(self, out_filename):
     """Builds the library and returns the path to the file."""
-    out_filename = in_temp(self.get_filename())
     create_lib(out_filename, self.build_objects())
-    return out_filename
 
   @classmethod
   def _inherit_list(cls, attr):
@@ -1864,7 +1862,7 @@ def copytree_exist_ok(src, dest):
         shared.safe_copy(os.path.join(src, dirname, f), os.path.join(destdir, f))
 
 
-def install_system_headers():
+def install_system_headers(stamp):
   install_dirs = {
     ('include',): '',
     ('lib', 'compiler-rt', 'include'): '',
@@ -1889,7 +1887,6 @@ def install_system_headers():
   # Removing this file, or running `emcc --clear-cache` or running
   # `./embuilder build sysroot --force` will cause the re-installation of
   # the system headers.
-  stamp = shared.Cache.get_path('sysroot_install.stamp')
   with open(stamp, 'w') as f:
     f.write('x')
   return stamp


### PR DESCRIPTION
When populating the cache with the creator functions that are passed to
`Cache.get` and `Cache.get_lib`, pass the name of the expected output
file to the creator function and assert that it creates it.  This avoid
unnessarily using a temporary file in most cases and saves some code
size/complexity.

Also add mpg123 to embuilder where it was missing.