### PR TITLE
Set dynamic libraries stack limit to match pthreads' stack limit

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1318,10 +1318,20 @@ var LibraryPThread = {
     return func.apply(null, _emscripten_receive_on_main_thread_js_callArgs);
   },
 
+#if MAIN_MODULE >= 1
+  $establishStackSpace__deps: ['$LDSO'],
+#endif
   $establishStackSpace: function(stackTop, stackMax) {
     _emscripten_stack_set_limits(stackTop, stackMax);
 #if STACK_OVERFLOW_CHECK >= 2
     ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
+#if MAIN_MODULE >= 1
+    Object.values(LDSO.loadedLibs).forEach(function (lib) {
+      if ("__set_stack_limits" in lib.module) {
+        lib.module.__set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
+      }
+    });
+#endif
 #endif
 
     // Call inside wasm module to set up the stack frame for this pthread in asm.js/wasm module scope

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5298,6 +5298,50 @@ int main(int argc, char** argv) {
 
     self.assertLess(side_dce_fail[1], 0.95 * side_dce_work[1]) # removing that function saves a chunk
 
+  def test_dynamic_linking_with_pthread_and_stack_check(self):
+    # Test that the stack overflow check is handled correctly
+    # for dynamically linked libraries running on threads.
+
+    # A side module that allocates memory in the stack
+    create_test_file('side.cpp', r'''
+      #include <stdio.h>
+      int side(void (*f)(int &)) {
+          int x = 42;
+          // Do something with x so that the compiler
+          // won't optimize it out, forcing it to
+          // allocate x in the stack.
+          if (f) f(x);
+          return x;
+      }
+      ''')
+    self.run_process([EMCC, '-o', 'side.wasm', 'side.cpp',
+      '-pthread', '-Wno-experimental',
+      '-s', 'SIDE_MODULE=1',
+      '-s', 'ASSERTIONS=2'])
+
+    # Run the side module in a thread
+    create_test_file('main.cpp', r'''
+      #include <thread>
+      int side(void (*f)(int &));
+      int main(void) {
+          std::thread([=]{
+              side(nullptr);
+              printf("success\n");
+          }).join();
+          return 0;
+      }
+      ''')
+
+    self.node_args += ['--experimental-wasm-threads', '--experimental-wasm-bulk-memory']
+    self.do_smart_test('main.cpp', ['success'], emcc_args=[
+      '-pthread', '-Wno-experimental',
+      '-s', 'PROXY_TO_PTHREAD',
+      '-s', 'EXIT_RUNTIME=1',
+      '-s', 'RUNTIME_LINKED_LIBS=[\'side.wasm\']',
+      '-s', 'MAIN_MODULE=1',
+      '-s', 'ASSERTIONS=2'
+    ])
+
   def test_ld_library_path(self):
     create_test_file('hello1.c', r'''
 #include <stdio.h>


### PR DESCRIPTION
Side modules are initialized with the main thread's stack limits. However, those limits are never updated in `establishStackSpace` to match the thread's stack limit when running with pthread.

This makes side modules running in pthreads and using stack space to incorrectly abort due stack overflow when compiling with `STACK_OVERFLOW_CHECK`.

Fixes #13327 