### PR TITLE
Improve support for runtime keepalive under node

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,14 @@ See docs/process.md for more on how version tagging works.
 
 2.0.25
 ------
+- By default (unless `EXIT_RUNTIME=1` is specified) emscripten programs running
+  under node will no longer call `process.exit()` on `exit()`.  Instead they
+  will simply unwind the stack and return to the event loop, much like they do
+  on the web.  In many cases the node process will then exit naturally if there
+  is nothing keeping the event loop going.
+  Note for users of node + pthreads: Because of the way that threads are
+  implemented under node multi-threaded programs now require `EXIT_RUNTIME=1`
+  (or call `emscripten_force_exit`) in order to actually bring down the process.
 - Drop support for node versions older than v5.10.0.  We now assume the
   existence of `Buffer.from` which was added in v5.10.0.  If it turns out
   there is still a need to support these older node versions we can

--- a/emcc.py
+++ b/emcc.py
@@ -1801,7 +1801,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
     # In non-MINIMAL_RUNTIME, the core runtime depends on these functions to be present. (In MINIMAL_RUNTIME, they are
     # no longer always bundled in)
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
-      '$keepRuntimeAlive',
       '$demangle',
       '$demangleAll',
       '$jsStackTrace',
@@ -1919,8 +1918,8 @@ def phase_linker_setup(options, state, newargs, settings_map):
     include_and_export('establishStackSpace')
     include_and_export('invokeEntryPoint')
     if not settings.MINIMAL_RUNTIME:
-      # noExitRuntime does not apply to MINIMAL_RUNTIME.
-      include_and_export('keepRuntimeAlive')
+      # keepRuntimeAlive does not apply to MINIMAL_RUNTIME.
+      settings.EXPORTED_RUNTIME_METHODS += ['keepRuntimeAlive']
 
     if settings.MODULARIZE:
       if not settings.EXPORT_ES6 and settings.EXPORT_NAME == 'Module':

--- a/src/library.js
+++ b/src/library.js
@@ -3563,7 +3563,6 @@ LibraryManager.library = {
     throw 'unwind';
   },
 
-  emscripten_force_exit__deps: ['$runtimeKeepaliveCounter'],
   emscripten_force_exit__proxy: 'sync',
   emscripten_force_exit__sig: 'vi',
   emscripten_force_exit: function(status) {
@@ -3580,16 +3579,8 @@ LibraryManager.library = {
   },
 
 #if !MINIMAL_RUNTIME
-  $runtimeKeepaliveCounter: 0,
-
-  $keepRuntimeAlive__deps: ['$runtimeKeepaliveCounter'],
-  $keepRuntimeAlive: function() {
-    return noExitRuntime || runtimeKeepaliveCounter > 0;
-  },
-
   // Callable in pthread without __proxy needed.
   $runtimeKeepalivePush__sig: 'v',
-  $runtimeKeepalivePush__deps: ['$runtimeKeepaliveCounter'],
   $runtimeKeepalivePush: function() {
     runtimeKeepaliveCounter += 1;
 #if RUNTIME_DEBUG
@@ -3598,7 +3589,6 @@ LibraryManager.library = {
   },
 
   $runtimeKeepalivePop__sig: 'v',
-  $runtimeKeepalivePop__deps: ['$runtimeKeepaliveCounter'],
   $runtimeKeepalivePop: function() {
 #if ASSERTIONS
     assert(runtimeKeepaliveCounter > 0);
@@ -3608,7 +3598,6 @@ LibraryManager.library = {
     err('runtimeKeepalivePop -> counter=' + runtimeKeepaliveCounter);
 #endif
   },
-
 
   // Used to call user callbacks from the embedder / event loop.  For example
   // setTimeout or any other kind of event handler that calls into user case
@@ -3684,6 +3673,14 @@ LibraryManager.library = {
     func();
   },
 #endif
+
+  $safeSetTimeout: function(func, timeout) {
+    {{{ runtimeKeepalivePush() }}}
+    return setTimeout(function() {
+      {{{ runtimeKeepalivePop() }}}
+      callUserCallback(func);
+    }, timeout);
+  },
 
   $asmjsMangle: function(x) {
     var unmangledSymbols = {{{ buildStringArray(WASM_SYSTEM_EXPORTS) }}};

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -304,10 +304,10 @@ mergeInto(LibraryManager.library, {
     },
   },
 
-  emscripten_sleep__deps: ['$Browser'],
+  emscripten_sleep__deps: ['$safeSetTimeout'],
   emscripten_sleep: function(ms) {
     Asyncify.handleSleep(function(wakeUp) {
-      Browser.safeSetTimeout(wakeUp, ms);
+      safeSetTimeout(wakeUp, ms);
     });
   },
 

--- a/src/library_bootstrap.js
+++ b/src/library_bootstrap.js
@@ -14,5 +14,4 @@ assert(false, "library_bootstrap.js only designed for use with BOOTSTRAPPING_STR
 assert(!LibraryManager.library);
 LibraryManager.library = {
   $callRuntimeCallbacks: function() {},
-  $keepRuntimeAlive: function() { return false }
 };

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -9,6 +9,7 @@ var LibraryBrowser = {
   $Browser__deps: [
     '$setMainLoop',
     '$callUserCallback',
+    '$safeSetTimeout',
     'emscripten_set_main_loop_timing',
 #if !MINIMAL_RUNTIME
     '$runtimeKeepalivePush',
@@ -230,7 +231,7 @@ var LibraryBrowser = {
           };
           audio.src = url;
           // workaround for chrome bug 124926 - we do not always get oncanplaythrough or onerror
-          Browser.safeSetTimeout(function() {
+          safeSetTimeout(function() {
             finish(audio); // try to use it even though it is not necessarily ready to play
           }, 10000);
         } else {
@@ -488,19 +489,17 @@ var LibraryBrowser = {
 
     // abort and pause-aware versions TODO: build main loop on top of this?
 
+    safeSetTimeout: function(func) {
+      // Legacy function, this is used by the SDL2 port so we need to keep it
+      // around at least until that is updated.
+      return safeSetTimeout(func);
+    },
     safeRequestAnimationFrame: function(func) {
       {{{ runtimeKeepalivePush() }}}
       return Browser.requestAnimationFrame(function() {
         {{{ runtimeKeepalivePop() }}}
         callUserCallback(func);
       });
-    },
-    safeSetTimeout: function(func, timeout) {
-      {{{ runtimeKeepalivePush() }}}
-      return setTimeout(function() {
-        {{{ runtimeKeepalivePop() }}}
-        callUserCallback(func);
-      }, timeout);
     },
 
     getMimetype: function(name) {
@@ -1105,10 +1104,10 @@ var LibraryBrowser = {
   },
 
   // Callable from pthread, executes in pthread context.
-  emscripten_async_run_script__deps: ['emscripten_run_script'],
+  emscripten_async_run_script__deps: ['emscripten_run_script', '$safeSetTimeout'],
   emscripten_async_run_script: function(script, millis) {
     // TODO: cache these to avoid generating garbage
-    Browser.safeSetTimeout(function() {
+    safeSetTimeout(function() {
       _emscripten_run_script(script);
     }, millis);
   },
@@ -1421,13 +1420,19 @@ var LibraryBrowser = {
 
   // Runs natively in pthread, no __proxy needed.
   emscripten_async_call__sig: 'viii',
+  emscripten_async_call__deps: ['$safeSetTimeout'],
   emscripten_async_call: function(func, arg, millis) {
     function wrapper() {
       {{{ makeDynCall('vi', 'func') }}}(arg);
     }
 
-    if (millis >= 0) {
-      Browser.safeSetTimeout(wrapper, millis);
+    if (millis >= 0
+#if ENVIRONMENT_MAY_BE_NODE
+      // node does not support requestAnimationFrame
+      || ENVIRONMENT_IS_NODE
+#endif
+    ) {
+      safeSetTimeout(wrapper, millis);
     } else {
       Browser.safeRequestAnimationFrame(wrapper);
     }

--- a/src/library_glut.js
+++ b/src/library_glut.js
@@ -418,24 +418,26 @@ var LibraryGLUT = {
   },
 
   glutIdleFunc__proxy: 'sync',
+  glutIdleFunc__deps: ['$safeSetTimeout'],
   glutIdleFunc__sig: 'vi',
   glutIdleFunc: function(func) {
     function callback() {
       if (GLUT.idleFunc) {
         {{{ makeDynCall('v', 'GLUT.idleFunc') }}}();
-        Browser.safeSetTimeout(callback, 4); // HTML spec specifies a 4ms minimum delay on the main thread; workers might get more, but we standardize here
+        safeSetTimeout(callback, 4); // HTML spec specifies a 4ms minimum delay on the main thread; workers might get more, but we standardize here
       }
     }
     if (!GLUT.idleFunc) {
-      Browser.safeSetTimeout(callback, 0);
+      safeSetTimeout(callback, 0);
     }
     GLUT.idleFunc = func;
   },
 
   glutTimerFunc__proxy: 'sync',
+  glutTimerFunc__deps: ['$safeSetTimeout'],
   glutTimerFunc__sig: 'viii',
   glutTimerFunc: function(msec, func, value) {
-    Browser.safeSetTimeout(function() { {{{ makeDynCall('vi', 'func') }}}(value); }, msec);
+    safeSetTimeout(function() { {{{ makeDynCall('vi', 'func') }}}(value); }, msec);
   },
 
   glutDisplayFunc__proxy: 'sync',

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2415,7 +2415,7 @@ var LibrarySDL = {
 
   // SDL_Audio
 
-  SDL_OpenAudio__deps: ['$autoResumeAudioContext'],
+  SDL_OpenAudio__deps: ['$autoResumeAudioContext', '$safeSetTimeout'],
   SDL_OpenAudio__proxy: 'sync',
   SDL_OpenAudio__sig: 'iii',
   SDL_OpenAudio: function(desired, obtained) {
@@ -2537,12 +2537,12 @@ var LibrarySDL = {
 
         if (SDL.audio.numAudioTimersPending < SDL.audio.numSimultaneouslyQueuedBuffers) {
           ++SDL.audio.numAudioTimersPending;
-          SDL.audio.timer = Browser.safeSetTimeout(SDL.audio.caller, Math.max(0.0, 1000.0*(secsUntilNextPlayStart-preemptBufferFeedSecs)));
+          SDL.audio.timer = safeSetTimeout(SDL.audio.caller, Math.max(0.0, 1000.0*(secsUntilNextPlayStart-preemptBufferFeedSecs)));
 
           // If we are risking starving, immediately queue an extra buffer.
           if (SDL.audio.numAudioTimersPending < SDL.audio.numSimultaneouslyQueuedBuffers) {
             ++SDL.audio.numAudioTimersPending;
-            Browser.safeSetTimeout(SDL.audio.caller, 1.0);
+            safeSetTimeout(SDL.audio.caller, 1.0);
           }
         }
       };
@@ -2639,6 +2639,7 @@ var LibrarySDL = {
   },
 
   SDL_PauseAudio__proxy: 'sync',
+  SDL_PauseAudio__deps: ['$safeSetTimeout'],
   SDL_PauseAudio__sig: 'vi',
   SDL_PauseAudio: function(pauseOn) {
     if (!SDL.audio) {
@@ -2653,7 +2654,7 @@ var LibrarySDL = {
     } else if (!SDL.audio.timer) {
       // Start the audio playback timer callback loop.
       SDL.audio.numAudioTimersPending = 1;
-      SDL.audio.timer = Browser.safeSetTimeout(SDL.audio.caller, 1);
+      SDL.audio.timer = safeSetTimeout(SDL.audio.caller, 1);
     }
     SDL.audio.paused = pauseOn;
   },

--- a/src/modules.js
+++ b/src/modules.js
@@ -416,6 +416,7 @@ function exportRuntime() {
     'setTempRet0',
     'callMain',
     'abort',
+    'keepRuntimeAlive',
   ];
 
   if (USE_OFFSET_CONVERTER) {

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -417,14 +417,6 @@ function exit(status, implicit) {
 #endif // EXIT_RUNTIME
 #endif // ASSERTIONS
 
-  // if this is just main exit-ing implicitly, and the status is 0, then we
-  // don't need to do anything here and can just leave. if the status is
-  // non-zero, though, then we need to report it.
-  // (we may have warned about this earlier, if a situation justifies doing so)
-  if (implicit && keepRuntimeAlive() && status === 0) {
-    return;
-  }
-
 #if USE_PTHREADS
   if (!implicit) {
     if (ENVIRONMENT_IS_PTHREAD) {

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -356,6 +356,11 @@ var __ATPOSTRUN__ = []; // functions called after the main() is called
 
 var runtimeInitialized = false;
 var runtimeExited = false;
+var runtimeKeepaliveCounter = 0;
+
+function keepRuntimeAlive() {
+  return noExitRuntime || runtimeKeepaliveCounter > 0;
+}
 
 function preRun() {
 #if USE_PTHREADS

--- a/src/shell.js
+++ b/src/shell.js
@@ -201,7 +201,11 @@ if (ENVIRONMENT_IS_NODE) {
   process['on']('unhandledRejection', abort);
 #endif
 
-  quit_ = function(status) {
+  quit_ = function(status, toThrow) {
+    if (keepRuntimeAlive()) {
+      process['exitCode'] = status;
+      throw toThrow;
+    }
     process['exit'](status);
   };
 

--- a/tests/core/test_emscripten_async_call.c
+++ b/tests/core/test_emscripten_async_call.c
@@ -1,0 +1,28 @@
+#include <assert.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <emscripten/emscripten.h>
+
+bool doneCallback = false;
+
+void myatexit() {
+  printf("myatexit\n");
+  assert(doneCallback);
+}
+
+void callback(void *arg) {
+  printf("callback\n");
+  doneCallback = true;
+  assert((int)arg == 42);
+  // Runtime should exit after this callback returns
+}
+
+int main() {
+  atexit(myatexit);
+  // The runtime should stay alive long enough for the callbackl
+  // to run.
+  emscripten_async_call(callback, (void*)42, 500);
+  printf("returning from main\n");
+  return 0;
+}

--- a/tests/core/test_emscripten_async_call.out
+++ b/tests/core/test_emscripten_async_call.out
@@ -1,0 +1,3 @@
+returning from main
+callback
+myatexit

--- a/tests/malloc_demangle_infinite_loop.cpp
+++ b/tests/malloc_demangle_infinite_loop.cpp
@@ -1,16 +1,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-int _Zxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(int i1)
-{
-	if (i1 > 0)
-		return _Zxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(--i1);
-	for(;;)
-		malloc(1);
-	return 1;
+int _Zxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(int i1) {
+  if (i1 > 0)
+    return _Zxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(--i1);
+  for(;;)
+    malloc(1);
+  return 1;
 }
 
-int main()
-{
-	_Zxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(100);
+int main() {
+  _Zxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx(100);
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7513,7 +7513,7 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('ASYNCIFY')
     self.set_setting('ASSERTIONS')
     self.set_setting('EXIT_RUNTIME', 1)
-    self.do_core_test('test_asyncify_during_exit.cpp', assert_returncode=1)
+    self.do_core_test('test_asyncify_during_exit.cpp', assert_returncode=NON_ZERO)
     print('NO_ASYNC')
     self.do_core_test('test_asyncify_during_exit.cpp', emcc_args=['-DNO_ASYNC'], out_suffix='_no_async')
 
@@ -8253,6 +8253,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_pthread_create_proxy(self):
     # with PROXY_TO_PTHREAD, we can synchronously depend on workers being available
     self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
     self.emcc_args += ['-DALLOW_SYNC']
     self.do_run_in_out_file_test('core/pthread/create.cpp')
 
@@ -8507,6 +8508,10 @@ NODEFS is no longer included by default; build with -lnodefs.js
     # 'none' should fail to link because the dependency on ntohs was not added.
     err = self.expect_fail([EMCC, 'connect.c', '-sREVERSE_DEPS=none'])
     self.assertContained('undefined symbol: ntohs', err)
+
+  def test_emscripten_async_call(self):
+    self.set_setting('EXIT_RUNTIME')
+    self.do_run_in_out_file_test(test_file('core/test_emscripten_async_call.c'))
 
 
 # Generate tests for everything


### PR DESCRIPTION
Move `Browser.safeSetTimeout` to top level library function (since this  
code should work just as well under node).                                  
                                                                                                              
Test that `emscripten_async_call` works under node and that the runtime  
is kept alive until the callback fires.                                     
                                                                            
In order to allow for this I've improved the handling of EXIT_RUNTIME=0  
under node:                                                                 
                                                                            
By default (unless `EXIT_RUNTIME=1` is specified) emscripten programs       
running under node will no longer call `process.exit()` on `exit()`.        
Instead they will simply unwind the stack return to the event loop, much 
like they do on the web.  In many cases the node process will still exit 
naturally if there is nothing keeping the event loop going.  To             
guarantee that the node process exits immediately please build with         
`EXIT_RUNTIME=1`.