### PR TITLE
Improve test_sigalrm. NFC

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4158,7 +4158,7 @@ window.close = function() {
 
   # Test that it is possible to send a signal via calling alarm(timeout), which in turn calls to the signal handler set by signal(SIGALRM, func);
   def test_sigalrm(self):
-    self.btest(test_file('sigalrm.cpp'), expected='0', args=['-O3'])
+    self.btest_exit(test_file('test_sigalrm.c'), args=['-O3'])
 
   def test_canvas_style_proxy(self):
     self.btest('canvas_style_proxy.c', expected='1', args=['--proxy-to-worker', '--shell-file', test_file('canvas_style_proxy_shell.html'), '--pre-js', test_file('canvas_style_proxy_pre.js')])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5285,7 +5285,7 @@ Module['onRuntimeInitialized'] = function() {
     self.do_runf(test_file('fs/test_64bit.c'), 'success')
 
   def test_sigalrm(self):
-    self.do_runf(test_file('sigalrm.cpp'), '')
+    self.do_runf(test_file('test_sigalrm.c'), 'Received alarm!')
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
   def test_unistd_access(self):

--- a/tests/test_sigalrm.c
+++ b/tests/test_sigalrm.c
@@ -9,24 +9,15 @@
 #include <unistd.h>
 #include <pthread.h>
 
-void alarm_handler(int dummy)
-{
-	printf("Received alarm!\n");
-#ifdef REPORT_RESULT
-	REPORT_RESULT(0);
-#endif
-	exit(0);
+void alarm_handler(int dummy) {
+  printf("Received alarm!\n");
+  exit(0);
 }
 
-int main()
-{
-	if (signal(SIGALRM, alarm_handler) == SIG_ERR)
-	{
-		printf("Error in signal()!\n");
-#ifdef REPORT_RESULT
-		REPORT_RESULT(1);
-#endif
-		exit(1);
-	}
-	alarm(5);
+int main() {
+  if (signal(SIGALRM, alarm_handler) == SIG_ERR) {
+    printf("Error in signal()!\n");
+    exit(1);
+  }
+  alarm(1);
 }


### PR DESCRIPTION
- Use btest_exit to avoid reporting macros.
- Check out expected output in test_core.py
- Use C over C++ for simple tests like this.
- Avoid 5 second delay by using a 1 second alarm.