### PR TITLE
Fix incorrect #ifdef in immintrin.h

### DIFF
--- a/system/include/compat/immintrin.h
+++ b/system/include/compat/immintrin.h
@@ -11,11 +11,11 @@
 #include <avxintrin.h>
 #endif
 
-#ifdef __SSE_4_2__
+#ifdef __SSE4_2__
 #include <nmmintrin.h>
 #endif
 
-#ifdef __SSE_4_1__
+#ifdef __SSE4_1__
 #include <smmintrin.h>
 #endif
 


### PR DESCRIPTION
These SSE4.1 and SSE4.2 definitions are defined respectively as `__SSE4_1__` and `__SSE4_2__`, see:
https://github.com/emscripten-core/emscripten/blob/2a9cef1671ede955b31a3569fbf5fd255e51113a/tools/shared.py#L499
https://github.com/emscripten-core/emscripten/blob/2a9cef1671ede955b31a3569fbf5fd255e51113a/tools/shared.py#L502

This fixes build failures for libraries that include only `immintrin.h` prior using these intrinsics, see for example:
<details>
  <summary>Details</summary>

```
[2/5] Compiling C object libspng.a.p/spng_spng.c.o
FAILED: libspng.a.p/spng_spng.c.o 
emcc -Ilibspng.a.p -I. -I.. -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -O3 -O3 -fno-rtti -fno-exceptions -mnontrapping-fptoint -msimd128 -munimplemented-simd128 -msse4.1 -DSPNG_SSE=4 -fPIC -DSPNG_STATIC -MD -MQ libspng.a.p/spng_spng.c.o -MF libspng.a.p/spng_spng.c.o.d -o libspng.a.p/spng_spng.c.o -c ../spng/spng.c
../spng/spng.c:4416:11: error: implicit declaration of function '_mm_blendv_epi8' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
   return _mm_blendv_epi8(e, t, c);
          ^
../spng/spng.c:4416:11: error: returning 'int' from a function with incompatible result type '__m128i' (aka '__i32x4')
   return _mm_blendv_epi8(e, t, c);
          ^~~~~~~~~~~~~~~~~~~~~~~~
2 errors generated.
emcc: error: '/emsdk/upstream/bin/clang -DEMSCRIPTEN -fignore-exceptions -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -Xclang -iwithsysroot/include/SDL -target wasm32-unknown-emscripten -D__EMSCRIPTEN_major__=2 -D__EMSCRIPTEN_minor__=0 -D__EMSCRIPTEN_tiny__=13 -D_LIBCPP_ABI_VERSION=2 -Dunix -D__unix -D__unix__ -Werror=implicit-function-declaration --sysroot=/emsdk/upstream/emscripten/cache/sysroot -D__SSE__=1 -D__SSE2__=1 -D__SSE3__=1 -D__SSSE3__=1 -D__SSE4_1__=1 -Xclang -iwithsysroot/include/compat -Ilibspng.a.p -I. -I.. -Xclang -fcolor-diagnostics -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=c99 -O3 -O3 -fno-rtti -fno-exceptions -mnontrapping-fptoint -msimd128 -munimplemented-simd128 -DSPNG_SSE=4 -fPIC -DSPNG_STATIC -MD -MQ libspng.a.p/spng_spng.c.o -MF libspng.a.p/spng_spng.c.o.d -c ../spng/spng.c -o libspng.a.p/spng_spng.c.o' failed (1)
ninja: build stopped: subcommand failed.
```
</details>