### PR TITLE
Avoid using get_building_env in test code

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -101,6 +101,7 @@ TEST_ROOT = path_from_root('tests')
 WEBIDL_BINDER = shared.bat_suffix(path_from_root('tools/webidl_binder'))
 
 EMBUILDER = shared.bat_suffix(path_from_root('embuilder'))
+EMMAKE = shared.bat_suffix(path_from_root('emmake'))
 
 
 if EMTEST_VERBOSE:
@@ -848,7 +849,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def get_library(self, name, generated_libs, configure=['sh', './configure'],
                   configure_args=[], make=['make'], make_args=None,
-                  env_init={}, cache_name_extra='', native=False):
+                  env_init=None, cache_name_extra='', native=False):
+    if env_init is None:
+      env_init = {}
     if make_args is None:
       make_args = ['-j', str(shared.get_num_cores())]
 
@@ -878,9 +881,12 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       # Avoid += so we don't mutate the default arg
       configure = configure + configure_args
 
+    cflags = ' '.join(self.get_emcc_args())
+    env_init.setdefault('CFLAGS', cflags)
+    env_init.setdefault('CXXFLAGS', cflags)
     return build_library(name, build_dir, output_dir, generated_libs, configure,
                          make, make_args, self.library_cache,
-                         cache_name, env_init=env_init, native=native, cflags=self.get_emcc_args())
+                         cache_name, env_init=env_init, native=native)
 
   def clear(self):
     delete_contents(self.get_dir())
@@ -1650,8 +1656,7 @@ def build_library(name,
                   cache=None,
                   cache_name=None,
                   env_init={},
-                  native=False,
-                  cflags=[]):
+                  native=False):
   """Build a library and cache the result.  We build the library file
   once and cache it for all our tests. (We cache in memory since the test
   directory is destroyed and recreated for each test. Note that we cache
@@ -1670,12 +1675,13 @@ def build_library(name,
   shutil.copytree(source_dir, project_dir)
 
   generated_libs = [os.path.join(project_dir, lib) for lib in generated_libs]
+
   if native:
     env = clang_native.get_clang_native_env()
   else:
-    env = building.get_building_env(cflags=cflags)
-  for k, v in env_init.items():
-    env[k] = v
+    env = os.environ.copy()
+  env.update(env_init)
+
   if configure:
     if configure[0] == 'cmake':
       configure = [EMCMAKE] + configure
@@ -1696,6 +1702,9 @@ def build_library(name,
       print(read_file(Path(project_dir, 'configure_err')))
       print('-- end configure stderr --')
       raise
+    # if we run configure or cmake we don't then need any kind
+    # of special env when we run make below
+    env = None
 
   def open_make_out(mode='r'):
     return open(os.path.join(project_dir, 'make.out'), mode)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from urllib.request import urlopen
 
 from runner import BrowserCore, RunnerCore, path_from_root, has_browser, EMTEST_BROWSER, Reporting
-from runner import create_file, parameterized, ensure_dir, disabled, test_file, WEBIDL_BINDER
+from runner import create_file, parameterized, ensure_dir, disabled, test_file, WEBIDL_BINDER, EMMAKE
 from runner import read_file
 from tools import shared
 from tools import system_libs
@@ -1747,7 +1747,7 @@ keydown(100);keyup(100); // trigger the end
       Path('Chapter_9/TextureWrap', 'CH09_TextureWrap.o'),
       Path('Chapter_10/MultiTexture', 'CH10_MultiTexture.o'),
       Path('Chapter_13/ParticleSystem', 'CH13_ParticleSystem.o'),
-    ], configure=None)
+    ], configure=None, make=[EMMAKE, 'make'])
 
     def book_path(*pathelems):
       return test_file('glbook', *pathelems)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,7 +28,7 @@ from runner import RunnerCore, path_from_root, requires_native_clang, test_file
 from runner import skip_if, needs_dylink, no_windows, is_slow_test, create_file, parameterized
 from runner import env_modify, with_env_modify, disabled, node_pthreads
 from runner import read_file, read_binary
-from runner import NON_ZERO, WEBIDL_BINDER, EMBUILDER
+from runner import NON_ZERO, WEBIDL_BINDER, EMBUILDER, EMMAKE
 import clang_native
 
 # decorators for limiting which modes a test can run in
@@ -463,7 +463,7 @@ class TestCoreBase(RunnerCore):
   def test_cube2hash(self):
     # A good test of i64 math
     self.do_run('// empty file', 'Usage: hashstring <seed>',
-                libraries=self.get_library('third_party/cube2hash', ['libcube2hash.a'], configure=None),
+                libraries=self.get_library('third_party/cube2hash', ['libcube2hash.a'], configure=None, make=[EMMAKE, 'make']),
                 includes=[test_file('third_party/cube2hash')], assert_returncode=NON_ZERO)
 
     for text, output in [('fleefl', '892BDB6FD3F62E863D63DA55851700FDE3ACF30204798CE9'),
@@ -5948,10 +5948,11 @@ void* operator new(size_t size) {
   def test_lua(self):
     self.emcc_args.remove('-Werror')
 
+    libs = self.get_library('third_party/lua', [Path('src/lua.o'), Path('src/liblua.a')], make=[EMMAKE, 'make', 'generic'], configure=None)
     self.do_run('',
                 'hello lua world!\n17\n1\n2\n3\n4\n7',
                 args=['-e', '''print("hello lua world!");print(17);for x = 1,4 do print(x) end;print(10-3)'''],
-                libraries=self.get_library('third_party/lua', [Path('src/lua.o'), Path('src/liblua.a')], make=['make', 'generic'], configure=None),
+                libraries=libs,
                 includes=[test_file('lua')],
                 output_nicerizer=lambda string, err: (string + err).replace('\n\n', '\n').replace('\n\n', '\n'))
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -156,7 +156,7 @@ def remove_quotes(arg):
     return arg
 
 
-def get_building_env(cflags=[]):
+def get_building_env():
   env = os.environ.copy()
   # point CC etc. to the em* tools.
   env['CC'] = EMCC
@@ -167,8 +167,6 @@ def get_building_env(cflags=[]):
   env['LDSHARED'] = EMCC
   env['RANLIB'] = EMRANLIB
   env['EMSCRIPTEN_TOOLS'] = path_from_root('tools')
-  if cflags:
-    env['CFLAGS'] = env['EMMAKEN_CFLAGS'] = ' '.join(cflags)
   env['HOST_CC'] = CLANG_CC
   env['HOST_CXX'] = CLANG_CXX
   env['HOST_CFLAGS'] = '-W' # if set to nothing, CFLAGS is used, which we don't want


### PR DESCRIPTION
Rather than using the internal `building.get_building_env` function
we can just make sure we run make via `emmake` (or that we use
`emcmake` or `emconfigure`).

This is good idea because it ensures that the test code is using the same
entry points that our users will use and not taking any shortcuts.

This also avoids making use of the `EMMAKEN_CFLAGS` hack.

If we do use `emcmake` or `emconfigure` then any environment varaibles
should be internalized during that phase so we don't need to pass a
custom envrionment to the `make` call.