### PR TITLE
Fix syncfs with existing directories

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -545,3 +545,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Alexey Shamrin <shamrin@gmail.com>
 * Ben den Hollander <bdenhollander@dynascape.com> (copyright owned by DynaScape Software Inc.)
 * Akul Penugonda <akulvp@gmail.com>
+* Pawel Czarnecki <pawel@8thwall.com> (copyright owned by 8th Wall, Inc.)

--- a/AUTHORS
+++ b/AUTHORS
@@ -546,3 +546,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Ben den Hollander <bdenhollander@dynascape.com> (copyright owned by DynaScape Software Inc.)
 * Akul Penugonda <akulvp@gmail.com>
 * Pawel Czarnecki <pawel@8thwall.com> (copyright owned by 8th Wall, Inc.)
+* Camil Staps <info@camilstaps.nl>

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -169,7 +169,7 @@ mergeInto(LibraryManager.library, {
     storeLocalEntry: function(path, entry, callback) {
       try {
         if (FS.isDir(entry['mode'])) {
-          FS.mkdir(path, entry['mode']);
+          FS.mkdirTree(path, entry['mode']);
         } else if (FS.isFile(entry['mode'])) {
           FS.writeFile(path, entry['contents'], { canOwn: true });
         } else {


### PR DESCRIPTION
This is the same PR as https://github.com/emscripten-core/emscripten/pull/12569, which was intended to fix an exception when `syncfs` encounters a directory which already exists. Modifications to the original PR:

- I have squashed the commits because the final diff was only one line. I hope this is fine with you @VinnyOG.
- A new test has been added (which is what prevented #12569 from getting merged).

Closes #12562.