### PR TITLE
Enable wasm EH tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -88,7 +88,7 @@ def with_both_exception_handling(f):
   assert callable(f)
 
   def metafunc(self, native_exceptions):
-    if native_exceptions and False: # TODO: re-enable when V8 and LLVM support the updated EH proposal
+    if native_exceptions:
       # Wasm EH is currently supported only in wasm backend and V8
       if not self.is_wasm():
         self.skipTest('wasm2js does not support wasm exceptions')


### PR DESCRIPTION
Now EH tests pass with wasm EH for wasm0, wasm1, wasm2, wasm3, and
wasms, we can enable this.