### PR TITLE
Use keepalive system in emscripten_set_timeout et al.

### DIFF
--- a/tests/emscripten_set_immediate.c
+++ b/tests/emscripten_set_immediate.c
@@ -1,4 +1,5 @@
 #include <emscripten/html5.h>
+#include <stdlib.h>
 #include <assert.h>
 
 int func1Executed = 0;
@@ -6,41 +7,31 @@ int func2Executed = 0;
 
 void func1(void *userData);
 
-void func2(void *userData)
-{
-	assert((int)userData == 2);
-	++func2Executed;
+void func2(void *userData) {
+  assert((int)userData == 2);
+  ++func2Executed;
 
-	if (func2Executed == 1)
-	{
-		// Test canceling a setImmediate: register a callback but then cancel it immediately
-		long id = emscripten_set_immediate(func1, (void*)2);
-		emscripten_clear_immediate(id);
+  if (func2Executed == 1) {
+    // Test canceling a setImmediate: register a callback but then cancel it immediately
+    long id = emscripten_set_immediate(func1, (void*)2);
+    emscripten_clear_immediate(id);
 
-		emscripten_set_timeout(func2, 100, (void*)2);
-	}
-	if (func2Executed == 2)
-	{
-#ifdef REPORT_RESULT
-		assert(func1Executed == 1);
-		REPORT_RESULT(0);
-#endif
-	}
+    emscripten_set_timeout(func2, 100, (void*)2);
+  }
+  if (func2Executed == 2) {
+    assert(func1Executed == 1);
+    exit(0);
+  }
 }
 
-void func1(void *userData)
-{
-	assert((int)userData == 1);
-	++func1Executed;
-
-#ifdef REPORT_RESULT
-	assert(func1Executed == 1);
-#endif
-
-	emscripten_set_immediate(func2, (void*)2);
+void func1(void *userData) {
+  assert((int)userData == 1);
+  ++func1Executed;
+  assert(func1Executed == 1);
+  emscripten_set_immediate(func2, (void*)2);
 }
 
-int main()
-{
-	emscripten_set_immediate(func1, (void*)1);
+int main() {
+  emscripten_set_immediate(func1, (void*)1);
+  return 99;
 }

--- a/tests/emscripten_set_immediate_loop.c
+++ b/tests/emscripten_set_immediate_loop.c
@@ -1,29 +1,25 @@
 #include <emscripten/html5.h>
 #include <assert.h>
+#include <stdlib.h>
 
 int funcExecuted = 0;
 
-void testDone(void *userData)
-{
-	assert((int)userData == 2);
-	assert(funcExecuted == 10);
-#ifdef REPORT_RESULT
-	REPORT_RESULT(0);
-#endif
+void testDone(void *userData) {
+  assert((int)userData == 2);
+  assert(funcExecuted == 10);
+  exit(0);
 }
 
-EM_BOOL tick(void *userData)
-{
-	assert((int)userData == 1);
-	++funcExecuted;
-	if (funcExecuted == 10)
-	{
-		emscripten_set_timeout(testDone, 300, (void*)2);
-	}
-	return funcExecuted < 10;
+EM_BOOL tick(void *userData) {
+  assert((int)userData == 1);
+  ++funcExecuted;
+  if (funcExecuted == 10) {
+    emscripten_set_timeout(testDone, 300, (void*)2);
+  }
+  return funcExecuted < 10;
 }
 
-int main()
-{
-	emscripten_set_immediate_loop(tick, (void*)1);
+int main() {
+  emscripten_set_immediate_loop(tick, (void*)1);
+  return 99;
 }

--- a/tests/emscripten_set_interval.c
+++ b/tests/emscripten_set_interval.c
@@ -1,37 +1,33 @@
 #include <emscripten.h>
 #include <emscripten/html5.h>
 #include <assert.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 int funcExecuted = 0;
 
-void testDone(void *userData)
-{
-	assert((int)userData == 2);
-	assert(funcExecuted == 10);
-#ifdef REPORT_RESULT
-	REPORT_RESULT(0);
-#endif
+void testDone(void *userData) {
+  assert((int)userData == 2);
+  assert(funcExecuted == 10);
+  exit(0);
 }
 
 long intervalId = 0;
 
-void tick(void *userData)
-{
-	assert((int)userData == 1);
-	++funcExecuted;
-	if (funcExecuted == 10)
-	{
-		emscripten_set_timeout(testDone, 300, (void*)2);
-	}
-	if (funcExecuted >= 10)
-	{
-		emscripten_clear_interval(intervalId);
-	}
+void tick(void *userData) {
+  assert((int)userData == 1);
+  ++funcExecuted;
+  if (funcExecuted == 10) {
+    emscripten_set_timeout(testDone, 300, (void*)2);
+  }
+  if (funcExecuted >= 10) {
+    printf("clearing interval..\n");
+    emscripten_clear_interval(intervalId);
+  }
 }
 
-int main()
-{
-	intervalId = emscripten_set_interval(tick, 100, (void*)1);
-	emscripten_exit_with_live_runtime();
-	return 0;
+int main() {
+  intervalId = emscripten_set_interval(tick, 100, (void*)1);
+  emscripten_exit_with_live_runtime();
+  return 99;
 }

--- a/tests/emscripten_set_timeout.c
+++ b/tests/emscripten_set_timeout.c
@@ -2,48 +2,43 @@
 #include <emscripten/html5.h>
 #include <emscripten/em_asm.h>
 #include <assert.h>
+#include <stdlib.h>
 
 int func1Executed = 0;
 int func2Executed = 0;
 
 void func1(void *userData);
 
-void func2(void *userData)
-{
-	assert((int)userData == 2);
-	++func2Executed;
+void func2(void *userData) {
+  assert((int)userData == 2);
+  ++func2Executed;
 
-	if (func2Executed == 1)
-	{
-		// Test canceling a setTimeout: register a callback but then cancel it immediately
-		long id = emscripten_set_timeout(func1, 10, (void*)2);
-		emscripten_clear_timeout(id);
+  if (func2Executed == 1)
+  {
+    // Test canceling a setTimeout: register a callback but then cancel it immediately
+    long id = emscripten_set_timeout(func1, 10, (void*)2);
+    emscripten_clear_timeout(id);
 
-		emscripten_set_timeout(func2, 100, (void*)2);
-	}
-	if (func2Executed == 2)
-	{
-#ifdef REPORT_RESULT
-		assert(func1Executed == 1);
-		REPORT_RESULT(0);
-#endif
-	}
+    emscripten_set_timeout(func2, 100, (void*)2);
+  }
+  if (func2Executed == 2)
+  {
+    assert(func1Executed == 1);
+    exit(0);
+  }
 }
 
-void func1(void *userData)
-{
-	assert((int)userData == 1);
-	++func1Executed;
+void func1(void *userData) {
+  assert((int)userData == 1);
+  ++func1Executed;
 
-#ifdef REPORT_RESULT
-	assert(func1Executed == 1);
-#endif
+  assert(func1Executed == 1);
 
-	emscripten_set_timeout(func2, 100, (void*)2);
+  emscripten_set_timeout(func2, 100, (void*)2);
 }
 
-int main()
-{
-	emscripten_set_timeout(func1, 100, (void*)1);
-	emscripten_exit_with_live_runtime();
+int main() {
+  emscripten_set_timeout(func1, 100, (void*)1);
+  emscripten_exit_with_live_runtime();
+  return 99;
 }

--- a/tests/emscripten_set_timeout_loop.c
+++ b/tests/emscripten_set_timeout_loop.c
@@ -2,35 +2,31 @@
 #include <emscripten/html5.h>
 #include <emscripten/em_asm.h>
 #include <assert.h>
+#include <stdlib.h>
 
 double previousSetTimeouTime = 0;
 int funcExecuted = 0;
 
-void testDone(void *userData)
-{
-	assert((int)userData == 2);
-	assert(funcExecuted == 10);
-#ifdef REPORT_RESULT
-	REPORT_RESULT(0);
-#endif
+void testDone(void *userData) {
+  assert((int)userData == 2);
+  assert(funcExecuted == 10);
+  exit(0);
 }
 
-EM_BOOL tick(double time, void *userData)
-{
-	assert(time >= previousSetTimeouTime);
-	previousSetTimeouTime = time;
-	assert((int)userData == 1);
-	++funcExecuted;
-	if (funcExecuted == 10)
-	{
-		emscripten_set_timeout(testDone, 300, (void*)2);
-	}
-	return funcExecuted < 10;
+EM_BOOL tick(double time, void *userData) {
+  assert(time >= previousSetTimeouTime);
+  previousSetTimeouTime = time;
+  assert((int)userData == 1);
+  ++funcExecuted;
+  if (funcExecuted == 10)
+  {
+    emscripten_set_timeout(testDone, 300, (void*)2);
+  }
+  return funcExecuted < 10;
 }
 
-int main()
-{
-	emscripten_set_timeout_loop(tick, 100, (void*)1);
-	emscripten_exit_with_live_runtime();
-	return 0;
+int main() {
+  emscripten_set_timeout_loop(tick, 100, (void*)1);
+  emscripten_exit_with_live_runtime();
+  return 99;
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -760,7 +760,6 @@ If manually bisecting:
     html = html.replace('</body>', '''
 <script>
 function assert(x, y) { if (!x) throw 'assertion failed ' + y }
-
 %s
 
 var windowClose = window.close;
@@ -4881,21 +4880,21 @@ window.close = function() {
 
   @requires_threads
   def test_emscripten_set_timeout(self):
-    self.btest(test_file('emscripten_set_timeout.c'), '0', args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+    self.btest_exit(test_file('emscripten_set_timeout.c'), args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
 
   @requires_threads
   def test_emscripten_set_timeout_loop(self):
-    self.btest(test_file('emscripten_set_timeout_loop.c'), '0', args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+    self.btest_exit(test_file('emscripten_set_timeout_loop.c'), args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
 
   def test_emscripten_set_immediate(self):
-    self.btest(test_file('emscripten_set_immediate.c'), '0')
+    self.btest_exit(test_file('emscripten_set_immediate.c'))
 
   def test_emscripten_set_immediate_loop(self):
-    self.btest(test_file('emscripten_set_immediate_loop.c'), '0')
+    self.btest_exit(test_file('emscripten_set_immediate_loop.c'))
 
   @requires_threads
   def test_emscripten_set_interval(self):
-    self.btest(test_file('emscripten_set_interval.c'), '0', args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+    self.btest_exit(test_file('emscripten_set_interval.c'), args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
 
   # Test emscripten_performance_now() and emscripten_date_now()
   @requires_threads


### PR DESCRIPTION
Without this EXIT_RUNTIME=1 builds will exit early
even when there is timeout pending.

I'm planning a followup to help remove some of this
boilerplate.