### PR TITLE
Re-raise pthread exceptions back on the main thread

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 - Added `EM_ASYNC_JS` macro - similar to `EM_JS`, but allows using `await`
   inside the JS block and automatically integrates with Asyncify without
   the need for listing the declared function in `ASYNCIFY_IMPORTS` (#9709).
+- Errors that occur on pthreads (e.g. uncaught exception) will now get re-thrown
+  on the main thread rather than simply being logged (#13666).
 
 2.0.26 - 07/26/2021
 -------------------

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -9,6 +9,7 @@ var LibraryPThread = {
   $PThread__deps: ['_emscripten_thread_init',
                    'emscripten_futex_wake', '$killThread',
                    '$cancelThread', '$cleanupThread',
+                   '$handleException',
                    ],
   $PThread: {
     // Contains all Workers that are idle/unused and not currently hosting an
@@ -362,8 +363,7 @@ var LibraryPThread = {
           try {
             exit(d['returnCode']);
           } catch (e) {
-            if (e instanceof ExitStatus) return;
-            throw e;
+            handleException(e);
           }
         } else if (cmd === 'cancelDone') {
           PThread.returnWorkerToPool(worker);
@@ -379,6 +379,7 @@ var LibraryPThread = {
 
       worker.onerror = function(e) {
         err('pthread sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
+        throw e;
       };
 
 #if ENVIRONMENT_MAY_BE_NODE
@@ -386,10 +387,10 @@ var LibraryPThread = {
         worker.on('message', function(data) {
           worker.onmessage({ data: data });
         });
-        worker.on('error', function(data) {
-          worker.onerror(data);
+        worker.on('error', function(e) {
+          worker.onerror(e);
         });
-        worker.on('exit', function(data) {
+        worker.on('exit', function() {
           // TODO: update the worker queue?
           // See: https://github.com/emscripten-core/emscripten/issues/9763
         });

--- a/tests/other/test_pthread_js_exception.c
+++ b/tests/other/test_pthread_js_exception.c
@@ -1,0 +1,7 @@
+#include <emscripten.h>
+
+int main() {
+  // Cause a JS exception
+  EM_ASM({foo = missing;});
+  return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4468,16 +4468,19 @@ window.close = function() {
       print(str(cmd))
       self.btest('gl_in_proxy_pthread.cpp', expected='1', args=cmd)
 
+  @parameterized({
+    'proxy': (['-sPROXY_TO_PTHREAD'],),
+    '': ([],),
+  })
   @requires_threads
   @requires_graphics_hardware
   @requires_offscreen_canvas
-  def test_webgl_resize_offscreencanvas_from_main_thread(self):
-    for args1 in [[], ['-s', 'PROXY_TO_PTHREAD']]:
-      for args2 in [[], ['-DTEST_SYNC_BLOCKING_LOOP=1']]:
-        for args3 in [[], ['-s', 'OFFSCREENCANVAS_SUPPORT', '-s', 'OFFSCREEN_FRAMEBUFFER']]:
-          cmd = args1 + args2 + args3 + ['-s', 'USE_PTHREADS', '-lGL', '-s', 'GL_DEBUG']
-          print(str(cmd))
-          self.btest('resize_offscreencanvas_from_main_thread.cpp', expected='1', args=cmd)
+  def test_webgl_resize_offscreencanvas_from_main_thread(self, args):
+    for args2 in [[], ['-DTEST_SYNC_BLOCKING_LOOP=1']]:
+      for args3 in [[], ['-s', 'OFFSCREENCANVAS_SUPPORT', '-s', 'OFFSCREEN_FRAMEBUFFER']]:
+        cmd = args + args2 + args3 + ['-s', 'USE_PTHREADS', '-lGL', '-s', 'GL_DEBUG']
+        print(str(cmd))
+        self.btest('resize_offscreencanvas_from_main_thread.cpp', expected='1', args=cmd)
 
   @requires_graphics_hardware
   def test_webgl_simple_enable_extensions(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10879,3 +10879,14 @@ void foo() {}
     ]
     self.do_runf(test_file('pthread/test_pthread_lsan_leak.cpp'), expected, assert_all=True, emcc_args=['-fsanitize=leak'])
     self.do_runf(test_file('pthread/test_pthread_lsan_leak.cpp'), expected, assert_all=True, emcc_args=['-fsanitize=address'])
+
+  @node_pthreads
+  def test_pthread_js_exception(self):
+    # Ensure that JS exceptions propagate back to the main main thread and cause node
+    # to exit with an error.
+    self.set_setting('USE_PTHREADS')
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    self.build(test_file('other', 'test_pthread_js_exception.c'))
+    err = self.run_js('test_pthread_js_exception.js', assert_returncode=NON_ZERO)
+    self.assertContained('missing is not defined', err)


### PR DESCRIPTION
Without this the parent node process will continue, which is
especially bad in PROXY_TO_PTHREAD and test code since the
node process will never exit.

Should help with #14344 (at least it should prevent the uncaught unwind issue).