### PR TITLE
"fix" arcane closure madness

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -297,6 +297,6 @@ var GPUValidationError;
 var GPUOutOfMemoryError;
 
 /*
- * See #13965
+ * Avoid closure minifying anything to "id". See #13965
  */
 var id;

--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -295,3 +295,8 @@ var sampleRate;
  */
 var GPUValidationError;
 var GPUOutOfMemoryError;
+
+/*
+ * See #13965
+ */
+var id;

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -796,7 +796,7 @@ var LibraryJSEvents = {
       var e = ev || event;
 
       var nodeName = JSEvents.getNodeNameForTarget(e.target);
-      var id = (e.target.id && typeof e.target.id === 'string') ? e.target.id : '';
+      var id = e.target.id ? e.target.id : '';
 
 #if USE_PTHREADS
       var focusEvent = targetThread ? _malloc( {{{ C_STRUCTS.EmscriptenFocusEvent.__size__ }}} ) : JSEvents.focusEvent;

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -796,7 +796,7 @@ var LibraryJSEvents = {
       var e = ev || event;
 
       var nodeName = JSEvents.getNodeNameForTarget(e.target);
-      var id = e.target.id ? e.target.id : '';
+      var id = (e.target.id && typeof e.target.id === 'string') ? e.target.id : '';
 
 #if USE_PTHREADS
       var focusEvent = targetThread ? _malloc( {{{ C_STRUCTS.EmscriptenFocusEvent.__size__ }}} ) : JSEvents.focusEvent;


### PR DESCRIPTION
The problem here is that `e.target` may be (for whatever reason) the `window` object. Closure may actually emit a global function named `id`, which will be accessible through `window.id`. If both of these conditions are met, `e.target.id ? e.target.id : ''` will evaluate to a function value instead of a string, and we will end up calling `StringToUTF8` on it, which will throw an exception.