### PR TITLE
Fix and test INCLUDE_FULL_LIBRARY

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1401,6 +1401,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # memory init file is not supported with side modules, must be executable synchronously (for dlopen)
       options.memory_init_file = False
 
+    # If we are including the entire JS library then we know for sure we will, by definition,
+    # require all the reverse dependencies.
+    if shared.Settings.INCLUDE_FULL_LIBRARY:
+      default_setting('REVERSE_DEPS', 'all')
+
     if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
       if shared.Settings.MAIN_MODULE == 1 or shared.Settings.SIDE_MODULE == 1:
         shared.Settings.LINKABLE = 1

--- a/src/library_exceptions_stub.js
+++ b/src/library_exceptions_stub.js
@@ -25,9 +25,12 @@ var LibraryExceptions = {};
   '__resumeException',
 ].forEach(function(name) {
   LibraryExceptions[name] = function() { abort(); };
+#if !INCLUDE_FULL_LIBRARY
+  // This method of link-time error genertation is not compatible with INCLUDE_FULL_LIBRARY
   LibraryExceptions[name + '__deps'] = [function() {
     error('DISABLE_EXCEPTION_THROWING was set (likely due to -fno-exceptions), which means no C++ exception throwing support code is linked in, but such support is required by symbol ' + name + '. Either do not set DISABLE_EXCEPTION_THROWING (if you do want exception throwing) or compile all source files with -fno-except (so that no exceptions support code is required); also make sure DISABLE_EXCEPTION_CATCHING is set to the right value - if you want exceptions, it should be off, and vice versa.');
   }];
+#endif
 });
 
 mergeInto(LibraryManager.library, LibraryExceptions);

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3536,8 +3536,10 @@ var LibraryGL = {
   glBindVertexArrayOES: 'glBindVertexArray',
   glIsVertexArrayOES: 'glIsVertexArray',
 
+#if LEGACY_GL_EMULATION
   // GLU
 
+  gluPerspective__deps: ['$GLImmediate'],
   gluPerspective: function(fov, aspect, near, far) {
     GLImmediate.matricesModified = true;
     GLImmediate.matrixVersion[GLImmediate.currentMatrix] = (GLImmediate.matrixVersion[GLImmediate.currentMatrix] + 1)|0;
@@ -3546,6 +3548,7 @@ var LibraryGL = {
                                                GLImmediate.matrix[GLImmediate.currentMatrix]);
   },
 
+  gluLookAt__deps: ['$GLImmediate'],
   gluLookAt: function(ex, ey, ez, cx, cy, cz, ux, uy, uz) {
     GLImmediate.matricesModified = true;
     GLImmediate.matrixVersion[GLImmediate.currentMatrix] = (GLImmediate.matrixVersion[GLImmediate.currentMatrix] + 1)|0;
@@ -3553,6 +3556,7 @@ var LibraryGL = {
         [cx, cy, cz], [ux, uy, uz]);
   },
 
+  gluProject__deps: ['$GLImmediate'],
   gluProject: function(objX, objY, objZ, model, proj, view, winX, winY, winZ) {
     // The algorithm for this functions comes from Mesa
 
@@ -3583,6 +3587,7 @@ var LibraryGL = {
     return 1 /* GL_TRUE */;
   },
 
+  gluUnProject__deps: ['$GLImmediate'],
   gluUnProject: function(winX, winY, winZ, model, proj, view, objX, objY, objZ) {
     var result = GLImmediate.matrixLib.mat4.unproject([winX, winY, winZ],
         {{{ makeHEAPView('F64', 'model', 'model+' + (16*8)) }}},
@@ -3604,6 +3609,7 @@ var LibraryGL = {
   gluOrtho2D: function(left, right, bottom, top) {
     _glOrtho(left, right, bottom, top, -1, 1);
   },
+#endif // LEGACY_GL_EMULATION
 
   // GLES2 emulation
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7515,6 +7515,15 @@ end
     proc = test(check=True, extra=['-s', 'IGNORE_CLOSURE_COMPILER_ERRORS'])
     self.assertNotContained(WARNING, proc.stderr)
 
+  def test_full_js_library(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'INCLUDE_FULL_LIBRARY'])
+
+  def test_full_js_library_gl_emu(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'INCLUDE_FULL_LIBRARY', '-s', 'LEGACY_GL_EMULATION'])
+
+  def test_full_js_library_no_exception_throwing(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'INCLUDE_FULL_LIBRARY', '-s', 'DISABLE_EXCEPTION_THROWING'])
+
   def test_closure_full_js_library(self):
     # test for closure errors in the entire JS library
     # We must ignore various types of errors that are expected in this situation, as we


### PR DESCRIPTION
The main fix here is to set `REVERSE_DEPS` to `all` when building
with `INCLUDE_FULL_LIBRARY`.

The second fix is to wrap `LEGACY_GL_EMULATION` around
a few functions in `library_webgl.js` which rely on 
`GLImmediate` (which is only defined in `LEGACY_GL_EMULATION`
mode).

Fixes: #13794