### PR TITLE
Add OPTIMIZE_REVERSE_DEPS setting to skip input symbol scanning

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,15 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- Add new setting: OPTIMIZE_REVERSE_DEPS. This is enabled by default.  Can be
+  disabled in order to improve link times (by avoiding scanning input files for
+  symbols prior to linking).  Disabling this will cause all possible reverse
+  dependencies to be included, which for most large programs should not be an
+  issue.  For small programs (for example programs that don't use malloc,
+  disabling OPTIMIZE_REVERSE_DEPS is not recommended.
+  This option partially replaces the EMCC_ONLY_FORCED_STDLIBS environment
+  variable would also had the effect of skipping this scaning process.  For this
+  reason we now issue a deprecation warning if EMCC_ONLY_FORCED_STDLIBS is set.
 
 2.0.13: 01/19/2021
 ------------------

--- a/embuilder.py
+++ b/embuilder.py
@@ -29,14 +29,14 @@ SYSTEM_TASKS = list(SYSTEM_LIBRARIES.keys())
 SYSTEM_TASKS += ['struct_info']
 
 # Minimal subset of SYSTEM_TASKS used by CI systems to build enough to useful
+# TODO Re-add 'except' versions of libc++abi, libc++, and libunwind after the
+# new EH implementation is stablized
 MINIMAL_TASKS = [
     'libcompiler_rt',
     'libc',
     'libc++abi',
-    'libc++abi-except',
     'libc++abi-noexcept',
     'libc++',
-    'libc++-except',
     'libc++-noexcept',
     'libal',
     'libdlmalloc',
@@ -52,8 +52,7 @@ MINIMAL_TASKS = [
     'libc_rt_wasm',
     'struct_info',
     'libstandalonewasm',
-    'crt1',
-    'libunwind-except'
+    'crt1'
 ]
 
 USER_TASKS = [

--- a/src/settings.js
+++ b/src/settings.js
@@ -1682,6 +1682,13 @@ var IMPORTED_MEMORY = 0;
 // to loading split modules.
 var SPLIT_MODULE = 0;
 
+// When calculating reverse dependencies (dependecies on native functions
+// from JS functions) use the undefined symbols of the input objects files
+// to determine more precisely which ones to include.  Disabling this
+// will speed up link times, but will conservatively include possibly
+// unnecessary native functions.
+var OPTIMIZE_REVERSE_DEPS = 1;
+
 //===========================================
 // Internal, used for testing only, from here
 //===========================================

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4243,7 +4243,9 @@ int main() {
   })
   def test_only_force_stdlibs(self, env, fail):
     with env_modify(env):
-      self.run_process([EMXX, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'])
+      err = self.run_process([EMXX, path_from_root('tests', 'hello_libcxx.cpp'), '-s', 'WARN_ON_UNDEFINED_SYMBOLS=0'], stderr=PIPE).stderr
+      if 'EMCC_ONLY_FORCED_STDLIBS' in env:
+        self.assertContained('EMCC_ONLY_FORCED_STDLIBS is deprecated', err)
       if fail:
         output = self.expect_fail(config.NODE_JS + ['a.out.js'], stdout=PIPE)
         self.assertContained('missing function', output)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -17,6 +17,7 @@ from glob import iglob
 
 from . import shared, building, ports, config, utils
 from . import deps_info, tempfiles
+from . import diagnostics
 from tools.shared import mangle_c_symbol_name, demangle_c_symbol_name
 
 logger = logging.getLogger('system_libs')
@@ -1359,14 +1360,13 @@ def warn_on_unexported_main(symbolses):
         return
 
 
-def handle_reverse_deps(input_files, only_forced):
-  # If we are only doing forced stdlibs, then we don't know the actual
-  # symbols we need, and must assume all of deps_info must be exported.
-  # Note that this might cause warnings on exports that do not exist.
-  if only_forced:
-    for key, value in deps_info.deps_info.items():
-      for dep in value:
-        shared.Settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(dep))
+def handle_reverse_deps(input_files):
+  if not shared.Settings.OPTIMIZE_REVERSE_DEPS:
+    # When not optimzing we add all possible reverse dependencies rather
+    # than scanning the input files
+    for symbols in deps_info.deps_info.values():
+      for symbol in symbols:
+        shared.Settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(symbol))
     return
 
   added = set()
@@ -1411,7 +1411,13 @@ def calculate(input_files, cxx, forced):
   # the proper list of actually needed libraries, errors can occur. See below for how we must
   # export all the symbols in deps_info when using this option.
   only_forced = os.environ.get('EMCC_ONLY_FORCED_STDLIBS')
-  handle_reverse_deps(input_files, only_forced)
+  if only_forced:
+    # One of the purposes EMCC_ONLY_FORCED_STDLIBS was to skip the scanning
+    # of the input files for reverse dependencies.
+    diagnostics.warning('deprecated', 'EMCC_ONLY_FORCED_STDLIBS is deprecated.  Use `-nostdlib` and/or `-s OPTIMIZE_REVERSE_DEPS` depending on the desired result')
+    shared.Settings.OPTIMIZE_REVERSE_DEPS = 0
+
+  handle_reverse_deps(input_files)
 
   libs_to_link = []
   already_included = set()

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1363,7 +1363,7 @@ def handle_reverse_deps(input_files, only_forced):
   # If we are only doing forced stdlibs, then we don't know the actual
   # symbols we need, and must assume all of deps_info must be exported.
   # Note that this might cause warnings on exports that do not exist.
-  if only_forced and not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
+  if only_forced:
     for key, value in deps_info.deps_info.items():
       for dep in value:
         shared.Settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(dep))
@@ -1453,8 +1453,7 @@ def calculate(input_files, cxx, forced):
     add_library(system_libs_map[forced])
 
   if only_forced:
-    if not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
-      add_library(system_libs_map['libc_rt_wasm'])
+    add_library(system_libs_map['libc_rt_wasm'])
     add_library(system_libs_map['libcompiler_rt'])
   else:
     if shared.Settings.AUTO_NATIVE_LIBRARIES:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -572,9 +572,9 @@ class NoExceptLibrary(Library):
   @classmethod
   def variations(cls, **kwargs):
     combos = super(NoExceptLibrary, cls).variations()
+    # TODO Reenable 'wasm' option after the new EH implementation is stabilized
     return ([dict(eh_mode=exceptions.none, **combo) for combo in combos] +
-            [dict(eh_mode=exceptions.emscripten, **combo) for combo in combos] +
-            [dict(eh_mode=exceptions.wasm, **combo) for combo in combos])
+            [dict(eh_mode=exceptions.emscripten, **combo) for combo in combos])
 
   @classmethod
   def get_default_variation(cls, **kwargs):


### PR DESCRIPTION
Add OPTIMIZE_REVERSE_DEPS setting to skip input symbol scanning

When this option is enabled (the default) we scan input objects
using llvm-nm to get a conservative estimate of the required
reverse dependencies.

With this option disabled we are even more conservative and simply
include all reverse dependencies.

As a followup we can consider changing the default for certain opt
levels.

Fixes: #13409