### PR TITLE
Fix C++ thread::hardware_concurrency under node

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -280,7 +280,7 @@ LibraryManager.library = {
     }
   },
 
-  sysconf__deps: ['$setErrNo'],
+  sysconf__deps: ['$setErrNo', 'emscripten_num_logical_cores'],
   sysconf__proxy: 'sync',
   sysconf__sig: 'ii',
   sysconf: function(name) {
@@ -429,8 +429,7 @@ LibraryManager.library = {
       case {{{ cDefine('_SC_TZNAME_MAX') }}}: return 6;
       case {{{ cDefine('_SC_THREAD_DESTRUCTOR_ITERATIONS') }}}: return 4;
       case {{{ cDefine('_SC_NPROCESSORS_ONLN') }}}: {
-        if (typeof navigator === 'object') return navigator['hardwareConcurrency'] || 1;
-        return 1;
+        return _emscripten_num_logical_cores();
       }
     }
     setErrNo({{{ cDefine('EINVAL') }}});


### PR DESCRIPTION
The codepath for thread::hardware_concurrency was relying
on `sysconf('_SC_NPROCESSORS_ONLN')` was duplicating the
logic in `emscripten_num_logical_cores` but without any
node support.

The other difference is that `emscripten_num_logical_cores`
always returns 1 when code it not build with USE_PTHREADS.