### PR TITLE
Add EXIT_RUNTIME when running test_pthread_exit_process

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8247,7 +8247,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_exit_process(self):
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
-    self.emcc_args += ['--pre-js', test_file('core', 'pthread', 'test_pthread_exit_runtime.pre.js')]
+    self.emcc_args += ['-DEXIT_RUNTIME', '--pre-js', test_file('core', 'pthread', 'test_pthread_exit_runtime.pre.js')]
     self.do_run_in_out_file_test('core', 'pthread', 'test_pthread_exit_runtime.c', assert_returncode=42)
 
   @node_pthreads


### PR DESCRIPTION
The other test below (test_pthread_no_exit_process) is the one that
is supposed to run without EXIT_RUNTIME.

This will hopefully address recent flakiness reports.