### PR TITLE
Don't rely on LLVM's -debug flag in tests

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9086,7 +9086,7 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     self.assertContained('warning: ignoring unsupported linker flag: `-rpath-link`', out)
 
     out = self.run_process([EMCC, path_from_root('tests', 'hello_world.cpp'),
-                            '-Wl,--no-check-features,-mllvm,-debug'], stderr=PIPE).stderr
+                            '-Wl,--no-check-features'], stderr=PIPE).stderr
     self.assertNotContained('warning: ignoring unsupported linker flag', out)
 
     out = self.run_process([EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,-allow-shlib-undefined'], stderr=PIPE).stderr

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9086,7 +9086,7 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     self.assertContained('warning: ignoring unsupported linker flag: `-rpath-link`', out)
 
     out = self.run_process([EMCC, path_from_root('tests', 'hello_world.cpp'),
-                            '-Wl,--no-check-features'], stderr=PIPE).stderr
+                            '-Wl,--no-check-features,-mllvm,--data-sections'], stderr=PIPE).stderr
     self.assertNotContained('warning: ignoring unsupported linker flag', out)
 
     out = self.run_process([EMCC, path_from_root('tests', 'hello_world.cpp'), '-Wl,-allow-shlib-undefined'], stderr=PIPE).stderr


### PR DESCRIPTION
It's compiled away in release/non-asserts mode, so the invocation fails
with an unknown argument.