### PR TITLE
Don't ignore munmap of unknown addresses

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -276,12 +276,11 @@ var SyscallsLibrary = {
 #if CAN_ADDRESS_2GB
     addr >>>= 0;
 #endif
-    if ((addr | 0) === {{{ cDefine('MAP_FAILED') }}} || len === 0) {
-      return -{{{ cDefine('EINVAL') }}};
-    }
     // TODO: support unmmap'ing parts of allocations
     var info = SYSCALLS.mappings[addr];
-    if (!info) return 0;
+    if (len === 0 || !info) {
+      return -{{{ cDefine('EINVAL') }}};
+    }
     if (len === info.len) {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
       var stream = FS.getStream(info.fd);

--- a/tests/other/test_mmap_and_munmap.cpp
+++ b/tests/other/test_mmap_and_munmap.cpp
@@ -190,7 +190,7 @@ int test_unmap_wrong_addr() {
     TEST_START();
     errno = 0;
 
-    ASSERT(munmap(MAP_FAILED, file_len()) == -1 && errno == EINVAL,
+    ASSERT(munmap((void*)0xdeadbeef, file_len()) == -1 && errno == EINVAL,
            "Expected EINVAL, as munmap should fail for wrong addr argument");
     TEST_PASS();
 }


### PR DESCRIPTION
Returning zero here could cause the program to think it
had successfully deallocated the underlying memory.

See #14504