### PR TITLE
Use "dylink" section for main module dependencies

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1418,7 +1418,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       shared.Settings.RELOCATABLE = 1
 
     if shared.Settings.RELOCATABLE:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$reportUndefinedSymbols', '$relocateExports', '$GOTHandler']
+      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+          '$reportUndefinedSymbols',
+          '$relocateExports',
+          '$GOTHandler',
+          '$getDylinkMetadata',
+      ]
       if options.use_closure_compiler:
         exit_with_error('cannot use closure compiler on shared modules')
       if shared.Settings.MINIMAL_RUNTIME:
@@ -2860,8 +2865,8 @@ def do_binaryen(target, options, wasm_target):
     building.eval_ctors(final_js, wasm_target, debug_info=intermediate_debug_info)
 
   # after generating the wasm, do some final operations
-  if shared.Settings.SIDE_MODULE:
-    webassembly.add_dylink_section(wasm_target, shared.Settings.RUNTIME_LINKED_LIBS)
+  if shared.Settings.RELOCATABLE:
+    webassembly.update_dylink_section(wasm_target, shared.Settings.RUNTIME_LINKED_LIBS)
 
   if shared.Settings.EMIT_EMSCRIPTEN_METADATA:
     diagnostics.warning('deprecated', 'We hope to remove support for EMIT_EMSCRIPTEN_METADATA. See https://github.com/emscripten-core/emscripten/issues/12231')

--- a/src/worker.js
+++ b/src/worker.js
@@ -45,9 +45,16 @@ Module['instantiateWasm'] = function(info, receiveInstance) {
   // Instantiate from the module posted from the main thread.
   // We can just use sync instantiation in the worker.
   var instance = new WebAssembly.Instance(Module['wasmModule'], info);
+#if RELOCATABLE || MAIN_MODULE
+  receiveInstance(instance, Module['wasmModule']);
+#else
+  // TODO: Due to Closure regression https://github.com/google/closure-compiler/issues/3193,
+  // the above line no longer optimizes out down to the following line.
+  // When the regression is fixed, we can remove this if/else.
+  receiveInstance(instance);
+#endif
   // We don't need the module anymore; new threads will be spawned from the main thread.
   Module['wasmModule'] = null;
-  receiveInstance(instance); // The second 'module' parameter is intentionally null here, we don't need to keep a ref to the Module object from here.
   return instance.exports;
 };
 #endif

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -130,12 +130,11 @@ def parse_dylink_section(wasm_file):
   return (mem_size, mem_align, table_size, table_align, section_end)
 
 
-def add_dylink_section(wasm_file, needed_dynlibs):
+def update_dylink_section(wasm_file, needed_dynlibs):
   # A wasm shared library has a special "dylink" section, see tools-conventions repo.
   # This function adds this section to the beginning on the given file.
 
   mem_size, mem_align, table_size, table_align, section_end = parse_dylink_section(wasm_file)
-  logger.debug('creating wasm dynamic library with mem size %d, table size %d, align %d' % (mem_size, table_size, mem_align))
 
   section_name = b'\06dylink' # section name, including prefixed size
   contents = (toLEB(mem_size) + toLEB(mem_align) +


### PR DESCRIPTION
We already do this for side modules so it seems consistent
and cleaner.