### PR TITLE
Remove JS-only functions from deps_info.py

### DIFF
--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -49,7 +49,6 @@
 #       both here and in the JS compiler.
 
 deps_info = {
-  '$getTypeName': ['free'],
   'Mix_LoadWAV_RW': ['fileno'],
   'SDL_CreateRGBSurface': ['malloc', 'free'],
   'SDL_GL_GetProcAddress': ['emscripten_GetProcAddress'],
@@ -174,7 +173,6 @@ deps_info = {
   'emscripten_websocket_set_onmessage_callback_on_thread': ['malloc', 'free'],
   'emscripten_websocket_set_onopen_callback_on_thread': ['malloc', 'free'],
   'emscripten_wget_data': ['malloc', 'free'],
-  'formatString': ['strlen'],
   'freeaddrinfo': ['free'],
   'freelocale': ['free'],
   'freopen': ['free'],
@@ -219,7 +217,6 @@ deps_info = {
   'socket': ['htonl', 'htons', 'ntohs'],
   'socketpair': ['htons', 'ntohs'],
   'strerror': ['malloc', 'free'],
-  'stringToNewUTF8': ['malloc', 'free'],
   'syslog': ['malloc', 'htons', 'ntohs'],
   'timegm': ['_get_tzname', '_get_daylight', '_get_timezone', 'malloc', 'free'],
   'times': ['memset'],


### PR DESCRIPTION
I'm working on a test that will verify each of the entries in the
deps_info so that its impossible to becoming out-of-date or inaccruate.

This change is the first result of that.  These functions are JS-only
and not visible to native code.  There is no way to for them to be
referenced from native code and no way for them to show up in the output
of llvm-nm.