### PR TITLE
Disable newly added warning about link-time setting used when compiling

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,8 @@ See docs/process.md for more on how version tagging works.
 - The version string reported by `-v`/`--version` now includes a `-git` suffix
   (e.g. `2.0.19-git`) when running from git checkout (to help distinguish
   unreleased git versions from official releases) (#14092).
+- Temporarily back out new `-Wunused-command-line-argument` warnings introduced
+  in 2.0.19.
 
 2.0.19: 05/04/2021
 ------------------

--- a/emcc.py
+++ b/emcc.py
@@ -50,7 +50,7 @@ from tools import js_manipulation
 from tools import wasm2c
 from tools import webassembly
 from tools import config
-from tools.settings import settings, MEM_SIZE_SETTINGS, COMPILE_TIME_SETTINGS
+from tools.settings import settings, MEM_SIZE_SETTINGS
 
 logger = logging.getLogger('emcc')
 
@@ -1317,9 +1317,12 @@ def phase_setup(state):
   state.compile_only = state.has_dash_c or state.has_dash_S or state.has_header_inputs or state.preprocess_only
 
   if state.compile_only:
-    for key in settings_map:
-      if key not in COMPILE_TIME_SETTINGS:
-        diagnostics.warning('unused-command-line-argument', "linker setting ignored during compilation: '%s'" % key)
+    # TODO(sbc): Re-enable these warnings once we are sure we don't have any false
+    # positives.  See: https://github.com/emscripten-core/emscripten/pull/14109
+    pass
+    # for key in settings_map:
+    #   if key not in COMPILE_TIME_SETTINGS:
+    #     diagnostics.warning('unused-command-line-argument', "linker setting ignored during compilation: '%s'" % key)
   else:
     ldflags = emsdk_ldflags(newargs)
     for f in ldflags:


### PR DESCRIPTION
This is essentially a revert of #14042.

We had some false positives here (#14104), and some comments on the
mailing list that made me think we should hold off until I've landed my
changes that make false positives impossible.  See: #14109