### PR TITLE
Optimize _mm_movemask* intrinsics

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -169,7 +169,7 @@ In addition to consulting the tables below, you can turn on diagnostics for slow
    * - _mm_storeu_si64
      - 💡 emulated with scalar store
    * - _mm_movemask_ps
-     - 💣 No Wasm SIMD support. Emulated in scalar. `simd/#131 <https://github.com/WebAssembly/simd/issues/131>`_
+     - ✅ wasm_i32x4_bitmask
    * - _mm_move_ss
      - 💡 emulated with a shuffle. VM must guess type.
    * - _mm_add_ps
@@ -583,9 +583,9 @@ The following table highlights the availability and expected performance of diff
    * - _mm_move_sd
      - 💡 emulated with a shuffle. VM must guess type.
    * - _mm_movemask_epi8
-     - ❌ scalarized
+     - ✅ wasm_i8x16_bitmask
    * - _mm_movemask_pd
-     - ❌ scalarized
+     - ✅ wasm_i64x2_bitmask
    * - _mm_mul_epu32
      - ❌ scalarized
    * - _mm_mul_pd

--- a/system/include/compat/emmintrin.h
+++ b/system/include/compat/emmintrin.h
@@ -1386,16 +1386,7 @@ _mm_packus_epi16(__m128i __a, __m128i __b)
 static __inline__ int __attribute__((__always_inline__, __nodebug__))
 _mm_movemask_epi8(__m128i __a)
 {
-  // TODO: optimize
-  union {
-    unsigned char x[16];
-    __m128i m;
-  } src;
-  src.m = __a;
-  unsigned int x = 0;
-  for(int i = 0; i < 16; ++i)
-    x |= ((unsigned int)src.x[i] >> 7) << i;
-  return (int)x;
+  return (int)wasm_i8x16_bitmask((v128_t)__a);
 }
 
 #define _mm_shuffle_epi32(__a, __imm) __extension__ ({ \
@@ -1489,12 +1480,7 @@ _mm_unpacklo_pd(__m128d __a, __m128d __b)
 static __inline__ int __attribute__((__always_inline__, __nodebug__))
 _mm_movemask_pd(__m128d __a)
 {
-  union {
-    unsigned long long x[2];
-    __m128d m;
-  } __attribute__((__packed__, __may_alias__)) src;
-  src.m = __a;
-  return (src.x[0] >> 63) | ((src.x[1] >> 63) << 1);
+  return (int)wasm_i64x2_bitmask((v128_t)__a);
 }
 
 #define _mm_shuffle_pd(__a, __b, __i) __extension__ ({ \

--- a/system/include/compat/xmmintrin.h
+++ b/system/include/compat/xmmintrin.h
@@ -197,17 +197,7 @@ _mm_storeu_ps(float *__p, __m128 __a)
 static __inline__ int __attribute__((__always_inline__, __nodebug__))
 _mm_movemask_ps(__m128 __a)
 {
-  // TODO: Use .bitmask instruction when available:
-  // https://github.com/WebAssembly/simd/pull/201
-  union {
-    __m128 __v;
-    unsigned int __x[4];
-  } __attribute__((__packed__, __may_alias__)) __p;
-  __p.__v = __a;
-  return (__p.__x[0] >> 31)
-    | ((__p.__x[1] >> 30) & 2)
-    | ((__p.__x[2] >> 29) & 4)
-    | ((__p.__x[3] >> 28) & 8);
+  return (int)wasm_i32x4_bitmask((v128_t)__a);
 }
 
 static __inline__ __m128 __attribute__((__always_inline__, __nodebug__))


### PR DESCRIPTION
Implement `_mm_movemask_epi8`/`_mm_movemask_ps`/`_mm_movemask_pd` on top of
`wasm_i8x16_bitmask`/`wasm_i32x4_bitmask`/`wasm_i64x2_bitmask` intrinsics from
the final version of WebAssembly SIMD