### PR TITLE
Rather than disabling the bullet test, temporarily remove -g from the build

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6145,6 +6145,10 @@ void* operator new(size_t size) {
   })
   # Called thus so it runs late in the alphabetical cycle... it is long
   def test_bullet(self, use_cmake):
+    if not use_cmake:
+      # Temporarily disabled
+      self.skipTest('https://github.com/emscripten-core/emscripten/issues/14255')
+
     if WINDOWS and not use_cmake:
       self.skipTest("Windows cannot run configure sh scripts")
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1670,7 +1670,6 @@ int f() {
     self.emcc(test_file('jpeg_test.c'), ['--embed-file', 'screenshot.jpg', '-s', 'USE_LIBJPEG'], output_filename='a.out.js')
     self.assertContained('Image is 600 by 450 with 3 components', self.run_js('a.out.js', args=['screenshot.jpg']))
 
-  @disabled('https://github.com/emscripten-core/emscripten/issues/14255')
   def test_bullet(self):
     self.emcc(test_file('bullet_hello_world.cpp'), ['-s', 'USE_BULLET'], output_filename='a.out.js')
     self.assertContained('BULLET RUNNING', self.run_process(config.JS_ENGINES[0] + ['a.out.js'], stdout=PIPE, stderr=PIPE).stdout)

--- a/tools/ports/bullet.py
+++ b/tools/ports/bullet.py
@@ -45,7 +45,8 @@ def get(ports, settings, shared):
       for dir in dirs:
         includes.append(os.path.join(root, dir))
 
-    ports.build_port(src_path, final, includes=includes, exclude_dirs=['MiniCL'])
+    # Debug info temporarly disabled due to: https://github.com/emscripten-core/emscripten/issues/14255
+    ports.build_port(src_path, final, includes=includes, exclude_dirs=['MiniCL'], debug_info=False)
 
   return [shared.Cache.get_lib('libbullet.a', create)]
 

--- a/tools/ports/mpg123.py
+++ b/tools/ports/mpg123.py
@@ -84,7 +84,8 @@ def get(ports, settings, shared):
       commands.append([shared.EMCC, '-c', src, '-O2', '-o', obj, '-w'] + flags)
       objects.append(obj)
 
-    ports.run_commands(commands)
+    # Debug info temporarly disabled due to: https://github.com/emscripten-core/emscripten/issues/14255
+    ports.run_commands(commands, debug_info=False)
     ports.create_lib(output_path, objects)
 
     # copy header to a location so it can be used as 'MPG123/'


### PR DESCRIPTION
We are seeing more failures related to crash that is currently
occurring when bullet is built with `-g`.  This changes the way
we temporarily work around this issue.

Also it seems that mpg123 is now also experiencing the same
crash.  All the more reason to get this fixed upstream ASAP.

See https://github.com/emscripten-core/emscripten/issues/14255