### PR TITLE
Allow character substitution of wasm symbol names

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -47,6 +47,9 @@ Current Trunk
   of ccache via emsdk, or from https://github.com/juj/ccache/tree/emscripten,
   and run explicitly with "ccache emcc ..." after installing, or automatically
   just with "emcc ..." after activating ccache via emsdk (#13498).
+- Added support to use a custom set of substitution characters . # and ? to
+  ease passing arrays of C symbols on the command line to ASYNCIFY_* settings.
+  (#13477)
 - Using EM_ASM and EM_JS in a side module will now result in an error (since
   this is not implemented yet).  This could effect users were previously
   inadvertently including (but not actually using) EM_ASM or EM_JS functions in

--- a/emcc.py
+++ b/emcc.py
@@ -627,6 +627,15 @@ def is_dash_s_for_emcc(args, i):
   return arg.isidentifier() and arg.isupper()
 
 
+def unmangle_symbols_from_cmdline(symbols):
+  def unmangle(x):
+    return x.replace('.', ' ').replace('#', '&').replace('?', ',')
+
+  if type(symbols) is list:
+    return [unmangle(x) for x in symbols]
+  return unmangle(x)
+
+
 def parse_s_args(args):
   settings_changes = []
   for i in range(len(args)):
@@ -1458,6 +1467,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_base',
                                              '_emscripten_stack_get_end',
                                              '_emscripten_stack_set_limits']
+
+    shared.Settings.ASYNCIFY_ADD = unmangle_symbols_from_cmdline(shared.Settings.ASYNCIFY_ADD)
+    shared.Settings.ASYNCIFY_REMOVE = unmangle_symbols_from_cmdline(shared.Settings.ASYNCIFY_REMOVE)
+    shared.Settings.ASYNCIFY_ONLY = unmangle_symbols_from_cmdline(shared.Settings.ASYNCIFY_ONLY)
 
     # SSEx is implemented on top of SIMD128 instruction set, but do not pass SSE flags to LLVM
     # so it won't think about generating native x86 SSE code.

--- a/emcc.py
+++ b/emcc.py
@@ -633,7 +633,7 @@ def unmangle_symbols_from_cmdline(symbols):
 
   if type(symbols) is list:
     return [unmangle(x) for x in symbols]
-  return unmangle(x)
+  return unmangle(symbols)
 
 
 def parse_s_args(args):

--- a/src/settings.js
+++ b/src/settings.js
@@ -719,6 +719,7 @@ var ASYNCIFY_STACK_SIZE = 4096;
 // to know you got this right), so this is not recommended unless you
 // really know what are doing, and need to optimize every bit of speed
 // and size.
+//
 // The names in this list are names from the WebAssembly Names section. The
 // wasm backend will emit those names in *human-readable* form instead of
 // typical C++ mangling. For example, you should write Struct::func()
@@ -730,7 +731,23 @@ var ASYNCIFY_STACK_SIZE = 4096;
 // changes which would mean a single list couldn't work for both -O0 and -O1
 // builds, etc.). You can inspect the wasm binary to look for the actual names,
 // either directly or using wasm-objdump or wasm-dis, etc.
+//
 // Simple '*' wildcard matching is supported.
+//
+// To avoid dealing with limitations in operating system shells or build system
+// escaping, the following substitutions can be made:
+// - ' ' -> '.',
+// - '&' -> '%',
+// - ',' -> '.'.
+//
+// That is, the function
+//    "foo(char const*, int&)" can be inputted as
+//    "foo(char.const*?.int%)" on the command line instead.
+//
+// Note: Whitespace is part of the function signature! I.e.
+//    "foo(char const *, int &)" will not match "foo(char const*, int&)", and
+// neither would "foo(const char*, int &)".
+//
 // [link]
 var ASYNCIFY_REMOVE = [];
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -737,7 +737,7 @@ var ASYNCIFY_STACK_SIZE = 4096;
 // To avoid dealing with limitations in operating system shells or build system
 // escaping, the following substitutions can be made:
 // - ' ' -> '.',
-// - '&' -> '%',
+// - '&' -> '#',
 // - ',' -> '.'.
 //
 // That is, the function

--- a/src/settings.js
+++ b/src/settings.js
@@ -738,11 +738,11 @@ var ASYNCIFY_STACK_SIZE = 4096;
 // escaping, the following substitutions can be made:
 // - ' ' -> '.',
 // - '&' -> '#',
-// - ',' -> '.'.
+// - ',' -> '?'.
 //
 // That is, the function
 //    "foo(char const*, int&)" can be inputted as
-//    "foo(char.const*?.int%)" on the command line instead.
+//    "foo(char.const*?.int#)" on the command line instead.
 //
 // Note: Whitespace is part of the function signature! I.e.
 //    "foo(char const *, int &)" will not match "foo(char const*, int&)", and

--- a/tests/browser/test_asyncify_tricky_function_sig.cpp
+++ b/tests/browser/test_asyncify_tricky_function_sig.cpp
@@ -1,0 +1,38 @@
+#include <stdio.h>
+#include <emscripten.h>
+
+volatile int x;
+
+int bar() { return 1; }
+
+__attribute__((noinline))
+int foo(const char *str, int &i)
+{
+  if (x == 1337) return bar(); // don't inline me
+  printf("foo %s\n", str);
+  emscripten_sleep(1);
+  printf("foo %d\n", i);
+  return 42;
+}
+
+__attribute__((noinline))
+int foo2()
+{
+  if (x == 1337) return bar(); // don't inline me
+  printf("foo2 1\n");
+  emscripten_sleep(1);
+  printf("foo2 2\n");
+  return 43;
+}
+
+int main()
+{
+  printf("main 1\n");
+  int j = 42;
+  const char *str = "hello";
+  int ret = foo(str, j);
+  printf("main %d\n", ret);
+  int ret2 = foo2();
+  printf("ret2 %d\n", ret2);
+  REPORT_RESULT(ret + ret2);
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3211,7 +3211,7 @@ window.close = function() {
       self.btest('browser/async.cpp', '1', args=['-O' + str(opts), '-g2', '-s', 'ASYNCIFY'])
 
   def test_asyncify_tricky_function_sig(self):
-    self.btest('browser/test_asyncify_tricky_function_sig.cpp', '1', args=['-s', 'ASYNCIFY_ONLY=[foo(char.const*?.int#),foo2()]', '-s', 'ASYNCIFY=1'])
+    self.btest('browser/test_asyncify_tricky_function_sig.cpp', '85', args=['-s', 'ASYNCIFY_ONLY=[foo(char.const*?.int#),foo2(),main,__original_main]', '-s', 'ASYNCIFY=1'])
 
   @requires_threads
   def test_async_in_pthread(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3210,6 +3210,9 @@ window.close = function() {
       print(opts)
       self.btest('browser/async.cpp', '1', args=['-O' + str(opts), '-g2', '-s', 'ASYNCIFY'])
 
+  def test_asyncify_tricky_function_sig(self):
+    self.btest('browser/test_asyncify_tricky_function_sig.cpp', '1', args=['-s', 'ASYNCIFY_ONLY=[foo(char.const*?.int#),foo2()]', '-s', 'ASYNCIFY=1'])
+
   @requires_threads
   def test_async_in_pthread(self):
     self.btest('browser/async.cpp', '1', args=['-s', 'ASYNCIFY', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-g'])


### PR DESCRIPTION
Allow character substitution of wasm symbol names to avoid working around complex string escaping issues in operating system shells and build systems.

Wasm toolchain compiled functions do not support name mangling. As result, the generated function names can contain difficult to deal with characters ` `, `&` and `,` (and maybe others).

When attempting to pass a complex signature to a function, such as `foo(char const*, int&)` to ASYNCIFY_ONLY/ASYNCIFY_ADD/ASYNCIFY_REMOVE, one might as a first try pass

```
emcc -s ASYNCIFY_ONLY=[foo(char const*, int&)] ...
```

However that has the problem that it passes the cmdline args `emcc`, `-s`, `ASYNCIFY_ONLY=[foo(char`, `const*,`, `int&)]`, `...` from the terminal (as one would expect is sensible). Then, adding quotes, one gets

```
emcc -s "ASYNCIFY_ONLY=[foo(char const*, int&)]" ...
```
On Windows, the command line interpreter consumes the quotes `"` to denote a single cmdline argument element, Emscripten will not see them, but will receive `emcc`, `-s`, `ASYNCIFY_ONLY=[foo(char const*, int&)]`, `...`.

However that has the issue with `,` character in the function name, since it is treated as JSON array element separator. Hence emcc suggests to quote the arguments. Hence, one gets
```
emcc -s "ASYNCIFY_ONLY=[\"foo(char const*, int&)\"]" ...
```
However that does not work either on Windows, because the `&` character works as a special delimiter character for issuing two commands from the command line. (`echo a & echo b` prints `a<newline>b`). On Windows `&` cannot be escaped with `\&`, nor with `&&`, but the escape symbol is... `"&"`. Hence one finally gets
```
emcc -s "ASYNCIFY_ONLY=[\"foo(char const*, int"&")\"]" ...
```
which actually works, just barely, and I have no idea why or how. Maybe Windows command line interpreter first short-circuit scans for `"&"` -> `&` without paying attention to any reasonable left-to-right or right-to-left `"` for any quote matching rules?.

However, when one takes that syntax to any kind of build system (CMake, Ninja, MinGW Makefiles, Tundra, ...), things just spectacularly fall apart again. One needs to at least escape `"` with `\"`, then double escape `\` with `\\`, leading into an utterly unreadable, and even worse, unmaintainable mess. And on top of that, the `"&"` escaping no longer seems to work, but Windows sees it again as a two command delimiter.

Finally, Linux and macOS have different terminal quoting rules, which leads to needing to start all of this from scratch on those OSes to come up with quoting and escaping rules that pass the terminals there. This can be observed e.g. at https://github.com/gabrielcuvillier/d3wasm/blob/ece7b9869eee5f4927b07efe3cf4146d6a562205/neo/CMakeLists.txt#L240 where two custom quoting rules have been devised for Windows vs Linux. CC @gabrielcuvillier 

To avoid all of these issues, this PR bluntly adds single character substitution rules to avoid needing to fight build system and OS shell expansion rules:
 - ` ` -> `.`
 - `&` -> `#`
 - `,` -> `?`

This way one can call on command line

```
emcc -s ASYNCIFY_ONLY=[foo(char.const*?.int#)] ...
```

No quotes, no escapes, no bs, and guaranteed to work cross platforms. Very unreadable, but still more readable than a sea of `\\\\""`s, and safe and less brittle. Developing custom tooling in build systems for automated single character substitution and unsubstitution will be at least three orders of magnitudes easier than multicharacter backslash-double-quote escape-unescape matching quotes searching substitution.

Are there other `-s` settings that take in raw wasm function names without mangling?