### PR TITLE
Remove llvm_ prefixed intrinsics from library_pthread.c

### DIFF
--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -919,12 +919,6 @@ int _emscripten_call_on_thread(
   }
 }
 
-void llvm_memory_barrier() { emscripten_atomic_fence(); }
-
-int llvm_atomic_load_add_i32_p0i32(int* ptr, int delta) {
-  return emscripten_atomic_add_u32(ptr, delta);
-}
-
 // Stores the memory address that the main thread is waiting on, if any. If
 // the main thread is waiting, we wake it up before waking up any workers.
 EMSCRIPTEN_KEEPALIVE void* _emscripten_main_thread_futex;


### PR DESCRIPTION
These might have been generated by the compiler at some point in the
past but I don't think they are needed anymore.