### PR TITLE
Add support for Module.dynamicLibraries in pthreads

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -439,6 +439,9 @@ var LibraryPThread = {
 #if USE_OFFSET_CONVERTER
         'wasmOffsetConverter': wasmOffsetConverter,
 #endif
+#if MAIN_MODULE
+        'dynamicLibraries': Module['dynamicLibraries'],
+#endif
       });
     },
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -101,6 +101,10 @@ this.onmessage = function(e) {
       Module['wasmModule'] = e.data.wasmModule;
 #endif // MINIMAL_RUNTIME
 
+#if MAIN_MODULE
+      Module['dynamicLibraries'] = e.data.dynamicLibraries;
+#endif
+
       {{{ makeAsmImportsAccessInPthread('wasmMemory') }}} = e.data.wasmMemory;
 
 #if LOAD_SOURCE_MAP

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8249,14 +8249,16 @@ NODEFS is no longer included by default; build with -lnodefs.js
         });
       ''')
 
-    self.dylink_test(r'''
+    self.dylink_test(
+      r'''
         #include <stdio.h>
         int side();
         int main() {
           printf("result is %d", side());
           return 0;
         }
-      ''', '''
+      ''',
+      r'''
         int side() { return 42; }
       ''',
       'result is 42',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8241,12 +8241,12 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('EXPORT_NAME', 'createMyModule')
 
     def post(filename):
-      shutil.move(filename, '{filename}.module.js')
-      create_test_file(filename, '''
+      shutil.move(filename, f'{filename}.module.js')
+      create_test_file(filename, f'''
         var createMyModule = require('./{filename}.module.js');
-        createMyModule({
+        createMyModule({{
           dynamicLibraries: ['liblib.so']
-        });
+        }});
       ''')
 
     self.dylink_test(

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1479,7 +1479,8 @@ int f() {
     create_test_file('side.c', r'''
       int side() { return 42; }
     ''')
-    self.run_process([EMCC,
+    self.run_process([
+      EMCC,
       '-pthread', '-Wno-experimental',
       '-s', 'SIDE_MODULE',
       '-o', 'side.wasm',

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1465,49 +1465,6 @@ int f() {
         '-s', 'ASSERTIONS=2'
       ])
 
-  def test_Module_dynamicLibraries_pthreads(self):
-    # test that Module.dynamicLibraries works with pthreads
-
-    create_test_file('main.c', r'''
-      #include <stdio.h>
-      int side();
-      int main() {
-        printf("%d", side());
-        return 0;
-      }
-    ''')
-    create_test_file('side.c', r'''
-      int side() { return 42; }
-    ''')
-    self.run_process([
-      EMCC,
-      '-pthread', '-Wno-experimental',
-      '-s', 'SIDE_MODULE',
-      '-o', 'side.wasm',
-      'side.c'
-    ])
-    self.run_process([
-        EMCC,
-        '-pthread', '-Wno-experimental',
-        '-s', 'PROXY_TO_PTHREAD',
-        '-s', 'EXIT_RUNTIME=1',
-        '-s', 'MODULARIZE=1',
-        '-s', 'EXPORT_NAME=createMyModule',
-        '-s', 'MAIN_MODULE',
-        '-o', 'main.js',
-        'main.c'
-    ])
-    create_test_file('test.js', '''
-      var createMyModule = require('./main.js');
-      createMyModule({
-        dynamicLibraries: ['side.wasm']
-      });
-    ''')
-
-    self.node_args += ['--experimental-wasm-threads', '--experimental-wasm-bulk-memory']
-    seen = self.run_js('test.js', assert_returncode=0)
-    self.assertContained(['42'], seen)
-
   def test_multidynamic_link(self):
     # Linking the same dynamic library in statically will error, normally, since we statically link
     # it, causing dupe symbols


### PR DESCRIPTION
Currently `Module.dynamicLibraries` is only accounted for in the main module.
This change makes pthreads aware of this property.

Add the value of `Module.dynamicLibraries` to the `'load'`'s `postMessage` to the pthread worker.