### PR TITLE
Propagate errors thrown after Asyncify call

### DIFF
--- a/src/library_async.js
+++ b/src/library_async.js
@@ -48,7 +48,7 @@ mergeInto(LibraryManager.library, {
     callStackIdToName: {},
     callStackId: 0,
     afterUnwind: null,
-    asyncFinalizers: [], // functions to run when *all* asynchronicity is done
+    asyncPromiseHandlers: null, // { resolve, reject } pair for when *all* asynchronicity is done
     sleepCallbacks: [], // functions to call every time we sleep
 
     getCallStackId: function(funcName) {
@@ -151,10 +151,13 @@ mergeInto(LibraryManager.library, {
     whenDone: function() {
 #if ASSERTIONS
       assert(Asyncify.currData, 'Tried to wait for an async operation when none is in progress.');
-      assert(!Asyncify.asyncFinalizers.length, 'Cannot have multiple async operations in flight at once');
+      assert(!Asyncify.asyncPromiseHandlers, 'Cannot have multiple async operations in flight at once');
 #endif
-      return new Promise(function(resolve) {
-        Asyncify.asyncFinalizers.push(resolve);
+      return new Promise(function(resolve, reject) {
+        Asyncify.asyncPromiseHandlers = {
+          resolve: resolve,
+          reject: reject
+        };
       });
     },
 
@@ -247,7 +250,13 @@ mergeInto(LibraryManager.library, {
           if (typeof Browser !== 'undefined' && Browser.mainLoop.func) {
             Browser.mainLoop.resume();
           }
-          var asyncWasmReturnValue = Asyncify.doRewind(Asyncify.currData);
+          var asyncWasmReturnValue, isError = false;
+          try {
+            asyncWasmReturnValue = Asyncify.doRewind(Asyncify.currData);
+          } catch (err) {
+            asyncWasmReturnValue = err;
+            isError = true;
+          }
           if (!Asyncify.currData) {
             // All asynchronous execution has finished.
             // `asyncWasmReturnValue` now contains the final
@@ -261,11 +270,11 @@ mergeInto(LibraryManager.library, {
             // contains the return value of the exported WASM function
             // that may have called C functions that
             // call `Asyncify.handleSleep()`.
-            var asyncFinalizers = Asyncify.asyncFinalizers;
-            Asyncify.asyncFinalizers = [];
-            asyncFinalizers.forEach(function(func) {
-              func(asyncWasmReturnValue);
-            });
+            var asyncPromiseHandlers = Asyncify.asyncPromiseHandlers;
+            if (asyncPromiseHandlers) {
+              Asyncify.asyncPromiseHandlers = null;
+              (isError ? asyncPromiseHandlers.reject : asyncPromiseHandlers.resolve)(asyncWasmReturnValue);
+            }
           }
         });
         reachedAfterCallback = true;

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -257,6 +257,7 @@ mergeInto(LibraryManager.library, {
             asyncWasmReturnValue = err;
             isError = true;
           }
+          // Track whether the return value was handled by any promise handlers.
           var handled = false;
           if (!Asyncify.currData) {
             // All asynchronous execution has finished.
@@ -279,6 +280,9 @@ mergeInto(LibraryManager.library, {
             }
           }
           if (isError && !handled) {
+            // If there was an error and it was not handled by now, we have no choice but to
+            // rethrow that error into the global scope where it can be caught only by
+            // `onerror` or `onunhandledpromiserejection`.
             throw asyncWasmReturnValue;
           }
         });

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -257,6 +257,7 @@ mergeInto(LibraryManager.library, {
             asyncWasmReturnValue = err;
             isError = true;
           }
+          var handled = false;
           if (!Asyncify.currData) {
             // All asynchronous execution has finished.
             // `asyncWasmReturnValue` now contains the final
@@ -274,7 +275,11 @@ mergeInto(LibraryManager.library, {
             if (asyncPromiseHandlers) {
               Asyncify.asyncPromiseHandlers = null;
               (isError ? asyncPromiseHandlers.reject : asyncPromiseHandlers.resolve)(asyncWasmReturnValue);
+              handled = true;
             }
+          }
+          if (isError && !handled) {
+            throw asyncWasmReturnValue;
           }
         });
         reachedAfterCallback = true;

--- a/tests/core/embind_lib_with_asyncify.cpp
+++ b/tests/core/embind_lib_with_asyncify.cpp
@@ -11,6 +11,11 @@ EM_JS(int, sleep_and_return, (int x), {
 	return Asyncify.handleSleep(wakeUp => setTimeout(wakeUp, 10, x));
 });
 
+void delayed_throw() {
+	sleep_and_return(0);
+	EM_ASM({ throw new Error('my message'); });
+}
+
 int foo() {
 	return sleep_and_return(10);
 }
@@ -40,6 +45,7 @@ private:
 };
 
 EMSCRIPTEN_BINDINGS(embind_async) {
+	function("delayed_throw", &delayed_throw);
 	function("foo", &foo);
 
 	class_<Bar>("Bar")

--- a/tests/core/embind_lib_with_asyncify.test.js
+++ b/tests/core/embind_lib_with_asyncify.test.js
@@ -1,5 +1,10 @@
 Module.onRuntimeInitialized = async () => {
   try {
+    let delayedThrowResult = Module.delayed_throw();
+    assert(delayedThrowResult instanceof Promise);
+    let err = await delayedThrowResult.then(() => '', err => err.message);
+    assert(err === 'my message', `"${err}" doesn't contain the expected error`);
+
     let fooResult = Module.foo();
     assert(fooResult instanceof Promise);
     fooResult = await fooResult;
@@ -29,7 +34,7 @@ Module.onRuntimeInitialized = async () => {
       } catch (e) {
         err = e.message;
       }
-      assert(err.startsWith('abort(Assertion failed: Cannot have multiple async operations in flight at once)'));
+      assert(err.startsWith('abort(Assertion failed: Cannot have multiple async operations in flight at once)'), `"${err}" doesn't contain the assertion error`);
     }
 
     console.log('ok');


### PR DESCRIPTION
Previously any errors thrown after an Asyncify pause would be asynchronously thrown in a global context, with no way to catch and handle them except for `window.onerror`.

This PR builds on top of #14664, catches such errors and reports them as Promise rejections on outermost `ccall` or Embind invocation.

I also replaced `asyncFinalizers` array with a single object, since we forbid using more than one finalize in-progress anyway.