### PR TITLE
WIP: Distinguish between stdout and stderr and emscripten logging (out and…

### DIFF
--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -486,7 +486,7 @@ mergeInto(LibraryManager.library, {
     var result = formatString(format, varargs);
     var string = intArrayToString(result);
     if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
-    out(string);
+    stdout(string);
     return result.length;
   },
   puts: function(s) {
@@ -494,7 +494,7 @@ mergeInto(LibraryManager.library, {
     var result = UTF8ToString(s);
     var string = result.substr(0);
     if (string[string.length-1] === '\n') string = string.substr(0, string.length-1); // remove a final \n, as Module.print will do that
-    out(string);
+    stdout(string);
     return result.length;
   },
 });

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1400,13 +1400,13 @@ FS.staticInit();` +
       }
 
       // open default streams for the stdin, stdout and stderr devices
-      var stdin = FS.open('/dev/stdin', {{{ cDefine('O_RDONLY') }}});
-      var stdout = FS.open('/dev/stdout', {{{ cDefine('O_WRONLY') }}});
-      var stderr = FS.open('/dev/stderr', {{{ cDefine('O_WRONLY') }}});
+      var _stdin = FS.open('/dev/stdin', {{{ cDefine('O_RDONLY') }}});
+      var _stdout = FS.open('/dev/stdout', {{{ cDefine('O_WRONLY') }}});
+      var _stderr = FS.open('/dev/stderr', {{{ cDefine('O_WRONLY') }}});
 #if ASSERTIONS
-      assert(stdin.fd === 0, 'invalid handle for stdin (' + stdin.fd + ')');
-      assert(stdout.fd === 1, 'invalid handle for stdout (' + stdout.fd + ')');
-      assert(stderr.fd === 2, 'invalid handle for stderr (' + stderr.fd + ')');
+      assert(_stdin.fd === 0, 'invalid handle for stdin (' + _stdin.fd + ')');
+      assert(_stdout.fd === 1, 'invalid handle for stdout (' + _stdout.fd + ')');
+      assert(_stderr.fd === 2, 'invalid handle for stderr (' + _stderr.fd + ')');
 #endif
     },
     ensureErrnoError: function() {

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -150,7 +150,7 @@ mergeInto(LibraryManager.library, {
       },
       put_char: function(tty, val) {
         if (val === null || val === {{{ charCode('\n') }}}) {
-          out(UTF8ArrayToString(tty.output, 0));
+          stdout(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         } else {
           if (val != 0) tty.output.push(val); // val == 0 would cut text output off in the middle.
@@ -158,7 +158,7 @@ mergeInto(LibraryManager.library, {
       },
       flush: function(tty) {
         if (tty.output && tty.output.length > 0) {
-          out(UTF8ArrayToString(tty.output, 0));
+          stdout(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         }
       }
@@ -166,7 +166,7 @@ mergeInto(LibraryManager.library, {
     default_tty1_ops: {
       put_char: function(tty, val) {
         if (val === null || val === {{{ charCode('\n') }}}) {
-          err(UTF8ArrayToString(tty.output, 0));
+          stderr(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         } else {
           if (val != 0) tty.output.push(val);
@@ -174,7 +174,7 @@ mergeInto(LibraryManager.library, {
       },
       flush: function(tty) {
         if (tty.output && tty.output.length > 0) {
-          err(UTF8ArrayToString(tty.output, 0));
+          stderr(UTF8ArrayToString(tty.output, 0));
           tty.output = [];
         }
       }

--- a/src/shell.js
+++ b/src/shell.js
@@ -354,6 +354,21 @@ if (ENVIRONMENT_IS_NODE) {
 // stderr, respectively.
 {{{ makeModuleReceiveWithVar('out', 'print',    'console.log.bind(console)',  true) }}}
 {{{ makeModuleReceiveWithVar('err', 'printErr', 'console.warn.bind(console)', true) }}}
+var stdout = out;
+var stderr = err;
+
+#if USE_PTHREADS
+// For pthread builds wrap all err() and out() calls so that message include the
+// thread ID.
+out = function(msg) {
+  if (runtimeInitialized) msg = 'tid:0x' + _pthread_self() + ': ' + msg;
+  stdout(msg)
+}
+err = function(msg) {
+  if (runtimeInitialized) msg = 'tid:0x' + _pthread_self() + ': ' + msg;
+  stderr(msg)
+}
+#endif
 
 // Merge back in the overrides
 for (key in moduleOverrides) {

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -101,6 +101,9 @@ function err(text) {
   console.error(text);
 }
 
+var stdout = out;
+var stderr = err;
+
 // Override this function in a --pre-js file to get a signal for when
 // compilation is ready. In that callback, call the function run() to start
 // the program.


### PR DESCRIPTION
… err)

It can be useful to be able to tell the difference between
emscripten's internal log message (calls to err() and out())
and the actual program stderr and stdout.

As an example here I attach the thread ID to all emscripten
log message when running with USE_PTHREADS.