### PR TITLE
Run ATMAIN functions even when HAS_MAIN is false

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -151,7 +151,7 @@ def update_settings_glue(metadata, DEBUG):
 
 def apply_static_code_hooks(forwarded_json, code):
   code = shared.do_replace(code, '<<< ATINITS >>>', str(forwarded_json['ATINITS']))
-  if settings.HAS_MAIN:
+  if forwarded_json['ATMAINS']:
     code = shared.do_replace(code, '<<< ATMAINS >>>', str(forwarded_json['ATMAINS']))
   if settings.EXIT_RUNTIME:
     code = shared.do_replace(code, '<<< ATEXITS >>>', str(forwarded_json['ATEXITS']))

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -319,9 +319,7 @@ function run(args) {
 
     initRuntime();
 
-#if HAS_MAIN
     preMain();
-#endif
 
 #if MODULARIZE
     readyPromiseResolve(Module);

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -13,7 +13,9 @@ function run() {
   emscriptenMemoryProfiler.onPreloadComplete();
 #endif
 
+#if ATMAINS.length
   <<< ATMAINS >>>
+#endif
 
 #if PROXY_TO_PTHREAD
   // User requested the PROXY_TO_PTHREAD option, so call a stub main which
@@ -47,6 +49,10 @@ function run() {
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
 #endif
+}
+#elif ATMAINS.length
+function run() {
+  <<< ATMAINS >>>
 }
 #endif
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -397,7 +397,6 @@ function initRuntime() {
   callRuntimeCallbacks(__ATINIT__);
 }
 
-#if HAS_MAIN
 function preMain() {
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
@@ -405,10 +404,11 @@ function preMain() {
 #if USE_PTHREADS
   if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
 #endif
+#if ATMAINS.length
   <<< ATMAINS >>>
+#endif
   callRuntimeCallbacks(__ATMAIN__);
 }
-#endif
 
 function exitRuntime() {
 #if STACK_OVERFLOW_CHECK

--- a/src/shell_minimal.js
+++ b/src/shell_minimal.js
@@ -108,7 +108,7 @@ function ready() {
 #if MODULARIZE && EXPORT_READY_PROMISE
   readyPromiseResolve(Module);
 #endif // MODULARIZE
-#if INVOKE_RUN && HAS_MAIN
+#if INVOKE_RUN && (HAS_MAIN || ATMAINS.length)
 #if USE_PTHREADS
   if (!ENVIRONMENT_IS_PTHREAD) {
 #endif


### PR DESCRIPTION
This behaviour was removed in 6e794e6 but it turns out the the sole user
of ATMAIN (library_fs.js) was depending on this to run, even in programs
with no main function.

Fixes: #14299