### PR TITLE
Fix uniform preprocessing

### DIFF
--- a/src/library_c_preprocessor.js
+++ b/src/library_c_preprocessor.js
@@ -109,7 +109,7 @@ mergeInto(LibraryManager.library, {
 
     // Expands preprocessing macros on substring str[lineStart...lineEnd]
     function expandMacros(str, lineStart, lineEnd) {
-      if (!lineEnd) lineEnd = str.length;
+      if (lineEnd === undefined) lineEnd = str.length;
       var len = str.length;
       var out = '';
       for(var i = lineStart; i < lineEnd; ++i) {
@@ -235,7 +235,6 @@ mergeInto(LibraryManager.library, {
       var space = nextWhitespace(code, j);
       var directive = code.substring(j+1, space);
       var expression = code.substring(space, i).trim();
-
       switch(directive) {
       case 'if':
         var tokens = tokenize(expandMacros(expression, 0));

--- a/src/library_c_preprocessor.js
+++ b/src/library_c_preprocessor.js
@@ -273,13 +273,14 @@ mergeInto(LibraryManager.library, {
         break;
       case 'undef': delete defs[expression]; break;
       default:
-        if (directive == 'version' || directive == 'pragma' || directive == 'extension') { // GLSL shader compiler specific #directives.
-          out += expandMacros(code, lineStart, i) + '\n';
-        } else {
+        if (directive != 'version' && directive != 'pragma' && directive != 'extension') { // GLSL shader compiler specific #directives.
 #if ASSERTIONS
           console.error('Unrecognized preprocessor directive #' + directive + '!');
 #endif
         }
+
+        // Unknown preprocessor macro, just pass through the line to output.
+        out += expandMacros(code, lineStart, i) + '\n';
       }
     }
     return out;

--- a/src/library_c_preprocessor.js
+++ b/src/library_c_preprocessor.js
@@ -84,16 +84,16 @@ mergeInto(LibraryManager.library, {
       var out = [], len = exprString.length;
       for(var i = 0; i <= len; ++i) {
         var kind = classifyChar(exprString, i);
-        if (kind == 2 || kind == 3) { // a character or a number
+        if (kind == 2/*0-9*/ || kind == 3/*a-z*/) { // a character or a number
           for(var j = i+1; j <= len; ++j) {
             var kind2 = classifyChar(exprString, j);
-            if (kind2 != kind && (kind2 != 2 || kind != 3)) { // parse number sequence "423410", and identifier sequence "FOO32BAR"
+            if (kind2 != kind && (kind2 != 2/*0-9*/ || kind != 3/*a-z*/)) { // parse number sequence "423410", and identifier sequence "FOO32BAR"
               out.push(exprString.substring(i, j));
               i = j-1;
               break;
             }
           }
-        } else if (kind == 1) {
+        } else if (kind == 1/*operator symbol*/) {
           // Lookahead for two-character operators.
           var op2 = exprString.substr(i, 2);
           if (['<=', '>=', '==', '!=', '&&', '||'].includes(op2)) {
@@ -114,21 +114,21 @@ mergeInto(LibraryManager.library, {
       var out = '';
       for(var i = lineStart; i < lineEnd; ++i) {
         var kind = classifyChar(str, i);
-        if (kind == 3) {
+        if (kind == 3/*a-z*/) {
           for(var j = i + 1; j <= lineEnd; ++j) {
             var kind2 = classifyChar(str, j);
-            if (kind2 != 2 && kind2 != 3) {
+            if (kind2 != 2/*0-9*/ && kind2 != 3/*a-z*/) {
               var symbol = str.substring(i, j);
               var pp = defs[symbol];
               if (pp) {
                 var expanded = str.substring(lineStart, i);
-                if (str[j] == '(') {
+                if (pp.length && str[j] == '(') { // Expanding a macro? (#define FOO(X) ...)
                   var closeParens = find_closing_parens_index(str, j);
 #if ASSERTIONS
                   assert(str[closeParens] == ')');
 #endif
                   expanded += pp(str.substring(j+1, closeParens).split(',')) + str.substring(closeParens+1, lineEnd);
-                } else {
+                } else { // Expanding a non-macro (#define FOO BAR)
                   expanded += pp() + str.substring(j, lineEnd);
                 }
                 return expandMacros(expanded, 0);

--- a/src/library_c_preprocessor.js
+++ b/src/library_c_preprocessor.js
@@ -273,7 +273,7 @@ mergeInto(LibraryManager.library, {
         break;
       case 'undef': delete defs[expression]; break;
       default:
-        if (directive == 'version' || directive == 'pragma') { // GLSL shader compiler specific #directives.
+        if (directive == 'version' || directive == 'pragma' || directive == 'extension') { // GLSL shader compiler specific #directives.
           out += expandMacros(code, lineStart, i) + '\n';
         } else {
 #if ASSERTIONS

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3083,15 +3083,15 @@ var LibraryGL = {
 
 #if GL_EXPLICIT_UNIFORM_LOCATION
     // Extract the layout(location = x) directives.
-    var regex = /layout\s*\(\s*location\s*=\s*(-?\d+)\s*\)\s*(uniform\s+\w+\s+(\w+))/g, explicitUniformLocations = {}, match;
+    var regex = /layout\s*\(\s*location\s*=\s*(-?\d+)\s*\)\s*(uniform\s+((lowp|mediump|highp)\s+)?\w+\s+(\w+))/g, explicitUniformLocations = {}, match;
     while(match = regex.exec(source)) {
 #if GL_DEBUG
       console.dir(match);
 #endif
-      explicitUniformLocations[match[3]] = jstoi_q(match[1]);
+      explicitUniformLocations[match[5]] = jstoi_q(match[1]);
 #if GL_TRACK_ERRORS
-      if (!(explicitUniformLocations[match[3]] >= 0 && explicitUniformLocations[match[3]] < 1048576)) {
-        console.error('Specified an out of range layout(location=x) directive "' + explicitUniformLocations[match[3]] + '"! (' + match[0] + ')');
+      if (!(explicitUniformLocations[match[5]] >= 0 && explicitUniformLocations[match[5]] < 1048576)) {
+        console.error('Specified an out of range layout(location=x) directive "' + explicitUniformLocations[match[5]] + '"! (' + match[0] + ')');
         GL.recordError(0x501 /* GL_INVALID_VALUE */);
         return;
       }

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3399,7 +3399,7 @@ var LibraryGL = {
       Object.keys(s.explicitUniformLocations).forEach(function(shaderLocation) {
         var loc = s.explicitUniformLocations[shaderLocation];
         // Record each explicit uniform location temporarily as a non-array uniform
-        // with size=1, this is not true, but on the first glGetUniformLocation() call
+        // with size=1. This is not true, but on the first glGetUniformLocation() call
         // the array sizes will get populated to correct sizes.
         program.uniformSizeAndIdsByName[shaderLocation] = [1, loc];
 #if GL_DEBUG
@@ -3408,7 +3408,7 @@ var LibraryGL = {
 
         // Make sure we will never automatically assign locations within the range
         // used for explicit layout(location=x) variables.
-        program.uniformIdCounter = Math.max(program.uniformIdCounter, loc);
+        program.uniformIdCounter = Math.max(program.uniformIdCounter, loc + 1);
       });
     });
 #endif

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -3495,9 +3495,12 @@ var LibraryGL = {
     GLctx.useProgram(program);
     // Record the currently active program so that we can access the uniform
     // mapping table of that program.
-    GLctx.currentProgram = program;
 #if GL_EXPLICIT_UNIFORM_BINDING
-    webglApplyExplicitProgramBindings();
+    if ((GLctx.currentProgram = program)) {
+      webglApplyExplicitProgramBindings();
+    }
+#else
+    GLctx.currentProgram = program;
 #endif
   },
 

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -2045,16 +2045,30 @@ var LibraryGL = {
   // the currently active shader in this GL context.
   $webglGetUniformLocation: function(location) {
     var p = GLctx.currentProgram;
-    var webglLoc = p.uniformLocsById[location];
-    // p.uniformLocsById[location] stores either an integer, or a WebGLUniformLocation.
 
-    // If an integer, we have not yet bound the location, so do it now. The integer value specifies the array index
-    // we should bind to.
-    if (webglLoc >= 0) {
-      p.uniformLocsById[location] = webglLoc = GLctx.getUniformLocation(p, p.uniformArrayNamesById[location] + (webglLoc > 0 ? '[' + webglLoc + ']' : ''));
+#if !GL_TRACK_ERRORS && ASSERTIONS
+    // In -s GL_TRACK_ERRORS=0 build mode do not allow calling glUniform*() without an active GL program.
+    assert(p, 'Attempted to call glUniform*() without an active GL program set! (build with -s GL_TRACK_ERRORS=1 for standards-conformant behavior)');
+#endif
+
+#if GL_TRACK_ERRORS
+    if (p) {
+#endif
+      var webglLoc = p.uniformLocsById[location];
+      // p.uniformLocsById[location] stores either an integer, or a WebGLUniformLocation.
+
+      // If an integer, we have not yet bound the location, so do it now. The integer value specifies the array index
+      // we should bind to.
+      if (webglLoc >= 0) {
+        p.uniformLocsById[location] = webglLoc = GLctx.getUniformLocation(p, p.uniformArrayNamesById[location] + (webglLoc > 0 ? '[' + webglLoc + ']' : ''));
+      }
+      // Else an already cached WebGLUniformLocation, return it.
+      return webglLoc;
+#if GL_TRACK_ERRORS
+    } else {
+      GL.recordError(0x502/*GL_INVALID_OPERATION*/);
     }
-    // Else an already cached WebGLUniformLocation, return it.
-    return webglLoc;
+#endif
   },
 
   glGetUniformLocation__sig: 'iii',
@@ -2077,81 +2091,89 @@ var LibraryGL = {
     assert(!name.includes(' '), 'Uniform names passed to glGetUniformLocation() should not contain spaces! (received "' + name + '")');
 #endif
 
-    program = GL.programs[program];
-    var uniformLocsById = program.uniformLocsById; // Maps GLuint -> WebGLUniformLocation
-    var uniformSizeAndIdsByName = program.uniformSizeAndIdsByName; // Maps name -> [uniform array length, GLuint]
-    var i, j;
-    var arrayIndex = 0;
-    var uniformBaseName = name;
+    if (program = GL.programs[program]) {
+      var uniformLocsById = program.uniformLocsById; // Maps GLuint -> WebGLUniformLocation
+      var uniformSizeAndIdsByName = program.uniformSizeAndIdsByName; // Maps name -> [uniform array length, GLuint]
+      var i, j;
+      var arrayIndex = 0;
+      var uniformBaseName = name;
 
-    // Invariant: when populating integer IDs for uniform locations, we must maintain the precondition that
-    // arrays reside in contiguous addresses, i.e. for a 'vec4 colors[10];', colors[4] must be at location colors[0]+4.
-    // However, user might call glGetUniformLocation(program, "colors") for an array, so we cannot discover based on the user
-    // input arguments whether the uniform we are dealing with is an array. The only way to discover which uniforms are arrays
-    // is to enumerate over all the active uniforms in the program.
-    var leftBrace = getLeftBracePos(name);
+      // Invariant: when populating integer IDs for uniform locations, we must maintain the precondition that
+      // arrays reside in contiguous addresses, i.e. for a 'vec4 colors[10];', colors[4] must be at location colors[0]+4.
+      // However, user might call glGetUniformLocation(program, "colors") for an array, so we cannot discover based on the user
+      // input arguments whether the uniform we are dealing with is an array. The only way to discover which uniforms are arrays
+      // is to enumerate over all the active uniforms in the program.
+      var leftBrace = getLeftBracePos(name);
 
-    // On the first time invocation of glGetUniformLocation on this shader program:
-    // initialize cache data structures and discover which uniforms are arrays.
-    if (!uniformLocsById) {
-      // maps GLint integer locations to WebGLUniformLocations
-      program.uniformLocsById = uniformLocsById = {};
-      // maps integer locations back to uniform name strings, so that we can lazily fetch uniform array locations
-      program.uniformArrayNamesById = {};
+      // On the first time invocation of glGetUniformLocation on this shader program:
+      // initialize cache data structures and discover which uniforms are arrays.
+      if (!uniformLocsById) {
+        // maps GLint integer locations to WebGLUniformLocations
+        program.uniformLocsById = uniformLocsById = {};
+        // maps integer locations back to uniform name strings, so that we can lazily fetch uniform array locations
+        program.uniformArrayNamesById = {};
 
-      for (i = 0; i < GLctx.getProgramParameter(program, 0x8B86/*GL_ACTIVE_UNIFORMS*/); ++i) {
-        var u = GLctx.getActiveUniform(program, i);
-        var nm = u.name;
-        var sz = u.size;
-        var lb = getLeftBracePos(nm);
-        var arrayName = lb > 0 ? nm.slice(0, lb) : nm;
+        for (i = 0; i < GLctx.getProgramParameter(program, 0x8B86/*GL_ACTIVE_UNIFORMS*/); ++i) {
+          var u = GLctx.getActiveUniform(program, i);
+          var nm = u.name;
+          var sz = u.size;
+          var lb = getLeftBracePos(nm);
+          var arrayName = lb > 0 ? nm.slice(0, lb) : nm;
 
-#if GL_EXPLICIT_UNIFORM_LOCATION
-        // Acquire the preset location from the explicit uniform location if one was specified, or
-        // programmatically assign a new one if not.
-        var id = uniformSizeAndIdsByName[arrayName] ? uniformSizeAndIdsByName[arrayName][1] : program.uniformIdCounter;
-        program.uniformIdCounter = Math.max(id + sz, program.uniformIdCounter);
-#else
-        // Assign a new location.
-        var id = program.uniformIdCounter;
-        program.uniformIdCounter += sz;
-#endif
-        // Eagerly get the location of the uniformArray[0] base element.
-        // The remaining indices >0 will be left for lazy evaluation to
-        // improve performance. Those may never be needed to fetch, if the
-        // application fills arrays always in full starting from the first
-        // element of the array.
-        uniformSizeAndIdsByName[arrayName] = [sz, id];
+  #if GL_EXPLICIT_UNIFORM_LOCATION
+          // Acquire the preset location from the explicit uniform location if one was specified, or
+          // programmatically assign a new one if not.
+          var id = uniformSizeAndIdsByName[arrayName] ? uniformSizeAndIdsByName[arrayName][1] : program.uniformIdCounter;
+          program.uniformIdCounter = Math.max(id + sz, program.uniformIdCounter);
+  #else
+          // Assign a new location.
+          var id = program.uniformIdCounter;
+          program.uniformIdCounter += sz;
+  #endif
+          // Eagerly get the location of the uniformArray[0] base element.
+          // The remaining indices >0 will be left for lazy evaluation to
+          // improve performance. Those may never be needed to fetch, if the
+          // application fills arrays always in full starting from the first
+          // element of the array.
+          uniformSizeAndIdsByName[arrayName] = [sz, id];
 
-        // Store placeholder integers in place that highlight that these
-        // >0 index locations are array indices pending population.
-        for(j = 0; j < sz; ++j) {
-          uniformLocsById[id] = j;
-          program.uniformArrayNamesById[id++] = arrayName;
+          // Store placeholder integers in place that highlight that these
+          // >0 index locations are array indices pending population.
+          for(j = 0; j < sz; ++j) {
+            uniformLocsById[id] = j;
+            program.uniformArrayNamesById[id++] = arrayName;
+          }
+        }
+      }
+
+      // If user passed an array accessor "[index]", parse the array index off the accessor.
+      if (leftBrace > 0) {
+  #if GL_ASSERTIONS
+        assert(name.slice(leftBrace + 1).length == 1 || !isNaN(jstoi_q(name.slice(leftBrace + 1))), 'Malformed input parameter name "' + name + '" passed to glGetUniformLocation!');
+  #endif
+        arrayIndex = jstoi_q(name.slice(leftBrace + 1)) >>> 0; // "index]", coerce parseInt(']') with >>>0 to treat "foo[]" as "foo[0]" and foo[-1] as unsigned out-of-bounds.
+        uniformBaseName = name.slice(0, leftBrace);
+      }
+
+      // Have we cached the location of this uniform before?
+      var sizeAndId = uniformSizeAndIdsByName[uniformBaseName]; // A pair [array length, GLint of the uniform location]
+
+      // If an uniform with this name exists, and if its index is within the array limits (if it's even an array),
+      // query the WebGLlocation, or return an existing cached location.
+      if (sizeAndId && arrayIndex < sizeAndId[0]) {
+        arrayIndex += sizeAndId[1]; // Add the base location of the uniform to the array index offset.
+        if ((uniformLocsById[arrayIndex] = uniformLocsById[arrayIndex] || GLctx.getUniformLocation(program, name))) {
+          return arrayIndex;
         }
       }
     }
-
-    // If user passed an array accessor "[index]", parse the array index off the accessor.
-    if (leftBrace > 0) {
-#if GL_ASSERTIONS
-      assert(name.slice(leftBrace + 1).length == 1 || !isNaN(jstoi_q(name.slice(leftBrace + 1))), 'Malformed input parameter name "' + name + '" passed to glGetUniformLocation!');
+#if GL_TRACK_ERRORS
+    else {
+      // N.b. we are currently unable to distinguish between GL program IDs that never existed vs GL program IDs that have been deleted,
+      // so report GL_INVALID_VALUE in both cases.
+      GL.recordError(0x501 /* GL_INVALID_VALUE */);
+    }
 #endif
-      arrayIndex = jstoi_q(name.slice(leftBrace + 1)) >>> 0; // "index]", coerce parseInt(']') with >>>0 to treat "foo[]" as "foo[0]" and foo[-1] as unsigned out-of-bounds.
-      uniformBaseName = name.slice(0, leftBrace);
-    }
-
-    // Have we cached the location of this uniform before?
-    var sizeAndId = uniformSizeAndIdsByName[uniformBaseName]; // A pair [array length, GLint of the uniform location]
-
-    // If an uniform with this name exists, and if its index is within the array limits (if it's even an array),
-    // query the WebGLlocation, or return an existing cached location.
-    if (sizeAndId && arrayIndex < sizeAndId[0]) {
-      arrayIndex += sizeAndId[1]; // Add the base location of the uniform to the array index offset.
-      if ((uniformLocsById[arrayIndex] = uniformLocsById[arrayIndex] || GLctx.getUniformLocation(program, name))) {
-        return arrayIndex;
-      }
-    }
     return -1;
   },
 

--- a/tests/test_c_preprocessor.c
+++ b/tests/test_c_preprocessor.c
@@ -171,6 +171,9 @@ EM_JS(void, test_c_preprocessor, (void), {
 
 	test('#define FOO() bar\nFOO()\n', 'bar\n'); // Test preprocessor macros that do not take in any parameters
 
+	test('#define FOO 1\n#if FOO\n#define BAR this_is_right\n#else\n#define BAR this_is_wrong\n#endif\nBAR',
+	     'this_is_right\n');
+
 	if (numFailed) throw numFailed + ' tests failed!';
 });
 

--- a/tests/test_c_preprocessor.c
+++ b/tests/test_c_preprocessor.c
@@ -168,6 +168,9 @@ EM_JS(void, test_c_preprocessor, (void), {
 	test('#extension GL_EXT_shader_texture_lod : enable\n', '#extension GL_EXT_shader_texture_lod : enable\n'); // Test that GLSL preprocessor macros are preserved
 	test('#version 300 es\n', '#version 300 es\n'); // Test that GLSL preprocessor macros are preserved
 	test('#pragma foo\n', '#pragma foo\n'); // Test that GLSL preprocessor macros are preserved
+
+	test('#define FOO() bar\nFOO()\n', 'bar\n'); // Test preprocessor macros that do not take in any parameters
+
 	if (numFailed) throw numFailed + ' tests failed!';
 });
 

--- a/tests/test_c_preprocessor.c
+++ b/tests/test_c_preprocessor.c
@@ -171,8 +171,9 @@ EM_JS(void, test_c_preprocessor, (void), {
 
 	test('#define FOO() bar\nFOO()\n', 'bar\n'); // Test preprocessor macros that do not take in any parameters
 
-	test('#define FOO 1\n#if FOO\n#define BAR this_is_right\n#else\n#define BAR this_is_wrong\n#endif\nBAR',
-	     'this_is_right\n');
+	test('#define FOO 1\n#if FOO\n#define BAR this_is_right\n#else\n#define BAR this_is_wrong\n#endif\nBAR', 'this_is_right\n'); // Test nested #defines in both sides of an #if-#else block.
+
+	test('\n#define FOO 1\nFOO\n', '\n1\n'); // Test that preprocessor is not confused by an input that starts with a \n
 
 	if (numFailed) throw numFailed + ' tests failed!';
 });

--- a/tests/test_c_preprocessor.c
+++ b/tests/test_c_preprocessor.c
@@ -164,6 +164,10 @@ EM_JS(void, test_c_preprocessor, (void), {
 	test('#define FOO 0\n#undef FOO\n#if defined(FOO)\nA\n#endif', "");  // Test defined() macro after #undef
 
 	test('#define SAMPLE_TEXTURE_2D texture \nvec4 c = SAMPLE_TEXTURE_2D(tex, texCoord);\n', 'vec4 c = texture(tex, texCoord);\n'); // Test expanding a non-macro to a macro-like call site
+
+	test('#extension GL_EXT_shader_texture_lod : enable\n', '#extension GL_EXT_shader_texture_lod : enable\n'); // Test that GLSL preprocessor macros are preserved
+	test('#version 300 es\n', '#version 300 es\n'); // Test that GLSL preprocessor macros are preserved
+	test('#pragma foo\n', '#pragma foo\n'); // Test that GLSL preprocessor macros are preserved
 	if (numFailed) throw numFailed + ' tests failed!';
 });
 

--- a/tests/test_c_preprocessor.c
+++ b/tests/test_c_preprocessor.c
@@ -163,6 +163,7 @@ EM_JS(void, test_c_preprocessor, (void), {
 	test('#define FOO 0\n#if defined(FOO)\nA\n#endif', "A\n");  // Test defined() macro
 	test('#define FOO 0\n#undef FOO\n#if defined(FOO)\nA\n#endif', "");  // Test defined() macro after #undef
 
+	test('#define SAMPLE_TEXTURE_2D texture \nvec4 c = SAMPLE_TEXTURE_2D(tex, texCoord);\n', 'vec4 c = texture(tex, texCoord);\n'); // Test expanding a non-macro to a macro-like call site
 	if (numFailed) throw numFailed + ' tests failed!';
 });
 

--- a/tests/webgl2_ubo_layout_binding.c
+++ b/tests/webgl2_ubo_layout_binding.c
@@ -187,6 +187,10 @@ int main(int argc, char *argv[])
   assert(glGetError());
   assert(!glGetError());
 
+  // Test that glUseProgram(0) succeeds without errors.
+  glUseProgram(0);
+  assert(!glGetError());
+
   printf("Test passed!\n");
 #ifdef REPORT_RESULT
   REPORT_RESULT(1);

--- a/tests/webgl_explicit_uniform_location.c
+++ b/tests/webgl_explicit_uniform_location.c
@@ -134,6 +134,24 @@ int main(int argc, char *argv[])
   glUniform4f(11/*color2*/, 0.2f, 0.2f, 0.3f, 1.f);
   assert(glGetError() == GL_INVALID_OPERATION);
 
+  // Test that explicit and implicit uniform location numberings do not collide
+  GLuint program2 = glCreateProgram();
+  glAttachShader(program2, CompileShader(GL_VERTEX_SHADER,
+    "#version 300 es\n"
+    "uniform mat4 world;\n"
+    "layout(location = 1) uniform mat4 view;\n" // Should get an automatically assigned location that starts numbering after the highest location that is used explicitly (at 2)
+    "layout(location = 0) in vec4 pos;\n"
+    "void main() { gl_Position = view*world*pos; }"));
+  glAttachShader(program2, CompileShader(GL_FRAGMENT_SHADER,
+    "#version 300 es\n"
+    "out highp vec4 outColor;\n"
+    "void main() { outColor = vec4(0,0,0,1); }"));
+  glLinkProgram(program2);
+  assert(glGetError() == GL_NO_ERROR && "Shader program link failed");
+
+  assert(glGetUniformLocation(program2, "world") == 2);
+  assert(glGetUniformLocation(program2, "view") == 1);
+
   printf("Test passed!\n");
 #ifdef REPORT_RESULT
   REPORT_RESULT(1);

--- a/tests/webgl_explicit_uniform_location.c
+++ b/tests/webgl_explicit_uniform_location.c
@@ -63,6 +63,8 @@ int main(int argc, char *argv[])
     "LOCATION(0) out highp vec4 SV_TARGET0; // Make sure MRT output locations don't get removed by preprocessor\n"
     "void main() { SV_TARGET0 = vec4(color,1) + color2 + vec4(colors[0].r, colors[1].g, colors[2].b, 1) + vec4(colors2[0].r, colors2[1].g, colors2[2].b, 1); }");
 
+    "#extension GL_EXT_shader_texture_lod : enable\n" // Make sure we don't get confused by GLSL preprocessor macros
+
   GLuint program = glCreateProgram();
   glAttachShader(program, vs);
   glAttachShader(program, ps);

--- a/tests/webgl_explicit_uniform_location.c
+++ b/tests/webgl_explicit_uniform_location.c
@@ -63,8 +63,6 @@ int main(int argc, char *argv[])
     "LOCATION(0) out highp vec4 SV_TARGET0; // Make sure MRT output locations don't get removed by preprocessor\n"
     "void main() { SV_TARGET0 = vec4(color,1) + color2 + vec4(colors[0].r, colors[1].g, colors[2].b, 1) + vec4(colors2[0].r, colors2[1].g, colors2[2].b, 1); }");
 
-    "#extension GL_EXT_shader_texture_lod : enable\n" // Make sure we don't get confused by GLSL preprocessor macros
-
   GLuint program = glCreateProgram();
   glAttachShader(program, vs);
   glAttachShader(program, ps);

--- a/tests/webgl_explicit_uniform_location.c
+++ b/tests/webgl_explicit_uniform_location.c
@@ -56,9 +56,9 @@ int main(int argc, char *argv[])
     "#version 300 es\n"
     "precision lowp float;\n"
     "#define LOCATION(x) layout(location=x)\n"
-    "LOCATION(8) uniform vec3 color;\n"
-    "LOCATION(11) uniform vec4 color2;\n"
-    "layout(location = 18) uniform vec3 colors[3];\n"
+    "LOCATION(8) uniform highp vec3 color;\n"
+    "LOCATION(11) uniform mediump vec4 color2;\n"
+    "layout(location = 18) uniform lowp vec3 colors[3];\n"
     "layout(location = 24) uniform vec3 colors2[3];\n"
     "LOCATION(0) out highp vec4 SV_TARGET0; // Make sure MRT output locations don't get removed by preprocessor\n"
     "void main() { SV_TARGET0 = vec4(color,1) + color2 + vec4(colors[0].r, colors[1].g, colors[2].b, 1) + vec4(colors2[0].r, colors2[1].g, colors2[2].b, 1); }");

--- a/tests/webgl_explicit_uniform_location.c
+++ b/tests/webgl_explicit_uniform_location.c
@@ -36,6 +36,7 @@ int main(int argc, char *argv[])
   emscripten_webgl_init_context_attributes(&attr);
   attr.majorVersion = 2;
   EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
+  assert(ctx);
   emscripten_webgl_make_context_current(ctx);
 
   GLint maxUniformLocations = 0;
@@ -119,6 +120,19 @@ int main(int argc, char *argv[])
   assert(data[1] == 178);
   assert(data[2] == 204);
   assert(data[3] == 255);
+
+  // Test that setting program zero is allowed
+  glUseProgram(0);
+  assert(!glGetError());
+
+  // Test that calling glGetUniformLocation() without an active program should report a GL_INVALID_VALUE.
+  glGetUniformLocation(0, "colors[0]");
+  assert(glGetError() == GL_INVALID_VALUE);
+
+  // Test that calling glUniform*() without an active program should report a GL_INVALID_OPERATION.
+  assert(!glGetError());
+  glUniform4f(11/*color2*/, 0.2f, 0.2f, 0.3f, 1.f);
+  assert(glGetError() == GL_INVALID_OPERATION);
 
   printf("Test passed!\n");
 #ifdef REPORT_RESULT


### PR DESCRIPTION
Fix C preprocessor library on construct
```js
#define SAMPLE_TEXTURE_2D texture
vec4 c = SAMPLE_TEXTURE_2D(tex, texCoord);
```
where a non-macro #define is expanded to a destination string that looks like a macro.

Fix `glGetUniformLocation(program, ...)` to return GL error GL_INVALID_VALUE when called on a nonexisting program.

Fix `glUniform*()` to produce GL_INVALID_OPERATION when called on a nonexisting bound program. (#14079)

Fix specifying `#extension GL_EXT_shader_texture_lod : enable` in GLSL shaders when building with `-s GL_EXPLICIT_UNIFORM_LOCATION=1` or `-s GL_EXPLICIT_UNIFORM_BINDING=1`.

Fix calling `glUseProgram(0)` when using `-s GL_EXPLICIT_UNIFORM_BINDING=1`.

Fix nested parsing issue in C preprocessor where `#define` and `#undef` statements would be incorrectly processed even in the excluded out blocks.

Fix a preprocessing issue when the input starts with a newline `\n`.

Fix an issue where implicit and explicit uniform locations could stomp on each other due to a off-by-one issue in assigning IDs.

Fix an issue in uniform location handling that explicit lowp, mediump and highp qualifiers were not parsed properly.

Add tests.
