### PR TITLE
Update SIMD builtin names

### DIFF
--- a/tests/test_wasm_builtin_simd.cpp
+++ b/tests/test_wasm_builtin_simd.cpp
@@ -342,20 +342,20 @@ i8x16 TESTFN i8x16_shr_u(i8x16 vec, int32_t shift) {
 i8x16 TESTFN i8x16_add(i8x16 x, i8x16 y) {
   return x + y;
 }
-i8x16 TESTFN i8x16_add_saturate_s(i8x16 x, i8x16 y) {
-  return __builtin_wasm_add_saturate_s_i8x16(x, y);
+i8x16 TESTFN i8x16_add_sat_s(i8x16 x, i8x16 y) {
+  return __builtin_wasm_add_sat_s_i8x16(x, y);
 }
-u8x16 TESTFN i8x16_add_saturate_u(u8x16 x, u8x16 y) {
-  return __builtin_wasm_add_saturate_u_i8x16(x, y);
+u8x16 TESTFN i8x16_add_sat_u(u8x16 x, u8x16 y) {
+  return __builtin_wasm_add_sat_u_i8x16(x, y);
 }
 i8x16 TESTFN i8x16_sub(i8x16 x, i8x16 y) {
   return x - y;
 }
-i8x16 TESTFN i8x16_sub_saturate_s(i8x16 x, i8x16 y) {
-  return __builtin_wasm_sub_saturate_s_i8x16(x, y);
+i8x16 TESTFN i8x16_sub_sat_s(i8x16 x, i8x16 y) {
+  return __builtin_wasm_sub_sat_s_i8x16(x, y);
 }
-u8x16 TESTFN i8x16_sub_saturate_u(u8x16 x, u8x16 y) {
-  return __builtin_wasm_sub_saturate_u_i8x16(x, y);
+u8x16 TESTFN i8x16_sub_sat_u(u8x16 x, u8x16 y) {
+  return __builtin_wasm_sub_sat_u_i8x16(x, y);
 }
 // TODO: min_s / min_u / max_s / max_u
 u8x16 TESTFN i8x16_avgr_u(u8x16 x, u8x16 y) {
@@ -382,20 +382,20 @@ i16x8 TESTFN i16x8_shr_u(i16x8 vec, int32_t shift) {
 i16x8 TESTFN i16x8_add(i16x8 x, i16x8 y) {
   return x + y;
 }
-i16x8 TESTFN i16x8_add_saturate_s(i16x8 x, i16x8 y) {
-  return __builtin_wasm_add_saturate_s_i16x8(x, y);
+i16x8 TESTFN i16x8_add_sat_s(i16x8 x, i16x8 y) {
+  return __builtin_wasm_add_sat_s_i16x8(x, y);
 }
-u16x8 TESTFN i16x8_add_saturate_u(u16x8 x, u16x8 y) {
-  return __builtin_wasm_add_saturate_u_i16x8(x, y);
+u16x8 TESTFN i16x8_add_sat_u(u16x8 x, u16x8 y) {
+  return __builtin_wasm_add_sat_u_i16x8(x, y);
 }
 i16x8 TESTFN i16x8_sub(i16x8 x, i16x8 y) {
   return x - y;
 }
-i16x8 TESTFN i16x8_sub_saturate_s(i16x8 x, i16x8 y) {
-  return __builtin_wasm_sub_saturate_s_i16x8(x, y);
+i16x8 TESTFN i16x8_sub_sat_s(i16x8 x, i16x8 y) {
+  return __builtin_wasm_sub_sat_s_i16x8(x, y);
 }
-u16x8 TESTFN i16x8_sub_saturate_u(u16x8 x, u16x8 y) {
-  return __builtin_wasm_sub_saturate_u_i16x8(x, y);
+u16x8 TESTFN i16x8_sub_sat_u(u16x8 x, u16x8 y) {
+  return __builtin_wasm_sub_sat_u_i16x8(x, y);
 }
 i16x8 TESTFN i16x8_mul(i16x8 x, i16x8 y) {
   return x * y;
@@ -1059,14 +1059,14 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ((i8x16){3, 17, 0, 0, 0, 135, 109, 46, 145, 225, 48, 184, 17, 249, 128, 215})
   );
   expect_vec(
-    i8x16_add_saturate_s(
+    i8x16_add_sat_s(
       (i8x16){0, 42, 255, 128, 127, 129, 6, 29, 103, 196, 231, 142, 17, 250, 1, 73},
       (i8x16){3, 231, 1, 128, 129, 6, 103, 17, 42, 29, 73, 42, 0, 255, 127, 142}
     ),
     ((i8x16){3, 17, 0, 128, 0, 135, 109, 46, 127, 225, 48, 184, 17, 249, 127, 215})
   );
   expect_vec(
-    i8x16_add_saturate_u(
+    i8x16_add_sat_u(
       (u8x16){0, 42, 255, 128, 127, 129, 6, 29, 103, 196, 231, 142, 17, 250, 1, 73},
       (u8x16){3, 231, 1, 128, 129, 6, 103, 17, 42, 29, 73, 42, 0, 255, 127, 142}
     ),
@@ -1080,14 +1080,14 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ((i8x16){253, 67, 254, 0, 254, 123, 159, 12, 61, 167, 158, 100, 17, 251, 130, 187})
   );
   expect_vec(
-    i8x16_sub_saturate_s(
+    i8x16_sub_sat_s(
       (i8x16){0, 42, 255, 128, 127, 129, 6, 29, 103, 196, 231, 142, 17, 250, 1, 73},
       (i8x16){3, 231, 1, 128, 129, 6, 103, 17, 42, 29, 73, 42, 0, 255, 127, 142}
     ),
     ((i8x16){253, 67, 254, 0, 127, 128, 159, 12, 61, 167, 158, 128, 17, 251, 130, 127})
   );
   expect_vec(
-    i8x16_sub_saturate_u(
+    i8x16_sub_sat_u(
       (u8x16){0, 42, 255, 128, 127, 129, 6, 29, 103, 196, 231, 142, 17, 250, 1, 73},
       (u8x16){3, 231, 1, 128, 129, 6, 103, 17, 42, 29, 73, 42, 0, 255, 127, 142}
     ),
@@ -1146,14 +1146,14 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ((i16x8){768, -255, 0, 0, -30976, 12288, -1792, -32768})
   );
   expect_vec(
-    i16x8_add_saturate_s(
+    i16x8_add_sat_s(
       (i16x8){0, -256, -32768, 32512, -32512, -6400, -1536, 32766},
       (i16x8){768, 1, -32768, -32512, 1536, 18688, -256, 2}
     ),
     ((i16x8){768, -255, -32768, 0, -30976, 12288, -1792, 32767})
   );
   expect_vec(
-    i16x8_add_saturate_u(
+    i16x8_add_sat_u(
       (u16x8){0, -256, -32768, 32512, -32512, -6400, -1536, 32766},
       (u16x8){768, 1, -32768, -32512, 1536, 18688, -256, 2}
     ),
@@ -1167,14 +1167,14 @@ int EMSCRIPTEN_KEEPALIVE __attribute__((__optnone__)) main(int argc, char** argv
     ((i16x8){-768, -257, 0, -512, 31488, -25088, -1280, 32764})
   );
   expect_vec(
-    i16x8_sub_saturate_s(
+    i16x8_sub_sat_s(
       (i16x8){0, -256, -32768, 32512, -32512, -6400, -1536, 32766},
       (i16x8){768, 1, -32768, -32512, 1536, 18688, -256, 2}
     ),
     ((i16x8){-768, -257, 0, 32767, -32768, -25088, -1280, 32764})
   );
   expect_vec(
-    i16x8_sub_saturate_u(
+    i16x8_sub_sat_u(
       (u16x8){0, -256, -32768, 32512, -32512, -6400, -1536, 32766},
       (u16x8){768, 1, -32768, -32512, 1536, 18688, -256, 2}
     ),


### PR DESCRIPTION
These builtin functions were renamed upstream to match the new names for the
underlying instructions.