### PR TITLE
Remove auto-skip of missing SharedArrayBuffer. NFC

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -306,7 +306,6 @@ assert(typeof Int32Array !== 'undefined' && typeof Float64Array !== 'undefined' 
 #endif
 
 #if IN_TEST_HARNESS
-
 // Test runs in browsers should always be free from uncaught exceptions. If an uncaught exception is thrown, we fail browser test execution in the REPORT_RESULT() macro to output an error value.
 if (ENVIRONMENT_IS_WEB) {
   window.addEventListener('error', function(e) {
@@ -315,15 +314,6 @@ if (ENVIRONMENT_IS_WEB) {
     Module['pageThrewException'] = true;
   });
 }
-
-#if USE_PTHREADS
-if (typeof SharedArrayBuffer === 'undefined' || typeof Atomics === 'undefined') {
-  var xhr = new XMLHttpRequest();
-  xhr.open('GET', 'http://localhost:8888/report_result?skipped:%20SharedArrayBuffer%20is%20not%20supported!');
-  xhr.send();
-  setTimeout(function() { window.close() }, 2000);
-}
-#endif
 #endif
 
 #if IMPORTED_MEMORY


### PR DESCRIPTION
We already have the `@requires_threads` on all tests that
require threads and `EMTEST_LACKS_THREAD_SUPPORT` for those
that want to skip them.