### PR TITLE
Allow usage of `argc` and `argv` when `main` is in a side module

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -136,7 +136,9 @@ def update_settings_glue(metadata, DEBUG):
     if shared.Settings.INITIAL_TABLE == -1:
       shared.Settings.INITIAL_TABLE = metadata['tableSize'] + 1
 
-  shared.Settings.MAIN_READS_PARAMS = metadata['mainReadsParams']
+  # When using dynamic linking the main function might be in a side module.
+  # To be safe assume they do take input parametes.
+  shared.Settings.MAIN_READS_PARAMS = metadata['mainReadsParams'] or shared.Settings.MAIN_MODULE
 
   # Store exports for Closure compiler to be able to track these as globals in
   # -s DECLARE_ASM_MODULE_EXPORTS=0 builds.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4521,6 +4521,30 @@ res64 - external 64\n''', header='''
                      header=header,
                      expected='success')
 
+  @needs_dlfcn
+  def test_dylink_argv_argc(self):
+    # Verify that argc and argv can be sent to main when main is in a side module
+
+    self.emcc_args += ['--extern-pre-js', 'pre.js']
+
+    create_test_file('pre.js', '''
+      var Module = { arguments: ['hello', 'world!'] }
+    ''')
+
+    self.dylink_test(
+      '', # main module is empty.
+      r'''
+      #include <stdio.h>
+      int main(int argc, char const *argv[]) {
+        printf("%d ", argc);
+        for (int i=1; i<argc; i++) printf("%s ", argv[i]);
+        printf("\n");
+        return 0;
+      }
+      ''',
+      expected='3 hello world!',
+      need_reverse=False)
+
   def test_random(self):
     src = r'''#include <stdlib.h>
 #include <stdio.h>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1465,47 +1465,6 @@ int f() {
         '-s', 'ASSERTIONS=2'
       ])
 
-  def test_side_module_main_argc_argv(self):
-    # Verify that argc and argv can be sent to main when main is in a side module
-
-    # A side module with a main that takes argc and argv.
-    create_test_file('side.c', r'''
-      #include <stdio.h>
-      int main(int argc, char const *argv[]) {
-        printf("%d ", argc);
-        for (int i=1; i<argc; i++) printf("%s ", argv[i]);
-        printf("\n");
-        return 0;
-      }
-      ''')
-    
-    create_test_file('main.c', '')
-
-    self.run_process([
-      EMCC,
-      '-o', 'side.wasm',
-      'side.c',
-      '-s', 'SIDE_MODULE=1'])
-    
-    self.run_process([
-      EMCC,
-      '-o', 'main.js',
-      'main.c',
-      '-s', 'MAIN_MODULE=1',
-      '-s', 'RUNTIME_LINKED_LIBS=[\'side.wasm\']',
-      '-s', 'MODULARIZE=1',
-      '-s', 'EXPORT_NAME=createMyModule'])
-
-    create_test_file('test.js', '''
-      var createMyModule = require('./main.js');
-      createMyModule({
-        arguments: ['hello', 'world!']
-      });
-      ''')
-
-    seen = self.run_js('test.js', assert_returncode=0)
-    self.assertContained(['3 hello world!'], seen)
-
   def test_multidynamic_link(self):
     # Linking the same dynamic library in statically will error, normally, since we statically link
     # it, causing dupe symbols

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1465,6 +1465,47 @@ int f() {
         '-s', 'ASSERTIONS=2'
       ])
 
+  def test_side_module_main_argc_argv(self):
+    # Verify that argc and argv can be sent to main when main is in a side module
+
+    # A side module with a main that takes argc and argv.
+    create_test_file('side.c', r'''
+      #include <stdio.h>
+      int main(int argc, char const *argv[]) {
+        printf("%d ", argc);
+        for (int i=1; i<argc; i++) printf("%s ", argv[i]);
+        printf("\n");
+        return 0;
+      }
+      ''')
+    
+    create_test_file('main.c', '')
+
+    self.run_process([
+      EMCC,
+      '-o', 'side.wasm',
+      'side.c',
+      '-s', 'SIDE_MODULE=1'])
+    
+    self.run_process([
+      EMCC,
+      '-o', 'main.js',
+      'main.c',
+      '-s', 'MAIN_MODULE=1',
+      '-s', 'RUNTIME_LINKED_LIBS=[\'side.wasm\']',
+      '-s', 'MODULARIZE=1',
+      '-s', 'EXPORT_NAME=createMyModule'])
+
+    create_test_file('test.js', '''
+      var createMyModule = require('./main.js');
+      createMyModule({
+        arguments: ['hello', 'world!']
+      });
+      ''')
+
+    seen = self.run_js('test.js', assert_returncode=0)
+    self.assertContained(['3 hello world!'], seen)
+
   def test_multidynamic_link(self):
     # Linking the same dynamic library in statically will error, normally, since we statically link
     # it, causing dupe symbols


### PR DESCRIPTION
When `main` is in a side module the main module assumes that `main` takes no arguments.
This results in the `main` in  the side module not being able to take any input arguments.
This change always enable `MAIN_READS_PARAMS` when building with dynamic linking.