### PR TITLE
[Wasm2C] Support multiple libraries by using wasm2c prefixing

### DIFF
--- a/tests/other/wasm2c/my-code-multi.c
+++ b/tests/other/wasm2c/my-code-multi.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+
+extern void a_wasmbox_init(void);
+extern void b_wasmbox_init(void);
+
+extern int (*a_Z_twiceZ_ii)(int);
+extern int (*b_Z_thriceZ_ii)(int);
+
+int main() {
+  puts("Initializing sandboxed unsafe libraries");
+  a_wasmbox_init();
+  b_wasmbox_init();
+  printf("Calling twice on 21 returns %d\n", a_Z_twiceZ_ii(21));
+  printf("Calling thrice on 10 returns %d\n", b_Z_thriceZ_ii(10));
+}

--- a/tests/other/wasm2c/my-code-multi.c
+++ b/tests/other/wasm2c/my-code-multi.c
@@ -1,5 +1,7 @@
 #include <stdio.h>
 
+// Note the prefixing (a_, b_) on all functions from the two libraries.
+
 extern void a_wasmbox_init(void);
 extern void b_wasmbox_init(void);
 

--- a/tests/other/wasm2c/output-multi.txt
+++ b/tests/other/wasm2c/output-multi.txt
@@ -1,0 +1,3 @@
+Initializing sandboxed unsafe libraries
+Calling twice on 21 returns 42
+Calling thrice on 10 returns 30

--- a/tests/other/wasm2c/unsafe-library-a.c
+++ b/tests/other/wasm2c/unsafe-library-a.c
@@ -1,0 +1,6 @@
+#include <emscripten.h>
+
+EMSCRIPTEN_KEEPALIVE
+int twice(int x) {
+  return x + x;
+}

--- a/tests/other/wasm2c/unsafe-library-b.c
+++ b/tests/other/wasm2c/unsafe-library-b.c
@@ -1,0 +1,6 @@
+#include <emscripten.h>
+
+EMSCRIPTEN_KEEPALIVE
+int thrice(int x) {
+  return x + x + x;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9632,6 +9632,8 @@ int main() {
       self.run_process([EMCC,
                         test_file('other', 'wasm2c', f'unsafe-library-{lib}.c'),
                         '-O3', '-o', f'lib{lib}.wasm', '-s', 'WASM2C', '--no-entry'])
+      # build with a different WASM_RT_MODULE_PREFIX for each library, so that
+      # they do not have colliding symbols
       self.run_process([CLANG_CC, f'lib{lib}.wasm.c', '-O3', '-c',
                         f'-DWASM_RT_MODULE_PREFIX={lib}_'] +
                        clang_native.get_clang_native_args(),

--- a/tools/wasm2c.py
+++ b/tools/wasm2c.py
@@ -47,9 +47,9 @@ def get_func_types(code):
     We look for this pattern:
 
     static void init_func_types(void) {
-      func_types[0] = WASM_RT_ADD_PREFIX(wasm_rt_register_func_type)(3, 1, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32);
-      func_types[1] = WASM_RT_ADD_PREFIX(wasm_rt_register_func_type)(1, 1, WASM_RT_I32, WASM_RT_I32);
-      func_types[2] = WASM_RT_ADD_PREFIX(wasm_rt_register_func_type)(0, 0);
+      func_types[0] = wasm_rt_register_func_type(3, 1, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32);
+      func_types[1] = wasm_rt_register_func_type(1, 1, WASM_RT_I32, WASM_RT_I32);
+      func_types[2] = wasm_rt_register_func_type(0, 0);
     }
 
     We return a map of signatures names to their index.
@@ -58,7 +58,7 @@ def get_func_types(code):
   if not init_func_types:
     return {}
   ret = {}
-  for entry in re.findall(r'func_types\[(\d+)\] = WASM_RT_ADD_PREFIX(wasm_rt_register_func_type)\((\d+), (\d+),? ?([^)]+)?\);', init_func_types[0]):
+  for entry in re.findall(r'func_types\[(\d+)\] = wasm_rt_register_func_type\((\d+), (\d+),? ?([^)]+)?\);', init_func_types[0]):
     index, params, results, types = entry
     index = int(index)
     params = int(params)
@@ -155,7 +155,7 @@ extern void wasmbox_init(void);
     type_index = all_func_types[sig]
 
     invokes.append(r'''
-IMPORT_IMPL(%(return_type)s, WASM_RT_ADD_PREFIX(Z_envZ_invoke_%(sig)sZ_%(wabt_sig)s), (%(full_typed_args)s), {
+IMPORT_IMPL(%(return_type)s, Z_envZ_invoke_%(sig)sZ_%(wabt_sig)s, (%(full_typed_args)s), {
   VERBOSE_LOG("invoke\n"); // waka
   u32 sp = WASM_RT_ADD_PREFIX(Z_stackSaveZ_iv)();
   if (next_setjmp >= MAX_SETJMP_STACK) {

--- a/tools/wasm2c.py
+++ b/tools/wasm2c.py
@@ -47,9 +47,9 @@ def get_func_types(code):
     We look for this pattern:
 
     static void init_func_types(void) {
-      func_types[0] = wasm_rt_register_func_type(3, 1, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32);
-      func_types[1] = wasm_rt_register_func_type(1, 1, WASM_RT_I32, WASM_RT_I32);
-      func_types[2] = wasm_rt_register_func_type(0, 0);
+      func_types[0] = WASM_RT_ADD_PREFIX(wasm_rt_register_func_type)(3, 1, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32, WASM_RT_I32);
+      func_types[1] = WASM_RT_ADD_PREFIX(wasm_rt_register_func_type)(1, 1, WASM_RT_I32, WASM_RT_I32);
+      func_types[2] = WASM_RT_ADD_PREFIX(wasm_rt_register_func_type)(0, 0);
     }
 
     We return a map of signatures names to their index.
@@ -58,7 +58,7 @@ def get_func_types(code):
   if not init_func_types:
     return {}
   ret = {}
-  for entry in re.findall(r'func_types\[(\d+)\] = wasm_rt_register_func_type\((\d+), (\d+),? ?([^)]+)?\);', init_func_types[0]):
+  for entry in re.findall(r'func_types\[(\d+)\] = WASM_RT_ADD_PREFIX(wasm_rt_register_func_type)\((\d+), (\d+),? ?([^)]+)?\);', init_func_types[0]):
     index, params, results, types = entry
     index = int(index)
     params = int(params)
@@ -155,9 +155,9 @@ extern void wasmbox_init(void);
     type_index = all_func_types[sig]
 
     invokes.append(r'''
-IMPORT_IMPL(%(return_type)s, Z_envZ_invoke_%(sig)sZ_%(wabt_sig)s, (%(full_typed_args)s), {
+IMPORT_IMPL(%(return_type)s, WASM_RT_ADD_PREFIX(Z_envZ_invoke_%(sig)sZ_%(wabt_sig)s), (%(full_typed_args)s), {
   VERBOSE_LOG("invoke\n"); // waka
-  u32 sp = Z_stackSaveZ_iv();
+  u32 sp = WASM_RT_ADD_PREFIX(Z_stackSaveZ_iv)();
   if (next_setjmp >= MAX_SETJMP_STACK) {
     abort_with_message("too many nested setjmps");
   }
@@ -169,8 +169,8 @@ IMPORT_IMPL(%(return_type)s, Z_envZ_invoke_%(sig)sZ_%(wabt_sig)s, (%(full_typed_
     /* if we got here, no longjmp or exception happened, we returned normally */
   } else {
     /* A longjmp or an exception took us here. */
-    Z_stackRestoreZ_vi(sp);
-    Z_setThrewZ_vii(1, 0);
+    WASM_RT_ADD_PREFIX(Z_stackRestoreZ_vi)(sp);
+    WASM_RT_ADD_PREFIX(Z_setThrewZ_vii)(1, 0);
   }
   next_setjmp--;
   %(return)s
@@ -206,6 +206,29 @@ IMPORT_IMPL(%(return_type)s, Z_envZ_invoke_%(sig)sZ_%(wabt_sig)s, (%(full_typed_
     total = total.replace(MEM_ACCESS, '[addr & %d]' % (settings.INITIAL_MEMORY - 1))
   else:
     exit_with_error('bad sandboxing')
+
+  # adjust prefixing: emit simple output that works with multiple libraries,
+  # each compiled into its own single .c file, by adding 'static' in some places
+  # TODO: decide on the proper pattern for this in an upstream discussion in
+  #       wasm2c; another option would be to prefix all these things.
+  for rep in [
+    'uint32_t wasm_rt_register_func_type(',
+    'void wasm_rt_trap(',
+    'void wasm_rt_allocate_memory(',
+    'uint32_t wasm_rt_grow_memory(',
+    'void wasm_rt_allocate_table(',
+    'jmp_buf g_jmp_buf',
+    'uint32_t g_func_type_count',
+    'FuncType* g_func_types',
+    'uint32_t wasm_rt_call_stack_depth',
+    'uint32_t g_saved_call_stack_depth',
+  ]:
+    # remove 'extern' from declaration
+    total = total.replace('extern ' + rep, rep)
+    # add 'static' to implementation
+    old = total
+    total = total.replace(rep, 'static ' + rep)
+    assert old != total, f'did not find "{rep}"'
 
   # write out the final file
   with open(c_file, 'w') as out:

--- a/tools/wasm2c/base.c
+++ b/tools/wasm2c/base.c
@@ -34,11 +34,11 @@ typedef signed long ssize_t;
 
 #define TRAP(x) (wasm_rt_trap(WASM_RT_TRAP_##x), 0)
 
-#define MEMACCESS(addr) ((void*)&Z_memory->data[addr])
+#define MEMACCESS(addr) ((void*)&WASM_RT_ADD_PREFIX(Z_memory)->data[addr])
 
 #undef MEMCHECK
 #define MEMCHECK(a, t)  \
-  if (UNLIKELY((a) + sizeof(t) > Z_memory->size)) TRAP(OOB)
+  if (UNLIKELY((a) + sizeof(t) > WASM_RT_ADD_PREFIX(Z_memory)->size)) TRAP(OOB)
 
 #undef DEFINE_LOAD
 #define DEFINE_LOAD(name, t1, t2, t3)              \
@@ -94,7 +94,7 @@ static ret _##name params { \
   VERBOSE_LOG("[import: " #name "]\n"); \
   body \
 } \
-ret (*name) params = _##name;
+ret (*WASM_RT_ADD_PREFIX(name)) params = _##name;
 
 #define STUB_IMPORT_IMPL(ret, name, params, returncode) IMPORT_IMPL(ret, name, params, { return returncode; });
 
@@ -127,7 +127,7 @@ IMPORT_IMPL(void, Z_envZ_emscripten_longjmpZ_vii, (u32 buf, u32 value), {
   if (next_setjmp == 0) {
     abort_with_message("longjmp without setjmp");
   }
-  Z_setThrewZ_vii(buf, value ? value : 1);
+  WASM_RT_ADD_PREFIX(Z_setThrewZ_vii)(buf, value ? value : 1);
   longjmp(setjmp_stack[next_setjmp - 1], 1);
 });
 

--- a/tools/wasm2c/main.c
+++ b/tools/wasm2c/main.c
@@ -36,7 +36,7 @@ int main(int argc, char** argv) {
     printf("[wasm trap %d, halting]\n", trap_code);
     return 1;
   } else {
-    Z__startZ_vv();
+    WASM_RT_ADD_PREFIX(Z__startZ_vv)();
   }
   return 0;
 }

--- a/tools/wasm2c/reactor.c
+++ b/tools/wasm2c/reactor.c
@@ -1,7 +1,7 @@
 // TODO: optional prefixing
-void wasmbox_init(void) {
+void WASM_RT_ADD_PREFIX(wasmbox_init)(void) {
   // Initialize wasm2c runtime.
-  init();
+  WASM_RT_ADD_PREFIX(init)();
 
   // Set up handling for a trap
   int trap_code;
@@ -9,6 +9,6 @@ void wasmbox_init(void) {
     printf("[wasm trap %d, halting]\n", trap_code);
     abort();
   } else {
-    Z__initializeZ_vv();
+    WASM_RT_ADD_PREFIX(Z__initializeZ_vv)();
   }
 }


### PR DESCRIPTION
wasm2c has a `WASM_RT_ADD_PREFIX` define that it looks for, and if
present it prefixes all exports etc. with it. That allows linking in multiple wasm2c
outputs into a single program. This PR uses the prefix in the additional support
code that we add, and includes a full test of linking in two prefixed libraries.

This basically works by compiling one library with prefix `foo_` and another
with `bar_`, and then you can initialize one with `foo_init()`, call its exports
using `foo_EXPORT_NAME()` etc. etc.

This is mostly straightforward except for `wasm_rt_register_func_type` etc.
which wasm2c currently emits as `extern` - suggesting that the "runtime"
be shared among such linked libraries. That seems dangerous to me. For
now, get things to work by converting those to be `static` instead. That way
we have 100% modularity, but that is something we may want to discuss
at the wabt level.
