### PR TITLE
Remove unused makeBigInt runtime function

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,8 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- The `makeBigInt` function was removed from the emscripten runtime since it
+  had no internal users.
 - `EXTRA_EXPORTED_RUNTIME_METHODS` is deprecated in favor of just using
   `EXPORTED_RUNTIME_METHODS`.
 - When building with `MAIN_MODULE=2` the linker will now automatically include

--- a/src/modules.js
+++ b/src/modules.js
@@ -391,7 +391,7 @@ function exportRuntime() {
     return maybeExport(name, true);
   }
 
-  // All possible runtime elements to export
+  // All possible runtime elements that can be exported
   var runtimeElements = [
     'intArrayFromString',
     'intArrayToString',
@@ -432,7 +432,6 @@ function exportRuntime() {
     'removeFunction',
     'getFuncWrapper',
     'prettyPrint',
-    'makeBigInt',
     'dynCall',
     'getCompilerSetting',
     'print',

--- a/src/support.js
+++ b/src/support.js
@@ -22,10 +22,6 @@ function warnOnce(text) {
 
 #include "runtime_debug.js"
 
-function makeBigInt(low, high, unsigned) {
-  return unsigned ? ((+((low>>>0)))+((+((high>>>0)))*4294967296.0)) : ((+((low>>>0)))+((+((high|0)))*4294967296.0));
-}
-
 var tempRet0 = 0;
 
 var setTempRet0 = function(value) {


### PR DESCRIPTION
The last usage in emscripten of this function was removed when
library_int53.js was added in #10353.

It is concievable that some exteral code is adding `makeBigInt` to
`EXPORTED_RUNTIME_METHODS`, but I don't think that is good enough reason
for is to keep dead runtime code around.