### PR TITLE
Skip LSan for dylink tests

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -396,7 +396,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if not self.is_wasm():
       self.skipTest('no dynamic linking support in wasm2js yet')
     if '-fsanitize=address' in self.emcc_args:
-      self.skipTest('no dynamic linking support in asan yet')
+      self.skipTest('no dynamic linking support in ASan yet')
+    if '-fsanitize=leak' in self.emcc_args:
+      self.skipTest('no dynamic linking support in LSan yet')
 
   def uses_memory_init_file(self):
     if self.get_setting('SIDE_MODULE') or (self.is_wasm() and not self.get_setting('WASM2JS')):


### PR DESCRIPTION
It [looks](https://github.com/emscripten-core/emscripten/blob/f2c2432c43e2392473582e31484232bea047b324/emcc.py#L2037-L2038) LSan does not currently support dynamic linking, but
`check_dylink` only skips tests for ASan. This makes tests skipped for
LSan too.