### PR TITLE
Allow normal program exit to be detected under MINIMAL_RUNTIME

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2031,7 +2031,10 @@ def phase_linker_setup(options, state, newargs, settings_map):
     if options.shell_path == shared.path_from_root('src', 'shell.html'):
       options.shell_path = shared.path_from_root('src', 'shell_minimal_runtime.html')
 
-    if settings.ASSERTIONS and settings.MINIMAL_RUNTIME:
+    if settings.EXIT_RUNTIME:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['proc_exit']
+
+    if settings.ASSERTIONS:
       # In ASSERTIONS-builds, functions UTF8ArrayToString() and stringToUTF8Array() (which are not JS library functions), both
       # use warnOnce(), which in MINIMAL_RUNTIME is a JS library function, so explicitly have to mark dependency to warnOnce()
       # in that case. If string functions are turned to library functions in the future, then JS dependency tracking can be

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -39,7 +39,11 @@ function run() {
 #if ASSERTIONS
   runtimeExited = true;
 #endif
+
+#if EXIT_RUNTIME
+  _proc_exit(ret);
 #endif
+#endif // PROXY_TO_PTHREAD
 
 #if STACK_OVERFLOW_CHECK
   checkStackCookie();
@@ -234,9 +238,10 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
     postMessage({ 'cmd': 'loaded' });
   }
 #endif
+}
 
 #if ASSERTIONS || WASM == 2
-}).catch(function(error) {
+, function(error) {
 #if ASSERTIONS
   console.error(error);
 #endif
@@ -254,5 +259,6 @@ WebAssembly.instantiate(Module['wasm'], imports).then(function(output) {
   }
 #endif
 #endif // WASM == 2
+}
 #endif // ASSERTIONS || WASM == 2
-});
+);

--- a/tests/browser_reporting.js
+++ b/tests/browser_reporting.js
@@ -32,21 +32,26 @@ function reportErrorToServer(message) {
 }
 
 if (typeof window === 'object' && window) {
-  window.addEventListener('error', function(e) {
-    var xhr = new XMLHttpRequest();
+  function report_error(e) {
     // MINIMAL_RUNTIME doesn't handle exit or call the below onExit handler
     // so we detect the exit by parsing the uncaught exception message.
-    var offset = e.message.indexOf('exit(');
+    var message = e.message || e;
+    console.error("got top level error: " + message);
+    var offset = message.indexOf('exit(');
     if (offset != -1) {
-      var status = e.message.substring(offset + 5);
+      var status = message.substring(offset + 5);
       offset = status.indexOf(')')
       status = status.substr(0, offset)
+      console.error(status);
       maybeReportResultToServer('exit:' + status);
     } else {
+      var xhr = new XMLHttpRequest();
       xhr.open('GET', encodeURI('http://localhost:8888?exception=' + e.message + ' / ' + e.stack));
       xhr.send();
     }
-  });
+  }
+  window.addEventListener('error', report_error);
+  window.addEventListener('unhandledrejection', event => report_error(event.reason));
 }
 
 if (hasModule) {

--- a/tests/minimal_runtime_exit_handling.js
+++ b/tests/minimal_runtime_exit_handling.js
@@ -1,0 +1,19 @@
+function onerror(e) {
+  // MINIMAL_RUNTIME + EXIT_RUNTIME throws `exit(status)` when exit() is called
+  // or when main is done.
+  // Unlike the normal runtime it doesn't call process.exit.
+  var message = e.message || e;
+  var offset = message.indexOf('exit(');
+  if (offset != -1) {
+    var status = message.substring(offset + 5);
+    offset = status.indexOf(')')
+    status = status.substr(0, offset)
+    process['exitCode'] = status;
+  } else {
+    console.log(e)
+    process['exitCode'] = 1;
+  }
+}
+
+// Unhandled rejections end up here too because we run node with --unhandled-rejections=throw
+process.on('uncaughtException', function(err, origin) { onerror(err); });

--- a/tests/small_hello_world.c
+++ b/tests/small_hello_world.c
@@ -3,7 +3,4 @@
 int main()
 {
 	emscripten_console_log("hello!");
-#ifdef REPORT_RESULT
-	REPORT_RESULT(0);
-#endif
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1034,6 +1034,7 @@ int main()
     self.set_setting('EXIT_RUNTIME')
     self.maybe_closure()
     self.set_setting('MINIMAL_RUNTIME')
+    self.emcc_args += ['--pre-js', test_file('minimal_runtime_exit_handling.js')]
     for support_longjmp in [0, 1]:
       self.set_setting('SUPPORT_LONGJMP', support_longjmp)
 
@@ -1041,12 +1042,7 @@ int main()
       self.do_run_from_file(test_file('core/test_exceptions.cpp'), test_file('core/test_exceptions_caught.out'))
 
       self.set_setting('DISABLE_EXCEPTION_CATCHING')
-      expect_fail = True
-      if self.is_wasm() and not is_optimizing(self.emcc_args):
-        # TODO: Debug builds with MINIMAL_RUNTIME currrently catch unhandled exceptions
-        # thrown during `_main`
-        expect_fail = False
-      self.do_run_from_file(test_file('core/test_exceptions.cpp'), test_file('core/test_exceptions_uncaught.out'), assert_returncode=NON_ZERO if expect_fail else 0)
+      self.do_run_from_file(test_file('core/test_exceptions.cpp'), test_file('core/test_exceptions_uncaught.out'), assert_returncode=NON_ZERO)
 
   @with_both_exception_handling
   def test_exceptions_custom(self):
@@ -1899,12 +1895,7 @@ int main(int argc, char **argv) {
     self.set_setting('MINIMAL_RUNTIME')
     src = test_file('core/test_memorygrowth.c')
     # Fail without memory growth
-    expect_fail = True
-    if self.is_wasm() and not is_optimizing(self.emcc_args):
-      # TODO: Debug builds with MINIMAL_RUNTIME currrently catch unhandled exceptions
-      # thrown during `_main`
-      expect_fail = False
-    self.do_runf(src, 'OOM', assert_returncode=NON_ZERO if expect_fail else 0)
+    self.do_runf(src, 'OOM', assert_returncode=NON_ZERO)
     # Win with it
     self.set_setting('ALLOW_MEMORY_GROWTH')
     self.do_runf(src, '*pre: hello,4.955*\n*hello,4.955*\n*hello,4.955*')


### PR DESCRIPTION
Followup to #14586 which allowed the test framework to detect `exit()`
calls with MINIMAL_RUNTIME + EXIT_RUNTIME.    This change extends
that support to normal program exit (returning from main)  which was previously
undetectable.

We also add a `window.unhandledrejection` handler to
`browser_reporting.js` since under MINIMAL_RUNTIME that main function
runs in the `then()` handler of `WebAssembly.instantiate` and so any
exceptions thown from there show up as unhandled promise rejections.
This change is generally useful, and enables us to detech more types
of errors during testing.

I've also moved error handling code for MINIMAL_RUNTIME from a
`WebAssembly.instantiate.then().catch()` to the `onerror` handler of the
`WebAssembly.instantiate.then()`.  This means that is will now catch
only errors during `WebAssembly.instantiate` and not excpetions throwns
by user code after instantiation.  This avoids the JS fallback handling
code in the case the application throws and exceptions or calls exit().