### PR TITLE
[SPLIT_MODULE] Change secondary name to <module>.deferred.wasm

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ See docs/process.md for more on how version tagging works.
   as regular data sections.   This behaviour can be be disabled with `-Wl,-O0`.
   This should significantly reduce the size of dwarf debug information in the
   wasm binary.
+- The experimental SPLIT_MODULE setting now expects the secondary module to be
+  named `<module>.deferred.wasm` instead of `<module>.wasm.deferred`.
 
 2.0.21: 05/18/2021
 ------------------

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -835,7 +835,9 @@ var splitModuleProxyHandler = {
     return function() {
       err('placeholder function called: ' + prop);
       var imports = {'primary': Module['asm']};
-      instantiateSync(wasmBinaryFile + '.deferred', imports);
+      // Replace '.wasm' suffix with '.deferred.wasm'.
+      var deferred = wasmBinaryFile.slice(0, -5) + '.deferred.wasm'
+      instantiateSync(deferred, imports);
       err('instantiated deferred module, continuing');
 #if RELOCATABLE
       // When the table is dynamically laid out, the placeholder functions names

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10234,7 +10234,7 @@ exec "$@"
 
     os.remove('test_split_module.wasm')
     os.rename('primary.wasm', 'test_split_module.wasm')
-    os.rename('secondary.wasm', 'test_split_module.wasm.deferred')
+    os.rename('secondary.wasm', 'test_split_module.deferred.wasm')
     result = self.run_js('test_split_module.js')
     self.assertNotIn('profile', result)
     self.assertIn('Hello! answer: 42', result)
@@ -10273,7 +10273,7 @@ exec "$@"
 
     os.remove('test_split_main_module.wasm')
     os.rename('primary.wasm', 'test_split_main_module.wasm')
-    os.rename('secondary.wasm', 'test_split_main_module.wasm.deferred')
+    os.rename('secondary.wasm', 'test_split_main_module.deferred.wasm')
     result = self.run_js('test_split_main_module.js')
     self.assertNotIn('profile', result)
     self.assertIn('Hello from main!', result)


### PR DESCRIPTION
Keeping the .wasm at the end may play nicer with web servers that use the file
extension to determine the MIME type of the content.