### PR TITLE
emscripten.py: Strip leading `_` from externs conditionally. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -113,7 +113,7 @@ def update_settings_glue(metadata, DEBUG):
   all_funcs = shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE + [shared.JS.to_nice_ident(d) for d in metadata['declares']]
   shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = sorted(set(all_funcs).difference(metadata['exports']))
 
-  shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [x[1:] for x in metadata['externs']]
+  shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += metadata['externs']
   # With the wasm backend the set of implemented functions is identical to the set of exports
   shared.Settings.IMPLEMENTED_FUNCTIONS = [asmjs_mangle(x) for x in metadata['exports']]
 
@@ -736,7 +736,7 @@ def create_module(sending, receiving, invoke_funcs, metadata):
   receiving += create_named_globals(metadata)
   module = []
 
-  module.append('var asmLibraryArg = %s;\n' % (sending))
+  module.append('var asmLibraryArg = %s;\n' % sending)
   if shared.Settings.ASYNCIFY and shared.Settings.ASSERTIONS:
     module.append('Asyncify.instrumentWasmImports(asmLibraryArg);\n')
 
@@ -778,13 +778,15 @@ def load_metadata_wasm(metadata_raw, DEBUG):
       exit_with_error('unexpected metadata key received from wasm-emscripten-finalize: %s', key)
     metadata[key] = value
 
+  if DEBUG:
+    logger.debug("Metadata parsed: " + pprint.pformat(metadata))
+
   # Support older metadata when asmConsts values were lists.  We only use the first element
   # nowadays
   # TODO(sbc): remove this once binaryen has been changed to only emit the single element
   metadata['asmConsts'] = {k: v[0] if type(v) is list else v for k, v in metadata['asmConsts'].items()}
-
-  if DEBUG:
-    logger.debug("Metadata parsed: " + pprint.pformat(metadata))
+  # TODO(sbc): Remove this once binaryen stopped adding the extra '_'
+  metadata['externs'] = [x[1:] if x[0] == '_' else x for x in metadata['externs']]
 
   # Calculate the subset of exports that were explicitly marked with llvm.used.
   # These are any exports that were not requested on the command line and are


### PR DESCRIPTION
This will allow the extra `_` to be removed from the binaryen
metadata.