### PR TITLE
Use `__cxa_thread_atexit` over `pthread_cleanup_push` to free TLS data. NFC.

### DIFF
--- a/system/lib/pthread/emscripten_tls_init.c
+++ b/system/lib/pthread/emscripten_tls_init.c
@@ -8,8 +8,25 @@
 #include <emscripten/emmalloc.h>
 #include <pthread.h>
 
+// Uncomment to trace TLS allocations.
+// #define DEBUG_TLS
+#ifdef DEBUG_TLS
+#include <stdio.h>
+#endif
+
 // linker-generated symbol that loads static TLS data at the given location.
 extern void __wasm_init_tls(void *memory);
+
+extern int __cxa_thread_atexit(void (*)(void *), void *, void *);
+
+extern int __dso_handle;
+
+static void free_tls(void* tls_block) {
+#ifdef DEBUG_TLS
+  printf("tls free: thread[%p] dso[%p] <- %p\n", pthread_self(), &__dso_handle, tls_block);
+#endif
+  emscripten_builtin_free(tls_block);
+}
 
 // Note that ASan constructor priority is 50, and we must be higher.
 __attribute__((constructor(49)))
@@ -18,7 +35,10 @@ void emscripten_tls_init(void) {
   size_t tls_align = __builtin_wasm_tls_align();
   if (tls_size) {
     void *tls_block = emscripten_builtin_memalign(tls_align, tls_size);
+#ifdef DEBUG_TLS
+    printf("tls init: thread[%p] dso[%p] -> %p\n", pthread_self(), &__dso_handle, tls_block);
+#endif
     __wasm_init_tls(tls_block);
-    pthread_cleanup_push(emscripten_builtin_free, tls_block);
+    __cxa_thread_atexit(free_tls, tls_block, &__dso_handle);
   }
 }

--- a/tests/other/metadce/minimal_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -39,6 +39,7 @@ $emscripten_sync_run_in_main_thread
 $emscripten_sync_run_in_main_thread
 $emscripten_tls_init
 $emscripten_wait_for_call_v
+$free_tls
 $init_mparams
 $internal_memalign
 $pthread_mutex_init


### PR DESCRIPTION
pthread_cleanup_push and pthread_cleanup_pop are really
supposed to come pairs syntactically so using just `push`
is not correct.

Indeed the pending musl upgrade makes this code fail to
compile.

From the man page:
```
  POSIX.1 permits pthread_cleanup_push() and pthread_cleanup_pop()
  to be implemented as macros that expand to text containing '{'
  and '}', respectively.  For this reason, the caller must ensure
  that calls to these functions are paired within the same
  function, and at the same lexical nesting level.  (In other
  words, a clean-up handler is established only during the
  execution of a specified section of code.)
```