### PR TITLE
Allow `profile_block` to be used as a decorator. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -823,9 +823,9 @@ def normalize_line_endings(text):
 def generate_struct_info():
   generated_struct_info_name = 'generated_struct_info.json'
 
+  @ToolchainProfiler.profile_block('gen_struct_info')
   def generate_struct_info(out):
-    with ToolchainProfiler.profile_block('gen_struct_info'):
-      gen_struct_info.main(['-q', '-o', out])
+    gen_struct_info.main(['-q', '-o', out])
 
   settings.STRUCT_INFO = shared.Cache.get(generated_struct_info_name, generate_struct_info)
 

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -127,26 +127,26 @@ end_asm_marker = '// EMSCRIPTEN_END_ASM\n'
 
 # Given a set of functions of form (ident, text), and a preferred chunk size,
 # generates a set of chunks for parallel processing and caching.
+@ToolchainProfiler.profile_block('chunkify')
 def chunkify(funcs, chunk_size):
-  with ToolchainProfiler.profile_block('chunkify'):
-    chunks = []
-    # initialize reasonably, the rest of the funcs we need to split out
-    curr = []
-    total_size = 0
-    for i in range(len(funcs)):
-      func = funcs[i]
-      curr_size = len(func[1])
-      if total_size + curr_size < chunk_size:
-        curr.append(func)
-        total_size += curr_size
-      else:
-        chunks.append(curr)
-        curr = [func]
-        total_size = curr_size
-    if curr:
+  chunks = []
+  # initialize reasonably, the rest of the funcs we need to split out
+  curr = []
+  total_size = 0
+  for i in range(len(funcs)):
+    func = funcs[i]
+    curr_size = len(func[1])
+    if total_size + curr_size < chunk_size:
+      curr.append(func)
+      total_size += curr_size
+    else:
       chunks.append(curr)
-      curr = None
-    return [''.join(func[1] for func in chunk) for chunk in chunks] # remove function names
+      curr = [func]
+      total_size = curr_size
+  if curr:
+    chunks.append(curr)
+    curr = None
+  return [''.join(func[1] for func in chunk) for chunk in chunks] # remove function names
 
 
 def run_on_js(filename, passes, extra_info=None, just_split=False, just_concat=False):
@@ -396,11 +396,11 @@ EMSCRIPTEN_FUNCS();
   return filename
 
 
+@ToolchainProfiler.profile_block('js_optimizer.run_on_js')
 def run(filename, passes, extra_info=None):
   just_split = 'receiveJSON' in passes
   just_concat = 'emitJSON' in passes
-  with ToolchainProfiler.profile_block('js_optimizer.run_on_js'):
-    return run_on_js(filename, passes, extra_info=extra_info, just_split=just_split, just_concat=just_concat)
+  return run_on_js(filename, passes, extra_info=extra_info, just_split=just_split, just_concat=just_concat)
 
 
 def main():

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1944,6 +1944,6 @@ def install_system_headers(stamp):
   return stamp
 
 
+@ToolchainProfiler.profile_block('ensure_sysroot')
 def ensure_sysroot():
-  with ToolchainProfiler.profile_block('ensure_sysroot'):
-    shared.Cache.get('sysroot_install.stamp', install_system_headers, what='system headers')
+  shared.Cache.get('sysroot_install.stamp', install_system_headers, what='system headers')

--- a/tools/toolchain_profiler.py
+++ b/tools/toolchain_profiler.py
@@ -8,6 +8,7 @@ import os
 import time
 import sys
 import tempfile
+from contextlib import ContextDecorator
 
 sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -191,7 +192,7 @@ if EMPROFILE:
       for b in ToolchainProfiler.block_stack[::-1]:
         ToolchainProfiler.exit_block(b)
 
-    class ProfileBlock:
+    class ProfileBlock(ContextDecorator):
       def __init__(self, block_name):
         self.block_name = block_name
 
@@ -240,8 +241,8 @@ else:
     def exit_block(block_name):
       pass
 
-    class ProfileBlock:
-      def __init__(self, block_name):
+    class ProfileBlock(ContextDecorator):
+      def __init__(self):
         pass
 
       def __enter__(self):
@@ -252,4 +253,4 @@ else:
 
     @staticmethod
     def profile_block(block_name):
-      return ToolchainProfiler.ProfileBlock(block_name)
+      return ToolchainProfiler.ProfileBlock()


### PR DESCRIPTION
Convert some cases where we were profiling entire functions to use the
decorator.

The hope is that this should allow us to add profiling when/where we
need to without needing to re-indent any code.