### PR TITLE
Fix broken "Releases" Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 VERSION = $(shell cat emscripten-version.txt | sed s/\"//g)
-DESTDIR ?= ../emscripten-$(VERSION)
+TMPDESTDIR := $(shell mktemp -d)
+DESTDIR ?= $(TMPDESTDIR)/emscripten-$(VERSION)
 DISTFILE = emscripten-$(VERSION).tar.bz2
 
 dist: $(DISTFILE)

--- a/tools/install.py
+++ b/tools/install.py
@@ -37,6 +37,9 @@ logger = logging.getLogger('install')
 
 
 def add_revision_file(target):
+  if not os.path.exists('.git'):
+    print('skipping generate emscripten-revision.txt as .git directory does not exist')
+    return
   # text=True would be better than encoding here, but it's only supported in 3.7+
   git_hash = subprocess.check_output(['git', 'rev-parse', 'HEAD'], encoding='utf-8').strip()
   with open(os.path.join(target, 'emscripten-revision.txt'), 'w') as f:


### PR DESCRIPTION
It's safe to assume all the Makefiles in https://github.com/emscripten-core/emscripten/releases are broken
You can test this by downloading the tarball or zip from there, extract it, cd into it and run make.

I found these problems when trying to package `emscripten` for Termux / Android. See https://github.com/termux/termux-packages/issues/5043. Should be done prototyping soon...