### PR TITLE
Always define noExitRuntime

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -432,7 +432,9 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
 }
 
 function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
-  if (typeof noExitRuntime !== 'undefined') noExitRuntime = true; // If we are the main Emscripten runtime, we should not be closing down.
+  // Avoid shutting down the runtime since we want to wait for the async
+  // response.
+  noExitRuntime = true;
 
   var fetch_attr = fetch + {{{ C_STRUCTS.emscripten_fetch_t.__attributes }}};
   var requestMethod = UTF8ToString(fetch_attr);

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1143,7 +1143,8 @@ function expectToReceiveOnModule(name) {
 function makeRemovedModuleAPIAssert(moduleName, localName) {
   if (!ASSERTIONS) return '';
   if (!localName) localName = moduleName;
-  return `if (!Object.getOwnPropertyDescriptor(Module, '${moduleName}')) {
+  return `
+if (!Object.getOwnPropertyDescriptor(Module, '${moduleName}')) {
   Object.defineProperty(Module, '${moduleName}', {
     configurable: true,
     get: function() {
@@ -1162,7 +1163,7 @@ function makeModuleReceive(localName, moduleName) {
   if (expectToReceiveOnModule(moduleName)) {
     // Usually the local we use is the same as the Module property name,
     // but sometimes they must differ.
-    ret = "if (Module['" + moduleName + "']) " + localName + " = Module['" + moduleName + "'];";
+    ret = `\nif (Module['${moduleName}']) ${localName} = Module['${moduleName}'];`;
   }
   ret += makeRemovedModuleAPIAssert(moduleName, localName);
   return ret;

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -509,25 +509,18 @@ if (Module['noInitialRun']) shouldRunNow = false;
 
 #endif // HAS_MAIN
 
-#if EXIT_RUNTIME == 0
 #if USE_PTHREADS
-// EXIT_RUNTIME=0 only applies to the default behavior of the main browser
-// thread.
-// The default behaviour for pthreads is always to exit once they return
-// from their entry point (or call pthread_exit).  If we set noExitRuntime
-// to true here on pthreads they would never complete and attempt to
-// pthread_join to them would block forever.
-// pthreads can still choose to set `noExitRuntime` explicitly, or
-// call emscripten_unwind_to_js_event_loop to extend their lifetime beyond
-// their main function.  See comment in src/worker.js for more.
-noExitRuntime = !ENVIRONMENT_IS_PTHREAD;
-#else
-noExitRuntime = true;
-#endif
-#endif
-
-#if USE_PTHREADS
-if (ENVIRONMENT_IS_PTHREAD) PThread.initWorker();
+if (ENVIRONMENT_IS_PTHREAD) {
+  // The default behaviour for pthreads is always to exit once they return
+  // from their entry point (or call pthread_exit).  If we set noExitRuntime
+  // to true here on pthreads they would never complete and attempt to
+  // pthread_join to them would block forever.
+  // pthreads can still choose to set `noExitRuntime` explicitly, or
+  // call emscripten_unwind_to_js_event_loop to extend their lifetime beyond
+  // their main function.  See comment in src/worker.js for more.
+  noExitRuntime = false;
+  PThread.initWorker();
+}
 #endif
 
 run();

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -20,7 +20,7 @@ out = err = function(){};
 #endif
 
 {{{ makeModuleReceiveWithVar('wasmBinary') }}}
-{{{ makeModuleReceiveWithVar('noExitRuntime') }}}
+{{{ makeModuleReceiveWithVar('noExitRuntime', undefined, EXIT_RUNTIME ? 'false' : 'true') }}}
 
 #if WASM != 2 && MAYBE_WASM2JS
 #if !WASM2JS


### PR DESCRIPTION
Previously when EXIT_RUNTIME was set we were leaving it as undefined.
This change explicitly initializes it.

The old behavior had caused some odd behavior previously in `Fetch.js`
where `noExitRuntime` was not set at the start of a fetch request (as
would be expected).

Also, minor formatting cleanup of module receiving code which I noticed
was pretty hard to read in the final output file.