### PR TITLE
Return null in webglGetUniformLocation if no program is bound

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -2045,6 +2045,9 @@ var LibraryGL = {
   // the currently active shader in this GL context.
   $webglGetUniformLocation: function(location) {
     var p = GLctx.currentProgram;
+    if (!p) {
+      return null;
+    }
     var webglLoc = p.uniformLocsById[location];
     // p.uniformLocsById[location] stores either an integer, or a WebGLUniformLocation.
 


### PR DESCRIPTION
After updating Emscripten our app crashes in webglGetUniformLocation when no shader is bound.

The crash is caused by reading `uniformLocsById` from `GLctx.currentProgram` which is null. 

This PR changes webglGetUniformLocation to return null if there is no bound program.