### PR TITLE
Fix for nested dirs in bundler-friendly URLs

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2412,9 +2412,11 @@ def phase_post_link(options, in_wasm, wasm_target, target):
   settings.TARGET_BASENAME = unsuffixed_basename(target)
 
   if options.oformat in (OFormat.JS, OFormat.MJS):
-    settings.TARGET_JS_NAME = target
+    settings.TARGET_JS_PATH = target
   else:
-    settings.TARGET_JS_NAME = get_secondary_target(target, '.js')
+    settings.TARGET_JS_PATH = get_secondary_target(target, '.js')
+
+  settings.TARGET_JS_NAME = os.path.basename(settings.TARGET_JS_PATH)
 
   if settings.MEM_INIT_IN_WASM:
     memfile = None
@@ -2573,7 +2575,7 @@ def phase_final_emitting(options, target, wasm_target, memfile):
 
   shared.JS.handle_license(final_js)
 
-  js_target = settings.TARGET_JS_NAME
+  js_target = settings.TARGET_JS_PATH
 
   # The JS is now final. Move it to its final location
   move_file(final_js, js_target)

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -35,6 +35,9 @@ var EXPORT_IF_DEFINED = [];
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';
 
+// stores the relative path of the output JS file
+var TARGET_JS_PATH = '';
+
 // stores the base name (with extension) of the output JS file
 var TARGET_JS_NAME = '';
 


### PR DESCRIPTION
During review of #14135 some of the changes made TARGET_JS_NAME to be a relative path instead of a basename.

This way, when someone specified `-pthread -o out.js`, it worked fine, but if someone used `-pthread -o nested/dir/out.js` then the `nested/dir/out.worker.js` would have a reference to `./nested/dir/out.js` not to `./out.js` as it should for a file alongside it.