### PR TITLE
Remove undef Browser.safeCallback and Browser.safeSetInterval

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- Remove unused `Browser.safeSetInterval` and `Browser.safeCallback`.  These
+  didn't any callers in emscripten itself or any testing.  If there are users of
+  these functions we could re-enable them with some testing.
 - Fix race condition when running many emcc processes after clearing the cache.
   The processes would race to run the sanity checks and could interfere with
   each other (#13299).

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,7 +21,7 @@ See docs/process.md for more on how version tagging works.
 Current Trunk
 -------------
 - Remove unused `Browser.safeSetInterval` and `Browser.safeCallback`.  These
-  didn't any callers in emscripten itself or any testing.  If there are users of
+  had no callers in emscripten itself or any testing.  If there are users of
   these functions we could re-enable them with some testing.
 - Fix race condition when running many emcc processes after clearing the cache.
   The processes would race to run the sanity checks and could interfere with

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -479,13 +479,6 @@ var LibraryBrowser = {
       RAF(func);
     },
 
-    // generic abort-aware wrapper for an async callback
-    safeCallback: function(func) {
-      return function() {
-        if (!ABORT) return func.apply(null, arguments);
-      };
-    },
-
     // abort and pause-aware versions TODO: build main loop on top of this?
 
     safeRequestAnimationFrame: function(func) {
@@ -497,13 +490,6 @@ var LibraryBrowser = {
     safeSetTimeout: function(func, timeout) {
       noExitRuntime = true;
       return setTimeout(function() {
-        if (ABORT) return;
-        func();
-      }, timeout);
-    },
-    safeSetInterval: function(func, timeout) {
-      noExitRuntime = true;
-      return setInterval(function() {
         if (ABORT) return;
         func();
       }, timeout);


### PR DESCRIPTION
These were not used or tested anywhere in emscripten.  Its possible
that external developers could be accessing them so I mentioned the
removal in the changelog.