### PR TITLE
Tolerate people linking duplicated libraries

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -134,7 +134,8 @@ def unique_ordered(values):
   seen = set()
 
   def check(value):
-    if value in seen:
+    # Dedup value if it already exists and it's not a link flag (flags start with '-')
+    if value in seen and not value.startswith('-'):
       return False
     seen.add(value)
     return True

--- a/tools/building.py
+++ b/tools/building.py
@@ -607,6 +607,10 @@ def link_lld(args, target, external_symbol_list=None):
   # grouping.
   args = [a for a in args if a not in ('--start-group', '--end-group')]
 
+  # Finish link
+  # tolerate people trying to link a.so a.so etc.
+  args = unique_ordered(args)
+
   # Emscripten currently expects linkable output (SIDE_MODULE/MAIN_MODULE) to
   # include all archive contents.
   if Settings.LINKABLE:


### PR DESCRIPTION
Tolerate people linking duplicated libraries when churning out an executable.
E.g.
`emcc foo.a foo.a -o final.js`