### PR TITLE
Perform full `pthread_exit` logic on return from thread entry point

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1857,6 +1857,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
       '__emscripten_call_on_thread',
       '__emscripten_main_thread_futex',
       '__emscripten_thread_init',
+      '__emscripten_thread_exit',
       '_emscripten_current_thread_process_queued_calls',
       '__emscripten_allow_main_runtime_queued_calls',
       '_emscripten_futex_wake',
@@ -1870,7 +1871,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
       '_emscripten_tls_init',
       '_pthread_self',
       '_pthread_testcancel',
-      '_pthread_exit',
     ]
     # Some of these symbols are using by worker.js but otherwise unreferenced.
     # Because emitDCEGraph only considered the main js file, and not worker.js

--- a/src/library.js
+++ b/src/library.js
@@ -3632,20 +3632,20 @@ LibraryManager.library = {
     }
     try {
       func();
+#if EXIT_RUNTIME || USE_PTHREADS
+#if USE_PTHREADS && !EXIT_RUNTIME
+      if (ENVIRONMENT_IS_PTHREAD)
+#endif
+        maybeExit();
+#endif
     } catch (e) {
       handleException(e);
     }
-#if EXIT_RUNTIME || USE_PTHREADS
-#if USE_PTHREADS && !EXIT_RUNTIME
-    if (ENVIRONMENT_IS_PTHREAD)
-#endif
-      maybeExit();
-#endif
   },
 
   $maybeExit__deps: ['exit', '$handleException',
 #if USE_PTHREADS
-    'pthread_exit',
+    '_emscripten_thread_exit',
 #endif
   ],
   $maybeExit: function() {
@@ -3658,7 +3658,7 @@ LibraryManager.library = {
 #endif
       try {
 #if USE_PTHREADS
-        if (ENVIRONMENT_IS_PTHREAD) _pthread_exit(EXITSTATUS);
+        if (ENVIRONMENT_IS_PTHREAD) __emscripten_thread_exit(EXITSTATUS);
         else
 #endif
         _exit(EXITSTATUS);

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -55,8 +55,6 @@ var LibraryPThread = {
       // things.
       PThread['receiveObjectTransfer'] = PThread.receiveObjectTransfer;
       PThread['threadInit'] = PThread.threadInit;
-      PThread['threadCancel'] = PThread.threadCancel;
-      PThread['threadExit'] = PThread.threadExit;
       PThread['setExitStatus'] = PThread.setExitStatus;
 #endif
     },
@@ -162,29 +160,6 @@ var LibraryPThread = {
 
     setExitStatus: function(status) {
       EXITSTATUS = status;
-    },
-
-    // Called when we are performing a pthread_exit(), either explicitly called
-    // by programmer, or implicitly when leaving the thread main function.
-    threadExit: function(exitCode) {
-      var tb = _pthread_self();
-      if (tb) { // If we haven't yet exited?
-#if PTHREADS_DEBUG
-        out('Pthread 0x' + tb.toString(16) + ' exited.');
-#endif
-        PThread.runExitHandlersAndDeinitThread(tb, exitCode);
-
-        if (ENVIRONMENT_IS_PTHREAD) {
-          // Note: in theory we would like to return any offscreen canvases back to the main thread,
-          // but if we ever fetched a rendering context for them that would not be valid, so we don't try.
-          postMessage({ 'cmd': 'exit' });
-        }
-      }
-    },
-
-    threadCancel: function() {
-      PThread.runExitHandlersAndDeinitThread(_pthread_self(), -1/*PTHREAD_CANCELED*/);
-      postMessage({ 'cmd': 'cancelDone' });
     },
 
     terminateAllThreads: function() {
@@ -992,12 +967,22 @@ var LibraryPThread = {
 
   __pthread_exit_js__deps: ['exit'],
   __pthread_exit_js: function(status) {
+    // Called when we are performing a pthread_exit(), either explicitly called
+    // by programmer, or implicitly when leaving the thread main function.
     if (!ENVIRONMENT_IS_PTHREAD) {
       PThread.runExitHandlers();
       _exit(status);
-    } else PThread.threadExit(status);
-    // pthread_exit is marked noReturn, so we must not return from it.
-    throw 'unwind';
+    } else {
+      var tb = _pthread_self();
+#if PTHREADS_DEBUG
+      out('Pthread 0x' + tb.toString(16) + ' exited.');
+#endif
+      PThread.runExitHandlersAndDeinitThread(tb, status);
+
+      // Note: in theory we would like to return any offscreen canvases back to the main thread,
+      // but if we ever fetched a rendering context for them that would not be valid, so we don't try.
+      postMessage({ 'cmd': 'exit' });
+    }
   },
 
   __cxa_thread_atexit__sig: 'vii',

--- a/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -2,7 +2,6 @@ $GetQueue
 $__emscripten_pthread_data_constructor
 $__errno_location
 $__pthread_create
-$__pthread_exit
 $__pthread_mutex_lock
 $__pthread_mutex_trylock
 $__pthread_mutex_unlock
@@ -14,6 +13,7 @@ $__wasm_init_memory
 $_do_call
 $_emscripten_call_on_thread
 $_emscripten_do_dispatch_to_thread
+$_emscripten_thread_exit
 $_emscripten_thread_init
 $_main_thread
 $_pthread_isduecanceled


### PR DESCRIPTION
Split the logic from `pthread_exit` into `_emscripten_pthread_exit`
so it can be called after return from thread main rather than just
the `threadExit` part.

This is a useful precursor to the musl upgrade and was split
out from #13006.  With that change, the native part of `pthread_exit`
performs part of the shutdown process.

Calling `_emscripten_pthread_exit` can also be used to perform
a thread exit without the `unwind` exception being thrown in places
where we don't need to unwind.