### PR TITLE
Add __sys_shutdown stub library function

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -602,6 +602,11 @@ var SyscallsLibrary = {
     sock.sock_ops.connect(sock, info.addr, info.port);
     return 0;
   },
+  __sys_shutdown__deps: ['$getSocketFromFD'],
+  __sys_shutdown: function(fd, how) {
+    getSocketFromFD(fd);
+    return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
+  },
   __sys_accept4__deps: ['$getSocketFromFD', '_write_sockaddr', '$DNS'],
   __sys_accept4: function(fd, addr, addrlen, flags) {
     var sock = getSocketFromFD(fd);

--- a/tests/sockets/test_sin_zero.c
+++ b/tests/sockets/test_sin_zero.c
@@ -34,6 +34,7 @@ int main() {
   for (int i = 0; i < 8; i++) {
     assert(adr_inet4->sin_zero[i] == 0);
   }
+  shutdown(s, SHUT_RDWR);
 
   puts("success");
 


### PR DESCRIPTION
We never really supported this syscall but prior to #13272 this
fact was not evident since the generic socketcall handler had a
catchall the returned ENOSYS.

Fixes: #13393