### PR TITLE
Accept minor code size regressions after LLVM update

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -2,9 +2,9 @@
   "a.html": 588,
   "a.html.gz": 386,
   "a.js": 19947,
-  "a.js.gz": 8158,
+  "a.js.gz": 8160,
   "a.mem": 3171,
   "a.mem.gz": 2715,
   "total": 23706,
-  "total_gz": 11259
+  "total_gz": 11261
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -2,9 +2,9 @@
   "a.html": 588,
   "a.html.gz": 386,
   "a.js": 19429,
-  "a.js.gz": 7990,
+  "a.js.gz": 7995,
   "a.mem": 3171,
   "a.mem.gz": 2715,
   "total": 23188,
-  "total_gz": 11091
+  "total_gz": 11096
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12589,
-  "a.html.gz": 6771,
-  "total": 12589,
-  "total_gz": 6771
+  "a.html": 12609,
+  "a.html.gz": 6781,
+  "total": 12609,
+  "total_gz": 6781
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17332,
-  "a.html.gz": 7453,
-  "total": 17332,
-  "total_gz": 7453
+  "a.html": 17370,
+  "a.html.gz": 7492,
+  "total": 17370,
+  "total_gz": 7492
 }


### PR DESCRIPTION
LLVM change: https://github.com/llvm/llvm-project/commit/9423f78240a216e3f38b394a41fe3427dee22c26

That uses unsigned operations in more places. Those are less size-efficient
than signed ones in wasm2js, so unfortunately this increases code size there.
I do not see a simple way to optimize things better in wasm2js - the LLVM
change just switches to an unsigned operation, but then that gets taken
into account in later work - apparently sometimes helpful, hence the change -
and the result is not a simple unsigned operation we can replace easily.