### PR TITLE
Fix Asyncify + Closure

### DIFF
--- a/src/closure-externs/dyncall-externs.js
+++ b/src/closure-externs/dyncall-externs.js
@@ -1,0 +1,24 @@
+/**
+ * If DYNCALLS is enabled, then we will emit dynCall_* calls. If we happen to
+ * emit JS with such a call, but that code path is never reached, and the wasm
+ * does not contain any method with that signature, then we would not emit a
+ * dynCall_* method and closure would error.
+ */
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
+var dynCall_v;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
+var dynCall_vi;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
+var dynCall_vii;
+/**
+ * @suppress {duplicate, undefinedVars}
+ */
+var dynCall_iii;
+
+

--- a/src/closure-externs/dyncall-externs.js
+++ b/src/closure-externs/dyncall-externs.js
@@ -2,7 +2,13 @@
  * If DYNCALLS is enabled, then we will emit dynCall_* calls. If we happen to
  * emit JS with such a call, but that code path is never reached, and the wasm
  * does not contain any method with that signature, then we would not emit a
- * dynCall_* method and closure would error.
+ * dynCall_* method and closure would error. Define the common signatures here
+ * to avoid that.
+ *
+ * TODO: Fix https://github.com/emscripten-core/emscripten/issues/13858 in
+ *       another way, either by landing
+ *       https://github.com/emscripten-core/emscripten/pull/12088 or otherwise
+ *       removing DYNCALLS.
  */
 /**
  * @suppress {duplicate, undefinedVars}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7456,6 +7456,7 @@ Module['onRuntimeInitialized'] = function() {
   @no_asan('asyncify stack operations confuse asan')
   def test_fibers_asyncify(self):
     self.set_setting('ASYNCIFY')
+    self.maybe_closure()
     self.do_runf(test_file('test_fibers.cpp'), '*leaf-0-100-1-101-1-102-2-103-3-104-5-105-8-106-13-107-21-108-34-109-*')
 
   def test_asyncify_unused(self):

--- a/tools/building.py
+++ b/tools/building.py
@@ -820,6 +820,9 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
                          if name.endswith('.js')]
       CLOSURE_EXTERNS += BROWSER_EXTERNS
 
+  if settings.DYNCALLS:
+    CLOSURE_EXTERNS += [path_from_root('src', 'closure-externs', 'dyncall-externs.js')]
+
   if settings.MINIMAL_RUNTIME and settings.USE_PTHREADS and not settings.MODULARIZE:
     CLOSURE_EXTERNS += [path_from_root('src', 'minimal_runtime_worker_externs.js')]
 


### PR DESCRIPTION
Asyncify enables `DYNCALLS`, and closure + `DYNCALLS` regressed
in #12046 which removed the closure externs for them. This restores the
externs only in `DYNCALLS` mode at least, which avoids it affecting the
normal mode.

Fixes #13858