### PR TITLE
clean_env: Also clean CXXFLAGS

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -74,7 +74,7 @@ def clean_env():
   # At least one port also uses autoconf (harfbuzz) so we also need to clear
   # CFLAGS/LDFLAGS which we don't want to effect the inner call to configure.
   safe_env = os.environ.copy()
-  for opt in ['CFLAGS', 'LDFLAGS', 'EMCC_CFLAGS', 'EMMAKEN_CFLAGS', 'EMMAKEN_JUST_CONFIGURE']:
+  for opt in ['CFLAGS', 'CXXFLAGS', 'LDFLAGS', 'EMCC_CFLAGS', 'EMMAKEN_CFLAGS', 'EMMAKEN_JUST_CONFIGURE']:
     if opt in safe_env:
       del safe_env[opt]
   return safe_env


### PR DESCRIPTION
CMake will pick up both `CFLAGS` and `CXXFLAGS` if they are defined (and
set them as `CMAKE_C_FLAGS` and `CMAKE_CXX_FLAGS` respectively)