### PR TITLE
Unexpected "OpenGL ES 3.0 (WebGL 1.0)" reported by glGetString(GL_VER…

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -962,10 +962,12 @@ var LibraryGL = {
       var handle = GL.getNewId(GL.contexts);
 #endif // USE_PTHREADS
 
+      // workaround Safari bug returning WebGL 1.0 context by canvas.getContext("webgl2") if WebGL context was already created
+      var majVerWebGl = (typeof WebGL2RenderingContext === 'undefined' || !(ctx instanceof WebGL2RenderingContext)) ? 1 : webGLContextAttributes.majorVersion;
       var context = {
         handle: handle,
         attributes: webGLContextAttributes,
-        version: webGLContextAttributes.majorVersion,
+        version: majVerWebGl,
         GLctx: ctx
       };
 


### PR DESCRIPTION
…SION) #13295

In Safari 14 with experimental WebGL 2.0 disabled, canvas.getContext("webgl2") returns NULL first time.
However calling the same method after creation of WebGL 1.0 context suddenly returns non-NULL context!
This is inconsistent with other browsers and causes Emscripten to misbehave
if context creation routines are called multiple times (with intention to re-use existing context).