### PR TITLE
Print Clang location on failed version check

### DIFF
--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -233,7 +233,7 @@ class sanity(RunnerCore):
           try_delete(default_config)
 
   def test_llvm(self):
-    LLVM_WARNING = 'LLVM version appears incorrect'
+    LLVM_WARNING = 'LLVM version for clang executable'
 
     restore_and_set_up()
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -258,7 +258,7 @@ def check_llvm_version():
   actual = get_clang_version()
   if EXPECTED_LLVM_VERSION in actual:
     return True
-  diagnostics.warning('version-check', 'LLVM version appears incorrect (seeing "%s", expected "%s")', actual, EXPECTED_LLVM_VERSION)
+  diagnostics.warning('version-check', 'LLVM version for clang executable "%s" appears incorrect (seeing "%s", expected "%s")', CLANG_CC, actual, EXPECTED_LLVM_VERSION)
   return False
 
 


### PR DESCRIPTION
When Clang version check fails, print the location where Clang was actually invoked from to help debug problems.