### PR TITLE
Cleanup default generated config file

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -142,6 +142,19 @@ def parse_config_file():
     elif key in config:
       globals()[key] = config[key]
 
+  # Handle legacy environment variables that were previously honored by the
+  # default config file.
+  LEGACY_ENV_VARS = {
+    'LLVM': 'EM_LLVM_ROOT',
+    'BINARYEN': 'EM_BINARYEN_ROOT',
+    'NODE': 'EM_NODE_JS',
+  }
+  for key, new_key in LEGACY_ENV_VARS.items():
+    env_value = os.environ.get(key)
+    if env_value and new_key not in os.environ:
+      logger.warning(f'warning: honoring legacy environment variable `{key}`.  Please switch to using `{new_key}` instead`')
+      globals()[new_key] = env_value
+
   # Certain keys are mandatory
   for key in ('LLVM_ROOT', 'NODE_JS', 'BINARYEN_ROOT'):
     if key not in config:

--- a/tools/settings_template.py
+++ b/tools/settings_template.py
@@ -12,18 +12,16 @@
 # is not valid, but LLVM='c:\\llvm\\' and LLVM='c:/llvm/'
 # are.
 
-import os
-
 # This is used by external projects in order to find emscripten.  It is not used
 # by emscripten itself.
-EMSCRIPTEN_ROOT = os.path.expanduser(os.getenv('EMSCRIPTEN', '{{{ EMSCRIPTEN_ROOT }}}')) # directory
+EMSCRIPTEN_ROOT = '{{{ EMSCRIPTEN_ROOT }}}' # directory
 
-LLVM_ROOT = os.path.expanduser(os.getenv('LLVM', '{{{ LLVM_ROOT }}}')) # directory
-BINARYEN_ROOT = os.path.expanduser(os.getenv('BINARYEN', '')) # directory
+LLVM_ROOT = '{{{ LLVM_ROOT }}}' # directory
+BINARYEN_ROOT = '' # directory
 
 # Location of the node binary to use for running the JS parts of the compiler.
 # This engine must exist, or nothing can be compiled.
-NODE_JS = os.path.expanduser(os.getenv('NODE', '{{{ NODE }}}')) # executable
+NODE_JS = '{{{ NODE }}}' # executable
 
 JAVA = 'java' # executable
 
@@ -33,20 +31,23 @@ JAVA = 'java' # executable
 #
 # Alternative JS engines to use during testing:
 #
-# SPIDERMONKEY_ENGINE = [os.path.expanduser(os.getenv('SPIDERMONKEY', 'js'))] # executable
-# V8_ENGINE = os.path.expanduser(os.getenv('V8', 'd8')) # executable
+# SPIDERMONKEY_ENGINE = ['js'] # executable
+# V8_ENGINE = 'd8' # executable
 #
 # All JS engines to use when running the automatic tests. Not all the engines in
 # this list must exist (if they don't, they will be skipped in the test runner).
 #
 # JS_ENGINES = [NODE_JS] # add V8_ENGINE or SPIDERMONKEY_ENGINE if you have them installed too.
 #
+# import os
 # WASMER = os.path.expanduser(os.path.join('~', '.wasmer', 'bin', 'wasmer'))
 # WASMTIME = os.path.expanduser(os.path.join('~', 'wasmtime'))
 #
 # Wasm engines to use in STANDALONE_WASM tests.
 #
 # WASM_ENGINES = [] # add WASMER or WASMTIME if you have them installed
+#
+################################################################################
 #
 # Other options
 #


### PR DESCRIPTION
The old method of reading env vars directly in the config file is no
longer needed now that all config var are implicitly overridable via the
environment.

Support the old default env var names for a while in case folks are
using them.