### PR TITLE
Use MAIN_MODULE=2 in all remaining `test_dylink` tests. NFC

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3583,7 +3583,7 @@ ok
     return self.dylink_testf(main, side, expected, force_c, **kwargs)
 
   def dylink_testf(self, main, side, expected=None, force_c=False, main_emcc_args=[],
-                   need_reverse=True, auto_load=True, main_module=2, **kwargs):
+                   need_reverse=True, auto_load=True, **kwargs):
     self.maybe_closure()
     # Same as dylink_test but takes source code as filenames on disc.
     old_args = self.emcc_args.copy()
@@ -3605,8 +3605,7 @@ ok
       out_file = self.build(side, js_outfile=(side_suffix == 'js'))
     shutil.move(out_file, 'liblib.so')
 
-    # main settings
-    self.set_setting('MAIN_MODULE', main_module)
+    self.set_setting('MAIN_MODULE', 2)
     self.clear_setting('SIDE_MODULE')
     if auto_load:
       # Normally we don't report undefined symbols when linking main modules but
@@ -3633,7 +3632,7 @@ ok
       # Test the reverse as well.  There we flip the role of the side module and main module.
       # - We add --no-entry since the side module doesn't have a `main`
       self.dylink_testf(side, main, expected, force_c, main_emcc_args + ['--no-entry'],
-                        need_reverse=False, main_module=main_module, **kwargs)
+                        need_reverse=False, **kwargs)
 
   def do_basic_dylink_test(self, **kwargs):
     self.dylink_test(r'''
@@ -4318,8 +4317,6 @@ res64 - external 64\n''', header='''
   @with_both_exception_handling
   @needs_dylink
   def test_dylink_raii_exceptions(self):
-    # MAIN_MODULE=1 still needed in this test due to:
-    # https://github.com/emscripten-core/emscripten/issues/13786
     self.dylink_test(main=r'''
       #include <stdio.h>
       extern int side();
@@ -4346,7 +4343,7 @@ res64 - external 64\n''', header='''
         volatile ifdi p = func_with_special_sig;
         return p(2.18281, 3.14159, 42);
       }
-    ''', expected=['special 2.182810 3.141590 42\ndestroy\nfrom side: 1337.\n'], main_module=1)
+    ''', expected=['special 2.182810 3.141590 42\ndestroy\nfrom side: 1337.\n'])
 
   @needs_dylink
   @disabled('https://github.com/emscripten-core/emscripten/issues/12815')
@@ -4588,12 +4585,9 @@ res64 - external 64\n''', header='''
     }
     '''
 
-    # MAIN_MODULE=1 still needed in this test due to:
-    # https://github.com/emscripten-core/emscripten/issues/13786
     self.dylink_test(main=main,
                      side=side,
                      header=header,
-                     main_module=1,
                      expected='success')
 
   @needs_dylink


### PR DESCRIPTION
These tests seem to to pass just fine now with `MAIN_MODULE=2`.
I'm not sure if they were marked in error as failing, or if there
was some intervening fix.