### PR TITLE
Add test for MINIMAL_RUNTIME + STRICT_JS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1538,6 +1538,8 @@ def phase_linker_setup(options, state, newargs, settings_map):
   # errno support by default.
   if settings.MINIMAL_RUNTIME:
     default_setting('SUPPORT_ERRNO', 0)
+    # Require explicit -lfoo.js flags to link with JS libraries.
+    default_setting('AUTO_JS_LIBRARIES', 0)
 
   if settings.STRICT:
     default_setting('STRICT_JS', 1)
@@ -1547,6 +1549,9 @@ def phase_linker_setup(options, state, newargs, settings_map):
     default_setting('IGNORE_MISSING_MAIN', 0)
     default_setting('DEFAULT_TO_CXX', 0)
     default_setting('ALLOW_UNIMPLEMENTED_SYSCALLS', 0)
+
+  if not settings.AUTO_JS_LIBRARIES:
+    default_setting('USE_SDL', 0)
 
   # Default to TEXTDECODER=2 (always use TextDecoder to decode UTF-8 strings)
   # in -Oz builds, since custom decoder for UTF-8 takes up space.
@@ -2027,9 +2032,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
       # in that case. If string functions are turned to library functions in the future, then JS dependency tracking can be
       # used and this special directive can be dropped.
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$warnOnce']
-
-    # Require explicit -lfoo.js flags to link with JS libraries.
-    settings.AUTO_JS_LIBRARIES = 0
 
   if settings.MODULARIZE and not (settings.EXPORT_ES6 and not settings.SINGLE_FILE) and \
      settings.EXPORT_NAME == 'Module' and options.oformat == OFormat.HTML and \

--- a/src/library.js
+++ b/src/library.js
@@ -583,7 +583,7 @@ LibraryManager.library = {
   timelocal: 'mktime',
 
 #if MINIMAL_RUNTIME
-  gmtime_r__deps: ['allocateUTF8'],
+  gmtime_r__deps: ['$allocateUTF8'],
 #endif
   gmtime_r__sig: 'iii',
   gmtime_r: function(time, tmPtr) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1338,6 +1338,8 @@ var LEGALIZE_JS_FFI = 1;
 // Specify the SDL version that is being linked against.
 // 1, the default, is 1.3, which is implemented in JS
 // 2 is a port of the SDL C code on emscripten-ports
+// When AUTO_JS_LIBRARIES is set to 0 this defaults to 0 and SDL
+// is not linked in.
 // [link]
 var USE_SDL = 1;
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7773,6 +7773,9 @@ end
   def test_full_js_library_no_exception_throwing(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY', '-sDISABLE_EXCEPTION_THROWING'])
 
+  def test_full_js_library_minimal_runtime(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-sSTRICT_JS', '-sINCLUDE_FULL_LIBRARY', '-sMINIMAL_RUNTIME'])
+
   def test_closure_full_js_library(self):
     # test for closure errors in the entire JS library
     # We must ignore various types of errors that are expected in this situation, as we


### PR DESCRIPTION
Also, when AUTO_JS_LIBRARIES is set to 0 (as it is by default in
MINIMAL_RUNTIME mode) we don't want to be including SDL by default
(since it depends on other JS libraies such as library_browser.js).