### PR TITLE
Show short pthread warning when ASSERTIONS=0

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -465,16 +465,20 @@ var LibraryPThread = {
 
     getNewWorker: function() {
       if (PThread.unusedWorkers.length == 0) {
-#if !PROXY_TO_PTHREAD
-#if PTHREAD_POOL_SIZE_STRICT == 1
+#if !PROXY_TO_PTHREAD && PTHREAD_POOL_SIZE_STRICT
+#if ASSERTIONS
         err('Tried to spawn a new thread, but the thread pool is exhausted.\n' +
         'This might result in a deadlock unless some threads eventually exit or the code explicitly breaks out to the event loop.\n' +
         'If you want to increase the pool size, use setting `-s PTHREAD_POOL_SIZE=...`.'
+#if PTHREAD_POOL_SIZE_STRICT == 1
         + '\nIf you want to throw an explicit error instead of the risk of deadlocking in those cases, use setting `-s PTHREAD_POOL_SIZE_STRICT=2`.'
+#endif
         );
+#else
+        err('No available workers in the PThread pool');
 #endif
 #if PTHREAD_POOL_SIZE_STRICT == 2
-        err('No available workers in the PThread pool');
+        // Don't return a Worker, which will translate into an EAGAIN error.
         return;
 #endif
 #endif


### PR DESCRIPTION
A minor follow-up to https://github.com/emscripten-core/emscripten/pull/13591: during the changes after opening the initial PR, I left the long warning in code even in `-s ASSERTIONS=0` / optimized builds.

That's not what we want for code size reasons, so fixing it up.