### PR TITLE
Prefer to use `__lsan_{disable,enable}`

### DIFF
--- a/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan_common_emscripten.cpp
@@ -177,11 +177,4 @@ void ProcessThreads(SuspendedThreadsList const &suspended_threads,
 
 } // namespace __lsan
 
-extern "C" void __lsan_disable_in_this_thread() {
-  __lsan::DisableInThisThread();
-}
-
-extern "C" void __lsan_enable_in_this_thread() {
-  __lsan::EnableInThisThread();
-}
 #endif // CAN_SANITIZE_LEAKS && SANITIZER_EMSCRIPTEN


### PR DESCRIPTION
This should be considered as non-functional change, expect for the
`__has_feature(leak_sanitizer)` addition (which has been added
to also do this when using `-fsanitize=leak` instrumentation option).