### PR TITLE
ensure the html output has an html extension

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2432,7 +2432,8 @@ def post_link(options, in_wasm, wasm_target, target):
 
     # If we were asked to also generate HTML, do that
     if options.oformat == OFormat.HTML:
-      generate_html(target, options, js_target, target_basename,
+      html_target = unsuffixed(js_target) + '.html'
+      generate_html(html_target, options, js_target, target_basename,
                     wasm_target, memfile)
     elif shared.Settings.PROXY_TO_WORKER:
       generate_worker_js(target, js_target, target_basename)


### PR DESCRIPTION
I'm not sure if this is the correct approach or not.

The bazel toolchain passes `-o bazel/output/path` to the emcc.py during link. This results in the python variables `target` and `js_target` being set to the same value (something like `bazel/output/path/filename.js`.) When emcc.py then attempts to generate the html, it overwrites the js.

By adding the `.html` extension, this ensures its never overridden.