### PR TITLE
Improve changelog [ci skip]

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,7 +22,9 @@ See docs/process.md for more on how version tagging works.
 ------
 - The alignment of `long double`, which is a 128-bit floating-point value
   implemented in software, is reduced from 16 to 8. The lower alignment allows
-  `max_align_t` to properly match the alignment we use for malloc (8). (#10072)
+  `max_align_t` to properly match the alignment we use for malloc, which is 8
+  (raising malloc's alignment to achieve correctness the other way would come
+  with a performance regression). (#10072)
 - The `alignMemory` function is now a library function and therefore not
   included by default.  Debug builds will automatically abort if you try
   to use this function without including it.  The normal library `__deps`


### PR DESCRIPTION
(This is mainly to restart the emscripten roller, which hit a random failure. Restarting
it will hopefully get the LLVM roll to finally pass after a week.)