### PR TITLE
No system lib multiprocessing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- Removed use of Python multiprocessing library because of stability issues. Added
+  new environment variable EM_PYTHON_MULTIPROCESSING=1 that can be enabled
+  to revert back to using Python multiprocessing. (#13493)
 - Binaryen now always inlines single-use functions. This should reduce code size
   and improve performance (#13744).
 

--- a/embuilder.py
+++ b/embuilder.py
@@ -15,6 +15,7 @@ running multiple build commands in parallel, confusion can occur).
 import argparse
 import logging
 import sys
+import time
 
 from tools import shared
 from tools import system_libs
@@ -112,6 +113,9 @@ def build_port(port_name):
 
 def main():
   global force
+
+  all_build_start_time = time.time()
+
   parser = argparse.ArgumentParser(description=__doc__,
                                    formatter_class=argparse.RawDescriptionHelpFormatter,
                                    epilog=get_help())
@@ -166,6 +170,7 @@ def main():
     print('Building targets: %s' % ' '.join(tasks))
   for what in tasks:
     logger.info('building and verifying ' + what)
+    start_time = time.time()
     if what in SYSTEM_LIBRARIES:
       library = SYSTEM_LIBRARIES[what]
       if force:
@@ -260,7 +265,13 @@ def main():
       logger.error('unfamiliar build target: ' + what)
       return 1
 
-    logger.info('...success')
+    time_taken = time.time() - start_time
+    logger.info('...success. Took %s(%.2fs)' % (('%02d:%02d mins ' % (time_taken // 60, time_taken % 60) if time_taken >= 60 else ''), time_taken))
+
+  if len(tasks) > 1:
+    all_build_time_taken = time.time() - all_build_start_time
+    logger.info('Built %d targets in %s(%.2fs)' % (len(tasks), ('%02d:%02d mins ' % (all_build_time_taken // 60, all_build_time_taken % 60) if all_build_time_taken >= 60 else ''), all_build_time_taken))
+
   return 0
 
 

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -791,7 +791,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
                   configure_args=[], make=['make'], make_args=None,
                   env_init={}, cache_name_extra='', native=False):
     if make_args is None:
-      make_args = ['-j', str(building.get_num_cores())]
+      make_args = ['-j', str(shared.get_num_cores())]
 
     build_dir = self.get_build_dir()
     output_dir = self.get_dir()

--- a/tools/building.py
+++ b/tools/building.py
@@ -3,7 +3,6 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-import atexit
 import json
 import logging
 import os

--- a/tools/building.py
+++ b/tools/building.py
@@ -12,7 +12,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from subprocess import STDOUT, PIPE
+from subprocess import PIPE
 
 from . import diagnostics
 from . import response_file
@@ -79,6 +79,7 @@ def extract_archive_contents(archive_files):
   archive_results = shared.run_multiple_processes([[LLVM_AR, 't', a] for a in archive_files], pipe_stdout=True)
 
   unpack_temp_dir = tempfile.mkdtemp('_archive_contents', 'emscripten_temp_')
+
   def clean_at_exit():
     try_delete(unpack_temp_dir)
   shared.atexit.register(clean_at_exit)
@@ -110,7 +111,7 @@ def extract_archive_contents(archive_files):
   for a in archive_contents:
     missing_contents = [x for x in a['o_files'] if not os.path.exists(x)]
     if missing_contents:
-      exit_with_error('llvm-ar failed to extract file(s) ' + str(missing_contents) + ' from archive file ' + f + '! Error:' + str(proc.stdout))
+      exit_with_error('llvm-ar failed to extract file(s) ' + str(missing_contents) + ' from archive file ' + f + '!')
 
   return archive_contents
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -229,7 +229,6 @@ def llvm_nm_multiple(files):
   with ToolchainProfiler.profile_block('llvm_nm_multiple'):
     if len(files) == 0:
       return []
-
     # Run llvm-nm only files that we haven't cached yet
     llvm_nm_files = [f for f in files if f not in nm_cache]
 
@@ -246,7 +245,7 @@ def llvm_nm_multiple(files):
       for i in range(len(results)):
         nm_cache[a_files[i]] = parse_symbols(results[i])
 
-    # Issue a single call for multiple .o files
+    # Issue a single batch call for multiple .o files
     if len(o_files) > 0:
       cmd = [LLVM_NM] + o_files
       cmd = get_command_with_possible_response_file(cmd)

--- a/tools/building.py
+++ b/tools/building.py
@@ -6,7 +6,6 @@
 import atexit
 import json
 import logging
-import multiprocessing
 import os
 import re
 import shlex
@@ -36,7 +35,6 @@ from .utils import WINDOWS
 logger = logging.getLogger('building')
 
 #  Building
-multiprocessing_pool = None
 binaryen_checked = False
 
 EXPECTED_BINARYEN_VERSION = 100
@@ -119,15 +117,6 @@ def extract_archive_contents(archive_file):
   }
 
 
-def g_multiprocessing_initializer(*args):
-  for item in args:
-    (key, value) = item.split('=', 1)
-    if key == 'EMCC_POOL_CWD':
-      os.chdir(value)
-    else:
-      os.environ[key] = value
-
-
 def unique_ordered(values):
   """return a list of unique values in an input list, without changing order
   (list(set(.)) would change order randomly).
@@ -150,74 +139,6 @@ def clear():
   nm_cache.clear()
   ar_contents.clear()
   _is_ar_cache.clear()
-
-
-def get_num_cores():
-  return int(os.environ.get('EMCC_CORES', multiprocessing.cpu_count()))
-
-
-# Multiprocessing pools are very slow to build up and tear down, and having
-# several pools throughout the application has a problem of overallocating
-# child processes. Therefore maintain a single centralized pool that is shared
-# between all pooled task invocations.
-def get_multiprocessing_pool():
-  global multiprocessing_pool
-  if not multiprocessing_pool:
-    cores = get_num_cores()
-
-    # If running with one core only, create a mock instance of a pool that does not
-    # actually spawn any new subprocesses. Very useful for internal debugging.
-    if cores == 1:
-      class FakeMultiprocessor(object):
-        def map(self, func, tasks, *args, **kwargs):
-          results = []
-          for t in tasks:
-            results += [func(t)]
-          return results
-
-        def map_async(self, func, tasks, *args, **kwargs):
-          class Result:
-            def __init__(self, func, tasks):
-              self.func = func
-              self.tasks = tasks
-
-            def get(self, timeout):
-              results = []
-              for t in tasks:
-                results += [func(t)]
-              return results
-
-          return Result(func, tasks)
-
-      multiprocessing_pool = FakeMultiprocessor()
-    else:
-      child_env = [
-        # Multiprocessing pool children must have their current working
-        # directory set to a safe path that is guaranteed not to die in
-        # between of executing commands, or otherwise the pool children will
-        # have trouble spawning subprocesses of their own.
-        'EMCC_POOL_CWD=' + path_from_root(),
-        # Multiprocessing pool children can't spawn their own linear number of
-        # children, that could cause a quadratic amount of spawned processes.
-        'EMCC_CORES=1'
-      ]
-      multiprocessing_pool = multiprocessing.Pool(processes=cores, initializer=g_multiprocessing_initializer, initargs=child_env)
-
-      def close_multiprocessing_pool():
-        global multiprocessing_pool
-        try:
-          # Shut down the pool explicitly, because leaving that for Python to do at process shutdown is buggy and can generate
-          # noisy "WindowsError: [Error 5] Access is denied" spam which is not fatal.
-          multiprocessing_pool.terminate()
-          multiprocessing_pool.join()
-          multiprocessing_pool = None
-        except OSError as e:
-          # Mute the "WindowsError: [Error 5] Access is denied" errors, raise all others through
-          if not (sys.platform.startswith('win') and isinstance(e, WindowsError) and e.winerror == 5):
-            raise
-      atexit.register(close_multiprocessing_pool)
-
-  return multiprocessing_pool
 
 
 # .. but for Popen, we cannot have doublequotes, so provide functionality to
@@ -358,46 +279,6 @@ def llvm_nm(file):
   return llvm_nm_multiple([file])[0]
 
 
-def read_link_inputs(files):
-  with ToolchainProfiler.profile_block('read_link_inputs'):
-    # Before performing the link, we need to look at each input file to determine which symbols
-    # each of them provides. Do this in multiple parallel processes.
-    archive_names = [] # .a files passed in to the command line to the link
-    object_names = [] # .o/.bc files passed in to the command line to the link
-    for f in files:
-      absolute_path_f = make_paths_absolute(f)
-
-      if absolute_path_f not in ar_contents and is_ar(absolute_path_f):
-        archive_names.append(absolute_path_f)
-      elif absolute_path_f not in nm_cache and is_bitcode(absolute_path_f):
-        object_names.append(absolute_path_f)
-
-    # Archives contain objects, so process all archives first in parallel to obtain the object files in them.
-    pool = get_multiprocessing_pool()
-    object_names_in_archives = pool.map(extract_archive_contents, archive_names)
-
-    def clean_temporary_archive_contents_directory(directory):
-      def clean_at_exit():
-        try_delete(directory)
-      if directory:
-        atexit.register(clean_at_exit)
-
-    for n in range(len(archive_names)):
-      if object_names_in_archives[n]['returncode'] != 0:
-        raise Exception('llvm-ar failed on archive ' + archive_names[n] + '!')
-      ar_contents[archive_names[n]] = object_names_in_archives[n]['files']
-      clean_temporary_archive_contents_directory(object_names_in_archives[n]['dir'])
-
-    for o in object_names_in_archives:
-      for f in o['files']:
-        if f not in nm_cache:
-          object_names.append(f)
-
-    # Next, extract symbols from all object files (either standalone or inside archives we just extracted)
-    # The results are not used here directly, but populated to llvm-nm cache structure.
-    llvm_nm_multiple(object_names)
-
-
 def llvm_backend_args():
   # disable slow and relatively unimportant optimization passes
   args = ['-combiner-global-alias-analysis=false']
@@ -425,11 +306,7 @@ def llvm_backend_args():
 
 
 def link_to_object(linker_inputs, target):
-  # link using lld unless LTO is requested (lld can't output LTO/bitcode object files).
-  if not Settings.LTO:
-    link_lld(linker_inputs + ['--relocatable'], target)
-  else:
-    link_bitcode(linker_inputs, target)
+  link_lld(linker_inputs + ['--relocatable'], target)
 
 
 def link_llvm(linker_inputs, target):
@@ -555,144 +432,6 @@ def link_lld(args, target, external_symbol_list=None):
 
   cmd = get_command_with_possible_response_file(cmd)
   check_call(cmd)
-
-
-def link_bitcode(files, target, force_archive_contents=False):
-  # "Full-featured" linking: looks into archives (duplicates lld functionality)
-  actual_files = []
-  # Tracking unresolveds is necessary for .a linking, see below.
-  # Specify all possible entry points to seed the linking process.
-  # For a simple application, this would just be "main".
-  unresolved_symbols = set([func[1:] for func in Settings.EXPORTED_FUNCTIONS])
-  resolved_symbols = set()
-  # Paths of already included object files from archives.
-  added_contents = set()
-  has_ar = False
-  for f in files:
-    if not f.startswith('-'):
-      has_ar = has_ar or is_ar(make_paths_absolute(f))
-
-  # If we have only one archive or the force_archive_contents flag is set,
-  # then we will add every object file we see, regardless of whether it
-  # resolves any undefined symbols.
-  force_add_all = len(files) == 1 or force_archive_contents
-
-  # Considers an object file for inclusion in the link. The object is included
-  # if force_add=True or if the object provides a currently undefined symbol.
-  # If the object is included, the symbol tables are updated and the function
-  # returns True.
-  def consider_object(f, force_add=False):
-    new_symbols = llvm_nm(f)
-    # Check if the object was valid according to llvm-nm. It also accepts
-    # native object files.
-    if not new_symbols.is_valid_for_nm():
-      diagnostics.warning('emcc', 'object %s is not valid according to llvm-nm, cannot link', f)
-      return False
-    # Check the object is valid for us, and not a native object file.
-    if not is_bitcode(f):
-      exit_with_error('unknown file type: %s', f)
-    provided = new_symbols.defs.union(new_symbols.commons)
-    do_add = force_add or not unresolved_symbols.isdisjoint(provided)
-    if do_add:
-      logger.debug('adding object %s to link (forced: %d)' % (f, force_add))
-      # Update resolved_symbols table with newly resolved symbols
-      resolved_symbols.update(provided)
-      # Update unresolved_symbols table by adding newly unresolved symbols and
-      # removing newly resolved symbols.
-      unresolved_symbols.update(new_symbols.undefs.difference(resolved_symbols))
-      unresolved_symbols.difference_update(provided)
-      actual_files.append(f)
-    return do_add
-
-  # Traverse a single archive. The object files are repeatedly scanned for
-  # newly satisfied symbols until no new symbols are found. Returns true if
-  # any object files were added to the link.
-  def consider_archive(f, force_add):
-    added_any_objects = False
-    loop_again = True
-    logger.debug('considering archive %s' % (f))
-    contents = ar_contents[f]
-    while loop_again: # repeatedly traverse until we have everything we need
-      loop_again = False
-      for content in contents:
-        if content in added_contents:
-          continue
-        # Link in the .o if it provides symbols, *or* this is a singleton archive (which is
-        # apparently an exception in gcc ld)
-        if consider_object(content, force_add=force_add):
-          added_contents.add(content)
-          loop_again = True
-          added_any_objects = True
-    logger.debug('done running loop of archive %s' % (f))
-    return added_any_objects
-
-  read_link_inputs([x for x in files if not x.startswith('-')])
-
-  # Rescan a group of archives until we don't find any more objects to link.
-  def scan_archive_group(group):
-    loop_again = True
-    logger.debug('starting archive group loop')
-    while loop_again:
-      loop_again = False
-      for archive in group:
-        if consider_archive(archive, force_add=False):
-          loop_again = True
-    logger.debug('done with archive group loop')
-
-  current_archive_group = None
-  in_whole_archive = False
-  for f in files:
-    absolute_path_f = make_paths_absolute(f)
-    if f.startswith('-'):
-      if f in ['--start-group', '-(']:
-        assert current_archive_group is None, 'Nested --start-group, missing --end-group?'
-        current_archive_group = []
-      elif f in ['--end-group', '-)']:
-        assert current_archive_group is not None, '--end-group without --start-group'
-        scan_archive_group(current_archive_group)
-        current_archive_group = None
-      elif f in ['--whole-archive', '-whole-archive']:
-        in_whole_archive = True
-      elif f in ['--no-whole-archive', '-no-whole-archive']:
-        in_whole_archive = False
-      else:
-        # Command line flags should already be vetted by the time this method
-        # is called, so this is an internal error
-        assert False, 'unsupported link flag: ' + f
-    elif is_ar(absolute_path_f):
-      # Extract object files from ar archives, and link according to gnu ld semantics
-      # (link in an entire .o from the archive if it supplies symbols still unresolved)
-      consider_archive(absolute_path_f, in_whole_archive or force_add_all)
-      # If we're inside a --start-group/--end-group section, add to the list
-      # so we can loop back around later.
-      if current_archive_group is not None:
-        current_archive_group.append(absolute_path_f)
-    elif is_bitcode(absolute_path_f):
-      if has_ar:
-        consider_object(f, force_add=True)
-      else:
-        # If there are no archives then we can simply link all valid object
-        # files and skip the symbol table stuff.
-        actual_files.append(f)
-    else:
-      exit_with_error('unknown file type: %s', f)
-
-  # We have to consider the possibility that --start-group was used without a matching
-  # --end-group; GNU ld permits this behavior and implicitly treats the end of the
-  # command line as having an --end-group.
-  if current_archive_group:
-    logger.debug('--start-group without matching --end-group, rescanning')
-    scan_archive_group(current_archive_group)
-    current_archive_group = None
-
-  try_delete(target)
-
-  # Finish link
-  # tolerate people trying to link a.so a.so etc.
-  actual_files = unique_ordered(actual_files)
-
-  logger.debug('emcc: linking: %s to %s', actual_files, target)
-  link_llvm(actual_files, target)
 
 
 def get_command_with_possible_response_file(cmd):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -144,7 +144,7 @@ def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp
             # then look again if any process has completed.
             try:
               out, err = processes[0][1].communicate(0.2)
-              return (0, out, err)
+              return (0, out.decode('UTF-8') if out else '', err.decode('UTF-8') if err else '')
             except subprocess.TimeoutExpired:
               pass
 
@@ -152,12 +152,12 @@ def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp
         idx, finished_process = processes[j]
         del processes[j]
         if pipe_stdout:
-          std_outs += [(idx, out.decode('UTF-8'))]
+          std_outs += [(idx, out)]
         if check and finished_process.returncode != 0:
           if out:
-            logger.info(out.decode('UTF-8'))
+            logger.info(out)
           if err:
-            logger.error(err.decode('UTF-8'))
+            logger.error(err)
           raise Exception('Subprocess %d/%d failed with return code %d! (cmdline: %s)' % (idx + 1, len(commands), finished_process.returncode, shlex_join(commands[idx])))
         num_completed += 1
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -25,7 +25,7 @@ if sys.version_info < (3, 6):
 
 from .toolchain_profiler import ToolchainProfiler
 from .tempfiles import try_delete
-from .utils import path_from_root, exit_with_error, safe_ensure_dirs, WINDOWS
+from .utils import path_from_root, exit_with_error, safe_ensure_dirs, WINDOWS, LINUX
 from . import cache, tempfiles, colored_logger
 from . import diagnostics
 from . import config
@@ -37,6 +37,9 @@ DEBUG_SAVE = DEBUG or int(os.environ.get('EMCC_DEBUG_SAVE', '0'))
 EXPECTED_NODE_VERSION = (4, 1, 1)
 EXPECTED_LLVM_VERSION = "13.0"
 PYTHON = sys.executable
+
+# Used only on Linux
+multiprocessing_pool = None
 
 # can add  %(asctime)s  to see timestamps
 logging.basicConfig(format='%(name)s:%(levelname)s: %(message)s',
@@ -100,37 +103,29 @@ def get_num_cores():
   return int(os.environ.get('EMCC_CORES', os.cpu_count()))
 
 
-multiprocessing_pool = None
-
-def get_multiprocessing_pool():
-  import multiprocessing
-  global multiprocessing_pool
-  if multiprocessing_pool:
-    return multiprocessing_pool
-  multiprocessing_pool = multiprocessing.Pool(processes=get_num_cores())
-  return multiprocessing_pool
-
-
 def mp_run_process(command_tuple):
   cmd, env, route_stdout_to_temp_files_suffix, pipe_stdout, check, cwd = command_tuple
   std_out = temp_files.get(route_stdout_to_temp_files_suffix) if route_stdout_to_temp_files_suffix else (subprocess.PIPE if pipe_stdout else None)
   ret = std_out.name if route_stdout_to_temp_files_suffix else None
   proc = subprocess.Popen(cmd, stdout=std_out, stderr=subprocess.PIPE if pipe_stdout else None, env=env, cwd=cwd)
-  out, err = proc.communicate()
+  out, _ = proc.communicate()
   if pipe_stdout:
     ret = out.decode('UTF-8')
   return ret
 
-
-def run_multiple_processes_multiprocessing(commands, env, route_stdout_to_temp_files_suffix, pipe_stdout, check, cwd):
-  return get_multiprocessing_pool().map(mp_run_process, [(cmd, env, route_stdout_to_temp_files_suffix, pipe_stdout, check, cwd) for cmd in commands], chunksize=1)
 
 # Runs multiple subprocess commands.
 # bool 'check': If True (default), raises an exception if any of the subprocesses failed with a nonzero exit code.
 # string 'route_stdout_to_temp_files_suffix': if not None, all stdouts are instead written to files, and an array of filenames is returned.
 # bool 'pipe_stdout': If True, an array of stdouts is returned, for each subprocess.
 def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp_files_suffix=None, pipe_stdout=False, check=True, cwd=None):
-  return run_multiple_processes_multiprocessing(commands, env, route_stdout_to_temp_files_suffix, pipe_stdout, check, cwd)
+  # Spawning multiple processes on Linux is slower without multiprocessing pool. On Windows and macOS, not using multiprocessing pool is faster.
+  if LINUX:
+    import multiprocessing
+    global multiprocessing_pool
+    if not multiprocessing_pool:
+      multiprocessing_pool = multiprocessing.Pool(processes=get_num_cores())
+    return multiprocessing_pool.map(mp_run_process, [(cmd, env, route_stdout_to_temp_files_suffix, pipe_stdout, check, cwd) for cmd in commands], chunksize=1)
 
   std_outs = []
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -176,7 +176,7 @@ def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp
                 if i < len(commands):
                   launch_new_process()
                 out, err = processes[j][1].communicate()
-                return (j, '', '')
+                return (j, out.decode('UTF-8') if out else '', err.decode('UTF-8') if err else '')
               j += 1
             # All processes still running; wait a short while for the first (oldest) process to finish,
             # then look again if any process has completed.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -105,7 +105,7 @@ def get_num_cores():
 # bool 'check': If True (default), raises an exception if any of the subprocesses failed with a nonzero exit code.
 # string 'route_stdout_to_temp_files_suffix': if not None, all stdouts are instead written to files, and an array of filenames is returned.
 # bool 'pipe_stdout': If True, an array of stdouts is returned, for each subprocess.
-def run_multiple_processes(commands, child_env=None, route_stdout_to_temp_files_suffix=None, pipe_stdout=False, check=True, cwd=None):
+def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp_files_suffix=None, pipe_stdout=False, check=True, cwd=None):
   std_outs = []
 
   # TODO: Experiment with registering a signal handler here to see if that helps with Ctrl-C locking up the command prompt
@@ -126,7 +126,7 @@ def run_multiple_processes(commands, child_env=None, route_stdout_to_temp_files_
         std_out = temp_files.get(route_stdout_to_temp_files_suffix) if route_stdout_to_temp_files_suffix else (subprocess.PIPE if pipe_stdout else None)
         if DEBUG:
           logger.debug('Running subprocess %d/%d: %s' % (end + 1, len(commands), ' '.join(commands[end])))
-        processes += [subprocess.Popen(commands[end], stdout=std_out, env=child_env if child_env else os.environ.copy(), cwd=cwd)]
+        processes += [subprocess.Popen(commands[end], stdout=std_out, env=env, cwd=cwd)]
         if route_stdout_to_temp_files_suffix:
           std_outs += [std_out.name]
         end += 1

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -25,7 +25,7 @@ if sys.version_info < (3, 6):
 
 from .toolchain_profiler import ToolchainProfiler
 from .tempfiles import try_delete
-from .utils import path_from_root, exit_with_error, safe_ensure_dirs, WINDOWS, LINUX
+from .utils import path_from_root, exit_with_error, safe_ensure_dirs, WINDOWS
 from . import cache, tempfiles, colored_logger
 from . import diagnostics
 from . import config

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -145,7 +145,7 @@ def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp
             try:
               out, err = processes[0][1].communicate(0.2)
               return (0, out, err)
-            except TimeoutExpired:
+            except subprocess.TimeoutExpired:
               pass
 
         j, out, err = get_finished_process()

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -111,7 +111,7 @@ def run_multiple_processes(commands, child_env=None, route_stdout_to_temp_files_
   #   sys.exit(1)
   # signal.signal(signal.SIGINT, signal_handler)
 
-  with ToolchainProfiler.profile_block('parallel_run_js_optimizers'):
+  with ToolchainProfiler.profile_block('run_multiple_processes'):
     processes = []
     start = 0
     end = 0

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -130,7 +130,7 @@ def run_multiple_processes(commands, child_env=None, route_stdout_to_temp_files_
         # Too many commands running in parallel, wait for one to finish.
         out, err = processes[start].communicate()
         if pipe_stdout:
-          std_outs += out.decode('UTF-8')
+          std_outs += [out.decode('UTF-8')]
         if check and processes[start].returncode != 0:
           if out:
             logger.info(out.decode('UTF-8'))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -123,16 +123,21 @@ def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp
     temp_files = configuration.get_temp_files()
     i = 0
     num_completed = 0
+
+    def launch_new_process():
+      nonlocal processes, std_outs, i
+      std_out = temp_files.get(route_stdout_to_temp_files_suffix) if route_stdout_to_temp_files_suffix else (subprocess.PIPE if pipe_stdout else None)
+      if DEBUG:
+        logger.debug('Running subprocess %d/%d: %s' % (i + 1, len(commands), ' '.join(commands[i])))
+      processes += [(i, subprocess.Popen(commands[i], stdout=std_out, stderr=subprocess.PIPE if pipe_stdout else None, env=env, cwd=cwd))]
+      if route_stdout_to_temp_files_suffix:
+        std_outs += [(i, std_out.name)]
+      i += 1
+
     while num_completed < len(commands):
       if i < len(commands) and len(processes) < num_parallel_processes:
         # Not enough parallel processes running, spawn a new one.
-        std_out = temp_files.get(route_stdout_to_temp_files_suffix) if route_stdout_to_temp_files_suffix else (subprocess.PIPE if pipe_stdout else None)
-        if DEBUG:
-          logger.debug('Running subprocess %d/%d: %s' % (i + 1, len(commands), ' '.join(commands[i])))
-        processes += [(i, subprocess.Popen(commands[i], stdout=std_out, stderr=subprocess.PIPE if pipe_stdout else None, env=env, cwd=cwd))]
-        if route_stdout_to_temp_files_suffix:
-          std_outs += [(i, std_out.name)]
-        i += 1
+        launch_new_process()
       else:
         # Not spawning a new process (Too many commands running in parallel, or no commands left): find if a process has finished.
         def get_finished_process():
@@ -140,6 +145,9 @@ def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp
             j = 0
             while j < len(processes):
               if processes[j][1].poll() is not None:
+                # Immediately launch the next process to maximize utilization
+                if i < len(commands):
+                  launch_new_process()
                 out, err = processes[j][1].communicate()
                 return (j, '', '')
               j += 1

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -97,8 +97,7 @@ def run_process(cmd, check=True, input=None, *args, **kw):
 
 
 def get_num_cores():
-  import multiprocessing
-  return int(os.environ.get('EMCC_CORES', multiprocessing.cpu_count()))
+  return int(os.environ.get('EMCC_CORES', os.cpu_count()))
 
 
 # Runs multiple subprocess commands.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -106,10 +106,10 @@ def run_multiple_processes(commands, child_env=None, route_stdout_to_temp_files_
 
   # TODO: Experiment with registering a signal handler here to see if that helps with Ctrl-C locking up the command prompt
   # when multiple child processes have been spawned.
-  #import signal
-  #def signal_handler(sig, frame):
-  #  sys.exit(1)
-  #signal.signal(signal.SIGINT, signal_handler)
+  # import signal
+  # def signal_handler(sig, frame):
+  #   sys.exit(1)
+  # signal.signal(signal.SIGINT, signal_handler)
 
   with ToolchainProfiler.profile_block('parallel_run_js_optimizers'):
     processes = []

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -107,6 +107,9 @@ def get_num_cores():
 def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp_files_suffix=None, pipe_stdout=False, check=True, cwd=None):
   std_outs = []
 
+  if route_stdout_to_temp_files_suffix and pipe_stdout:
+    raise Exception('Cannot simultaneously pipe stdout to file and a string! Choose one or the other.')
+
   # TODO: Experiment with registering a signal handler here to see if that helps with Ctrl-C locking up the command prompt
   # when multiple child processes have been spawned.
   # import signal
@@ -126,7 +129,7 @@ def run_multiple_processes(commands, env=os.environ.copy(), route_stdout_to_temp
         std_out = temp_files.get(route_stdout_to_temp_files_suffix) if route_stdout_to_temp_files_suffix else (subprocess.PIPE if pipe_stdout else None)
         if DEBUG:
           logger.debug('Running subprocess %d/%d: %s' % (i + 1, len(commands), ' '.join(commands[i])))
-        processes += [(i, subprocess.Popen(commands[i], stdout=std_out, env=env, cwd=cwd))]
+        processes += [(i, subprocess.Popen(commands[i], stdout=std_out, stderr=subprocess.PIPE if pipe_stdout else None, env=env, cwd=cwd))]
         if route_stdout_to_temp_files_suffix:
           std_outs += [(i, std_out.name)]
         i += 1

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -86,9 +86,7 @@ def run_build_commands(commands):
 
 
 
-  safe_env = clean_env()  # We already did a sanity check launching the compiler once, no need to launch the compiler
-  # again on each child subprocess spawn.
-  safe_env['EMCC_SKIP_SANITY_CHECK'] = '1'
+  safe_env = clean_env()
 
   # If we got spawned by ccache, then launch subprocesses in ccache as well.
   if 'EMCC_CCACHE_' in safe_env:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -88,25 +88,18 @@ def run_build_commands(commands):
 
   safe_env = clean_env()
 
-  # If we got spawned by ccache, then launch subprocesses in ccache as well.
-  if 'EMCC_CCACHE_' in safe_env:
-    safe_env['EMCC_CCACHE'] = '1'
-
   for i in range(len(commands)):
     # TODO(sbc): Remove this one we remove the test_em_config_env_var test
     commands[i].append('-Wno-deprecated')
 
     # For subprocess spawns, do not route via the OS batch script launcher, but directly
     # spawn the python script. This saves ~2 seconds on libc build.
-    # However if we are using ccache, we must use the wrappers, since they dispatch
-    # execution to ccache executable.
-    if 'EMCC_CCACHE' not in safe_env:
-      if commands[i][0].endswith('emcc.bat'):
-        commands[i][0] = commands[i][0].replace('emcc.bat', 'emcc.py')
-        commands[i] = [sys.executable] + commands[i]
-      elif commands[i][0].endswith('emcc'):
-        commands[i][0] = commands[i][0].replace('emcc', 'emcc.py')
-        commands[i] = [sys.executable] + commands[i]
+    if commands[i][0].endswith('emcc.bat'):
+      commands[i][0] = commands[i][0].replace('emcc.bat', 'emcc.py')
+      commands[i] = [sys.executable] + commands[i]
+    elif commands[i][0].endswith('emcc'):
+      commands[i][0] = commands[i][0].replace('emcc', 'emcc.py')
+      commands[i] = [sys.executable] + commands[i]
 
   shared.run_multiple_processes(commands)
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -9,7 +9,6 @@ import itertools
 import logging
 import os
 import shutil
-import subprocess
 import sys
 from glob import iglob
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -84,10 +84,6 @@ def run_build_commands(commands):
   # to setup the sysroot itself.
   ensure_sysroot()
 
-
-
-  safe_env = clean_env()
-
   for i in range(len(commands)):
     # TODO(sbc): Remove this one we remove the test_em_config_env_var test
     commands[i].append('-Wno-deprecated')
@@ -101,7 +97,7 @@ def run_build_commands(commands):
       commands[i][0] = commands[i][0].replace('emcc', 'emcc.py')
       commands[i] = [sys.executable] + commands[i]
 
-  shared.run_multiple_processes(commands)
+  shared.run_multiple_processes(commands, env=clean_env())
 
 
 def create_lib(libname, inputs):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -88,15 +88,6 @@ def run_build_commands(commands):
     # TODO(sbc): Remove this one we remove the test_em_config_env_var test
     commands[i].append('-Wno-deprecated')
 
-    # For subprocess spawns, do not route via the OS batch script launcher, but directly
-    # spawn the python script. This saves ~2 seconds on libc build.
-    if commands[i][0].endswith('emcc.bat'):
-      commands[i][0] = commands[i][0].replace('emcc.bat', 'emcc.py')
-      commands[i] = [sys.executable] + commands[i]
-    elif commands[i][0].endswith('emcc'):
-      commands[i][0] = commands[i][0].replace('emcc', 'emcc.py')
-      commands[i] = [sys.executable] + commands[i]
-
   shared.run_multiple_processes(commands, env=clean_env())
 
 


### PR DESCRIPTION
This PR removes the use of the python `multiprocessing` library, and replaces the remaining uses with `Popen`.

The benefits of dropping multiprocessing are:
 - removing multiprocessing in system lib building gives ~1 second improvement on building libc (and ~10 second improvement on embuilder.py build ALL),
 - removing multiprocessing on JS optimizer gives ~4 second improvement when building d3wasm to wasm2js,
 - tapping Ctrl-C works better and doesn't actually make python kill your system on Windows, (#8013)
    - unfortunately the long ^C stack traces still occur, but at least won't have multiprocessing hangs in there, adding a signal handler seems to help things as well. (not done in this PR)
 - less code to maintain, and no need to deal with fragile python multiprocessing pickling and atexit bugs. (#8719, #9240, https://github.com/gevent/gevent/issues/1023, https://forum.unity.com/threads/2019-4-18-cli-build-fail-editor-works-emscripten-error-6-the-handle-is-invalid.1043419/, #718 which still exists..)

Using multiprocessing in test suite is fine to me. (although running the test suite does hard lock my 2990WX system still unless I demote to EMCC_CORES=32, but that is another issue) Test runner is not performance critical for end users.
