### PR TITLE
Remove unused include in emmintrin.h

### DIFF
--- a/system/include/compat/emmintrin.h
+++ b/system/include/compat/emmintrin.h
@@ -12,7 +12,6 @@
 #endif
 
 #include <xmmintrin.h>
-#include <emscripten/emscripten.h>
 
 #define __MIN(x, y) ((x) <= (y) ? (x) : (y))
 #define __MAX(x, y) ((x) >= (y) ? (x) : (y))


### PR DESCRIPTION
In `system/include/compat/emmintrin.h`, including `<emscripten/emscripten.h>` seems to be meaningless.
([Some libraries](https://github.com/Cyan4973/xxHash/blob/dev/xxhash.h#L2587) tries to use SSE headers in C language linkage, which causes the compile error that templates are not available in C language linkage.)