### PR TITLE
Make llvm version check into an error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 2.0.25
 ------
+- Attempting to use emscripten with an incompatible version of llvm will now
+  result in a hard error.  We make use linker flags that don't exist in
+  llvm 12 so its really not possible to use older versions without patching.
 - A new setting called `ALLOW_UNIMPLEMENTED_SYSCALLS` was added.  This setting
   is enabled by default but, if disabled, will generate link-time errors if
   a program references an unimplemented syscall.  This setting is disabled

--- a/tests/test_sanity.py
+++ b/tests/test_sanity.py
@@ -234,14 +234,14 @@ class sanity(RunnerCore):
           try_delete(default_config)
 
   def test_llvm(self):
-    LLVM_WARNING = 'LLVM version for clang executable'
+    LLVM_ERROR = 'incompatible LLVM version'
 
     restore_and_set_up()
 
     # Clang should report the version number we expect, and emcc should not warn
-    assert shared.check_llvm_version()
+    shared.check_llvm_version()
     output = self.check_working(EMCC)
-    self.assertNotContained(LLVM_WARNING, output)
+    self.assertNotContained(LLVM_ERROR, output)
 
     # Fake a different llvm version
     restore_and_set_up()
@@ -265,10 +265,10 @@ class sanity(RunnerCore):
         make_fake_tool(self.in_dir('fake', 'llvm-nm'), '%s.%s' % (expected_x, expected_y))
         did_modify = inc_x != 0 or inc_y != 0
         if did_modify:
-          output = self.check_working(EMCC, LLVM_WARNING)
+          output = self.check_working(EMCC, LLVM_ERROR)
         else:
           output = self.check_working(EMCC)
-          self.assertNotContained(LLVM_WARNING, output)
+          self.assertNotContained(LLVM_ERROR, output)
 
   def test_emscripten_root(self):
     # The correct path

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -270,10 +270,8 @@ def get_clang_version():
 
 def check_llvm_version():
   actual = get_clang_version()
-  if EXPECTED_LLVM_VERSION in actual:
-    return True
-  diagnostics.warning('version-check', 'LLVM version for clang executable "%s" appears incorrect (seeing "%s", expected "%s")', CLANG_CC, actual, EXPECTED_LLVM_VERSION)
-  return False
+  if EXPECTED_LLVM_VERSION not in actual:
+    exit_with_error(f'incompatible LLVM version. "{CLANG_CC}" reports version "{actual}" but emscripten requires "{EXPECTED_LLVM_VERSION}"')
 
 
 def get_llc_targets():


### PR DESCRIPTION
Using emscripten with the wrong llvm version is not possible and we
should be clear about that.  The fact that it has historically just
been a warning has led to folks trying to use mismatched versions and
reporting bugs about it.

Trying to make emscripten work with an incompatible version of llvm will
most likely require a patch and so a modified expected version can be
part of any such patch.