### PR TITLE
Rename libgl.a -> libGL.a

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -48,7 +48,7 @@ MINIMAL_TASKS = [
     'libemmalloc-memvalidate',
     'libemmalloc-verbose',
     'libemmalloc-memvalidate-verbose',
-    'libgl',
+    'libGL',
     'libhtml5',
     'libsockets',
     'libc_rt_wasm',
@@ -91,6 +91,9 @@ USER_TASKS = [
 temp_files = shared.configuration.get_temp_files()
 logger = logging.getLogger('embuilder')
 force = False
+legacy_prefixes = {
+  'libgl': 'libGL',
+}
 
 
 def get_help():
@@ -170,6 +173,9 @@ def main():
     tasks = [x for x in tasks if x not in skip_tasks]
     print('Building targets: %s' % ' '.join(tasks))
   for what in tasks:
+    for old, new in legacy_prefixes.items():
+      if what.startswith(old):
+        what = what.replace(old, new)
     logger.info('building and verifying ' + what)
     start_time = time.time()
     if what in SYSTEM_LIBRARIES:

--- a/tools/building.py
+++ b/tools/building.py
@@ -1371,7 +1371,7 @@ def map_to_js_libs(library_name):
   }
   # And some are hybrid and require JS and native libraries to be included
   native_library_map = {
-    'GL': 'libgl',
+    'GL': 'libGL',
   }
 
   if library_name in library_map:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1104,8 +1104,8 @@ class libal(Library):
   src_files = ['al.c']
 
 
-class libgl(MTLibrary):
-  name = 'libgl'
+class libGL(MTLibrary):
+  name = 'libGL'
 
   src_dir = ['system', 'lib', 'gl']
   src_files = ['gl.c', 'webgl1.c', 'libprocaddr.c']
@@ -1526,7 +1526,7 @@ def calculate(input_files, forced):
     add_library('libcompiler_rt')
   else:
     if settings.AUTO_NATIVE_LIBRARIES:
-      add_library('libgl')
+      add_library('libGL')
       add_library('libal')
       add_library('libhtml5')
 


### PR DESCRIPTION
This is how the library is traditionally named.  This is
mostly and implementation detail since we map incoming
`-lGL` to whatever name we choose in `map_to_js_libs`.

Related to https://github.com/emscripten-core/emscripten/issues/14341
and https://github.com/emscripten-core/emscripten/pull/14342.