### PR TITLE
Resolve assertion failure in LSan

### DIFF
--- a/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp
@@ -145,8 +145,15 @@ static void ProcessThreadsCallback(ThreadContextBase *tctx, void *arg) {
     // we can for the current thread.
     if (tctx->tid == GetCurrentThread()) {
       uptr sp = (uptr) __builtin_frame_address(0);
-      CHECK(stack_begin <= sp && sp < stack_end);
-      stack_begin = sp;
+      if (sp < stack_begin || sp >= stack_end) {
+        // SP is outside the recorded stack range (e.g. the thread is running a
+        // signal handler on alternate stack, or swapcontext was used).
+        // Again, consider the entire stack range to be reachable.
+        LOG_THREADS("WARNING: stack pointer not in stack range.\n");
+      } else {
+        // Shrink the stack range to ignore out-of-scope values.
+        stack_begin = sp;
+      }
     }
 
     ScanRangeForPointers(stack_begin, stack_end, frontier, "STACK", kReachable);


### PR DESCRIPTION
By re-syncing `lsan_common_emscripten.cpp` with `lsan_common.cpp`,
except for the guard page skip logic (`IsAccessibleMemoryRange`
always returns true on Emscripten).

---

The added test case in PR #14481 seems to trigger this assertion
failure:

<details>
  <summary>Details</summary>

```
$ ./tests/runner asan.test_pthread_atexit
Test suites:
['test_core']
Running test_core: (1 tests)
(checking sanity from test runner)
shared:INFO: (Emscripten: Running sanity checks)
test_pthread_atexit (test_core.asan) ... -- begin program output --
done waiting - counter is: 0
==42==AddressSanitizer CHECK failed: /home/kleisauke/emscripten/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp:148 "((stack_begin <= sp && sp < stack_end)) != (0)" (0x0, 0x0)
    #0 0x1b027 in __asan::AsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long)+0x1b027 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1b027)
    #1 0x21098 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long)+0x21098 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x21098)
    #2 0x1ec02 in __lsan::ProcessThreadsCallback(__sanitizer::ThreadContextBase*, void*)+0x1ec02 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1ec02)
    #3 0x211c2 in __sanitizer::ThreadRegistry::RunCallbackForEachThreadLocked(void (*)(__sanitizer::ThreadContextBase*, void*), void*)+0x211c2 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x211c2)
    #4 0x1d6a2 in __lsan::CheckForLeaksCallback(__sanitizer::SuspendedThreadsList const&, void*)+0x1d6a2 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1d6a2)
    #5 0x1d069 in __lsan::CheckForLeaks()+0x1d069 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1d069)
    #6 0x1cf41 in __lsan::DoLeakCheck()+0x1cf41 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1cf41)
    #7 0x8000049b in callRuntimeCallbacks /tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.js:1179:24

-- end program output --
FAIL

======================================================================
FAIL: test_pthread_atexit (test_core.asan)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kleisauke/emscripten/tests/common.py", line 193, in decorated
    f(self)
  File "/home/kleisauke/emscripten/tests/test_core.py", line 2330, in test_pthread_atexit
    self.do_run_in_out_file_test('pthread/test_pthread_atexit.c')
  File "/home/kleisauke/emscripten/tests/common.py", line 1004, in do_run_in_out_file_test
    self._build_and_run(srcfile, expected, **kwargs)
  File "/home/kleisauke/emscripten/tests/common.py", line 1045, in _build_and_run
    js_output = self.run_js(js_file, engine, args, output_nicerizer=output_nicerizer, assert_returncode=assert_returncode)
  File "/home/kleisauke/emscripten/tests/common.py", line 666, in run_js
    self.fail('JS subprocess failed (%s): %s.  Output:\n%s' % (error.cmd, error.returncode, ret))
AssertionError: JS subprocess failed (/home/kleisauke/emsdk/node/14.15.5_64bit/bin/node --experimental-wasm-threads --experimental-wasm-bulk-memory test_pthread_atexit.js): 1.  Output:
done waiting - counter is: 0
==42==AddressSanitizer CHECK failed: /home/kleisauke/emscripten/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp:148 "((stack_begin <= sp && sp < stack_end)) != (0)" (0x0, 0x0)
    #0 0x1b027 in __asan::AsanCheckFailed(char const*, int, char const*, unsigned long long, unsigned long long)+0x1b027 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1b027)
    #1 0x21098 in __sanitizer::CheckFailed(char const*, int, char const*, unsigned long long, unsigned long long)+0x21098 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x21098)
    #2 0x1ec02 in __lsan::ProcessThreadsCallback(__sanitizer::ThreadContextBase*, void*)+0x1ec02 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1ec02)
    #3 0x211c2 in __sanitizer::ThreadRegistry::RunCallbackForEachThreadLocked(void (*)(__sanitizer::ThreadContextBase*, void*), void*)+0x211c2 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x211c2)
    #4 0x1d6a2 in __lsan::CheckForLeaksCallback(__sanitizer::SuspendedThreadsList const&, void*)+0x1d6a2 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1d6a2)
    #5 0x1d069 in __lsan::CheckForLeaks()+0x1d069 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1d069)
    #6 0x1cf41 in __lsan::DoLeakCheck()+0x1cf41 (/tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.wasm+0x1cf41)
    #7 0x8000049b in callRuntimeCallbacks /tmp/emscripten_test_asan_okue_iyd/test_pthread_atexit.js:1179:24



----------------------------------------------------------------------
Ran 1 test in 1.932s

FAILED (failures=1)
```
</details>
