### PR TITLE
Add diagnosis to nmmintrin, smmintrin, avxintrin compat headers

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -902,9 +902,9 @@ The following table highlights the availability and expected performance of diff
    * - _mm_blendv_ps
      - ⚠️ emulated with a SIMD shr+and+andnot+or
    * - _mm_ceil_pd
-     - ❌ scalarized
+     - ✅ wasm_f64x2_ceil
    * - _mm_ceil_ps
-     - ❌ scalarized
+     - ✅ wasm_f32x4_ceil
    * - _mm_ceil_sd
      - ❌ scalarized
    * - _mm_ceil_ss
@@ -948,9 +948,9 @@ The following table highlights the availability and expected performance of diff
    * - _mm_extract_ps
      - ✅ wasm_i32x4_extract_lane
    * - _mm_floor_pd
-     - ❌ scalarized
+     - ✅ wasm_f64x2_floor
    * - _mm_floor_ps
-     - ❌ scalarized
+     - ✅ wasm_f32x4_floor
    * - _mm_floor_sd
      - ❌ scalarized
    * - _mm_floor_ss
@@ -1007,21 +1007,21 @@ The following table highlights the availability and expected performance of diff
      - ❌ scalarized
    * - _mm_testc_si128
      - ❌ scalarized
-   * - _mm_test_nzc_si128
+   * - _mm_testnzc_si128
      - ❌ scalarized
    * - _mm_testz_si128
      - ❌ scalarized
 
 The following table highlights the availability and expected performance of different SSE4.2 intrinsics. Refer to `Intel Intrinsics Guide on SSE4.2 <https://software.intel.com/sites/landingpage/IntrinsicsGuide/#techs=SSE4_2>`_.
 
-.. list-table:: x86 SSE4.1 intrinsics available via #include <smmintrin.h>
+.. list-table:: x86 SSE4.2 intrinsics available via #include <nmmintrin.h>
    :widths: 20 30
    :header-rows: 1
 
    * - Intrinsic name
      - WebAssembly SIMD support
    * - _mm_cmpgt_epi64
-     - ❌ scalarized
+     - ✅ wasm_i64x2_gt
 
 ⚫ The SSE4.2 functions that deal with string comparisons and CRC calculations are not available:
  - _mm_cmpestra, _mm_cmpestrc, _mm_cmpestri, _mm_cmpestrm, _mm_cmpestro, _mm_cmpestrs, _mm_cmpestrz, _mm_cmpistra, _mm_cmpistrc, _mm_cmpistri, _mm_cmpistrm, _mm_cmpistro, _mm_cmpistrs, _mm_cmpistrz, _mm_crc32_u16, _mm_crc32_u32, _mm_crc32_u64, _mm_crc32_u8

--- a/system/include/compat/avxintrin.h
+++ b/system/include/compat/avxintrin.h
@@ -152,14 +152,14 @@ _mm_maskload_ps(const float *__mem_addr, __m128i __mask)
   return _mm_and_ps(_mm_load_ps(__mem_addr), (__m128)_mm_srai_epi32(__mask, 31));
 }
 
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
+static __inline__ void __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_maskstore_pd(double *__mem_addr, __m128i __mask, __m128d __a)
 {
   if ((wasm_i64x2_extract_lane(__mask, 0) & 0x8000000000000000ull) != 0) __mem_addr[0] = wasm_f64x2_extract_lane(__a, 0);
   if ((wasm_i64x2_extract_lane(__mask, 1) & 0x8000000000000000ull) != 0) __mem_addr[1] = wasm_f64x2_extract_lane(__a, 1);
 }
 
-static __inline__ void __attribute__((__always_inline__, __nodebug__))
+static __inline__ void __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_maskstore_ps(float *__mem_addr, __m128i __mask, __m128 __a)
 {
   if ((wasm_i32x4_extract_lane(__mask, 0) & 0x80000000ull) != 0) __mem_addr[0] = wasm_f32x4_extract_lane(__a, 0);

--- a/system/include/compat/nmmintrin.h
+++ b/system/include/compat/nmmintrin.h
@@ -16,7 +16,7 @@
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_cmpgt_epi64(__m128i __a, __m128i __b)
 {
-  return (__m128i)((__i64x2)__a > (__i64x2)__b);
+  return wasm_i64x2_gt(__a, __b);
 }
 
 // Unsupported functions:

--- a/system/include/compat/smmintrin.h
+++ b/system/include/compat/smmintrin.h
@@ -79,26 +79,22 @@ _mm_blendv_ps(__m128 __a, __m128 __b, __m128 __mask)
 static __inline__ __m128d __attribute__((__always_inline__, __nodebug__))
 _mm_ceil_pd(__m128d __a)
 {
-  return (__m128d)wasm_f64x2_make(__builtin_ceil(wasm_f64x2_extract_lane(__a, 0)),
-                                  __builtin_ceil(wasm_f64x2_extract_lane(__a, 1)));
+  return (__m128d)wasm_f64x2_ceil((v128_t)__a);
 }
 
 static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
 _mm_ceil_ps(__m128 __a)
 {
-  return (__m128)wasm_f32x4_make(__builtin_ceilf(wasm_f32x4_extract_lane(__a, 0)),
-                                 __builtin_ceilf(wasm_f32x4_extract_lane(__a, 1)),
-                                 __builtin_ceilf(wasm_f32x4_extract_lane(__a, 2)),
-                                 __builtin_ceilf(wasm_f32x4_extract_lane(__a, 3)));
+  return (__m128)wasm_f32x4_ceil((v128_t)__a);
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_ceil_ss(__m128 __a, __m128 __b)
 {
   return (__m128)wasm_f32x4_replace_lane(__a, 0, __builtin_ceilf(wasm_f32x4_extract_lane(__b, 0)));
 }
 
-static __inline__ __m128d __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128d __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_ceil_sd(__m128d __a, __m128d __b)
 {
   return (__m128d)wasm_f64x2_replace_lane(__a, 0, __builtin_ceil(wasm_f64x2_extract_lane(__b, 0)));
@@ -107,26 +103,22 @@ _mm_ceil_sd(__m128d __a, __m128d __b)
 static __inline__ __m128d __attribute__((__always_inline__, __nodebug__))
 _mm_floor_pd(__m128d __a)
 {
-  return (__m128d)wasm_f64x2_make(__builtin_floor(wasm_f64x2_extract_lane(__a, 0)),
-                                  __builtin_floor(wasm_f64x2_extract_lane(__a, 1)));
+  return (__m128d)wasm_f64x2_floor((v128_t)__a);
 }
 
 static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
 _mm_floor_ps(__m128 __a)
 {
-  return (__m128)wasm_f32x4_make(__builtin_floorf(wasm_f32x4_extract_lane(__a, 0)),
-                                 __builtin_floorf(wasm_f32x4_extract_lane(__a, 1)),
-                                 __builtin_floorf(wasm_f32x4_extract_lane(__a, 2)),
-                                 __builtin_floorf(wasm_f32x4_extract_lane(__a, 3)));
+  return (__m128)wasm_f32x4_floor((v128_t)__a);
 }
 
-static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128 __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_floor_ss(__m128 __a, __m128 __b)
 {
   return (__m128)wasm_f32x4_replace_lane(__a, 0, __builtin_floorf(wasm_f32x4_extract_lane(__b, 0)));
 }
 
-static __inline__ __m128d __attribute__((__always_inline__, __nodebug__))
+static __inline__ __m128d __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_floor_sd(__m128d __a, __m128d __b)
 {
   return (__m128d)wasm_f64x2_replace_lane(__a, 0, __builtin_floor(wasm_f64x2_extract_lane(__b, 0)));
@@ -214,7 +206,7 @@ _mm_mullo_epi32(__m128i __a, __m128i __b)
   return (__m128i)wasm_i32x4_mul(__a, __b);
 }
 
-static __inline__  __m128i __attribute__((__always_inline__, __nodebug__))
+static __inline__  __m128i __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_mul_epi32(__m128i __a, __m128i __b)
 {
   return (__m128i)wasm_i64x2_make(
@@ -329,14 +321,14 @@ _mm_max_epu32(__m128i __a, __m128i __b)
 #define _mm_extract_epi64(__a, __imm8) __extension__ ({       \
                                        wasm_i64x2_extract_lane((__a), (__imm8) & 1); })
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_testz_si128(__m128i __a, __m128i __b)
 {
   v128_t __m = wasm_v128_and(__a, __b);
   return (wasm_i64x2_extract_lane(__m, 0) | wasm_i64x2_extract_lane(__m, 1)) == 0;
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_testc_si128(__m128i __a, __m128i __b)
 {
   v128_t __m = wasm_v128_andnot(__b, __a);
@@ -352,20 +344,20 @@ _mm_testnzc_si128(__m128i __a, __m128i __b)
       && (wasm_i64x2_extract_lane(__m2, 0) | wasm_i64x2_extract_lane(__m2, 1));
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_test_all_ones(__m128i __a)
 {
   return (wasm_i64x2_extract_lane(__a, 0) & wasm_i64x2_extract_lane(__a, 1)) == 0xFFFFFFFFFFFFFFFFull;
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_test_all_zeros(__m128i __a, __m128i __mask)
 {
   v128_t __m = wasm_v128_and(__a, __mask);
   return (wasm_i64x2_extract_lane(__m, 0) | wasm_i64x2_extract_lane(__m, 1)) == 0;
 }
 
-static __inline__ int __attribute__((__always_inline__, __nodebug__))
+static __inline__ int __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
 _mm_test_mix_ones_zeros(__m128i __a, __m128i __mask)
 {
   v128_t __m = wasm_v128_and(__a, __mask);


### PR DESCRIPTION
Following the chart in simd.rst:
- update SSE intrinsics with Wasm instructions and update chart to
reflect optimized implementations
- typo in _mm_testnzc_si128 in doc
- typo in SSE4.2 in doc
- add diagnosis for slow emulated instructions in smmintrin.h