### PR TITLE
Correctly fix windows parentheses mix-up

### DIFF
--- a/em++.bat
+++ b/em++.bat
@@ -2,7 +2,7 @@
 :: To modify this file, edit `tools/run_python_compiler.bat` and then run
 :: `tools/create_entry_points.py`
 
-@setlocal
+@setlocal enabledelayedexpansion
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
@@ -11,9 +11,9 @@
 @set ARGS=%*
 @if "%_EMCC_CCACHE%"=="" (
   :: Do regular invocation of em++.py compiler
-  "%EM_PY%" "%~dp0\%~n0.py" %ARGS:)=^)%
+  "%EM_PY%" "%~dp0\%~n0.py" !ARGS!
 ) else (
   :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set _EMCC_CCACHE=
-  ccache "%~dp0\%~n0.bat" %ARGS:)=^)%
+  ccache "%~dp0\%~n0.bat" !ARGS!
 )

--- a/emcc.bat
+++ b/emcc.bat
@@ -2,7 +2,7 @@
 :: To modify this file, edit `tools/run_python_compiler.bat` and then run
 :: `tools/create_entry_points.py`
 
-@setlocal
+@setlocal enabledelayedexpansion
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
@@ -11,9 +11,9 @@
 @set ARGS=%*
 @if "%_EMCC_CCACHE%"=="" (
   :: Do regular invocation of em++.py compiler
-  "%EM_PY%" "%~dp0\%~n0.py" %ARGS:)=^)%
+  "%EM_PY%" "%~dp0\%~n0.py" !ARGS!
 ) else (
   :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set _EMCC_CCACHE=
-  ccache "%~dp0\%~n0.bat" %ARGS:)=^)%
+  ccache "%~dp0\%~n0.bat" !ARGS!
 )

--- a/tools/run_python_compiler.bat
+++ b/tools/run_python_compiler.bat
@@ -2,7 +2,7 @@
 :: To modify this file, edit `tools/run_python_compiler.bat` and then run
 :: `tools/create_entry_points.py`
 
-@setlocal
+@setlocal enabledelayedexpansion
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
@@ -11,9 +11,9 @@
 @set ARGS=%*
 @if "%_EMCC_CCACHE%"=="" (
   :: Do regular invocation of em++.py compiler
-  "%EM_PY%" "%~dp0\%~n0.py" %ARGS:)=^)%
+  "%EM_PY%" "%~dp0\%~n0.py" !ARGS!
 ) else (
   :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set _EMCC_CCACHE=
-  ccache "%~dp0\%~n0.bat" %ARGS:)=^)%
+  ccache "%~dp0\%~n0.bat" !ARGS!
 )


### PR DESCRIPTION
This issue was attempted to fix in #13698 by escaping `)` but it turned
out to be an incomplete fix, because it fixed the breaking tests then
but broke other ones instead depending on their syntax. This PR tries to
fix it correctly by using `enabledelayedexpansion` feature of batch
files. We can enable delayed expansion of variables within a batch file
by
```
@setlocal enabledelayedexpansion
```
And if you use variables not by the usual syntax `%VAR%` but `!VAR!`, it
is expanded in a delayed manner, after all parentheses for `if`s and
`else`s are expanded.