### PR TITLE
Remove EM_EXCLUSIVE_CACHE_ACCESS. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -822,7 +822,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       print(shared.shlex_join(parts[1:]))
     return 0
 
-  shared.check_sanity(force=DEBUG)
+  shared.check_sanity()
 
   def get_language_mode(args):
     return_next = False

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -13,16 +13,6 @@ logger = logging.getLogger('cache')
 
 # Permanent cache for system librarys and ports
 class Cache:
-  # If EM_EXCLUSIVE_CACHE_ACCESS is true, this process is allowed to have direct
-  # access to the Emscripten cache without having to obtain an interprocess lock
-  # for it. Generally this is false, and this is used in the case that
-  # Emscripten process recursively calls to itself when building the cache, in
-  # which case the parent Emscripten process has already locked the cache.
-  # Essentially the env. var EM_EXCLUSIVE_CACHE_ACCESS signals from parent to
-  # child process that the child can reuse the lock that the parent already has
-  # acquired.
-  EM_EXCLUSIVE_CACHE_ACCESS = int(os.environ.get('EM_EXCLUSIVE_CACHE_ACCESS', '0'))
-
   def __init__(self, dirname):
     # figure out the root directory for all caching
     dirname = os.path.normpath(dirname)
@@ -41,30 +31,31 @@ class Cache:
       # should never happen
       raise Exception('Attempt to lock the cache but FROZEN_CACHE is set')
 
-    if not self.EM_EXCLUSIVE_CACHE_ACCESS and self.acquired_count == 0:
+    if self.acquired_count == 0:
       logger.debug('PID %s acquiring multiprocess file lock to Emscripten cache at %s' % (str(os.getpid()), self.dirname))
+      # This should never happen because any calls to emcc make when populating the
+      # cache should not themselves attempt to acquire the cache lock.  For example,
+      # it should never be the case that while holding the cache lock to build libraryA
+      # a build of libraryB is needed.  This would be a bug in the dependency graph
+      # since if libraryA depended on libraryB it should already have been built and
+      # cached before the libraryA build started.
+      assert 'EM_PARENT_HOLDS_CACHE_LOCK' not in os.environ
       try:
         self.filelock.acquire(60)
       except filelock.Timeout:
-        # The multiprocess cache locking can be disabled altogether by setting EM_EXCLUSIVE_CACHE_ACCESS=1 environment
-        # variable before building. (in that case, use "embuilder.py build ALL" to prepopulate the cache)
         logger.warning('Accessing the Emscripten cache at "' + self.dirname + '" is taking a long time, another process should be writing to it. If there are none and you suspect this process has deadlocked, try deleting the lock file "' + self.filelock_name + '" and try again. If this occurs deterministically, consider filing a bug.')
         self.filelock.acquire()
 
-      self.prev_EM_EXCLUSIVE_CACHE_ACCESS = os.environ.get('EM_EXCLUSIVE_CACHE_ACCESS')
-      os.environ['EM_EXCLUSIVE_CACHE_ACCESS'] = '1'
+      os.environ['EM_PARENT_HOLDS_CACHE_LOCK'] = '1'
       logger.debug('done')
     self.acquired_count += 1
 
   def release_cache_lock(self):
     self.acquired_count -= 1
     assert self.acquired_count >= 0, "Called release more times than acquire"
-    if not self.EM_EXCLUSIVE_CACHE_ACCESS and self.acquired_count == 0:
-      if self.prev_EM_EXCLUSIVE_CACHE_ACCESS:
-        os.environ['EM_EXCLUSIVE_CACHE_ACCESS'] = self.prev_EM_EXCLUSIVE_CACHE_ACCESS
-      else:
-        del os.environ['EM_EXCLUSIVE_CACHE_ACCESS']
+    if self.acquired_count == 0:
       self.filelock.release()
+      del os.environ['EM_PARENT_HOLDS_CACHE_LOCK']
       logger.debug('PID %s released multiprocess file lock to Emscripten cache at %s' % (str(os.getpid()), self.dirname))
 
   @contextlib.contextmanager

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -283,6 +283,9 @@ def check_sanity(force=False):
   # not re-run the tests.
   os.environ['EMCC_SKIP_SANITY_CHECK'] = '1'
 
+  if DEBUG:
+    force = True
+
   if config.FROZEN_CACHE:
     if force:
       perform_sanity_checks()
@@ -403,17 +406,18 @@ class Configuration(object):
       except Exception as e:
         exit_with_error(str(e) + 'Could not create canonical temp dir. Check definition of TEMP_DIR in ' + config.config_file_location())
 
-      # Since the cannonical temp directory is, by definition, the same
+      # Since the canonical temp directory is, by definition, the same
       # between all processes that run in DEBUG mode we need to use a multi
       # process lock to prevent more than one process from writing to it.
       # This is because emcc assumes that it can use non-unique names inside
       # the temp directory.
-      # In the case where we run emcc recurively to populate the cache we
-      # do (sadly) still need to ignore this lock, in the same way we do for
-      # the cache lock.
-      if 'EM_EXCLUSIVE_CACHE_ACCESS' not in os.environ:
+      # Sadly we need to allow child processes to access this directory
+      # though, since emcc can recursively call itself when building
+      # libraries and ports.
+      if 'EM_HAVE_TEMP_DIR_LOCK' not in os.environ:
         filelock_name = os.path.join(self.EMSCRIPTEN_TEMP_DIR, 'emscripten.lock')
         lock = filelock.FileLock(filelock_name)
+        os.environ['EM_HAVE_TEMP_DIR_LOCK'] = '1'
         lock.acquire()
         atexit.register(lock.release)
 


### PR DESCRIPTION
This is my second attempt at removing this and I think I've
got it right this time.

The cache lock should never normally be needed in recursive
builds so assert if a parent process holds the lock. See
the comment as to why this should never happen (and if it
does its a bug).