### PR TITLE
Set uname machine to reflect wasm architecture

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,7 @@ Current Trunk
 - System libraries are now compiled with debug info (`-g`).  This doesn't
   affect release builds (builds without `-g`) but allows DWARF debugging of
   types defined in system libraries such as C++ STL types (#13078).
+- uname machine field is now either wasm32 or wasm64 instead of x86-JS (#13440)
 
 2.0.14: 02/14/2021
 ------------------

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -792,7 +792,11 @@ var SyscallsLibrary = {
     copyString('nodename', 'emscripten');
     copyString('release', '1.0');
     copyString('version', '#1');
-    copyString('machine', 'x86-JS');
+#if MEMORY64 == 1
+    copyString('machine', 'wasm64');
+#else
+    copyString('machine', 'wasm32');
+#endif
     return 0;
   },
   __sys_mprotect__nothrow: true,

--- a/tests/core/test_uname.out
+++ b/tests/core/test_uname.out
@@ -3,4 +3,4 @@ sysname: Emscripten
 nodename: emscripten
 release: 1.0
 version: #1
-machine: x86-JS
+machine: wasm32


### PR DESCRIPTION
The uname machine is used by various libraries to determine the system architecture, such as "amd64" or "i386".  It would be more useful to use this to return the string "wasm32" (or "wasm64"), which is by far the most common string used to describe the architecture of a WebAssembly binary, and more useful and correct than the current "x86-JS".

Vaguely related to #13356