### PR TITLE
Update list of supported extensions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -561,3 +561,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Radek Doulik <radek.doulik@gmail.com> (copyright owned by Microsoft, Inc.)
 * Érico Porto <ericoporto2008@gmail.com>
 * Albert Vaca Cintora <albertvaka@gmail.com>
+* Zhi An Ng <zhin@google.com> (copyright owned by Google, Inc.)

--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -92,7 +92,7 @@ Compiling SIMD code targeting x86 SSE instruction set
 
 Emscripten supports compiling existing codebases that use x86 SSE by passing the `-msse` directive to the compiler, and including the header `<xmmintrin.h>`.
 
-Currently only the SSE1 and SSE2 instruction sets are supported.
+Currently only the SSE1, SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, and 128-bit AVX instruction sets are supported.
 
 The following table highlights the availability and expected performance of different SSE1 intrinsics. Even if you are directly targeting the native Wasm SIMD opcodes via wasm_simd128.h header, this table can be useful for understanding the performance limitations that the Wasm SIMD specification has when running on x86 hardware.
 


### PR DESCRIPTION
SSE3 and SSSE3 added in 17960af5ea7c0ff1ef82eb1a9a4d46d3eda29233.
SSE4.1, SSE4.2, and 128-bit AVX added in
968c7a557dcb7b8e332e5b990bc600ea417c4602.