### PR TITLE
Pin v8 used in CI to 9.1.146

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ executors:
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
+      # Currently pinned to 9.1.146 due to https://bugs.chromium.org/p/v8/issues/detail?id=11581
+      V8_VERSION: "9.1.146"
   mac:
     environment:
       EMSDK_NOTTY: "1"
@@ -57,7 +59,7 @@ commands:
             # test v8 with --wasm-staging which enables new features. we use v8
             # as a "bleeding edge" shell here, basically, with node being the
             # primary shell (which we run without any special flags)
-            echo "V8_ENGINE = [os.path.expanduser('~/.jsvu/v8'), '--wasm-staging']" >> .emscripten
+            echo "V8_ENGINE = [os.path.expanduser('~/.jsvu/v8-${V8_VERSION}'), '--wasm-staging']" >> .emscripten
             echo "JS_ENGINES = [NODE_JS]" >> .emscripten
             echo "if os.path.exists(V8_ENGINE[0]): JS_ENGINES.append(V8_ENGINE)" >> .emscripten
             echo "WASM_ENGINES = []" >> .emscripten
@@ -390,7 +392,7 @@ jobs:
             export PATH="`pwd`/node-v12.13.0-linux-x64/bin:${PATH}"
             npm install jsvu -g
             export PATH="${HOME}/.jsvu:${PATH}"
-            jsvu --os=default --engines=v8
+            jsvu --os=default --engines=v8 v8@${V8_VERSION}
       - build
       - build-libs-and-freeze
       - persist


### PR DESCRIPTION
There is currently a terbofan crash in 9.1.147+ affecting
the follow tests:

  wasm0.test_dylink_raii_exceptions_wasm_eh
  wasm0.test_dylink_i64_b
  wasm0.test_dlfcn_feature_in_lib

Pinning v8 allows us to continue work on emscripten without being
effecting by outside changes.  We do want to be able to find
and fix problems in v8 when they come up though we probably want some
kind of scheduled roll here.