### PR TITLE
tests: Fix get_library for native builds / test_benchmark.py

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1564,8 +1564,8 @@ def build_library(name,
                   build_dir,
                   output_dir,
                   generated_libs,
-                  configure=['sh', './configure'],
-                  make=['make'],
+                  configure,
+                  make,
                   make_args=[],
                   cache=None,
                   cache_name=None,
@@ -1596,11 +1596,18 @@ def build_library(name,
     env = os.environ.copy()
   env.update(env_init)
 
-  if configure:
-    if configure[0] == 'cmake':
-      configure = [EMCMAKE] + configure
+  if not native:
+    # Inject emcmake, emconfigure or emmake accordingly, but only if we are
+    # cross compiling.
+    if configure:
+      if configure[0] == 'cmake':
+        configure = [EMCMAKE] + configure
+      else:
+        configure = [EMCONFIGURE] + configure
     else:
-      configure = [EMCONFIGURE] + configure
+      make = [EMMAKE] + make
+
+  if configure:
     try:
       with open(os.path.join(project_dir, 'configure_out'), 'w') as out:
         with open(os.path.join(project_dir, 'configure_err'), 'w') as err:

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -385,7 +385,7 @@ if config.SPIDERMONKEY_ENGINE and config.SPIDERMONKEY_ENGINE in config.JS_ENGINE
 
 if config.NODE_JS and config.NODE_JS in config.JS_ENGINES:
   benchmarkers += [
-    # EmscriptenBenchmarker('Node.js', shared.NODE_JS),
+    # EmscriptenBenchmarker('Node.js', config.NODE_JS),
   ]
 
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from urllib.request import urlopen
 
 from common import BrowserCore, RunnerCore, path_from_root, has_browser, EMTEST_BROWSER, Reporting
-from common import create_file, parameterized, ensure_dir, disabled, test_file, WEBIDL_BINDER, EMMAKE
+from common import create_file, parameterized, ensure_dir, disabled, test_file, WEBIDL_BINDER
 from common import read_file, require_v8
 from tools import shared
 from tools import system_libs
@@ -1759,7 +1759,7 @@ keydown(100);keyup(100); // trigger the end
       Path('Chapter_9/TextureWrap', 'CH09_TextureWrap.o'),
       Path('Chapter_10/MultiTexture', 'CH10_MultiTexture.o'),
       Path('Chapter_13/ParticleSystem', 'CH13_ParticleSystem.o'),
-    ], configure=None, make=[EMMAKE, 'make'])
+    ], configure=None)
 
     def book_path(*pathelems):
       return test_file('glbook', *pathelems)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -28,7 +28,7 @@ from common import RunnerCore, path_from_root, requires_native_clang, test_file
 from common import skip_if, needs_dylink, no_windows, is_slow_test, create_file, parameterized
 from common import env_modify, with_env_modify, disabled, node_pthreads
 from common import read_file, read_binary, require_node, require_v8
-from common import NON_ZERO, WEBIDL_BINDER, EMBUILDER, EMMAKE
+from common import NON_ZERO, WEBIDL_BINDER, EMBUILDER
 import clang_native
 
 # decorators for limiting which modes a test can run in
@@ -464,7 +464,7 @@ class TestCoreBase(RunnerCore):
   def test_cube2hash(self):
     # A good test of i64 math
     self.do_run('// empty file', 'Usage: hashstring <seed>',
-                libraries=self.get_library('third_party/cube2hash', ['libcube2hash.a'], configure=None, make=[EMMAKE, 'make']),
+                libraries=self.get_library('third_party/cube2hash', ['libcube2hash.a'], configure=None),
                 includes=[test_file('third_party/cube2hash')], assert_returncode=NON_ZERO)
 
     for text, output in [('fleefl', '892BDB6FD3F62E863D63DA55851700FDE3ACF30204798CE9'),
@@ -5959,7 +5959,7 @@ void* operator new(size_t size) {
   def test_lua(self):
     self.emcc_args.remove('-Werror')
 
-    libs = self.get_library('third_party/lua', [Path('src/lua.o'), Path('src/liblua.a')], make=[EMMAKE, 'make', 'generic'], configure=None)
+    libs = self.get_library('third_party/lua', [Path('src/lua.o'), Path('src/liblua.a')], make=['make', 'generic'], configure=None)
     self.do_run('',
                 'hello lua world!\n17\n1\n2\n3\n4\n7',
                 args=['-e', '''print("hello lua world!");print(17);for x = 1,4 do print(x) end;print(10-3)'''],


### PR DESCRIPTION
We now inject emcmake, emconfigure, emmake automatically at
the start of the command line when doing an emscripten build
but not when doing a native build.

Tested with benchmark.test_zzz_box2d.