### PR TITLE
Minor cleanup of tempfiles.py. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -425,7 +425,7 @@ def ensure_archive_index(archive_file):
     run_process([shared.LLVM_RANLIB, archive_file])
 
 
-def get_all_js_syms(temp_files):
+def get_all_js_syms():
   # Runs the js compiler to generate a list of all symbols available in the JS
   # libraries.  This must be done separately for each linker invokation since the
   # list of symbols depends on what settings are used.
@@ -439,7 +439,7 @@ def get_all_js_syms(temp_files):
     shared.Settings.INCLUDE_FULL_LIBRARY = True
     shared.Settings.ONLY_CALC_JS_SYMBOLS = True
     emscripten.generate_struct_info()
-    glue, forwarded_data = emscripten.compile_settings(temp_files)
+    glue, forwarded_data = emscripten.compile_settings()
     forwarded_json = json.loads(forwarded_data)
     library_fns = forwarded_json['Functions']['libraryFunctions']
     library_fns_list = []
@@ -2139,7 +2139,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # TODO: we could check if this is a fastcomp build, and still speed things up here
     js_funcs = None
     if shared.Settings.LLD_REPORT_UNDEFINED and shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS:
-      js_funcs = get_all_js_syms(misc_temp_files)
+      js_funcs = get_all_js_syms()
       log_time('JS symbol generation')
     building.link_lld(linker_inputs, wasm_target, external_symbol_list=js_funcs)
     # Special handling for when the user passed '-Wl,--version'.  In this case the linker

--- a/emscripten.py
+++ b/emscripten.py
@@ -174,9 +174,9 @@ def apply_static_code_hooks(forwarded_json, code):
   return code
 
 
-def compile_settings(temp_files):
+def compile_settings():
   # Save settings to a file to work around v8 issue 1579
-  with temp_files.get_file('.txt') as settings_file:
+  with shared.configuration.get_temp_files().get_file('.txt') as settings_file:
     with open(settings_file, 'w') as s:
       json.dump(shared.Settings.to_dict(), s, sort_keys=True)
 
@@ -281,7 +281,7 @@ def create_named_globals(metadata):
   return '\n'.join(named_globals)
 
 
-def emscript(in_wasm, out_wasm, outfile_js, memfile, temp_files, DEBUG):
+def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
   # Overview:
   #   * Run wasm-emscripten-finalize to extract metadata and modify the binary
   #     to use emscripten's wasm<->JS ABI
@@ -313,7 +313,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, temp_files, DEBUG):
     set_memory(static_bump)
     logger.debug('stack_base: %d, stack_max: %d, heap_base: %d', shared.Settings.STACK_BASE, shared.Settings.STACK_MAX, shared.Settings.HEAP_BASE)
 
-  glue, forwarded_data = compile_settings(temp_files)
+  glue, forwarded_data = compile_settings()
   if DEBUG:
     logger.debug('  emscript: glue took %s seconds' % (time.time() - t))
     t = time.time()
@@ -844,10 +844,7 @@ def generate_struct_info():
 
 
 def run(in_wasm, out_wasm, outfile_js, memfile):
-  temp_files = shared.configuration.get_temp_files()
   if not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
     generate_struct_info()
 
-  return temp_files.run_and_clean(lambda: emscript(
-      in_wasm, out_wasm, outfile_js, memfile, temp_files, shared.DEBUG)
-  )
+  emscript(in_wasm, out_wasm, outfile_js, memfile, shared.DEBUG)

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -423,7 +423,7 @@ class Configuration(object):
 
   def get_temp_files(self):
     return tempfiles.TempFiles(
-      tmp=self.TEMP_DIR if not DEBUG else get_emscripten_temp_dir(),
+      tmpdir=self.TEMP_DIR if not DEBUG else get_emscripten_temp_dir(),
       save_debug_files=os.environ.get('EMCC_DEBUG_SAVE'))
 
 

--- a/tools/tempfiles.py
+++ b/tools/tempfiles.py
@@ -54,8 +54,8 @@ def try_delete(pathname):
 
 
 class TempFiles(object):
-  def __init__(self, tmp, save_debug_files=False):
-    self.tmp = tmp
+  def __init__(self, tmpdir, save_debug_files):
+    self.tmpdir = tmpdir
     self.save_debug_files = save_debug_files
     self.to_clean = []
 
@@ -66,17 +66,19 @@ class TempFiles(object):
 
   def get(self, suffix):
     """Returns a named temp file with the given prefix."""
-    named_file = tempfile.NamedTemporaryFile(dir=self.tmp, suffix=suffix, delete=False)
+    named_file = tempfile.NamedTemporaryFile(dir=self.tmpdir, suffix=suffix, delete=False)
     self.note(named_file.name)
     return named_file
 
   def get_file(self, suffix):
-    """Returns an object representing a RAII-like access to a temp file, that has convenient pythonesque
-    semantics for being used via a construct 'with TempFiles.get_file(..) as filename:'. The file will be
-    deleted immediately once the 'with' block is exited."""
+    """Returns an object representing a RAII-like access to a temp file
+    that has convenient pythonesque semantics for being used via a construct
+      'with TempFiles.get_file(..) as filename:'.
+    The file will be deleted immediately once the 'with' block is exited.
+    """
     class TempFileObject(object):
       def __enter__(self_):
-        self_.file = tempfile.NamedTemporaryFile(dir=self.tmp, suffix=suffix, delete=False)
+        self_.file = tempfile.NamedTemporaryFile(dir=self.tmpdir, suffix=suffix, delete=False)
         self_.file.close() # NamedTemporaryFile passes out open file handles, but callers prefer filenames (and open their own handles manually if needed)
         return self_.file.name
 
@@ -87,20 +89,14 @@ class TempFiles(object):
 
   def get_dir(self):
     """Returns a named temp directory with the given prefix."""
-    directory = tempfile.mkdtemp(dir=self.tmp)
+    directory = tempfile.mkdtemp(dir=self.tmpdir)
     self.note(directory)
     return directory
 
   def clean(self):
     if self.save_debug_files:
-      print('not cleaning up temp files since in debug-save mode, see them in %s' % (self.tmp,), file=sys.stderr)
+      print(f'not cleaning up temp files since in debug-save mode, see them in ${self.tmpdir}', file=sys.stderr)
       return
     for filename in self.to_clean:
       try_delete(filename)
     self.to_clean = []
-
-  def run_and_clean(self, func):
-    try:
-      return func()
-    finally:
-      self.clean()


### PR DESCRIPTION
- Avoid passing temp_files around in emscripten.py, and just use
  shared.configuration.get_temp_files directly in the single place
  it was needed. Also remove the use of `run_and_clean`.  The cleanup
  happens automatically on process exit anyway.
- Remove the now unused `run_and_clean` method.
- Make the save_debug_files argument non-optional (there is only
  one caller which explicitly passes this.
- Rename member from tmp -> tmpdir to be a little more explicit.