### PR TITLE
Remove unneeded makedev/major/minor functions from JS library

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1494,26 +1494,6 @@ LibraryManager.library = {
   },
 
   // ==========================================================================
-  // sys/types.h
-  // ==========================================================================
-  // http://www.kernel.org/doc/man-pages/online/pages/man3/minor.3.html
-  makedev__sig: 'iii',
-  makedev: function(maj, min) {
-    return ((maj) << 8 | (min));
-  },
-  gnu_dev_makedev: 'makedev',
-  major__sig: 'ii',
-  major: function(dev) {
-    return ((dev) >> 8);
-  },
-  gnu_dev_major: 'major',
-  minor__sig: 'ii',
-  minor: function(dev) {
-    return ((dev) & 0xff);
-  },
-  gnu_dev_minor: 'minor',
-
-  // ==========================================================================
   // setjmp.h
   // ==========================================================================
 


### PR DESCRIPTION
These are not functions but macros, implemented in `sys/sysmacros.h`.