### PR TITLE
Avoid use of EM_ASM in atomic_arch.h. NFC

### DIFF
--- a/system/lib/libc/emscripten_pthread.c
+++ b/system/lib/libc/emscripten_pthread.c
@@ -1,6 +1,7 @@
 #include <pthread.h>
 #include "libc.h"
 #include "pthread_impl.h"
+#include <emscripten.h>
 
 #if !__EMSCRIPTEN_PTHREADS__
 static struct pthread __main_pthread;

--- a/system/lib/libc/musl/arch/emscripten/atomic_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/atomic_arch.h
@@ -2,8 +2,6 @@
 #define _INTERNAL_ATOMIC_H
 
 #include <stdint.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
 
 #define a_clz_l __builtin_clz
 #define a_ctz_l __builtin_ctz
@@ -107,7 +105,7 @@ static inline void a_spin()
 #define a_crash a_crash
 static inline void a_crash()
 {
-  EM_ASM( abort() );
+  __builtin_trap();
 }
 
 #endif

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -1,6 +1,6 @@
 #include <wasi/api.h>
 #include <wasi/wasi-helpers.h>
-#include <emscripten/emscripten.h>
+#include <emscripten/em_macros.h>
 
 #define __SYSCALL_LL_E(x) \
 ((union { long long ll; long l[2]; }){ .ll = x }).l[0], \


### PR DESCRIPTION
Also avoid including emscripten headers unnecessarily.