### PR TITLE
Optimize URIUtils.js. NFC

### DIFF
--- a/src/URIUtils.js
+++ b/src/URIUtils.js
@@ -4,23 +4,16 @@
  * SPDX-License-Identifier: MIT
  */
 
-function hasPrefix(str, prefix) {
-  return String.prototype.startsWith ?
-      str.startsWith(prefix) :
-      str.indexOf(prefix) === 0;
-}
-
 // Prefix of data URIs emitted by SINGLE_FILE and related options.
 var dataURIPrefix = 'data:application/octet-stream;base64,';
 
 // Indicates whether filename is a base64 data URI.
 function isDataURI(filename) {
-  return hasPrefix(filename, dataURIPrefix);
+  // Prefix of data URIs emitted by SINGLE_FILE and related options.
+  return filename.startsWith(dataURIPrefix);
 }
-
-var fileURIPrefix = "file://";
 
 // Indicates whether filename is delivered via file protocol (as opposed to http/https)
 function isFileURI(filename) {
-  return hasPrefix(filename, fileURIPrefix);
+  return filename.startsWith('file://');
 }


### PR DESCRIPTION
I can't see why startsWith was used conditionally here.

It looks like its been supported on all browsers for a very long time:
https://caniuse.com/?search=startsWith

We also already use it several other JS libraries:

- library_async.js
- library_dylink.js
- library_stack_trace.js
- library_webgl.js