### PR TITLE
Minor refactoring of ports system. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2243,7 +2243,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # link in ports and system libraries, if necessary
     if not shared.Settings.SIDE_MODULE:
       # Ports are always linked into the main module, never the size module.
-      extra_files_to_link += system_libs.get_ports(shared.Settings)
+      extra_files_to_link += system_libs.get_ports_libs(shared.Settings)
     if '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
       link_as_cxx = run_via_emxx
       # Traditionally we always link as C++.  For compatibility we continue to do that,

--- a/tools/building.py
+++ b/tools/building.py
@@ -324,7 +324,7 @@ def configure(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
   if EM_BUILD_VERBOSE >= 1:
     stderr = None
   print('configure: ' + shared.shlex_join(args), file=sys.stderr)
-  run_process(args, stdout=stdout, stderr=stderr, env=env, **kwargs)
+  check_call(args, stdout=stdout, stderr=stderr, env=env, **kwargs)
 
 
 def make(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
@@ -349,7 +349,7 @@ def make(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
   if EM_BUILD_VERBOSE >= 1:
     stderr = None
   print('make: ' + ' '.join(args), file=sys.stderr)
-  run_process(args, stdout=stdout, stderr=stderr, env=env, shell=WINDOWS, **kwargs)
+  check_call(args, stdout=stdout, stderr=stderr, env=env, shell=WINDOWS, **kwargs)
 
 
 def make_paths_absolute(f):

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1794,24 +1794,6 @@ class Ports(object):
     shared.try_delete(os.path.join(Ports.get_build_dir(), name))
 
 
-# get all ports
-def get_ports(settings):
-  ret = []
-  needed = get_needed_ports(settings)
-
-  for port in dependency_order(needed):
-    if port.needed(settings):
-      try:
-        # ports return their output files, which will be linked, or a txt file
-        ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
-      except Exception:
-        logger.error('a problem occurred when using an emscripten-ports library.  try to run `emcc --clear-ports` and then run this command again')
-        raise
-
-  ret.reverse()
-  return ret
-
-
 def dependency_order(port_list):
   # Perform topological sort of ports according to the dependency DAG
   port_map = {p.name: p for p in port_list}
@@ -1868,7 +1850,29 @@ def clear_port(port_name, settings):
   port.clear(Ports, settings, shared)
 
 
-def add_ports_cflags(args, settings):
+def get_ports_libs(settings):
+  """Called add link time to calculate the list of port libraries.
+  Can have the side effect of building and installing the needed ports.
+  """
+  ret = []
+  needed = get_needed_ports(settings)
+
+  for port in dependency_order(needed):
+    if port.needed(settings):
+      # ports return their output files, which will be linked, or a txt file
+      ret += [f for f in port.get(Ports, settings, shared) if not f.endswith('.txt')]
+
+  ret.reverse()
+  return ret
+
+
+def add_ports_cflags(args, settings): # noqa: U100
+  """Called during compile phase add any compiler flags (e.g -Ifoo) needed
+  by the selected ports.  Can also add/change settings.
+
+  Can have the side effect of building and installing the needed ports.
+  """
+
   # Legacy SDL1 port is not actually a port at all but builtin
   if settings.USE_SDL == 1:
     args += ['-Xclang', '-iwithsysroot/include/SDL']
@@ -1880,8 +1884,6 @@ def add_ports_cflags(args, settings):
   for port in dependency_order(needed):
     port.get(Ports, settings, shared)
     args += port.process_args(Ports)
-
-  return args
 
 
 def show_ports():


### PR DESCRIPTION
Rename get_ports() to get_ports_libs() to better reflect
its purpose.

Use check_call over run_process when calling configure and
make.  These handles failure by exiting with a nice message
rather than throwing an generating a backtrace.

Remove try/catch block from this function for several reasons
1. General try/catch block like this are too broad of brush
   and catch all kind of things such as internal error that
   we don't want to handle here.
2. It matches th compantion functions add_ports_cflags
3. The companion function add_ports_cflags() is actually where
   all ports will be build in 99.9% of cases since that what
   is called during the compile phase.  By the time we get the
   link phase, in almost all cases the port will already be
   built.
4. If any given port fails to build it should already be
   calling exit_with_error with a reasonable message.