### PR TITLE
Use C11 atomics in library_pthread.c

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -9,6 +9,7 @@
 
 #include <inttypes.h>
 #include <pthread.h>
+
 #include <emscripten/html5.h>
 
 #ifdef __cplusplus
@@ -139,7 +140,7 @@ typedef struct em_queued_call
 {
   int functionEnum;
   void *functionPtr;
-  int operationDone;
+  _Atomic uint32_t operationDone;
   em_variant_val args[EM_QUEUED_JS_CALL_MAX_ARGS];
   em_variant_val returnValue;
 

--- a/tests/other/metadce/minimal_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -28,7 +28,6 @@ $dlmemalign
 $em_queued_call_free
 $em_queued_call_malloc
 $emscripten_async_run_in_main_thread
-$emscripten_atomic_store_u32
 $emscripten_current_thread_process_queued_calls
 $emscripten_get_global_libc
 $emscripten_main_thread_process_queued_calls


### PR DESCRIPTION
Avoids including emscripten_atomic_store_u32 in all threaded
programs.

Also, remove unneccary use of atomic ops on CallQueue which is
protected by a lock already (noticed by @tlively).