### PR TITLE
Add centralized handling for calling user callbacks

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1599,7 +1599,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if not shared.Settings.MINIMAL_RUNTIME:
       # In non-MINIMAL_RUNTIME, the core runtime depends on these functions to be present. (In MINIMAL_RUNTIME, they are
       # no longer always bundled in)
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$demangle', '$demangleAll', '$jsStackTrace', '$stackTrace']
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+        '$keepRuntimeAlive',
+        '$demangle',
+        '$demangleAll',
+        '$jsStackTrace',
+        '$stackTrace'
+      ]
 
     if shared.Settings.FILESYSTEM:
       # to flush streams on FS exit, we need to be able to call fflush
@@ -1716,7 +1722,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       include_and_export('invokeEntryPoint')
       if not shared.Settings.MINIMAL_RUNTIME:
         # noExitRuntime does not apply to MINIMAL_RUNTIME.
-        include_and_export('getNoExitRuntime')
+        include_and_export('keepRuntimeAlive')
 
       if shared.Settings.MODULARIZE:
         if shared.Settings.EXPORT_NAME == 'Module':

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -432,11 +432,9 @@ function fetchXHR(fetch, onsuccess, onerror, onprogress, onreadystatechange) {
 }
 
 function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
-#if !MINIMAL_RUNTIME
   // Avoid shutting down the runtime since we want to wait for the async
   // response.
-  noExitRuntime = true;
-#endif
+  {{{ runtimeKeepalivePush() }}}
 
   var fetch_attr = fetch + {{{ C_STRUCTS.emscripten_fetch_t.__attributes }}};
   var requestMethod = UTF8ToString(fetch_attr);
@@ -458,29 +456,39 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
 #if FETCH_DEBUG
     console.log('fetch: operation success. e: ' + e);
 #endif
-    if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
-    else if (successcb) successcb(fetch);
+    {{{ runtimeKeepalivePop() }}}
+    callUserCallback(function() {
+      if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
+      else if (successcb) successcb(fetch);
+    });
   };
 
   var reportProgress = function(fetch, xhr, e) {
-    if (onprogress) {{{ makeDynCall('vi', 'onprogress') }}}(fetch);
-    else if (progresscb) progresscb(fetch);
+    callUserCallback(function() {
+      if (onprogress) {{{ makeDynCall('vi', 'onprogress') }}}(fetch);
+      else if (progresscb) progresscb(fetch);
+    });
   };
 
   var reportError = function(fetch, xhr, e) {
 #if FETCH_DEBUG
     console.error('fetch: operation failed: ' + e);
 #endif
-    if (onerror) {{{ makeDynCall('vi', 'onerror') }}}(fetch);
-    else if (errorcb) errorcb(fetch);
+    {{{ runtimeKeepalivePop() }}}
+    callUserCallback(function() {
+      if (onerror) {{{ makeDynCall('vi', 'onerror') }}}(fetch);
+      else if (errorcb) errorcb(fetch);
+    });
   };
 
   var reportReadyStateChange = function(fetch, xhr, e) {
 #if FETCH_DEBUG
     console.log('fetch: ready state change. e: ' + e);
 #endif
-    if (onreadystatechange) {{{ makeDynCall('vi', 'onreadystatechange') }}}(fetch);
-    else if (readystatechangecb) readystatechangecb(fetch);
+    callUserCallback(function() {
+      if (onreadystatechange) {{{ makeDynCall('vi', 'onreadystatechange') }}}(fetch);
+      else if (readystatechangecb) readystatechangecb(fetch);
+    });
   };
 
   var performUncachedXhr = function(fetch, xhr, e) {
@@ -499,15 +507,21 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
 #if FETCH_DEBUG
       console.log('fetch: IndexedDB store succeeded.');
 #endif
-      if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
-      else if (successcb) successcb(fetch);
+      {{{ runtimeKeepalivePop() }}}
+      callUserCallback(function() {
+        if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
+        else if (successcb) successcb(fetch);
+      });
     };
     var storeError = function(fetch, xhr, e) {
 #if FETCH_DEBUG
       console.error('fetch: IndexedDB store failed.');
 #endif
-      if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
-      else if (successcb) successcb(fetch);
+      {{{ runtimeKeepalivePop() }}}
+      callUserCallback(function() {
+        if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
+        else if (successcb) successcb(fetch);
+      });
     };
     fetchCacheData(Fetch.dbInstance, fetch, xhr.response, storeSuccess, storeError);
   };

--- a/src/library.js
+++ b/src/library.js
@@ -3771,13 +3771,16 @@ LibraryManager.library = {
   },
 
   // Callable in pthread without __proxy needed.
-  emscripten_exit_with_live_runtime: function() {
+  emscripten_exit_with_live_runtime__sig: 'v',
 #if !MINIMAL_RUNTIME
-    noExitRuntime = true;
+  emscripten_exit_with_live_runtime__deps: ['$runtimeKeepalivePush'],
 #endif
+  emscripten_exit_with_live_runtime: function() {
+    {{{ runtimeKeepalivePush() }}}
     throw 'unwind';
   },
 
+  emscripten_force_exit__deps: ['$runtimeKeepaliveCounter'],
   emscripten_force_exit__proxy: 'sync',
   emscripten_force_exit__sig: 'vi',
   emscripten_force_exit: function(status) {
@@ -3788,9 +3791,111 @@ LibraryManager.library = {
 #endif
 #if !MINIMAL_RUNTIME
     noExitRuntime = false;
+    runtimeKeepaliveCounter = 0;
 #endif
     exit(status);
   },
+
+#if !MINIMAL_RUNTIME
+  $runtimeKeepaliveCounter: 0,
+
+  $keepRuntimeAlive__deps: ['$runtimeKeepaliveCounter'],
+  $keepRuntimeAlive: function() {
+    return noExitRuntime || runtimeKeepaliveCounter > 0;
+  },
+
+  // Callable in pthread without __proxy needed.
+  $runtimeKeepalivePush__sig: 'v',
+  $runtimeKeepalivePush__deps: ['$runtimeKeepaliveCounter'],
+  $runtimeKeepalivePush: function() {
+    runtimeKeepaliveCounter += 1;
+#if RUNTIME_DEBUG
+    err('runtimeKeepalivePush -> counter=' + runtimeKeepaliveCounter);
+#endif
+  },
+
+  $runtimeKeepalivePop__sig: 'v',
+  $runtimeKeepalivePop__deps: ['$runtimeKeepaliveCounter'],
+  $runtimeKeepalivePop: function() {
+#if ASSERTIONS
+    assert(runtimeKeepaliveCounter > 0);
+#endif
+    runtimeKeepaliveCounter -= 1;
+#if RUNTIME_DEBUG
+    err('runtimeKeepalivePop -> counter=' + runtimeKeepaliveCounter);
+#endif
+  },
+
+
+  // Used to call user callbacks from the embedder / event loop.  For example
+  // setTimeout or any other kind of event handler that calls into user case
+  // needs to use this wrapper.
+  //
+  // The job of this wrapper is the handle emscripten-specfic exceptions such
+  // as ExitStatus and 'unwind' and prevent these from escaping to the top
+  // level.
+#if EXIT_RUNTIME || USE_PTHREADS
+  $callUserCallback__deps: ['$maybeExit'],
+#endif
+  $callUserCallback: function(func) {
+    if (ABORT) {
+#if ASSERTIONS
+      err('user callback triggered after application aborted.  Ignoring.');
+      return;
+#endif
+    }
+    try {
+      func();
+    } catch (e) {
+      if (e instanceof ExitStatus) {
+        return;
+      } else if (e !== 'unwind') {
+        // And actual unexpected user-exectpion occured
+        if (e && typeof e === 'object' && e.stack) err('exception thrown: ' + [e, e.stack]);
+        throw e;
+      }
+    }
+#if EXIT_RUNTIME || USE_PTHREADS
+#if USE_PTHREADS && !EXIT_RUNTIME
+    if (ENVIRONMENT_IS_PTHREAD)
+#endif
+      maybeExit();
+#endif
+  },
+
+  $maybeExit__deps: ['exit',
+#if USE_PTHREADS
+    'pthread_exit',
+#endif
+  ],
+  $maybeExit: function() {
+#if RUNTIME_DEBUG
+    err('maybeExit: user callback done: runtimeKeepaliveCounter=' + runtimeKeepaliveCounter);
+#endif
+    if (!keepRuntimeAlive()) {
+#if RUNTIME_DEBUG
+      err('maybeExit: calling exit() implicitly after user callback completed: ' + EXITSTATUS);
+#endif
+      try {
+#if USE_PTHREADS
+        if (ENVIRONMENT_IS_PTHREAD) _pthread_exit(EXITSTATUS);
+        else
+#endif
+        _exit(EXITSTATUS);
+      } catch (e) {
+        if (e instanceof ExitStatus) {
+          return;
+        }
+        throw e;
+      }
+    }
+  },
+#else
+  // MINIMAL_RUNTIME doesn't support the runtimeKeepalive stuff
+  $callUserCallback: function(func) {
+    func();
+  },
+#endif
 };
 
 function autoAddDeps(object, name) {

--- a/src/library_bootstrap.js
+++ b/src/library_bootstrap.js
@@ -13,5 +13,6 @@ assert(false, "library_bootstrap.js only designed for use with BOOTSTRAPPING_STR
 
 assert(!LibraryManager.library);
 LibraryManager.library = {
-  $callRuntimeCallbacks: function() {}
+  $callRuntimeCallbacks: function() {},
+  $keepRuntimeAlive: function() { return false }
 };

--- a/src/library_fetch.js
+++ b/src/library_fetch.js
@@ -25,11 +25,21 @@ var LibraryFetch = {
   $fetchXHR: fetchXHR,
 
   emscripten_start_fetch: startFetch,
-  emscripten_start_fetch__deps: ['$Fetch', '$fetchXHR',
-#if FETCH_SUPPORT_INDEXEDDB
-  '$fetchCacheData', '$fetchLoadCachedData', '$fetchDeleteCachedData',
+  emscripten_start_fetch__deps: [
+    '$Fetch',
+    '$fetchXHR',
+    '$callUserCallback',
+    'emscripten_is_main_browser_thread',
+#if !MINIMAL_RUNTIME
+    '$runtimeKeepalivePush',
+    '$runtimeKeepalivePop',
 #endif
-  'emscripten_is_main_browser_thread']
+#if FETCH_SUPPORT_INDEXEDDB
+    '$fetchCacheData',
+    '$fetchLoadCachedData',
+    '$fetchDeleteCachedData',
+#endif
+  ]
 };
 
 mergeInto(LibraryManager.library, LibraryFetch);

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -21,15 +21,15 @@ mergeInto(LibraryManager.library, {
       // For more documentation see system/include/emscripten/emscripten.h
       Module['websocket']._callbacks = {};
       Module['websocket']['on'] = /** @this{Object} */ function(event, callback) {
-	    if ('function' === typeof callback) {
-		  this._callbacks[event] = callback;
+        if ('function' === typeof callback) {
+          this._callbacks[event] = callback;
         }
-	    return this;
+        return this;
       };
 
       Module['websocket'].emit = /** @this{Object} */ function(event, param) {
-	    if ('function' === typeof this._callbacks[event]) {
-		  this._callbacks[event].call(this, param);
+        if ('function' === typeof this._callbacks[event]) {
+          this._callbacks[event].call(this, param);
         }
       };
 
@@ -733,15 +733,10 @@ mergeInto(LibraryManager.library, {
    * will deregister the callback registered for that Event.
    */
 #if !MINIMAL_RUNTIME
-  $_setNetworkCallback__deps: [
-    '$runtimeKeepalivePush',
-    '$runtimeKeepalivePop'
-  ],
+  $_setNetworkCallback__deps: ['$runtimeKeepalivePush'],
 #endif
   $_setNetworkCallback: function(event, userData, callback) {
     function _callback(data) {
-      {{{ runtimeKeepalivePop() }}}
-      if (!callback) return;
       try {
         if (event === 'error') {
           var sp = stackSave();
@@ -761,8 +756,10 @@ mergeInto(LibraryManager.library, {
       }
     };
 
+    // FIXME(sbc): This has no corresponding Pop so will currently keep the
+    // runtime alive indefinitely.
     {{{ runtimeKeepalivePush() }}}
-    Module['websocket']['on'](event, _callback);
+    Module['websocket']['on'](event, callback ? _callback : null);
   },
   emscripten_set_socket_error_callback__deps: ['$_setNetworkCallback'],
   emscripten_set_socket_error_callback: function(userData, callback) {

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -732,8 +732,16 @@ mergeInto(LibraryManager.library, {
    * Passing a NULL callback function to a emscripten_set_socket_*_callback call
    * will deregister the callback registered for that Event.
    */
+#if !MINIMAL_RUNTIME
+  $_setNetworkCallback__deps: [
+    '$runtimeKeepalivePush',
+    '$runtimeKeepalivePop'
+  ],
+#endif
   $_setNetworkCallback: function(event, userData, callback) {
     function _callback(data) {
+      {{{ runtimeKeepalivePop() }}}
+      if (!callback) return;
       try {
         if (event === 'error') {
           var sp = stackSave();
@@ -753,8 +761,8 @@ mergeInto(LibraryManager.library, {
       }
     };
 
-    noExitRuntime = true;
-    Module['websocket']['on'](event, callback ? _callback : null);
+    {{{ runtimeKeepalivePush() }}}
+    Module['websocket']['on'](event, _callback);
   },
   emscripten_set_socket_error_callback__deps: ['$_setNetworkCallback'],
   emscripten_set_socket_error_callback: function(userData, callback) {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1291,3 +1291,21 @@ function makeMalloc(source, param) {
   }
   return `abort('malloc was not included, but is needed in ${source}. Adding "_malloc" to EXPORTED_FUNCTIONS should fix that. This may be a bug in the compiler, please file an issue.');`;
 }
+
+// Adds a call to runtimeKeepalivePush, if needed by the current build
+// configuration.
+// We skip this completely in MINIMAL_RUNTIME and also in builds that
+// don't ever need to exit the runtime.
+function runtimeKeepalivePush() {
+  if (MINIMAL_RUNTIME || (EXIT_RUNTIME == 0 && USE_PTHREADS == 0)) return '';
+  return 'runtimeKeepalivePush();';
+}
+
+// Adds a call to runtimeKeepalivePush, if needed by the current build
+// configuration.
+// We skip this completely in MINIMAL_RUNTIME and also in builds that
+// don't ever need to exit the runtime.
+function runtimeKeepalivePop() {
+  if (MINIMAL_RUNTIME || (EXIT_RUNTIME == 0 && USE_PTHREADS == 0)) return '';
+  return 'runtimeKeepalivePop();';
+}

--- a/tests/emscripten_main_loop_and_blocker.cpp
+++ b/tests/emscripten_main_loop_and_blocker.cpp
@@ -16,6 +16,8 @@ void final(void*) {
   assert(frame == 20);
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
+#else
+  exit(0);
 #endif
 }
 
@@ -23,6 +25,8 @@ void looper() {
   if (blockerExecuted == false) {
 #ifdef REPORT_RESULT
     REPORT_RESULT(1);
+#else
+    exit(1);
 #endif
   }
 
@@ -48,4 +52,7 @@ int main() {
   prevTime = emscripten_get_now();
   emscripten_push_uncounted_main_loop_blocker(main_loop_blocker, NULL);
   emscripten_set_main_loop(looper, 60, 1);
+  // Should never get here
+  assert(false);
+  return 99;
 }

--- a/tests/fetch/from_thread.cpp
+++ b/tests/fetch/from_thread.cpp
@@ -1,0 +1,95 @@
+// Copyright 2021 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <string.h>
+#include <stdio.h>
+#include <math.h>
+#include <assert.h>
+#include <emscripten/fetch.h>
+#include <pthread.h>
+
+int result = 0;
+void* thread_main(void* arg) {
+  emscripten_fetch_attr_t attr;
+  emscripten_fetch_attr_init(&attr);
+  strcpy(attr.requestMethod, "GET");
+  attr.userData = (void*)0x12345678;
+  attr.attributes = EMSCRIPTEN_FETCH_REPLACE | EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
+
+  attr.onsuccess = [](emscripten_fetch_t *fetch) {
+    assert(fetch);
+    printf("Finished downloading %llu bytes\n", fetch->numBytes);
+    assert(fetch->url);
+    assert(!strcmp(fetch->url, "gears.png"));
+    assert(fetch->id != 0);
+    assert((uintptr_t)fetch->userData == 0x12345678);
+    assert(fetch->totalBytes == 6407);
+    assert(fetch->numBytes == fetch->totalBytes);
+    assert(fetch->data != 0);
+    // Compute rudimentary checksum of data
+    uint8_t checksum = 0;
+    for(int i = 0; i < fetch->numBytes; ++i)
+      checksum ^= fetch->data[i];
+    printf("Data checksum: %02X\n", checksum);
+    assert(checksum == 0x08);
+    emscripten_fetch_close(fetch);
+    result = 42;
+#ifdef DO_PTHREAD_EXIT
+    pthread_exit(&result);
+#endif
+  };
+
+  attr.onprogress = [](emscripten_fetch_t *fetch) {
+    assert(fetch);
+    if (fetch->status != 200) return;
+    printf("onprogress: dataOffset: %llu, numBytes: %llu, totalBytes: %llu\n", fetch->dataOffset, fetch->numBytes, fetch->totalBytes);
+    if (fetch->totalBytes > 0) {
+      printf("Downloading.. %.2f%% complete.\n", (fetch->dataOffset + fetch->numBytes) * 100.0 / fetch->totalBytes);
+    } else {
+      printf("Downloading.. %lld bytes complete.\n", fetch->dataOffset + fetch->numBytes);
+    }
+    // We must receive a call to the onprogress handler with 100% completion.
+    if (fetch->dataOffset + fetch->numBytes == fetch->totalBytes) ++result;
+    assert(fetch->dataOffset + fetch->numBytes <= fetch->totalBytes);
+    assert(fetch->url);
+    assert(!strcmp(fetch->url, "gears.png"));
+    assert(fetch->id != 0);
+    assert((uintptr_t)fetch->userData == 0x12345678);
+  };
+
+  attr.onerror = [](emscripten_fetch_t *fetch) {
+    assert(false && "onerror handler called, but the transfer should have succeeded!");
+    result = 43;
+#ifdef DO_PTHREAD_EXIT
+    pthread_exit(&result);
+#endif
+  };
+
+  emscripten_fetch_t *fetch = emscripten_fetch(&attr, "gears.png");
+  assert(fetch);
+  static int my_result = 99;
+  return (void*)&my_result;
+}
+
+
+int main() {
+  pthread_t thread;
+  pthread_create(&thread, NULL, thread_main, NULL);
+  int* res;
+  printf("joining fetch thread\n");
+  pthread_join(thread, (void**)&res);
+  printf("join done\n");
+  printf("fetch thread complete: result=%d\n", *res);
+#if DO_PTHREAD_EXIT
+  // if we don't use pthread_exit then exit status should be &result
+  assert(res == &result);
+#else
+  // if we don't use pthread_exit then we expect the exit status to
+  // be what was returned from thread_main.
+  assert(*res == 99);
+#endif
+  REPORT_RESULT(result);
+  return result;
+}

--- a/tests/other/test_runtime_keepalive.cpp
+++ b/tests/other/test_runtime_keepalive.cpp
@@ -1,0 +1,28 @@
+#include <emscripten.h>
+#include <stdio.h>
+
+int main() {
+  EM_ASM({
+    Module["onExit"] = () => { out("onExit"); };
+    runtimeKeepalivePush();
+    out("runtimeKeepalivePush done");
+    counter = 0;
+    function timerCallback() {
+      if (counter < 5) {
+        runtimeKeepalivePush();
+        out("runtimeKeepalivePush done");
+      } else {
+        runtimeKeepalivePop();
+        out("runtimeKeepalivePop done");
+      }
+      counter += 1;
+      callUserCallback(() => {
+        out("in user callback: " + counter);
+      }, 0);
+      setTimeout(timerCallback, 0);
+    }
+    setTimeout(timerCallback, 0);
+  });
+  puts("returning from main");
+  return 0;
+}

--- a/tests/other/test_runtime_keepalive.out
+++ b/tests/other/test_runtime_keepalive.out
@@ -1,0 +1,25 @@
+runtimeKeepalivePush done
+returning from main
+runtimeKeepalivePush done
+in user callback: 1
+runtimeKeepalivePush done
+in user callback: 2
+runtimeKeepalivePush done
+in user callback: 3
+runtimeKeepalivePush done
+in user callback: 4
+runtimeKeepalivePush done
+in user callback: 5
+runtimeKeepalivePop done
+in user callback: 6
+runtimeKeepalivePop done
+in user callback: 7
+runtimeKeepalivePop done
+in user callback: 8
+runtimeKeepalivePop done
+in user callback: 9
+runtimeKeepalivePop done
+in user callback: 10
+runtimeKeepalivePop done
+in user callback: 11
+onExit

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1823,6 +1823,12 @@ keydown(100);keyup(100); // trigger the end
       self.btest('emscripten_main_loop_and_blocker.cpp', '0', args=args)
 
   @requires_threads
+  def test_emscripten_main_loop_and_blocker_exit(self):
+    # Same as above but tests that EXIT_RUNTIME works with emscripten_main_loop.  The
+    # app should still stay alive until the loop ends
+    self.btest_exit('emscripten_main_loop_and_blocker.cpp', 0)
+
+  @requires_threads
   def test_emscripten_main_loop_setimmediate(self):
     for args in [[], ['--proxy-to-worker'], ['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD']]:
       self.btest('emscripten_main_loop_setimmediate.cpp', '1', args=args)
@@ -4386,6 +4392,18 @@ window.close = function() {
                  expected='1',
                  args=['-s', 'FETCH_DEBUG', '-s', 'FETCH'] + arg,
                  also_asmjs=True)
+
+  @parameterized({
+    '': ([],),
+    'pthread_exit': (['-DDO_PTHREAD_EXIT'],),
+  })
+  @requires_threads
+  def test_fetch_from_thread(self, args):
+    shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')
+    self.btest('fetch/from_thread.cpp',
+               expected='42',
+               args=args + ['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'FETCH_DEBUG', '-s', 'FETCH', '-DFILE_DOES_NOT_EXIST'],
+               also_asmjs=True)
 
   def test_fetch_to_indexdb(self):
     shutil.copyfile(path_from_root('tests', 'gears.png'), 'gears.png')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10104,3 +10104,9 @@ exec "$@"
       return self.skipTest('no shell to test')
     self.run_process([EMCC, path_from_root('tests', 'hello_world.c'), '-Oz'])
     self.assertContained('hello, world!', self.run_js('a.out.js', engine=config.V8_ENGINE))
+
+  def test_runtime_keepalive(self):
+    self.uses_es6 = True
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$runtimeKeepalivePush', '$runtimeKeepalivePop', '$callUserCallback'])
+    self.set_setting('EXIT_RUNTIME')
+    self.do_other_test('test_runtime_keepalive.cpp')


### PR DESCRIPTION
This change also changes the way outstanding works keeps the runtime
alive.

We now use a counter rather than a single noExitRuntime variable so
that once outstanding works is complete the thread can be shutdown
if needed.

The specific need for this comes the use case of running fetch thread
and wanting to exit the thread once the fetch completes.  Without
this change `pthread_exit` from a fetch callback generated an
`uncaught unwind` message on the console.

Also if one wants the fetch thread to become joinable there was no
way other than calling `pthread_exit` which has no parallel in the C++
threads world and has issues around calling C++ destructors on the
stack.  With this solution the thread will exit automatically when returning
from the fetch callback.   