### PR TITLE
Minify js when -Oz passed

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -309,7 +309,7 @@ def setup_environment_settings():
 
 
 def minify_whitespace():
-  return settings.OPT_LEVEL >= 2 and settings.DEBUG_LEVEL == 0
+  return settings.OPT_LEVEL >= 2 and (settings.DEBUG_LEVEL == 0 or settings.SHRINK_LEVEL >= 2)
 
 
 def embed_memfile():


### PR DESCRIPTION
I feel like this makes sense; I was looking into how to get asset size down and I realized I was passing `-Oz` but still had a bunch of JS. Maybe it should be enabled even with `-Os`?