### PR TITLE
Remove EXPORTED_FUNCTIONS from jsifier output. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -333,9 +333,6 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
     # In regular runtime, atinits etc. exist in the preamble part
     pre = apply_static_code_hooks(forwarded_json, pre)
 
-  # merge forwarded data
-  settings.EXPORTED_FUNCTIONS = forwarded_json['EXPORTED_FUNCTIONS']
-
   asm_consts = create_asm_consts(metadata)
   em_js_funcs = create_em_js(metadata)
   asm_const_pairs = ['%s: %s' % (key, value) for key, value in asm_consts]
@@ -793,6 +790,7 @@ def load_metadata_wasm(metadata_raw, DEBUG):
   unexpected_exports = [asmjs_mangle(e) for e in unexpected_exports]
   unexpected_exports = [e for e in unexpected_exports if e not in settings.EXPORTED_FUNCTIONS]
   building.user_requested_exports.update(unexpected_exports)
+  settings.EXPORTED_FUNCTIONS.extend(unexpected_exports)
 
   return metadata
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -145,10 +145,8 @@ function JSify(functionsOnly) {
         return '';
       }
 
-      // if the function was implemented in compiled code, we just need to export it so we can reach it from JS
+      // if the function was implemented in compiled code, there is no need to include the js version
       if (ident in WASM_EXPORTS) {
-        EXPORTED_FUNCTIONS[finalName] = 1;
-        // stop here: we don't need to add anything from our js libraries, not even deps, compiled code is on it
         return '';
       }
 
@@ -430,7 +428,6 @@ function JSify(functionsOnly) {
 
     print('\n//FORWARDED_DATA:' + JSON.stringify({
       libraryFunctions: libraryFunctions,
-      EXPORTED_FUNCTIONS: EXPORTED_FUNCTIONS,
       ATINITS: ATINITS.join('\n'),
       ATMAINS: ATMAINS.join('\n'),
       ATEXITS: ATEXITS.join('\n'),


### PR DESCRIPTION
`EXPORTED_FUNCTIONS` is read by jsifier but there is no need to be able
to modify it.  Keeping it as readonly simplifies the logic and avoids
serialization through json.