### PR TITLE
Fix remaining issues reporting undefined symbols in MAIN_MODULE/RELOCATABLE/LINKABLE builds

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1438,12 +1438,14 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         settings.EXPORT_ALL = 1
       settings.RELOCATABLE = 1
 
+    if settings.MAIN_MODULE:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getDylinkMetadata']
+
     if settings.RELOCATABLE:
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
           '$reportUndefinedSymbols',
           '$relocateExports',
           '$GOTHandler',
-          '$getDylinkMetadata',
           '__heap_base',
           '__stack_pointer',
       ]
@@ -1625,7 +1627,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     if settings.SIDE_MODULE and settings.GLOBAL_BASE != -1:
       exit_with_error('Cannot set GLOBAL_BASE when building SIDE_MODULE')
 
-    if settings.RELOCATABLE:
+    if settings.RELOCATABLE or settings.LINKABLE:
       default_setting('ERROR_ON_UNDEFINED_SYMBOLS', 0)
       default_setting('WARN_ON_UNDEFINED_SYMBOLS', 0)
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -159,7 +159,7 @@ function JSify(functionsOnly) {
       var noExport = false;
 
       if (!LibraryManager.library.hasOwnProperty(ident)) {
-        if (!isDefined(ident) && !LINKABLE) {
+        if (!isDefined(ident)) {
           var msg = 'undefined symbol: ' + ident;
           if (dependent) msg += ' (referenced by ' + dependent + ')';
           if (ERROR_ON_UNDEFINED_SYMBOLS) {

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -139,13 +139,15 @@ int pthread_setspecific(pthread_key_t key, const void* value) {
 /*magic number to detect if we have not run yet*/
 #define PTHREAD_ONCE_MAGIC_ID 0x13579BDF
 
-int pthread_once(pthread_once_t* once_control, void (*init_routine)(void)) {
+int __pthread_once(pthread_once_t* once_control, void (*init_routine)(void)) {
   if (*once_control != PTHREAD_ONCE_MAGIC_ID) {
     init_routine();
     *once_control = PTHREAD_ONCE_MAGIC_ID;
   }
   return 0;
 }
+
+weak_alias(__pthread_once, pthread_once);
 
 int pthread_cond_wait(pthread_cond_t *cond, pthread_mutex_t *mutex) {
   return 0;

--- a/tests/other/test_check_undefined.c
+++ b/tests/other/test_check_undefined.c
@@ -1,0 +1,5 @@
+int foo();
+
+int main() {
+  return foo();
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10339,3 +10339,17 @@ exec "$@"
     # Test that ERROR_ON_UNDEFINED_SYMBOLS works with MAIN_MODULE.
     self.run_process([EMCC, '-sMAIN_MODULE', '-sERROR_ON_UNDEFINED_SYMBOLS', test_file('hello_world.c')])
     self.run_js('a.out.js')
+
+  @parameterized({
+    'main_module': ('-sRELOCATABLE',),
+    'linkable': ('-sLINKABLE',),
+    'relocatable': ('-sMAIN_MODULE',),
+  })
+  def test_check_undefined(self, flag):
+    # positive case: no undefined symbols
+    self.run_process([EMCC, flag, '-sERROR_ON_UNDEFINED_SYMBOLS', test_file('hello_world.c')])
+    self.run_js('a.out.js')
+
+    # negative case: foo is undefined in test_check_undefined.c
+    err = self.expect_fail([EMCC, flag, '-sERROR_ON_UNDEFINED_SYMBOLS', test_file('other', 'test_check_undefined.c')])
+    self.assertContained('undefined symbol: foo', err)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -641,7 +641,8 @@ class libcompiler_rt(MTLibrary):
 
   cflags = ['-O2', '-fno-builtin']
   src_dir = ['system', 'lib', 'compiler-rt', 'lib', 'builtins']
-  src_files = glob_in_path(src_dir, '*.c')
+  # gcc_personality_v0.c depends on libunwind, which don't include by default.
+  src_files = glob_in_path(src_dir, '*.c', excludes=['gcc_personality_v0.c'])
   src_files += files_in_path(
       path_components=['system', 'lib', 'compiler-rt'],
       filenames=[
@@ -690,7 +691,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         'getgrouplist.c', 'initgroups.c', 'wordexp.c', 'timer_create.c',
         'faccessat.c',
         # 'process' exclusion
-        'fork.c', 'vfork.c', 'posix_spawn.c', 'execve.c', 'waitid.c', 'system.c'
+        'fork.c', 'vfork.c', 'posix_spawn.c', 'posix_spawnp.c', 'execve.c', 'waitid.c', 'system.c'
     ]
 
     ignore += LIBC_SOCKETS


### PR DESCRIPTION
Move `gcc_personality_v0.c` to `libunwind`.  This prevents this object file
from being included except when libunwind is present.  Without this, including
`libcompiler-rt` with `-whole-archive` produces undefined symbols for 
`_Unwind_GetIP` and other `libunwind` symbols.

Also, allow programs built with `-sLINKABLE` to report undefined symbol
errors.  By default we don't report errors, but this can be overridden on the
command line).  The issue here was that `MAIN_MODULE=1` sets 
`LINKABLE` which meant we were then not actually reporting  any undefined
symbols.