### PR TITLE
Allow ERROR_ON_UNDEFINED_SYMBOLS + MAIN_MODULE

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1421,7 +1421,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           '__heap_base',
           '__stack_pointer',
       ]
-      # This needs to be exported on the Module object too so its visible
+      # This needs to be exported on the Module object too so it's visible
       # to side modules too.
       shared.Settings.EXPORTED_FUNCTIONS += ['___heap_base']
       if options.use_closure_compiler:

--- a/emcc.py
+++ b/emcc.py
@@ -1418,7 +1418,12 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           '$relocateExports',
           '$GOTHandler',
           '$getDylinkMetadata',
+          '__heap_base',
+          '__stack_pointer',
       ]
+      # This needs to be exported on the Module object too so its visible
+      # to side modules too.
+      shared.Settings.EXPORTED_FUNCTIONS += ['___heap_base']
       if options.use_closure_compiler:
         exit_with_error('cannot use closure compiler on shared modules')
       if shared.Settings.MINIMAL_RUNTIME:

--- a/src/library.js
+++ b/src/library.js
@@ -3666,6 +3666,23 @@ LibraryManager.library = {
     func();
   },
 #endif
+
+#if RELOCATABLE
+  // These get set in emscripten.py during add_standard_wasm_imports, but are
+  // included here so they don't show up as undefined symbols at js compile
+  // time.
+  __stack_pointer: "new WebAssembly.Global({value: 'i32', mutable: true}, {{{ STACK_BASE }}})",
+  // tell the memory segments where to place themselves
+  __memory_base: '{{{ GLOBAL_BASE }}}',
+  // the wasm backend reserves slot 0 for the NULL function pointer
+  __table_base: 1,
+  // To support such allocations during startup, track them on __heap_base and
+  // then when the main module is loaded it reads that value and uses it to
+  // initialize sbrk (the main module is relocatable itself, and so it does not
+  // have __heap_base hardcoded into it - it receives it from JS as an extern
+  // global, basically).
+  __heap_base: '{{{ HEAP_BASE }}}',
+#endif
 };
 
 function autoAddDeps(object, name) {

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -240,7 +240,7 @@ var LibraryDylink = {
   // use normally malloc from the main program to do these allocations).
 
   // Allocate memory even if malloc isn't ready yet.
-  $getMemory__deps: ['$GOT'],
+  $getMemory__deps: ['$GOT', '__heap_base'],
   $getMemory: function(size) {
     // After the runtime is initialized, we must only use sbrk() normally.
 #if DYLINK_DEBUG
@@ -248,12 +248,12 @@ var LibraryDylink = {
 #endif
     if (runtimeInitialized)
       return _malloc(size);
-    var ret = Module['___heap_base'];
+    var ret = ___heap_base;
     var end = (ret + size + 15) & -16;
 #if ASSERTIONS
     assert(end <= HEAP8.length, 'failure to getMemory - memory growth etc. is not supported there, call malloc/sbrk directly or increase INITIAL_MEMORY');
 #endif
-    Module['___heap_base'] = end;
+    ___heap_base = end;
     GOT['__heap_base'].value = end;
     return ret;
   },

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -287,17 +287,6 @@ function updateGlobalBufferAndViews(buf) {
 #endif
 }
 
-#if RELOCATABLE
-var __stack_pointer = new WebAssembly.Global({value: 'i32', mutable: true}, {{{ STACK_BASE }}});
-
-// To support such allocations during startup, track them on __heap_base and
-// then when the main module is loaded it reads that value and uses it to
-// initialize sbrk (the main module is relocatable itself, and so it does not
-// have __heap_base hardcoded into it - it receives it from JS as an extern
-// global, basically).
-Module['___heap_base'] = {{{ HEAP_BASE }}};
-#endif // RELOCATABLE
-
 var TOTAL_STACK = {{{ TOTAL_STACK }}};
 #if ASSERTIONS
 if (Module['TOTAL_STACK']) assert(TOTAL_STACK === Module['TOTAL_STACK'], 'the stack size can no longer be determined at runtime')

--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 4946,
   "a.js.gz": 2383,
-  "a.wasm": 10354,
-  "a.wasm.gz": 6673,
-  "total": 15863,
-  "total_gz": 9433
+  "a.wasm": 10352,
+  "a.wasm.gz": 6676,
+  "total": 15861,
+  "total_gz": 9436
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -2,9 +2,9 @@
   "a.html": 588,
   "a.html.gz": 386,
   "a.js": 19947,
-  "a.js.gz": 8160,
+  "a.js.gz": 8158,
   "a.mem": 3171,
   "a.mem.gz": 2715,
   "total": 23706,
-  "total_gz": 11261
+  "total_gz": 11259
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 377,
   "a.js": 4428,
   "a.js.gz": 2208,
-  "a.wasm": 10354,
-  "a.wasm.gz": 6673,
-  "total": 15345,
-  "total_gz": 9258
+  "a.wasm": 10352,
+  "a.wasm.gz": 6676,
+  "total": 15343,
+  "total_gz": 9261
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -2,9 +2,9 @@
   "a.html": 588,
   "a.html.gz": 386,
   "a.js": 19429,
-  "a.js.gz": 7995,
+  "a.js.gz": 7990,
   "a.mem": 3171,
   "a.mem.gz": 2715,
   "total": 23188,
-  "total_gz": 11096
+  "total_gz": 11091
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12585,
-  "a.html.gz": 6756,
-  "total": 12585,
-  "total_gz": 6756
+  "a.html": 12589,
+  "a.html.gz": 6771,
+  "total": 12589,
+  "total_gz": 6771
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17327,
-  "a.html.gz": 7448,
-  "total": 17327,
-  "total_gz": 7448
+  "a.html": 17332,
+  "a.html.gz": 7453,
+  "total": 17332,
+  "total_gz": 7453
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10319,3 +10319,8 @@ exec "$@"
       # wasm2js optimizations use multiprocessing to run multiple node
       # invocations
       self.run_process([EMCC, test_file('hello_world.c'), '-sWASM=0', '-O2'])
+
+  def test_main_module_no_undefined(self):
+    # Test that ERROR_ON_UNDEFINED_SYMBOLS works with MAIN_MODULE.
+    self.run_process([EMCC, '-sMAIN_MODULE', '-sERROR_ON_UNDEFINED_SYMBOLS', test_file('hello_world.c')])
+    self.run_js('a.out.js')


### PR DESCRIPTION
The primary change here is make symbols like `__stack_pointer` and `__heap_base` part
of the JS library and therefore visible to the jsifier that reports undefined symbols.

The second change is to have `create_sending` supply symbols required by the wasm
module that are listed as `'externs'` (undefined data addresses) as well as the `'declares'`
(undefined functions).

Fixes: #3388