### PR TITLE
Work around Closure compiler issue with unicode characters

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3014,6 +3014,7 @@ else if (typeof exports === 'object')
   exports["%(EXPORT_NAME)s"] = %(EXPORT_NAME)s;
 ''' % {'EXPORT_NAME': shared.Settings.EXPORT_NAME})
 
+  shared.configuration.get_temp_files().note(final_js)
   save_intermediate('modularized')
 
 

--- a/emcc.py
+++ b/emcc.py
@@ -2902,9 +2902,11 @@ def do_binaryen(target, options, wasm_target):
                                use_closure_compiler=options.use_closure_compiler,
                                debug_info=debug_info,
                                symbols_file=symbols_file)
+
+    shared.configuration.get_temp_files().note(wasm2js)
+
     if shared.Settings.WASM == 2:
       safe_copy(wasm2js, wasm2js_template)
-      shared.try_delete(wasm2js)
 
     if shared.Settings.WASM != 2:
       final_js = wasm2js

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7473,7 +7473,7 @@ end
     test = "☃ äö Ć € ' 🦠.c"
     shutil.copyfile(test_file('hello_world.c'), test)
     externs = '💩' + test
-    open(externs, 'w').write('')
+    create_file(externs, '')
     self.run_process([EMCC, test, '--closure=1', '--closure-args', '--externs "' + externs + '"'])
 
   def test_toolchain_profiler(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7468,6 +7468,14 @@ end
   def test_closure_externs(self):
     self.run_process([EMCC, test_file('hello_world.c'), '--closure=1', '--pre-js', test_file('test_closure_externs_pre_js.js'), '--closure-args', '--externs "' + test_file('test_closure_externs.js') + '"'])
 
+  # Tests that it is possible to enable the Closure compiler via --closure=1 even if any of the input files reside in a path with unicode characters.
+  def test_closure_cmdline_utf8_chars(self):
+    test = "☃ äö Ć € ' 🦠.c"
+    shutil.copyfile(test_file('hello_world.c'), test)
+    externs = '💩' + test
+    open(externs, 'w').write('')
+    self.run_process([EMCC, test, '--closure=1', '--closure-args', '--externs "' + externs + '"'])
+
   def test_toolchain_profiler(self):
     environ = os.environ.copy()
     environ['EM_PROFILE_TOOLCHAIN'] = '1'

--- a/tools/building.py
+++ b/tools/building.py
@@ -993,8 +993,6 @@ def closure_compiler(filename, pretty=True, advanced=True, extra_closure_args=No
 
     if Settings.MINIMAL_RUNTIME and Settings.USE_PTHREADS and not Settings.MODULARIZE:
       CLOSURE_EXTERNS += [path_from_root('src', 'minimal_runtime_worker_externs.js')]
-    outfile = filename + '.cc.js'
-    configuration.get_temp_files().note(outfile)
 
     args = ['--compilation_level', 'ADVANCED_OPTIMIZATIONS' if advanced else 'SIMPLE_OPTIMIZATIONS']
     # Keep in sync with ecmaVersion in tools/acorn-optimizer.js
@@ -1006,19 +1004,43 @@ def closure_compiler(filename, pretty=True, advanced=True, extra_closure_args=No
     # Tell closure never to inject the 'use strict' directive.
     args += ['--emit_use_strict=false']
 
+    # Closure compiler is unable to deal with path names that are not 7-bit ASCII:
+    # https://github.com/google/closure-compiler/issues/3784
+    outfile = configuration.get_temp_files().get('.cc.js').name  # Safe 7-bit filename
+    def move_to_safe_7bit_ascii_filename(filename):
+      safe_filename = configuration.get_temp_files().get('.js').name  # Safe 7-bit filename
+      shutil.copyfile(filename, safe_filename)
+      return os.path.relpath(safe_filename, configuration.get_temp_files_directory())
+
     for e in CLOSURE_EXTERNS:
-      args += ['--externs', e]
-    args += ['--js_output_file', outfile]
+      args += ['--externs', move_to_safe_7bit_ascii_filename(e)]
+
+    for i in range(len(user_args)):
+      if user_args[i] == '--externs':
+        user_args[i+1] = move_to_safe_7bit_ascii_filename(user_args[i+1])
+
+    # Specify output file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
+    args += ['--js_output_file', os.path.relpath(outfile, configuration.get_temp_files_directory())]
 
     if Settings.IGNORE_CLOSURE_COMPILER_ERRORS:
       args.append('--jscomp_off=*')
     if pretty:
       args += ['--formatting', 'PRETTY_PRINT']
-    args += ['--js', filename]
+    # Specify input file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
+    args += ['--js', move_to_safe_7bit_ascii_filename(filename)]
     cmd = closure_cmd + args + user_args
     logger.debug('closure compiler: ' + ' '.join(cmd))
 
-    proc = run_process(cmd, stderr=PIPE, check=False, env=env)
+    # Closure compiler does not work if any of the input files contain characters outside the
+    # 7-bit ASCII range. Therefore make sure the command line we pass does not contain any such
+    # input files by passing all input filenames relative to the cwd. (user temp directory might
+    # be in user's home directory, and user's profile name might contain unicode characters)
+    cwd = os.getcwd()
+    try:
+      os.chdir(configuration.get_temp_files_directory())
+      proc = run_process(cmd, stderr=PIPE, check=False, env=env)
+    finally:
+      os.chdir(cwd)
 
     # XXX Closure bug: if Closure is invoked with --create_source_map, Closure should create a
     # outfile.map source map file (https://github.com/google/closure-compiler/wiki/Source-Maps)

--- a/tools/building.py
+++ b/tools/building.py
@@ -1007,6 +1007,7 @@ def closure_compiler(filename, pretty=True, advanced=True, extra_closure_args=No
     # Closure compiler is unable to deal with path names that are not 7-bit ASCII:
     # https://github.com/google/closure-compiler/issues/3784
     outfile = configuration.get_temp_files().get('.cc.js').name  # Safe 7-bit filename
+
     def move_to_safe_7bit_ascii_filename(filename):
       safe_filename = configuration.get_temp_files().get('.js').name  # Safe 7-bit filename
       shutil.copyfile(filename, safe_filename)
@@ -1017,7 +1018,7 @@ def closure_compiler(filename, pretty=True, advanced=True, extra_closure_args=No
 
     for i in range(len(user_args)):
       if user_args[i] == '--externs':
-        user_args[i+1] = move_to_safe_7bit_ascii_filename(user_args[i+1])
+        user_args[i + 1] = move_to_safe_7bit_ascii_filename(user_args[i + 1])
 
     # Specify output file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
     args += ['--js_output_file', os.path.relpath(outfile, configuration.get_temp_files_directory())]

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -421,17 +421,14 @@ class Configuration(object):
         lock.acquire()
         atexit.register(lock.release)
 
-  def get_temp_files_directory(self):
+  def get_temp_files(self):
     if DEBUG_SAVE:
       # In debug mode store all temp files in the emscripten-specific temp dir
       # and don't worry about cleaning them up.
-      return get_emscripten_temp_dir()
+      return tempfiles.TempFiles(get_emscripten_temp_dir(), save_debug_files=True)
     else:
       # Otherwise use the system tempdir and try to clean up after ourselves.
-      return self.TEMP_DIR
-
-  def get_temp_files(self):
-    return tempfiles.TempFiles(self.get_temp_files_directory(), save_debug_files=DEBUG_SAVE)
+      return tempfiles.TempFiles(self.TEMP_DIR, save_debug_files=False)
 
 
 def apply_configuration():

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -421,14 +421,17 @@ class Configuration(object):
         lock.acquire()
         atexit.register(lock.release)
 
-  def get_temp_files(self):
+  def get_temp_files_directory(self):
     if DEBUG_SAVE:
       # In debug mode store all temp files in the emscripten-specific temp dir
       # and don't worry about cleaning them up.
-      return tempfiles.TempFiles(get_emscripten_temp_dir(), save_debug_files=True)
+      return get_emscripten_temp_dir()
     else:
       # Otherwise use the system tempdir and try to clean up after ourselves.
-      return tempfiles.TempFiles(self.TEMP_DIR, save_debug_files=False)
+      return self.TEMP_DIR
+
+  def get_temp_files(self):
+    return tempfiles.TempFiles(self.get_temp_files_directory(), save_debug_files=DEBUG_SAVE)
 
 
 def apply_configuration():


### PR DESCRIPTION
Work around Closure compiler issue https://github.com/google/closure-compiler/issues/3784 that prevents calling Closure compiler with a cmdline that contains unicode characters.