### PR TITLE
Set `RELOCATABLE` if `-fPIC` is passed on the command line

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -834,8 +834,10 @@ def get_cflags(options, user_args):
     cflags.append('-fno-inline-functions')
 
   if settings.RELOCATABLE:
-    cflags.append('-fPIC')
-    cflags.append('-fvisibility=default')
+    if '-fPIC' not in user_args:
+      cflags.append('-fPIC')
+    if not any(a.startswith('-fvisibility') for a in user_args):
+      cflags.append('-fvisibility=default')
 
   if settings.LTO:
     cflags.append('-flto=' + settings.LTO)
@@ -1310,7 +1312,7 @@ def phase_setup(options, state, newargs, settings_map):
     if options.output_file and len(input_files) > 1:
       exit_with_error('cannot specify -o with -c/-S/-E/-M and multiple source files')
 
-  if settings.MAIN_MODULE or settings.SIDE_MODULE:
+  if settings.MAIN_MODULE or settings.SIDE_MODULE or '-fPIC' in newargs:
     settings.RELOCATABLE = 1
 
   if settings.USE_PTHREADS and '-pthread' not in newargs:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10674,3 +10674,8 @@ kill -9 $$
     self.run_process([EMCC, '-c', 'main.c'])
     self.run_process([EMAR, 'crs', 'libtest.bc', 'main.o'])
     self.run_process([EMCC, 'libtest.bc', 'libtest.bc'])
+
+  def test_pic_implies_relocatable(self):
+    # Test that `-fPIC` implies `-s RELOCATABLE` which implies `-fvisibility=default`
+    out = self.run_process([EMCC, '-fPIC', '-c', test_file('hello_world.c'), '-v'], stderr=PIPE).stderr
+    self.assertContained('-fvisibility=default', out)


### PR DESCRIPTION
Also avoid adding `-fPIC` a second time if it already exists.

This is a partial fix for #14488 since now building with `-fPIC -s
USE_LIBJPEG=1` will correctly cause the `pic` version of libjpeg to be
built and installed.

This is hard to test for since it involves something that is mostly and
internal detail (which verion of libjpeg is build when copiling with `-c`).

I decided to instead test for another side effect of `-s RELOCATABLE`
which is the `-fvisibility=default` compiler flag.