### PR TITLE
Do not error on deprecated functions in SIMD intrinsics test

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5851,6 +5851,8 @@ return malloc(size);
     # Improves test readability
     self.emcc_args.append('-Wno-c++11-narrowing')
     self.emcc_args.extend(['-Wpedantic', '-Werror', '-Wall', '-xc++'])
+    # Ignore deprecation errors for now
+    self.emcc_args.append('-Wno-error=deprecated-declarations')
     run()
     self.emcc_args.append('-funsigned-char')
     run()


### PR DESCRIPTION
The names of some intrinsic functions will soon change in upstream LLVM, but the
old names will be marked deprecated and preserved for some time. This PR should
smooth the transition by allowing use of the deprecated names without errors. A
future PR will update the deprecated names to the new names and remove this
exception.