### PR TITLE
Fix init order so that emmalloc comes earlier

### DIFF
--- a/system/lib/README.md
+++ b/system/lib/README.md
@@ -1,0 +1,26 @@
+Source code for C/C++ system libaries
+=====================================
+
+This directory contains the source code for libc, libc++ and other C/C++ system
+libraries.  Where possible these are clones of upstream projects (e.g. musl).
+For more details about each library see the individual readme files in the
+subdirectoris.
+
+Static constructor ordering
+---------------------------
+
+These are several static constructors in the emscripten system libraries and they
+are in a specific order.  When adding/remove/updating these please update this
+document.
+
+These current set of static constructors in system libraries and their priorities
+(lowest run first) are:
+
+- 47: `initialize_emmalloc_heap` (emmalloc.c)
+- 48: `__emscripten_pthread_data_constructor` (pthread/emscripten_tls_init.c)
+- 49: `emscripten_tls_init` (pthread/library_pthread.c)
+- 50: asan init (??)
+
+Priorities 0 - 100 are reserved for system libraries and user-level
+constructors should all run at 101 and above (for example libc++ initializes
+its standard I/O streams at priority 101).

--- a/system/lib/pthread/emscripten_tls_init.c
+++ b/system/lib/pthread/emscripten_tls_init.c
@@ -28,7 +28,7 @@ static void free_tls(void* tls_block) {
   emscripten_builtin_free(tls_block);
 }
 
-// Note that ASan constructor priority is 50, and we must be higher.
+//See system/lib/README.md for static constructor ordering.
 __attribute__((constructor(49)))
 void emscripten_tls_init(void) {
   size_t tls_size = __builtin_wasm_tls_size();

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -885,12 +885,7 @@ EM_JS(void, initPthreadsJS, (void* tb), {
   PThread.initRuntime(tb);
 })
 
-// We must initialize the runtime at the proper time, which is after memory is
-// initialized and before any userland global ctors.  We must also keep this
-// function alive so it is always called.
-// This must run before any userland ctors.
-// Note that ASan constructor priority is 50, and we must be higher.
-EMSCRIPTEN_KEEPALIVE
+// See system/lib/README.md for static constructor ordering.
 __attribute__((constructor(48)))
 void __emscripten_pthread_data_constructor(void) {
   initPthreadsJS(&__main_pthread);

--- a/tests/core/test_emmalloc.c
+++ b/tests/core/test_emmalloc.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 
 #include <emscripten.h>
+#include <emscripten/emmalloc.h>
 
 #ifndef RANDOM_ITERS
 #define RANDOM_ITERS 12345
@@ -17,9 +18,14 @@
 void emmalloc_blank_slate_from_orbit();
 
 void stage(const char* name) {
+  // Using printf here over out, at least until we can fix
+  // https://github.com/emscripten-core/emscripten/issues/14804
+  printf(">> %s\n", name);
+  /*
   EM_ASM({
-    out('\n>> ' + UTF8ToString($0) + '\n');
+    out('>> ' + UTF8ToString($0) + '\n');
   }, name);
+  */
 }
 
 void basics() {
@@ -147,7 +153,7 @@ void aligned() {
       emmalloc_blank_slate_from_orbit();
       size_t first = (size_t)memalign(i, 100);
       size_t second = (size_t)memalign(j, 100);
-      printf("%d %d => %d %d\n", i, j, first, second);
+      printf("%d %d => %zu %zu\n", i, j, first, second);
       check_aligned(i, first);
       check_aligned(j, second);
     }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2363,6 +2363,17 @@ The current type of b is: 9
     self.add_pre_run("Module.onAbort = function() { console.log('onAbort called'); }")
     self.do_run_in_out_file_test('pthread/test_pthread_abort.c', assert_returncode=NON_ZERO)
 
+  @no_asan('ASan does not support custom memory allocators')
+  @no_lsan('LSan does not support custom memory allocators')
+  @node_pthreads
+  def test_pthread_emmalloc(self):
+    self.emcc_args += ['-fno-builtin']
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('ASSERTIONS=2')
+    self.set_setting('MALLOC', 'emmalloc')
+    self.do_core_test('test_emmalloc.c')
+
   def test_tcgetattr(self):
     self.do_runf(test_file('termios/test_tcgetattr.c'), 'success')
 


### PR DESCRIPTION
This allows pthread initialization, for example, to call malloc.

This is an alternative to
https://github.com/emscripten-core/emscripten/pull/14774 which avoids the
static constructor completely.

Fixes: #14766