### PR TITLE
Stop doing extra optimization work in standalone mode

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,11 @@ See docs/process.md for more on how version tagging works.
 - Reinstated the warning on linker-only `-s` settings passed when not linking
   (i.e. when compiling with `-c`).  As before this can disabled with
   `-Wno-unused-command-line-argument` (#14182).
+- Standalone wasm mode no longer does extra binaryen work during link. It used
+  to remove unneeded imports, in hopes of avoiding nonstandard imports that
+  could prevent running in WASI VMs, but that has not been needed any more. A
+  minor side effect you might see from this is a larger wasm size in standalone
+  mode when not optimizing (but optimized builds are unaffected).
 
 2.0.23
 ------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -37,7 +37,7 @@ See docs/process.md for more on how version tagging works.
   to remove unneeded imports, in hopes of avoiding nonstandard imports that
   could prevent running in WASI VMs, but that has not been needed any more. A
   minor side effect you might see from this is a larger wasm size in standalone
-  mode when not optimizing (but optimized builds are unaffected).
+  mode when not optimizing (but optimized builds are unaffected). (#14338)
 
 2.0.23
 ------

--- a/emcc.py
+++ b/emcc.py
@@ -521,10 +521,6 @@ def get_binaryen_passes():
       passes += ['--no-exit-runtime']
   if run_binaryen_optimizer:
     passes += [building.opt_level_to_str(settings.OPT_LEVEL, settings.SHRINK_LEVEL)]
-  elif settings.STANDALONE_WASM:
-    # even if not optimizing, make an effort to remove all unused imports and
-    # exports, to make the wasm as standalone as possible
-    passes += ['--remove-unused-module-elements']
   # when optimizing, use the fact that low memory is never used (1024 is a
   # hardcoded value in the binaryen pass)
   if run_binaryen_optimizer and settings.GLOBAL_BASE >= 1024:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9683,6 +9683,8 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     ok(required_flags + ['-O1'])
     # Exception support shouldn't require changes after linking
     ok(required_flags + ['-fexceptions'])
+    # Standalone mode should not do anything special to the wasm.
+    ok(required_flags + ['-sSTANDALONE_WASM'])
 
     # other builds fail with a standard message + extra details
     def fail(args, details):


### PR DESCRIPTION
Before this PR we would try to remove unneeded imports, as they might cause
a wasm not to run in a WASI VM if it were nonstandard. However, I think that
was only an issue when bringing up standalone mode (as we converted nonstandard
things to WASI). Today, I verified that building hello world (even with C++ iostreams)
in `-O0` will run in both wasmtime and wasmer without issue.

While there may be cases in which there are nonstandard imports, it is best
to let the user explicitly run the optimizer to work around that, as otherwise it
adds complexity (in particular, as @sbc100 noticed, if we automatically run the
optimizer even in unoptimized builds, it means that
`ERROR_ON_WASM_CHANGES_AFTER_LINK` will always error in
standalone mode).