### PR TITLE
Reland: Warn if link-only settings are used in compile-only mode

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -30,6 +30,9 @@ See docs/process.md for more on how version tagging works.
   desirable.  Folks that were previously using `CMAKE_INSTALL_PREFIX` to build
   their own secondary sysroot may be able to simplify their build system by
   removing this completely and relying on the new default.
+- Reinstated the warning on linker-only `-s` settings passed when not linking
+  (i.e. when compiling with `-c`).  As before this can disabled with
+  `-Wno-unused-command-line-argument` (#14182).
 
 2.0.23
 ------

--- a/emcc.py
+++ b/emcc.py
@@ -1314,11 +1314,9 @@ def phase_setup(options, state, newargs, settings_map):
     state.mode = Mode.COMPILE_ONLY
 
   if state.mode in (Mode.COMPILE_ONLY, Mode.PREPROCESS_ONLY):
-    # TODO(sbc): Re-enable these warnings once we are sure we don't have any false
-    # positives.  See: https://github.com/emscripten-core/emscripten/pull/14109
-    # for key in settings_map:
-    #   if key not in COMPILE_TIME_SETTINGS:
-    #     diagnostics.warning('unused-command-line-argument', "linker setting ignored during compilation: '%s'" % key)
+    for key in settings_map:
+       if key not in COMPILE_TIME_SETTINGS:
+         diagnostics.warning('unused-command-line-argument', "linker setting ignored during compilation: '%s'" % key)
     if state.has_dash_c:
       if '-emit-llvm' in newargs:
         options.default_object_extension = '.bc'

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10580,3 +10580,7 @@ kill -9 $$
 
   def test_concepts(self):
     self.do_runf(test_file('other', 'test_concepts.cpp'), '', emcc_args=['-std=c++20'])
+
+  def test_link_only_setting_warning(self):
+    err = self.run_process([EMCC, '-sALLOW_MEMORY_GROWTH', '-c', test_file('hello_world.c')], stderr=PIPE).stderr
+    self.assertContained("warning: linker setting ignored during compilation: 'ALLOW_MEMORY_GROWTH' [-Wunused-command-line-argument]", err)


### PR DESCRIPTION
Originally landed in #14042 and then reverted in #13884.

Since then I landed a change that makes false positives impossible by
asserting if any link-only setting is accessed before the link phase.
This means that there are cannot be any setting that is used during the
compile phase that is *not* part of COMPILE_TIME_SETTINGS.  If such a
setting existed we would hit an assert during testing.  (Obviously this
depends on our test coverage being good).