### PR TITLE
Remove legacy __sys_exit syscall. NFC

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -305,10 +305,6 @@ var SyscallsLibrary = {
     return 0;
   },
 
-  __sys_exit: function(status) {
-    exit(status);
-    // no return
-  },
   __sys_open: function(path, flags, varargs) {
     var pathname = SYSCALLS.getStr(path);
     var mode = varargs ? SYSCALLS.get() : 0;
@@ -1214,13 +1210,6 @@ var SyscallsLibrary = {
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
 
-#if MINIMAL_RUNTIME
-  __sys_exit_group__deps: ['$exit'],
-#endif
-  __sys_exit_group: function(status) {
-    exit(status);
-    return 0;
-  },
   __sys_statfs64: function(path, size, buf) {
     path = SYSCALLS.getStr(path);
 #if ASSERTIONS

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -483,7 +483,9 @@ uptr internal_execve(const char *filename, char *const argv[],
 
 #if !SANITIZER_NETBSD
 void internal__exit(int exitcode) {
-#if SANITIZER_FREEBSD || SANITIZER_SOLARIS
+#if SANITIZER_EMSCRIPTEN
+  __wasi_proc_exit(exitcode);
+#elif SANITIZER_FREEBSD || SANITIZER_SOLARIS
   internal_syscall(SYSCALL(exit), exitcode);
 #else
   internal_syscall(SYSCALL(exit_group), exitcode);

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -14,7 +14,6 @@ extern "C" {
 /* Causes the final import in the wasm binary be named "env.sys_<name>" */
 #define SYS_IMPORT(NAME) EM_IMPORT(__sys_##NAME)
 
-long SYS_IMPORT(exit) __syscall1(long exit_code);
 long SYS_IMPORT(open) __syscall5(long path, long flags, ...); // mode is optional
 long SYS_IMPORT(link) __syscall9(long oldpath, long newpath);
 long SYS_IMPORT(unlink) __syscall10(long path);
@@ -96,7 +95,6 @@ long SYS_IMPORT(mincore) __syscall218(long addr, long length, long vec);
 long SYS_IMPORT(madvise1) __syscall219(long addr, long length, long advice);
 long SYS_IMPORT(getdents64) __syscall220(long fd, long dirp, long count);
 long SYS_IMPORT(fcntl64) __syscall221(long fd, long cmd, ...);
-long SYS_IMPORT(exit_group) __syscall252(long status);
 long SYS_IMPORT(statfs64) __syscall268(long path, long size, long buf);
 long SYS_IMPORT(fstatfs64) __syscall269(long fd, long size, long buf);
 long SYS_IMPORT(fadvise64_64)


### PR DESCRIPTION
This was replaced by the WASI `proc_exit` syscall a while
back.