### PR TITLE
Use cloud storage mirror of libjpeg archive

### DIFF
--- a/tools/ports/libjpeg.py
+++ b/tools/ports/libjpeg.py
@@ -16,7 +16,10 @@ def needed(settings):
 
 
 def get(ports, settings, shared):
-  ports.fetch_project('libjpeg', 'https://www.ijg.org/files/jpegsrc.v9c.tar.gz', 'jpeg-9c', sha512hash=HASH)
+  # Archive mirrored from http://www.ijg.org/files/jpegsrc.v9c.tar.gz.
+  # We have issues where python urllib was not able to load from the www.ijg.org webserver
+  # and was resulting in 403: Forbidden.
+  ports.fetch_project('libjpeg', 'https://storage.googleapis.com/webassembly/emscripten-ports/jpegsrc.v9c.tar.gz', 'jpeg-9c', sha512hash=HASH)
 
   def create(final):
     logging.info('building port: libjpeg')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -10,6 +10,7 @@ import logging
 import os
 import shutil
 import sys
+import urllib.request
 from glob import iglob
 
 from .toolchain_profiler import ToolchainProfiler
@@ -1736,14 +1737,8 @@ class Ports:
     def retrieve():
       # retrieve from remote server
       logger.info('retrieving port: ' + name + ' from ' + url)
-      try:
-        import requests
-        response = requests.get(url)
-        data = response.content
-      except ImportError:
-        from urllib.request import urlopen
-        f = urlopen(url)
-        data = f.read()
+      f = urllib.request.urlopen(url)
+      data = f.read()
 
       if sha512hash:
         actual_hash = hashlib.sha512(data).hexdigest()


### PR DESCRIPTION
It turns out that the www.ijg.org refused requests from the urllib
library for some reason.

This issues was being masked by the fact that system_libs.py prefers to
use `requests` when it is installed.  This change undoes that.  This
feature was originally added in #8667 to deal with older python
installations but these days we supply our own python as part of emsdk
so we should be able to depend on a recent/correct version.  Having the
fallback here just makes testing harder.

Fixes: #13869