### PR TITLE
Avoid excessive console logging in browser tests. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -200,7 +200,7 @@ var LibraryPThread = {
     threadExit: function(exitCode) {
       var tb = _pthread_self();
       if (tb) { // If we haven't yet exited?
-#if ASSERTIONS
+#if PTHREADS_DEBUG
         err('Pthread 0x' + tb.toString(16) + ' exited.');
 #endif
         PThread.runExitHandlersAndDeinitThread(tb, exitCode);

--- a/src/worker.js
+++ b/src/worker.js
@@ -308,7 +308,7 @@ self.onmessage = function(e) {
             Module['PThread'].threadExit(-2);
             throw ex;
           }
-#if ASSERTIONS
+#if PTHREADS_DEBUG
         } else {
           // else e == 'unwind', and we should fall through here and keep the pthread alive for asynchronous events.
           err('Pthread 0x' + Module['_pthread_self']().toString(16) + ' completed its pthread main entry point with an unwind, keeping the pthread worker alive for asynchronous operation.');

--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -28,7 +28,7 @@ void *ThreadMain(void *arg)
 
 #define N 100
 
-	EM_ASM(err('Thread idx '+$0+': sorting ' + $1 + ' numbers with param ' + $2 + '.'), idx, N, param);
+	//EM_ASM(err('Thread idx '+$0+': sorting ' + $1 + ' numbers with param ' + $2 + '.'), idx, N, param);
 
 	unsigned int n[N];
 	for(unsigned int i = 0; i < N; ++i)
@@ -47,11 +47,12 @@ void *ThreadMain(void *arg)
 		}
 	// Ensure all elements are in place.
 	int numGood = 0;
-	for(unsigned int i = 0; i < N; ++i)
+	for(unsigned int i = 0; i < N; ++i) {
 		if (n[i] == i) ++numGood;
 		else EM_ASM(err('n['+$0+']='+$1), i, n[i]);
+	}
 
-	EM_ASM(out('Thread idx ' + $0 + ' with param '+$1+': all done with result '+$2+'.'), idx, param, numGood);
+	//EM_ASM(out('Thread idx ' + $0 + ' with param '+$1+': all done with result '+$2+'.'), idx, param, numGood);
 	pthread_exit((void*)numGood);
 }
 
@@ -84,8 +85,8 @@ int main()
 		CreateThread(i);
 
 	// Join all threads and create more.
-        while (numThreadsToCreate > 0)
-        {
+	while (numThreadsToCreate > 0)
+	{
 		for(int i = 0; i < NUM_THREADS; ++i)
 		{
 			if (thread[i])
@@ -93,7 +94,7 @@ int main()
 				int status;
 				int rc = pthread_join(thread[i], (void**)&status);
 				assert(rc == 0);
-				EM_ASM(err('Main: Joined thread idx ' + $0 + ' (param ' + $1 + ') with status ' + $2), i, global_shared_data[i], (int)status);
+				//EM_ASM(err('Main: Joined thread idx ' + $0 + ' (param ' + $1 + ') with status ' + $2), i, global_shared_data[i], (int)status);
 				assert(status == N);
 				thread[i] = 0;
 				if (numThreadsToCreate > 0)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3924,11 +3924,9 @@ window.close = function() {
   # Test that pthreads are able to do printf.
   @requires_threads
   def test_pthread_printf(self):
-    def run(debug):
-       self.btest(test_file('pthread/test_pthread_printf.cpp'), expected='0', args=['-s', 'INITIAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE', '-s', 'LIBRARY_DEBUG=%d' % debug])
-
-    run(debug=True)
-    run(debug=False)
+    args = ['-s', 'INITIAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE']
+    # args += ['-sLIBRARY_DEBUG']
+    self.btest(test_file('pthread/test_pthread_printf.cpp'), expected='0', args=args)
 
   # Test that pthreads are able to do cout. Failed due to https://bugzilla.mozilla.org/show_bug.cgi?id=1154858.
   @requires_threads
@@ -4427,7 +4425,8 @@ window.close = function() {
   @requires_graphics_hardware
   def test_webgl_offscreen_canvas_in_proxied_pthread(self):
     for asyncify in [0, 1]:
-      cmd = ['-s', 'USE_PTHREADS', '-s', 'OFFSCREENCANVAS_SUPPORT', '-lGL', '-s', 'GL_DEBUG', '-s', 'PROXY_TO_PTHREAD']
+      cmd = ['-s', 'USE_PTHREADS', '-s', 'OFFSCREENCANVAS_SUPPORT', '-lGL', '-s', 'PROXY_TO_PTHREAD']
+      # cmd += ['-sGL_DEBUG']
       if asyncify:
         # given the synchronous render loop here, asyncify is needed to see intermediate frames and
         # the gradual color change
@@ -4442,7 +4441,8 @@ window.close = function() {
     for args1 in [[], ['-s', 'PROXY_TO_PTHREAD']]:
       for args2 in [[], ['-DTEST_SYNC_BLOCKING_LOOP=1']]:
         for args3 in [[], ['-s', 'OFFSCREENCANVAS_SUPPORT', '-s', 'OFFSCREEN_FRAMEBUFFER']]:
-          cmd = args1 + args2 + args3 + ['-s', 'USE_PTHREADS', '-lGL', '-s', 'GL_DEBUG']
+          cmd = args1 + args2 + args3 + ['-s', 'USE_PTHREADS', '-lGL']
+          # cmd += ['-sGL_DEBUG']
           print(str(cmd))
           self.btest('resize_offscreencanvas_from_main_thread.cpp', expected='1', args=cmd)
 
@@ -4669,7 +4669,8 @@ window.close = function() {
       ['-DTEST_EXPLICIT_CONTEXT_SWAP=1',    '-s', 'PROXY_TO_PTHREAD', '-s', 'USE_PTHREADS', '-s',   'OFFSCREEN_FRAMEBUFFER=1', '-DTEST_MANUALLY_SET_ELEMENT_CSS_SIZE=1'],
       ['-DTEST_EMSCRIPTEN_SET_MAIN_LOOP=1', '-s', 'OFFSCREENCANVAS_SUPPORT'],
     ]:
-      cmd = ['-lGL', '-O3', '-g2', '--shell-file', test_file('canvas_animate_resize_shell.html'), '-s', 'GL_DEBUG', '--threadprofiler'] + args
+      cmd = ['-lGL', '-O3', '-g2', '--shell-file', test_file('canvas_animate_resize_shell.html'), '--threadprofiler'] + args
+      # cmd += ['-sGL_DEBUG']
       print(' '.join(cmd))
       self.btest_exit('canvas_animate_resize.cpp', args=cmd)
 


### PR DESCRIPTION
This was resulting a lot of noise in console logs which get
recorded by CI which meant circle CI was always saying:

```
Your output is too large to display in the browser.

Only the last 400000 characters are displayed.
```