### PR TITLE
Update expectations after llvm commit. NFC

### DIFF
--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12605,
-  "a.html.gz": 6770,
-  "total": 12605,
-  "total_gz": 6770
+  "a.html": 12589,
+  "a.html.gz": 6757,
+  "total": 12589,
+  "total_gz": 6757
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17371,
-  "a.html.gz": 7492,
-  "total": 17371,
-  "total_gz": 7492
+  "a.html": 17326,
+  "a.html.gz": 7464,
+  "total": 17326,
+  "total_gz": 7464
 }


### PR DESCRIPTION
I bisects this to an LLVM change already rolled in and is currently 
breaking emscripten CI: https://reviews.llvm.org/rG9423f78240a2#990953

This seems to be a size win for wasm and slight regression for wasm2g.
Its a revert, so its likely we could this re-land in the future causing us
to have to revert this change.