### PR TITLE
Restore C stack on unwind

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3595,6 +3595,9 @@ LibraryManager.library = {
 #endif
       return;
     }
+
+    var stackTop = stackSave();
+
     // For synchronous calls, let any exceptions propagate, and don't let the runtime exit.
     if (synchronous) {
       func();
@@ -3609,6 +3612,8 @@ LibraryManager.library = {
         // And actual unexpected user-exectpion occured
         if (e && typeof e === 'object' && e.stack) err('exception thrown: ' + [e, e.stack]);
         throw e;
+      } else {
+        stackRestore(stackTop);
       }
     }
 #if EXIT_RUNTIME || USE_PTHREADS

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -143,6 +143,8 @@ function callMain(args) {
   if (!entryFunction) return;
 #endif
 
+  var stackTop = stackSave();
+
 #if MAIN_READS_PARAMS && STANDALONE_WASM
   mainArgs = [thisProgram].concat(args)
 #elif MAIN_READS_PARAMS
@@ -194,6 +196,10 @@ function callMain(args) {
     exit(ret, /* implicit = */ true);
   }
   catch (e) {
+    if (e == 'unwind') {
+      stackRestore(stackTop);
+    }
+
     // Certain exception types we do not treat as errors since they are used for
     // internal control flow.
     // 1. ExitStatus, which is thrown by exit()


### PR DESCRIPTION
This PR includes the opposite solution to [skip stackRestore in invoke_* when 'unwind' is thrown](https://github.com/emscripten-core/emscripten/pull/14592), `callMain` and `callUserCallback` call `stackRestore` when `unwind` is thrown.

 Inconsistency in the behaviors of the program that contains _c++ lambda_ + _try block_ + _emscripten_set_main_loop_ will be fixed.