### PR TITLE
Use seprate system libraries for thinLTO

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -842,10 +842,10 @@ def get_cflags(options, user_args):
     cflags.append('-fvisibility=default')
 
   if settings.LTO:
-    cflags.append('-flto=' + settings.LTO)
+    if not any(a.startswith('-flto') for a in user_args):
+      cflags.append('-flto=' + settings.LTO)
   else:
-    # With LTO mode these args get passed instead
-    # at link time when the backend runs.
+    # In LTO mode these args get passed instead at link time when the backend runs.
     for a in building.llvm_backend_args():
       cflags += ['-mllvm', a]
 

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -109,7 +109,10 @@ class Cache:
     # if relevant, use a subdir of the cache
     subdir = []
     if settings.LTO:
-      subdir.append('lto')
+      if settings.LTO == 'thin':
+        subdir.append('thinlto')
+      else:
+        subdir.append('lto')
     if settings.RELOCATABLE:
       subdir.append('pic')
     if subdir:


### PR DESCRIPTION
Also, avoid passing `-flto` more than once to the compiler.

ThinLTO is still pretty much untested, both here, and upstream.  This
change doesn't effect that but does fix a real issue.

Fixes: #14694