### PR TITLE
Split out C++ code in of gen_struct_info.py. NFC

### DIFF
--- a/src/struct_info_cxx.json
+++ b/src/struct_info_cxx.json
@@ -1,0 +1,14 @@
+[
+    {
+        "file": "cxa_exception.h",
+        "structs": {
+            "__cxxabiv1::__cxa_exception": [
+              "exceptionDestructor",
+              "referenceCount",
+              "exceptionType",
+              "caught",
+              "rethrown"
+            ]
+        }
+    }
+]

--- a/src/struct_info_internal.json
+++ b/src/struct_info_internal.json
@@ -40,17 +40,5 @@
               "global_locale"
             ]
         }
-    },
-    {
-        "file": "cxa_exception.h",
-        "structs": {
-            "__cxxabiv1::__cxa_exception": [
-              "exceptionDestructor",
-              "referenceCount",
-              "exceptionType",
-              "caught",
-              "rethrown"
-            ]
-        }
     }
 ]


### PR DESCRIPTION
This was split out from #13006 since the newer musl internal headers
don't parse in C++ mode.