### PR TITLE
add test on wasm split

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10168,7 +10168,7 @@ exec "$@"
     self.assertExists('a.out.wasm')
     self.assertExists('a.out.wasm.orig')
     # train
-    ret = self.run_process(config.NODE_JS + ['a.out.js'], stdout=PIPE).stdout
+    self.run_process(config.NODE_JS + ['a.out.js'], stdout=PIPE).stdout
     self.assertExists('profile.data')
     # split
     wasm_split = os.path.join(building.get_binaryen_bin(), 'wasm-split')


### PR DESCRIPTION
Using optimisation -Oz fails the wasm-split with following error:

```
wasm-split: /b/s/w/ir/cache/builder/emscripten-releases/binaryen/src/ir/module-splitting.cpp:153: void wasm::ModuleSplitting::(anonymous namespace)::TableSlotManager::addSlot(wasm::Name, wasm::ModuleSplitting::(anonymous namespace)::TableSlotManager::Slot): Assertion `it.second && "Function already has multiple table slots"' failed.
test_wasm_split (test_other.other) ... FAIL
```

PS: The main purpose of this test case is to share a reproducer for 
https://github.com/emscripten-core/emscripten/issues/13928 