### PR TITLE
Fix PROXYFS seek end bug

### DIFF
--- a/src/library_proxyfs.js
+++ b/src/library_proxyfs.js
@@ -199,7 +199,7 @@ mergeInto(LibraryManager.library, {
         } else if (whence === {{{ cDefine('SEEK_END') }}}) {
           if (FS.isFile(stream.node.mode)) {
             try {
-              var stat = stream.node.mount.opts.fs.fstat(stream.nfd);
+              var stat = stream.node.node_ops.getattr(stream.node);
               position += stat.size;
             } catch (e) {
               throw new FS.ErrnoError(ERRNO_CODES[e.code]);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -3028,7 +3028,6 @@ EMSCRIPTEN_KEEPALIVE int myreadSeekEnd() {
     self.assertContained(section + ":m1 read:test1", out)
     self.assertContained(section + ":m2 read:test2", out)
     self.assertContained(section + ":m0 read m0:test0_0", out)
-
     section = "test seek."
     self.assertContained(section + ":file size:6", out)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2871,6 +2871,10 @@ print("m2 read");
 m2.ccall('myread0','number',[],[]);
 print("m0 read m0");
 m0.ccall('myread0','number',[],[]);
+
+section = "test seek.";
+print("file size");
+m0.ccall('myreadSeekEnd', 'number', [], []);
 ''')
 
     create_file('proxyfs_pre.js', r'''
@@ -2969,6 +2973,18 @@ EMSCRIPTEN_KEEPALIVE int myreade() {
   fclose(in);
   return 0;
 }
+
+EMSCRIPTEN_KEEPALIVE int myreadSeekEnd() {
+  FILE* in = fopen("/working2/hoge.txt","r");
+
+  fseek(in, 0L, SEEK_END);
+  int fileSize = ftell(in);
+  fseek(in, 0L, SEEK_SET);
+  printf("%d\n", fileSize);
+
+  fclose(in);
+  return 0;
+}
 ''')
 
     self.run_process([EMCC,
@@ -3012,6 +3028,9 @@ EMSCRIPTEN_KEEPALIVE int myreade() {
     self.assertContained(section + ":m1 read:test1", out)
     self.assertContained(section + ":m2 read:test2", out)
     self.assertContained(section + ":m0 read m0:test0_0", out)
+
+    section = "test seek."
+    self.assertContained(section + ":file size:6", out)
 
   def test_dependency_file(self):
     # Issue 1732: -MMD (and friends) create dependency files that need to be


### PR DESCRIPTION
This PR addresses https://github.com/emscripten-core/emscripten/issues/12367 (cc @vadimkantorov @junjihashimoto @sbc100):

* Use vadimkantorov's patch to `library_proxyfs.js` (thanks!)
* To prevent this from happening in the future, I added an additional test to make sure we can get the correct file size of a file mounted on a `PROXYFS` filesystem

### Tests

The additional tests calculates the file size of the file `/working2/hoge.txt`, which is 6 bytes, but currently returns 0. Note: `working2/` is the folder that mounts the filesystem of module 2.

#### Before the patch:

```bash
$ tests/runner --verbose other.test_proxyfs
[...]
parent m0 writes and reads children's files.:m0 read m0:test0_0
test seek.:file size:0
```

#### After the patch:

```bash
$ tests/runner --verbose other.test_proxyfs
[...]
parent m0 writes and reads children's files.:m0 read m0:test0_0
test seek.:file size:6
```
