### PR TITLE
Remove redundant adding of exports to metadce graph. NFC.

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -953,19 +953,6 @@ def metadce(js_file, wasm_file, minify_whitespace, debug_info):
   extra_info = '{ "exports": [' + ','.join(map(lambda x: '["' + x[0] + '","' + x[1] + '"]', settings.MODULE_EXPORTS)) + ']}'
   txt = acorn_optimizer(js_file, ['emitDCEGraph', 'noPrint'], return_output=True, extra_info=extra_info)
   graph = json.loads(txt)
-  # add exports based on the backend output, that are not present in the JS
-  if not settings.DECLARE_ASM_MODULE_EXPORTS:
-    exports = set()
-    for item in graph:
-      if 'export' in item:
-        exports.add(item['export'])
-    for export, unminified in settings.MODULE_EXPORTS:
-      if export not in exports:
-        graph.append({
-          'export': export,
-          'name': 'emcc$export$' + export,
-          'reaches': []
-        })
   # ensure that functions expected to be exported to the outside are roots
   for item in graph:
     if 'export' in item:


### PR DESCRIPTION
This code attempts to add exports to the graph when the
normal method of looking for them in the JS input source
does not work.  I noticed two issues with this code:

1. These exact exports are already injected into the graph via
   the extra_info that is passed to emitDCEGraph.  I believe this
   extra_info technique was added after, and that made this
   code redundant.
2. The mangled symbol name is used rather than unmangled name
   (called unminified here).  As far as I can tell the exports in the
   graph expect to use unmanagled name (see the code right below
   that iterates through exports in the graph and clearly expects
   unmangled names).