### PR TITLE
Optimize _mm_mul_epi32/_mm_mul_epu32

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -587,7 +587,7 @@ The following table highlights the availability and expected performance of diff
    * - _mm_movemask_pd
      - ❌ scalarized
    * - _mm_mul_epu32
-     - ❌ scalarized
+     - ⚠️ emulated with wasm_u64x2_extmul_low_u32x4 + 2 shuffles
    * - _mm_mul_pd
      - ✅ wasm_f64x2_mul
    * - _mm_mul_sd
@@ -984,7 +984,7 @@ The following table highlights the availability and expected performance of diff
    * - _mm_mpsadbw_epu8
      - 💣 scalarized
    * - _mm_mul_epi32
-     - ❌ scalarized
+     - ⚠️ emulated with wasm_i64x2_extmul_low_i32x4 + 2 shuffles
    * - _mm_mullo_epi32
      - ✅ wasm_i32x4_mul
    * - _mm_packus_epi32

--- a/system/include/compat/emmintrin.h
+++ b/system/include/compat/emmintrin.h
@@ -724,18 +724,9 @@ _mm_mullo_epi16(__m128i __a, __m128i __b)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_mul_epu32(__m128i __a, __m128i __b)
 {
-  // TODO: optimize
-  unsigned long long a0 = (unsigned long long)(unsigned int)__a[0];
-  unsigned long long a2 = (unsigned long long)(unsigned int)__a[2];
-  unsigned long long b0 = (unsigned long long)(unsigned int)__b[0];
-  unsigned long long b2 = (unsigned long long)(unsigned int)__b[2];
-  union {
-    unsigned long long x[2];
-    __m128i m;
-  } u;
-  u.x[0] = a0*b0;
-  u.x[1] = a2*b2;
-  return u.m;
+  return (__m128i)wasm_u64x2_extmul_low_u32x4(
+      wasm_v32x4_shuffle((v128_t)__a, (v128_t)__a, 0, 2, 0, 2),
+      wasm_v32x4_shuffle((v128_t)__b, (v128_t)__b, 0, 2, 0, 2));
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))

--- a/system/include/compat/smmintrin.h
+++ b/system/include/compat/smmintrin.h
@@ -206,12 +206,12 @@ _mm_mullo_epi32(__m128i __a, __m128i __b)
   return (__m128i)wasm_i32x4_mul(__a, __b);
 }
 
-static __inline__  __m128i __attribute__((__always_inline__, __nodebug__, DIAGNOSE_SLOW))
+static __inline__  __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_mul_epi32(__m128i __a, __m128i __b)
 {
-  return (__m128i)wasm_i64x2_make(
-      wasm_i32x4_extract_lane(__a, 0) * (long long)wasm_i32x4_extract_lane(__b, 0),
-      wasm_i32x4_extract_lane(__a, 2) * (long long)wasm_i32x4_extract_lane(__b, 2));
+  return (__m128i)wasm_i64x2_extmul_low_i32x4(
+      (v128_t)_mm_shuffle_epi32(__a, _MM_SHUFFLE(2, 0, 2, 0)),
+      (v128_t)_mm_shuffle_epi32(__b, _MM_SHUFFLE(2, 0, 2, 0)));
 }
 
 #define _mm_dp_ps(__a, __b, __imm8) __extension__ ({ \


### PR DESCRIPTION
Implement `_mm_mul_epi32`/`_mm_mul_epu32` on top of extended multiplication intrinsics from the final WebAssembly SIMD specification