### PR TITLE
Make alignMemory into a library function

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ jobs:
     steps:
       - run-tests:
           # also add a few asan tests
-          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread*"
+          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime"
   test-wasm3:
     executor: bionic
     steps:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 2.0.26
 ------
+- The `alignMemory` function is now a library function and therefore not
+  included by default.  Debug builds will automatically abort if you try
+  to use this function without including it.  The normal library `__deps`
+  mechanism can be used to include it, or can be added to
+  `DEFAULT_LIBRARY_FUNCS_TO_INCLUDE`.
 
 2.0.25 - 06/30/2021
 -------------------

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -232,9 +232,7 @@ function JSify(functionsOnly) {
       } else if (typeof snippet === 'function') {
         isFunction = true;
         snippet = processLibraryFunction(snippet, ident, finalName);
-        if (!isJsOnlyIdentifier(ident[0])) {
-          libraryFunctions.push(finalName);
-        }
+        libraryFunctions.push(finalName);
       }
 
       // If a JS library item specifies xxx_import: true, then explicitly mark that symbol to be exported

--- a/src/library.js
+++ b/src/library.js
@@ -3682,9 +3682,16 @@ LibraryManager.library = {
     if (dep) addRunDependency(dep);
   },
 
+  $alignMemory: function(size, alignment) {
+#if ASSERTIONS
+    assert(alignment, "alignment argument is required");
+#endif
+    return Math.ceil(size / alignment) * alignment;
+  },
+
   // Allocate memory for an mmap operation. This allocates space of the right
   // page-aligned size, and clears the allocated space.
-  $mmapAlloc__deps: ['$zeroMemory'],
+  $mmapAlloc__deps: ['$zeroMemory', '$alignMemory'],
   $mmapAlloc: function(size) {
 #if hasExportedFunction('_memalign')
     size = alignMemory(size, {{{ WASM_PAGE_SIZE }}});

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -348,7 +348,7 @@ var LibraryDylink = {
 
   // Loads a side module from binary data or compiled Module. Returns the module's exports or a
   // promise that resolves to its exports if the loadAsync flag is set.
-  $loadWebAssemblyModule__deps: ['$loadDynamicLibrary', '$createInvokeFunction', '$getMemory', '$relocateExports', '$resolveGlobalSymbol', '$GOTHandler', '$getDylinkMetadata'],
+  $loadWebAssemblyModule__deps: ['$loadDynamicLibrary', '$createInvokeFunction', '$getMemory', '$relocateExports', '$resolveGlobalSymbol', '$GOTHandler', '$getDylinkMetadata', '$alignMemory'],
   $loadWebAssemblyModule: function(binary, flags) {
     var metadata = getDylinkMetadata(binary);
 #if ASSERTIONS

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1212,10 +1212,18 @@ function makeModuleReceiveWithVar(localName, moduleName, defaultValue, noAssert)
 }
 
 function makeRemovedFSAssert(fsName) {
-  if (!ASSERTIONS) return;
+  assert(ASSERTIONS);
   const lower = fsName.toLowerCase();
   if (SYSTEM_JS_LIBRARIES.includes('library_' + lower + '.js')) return '';
   return `var ${fsName} = '${fsName} is no longer included by default; build with -l${lower}.js';`;
+}
+
+function makeRemovedRuntimeFunction(name) {
+  assert(ASSERTIONS);
+  if (libraryFunctions.includes(name)) {
+    return '';
+  }
+  return `function ${name}() { abort('\`${name}\` is now a library function and not included by default; add it to your library.js __deps or to DEFAULT_LIBRARY_FUNCS_TO_INCLUDE on the command line'); }`;
 }
 
 // Given an array of elements [elem1,elem2,elem3], returns a string "['elem1','elem2','elem3']"

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -43,11 +43,6 @@ function getNativeTypeSize(type) {
   }
 }
 
-function alignMemory(size, factor) {
-  if (!factor) factor = STACK_ALIGN; // stack alignment (16-byte) by default
-  return Math.ceil(size / factor) * factor;
-}
-
 var Runtime = {
   getNativeTypeSize: getNativeTypeSize,
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -409,6 +409,7 @@ assert(typeof Module['TOTAL_MEMORY'] === 'undefined', 'Module.TOTAL_MEMORY has b
 {{{ makeRemovedFSAssert('PROXYFS') }}}
 {{{ makeRemovedFSAssert('WORKERFS') }}}
 {{{ makeRemovedFSAssert('NODEFS') }}}
+{{{ makeRemovedRuntimeFunction('alignMemory') }}}
 
 #if USE_PTHREADS
 assert(ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER || ENVIRONMENT_IS_NODE, 'Pthreads do not work in this environment yet (need Web Workers, or an alternative to them)');

--- a/src/support.js
+++ b/src/support.js
@@ -6,8 +6,6 @@
 
 var STACK_ALIGN = {{{ STACK_ALIGN }}};
 
-{{{ alignMemory }}}
-
 {{{ getNativeTypeSize }}}
 
 function warnOnce(text) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10733,3 +10733,9 @@ void foo() {}
     self.run_process([EMCC, test_file('hello_world.c')])
     err = self.run_js('a.out.js', assert_returncode=NON_ZERO)
     self.assertContained('shell environment detected but not enabled at build time.', err)
+
+  def test_removed_runtime_function(self):
+    create_file('post.js', 'alignMemory(100, 4);')
+    self.run_process([EMCC, test_file('hello_world.c'), '--post-js=post.js'])
+    err = self.run_js('a.out.js', assert_returncode=NON_ZERO)
+    self.assertContained('`alignMemory` is now a library function and not included by default; add it to your library.js __deps or to DEFAULT_LIBRARY_FUNCS_TO_INCLUDE on the command line', err)


### PR DESCRIPTION
This allows it to be used in MINIMAL_RUNTIME which can end up depending
on it in asan builds due to asan using mmap (which calls mmapAlloc).

This fixes the current failure on the waterfall of:
  asan.test_dyncall_specific_minimal_runtime

Also remove the default for the second argument here.  There are only
two call sites and both of them specify an alignment.