### PR TITLE
Enable custom locations in create_entry_points.py

### DIFF
--- a/emdump
+++ b/emdump
@@ -26,4 +26,4 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-exec "$PYTHON" "$0.py" "$@"
+exec "$PYTHON" "$(dirname $0)/tools/emdump.py" "$@"

--- a/emdump.bat
+++ b/emdump.bat
@@ -8,4 +8,4 @@
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+@"%EM_PY%" "%~dp0\tools\emdump.py" %*

--- a/emprofile
+++ b/emprofile
@@ -26,4 +26,4 @@ if [ -z "$PYTHON" ]; then
   exit 1
 fi
 
-exec "$PYTHON" "tools/$0.py" "$@"
+exec "$PYTHON" "$(dirname $0)/tools/emprofile.py" "$@"

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -8,4 +8,4 @@
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\tools\%~n0.py" %*
+@"%EM_PY%" "%~dp0\tools\emprofile.py" %*


### PR DESCRIPTION
As and example the python code for the emdump tool lives in
tools/emdump.py, but we want the entey point to be at the top
level of emscripten.

Hopefully this will help with #13464