### PR TITLE
Add libvorbisfile port (enabled with USE_VORBIS=1)

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1640,6 +1640,13 @@ int f() {
     self.emcc(test_file('vorbis_test.c'), ['-s', 'USE_VORBIS'], output_filename='a.out.js')
     self.assertContained('ALL OK', self.run_process(config.JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).stdout)
 
+  def test_vorbisfile(self):
+    shutil.copyfile(test_file('sounds', 'the_entertainer.ogg'), os.path.join(self.get_dir(), 'music.ogg'))
+    self.emcc(test_file('vorbisfile_test.c'), ['--embed-file', 'music.ogg', '-s', 'USE_VORBIS'], output_filename='a.out.js')
+    output = self.run_process(config.JS_ENGINES[0] + ['a.out.js', 'music.ogg'], stdout=PIPE, stderr=PIPE).stdout
+    self.assertContained('Decoded length: 2677622 samples', output)
+    self.assertContained('ALL OK', output)
+
   def test_bzip2(self):
     self.emcc(test_file('bzip2_test.c'), ['-s', 'USE_BZIP2=1'], output_filename='a.out.js')
     self.assertContained("usage: unzcrash filename", self.run_process(config.JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).stdout)

--- a/tests/vorbisfile_test.c
+++ b/tests/vorbisfile_test.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2015 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+/********************************************************************
+ *                                                                  *
+ * THIS FILE IS PART OF THE OggVorbis SOFTWARE CODEC SOURCE CODE.   *
+ * USE, DISTRIBUTION AND REPRODUCTION OF THIS LIBRARY SOURCE IS     *
+ * GOVERNED BY A BSD-STYLE SOURCE LICENSE INCLUDED WITH THIS SOURCE *
+ * IN 'COPYING'. PLEASE READ THESE TERMS BEFORE DISTRIBUTING.       *
+ *                                                                  *
+ * THE OggVorbis SOURCE CODE IS (C) COPYRIGHT 1994-2007             *
+ * by the Xiph.Org Foundation https://xiph.org/                     *
+ *                                                                  *
+ ********************************************************************
+
+ function: simple example decoder using vorbisfile
+
+ ********************************************************************/
+
+/* Takes a vorbis bitstream from stdin and writes raw stereo PCM to
+   stdout using vorbisfile. Using vorbisfile is much simpler than
+   dealing with libvorbis. */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#include <vorbis/codec.h>
+#include <vorbis/vorbisfile.h>
+
+char pcmout[4096]; /* take 4k out of the data segment, not the stack */
+
+int main(int argc, char** argv) {
+  OggVorbis_File vf;
+  int eof=0;
+  int current_section;
+  FILE* input = fopen(argv[1], "rb");
+
+  if (input == NULL) {
+      fprintf(stderr,"Cannot open input file %s.\n", argv[1]);
+      exit(1);
+  }
+
+  if(ov_open_callbacks(input, &vf, NULL, 0, OV_CALLBACKS_NOCLOSE) < 0) {
+      fprintf(stderr,"Input does not appear to be an Ogg bitstream.\n");
+      exit(1);
+  }
+
+  /* Throw the comments plus a few lines about the bitstream we're
+     decoding */
+  {
+    char **ptr=ov_comment(&vf,-1)->user_comments;
+    vorbis_info *vi=ov_info(&vf,-1);
+    while(*ptr) {
+      fprintf(stderr,"%s\n",*ptr);
+      ++ptr;
+    }
+    printf("\nBitstream is %d channel, %ldHz\n",vi->channels,vi->rate);
+    printf("\nDecoded length: %ld samples\n", (long)ov_pcm_total(&vf,-1));
+    printf("Encoded by: %s\n\n",ov_comment(&vf,-1)->vendor);
+  }
+
+  while(!eof) {
+    long ret=ov_read(&vf,pcmout,sizeof(pcmout),0,2,1,&current_section);
+    if (ret == 0) {
+      /* EOF */
+      eof=1;
+    } else if (ret < 0) {
+      if(ret==OV_EBADLINK) {
+        fprintf(stderr,"Corrupt bitstream section! Exiting.\n");
+        exit(1);
+      }
+
+      /* some other error in the stream.  Not a problem, just reporting it in
+         case we (the app) cares.  In this case, we don't. */
+    }
+  }
+
+  /* cleanup */
+  ov_clear(&vf);
+  fclose(input);
+
+  printf("ALL OK\n");
+  return(0);
+}

--- a/tools/ports/vorbis.py
+++ b/tools/ports/vorbis.py
@@ -33,11 +33,15 @@ def get(ports, settings, shared):
                      ['-s', 'USE_OGG=1'], ['psytune', 'barkmel', 'tone', 'misc'])
     ports.install_header_dir(os.path.join(source_path, 'include', 'vorbis'))
 
-  return [shared.Cache.get_lib('libvorbis.a', create)]
+  return [
+    shared.Cache.get_lib('libvorbis.a', create),
+    shared.Cache.get_lib('libvorbisfile.a', create),
+  ]
 
 
 def clear(ports, settings, shared):
   shared.Cache.erase_lib('libvorbis.a')
+  shared.Cache.erase_lib('libvorbisfile.a')
 
 
 def process_dependencies(settings):


### PR DESCRIPTION
Both libvorbis and libvorbisfile are built from the vorbis repository, might as well make it available.

Used by https://github.com/intgr/uqm-emscripten