### PR TITLE
Add a test for EM_PYTHON_MULTIPROCESSING

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,9 +24,10 @@ Current Trunk
   things about how LLVM optimizes and inlines, so it may cause noticeable
   changes in compile times, code size, and speed, either for better or for
   worse. (#13427)
-- Removed use of Python multiprocessing library because of stability issues. Added
-  new environment variable EM_PYTHON_MULTIPROCESSING=1 that can be enabled
-  to revert back to using Python multiprocessing. (#13493)
+- Removed use of Python multiprocessing library because of stability issues.
+  Added a new environment variable `EM_PYTHON_MULTIPROCESSING=1` that can be set
+  to revert back to using Python multiprocessing, in case there are reports of
+  regressions (that variable is intended to be temporary). (#13493)
 - Binaryen now always inlines single-use functions. This should reduce code size
   and improve performance (#13744).
 - Fix generating of symbol files with `--emit-symbol-map` for JS targets.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2274,9 +2274,9 @@ int f() {
         return 0;
       }
     ''')
+    cmd = [EMCC, '-s', 'ASSERTIONS', 'conftest.c', '-o', 'conftest']
     with env_modify({'EMMAKEN_JUST_CONFIGURE': '1'}):
-      cmd = [EMCC, '-s', 'ASSERTIONS', 'conftest.c', '-o', 'conftest']
-    output = self.run_process(cmd, stderr=PIPE)
+      output = self.run_process(cmd, stderr=PIPE)
     self.assertNotContained('emcc: warning: treating -s as linker option', output.stderr)
     self.assertExists('conftest')
 
@@ -10256,3 +10256,9 @@ exec "$@"
     self.assertExists('hello.wasm')
     self.assertExists('hello_.wasm')
     self.assertContained('hello, world!', self.run_js('hello.wasm'))
+
+  def test_EM_PYTHON_MULTIPROCESSING(self):
+    with env_modify({'EM_PYTHON_MULTIPROCESSING': '1'}):
+      # wasm2js optimizations use multiprocessing to run multiple node
+      # invocations
+      self.run_process([EMCC, test_file('hello_world.c'), '-sWASM=0', '-O2'])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2274,9 +2274,10 @@ int f() {
         return 0;
       }
     ''')
+    # the name "conftest.c" is enough to make us use a configure-like mode,
+    # the same as if EMMAKEN_JUST_CONFIGURE=1 were set in the env.
     cmd = [EMCC, '-s', 'ASSERTIONS', 'conftest.c', '-o', 'conftest']
-    with env_modify({'EMMAKEN_JUST_CONFIGURE': '1'}):
-      output = self.run_process(cmd, stderr=PIPE)
+    output = self.run_process(cmd, stderr=PIPE)
     self.assertNotContained('emcc: warning: treating -s as linker option', output.stderr)
     self.assertExists('conftest')
 


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/pull/13493

Also contains a drive-by fix for a test that used `env_modify` incorrectly.