### PR TITLE
Fix LLD_REPORT_UNDEFINED in with dynamic linking

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -153,6 +153,9 @@ function JSify(functionsOnly) {
       var noExport = false;
 
       if (!LibraryManager.library.hasOwnProperty(ident)) {
+        if (ONLY_CALC_JS_SYMBOLS) {
+          return;
+        }
         if (!isDefined(ident)) {
           var msg = 'undefined symbol: ' + ident;
           if (dependent) msg += ' (referenced by ' + dependent + ')';

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3676,6 +3676,11 @@ ok
     self.do_basic_dylink_test()
 
   @needs_dylink
+  def test_dylink_basics_lld_report_undefined(self):
+    self.set_setting('LLD_REPORT_UNDEFINED')
+    self.do_basic_dylink_test()
+
+  @needs_dylink
   def test_dylink_no_export(self):
     self.set_setting('NO_DECLARE_ASM_MODULE_EXPORTS')
     self.do_basic_dylink_test()


### PR DESCRIPTION
The fix here is when we run the js compiler in pre-link in
ONLY_CALC_JS_SYMBOLS mode we don't want to be reporting undefined
symbols at that point.  Since the main module has not been built yet we
don't know what symbols it will provide so reporting undefined symbols
here doesn't many any sense.