### PR TITLE
libcxxabi: Avoid using cxa_exception.h with emscripten exceptions.  NFC

### DIFF
--- a/system/lib/libcxxabi/src/cxa_default_handlers.cpp
+++ b/system/lib/libcxxabi/src/cxa_default_handlers.cpp
@@ -13,11 +13,13 @@
 #include "abort_message.h"
 #include "cxxabi.h"
 #include "cxa_handlers.h"
-#include "cxa_exception.h"
 #include "private_typeinfo.h"
 #include "include/atomic_support.h"
 
 #if !defined(LIBCXXABI_SILENT_TERMINATE)
+// XXX EMSCRIPTEN: this header is not compatible with emscripten exceptions
+// and is only needed when !LIBCXXABI_SILENT_TERMINATE
+#include "cxa_exception.h"
 
 _LIBCPP_SAFE_STATIC
 static const char* cause = "uncaught";

--- a/system/lib/libcxxabi/src/cxa_exception.h
+++ b/system/lib/libcxxabi/src/cxa_exception.h
@@ -17,6 +17,13 @@
 #include "cxxabi.h"
 #include "unwind.h"
 
+#ifdef __USING_EMSCRIPTEN_EXCEPTIONS__
+// Under emscripten-style exception handling the __cxa_exception type is
+// defined in JavaScript in src/library_exceptions.js.
+// Any usage of this header would lead to incompatabilities.
+#error "Not compatible with emscripten-style exception handling"
+#endif
+
 namespace __cxxabiv1 {
 
 static const uint64_t kOurExceptionClass          = 0x434C4E47432B2B00; // CLNGC++\0

--- a/system/lib/libcxxabi/src/cxa_handlers.cpp
+++ b/system/lib/libcxxabi/src/cxa_handlers.cpp
@@ -15,35 +15,11 @@
 #include "abort_message.h"
 #include "cxxabi.h"
 #include "cxa_handlers.h"
+#ifndef __USING_EMSCRIPTEN_EXCEPTIONS__
 #include "cxa_exception.h"
+#endif
 #include "private_typeinfo.h"
 #include "include/atomic_support.h"
-
-namespace __cxxabiv1 {
-
-#ifdef __USING_EMSCRIPTEN_EXCEPTIONS__
-// XXX EMSCRIPTEN: Copied from cxa_exception.cpp since we don't compile that
-// file in Emscripten EH mode. Note that in no-exceptions builds we include
-// cxa_noexception.cpp which provides stubs of those anyhow.
-
-//  Is it one of ours?
-uint64_t __getExceptionClass(const _Unwind_Exception* unwind_exception) {
-//	On x86 and some ARM unwinders, unwind_exception->exception_class is
-//		a uint64_t. On other ARM unwinders, it is a char[8]
-//	See: http://infocenter.arm.com/help/topic/com.arm.doc.ihi0038b/IHI0038B_ehabi.pdf
-//	So we just copy it into a uint64_t to be sure.
-	uint64_t exClass;
-	::memcpy(&exClass, &unwind_exception->exception_class, sizeof(exClass));
-	return exClass;
-}
-
-bool __isOurExceptionClass(const _Unwind_Exception* unwind_exception) {
-    return (__getExceptionClass(unwind_exception) & get_vendor_and_language) == 
-           (kOurExceptionClass                    & get_vendor_and_language);
-}
-#endif
-
-}
 
 namespace std
 {
@@ -99,7 +75,7 @@ __attribute__((noreturn))
 void
 terminate() _NOEXCEPT
 {
-#ifndef _LIBCXXABI_NO_EXCEPTIONS
+#if !defined(_LIBCXXABI_NO_EXCEPTIONS) && !defined(__USING_EMSCRIPTEN_EXCEPTIONS__)
     // If there might be an uncaught exception
     using namespace __cxxabiv1;
     __cxa_eh_globals* globals = __cxa_get_globals_fast();

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -932,6 +932,9 @@ class libcxxabi(NoExceptLibrary, MTLibrary):
       cflags.append('-D_LIBCXXABI_NO_EXCEPTIONS')
     elif self.eh_mode == Exceptions.EMSCRIPTEN:
       cflags.append('-D__USING_EMSCRIPTEN_EXCEPTIONS__')
+      # The code used to interpret exceptions during terminate
+      # is not compatible with emscripten exceptions.
+      cflags.append('-DLIBCXXABI_SILENT_TERMINATE')
     elif self.eh_mode == Exceptions.WASM:
       cflags.append('-D__USING_WASM_EXCEPTIONS__')
     return cflags
@@ -942,7 +945,6 @@ class libcxxabi(NoExceptLibrary, MTLibrary):
       'cxa_aux_runtime.cpp',
       'cxa_default_handlers.cpp',
       'cxa_demangle.cpp',
-      'cxa_exception_storage.cpp',
       'cxa_guard.cpp',
       'cxa_handlers.cpp',
       'cxa_virtual.cpp',
@@ -957,6 +959,7 @@ class libcxxabi(NoExceptLibrary, MTLibrary):
       filenames += ['cxa_noexception.cpp']
     elif self.eh_mode == Exceptions.WASM:
       filenames += [
+        'cxa_exception_storage.cpp',
         'cxa_exception.cpp',
         'cxa_personality.cpp'
       ]


### PR DESCRIPTION
Any file that uses this header is going to be (almost by definition) ot
compatible with emscripten exceptions which have their own definition in
JS which doesn't match the one in this header file.

This change came out of trying to figure out why __cxa_exception didn't
seem to work under emscripten exceptions and hopefully clears up any
confusion.