### PR TITLE
Update fetch.rst to display cli args in monotype

### DIFF
--- a/site/source/docs/api_reference/fetch.rst
+++ b/site/source/docs/api_reference/fetch.rst
@@ -12,8 +12,8 @@ network requests can be run either synchronously or asynchronously as desired.
 
 .. note::
 
-  In order to use the Fetch API, you would need to compile your code with **-s
-  FETCH=1**.
+  In order to use the Fetch API, you would need to compile your code with ``-s
+  FETCH=1``.
 
 Introduction
 ============
@@ -193,11 +193,11 @@ emscripten_fetch() returns.
   restrictions, depending on which Emscripten build mode (linker flags) is used:
 
   - **No flags**: Only asynchronous Fetch operations are available.
-  - **--proxy-to-worker**: Synchronous Fetch operations are allowed for fetches
+  - ``--proxy-to-worker``: Synchronous Fetch operations are allowed for fetches
     that only do an XHR but do not interact with IndexedDB.
-  - **-s USE_PTHREADS=1**: Synchronous Fetch operations are available on
+  - ``-s USE_PTHREADS=1``: Synchronous Fetch operations are available on
     pthreads, but not on the main thread.
-  - **--proxy-to-worker** + **-s USE_PTHREADS=1**: Synchronous Fetch operations
+  - ``--proxy-to-worker`` + ``-s USE_PTHREADS=1``: Synchronous Fetch operations
     are available both on the main thread and pthreads.
 
 Waitable Fetches
@@ -241,10 +241,10 @@ issuing thread can perform some other work until the fetch completes.
 
   Waitable fetches are available only in certain build modes:
 
-  - **No flags** or **--proxy-to-worker**: Waitable fetches are not available.
-  - **-s USE_PTHREADS=1**: Waitable fetches are available on pthreads, but not
+  - **No flags** or ``--proxy-to-worker``: Waitable fetches are not available.
+  - ``-s USE_PTHREADS=1``: Waitable fetches are available on pthreads, but not
     on the main thread.
-  - **--proxy-to-worker** + **-s USE_PTHREADS=1**: Waitable fetches are
+  - ``--proxy-to-worker`` + ``-s USE_PTHREADS=1``: Waitable fetches are
     available on all threads.
 
 Tracking Progress


### PR DESCRIPTION
The text `--proxy-to-worker` is currently displayed as `–proxy-to-worker` (note the single wide-dash instead of two hyphens) at https://emscripten.org/docs/api_reference/fetch.html?highlight=fetch.

I have modified the page's source to display `--proxy-to-worker` and other cli args in monotype which should prevent this.

I spent a few hours with the linker flag `-proxy-to-worker` before second guessing whether it should have a second leading hyphen.
I hope this change can save others that time :)