### PR TITLE
Directly export em_js string symbols

### DIFF
--- a/system/include/emscripten/em_js.h
+++ b/system/include/emscripten/em_js.h
@@ -27,25 +27,28 @@
 
 // EM_JS declares the JS function with a C function prototype, which becomes a
 // function import in asm.js/wasm. It also declares an __em_js__-prefixed
-// function, which we can use to pass information to the Emscripten compiler
+// string constant, which we can use to pass information to the Emscripten compiler
 // that survives going through LLVM.
 // Example:
+//
 //   EM_JS(int, foo, (int x, int y), { return 2 * x + y; })
+//
 // would get translated into:
-//   int foo(int x, int y);
-//   __attribute__((used, visibility("default"), import_name("foo")))
-//   const char* __em_js__foo() {
-//     return "(int x, int y)<::>{ return 2 * x + y; }";
-//   }
+//
+//   __attribute__((import_name("foo"))) int foo(int x, int y);
+//
+//   __attribute__((used, visibility("default")))
+//   char __em_js__foo[] = "(int x, int y)<::>{ return 2 * x + y; }";
+//
 // We pack the arguments and function body into a constant string so it's
-// readable from asm.js/wasm post-processing.
-// Later we see a function called __em_js__foo, meaning we need to create a JS
+// readable during wasm post-processing.
+// Later we see an export called __em_js__foo, meaning we need to create a JS
 // function:
 //   function foo(x, y) { return 2 * x + y; }
 // We use <::> to separate the arguments from the function body because it isn't
 // valid anywhere in a C function declaration.
 
-// Generated __em_js__-prefixed functions are read by binaryen, and the string
+// Generated __em_js__-prefixed symbols are read by binaryen, and the string
 // data is extracted into the Emscripten metadata dictionary under the
 // "emJsFuncs" key. emJsFuncs itself is a dictionary where the keys are function
 // names (not prefixed with __em_js__), and the values are the <::>-including
@@ -56,9 +59,8 @@
 
 #define EM_JS(ret, name, params, ...)                                                              \
   _EM_JS_CPP_BEGIN                                                                                 \
-  extern ret name params EM_IMPORT(name);                                                          \
-  __attribute__((used, visibility("default"))) const char* __em_js__##name() {                     \
-    __attribute__((section("em_js"), aligned(1))) static const char s[] = #params "<::>" #__VA_ARGS__;          \
-    return s;                                                                                      \
-  }                                                                                                \
+  ret name params EM_IMPORT(name);                                                                 \
+  EMSCRIPTEN_KEEPALIVE                                                                             \
+  __attribute__((section("em_js"), aligned(1))) char __em_js__##name[] =                           \
+    #params "<::>" #__VA_ARGS__;                                                                   \
   _EM_JS_CPP_END


### PR DESCRIPTION
Previously we were exporting function that return said
address.  This mechanism is simpler and cleaner.