### PR TITLE
Use toolchain_profiler to log block durations. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -184,22 +184,6 @@ def save_intermediate_with_wasm(name, wasm_binary):
   building.save_intermediate(wasm_binary, name + '.wasm')
 
 
-class TimeLogger:
-  last = time.time()
-
-  @staticmethod
-  def update():
-    TimeLogger.last = time.time()
-
-
-def log_time(name):
-  """Log out times for emcc stages"""
-  if DEBUG:
-    now = time.time()
-    logger.debug('emcc step "%s" took %.2f seconds', name, now - TimeLogger.last)
-    TimeLogger.update()
-
-
 def base64_encode(b):
   b64 = base64.b64encode(b)
   return b64.decode('ascii')
@@ -2099,8 +2083,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     settings.PROFILING_FUNCS = options.profiling_funcs
     settings.SOURCE_MAP_BASE = options.source_map_base or ''
 
+  ##########################################
   # exit block 'parse arguments and setup'
-  log_time('parse arguments and setup')
+  ##########################################
 
   linker_inputs = []
   if options.post_link:
@@ -2239,8 +2224,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
         logger.debug('using object file: ' + input_file)
         linker_inputs.append((i, input_file))
 
+  ##########################################
   # exit block 'compile inputs'
-  log_time('compile inputs')
+  ##########################################
 
   if compile_only:
     logger.debug('stopping after compile phase')
@@ -2306,8 +2292,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       extra_files_to_link += system_libs.calculate([f for _, f in sorted(linker_inputs)] + extra_files_to_link, link_as_cxx, forced=forced_stdlibs)
     linker_arguments += extra_files_to_link
 
+  ##########################################
   # exit block 'calculate system libraries'
-  log_time('calculate system libraries')
+  ##########################################
 
   def dedup_list(lst):
     rtn = []
@@ -2330,16 +2317,17 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     # TODO: we could check if this is a fastcomp build, and still speed things up here
     js_funcs = None
     if settings.LLD_REPORT_UNDEFINED and settings.ERROR_ON_UNDEFINED_SYMBOLS:
-      js_funcs = get_all_js_syms()
-      log_time('JS symbol generation')
+      with ToolchainProfiler.profile_block('JS symbol generation'):
+        js_funcs = get_all_js_syms()
     building.link_lld(linker_arguments, wasm_target, external_symbol_list=js_funcs)
     # Special handling for when the user passed '-Wl,--version'.  In this case the linker
     # does not create the output file, but just prints its version and exits with 0.
     if '--version' in linker_arguments:
       return 0
 
+  ##########################################
   # exit block 'link'
-  log_time('link')
+  ##########################################
 
   if target == os.devnull:
     # TODO(sbc): In theory we should really run the whole pipeline even if the output is
@@ -2393,8 +2381,9 @@ def post_link(options, in_wasm, wasm_target, target):
     emscripten.run(in_wasm, wasm_target, final_js, memfile)
     save_intermediate('original')
 
+  ##########################################
   # exit block 'emscript'
-  log_time('emscript)')
+  ##########################################
 
   with ToolchainProfiler.profile_block('source transforms'):
     # Embed and preload files
@@ -2441,8 +2430,9 @@ def post_link(options, in_wasm, wasm_target, target):
       shared.check_call(building.remove_quotes(shlex.split(options.js_transform, posix=posix) + [os.path.abspath(final_js)]))
       save_intermediate('transformed')
 
+  ##########################################
   # exit block 'source transforms'
-  log_time('source transforms')
+  ##########################################
 
   if memfile and not settings.MINIMAL_RUNTIME:
     # MINIMAL_RUNTIME doesn't use `var memoryInitializer` but instead expects Module['mem'] to
@@ -2455,12 +2445,12 @@ def post_link(options, in_wasm, wasm_target, target):
       open(final_js + '.mem.js', 'w').write(src)
       final_js += '.mem.js'
 
-    log_time('memory initializer')
+    ##########################################
+    # exit block 'memory initializer'
+    ##########################################
 
-  with ToolchainProfiler.profile_block('binaryen'):
-    do_binaryen(target, options, wasm_target)
+  do_binaryen(target, options, wasm_target)
 
-  log_time('binaryen')
   # If we are not emitting any JS then we are all done now
   if options.oformat == OFormat.WASM:
     return
@@ -2543,8 +2533,9 @@ def post_link(options, in_wasm, wasm_target, target):
     if options.executable:
       make_js_executable(js_target)
 
-  log_time('final emitting')
+  ##########################################
   # exit block 'final emitting'
+  ##########################################
 
   return 0
 
@@ -2881,6 +2872,7 @@ def parse_args(newargs):
   return options, settings_changes, user_js_defines, newargs
 
 
+@ToolchainProfiler.profile_block('binaryen')
 def do_binaryen(target, options, wasm_target):
   global final_js
   logger.debug('using binaryen')


### PR DESCRIPTION
Even when EMPROFILE is not enabled it is still useful to use logger to
output the duration of each block.  In fact, were were already doing this
in emcc.  This change makes this work tranparantly for all profiled
blocks.