### PR TITLE
Simplify library search process

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,8 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
-- Refactoring of the library search algorithm means that emscripten no longer
-  supports some (unintented) methods of library lookup:
+- In order to behave more like clang and gcc, emscripten no longer
+  supports some nonstandard methods of library lookup (that worked
+  unintentionally and were untested and not documented):
     1. Linking with `-llibc` rather than `-lc` will no longer work.
     2. Linking a library called `foo.a` via `-lfoo` will no longer work.
        (libraries found via `-l` have to start with `lib`)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- Refactoring of the library search algorithm means that emscripten no longer
+  supports some (unintented) methods of library lookup:
+    1. Linking with `-llibc` rather than `-lc` will no longer work.
+    2. Linking a library called `foo.a` via `-lfoo` will no longer work.
+       (libraries found via `-l` have to start with `lib`)
 - Use LLVM's new pass manager by default, as LLVM does. This changes a bunch of
   things about how LLVM optimizes and inlines, so it may cause noticeable
   changes in compile times, code size, and speed, either for better or for

--- a/emcc.py
+++ b/emcc.py
@@ -3287,25 +3287,21 @@ def process_libraries(libs, lib_dirs, temp_files):
   libraries = []
   consumed = []
   suffixes = STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS
-  prefixes = ('', 'lib')
 
   # Find library files
   for i, lib in libs:
     logger.debug('looking for library "%s"', lib)
 
     found = False
-    for prefix in prefixes:
-      for suff in suffixes:
-        name = prefix + lib + suff
-        for lib_dir in lib_dirs:
-          path = os.path.join(lib_dir, name)
-          if os.path.exists(path):
-            logger.debug('found library "%s" at %s', lib, path)
-            temp_files.append((i, path))
-            consumed.append(i)
-            found = True
-            break
-        if found:
+    for suff in suffixes:
+      name = 'lib' + lib + suff
+      for lib_dir in lib_dirs:
+        path = os.path.join(lib_dir, name)
+        if os.path.exists(path):
+          logger.debug('found library "%s" at %s', lib, path)
+          temp_files.append((i, path))
+          consumed.append(i)
+          found = True
           break
       if found:
         break


### PR DESCRIPTION
When searching for libraries we were looking for both the `lib`
prefixed version and the non-`lib`-prefixed name.

While refactoring code in #13799 I noticed that we really don't need
to be handling both these cases.  We can assume that file on disc will
always have the lib prefix and the library names being processed here
will never have it.

This does remove some undocumented/untested (and I would have better
not supported) uses.

1. Linking with `-llibc` rather than `-lc` will no longer work.
2. Linking a library called `foo.a` (without a `lib` prefix) via `-lfoo`
   will no longer work.

Neither of these use cases is supported by gcc or clang and I don't
think it was ever intentional that we supported these.