### PR TITLE
Remove PThreads note about SAB removal

### DIFF
--- a/site/source/docs/porting/pthreads.rst
+++ b/site/source/docs/porting/pthreads.rst
@@ -4,7 +4,7 @@
 Pthreads support
 ==============================
 
-.. note:: Browsers are `currently shipping <https://webassembly.org/roadmap/>`_ SharedArrayBuffer gated behind Cross Origin Opener Policy (COOP) and Cross Origin Embedder Policy (COEP) headers. Pthreads code will not work in deployed environment unless these headers are correctly set. For more information click `this <https://web.dev/coop-coep>`_
+.. note:: Browsers `that have implemented and enabled <https://webassembly.org/roadmap/>`_ SharedArrayBuffer, are gating it behind Cross Origin Opener Policy (COOP) and Cross Origin Embedder Policy (COEP) headers. Pthreads code will not work in deployed environment unless these headers are correctly set. For more information click `this <https://web.dev/coop-coep>`_
 
 Emscripten has support for multithreading using SharedArrayBuffer in browsers. That API allows sharing memory between the main thread and web workers as well as atomic operations for synchronization, which enables Emscripten to implement support for the Pthreads (POSIX threads) API. This support is considered stable in Emscripten.
 

--- a/site/source/docs/porting/pthreads.rst
+++ b/site/source/docs/porting/pthreads.rst
@@ -4,15 +4,9 @@
 Pthreads support
 ==============================
 
-.. note:: Browsers are currently shipping SharedArrayBuffer gated behind Cross Origin Opener Policy (COOP) and Cross Origin Embedder Policy (COEP) headers. Pthreads code will not work in deployed environment unless these headers are correctly set. For more information click `this <https://web.dev/coop-coep>`_
+.. note:: Browsers are `currently shipping <https://webassembly.org/roadmap/>`_ SharedArrayBuffer gated behind Cross Origin Opener Policy (COOP) and Cross Origin Embedder Policy (COEP) headers. Pthreads code will not work in deployed environment unless these headers are correctly set. For more information click `this <https://web.dev/coop-coep>`_
 
 Emscripten has support for multithreading using SharedArrayBuffer in browsers. That API allows sharing memory between the main thread and web workers as well as atomic operations for synchronization, which enables Emscripten to implement support for the Pthreads (POSIX threads) API. This support is considered stable in Emscripten.
-
-.. note:: As of Sep 2019, some browsers have disabled SharedArrayBuffer due to
-          the Spectre set of vulnerabilities. Until it is restored you can still
-          experiment with it if you flip a pref in those browsers. In other
-          browsers (like Chrome on desktop), SharedArrayBuffer is fully enabled
-          by default and you don't need to flip any flags.
 
 Compiling with pthreads enabled
 ===============================


### PR DESCRIPTION
That note is tecnically outdated now and seems confusing alongside the new note above. Browsers now did start re-enabling SAB, and using it in Chrome without flags is no longer allowed either.