### PR TITLE
Remove setTempRet0, getTempRet0 from WASM_SYSTEM_EXPORTS

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -23,6 +23,9 @@
 LibraryManager.library = {
   // ==========================================================================
   // getTempRet0/setTempRet0: scratch space handling i64 return
+  //
+  // These are trivial wrappers around runtime functions that make these symbols
+  // available to native code.
   // ==========================================================================
 
   getTempRet0__sig: 'i',
@@ -3316,12 +3319,8 @@ LibraryManager.library = {
 #if !DECLARE_ASM_MODULE_EXPORTS
   // When DECLARE_ASM_MODULE_EXPORTS is not set we export native symbols
   // at runtime rather than statically in JS code.
+  $exportAsmFunctions__deps: ['$asmjsMangle'],
   $exportAsmFunctions: function(asm) {
-    var asmjsMangle = function(x) {
-      var unmangledSymbols = {{{ buildStringArray(WASM_SYSTEM_EXPORTS) }}};
-      return x.indexOf('dynCall_') == 0 || unmangledSymbols.indexOf(x) != -1 ? x : '_' + x;
-    };
-
 #if ENVIRONMENT_MAY_BE_NODE && ENVIRONMENT_MAY_BE_WEB
     var global_object = (typeof process !== "undefined" ? global : this);
 #elif ENVIRONMENT_MAY_BE_NODE
@@ -3679,6 +3678,11 @@ LibraryManager.library = {
     func();
   },
 #endif
+
+  $asmjsMangle: function(x) {
+    var unmangledSymbols = {{{ buildStringArray(WASM_SYSTEM_EXPORTS) }}};
+    return x.indexOf('dynCall_') == 0 || unmangledSymbols.indexOf(x) != -1 ? x : '_' + x;
+  },
 
 #if RELOCATABLE
   // These get set in emscripten.py during add_standard_wasm_imports, but are

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -5,11 +5,6 @@
 
 var LibraryDylink = {
 #if RELOCATABLE
-  $asmjsMangle: function(x) {
-    var unmangledSymbols = {{{ buildStringArray(WASM_SYSTEM_EXPORTS) }}};
-    return x.indexOf('dynCall_') == 0 || unmangledSymbols.indexOf(x) != -1 ? x : '_' + x;
-  },
-
   $resolveGlobalSymbol__deps: ['$asmjsMangle'],
   $resolveGlobalSymbol: function(symName, direct) {
     var sym;

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -138,7 +138,7 @@ var TARGET_NOT_SUPPORTED = 0x7FFFFFFF;
 // Wasm backend symbols that are considered system symbols and don't
 // have the normal C symbol name mangled applied (== prefix with an underscore)
 // (Also implicily on this list is any function that starts with string "dynCall_")
-var WASM_SYSTEM_EXPORTS = ['setTempRet0', 'getTempRet0', 'stackAlloc', 'stackSave', 'stackRestore'];
+var WASM_SYSTEM_EXPORTS = ['stackAlloc', 'stackSave', 'stackRestore'];
 
 // Internal: value of -flto argument (either full or thin)
 var LTO = 0;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3891,7 +3891,6 @@ ok
 
   @needs_dylink
   def test_dylink_i64(self):
-    # Runs with main_module=1 due to undefined getTempRet0 otherwise
     self.dylink_test(r'''
       #include <stdio.h>
       #include <stdint.h>
@@ -3905,12 +3904,11 @@ ok
       int64_t sidey() {
         return 42;
       }
-    ''', 'other says 42.', force_c=True, main_module=1)
+    ''', 'other says 42.', force_c=True)
 
   @all_engines
   @needs_dylink
   def test_dylink_i64_b(self):
-    # Runs with main_module=1 due to undefined getTempRet0 otherwise
     self.dylink_test(r'''
       #include <stdio.h>
       #include <stdint.h>
@@ -3940,12 +3938,11 @@ ok
         x = 18 - x;
         return x;
       }
-    ''', 'other says -1311768467750121224.\nmy fp says: 43.\nmy second fp says: 43.', force_c=True, main_module=1)
+    ''', 'other says -1311768467750121224.\nmy fp says: 43.\nmy second fp says: 43.', force_c=True)
 
   @needs_dylink
   @also_with_wasm_bigint
   def test_dylink_i64_c(self):
-    # Runs with main_module=1 due to undefined getTempRet0 otherwise
     self.dylink_test(r'''
       #include <stdio.h>
       #include <inttypes.h>
@@ -3993,7 +3990,7 @@ res64 - external 64\n''', header='''
       #include <stdint.h>
       EMSCRIPTEN_KEEPALIVE int32_t function_ret_32(int32_t i, int32_t j, int32_t k);
       EMSCRIPTEN_KEEPALIVE int64_t function_ret_64(int32_t i, int32_t j, int32_t k);
-    ''', force_c=True, main_module=1)
+    ''', force_c=True)
 
   @needs_dylink
   @also_with_wasm_bigint


### PR DESCRIPTION
This change allows more dynamic linking tests to build and run with
`MAIN_MODULE=2` rather than `MAIN_MODULE=2`.

Some background: `setTempRet0` and `getTempRet0` are a little odd
because they exist bot as runtime functions accessible from JS as
`setTempRet0` and `getTempRet0` but also as library functions accessible
as `_getTempRet0` and `_getTempRet0`.

The only JS symbols that can be linked with native code are JS library
symbols.  Runtime symbols like `setTempRet0` and `getTempRet0` are not
indended to be used to resolve undefined native symbols.  Undefined
native symbols will resolve to `_getTempRet0` and `_setTempRet0` in
jsifier (which unconditionally adds the `_` to JS library function
names).

More background: I believe `WASM_SYSTEM_EXPORTS` is designed to allow
certain symbols to be exported *from* wasm without mangling.  However,
these two symbols are always defined in JS and never defined in wasm so
I don't believe they ever belonged in this list.

The reason this fix is needed in order to enable more use of
`MAIN_MODULE=2` is that in `MAIN_MODULE=1` mode `getTempRet0` (the
runtime function is getting exported as part of `asmLibraryArgs`).
However in `MAIN_MODULE=2` mode we rely instead on the symbol existing
on the module object which it never does (without this change).  The
result is that we hit the default error:

```
  RuntimeError: abort('getTempRet0' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ)) at Error
```

I plan on following up by removing the runtime versions of these
functions completely, but I wanted to land this change on its own
to make any issues easy to bisect.