### PR TITLE
Add `.wasm` extention into DYNAMICLIB_ENDINGS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -67,7 +67,7 @@ SOURCE_ENDINGS = C_ENDINGS + CXX_ENDINGS + OBJC_ENDINGS + OBJCXX_ENDINGS + SPECI
 C_ENDINGS = C_ENDINGS + SPECIAL_ENDINGLESS_FILENAMES # consider the special endingless filenames like /dev/null to be C
 
 EXECUTABLE_ENDINGS = ('.wasm', '.html', '.js', '.mjs', '.out', '')
-DYNAMICLIB_ENDINGS = ('.dylib', '.so') # Windows .dll suffix is not included in this list, since those are never linked to directly on the command line.
+DYNAMICLIB_ENDINGS = ('.dylib', '.so', '.wasm') # Windows .dll suffix is not included in this list, since those are never linked to directly on the command line.
 STATICLIB_ENDINGS = ('.a',)
 ASSEMBLY_ENDINGS = ('.ll', '.s')
 HEADER_ENDINGS = ('.h', '.hxx', '.hpp', '.hh', '.H', '.HXX', '.HPP', '.HH')


### PR DESCRIPTION
With this modification, emcc will accept '*.wasm' input as dynamic libraries.

The MIME type of '.so', '.dylib' are 'application/octen-stream', which commonly will not be compressed on download. 
Using '.wasm' as the extension of dynamic libraries will reduce downloaded size.