### PR TITLE
Added more missing signatures

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -126,6 +126,7 @@ var LibraryEmVal = {
     return __emval_register({});
   },
 
+  _emval_new_cstring__sig: 'ii',
   _emval_new_cstring__deps: ['$getStringOrSymbol', '_emval_register'],
   _emval_new_cstring: function(v) {
     return __emval_register(getStringOrSymbol(v));
@@ -241,6 +242,7 @@ var LibraryEmVal = {
     })()('return this')();
   },
 #endif
+  _emval_get_global__sig: 'ii',
   _emval_get_global__deps: ['_emval_register', '$getStringOrSymbol', '$emval_get_global'],
   _emval_get_global: function(name) {
     if (name===0) {
@@ -271,7 +273,8 @@ var LibraryEmVal = {
     value = requireHandle(value);
     handle[key] = value;
   },
-
+    
+  _emval_as__sig: 'iiii',
   _emval_as__deps: ['_emval_register', '$requireHandle', '$requireRegisteredType'],
   _emval_as: function(handle, returnType, destructorsRef) {
     handle = requireHandle(handle);


### PR DESCRIPTION
Causes runtime errors (cannot read slice property) when MAIN_MODULE=1 and -O3.  There may be more signatures that need to be added, but my project just hasn't used those functions yet.