### PR TITLE
Switch hardbuzz port away from depending on cmake and make

### DIFF
--- a/tools/ports/harfbuzz.py
+++ b/tools/ports/harfbuzz.py
@@ -4,15 +4,70 @@
 # found in the LICENSE file.
 
 import os
-import shutil
 import logging
 
-from tools import system_libs
-
-TAG = '1.7.5'
-HASH = 'c2c13fc97bb74f0f13092b07804f7087e948bce49793f48b62c2c24a5792523acc0002840bebf21829172bb2e7c3df9f9625250aec6c786a55489667dd04d6a0'
+TAG = '2.8.1'
+HASH = 'c969ec1677f2f023c05698a226c96b23a815db732f1561d486b25b07c3663ea8192e49ee1253b7b623b43d713b9230df3265a47da6fd65378256ecada90c6ae4'
 
 deps = ['freetype']
+
+srcs = '''
+hb-aat-layout.cc
+hb-aat-map.cc
+hb-blob.cc
+hb-buffer-serialize.cc
+hb-buffer.cc
+hb-common.cc
+hb-draw.cc
+hb-face.cc
+hb-fallback-shape.cc
+hb-font.cc
+hb-map.cc
+hb-number.cc
+hb-ot-cff1-table.cc
+hb-ot-cff2-table.cc
+hb-ot-color.cc
+hb-ot-face.cc
+hb-ot-font.cc
+hb-ot-layout.cc
+hb-ot-map.cc
+hb-ot-math.cc
+hb-ot-meta.cc
+hb-ot-metrics.cc
+hb-ot-name.cc
+hb-ot-shape-complex-arabic.cc
+hb-ot-shape-complex-default.cc
+hb-ot-shape-complex-hangul.cc
+hb-ot-shape-complex-hebrew.cc
+hb-ot-shape-complex-indic-table.cc
+hb-ot-shape-complex-indic.cc
+hb-ot-shape-complex-khmer.cc
+hb-ot-shape-complex-myanmar.cc
+hb-ot-shape-complex-syllabic.cc
+hb-ot-shape-complex-thai.cc
+hb-ot-shape-complex-use.cc
+hb-ot-shape-complex-vowel-constraints.cc
+hb-ot-shape-fallback.cc
+hb-ot-shape-normalize.cc
+hb-ot-shape.cc
+hb-ot-tag.cc
+hb-ot-var.cc
+hb-set.cc
+hb-shape-plan.cc
+hb-shape.cc
+hb-shaper.cc
+hb-static.cc
+hb-style.cc
+hb-ucd.cc
+hb-unicode.cc
+hb-glib.cc
+hb-ft.cc
+hb-graphite2.cc
+hb-uniscribe.cc
+hb-gdi.cc
+hb-directwrite.cc
+hb-coretext.cc
+'''.split()
 
 
 def needed(settings):
@@ -25,7 +80,7 @@ def get_lib_name(settings):
 
 def get(ports, settings, shared):
   ports.fetch_project('harfbuzz', 'https://github.com/harfbuzz/harfbuzz/releases/download/' +
-                      TAG + '/harfbuzz-' + TAG + '.tar.bz2', 'harfbuzz-' + TAG, sha512hash=HASH)
+                      TAG + '/harfbuzz-' + TAG + '.tar.xz', 'harfbuzz-' + TAG, sha512hash=HASH)
 
   def create(final):
     logging.info('building port: harfbuzz')
@@ -33,41 +88,56 @@ def get(ports, settings, shared):
 
     source_path = os.path.join(ports.get_dir(), 'harfbuzz', 'harfbuzz-' + TAG)
     build_path = os.path.join(ports.get_build_dir(), 'harfbuzz')
-
-    freetype_lib = shared.Cache.get_path(shared.Cache.get_lib_name('libfreetype.a'))
     freetype_include = os.path.join(ports.get_include_dir(), 'freetype2', 'freetype')
-    freetype_include_dirs = freetype_include + ';' + os.path.join(freetype_include, 'config')
+    ports.install_headers(os.path.join(source_path, 'src'), target='harfbuzz')
 
-    cmake_cmd = [
-      shared.EMCMAKE,
-      'cmake',
-      '-B' + build_path,
-      '-H' + source_path,
-      '-DCMAKE_BUILD_TYPE=Release',
-      '-DCMAKE_INSTALL_PREFIX=' + build_path,
-      '-DFREETYPE_INCLUDE_DIRS=' + freetype_include_dirs,
-      '-DFREETYPE_LIBRARY=' + freetype_lib,
-      '-DHB_HAVE_FREETYPE=ON'
-    ]
+    # TODO(sbc): Look into HB_TINY, HB_LEAN, HB_MINI options.  Remove
+    # HAVE_MMAP/HAVE_MPROTECT/HAVE_SYSCONF since we don't really support those?
 
-    extra_cflags = []
+    # These cflags are the ones that the cmake build selects when running emcmake
+    # with harfbuzz
+    cflags = '''
+    -DHAVE_FREETYPE
+    -DHAVE_ATEXIT
+    -DHAVE_FALLBACK
+    -DHAVE_FT_SET_VAR_BLEND_COORDINATES
+    -DHAVE_INTEL_ATOMIC_PRIMITIVES
+    -DHAVE_MMAP
+    -DHAVE_MPROTECT
+    -DHAVE_OT
+    -DHAVE_STRTOD_L
+    -DHAVE_SYSCONF
+    -DHAVE_UCDN
+    -DHAVE_UNIST_H
+    -DHAVE_XLOCALE_H
+    -DHAVE_SYS_MMAN_H
+    -DHAVE_UNISTD_H
+    -fno-rtti
+    -fno-exceptions
+    -O3
+    -DNDEBUG
+    '''.split()
+
+    cflags += ['-I' + freetype_include, '-I' + os.path.join(freetype_include, 'config')]
 
     if settings.RELOCATABLE:
-      extra_cflags.append('-fPIC')
+      cflags.append('-fPIC')
 
     if settings.USE_PTHREADS:
-      extra_cflags.append('-pthread')
+      cflags.append('-pthread')
+      cflags.append('-DHAVE_PTHREAD')
+    else:
+      cflags.append('-DHB_NO_MT')
 
-    if len(extra_cflags):
-      cmake_cmd += ['-DCMAKE_CXX_FLAGS="{}"'.format(' '.join(extra_cflags))]
-      cmake_cmd += ['-DCMAKE_C_FLAGS="{}"'.format(' '.join(extra_cflags))]
-
-    shared.run_process(cmake_cmd, env=system_libs.clean_env())
-    shared.run_process(['cmake', '--build', build_path, '--target', 'install'])
-
-    ports.install_header_dir(os.path.join(build_path, 'include', 'harfbuzz'))
-
-    shutil.copyfile(os.path.join(build_path, 'libharfbuzz.a'), final)
+    commands = []
+    o_s = []
+    for src in srcs:
+      o = os.path.join(build_path, src + '.o')
+      shared.safe_ensure_dirs(os.path.dirname(o))
+      commands.append([shared.EMCC, '-c', os.path.join(source_path, 'src', src), '-o', o] + cflags)
+      o_s.append(o)
+    ports.run_commands(commands)
+    ports.create_lib(final, o_s)
 
   return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 
@@ -81,7 +151,7 @@ def process_dependencies(settings):
 
 
 def process_args(ports):
-  return ['-I' + os.path.join(ports.get_build_dir(), 'harfbuzz', 'include', 'harfbuzz')]
+  return ['-I' + os.path.join(ports.get_include_dir(), 'harfbuzz')]
 
 
 def show():

--- a/tools/ports/zlib.py
+++ b/tools/ports/zlib.py
@@ -35,7 +35,7 @@ def get(ports, settings, shared):
     commands = []
     o_s = []
     for src in srcs:
-      o = os.path.join(ports.get_build_dir(), 'zlib', src + '.o')
+      o = os.path.join(dest_path, src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
       commands.append([shared.EMCC, os.path.join(dest_path, src), '-O2', '-o', o, '-I' + dest_path, '-w', '-c'])
       o_s.append(o)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1774,12 +1774,9 @@ class Ports:
               Ports.clear_project_build(name)
             return
 
-    if url.endswith('.tar.bz2'):
-      fullpath = fullname + '.tar.bz2'
-    elif url.endswith('.tar.gz'):
-      fullpath = fullname + '.tar.gz'
-    else:
-      fullpath = fullname + '.zip'
+    url_filename = url.rsplit('/')[-1]
+    ext = url_filename.split('.', 1)[1]
+    fullpath = fullname + '.' + ext
 
     if name not in Ports.name_cache: # only mention each port once in log
       logger.debug(f'including port: {name}')


### PR DESCRIPTION
Instead just build the source files in the same way we do for other
ports.

I'm not sure how much testing we have for harfbuzz but its used in
sdl2-ttf which does have some tests.

Fixes: #14321