### PR TITLE
Fix for `-lGL` + `AUTO_NATIVE_LIBRARIES=0`

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3523,6 +3523,17 @@ def process_libraries(state, linker_inputs):
       continue
 
     logger.debug('looking for library "%s"', lib)
+    js_libs, native_lib = building.map_to_js_libs(lib)
+    if js_libs is not None:
+      libraries += [(i, js_lib) for js_lib in js_libs]
+      # If native_lib is returned then include it in the link
+      # via forced_stdlibs.
+      if native_lib:
+        state.forced_stdlibs.append(native_lib)
+      continue
+
+    if building.map_and_apply_to_settings(lib):
+      continue
 
     path = None
     for suff in suffixes:
@@ -3534,11 +3545,8 @@ def process_libraries(state, linker_inputs):
     if path:
       linker_inputs.append((i, path))
       continue
-    jslibs = building.map_to_js_libs(lib)
-    if jslibs is not None:
-      libraries += [(i, jslib) for jslib in jslibs]
-    elif not building.map_and_apply_to_settings(lib):
-      new_flags.append((i, flag))
+
+    new_flags.append((i, flag))
 
   settings.SYSTEM_JS_LIBRARIES += libraries
 

--- a/tests/other/test_explict_gl_linking.c
+++ b/tests/other/test_explict_gl_linking.c
@@ -1,0 +1,5 @@
+#include <EGL/egl.h>
+
+int main() {
+    return (int)eglGetProcAddress("foo");
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10645,3 +10645,9 @@ kill -9 $$
     self.assertContained(' -lc-mt ', err)
     self.assertContained(' -ldlmalloc-mt ', err)
     self.assertContained(' -lcompiler_rt-mt ', err)
+
+  def test_explict_gl_linking(self):
+    # Test that libGL can be linked explictly via `-lGL` rather than implictly.
+    # Here we use NO_AUTO_NATIVE_LIBRARIES to disable the implictly linking that normally
+    # includes the native GL library.
+    self.run_process([EMCC, test_file('other/test_explict_gl_linking.c'), '-sNO_AUTO_NATIVE_LIBRARIES', '-lGL'])

--- a/tools/building.py
+++ b/tools/building.py
@@ -1333,10 +1333,14 @@ def is_wasm_dylib(filename):
   return False
 
 
-# Given the name of a special Emscripten-implemented system library, returns an
-# array of absolute paths to JS library files inside emscripten/src/ that
-# corresponds to the library name.
 def map_to_js_libs(library_name):
+  """Given the name of a special Emscripten-implemented system library, returns an
+  pair containing
+  1. Array of absolute paths to JS library files, inside emscripten/src/ that corresponds to the
+     library name. `None` means there is no mapping and the library will be processed by the linker
+     as a require for normal native library.
+  2. Optional name of a corresponding native library to link in.
+  """
   # Some native libraries are implemented in Emscripten as system side JS libraries
   library_map = {
     'EGL': ['library_egl.js'],
@@ -1364,23 +1368,21 @@ def map_to_js_libs(library_name):
     # This is the name of GNU's C++ standard library. We ignore it here
     # for compatability with GNU toolchains.
     'stdc++': [],
-    # This means that linking against libc with `-lc` is ignored when the
-    # library is not found (It does work if library already exists in the
-    # sysroot because that case is handled before we call (map_to_js_libs).
-    # TODO(sbc): We should probably remove this and allow `-lc` to make it all
-    # the way to the linker.
-    'c': [],
+  }
+  # And some are hybrid and require JS and native libraries to be included
+  native_library_map = {
+    'GL': 'libgl',
   }
 
   if library_name in library_map:
     libs = library_map[library_name]
     logger.debug('Mapping library `%s` to JS libraries: %s' % (library_name, libs))
-    return libs
+    return (libs, native_library_map.get(library_name))
 
   if library_name.endswith('.js') and os.path.isfile(path_from_root('src', 'library_' + library_name)):
-    return ['library_' + library_name]
+    return (['library_' + library_name], None)
 
-  return None
+  return (None, None)
 
 
 # Map a linker flag to a settings. This lets a user write -lSDL2 and it will have the same effect as


### PR DESCRIPTION
When calling `map_to_js_libs('GL')` we were mapping this to the JS          
libraries, and not also including the native `libgl` library.  Normally  
this doesn't matter since `libgl` is included by default, but not
when `AUTO_NATIVE_LIBRARIES=0` is used.     

This also happens to fix an old bug (#10171) where we would look on the                            
file system for `libGL.a` before looking in `map_to_js_libs`.

Fixes: #10171
Fixes: #14335