### PR TITLE
wasm2c: abort=>trap

### DIFF
--- a/tools/wasm2c/base.c
+++ b/tools/wasm2c/base.c
@@ -102,7 +102,7 @@ ret (*name) params = _##name;
 
 static void abort_with_message(const char* message) {
   fprintf(stderr, "%s\n", message);
-  abort();
+  TRAP(UNREACHABLE);
 }
 
 // Maintain a stack of setjmps, each jump taking us back to the last invoke.


### PR DESCRIPTION
`abort()` would affect the entire outside program. Instead, trap, so the
outside can handle it if it wants.

We call this method on bad errors, but they are still bad errors inside
the sandbox, so the outside can destroy the sandbox and forget about
it.