### PR TITLE
Update expectations based on binaryen change. NFC

### DIFF
--- a/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.sent
+++ b/tests/other/metadce/hello_world_O3_MAIN_MODULE_2.sent
@@ -1,3 +1,4 @@
+__heap_base
 __indirect_function_table
 __memory_base
 __stack_pointer

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6992,7 +6992,9 @@ int main() {
     # we don't metadce with linkable code! other modules may want stuff
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [],  10135), # noqa
+    # Temporarily disabled while https://github.com/WebAssembly/binaryen/pull/3831
+    # rolls in.
+    #'main_module_2': (['-O3', '-s', 'MAIN_MODULE=2'], [], [],  10135), # noqa
   })
   def test_metadce_hello(self, *args):
     self.run_metadce_test('hello_world.cpp', *args)


### PR DESCRIPTION
This extra export on `asmLibraryArgs` is due to:
https://github.com/WebAssembly/binaryen/pull/3831 which is currently
failing in the auto-roller.  Temporarily disable this test until that
change has rolled in.

The module imports `GOT.data.__heap_base` which means we need to keep
the `__heap_base` value alive on on whatever object we use to resolve
global symbols.  So technically this isn't needed today since but it
will be once we land #13949.  Once #13949 lands we should be able to
remove `__heap_base` from the Module object to regain any lost bytes
here.