### PR TITLE
Error on undefined data symbols rather than giving them address zero

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -22,8 +22,9 @@ See docs/process.md for more on how version tagging works.
 ------
 - Undefined data symbols (in static executables) are no longer silently ignored
   at link time.  The previous behaviour (which was to silently give all
-  undefined data symbols address zero) can be enabled by passing either
-  `-Wl,--allow-undefined` or `-Wl,--unresolved-symbols=ignore-all`.
+  undefined data symbols address zero, which could lead to bugs)
+  can be enabled by passing either `-Wl,--allow-undefined` or
+  `-Wl,--unresolved-symbols=ignore-all`.
 - The alignment of `long double`, which is a 128-bit floating-point value
   implemented in software, is reduced from 16 to 8. The lower alignment allows
   `max_align_t` to properly match the alignment we use for malloc, which is 8

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 2.0.26
 ------
+- Undefined data symbols (in static executables) are no longer silently ignored
+  at link time.  The previous behaviour (which was to silently give all
+  undefined data symbols address zero) can be enabled by passing either
+  `-Wl,--allow-undefined` or `-Wl,--unresolved-symbols=ignore-all`.
 - The alignment of `long double`, which is a 128-bit floating-point value
   implemented in software, is reduced from 16 to 8. The lower alignment allows
   `max_align_t` to properly match the alignment we use for malloc, which is 8

--- a/tests/common.py
+++ b/tests/common.py
@@ -827,6 +827,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       return shared.run_process(cmd, check=check, **args)
     except subprocess.CalledProcessError as e:
       if check and e.returncode != 0:
+        print(e.stdout)
+        print(e.stderr)
         self.fail('subprocess exited with non-zero return code(%d): `%s`' %
                   (e.returncode, shared.shlex_join(cmd)))
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -357,7 +357,7 @@ def lld_flags_for_executable(external_symbols):
       f.write('\n'.join(external_symbols))
     cmd.append('--allow-undefined-file=%s' % undefs)
   else:
-    cmd.append('--allow-undefined')
+    cmd.append('--import-undefined')
 
   if settings.IMPORTED_MEMORY:
     cmd.append('--import-memory')
@@ -387,7 +387,7 @@ def lld_flags_for_executable(external_symbols):
       # Filter out symbols external/JS symbols
       c_exports = [e for e in c_exports if e not in external_symbols]
     for export in c_exports:
-      cmd += ['--export', export]
+      cmd.append('--export-if-defined=' + export)
 
     for export in settings.EXPORT_IF_DEFINED:
       cmd.append('--export-if-defined=' + export)


### PR DESCRIPTION
Previously, undefined data symbols we ignored by the linker due to the
use of `--allow-undefined` which causes undefined functions to be
imports but give all undefined data sybmols address zero.  Sadly there
is no way to turn data symbol references into imports like there is for
functions (due to the way codegen works for static binaries).

The new `--import-undefined` works the same for function but errors
out on undefined data symbols.

Users that want the previous behavior which is to give all undefined
data symbols address zero (like an weak undefined symbol) can use
with `-Wl,--allow-undefined` or `-Wl,--unresolved-symbols=ignore-all`.

Fixes: #14106