### PR TITLE
Remove thread support checks from pthread tests. NFC

### DIFF
--- a/tests/pthread/main_thread_join.cpp
+++ b/tests/pthread/main_thread_join.cpp
@@ -5,7 +5,6 @@
 
 #include <assert.h>
 #include <emscripten.h>
-#include <emscripten/threading.h>
 #include <pthread.h>
 #include <stdio.h>
 
@@ -45,11 +44,6 @@ pthread_t CreateThread() {
 }
 
 int main() {
-  if (!emscripten_has_threading_support()) {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   thread = CreateThread();
 #ifdef TRY_JOIN
   emscripten_set_main_loop(loop, 0, 0);

--- a/tests/pthread/main_thread_wait.cpp
+++ b/tests/pthread/main_thread_wait.cpp
@@ -9,12 +9,6 @@
 #include <stdio.h>
 
 int main() {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   // This should fail on the main thread.
   puts("trying to block...");
   pthread_cond_t cv = PTHREAD_COND_INITIALIZER;

--- a/tests/pthread/test_futex_wake_all.cpp
+++ b/tests/pthread/test_futex_wake_all.cpp
@@ -57,12 +57,6 @@ void *WaitingThread(void *arg)
 
 int main()
 {
-	if (!emscripten_has_threading_support())
-	{
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	for(int i = 0; i < NUM_THREADS; ++i)
 	{
 		pthread_create(waitingThreads+i, 0, WaitingThread, (void*)i);

--- a/tests/pthread/test_large_pthread_allocation.cpp
+++ b/tests/pthread/test_large_pthread_allocation.cpp
@@ -11,7 +11,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <emscripten.h>
-#include <emscripten/threading.h>
 #include <vector>
 
 pthread_t threads[50];
@@ -34,12 +33,6 @@ void JoinThread(int idx) {
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   // This test should be run with a prewarmed pool of size 50. They should be fully allocated.
   assert(EM_ASM_INT(return PThread.unusedWorkers.length) == 50);
 

--- a/tests/pthread/test_pthread_64bit_atomics.cpp
+++ b/tests/pthread/test_pthread_64bit_atomics.cpp
@@ -139,12 +139,6 @@ int main()
 
 	uint64_t prevU64 = emscripten_atomic_add_u64((void*)&globalU64, 1); assert(prevU64 == 4);
 
-	if (!emscripten_has_threading_support())
-	{
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	for(int i = 0; i < 7; ++i)
 		RunTest(i);
 

--- a/tests/pthread/test_pthread_atomics.cpp
+++ b/tests/pthread/test_pthread_atomics.cpp
@@ -159,12 +159,6 @@ int main()
 	emscripten_atomic_fence();
 	__sync_synchronize();
 
-	if (!emscripten_has_threading_support())
-	{
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	for(int i = 0; i < 7; ++i)
 		RunTest(i);
 

--- a/tests/pthread/test_pthread_attr_getstack.cpp
+++ b/tests/pthread/test_pthread_attr_getstack.cpp
@@ -7,8 +7,6 @@
 #include <stdlib.h>
 #include <pthread.h>
 #include <unistd.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
 #include <assert.h>
 
 void *ThreadMain(void *arg)
@@ -42,12 +40,6 @@ void *ThreadMain(void *arg)
 
 int main()
 {
-	if (!emscripten_has_threading_support())
-	{
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	pthread_t thread;
 	int rc, result;
 

--- a/tests/pthread/test_pthread_barrier.cpp
+++ b/tests/pthread/test_pthread_barrier.cpp
@@ -5,7 +5,6 @@
 
 // This file tests pthread barrier usage.
 
-#include <emscripten/threading.h>
 #include <pthread.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -72,14 +71,11 @@ int main(int argc, char **argv)
     assert(ret == 0);
 
     for(int i = 0; i < THREADS; ++i) pthread_create(&thr[i], NULL, &thread_main, (void*)i);
-    if (emscripten_has_threading_support())
+    for(int i = 0; i < THREADS; ++i)
     {
-        for(int i = 0; i < THREADS; ++i)
-        {
-            int totalSum = 0;
-            pthread_join(thr[i], (void**)&totalSum);
-            assert(totalSum == expectedTotalSum);
-        }
+        int totalSum = 0;
+        pthread_join(thr[i], (void**)&totalSum);
+        assert(totalSum == expectedTotalSum);
     }
 
     return 0;

--- a/tests/pthread/test_pthread_cancel.cpp
+++ b/tests/pthread/test_pthread_cancel.cpp
@@ -10,10 +10,9 @@
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 
-volatile long res = 43;
+_Atomic long res = 43;
 static void cleanup_handler(void *arg)
 {
   EM_ASM(out('Called clean-up handler with arg ' + $0), arg);
@@ -37,12 +36,6 @@ pthread_t thr;
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   int s = pthread_create(&thr, NULL, thread_start, (void*)0);
   assert(s == 0);
   EM_ASM(out('Canceling thread..'););
@@ -51,7 +44,7 @@ int main()
 
   for(;;)
   {
-    int result = emscripten_atomic_load_u32((const void*)&res);
+    int result = res;
     if (result == 1)
     {
       EM_ASM_INT( { out('After canceling, shared variable = ' + $0 + '.'); }, result);

--- a/tests/pthread/test_pthread_cancel_cond_wait.cpp
+++ b/tests/pthread/test_pthread_cancel_cond_wait.cpp
@@ -11,7 +11,6 @@
 #include <unistd.h>
 #include <errno.h>
 #include <emscripten.h>
-#include <emscripten/threading.h>
 
 pthread_barrier_t barrier;
 pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -55,11 +54,6 @@ static void *thread_start(void *arg) {
 }
 
 int main() {
-  if (!emscripten_has_threading_support()) {
-    printf("Skipped: Threading is not supported.\n");
-    return 1;
-  }
-
   pthread_barrier_init(&barrier, nullptr, 2);
 
   pthread_t thr;

--- a/tests/pthread/test_pthread_cleanup.cpp
+++ b/tests/pthread/test_pthread_cleanup.cpp
@@ -10,8 +10,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 
 // Stores/encodes the results of calling to cleanup handlers.
 long cleanupState = 1;
@@ -65,11 +64,6 @@ pthread_t thr[4];
 
 int main() {
   int result = 0;
-
-  if (!emscripten_has_threading_support()) {
-     printf("Skipped: Threading is not supported.\n");
-     return 0;
-  }
 
   pthread_cleanup_push(cleanup_handler1, (void*)9998);
   pthread_cleanup_push(cleanup_handler1, (void*)9999);

--- a/tests/pthread/test_pthread_condition_variable.cpp
+++ b/tests/pthread/test_pthread_condition_variable.cpp
@@ -7,7 +7,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <emscripten/emscripten.h>
-#include <emscripten/threading.h>
 
 #define NUM_THREADS  3
 #define TCOUNT 10
@@ -83,21 +82,18 @@ int main (int argc, char *argv[])
 
   /* Initialize mutex and condition variable objects */
   pthread_mutex_init(&count_mutex, NULL);
-  pthread_cond_init (&count_threshold_cv, NULL);
+  pthread_cond_init(&count_threshold_cv, NULL);
 
   /* For portability, explicitly create threads in a joinable state */
   pthread_create(&threads[0], NULL, watch_count, (void *)t1);
   pthread_create(&threads[1], NULL, inc_count, (void *)t2);
   pthread_create(&threads[2], NULL, inc_count, (void *)t3);
 
-  if (emscripten_has_threading_support())
-  {
-    /* Wait for all threads to complete */
-    for (i=0; i<NUM_THREADS; i++) {
-      pthread_join(threads[i], NULL);
-    }
-    printf ("Main(): Waited on %d  threads. Done.\n", NUM_THREADS);
+  /* Wait for all threads to complete */
+  for (i=0; i<NUM_THREADS; i++) {
+    pthread_join(threads[i], NULL);
   }
+  printf ("Main(): Waited on %d  threads. Done.\n", NUM_THREADS);
 
   /* Clean up and exit */
   pthread_mutex_destroy(&count_mutex);

--- a/tests/pthread/test_pthread_create.cpp
+++ b/tests/pthread/test_pthread_create.cpp
@@ -6,8 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 #include <assert.h>
 
 #define NUM_THREADS 8
@@ -70,12 +69,6 @@ void CreateThread(int i)
 
 int main()
 {
-	if (!emscripten_has_threading_support())
-	{
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	// Create initial threads.
 	for(int i = 0; i < NUM_THREADS; ++i)
 		CreateThread(i);

--- a/tests/pthread/test_pthread_create_pthread.cpp
+++ b/tests/pthread/test_pthread_create_pthread.cpp
@@ -4,8 +4,7 @@
 // found in the LICENSE file.
 
 #include <pthread.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -35,12 +34,6 @@ static void *thread1_start(void *arg)
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   pthread_t thr;
   pthread_create(&thr, NULL, thread1_start, NULL);
 

--- a/tests/pthread/test_pthread_file_io.cpp
+++ b/tests/pthread/test_pthread_file_io.cpp
@@ -4,8 +4,7 @@
 // found in the LICENSE file.
 
 #include <pthread.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -31,12 +30,6 @@ static void *thread1_start(void *arg)
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   FILE *handle = fopen("file1.txt", "w");
   fputs("hello!", handle);
   fclose(handle);

--- a/tests/pthread/test_pthread_gcc_spinlock.cpp
+++ b/tests/pthread/test_pthread_gcc_spinlock.cpp
@@ -47,11 +47,6 @@ void *ThreadMain(void *arg)
 int main()
 {
 	int result = 0;
-	if (!emscripten_has_threading_support())
-	{
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
 
 	pthread_t thread[NUM_THREADS];
 

--- a/tests/pthread/test_pthread_hardware_concurrency.cpp
+++ b/tests/pthread/test_pthread_hardware_concurrency.cpp
@@ -8,7 +8,6 @@
 #include <memory.h>
 #include <pthread.h>
 #include <emscripten.h>
-#include <emscripten/threading.h>
 #include <assert.h>
 
 #include <thread>
@@ -65,12 +64,6 @@ void RunTest(int test)
 
 int main()
 {
-	if (!emscripten_has_threading_support())
-	{
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
   // Do a bunch of joins, verifying the Worker pool works.
 	for(int i = 0; i < 7; ++i)
 		RunTest(i);

--- a/tests/pthread/test_pthread_iostream.cpp
+++ b/tests/pthread/test_pthread_iostream.cpp
@@ -6,8 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
 #include <assert.h>
 #include <iostream>
 
@@ -22,12 +20,6 @@ int numThreadsToCreate = 1000;
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
 	pthread_t thread;
 	int rc = pthread_create(&thread, NULL, ThreadMain, 0);
 	assert(rc == 0);

--- a/tests/pthread/test_pthread_join.cpp
+++ b/tests/pthread/test_pthread_join.cpp
@@ -10,8 +10,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 
 long fib(long n)
 {
@@ -34,12 +33,6 @@ int main()
   // Test existence of nanosleep(), https://github.com/emscripten-core/emscripten/issues/4578
   struct timespec ts = { 1, 0 };
   nanosleep(&ts, 0);
-
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
 
   pthread_t thr;
 

--- a/tests/pthread/test_pthread_kill.cpp
+++ b/tests/pthread/test_pthread_kill.cpp
@@ -12,7 +12,6 @@
 #include <errno.h>
 #include <signal.h>
 #include <emscripten.h>
-#include <emscripten/threading.h>
 
 _Atomic int sharedVar = 0;
 
@@ -37,12 +36,6 @@ void BusySleep(double msecs)
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   sharedVar = 0;
   int s = pthread_create(&thr, NULL, thread_start, 0);
   assert(s == 0);

--- a/tests/pthread/test_pthread_malloc.cpp
+++ b/tests/pthread/test_pthread_malloc.cpp
@@ -4,8 +4,7 @@
 // found in the LICENSE file.
 
 #include <pthread.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -40,11 +39,6 @@ static void *thread_start(void *arg)
 
 int main()
 {
-  if (!emscripten_has_threading_support()) {
-    printf("Skipped: threading support is not available!\n");
-    return 0;
-  }
-
   pthread_t thr[NUM_THREADS];
   for(int i = 0; i < NUM_THREADS; ++i)
     pthread_create(&thr[i], NULL, thread_start, (void*)(i*N));

--- a/tests/pthread/test_pthread_malloc_free.cpp
+++ b/tests/pthread/test_pthread_malloc_free.cpp
@@ -5,7 +5,6 @@
 
 #include <pthread.h>
 #include <emscripten.h>
-#include <emscripten/threading.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -32,10 +31,6 @@ static void *thread_start(void *arg)
 
 int main()
 {
-  if (!emscripten_has_threading_support()) {
-    printf("Skipped: threading support is not available!\n");
-    return 0;
-  }
   pthread_t thr[NUM_THREADS];
   for(int i = 0; i < NUM_THREADS; ++i)
   {

--- a/tests/pthread/test_pthread_memory_growth.c
+++ b/tests/pthread/test_pthread_memory_growth.c
@@ -9,7 +9,6 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <emscripten.h>
-#include <emscripten/threading.h>
 
 static void *thread_start(void *arg)
 {
@@ -24,11 +23,6 @@ static void *thread_start(void *arg)
 int main()
 {
   printf("prep\n");
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
 
   pthread_t thr;
 

--- a/tests/pthread/test_pthread_memory_growth_mainthread.c
+++ b/tests/pthread/test_pthread_memory_growth_mainthread.c
@@ -8,8 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <assert.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 
 static void *thread_start(void *arg)
 {
@@ -31,11 +30,6 @@ char* test() {
 int main()
 {
   printf("prep\n");
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
 
   printf("start main\n");
   EM_ASM({ assert(HEAP8.length === 32 * 1024 * 1024, "start at 32MB") });

--- a/tests/pthread/test_pthread_mutex.cpp
+++ b/tests/pthread/test_pthread_mutex.cpp
@@ -102,10 +102,6 @@ int main()
 	pthread_mutex_lock(&lock);
 	pthread_mutex_unlock(&lock);
 
-	if (!emscripten_has_threading_support()) {
-		return 0;
-	}
-
 	// Create new threads in parallel.
 	for(int i = 0; i < NUM_THREADS; ++i)
 		CreateThread(i, threadNum++);

--- a/tests/pthread/test_pthread_nested_spawns.cpp
+++ b/tests/pthread/test_pthread_nested_spawns.cpp
@@ -6,7 +6,6 @@
 #include <cassert>
 #include <stdio.h>
 #include <pthread.h>
-#include <emscripten/threading.h>
 
 int result = 0;
 
@@ -25,10 +24,6 @@ static void *thread_func(void *vptr_args) {
 }
 
 int main(void) {
-  if (!emscripten_has_threading_support()) {
-    return 0;
-  }
-
   pthread_t thread;
   puts("a");
   pthread_create(&thread, NULL, thread_func, NULL);

--- a/tests/pthread/test_pthread_preallocates_workers.cpp
+++ b/tests/pthread/test_pthread_preallocates_workers.cpp
@@ -10,8 +10,7 @@
 #include <assert.h>
 #include <unistd.h>
 #include <errno.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
+#include <emscripten/em_asm.h>
 #include <vector>
 
 pthread_t threads[5];
@@ -36,12 +35,6 @@ void CreateThread(int idx) {
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   // This test should be run with a prewarmed pool of size 4. None
   // of the threads are allocated yet.
   assert(EM_ASM_INT(return PThread.unusedWorkers.length) == 4);

--- a/tests/pthread/test_pthread_printf.cpp
+++ b/tests/pthread/test_pthread_printf.cpp
@@ -6,8 +6,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
 #include <errno.h>
 #include <assert.h>
 
@@ -21,16 +19,11 @@ int main()
 {
 	pthread_t thread;
 	int rc = pthread_create(&thread, NULL, ThreadMain, 0);
-	if (emscripten_has_threading_support()) {
-		assert(rc == 0);
+	assert(rc == 0);
 
-		rc = pthread_join(thread, NULL);
-		assert(rc == 0);
+	rc = pthread_join(thread, NULL);
+	assert(rc == 0);
 
-		printf("The thread should print 'Hello from thread, string: str, int: 5, double: 42.0'\n");
-	} else {
-		assert(rc == EAGAIN);
-	}
-
+	printf("The thread should print 'Hello from thread, string: str, int: 5, double: 42.0'\n");
 	return 0;
 }

--- a/tests/pthread/test_pthread_proxying_in_futex_wait.cpp
+++ b/tests/pthread/test_pthread_proxying_in_futex_wait.cpp
@@ -32,12 +32,6 @@ void *ThreadMain(void *arg)
 
 int main()
 {
-	if (!emscripten_has_threading_support())
-	{
-		printf("Skipped: Threading is not supported.\n");
-		return 0;
-	}
-
 	pthread_t thread;
 	int rc = pthread_create(&thread, NULL, ThreadMain, 0);
 	assert(rc == 0);

--- a/tests/pthread/test_pthread_sbrk.cpp
+++ b/tests/pthread/test_pthread_sbrk.cpp
@@ -5,7 +5,6 @@
 
 #include <pthread.h>
 #include <emscripten.h>
-#include <emscripten/threading.h>
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
@@ -101,11 +100,6 @@ static void *thread_start(void *arg)
 
 int main()
 {
-  if (!emscripten_has_threading_support()) {
-    printf("Skipped: threading support is not available!\n");
-    return 0;
-  }
-
   printf("starting test, aborting? %d\n", ABORTING_MALLOC);
 
   int ret = pthread_barrier_init(&barrierWaitToAlloc, NULL, NUM_THREADS);

--- a/tests/pthread/test_pthread_volatile.cpp
+++ b/tests/pthread/test_pthread_volatile.cpp
@@ -7,8 +7,6 @@
 #include <pthread.h>
 #include <stdio.h>
 #include <errno.h>
-#include <emscripten.h>
-#include <emscripten/threading.h>
 
 // Toggle to use two different methods for updating shared data (C++03 volatile
 // vs explicit atomic ops).  Note that using a volatile variable explicitly
@@ -30,12 +28,6 @@ static void *thread_start(void *arg) // thread: just flip the shared flag and qu
 
 int main()
 {
-  if (!emscripten_has_threading_support())
-  {
-    printf("Skipped: Threading is not supported.\n");
-    return 0;
-  }
-
   pthread_t thr;
   int rc = pthread_create(&thr, NULL, thread_start, (void*)0);
   if (rc != 0)


### PR DESCRIPTION
These checks are rather pointless since we don't run any of these tests
without thread support enabled.

There are also several downsides to including this check everywhere:

1. Could lead to false positives since the fallback is simply to
   return zero (success).
2. Prevents the tests from being compiled and run outside of emscripten.
3. Add needless complexit to tests and needless includes of
   emscripten-specific headers.

There are some tests that actually do look like they are designed to be
run in two different modes: with real threading and with stubs.  I left
those tests alone, even those I can't see any cases were we actually run
those tests without pthreads enabled in the test suite.