### PR TITLE
Add diagnostics for slow emulation paths (xmmintrin.h)

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -110,6 +110,8 @@ The following legend is used to highlight the expected performance of various in
 
 Certain intrinsics in the table below are marked "virtual". This means that there does not actually exist a native x86 SSE instruction set opcode to implement them, but native compilers offer the function as a convenience. Different compilers might generate a different instruction sequence for these.
 
+In addition to consulting the tables below, you can turn on diagnostics for slow, emulated functions by defining `__EMSCRIPTEN_SIMD_COMPAT_SLOW`. This will print out warnings if you attempt to use any of the slow paths (corresponding to ❌ or 💣 in the legend).
+
 .. list-table:: x86 SSE intrinsics available via #include <xmmintrin.h>
    :widths: 20 30
    :header-rows: 1

--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -110,7 +110,7 @@ The following legend is used to highlight the expected performance of various in
 
 Certain intrinsics in the table below are marked "virtual". This means that there does not actually exist a native x86 SSE instruction set opcode to implement them, but native compilers offer the function as a convenience. Different compilers might generate a different instruction sequence for these.
 
-In addition to consulting the tables below, you can turn on diagnostics for slow, emulated functions by defining `__EMSCRIPTEN_SIMD_COMPAT_SLOW`. This will print out warnings if you attempt to use any of the slow paths (corresponding to ❌ or 💣 in the legend).
+In addition to consulting the tables below, you can turn on diagnostics for slow, emulated functions by defining the macro `WASM_SIMD_COMPAT_SLOW`. This will print out warnings if you attempt to use any of the slow paths (corresponding to ❌ or 💣 in the legend).
 
 .. list-table:: x86 SSE intrinsics available via #include <xmmintrin.h>
    :widths: 20 30

--- a/system/include/compat/xmmintrin.h
+++ b/system/include/compat/xmmintrin.h
@@ -16,6 +16,12 @@
 #error "SSE instruction set not enabled"
 #endif
 
+#ifdef __EMSCRIPTEN_SIMD_COMPAT_SLOW
+#define DIAGNOSE_SLOW diagnose_if(1, "Instruction emulated via slow path.", "warning")
+#else
+#define DIAGNOSE_SLOW
+#endif
+
 // Emscripten SIMD support doesn't support MMX/float32x2/__m64.
 // However, we support loading and storing 2-vectors, so
 // recognize the type at least.
@@ -74,13 +80,13 @@ _mm_load_ps(const float *__p)
   return *(__m128*)__p;
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_loadl_pi(__m128 __a, const void /*__m64*/ *__p)
 {
   return (__m128)__f32x4_shuffle(wasm_f32x4_make(((float*)__p)[0], ((float*)__p)[1], 0.f, 0.f), __a, 0, 1, 6, 7);
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_loadh_pi(__m128 __a, const void /*__m64*/ *__p)
 {
   return (__m128)__f32x4_shuffle(__a, wasm_f32x4_make(((float*)__p)[0], ((float*)__p)[1], 0.f, 0.f), 0, 1, 4, 5);
@@ -106,13 +112,13 @@ _mm_load_ps1(const float *__p)
 }
 #define _mm_load1_ps _mm_load_ps1
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_load_ss(const float *__p)
 {
   return (__m128)wasm_f32x4_make(*__p, 0.f, 0.f, 0.f);
 }
 
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
+static __inline__ void __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_storel_pi(__m64 *__p, __m128 __a)
 {
   *__p = (__m64) { __a[0], __a[1] };
@@ -121,7 +127,7 @@ _mm_storel_pi(__m64 *__p, __m128 __a)
 static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
 _mm_movehl_ps(__m128 __a, __m128 __b);
 
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
+static __inline__ void __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_storeh_pi(__m64 *__p, __m128 __a)
 {
   _mm_storel_pi(__p, _mm_movehl_ps(__a, __a));
@@ -284,13 +290,13 @@ _mm_max_ss(__m128 __a, __m128 __b)
   return _mm_move_ss(__a, _mm_max_ps(__a, __b));
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_rcp_ps(__m128 __a)
 {
     return (__m128)wasm_f32x4_div((v128_t)_mm_set1_ps(1.0f), (v128_t)__a);
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_rcp_ss(__m128 __a)
 {
   return _mm_move_ss(__a, _mm_rcp_ps(__a));
@@ -416,24 +422,24 @@ _mm_cmpgt_ss(__m128 __a, __m128 __b)
   return _mm_move_ss(__a, _mm_cmpgt_ps(__a, __b));
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__)) _mm_cmpord_ps(__m128 __a, __m128 __b)
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW)) _mm_cmpord_ps(__m128 __a, __m128 __b)
 {
   return (__m128)wasm_v128_and(wasm_f32x4_eq((v128_t)__a, (v128_t)__a),
                                wasm_f32x4_eq((v128_t)__b, (v128_t)__b));
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__)) _mm_cmpord_ss(__m128 __a, __m128 __b)
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW)) _mm_cmpord_ss(__m128 __a, __m128 __b)
 {
   return _mm_move_ss(__a, _mm_cmpord_ps(__a, __b));
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__)) _mm_cmpunord_ps(__m128 __a, __m128 __b)
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW)) _mm_cmpunord_ps(__m128 __a, __m128 __b)
 {
   return (__m128)wasm_v128_or(wasm_f32x4_ne((v128_t)__a, (v128_t)__a),
                               wasm_f32x4_ne((v128_t)__b, (v128_t)__b));
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__)) _mm_cmpunord_ss(__m128 __a, __m128 __b)
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW)) _mm_cmpunord_ss(__m128 __a, __m128 __b)
 {
   return _mm_move_ss(__a, _mm_cmpunord_ps(__a, __b));
 }
@@ -522,79 +528,79 @@ _mm_cmpnlt_ss(__m128 __a, __m128 __b)
   return _mm_move_ss(__a, _mm_cmpnlt_ps(__a, __b));
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_comieq_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) == wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_comige_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) >= wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_comigt_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) > wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_comile_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) <= wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_comilt_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) < wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_comineq_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) != wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_ucomieq_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) == wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_ucomige_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) >= wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_ucomigt_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) > wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_ucomile_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) <= wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_ucomilt_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) < wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_ucomineq_ss(__m128 __a, __m128 __b)
 {
   return wasm_f32x4_extract_lane(__a, 0) != wasm_f32x4_extract_lane(__b, 0);
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_cvtsi32_ss(__m128 __a, int __b)
 {
   __f32x4 __v = (__f32x4)__a;
@@ -603,7 +609,7 @@ _mm_cvtsi32_ss(__m128 __a, int __b)
 }
 #define _mm_cvt_si2ss _mm_cvtsi32_ss
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__)) _mm_cvtss_si32(__m128 __a)
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW)) _mm_cvtss_si32(__m128 __a)
 {
   int x = lrint(((__f32x4)__a)[0]);
   if (x != 0 || fabsf(((__f32x4)__a)[0]) < 2.f)
@@ -613,7 +619,7 @@ static __inline__ int __attribute__((__always_inline__, __nodebug__)) _mm_cvtss_
 }
 #define _mm_cvt_ss2si _mm_cvtss_si32
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__)) _mm_cvttss_si32(__m128 __a)
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW)) _mm_cvttss_si32(__m128 __a)
 {
   int x = lrint(((__f32x4)__a)[0]);
   if (x != 0 || fabsf(((__f32x4)__a)[0]) < 2.f)
@@ -623,7 +629,7 @@ static __inline__ int __attribute__((__always_inline__, __nodebug__)) _mm_cvttss
 }
 #define _mm_cvtt_ss2si _mm_cvttss_si32
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_cvtsi64_ss(__m128 __a, long long __b)
 {
   __f32x4 __v = (__f32x4)__a;
@@ -631,7 +637,7 @@ _mm_cvtsi64_ss(__m128 __a, long long __b)
   return (__m128)__v;
 }
 
-static __inline__ long long __attribute__((__always_inline__, __nodebug__))
+static __inline__ long long __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_cvtss_si64(__m128 __a)
 {
   if (isnan(((__f32x4)__a)[0]) || isinf(((__f32x4)__a)[0])) return 0x8000000000000000LL;
@@ -642,7 +648,7 @@ _mm_cvtss_si64(__m128 __a)
     return 0x8000000000000000LL;
 }
 
-static __inline__ long long __attribute__((__always_inline__, __nodebug__))
+static __inline__ long long __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_cvttss_si64(__m128 __a)
 {
   if (isnan(((__f32x4)__a)[0]) || isinf(((__f32x4)__a)[0])) return 0x8000000000000000LL;

--- a/system/include/compat/xmmintrin.h
+++ b/system/include/compat/xmmintrin.h
@@ -16,7 +16,7 @@
 #error "SSE instruction set not enabled"
 #endif
 
-#ifdef __EMSCRIPTEN_SIMD_COMPAT_SLOW
+#ifdef WASM_SIMD_COMPAT_SLOW
 #define DIAGNOSE_SLOW diagnose_if(1, "Instruction emulated via slow path.", "warning")
 #else
 #define DIAGNOSE_SLOW

--- a/tests/sse/test_sse_diagnostic.cpp
+++ b/tests/sse/test_sse_diagnostic.cpp
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <wasm_simd128.h>
+#include <xmmintrin.h>
+
+int main() {
+  __m128 a = _mm_set_ps(1.0f, 2.0f, 3.0f, 4.0f);
+  __m128 b = _mm_rcp_ps(a);
+  return (int)wasm_f32x4_extract_lane(b, 0);
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6004,6 +6004,17 @@ return malloc(size);
     self.maybe_closure()
     self.do_runf(src, native_result)
 
+  @wasm_simd
+  def test_sse_diagnostics(self):
+    self.emcc_args.remove('-Werror')
+    src = test_file('sse', 'test_sse1.cpp')
+
+    p = self.run_process(
+            [shared.EMXX, src, '-msse', '-D__EMSCRIPTEN_SIMD_COMPAT_SLOW'] +
+                self.get_emcc_args(main_file=True),
+            capture_output=True)
+    self.assertContained('Instruction emulated via slow path.', p.stderr)
+
   @no_asan('call stack exceeded on some versions of node')
   def test_gcc_unmangler(self):
     self.emcc_args += ['-I' + test_file('third_party', 'libiberty')]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6010,7 +6010,7 @@ return malloc(size);
     src = test_file('sse', 'test_sse_diagnostic.cpp')
 
     p = self.run_process(
-      [shared.EMXX, src, '-msse', '-D__EMSCRIPTEN_SIMD_COMPAT_SLOW'] + self.get_emcc_args(main_file=True),
+      [shared.EMXX, src, '-msse', '-DWASM_SIMD_COMPAT_SLOW'] + self.get_emcc_args(main_file=True),
       stderr=PIPE)
     self.assertContained('Instruction emulated via slow path.', p.stderr)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6007,7 +6007,7 @@ return malloc(size);
   @wasm_simd
   def test_sse_diagnostics(self):
     self.emcc_args.remove('-Werror')
-    src = test_file('sse', 'test_sse1.cpp')
+    src = test_file('sse', 'test_sse_diagnostic.cpp')
 
     p = self.run_process(
       [shared.EMXX, src, '-msse', '-D__EMSCRIPTEN_SIMD_COMPAT_SLOW'] + self.get_emcc_args(main_file=True),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6010,7 +6010,7 @@ return malloc(size);
     src = test_file('sse', 'test_sse_diagnostic.cpp')
 
     p = self.run_process(
-      [shared.EMXX, src, '-msse', '-DWASM_SIMD_COMPAT_SLOW'] + self.get_emcc_args(main_file=True),
+      [shared.EMXX, src, '-msse', '-DWASM_SIMD_COMPAT_SLOW'] + self.get_emcc_args(),
       stderr=PIPE)
     self.assertContained('Instruction emulated via slow path.', p.stderr)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6010,9 +6010,9 @@ return malloc(size);
     src = test_file('sse', 'test_sse1.cpp')
 
     p = self.run_process(
-            [shared.EMXX, src, '-msse', '-D__EMSCRIPTEN_SIMD_COMPAT_SLOW'] +
-                self.get_emcc_args(main_file=True),
-            capture_output=True)
+      [shared.EMXX, src, '-msse', '-D__EMSCRIPTEN_SIMD_COMPAT_SLOW'] +
+      self.get_emcc_args(main_file=True),
+      capture_output=True)
     self.assertContained('Instruction emulated via slow path.', p.stderr)
 
   @no_asan('call stack exceeded on some versions of node')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6010,9 +6010,8 @@ return malloc(size);
     src = test_file('sse', 'test_sse1.cpp')
 
     p = self.run_process(
-      [shared.EMXX, src, '-msse', '-D__EMSCRIPTEN_SIMD_COMPAT_SLOW'] +
-      self.get_emcc_args(main_file=True),
-      capture_output=True)
+      [shared.EMXX, src, '-msse', '-D__EMSCRIPTEN_SIMD_COMPAT_SLOW'] + self.get_emcc_args(main_file=True),
+      stderr=PIPE)
     self.assertContained('Instruction emulated via slow path.', p.stderr)
 
   @no_asan('call stack exceeded on some versions of node')


### PR DESCRIPTION
From the list in
https://emscripten.org/docs/porting/simd.html#compiling-simd-code-targeting-x86-sse-instruction-set,
basically all the instructions with red crosses are marked as slow
(except _MM_GET_EXCEPTION_STATE which doesn't do anything).

To enable diagnostics, define __EMSCRIPTEN_SIMD_COMPAT_SLOW.

Right now only for xmmintrin.h, other headers will be modified in future
patches.

Partially addresses #12871.