### PR TITLE
Temporarily disable wasm EH build

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -29,14 +29,14 @@ SYSTEM_TASKS = list(SYSTEM_LIBRARIES.keys())
 SYSTEM_TASKS += ['struct_info']
 
 # Minimal subset of SYSTEM_TASKS used by CI systems to build enough to useful
+# TODO Re-add 'except' versions of libc++abi, libc++, and libunwind after the
+# new EH implementation is stablized
 MINIMAL_TASKS = [
     'libcompiler_rt',
     'libc',
     'libc++abi',
-    'libc++abi-except',
     'libc++abi-noexcept',
     'libc++',
-    'libc++-except',
     'libc++-noexcept',
     'libal',
     'libdlmalloc',
@@ -52,8 +52,7 @@ MINIMAL_TASKS = [
     'libc_rt_wasm',
     'struct_info',
     'libstandalonewasm',
-    'crt1',
-    'libunwind-except'
+    'crt1'
 ]
 
 USER_TASKS = [

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -572,9 +572,9 @@ class NoExceptLibrary(Library):
   @classmethod
   def variations(cls, **kwargs):
     combos = super(NoExceptLibrary, cls).variations()
+    # TODO Reenable 'wasm' option after the new EH implementation is stabilized
     return ([dict(eh_mode=exceptions.none, **combo) for combo in combos] +
-            [dict(eh_mode=exceptions.emscripten, **combo) for combo in combos] +
-            [dict(eh_mode=exceptions.wasm, **combo) for combo in combos])
+            [dict(eh_mode=exceptions.emscripten, **combo) for combo in combos])
 
   @classmethod
   def get_default_variation(cls, **kwargs):


### PR DESCRIPTION
The implementation for the new EH spec started landing in LLVM and
Binaryen recently, but it has not been well tested against building
Emscripten libraries yet. This disables wasm EH build temporarily; we
will re-enable it once the implementation is stabilized.