### PR TITLE
Fix return in {{{ makeDynCall }}} macro and add test.

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -994,7 +994,7 @@ function asmFFICoercion(value, type) {
 function makeDynCall(sig, funcPtr) {
   assert(sig.indexOf('j') == -1, 'Cannot specify 64-bit signatures ("j" in signature string) with makeDynCall!');
 
-  let returnExpr = sig[0] == 'v' ? '' : 'return';
+  const returnExpr = (sig[0] == 'v') ? '' : 'return';
 
   let args = [];
   for (let i = 1; i < sig.length; ++i) {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -994,7 +994,7 @@ function asmFFICoercion(value, type) {
 function makeDynCall(sig, funcPtr) {
   assert(sig.indexOf('j') == -1, 'Cannot specify 64-bit signatures ("j" in signature string) with makeDynCall!');
 
-  var returnExpr = sig[0] == 'v' ? '' : 'return';
+  let returnExpr = sig[0] == 'v' ? '' : 'return';
 
   let args = [];
   for (let i = 1; i < sig.length; ++i) {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -992,37 +992,36 @@ function asmFFICoercion(value, type) {
 }
 
 function makeDynCall(sig, funcPtr) {
-  assert(sig.indexOf('j') == -1);
+  assert(sig.indexOf('j') == -1, 'Cannot specify 64-bit signatures ("j" in signature string) with makeDynCall!');
+
+  var returnExpr = sig[0] == 'v' ? '' : 'return';
+
+  let args = [];
+  for (let i = 1; i < sig.length; ++i) {
+    args.push(`a${i}`);
+  }
+  args = args.join(', ');
+
   if (funcPtr === undefined) {
     printErr(`warning: ${currentlyParsedFilename}: \
 Legacy use of {{{ makeDynCall("${sig}") }}}(funcPtr, arg1, arg2, ...). \
 Starting from Emscripten 2.0.2 (Aug 31st 2020), syntax for makeDynCall has changed. \
 New syntax is {{{ makeDynCall("${sig}", "funcPtr") }}}(arg1, arg2, ...). \
 Please update to new syntax.`);
-    const ret = (sig[0] == 'v') ? 'return ' : '';
-    let args = [];
-    for (let i = 1; i < sig.length; ++i) {
-      args.push(`a${i}`);
-    }
-    args = args.join(', ');
 
     if (DYNCALLS) {
-      return `(function(cb, ${args}) { return getDynCaller("${sig}", cb)(${args}) })`;
+      return `(function(cb, ${args}) { ${returnExpr} getDynCaller("${sig}", cb)(${args}) })`;
     } else {
-      return `(function(cb, ${args}) { return wasmTable.get(cb)(${args}) })`;
+      return `(function(cb, ${args}) { ${returnExpr} wasmTable.get(cb)(${args}) })`;
     }
   }
+
   if (DYNCALLS) {
     const dyncall = exportedAsmFunc(`dynCall_${sig}`);
     if (sig.length > 1) {
-      let args = [];
-      for (let i = 1; i < sig.length; ++i) {
-        args.push(`a${i}`);
-      }
-      args = args.join(', ');
-      return `(function(${args}) { ${dyncall}.apply(null, [${funcPtr}, ${args}]); })`;
+      return `(function(${args}) { ${returnExpr} ${dyncall}.apply(null, [${funcPtr}, ${args}]); })`;
     } else {
-      return `(function() { ${dyncall}.call(null, ${funcPtr}); })`;
+      return `(function() { ${returnExpr} ${dyncall}.call(null, ${funcPtr}); })`;
     }
   } else {
     return `wasmTable.get(${funcPtr})`;

--- a/tests/core/test_dyncalls.js
+++ b/tests/core/test_dyncalls.js
@@ -19,5 +19,9 @@ mergeInto(LibraryManager.library, {
     //    (this form should never be used, it is suboptimal for performance, but provided for legacy compatibility)
     var ret = dynCall('iii', funcPtr, [2, 3]); // Available only in WASM_BIGINT != 2 builds
     console.log('iii returned ' + ret);
+
+    // 3. Access a dynCall using the makeDynCall macro:
+    var ret = {{{ makeDynCall('iii', 'funcPtr') }}}(2, 3);
+    console.log('iii returned ' + ret);
   }
 });

--- a/tests/core/test_dyncalls.out
+++ b/tests/core/test_dyncalls.out
@@ -4,3 +4,5 @@ iii: i=1,j=2
 iii returned 42
 iii: i=2,j=3
 iii returned 42
+iii: i=2,j=3
+iii returned 42


### PR DESCRIPTION
Fix return in {{{ makeDynCall }}} macro and add test. Clean up unused code and code duplication. Optimize code size to avoid unnecessary 'return's on void functions.