### PR TITLE
Fix sdl2_gfx to build against SDL2 headers

### DIFF
--- a/tests/sdl2_misc.c
+++ b/tests/sdl2_misc.c
@@ -18,8 +18,6 @@
 int main(int argc, char *argv[])
 {
     SDL_Window *window;
-    SDL_Surface *surface;
-    SDL_Cursor *cursor;
 
     if ( SDL_Init(SDL_INIT_VIDEO) != 0 ) {
         printf("Unable to initialize SDL: %s\n", SDL_GetError());

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1616,6 +1616,10 @@ int f() {
     # symbols in the library (because LINKABLE includes the entire library).
     self.emcc(test_file('sdl2_misc.c'), ['-sLINKABLE', '-sUSE_SDL=2'], output_filename='a.out.js')
 
+  def test_sdl2_gfx_linkable(self):
+    # Same as above but for sdl2_gfx library
+    self.emcc(test_file('sdl2_misc.c'), ['-Wl,-fatal-warnings', '-sLINKABLE', '-sUSE_SDL_GFX=2'], output_filename='a.out.js')
+
   def test_libpng(self):
     shutil.copyfile(test_file('third_party/libpng/pngtest.png'), 'pngtest.png')
     self.emcc(test_file('third_party/libpng/pngtest.c'), ['--embed-file', 'pngtest.png', '-s', 'USE_LIBPNG'], output_filename='a.out.js')

--- a/tools/ports/sdl2_gfx.py
+++ b/tools/ports/sdl2_gfx.py
@@ -10,6 +10,8 @@ import logging
 TAG = '2b147ffef10ec541d3eace326eafe11a54e635f8'
 HASH = 'f39f1f50a039a1667fe92b87d28548d32adcf0eb8526008656de5315039aa21f29d230707caa47f80f6b3a412a577698cd4bbfb9458bb92ac47e6ba993b8efe6'
 
+deps = ['sdl2']
+
 
 def needed(settings):
   return settings.USE_SDL_GFX == 2
@@ -28,7 +30,7 @@ def get(ports, settings, shared):
 
     shutil.rmtree(dest_path, ignore_errors=True)
     shutil.copytree(source_path, dest_path)
-    ports.build_port(dest_path, final, [dest_path], exclude_dirs=['test'])
+    ports.build_port(dest_path, final, [dest_path], exclude_dirs=['test'], flags=['-sUSE_SDL=2'])
 
     ports.install_headers(source_path, target='SDL2')
 
@@ -37,6 +39,10 @@ def get(ports, settings, shared):
 
 def clear(ports, settings, shared):
   shared.Cache.erase_lib('libSDL2_gfx.a')
+
+
+def process_dependencies(settings):
+  settings.USE_SDL = 2
 
 
 def process_args(ports):

--- a/tools/ports/sdl2_image.py
+++ b/tools/ports/sdl2_image.py
@@ -8,6 +8,8 @@ import os
 TAG = 'version_4'
 HASH = '30a7b04652239bccff3cb1fa7cd8ae602791b5f502a96df39585c13ebc4bb2b64ba1598c0d1f5382028d94e04a5ca02185ea06bf7f4b3520f6df4cc253f9dd24'
 
+deps = ['sdl2']
+
 
 def needed(settings):
   return settings.USE_SDL_IMAGE == 2
@@ -61,8 +63,6 @@ def clear(ports, settings, shared):
 
 
 def process_dependencies(settings):
-  global deps
-  deps = ['sdl2']
   settings.USE_SDL = 2
   if 'png' in settings.SDL2_IMAGE_FORMATS:
     deps.append('libpng')

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -10,6 +10,8 @@ import logging
 TAG = 'release-2.0.2'
 HASH = 'b9d03061d177f20f4e03f3e3553afd7bfe0c05da7b9a774312b389318e747cf9724e0475e9afff6a64ce31bab0217e2afb2619d75556753fbbb6ecafa9775219'
 
+deps = ['sdl2']
+
 
 def needed(settings):
   return settings.USE_SDL_MIXER == 2
@@ -88,8 +90,6 @@ def clear(ports, settings, shared):
 
 
 def process_dependencies(settings):
-  global deps
-  deps = ['sdl2']
   settings.USE_SDL = 2
   if "ogg" in settings.SDL2_MIXER_FORMATS:
     deps.append('vorbis')

--- a/tools/ports/sdl2_net.py
+++ b/tools/ports/sdl2_net.py
@@ -9,6 +9,8 @@ import logging
 TAG = 'version_2'
 HASH = '317b22ad9b6b2f7b40fac7b7c426da2fa2da1803bbe58d480631f1e5b190d730763f2768c77c72affa806c69a1e703f401b15a1be3ec611cd259950d5ebc3711'
 
+deps = ['sdl2']
+
 
 def needed(settings):
   return settings.USE_SDL_NET == 2
@@ -40,6 +42,10 @@ def get(ports, settings, shared):
 
 def clear(ports, settings, shared):
   shared.Cache.erase_lib('libSDL2_net.a')
+
+
+def process_dependencies(settings):
+  settings.USE_SDL = 2
 
 
 def process_args(ports):


### PR DESCRIPTION
Previously it was building against SDL1 headers, which was resuling in
the wrong signature for SDL_SetError being used.

Also, be consistent in all the sdl2 ports about depending on sdl2
itself.

Fixes: #14211