### PR TITLE
Proxy abort back to main thread

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -448,6 +448,7 @@ LibraryManager.library = {
   // TODO: There are currently two abort() functions that get imported to asm module scope: the built-in runtime function abort(),
   // and this function _abort(). Remove one of these, importing two functions for the same purpose is wasteful.
   abort__sig: 'v',
+  abort__proxy: 'sync',
   abort: function() {
 #if MINIMAL_RUNTIME
     // In MINIMAL_RUNTIME the module object does not exist, so its behavior to abort is to throw directly.

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -595,7 +595,7 @@ function abort(what) {
 #endif
 
 #if USE_PTHREADS
-  if (ENVIRONMENT_IS_PTHREAD) console.error('Pthread aborting at ' + new Error().stack);
+  assert(!ENVIRONMENT_IS_PTHREAD);
 #endif
   what += '';
   err(what);

--- a/tests/pthread/test_pthread_abort.c
+++ b/tests/pthread/test_pthread_abort.c
@@ -1,0 +1,12 @@
+// Copyright 2021 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+
+#include <stdio.h>
+#include <stdlib.h>
+
+int main() {
+  abort();
+  __builtin_unreachable();
+}

--- a/tests/pthread/test_pthread_abort.out
+++ b/tests/pthread/test_pthread_abort.out
@@ -1,0 +1,1 @@
+onAbort called

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2338,6 +2338,12 @@ The current type of b is: 9
     self.set_setting('EXIT_RUNTIME')
     self.do_run_in_out_file_test('pthread/test_pthread_setspecific_mainthread.c')
 
+  @node_pthreads
+  def test_pthread_abort(self):
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.add_pre_run("Module.onAbort = function() { console.log('onAbort called'); }")
+    self.do_run_in_out_file_test('pthread/test_pthread_abort.c', assert_returncode=NON_ZERO)
+
   def test_tcgetattr(self):
     self.do_runf(test_file('termios/test_tcgetattr.c'), 'success')
 


### PR DESCRIPTION
This allows the `Module.onAbort` handler to be called.

Fixes: #11345