### PR TITLE
Assume Buffer.from exists under node

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 2.0.25
 ------
+- Drop support for node versions older than v5.10.0.  We now assume the
+  existence of `Buffer.from` which was added in v5.10.0.  If it turns out
+  there is still a need to support these older node versions we can
+  add a polyfil under LEGACY_VM_SUPPORT (#14447).
 
 2.0.24 - 06/10/2021
 -------------------

--- a/src/base64Decode.js
+++ b/src/base64Decode.js
@@ -38,11 +38,7 @@ base64ReverseLookup[47] = 63; // '/'
 function base64Decode(b64) {
 #if ENVIRONMENT_MAY_BE_NODE
   if (typeof ENVIRONMENT_IS_NODE !== 'undefined' && ENVIRONMENT_IS_NODE) {
-    try {
-      var buf = Buffer.from(b64, 'base64');
-    } catch (_) {
-      var buf = new Buffer(b64, 'base64');
-    }
+    var buf = Buffer.from(b64, 'base64');
     return new Uint8Array(buf.buffer, buf.byteOffset, buf.byteLength);
   }
 #endif

--- a/src/base64Utils.js
+++ b/src/base64Utils.js
@@ -44,14 +44,7 @@ var decodeBase64 = typeof atob === 'function' ? atob : function (input) {
 function intArrayFromBase64(s) {
 #if ENVIRONMENT_MAY_BE_NODE
   if (typeof ENVIRONMENT_IS_NODE === 'boolean' && ENVIRONMENT_IS_NODE) {
-    var buf;
-    try {
-      // TODO: Update Node.js externs, Closure does not recognize the following Buffer.from()
-      /**@suppress{checkTypes}*/
-      buf = Buffer.from(s, 'base64');
-    } catch (_) {
-      buf = new Buffer(s, 'base64');
-    }
+    var buf = Buffer.from(s, 'base64');
     return new Uint8Array(buf['buffer'], buf['byteOffset'], buf['byteLength']);
   }
 #endif

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -28,12 +28,6 @@ mergeInto(LibraryManager.library, {
         "{{{ cDefine('O_WRONLY') }}}": flags["O_WRONLY"]
       };
     },
-    bufferFrom: function (arrayBuffer) {
-      // Node.js < 4.5 compatibility: Buffer.from does not support ArrayBuffer
-      // Buffer.from before 4.5 was just a method inherited from Uint8Array
-      // Buffer.alloc has been added with Buffer.from together, so check it instead
-      return Buffer["alloc"] ? Buffer.from(arrayBuffer) : new Buffer(arrayBuffer);
-    },
     convertNodeCode: function(e) {
       var code = e.code;
 #if ASSERTIONS
@@ -262,14 +256,14 @@ mergeInto(LibraryManager.library, {
         // Node.js < 6 compatibility: node errors on 0 length reads
         if (length === 0) return 0;
         try {
-          return fs.readSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
+          return fs.readSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(NODEFS.convertNodeCode(e));
         }
       },
       write: function (stream, buffer, offset, length, position) {
         try {
-          return fs.writeSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
+          return fs.writeSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
         } catch (e) {
           throw new FS.ErrnoError(NODEFS.convertNodeCode(e));
         }

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -98,7 +98,7 @@ mergeInto(LibraryManager.library, {
       }
       var seeking = typeof position !== 'undefined';
       if (!seeking && stream.seekable) position = stream.position;
-      var bytesRead = fs.readSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
+      var bytesRead = fs.readSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
       // update position marker when non-seeking
       if (!seeking) stream.position += bytesRead;
       return bytesRead;
@@ -114,7 +114,7 @@ mergeInto(LibraryManager.library, {
       }
       var seeking = typeof position !== 'undefined';
       if (!seeking && stream.seekable) position = stream.position;
-      var bytesWritten = fs.writeSync(stream.nfd, NODEFS.bufferFrom(buffer.buffer), offset, length, position);
+      var bytesWritten = fs.writeSync(stream.nfd, Buffer.from(buffer.buffer), offset, length, position);
       // update position marker when non-seeking
       if (!seeking) stream.position += bytesWritten;
       return bytesWritten;

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -108,7 +108,7 @@ mergeInto(LibraryManager.library, {
           if (ENVIRONMENT_IS_NODE) {
             // we will read data by chunks of BUFSIZE
             var BUFSIZE = 256;
-            var buf = Buffer.alloc ? Buffer.alloc(BUFSIZE) : new Buffer(BUFSIZE);
+            var buf = Buffer.alloc(BUFSIZE);
             var bytesRead = 0;
 
             try {

--- a/tests/module/test_stdin.c
+++ b/tests/module/test_stdin.c
@@ -6,6 +6,7 @@
  */
 
 #include <errno.h>
+#include <string.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -16,8 +17,7 @@
 
 int line = 0;
 
-void main_loop()
-{
+void main_loop() {
   char str[10] = {0};
   int ret;
 
@@ -33,8 +33,8 @@ void main_loop()
     }
 
     int err = ferror(stdin);
-    if (ferror(stdin) && errno != EAGAIN) {
-      printf("error %d\n", err);
+    if (err && errno != EAGAIN) {
+      printf("error %s\n", strerror(errno));
       exit(EXIT_FAILURE);
     }
 
@@ -47,8 +47,7 @@ void main_loop()
   }
 }
 
-int main(int argc, char const *argv[])
-{
+int main(int argc, char const *argv[]) {
   fcntl(STDIN_FILENO, F_SETFL, O_NONBLOCK);
 
   // SM shell doesn't implement an event loop and therefor doesn't support

--- a/third_party/closure-compiler/node-externs/buffer.js
+++ b/third_party/closure-compiler/node-externs/buffer.js
@@ -375,6 +375,20 @@ nodeBuffer.SlowBuffer.prototype.slice = function(start, end) {};
  */
 nodeBuffer.SlowBuffer.prototype.toString = function() {};
 
+/**
+ * @param {number} size
+ * @param {(string|!Buffer|number)=} fill
+ * @param {string=} encoding
+ * @return {!Buffer}
+ */
+nodeBuffer.Buffer.alloc;
+
+/**
+ * @param {Array} aray
+ * @return {!Buffer}
+ */
+nodeBuffer.Buffer.from;
+
 //
 // Legacy
 //

--- a/tools/lz4-compress.js
+++ b/tools/lz4-compress.js
@@ -150,7 +150,7 @@ if (!(data instanceof ArrayBuffer)) {
 
 var start = Date.now();
 var compressedData = MiniLZ4.compressPackage(data);
-nodeFS['writeFileSync'](output, Buffer(compressedData['data']));
+nodeFS['writeFileSync'](output, Buffer.from(compressedData['data']));
 compressedData['data'] = null;
 printErr('compressed in ' + (Date.now() - start) + ' ms');
 print(JSON.stringify(compressedData));


### PR DESCRIPTION
I don't think there is any need to continue to support node version
older than v5.10.0 which was when Buffer.from was added.

If we do want to support this we should do it via a polyfill that
is enabled under LEGACY_VM_SUPPORT.

I noticed this issue because lz4-compress.js was generating a
deprecation warning about this method.

See: https://nodejs.org/api/buffer.html#buffer_static_method_buffer_alloc_size_fill_encoding
And: https://nodejs.org/api/buffer.html#buffer_static_method_buffer_from_array
