### PR TITLE
Use legacy pass manager when wasm EH is enabled

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -857,7 +857,9 @@ def get_cflags(options, user_args):
              '-D__unix__']
 
   # When wasm EH is enabled, we use the legacy pass manager because the new pass
-  # manager + wasm EH has some known bugs. TODO Use the new pass manager.
+  # manager + wasm EH has some known bugs. See
+  # https://github.com/emscripten-core/emscripten/issues/14180.
+  # TODO Switch to the new pass manager.
   if settings.EXCEPTION_HANDLING:
     cflags += ['-flegacy-pass-manager']
 

--- a/emcc.py
+++ b/emcc.py
@@ -856,6 +856,11 @@ def get_cflags(options, user_args):
              '-D__unix',
              '-D__unix__']
 
+  # When wasm EH is enabled, we use the legacy pass manager because the new pass
+  # manager + wasm EH has some known bugs. TODO Use the new pass manager.
+  if settings.EXCEPTION_HANDLING:
+    cflags += ['-flegacy-pass-manager']
+
   # Changes to default clang behavior
 
   # Implicit functions can cause horribly confusing function pointer type errors, see #2175

--- a/tools/building.py
+++ b/tools/building.py
@@ -457,8 +457,10 @@ def link_lld(args, target, external_symbols=None):
 
   # Wasm exception handling. This is a CodeGen option for the LLVM backend, so
   # wasm-ld needs to take this for the LTO mode.
+  # When wasm EH is enabled, we use the legacy pass manager because the new pass
+  # manager + wasm EH has some known bugs. TODO Use the new pass manager.
   if settings.EXCEPTION_HANDLING:
-    cmd += ['-mllvm', '-exception-model=wasm']
+    cmd += ['-mllvm', '-exception-model=wasm', '--lto-legacy-pass-manager']
 
   # For relocatable output (generating an object file) we don't pass any of the
   # normal linker flags that are used when building and exectuable

--- a/tools/building.py
+++ b/tools/building.py
@@ -458,7 +458,9 @@ def link_lld(args, target, external_symbols=None):
   # Wasm exception handling. This is a CodeGen option for the LLVM backend, so
   # wasm-ld needs to take this for the LTO mode.
   # When wasm EH is enabled, we use the legacy pass manager because the new pass
-  # manager + wasm EH has some known bugs. TODO Use the new pass manager.
+  # manager + wasm EH has some known bugs. See
+  # https://github.com/emscripten-core/emscripten/issues/14180.
+  # TODO Switch to the new pass manager.
   if settings.EXCEPTION_HANDLING:
     cmd += ['-mllvm', '-exception-model=wasm', '--lto-legacy-pass-manager']
 


### PR DESCRIPTION
This is a temporary measure for our clients who are experimenting with
this new feature. See #14180.

Not sure how to add a test for this.