### PR TITLE
Add new API for keeping runtime alive

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1479,7 +1479,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if not shared.Settings.MINIMAL_RUNTIME:
       # In non-MINIMAL_RUNTIME, the core runtime depends on these functions to be present. (In MINIMAL_RUNTIME, they are
       # no longer always bundled in)
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$demangle', '$demangleAll', '$jsStackTrace', '$stackTrace']
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+        '$keepRuntimeAlive',
+        '$demangle',
+        '$demangleAll',
+        '$jsStackTrace',
+        '$stackTrace'
+      ]
 
     if shared.Settings.FILESYSTEM:
       # to flush streams on FS exit, we need to be able to call fflush
@@ -1599,7 +1605,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       include_and_export('invokeEntryPoint')
       if not shared.Settings.MINIMAL_RUNTIME:
         # noExitRuntime does not apply to MINIMAL_RUNTIME.
-        include_and_export('getNoExitRuntime')
+        include_and_export('keepRuntimeAlive')
 
       if shared.Settings.MODULARIZE:
         if shared.Settings.EXPORT_NAME == 'Module':

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -432,7 +432,9 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
 }
 
 function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
-  if (typeof noExitRuntime !== 'undefined') noExitRuntime = true; // If we are the main Emscripten runtime, we should not be closing down.
+  // Avoid shutting down the runtime since we want to wait for the async
+  // response.
+  _emscripten_runtime_keepalive_push();
 
   var fetch_attr = fetch + {{{ C_STRUCTS.emscripten_fetch_t.__attributes }}};
   var requestMethod = UTF8ToString(fetch_attr);
@@ -454,29 +456,39 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
 #if FETCH_DEBUG
     console.log('fetch: operation success. e: ' + e);
 #endif
-    if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
-    else if (successcb) successcb(fetch);
+    _emscripten_runtime_keepalive_pop();
+    callUserCallback(function() {
+      if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
+      else if (successcb) successcb(fetch);
+    });
   };
 
   var reportProgress = function(fetch, xhr, e) {
-    if (onprogress) {{{ makeDynCall('vi', 'onprogress') }}}(fetch);
-    else if (progresscb) progresscb(fetch);
+    callUserCallback(function() {
+      if (onprogress) {{{ makeDynCall('vi', 'onprogress') }}}(fetch);
+      else if (progresscb) progresscb(fetch);
+    });
   };
 
   var reportError = function(fetch, xhr, e) {
 #if FETCH_DEBUG
     console.error('fetch: operation failed: ' + e);
 #endif
-    if (onerror) {{{ makeDynCall('vi', 'onerror') }}}(fetch);
-    else if (errorcb) errorcb(fetch);
+    _emscripten_runtime_keepalive_pop();
+    callUserCallback(function() {
+      if (onerror) {{{ makeDynCall('vi', 'onerror') }}}(fetch);
+      else if (errorcb) errorcb(fetch);
+    });
   };
 
   var reportReadyStateChange = function(fetch, xhr, e) {
 #if FETCH_DEBUG
     console.log('fetch: ready state change. e: ' + e);
 #endif
-    if (onreadystatechange) {{{ makeDynCall('vi', 'onreadystatechange') }}}(fetch);
-    else if (readystatechangecb) readystatechangecb(fetch);
+    callUserCallback(function() {
+      if (onreadystatechange) {{{ makeDynCall('vi', 'onreadystatechange') }}}(fetch);
+      else if (readystatechangecb) readystatechangecb(fetch);
+    });
   };
 
   var performUncachedXhr = function(fetch, xhr, e) {
@@ -495,15 +507,21 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
 #if FETCH_DEBUG
       console.log('fetch: IndexedDB store succeeded.');
 #endif
-      if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
-      else if (successcb) successcb(fetch);
+      _emscripten_runtime_keepalive_pop();
+      callUserCallback(function() {
+        if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
+        else if (successcb) successcb(fetch);
+      });
     };
     var storeError = function(fetch, xhr, e) {
 #if FETCH_DEBUG
       console.error('fetch: IndexedDB store failed.');
 #endif
-      if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
-      else if (successcb) successcb(fetch);
+      _emscripten_runtime_keepalive_pop();
+      callUserCallback(function() {
+        if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
+        else if (successcb) successcb(fetch);
+      });
     };
     fetchCacheData(Fetch.dbInstance, fetch, xhr.response, storeSuccess, storeError);
   };

--- a/src/library_bootstrap.js
+++ b/src/library_bootstrap.js
@@ -13,5 +13,6 @@ assert(false, "library_bootstrap.js only designed for use with BOOTSTRAPPING_STR
 
 assert(!LibraryManager.library);
 LibraryManager.library = {
-  $callRuntimeCallbacks: function() {}
+  $callRuntimeCallbacks: function() {},
+  $keepRuntimeAlive: function() { return false }
 };

--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -25,11 +25,19 @@ var LibraryFetch = {
   $fetchXHR: fetchXHR,
 
   emscripten_start_fetch: startFetch,
-  emscripten_start_fetch__deps: ['$Fetch', '$fetchXHR',
+  emscripten_start_fetch__deps: [
+    '$Fetch',
+    '$fetchXHR',
+    '$callUserCallback',
+    'emscripten_is_main_browser_thread',
+    'emscripten_runtime_keepalive_push',
+    'emscripten_runtime_keepalive_pop',
 #if FETCH_SUPPORT_INDEXEDDB
-  '$fetchCacheData', '$fetchLoadCachedData', '$fetchDeleteCachedData',
+    '$fetchCacheData',
+    '$fetchLoadCachedData',
+    '$fetchDeleteCachedData',
 #endif
-  'emscripten_is_main_browser_thread']
+  ]
 };
 
 mergeInto(LibraryManager.library, LibraryFetch);

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1178,7 +1178,7 @@ var LibraryPThread = {
   __call_main: function(argc, argv) {
     var returnCode = {{{ exportedAsmFunc('_main') }}}(argc, argv);
 #if EXIT_RUNTIME
-    if (!noExitRuntime) {
+    if (!keepRuntimeAlive()) {
       // exitRuntime enabled, proxied main() finished in a pthread, shut down the process.
 #if ASSERTIONS
       out('Proxied main thread 0x' + _pthread_self().toString(16) + ' finished with return code ' + returnCode + '. EXIT_RUNTIME=1 set, quitting process.');
@@ -1332,11 +1332,6 @@ var LibraryPThread = {
     // current position of the stack.
     writeStackCookie();
 #endif
-  },
-
-  // allow pthreads to check if noExitRuntime from worker.js
-  $getNoExitRuntime: function() {
-    return noExitRuntime;
   },
 
   $invokeEntryPoint: function(ptr, arg) {

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -732,8 +732,14 @@ mergeInto(LibraryManager.library, {
    * Passing a NULL callback function to a emscripten_set_socket_*_callback call
    * will deregister the callback registered for that Event.
    */
+  $_setNetworkCallback__deps: [
+    'emscripten_runtime_keepalive_push',
+    'emscripten_runtime_keepalive_pop'
+  ],
   $_setNetworkCallback: function(event, userData, callback) {
     function _callback(data) {
+      _emscripten_runtime_keepalive_pop();
+      if (!callback) return;
       try {
         if (event === 'error') {
           var sp = stackSave();
@@ -753,8 +759,8 @@ mergeInto(LibraryManager.library, {
       }
     };
 
-    noExitRuntime = true;
-    Module['websocket']['on'](event, callback ? _callback : null);
+    _emscripten_runtime_keepalive_push();
+    Module['websocket']['on'](event, _callback);
   },
   emscripten_set_socket_error_callback__deps: ['$_setNetworkCallback'],
   emscripten_set_socket_error_callback: function(userData, callback) {

--- a/src/worker.js
+++ b/src/worker.js
@@ -217,7 +217,7 @@ this.onmessage = function(e) {
         // The thread might have finished without calling pthread_exit(). If so,
         // then perform the exit operation ourselves.
         // (This is a no-op if explicit pthread_exit() had been called prior.)
-        if (!Module['getNoExitRuntime']())
+        if (!Module['keepRuntimeAlive']())
 #endif
           Module['PThread'].threadExit(result);
       } catch(ex) {
@@ -237,7 +237,7 @@ this.onmessage = function(e) {
           // ExitStatus not present in MINIMAL_RUNTIME
 #if !MINIMAL_RUNTIME
           if (ex instanceof Module['ExitStatus']) {
-            if (Module['getNoExitRuntime']()) {
+            if (Module['keepRuntimeAlive']()) {
 #if ASSERTIONS
               err('Pthread 0x' + Module['_pthread_self']().toString(16) + ' called exit(), staying alive due to noExitRuntime.');
 #endif

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -90,6 +90,8 @@ void emscripten_set_main_loop_expected_blockers(int num);
 
 void emscripten_async_call(em_arg_callback_func func, void *arg, int millis);
 
+void emscripten_runtime_keepalive_push(void);
+void emscripten_runtime_keepalive_pop(void);
 void emscripten_exit_with_live_runtime(void);
 void emscripten_force_exit(int status);
 

--- a/tests/emscripten_main_loop.cpp
+++ b/tests/emscripten_main_loop.cpp
@@ -13,10 +13,8 @@ int frame = 0;
 
 void final(void*) {
   assert(frame == 110);
-#ifdef REPORT_RESULT
   printf("Test passed.\n");
-  REPORT_RESULT(0);
-#endif
+  exit(frame);
 }
 
 void looper() {
@@ -29,11 +27,8 @@ void looper() {
     timesTooSoon++;
     if (timesTooSoon >= 10) {
       printf("Abort: main loop tick was called too quickly after the previous frame, too many times!\n");
-#ifdef REPORT_RESULT
-      REPORT_RESULT(1);
-#endif
       emscripten_cancel_main_loop();
-      exit(0);
+      exit(1);
     }
   }
   prevTime = curTime;
@@ -42,11 +37,8 @@ void looper() {
     timesTooSoon++;
     if (timesTooSoon >= 2) {
       printf("Abort: With swap interval of 4, we should be running at most 15fps! (or 30fps on 120Hz displays) but seems like swap control is not working and we are running at 60fps!\n");
-#ifdef REPORT_RESULT
-      REPORT_RESULT(2);
-#endif
       emscripten_cancel_main_loop();
-      exit(0);
+      exit(2);
     }
   }
   if (frame > 0 && frame < 90 && frame % 10 == 0) {

--- a/tests/emscripten_main_loop_and_blocker.cpp
+++ b/tests/emscripten_main_loop_and_blocker.cpp
@@ -16,6 +16,8 @@ void final(void*) {
   assert(frame == 20);
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
+#else
+  exit(0);
 #endif
 }
 
@@ -23,6 +25,8 @@ void looper() {
   if (blockerExecuted == false) {
 #ifdef REPORT_RESULT
     REPORT_RESULT(1);
+#else
+    exit(1);
 #endif
   }
 

--- a/tests/fetch/to_memory.cpp
+++ b/tests/fetch/to_memory.cpp
@@ -15,8 +15,7 @@ int result = 0;
 // then testing an XHR of a missing file.
 // #define FILE_DOES_NOT_EXIST
 
-int main()
-{
+int main() {
   emscripten_fetch_attr_t attr;
   emscripten_fetch_attr_init(&attr);
   strcpy(attr.requestMethod, "GET");
@@ -28,7 +27,7 @@ int main()
     assert(false && "onsuccess handler called, but the file shouldn't exist"); // Shouldn't reach here if the file doesn't exist
 #endif
     assert(fetch);
-    printf("Finished downloading %llu bytes\n", fetch->numBytes);
+    printf("onsuccess: Finished downloading %llu bytes\n", fetch->numBytes);
     assert(fetch->url);
     assert(!strcmp(fetch->url, "gears.png"));
     assert(fetch->id != 0);
@@ -40,16 +39,15 @@ int main()
     uint8_t checksum = 0;
     for(int i = 0; i < fetch->numBytes; ++i)
       checksum ^= fetch->data[i];
-    printf("Data checksum: %02X\n", checksum);
+    printf("onsuccess: Data checksum: %02X\n", checksum);
     assert(checksum == 0x08);
     emscripten_fetch_close(fetch);
 
 #ifdef REPORT_RESULT
-#ifndef FILE_DOES_NOT_EXIST
-    result = 1;
-#endif
     // Fetch API appears to sometimes call the handlers more than once, see https://github.com/emscripten-core/emscripten/pull/8191
     MAYBE_REPORT_RESULT(result);
+#else
+    exit(result);
 #endif
   };
 
@@ -58,15 +56,15 @@ int main()
     if (fetch->status != 200) return;
     printf("onprogress: dataOffset: %llu, numBytes: %llu, totalBytes: %llu\n", fetch->dataOffset, fetch->numBytes, fetch->totalBytes);
     if (fetch->totalBytes > 0) {
-      printf("Downloading.. %.2f%% complete.\n", (fetch->dataOffset + fetch->numBytes) * 100.0 / fetch->totalBytes);
+      printf("onprogress:  .. %.2f%% complete.\n", (fetch->dataOffset + fetch->numBytes) * 100.0 / fetch->totalBytes);
     } else {
-      printf("Downloading.. %lld bytes complete.\n", fetch->dataOffset + fetch->numBytes);
+      printf("onprogress:  .. %lld bytes complete.\n", fetch->dataOffset + fetch->numBytes);
     }
 #ifdef FILE_DOES_NOT_EXIST
     assert(false && "onprogress handler called, but the file should not exist"); // We should not receive progress reports if the file doesn't exist.
 #endif
     // We must receive a call to the onprogress handler with 100% completion.
-    if (fetch->dataOffset + fetch->numBytes == fetch->totalBytes) ++result;
+    if (fetch->dataOffset + fetch->numBytes == fetch->totalBytes) result = 1;
     assert(fetch->dataOffset + fetch->numBytes <= fetch->totalBytes);
     assert(fetch->url);
     assert(!strcmp(fetch->url, "gears.png"));
@@ -75,7 +73,7 @@ int main()
   };
 
   attr.onerror = [](emscripten_fetch_t *fetch) {
-    printf("Download failed!\n");
+    printf("onerror: Download failed!\n");
 #ifndef FILE_DOES_NOT_EXIST
     assert(false && "onerror handler called, but the transfer should have succeeded!"); // The file exists, shouldn't reach here.
 #endif
@@ -85,15 +83,17 @@ int main()
     assert((uintptr_t)fetch->userData == 0x12345678);
 
 #ifdef REPORT_RESULT
-#ifdef FILE_DOES_NOT_EXIST
-    result = 1;
-#endif
-    // Fetch API appears to sometimes call the handlers more than once, see https://github.com/emscripten-core/emscripten/pull/8191
-    MAYBE_REPORT_RESULT(result);
+    // Fetch API appears to sometimes call the handlers more than once, see
+    // https://github.com/emscripten-core/emscripten/pull/8191
+    MAYBE_REPORT_RESULT(404);
+#else
+    exit(404);
 #endif
   };
 
   emscripten_fetch_t *fetch = emscripten_fetch(&attr, "gears.png");
   assert(fetch != 0);
-  memset(&attr, 0, sizeof(attr)); // emscripten_fetch() must be able to operate without referencing to this structure after the call.
+  // emscripten_fetch() must be able to operate without referencing to this structure after the call.
+  memset(&attr, 0, sizeof(attr));
+  return 0;
 }

--- a/tests/webgl_create_context.cpp
+++ b/tests/webgl_create_context.cpp
@@ -27,29 +27,26 @@ std::vector<std::string> &split(const std::string &s, char delim, std::vector<st
     }
     return elems;
 }
+
 std::vector<std::string> split(const std::string &s, char delim) {
     std::vector<std::string> elems;
     split(s, delim, elems);
     return elems;
 }
 
-GLint GetInt(GLenum param)
-{
+GLint GetInt(GLenum param) {
   GLint value;
   glGetIntegerv(param, &value);
   return value;
 }
 
 void final(void*) {
-#ifdef REPORT_RESULT
-  REPORT_RESULT(0);
-#endif
+  exit(0);
 }
 
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context;
 
-void loop()
-{
+void loop() {
   EMSCRIPTEN_RESULT res;
   if (!context) {
     // new rendering frame started without a context
@@ -77,21 +74,19 @@ void loop()
   }
 }
 
-int main()
-{
-  bool first = true;
+int main() {
   EmscriptenWebGLContextAttributes attrs;
   int depth = 0;
   int stencil = 0;
   int antialias = 0;
 #ifndef NO_DEPTH
-  for(depth = 0; depth <= 1; ++depth)
+  for (depth = 0; depth <= 1; ++depth)
 #endif
 #ifndef NO_STENCIL
-  for(stencil = 0; stencil <= 1; ++stencil)
+  for (stencil = 0; stencil <= 1; ++stencil)
 #endif
 #ifndef NO_ANTIALIAS
-  for(antialias = 0; antialias <= 1; ++antialias)
+  for (antialias = 0; antialias <= 1; ++antialias)
 #endif
   {
     emscripten_webgl_init_context_attributes(&attrs);
@@ -105,7 +100,7 @@ int main()
       Module['canvas'].parentElement.appendChild(canvas2);
       canvas2.id = 'customCanvas';
     );
-    
+
     assert(emscripten_webgl_get_current_context() == 0);
     EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context = emscripten_webgl_create_context("#customCanvas", &attrs);
     assert(context > 0); // Must have received a valid context.
@@ -146,9 +141,8 @@ int main()
     printf("RGBA: %d%d%d%d, Depth: %d, Stencil: %d, Samples: %d\n",
       GetInt(GL_RED_BITS), GetInt(GL_GREEN_BITS), GetInt(GL_BLUE_BITS), GetInt(GL_ALPHA_BITS),
       numDepthBits, numStencilBits, numSamples);
-    
-    if (!depth && stencil && numDepthBits && numStencilBits && EM_ASM_INT(navigator.userAgent.toLowerCase().indexOf('firefox')) > -1)
-    {
+
+    if (!depth && stencil && numDepthBits && numStencilBits && EM_ASM_INT(navigator.userAgent.toLowerCase().indexOf('firefox')) > -1) {
       numDepthBits = 0;
       printf("Applying workaround to ignore Firefox bug https://bugzilla.mozilla.org/show_bug.cgi?id=982477\n");
     }
@@ -193,11 +187,8 @@ int main()
       canvas2.parentElement.removeChild(canvas2);
     );
   }
-  
+
   // result will be reported when mainLoop completes
   emscripten_set_main_loop(loop, 0, 0);
-
-#ifndef REPORT_RESULT
   return 0;
-#endif
 }


### PR DESCRIPTION
This change adds two new JS library functions which can
be used to control the emscripten runtime state in a more
precise way than the (now legacy) `noExitRuntime` variable:

- `emscripten_runtime_keepalive_pop()`
- `emscripten_runtime_keepalive_push()`

The `noExitRuntime` variable still exists and will be honored
but we no longer use it internally.

Calls to user code are now all wrapped in a new `callUserCallback`
library function.   This function handles 'unwind' exceptions as well
has exiting correctly once the keepalive counter hits zero.

Part of addressing #13193