### PR TITLE
Set dynamicLibraries globally. NFC.

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -694,11 +694,7 @@ var LibraryDylink = {
 #if DYLINK_DEBUG
     err('preloadDylibs');
 #endif
-    var libs = {{{ JSON.stringify(RUNTIME_LINKED_LIBS) }}};
-    if (Module['dynamicLibraries']) {
-      libs = libs.concat(Module['dynamicLibraries'])
-    }
-    if (!libs.length) {
+    if (!dynamicLibraries.length) {
 #if DYLINK_DEBUG
       err('preloadDylibs: no libraries to preload');
 #endif
@@ -710,7 +706,7 @@ var LibraryDylink = {
     if (!readBinary) {
       // we can't read binary data synchronously, so preload
       addRunDependency('preloadDylibs');
-      libs.reduce(function(chain, lib) {
+      dynamicLibraries.reduce(function(chain, lib) {
         return chain.then(function() {
           return loadDynamicLibrary(lib, {loadAsync: true, global: true, nodelete: true, allowUndefined: true});
         });
@@ -722,7 +718,7 @@ var LibraryDylink = {
       return;
     }
 
-    libs.forEach(function(lib) {
+    dynamicLibraries.forEach(function(lib) {
       // libraries linked to main never go away
       loadDynamicLibrary(lib, {global: true, nodelete: true, allowUndefined: true});
     });

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -19,6 +19,13 @@ Module.realPrint = out;
 out = err = function(){};
 #endif
 
+#if RELOCATABLE
+{{{ makeModuleReceiveWithVar('dynamicLibraries', undefined, '[]', true) }}}
+#if RUNTIME_LINKED_LIBS
+dynamicLibraries = {{{ JSON.stringify(RUNTIME_LINKED_LIBS) }}}.concat(dynamicLibraries);
+#endif
+#endif
+
 {{{ makeModuleReceiveWithVar('wasmBinary') }}}
 {{{ makeModuleReceiveWithVar('noExitRuntime', undefined, EXIT_RUNTIME ? 'false' : 'true') }}}
 


### PR DESCRIPTION
This is a precursor to being able to read the list of shared
libraries directly from the 'dylink' section of the main module
(like we already do for side modules).