### PR TITLE
Fix conditional expression in musl's dup2. NFC.

### DIFF
--- a/system/lib/libc/musl/src/unistd/dup2.c
+++ b/system/lib/libc/musl/src/unistd/dup2.c
@@ -14,7 +14,7 @@ int dup2(int old, int new)
 #else
 	if (old==new) {
 #ifdef __EMSCRIPTEN__
-		r = __wasi_fd_is_valid(old);
+		r = __wasi_fd_is_valid(old) ? 0 : -1;
 #else
 		r = __syscall(SYS_fcntl, old, F_GETFD);
 #endif

--- a/system/lib/libc/musl/src/unistd/dup2.c
+++ b/system/lib/libc/musl/src/unistd/dup2.c
@@ -13,10 +13,10 @@ int dup2(int old, int new)
 	while ((r=__syscall(SYS_dup2, old, new))==-EBUSY);
 #else
 	if (old==new) {
-#if __EMSCRIPTEN__
-		r = __syscall(SYS_fcntl, old, F_GETFD);
-#else
+#ifdef __EMSCRIPTEN__
 		r = __wasi_fd_is_valid(old);
+#else
+		r = __syscall(SYS_fcntl, old, F_GETFD);
 #endif
 		if (r >= 0) return old;
 	} else {

--- a/tests/unistd/dup.c
+++ b/tests/unistd/dup.c
@@ -39,5 +39,12 @@ int main() {
   printf("\n");
   errno = 0;
 
+  printf("DUP2 err\n");
+  f = dup2(-2, -2);
+  printf("f: %d\n", f == -1);
+  printf("errno: %d\n", errno);
+  printf("close(f): %d\n", close(f));
+  errno = 0;
+
   return 0;
 }

--- a/tests/unistd/dup.out
+++ b/tests/unistd/dup.out
@@ -13,3 +13,8 @@ f2,f3: 1
 close(f1): 0
 close(f2): 0
 close(f3): -1
+
+DUP2 err
+f: 1
+errno: 8
+close(f): -1


### PR DESCRIPTION
The if/else branch of the conditional expression was reversed.

Non-functional change since it will eventually call the `SYS_dup2`
syscall (i.e. `SYS_dup2` is always defined). So, this is only useful
for reference purposes.