### PR TITLE
Remove LIBRARY_DEPS_TO_AUTOEXPORT setting

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -264,16 +264,6 @@ function JSify(functionsOnly) {
       if (redirectedIdent) {
         deps = deps.concat(LibraryManager.library[redirectedIdent + '__deps'] || []);
       }
-      // In asm, dependencies implemented in C might be needed by JS library functions.
-      // We don't know yet if they are implemented in C or not. To be safe, export such
-      // special cases.
-      [LIBRARY_DEPS_TO_AUTOEXPORT].forEach((special) => {
-        deps.forEach((dep) => {
-          if (dep == special && !EXPORTED_FUNCTIONS[dep]) {
-            EXPORTED_FUNCTIONS[dep] = 1;
-          }
-        });
-      });
       if (VERBOSE) {
         printErr('adding ' + finalName + ' and deps ' + deps + ' : ' + (snippet + '').substr(0, 40));
       }

--- a/src/settings.js
+++ b/src/settings.js
@@ -932,13 +932,6 @@ var RETAIN_COMPILER_SETTINGS = 0;
 // [link]
 var DEFAULT_LIBRARY_FUNCS_TO_INCLUDE = [];
 
-// This list is also used to determine auto-exporting of library dependencies
-// (i.e., functions that might be dependencies of JS library functions, that if
-// so we must export so that if they are implemented in C they will be
-// accessible, in ASM_JS mode).
-// [link]
-var LIBRARY_DEPS_TO_AUTOEXPORT = ['memcpy'];
-
 // Include all JS library functions instead of the sum of
 // DEFAULT_LIBRARY_FUNCS_TO_INCLUDE + any functions used by the generated code.
 // This is needed when dynamically loading (i.e. dlopen) modules that make use
@@ -2026,4 +2019,5 @@ var LEGACY_SETTINGS = [
   ['ASM_PRIMITIVE_VARS', [[]], 'No longer needed'],
   ['WORKAROUND_IOS_9_RIGHT_SHIFT_BUG', [0], 'Wasm2JS does not support iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 (devices with end-of-life at iOS 9.3.5) and older'],
   ['RUNTIME_FUNCS_TO_IMPORT', [[]], 'No longer needed'],
+  ['LIBRARY_DEPS_TO_AUTOEXPORT', [[]], 'No longer needed'],
 ];


### PR DESCRIPTION
This settings seems to relate to asm.js.  It referes to symbols that
night be implemented in C, but the only symbol listsed by default
(`memcpy`) is *always* implemented in C these days.

The effect seems to be to export `memcpy` on the Module object in the
case that any JS function depends on memcpy.  I can't see why we want to
do that.