### PR TITLE
Add basic dylink + pthread + TLS test. NFC

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4631,6 +4631,42 @@ res64 - external 64\n''', header='''
     side = test_file('core', 'test_dylink_weak_side.c')
     self.dylink_testf(main, side, force_c=True, need_reverse=False)
 
+  @node_pthreads
+  @needs_dylink
+  def test_dylink_tls(self):
+    # We currently can't export TLS symbols from module since we don't have
+    # and ABI for signaling which exports are TLS and which are regular
+    # data exports.
+
+    # TODO(sbc): Add tests that depend on importing/exported TLS symbols
+    # once we figure out how to do that.
+    create_file('main.c', r'''
+      #include <stdio.h>
+
+      _Thread_local int foo = 10;
+
+      void sidey();
+
+      int main(int argc, char const *argv[]) {
+        printf("main TLS: %d\n", foo);
+        sidey();
+        return 0;
+      }
+    ''')
+    create_file('side.c', r'''
+      #include <stdio.h>
+
+      _Thread_local int bar = 11;
+
+      void sidey() {
+        printf("side TLS: %d\n", bar);
+      }
+    ''')
+    self.emcc_args.append('-Wno-experimental')
+    self.dylink_testf('main.c', 'side.c',
+                      expected='main TLS: 10\nside TLS: 11\n',
+                      need_reverse=False)
+
   def test_random(self):
     src = r'''#include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
We don't currently support importing or exporting TLS symbols between
modules.  This test doesn't attempt to do that it just uses TLS locally
in both the main and the side module.

See https://reviews.llvm.org/D102044
See #14120