### PR TITLE
Use _Exit and _exit from musl source. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -163,12 +163,6 @@ LibraryManager.library = {
 #endif
   },
 
-  _exit__sig: 'vi',
-  _exit: 'exit',
-
-  _Exit__sig: 'vi',
-  _Exit: 'exit',
-
 #if MINIMAL_RUNTIME
   $exit: function(status) {
     throw 'exit(' + status + ')';

--- a/system/lib/libc/musl/src/exit/_Exit.c
+++ b/system/lib/libc/musl/src/exit/_Exit.c
@@ -3,6 +3,10 @@
 
 _Noreturn void _Exit(int ec)
 {
+#ifdef __EMSCRIPTEN__
+	__wasi_proc_exit(ec);
+#else
 	__syscall(SYS_exit_group, ec);
 	for (;;) __syscall(SYS_exit, ec);
+#endif
 }

--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -25,11 +25,6 @@
 
 // libc
 
-void _Exit(int status) {
-  __wasi_proc_exit(status);
-  __builtin_unreachable();
-}
-
 void abort() {
   _Exit(1);
 }


### PR DESCRIPTION
This is part 1 of a change I'm working on to use musl's exit code.  This
is NFC because we endup calling proc_exit which calls exit in any case.