### PR TITLE
Fix for wasmOffsetConverter with MODULARIZE + USE_PTHREAD

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2088,9 +2088,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
         '___global_base'
     ]
 
-  if settings.USE_OFFSET_CONVERTER and settings.USE_PTHREADS:
-    settings.EXPORTED_RUNTIME_METHODS += ['WasmOffsetConverter']
-
   if settings.USE_OFFSET_CONVERTER and settings.WASM2JS:
     exit_with_error('wasm2js is not compatible with USE_OFFSET_CONVERTER (see #14630)')
 
@@ -2163,9 +2160,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
 
   if sanitize and settings.GENERATE_SOURCE_MAP:
     settings.LOAD_SOURCE_MAP = 1
-
-  if settings.LOAD_SOURCE_MAP and settings.USE_PTHREADS:
-    settings.EXPORTED_RUNTIME_METHODS += ['WasmSourceMap']
 
   if settings.GLOBAL_BASE == -1:
     # default if nothing else sets it

--- a/src/library.js
+++ b/src/library.js
@@ -2952,6 +2952,9 @@ LibraryManager.library = {
 #if !USE_OFFSET_CONVERTER
     abort('Cannot use emscripten_generate_pc (needed by __builtin_return_address) without -s USE_OFFSET_CONVERTER');
 #else
+#if ASSERTIONS
+    assert(wasmOffsetConverter);
+#endif
     var match;
 
     if (match = /\bwasm-function\[\d+\]:(0x[0-9a-f]+)/.exec(frame)) {

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -234,7 +234,6 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
 #if USE_PTHREADS
   // This Worker is now ready to host pthreads, tell the main thread we can proceed.
   if (ENVIRONMENT_IS_PTHREAD) {
-    moduleLoaded();
     postMessage({ 'cmd': 'loaded' });
   }
 #endif

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -919,6 +919,21 @@ function instantiateSync(file, info) {
 }
 #endif
 
+#if LOAD_SOURCE_MAP || USE_OFFSET_CONVERTER
+// When using postMessage to send an object, it is processed by the structured clone algorithm.
+// The prototype, and hence methods, on that object is then lost. This function adds back the lost prototype.
+// This does not work with nested objects that has prototypes, but it suffices for WasmSourceMap and WasmOffsetConverter.
+function resetPrototype(constructor, attrs) {
+  var object = Object.create(constructor.prototype);
+  for (var key in attrs) {
+    if (attrs.hasOwnProperty(key)) {
+      object[key] = attrs[key];
+    }
+  }
+  return object;
+}
+#endif
+
 // Create the wasm instance.
 // Receives the wasm imports, returns the exports.
 function createWasm() {
@@ -1174,28 +1189,27 @@ function createWasm() {
   // to manually instantiate the Wasm module themselves. This allows pages to run the instantiation parallel
   // to any other async startup actions they are performing.
   if (Module['instantiateWasm']) {
+#if USE_OFFSET_CONVERTER
+#if ASSERTIONS && USE_PTHREADS
+    if (ENVIRONMENT_IS_PTHREAD) {
+      assert(Module['wasmOffsetData'], 'wasmOffsetData not found on Module object');
+    }
+#endif
+    wasmOffsetConverter = resetPrototype(WasmOffsetConverter, Module['wasmOffsetData']);
+    {{{ runOnMainThread("removeRunDependency('offset-converter');") }}}
+#endif
+#if LOAD_SOURCE_MAP
+#if ASSERTIONS && USE_PTHREADS
+    if (ENVIRONMENT_IS_PTHREAD) {
+      assert(Module['wasmSourceMapData'], 'wasmSourceMapData not found on Module object');
+    }
+#endif
+    wasmSourceMap = resetPrototype(WasmSourceMap, Module['wasmSourceMapData']);
+#endif
     try {
       var exports = Module['instantiateWasm'](info, receiveInstance);
 #if ASYNCIFY
       exports = Asyncify.instrumentWasmExports(exports);
-#endif
-#if USE_OFFSET_CONVERTER
-      {{{
-        runOnMainThread(`
-          // We have no way to create an OffsetConverter in this code path since
-          // we have no access to the wasm binary (only the user does). Instead,
-          // create a fake one that reports we cannot identify functions from
-          // their binary offsets.
-          // Note that we only do this on the main thread, as the workers
-          // receive the OffsetConverter data from there.
-          wasmOffsetConverter = {
-            getName: function() {
-              return 'unknown-due-to-instantiateWasm';
-            }
-          };
-          removeRunDependency('offset-converter');
-        `)
-      }}}
 #endif
       return exports;
     } catch(e) {

--- a/tests/core/test_return_address.c
+++ b/tests/core/test_return_address.c
@@ -7,12 +7,24 @@
 
 #include <assert.h>
 #include <stdio.h>
+#include <string.h>
 
 void *emscripten_return_address(int level);
+const char *emscripten_pc_get_function(void* pc);
 
-void func() {
-  assert(emscripten_return_address(0) != 0);
+__attribute__((noinline)) void func() {
+  void* rtn_addr = emscripten_return_address(0);
+  void* rtn_addr2 = __builtin_return_address(0);
+  const char* caller_name = emscripten_pc_get_function(rtn_addr);
+  printf("emscripten_return_address: %p\n", rtn_addr);
+  printf("emscripten_pc_get_function: %s\n", caller_name);
+  assert(rtn_addr != 0);
+  assert(rtn_addr2 != 0);
+  assert(rtn_addr == rtn_addr2);
+#ifdef DEBUG
+  assert(strcmp(caller_name, "main") == 0);
   assert(emscripten_return_address(50) == 0);
+#endif
 }
 
 // We need to take these two arguments or clang can potentially generate

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8317,6 +8317,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('USE_OFFSET_CONVERTER')
+    if '-g' in self.emcc_args:
+      self.emcc_args += ['-DDEBUG']
     self.do_runf(test_file('core/test_return_address.c'), 'passed')
 
   @node_pthreads
@@ -8328,6 +8330,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('MODULARIZE')
     create_file('post.js', 'var m = require("./test_return_address.js"); m();')
     self.emcc_args += ['--extern-post-js', 'post.js', '-s', 'EXPORT_NAME=foo']
+    if '-g' in self.emcc_args:
+      self.emcc_args += ['-DDEBUG']
     self.do_runf(test_file('core/test_return_address.c'), 'passed')
 
   def test_emscripten_atomics_stub(self):


### PR DESCRIPTION
I tried to fix this in #13236 but I don't think it was ever working
correctly.  In `MODULARIZE` mode `wasmOffsetConverter` was not being
defined within the module itself (where it is used).  his change moves
the construction of `wasmOffsetConverter` and `wasmSourceMap` so they
always occur inside the module.

I've also improved the testing of `wasmOffsetConverter` so we actually
verify that it works in `tests/core/test_return_address.c`.