### PR TITLE
Fix typo in worker_api_2_main.cpp. NFC.

### DIFF
--- a/tests/worker_api_2_main.cpp
+++ b/tests/worker_api_2_main.cpp
@@ -37,7 +37,7 @@ void c3(char *data, int size, void *arg) { // tests calls different in different
     c3_8++;
     assert(calls == 1);
   }
-  if (c3_7 && c3_7) { // note: racey, responses from 2 workers here
+  if (c3_7 && c3_8) { // note: racey, responses from 2 workers here
     emscripten_destroy_worker(w1);
     REPORT_RESULT(11);
     emscripten_force_exit(0);


### PR DESCRIPTION
I can't say I understand this test well enough to know how it was
passing before but this seems like it is clearly a typo.

Without this change the test happens to occationally generate
abort(CompileError bad magic number) error at least some of the time.
These abort() don't see to cause the test to fail but I have another
chnage the makes the test runner more sensitive to abort() exceptions
propogating all the way out: #13631

Fixing this typo seems to make these aborts go away.