### PR TITLE
emcmake: Require compatible generator when running on windows

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -47,6 +47,9 @@ variables so that emcc etc. are used. Typical usage:
       args += ['-G', 'MinGW Makefiles']
     elif utils.which('ninja'):
       args += ['-G', 'Ninja']
+    else:
+      print('emcmake: no compatible cmake generator found; Please install ninja or mingw32-make, or specify a generator explicitly using -G', file=sys.stderr)
+      return 1
 
   # CMake has a requirement that it wants sh.exe off PATH if MinGW Makefiles
   # is being used. This happens quite often, so do this automatically on


### PR DESCRIPTION
We have had several reports of folks trying and failing to use the
harfbuzz (via sdl2_ttf) port and failing on windows because no
compatible cmake generator was available.

The default generator on windows (Visual Studio) won't work for cross
compiling.

This doesn't fix the issue but at least gives an actionable error
message.

Fixes: #14321
Fixes: #14027