### PR TITLE
Enable `btest_exit` to work with `MINIMAL_RUNTIME`

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3542,6 +3542,9 @@ LibraryManager.library = {
     throw 'unwind';
   },
 
+#if MINIMAL_RUNTIME
+  emscripten_force_exit__deps: ['exit'],
+#endif
   emscripten_force_exit__proxy: 'sync',
   emscripten_force_exit__sig: 'vi',
   emscripten_force_exit: function(status) {
@@ -3550,11 +3553,13 @@ LibraryManager.library = {
     warnOnce('emscripten_force_exit cannot actually shut down the runtime, as the build does not have EXIT_RUNTIME set');
 #endif
 #endif
-#if !MINIMAL_RUNTIME
+#if MINIMAL_RUNTIME
+    _exit(status);
+#else
     noExitRuntime = false;
     runtimeKeepaliveCounter = 0;
-#endif
     exit(status);
+#endif
   },
 
 #if !MINIMAL_RUNTIME

--- a/tests/browser_reporting.js
+++ b/tests/browser_reporting.js
@@ -34,8 +34,18 @@ function reportErrorToServer(message) {
 if (typeof window === 'object' && window) {
   window.addEventListener('error', function(e) {
     var xhr = new XMLHttpRequest();
-    xhr.open('GET', encodeURI('http://localhost:8888?exception=' + e.message + ' / ' + e.stack));
-    xhr.send();
+    // MINIMAL_RUNTIME doesn't handle exit or call the below onExit handler
+    // so we detect the exit by parsing the uncaught exception message.
+    var offset = e.message.indexOf('exit(');
+    if (offset != -1) {
+      var status = e.message.substring(offset + 5);
+      offset = status.indexOf(')')
+      status = status.substr(0, offset)
+      maybeReportResultToServer('exit:' + status);
+    } else {
+      xhr.open('GET', encodeURI('http://localhost:8888?exception=' + e.message + ' / ' + e.stack));
+      xhr.send();
+    }
   });
 }
 

--- a/tests/pthread/hello_thread.c
+++ b/tests/pthread/hello_thread.c
@@ -12,15 +12,14 @@
 void *thread_main(void *arg)
 {
 	EM_ASM(out('hello from thread!'));
-#ifdef REPORT_RESULT
-	REPORT_RESULT(1);
-#endif
-	return 0;
+	emscripten_force_exit(0);
+	__builtin_unreachable();
 }
 
 int main()
 {
 	pthread_t thread;
 	pthread_create(&thread, NULL, thread_main, NULL);
-	emscripten_unwind_to_js_event_loop();
+	emscripten_exit_with_live_runtime();
+	__builtin_unreachable();
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4311,7 +4311,7 @@ window.close = function() {
     size = os.path.getsize('test.js')
     print('size:', size)
     # Note that this size includes test harness additions (for reporting the result, etc.).
-    self.assertLess(abs(size - 5368), 100)
+    self.assertLess(abs(size - 5477), 100)
 
   # Tests that it is possible to initialize and render WebGL content in a pthread by using OffscreenCanvas.
   # -DTEST_CHAINED_WEBGL_CONTEXT_PASSING: Tests that it is possible to transfer WebGL canvas in a chain from main thread -> thread 1 -> thread 2 and then init and render WebGL content there.
@@ -4697,13 +4697,13 @@ window.close = function() {
   def test_pthread_hello_thread(self):
     for opts in [[], ['-O3']]:
       for modularize in [[], ['-s', 'MODULARIZE', '-s', 'EXPORT_NAME=MyModule', '--shell-file', test_file('shell_that_launches_modularize.html')]]:
-        self.btest(test_file('pthread/hello_thread.c'), expected='1', args=['-s', 'USE_PTHREADS'] + modularize + opts)
+        self.btest_exit(test_file('pthread/hello_thread.c'), args=['-s', 'USE_PTHREADS'] + modularize + opts)
 
   # Tests that a pthreads build of -s MINIMAL_RUNTIME=1 works well in different build modes
   def test_minimal_runtime_hello_pthread(self):
     for opts in [[], ['-O3']]:
       for modularize in [[], ['-s', 'MODULARIZE', '-s', 'EXPORT_NAME=MyModule']]:
-        self.btest(test_file('pthread/hello_thread.c'), expected='1', args=['-s', 'MINIMAL_RUNTIME', '-s', 'USE_PTHREADS'] + modularize + opts)
+        self.btest_exit(test_file('pthread/hello_thread.c'), args=['-s', 'MINIMAL_RUNTIME', '-s', 'USE_PTHREADS'] + modularize + opts)
 
   # Tests memory growth in pthreads mode, but still on the main thread.
   @requires_threads
@@ -4739,9 +4739,10 @@ window.close = function() {
   @requires_threads
   def test_load_js_from_blob_with_pthreads(self):
     # TODO: enable this with wasm, currently pthreads/atomics have limitations
-    self.compile_btest([test_file('pthread/hello_thread.c'), '-s', 'USE_PTHREADS', '-o', 'hello_thread_with_blob_url.js'])
+    self.set_setting('EXIT_RUNTIME')
+    self.compile_btest([test_file('pthread/hello_thread.c'), '-s', 'USE_PTHREADS', '-o', 'hello_thread_with_blob_url.js'], reporting=Reporting.JS_ONLY)
     shutil.copyfile(test_file('pthread/main_js_as_blob_loader.html'), 'hello_thread_with_blob_url.html')
-    self.run_browser('hello_thread_with_blob_url.html', 'hello from thread!', '/report_result?1')
+    self.run_browser('hello_thread_with_blob_url.html', 'hello from thread!', '/report_result?exit:0')
 
   # Tests that base64 utils work in browser with no native atob function
   def test_base64_atob_fallback(self):


### PR DESCRIPTION
Unlike the normal runtime we can't detect exit using the
`onExit` handler so we need to detect the specific uncaught
exception.
