### PR TITLE
Pass 1 explicitly to some set_setting() calls (NFC)

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1111,7 +1111,7 @@ int main() {
 
   def test_exceptions_off(self):
     for support_longjmp in [0, 1]:
-      self.set_setting('DISABLE_EXCEPTION_CATCHING')
+      self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
       self.do_run_from_file(test_file('core', 'test_exceptions.cpp'), test_file('core', 'test_exceptions_uncaught.out'), assert_returncode=NON_ZERO)
 
   @no_asan('TODO: ASan support in minimal runtime')
@@ -1126,7 +1126,7 @@ int main() {
       self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
       self.do_run_from_file(test_file('core', 'test_exceptions.cpp'), test_file('core', 'test_exceptions_caught.out'))
 
-      self.set_setting('DISABLE_EXCEPTION_CATCHING')
+      self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
       # TODO: Node currently returns 0 for unhandled promise rejections.
       # Switch this to True when they change their default
       expect_fail = False
@@ -1261,7 +1261,7 @@ int main(int argc, char **argv)
     fake_size = len(open('test_exceptions_allowed.js').read())
     shutil.copyfile('test_exceptions_allowed.js', 'fake.js')
 
-    self.set_setting('DISABLE_EXCEPTION_CATCHING')
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
     self.do_run_from_file(src, empty_output, assert_returncode=NON_ZERO)
     disabled_size = len(open('test_exceptions_allowed.js').read())
     shutil.copyfile('test_exceptions_allowed.js', 'disabled.js')
@@ -5204,7 +5204,7 @@ main( int argv, char ** argc ) {
 
   @also_with_noderawfs
   def test_fs_writeFile(self):
-    self.set_setting('DISABLE_EXCEPTION_CATCHING') # see issue 2334
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 1) # see issue 2334
     self.do_run_in_out_file_test('fs', 'test_writeFile.cpp')
 
   def test_fs_write(self):
@@ -5983,7 +5983,7 @@ return malloc(size);
   @no_asan('local count too large for VMs')
   @is_slow_test
   def test_sqlite(self):
-    self.set_setting('DISABLE_EXCEPTION_CATCHING')
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 1)
     self.set_setting('EXPORTED_FUNCTIONS', ['_main', '_sqlite3_open', '_sqlite3_close', '_sqlite3_exec', '_sqlite3_free'])
     if '-g' in self.emcc_args:
       print("disabling inlining") # without registerize (which -g disables), we generate huge amounts of code


### PR DESCRIPTION
`DISABLE_EXCEPTION_CATCHING` can take 0, 1, or 2. This is not an on-off
switches that only take 0 or 1, but when its argument is 1 it is
currently omitted. I think in this case it is more readable if we
actually pass the explicit argument. This is more of a drive-by fix and
does not intend to include all settings that can take any numeric
values.