### PR TITLE
Move `exit_with_live_runtime` and `force_exit` out of `library_browser.js`. NFC

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -432,9 +432,11 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
 }
 
 function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
+#if !MINIMAL_RUNTIME
   // Avoid shutting down the runtime since we want to wait for the async
   // response.
   noExitRuntime = true;
+#endif
 
   var fetch_attr = fetch + {{{ C_STRUCTS.emscripten_fetch_t.__attributes }}};
   var requestMethod = UTF8ToString(fetch_attr);

--- a/src/library.js
+++ b/src/library.js
@@ -3780,6 +3780,28 @@ LibraryManager.library = {
       }
     }
   },
+
+  // Callable in pthread without __proxy needed.
+  emscripten_exit_with_live_runtime: function() {
+#if !MINIMAL_RUNTIME
+    noExitRuntime = true;
+#endif
+    throw 'unwind';
+  },
+
+  emscripten_force_exit__proxy: 'sync',
+  emscripten_force_exit__sig: 'vi',
+  emscripten_force_exit: function(status) {
+#if EXIT_RUNTIME == 0
+#if ASSERTIONS
+    warnOnce('emscripten_force_exit cannot actually shut down the runtime, as the build does not have EXIT_RUNTIME set');
+#endif
+#endif
+#if !MINIMAL_RUNTIME
+    noExitRuntime = false;
+#endif
+    exit(status);
+  },
 };
 
 function autoAddDeps(object, name) {

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -178,7 +178,9 @@ mergeInto(LibraryManager.library, {
 
     handleSleep: function(startAsync) {
       if (ABORT) return;
+#if !MINIMAL_RUNTIME
       noExitRuntime = true;
+#endif
 #if ASYNCIFY_DEBUG
       err('ASYNCIFY: handleSleep ' + Asyncify.state);
 #endif
@@ -453,7 +455,9 @@ mergeInto(LibraryManager.library, {
   emscripten_fiber_swap__deps: ["$Asyncify", "$Fibers"],
   emscripten_fiber_swap: function(oldFiber, newFiber) {
     if (ABORT) return;
+#if !MINIMAL_RUNTIME
     noExitRuntime = true;
+#endif
 #if ASYNCIFY_DEBUG
     err('ASYNCIFY/FIBER: swap', oldFiber, '->', newFiber, 'state:', Asyncify.state);
 #endif

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -1354,24 +1354,6 @@ var LibraryBrowser = {
     }
   },
 
-  // Callable in pthread without __proxy needed.
-  emscripten_exit_with_live_runtime: function() {
-    noExitRuntime = true;
-    throw 'unwind';
-  },
-
-  emscripten_force_exit__proxy: 'sync',
-  emscripten_force_exit__sig: 'vi',
-  emscripten_force_exit: function(status) {
-#if EXIT_RUNTIME == 0
-#if ASSERTIONS
-    warnOnce('emscripten_force_exit cannot actually shut down the runtime, as the build does not have EXIT_RUNTIME set');
-#endif
-#endif
-    noExitRuntime = false;
-    exit(status);
-  },
-
   emscripten_get_window_title__proxy: 'sync',
   emscripten_get_window_title__sig: 'iv',
   emscripten_get_window_title: function() {


### PR DESCRIPTION
These are core functions that are not specific the browser
environment.

Also, avoid referencing `noExitRuntime` when `MINIMAL_RUNTIME` is
set since this is not a thing in that configuration.

Split out from #13335