### PR TITLE
Move entry points for pthread_create/join/detach to native code. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1859,6 +1859,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
       '_emscripten_tls_init',
       '_pthread_self',
       '_pthread_testcancel',
+      '_pthread_exit',
     ]
     # Some of these symbols are using by worker.js but otherwise unreferenced.
     # Because emitDCEGraph only considered the main js file, and not worker.js

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -662,9 +662,9 @@ var LibraryPThread = {
     return navigator['hardwareConcurrency'];
   },
     
-  {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create__sig: 'iiiii',
-  {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create__deps: ['$spawnThread', 'pthread_self', 'memalign', 'emscripten_sync_run_in_main_thread_4'],
-  {{{ USE_LSAN || USE_ASAN ? 'emscripten_builtin_' : '' }}}pthread_create: function(pthread_ptr, attr, start_routine, arg) {
+  __pthread_create_js__sig: 'iiiii',
+  __pthread_create_js__deps: ['$spawnThread', 'pthread_self', 'memalign', 'emscripten_sync_run_in_main_thread_4'],
+  __pthread_create_js: function(pthread_ptr, attr, start_routine, arg) {
     if (typeof SharedArrayBuffer === 'undefined') {
       err('Current environment does not support SharedArrayBuffer, pthreads are not available!');
       return {{{ cDefine('EAGAIN') }}};
@@ -957,8 +957,8 @@ var LibraryPThread = {
     }
   },
 
-  {{{ USE_LSAN ? 'emscripten_builtin_' : '' }}}pthread_join__deps: ['_emscripten_do_pthread_join'],
-  {{{ USE_LSAN ? 'emscripten_builtin_' : '' }}}pthread_join: function(thread, status) {
+  __pthread_join_js__deps: ['_emscripten_do_pthread_join'],
+  __pthread_join_js: function(thread, status) {
     return __emscripten_do_pthread_join(thread, status, true);
   },
 
@@ -1012,8 +1012,8 @@ var LibraryPThread = {
     return 0;
   },
 
-  {{{ USE_LSAN ? 'emscripten_builtin_' : '' }}}pthread_detach__sig: 'vi',
-  {{{ USE_LSAN ? 'emscripten_builtin_' : '' }}}pthread_detach: function(thread) {
+  __pthread_detach_js__sig: 'vi',
+  __pthread_detach_js: function(thread) {
     if (!thread) {
       err('pthread_detach attempted on a null thread pointer!');
       return ERRNO_CODES.ESRCH;
@@ -1031,16 +1031,8 @@ var LibraryPThread = {
     return wasDetached ? ERRNO_CODES.EINVAL : 0;
   },
 
-  // C11 thread version.
-  // TODO: remove this in favor or compiling musl/src/thread/pthread_detach.c
-#if USE_LSAN
-  thrd_detach: 'emscripten_builtin_pthread_detach',
-#else
-  thrd_detach: 'pthread_detach',
-#endif
-
-  pthread_exit__deps: ['exit'],
-  pthread_exit: function(status) {
+  __pthread_exit_js__deps: ['exit'],
+  __pthread_exit_js: function(status) {
     if (!ENVIRONMENT_IS_PTHREAD) _exit(status);
     else PThread.threadExit(status);
     // pthread_exit is marked noReturn, so we must not return from it.

--- a/system/lib/libc/musl/src/thread/thrd_create.c
+++ b/system/lib/libc/musl/src/thread/thrd_create.c
@@ -1,11 +1,6 @@
 #include "pthread_impl.h"
 #include <threads.h>
 
-// XXX Emscripten implements pthread_create directly rather than __pthread_create
-#ifdef __EMSCRIPTEN__
-#define __pthread_create pthread_create
-#endif
-
 int __pthread_create(pthread_t *restrict, const pthread_attr_t *restrict, void *(*)(void *), void *restrict);
 
 int thrd_create(thrd_t *thr, thrd_start_t func, void *arg)

--- a/system/lib/libc/musl/src/thread/thrd_exit.c
+++ b/system/lib/libc/musl/src/thread/thrd_exit.c
@@ -1,11 +1,6 @@
 #include "pthread_impl.h"
 #include <threads.h>
 
-// XXX Emscripten implements pthread_exit directly rather than __pthread_exit
-#ifdef __EMSCRIPTEN__
-#define __pthread_exit pthread_exit
-#endif
-
 _Noreturn void __pthread_exit(void *);
 
 _Noreturn void thrd_exit(int result)

--- a/system/lib/libc/musl/src/thread/thrd_join.c
+++ b/system/lib/libc/musl/src/thread/thrd_join.c
@@ -1,11 +1,6 @@
 #include <stdint.h>
 #include <threads.h>
 
-// XXX Emscripten implements implements pthread_join directly rather than __pthread_join
-#ifdef __EMSCRIPTEN__
-#define __pthread_join pthread_join
-#endif
-
 int __pthread_join(thrd_t, void**);
 
 int thrd_join(thrd_t t, int *res)

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -182,7 +182,7 @@ extern int _emscripten_notify_thread_queue(pthread_t targetThreadId, pthread_t m
 #if __has_feature(leak_sanitizer) || __has_feature(address_sanitizer)
 #define HAS_SANITIZER
 #include <sanitizer/lsan_interface.h>
-int emscripten_builtin_pthread_create(void *thread, void *attr,
+int emscripten_builtin_pthread_create(pthread_t *thread, const pthread_attr_t* attr,
                                       void *(*callback)(void *), void *arg);
 #endif
 #endif
@@ -975,3 +975,32 @@ void __emscripten_pthread_data_constructor(void) {
   initPthreadsJS();
   pthread_self()->locale = &libc.global_locale;
 }
+
+extern int __pthread_create_js(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine) (void *), void *arg);
+
+int __pthread_create(pthread_t *thread, const pthread_attr_t *attr, void *(*start_routine) (void *), void *arg) {
+  return __pthread_create_js(thread, attr, start_routine, arg);
+}
+weak_alias(__pthread_create, emscripten_builtin_pthread_create);
+weak_alias(__pthread_create, pthread_create);
+
+extern int __pthread_join_js(pthread_t thread, void **retval);
+int __pthread_join(pthread_t thread, void **retval) {
+  return __pthread_join_js(thread, retval);
+}
+weak_alias(__pthread_join, emscripten_builtin_pthread_join);
+weak_alias(__pthread_join, pthread_join);
+
+extern int __pthread_detach_js(pthread_t t);
+int __pthread_detach(pthread_t t) {
+  return __pthread_detach_js(t);
+}
+weak_alias(__pthread_detach, emscripten_builtin_pthread_detach);
+weak_alias(__pthread_detach, pthread_detach);
+weak_alias(__pthread_detach, thrd_detach);
+
+extern _Noreturn void __pthread_exit_js(void* status);
+_Noreturn void __pthread_exit(void* status) {
+   __pthread_exit_js(status);
+}
+weak_alias(__pthread_exit, pthread_exit);

--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -212,9 +212,11 @@ int pthread_cancel(pthread_t thread) {
   return 0;
 }
 
-_Noreturn void pthread_exit(void* status) {
+_Noreturn void __pthread_exit(void* status) {
    exit((int)status);
 }
+
+weak_alias(__pthread_exit, pthread_exit);
 
 int __pthread_detach(pthread_t t) {
   return 0;

--- a/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -37,6 +37,7 @@ $emscripten_tls_init
 $free_tls
 $init_mparams
 $main
+$pthread_create
 $sbrk
 $stackAlloc
 $stackRestore


### PR DESCRIPTION
This avoids the nasty syntax for adjusting the names of the
functions and paves the way for all/part of the code to be
moved to native.  This also helps with the pending musl upgrade.