### PR TITLE
Separate out handling of dummy glibc libraries. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3507,6 +3507,14 @@ def process_libraries(link_flags, lib_dirs, linker_inputs):
   libraries = []
   suffixes = STATICLIB_ENDINGS + DYNAMICLIB_ENDINGS
   system_libs_map = system_libs.Library.get_usable_variations()
+  # These libraries are seperate under glibc but with musl they are all rolled into
+  # a single libc.  For compatability we silectly ignore these.
+  ignore_libraries = [
+    'm',
+    'rt',
+    'pthread',
+    'dl',
+  ]
 
   # Find library files
   for i, flag in link_flags:
@@ -3514,6 +3522,8 @@ def process_libraries(link_flags, lib_dirs, linker_inputs):
       new_flags.append((i, flag))
       continue
     lib = strip_prefix(flag, '-l')
+    if lib in ignore_libraries:
+      continue
     # We don't need to resolve system libraries to absolute paths here, we can just
     # let wasm-ld handle that.  However, we do want to map to the correct variant.
     # For example we map `-lc` to `-lc-mt` if we are building with threading support.

--- a/tools/building.py
+++ b/tools/building.py
@@ -1340,7 +1340,6 @@ def map_to_js_libs(library_name):
   # Some native libraries are implemented in Emscripten as system side JS libraries
   library_map = {
     'c': [],
-    'dl': [],
     'EGL': ['library_egl.js'],
     'GL': ['library_webgl.js', 'library_html5_webgl.js'],
     'webgl.js': ['library_webgl.js', 'library_html5_webgl.js'],
@@ -1351,10 +1350,7 @@ def map_to_js_libs(library_name):
     'glfw3': ['library_glfw.js'],
     'GLU': [],
     'glut': ['library_glut.js'],
-    'm': [],
     'openal': ['library_openal.js'],
-    'rt': [],
-    'pthread': [],
     'X11': ['library_xlib.js'],
     'SDL': ['library_sdl.js'],
     'stdc++': [],


### PR DESCRIPTION
Note that libc and libstdc++ are a little different and we might want to revisit how to handle those.

Split out from #14337