### PR TITLE
Declare setting object in settings.py. NFC

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -19,6 +19,7 @@ import time
 
 from tools import shared
 from tools import system_libs
+from tools.settings import settings
 import emscripten
 
 
@@ -106,9 +107,9 @@ Issuing 'embuilder.py build ALL' causes each task to be built.
 
 def build_port(port_name):
   if force:
-    system_libs.clear_port(port_name, shared.Settings)
+    system_libs.clear_port(port_name, settings)
 
-  system_libs.build_port(port_name, shared.Settings)
+  system_libs.build_port(port_name, settings)
 
 
 def main():
@@ -139,10 +140,10 @@ def main():
   shared.check_sanity()
 
   if args.lto:
-    shared.Settings.LTO = "full"
+    settings.LTO = "full"
 
   if args.pic:
-    shared.Settings.RELOCATABLE = 1
+    settings.RELOCATABLE = 1
 
   if args.force:
     force = True
@@ -187,9 +188,9 @@ def main():
     elif what == 'icu':
       build_port('icu')
     elif what == 'zlib':
-      shared.Settings.USE_ZLIB = 1
+      settings.USE_ZLIB = 1
       build_port('zlib')
-      shared.Settings.USE_ZLIB = 0
+      settings.USE_ZLIB = 0
     elif what == 'bzip2':
       build_port('bzip2')
     elif what == 'bullet':
@@ -207,46 +208,46 @@ def main():
     elif what == 'sdl2':
       build_port('sdl2')
     elif what == 'sdl2-mt':
-      shared.Settings.USE_PTHREADS = 1
+      settings.USE_PTHREADS = 1
       build_port('sdl2')
-      shared.Settings.USE_PTHREADS = 0
+      settings.USE_PTHREADS = 0
     elif what == 'sdl2-gfx':
       build_port('sdl2_gfx')
     elif what == 'sdl2-image':
       build_port('sdl2_image')
     elif what == 'sdl2-image-png':
-      shared.Settings.SDL2_IMAGE_FORMATS = ["png"]
+      settings.SDL2_IMAGE_FORMATS = ["png"]
       build_port('sdl2_image')
-      shared.Settings.SDL2_IMAGE_FORMATS = []
+      settings.SDL2_IMAGE_FORMATS = []
     elif what == 'sdl2-image-jpg':
-      shared.Settings.SDL2_IMAGE_FORMATS = ["jpg"]
+      settings.SDL2_IMAGE_FORMATS = ["jpg"]
       build_port('sdl2_image')
-      shared.Settings.SDL2_IMAGE_FORMATS = []
+      settings.SDL2_IMAGE_FORMATS = []
     elif what == 'sdl2-net':
       build_port('sdl2_net')
     elif what == 'sdl2-mixer':
-      old_formats = shared.Settings.SDL2_MIXER_FORMATS
-      shared.Settings.SDL2_MIXER_FORMATS = []
+      old_formats = settings.SDL2_MIXER_FORMATS
+      settings.SDL2_MIXER_FORMATS = []
       build_port('sdl2_mixer')
-      shared.Settings.SDL2_MIXER_FORMATS = old_formats
+      settings.SDL2_MIXER_FORMATS = old_formats
     elif what == 'sdl2-mixer-ogg':
-      old_formats = shared.Settings.SDL2_MIXER_FORMATS
-      shared.Settings.SDL2_MIXER_FORMATS = ["ogg"]
+      old_formats = settings.SDL2_MIXER_FORMATS
+      settings.SDL2_MIXER_FORMATS = ["ogg"]
       build_port('sdl2_mixer')
-      shared.Settings.SDL2_MIXER_FORMATS = old_formats
+      settings.SDL2_MIXER_FORMATS = old_formats
     elif what == 'sdl2-mixer-mp3':
-      old_formats = shared.Settings.SDL2_MIXER_FORMATS
-      shared.Settings.SDL2_MIXER_FORMATS = ["mp3"]
+      old_formats = settings.SDL2_MIXER_FORMATS
+      settings.SDL2_MIXER_FORMATS = ["mp3"]
       build_port('sdl2_mixer')
-      shared.Settings.SDL2_MIXER_FORMATS = old_formats
+      settings.SDL2_MIXER_FORMATS = old_formats
     elif what == 'freetype':
       build_port('freetype')
     elif what == 'harfbuzz':
       build_port('harfbuzz')
     elif what == 'harfbuzz-mt':
-      shared.Settings.USE_PTHREADS = 1
+      settings.USE_PTHREADS = 1
       build_port('harfbuzz')
-      shared.Settings.USE_PTHREADS = 0
+      settings.USE_PTHREADS = 0
     elif what == 'sdl2-ttf':
       build_port('sdl2_ttf')
     elif what == 'cocos2d':
@@ -254,9 +255,9 @@ def main():
     elif what == 'regal':
       build_port('regal')
     elif what == 'regal-mt':
-      shared.Settings.USE_PTHREADS = 1
+      settings.USE_PTHREADS = 1
       build_port('regal')
-      shared.Settings.USE_PTHREADS = 0
+      settings.USE_PTHREADS = 0
     elif what == 'boost_headers':
       build_port('boost_headers')
     elif what == 'mpg123':

--- a/emcc.py
+++ b/emcc.py
@@ -51,7 +51,7 @@ from tools import js_manipulation
 from tools import wasm2c
 from tools import webassembly
 from tools import config
-from tools import settings
+from tools.settings import settings
 
 if __name__ == '__main__':
   ToolchainProfiler.record_process_start()
@@ -267,48 +267,48 @@ class EmccOptions:
 def will_metadce():
   # The metadce JS parsing code does not currently support the JS that gets generated
   # when assertions are enabled.
-  if shared.Settings.ASSERTIONS:
+  if settings.ASSERTIONS:
     return False
-  return shared.Settings.OPT_LEVEL >= 3 or shared.Settings.SHRINK_LEVEL >= 1
+  return settings.OPT_LEVEL >= 3 or settings.SHRINK_LEVEL >= 1
 
 
 def setup_environment_settings():
   # Environment setting based on user input
-  environments = shared.Settings.ENVIRONMENT.split(',')
+  environments = settings.ENVIRONMENT.split(',')
   if any([x for x in environments if x not in VALID_ENVIRONMENTS]):
-    exit_with_error('Invalid environment specified in "ENVIRONMENT": ' + shared.Settings.ENVIRONMENT + '. Should be one of: ' + ','.join(VALID_ENVIRONMENTS))
+    exit_with_error('Invalid environment specified in "ENVIRONMENT": ' + settings.ENVIRONMENT + '. Should be one of: ' + ','.join(VALID_ENVIRONMENTS))
 
-  shared.Settings.ENVIRONMENT_MAY_BE_WEB = not shared.Settings.ENVIRONMENT or 'web' in environments
-  shared.Settings.ENVIRONMENT_MAY_BE_WEBVIEW = not shared.Settings.ENVIRONMENT or 'webview' in environments
-  shared.Settings.ENVIRONMENT_MAY_BE_NODE = not shared.Settings.ENVIRONMENT or 'node' in environments
-  shared.Settings.ENVIRONMENT_MAY_BE_SHELL = not shared.Settings.ENVIRONMENT or 'shell' in environments
+  settings.ENVIRONMENT_MAY_BE_WEB = not settings.ENVIRONMENT or 'web' in environments
+  settings.ENVIRONMENT_MAY_BE_WEBVIEW = not settings.ENVIRONMENT or 'webview' in environments
+  settings.ENVIRONMENT_MAY_BE_NODE = not settings.ENVIRONMENT or 'node' in environments
+  settings.ENVIRONMENT_MAY_BE_SHELL = not settings.ENVIRONMENT or 'shell' in environments
 
   # The worker case also includes Node.js workers when pthreads are
   # enabled and Node.js is one of the supported environments for the build to
   # run on. Node.js workers are detected as a combination of
   # ENVIRONMENT_IS_WORKER and ENVIRONMENT_IS_NODE.
-  shared.Settings.ENVIRONMENT_MAY_BE_WORKER = \
-      not shared.Settings.ENVIRONMENT or \
+  settings.ENVIRONMENT_MAY_BE_WORKER = \
+      not settings.ENVIRONMENT or \
       'worker' in environments or \
-      (shared.Settings.ENVIRONMENT_MAY_BE_NODE and shared.Settings.USE_PTHREADS)
+      (settings.ENVIRONMENT_MAY_BE_NODE and settings.USE_PTHREADS)
 
-  if not shared.Settings.ENVIRONMENT_MAY_BE_WORKER and shared.Settings.PROXY_TO_WORKER:
+  if not settings.ENVIRONMENT_MAY_BE_WORKER and settings.PROXY_TO_WORKER:
     exit_with_error('If you specify --proxy-to-worker and specify a "-s ENVIRONMENT=" directive, it must include "worker" as a target! (Try e.g. -s ENVIRONMENT=web,worker)')
 
-  if not shared.Settings.ENVIRONMENT_MAY_BE_WORKER and shared.Settings.USE_PTHREADS:
+  if not settings.ENVIRONMENT_MAY_BE_WORKER and settings.USE_PTHREADS:
     exit_with_error('When building with multithreading enabled and a "-s ENVIRONMENT=" directive is specified, it must include "worker" as a target! (Try e.g. -s ENVIRONMENT=web,worker)')
 
 
 def minify_whitespace():
-  return shared.Settings.OPT_LEVEL >= 2 and shared.Settings.DEBUG_LEVEL == 0
+  return settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL == 0
 
 
 def embed_memfile():
-  return (shared.Settings.SINGLE_FILE or
-          (shared.Settings.MEM_INIT_METHOD == 0 and
-           (not shared.Settings.MAIN_MODULE and
-            not shared.Settings.SIDE_MODULE and
-            not shared.Settings.GENERATE_SOURCE_MAP)))
+  return (settings.SINGLE_FILE or
+          (settings.MEM_INIT_METHOD == 0 and
+           (not settings.MAIN_MODULE and
+            not settings.SIDE_MODULE and
+            not settings.GENERATE_SOURCE_MAP)))
 
 
 def expand_byte_size_suffixes(value):
@@ -329,7 +329,7 @@ def expand_byte_size_suffixes(value):
 
 def apply_settings(changes):
   """Take a map of users settings {NAME: VALUE} and apply them to the global
-  Settings object.
+  settings object.
   """
 
   def standardize_setting_change(key, value):
@@ -367,7 +367,7 @@ def apply_settings(changes):
     else:
       value = value.replace('\\', '\\\\')
 
-    existing = getattr(shared.Settings, user_key, None)
+    existing = getattr(settings, user_key, None)
     expect_list = type(existing) == list
 
     try:
@@ -382,15 +382,15 @@ def apply_settings(changes):
     if expect_list != (type(value) == list):
       exit_with_error('setting `%s` expects `%s` but got `%s`' % (user_key, type(existing), type(value)))
 
-    setattr(shared.Settings, user_key, value)
+    setattr(settings, user_key, value)
 
     if key == 'EXPORTED_FUNCTIONS':
       # used for warnings in emscripten.py
-      shared.Settings.USER_EXPORTED_FUNCTIONS = shared.Settings.EXPORTED_FUNCTIONS.copy()
+      settings.USER_EXPORTED_FUNCTIONS = settings.EXPORTED_FUNCTIONS.copy()
 
     # TODO(sbc): Remove this legacy way.
     if key == 'WASM_OBJECT_FILES':
-      shared.Settings.LTO = 0 if value else 'full'
+      settings.LTO = 0 if value else 'full'
 
 
 def is_ar_file_with_missing_index(archive_file):
@@ -417,7 +417,7 @@ def is_ar_file_with_missing_index(archive_file):
 
 def ensure_archive_index(archive_file):
   # Fastcomp linking works without archive indexes.
-  if not shared.Settings.AUTO_ARCHIVE_INDEXES:
+  if not settings.AUTO_ARCHIVE_INDEXES:
     return
   if is_ar_file_with_missing_index(archive_file):
     diagnostics.warning('emcc', '%s: archive is missing an index; Use emar when creating libraries to ensure an index is created', archive_file)
@@ -432,12 +432,12 @@ def get_all_js_syms():
   # TODO(sbc): Find a way to optimize this.  Potentially we could add a super-set
   # mode of the js compiler that would generate a list of all possible symbols
   # that could be checked in.
-  old_full = shared.Settings.INCLUDE_FULL_LIBRARY
+  old_full = settings.INCLUDE_FULL_LIBRARY
   try:
     # Temporarily define INCLUDE_FULL_LIBRARY since we want a full list
     # of all available JS library functions.
-    shared.Settings.INCLUDE_FULL_LIBRARY = True
-    shared.Settings.ONLY_CALC_JS_SYMBOLS = True
+    settings.INCLUDE_FULL_LIBRARY = True
+    settings.ONLY_CALC_JS_SYMBOLS = True
     emscripten.generate_struct_info()
     glue, forwarded_data = emscripten.compile_settings()
     forwarded_json = json.loads(forwarded_data)
@@ -448,8 +448,8 @@ def get_all_js_syms():
         name = shared.demangle_c_symbol_name(name)
         library_fns_list.append(name)
   finally:
-    shared.Settings.ONLY_CALC_JS_SYMBOLS = False
-    shared.Settings.INCLUDE_FULL_LIBRARY = old_full
+    settings.ONLY_CALC_JS_SYMBOLS = False
+    settings.INCLUDE_FULL_LIBRARY = old_full
 
   return library_fns_list
 
@@ -506,50 +506,50 @@ def get_binaryen_passes():
   # great majority of the work; not running the binaryen optimizer in that case
   # keeps -O1 mostly-optimized while compiling quickly and without rewriting
   # DWARF etc.
-  run_binaryen_optimizer = shared.Settings.OPT_LEVEL >= 2
+  run_binaryen_optimizer = settings.OPT_LEVEL >= 2
 
   passes = []
   # safe heap must run before post-emscripten, so post-emscripten can apply the sbrk ptr
-  if shared.Settings.SAFE_HEAP:
+  if settings.SAFE_HEAP:
     passes += ['--safe-heap']
-  if shared.Settings.MEMORY64 == 2:
+  if settings.MEMORY64 == 2:
     passes += ['--memory64-lowering']
   if run_binaryen_optimizer:
     passes += ['--post-emscripten']
-    if not shared.Settings.EXIT_RUNTIME:
+    if not settings.EXIT_RUNTIME:
       passes += ['--no-exit-runtime']
   if run_binaryen_optimizer:
-    passes += [building.opt_level_to_str(shared.Settings.OPT_LEVEL, shared.Settings.SHRINK_LEVEL)]
-  elif shared.Settings.STANDALONE_WASM:
+    passes += [building.opt_level_to_str(settings.OPT_LEVEL, settings.SHRINK_LEVEL)]
+  elif settings.STANDALONE_WASM:
     # even if not optimizing, make an effort to remove all unused imports and
     # exports, to make the wasm as standalone as possible
     passes += ['--remove-unused-module-elements']
   # when optimizing, use the fact that low memory is never used (1024 is a
   # hardcoded value in the binaryen pass)
-  if run_binaryen_optimizer and shared.Settings.GLOBAL_BASE >= 1024:
+  if run_binaryen_optimizer and settings.GLOBAL_BASE >= 1024:
     passes += ['--low-memory-unused']
-  if shared.Settings.AUTODEBUG:
+  if settings.AUTODEBUG:
     # adding '--flatten' here may make these even more effective
     passes += ['--instrument-locals']
     passes += ['--log-execution']
     passes += ['--instrument-memory']
-    if shared.Settings.LEGALIZE_JS_FFI:
+    if settings.LEGALIZE_JS_FFI:
       # legalize it again now, as the instrumentation may need it
       passes += ['--legalize-js-interface']
-  if shared.Settings.EMULATE_FUNCTION_POINTER_CASTS:
+  if settings.EMULATE_FUNCTION_POINTER_CASTS:
     # note that this pass must run before asyncify, as if it runs afterwards we only
     # generate the  byn$fpcast_emu  functions after asyncify runs, and so we wouldn't
     # be able to further process them.
     passes += ['--fpcast-emu']
-  if shared.Settings.ASYNCIFY:
+  if settings.ASYNCIFY:
     passes += ['--asyncify']
-    if shared.Settings.ASSERTIONS:
+    if settings.ASSERTIONS:
       passes += ['--pass-arg=asyncify-asserts']
-    if shared.Settings.ASYNCIFY_ADVISE:
+    if settings.ASYNCIFY_ADVISE:
       passes += ['--pass-arg=asyncify-verbose']
-    if shared.Settings.ASYNCIFY_IGNORE_INDIRECT:
+    if settings.ASYNCIFY_IGNORE_INDIRECT:
       passes += ['--pass-arg=asyncify-ignore-indirect']
-    passes += ['--pass-arg=asyncify-imports@%s' % ','.join(shared.Settings.ASYNCIFY_IMPORTS)]
+    passes += ['--pass-arg=asyncify-imports@%s' % ','.join(settings.ASYNCIFY_IMPORTS)]
 
     # shell escaping can be confusing; try to emit useful warnings
     def check_human_readable_list(items):
@@ -561,16 +561,16 @@ def get_binaryen_passes():
           logger.warning('''Try to quote the entire argument, like this: -s 'ASYNCIFY_ONLY=["foo(int, char)", "bar"]' ''')
           break
 
-    if shared.Settings.ASYNCIFY_REMOVE:
-      check_human_readable_list(shared.Settings.ASYNCIFY_REMOVE)
-      passes += ['--pass-arg=asyncify-removelist@%s' % ','.join(shared.Settings.ASYNCIFY_REMOVE)]
-    if shared.Settings.ASYNCIFY_ADD:
-      check_human_readable_list(shared.Settings.ASYNCIFY_ADD)
-      passes += ['--pass-arg=asyncify-addlist@%s' % ','.join(shared.Settings.ASYNCIFY_ADD)]
-    if shared.Settings.ASYNCIFY_ONLY:
-      check_human_readable_list(shared.Settings.ASYNCIFY_ONLY)
-      passes += ['--pass-arg=asyncify-onlylist@%s' % ','.join(shared.Settings.ASYNCIFY_ONLY)]
-  if shared.Settings.BINARYEN_IGNORE_IMPLICIT_TRAPS:
+    if settings.ASYNCIFY_REMOVE:
+      check_human_readable_list(settings.ASYNCIFY_REMOVE)
+      passes += ['--pass-arg=asyncify-removelist@%s' % ','.join(settings.ASYNCIFY_REMOVE)]
+    if settings.ASYNCIFY_ADD:
+      check_human_readable_list(settings.ASYNCIFY_ADD)
+      passes += ['--pass-arg=asyncify-addlist@%s' % ','.join(settings.ASYNCIFY_ADD)]
+    if settings.ASYNCIFY_ONLY:
+      check_human_readable_list(settings.ASYNCIFY_ONLY)
+      passes += ['--pass-arg=asyncify-onlylist@%s' % ','.join(settings.ASYNCIFY_ONLY)]
+  if settings.BINARYEN_IGNORE_IMPLICIT_TRAPS:
     passes += ['--ignore-implicit-traps']
   # normally we can assume the memory, if imported, has not been modified
   # beforehand (in fact, in most cases the memory is not even imported anyhow,
@@ -578,13 +578,13 @@ def get_binaryen_passes():
   # the one exception is dynamic linking of a side module: the main module is ok
   # as it is loaded first, but the side module may be assigned memory that was
   # previously used.
-  if run_binaryen_optimizer and not shared.Settings.SIDE_MODULE:
+  if run_binaryen_optimizer and not settings.SIDE_MODULE:
     passes += ['--zero-filled-memory']
 
-  if shared.Settings.BINARYEN_EXTRA_PASSES:
+  if settings.BINARYEN_EXTRA_PASSES:
     # BINARYEN_EXTRA_PASSES is comma-separated, and we support both '-'-prefixed and
     # unprefixed pass names
-    extras = shared.Settings.BINARYEN_EXTRA_PASSES.split(',')
+    extras = settings.BINARYEN_EXTRA_PASSES.split(',')
     passes += [('--' + p) if p[0] != '-' else p for p in extras if p]
 
   return passes
@@ -635,8 +635,8 @@ def process_dynamic_libs(dylibs):
         continue
       new_exports.append(imp.field)
     logger.debug('Adding exports based on `%s`: %s', dylib, new_exports)
-    shared.Settings.EXPORTED_FUNCTIONS.extend(shared.asmjs_mangle(e) for e in new_exports)
-    shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.extend(new_exports)
+    settings.EXPORTED_FUNCTIONS.extend(shared.asmjs_mangle(e) for e in new_exports)
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.extend(new_exports)
 
 
 def unmangle_symbols_from_cmdline(symbols):
@@ -742,7 +742,7 @@ def get_clang_flags():
 
 
 def get_llvm_target():
-  if shared.Settings.MEMORY64:
+  if settings.MEMORY64:
     return 'wasm64-unknown-emscripten'
   else:
     return 'wasm32-unknown-emscripten'
@@ -763,28 +763,28 @@ def get_cflags(options, user_args):
   if options.tracing:
     cflags.append('-D__EMSCRIPTEN_TRACING__=1')
 
-  if shared.Settings.USE_PTHREADS:
+  if settings.USE_PTHREADS:
     cflags.append('-D__EMSCRIPTEN_PTHREADS__=1')
 
-  if not shared.Settings.STRICT:
+  if not settings.STRICT:
     # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
     # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
     cflags.append('-DEMSCRIPTEN')
 
   # if exception catching is disabled, we can prevent that code from being
   # generated in the frontend
-  if shared.Settings.DISABLE_EXCEPTION_CATCHING and not shared.Settings.EXCEPTION_HANDLING:
+  if settings.DISABLE_EXCEPTION_CATCHING and not settings.EXCEPTION_HANDLING:
     cflags.append('-fignore-exceptions')
 
-  if shared.Settings.INLINING_LIMIT:
+  if settings.INLINING_LIMIT:
     cflags.append('-fno-inline-functions')
 
-  if shared.Settings.RELOCATABLE:
+  if settings.RELOCATABLE:
     cflags.append('-fPIC')
     cflags.append('-fvisibility=default')
 
-  if shared.Settings.LTO:
-    cflags.append('-flto=' + shared.Settings.LTO)
+  if settings.LTO:
+    cflags.append('-flto=' + settings.LTO)
   else:
     # With LTO mode these args get passed instead
     # at link time when the backend runs.
@@ -813,7 +813,7 @@ def get_cflags(options, user_args):
   #   -Wno-implicit-function-declaration
   cflags += ['-Werror=implicit-function-declaration']
 
-  system_libs.add_ports_cflags(cflags, shared.Settings)
+  system_libs.add_ports_cflags(cflags, settings)
 
   if os.environ.get('EMMAKEN_NO_SDK') or '-nostdinc' in user_args:
     return cflags
@@ -1011,24 +1011,24 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       options.pre_js += open(shared.path_from_root('src', 'emrun_prejs.js')).read() + '\n'
       options.post_js += open(shared.path_from_root('src', 'emrun_postjs.js')).read() + '\n'
       # emrun mode waits on program exit
-      shared.Settings.EXIT_RUNTIME = 1
+      settings.EXIT_RUNTIME = 1
 
     if options.cpu_profiler:
       options.post_js += open(shared.path_from_root('src', 'cpuprofiler.js')).read() + '\n'
 
     if options.memory_profiler:
-      shared.Settings.MEMORYPROFILER = 1
+      settings.MEMORYPROFILER = 1
 
     if options.thread_profiler:
       options.post_js += open(shared.path_from_root('src', 'threadprofiler.js')).read() + '\n'
 
     if options.memory_init_file is None:
-      options.memory_init_file = shared.Settings.OPT_LEVEL >= 2
+      options.memory_init_file = settings.OPT_LEVEL >= 2
 
     # TODO: support source maps with js_transform
-    if options.js_transform and shared.Settings.GENERATE_SOURCE_MAP:
+    if options.js_transform and settings.GENERATE_SOURCE_MAP:
       logger.warning('disabling source maps because a js transform is being done')
-      shared.Settings.GENERATE_SOURCE_MAP = 0
+      settings.GENERATE_SOURCE_MAP = 0
 
     explicit_settings_changes, newargs = parse_s_args(newargs)
     settings_changes += explicit_settings_changes
@@ -1143,23 +1143,23 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     strict_cmdline = settings_map.get('STRICT')
     if strict_cmdline:
-      shared.Settings.STRICT = int(strict_cmdline)
+      settings.STRICT = int(strict_cmdline)
 
     # Apply optimization level settings
 
-    if shared.Settings.OPT_LEVEL >= 1:
-      shared.Settings.ASSERTIONS = 0
-    if shared.Settings.SHRINK_LEVEL >= 2:
-      shared.Settings.EVAL_CTORS = 1
+    if settings.OPT_LEVEL >= 1:
+      settings.ASSERTIONS = 0
+    if settings.SHRINK_LEVEL >= 2:
+      settings.EVAL_CTORS = 1
 
     # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also
     # want to opt out of ERROR_ON_UNDEFINED_SYMBOLS.
     if settings_map.get('WARN_ON_UNDEFINED_SYMBOLS') == '0':
-      shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
+      settings.ERROR_ON_UNDEFINED_SYMBOLS = 0
 
-    if shared.Settings.MINIMAL_RUNTIME or settings_map.get('MINIMAL_RUNTIME') in ('1', '2'):
+    if settings.MINIMAL_RUNTIME or settings_map.get('MINIMAL_RUNTIME') in ('1', '2'):
       # Remove the default exported functions 'malloc', 'free', etc. those should only be linked in if used
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
 
     # Apply -s settings in newargs here (after optimization levels, so they can override them)
     apply_settings(settings_map)
@@ -1168,14 +1168,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     if os.environ.get('EMMAKEN_JUST_CONFIGURE') or 'conftest.c' in args:
       # configure tests want a more shell-like style, where we emit return codes on exit()
-      shared.Settings.EXIT_RUNTIME = 1
+      settings.EXIT_RUNTIME = 1
       # use node.js raw filesystem access, to behave just like a native executable
-      shared.Settings.NODERAWFS = 1
+      settings.NODERAWFS = 1
       # Add `#!` line to output JS and make it executable.
       options.executable = True
       # Autoconf expects the executable output file to be called `a.out`
       default_target_name = 'a.out'
-    elif shared.Settings.SIDE_MODULE:
+    elif settings.SIDE_MODULE:
       default_target_name = 'a.out.wasm'
     else:
       default_target_name = 'a.out.js'
@@ -1193,11 +1193,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     else:
       target = default_target_name
 
-    shared.Settings.TARGET_BASENAME = target_basename = unsuffixed_basename(target)
+    settings.TARGET_BASENAME = target_basename = unsuffixed_basename(target)
 
-    if shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS:
+    if settings.EXTRA_EXPORTED_RUNTIME_METHODS:
       diagnostics.warning('deprecated', 'EXTRA_EXPORTED_RUNTIME_METHODS is deprecated, please use EXPORTED_RUNTIME_METHODS instead')
-      shared.Settings.EXPORTED_RUNTIME_METHODS += shared.Settings.EXTRA_EXPORTED_RUNTIME_METHODS
+      settings.EXPORTED_RUNTIME_METHODS += settings.EXTRA_EXPORTED_RUNTIME_METHODS
 
     final_suffix = get_file_suffix(target)
 
@@ -1222,7 +1222,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # If no output format was sepecific we try to imply the format based on
     # the output filename extension.
     if not options.oformat:
-      if shared.Settings.SIDE_MODULE or final_suffix == '.wasm':
+      if settings.SIDE_MODULE or final_suffix == '.wasm':
         options.oformat = OFormat.WASM
       elif final_suffix == '.mjs':
         options.oformat = OFormat.MJS
@@ -1232,8 +1232,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         options.oformat = OFormat.JS
 
     if options.oformat == OFormat.MJS:
-      shared.Settings.EXPORT_ES6 = 1
-      shared.Settings.MODULARIZE = 1
+      settings.EXPORT_ES6 = 1
+      settings.MODULARIZE = 1
 
     if options.oformat in (OFormat.WASM, OFormat.BARE):
       # If the user asks directly for a wasm file then this *is* the target
@@ -1244,34 +1244,34 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
 
     # Apply user -jsD settings
     for s in user_js_defines:
-      shared.Settings[s[0]] = s[1]
+      settings[s[0]] = s[1]
 
     shared.verify_settings()
 
-    if (options.oformat == OFormat.WASM or shared.Settings.PURE_WASI) and not shared.Settings.SIDE_MODULE:
+    if (options.oformat == OFormat.WASM or settings.PURE_WASI) and not settings.SIDE_MODULE:
       # if the output is just a wasm file, it will normally be a standalone one,
       # as there is no JS. an exception are side modules, as we can't tell at
       # compile time whether JS will be involved or not - the main module may
       # have JS, and the side module is expected to link against that.
       # we also do not support standalone mode in fastcomp.
-      shared.Settings.STANDALONE_WASM = 1
+      settings.STANDALONE_WASM = 1
 
-    if shared.Settings.LZ4:
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['LZ4']
+    if settings.LZ4:
+      settings.EXPORTED_RUNTIME_METHODS += ['LZ4']
 
-    if shared.Settings.WASM2C:
+    if settings.WASM2C:
       # wasm2c only makes sense with standalone wasm - there will be no JS,
       # just wasm and then C
-      shared.Settings.STANDALONE_WASM = 1
+      settings.STANDALONE_WASM = 1
       # wasm2c doesn't need any special handling of i64, we have proper i64
       # handling on the FFI boundary, which is exactly like the case of JS with
       # BigInt support
-      shared.Settings.WASM_BIGINT = 1
+      settings.WASM_BIGINT = 1
 
     if options.no_entry:
-      shared.Settings.EXPECT_MAIN = 0
-    elif shared.Settings.STANDALONE_WASM:
-      if '_main' in shared.Settings.EXPORTED_FUNCTIONS:
+      settings.EXPECT_MAIN = 0
+    elif settings.STANDALONE_WASM:
+      if '_main' in settings.EXPORTED_FUNCTIONS:
         # TODO(sbc): Make this into a warning?
         logger.debug('including `_main` in EXPORTED_FUNCTIONS is not necessary in standalone mode')
     else:
@@ -1281,20 +1281,20 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # 2. If the user doesn't export anything we default to exporting `_main` (unless `--no-entry`
       #    is specified (see above).
       if 'EXPORTED_FUNCTIONS' in settings_map:
-        if '_main' not in shared.Settings.USER_EXPORTED_FUNCTIONS:
-          shared.Settings.EXPECT_MAIN = 0
+        if '_main' not in settings.USER_EXPORTED_FUNCTIONS:
+          settings.EXPECT_MAIN = 0
       else:
-        assert not shared.Settings.EXPORTED_FUNCTIONS
-        shared.Settings.EXPORTED_FUNCTIONS = ['_main']
+        assert not settings.EXPORTED_FUNCTIONS
+        settings.EXPORTED_FUNCTIONS = ['_main']
 
-    if shared.Settings.STANDALONE_WASM:
+    if settings.STANDALONE_WASM:
       # In STANDALONE_WASM mode we either build a command or a reactor.
       # See https://github.com/WebAssembly/WASI/blob/main/design/application-abi.md
       # For a command we always want EXIT_RUNTIME=1
       # For a reactor we always want EXIT_RUNTIME=0
       if 'EXIT_RUNTIME' in settings_map:
         exit_with_error('Explictly setting EXIT_RUNTIME not compatible with STANDALONE_WASM.  EXIT_RUNTIME will always be True for programs (with a main function) and False for reactors (not main function).')
-      shared.Settings.EXIT_RUNTIME = shared.Settings.EXPECT_MAIN
+      settings.EXIT_RUNTIME = settings.EXPECT_MAIN
 
     def filter_out_dynamic_libs(inputs):
       # If not compiling to JS, then we are compiling to an intermediate bitcode
@@ -1328,7 +1328,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     input_files = filter_out_dynamic_libs(input_files)
     input_files = filter_out_duplicate_dynamic_libs(input_files)
 
-    if shared.Settings.MAIN_MODULE:
+    if settings.MAIN_MODULE:
       dylibs = [i[1] for i in input_files if get_file_suffix(i[1]) in DYNAMICLIB_ENDINGS]
       process_dynamic_libs(dylibs)
 
@@ -1336,33 +1336,33 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       exit_with_error('no input files')
 
     # Note the exports the user requested
-    building.user_requested_exports = shared.Settings.EXPORTED_FUNCTIONS.copy()
+    building.user_requested_exports = settings.EXPORTED_FUNCTIONS.copy()
 
     def default_setting(name, new_default):
       if name not in settings_map:
-        setattr(shared.Settings, name, new_default)
+        setattr(settings, name, new_default)
 
     # -s ASSERTIONS=1 implies basic stack overflow checks, and ASSERTIONS=2
     # implies full stack overflow checks.
-    if shared.Settings.ASSERTIONS:
+    if settings.ASSERTIONS:
       # However, we don't set this default in PURE_WASI, or when we are linking without standard
       # libraries because STACK_OVERFLOW_CHECK depends on emscripten_stack_get_end which is defined
       # in libcompiler-rt.
-      if not shared.Settings.PURE_WASI and '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
-        default_setting('STACK_OVERFLOW_CHECK', max(shared.Settings.ASSERTIONS, shared.Settings.STACK_OVERFLOW_CHECK))
+      if not settings.PURE_WASI and '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
+        default_setting('STACK_OVERFLOW_CHECK', max(settings.ASSERTIONS, settings.STACK_OVERFLOW_CHECK))
 
-    if shared.Settings.LLD_REPORT_UNDEFINED or shared.Settings.STANDALONE_WASM:
+    if settings.LLD_REPORT_UNDEFINED or settings.STANDALONE_WASM:
       # Reporting undefined symbols at wasm-ld time requires us to know if we have a `main` function
       # or not, as does standalone wasm mode.
       # TODO(sbc): Remove this once this becomes the default
-      shared.Settings.IGNORE_MISSING_MAIN = 0
+      settings.IGNORE_MISSING_MAIN = 0
 
     # It is unlikely that developers targeting "native web" APIs with MINIMAL_RUNTIME need
     # errno support by default.
-    if shared.Settings.MINIMAL_RUNTIME:
+    if settings.MINIMAL_RUNTIME:
       default_setting('SUPPORT_ERRNO', 0)
 
-    if shared.Settings.STRICT:
+    if settings.STRICT:
       default_setting('STRICT_JS', 1)
       default_setting('AUTO_JS_LIBRARIES', 0)
       default_setting('AUTO_NATIVE_LIBRARIES', 0)
@@ -1376,8 +1376,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # https://github.com/whatwg/encoding/issues/172
     # When supporting shell environments, do not do this as TextDecoder is not
     # widely supported there.
-    if shared.Settings.SHRINK_LEVEL >= 2 and not shared.Settings.USE_PTHREADS and \
-       not shared.Settings.ENVIRONMENT_MAY_BE_SHELL:
+    if settings.SHRINK_LEVEL >= 2 and not settings.USE_PTHREADS and \
+       not settings.ENVIRONMENT_MAY_BE_SHELL:
       default_setting('TEXTDECODER', 2)
 
     # If set to 1, we will run the autodebugger (the automatic debugging tool, see
@@ -1385,61 +1385,61 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # is useful because including dlmalloc makes it hard to compare native and js
     # builds
     if os.environ.get('EMCC_AUTODEBUG'):
-      shared.Settings.AUTODEBUG = 1
+      settings.AUTODEBUG = 1
 
     # Use settings
 
-    if shared.Settings.DEBUG_LEVEL > 1 and options.use_closure_compiler:
+    if settings.DEBUG_LEVEL > 1 and options.use_closure_compiler:
       diagnostics.warning('emcc', 'disabling closure because debug info was requested')
       options.use_closure_compiler = False
 
-    if shared.Settings.WASM == 2 and shared.Settings.SINGLE_FILE:
+    if settings.WASM == 2 and settings.SINGLE_FILE:
       exit_with_error('cannot have both WASM=2 and SINGLE_FILE enabled at the same time')
 
-    if shared.Settings.SEPARATE_DWARF and shared.Settings.WASM2JS:
+    if settings.SEPARATE_DWARF and settings.WASM2JS:
       exit_with_error('cannot have both SEPARATE_DWARF and WASM2JS at the same time (as there is no wasm file)')
 
-    if shared.Settings.MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and shared.Settings.MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION:
+    if settings.MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and settings.MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION:
       exit_with_error('MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION are mutually exclusive!')
 
     if options.emrun:
-      if shared.Settings.MINIMAL_RUNTIME:
+      if settings.MINIMAL_RUNTIME:
         exit_with_error('--emrun is not compatible with -s MINIMAL_RUNTIME=1')
-      shared.Settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
+      settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
 
     if options.use_closure_compiler:
-      shared.Settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
+      settings.USE_CLOSURE_COMPILER = options.use_closure_compiler
 
-    if shared.Settings.CLOSURE_WARNINGS not in ['quiet', 'warn', 'error']:
-      exit_with_error('Invalid option -s CLOSURE_WARNINGS=%s specified! Allowed values are "quiet", "warn" or "error".' % shared.Settings.CLOSURE_WARNINGS)
+    if settings.CLOSURE_WARNINGS not in ['quiet', 'warn', 'error']:
+      exit_with_error('Invalid option -s CLOSURE_WARNINGS=%s specified! Allowed values are "quiet", "warn" or "error".' % settings.CLOSURE_WARNINGS)
 
     # Include dynCall() function by default in DYNCALLS builds in classic runtime; in MINIMAL_RUNTIME, must add this explicitly.
-    if shared.Settings.DYNCALLS and not shared.Settings.MINIMAL_RUNTIME:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$dynCall']
+    if settings.DYNCALLS and not settings.MINIMAL_RUNTIME:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$dynCall']
 
-    if shared.Settings.MAIN_MODULE:
-      assert not shared.Settings.SIDE_MODULE
-      if shared.Settings.MAIN_MODULE == 1:
-        shared.Settings.INCLUDE_FULL_LIBRARY = 1
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$preloadDylibs']
-    elif shared.Settings.SIDE_MODULE:
-      assert not shared.Settings.MAIN_MODULE
+    if settings.MAIN_MODULE:
+      assert not settings.SIDE_MODULE
+      if settings.MAIN_MODULE == 1:
+        settings.INCLUDE_FULL_LIBRARY = 1
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$preloadDylibs']
+    elif settings.SIDE_MODULE:
+      assert not settings.MAIN_MODULE
       # memory init file is not supported with side modules, must be executable synchronously (for dlopen)
       options.memory_init_file = False
 
     # If we are including the entire JS library then we know for sure we will, by definition,
     # require all the reverse dependencies.
-    if shared.Settings.INCLUDE_FULL_LIBRARY:
+    if settings.INCLUDE_FULL_LIBRARY:
       default_setting('REVERSE_DEPS', 'all')
 
-    if shared.Settings.MAIN_MODULE or shared.Settings.SIDE_MODULE:
-      if shared.Settings.MAIN_MODULE == 1 or shared.Settings.SIDE_MODULE == 1:
-        shared.Settings.LINKABLE = 1
-        shared.Settings.EXPORT_ALL = 1
-      shared.Settings.RELOCATABLE = 1
+    if settings.MAIN_MODULE or settings.SIDE_MODULE:
+      if settings.MAIN_MODULE == 1 or settings.SIDE_MODULE == 1:
+        settings.LINKABLE = 1
+        settings.EXPORT_ALL = 1
+      settings.RELOCATABLE = 1
 
-    if shared.Settings.RELOCATABLE:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+    if settings.RELOCATABLE:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
           '$reportUndefinedSymbols',
           '$relocateExports',
           '$GOTHandler',
@@ -1449,43 +1449,43 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       ]
       # This needs to be exported on the Module object too so it's visible
       # to side modules too.
-      shared.Settings.EXPORTED_FUNCTIONS += ['___heap_base']
-      if shared.Settings.MINIMAL_RUNTIME:
+      settings.EXPORTED_FUNCTIONS += ['___heap_base']
+      if settings.MINIMAL_RUNTIME:
         exit_with_error('MINIMAL_RUNTIME is not compatible with relocatable output')
-      if shared.Settings.WASM2JS:
+      if settings.WASM2JS:
         exit_with_error('WASM2JS is not compatible with relocatable output')
       # shared modules need memory utilities to allocate their memory
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['allocate']
-      shared.Settings.ALLOW_TABLE_GROWTH = 1
+      settings.EXPORTED_RUNTIME_METHODS += ['allocate']
+      settings.ALLOW_TABLE_GROWTH = 1
 
     # various settings require sbrk() access
-    if shared.Settings.DETERMINISTIC or \
-       shared.Settings.EMSCRIPTEN_TRACING or \
-       shared.Settings.MALLOC == 'emmalloc' or \
-       shared.Settings.SAFE_HEAP or \
-       shared.Settings.MEMORYPROFILER:
-      shared.Settings.EXPORTED_FUNCTIONS += ['_sbrk']
+    if settings.DETERMINISTIC or \
+       settings.EMSCRIPTEN_TRACING or \
+       settings.MALLOC == 'emmalloc' or \
+       settings.SAFE_HEAP or \
+       settings.MEMORYPROFILER:
+      settings.EXPORTED_FUNCTIONS += ['_sbrk']
 
-    if shared.Settings.MEMORYPROFILER:
-      shared.Settings.EXPORTED_FUNCTIONS += ['___heap_base',
-                                             '_emscripten_stack_get_base',
-                                             '_emscripten_stack_get_end',
-                                             '_emscripten_stack_get_current']
+    if settings.MEMORYPROFILER:
+      settings.EXPORTED_FUNCTIONS += ['___heap_base',
+                                      '_emscripten_stack_get_base',
+                                      '_emscripten_stack_get_end',
+                                      '_emscripten_stack_get_current']
 
-    if shared.Settings.ASYNCIFY_LAZY_LOAD_CODE:
-      shared.Settings.ASYNCIFY = 1
+    if settings.ASYNCIFY_LAZY_LOAD_CODE:
+      settings.ASYNCIFY = 1
 
-    if shared.Settings.ASYNCIFY:
+    if settings.ASYNCIFY:
       # See: https://github.com/emscripten-core/emscripten/issues/12065
       # See: https://github.com/emscripten-core/emscripten/issues/12066
-      shared.Settings.DYNCALLS = 1
-      shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_base',
-                                             '_emscripten_stack_get_end',
-                                             '_emscripten_stack_set_limits']
+      settings.DYNCALLS = 1
+      settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_base',
+                                      '_emscripten_stack_get_end',
+                                      '_emscripten_stack_set_limits']
 
-    shared.Settings.ASYNCIFY_ADD = unmangle_symbols_from_cmdline(shared.Settings.ASYNCIFY_ADD)
-    shared.Settings.ASYNCIFY_REMOVE = unmangle_symbols_from_cmdline(shared.Settings.ASYNCIFY_REMOVE)
-    shared.Settings.ASYNCIFY_ONLY = unmangle_symbols_from_cmdline(shared.Settings.ASYNCIFY_ONLY)
+    settings.ASYNCIFY_ADD = unmangle_symbols_from_cmdline(settings.ASYNCIFY_ADD)
+    settings.ASYNCIFY_REMOVE = unmangle_symbols_from_cmdline(settings.ASYNCIFY_REMOVE)
+    settings.ASYNCIFY_ONLY = unmangle_symbols_from_cmdline(settings.ASYNCIFY_ONLY)
 
     # SSEx is implemented on top of SIMD128 instruction set, but do not pass SSE flags to LLVM
     # so it won't think about generating native x86 SSE code.
@@ -1504,8 +1504,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           diagnostics.warning('emcc', 'linking a library with `-shared` will emit a static object file.  This is a form of emulation to support existing build systems.  If you want to build a runtime shared library use the SIDE_MODULE setting.')
         link_to_object = True
 
-    if shared.Settings.SUPPORT_BIG_ENDIAN:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+    if settings.SUPPORT_BIG_ENDIAN:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
         '$LE_HEAP_STORE_U16',
         '$LE_HEAP_STORE_I16',
         '$LE_HEAP_STORE_U32',
@@ -1520,108 +1520,108 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         '$LE_HEAP_LOAD_F64'
       ]
 
-    if shared.Settings.STACK_OVERFLOW_CHECK:
+    if settings.STACK_OVERFLOW_CHECK:
       # The basic writeStackCookie/checkStackCookie mechanism just needs to know where the end
       # of the stack is.
-      shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_end', '_emscripten_stack_get_free']
-      if shared.Settings.STACK_OVERFLOW_CHECK == 2:
+      settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_end', '_emscripten_stack_get_free']
+      if settings.STACK_OVERFLOW_CHECK == 2:
         # The full checking done by binaryen's `StackCheck` pass also needs to know the base of the
         # stack.
-        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_base']
+        settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_base']
 
       # We call one of these two functions during startup which caches the stack limits
       # in wasm globals allowing get_base/get_free to be super fast.
       # See compiler-rt/stack_limits.S.
-      if shared.Settings.RELOCATABLE:
-        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_set_limits']
+      if settings.RELOCATABLE:
+        settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_set_limits']
       else:
-        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_init']
+        settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_init']
 
-    if shared.Settings.MODULARIZE:
-      if shared.Settings.PROXY_TO_WORKER:
+    if settings.MODULARIZE:
+      if settings.PROXY_TO_WORKER:
         exit_with_error('-s MODULARIZE=1 is not compatible with --proxy-to-worker (if you want to run in a worker with -s MODULARIZE=1, you likely want to do the worker side setup manually)')
       # in MINIMAL_RUNTIME we may not need to emit the Promise code, as the
       # HTML output creates a singleton instance, and it does so without the
       # Promise. However, in Pthreads mode the Promise is used for worker
       # creation.
-      if shared.Settings.MINIMAL_RUNTIME and options.oformat == OFormat.HTML and not shared.Settings.USE_PTHREADS:
-        shared.Settings.EXPORT_READY_PROMISE = 0
+      if settings.MINIMAL_RUNTIME and options.oformat == OFormat.HTML and not settings.USE_PTHREADS:
+        settings.EXPORT_READY_PROMISE = 0
 
-    if shared.Settings.LEGACY_VM_SUPPORT:
-      if shared.Settings.WASM2JS:
-        shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
+    if settings.LEGACY_VM_SUPPORT:
+      if settings.WASM2JS:
+        settings.POLYFILL_OLD_MATH_FUNCTIONS = 1
 
       # Support all old browser versions
-      shared.Settings.MIN_FIREFOX_VERSION = 0
-      shared.Settings.MIN_SAFARI_VERSION = 0
-      shared.Settings.MIN_IE_VERSION = 0
-      shared.Settings.MIN_EDGE_VERSION = 0
-      shared.Settings.MIN_CHROME_VERSION = 0
+      settings.MIN_FIREFOX_VERSION = 0
+      settings.MIN_SAFARI_VERSION = 0
+      settings.MIN_IE_VERSION = 0
+      settings.MIN_EDGE_VERSION = 0
+      settings.MIN_CHROME_VERSION = 0
 
-    if shared.Settings.MIN_CHROME_VERSION <= 37:
-      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
+    if settings.MIN_CHROME_VERSION <= 37:
+      settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 1
 
     setup_environment_settings()
 
     # Silently drop any individual backwards compatibility emulation flags that are known never to occur on browsers that support WebAssembly.
-    if not shared.Settings.WASM2JS:
-      shared.Settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
-      shared.Settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
+    if not settings.WASM2JS:
+      settings.POLYFILL_OLD_MATH_FUNCTIONS = 0
+      settings.WORKAROUND_OLD_WEBGL_UNIFORM_UPLOAD_IGNORED_OFFSET_BUG = 0
 
     forced_stdlibs = []
 
-    if shared.Settings.STB_IMAGE and final_suffix in EXECUTABLE_ENDINGS:
+    if settings.STB_IMAGE and final_suffix in EXECUTABLE_ENDINGS:
       forced_stdlibs.append('libstb_image')
-      shared.Settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
+      settings.EXPORTED_FUNCTIONS += ['_stbi_load', '_stbi_load_from_memory', '_stbi_image_free']
 
-    if shared.Settings.USE_WEBGL2:
-      shared.Settings.MAX_WEBGL_VERSION = 2
+    if settings.USE_WEBGL2:
+      settings.MAX_WEBGL_VERSION = 2
 
-    if not shared.Settings.GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS and shared.Settings.GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS:
+    if not settings.GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS and settings.GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS:
       exit_with_error('-s GL_SUPPORT_SIMPLE_ENABLE_EXTENSIONS=0 only makes sense with -s GL_SUPPORT_AUTOMATIC_ENABLE_EXTENSIONS=0!')
 
-    if shared.Settings.ASMFS and final_suffix in EXECUTABLE_ENDINGS:
+    if settings.ASMFS and final_suffix in EXECUTABLE_ENDINGS:
       forced_stdlibs.append('libasmfs')
-      shared.Settings.FILESYSTEM = 0
-      shared.Settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
-      shared.Settings.FETCH = 1
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_asmfs.js')))
+      settings.FILESYSTEM = 0
+      settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
+      settings.FETCH = 1
+      settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_asmfs.js')))
 
     # Explicitly drop linking in a malloc implementation if program is not using any dynamic allocation calls.
-    if not shared.Settings.USES_DYNAMIC_ALLOC:
-      shared.Settings.MALLOC = 'none'
+    if not settings.USES_DYNAMIC_ALLOC:
+      settings.MALLOC = 'none'
 
-    if shared.Settings.MALLOC == 'emmalloc':
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_emmalloc.js')))
+    if settings.MALLOC == 'emmalloc':
+      settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_emmalloc.js')))
 
-    if shared.Settings.FETCH and final_suffix in EXECUTABLE_ENDINGS:
+    if settings.FETCH and final_suffix in EXECUTABLE_ENDINGS:
       forced_stdlibs.append('libfetch')
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_fetch.js')))
-      if shared.Settings.USE_PTHREADS:
-        shared.Settings.FETCH_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.fetch.js'
+      settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_fetch.js')))
+      if settings.USE_PTHREADS:
+        settings.FETCH_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.fetch.js'
 
-    if shared.Settings.DEMANGLE_SUPPORT:
-      shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
+    if settings.DEMANGLE_SUPPORT:
+      settings.EXPORTED_FUNCTIONS += ['___cxa_demangle']
 
-    if shared.Settings.FULL_ES3:
-      shared.Settings.FULL_ES2 = 1
-      shared.Settings.MAX_WEBGL_VERSION = max(2, shared.Settings.MAX_WEBGL_VERSION)
+    if settings.FULL_ES3:
+      settings.FULL_ES2 = 1
+      settings.MAX_WEBGL_VERSION = max(2, settings.MAX_WEBGL_VERSION)
 
-    if shared.Settings.EMBIND:
+    if settings.EMBIND:
       forced_stdlibs.append('libembind')
 
-    shared.Settings.EXPORTED_FUNCTIONS += ['_stackSave', '_stackRestore', '_stackAlloc']
-    if not shared.Settings.STANDALONE_WASM:
+    settings.EXPORTED_FUNCTIONS += ['_stackSave', '_stackRestore', '_stackAlloc']
+    if not settings.STANDALONE_WASM:
       # in standalone mode, crt1 will call the constructors from inside the wasm
-      shared.Settings.EXPORTED_FUNCTIONS.append('___wasm_call_ctors')
+      settings.EXPORTED_FUNCTIONS.append('___wasm_call_ctors')
 
-    if shared.Settings.RELOCATABLE and not shared.Settings.DYNAMIC_EXECUTION:
+    if settings.RELOCATABLE and not settings.DYNAMIC_EXECUTION:
       exit_with_error('cannot have both DYNAMIC_EXECUTION=0 and RELOCATABLE enabled at the same time, since RELOCATABLE needs to eval()')
 
-    if shared.Settings.SIDE_MODULE and shared.Settings.GLOBAL_BASE != -1:
+    if settings.SIDE_MODULE and settings.GLOBAL_BASE != -1:
       exit_with_error('Cannot set GLOBAL_BASE when building SIDE_MODULE')
 
-    if shared.Settings.RELOCATABLE:
+    if settings.RELOCATABLE:
       default_setting('ERROR_ON_UNDEFINED_SYMBOLS', 0)
       default_setting('WARN_ON_UNDEFINED_SYMBOLS', 0)
 
@@ -1634,25 +1634,25 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       else:
         exit_with_error('DISABLE_EXCEPTION_CATCHING and EXCEPTION_CATCHING_ALLOWED are mutually exclusive')
 
-    if shared.Settings.EXCEPTION_CATCHING_ALLOWED:
-      shared.Settings.DISABLE_EXCEPTION_CATCHING = 0
+    if settings.EXCEPTION_CATCHING_ALLOWED:
+      settings.DISABLE_EXCEPTION_CATCHING = 0
 
-    if shared.Settings.DISABLE_EXCEPTION_THROWING and not shared.Settings.DISABLE_EXCEPTION_CATCHING:
+    if settings.DISABLE_EXCEPTION_THROWING and not settings.DISABLE_EXCEPTION_CATCHING:
       exit_with_error("DISABLE_EXCEPTION_THROWING was set (probably from -fno-exceptions) but is not compatible with enabling exception catching (DISABLE_EXCEPTION_CATCHING=0). If you don't want exceptions, set DISABLE_EXCEPTION_CATCHING to 1; if you do want exceptions, don't link with -fno-exceptions")
 
     if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
-      if shared.Settings.NODERAWFS:
+      if settings.NODERAWFS:
         exit_with_error('--preload-file and --embed-file cannot be used with NODERAWFS which disables virtual filesystem')
       # if we include any files, or intend to use preload plugins, then we definitely need filesystem support
-      shared.Settings.FORCE_FILESYSTEM = 1
+      settings.FORCE_FILESYSTEM = 1
 
-    if shared.Settings.PROXY_TO_WORKER or options.use_preload_plugins:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$Browser']
+    if settings.PROXY_TO_WORKER or options.use_preload_plugins:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$Browser']
 
-    if not shared.Settings.MINIMAL_RUNTIME:
+    if not settings.MINIMAL_RUNTIME:
       # In non-MINIMAL_RUNTIME, the core runtime depends on these functions to be present. (In MINIMAL_RUNTIME, they are
       # no longer always bundled in)
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
         '$keepRuntimeAlive',
         '$demangle',
         '$demangleAll',
@@ -1660,43 +1660,43 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         '$stackTrace'
       ]
 
-    if shared.Settings.FILESYSTEM:
+    if settings.FILESYSTEM:
       # to flush streams on FS exit, we need to be able to call fflush
       # we only include it if the runtime is exitable, or when ASSERTIONS
       # (ASSERTIONS will check that streams do not need to be flushed,
       # helping people see when they should have enabled EXIT_RUNTIME)
-      if shared.Settings.EXIT_RUNTIME or shared.Settings.ASSERTIONS:
-        shared.Settings.EXPORTED_FUNCTIONS += ['_fflush']
+      if settings.EXIT_RUNTIME or settings.ASSERTIONS:
+        settings.EXPORTED_FUNCTIONS += ['_fflush']
 
-    if shared.Settings.SUPPORT_ERRNO:
+    if settings.SUPPORT_ERRNO:
       # so setErrNo JS library function can report errno back to C
-      shared.Settings.EXPORTED_FUNCTIONS += ['___errno_location']
+      settings.EXPORTED_FUNCTIONS += ['___errno_location']
 
-    if shared.Settings.SAFE_HEAP:
+    if settings.SAFE_HEAP:
       # SAFE_HEAP check includes calling emscripten_get_sbrk_ptr() from wasm
-      shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_get_sbrk_ptr', '_emscripten_stack_get_base']
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$unSign']
+      settings.EXPORTED_FUNCTIONS += ['_emscripten_get_sbrk_ptr', '_emscripten_stack_get_base']
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$unSign']
 
-    if not shared.Settings.DECLARE_ASM_MODULE_EXPORTS:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$exportAsmFunctions']
+    if not settings.DECLARE_ASM_MODULE_EXPORTS:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$exportAsmFunctions']
 
-    if shared.Settings.ALLOW_MEMORY_GROWTH:
+    if settings.ALLOW_MEMORY_GROWTH:
       # Setting ALLOW_MEMORY_GROWTH turns off ABORTING_MALLOC, as in that mode we default to
       # the behavior of trying to grow and returning 0 from malloc on failure, like
       # a standard system would. However, if the user sets the flag it
       # overrides that.
       default_setting('ABORTING_MALLOC', 0)
 
-    if shared.Settings.USE_PTHREADS:
-      if shared.Settings.USE_PTHREADS == 2:
+    if settings.USE_PTHREADS:
+      if settings.USE_PTHREADS == 2:
         exit_with_error('USE_PTHREADS=2 is no longer supported')
-      if shared.Settings.ALLOW_MEMORY_GROWTH:
+      if settings.ALLOW_MEMORY_GROWTH:
         diagnostics.warning('pthreads-mem-growth', 'USE_PTHREADS + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271')
       # UTF8Decoder.decode may not work with a view of a SharedArrayBuffer, see https://github.com/whatwg/encoding/issues/172
-      shared.Settings.TEXTDECODER = 0
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_pthread.js')))
+      settings.TEXTDECODER = 0
+      settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_pthread.js')))
       newargs += ['-pthread']
-      shared.Settings.EXPORTED_FUNCTIONS += [
+      settings.EXPORTED_FUNCTIONS += [
         '___emscripten_pthread_data_constructor',
         '___pthread_tsd_run_dtors',
         '__emscripten_call_on_thread',
@@ -1727,17 +1727,17 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       building.user_requested_exports.append('_emscripten_current_thread_process_queued_calls')
 
       # set location of worker.js
-      shared.Settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
+      settings.PTHREAD_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.worker.js'
     else:
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_pthread_stub.js')))
+      settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_pthread_stub.js')))
 
-    if shared.Settings.FORCE_FILESYSTEM and not shared.Settings.MINIMAL_RUNTIME:
+    if settings.FORCE_FILESYSTEM and not settings.MINIMAL_RUNTIME:
       # when the filesystem is forced, we export by default methods that filesystem usage
       # may need, including filesystem usage from standalone file packager output (i.e.
       # file packages not built together with emcc, but that are loaded at runtime
       # separately, and they need emcc's output to contain the support they need)
-      if not shared.Settings.ASMFS:
-        shared.Settings.EXPORTED_RUNTIME_METHODS += [
+      if not settings.ASMFS:
+        settings.EXPORTED_RUNTIME_METHODS += [
           'FS_createPath',
           'FS_createDataFile',
           'FS_createPreloadedFile',
@@ -1746,88 +1746,88 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           'FS_unlink'
         ]
 
-      shared.Settings.EXPORTED_RUNTIME_METHODS += [
+      settings.EXPORTED_RUNTIME_METHODS += [
         'addRunDependency',
         'removeRunDependency',
       ]
 
-    if not shared.Settings.MINIMAL_RUNTIME or shared.Settings.EXIT_RUNTIME:
+    if not settings.MINIMAL_RUNTIME or settings.EXIT_RUNTIME:
       # MINIMAL_RUNTIME only needs callRuntimeCallbacks in certain cases, but the normal runtime
       # always does.
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks']
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$callRuntimeCallbacks']
 
-    if shared.Settings.USE_PTHREADS:
+    if settings.USE_PTHREADS:
       # memalign is used to ensure allocated thread stacks are aligned.
-      shared.Settings.EXPORTED_FUNCTIONS += ['_memalign']
+      settings.EXPORTED_FUNCTIONS += ['_memalign']
 
-      if shared.Settings.MINIMAL_RUNTIME:
+      if settings.MINIMAL_RUNTIME:
         building.user_requested_exports += ['exit']
 
-      if shared.Settings.PROXY_TO_PTHREAD:
-        shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_proxy_main']
+      if settings.PROXY_TO_PTHREAD:
+        settings.EXPORTED_FUNCTIONS += ['_emscripten_proxy_main']
 
       # pthread stack setup and other necessary utilities
       def include_and_export(name):
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$' + name]
-        shared.Settings.EXPORTED_FUNCTIONS += [name]
+        settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$' + name]
+        settings.EXPORTED_FUNCTIONS += [name]
 
       include_and_export('establishStackSpace')
       include_and_export('invokeEntryPoint')
-      if not shared.Settings.MINIMAL_RUNTIME:
+      if not settings.MINIMAL_RUNTIME:
         # noExitRuntime does not apply to MINIMAL_RUNTIME.
         include_and_export('keepRuntimeAlive')
 
-      if shared.Settings.MODULARIZE:
-        if shared.Settings.EXPORT_NAME == 'Module':
+      if settings.MODULARIZE:
+        if settings.EXPORT_NAME == 'Module':
           exit_with_error('pthreads + MODULARIZE currently require you to set -s EXPORT_NAME=Something (see settings.js) to Something != Module, so that the .worker.js file can work')
 
         # MODULARIZE+USE_PTHREADS mode requires extra exports out to Module so that worker.js
         # can access them:
 
         # general threading variables:
-        shared.Settings.EXPORTED_RUNTIME_METHODS += ['PThread']
+        settings.EXPORTED_RUNTIME_METHODS += ['PThread']
 
         # To keep code size to minimum, MINIMAL_RUNTIME does not utilize the global ExitStatus
         # object, only regular runtime has it.
-        if not shared.Settings.MINIMAL_RUNTIME:
-          shared.Settings.EXPORTED_RUNTIME_METHODS += ['ExitStatus']
+        if not settings.MINIMAL_RUNTIME:
+          settings.EXPORTED_RUNTIME_METHODS += ['ExitStatus']
 
-      if shared.Settings.SIDE_MODULE:
+      if settings.SIDE_MODULE:
         diagnostics.warning('experimental', '-s SIDE_MODULE + pthreads is experimental')
-      elif shared.Settings.MAIN_MODULE:
+      elif settings.MAIN_MODULE:
         diagnostics.warning('experimental', '-s MAIN_MODULE + pthreads is experimental')
-      elif shared.Settings.LINKABLE:
+      elif settings.LINKABLE:
         diagnostics.warning('experimental', '-s LINKABLE + pthreads is experimental')
 
-      if shared.Settings.PROXY_TO_WORKER:
+      if settings.PROXY_TO_WORKER:
         exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
     else:
-      if shared.Settings.PROXY_TO_PTHREAD:
+      if settings.PROXY_TO_PTHREAD:
         exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
 
     def check_memory_setting(setting):
-      if shared.Settings[setting] % webassembly.WASM_PAGE_SIZE != 0:
-        exit_with_error(f'{setting} must be a multiple of WebAssembly page size (64KiB), was {shared.Settings[setting]}')
+      if settings[setting] % webassembly.WASM_PAGE_SIZE != 0:
+        exit_with_error(f'{setting} must be a multiple of WebAssembly page size (64KiB), was {settings[setting]}')
 
     check_memory_setting('INITIAL_MEMORY')
-    if shared.Settings.INITIAL_MEMORY >= 2 * 1024 * 1024 * 1024:
+    if settings.INITIAL_MEMORY >= 2 * 1024 * 1024 * 1024:
       exit_with_error('INITIAL_MEMORY must be less than 2GB due to current spec limitations')
-    if shared.Settings.INITIAL_MEMORY < shared.Settings.TOTAL_STACK:
-      exit_with_error(f'INITIAL_MEMORY must be larger than TOTAL_STACK, was {shared.Settings.INITIAL_MEMORY} (TOTAL_STACK={shared.Settings.TOTAL_STACK})')
-    if shared.Settings.MAXIMUM_MEMORY != -1:
+    if settings.INITIAL_MEMORY < settings.TOTAL_STACK:
+      exit_with_error(f'INITIAL_MEMORY must be larger than TOTAL_STACK, was {settings.INITIAL_MEMORY} (TOTAL_STACK={settings.TOTAL_STACK})')
+    if settings.MAXIMUM_MEMORY != -1:
       check_memory_setting('MAXIMUM_MEMORY')
-    if shared.Settings.MEMORY_GROWTH_LINEAR_STEP != -1:
+    if settings.MEMORY_GROWTH_LINEAR_STEP != -1:
       check_memory_setting('MEMORY_GROWTH_LINEAR_STEP')
-    if shared.Settings.USE_PTHREADS and shared.Settings.ALLOW_MEMORY_GROWTH and shared.Settings.MAXIMUM_MEMORY == -1:
+    if settings.USE_PTHREADS and settings.ALLOW_MEMORY_GROWTH and settings.MAXIMUM_MEMORY == -1:
       exit_with_error('If pthreads and memory growth are enabled, MAXIMUM_MEMORY must be set')
 
-    if shared.Settings.EXPORT_ES6 and not shared.Settings.MODULARIZE:
+    if settings.EXPORT_ES6 and not settings.MODULARIZE:
       # EXPORT_ES6 requires output to be a module
       if 'MODULARIZE' in settings_map:
         exit_with_error('EXPORT_ES6 requires MODULARIZE to be set')
-      shared.Settings.MODULARIZE = 1
+      settings.MODULARIZE = 1
 
-    if shared.Settings.MODULARIZE and not shared.Settings.DECLARE_ASM_MODULE_EXPORTS:
+    if settings.MODULARIZE and not settings.DECLARE_ASM_MODULE_EXPORTS:
       # When MODULARIZE option is used, currently requires declaring all module exports
       # individually - TODO: this could be optimized
       exit_with_error('DECLARE_ASM_MODULE_EXPORTS=0 is not compatible with MODULARIZE')
@@ -1835,73 +1835,73 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # When not declaring wasm module exports in outer scope one by one, disable minifying
     # wasm module export names so that the names can be passed directly to the outer scope.
     # Also, if using library_exports.js API, disable minification so that the feature can work.
-    if not shared.Settings.DECLARE_ASM_MODULE_EXPORTS or 'exports.js' in [x for _, x in libs]:
-      shared.Settings.MINIFY_ASMJS_EXPORT_NAMES = 0
+    if not settings.DECLARE_ASM_MODULE_EXPORTS or 'exports.js' in [x for _, x in libs]:
+      settings.MINIFY_ASMJS_EXPORT_NAMES = 0
 
     # Enable minification of wasm imports and exports when appropriate, if we
     # are emitting an optimized JS+wasm combo (then the JS knows how to load the minified names).
     # Things that process the JS after this operation would be done must disable this.
     # For example, ASYNCIFY_LAZY_LOAD_CODE needs to identify import names.
     if will_metadce() and \
-        shared.Settings.OPT_LEVEL >= 2 and \
-        shared.Settings.DEBUG_LEVEL <= 2 and \
+        settings.OPT_LEVEL >= 2 and \
+        settings.DEBUG_LEVEL <= 2 and \
         options.oformat not in (OFormat.WASM, OFormat.BARE) and \
-        not shared.Settings.LINKABLE and \
-        not shared.Settings.STANDALONE_WASM and \
-        not shared.Settings.AUTODEBUG and \
-        not shared.Settings.ASSERTIONS and \
-        not shared.Settings.RELOCATABLE and \
-        not shared.Settings.ASYNCIFY_LAZY_LOAD_CODE and \
-            shared.Settings.MINIFY_ASMJS_EXPORT_NAMES:
-      shared.Settings.MINIFY_WASM_IMPORTS_AND_EXPORTS = 1
-      shared.Settings.MINIFY_WASM_IMPORTED_MODULES = 1
+        not settings.LINKABLE and \
+        not settings.STANDALONE_WASM and \
+        not settings.AUTODEBUG and \
+        not settings.ASSERTIONS and \
+        not settings.RELOCATABLE and \
+        not settings.ASYNCIFY_LAZY_LOAD_CODE and \
+            settings.MINIFY_ASMJS_EXPORT_NAMES:
+      settings.MINIFY_WASM_IMPORTS_AND_EXPORTS = 1
+      settings.MINIFY_WASM_IMPORTED_MODULES = 1
 
-    if shared.Settings.MINIMAL_RUNTIME:
+    if settings.MINIMAL_RUNTIME:
       # Minimal runtime uses a different default shell file
       if options.shell_path == shared.path_from_root('src', 'shell.html'):
         options.shell_path = shared.path_from_root('src', 'shell_minimal_runtime.html')
 
-      if shared.Settings.ASSERTIONS and shared.Settings.MINIMAL_RUNTIME:
+      if settings.ASSERTIONS and settings.MINIMAL_RUNTIME:
         # In ASSERTIONS-builds, functions UTF8ArrayToString() and stringToUTF8Array() (which are not JS library functions), both
         # use warnOnce(), which in MINIMAL_RUNTIME is a JS library function, so explicitly have to mark dependency to warnOnce()
         # in that case. If string functions are turned to library functions in the future, then JS dependency tracking can be
         # used and this special directive can be dropped.
-        shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$warnOnce']
+        settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$warnOnce']
 
       # Require explicit -lfoo.js flags to link with JS libraries.
-      shared.Settings.AUTO_JS_LIBRARIES = 0
+      settings.AUTO_JS_LIBRARIES = 0
 
-    if shared.Settings.MODULARIZE and shared.Settings.EXPORT_NAME == 'Module' and options.oformat == OFormat.HTML and \
+    if settings.MODULARIZE and settings.EXPORT_NAME == 'Module' and options.oformat == OFormat.HTML and \
        (options.shell_path == shared.path_from_root('src', 'shell.html') or options.shell_path == shared.path_from_root('src', 'shell_minimal.html')):
       exit_with_error('Due to collision in variable name "Module", the shell file "' + options.shell_path + '" is not compatible with build options "-s MODULARIZE=1 -s EXPORT_NAME=Module". Either provide your own shell file, change the name of the export to something else to avoid the name collision. (see https://github.com/emscripten-core/emscripten/issues/7950 for details)')
 
-    if shared.Settings.STANDALONE_WASM:
-      if shared.Settings.USE_PTHREADS:
+    if settings.STANDALONE_WASM:
+      if settings.USE_PTHREADS:
         exit_with_error('STANDALONE_WASM does not support pthreads yet')
-      if shared.Settings.MINIMAL_RUNTIME:
+      if settings.MINIMAL_RUNTIME:
         exit_with_error('MINIMAL_RUNTIME reduces JS size, and is incompatible with STANDALONE_WASM which focuses on ignoring JS anyhow and being 100% wasm')
       # the wasm must be runnable without the JS, so there cannot be anything that
       # requires JS legalization
-      shared.Settings.LEGALIZE_JS_FFI = 0
+      settings.LEGALIZE_JS_FFI = 0
 
     # TODO(sbc): Remove WASM2JS here once the size regression it would introduce has been fixed.
-    if shared.Settings.USE_PTHREADS or shared.Settings.RELOCATABLE or shared.Settings.ASYNCIFY_LAZY_LOAD_CODE or shared.Settings.WASM2JS:
-      shared.Settings.IMPORTED_MEMORY = 1
+    if settings.USE_PTHREADS or settings.RELOCATABLE or settings.ASYNCIFY_LAZY_LOAD_CODE or settings.WASM2JS:
+      settings.IMPORTED_MEMORY = 1
 
-    if shared.Settings.WASM_BIGINT:
-      shared.Settings.LEGALIZE_JS_FFI = 0
+    if settings.WASM_BIGINT:
+      settings.LEGALIZE_JS_FFI = 0
 
-    if shared.Settings.SINGLE_FILE:
-      shared.Settings.GENERATE_SOURCE_MAP = 0
+    if settings.SINGLE_FILE:
+      settings.GENERATE_SOURCE_MAP = 0
 
-    if options.use_closure_compiler == 2 and not shared.Settings.WASM2JS:
+    if options.use_closure_compiler == 2 and not settings.WASM2JS:
       exit_with_error('closure compiler mode 2 assumes the code is asm.js, so not meaningful for wasm')
 
     if 'MEM_INIT_METHOD' in settings_map:
       exit_with_error('MEM_INIT_METHOD is not supported in wasm. Memory will be embedded in the wasm binary if threads are not used, and included in a separate file if threads are used.')
 
-    if shared.Settings.WASM2JS:
-      shared.Settings.MAYBE_WASM2JS = 1
+    if settings.WASM2JS:
+      settings.MAYBE_WASM2JS = 1
       # when using wasm2js, if the memory segments are in the wasm then they
       # end up converted by wasm2js into base64 encoded JS. alternatively, we
       # can use a .mem file like asm.js used to.
@@ -1909,15 +1909,15 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       # a .mem file in most cases, since it is binary & compact). however, for
       # pthreads we must keep the memory segments in the wasm as they will be
       # passive segments which the .mem format cannot handle.
-      shared.Settings.MEM_INIT_IN_WASM = not options.memory_init_file or shared.Settings.SINGLE_FILE or shared.Settings.USE_PTHREADS
+      settings.MEM_INIT_IN_WASM = not options.memory_init_file or settings.SINGLE_FILE or settings.USE_PTHREADS
     else:
       # wasm includes the mem init in the wasm binary. The exception is
       # wasm2js, which behaves more like js.
       options.memory_init_file = True
-      shared.Settings.MEM_INIT_IN_WASM = True
+      settings.MEM_INIT_IN_WASM = True
 
     # wasm side modules have suffix .wasm
-    if shared.Settings.SIDE_MODULE and target.endswith('.js'):
+    if settings.SIDE_MODULE and target.endswith('.js'):
       diagnostics.warning('emcc', 'output suffix .js requested, but wasm side modules are just wasm files; emitting only a .wasm, no .js')
 
     sanitize = set()
@@ -1929,8 +1929,8 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         sanitize.difference_update(arg.split('=', 1)[1].split(','))
 
     if sanitize:
-      shared.Settings.USE_OFFSET_CONVERTER = 1
-      shared.Settings.EXPORTED_FUNCTIONS += [
+      settings.USE_OFFSET_CONVERTER = 1
+      settings.EXPORTED_FUNCTIONS += [
           '_memalign',
           '_emscripten_builtin_memalign',
           '_emscripten_builtin_malloc',
@@ -1939,28 +1939,28 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           '___global_base'
       ]
 
-    if shared.Settings.USE_OFFSET_CONVERTER and shared.Settings.USE_PTHREADS:
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['WasmOffsetConverter']
+    if settings.USE_OFFSET_CONVERTER and settings.USE_PTHREADS:
+      settings.EXPORTED_RUNTIME_METHODS += ['WasmOffsetConverter']
 
     if sanitize & UBSAN_SANITIZERS:
       if '-fsanitize-minimal-runtime' in newargs:
-        shared.Settings.UBSAN_RUNTIME = 1
+        settings.UBSAN_RUNTIME = 1
       else:
-        shared.Settings.UBSAN_RUNTIME = 2
+        settings.UBSAN_RUNTIME = 2
 
     if 'leak' in sanitize:
-      shared.Settings.USE_LSAN = 1
-      shared.Settings.EXIT_RUNTIME = 1
+      settings.USE_LSAN = 1
+      settings.EXIT_RUNTIME = 1
 
-      if shared.Settings.LINKABLE:
+      if settings.LINKABLE:
         exit_with_error('LSan does not support dynamic linking')
 
     if 'address' in sanitize:
-      shared.Settings.USE_ASAN = 1
-      if not shared.Settings.UBSAN_RUNTIME:
-        shared.Settings.UBSAN_RUNTIME = 2
+      settings.USE_ASAN = 1
+      if not settings.UBSAN_RUNTIME:
+        settings.UBSAN_RUNTIME = 2
 
-      shared.Settings.EXPORTED_FUNCTIONS += [
+      settings.EXPORTED_FUNCTIONS += [
         '_emscripten_builtin_memset',
         '_asan_c_load_1', '_asan_c_load_1u',
         '_asan_c_load_2', '_asan_c_load_2u',
@@ -1972,82 +1972,82 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         '_asan_c_store_f', '_asan_c_store_d',
       ]
 
-      if shared.Settings.ASAN_SHADOW_SIZE != -1:
+      if settings.ASAN_SHADOW_SIZE != -1:
         diagnostics.warning('emcc', 'ASAN_SHADOW_SIZE is ignored and will be removed in a future release')
 
-      if shared.Settings.GLOBAL_BASE != -1:
+      if settings.GLOBAL_BASE != -1:
         exit_with_error("ASan does not support custom GLOBAL_BASE")
 
-      max_mem = shared.Settings.INITIAL_MEMORY
-      if shared.Settings.ALLOW_MEMORY_GROWTH:
-        max_mem = shared.Settings.MAXIMUM_MEMORY
+      max_mem = settings.INITIAL_MEMORY
+      if settings.ALLOW_MEMORY_GROWTH:
+        max_mem = settings.MAXIMUM_MEMORY
         if max_mem == -1:
           exit_with_error('ASan requires a finite MAXIMUM_MEMORY')
 
       shadow_size = max_mem // 8
-      shared.Settings.GLOBAL_BASE = shadow_size
+      settings.GLOBAL_BASE = shadow_size
 
-      if shared.Settings.SAFE_HEAP:
+      if settings.SAFE_HEAP:
         # SAFE_HEAP instruments ASan's shadow memory accesses.
         # Since the shadow memory starts at 0, the act of accessing the shadow memory is detected
         # by SAFE_HEAP as a null pointer dereference.
         exit_with_error('ASan does not work with SAFE_HEAP')
 
-      if shared.Settings.LINKABLE:
+      if settings.LINKABLE:
         exit_with_error('ASan does not support dynamic linking')
 
-    if sanitize and shared.Settings.GENERATE_SOURCE_MAP:
-      shared.Settings.LOAD_SOURCE_MAP = 1
+    if sanitize and settings.GENERATE_SOURCE_MAP:
+      settings.LOAD_SOURCE_MAP = 1
 
-    if shared.Settings.LOAD_SOURCE_MAP and shared.Settings.USE_PTHREADS:
-      shared.Settings.EXPORTED_RUNTIME_METHODS += ['WasmSourceMap']
+    if settings.LOAD_SOURCE_MAP and settings.USE_PTHREADS:
+      settings.EXPORTED_RUNTIME_METHODS += ['WasmSourceMap']
 
-    if shared.Settings.GLOBAL_BASE == -1:
+    if settings.GLOBAL_BASE == -1:
       # default if nothing else sets it
       # a higher global base is useful for optimizing load/store offsets, as it
       # enables the --post-emscripten pass
-      shared.Settings.GLOBAL_BASE = 1024
+      settings.GLOBAL_BASE = 1024
 
     # various settings require malloc/free support from JS
-    if shared.Settings.RELOCATABLE or \
-       shared.Settings.BUILD_AS_WORKER or \
-       shared.Settings.USE_WEBGPU or \
-       shared.Settings.USE_PTHREADS or \
-       shared.Settings.OFFSCREENCANVAS_SUPPORT or \
-       shared.Settings.LEGACY_GL_EMULATION or \
-       not shared.Settings.DISABLE_EXCEPTION_CATCHING or \
-       shared.Settings.ASYNCIFY or \
-       shared.Settings.ASMFS or \
-       shared.Settings.DEMANGLE_SUPPORT or \
-       shared.Settings.FORCE_FILESYSTEM or \
-       shared.Settings.STB_IMAGE or \
-       shared.Settings.EMBIND or \
-       shared.Settings.FETCH or \
-       shared.Settings.PROXY_POSIX_SOCKETS or \
+    if settings.RELOCATABLE or \
+       settings.BUILD_AS_WORKER or \
+       settings.USE_WEBGPU or \
+       settings.USE_PTHREADS or \
+       settings.OFFSCREENCANVAS_SUPPORT or \
+       settings.LEGACY_GL_EMULATION or \
+       not settings.DISABLE_EXCEPTION_CATCHING or \
+       settings.ASYNCIFY or \
+       settings.ASMFS or \
+       settings.DEMANGLE_SUPPORT or \
+       settings.FORCE_FILESYSTEM or \
+       settings.STB_IMAGE or \
+       settings.EMBIND or \
+       settings.FETCH or \
+       settings.PROXY_POSIX_SOCKETS or \
        options.memory_profiler or \
        sanitize:
-      shared.Settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
+      settings.EXPORTED_FUNCTIONS += ['_malloc', '_free']
 
-    if not shared.Settings.DISABLE_EXCEPTION_CATCHING:
+    if not settings.DISABLE_EXCEPTION_CATCHING:
       # If not for LTO builds, we could handle these by adding deps_info.py
       # entries for __cxa_find_matching_catch_* functions.  However, under
       # LTO these symbols don't exist prior the linking.
-      shared.Settings.EXPORTED_FUNCTIONS += ['___cxa_is_pointer_type', '___cxa_can_catch']
+      settings.EXPORTED_FUNCTIONS += ['___cxa_is_pointer_type', '___cxa_can_catch']
 
-    if shared.Settings.ASYNCIFY:
-      if not shared.Settings.ASYNCIFY_IGNORE_INDIRECT:
+    if settings.ASYNCIFY:
+      if not settings.ASYNCIFY_IGNORE_INDIRECT:
         # if we are not ignoring indirect calls, then we must treat invoke_* as if
         # they are indirect calls, since that is what they do - we can't see their
         # targets statically.
-        shared.Settings.ASYNCIFY_IMPORTS += ['invoke_*']
+        settings.ASYNCIFY_IMPORTS += ['invoke_*']
       # with pthreads we may call main through the __call_main mechanism, which can
       # therefore reach anything in the program, so mark it as possibly causing a
       # sleep (the asyncify analysis doesn't look through JS, just wasm, so it can't
       # see what it itself calls)
-      if shared.Settings.USE_PTHREADS:
-        shared.Settings.ASYNCIFY_IMPORTS += ['__call_main']
+      if settings.USE_PTHREADS:
+        settings.ASYNCIFY_IMPORTS += ['__call_main']
       # add the default imports
-      shared.Settings.ASYNCIFY_IMPORTS += DEFAULT_ASYNCIFY_IMPORTS
+      settings.ASYNCIFY_IMPORTS += DEFAULT_ASYNCIFY_IMPORTS
 
       # return the full import name, including module. The name may
       # already have a module prefix; if not, we assume it is "env".
@@ -2056,42 +2056,42 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
           return name
         return 'env.' + name
 
-      shared.Settings.ASYNCIFY_IMPORTS = [get_full_import_name(i) for i in shared.Settings.ASYNCIFY_IMPORTS]
+      settings.ASYNCIFY_IMPORTS = [get_full_import_name(i) for i in settings.ASYNCIFY_IMPORTS]
 
-    if shared.Settings.WASM2JS and shared.Settings.GENERATE_SOURCE_MAP:
+    if settings.WASM2JS and settings.GENERATE_SOURCE_MAP:
       exit_with_error('wasm2js does not support source maps yet (debug in wasm for now)')
 
-    if shared.Settings.NODE_CODE_CACHING:
-      if shared.Settings.WASM_ASYNC_COMPILATION:
+    if settings.NODE_CODE_CACHING:
+      if settings.WASM_ASYNC_COMPILATION:
         exit_with_error('NODE_CODE_CACHING requires sync compilation (WASM_ASYNC_COMPILATION=0)')
       if not shared.target_environment_may_be('node'):
         exit_with_error('NODE_CODE_CACHING only works in node, but target environments do not include it')
-      if shared.Settings.SINGLE_FILE:
+      if settings.SINGLE_FILE:
         exit_with_error('NODE_CODE_CACHING saves a file on the side and is not compatible with SINGLE_FILE')
 
-    if options.tracing and shared.Settings.ALLOW_MEMORY_GROWTH:
-      shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
-      shared.Settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_current',
-                                             '_emscripten_stack_get_base',
-                                             '_emscripten_stack_get_end']
+    if options.tracing and settings.ALLOW_MEMORY_GROWTH:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['emscripten_trace_report_memory_layout']
+      settings.EXPORTED_FUNCTIONS += ['_emscripten_stack_get_current',
+                                      '_emscripten_stack_get_base',
+                                      '_emscripten_stack_get_end']
 
     # Any "pointers" passed to JS will now be i64's, in both modes.
-    if shared.Settings.MEMORY64:
+    if settings.MEMORY64:
       if settings_map.get('WASM_BIGINT') == '0':
         exit_with_error('MEMORY64 is not compatible with WASM_BIGINT=0')
-      shared.Settings.WASM_BIGINT = 1
+      settings.WASM_BIGINT = 1
 
     # check if we can address the 2GB mark and higher: either if we start at
     # 2GB, or if we allow growth to either any amount or to 2GB or more.
-    if shared.Settings.INITIAL_MEMORY > 2 * 1024 * 1024 * 1024 or \
-       (shared.Settings.ALLOW_MEMORY_GROWTH and
-        (shared.Settings.MAXIMUM_MEMORY < 0 or
-         shared.Settings.MAXIMUM_MEMORY > 2 * 1024 * 1024 * 1024)):
-      shared.Settings.CAN_ADDRESS_2GB = 1
+    if settings.INITIAL_MEMORY > 2 * 1024 * 1024 * 1024 or \
+       (settings.ALLOW_MEMORY_GROWTH and
+        (settings.MAXIMUM_MEMORY < 0 or
+         settings.MAXIMUM_MEMORY > 2 * 1024 * 1024 * 1024)):
+      settings.CAN_ADDRESS_2GB = 1
 
-    shared.Settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
-    shared.Settings.PROFILING_FUNCS = options.profiling_funcs
-    shared.Settings.SOURCE_MAP_BASE = options.source_map_base or ''
+    settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
+    settings.PROFILING_FUNCS = options.profiling_funcs
+    settings.SOURCE_MAP_BASE = options.source_map_base or ''
 
     ## Compile source code to bitcode
 
@@ -2141,7 +2141,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       if src.endswith(CXX_ENDINGS):
         return True
       # Finally fall back to the default
-      if shared.Settings.DEFAULT_TO_CXX:
+      if settings.DEFAULT_TO_CXX:
         # Default to using C++ even when run as `emcc`.
         # This means that emcc will act as a C++ linker when no source files are
         # specified.
@@ -2251,7 +2251,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   for f in ldflags:
     add_link_flag(sys.maxsize, f)
 
-  using_lld = not (link_to_object and shared.Settings.LTO)
+  using_lld = not (link_to_object and settings.LTO)
   link_flags = filter_link_flags(link_flags, using_lld)
 
   # Decide what we will link
@@ -2269,7 +2269,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       logger.debug('stopping after linking to object file')
       return 0
 
-  if final_suffix in ('.o', '.bc', '.so', '.dylib') and not shared.Settings.SIDE_MODULE:
+  if final_suffix in ('.o', '.bc', '.so', '.dylib') and not settings.SIDE_MODULE:
    diagnostics.warning('emcc', 'generating an executable with an object extension (%s).  If you meant to build an object file please use `-c, `-r`, or `-shared`' % final_suffix)
 
   ## Continue on to create JavaScript
@@ -2277,14 +2277,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   with ToolchainProfiler.profile_block('calculate system libraries'):
     extra_files_to_link = []
     # link in ports and system libraries, if necessary
-    if not shared.Settings.SIDE_MODULE:
+    if not settings.SIDE_MODULE:
       # Ports are always linked into the main module, never the size module.
-      extra_files_to_link += system_libs.get_ports_libs(shared.Settings)
+      extra_files_to_link += system_libs.get_ports_libs(settings)
     if '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
       link_as_cxx = run_via_emxx
       # Traditionally we always link as C++.  For compatibility we continue to do that,
       # unless running in strict mode.
-      if not shared.Settings.STRICT and '-nostdlib++' not in newargs:
+      if not settings.STRICT and '-nostdlib++' not in newargs:
         link_as_cxx = True
       extra_files_to_link += system_libs.calculate([f for _, f in sorted(temp_files)] + extra_files_to_link, link_as_cxx, forced=forced_stdlibs)
     linker_inputs += extra_files_to_link
@@ -2299,10 +2299,10 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         rtn.append(item)
     return rtn
 
-  # Make a final pass over shared.Settings.EXPORTED_FUNCTIONS to remove any
+  # Make a final pass over settings.EXPORTED_FUNCTIONS to remove any
   # duplication between functions added by the driver/libraries and function
   # specified by the user
-  shared.Settings.EXPORTED_FUNCTIONS = dedup_list(shared.Settings.EXPORTED_FUNCTIONS)
+  settings.EXPORTED_FUNCTIONS = dedup_list(settings.EXPORTED_FUNCTIONS)
 
   with ToolchainProfiler.profile_block('link'):
     logger.debug('linking: ' + str(linker_inputs))
@@ -2312,7 +2312,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # fastcomp deferred linking opts.
     # TODO: we could check if this is a fastcomp build, and still speed things up here
     js_funcs = None
-    if shared.Settings.LLD_REPORT_UNDEFINED and shared.Settings.ERROR_ON_UNDEFINED_SYMBOLS:
+    if settings.LLD_REPORT_UNDEFINED and settings.ERROR_ON_UNDEFINED_SYMBOLS:
       js_funcs = get_all_js_syms()
       log_time('JS symbol generation')
     building.link_lld(linker_inputs, wasm_target, external_symbol_list=js_funcs)
@@ -2357,7 +2357,7 @@ def post_link(options, in_wasm, wasm_target, target):
   if options.oformat != OFormat.WASM:
     final_js = in_temp(target_basename + '.js')
 
-  if shared.Settings.MEM_INIT_IN_WASM:
+  if settings.MEM_INIT_IN_WASM:
     memfile = None
   else:
     memfile = shared.replace_or_append_suffix(target, '.mem')
@@ -2366,12 +2366,12 @@ def post_link(options, in_wasm, wasm_target, target):
     # Emscripten
     logger.debug('emscript')
     if options.memory_init_file:
-      shared.Settings.MEM_INIT_METHOD = 1
+      settings.MEM_INIT_METHOD = 1
     else:
-      assert shared.Settings.MEM_INIT_METHOD != 1
+      assert settings.MEM_INIT_METHOD != 1
 
     if embed_memfile():
-      shared.Settings.SUPPORT_BASE64_EMBEDDING = 1
+      settings.SUPPORT_BASE64_EMBEDDING = 1
 
     emscripten.run(in_wasm, wasm_target, final_js, memfile)
     save_intermediate('original')
@@ -2383,7 +2383,7 @@ def post_link(options, in_wasm, wasm_target, target):
     # Embed and preload files
     if len(options.preload_files) or len(options.embed_files):
       logger.debug('setting up files')
-      file_args = ['--from-emcc', '--export-name=' + shared.Settings.EXPORT_NAME]
+      file_args = ['--from-emcc', '--export-name=' + settings.EXPORT_NAME]
       if len(options.preload_files):
         file_args.append('--preload')
         file_args += options.preload_files
@@ -2395,7 +2395,7 @@ def post_link(options, in_wasm, wasm_target, target):
         file_args += options.exclude_files
       if options.use_preload_cache:
         file_args.append('--use-preload-cache')
-      if shared.Settings.LZ4:
+      if settings.LZ4:
         file_args.append('--lz4')
       if options.use_preload_plugins:
         file_args.append('--use-preload-plugins')
@@ -2427,7 +2427,7 @@ def post_link(options, in_wasm, wasm_target, target):
   # exit block 'source transforms'
   log_time('source transforms')
 
-  if memfile and not shared.Settings.MINIMAL_RUNTIME:
+  if memfile and not settings.MINIMAL_RUNTIME:
     # MINIMAL_RUNTIME doesn't use `var memoryInitializer` but instead expects Module['mem'] to
     # be loaded before the module.  See src/postamble_minimal.js.
     with ToolchainProfiler.profile_block('memory initializer'):
@@ -2455,28 +2455,28 @@ def post_link(options, in_wasm, wasm_target, target):
     # src = re.sub(r'\n+[ \n]*\n+', '\n', src)
     # open(final_js, 'w').write(src)
 
-    if shared.Settings.USE_PTHREADS:
+    if settings.USE_PTHREADS:
       target_dir = os.path.dirname(os.path.abspath(target))
-      worker_output = os.path.join(target_dir, shared.Settings.PTHREAD_WORKER_FILE)
+      worker_output = os.path.join(target_dir, settings.PTHREAD_WORKER_FILE)
       with open(worker_output, 'w') as f:
         f.write(shared.read_and_preprocess(shared.path_from_root('src', 'worker.js'), expand_macros=True))
 
       # Minify the worker.js file in optimized builds
-      if (shared.Settings.OPT_LEVEL >= 1 or shared.Settings.SHRINK_LEVEL >= 1) and not shared.Settings.DEBUG_LEVEL:
+      if (settings.OPT_LEVEL >= 1 or settings.SHRINK_LEVEL >= 1) and not settings.DEBUG_LEVEL:
         minified_worker = building.acorn_optimizer(worker_output, ['minifyWhitespace'], return_output=True)
         open(worker_output, 'w').write(minified_worker)
 
     # track files that will need native eols
     generated_text_files_with_native_eols = []
 
-    if shared.Settings.MODULARIZE:
+    if settings.MODULARIZE:
       modularize()
 
     module_export_name_substitution()
 
     # Run a final regex pass to clean up items that were not possible to optimize by Closure, or unoptimalities that were left behind
     # by processing steps that occurred after Closure.
-    if shared.Settings.MINIMAL_RUNTIME == 2 and shared.Settings.USE_CLOSURE_COMPILER and shared.Settings.DEBUG_LEVEL == 0 and not shared.Settings.SINGLE_FILE:
+    if settings.MINIMAL_RUNTIME == 2 and settings.USE_CLOSURE_COMPILER and settings.DEBUG_LEVEL == 0 and not settings.SINGLE_FILE:
       # Process .js runtime file. Note that we need to handle the license text
       # here, so that it will not confuse the hacky script.
       shared.JS.handle_license(final_js)
@@ -2503,20 +2503,20 @@ def post_link(options, in_wasm, wasm_target, target):
     # The JS is now final. Move it to its final location
     move_file(final_js, js_target)
 
-    if not shared.Settings.SINGLE_FILE:
+    if not settings.SINGLE_FILE:
       generated_text_files_with_native_eols += [js_target]
 
     # If we were asked to also generate HTML, do that
     if options.oformat == OFormat.HTML:
       generate_html(target, options, js_target, target_basename,
                     wasm_target, memfile)
-    elif shared.Settings.PROXY_TO_WORKER:
+    elif settings.PROXY_TO_WORKER:
       generate_worker_js(target, js_target, target_basename)
 
     if embed_memfile() and memfile:
       shared.try_delete(memfile)
 
-    if shared.Settings.SPLIT_MODULE:
+    if settings.SPLIT_MODULE:
       diagnostics.warning('experimental', 'The SPLIT_MODULE setting is experimental and subject to change')
       do_split_module(wasm_target)
 
@@ -2596,13 +2596,13 @@ def parse_args(newargs):
       options.requested_level = arg[2:] or '2'
       if options.requested_level == 's':
         options.requested_level = 2
-        shared.Settings.SHRINK_LEVEL = 1
+        settings.SHRINK_LEVEL = 1
         settings_changes.append('INLINING_LIMIT=1')
       elif options.requested_level == 'z':
         options.requested_level = 2
-        shared.Settings.SHRINK_LEVEL = 2
+        settings.SHRINK_LEVEL = 2
         settings_changes.append('INLINING_LIMIT=1')
-      shared.Settings.OPT_LEVEL = validate_arg_level(options.requested_level, 3, 'Invalid optimization level: ' + arg, clamp=True)
+      settings.OPT_LEVEL = validate_arg_level(options.requested_level, 3, 'Invalid optimization level: ' + arg, clamp=True)
     elif check_arg('--js-opts'):
       logger.warning('--js-opts ignored when using llvm backend')
       consume_arg()
@@ -2610,9 +2610,9 @@ def parse_args(newargs):
       diagnostics.warning('deprecated', '--llvm-opts is deprecated.  All non-emcc args are passed through to clang.')
     elif arg.startswith('-flto'):
       if '=' in arg:
-        shared.Settings.LTO = arg.split('=')[1]
+        settings.LTO = arg.split('=')[1]
       else:
-        shared.Settings.LTO = "full"
+        settings.LTO = "full"
     elif check_arg('--llvm-lto'):
       logger.warning('--llvm-lto ignored when using llvm backend')
       consume_arg()
@@ -2645,22 +2645,22 @@ def parse_args(newargs):
       arg = consume_arg()
       if arg != '0':
         exit_with_error('0 is the only supported option for --minify; 1 has been deprecated')
-      shared.Settings.DEBUG_LEVEL = max(1, shared.Settings.DEBUG_LEVEL)
+      settings.DEBUG_LEVEL = max(1, settings.DEBUG_LEVEL)
     elif arg.startswith('-g'):
       options.requested_debug = arg
       requested_level = arg[2:] or '3'
       if is_int(requested_level):
         # the -gX value is the debug level (-g1, -g2, etc.)
-        shared.Settings.DEBUG_LEVEL = validate_arg_level(requested_level, 4, 'Invalid debug level: ' + arg)
+        settings.DEBUG_LEVEL = validate_arg_level(requested_level, 4, 'Invalid debug level: ' + arg)
         # if we don't need to preserve LLVM debug info, do not keep this flag
         # for clang
-        if shared.Settings.DEBUG_LEVEL < 3:
+        if settings.DEBUG_LEVEL < 3:
           newargs[i] = ''
         else:
           # for 3+, report -g to clang as -g4 etc. are not accepted
           newargs[i] = '-g'
-          if shared.Settings.DEBUG_LEVEL == 4:
-            shared.Settings.GENERATE_SOURCE_MAP = 1
+          if settings.DEBUG_LEVEL == 4:
+            settings.GENERATE_SOURCE_MAP = 1
             diagnostics.warning('deprecated', 'please replace -g4 with -gsource-map')
       else:
         if requested_level.startswith('force_dwarf'):
@@ -2674,20 +2674,20 @@ def parse_args(newargs):
           if requested_level != 'separate-dwarf':
             if not requested_level.startswith('separate-dwarf=') or requested_level.count('=') != 1:
               exit_with_error('invalid -gseparate-dwarf=FILENAME notation')
-            shared.Settings.SEPARATE_DWARF = requested_level.split('=')[1]
+            settings.SEPARATE_DWARF = requested_level.split('=')[1]
           else:
-            shared.Settings.SEPARATE_DWARF = True
+            settings.SEPARATE_DWARF = True
         elif requested_level == 'source-map':
-          shared.Settings.GENERATE_SOURCE_MAP = 1
+          settings.GENERATE_SOURCE_MAP = 1
           newargs[i] = '-g'
         # a non-integer level can be something like -gline-tables-only. keep
         # the flag for the clang frontend to emit the appropriate DWARF info.
         # set the emscripten debug level to 3 so that we do not remove that
         # debug info during link (during compile, this does not make a
         # difference).
-        shared.Settings.DEBUG_LEVEL = 3
+        settings.DEBUG_LEVEL = 3
     elif check_flag('-profiling') or check_flag('--profiling'):
-      shared.Settings.DEBUG_LEVEL = max(shared.Settings.DEBUG_LEVEL, 2)
+      settings.DEBUG_LEVEL = max(settings.DEBUG_LEVEL, 2)
       options.profiling = True
     elif check_flag('-profiling-funcs') or check_flag('--profiling-funcs'):
       options.profiling_funcs = True
@@ -2697,14 +2697,14 @@ def parse_args(newargs):
       options.tracing = True
       newargs[i] = ''
       settings_changes.append("EMSCRIPTEN_TRACING=1")
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_trace.js')))
+      settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_trace.js')))
     elif check_flag('--emit-symbol-map'):
       options.emit_symbol_map = True
-      shared.Settings.EMIT_SYMBOL_MAP = 1
+      settings.EMIT_SYMBOL_MAP = 1
     elif check_flag('--bind'):
-      shared.Settings.EMBIND = 1
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'embind', 'emval.js')))
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'embind', 'embind.js')))
+      settings.EMBIND = 1
+      settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'embind', 'emval.js')))
+      settings.SYSTEM_JS_LIBRARIES.append((0, shared.path_from_root('src', 'embind', 'embind.js')))
     elif check_arg('--embed-file'):
       options.embed_files.append(consume_arg())
     elif check_arg('--preload-file'):
@@ -2728,7 +2728,7 @@ def parse_args(newargs):
     elif check_flag('--no-entry'):
       options.no_entry = True
     elif check_arg('--js-library'):
-      shared.Settings.SYSTEM_JS_LIBRARIES.append((i + 1, os.path.abspath(consume_arg_file())))
+      settings.SYSTEM_JS_LIBRARIES.append((i + 1, os.path.abspath(consume_arg_file())))
     elif check_flag('--remove-duplicates'):
       diagnostics.warning('legacy-settings', '--remove-duplicates is deprecated as it is no longer needed. If you cannot link without it, file a bug with a testcase')
     elif check_flag('--jcache'):
@@ -2779,15 +2779,15 @@ def parse_args(newargs):
       options.thread_profiler = True
       settings_changes.append('PTHREADS_PROFILING=1')
     elif arg == '-fno-exceptions':
-      shared.Settings.DISABLE_EXCEPTION_CATCHING = 1
-      shared.Settings.DISABLE_EXCEPTION_THROWING = 1
-      shared.Settings.EXCEPTION_HANDLING = 0
+      settings.DISABLE_EXCEPTION_CATCHING = 1
+      settings.DISABLE_EXCEPTION_THROWING = 1
+      settings.EXCEPTION_HANDLING = 0
     elif arg == '-fexceptions':
       eh_enabled = True
     elif arg == '-fwasm-exceptions':
       wasm_eh_enabled = True
     elif arg == '-fignore-exceptions':
-      shared.Settings.DISABLE_EXCEPTION_CATCHING = 1
+      settings.DISABLE_EXCEPTION_CATCHING = 1
     elif check_arg('--default-obj-ext'):
       options.default_object_extension = consume_arg()
       if not options.default_object_extension.startswith('.'):
@@ -2817,16 +2817,16 @@ def parse_args(newargs):
       colored_logger.disable()
       diagnostics.color_enabled = False
     elif arg == '-fno-rtti':
-      shared.Settings.USE_RTTI = 0
+      settings.USE_RTTI = 0
     elif arg == '-frtti':
-      shared.Settings.USE_RTTI = 1
+      settings.USE_RTTI = 1
     elif arg.startswith('-jsD'):
       key = arg[4:]
       if '=' in key:
         key, value = key.split('=')
       else:
         value = '1'
-      if key in shared.Settings.keys():
+      if key in settings.keys():
         exit_with_error(arg + ': cannot change built-in settings values with a -jsD directive. Pass -s ' + key + '=' + value + ' instead!')
       user_js_defines += [(key, value)]
       newargs[i] = ''
@@ -2852,13 +2852,13 @@ def parse_args(newargs):
   # exception handling by default when -fexceptions is given when wasm
   # exception handling becomes stable.
   if wasm_eh_enabled:
-    shared.Settings.EXCEPTION_HANDLING = 1
-    shared.Settings.DISABLE_EXCEPTION_THROWING = 1
-    shared.Settings.DISABLE_EXCEPTION_CATCHING = 1
+    settings.EXCEPTION_HANDLING = 1
+    settings.DISABLE_EXCEPTION_THROWING = 1
+    settings.DISABLE_EXCEPTION_CATCHING = 1
   elif eh_enabled:
-    shared.Settings.EXCEPTION_HANDLING = 0
-    shared.Settings.DISABLE_EXCEPTION_THROWING = 0
-    shared.Settings.DISABLE_EXCEPTION_CATCHING = 0
+    settings.EXCEPTION_HANDLING = 0
+    settings.DISABLE_EXCEPTION_THROWING = 0
+    settings.DISABLE_EXCEPTION_CATCHING = 0
 
   newargs = [a for a in newargs if a]
   return options, settings_changes, user_js_defines, newargs
@@ -2867,23 +2867,23 @@ def parse_args(newargs):
 def do_binaryen(target, options, wasm_target):
   global final_js
   logger.debug('using binaryen')
-  if shared.Settings.GENERATE_SOURCE_MAP and not shared.Settings.SOURCE_MAP_BASE:
+  if settings.GENERATE_SOURCE_MAP and not settings.SOURCE_MAP_BASE:
     logger.warning("Wasm source map won't be usable in a browser without --source-map-base")
   # whether we need to emit -g (function name debug info) in the final wasm
-  debug_info = shared.Settings.DEBUG_LEVEL >= 2 or options.profiling_funcs
+  debug_info = settings.DEBUG_LEVEL >= 2 or options.profiling_funcs
   # whether we need to emit -g in the intermediate binaryen invocations (but not necessarily at the very end).
   # this is necessary for emitting a symbol map at the end.
-  intermediate_debug_info = bool(debug_info or options.emit_symbol_map or shared.Settings.ASYNCIFY_ONLY or shared.Settings.ASYNCIFY_REMOVE or shared.Settings.ASYNCIFY_ADD)
+  intermediate_debug_info = bool(debug_info or options.emit_symbol_map or settings.ASYNCIFY_ONLY or settings.ASYNCIFY_REMOVE or settings.ASYNCIFY_ADD)
   # note that wasm-ld can strip DWARF info for us too (--strip-debug), but it
   # also strips the Names section. so to emit just the Names section we don't
   # tell wasm-ld to strip anything, and we do it here.
-  strip_debug = shared.Settings.DEBUG_LEVEL < 3
-  strip_producers = not shared.Settings.EMIT_PRODUCERS_SECTION
+  strip_debug = settings.DEBUG_LEVEL < 3
+  strip_producers = not settings.EMIT_PRODUCERS_SECTION
   # run wasm-opt if we have work for it: either passes, or if we are using
   # source maps (which requires some extra processing to keep the source map
   # but remove DWARF)
   passes = get_binaryen_passes()
-  if passes or shared.Settings.GENERATE_SOURCE_MAP:
+  if passes or settings.GENERATE_SOURCE_MAP:
     # if we need to strip certain sections, and we have wasm-opt passes
     # to run anyhow, do it with them.
     if strip_debug:
@@ -2903,28 +2903,28 @@ def do_binaryen(target, options, wasm_target):
       building.save_intermediate(wasm_target, 'pre-strip.wasm')
       building.strip(wasm_target, wasm_target, debug=strip_debug, producers=strip_producers)
 
-  if shared.Settings.EVAL_CTORS:
+  if settings.EVAL_CTORS:
     building.save_intermediate(wasm_target, 'pre-ctors.wasm')
     building.eval_ctors(final_js, wasm_target, debug_info=intermediate_debug_info)
 
   # after generating the wasm, do some final operations
 
   # Add extra dylibs if needed.
-  if shared.Settings.RUNTIME_LINKED_LIBS:
-    webassembly.update_dylink_section(wasm_target, shared.Settings.RUNTIME_LINKED_LIBS)
+  if settings.RUNTIME_LINKED_LIBS:
+    webassembly.update_dylink_section(wasm_target, settings.RUNTIME_LINKED_LIBS)
 
-  if shared.Settings.EMIT_EMSCRIPTEN_METADATA:
+  if settings.EMIT_EMSCRIPTEN_METADATA:
     diagnostics.warning('deprecated', 'We hope to remove support for EMIT_EMSCRIPTEN_METADATA. See https://github.com/emscripten-core/emscripten/issues/12231')
     webassembly.add_emscripten_metadata(wasm_target)
 
   if final_js:
-    if shared.Settings.SUPPORT_BIG_ENDIAN:
+    if settings.SUPPORT_BIG_ENDIAN:
       final_js = building.little_endian_heap(final_js)
 
     # >=2GB heap support requires pointers in JS to be unsigned. rather than
     # require all pointers to be unsigned by default, which increases code size
     # a little, keep them signed, and just unsign them here if we need that.
-    if shared.Settings.CAN_ADDRESS_2GB:
+    if settings.CAN_ADDRESS_2GB:
       final_js = building.use_unsigned_pointers_in_js(final_js)
 
     # pthreads memory growth requires some additional JS fixups.
@@ -2932,16 +2932,16 @@ def do_binaryen(target, options, wasm_target):
     # adds some >>> 0 things, while growth will replace a HEAP8 with a call to
     # a method to get the heap, and that call would not be recognized by the
     # unsigning pass
-    if shared.Settings.USE_PTHREADS and shared.Settings.ALLOW_MEMORY_GROWTH:
+    if settings.USE_PTHREADS and settings.ALLOW_MEMORY_GROWTH:
       final_js = building.apply_wasm_memory_growth(final_js)
 
-    if shared.Settings.USE_ASAN:
+    if settings.USE_ASAN:
       final_js = building.instrument_js_for_asan(final_js)
 
-    if shared.Settings.SAFE_HEAP:
+    if settings.SAFE_HEAP:
       final_js = building.instrument_js_for_safe_heap(final_js)
 
-    if shared.Settings.OPT_LEVEL >= 2 and shared.Settings.DEBUG_LEVEL <= 2:
+    if settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL <= 2:
       # minify the JS. Do not minify whitespace if Closure is used, so that
       # Closure can print out readable error messages (Closure will then
       # minify whitespace afterwards)
@@ -2953,7 +2953,7 @@ def do_binaryen(target, options, wasm_target):
                                          debug_info=intermediate_debug_info)
       save_intermediate_with_wasm('postclean', wasm_target)
 
-  if shared.Settings.ASYNCIFY_LAZY_LOAD_CODE:
+  if settings.ASYNCIFY_LAZY_LOAD_CODE:
     building.asyncify_lazy_load_code(wasm_target, debug=intermediate_debug_info)
 
   def preprocess_wasm2js_script():
@@ -2970,8 +2970,8 @@ def do_binaryen(target, options, wasm_target):
 
   symbols_file = shared.replace_or_append_suffix(target, '.symbols') if options.emit_symbol_map else None
 
-  if shared.Settings.WASM2JS:
-    if shared.Settings.WASM == 2:
+  if settings.WASM2JS:
+    if settings.WASM == 2:
       wasm2js_template = wasm_target + '.js'
       open(wasm2js_template, 'w').write(preprocess_wasm2js_script())
       # generate secondary file for JS symbols
@@ -2982,7 +2982,7 @@ def do_binaryen(target, options, wasm_target):
 
     wasm2js = building.wasm2js(wasm2js_template,
                                wasm_target,
-                               opt_level=shared.Settings.OPT_LEVEL,
+                               opt_level=settings.OPT_LEVEL,
                                minify_whitespace=minify_whitespace(),
                                use_closure_compiler=options.use_closure_compiler,
                                debug_info=debug_info,
@@ -2991,10 +2991,10 @@ def do_binaryen(target, options, wasm_target):
 
     shared.configuration.get_temp_files().note(wasm2js)
 
-    if shared.Settings.WASM == 2:
+    if settings.WASM == 2:
       safe_copy(wasm2js, wasm2js_template)
 
-    if shared.Settings.WASM != 2:
+    if settings.WASM != 2:
       final_js = wasm2js
       # if we only target JS, we don't need the wasm any more
       shared.try_delete(wasm_target)
@@ -3009,17 +3009,17 @@ def do_binaryen(target, options, wasm_target):
     building.handle_final_wasm_symbols(wasm_file=wasm_target, symbols_file=symbols_file, debug_info=debug_info)
     save_intermediate_with_wasm('symbolmap', wasm_target)
 
-  if shared.Settings.DEBUG_LEVEL >= 3 and shared.Settings.SEPARATE_DWARF and os.path.exists(wasm_target):
-    building.emit_debug_on_side(wasm_target, shared.Settings.SEPARATE_DWARF)
+  if settings.DEBUG_LEVEL >= 3 and settings.SEPARATE_DWARF and os.path.exists(wasm_target):
+    building.emit_debug_on_side(wasm_target, settings.SEPARATE_DWARF)
 
-  if shared.Settings.WASM2C:
+  if settings.WASM2C:
     wasm2c.do_wasm2c(wasm_target)
 
   # replace placeholder strings with correct subresource locations
-  if final_js and shared.Settings.SINGLE_FILE and not shared.Settings.WASM2JS:
+  if final_js and settings.SINGLE_FILE and not settings.WASM2JS:
     js = open(final_js).read()
 
-    if shared.Settings.MINIMAL_RUNTIME:
+    if settings.MINIMAL_RUNTIME:
       js = do_replace(js, '<<< WASM_BINARY_DATA >>>', base64_encode(open(wasm_target, 'rb').read()))
     else:
       js = do_replace(js, '<<< WASM_BINARY_FILE >>>', shared.JS.get_subresource_location(wasm_target))
@@ -3030,13 +3030,13 @@ def do_binaryen(target, options, wasm_target):
 
 def modularize():
   global final_js
-  logger.debug('Modularizing, assigning to var ' + shared.Settings.EXPORT_NAME)
+  logger.debug('Modularizing, assigning to var ' + settings.EXPORT_NAME)
   src = open(final_js).read()
 
-  return_value = shared.Settings.EXPORT_NAME
-  if shared.Settings.WASM_ASYNC_COMPILATION:
+  return_value = settings.EXPORT_NAME
+  if settings.WASM_ASYNC_COMPILATION:
     return_value += '.ready'
-  if not shared.Settings.EXPORT_READY_PROMISE:
+  if not settings.EXPORT_READY_PROMISE:
     return_value = '{}'
 
   src = '''
@@ -3048,22 +3048,22 @@ function(%(EXPORT_NAME)s) {
   return %(return_value)s
 }
 ''' % {
-    'EXPORT_NAME': shared.Settings.EXPORT_NAME,
+    'EXPORT_NAME': settings.EXPORT_NAME,
     'src': src,
     'return_value': return_value
   }
 
-  if shared.Settings.MINIMAL_RUNTIME and not shared.Settings.USE_PTHREADS:
+  if settings.MINIMAL_RUNTIME and not settings.USE_PTHREADS:
     # Single threaded MINIMAL_RUNTIME programs do not need access to
     # document.currentScript, so a simple export declaration is enough.
-    src = 'var %s=%s' % (shared.Settings.EXPORT_NAME, src)
+    src = 'var %s=%s' % (settings.EXPORT_NAME, src)
   else:
     script_url_node = ""
     # When MODULARIZE this JS may be executed later,
     # after document.currentScript is gone, so we save it.
     # In EXPORT_ES6 + USE_PTHREADS the 'thread' is actually an ES6 module webworker running in strict mode,
     # so doesn't have access to 'document'. In this case use 'import.meta' instead.
-    if shared.Settings.EXPORT_ES6 and shared.Settings.USE_ES6_IMPORT_META:
+    if settings.EXPORT_ES6 and settings.USE_ES6_IMPORT_META:
       script_url = "import.meta.url"
     else:
       script_url = "typeof document !== 'undefined' && document.currentScript ? document.currentScript.src : undefined"
@@ -3076,7 +3076,7 @@ var %(EXPORT_NAME)s = (function() {
   return (%(src)s);
 })();
 ''' % {
-      'EXPORT_NAME': shared.Settings.EXPORT_NAME,
+      'EXPORT_NAME': settings.EXPORT_NAME,
       'script_url': script_url,
       'script_url_node': script_url_node,
       'src': src
@@ -3088,9 +3088,9 @@ var %(EXPORT_NAME)s = (function() {
 
     # Export using a UMD style export, or ES6 exports if selected
 
-    if shared.Settings.EXPORT_ES6:
-      f.write('export default %s;' % shared.Settings.EXPORT_NAME)
-    elif not shared.Settings.MINIMAL_RUNTIME:
+    if settings.EXPORT_ES6:
+      f.write('export default %s;' % settings.EXPORT_NAME)
+    elif not settings.MINIMAL_RUNTIME:
       f.write('''\
 if (typeof exports === 'object' && typeof module === 'object')
   module.exports = %(EXPORT_NAME)s;
@@ -3098,7 +3098,7 @@ else if (typeof define === 'function' && define['amd'])
   define([], function() { return %(EXPORT_NAME)s; });
 else if (typeof exports === 'object')
   exports["%(EXPORT_NAME)s"] = %(EXPORT_NAME)s;
-''' % {'EXPORT_NAME': shared.Settings.EXPORT_NAME})
+''' % {'EXPORT_NAME': settings.EXPORT_NAME})
 
   shared.configuration.get_temp_files().note(final_js)
   save_intermediate('modularized')
@@ -3106,19 +3106,19 @@ else if (typeof exports === 'object')
 
 def module_export_name_substitution():
   global final_js
-  logger.debug('Private module export name substitution with ' + shared.Settings.EXPORT_NAME)
+  logger.debug('Private module export name substitution with ' + settings.EXPORT_NAME)
   with open(final_js) as f:
     src = f.read()
   final_js += '.module_export_name_substitution.js'
-  if shared.Settings.MINIMAL_RUNTIME:
+  if settings.MINIMAL_RUNTIME:
     # In MINIMAL_RUNTIME the Module object is always present to provide the .asm.js/.wasm content
-    replacement = shared.Settings.EXPORT_NAME
+    replacement = settings.EXPORT_NAME
   else:
-    replacement = "typeof %(EXPORT_NAME)s !== 'undefined' ? %(EXPORT_NAME)s : {}" % {"EXPORT_NAME": shared.Settings.EXPORT_NAME}
+    replacement = "typeof %(EXPORT_NAME)s !== 'undefined' ? %(EXPORT_NAME)s : {}" % {"EXPORT_NAME": settings.EXPORT_NAME}
   src = re.sub(r'{\s*[\'"]?__EMSCRIPTEN_PRIVATE_MODULE_EXPORT_NAME_SUBSTITUTION__[\'"]?:\s*1\s*}', replacement, src)
   # For Node.js and other shell environments, create an unminified Module object so that
   # loading external .asm.js file that assigns to Module['asm'] works even when Closure is used.
-  if shared.Settings.MINIMAL_RUNTIME and (shared.target_environment_may_be('node') or shared.target_environment_may_be('shell')):
+  if settings.MINIMAL_RUNTIME and (shared.target_environment_may_be('node') or shared.target_environment_may_be('shell')):
     src = 'if(typeof Module==="undefined"){var Module={};}\n' + src
   with open(final_js, 'w') as f:
     f.write(src)
@@ -3134,8 +3134,8 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
   assert '{{{ SCRIPT }}}' in shell, 'HTML shell must contain  {{{ SCRIPT }}}  , see src/shell.html for an example'
   base_js_target = os.path.basename(js_target)
 
-  if shared.Settings.PROXY_TO_WORKER:
-    proxy_worker_filename = (shared.Settings.PROXY_TO_WORKER_FILENAME or target_basename) + '.js'
+  if settings.PROXY_TO_WORKER:
+    proxy_worker_filename = (settings.PROXY_TO_WORKER_FILENAME or target_basename) + '.js'
     worker_js = worker_js_script(proxy_worker_filename)
     script.inline = ('''
   var filename = '%s';
@@ -3158,8 +3158,8 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
     # Normal code generation path
     script.src = base_js_target
 
-  if not shared.Settings.SINGLE_FILE:
-    if memfile and not shared.Settings.MINIMAL_RUNTIME:
+  if not settings.SINGLE_FILE:
+    if memfile and not settings.MINIMAL_RUNTIME:
       # start to load the memory init file in the HTML, in parallel with the JS
       script.un_src()
       script.inline = ('''
@@ -3172,7 +3172,7 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
           meminitXHR.send(null);
 ''' % shared.JS.get_subresource_location(memfile)) + script.inline
 
-    if not shared.Settings.WASM_ASYNC_COMPILATION:
+    if not settings.WASM_ASYNC_COMPILATION:
       # We need to load the wasm file before anything else, it has to be synchronously ready TODO: optimize
       script.un_src()
       script.inline = '''
@@ -3194,7 +3194,7 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
           wasmXHR.send(null);
 ''' % (shared.JS.get_subresource_location(wasm_target), script.inline)
 
-    if shared.Settings.WASM == 2:
+    if settings.WASM == 2:
       # If target browser does not support WebAssembly, we need to load the .wasm.js file before the main .js file.
       script.un_src()
       script.inline = '''
@@ -3220,10 +3220,10 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
       content = read_and_preprocess(shared.path_from_root('src', filename))
       script.inline = content + script.inline
 
-    script.inline = 'var ASSERTIONS = %s;\n%s' % (shared.Settings.ASSERTIONS, script.inline)
+    script.inline = 'var ASSERTIONS = %s;\n%s' % (settings.ASSERTIONS, script.inline)
 
   # inline script for SINGLE_FILE output
-  if shared.Settings.SINGLE_FILE:
+  if settings.SINGLE_FILE:
     js_contents = script.inline or ''
     if script.src:
       js_contents += open(js_target).read()
@@ -3243,12 +3243,12 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
 
 
 def minify_html(filename):
-  if shared.Settings.DEBUG_LEVEL >= 2:
+  if settings.DEBUG_LEVEL >= 2:
     return
 
   opts = []
   # -g1 and greater retain whitespace and comments in source
-  if shared.Settings.DEBUG_LEVEL == 0:
+  if settings.DEBUG_LEVEL == 0:
     opts += ['--collapse-whitespace',
              '--collapse-inline-tag-whitespace',
              '--remove-comments',
@@ -3256,7 +3256,7 @@ def minify_html(filename):
              '--sort-attributes',
              '--sort-class-name']
   # -g2 and greater do not minify HTML at all
-  if shared.Settings.DEBUG_LEVEL <= 1:
+  if settings.DEBUG_LEVEL <= 1:
     opts += ['--decode-entities',
              '--collapse-boolean-attributes',
              '--remove-attribute-quotes',
@@ -3290,33 +3290,33 @@ def generate_html(target, options, js_target, target_basename,
                   wasm_target, memfile):
   logger.debug('generating HTML')
 
-  if shared.Settings.EXPORT_NAME != 'Module' and \
-     not shared.Settings.MINIMAL_RUNTIME and \
+  if settings.EXPORT_NAME != 'Module' and \
+     not settings.MINIMAL_RUNTIME and \
      options.shell_path == shared.path_from_root('src', 'shell.html'):
     # the minimal runtime shell HTML is designed to support changing the export
     # name, but the normal one does not support that currently
     exit_with_error('Customizing EXPORT_NAME requires that the HTML be customized to use that name (see https://github.com/emscripten-core/emscripten/issues/10086)')
 
-  if shared.Settings.MINIMAL_RUNTIME:
+  if settings.MINIMAL_RUNTIME:
     generate_minimal_runtime_html(target, options, js_target, target_basename)
   else:
     generate_traditional_runtime_html(target, options, js_target, target_basename,
                                       wasm_target, memfile)
 
-  if shared.Settings.MINIFY_HTML and (shared.Settings.OPT_LEVEL >= 1 or shared.Settings.SHRINK_LEVEL >= 1):
+  if settings.MINIFY_HTML and (settings.OPT_LEVEL >= 1 or settings.SHRINK_LEVEL >= 1):
     minify_html(target)
 
 
 def generate_worker_js(target, js_target, target_basename):
   # compiler output is embedded as base64
-  if shared.Settings.SINGLE_FILE:
+  if settings.SINGLE_FILE:
     proxy_worker_filename = shared.JS.get_subresource_location(js_target)
 
   # compiler output goes in .worker.js file
   else:
     move_file(js_target, unsuffixed(js_target) + '.worker.js')
     worker_target_basename = target_basename + '.worker'
-    proxy_worker_filename = (shared.Settings.PROXY_TO_WORKER_FILENAME or worker_target_basename) + '.js'
+    proxy_worker_filename = (settings.PROXY_TO_WORKER_FILENAME or worker_target_basename) + '.js'
 
   target_contents = worker_js_script(proxy_worker_filename)
   open(target, 'w').write(target_contents)
@@ -3362,12 +3362,12 @@ def process_libraries(libs, lib_dirs, temp_files):
       elif building.map_and_apply_to_settings(lib):
         consumed.append(i)
 
-  shared.Settings.SYSTEM_JS_LIBRARIES += libraries
+  settings.SYSTEM_JS_LIBRARIES += libraries
 
   # At this point processing SYSTEM_JS_LIBRARIES is finished, no more items will be added to it.
   # Sort the input list from (order, lib_name) pairs to a flat array in the right order.
-  shared.Settings.SYSTEM_JS_LIBRARIES.sort(key=lambda lib: lib[0])
-  shared.Settings.SYSTEM_JS_LIBRARIES = [lib[1] for lib in shared.Settings.SYSTEM_JS_LIBRARIES]
+  settings.SYSTEM_JS_LIBRARIES.sort(key=lambda lib: lib[0])
+  settings.SYSTEM_JS_LIBRARIES = [lib[1] for lib in settings.SYSTEM_JS_LIBRARIES]
   return consumed
 
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -25,6 +25,7 @@ from tools import gen_struct_info
 from tools import webassembly
 from tools.shared import WINDOWS, path_from_root, exit_with_error, asmjs_mangle, treat_as_user_function
 from tools.toolchain_profiler import ToolchainProfiler
+from tools.settings import settings
 
 logger = logging.getLogger('emscripten')
 
@@ -40,7 +41,7 @@ def compute_minimal_runtime_initializer_and_exports(post, exports, receiving):
   exports_that_are_not_initializers = [asmjs_mangle(x) for x in exports_that_are_not_initializers]
 
   # Decide whether we should generate the global dynCalls dictionary for the dynCall() function?
-  if shared.Settings.DYNCALLS and '$dynCall' in shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE and len([x for x in exports_that_are_not_initializers if x.startswith('dynCall_')]) > 0:
+  if settings.DYNCALLS and '$dynCall' in settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE and len([x for x in exports_that_are_not_initializers if x.startswith('dynCall_')]) > 0:
     exports_that_are_not_initializers += ['dynCalls = {}']
 
   declares = 'var ' + ',\n '.join(exports_that_are_not_initializers) + ';'
@@ -67,12 +68,12 @@ def optimize_syscalls(declares, DEBUG):
   MAIN_MODULE since a side module might need the filesystem.
   """
   relevant_settings = ['FORCE_FILESYSTEM', 'INCLUDE_FULL_LIBRARY', 'MAIN_MODULE']
-  if any(shared.Settings[s] for s in relevant_settings):
+  if any(settings[s] for s in relevant_settings):
     return
 
-  if shared.Settings.FILESYSTEM == 0:
+  if settings.FILESYSTEM == 0:
     # without filesystem support, it doesn't matter what syscalls need
-    shared.Settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
+    settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
   else:
     syscall_prefixes = ('__sys', 'fd_')
     syscalls = [d for d in declares if d.startswith(syscall_prefixes)]
@@ -87,7 +88,7 @@ def optimize_syscalls(declares, DEBUG):
     ])):
       if DEBUG:
         logger.debug('very limited syscalls (%s) so disabling full filesystem support', ', '.join(str(s) for s in syscalls))
-      shared.Settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
+      settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
 
 
 def is_int(x):
@@ -106,38 +107,38 @@ def update_settings_glue(metadata, DEBUG):
   optimize_syscalls(metadata['declares'], DEBUG)
 
   # Integrate info from backend
-  if shared.Settings.SIDE_MODULE:
+  if settings.SIDE_MODULE:
     # we don't need any JS library contents in side modules
-    shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = []
 
-  all_funcs = shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE + [shared.JS.to_nice_ident(d) for d in metadata['declares']]
-  shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = sorted(set(all_funcs).difference(metadata['exports']))
+  all_funcs = settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE + [shared.JS.to_nice_ident(d) for d in metadata['declares']]
+  settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = sorted(set(all_funcs).difference(metadata['exports']))
 
-  shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += metadata['globalImports']
+  settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += metadata['globalImports']
 
   all_exports = metadata['exports'] + list(metadata['namedGlobals'].keys())
-  shared.Settings.IMPLEMENTED_FUNCTIONS = [asmjs_mangle(x) for x in all_exports]
+  settings.IMPLEMENTED_FUNCTIONS = [asmjs_mangle(x) for x in all_exports]
 
-  shared.Settings.BINARYEN_FEATURES = metadata['features']
-  if shared.Settings.RELOCATABLE:
+  settings.BINARYEN_FEATURES = metadata['features']
+  if settings.RELOCATABLE:
     # When building relocatable output (e.g. MAIN_MODULE) the reported table
     # size does not include the reserved slot at zero for the null pointer.
     # Instead we use __table_base to offset the elements by 1.
-    if shared.Settings.INITIAL_TABLE == -1:
-      shared.Settings.INITIAL_TABLE = metadata['tableSize'] + 1
+    if settings.INITIAL_TABLE == -1:
+      settings.INITIAL_TABLE = metadata['tableSize'] + 1
 
-  shared.Settings.HAS_MAIN = shared.Settings.MAIN_MODULE or shared.Settings.STANDALONE_WASM or '_main' in shared.Settings.IMPLEMENTED_FUNCTIONS
+  settings.HAS_MAIN = settings.MAIN_MODULE or settings.STANDALONE_WASM or '_main' in settings.IMPLEMENTED_FUNCTIONS
 
   # When using dynamic linking the main function might be in a side module.
   # To be safe assume they do take input parametes.
-  shared.Settings.MAIN_READS_PARAMS = metadata['mainReadsParams'] or shared.Settings.MAIN_MODULE
+  settings.MAIN_READS_PARAMS = metadata['mainReadsParams'] or settings.MAIN_MODULE
 
   # Store exports for Closure compiler to be able to track these as globals in
   # -s DECLARE_ASM_MODULE_EXPORTS=0 builds.
-  shared.Settings.MODULE_EXPORTS = [(asmjs_mangle(f), f) for f in metadata['exports']]
+  settings.MODULE_EXPORTS = [(asmjs_mangle(f), f) for f in metadata['exports']]
 
-  if shared.Settings.STACK_OVERFLOW_CHECK and not shared.Settings.SIDE_MODULE:
-    shared.Settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
+  if settings.STACK_OVERFLOW_CHECK and not settings.SIDE_MODULE:
+    settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']
     # writeStackCookie and checkStackCookie both rely on emscripten_stack_get_end being
     # exported.  In theory it should always be present since its defined in compiler-rt.
     assert 'emscripten_stack_get_end' in metadata['exports']
@@ -145,9 +146,9 @@ def update_settings_glue(metadata, DEBUG):
 
 def apply_static_code_hooks(forwarded_json, code):
   code = shared.do_replace(code, '<<< ATINITS >>>', str(forwarded_json['ATINITS']))
-  if shared.Settings.HAS_MAIN:
+  if settings.HAS_MAIN:
     code = shared.do_replace(code, '<<< ATMAINS >>>', str(forwarded_json['ATMAINS']))
-  if shared.Settings.EXIT_RUNTIME:
+  if settings.EXIT_RUNTIME:
     code = shared.do_replace(code, '<<< ATEXITS >>>', str(forwarded_json['ATEXITS']))
   return code
 
@@ -162,7 +163,7 @@ def compile_settings():
   # Save settings to a file to work around v8 issue 1579
   with shared.configuration.get_temp_files().get_file('.txt') as settings_file:
     with open(settings_file, 'w') as s:
-      json.dump(shared.Settings.dict(), s, sort_keys=True)
+      json.dump(settings.dict(), s, sort_keys=True)
 
     # Call js compiler
     env = os.environ.copy()
@@ -176,17 +177,17 @@ def compile_settings():
 
 
 def set_memory(static_bump):
-  stack_low = align_memory(shared.Settings.GLOBAL_BASE + static_bump)
-  stack_high = align_memory(stack_low + shared.Settings.TOTAL_STACK)
-  shared.Settings.STACK_BASE = stack_high
-  shared.Settings.STACK_MAX = stack_low
-  shared.Settings.HEAP_BASE = align_memory(stack_high)
+  stack_low = align_memory(settings.GLOBAL_BASE + static_bump)
+  stack_high = align_memory(stack_low + settings.TOTAL_STACK)
+  settings.STACK_BASE = stack_high
+  settings.STACK_MAX = stack_low
+  settings.HEAP_BASE = align_memory(stack_high)
 
 
 def report_missing_symbols(pre):
   # the initial list of missing functions are that the user explicitly exported
   # but were not implemented in compiled code
-  missing = set(shared.Settings.USER_EXPORTED_FUNCTIONS) - set(shared.Settings.IMPLEMENTED_FUNCTIONS)
+  missing = set(settings.USER_EXPORTED_FUNCTIONS) - set(settings.IMPLEMENTED_FUNCTIONS)
 
   for requested in sorted(missing):
     if (f'function {requested}(') not in pre:
@@ -194,24 +195,24 @@ def report_missing_symbols(pre):
 
   # Special hanlding for the `_main` symbol
 
-  if shared.Settings.STANDALONE_WASM:
+  if settings.STANDALONE_WASM:
     # standalone mode doesn't use main, and it always reports missing entry point at link time.
     # In this mode we never expect _main in the export list.
     return
 
-  if shared.Settings.IGNORE_MISSING_MAIN:
+  if settings.IGNORE_MISSING_MAIN:
     # The default mode for emscripten is to ignore the missing main function allowing
     # maximum compatibility.
     return
 
-  if shared.Settings.EXPECT_MAIN and '_main' not in shared.Settings.IMPLEMENTED_FUNCTIONS:
+  if settings.EXPECT_MAIN and '_main' not in settings.IMPLEMENTED_FUNCTIONS:
     # For compatibility with the output of wasm-ld we use the same wording here in our
     # error message as if wasm-ld had failed (i.e. in LLD_REPORT_UNDEFINED mode).
     exit_with_error('entry symbol not defined (pass --no-entry to suppress): main')
 
 
 def proxy_debug_print(sync):
-  if shared.Settings.PTHREADS_DEBUG:
+  if settings.PTHREADS_DEBUG:
     if sync:
       return 'warnOnce("sync proxying function " + code);'
     else:
@@ -253,10 +254,10 @@ def create_named_globals(metadata):
   named_globals = []
   for k, v in metadata['namedGlobals'].items():
     v = int(v)
-    if shared.Settings.RELOCATABLE:
-      v += shared.Settings.GLOBAL_BASE
+    if settings.RELOCATABLE:
+      v += settings.GLOBAL_BASE
     mangled = asmjs_mangle(k)
-    if shared.Settings.MINIMAL_RUNTIME:
+    if settings.MINIMAL_RUNTIME:
       named_globals.append("var %s = %s;" % (mangled, v))
     else:
       named_globals.append("var %s = Module['%s'] = %s;" % (mangled, mangled, v))
@@ -270,18 +271,18 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
   #     to use emscripten's wasm<->JS ABI
   #   * Use the metadata to generate the JS glue that goes with the wasm
 
-  if shared.Settings.SINGLE_FILE:
+  if settings.SINGLE_FILE:
     # placeholder strings for JS glue, to be replaced with subresource locations in do_binaryen
-    shared.Settings.WASM_BINARY_FILE = '<<< WASM_BINARY_FILE >>>'
+    settings.WASM_BINARY_FILE = '<<< WASM_BINARY_FILE >>>'
   else:
     # set file locations, so that JS glue can find what it needs
-    shared.Settings.WASM_BINARY_FILE = shared.JS.escape_for_js_string(os.path.basename(out_wasm))
+    settings.WASM_BINARY_FILE = shared.JS.escape_for_js_string(os.path.basename(out_wasm))
 
   metadata = finalize_wasm(in_wasm, out_wasm, memfile, DEBUG)
 
   update_settings_glue(metadata, DEBUG)
 
-  if shared.Settings.SIDE_MODULE:
+  if settings.SIDE_MODULE:
     if metadata['asmConsts']:
       exit_with_error('EM_ASM is not supported in side modules')
     if metadata['emJsFuncs']:
@@ -295,10 +296,10 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
 
   # memory and global initializers
 
-  if shared.Settings.RELOCATABLE:
+  if settings.RELOCATABLE:
     static_bump = align_memory(webassembly.parse_dylink_section(in_wasm)[0])
     set_memory(static_bump)
-    logger.debug('stack_base: %d, stack_max: %d, heap_base: %d', shared.Settings.STACK_BASE, shared.Settings.STACK_MAX, shared.Settings.HEAP_BASE)
+    logger.debug('stack_base: %d, stack_max: %d, heap_base: %d', settings.STACK_BASE, settings.STACK_MAX, settings.HEAP_BASE)
 
   glue, forwarded_data = compile_settings()
   if DEBUG:
@@ -315,7 +316,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
 
   exports = metadata['exports']
 
-  if shared.Settings.ASYNCIFY:
+  if settings.ASYNCIFY:
     exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
 
   report_missing_symbols(pre)
@@ -324,7 +325,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
     logger.debug('emscript: skipping remaining js glue generation')
     return
 
-  if shared.Settings.MINIMAL_RUNTIME:
+  if settings.MINIMAL_RUNTIME:
     # In MINIMAL_RUNTIME, atinit exists in the postamble part
     post = apply_static_code_hooks(forwarded_json, post)
   else:
@@ -332,7 +333,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
     pre = apply_static_code_hooks(forwarded_json, pre)
 
   # merge forwarded data
-  shared.Settings.EXPORTED_FUNCTIONS = forwarded_json['EXPORTED_FUNCTIONS']
+  settings.EXPORTED_FUNCTIONS = forwarded_json['EXPORTED_FUNCTIONS']
 
   asm_consts = create_asm_consts(metadata)
   em_js_funcs = create_em_js(forwarded_json, metadata)
@@ -351,8 +352,8 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
     sending = create_sending(invoke_funcs, metadata)
     receiving = create_receiving(exports)
 
-    if shared.Settings.MINIMAL_RUNTIME:
-      if shared.Settings.DECLARE_ASM_MODULE_EXPORTS:
+    if settings.MINIMAL_RUNTIME:
+      if settings.DECLARE_ASM_MODULE_EXPORTS:
         post = compute_minimal_runtime_initializer_and_exports(post, exports, receiving)
       receiving = ''
 
@@ -383,51 +384,51 @@ def finalize_wasm(infile, outfile, memfile, DEBUG):
   # if we don't need to modify the wasm, don't tell finalize to emit a wasm file
   modify_wasm = False
 
-  if shared.Settings.WASM2JS:
+  if settings.WASM2JS:
     # wasm2js requires full legalization (and will do extra wasm binary
     # later processing later anyhow)
     modify_wasm = True
-  if shared.Settings.GENERATE_SOURCE_MAP:
+  if settings.GENERATE_SOURCE_MAP:
     building.emit_wasm_source_map(infile, infile + '.map', outfile)
     building.save_intermediate(infile + '.map', 'base_wasm.map')
-    args += ['--output-source-map-url=' + shared.Settings.SOURCE_MAP_BASE + os.path.basename(outfile) + '.map']
+    args += ['--output-source-map-url=' + settings.SOURCE_MAP_BASE + os.path.basename(outfile) + '.map']
     modify_wasm = True
-  if shared.Settings.DEBUG_LEVEL >= 2 or shared.Settings.ASYNCIFY_ADD or shared.Settings.ASYNCIFY_ADVISE or shared.Settings.ASYNCIFY_ONLY or shared.Settings.ASYNCIFY_REMOVE or shared.Settings.EMIT_SYMBOL_MAP or shared.Settings.PROFILING_FUNCS:
+  if settings.DEBUG_LEVEL >= 2 or settings.ASYNCIFY_ADD or settings.ASYNCIFY_ADVISE or settings.ASYNCIFY_ONLY or settings.ASYNCIFY_REMOVE or settings.EMIT_SYMBOL_MAP or settings.PROFILING_FUNCS:
     args.append('-g')
-  if shared.Settings.WASM_BIGINT:
+  if settings.WASM_BIGINT:
     args.append('--bigint')
-  if shared.Settings.DYNCALLS:
+  if settings.DYNCALLS:
     # we need to add all dyncalls to the wasm
     modify_wasm = True
   else:
-    if shared.Settings.WASM_BIGINT:
+    if settings.WASM_BIGINT:
       args.append('--no-dyncalls')
     else:
       args.append('--dyncalls-i64')
       # we need to add some dyncalls to the wasm
       modify_wasm = True
-  if shared.Settings.LEGALIZE_JS_FFI:
+  if settings.LEGALIZE_JS_FFI:
     # When we dynamically link our JS loader adds functions from wasm modules to
     # the table. It must add the original versions of them, not legalized ones,
     # so that indirect calls have the right type, so export those.
-    if shared.Settings.RELOCATABLE:
+    if settings.RELOCATABLE:
       args.append('--pass-arg=legalize-js-interface-export-originals')
     modify_wasm = True
   else:
     args.append('--no-legalize-javascript-ffi')
   if memfile:
     args.append(f'--separate-data-segments={memfile}')
-    args.append(f'--global-base={shared.Settings.GLOBAL_BASE}')
+    args.append(f'--global-base={settings.GLOBAL_BASE}')
     modify_wasm = True
-  if shared.Settings.SIDE_MODULE:
+  if settings.SIDE_MODULE:
     args.append('--side-module')
-  if shared.Settings.STACK_OVERFLOW_CHECK >= 2:
+  if settings.STACK_OVERFLOW_CHECK >= 2:
     args.append('--check-stack-overflow')
     modify_wasm = True
-  if shared.Settings.STANDALONE_WASM:
+  if settings.STANDALONE_WASM:
     args.append('--standalone-wasm')
 
-  if shared.Settings.DEBUG_LEVEL >= 3:
+  if settings.DEBUG_LEVEL >= 3:
     args.append('--dwarf')
   stdout = building.run_binaryen_command('wasm-emscripten-finalize',
                                          infile=infile,
@@ -438,7 +439,7 @@ def finalize_wasm(infile, outfile, memfile, DEBUG):
     building.save_intermediate(infile, 'post_finalize.wasm')
   elif infile != outfile:
     shutil.copy(infile, outfile)
-  if shared.Settings.GENERATE_SOURCE_MAP:
+  if settings.GENERATE_SOURCE_MAP:
     building.save_intermediate(infile + '.map', 'post_finalize.map')
 
   if memfile:
@@ -490,27 +491,27 @@ def create_em_js(forwarded_json, metadata):
 
 
 def add_standard_wasm_imports(send_items_map):
-  if shared.Settings.IMPORTED_MEMORY:
+  if settings.IMPORTED_MEMORY:
     memory_import = 'wasmMemory'
-    if shared.Settings.MODULARIZE and shared.Settings.USE_PTHREADS:
+    if settings.MODULARIZE and settings.USE_PTHREADS:
       # Pthreads assign wasmMemory in their worker startup. In MODULARIZE mode, they cannot assign inside the
       # Module scope, so lookup via Module as well.
       memory_import += " || Module['wasmMemory']"
     send_items_map['memory'] = memory_import
 
-  if shared.Settings.SAFE_HEAP:
+  if settings.SAFE_HEAP:
     send_items_map['segfault'] = 'segfault'
     send_items_map['alignfault'] = 'alignfault'
 
-  if shared.Settings.RELOCATABLE:
+  if settings.RELOCATABLE:
     send_items_map['__indirect_function_table'] = 'wasmTable'
 
-  if shared.Settings.MAYBE_WASM2JS or shared.Settings.AUTODEBUG or shared.Settings.LINKABLE:
+  if settings.MAYBE_WASM2JS or settings.AUTODEBUG or settings.LINKABLE:
     # legalization of i64 support code may require these in some modes
     send_items_map['setTempRet0'] = 'setTempRet0'
     send_items_map['getTempRet0'] = 'getTempRet0'
 
-  if shared.Settings.AUTODEBUG:
+  if settings.AUTODEBUG:
     send_items_map['log_execution'] = '''function(loc) {
       console.log('log_execution ' + loc);
     }'''
@@ -646,7 +647,7 @@ def make_export_wrappers(exports, delay_assignment):
     # The emscripten stack functions are called very early (by writeStackCookie) before
     # the runtime is initialized so we can't create these wrappers that check for
     # runtimeInitialized.
-    if shared.Settings.ASSERTIONS and not name.startswith('emscripten_stack_'):
+    if settings.ASSERTIONS and not name.startswith('emscripten_stack_'):
       # With assertions enabled we create a wrapper that are calls get routed through, for
       # the lifetime of the program.
       if delay_assignment:
@@ -679,7 +680,7 @@ var %(mangled)s = Module["%(mangled)s"] = asm["%(name)s"]
 def create_receiving(exports):
   # When not declaring asm exports this section is empty and we instead programatically export
   # symbols on the global object by calling exportAsmFunctions after initialization
-  if not shared.Settings.DECLARE_ASM_MODULE_EXPORTS:
+  if not settings.DECLARE_ASM_MODULE_EXPORTS:
     return ''
 
   exports_that_are_not_initializers = [x for x in exports if x != WASM_INIT_FUNC]
@@ -688,25 +689,25 @@ def create_receiving(exports):
 
   # with WASM_ASYNC_COMPILATION that asm object may not exist at this point in time
   # so we need to support delayed assignment.
-  delay_assignment = shared.Settings.WASM_ASYNC_COMPILATION and not shared.Settings.MINIMAL_RUNTIME
+  delay_assignment = settings.WASM_ASYNC_COMPILATION and not settings.MINIMAL_RUNTIME
   if not delay_assignment:
-    if shared.Settings.MINIMAL_RUNTIME:
+    if settings.MINIMAL_RUNTIME:
       # In Wasm exports are assigned inside a function to variables existing in top level JS scope, i.e.
       # var _main;
       # WebAssembly.instantiate(Module["wasm"], imports).then((function(output) {
       # var asm = output.instance.exports;
       # _main = asm["_main"];
-      generate_dyncall_assignment = shared.Settings.DYNCALLS and '$dynCall' in shared.Settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE
+      generate_dyncall_assignment = settings.DYNCALLS and '$dynCall' in settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE
       for s in exports_that_are_not_initializers:
         mangled = asmjs_mangle(s)
         dynCallAssignment = ('dynCalls["' + s.replace('dynCall_', '') + '"] = ') if generate_dyncall_assignment and mangled.startswith('dynCall_') else ''
         receiving += [dynCallAssignment + mangled + ' = asm["' + s + '"];']
     else:
-      if shared.Settings.MINIMAL_RUNTIME:
+      if settings.MINIMAL_RUNTIME:
         # In wasm2js exports can be directly processed at top level, i.e.
         # var asm = Module["asm"](asmLibraryArg, buffer);
         # var _main = asm["_main"];
-        if shared.Settings.USE_PTHREADS and shared.Settings.MODULARIZE:
+        if settings.USE_PTHREADS and settings.MODULARIZE:
           # TODO: As a temp solution, multithreaded MODULARIZED MINIMAL_RUNTIME builds export all
           # symbols like regular runtime does.
           # Fix this by migrating worker.js code to reside inside the Module so it is in the same
@@ -720,7 +721,7 @@ def create_receiving(exports):
   else:
     receiving += make_export_wrappers(exports, delay_assignment)
 
-  if shared.Settings.MINIMAL_RUNTIME:
+  if settings.MINIMAL_RUNTIME:
     return '\n  '.join(receiving) + '\n'
   else:
     return '\n'.join(receiving) + '\n'
@@ -732,10 +733,10 @@ def create_module(sending, receiving, invoke_funcs, metadata):
   module = []
 
   module.append('var asmLibraryArg = %s;\n' % sending)
-  if shared.Settings.ASYNCIFY and shared.Settings.ASSERTIONS:
+  if settings.ASYNCIFY and settings.ASSERTIONS:
     module.append('Asyncify.instrumentWasmImports(asmLibraryArg);\n')
 
-  if not shared.Settings.MINIMAL_RUNTIME:
+  if not settings.MINIMAL_RUNTIME:
     module.append("var asm = createWasm();\n")
 
   module.append(receiving)
@@ -790,7 +791,7 @@ def load_metadata_wasm(metadata_raw, DEBUG):
   # not known auto-generated system functions.
   unexpected_exports = [e for e in metadata['exports'] if treat_as_user_function(e)]
   unexpected_exports = [asmjs_mangle(e) for e in unexpected_exports]
-  unexpected_exports = [e for e in unexpected_exports if e not in shared.Settings.EXPORTED_FUNCTIONS]
+  unexpected_exports = [e for e in unexpected_exports if e not in settings.EXPORTED_FUNCTIONS]
   building.user_requested_exports += unexpected_exports
 
   return metadata
@@ -822,11 +823,11 @@ def generate_struct_info():
     with ToolchainProfiler.profile_block('gen_struct_info'):
       gen_struct_info.main(['-q', '-o', out])
 
-  shared.Settings.STRUCT_INFO = shared.Cache.get(generated_struct_info_name, generate_struct_info)
+  settings.STRUCT_INFO = shared.Cache.get(generated_struct_info_name, generate_struct_info)
 
 
 def run(in_wasm, out_wasm, outfile_js, memfile):
-  if not shared.Settings.BOOTSTRAPPING_STRUCT_INFO:
+  if not settings.BOOTSTRAPPING_STRUCT_INFO:
     generate_struct_info()
 
   emscript(in_wasm, out_wasm, outfile_js, memfile, shared.DEBUG)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8488,7 +8488,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('TOTAL_STACK', 4 * 1024 * 1024)
     self.do_core_test('test_stack_get_free.c')
 
-  # Tests Settings.ABORT_ON_WASM_EXCEPTIONS
+  # Tests settings.ABORT_ON_WASM_EXCEPTIONS
   def test_abort_on_exceptions(self):
     self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap'])

--- a/tools/building.py
+++ b/tools/building.py
@@ -20,7 +20,7 @@ from . import shared
 from . import webassembly
 from . import config
 from .toolchain_profiler import ToolchainProfiler
-from .shared import Settings, CLANG_CC, CLANG_CXX, PYTHON
+from .shared import CLANG_CC, CLANG_CXX, PYTHON
 from .shared import LLVM_NM, EMCC, EMAR, EMXX, EMRANLIB, WASM_LD, LLVM_AR
 from .shared import LLVM_LINK, LLVM_OBJCOPY
 from .shared import try_delete, run_process, check_call, exit_with_error
@@ -30,6 +30,7 @@ from .shared import TEMP_DIR
 from .shared import CANONICAL_TEMP_DIR, LLVM_DWARFDUMP, demangle_c_symbol_name
 from .shared import get_emscripten_temp_dir, exe_suffix, is_c_symbol
 from .utils import WINDOWS
+from .settings import settings
 
 logger = logging.getLogger('building')
 
@@ -312,17 +313,17 @@ def llvm_backend_args():
   args = ['-combiner-global-alias-analysis=false']
 
   # asm.js-style exception handling
-  if not Settings.DISABLE_EXCEPTION_CATCHING:
+  if not settings.DISABLE_EXCEPTION_CATCHING:
     args += ['-enable-emscripten-cxx-exceptions']
-  if Settings.EXCEPTION_CATCHING_ALLOWED:
+  if settings.EXCEPTION_CATCHING_ALLOWED:
     # When 'main' has a non-standard signature, LLVM outlines its content out to
     # '__original_main'. So we add it to the allowed list as well.
-    if 'main' in Settings.EXCEPTION_CATCHING_ALLOWED:
-      Settings.EXCEPTION_CATCHING_ALLOWED += ['__original_main']
-    allowed = ','.join(Settings.EXCEPTION_CATCHING_ALLOWED)
+    if 'main' in settings.EXCEPTION_CATCHING_ALLOWED:
+      settings.EXCEPTION_CATCHING_ALLOWED += ['__original_main']
+    allowed = ','.join(settings.EXCEPTION_CATCHING_ALLOWED)
     args += ['-emscripten-cxx-exceptions-allowed=' + allowed]
 
-  if Settings.SUPPORT_LONGJMP:
+  if settings.SUPPORT_LONGJMP:
     # asm.js-style setjmp/longjmp handling
     args += ['-enable-emscripten-sjlj']
 
@@ -335,7 +336,7 @@ def llvm_backend_args():
 
 def link_to_object(linker_inputs, target):
   # link using lld unless LTO is requested (lld can't output LTO/bitcode object files).
-  if not Settings.LTO:
+  if not settings.LTO:
     link_lld(linker_inputs + ['--relocatable'], target)
   else:
     link_bitcode(linker_inputs, target)
@@ -358,28 +359,28 @@ def lld_flags_for_executable(external_symbol_list):
   else:
     cmd.append('--allow-undefined')
 
-  if Settings.IMPORTED_MEMORY:
+  if settings.IMPORTED_MEMORY:
     cmd.append('--import-memory')
 
-  if Settings.USE_PTHREADS:
+  if settings.USE_PTHREADS:
     cmd.append('--shared-memory')
 
-  if Settings.MEMORY64:
+  if settings.MEMORY64:
     cmd.append('-mwasm64')
 
   # wasm-ld can strip debug info for us. this strips both the Names
   # section and DWARF, so we can only use it when we don't need any of
   # those things.
-  if Settings.DEBUG_LEVEL < 2 and (not Settings.EMIT_SYMBOL_MAP and
-                                   not Settings.PROFILING_FUNCS and
-                                   not Settings.ASYNCIFY):
+  if settings.DEBUG_LEVEL < 2 and (not settings.EMIT_SYMBOL_MAP and
+                                   not settings.PROFILING_FUNCS and
+                                   not settings.ASYNCIFY):
     cmd.append('--strip-debug')
 
-  if Settings.LINKABLE:
+  if settings.LINKABLE:
     cmd.append('--export-all')
     cmd.append('--no-gc-sections')
   else:
-    c_exports = [e for e in Settings.EXPORTED_FUNCTIONS if is_c_symbol(e)]
+    c_exports = [e for e in settings.EXPORTED_FUNCTIONS if is_c_symbol(e)]
     # Strip the leading underscores
     c_exports = [demangle_c_symbol_name(e) for e in c_exports]
     if external_symbol_list:
@@ -388,44 +389,44 @@ def lld_flags_for_executable(external_symbol_list):
     for export in c_exports:
       cmd += ['--export', export]
 
-  if Settings.RELOCATABLE:
+  if settings.RELOCATABLE:
     cmd.append('--experimental-pic')
-    if Settings.SIDE_MODULE:
+    if settings.SIDE_MODULE:
       cmd.append('-shared')
     else:
       cmd.append('-pie')
-    if not Settings.LINKABLE:
+    if not settings.LINKABLE:
       cmd.append('--no-export-dynamic')
   else:
     cmd.append('--export-table')
-    if Settings.ALLOW_TABLE_GROWTH:
+    if settings.ALLOW_TABLE_GROWTH:
       cmd.append('--growable-table')
 
-  if not Settings.SIDE_MODULE:
+  if not settings.SIDE_MODULE:
     # Export these two section start symbols so that we can extact the string
     # data that they contain.
     cmd += [
       '--export', '__start_em_asm',
       '--export', '__stop_em_asm',
-      '-z', 'stack-size=%s' % Settings.TOTAL_STACK,
-      '--initial-memory=%d' % Settings.INITIAL_MEMORY,
+      '-z', 'stack-size=%s' % settings.TOTAL_STACK,
+      '--initial-memory=%d' % settings.INITIAL_MEMORY,
     ]
 
-    if Settings.STANDALONE_WASM:
-      # when Settings.EXPECT_MAIN is set we fall back to wasm-ld default of _start
-      if not Settings.EXPECT_MAIN:
+    if settings.STANDALONE_WASM:
+      # when settings.EXPECT_MAIN is set we fall back to wasm-ld default of _start
+      if not settings.EXPECT_MAIN:
         cmd += ['--entry=_initialize']
     else:
-      if Settings.EXPECT_MAIN and not Settings.IGNORE_MISSING_MAIN:
+      if settings.EXPECT_MAIN and not settings.IGNORE_MISSING_MAIN:
         cmd += ['--entry=main']
       else:
         cmd += ['--no-entry']
-    if not Settings.ALLOW_MEMORY_GROWTH:
-      cmd.append('--max-memory=%d' % Settings.INITIAL_MEMORY)
-    elif Settings.MAXIMUM_MEMORY != -1:
-      cmd.append('--max-memory=%d' % Settings.MAXIMUM_MEMORY)
-    if not Settings.RELOCATABLE:
-      cmd.append('--global-base=%s' % Settings.GLOBAL_BASE)
+    if not settings.ALLOW_MEMORY_GROWTH:
+      cmd.append('--max-memory=%d' % settings.INITIAL_MEMORY)
+    elif settings.MAXIMUM_MEMORY != -1:
+      cmd.append('--max-memory=%d' % settings.MAXIMUM_MEMORY)
+    if not settings.RELOCATABLE:
+      cmd.append('--global-base=%s' % settings.GLOBAL_BASE)
 
   return cmd
 
@@ -441,11 +442,11 @@ def link_lld(args, target, external_symbol_list=None):
 
   # Emscripten currently expects linkable output (SIDE_MODULE/MAIN_MODULE) to
   # include all archive contents.
-  if Settings.LINKABLE:
+  if settings.LINKABLE:
     args.insert(0, '--whole-archive')
     args.append('--no-whole-archive')
 
-  if Settings.STRICT:
+  if settings.STRICT:
     args.append('--fatal-warnings')
 
   cmd = [WASM_LD, '-o', target] + args
@@ -467,7 +468,7 @@ def link_bitcode(files, target, force_archive_contents=False):
   # Tracking unresolveds is necessary for .a linking, see below.
   # Specify all possible entry points to seed the linking process.
   # For a simple application, this would just be "main".
-  unresolved_symbols = set([func[1:] for func in Settings.EXPORTED_FUNCTIONS])
+  unresolved_symbols = set([func[1:] for func in settings.EXPORTED_FUNCTIONS])
   resolved_symbols = set()
   # Paths of already included object files from archives.
   added_contents = set()
@@ -695,9 +696,9 @@ def acorn_optimizer(filename, passes, extra_info=None, return_output=False):
   cmd = config.NODE_JS + [optimizer, filename] + passes
   # Keep JS code comments intact through the acorn optimization pass so that JSDoc comments
   # will be carried over to a later Closure run.
-  if Settings.USE_CLOSURE_COMPILER:
+  if settings.USE_CLOSURE_COMPILER:
     cmd += ['--closureFriendly']
-  if Settings.VERBOSE:
+  if settings.VERBOSE:
     cmd += ['verbose']
   if not return_output:
     next = original_filename + '.jso.js'
@@ -715,7 +716,7 @@ def eval_ctors(js_file, binary_file, debug_info=False): # noqa
   logger.debug('Ctor evalling in the wasm backend is disabled due to https://github.com/emscripten-core/emscripten/issues/9527')
   return
   # TODO re-enable
-  # cmd = [PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, binary_file, str(Settings.INITIAL_MEMORY), str(Settings.TOTAL_STACK), str(Settings.GLOBAL_BASE), binaryen_bin, str(int(debug_info))]
+  # cmd = [PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, binary_file, str(settings.INITIAL_MEMORY), str(settings.TOTAL_STACK), str(settings.GLOBAL_BASE), binaryen_bin, str(int(debug_info))]
   # if binaryen_bin:
   #   cmd += get_binaryen_feature_flags()
   # check_call(cmd)
@@ -789,9 +790,9 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
     # Closure compiler needs to know about all exports that come from the wasm module, because to optimize for small code size,
     # the exported symbols are added to global scope via a foreach loop in a way that evades Closure's static analysis. With an explicit
     # externs file for the exports, Closure is able to reason about the exports.
-    if Settings.MODULE_EXPORTS and not Settings.DECLARE_ASM_MODULE_EXPORTS:
+    if settings.MODULE_EXPORTS and not settings.DECLARE_ASM_MODULE_EXPORTS:
       # Generate an exports file that records all the exported symbols from the wasm module.
-      module_exports_suppressions = '\n'.join(['/**\n * @suppress {duplicate, undefinedVars}\n */\nvar %s;\n' % i for i, j in Settings.MODULE_EXPORTS])
+      module_exports_suppressions = '\n'.join(['/**\n * @suppress {duplicate, undefinedVars}\n */\nvar %s;\n' % i for i, j in settings.MODULE_EXPORTS])
       exports_file = configuration.get_temp_files().get('_module_exports.js')
       exports_file.write(module_exports_suppressions.encode())
       exports_file.close()
@@ -821,7 +822,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
                            if name.endswith('.js')]
         CLOSURE_EXTERNS += BROWSER_EXTERNS
 
-    if Settings.MINIMAL_RUNTIME and Settings.USE_PTHREADS and not Settings.MODULARIZE:
+    if settings.MINIMAL_RUNTIME and settings.USE_PTHREADS and not settings.MODULARIZE:
       CLOSURE_EXTERNS += [path_from_root('src', 'minimal_runtime_worker_externs.js')]
 
     args = ['--compilation_level', 'ADVANCED_OPTIMIZATIONS' if advanced else 'SIMPLE_OPTIMIZATIONS']
@@ -854,7 +855,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
     # Specify output file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
     args += ['--js_output_file', os.path.relpath(outfile, tempfiles.tmpdir)]
 
-    if Settings.IGNORE_CLOSURE_COMPILER_ERRORS:
+    if settings.IGNORE_CLOSURE_COMPILER_ERRORS:
       args.append('--jscomp_off=*')
     if pretty:
       args += ['--formatting', 'PRETTY_PRINT']
@@ -880,13 +881,13 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
     if proc.returncode != 0:
       logger.error('Closure compiler run failed:\n')
     elif len(proc.stderr.strip()) > 0:
-      if Settings.CLOSURE_WARNINGS == 'error':
+      if settings.CLOSURE_WARNINGS == 'error':
         logger.error('Closure compiler completed with warnings and -s CLOSURE_WARNINGS=error enabled, aborting!\n')
-      elif Settings.CLOSURE_WARNINGS == 'warn':
+      elif settings.CLOSURE_WARNINGS == 'warn':
         logger.warn('Closure compiler completed with warnings:\n')
 
     # Print input file (long wall of text!)
-    if DEBUG == 2 and (proc.returncode != 0 or (len(proc.stderr.strip()) > 0 and Settings.CLOSURE_WARNINGS != 'quiet')):
+    if DEBUG == 2 and (proc.returncode != 0 or (len(proc.stderr.strip()) > 0 and settings.CLOSURE_WARNINGS != 'quiet')):
       input_file = open(filename, 'r').read().splitlines()
       for i in range(len(input_file)):
         sys.stderr.write(str(i + 1) + ': ' + input_file[i] + '\n')
@@ -900,9 +901,9 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
         msg += ' the error message may be clearer with -g1 and EMCC_DEBUG=2 set'
       exit_with_error(msg)
 
-    if len(proc.stderr.strip()) > 0 and Settings.CLOSURE_WARNINGS != 'quiet':
+    if len(proc.stderr.strip()) > 0 and settings.CLOSURE_WARNINGS != 'quiet':
       # print list of warnings (possibly long wall of text if input was minified)
-      if Settings.CLOSURE_WARNINGS == 'error':
+      if settings.CLOSURE_WARNINGS == 'error':
         logger.error(proc.stderr)
       else:
         logger.warn(proc.stderr)
@@ -913,7 +914,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
       elif DEBUG != 2:
         logger.warn('(rerun with EMCC_DEBUG=2 enabled to dump Closure input file)')
 
-      if Settings.CLOSURE_WARNINGS == 'error':
+      if settings.CLOSURE_WARNINGS == 'error':
         exit_with_error('closure compiler produced warnings and -s CLOSURE_WARNINGS=error enabled')
 
     return outfile
@@ -926,7 +927,7 @@ def minify_wasm_js(js_file, wasm_file, expensive_optimizations, minify_whitespac
   # use AJSDCE (aggressive JS DCE, performs multiple iterations). Clean up
   # whitespace if necessary too.
   passes = []
-  if not Settings.LINKABLE:
+  if not settings.LINKABLE:
     passes.append('JSDCE' if not expensive_optimizations else 'AJSDCE')
   if minify_whitespace:
     passes.append('minifyWhitespace')
@@ -935,7 +936,7 @@ def minify_wasm_js(js_file, wasm_file, expensive_optimizations, minify_whitespac
     js_file = acorn_optimizer(js_file, passes)
   # if we can optimize this js+wasm combination under the assumption no one else
   # will see the internals, do so
-  if not Settings.LINKABLE:
+  if not settings.LINKABLE:
     # if we are optimizing for size, shrink the combined wasm+JS
     # TODO: support this when a symbol map is used
     if expensive_optimizations:
@@ -947,8 +948,8 @@ def minify_wasm_js(js_file, wasm_file, expensive_optimizations, minify_whitespac
         passes.append('minifyWhitespace')
       logger.debug('running post-meta-DCE cleanup on shell code: ' + ' '.join(passes))
       js_file = acorn_optimizer(js_file, passes)
-      if Settings.MINIFY_WASM_IMPORTS_AND_EXPORTS:
-        js_file = minify_wasm_imports_and_exports(js_file, wasm_file, minify_whitespace=minify_whitespace, minify_exports=Settings.MINIFY_ASMJS_EXPORT_NAMES, debug_info=debug_info)
+      if settings.MINIFY_WASM_IMPORTS_AND_EXPORTS:
+        js_file = minify_wasm_imports_and_exports(js_file, wasm_file, minify_whitespace=minify_whitespace, minify_exports=settings.MINIFY_ASMJS_EXPORT_NAMES, debug_info=debug_info)
   return js_file
 
 
@@ -957,16 +958,16 @@ def metadce(js_file, wasm_file, minify_whitespace, debug_info):
   logger.debug('running meta-DCE')
   temp_files = configuration.get_temp_files()
   # first, get the JS part of the graph
-  extra_info = '{ "exports": [' + ','.join(map(lambda x: '["' + x[0] + '","' + x[1] + '"]', Settings.MODULE_EXPORTS)) + ']}'
+  extra_info = '{ "exports": [' + ','.join(map(lambda x: '["' + x[0] + '","' + x[1] + '"]', settings.MODULE_EXPORTS)) + ']}'
   txt = acorn_optimizer(js_file, ['emitDCEGraph', 'noPrint'], return_output=True, extra_info=extra_info)
   graph = json.loads(txt)
   # add exports based on the backend output, that are not present in the JS
-  if not Settings.DECLARE_ASM_MODULE_EXPORTS:
+  if not settings.DECLARE_ASM_MODULE_EXPORTS:
     exports = set()
     for item in graph:
       if 'export' in item:
         exports.add(item['export'])
-    for export, unminified in Settings.MODULE_EXPORTS:
+    for export, unminified in settings.MODULE_EXPORTS:
       if export not in exports:
         graph.append({
           'export': export,
@@ -979,17 +980,17 @@ def metadce(js_file, wasm_file, minify_whitespace, debug_info):
       export = item['export']
       # wasm backend's exports are prefixed differently inside the wasm
       export = asmjs_mangle(export)
-      if export in user_requested_exports or Settings.EXPORT_ALL:
+      if export in user_requested_exports or settings.EXPORT_ALL:
         item['root'] = True
   # in standalone wasm, always export the memory
-  if not Settings.IMPORTED_MEMORY:
+  if not settings.IMPORTED_MEMORY:
     graph.append({
       'export': 'memory',
       'name': 'emcc$export$memory',
       'reaches': [],
       'root': True
     })
-  if not Settings.RELOCATABLE:
+  if not settings.RELOCATABLE:
     graph.append({
       'export': '__indirect_function_table',
       'name': 'emcc$export$__indirect_function_table',
@@ -1016,7 +1017,7 @@ def metadce(js_file, wasm_file, minify_whitespace, debug_info):
   ])
   for item in graph:
     if 'import' in item and item['import'][1][1:] in WASI_IMPORTS:
-      item['import'][0] = Settings.WASI_MODULE_NAME
+      item['import'][0] = settings.WASI_MODULE_NAME
   # fixup wasm backend prefixing
   for item in graph:
     if 'import' in item:
@@ -1060,8 +1061,8 @@ def asyncify_lazy_load_code(wasm_target, debug):
   # segments have already been applied by the initial wasm, and apply the knowledge
   # that it will only rewind, after which optimizations can remove some code
   args = ['--remove-memory', '--mod-asyncify-never-unwind']
-  if Settings.OPT_LEVEL > 0:
-    args.append(opt_level_to_str(Settings.OPT_LEVEL, Settings.SHRINK_LEVEL))
+  if settings.OPT_LEVEL > 0:
+    args.append(opt_level_to_str(settings.OPT_LEVEL, settings.SHRINK_LEVEL))
   run_wasm_opt(wasm_target,
                wasm_target + '.lazy.wasm',
                args=args,
@@ -1072,8 +1073,8 @@ def asyncify_lazy_load_code(wasm_target, debug):
   # TODO: support other asyncify stuff, imports that don't always unwind?
   # TODO: source maps etc.
   args = ['--mod-asyncify-always-and-only-unwind']
-  if Settings.OPT_LEVEL > 0:
-    args.append(opt_level_to_str(Settings.OPT_LEVEL, Settings.SHRINK_LEVEL))
+  if settings.OPT_LEVEL > 0:
+    args.append(opt_level_to_str(settings.OPT_LEVEL, settings.SHRINK_LEVEL))
   run_wasm_opt(infile=wasm_target,
                outfile=wasm_target,
                args=args,
@@ -1086,7 +1087,7 @@ def minify_wasm_imports_and_exports(js_file, wasm_file, minify_whitespace, minif
   if minify_exports:
     # standalone wasm mode means we need to emit a wasi import module.
     # otherwise, minify even the imported module names.
-    if Settings.MINIFY_WASM_IMPORTED_MODULES:
+    if settings.MINIFY_WASM_IMPORTED_MODULES:
       pass_name = '--minify-imports-and-exports-and-modules'
     else:
       pass_name = '--minify-imports-and-exports'
@@ -1134,7 +1135,7 @@ def wasm2js(js_file, wasm_file, opt_level, minify_whitespace, use_closure_compil
   # JS optimizations
   if opt_level >= 2:
     passes = []
-    if not debug_info and not Settings.USE_PTHREADS:
+    if not debug_info and not settings.USE_PTHREADS:
       passes += ['minifyNames']
       if symbols_file_js:
         passes += ['symbolMap=%s' % symbols_file_js]
@@ -1204,10 +1205,10 @@ def strip(infile, outfile, debug=False, producers=False):
 #       wasm as well
 def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   # if the dwarf filename wasn't provided, use the default target + a suffix
-  wasm_file_with_dwarf = shared.Settings.SEPARATE_DWARF
+  wasm_file_with_dwarf = settings.SEPARATE_DWARF
   if wasm_file_with_dwarf is True:
     wasm_file_with_dwarf = wasm_file + '.debug.wasm'
-  embedded_path = shared.Settings.SEPARATE_DWARF_URL
+  embedded_path = settings.SEPARATE_DWARF_URL
   if not embedded_path:
     # a path was provided - make it relative to the wasm.
     embedded_path = os.path.relpath(wasm_file_with_dwarf,
@@ -1356,8 +1357,8 @@ def map_to_js_libs(library_name):
   return None
 
 
-# map a linker flag to a Settings option, and apply it. this lets a user write
-# -lSDL2 and it will have the same effect as -s USE_SDL=2.
+# Map a linker flag to a settings. This lets a user write -lSDL2 and it will have the same effect as
+# -s USE_SDL=2.
 def map_and_apply_to_settings(library_name):
   # most libraries just work, because the -l name matches the name of the
   # library we build. however, if a library has variations, which cause us to
@@ -1370,7 +1371,7 @@ def map_and_apply_to_settings(library_name):
   if library_name in library_map:
     for key, value in library_map[library_name]:
       logger.debug('Mapping library `%s` to settings changes: %s = %s' % (library_name, key, value))
-      setattr(shared.Settings, key, value)
+      setattr(settings, key, value)
     return True
 
   return False
@@ -1391,11 +1392,11 @@ def emit_wasm_source_map(wasm_file, map_file, final_wasm):
 def get_binaryen_feature_flags():
   # start with the MVP features, add the rest as needed
   ret = ['--mvp-features']
-  if Settings.USE_PTHREADS:
+  if settings.USE_PTHREADS:
     ret += ['--enable-threads']
-  if Settings.MEMORY64:
+  if settings.MEMORY64:
     ret += ['--enable-memory64']
-  ret += Settings.BINARYEN_FEATURES
+  ret += settings.BINARYEN_FEATURES
   return ret
 
 
@@ -1433,7 +1434,7 @@ def get_binaryen_bin():
 def run_binaryen_command(tool, infile, outfile=None, args=[], debug=False, stdout=None):
   cmd = [os.path.join(get_binaryen_bin(), tool)]
   if outfile and tool == 'wasm-opt' and \
-     (Settings.DEBUG_LEVEL < 3 or shared.Settings.GENERATE_SOURCE_MAP):
+     (settings.DEBUG_LEVEL < 3 or settings.GENERATE_SOURCE_MAP):
     # remove any dwarf debug info sections, if the debug level is <3, as
     # we don't need them; also remove them if we use source maps (which are
     # implemented separately from dwarf).
@@ -1452,15 +1453,15 @@ def run_binaryen_command(tool, infile, outfile=None, args=[], debug=False, stdou
     cmd += [infile]
   if outfile:
     cmd += ['-o', outfile]
-    if Settings.ERROR_ON_WASM_CHANGES_AFTER_LINK:
+    if settings.ERROR_ON_WASM_CHANGES_AFTER_LINK:
       # emit some extra helpful text for common issues
       extra = ''
       # a plain -O0 build *almost* doesn't need post-link changes, except for
       # legalization. show a clear error for those (as the flags the user passed
       # in are not enough to see what went wrong)
-      if shared.Settings.LEGALIZE_JS_FFI:
+      if settings.LEGALIZE_JS_FFI:
         extra += '\nnote: to disable int64 legalization (which requires changes after link) use -s WASM_BIGINT'
-      if shared.Settings.OPT_LEVEL > 0:
+      if settings.OPT_LEVEL > 0:
         extra += '\nnote: -O2+ optimizations always require changes, build with -O0 or -O1 instead'
       exit_with_error('changes to the wasm are required after link, but disallowed by ERROR_ON_WASM_CHANGES_AFTER_LINK: ' + str(cmd) + extra)
   if debug:
@@ -1470,7 +1471,7 @@ def run_binaryen_command(tool, infile, outfile=None, args=[], debug=False, stdou
     cmd += get_binaryen_feature_flags()
   # if we are emitting a source map, every time we load and save the wasm
   # we must tell binaryen to update it
-  if Settings.GENERATE_SOURCE_MAP and outfile:
+  if settings.GENERATE_SOURCE_MAP and outfile:
     cmd += ['--input-source-map=' + infile + '.map']
     cmd += ['--output-source-map=' + outfile + '.map']
   ret = check_call(cmd, stdout=stdout).stdout

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -7,6 +7,7 @@ import contextlib
 import logging
 import os
 from . import tempfiles, filelock, config, utils
+from .settings import settings
 
 logger = logging.getLogger('cache')
 
@@ -98,15 +99,15 @@ class Cache:
 
   def get_lib_dir(self, absolute):
     path = os.path.join(self.get_sysroot_dir(absolute=absolute), 'lib')
-    if shared.Settings.MEMORY64:
+    if settings.MEMORY64:
       path = os.path.join(path, 'wasm64-emscripten')
     else:
       path = os.path.join(path, 'wasm32-emscripten')
     # if relevant, use a subdir of the cache
     subdir = []
-    if shared.Settings.LTO:
+    if settings.LTO:
       subdir.append('lto')
-    if shared.Settings.RELOCATABLE:
+    if settings.RELOCATABLE:
       subdir.append('pic')
     if subdir:
       path = os.path.join(path, '-'.join(subdir))
@@ -160,6 +161,3 @@ class Cache:
       logger.info(' - ok')
 
     return cachename
-
-
-from . import shared

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -89,6 +89,7 @@ sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tools import shared
 from tools import system_libs
+from tools.settings import settings
 
 QUIET = (__name__ != '__main__')
 DEBUG = False
@@ -270,8 +271,8 @@ def inspect_headers(headers, cflags):
   # TODO(sbc): Remove this one we remove the test_em_config_env_var test
   cmd += ['-Wno-deprecated']
 
-  if shared.Settings.LTO:
-    cmd += ['-flto=' + shared.Settings.LTO]
+  if settings.LTO:
+    cmd += ['-flto=' + settings.LTO]
 
   show(shared.shlex_join(cmd))
   try:

--- a/tools/js_manipulation.py
+++ b/tools/js_manipulation.py
@@ -3,12 +3,12 @@
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
 # found in the LICENSE file.
 
-from . import shared
+from .settings import settings
 
 
 def add_files_pre_js(user_pre_js, files_pre_js):
   # the normal thing is to just combine the pre-js content
-  if not shared.Settings.ASSERTIONS:
+  if not settings.ASSERTIONS:
     return files_pre_js + user_pre_js
 
   # if a user pre-js tramples the file code's changes to Module.preRun

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -10,108 +10,103 @@ import re
 from .utils import path_from_root, exit_with_error
 from . import diagnostics
 
-attrs = {}
-legacy_settings = {}
-alt_names = {}
-internal_settings = set()
-
-
-def load_settings():
-  attrs.clear()
-  legacy_settings.clear()
-  alt_names.clear()
-  internal_settings.clear()
-
-  # Load the JS defaults into python.
-  settings = open(path_from_root('src', 'settings.js')).read().replace('//', '#')
-  settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
-  # Variable TARGET_NOT_SUPPORTED is referenced by value settings.js (also beyond declaring it),
-  # so must pass it there explicitly.
-  exec(settings, {'attrs': attrs})
-
-  settings = open(path_from_root('src', 'settings_internal.js')).read().replace('//', '#')
-  settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
-  internal_attrs = {}
-  exec(settings, {'attrs': internal_attrs})
-  attrs.update(internal_attrs)
-
-  if 'EMCC_STRICT' in os.environ:
-    attrs['STRICT'] = int(os.environ.get('EMCC_STRICT'))
-
-  # Special handling for LEGACY_SETTINGS.  See src/setting.js for more
-  # details
-  for legacy in attrs['LEGACY_SETTINGS']:
-    if len(legacy) == 2:
-      name, new_name = legacy
-      legacy_settings[name] = (None, 'setting renamed to ' + new_name)
-      alt_names[name] = new_name
-      alt_names[new_name] = name
-      default_value = attrs[new_name]
-    else:
-      name, fixed_values, err = legacy
-      legacy_settings[name] = (fixed_values, err)
-      default_value = fixed_values[0]
-    assert name not in attrs, 'legacy setting (%s) cannot also be a regular setting' % name
-    if not attrs['STRICT']:
-      attrs[name] = default_value
-
-  internal_settings.update(internal_attrs.keys())
-
-
-def set_setting(name, value):
-  if name == 'STRICT' and value:
-    for a in legacy_settings:
-      attrs.pop(a, None)
-
-  if name in legacy_settings:
-    # TODO(sbc): Rather then special case this we should have STRICT turn on the
-    # legacy-settings warning below
-    if attrs['STRICT']:
-      exit_with_error('legacy setting used in strict mode: %s', name)
-    fixed_values, error_message = legacy_settings[name]
-    if fixed_values and value not in fixed_values:
-      exit_with_error('Invalid command line option -s ' + name + '=' + str(value) + ': ' + error_message)
-    diagnostics.warning('legacy-settings', 'use of legacy setting: %s (%s)', name, error_message)
-
-  if name in alt_names:
-    alt_name = alt_names[name]
-    attrs[alt_name] = value
-
-  if name not in attrs:
-    msg = "Attempt to set a non-existent setting: '%s'\n" % name
-    suggestions = difflib.get_close_matches(name, list(attrs.keys()))
-    suggestions = [s for s in suggestions if s not in legacy_settings]
-    suggestions = ', '.join(suggestions)
-    if suggestions:
-      msg += ' - did you mean one of %s?\n' % suggestions
-    msg += " - perhaps a typo in emcc's  -s X=Y  notation?\n"
-    msg += ' - (see src/settings.js for valid values)'
-    exit_with_error(msg)
-
-  attrs[name] = value
-
 
 class SettingsManager:
+  attrs = {}
+  legacy_settings = {}
+  alt_names = {}
+  internal_settings = set()
+
   def __init__(self):
-    load_settings()
+    self.attrs.clear()
+    self.legacy_settings.clear()
+    self.alt_names.clear()
+    self.internal_settings.clear()
+
+    # Load the JS defaults into python.
+    settings = open(path_from_root('src', 'settings.js')).read().replace('//', '#')
+    settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
+    # Variable TARGET_NOT_SUPPORTED is referenced by value settings.js (also beyond declaring it),
+    # so must pass it there explicitly.
+    exec(settings, {'attrs': self.attrs})
+
+    settings = open(path_from_root('src', 'settings_internal.js')).read().replace('//', '#')
+    settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
+    internal_attrs = {}
+    exec(settings, {'attrs': internal_attrs})
+    self.attrs.update(internal_attrs)
+
+    if 'EMCC_STRICT' in os.environ:
+      self.attrs['STRICT'] = int(os.environ.get('EMCC_STRICT'))
+
+    # Special handling for LEGACY_SETTINGS.  See src/setting.js for more
+    # details
+    for legacy in self.attrs['LEGACY_SETTINGS']:
+      if len(legacy) == 2:
+        name, new_name = legacy
+        self.legacy_settings[name] = (None, 'setting renamed to ' + new_name)
+        self.alt_names[name] = new_name
+        self.alt_names[new_name] = name
+        default_value = self.attrs[new_name]
+      else:
+        name, fixed_values, err = legacy
+        self.legacy_settings[name] = (fixed_values, err)
+        default_value = fixed_values[0]
+      assert name not in self.attrs, 'legacy setting (%s) cannot also be a regular setting' % name
+      if not self.attrs['STRICT']:
+        self.attrs[name] = default_value
+
+    self.internal_settings.update(internal_attrs.keys())
 
   def dict(self):
-    return attrs
+    return self.attrs
 
   def keys(self):
-    return attrs.keys()
+    return self.attrs.keys()
 
   def __getattr__(self, attr):
-    if attr in attrs:
-      return attrs[attr]
+    if attr in self.attrs:
+      return self.attrs[attr]
     else:
-      raise AttributeError("Settings object has no attribute '%s'" % attr)
+      raise AttributeError("no such setting: '%s'" % attr)
 
-  def __setattr__(self, attr, value):
-    set_setting(attr, value)
+  def __setattr__(self, name, value):
+    if name == 'STRICT' and value:
+      for a in self.legacy_settings:
+        self.attrs.pop(a, None)
+
+    if name in self.legacy_settings:
+      # TODO(sbc): Rather then special case this we should have STRICT turn on the
+      # legacy-settings warning below
+      if self.attrs['STRICT']:
+        exit_with_error('legacy setting used in strict mode: %s', name)
+      fixed_values, error_message = self.legacy_settings[name]
+      if fixed_values and value not in fixed_values:
+        exit_with_error('Invalid command line option -s ' + name + '=' + str(value) + ': ' + error_message)
+      diagnostics.warning('legacy-settings', 'use of legacy setting: %s (%s)', name, error_message)
+
+    if name in self.alt_names:
+      alt_name = self.alt_names[name]
+      self.attrs[alt_name] = value
+
+    if name not in self.attrs:
+      msg = "Attempt to set a non-existent setting: '%s'\n" % name
+      suggestions = difflib.get_close_matches(name, list(self.attrs.keys()))
+      suggestions = [s for s in suggestions if s not in self.legacy_settings]
+      suggestions = ', '.join(suggestions)
+      if suggestions:
+        msg += ' - did you mean one of %s?\n' % suggestions
+      msg += " - perhaps a typo in emcc's  -s X=Y  notation?\n"
+      msg += ' - (see src/settings.js for valid values)'
+      exit_with_error(msg)
+
+    self.attrs[name] = value
 
   def __getitem__(self, key):
-    return attrs[key]
+    return self.attrs[key]
 
   def __setitem__(self, key, value):
-    attrs[key] = value
+    self.attrs[key] = value
+
+
+settings = SettingsManager()

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -17,6 +17,7 @@ from . import shared, building, ports, config, utils
 from . import deps_info, tempfiles
 from . import diagnostics
 from tools.shared import mangle_c_symbol_name, demangle_c_symbol_name
+from tools.settings import settings
 
 logger = logging.getLogger('system_libs')
 
@@ -57,12 +58,12 @@ def get_base_cflags(force_object_files=False):
   # Always build system libraries with debug information.  Non-debug builds
   # will ignore this at link time because we link with `-strip-debug`.
   flags = ['-g']
-  if shared.Settings.LTO and not force_object_files:
-    flags += ['-flto=' + shared.Settings.LTO]
-  if shared.Settings.RELOCATABLE:
+  if settings.LTO and not force_object_files:
+    flags += ['-flto=' + settings.LTO]
+  if settings.RELOCATABLE:
     flags += ['-s', 'RELOCATABLE']
-  if shared.Settings.MEMORY64:
-    flags += ['-s', 'MEMORY64=' + str(shared.Settings.MEMORY64)]
+  if settings.MEMORY64:
+    flags += ['-s', 'MEMORY64=' + str(settings.MEMORY64)]
   return flags
 
 
@@ -205,7 +206,7 @@ class Library:
 
     @classmethod
     def get_default_variation(cls, **kwargs):
-      return super().get_default_variation(my_parameter=shared.Settings.MY_PARAMETER, **kwargs)
+      return super().get_default_variation(my_parameter=settings.MY_PARAMETER, **kwargs)
 
   This allows the correct variation of the library to be selected when building
   code with Emscripten.
@@ -505,7 +506,7 @@ class MTLibrary(Library):
 
   @classmethod
   def get_default_variation(cls, **kwargs):
-    return super(MTLibrary, cls).get_default_variation(is_mt=shared.Settings.USE_PTHREADS, **kwargs)
+    return super(MTLibrary, cls).get_default_variation(is_mt=settings.USE_PTHREADS, **kwargs)
 
 
 class OptimizedAggressivelyForSizeLibrary(Library):
@@ -531,7 +532,7 @@ class OptimizedAggressivelyForSizeLibrary(Library):
 
   @classmethod
   def get_default_variation(cls, **kwargs):
-    return super(OptimizedAggressivelyForSizeLibrary, cls).get_default_variation(is_optz=shared.Settings.SHRINK_LEVEL >= 2, **kwargs)
+    return super(OptimizedAggressivelyForSizeLibrary, cls).get_default_variation(is_optz=settings.SHRINK_LEVEL >= 2, **kwargs)
 
 
 class exceptions:
@@ -586,9 +587,9 @@ class NoExceptLibrary(Library):
 
   @classmethod
   def get_default_variation(cls, **kwargs):
-    if shared.Settings.EXCEPTION_HANDLING:
+    if settings.EXCEPTION_HANDLING:
       eh_mode = exceptions.wasm
-    elif shared.Settings.DISABLE_EXCEPTION_CATCHING == 1:
+    elif settings.DISABLE_EXCEPTION_CATCHING == 1:
       eh_mode = exceptions.none
     else:
       eh_mode = exceptions.emscripten
@@ -629,7 +630,7 @@ class AsanInstrumentedLibrary(Library):
 
   @classmethod
   def get_default_variation(cls, **kwargs):
-    return super(AsanInstrumentedLibrary, cls).get_default_variation(is_asan=shared.Settings.USE_ASAN, **kwargs)
+    return super(AsanInstrumentedLibrary, cls).get_default_variation(is_asan=settings.USE_ASAN, **kwargs)
 
 
 class libcompiler_rt(MTLibrary):
@@ -859,7 +860,7 @@ class crt1(MuslInternalLibrary):
     return '.o'
 
   def can_use(self):
-    return super(crt1, self).can_use() and shared.Settings.STANDALONE_WASM
+    return super(crt1, self).can_use() and settings.STANDALONE_WASM
 
 
 class crt1_reactor(MuslInternalLibrary):
@@ -874,7 +875,7 @@ class crt1_reactor(MuslInternalLibrary):
     return '.o'
 
   def can_use(self):
-    return super(crt1_reactor, self).can_use() and shared.Settings.STANDALONE_WASM
+    return super(crt1_reactor, self).can_use() and settings.STANDALONE_WASM
 
 
 class crtbegin(Library):
@@ -1039,7 +1040,7 @@ class libmalloc(MTLibrary):
     return name
 
   def can_use(self):
-    return super(libmalloc, self).can_use() and shared.Settings.MALLOC != 'none'
+    return super(libmalloc, self).can_use() and settings.MALLOC != 'none'
 
   @classmethod
   def vary_on(cls):
@@ -1048,12 +1049,12 @@ class libmalloc(MTLibrary):
   @classmethod
   def get_default_variation(cls, **kwargs):
     return super(libmalloc, cls).get_default_variation(
-      malloc=shared.Settings.MALLOC,
-      is_debug=shared.Settings.ASSERTIONS >= 2,
-      use_errno=shared.Settings.SUPPORT_ERRNO,
-      is_tracing=shared.Settings.EMSCRIPTEN_TRACING,
-      memvalidate='memvalidate' in shared.Settings.MALLOC,
-      verbose='verbose' in shared.Settings.MALLOC,
+      malloc=settings.MALLOC,
+      is_debug=settings.ASSERTIONS >= 2,
+      use_errno=settings.SUPPORT_ERRNO,
+      is_tracing=settings.EMSCRIPTEN_TRACING,
+      memvalidate='memvalidate' in settings.MALLOC,
+      verbose='verbose' in settings.MALLOC,
       **kwargs
     )
 
@@ -1125,10 +1126,10 @@ class libgl(MTLibrary):
   @classmethod
   def get_default_variation(cls, **kwargs):
     return super(libgl, cls).get_default_variation(
-      is_legacy=shared.Settings.LEGACY_GL_EMULATION,
-      is_webgl2=shared.Settings.MAX_WEBGL_VERSION >= 2,
-      is_ofb=shared.Settings.OFFSCREEN_FRAMEBUFFER,
-      is_full_es3=shared.Settings.FULL_ES3,
+      is_legacy=settings.LEGACY_GL_EMULATION,
+      is_webgl2=settings.MAX_WEBGL_VERSION >= 2,
+      is_ofb=settings.OFFSCREEN_FRAMEBUFFER,
+      is_full_es3=settings.FULL_ES3,
       **kwargs
     )
 
@@ -1170,7 +1171,7 @@ class libembind(Library):
 
   @classmethod
   def get_default_variation(cls, **kwargs):
-    return super(libembind, cls).get_default_variation(with_rtti=shared.Settings.USE_RTTI, **kwargs)
+    return super(libembind, cls).get_default_variation(with_rtti=settings.USE_RTTI, **kwargs)
 
 
 class libfetch(MTLibrary):
@@ -1327,7 +1328,7 @@ class libstandalonewasm(MuslInternalLibrary):
   @classmethod
   def get_default_variation(cls, **kwargs):
     return super(libstandalonewasm, cls).get_default_variation(
-      is_mem_grow=shared.Settings.ALLOW_MEMORY_GROWTH,
+      is_mem_grow=settings.ALLOW_MEMORY_GROWTH,
       **kwargs
     )
 
@@ -1376,9 +1377,9 @@ class libjsmath(Library):
 # confusing, so issue a warning.
 def warn_on_unexported_main(symbolses):
   # In STANDALONE_WASM we don't expect main to be explictly exported
-  if shared.Settings.STANDALONE_WASM:
+  if settings.STANDALONE_WASM:
     return
-  if '_main' not in shared.Settings.EXPORTED_FUNCTIONS:
+  if '_main' not in settings.EXPORTED_FUNCTIONS:
     for symbols in symbolses:
       if 'main' in symbols.defs:
         logger.warning('main() is in the input files, but "_main" is not in EXPORTED_FUNCTIONS, which means it may be eliminated as dead code. Export it if you want main() to run.')
@@ -1386,18 +1387,18 @@ def warn_on_unexported_main(symbolses):
 
 
 def handle_reverse_deps(input_files):
-  if shared.Settings.REVERSE_DEPS == 'none':
+  if settings.REVERSE_DEPS == 'none':
     return
-  elif shared.Settings.REVERSE_DEPS == 'all':
+  elif settings.REVERSE_DEPS == 'all':
     # When not optimzing we add all possible reverse dependencies rather
     # than scanning the input files
     for symbols in deps_info.deps_info.values():
       for symbol in symbols:
-        shared.Settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(symbol))
+        settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(symbol))
     return
 
-  if shared.Settings.REVERSE_DEPS != 'auto':
-    shared.exit_with_error(f'invalid values for REVERSE_DEPS: {shared.Settings.REVERSE_DEPS}')
+  if settings.REVERSE_DEPS != 'auto':
+    shared.exit_with_error(f'invalid values for REVERSE_DEPS: {settings.REVERSE_DEPS}')
 
   added = set()
 
@@ -1410,7 +1411,7 @@ def handle_reverse_deps(input_files):
         for dep in deps:
           need.undefs.add(dep)
           logger.debug('adding dependency on %s due to deps-info on %s' % (dep, ident))
-          shared.Settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(dep))
+          settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(dep))
     if more:
       add_reverse_deps(need) # recurse to get deps of deps
 
@@ -1426,8 +1427,8 @@ def handle_reverse_deps(input_files):
     symbolses.append(Dummy())
 
   # depend on exported functions
-  for export in shared.Settings.EXPORTED_FUNCTIONS:
-    if shared.Settings.VERBOSE:
+  for export in settings.EXPORTED_FUNCTIONS:
+    if settings.VERBOSE:
       logger.debug('adding dependency on export %s' % export)
     symbolses[0].undefs.add(demangle_c_symbol_name(export))
 
@@ -1445,7 +1446,7 @@ def calculate(input_files, cxx, forced):
     # One of the purposes EMCC_ONLY_FORCED_STDLIBS was to skip the scanning
     # of the input files for reverse dependencies.
     diagnostics.warning('deprecated', 'EMCC_ONLY_FORCED_STDLIBS is deprecated.  Use `-nostdlib` and/or `-s REVERSE_DEPS=none` depending on the desired result')
-    shared.Settings.REVERSE_DEPS = 'all'
+    settings.REVERSE_DEPS = 'all'
 
   handle_reverse_deps(input_files)
 
@@ -1476,14 +1477,14 @@ def calculate(input_files, cxx, forced):
     need_whole_archive = lib.name in force_include and lib.get_ext() == '.a'
     libs_to_link.append((lib.get_path(), need_whole_archive))
 
-  if shared.Settings.USE_PTHREADS:
+  if settings.USE_PTHREADS:
     add_library('crtbegin')
 
-  if shared.Settings.SIDE_MODULE:
+  if settings.SIDE_MODULE:
     return [l[0] for l in libs_to_link]
 
-  if shared.Settings.STANDALONE_WASM:
-    if shared.Settings.EXPECT_MAIN:
+  if settings.STANDALONE_WASM:
+    if settings.EXPECT_MAIN:
       add_library('crt1')
     else:
       add_library('crt1_reactor')
@@ -1497,20 +1498,20 @@ def calculate(input_files, cxx, forced):
     add_library('libc_rt_wasm')
     add_library('libcompiler_rt')
   else:
-    if shared.Settings.AUTO_NATIVE_LIBRARIES:
+    if settings.AUTO_NATIVE_LIBRARIES:
       add_library('libgl')
       add_library('libal')
       add_library('libhtml5')
 
-    sanitize = shared.Settings.USE_LSAN or shared.Settings.USE_ASAN or shared.Settings.UBSAN_RUNTIME
+    sanitize = settings.USE_LSAN or settings.USE_ASAN or settings.UBSAN_RUNTIME
 
     # JS math must come before anything else, so that it overrides the normal
     # libc math.
-    if shared.Settings.JS_MATH:
+    if settings.JS_MATH:
       add_library('libjsmath')
 
     # to override the normal libc printf, we must come before it
-    if shared.Settings.PRINTF_LONG_DOUBLE:
+    if settings.PRINTF_LONG_DOUBLE:
       add_library('libprintf_long_double')
 
     add_library('libc')
@@ -1519,29 +1520,29 @@ def calculate(input_files, cxx, forced):
       add_library('libc++')
     if cxx or sanitize:
       add_library('libc++abi')
-      if shared.Settings.EXCEPTION_HANDLING:
+      if settings.EXCEPTION_HANDLING:
         add_library('libunwind')
-    if shared.Settings.MALLOC != 'none':
+    if settings.MALLOC != 'none':
       add_library('libmalloc')
-    if shared.Settings.STANDALONE_WASM:
+    if settings.STANDALONE_WASM:
       add_library('libstandalonewasm')
     add_library('libc_rt_wasm')
 
-    if shared.Settings.USE_LSAN:
+    if settings.USE_LSAN:
       force_include.add('liblsan_rt')
       add_library('liblsan_rt')
 
-    if shared.Settings.USE_ASAN:
+    if settings.USE_ASAN:
       force_include.add('libasan_rt')
       add_library('libasan_rt')
       add_library('libasan_js')
 
-    if shared.Settings.UBSAN_RUNTIME == 1:
+    if settings.UBSAN_RUNTIME == 1:
       add_library('libubsan_minimal_rt_wasm')
-    elif shared.Settings.UBSAN_RUNTIME == 2:
+    elif settings.UBSAN_RUNTIME == 2:
       add_library('libubsan_rt')
 
-    if shared.Settings.USE_LSAN or shared.Settings.USE_ASAN:
+    if settings.USE_LSAN or settings.USE_ASAN:
       add_library('liblsan_common_rt')
 
     if sanitize:
@@ -1553,20 +1554,20 @@ def calculate(input_files, cxx, forced):
     # somehow figure out which of their object files will actually be linked in -
     # but only lld knows that). so just directly handle that here.
     if sanitize:
-      shared.Settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name('memset'))
+      settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name('memset'))
 
-    if shared.Settings.PROXY_POSIX_SOCKETS:
+    if settings.PROXY_POSIX_SOCKETS:
       add_library('libsockets_proxy')
     else:
       add_library('libsockets')
 
-    if shared.Settings.USE_WEBGPU:
+    if settings.USE_WEBGPU:
       add_library('libwebgpu_cpp')
 
   # When LINKABLE is set the entire link command line is wrapped in --whole-archive by
   # building.link_ldd.  And since --whole-archive/--no-whole-archive processing does not nest we
   # shouldn't add any extra `--no-whole-archive` or we will undo the intent of building.link_ldd.
-  if shared.Settings.LINKABLE:
+  if settings.LINKABLE:
     return [l[0] for l in libs_to_link]
 
   # Wrap libraries in --whole-archive, as needed.  We need to do this last
@@ -1795,7 +1796,7 @@ class Ports:
   @staticmethod
   def clear_project_build(name):
     port = ports.ports_by_name[name]
-    port.clear(Ports, shared.Settings, shared)
+    port.clear(Ports, settings, shared)
     shared.try_delete(os.path.join(Ports.get_build_dir(), name))
 
 

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -13,6 +13,7 @@ import os
 import sys
 
 from . import shared
+from .settings import settings
 
 sys.path.append(shared.path_from_root('third_party'))
 
@@ -55,8 +56,8 @@ def readSLEB(iobuf):
 
 
 def add_emscripten_metadata(wasm_file):
-  mem_size = shared.Settings.INITIAL_MEMORY // WASM_PAGE_SIZE
-  global_base = shared.Settings.GLOBAL_BASE
+  mem_size = settings.INITIAL_MEMORY // WASM_PAGE_SIZE
+  global_base = settings.GLOBAL_BASE
 
   logger.debug('creating wasm emscripten metadata section with mem size %d' % mem_size)
   name = b'\x13emscripten_metadata' # section name, including prefixed size
@@ -84,7 +85,7 @@ def add_emscripten_metadata(wasm_file):
     # tempDoublePtr, always 0 in wasm backend
     toLEB(0) +
 
-    toLEB(int(shared.Settings.STANDALONE_WASM))
+    toLEB(int(settings.STANDALONE_WASM))
 
     # NB: more data can be appended here as long as you increase
     #     the EMSCRIPTEN_METADATA_MINOR


### PR DESCRIPTION
Breaks at least one dependency cycle between cache.py and shared.py.

This is quite a big change but it roughly equates to renaming
`shared.Settings` to just `settings` in most location.  This makes use
of settings more concise and readable.