### PR TITLE
Fix strtol result when no chars are consumed.

### DIFF
--- a/system/lib/libc/musl/src/stdlib/strtol.c
+++ b/system/lib/libc/musl/src/stdlib/strtol.c
@@ -18,6 +18,7 @@
 static unsigned long long strtox(const char *s, char **p, int base, unsigned long long lim) {
 	int neg=0;
 	unsigned long long y=0;
+	const char* orig = s;
 
 	if (base > 36) {
 		errno = EINVAL;
@@ -32,8 +33,11 @@ static unsigned long long strtox(const char *s, char **p, int base, unsigned lon
 		s++;
 	}
 
+	int found_digit = 0;
+
 	// Handle hex/octal prefix 0x/00
 	if ((base == 0 || base == 16) && *s=='0') {
+		found_digit = 1;
 		s++;
 		if ((*s|32)=='x') {
 			s++;
@@ -57,9 +61,16 @@ static unsigned long long strtox(const char *s, char **p, int base, unsigned lon
 			overflow = 1;
 			continue;
 		}
+		found_digit = 1;
 		y = y*base + val;
 	}
-	if (p) *p = (char*)s;
+	if (p) {
+		if (found_digit) {
+			*p = (char*)s;
+		} else {
+			*p = (char*)orig;
+		}
+	}
 	if (overflow) {
 		// We exit'd the above loop due to overflow
 		errno = ERANGE;

--- a/tests/core/test_strtol.c
+++ b/tests/core/test_strtol.c
@@ -77,6 +77,8 @@ int main() {
   check("hello", 30);
   check("hello", 10);
   check("not-a-number", 0);
+  check(" ", 0);
+  check("-", 0);
   check("  0x12end", 0);
 
   return 0;

--- a/tests/core/test_strtol.out
+++ b/tests/core/test_strtol.out
@@ -217,5 +217,9 @@ strtol("hello", 0, 10) = 0
 consumed 0 bytes
 strtol("not-a-number", 0, 0) = 0
 consumed 0 bytes
+strtol(" ", 0, 0) = 0
+consumed 0 bytes
+strtol("-", 0, 0) = 0
+consumed 0 bytes
 strtol("  0x12end", 0, 0) = 302
 consumed 7 bytes


### PR DESCRIPTION
Followup to #13523.  When no digits are processed endptr should be set
to the original start of the string.

Fixes: #13803