### PR TITLE
Use `-lxxx` internally rather than full library path

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,12 @@ See docs/process.md for more on how version tagging works.
 2.0.24
 ------
 - Support `--preload-file` in Node.js. (#11785)
+- System libraries are now passed to the linker internally via `-lfoo` rather
+  than using their full path.  This is in line with how gcc and clang pass system
+  libraries to the linker.  This should not effect any builds unless a project a
+  happens to have, for example, a file called `libc.a` in one of its library
+  paths.  This would have the effect of overriding the system library (as it
+  would with gcc or clang) (#14342).
 - CMake projects (those that either use emcmake or use Emscripten.cmake
   directly) are new configured to install (by default) directly into the
   emscripten sysroot.  This means that running `cmake --install` (or running the

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -300,6 +300,20 @@ class Library:
     """
     return shared.Cache.get_lib(self.get_filename(), self.build)
 
+  def get_link_flag(self):
+    """
+    Gets the link flags needed to use the library.
+
+    This will trigger a build if this library is not in the cache.
+    """
+    fullpath = self.get_path()
+    # For non-libaries (e.g. crt1.o) we pass the entire path to the linker
+    if self.get_ext() != '.a':
+      return fullpath
+    # For libraries (.a) files, we pass the abbreviated `-l` form.
+    base = shared.unsuffixed_basename(fullpath)
+    return '-l' + shared.strip_prefix(base, 'lib')
+
   def get_files(self):
     """
     Gets a list of source files for this library.
@@ -1487,7 +1501,7 @@ def calculate(input_files, forced):
     logger.debug('including %s (%s)' % (lib.name, lib.get_filename()))
 
     need_whole_archive = lib.name in force_include and lib.get_ext() == '.a'
-    libs_to_link.append((lib.get_path(), need_whole_archive))
+    libs_to_link.append((lib.get_link_flag(), need_whole_archive))
 
   if settings.USE_PTHREADS:
     add_library('crtbegin')


### PR DESCRIPTION
Since we already supply the correct `-L` path we can rely on wasm-ld to
find, for example, `libc.a` by simply passing `-lc` rather than its full
path.

This is in line with what gcc and clang do.

This is almost NFC, except in that case where the user supplies a
library path via `-L` which happens to contain a system library
(e.g. `libc.a`).  In this case, as with clang or gcc, that file will be
chosen over the system one.

This makes the linker command lines shorter, more readable, more inline
with other compilers.