### PR TITLE
Remove pathconf modificaions from upstream musl

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,13 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- values returns from `pathconf` now match the defintions found in header files
+  and/or upstream musl:
+    _PC_LINK_MAX 3200 -> 8
+    _PC_SYNC_IO -1 -> 1
+    _PC_REC_INCR_XFER_SIZE -1 -> 4096
+    _PC_REC_MAX_XFER_SIZE -1 -> 4096
+    _PC_SYMLINK_MAX -1 -> 255
 - Added support for wrapping emcc and em++ via ccache: install Emscripten port
   of ccache via emsdk, or from https://github.com/juj/ccache/tree/emscripten,
   and run explicitly with "ccache emcc ..." after installing, or automatically

--- a/system/lib/libc/musl/src/conf/fpathconf.c
+++ b/system/lib/libc/musl/src/conf/fpathconf.c
@@ -5,7 +5,7 @@
 long fpathconf(int fd, int name)
 {
 	static const short values[] = {
-		[_PC_LINK_MAX] = 32000, // XXX EMSCRIPTEN replace _POSIX_LINK_MAX,
+		[_PC_LINK_MAX] = _POSIX_LINK_MAX,
 		[_PC_MAX_CANON] = _POSIX_MAX_CANON,
 		[_PC_MAX_INPUT] = _POSIX_MAX_INPUT,
 		[_PC_NAME_MAX] = NAME_MAX,
@@ -14,17 +14,17 @@ long fpathconf(int fd, int name)
 		[_PC_CHOWN_RESTRICTED] = 1,
 		[_PC_NO_TRUNC] = 1,
 		[_PC_VDISABLE] = 0,
-		[_PC_SYNC_IO] = -1, // XXX EMSCRIPTEN replace -1
+		[_PC_SYNC_IO] = 1,
 		[_PC_ASYNC_IO] = -1,
 		[_PC_PRIO_IO] = -1,
 		[_PC_SOCK_MAXBUF] = -1,
 		[_PC_FILESIZEBITS] = FILESIZEBITS,
-		[_PC_REC_INCR_XFER_SIZE] = -1, // XXX EMSCRIPTEN replace 4096,
-		[_PC_REC_MAX_XFER_SIZE] = -1, // XXX EMSCRIPTEN replace 4096,
+		[_PC_REC_INCR_XFER_SIZE] = 4096,
+		[_PC_REC_MAX_XFER_SIZE] = 4096,
 		[_PC_REC_MIN_XFER_SIZE] = 4096,
 		[_PC_REC_XFER_ALIGN] = 4096,
 		[_PC_ALLOC_SIZE_MIN] = 4096,
-		[_PC_SYMLINK_MAX] = -1, // XXX EMSCRIPTEN replace SYMLINK_MAX,
+		[_PC_SYMLINK_MAX] = SYMLINK_MAX,
 		[_PC_2_SYMLINKS] = 1
 	};
 	if (name >= sizeof(values)/sizeof(values[0])) {

--- a/tests/unistd/pathconf.out
+++ b/tests/unistd/pathconf.out
@@ -1,4 +1,4 @@
-_PC_LINK_MAX: 32000
+_PC_LINK_MAX: 8
 errno: 0
 
 _PC_MAX_CANON: 255
@@ -37,7 +37,7 @@ errno: 0
 _PC_VDISABLE: 0
 errno: 0
 
-_PC_SYNC_IO: -1
+_PC_SYNC_IO: 1
 errno: 0
 
 _PC_ASYNC_IO: -1
@@ -49,13 +49,13 @@ errno: 0
 _PC_SOCK_MAXBUF: -1
 errno: 0
 
-_PC_REC_INCR_XFER_SIZE: -1
+_PC_REC_INCR_XFER_SIZE: 4096
 errno: 0
 
-_PC_REC_MAX_XFER_SIZE: -1
+_PC_REC_MAX_XFER_SIZE: 4096
 errno: 0
 
-_PC_SYMLINK_MAX: -1
+_PC_SYMLINK_MAX: 255
 errno: 0
 
 _PC_FILESIZEBITS: 64


### PR DESCRIPTION
I don't think these modifications were indented, but more an
accident of history since these started life in a custom JS
implementation.