### PR TITLE
Fix dynCall return value being discarded

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -542,3 +542,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Patric Stout <github@truebrain.nl>
 * Jinoh Kang <jinoh.kang.kr@gmail.com>
 * Jorge Prendes <jorge.prendes@gmail.com>
+* David Apollo <devappd@outlook.com>

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1020,9 +1020,9 @@ Please update to new syntax.`);
         args.push(`a${i}`);
       }
       args = args.join(', ');
-      return `(function(${args}) { ${dyncall}.apply(null, [${funcPtr}, ${args}]); })`;
+      return `(function(${args}) { return ${dyncall}.apply(null, [${funcPtr}, ${args}]); })`;
     } else {
-      return `(function() { ${dyncall}.call(null, ${funcPtr}); })`;
+      return `(function() { return ${dyncall}.call(null, ${funcPtr}); })`;
     }
   } else {
     return `wasmTable.get(${funcPtr})`;

--- a/tests/click_preventdefault.c
+++ b/tests/click_preventdefault.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <emscripten.h>
+#include <emscripten/html5.h>
+
+// The event handler functions can return 1 to suppress the event and disable the default action. That calls event.preventDefault();
+// Returning 0 signals that the event was not consumed by the code, and will allow the event to pass on and bubble up normally.
+EM_BOOL click_callback(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData)
+{
+  return 1;
+}
+
+int main(int argc, char **argv)
+{
+  // Suppress the event's default action early via a capture handler.
+  emscripten_set_click_callback(EMSCRIPTEN_EVENT_TARGET_WINDOW, 0, 1, click_callback);
+
+  EM_ASM({
+    // Check if the earlier prevention was successful.
+    window.addEventListener("click", function(e) {
+      var result = e.defaultPrevented;
+      if (result) {
+        console.log("Test passed!")
+      } else {
+        console.log("Test failed! Event default must be prevented in earlier handler.")
+      }
+      reportResultToServer(Number(result));
+    }, false);
+
+    function sendEvent(type, data) {
+      var event = document.createEvent('Event');
+      event.initEvent(type, true, true);
+      for(var d in data) event[d] = data[d];
+      window.dispatchEvent(event);
+    }
+    sendEvent('click', { screenX: 123, screenY: 456, clientX: 123, clientY: 456, button: 0, buttons: 1 });
+  });
+
+  return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -916,6 +916,13 @@ keydown(100);keyup(100); // trigger the end
 
     self.btest('keydown_preventdefault_proxy.cpp', '300', args=['--proxy-to-worker', '-s', '''EXPORTED_FUNCTIONS=['_main']'''], manual_reference=True, post_build=post)
 
+  def test_click_preventdefault(self):
+    for _args in [
+      [],
+      ['-s', 'DYNCALLS']
+    ]:
+      self.btest('click_preventdefault.c', '1', args=_args)
+
   def test_sdl_text(self):
     create_test_file('pre.js', '''
       Module.postRun = function() {


### PR DESCRIPTION
Per #13320, event handler capture was failing in `-s DYNCALLS` and `-s ASYNCIFY` because the callback dynCall's return value was being discarded. Adding `return` to the call fixes this case. 

To discuss impact: in an SDL application, 16 dynCalls are changed. 5 calls ignore the return value and 11 calls are event handlers which follow the pattern:

`if ((function(a1, a2, a3) { return dynCall_iiii.apply(null, [callbackfunc, a1, a2, a3]); })(eventTypeId, focusEvent, userData)) e.preventDefault();`

Therefore, I added a test case only to test the `event.preventDefault()` behavior. I'm unfamiliar on the testing convention here, so LMK if there's a better approach.
