### PR TITLE
Compile emmalloc as C rather than C++. NFC

### DIFF
--- a/system/lib/sbrk.c
+++ b/system/lib/sbrk.c
@@ -109,15 +109,16 @@ Error:
   return (void*)-1;
 }
 
-int brk(uintptr_t ptr) {
+int brk(void* ptr) {
 #if __EMSCRIPTEN_PTHREADS__
   // FIXME
   printf("brk() is not theadsafe yet, https://github.com/emscripten-core/emscripten/issues/10006");
   abort();
-#endif
+#else
   uintptr_t last = (uintptr_t)sbrk(0);
-  if (sbrk(ptr - last) == (void*)-1) {
+  if (sbrk((uintptr_t)ptr - last) == (void*)-1) {
     return -1;
   }
   return 0;
+#endif
 }

--- a/tests/core/test_emmalloc.c
+++ b/tests/core/test_emmalloc.c
@@ -14,7 +14,7 @@
 #define RANDOM_ITERS 12345
 #endif
 
-extern "C" void emmalloc_blank_slate_from_orbit();
+void emmalloc_blank_slate_from_orbit();
 
 void stage(const char* name) {
   EM_ASM({

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -854,10 +854,10 @@ base align: 0, 0, 0, 0'''])
     self.set_setting('MALLOC', 'none')
     self.emcc_args += ['-fno-builtin'] + list(args)
 
-    self.do_run(read_file(path_from_root('system/lib/emmalloc.cpp')) +
+    self.do_run(read_file(path_from_root('system/lib/emmalloc.c')) +
                 read_file(path_from_root('system/lib/sbrk.c')) +
-                read_file(test_file('core/test_emmalloc.cpp')),
-                read_file(test_file('core/test_emmalloc.out')))
+                read_file(test_file('core/test_emmalloc.c')),
+                read_file(test_file('core/test_emmalloc.out')), force_c=True)
 
   @no_asan('ASan does not support custom memory allocators')
   @no_lsan('LSan does not support custom memory allocators')

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1061,7 +1061,7 @@ class libmalloc(MTLibrary):
   def get_files(self):
     malloc_base = self.malloc.replace('-memvalidate', '').replace('-verbose', '').replace('-debug', '')
     malloc = shared.path_from_root('system', 'lib', {
-      'dlmalloc': 'dlmalloc.c', 'emmalloc': 'emmalloc.cpp',
+      'dlmalloc': 'dlmalloc.c', 'emmalloc': 'emmalloc.c',
     }[malloc_base])
     sbrk = shared.path_from_root('system', 'lib', 'sbrk.c')
     return [malloc, sbrk]


### PR DESCRIPTION
It doesn't use any C++ features and this avoids any possible dependency
beforee malloc (part of libc) and libc++/libc++abi (which would be bad).