### PR TITLE
Revert musl change to asctime.c. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -676,9 +676,10 @@ LibraryManager.library = {
   },
   __localtime_r: 'localtime_r',
 
-  asctime_r__deps: ['mktime'],
-  asctime_r__sig: 'iii',
-  asctime_r: function(tmPtr, buf) {
+  // musl-internal function used to implement both `asctime` and `asctime_r`
+  __asctime__deps: ['mktime'],
+  __asctime__sig: 'iii',
+  __asctime: function(tmPtr, buf) {
     var date = {
       tm_sec: {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_sec, 'i32') }}},
       tm_min: {{{ makeGetValue('tmPtr', C_STRUCTS.tm.tm_min, 'i32') }}},
@@ -705,13 +706,12 @@ LibraryManager.library = {
     stringToUTF8(s, buf, 26);
     return buf;
   },
-  __asctime_r: 'asctime_r',
 
-  ctime_r__deps: ['localtime_r', 'asctime_r'],
+  ctime_r__deps: ['localtime_r', '__asctime'],
   ctime_r__sig: 'iii',
   ctime_r: function(time, buf) {
     var stack = stackSave();
-    var rv = _asctime_r(_localtime_r(time, stackAlloc({{{ C_STRUCTS.tm.__size__ }}})), buf);
+    var rv = ___asctime(_localtime_r(time, stackAlloc({{{ C_STRUCTS.tm.__size__ }}})), buf);
     stackRestore(stack);
     return rv;
   },

--- a/system/lib/libc/musl/src/time/asctime.c
+++ b/system/lib/libc/musl/src/time/asctime.c
@@ -1,9 +1,9 @@
 #include <time.h>
 
-char *__asctime_r(const struct tm *, char *);
+char *__asctime(const struct tm *, char *);
 
 char *asctime(const struct tm *tm)
 {
 	static char buf[26];
-	return __asctime_r(tm, buf);
+	return __asctime(tm, buf);
 }

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -729,7 +729,15 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
     # Allowed files from ignored modules
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'time'],
-        filenames=['clock_settime.c', 'asctime.c', 'ctime.c', 'gmtime.c', 'localtime.c', 'nanosleep.c'])
+        filenames=[
+          'clock_settime.c',
+          'asctime_r.c',
+          'asctime.c',
+          'ctime.c',
+          'gmtime.c',
+          'localtime.c',
+          'nanosleep.c'
+        ])
     libc_files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'legacy'],
         filenames=['getpagesize.c', 'err.c'])
@@ -1351,7 +1359,6 @@ class libstandalonewasm(MuslInternalLibrary):
                    '__tm_to_secs.c',
                    '__tz.c',
                    '__year_to_secs.c',
-                   'asctime_r.c',
                    'clock.c',
                    'clock_gettime.c',
                    'ctime_r.c',


### PR DESCRIPTION
It looks like a patch from a more recent version of musl was applied
in #12043.

This change reverts that and removes the extra alias needed in in
library.js.  library.js now implements just a single `__asctime` which
is used by both `asctime.c` and `asctime_r.c`.   I've also added 
`asctime_r.c` to the build so that symbol will come from musl now.

This is in the name doing more with musl (without patches) and less in JS.