### PR TITLE
musl: fix weak_alias in projects expecting glibc behavior

### DIFF
--- a/system/lib/libc/musl/src/internal/libc.h
+++ b/system/lib/libc/musl/src/internal/libc.h
@@ -61,7 +61,7 @@ extern char **__environ;
 
 #undef weak_alias
 #define weak_alias(old, new) \
-	extern __typeof(old) new __attribute__((weak, alias(#old)))
+	extern __typeof(old) new __attribute__((weak, alias(#old)));
 
 #undef LFS64_2
 #define LFS64_2(x, y) weak_alias(x, y)


### PR DESCRIPTION
This patch fixes #14350, by adding a semicolon. The macro can be
used in both cases :
- weak_alias(fun, alias)
- weak_alias(fun, alias);

This is possible because calling (for eg.) :
```C
extern __typeof(__memchr) memchr __attribute__((__weak__, __alias__("__memchr")));;
```

with two semicolons is valid, it won't break the current `weak_alias();` calls in musl with the semicolon