### PR TITLE
Fix asan.test_utf8_textdecoder

### DIFF
--- a/tests/benchmark_utf8.cpp
+++ b/tests/benchmark_utf8.cpp
@@ -26,7 +26,6 @@ long utf8_corpus_length = 0;
 
 char *randomString(int len) {
   if (!utf8_corpus) {
-//    FILE *handle = fopen("ascii_corpus.txt", "rb");
     FILE *handle = fopen("utf8_corpus.txt", "rb");
     fseek(handle, 0, SEEK_END);
     utf8_corpus_length = ftell(handle);
@@ -46,8 +45,8 @@ char *randomString(int len) {
   char *s = new char[len+1];
   memcpy(s, utf8_corpus + startIdx, len);
   s[len] = '\0';
-  while(((unsigned char)s[len-1] & 0xC0) == 0x80) { s[--len] = '\0'; }
-  while(((unsigned char)s[len-1] & 0xC0) == 0xC0) { s[--len] = '\0'; }
+  while(len > 0 && ((unsigned char)s[len-1] & 0xC0) == 0x80) { s[--len] = '\0'; }
+  while(len > 0 && ((unsigned char)s[len-1] & 0xC0) == 0xC0) { s[--len] = '\0'; }
   assert(len >= 0);
   return s;
 }


### PR DESCRIPTION
The test has some loops that try to remove certain utf8 characters
from the end (whitespace? I don't know enough utf8). The loops were
missing a check on the string size not being 0.

This bug existed before #14399, but before that PR we always used
strings of size 8, and apparently were lucky enough to not run into
a run of 8 characters that we want to remove. With that PR, the bug
unsurfaced as we try various lengths, even 1.

The asan test suite will be green again after this.