### PR TITLE
Remove old/outdated readme. NFC

### DIFF
--- a/system/lib/libcxx/include/readme.txt
+++ b/system/lib/libcxx/include/readme.txt
@@ -1,1 +1,0 @@
-These files are from libc++, release 8.0.0.


### PR DESCRIPTION
This tree now lives under system/lib/libcxx which already
has its own readme.