### PR TITLE
Remove unsed PROXIED_FUNCTION_SIGNATURES. NFC.

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -128,21 +128,6 @@ def update_settings_glue(metadata, DEBUG):
     # functions in the module.
     shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$readAsmConstArgs']
 
-    # Extract the list of function signatures that MAIN_THREAD_EM_ASM blocks in
-    # the compiled code have, each signature will need a proxy function invoker
-    # generated for it.
-    def read_proxied_function_signatures(asmConsts):
-      proxied_function_signatures = set()
-      for _, sigs, proxying_types in asmConsts.values():
-        for sig, proxying_type in zip(sigs, proxying_types):
-          if proxying_type == 'sync_on_main_thread_':
-            proxied_function_signatures.add(sig + '_sync')
-          elif proxying_type == 'async_on_main_thread_':
-            proxied_function_signatures.add(sig + '_async')
-      return list(proxied_function_signatures)
-
-    shared.Settings.PROXIED_FUNCTION_SIGNATURES = read_proxied_function_signatures(metadata['asmConsts'])
-
   shared.Settings.BINARYEN_FEATURES = metadata['features']
   if shared.Settings.RELOCATABLE:
     # When building relocatable output (e.g. MAIN_MODULE) the reported table

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -98,9 +98,6 @@ var PROFILING_FUNCS = 0;
 // Whether we are emitting a symbol map. You should not modify this.
 var EMIT_SYMBOL_MAP = 0;
 
-// tracks the list of EM_ASM signatures that are proxied between threads.
-var PROXIED_FUNCTION_SIGNATURES = [];
-
 // List of function explicitly exported by user on the command line.
 var USER_EXPORTED_FUNCTIONS = [];
 


### PR DESCRIPTION
As far as I can tell this is assigned to but never read from.  Its last
usage seems to have been removed in #7865.