### PR TITLE
Fix for relative EM_CACHE settings

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2874,7 +2874,7 @@ def parse_args(newargs):
       config.CACHE = os.path.normpath(consume_arg())
       shared.reconfigure_cache()
     elif check_flag('--clear-cache'):
-      logger.info('clearing cache as requested by --clear-cache')
+      logger.info('clearing cache as requested by --clear-cache: `%s`', shared.Cache.dirname)
       shared.Cache.erase()
       shared.check_sanity(force=True) # this is a good time for a sanity check
       should_exit = True

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -493,13 +493,17 @@ fi
     self.assertEqual(num_times_libc_was_built, 1)
 
   @parameterized({
-    '': [False],
-    'response_files': [True]
+    '': [False, False],
+    'response_files': [True, False],
+    'relative': [False, True]
   })
-  def test_emcc_cache_flag(self, use_response_files):
+  def test_emcc_cache_flag(self, use_response_files, relative):
     restore_and_set_up()
 
-    cache_dir_name = self.in_dir('emscripten_cache')
+    if relative:
+      cache_dir_name = 'emscripten_cache'
+    else:
+      cache_dir_name = self.in_dir('emscripten_cache')
     self.assertFalse(os.path.exists(cache_dir_name))
     create_file('test.c', r'''
       #include <stdio.h>

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1916,13 +1916,15 @@ def show_ports():
 
 # Once we require python 3.8 we can use shutil.copytree with
 # dirs_exist_ok=True and remove this function.
-def copytree_exist_ok(src, dest):
-  with utils.chdir(src):
-    for dirname, dirs, files in os.walk('.'):
-      destdir = os.path.join(dest, dirname)
-      utils.safe_ensure_dirs(destdir)
-      for f in files:
-        shared.safe_copy(os.path.join(src, dirname, f), os.path.join(destdir, f))
+def copytree_exist_ok(src, dst):
+  os.makedirs(dst, exist_ok=True)
+  for entry in os.scandir(src):
+    srcname = os.path.join(src, entry.name)
+    dstname = os.path.join(dst, entry.name)
+    if entry.is_dir():
+      copytree_exist_ok(srcname, dstname)
+    else:
+      shared.safe_copy(srcname, dstname)
 
 
 def install_system_headers(stamp):


### PR DESCRIPTION
Using chdir in copytree_exist_ok was causing relatives paths to fail.
Use recursion instead of os.walk to avoid this.  (This is how
os.copytree works in python's stdlib anyway).

Fixes: #14185