### PR TITLE
Don't inline EXCEPTION_CATCHING_ALLOWED functions in LLVM

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1295,6 +1295,14 @@ int main(int argc, char **argv)
 
     self.do_core_test('test_exceptions_allowed_uncaught.cpp')
 
+  def test_exceptions_allowed_inlining(self):
+    self.set_setting('DISABLE_EXCEPTION_CATCHING', 2)
+    self.set_setting('EXCEPTION_CATCHING_ALLOWED', ["_Z12somefunctionv"])
+    # make sure inlining is allowed
+    self.set_setting('INLINING_LIMIT', 0)
+
+    self.do_core_test('test_exceptions_allowed.cpp')
+
   @with_both_exception_handling
   def test_exceptions_uncaught(self):
     # needs to flush stdio streams

--- a/tools/building.py
+++ b/tools/building.py
@@ -488,6 +488,10 @@ def llvm_backend_args():
   if Settings.DISABLE_EXCEPTION_CATCHING == 2:
     allowed = ','.join(Settings.EXCEPTION_CATCHING_ALLOWED or ['__fake'])
     args += ['-emscripten-cxx-exceptions-allowed=' + allowed]
+    # make sure catching-allowed funcitons are not inlined before we do code
+    # transformation for EH in the backend
+    for func in Settings.EXCEPTION_CATCHING_ALLOWED:
+      args += ['--force-attribute=' + func + ':noinline']
 
   if Settings.SUPPORT_LONGJMP:
     # asm.js-style setjmp/longjmp handling


### PR DESCRIPTION
Currently, when `-O2` or `-O3` is given, functions specified in
`EXCEPTION_CATCHING_ALLOWED` can be inlined in LLVM middle ends before
we reach [WebAssemblyLowerEmscriptenEHSjLj](https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp) pass in LLVM backend and thus
don't get transformed for exception catching.

This PR fixes the issue by adding `--force-attribute=FUNC_NAME:noinline`
for each function name in `EXCEPTION_CATCHING_ALLOWED`, which adds
`noinline` attribute to the specified function and thus excludes the
function from inlining candidates in optimization passes.

It is fine to inline those functions after we run
WebAssemblyLowerEmscriptenEHSjLj; so this does not affect Binaryen
flags.

Fixes a part of #10721.