### PR TITLE
Remove unused/broken abortFnPtrError JS helper. NFC

### DIFF
--- a/src/runtime_assertions.js
+++ b/src/runtime_assertions.js
@@ -16,18 +16,4 @@
 })();
 #endif
 
-function abortFnPtrError(ptr, sig) {
-#if ASSERTIONS >= 2
-	var possibleSig = '';
-	for (var x in debug_tables) {
-		var tbl = debug_tables[x];
-		if (tbl[ptr]) {
-			possibleSig += 'as sig "' + x + '" pointing to function ' + tbl[ptr] + ', ';
-		}
-	}
-	abort("Invalid function pointer " + ptr + " called with signature '" + sig + "'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this). This pointer might make sense in another type signature: " + possibleSig);
-#else
-	abort("Invalid function pointer " + ptr + " called with signature '" + sig + "'. Perhaps this is an invalid value (e.g. caused by calling a virtual method on a NULL pointer)? Or calling a function with an incorrect type, which will fail? (it is worth building your source files with -Werror (warnings are errors), as warnings can indicate undefined behavior which can cause this). Build with ASSERTIONS=2 for more info.");
-#endif
-}
 #endif // ASSERTIONS


### PR DESCRIPTION
debug_tables no longer exists so there is no way this function can work
these days.

I noticed this while working on removing closure compiler errors.