### PR TITLE
Fix stringToNewUTF8() with null or empty string

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -41,13 +41,11 @@ LibraryManager.library = {
 
   $stringToNewUTF8__deps: ['malloc'],
   $stringToNewUTF8: function(jsString) {
-    if (jsString) {
-      var length = lengthBytesUTF8(jsString)+1;
-      var cString = _malloc(length);
-      stringToUTF8(jsString, cString, length);
-      return cString;
-    }
-    // Return implicit undefined to be coerced to a 0 pointer in WebAssembly side.
+    jsString = jsString || ''; // We always want to allocate a nonzero pointer.
+    var length = lengthBytesUTF8(jsString)+1;
+    var cString = _malloc(length);
+    stringToUTF8(jsString, cString, length);
+    return cString;
   },
 
   // ==========================================================================

--- a/src/library.js
+++ b/src/library.js
@@ -41,10 +41,13 @@ LibraryManager.library = {
 
   $stringToNewUTF8__deps: ['malloc'],
   $stringToNewUTF8: function(jsString) {
-    var length = lengthBytesUTF8(jsString)+1;
-    var cString = _malloc(length);
-    stringToUTF8(jsString, cString, length);
-    return cString;
+    if (jsString) {
+      var length = lengthBytesUTF8(jsString)+1;
+      var cString = _malloc(length);
+      stringToUTF8(jsString, cString, length);
+      return cString;
+    }
+    // Return implicit undefined to be coerced to a 0 pointer in WebAssembly side.
   },
 
   // ==========================================================================

--- a/src/library.js
+++ b/src/library.js
@@ -41,7 +41,6 @@ LibraryManager.library = {
 
   $stringToNewUTF8__deps: ['malloc'],
   $stringToNewUTF8: function(jsString) {
-    jsString = jsString || ''; // We always want to allocate a nonzero pointer.
     var length = lengthBytesUTF8(jsString)+1;
     var cString = _malloc(length);
     stringToUTF8(jsString, cString, length);

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1118,65 +1118,70 @@ var LibraryGL = {
   glGetString__sig: 'ii',
   glGetString__deps: ['$stringToNewUTF8'],
   glGetString: function(name_) {
-    if (GL.stringCache[name_]) return GL.stringCache[name_];
-    var ret;
-    switch (name_) {
-      case 0x1F03 /* GL_EXTENSIONS */:
-        var exts = GLctx.getSupportedExtensions() || []; // .getSupportedExtensions() can return null if context is lost, so coerce to empty array.
+    if (!GL.stringCache[name_]) {
+      var ret;
+      switch (name_) {
+        case 0x1F03 /* GL_EXTENSIONS */:
+          var exts = GLctx.getSupportedExtensions() || []; // .getSupportedExtensions() can return null if context is lost, so coerce to empty array.
 #if GL_EXTENSIONS_IN_PREFIXED_FORMAT
-        exts = exts.concat(exts.map(function(e) { return "GL_" + e; }));
+          exts = exts.concat(exts.map(function(e) { return "GL_" + e; }));
 #endif
-        ret = stringToNewUTF8(exts.join(' '));
-        break;
-      case 0x1F00 /* GL_VENDOR */:
-      case 0x1F01 /* GL_RENDERER */:
-      case 0x9245 /* UNMASKED_VENDOR_WEBGL */:
-      case 0x9246 /* UNMASKED_RENDERER_WEBGL */:
+          ret = stringToNewUTF8(exts.join(' '));
+          break;
+        case 0x1F00 /* GL_VENDOR */:
+        case 0x1F01 /* GL_RENDERER */:
+        case 0x9245 /* UNMASKED_VENDOR_WEBGL */:
+        case 0x9246 /* UNMASKED_RENDERER_WEBGL */:
 #if !GL_EMULATE_GLES_VERSION_STRING_FORMAT
-      case 0x1F02 /* GL_VERSION */:
-      case 0x8B8C /* GL_SHADING_LANGUAGE_VERSION */:
+        case 0x1F02 /* GL_VERSION */:
+        case 0x8B8C /* GL_SHADING_LANGUAGE_VERSION */:
 #endif
-        var s = GLctx.getParameter(name_);
-        if (!s) {
-          GL.recordError(0x500/*GL_INVALID_ENUM*/);
+          var s = GLctx.getParameter(name_);
+#if GL_TRACK_ERRORS
+          if (!s) {
+            GL.recordError(0x500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-          err('GL_INVALID_ENUM in glGetString: Received empty parameter for query name ' + name_ + '!'); // This occurs e.g. if one attempts GL_UNMASKED_VENDOR_WEBGL when it is not supported.
+            err('GL_INVALID_ENUM in glGetString: Received empty parameter for query name ' + name_ + '!'); // This occurs e.g. if one attempts GL_UNMASKED_VENDOR_WEBGL when it is not supported.
 #endif
-        }
-        ret = stringToNewUTF8(s);
-        break;
+          }
+#endif
+          ret = stringToNewUTF8(s);
+          break;
 
 #if GL_EMULATE_GLES_VERSION_STRING_FORMAT
-      case 0x1F02 /* GL_VERSION */:
-        var glVersion = GLctx.getParameter(0x1F02 /*GL_VERSION*/);
-        // return GLES version string corresponding to the version of the WebGL context
+        case 0x1F02 /* GL_VERSION */:
+          var glVersion = GLctx.getParameter(0x1F02 /*GL_VERSION*/);
+          // return GLES version string corresponding to the version of the WebGL context
 #if MAX_WEBGL_VERSION >= 2
-        if ({{{ isCurrentContextWebGL2() }}}) glVersion = 'OpenGL ES 3.0 (' + glVersion + ')';
-        else
+          if ({{{ isCurrentContextWebGL2() }}}) glVersion = 'OpenGL ES 3.0 (' + glVersion + ')';
+          else
 #endif
-        {
-          glVersion = 'OpenGL ES 2.0 (' + glVersion + ')';
-        }
-        ret = stringToNewUTF8(glVersion);
-        break;
-      case 0x8B8C /* GL_SHADING_LANGUAGE_VERSION */:
-        var glslVersion = GLctx.getParameter(0x8B8C /*GL_SHADING_LANGUAGE_VERSION*/);
-        // extract the version number 'N.M' from the string 'WebGL GLSL ES N.M ...'
-        var ver_re = /^WebGL GLSL ES ([0-9]\.[0-9][0-9]?)(?:$| .*)/;
-        var ver_num = glslVersion.match(ver_re);
-        if (ver_num !== null) {
-          if (ver_num[1].length == 3) ver_num[1] = ver_num[1] + '0'; // ensure minor version has 2 digits
-          glslVersion = 'OpenGL ES GLSL ES ' + ver_num[1] + ' (' + glslVersion + ')';
-        }
-        ret = stringToNewUTF8(glslVersion);
-        break;
+          {
+            glVersion = 'OpenGL ES 2.0 (' + glVersion + ')';
+          }
+          ret = stringToNewUTF8(glVersion);
+          break;
+        case 0x8B8C /* GL_SHADING_LANGUAGE_VERSION */:
+          var glslVersion = GLctx.getParameter(0x8B8C /*GL_SHADING_LANGUAGE_VERSION*/);
+          // extract the version number 'N.M' from the string 'WebGL GLSL ES N.M ...'
+          var ver_re = /^WebGL GLSL ES ([0-9]\.[0-9][0-9]?)(?:$| .*)/;
+          var ver_num = glslVersion.match(ver_re);
+          if (ver_num !== null) {
+            if (ver_num[1].length == 3) ver_num[1] = ver_num[1] + '0'; // ensure minor version has 2 digits
+            glslVersion = 'OpenGL ES GLSL ES ' + ver_num[1] + ' (' + glslVersion + ')';
+          }
+          ret = stringToNewUTF8(glslVersion);
+          break;
 #endif
-      default:
-        GL.recordError(0x500/*GL_INVALID_ENUM*/);
+#if GL_TRACK_ERRORS
+        default:
+          GL.recordError(0x500/*GL_INVALID_ENUM*/);
 #if GL_ASSERTIONS
-        err('GL_INVALID_ENUM in glGetString: Unknown parameter ' + name_ + '!');
+          err('GL_INVALID_ENUM in glGetString: Unknown parameter ' + name_ + '!');
 #endif
-        return 0;
+#endif
+          // fall through
+      }
     }
     GL.stringCache[name_] = ret;
     return ret;

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1118,8 +1118,8 @@ var LibraryGL = {
   glGetString__sig: 'ii',
   glGetString__deps: ['$stringToNewUTF8'],
   glGetString: function(name_) {
-    if (!GL.stringCache[name_]) {
-      var ret;
+    var ret = GL.stringCache[name_];
+    if (!ret) {
       switch (name_) {
         case 0x1F03 /* GL_EXTENSIONS */:
           var exts = GLctx.getSupportedExtensions() || []; // .getSupportedExtensions() can return null if context is lost, so coerce to empty array.
@@ -1182,8 +1182,8 @@ var LibraryGL = {
 #endif
           // fall through
       }
+      GL.stringCache[name_] = ret;
     }
-    GL.stringCache[name_] = ret;
     return ret;
   },
 

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1145,7 +1145,7 @@ var LibraryGL = {
 #endif
           }
 #endif
-          ret = stringToNewUTF8(s);
+          ret = s && stringToNewUTF8(s);
           break;
 
 #if GL_EMULATE_GLES_VERSION_STRING_FORMAT

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2582,6 +2582,10 @@ Module["preRun"].push(function () {
       print(opts)
       self.btest(test_file('webgl_shader_source_length.cpp'), args=opts + ['-lGL'], expected='0')
 
+  # Tests calling glGetString(GL_UNMASKED_VENDOR_WEBGL).
+  def test_webgl_unmasked_vendor_webgl(self):
+    self.btest(test_file('webgl_unmasked_vendor_webgl.c'), args=['-lGL'], expected='0')
+
   def test_webgl2(self):
     for opts in [
       ['-s', 'MIN_CHROME_VERSION=0'],

--- a/tests/webgl_create_context.cpp
+++ b/tests/webgl_create_context.cpp
@@ -119,6 +119,7 @@ int main()
     for(size_t i = 0; i < exts.size(); ++i)
     {
       EM_BOOL supported = emscripten_webgl_enable_extension(context, exts[i].c_str());
+      printf("%s\n", exts[i].c_str());
       assert(supported);
     }
 

--- a/tests/webgl_unmasked_vendor_webgl.c
+++ b/tests/webgl_unmasked_vendor_webgl.c
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <string.h>
+#include <emscripten/html5.h>
+#include <GLES2/gl2.h>
+#include <webgl/webgl1_ext.h>
+#include <assert.h>
+
+int main()
+{
+  EmscriptenWebGLContextAttributes attr;
+  emscripten_webgl_init_context_attributes(&attr);
+  attr.enableExtensionsByDefault = 0;
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
+  emscripten_webgl_make_context_current(ctx);
+
+  assert(!glGetError());
+
+  // This should gracefully return null and record a GL error.
+  const char *str = (const char *)glGetString(GL_UNMASKED_VENDOR_WEBGL);
+  printf("%s\n", str);
+  assert(glGetError());
+  assert(!glGetError()); // One error is enough
+
+  EM_BOOL success = emscripten_webgl_enable_extension(ctx, "WEBGL_debug_renderer_info");
+  if (!success)
+  {
+  	// Browser does not have WEBGL_debug_renderer_info, skip remainder and return success.
+#ifdef REPORT_RESULT
+  	REPORT_RESULT(0);
+#endif
+  	return 0;
+  }
+
+  assert(!glGetError());
+
+  str = (const char *)glGetString(GL_UNMASKED_VENDOR_WEBGL);
+  printf("%s\n", str);
+  assert(strlen(str) > 3); // Should get something (dependent on hardware)
+  assert(!glGetError());
+
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+}


### PR DESCRIPTION
Fix calling stringToNewUTF8() with a null or empty input parameter. Optimize code size of glGetString(). Fixes #10494.