### PR TITLE
Optimize llvm-nm

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -390,7 +390,7 @@ def llvm_nm_multiple(files):
         break
       colon = results.rfind(':', i, nl)
       if colon >= 0 and results[colon + 1] == '\n': # New file start?
-        nm_cache[filename] = parse_symbols(results[file_start:i-1])
+        nm_cache[filename] = parse_symbols(results[file_start:i - 1])
         filename = results[i:colon].strip()
         file_start = colon + 2
       i = nl + 1

--- a/tools/building.py
+++ b/tools/building.py
@@ -362,6 +362,8 @@ def make_paths_absolute(f):
 # The results are populated in nm_cache
 def llvm_nm_multiple(files):
   with ToolchainProfiler.profile_block('llvm_nm_multiple'):
+    if len(files) == 0:
+      return []
     # Run llvm-nm on files that we haven't cached yet
     llvm_nm_files = [f for f in files if f not in nm_cache]
     cmd = [LLVM_NM] + llvm_nm_files

--- a/tools/building.py
+++ b/tools/building.py
@@ -365,7 +365,14 @@ def llvm_nm_multiple(files):
     # Run llvm-nm on files that we haven't cached yet
     llvm_nm_files = [f for f in files if f not in nm_cache]
     cmd = [LLVM_NM] + llvm_nm_files
-    results = run_process(cmd, stdout=PIPE, stderr=PIPE).stdout
+    results = run_process(cmd, stdout=PIPE, stderr=PIPE, check=False)
+
+    # If one or more of the input files cannot be processed, llvm-nm will return a non-zero error code, but it will still process and print
+    # out all the other files in order. So even if process return code is non zero, we should always look at what we got to stdout.
+    if results.returncode != 0:
+      logger.debug('Subcommand ' + ' '.join(cmd) + ' failed with return code ' + str(results.returncode) + '! (An input file was corrupt?)')
+
+    results = results.stdout
 
     # llvm-nm produces a single listing of form
     # file1.o:

--- a/tools/building.py
+++ b/tools/building.py
@@ -389,10 +389,10 @@ def llvm_nm_multiple(files):
       if nl < 0:
         break
       colon = results.rfind(':', i, nl)
-      if colon >= 0 and results[colon+1] == '\n': # New file start?
+      if colon >= 0 and results[colon + 1] == '\n': # New file start?
         nm_cache[filename] = parse_symbols(results[file_start:i-1])
         filename = results[i:colon].strip()
-        file_start = colon+2
+        file_start = colon + 2
       i = nl + 1
 
     nm_cache[filename] = parse_symbols(results[file_start:])

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1394,7 +1394,7 @@ def handle_reverse_deps(input_files):
       add_reverse_deps(need) # recurse to get deps of deps
 
   # Scan symbols
-  symbolses = building.parallel_llvm_nm([os.path.abspath(t) for t in input_files])
+  symbolses = building.llvm_nm_multiple([os.path.abspath(t) for t in input_files])
 
   warn_on_unexported_main(symbolses)
 


### PR DESCRIPTION
Optimize llvm-nm invocations from Emscripten. In python creating a multiprocessing pool is *extremely* slow, and can take 500ms-1 second. If there are only few files to llvm-nm, do those sequentially since a single llvm-nm only takes about 10-20ms.