### PR TITLE
Several cleanups in preparation for musl update. NFC.

### DIFF
--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -23,6 +23,7 @@ var LibraryPThreadStub = {
     _pthread_cleanup_push.level = __ATEXIT__.length;
   },
 
+  pthread_cleanup_pop__deps: ['pthread_cleanup_push'],
   pthread_cleanup_pop__sig: 'vi',
   pthread_cleanup_pop: function(execute) {
     assert(_pthread_cleanup_push.level == __ATEXIT__.length, 'cannot pop if something else added meanwhile!');

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -209,8 +209,7 @@
                 "tv_sec",
                 "tv_usec"
             ]
-        },
-        "defines": []
+        }
     },
     {
         "file": "time.h",

--- a/src/struct_info_internal.json
+++ b/src/struct_info_internal.json
@@ -3,7 +3,7 @@
     // libc - internal
     // ===========================================
     {
-        "file": "system/lib/libc/musl/src/internal/pthread_impl.h",
+        "file": "pthread_impl.h",
         "structs": {
             "pthread": [
               "threadStatus",
@@ -25,7 +25,7 @@
         "defines": ["__ATTRP_C11_THREAD"]
     },
     {
-        "file": "system/lib/libc/musl/src/internal/libc.h",
+        "file": "libc.h",
         "structs": {
             "libc": [
               "global_locale"

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -193,7 +193,7 @@ def gen_inspect_code(path, struct, code):
   c_ascent(code)
 
 
-def inspect_headers(headers, cpp_opts):
+def inspect_headers(headers, cflags):
   code = ['#include <stdio.h>', '#include <stddef.h>']
   for header in headers:
     code.append('#include "' + header['name'] + '"')
@@ -249,19 +249,19 @@ def inspect_headers(headers, cpp_opts):
   info = []
   # Compile the program.
   show('Compiling generated code...')
+
   # -Oz optimizes enough to avoid warnings on code size/num locals
-  cmd = [shared.EMCC] + cpp_opts + ['-o', js_file[1], src_file[1],
-                                    '-O0',
-                                    '-Werror',
-                                    '-Wno-format',
-                                    '-nostdlib',
-                                    compiler_rt,
-                                    '-I', shared.path_from_root(),
-                                    '-s', 'BOOTSTRAPPING_STRUCT_INFO=1',
-                                    '-s', 'STRICT',
-                                    # Use SINGLE_FILE=1 so there is only a single
-                                    # file to cleanup.
-                                    '-s', 'SINGLE_FILE']
+  cmd = [shared.EMCC] + cflags + ['-o', js_file[1], src_file[1],
+                                  '-O0',
+                                  '-Werror',
+                                  '-Wno-format',
+                                  '-nostdlib',
+                                  compiler_rt,
+                                  '-s', 'BOOTSTRAPPING_STRUCT_INFO=1',
+                                  '-s', 'STRICT',
+                                  # Use SINGLE_FILE=1 so there is only a single
+                                  # file to cleanup.
+                                  '-s', 'SINGLE_FILE']
 
   # Default behavior for emcc is to warn for binaryen version check mismatches
   # so we should try to match that behavior.
@@ -306,13 +306,13 @@ def merge_info(target, src):
     target['structs'][key] = value
 
 
-def inspect_code(headers, cpp_opts):
+def inspect_code(headers, cflags):
   if not DEBUG:
-    info = inspect_headers(headers, cpp_opts)
+    info = inspect_headers(headers, cflags)
   else:
     info = {'defines': {}, 'structs': {}}
     for header in headers:
-      merge_info(info, inspect_headers([header], cpp_opts))
+      merge_info(info, inspect_headers([header], cflags))
   return info
 
 
@@ -391,17 +391,21 @@ def main(args):
   QUIET = args.quiet
 
   # Avoid parsing problems due to gcc specifc syntax.
-  cpp_opts = ['-D_GNU_SOURCE']
+  cflags = ['-D_GNU_SOURCE']
 
   # Add the user options to the list as well.
   for path in args.includes:
-    cpp_opts.append('-I' + path)
+    cflags.append('-I' + path)
 
   for arg in args.defines:
-    cpp_opts.append('-D' + arg)
+    cflags.append('-D' + arg)
 
   for arg in args.undefines:
-    cpp_opts.append('-U' + arg)
+    cflags.append('-U' + arg)
+
+  internal_cflags = [
+    '-I' + shared.path_from_root('system', 'lib', 'libc', 'musl', 'src', 'internal'),
+  ]
 
   # Look for structs in all passed headers.
   info = {'defines': {}, 'structs': {}}
@@ -410,7 +414,11 @@ def main(args):
     # This is a JSON file, parse it.
     header_files = parse_json(f)
     # Inspect all collected structs.
-    info_fragment = inspect_code(header_files, cpp_opts)
+    if 'internal' in f:
+      use_cflags = cflags + internal_cflags
+    else:
+      use_cflags = cflags
+    info_fragment = inspect_code(header_files, use_cflags)
     merge_info(info, info_fragment)
 
   output_json(info, args.output)


### PR DESCRIPTION
- library_pthread_stub.js: Add missing dependency to pthread_cleanup_pop
- gen_struct_info: add musl internal include paths when needed
- system_libs.py: improve debugging for failed builds
- simplify/improve ignore list handling when processing musl sources.