### PR TITLE
Always write UTF-8 response files on windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -469,7 +469,7 @@ jobs:
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - run-tests:
-          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths"
+          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file"
   test-mac:
     executor: mac
     steps:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7464,6 +7464,11 @@ end
     create_file('file1', ' ')
     self.run_process([EMAR, 'cr', 'file1.a', 'file1', 'file1'])
 
+  # It seems our response file parsing, which is currently just shlex.split(), is
+  # not up to the task on windows. This wasn't a problem that became apparent until
+  # after https://github.com/emscripten-core/emscripten/pull/13954 which
+  # broke this test because we starting parsing incoming response files in emar.py.
+  @no_windows('https://github.com/emscripten-core/emscripten/pull/13954')
   def test_emar_response_file(self):
     # Test that special character such as single quotes in filenames survive being
     # sent via response file

--- a/tools/response_file.py
+++ b/tools/response_file.py
@@ -40,8 +40,21 @@ def create_response_file(args, directory):
     if ' ' in arg:
       arg = '"%s"' % arg
     contents += arg + '\n'
-  with os.fdopen(response_fd, 'w') as f:
+
+  # When writing windows repsonse files force the encoding to UTF8 which we know
+  # that llvm tools understand.  Without this, we get whatever the default codepage
+  # might be.
+  # See: https://github.com/llvm/llvm-project/blob/3f3d1c901d7abcc5b91468335679b1b27d8a02dd/llvm/include/llvm/Support/Program.h#L168-L170
+  # And: https://github.com/llvm/llvm-project/blob/63d16d06f5b8f71382033b5ea4aa668f8150817a/clang/include/clang/Driver/Job.h#L58-L69
+  # TODO(sbc): Should we also force utf-8 on non-windows?
+  if WINDOWS:
+    encoding = 'utf-8'
+  else:
+    encoding = None
+
+  with os.fdopen(response_fd, 'w', encoding=encoding) as f:
     f.write(contents)
+
   if DEBUG:
     logging.warning('Creating response file ' + response_filename + ' with following contents: ' + contents)
 


### PR DESCRIPTION
llvm tools apparently all support this and also write UTF8 response         
files themselves.             
                                                                                                                    
See clang/include/clang/Driver/Job.h:                                    
                                                                         
```                                                                      
  /// Windows use cases: - GCC and Binutils on mingw only accept ANSI response
  /// files encoded with the system current code page.                   
  /// - MSVC's CL.exe and LINK.exe accept UTF16 on Windows.              
  /// - Clang accepts both UTF8 and UTF16.                               
```

This change is needed in order to enabled  `test_emar_response_file` on
github CI.

However we cannot actually run `test_emar_response_file` right now because
it was broken by #13954 so this change also temporarily disables that test.
I verified that if rebased on top of a revert of #13954 the CI is is green for
this PR.