### PR TITLE
use wasm object format when '-shared' and 'side_module' are specified

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -18,7 +18,7 @@ set(CMAKE_SYSTEM_NAME Emscripten)
 set(CMAKE_SYSTEM_VERSION 1)
 
 set(CMAKE_CROSSCOMPILING TRUE)
-set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
 
 # Advertise Emscripten as a 32-bit platform (as opposed to
 # CMAKE_SYSTEM_PROCESSOR=x86_64 for 64-bit platform), since some projects (e.g.

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -29,7 +29,7 @@ set(CMAKE_SYSTEM_PROCESSOR x86)
 # of an outputted .so library: e.g. "libfoo.so, libfoo.so.1, libfoo.so.1.4" etc.
 # This feature is activated if a shared library project has the property
 # SOVERSION defined.
-set(CMAKE_SHARED_LIBRARY_SONAME_C_FLAG "-Wl,-soname,")
+set(CMAKE_SHARED_LIBRARY_SONAME_C_FLAG "-Wl,-soname=")
 
 # In CMake, CMAKE_HOST_WIN32 is set when we are cross-compiling from Win32 to
 # Emscripten:

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -18,7 +18,7 @@ set(CMAKE_SYSTEM_NAME Emscripten)
 set(CMAKE_SYSTEM_VERSION 1)
 
 set(CMAKE_CROSSCOMPILING TRUE)
-set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
 
 # Advertise Emscripten as a 32-bit platform (as opposed to
 # CMAKE_SYSTEM_PROCESSOR=x86_64 for 64-bit platform), since some projects (e.g.
@@ -29,7 +29,7 @@ set(CMAKE_SYSTEM_PROCESSOR x86)
 # of an outputted .so library: e.g. "libfoo.so, libfoo.so.1, libfoo.so.1.4" etc.
 # This feature is activated if a shared library project has the property
 # SOVERSION defined.
-set(CMAKE_SHARED_LIBRARY_SONAME_C_FLAG "-Wl,-soname=")
+set(CMAKE_SHARED_LIBRARY_SONAME_C_FLAG "-Wl,-soname,")
 
 # In CMake, CMAKE_HOST_WIN32 is set when we are cross-compiling from Win32 to
 # Emscripten:

--- a/emcc.py
+++ b/emcc.py
@@ -1408,14 +1408,14 @@ def phase_linker_setup(options, state, newargs, settings_map):
 
   # If no output format was sepecific we try to imply the format based on
   # the output filename extension.
-  if not options.oformat and (options.shared or options.relocatable):
+  if not options.oformat and (options.relocatable or (options.shared and not settings.SIDE_MODULE)):
     # Until we have a better story for actually producing runtime shared libraries
     # we support a compatibility mode where shared libraries are actually just
     # object files linked with `wasm-ld --relocatable` or `llvm-link` in the case
     # of LTO.
     if final_suffix in EXECUTABLE_ENDINGS:
       diagnostics.warning('emcc', '-shared/-r used with executable output suffix. This behaviour is deprecated.  Please remove -shared/-r to build an executable or avoid the executable suffix (%s) when building object files.' % final_suffix)
-    elif not (options.shared and settings.SIDE_MODULE):
+    else:
       if options.shared:
         diagnostics.warning('emcc', 'linking a library with `-shared` will emit a static object file.  This is a form of emulation to support existing build systems.  If you want to build a runtime shared library use the SIDE_MODULE setting.')
       options.oformat = OFormat.OBJECT

--- a/emcc.py
+++ b/emcc.py
@@ -1415,7 +1415,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
     # of LTO.
     if final_suffix in EXECUTABLE_ENDINGS:
       diagnostics.warning('emcc', '-shared/-r used with executable output suffix. This behaviour is deprecated.  Please remove -shared/-r to build an executable or avoid the executable suffix (%s) when building object files.' % final_suffix)
-    else:
+    elif not (options.shared and settings.SIDE_MODULE):
       if options.shared:
         diagnostics.warning('emcc', 'linking a library with `-shared` will emit a static object file.  This is a form of emulation to support existing build systems.  If you want to build a runtime shared library use the SIDE_MODULE setting.')
       options.oformat = OFormat.OBJECT

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10139,7 +10139,7 @@ int main () {
     self.assertContained('warning: -shared/-r used with executable output suffix', err)
     self.run_js('out.js')
 
-  def test_shared_and_shared_module_flag(self):
+  def test_shared_and_side_module_flag(self):
     # Test that `-shared` and `-s SIDE_MODULE` flag causes wasm dylib generation without a warning.
     err = self.run_process([EMCC, '-shared', '-s', 'SIDE_MODULE=1', test_file('hello_world.c'), '-o', 'out.foo'], stderr=PIPE).stderr
     self.assertNotContained('linking a library with `-shared` will emit a static object', err)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -119,6 +119,9 @@ class other(RunnerCore):
   def assertIsObjectFile(self, filename):
     self.assertTrue(building.is_wasm(filename))
 
+  def assertIsWasmDylib(self, filename):
+    self.assertTrue(building.is_wasm_dylib(filename))
+
   def do_other_test(self, testname, emcc_args=[], **kwargs):
     self.do_run_in_out_file_test('other', testname, emcc_args=emcc_args, **kwargs)
 
@@ -10135,6 +10138,18 @@ int main () {
                            stderr=PIPE).stderr
     self.assertContained('warning: -shared/-r used with executable output suffix', err)
     self.run_js('out.js')
+
+  def test_shared_and_shared_module_flag(self):
+    # Test that `-shared` and `-s SIDE_MODULE` flag causes wasm dylib generation without a warning.
+    err = self.run_process([EMCC, '-shared', '-s', 'SIDE_MODULE=1', test_file('hello_world.c'), '-o', 'out.foo'], stderr=PIPE).stderr
+    self.assertNotContained('linking a library with `-shared` will emit a static object', err)
+    self.assertIsWasmDylib('out.foo')
+
+    # Test that `-shared` and `-s SIDE_MODULE` flag causes wasm dylib generation without a warning even if given exectuable output name.
+    err = self.run_process([EMCC, '-shared', '-s', 'SIDE_MODULE=1', test_file('hello_world.c'), '-o', 'out.wasm'],
+                           stderr=PIPE).stderr
+    self.assertNotContained('warning: -shared/-r used with executable output suffix', err)
+    self.assertIsWasmDylib('out.wasm')
 
   @no_windows('windows does not support shbang syntax')
   @with_env_modify({'EMMAKEN_JUST_CONFIGURE': '1'})


### PR DESCRIPTION
This modification will enhance compatibility with cmake or auto-tool based projects, which add '-shared' flag when building shared libraries.