### PR TITLE
Fix the handling of shared library dependencies in subfolders.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -673,7 +673,7 @@ def process_dynamic_libs(dylibs, lib_dirs):
         extras.append(path)
         seen.add(needed)
       else:
-        exit_with_error(f'{os.path.basename(dylib)}: shared library dependency not found: `{needed}`')
+        exit_with_error(f'{os.path.normpath(dylib)}: shared library dependency not found: `{needed}`')
       to_process.append(path)
 
   dylibs += extras

--- a/emcc.py
+++ b/emcc.py
@@ -673,7 +673,7 @@ def process_dynamic_libs(dylibs, lib_dirs):
         extras.append(path)
         seen.add(needed)
       else:
-        exit_with_error(f'{dylib}: shared library dependency not found: `{needed}`')
+        exit_with_error(f'{os.path.basename(dylib)}: shared library dependency not found: `{needed}`')
       to_process.append(path)
 
   dylibs += extras

--- a/emcc.py
+++ b/emcc.py
@@ -671,9 +671,10 @@ def process_dynamic_libs(dylibs, lib_dirs):
       path = find_library(needed, lib_dirs)
       if path:
         extras.append(path)
+        seen.add(needed)
       else:
         exit_with_error(f'{dylib}: shared library dependency not found: `{needed}`')
-      to_process.append(needed)
+      to_process.append(path)
 
   dylibs += extras
   for dylib in dylibs:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7392,7 +7392,7 @@ int main() {
     os.mkdir('subdir')
     self.run_process([EMCC, test_file('hello_world.c'), '-s', 'SIDE_MODULE', '-o', 'subdir/libside1.so'])
     self.run_process([EMCC, test_file('hello_world.c'), '-s', 'SIDE_MODULE', '-o', 'subdir/libside2.so', '-L', 'subdir', '-lside1'])
-    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'MAIN_MODULE', '-o', 'subdir/main.js', '-L', 'subdir', '-lside2'])
+    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'MAIN_MODULE', '-o', 'main.js', '-L', 'subdir', '-lside2'])
 
   @is_slow_test
   def test_lto(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7387,6 +7387,13 @@ int main() {
     err = self.expect_fail(final_link)
     self.assertContained('error: libside2.wasm: shared library dependency not found: `libside1.wasm`', err)
 
+  def test_side_module_folder_deps(self):
+    # Build side modules in a subfolder
+    os.mkdir('subdir')
+    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'SIDE_MODULE', '-o', 'subdir/libside1.so'])
+    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'SIDE_MODULE', '-o', 'subdir/libside2.so', '-L', 'subdir', '-lside1'])
+    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'MAIN_MODULE', '-o', 'subdir/main.js', '-L', 'subdir', '-lside2'])
+
   @is_slow_test
   def test_lto(self):
     # test building of non-wasm-object-files libraries, building with them, and running them


### PR DESCRIPTION
Atm the linking fails with a hard error for dependencies of dynamic libraries that are in subdirectories.