### PR TITLE
Partially revert commit that broke using emrun.py outside the tree

### DIFF
--- a/emrun.py
+++ b/emrun.py
@@ -12,6 +12,8 @@ Usage: emrun <options> filename.html <args to program>
 See emrun --help for more information
 """
 
+# N.B. Do not introduce external dependencies to this file. It is often used
+# standalone outside Emscripten directory tree.
 import argparse
 import atexit
 import cgi

--- a/emrun.py
+++ b/emrun.py
@@ -39,12 +39,14 @@ if sys.version_info.major == 2:
   from SimpleHTTPServer import SimpleHTTPRequestHandler
   from urllib import unquote
   from urlparse import urlsplit
+
   def print_to_handle(handle, line):
-    print >> handle, line
+    print >> handle, line # noqa: F633
 else:
   import socketserver
   from http.server import HTTPServer, SimpleHTTPRequestHandler
   from urllib.parse import unquote, urlsplit
+
   def print_to_handle(handle, line):
     handle.write(line + '\n')
 


### PR DESCRIPTION
Partially revert commit that broke using emrun.py outside the tree. People often deploy emrun.py into their own CIs and infrastructure outside Emscripten.

commit 4fc6505151b5325734c6b05252891a8601d87729
Author: Sam Clegg <sbc@chromium.org>
Date:   Sun Sep 13 19:05:11 2020 -0700

    Use shared wrappers for shutils. NFC. (#12200)

    We we not being consistent in our use of safe_copy and
    safe_move and try_delete.