### PR TITLE
Temporarily disable linker string merging. NFC

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -360,6 +360,11 @@ def lld_flags_for_executable(external_symbols):
   else:
     cmd.append('--allow-undefined')
 
+  # Disable string merging in the linker, at least until we there is
+  # an upstream fix for https://bugs.llvm.org/show_bug.cgi?id=50291.
+  # (-O level only effect string merging in wasm-ld today).
+  cmd.append('-O0')
+
   if settings.IMPORTED_MEMORY:
     cmd.append('--import-memory')
 


### PR DESCRIPTION
The llvm roller is currently blocked due to
https://bugs.llvm.org/show_bug.cgi?id=50291.

This change disables linker string merging, thus allowing the llvm
roller to continue.  In the future re-enable and let emscripten
CI verify any llvm-side fix.