### PR TITLE
Remove no-op quote replacement in CMAKE_CROSSCOMPILING_EMULATOR

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -36,7 +36,7 @@ variables so that emcc etc. are used. Typical usage:
     args.append('-DCMAKE_TOOLCHAIN_FILE=' + utils.path_from_root('cmake', 'Modules', 'Platform', 'Emscripten.cmake'))
 
   if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
-    node_js = config.NODE_JS[0].replace('"', '\"')
+    node_js = config.NODE_JS[0]
     args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js}')
 
   # On Windows specify MinGW Makefiles or ninja if we have them and no other


### PR DESCRIPTION
This typo was first introduced back in
b8411b9fba58b2478f1d5297d97360a65b34543f.

I verified locally that we don't need or want this attempted
replacement.  Quotation marks in the NODE_JS_[0] work fine without it
and indeed would fail if they were actually escaped correctly.

If I instead attempt to fix this escaping I get:

/bin/sh: line 1: /usr/local/google/home/sbc/dev/wasm/emsdk/node/14.15.5_64\"bit/bin/node: No such file or directory