### PR TITLE
Rebaseline code size test after llvm change. NFC

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 19904,
-  "a.js.gz": 8151,
+  "a.js": 19843,
+  "a.js.gz": 8139,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 23663,
-  "total_gz": 11252
+  "total": 23602,
+  "total_gz": 11240
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 19386,
-  "a.js.gz": 7992,
+  "a.js": 19325,
+  "a.js.gz": 7982,
   "a.mem": 3171,
   "a.mem.gz": 2715,
-  "total": 23145,
-  "total_gz": 11093
+  "total": 23084,
+  "total_gz": 11083
 }


### PR DESCRIPTION
Looks like https://reviews.llvm.org/D101191 gave us a
little code size win.  I'm not sure how.