### PR TITLE
Fix pthreads+dylink+long .so names

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -272,7 +272,7 @@ var LibraryDylink = {
     if (binary instanceof WebAssembly.Module) {
       var dylinkSection = WebAssembly.Module.customSections(binary, "dylink");
       assert(dylinkSection.length != 0, 'need dylink section');
-      binary = new Int8Array(dylinkSection[0]);
+      binary = new Uint8Array(dylinkSection[0]);
     } else {
       var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
       assert(int32View[0] == 0x6d736100, 'need to see wasm magic number'); // \0asm


### PR DESCRIPTION
In pthreads mode, TextDecoder is wrapped in a special way. The logic there
receives buffers and copies them. It asserts the buffer is a `Uint8array`. The
dylink code hits that assertion as it creates a `Int8Array` and sends it there.
We could make the wrapper support signed views too, but it seems simpler
to just use the same unsigned view there, which is clearer anyhow.

Fixes #14833