### PR TITLE
Convert _read_sockaddr/_write_sockaddr to JS-only functions

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2267,8 +2267,8 @@ LibraryManager.library = {
     return str;
   },
 
-  _read_sockaddr__deps: ['$Sockets', '_inet_ntop4_raw', '_inet_ntop6_raw', 'ntohs'],
-  _read_sockaddr: function (sa, salen) {
+  $readSockaddr__deps: ['$Sockets', '_inet_ntop4_raw', '_inet_ntop6_raw', 'ntohs'],
+  $readSockaddr: function (sa, salen) {
     // family / port offsets are common to both sockaddr_in and sockaddr_in6
     var family = {{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_family, 'i16') }}};
     var port = _ntohs({{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_port, 'i16', undefined, true) }}});
@@ -2300,8 +2300,8 @@ LibraryManager.library = {
 
     return { family: family, addr: addr, port: port };
   },
-  _write_sockaddr__deps: ['$Sockets', '_inet_pton4_raw', '_inet_pton6_raw'],
-  _write_sockaddr: function (sa, family, addr, port, addrlen) {
+  $writeSockaddr__deps: ['$Sockets', '_inet_pton4_raw', '_inet_pton6_raw'],
+  $writeSockaddr: function (sa, family, addr, port, addrlen) {
     switch (family) {
       case {{{ cDefine('AF_INET') }}}:
         addr = __inet_pton4_raw(addr);
@@ -2311,7 +2311,7 @@ LibraryManager.library = {
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_family, 'family', 'i16') }}};
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_addr.s_addr, 'addr', 'i32') }}};
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_port, '_htons(port)', 'i16') }}};
-        /* Use makeSetValue instead of memset to avoid adding memset dependency for all users of _write_sockaddr. */
+        /* Use makeSetValue instead of memset to avoid adding memset dependency for all users of writeSockaddr. */
         {{{ assert(C_STRUCTS.sockaddr_in.__size__ - C_STRUCTS.sockaddr_in.sin_zero == 8), '' }}}
         {{{ makeSetValue('sa', C_STRUCTS.sockaddr_in.sin_zero, '0', 'i64') }}};
         break;
@@ -2443,7 +2443,7 @@ LibraryManager.library = {
     return 0;
   },
 
-  getaddrinfo__deps: ['$Sockets', '$DNS', '_inet_pton4_raw', '_inet_ntop4_raw', '_inet_pton6_raw', '_inet_ntop6_raw', '_write_sockaddr'],
+  getaddrinfo__deps: ['$Sockets', '$DNS', '_inet_pton4_raw', '_inet_ntop4_raw', '_inet_pton6_raw', '_inet_ntop6_raw', '$writeSockaddr'],
   getaddrinfo__proxy: 'sync',
   getaddrinfo__sig: 'iiiii',
   getaddrinfo: function(node, service, hint, out) {
@@ -2471,7 +2471,7 @@ LibraryManager.library = {
         __inet_ntop6_raw(addr) :
         __inet_ntop4_raw(addr);
       sa = _malloc(salen);
-      errno = __write_sockaddr(sa, family, addr, port);
+      errno = writeSockaddr(sa, family, addr, port);
       assert(!errno);
 
       ai = _malloc({{{ C_STRUCTS.addrinfo.__size__ }}});
@@ -2615,9 +2615,9 @@ LibraryManager.library = {
     return 0;
   },
 
-  getnameinfo__deps: ['$Sockets', '$DNS', '_read_sockaddr'],
+  getnameinfo__deps: ['$Sockets', '$DNS', '$readSockaddr'],
   getnameinfo: function (sa, salen, node, nodelen, serv, servlen, flags) {
-    var info = __read_sockaddr(sa, salen);
+    var info = readSockaddr(sa, salen);
     if (info.errno) {
       return {{{ cDefine('EAI_FAMILY') }}};
     }

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -86,7 +86,6 @@ deps_info = {
   '_embind_register_std_string': ['free'],
   '_embind_register_std_wstring': ['free'],
   '_inet_ntop6_raw': ['ntohs'],
-  '_read_sockaddr': ['ntohs'],
   'alGetProcAddress': ['emscripten_GetAlProcAddress'],
   'alGetString': ['malloc', 'free'],
   'alcGetProcAddress': ['emscripten_GetAlcProcAddress'],


### PR DESCRIPTION
These function operator on JS objects and as such cannot be
called from native code.

As such is it also meaningless to include then in deps_info.py.
This is because only symbols referenced by native object files
make sense to appear in deps_info.py.  See #13431 for more on this.