### PR TITLE
Fix for pthread_kill + EXIT_RUNTIME

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -534,6 +534,7 @@ var LibraryPThread = {
     if (!pthread_ptr) throw 'Internal Error! Null pthread_ptr in killThread!';
     {{{ makeSetValue('pthread_ptr', C_STRUCTS.pthread.self, 0, 'i32') }}};
     var pthread = PThread.pthreads[pthread_ptr];
+    delete PThread.pthreads[pthread_ptr];
     pthread.worker.terminate();
     PThread.freeThreadData(pthread);
     // The worker was completely nuked (not just the pthread execution it was hosting), so remove it from running workers

--- a/tests/pthread/test_pthread_kill.cpp
+++ b/tests/pthread/test_pthread_kill.cpp
@@ -39,9 +39,6 @@ int main()
 {
   if (!emscripten_has_threading_support())
   {
-#ifdef REPORT_RESULT
-    REPORT_RESULT(0);
-#endif
     printf("Skipped: Threading is not supported.\n");
     return 0;
   }
@@ -75,7 +72,5 @@ int main()
   // Finally test that the thread is not doing any work and it is dead.
   assert(sharedVar == 0);
   printf("Main: Done. Successfully killed thread. sharedVar: %d\n", sharedVar);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(sharedVar);
-#endif
+  return 0;
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3886,7 +3886,7 @@ window.close = function() {
   @no_chrome('pthread_kill hangs chrome renderer, and keep subsequent tests from passing')
   @requires_threads
   def test_pthread_kill(self):
-    self.btest(test_file('pthread/test_pthread_kill.cpp'), expected='0', args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE=8'])
+    self.btest_exit(test_file('pthread/test_pthread_kill.cpp'), args=['-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE=8'])
 
   # Test that pthread cleanup stack (pthread_cleanup_push/_pop) works.
   @requires_threads


### PR DESCRIPTION
The killed thread was not being correcltly removed from PThread.pthreads
so terminateAllThreads (which only happens when the runtime exists) was
crashing.