### PR TITLE
Interleave stdout and stderr in test output. NFC

### DIFF
--- a/tests/other/test_standalone_syscalls.cpp
+++ b/tests/other/test_standalone_syscalls.cpp
@@ -25,7 +25,7 @@ int main() {
   write(1, "\n", 1);
   // emscripten_log API works
   emscripten_console_log("log");
-  // warnings/errors go to stderr, and are not noticed in this test
+  // warnings/errors go to stderr
   emscripten_console_warn("warn");
   emscripten_console_error("error");
   emscripten_console_log("log2");

--- a/tests/other/test_standalone_syscalls.out
+++ b/tests/other/test_standalone_syscalls.out
@@ -1,3 +1,5 @@
 hello
 log
+warn
+error
 log2

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -327,7 +327,7 @@ class TestCoreBase(RunnerCore):
 
   def test_int53(self):
     self.emcc_args += ['-s', 'DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[$convertI32PairToI53,$convertU32PairToI53,$readI53FromU64,$readI53FromI64,$writeI53ToI64,$writeI53ToI64Clamped,$writeI53ToU64Clamped,$writeI53ToI64Signaling,$writeI53ToU64Signaling]']
-    self.do_core_test('test_int53.c')
+    self.do_core_test('test_int53.c', interleaved_output=False)
 
   def test_i64(self):
     self.do_core_test('test_i64.c')
@@ -2311,7 +2311,7 @@ The current type of b is: 9
 
   @node_pthreads
   def test_pthread_dispatch_after_exit(self):
-    self.do_run_in_out_file_test('pthread/test_pthread_dispatch_after_exit.c')
+    self.do_run_in_out_file_test('pthread/test_pthread_dispatch_after_exit.c', interleaved_output=False)
 
   @node_pthreads
   def test_pthread_nested_work_queue(self):
@@ -2396,9 +2396,9 @@ The current type of b is: 9
   def test_memcpy_memcmp(self):
     self.banned_js_engines = [config.V8_ENGINE] # Currently broken under V8_ENGINE but not node
 
-    def check(result, err):
-      result = result.replace('\n \n', '\n') # remove extra node output
-      return hashlib.sha1(result.encode('utf-8')).hexdigest()
+    def check(output):
+      output = output.replace('\n \n', '\n') # remove extra node output
+      return hashlib.sha1(output.encode('utf-8')).hexdigest()
 
     self.do_core_test('test_memcpy_memcmp.c', output_nicerizer=check)
 
@@ -2742,7 +2742,7 @@ The current type of b is: 9
       }
       '''
     self.do_run(src, 'Sort with main comparison: 5 4 3 2 1 *Sort with lib comparison: 1 2 3 4 5 *',
-                output_nicerizer=lambda x, err: x.replace('\n', '*'))
+                output_nicerizer=lambda x: x.replace('\n', '*'))
 
   @needs_dylink
   def test_dlfcn_data_and_fptr(self):
@@ -4854,8 +4854,8 @@ Module = {
     mem_file = 'files.js.mem'
     try_delete(mem_file)
 
-    def clean(out, err):
-      return '\n'.join([line for line in (out + err).split('\n') if 'binaryen' not in line and 'wasm' not in line and 'so not running' not in line])
+    def clean(out):
+      return '\n'.join([line for line in out.split('\n') if 'binaryen' not in line and 'wasm' not in line and 'so not running' not in line])
 
     self.do_runf(test_file('files.cpp'), ('size: 7\ndata: 100,-56,50,25,10,77,123\nloop: 100 -56 50 25 10 77 123 \ninput:hi there!\ntexto\n$\n5 : 10,30,20,11,88\nother=some data.\nseeked=me da.\nseeked=ata.\nseeked=ta.\nfscanfed: 10 - hello\n5 bytes to dev/null: 5\nok.\ntexte\n', 'size: 7\ndata: 100,-56,50,25,10,77,123\nloop: 100 -56 50 25 10 77 123 \ninput:hi there!\ntexto\ntexte\n$\n5 : 10,30,20,11,88\nother=some data.\nseeked=me da.\nseeked=ata.\nseeked=ta.\nfscanfed: 10 - hello\n5 bytes to dev/null: 5\nok.\n'),
                  output_nicerizer=clean)
@@ -4891,8 +4891,8 @@ Module = {
       }
       '''
 
-    def clean(out, err):
-      return '\n'.join(l for l in (out + err).splitlines() if 'warning' not in l and 'binaryen' not in l)
+    def clean(out):
+      return '\n'.join(l for l in out.splitlines() if 'warning' not in l and 'binaryen' not in l)
 
     self.do_run(src, ('got: 35\ngot: 45\ngot: 25\ngot: 15\nisatty? 0,0,1\n', 'got: 35\ngot: 45\ngot: 25\ngot: 15\nisatty? 0,0,1', 'isatty? 0,0,1\ngot: 35\ngot: 45\ngot: 25\ngot: 15'), output_nicerizer=clean)
 
@@ -5440,7 +5440,7 @@ Module['onRuntimeInitialized'] = function() {
       self.emcc_args = orig_compiler_opts + ['-D' + fs]
       if fs == 'NODEFS':
         self.emcc_args += ['-lnodefs.js']
-      self.do_run_in_out_file_test('unistd/misc.c', js_engines=[config.NODE_JS])
+      self.do_run_in_out_file_test('unistd/misc.c', js_engines=[config.NODE_JS], interleaved_output=False)
 
   # i64s in the API, which we'd need to legalize for JS, so in standalone mode
   # all we can test is wasm VMs
@@ -5677,7 +5677,7 @@ int main(void) {
           f.write(src)
         self.build('fasta.cpp')
         for arg, output in results:
-          self.do_run('fasta.js', output, args=[str(arg)], output_nicerizer=lambda x, err: x.replace('\n', '*'), no_build=True)
+          self.do_run('fasta.js', output, args=[str(arg)], output_nicerizer=lambda x: x.replace('\n', '*'), no_build=True)
         shutil.copyfile('fasta.js', '%s.js' % t)
 
     test([])
@@ -5963,7 +5963,7 @@ void* operator new(size_t size) {
                 args=['-e', '''print("hello lua world!");print(17);for x = 1,4 do print(x) end;print(10-3)'''],
                 libraries=libs,
                 includes=[test_file('lua')],
-                output_nicerizer=lambda string, err: (string + err).replace('\n\n', '\n').replace('\n\n', '\n'))
+                output_nicerizer=lambda output: output.replace('\n\n', '\n').replace('\n\n', '\n'))
 
   @no_asan('issues with freetype itself')
   @needs_make('configure script')
@@ -6171,7 +6171,7 @@ void* operator new(size_t size) {
 
       # We use doubles in JS, so we get slightly different values than native code. So we
       # check our output by comparing the average pixel difference
-      def image_compare(output, err):
+      def image_compare(output):
         # Get the image generated by JS, from the JSON.stringify'd array
         m = re.search(r'\[[\d, -]*\]', output)
         self.assertIsNotNone(m, 'Failed to find proper image output in: ' + output)
@@ -6269,10 +6269,10 @@ void* operator new(size_t size) {
     # (but without the specific output, as it is logging the actual locals
     # used and so forth, which will change between opt modes and updates of
     # llvm etc.)
-    def check(out, err):
+    def check(out):
       for msg in ['log_execution', 'get_i32', 'set_i32', 'load_ptr', 'load_val', 'store_ptr', 'store_val']:
         self.assertIn(msg, out)
-      return out + err
+      return out
 
     self.do_runf(test_file('core/test_autodebug.c'),
                  'success', output_nicerizer=check)
@@ -6536,7 +6536,7 @@ void* operator new(size_t size) {
     self.emcc_args += ['-DGROWTH']
     # enable costly assertions to verify correct table behavior
     self.set_setting('ASSERTIONS', 2)
-    self.do_run_in_out_file_test('interop/test_add_function.cpp')
+    self.do_run_in_out_file_test('interop/test_add_function.cpp', interleaved_output=False)
 
   def test_getFuncWrapper_sig_alias(self):
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$getFuncWrapper'])
@@ -7249,11 +7249,11 @@ someweirdtext
     if '-g' not in self.emcc_args:
       self.emcc_args.append('-g')
     self.emcc_args += ['-DRUN_FROM_JS_SHELL']
-    self.do_run_in_out_file_test('emscripten_log/emscripten_log.cpp')
+    self.do_run_in_out_file_test('emscripten_log/emscripten_log.cpp', interleaved_output=False)
     # test closure compiler as well
     if self.maybe_closure():
       self.emcc_args += ['-g1'] # extra testing
-      self.do_run_in_out_file_test('emscripten_log/emscripten_log_with_closure.cpp')
+      self.do_run_in_out_file_test('emscripten_log/emscripten_log_with_closure.cpp', interleaved_output=False)
 
   def test_float_literals(self):
     self.do_run_in_out_file_test('test_float_literals.cpp')
@@ -8506,7 +8506,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('ABORT_ON_WASM_EXCEPTIONS')
     self.set_setting('EXPORTED_RUNTIME_METHODS', ['ccall', 'cwrap'])
     self.emcc_args += ['--bind', '--post-js', test_file('core/test_abort_on_exception_post.js')]
-    self.do_core_test('test_abort_on_exception.cpp')
+    self.do_core_test('test_abort_on_exception.cpp', interleaved_output=False)
 
   @needs_dylink
   def test_gl_main_module(self):

--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -105,9 +105,9 @@ struct_ptr_array[0]->attr2 == 101
 4 : 0.25
 9 : 0.01
 10 : -20.42
-Parent:42
-
-done.
 Assertion failed: [CHECK FAILED] Parent::Parent(val:val): Expecting <integer>
+Parent:42
 Assertion failed: [CHECK FAILED] Parent::voidStar(something:something): Expecting <pointer>
 Assertion failed: [CHECK FAILED] StringUser::Print(anotherString:anotherString): Expecting <string>
+
+done.


### PR DESCRIPTION
Without this change all `stderr/err()` output is displayed after
all `stdout/out()` output which can be very confusing when
debugging.