### PR TITLE
Fix windows-only typo in emmake.py

### DIFF
--- a/emmake.py
+++ b/emmake.py
@@ -48,7 +48,7 @@ variables so that emcc etc. are used. Typical usage:
   # On Windows prefer building with mingw32-make instead of make, if it exists.
   if utils.WINDOWS:
     if args[0] == 'make':
-      mingw32_make = building.which('mingw32-make')
+      mingw32_make = utils.which('mingw32-make')
       if mingw32_make:
         args[0] = mingw32_make
 


### PR DESCRIPTION
This was a mistake that we introduced in #13772.

Fixes https://github.com/emscripten-core/emsdk/issues/780