### PR TITLE
Remove unused implementedFunctions from jsifier metadata. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -312,10 +312,6 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
     t = time.time()
 
   forwarded_json = json.loads(forwarded_data)
-  # For the wasm backend the implementedFunctions from compiler.js should
-  # always be empty. This only gets populated for __asm function when using
-  # the JS backend.
-  assert not forwarded_json['Functions']['implementedFunctions']
 
   pre, post = glue.split('// EMSCRIPTEN_END_FUNCS')
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -152,10 +152,6 @@ function JSify(functionsOnly) {
         return '';
       }
 
-      // Don't replace implemented functions with library ones (which can happen when we add dependencies).
-      // Note: We don't return the dependencies here. Be careful not to end up where this matters
-      if (finalName in Functions.implementedFunctions) return '';
-
       var noExport = false;
 
       if (!LibraryManager.library.hasOwnProperty(ident)) {

--- a/src/modules.js
+++ b/src/modules.js
@@ -40,8 +40,6 @@ function genArgSequence(n) {
 }
 
 var Functions = {
-  // All functions that will be implemented in this file. Maps id to signature
-  implementedFunctions: {},
   // functions added from the library. value 2 means asmLibraryFunction
   libraryFunctions: {},
 };
@@ -290,26 +288,6 @@ var LibraryManager = {
 
     this.loaded = true;
   },
-
-  // Given an ident, see if it is an alias for something, and so forth, returning
-  // the earliest ancestor (the root)
-  getRootIdent: function(ident) {
-    if (!this.library) return null;
-    var ret = LibraryManager.library[ident];
-    if (!ret) return null;
-    var last = ident;
-    while (typeof ret === 'string') {
-      last = ret;
-      ret = LibraryManager.library[ret];
-    }
-    return last;
-  },
-
-  isStubFunction: function(ident) {
-    var libCall = LibraryManager.library[ident.substr(1)];
-    return typeof libCall === 'function' && libCall.toString().replace(/\s/g, '') === 'function(){}'
-                                         && !(ident in Functions.implementedFunctions);
-  }
 };
 
 if (!BOOTSTRAPPING_STRUCT_INFO) {


### PR DESCRIPTION
This key is never assigned and we assert that its empty after running JS
compiler, so just remove it.

The purpose that his served in the amjs.js world in `jsifier.js` is taken care of
by checking WASM_EXPORTS in the block directly above the deleted code.