### PR TITLE
Pass `--detect-features` to binaryen unless finalize has extracted them already

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2903,13 +2903,12 @@ def do_binaryen(target, options, wasm_target):
                           wasm_target,
                           args=passes,
                           debug=intermediate_debug_info)
-  else:
+  elif strip_debug or strip_producers:
     # we are not running wasm-opt. if we need to strip certain sections
     # then do so using llvm-objcopy which is fast and does not rewrite the
     # code (which is better for debug info)
-    if strip_debug or strip_producers:
-      building.save_intermediate(wasm_target, 'pre-strip.wasm')
-      building.strip(wasm_target, wasm_target, debug=strip_debug, producers=strip_producers)
+    building.save_intermediate(wasm_target, 'pre-strip.wasm')
+    building.strip(wasm_target, wasm_target, debug=strip_debug, producers=strip_producers)
 
   if settings.EVAL_CTORS:
     building.save_intermediate(wasm_target, 'pre-ctors.wasm')

--- a/tools/building.py
+++ b/tools/building.py
@@ -1389,14 +1389,12 @@ def emit_wasm_source_map(wasm_file, map_file, final_wasm):
 
 
 def get_binaryen_feature_flags():
-  # start with the MVP features, add the rest as needed
-  ret = ['--mvp-features']
-  if settings.USE_PTHREADS:
-    ret += ['--enable-threads']
-  if settings.MEMORY64:
-    ret += ['--enable-memory64']
-  ret += settings.BINARYEN_FEATURES
-  return ret
+  # settings.BINARYEN_FEATURES is empty unless features have been extracted by
+  # wasm-emscripten-finalize already.
+  if settings.BINARYEN_FEATURES:
+    return settings.BINARYEN_FEATURES
+  else:
+    return ['--detect-features']
 
 
 def check_binaryen(bindir):
@@ -1466,8 +1464,7 @@ def run_binaryen_command(tool, infile, outfile=None, args=[], debug=False, stdou
   if debug:
     cmd += ['-g'] # preserve the debug info
   # if the features are not already handled, handle them
-  if '--detect-features' not in cmd:
-    cmd += get_binaryen_feature_flags()
+  cmd += get_binaryen_feature_flags()
   # if we are emitting a source map, every time we load and save the wasm
   # we must tell binaryen to update it
   if settings.GENERATE_SOURCE_MAP and outfile:


### PR DESCRIPTION
This means that running finalize at all can become optional.