### PR TITLE
Deprecate EMMAKEN_NO_SDK

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -604,8 +604,6 @@ Environment variables
 
    * "EMMAKEN_JUST_CONFIGURE" [other]
 
-   * "EMMAKEN_NO_SDK" [compile+link]
-
    * "EMCC_AUTODEBUG" [compile+link]
 
    * "EMCC_CFLAGS" [compile+link]

--- a/emcc.py
+++ b/emcc.py
@@ -18,9 +18,6 @@ emcc can be influenced by a few environment variables:
                (by default /tmp/emscripten_temp). "2" will save additional emcc-*
                steps, that would normally not be separately produced (so this
                slows down compilation).
-
-  EMMAKEN_NO_SDK - Will tell emcc *not* to use the emscripten headers. Instead
-                   your system headers will be used.
 """
 
 from tools.toolchain_profiler import ToolchainProfiler
@@ -710,9 +707,6 @@ def parse_s_args(args):
 
 
 def emsdk_ldflags(user_args):
-  if os.environ.get('EMMAKEN_NO_SDK'):
-    return []
-
   library_paths = [
      shared.Cache.get_lib_dir(absolute=True)
   ]
@@ -843,9 +837,6 @@ def get_cflags(options, user_args):
   cflags += ['-Werror=implicit-function-declaration']
 
   system_libs.add_ports_cflags(cflags, settings)
-
-  if os.environ.get('EMMAKEN_NO_SDK') or '-nostdinc' in user_args:
-    return cflags
 
   cflags += emsdk_cflags(user_args)
   return cflags
@@ -1003,6 +994,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   EMMAKEN_CFLAGS = os.environ.get('EMMAKEN_CFLAGS')
   if EMMAKEN_CFLAGS:
     args += shlex.split(EMMAKEN_CFLAGS)
+
+  if 'EMMAKEN_NO_SDK' in os.environ:
+    args.append('-nostdlib')
+    args.append('-nostdinc')
+    diagnostics.warning('deprecated', 'EMMAKEN_NO_SDK is deprecated.  Please use the standard `-nostdinc` and/or `-nostdlib` options')
 
   # ---------------- End configs -------------
   state = EmccState(args)

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -517,7 +517,6 @@ Environment variables
   - ``EMMAKEN_CFLAGS`` [compile+link]
   - ``EMMAKEN_COMPILER`` [compile+link] Deprecated. Avoid using.
   - ``EMMAKEN_JUST_CONFIGURE`` [other]
-  - ``EMMAKEN_NO_SDK`` [compile+link]
   - ``EMCC_AUTODEBUG`` [compile+link]
   - ``EMCC_CFLAGS`` [compile+link]
   - ``EMCC_CORES`` [general]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7578,10 +7578,9 @@ end
     self.run_process([EMCC, test, '--closure=1', '--closure-args', '--externs "' + externs + '"'])
 
   def test_toolchain_profiler(self):
-    environ = os.environ.copy()
-    environ['EMPROFILE'] = '1'
-    # replaced subprocess functions should not cause errors
-    self.run_process([EMCC, test_file('hello_world.c')], env=environ)
+    with env_modify({'EMPROFILE': '1'}):
+      # replaced subprocess functions should not cause errors
+      self.run_process([EMCC, test_file('hello_world.c')])
 
   def test_noderawfs(self):
     fopen_write = open(test_file('asmfs', 'fopen_write.cpp')).read()
@@ -10377,3 +10376,9 @@ exec "$@"
     # negative case: foo is undefined in test_check_undefined.c
     err = self.expect_fail([EMCC, flag, '-sERROR_ON_UNDEFINED_SYMBOLS', test_file('other', 'test_check_undefined.c')])
     self.assertContained('undefined symbol: foo', err)
+
+  def test_EMMAKEN_NO_SDK(self):
+    with env_modify({'EMMAKEN_NO_SDK': '1'}):
+      err = self.expect_fail([EMCC, test_file('hello_world.c')])
+      self.assertContained("warning: EMMAKEN_NO_SDK is deprecated", err)
+      self.assertContained("fatal error: 'stdio.h' file not found", err)


### PR DESCRIPTION
This change deprecates EMMAKEN_NO_SDK but also adds a test
to verify its behavior oar.

The previous behavior of `EMMAKEN_NO_SDK` is emulated by setting
`-nostdinc` and `-nostdlib`.