### PR TITLE
Avoid marking memcpy/memmove/memset as no_santitize("address").

### DIFF
--- a/system/lib/libc/emscripten_memcpy.c
+++ b/system/lib/libc/emscripten_memcpy.c
@@ -10,11 +10,8 @@
 // HEAPU8.set()
 void* emscripten_memcpy_big(void *restrict dest, const void *restrict src, size_t n) EM_IMPORT(emscripten_memcpy_big);
 
-// XXX EMSCRIPTEN ASAN: build an uninstrumented version of memcpy
-#if defined(__EMSCRIPTEN__) && defined(__has_feature)
 #if __has_feature(address_sanitizer)
-#define memcpy __attribute__((no_sanitize("address"))) emscripten_builtin_memcpy
-#endif
+#define memcpy emscripten_builtin_memcpy
 #endif
 
 #ifdef EMSCRIPTEN_OPTIMIZE_FOR_OZ

--- a/system/lib/libc/emscripten_memmove.c
+++ b/system/lib/libc/emscripten_memmove.c
@@ -1,8 +1,5 @@
-// XXX EMSCRIPTEN ASAN: build an uninstrumented version of memmove
-#if defined(__EMSCRIPTEN__) && defined(__has_feature)
 #if __has_feature(address_sanitizer)
-#define memmove __attribute__((no_sanitize("address"))) emscripten_builtin_memmove
-#endif
+#define memmove emscripten_builtin_memmove
 #endif
 
 #ifdef EMSCRIPTEN_OPTIMIZE_FOR_OZ

--- a/system/lib/libc/emscripten_memset.c
+++ b/system/lib/libc/emscripten_memset.c
@@ -1,8 +1,5 @@
-// XXX EMSCRIPTEN ASAN: build an uninstrumented version of memset
-#if defined(__EMSCRIPTEN__) && defined(__has_feature)
 #if __has_feature(address_sanitizer)
-#define memset __attribute__((no_sanitize("address"))) emscripten_builtin_memset
-#endif
+#define memset emscripten_builtin_memset
 #endif
 
 #ifdef EMSCRIPTEN_OPTIMIZE_FOR_OZ

--- a/system/lib/libc/musl/src/string/memcpy.c
+++ b/system/lib/libc/musl/src/string/memcpy.c
@@ -7,7 +7,8 @@ void *memcpy(void *restrict dest, const void *restrict src, size_t n)
 	unsigned char *d = dest;
 	const unsigned char *s = src;
 
-#ifdef __GNUC__
+/* XXX EMSCRIPTEN: add __has_feature check */
+#if defined(__GNUC__) && !__has_feature(address_sanitizer)
 
 #if __BYTE_ORDER == __LITTLE_ENDIAN
 #define LS >>

--- a/system/lib/libc/musl/src/string/memmove.c
+++ b/system/lib/libc/musl/src/string/memmove.c
@@ -15,7 +15,8 @@ void *memmove(void *dest, const void *src, size_t n)
 	if ((uintptr_t)s-(uintptr_t)d-n <= -2*n) return memcpy(d, s, n);
 
 	if (d<s) {
-#ifdef __GNUC__
+/* XXX EMSCRIPTEN: add __has_feature check */
+#if defined(__GNUC__) && !__has_feature(address_sanitizer)
 		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
 			while ((uintptr_t)d % WS) {
 				if (!n--) return dest;
@@ -26,7 +27,8 @@ void *memmove(void *dest, const void *src, size_t n)
 #endif
 		for (; n; n--) *d++ = *s++;
 	} else {
-#ifdef __GNUC__
+/* XXX EMSCRIPTEN: add __has_feature check */
+#if defined(__GNUC__) && !__has_feature(address_sanitizer)
 		if ((uintptr_t)s % WS == (uintptr_t)d % WS) {
 			while ((uintptr_t)(d+n) % WS) {
 				if (!n--) return dest;

--- a/system/lib/libc/musl/src/string/memset.c
+++ b/system/lib/libc/musl/src/string/memset.c
@@ -29,7 +29,8 @@ void *memset(void *dest, int c, size_t n)
 	n -= k;
 	n &= -4;
 
-#ifdef __GNUC__
+/* XXX EMSCRIPTEN: add __has_feature check */
+#if defined(__GNUC__) && !__has_feature(address_sanitizer)
 	typedef uint32_t __attribute__((__may_alias__)) u32;
 	typedef uint64_t __attribute__((__may_alias__)) u64;
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -719,7 +719,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
 
     # individual files
     ignore += [
-        'memcpy.c', 'memset.c', 'memmove.c', 'getaddrinfo.c', 'getnameinfo.c',
+        'getaddrinfo.c', 'getnameinfo.c',
         'res_query.c', 'res_querydomain.c', 'gai_strerror.c',
         'proto.c', 'gethostbyaddr.c', 'gethostbyaddr_r.c', 'gethostbyname.c',
         'gethostbyname2_r.c', 'gethostbyname_r.c', 'gethostbyname2.c',
@@ -727,7 +727,9 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         'getgrouplist.c', 'initgroups.c', 'wordexp.c', 'timer_create.c',
         'faccessat.c',
         # 'process' exclusion
-        'fork.c', 'vfork.c', 'posix_spawn.c', 'posix_spawnp.c', 'execve.c', 'waitid.c', 'system.c'
+        'fork.c', 'vfork.c', 'posix_spawn.c', 'posix_spawnp.c', 'execve.c', 'waitid.c', 'system.c',
+        # We provide emscripten-optimized versions of these functions
+        'memcpy.c', 'memset.c', 'memmove.c',
     ]
 
     ignore += LIBC_SOCKETS


### PR DESCRIPTION
This is subset of #14653 but a little simplier and also applies to
memset and memmove.