### PR TITLE
Compile gen_struct_info in a hermetic environment

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10029,6 +10029,13 @@ exec "$@"
     self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '-o', 'out.json'])
     self.assertFileContents(test_file('reference_struct_info.json'), open('out.json').read())
 
+  def test_gen_struct_info_env(self):
+    # gen_struct_info.py builds C code in a very particlar way.  We don't want EMMAKEN_CFLAGS to
+    # be injected which could cause it to fail.
+    # For example -O2 causes printf -> iprintf which will fail with undefined symbol iprintf.
+    with env_modify({'EMMAKEN_CFLAGS': '-O2 BAD_ARG'}):
+      self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '-o', 'out.json'])
+
   def test_relocatable_limited_exports(self):
     # Building with RELOCATABLE should *not* automatically export all sybmols.
     self.run_process([EMCC, test_file('hello_world.c'), '-sRELOCATABLE', '-o', 'out.wasm'])

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -275,7 +275,7 @@ def inspect_headers(headers, cflags):
 
   show(shared.shlex_join(cmd))
   try:
-    subprocess.check_call(cmd)
+    subprocess.check_call(cmd, env=system_libs.clean_env())
   except subprocess.CalledProcessError as e:
     sys.stderr.write('FAIL: Compilation failed!: %s\n' % e.cmd)
     sys.exit(1)
@@ -284,11 +284,12 @@ def inspect_headers(headers, cflags):
   show('Calling generated program... ' + js_file[1])
   info = shared.run_js_tool(js_file[1], stdout=shared.PIPE).splitlines()
 
-  # Remove all temporary files.
-  os.unlink(src_file[1])
+  if not DEBUG:
+    # Remove all temporary files.
+    os.unlink(src_file[1])
 
-  if os.path.exists(js_file[1]):
-    os.unlink(js_file[1])
+    if os.path.exists(js_file[1]):
+      os.unlink(js_file[1])
 
   # Parse the output of the program into a dict.
   return parse_c_output(info)


### PR DESCRIPTION
At least prevent `EMMAKEN_CFLAGS` from influencing it.
If `gen_struct_info` is run with `EMMAKEN_CFLAGS=-O2` it
will fail with undefined symbol `iprintf`.

I noticed this when running `test_poppler` with an empty
cache.  It was failing consistently to generate struct info.