### PR TITLE
Fix Box2D benchmark compilation: don't assign a pointer to a bool

### DIFF
--- a/tests/third_party/box2d/Box2D/Collision/Shapes/b2ChainShape.h
+++ b/tests/third_party/box2d/Box2D/Collision/Shapes/b2ChainShape.h
@@ -95,8 +95,8 @@ inline b2ChainShape::b2ChainShape()
 	m_radius = b2_polygonRadius;
 	m_vertices = NULL;
 	m_count = 0;
-	m_hasPrevVertex = NULL;
-	m_hasNextVertex = NULL;
+	m_hasPrevVertex = false;
+	m_hasNextVertex = false;
 }
 
 #endif


### PR DESCRIPTION
Clang has started to warn/error on that apparently.