### PR TITLE
Always merge main module symbols

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -967,11 +967,13 @@ function createWasm() {
 
     Module['asm'] = exports;
 
-#if MAIN_MODULE && AUTOLOAD_DYLIBS
+#if MAIN_MODULE
+#if AUTOLOAD_DYLIBS
     var metadata = getDylinkMetadata(module);
     if (metadata.neededDynlibs) {
       dynamicLibraries = metadata.neededDynlibs.concat(dynamicLibraries);
     }
+#endif
     mergeLibSymbols(exports, 'main')
 #endif
 


### PR DESCRIPTION
This is a followup to #13949 which added the `#if` but
didn't get the conditions quite right.