### PR TITLE
Support Wasm EH with LTO

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1116,17 +1116,6 @@ int main() {
       self.set_setting('SUPPORT_LONGJMP', support_longjmp)
       self.do_run_from_file(test_file('core', 'test_exceptions.cpp'), test_file('core', 'test_exceptions_caught.out'))
 
-  # We have LTO tests covered in 'wasmltoN' targets, but they don't run as a
-  # part of Emscripten CI, so we make a separate LTO test here.
-  @with_both_exception_handling
-  def test_exceptions_lto(self):
-    self.set_setting('EXCEPTION_DEBUG')
-    self.emcc_args += ['-flto']
-    self.maybe_closure()
-    for support_longjmp in [0, 1]:
-      self.set_setting('SUPPORT_LONGJMP', support_longjmp)
-      self.do_run_from_file(test_file('core', 'test_exceptions.cpp'), test_file('core', 'test_exceptions_caught.out'))
-
   def test_exceptions_off(self):
     for support_longjmp in [0, 1]:
       self.set_setting('DISABLE_EXCEPTION_CATCHING')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1116,6 +1116,17 @@ int main() {
       self.set_setting('SUPPORT_LONGJMP', support_longjmp)
       self.do_run_from_file(test_file('core', 'test_exceptions.cpp'), test_file('core', 'test_exceptions_caught.out'))
 
+  # We have LTO tests covered in 'wasmltoN' targets, but they don't run as a
+  # part of Emscripten CI, so we make a separate LTO test here.
+  @with_both_exception_handling
+  def test_exceptions_lto(self):
+    self.set_setting('EXCEPTION_DEBUG')
+    self.emcc_args += ['-flto']
+    self.maybe_closure()
+    for support_longjmp in [0, 1]:
+      self.set_setting('SUPPORT_LONGJMP', support_longjmp)
+      self.do_run_from_file(test_file('core', 'test_exceptions.cpp'), test_file('core', 'test_exceptions_caught.out'))
+
   def test_exceptions_off(self):
     for support_longjmp in [0, 1]:
       self.set_setting('DISABLE_EXCEPTION_CATCHING')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7280,6 +7280,8 @@ int main() {
   # We have LTO tests covered in 'wasmltoN' targets in test_core.py, but they
   # don't run as a part of Emscripten CI, so we add a separate LTO test here.
   def test_lto_wasm_exceptions(self):
+    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
+      self.skipTest('d8 required to run wasm eh tests')
     self.set_setting('EXCEPTION_DEBUG')
     self.emcc_args += ['-fwasm-exceptions', '-flto']
     self.v8_args.append('--experimental-wasm-eh')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7277,6 +7277,15 @@ int main() {
       seen_bitcode = building.is_bitcode('a.o')
       self.assertEqual(expect_bitcode, seen_bitcode, 'must emit LTO-capable bitcode when flags indicate so (%s)' % str(flags))
 
+  # We have LTO tests covered in 'wasmltoN' targets in test_core.py, but they
+  # don't run as a part of Emscripten CI, so we add a separate LTO test here.
+  def test_lto_wasm_exceptions(self):
+    self.set_setting('EXCEPTION_DEBUG')
+    self.emcc_args += ['-fwasm-exceptions', '-flto']
+    self.v8_args.append('--experimental-wasm-eh')
+    self.js_engines = [config.V8_ENGINE]
+    self.do_run_from_file(test_file('core', 'test_exceptions.cpp'), test_file('core', 'test_exceptions_caught.out'))
+
   def test_wasm_nope(self):
     for opts in [[], ['-O2']]:
       print(opts)

--- a/tools/building.py
+++ b/tools/building.py
@@ -453,6 +453,11 @@ def link_lld(args, target, external_symbol_list=None):
   for a in llvm_backend_args():
     cmd += ['-mllvm', a]
 
+  # Wasm exception handling. This is a CodeGen option for the LLVM backend, so
+  # wasm-ld needs to take this for the LTO mode.
+  if settings.EXCEPTION_HANDLING:
+    cmd += ['-mllvm', '-exception-model=wasm']
+
   # For relocatable output (generating an object file) we don't pass any of the
   # normal linker flags that are used when building and exectuable
   if '--relocatable' not in args and '-r' not in args:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -961,6 +961,11 @@ class libcxx(NoExceptLibrary, MTLibrary):
 
 class libunwind(NoExceptLibrary, MTLibrary):
   name = 'libunwind'
+  # Because calls to _Unwind_CallPersonality are generated during LTO, libunwind
+  # can't currently be part of LTO.
+  # See https://bugs.llvm.org/show_bug.cgi?id=44353
+  force_object_files = True
+
   cflags = ['-Oz', '-D_LIBUNWIND_DISABLE_VISIBILITY_ANNOTATIONS']
   src_dir = ['system', 'lib', 'libunwind', 'src']
   # Without this we can't build libunwind since it will pickup the unwind.h


### PR DESCRIPTION
I'm not sure whether I should a separate test here, because it will
going to be a duplicate of any of existing EH tests with only
`self.emcc_args += ['-flto']` added, and we can already test all
existing tests in test_core.py using `wasmltoN` targets.

All EH tests annotated with `with_both_exception_handling` decorators
pass all of `wasmlto0`, `wasmlto1`, `wasmlto2`, `wasmlto3`, and
`wasmltos` modes. (`wasmltoz` fails because of a known issue with V8
that affects non-EH tests too. `wasmz` fails for the same reason.)

Fixes #13665.