### PR TITLE
Use btest_exit with test_fetch_sync_xhr

### DIFF
--- a/tests/fetch/sync_xhr.cpp
+++ b/tests/fetch/sync_xhr.cpp
@@ -48,5 +48,11 @@ int main()
   if (result == -1) {
     printf("emscripten_fetch() failed to run synchronously!\n");
   }
+  #ifndef __EMSCRIPTEN_PTHREADS__
+  // For proxy-to-worker mode (the only case where we can do sync xhr in main())
+  // Just use REPORT_RESULT
+  REPORT_RESULT(result);
+  #endif
+  // Otherwise test that the exit status gets returned correctly.
   return result;
 }

--- a/tests/fetch/sync_xhr.cpp
+++ b/tests/fetch/sync_xhr.cpp
@@ -9,7 +9,7 @@
 #include <assert.h>
 #include <emscripten/fetch.h>
 
-int result = 0;
+int result = -1;
 
 int main()
 {
@@ -28,11 +28,7 @@ int main()
     assert(checksum == 0x08);
     emscripten_fetch_close(fetch);
 
-    if (result == 0) result = 1;
-#ifdef REPORT_RESULT
-    // Fetch API appears to sometimes call the handlers more than once, see https://github.com/emscripten-core/emscripten/pull/8191
-    MAYBE_REPORT_RESULT(result);
-#endif
+    if (result == -1) result = 0;
   };
 
   attr.onprogress = [](emscripten_fetch_t *fetch) {
@@ -49,12 +45,8 @@ int main()
   };
 
   emscripten_fetch_t *fetch = emscripten_fetch(&attr, "gears.png");
-  if (result == 0) {
-    result = 2;
+  if (result == -1) {
     printf("emscripten_fetch() failed to run synchronously!\n");
   }
-#ifdef REPORT_RESULT
-  // Fetch API appears to sometimes call the handlers more than once, see https://github.com/emscripten-core/emscripten/pull/8191
-  MAYBE_REPORT_RESULT(result);
-#endif
+  return result;
 }

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -443,7 +443,6 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     if EMTEST_SAVE_DIR:
       self.working_dir = os.path.join(self.temp_dir, 'emscripten_test')
-      print('working_dir ' + self.working_dir)
       if os.path.exists(self.working_dir):
         if EMTEST_SAVE_DIR == 2:
           print('Not clearing existing test directory')

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -443,6 +443,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
     if EMTEST_SAVE_DIR:
       self.working_dir = os.path.join(self.temp_dir, 'emscripten_test')
+      print('working_dir ' + self.working_dir)
       if os.path.exists(self.working_dir):
         if EMTEST_SAVE_DIR == 2:
           print('Not clearing existing test directory')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4465,7 +4465,7 @@ window.close = function() {
     shutil.copyfile(test_file('gears.png'), 'gears.png')
     self.btest_exit('fetch/sync_xhr.cpp', args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
 
-  # Tests emscripten_fetch() usage when user passes none of trhe main 3 flags (append/replace/no_download).
+  # Tests emscripten_fetch() usage when user passes none of the main 3 flags (append/replace/no_download).
   # In that case, in append is implicitly understood.
   @requires_threads
   def test_fetch_implicit_append(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4482,8 +4482,7 @@ window.close = function() {
   @requires_threads
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
-    self.btest('fetch/sync_xhr.cpp',
-               expected='1',
+    self.btest_exit('fetch/sync_xhr.cpp',
                args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
                also_asmjs=True)
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4463,9 +4463,9 @@ window.close = function() {
   @requires_threads
   def test_fetch_sync_xhr(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
-    self.btest('fetch/sync_xhr.cpp', expected='1', args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+    self.btest_exit('fetch/sync_xhr.cpp', args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
 
-  # Tests emscripten_fetch() usage when user passes none of the main 3 flags (append/replace/no_download).
+  # Tests emscripten_fetch() usage when user passes none of trhe main 3 flags (append/replace/no_download).
   # In that case, in append is implicitly understood.
   @requires_threads
   def test_fetch_implicit_append(self):

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4483,8 +4483,8 @@ window.close = function() {
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
     self.btest_exit('fetch/sync_xhr.cpp',
-               args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
-               also_asmjs=True)
+                    args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
+                    also_asmjs=True)
 
   # Tests waiting on EMSCRIPTEN_FETCH_WAITABLE request from a worker thread
   @no_wasm_backend("emscripten_fetch_wait uses an asm.js based web worker")

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4482,9 +4482,10 @@ window.close = function() {
   @requires_threads
   def test_fetch_sync_xhr_in_proxy_to_worker(self):
     shutil.copyfile(test_file('gears.png'), 'gears.png')
-    self.btest_exit('fetch/sync_xhr.cpp',
-                    args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
-                    also_asmjs=True)
+    self.btest('fetch/sync_xhr.cpp',
+               expected='0',
+               args=['-s', 'FETCH_DEBUG', '-s', 'FETCH', '--proxy-to-worker'],
+               also_asmjs=True)
 
   # Tests waiting on EMSCRIPTEN_FETCH_WAITABLE request from a worker thread
   @no_wasm_backend("emscripten_fetch_wait uses an asm.js based web worker")


### PR DESCRIPTION
Convert this test to use exit_runtime. This makes it depend on running the code after `emscripten_fetch()` returns.
