### PR TITLE
Add test for C++20 concepts. NFC

### DIFF
--- a/tests/other/test_concepts.cpp
+++ b/tests/other/test_concepts.cpp
@@ -1,0 +1,15 @@
+#include <concepts>
+
+template <typename T>
+concept Test = std::destructible<T>;
+
+template <Test T>
+class MyTest {
+public:
+    T value;
+};
+
+int main() {
+    MyTest<int> test;
+    return 0;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10559,3 +10559,6 @@ kill -9 $$
     with env_modify({'EM_COMPILER_WRAPPER': './die.sh'}):
       err = self.expect_fail([EMCC, test_file('hello_world.c')])
       self.assertContained('failed (received SIGKILL (-9))', err)
+
+  def test_concepts(self):
+    self.do_runf(test_file('other', 'test_concepts.cpp'), '', emcc_args=['-std=c++20'])


### PR DESCRIPTION
Now that libcxx is updated to llvm-12, test that the concepts header is
usable.

Sadly it looks like llvm has not yet implemented `std::movable` which
was requested in #14236, but that is really an upstream issue at this
point.

Fixes: #14236