### PR TITLE
Add missing deps for `vsyslog`

### DIFF
--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -187,6 +187,7 @@ _deps_info = {
   'setprotoent': ['malloc'],
   'setgroups': ['sysconf'],
   'syslog': ['malloc', 'ntohs'],
+  'vsyslog': ['malloc', 'ntohs'],
   'timegm': ['_get_tzname', '_get_daylight', '_get_timezone', 'malloc'],
   'tzset': ['_get_tzname', '_get_daylight', '_get_timezone', 'malloc'],
   'uuid_compare': ['memcmp'],


### PR DESCRIPTION
`vsyslog` is an alias for `syslog` so has the same deps.

The `test_deps_info` test takes care of confirming this is
both necessary and sufficient.