### PR TITLE
Avoid fflush export in STANDALONE_WASM mode

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1818,7 +1818,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
       '$stackTrace'
     ]
 
-  if settings.FILESYSTEM and not settings.BOOTSTRAPPING_STRUCT_INFO:
+  if settings.FILESYSTEM and not settings.BOOTSTRAPPING_STRUCT_INFO and not settings.STANDALONE_WASM:
     # to flush streams on FS exit, we need to be able to call fflush
     # we only include it if the runtime is exitable, or when ASSERTIONS
     # (ASSERTIONS will check that streams do not need to be flushed,


### PR DESCRIPTION
STANDALONE_WASM flushes its std streams on exit via calling
`__stdio_exit` (from musl/src/stdio/__stdio_exit.c) form `exit` (from
musl/src/exit/exit.c).