### PR TITLE
Update log2ceilLookup

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -271,7 +271,7 @@ var LibraryGL = {
     // if x was rounded up to next pow2, which index is the single '1' bit at?
     // Then log2ceilLookup[x] returns ceil(log2(x)).
     log2ceilLookup: function(i) {
-      return 32 - Math.clz32(i-1);
+      return 32 - Math.clz32(i === 0 ? 0 : i - 1);
     },
 
     generateTempBuffers: function(quads, context) {


### PR DESCRIPTION
If you try to use `glDrawArrays` with `count==0`, then you will have runtime error:
```
exception thrown: TypeError: Cannot read property 'undefined' of undefined,TypeError: Cannot read property 'undefined' of undefined
    at Object.getTempVertexBuffer (eval at value (), <anonymous>:7198:29)
    at Object.preDrawHandleClientVertexAttribBindings (eval at value (), <anonymous>:7258:24)
    at _glDrawArrays (eval at value (), <anonymous>:7553:10)
...
```

This happen because `getTempVertexBuffer` uses `log2ceilLookup` to get `ringbuffer` index. In case of `0`, index will be `32` it is out of range:
```
        var idx = GL.log2ceilLookup(sizeBytes);
        var ringbuffer = GL.currentContext.tempVertexBuffers1[idx];
```
Length of tempVertexBuffer is calculated as follow:
```
       var largestIndex = GL.log2ceilLookup(GL.MAX_TEMP_BUFFER_SIZE);
```
With my fix `count 0, 1` will use `ceil 0`.

P. S. This is regression, it happened on game that works normally before.
