### PR TITLE
Simplify pthread_testcancel. NFC

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -233,9 +233,7 @@ self.onmessage = function(e) {
         }
 #endif
       } catch(ex) {
-        if (ex === 'Canceled!') {
-          Module['PThread'].threadCancel();
-        } else if (ex != 'unwind') {
+        if (ex != 'unwind') {
 #if ASSERTIONS
           // FIXME(sbc): Figure out if this is still needed or useful.  Its not
           // clear to me how this check could ever fail.  In order to get into

--- a/system/lib/pthread/pthread_testcancel.c
+++ b/system/lib/pthread/pthread_testcancel.c
@@ -7,7 +7,6 @@
 
 #include "pthread_impl.h"
 #include <pthread.h>
-#include <emscripten/em_asm.h>
 
 int _pthread_isduecanceled(struct pthread* pthread_ptr) {
   return pthread_ptr->threadStatus == 2 /*canceled*/;
@@ -18,7 +17,7 @@ void __pthread_testcancel() {
   if (self->canceldisable)
     return;
   if (_pthread_isduecanceled(self)) {
-    EM_ASM(throw 'Canceled!');
+    pthread_exit(PTHREAD_CANCELED);
   }
 }
 


### PR DESCRIPTION
Simply use `pthread_exit` avoid the extra `EM_ASM` and specific new
exception string.

This also happens to be how much implements this. See
musl/src/thread/pthread_cancel.c