### PR TITLE
Optimize memcmp

### DIFF
--- a/system/lib/libc/musl/src/string/memcmp.c
+++ b/system/lib/libc/musl/src/string/memcmp.c
@@ -1,8 +1,32 @@
+#if __EMSCRIPTEN__
+#include <stdint.h>
+#endif
 #include <string.h>
 
 int memcmp(const void *vl, const void *vr, size_t n)
 {
 	const unsigned char *l=vl, *r=vr;
+
+// XXX EMSCRIPTEN: add an optimized version.
+#if !defined(EMSCRIPTEN_OPTIMIZE_FOR_OZ) && !__has_feature(address_sanitizer)
+	// If we have enough bytes, and everything is aligned, loop on words instead
+	// of single bytes.
+	if (n >= 4 && ((((uintptr_t)l) & 3) | (((uintptr_t)r) & 3))) {
+		while (n >= 4) {
+			if (*((uint32_t *)l) != *((uint32_t *)r)) {
+				// Go to the single-byte loop to find the specific byte.
+				break;
+			}
+			l += 4;
+			r += 4;
+			n -= 4;
+		}
+	}
+#endif
+
+#if defined(EMSCRIPTEN_OPTIMIZE_FOR_OZ)
+#pragma clang loop unroll(disable)
+#endif
 	for (; n && *l == *r; n--, l++, r++);
 	return n ? *l-*r : 0;
 }

--- a/system/lib/libc/musl/src/string/memcmp.c
+++ b/system/lib/libc/musl/src/string/memcmp.c
@@ -11,7 +11,7 @@ int memcmp(const void *vl, const void *vr, size_t n)
 #if !defined(EMSCRIPTEN_OPTIMIZE_FOR_OZ) && !__has_feature(address_sanitizer)
 	// If we have enough bytes, and everything is aligned, loop on words instead
 	// of single bytes.
-	if (n >= 4 && ((((uintptr_t)l) & 3) | (((uintptr_t)r) & 3))) {
+	if (n >= 4 && !((((uintptr_t)l) & 3) | (((uintptr_t)r) & 3))) {
 		while (n >= 4) {
 			if (*((uint32_t *)l) != *((uint32_t *)r)) {
 				// Go to the single-byte loop to find the specific byte.


### PR DESCRIPTION
This does similar things to what we already do for memcpy etc.,
doing word-sized operations where possible.

On artificial benchmarks this is up to 3.7x faster. This is motivated
by a real-world benchmark where memcmp is very high in the profile.

For consistency, also apply `EMSCRIPTEN_OPTIMIZE_FOR_OZ` as we
do for memcpy etc., to not unroll loops in clang in that case.