### PR TITLE
Allow unsetting default environment vars

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -568,3 +568,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Ian Jackson <ijackson@chiark.greenend.org.uk>
 * Brian Gontowski <brian@gontowski.com>
 * Bobbie Chen <bobbie.chen75@gmail.com>
+* Camillo Lugaresi <camillol@google.com> (copyright owned by Google LLC)

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -45,6 +45,9 @@ See docs/process.md for more on how version tagging works.
   could prevent running in WASI VMs, but that has not been needed any more. A
   minor side effect you might see from this is a larger wasm size in standalone
   mode when not optimizing (but optimized builds are unaffected). (#14338)
+- You can now explicitly request that an environment variable remain unset by
+  setting its value in `ENV` to `undefined`. This is useful for variables, such
+  as `LANG`, for which Emscripten normally provides a default value.
 
 2.0.23
 ------

--- a/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/Interacting-with-code.rst
@@ -752,6 +752,15 @@ For example, to set an environment variable ``MY_FILE_ROOT`` to be
 
     Module.preRun.push(function() {ENV.MY_FILE_ROOT = "/usr/lib/test"})
 
+Note that Emscripten will set default values for some environment variables
+(e.g. LANG) after you have configured ``ENV``, if you have not set your own
+values. If you want such variables to remain unset, you can explicitly set
+their value to `undefined`. For example:
+
+.. code:: javascript
+
+    Module.preRun.push(function() {ENV.LANG = undefined})
+
 .. _interacting-with-code-binding-cpp:
 
 Binding C++ and JavaScript — WebIDL Binder and Embind

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -33,7 +33,11 @@ var WasiLibrary = {
       };
       // Apply the user-provided values, if any.
       for (var x in ENV) {
-        env[x] = ENV[x];
+        // x is a key in ENV; if ENV[x] is undefined, that means it was
+        // explicitly set to be so. We allow user code to do that to
+        // force variables with default values to remain unset.
+        if (ENV[x] === undefined) delete env[x];
+        else env[x] = ENV[x];
       }
       var strings = [];
       for (var x in env) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6615,7 +6615,7 @@ mergeInto(LibraryManager.library, {
   def test_override_c_environ(self):
     create_file('pre.js', r'''
       var Module = {
-        preRun: [function() { ENV.hello = 'world' }]
+        preRun: [function() { ENV.hello = 'world'; ENV.LANG = undefined; }]
       };
     ''')
     create_file('src.cpp', r'''
@@ -6623,10 +6623,13 @@ mergeInto(LibraryManager.library, {
       #include <stdio.h>
       int main() {
         printf("|%s|\n", getenv("hello"));
+        printf("LANG is %s\n", getenv("LANG") ? "set" : "not set");
       }
     ''')
     self.run_process([EMXX, 'src.cpp', '--pre-js', 'pre.js'])
-    self.assertContained('|world|', self.run_js('a.out.js'))
+    output = self.run_js('a.out.js')
+    self.assertContained('|world|', output)
+    self.assertContained('LANG is not set', output)
 
     create_file('pre.js', r'''
       var Module = {


### PR DESCRIPTION
User code can set environment variables in ENV, which are then merged
with Emscripten's defaults. However, there is currently no way to unset
a variable entirely: if it's not set in ENV, it will just keep the
default value. For instance, you cannot unset LANG.

This change makes it possible to explicitly unset variables by setting
the corresponding entry in ENV to undefined.

Note that the existing behavior for undefined in ENV is to represent it
as the string "undefined" in C. That's not a useful behavior (anyone who
actually wants that effect will pass the JavaScript string "undefined"
instead), so we are free to repurpose it.