### PR TITLE
Remove redundant argument to fetch_project. NFC

### DIFF
--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -24,7 +24,7 @@ def get_lib_name(settings):
 
 def get(ports, settings, shared):
   ports.fetch_project('harfbuzz', 'https://github.com/harfbuzz/harfbuzz/releases/download/' +
-                      TAG + '/harfbuzz-' + TAG + '.tar.bz2', 'harfbuzz-' + TAG, is_tarbz2=True, sha512hash=HASH)
+                      TAG + '/harfbuzz-' + TAG + '.tar.bz2', 'harfbuzz-' + TAG, sha512hash=HASH)
 
   def create(final):
     logging.info('building port: harfbuzz')

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -16,7 +16,7 @@ def needed(settings):
 
 
 def get(ports, settings, shared):
-  ports.fetch_project('mpg123', 'https://www.mpg123.de/download/mpg123-1.26.2.tar.bz2', 'mpg123-' + TAG, is_tarbz2=True, sha512hash=HASH)
+  ports.fetch_project('mpg123', 'https://www.mpg123.de/download/mpg123-1.26.2.tar.bz2', 'mpg123-' + TAG, sha512hash=HASH)
 
   def create(output_path):
     logging.info('building port: mpg123')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1658,7 +1658,7 @@ class Ports(object):
   name_cache = set()
 
   @staticmethod
-  def fetch_project(name, url, subdir, is_tarbz2=False, sha512hash=None):
+  def fetch_project(name, url, subdir, sha512hash=None):
     # To compute the sha512 hash, run `curl URL | sha512sum`.
     fullname = os.path.join(Ports.get_dir(), name)
 
@@ -1700,7 +1700,7 @@ class Ports(object):
               Ports.clear_project_build(name)
             return
 
-    if is_tarbz2:
+    if url.endswith('.tar.bz2'):
       fullpath = fullname + '.tar.bz2'
     elif url.endswith('.tar.gz'):
       fullpath = fullname + '.tar.gz'
@@ -1732,7 +1732,7 @@ class Ports(object):
       open(fullpath, 'wb').write(data)
 
     def check_tag():
-      if is_tarbz2:
+      if url.endswith('.tar.bz2'):
         names = tarfile.open(fullpath, 'r:bz2').getnames()
       elif url.endswith('.tar.gz'):
         names = tarfile.open(fullpath, 'r:gz').getnames()


### PR DESCRIPTION
Given that we detect the type based on filename for other cases it seems
like we don't need this extra arg.