### PR TITLE
Add an option to avoid Node.js support in the file packager

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2520,6 +2520,8 @@ def phase_source_transforms(options, target):
       file_args.append('--lz4')
     if options.use_preload_plugins:
       file_args.append('--use-preload-plugins')
+    if not settings.ENVIRONMENT_MAY_BE_NODE:
+      file_args.append('--no-node')
     file_code = shared.check_call([shared.FILE_PACKAGER, unsuffixed(target) + '.data'] + file_args, stdout=PIPE).stdout
     options.pre_js = js_manipulation.add_files_pre_js(options.pre_js, file_code)
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -719,10 +719,17 @@ If manually bisecting:
     shutil.copyfile(test_file('screenshot.jpg'), 'screenshot.not')
     self.btest('sdl_image_prepare.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'], also_proxied=True, manually_trigger_reftest=True)
 
-  def test_sdl_image_prepare_data(self):
+  @parameterized({
+    '': ([],),
+    # add testing for closure on preloaded files + ENVIRONMENT=web (we must not
+    # emit any node.js code here, see
+    # https://github.com/emscripten-core/emscripten/issues/14486
+    'closure_webonly': (['--closure', '1', '-s', 'ENVIRONMENT=web'],)
+  })
+  def test_sdl_image_prepare_data(self, args):
     # load an image file, get pixel data.
     shutil.copyfile(test_file('screenshot.jpg'), 'screenshot.not')
-    self.btest('sdl_image_prepare_data.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'], manually_trigger_reftest=True)
+    self.btest('sdl_image_prepare_data.c', reference='screenshot.jpg', args=['--preload-file', 'screenshot.not', '-lSDL', '-lGL'] + args, manually_trigger_reftest=True)
 
   def test_sdl_image_must_prepare(self):
     # load an image file, get pixel data.

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -782,7 +782,7 @@ def main():
       function handleError(error) {
         console.error('package error:', error);
       };
-    ''' % { 'node_support_code' : node_support_code }
+    ''' % {'node_support_code': node_support_code}
 
     code += r'''
       function processPackageData(arrayBuffer) {


### PR DESCRIPTION
Another option here might be to add full preprocessor support to the
file packager, but that would be a large change given the different use
cases and current code structure. Specific options is consistent with
the current codebase.

Fixes #14486