### PR TITLE
__sys_wait4: Return ENOSYS instead of aborting

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -770,7 +770,7 @@ var SyscallsLibrary = {
   },
   __sys_wait4__proxy: false,
   __sys_wait4: function(pid, wstart, options, rusage) {
-    abort('cannot wait on child processes');
+    return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
   },
   __sys_setdomainname__nothrow: true,
   __sys_setdomainname__proxy: false,


### PR DESCRIPTION
This allows the caller to handle the error more gracefully, and is consistent with how we handle other unsupported syscalls.
