### PR TITLE
Add support for EXPORT_ES6 + `-o .html`

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -172,6 +172,9 @@ class browser(BrowserCore):
     self.btest('hello_world_sdl.cpp', reference='htmltest.png', args=['-lSDL', '-lGL'])
     self.btest('hello_world_sdl.cpp', reference='htmltest.png', args=['-s', 'USE_SDL', '-lGL']) # is the default anyhow
 
+  def test_sdl1_es6(self):
+    self.btest('hello_world_sdl.cpp', reference='htmltest.png', args=['-s', 'USE_SDL', '-lGL', '-s', 'EXPORT_ES6'])
+
   # Deliberately named as test_zzz_* to make this test the last one
   # as this test may take the focus away from the main test window
   # by opening a new window and possibly not closing it.


### PR DESCRIPTION
This PR allows using `-s EXPORT_ES6 -o something.html` where it was previously forbidden. This way, user gets default HTML shell for testing their app alongside regular ES6 JS output.

This PR is a bit similar to #14139 in that it leverages the fact that, when using proper ES modules, we don't pollute global namespace and so don't care about `EXPORT_NAME` conflicts.

Note that `-o something.html` + `-s EXPORT_ES6` + `-s SINGLE_FILE` is still forbidden because `SINGLE_FILE` forces `Module` variable to be inlined back into the same scope as the `Module` config variable. For most users this combo probably doesn't matter though.

Fixes #12513.