### PR TITLE
Emit bundler-friendly URL locators

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2543,12 +2543,11 @@ def phase_final_emitting(options, target, wasm_target, memfile):
   # Unmangle previously mangled `import.meta` references in both main code and libraries.
   # See also: `preprocess` in parseTools.js.
   if settings.EXPORT_ES6 and settings.USE_ES6_IMPORT_META:
-    with open(final_js, 'r+') as f:
-      src = f.read()
-      src = src.replace('EMSCRIPTEN$IMPORT$META', 'import.meta')
-      f.seek(0)
-      f.write(src)
-      f.truncate()
+    src = open(final_js).read()
+    final_js += '.esmeta.js'
+    with open(final_js, 'w') as f:
+      f.write(src.replace('EMSCRIPTEN$IMPORT$META', 'import.meta'))
+    save_intermediate('es6-import-meta')
 
   # Apply pre and postjs files
   if options.extern_pre_js or options.extern_post_js:

--- a/emcc.py
+++ b/emcc.py
@@ -1206,14 +1206,6 @@ def phase_setup(state):
   else:
     target = 'a.out.js'
 
-  if options.oformat in (OFormat.JS, OFormat.MJS):
-    js_target = target
-  else:
-    js_target = get_secondary_target(target, '.js')
-  settings.TARGET_JS_NAME = js_target
-
-  settings.TARGET_BASENAME = unsuffixed_basename(target)
-
   if settings.EXTRA_EXPORTED_RUNTIME_METHODS:
     diagnostics.warning('deprecated', 'EXTRA_EXPORTED_RUNTIME_METHODS is deprecated, please use EXPORTED_RUNTIME_METHODS instead')
     settings.EXPORTED_RUNTIME_METHODS += settings.EXTRA_EXPORTED_RUNTIME_METHODS
@@ -2404,6 +2396,14 @@ def phase_post_link(options, in_wasm, wasm_target, target):
 
   if options.oformat != OFormat.WASM:
     final_js = in_temp(target_basename + '.js')
+
+  settings.TARGET_BASENAME = unsuffixed_basename(target)
+
+  if options.oformat in (OFormat.JS, OFormat.MJS):
+    js_target = target
+  else:
+    js_target = get_secondary_target(target, '.js')
+  settings.TARGET_JS_NAME = js_target
 
   if settings.MEM_INIT_IN_WASM:
     memfile = None

--- a/emcc.py
+++ b/emcc.py
@@ -1206,8 +1206,13 @@ def phase_setup(state):
   else:
     target = 'a.out.js'
 
-  settings.TARGET_BASENAME_WITH_EXT = os.path.basename(target)
-  settings.TARGET_BASENAME = unsuffixed(settings.TARGET_BASENAME_WITH_EXT)
+  if options.oformat in (OFormat.JS, OFormat.MJS):
+    js_target = target
+  else:
+    js_target = get_secondary_target(target, '.js')
+  settings.TARGET_JS_NAME = js_target
+
+  settings.TARGET_BASENAME = unsuffixed_basename(target)
 
   if settings.EXTRA_EXPORTED_RUNTIME_METHODS:
     diagnostics.warning('deprecated', 'EXTRA_EXPORTED_RUNTIME_METHODS is deprecated, please use EXPORTED_RUNTIME_METHODS instead')
@@ -2558,10 +2563,7 @@ def phase_final_emitting(options, target, wasm_target, memfile):
 
   shared.JS.handle_license(final_js)
 
-  if options.oformat in (OFormat.JS, OFormat.MJS):
-    js_target = target
-  else:
-    js_target = get_secondary_target(target, '.js')
+  js_target = settings.TARGET_JS_NAME
 
   # The JS is now final. Move it to its final location
   move_file(final_js, js_target)

--- a/emcc.py
+++ b/emcc.py
@@ -2400,10 +2400,9 @@ def phase_post_link(options, in_wasm, wasm_target, target):
   settings.TARGET_BASENAME = unsuffixed_basename(target)
 
   if options.oformat in (OFormat.JS, OFormat.MJS):
-    js_target = target
+    settings.TARGET_JS_NAME = target
   else:
-    js_target = get_secondary_target(target, '.js')
-  settings.TARGET_JS_NAME = js_target
+    settings.TARGET_JS_NAME = get_secondary_target(target, '.js')
 
   if settings.MEM_INIT_IN_WASM:
     memfile = None

--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -11,6 +11,9 @@
  * The closure_compiler() method in tools/shared.py refers to this file when calling closure.
  */
 
+// Special placeholder for `import.meta`.
+var EMSCRIPTEN$IMPORT$META;
+
 // Closure externs used by library_sockfs.js
 
 /**

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -33,6 +33,14 @@ function processMacros(text) {
 // Param filenameHint can be passed as a description to identify the file that is being processed, used
 // to locate errors for reporting and for html files to stop expansion between <style> and </style>.
 function preprocess(text, filenameHint) {
+  if (EXPORT_ES6 && USE_ES6_IMPORT_META) {
+    // `eval`, Terser and Closure don't support module syntax; to allow it,
+    // we need to temporarily replace `import.meta` usages with placeholders
+    // during preprocess phase, and back after all the other ops.
+    // See also: `phase_final_emitting` in emcc.py.
+    text = text.replace(/\bimport\.meta\b/g, 'EMSCRIPTEN$IMPORT$META');
+  }
+
   const IGNORE = 0;
   const SHOW = 1;
   // This state is entered after we have shown one of the block of an if/elif/else sequence.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -746,10 +746,15 @@ function instrumentWasmTableWithAbort() {
 }
 #endif
 
+#if EXPORT_ES6
+// Use bundler-friendly `new URL(..., import.meta.url)` pattern; works in browsers too.
+var wasmBinaryFile = new URL('{{{ WASM_BINARY_FILE }}}', import.meta.url).toString();
+#else
 var wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
 if (!isDataURI(wasmBinaryFile)) {
   wasmBinaryFile = locateFile(wasmBinaryFile);
 }
+#endif
 
 function getBinary(file) {
   try {
@@ -809,7 +814,7 @@ function getBinaryPromise() {
     }
 #endif
   }
-    
+
   // Otherwise, getBinary should be able to get it synchronously
   return Promise.resolve().then(function() { return getBinary(wasmBinaryFile); });
 }

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -32,8 +32,8 @@ var SIDE_MODULE_IMPORTS = [];
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 
-// stores the base name of the output file with extension (TARGET_BASENAME.js or TARGET_BASENAME.mjs)
-var TARGET_BASENAME_WITH_EXT = '';
+// stores the base name (with extension) of the output JS file
+var TARGET_JS_NAME = '';
 
 // Indicates that the syscalls (which we see statically) indicate that they need
 // full filesystem support. Otherwise, when just a small subset are used, we can

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -32,6 +32,9 @@ var SIDE_MODULE_IMPORTS = [];
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 
+// stores the base name of the output file with extension (TARGET_BASENAME.js or TARGET_BASENAME.mjs)
+var TARGET_BASENAME_WITH_EXT = '';
+
 // Indicates that the syscalls (which we see statically) indicate that they need
 // full filesystem support. Otherwise, when just a small subset are used, we can
 // get away without including the full filesystem - in particular, if open() is

--- a/src/worker.js
+++ b/src/worker.js
@@ -168,7 +168,7 @@ self.onmessage = function(e) {
 #endif
 
 #if MODULARIZE && EXPORT_ES6
-      (e.data.urlOrBlob ? import(e.data.urlOrBlob) : import('./{{{ TARGET_BASENAME_WITH_EXT }}}')).then(function({{{ EXPORT_NAME }}}) {
+      (e.data.urlOrBlob ? import(e.data.urlOrBlob) : import('./{{{ TARGET_JS_NAME }}}')).then(function({{{ EXPORT_NAME }}}) {
         return {{{ EXPORT_NAME }}}.default(Module);
       }).then(function(instance) {
         Module = instance;

--- a/src/worker.js
+++ b/src/worker.js
@@ -168,7 +168,7 @@ self.onmessage = function(e) {
 #endif
 
 #if MODULARIZE && EXPORT_ES6
-      import(e.data.urlOrBlob).then(function({{{ EXPORT_NAME }}}) {
+      (e.data.urlOrBlob ? import(e.data.urlOrBlob) : import('./{{{ TARGET_BASENAME_WITH_EXT }}}')).then(function({{{ EXPORT_NAME }}}) {
         return {{{ EXPORT_NAME }}}.default(Module);
       }).then(function(instance) {
         Module = instance;


### PR DESCRIPTION
This PR changes loading of main Wasm binary as well as helper Worker used by PThread integration to use a URL expression that can be both used directly by browsers as well as statically detected by bundlers like Webpack.

The main caveats are:
1. Emscripten is very configurable, so some of the new conditions might look odd but are necessary to keep backward compatibility and allow overriding bundler-friendly URL with a custom one during runtime.
2. None of Closure, our fork of Terser, or even `eval` (which is used by Emscripten's JS library preprocessing) support `import.meta` expressions without more work. While Closure seems to have _just_ implemented such support, and it wouldn't be too hard to add it to our Terser too, `eval` usage would still require a string replacement before execution (or complete revamp).
  To keep implementation simple, for now I went with just string replacement that covers all tools - this way, we replace `import.meta` -> `EMSCRIPTEN$IMPORT$META` only once when JS is added before any of this tooling is executed, and then replace back after everything is done right before the final emit.
  We might want to revisit this in future, but for now this works well and covers all the tooling incompatibilities together.
3. This won't work in Node.js, since it's not compatible with `EXPORT_ES6` in general yet.
4. I've only updated places for loading main Wasm binary and PThread code. This should cover majority of use-cases, but other external files like side modules, proxy-to-pthread, proxy-to-worker, external memory loading etc. are not covered by this PR and need to be updated separately if someone wants them to work with bundlers out of the box too.

Fixes #13571.