### PR TITLE
Save result of running `llvm-nm` to cache. NFC.

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -236,7 +236,7 @@ class EmscriptenBenchmarker(Benchmarker):
 
   def cleanup(self):
     os.environ = self.old_env
-    building.clear()
+    building.clear_caches()
 
 
 class EmscriptenWasm2CBenchmarker(EmscriptenBenchmarker):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -23,6 +23,7 @@ import time
 import tempfile
 import unittest
 import uuid
+from pathlib import Path
 from subprocess import PIPE, STDOUT
 
 if __name__ == '__main__':
@@ -9905,3 +9906,24 @@ exec "$@"
     self.assertGreater(len(exports_linkable), 1000)
     self.assertIn('sendmsg', exports_linkable)
     self.assertNotIn('sendmsg', exports)
+
+  @uses_canonical_tmp
+  def test_nm_cache(self):
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-c'])
+    now = time.time()
+    past = now - 10
+    os.utime('hello_world.o', (past, past))
+    with env_modify({'EMCC_DEBUG': '1'}):
+      err = self.run_process([EMCC, 'hello_world.o'], stderr=PIPE).stderr
+
+      self.assertContained('llvm-nm', err)
+
+      # Second time linking the same object should used the cached nm result
+      err = self.run_process([EMCC, 'hello_world.o'], stderr=PIPE).stderr
+      self.assertNotContained('llvm-nm', err)
+
+      # Set the timestamp forward again to the current time.
+      # This should trigger nm once again.
+      os.utime('hello_world.o', (now, now))
+      err = self.run_process([EMCC, 'hello_world.o'], stderr=PIPE).stderr
+      self.assertContained('llvm-nm', err)

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -81,7 +81,7 @@ class Cache:
 
   def get_sysroot_dir(self, absolute):
     if absolute:
-      return os.path.join(self.dirname, 'sysroot')
+      return self.get_path('sysroot')
     return 'sysroot'
 
   def get_include_dir(self):
@@ -111,7 +111,7 @@ class Cache:
 
   def erase_file(self, shortname):
     with self.lock():
-      name = os.path.join(self.dirname, shortname)
+      name = self.get_path(shortname)
       if os.path.exists(name):
         logger.info('deleting cached file: %s', name)
         tempfiles.try_delete(name)
@@ -123,7 +123,7 @@ class Cache:
   # Request a cached file. If it isn't in the cache, it will be created with
   # the given creator function
   def get(self, shortname, creator, what=None, force=False):
-    cachename = os.path.join(self.dirname, shortname)
+    cachename = self.get_path(shortname)
     cachename = os.path.abspath(cachename)
     # Check for existence before taking the lock in case we can avoid the
     # lock completely.


### PR DESCRIPTION
This can avoid the cost of running llvm-nm and parsing the
output for each and every object file.

Fixes https://crbug.com/1171844