### PR TITLE
Remove asbytes helper function. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -40,7 +40,7 @@ import emscripten
 from tools import shared, system_libs
 from tools import colored_logger, diagnostics, building
 from tools.shared import unsuffixed, unsuffixed_basename, WINDOWS, safe_move, safe_copy
-from tools.shared import run_process, asbytes, read_and_preprocess, exit_with_error, DEBUG
+from tools.shared import run_process, read_and_preprocess, exit_with_error, DEBUG
 from tools.shared import do_replace
 from tools.response_file import substitute_response_files
 from tools.minimal_runtime_shell import generate_minimal_runtime_html
@@ -3032,8 +3032,9 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
 
   html_contents = do_replace(shell, '{{{ SCRIPT }}}', script.replacement())
   html_contents = tools.line_endings.convert_line_endings(html_contents, '\n', options.output_eol)
+  # Force UTF-8 output for consistency across platforms and with the web.
   with open(target, 'wb') as f:
-    f.write(asbytes(html_contents))
+    f.write(html_contents.encode('utf-8'))
 
 
 def minify_html(filename):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -60,7 +60,6 @@ from tools.shared import TEMP_DIR, EMCC, EMXX, DEBUG
 from tools.shared import EMSCRIPTEN_TEMP_DIR
 from tools.shared import EM_BUILD_VERBOSE
 from tools.shared import get_canonical_temp_dir, try_delete
-from tools.shared import asbytes
 from tools.utils import MACOS, WINDOWS
 from tools import shared, line_endings, building, config
 
@@ -1223,7 +1222,7 @@ def harness_server_func(in_queue, out_queue, port):
           assert in_queue.empty(), 'should not be any blockage - one test runs at a time'
           assert out_queue.empty(), 'the single response from the last test was read'
           # tell the browser to load the test
-          self.wfile.write(b'COMMAND:' + url)
+          self.wfile.write(b'COMMAND:' + url.encode('utf-8'))
           # move us to the right place to serve the files for the new test
           os.chdir(dir)
         else:
@@ -1343,7 +1342,7 @@ class BrowserCore(RunnerCore):
     if expectedResult is not None:
       try:
         self.harness_in_queue.put((
-          asbytes('http://localhost:%s/%s' % (self.port, html_file)),
+          'http://localhost:%s/%s' % (self.port, html_file),
           self.get_dir()
         ))
         received_output = False

--- a/tools/building.py
+++ b/tools/building.py
@@ -29,7 +29,7 @@ from .shared import try_delete, run_process, check_call, exit_with_error
 from .shared import configuration, path_from_root
 from .shared import asmjs_mangle, DEBUG
 from .shared import EM_BUILD_VERBOSE, TEMP_DIR
-from .shared import CANONICAL_TEMP_DIR, LLVM_DWARFDUMP, demangle_c_symbol_name, asbytes
+from .shared import CANONICAL_TEMP_DIR, LLVM_DWARFDUMP, demangle_c_symbol_name
 from .shared import get_emscripten_temp_dir, exe_suffix, is_c_symbol
 from .utils import which, WINDOWS
 
@@ -1369,7 +1369,7 @@ def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   # embed a section in the main wasm to point to the file with external DWARF,
   # see https://yurydelendik.github.io/webassembly-dwarf/#external-DWARF
   section_name = b'\x13external_debug_info' # section name, including prefixed size
-  filename_bytes = asbytes(embedded_path)
+  filename_bytes = embedded_path.encode('utf-8')
   contents = webassembly.toLEB(len(filename_bytes)) + filename_bytes
   section_size = len(section_name) + len(contents)
   with open(wasm_file, 'ab') as f:

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -226,9 +226,9 @@ def inspect_headers(headers, cflags):
   code.append('}')
 
   # Write the source code to a temporary file.
-  src_file = tempfile.mkstemp('.c')
+  src_file = tempfile.mkstemp('.c', text=True)
   show('Generating C code... ' + src_file[1])
-  os.write(src_file[0], shared.asbytes('\n'.join(code)))
+  os.write(src_file[0], '\n'.join(code).encode())
 
   js_file = tempfile.mkstemp('.js')
 

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -183,5 +183,6 @@ def generate_minimal_runtime_html(target, options, js_target, target_basename):
     js_contents = ''
   shell = shell.replace('{{{ JS_CONTENTS_IN_SINGLE_FILE_BUILD }}}', js_contents)
   shell = line_endings.convert_line_endings(shell, '\n', options.output_eol)
+  # Force UTF-8 output for consistency across platforms and with the web.
   with open(target, 'wb') as f:
-    f.write(shared.asbytes(shell))
+    f.write(shell.encode('utf-8'))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -881,13 +881,6 @@ function%s(%s) {
     return ret
 
 
-def asbytes(s):
-  if isinstance(s, bytes):
-    # Do not attempt to encode bytes
-    return s
-  return s.encode('utf-8')
-
-
 def suffix(name):
   """Return the file extension"""
   return os.path.splitext(name)[1]

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -164,7 +164,7 @@ def add_dylink_section(wasm_file, needed_dynlibs):
   # https://github.com/WebAssembly/tool-conventions/pull/77
   contents += toLEB(len(needed_dynlibs))
   for dyn_needed in needed_dynlibs:
-    dyn_needed = bytes(shared.asbytes(dyn_needed))
+    dyn_needed = dyn_needed.encode('utf-8')
     contents += toLEB(len(dyn_needed))
     contents += dyn_needed
 


### PR DESCRIPTION
As a followup to #13617 we can/should also remove asbytes.

The users of this fuction were replaced as follows:

gen_struct_info.py:
  Prefer `.encode()` to get default encoding here (no need to force
  UTF-8)

webassembly.py:
building.py:
  Explictly force utf-8 here since its part of the webassembly spec.

emcc.py:
tools/minimal_runtime_shell.py:
  Explictly force utf8 here since we are writing html that we want
  to be encoded as UTF8.  At least I think this is what we want here
  rather than the system default encoding?
