### PR TITLE
Don't free thread data until after terminating workers

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -156,8 +156,8 @@ var LibraryPThread = {
 #if ASSERTIONS
         assert(pthread, 'This Worker should have a pthread it is executing');
 #endif
-        PThread.freeThreadData(pthread);
         worker.terminate();
+        PThread.freeThreadData(pthread);
       }
       PThread.runningWorkers = [];
     },


### PR DESCRIPTION
Freeing the thread data while the worker hosting the thread is still
running could cause issues in the final moments of the workers life.