### PR TITLE
[Wasm Exceptions] Error on linking with -O2+, for now

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1909,6 +1909,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
          shared.Settings.MAXIMUM_MEMORY > 2 * 1024 * 1024 * 1024)):
       shared.Settings.CAN_ADDRESS_2GB = 1
 
+    if shared.Settings.EXCEPTION_HANDLING and shared.Settings.OPT_LEVEL >= 2 and not compile_only:
+      exit_with_error('wasm exception handling support is still experimental, and not supported in -O2+ yet')
+
     shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
     shared.Settings.PROFILING_FUNCS = options.profiling_funcs
     shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''

--- a/emcc.py
+++ b/emcc.py
@@ -1910,7 +1910,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.CAN_ADDRESS_2GB = 1
 
     if shared.Settings.EXCEPTION_HANDLING and shared.Settings.OPT_LEVEL >= 2 and not compile_only:
-      exit_with_error('wasm exception handling support is still experimental, and not supported in -O2+ yet')
+      exit_with_error('wasm exception handling support is still experimental, and linking is not supported in -O2+ yet')
 
     shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
     shared.Settings.PROFILING_FUNCS = options.profiling_funcs

--- a/emcc.py
+++ b/emcc.py
@@ -1910,7 +1910,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.CAN_ADDRESS_2GB = 1
 
     if shared.Settings.EXCEPTION_HANDLING and shared.Settings.OPT_LEVEL >= 2 and not compile_only:
-      exit_with_error('wasm exception handling support is still experimental, and linking is not supported in -O2+ yet')
+      exit_with_error('wasm exception handling support is still experimental, and linking with -O2+ is not supported yet')
 
     shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
     shared.Settings.PROFILING_FUNCS = options.profiling_funcs

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10046,6 +10046,9 @@ exec "$@"
   def test_wasm_exception_handing(self):
     # building an object file is fine
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions', '-c'])
+
     # TODO: test -O1 linking works, but libc++ cannot be built yet
+
+    # linking with -O2+ is not ok currently
     err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions'])
     self.assertContained('wasm exception handling support is still experimental, and not supported in -O2+ yet', err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10043,7 +10043,7 @@ exec "$@"
         if direct not in js and via_module not in js and assignment not in js:
           self.fail(f'use of declared dependency {dep} not found in JS output for {function}')
 
-  def test_wasm_exception_handing(self):
+  def test_wasm_exception_handing_support(self):
     # building an object file is fine
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions', '-c'])
 
@@ -10051,4 +10051,4 @@ exec "$@"
 
     # linking with -O2+ is not ok currently
     err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions'])
-    self.assertContained('wasm exception handling support is still experimental, and linking is not supported in -O2+ yet', err)
+    self.assertContained('wasm exception handling support is still experimental, and linking with -O2+ is not supported yet', err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10042,3 +10042,10 @@ exec "$@"
         print(f'  checking for: {dep}')
         if direct not in js and via_module not in js and assignment not in js:
           self.fail(f'use of declared dependency {dep} not found in JS output for {function}')
+
+  def test_wasm_exception_handing(self):
+    # building an object file is fine
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions', '-c'])
+    # TODO: test -O1 linking works, but libc++ cannot be built yet
+    err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions'])
+    self.assertContained('wasm exception handling support is still experimental, and not supported in -O2+ yet', err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10051,4 +10051,4 @@ exec "$@"
 
     # linking with -O2+ is not ok currently
     err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions'])
-    self.assertContained('wasm exception handling support is still experimental, and not supported in -O2+ yet', err)
+    self.assertContained('wasm exception handling support is still experimental, and linking is not supported in -O2+ yet', err)


### PR DESCRIPTION
This implements a solution to https://github.com/WebAssembly/binaryen/issues/3586, specifically it errors
at link if wasm exceptions are enabled in -O2+ (which is when binaryen opts would be
run).

I know we didn't fully decide on whether to error or warn, but I think I agree
with @aheejin that erroring is best. It's the simplest and least likely to be
surprising I think.

Fixes https://github.com/WebAssembly/binaryen/issues/3586