### PR TITLE
Add dylink test to show weakly defined function issue. NFC

### DIFF
--- a/tests/core/test_dylink_weak_main.c
+++ b/tests/core/test_dylink_weak_main.c
@@ -1,0 +1,13 @@
+#include <stdio.h>
+
+void side();
+
+__attribute__((weak)) int foo() {
+  return 42;
+}
+
+int main(int argc, char const *argv[]) {
+  printf("main foo() -> %d\n", foo());
+  side();
+  return 0;
+}

--- a/tests/core/test_dylink_weak_main.out
+++ b/tests/core/test_dylink_weak_main.out
@@ -1,0 +1,2 @@
+main foo() -> 42
+side foo() -> 42

--- a/tests/core/test_dylink_weak_side.c
+++ b/tests/core/test_dylink_weak_side.c
@@ -1,0 +1,11 @@
+#include <stdio.h>
+
+extern int foo();
+
+__attribute__((weak)) int foo() {
+  return 99;
+}
+
+void side() {
+  printf("side foo() -> %d\n", foo());
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4602,6 +4602,14 @@ res64 - external 64\n''', header='''
       expected='3 hello world!',
       need_reverse=False)
 
+  @disabled('https://github.com/emscripten-core/emscripten/issues/13773')
+  def test_dylink_weak(self):
+    # Verify that weakly symbols can be defined in both side module and main
+    # module
+    main = test_file('core', 'test_dylink_weak_main.c')
+    side = test_file('core', 'test_dylink_weak_side.c')
+    self.dylink_testf(main, side, force_c=True, need_reverse=False)
+
   def test_random(self):
     src = r'''#include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
Currently we don't support weakly defined functions that
exist in both the main and the side module.