### PR TITLE
In STRICT mode set DEFAULT_TO_CXX setting before the compiler phase

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1197,6 +1197,13 @@ def phase_setup(options, state, newargs, settings_map):
     diagnostics.warning('deprecated', 'RUNTIME_LINKED_LIBS is deprecated; you can simply list the libraries directly on the commandline now')
     newargs += settings.RUNTIME_LINKED_LIBS
 
+  def default_setting(name, new_default):
+    if name not in settings_map:
+      setattr(settings, name, new_default)
+
+  if settings.STRICT:
+    default_setting('DEFAULT_TO_CXX', 0)
+
   # Find input files
 
   # These three arrays are used to store arguments of different types for
@@ -1545,7 +1552,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
     default_setting('AUTO_NATIVE_LIBRARIES', 0)
     default_setting('AUTO_ARCHIVE_INDEXES', 0)
     default_setting('IGNORE_MISSING_MAIN', 0)
-    default_setting('DEFAULT_TO_CXX', 0)
     default_setting('ALLOW_UNIMPLEMENTED_SYSCALLS', 0)
 
   # Default to TEXTDECODER=2 (always use TextDecoder to decode UTF-8 strings)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10001,10 +10001,15 @@ Module.arguments has been replaced with plain arguments_ (the initial value can 
     err = self.expect_fail([EMCC, '-std=gnu11', '-c', 'foo.h'])
     self.assertContained("'-std=gnu11' not allowed with 'C++'", err)
 
-    # If we disable DEFAULT_TO_CXX the emcc can be used with cflags, but can't be used to build
-    # C++ headers
+    # If we disable DEFAULT_TO_CXX the emcc can be used with C-only flags (e.g. -std=gnu11),
     self.run_process([EMCC, '-std=gnu11', '-c', 'foo.h', '-s', 'DEFAULT_TO_CXX=0'])
+
+    # But can't be used to build C++ headers
     err = self.expect_fail([EMCC, '-c', 'cxxfoo.h', '-s', 'DEFAULT_TO_CXX=0'])
+    self.assertContained("'string' file not found", err)
+
+    # Check that STRICT also disables DEFAULT_TO_CXX
+    err = self.expect_fail([EMCC, '-c', 'cxxfoo.h', '-s', 'STRICT'])
     self.assertContained("'string' file not found", err)
 
     # Using em++ should alwasy work for C++ headers


### PR DESCRIPTION
Without this the setting of `DEFAULT_TO_CXX` does not effect
the compile phase.