### PR TITLE
Add @require_v8 and @require_node test decorators. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -461,6 +461,7 @@ jobs:
       # clang can compile but not link in the current setup, see
       # https://github.com/emscripten-core/emscripten/pull/11382#pullrequestreview-428902638
       EMTEST_LACKS_NATIVE_CLANG: "1"
+      EMTEST_SKIP_V8: "1"
     steps:
       - checkout
       - run:
@@ -478,6 +479,8 @@ jobs:
           test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file wasm2.test_utf16 other.test_special_chars_in_arguments"
   test-mac:
     executor: mac
+    environment:
+      EMTEST_SKIP_V8: "1"
     steps:
       - run:
           name: Install brew package dependencies

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -208,6 +208,26 @@ def requires_native_clang(func):
   return decorated
 
 
+def require_node(func):
+  assert callable(func)
+
+  def decorated(self, *args, **kwargs):
+    self.require_node()
+    return func(self, *args, **kwargs)
+
+  return decorated
+
+
+def require_v8(func):
+  assert callable(func)
+
+  def decorated(self, *args, **kwargs):
+    self.require_v8()
+    return func(self, *args, **kwargs)
+
+  return decorated
+
+
 def node_pthreads(f):
   def decorated(self):
     self.set_setting('USE_PTHREADS')
@@ -418,6 +438,22 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       self.skipTest('no dynamic linking support in ASan yet')
     if '-fsanitize=leak' in self.emcc_args:
       self.skipTest('no dynamic linking support in LSan yet')
+
+  def require_v8(self):
+    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
+      if 'EMTEST_SKIP_V8' in os.environ:
+        self.skipTest('test requires v8 and EMTEST_SKIP_V8 is set')
+      else:
+        self.fail('d8 required to run this test.  Use EMTEST_SKIP_V8 to skip')
+    self.js_engines = [config.V8_ENGINE]
+
+  def require_node(self):
+    if not config.NODE_JS or config.NODE_JS not in config.JS_ENGINES:
+      if 'EMTEST_SKIP_NODE' in os.environ:
+        self.skipTest('test requires node and EMTEST_SKIP_NODE is set')
+      else:
+        self.fail('node required to run this test.  Use EMTEST_SKIP_NODE to skip')
+    self.js_engines = [config.NODE_JS]
 
   def uses_memory_init_file(self):
     if self.get_setting('SIDE_MODULE') or (self.is_wasm() and not self.get_setting('WASM2JS')):
@@ -678,7 +714,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     stderr = self.in_dir('stderr')
     error = None
     if not engine:
-      engine = config.JS_ENGINES[0]
+      engine = self.js_engines[0]
     if engine == config.NODE_JS:
       engine = engine + self.node_args
     if engine == config.V8_ENGINE:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -38,8 +38,7 @@ logger = logging.getLogger("test_core")
 
 def wasm_simd(f):
   def decorated(self):
-    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
-      self.skipTest('wasm simd only supported in d8 for now')
+    self.require_v8()
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')
     if '-O3' in self.emcc_args:
@@ -47,18 +46,15 @@ def wasm_simd(f):
     self.emcc_args.append('-msimd128')
     self.emcc_args.append('-fno-lax-vector-conversions')
     self.v8_args.append('--experimental-wasm-simd')
-    self.js_engines = [config.V8_ENGINE]
     f(self)
   return decorated
 
 
 def bleeding_edge_wasm_backend(f):
   def decorated(self):
-    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
-      self.skipTest('only works in d8 for now')
+    self.require_v8()
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')
-    self.js_engines = [config.V8_ENGINE]
     f(self)
   return decorated
 
@@ -69,8 +65,8 @@ def also_with_wasm_bigint(f):
     f(self)
     if self.is_wasm():
       self.set_setting('WASM_BIGINT')
+      self.require_node()
       self.node_args.append('--experimental-wasm-bigint')
-      self.js_engines = [config.NODE_JS]
       f(self)
   return decorated
 
@@ -99,14 +95,12 @@ def with_both_exception_handling(f):
       # Wasm EH is currently supported only in wasm backend and V8
       if not self.is_wasm():
         self.skipTest('wasm2js does not support wasm exceptions')
-      if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
-        self.skipTest('d8 required to run wasm eh tests')
+      self.require_v8()
       # FIXME Temporarily disabled. Enable this later when the bug is fixed.
       if '-fsanitize=address' in self.emcc_args:
         self.skipTest('Wasm EH does not work with asan yet')
       self.emcc_args.append('-fwasm-exceptions')
       self.v8_args.append('--experimental-wasm-eh')
-      self.js_engines = [config.V8_ENGINE]
       f(self)
     else:
       self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -35,7 +35,7 @@ from tools.shared import CLANG_CC, CLANG_CXX, LLVM_AR, LLVM_DWARFDUMP, EMCMAKE, 
 from runner import RunnerCore, path_from_root, is_slow_test, ensure_dir, disabled, make_executable
 from runner import env_modify, no_mac, no_windows, requires_native_clang, with_env_modify
 from runner import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROOT, test_file
-from runner import compiler_for, read_file, read_binary, EMBUILDER
+from runner import compiler_for, read_file, read_binary, EMBUILDER, require_v8, require_node
 from tools import shared, building, utils, deps_info
 import jsrun
 import clang_native
@@ -2600,12 +2600,12 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
       print(output)
     self.assertLess(output.count('Cannot enlarge memory arrays'),  5)
 
+  @require_node
   def test_module_exports_with_closure(self):
-    # This test checks that module.export is retained when JavaScript is minified by compiling with --closure 1
-    # This is important as if module.export is not present the Module object will not be visible to node.js
-
-    # First make sure test.js isn't present.
-    self.clear()
+    # This test checks that module.export is retained when JavaScript
+    # is minified by compiling with --closure 1
+    # This is important as if module.export is not present the Module
+    # object will not be visible to node.js
 
     # compile with -O2 --closure 0
     self.run_process([EMCC, test_file('Module-exports/test.c'),
@@ -2625,8 +2625,7 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
     # Check that main.js (which requires test.js) completes successfully when run in node.js
     # in order to check that the exports are indeed functioning correctly.
     shutil.copyfile(test_file('Module-exports/main.js'), 'main.js')
-    if config.NODE_JS in config.JS_ENGINES:
-      self.assertContained('bufferTest finished', self.run_js('main.js'))
+    self.assertContained('bufferTest finished', self.run_js('main.js'))
 
     # Delete test.js again and check it's gone.
     try_delete('test.js')
@@ -2650,14 +2649,11 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
 
     # Check that main.js (which requires test.js) completes successfully when run in node.js
     # in order to check that the exports are indeed functioning correctly.
-    if config.NODE_JS in config.JS_ENGINES:
-      self.assertContained('bufferTest finished', self.run_js('main.js', engine=config.NODE_JS))
+    self.assertContained('bufferTest finished', self.run_js('main.js'))
 
+  @require_node
   def test_node_catch_exit(self):
     # Test that in node.js exceptions are not caught if NODEJS_EXIT_CATCH=0
-    if config.NODE_JS not in config.JS_ENGINES:
-      return
-
     create_file('count.c', '''
       #include <string.h>
       int count(const char *str) {
@@ -2677,19 +2673,18 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
 
     # Check that the ReferenceError is caught and rethrown and thus the original error line is masked
     self.assertNotContained(reference_error_text,
-                            self.run_js('index.js', engine=config.NODE_JS, assert_returncode=NON_ZERO))
+                            self.run_js('index.js', assert_returncode=NON_ZERO))
 
     self.run_process([EMCC, 'count.c', '-o', 'count.js', '-s', 'NODEJS_CATCH_EXIT=0'])
 
     # Check that the ReferenceError is not caught, so we see the error properly
     self.assertContained(reference_error_text,
-                         self.run_js('index.js', engine=config.NODE_JS, assert_returncode=NON_ZERO))
+                         self.run_js('index.js', assert_returncode=NON_ZERO))
 
+  @require_node
   def test_exported_runtime_methods(self):
-    # Test with node.js that the EXPORTED_RUNTIME_METHODS setting is considered by libraries
-    if config.NODE_JS not in config.JS_ENGINES:
-      self.skipTest("node engine required for this test")
-
+    # Test with node.js that the EXPORTED_RUNTIME_METHODS setting is
+    # considered by libraries
     create_file('count.c', '''
       #include <string.h>
       int count(const char *str) {
@@ -2709,13 +2704,12 @@ void wakaw::Cm::RasterBase<wakaw::watwat::Polocator>::merbine1<wakaw::Cm::Raster
                      'EXPORTED_RUNTIME_METHODS=FS_writeFile', '-o', 'count.js'])
 
     # Check that the Module.FS_writeFile exists
-    self.assertNotContained(reference_error_text,
-                            self.run_js('index.js', engine=config.NODE_JS))
+    self.assertNotContained(reference_error_text, self.run_js('index.js'))
 
     self.run_process([EMCC, 'count.c', '-s', 'FORCE_FILESYSTEM', '-o', 'count.js'])
 
     # Check that the Module.FS_writeFile is not exported
-    out = self.run_js('index.js', engine=config.NODE_JS)
+    out = self.run_js('index.js')
     self.assertContained(reference_error_text, out)
 
   def test_fs_stream_proto(self):
@@ -2761,6 +2755,7 @@ int main()
       out = self.run_js('a.out.js', engine=engine)
       self.assertContained('File size: 724', out)
 
+  @require_node
   def test_node_emscripten_num_logical_cores(self):
     # Test with node.js that the emscripten_num_logical_cores method is working
     create_file('src.cpp', r'''
@@ -5103,12 +5098,14 @@ int main(void) {
     self.run_process([EMCC, 'libfoo.a'])
     self.assertContained('hello, world!', self.run_js('a.out.js'))
 
+  @require_node
   def test_require(self):
     inname = test_file('hello_world.c')
     self.emcc(inname, args=['-s', 'ASSERTIONS=0'], output_filename='a.out.js')
     output = self.run_process(config.NODE_JS + ['-e', 'require("./a.out.js")'], stdout=PIPE, stderr=PIPE)
     assert output.stdout == 'hello, world!\n' and output.stderr == '', 'expected no output, got\n===\nSTDOUT\n%s\n===\nSTDERR\n%s\n===\n' % (output.stdout, output.stderr)
 
+  @require_node
   def test_require_modularize(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-s', 'MODULARIZE', '-s', 'ASSERTIONS=0'])
     src = read_file('a.out.js')
@@ -7416,13 +7413,11 @@ int main() {
 
   # We have LTO tests covered in 'wasmltoN' targets in test_core.py, but they
   # don't run as a part of Emscripten CI, so we add a separate LTO test here.
+  @require_v8
   def test_lto_wasm_exceptions(self):
-    if not config.V8_ENGINE or config.V8_ENGINE not in config.JS_ENGINES:
-      self.skipTest('d8 required to run wasm eh tests')
     self.set_setting('EXCEPTION_DEBUG')
     self.emcc_args += ['-fwasm-exceptions', '-flto']
     self.v8_args.append('--experimental-wasm-eh')
-    self.js_engines = [config.V8_ENGINE]
     self.do_run_from_file(test_file('core/test_exceptions.cpp'), test_file('core/test_exceptions_caught.out'))
 
   def test_wasm_nope(self):
@@ -7434,6 +7429,7 @@ int main() {
       out = self.run_js('a.out.js', assert_returncode=NON_ZERO)
       self.assertContained('no native wasm support detected', out)
 
+  @require_node
   def test_jsrun(self):
     print(config.NODE_JS)
     jsrun.WORKING_ENGINES = {}
@@ -8149,6 +8145,7 @@ T5:ASSERTIONS
 T6:(else) !ASSERTIONS""", output)
 
   # Tests that Emscripten-compiled applications can be run from a relative path with node command line that is different than the current working directory.
+  @require_node
   def test_node_js_run_from_different_directory(self):
     ensure_dir('subdir')
     self.run_process([EMCC, test_file('hello_world.c'), '-o', Path('subdir/a.js'), '-O3'])
@@ -8156,6 +8153,7 @@ T6:(else) !ASSERTIONS""", output)
     self.assertContained('hello, world!', ret)
 
   # Tests that a pthreads + modularize build can be run in node js
+  @require_node
   def test_node_js_pthread_module(self):
     # create module loader script
     moduleLoader = 'moduleLoader.js'
@@ -10473,13 +10471,12 @@ exec "$@"
         if direct not in js and via_module not in js and assignment not in js:
           self.fail(f'use of declared dependency {dep} not found in JS output for {function}')
 
+  @require_v8
   def test_shell_Oz(self):
     # regression test for -Oz working on non-web, non-node environments that
     # lack TextDecoder
-    if config.V8_ENGINE not in config.JS_ENGINES:
-      return self.skipTest('no shell to test')
     self.run_process([EMCC, test_file('hello_world.c'), '-Oz'])
-    self.assertContained('hello, world!', self.run_js('a.out.js', engine=config.V8_ENGINE))
+    self.assertContained('hello, world!', self.run_js('a.out.js'))
 
   def test_runtime_keepalive(self):
     self.uses_es6 = True


### PR DESCRIPTION
In some cases these decorators make the tests more strict in that the
tests, by default, will fail if the engine required is not found.

This means that tests will not silently start skipping if, for example,
v8 is misconfigured.  Instead it means that developers who what to skip
such tests need to explicitly opt in using EMTEST_SKIP_NODE or
EMTEST_SKIP_D8.