### PR TITLE
Add support for simplified `-s` list parsing

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- Lists that are passed on the command line can now skip the opening an closing
+  braces, allowing for simpler, more readable settings.  e.g.
+    `-s EXPORTED_FUNCTIONS=foo,bar`
 - Values returned from `sysconf` now more closely match the definitions found in
   header files and in upstream musl (#13713).
 - `DISABLE_EXCEPTION_CATCHING=2` is now deprecated since it can be inferred from

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -104,9 +104,20 @@ Options that are modified or new in *emcc* are listed below:
 
    Note:
 
-     For options that are lists, you need quotation marks (") around
-     the list in most shells (to avoid errors being raised). Two
-     examples are shown below:
+     Lists can be specified without or without quotes around each
+     element and with or without brackets around the list.  For
+     example all the following are equivelent:
+
+        -s EXPORTED_FUNCTIONS=foo,bar
+        -s EXPORTED_FUNCTIONS="foo","bar"
+        -s EXPORTED_FUNCTIONS=["foo","bar"]
+        -s EXPORTED_FUNCTIONS=[foo,bar]
+
+   Note:
+
+     For lists that include brackets or quote, you need quotation
+     marks (") around the list in most shells (to avoid errors being
+     raised). Two examples are shown below:
 
         -s RUNTIME_LINKED_LIBS="['liblib.so']"
         -s "RUNTIME_LINKED_LIBS=['liblib.so']"

--- a/emcc.py
+++ b/emcc.py
@@ -368,19 +368,22 @@ def apply_settings(changes):
       value = open(filename).read()
     else:
       value = value.replace('\\', '\\\\')
+
+    existing = getattr(shared.Settings, user_key, None)
+    expect_list = type(existing) == list
+
     try:
-      value = parse_value(value)
+      value = parse_value(value, expect_list)
     except Exception as e:
       exit_with_error('a problem occurred in evaluating the content after a "-s", specifically "%s=%s": %s', key, value, str(e))
 
     # Do some basic type checking by comparing to the existing settings.
     # Sadly we can't do this generically in the SettingsManager since there are settings
     # that so change types internally over time.
-    existing = getattr(shared.Settings, user_key, None)
-    if existing is not None:
-      # We only currently worry about lists vs non-lists.
-      if (type(existing) == list) != (type(value) == list):
-        exit_with_error('setting `%s` expects `%s` but got `%s`' % (user_key, type(existing), type(value)))
+    # We only currently worry about lists vs non-lists.
+    if expect_list != (type(value) == list):
+      exit_with_error('setting `%s` expects `%s` but got `%s`' % (user_key, type(existing), type(value)))
+
     setattr(shared.Settings, user_key, value)
 
     if key == 'EXPORTED_FUNCTIONS':
@@ -2570,7 +2573,7 @@ def parse_args(newargs):
       logger.warning('--js-opts ignored when using llvm backend')
       consume_arg()
     elif check_arg('--llvm-opts'):
-      options.llvm_opts = parse_value(consume_arg())
+      options.llvm_opts = parse_value(consume_arg(), expect_list=True)
     elif arg.startswith('-flto'):
       if '=' in arg:
         shared.Settings.LTO = arg.split('=')[1]
@@ -3368,10 +3371,7 @@ def is_valid_abspath(options, path_name):
   return False
 
 
-def parse_value(text):
-  if not text:
-    return text
-
+def parse_value(text, expect_list):
   # Note that using response files can introduce whitespace, if the file
   # has a newline at the end. For that reason, we rstrip() in relevant
   # places here.
@@ -3418,14 +3418,15 @@ def parse_value(text):
 
   def parse_string_list(text):
     text = text.rstrip()
-    if text[-1] != ']':
-      exit_with_error('unclosed opened string list. expected final character to be "]" in "%s"' % (text))
-    inner = text[1:-1]
-    if inner.strip() == "":
+    if text and text[0] == '[':
+      if text[-1] != ']':
+        exit_with_error('unclosed opened string list. expected final character to be "]" in "%s"' % (text))
+      text = text[1:-1]
+    if text.strip() == "":
       return []
-    return parse_string_list_members(inner)
+    return parse_string_list_members(text)
 
-  if text[0] == '[':
+  if expect_list or (text and text[0] == '['):
     # if json parsing fails, we fall back to our own parser, which can handle a few
     # simpler syntaxes
     try:

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -96,7 +96,16 @@ Options that are modified or new in *emcc* are listed below:
 
   .. note:: If no value is specifed it will default to ``1``.
 
-  .. note:: For options that are lists, you need quotation marks (") around the list in most shells (to avoid errors being raised). Two examples are shown below:
+  .. note:: Lists can be specified without or without quotes around each element and with or without brackets around the list.  For example all the following are equivelent:
+
+    ::
+
+      -s EXPORTED_FUNCTIONS=foo,bar
+      -s EXPORTED_FUNCTIONS="foo","bar"
+      -s EXPORTED_FUNCTIONS=["foo","bar"]
+      -s EXPORTED_FUNCTIONS=[foo,bar]
+
+  .. note:: For lists that include brackets or quote, you need quotation marks (") around the list in most shells (to avoid errors being raised). Two examples are shown below:
 
     ::
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6210,8 +6210,6 @@ high = 1234
     self.assertNotContained('a problem occurred in evaluating the content after a "-s", specifically', err)
 
   def test_dash_s_wrong_type(self):
-    err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-s', 'EXPORTED_FUNCTIONS=foo'])
-    self.assertContained("error: setting `EXPORTED_FUNCTIONS` expects `<class 'list'>` but got `<class 'str'>`", err)
     err = self.expect_fail([EMCC, test_file('hello_world.cpp'), '-s', 'EXIT_RUNTIME=[foo,bar]'])
     self.assertContained("error: setting `EXIT_RUNTIME` expects `<class 'int'>` but got `<class 'list'>`", err)
 
@@ -7956,7 +7954,7 @@ test_module().then((test_module_instance) => {
       f.write(b'!<arch>\n')
     self.assertTrue(building.is_ar(fname))
 
-  def test_emcc_parsing(self):
+  def test_dash_s_list_parsing(self):
     create_file('src.c', r'''
         #include <stdio.h>
         void a() { printf("a\n"); }
@@ -7977,6 +7975,10 @@ test_module().then((test_module_instance) => {
       ('EXPORTED_FUNCTIONS=[_a,_b,_c,_d]', ''),
       # No quotes with spaces
       ('EXPORTED_FUNCTIONS=[_a, _b, _c, _d]', ''),
+      # No brackets needed either
+      ('EXPORTED_FUNCTIONS=_a,_b,_c,_d', ''),
+      # No brackets with spaced
+      ('EXPORTED_FUNCTIONS=_a, _b, _c, _d', ''),
       # extra space at end - should be ignored
       ("EXPORTED_FUNCTIONS=['_a', '_b', '_c', '_d' ]", ''),
       # extra newline in response file - should be ignored


### PR DESCRIPTION
With this change the opening and closing braced are no
longer required.  `e.g. -s EXPORTED_FUNCTIONS=_foo,_bar`

This form is more inline with traditional compiler arguments
where lists of C symbols are to be passed.