### PR TITLE
Avoid leaking shadow stack space when explictly unwinding

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3606,9 +3606,11 @@ LibraryManager.library = {
       func();
       return;
     }
+    var sp = stackSave();
     try {
       func();
     } catch (e) {
+      stackRestore(sp);
       if (e instanceof ExitStatus) {
         return;
       } else if (e !== 'unwind') {

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -160,6 +160,7 @@ function callMain(args) {
   var argv = 0;
 #endif // MAIN_READS_PARAMS
 
+  var sp = stackSave(sp);
   try {
 #if BENCHMARK
     var start = Date.now();
@@ -194,6 +195,7 @@ function callMain(args) {
     exit(ret, /* implicit = */ true);
   }
   catch (e) {
+    stackRestore(sp);
     // Certain exception types we do not treat as errors since they are used for
     // internal control flow.
     // 1. ExitStatus, which is thrown by exit()


### PR DESCRIPTION
When user code unwinds the stack by calling
`emscripten_unwind_to_js_event_loop` or
`emscripten_exit_with_live_runtime` we were previously leaking any
shadow stack space used.