### PR TITLE
Remove unsupported -s WORKAROUND_IOS_9_RIGHT_SHIFT_BUG=1 option.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1381,8 +1381,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.MIN_EDGE_VERSION = 0
       shared.Settings.MIN_CHROME_VERSION = 0
 
-    if shared.Settings.MIN_SAFARI_VERSION <= 9 and shared.Settings.WASM2JS:
-      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 1
+    if shared.Settings.MIN_SAFARI_VERSION <= 90305:
+      exit_with_error('MIN_SAFARI_VERSION <= 90305: Emscripten does not support iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 (devices with end-of-life at iOS 9.3.5) and older. (browser has no Wasm support, and Wasm2JS support would not run). Please pass -s MIN_SAFARI_VERSION=100000 or higher.')
 
     if shared.Settings.MIN_CHROME_VERSION <= 37:
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
@@ -1392,7 +1392,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
     if not shared.Settings.WASM2JS:
       shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
-      shared.Settings.WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
 
     if shared.Settings.STB_IMAGE and final_suffix in EXECUTABLE_ENDINGS:

--- a/emcc.py
+++ b/emcc.py
@@ -1381,9 +1381,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.MIN_EDGE_VERSION = 0
       shared.Settings.MIN_CHROME_VERSION = 0
 
-    if shared.Settings.MIN_SAFARI_VERSION <= 90305:
-      diagnostics.warning('MIN_SAFARI_VERSION <= 90305: Emscripten does not support iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 (devices with end-of-life at iOS 9.3.5) and older due to a bug in Safari JS execution. (browser has no Wasm support, and Wasm2JS support would not run, see https://github.com/emscripten-core/emscripten-fastcomp/pull/231). Please pass -s MIN_SAFARI_VERSION=100000 or higher.')
-
     if shared.Settings.MIN_CHROME_VERSION <= 37:
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
 

--- a/emcc.py
+++ b/emcc.py
@@ -1376,7 +1376,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Support all old browser versions
       shared.Settings.MIN_FIREFOX_VERSION = 0
-      shared.Settings.MIN_SAFARI_VERSION = 100000
+      shared.Settings.MIN_SAFARI_VERSION = 0
       shared.Settings.MIN_IE_VERSION = 0
       shared.Settings.MIN_EDGE_VERSION = 0
       shared.Settings.MIN_CHROME_VERSION = 0

--- a/emcc.py
+++ b/emcc.py
@@ -1376,13 +1376,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
       # Support all old browser versions
       shared.Settings.MIN_FIREFOX_VERSION = 0
-      shared.Settings.MIN_SAFARI_VERSION = 0
+      shared.Settings.MIN_SAFARI_VERSION = 100000
       shared.Settings.MIN_IE_VERSION = 0
       shared.Settings.MIN_EDGE_VERSION = 0
       shared.Settings.MIN_CHROME_VERSION = 0
 
     if shared.Settings.MIN_SAFARI_VERSION <= 90305:
-      exit_with_error('MIN_SAFARI_VERSION <= 90305: Emscripten does not support iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 (devices with end-of-life at iOS 9.3.5) and older. (browser has no Wasm support, and Wasm2JS support would not run). Please pass -s MIN_SAFARI_VERSION=100000 or higher.')
+      diagnostics.warning('MIN_SAFARI_VERSION <= 90305: Emscripten does not support iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 (devices with end-of-life at iOS 9.3.5) and older due to a bug in Safari JS execution. (browser has no Wasm support, and Wasm2JS support would not run, see https://github.com/emscripten-core/emscripten-fastcomp/pull/231). Please pass -s MIN_SAFARI_VERSION=100000 or higher.')
 
     if shared.Settings.MIN_CHROME_VERSION <= 37:
       shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -27,7 +27,7 @@ var LibraryJSEvents = {
     // so that we can report information about that element in the event message.
     previousFullscreenElement: null,
 
-#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 8 || MIN_EDGE_VERSION <= 12 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
+#if MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION <= 80000 || MIN_EDGE_VERSION <= 12 || MIN_CHROME_VERSION <= 21 // https://caniuse.com/#search=movementX
     // Remember the current mouse coordinates in case we need to emulate movementXY generation for browsers that don't support it.
     // Some browsers (e.g. Safari 6.0.5) only give movementXY when Pointerlock is active.
     previousScreenX: null,
@@ -2802,7 +2802,7 @@ var LibraryJSEvents = {
 #if ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
     return (typeof devicePixelRatio === 'number' && devicePixelRatio) || 1.0;
 #else // otherwise, on the web and in workers, things are simpler
-#if MIN_IE_VERSION < 11 || MIN_FIREFOX_VERSION < 18 || MIN_CHROME_VERSION < 4 || MIN_SAFARI_VERSION < 3010 // https://caniuse.com/#feat=devicepixelratio
+#if MIN_IE_VERSION < 11 || MIN_FIREFOX_VERSION < 18 || MIN_CHROME_VERSION < 4 || MIN_SAFARI_VERSION < 30100 // https://caniuse.com/#feat=devicepixelratio
     return window.devicePixelRatio || 1.0;
 #else
     return devicePixelRatio;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1619,7 +1619,9 @@ var MIN_FIREFOX_VERSION = 65;
 // Mojave.
 // NOTE: Emscripten is unable to produce code that would work in iOS 9.3.5 and
 // older, i.e. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 and older,
-// see https://github.com/emscripten-core/emscripten/pull/7191.
+// see https://github.com/emscripten-core/emscripten/pull/7191. Setting this to
+// a value smaller than 90305 (9.3.5) will be interpreted as targeting 100000
+// (10.0.0).
 // [link]
 var MIN_SAFARI_VERSION = 120000;
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1619,9 +1619,7 @@ var MIN_FIREFOX_VERSION = 65;
 // Mojave.
 // NOTE: Emscripten is unable to produce code that would work in iOS 9.3.5 and
 // older, i.e. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 and older,
-// see https://github.com/emscripten-core/emscripten/pull/7191. Setting this to
-// a value smaller than 90305 (9.3.5) will be interpreted as targeting 100000
-// (10.0.0).
+// see https://github.com/emscripten-core/emscripten/pull/7191.
 // [link]
 var MIN_SAFARI_VERSION = 120000;
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -556,17 +556,6 @@ var USE_WEBGPU = 0;
 // [link]
 var STB_IMAGE = 0;
 
-// If WORKAROUND_IOS_9_RIGHT_SHIFT_BUG==1, work around Safari/WebKit bug in iOS 9.3.5: https://bugs.webkit.org/show_bug.cgi?id=151514 where computing "a >> b" or "a >>> b" in
-// JavaScript would erroneously output 0 when a!=0 and b==0, after suitable JIT compiler optimizations have been applied to a function at runtime (bug does not
-// occur in debug builds). Fix was landed in https://trac.webkit.org/changeset/196591/webkit on Feb 15th 2016. iOS 9.3.5 was released on August 25 2016, but
-// oddly did not have the fix. iOS Safari 10.3.3 was released on July 19 2017, that no longer has the issue. Unknown which released version between these was the
-// first to contain the fix, though notable is that iOS 9.3.5 and iOS 10.3.3 are the two consecutive "end-of-life" versions of iOS that users are likely
-// to be on, e.g. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 all had end-of-life at iOS 9.3.5 (tested to be affected),
-// and iPad 4, iPhone 5 and iPhone 5c all had end-of-life at iOS 10.3.3 (confirmed not affected).
-// If you do not care about old iOS 9 support, keep this disabled.
-// [link]
-var WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0;
-
 // From Safari 8 (where WebGL was introduced to Safari) onwards, OES_texture_half_float and OES_texture_half_float_linear extensions
 // are broken and do not function correctly, when used as source textures.
 // See https://bugs.webkit.org/show_bug.cgi?id=183321, https://bugs.webkit.org/show_bug.cgi?id=169999,
@@ -589,7 +578,6 @@ var POLYFILL_OLD_MATH_FUNCTIONS = 0;
 // the highest possible probability of the code working everywhere, even in rare old
 // browsers and shell environments. Specifically:
 //  * Add polyfilling for Math.clz32, Math.trunc, Math.imul, Math.fround. (-s POLYFILL_OLD_MATH_FUNCTIONS=1)
-//  * Work around iOS 9 right shift bug (-s WORKAROUND_IOS_9_RIGHT_SHIFT_BUG=1)
 //  * Work around old Chromium WebGL 1 bug (-s WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG=1)
 //  * Disable WebAssembly. (Must be paired with -s WASM=0)
 //  * Adjusts MIN_X_VERSION settings to 0 to include support for all browser versions.
@@ -1628,7 +1616,10 @@ var MIN_FIREFOX_VERSION = 65;
 // Specifies the oldest version of desktop Safari to target. Version is encoded
 // in MMmmVV, e.g. 70101 denotes Safari 7.1.1.
 // Safari 12.0.0 was released on September 17, 2018, bundled with macOS 10.14.0
-// Mojave
+// Mojave.
+// NOTE: Emscripten is unable to produce code that would work in iOS 9.3.5 and
+// older, i.e. iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 and older,
+// see https://github.com/emscripten-core/emscripten/pull/7191.
 // [link]
 var MIN_SAFARI_VERSION = 120000;
 
@@ -1977,4 +1968,5 @@ var LEGACY_SETTINGS = [
   ['BINARYEN_SCRIPTS', [""], 'No longer needed'],
   ['WARN_UNALIGNED', [0, 1], 'No longer needed'],
   ['ASM_PRIMITIVE_VARS', [[]], 'No longer needed'],
+  ['WORKAROUND_IOS_9_RIGHT_SHIFT_BUG', [0], 'Wasm2JS does not support iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 (devices with end-of-life at iOS 9.3.5) and older']
 ];

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2513,7 +2513,7 @@ Module["preRun"].push(function () {
     '': ([],),
     'closure': (['-O2', '-g1', '--closure', '1', '-s', 'HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS=0'],),
     'pthread': (['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'],),
-    'legacy': (['-s', 'MIN_FIREFOX_VERSION=0', '-s', 'MIN_SAFARI_VERSION=0', '-s', 'MIN_IE_VERSION=0', '-s', 'MIN_EDGE_VERSION=0', '-s', 'MIN_CHROME_VERSION=0'],)
+    'legacy': (['-s', 'MIN_FIREFOX_VERSION=0', '-s', 'MIN_SAFARI_VERSION=90306', '-s', 'MIN_IE_VERSION=0', '-s', 'MIN_EDGE_VERSION=0', '-s', 'MIN_CHROME_VERSION=0'],)
   })
   @requires_threads
   def test_html5_core(self, opts):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2513,7 +2513,7 @@ Module["preRun"].push(function () {
     '': ([],),
     'closure': (['-O2', '-g1', '--closure', '1', '-s', 'HTML5_SUPPORT_DEFERRING_USER_SENSITIVE_REQUESTS=0'],),
     'pthread': (['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'],),
-    'legacy': (['-s', 'MIN_FIREFOX_VERSION=0', '-s', 'MIN_SAFARI_VERSION=90306', '-s', 'MIN_IE_VERSION=0', '-s', 'MIN_EDGE_VERSION=0', '-s', 'MIN_CHROME_VERSION=0'],)
+    'legacy': (['-s', 'MIN_FIREFOX_VERSION=0', '-s', 'MIN_SAFARI_VERSION=0', '-s', 'MIN_IE_VERSION=0', '-s', 'MIN_EDGE_VERSION=0', '-s', 'MIN_CHROME_VERSION=0'],)
   })
   @requires_threads
   def test_html5_core(self, opts):


### PR DESCRIPTION
Remove unsupported -s WORKAROUND_IOS_9_RIGHT_SHIFT_BUG=1 option. Fix uses of MIN_SAFARI_VERSION.

Tested with
```a.c
#include <emscripten.h>

int main()
{
	int a = EM_ASM_INT(return 1);
	int b = EM_ASM_INT(return 0);
	int c = a >> b;
	EM_ASM(console.log($0), c);
}
```

that Wasm2JS does produce offending code that might fail on iPhone 4s and older:

```js
function __original_main() {
 var $0 = 0, $1 = 0, $2 = 0;
 $0 = __stack_pointer - 16 | 0;
 __stack_pointer = $0;
 HEAP8[$0 + 15 | 0] = 0;
 $1 = emscripten_asm_const_int(1024, $0 + 15 | 0, 0) | 0;
 HEAP8[$0 + 14 | 0] = 0;
 $2 = emscripten_asm_const_int(1033, $0 + 14 | 0, 0) | 0;
 HEAP8[$0 + 12 | 0] = 105;
 HEAP8[$0 + 13 | 0] = 0;
 HEAP32[$0 >> 2] = $1 >> $2; // (*)
 emscripten_asm_const_int(1042, $0 + 12 | 0, $0 | 0) | 0;
 __stack_pointer = $0 + 16 | 0;
 return 0;
}
```

See https://github.com/emscripten-core/emscripten/pull/7191 for the original issue.

Fortunately our min spec is no longer at iPhone 4s, but higher, so it is not an issue that Wasm2JS does not work for devices so old.