### PR TITLE
Mark USE_ZLIB and other port settings as valid in compile-only mode.

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9941,7 +9941,7 @@ int main () {
     # Tests that explicitly exported `_main` does not fail, even though `_start` is the entry
     # point.
     # We should consider making this a warning since the `_main` export is redundant.
-    self.run_process([EMCC, '-sEXPORTED_FUNCTIONS=_main', '-sSTANDALONE_WASM', '-c', test_file('core', 'test_hello_world.c')])
+    self.run_process([EMCC, '-sEXPORTED_FUNCTIONS=_main', '-sSTANDALONE_WASM', test_file('core', 'test_hello_world.c')])
 
   def test_missing_malloc_export(self):
     # we used to include malloc by default. show a clear error in builds with

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -26,8 +26,9 @@ MEM_SIZE_SETTINGS = (
 COMPILE_TIME_SETTINGS = (
     'MEMORY64',
     'INLINING_LIMIT',
-    'DISABLE_EXCEPTION_CATCHING',
     'EXCEPTION_CATCHING_ALLOWED',
+    'DISABLE_EXCEPTION_CATCHING',
+    'DISABLE_EXCEPTION_THROWING',
     'MAIN_MODULE',
     'SIDE_MODULE',
     'RELOCATABLE',
@@ -36,6 +37,31 @@ COMPILE_TIME_SETTINGS = (
     'USE_PTHREADS',
     'SUPPORT_LONGJMP',
     'DEFAULT_TO_CXX',
+    'WASM_OBJECT_FILES',
+
+    # All port-related settings are valid at compile time
+    'USE_SDL',
+    'USE_LIBPNG',
+    'USE_BULLET',
+    'USE_ZLIB',
+    'USE_BZIP2',
+    'USE_VORBIS',
+    'USE_COCOS2D',
+    'USE_ICU',
+    'USE_MODPLUG',
+    'USE_SDL_MIXER',
+    'USE_SDL_IMAGE',
+    'USE_SDL_TTF',
+    'USE_SDL_NET',
+    'USE_SDL_GFX',
+    'USE_LIBJPEG',
+    'USE_OGG',
+    'USE_REGAL',
+    'USE_BOOST_HEADERS',
+    'USE_HARFBUZZ',
+    'USE_MPG123',
+    'USE_GIFLIB',
+    'USE_FREETYPE',
 )
 
 


### PR DESCRIPTION
This was an oversight in #14042

Fixes: #14102