### PR TITLE
Fix `embuilder --force` for ports

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -102,9 +102,9 @@ Issuing 'embuilder.py build ALL' causes each task to be built.
 ''' % '\n        '.join(all_tasks)
 
 
-def build_port(port_name, lib_name):
+def build_port(port_name):
   if force:
-    shared.Cache.erase_file(shared.Cache.get_lib_name(lib_name))
+    system_libs.clear_port(port_name, shared.Settings)
 
   system_libs.build_port(port_name, shared.Settings)
 
@@ -179,82 +179,82 @@ def main():
         shared.Cache.erase_file('generated_struct_info.json')
       emscripten.generate_struct_info()
     elif what == 'icu':
-      build_port('icu', 'libicuuc.a')
+      build_port('icu')
     elif what == 'zlib':
       shared.Settings.USE_ZLIB = 1
-      build_port('zlib', 'libz.a')
+      build_port('zlib')
       shared.Settings.USE_ZLIB = 0
     elif what == 'bzip2':
-      build_port('bzip2', 'libbz2.a')
+      build_port('bzip2')
     elif what == 'bullet':
-      build_port('bullet', 'libbullet.a')
+      build_port('bullet')
     elif what == 'vorbis':
-      build_port('vorbis', 'libvorbis.a')
+      build_port('vorbis')
     elif what == 'ogg':
-      build_port('ogg', 'libogg.a')
+      build_port('ogg')
     elif what == 'giflib':
-      build_port('giflib', 'libgif.a')
+      build_port('giflib')
     elif what == 'libjpeg':
-      build_port('libjpeg', 'libjpeg.a')
+      build_port('libjpeg')
     elif what == 'libpng':
-      build_port('libpng', 'libpng.a')
+      build_port('libpng')
     elif what == 'sdl2':
-      build_port('sdl2', 'libSDL2.a')
+      build_port('sdl2')
     elif what == 'sdl2-mt':
       shared.Settings.USE_PTHREADS = 1
-      build_port('sdl2', 'libSDL2-mt.a')
+      build_port('sdl2')
       shared.Settings.USE_PTHREADS = 0
     elif what == 'sdl2-gfx':
-      build_port('sdl2_gfx', 'libSDL2_gfx.a')
+      build_port('sdl2_gfx')
     elif what == 'sdl2-image':
-      build_port('sdl2_image', 'libSDL2_image.a')
+      build_port('sdl2_image')
     elif what == 'sdl2-image-png':
       shared.Settings.SDL2_IMAGE_FORMATS = ["png"]
-      build_port('sdl2_image', 'libSDL2_image_png.a')
+      build_port('sdl2_image')
       shared.Settings.SDL2_IMAGE_FORMATS = []
     elif what == 'sdl2-image-jpg':
       shared.Settings.SDL2_IMAGE_FORMATS = ["jpg"]
-      build_port('sdl2_image', 'libSDL2_image_jpg.a')
+      build_port('sdl2_image')
       shared.Settings.SDL2_IMAGE_FORMATS = []
     elif what == 'sdl2-net':
-      build_port('sdl2_net', 'libSDL2_net.a')
+      build_port('sdl2_net')
     elif what == 'sdl2-mixer':
       old_formats = shared.Settings.SDL2_MIXER_FORMATS
       shared.Settings.SDL2_MIXER_FORMATS = []
-      build_port('sdl2_mixer', 'libSDL2_mixer.a')
+      build_port('sdl2_mixer')
       shared.Settings.SDL2_MIXER_FORMATS = old_formats
     elif what == 'sdl2-mixer-ogg':
       old_formats = shared.Settings.SDL2_MIXER_FORMATS
       shared.Settings.SDL2_MIXER_FORMATS = ["ogg"]
-      build_port('sdl2_mixer', 'libSDL2_mixer_ogg.a')
+      build_port('sdl2_mixer')
       shared.Settings.SDL2_MIXER_FORMATS = old_formats
     elif what == 'sdl2-mixer-mp3':
       old_formats = shared.Settings.SDL2_MIXER_FORMATS
       shared.Settings.SDL2_MIXER_FORMATS = ["mp3"]
-      build_port('sdl2_mixer', 'libSDL2_mixer_mp3.a')
+      build_port('sdl2_mixer')
       shared.Settings.SDL2_MIXER_FORMATS = old_formats
     elif what == 'freetype':
-      build_port('freetype', 'libfreetype.a')
+      build_port('freetype')
     elif what == 'harfbuzz':
-      build_port('harfbuzz', 'libharfbuzz.a')
+      build_port('harfbuzz')
     elif what == 'harfbuzz-mt':
       shared.Settings.USE_PTHREADS = 1
-      build_port('harfbuzz', 'libharfbuzz-mt.a')
+      build_port('harfbuzz')
       shared.Settings.USE_PTHREADS = 0
     elif what == 'sdl2-ttf':
-      build_port('sdl2_ttf', 'libSDL2_ttf.a')
+      build_port('sdl2_ttf')
     elif what == 'cocos2d':
-      build_port('cocos2d', 'libcocos2d.a')
+      build_port('cocos2d')
     elif what == 'regal':
-      build_port('regal', 'libregal.a')
+      build_port('regal')
     elif what == 'regal-mt':
       shared.Settings.USE_PTHREADS = 1
-      build_port('regal', 'libregal-mt.a')
+      build_port('regal')
       shared.Settings.USE_PTHREADS = 0
     elif what == 'boost_headers':
-      build_port('boost_headers', 'libboost_headers.a')
+      build_port('boost_headers')
     elif what == 'mpg123':
-      build_port('mpg123', 'libmpg123.a')
+      build_port('mpg123')
     else:
       logger.error('unfamiliar build target: ' + what)
       return 1

--- a/tools/ports/boost_headers.py
+++ b/tools/ports/boost_headers.py
@@ -49,7 +49,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libboost_headers.a')
+  shared.Cache.erase_lib('libboost_headers.a')
 
 
 def process_args(ports):

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -51,7 +51,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libbullet.a')
+  shared.Cache.erase_lib('libbullet.a')
 
 
 def process_args(ports):

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -49,7 +49,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libbz2.a')
+  shared.Cache.erase_lib('libbz2.a')
 
 
 def process_args(ports):

--- a/tools/ports/cocos2d.py
+++ b/tools/ports/cocos2d.py
@@ -74,7 +74,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libcocos2d.a')
+  shared.Cache.erase_lib('libcocos2d.a')
 
 
 def process_dependencies(settings):

--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -111,7 +111,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libfreetype.a')
+  shared.Cache.erase_lib('libfreetype.a')
 
 
 def process_args(ports):

--- a/tools/ports/giflib.py
+++ b/tools/ports/giflib.py
@@ -35,7 +35,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libgif.a')
+  shared.Cache.erase_lib('libgif.a')
 
 
 def process_args(ports):

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -72,7 +72,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file(get_lib_name(settings))
+  shared.Cache.erase_lib(get_lib_name(settings))
 
 
 def process_dependencies(settings):

--- a/tools/ports/icu.py
+++ b/tools/ports/icu.py
@@ -78,9 +78,9 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file(libname_libicu_common)
-  shared.Cache.erase_file(libname_libicu_stubdata)
-  shared.Cache.erase_file(libname_libicu_i18n)
+  shared.Cache.erase_lib(libname_libicu_common)
+  shared.Cache.erase_lib(libname_libicu_stubdata)
+  shared.Cache.erase_lib(libname_libicu_i18n)
 
 
 def process_args(ports):

--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -43,7 +43,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libjpeg.a')
+  shared.Cache.erase_lib('libjpeg.a')
 
 
 def process_args(ports):

--- a/tools/ports/libmodplug.py
+++ b/tools/ports/libmodplug.py
@@ -102,7 +102,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libmodplug.a')
+  shared.Cache.erase_lib('libmodplug.a')
 
 
 def process_args(ports):

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -38,7 +38,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libpng.a')
+  shared.Cache.erase_lib('libpng.a')
 
 
 def process_dependencies(settings):

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -94,7 +94,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libmpg123.a')
+  shared.Cache.erase_lib('libmpg123.a')
 
 
 def process_args(ports):

--- a/tools/ports/ogg.py
+++ b/tools/ports/ogg.py
@@ -40,7 +40,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libogg.a')
+  shared.Cache.erase_lib('libogg.a')
 
 
 def process_args(ports):

--- a/tools/ports/regal.py
+++ b/tools/ports/regal.py
@@ -140,7 +140,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file(get_lib_name(settings))
+  shared.Cache.erase_lib(get_lib_name(settings))
 
 
 def process_dependencies(settings):

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -36,7 +36,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libSDL2_gfx.a')
+  shared.Cache.erase_lib('libSDL2_gfx.a')
 
 
 def process_args(ports):

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -84,7 +84,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libSDL2_mixer.a')
+  shared.Cache.erase_lib('libSDL2_mixer.a')
 
 
 def process_dependencies(settings):

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -39,7 +39,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libSDL2_net.a')
+  shared.Cache.erase_lib('libSDL2_net.a')
 
 
 def process_args(ports):

--- a/tools/ports/sdl2_ttf.py
+++ b/tools/ports/sdl2_ttf.py
@@ -42,7 +42,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libSDL2_ttf.a')
+  shared.Cache.erase_lib('libSDL2_ttf.a')
 
 
 def process_dependencies(settings):

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -37,7 +37,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libvorbis.a')
+  shared.Cache.erase_lib('libvorbis.a')
 
 
 def process_dependencies(settings):

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -46,7 +46,7 @@ def get(ports, settings, shared):
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_file('libz.a')
+  shared.Cache.erase_lib('libz.a')
 
 
 def process_args(ports):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1835,6 +1835,11 @@ def build_port(port_name, settings):
     port.get(Ports, settings, shared)
 
 
+def clear_port(port_name, settings):
+  port = ports.ports_by_name[port_name]
+  port.clear(Ports, settings, shared)
+
+
 def add_ports_cflags(args, settings):
   # Legacy SDL1 port is not actually a port at all but builtin
   if settings.USE_SDL == 1:


### PR DESCRIPTION
Use each `clear` function of each port file in order to clear
it before rebuilding.

This unearthed the fact that the clear functions were not actually
working and they all needed updating.