### PR TITLE
Use a clean environment when building harfbuzz

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -558,3 +558,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Rafael Brune <mail@rbrune.de>
 * Aleksi Sapon <aleksi.sapon@faro.com> (copyright owned by FARO Technologies, Inc.)
 * Radek Doulik <radek.doulik@gmail.com> (copyright owned by Microsoft, Inc.)
+* Albert Vaca Cintora <albertvaka@gmail.com>

--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -7,6 +7,8 @@ import os
 import shutil
 import logging
 
+from tools import system_libs
+
 TAG = '1.7.5'
 HASH = 'c2c13fc97bb74f0f13092b07804f7087e948bce49793f48b62c2c24a5792523acc0002840bebf21829172bb2e7c3df9f9625250aec6c786a55489667dd04d6a0'
 
@@ -60,7 +62,7 @@ def get(ports, settings, shared):
       cmake_cmd += ['-DCMAKE_CXX_FLAGS="{}"'.format(' '.join(extra_cflags))]
       cmake_cmd += ['-DCMAKE_C_FLAGS="{}"'.format(' '.join(extra_cflags))]
 
-    shared.run_process(cmake_cmd)
+    shared.run_process(cmake_cmd, env=system_libs.clean_env())
     shared.run_process(['cmake', '--build', build_path, '--target', 'install'])
 
     ports.install_header_dir(os.path.join(build_path, 'include', 'harfbuzz'))


### PR DESCRIPTION
Prevent CMake from picking up the parent project CFLAGS.

Fixes: https://github.com/emscripten-core/emsdk/issues/796