### PR TITLE
Fix test_dasho_is_dir in Windows

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6713,10 +6713,14 @@ int main() {
 
     ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.', '--oformat=wasm'])
     self.assertContained('wasm-ld: error: cannot open output file .: Is a directory', ret)
+    self.assertContained('wasm-ld: error: cannot open output file .:', ret)
+    # Linux/Mac and Windows's error messages are slightly different
+    self.assertContained(['Is a directory', 'is a directory'], ret)
 
     ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.', '--oformat=html'])
     self.assertContained('emcc: error: cannot write output file:', ret)
-    self.assertContained("Is a directory: '.'", ret)
+    # Linux/Mac and Windows's error codes and messages are different
+    self.assertContained(['Is a directory', 'Permission denied'], ret)
 
   def test_binaryen_ctors(self):
     # ctor order must be identical to js builds, deterministically

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6712,7 +6712,6 @@ int main() {
     self.assertContained('emcc: error: cannot write output file `.`: Is a directory', ret)
 
     ret = self.expect_fail([EMCC, test_file('hello_world.c'), '-o', '.', '--oformat=wasm'])
-    self.assertContained('wasm-ld: error: cannot open output file .: Is a directory', ret)
     self.assertContained('wasm-ld: error: cannot open output file .:', ret)
     # Linux/Mac and Windows's error messages are slightly different
     self.assertContained(['Is a directory', 'is a directory'], ret)


### PR DESCRIPTION
`test_dasho_is_dir` contains these three tests:
```
$ emcc tests/hello_world.c -o .                (a)
$ emcc tests/hello_world.c -o . --oformat=wasm (b)
$ emcc tests/hello_world.c -o . --oformat=html (c)
```

(a) errors out with
```
emcc: error: cannot write output file `.`: Is a directory
```
in all platforms. This message is printed by emcc.py.

(b) errors out with:
In Linux and Mac:
```
wasm-ld: error: cannot open output file .: Is a directory
```
In Windows:
```
wasm-ld: error: cannot open output file .: is a directory
```
Note that the `i`'s case in `is` is different. Note that this message is
not printed by emcc.py here; it is rather generated by wasm-ld, but it
doesn't seem to be printed from lld code. It looks it is printed from
the input/output system in the OSes, which explains the
uppercase/lowercase difference.

(c) errors out with:
In Linux and Mac:
```
emcc: error: cannot write output file: [Errno 21] Is a directory: '.'
```
In Windows:
```
emcc: error: cannot write output file: [Errno 13] Permission denied: '.'
```
So the `error: cannot write output file` part is printed by emcc.py, but
the "Is a directory" part is printed by the OS, and apparently Windows
prints a different message and error code.

So this PR fixes these problems by passing (b) and (c)'s
`assertContained` a list of two different messages so that either of
them can be found.