### PR TITLE
Use python3 specifically in sdl2-config

### DIFF
--- a/system/bin/sdl2-config
+++ b/system/bin/sdl2-config
@@ -1,6 +1,5 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
-from __future__ import print_function
 import sys
 
 print('emscripten sdl2-config called with', ' '.join(sys.argv), file=sys.stderr)


### PR DESCRIPTION
This is fix for systems that don't have python executable
in the path (but do have python3).

In particular debian (and google workstations) seem to be
transitioning away from shipping python2 as python in
$PATH.