### PR TITLE
Revert "Remove unused `hasExportedFunction` helper from  src/parseToo…

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1237,6 +1237,19 @@ function makeAsmImportsAccessInPthread(variable) {
   return variable;
 }
 
+function _asmjsDemangle(symbol) {
+  if (symbol in WASM_SYSTEM_EXPORTS) {
+    return symbol;
+  }
+  // Strip leading "_"
+  assert(symbol.startsWith('_'));
+  return symbol.substr(1);
+}
+
+function hasExportedFunction(func) {
+  return Object.keys(WASM_EXPORTS).includes(_asmjsDemangle(func));
+}
+
 // JS API I64 param handling: if we have BigInt support, the ABI is simple,
 // it is a BigInt. Otherwise, we legalize into pairs of i32s.
 function defineI64Param(name) {
@@ -1289,7 +1302,7 @@ function addReadyPromiseAssertions(promise) {
 }
 
 function makeMalloc(source, param) {
-  if ('malloc' in WASM_EXPORTS) {
+  if (hasExportedFunction('_malloc')) {
     return `_malloc(${param})`;
   }
   // It should be impossible to call some functions without malloc being

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -76,7 +76,7 @@ function initRuntime(asm) {
 #endif
 #endif
 
-#if '__wasm_call_ctors' in WASM_EXPORTS
+#if hasExportedFunction('___wasm_call_ctors')
   asm['__wasm_call_ctors']();
 #endif
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -184,12 +184,12 @@ function cwrap(ident, returnType, argTypes, opts) {
 #if ASSERTIONS
 // We used to include malloc/free by default in the past. Show a helpful error in
 // builds with assertions.
-#if !('malloc' in WASM_EXPORTS)
+#if !hasExportedFunction('_malloc')
 function _malloc() {
   abort("malloc() called but not included in the build - add '_malloc' to EXPORTED_FUNCTIONS");
 }
 #endif // malloc
-#if !('free' in WASM_EXPORTS)
+#if !hasExportedFunction('_free')
 function _free() {
   // Show a helpful error since we used to include free by default in the past.
   abort("free() called but not included in the build - add '_free' to EXPORTED_FUNCTIONS");
@@ -972,7 +972,7 @@ function createWasm() {
 #endif
 #endif
 
-#if '__wasm_call_ctors' in WASM_EXPORTS
+#if hasExportedFunction('___wasm_call_ctors')
     addOnInit(Module['asm']['__wasm_call_ctors']);
 #endif
 


### PR DESCRIPTION
…ls.js. NFC (#14009)"

This reverts commit da26539c7c048b33d1bf67517e8f54c85eb47dec.

Rather than remove `hasExportedFunction`, instead continue to use it in  
our library code.                                                        
                                                                         
This change does still effect the semantics of the function but          
hopefully in a way that makes it more accurate:  Previously we were                                                                   
using `EXPORTED_FUNCTIONS` which is user-supplied list that can include  
both native and JS symbols, and in some cases can contain symbols that   
are not actually defined.  WASM_EXPORTS on the other hand is an explicit
list of native symbols derived directly from the compiled binary.  
