### PR TITLE
Ccache

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -645,6 +645,8 @@ Environment variables
 
    * "EM_CONFIG" [general]
 
+   * "EM_LLVM_ROOT" [compile+link]
+
 Search for 'os.environ' in emcc.py to see how these are used. The most
 interesting is possibly "EMCC_DEBUG", which forces the compiler to
 dump its build and temporary files to a temporary directory where they

--- a/em++
+++ b/em++
@@ -26,9 +26,9 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-if [ "$EMCC_CCACHE" == "1" ]; then
+if [ -z "$EMCC_CCACHE" ]; then
+  exec "$PYTHON" "$0.py" "$@"
+else
   unset EMCC_CCACHE
   exec ccache "$0" "$@"
-else
-  exec "$PYTHON" "$0.py" "$@"
 fi

--- a/em++
+++ b/em++
@@ -26,4 +26,9 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-exec "$PYTHON" "$0.py" "$@"
+if [ -z "$EMCC_CCACHE" ]; then
+  exec "$PYTHON" "$0.py" "$@"
+else
+  unset EMCC_CCACHE
+  exec ccache "$0" "$@"
+fi

--- a/em++
+++ b/em++
@@ -26,9 +26,9 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-if [ -z "$EMCC_CCACHE" ]; then
-  exec "$PYTHON" "$0.py" "$@"
-else
+if [ "$EMCC_CCACHE" == "1" ]; then
   unset EMCC_CCACHE
   exec ccache "$0" "$@"
+else
+  exec "$PYTHON" "$0.py" "$@"
 fi

--- a/em++.bat
+++ b/em++.bat
@@ -14,5 +14,5 @@
 ) else (
   :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set EMCC_CCACHE=
-  ccache "%EMCC_CCACHE%\%~n0.bat" %*
+  ccache "%~dp0\%~n0.bat" %*
 )

--- a/em++.bat
+++ b/em++.bat
@@ -12,9 +12,7 @@
   :: Do regular invocation of em++.py compiler
   "%EM_PY%" "%~dp0\%~n0.py" %*
 ) else (
-  :: Invoke the compiler via ccache, use a wrapper in ccache installation directory.
-  if "%EMSCRIPTEN%"=="" (
-    set EMSCRIPTEN=%~dp0
-  )
+  :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
+  set EMCC_CCACHE=
   ccache "%EMCC_CCACHE%\%~n0.bat" %*
 )

--- a/em++.bat
+++ b/em++.bat
@@ -8,4 +8,13 @@
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+@if "%EMCC_CCACHE%"=="" (
+  :: Do regular invocation of em++.py compiler
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  :: Invoke the compiler via ccache, use a wrapper in ccache installation directory.
+  if "%EMSCRIPTEN%"=="" (
+    set EMSCRIPTEN=%~dp0
+  )
+  ccache "%EMCC_CCACHE%\%~n0.bat" %*
+)

--- a/emcc
+++ b/emcc
@@ -26,9 +26,9 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-if [ "$EMCC_CCACHE" == "1" ]; then
+if [ -z "$EMCC_CCACHE" ]; then
+  exec "$PYTHON" "$0.py" "$@"
+else
   unset EMCC_CCACHE
   exec ccache "$0" "$@"
-else
-  exec "$PYTHON" "$0.py" "$@"
 fi

--- a/emcc
+++ b/emcc
@@ -26,4 +26,9 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-exec "$PYTHON" "$0.py" "$@"
+if [ -z "$EMCC_CCACHE" ]; then
+  exec "$PYTHON" "$0.py" "$@"
+else
+  unset EMCC_CCACHE
+  exec ccache "$0" "$@"
+fi

--- a/emcc
+++ b/emcc
@@ -26,9 +26,9 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-if [ -z "$EMCC_CCACHE" ]; then
-  exec "$PYTHON" "$0.py" "$@"
-else
+if [ "$EMCC_CCACHE" == "1" ]; then
   unset EMCC_CCACHE
   exec ccache "$0" "$@"
+else
+  exec "$PYTHON" "$0.py" "$@"
 fi

--- a/emcc.bat
+++ b/emcc.bat
@@ -14,5 +14,5 @@
 ) else (
   :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set EMCC_CCACHE=
-  ccache "%EMCC_CCACHE%\%~n0.bat" %*
+  ccache "%~dp0\%~n0.bat" %*
 )

--- a/emcc.bat
+++ b/emcc.bat
@@ -12,9 +12,7 @@
   :: Do regular invocation of em++.py compiler
   "%EM_PY%" "%~dp0\%~n0.py" %*
 ) else (
-  :: Invoke the compiler via ccache, use a wrapper in ccache installation directory.
-  if "%EMSCRIPTEN%"=="" (
-    set EMSCRIPTEN=%~dp0
-  )
+  :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
+  set EMCC_CCACHE=
   ccache "%EMCC_CCACHE%\%~n0.bat" %*
 )

--- a/emcc.bat
+++ b/emcc.bat
@@ -8,4 +8,13 @@
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+@if "%EMCC_CCACHE%"=="" (
+  :: Do regular invocation of em++.py compiler
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  :: Invoke the compiler via ccache, use a wrapper in ccache installation directory.
+  if "%EMSCRIPTEN%"=="" (
+    set EMSCRIPTEN=%~dp0
+  )
+  ccache "%EMCC_CCACHE%\%~n0.bat" %*
+)

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -540,7 +540,7 @@ Environment variables
   - ``EMCC_SKIP_SANITY_CHECK`` [general]
   - ``EM_IGNORE_SANITY`` [general]
   - ``EM_CONFIG`` [general]
-  - ``EM_LLVM_ROOT``
+  - ``EM_LLVM_ROOT`` [compile+link]
 
 Search for 'os.environ' in `emcc.py <https://github.com/emscripten-core/emscripten/blob/main/emcc.py>`_ to see how these are used. The most interesting is possibly ``EMCC_DEBUG``, which forces the compiler to dump its build and temporary files to a temporary directory where they can be reviewed.
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -540,6 +540,7 @@ Environment variables
   - ``EMCC_SKIP_SANITY_CHECK`` [general]
   - ``EM_IGNORE_SANITY`` [general]
   - ``EM_CONFIG`` [general]
+  - ``EM_LLVM_ROOT``
 
 Search for 'os.environ' in `emcc.py <https://github.com/emscripten-core/emscripten/blob/main/emcc.py>`_ to see how these are used. The most interesting is possibly ``EMCC_DEBUG``, which forces the compiler to dump its build and temporary files to a temporary directory where they can be reviewed.
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1187,7 +1187,7 @@ var DYNAMIC_EXECUTION = 1;
 var BOOTSTRAPPING_STRUCT_INFO = 0;
 
 // Add some calls to emscripten tracing APIs
-// [link]
+// [compile+link]
 var EMSCRIPTEN_TRACING = 0;
 
 // Specify the GLFW version that is being linked against.  Only relevant, if you

--- a/tools/create_entry_points.py
+++ b/tools/create_entry_points.py
@@ -7,25 +7,28 @@
 """Tool for creating/maintains the python launcher scripts for all the emscripten
 python tools.
 
-This tools makes copies or `run_python.sh` and `run_python.bat` script for each
-entry point.  On UNIX we previously used symbolic links for simplicity but this
-breaks MINGW users on windows who want use the shell script launcher but don't
-have symlink support (sigh).
+This tools makes copies or `run_python.sh/.bat` and `run_python_compiler.sh/.bat`
+script for each entry point. On UNIX we previously used symbolic links for
+simplicity but this breaks MINGW users on windows who want use the shell script
+launcher but don't have symlink support.
 """
 
 import os
 import shutil
 import sys
 
+compiler_entry_points = '''
+emcc
+em++
+'''.split()
+
 entry_points = '''
 emar
 embuilder
-emcc
 emcmake
 em-config
 emconfigure
 emmake
-em++
 emranlib
 emrun
 emscons
@@ -39,13 +42,23 @@ tests/runner
 def main():
   tools_dir = os.path.dirname(os.path.abspath(__file__))
   root_dir = os.path.dirname(tools_dir)
-  sh_file = os.path.join(tools_dir, 'run_python.sh')
-  bat_file = os.path.join(tools_dir, 'run_python.bat')
-  for entry_point in entry_points:
-    if os.path.exists(os.path.join(root_dir, entry_point)):
-        os.remove(os.path.join(root_dir, entry_point))
-    shutil.copy2(sh_file, os.path.join(root_dir, entry_point))
-    shutil.copy2(bat_file, os.path.join(root_dir, entry_point) + '.bat')
+
+  def generate_entry_points(cmd, path):
+    sh_file = path + '.sh'
+    bat_file = path + '.bat'
+    for entry_point in cmd:
+      dst = os.path.join(root_dir, entry_point)
+      if os.path.exists(dst):
+          os.remove(dst)
+      shutil.copy2(sh_file, dst)
+
+      dst += '.bat'
+      if os.path.exists(dst):
+          os.remove(dst)
+      shutil.copy2(bat_file, dst)
+
+  generate_entry_points(entry_points, os.path.join(tools_dir, 'run_python'))
+  generate_entry_points(compiler_entry_points, os.path.join(tools_dir, 'run_python_compiler'))
 
 
 if __name__ == '__main__':

--- a/tools/run_python_compiler.bat
+++ b/tools/run_python_compiler.bat
@@ -1,0 +1,18 @@
+:: Entry point for running python scripts on windows systems.
+:: To modify this file, edit `tools/run_python.bat` and then run
+:: `tools/create_entry_points.py`
+
+@setlocal
+@set EM_PY=%EMSDK_PYTHON%
+@if "%EM_PY%"=="" (
+  set EM_PY=python
+)
+
+@if "%EMCC_CCACHE%"=="" (
+  :: Do regular invocation of em++.py compiler
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
+  set EMCC_CCACHE=
+  ccache "%~dp0\%~n0.bat" %*
+)

--- a/tools/run_python_compiler.sh
+++ b/tools/run_python_compiler.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Copyright 2020 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+#
+# Entry point for running python scripts on UNIX systems.
+#
+# To modify this file, edit `tools/run_python.sh` and then run
+# `tools/create_entry_points.py`
+
+if [ -z "$PYTHON" ]; then
+  PYTHON=$EMSDK_PYTHON
+fi
+
+if [ -z "$PYTHON" ]; then
+  PYTHON=$(which python3 2> /dev/null)
+fi
+
+if [ -z "$PYTHON" ]; then
+  PYTHON=$(which python 2> /dev/null)
+fi
+
+if [ -z "$PYTHON" ]; then
+  echo 'unable to find python in $PATH'
+  exit 1
+fi
+
+if [ -z "$EMCC_CCACHE" ]; then
+  exec "$PYTHON" "$0.py" "$@"
+else
+  unset EMCC_CCACHE
+  exec ccache "$0" "$@"
+fi


### PR DESCRIPTION
This PR adds support to ccache for Emscripten. The corresponding PR for emsdk is at https://github.com/emscripten-core/emsdk/pull/711 and the corresponding changes to ccache itself are at https://github.com/juj/ccache/tree/emscripten.

The general mechanism is that after activating ccache in Emscripten SDK, emcc and em++ will automatically take usage of the installed ccache tool.

Usage:

```
emsdk install sdk-upstream-master-64bit ccache-git-emscripten-64bit
emsdk activate sdk-upstream-master-64bit  ccache-git-emscripten-64bit
cd %EMSCRIPTEN%
git remote add juj https://github.com/juj/emscripten.git
git fetch emscripten
git checkout ccache

# Example 1: rebuilding libc is fast from cache:
ccache -s # check initial ccache statistics: zero compiled files in cache
emcc --clear-cache

python embuilder.py build libc # cache miss
ccache -s # will show 862 files missed cache

ccache -z # zero ccache statistics

emcc --clear-cache
python embuilder.py build libc # cache hit!
ccache -s # now shows 862 files found from cache

# Example 2: rebuilding custom code is fast from cache:
ccache -z # zero statistics
emcc -c tests\hello_world.c -o a.o # cache miss
ccache -s # shows one file missed cache
emcc -c tests\hello_world.c -o a.o # cache hit!
ccache -s # shows one file hit cache
```
