### PR TITLE
Fix ASan handling of WasmOffsetConverter reading on a pthread

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -1125,17 +1125,41 @@ function createWasm() {
         typeof fetch === 'function') {
       return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
         var result = WebAssembly.instantiateStreaming(response, info);
+
 #if USE_OFFSET_CONVERTER
-        // This doesn't actually do another request, it only copies the Response object.
-        // Copying lets us consume it independently of WebAssembly.instantiateStreaming.
-        Promise.all([response.clone().arrayBuffer(), result]).then(function (results) {
-          wasmOffsetConverter = new WasmOffsetConverter(new Uint8Array(results[0]), results[1].module);
-          {{{ runOnMainThread("removeRunDependency('offset-converter');") }}}
-        }, function(reason) {
-          err('failed to initialize offset-converter: ' + reason);
-        });
+        // We need the wasm binary for the offset converter. Clone the response
+        // in order to get its arrayBuffer (cloning should be more efficient
+        // than doing another entire request).
+        // (We must clone the response now in order to use it later, as if we
+        // try to clone it asynchronously lower down then we will get a
+        // "response was already consumed" error.)
+        var clonedResponsePromise = response.clone().arrayBuffer();
 #endif
-        return result.then(receiveInstantiationResult, function(reason) {
+
+        return result.then(
+#if !USE_OFFSET_CONVERTER
+          receiveInstantiationResult,
+#else
+          function(instantiationResult) {
+            // When using the offset converter, we must interpose here. First,
+            // the instantiation result must arrive (if it fails, the error
+            // handling later down will handle it). Once it arrives, we can
+            // initialize the offset converter. And only then is it valid to
+            // call receiveInstantiationResult, as that function will use the
+            // offset converter (in the case of pthreads, it will create the
+            // pthreads and send them the offsets along with the wasm instance).
+
+            clonedResponsePromise.then(function(arrayBufferResult) {
+              wasmOffsetConverter = new WasmOffsetConverter(new Uint8Array(arrayBufferResult), instantiationResult.module);
+              {{{ runOnMainThread("removeRunDependency('offset-converter');") }}}
+
+              receiveInstantiationResult(instantiationResult);
+            }, function(reason) {
+              err('failed to initialize offset-converter: ' + reason);
+            });
+          },
+#endif
+          function(reason) {
             // We expect the most common failure cause to be a bad MIME type for the binary,
             // in which case falling back to ArrayBuffer instantiation should work.
             err('wasm streaming compile failed: ' + reason);

--- a/tests/pthread/test_pthread_asan_use_after_free_2.cpp
+++ b/tests/pthread/test_pthread_asan_use_after_free_2.cpp
@@ -1,0 +1,10 @@
+#include <iostream>
+#include <thread>
+
+int main() {
+  std::thread([]() {
+    int* p = new int(1);
+    delete p;
+    std::cout << *p;
+  }).detach();
+}

--- a/tests/pthread/test_pthread_asan_use_after_free_2.js
+++ b/tests/pthread/test_pthread_asan_use_after_free_2.js
@@ -1,0 +1,25 @@
+(function () {
+  var output = [];
+  Module['printErr'] = function (text) {
+    if (text == '==42==ABORTING') {
+      var result = output.join('\n');
+      var passed = [
+        'ERROR: AddressSanitizer: heap-use-after-free on address',
+        'READ of size 4',
+        'is located 0 bytes inside of 4-byte region',
+        'freed by thread T1 here:',
+        'previously allocated by thread T1 here:',
+        'Thread T1 created by T0 here:',
+        'SUMMARY: AddressSanitizer: heap-use-after-free',
+        'Shadow bytes around the buggy address:',
+        'Shadow byte legend (one shadow byte represents 8 application bytes):',
+      ].every(function (snippet) {
+        return result.indexOf(snippet) >= 0;
+      });
+      reportResultToServer(passed ? 1 : 0);
+      return;
+    }
+    output.push(text);
+    console.log(text);
+  };
+})();

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4144,6 +4144,14 @@ window.close = function() {
     self.btest(test_file('pthread/test_pthread_asan_use_after_free.cpp'), expected='1', args=['-fsanitize=address', '-s', 'INITIAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free.js')])
 
   @requires_threads
+  def test_pthread_asan_use_after_free_2(self):
+    # similiar to test_pthread_asan_use_after_free, but using a pool instead
+    # of proxy-to-pthread, and also the allocation happens on the pthread
+    # (which tests that it can use the offset converter to get the stack
+    # trace there)
+    self.btest(test_file('pthread/test_pthread_asan_use_after_free_2.cpp'), expected='1', args=['-fsanitize=address', '-s', 'INITIAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE=1', '--pre-js', test_file('pthread/test_pthread_asan_use_after_free_2.js')])
+
+  @requires_threads
   def test_pthread_exit_process(self):
     args = ['-s', 'USE_PTHREADS',
             '-s', 'PROXY_TO_PTHREAD',


### PR DESCRIPTION
If ASan wants to show a stack trace on a pthread (like the trace to get to
an allocation that was later used after free), then it needs access to the
WasmOffsetConverter. We had a race there, where it could postMessage
the WasmOffsetConverter before that object was actually filled with the
data it needs (function offsets). See details in comments.

Fixes #13205