### PR TITLE
Fix sockets.test_enet. NFC

### DIFF
--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -284,7 +284,7 @@ class sockets(BrowserCore):
     shared.try_delete('enet')
     shutil.copytree(test_file('third_party', 'enet'), 'enet')
     with utils.chdir('enet'):
-      self.run_process([path_from_root('emconfigure'), './configure'])
+      self.run_process([path_from_root('emconfigure'), './configure', '--disable-shared'])
       self.run_process([path_from_root('emmake'), 'make'])
       enet = [self.in_dir('enet', '.libs', 'libenet.a'), '-I' + self.in_dir('enet', 'include')]
 


### PR DESCRIPTION
This isn't actually a fix for the linker crash but a workaround
to fix emscripten CI.  I'll leave the bug open until we have an
actual fix upstream.

See: #14220