### PR TITLE
Run emcmake and emconfigure via launcher scripts. NFC

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -28,7 +28,7 @@ from .shared import LLVM_LINK, LLVM_OBJCOPY
 from .shared import try_delete, run_process, check_call, exit_with_error
 from .shared import configuration, path_from_root
 from .shared import asmjs_mangle, DEBUG
-from .shared import EM_BUILD_VERBOSE, TEMP_DIR
+from .shared import TEMP_DIR
 from .shared import CANONICAL_TEMP_DIR, LLVM_DWARFDUMP, demangle_c_symbol_name
 from .shared import get_emscripten_temp_dir, exe_suffix, is_c_symbol
 from .utils import which, WINDOWS
@@ -304,11 +304,8 @@ def handle_cmake_toolchain(args, env):
   return (args, env)
 
 
-def configure(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
-  if env:
-    env = env.copy()
-  else:
-    env = get_building_env(cflags=cflags)
+def configure(args):
+  env = get_building_env()
   if 'cmake' in args[0]:
     # Note: EMMAKEN_JUST_CONFIGURE shall not be enabled when configuring with
     #       CMake. This is because CMake does expect to be able to do
@@ -319,17 +316,12 @@ def configure(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
     # compilation with emcc, but instead do builds natively with Clang. This
     # is a heuristic emulation that may or may not work.
     env['EMMAKEN_JUST_CONFIGURE'] = '1'
-  if EM_BUILD_VERBOSE >= 2:
-    stdout = None
-  if EM_BUILD_VERBOSE >= 1:
-    stderr = None
   print('configure: ' + shared.shlex_join(args), file=sys.stderr)
-  check_call(args, stdout=stdout, stderr=stderr, env=env, **kwargs)
+  check_call(args, env=env)
 
 
-def make(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
-  if env is None:
-    env = get_building_env(cflags=cflags)
+def make(args):
+  env = get_building_env()
 
   # On Windows prefer building with mingw32-make instead of make, if it exists.
   if WINDOWS:
@@ -344,12 +336,8 @@ def make(args, stdout=None, stderr=None, env=None, cflags=[], **kwargs):
   # On Windows, run the execution through shell to get PATH expansion and
   # executable extension lookup, e.g. 'sdl2-config' will match with
   # 'sdl2-config.bat' in PATH.
-  if EM_BUILD_VERBOSE >= 2:
-    stdout = None
-  if EM_BUILD_VERBOSE >= 1:
-    stderr = None
   print('make: ' + ' '.join(args), file=sys.stderr)
-  check_call(args, stdout=stdout, stderr=stderr, env=env, shell=WINDOWS, **kwargs)
+  check_call(args, shell=WINDOWS, env=env)
 
 
 def make_paths_absolute(f):

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -6,7 +6,6 @@
 import os
 import shutil
 import logging
-from tools import building
 
 TAG = '1.7.5'
 HASH = 'c2c13fc97bb74f0f13092b07804f7087e948bce49793f48b62c2c24a5792523acc0002840bebf21829172bb2e7c3df9f9625250aec6c786a55489667dd04d6a0'
@@ -37,7 +36,8 @@ def get(ports, settings, shared):
     freetype_include = os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')
     freetype_include_dirs = freetype_include + ';' + os.path.join(freetype_include, 'config')
 
-    configure_args = [
+    cmake_cmd = [
+      shared.EMCMAKE,
       'cmake',
       '-B' + build_path,
       '-H' + source_path,
@@ -57,10 +57,10 @@ def get(ports, settings, shared):
       extra_cflags.append('-pthread')
 
     if len(extra_cflags):
-      configure_args += ['-DCMAKE_CXX_FLAGS="{}"'.format(' '.join(extra_cflags))]
-      configure_args += ['-DCMAKE_C_FLAGS="{}"'.format(' '.join(extra_cflags))]
+      cmake_cmd += ['-DCMAKE_CXX_FLAGS="{}"'.format(' '.join(extra_cflags))]
+      cmake_cmd += ['-DCMAKE_C_FLAGS="{}"'.format(' '.join(extra_cflags))]
 
-    building.configure(configure_args)
+    shared.run_process(cmake_cmd)
     shared.run_process(['cmake', '--build', build_path, '--target', 'install'])
 
     ports.install_header_dir(os.path.join(build_path, 'include', 'harfbuzz'))

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -870,6 +870,8 @@ EMCC = bat_suffix(path_from_root('emcc'))
 EMXX = bat_suffix(path_from_root('em++'))
 EMAR = bat_suffix(path_from_root('emar'))
 EMRANLIB = bat_suffix(path_from_root('emranlib'))
+EMCMAKE = bat_suffix(path_from_root('emcmake'))
+EMCONFIGURE = bat_suffix(path_from_root('emconfigure'))
 FILE_PACKAGER = bat_suffix(path_from_root('tools', 'file_packager'))
 
 apply_configuration()


### PR DESCRIPTION
We only have couple of places where we were using
`building.configure` and `building.cmake` internally.
Its cleaner and simpler to run the via a subprocess
especially in the test suite so we get actual black
box testing.

As a followup we may be able move some of these
functions into the `emmake.py` and `emconfigure.py`
scripts where it make more sense.