### PR TITLE
[UBSan] Fix infinite recursion in type_info::operator==

### DIFF
--- a/system/lib/libcxx/include/typeinfo
+++ b/system/lib/libcxx/include/typeinfo
@@ -301,6 +301,9 @@ public:
       return __impl::__hash(__type_name);
     }
 
+    // XXX Emscripten: adding `always_inline` fixes
+    // https://github.com/emscripten-core/emscripten/issues/13330
+    __attribute__((always_inline))
     _LIBCPP_INLINE_VISIBILITY
     bool operator==(const type_info& __arg) const _NOEXCEPT
     {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7900,6 +7900,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf(path_from_root('tests', 'core', 'test_ubsan_full_null_ref.cpp'),
                  post_build=modify_env, assert_all=True, expected_output=expected_output)
 
+  @no_wasm2js('TODO: sanitizers in wasm2js')
   def test_ubsan_typeinfo_eq(self):
     # https://github.com/emscripten-core/emscripten/issues/13330
     src = r'''

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7900,6 +7900,20 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_runf(path_from_root('tests', 'core', 'test_ubsan_full_null_ref.cpp'),
                  post_build=modify_env, assert_all=True, expected_output=expected_output)
 
+  def test_ubsan_typeinfo_eq(self):
+    # https://github.com/emscripten-core/emscripten/issues/13330
+    src = r'''
+      #include <typeinfo>
+      #include <stdio.h>
+      int main() {
+        int mismatch = typeid(int) != typeid(int);
+        printf("ok\n");
+        return mismatch;
+      }
+      '''
+    self.emcc_args.append('-fsanitize=undefined')
+    self.do_run(src, 'ok\n')
+
   def test_template_class_deduction(self):
     self.emcc_args += ['-std=c++17']
     self.do_run_in_out_file_test('tests', 'core', 'test_template_class_deduction.cpp')


### PR DESCRIPTION
Under UBSan, comparing type_infos triggers a lookup in UBSan's typeinfo cache.
When this cache is not warm, this causes a cache miss, and the code path that
handles that ends up calling __dynamic_cast. __dynamic_cast itself ends up
comparing type_infos and this recursion ends up exhausting the stack.

```
RangeError: Maximum call stack size exceeded
    ...
    at std::type_info::operator==(std::type_info const&) const
    at is_equal(std::type_info const*, std::type_info const*, bool) 
    at __dynamic_cast (<anonymous>:wasm-function[40]:0x8fb)
    at __ubsan::checkDynamicType(void*, void*, unsigned long)
    at HandleDynamicTypeCacheMiss(__ubsan::DynamicTypeCacheMissData*,
        unsigned long, unsigned long, __ubsan::ReportOptions)
    at __ubsan_handle_dynamic_type_cache_miss
    at std::type_info::operator==(std::type_info const&) const
    ...
```

This is not a problem on native platforms because inlining and follow-on
optimizations remove the call to type_info::operator== under __dynamic_cast, so
UBSan never re-enters its type checking routine. In Emscripten, however, we
build libc++abi with -Oz, so these optimizations do not take place. The fix is
to add __attribute__((always_inline)) to type_info::operator==, which is enough
to get the recursion optimized out in -Oz.

Fixes #13330.
Fixes #13324.