### PR TITLE
Switch from addAtMain to addAtInit in library_fs.js

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -27,13 +27,17 @@ mergeInto(LibraryManager.library, {
     ],
   $FS__postset: function() {
     // TODO: do we need noFSInit?
-    addAtInit('if (!Module["noFSInit"] && !FS.init.initialized) FS.init();');
-    addAtMain('FS.ignorePermissions = false;');
+    addAtInit(`
+if (!Module["noFSInit"] && !FS.init.initialized)
+  FS.init();
+FS.ignorePermissions = false;
+`)
     addAtExit('FS.quit();');
     // We must statically create FS.FSNode here so that it is created in a manner
     // that is visible to Closure compiler. That lets us use type annotations for
     // Closure to the "this" pointer in various node creation functions.
-    return `var FSNode = /** @constructor */ function(parent, name, mode, rdev) {
+    return `
+var FSNode = /** @constructor */ function(parent, name, mode, rdev) {
   if (!parent) {
     parent = this;  // root node sets parent to itself
   }
@@ -97,8 +101,8 @@ FS.staticInit();` +
     initialized: false,
     // Whether we are currently ignoring permissions. Useful when preparing the
     // filesystem and creating files inside read-only folders.
-    // This is set to false when the runtime is initialized, allowing you
-    // to modify the filesystem freely before run() is called.
+    // This is set to false during `preInit`, allowing you to modify the
+    // filesystem freely up until that point (e.g. during `preRun`).
     ignorePermissions: true,
     trackingDelegate: {},
     tracking: {

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1078,6 +1078,8 @@ function addAtInit(code) {
   ATINITS.push(code);
 }
 
+// TODO(sbc): There are no more uses to ATMAINS or addAtMain in emscripten.
+// We should look into removing these.
 global.ATMAINS = [];
 
 function addAtMain(code) {


### PR DESCRIPTION
Using addAtMain stopped working for programs without main functions
(HAS_MAIN not defined) after #13901.

Code that needs to populate the FS is mostly likely going to be run
during preRun callback which all happen before ATINITs.