### PR TITLE
Cache wasmTable.get()

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2002,9 +2002,11 @@ def phase_linker_setup(options, state, newargs, settings_map):
     settings.MINIFY_WASM_IMPORTS_AND_EXPORTS = 1
     settings.MINIFY_WASM_IMPORTED_MODULES = 1
 
-  # Cache the wasm table for speed in builds not optimizing for size.
+  # Cache the wasm table for speed in builds not optimizing for size. We also
+  # cannot cache when using dynamic linking.
   settings.CACHE_WASM_TABLE = settings.OPT_LEVEL >= 2 and \
-                              settings.SHRINK_LEVEL == 0
+                              settings.SHRINK_LEVEL == 0 and \
+                              not settings.RELOCATABLE
 
   if settings.MINIMAL_RUNTIME:
     # Minimal runtime uses a different default shell file

--- a/emcc.py
+++ b/emcc.py
@@ -2004,9 +2004,8 @@ def phase_linker_setup(options, state, newargs, settings_map):
 
   # Cache the wasm table for speed in builds not optimizing for size. We also
   # cannot cache when using dynamic linking.
-  settings.CACHE_WASM_TABLE = settings.OPT_LEVEL >= 2 and \
-                              settings.SHRINK_LEVEL == 0 and \
-                              not settings.RELOCATABLE
+  settings.CACHE_WASM_TABLE = not settings.RELOCATABLE and \
+      settings.OPT_LEVEL >= 2 and settings.SHRINK_LEVEL == 0
 
   if settings.MINIMAL_RUNTIME:
     # Minimal runtime uses a different default shell file

--- a/emcc.py
+++ b/emcc.py
@@ -2002,6 +2002,10 @@ def phase_linker_setup(options, state, newargs, settings_map):
     settings.MINIFY_WASM_IMPORTS_AND_EXPORTS = 1
     settings.MINIFY_WASM_IMPORTED_MODULES = 1
 
+  # Cache the wasm table for speed in builds not optimizing for size.
+  settings.CACHE_WASM_TABLE = settings.OPT_LEVEL >= 2 and \
+                              settings.SHRINK_LEVEL == 0
+
   if settings.MINIMAL_RUNTIME:
     # Minimal runtime uses a different default shell file
     if options.shell_path == shared.path_from_root('src', 'shell.html'):

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -203,6 +203,7 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
 #if ASSERTIONS
   assert(wasmTable);
 #endif
+#include "runtime_cache_table.js"
 
 #if !IMPORTED_MEMORY
   wasmMemory = asm['memory'];

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -997,6 +997,7 @@ function createWasm() {
 #if ASSERTIONS && !PURE_WASI
     assert(wasmTable, "table not found in wasm exports");
 #endif
+#include "runtime_cache_table.js"
 #endif
 
 #if hasExportedFunction('___wasm_call_ctors')

--- a/src/runtime_cache_table.js
+++ b/src/runtime_cache_table.js
@@ -1,4 +1,9 @@
 #if CACHE_WASM_TABLE
+// Wrap the wasm table with a cache, to avoid repeatedly calling table.get().
+// That operation is fairly heavyweight in VMs.
+// N.B.: This cache assumes that the wasm does not modify the table, which is
+//       not necessarily true in relocatable builds (a side module segment may
+//       add items), or if we some day use wasm table operations in wasm.
 var originalWasmTable = wasmTable;
 wasmTable = {
   _cache: [],
@@ -22,7 +27,7 @@ wasmTable = {
   },
   grow: function(by) {
     var ret = originalWasmTable.grow(by);
-    length = wasmTable.length;
+    wasmTable.length = originalWasmTable.length;
     return ret;
   }
 };

--- a/src/runtime_cache_table.js
+++ b/src/runtime_cache_table.js
@@ -1,0 +1,29 @@
+#if CACHE_WASM_TABLE
+var originalWasmTable = wasmTable;
+wasmTable = {
+  _cache: [],
+  length: wasmTable.length,
+  get: function(i) {
+    if (i >= wasmTable._cache.length) {
+      wasmTable._cache.length = i;
+    }
+    var existing = wasmTable._cache[i];
+    if (existing) {
+      return existing;
+    }
+    return wasmTable._cache[i] = originalWasmTable.get(i);
+  },
+  set: function(i, func) {
+    if (i >= wasmTable._cache.length) {
+      wasmTable._cache.length = i;
+    }
+    wasmTable._cache[i] = func;
+    return originalWasmTable.set(i, func);
+  },
+  grow: function(by) {
+    var ret = originalWasmTable.grow(by);
+    length = wasmTable.length;
+    return ret;
+  }
+};
+#endif

--- a/src/runtime_init_table.js
+++ b/src/runtime_init_table.js
@@ -7,6 +7,9 @@ var wasmTable = new WebAssembly.Table({
 #endif
   'element': 'anyfunc'
 });
+
+#include "runtime_cache_table.js"
+
 #else
 // In regular non-RELOCATABLE mode the table is exported
 // from the wasm module and this will be assigned once

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -213,3 +213,7 @@ var HAS_MAIN = 0;
 
 // Set to true if we are linking as C++ and including C++ stdlibs
 var LINK_AS_CXX = 0;
+
+// Set when we optimize wasmTable accesses by wrapping the raw WebAssembly.Table
+// with a cache.
+var CACHE_WASM_TABLE = 0;

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4297,7 +4297,7 @@ window.close = function() {
     size = os.path.getsize('test.js')
     print('size:', size)
     # Note that this size includes test harness additions (for reporting the result, etc.).
-    self.assertLess(abs(size - 5368), 100)
+    self.assertLess(abs(size - 5643), 100)
 
   # Tests that it is possible to initialize and render WebGL content in a pthread by using OffscreenCanvas.
   # -DTEST_CHAINED_WEBGL_CONTEXT_PASSING: Tests that it is possible to transfer WebGL canvas in a chain from main thread -> thread 1 -> thread 2 and then init and render WebGL content there.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9251,7 +9251,7 @@ int main(void) {
     # Changing this option to [] should decrease code size.
     self.assertLess(changed, normal)
     # Check an absolute code size as well, with some slack.
-    self.assertLess(abs(changed - 5872), 150)
+    self.assertLess(abs(changed - 6075), 150)
 
   def test_llvm_includes(self):
     create_file('atomics.c', '#include <stdatomic.h>')


### PR DESCRIPTION
This is an alternative to https://github.com/emscripten-core/emscripten/pull/13844, and is aimed at fixing the performance issues in
https://github.com/emscripten-core/emscripten/issues/12733 and https://github.com/emscripten-core/emscripten/issues/13796 I spent some time on this now as @juj may not be available
to work on that PR for a while.

This wraps around our `wasmTable` instance with a simple cache of values. It
lets us avoid calling `wasmTable.get` on the same index more than once. This
depends on the table only being modified from JS, which is true for now at least
in non-relocatable mode.

This enables the caching in optimized builds not focused on size. But it does
make them larger, so perhaps this should not be on by default - thoughts?

Testing locally, this makes the benchmark from #12733 4x faster as expected.
@jpharvey perhaps you can verify if this helps your case as well?
