### PR TITLE
Add signature for emscripten_run_script_string in library.js

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2899,6 +2899,7 @@ LibraryManager.library = {
     {{{ makeEval('return eval(UTF8ToString(ptr))|0;') }}}
   },
 
+  emscripten_run_script_string__sig: 'ii',
   emscripten_run_script_string: function(ptr) {
     {{{ makeEval("var s = eval(UTF8ToString(ptr));") }}}
     if (s == null) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3776,6 +3776,7 @@ ok
       expected='hello 1: 56.779999\ngot: 1\nhello 1: 12.340000\n',
       header='typedef float (*floatfunc)(float);', force_c=True, main_module=2)
 
+  @needs_dlfcn
   def test_missing_signatures(self):
     create_test_file('test_sig.c', r'''#include <emscripten.h>
                                        int main() {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3785,7 +3785,7 @@ ok
                 return std::count(sig_check_list.begin(),sig_check_list.end(),nullptr);
               }
     '''
-    self.set_setting('MAIN_MODULE',1)
+    self.set_setting('MAIN_MODULE', 1)
     self.do_run(src, '')
 
   @needs_dlfcn

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3777,16 +3777,13 @@ ok
       header='typedef float (*floatfunc)(float);', force_c=True, main_module=2)
 
   def test_missing_signatures(self):
-    src = r'''#include <list>
-              #include <emscripten.h>
-              int main() {
-                std::list<void*> sig_check_list{ (void*)&emscripten_run_script_string,
-                                                 (void*)&emscripten_run_script};
-                return std::count(sig_check_list.begin(),sig_check_list.end(),nullptr);
-              }
-    '''
+    create_test_file('test_sig.c', r'''#include <emscripten.h>
+                                       int main() {
+                                         return 0 == ( (int)&emscripten_run_script_string +
+                                                       (int)&emscripten_run_script );
+                                       }''')
     self.set_setting('MAIN_MODULE', 1)
-    self.do_run(src, '')
+    self.do_runf('test_sig.c', '')
 
   @needs_dlfcn
   def test_dylink_global_init(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3776,6 +3776,18 @@ ok
       expected='hello 1: 56.779999\ngot: 1\nhello 1: 12.340000\n',
       header='typedef float (*floatfunc)(float);', force_c=True, main_module=2)
 
+  def test_missing_signatures(self):
+    src = r'''#include <list>
+              #include <emscripten.h>
+              int main() {
+                std::list<void*> sig_check_list{ (void*)&emscripten_run_script_string,
+                                                 (void*)&emscripten_run_script};
+                return std::count(sig_check_list.begin(),sig_check_list.end(),nullptr);
+              }
+    '''
+    self.set_setting('MAIN_MODULE',1)
+    self.do_run(src, '')
+
   @needs_dlfcn
   def test_dylink_global_init(self):
     self.dylink_test(r'''


### PR DESCRIPTION
Adds the signature for emscripten_run_script_string + add a minimal test case that triggers exception with missing signature.
Resolves #13354