### PR TITLE
Add catch statement to fetch of wasm file

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1105,6 +1105,10 @@ function createWasm() {
             err('falling back to ArrayBuffer instantiation');
             return instantiateArrayBuffer(receiveInstantiatedSource);
           });
+      }).catch(function(error) {
+        err("could not download wasm file");
+        err("falling back to ArrayBuffer instantiation");
+        return instantiateArrayBuffer(receiveInstantiatedSource);
       });
     } else {
       return instantiateArrayBuffer(receiveInstantiatedSource);


### PR DESCRIPTION
There may be cases where the fetch for the wasm file fails. The current implementation currently stalls if there is an error fetching the wasm file, causing the code to hang. In this case, a simple catch statement was added to the fetch request to revert back to the array buffer instantiation.