### PR TITLE
Split test_sse4_1 and test_avx tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -136,6 +136,7 @@ commands:
           command: |
             $PYTHON_BIN tests/runner.py << parameters.test_targets >>
             $PYTHON_BIN tools/check_clean.py
+          no_output_timeout: 30m
   run-tests-mac:
     description: "Runs emscripten tests"
     parameters:

--- a/tests/sse/test_avx.cpp
+++ b/tests/sse/test_avx.cpp
@@ -19,29 +19,52 @@ int numInterestingInts = sizeof(interesting_ints_)/sizeof(interesting_ints_[0]);
 double *interesting_doubles = get_interesting_doubles();
 int numInterestingDoubles = sizeof(interesting_doubles_)/sizeof(interesting_doubles_[0]);
 
-int main()
-{
-	assert(numInterestingFloats % 4 == 0);
-	assert(numInterestingInts % 4 == 0);
-	assert(numInterestingDoubles % 4 == 0);	
+void test_broadcast() {
+  Ret_FloatPtr(__m128, _mm_broadcast_ss, 1, 1);
+}
 
-	Ret_FloatPtr(__m128, _mm_broadcast_ss, 1, 1);
-	Ret_M128d_M128d_Tint_5bits(__m128d, _mm_cmp_pd);
-	Ret_M128_M128_Tint_5bits(__m128, _mm_cmp_ps);
-	Ret_M128d_M128d_Tint_5bits(__m128d, _mm_cmp_sd);
-	Ret_M128_M128_Tint_5bits(__m128, _mm_cmp_ss);
-	Ret_DoublePtr_M128i(__m128d, _mm_maskload_pd, 2, 2);
-	Ret_FloatPtr_M128i(__m128, _mm_maskload_ps, 4, 4);
-	void_OutDoublePtr_M128i_M128d(_mm_maskstore_pd, double*, 16, 8);
-	void_OutFloatPtr_M128i_M128(_mm_maskstore_ps, float*, 16, 4);
-	Ret_M128d_Tint(__m128d, _mm_permute_pd);
-	Ret_M128_Tint(__m128, _mm_permute_ps);
-	Ret_M128d_M128d(__m128d, _mm_permutevar_pd);
-	Ret_M128_M128(__m128, _mm_permutevar_ps);
-	Ret_M128d_M128d(int, _mm_testc_pd);
-	Ret_M128_M128(int, _mm_testc_ps);
-	Ret_M128d_M128d(int, _mm_testnzc_pd);
-	Ret_M128_M128(int, _mm_testnzc_ps);
-	Ret_M128d_M128d(int, _mm_testz_pd);
-	Ret_M128_M128(int, _mm_testz_ps);
+void test_cmp() {
+  Ret_M128d_M128d_Tint_5bits(__m128d, _mm_cmp_pd);
+  Ret_M128_M128_Tint_5bits(__m128, _mm_cmp_ps);
+  Ret_M128d_M128d_Tint_5bits(__m128d, _mm_cmp_sd);
+  Ret_M128_M128_Tint_5bits(__m128, _mm_cmp_ss);
+}
+
+void test_maskload() {
+  Ret_DoublePtr_M128i(__m128d, _mm_maskload_pd, 2, 2);
+  Ret_FloatPtr_M128i(__m128, _mm_maskload_ps, 4, 4);
+}
+
+void test_maskstore() {
+  void_OutDoublePtr_M128i_M128d(_mm_maskstore_pd, double*, 16, 8);
+  void_OutFloatPtr_M128i_M128(_mm_maskstore_ps, float*, 16, 4);
+}
+
+void test_permute() {
+  Ret_M128d_Tint(__m128d, _mm_permute_pd);
+  Ret_M128_Tint(__m128, _mm_permute_ps);
+  Ret_M128d_M128d(__m128d, _mm_permutevar_pd);
+  Ret_M128_M128(__m128, _mm_permutevar_ps);
+}
+
+void test_test() {
+  Ret_M128d_M128d(int, _mm_testc_pd);
+  Ret_M128_M128(int, _mm_testc_ps);
+  Ret_M128d_M128d(int, _mm_testnzc_pd);
+  Ret_M128_M128(int, _mm_testnzc_ps);
+  Ret_M128d_M128d(int, _mm_testz_pd);
+  Ret_M128_M128(int, _mm_testz_ps);
+}
+
+int main() {
+  assert(numInterestingFloats % 4 == 0);
+  assert(numInterestingInts % 4 == 0);
+  assert(numInterestingDoubles % 4 == 0);
+
+  test_broadcast();
+  test_cmp();
+  test_maskload();
+  test_maskstore();
+  test_permute();
+  test_test();
 }

--- a/tests/sse/test_sse4_1.cpp
+++ b/tests/sse/test_sse4_1.cpp
@@ -19,96 +19,126 @@ int numInterestingInts = sizeof(interesting_ints_)/sizeof(interesting_ints_[0]);
 double *interesting_doubles = get_interesting_doubles();
 int numInterestingDoubles = sizeof(interesting_doubles_)/sizeof(interesting_doubles_[0]);
 
-void test_round()
-{
-	Ret_M128d(__m128d, _mm_ceil_pd);
-	Ret_M128(__m128, _mm_ceil_ps);
-	Ret_M128d_M128d(__m128d, _mm_ceil_sd);
-	Ret_M128_M128(__m128, _mm_ceil_ss);	
-	Ret_M128d(__m128d, _mm_floor_pd);
-	Ret_M128(__m128, _mm_floor_ps);
-	Ret_M128d_M128d(__m128d, _mm_floor_sd);
-	Ret_M128_M128(__m128, _mm_floor_ss);
-	Ret_M128d_Tint(__m128d, _mm_round_pd);
-	Ret_M128_Tint(__m128, _mm_round_ps);
-	Ret_M128d_M128d_Tint(__m128d, _mm_round_sd);
-	Ret_M128_M128_Tint(__m128, _mm_round_ss);
+void test_round() {
+  Ret_M128d(__m128d, _mm_ceil_pd);
+  Ret_M128(__m128, _mm_ceil_ps);
+  Ret_M128d_M128d(__m128d, _mm_ceil_sd);
+  Ret_M128_M128(__m128, _mm_ceil_ss);
+  Ret_M128d(__m128d, _mm_floor_pd);
+  Ret_M128(__m128, _mm_floor_ps);
+  Ret_M128d_M128d(__m128d, _mm_floor_sd);
+  Ret_M128_M128(__m128, _mm_floor_ss);
+  Ret_M128d_Tint(__m128d, _mm_round_pd);
+  Ret_M128_Tint(__m128, _mm_round_ps);
+  Ret_M128d_M128d_Tint(__m128d, _mm_round_sd);
+  Ret_M128_M128_Tint(__m128, _mm_round_ss);
+}
+
+void test_blend() {
+  Ret_M128i_M128i_Tint(__m128i, _mm_blend_epi16);
+  Ret_M128d_M128d_Tint(__m128d, _mm_blend_pd);
+  Ret_M128_M128_Tint(__m128, _mm_blend_ps);
+  Ret_M128i_M128i_M128i(__m128i, _mm_blendv_epi8);
+  Ret_M128d_M128d_M128d(__m128d, _mm_blendv_pd);
+  Ret_M128_M128_M128(__m128, _mm_blendv_ps);
+}
+
+void test_cvte() {
+  Ret_M128i(__m128i, _mm_cvtepi16_epi32);
+  Ret_M128i(__m128i, _mm_cvtepi16_epi64);
+  Ret_M128i(__m128i, _mm_cvtepi32_epi64);
+  Ret_M128i(__m128i, _mm_cvtepi8_epi16);
+  Ret_M128i(__m128i, _mm_cvtepi8_epi32);
+  Ret_M128i(__m128i, _mm_cvtepi8_epi64);
+  Ret_M128i(__m128i, _mm_cvtepu16_epi32);
+  Ret_M128i(__m128i, _mm_cvtepu16_epi64);
+  Ret_M128i(__m128i, _mm_cvtepu32_epi64);
+  Ret_M128i(__m128i, _mm_cvtepu8_epi16);
+  Ret_M128i(__m128i, _mm_cvtepu8_epi32);
+  Ret_M128i(__m128i, _mm_cvtepu8_epi64);
+}
+
+void test_dp() {
+  testNaNBits = false;
+  Ret_M128d_M128d_Tint(__m128d, _mm_dp_pd);
+  Ret_M128_M128_Tint(__m128, _mm_dp_ps); // _mm_dp_ps emulation does not match NaN bit selection rules (seems to be unspecified)
+  testNaNBits = true;
+}
+
+void test_extract() {
+  Ret_M128i_Tint(int, _mm_extract_epi32);
+  Ret_M128i_Tint(int64_t, _mm_extract_epi64);
+  Ret_M128i_Tint(int, _mm_extract_epi8);
+  Ret_M128_Tint(float, _mm_extract_ps);
+}
+
+void test_insert() {
+  Ret_M128i_int_Tint(__m128i, _mm_insert_epi32);
+  Ret_M128i_int_Tint(__m128i, _mm_insert_epi64);
+  Ret_M128_M128_Tint(__m128, _mm_insert_ps);
+}
+
+void test_minmax() {
+  Ret_M128i_M128i(__m128i, _mm_max_epi32);
+  Ret_M128i_M128i(__m128i, _mm_max_epi8);
+  Ret_M128i_M128i(__m128i, _mm_max_epu16);
+  Ret_M128i_M128i(__m128i, _mm_max_epu32);
+  Ret_M128i_M128i(__m128i, _mm_min_epi32);
+  Ret_M128i_M128i(__m128i, _mm_min_epi8);
+  Ret_M128i_M128i(__m128i, _mm_min_epu16);
+  Ret_M128i_M128i(__m128i, _mm_min_epu32);
+}
+
+void test_misc() {
+  Ret_M128i_M128i(__m128i, _mm_cmpeq_epi64);
+  Ret_M128i(__m128i, _mm_minpos_epu16);
+  Ret_M128i_M128i_Tint(__m128i, _mm_mpsadbw_epu8);
+  Ret_M128i_M128i(__m128i, _mm_mul_epi32);
+  Ret_M128i_M128i(__m128i, _mm_mullo_epi32);
+  Ret_M128i_M128i(__m128i, _mm_packus_epi32);
+  Ret_IntPtr(__m128i, _mm_stream_load_si128, __m128i*, 4, 4);
+}
+
+void test_test() {
+  Ret_M128i(int, _mm_test_all_ones);
+  printf("_mm_test_all_ones(0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_all_ones(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_test_all_ones(0xFFFFFFFFFFFFFFFEull): %d\n", _mm_test_all_ones(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull)));
+  printf("_mm_test_all_ones(0): %d\n", _mm_test_all_ones(_mm_set1_epi64x(0)));
+  Ret_M128i_M128i(int, _mm_test_all_zeros);
+  printf("_mm_test_all_zeros(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_all_zeros(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_test_all_zeros(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_all_zeros(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_test_all_zeros(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_all_zeros(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  Ret_M128i_M128i(int, _mm_test_mix_ones_zeros);
+  printf("_mm_test_mix_ones_zeros(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_mix_ones_zeros(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_test_mix_ones_zeros(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_mix_ones_zeros(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_test_mix_ones_zeros(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_mix_ones_zeros(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  Ret_M128i_M128i(int, _mm_testc_si128);
+  printf("_mm_testc_si128(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testc_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_testc_si128(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testc_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_testc_si128(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testc_si128(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  Ret_M128i_M128i(int, _mm_testnzc_si128);
+  printf("_mm_testnzc_si128(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testnzc_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_testnzc_si128(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testnzc_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_testnzc_si128(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testnzc_si128(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  Ret_M128i_M128i(int, _mm_testz_si128);
+  printf("_mm_testz_si128(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testz_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_testz_si128(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testz_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  printf("_mm_testz_si128(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testz_si128(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
 }
 
 int main()
 {
-	assert(numInterestingFloats % 4 == 0);
-	assert(numInterestingInts % 4 == 0);
-	assert(numInterestingDoubles % 4 == 0);	
+  assert(numInterestingFloats % 4 == 0);
+  assert(numInterestingInts % 4 == 0);
+  assert(numInterestingDoubles % 4 == 0);
 
-	test_round();
-
-	Ret_M128i_M128i_Tint(__m128i, _mm_blend_epi16);
-	Ret_M128d_M128d_Tint(__m128d, _mm_blend_pd);
-	Ret_M128_M128_Tint(__m128, _mm_blend_ps);
-	Ret_M128i_M128i_M128i(__m128i, _mm_blendv_epi8);
-	Ret_M128d_M128d_M128d(__m128d, _mm_blendv_pd);
-	Ret_M128_M128_M128(__m128, _mm_blendv_ps);
-	Ret_M128i_M128i(__m128i, _mm_cmpeq_epi64);
-	Ret_M128i(__m128i, _mm_cvtepi16_epi32);
-	Ret_M128i(__m128i, _mm_cvtepi16_epi64);
-	Ret_M128i(__m128i, _mm_cvtepi32_epi64);
-	Ret_M128i(__m128i, _mm_cvtepi8_epi16);
-	Ret_M128i(__m128i, _mm_cvtepi8_epi32);
-	Ret_M128i(__m128i, _mm_cvtepi8_epi64);
-	Ret_M128i(__m128i, _mm_cvtepu16_epi32);
-	Ret_M128i(__m128i, _mm_cvtepu16_epi64);
-	Ret_M128i(__m128i, _mm_cvtepu32_epi64);
-	Ret_M128i(__m128i, _mm_cvtepu8_epi16);
-	Ret_M128i(__m128i, _mm_cvtepu8_epi32);
-	Ret_M128i(__m128i, _mm_cvtepu8_epi64);
-	testNaNBits = false;
-	Ret_M128d_M128d_Tint(__m128d, _mm_dp_pd);
-	Ret_M128_M128_Tint(__m128, _mm_dp_ps); // _mm_dp_ps emulation does not match NaN bit selection rules (seems to be unspecified)
-	testNaNBits = true;
-	Ret_M128i_Tint(int, _mm_extract_epi32);
-	Ret_M128i_Tint(int64_t, _mm_extract_epi64);
-	Ret_M128i_Tint(int, _mm_extract_epi8);
-	Ret_M128_Tint(float, _mm_extract_ps);
-	Ret_M128i_int_Tint(__m128i, _mm_insert_epi32);
-	Ret_M128i_int_Tint(__m128i, _mm_insert_epi64);
-	Ret_M128_M128_Tint(__m128, _mm_insert_ps);
-	Ret_M128i_M128i(__m128i, _mm_max_epi32);
-	Ret_M128i_M128i(__m128i, _mm_max_epi8);
-	Ret_M128i_M128i(__m128i, _mm_max_epu16);
-	Ret_M128i_M128i(__m128i, _mm_max_epu32);
-	Ret_M128i_M128i(__m128i, _mm_min_epi32);
-	Ret_M128i_M128i(__m128i, _mm_min_epi8);
-	Ret_M128i_M128i(__m128i, _mm_min_epu16);
-	Ret_M128i_M128i(__m128i, _mm_min_epu32);
-	Ret_M128i(__m128i, _mm_minpos_epu16);
-	Ret_M128i_M128i_Tint(__m128i, _mm_mpsadbw_epu8);
-	Ret_M128i_M128i(__m128i, _mm_mul_epi32);
-	Ret_M128i_M128i(__m128i, _mm_mullo_epi32);
-	Ret_M128i_M128i(__m128i, _mm_packus_epi32);
-	Ret_IntPtr(__m128i, _mm_stream_load_si128, __m128i*, 4, 4);
-	Ret_M128i(int, _mm_test_all_ones);
-	printf("_mm_test_all_ones(0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_all_ones(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_test_all_ones(0xFFFFFFFFFFFFFFFEull): %d\n", _mm_test_all_ones(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull)));
-	printf("_mm_test_all_ones(0): %d\n", _mm_test_all_ones(_mm_set1_epi64x(0)));
-	Ret_M128i_M128i(int, _mm_test_all_zeros);
-	printf("_mm_test_all_zeros(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_all_zeros(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_test_all_zeros(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_all_zeros(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_test_all_zeros(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_all_zeros(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	Ret_M128i_M128i(int, _mm_test_mix_ones_zeros);
-	printf("_mm_test_mix_ones_zeros(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_mix_ones_zeros(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_test_mix_ones_zeros(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_mix_ones_zeros(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_test_mix_ones_zeros(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_test_mix_ones_zeros(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	Ret_M128i_M128i(int, _mm_testc_si128);
-	printf("_mm_testc_si128(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testc_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_testc_si128(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testc_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_testc_si128(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testc_si128(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	Ret_M128i_M128i(int, _mm_testnzc_si128);
-	printf("_mm_testnzc_si128(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testnzc_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_testnzc_si128(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testnzc_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_testnzc_si128(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testnzc_si128(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	Ret_M128i_M128i(int, _mm_testz_si128);
-	printf("_mm_testz_si128(0xFFFFFFFFFFFFFFFFull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testz_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_testz_si128(0xFFFFFFFFFFFFFFFEull, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testz_si128(_mm_set1_epi64x(0xFFFFFFFFFFFFFFFEull), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
-	printf("_mm_testz_si128(0, 0xFFFFFFFFFFFFFFFFull): %d\n", _mm_testz_si128(_mm_set1_epi64x(0), _mm_set1_epi64x(0xFFFFFFFFFFFFFFFFull)));
+  test_round();
+  test_blend();
+  test_cvte();
+  test_dp();
+  test_extract();
+  test_insert();
+  test_minmax();
+  test_misc();
+  test_test();
 }


### PR DESCRIPTION
These SIMD tests took an inordinately long amount of time to run because
compiling their very large functions took a long time. This PR reduces their
execution time by splitting up the functions, although they still take far too
long to run. Profiling indicates that most time is spent in the WebAssembly
Register Stackify pass in the LLVM backend.