### PR TITLE
Recommend using a response file for asyncify options. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -554,10 +554,11 @@ def get_binaryen_passes():
     def check_human_readable_list(items):
       for item in items:
         if item.count('(') != item.count(')'):
-          logger.warning('''emcc: ASYNCIFY list contains an item without balanced parentheses ("(", ")"):''')
-          logger.warning('''   ''' + item)
-          logger.warning('''This may indicate improper escaping that led to splitting inside your names.''')
-          logger.warning('''Try to quote the entire argument, like this: -s 'ASYNCIFY_ONLY=["foo(int, char)", "bar"]' ''')
+          logger.warning('emcc: ASYNCIFY list contains an item without balanced parentheses ("(", ")"):')
+          logger.warning('   ' + item)
+          logger.warning('This may indicate improper escaping that led to splitting inside your names.')
+          logger.warning('Try using a response file. e.g: -sASYNCIFY_ONLY=@funcs.txt. The format is a simple')
+          logger.warning('text file, one line per function.')
           break
 
     if settings.ASYNCIFY_REMOVE:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8285,7 +8285,7 @@ _d
     proc = self.run_process([EMCC, test_file('hello_world.c'), '-s', 'ASYNCIFY', '-s', "ASYNCIFY_ONLY=[DOS_ReadFile(unsigned short, unsigned char*, unsigned short*, bool)]"], stdout=PIPE, stderr=PIPE)
     self.assertContained('emcc: ASYNCIFY list contains an item without balanced parentheses', proc.stderr)
     self.assertContained('   DOS_ReadFile(unsigned short', proc.stderr)
-    self.assertContained('Try to quote the entire argument', proc.stderr)
+    self.assertContained('Try using a response file', proc.stderr)
 
   def test_asyncify_response_file(self):
     create_file('a.txt', r'''[


### PR DESCRIPTION
Trying to do escaping on the command line is hard.  We can
avoid the problem using a file instead.

The option to use a simple flat file format was added in #14170.