### PR TITLE
Remove weak_alias from musl/include/features.h.

### DIFF
--- a/system/lib/libc/musl/include/features.h
+++ b/system/lib/libc/musl/include/features.h
@@ -33,7 +33,4 @@
 #define _Noreturn
 #endif
 
-#define weak_alias(old, new) \
-	extern __typeof(old) new __attribute__((__weak__, __alias__(#old)))
-
 #endif

--- a/system/lib/libc/musl/src/string/stpcpy.c
+++ b/system/lib/libc/musl/src/string/stpcpy.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
+#include "libc.h"
 
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)

--- a/system/lib/libc/musl/src/string/stpncpy.c
+++ b/system/lib/libc/musl/src/string/stpncpy.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
+#include "libc.h"
 
 #define ALIGN (sizeof(size_t)-1)
 #define ONES ((size_t)-1/UCHAR_MAX)

--- a/system/lib/libc/musl/src/string/strchrnul.c
+++ b/system/lib/libc/musl/src/string/strchrnul.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
+#include "libc.h"
 
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)


### PR DESCRIPTION
This was added in #11215 to maintain comatability with upgraded version
of stpcpy.c/stpncpy.c/strchrnul.c.

However, this macro was never indended to exposed outside of musl
itself.  In musl v1.2.2 this macro lives in the *internal* version of
features.h but musl v1.1.15 does't have an internal features.h.  Instead
this macro lives in libc.h in v1.1.15.

See: #14352
Fixes: #14350