### PR TITLE
Fix missing out/err logging with node + pthreads

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -393,12 +393,26 @@ if (ENVIRONMENT_IS_NODE) {
     global.performance = require('perf_hooks').performance;
   }
 }
-#endif
 
 // Set up the out() and err() hooks, which are how we can print to stdout or
 // stderr, respectively.
+// Normally just binding console.log/console.warn here works fine, but
+// under node (with workers) we see missing/out-of-order messages so route
+// directly to stdout and stderr.
+// See https://github.com/emscripten-core/emscripten/issues/14804
+var defaultPrint = console.log.bind(console);
+var defaultPrintErr = console.warn.bind(console);
+if (ENVIRONMENT_IS_NODE) {
+  var fs = require('fs');
+  defaultPrint = function(str) { fs.writeSync(1, str + '\n'); };
+  defaultPrintErr = function(str) { fs.writeSync(2, str + '\n'); };
+}
+{{{ makeModuleReceiveWithVar('out', 'print',    'defaultPrint',    true) }}}
+{{{ makeModuleReceiveWithVar('err', 'printErr', 'defaultPrintErr', true) }}}
+#else
 {{{ makeModuleReceiveWithVar('out', 'print',    'console.log.bind(console)',  true) }}}
 {{{ makeModuleReceiveWithVar('err', 'printErr', 'console.warn.bind(console)', true) }}}
+#endif
 
 // Merge back in the overrides
 for (key in moduleOverrides) {

--- a/tests/core/pthread/test_pthread_dylink_tls.c
+++ b/tests/core/pthread/test_pthread_dylink_tls.c
@@ -7,8 +7,8 @@ int get_side_tls2();
 int* get_side_tls_address();
 int* get_side_tls_address2();
 
-__thread int main_tls = 10;
-__thread int main_tls2 = 11;
+static __thread int main_tls = 10;
+static __thread int main_tls2 = 11;
 extern __thread int side_tls;
 extern __thread int side_tls2;
 

--- a/tests/other/test_pthread_out_err.c
+++ b/tests/other/test_pthread_out_err.c
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <emscripten/em_asm.h>
+
+void out(const char* msg) {
+  EM_ASM({ out(UTF8ToString($0)); }, msg);
+}
+
+void err(const char* msg) {
+  EM_ASM({ err(UTF8ToString($0)); }, msg);
+}
+
+// Test that stdout/printf and emscripten JS logging functions (out()
+// and err()) are interleaved as expected and all arrive at the console.
+// See https://github.com/emscripten-core/emscripten/issues/14804
+int main() {
+  printf("printf 1\n");
+  out   ("out    1");
+  err   ("err    1");
+  printf("printf 2\n");
+  out   ("out    2");
+  err   ("err    2");
+  printf("printf 3\n");
+  out   ("out    3");
+  err   ("err    3");
+  printf("done\n");
+  return 0;
+}

--- a/tests/other/test_pthread_out_err.out
+++ b/tests/other/test_pthread_out_err.out
@@ -1,0 +1,10 @@
+printf 1
+out    1
+err    1
+printf 2
+out    2
+err    2
+printf 3
+out    3
+err    3
+done

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11090,3 +11090,10 @@ void foo() {}
   def test_windows_batch_script_workaround(self):
     self.run_process([EMCC, test_file('hello_world.c')])
     self.assertExists('a.out.js')
+
+  @node_pthreads
+  def test_pthread_out_err(self):
+    self.set_setting('USE_PTHREADS')
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    self.do_other_test('test_pthread_out_err.c')


### PR DESCRIPTION
Without this fix enabling DEBUG_XXX options is very confusing because message from
the JavaScript side can be lost of out-of-order.

Fixes: #14804