### PR TITLE
Use existing readAsync function in library_dylink.js.  NFC.

### DIFF
--- a/src/base64Utils.js
+++ b/src/base64Utils.js
@@ -68,8 +68,8 @@ function intArrayFromBase64(s) {
   }
 }
 
-// If filename is a base64 data URI, parses and returns data (Buffer on node,
-// Uint8Array otherwise). If filename is not a base64 data URI, returns undefined.
+// If filename is a base64 data URI, parses and returns data (Uint8Array). If
+// filename is not a base64 data URI, returns undefined.
 function tryParseAsDataURI(filename) {
   if (!isDataURI(filename)) {
     return;

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -283,7 +283,7 @@ var LibraryDylink = {
       assert(dylinkSection.length != 0, 'need dylink section');
       binary = new Int8Array(dylinkSection[0]);
     } else {
-      var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
+      var int32View = new Uint32Array(binary.buffer, 0, 1);
       assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0asm
       // we should see the dylink section right after the magic number and wasm version
       assert(binary[8] === 0, 'need the dylink section to be first')

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -252,13 +252,8 @@ var LibraryDylink = {
 
   // fetchBinary fetches binary data @ url. (async)
   $fetchBinary: function(url) {
-    return fetch(url, { credentials: 'same-origin' }).then(function(response) {
-      if (!response['ok']) {
-        throw "failed to load binary file at '" + url + "'";
-      }
-      return response['arrayBuffer']();
-    }).then(function(buffer) {
-      return new Uint8Array(buffer);
+    return new Promise(function(resolve, reject) {
+      readAsync(url, resolve, reject);
     });
   },
 

--- a/src/node_shell_read.js
+++ b/src/node_shell_read.js
@@ -19,9 +19,5 @@ read_ = function shell_read(filename, binary) {
 
 readBinary = function readBinary(filename) {
   var ret = read_(filename, true);
-  if (!ret.buffer) {
-    ret = new Uint8Array(ret);
-  }
-  assert(ret.buffer);
-  return ret;
+  return new Uint8Array(ret);
 };

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -24,7 +24,6 @@ function runMemoryInitializer() {
   } else {
     addRunDependency('memory initializer');
     var applyMemoryInitializer = function(data) {
-      if (data.byteLength) data = new Uint8Array(data);
 #if ASSERTIONS
       for (var i = 0; i < data.length; i++) {
         assert(HEAPU8[{{{ GLOBAL_BASE }}} + i] === 0, "area for memory initializer should not have been touched before it's loaded");
@@ -57,12 +56,12 @@ function runMemoryInitializer() {
       // a network request has already been created, just use that
       var useRequest = function() {
         var request = Module['memoryInitializerRequest'];
-        var response = request.response;
+        var response = new Uint8Array(request.response);
         if (request.status !== 200 && request.status !== 0) {
 #if SUPPORT_BASE64_EMBEDDING
           var data = tryParseAsDataURI(Module['memoryInitializerRequestURL']);
           if (data) {
-            response = data.buffer;
+            response = data;
           } else {
 #endif
             // If you see this warning, the issue may be that you are using locateFile and defining it in JS. That

--- a/src/web_or_worker_shell_read.js
+++ b/src/web_or_worker_shell_read.js
@@ -51,13 +51,13 @@
     xhr.responseType = 'arraybuffer';
     xhr.onload = function() {
       if (xhr.status == 200 || (xhr.status == 0 && xhr.response)) { // file URLs can return 0
-        onload(xhr.response);
+        onload(new Uint8Array(xhr.response));
         return;
       }
 #if SUPPORT_BASE64_EMBEDDING
       var data = tryParseAsDataURI(url);
       if (data) {
-        onload(data.buffer);
+        onload(data);
         return;
       }
 #endif

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9240,7 +9240,7 @@ int main(void) {
     # Changing this option to [] should decrease code size.
     self.assertLess(changed, normal)
     # Check an absolute code size as well, with some slack.
-    self.assertLess(abs(changed - 5872), 150)
+    self.assertLess(abs(changed - 5711), 150)
 
   def test_llvm_includes(self):
     create_file('atomics.c', '#include <stdatomic.h>')


### PR DESCRIPTION
Rather than re-implementing readAsync using fetch, just use
the existing function.

Also, remove redundancy in `int32View` creation.