### PR TITLE
Add EXPORT_IF_DEFINED internal setting for soft exports

### DIFF
--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -29,6 +29,9 @@ var SIDE_MODULE_EXPORTS = [];
 // module (or other side modules) will need to provide.
 var SIDE_MODULE_IMPORTS = [];
 
+// Like EXPORTED_FUNCTIONS, but will not error if symbol is missing
+var EXPORT_IF_DEFINED = [];
+
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4560,6 +4560,9 @@ res64 - external 64\n''', header='''
     # in the another module.
     # Each module will define its own copy of certain COMDAT symbols such as
     # each classs's typeinfo, but at runtime they should both use the same one.
+    # Use LLD_REPORT_UNDEFINED to test that it works as expected with weak/COMDAT
+    # symbols.
+    self.set_setting('LLD_REPORT_UNDEFINED')
     header = '''
     #include <cstddef>
 
@@ -8370,6 +8373,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args.append('-Wno-experimental')
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_PTHREADS')
+    self.set_setting('LLD_REPORT_UNDEFINED')
     self.set_setting('PTHREAD_POOL_SIZE=2')
     main = test_file('core', 'pthread', 'test_pthread_dylink.c')
     side = test_file('core', 'pthread', 'test_pthread_dylink_side.c')

--- a/tools/building.py
+++ b/tools/building.py
@@ -390,6 +390,9 @@ def lld_flags_for_executable(external_symbols):
     for export in c_exports:
       cmd += ['--export', export]
 
+    for export in settings.EXPORT_IF_DEFINED:
+      cmd.append('--export-if-defined=' + export)
+
   if settings.RELOCATABLE:
     cmd.append('--experimental-pic')
     if settings.SIDE_MODULE:
@@ -407,8 +410,6 @@ def lld_flags_for_executable(external_symbols):
     # Export these two section start symbols so that we can extact the string
     # data that they contain.
     cmd += [
-      '--export-if-defined', '__start_em_asm',
-      '--export-if-defined', '__stop_em_asm',
       '-z', 'stack-size=%s' % settings.TOTAL_STACK,
       '--initial-memory=%d' % settings.INITIAL_MEMORY,
     ]


### PR DESCRIPTION
When a side module both imports and exports a symbol (this can happen
when it needs that address of a functions or when a symbol is weakly
defined) we want to export those symbols from the main module if and
only if they are defined, but we do want want to generate error when they
are missing.

Normally this isn't a problem because we pass `--allow-undefined` but
after this change we can use `LLD_REPORT_UNDEFINED` in more dynamic linking
builds.