### PR TITLE
[not for commit] Fetch: Calling runtimeKeepalivePop before user callbacks causes undesired runtime exit with sync fetch 

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -451,6 +451,7 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
 #endif
   var fetchAttrAppend = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_APPEND') }}});
   var fetchAttrReplace = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_REPLACE') }}});
+  var fetchAttrSynchronous = !!(fetchAttributes & {{{ cDefine('EMSCRIPTEN_FETCH_SYNCHRONOUS') }}});
 
   var reportSuccess = function(fetch, xhr, e) {
 #if FETCH_DEBUG
@@ -460,14 +461,14 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
     callUserCallback(function() {
       if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
       else if (successcb) successcb(fetch);
-    });
+    }, fetchAttrSynchronous);
   };
 
   var reportProgress = function(fetch, xhr, e) {
     callUserCallback(function() {
       if (onprogress) {{{ makeDynCall('vi', 'onprogress') }}}(fetch);
       else if (progresscb) progresscb(fetch);
-    });
+    }, fetchAttrSynchronous);
   };
 
   var reportError = function(fetch, xhr, e) {
@@ -478,7 +479,7 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
     callUserCallback(function() {
       if (onerror) {{{ makeDynCall('vi', 'onerror') }}}(fetch);
       else if (errorcb) errorcb(fetch);
-    });
+    }, fetchAttrSynchronous);
   };
 
   var reportReadyStateChange = function(fetch, xhr, e) {
@@ -488,7 +489,7 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
     callUserCallback(function() {
       if (onreadystatechange) {{{ makeDynCall('vi', 'onreadystatechange') }}}(fetch);
       else if (readystatechangecb) readystatechangecb(fetch);
-    });
+    }, fetchAttrSynchronous);
   };
 
   var performUncachedXhr = function(fetch, xhr, e) {
@@ -511,7 +512,7 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
       callUserCallback(function() {
         if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
         else if (successcb) successcb(fetch);
-      });
+      }, fetchAttrSynchronous);
     };
     var storeError = function(fetch, xhr, e) {
 #if FETCH_DEBUG
@@ -521,7 +522,7 @@ function startFetch(fetch, successcb, errorcb, progresscb, readystatechangecb) {
       callUserCallback(function() {
         if (onsuccess) {{{ makeDynCall('vi', 'onsuccess') }}}(fetch);
         else if (successcb) successcb(fetch);
-      });
+      }, fetchAttrSynchronous);
     };
     fetchCacheData(Fetch.dbInstance, fetch, xhr.response, storeSuccess, storeError);
   };

--- a/src/library.js
+++ b/src/library.js
@@ -3607,13 +3607,14 @@ LibraryManager.library = {
 #if EXIT_RUNTIME || USE_PTHREADS
   $callUserCallback__deps: ['$maybeExit'],
 #endif
-  $callUserCallback: function(func, synchronous = false) {
+  $callUserCallback: function(func, synchronous) {
     if (ABORT) {
 #if ASSERTIONS
       err('user callback triggered after application aborted.  Ignoring.');
       return;
 #endif
     }
+    synchronous = synchronous || false;
     // For synchronous calls, let any exceptions propagate, and don't let the runtime exit.
     if (synchronous) {
       func();

--- a/src/library.js
+++ b/src/library.js
@@ -3607,12 +3607,17 @@ LibraryManager.library = {
 #if EXIT_RUNTIME || USE_PTHREADS
   $callUserCallback__deps: ['$maybeExit'],
 #endif
-  $callUserCallback: function(func) {
+  $callUserCallback: function(func, synchronous = false) {
     if (ABORT) {
 #if ASSERTIONS
       err('user callback triggered after application aborted.  Ignoring.');
       return;
 #endif
+    }
+    // For synchronous calls, let any exceptions propagate, and don't let the runtime exit.
+    if (synchronous) {
+      func();
+      return;
     }
     try {
       func();

--- a/tests/fetch/sync_xhr.cpp
+++ b/tests/fetch/sync_xhr.cpp
@@ -7,12 +7,19 @@
 #include <stdio.h>
 #include <math.h>
 #include <assert.h>
+#include <emscripten.h>
 #include <emscripten/fetch.h>
 
 int result = -1;
 
 int main()
 {
+  // If an exception is thrown from the user callback, it bubbles up to self.onerror but is otherwise completely
+  // swallowed by xhr.send.
+  EM_ASM({self.onerror = function() {
+           console.log('Got error');
+           HEAP32[$0 >> 2] = 2;
+         };}, &result);
   emscripten_fetch_attr_t attr;
   emscripten_fetch_attr_init(&attr);
   strcpy(attr.requestMethod, "GET");

--- a/tests/fetch/sync_xhr.cpp
+++ b/tests/fetch/sync_xhr.cpp
@@ -48,5 +48,11 @@ int main()
   if (result == -1) {
     printf("emscripten_fetch() failed to run synchronously!\n");
   }
+  #ifndef __EMSCRIPTEN_PTHREADS__
+  // For proxy-to-worker mode (the only case where we can do sync xhr in main())
+  // Just use REPORT_RESULT
+  REPORT_RESULT(result);
+  #endif
+  // Otherwise test that the exit status gets returned correctly.
   return result;
 }

--- a/tests/fetch/sync_xhr.cpp
+++ b/tests/fetch/sync_xhr.cpp
@@ -9,7 +9,7 @@
 #include <assert.h>
 #include <emscripten/fetch.h>
 
-int result = 0;
+int result = -1;
 
 int main()
 {
@@ -28,11 +28,7 @@ int main()
     assert(checksum == 0x08);
     emscripten_fetch_close(fetch);
 
-    if (result == 0) result = 1;
-#ifdef REPORT_RESULT
-    // Fetch API appears to sometimes call the handlers more than once, see https://github.com/emscripten-core/emscripten/pull/8191
-    MAYBE_REPORT_RESULT(result);
-#endif
+    if (result == -1) result = 0;
   };
 
   attr.onprogress = [](emscripten_fetch_t *fetch) {
@@ -49,12 +45,8 @@ int main()
   };
 
   emscripten_fetch_t *fetch = emscripten_fetch(&attr, "gears.png");
-  if (result == 0) {
-    result = 2;
+  if (result == -1) {
     printf("emscripten_fetch() failed to run synchronously!\n");
   }
-#ifdef REPORT_RESULT
-  // Fetch API appears to sometimes call the handlers more than once, see https://github.com/emscripten-core/emscripten/pull/8191
-  MAYBE_REPORT_RESULT(result);
-#endif
+  return result;
 }

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -443,7 +443,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     if EMTEST_SAVE_DIR:
       self.working_dir = os.path.join(self.temp_dir, 'emscripten_test')
-      print('working_dir ' + self.working_dir)
       if os.path.exists(self.working_dir):
         if EMTEST_SAVE_DIR == 2:
           print('Not clearing existing test directory')

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -443,6 +443,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     if EMTEST_SAVE_DIR:
       self.working_dir = os.path.join(self.temp_dir, 'emscripten_test')
+      print('working_dir ' + self.working_dir)
       if os.path.exists(self.working_dir):
         if EMTEST_SAVE_DIR == 2:
           print('Not clearing existing test directory')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4489,7 +4489,7 @@ window.close = function() {
     shutil.copyfile(test_file('gears.png'), 'gears.png')
     self.btest_exit('fetch/sync_xhr.cpp', args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
 
-  # Tests emscripten_fetch() usage when user passes none of trhe main 3 flags (append/replace/no_download).
+  # Tests emscripten_fetch() usage when user passes none of the main 3 flags (append/replace/no_download).
   # In that case, in append is implicitly understood.
   @requires_threads
   def test_fetch_implicit_append(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4487,9 +4487,9 @@ window.close = function() {
   @requires_threads
   def test_fetch_sync_xhr(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
-    self.btest('fetch/sync_xhr.cpp', expected='1', args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/sync_xhr.cpp', args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
 
-  # Tests emscripten_fetch() usage when user passes none of the main 3 flags (append/replace/no_download).
+  # Tests emscripten_fetch() usage when user passes none of trhe main 3 flags (append/replace/no_download).
   # In that case, in append is implicitly understood.
   @requires_threads
   def test_fetch_implicit_append(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4506,8 +4506,7 @@ window.close = function() {
   @requires_threads
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
-    self.btest('fetch/sync_xhr.cpp',
-               expected='1',
+    self.btest_exit('fetch/sync_xhr.cpp',
                args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
                also_asmjs=True)
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4507,8 +4507,8 @@ window.close = function() {
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
     self.btest_exit('fetch/sync_xhr.cpp',
-               args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
-               also_asmjs=True)
+                    args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
+                    also_asmjs=True)
 
   # Tests waiting on EMSCRIPTEN_FETCH_WAITABLE request from a worker thread
   @no_wasm_backend("emscripten_fetch_wait uses an asm.js based web worker")

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4506,9 +4506,10 @@ window.close = function() {
   @requires_threads
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
-    self.btest_exit('fetch/sync_xhr.cpp',
-                    args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
-                    also_asmjs=True)
+    self.btest('fetch/sync_xhr.cpp',
+               expected='0',
+               args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
+               also_asmjs=True)
 
   # Tests waiting on EMSCRIPTEN_FETCH_WAITABLE request from a worker thread
   @no_wasm_backend("emscripten_fetch_wait uses an asm.js based web worker")


### PR DESCRIPTION
We got a report that when using synchronous fetch on a thread, the code after `emscripten_fetch()` returns wasn't being run (the thread was instead exiting after the user callback was called). I think what is happening is that we are decrementing the keepalive count in `runtimeKeepalivePop` (which reduces the count to 0) and then `calluserCallback` calls `maybeExit()` after the user callback returns, and exits the thread immediately rather than returning to the caller of emscripten_fetch().
That seems like the desired behavior in the async case (where the XHR callback is coming from the event loop and no user code is on the stack), but not right for the sync case where the user code is on the stack (you could perhaps think of that as being a reference that should keep the runtime alive).

But I checked and we have a test for this case (fetch/sync_xhr.cpp) and it's not failing for me locally or on the bots. Also I realized that we always want to return from `emscripten_fetch()` and `startFetch` even has a keepalivePush at the top which should be preventing. so maybe something else is going on there. 

Anyway I experimented with the change in this PR, but I don't think it's quite right.