### PR TITLE
Fix ASYNCIFY + EXIT_RUNTIME check

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -25,7 +25,8 @@ mergeInto(LibraryManager.library, {
     State: {
       Normal: 0,
       Unwinding: 1,
-      Rewinding: 2
+      Rewinding: 2,
+      Disabled: 3,
     },
     state: 0,
     StackSize: {{{ ASYNCIFY_STACK_SIZE }}},
@@ -83,11 +84,6 @@ mergeInto(LibraryManager.library, {
           }
         })(x);
       }
-    },
-
-    checkStateAfterExitRuntime: function() {
-      assert(Asyncify.state === Asyncify.State.None,
-            'Asyncify cannot be done during or after the runtime exits');
     },
 #endif
 
@@ -183,6 +179,9 @@ mergeInto(LibraryManager.library, {
     },
 
     handleSleep: function(startAsync) {
+#if ASSERTIONS
+      assert(Asyncify.state !== Asyncify.State.Disabled, 'Asyncify cannot be done during or after the runtime exits');
+#endif
       if (ABORT) return;
 #if !MINIMAL_RUNTIME
       noExitRuntime = true;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -411,6 +411,10 @@ function preMain() {
 #endif
 
 function exitRuntime() {
+#if ASYNCIFY && ASSERTIONS
+  // ASYNCIFY cannot be used once the runtime starts shutting down.
+  Asyncify.state = Asyncify.State.Disabled;
+#endif
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
 #endif
@@ -423,9 +427,6 @@ function exitRuntime() {
 #if USE_PTHREADS
   PThread.runExitHandlers();
 #endif
-#endif
-#if ASYNCIFY && ASSERTIONS
-  Asyncify.checkStateAfterExitRuntime();
 #endif
   runtimeExited = true;
 }

--- a/tests/core/test_asyncify_during_exit.cpp
+++ b/tests/core/test_asyncify_during_exit.cpp
@@ -7,10 +7,13 @@ void during_exit() {
   // An attempt to sleep during exit, which is not allowed (the exit process is
   // done in synchronous JS).
   EM_ASM({ out("during_exit 1") });
+#ifndef NO_ASYNC
   emscripten_sleep(100);
+#endif
   EM_ASM({ out("during_exit 2") });
 }
 
 int main() {
   atexit(&during_exit);
+  return 0;
 }

--- a/tests/core/test_asyncify_during_exit_no_async.out
+++ b/tests/core/test_asyncify_during_exit_no_async.out
@@ -1,0 +1,2 @@
+during_exit 1
+during_exit 2

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -1078,7 +1078,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def do_run_in_out_file_test(self, *path, **kwargs):
     srcfile = test_file(*path)
-    outfile = shared.unsuffixed(srcfile) + '.out'
+    out_suffix = kwargs.pop('out_suffix', '')
+    outfile = shared.unsuffixed(srcfile) + out_suffix + '.out'
     expected = read_file(outfile)
     self._build_and_run(srcfile, expected, **kwargs)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7497,6 +7497,8 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('ASSERTIONS')
     self.set_setting('EXIT_RUNTIME', 1)
     self.do_core_test('test_asyncify_during_exit.cpp', assert_returncode=1)
+    print('NO_ASYNC')
+    self.do_core_test('test_asyncify_during_exit.cpp', emcc_args=['-DNO_ASYNC'], out_suffix='_no_async')
 
   @no_asan('asyncify stack operations confuse asan')
   @no_wasm2js('TODO: lazy loading in wasm2js')


### PR DESCRIPTION
This check had a typo and was doing `Asyncify.state === Asyncify.State.None`
rather than `Asyncify.state === Asyncify.State.Normal`.

This meant it was always firing if any ASYNCIFY program happened to
actually exit the runtime.  Note that ASYNCIFY programs almost never
exit so this should not actually effect most programs.  This is because any
actual use of async functions during main will disable exiting of the
runtime (See #14417).

However, even after fixing the typo this assert still fires in all cases
because `Normal` is the state adter the rewinding is done.

Instead I use a an explict debug state to indicate that asyncify is
currnetly disabled.

I added null version of test that doesn't use ASYNCIFY during exit
to be sure this fires only right cases.