### PR TITLE
Deprecate DISABLE_EXCEPTION_CATCHING=2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,11 @@ Current Trunk
 -------------
 - Values returned from `sysconf` now more closely match the definitions found in
   header files and in upstream musl (#13713).
+- `DISABLE_EXCEPTION_CATCHING=2` is now deprecated since it can be inferred from
+  the presence of the `EXCEPTION_CATCHING_ALLOWED` list.  This makes
+  `DISABLE_EXCEPTION_CATCHING` a simple binary option (0 or 1) which defaults to
+  0 which will be set to 1 internally if `EXCEPTION_CATCHING_ALLOWED` list is
+  specified.
 - Values returned from `pathconf` now match the definitions found in header files
   and/or upstream musl:
     _PC_LINK_MAX 3200 -> 8

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -873,8 +873,8 @@ function makeStructuralReturn(values) {
 }
 
 function makeThrow(what) {
-  if (ASSERTIONS && DISABLE_EXCEPTION_CATCHING == 1) {
-    what += ' + " - Exception catching is disabled, this exception cannot be caught. Compile with -s DISABLE_EXCEPTION_CATCHING=0 or DISABLE_EXCEPTION_CATCHING=2 to catch."';
+  if (ASSERTIONS && DISABLE_EXCEPTION_CATCHING) {
+    what += ' + " - Exception catching is disabled, this exception cannot be caught. Compile with -s NO_DISABLE_EXCEPTION_CATCHING or -s EXCEPTION_CATCHING_ALLOWED=[..] to catch."';
     if (MAIN_MODULE) {
       what += ' + " (note: in dynamic linking, if a side module wants exceptions, the main module must be built with that support)"';
     }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -658,11 +658,12 @@ function createExportWrapper(name, fixedasm) {
 #endif
 
 #if ABORT_ON_WASM_EXCEPTIONS
-// When DISABLE_EXCEPTION_CATCHING != 1 `abortWrapperDepth` counts the recursion
-// level of the wrapper function so that we only handle exceptions at the top level
-// letting the exception mechanics work uninterrupted at the inner level.
-// Additionally, `abortWrapperDepth` is also manually incremented in callMain so that
-// we know to ignore exceptions from there since they're handled by callMain directly.
+// When exception catching is enabled (!DISABLE_EXCEPTION_CATCHING)
+// `abortWrapperDepth` counts the recursion level of the wrapper function so
+// that we only handle exceptions at the top level letting the exception
+// mechanics work uninterrupted at the inner level.  Additionally,
+// `abortWrapperDepth` is also manually incremented in callMain so that we know
+// to ignore exceptions from there since they're handled by callMain directly.
 var abortWrapperDepth = 0;
 
 // Creates a wrapper in a closure so that each wrapper gets it's own copy of 'original'
@@ -673,7 +674,7 @@ function makeAbortWrapper(original) {
       throw "program has already aborted!";
     }
 
-#if DISABLE_EXCEPTION_CATCHING != 1
+#if !DISABLE_EXCEPTION_CATCHING
     abortWrapperDepth += 1;
 #endif
     try {
@@ -692,7 +693,7 @@ function makeAbortWrapper(original) {
 
       abort("unhandled exception: " + [e, e.stack]);
     }
-#if DISABLE_EXCEPTION_CATCHING != 1
+#if !DISABLE_EXCEPTION_CATCHING
     finally {
       abortWrapperDepth -= 1;
     }

--- a/src/settings.js
+++ b/src/settings.js
@@ -643,22 +643,23 @@ var LZ4 = 0;
 // currently (in the future, wasm should improve that). When exceptions are
 // disabled, if an exception actually happens then it will not be caught
 // and the program will halt (so this will not introduce silent failures).
-// There are 3 specific modes here:
-// DISABLE_EXCEPTION_CATCHING = 0 - generate code to actually catch exceptions
-// DISABLE_EXCEPTION_CATCHING = 1 - disable exception catching at all
-// DISABLE_EXCEPTION_CATCHING = 2 - disable exception catching, but enables
-//                                  catching in list of allowed functions
+//
 // XXX note that this removes *catching* of exceptions, which is the main
 //     issue for speed, but you should build source files with
 //     -fno-exceptions to really get rid of all exceptions code overhead,
 //     as it may contain thrown exceptions that are never caught (e.g.
 //     just using std::vector can have that). -fno-rtti may help as well.
 //
+// This option is mutually exclusive with EXCEPTION_CATCHING_ALLOWED.
+//
 // [compile+link] - affects user code at compile and system libraries at link
 var DISABLE_EXCEPTION_CATCHING = 1;
 
-// Enables catching exception in the listed functions only, if
-// DISABLE_EXCEPTION_CATCHING = 2 is set
+// Enables catching exception but only in the listed functions.  This
+// option acts like a more precise version of `DISABLE_EXCEPTION_CATCHING=0`.
+//
+// This option is mutually exclusive with DISABLE_EXCEPTION_CATCHING.
+//
 // [compile+link] - affects user code at compile and system libraries at link
 var EXCEPTION_CATCHING_ALLOWED = [];
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -483,10 +483,10 @@ def llvm_backend_args():
   args = ['-combiner-global-alias-analysis=false']
 
   # asm.js-style exception handling
-  if Settings.DISABLE_EXCEPTION_CATCHING != 1:
+  if not Settings.DISABLE_EXCEPTION_CATCHING:
     args += ['-enable-emscripten-cxx-exceptions']
-  if Settings.DISABLE_EXCEPTION_CATCHING == 2:
-    allowed = ','.join(Settings.EXCEPTION_CATCHING_ALLOWED or ['__fake'])
+  if Settings.EXCEPTION_CATCHING_ALLOWED:
+    allowed = ','.join(Settings.EXCEPTION_CATCHING_ALLOWED)
     args += ['-emscripten-cxx-exceptions-allowed=' + allowed]
 
   if Settings.SUPPORT_LONGJMP:


### PR DESCRIPTION
We can instead imply this mode by the presence of the
`EXCEPTION_CATCHING_ALLOWED` list.

This turns `DISABLE_EXCEPTION_CATCHING` into a binary option
which is easier to deal with both internally and externally.