### PR TITLE
Mark Embind throw as [[noreturn]]

### DIFF
--- a/system/include/emscripten/val.h
+++ b/system/include/emscripten/val.h
@@ -563,7 +563,7 @@ namespace emscripten {
             return internal::_emval_delete(handle, val(property).handle);
         }
 
-        void throw_() const {
+        [[noreturn]] void throw_() const {
             internal::_emval_throw(handle);
         }
 


### PR DESCRIPTION
This method will immediately throw a value, meaning there is no way for it to return to Wasm.

Optimisations aside, adding this attribute allows to use `val.throw_()` in C++ without compiler complaining about `non-void function does not return a value in all control paths [-Wreturn-type]`.