### PR TITLE
fix: throw ENOSYS when ioctl request is unknown

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -553,3 +553,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Vasili Skurydzin <vasili.skurydzin@ibm.com>
 * Jakub Nowakowski <jn925+emcc@o2.pl>
 * Andrew Brown <andrew.brown@intel.com> (copyright owned by Intel Corporation)
+* Anirudh Giri <anirudhgirimail@gmail.com>

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -453,7 +453,7 @@ var SyscallsLibrary = {
         if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
         return 0;
       }
-      default: abort('bad ioctl syscall ' + op);
+      default: return -{{{ cDefine('ENOSYS') }}}; // bad ioctl syscall
     }
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -453,7 +453,7 @@ var SyscallsLibrary = {
         if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
         return 0;
       }
-      default: return -{{{ cDefine('ENOSYS') }}}; // bad ioctl syscall
+      default: return -{{{ cDefine('EINVAL') }}}; // bad ioctl syscall
     }
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },


### PR DESCRIPTION
Fixes #13810 

returns `ENOSYS` instead of aborting the process when ioctl request is known, hence fixing the issue.

https://github.com/anirudhgiri/emscripten/blob/660a951c8d0c075bb423ffc4f57c5ee565bfd0f0/src/library_syscall.js#L456

