### PR TITLE
Final part of settings refactor. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -161,7 +161,7 @@ def compile_settings():
   # Save settings to a file to work around v8 issue 1579
   with shared.configuration.get_temp_files().get_file('.txt') as settings_file:
     with open(settings_file, 'w') as s:
-      json.dump(shared.Settings.to_dict(), s, sort_keys=True)
+      json.dump(shared.Settings.dict(), s, sort_keys=True)
 
     # Call js compiler
     env = os.environ.copy()

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -4,7 +4,6 @@
 # found in the LICENSE file.
 
 import difflib
-import json
 import os
 import re
 
@@ -96,18 +95,8 @@ class SettingsManager:
   def __init__(self):
     load_settings()
 
-  # Transforms the Settings information into emcc-compatible args (-s X=Y, etc.). Basically
-  # the reverse of load_settings, except for -Ox which is relevant there but not here
-  def serialize(self):
-    ret = []
-    for key, value in attrs.items():
-      if key == key.upper():  # this is a hack. all of our settings are ALL_CAPS, python internals are not
-        jsoned = json.dumps(value, sort_keys=True)
-        ret += ['-s', key + '=' + jsoned]
-    return ret
-
-  def to_dict(self):
-    return attrs.copy()
+  def dict(self):
+    return attrs
 
   def keys(self):
     return attrs.keys()
@@ -120,9 +109,6 @@ class SettingsManager:
 
   def __setattr__(self, attr, value):
     set_setting(attr, value)
-
-  def get(self, key):
-    return attrs.get(key)
 
   def __getitem__(self, key):
     return attrs[key]

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -7,6 +7,7 @@ from subprocess import PIPE
 import atexit
 import binascii
 import base64
+import json
 import logging
 import os
 import re
@@ -749,9 +750,13 @@ def safe_copy(src, dst):
 def read_and_preprocess(filename, expand_macros=False):
   temp_dir = get_emscripten_temp_dir()
   # Create a settings file with the current settings to pass to the JS preprocessor
-  # Note: Settings.serialize returns an array of -s options i.e. ['-s', '<setting1>', '-s', '<setting2>', ...]
-  #       we only want the actual settings, hence the [1::2] slice operation.
-  settings_str = "var " + ";\nvar ".join(Settings.serialize()[1::2])
+
+  settings_str = ''
+  for key, value in Settings.dict().items():
+    assert key == key.upper()  # should only ever be uppercase keys in settings
+    jsoned = json.dumps(value, sort_keys=True)
+    settings_str += f'var {key} = {jsoned};\n'
+
   settings_file = os.path.join(temp_dir, 'settings.js')
   with open(settings_file, 'w') as f:
     f.write(settings_str)


### PR DESCRIPTION
Remove `serialize` method that is no longer needed.  We used
to need to serialize to a command line with `-s` flag but that
was a long time ago.  Now we can just go direct to json instead.