### PR TITLE
skip stackRestore in invoke_* when 'unwind' is thrown

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -718,7 +718,7 @@ function%s(%s) {
   try {
     %s
   } catch(e) {
-    if (e === e+0 && e !== 'unwind')
+    if (e === e+0 || e !== 'unwind')
       stackRestore(sp);
     %s
     _setThrew(1, 0);

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -718,7 +718,8 @@ function%s(%s) {
   try {
     %s
   } catch(e) {
-    stackRestore(sp);
+    if (e !== 'unwind')
+      stackRestore(sp);
     %s
     _setThrew(1, 0);
   }

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -718,7 +718,7 @@ function%s(%s) {
   try {
     %s
   } catch(e) {
-    if (e !== 'unwind')
+    if (e === e+0 && e !== 'unwind')
       stackRestore(sp);
     %s
     _setThrew(1, 0);


### PR DESCRIPTION
`emscripten_set_main_loop` with `-fexceptions` may cause stack corruption because `invoke_*` function always unwind stack regardless of the kind of exceptions.

This PR includes patch that stack is not unwound in `invoke_*` function when 'unwind' is thrown.