### PR TITLE
Do not default to TextDecoder-only in -Oz if targeting a shell

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1245,7 +1245,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # in -Oz builds, since custom decoder for UTF-8 takes up space.
     # In pthreads enabled builds, TEXTDECODER==2 may not work, see
     # https://github.com/whatwg/encoding/issues/172
-    if shared.Settings.SHRINK_LEVEL >= 2 and not shared.Settings.USE_PTHREADS:
+    # When supporting shell environments, do not do this as TextDecoder is not
+    # widely supported there.
+    if shared.Settings.SHRINK_LEVEL >= 2 and not shared.Settings.USE_PTHREADS and \
+       not shared.Settings.ENVIRONMENT_MAY_BE_SHELL:
       default_setting('TEXTDECODER', 2)
 
     # If set to 1, we will run the autodebugger (the automatic debugging tool, see

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10048,3 +10048,11 @@ exec "$@"
         print(f'  checking for: {dep}')
         if direct not in js and via_module not in js and assignment not in js:
           self.fail(f'use of declared dependency {dep} not found in JS output for {function}')
+
+  def test_shell_Oz(self):
+    # regression test for -Oz working on non-web, non-node environments that
+    # lack TextDecoder
+    if config.V8_ENGINE not in config.JS_ENGINES:
+      return self.skipTest('no shell to test')
+    self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-Oz'])
+    self.assertContained('hello, world!', self.run_js('a.out.js', engine=config.V8_ENGINE))


### PR DESCRIPTION
Shells may not have TextDecoder - only Web and Node are guaranteed to.