### PR TITLE
Fix exception swallowing in instrumentWasmExports

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -105,13 +105,14 @@ mergeInto(LibraryManager.library, {
               try {
                 return original.apply(null, arguments);
               } finally {
-                if (ABORT) return;
-                var y = Asyncify.exportCallStack.pop();
-                assert(y === x);
+                if (!ABORT) {
+                  var y = Asyncify.exportCallStack.pop();
+                  assert(y === x);
 #if ASYNCIFY_DEBUG >= 2
-                err('ASYNCIFY: ' + '  '.repeat(Asyncify.exportCallStack.length) + ' finally ' + x);
+                  err('ASYNCIFY: ' + '  '.repeat(Asyncify.exportCallStack.length) + ' finally ' + x);
 #endif
-                Asyncify.maybeStopUnwind();
+                  Asyncify.maybeStopUnwind();
+                }
               }
             };
           } else {

--- a/tests/core/test_asyncify_assertions.c
+++ b/tests/core/test_asyncify_assertions.c
@@ -1,8 +1,6 @@
 #include <stdio.h>
 #include <emscripten.h>
 
-extern "C" {
-
 EM_JS(void, suspend, (), {
   return Asyncify.handleSleep(function(wakeUp) {
     Module.resume = wakeUp;
@@ -32,6 +30,4 @@ int main() {
   suspend();
   suspend();
   printf("finish\n");
-}
-
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7498,7 +7498,7 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('ASYNCIFY')
     self.set_setting('ASYNCIFY_IMPORTS', ['suspend'])
     self.set_setting('ASSERTIONS')
-    self.do_core_test('test_asyncify_assertions.cpp')
+    self.do_core_test('test_asyncify_assertions.c', assert_returncode=NON_ZERO)
 
   @no_lsan('leaks asyncify stack during exit')
   @no_asan('leaks asyncify stack during exit')


### PR DESCRIPTION
This code was trying to do an early return but it was
inadvertently ignoring exceptions because it is returning
from a finally block.  Nasty.