### PR TITLE
Remove unused lists from jsifier. NFC

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -61,7 +61,7 @@ function stringifyWithFunctions(obj) {
 function JSify(data, functionsOnly) {
   var mainPass = !functionsOnly;
 
-  var itemsDict = { type: [], GlobalVariableStub: [], functionStub: [], function: [], GlobalVariable: [], GlobalVariablePostSet: [] };
+  var itemsDict = { type: [], functionStub: [], function: [], GlobalVariablePostSet: [] };
 
   if (mainPass) {
     // Add additional necessary items for the main pass. We can now do this since types are parsed (types can be used through
@@ -362,7 +362,7 @@ function JSify(data, functionsOnly) {
     //
 
     if (!mainPass) {
-      var generated = itemsDict.function.concat(itemsDict.type).concat(itemsDict.GlobalVariableStub).concat(itemsDict.GlobalVariable);
+      var generated = itemsDict.function.concat(itemsDict.type);
       print(generated.map((item) => item.JS).join('\n'));
       return;
     }


### PR DESCRIPTION
Neither GlobalVariableStub not GlobalVariable are ever written
to by this code.

Looks like they have not been used since 2015: 8d2ccfd2145296a43fc4bc9584aab898167fec53