### PR TITLE
Fix wasm2js[3sz].test_exceptions_allowed

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1273,8 +1273,6 @@ int main(int argc, char **argv)
       assert empty_size == fake_size, [empty_size, fake_size]
       # big change when we disable exception catching of the function
       assert size - empty_size > 0.01 * size, [empty_size, size]
-      # full disable can remove a little bit more
-      assert empty_size >= disabled_size, [empty_size, disabled_size]
 
   def test_exceptions_allowed_2(self):
     self.set_setting('DISABLE_EXCEPTION_CATCHING', 2)


### PR DESCRIPTION
We don't run these on CI so this breakage was not noticed. Or, it is
possible it just breaks on some machines, as the issue is that the
empty and disabled sizes here are extremely close to each other
(empty means "allow exceptions in no functions" and disabled means
"exceptions are disabled"), and so very minor minification changes can
lead to the JS size being a bit larger or smaller.

In principle the empty size could be bigger as there is some "base"
cost to having exceptions enabled at all, one would think, but it seems
like in `-O3/s/z` the optimizer is powerful enough to remove it. This does
not happen on `-O1/-O2`, interestingly.