### PR TITLE
Use a non-null value to force segfault in test_segfault

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1514,7 +1514,7 @@ int main() {
   def test_segfault(self):
     self.set_setting('SAFE_HEAP')
 
-    for addr in ['0', 'new D2()']:
+    for addr in ['4', 'new D2()']:
       print(addr)
       src = r'''
         #include <stdio.h>


### PR DESCRIPTION
Using 0 is undefined behavior, and the optimizer is now smart enough
to eliminate it