### PR TITLE
emcmake: Don't use get_building_env when running cmake

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -5,6 +5,7 @@
 # found in the LICENSE file.
 
 import sys
+import os
 from tools import building
 from tools import shared
 from tools import config
@@ -26,7 +27,6 @@ variables so that emcc etc. are used. Typical usage:
     return 1
 
   args = sys.argv[1:]
-  env = building.get_building_env()
 
   def has_substr(args, substr):
     return any(substr in s for s in args)
@@ -56,7 +56,9 @@ variables so that emcc etc. are used. Typical usage:
   # behalf of the user. See
   # http://www.cmake.org/Wiki/CMake_MinGW_Compiler_Issues
   if utils.WINDOWS and 'MinGW Makefiles' in args:
-    env = building.remove_sh_exe_from_path(env)
+    env = building.remove_sh_exe_from_path(os.environ)
+  else:
+    env = None
 
   print('configure: ' + shared.shlex_join(args), file=sys.stderr)
   try:

--- a/tools/building.py
+++ b/tools/building.py
@@ -185,9 +185,9 @@ def get_building_env(cflags=[]):
 # sh.exe removed from the PATH.  Used to work around CMake limitation with
 # MinGW Makefiles, where sh.exe is not allowed to be present.
 def remove_sh_exe_from_path(env):
+  # Should only ever be called on WINDOWS
+  assert WINDOWS
   env = env.copy()
-  if not WINDOWS:
-    return env
   path = env['PATH'].split(';')
   path = [p for p in path if not os.path.exists(os.path.join(p, 'sh.exe'))]
   env['PATH'] = ';'.join(path)


### PR DESCRIPTION
The cmake toolchain file should be enough to set everything
up correctly.  `get_building_env` is more for traditional
Makefiles or for autoconf where things are controlled much
more my the environment.