### PR TITLE
Fix a couple of spelling errors. NFC.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1808,7 +1808,7 @@ def phase_setup(state):
     ]
     # Some of these symbols are using by worker.js but otherwise unreferenced.
     # Because emitDCEGraph only considered the main js file, and not worker.js
-    # we have explictly mark these symbols as user-exported so that they will
+    # we have explicitly mark these symbols as user-exported so that they will
     # kept alive through DCE.
     # TODO: Find a less hacky way to do this, perhaps by also scanning worker.js
     # for roots.
@@ -2798,7 +2798,7 @@ def parse_args(newargs):
       if os.path.isabs(path_name) and not is_valid_abspath(options, path_name):
         # Of course an absolute path to a non-system-specific library or header
         # is fine, and you can ignore this warning. The danger are system headers
-        # that are e.g. x86 specific and nonportable. The emscripten bundled
+        # that are e.g. x86 specific and non-portable. The emscripten bundled
         # headers are modified to be portable, local system ones are generally not.
         diagnostics.warning(
             'absolute-paths', '-I or -L of an absolute path "' + arg +

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -50,7 +50,7 @@ logger = logging.getLogger('shared')
 
 # warning about absolute-paths is disabled by default, and not enabled by -Wall
 diagnostics.add_warning('absolute-paths', enabled=False, part_of_all=False)
-# unused diagnositic flags.  TODO(sbc): remove at some point
+# unused diagnostic flags.  TODO(sbc): remove at some point
 diagnostics.add_warning('almost-asm')
 diagnostics.add_warning('experimental')
 diagnostics.add_warning('invalid-input')
@@ -82,7 +82,7 @@ def shlex_join(cmd):
 
 
 def run_process(cmd, check=True, input=None, *args, **kw):
-  """Runs a subpocess returning the exit code.
+  """Runs a subprocess returning the exit code.
 
   By default this function will raise an exception on failure.  Therefor this should only be
   used if you want to handle such failures.  For most subprocesses, failures are not recoverable
@@ -729,7 +729,7 @@ def suffix(name):
 
 
 def unsuffixed(name):
-  """Return the filename without the extention.
+  """Return the filename without the extension.
 
   If there are multiple extensions this strips only the final one.
   """


### PR DESCRIPTION
I was experimenting with using pylint to check spelling in
commends and strings, but there are really way to many false
positives.

Here is what I tried:

  $ pylint --disable all --enable spelling emcc.py

Along with the following .pylintrc

```
[SPELLING]
spelling-dict=en_US
spelling-ignore-words=emscripten,emcc,emar,GNU,html,wasm,JS,js,gcc,fastcomp,dlmalloc,pthreads,malloc,compat,objcopy,llvm,binaryen,src,asm,webworker,args,initializer,frontend,backend,preprocessor,env,cmdline,autoconf,subresource,dereference,filesystem,asyncify,lto,memalign,pthread,DCE,bitcode,libtool,javascript,subprocess,stdout,stderr,bool,shlex,longjmp,minification
```