### PR TITLE
Workaround Safari WebGL issue: After successfully acquiring WebGL con…

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -592,6 +592,21 @@ var LibraryGL = {
       webGLContextAttributes['preserveDrawingBuffer'] = true;
 #endif
 
+#if MIN_SAFARI_VERSION != TARGET_NOT_SUPPORTED && GL_WORKAROUND_SAFARI_GETCONTEXT_BUG
+      // BUG: Workaround Safari WebGL issue: After successfully acquiring WebGL context on a canvas,
+      // calling .getContext() will always return that context independent of which 'webgl' or 'webgl2'
+      // context version was passed. See https://bugs.webkit.org/show_bug.cgi?id=222758 and
+      // https://github.com/emscripten-core/emscripten/issues/13295.
+      // TODO: Once the bug is fixed and shipped in Safari, adjust the Safari version field in above check.
+      if (!canvas.getContextSafariWebGL2Fixed) {
+        canvas.getContextSafariWebGL2Fixed = canvas.getContext;
+        canvas.getContext = function(ver, attrs) {
+          var gl = canvas.getContextSafariWebGL2Fixed(ver, attrs);
+          return ((ver == 'webgl') == (gl instanceof WebGLRenderingContext)) && gl;
+        }
+      }
+#endif
+
 #if MAX_WEBGL_VERSION >= 2 && MIN_CHROME_VERSION <= 57
       // BUG: Workaround Chrome WebGL 2 issue: the first shipped versions of WebGL 2 in Chrome 57 did not actually implement
       // the new garbage free WebGL 2 entry points that take an offset and a length to an existing heap (instead of having to

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -602,7 +602,7 @@ var LibraryGL = {
         canvas.getContextSafariWebGL2Fixed = canvas.getContext;
         canvas.getContext = function(ver, attrs) {
           var gl = canvas.getContextSafariWebGL2Fixed(ver, attrs);
-          return ((ver == 'webgl') == (gl instanceof WebGLRenderingContext)) && gl;
+          return ((ver == 'webgl') == (gl instanceof WebGLRenderingContext)) ? gl : null;
         }
       }
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -579,6 +579,13 @@ var WORKAROUND_IOS_9_RIGHT_SHIFT_BUG = 0;
 // [link]
 var GL_DISABLE_HALF_FLOAT_EXTENSION_IF_BROKEN = 0;
 
+// Workaround Safari WebGL issue: After successfully acquiring WebGL context on a canvas,
+// calling .getContext() will always return that context independent of which 'webgl' or 'webgl2'
+// context version was passed. See https://bugs.webkit.org/show_bug.cgi?id=222758 and
+// https://github.com/emscripten-core/emscripten/issues/13295.
+// Set this to 0 to force-disable the workaround if you know the issue will not affect you.
+var GL_WORKAROUND_SAFARI_GETCONTEXT_BUG = 1;
+
 // Use JavaScript math functions like Math.tan. This saves code size as we can avoid shipping
 // compiled musl code. However, it can be significantly slower as it calls out to JS. It
 // also may give different results as JS math is specced somewhat differently than libc, and

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8430,6 +8430,7 @@ int main () {
                                '-s', 'GL_SUPPORT_EXPLICIT_SWAP_CONTROL=0',
                                '-s', 'GL_POOL_TEMP_BUFFERS=0',
                                '-s', 'MIN_CHROME_VERSION=58',
+                               '-s', 'GL_WORKAROUND_SAFARI_GETCONTEXT_BUG=0',
                                '-s', 'NO_FILESYSTEM',
                                '--output_eol', 'linux',
                                '-Oz',


### PR DESCRIPTION
…text on a canvas, calling .getContext() will always return that context independent of which 'webgl' or 'webgl2' context version was passed. See https://bugs.webkit.org/show_bug.cgi?id=222758. Fixes #13295