### PR TITLE
Fix emscripten_get_heap_max's return value for 4GB

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -193,11 +193,9 @@ LibraryManager.library = {
 
   emscripten_get_heap_max: function() {
 #if ALLOW_MEMORY_GROWTH
-#if MAXIMUM_MEMORY == -1 // no maximum set, assume the best
-    return 4*1024*1024*1024 - {{{ WASM_PAGE_SIZE }}};
-#else
-    return {{{ MAXIMUM_MEMORY }}};
-#endif
+    // Handle the case of 4GB (which would wrap to 0 in the return value) by
+    // returning up to 4GB - one wasm page.
+    return {{{ Math.min(MAXIMUM_MEMORY, FOUR_GB - WASM_PAGE_SIZE) }}};
 #else // no growth
     return HEAPU8.length;
 #endif
@@ -295,16 +293,12 @@ LibraryManager.library = {
     // 4. If we were unable to allocate as much memory, it may be due to over-eager decision to excessively reserve due to (3) above.
     //    Hence if an allocation fails, cut down on the amount of excess growth, in an attempt to succeed to perform a smaller allocation.
 
-#if MAXIMUM_MEMORY != -1
-    // A limit was set for how much we can grow. We should not exceed that
+    // A limit is set for how much we can grow. We should not exceed that
     // (the wasm binary specifies it, so if we tried, we'd fail anyhow).
     // In CAN_ADDRESS_2GB mode, stay one Wasm page short of 4GB: while e.g. Chrome is able to allocate full 4GB Wasm memories, the size will wrap
     // back to 0 bytes in Wasm side for any code that deals with heap sizes, which would require special casing all heap size related code to treat
     // 0 specially.
-    var maxHeapSize = {{{ Math.min(MAXIMUM_MEMORY, 4294967296 - WASM_PAGE_SIZE) }}};
-#else
-    var maxHeapSize = {{{ (CAN_ADDRESS_2GB ? 4294967296 : 2147483648) - WASM_PAGE_SIZE }}};
-#endif
+    var maxHeapSize = {{{ Math.min(MAXIMUM_MEMORY, FOUR_GB - WASM_PAGE_SIZE) }}};
     if (requestedSize > maxHeapSize) {
 #if ASSERTIONS
       err('Cannot enlarge memory, asked to go up to ' + requestedSize + ' bytes, but the limit is ' + maxHeapSize + ' bytes!');

--- a/src/library.js
+++ b/src/library.js
@@ -194,7 +194,7 @@ LibraryManager.library = {
   emscripten_get_heap_max: function() {
 #if ALLOW_MEMORY_GROWTH
 #if MAXIMUM_MEMORY == -1 // no maximum set, assume the best
-    return 4*1024*1024*1024;
+    return 4*1024*1024*1024 - {{{ WASM_PAGE_SIZE }}};
 #else
     return {{{ MAXIMUM_MEMORY }}};
 #endif

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -7,6 +7,8 @@
 // Various tools for parsing LLVM. Utilities of various sorts, that are
 // specific to Emscripten (and hence not in utility.js).
 
+const FOUR_GB = 4 * 1024 * 1024 * 1024;
+
 let currentlyParsedFilename = '';
 
 // Does simple 'macro' substitution, using Django-like syntax,

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -90,14 +90,14 @@ function updateGlobalBufferAndViews(b) {
 #if USE_PTHREADS
 if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
-#if ALLOW_MEMORY_GROWTH && MAXIMUM_MEMORY != -1
+#if ALLOW_MEMORY_GROWTH && MAXIMUM_MEMORY != FOUR_GB
   var wasmMaximumMemory = {{{ MAXIMUM_MEMORY >>> 16 }}};
 #else
   var wasmMaximumMemory = {{{ INITIAL_MEMORY >>> 16}}};
 #endif
   wasmMemory = new WebAssembly.Memory({
     'initial': {{{ INITIAL_MEMORY >>> 16 }}}
-#if USE_PTHREADS || !ALLOW_MEMORY_GROWTH || MAXIMUM_MEMORY != -1
+#if USE_PTHREADS || !ALLOW_MEMORY_GROWTH || MAXIMUM_MEMORY != FOUR_GB
     , 'maximum': wasmMaximumMemory
 #endif
 #if USE_PTHREADS

--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -25,7 +25,7 @@ if (ENVIRONMENT_IS_PTHREAD) {
     wasmMemory = new WebAssembly.Memory({
       'initial': INITIAL_MEMORY / {{{ WASM_PAGE_SIZE }}}
 #if ALLOW_MEMORY_GROWTH
-#if MAXIMUM_MEMORY != -1
+#if MAXIMUM_MEMORY != FOUR_GB
       ,
       'maximum': {{{ MAXIMUM_MEMORY }}} / {{{ WASM_PAGE_SIZE }}}
 #endif

--- a/src/settings.js
+++ b/src/settings.js
@@ -173,8 +173,6 @@ var INITIAL_MEMORY = 16777216;
 // relevant when ALLOW_MEMORY_GROWTH is set, as without growth, the size of
 // INITIAL_MEMORY is the final size of memory anyhow.
 //
-// If this value is -1, it means there is no specified limit.
-//
 // Note that the default value here is 2GB, which means that by default if you
 // enable memory growth then we can grow up to 2GB but no higher. 2GB is a
 // natural limit for several reasons:
@@ -186,6 +184,8 @@ var INITIAL_MEMORY = 16777216;
 //     has support started to appear. As support is limited, it's safer for
 //     people to opt into >2GB+ heaps rather than get a build that may not
 //     work on all VMs.
+//
+// To use more than 2GB, set this to something higher, like 4GB.
 //
 // (This option was formerly called WASM_MEM_MAX and BINARYEN_MEM_MAX.)
 // [link]


### PR DESCRIPTION
The old value here wrapped to 0.