### PR TITLE
Correct glGetSynciv to place return value in values rather than length

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -543,3 +543,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Jinoh Kang <jinoh.kang.kr@gmail.com>
 * Jorge Prendes <jorge.prendes@gmail.com>
 * Alexey Shamrin <shamrin@gmail.com>
+* Akul Penugonda <akulvp@gmail.com>

--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -730,8 +730,10 @@ var LibraryWebGL2 = {
       return;
     }
     var ret = GLctx.getSyncParameter(GL.syncs[sync], pname);
-    {{{ makeSetValue('length', '0', 'ret', 'i32') }}};
-    if (ret !== null && length) {{{ makeSetValue('length', '0', '1', 'i32') }}}; // Report a single value outputted.
+    if (ret !== null) {
+      {{{ makeSetValue('values', '0', 'ret', 'i32') }}};
+      if (length) {{{ makeSetValue('length', '0', '1', 'i32') }}}; // Report a single value outputted.
+    }
   },
 
   glIsSync__sig: 'ii',


### PR DESCRIPTION
Per https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glGetSynciv.xhtml, glGetSynciv should be placing the returned parameter into "values", but this code places it into "length" which is possibly null, and overwritten on the next line. This PR fixes the issue, preventing a null pointer exception and allowing the correct value to be returned.