### PR TITLE
Warn when we map unrecognized library files to `-l` flags.

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1226,7 +1226,7 @@ int f() {
     ''')
 
     ensure_dir('subdir')
-    create_file('subdir/libfile.so', 'this is not llvm bitcode!')
+    create_file('subdir/libfile.so.1.2.3', 'this is not llvm bitcode!')
 
     create_file('libfile.cpp', '''
       #include <stdio.h>
@@ -1236,7 +1236,8 @@ int f() {
     ''')
 
     self.run_process([EMXX, 'libfile.cpp', '-shared', '-o', 'libfile.so'], stderr=PIPE)
-    self.run_process([EMXX, 'main.cpp', Path('subdir/libfile.so'), '-L.'])
+    err = self.run_process([EMXX, 'main.cpp', Path('subdir/libfile.so.1.2.3'), '-L.'], stderr=PIPE).stderr
+    self.assertContained('Mapping to `-lfile` and hoping for the best [-Wmap-unrecognized-libraries]', err)
     self.assertContained('hello from lib', self.run_js('a.out.js'))
 
   def test_identical_basenames(self):

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -65,6 +65,7 @@ diagnostics.add_warning('undefined', error=True)
 diagnostics.add_warning('deprecated', shared=True)
 diagnostics.add_warning('version-check')
 diagnostics.add_warning('export-main')
+diagnostics.add_warning('map-unrecognized-libraries')
 diagnostics.add_warning('unused-command-line-argument', shared=True)
 diagnostics.add_warning('pthreads-mem-growth')
 


### PR DESCRIPTION
This is a rather an odd feature and I think we should notify users if they
are relying on it.  Honestly I doubt many are.

See #14689 for an example of how confusing it can be when it goes wrong.

Also, make sure we strip off the full suffix in the case of `.so.1.2.3`
suffixes.