### PR TITLE
Avoid scalarization in _mm_madd_epi16

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -500,7 +500,7 @@ The following table highlights the availability and expected performance of diff
    * - _mm_loadu_si32
      - ❌ emulated with wasm_i32x4_make
    * - _mm_madd_epi16
-     - ❌ scalarized
+     - ✅ wasm_dot_s_i32x4_i16x8
    * - _mm_maskmoveu_si128
      - ❌ scalarized
    * - _mm_max_epi16

--- a/system/include/compat/emmintrin.h
+++ b/system/include/compat/emmintrin.h
@@ -669,20 +669,7 @@ _mm_avg_epu16(__m128i __a, __m128i __b)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_madd_epi16(__m128i __a, __m128i __b)
 {
-  // TODO: optimize
-  union {
-    signed short x[8];
-    __m128i m;
-  } src, src2;
-  union {
-    signed int x[4];
-    __m128i m;
-  } dst;
-  src.m = __a;
-  src2.m = __b;
-  for(int i = 0; i < 4; ++i)
-    dst.x[i] = src.x[i*2] * src2.x[i*2] + src.x[i*2+1] * src2.x[i*2+1];
-  return dst.m;
+  return (__m128i)__builtin_wasm_dot_s_i32x4_i16x8((__i16x8)__a, (__i16x8)__b);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))


### PR DESCRIPTION
The `i32x4.dot_i16x8_s` instruction was merged into the SIMD proposal with https://github.com/WebAssembly/simd/pull/127.

This instruction is already supported in Chrome stable. On the latest versions of Node, it can be tested with the `--wasm-simd-post-mvp` V8 flag. See for example:
```bash
$ cat >test.c <<EOL
#include <stdio.h>
#include <string.h>
#include <wasm_simd128.h>

void print128_num(v128_t var) {
  uint16_t val[8];
  memcpy(val, &var, sizeof(val));
  printf("%i %i %i %i %i %i %i %i\n",
         val[0], val[1], val[2], val[3],
         val[4], val[5], val[6], val[7]);
}

int main() {
  v128_t i = wasm_i16x8_splat(1);
  print128_num(__builtin_wasm_dot_s_i32x4_i16x8(i, i));
  return 0;
}
EOL
$ emcc -msimd128 test.c -otest.js
$ node -v
v15.8.0
$ node --experimental-wasm-simd --wasm-simd-post-mvp test.js
2 0 2 0 2 0 2 0
```