### PR TITLE
Add support for TLS in dynamic libraries

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2215,17 +2215,19 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   ## Continue on to create JavaScript
 
   with ToolchainProfiler.profile_block('calculate system libraries'):
+    extra_files_to_link = []
     # link in ports and system libraries, if necessary
-    if not shared.Settings.SIDE_MODULE: # shared libraries/side modules link no C libraries, need them in parent
-      extra_files_to_link = system_libs.get_ports(shared.Settings)
-      if '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
-        link_as_cxx = run_via_emxx
-        # Traditionally we always link as C++.  For compatibility we continue to do that,
-        # unless running in strict mode.
-        if not shared.Settings.STRICT and '-nostdlib++' not in newargs:
-          link_as_cxx = True
-        extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, link_as_cxx, forced=forced_stdlibs)
-      linker_inputs += extra_files_to_link
+    if not shared.Settings.SIDE_MODULE:
+      # Ports are always linked into the main module, never the size module.
+      extra_files_to_link += system_libs.get_ports(shared.Settings)
+    if '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
+      link_as_cxx = run_via_emxx
+      # Traditionally we always link as C++.  For compatibility we continue to do that,
+      # unless running in strict mode.
+      if not shared.Settings.STRICT and '-nostdlib++' not in newargs:
+        link_as_cxx = True
+      extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, link_as_cxx, forced=forced_stdlibs)
+    linker_inputs += extra_files_to_link
 
   # exit block 'calculate system libraries'
   log_time('calculate system libraries')

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -23,6 +23,7 @@ var LibraryPThread = {
     unusedWorkers: [],
     // Contains all Workers that are currently hosting an active pthread.
     runningWorkers: [],
+    tlsInitFunctions: [],
     initMainThreadBlock: function() {
 #if ASSERTIONS
       assert(!ENVIRONMENT_IS_PTHREAD);
@@ -87,7 +88,7 @@ var LibraryPThread = {
       // worker.js is not compiled together with us, and must access certain
       // things.
       PThread['receiveObjectTransfer'] = PThread.receiveObjectTransfer;
-      PThread['setThreadStatus'] = PThread.setThreadStatus;
+      PThread['threadInit'] = PThread.threadInit;
       PThread['threadCancel'] = PThread.threadCancel;
       PThread['threadExit'] = PThread.threadExit;
       PThread['setExitStatus'] = PThread.setExitStatus;
@@ -318,7 +319,18 @@ var LibraryPThread = {
       }
 #endif
     },
-
+    // Called by worker.js each time a thread is started.
+    threadInit: function() {
+#if PTHREADS_DEBUG
+      out("threadInit");
+#endif
+      PThread.setThreadStatus(_pthread_self(), {{{ cDefine('EM_THREAD_STATUS_RUNNING') }}});
+      // Call thread init functions (these are the emscripten_tls_init for each
+      // module loaded.
+      for (var i in PThread.tlsInitFunctions) {
+        PThread.tlsInitFunctions[i]();
+      }
+    },
     // Loads the WebAssembly module into the given list of Workers.
     // onFinishedLoading: A callback function that will be called once all of
     //                    the workers have been initialized and are

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -381,7 +381,7 @@ function initRuntime() {
   runtimeInitialized = true;
 
 #if USE_PTHREADS
-  if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
+  if (ENVIRONMENT_IS_PTHREAD) return;
 #endif
 
 #if STACK_OVERFLOW_CHECK >= 2
@@ -963,6 +963,10 @@ function createWasm() {
 
 #if '___wasm_call_ctors' in IMPLEMENTED_FUNCTIONS
     addOnInit(Module['asm']['__wasm_call_ctors']);
+#endif
+
+#if USE_PTHREADS
+    PThread.tlsInitFunctions.push(Module['asm']['emscripten_tls_init']);
 #endif
 
 #if ABORT_ON_WASM_EXCEPTIONS

--- a/src/worker.js
+++ b/src/worker.js
@@ -187,10 +187,8 @@ this.onmessage = function(e) {
 #endif
       // Also call inside JS module to set up the stack frame for this pthread in JS module scope
       Module['establishStackSpace'](top, max);
-      Module['_emscripten_tls_init']();
-
       Module['PThread'].receiveObjectTransfer(e.data);
-      Module['PThread'].setThreadStatus(Module['_pthread_self'](), 1/*EM_THREAD_STATUS_RUNNING*/);
+      Module['PThread'].threadInit();
 
 #if EMBIND
       // Embind must initialize itself on all threads, as it generates support JS.

--- a/tests/core/pthread/test_pthread_dylink_tls.c
+++ b/tests/core/pthread/test_pthread_dylink_tls.c
@@ -1,0 +1,60 @@
+#include <assert.h>
+#include <stdio.h>
+#include <pthread.h>
+
+int get_side_tls();
+int* get_side_tls_address();
+
+static __thread int main_tls = 10;
+
+int get_main_tls() {
+  return main_tls;
+}
+
+int* get_main_tls_address() {
+  return &main_tls;
+}
+
+void report_tls() {
+  //printf("side_tls address: %p\n", get_side_tls_address());
+  printf("side_tls value  : %d\n", get_side_tls());
+  //printf("main_tls address: %p\n", get_main_tls_address());
+  printf("main_tls value  : %d\n", get_main_tls());
+}
+
+void test_tls(int inc) {
+  report_tls();
+  int* m = get_main_tls_address();
+  int* s = get_side_tls_address();
+  *m = *m + inc;
+  *s = *s + inc;
+  printf("increment done\n");
+  report_tls();
+  printf("\n");
+}
+
+void* thread_main(void* arg) {
+  printf("thread: 2\n");
+  test_tls(10);
+  return NULL;
+}
+
+int main() {
+  printf("thread: 1\n");
+  test_tls(20);
+
+  int save_side = get_side_tls();
+  int save_main = get_main_tls();
+
+  // Now do the same on a second thread
+  pthread_t t;
+  pthread_create(&t, NULL, thread_main, NULL);
+  pthread_join(t, NULL);
+
+  // Check that the second thread does not effect the values
+  // of on the main thread.
+  assert(save_side == get_side_tls());
+  assert(save_main == get_main_tls());
+
+  printf("success\n");
+}

--- a/tests/core/pthread/test_pthread_dylink_tls.out
+++ b/tests/core/pthread/test_pthread_dylink_tls.out
@@ -1,0 +1,15 @@
+thread: 1
+side_tls value  : 42
+main_tls value  : 10
+increment done
+side_tls value  : 62
+main_tls value  : 30
+
+thread: 2
+side_tls value  : 42
+main_tls value  : 10
+increment done
+side_tls value  : 52
+main_tls value  : 20
+
+success

--- a/tests/core/pthread/test_pthread_dylink_tls_side.c
+++ b/tests/core/pthread/test_pthread_dylink_tls_side.c
@@ -1,0 +1,9 @@
+static __thread int mytls = 42;
+
+int get_side_tls() {
+  return mytls;
+}
+
+int* get_side_tls_address() {
+  return &mytls;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3549,6 +3549,10 @@ ok
                    need_reverse=True, auto_load=True, main_module=1, **kwargs):
     # Same as dylink_test but takes source code as filenames on disc.
     old_args = self.emcc_args[:]
+    if not expected:
+      outfile = shared.unsuffixed(main) + '.out'
+      if os.path.exists(outfile):
+        expected = open(outfile).read()
 
     # side settings
     self.clear_setting('MAIN_MODULE')
@@ -8306,6 +8310,17 @@ NODEFS is no longer included by default; build with -lnodefs.js
     main = test_file('core', 'pthread', 'test_pthread_dylink.c')
     side = test_file('core', 'pthread', 'test_pthread_dylink_side.c')
     self.dylink_testf(main, side, "success", need_reverse=False)
+
+  @needs_dylink
+  @node_pthreads
+  def test_pthread_dylink_tls(self):
+    self.emcc_args.append('-Wno-experimental')
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('USE_PTHREADS')
+    self.set_setting('PTHREAD_POOL_SIZE=1')
+    main = test_file('core', 'pthread', 'test_pthread_dylink_tls.c')
+    side = test_file('core', 'pthread', 'test_pthread_dylink_tls_side.c')
+    self.dylink_testf(main, side, need_reverse=False)
 
   @needs_dylink
   @node_pthreads


### PR DESCRIPTION
Put `emscripten_tls_init` into its own system library (object
file) that gets included in the link even for side modules.
Unlike other system libraries this function needed to exist
in each and every module, not just in the main module.

Since its a static constructor it will automatically get called
as part of `__post_instantiate` when loaded by the main thread and
we call it explicitly when loaded on a secondary thread.

Note that import/export to TLS symbols is still not yet
supported.