### PR TITLE
Add `-no-pie` to 'gcc' native benchmarker. NFC

### DIFF
--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -139,8 +139,7 @@ class NativeBenchmarker(Benchmarker):
       native_args = native_args + lib_builder(self.name, native=True, env_init=env)
     if not native_exec:
       compiler = self.cxx if filename.endswith('cpp') else self.cc
-      cmd = [
-        compiler,
+      cmd = compiler + [
         '-fno-math-errno',
         filename,
         '-o', filename + '.native'
@@ -355,8 +354,8 @@ class CheerpBenchmarker(Benchmarker):
 # Benchmarkers
 
 benchmarkers = [
-  NativeBenchmarker('clang', CLANG_CC, CLANG_CXX),
-  # NativeBenchmarker('gcc',   'gcc',    'g++')
+  NativeBenchmarker('clang', [CLANG_CC], [CLANG_CXX]),
+  # NativeBenchmarker('gcc',   ['gcc', '-no-pie'],  ['g++', '-no-pie'])
 ]
 
 if config.V8_ENGINE and config.V8_ENGINE in config.JS_ENGINES:


### PR DESCRIPTION
This means that we don't need to build all our static libraris (e.g.
libz.a) with `-fPIC`.  I guess gcc at some point made `-pie` the default
(or at least the gcc installation on my machine seems to be configured
that way).

Alternative to #14793