### PR TITLE
Improve support for LLD_REPORT_UNDEFINED

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9716,6 +9716,12 @@ int main() {
     self.assertContained('wasm-ld: error:', stderr)
     self.assertContained('main_0.o: undefined symbol: foo', stderr)
 
+  def test_lld_report_undefined_reverse_deps(self):
+    self.run_process([EMCC, '-sLLD_REPORT_UNDEFINED', '-sREVERSE_DEPS=all', test_file('hello_world.c')])
+
+  def test_lld_report_undefined_exceptions(self):
+    self.run_process([EMCC, '-sLLD_REPORT_UNDEFINED', '-fwasm-exceptions', test_file('hello_libcxx.cpp')])
+
   def test_4GB(self):
     stderr = self.expect_fail([EMCC, test_file('hello_world.c'), '-s', 'INITIAL_MEMORY=2GB'])
     self.assertContained('INITIAL_MEMORY must be less than 2GB due to current spec limitations', stderr)
@@ -10274,8 +10280,8 @@ exec "$@"
     # When debugging set this valud to the function that you want to start
     # with.  All symbols prior will be skipped over.
     start_at = None
-    assert not start_at or start_at in deps_info.deps_info
-    for function, deps in deps_info.deps_info.items():
+    assert not start_at or start_at in deps_info.get_deps_info()
+    for function, deps in deps_info.get_deps_info().items():
       if start_at:
         if function == start_at:
           start_at = None

--- a/tools/building.py
+++ b/tools/building.py
@@ -407,8 +407,8 @@ def lld_flags_for_executable(external_symbol_list):
     # Export these two section start symbols so that we can extact the string
     # data that they contain.
     cmd += [
-      '--export', '__start_em_asm',
-      '--export', '__stop_em_asm',
+      '--export-if-defined', '__start_em_asm',
+      '--export-if-defined', '__stop_em_asm',
       '-z', 'stack-size=%s' % settings.TOTAL_STACK,
       '--initial-memory=%d' % settings.INITIAL_MEMORY,
     ]

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -48,7 +48,9 @@
 # TODO: Move all __deps from src/library*.js to deps_info, and use that single source of info
 #       both here and in the JS compiler.
 
-deps_info = {
+from tools.settings import settings
+
+_deps_info = {
   'Mix_LoadWAV_RW': ['fileno'],
   'SDL_CreateRGBSurface': ['malloc', 'free'],
   'SDL_GL_GetProcAddress': ['malloc'],
@@ -60,7 +62,6 @@ deps_info = {
   'SDL_malloc': ['malloc', 'free'],
   '__cxa_allocate_exception': ['malloc'],
   '__cxa_end_catch': ['setThrew', 'free'],
-  '__cxa_begin_catch': ['__cxa_is_pointer_type'],
   '__cxa_free_exception': ['free'],
   '_embind_register_class': ['free'],
   '_embind_register_enum_value': ['free'],
@@ -101,7 +102,6 @@ deps_info = {
   'emscripten_set_batterylevelchange_callback_on_thread': ['malloc', 'free'],
   'emscripten_set_beforeunload_callback_on_thread': ['malloc', 'free'],
   'emscripten_set_blur_callback_on_thread': ['malloc', 'free'],
-  'emscripten_set_canvas_element_size_calling_thread': ['_emscripten_call_on_thread'],
   'emscripten_set_click_callback_on_thread': ['malloc', 'free'],
   'emscripten_set_dblclick_callback_on_thread': ['malloc', 'free'],
   'emscripten_set_devicemotion_callback_on_thread': ['malloc', 'free'],
@@ -122,7 +122,6 @@ deps_info = {
   'emscripten_set_mouseout_callback_on_thread': ['malloc', 'free'],
   'emscripten_set_mouseover_callback_on_thread': ['malloc', 'free'],
   'emscripten_set_mouseup_callback_on_thread': ['malloc', 'free'],
-  'emscripten_set_offscreencanvas_size_on_target_thread': ['_emscripten_call_on_thread', 'malloc', 'free'],
   'emscripten_set_offscreencanvas_size_on_target_thread_js': ['malloc', 'free'],
   'emscripten_set_orientationchange_callback_on_thread': ['malloc', 'free'],
   'emscripten_set_pointerlockchange_callback_on_thread': ['malloc', 'free'],
@@ -196,3 +195,12 @@ deps_info = {
   'wgpuBufferGetConstMappedRange': ['malloc', 'free'],
   'emscripten_glGetString': ['malloc'],
 }
+
+
+def get_deps_info():
+  if not settings.EXCEPTION_HANDLING and not settings.DISABLE_EXCEPTION_CATCHING:
+    _deps_info['__cxa_begin_catch'] = ['__cxa_is_pointer_type']
+  if settings.USE_PTHREADS:
+    _deps_info['emscripten_set_canvas_element_size_calling_thread'] = ['_emscripten_call_on_thread']
+    _deps_info['emscripten_set_offscreencanvas_size_on_target_thread'] = ['_emscripten_call_on_thread', 'malloc', 'free']
+  return _deps_info

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1414,7 +1414,7 @@ def handle_reverse_deps(input_files):
   elif settings.REVERSE_DEPS == 'all':
     # When not optimzing we add all possible reverse dependencies rather
     # than scanning the input files
-    for symbols in deps_info.deps_info.values():
+    for symbols in deps_info.get_deps_info().values():
       for symbol in symbols:
         settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(symbol))
     return
@@ -1426,7 +1426,7 @@ def handle_reverse_deps(input_files):
 
   def add_reverse_deps(need):
     more = False
-    for ident, deps in deps_info.deps_info.items():
+    for ident, deps in deps_info.get_deps_info().items():
       if ident in need.undefs and ident not in added:
         added.add(ident)
         more = True


### PR DESCRIPTION
This change fixes two issues:

1. Use `--export-if-defined` for optional symbols like __start_em_asm
   and `__stop_em_asm` which might or might not exist in the output.
2. Avoids ever including reverse dependencies that don't exist in
   certain configurations.