### PR TITLE
Always emit a "maximum" clause for WebAssembly.Memory

### DIFF
--- a/src/runtime_init_memory.js
+++ b/src/runtime_init_memory.js
@@ -23,14 +23,15 @@ if (ENVIRONMENT_IS_PTHREAD) {
 #endif
   {
     wasmMemory = new WebAssembly.Memory({
-      'initial': INITIAL_MEMORY / {{{ WASM_PAGE_SIZE }}}
+      'initial': INITIAL_MEMORY / {{{ WASM_PAGE_SIZE }}},
 #if ALLOW_MEMORY_GROWTH
-#if MAXIMUM_MEMORY != FOUR_GB
-      ,
+      // In theory we should not need to emit the maximum if we want "unlimited"
+      // or 4GB of memory, but VMs error on that atm, see
+      // https://github.com/emscripten-core/emscripten/issues/14130
+      // And in the pthreads case we definitely need to emit a maximum. So
+      // always emit one.
       'maximum': {{{ MAXIMUM_MEMORY }}} / {{{ WASM_PAGE_SIZE }}}
-#endif
 #else
-      ,
       'maximum': INITIAL_MEMORY / {{{ WASM_PAGE_SIZE }}}
 #endif // ALLOW_MEMORY_GROWTH
 #if USE_PTHREADS

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3860,6 +3860,11 @@ ok
                                                        (int)&emscripten_run_script );
                                        }''')
     self.set_setting('MAIN_MODULE', 1)
+    # also test main module with 4GB of memory. we need to emit a "maximum"
+    # clause then, even though 4GB is the maximum; see
+    # https://github.com/emscripten-core/emscripten/issues/14130
+    self.set_setting('ALLOW_MEMORY_GROWTH', '1')
+    self.set_setting('MAXIMUM_MEMORY', '4GB')
     self.do_runf('test_sig.c', '')
 
   @needs_dylink


### PR DESCRIPTION
It seems like we don't need it for 4GB, but VMs complain. See https://github.com/emscripten-core/emscripten/issues/14130

(We also definitely need it for pthreads.)

Fixes https://github.com/emscripten-core/emscripten/issues/14130