### PR TITLE
Detect dynamic libraries by contents rather than filename.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -624,7 +624,7 @@ def filter_out_dynamic_libs(options, inputs):
 
   # Filters out "fake" dynamic libraries that are really just intermediate object files.
   def check(input_file):
-    if get_file_suffix(input_file) in DYNAMICLIB_ENDINGS:
+    if get_file_suffix(input_file) in DYNAMICLIB_ENDINGS and not building.is_wasm_dylib(input_file):
       if not options.ignore_dynamic_linking:
         diagnostics.warning('emcc', 'ignoring dynamic library %s because not compiling to JS or HTML, remember to link it when compiling to JS or HTML at the end', os.path.basename(input_file))
       return False
@@ -640,7 +640,7 @@ def filter_out_duplicate_dynamic_libs(inputs):
   # Filter out duplicate "fake" shared libraries (intermediate object files).
   # See test_core.py:test_redundant_link
   def check(input_file):
-    if get_file_suffix(input_file) in DYNAMICLIB_ENDINGS:
+    if get_file_suffix(input_file) in DYNAMICLIB_ENDINGS and not building.is_wasm_dylib(input_file):
       abspath = os.path.abspath(input_file)
       if abspath in seen:
         return False
@@ -1080,7 +1080,7 @@ def phase_calculate_linker_inputs(options, state, linker_inputs):
     linker_inputs = filter_out_duplicate_dynamic_libs(linker_inputs)
 
   if settings.MAIN_MODULE:
-    dylibs = [i[1] for i in linker_inputs if get_file_suffix(i[1]) in DYNAMICLIB_ENDINGS]
+    dylibs = [i[1] for i in linker_inputs if building.is_wasm_dylib(i[1])]
     process_dynamic_libs(dylibs)
 
   linker_arguments = [val for _, val in sorted(linker_inputs + state.link_flags)]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7211,8 +7211,8 @@ int main() {
             print(engine)
             self.assertContained('hello, world!', self.run_js('out.wasm', engine=engine))
 
-  def test_wasm_targets_side_module(self):
-    # side modules do allow a wasm target
+  def test_side_module_naming(self):
+    # SIDE_MODULE should work with any arbirary filename
     for opts, target in [([], 'a.out.wasm'),
                          (['-o', 'lib.wasm'], 'lib.wasm'),
                          (['-o', 'lib.so'], 'lib.so'),
@@ -7220,12 +7220,14 @@ int main() {
       # specified target
       print('building: ' + target)
       self.clear()
-      self.run_process([EMCC, test_file('hello_world.cpp'), '-s', 'SIDE_MODULE', '-Werror'] + opts)
+      self.run_process([EMCC, test_file('hello_world.c'), '-s', 'SIDE_MODULE', '-Werror'] + opts)
       for x in os.listdir('.'):
         self.assertFalse(x.endswith('.js'))
-      self.assertTrue(building.is_wasm(target))
-      wasm_data = open(target, 'rb').read()
-      self.assertEqual(wasm_data.count(b'dylink'), 1)
+      self.assertTrue(building.is_wasm_dylib(target))
+
+      create_file('main.c', '')
+      self.run_process([EMCC, '-s', 'MAIN_MODULE=2', 'main.c', '-Werror', target])
+      self.run_js('a.out.js')
 
   @is_slow_test
   def test_lto(self):

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -40,6 +40,10 @@ EMSCRIPTEN_ABI_MAJOR, EMSCRIPTEN_ABI_MINOR = (0, 29)
 
 WASM_PAGE_SIZE = 65536
 
+MAGIC = b'\0asm'
+
+VERSION = b'\x01\0\0\0'
+
 HEADER_SIZE = 8
 
 LIMITS_HAS_MAX = 0x1
@@ -145,8 +149,8 @@ class Module:
     self.buf = open(filename, 'rb')
     magic = self.buf.read(4)
     version = self.buf.read(4)
-    assert magic == b'\0asm'
-    assert version == b'\x01\0\0\0'
+    assert magic == MAGIC
+    assert version == VERSION
 
   def __del__(self):
     self.buf.close()
@@ -192,10 +196,8 @@ def parse_dylink_section(wasm_file):
 
   dylink_section = next(module.sections())
   assert dylink_section.type == SecType.CUSTOM
-  section_size = dylink_section.size
-  section_offset = dylink_section.offset
-  section_end = section_offset + section_size
-  module.seek(section_offset)
+  section_end = dylink_section.offset + dylink_section.size
+  module.seek(dylink_section.offset)
   # section name
   section_name = module.readString()
   assert section_name == 'dylink'


### PR DESCRIPTION
This change identifies real wasm "dylib" files that do not get linked
into the output but added the "dylink" section.

When we filter out dynamic libraries in filter_out_dynamic_libs what we
are really filtering out is the fake dynamic libraries that are really
just static object files (`-shared` still produces these by default).