### PR TITLE
signals: add stub for sigwait

### DIFF
--- a/src/library_signals.js
+++ b/src/library_signals.js
@@ -157,7 +157,18 @@ var funs = {
   sigpending: function(set) {
     {{{ makeSetValue('set', 0, 0, 'i32') }}};
     return 0;
+  },
+
+  sigwait: function(set, sig) {
+    // POSIX SIGNALS are not supported
+    // if set contains an invalid signal number, EINVAL is returned
+    // in our case we return EINVAL all the time
+#if ASSERTIONS
+    err('Calling stub instead of sigwait()');
+#endif
+    return {{{ cDefine('EINVAL') }}};
   }
+	
   //signalfd
   //ppoll
   //epoll_pwait


### PR DESCRIPTION
Since POSIX signals are not supported, this allows code using sigwait() to receive -1, and not fail during compilation.