### PR TITLE
Fix asan false positives in strncpy

### DIFF
--- a/system/lib/libc/musl/src/string/stpncpy.c
+++ b/system/lib/libc/musl/src/string/stpncpy.c
@@ -10,7 +10,8 @@
 
 char *__stpncpy(char *restrict d, const char *restrict s, size_t n)
 {
-#ifdef __GNUC__
+/* XXX EMSCRIPTEN: add __has_feature check */
+#if defined(__GNUC__) && !__has_feature(address_sanitizer)
 	typedef size_t __attribute__((__may_alias__)) word;
 	word *wd;
 	const word *ws;

--- a/tests/other/test_asan_strncpy.c
+++ b/tests/other/test_asan_strncpy.c
@@ -1,0 +1,8 @@
+#include <string.h>
+
+int main() {
+  char from[] = "x";
+  char to[4];
+  strncpy(to, from, sizeof(to));
+  return 0;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9191,7 +9191,10 @@ int main(void) {
     ])
 
   def test_asan_pthread_stubs(self):
-    self.do_smart_test(test_file('other/test_asan_pthread_stubs.c'), emcc_args=['-fsanitize=address', '-sALLOW_MEMORY_GROWTH=1'])
+    self.do_smart_test(test_file('other/test_asan_pthread_stubs.c'), emcc_args=['-fsanitize=address', '-sALLOW_MEMORY_GROWTH'])
+
+  def test_asan_strncpy(self):
+    self.do_smart_test(test_file('other/test_asan_strncpy.c'), emcc_args=['-fsanitize=address', '-sALLOW_MEMORY_GROWTH'])
 
   @node_pthreads
   def test_proxy_to_pthread_stack(self):


### PR DESCRIPTION
This matches the existing patches to other similar functions (See #14652).

Fixes: #14618