### PR TITLE
Use callUserCallback in emscripten_async_wget

### DIFF
--- a/tests/browser_main.cpp
+++ b/tests/browser_main.cpp
@@ -5,6 +5,7 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <dlfcn.h>
 #include <emscripten.h>
 
@@ -36,12 +37,12 @@ void next(const char *x) {
   assert(twofunc() == 7);
   onefunc();
   int result = twofunc();
-  REPORT_RESULT(result);
+  exit(result);
 }
 
 int main() {
   emscripten_async_wget("lib.wasm", "thelib.wasm", next, NULL);
-  
+  printf("returning from main\n");
   return 0;
 }
 

--- a/tests/emscripten_fs_api_browser.c
+++ b/tests/emscripten_fs_api_browser.c
@@ -3,7 +3,9 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <emscripten.h>
 #include <assert.h>
 #include <string.h>
@@ -11,8 +13,6 @@
 #include "SDL/SDL_image.h"
 #include <sys/stat.h>
 #include <unistd.h>
- 
-extern "C" {
 
 int result = 1;
 int get_count = 0;
@@ -65,7 +65,7 @@ void wait_wgets() {
     assert(IMG_Load("/tmp/screen_shot.png"));
     assert(data_ok == 1 && data_bad == 1);
     emscripten_cancel_main_loop();
-    REPORT_RESULT(result);
+    exit(result);
   }
   assert(get_count <= 8);
 }
@@ -77,7 +77,8 @@ void onLoaded(const char* file) {
     result = 0;
   }
 
-  if (FILE * f = fopen(file, "r")) {
+  FILE * f = fopen(file, "r");
+  if (f) {
       printf("exists: %s\n", file);
       int c = fgetc (f);
       if (c == EOF) {
@@ -89,7 +90,7 @@ void onLoaded(const char* file) {
     result = 0;
     printf("!exists: %s\n", file);
   }
-  
+
   get_count++;
   printf("onLoaded %s\n", file);
 }
@@ -105,13 +106,13 @@ void onError(const char* file) {
 
 int main() {
   emscripten_async_wget(
-    "http://localhost:8888/this_is_not_a_file", 
+    "http://localhost:8888/this_is_not_a_file",
     "/tmp/null",
     onLoaded,
     onError);
 
   emscripten_async_wget(
-    "http://localhost:8888/test.html", 
+    "http://localhost:8888/test.html",
     "/tmp/test.html",
     onLoaded,
     onError);
@@ -143,7 +144,7 @@ int main() {
   char name[40];
   strcpy(name, "/tmp/screen_shot.png"); // test for issue #2349, name being free'd
   emscripten_async_wget(
-    "http://localhost:8888/screenshot.png", 
+    "http://localhost:8888/screenshot.png",
     name,
     onLoaded,
     onError);
@@ -153,6 +154,3 @@ int main() {
 
   return 0;
 }
-
-}
-

--- a/tests/emscripten_fs_api_browser2.c
+++ b/tests/emscripten_fs_api_browser2.c
@@ -4,13 +4,12 @@
 // found in the LICENSE file.
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <emscripten.h>
 #include <assert.h>
 #include <string.h>
 #include <SDL/SDL.h>
 #include "SDL/SDL_image.h"
- 
-extern "C" {
 
 int result = 1;
 int get_count = 0;
@@ -21,7 +20,8 @@ void onLoaded(const char* file) {
     result = 0;
   }
 
-  if (FILE * f = fopen(file, "r")) {
+  FILE * f = fopen(file, "r");
+  if (f) {
       printf("exists: %s\n", file);
       int c = fgetc (f);
       if (c == EOF) {
@@ -33,13 +33,12 @@ void onLoaded(const char* file) {
     result = 0;
     printf("!exists: %s\n", file);
   }
-  
+
   get_count++;
   printf("onLoaded %s\n", file);
 
   if (get_count == 2) {
-    emscripten_cancel_main_loop();
-    REPORT_RESULT(result);
+    exit(result);
   }
 }
 
@@ -50,20 +49,17 @@ void onError(const char* file) {
 
 int main() {
   emscripten_async_wget(
-    "http://localhost:8888/test.html", 
+    "http://localhost:8888/test.html",
     "/tmp/test.html",
     onLoaded,
     onError);
 
   // get another file to the same place
   emscripten_async_wget(
-    "http://localhost:8888/test.js", 
+    "http://localhost:8888/test.js",
     "/tmp/test.html",
     onLoaded,
     onError);
 
   return 0;
 }
-
-}
-

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1813,11 +1813,11 @@ keydown(100);keyup(100); // trigger the end
 
   def test_emscripten_fs_api(self):
     shutil.copyfile(test_file('screenshot.png'), 'screenshot.png') # preloaded *after* run
-    self.btest('emscripten_fs_api_browser.cpp', '1', args=['-lSDL'])
+    self.btest_exit('emscripten_fs_api_browser.c', assert_returncode=1, args=['-lSDL'])
 
   def test_emscripten_fs_api2(self):
-    self.btest('emscripten_fs_api_browser2.cpp', '1', args=['-s', "ASSERTIONS=0"])
-    self.btest('emscripten_fs_api_browser2.cpp', '1', args=['-s', "ASSERTIONS=1"])
+    self.btest_exit('emscripten_fs_api_browser2.c', assert_returncode=1, args=['-s', "ASSERTIONS=0"])
+    self.btest_exit('emscripten_fs_api_browser2.c', assert_returncode=1, args=['-s', "ASSERTIONS=1"])
 
   @requires_threads
   def test_emscripten_main_loop(self):
@@ -2431,11 +2431,11 @@ void *getBindBuffer() {
     self.btest('worker_api_main.cpp', expected='566')
 
   def test_emscripten_async_wget2(self):
-    self.btest('test_emscripten_async_wget2.cpp', expected='0')
+    self.btest_exit('test_emscripten_async_wget2.cpp')
 
-  def test_module(self):
+  def test_emscripten_async_wget_side_module(self):
     self.run_process([EMCC, test_file('browser_module.cpp'), '-o', 'lib.wasm', '-O2', '-s', 'SIDE_MODULE', '-s', 'EXPORTED_FUNCTIONS=_one,_two'])
-    self.btest('browser_main.cpp', args=['-O2', '-s', 'MAIN_MODULE'], expected='8')
+    self.btest_exit('browser_main.cpp', args=['-O2', '-s', 'MAIN_MODULE'], assert_returncode=8)
 
   @parameterized({
     'non-lz4': ([],),
@@ -2448,8 +2448,7 @@ void *getBindBuffer() {
         return 42;
       }
     ''')
-    self.run_process([EMCC, 'library.c', '-s', 'SIDE_MODULE', '-O2', '-o', 'library.wasm', '-s', 'EXPORT_ALL'])
-    os.rename('library.wasm', 'library.so')
+    self.run_process([EMCC, 'library.c', '-s', 'SIDE_MODULE', '-O2', '-o', 'library.so', '-s', 'EXPORT_ALL'])
     create_file('main.c', r'''
       #include <dlfcn.h>
       #include <stdio.h>

--- a/tests/test_emscripten_async_wget2.cpp
+++ b/tests/test_emscripten_async_wget2.cpp
@@ -309,7 +309,7 @@ void wait_https() {
   if (num_request == 0) {
     printf("End of all download ... %fs\n",(emscripten_get_now() - time_elapsed) / 1000.f);
     emscripten_cancel_main_loop();
-    REPORT_RESULT(0);
+    exit(0);
   }
 }
 


### PR DESCRIPTION
This allows the tests for this code to be converted to `btest_exit`
since calling `exit()` from within the callbacks now works as expected.