### PR TITLE
Optimize _mm_mulhi_epi16/_mm_mulhi_epu16

### DIFF
--- a/site/source/docs/porting/simd.rst
+++ b/site/source/docs/porting/simd.rst
@@ -593,9 +593,9 @@ The following table highlights the availability and expected performance of diff
    * - _mm_mul_sd
      - ⚠️ emulated with a shuffle
    * - _mm_mulhi_epi16
-     - ⚠️ emulated with a SIMD four widen+two mul+generic shuffle
+     - ⚠️ emulated with a 2x SIMD extmul+generic shuffle
    * - _mm_mulhi_epu16
-     - ⚠️ emulated with a SIMD four widen+two mul+generic shuffle
+     - ⚠️ emulated with a 2x SIMD extmul+generic shuffle
    * - _mm_mullo_epi16
      - ✅ wasm_i16x8_mul
    * - _mm_or_pd

--- a/system/include/compat/emmintrin.h
+++ b/system/include/compat/emmintrin.h
@@ -678,20 +678,16 @@ _mm_min_epu8(__m128i __a, __m128i __b)
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_mulhi_epi16(__m128i __a, __m128i __b)
 {
-  const v128_t lo = wasm_i32x4_mul(wasm_i32x4_widen_low_i16x8((v128_t)__a),
-                                   wasm_i32x4_widen_low_i16x8((v128_t)__b));
-  const v128_t hi = wasm_i32x4_mul(wasm_i32x4_widen_high_i16x8((v128_t)__a),
-                                   wasm_i32x4_widen_high_i16x8((v128_t)__b));
+  const v128_t lo = wasm_i32x4_extmul_low_i16x8((v128_t)__a, (v128_t)__b);
+  const v128_t hi = wasm_i32x4_extmul_high_i16x8((v128_t)__a, (v128_t)__b);
   return (__m128i)wasm_i16x8_shuffle(lo, hi, 1, 3, 5, 7, 9, 11, 13, 15);
 }
 
 static __inline__ __m128i __attribute__((__always_inline__, __nodebug__))
 _mm_mulhi_epu16(__m128i __a, __m128i __b)
 {
-  const v128_t lo = wasm_i32x4_mul(wasm_u32x4_extend_low_u16x8((v128_t)__a),
-                                   wasm_u32x4_extend_low_u16x8((v128_t)__b));
-  const v128_t hi = wasm_i32x4_mul(wasm_u32x4_extend_high_u16x8((v128_t)__a),
-                                   wasm_u32x4_extend_high_u16x8((v128_t)__b));
+  const v128_t lo = wasm_u32x4_extmul_low_u16x8((v128_t)__a, (v128_t)__b);
+  const v128_t hi = wasm_u32x4_extmul_high_u16x8((v128_t)__a, (v128_t)__b);
   return (__m128i)wasm_i16x8_shuffle(lo, hi, 1, 3, 5, 7, 9, 11, 13, 15);
 }
 


### PR DESCRIPTION
Use extended multiplication instructions from the final WebAssembly SIMD specification for emulation of these intrinsics