### PR TITLE
Include side module imports when building with MAIN_MODULE=2

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,6 +22,12 @@ Current Trunk
 -------------
 - `EXTRA_EXPORTED_RUNTIME_METHODS` is deprecated in favor of just using
   `EXPORTED_RUNTIME_METHODS`.
+- When building with `MAIN_MODULE=2` the linker will now automatically include
+  any symbols required by side modules found on the command line.  This means
+  that for many users of `MAIN_MODULE=2` it should not longer be necessary to
+  list explicit `EXPORTED_FUNCTIONS`.  Also, users of `MAIN_MODULE=1` with
+  dynamic linking (not dlopen) who list all side modules on the command line,
+  should be able to switch to `MAIN_MODULE=2` and get a reduction in code size.
 
 2.0.17: 04/10/2021
 ------------------

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -345,6 +345,10 @@ var LibraryDylink = {
       //
       // We should copy the symbols (which include methods and variables) from SIDE_MODULE to MAIN_MODULE.
 
+      if (!asmLibraryArg.hasOwnProperty(sym)) {
+        asmLibraryArg[sym] = libModule[sym];
+      }
+
       var module_sym = asmjsMangle(sym);
 
       if (!Module.hasOwnProperty(module_sym)) {
@@ -383,8 +387,6 @@ var LibraryDylink = {
 #if DYLINK_DEBUG
       err("loadModule: memoryBase=" + memoryBase);
 #endif
-      // prepare env imports
-      var env = asmLibraryArg;
       // TODO: use only __memory_base and __table_base, need to update asm.js backend
       var tableBase = wasmTable.length;
       wasmTable.grow(metadata.tableSize);
@@ -427,13 +429,6 @@ var LibraryDylink = {
         return resolved;
       }
 
-      // copy currently exported symbols so the new module can import them
-      for (var x in Module) {
-        if (!(x in env)) {
-          env[x] = Module[x];
-        }
-      }
-
       // TODO kill ↓↓↓ (except "symbols local to this module", it will likely be
       // not needed if we require that if A wants symbols from B it has to link
       // to B explicitly: similarly to -Wl,--no-undefined)
@@ -465,7 +460,7 @@ var LibraryDylink = {
           };
         }
       };
-      var proxy = new Proxy(env, proxyHandler);
+      var proxy = new Proxy(asmLibraryArg, proxyHandler);
       var info = {
         'GOT.mem': new Proxy(asmLibraryArg, GOTHandler),
         'GOT.func': new Proxy(asmLibraryArg, GOTHandler),


### PR DESCRIPTION
When linking the main module, look for side modules on the command line
and parse them for imports.

This means that users of MAIN_MODULE=2 who include the side
modules on the command line at link time should not need to
manually add to EXPORTED_FUNCTIONS.

Fixes: #13830