### PR TITLE
Limit LIBRARY_DEBUG to functions that can be exported to C/C++

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -97,13 +97,13 @@ function JSify(functionsOnly) {
     // It is possible that when printing the function as a string on Windows, the js interpreter we are in returns the string with Windows
     // line endings \r\n. This is undesirable, since line endings are managed in the form \n in the output for binary file writes, so
     // make sure the endings are uniform.
-    snippet = snippet.toString().replace(/\r\n/gm,"\n");
+    snippet = snippet.toString().replace(/\r\n/gm,'\n');
 
     // name the function; overwrite if it's already named
     snippet = snippet.replace(/function(?:\s+([^(]+))?\s*\(/, 'function ' + finalName + '(');
 
     // apply LIBRARY_DEBUG if relevant
-    if (LIBRARY_DEBUG) {
+    if (LIBRARY_DEBUG && !isJsOnlyIdentifier(ident)) {
       snippet = modifyFunction(snippet, (name, args, body) => {
         return 'function ' + name + '(' + args + ') {\n' +
                'var ret = (function() { if (runtimeDebug) err("[library call:' + finalName + ': " + Array.prototype.slice.call(arguments).map(prettyPrint) + "]");\n' +


### PR DESCRIPTION
I think the intent with this macro was that it was designed to trace at
the native/JS boundary.  As it stands, it traces all JS library functions
including those that take arbitrary JS objects as arguments.  This causes
`prettyPrint` to crash when trying to print those arguments.  For
example enabling `LIBRARY_DEBUG` with `MAIN_MODULE` will currently cause
the call to `$relocateExports` to crash trying to print the `exports` object
(which is an object with a null prototype and therefor without a
`toSrring()` method).