### PR TITLE
Fix benchmarks

### DIFF
--- a/tests/matrix_multiply.cpp
+++ b/tests/matrix_multiply.cpp
@@ -79,7 +79,6 @@ void Tick()
   if (++NumFramesDone >= NumFrames)
   {
     Done();
-    exit(0);
   }
 }
 
@@ -125,4 +124,10 @@ int main(int argc, char **argv)
     for(int i = 0; i < NumFrames; ++i)
       Tick();
   }
+  if (NumFramesDone != NumFrames) {
+    puts("Invalid number of frames");
+    abort();
+  }
+
+  return 0;
 }

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -210,7 +210,7 @@ class EmscriptenBenchmarker(Benchmarker):
       '-s', 'BENCHMARK=%d' % (1 if IGNORE_COMPILATION and not has_output_parser else 0),
       '-o', final
     ] + shared_args + emcc_args + LLVM_FEATURE_FLAGS + self.extra_args
-    if 'FORCE_FILESYSTEM=1' in cmd:
+    if 'FORCE_FILESYSTEM' in cmd:
       cmd = [arg if arg != 'FILESYSTEM=0' else 'FILESYSTEM=1' for arg in cmd]
     if PROFILING:
       cmd += ['--profiling-funcs']

--- a/tests/third_party/box2d/Makefile
+++ b/tests/third_party/box2d/Makefile
@@ -51,7 +51,7 @@ OBJECTS = \
 all: box2d.a
 
 %.o: %.cpp
-	$(CXX) $(CFLAGS) -I. $< -o $@ -O2 -c -fno-exceptions -fno-rtti
+	$(CXX) $(CFLAGS) -I. $< -o $@ -O2 -c -fno-exceptions -fno-rtti -Wno-null-conversion
 
 box2d.a: $(OBJECTS)
 	$(AR) rvs $@ $(OBJECTS)


### PR DESCRIPTION
1. Matrix multiply warns on `exit(0)` in node about a promise rejection. Avoid
  that cluttering the output.
2. Fix parsing of `-sX=Y` in the benchmark suite, which regressed when we
  changed things in #13156
3. Avoid a new clang warning in Box2D. Replaces https://github.com/emscripten-core/emscripten/pull/13457