### PR TITLE
Fixup ES6 URL locator for Closure

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -746,17 +746,18 @@ function instrumentWasmTableWithAbort() {
 }
 #endif
 
+var wasmBinaryFile;
 #if EXPORT_ES6 && USE_ES6_IMPORT_META && !SINGLE_FILE
 if (Module['locateFile']) {
 #endif
-  var wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
+  wasmBinaryFile = '{{{ WASM_BINARY_FILE }}}';
   if (!isDataURI(wasmBinaryFile)) {
     wasmBinaryFile = locateFile(wasmBinaryFile);
   }
 #if EXPORT_ES6 && USE_ES6_IMPORT_META && !SINGLE_FILE // in single-file mode, repeating WASM_BINARY_FILE would emit the contents again
 } else {
   // Use bundler-friendly `new URL(..., import.meta.url)` pattern; works in browsers too.
-  var wasmBinaryFile = new URL('{{{ WASM_BINARY_FILE }}}', import.meta.url).toString();
+  wasmBinaryFile = new URL('{{{ WASM_BINARY_FILE }}}', import.meta.url).toString();
 }
 #endif
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -217,6 +217,12 @@ class other(RunnerCore):
     self.assertNotContained("new URL('data:", src)
     self.assertContained("new Worker(new URL('hello_world.worker.js', import.meta.url))", src)
 
+  def test_emcc_output_mjs_closure(self):
+    self.run_process([EMCC, '-o', 'hello_world.mjs',
+                      test_file('hello_world.c'), '--closure=1'])
+    src = read_file('hello_world.mjs')
+    self.assertContained('new URL("hello_world.wasm", import.meta.url)', src)
+
   def test_export_es6_implies_modularize(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-s', 'EXPORT_ES6=1'])
     src = read_file('a.out.js')


### PR DESCRIPTION
Tweaking the preamble a bit to make `--closure 1` work with ES6 URL locators.

Looks like Closure doesn't like the duplicate variable declaration, even though it's perfectly valid JS (they're normally just merged into a single declaration).