### PR TITLE
Map user-specified system libraries to correct variants

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -490,13 +490,14 @@ class Library:
 
     This returns a dictionary of simple names to Library objects.
     """
-    result = {}
-    for subclass in cls.get_inheritance_tree():
-      if subclass.name:
-        library = subclass.get_default_variation()
-        if library.can_build() and library.can_use():
-          result[subclass.name] = library
-    return result
+    if not hasattr(cls, 'useable_variations'):
+      cls.useable_variations = {}
+      for subclass in cls.get_inheritance_tree():
+        if subclass.name:
+          library = subclass.get_default_variation()
+          if library.can_build() and library.can_use():
+            cls.useable_variations[subclass.name] = library
+    return cls.useable_variations
 
 
 class MTLibrary(Library):


### PR DESCRIPTION
Normally users don't specify system libraries such as
`libc` or `compiler-rt` on the command line.  However, when
they do, it makes sense map them to correct variant.

For example, linking with `-pthread` + `-lc` will now
end up including `libc-mt.a` rather than `libc.a`.

Fixes: #14341