### PR TITLE
Fix erroneous skipping of extra link flags

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -462,7 +462,11 @@ def filter_link_flags(flags, using_lld):
         # lld allows various flags to have either a single -foo or double --foo
         if f.startswith(flag) or f.startswith('-' + flag):
           diagnostics.warning('linkflags', 'ignoring unsupported linker flag: `%s`', f)
-          return False, takes_arg
+          # Skip the next argument if this linker flag takes and argument and that
+          # argument was not specified as a separately (i.e. it was specified as
+          # single arg containing an `=` char.)
+          skip_next = takes_arg and '=' not in f
+          return False, skip_next
       return True, False
     else:
       if f in SUPPORTED_LINKER_FLAGS:
@@ -748,11 +752,6 @@ def emsdk_ldflags(user_args):
 
   if '-nostdlib' in user_args:
     return ldflags
-
-  # TODO(sbc): Add system libraries here rather than conditionally including
-  # them via .symbols files.
-  libraries = []
-  ldflags += ['-l' + l for l in libraries]
 
   return ldflags
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9536,6 +9536,12 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     out = self.run_process([EMXX, test_file('hello_world.cpp'), '-Wl,-version-script,foo'], stderr=PIPE).stderr
     self.assertContained('warning: ignoring unsupported linker flag: `-version-script`', out)
 
+  def test_supported_linker_flag_skip_next(self):
+    # Regression test for a bug where skipping an unsupported linker flag
+    # could skip the next unrelated linker flag.
+    err = self.expect_fail([EMXX, test_file('hello_world.cpp'), '-Wl,-rpath=foo', '-lbar'])
+    self.assertContained('error: unable to find library -lbar', err)
+
   def test_linker_flags_pass_through(self):
     err = self.expect_fail([EMXX, test_file('hello_world.cpp'), '-Wl,--waka'])
     self.assertContained('wasm-ld: error: unknown argument: --waka', err)


### PR DESCRIPTION
When skipping unsupported linker flags we were not correctly handling
the case were the argument and its parameter were part of the same
argument joined with a `=`.