### PR TITLE
Remove shared.py:verify_settings. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1366,7 +1366,18 @@ def phase_setup(state):
   for s in user_js_defines:
     settings[s[0]] = s[1]
 
-  shared.verify_settings()
+  if settings.SAFE_HEAP not in [0, 1]:
+    exit_with_error('emcc: SAFE_HEAP must be 0 or 1')
+
+  if not settings.WASM:
+    # When the user requests non-wasm output, we enable wasm2js. that is,
+    # we still compile to wasm normally, but we compile the final output
+    # to js.
+    settings.WASM = 1
+    settings.WASM2JS = 1
+  if settings.WASM == 2:
+    # Requesting both Wasm and Wasm2JS support
+    settings.WASM2JS = 1
 
   if (options.oformat == OFormat.WASM or settings.PURE_WASI) and not settings.SIDE_MODULE:
     # if the output is just a wasm file, it will normally be a standalone one,

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -86,9 +86,8 @@ var WASI_MODULE_NAME = "wasi_snapshot_preview1";
 // (internal, use -lfoo or -lfoo.js to link to Emscripten system JS libraries)
 var SYSTEM_JS_LIBRARIES = [];
 
-// This will contain the emscripten version. You should not modify this. This
-// and the following few settings are useful in combination with
-// RETAIN_COMPILER_SETTINGS
+// This will contain the emscripten version. This can be useful in combination
+// with RETAIN_COMPILER_SETTINGS
 var EMSCRIPTEN_VERSION = '';
 
 // Will be set to 0 if -fno-rtti is used on the command line.

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -537,21 +537,6 @@ def target_environment_may_be(environment):
   return settings.ENVIRONMENT == '' or environment in settings.ENVIRONMENT.split(',')
 
 
-def verify_settings():
-  if settings.SAFE_HEAP not in [0, 1]:
-    exit_with_error('emcc: SAFE_HEAP must be 0 or 1 in fastcomp')
-
-  if not settings.WASM:
-    # When the user requests non-wasm output, we enable wasm2js. that is,
-    # we still compile to wasm normally, but we compile the final output
-    # to js.
-    settings.WASM = 1
-    settings.WASM2JS = 1
-  if settings.WASM == 2:
-    # Requesting both Wasm and Wasm2JS support
-    settings.WASM2JS = 1
-
-
 def print_compiler_stage(cmd):
   """Emulate the '-v' of clang/gcc by printing the name of the sub-command
   before executing it."""
@@ -833,7 +818,6 @@ FILE_PACKAGER = bat_suffix(path_from_root('tools', 'file_packager'))
 
 apply_configuration()
 
-verify_settings()
 Cache = cache.Cache(config.CACHE)
 
 PRINT_STAGES = int(os.getenv('EMCC_VERBOSE', '0'))


### PR DESCRIPTION
This function was originally designed as the place we would verify user
settings, but these days that all lives in emcc.py.

I'm planning a refactor there and moving this fragement into emcc.py
first will make that followup more clear.