### PR TITLE
Move use of __wasm_call_ctors to after module load. NFC.

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -358,13 +358,6 @@ var __ATPOSTRUN__ = []; // functions called after the main() is called
 var runtimeInitialized = false;
 var runtimeExited = false;
 
-#if '___wasm_call_ctors' in IMPLEMENTED_FUNCTIONS
-#if USE_PTHREADS
-if (!ENVIRONMENT_IS_PTHREAD)
-#endif
-__ATINIT__.push({ func: function() { ___wasm_call_ctors() } });
-#endif
-
 function preRun() {
 #if USE_PTHREADS
   if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
@@ -970,6 +963,10 @@ function createWasm() {
 #if ASSERTIONS && !PURE_WASI
     assert(wasmTable, "table not found in wasm exports");
 #endif
+#endif
+
+#if '___wasm_call_ctors' in IMPLEMENTED_FUNCTIONS
+    addOnInit(Module['asm']['__wasm_call_ctors']);
 #endif
 
 #if ABORT_ON_WASM_EXCEPTIONS


### PR DESCRIPTION
This avoids adding a pointless function wrapper and uses
the `addOnInit` helper function.

We also don't both with the `if !PTHREAD` check since
pthreads already don't call anything in the `__ATINIT__`
array.

Both these changes save a few bytes in the output.

This change is split out from work I am doing to add
support for TLS + dynamic linking.