### PR TITLE
Add support for layout(binding=x) in shaders.

### DIFF
--- a/docs/EMSCRIPTEN_explicit_uniform_binding.txt
+++ b/docs/EMSCRIPTEN_explicit_uniform_binding.txt
@@ -1,0 +1,173 @@
+Name
+
+    EMSCRIPTEN_explicit_uniform_binding
+
+Name Strings
+
+    GL_EMSCRIPTEN_explicit_uniform_binding
+
+Contributors
+
+    Jukka Jylänki, Unity Technologies
+    Brendan Duncan, Unity Technologies
+
+Contact
+
+    Jukka Jylänki, Unity Technologies (jukkaj 'at' unity3d.com)
+    Brendan Duncan, Unity Technologies (brendan.duncan 'at' unity3d.com)
+
+Status
+
+    Implemented in Emscripten 2.0.18 and newer for OpenGL ES 2 and
+    OpenGL ES 3 contexts. (April 2021)
+
+Version
+
+    Date: April 13, 2021
+    Revision: 1
+
+Dependencies
+
+    Emscripten 2.0.18 compiler targeting OpenGL ES 2.0 or OpenGL ES 3.0
+    versions.
+
+    Written against the OpenGL ES 2.0.25 and WebGL 1 specifications.
+
+Overview
+
+    WebGL 1 API provides a special type of uniforms called texture samplers.
+    The organization of these samplers is designed around the concept of
+    a file of device global multitexturing binding points. This provides a
+    layer of indirection: instead of directly connecting texture objects to
+    sampler uniforms in the shader, textures are set active in multitexturing
+    binding points, and samplers uniforms then each select a binding point to
+    sample from.
+
+    WebGL 2 API provides support for Uniform Buffer Objects (UBOs). Again,
+    instead of directly connecting a GPU buffer to a uniform block in the
+    shader, each UBO variable is connected to a slot in a file of uniform
+    block binding points, and the uniform block variables are assigned to
+    read from one of these uniform block binding points.
+
+    Sampler uniforms are assigned a multitexturing unit by calling the
+    function gl.uniform1i(). Uniform blocks are assigned a uniform block
+    binding point by calling the function gl.uniformBlockBinding().
+
+    By default after a successful shader link, all samplers and uniform blocks
+    are initially assigned the binding point zero. Instead of programmatically
+    reassigning the binding points in Wasm/JS code, it can be useful to specify
+    the default binding point to use in GLSL shader code. This allows a shader
+    compilation backend to generate multiple shader programs that have mutually
+    compatible layouts, without needing further coordination in application
+    code.
+
+    This extension adds support for specifying the initial multitexturing and
+    uniform block binding points for texture samplers and uniform blocks. This
+    is achieved via the same syntax that is available in Desktop OpenGL 4.2 and
+    the extension ARB_shading_language_420pack. There, a programmer may choose
+    to specify the integer binding point of a texture sampler or a uniform
+    block in advance directly in the submitted shader code. The GLSL directive
+
+        layout(binding = x) uniform sampler2D diffuse;
+
+    specifies that the sampler 'diffuse' should sample a texture located in
+    multitexturing unit 'x'.
+
+    Likewise, specifying
+
+        layout(binding = x) uniform myBlock { vec4 color; }
+
+    specifies that the uniform block 'myBlock' should read from the Uniform
+    Buffer Object located at uniform block binding point 'x'.
+
+    In sibling specifications, support for explicit binding points exist in
+    Desktop OpenGL 4.2 core specification and in the extension
+    ARB_shading_language_420pack.
+
+New Procedures and Functions
+
+    None.
+
+New Tokens
+
+    None.
+
+Additions to OpenGL ES Shading Language 1.00 Specification
+
+  Add to sampler qualifiers:
+
+    The qualifier "layout(binding = x)" can be prepended to a texture sampler
+    variable directive to bind the integer multitexturing unit that the given
+    sampler reads from:
+
+        layout(binding = x) uniform sampler2D diffuse;
+
+    Only one layout qualifier may appear in a single declaration.
+
+    Any sampler declared without a binding identifier is initially assigned to
+    sample from multitexturing unit zero. After a program is linked, the binding
+    points used for samplers with or without a binding identifier can be updated
+    by the OpenGL API.
+
+    If the binding identifier is used with an array, the first element of the 
+    array takes the specified unit and each subsequent element takes the next 
+    consecutive unit.
+
+    If the binding is less than zero, or greater than or equal to the 
+    implementation-dependent maximum supported number of units, a compilation 
+    error will occur. When the binding identifier is used with an array of size
+    N, all elements of the array from binding through binding + N - 1 must be 
+    within this range.
+
+Additions to OpenGL ES Shading Language 3.00 Specification
+
+  Add to Layout Qualifiers:
+
+    The qualifier "layout(binding = x)" can be prepended to a uniform block
+    variable directive:
+
+        layout(binding = x) uniform myBlock { vec4 color; }
+
+    The binding identifier specifies the uniform buffer binding point 
+    corresponding to the uniform block, which will be used to obtain the 
+    values of the member variables of the block.
+
+    Only one layout qualifier may appear in a single declaration.
+
+    Any uniform block declared without a binding identifier is initially 
+    assigned to block binding point zero. After a program is linked, the 
+    binding points used for uniform blocks declared with or without a binding 
+    identifier can be updated by the OpenGL API.
+
+    If the binding identifier is used with a uniform block instanced as an 
+    array then the first element of the array takes the specified block binding
+    and each subsequent element takes the next consecutive uniform block 
+    binding point.
+
+    If the binding point for any uniform block instance is less than zero, or 
+    greater than or equal to the implementation-dependent maximum number of 
+    uniform buffer bindings, a compilation error will occur.  When the binding 
+    identifier is used with a uniform block instanced as an array of size N, 
+    all elements of the array from binding through binding + N - 1 must be
+    within this range.
+
+Additions to Emscripten compiler
+
+    Instead of utilizing the runtime method WebGLRenderingContext.getExtension()
+    to coordinate enabling the extension, EMSCRIPTEN_explicit_uniform_binding
+    activation is controlled at compile time by specifying the flag
+
+        -s GL_EXPLICIT_UNIFORM_BINDING=1
+
+    to 'emcc' or 'em++' linker command line in the Emscripten compiler.
+
+    When this flag is passed, the extension EMSCRIPTEN_explicit_uniform_binding
+    is enabled for all contexts created in the application.
+
+    The choice of compile time activation is due to the considerable increase in
+    code size that is involved in enabling this extension.
+
+Revision History
+
+    Revision 1.0, April 13, 2021: juj
+        - First version

--- a/docs/EMSCRIPTEN_explicit_uniform_location.txt
+++ b/docs/EMSCRIPTEN_explicit_uniform_location.txt
@@ -80,6 +80,21 @@ Overview
     This extension adds support for specifying layout location qualifiers in
     GLSL shaders in OpenGL and OpenGL ES programs compiled via Emscripten.
 
+    The main benefit of layout location qualifiers in shaders is to enable
+    aligning shader uniforms across multiple compiled shader programs. For
+    example, if several compiler programs had a common shader uniform variable
+    "vec4 fogColor", without explicit location qualifiers, C/C++ code would
+    have to manage a mapping table that would track the uniform location of
+    fogColor in each shader program. Wiht explicit uniform locations, all shaders
+    can be compiled to locate fogColor in the same location index, thus greatly
+    simplifying C/C++ engine code.
+
+    In sibling specifications, support for explicit uniform locations exist in
+    OpenGL ES 3.1 and Desktop OpenGL 4.3 core specifications. Additionally,
+    Desktop OpenGL 3.3 and newer may support the ARB_explicit_uniform_location
+    extension that also offers the same functionality as this extension
+    EMSCRIPTEN_explicit_uniform_location does.
+
 New Procedures and Functions
 
     None.

--- a/docs/EMSCRIPTEN_explicit_uniform_location.txt
+++ b/docs/EMSCRIPTEN_explicit_uniform_location.txt
@@ -85,7 +85,7 @@ Overview
     example, if several compiler programs had a common shader uniform variable
     "vec4 fogColor", without explicit location qualifiers, C/C++ code would
     have to manage a mapping table that would track the uniform location of
-    fogColor in each shader program. Wiht explicit uniform locations, all shaders
+    fogColor in each shader program. With explicit uniform locations, all shaders
     can be compiled to locate fogColor in the same location index, thus greatly
     simplifying C/C++ engine code.
 

--- a/emcc.py
+++ b/emcc.py
@@ -1583,6 +1583,13 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if settings.USE_WEBGL2:
       settings.MAX_WEBGL_VERSION = 2
 
+    # MIN_WEBGL_VERSION=2 implies MAX_WEBGL_VERSION=2
+    if settings.MIN_WEBGL_VERSION == 2:
+      default_setting('MAX_WEBGL_VERSION', 2)
+
+    if settings.MIN_WEBGL_VERSION > settings.MAX_WEBGL_VERSION:
+      exit_with_error('MIN_WEBGL_VERSION must be smaller or equal to MAX_WEBGL_VERSION!')
+
     if not settings.GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS and settings.GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS:
       exit_with_error('-s GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS=0 only makes sense with -s GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS=0!')
 

--- a/src/modules.js
+++ b/src/modules.js
@@ -155,7 +155,7 @@ var LibraryManager = {
       libraries.push('library_webgl2.js');
     }
 
-    if (GL_EXPLICIT_UNIFORM_LOCATION) {
+    if (GL_EXPLICIT_UNIFORM_LOCATION || GL_EXPLICIT_UNIFORM_BINDING) {
       libraries.push('library_c_preprocessor.js');
     }
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -494,6 +494,10 @@ var WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0;
 // extension. See docs/EMSCRIPTEN_explicit_uniform_location.txt
 var GL_EXPLICIT_UNIFORM_LOCATION = 0;
 
+// If true, enables support for the EMSCRIPTEN_uniform_layout_binding WebGL
+// extension. See docs/EMSCRIPTEN_explicit_uniform_binding.txt
+var GL_EXPLICIT_UNIFORM_BINDING = 0;
+
 // Deprecated. Pass -s MAX_WEBGL_VERSION=2 to target WebGL 2.0.
 // [link]
 var USE_WEBGL2 = 0;

--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -339,3 +339,8 @@ WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedWEBGL(GLenum mode, co
 #define GL_RGB16_SNORM_EXT 0x8F9A
 #define GL_RGBA16_SNORM_EXT 0x8F9B
 #endif /* EMSCRIPTEN_GL_EXT_texture_norm16 */
+
+// EMSCRIPTEN_explicit_uniform_location
+#ifndef GL_MAX_UNIFORM_LOCATIONS
+#define GL_MAX_UNIFORM_LOCATIONS          0x826E
+#endif

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1243,6 +1243,14 @@ keydown(100);keyup(100); // trigger the end
   def test_webgl_explicit_uniform_location(self):
     self.btest('webgl_explicit_uniform_location.c', '1', args=['-s', 'GL_EXPLICIT_UNIFORM_LOCATION=1', '-s', 'MIN_WEBGL_VERSION=2'])
 
+  @requires_graphics_hardware
+  def test_webgl_sampler_layout_binding(self):
+    self.btest('webgl_sampler_layout_binding.c', '1', args=['-s', 'GL_EXPLICIT_UNIFORM_BINDING=1'])
+
+  @requires_graphics_hardware
+  def test_webgl2_ubo_layout_binding(self):
+    self.btest('webgl2_ubo_layout_binding.c', '1', args=['-s', 'GL_EXPLICIT_UNIFORM_BINDING=1', '-s', 'MIN_WEBGL_VERSION=2'])
+
   # Test that -s GL_PREINITIALIZED_CONTEXT=1 works and allows user to set Module['preinitializedWebGLContext'] to a preinitialized WebGL context.
   @requires_graphics_hardware
   def test_preinitialized_webgl_context(self):

--- a/tests/webgl2_ubo_layout_binding.c
+++ b/tests/webgl2_ubo_layout_binding.c
@@ -1,0 +1,180 @@
+// Copyright 2021 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
+#include <GLES3/gl3.h>
+#include <stdlib.h>
+
+GLuint CompileShader(GLenum type, const char *src)
+{
+  GLuint shader = glCreateShader(type);
+  glShaderSource(shader, 1, &src, NULL);
+  glCompileShader(shader);
+
+  GLint isCompiled = 0;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &isCompiled);
+  if (!isCompiled)
+  {
+    GLint maxLength = 0;
+    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
+    char *buf = (char*)malloc(maxLength+1);
+    glGetShaderInfoLog(shader, maxLength, &maxLength, buf);
+    printf("%s\n", buf);
+    free(buf);
+    return 0;
+  }
+  else
+  {
+    printf("Shader compiled OK!\n");
+  }
+
+  return shader;
+}
+
+GLuint CreateProgram(GLuint vertexShader, GLuint fragmentShader)
+{
+   GLuint program = glCreateProgram();
+   glAttachShader(program, vertexShader);
+   glAttachShader(program, fragmentShader);
+   glBindAttribLocation(program, 0, "pos");
+   glLinkProgram(program);
+   GLint linked = 0;
+   glGetProgramiv(program, GL_LINK_STATUS, &linked);
+   if (!linked) 
+   {
+      GLint infoLen = 0;
+      glGetProgramiv(program, GL_INFO_LOG_LENGTH, &infoLen);
+      if (infoLen)
+      {
+        char *infoLog = (char*)malloc(infoLen);
+        glGetProgramInfoLog(program, infoLen, NULL, infoLog);
+        printf("Error linking program:\n%s\n", infoLog);
+      }
+      assert(0);
+   }
+   return program;
+}
+
+int main(int argc, char *argv[])
+{
+  EmscriptenWebGLContextAttributes attr;
+  emscripten_webgl_init_context_attributes(&attr);
+  attr.majorVersion = 2;
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
+  emscripten_webgl_make_context_current(ctx);
+
+  GLuint vs = CompileShader(GL_VERTEX_SHADER,
+    "#version 300 es\n"
+    "in vec4 pos;\n"
+    "void main() { gl_Position = pos; }");
+
+  GLuint ps = CompileShader(GL_FRAGMENT_SHADER,
+    "#version 300 es\n"
+    "precision lowp float;\n"
+    "layout(binding = 4) uniform red { vec4 unused1; float r; };\n"
+    "layout(binding = 5, std140) uniform Green { float unused2; float g; } green;\n"
+    "layout(std140, binding = 6) uniform Blue { vec3 unused3; float b; } blue[2];\n"
+    "out vec4 outColor;\n"
+    "void main() { outColor = vec4(r, green.g, blue[0].b + blue[1].b, 1.0); }");
+
+  GLuint program = CreateProgram(vs, ps);
+  glUseProgram(program);
+
+  static const float vb[] = {
+     -1.0f, -1.0f,
+      1.0f, -1.0f,
+     -1.0f,  1.0f,
+     -1.0f,  1.0f,
+      1.0f, -1.0f,
+      1.0f,  1.0f,
+  };
+
+  GLuint vbo;
+  glGenBuffers(1, &vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(vb), vb, GL_STATIC_DRAW);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 8, 0);
+  glEnableVertexAttribArray(0);
+
+  struct {
+    float unused1[4];
+    float r;
+  } red = { 0, 0, 0, 0, 0.3f };
+
+  struct {
+    float unused2;
+    float g;
+  } green = { 0, 0.5f };
+
+  struct {
+    float unused3[3];
+    float b;
+  } blue[2] = { { 0, 0, 0, 0.3f }, { 0, 0, 0.f, 0.6f } };
+
+  GLuint bufs[4];
+  glGenBuffers(4, bufs);
+  glBindBuffer(GL_UNIFORM_BUFFER, bufs[0]);
+  glBufferData(GL_UNIFORM_BUFFER, sizeof(red), &red, GL_STATIC_DRAW);
+  glBindBuffer(GL_UNIFORM_BUFFER, bufs[1]);
+  glBufferData(GL_UNIFORM_BUFFER, sizeof(green), &green, GL_STATIC_DRAW);
+  glBindBuffer(GL_UNIFORM_BUFFER, bufs[2]);
+  glBufferData(GL_UNIFORM_BUFFER, sizeof(blue[0]), blue, GL_STATIC_DRAW);
+  glBindBuffer(GL_UNIFORM_BUFFER, bufs[3]);
+  glBufferData(GL_UNIFORM_BUFFER, sizeof(blue[1]), blue+1, GL_STATIC_DRAW);
+
+  glBindBufferBase(GL_UNIFORM_BUFFER, 4, bufs[0]);
+  glBindBufferBase(GL_UNIFORM_BUFFER, 5, bufs[1]);
+  glBindBufferBase(GL_UNIFORM_BUFFER, 6, bufs[2]);
+  glBindBufferBase(GL_UNIFORM_BUFFER, 7, bufs[3]);
+  glClearColor(0.3f,0.3f,0.3f,1);
+  glClear(GL_COLOR_BUFFER_BIT);
+  glDrawArrays(GL_TRIANGLES, 0, 6);
+
+  uint8_t data[4];
+  glReadPixels(160, 85, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, data);
+  printf("output color: %u, %u, %u, %u\n", data[0], data[1], data[2], data[3]);
+  assert(data[0] == 76);
+  assert(data[1] == 127);
+  assert(data[2] == 229);
+  assert(data[3] == 255);
+
+  // Try binding to a negative binding point, should fail:
+  assert(!glGetError());
+  printf("The following compile should produce an error:\n");
+  CompileShader(GL_FRAGMENT_SHADER,
+    "#version 300 es\n"
+    "precision lowp float;\n"
+    "layout(binding = -1) uniform red { float r; };\n"
+    "out vec4 outColor;\n"
+    "void main() { outColor = vec4(r, r, r, 1.0); }");
+  assert(glGetError());
+
+  // Try binding to a too high binding point, should fail:
+  GLint bindingPoints = 0;
+  glGetIntegerv(GL_MAX_COMBINED_UNIFORM_BLOCKS, &bindingPoints);
+  assert(bindingPoints > 0);
+  assert(!glGetError());
+
+  char str[1024];
+  sprintf(str, 
+    "#version 300 es\n"
+    "precision lowp float;\n"
+    "layout(binding = %d) uniform red { float r; };\n"
+    "out vec4 outColor;\n"
+    "void main() { outColor = vec4(r, r, r, 1.0); }", bindingPoints);
+  printf("The following compile should produce an error:\n");
+  CompileShader(GL_FRAGMENT_SHADER, str);
+  assert(glGetError());
+  assert(!glGetError());
+
+  printf("Test passed!\n");
+#ifdef REPORT_RESULT
+  REPORT_RESULT(1);
+#endif
+}

--- a/tests/webgl2_ubo_layout_binding.c
+++ b/tests/webgl2_ubo_layout_binding.c
@@ -113,17 +113,19 @@ int main(int argc, char *argv[])
   struct {
     float unused1[4];
     float r;
+    float unused2[3];
   } red = { 0, 0, 0, 0, 0.3f };
   printf("sizeof(red)=%d\n", (int)sizeof(red));
 
   struct {
-    float unused2;
+    float unused1;
     float g;
+    float unused2[2];
   } green = { 0, 0.5f };
   printf("sizeof(green)=%d\n", (int)sizeof(green));
 
   struct {
-    float unused3[3];
+    float unused1[3];
     float b;
   } blue[2] = { { 0, 0, 0, 0.3f }, { 0, 0, 0.f, 0.6f } };
   printf("sizeof(blue[0])=%d\n", (int)sizeof(blue[0]));

--- a/tests/webgl2_ubo_layout_binding.c
+++ b/tests/webgl2_ubo_layout_binding.c
@@ -86,6 +86,14 @@ int main(int argc, char *argv[])
   GLuint program = CreateProgram(vs, ps);
   glUseProgram(program);
 
+  int numBlocks;
+  glGetProgramiv(program, GL_ACTIVE_UNIFORM_BLOCKS, &numBlocks);
+  for(int i = 0; i < numBlocks; ++i) {
+    int size = -1;
+    glGetActiveUniformBlockiv(program, i, GL_UNIFORM_BLOCK_DATA_SIZE, &size);
+    printf("Uniform block at index %d: size: %d\n", i, size);
+  }
+
   static const float vb[] = {
      -1.0f, -1.0f,
       1.0f, -1.0f,
@@ -106,16 +114,19 @@ int main(int argc, char *argv[])
     float unused1[4];
     float r;
   } red = { 0, 0, 0, 0, 0.3f };
+  printf("sizeof(red)=%d\n", (int)sizeof(red));
 
   struct {
     float unused2;
     float g;
   } green = { 0, 0.5f };
+  printf("sizeof(green)=%d\n", (int)sizeof(green));
 
   struct {
     float unused3[3];
     float b;
   } blue[2] = { { 0, 0, 0, 0.3f }, { 0, 0, 0.f, 0.6f } };
+  printf("sizeof(blue[0])=%d\n", (int)sizeof(blue[0]));
 
   GLuint bufs[4];
   glGenBuffers(4, bufs);
@@ -132,7 +143,7 @@ int main(int argc, char *argv[])
   glBindBufferBase(GL_UNIFORM_BUFFER, 5, bufs[1]);
   glBindBufferBase(GL_UNIFORM_BUFFER, 6, bufs[2]);
   glBindBufferBase(GL_UNIFORM_BUFFER, 7, bufs[3]);
-  glClearColor(0.3f,0.3f,0.3f,1);
+  glClearColor(0.1f,0.1f,0.1f,1);
   glClear(GL_COLOR_BUFFER_BIT);
   glDrawArrays(GL_TRIANGLES, 0, 6);
 

--- a/tests/webgl_explicit_uniform_location.c
+++ b/tests/webgl_explicit_uniform_location.c
@@ -9,10 +9,7 @@
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
 #include <GLES2/gl2.h>
-
-#ifndef GL_MAX_UNIFORM_LOCATIONS
-#define GL_MAX_UNIFORM_LOCATIONS          0x826E
-#endif
+#include <webgl/webgl1_ext.h>
 
 GLuint CompileShader(GLenum type, const char *src)
 {
@@ -29,7 +26,6 @@ GLuint CreateProgram(GLuint vertexShader, GLuint fragmentShader)
    glAttachShader(program, vertexShader);
    glAttachShader(program, fragmentShader);
    glBindAttribLocation(program, 0, "apos");
-   glBindAttribLocation(program, 1, "acolor");
    glLinkProgram(program);
    return program;
 }
@@ -53,8 +49,7 @@ int main(int argc, char *argv[])
     " // layout(location = -1) uniform mat4 proj; // Invalid usage, check this is preprocessed away\n"
     " /* layout(location = 100000000) uniform mat4 proj; Invalid usage, check this is preprocessed away */\n"
     "layout(location = 0) in vec4 pos; // Make sure attribute layout locations don't get removed by preprocessor\n"
-    "out vec4 v_pos;\n"
-    "void main() { v_pos = pos; gl_Position = view*world*pos; }");
+    "void main() { gl_Position = view*world*pos; }");
 
   GLuint ps = CompileShader(GL_FRAGMENT_SHADER,
     "#version 300 es\n"
@@ -64,7 +59,6 @@ int main(int argc, char *argv[])
     "LOCATION(11) uniform vec4 color2;\n"
     "layout(location = 18) uniform vec3 colors[3];\n"
     "layout(location = 24) uniform vec3 colors2[3];\n"
-    "in vec4 v_pos;\n"
     "LOCATION(0) out highp vec4 SV_TARGET0; // Make sure MRT output locations don't get removed by preprocessor\n"
     "void main() { SV_TARGET0 = vec4(color,1) + color2 + vec4(colors[0].r, colors[1].g, colors[2].b, 1) + vec4(colors2[0].r, colors2[1].g, colors2[2].b, 1); }");
 

--- a/tests/webgl_sampler_layout_binding.c
+++ b/tests/webgl_sampler_layout_binding.c
@@ -1,0 +1,160 @@
+// Copyright 2021 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+#include <emscripten/emscripten.h>
+#include <emscripten/html5.h>
+#include <GLES2/gl2.h>
+#include <stdlib.h>
+
+GLuint CompileShader(GLenum type, const char *src)
+{
+  GLuint shader = glCreateShader(type);
+  glShaderSource(shader, 1, &src, NULL);
+  glCompileShader(shader);
+  assert(glGetError() == GL_NO_ERROR && "Shader compilation failed!");
+
+  GLint isCompiled = 0;
+  glGetShaderiv(shader, GL_COMPILE_STATUS, &isCompiled);
+  if (!isCompiled)
+  {
+    GLint maxLength = 0;
+    glGetShaderiv(shader, GL_INFO_LOG_LENGTH, &maxLength);
+    char *buf = (char*)malloc(maxLength+1);
+    glGetShaderInfoLog(shader, maxLength, &maxLength, buf);
+    printf("%s\n", buf);
+    free(buf);
+    return 0;
+  }
+
+  return shader;
+}
+
+GLuint CreateProgram(GLuint vertexShader, GLuint fragmentShader)
+{
+   GLuint program = glCreateProgram();
+   glAttachShader(program, vertexShader);
+   glAttachShader(program, fragmentShader);
+   glBindAttribLocation(program, 0, "pos");
+   glLinkProgram(program);
+   GLint linked = 0;
+   glGetProgramiv(program, GL_LINK_STATUS, &linked);
+   if (!linked) 
+   {
+      GLint infoLen = 0;
+      glGetProgramiv(program, GL_INFO_LOG_LENGTH, &infoLen);
+      if (infoLen)
+      {
+        char *infoLog = (char*)malloc(infoLen);
+        glGetProgramInfoLog(program, infoLen, NULL, infoLog);
+        printf("Error linking program:\n%s\n", infoLog);
+      }
+      assert(0);
+   }
+   return program;
+}
+
+int main(int argc, char *argv[])
+{
+  EmscriptenWebGLContextAttributes attr;
+  emscripten_webgl_init_context_attributes(&attr);
+  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
+  emscripten_webgl_make_context_current(ctx);
+
+  GLuint vs = CompileShader(GL_VERTEX_SHADER,
+    "attribute vec4 pos;\n"
+    "varying vec2 pUv;\n"
+    "void main() { pUv = pos.xy; gl_Position = pos; }");
+
+  GLuint ps = CompileShader(GL_FRAGMENT_SHADER,
+    "precision lowp float;\n"
+    "layout(binding = 4) uniform sampler2D tex;\n"
+    "varying vec2 pUv;\n"
+    "void main() { gl_FragColor = texture2D(tex, pUv); }");
+
+  GLuint program = CreateProgram(vs, ps);
+  glUseProgram(program);
+
+  GLuint tex[2];
+  glGenTextures(2, tex);
+
+  glActiveTexture(GL_TEXTURE0 + 4);
+  glBindTexture(GL_TEXTURE_2D, tex[0]);
+  uint32_t color[4] = {
+    0xFF0000FF,
+    0xFF00FF00,
+    0xFFFF0000,
+    0xFFFFFFFF,
+  };
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 2, 2, 0, GL_RGBA, GL_UNSIGNED_BYTE, color);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+  glActiveTexture(GL_TEXTURE0 + 5);
+  glBindTexture(GL_TEXTURE_2D, tex[1]);
+  uint32_t color2[4] = {
+    0xFFFF0000,
+    0xFFFF00FF,
+    0xFF00FF00,
+    0xFF000000,
+  };
+  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 2, 2, 0, GL_RGBA, GL_UNSIGNED_BYTE, color2);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+
+  static const float vb[] = {
+     -1.0f, -1.0f,
+      1.0f, -1.0f,
+     -1.0f,  1.0f,
+     -1.0f,  1.0f,
+      1.0f, -1.0f,
+      1.0f,  1.0f,
+  };
+
+  GLuint vbo;
+  glGenBuffers(1, &vbo);
+  glBindBuffer(GL_ARRAY_BUFFER, vbo);
+  glBufferData(GL_ARRAY_BUFFER, sizeof(vb), vb, GL_STATIC_DRAW);
+  glVertexAttribPointer(0, 2, GL_FLOAT, GL_FALSE, 8, 0);
+  glEnableVertexAttribArray(0);
+
+  glClearColor(0.3f,0.3f,0.3f,1);
+  glClear(GL_COLOR_BUFFER_BIT);
+  glDrawArrays(GL_TRIANGLES, 0, 6);
+
+  uint8_t data[4];
+  glReadPixels(160, 85, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, data);
+  printf("output color: %u, %u, %u, %u\n", data[0], data[1], data[2], data[3]);
+  assert(data[0] == 255);
+  assert(data[1] == 0);
+  assert(data[2] == 0);
+  assert(data[3] == 255);
+
+  GLuint ps2 = CompileShader(GL_FRAGMENT_SHADER,
+    "precision lowp float;\n"
+    "layout(binding = 4) uniform sampler2D tex[2];\n"
+    "varying vec2 pUv;\n"
+    "void main() { gl_FragColor = texture2D(tex[0], pUv) + texture2D(tex[1], pUv); }");
+
+  GLuint program2 = CreateProgram(vs, ps2);
+  glUseProgram(program2);
+
+  glClear(GL_COLOR_BUFFER_BIT);
+  glDrawArrays(GL_TRIANGLES, 0, 6);
+
+  glReadPixels(160, 85, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE, data);
+  printf("output 2 color: %u, %u, %u, %u\n", data[0], data[1], data[2], data[3]);
+  assert(data[0] == 255);
+  assert(data[1] == 0);
+  assert(data[2] == 255);
+  assert(data[3] == 255);
+
+  printf("Test passed!\n");
+#ifdef REPORT_RESULT
+  REPORT_RESULT(1);
+#endif
+}


### PR DESCRIPTION
This PR adds support for `layout(binding=x)` directive to WebGL shaders to allow prebinding texture samplers and uniform blocks to specific binding points.

Also fixes a build issue that `emcc -s MIN_WEBGL_VERSION=2` would not work properly. (we only supported `emcc -s MAX_WEBGL_VERSION=2`).