### PR TITLE
Disallow passing --minify 0, --profiling, -s INLINING_LIMIT and -gsep…

### DIFF
--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -127,7 +127,7 @@ Options that are modified or new in *emcc* are listed below:
   - When linking, this is equivalent to :ref:`-g3 <emcc-g3>`.
 
 ``-gseparate-dwarf[=FILENAME]``
-  [same as -g3 if passed at compile time, otherwise applies at link]
+  [link]
   Preserve debug information, but in a separate file on the side. This is the
   same as ``-g``, but the main file will contain no debug info. Instead, debug
   info will be present in a file on the side, in ``FILENAME`` if provided,
@@ -175,7 +175,7 @@ Options that are modified or new in *emcc* are listed below:
 .. _emcc-profiling:
 
 ``--profiling``
-  [same as -g2 if passed at compile time, otherwise applies at link]
+  [link]
   Use reasonable defaults when emitting JavaScript to make the build readable but still useful for profiling. This sets ``-g2`` (preserve whitespace and function names) and may also enable optimizations that affect performance and otherwise might not be performed in ``-g2``.
 
 ``--profiling-funcs``
@@ -321,7 +321,7 @@ Options that are modified or new in *emcc* are listed below:
 .. _emcc-minify:
 
 ``--minify 0``
-  [same as -g1 if passed at compile time, otherwise applies at link]
+  [link]
   Identical to ``-g1``.
 
 ``--js-transform <cmd>``

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9970,3 +9970,18 @@ exec "$@"
     self.assertGreater(len(exports_linkable), 1000)
     self.assertIn('sendmsg', exports_linkable)
     self.assertNotIn('sendmsg', exports)
+
+  # Some build options that change the debug setting value should only be passed at link time. At compile time,
+  # one should pass -gX instead.
+  def test_link_time_debug_settings(self):
+    err = self.expect_fail([EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', 'a.o', '--profiling'])
+    self.assertContained('-profiling is a link time setting!', err)
+
+    err = self.expect_fail([EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', 'a.o', '-s', 'INLINING_LIMIT=10'])
+    self.assertContained('-s INLINING_LIMIT is a link time setting!', err)
+
+    err = self.expect_fail([EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', 'a.o', '--minify', '0'])
+    self.assertContained('--minify is a link time setting!', err)
+
+    err = self.expect_fail([EMCC, '-c', path_from_root('tests', 'hello_world.c'), '-o', 'a.o', '-gseparate-dwarf'])
+    self.assertContained('-gseparate-dwarf is a link time setting!', err)


### PR DESCRIPTION
Disallow passing --minify 0, --profiling, -s INLINING_LIMIT and -gseparate-dwarf at compile stage for their side effects of changing debug level (-g setting). These are link time only settings.