### PR TITLE
Skip callbacks after abort

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3619,8 +3619,8 @@ LibraryManager.library = {
     if (ABORT) {
 #if ASSERTIONS
       err('user callback triggered after application aborted.  Ignoring.');
-      return;
 #endif
+      return;
     }
     // For synchronous calls, let any exceptions propagate, and don't let the runtime exit.
     if (synchronous) {


### PR DESCRIPTION
I believe this was an oversight when this code
was refactored as part of #13596.