### PR TITLE
Simplify libraryFunctions metadata exported from JS compiler

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -418,9 +418,8 @@ def get_all_js_syms():
     emscripten.generate_struct_info()
     glue, forwarded_data = emscripten.compile_settings()
     forwarded_json = json.loads(forwarded_data)
-    library_fns = forwarded_json['Functions']['libraryFunctions']
     library_fns_list = []
-    for name in library_fns:
+    for name in forwarded_json['libraryFunctions']:
       if shared.is_c_symbol(name):
         name = shared.demangle_c_symbol_name(name)
         library_fns_list.append(name)

--- a/emscripten.py
+++ b/emscripten.py
@@ -337,7 +337,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
   settings.EXPORTED_FUNCTIONS = forwarded_json['EXPORTED_FUNCTIONS']
 
   asm_consts = create_asm_consts(metadata)
-  em_js_funcs = create_em_js(forwarded_json, metadata)
+  em_js_funcs = create_em_js(metadata)
   asm_const_pairs = ['%s: %s' % (key, value) for key, value in asm_consts]
   asm_const_map = 'var ASM_CONSTS = {\n  ' + ',  \n '.join(asm_const_pairs) + '\n};\n'
   pre = pre.replace(
@@ -472,7 +472,7 @@ def create_asm_consts(metadata):
   return asm_consts
 
 
-def create_em_js(forwarded_json, metadata):
+def create_em_js(metadata):
   em_js_funcs = []
   separator = '<::>'
   for name, raw in metadata.get('emJsFuncs', {}).items():
@@ -486,7 +486,6 @@ def create_em_js(forwarded_json, metadata):
     arg_names = [arg.split()[-1].replace("*", "") for arg in args if arg]
     func = 'function {}({}){}'.format(name, ','.join(arg_names), body)
     em_js_funcs.append(func)
-    forwarded_json['Functions']['libraryFunctions'][name] = 1
 
   return em_js_funcs
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -219,7 +219,7 @@ function JSify(functionsOnly) {
           // In asm, we need to know about library functions. If there is a target, though, then no
           // need to consider this a library function - we will call directly to it anyhow
           if (!redirectedIdent && (typeof target == 'function')) {
-            Functions.libraryFunctions[finalName] = 1;
+            libraryFunctions.push(finalName);
           }
         }
       } else if (typeof snippet === 'object') {
@@ -228,14 +228,14 @@ function JSify(functionsOnly) {
         isFunction = true;
         snippet = processLibraryFunction(snippet, ident, finalName);
         if (!isJsOnlyIdentifier(ident[0])) {
-          Functions.libraryFunctions[finalName] = 1;
+          libraryFunctions.push(finalName);
         }
       }
 
       // If a JS library item specifies xxx_import: true, then explicitly mark that symbol to be exported
       // to wasm module.
       if (LibraryManager.library[ident + '__import']) {
-        Functions.libraryFunctions[finalName] = 1;
+        libraryFunctions.push(finalName);
       }
 
       if (ONLY_CALC_JS_SYMBOLS)
@@ -429,7 +429,7 @@ function JSify(functionsOnly) {
     print(processMacros(preprocess(shellParts[1], shellFile)));
 
     print('\n//FORWARDED_DATA:' + JSON.stringify({
-      Functions: Functions,
+      libraryFunctions: libraryFunctions,
       EXPORTED_FUNCTIONS: EXPORTED_FUNCTIONS,
       ATINITS: ATINITS.join('\n'),
       ATMAINS: ATMAINS.join('\n'),

--- a/src/modules.js
+++ b/src/modules.js
@@ -39,10 +39,8 @@ function genArgSequence(n) {
   return args;
 }
 
-var Functions = {
-  // functions added from the library. value 2 means asmLibraryFunction
-  libraryFunctions: {},
-};
+// List of functions that were added from the library.
+var libraryFunctions = [];
 
 var LibraryManager = {
   library: null,
@@ -507,4 +505,3 @@ function exportRuntime() {
   exports = exports.filter(function(name) { return name != '' });
   return exports.join('\n');
 }
-


### PR DESCRIPTION
We can just use a simple list here now, we no longer have anything that uses the `= 2` entries.