### PR TITLE
Remove tests of {i16x8,i32x4}.any_true

### DIFF
--- a/tests/test_wasm_builtin_simd.cpp
+++ b/tests/test_wasm_builtin_simd.cpp
@@ -367,9 +367,6 @@ i16x8 TESTFN i16x8_abs(i16x8 vec) {
 i16x8 TESTFN i16x8_neg(i16x8 vec) {
   return -vec;
 }
-int32_t TESTFN i16x8_any_true(i16x8 vec) {
-  return __builtin_wasm_any_true_i16x8(vec);
-}
 int32_t TESTFN i16x8_all_true(i16x8 vec) {
   return __builtin_wasm_all_true_i16x8(vec);
 }
@@ -412,9 +409,6 @@ i32x4 TESTFN i32x4_abs(i32x4 vec) {
 }
 i32x4 TESTFN i32x4_neg(i32x4 vec) {
   return -vec;
-}
-int32_t TESTFN i32x4_any_true(i32x4 vec) {
-  return __builtin_wasm_any_true_i32x4(vec);
 }
 int32_t TESTFN i32x4_all_true(i32x4 vec) {
   return __builtin_wasm_all_true_i32x4(vec);
@@ -1132,10 +1126,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     i16x8_neg((i16x8){0, 1, 42, -3, -56, 32767, -32768, 32766}),
     ((i16x8){0, -1, -42, 3, 56, -32767, -32768, -32766})
   );
-  expect_eq(i16x8_any_true((i16x8){0, 0, 0, 0, 0, 0, 0, 0}), 0);
-  expect_eq(i16x8_any_true((i16x8){0, 0, 1, 0, 0, 0, 0, 0}), 1);
-  expect_eq(i16x8_any_true((i16x8){1, 1, 1, 1, 1, 0, 1, 1}), 1);
-  expect_eq(i16x8_any_true((i16x8){1, 1, 1, 1, 1, 1, 1, 1}), 1);
   expect_eq(i16x8_all_true((i16x8){0, 0, 0, 0, 0, 0, 0, 0}), 0);
   expect_eq(i16x8_all_true((i16x8){0, 0, 1, 0, 0, 0, 0, 0}), 0);
   expect_eq(i16x8_all_true((i16x8){1, 1, 1, 1, 1, 0, 1, 1}), 0);
@@ -1224,10 +1214,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
   // i32x4 arithmetic
   expect_vec(i32x4_abs((i32x4){0, 1, 0x80000000, 0x80000001}), ((i32x4){0, 1, 0x80000000, 0x7fffffff}));
   expect_vec(i32x4_neg((i32x4){0, 1, 0x80000000, 0x80000001}), ((i32x4){0, -1, 0x80000000, 0x7fffffff}));
-  expect_eq(i32x4_any_true((i32x4){0, 0, 0, 0}), 0);
-  expect_eq(i32x4_any_true((i32x4){0, 0, 1, 0}), 1);
-  expect_eq(i32x4_any_true((i32x4){1, 0, 1, 1}), 1);
-  expect_eq(i32x4_any_true((i32x4){1, 1, 1, 1}), 1);
   expect_eq(i32x4_all_true((i32x4){0, 0, 0, 0}), 0);
   expect_eq(i32x4_all_true((i32x4){0, 0, 1, 0}), 0);
   expect_eq(i32x4_all_true((i32x4){1, 0, 1, 1}), 0);

--- a/tests/test_wasm_intrinsics_simd.c
+++ b/tests/test_wasm_intrinsics_simd.c
@@ -422,9 +422,6 @@ v128_t TESTFN i16x8_abs(v128_t vec) {
 v128_t TESTFN i16x8_neg(v128_t vec) {
   return wasm_i16x8_neg(vec);
 }
-bool TESTFN i16x8_any_true(v128_t vec) {
-  return wasm_i16x8_any_true(vec);
-}
 bool TESTFN i16x8_all_true(v128_t vec) {
   return wasm_i16x8_all_true(vec);
 }
@@ -478,9 +475,6 @@ v128_t TESTFN i32x4_abs(v128_t vec) {
 }
 v128_t TESTFN i32x4_neg(v128_t vec) {
   return wasm_i32x4_neg(vec);
-}
-int32_t TESTFN i32x4_any_true(v128_t vec) {
-  return wasm_i32x4_any_true(vec);
 }
 int32_t TESTFN i32x4_all_true(v128_t vec) {
   return wasm_i32x4_all_true(vec);
@@ -1375,10 +1369,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     i16x8_neg((v128_t)i16x8(0, 1, 42, -3, -56, 32767, -32768, 32766)),
     i16x8(0, -1, -42, 3, 56, -32767, -32768, -32766)
   );
-  expect_eq(i16x8_any_true((v128_t)i16x8(0, 0, 0, 0, 0, 0, 0, 0)), 0);
-  expect_eq(i16x8_any_true((v128_t)i16x8(0, 0, 1, 0, 0, 0, 0, 0)), 1);
-  expect_eq(i16x8_any_true((v128_t)i16x8(1, 1, 1, 1, 1, 0, 1, 1)), 1);
-  expect_eq(i16x8_any_true((v128_t)i16x8(1, 1, 1, 1, 1, 1, 1, 1)), 1);
   expect_eq(i16x8_all_true((v128_t)i16x8(0, 0, 0, 0, 0, 0, 0, 0)), 0);
   expect_eq(i16x8_all_true((v128_t)i16x8(0, 0, 1, 0, 0, 0, 0, 0)), 0);
   expect_eq(i16x8_all_true((v128_t)i16x8(1, 1, 1, 1, 1, 0, 1, 1)), 0);
@@ -1501,10 +1491,6 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     i32x4_neg((v128_t)i32x4(0, 1, 0x80000000, 0x80000001)),
     i32x4(0, -1, 0x80000000, 0x7fffffff)
   );
-  expect_eq(i32x4_any_true((v128_t)i32x4(0, 0, 0, 0)), 0);
-  expect_eq(i32x4_any_true((v128_t)i32x4(0, 0, 1, 0)), 1);
-  expect_eq(i32x4_any_true((v128_t)i32x4(1, 0, 1, 1)), 1);
-  expect_eq(i32x4_any_true((v128_t)i32x4(1, 1, 1, 1)), 1);
   expect_eq(i32x4_all_true((v128_t)i32x4(0, 0, 0, 0)), 0);
   expect_eq(i32x4_all_true((v128_t)i32x4(0, 0, 1, 0)), 0);
   expect_eq(i32x4_all_true((v128_t)i32x4(1, 0, 1, 1)), 0);


### PR DESCRIPTION
These instructions were removed from the spec proposal and from V8 because they
were redundant with i8x16.any_true, which has identical semantics. Since they
were removed from V8, these tests started failing. This PR fixes the breakage by
removing the obsolete tests. See https://github.com/WebAssembly/simd/issues/416.