### PR TITLE
Allow 8/16 alignment of long double to let ABI change to roll

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,8 +22,7 @@ See docs/process.md for more on how version tagging works.
 ------
 - The alignment of `long double`, which is a 128-bit floating-point value
   implemented in software, is reduced from 16 to 8. The lower alignment allows
-  `max_align_t` to be correctly defined as 8, and avoids raising it to 16 which
-  would regress performance. (#10072)
+  `max_align_t` to properly match the alignment we use for malloc (8). (#10072)
 - The `alignMemory` function is now a library function and therefore not
   included by default.  Debug builds will automatically abort if you try
   to use this function without including it.  The normal library `__deps`

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 2.0.26
 ------
+- The alignment of `long double`, which is a 128-bit floating-point value
+  implemented in software, is reduced from 16 to 8. The lower alignment allows
+  `max_align_t` to be correctly defined as 8, and avoids raising it to 16 which
+  would regress performance. (#10072)
 - The `alignMemory` function is now a library function and therefore not
   included by default.  Debug builds will automatically abort if you try
   to use this function without including it.  The normal library `__deps`

--- a/tests/core/test_stddef.cpp
+++ b/tests/core/test_stddef.cpp
@@ -26,7 +26,8 @@ void abort(void);
 
 int main() {
   // max_align_t on wasm backend is 16 due to sizeof(long double) being 16.
-  if (_Alignof(max_align_t) != 16)
+  // TODO: change this to just 8 after the new ABI rolls in.
+  if (_Alignof(max_align_t) != 16 && _Alignof(max_align_t) != 8)
     abort();
   puts("success");
   return 0;

--- a/tests/wasm32-unknown-emscripten.c
+++ b/tests/wasm32-unknown-emscripten.c
@@ -98,7 +98,8 @@ int main() {
   assert(sizeof(intmax_t) == 8);
   assert(__alignof(double) == 8);
   assert(sizeof(long double) == 16);
-  assert(__alignof(long double) == 16);
+  // TODO: change this to just 8 after the new ABI rolls in.
+  assert(__alignof(long double) == 16 || __alignof(long double) == 8);
   assert(sizeof(intptr_t) == 4);
   assert(sizeof(size_t) == 4);
   assert(sizeof(ptrdiff_t) == 4);


### PR DESCRIPTION
Also update the changelog now, to not forget later.