### PR TITLE
Don't recommend LLD_REPORT_UNDEFINED for indirect library symbols.

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -130,6 +130,8 @@ function JSify(functionsOnly) {
       // what we just added to the library.
     }
 
+    const TOP_LEVEL = 'top-level compiled C/C++ code';
+
     function addFromLibrary(item, dependent) {
       // dependencies can be JS functions, which we just run
       if (typeof item == 'function') return item();
@@ -161,7 +163,7 @@ function JSify(functionsOnly) {
           if (dependent) msg += ' (referenced by ' + dependent + ')';
           if (ERROR_ON_UNDEFINED_SYMBOLS) {
             error(msg);
-            if (!LLD_REPORT_UNDEFINED) {
+            if (dependent == TOP_LEVEL && !LLD_REPORT_UNDEFINED) {
               warnOnce('Link with `-s LLD_REPORT_UNDEFINED` to get more information on undefined symbols');
             }
             warnOnce('To disable errors for undefined symbols use `-s ERROR_ON_UNDEFINED_SYMBOLS=0`')
@@ -326,7 +328,7 @@ function JSify(functionsOnly) {
     }
 
     itemsDict.functionStub.push(item);
-    item.JS = addFromLibrary(item, 'top-level compiled C/C++ code');
+    item.JS = addFromLibrary(item, TOP_LEVEL);
   }
 
   // Final combiner

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9987,6 +9987,14 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
   def test_chained_js_error_diagnostics(self):
     err = self.expect_fail([EMCC, test_file('test_chained_js_error_diagnostics.c'), '--js-library', test_file('test_chained_js_error_diagnostics.js')])
     self.assertContained("error: undefined symbol: nonexistent_function (referenced by bar__deps: ['nonexistent_function'], referenced by foo__deps: ['bar'], referenced by top-level compiled C/C++ code)", err)
+    # Check that we don't recommend LLD_REPORT_UNDEFINED for chained dependencies.
+    self.assertNotContained('LLD_REPORT_UNDEFINED', err)
+
+    # Test without chaining.  In this case we don't include the JS library at all resulting in `foo`
+    # being undefined in the native code and in this case we recommend LLD_REPORT_UNDEFINED.
+    err = self.expect_fail([EMCC, test_file('test_chained_js_error_diagnostics.c')])
+    self.assertContained('error: undefined symbol: foo (referenced by top-level compiled C/C++ code)', err)
+    self.assertContained('Link with `-s LLD_REPORT_UNDEFINED` to get more information on undefined symbols', err)
 
   def test_xclang_flag(self):
     create_file('foo.h', ' ')


### PR DESCRIPTION
This flag only helps for undefined symbols that are directly
referenced by top-level C/C++.