### PR TITLE
Remove test expectation contents from test_exceptions_rethrow_missing

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1434,7 +1434,7 @@ int main(int argc, char **argv)
   @with_both_exception_handling
   def test_exceptions_rethrow_missing(self):
     create_test_file('main.cpp', 'int main() { throw; }')
-    self.do_runf('main.cpp', 'abort(no exception to throw)', assert_returncode=NON_ZERO)
+    self.do_runf('main.cpp', None, assert_returncode=NON_ZERO)
 
   @with_both_exception_handling
   def test_bad_typeid(self):


### PR DESCRIPTION
The expected output had specifics from the JS exceptions code, but with
wasm exceptions that isn't relevant. In any case, all we care about is that
the test halts with an error, not what the message is.

Fixes https://github.com/emscripten-core/emscripten/issues/13527