### PR TITLE
Rebaseline code size tests after LLVM improvements

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 5000,
-  "a.js.gz": 2422,
+  "a.js": 4987,
+  "a.js.gz": 2406,
   "a.wasm": 10310,
-  "a.wasm.gz": 6660,
-  "total": 15873,
-  "total_gz": 9459
+  "a.wasm.gz": 6658,
+  "total": 15860,
+  "total_gz": 9441
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 19890,
-  "a.js.gz": 8167,
+  "a.js": 19896,
+  "a.js.gz": 8153,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 23649,
-  "total_gz": 11267
+  "total": 23655,
+  "total_gz": 11253
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 563,
   "a.html.gz": 377,
-  "a.js": 4486,
-  "a.js.gz": 2249,
+  "a.js": 4471,
+  "a.js.gz": 2236,
   "a.wasm": 10310,
-  "a.wasm.gz": 6660,
-  "total": 15359,
-  "total_gz": 9286
+  "a.wasm.gz": 6658,
+  "total": 15344,
+  "total_gz": 9271
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 588,
   "a.html.gz": 386,
-  "a.js": 19375,
-  "a.js.gz": 7999,
+  "a.js": 19378,
+  "a.js.gz": 7989,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 23134,
-  "total_gz": 11099
+  "total": 23137,
+  "total_gz": 11089
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12521,
-  "a.html.gz": 6718,
-  "total": 12521,
-  "total_gz": 6718
+  "a.html": 12485,
+  "a.html.gz": 6697,
+  "total": 12485,
+  "total_gz": 6697
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17336,
-  "a.html.gz": 7444,
-  "total": 17336,
-  "total_gz": 7444
+  "a.html": 17299,
+  "a.html.gz": 7428,
+  "total": 17299,
+  "total_gz": 7428
 }


### PR DESCRIPTION
I didn't bisect on LLVM, but I did confirm the change comes from there
and not Binaryen or anywhere else.

Fixes current breakage on main here on github.