### PR TITLE
Remove the "first-use generates config file" magic

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -26,6 +26,10 @@ See docs/process.md for more on how version tagging works.
    - `EMMAKEN_COMPILER` -> `LLVM_ROOT` in the config settings
    - `EMMAKEN_CFLAGS` -> `EMCC_CFLAGS`
    - `EMMAKEN_NO_SDK` -> standard `-nostdlib` and `-nostdinc` flags
+- emscripten will no longer automatically create a config file if it can't
+  find one in the configured location.  Instead, it will error out and point the
+  user to the `--generate-config` option, in case that is what they want.
+  (#13962)
 
 3.1.5 - 02/17/2022
 ------------------

--- a/emcc.py
+++ b/emcc.py
@@ -3181,14 +3181,6 @@ def parse_args(newargs):
         options.output_eol = '\n'
       else:
         exit_with_error(f'Invalid value "{style}" to --output_eol!')
-    elif check_arg('--generate-config'):
-      optarg = consume_arg()
-      path = os.path.expanduser(optarg)
-      if os.path.exists(path):
-        exit_with_error(f'File {optarg} passed to --generate-config already exists!')
-      else:
-        config.generate_config(optarg)
-      should_exit = True
     # Record USE_PTHREADS setting because it controls whether --shared-memory is passed to lld
     elif arg == '-pthread':
       settings_changes.append('USE_PTHREADS=1')

--- a/site/source/docs/building_from_source/configuring_emscripten_settings.rst
+++ b/site/source/docs/building_from_source/configuring_emscripten_settings.rst
@@ -15,31 +15,36 @@ This article explains how to create and update the file when you are building Em
 Creating the compiler configuration file
 ========================================
 
-The settings file is created the first time a user runs :ref:`emcc <emccdoc>` (or any of the other Emscripten tools):
+A settings file is required to run :ref:`emcc <emccdoc>` (or any of the other
+Emscripten tools).  When you first run ``emcc`` it will direct you to the
+``--generate-config`` command line option which can be used to generate config
+file in the default location.
 
 1. Navigate to the directory where you cloned the Emscripten repository.
-2. Enter the command: 
+2. Enter the command:
 
-	::
-	
-		./emcc --help
+  ::
 
-	You should get a ``Welcome to Emscripten!`` message. Behind the scenes, Emscripten generates a file called ``.emscripten`` in your home folder.
-	
-	
-Emscripten makes a "best guess" at the correct locations for tools and updates the file appropriately. Where possible it will look for "system" apps (like Python and Java).
+    ./emcc --generate-config
+
+  You should get a ``An Emscripten settings file has been generated at:``
+  message, along with the contents of the config file.
+
+Emscripten makes a "best guess" at the correct locations for tools and updates
+the file appropriately. Where possible it will look for "system" apps (like
+Python and Java).
 
 In most cases it is necessary to edit the generated file and modify at least the
 ``LLVM_ROOT`` and ``BINARYEN_ROOT`` settings to point to the correct location of
 your local LLVM and Binaryen installations respectively.
 
+
 Locating the compiler configuration file (.emscripten)
 =======================================================
 
-The settings file (``.emscripten``) is created by default within the emscripten directory:
-
-In cases where the emscripten directory is read-only the users home directoy
-will be used:
+The settings file (``.emscripten``) is created by default within the emscripten
+directory (alongsize ``emcc`` itself).  In cases where the emscripten directory
+is read-only the users home directory will be used:
 
   - On Linux and macOS this file is named **~/.emscripten**, where ~ is the
     user's home directory.
@@ -54,7 +59,7 @@ Compiler configuration file-format
 
 .. note:: While the syntax is identical, the appearance of the default **.emscripten** file created by *emcc* is quite different than that created by :ref:`emsdk <compiler-configuration-file>`. This is because *emsdk* manages multiple target environments, and where possible hard codes the locations of those tools when a new environment is activated. The default file, by contrast, is managed by the user — and is designed to make that task as easy as possible.
 
-The file simply assigns paths to a number of *variables* representing the main tools used by Emscripten. For example, if the user installed python to the **C:/Python27/** directory, then the file might have the line: ::
+The file simply assigns paths to a number of *variables* representing the main tools used by Emscripten. For example, if the user installed python to the **C:\\Python38\\** directory, then the file might have the line: ::
 
 	PYTHON = 'C:\\Python38\\python.exe'
 	

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -183,14 +183,16 @@ class other(RunnerCore):
     self.assertContained('Running sanity checks', proc.stderr)
 
   def test_emcc_generate_config(self):
-    for compiler in [EMCC, EMXX]:
-      config_path = './emscripten_config'
-      self.run_process([compiler, '--generate-config', config_path])
-      self.assertExists(config_path, 'A config file should have been created at %s' % config_path)
-      config_contents = read_file(config_path)
-      self.assertContained('EMSCRIPTEN_ROOT', config_contents)
-      self.assertContained('LLVM_ROOT', config_contents)
-      os.remove(config_path)
+    config_path = './emscripten_config'
+    with env_modify({'EM_CONFIG': config_path}):
+      for compiler in [EMCC, EMXX]:
+        self.assertNotExists(config_path)
+        self.run_process([compiler, '--generate-config'])
+        self.assertExists(config_path)
+        config_contents = read_file(config_path)
+        self.assertContained('EMSCRIPTEN_ROOT', config_contents)
+        self.assertContained('LLVM_ROOT', config_contents)
+        os.remove(config_path)
 
   def test_emcc_output_mjs(self):
     self.run_process([EMCC, '-o', 'hello_world.mjs', test_file('hello_world.c')])


### PR DESCRIPTION
I think its cleaner if we just exit with an error if emscripten is not yet  
configured.  Especially since we already have an error mesasge for          
"config file not found" so this change means that first time users will  
now see that message (in which we now recommend the use of               
`--generate-config`).                                                    
                                                                         
There are a few reasons why I think this is better:             
                                                                         
1. We already have a error message for missing config file               
2. Currently when the config file is generated we return 0 without          
   actually doing anything, which could confuse build systems.           
3. In the case of a misconfigured systems (e.g. an accidentally         
   removed config file, or a EM_CONFIG pointing the wrong place)         
   the solution is probably not to simply just create a new              
   config, but to inform the developer and let them take action.  

Fixes: #13962