### PR TITLE
wasm2c: Add experimental sandboxing modes

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1845,6 +1845,14 @@ var PRINTF_LONG_DOUBLE = 0;
 // [link]
 var WASM2C = 0;
 
+// Experimental sandboxing mode, see
+// https://kripken.github.io/blog/wasm/2020/07/27/wasmboxc.html
+//
+//  * full: Normal full wasm2c sandboxing. This uses a signal handler if it can.
+//  * mask: Masks loads and stores.
+//  * none: No sandboxing at all.
+var WASM2C_SANDBOXING = 'full';
+
 // Setting this affects the path emitted in the wasm that refers to the DWARF
 // file, in -gseparate-dwarf mode. This allows the debugging file to be hosted
 // in a custom location.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6261,6 +6261,20 @@ return malloc(size);
     self.do_runf(test_file('core', 'test_autodebug.c'),
                  'success', output_nicerizer=check)
 
+  @parameterized({
+    'full': ('full',),
+    'mask': ('mask',),
+    'none': ('none',),
+  })
+  def test_wasm2c_sandboxing(self, mode):
+    if not can_do_standalone(self):
+      return self.skipTest('standalone mode not supported')
+    self.set_setting('STANDALONE_WASM')
+    self.set_setting('WASM2C')
+    self.set_setting('WASM2C_SANDBOXING', mode)
+    self.wasm_engines = []
+    self.do_core_test('test_hello_world.c')
+
   ### Integration tests
 
   @sync


### PR DESCRIPTION
This is mainly to allow benchmarking and exploration. I've had this in
a side branch for a while but it's less convenient for others that way.
