### PR TITLE
Update links to llvm sources

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -557,3 +557,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Philip Gossweiler <philip.gossweiler@outlook.com>
 * Rafael Brune <mail@rbrune.de>
 * Aleksi Sapon <aleksi.sapon@faro.com> (copyright owned by FARO Technologies, Inc.)
+* Radek Doulik <radek.doulik@gmail.com> (copyright owned by Microsoft, Inc.)

--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -15,7 +15,7 @@ At the source level, the GCC/Clang `SIMD Vector Extensions <https://gcc.gnu.org/
 
        #include <wasm_simd128.h>
 
-Separate documentation for the intrinsics header is a work in progress, but its usage is straightforward and its source can be found at `wasm_simd128.h <https://github.com/llvm/llvm-project/blob/master/clang/lib/Headers/wasm_simd128.h>`_. These intrinsics are under active development in parallel with the SIMD proposal and should not be considered any more stable than the proposal itself. Note that most engines will also require an extra flag to enable SIMD. For example, Node requires `--experimental-wasm-simd`.
+Separate documentation for the intrinsics header is a work in progress, but its usage is straightforward and its source can be found at `wasm_simd128.h <https://github.com/llvm/llvm-project/blob/main/clang/lib/Headers/wasm_simd128.h>`_. These intrinsics are under active development in parallel with the SIMD proposal and should not be considered any more stable than the proposal itself. Note that most engines will also require an extra flag to enable SIMD. For example, Node requires `--experimental-wasm-simd`.
 
 WebAssembly SIMD is not supported when using the Fastcomp backend.
 

--- a/system/lib/compiler-rt/include/sanitizer/tsan_interface_atomic.h
+++ b/system/lib/compiler-rt/include/sanitizer/tsan_interface_atomic.h
@@ -30,7 +30,7 @@ __extension__ typedef __int128 __tsan_atomic128;
 #endif
 
 // Part of ABI, do not change.
-// https://github.com/llvm/llvm-project/blob/master/libcxx/include/atomic
+// https://github.com/llvm/llvm-project/blob/main/libcxx/include/atomic
 typedef enum {
   __tsan_memory_order_relaxed,
   __tsan_memory_order_consume,

--- a/system/lib/libunwind/docs/index.rst
+++ b/system/lib/libunwind/docs/index.rst
@@ -101,4 +101,4 @@ Quick Links
 * `LLVM Bugzilla <https://bugs.llvm.org/>`_
 * `cfe-commits Mailing List`_
 * `cfe-dev Mailing List`_
-* `Browse libunwind Sources <https://github.com/llvm/llvm-project/blob/master/libunwind/>`_
+* `Browse libunwind Sources <https://github.com/llvm/llvm-project/blob/main/libunwind/>`_


### PR DESCRIPTION
I noticed the link to simd header from the documentation to llvm github
doesn't work anymore. So updated that and also other occurences
of the same.