### PR TITLE
Fix lack of JS function mapping for symbols file generation for WASM=0 and WASM=2 with --emit-symbol-map

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,7 +25,7 @@ Current Trunk
 - Fix generating of symbol files with `--emit-symbol-map` for ASM.js targets.
   When `-s WASM=2` is used. Two symbols are generated:
     - `[name].js.symbols` - storing WASM mapping
-    - `[name].wasm.js.symbols` - storing ASM.js mapping
+    - `[name].wasm.js.symbols` - storing JS mapping
   In other cases a single `[name].js.symbols` file is created.
 
 2.0.16: 03/25/2021

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,11 @@ Current Trunk
 -------------
 - Binaryen now always inlines single-use functions. This should reduce code size
   and improve performance (#13744).
+- Fix generating of symbol files with `--emit-symbol-map` for ASM.js targets.
+  When `-s WASM=2` is used. Two symbols are generated:
+    - `[name].js.symbols` - storing WASM mapping
+    - `[name].wasm.js.symbols` - storing ASM.js mapping
+  In other cases a single `[name].js.symbols` file is created.
 
 2.0.16: 03/25/2021
 ------------------
@@ -119,7 +124,7 @@ Current Trunk
 ------------------
 - `emscripten/vr.h` and other remnants of WebVR support removed. (#13210, which
   is a followup to #10460)
-- Stop overriding CMake default flags based on build type. This will 
+- Stop overriding CMake default flags based on build type. This will
   result in builds that are more like CMake does on other platforms. You
   may notice that `RelWithDebInfo` will now include debug info (it did not
   before, which appears to have been an error), and that `Release` will
@@ -308,7 +313,7 @@ Current Trunk
   is encountered. This makes the Emscripten program behave more like a native
   program where the OS would terminate the process and no further code can be
   executed when an unhandled exception (e.g. out-of-bounds memory access) happens.
-  Once the program aborts any exported function calls will fail with a "program 
+  Once the program aborts any exported function calls will fail with a "program
   has already aborted" exception to prevent calls into code with a potentially
   corrupted program state.
 - Use `__indirect_function_table` as the import name for the table, which is

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,9 +22,9 @@ Current Trunk
 -------------
 - Binaryen now always inlines single-use functions. This should reduce code size
   and improve performance (#13744).
-- Fix generating of symbol files with `--emit-symbol-map` for ASM.js targets.
+- Fix generating of symbol files with `--emit-symbol-map` for JS targets.
   When `-s WASM=2` is used. Two symbols are generated:
-    - `[name].js.symbols` - storing WASM mapping
+    - `[name].js.symbols` - storing Wasm mapping
     - `[name].wasm.js.symbols` - storing JS mapping
   In other cases a single `[name].js.symbols` file is created.
 

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -215,6 +215,12 @@ Options that are modified or new in *emcc* are listed below:
      happens in "-O2" and above, and when no "-g" option was specified
      to prevent minification.
 
+   Note:
+
+     When used with "-s WASM=2", two symbol files are created.
+     "[name].js.symbols" (with WASM symbols) and
+     "[name].wasm.js.symbols" (with ASM.js symbols)
+
 "-flto"
    [compile+link] Enables link-time optimizations (LTO).
 

--- a/emcc.py
+++ b/emcc.py
@@ -2949,7 +2949,7 @@ def do_binaryen(target, options, wasm_target):
     if shared.Settings.WASM == 2:
       wasm2js_template = wasm_target + '.js'
       open(wasm2js_template, 'w').write(preprocess_wasm2js_script())
-      # generate secondary file for asm.js symbols
+      # generate secondary file for JS symbols
       symbols_file_js = shared.replace_or_append_suffix(wasm2js_template, '.symbols') if options.emit_symbol_map else None
     else:
       wasm2js_template = final_js

--- a/emcc.py
+++ b/emcc.py
@@ -2949,8 +2949,11 @@ def do_binaryen(target, options, wasm_target):
     if shared.Settings.WASM == 2:
       wasm2js_template = wasm_target + '.js'
       open(wasm2js_template, 'w').write(preprocess_wasm2js_script())
+      # generate secondary file for asm.js symbols
+      symbols_file_js = shared.replace_or_append_suffix(wasm2js_template, '.symbols') if options.emit_symbol_map else None
     else:
       wasm2js_template = final_js
+      symbols_file_js = shared.replace_or_append_suffix(target, '.symbols') if options.emit_symbol_map else None
 
     wasm2js = building.wasm2js(wasm2js_template,
                                wasm_target,
@@ -2958,7 +2961,8 @@ def do_binaryen(target, options, wasm_target):
                                minify_whitespace=minify_whitespace(),
                                use_closure_compiler=options.use_closure_compiler,
                                debug_info=debug_info,
-                               symbols_file=symbols_file)
+                               symbols_file=symbols_file,
+                               symbols_file_js=symbols_file_js)
 
     shared.configuration.get_temp_files().note(wasm2js)
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -203,6 +203,8 @@ Options that are modified or new in *emcc* are listed below:
 
   .. note:: This is only relevant when :term:`minifying` global names, which happens in ``-O2`` and above, and when no ``-g`` option was specified to prevent minification.
 
+  .. note:: When used with ``-s WASM=2``, two symbol files are created. ``[name].js.symbols`` (with WASM symbols) and ``[name].wasm.js.symbols`` (with ASM.js symbols)
+
 .. _emcc-lto:
 
 ``-flto``

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3597,10 +3597,10 @@ EM_ASM({ _middle() });
         elif wasm == 1:
           self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'wasm', 'Primary symbols file should store WASM mappings')
         elif wasm == 2:
-          # special case when ASM and WASM targets are created
+          # special case when both JS and Wasm targets are created
           minified_middle_2 = get_minified_middle('a.out.wasm.js.symbols')
           self.assertNotEqual(minified_middle_2, None, "Missing minified 'middle' function")
-          self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'wasm', 'Primary symbols file should store WASM mappings')
+          self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'wasm', 'Primary symbols file should store Wasm mappings')
           self.assertEqual(guess_symbols_file_type('a.out.wasm.js.symbols'), 'js', 'Secondary symbols file should store JS mappings')
 
         # check we don't keep unnecessary debug info with wasm2js when emitting

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3523,6 +3523,30 @@ int main()
       self.assertContainedIf(warning, err, suffix in shared_suffixes)
 
   def test_symbol_map(self):
+    def get_symbols_lines(symbols_file):
+      self.assertTrue(os.path.isfile(symbols_file), "Symbols file %s isn't created" % symbols_file)
+      # check that the map is correct
+      with open(symbols_file) as f:
+        symbols = f.read()
+      lines = [line.split(':') for line in symbols.strip().split('\n')]
+      return lines
+
+    def get_minified_middle(symbols_file):
+      minified_middle = None
+      for minified, full in get_symbols_lines(symbols_file):
+        # handle both fastcomp and wasm backend notation
+        if full == 'middle':
+          minified_middle = minified
+          break
+      return minified_middle
+
+    def guess_symbols_file_type(symbols_file):
+      for minified, full in get_symbols_lines(symbols_file):
+        # define symbolication file by JS specific entries
+        if full in ['FUNCTION_TABLE', 'HEAP32']:
+          return 'js'
+      return 'wasm'
+
     UNMINIFIED_HEAP8 = 'var HEAP8 = new '
     UNMINIFIED_MIDDLE = 'function middle'
 
@@ -3553,17 +3577,9 @@ EM_ASM({ _middle() });
         cmd = [EMCC, 'src.c', '--emit-symbol-map'] + opts
         cmd += ['-s', 'WASM=%d' % wasm]
         self.run_process(cmd)
-        # check that the map is correct
-        with open('a.out.js.symbols') as f:
-          symbols = f.read()
-        lines = [line.split(':') for line in symbols.strip().split('\n')]
-        minified_middle = None
-        for minified, full in lines:
-          # handle both fastcomp and wasm backend notation
-          if full == '_middle' or full == 'middle':
-            minified_middle = minified
-            break
-        self.assertNotEqual(minified_middle, None)
+
+        minified_middle = get_minified_middle('a.out.js.symbols')
+        self.assertNotEqual(minified_middle, None, "Missing minified 'middle' function")
         if wasm:
           # stack traces are standardized enough that we can easily check that the
           # minified name is actually in the output
@@ -3574,6 +3590,19 @@ EM_ASM({ _middle() });
           wat = self.run_process([wasm_dis, 'a.out.wasm'], stdout=PIPE).stdout
           for func_start in ('(func $middle', '(func $_middle'):
             self.assertNotContained(func_start, wat)
+
+        # Ensure symbols file type according to `-s WASM=` mode
+        if wasm == 0:
+          self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'js', 'Primary symbols file should store JS mappings')
+        elif wasm == 1:
+          self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'wasm', 'Primary symbols file should store WASM mappings')
+        elif wasm == 2:
+          # special case when ASM and WASM targets are created
+          minified_middle_2 = get_minified_middle('a.out.wasm.js.symbols')
+          self.assertNotEqual(minified_middle_2, None, "Missing minified 'middle' function")
+          self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'wasm', 'Primary symbols file should store WASM mappings')
+          self.assertEqual(guess_symbols_file_type('a.out.wasm.js.symbols'), 'js', 'Secondary symbols file should store JS mappings')
+
         # check we don't keep unnecessary debug info with wasm2js when emitting
         # a symbol map
         if wasm == 0 and '-O' in str(opts):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3595,7 +3595,7 @@ EM_ASM({ _middle() });
         if wasm == 0:
           self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'js', 'Primary symbols file should store JS mappings')
         elif wasm == 1:
-          self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'wasm', 'Primary symbols file should store WASM mappings')
+          self.assertEqual(guess_symbols_file_type('a.out.js.symbols'), 'wasm', 'Primary symbols file should store Wasm mappings')
         elif wasm == 2:
           # special case when both JS and Wasm targets are created
           minified_middle_2 = get_minified_middle('a.out.wasm.js.symbols')

--- a/tools/building.py
+++ b/tools/building.py
@@ -1211,7 +1211,7 @@ def minify_wasm_imports_and_exports(js_file, wasm_file, minify_whitespace, minif
   return acorn_optimizer(js_file, passes, extra_info=json.dumps(extra_info))
 
 
-def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compiler, debug_info, symbols_file=None):
+def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compiler, debug_info, symbols_file=None, symbols_file_js=None):
   logger.debug('wasm2js')
   args = ['--emscripten']
   if opt_level > 0:
@@ -1230,6 +1230,8 @@ def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compil
     passes = []
     if not debug_info and not Settings.USE_PTHREADS:
       passes += ['minifyNames']
+      if symbols_file_js:
+        passes += ['symbolMap=%s' % symbols_file_js]
     if minify_whitespace:
       passes += ['minifyWhitespace']
     passes += ['last']


### PR DESCRIPTION
Current implementation either do not generate symbolication file for ASM.js flavors, or uses WASM symbols file. 
That can be easy verified with following commands: 
```sh
em++ main.cpp -o main.js -s WASM=0 -O2 --emit-symbol-map
#em++ main.cpp -o main.js -s WASM=1 -O2 --emit-symbol-map
#em++ main.cpp -o main.js -s WASM=2 -O2 --emit-symbol-map

ls -la | grep symbols
# .rw-r--r--@ 106k trzeci 27 Mar 23:42 main.js.symbols

cat main.js.symbols
# contains WASM mapping with format `digit:function_name`
```
Even for pure ASM.js builds we're getting WASM symbol file coming from: https://github.com/emscripten-core/emscripten/blob/2dcfec978c0e35e1252784eb9a8db53ff1fc7b90/tools/building.py#L1219-L1220

**Expected result** would be to have ASM.js mapping (with format `minified_name:full_name`) for ASM.js builds. 

The proposed change in current form will generate symbols file as follow:
* `For -s WASM=0`:
  * `[main].js.symbols` - with mapping for ASM.js code
* `For -s WASM=1`:
  * `[main].js.symbols` - with mappings for WASM code
* `For -s WASM=2`:
  * `[main].js.symbols` - with mappings for WASM code (backwards compatibility)
  * `[main].wasm.js.symbols` - with mapping sfor ASM.js code

In the current approach I wanted to preserve as much backwards compatibility as possible, so for any build that generates WASM artifact, the format of symbols file doesn't change. But I was considering whether an alternative solution would be useful more, where for `-s WASM=2` there is only `[main].js.symbols` generated, that contains both: WASM and ASM mappings. What do you think? 

Once the way to go is approved, I can update documentation and related tests. 


Thanks! 