### PR TITLE
Reinstate --cache flag in its original form

### DIFF
--- a/emar.py
+++ b/emar.py
@@ -11,14 +11,15 @@ This script acts as a frontend replacement for `llvm-ar`.
 
 import sys
 
-from tools import shared, building
+from tools import shared
 
 
 #
 # Main run() function
 #
 def run():
-  return shared.run_process([shared.LLVM_AR] + building.get_command_with_possible_response_file(sys.argv[1:]), stdin=sys.stdin, check=False).returncode
+  cmd = [shared.LLVM_AR] + sys.argv[1:]
+  return shared.run_process(cmd, stdin=sys.stdin, check=False).returncode
 
 
 if __name__ == '__main__':

--- a/emcc.py
+++ b/emcc.py
@@ -46,6 +46,7 @@ from tools import colored_logger, diagnostics, building
 from tools.shared import unsuffixed, unsuffixed_basename, WINDOWS, safe_copy
 from tools.shared import run_process, read_and_preprocess, exit_with_error, DEBUG
 from tools.shared import do_replace
+from tools.response_file import substitute_response_files
 from tools.minimal_runtime_shell import generate_minimal_runtime_html
 import tools.line_endings
 from tools import js_manipulation
@@ -925,6 +926,12 @@ def run(args):
   misc_temp_files = shared.configuration.get_temp_files()
 
   # Handle some global flags
+
+  # read response files very early on
+  try:
+    args = substitute_response_files(args)
+  except IOError as e:
+    exit_with_error(e)
 
   if '--help' in args:
     # Documentation for emcc and its options must be updated in:
@@ -2757,6 +2764,9 @@ def parse_args(newargs):
       diagnostics.warning('legacy-settings', '--remove-duplicates is deprecated as it is no longer needed. If you cannot link without it, file a bug with a testcase')
     elif check_flag('--jcache'):
       logger.error('jcache is no longer supported')
+    elif check_arg('--cache'):
+      config.CACHE = os.path.normpath(consume_arg())
+      shared.reconfigure_cache()
     elif check_flag('--clear-cache'):
       logger.info('clearing cache as requested by --clear-cache')
       shared.Cache.erase()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7464,11 +7464,6 @@ end
     create_file('file1', ' ')
     self.run_process([EMAR, 'cr', 'file1.a', 'file1', 'file1'])
 
-  # It seems our response file parsing, which is currently just shlex.split(), is
-  # not up to the task on windows. This wasn't a problem that became apparent until
-  # after https://github.com/emscripten-core/emscripten/pull/13954 which
-  # broke this test because we starting parsing incoming response files in emar.py.
-  @no_windows('https://github.com/emscripten-core/emscripten/pull/13954')
   def test_emar_response_file(self):
     # Test that special character such as single quotes in filenames survive being
     # sent via response file

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -521,11 +521,7 @@ fi
     # The cache directory must contain a sysroot
     self.assertTrue(os.path.exists(os.path.join(cache_dir_name, 'sysroot')))
 
-  @parameterized({
-    '': [False],
-    'response_files': [True]
-  })
-  def test_emconfig(self, use_response_files):
+  def test_emconfig(self):
     restore_and_set_up()
 
     fd, custom_config_filename = tempfile.mkstemp(prefix='.emscripten_config_')
@@ -541,17 +537,9 @@ fi
 
     temp_dir = tempfile.mkdtemp(prefix='emscripten_temp_')
 
-    args = ['--em-config', custom_config_filename]
-    if use_response_files:
-      rsp = response_file.create_response_file(args, shared.TEMP_DIR)
-      args = ['@' + rsp]
-
     with utils.chdir(temp_dir):
-      self.run_process([EMCC] + args + MINIMAL_HELLO_WORLD + ['-O2'])
+      self.run_process([EMCC, '--em-config', custom_config_filename] + MINIMAL_HELLO_WORLD + ['-O2'])
       result = self.run_js('a.out.js')
-
-    if use_response_files:
-      os.remove(rsp)
 
     self.assertContained('hello, world!', result)
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -7,7 +7,6 @@ import os
 import sys
 import logging
 from .utils import path_from_root, exit_with_error, __rootpath__, which
-from .response_file import substitute_response_files
 
 logger = logging.getLogger('shared')
 
@@ -240,46 +239,26 @@ emsdk_root = os.path.dirname(os.path.dirname(path_from_root()))
 emsdk_embedded_config = os.path.join(emsdk_root, '.emscripten')
 user_home_config = os.path.expanduser('~/.emscripten')
 
-# read response files very early on so that all subsequent code that accesses
-# sys.argv will see the expanded content.
-try:
-  sys.argv = substitute_response_files(sys.argv)
-except IOError as e:
-  exit_with_error(e)
-
-
-def consume_argv(name):
-  value = None
-  while name in sys.argv:
-    i = sys.argv.index(name)
-    if len(sys.argv) <= i + 1:
-      exit_with_error(name + ' must be followed by a filename')
-    value = sys.argv.pop(i + 1)
-    del sys.argv[i]
-  return value
-
-
-EM_CONFIG = consume_argv('--em-config')
-if not EM_CONFIG:
-  if 'EM_CONFIG' in os.environ:
-    EM_CONFIG = os.environ['EM_CONFIG']
-  elif os.path.exists(embedded_config):
-    EM_CONFIG = embedded_config
-  elif os.path.exists(emsdk_embedded_config):
-    EM_CONFIG = emsdk_embedded_config
-  elif os.path.exists(user_home_config):
-    EM_CONFIG = user_home_config
+if '--em-config' in sys.argv:
+  i = sys.argv.index('--em-config')
+  if len(sys.argv) <= i + 1:
+    exit_with_error('--em-config must be followed by a filename')
+  EM_CONFIG = sys.argv.pop(i + 1)
+  del sys.argv[i]
+elif 'EM_CONFIG' in os.environ:
+  EM_CONFIG = os.environ['EM_CONFIG']
+elif os.path.exists(embedded_config):
+  EM_CONFIG = embedded_config
+elif os.path.exists(emsdk_embedded_config):
+  EM_CONFIG = emsdk_embedded_config
+elif os.path.exists(user_home_config):
+  EM_CONFIG = user_home_config
+else:
+  if root_is_writable():
+    generate_config(embedded_config, first_time=True)
   else:
-    if root_is_writable():
-      generate_config(embedded_config, first_time=True)
-    else:
-      generate_config(user_home_config, first_time=True)
-    sys.exit(0)
-
-argv_cache = consume_argv('--cache')
-if argv_cache:
-  CACHE = os.path.abspath(os.path.expanduser(argv_cache))
-  os.environ['EM_CACHE'] = CACHE
+    generate_config(user_home_config, first_time=True)
+  sys.exit(0)
 
 # We used to support inline EM_CONFIG.
 if '\n' in EM_CONFIG:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -592,6 +592,11 @@ def asmjs_mangle(name):
     return name
 
 
+def reconfigure_cache():
+  global Cache
+  Cache = cache.Cache(config.CACHE)
+
+
 class JS:
   emscripten_license = '''\
 /**


### PR DESCRIPTION
This change reverts #13954 and reinstates the `--cache`
flag much as it existed prior to its removal in #11094.
Essentially this change reverts both of those changes.

This also allows us to re-enable the `test_emar_response_file`
test for windows.

We can look at landing more ubiquitous and robust response
file processing that #13954 was aiming at as followup.