### PR TITLE
Don't disable all parallelism when EMCC_DEBUG is set

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -462,7 +462,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       os.chdir(os.path.dirname(self.get_dir()))
       try_delete(self.get_dir())
 
-      if EMTEST_DETECT_TEMPFILE_LEAKS and not os.environ.get('EMCC_DEBUG'):
+      if EMTEST_DETECT_TEMPFILE_LEAKS and not DEBUG:
         temp_files_after_run = []
         for root, dirnames, filenames in os.walk(self.temp_dir):
           for dirname in dirnames:
@@ -1841,7 +1841,7 @@ def flattened_tests(loaded_tests):
 
 def suite_for_module(module, tests):
   suite_supported = module.__name__ in ('test_core', 'test_other', 'test_posixtest')
-  if not EMTEST_SAVE_DIR:
+  if not EMTEST_SAVE_DIR and not DEBUG:
     has_multiple_tests = len(tests) > 1
     has_multiple_cores = parallel_testsuite.num_cores() > 1
     if suite_supported and has_multiple_tests and has_multiple_cores:

--- a/tools/building.py
+++ b/tools/building.py
@@ -158,10 +158,6 @@ def clear():
 
 
 def get_num_cores():
-  if DEBUG:
-    # When in EMCC_DEBUG mode, only use a single core to avoid interleaving
-    # logging output and keeps things more deterministic.
-    return 1
   return int(os.environ.get('EMCC_CORES', multiprocessing.cpu_count()))
 
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -88,7 +88,7 @@ def run_build_commands(commands):
   # to setup the sysroot itself.
   ensure_sysroot()
   cores = min(len(commands), building.get_num_cores())
-  if cores <= 1:
+  if cores <= 1 or shared.DEBUG:
     for command in commands:
       run_one_command(command)
   else:


### PR DESCRIPTION
This enables certain parallel phases such as running llvm-nm in parallel
when calulating system libraries to link.  Developers who what to
disable parallism can continue to use `EMCC_CORES=1` as usual.

We previously disabled parallelism in debug mode for a couple of reason,
both of which ohly apply to emscripten subprocesses (not subprocesses in
general):

1. In debug mode emcc uses a single, canonical, temp directory.
   This means that if many emcc subprocesses all run in debug mode
   they can create colliding temp files with unpredictable results.
2. The interleaved debug output from many emcc subproceses was confusing

emscripten only really recursively calls itself in a couple of places:

1. When building system libraries/ports at link time.
2. When the test running launches emcc processes.

The risk of debug names colliding in (1) was greatly reduced by two
recent changes: #13329 #13370.

To counter (2) this change continues to disable test parallelism when
EMCC_DEBUG is enabled.

See https://bugs.chromium.org/p/chromium/issues/detail?id=1171844