### PR TITLE
base64_encode embedded data files

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -572,3 +572,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * Camillo Lugaresi <camillol@google.com> (copyright owned by Google LLC)
 * Chris Craig <emscripten@goldwave.com>
 * Le Yao <le.yao@intel.com> (copyright owned by Intel Corporation)
+* José Cadete <crudelios@gmail.com>

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -398,7 +398,7 @@ function JSify(functionsOnly) {
       print(preprocess(read('arrayUtils.js')));
     }
 
-    if (SUPPORT_BASE64_EMBEDDING && !MINIMAL_RUNTIME) {
+    if ((SUPPORT_BASE64_EMBEDDING || FORCE_FILESYSTEM) && !MINIMAL_RUNTIME) {
       print(preprocess(read('base64Utils.js')));
     }
 

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -57,6 +57,7 @@ Notes:
     subdir\file, in JS it will be subdir/file. For simplicity we treat the web platform as a *NIX.
 """
 
+import base64
 import os
 import sys
 import shutil
@@ -94,6 +95,9 @@ AV_WORKAROUND = 0
 excluded_patterns = []
 new_data_files = []
 
+def base64_encode(b):
+  b64 = base64.b64encode(b)
+  return b64.decode('ascii')
 
 def has_hidden_attribute(filepath):
   """Win32 code to test whether the given file has the hidden property set."""
@@ -464,18 +468,9 @@ def main():
     basename = os.path.basename(filename)
     if file_['mode'] == 'embed':
       # Embed
-      data = list(bytearray(utils.read_binary(file_['srcpath'])))
-      code += '''var fileData%d = [];\n''' % counter
-      if data:
-        parts = []
-        chunk_size = 10240
-        start = 0
-        while start < len(data):
-          parts.append('''fileData%d.push.apply(fileData%d, %s);\n'''
-                       % (counter, counter, str(data[start:start + chunk_size])))
-          start += chunk_size
-        code += ''.join(parts)
-      code += ('''Module['FS_createDataFile']('%s', '%s', fileData%d, true, true, false);\n'''
+      data = base64_encode(utils.read_binary(file_['srcpath']))
+      code += '''var fileData%d = '%s';\n''' % (counter, data)
+      code += ('''Module['FS_createDataFile']('%s', '%s', decodeBase64(fileData%d), true, true, false);\n'''
                % (dirname, basename, counter))
       counter += 1
     elif file_['mode'] == 'preload':

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -95,9 +95,11 @@ AV_WORKAROUND = 0
 excluded_patterns = []
 new_data_files = []
 
+
 def base64_encode(b):
   b64 = base64.b64encode(b)
   return b64.decode('ascii')
+
 
 def has_hidden_attribute(filepath):
   """Win32 code to test whether the given file has the hidden property set."""


### PR DESCRIPTION
When `file_packager --embed` (or `emcc --embed-file`) is used, this change reduces the embedded data size by about 75%.

It also plays nicer with the acorn optimizer, making it use less RAM when there is embedded data.

Do note that, as reported in #14482, the acorn optimizer still uses a lot of RAM, which possibly can be improved (that is way beyond my knowledge of this project). However, since the final html is now much smaller, less RAM is used by the optimizer as well.