### PR TITLE
Avoid disabling asan for memcpy

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -471,9 +471,13 @@ LibraryManager.library = {
     return limit;
   },
 
-#if SHRINK_LEVEL < 2 // In -Oz builds, we replace memcpy() altogether with a non-unrolled wasm variant, so we should never emit emscripten_memcpy_big() in the build.
+  // In -Oz builds, we replace memcpy() altogether with a non-unrolled wasm
+  // variant, so we should never emit emscripten_memcpy_big() in the build.
+  // In STANDALONE_WASM we aviud the emscripten_memcpy_big dependency so keep
+  // the wasm file standalone.
+#if SHRINK_LEVEL < 2 && !STANDALONE_WASM
 
-#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101 || STANDALONE_WASM
+#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 14 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 100101
   // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/copyWithin lists browsers that support TypedArray.prototype.copyWithin, but it
   // has outdated information for Safari, saying it would not support it.
   // https://github.com/WebKit/webkit/commit/24a800eea4d82d6d595cdfec69d0f68e733b5c52#diff-c484911d8df319ba75fce0d8e7296333R1 suggests support was added on Aug 28, 2015.

--- a/system/lib/libc/emscripten_memcpy.c
+++ b/system/lib/libc/emscripten_memcpy.c
@@ -5,21 +5,12 @@
 #include <stdint.h>
 #include <string.h>
 #include <emscripten/emscripten.h>
+#include "libc.h"
 
-// An external JS implementation that is efficient for very large copies, using
-// HEAPU8.set()
-void* emscripten_memcpy_big(void *restrict dest, const void *restrict src, size_t n) EM_IMPORT(emscripten_memcpy_big);
+// Use the simple/naive version of memcpy when building with asan
+#if defined(EMSCRIPTEN_OPTIMIZE_FOR_OZ) || __has_feature(address_sanitizer)
 
-// XXX EMSCRIPTEN ASAN: build an uninstrumented version of memcpy
-#if defined(__EMSCRIPTEN__) && defined(__has_feature)
-#if __has_feature(address_sanitizer)
-#define memcpy __attribute__((no_sanitize("address"))) emscripten_builtin_memcpy
-#endif
-#endif
-
-#ifdef EMSCRIPTEN_OPTIMIZE_FOR_OZ
-
-void *memcpy(void *dest, const void *src, size_t n) {
+static void *__memcpy(void *dest, const void *src, size_t n) {
   unsigned char *d = (unsigned char *)dest;
   const unsigned char *s = (const unsigned char *)src;
 #pragma clang loop unroll(disable)
@@ -29,7 +20,13 @@ void *memcpy(void *dest, const void *src, size_t n) {
 
 #else
 
-void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
+#ifndef EMSCRIPTEN_STANDALONE_WASM
+// An external JS implementation that is efficient for very large copies, using
+// HEAPU8.set()
+void* emscripten_memcpy_big(void *restrict dest, const void *restrict src, size_t n) EM_IMPORT(emscripten_memcpy_big);
+#endif
+
+static void *__memcpy(void *restrict dest, const void *restrict src, size_t n) {
   unsigned char *d = dest;
   const unsigned char *s = src;
 
@@ -37,10 +34,12 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
   unsigned char *block_aligned_d_end;
   unsigned char *d_end;
 
+#ifndef EMSCRIPTEN_STANDALONE_WASM
   if (n >= 512) {
     emscripten_memcpy_big(dest, src, n);
     return dest;
   }
+#endif
 
   d_end = d + n;
   if ((((uintptr_t)d) & 3) == (((uintptr_t)s) & 3)) {
@@ -101,3 +100,6 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t n) {
 }
 
 #endif
+
+weak_alias(__memcpy, emscripten_builtin_memcpy);
+weak_alias(__memcpy, memcpy);

--- a/tests/other/metadce/hello_world.funcs
+++ b/tests/other/metadce/hello_world.funcs
@@ -8,6 +8,7 @@ $__fwritex
 $__lock
 $__lockfile
 $__lshrti3
+$__memcpy
 $__ofl_lock
 $__ofl_unlock
 $__original_main
@@ -35,7 +36,6 @@ $isdigit
 $legalstub$dynCall_jiji
 $main
 $memchr
-$memcpy
 $memset
 $out
 $pad

--- a/tests/other/metadce/hello_world_O1.funcs
+++ b/tests/other/metadce/hello_world_O1.funcs
@@ -3,6 +3,7 @@ $__emscripten_stdout_seek
 $__errno_location
 $__fwritex
 $__lockfile
+$__memcpy
 $__original_main
 $__overflow
 $__stdio_write
@@ -15,7 +16,6 @@ $fputs
 $fwrite
 $legalstub$dynCall_jiji
 $main
-$memcpy
 $puts
 $stackAlloc
 $stackRestore

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1359,7 +1359,7 @@ class libstandalonewasm(MuslInternalLibrary):
   # LTO defeats the weak linking trick used in __original_main.c
   force_object_files = True
 
-  cflags = ['-Os']
+  cflags = ['-Os', '-fno-builtin']
   src_dir = ['system', 'lib']
 
   def __init__(self, **kwargs):
@@ -1374,9 +1374,9 @@ class libstandalonewasm(MuslInternalLibrary):
 
   def get_cflags(self):
     cflags = super().get_cflags()
-    cflags += ['-DNDEBUG']
+    cflags += ['-DNDEBUG', '-DEMSCRIPTEN_STANDALONE_WASM']
     if self.is_mem_grow:
-      cflags += ['-D__EMSCRIPTEN_MEMORY_GROWTH__=1']
+      cflags += ['-DEMSCRIPTEN_MEMORY_GROWTH']
     return cflags
 
   @classmethod
@@ -1391,12 +1391,15 @@ class libstandalonewasm(MuslInternalLibrary):
     )
 
   def get_files(self):
-    base_files = files_in_path(
+    files = files_in_path(
         path_components=['system', 'lib', 'standalone'],
         filenames=['standalone.c', 'standalone_wasm_stdio.c', '__original_main.c',
                    '__main_void.c', '__main_argc_argv.c'])
+    files += files_in_path(
+        path_components=['system', 'lib', 'libc'],
+        filenames=['emscripten_memcpy.c'])
     # It is more efficient to use JS methods for time, normally.
-    time_files = files_in_path(
+    files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'time'],
         filenames=['strftime.c',
                    '__month_to_secs.c',
@@ -1415,10 +1418,10 @@ class libstandalonewasm(MuslInternalLibrary):
                    'time.c'])
     # It is more efficient to use JS for __assert_fail, as it avoids always
     # including fprintf etc.
-    exit_files = files_in_path(
+    files += files_in_path(
         path_components=['system', 'lib', 'libc', 'musl', 'src', 'exit'],
         filenames=['assert.c', 'atexit.c', 'exit.c'])
-    return base_files + time_files + exit_files
+    return files
 
 
 class libjsmath(Library):


### PR DESCRIPTION
Rather than disabling asan during memcpy (which could lead to
real errors going undetected) just use the small/trivial version
of memcpy when building in asan mode.

Also avoid implementing a fake version of emscripten_memcpy_big
in standalone wasm mode.