### PR TITLE
Assert on calling main more than once

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -119,7 +119,7 @@ function callMain(args) {
 #if ASSERTIONS
   assert(runDependencies == 0, 'cannot call main when async dependencies remain! (listen on Module["onRuntimeInitialized"])');
   assert(__ATPRERUN__.length == 0, 'cannot call main when preRun functions remain to be called');
-  assert(!calledMain, 'main() is special in that it should only be called once in the C ABI');
+  assert(!calledMain, 'in the C world, main() is special in that it should only be called once');
 #endif
 
 #if STANDALONE_WASM

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -119,6 +119,7 @@ function callMain(args) {
 #if ASSERTIONS
   assert(runDependencies == 0, 'cannot call main when async dependencies remain! (listen on Module["onRuntimeInitialized"])');
   assert(__ATPRERUN__.length == 0, 'cannot call main when preRun functions remain to be called');
+  assert(!calledMain, 'main() is special in that it should only be called once in the C ABI');
 #endif
 
 #if STANDALONE_WASM


### PR DESCRIPTION
If `callMain` is called more than once, bad things can happen, such as
the stack allocation of argv perhaps overflowing, or issues with the runtime
initialization/shutdown. In general, in the C world it is simply not valid to
call main multiple times, so it seems reasonable to enforce this.

However, there might be a use case I am missing?

Background: #14312