### PR TITLE
Improve test_proxy_to_pthread_stack.c

### DIFF
--- a/tests/other/test_proxy_to_pthread_stack.c
+++ b/tests/other/test_proxy_to_pthread_stack.c
@@ -1,9 +1,24 @@
+#define _GNU_SOURCE
 #include <stdint.h>
+#include <assert.h>
 #include <stdlib.h>
-#include <emscripten.h>
+#include <stdio.h>
+#include <pthread.h>
 
 int main(void) {
+  pthread_attr_t attr;
+  pthread_getattr_np(pthread_self(), &attr);
+  size_t stacksize = 0;
+  pthread_attr_getstacksize(&attr, &stacksize);
+  printf("stack size %zd\n", stacksize);
+
+  // Run with TOTAL_STACK=128k.
+  assert(stacksize == 128*1024);
+
+  // Run with DEFAULT_PTHREAD_STACK_SIZE=64k.
+  // This would fail if we were actually running with only the default pthread stack size.
   int32_t data[64*1024];
-  EM_ASM({ console.log($0, "success"); }, data);
+  printf("data address %p\n", data);
+  printf("success\n");
   exit(0);
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8863,10 +8863,11 @@ int main(void) {
 
   @node_pthreads
   def test_proxy_to_pthread_stack(self):
+    # Check that the proxied main gets run with TOTAL_STACK setting and not
+    # DEFAULT_PTHREAD_STACK_SIZE.
     self.do_smart_test(test_file('other', 'test_proxy_to_pthread_stack.c'),
                        ['success'],
-                       engine=config.NODE_JS,
-                       emcc_args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'TOTAL_STACK=1048576'])
+                       emcc_args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'DEFAULT_PTHREAD_STACK_SIZE=64kb', '-s', 'TOTAL_STACK=128kb'])
 
   @parameterized({
     'async': ['-s', 'WASM_ASYNC_COMPILATION'],


### PR DESCRIPTION
Its not clear to my why the "console.log" message was sometimes
getting lost, but I think it has to do with the way console
message from threads are printed under node.

In any case this test is now more robust and precise about what
its testing.

Also remove `engine=config.NODE_JS` since that is implied by
the `@node_pthreads` decorator.

Fixes: #13567