### PR TITLE
Remove mangling from WASM_EXPORTS and SIDE_MODULE_EXPORTS internal lists. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -640,7 +640,7 @@ def process_dynamic_libs(dylibs):
 
     exports = webassembly.get_exports(dylib)
     for export in exports:
-      settings.SIDE_MODULE_EXPORTS.append(shared.asmjs_mangle(export.name))
+      settings.SIDE_MODULE_EXPORTS.append(export.name)
 
 
 def unmangle_symbols_from_cmdline(symbols):

--- a/emscripten.py
+++ b/emscripten.py
@@ -116,8 +116,7 @@ def update_settings_glue(metadata, DEBUG):
 
   settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += metadata['globalImports']
 
-  all_exports = metadata['exports'] + list(metadata['namedGlobals'].keys())
-  settings.WASM_EXPORTS = [asmjs_mangle(x) for x in all_exports]
+  settings.WASM_EXPORTS = metadata['exports'] + list(metadata['namedGlobals'].keys())
 
   # start with the MVP features, and add any detected features.
   settings.BINARYEN_FEATURES = ['--mvp-features'] + metadata['features']
@@ -133,7 +132,7 @@ def update_settings_glue(metadata, DEBUG):
     if settings.INITIAL_TABLE == -1:
       settings.INITIAL_TABLE = metadata['tableSize'] + 1
 
-  settings.HAS_MAIN = settings.MAIN_MODULE or settings.STANDALONE_WASM or '_main' in settings.WASM_EXPORTS
+  settings.HAS_MAIN = settings.MAIN_MODULE or settings.STANDALONE_WASM or 'main' in settings.WASM_EXPORTS
 
   # When using dynamic linking the main function might be in a side module.
   # To be safe assume they do take input parametes.
@@ -193,7 +192,7 @@ def set_memory(static_bump):
 def report_missing_symbols(pre):
   # the initial list of missing functions are that the user explicitly exported
   # but were not implemented in compiled code
-  missing = set(settings.USER_EXPORTED_FUNCTIONS) - set(settings.WASM_EXPORTS)
+  missing = set(settings.USER_EXPORTED_FUNCTIONS) - set(asmjs_mangle(e) for e in settings.WASM_EXPORTS)
 
   for requested in sorted(missing):
     if (f'function {requested}(') not in pre:
@@ -211,7 +210,7 @@ def report_missing_symbols(pre):
     # maximum compatibility.
     return
 
-  if settings.EXPECT_MAIN and '_main' not in settings.WASM_EXPORTS:
+  if settings.EXPECT_MAIN and 'main' not in settings.WASM_EXPORTS:
     # For compatibility with the output of wasm-ld we use the same wording here in our
     # error message as if wasm-ld had failed (i.e. in LLD_REPORT_UNDEFINED mode).
     exit_with_error('entry symbol not defined (pass --no-entry to suppress): main')

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -55,7 +55,7 @@ function isDefined(symName) {
   }
   // 'invoke_' symbols are created at runtime in libary_dylink.py so can
   // always be considered as defined.
-  if (RELOCATABLE && symName.startsWith('_invoke_')) {
+  if (RELOCATABLE && symName.startsWith('invoke_')) {
     return true;
   }
   return false;
@@ -146,7 +146,7 @@ function JSify(functionsOnly) {
       }
 
       // if the function was implemented in compiled code, we just need to export it so we can reach it from JS
-      if (finalName in WASM_EXPORTS) {
+      if (ident in WASM_EXPORTS) {
         EXPORTED_FUNCTIONS[finalName] = 1;
         // stop here: we don't need to add anything from our js libraries, not even deps, compiled code is on it
         return '';
@@ -159,7 +159,7 @@ function JSify(functionsOnly) {
       var noExport = false;
 
       if (!LibraryManager.library.hasOwnProperty(ident)) {
-        if (!isDefined(finalName) && !LINKABLE) {
+        if (!isDefined(ident) && !LINKABLE) {
           var msg = 'undefined symbol: ' + ident;
           if (dependent) msg += ' (referenced by ' + dependent + ')';
           if (ERROR_ON_UNDEFINED_SYMBOLS) {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1293,7 +1293,7 @@ function addReadyPromiseAssertions(promise) {
 }
 
 function makeMalloc(source, param) {
-  if ('_malloc' in WASM_EXPORTS) {
+  if ('malloc' in WASM_EXPORTS) {
     return `_malloc(${param})`;
   }
   // It should be impossible to call some functions without malloc being

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -76,7 +76,7 @@ function initRuntime(asm) {
 #endif
 #endif
 
-#if '___wasm_call_ctors' in WASM_EXPORTS
+#if '__wasm_call_ctors' in WASM_EXPORTS
   asm['__wasm_call_ctors']();
 #endif
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -184,12 +184,12 @@ function cwrap(ident, returnType, argTypes, opts) {
 #if ASSERTIONS
 // We used to include malloc/free by default in the past. Show a helpful error in
 // builds with assertions.
-#if !('_malloc' in WASM_EXPORTS)
+#if !('malloc' in WASM_EXPORTS)
 function _malloc() {
   abort("malloc() called but not included in the build - add '_malloc' to EXPORTED_FUNCTIONS");
 }
 #endif // malloc
-#if !('_free' in WASM_EXPORTS)
+#if !('free' in WASM_EXPORTS)
 function _free() {
   // Show a helpful error since we used to include free by default in the past.
   abort("free() called but not included in the build - add '_free' to EXPORTED_FUNCTIONS");
@@ -972,7 +972,7 @@ function createWasm() {
 #endif
 #endif
 
-#if '___wasm_call_ctors' in WASM_EXPORTS
+#if '__wasm_call_ctors' in WASM_EXPORTS
     addOnInit(Module['asm']['__wasm_call_ctors']);
 #endif
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -14,6 +14,18 @@
 // An array of all symbols exported from the wasm module.
 var MODULE_EXPORTS = [];
 
+// List of symbols exported from compiled code
+// These are raw symbol names and are not mangled to include the leading
+// underscore.
+// TODO(sbc): unify with MODULE_EXPORTS above.
+var WASM_EXPORTS = [];
+
+// An array of all symbols exported from all the side modules specified on the
+// command line.
+// These are raw symbol names and are not mangled to include the leading
+// underscore.
+var SIDE_MODULE_EXPORTS = [];
+
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 
@@ -61,9 +73,6 @@ var EMBIND = 0;
 
 // Whether the main() function reads the argc/argv parameters.
 var MAIN_READS_PARAMS = 1;
-
-// List of symbols exported from compiled code
-var WASM_EXPORTS = [];
 
 // Name of the file containing the Fetch *.fetch.js, if relevant
 var FETCH_WORKER_FILE = '';
@@ -193,5 +202,3 @@ var HEAP_BASE = 0;
 // Also set for STANDALONE_WASM since the _start function is needed to call
 // static ctors, even if there is no user main.
 var HAS_MAIN = 0;
-
-var SIDE_MODULE_EXPORTS = [];


### PR DESCRIPTION
This reduces the number of places where we have to deal with mangled
names, and will hopefully allow the removal of MODULE_EXPORTS (which is
essentially a duplicate of WASM_EXPORTS) as a followup.