### PR TITLE
Avoid direct use of setTimeout/EM_ASM in library_pthread.c

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1842,7 +1842,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
       '___emscripten_pthread_data_constructor',
       '___pthread_tsd_run_dtors',
       '__emscripten_call_on_thread',
-      '__emscripten_do_dispatch_to_thread',
       '__emscripten_main_thread_futex',
       '__emscripten_thread_init',
       '_emscripten_current_thread_process_queued_calls',

--- a/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.exports
+++ b/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.exports
@@ -13,7 +13,6 @@ L
 M
 N
 O
-P
 s
 t
 u

--- a/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -17,6 +17,7 @@ $_main_thread
 $_pthread_isduecanceled
 $a_cas
 $add
+$dispatch_to_thread_helper
 $dispose_chunk
 $dlfree
 $dlmalloc


### PR DESCRIPTION
Instead use emscripten_set_timeout, which in turn uses safeSetTimeout.