### PR TITLE
Rename internal MODULE_EXPORTS to WASM_FUNCTION_EXPORTS. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -117,6 +117,9 @@ def update_settings_glue(metadata, DEBUG):
   settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += metadata['globalImports']
 
   settings.WASM_EXPORTS = metadata['exports'] + list(metadata['namedGlobals'].keys())
+  # Store function exports so that Closure and metadce can track these even in
+  # -s DECLARE_ASM_MODULE_EXPORTS=0 builds.
+  settings.WASM_FUNCTION_EXPORTS = metadata['exports']
 
   # start with the MVP features, and add any detected features.
   settings.BINARYEN_FEATURES = ['--mvp-features'] + metadata['features']
@@ -137,10 +140,6 @@ def update_settings_glue(metadata, DEBUG):
   # When using dynamic linking the main function might be in a side module.
   # To be safe assume they do take input parametes.
   settings.MAIN_READS_PARAMS = metadata['mainReadsParams'] or settings.MAIN_MODULE
-
-  # Store exports for Closure compiler to be able to track these as globals in
-  # -s DECLARE_ASM_MODULE_EXPORTS=0 builds.
-  settings.MODULE_EXPORTS = [(asmjs_mangle(f), f) for f in metadata['exports']]
 
   if settings.STACK_OVERFLOW_CHECK and not settings.SIDE_MODULE:
     settings.EXPORTED_RUNTIME_METHODS += ['writeStackCookie', 'checkStackCookie']

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -11,14 +11,13 @@
 // and can be added/removed/renamed without fear of breaking out users.
 //
 
-// An array of all symbols exported from the wasm module.
-var MODULE_EXPORTS = [];
-
 // List of symbols exported from compiled code
 // These are raw symbol names and are not mangled to include the leading
 // underscore.
-// TODO(sbc): unify with MODULE_EXPORTS above.
 var WASM_EXPORTS = [];
+
+// Similar to above but only includes the functions symbols.
+var WASM_FUNCTION_EXPORTS = [];
 
 // An array of all symbols exported from all the side modules specified on the
 // command line.


### PR DESCRIPTION
Also, reduce it to just a single list, which makes its name and
contents consistent with `WASM_EXPORTS`.