### PR TITLE
Move test_override_system_js_lib_symbol to test_other. NFC

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -300,7 +300,7 @@ def parse_args(args):
                            'test.  Implies --cores=1.')
   parser.add_argument('--no-clean', action='store_true',
                       help='Do not clean the temporary directory before each test run')
-  parser.add_argument('--verbose', action='store_true', default=None)
+  parser.add_argument('--verbose', '-v', action='store_true', default=None)
   parser.add_argument('--all-engines', action='store_true', default=None)
   parser.add_argument('--detect-leaks', action='store_true', default=None)
   parser.add_argument('--skip-slow', action='store_true', help='Skip tests marked as slow')

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5071,20 +5071,6 @@ window.close = function() {
   def test_system(self):
     self.btest_exit(test_file('system.c'))
 
-  # Tests that it is possible to hook into/override a symbol defined in a system library.
-  @requires_graphics_hardware
-  def test_override_system_js_lib_symbol(self):
-    # This test verifies it is possible to override a symbol from WebGL library.
-
-    # When WebGL is implicitly linked in, the implicit linking should happen before any user --js-libraries, so that they can adjust
-    # the behavior afterwards.
-    self.btest_exit(test_file('test_override_system_js_lib_symbol.c'),
-                    args=['--js-library', test_file('test_override_system_js_lib_symbol.js')])
-
-    # When WebGL is explicitly linked to in strict mode, the linking order on command line should enable overriding.
-    self.btest_exit(test_file('test_override_system_js_lib_symbol.c'),
-                    args=['-s', 'AUTO_JS_LIBRARIES=0', '-lwebgl.js', '--js-library', test_file('test_override_system_js_lib_symbol.js')])
-
   @no_firefox('no 4GB support yet')
   @require_v8
   def test_zzz_zzz_4gb(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10816,3 +10816,15 @@ void foo() {}
     self.run_process([EMCC, test_file('hello_world.c'), '--post-js=post.js'])
     err = self.run_js('a.out.js', assert_returncode=NON_ZERO)
     self.assertContained('`alignMemory` is now a library function and not included by default; add it to your library.js __deps or to DEFAULT_LIBRARY_FUNCS_TO_INCLUDE on the command line', err)
+
+  # Tests that it is possible to hook into/override a symbol defined in a system library.
+  def test_override_system_js_lib_symbol(self):
+    # This test verifies it is possible to override a symbol from WebGL library.
+
+    # When WebGL is implicitly linked in, the implicit linking should happen before any user
+    # --js-libraries, so that they can adjust the behavior afterwards.
+    self.do_run_in_out_file_test(test_file('test_override_system_js_lib_symbol.c'), emcc_args=['--js-library', test_file('test_override_system_js_lib_symbol.js')])
+
+    # When WebGL is explicitly linked to in strict mode, the linking order on command line should enable overriding.
+    self.emcc_args += ['-sAUTO_JS_LIBRARIES=0', '-lwebgl.js', '--js-library', test_file('test_override_system_js_lib_symbol.js')]
+    self.do_run_in_out_file_test(test_file('test_override_system_js_lib_symbol.c'))

--- a/tests/test_override_system_js_lib_symbol.c
+++ b/tests/test_override_system_js_lib_symbol.c
@@ -7,15 +7,6 @@
 GLuint what_got_created(void);
 
 int main() {
-  EmscriptenWebGLContextAttributes attr;
-  emscripten_webgl_init_context_attributes(&attr);
-  EMSCRIPTEN_WEBGL_CONTEXT_HANDLE ctx = emscripten_webgl_create_context("#canvas", &attr);
-  emscripten_webgl_make_context_current(ctx);
-
-  GLuint texture;
-  glGenTextures(1, &texture);
-  glBindTexture(GL_TEXTURE_2D, texture);
-
   GLuint createType = GL_UNSIGNED_BYTE;
   glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, createType, 0);
   GLuint whatGotCreated = what_got_created();

--- a/tests/test_override_system_js_lib_symbol.js
+++ b/tests/test_override_system_js_lib_symbol.js
@@ -7,7 +7,18 @@ mergeInto(LibraryManager.library, {
 	glTexImage2D__deps: ['orig_glTexImage2D'],
 	glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
 		_glTexImage2D.createdType = type;
-		_orig_glTexImage2D(target, level, internalFormat, width, height, border, format, type, pixels);
+		// Check that the orignal fuction exists
+		assert(_orig_glTexImage2D);
+		// Also try invoking glTexImage2D to verify that it is actually the
+		// underlying functions from library_webgl.js
+		var texImage2D_called = false;
+		GLctx = {
+			texImage2D: function() {
+				texImage2D_called = true;
+			},
+		};
+		_orig_glTexImage2D();
+		assert(texImage2D_called);
 	},
 
 	what_got_created: function() {

--- a/tests/test_override_system_js_lib_symbol.out
+++ b/tests/test_override_system_js_lib_symbol.out
@@ -1,0 +1,1 @@
+Created texture of type 0x1401


### PR DESCRIPTION
This is a test of the core JS library linking semantics and should not need
actual browser or graphics support.