### PR TITLE
Mention llvm fork in libraries forked from llvm-project.

### DIFF
--- a/system/lib/compiler-rt/readme.txt
+++ b/system/lib/compiler-rt/readme.txt
@@ -1,4 +1,14 @@
-These files are from llvm-project/compiler-rt, release 10.0.0.
+llvm's compiler-rt
+------------------
+
+These files are from the llvm-project based on release 10.0.0.
+
+We maintain a local fork of llvm-project that contains any emscripten
+specific patches:
+
+  https://github.com/emscripten-core/llvm-project
+
+The current patch is based on:
 
 tag: llvmorg-10.0.0
 git: d32170dbd5b0d54436537b6b75beaf44324e0c28
@@ -11,7 +21,9 @@ Update Instructions
 
 Run `system/lib/update_compiler_rt.py path/to/llvm-root`
 
-Local Change
-------------
+Modifications
+-------------
 
-lib/builtins/powitf2.c: enable for wasm as well as PPC
+For a list of changes from upstream see the compiler-rt files that are part of:
+
+https://github.com/llvm/llvm-project/compare/llvmorg-10.0.0...emscripten-core:emscripten-libs-10.0.0

--- a/system/lib/libcxx/readme.txt
+++ b/system/lib/libcxx/readme.txt
@@ -1,4 +1,14 @@
-These files are from libc++, release branch 10.x.
+llvm's libcxx
+-------------
+
+These files are from the llvm-project based on release 10.0.0.
+
+We maintain a local fork of llvm-project that contains any emscripten
+specific patches:
+
+  https://github.com/emscripten-core/llvm-project
+
+The current patch is based on:
 
 tag: llvmorg-10.0.0
 git: d32170dbd5b0d54436537b6b75beaf44324e0c28
@@ -8,15 +18,9 @@ Update Instructions
 
 Run `system/lib/update_libcxx.py path/to/llvm-project`
 
-Local Modification
-------------------
+Modifications
+-------------
 
-Local modifications are marked with the comment: 'XXX EMSCRIPTEN'
+For a list of changes from upstream see the libcxx files that are part of:
 
-1. Define _LIBCPP_HAS_THREAD_API_PTHREAD in libcxx/__config./
-
-2. Define _LIBCPP_ELAST in libcxx/include/config_elast.h
-
-3. Set init_priority of __start_std_streams in libcxx/iostream.cpp
-
-4. Use _LIBCPP_USING_GETENTROPY (like wasi)
+https://github.com/llvm/llvm-project/compare/llvmorg-10.0.0...emscripten-core:emscripten-libs-10.0.0

--- a/system/lib/libcxxabi/readme.txt
+++ b/system/lib/libcxxabi/readme.txt
@@ -1,4 +1,14 @@
-These files are from libc++, release branch 10.x.
+llvm's libcxxabi
+----------------
+
+These files are from the llvm-project based on release 10.0.0.
+
+We maintain a local fork of llvm-project that contains any emscripten
+specific patches:
+
+  https://github.com/emscripten-core/llvm-project
+
+The current patch is based on:
 
 tag: llvmorg-10.0.0
 git: d32170dbd5b0d54436537b6b75beaf44324e0c28
@@ -8,19 +18,9 @@ Update Instructions
 
 Run `system/lib/update_libcxxabi.py path/to/llvm-root`
 
-Local Modification
-------------------
+Modifications
+-------------
 
-Local modifications are marked with the comment: 'XXX EMSCRIPTEN'
+For a list of changes from upstream see the libcxxabi files that are part of:
 
-1. Add __cxa_can_catch and __cxa_is_pointer_type to private_typeinfo.cpp.
-
-2. Duplicate __isOurExceptionClass in cxa_handlers.cpp since we don't compile
-   cxa_exception.cpp in Emscripten EH mode.
-
-The following changes are not marked with 'XXX EMSCRIPTEN'.
-
-3. Replace throw() with _NOEXCEPT macro defined in libcxx/include/__config.
-
-4. Wasm exception handling support code is added and guarded by
-   '#ifdef __USING_WASM_EXCEPTIONS__'.
+https://github.com/llvm/llvm-project/compare/llvmorg-10.0.0...emscripten-core:emscripten-libs-10.0.0


### PR DESCRIPTION
I created a fork of llvm-project to hold our fork and make
merging new changes easier.  Use that to document the changes
rather than trying to keep these readme files up-to-date.