### PR TITLE
Update acorn npm dependency to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -72,9 +72,9 @@
       }
     },
     "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.4.1.tgz",
+      "integrity": "sha512-asabaBSkEKosYKMITunzX177CXxQ4Q8BSSzMTKD+FefUhipQC70gfW5SiUDhYQ3vk8G+81HqQk7Fv9OXwwn9KA=="
     },
     "acorn-jsx": {
       "version": "5.3.1",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "ws": "~0.4.28"
   },
   "dependencies": {
-    "acorn": "7.3.1",
+    "acorn": "8.4.1",
     "google-closure-compiler": "20200920.0.0",
     "html-minifier-terser": "5.0.2",
     "wasm2c": "1.0.0"

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -943,7 +943,7 @@ function applyDCEGraphRemovals(ast) {
 
 // Need a parser to pass to acorn.Node constructor.
 // Create it once and reuse it.
-var stubParser = new acorn.Parser();
+var stubParser = new acorn.Parser({ecmaVersion: 2020})
 
 function createNode(props) {
   var node = new acorn.Node(stubParser);


### PR DESCRIPTION
The result of changing the version to `*` and then running `npm update
--save acorn`.

Fixes: #14569