### PR TITLE
[Asyncify] Assert on async operations not being done during or after shutdown.

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -84,6 +84,11 @@ mergeInto(LibraryManager.library, {
         })(x);
       }
     },
+
+    checkStateAfterExitRuntime: function() {
+      assert(Asyncify.state === Asyncify.State.None,
+            'Asyncify cannot be done during or after the runtime exits');
+    },
 #endif
 
     instrumentWasmExports: function(exports) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -422,6 +422,9 @@ function exitRuntime() {
   PThread.runExitHandlers();
 #endif
 #endif
+#if ASYNCIFY && ASSERTIONS
+  Asyncify.checkStateAfterExitRuntime();
+#endif
   runtimeExited = true;
 }
 

--- a/tests/core/asyncify_during_exit.cpp
+++ b/tests/core/asyncify_during_exit.cpp
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <emscripten.h>
+
+void during_exit() {
+  // An attempt to sleep during exit, which is not allowed (the exit process is
+  // done in synchronous JS).
+  EM_ASM({ out("during_exit 1") });
+  emscripten_sleep(100);
+  EM_ASM({ out("during_exit 2") });
+}
+
+int main() {
+  atexit(&during_exit);
+}

--- a/tests/core/asyncify_during_exit.out
+++ b/tests/core/asyncify_during_exit.out
@@ -1,0 +1,2 @@
+during_exit 1
+Assertion failed: Asyncify cannot be done during or after the runtime exits

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7510,6 +7510,12 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('ASSERTIONS')
     self.do_core_test('asyncify_assertions.cpp')
 
+  def test_asyncify_during_exit(self):
+    self.set_setting('ASYNCIFY')
+    self.set_setting('ASSERTIONS')
+    self.set_setting('EXIT_RUNTIME', 1)
+    self.do_core_test('asyncify_during_exit.cpp', assert_returncode=1)
+
   @no_asan('asyncify stack operations confuse asan')
   @no_wasm2js('TODO: lazy loading in wasm2js')
   @parameterized({


### PR DESCRIPTION
See #13993 - such operations are not allowed because the shutdown code is in
JS, which is synchronous. It would need to be moved to compiled code (where
Asyncify can instrument it) or to be rewritten to be async.
