### PR TITLE
Disable lsan.test_asyncify_during_exit. NFC

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7591,6 +7591,8 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('ASSERTIONS')
     self.do_core_test('asyncify_assertions.cpp')
 
+  @no_lsan('leaks asyncify stack during exit')
+  @no_asan('leaks asyncify stack during exit')
   def test_asyncify_during_exit(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASSERTIONS')
@@ -8679,9 +8681,9 @@ wasm2ss = make_run('wasm2ss', emcc_args=['-O2'], settings={'STACK_OVERFLOW_CHECK
 # Add DEFAULT_TO_CXX=0
 strict = make_run('strict', emcc_args=[], settings={'STRICT': 1})
 
-lsan = make_run('lsan', emcc_args=['-fsanitize=leak', '-O2'], settings={'ALLOW_MEMORY_GROWTH': 1})
-asan = make_run('asan', emcc_args=['-fsanitize=address', '-O2'], settings={'ALLOW_MEMORY_GROWTH': 1, 'INITIAL_MEMORY': '500mb'})
-asani = make_run('asani', emcc_args=['-fsanitize=address', '-O2', '--pre-js', os.path.join(os.path.dirname(__file__), 'asan-no-leak.js')],
+lsan = make_run('lsan', emcc_args=['-fsanitize=leak', '--profiling', '-O2'], settings={'ALLOW_MEMORY_GROWTH': 1})
+asan = make_run('asan', emcc_args=['-fsanitize=address', '--profiling', '-O2'], settings={'ALLOW_MEMORY_GROWTH': 1, 'INITIAL_MEMORY': '500mb'})
+asani = make_run('asani', emcc_args=['-fsanitize=address', '--profiling', '-O2', '--pre-js', os.path.join(os.path.dirname(__file__), 'asan-no-leak.js')],
                  settings={'ALLOW_MEMORY_GROWTH': 1, 'INITIAL_MEMORY': '500mb'})
 
 # Experimental modes (not tested by CI)


### PR DESCRIPTION
This test allocates the asyncify stack during the exit handlers and
it's never freed.

Interestingly enough this leak was not caught prior to #14280.
I did some investigation and found that prior to #14280 this
chunk was bring detected a reachable via the conservative stack
scan here:

 https://github.com/emscripten-core/emscripten/blob/98a8cbf5032f8d369be636a59180a59f1eb8833f/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp#L141-L153

If I comment out this stack scan then this leak will be
detected even before #14280

Also, add `--profiling` to asan and lsan builds to make
error reports more useful.

See #14360