### PR TITLE
Remove unused _ZSt9terminatev JS library function. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -425,11 +425,6 @@ LibraryManager.library = {
   // stdlib.h
   // ==========================================================================
 
-  _ZSt9terminatev__deps: ['exit'],
-  _ZSt9terminatev: function() {
-    _exit(-1234);
-  },
-
 #if MINIMAL_RUNTIME && !EXIT_RUNTIME
   atexit__sig: 'v', // atexit unsupported in MINIMAL_RUNTIME
   atexit: function(){},


### PR DESCRIPTION
This de-mangles to `std::terminate()` so I guess maybe it dates back to
time we didn't supply that in native code?