### PR TITLE
doc: Document initial x86 performance considerations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -552,3 +552,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Sharad Saxena <sharad.saxena@autodesk.com> (copyright owned by Autodesk, Inc.)
 * Vasili Skurydzin <vasili.skurydzin@ibm.com>
 * Jakub Nowakowski <jn925+emcc@o2.pl>
+* Andrew Brown <andrew.brown@intel.com> (copyright owned by Intel Corporation)


### PR DESCRIPTION
In previous Wasm SIMD meetings, the Emscripten documentation was proposed as a temporary holding place for noting performance considerations of problematic instructions. The list shown here is hardly complete; it is being submitted for discussion on how to present the information. (What is the easiest way to see the RST output before this is merged?).