### PR TITLE
Created wrapper for vector with JavaScript Array style API

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -562,3 +562,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Érico Porto <ericoporto2008@gmail.com>
 * Albert Vaca Cintora <albertvaka@gmail.com>
 * Zhi An Ng <zhin@google.com> (copyright owned by Google, Inc.)
+* Brian Gontowski <brian@gontowski.com>

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -2103,6 +2103,10 @@ var LibraryEmbind = {
         classType = classType[0];
         var humanName = classType.name + '.' + methodName;
 
+        if (methodName.startsWith("@@")) {
+            methodName = Symbol[methodName.substring(2)];
+        }
+
         if (isPureVirtual) {
             classType.registeredClass.pureVirtualFunctions.push(methodName);
         }

--- a/tests/embind/embind_test.cpp
+++ b/tests/embind/embind_test.cpp
@@ -1761,6 +1761,8 @@ EMSCRIPTEN_BINDINGS(tests) {
     register_vector<float>("FloatVector");
     register_vector<std::vector<int>>("IntegerVectorVector");
 
+    vector<double>("DoubleVector", "DoubleVectorIterator", "DoubleVectorValue");
+
     class_<DummyForPointer>("DummyForPointer");
 
     function("mallinfo", &emval_test_mallinfo);

--- a/tests/embind/test_val.cpp
+++ b/tests/embind/test_val.cpp
@@ -79,7 +79,7 @@ int main()
   ensure_js_not("a instanceof Number");
   
   test("template<typename T> val array(const std::vector<T> vec)");
-  vector<val> vec1;
+  std::vector<val> vec1;
   vec1.push_back(val(11));
   vec1.push_back(val("a"));
   vec1.push_back(val::array());
@@ -91,7 +91,7 @@ int main()
   ensure_js_not("a[0] == 12");
   ensure_js("a[1] == 'a'");
   ensure_js("a[2] instanceof Array");
-  vector<int> vec2;
+  std::vector<int> vec2;
   vec2.push_back(0);
   vec2.push_back(1);
   vec2.push_back(3);


### PR DESCRIPTION
This PR adds a new `std::vector` wrapper that implements most of the JavaScript Array API.

- The following functions and properties are available in JavaScript while using `std::vector` directly.
  - `concat` ¹
  - `copyWithin`
  - `entries` ²
  - `every`
  - `fill`
  - `filter`
  - `find`
  - `findIndex`
  - `forEach`
  - `from`
  - `includes`
  - `indexOf`
  - `join`
  - `keys` ²
  - `lastIndexOf`
  - `length`
  - `map`
  - `pop`
  - `push` ¹
  - `reduce`
  - `reduceRight`
  - `reverse`
  - `shift`
  - `slice`
  - `some`
  - `sort`
  - `splice` ¹
  - `toLocaleString`
  - `toString`
  - `unshift` ¹
  - `values` ²
  - ¹ _The variable argument syntax variations are not implemented as I do not know how to do this with Embind._
  - ² _These functions are iterable,_
- Since JavaScript does not support overloading the `[]` operator, `get` and `set` continue to be used instead, although they now support negative indexing.
- Since `std::vector` doesn't support undefined elements, `resize` is also retained.
- This is implemented as a new vector wrapper to avoid breaking existing JavaScript code that depends on the std::vector style API.

Here is the example from the test case...
```
vector<double>("DoubleVector", "DoubleVectorIterator", "DoubleVectorValue");
```

Notice that names must be provided for the vector wrapper along with the iterator and iterator value.  This result can be extended with `.function`, `.class_function`, `.property`, and `.class_property` if desired in the same manner as `class_`.

In JavaScript, the vector can be used like an Array, without requiring copying back and forth...

```
const vector = module.DoubleVector.from([1, 2, 3]);
for (const element of vector) {
    console.log(element);
}
vector.delete();
```