### PR TITLE
Remove unused library alias: `__ctime_r`

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -698,7 +698,6 @@ LibraryManager.library = {
     stackRestore(stack);
     return rv;
   },
-  __ctime_r: 'ctime_r',
 
   dysize: function(year) {
     var leap = ((year % 4 == 0) && ((year % 100 != 0) || (year % 400 == 0)));


### PR DESCRIPTION
Found when auditing untested library functions.

This was added as part of #12043 but unlike the other aliases musl does
not use `__ctime_r` anywhere so this alias is completely unused.