### PR TITLE
Remove get_building_env from tests/clang_native.py. NFC

### DIFF
--- a/tests/clang_native.py
+++ b/tests/clang_native.py
@@ -7,7 +7,6 @@ import logging
 import os
 from tools.shared import PIPE, run_process, CLANG_CC, CLANG_CXX
 from tools.utils import MACOS, WINDOWS, path_from_root
-from tools import building
 
 logger = logging.getLogger('clang_native')
 
@@ -37,15 +36,6 @@ def get_clang_native_env():
   env['CC'] = CLANG_CC
   env['CXX'] = CLANG_CXX
   env['LD'] = CLANG_CXX
-  # get a non-native one, and see if we have some of its effects - remove them if so
-  non_native = building.get_building_env()
-  # the ones that a non-native would modify
-  EMSCRIPTEN_MODIFIES = ['LDSHARED', 'AR', 'CROSS_COMPILE', 'NM', 'RANLIB']
-  for dangerous in EMSCRIPTEN_MODIFIES:
-    if env.get(dangerous) and env.get(dangerous) == non_native.get(dangerous):
-      # Remove this block completely assuming all tests pass without hitting
-      # this assert
-      assert False
 
   if MACOS:
     path = run_process(['xcrun', '--show-sdk-path'], stdout=PIPE).stdout.strip()


### PR DESCRIPTION
This seems unnecessary and we don't want unnecessary dependencies
between test code and the compiler driver itself.

Followup to #14412 which didn't actually remove this code, just made it
into an assert.