### PR TITLE
Also run test_pthread_lsan test under node. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -183,14 +183,14 @@ def require_v8(func):
 
 
 def node_pthreads(f):
-  def decorated(self):
+  def decorated(self, *args, **kwargs):
     self.set_setting('USE_PTHREADS')
     self.emcc_args += ['-Wno-pthreads-mem-growth']
     if self.get_setting('MINIMAL_RUNTIME'):
       self.skipTest('node pthreads not yet supported with MINIMAL_RUNTIME')
     self.js_engines = [config.NODE_JS]
     self.node_args += ['--experimental-wasm-threads', '--experimental-wasm-bulk-memory']
-    f(self)
+    f(self, *args, **kwargs)
   return decorated
 
 

--- a/tests/pthread/test_pthread_lsan_leak.cpp
+++ b/tests/pthread/test_pthread_lsan_leak.cpp
@@ -38,4 +38,5 @@ int main(int argc, char **argv) {
 
   __lsan_do_leak_check();
   fprintf(stderr, "LSAN TEST COMPLETE\n");
+  return 0;
 }

--- a/tests/pthread/test_pthread_lsan_no_leak.cpp
+++ b/tests/pthread/test_pthread_lsan_no_leak.cpp
@@ -13,10 +13,12 @@ void g(void) {
   void *stuff = malloc(3432);
   tls_ptr = malloc(1234);
   atomic_store(&thread_done, true);
+  printf("thread done\n");
   while (1);
 }
 
 int main(int argc, char **argv) {
+  printf("start\n");
   std::thread t(g);
   t.detach();
 
@@ -28,4 +30,5 @@ int main(int argc, char **argv) {
 
   __lsan_do_leak_check();
   fprintf(stderr, "LSAN TEST COMPLETE\n");
+  return 0;
 }

--- a/tests/pthread/test_pthread_lsan_no_leak.out
+++ b/tests/pthread/test_pthread_lsan_no_leak.out
@@ -1,0 +1,3 @@
+start
+thread done
+LSAN TEST COMPLETE


### PR DESCRIPTION
I was going to simply move these test to run only on node but in
doing so I noticed some subtle differences in the worker semantics
that effected the offset coverter so I decided its best to run
these in both environments.

However, debugging and maintaining the test is way simpler under
node since we are far better setup to test for stdout/stderr there