### PR TITLE
fork() and system(): Change errno value from EAGAIN to ENOSYS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -565,3 +565,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Érico Porto <ericoporto2008@gmail.com>
 * Albert Vaca Cintora <albertvaka@gmail.com>
 * Zhi An Ng <zhin@google.com> (copyright owned by Google, Inc.)
+* Ian Jackson <ijackson@chiark.greenend.org.uk>

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,9 @@ See docs/process.md for more on how version tagging works.
   static string data in your program.   This has long been part of the native
   ELF linker and should not be observable in well-behaved programs.  This
   behavior can be disabled by passing `-Wl,-O0`.
+- The functions `fork`, `vfork`, `posix_spawn` and `system` now fail with
+  the errno value `ENOSYS` (52) rather than `EAGAIN` (6).  This is more
+  correct, since they will never work and attempting to retry won't help.
 
 2.0.20: 05/04/2021
 ------------------

--- a/src/library.js
+++ b/src/library.js
@@ -171,7 +171,7 @@ LibraryManager.library = {
     // pid_t fork(void);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/fork.html
     // We don't support multiple processes.
-    setErrNo({{{ cDefine('EAGAIN') }}});
+    setErrNo({{{ cDefine('ENOSYS') }}});
     return -1;
   },
   vfork: 'fork',
@@ -411,7 +411,7 @@ LibraryManager.library = {
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/system.html
     // Can't call external programs.
     if (!command) return 0; // no shell available
-    setErrNo({{{ cDefine('EAGAIN') }}});
+    setErrNo({{{ cDefine('ENOSYS') }}});
     return -1;
   },
 

--- a/tests/core/test_support_errno.out
+++ b/tests/core/test_support_errno.out
@@ -1,3 +1,3 @@
 rtn     : -1
-errno   : 6
-strerror: Resource temporarily unavailable
+errno   : 52
+strerror: Function not implemented

--- a/tests/system.c
+++ b/tests/system.c
@@ -25,9 +25,9 @@ int main(void) {
 #else
   assert(system(NULL) == 0);
   assert(system("") == -1);
-  assert(errno == EAGAIN);
+  assert(errno == ENOSYS);
   assert(system("true") == -1);
-  assert(errno == EAGAIN);
+  assert(errno == ENOSYS);
 #ifdef REPORT_RESULT
   REPORT_RESULT(0);
 #endif

--- a/tests/unistd/misc.out
+++ b/tests/unistd/misc.out
@@ -25,8 +25,8 @@ lchown(good): 0, errno: 0
 lchown(bad): -1, errno: 44
 fchown(good): 0, errno: 0
 fchown(bad): -1, errno: 8
-fork: -1, errno: 6
-vfork: -1, errno: 6
+fork: -1, errno: 52
+vfork: -1, errno: 52
 crypt: ba4TuD1iozTxw, errno: 0
 encrypt, errno: 0
 getgid: 0, errno: 0


### PR DESCRIPTION
This is more correct.  Trying again will not help.

Fixes: #14124