### PR TITLE
tests: handle onAbort as well as onExit in browser_reporting.js

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1067,6 +1067,10 @@ function createWasm() {
         var search = location.search;
         if (search.indexOf('_rwasm=0') < 0) {
           location.href += (search ? search + '&' : '?') + '_rwasm=0';
+          // Return here to avoid calling abort() below.  The application
+          // still has a chance to start sucessfully do we don't want to
+          // trigger onAbort or onExit handlers.
+          return;
         }
 #if ENVIRONMENT_MAY_BE_NODE || ENVIRONMENT_MAY_BE_SHELL
       }

--- a/tests/browser/async_stack_overflow.cpp
+++ b/tests/browser/async_stack_overflow.cpp
@@ -6,27 +6,8 @@
 #include <stdio.h>
 #include <emscripten.h>
 
-int main() {
-  int x = EM_ASM_INT({
-    window.onerror = function(e) {
-      var message = e.toString();
-      var success = message.indexOf("unreachable") >= 0 || // firefox
-                    message.indexOf("Script error.") >= 0; // chrome
-      if (success && !Module.reported) {
-        Module.reported = true;
-        console.log("reporting success");
-        // manually REPORT_RESULT; we shouldn't call back into native code at this point
-        var xhr = new XMLHttpRequest();
-        xhr.open("GET", "http://localhost:8888/report_result?0");
-        xhr.onload = xhr.onerror = function() {
-          window.close();
-        };
-        xhr.send();
-      }
-    };
-    return 0;
-  });
-
+int main(int argc, char* argv[]) {
+  int x = argc;
   int y = x * x;
   int z = y * y;
   x++;

--- a/tests/browser/test_assert_failure.c
+++ b/tests/browser/test_assert_failure.c
@@ -1,0 +1,7 @@
+#include <assert.h>
+#include <stdbool.h>
+
+int main() {
+  assert(false && "this is a test");
+  return 0;
+}

--- a/tests/browser_reporting.js
+++ b/tests/browser_reporting.js
@@ -43,4 +43,8 @@ if (hasModule) {
   Module['onExit'] = function(status) {
     maybeReportResultToServer('exit:' + status);
   }
+
+  Module['onAbort'] = function(reason) {
+    maybeReportResultToServer('abort:' + reason);
+  }
 }

--- a/tests/pthread/main_thread_join.cpp
+++ b/tests/pthread/main_thread_join.cpp
@@ -54,22 +54,6 @@ int main() {
     return 0;
   }
 
-  int x = EM_ASM_INT({
-    onerror = function(e) {
-      var message = e.toString();
-      var success = message.indexOf("Blocking on the main thread is not allowed by default. See https://emscripten.org/docs/porting/pthreads.html#blocking-on-the-main-browser-thread") >= 0;
-      if (success && !Module.reported) {
-        Module.reported = true;
-        console.log("reporting success");
-        // manually REPORT_RESULT; we shouldn't call back into native code at this point
-        var xhr = new XMLHttpRequest();
-        xhr.open("GET", "http://localhost:8888/report_result?0");
-        xhr.send();
-      }
-    };
-    return 0;
-  });
-
   thread = CreateThread();
 #ifdef TRY_JOIN
   emscripten_set_main_loop(loop, 0, 0);

--- a/tests/pthread/main_thread_wait.cpp
+++ b/tests/pthread/main_thread_wait.cpp
@@ -18,22 +18,6 @@ int main() {
     return 0;
   }
 
-  int x = EM_ASM_INT({
-    onerror = function(e) {
-      var message = e.toString();
-      var success = message.indexOf("Blocking on the main thread is not allowed by default. See https://emscripten.org/docs/porting/pthreads.html#blocking-on-the-main-browser-thread") >= 0;
-      if (success && !Module.reported) {
-        Module.reported = true;
-        console.log("reporting success");
-        // manually REPORT_RESULT; we shouldn't call back into native code at this point
-        var xhr = new XMLHttpRequest();
-        xhr.open("GET", "http://localhost:8888/report_result?0");
-        xhr.send();
-      }
-    };
-    return 0;
-  });
-
   // This should fail on the main thread.
   puts("trying to block...");
   pthread_cond_t cv = PTHREAD_COND_INITIALIZER;

--- a/tests/pthread/test_safe_stack.js
+++ b/tests/pthread/test_safe_stack.js
@@ -1,5 +1,0 @@
-Module['onAbort'] = function (what) {
-  if (what == 'stack overflow') {
-    reportResultToServer(1);
-  }
-}

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -730,10 +730,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       fail_message += '\n' + msg
     self.fail(fail_message)
 
-  def assertIdenticalUrlEncoded(self, expected, actual, **kwargs):
-    """URL decodes the `actual` parameter before checking for equality."""
-    self.assertIdentical(expected, unquote(actual), **kwargs)
-
   def assertTextDataContained(self, text1, text2):
     text1 = text1.replace('\r\n', '\n')
     text2 = text2.replace('\r\n', '\n')
@@ -1367,8 +1363,9 @@ class BrowserCore(RunnerCore):
           self.skipTest(unquote(output[len('/report_result?skipped:'):]).strip())
         else:
           # verify the result, and try again if we should do so
+          output = unquote(output)
           try:
-            self.assertIdenticalUrlEncoded(expectedResult, output)
+            self.assertContained(expectedResult, output)
           except Exception as e:
             if extra_tries > 0:
               print('[test error (see below), automatically retrying]')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3263,7 +3263,7 @@ window.close = function() {
     self.btest('browser/async_returnvalue.cpp', '0', args=['-s', 'ASYNCIFY', '-s', 'ASYNCIFY_IGNORE_INDIRECT', '--js-library', path_from_root('tests', 'browser', 'async_returnvalue.js')] + args + ['-s', 'ASSERTIONS'])
 
   def test_async_stack_overflow(self):
-    self.btest('browser/async_stack_overflow.cpp', '0', args=['-s', 'ASYNCIFY', '-s', 'ASYNCIFY_STACK_SIZE=4'])
+    self.btest('browser/async_stack_overflow.cpp', 'abort:RuntimeError: unreachable', args=['-s', 'ASYNCIFY', '-s', 'ASYNCIFY_STACK_SIZE=4'])
 
   def test_async_bad_list(self):
     self.btest('browser/async_bad_list.cpp', '0', args=['-s', 'ASYNCIFY', '-s', 'ASYNCIFY_ONLY=[waka]', '--profiling'])
@@ -3322,7 +3322,7 @@ window.close = function() {
   def test_modularize_network_error(self):
     test_c_path = path_from_root('tests', 'browser_test_hello_world.c')
     browser_reporting_js_path = path_from_root('tests', 'browser_reporting.js')
-    self.compile_btest([test_c_path, '-s', 'MODULARIZE', '-s', 'EXPORT_NAME="createModule"', '--extern-pre-js', browser_reporting_js_path])
+    self.compile_btest([test_c_path, '-s', 'MODULARIZE', '-s', 'EXPORT_NAME="createModule"', '--extern-pre-js', browser_reporting_js_path], reporting=Reporting.NONE)
     create_test_file('a.html', '''
       <script src="a.out.js"></script>
       <script>
@@ -3342,7 +3342,7 @@ window.close = function() {
   def test_modularize_init_error(self):
     test_cpp_path = path_from_root('tests', 'browser', 'test_modularize_init_error.cpp')
     browser_reporting_js_path = path_from_root('tests', 'browser_reporting.js')
-    self.compile_btest([test_cpp_path, '-s', 'MODULARIZE', '-s', 'EXPORT_NAME="createModule"', '--extern-pre-js', browser_reporting_js_path])
+    self.compile_btest([test_cpp_path, '-s', 'MODULARIZE', '-s', 'EXPORT_NAME="createModule"', '--extern-pre-js', browser_reporting_js_path], reporting=Reporting.NONE)
     create_test_file('a.html', '''
       <script src="a.out.js"></script>
       <script>
@@ -3662,7 +3662,7 @@ window.close = function() {
   @requires_threads
   def test_pthread_main_thread_blocking(self, name):
     print('Test that we error if not ALLOW_BLOCKING_ON_MAIN_THREAD')
-    self.btest(path_from_root('tests', 'pthread', 'main_thread_%s.cpp' % name), expected='0', args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE', '-s', 'ALLOW_BLOCKING_ON_MAIN_THREAD=0'])
+    self.btest(path_from_root('tests', 'pthread', 'main_thread_%s.cpp' % name), expected='abort:Blocking on the main thread is not allowed by default.', args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE', '-s', 'ALLOW_BLOCKING_ON_MAIN_THREAD=0'])
     if name == 'join':
       print('Test that by default we just warn about blocking on the main thread.')
       self.btest(path_from_root('tests', 'pthread', 'main_thread_%s.cpp' % name), expected='1', args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE'])
@@ -4020,7 +4020,7 @@ window.close = function() {
     # Note that as the test runs with PROXY_TO_PTHREAD, we set TOTAL_STACK,
     # and not DEFAULT_PTHREAD_STACK_SIZE, as the pthread for main() gets the
     # same stack size as the main thread normally would.
-    self.btest(path_from_root('tests', 'core', 'test_safe_stack.c'), expected='1', args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'STACK_OVERFLOW_CHECK=2', '-s', 'TOTAL_STACK=64KB', '--pre-js', path_from_root('tests', 'pthread', 'test_safe_stack.js')])
+    self.btest(path_from_root('tests', 'core', 'test_safe_stack.c'), expected='abort:stack overflow', args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'STACK_OVERFLOW_CHECK=2', '-s', 'TOTAL_STACK=64KB'])
 
   @parameterized({
     'leak': ['test_pthread_lsan_leak', ['-g4']],
@@ -5017,6 +5017,9 @@ window.close = function() {
                # don't run this with the default extra_tries value, as this is
                # *meant* to notice something random, a race condition.
                extra_tries=0)
+
+  def test_assert_failure(self):
+    self.btest(path_from_root('tests', 'browser', 'test_assert_failure.c'), 'abort:Assertion failed: false && "this is a test"')
 
 
 EMRUN = path_from_root('emrun')


### PR DESCRIPTION
This fixes the problem that assert/abort was not being reporting during
btest_exit.
 
As a followup we probably want also want make sure we handle all JS
and C++ exceptions in some way too, but this is still a good fix on its
own.

Fixes: #13628