### PR TITLE
Disable poppler test for now

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6096,6 +6096,7 @@ void* operator new(size_t size) {
                  libraries=self.get_bullet_library(use_cmake),
                  includes=[test_file('third_party/bullet/src')])
 
+  @unittest.skip('LLVM changes have caused this C++ to no longer compile, https://github.com/emscripten-core/emscripten/issues/14614')
   @no_asan('issues with freetype itself')
   @needs_make('depends on freetype')
   @is_slow_test


### PR DESCRIPTION
See #14614 

It is unclear if we should restore this test - it's slow, and may not be really
adding much coverage. The last thing I remember it found is a debug
info regression where some C++ file crashed in clang with `-g`, some time
last year.