### PR TITLE
Fix llvm_nm_multiple handling of mis-named archive files

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10657,3 +10657,17 @@ kill -9 $$
     # Here we use NO_AUTO_NATIVE_LIBRARIES to disable the implictly linking that normally
     # includes the native GL library.
     self.run_process([EMCC, test_file('other/test_explict_gl_linking.c'), '-sNO_AUTO_NATIVE_LIBRARIES', '-lGL'])
+
+  def test_archive_bad_extension(self):
+    # Regression test for https://github.com/emscripten-core/emscripten/issues/14012
+    # where llvm_nm_multiple would be confused by archives names like object files.
+    create_file('main.c', '''
+    #include <sys/socket.h>
+    int main() {
+       return (int)&accept;
+    }
+    ''')
+
+    self.run_process([EMCC, '-c', 'main.c'])
+    self.run_process([EMAR, 'crs', 'libtest.bc', 'main.o'])
+    self.run_process([EMCC, 'libtest.bc', 'libtest.bc'])

--- a/tools/building.py
+++ b/tools/building.py
@@ -212,8 +212,8 @@ def llvm_nm_multiple(files):
   # files are all .o or .bc files. Because of llvm-nm output format, we cannot
   # llvm-nm multiple .a files in one call, but those must be individually checked.
 
-  o_files = [f for f in llvm_nm_files if os.path.splitext(f)[1].lower() in ['.o', '.obj', '.bc']]
-  a_files = [f for f in llvm_nm_files if f not in o_files]
+  a_files = [f for f in llvm_nm_files if is_ar(f)]
+  o_files = [f for f in llvm_nm_files if f not in a_files]
 
   # Issue parallel calls for .a files
   if len(a_files) > 0:


### PR DESCRIPTION
Don't trust the file extension. We have some folks who had build
systems that produce archive files with the `.bc` extension for
legacy reasons.

This is simpler fix than #14053, which can/should land as a followup
once its ready.

Fixes: #14012