### PR TITLE
Allow wasm EH on linking with -O2+

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1909,9 +1909,6 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
          shared.Settings.MAXIMUM_MEMORY > 2 * 1024 * 1024 * 1024)):
       shared.Settings.CAN_ADDRESS_2GB = 1
 
-    if shared.Settings.EXCEPTION_HANDLING and shared.Settings.OPT_LEVEL >= 2 and not compile_only:
-      exit_with_error('wasm exception handling support is still experimental, and linking with -O2+ is not supported yet')
-
     shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
     shared.Settings.PROFILING_FUNCS = options.profiling_funcs
     shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10048,13 +10048,3 @@ exec "$@"
         print(f'  checking for: {dep}')
         if direct not in js and via_module not in js and assignment not in js:
           self.fail(f'use of declared dependency {dep} not found in JS output for {function}')
-
-  def test_wasm_exception_handing_support(self):
-    # building an object file is fine
-    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions', '-c'])
-
-    # TODO: test -O1 linking works, but libc++ cannot be built yet
-
-    # linking with -O2+ is not ok currently
-    err = self.expect_fail([EMCC, path_from_root('tests', 'hello_world.c'), '-O2', '-fwasm-exceptions'])
-    self.assertContained('wasm exception handling support is still experimental, and linking with -O2+ is not supported yet', err)


### PR DESCRIPTION
This reverts #13541. This is necessary for #13572 to pass on all options
with which test_core.py is tested.