### PR TITLE
Fix .bat launcher to allow special characters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -473,7 +473,7 @@ jobs:
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - run-tests:
-          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file wasm2.test_utf16"
+          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file wasm2.test_utf16 other.test_special_chars_in_arguments"
   test-mac:
     executor: mac
     steps:

--- a/em++.bat
+++ b/em++.bat
@@ -5,18 +5,18 @@
 :: To make modifications to this file, edit `tools/run_python_compiler.bat` and
 :: then run `tools/create_entry_points.py`
 
-@setlocal enabledelayedexpansion
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@set ARGS=%*
 @if "%_EMCC_CCACHE%"=="" (
-  :: Do regular invocation of em++.py compiler
-  "%EM_PY%" "%~dp0\%~n0.py" !ARGS!
+  :: Do regular invocation of the python compiler driver
+  set CMD="%EM_PY%" "%~dp0\%~n0.py"
 ) else (
   :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set _EMCC_CCACHE=
-  ccache "%~dp0\%~n0.bat" !ARGS!
+  set CMD=ccache "%~dp0\%~n0.bat"
 )
+
+@%CMD% %*

--- a/emcc.bat
+++ b/emcc.bat
@@ -5,18 +5,18 @@
 :: To make modifications to this file, edit `tools/run_python_compiler.bat` and
 :: then run `tools/create_entry_points.py`
 
-@setlocal enabledelayedexpansion
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@set ARGS=%*
 @if "%_EMCC_CCACHE%"=="" (
-  :: Do regular invocation of em++.py compiler
-  "%EM_PY%" "%~dp0\%~n0.py" !ARGS!
+  :: Do regular invocation of the python compiler driver
+  set CMD="%EM_PY%" "%~dp0\%~n0.py"
 ) else (
   :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set _EMCC_CCACHE=
-  ccache "%~dp0\%~n0.bat" !ARGS!
+  set CMD=ccache "%~dp0\%~n0.bat"
 )
+
+@%CMD% %*

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10534,3 +10534,12 @@ exec "$@"
       '-std=c++17',
       '-D_LIBCPP_ENABLE_CXX17_REMOVED_AUTO_PTR',
       '-Wno-deprecated-declarations'])
+
+  def test_special_chars_in_arguments(self):
+    # We had some regressions where the windows `.bat` files that run the compiler
+    # driver were failing to accept certain special characters such as `(`, `)` and `!`.
+    # See https://github.com/emscripten-core/emscripten/issues/14063
+    create_file('test(file).c', 'int main() { return 0; }')
+    create_file('test!.c', 'int main() { return 0; }')
+    self.run_process([EMCC, 'test(file).c'])
+    self.run_process([EMCC, 'test!.c'])

--- a/tools/run_python_compiler.bat
+++ b/tools/run_python_compiler.bat
@@ -5,18 +5,18 @@
 :: To make modifications to this file, edit `tools/run_python_compiler.bat` and
 :: then run `tools/create_entry_points.py`
 
-@setlocal enabledelayedexpansion
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@set ARGS=%*
 @if "%_EMCC_CCACHE%"=="" (
-  :: Do regular invocation of em++.py compiler
-  "%EM_PY%" "%~dp0\%~n0.py" !ARGS!
+  :: Do regular invocation of the python compiler driver
+  set CMD="%EM_PY%" "%~dp0\%~n0.py"
 ) else (
   :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set _EMCC_CCACHE=
-  ccache "%~dp0\%~n0.bat" !ARGS!
+  set CMD=ccache "%~dp0\%~n0.bat"
 )
+
+@%CMD% %*


### PR DESCRIPTION
Using `$*` inside the if/else blocks here was confusing the bat file
processor making it impossible to support commands that contains braces
and exclamation points.

There was an attempted fix made in #13723 which seemed hopefull but it
prevented the exclamation point.  Hopefully this will fix both cases.

Thanks to Mysoft on discord for the suggestion.

Fixes: #14063