### PR TITLE
file_packager.py: only store the audio file attribute when true

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -459,7 +459,7 @@ def main():
         ''' % (create_preloaded if use_preload_plugins else create_data, '''
               var files = metadata['files'];
               for (var i = 0; i < files.length; ++i) {
-                new DataRequest(files[i]['start'], files[i]['end'], files[i]['audio']).open('GET', files[i]['filename']);
+                new DataRequest(files[i]['start'], files[i]['end'], files[i]['audio'] || 0).open('GET', files[i]['filename']);
               }
       ''')
 
@@ -478,12 +478,16 @@ def main():
     elif file_['mode'] == 'preload':
       # Preload
       counter += 1
-      metadata['files'].append({
+
+      metadata_el = {
         'filename': file_['dstpath'],
         'start': file_['data_start'],
         'end': file_['data_end'],
-        'audio': 1 if filename[-4:] in AUDIO_SUFFIXES else 0,
-      })
+      }
+      if filename[-4:] in AUDIO_SUFFIXES:
+        metadata_el['audio'] = 1
+
+      metadata['files'].append(metadata_el)
     else:
       assert 0
 


### PR DESCRIPTION
In the .js generated by file_packager.py which currently produces the following attributes for each file,
```
{"filename":"<path>","start":<start>,"end":<end>,"audio":0}
```
(exemple [here](https://cdn.jsdelivr.net/pyodide/v0.18.0a1/full/pyodide.asm.js)) only store the audio attribute when it's set to 1. Otherwise assume that it is 0 (which should be the case for the vast majority of files). Resulting in,
```
{"filename":"<path>","start":<start>,"end":<end>}
```
This saves 9 bytes per file, or in the above linked example about 10kB for 1100 files.

Related to https://github.com/emscripten-core/emscripten/issues/14695