### PR TITLE
Don't run cleanup/atexit code from _exit/_Exit/wasi.proc_exit

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -156,19 +156,16 @@ LibraryManager.library = {
   },
 
   exit__sig: 'vi',
-  exit: function(status) {
 #if MINIMAL_RUNTIME
-    throw 'exit(' + status + ')';
+  // minimal runtime doesn't do any exit cleanup handling so just
+  // map exit directly to the lower-level proc_exit syscall.
+  exit: 'proc_exit',
+  $exit: 'exit',
 #else
+  exit: function(status) {
     // void _exit(int status);
     // http://pubs.opengroup.org/onlinepubs/000095399/functions/exit.html
     exit(status);
-#endif
-  },
-
-#if MINIMAL_RUNTIME
-  $exit: function(status) {
-    throw 'exit(' + status + ')';
   },
 #endif
 

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -5,11 +5,14 @@
  */
 
 var WasiLibrary = {
-  proc_exit__deps: ['exit'],
   proc_exit__nothrow: true,
   proc_exit__sig: 'vi',
   proc_exit: function(code) {
-    _exit(code);
+#if MINIMAL_RUNTIME
+    throw 'exit(' + code + ')';
+#else
+    procExit(code);
+#endif
   },
 
   $getEnvStrings__deps: ['$ENV', '$getExecutableName'],

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -456,17 +456,24 @@ function exit(status, implicit) {
 #if USE_PTHREADS
     PThread.terminateAllThreads();
 #endif
-
     exitRuntime();
-
-#if expectToReceiveOnModule('onExit')
-    if (Module['onExit']) Module['onExit'](status);
-#endif
-
-    ABORT = true;
   }
 
-  quit_(status, new ExitStatus(status));
+  procExit(status);
+}
+
+function procExit(code) {
+  EXITSTATUS = code;
+  if (!keepRuntimeAlive()) {
+#if USE_PTHREADS
+    PThread.terminateAllThreads();
+#endif
+#if expectToReceiveOnModule('onExit')
+    if (Module['onExit']) Module['onExit'](code);
+#endif
+    ABORT = true;
+  }
+  quit_(code, new ExitStatus(code));
 }
 
 #if expectToReceiveOnModule('preInit')


### PR DESCRIPTION
The `_exit/_Exit` C functions are not supposed to run any cleanup
handlers.  They correspond to directly calling the `proc_exit` syscall
which likewise is expected to exit immediately.

See https://github.com/emscripten-core/emscripten/issues/11345#issuecomment-881543893