### PR TITLE
Update expected llvm version to 13.0

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -156,6 +156,7 @@ class other(RunnerCore):
       os.close(master)
       os.close(slave)
 
+  @disabled('let LLVM 13 roll in')
   def test_emcc_v(self):
     for compiler in [EMCC, EMXX]:
       # -v, without input files

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -12,7 +12,7 @@ import tempfile
 import zipfile
 from subprocess import PIPE, STDOUT
 
-from runner import RunnerCore, path_from_root, env_modify
+from runner import RunnerCore, path_from_root, env_modify, disabled
 from runner import create_test_file, ensure_dir, make_executable
 from tools.config import config_file, EM_CONFIG
 from tools.shared import PYTHON, EMCC
@@ -232,6 +232,7 @@ class sanity(RunnerCore):
           self.assertContained('error:', output) # sanity check should fail
       try_delete(default_config)
 
+  @disabled('let LLVM 13 roll in')
   def test_llvm(self):
     LLVM_WARNING = 'LLVM version appears incorrect'
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -34,7 +34,7 @@ from . import config
 DEBUG = int(os.environ.get('EMCC_DEBUG', '0'))
 EXPECTED_NODE_VERSION = (4, 1, 1)
 EXPECTED_BINARYEN_VERSION = 99
-EXPECTED_LLVM_VERSION = "12.0"
+EXPECTED_LLVM_VERSION = "13.0"
 SIMD_INTEL_FEATURE_TOWER = ['-msse', '-msse2', '-msse3', '-mssse3', '-msse4.1', '-msse4.2', '-mavx']
 SIMD_NEON_FLAGS = ['-mfpu=neon']
 PYTHON = sys.executable
@@ -158,6 +158,8 @@ def get_clang_version():
 
 
 def check_llvm_version():
+  # Let LLVM 13 roll in
+  return True
   actual = get_clang_version()
   if EXPECTED_LLVM_VERSION in actual:
     return True


### PR DESCRIPTION
This change temporarily disables the version check to allow
the llvm change to roll in.

Copied from the previous time around: #11637.