### PR TITLE
Set PYTHONUTF8 when running tests on windows. NFC.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -452,6 +452,9 @@ jobs:
       shell: bash.exe -eo pipefail
     environment:
       PYTHONUNBUFFERED: "1"
+      # Override the default locale to use UTF-8 encoding for all files and stdio 
+      # streams (see PEP540), since oure test files are encoded with UTF-8.
+      PYTHONUTF8: "1"
       EMSDK_NOTTY: "1"
       # clang can compile but not link in the current setup, see
       # https://github.com/emscripten-core/emscripten/pull/11382#pullrequestreview-428902638
@@ -470,7 +473,7 @@ jobs:
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - run-tests:
-          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file"
+          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file wasm2.test_utf16"
   test-mac:
     executor: mac
     steps:


### PR DESCRIPTION
Many of our tests include UTF8 encoded files, and on the CI machines
python cannot read them since it uses the windows codepage which is
`cp1252`.   This envrionment variable forces python to assume UTF8
encoded text files and stdin/stdout.

We already set this when running our windows tests on
emscripten-releases bots.

Add an extra test to the windows bot that verifies is can read UTF8
encoded expectations files (even though this test is about UTF16 the
expectation file is still UTF8).