### PR TITLE
Update link to the source of WebIDL.py

### DIFF
--- a/third_party/WebIDL.py
+++ b/third_party/WebIDL.py
@@ -1,4 +1,4 @@
-# from http://mxr.mozilla.org/mozilla-central/source/dom/bindings/parser/WebIDL.py
+# from https://hg.mozilla.org/mozilla-central/file/tip/dom/bindings/parser/WebIDL.py
 # rev 501baeb3a034
 
 # This Source Code Form is subject to the terms of the Mozilla Public


### PR DESCRIPTION
Update link to the source file in Mozilla codebase, the old one doesn't work anymore.