### PR TITLE
Fix quoting of CMAKE_CROSSCOMPILING_EMULATOR

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -34,11 +34,10 @@ variables so that emcc etc. are used. Typical usage:
   # Append the Emscripten toolchain file if the user didn't specify one.
   if not has_substr(args, '-DCMAKE_TOOLCHAIN_FILE'):
     args.append('-DCMAKE_TOOLCHAIN_FILE=' + utils.path_from_root('cmake', 'Modules', 'Platform', 'Emscripten.cmake'))
-  node_js = config.NODE_JS
 
   if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
     node_js = config.NODE_JS[0].replace('"', '\"')
-    args.append('-DCMAKE_CROSSCOMPILING_EMULATOR="%s"' % node_js)
+    args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js}')
 
   # On Windows specify MinGW Makefiles or ninja if we have them and no other
   # toolchain was specified, to keep CMake from pulling in a native Visual

--- a/tests/cmake/post_build/CMakeLists.txt
+++ b/tests/cmake/post_build/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(post_build)
+
+add_executable(hello ../../hello_world.c)
+
+add_custom_command(TARGET hello POST_BUILD
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:hello>
+)
+
+enable_testing()
+
+add_test(NAME hello
+    COMMAND ${CMAKE_CROSSCOMPILING_EMULATOR} $<TARGET_FILE:hello>
+)

--- a/tests/cmake/post_build/out.txt
+++ b/tests/cmake/post_build/out.txt
@@ -1,0 +1,1 @@
+hello, world!

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -552,7 +552,8 @@ f.close()
     'html':        ('target_html',    'hello_world_gles.html', ['-DCMAKE_BUILD_TYPE=Release']),
     'library':     ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=MinSizeRel']),
     'static_cpp':  ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DCPP_LIBRARY_TYPE=STATIC']),
-    'stdproperty': ('stdproperty',    'helloworld.js',         [])
+    'stdproperty': ('stdproperty',    'helloworld.js',         []),
+    'post_build':  ('post_build',     'hello.js',              []),
   })
   def test_cmake(self, test_dir, output_file, cmake_args):
     # Test all supported generators.
@@ -599,6 +600,9 @@ f.close()
         if output_file.endswith('.js'):
           ret = self.run_process(config.NODE_JS + [tempdirname + '/' + output_file], stdout=PIPE).stdout
           self.assertTextDataIdentical(read_file(cmakelistsdir + '/out.txt').strip(), ret.strip())
+
+        if test_dir == 'post_build':
+          ret = self.run_process(['ctest'], env=env)
 
   # Test that the various CMAKE_xxx_COMPILE_FEATURES that are advertised for the Emscripten toolchain match with the actual language features that Clang supports.
   # If we update LLVM version and this test fails, copy over the new advertised features from Clang and place them to cmake/Modules/Platform/Emscripten.cmake.


### PR DESCRIPTION
This actually fixes two different failures, one was the quoting          
in the CMakeLists.txt file itself, which seems to have become            
more strict with later versions of cmake reporting:                      
                                                                         
```                                                                      
CMake Error at CMakeLists.txt:7 (add_custom_command):                    
  COMMAND may not contain literal quotes:                                
                                                                         
    "/usr/local/google/home/sbc/dev/wasm/emsdk/node/14.15.5_64bit/bin/node"
```                                                                      
                                                                         
This error does not occur with cmake version 3.13, for example.          
                                                                         
The second issue is with the actual runing of the tests.  Even on        
older versions of cmake this was failing with:                           
                                                                         
```                                                                                                                           
make[2]: "/usr/local/google/home/sbc/dev/wasm/emsdk/node/14.15.5_64bit/bin/node": No such file or directory
make[2]: *** [CMakeFiles/hello.dir/build.make:86: hello.js] Error 127       
make[1]: *** [CMakeFiles/Makefile2:73: CMakeFiles/hello.dir/all] Error 2 
```               

Fixes: #10028