### PR TITLE
minimal CMake how-to added to Building Projects

### DIFF
--- a/site/source/docs/compiling/Building-Projects.rst
+++ b/site/source/docs/compiling/Building-Projects.rst
@@ -73,6 +73,28 @@ WebAssembly.
   not the native system compiler. If *emcc* is not used, you may need to modify
   the configure or cmake scripts.
 
+.. _building-projects-with-cmake:
+
+Using CMake with Emscripten
+==================================
+
+If you have not already, first, you have to install and activate the SDK tag you wish to use, and after, you must add the environment variables in your terminal.
+
+.. code-block:: bash
+
+  ./emsdk install latest  # Download and install the latest SDK. You probably already did this!
+  ./emsdk activate latest # Make the "latest" SDK "active" for the current user
+  source ./emsdk_env.sh   # Activate PATH and other environment variables in the existing terminal
+  
+After activating the environment variables, you will have the `emcmake` utility available on the terminal. You always should use `emcmake` before any CMake invocation. It will pass to CMake the correct toolchain for building your projects.  
+
+.. code-block:: bash
+
+  mkdir build && cd build
+  emcmake cmake ..
+  make
+
+Do not use `emmake` before `make` with CMake generated makefiles.
 
 .. _building-projects-build-outputs:
 

--- a/site/source/docs/compiling/Building-Projects.rst
+++ b/site/source/docs/compiling/Building-Projects.rst
@@ -78,15 +78,11 @@ WebAssembly.
 Using CMake with Emscripten
 ==================================
 
-If you have not already, first, you have to install and activate the SDK tag you wish to use, and after, you must add the environment variables in your terminal.
+If you have not already, first, you have to install and activate the SDK tag you wish to use. 
+Make sure emcc and other tools are in your PATH already (e.g. using ``source ./emsdk_env.sh``).
 
-.. code-block:: bash
-
-  ./emsdk install latest  # Download and install the latest SDK. You probably already did this!
-  ./emsdk activate latest # Make the "latest" SDK "active" for the current user
-  source ./emsdk_env.sh   # Activate PATH and other environment variables in the existing terminal
-  
-After activating the environment variables, you will have the `emcmake` utility available on the terminal. You always should use `emcmake` before any CMake invocation. It will pass to CMake the correct toolchain for building your projects.  
+Once you have the ``emcmake`` utility available on your terminal, use it before any CMake invocation. 
+It will pass to CMake the correct toolchain for building your projects.  
 
 .. code-block:: bash
 
@@ -94,7 +90,7 @@ After activating the environment variables, you will have the `emcmake` utility 
   emcmake cmake ..
   make
 
-Do not use `emmake` before `make` with CMake generated makefiles.
+There is no need to use ``emmake`` on a makefile generated from cmake.
 
 .. _building-projects-build-outputs:
 


### PR DESCRIPTION
wrote a very minimal CMake how to build. Chose to not mention any of the internals that goes into the CMakeLists.txt when they tailored for Emscripten - I imagine these may be changed fairly frequently?

I also added a bit on the emsdk, the important bit being the `source ./emsdk_env.sh` which is not mentioned anywhere on this page and instead the whole page uses a weird assumption that you have the tools copied locally in your project - like, how else would I invoke `./emcmake` instead of just `emcmake`? Also the activation sets the ` CMAKE_TOOLCHAIN_FILE` which is very important.