### PR TITLE
Fix settings.js doc for INLINING_LIMIT

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2562,12 +2562,12 @@ def parse_args(newargs):
         options.llvm_opts = ['-Os']
         options.requested_level = 2
         shared.Settings.SHRINK_LEVEL = 1
-        settings_changes.append('INLINING_LIMIT=50')
+        settings_changes.append('INLINING_LIMIT=1')
       elif options.requested_level == 'z':
         options.llvm_opts = ['-Oz']
         options.requested_level = 2
         shared.Settings.SHRINK_LEVEL = 2
-        settings_changes.append('INLINING_LIMIT=25')
+        settings_changes.append('INLINING_LIMIT=1')
       shared.Settings.OPT_LEVEL = validate_arg_level(options.requested_level, 3, 'Invalid optimization level: ' + arg, clamp=True)
     elif check_arg('--js-opts'):
       logger.warning('--js-opts ignored when using llvm backend')

--- a/src/settings.js
+++ b/src/settings.js
@@ -290,11 +290,8 @@ var IGNORE_CLOSURE_COMPILER_ERRORS = 0;
 // [link]
 var DECLARE_ASM_MODULE_EXPORTS = 1;
 
-// A limit on inlining. If 0, we will inline normally in LLVM and closure. If
-// greater than 0, we will *not* inline in LLVM, and we will prevent inlining of
-// functions of this size or larger in closure. 50 is a reasonable setting if
-// you do not want inlining
-// [compile+link]
+// If 0, prevents inlining if set to 1. If 0, we will inline normally in LLVM.
+// [compile]
 var INLINING_LIMIT = 0;
 
 // If set to 1, perform acorn pass that converts each HEAP access into a

--- a/src/settings.js
+++ b/src/settings.js
@@ -291,6 +291,7 @@ var IGNORE_CLOSURE_COMPILER_ERRORS = 0;
 var DECLARE_ASM_MODULE_EXPORTS = 1;
 
 // If 0, prevents inlining if set to 1. If 0, we will inline normally in LLVM.
+// This does not affect the inlining policy in Binaryen.
 // [compile]
 var INLINING_LIMIT = 0;
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -765,7 +765,7 @@ class TestCoreBase(RunnerCore):
     self.do_core_test('test_loop.c')
 
   def test_stack(self):
-    self.set_setting('INLINING_LIMIT', 50)
+    self.set_setting('INLINING_LIMIT')
     # some extra coverage in all test suites for stack checks
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
 
@@ -1238,7 +1238,7 @@ int main(int argc, char **argv)
   def test_exceptions_allowed(self):
     self.set_setting('EXCEPTION_CATCHING_ALLOWED', ["_Z12somefunctionv"])
     # otherwise it is inlined and not identified
-    self.set_setting('INLINING_LIMIT', 50)
+    self.set_setting('INLINING_LIMIT')
 
     self.do_core_test('test_exceptions_allowed.cpp')
     size = os.path.getsize('test_exceptions_allowed.js')
@@ -1622,7 +1622,7 @@ int main() {
     # of the program directory influences how much stack we need, and so
     # long random temp dir names can lead to random failures. The stack
     # size was increased here to avoid that.
-    self.set_setting('INLINING_LIMIT', 50)
+    self.set_setting('INLINING_LIMIT')
     self.set_setting('TOTAL_STACK', 8 * 1024)
 
     self.do_core_test('test_stack_varargs.c')
@@ -1708,7 +1708,7 @@ int main() {
 
   def test_stack_void(self):
     self.emcc_args.append('-Wno-format-extra-args')
-    self.set_setting('INLINING_LIMIT', 50)
+    self.set_setting('INLINING_LIMIT')
     self.do_core_test('test_stack_void.c')
 
   def test_life(self):
@@ -2286,7 +2286,7 @@ The current type of b is: 9
     self.do_core_test('test_functionpointer_libfunc_varargs.c')
 
   def test_structbyval(self):
-    self.set_setting('INLINING_LIMIT', 50)
+    self.set_setting('INLINING_LIMIT')
 
     # part 1: make sure that normally, passing structs by value works
 
@@ -6016,7 +6016,7 @@ return malloc(size);
     self.set_setting('EXPORTED_FUNCTIONS', ['_main', '_sqlite3_open', '_sqlite3_close', '_sqlite3_exec', '_sqlite3_free'])
     if '-g' in self.emcc_args:
       print("disabling inlining") # without registerize (which -g disables), we generate huge amounts of code
-      self.set_setting('INLINING_LIMIT', 50)
+      self.set_setting('INLINING_LIMIT')
 
     # newer clang has a warning for implicit conversions that lose information,
     # which happens in sqlite (see #9138)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6578,7 +6578,7 @@ int main() {
 }
 ''')
 
-    # Without the 'INLINING_LIMIT=1', -O2 inlines foo()
+    # Without the 'INLINING_LIMIT', -O2 inlines foo()
     cmd = [EMCC, '-c', 'test.c', '-O2', '-o', 'test.o', '-s', 'INLINING_LIMIT', '-flto']
     self.run_process(cmd)
     # If foo() had been wrongly inlined above, internalizing foo and running


### PR DESCRIPTION
This option was created as a numeric scale but currently what only
matters is if it is 0 or not, effectively making this a boolean switch.
This PR fixes the comment for `INLINING_LIMIT` in settings.js and
converts uses of `INLINING_LIMIT` options in tests that use values
greater than 1 to use 1.