### PR TITLE
Make it easier to detect thread pool exhaustion

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -465,15 +465,17 @@ var LibraryPThread = {
 
     getNewWorker: function() {
       if (PThread.unusedWorkers.length == 0) {
-#if PTHREAD_POOL_SIZE_STRICT || ASSERTIONS
-        var warning = 'Tried to spawn a new thread, but the thread pool is exhausted.\n' +
+#if ASSERTIONS
+        err('Tried to spawn a new thread, but the thread pool is exhausted.\n' +
         'This will result in a deadlock unless the code explicitly breaks out to the event loop.\n' +
-        'If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.';
+        'If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.'
 #if !PTHREAD_POOL_SIZE_STRICT
-        err(warning + '\nIf you want to throw an explicit error instead of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=1`.');
-#else
-        throw new Error(warning);
+        + '\nIf you want to throw an explicit error instead of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=1`.'
 #endif
+        );
+#endif
+#if PTHREAD_POOL_SIZE_STRICT
+        throw new Error('No available workers in the PThread pool');
 #endif
         PThread.allocateUnusedWorker();
         PThread.loadWasmModuleToWorker(PThread.unusedWorkers[0]);

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -465,7 +465,7 @@ var LibraryPThread = {
 
     getNewWorker: function() {
       if (PThread.unusedWorkers.length == 0) {
-#if PROXY_TO_PTHREAD
+#if !PROXY_TO_PTHREAD
 #if ASSERTIONS || PTHREADS_DEBUG
         err('Tried to spawn a new thread, but the thread pool is exhausted.\n' +
         'This will result in a deadlock unless the code explicitly breaks out to the event loop.\n' +

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -465,7 +465,8 @@ var LibraryPThread = {
 
     getNewWorker: function() {
       if (PThread.unusedWorkers.length == 0) {
-#if ASSERTIONS
+#if PROXY_TO_PTHREAD
+#if ASSERTIONS || PTHREADS_DEBUG
         err('Tried to spawn a new thread, but the thread pool is exhausted.\n' +
         'This will result in a deadlock unless the code explicitly breaks out to the event loop.\n' +
         'If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.'
@@ -476,6 +477,7 @@ var LibraryPThread = {
 #endif
 #if PTHREAD_POOL_SIZE_STRICT
         throw new Error('No available workers in the PThread pool');
+#endif
 #endif
         PThread.allocateUnusedWorker();
         PThread.loadWasmModuleToWorker(PThread.unusedWorkers[0]);

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -465,6 +465,16 @@ var LibraryPThread = {
 
     getNewWorker: function() {
       if (PThread.unusedWorkers.length == 0) {
+#if PTHREAD_POOL_SIZE_STRICT || ASSERTIONS
+        var warning = 'Tried to spawn a new thread, but the thread pool is exhausted.\n' +
+        'This will result in a deadlock unless the code explicitly breaks out to the event loop.\n' +
+        'If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.';
+#if !PTHREAD_POOL_SIZE_STRICT
+        err(warning + '\nIf you want to throw an explicit error instead of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=1`.');
+#else
+        throw new Error(warning);
+#endif
+#endif
         PThread.allocateUnusedWorker();
         PThread.loadWasmModuleToWorker(PThread.unusedWorkers[0]);
       }

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -468,10 +468,10 @@ var LibraryPThread = {
 #if !PROXY_TO_PTHREAD
 #if PTHREAD_POOL_SIZE_STRICT
         err('Tried to spawn a new thread, but the thread pool is exhausted.\n' +
-        'This will result in a deadlock unless the code explicitly breaks out to the event loop.\n' +
+        'This might result in a deadlock unless some threads eventually exit or the code explicitly breaks out to the event loop.\n' +
         'If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.'
 #if PTHREAD_POOL_SIZE_STRICT == 1
-        + '\nIf you want to throw an explicit error instead of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=2`.'
+        + '\nIf you want to throw an explicit error instead of the risk of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=2`.'
 #endif
         );
 #endif

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -466,16 +466,15 @@ var LibraryPThread = {
     getNewWorker: function() {
       if (PThread.unusedWorkers.length == 0) {
 #if !PROXY_TO_PTHREAD
-#if PTHREAD_POOL_SIZE_STRICT
+#if PTHREAD_POOL_SIZE_STRICT == 1
         err('Tried to spawn a new thread, but the thread pool is exhausted.\n' +
         'This might result in a deadlock unless some threads eventually exit or the code explicitly breaks out to the event loop.\n' +
         'If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.'
-#if PTHREAD_POOL_SIZE_STRICT == 1
         + '\nIf you want to throw an explicit error instead of the risk of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=2`.'
-#endif
         );
 #endif
 #if PTHREAD_POOL_SIZE_STRICT == 2
+        err('No available workers in the PThread pool');
         return;
 #endif
 #endif
@@ -544,7 +543,7 @@ var LibraryPThread = {
     var worker = PThread.getNewWorker();
 
     if (!worker) {
-      err('No available workers in the PThread pool');
+      // No available workers in the PThread pool.
       return {{{ cDefine('EAGAIN') }}};
     }
     if (worker.pthread !== undefined) throw 'Internal error!';

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -466,16 +466,16 @@ var LibraryPThread = {
     getNewWorker: function() {
       if (PThread.unusedWorkers.length == 0) {
 #if !PROXY_TO_PTHREAD
-#if ASSERTIONS || PTHREADS_DEBUG
+#if PTHREAD_POOL_SIZE_STRICT
         err('Tried to spawn a new thread, but the thread pool is exhausted.\n' +
         'This will result in a deadlock unless the code explicitly breaks out to the event loop.\n' +
         'If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.'
-#if !PTHREAD_POOL_SIZE_STRICT
-        + '\nIf you want to throw an explicit error instead of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=1`.'
+#if PTHREAD_POOL_SIZE_STRICT == 1
+        + '\nIf you want to throw an explicit error instead of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=2`.'
 #endif
         );
 #endif
-#if PTHREAD_POOL_SIZE_STRICT
+#if PTHREAD_POOL_SIZE_STRICT == 2
         throw new Error('No available workers in the PThread pool');
 #endif
 #endif

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -831,9 +831,8 @@ var LibraryPThread = {
       // new thread, the thread creation must be deferred to the main JS thread.
       threadParams.cmd = 'spawnThread';
       postMessage(threadParams, transferList);
-      // We don't care about actual exit code, because spawnThread
-      // only returns non-0 as part of the PTHREAD_POOL_SIZE_STRICT check, which
-      // doesn't apply to the PROXY_TO_PTHREAD mode we're in anyway.
+      // When we defer thread creation this way, we have no way to detect thread
+      // creation synchronously today, so we have to assume success and return 0.
       return 0;
     }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1459,6 +1459,17 @@ var USE_PTHREADS = 0;
 // [link] - affects generated JS runtime code at link time
 var PTHREAD_POOL_SIZE = '';
 
+// Normally, applications can create new threads even when the pool is empty.
+// When application breaks out to the JS event loop before trying to block on
+// the thread via `pthread_join` or via manual condvars,
+// an extra Worker will be created and the thread callback will be executed.
+// However, breaking out to the event loop requires custom modifications to
+// the code to adapt it to the Web, and not something that works for
+// off-the-shelf apps. Those apps without any modifications are most likely
+// to deadlock. This setting ensures that, instead of a deadlock, they get
+// a runtime error instead that can be at least handled from the JS side.
+var PTHREAD_POOL_SIZE_STRICT = 0;
+
 // If your application does not need the ability to synchronously create
 // threads, but it would still like to opportunistically speed up initial thread
 // startup time by prewarming a pool of Workers, you can specify the size of

--- a/src/settings.js
+++ b/src/settings.js
@@ -1468,7 +1468,12 @@ var PTHREAD_POOL_SIZE = '';
 // off-the-shelf apps. Those apps without any modifications are most likely
 // to deadlock. This setting ensures that, instead of a deadlock, they get
 // a runtime error instead that can be at least handled from the JS side.
-var PTHREAD_POOL_SIZE_STRICT = 0;
+// Values:
+//  - `0` - disable warnings on thread pool exhaustion
+//  - `1` - enable warnings on thread pool exhaustion (default)
+//  - `2` - make thread pool exhaustion a hard error
+// [link]
+var PTHREAD_POOL_SIZE_STRICT = 1;
 
 // If your application does not need the ability to synchronously create
 // threads, but it would still like to opportunistically speed up initial thread

--- a/src/settings.js
+++ b/src/settings.js
@@ -1466,8 +1466,9 @@ var PTHREAD_POOL_SIZE = '';
 // However, breaking out to the event loop requires custom modifications to
 // the code to adapt it to the Web, and not something that works for
 // off-the-shelf apps. Those apps without any modifications are most likely
-// to deadlock. This setting ensures that, instead of a deadlock, they get
-// a runtime error instead that can be at least handled from the JS side.
+// to deadlock. This setting ensures that, instead of a risking a deadlock,
+// they get a runtime EAGAIN error instead that can be at least gracefully
+// handled from the C / C++ side.
 // Values:
 //  - `0` - disable warnings on thread pool exhaustion
 //  - `1` - enable warnings on thread pool exhaustion (default)

--- a/src/settings.js
+++ b/src/settings.js
@@ -1461,13 +1461,13 @@ var PTHREAD_POOL_SIZE = '';
 
 // Normally, applications can create new threads even when the pool is empty.
 // When application breaks out to the JS event loop before trying to block on
-// the thread via `pthread_join` or via manual condvars,
+// the thread via `pthread_join` or any other blocking primitive,
 // an extra Worker will be created and the thread callback will be executed.
 // However, breaking out to the event loop requires custom modifications to
 // the code to adapt it to the Web, and not something that works for
 // off-the-shelf apps. Those apps without any modifications are most likely
 // to deadlock. This setting ensures that, instead of a risking a deadlock,
-// they get a runtime EAGAIN error instead that can be at least gracefully
+// they get a runtime EAGAIN error instead that can at least be gracefully
 // handled from the C / C++ side.
 // Values:
 //  - `0` - disable warnings on thread pool exhaustion

--- a/tests/pthread/test_pthread_c11_threads.c
+++ b/tests/pthread/test_pthread_c11_threads.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <assert.h>
 #include <threads.h>
 
@@ -22,6 +23,12 @@ int run_with_exit(void* arg) {
   thrd_exit(43);
 }
 
+#ifdef REPORT_RESULT
+#define EM_ASSERT(x) if (!(x)) { REPORT_RESULT(1); abort(); }
+#else
+#define EM_ASSERT(x) assert(x)
+#endif
+
 int main(int argc, char* argv[]) {
   int result = 0;
   printf("thrd_current: %p\n", thrd_current());
@@ -32,31 +39,31 @@ int main(int argc, char* argv[]) {
   thrd_t t3;
   thrd_t t4;
 
-  thrd_create(&t1, thread_main, NULL);
-  thrd_create(&t2, thread_main, NULL);
-  thrd_create(&t3, thread_main, NULL);
-  thrd_create(&t4, thread_main, NULL);
+  EM_ASSERT(thrd_create(&t1, thread_main, NULL) == thrd_success);
+  EM_ASSERT(thrd_create(&t2, thread_main, NULL) == thrd_success);
+  EM_ASSERT(thrd_create(&t3, thread_main, NULL) == thrd_success);
+  EM_ASSERT(thrd_create(&t4, thread_main, NULL) == thrd_success);
 
-  assert(!thrd_equal(t1, t2));
-  assert(thrd_equal(t1, t1));
+  EM_ASSERT(!thrd_equal(t1, t2));
+  EM_ASSERT(thrd_equal(t1, t1));
 
-  thrd_join(t1, &result);
-  thrd_join(t2, &result);
-  thrd_join(t3, &result);
-  thrd_join(t4, &result);
-  assert(result == 42);
-  assert(counter == 1);
+  EM_ASSERT(thrd_join(t1, &result) == thrd_success);
+  EM_ASSERT(thrd_join(t2, &result) == thrd_success);
+  EM_ASSERT(thrd_join(t3, &result) == thrd_success);
+  EM_ASSERT(thrd_join(t4, &result) == thrd_success);
+  EM_ASSERT(result == 42);
+  EM_ASSERT(counter == 1);
 
   // Test thrd_exit return value
   thrd_t t5;
-  thrd_create(&t5, run_with_exit, NULL);
-  thrd_join(t5, &result);
-  assert(result == 43);
+  EM_ASSERT(thrd_create(&t5, run_with_exit, NULL) == thrd_success);
+  EM_ASSERT(thrd_join(t5, &result) == thrd_success);
+  EM_ASSERT(result == 43);
 
   // Test thrd_detach
   thrd_t t6;
-  thrd_create(&t6, thread_main, NULL);
-  thrd_detach(t6);
+  EM_ASSERT(thrd_create(&t6, thread_main, NULL) == thrd_success);
+  EM_ASSERT(thrd_detach(t6) == thrd_success);
 
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);

--- a/tests/pthread/test_pthread_c11_threads.c
+++ b/tests/pthread/test_pthread_c11_threads.c
@@ -23,12 +23,6 @@ int run_with_exit(void* arg) {
   thrd_exit(43);
 }
 
-#ifdef REPORT_RESULT
-#define EM_ASSERT(x) if (!(x)) { REPORT_RESULT(1); abort(); }
-#else
-#define EM_ASSERT(x) assert(x)
-#endif
-
 int main(int argc, char* argv[]) {
   int result = 0;
   printf("thrd_current: %p\n", thrd_current());
@@ -39,31 +33,31 @@ int main(int argc, char* argv[]) {
   thrd_t t3;
   thrd_t t4;
 
-  EM_ASSERT(thrd_create(&t1, thread_main, NULL) == thrd_success);
-  EM_ASSERT(thrd_create(&t2, thread_main, NULL) == thrd_success);
-  EM_ASSERT(thrd_create(&t3, thread_main, NULL) == thrd_success);
-  EM_ASSERT(thrd_create(&t4, thread_main, NULL) == thrd_success);
+  assert(thrd_create(&t1, thread_main, NULL) == thrd_success);
+  assert(thrd_create(&t2, thread_main, NULL) == thrd_success);
+  assert(thrd_create(&t3, thread_main, NULL) == thrd_success);
+  assert(thrd_create(&t4, thread_main, NULL) == thrd_success);
 
-  EM_ASSERT(!thrd_equal(t1, t2));
-  EM_ASSERT(thrd_equal(t1, t1));
+  assert(!thrd_equal(t1, t2));
+  assert(thrd_equal(t1, t1));
 
-  EM_ASSERT(thrd_join(t1, &result) == thrd_success);
-  EM_ASSERT(thrd_join(t2, &result) == thrd_success);
-  EM_ASSERT(thrd_join(t3, &result) == thrd_success);
-  EM_ASSERT(thrd_join(t4, &result) == thrd_success);
-  EM_ASSERT(result == 42);
-  EM_ASSERT(counter == 1);
+  assert(thrd_join(t1, &result) == thrd_success);
+  assert(thrd_join(t2, &result) == thrd_success);
+  assert(thrd_join(t3, &result) == thrd_success);
+  assert(thrd_join(t4, &result) == thrd_success);
+  assert(result == 42);
+  assert(counter == 1);
 
   // Test thrd_exit return value
   thrd_t t5;
-  EM_ASSERT(thrd_create(&t5, run_with_exit, NULL) == thrd_success);
-  EM_ASSERT(thrd_join(t5, &result) == thrd_success);
-  EM_ASSERT(result == 43);
+  assert(thrd_create(&t5, run_with_exit, NULL) == thrd_success);
+  assert(thrd_join(t5, &result) == thrd_success);
+  assert(result == 43);
 
   // Test thrd_detach
   thrd_t t6;
-  EM_ASSERT(thrd_create(&t6, thread_main, NULL) == thrd_success);
-  EM_ASSERT(thrd_detach(t6) == thrd_success);
+  assert(thrd_create(&t6, thread_main, NULL) == thrd_success);
+  assert(thrd_detach(t6) == thrd_success);
 
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -16,17 +16,19 @@ static void *thread2_start(void *arg)
 {
   EM_ASM(out('thread2_start!'));
   ++result;
-
-  pthread_exit(0);
+  return NULL;
 }
 
 static void *thread1_start(void *arg)
 {
-  EM_ASM(out('thread1_start!'));
+  EM_ASM(out('thread1_start!'); debugger);
   pthread_t thr;
-  pthread_create(&thr, NULL, thread2_start, 0);
-  pthread_join(thr, 0);
-  pthread_exit(0);
+  if (pthread_create(&thr, NULL, thread2_start, NULL) != 0) {
+    result = -200;
+    return NULL;
+  }
+  pthread_join(thr, NULL);
+  return NULL;
 }
 
 int main()
@@ -41,7 +43,7 @@ int main()
   }
 
   pthread_t thr;
-  pthread_create(&thr, NULL, thread1_start, 0);
+  pthread_create(&thr, NULL, thread1_start, NULL);
 
   pthread_attr_t attr;
   pthread_getattr_np(thr, &attr);
@@ -49,10 +51,10 @@ int main()
   void *stack_addr;
   pthread_attr_getstack(&attr, &stack_addr, &stack_size);
   printf("stack_size: %d, stack_addr: %p\n", (int)stack_size, stack_addr);
-  if (stack_size != 2*1024*1024 || stack_addr == 0)
+  if (stack_size != 2*1024*1024 || stack_addr == NULL)
     result = -100; // Report failure.
 
-  pthread_join(thr, 0);
+  pthread_join(thr, NULL);
 
 #ifdef REPORT_RESULT
   REPORT_RESULT(result);

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -21,7 +21,7 @@ static void *thread2_start(void *arg)
 
 static void *thread1_start(void *arg)
 {
-  EM_ASM(out('thread1_start!'); debugger);
+  EM_ASM(out('thread1_start!'));
   pthread_t thr;
   if (pthread_create(&thr, NULL, thread2_start, NULL) != 0) {
     result = -200;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3637,7 +3637,7 @@ window.close = function() {
                args=['-g2', '-xc', '-std=gnu11', '-pthread', '-s', 'PTHREAD_POOL_SIZE=4', '-s', 'PTHREAD_POOL_SIZE_STRICT=2', '-s', 'TOTAL_MEMORY=64mb'])
     # Check that it fails instead of deadlocking on insufficient number of threads in the pool.
     self.btest(path_from_root('tests', 'pthread', 'test_pthread_c11_threads.c'),
-               expected='1',
+               expected='abort:Assertion failed: thrd_create(&t4, thread_main, NULL) == thrd_success',
                args=['-g2', '-xc', '-std=gnu11', '-pthread', '-s', 'PTHREAD_POOL_SIZE=3', '-s', 'PTHREAD_POOL_SIZE_STRICT=2', '-s', 'TOTAL_MEMORY=64mb'])
 
   @requires_threads

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3629,6 +3629,24 @@ window.close = function() {
                expected='0',
                args=['-g4', '-std=gnu11', '-xc', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'TOTAL_MEMORY=64mb'])
 
+  @requires_threads
+  def test_pthread_pool_size_strict(self):
+    # Check that it doesn't fail with sufficient number of threads in the pool.
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_c11_threads.c'),
+               expected='0',
+               args=['-g2', '-xc', '-std=gnu11', '-pthread', '-s', 'PTHREAD_POOL_SIZE=4', '-s', 'PTHREAD_POOL_SIZE_STRICT=2', '-s', 'TOTAL_MEMORY=64mb'])
+    # Check that it fails instead of deadlocking on insufficient number of threads in the pool.
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_c11_threads.c'),
+               expected='1',
+               args=['-g2', '-xc', '-std=gnu11', '-pthread', '-s', 'PTHREAD_POOL_SIZE=3', '-s', 'PTHREAD_POOL_SIZE_STRICT=2', '-s', 'TOTAL_MEMORY=64mb'])
+
+  @requires_threads
+  def test_pthread_in_pthread_pool_size_strict(self):
+    # Check that it fails when there's a pthread creating another pthread.
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_create_pthread.cpp'), expected='1', args=['-g2', '-pthread', '-s', 'PTHREAD_POOL_SIZE=2', '-s', 'PTHREAD_POOL_SIZE_STRICT=2'])
+    # Check that it fails when there's a pthread creating another pthread.
+    self.btest(path_from_root('tests', 'pthread', 'test_pthread_create_pthread.cpp'), expected='-200', args=['-g2', '-pthread', '-s', 'PTHREAD_POOL_SIZE=1', '-s', 'PTHREAD_POOL_SIZE_STRICT=2'])
+
   # Test that the emscripten_ atomics api functions work.
   @parameterized({
     'normal': ([],),


### PR DESCRIPTION
Off-the-shelf C++ code doesn't know anything about JS event loop, and "normal" usages of `pthread_create` + `pthread_join` or any form of locks just deadlock silently.

This frequently leads to user confusion and those issues are not the easiest to debug. Some long-term solutions were proposed in https://github.com/emscripten-core/emscripten/issues/9910 and in https://github.com/emscripten-core/emscripten/issues/11554#issuecomment-699082669, but they require more design work.

For now this can at least fix https://github.com/emscripten-core/emscripten/issues/11554 and 1) warn users that the thread pool is exhausted in debug builds (`-s ASSERTIONS=1`) and 2) add an option `PTHREAD_POOL_SIZE_STRICT` to make such exhaustion a hard error in release builds for users who don't expect to create any more threads than preconfigured during the build time.

---

Example output before/after:

```bash
rreverser@rreverser:~/emscripten$ emcc temp.cpp -o temp.js -pthread
rreverser@rreverser:~/emscripten$ node --experimental-wasm-threads --experimental-wasm-bulk-memory temp.js
Before Thread
^C # cancelled because app was locked

rreverser@rreverser:~/emscripten$ ./emcc temp.cpp -o temp.js -pthread
rreverser@rreverser:~/emscripten$ node --experimental-wasm-threads --experimental-wasm-bulk-memory temp.js
Before Thread
Tried to spawn a new thread, but the thread pool is exhausted.
This will result in a deadlock unless the code explicitly breaks out to the event loop.
If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.
If you want to throw an explicit error instead of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=1`.
^C # cancelled because app was locked

rreverser@rreverser:~/emscripten$ ./emcc temp.cpp -o temp.js -pthread -s PTHREAD_POOL_SIZE_STRICT=1
rreverser@rreverser:~/emscripten$ node --experimental-wasm-threads --experimental-wasm-bulk-memory temp.js
Before Thread
Tried to spawn a new thread, but the thread pool is exhausted.
This will result in a deadlock unless the code explicitly breaks out to the event loop.
If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.
exception thrown: Error: No available workers in the PThread pool,Error: No available workers in the PThread pool
    at Object.getNewWorker (/usr/local/google/home/rreverser/emscripten/temp.js:2173:17)
    at spawnThread (/usr/local/google/home/rreverser/emscripten/temp.js:2982:28)
    at _pthread_create (/usr/local/google/home/rreverser/emscripten/temp.js:3138:9)
    at <anonymous>:wasm-function[25]:0x923
    at main (<anonymous>:wasm-function[26]:0x956)
    at /usr/local/google/home/rreverser/emscripten/temp.js:1639:22
    at callMain (/usr/local/google/home/rreverser/emscripten/temp.js:3655:15)
    at doRun (/usr/local/google/home/rreverser/emscripten/temp.js:3732:23)
    at run (/usr/local/google/home/rreverser/emscripten/temp.js:3747:5)
    at runCaller (/usr/local/google/home/rreverser/emscripten/temp.js:3633:19)

rreverser@rreverser:~/emscripten$ ./emcc temp.cpp -o temp.js -pthread -s PTHREAD_POOL_SIZE_STRICT=1 -s ASSERTIONS=0
rreverser@rreverser:~/emscripten$ node --experimental-wasm-threads --experimental-wasm-bulk-memory temp.js
Before Thread
exception thrown: Error: No available workers in the PThread pool,Error: No available workers in the PThread pool
    at Object.getNewWorker (/usr/local/google/home/rreverser/emscripten/temp.js:1892:17)
    at spawnThread (/usr/local/google/home/rreverser/emscripten/temp.js:2676:28)
    at _pthread_create (/usr/local/google/home/rreverser/emscripten/temp.js:2832:9)
    at <anonymous>:wasm-function[25]:0x8be
    at main (<anonymous>:wasm-function[26]:0x8f1)
    at Module._main (/usr/local/google/home/rreverser/emscripten/temp.js:2985:60)
    at callMain (/usr/local/google/home/rreverser/emscripten/temp.js:3156:15)
    at doRun (/usr/local/google/home/rreverser/emscripten/temp.js:3222:23)
    at run (/usr/local/google/home/rreverser/emscripten/temp.js:3237:5)
    at runCaller (/usr/local/google/home/rreverser/emscripten/temp.js:3136:19)
# thrown a hard error and exited without long warning
```

---

Another alternative I considered was untying this warning from `ASSERTIONS`. There are two reasons to go that route:

1. This is not always an error and advanced users who return to event loop between thread creation & usage might want to disable this particular warning separately from other assertions.
2. Majority of users might want to see at least a warning even in release builds where other assertions are disabled, since number of threads can depend on the input data.

If that's an acceptable option, then I'd instead define `PTHREAD_POOL_SIZE_STRICT` as follows:

 - `-s PTHREAD_POOL_SIZE_STRICT=0` -> no warnings for users who know what they're doing and adapted their code to break out to the event loop
 - `-s PTHREAD_POOL_SIZE_STRICT=1` -> default option, show warning but still try to create a thread, so that users at least know why there's a deadlock if it occurs
 - `-s PTHREAD_POOL_SIZE_STRICT=2` -> for users who saw the warning and decided to go all-in on the limit, as they are just trying to compile a code to the Web and don't want to mess with event loop APIs