### PR TITLE
Fix setImmediate pollyfill in strict mode

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2673,40 +2673,50 @@ var LibraryJSEvents = {
   },
 
   $polyfillSetImmediate__postset:
-    'var __setImmediate_id_counter = 0;\n' +
-    'var __setImmediate_queue = [];\n' +
-    'var __setImmediate_message_id = "_si";\n' +
-    'function __setImmediate_cb(e) {\n' +
-      'if (e.data === __setImmediate_message_id) {\n' +
-        'e.stopPropagation();\n' +
-        '__setImmediate_queue.shift()();\n' +
-        '++__setImmediate_id_counter;\n' +
+    'var emSetImmediate;\n' +
+    'var emClearImmediate;\n' +
+    'if (typeof setImmediate !== "undefined") {\n' +
+      'emSetImmediate = setImmediate;\n' +
+      'emClearImmediate = clearImmediate;\n' +
+    '} else if (typeof addEventListener === "function") {\n' +
+      'var __setImmediate_id_counter = 0;\n' +
+      'var __setImmediate_queue = [];\n' +
+      'var __setImmediate_message_id = "_si";\n' +
+      'function __setImmediate_cb(e) {\n' +
+        'if (e.data === __setImmediate_message_id) {\n' +
+          'e.stopPropagation();\n' +
+          '__setImmediate_queue.shift()();\n' +
+          '++__setImmediate_id_counter;\n' +
+        '}\n' +
       '}\n' +
-    '}\n' +
-    'if (typeof setImmediate === "undefined" && typeof addEventListener === "function") {\n' +
       'addEventListener("message", __setImmediate_cb, true);\n' +
-      'setImmediate = function(func) {\n' +
+      'emSetImmediate = function(func) {\n' +
         'postMessage(__setImmediate_message_id, "*");\n' +
         'return __setImmediate_id_counter + __setImmediate_queue.push(func) - 1;\n' +
       '}\n' +
-      'clearImmediate = /**@type{function(number=)}*/(function(id) {\n' +
+      'emClearImmediate = /**@type{function(number=)}*/(function(id) {\n' +
         'var index = id - __setImmediate_id_counter;\n' +
         'if (index >= 0 && index < __setImmediate_queue.length) __setImmediate_queue[index] = function() {};\n' + // must preserve the order and count of elements in the queue, so replace the pending callback with an empty function
       '})\n' +
     '}',
 
-  $polyfillSetImmediate: function() { /* nop, used for its postset to ensure setImmediate() polyfill is not duplicated between emscripten_set_immediate() and emscripten_set_immediate_loop() if application links to both of them.*/ },
+  $polyfillSetImmediate: function() {
+    // nop, used for its postset to ensure setImmediate() polyfill is
+    // not duplicated between emscripten_set_immediate() and
+    // emscripten_set_immediate_loop() if application links to both of them.
+  },
 
   emscripten_set_immediate__deps: ['$polyfillSetImmediate'],
   emscripten_set_immediate: function(cb, userData) {
     polyfillSetImmediate();
-    return setImmediate(function() {
+    return emSetImmediate(function() {
       {{{ makeDynCall('vi', 'cb') }}}(userData);
     });
   },
 
+  emscripten_clear_immediate__deps: ['$polyfillSetImmediate'],
   emscripten_clear_immediate: function(id) {
-    clearImmediate(id);
+    emClearImmediate(id);
   },
 
   emscripten_set_immediate_loop__deps: ['$polyfillSetImmediate'],
@@ -2714,10 +2724,10 @@ var LibraryJSEvents = {
     polyfillSetImmediate();
     function tick() {
       if ({{{ makeDynCall('ii', 'cb') }}}(userData)) {
-        setImmediate(tick);
+        emSetImmediate(tick);
       }
     }
-    return setImmediate(tick);
+    return emSetImmediate(tick);
   },
 
   emscripten_set_timeout: function(cb, msecs, userData) {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5109,6 +5109,9 @@ window.close = function() {
   def test_assert_failure(self):
     self.btest(test_file('browser', 'test_assert_failure.c'), 'abort:Assertion failed: false && "this is a test"')
 
+  def test_full_js_library_strict(self):
+    self.btest_exit(test_file('hello_world.c'), args=['-sINCLUDE_FULL_LIBRARY', '-sSTRICT_JS'])
+
 
 EMRUN = path_from_root('emrun')
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7544,13 +7544,13 @@ end
     self.assertNotContained(WARNING, proc.stderr)
 
   def test_full_js_library(self):
-    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'INCLUDE_FULL_LIBRARY'])
+    self.run_process([EMCC, test_file('hello_world.c'), '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY'])
 
   def test_full_js_library_gl_emu(self):
-    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'INCLUDE_FULL_LIBRARY', '-s', 'LEGACY_GL_EMULATION'])
+    self.run_process([EMCC, test_file('hello_world.c'), '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY', '-sLEGACY_GL_EMULATION'])
 
   def test_full_js_library_no_exception_throwing(self):
-    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'INCLUDE_FULL_LIBRARY', '-s', 'DISABLE_EXCEPTION_THROWING'])
+    self.run_process([EMCC, test_file('hello_world.c'), '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY', '-sDISABLE_EXCEPTION_THROWING'])
 
   def test_closure_full_js_library(self):
     # test for closure errors in the entire JS library


### PR DESCRIPTION
This required adding a browser test that includes this pollyfill
because the issue doesn't show up in node (setImmediate *is* defined
in node).

Fixes: #12568