### PR TITLE
Avoid setting noExitRuntime when using fibres/asyncify

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -190,16 +190,8 @@ function callMain(args) {
     assert(ret == 0, '_emscripten_proxy_main failed to start proxy thread: ' + ret);
 #endif
 #else
-#if ASYNCIFY
-    // if we are saving the stack, then do not call exit, we are not
-    // really exiting now, just unwinding the JS stack
-    if (!keepRuntimeAlive()) {
-#endif // ASYNCIFY
-      // if we're not running an evented main loop, it's time to exit
-      exit(ret, /* implicit = */ true);
-#if ASYNCIFY
-    }
-#endif // ASYNCIFY
+    // if we're not running an evented main loop, it's time to exit
+    exit(ret, /* implicit = */ true);
   }
   catch(e) {
     if (e instanceof ExitStatus) {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2714,11 +2714,11 @@ Module["preRun"].push(function () {
 
   def test_wget(self):
     create_file('test.txt', 'emscripten')
-    self.btest(test_file('test_wget.c'), expected='1', args=['-s', 'ASYNCIFY'])
+    self.btest_exit(test_file('test_wget.c'), args=['-s', 'ASYNCIFY'])
 
   def test_wget_data(self):
     create_file('test.txt', 'emscripten')
-    self.btest(test_file('test_wget_data.c'), expected='1', args=['-O2', '-g2', '-s', 'ASYNCIFY'])
+    self.btest_exit(test_file('test_wget_data.c'), args=['-O2', '-g2', '-s', 'ASYNCIFY'])
 
   @parameterized({
     '': ([],),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7383,6 +7383,7 @@ Module['onRuntimeInitialized'] = function() {
     self.do_run(src, 'HelloWorld')
 
     print('check ccall promise')
+    self.clear_setting('EXIT_RUNTIME')
     self.set_setting('EXPORTED_FUNCTIONS', ['_stringf', '_floatf'])
     src = r'''
 #include <stdio.h>

--- a/tests/test_wget.c
+++ b/tests/test_wget.c
@@ -5,28 +5,36 @@
  * found in the LICENSE file.
  */
 
+#include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
 #include <emscripten.h>
 
-int main()
-{
-    const char * file = "/test.txt";
-    emscripten_wget(file , file);
-    FILE * f = fopen(file, "r");
-    int result = 0;
-    if(f) {
 #define BUFSIZE 1024
-        char buf[BUFSIZE];
-        fgets(buf, BUFSIZE, f);
-        buf[BUFSIZE-1] = 0;
-        for(int i = 0; i < BUFSIZE; ++i)
-            buf[i] = tolower(buf[i]);
-        if(strstr(buf, "emscripten")) 
-            result = 1;
-        fclose(f);
-    }
-    REPORT_RESULT(result);
-    return 0;
+
+int main() {
+  const char * file = "/test.txt";
+  printf("calling wget\n");
+  emscripten_wget(file , file);
+  printf("back from wget\n");
+
+  FILE * f = fopen(file, "r");
+  assert(f);
+
+  char buf[BUFSIZE];
+  fgets(buf, BUFSIZE, f);
+  buf[BUFSIZE-1] = 0;
+  for(int i = 0; i < BUFSIZE; ++i) {
+    buf[i] = tolower(buf[i]);
+  }
+  assert(strstr(buf, "emscripten"));
+  fclose(f);
+
+  printf("exiting main\n");
+  // Implicit return from main with ASYNCIFY + EXIT_RUNTIME
+  // currently doesn't work so we need to explictly exit.
+  // https://github.com/emscripten-core/emscripten/issues/14417
+  exit(0);
 }

--- a/tests/test_wget_data.c
+++ b/tests/test_wget_data.c
@@ -6,29 +6,31 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <ctype.h>
 #include <string.h>
 #include <assert.h>
 
 #include <emscripten.h>
 
-int main()
-{
-    const char * file = "/test.txt";
-    void* buffer;
-    int num, error;
+int main() {
+  const char * file = "/test.txt";
+  void* buffer;
+  int num, error;
 
-    printf("load %s\n", file);
-    emscripten_wget_data(file, &buffer, &num, &error);
-    assert(!error);
-    printf("buffer: %s\n", (char*)buffer);
-    assert(strstr(buffer, "emscripten") == buffer); 
+  printf("load %s\n", file);
+  emscripten_wget_data(file, &buffer, &num, &error);
+  assert(!error);
+  printf("buffer: %s\n", (char*)buffer);
+  assert(strstr(buffer, "emscripten") == buffer); 
 
-    printf("load non-existing\n");
-    emscripten_wget_data("doesnotexist", &buffer, &num, &error);
-    assert(error);
+  printf("load non-existing\n");
+  emscripten_wget_data("doesnotexist", &buffer, &num, &error);
+  assert(error);
 
-    printf("ok!\n");
-    REPORT_RESULT(1);
-    return 0;
+  printf("ok!\n");
+  // Implicit return from main with ASYNCIFY + EXIT_RUNTIME
+  // currently doesn't work so we need to explictly exit.
+  // https://github.com/emscripten-core/emscripten/issues/14417
+  exit(0);
 }


### PR DESCRIPTION
`noExitRuntime` was getting set here and never getting unset meaning
that code that uses asyncify/fibres was never able to exit correctly.

Instead, we can use the new keepalive system to track when we there
is an outstanding unwound fibre/stack that could potentially be
rewound.  As long as there is potential to rewind a stack we don't
exit the runtime.

This system doesn't take into account multiple re-winding of the
same state/stack but AFAICT we don't even to that (yet).