### PR TITLE
Use musl version of pthread_setcancelstate. NFC

### DIFF
--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -101,16 +101,6 @@ int pthread_mutexattr_setprioceiling(pthread_mutexattr_t *attr, int prioceiling)
   return EPERM;
 }
 
-int pthread_setcancelstate(int new, int* old) {
-  if (new > 1U)
-    return EINVAL;
-  struct pthread* self = pthread_self();
-  if (old)
-    *old = self->canceldisable;
-  self->canceldisable = new;
-  return 0;
-}
-
 int _pthread_isduecanceled(struct pthread* pthread_ptr) {
   return pthread_ptr->threadStatus == 2 /*canceled*/;
 }


### PR DESCRIPTION
The C version of this function in library_pthread.c was identical to the
musl version except the musl version allows values of <=2 as opposed to
<=1.  This difference doesn't appear to be material or intentional.

The custom C version seems to have been ported from the original JS
version back in 64088da3a3291d916b571379ad598170f1ffa25c.