### PR TITLE
Update code size and metadce expectations after an LLVM roll broke things

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 4927,
   "a.js.gz": 2352,
-  "a.wasm": 10895,
-  "a.wasm.gz": 6927,
-  "total": 16385,
-  "total_gz": 9656
+  "a.wasm": 10915,
+  "a.wasm.gz": 6937,
+  "total": 16405,
+  "total_gz": 9666
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 21317,
-  "a.js.gz": 8276,
+  "a.js": 21374,
+  "a.js.gz": 8303,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 25076,
-  "total_gz": 11377
+  "total": 25133,
+  "total_gz": 11404
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 4410,
   "a.js.gz": 2172,
-  "a.wasm": 10895,
-  "a.wasm.gz": 6927,
-  "total": 15868,
-  "total_gz": 9476
+  "a.wasm": 10915,
+  "a.wasm.gz": 6937,
+  "total": 15888,
+  "total_gz": 9486
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 20801,
-  "a.js.gz": 8114,
+  "a.js": 20858,
+  "a.js.gz": 8141,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 24560,
-  "total_gz": 11215
+  "total": 24617,
+  "total_gz": 11242
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 13742,
-  "a.html.gz": 7291,
-  "total": 13742,
-  "total_gz": 7291
+  "a.html": 13822,
+  "a.html.gz": 7333,
+  "total": 13822,
+  "total_gz": 7333
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 18967,
-  "a.html.gz": 7938,
-  "total": 18967,
-  "total_gz": 7938
+  "a.html": 19012,
+  "a.html.gz": 7965,
+  "total": 19012,
+  "total_gz": 7965
 }

--- a/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
+++ b/tests/other/metadce/mem_no_argv_O3_STANDALONE_WASM_flto.funcs
@@ -1,3 +1,4 @@
 $__wasm_call_ctors
 $_start
 $dlmalloc
+$sbrk

--- a/tests/other/metadce/minimal_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -46,3 +46,4 @@ $sbrk
 $stackAlloc
 $stackRestore
 $stackSave
+$tmalloc_small


### PR DESCRIPTION
Looks like some minor regressions perhaps due to less inlining happening? (as
more functions appear in metadce output)