### PR TITLE
Default to reporting undefined symbol errors when building with MAIN_MODULE.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,14 @@ See docs/process.md for more on how version tagging works.
 
 Current Trunk
 -------------
+- When building with `-s MAIN_MODULE` emscripten will now error on undefined
+  symbol by default.  This matches the behvious of clang/gcc/msvc.  This
+  requires that your side modules be present on the command line.  If you do not
+  specify your side modules on the command line (either direcly or via
+  `RUNTIME_LINKED_LIBS`) you may need to add `-s WARN_ON_UNDEFINED_SYMBOLS=0` to
+  avoid errors about symbol that are missing at link time (but present in your
+  side modules provided at runtime).  We hope that this case is not common and
+  most users are building with side modules listed on the command line (#14060).
 - The `RUNTIME_LINKED_LIBS` setting is now deprecated.  It's better to simply
   list dynamic library dependencies directly on the command line.
 

--- a/emcc.py
+++ b/emcc.py
@@ -648,7 +648,24 @@ def filter_out_duplicate_dynamic_libs(inputs):
   return [f for f in inputs if check(f[1])]
 
 
-def process_dynamic_libs(dylibs):
+def process_dynamic_libs(dylibs, lib_dirs):
+  extras = []
+  seen = set()
+  to_process = dylibs.copy()
+  while to_process:
+    dylib = to_process.pop()
+    dylink = webassembly.parse_dylink_section(dylib)
+    for needed in dylink.needed:
+      if needed in seen:
+        continue
+      path = find_library(needed, lib_dirs)
+      if path:
+        extras.append(path)
+      else:
+        exit_with_error(f'{dylib}: shared library dependency not found: `{needed}`')
+      to_process.append(needed)
+
+  dylibs += extras
   for dylib in dylibs:
     imports = webassembly.get_imports(dylib)
     imports = [i.field for i in imports if i.kind in (webassembly.ExternType.FUNC, webassembly.ExternType.GLOBAL)]
@@ -1087,7 +1104,7 @@ def phase_calculate_linker_inputs(options, state, linker_inputs):
 
   if settings.MAIN_MODULE:
     dylibs = [i[1] for i in linker_inputs if building.is_wasm_dylib(i[1])]
-    process_dynamic_libs(dylibs)
+    process_dynamic_libs(dylibs, state.lib_dirs)
 
   linker_arguments = [val for _, val in sorted(linker_inputs + state.link_flags)]
   return linker_arguments
@@ -1702,7 +1719,9 @@ def phase_setup(state):
   if settings.SIDE_MODULE and settings.GLOBAL_BASE != -1:
     exit_with_error('Cannot set GLOBAL_BASE when building SIDE_MODULE')
 
-  if settings.RELOCATABLE or settings.LINKABLE:
+  # When building a side module we currently have to assume that any undefined
+  # symbols that exist at link time will be satisfied by the main module or JS.
+  if settings.SIDE_MODULE:
     default_setting('ERROR_ON_UNDEFINED_SYMBOLS', 0)
     default_setting('WARN_ON_UNDEFINED_SYMBOLS', 0)
 
@@ -3359,6 +3378,15 @@ def worker_js_script(proxy_worker_filename):
   return web_gl_client_src + '\n' + proxy_client_src
 
 
+def find_library(lib, lib_dirs):
+  for lib_dir in lib_dirs:
+    path = os.path.join(lib_dir, lib)
+    if os.path.isfile(path):
+      logger.debug('found library "%s" at %s', lib, path)
+      return path
+  return None
+
+
 def process_libraries(libs, lib_dirs, linker_inputs):
   libraries = []
   consumed = []
@@ -3368,21 +3396,17 @@ def process_libraries(libs, lib_dirs, linker_inputs):
   for i, lib in libs:
     logger.debug('looking for library "%s"', lib)
 
-    found = False
+    path = None
     for suff in suffixes:
       name = 'lib' + lib + suff
-      for lib_dir in lib_dirs:
-        path = os.path.join(lib_dir, name)
-        if os.path.exists(path):
-          logger.debug('found library "%s" at %s', lib, path)
-          linker_inputs.append((i, path))
-          consumed.append(i)
-          found = True
-          break
-      if found:
+      path = find_library(name, lib_dirs)
+      if path:
         break
 
-    if not found:
+    if path:
+      linker_inputs.append((i, path))
+      consumed.append(i)
+    else:
       jslibs = building.map_to_js_libs(lib)
       if jslibs is not None:
         libraries += [(i, jslib) for jslib in jslibs]

--- a/emscripten.py
+++ b/emscripten.py
@@ -301,7 +301,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
   # memory and global initializers
 
   if settings.RELOCATABLE:
-    static_bump = align_memory(webassembly.parse_dylink_section(in_wasm)[0])
+    static_bump = align_memory(webassembly.parse_dylink_section(in_wasm).mem_size)
     set_memory(static_bump)
     logger.debug('stack_base: %d, stack_max: %d, heap_base: %d', settings.STACK_BASE, settings.STACK_MAX, settings.HEAP_BASE)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3617,12 +3617,13 @@ ok
     self.set_setting('MAIN_MODULE', 2)
     self.clear_setting('SIDE_MODULE')
     if auto_load:
-      # Normally we don't report undefined symbols when linking main modules but
-      # in this case we know all the side modules are specified on the command line.
-      # TODO(sbc): Make this the default one day
-      self.set_setting('ERROR_ON_UNDEFINED_SYMBOLS')
       self.emcc_args += main_emcc_args
       self.emcc_args.append('liblib.so')
+    else:
+      # When not auto loading (i.e. when not specifying the side module on the
+      # command line) we need to disable warnings on undefined symbols.
+      self.set_setting('WARN_ON_UNDEFINED_SYMBOLS', 0)
+
     if force_c:
       self.emcc_args.append('-nostdlib++')
 
@@ -4466,7 +4467,8 @@ res64 - external 64\n''', header='''
   @needs_dylink
   def test_dylink_dso_needed(self):
     def do_run(src, expected_output, emcc_args=[]):
-      self.do_run(src + 'int main() { return test_main(); }', expected_output, emcc_args=emcc_args)
+      create_file('main.c', src + 'int main() { return test_main(); }')
+      self.do_runf('main.c', expected_output, emcc_args=emcc_args)
     self._test_dylink_dso_needed(do_run)
 
   @needs_dylink

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -139,6 +139,7 @@ Section = namedtuple('Section', ['type', 'size', 'offset'])
 Limits = namedtuple('Limits', ['flags', 'initial', 'maximum'])
 Import = namedtuple('Import', ['kind', 'module', 'field'])
 Export = namedtuple('Export', ['name', 'kind', 'index'])
+Dylink = namedtuple('Dylink', ['mem_size', 'mem_align', 'table_size', 'table_align', 'needed'])
 
 
 class Module:
@@ -196,7 +197,6 @@ def parse_dylink_section(wasm_file):
 
   dylink_section = next(module.sections())
   assert dylink_section.type == SecType.CUSTOM
-  section_end = dylink_section.offset + dylink_section.size
   module.seek(dylink_section.offset)
   # section name
   section_name = module.readString()
@@ -213,7 +213,7 @@ def parse_dylink_section(wasm_file):
     needed.append(libname)
     needed_count -= 1
 
-  return (mem_size, mem_align, table_size, table_align, section_end, needed)
+  return Dylink(mem_size, mem_align, table_size, table_align, needed)
 
 
 def get_exports(wasm_file):


### PR DESCRIPTION
For users that specify dynamic library dependencies on the command line
we can/should report undefined symbols at link time.

The only users that will, as a result of this change, need to add `-s
ERROR_ON_UNDEFINED_SYMBOLS=0` are those that specify or load libraries
at runtime using `loadWebAssemblyModule` or specifying
`dynamicLibraries` at runtime.  (Note that users of `dlopen` will not be
effected in this way).