### PR TITLE
Remove unknown/unused/untested `timelocal` library function

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -580,7 +580,6 @@ LibraryManager.library = {
 
     return (date.getTime() / 1000)|0;
   },
-  timelocal: 'mktime',
 
 #if MINIMAL_RUNTIME
   gmtime_r__deps: ['allocateUTF8'],


### PR DESCRIPTION
Found when auditing untested library functions.

This alias function was added back in
48a2a87ebac0836508b85bfe82be24f325487a54 as part of the
implemention of time.h function but I can't find anything
about this function existing on any system.

Perhaps it was typo for `localtime`, which is a thing?