### PR TITLE
Require sphinx-build 2.4.4 to build site

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,10 @@
 # TODO(sbc): switch to using Pipenv since it seems like that way to go
 # these day managing python deps.
-# These requirements are only needed for developers who want to run # flake8 on
-# the codebase, not for users of emscripten.
+# These requirements are only needed for developers who want to run flake8 on
+# the codebase and generate docs using Sphinx, not for users of emscripten.
 # Install with `pip3 install -r requirements-dev.txt`
 
 flake8==3.9.0
 flake8-unused-arguments==0.0.6
 coverage==5.5
+Sphinx==2.4.4

--- a/site/Makefile
+++ b/site/Makefile
@@ -4,12 +4,17 @@
 # You can set these variables from the command line.
 SPHINXOPTS    = -W
 SPHINXBUILD   = sphinx-build
+SPHINXVERSION = 2.4.4
 PAPER         =
 BUILDDIR      = build
 
 # User-friendly check for sphinx-build
 ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+$(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx version 2.4.4 installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
+endif
+
+ifneq ($(shell $(SPHINXBUILD) --version), $(SPHINXBUILD) $(SPHINXVERSION))
+$(error This project requires $(SPHINXBUILD) $(SPHINXVERSION), but you have $(shell $(SPHINXBUILD) --version). Please install the correct version: http://sphinx-doc.org/)
 endif
 
 # Internal variables.


### PR DESCRIPTION
Addresses https://github.com/emscripten-core/emscripten/issues/13463 following Sam's last comment: 

> The way this works today is that, at any given time, the site needs to be build with a specific sphinx version. As of today, that version is 2.4.4. I've tried to upgrade to version 3 in the past but run into issues.. but we should try again.
> 
> I really want to keep the `-W` so the site builds warning-free but perhaps we can and should fail-fast if the wrong version is used.
> 
> There are several improvements we could make here:
> 
>     1. Clearly document the exact version we require.
> 
>     2. Upgrade to a more recent version
> 
>     3. Fail fast on attempts to build the site with any other version.

New behavior if sphinx-build not found (added `version 2.4.4` to this message):
```
$ make html
Makefile:13: *** The 'sphinx-build' command was not found. Make sure you have Sphinx version 2.4.4 installed, then set the SPHINXBUILD environment variable to point to the full path of the 'sphinx-build' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/.  Stop.
```

New behavior if sphinx-build has the wrong version:
```
$ make html
Makefile:17: *** This project requires sphinx-build 2.4.4, but you have sphinx-build 4.0.1. Please install the correct version: http://sphinx-doc.org/.  Stop.
```
