### PR TITLE
Relax custom EXPORT_NAME requirement for EXPORT_ES6

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1886,7 +1886,7 @@ def phase_setup(state):
       include_and_export('keepRuntimeAlive')
 
     if settings.MODULARIZE:
-      if settings.EXPORT_NAME == 'Module':
+      if not settings.EXPORT_ES6 and settings.EXPORT_NAME == 'Module':
         exit_with_error('pthreads + MODULARIZE currently require you to set -s EXPORT_NAME=Something (see settings.js) to Something != Module, so that the .worker.js file can work')
 
       # MODULARIZE+USE_PTHREADS mode requires extra exports out to Module so that worker.js

--- a/src/worker.js
+++ b/src/worker.js
@@ -168,8 +168,8 @@ self.onmessage = function(e) {
 #endif
 
 #if MODULARIZE && EXPORT_ES6
-      import(e.data.urlOrBlob).then(function({{{ EXPORT_NAME }}}) {
-        return {{{ EXPORT_NAME }}}.default(Module);
+      import(e.data.urlOrBlob).then(function(exports) {
+        return exports.default(Module);
       }).then(function(instance) {
         Module = instance;
         moduleLoaded();

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -196,10 +196,9 @@ class other(RunnerCore):
 
   def test_emcc_output_worker_mjs(self):
     self.run_process([EMCC, '-o', 'hello_world.mjs', '-pthread', '-O1',
-                      test_file('hello_world.c'),
-                      '-s', 'EXPORT_NAME=FooModule'])
+                      test_file('hello_world.c')])
     with open('hello_world.mjs') as f:
-      self.assertContained('export default FooModule;', f.read())
+      self.assertContained('export default Module;', f.read())
     with open('hello_world.worker.js') as f:
       self.assertContained('import(', f.read())
 


### PR DESCRIPTION
Unlike regular MODULARIZE, EXPORT_ES6 doesn't rely on global scope for names, and instead uses real modules, so there's no reason for it to require custom EXPORT_NAME override.