### PR TITLE
Avoid setting `_LIBCPP_HAS_CATOPEN` in libcxx. NFC.

### DIFF
--- a/system/lib/libcxx/include/__config
+++ b/system/lib/libcxx/include/__config
@@ -909,7 +909,7 @@ typedef unsigned int   char32_t;
 
 #if defined(__unix__) || (defined(__APPLE__) && defined(__MACH__))
 // Most unix variants have catopen.  These are the specific ones that don't.
-#  if !defined(__BIONIC__) && !defined(_NEWLIB_VERSION)
+#  if !defined(__BIONIC__) && !defined(_NEWLIB_VERSION) && !defined(__EMSCRIPTEN__) // XXX Emscripten catopen always returns -1
 #    define _LIBCPP_HAS_CATOPEN 1
 #  endif
 #endif


### PR DESCRIPTION
This is to avoid unnecessary calls to the messages catalog functions,
which are currently not supported within Emscripten.

Note that since musl v1.1.24 these functions are supported, see:
https://git.musl-libc.org/cgit/musl/commit?id=7590203c486d9002522019045d34ee3dee0a66f5

But this would then add a dependency on `__map_file` (which is 
currently no-op).

---

The alternative would be to support message catalogs and the
`__map_file` function in the pending musl upgrade, but I'm not
quite sure if this can be supported, see for details: https://github.com/emscripten-core/emscripten/commit/c9bfee30c484165fe0e41e8d0aa8102986dc9739.
