### PR TITLE
Only warn about unimplemented syscalls when assertions are enabled.

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1451,15 +1451,21 @@ function unimplementedSycall(name) {
   SyscallsLibrary[name + '__nothrow'] = true;
   SyscallsLibrary[name + '__proxy'] = false;
   SyscallsLibrary[name + '__unimplemented'] = true;
-  msg = `\n  err('warning: unsupported syscall: ${name}');`;
+  const errcode = cDefine('ENOSYS');
+#if ASSERTIONS
+  const msg = `\n  err('warning: unsupported syscall: ${name}');`;
   if (SyscallsLibrary[name]) {
     SyscallsLibrary[name] = modifyFunction(SyscallsLibrary[name].toString(), (name, args, body) => {
             return `function(${args}) {\n  ${msg}${body}\n}\n`;
           });
   } else {
-    errcode = cDefine('ENOSYS');
     SyscallsLibrary[name] = `function() {\n  ${msg}return -${errcode};\n}`;
   }
+#else
+  if (!SyscallsLibrary[name]) {
+    SyscallsLibrary[name] = `function() { return -${errcode};\n}`;
+  }
+#endif
 }
 
 [

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10832,6 +10832,11 @@ void foo() {}
       err = self.run_js('a.out.js')
       self.assertContained('warning: unsupported syscall: __sys_mincore', err)
 
+      # Setting ASSERTIONS=0 should avoid the runtime warning
+      self.run_process(cmd + ['-sASSERTIONS=0'])
+      err = self.run_js('a.out.js')
+      self.assertNotContained('warning: unsupported syscall', err)
+
   @require_v8
   def test_missing_shell_support(self):
     # By default shell support is not included


### PR DESCRIPTION
Fixes: https://github.com/emscripten-core/emsdk/issues/865