### PR TITLE
circleci: macOS: don't try to `brew install` packages that are already installed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,9 @@ commands:
           name: Install brew package dependencies
           environment:
             HOMEBREW_NO_AUTO_UPDATE: "1"
-          command: brew install python3 cmake
+          command: |
+            brew list cmake || brew install cmake
+            brew list python3 || brew install python3
       - run:
           name: run tests
           command: |
@@ -477,7 +479,9 @@ jobs:
           name: Install brew package dependencies
           environment:
             HOMEBREW_NO_AUTO_UPDATE: "1"
-          command: brew install python3 cmake
+          command: |
+            brew list cmake || brew install cmake
+            brew list python3 || brew install python3
       - checkout
       - build
       # note we do *not* build all libraries and freeze the cache; as we run


### PR DESCRIPTION
It seems that circleci recently started pre-installing python3 which
broke our CI with:

```
Error: python@3.9 3.9.0_1 is already installed
To upgrade to 3.9.4, run:
  brew upgrade python@3.9
```

This is kind of shame that brew can't just handle this case cleanly.  I
chose this approach over the `brew bundle` because it seemed a little
simpler to me (someone who doesn't know brew or brew bundle).

See https://apple.stackexchange.com/questions/284379/with-homebrew-how-to-check-if-a-software-package-is-installed
See https://github.com/Homebrew/brew/issues/2491