### PR TITLE
Fail if compiler output file is a directory

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6703,9 +6703,20 @@ int main() {
     ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-s', 'MAXIMUM_MEMORY=34603009']) # 33MB + 1 byte
     self.assertContained('MAXIMUM_MEMORY must be a multiple of WebAssembly page size (64KiB)', ret)
 
-  def test_invalid_output_dir(self):
+  def test_dasho_invalid_dir(self):
     ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', os.path.join('NONEXISTING_DIRECTORY', 'out.js')])
     self.assertContained('specified output file (NONEXISTING_DIRECTORY%sout.js) is in a directory that does not exist' % os.path.sep, ret)
+
+  def test_dasho_is_dir(self):
+    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.'])
+    self.assertContained('emcc: error: cannot write output file `.`: Is a directory', ret)
+
+    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.', '--oformat=wasm'])
+    self.assertContained('wasm-ld: error: cannot open output file .: Is a directory', ret)
+
+    ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.', '--oformat=html'])
+    self.assertContained('emcc: error: cannot write output file:', ret)
+    self.assertContained("Is a directory: '.'", ret)
 
   def test_binaryen_ctors(self):
     # ctor order must be identical to js builds, deterministically

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -788,19 +788,6 @@ def unsuffixed_basename(name):
   return os.path.basename(unsuffixed(name))
 
 
-def safe_move(src, dst):
-  logging.debug('move: %s -> %s', src, dst)
-  src = os.path.abspath(src)
-  dst = os.path.abspath(dst)
-  if os.path.isdir(dst):
-    dst = os.path.join(dst, os.path.basename(src))
-  if src == dst:
-    return
-  if dst == os.devnull:
-    return
-  shutil.move(src, dst)
-
-
 def safe_copy(src, dst):
   logging.debug('copy: %s -> %s', src, dst)
   src = os.path.abspath(src)


### PR DESCRIPTION
When the output is a wasm file wasm-ld already fails
in this way.  This change means that js and html output
also fail in the same way.

See #13684