### PR TITLE
Better handling of unimplemented syscalls

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 2.0.25
 ------
+- A new setting called `ALLOW_UNIMPLEMENTED_SYSCALLS` was added.  This setting
+  is enabled by default but, if disabled, will generate link-time errors if
+  a program references an unimplemented syscall.  This setting is disabled
+  by default in `STRICT` mode.
 - By default (unless `EXIT_RUNTIME=1` is specified) emscripten programs running
   under node will no longer call `process.exit()` on `exit()`.  Instead they
   will simply unwind the stack and return to the event loop, much like they do

--- a/emcc.py
+++ b/emcc.py
@@ -1537,6 +1537,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
     default_setting('AUTO_ARCHIVE_INDEXES', 0)
     default_setting('IGNORE_MISSING_MAIN', 0)
     default_setting('DEFAULT_TO_CXX', 0)
+    default_setting('ALLOW_UNIMPLEMENTED_SYSCALLS', 0)
 
   # Default to TEXTDECODER=2 (always use TextDecoder to decode UTF-8 strings)
   # in -Oz builds, since custom decoder for UTF-8 takes up space.

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -194,6 +194,10 @@ function JSify(functionsOnly) {
         }
       }
 
+      if (!ALLOW_UNIMPLEMENTED_SYSCALLS && LibraryManager.library[ident + '__unimplemented']) {
+        error(`attempt to link unsupport syscall: ${ident} (use -s ALLOW_UNIMPLEMENTED_SYSCALLS (the default) to allow linking with a stub version`);
+      }
+
       var original = LibraryManager.library[ident];
       var snippet = original;
       var redirectedIdent = null;

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -391,11 +391,6 @@ var SyscallsLibrary = {
 
     return 0;
   },
-  __sys_acct__nothrow: true,
-  __sys_acct__proxy: false,
-  __sys_acct: function(filename) {
-    return -{{{ cDefine('ENOSYS') }}}; // unsupported features
-  },
   __sys_ioctl: function(fd, op, varargs) {
 #if SYSCALLS_REQUIRE_FILESYSTEM == 0
 #if SYSCALL_DEBUG
@@ -492,9 +487,6 @@ var SyscallsLibrary = {
   },
   __sys_getrusage__deps: ['$zeroMemory'],
   __sys_getrusage: function(who, usage) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
-#endif
     zeroMemory(usage, {{{ C_STRUCTS.rusage.__size__ }}});
     {{{ makeSetValue('usage', C_STRUCTS.rusage.ru_utime.tv_sec, '1', 'i32') }}}; // fake some values
     {{{ makeSetValue('usage', C_STRUCTS.rusage.ru_utime.tv_usec, '2', 'i32') }}};
@@ -570,12 +562,6 @@ var SyscallsLibrary = {
     assert(!errno);
 #endif
     return 0;
-  },
-  __sys_socketpair: function() {
-#if SYSCALL_DEBUG
-    err('unsupported syscall: __sys_socketpair');
-#endif
-    return -{{{ cDefine('ENOSYS') }}};
   },
   __sys_setsockopt: function(fd) {
     return -{{{ cDefine('ENOPROTOOPT') }}}; // The option is unknown at the level indicated.
@@ -760,15 +746,6 @@ var SyscallsLibrary = {
     return bytesRead;
   },
 #endif // ~PROXY_POSIX_SOCKETS==0
-  __sys_setitimer__nothrow: true,
-  __sys_setitimer__proxy: false,
-  __sys_setitimer: function(which, new_value, old_value) {
-    return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
-  },
-  __sys_wait4__proxy: false,
-  __sys_wait4: function(pid, wstart, options, rusage) {
-    return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
-  },
   __sys_setdomainname__nothrow: true,
   __sys_setdomainname__proxy: false,
   __sys_setdomainname: function(name, size) {
@@ -796,8 +773,6 @@ var SyscallsLibrary = {
 #endif
     return 0;
   },
-  __sys_mprotect__nothrow: true,
-  __sys_mprotect__proxy: false,
   __sys_mprotect: function(addr, len, size) {
     return 0; // let's not and say we did
   },
@@ -912,32 +887,22 @@ var SyscallsLibrary = {
     var stream = SYSCALLS.getStreamFromFD(fd);
     return 0; // we can't do anything synchronously; the in-memory FS is already synced to
   },
-  __sys_mlock__nothrow: true,
-  __sys_mlock__proxy: false,
   __sys_mlock__sig: 'iii',
   __sys_mlock: function(addr, len) {
     return 0;
   },
-  __sys_munlock__nothrow: true,
-  __sys_munlock__proxy: false,
   __sys_munlock__sig: 'iii',
   __sys_munlock: function(addr, len) {
     return 0;
   },
-  __sys_mlockall__nothrow: true,
-  __sys_mlockall__proxy: false,
   __sys_mlockall__sig: 'ii',
   __sys_mlockall: function(flags) {
     return 0;
   },
-  __sys_munlockall__nothrow: true,
-  __sys_munlockall__proxy: false,
   __sys_munlockall__sig: 'i',
   __sys_munlockall: function() {
     return 0;
   },
-  __sys_mremap__nothrow: true,
-  __sys_mremap__proxy: false,
   __sys_mremap: function(old_addr, old_size, new_size, flags) {
     return -{{{ cDefine('ENOMEM') }}}; // never succeed
   },
@@ -961,12 +926,7 @@ var SyscallsLibrary = {
     }
     return nonzero;
   },
-  __sys_rt_sigqueueinfo__nothrow: true,
-  __sys_rt_sigqueueinfo__proxy: false,
   __sys_rt_sigqueueinfo: function(tgid, pid, uinfo) {
-#if SYSCALL_DEBUG
-    err('warning: ignoring SYS_rt_sigqueueinfo');
-#endif
     return 0;
   },
 
@@ -979,9 +939,6 @@ var SyscallsLibrary = {
     return buf;
   },
   __sys_ugetrlimit: function(resource, rlim) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
-#endif
     {{{ makeSetValue('rlim', C_STRUCTS.rlimit.rlim_cur, '-1', 'i32') }}};  // RLIM_INFINITY
     {{{ makeSetValue('rlim', C_STRUCTS.rlimit.rlim_cur + 4, '-1', 'i32') }}};  // RLIM_INFINITY
     {{{ makeSetValue('rlim', C_STRUCTS.rlimit.rlim_max, '-1', 'i32') }}};  // RLIM_INFINITY
@@ -1089,26 +1046,15 @@ var SyscallsLibrary = {
   __sys_getresuid32__nothrow: true,
   __sys_getresuid32__proxy: false,
   __sys_getresuid32: '__sys_getresgid32',
-  __sys_getresgid32__nothrow: true,
-  __sys_getresgid32__proxy: false,
   __sys_getresgid32: function(ruid, euid, suid) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
-#endif
     {{{ makeSetValue('ruid', '0', '0', 'i32') }}};
     {{{ makeSetValue('euid', '0', '0', 'i32') }}};
     {{{ makeSetValue('suid', '0', '0', 'i32') }}};
     return 0;
   },
-  __sys_mincore__nothrow: true,
-  __sys_mincore__proxy: false,
-  __sys_mincore: function(addr, length, vec) {
-    return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
-  },
-  __sys_madvise1__nothrow: true,
-  __sys_madvise1__proxy: false,
   __sys_madvise1: function(addr, length, advice) {
-    return 0; // advice is welcome, but ignored
+    // advice is welcome, but ignored
+    return 0;
   },
   __sys_getdents64: function(fd, dirp, count) {
     var stream = SYSCALLS.getStreamFromFD(fd)
@@ -1350,15 +1296,7 @@ var SyscallsLibrary = {
     path = SYSCALLS.calculateAt(dirfd, path);
     return SYSCALLS.doAccess(path, amode);
   },
-  __sys_pselect6__nothrow: true,
-  __sys_pselect6__proxy: false,
-  __sys_pselect6: function() {
-    return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
-  },
   __sys_utimensat: function(dirfd, path, times, flags) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
-#endif
     path = SYSCALLS.getStr(path);
 #if ASSERTIONS
     assert(flags === 0);
@@ -1372,7 +1310,7 @@ var SyscallsLibrary = {
     nanoseconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_nsec, 'i32') }}};
     var mtime = (seconds*1000) + (nanoseconds/(1000*1000));
     FS.utime(path, atime, mtime);
-    return 0;  
+    return 0;
   },
   __sys_fallocate: function(fd, mode, off_low, off_high, len_low, len_high) {
     var stream = SYSCALLS.getStreamFromFD(fd)
@@ -1386,7 +1324,7 @@ var SyscallsLibrary = {
   },
   __sys_dup3: function(fd, suggestFD, flags) {
 #if SYSCALL_DEBUG
-    err('warning: untested syscall');
+    err('warning: untested syscall: dup3');
 #endif
     var old = SYSCALLS.getStreamFromFD(fd);
 #if ASSERTIONS
@@ -1395,20 +1333,7 @@ var SyscallsLibrary = {
     if (old.fd === suggestFD) return -{{{ cDefine('EINVAL') }}};
     return SYSCALLS.doDup(old.path, old.flags, suggestFD);
   },
-  __sys_pipe2__nothrow: true,
-  __sys_pipe2__proxy: false,
-  __sys_pipe2: function(fds, flags) {
-    return -{{{ cDefine('ENOSYS') }}}; // unsupported feature
-  },
 
-  __sys_recvmmsg__nothrow: true,
-  __sys_recvmmsg__proxy: false,
-  __sys_recvmmsg: function(sockfd, msgvec, vlen, flags) {
-#if SYSCALL_DEBUG
-    err('warning: ignoring SYS_recvmmsg');
-#endif
-    return 0;
-  },
   __sys_prlimit64: function(pid, resource, new_limit, old_limit) {
     if (old_limit) { // just report no limits
       {{{ makeSetValue('old_limit', C_STRUCTS.rlimit.rlim_cur, '-1', 'i32') }}};  // RLIM_INFINITY
@@ -1416,14 +1341,6 @@ var SyscallsLibrary = {
       {{{ makeSetValue('old_limit', C_STRUCTS.rlimit.rlim_max, '-1', 'i32') }}};  // RLIM_INFINITY
       {{{ makeSetValue('old_limit', C_STRUCTS.rlimit.rlim_max + 4, '-1', 'i32') }}};  // RLIM_INFINITY
     }
-    return 0;
-  },
-  __sys_sendmmsg__nothrow: true,
-  __sys_sendmmsg__proxy: false,
-  __sys_sendmmsg: function(sockfd, msg, flags) {
-#if SYSCALL_DEBUG
-    err('warning: ignoring SYS_sendmmsg');
-#endif
     return 0;
   },
 };
@@ -1531,5 +1448,46 @@ function wrapSyscallFunction(x, library, isWasi) {
 for (var x in SyscallsLibrary) {
   wrapSyscallFunction(x, SyscallsLibrary, false);
 }
+
+function unimplementedSycall(name) {
+  SyscallsLibrary[name + '__nothrow'] = true;
+  SyscallsLibrary[name + '__proxy'] = false;
+  SyscallsLibrary[name + '__unimplemented'] = true;
+  msg = `\n  err('warning: unsupported syscall: ${name}');`;
+  if (SyscallsLibrary[name]) {
+    SyscallsLibrary[name] = modifyFunction(SyscallsLibrary[name].toString(), (name, args, body) => {
+            return `function(${args}) {\n  ${msg}${body}\n}\n`;
+          });
+  } else {
+    errcode = cDefine('ENOSYS');
+    SyscallsLibrary[name] = `function() {\n  ${msg}return -${errcode};\n}`;
+  }
+}
+
+[
+  '__sys_acct',
+  '__sys_getresgid32',
+  '__sys_getrusage',
+  '__sys_madvise1',
+  '__sys_mincore',
+  '__sys_mlock',
+  '__sys_mlockall',
+  '__sys_mprotect',
+  '__sys_mremap',
+  '__sys_munlock',
+  '__sys_munlockall',
+  '__sys_pipe2',
+  '__sys_prlimit64',
+  '__sys_pselect6',
+  '__sys_recvmmsg',
+  '__sys_rt_sigqueueinfo',
+  '__sys_sendmmsg',
+  '__sys_setitimer',
+  '__sys_shutdown',
+  '__sys_socketpair',
+  '__sys_setsockopt',
+  '__sys_ugetrlimit',
+  '__sys_wait4',
+].forEach(unimplementedSycall);
 
 mergeInto(LibraryManager.library, SyscallsLibrary);

--- a/src/settings.js
+++ b/src/settings.js
@@ -1028,6 +1028,7 @@ var LINKABLE = 0;
 //   * AUTO_NATIVE_LIBRARIES is disabled.
 //   * AUTO_ARCHIVE_INDEXES is disabled.
 //   * DEFAULT_TO_CXX is disabled.
+//   * ALLOW_UNIMPLEMENTED_SYSCALLS is disabled.
 // [compile+link]
 var STRICT = 0;
 
@@ -1938,6 +1939,11 @@ var REVERSE_DEPS = 'auto';
 // For MAIN_MODULE builds, automatically load any dynamic library dependencies
 // on startup, before loading the main module.
 var AUTOLOAD_DYLIBS = 1;
+
+// Include unimplemented JS syscalls to be included in the final output.  This
+// allows programs that depend on these syscalls at runtime to be compiled, even
+// though these syscalls will fail (or do nothing) at runtime.
+var ALLOW_UNIMPLEMENTED_SYSCALLS = 1;
 
 //===========================================
 // Internal, used for testing only, from here

--- a/src/utility.js
+++ b/src/utility.js
@@ -111,9 +111,19 @@ function isNumber(x) {
 }
 
 function isJsLibraryConfigIdentifier(ident) {
-  return ident.endsWith('__sig') || ident.endsWith('__proxy') || ident.endsWith('__asm') || ident.endsWith('__inline')
-   || ident.endsWith('__deps') || ident.endsWith('__postset') || ident.endsWith('__docs') || ident.endsWith('__import')
-   || ident.endsWith('__nothrow');
+  suffixes = [
+    '__sig',
+    '__proxy',
+    '__asm',
+    '__inline',
+    '__deps',
+    '__postset',
+    '__docs',
+    '__import',
+    '__nothrow',
+    '__unimplemented'
+  ];
+  return suffixes.some((suffix) => ident.endsWith(suffix));
 }
 
 // Sets


### PR DESCRIPTION
Add a new setting, `ALLOW_UNIMPLEMENTED_SYSCALLS`, which is enabled by
default but is disabled in STICT mode.  This option will cause any usage
of unimplemented syscalls to become a linker error.

Also we now single location were we can hook into unimplemented syscalls
for adding logging/warnings etc.