### PR TITLE
Fix SIDE_MODULE + STACK_OVERFLOW_CHECK

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1326,10 +1326,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         setattr(shared.Settings, name, new_default)
 
     # -s ASSERTIONS=1 implies basic stack overflow checks, and ASSERTIONS=2
-    # implies full stack overflow checks (unless the user specifically set
-    # something else)
+    # implies full stack overflow checks.
     if shared.Settings.ASSERTIONS:
-      default_setting('STACK_OVERFLOW_CHECK',  max(shared.Settings.ASSERTIONS, shared.Settings.STACK_OVERFLOW_CHECK))
+      # However, we don't set this default in PURE_WASI, or when we are linking without standard
+      # libraries because STACK_OVERFLOW_CHECK depends on emscripten_stack_get_end which is defined
+      # in libcompiler-rt.
+      if not shared.Settings.PURE_WASI and '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
+        default_setting('STACK_OVERFLOW_CHECK', max(shared.Settings.ASSERTIONS, shared.Settings.STACK_OVERFLOW_CHECK))
 
     if shared.Settings.LLD_REPORT_UNDEFINED or shared.Settings.STANDALONE_WASM:
       # Reporting undefined symbols at wasm-ld time requires us to know if we have a `main` function

--- a/emscripten.py
+++ b/emscripten.py
@@ -138,12 +138,11 @@ def update_settings_glue(metadata, DEBUG):
   # -s DECLARE_ASM_MODULE_EXPORTS=0 builds.
   shared.Settings.MODULE_EXPORTS = [(asmjs_mangle(f), f) for f in metadata['exports']]
 
-  if shared.Settings.STACK_OVERFLOW_CHECK:
-    if 'emscripten_stack_get_end' not in metadata['exports']:
-      logger.warning('STACK_OVERFLOW_CHECK disabled because emscripten stack helpers not exported')
-      shared.Settings.STACK_OVERFLOW_CHECK = 0
-    else:
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
+  if shared.Settings.STACK_OVERFLOW_CHECK and not shared.Settings.SIDE_MODULE:
+    shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
+    # writeStackCookie and checkStackCookie both rely on emscripten_stack_get_end being
+    # exported.  In theory it should always be present since its defined in compiler-rt.
+    assert 'emscripten_stack_get_end' in metadata['exports']
 
 
 def apply_static_code_hooks(forwarded_json, code):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8172,15 +8172,18 @@ NODEFS is no longer included by default; build with -lnodefs.js
     ''', '''
       #include <string.h>
 
+      static int accumulator = 0;
+
       int f(int *b) {
-        int a[64];
-        memset(b, 0, 2048 * sizeof(int));
+        // Infinite recursion while recording stack pointer locations
+        // so that compiler can't eliminate the stack allocs.
+        accumulator += (int)b;
+        int a[1024];
         return f(a);
       }
 
       void sidey() {
-        int a[2048];
-        f(a);
+        f(NULL);
       }
     ''', ['abort(stack overflow)', '__handle_stack_overflow'], assert_returncode=NON_ZERO, force_c=True)
 


### PR DESCRIPTION
We have check for the `emscripten_stack_get_end` export but that
won't exist for SIDE_MODULE since it doesn't link against compiler-rt
(which is where `emscripten_stack_get_end` lives).

What is more, disabling STACK_OVERFLOW_CHECK at this point is two
late since it happens after binaryen has run.  Instead, error out
here.  I can't think of use case where we want to support building
with STACK_OVERFLOW_CHECK but we could run without this export.

Also, update the test to be sure that its not calling back into the
main module when the stack overflows.

Fixes: #13532