### PR TITLE
Added missing signature

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -658,7 +658,8 @@ var LibraryPThread = {
 #endif
     return navigator['hardwareConcurrency'];
   },
-
+    
+  {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create__sig: 'iiiii',
   {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create__deps: ['$spawnThread', 'pthread_self', 'memalign', 'emscripten_sync_run_in_main_thread_4'],
   {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create: function(pthread_ptr, attr, start_routine, arg) {
     if (typeof SharedArrayBuffer === 'undefined') {


### PR DESCRIPTION
Causes runtime error (cannot access slice property) when MAIN_MODULE=1 and -O3 and -pthread.