### PR TITLE
Avoid reading from va_arg list when no argument is passed

### DIFF
--- a/system/lib/libc/musl/src/fcntl/fcntl.c
+++ b/system/lib/libc/musl/src/fcntl/fcntl.c
@@ -8,10 +8,15 @@
 int fcntl(int fd, int cmd, ...)
 {
 	unsigned long arg;
-	va_list ap;
-	va_start(ap, cmd);
-	arg = va_arg(ap, unsigned long);
-	va_end(ap);
+	// XXX Emscripten: According to the va_arg man page it is undefined behaviour to
+	// read arguments that are not passed.  This can lead to a false positive
+	// in SAFE_HEAP, so avoid it.
+	if (cmd != F_GETFL && cmd != F_GETFD && cmd != F_GETOWN) {
+		va_list ap;
+		va_start(ap, cmd);
+		arg = va_arg(ap, unsigned long);
+		va_end(ap);
+	}
 	if (cmd == F_SETFL) arg |= O_LARGEFILE;
 	if (cmd == F_SETLKW) return syscall_cp(SYS_fcntl, fd, cmd, (void *)arg);
 	if (cmd == F_GETOWN) {
@@ -25,8 +30,7 @@ int fcntl(int fd, int cmd, ...)
 		int ret = __syscall(SYS_fcntl, fd, F_DUPFD_CLOEXEC, arg);
 		if (ret != -EINVAL) {
 #ifndef __EMSCRIPTEN__ // CLOEXEC makes no sense for a single process
-			if (ret >= 0)
-				__syscall(SYS_fcntl, ret, F_SETFD, FD_CLOEXEC);
+			if (ret >= 0) __syscall(SYS_fcntl, ret, F_SETFD, FD_CLOEXEC);
 #endif
 			return __syscall_ret(ret);
 		}

--- a/tests/fcntl/test_fcntl.c
+++ b/tests/fcntl/test_fcntl.c
@@ -34,7 +34,7 @@ int main() {
   printf("\n");
   errno = 0;
 
-  printf("F_SETFD: %d\n", fcntl(f, F_SETFD));
+  printf("F_SETFD: %d\n", fcntl(f, F_SETFD, -1));
   printf("errno: %d\n", errno);
   printf("\n");
   errno = 0;
@@ -82,7 +82,7 @@ int main() {
   printf("\n");
   errno = 0;
 
-  printf("INVALID: %d\n", fcntl(f, 123));
+  printf("INVALID: %d\n", fcntl(f, 123, -1));
   printf("errno: %d\n", errno);
 
   return 0;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5093,7 +5093,6 @@ main( int argv, char ** argc ) {
   def test_stat_mknod(self):
     self.do_runf(test_file('stat', 'test_mknod.c'), 'success')
 
-  @no_safe_heap('https://github.com/emscripten-core/emscripten/issues/12433')
   def test_fcntl(self):
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
     self.do_run_in_out_file_test('fcntl', 'test_fcntl.c')


### PR DESCRIPTION
See https://github.com/emscripten-core/emscripten/issues/14020

Fixes: #12433