### PR TITLE
Revert #13862: Fail at link time if exception catching is e…

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2185,9 +2185,10 @@ def phase_linker_setup(options, state, newargs, settings_map):
 
   if not settings.DISABLE_EXCEPTION_CATCHING:
     settings.EXPORTED_FUNCTIONS += [
-      # If not for LTO builds, we could handle these by adding deps_info.py
-      # entries for __cxa_find_matching_catch_* functions.  However, under
-      # LTO these symbols don't exist prior the linking.
+      # For normal builds the entries in deps_info.py are enough to include
+      # these symbols whenever __cxa_find_matching_catch_* functions are
+      # found.  However, under LTO these symbols don't exist prior to linking
+      # so we include then unconditionally when exceptions are enabled.
       '___cxa_is_pointer_type',
       '___cxa_can_catch',
 

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -110,7 +110,7 @@ var LibraryExceptions = {
     };
   },
 
-  $CatchInfo__deps: ['$ExceptionInfo'],
+  $CatchInfo__deps: ['$ExceptionInfo', '__cxa_is_pointer_type'],
   // This native structure is returned from __cxa_find_matching_catch, and serves as catching
   // context, i.e. stores information required to proceed with a specific selected catch. It stores
   // base and adjusted pointers of a thrown object. It is allocated dynamically and should be freed
@@ -143,7 +143,6 @@ var LibraryExceptions = {
       return {{{ makeGetValue('this.ptr', 'ptrSize', '*') }}};
     };
 
-#if !DISABLE_EXCEPTION_CATCHING
     // Get pointer which is expected to be received by catch clause in C++ code. It may be adjusted
     // when the pointer is casted to some of the exception object base classes (e.g. when virtual
     // inheritance is used). When a pointer is thrown this method should return the thrown pointer
@@ -171,7 +170,6 @@ var LibraryExceptions = {
     } else {
       this.ptr = ptr;
     }
-#endif
   },
 
   $exception_addRef: function (info) {
@@ -291,7 +289,6 @@ var LibraryExceptions = {
     return type;
   },
 
-#if !DISABLE_EXCEPTION_CATCHING
   __cxa_begin_catch__deps: ['$CatchInfo', '$exceptionCaught', '$exception_addRef',
                             '$uncaughtExceptionCount'],
   __cxa_begin_catch: function(ptr) {
@@ -341,7 +338,6 @@ var LibraryExceptions = {
 #endif
     return new CatchInfo(ptr).get_exception_ptr();
   },
-#endif
 
   __cxa_uncaught_exceptions__deps: ['$uncaughtExceptionCount'],
   __cxa_uncaught_exceptions: function() {
@@ -377,7 +373,6 @@ var LibraryExceptions = {
     ___cxa_rethrow();
   },
 
-#if !DISABLE_EXCEPTION_CATCHING
   // Finds a suitable catch clause for when an exception is thrown.
   // In normal compilers, this functionality is handled by the C++
   // 'personality' routine. This is passed a fairly complex structure
@@ -447,26 +442,8 @@ var LibraryExceptions = {
     catchInfo.free();
     {{{ makeThrow('ptr') }}}
   },
-#endif
 };
 
-
-#if DISABLE_EXCEPTION_CATCHING
-[
-  '__cxa_begin_catch',
-  '__cxa_end_catch',
-  '__resumeException',
-  '__cxa_find_matching_catch',
-  '__cxa_get_exception_ptr',
-].forEach(function(name) {
-  LibraryExceptions[name] = function() { abort(); };
-#if !INCLUDE_FULL_LIBRARY
-  LibraryExceptions[name + '__deps'] = [function() {
-    error('DISABLE_EXCEPTION_CATCHING was set, which means no C++ exception catching support code is linked in, but such support is required by symbol `' + name + '`. Either link with DISABLE_EXCEPTION_CATCHING=0 (if you do want exception catching) or compile all source files with DISABLE_EXCEPTION_CATCHING=1 (the default) (so that no exception catching support code is required).');
-  }];
-#endif
-});
-#else
 // In LLVM, exceptions generate a set of functions of form __cxa_find_matching_catch_1(), __cxa_find_matching_catch_2(), etc.
 // where the number specifies the number of arguments. In Emscripten, route all these to a single function '__cxa_find_matching_catch'
 // that variadically processes all of these functions using JS 'arguments' object.
@@ -475,6 +452,5 @@ addCxaCatch = function(n) {
   LibraryManager.library['__cxa_find_matching_catch_' + n + '__sig'] = new Array(n + 2).join('i');
   LibraryManager.library['__cxa_find_matching_catch_' + n + '__deps'] = LibraryExceptions['__cxa_find_matching_catch__deps'];
 };
-#endif
 
 mergeInto(LibraryManager.library, LibraryExceptions);

--- a/system/lib/libcxxabi/src/private_typeinfo.cpp
+++ b/system/lib/libcxxabi/src/private_typeinfo.cpp
@@ -1290,7 +1290,15 @@ __base_class_type_info::search_below_dst(__dynamic_cast_info* info,
 
 // XXX EMSCRIPTEN
 
-#ifdef __USING_EMSCRIPTEN_EXCEPTIONS__
+#ifndef __USING_WASM_EXCEPTIONS__
+
+// These functions are used by the emscripten-style exception handling
+// mechanism.
+// Note that they need to be included even in the `-noexcept` build of
+// libc++abi to support the case where some parts of a project are built
+// with exception catching enabled, but at link time exception catching
+// is disabled.  In this case dependencies to these functions (and the JS
+// functions which call them) will still exist in the final build.
 extern "C" {
 
 int __cxa_can_catch(__shim_type_info* catchType, __shim_type_info* excpType, void **thrown) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9238,13 +9238,10 @@ int main(void) {
       }
     ''')
     self.run_process([EMXX, 'src.cpp', '-c', '-o', 'src.o'] + compile_flags)
-    if compile_flags and not link_flags:
-      out = self.expect_fail([EMXX, 'src.o'] + link_flags)
-      self.assertContained('error: DISABLE_EXCEPTION_CATCHING was set, which means no C++ exception catching support code is linked in, but such support is required by symbol `__cxa_begin_catch`.', out)
-      return
-
     self.run_process([EMXX, 'src.o'] + link_flags)
     result = self.run_js('a.out.js', assert_returncode=0 if expect_caught else NON_ZERO)
+    if not expect_caught:
+      self.assertContainedIf('exception catching is disabled, this exception cannot be caught', result, expect_caught)
     self.assertContainedIf('CAUGHT', result, expect_caught)
 
   def test_exceptions_with_closure_and_without_catching(self):

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -198,8 +198,18 @@ _deps_info = {
 
 
 def get_deps_info():
-  if not settings.EXCEPTION_HANDLING and not settings.DISABLE_EXCEPTION_CATCHING:
+  if not settings.EXCEPTION_HANDLING and settings.LINK_AS_CXX:
     _deps_info['__cxa_begin_catch'] = ['__cxa_is_pointer_type']
+    _deps_info['__cxa_find_matching_catch'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_1'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_2'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_3'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_4'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_5'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_6'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_7'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_8'] = ['__cxa_can_catch']
+    _deps_info['__cxa_find_matching_catch_9'] = ['__cxa_can_catch']
   if settings.USE_PTHREADS:
     _deps_info['emscripten_set_canvas_element_size_calling_thread'] = ['_emscripten_call_on_thread']
     _deps_info['emscripten_set_offscreencanvas_size_on_target_thread'] = ['_emscripten_call_on_thread', 'malloc', 'free']


### PR DESCRIPTION
…nabled at compile time but not link time

In #13862 we stopped including exception catching code when
linking with `DISABLE_EXCEPTION_CATCHING`.  Otherwise closure
would complain about undefined references to `__cxa_is_pointer_type`
and `___cxa_can_catch`.

Instead, this patch unconditionally includes those two function
in `libc++abi` even in the `noexcept` version of that library.
Since these are normal native symbols they should only be linked
in if needed so there should be no overhead for application that
don't need them.

Since these symbols are unconditional dependencies of the exception
handling JS functions, but `libc++abi` is not always linked (for example
if `-nostdlib++` is passed) I also needed to make library_exceptions.js
conditionally included only if we are also linking `libc++abi`.   Same
with the unwind JS functions.  This allows `INCLUDE_FULL_LIBRARY`
to work with `-nostdlib++`.