### PR TITLE
Bump v8 to 9.1.269, update V8 flags for SIMD

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,7 @@ executors:
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
-      # Currently pinned to 9.1.146 due to https://bugs.chromium.org/p/v8/issues/detail?id=11581
-      V8_VERSION: "9.1.146"
+      V8_VERSION: "9.1.269"
   mac:
     environment:
       EMSDK_NOTTY: "1"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,7 @@ commands:
             # test v8 with --wasm-staging which enables new features. we use v8
             # as a "bleeding edge" shell here, basically, with node being the
             # primary shell (which we run without any special flags)
+            # Refer to commit 0bc3640 if we need to pin V8 version.
             echo "V8_ENGINE = [os.path.expanduser('~/.jsvu/v8'), '--wasm-staging']" >> .emscripten
             echo "JS_ENGINES = [NODE_JS]" >> .emscripten
             echo "if os.path.exists(V8_ENGINE[0]): JS_ENGINES.append(V8_ENGINE)" >> .emscripten

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,6 @@ executors:
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
-      # Currently pinned to 9.1.146 due to https://bugs.chromium.org/p/v8/issues/detail?id=11581
-      V8_VERSION: "9.1.146"
   mac:
     environment:
       EMSDK_NOTTY: "1"
@@ -59,7 +57,7 @@ commands:
             # test v8 with --wasm-staging which enables new features. we use v8
             # as a "bleeding edge" shell here, basically, with node being the
             # primary shell (which we run without any special flags)
-            echo "V8_ENGINE = [os.path.expanduser('~/.jsvu/v8-${V8_VERSION}'), '--wasm-staging']" >> .emscripten
+            echo "V8_ENGINE = [os.path.expanduser('~/.jsvu/v8'), '--wasm-staging']" >> .emscripten
             echo "JS_ENGINES = [NODE_JS]" >> .emscripten
             echo "if os.path.exists(V8_ENGINE[0]): JS_ENGINES.append(V8_ENGINE)" >> .emscripten
             echo "WASM_ENGINES = []" >> .emscripten
@@ -394,7 +392,7 @@ jobs:
             export PATH="`pwd`/node-v12.13.0-linux-x64/bin:${PATH}"
             npm install jsvu -g
             export PATH="${HOME}/.jsvu:${PATH}"
-            jsvu --os=default --engines=v8 v8@${V8_VERSION}
+            jsvu --os=default --engines=v8
       - build
       - build-libs-and-freeze
       - persist

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,8 @@ executors:
       EMCC_CORES: "4"
       EMSDK_NOTTY: "1"
       EMTEST_WASI_SYSROOT: "~/wasi-sdk/wasi-sysroot"
-      V8_VERSION: "9.1.269"
+      # Currently pinned to 9.1.146 due to https://bugs.chromium.org/p/v8/issues/detail?id=11581
+      V8_VERSION: "9.1.146"
   mac:
     environment:
       EMSDK_NOTTY: "1"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,6 +44,7 @@ def wasm_simd(f):
       self.skipTest('SIMD tests are too slow with -O3 in the new LLVM pass manager, https://github.com/emscripten-core/emscripten/issues/13427')
     self.emcc_args.append('-msimd128')
     self.emcc_args.append('-fno-lax-vector-conversions')
+    self.v8_args.append('--experimental-wasm-simd')
     self.js_engines = [config.V8_ENGINE]
     f(self)
   return decorated

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -44,7 +44,6 @@ def wasm_simd(f):
       self.skipTest('SIMD tests are too slow with -O3 in the new LLVM pass manager, https://github.com/emscripten-core/emscripten/issues/13427')
     self.emcc_args.append('-msimd128')
     self.emcc_args.append('-fno-lax-vector-conversions')
-    self.v8_args.append('--experimental-wasm-simd')
     self.js_engines = [config.V8_ENGINE]
     f(self)
   return decorated


### PR DESCRIPTION
--experimental-wasm-simd is no longer needed for v8.