### PR TITLE
Report error if EM_ASM or EM_JS used in side modules

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- Using EM_ASM and EM_JS in a side module will now result in an error (since
+  this is not implemented yet).  This could effect users were previously
+  inadvertently including (but not actually using) EM_ASM or EM_JS functions in
+  side modules. (#13649)
 - Remove dependency on Uglify by finishing the rewrite of passes to acorn
  (#13636, #13621).
 - Primary development branch switched from `master` to `main`.

--- a/emscripten.py
+++ b/emscripten.py
@@ -284,6 +284,10 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
   update_settings_glue(metadata, DEBUG)
 
   if shared.Settings.SIDE_MODULE:
+    if metadata['asmConsts']:
+      exit_with_error('EM_ASM is not supported in side modules')
+    if metadata['emJsFuncs']:
+      exit_with_error('EM_JS is not supported in side modules')
     logger.debug('emscript: skipping remaining js glue generation')
     return
 

--- a/src/library.js
+++ b/src/library.js
@@ -3496,6 +3496,9 @@ LibraryManager.library = {
     code -= {{{ GLOBAL_BASE }}};
 #endif
     var args = readAsmConstArgs(sigPtr, argbuf);
+#if ASSERTIONS
+    if (!ASM_CONSTS.hasOwnProperty(code)) abort('No EM_ASM constant found at address ' + code);
+#endif
     return ASM_CONSTS[code].apply(null, args);
   },
   emscripten_asm_const_double: 'emscripten_asm_const_int',
@@ -3519,6 +3522,9 @@ LibraryManager.library = {
       // (positive numbers are non-EM_ASM calls).
       return _emscripten_proxy_to_main_thread_js.apply(null, [-1 - code, sync].concat(args));
     }
+#endif
+#if ASSERTIONS
+    if (!ASM_CONSTS.hasOwnProperty(code)) abort('No EM_ASM constant found at address ' + code);
 #endif
     return ASM_CONSTS[code].apply(null, args);
   },

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2228,7 +2228,7 @@ void *getBindBuffer() {
         return suppInt;
       }
     ''')
-    self.compile_btest(['supp.cpp', '-o', 'supp.wasm', '-s', 'SIDE_MODULE', '-O2', '-s', 'EXPORT_ALL'])
+    self.run_process([EMCC, 'supp.cpp', '-o', 'supp.wasm', '-s', 'SIDE_MODULE', '-O2', '-s', 'EXPORT_ALL'])
     self.btest_exit('main.cpp', args=['-DBROWSER=1', '-s', 'MAIN_MODULE', '-O2', '-s', 'RUNTIME_LINKED_LIBS=[supp.wasm]', '-s', 'EXPORT_ALL'], assert_returncode=76)
 
   def test_pre_run_deps(self):
@@ -2418,7 +2418,7 @@ void *getBindBuffer() {
     self.btest('test_emscripten_async_wget2.cpp', expected='0')
 
   def test_module(self):
-    self.compile_btest([path_from_root('tests', 'browser_module.cpp'), '-o', 'lib.wasm', '-O2', '-s', 'SIDE_MODULE', '-s', 'EXPORTED_FUNCTIONS=[_one,_two]'])
+    self.run_process([EMCC, path_from_root('tests', 'browser_module.cpp'), '-o', 'lib.wasm', '-O2', '-s', 'SIDE_MODULE', '-s', 'EXPORTED_FUNCTIONS=[_one,_two]'])
     self.btest('browser_main.cpp', args=['-O2', '-s', 'MAIN_MODULE'], expected='8')
 
   @parameterized({
@@ -2432,7 +2432,7 @@ void *getBindBuffer() {
         return 42;
       }
     ''')
-    self.compile_btest(['library.c', '-s', 'SIDE_MODULE', '-O2', '-o', 'library.wasm', '-s', 'EXPORT_ALL'])
+    self.run_process([EMCC, 'library.c', '-s', 'SIDE_MODULE', '-O2', '-o', 'library.wasm', '-s', 'EXPORT_ALL'])
     os.rename('library.wasm', 'library.so')
     create_test_file('main.c', r'''
       #include <dlfcn.h>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10110,3 +10110,11 @@ exec "$@"
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$runtimeKeepalivePush', '$runtimeKeepalivePop', '$callUserCallback'])
     self.set_setting('EXIT_RUNTIME')
     self.do_other_test('test_runtime_keepalive.cpp')
+
+  def test_em_asm_side_module(self):
+    err = self.expect_fail([EMCC, '-sSIDE_MODULE', path_from_root('tests/hello_world_em_asm.c')])
+    self.assertContained('EM_ASM is not supported in side modules', err)
+
+  def test_em_js_side_module(self):
+    err = self.expect_fail([EMCC, '-sSIDE_MODULE', path_from_root('tests/core/test_em_js.cpp')])
+    self.assertContained('EM_JS is not supported in side modules', err)


### PR DESCRIPTION
We don't currently support either of these because they require
the JS code to be injected into the main js file.

See #13644