### PR TITLE
Check for expected failures in test_posixtest.py

### DIFF
--- a/tests/parallel_testsuite.py
+++ b/tests/parallel_testsuite.py
@@ -138,6 +138,16 @@ class BufferedParallelTestResult():
       print(test, '... ok (%.2fs)' % (time.perf_counter() - self.start_time), file=sys.stderr)
     self.buffered_result = BufferedTestSuccess(test)
 
+  def addExpectedFailure(self, test, err):
+    if hasattr(time, 'perf_counter'):
+      print(test, '... expected failure (%.2fs)' % (time.perf_counter() - self.start_time), file=sys.stderr)
+    self.buffered_result = BufferedTestExpectedFailure(test, err)
+
+  def addUnexpectedSuccess(self, test):
+    if hasattr(time, 'perf_counter'):
+      print(test, '... unexpected success (%.2fs)' % (time.perf_counter() - self.start_time), file=sys.stderr)
+    self.buffered_result = BufferedTestUnexpectedSuccess(test)
+
   def addSkip(self, test, reason):
     print(test, "... skipped '%s'" % reason, file=sys.stderr)
     self.buffered_result = BufferedTestSkip(test, reason)
@@ -182,9 +192,19 @@ class BufferedTestFailure(BufferedTestBase):
     result.addFailure(self.test, self.error)
 
 
+class BufferedTestExpectedFailure(BufferedTestBase):
+  def updateResult(self, result):
+    result.addExpectedFailure(self.test, self.error)
+
+
 class BufferedTestError(BufferedTestBase):
   def updateResult(self, result):
     result.addError(self.test, self.error)
+
+
+class BufferedTestUnexpectedSuccess(BufferedTestBase):
+  def updateResult(self, result):
+    result.addUnexpectedSuccess(self.test)
 
 
 class FakeTraceback():

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -284,7 +284,7 @@ def run_tests(options, suites):
     res = testRunner.run(suite)
     msg = ('%s: %s run, %s errors, %s failures, %s skipped' %
            (mod_name, res.testsRun, len(res.errors), len(res.failures), len(res.skipped)))
-    num_failures += len(res.errors) + len(res.failures)
+    num_failures += len(res.errors) + len(res.failures) + len(res.unexpectedSuccesses)
     resultMessages.append(msg)
 
   if len(resultMessages) > 1:
@@ -294,8 +294,7 @@ def run_tests(options, suites):
     for msg in resultMessages:
       print('    ' + msg)
 
-  # Return the number of failures as the process exit code for automating success/failure reporting.
-  return min(num_failures, 255)
+  return num_failures
 
 
 def parse_args(args):
@@ -371,7 +370,11 @@ def main(args):
     print('ERROR: could not find the following tests: ' + ' '.join(unmatched_tests))
     return 1
 
-  return run_tests(options, suites)
+  num_failures = run_tests(options, suites)
+  # Return the number of failures as the process exit code
+  # for automating success/failure reporting.  Return codes
+  # over 125 are not well supported on UNIX.
+  return min(num_failures, 125)
 
 
 if __name__ == '__main__':

--- a/tests/test_posixtest.py
+++ b/tests/test_posixtest.py
@@ -11,6 +11,7 @@ See
 
 import glob
 import os
+import unittest
 
 from common import RunnerCore, path_from_root, node_pthreads
 import test_posixtest_browser
@@ -29,7 +30,6 @@ class posixtest(RunnerCore):
 def filter_tests(all_tests):
   pthread_tests = [t for t in all_tests if t.startswith('pthread_')]
   # filter out some tests we don't support
-  pthread_tests = [t for t in pthread_tests if not t.startswith('pthread_atfork')]
   pthread_tests = [t for t in pthread_tests if not t.startswith('pthread_sigmask')]
   return pthread_tests
 
@@ -48,13 +48,29 @@ def get_pthread_tests():
 
 # Mark certain tests as unsupported
 # TODO: Investigate failing semaphores tests.
-unsupported = {
+unsupported_noreturn = {
   'test_pthread_atfork_1_1': 'fork() and multiple processes are not supported',
   'test_pthread_atfork_1_2': 'fork() and multiple processes are not supported',
   'test_pthread_atfork_2_1': 'fork() and multiple processes are not supported',
   'test_pthread_atfork_2_2': 'fork() and multiple processes are not supported',
   'test_pthread_atfork_3_2': 'fork() and multiple processes are not supported',
   'test_pthread_atfork_4_1': 'fork() and multiple processes are not supported',
+  'test_pthread_kill_1_1': 'signals are not supported',
+  'test_pthread_create_1_5': 'semaphores are not supported',
+  'test_pthread_exit_6_1': 'lacking necessary mmap() support',
+  'test_pthread_spin_lock_1_1': 'signals are not supported',
+  'test_pthread_mutex_lock_5_1': 'signals are not supported',
+  'test_pthread_mutexattr_settype_2_1': 'interrupting pthread_mutex_lock wait via SIGALRM is not supported',
+  'test_pthread_spin_lock_3_1': 'signals are not supported',
+  'test_pthread_mutex_lock_3_1': 'signals are not supported',
+  'test_pthread_create_14_1': 'signals are not supported',
+  'test_pthread_detach_4_3': 'signals are not supported',
+  'test_pthread_join_6_3': 'signals are not supported',
+  'test_pthread_cond_init_4_2': 'signals are not supported',
+  'test_pthread_barrier_wait_3_2': 'signals are not supported',
+}
+
+unsupported = {
   'test_pthread_attr_setinheritsched_2_3': 'scheduling policy/parameters are not supported',
   'test_pthread_attr_setinheritsched_2_4': 'scheduling policy/parameters are not supported',
   'test_pthread_attr_setschedparam_1_3': 'scheduling policy/parameters are not supported',
@@ -62,58 +78,34 @@ unsupported = {
   'test_pthread_attr_setschedpolicy_4_1': 'scheduling policy/parameters are not supported',
   'test_pthread_barrierattr_getpshared_2_1': 'shm_open and shm_unlink are not supported',
   'test_pthread_barrier_wait_3_1': 'signals are not supported',
-  'test_pthread_barrier_wait_3_2': 'signals are not supported',
-  'test_pthread_cancel_5_2': 'signals are not supported',
   'test_pthread_cond_broadcast_1_2': 'lacking necessary mmap() support',
   'test_pthread_cond_broadcast_2_3': 'lacking necessary mmap() support',
-  'test_pthread_cond_broadcast_4_2': 'signals are not supported',
   'test_pthread_cond_destroy_2_1': 'lacking necessary mmap() support',
   'test_pthread_cond_init_1_2': 'clock_settime() is not supported',
   'test_pthread_cond_init_1_3': 'lacking necessary mmap() support',
   'test_pthread_cond_init_2_2': 'clock_settime() is not supported',
   'test_pthread_cond_init_4_1': 'fork() and multiple processes are not supported',
-  'test_pthread_cond_init_4_2': 'signals are not supported',
   'test_pthread_cond_signal_1_2': 'lacking necessary mmap() support',
-  'test_pthread_cond_signal_4_2': 'signals are not supported',
   'test_pthread_cond_timedwait_2_4': 'lacking necessary mmap() support',
   'test_pthread_cond_timedwait_2_7': 'lacking necessary mmap() support',
   'test_pthread_cond_timedwait_4_2': 'lacking necessary mmap() support',
   'test_pthread_cond_wait_2_2': 'lacking necessary mmap() support',
-  'test_pthread_cond_wait_4_1': 'fork() and multiple processes are not supported',
-  'test_pthread_create_1_5': 'semaphores are not supported',
-  'test_pthread_create_1_6': 'semaphores are not supported',
   'test_pthread_create_8_1': 'signals are not supported',
   'test_pthread_create_8_2': 'signals are not supported',
   'test_pthread_create_10_1': 'signals are not supported',
-  'test_pthread_create_14_1': 'signals are not supported',
-  'test_pthread_create_15_1': 'signals are not supported',
-  'test_pthread_detach_4_3': 'signals are not supported',
-  'test_pthread_equal_2_1': 'signals are not supported',
-  'test_pthread_exit_6_1': 'lacking necessary mmap() support',
-  'test_pthread_exit_6_2': 'semaphores are not supported',
   'test_pthread_getschedparam_1_3': 'scheduling policy/parameters are not supported',
-  'test_pthread_getschedparam_4_1': 'signals are not supported',
-  'test_pthread_join_6_3': 'signals are not supported',
-  'test_pthread_kill_1_1': 'signals are not supported',
   'test_pthread_kill_1_2': 'signals are not supported',
-  'test_pthread_kill_8_1': 'signals are not supported',
   'test_pthread_mutexattr_getprioceiling_1_2': 'pthread_mutexattr_setprioceiling is not supported',
   'test_pthread_mutexattr_getprotocol_1_2': 'pthread_mutexattr_setprotocol is not supported',
   'test_pthread_mutexattr_setprioceiling_1_1': 'pthread_mutexattr_setprioceiling is not supported',
   'test_pthread_mutexattr_setprioceiling_3_1': 'pthread_mutexattr_setprioceiling is not supported',
   'test_pthread_mutexattr_setprioceiling_3_2': 'pthread_mutexattr_setprioceiling is not supported',
   'test_pthread_mutexattr_setprotocol_1_1': 'setting pthread_mutexattr_setprotocol to a nonzero value is not supported',
-  'test_pthread_mutexattr_settype_2_1': 'interrupting pthread_mutex_lock wait via SIGALRM is not supported',
   'test_pthread_mutex_getprioceiling_1_1': 'pthread_mutex_getprioceiling is not supported',
-  'test_pthread_mutex_init_1_2': 'signals are not supported',
   'test_pthread_mutex_init_5_1': 'fork() and multiple processes are not supported',
-  'test_pthread_mutex_lock_3_1': 'signals are not supported',
-  'test_pthread_mutex_lock_5_1': 'signals are not supported',
   'test_pthread_mutex_trylock_1_2': 'lacking necessary mmap() support',
   'test_pthread_mutex_trylock_2_1': 'lacking necessary mmap() support',
   'test_pthread_mutex_trylock_4_2': 'lacking necessary mmap() support',
-  'test_pthread_mutex_trylock_4_3': 'signals are not supported',
-  'test_pthread_once_6_1': 'signals are not supported',
   'test_pthread_rwlockattr_getpshared_2_1': 'shm_open and shm_unlink are not supported',
   'test_pthread_rwlock_rdlock_2_1': 'thread priorities not supported, cannot test rwlocking in priority order',
   'test_pthread_rwlock_rdlock_2_2': 'thread priorities not supported, cannot test rwlocking in priority order',
@@ -122,13 +114,9 @@ unsupported = {
   'test_pthread_rwlock_timedrdlock_6_2': 'signals are not supported',
   'test_pthread_rwlock_timedwrlock_6_1': 'signals are not supported',
   'test_pthread_rwlock_timedwrlock_6_2': 'signals are not supported',
-  'test_pthread_rwlock_unlock_3_1': 'thread priorities not supported, cannot test rwlocking in priority order',
   'test_pthread_rwlock_wrlock_2_1': 'signals are not supported',
-  'test_pthread_setschedparam_5_1': 'signals are not supported',
   'test_pthread_spin_init_2_1': 'shm_open and shm_unlink are not supported',
   'test_pthread_spin_init_2_2': 'shm_open and shm_unlink are not supported',
-  'test_pthread_spin_lock_1_1': 'signals are not supported',
-  'test_pthread_spin_lock_3_1': 'signals are not supported',
 }
 
 # Mark certain tests as flaky, which may sometimes fail.
@@ -136,12 +124,19 @@ unsupported = {
 flaky = {
   'test_pthread_cond_signal_1_1': 'flaky: https://github.com/emscripten-core/emscripten/issues/13283',
   'test_pthread_barrier_wait_2_1': 'flaky: https://github.com/emscripten-core/emscripten/issues/14508',
+  'test_pthread_rwlock_unlock_3_1': 'Test fail: writer did not get write lock, when main release the lock',
 }
 
-# Mark certain tests as not passing
+# Mark certain tests as disabled.  These are tests that are either flaky or never return.
 disabled = {
-  **unsupported,
   **flaky,
+  **unsupported_noreturn,
+}
+
+# These tests are known to fail reliably.  We run them anyway so that we can
+# detect fixes overtime.
+expect_fail = {
+  **unsupported,
   'test_pthread_attr_setscope_5_1': 'internally skipped (PTS_UNTESTED)',
 }
 
@@ -164,6 +159,9 @@ def make_test(name, testfile, browser):
       self.btest_exit(testfile, args=args)
     else:
       self.do_runf(testfile, emcc_args=args)
+
+  if name in expect_fail:
+    f = unittest.expectedFailure(f)
 
   return f
 


### PR DESCRIPTION
For most failing test we can run tests to verify that they fail which
also means that if they get fixed it will be picked up by CI, keeping
the list of known failure accurate.