### PR TITLE
Delay setting runtimeInitialized, even on pthreads

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -295,7 +295,7 @@ function run(args) {
     // creation promise can be resolved, marking the pthread-Module as initialized.
     readyPromiseResolve(Module);
 #endif // MODULARIZE
-
+    initRuntime();
     postMessage({ 'cmd': 'loaded' });
     return;
   }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -358,10 +358,6 @@ if (!ENVIRONMENT_IS_PTHREAD)
 __ATINIT__.push({ func: function() { ___wasm_call_ctors() } });
 #endif
 
-#if USE_PTHREADS
-if (ENVIRONMENT_IS_PTHREAD) runtimeInitialized = true; // The runtime is hosted in the main thread, and bits shared to pthreads via SharedArrayBuffer. No need to init again in pthread.
-#endif
-
 function preRun() {
 #if USE_PTHREADS
   if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
@@ -387,6 +383,11 @@ function initRuntime() {
   assert(!runtimeInitialized);
 #endif
   runtimeInitialized = true;
+
+#if USE_PTHREADS
+  if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
+#endif
+
 #if STACK_OVERFLOW_CHECK >= 2
 #if RUNTIME_LOGGING
   err('__set_stack_limits: ' + _emscripten_stack_get_base() + ', ' + _emscripten_stack_get_end());

--- a/tests/core/pthread/test_pthread_dylink.c
+++ b/tests/core/pthread/test_pthread_dylink.c
@@ -1,0 +1,38 @@
+#include <pthread.h>
+#include <stdio.h>
+#include "test_pthread_dylink.h"
+
+int foo_main = 77;
+
+int bar_main() {
+  return 42;
+}
+
+void print_addresses() {
+  printf("main_module: &foo_main %p -> %d\n", &foo_main, foo_main);
+  printf("main_module: &foo_side %p -> %d\n", &foo_side, foo_side);
+  printf("main_module: &bar_main %p\n", &bar_main);
+  printf("main_module: &bar_side %p\n", &bar_side);
+}
+
+void* thread_main(void* arg) {
+  printf("secondary thread:\n");
+  print_addresses();
+  print_addresses_side();
+  printf("\n");
+  return NULL;
+}
+
+int main(int argc, char* argv[]) {
+  printf("main thread:\n");
+  print_addresses();
+  print_addresses_side();
+  printf("\n");
+
+  pthread_t thread;
+  pthread_create(&thread, NULL, thread_main, NULL);
+  pthread_join(thread, NULL);
+
+  printf("success\n");
+  return 0;
+}

--- a/tests/core/pthread/test_pthread_dylink.h
+++ b/tests/core/pthread/test_pthread_dylink.h
@@ -1,0 +1,7 @@
+extern int foo_main;  // Data defind in main
+extern int foo_side;  // Data defind in side
+
+int bar_main();  // Function defined in main
+int bar_side();  // Function defined in side
+
+void print_addresses_side();

--- a/tests/core/pthread/test_pthread_dylink_side.c
+++ b/tests/core/pthread/test_pthread_dylink_side.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include "test_pthread_dylink.h"
+
+int foo_side = 55;
+
+int bar_side() {
+  return 42;
+}
+
+void print_addresses_side() {
+  printf("side_module: &foo_main %p -> %d\n", &foo_main, foo_main);
+  printf("side_module: &foo_side %p -> %d\n", &foo_side, foo_side);
+  printf("side_module: &bar_main %p\n", &bar_main);
+  printf("side_module: &bar_side %p\n", &bar_side);
+}

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -593,6 +593,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       # side memory init file, or an empty one in the js
       assert ('/* memory initializer */' not in src) or ('/* memory initializer */ allocate([]' in src)
 
+    return output
+
   def get_func(self, src, name):
     start = src.index('function ' + name + '(')
     t = start

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3533,28 +3533,36 @@ ok
       '''
     self.do_run(src, 'float: 42.\n')
 
-  def dylink_test(self, main, side, expected=None, header=None, main_emcc_args=[],
-                  force_c=False, need_reverse=True, auto_load=True, main_module=1, **kwargs):
+  def dylink_test(self, main, side, expected=None, header=None, force_c=False, **kwargs):
+    # Same as dylink_testf but take source code in string form
+    if not isinstance(side, list):
+      side_file = 'liblib.cpp' if not force_c else 'liblib.c'
+      create_test_file(side_file, side)
+      side = side_file
+    if not isinstance(main, list):
+      main_file = 'main.cpp' if not force_c else 'main.c'
+      create_test_file(main_file, main)
+      main = main_file
     if header:
       create_test_file('header.h', header)
 
+    return self.dylink_testf(main, side, expected, force_c, **kwargs)
+
+  def dylink_testf(self, main, side, expected=None, force_c=False, main_emcc_args=[],
+                   need_reverse=True, auto_load=True, main_module=1, **kwargs):
+    # Same as dylink_test but takes source code as filenames on disc.
     old_args = self.emcc_args[:]
 
     # side settings
     self.clear_setting('MAIN_MODULE')
     self.set_setting('SIDE_MODULE')
     side_suffix = 'wasm' if self.is_wasm() else 'js'
-    out_file = 'liblib.' + side_suffix
     if isinstance(side, list):
+      out_file = 'liblib.' + side_suffix
       # side is just a library
-      try_delete(out_file)
       self.run_process([EMCC] + side + self.get_emcc_args() + ['-o', out_file])
     else:
-      filename = 'liblib.cpp' if not force_c else 'liblib.c'
-      try_delete(out_file)
-      with open(filename, 'w') as f:
-        f.write(side)
-      self.build(filename, js_outfile=(side_suffix == 'js'))
+      out_file = self.build(side, js_outfile=(side_suffix == 'js'))
     shutil.move(out_file, 'liblib.so')
 
     # main settings
@@ -3568,11 +3576,11 @@ ok
 
     if isinstance(main, list):
       # main is just a library
-      try_delete('src.js')
-      self.run_process([EMCC] + main + self.get_emcc_args() + ['-o', 'src.js'])
-      self.do_run('src.js', expected, no_build=True, **kwargs)
+      try_delete('main.js')
+      self.run_process([EMCC] + main + self.get_emcc_args() + ['-o', 'main.js'])
+      self.do_run('main.js', expected, no_build=True, **kwargs)
     else:
-      self.do_run(main, expected, force_c=force_c, **kwargs)
+      self.do_runf(main, expected, force_c=force_c, **kwargs)
 
     self.emcc_args = old_args
 
@@ -3581,8 +3589,8 @@ ok
       # Test the reverse as well.  There we flip the role of the side module and main module.
       # - We add --no-entry since the side module doesn't have a `main`
       # - We set main_module to 1 since in most cases MAIN_MODULE=2 doesn't work when flipped.
-      self.dylink_test(side, main, expected, header, main_emcc_args + ['--no-entry'],
-                       force_c, need_reverse=False, main_module=1,  **kwargs)
+      self.dylink_testf(side, main, expected, force_c, main_emcc_args + ['--no-entry'],
+                        need_reverse=False, main_module=1,  **kwargs)
 
   def do_basic_dylink_test(self, **kwargs):
     self.dylink_test(r'''
@@ -3603,8 +3611,8 @@ ok
 
   @needs_dlfcn
   def test_dylink_basics(self):
-    self.do_basic_dylink_test()
-    self.verify_in_strict_mode('src.js')
+    self.do_basic_dylink_test(need_reverse=False)
+    self.verify_in_strict_mode('main.js')
 
   @needs_dlfcn
   def test_dylink_basics_no_modify(self):
@@ -3834,7 +3842,6 @@ ok
     print('check warnings')
     self.set_setting('ASSERTIONS', 2)
     test()
-    self.run_js('src.js')
     # TODO: this in wasm
     # full = self.run_js('src.js')
     # self.assertNotContained('already exists', full)
@@ -8283,11 +8290,22 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
   @needs_dlfcn
   @node_pthreads
-  def test_pthread_dynamic_linking(self):
+  def test_pthread_dylink_basics(self):
     self.emcc_args.append('-Wno-experimental')
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.do_basic_dylink_test()
+
+  @needs_dlfcn
+  @node_pthreads
+  def test_pthread_dylink(self):
+    self.emcc_args.append('-Wno-experimental')
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('USE_PTHREADS')
+    self.set_setting('PTHREAD_POOL_SIZE=2')
+    main = path_from_root('tests', 'core', 'pthread', 'test_pthread_dylink.c')
+    side = path_from_root('tests', 'core', 'pthread', 'test_pthread_dylink_side.c')
+    self.dylink_testf(main, side, "success", need_reverse=False)
 
   @needs_dlfcn
   @node_pthreads


### PR DESCRIPTION
This means the `getMemory` in library_dylink.js (and potentially
other functions) works the same on the main the thread as on the
worker threads.   Without this `getMemory` falsely thinks the
runtime has been initialized and will call malloc rather than
doing static allocation when pre-loading shared libraries.

This solves part of the same issue that is solved by #13395.