### PR TITLE
Update llvm dependency to 13.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ commands:
             echo "WASM_ENGINES = []" >> .emscripten
             test -f ~/vms/wasmtime && echo "WASMTIME = os.path.expanduser(os.path.join('~', 'vms', 'wasmtime')) ; WASM_ENGINES.append(WASMTIME)" >> .emscripten || true
             test -f ~/vms/wasmer && echo "WASMER = os.path.expanduser(os.path.join('~', 'vms', 'wasmer')) ; WASM_ENGINES.append(WASMER)" >> .emscripten || true
-            test -d ~/wasi-sdk && cp -ar ~/wasi-sdk/lib/ ~/emsdk/upstream/lib/clang/12.0.0/
+            test -d ~/wasi-sdk && cp -ar ~/wasi-sdk/lib/ ~/emsdk/upstream/lib/clang/13.0.0/
             cd -
             echo "final .emscripten:"
             cat ~/emsdk/.emscripten

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -156,7 +156,6 @@ class other(RunnerCore):
       os.close(master)
       os.close(slave)
 
-  @disabled('let LLVM 13 roll in')
   def test_emcc_v(self):
     for compiler in [EMCC, EMXX]:
       # -v, without input files

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -12,7 +12,7 @@ import tempfile
 import zipfile
 from subprocess import PIPE, STDOUT
 
-from runner import RunnerCore, path_from_root, env_modify, disabled
+from runner import RunnerCore, path_from_root, env_modify
 from runner import create_test_file, ensure_dir, make_executable
 from tools.config import config_file, EM_CONFIG
 from tools.shared import PYTHON, EMCC
@@ -232,7 +232,6 @@ class sanity(RunnerCore):
           self.assertContained('error:', output) # sanity check should fail
       try_delete(default_config)
 
-  @disabled('let LLVM 13 roll in')
   def test_llvm(self):
     LLVM_WARNING = 'LLVM version appears incorrect'
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -159,8 +159,6 @@ def get_clang_version():
 
 
 def check_llvm_version():
-  # Let LLVM 13 roll in
-  return True
   actual = get_clang_version()
   if EXPECTED_LLVM_VERSION in actual:
     return True


### PR DESCRIPTION
Followup on #13358.  Remove exceptions now that llvm 13 has rolled
into emscripten-releases.