### PR TITLE
Gracefully handle running out of memory while IDBFS operation

### DIFF
--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -209,7 +209,12 @@ mergeInto(LibraryManager.library, {
       };
     },
     storeRemoteEntry: function(store, path, entry, callback) {
-      var req = store.put(entry, path);
+      try {
+        var req = store.put(entry, path);
+      } catch (e) {
+        callback(this.error);
+        return;
+      }
       req.onsuccess = function() { callback(null); };
       req.onerror = function(e) {
         callback(this.error);

--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -212,7 +212,7 @@ mergeInto(LibraryManager.library, {
       try {
         var req = store.put(entry, path);
       } catch (e) {
-        callback(this.error);
+        callback(e);
         return;
       }
       req.onsuccess = function() { callback(null); };


### PR DESCRIPTION
We can see a pretty substantial amount of errors on Firefox caused OOM during IDBFS operation: 
> Failed to execute 'put' on 'IDBObjectStore': Data cannot be cloned, out of memory

This mostly is happening for Windows 7 users - therefore I assume 32bit browsers. 

This patch aims to gracefully handle this