### PR TITLE
Fix ReferenceError: ___sys_statfs64 is not defined

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1175,7 +1175,7 @@ var SyscallsLibrary = {
   },
   __sys_fstatfs64: function(fd, size, buf) {
     var stream = SYSCALLS.getStreamFromFD(fd);
-    return __sys_statfs64(0, size, buf);
+    return __sys_statfs64(stream.path, size, buf);
   },
   __sys_fadvise64_64__nothrow: true,
   __sys_fadvise64_64__proxy: false,

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1175,7 +1175,7 @@ var SyscallsLibrary = {
   },
   __sys_fstatfs64: function(fd, size, buf) {
     var stream = SYSCALLS.getStreamFromFD(fd);
-    return ___sys_statfs64(0, size, buf);
+    return __sys_statfs64(0, size, buf);
   },
   __sys_fadvise64_64__nothrow: true,
   __sys_fadvise64_64__proxy: false,


### PR DESCRIPTION
It looks like there was one redundant underscore, as `__sys_statfs64` exists and `___sys_statfs64` does  not:

https://github.com/emscripten-core/emscripten/blob/0c070488619cf556e4917cd88c0a868faf611c13/src/library_syscall.js#L1157

and we should rather pass the stream path to the method?

fixes #14602