### PR TITLE
Warn if MAXIUMUM_MEMORY used without ALLOW_MEMORY_GROWTH. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1978,6 +1978,9 @@ def phase_linker_setup(options, state, newargs, settings_map):
   if settings.MEMORY_GROWTH_LINEAR_STEP != -1:
     check_memory_setting('MEMORY_GROWTH_LINEAR_STEP')
 
+  if 'MAXIMUM_MEMORY' in settings_map and not settings.ALLOW_MEMORY_GROWTH:
+    diagnostics.warning('unused-command-line-argument', 'MAXIMUM_MEMORY is only meaningful with ALLOW_MEMORY_GROWTH')
+
   if settings.EXPORT_ES6 and not settings.MODULARIZE:
     # EXPORT_ES6 requires output to be a module
     if 'MODULARIZE' in settings_map:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2012,15 +2012,14 @@ int main(int argc, char **argv) {
     self.do_core_test('test_memorygrowth_3.c')
 
   @parameterized({
-    'nogrow': (['-s', 'ALLOW_MEMORY_GROWTH=0'],),
-    'grow': (['-s', 'ALLOW_MEMORY_GROWTH'],)
+    'nogrow': ([],),
+    'grow': (['-sALLOW_MEMORY_GROWTH', '-sMAXIMUM_MEMORY=18MB'],)
   })
   @no_asan('requires more memory when growing')
   def test_aborting_new(self, args):
     # test that C++ new properly errors if we fail to malloc when growth is
     # enabled, with or without growth
     self.emcc_args += args
-    self.set_setting('MAXIMUM_MEMORY', '18MB')
     self.do_core_test('test_aborting_new.cpp')
 
   @no_wasm2js('no WebAssembly.Memory()')


### PR DESCRIPTION
Previously we were silently ignoring it.  We considered the alternative
which would be to automatically enable ALLOW_MEMORT_GROWTH but decided
that would be more of a breaking/surprise change.