### PR TITLE
Do not unroll loops in system libs

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -249,7 +249,7 @@ class Library(object):
 
   # A list of flags to pass to emcc.
   # The flags for the parent class is automatically inherited.
-  cflags = ['-Werror']
+  cflags = ['-Werror', '-fno-unroll-loops']
 
   # A list of directories to put in the include path when building.
   # This is a list of tuples of path components.


### PR DESCRIPTION
Code size had regressed and broken many of the metadce tests since loop
unrolling landed upstream in LLVM. To avoid propagating the increased code size
to users, this PR adds -fno-unroll-loops to all system lib builds rather than
updating the test expectations.