### PR TITLE
error on use of longjmp with pthreads + dynamic linking

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1934,18 +1934,23 @@ def phase_linker_setup(options, state, newargs, settings_map):
       if not settings.MINIMAL_RUNTIME:
         settings.EXPORTED_RUNTIME_METHODS += ['ExitStatus']
 
-    if settings.SIDE_MODULE:
-      diagnostics.warning('experimental', '-s SIDE_MODULE + pthreads is experimental')
-    elif settings.MAIN_MODULE:
-      diagnostics.warning('experimental', '-s MAIN_MODULE + pthreads is experimental')
-    elif settings.LINKABLE:
-      diagnostics.warning('experimental', '-s LINKABLE + pthreads is experimental')
+    if settings.RELOCATABLE:
+      # phtreads + dyanmic linking has certain limitations
+      if settings.SIDE_MODULE:
+        diagnostics.warning('experimental', '-s SIDE_MODULE + pthreads is experimental')
+      elif settings.MAIN_MODULE:
+        diagnostics.warning('experimental', '-s MAIN_MODULE + pthreads is experimental')
+      elif settings.LINKABLE:
+        diagnostics.warning('experimental', '-s LINKABLE + pthreads is experimental')
+
+      default_setting('SUPPORT_LONGJMP', 0)
+      if settings.SUPPORT_LONGJMP:
+        exit_with_error('SUPPORT_LONGJMP is not compatible with pthreads + dynamic linking')
 
     if settings.PROXY_TO_WORKER:
       exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
-  else:
-    if settings.PROXY_TO_PTHREAD:
-      exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
+  elif settings.PROXY_TO_PTHREAD:
+    exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
 
   def check_memory_setting(setting):
     if settings[setting] % webassembly.WASM_PAGE_SIZE != 0:

--- a/src/library.js
+++ b/src/library.js
@@ -1500,6 +1500,7 @@ LibraryManager.library = {
   _emscripten_throw_longjmp__sig: 'v',
   _emscripten_throw_longjmp: function() { throw 'longjmp'; },
 #if !SUPPORT_LONGJMP
+#if !INCLUDE_FULL_LIBRARY
   // These are in order to print helpful error messages when either longjmp of
   // setjmp is used.
   longjmp__deps: [function() {
@@ -1516,6 +1517,7 @@ LibraryManager.library = {
   get _emscripten_throw_longjmp__deps() {
     return this.longjmp__deps;
   },
+#endif
   // will never be emitted, as the dep errors at compile time
   longjmp__unimplemented: true,
   longjmp: function(env, value) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1636,6 +1636,14 @@ int f() {
         'side.wasm',
       ])
 
+  def test_dylink_pthread_warning(self):
+    err = self.expect_fail([EMCC, '-Werror', '-sMAIN_MODULE', '-sUSE_PTHREADS', test_file('hello_world.c')])
+    self.assertContained('error: -s MAIN_MODULE + pthreads is experimental', err)
+
+  def test_dylink_pthread_longjmp(self):
+    err = self.expect_fail([EMCC, '-sMAIN_MODULE', '-sUSE_PTHREADS', '-sSUPPORT_LONGJMP', test_file('hello_world.c')])
+    self.assertContained('SUPPORT_LONGJMP is not compatible with pthreads + dynamic linking', err)
+
   def test_dylink_no_autoload(self):
     create_file('main.c', r'''
       #include <stdio.h>


### PR DESCRIPTION
This relies on exporting TLS symbols which we currently do not support.

By default we disable SUPPORT_LONGJMP in this configuration.  If the
user tries to explicitly enable it we error out.

See #14461