### PR TITLE
Update upstream URL for libjpeg. NFC

### DIFF
--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -8,7 +8,7 @@ import shutil
 import logging
 
 VERSION = '9c'
-HASH = '2b581c60ae401a79bbbe748ff2deeda5acd50bfd2ea22e5926e36d34b9ebcffb6580b0ff48e972c1441583e30e21e1ea821ca0423f9c67ce08a31dffabdbe6b7'
+HASH = 'b2affe9a1688bd49fc033f4682c4a242d4ee612f1affaef532f5adcb4602efc4433c4a52a4b3d69e7440ff1f6413b1b041b419bc90efd6d697999961a9a6afb7'
 
 
 def needed(settings):
@@ -16,7 +16,7 @@ def needed(settings):
 
 
 def get(ports, settings, shared):
-  ports.fetch_project('libjpeg', 'https://dl.bintray.com/homebrew/mirror/jpeg-9c.tar.gz', 'jpeg-9c', sha512hash=HASH)
+  ports.fetch_project('libjpeg', 'https://www.ijg.org/files/jpegsrc.v9c.tar.gz', 'jpeg-9c', sha512hash=HASH)
 
   def create(final):
     logging.info('building port: libjpeg')


### PR DESCRIPTION
The old URL seems to be generating `Forbidden!`.

I wonder if we should start maintaining our own mirror to avoid
this kind of thing.