### PR TITLE
Allow `abort` to be called in pthread workers

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -574,9 +574,6 @@ function abort(what) {
   }
 #endif
 
-#if USE_PTHREADS
-  assert(!ENVIRONMENT_IS_PTHREAD);
-#endif
   what += '';
   err(what);
 


### PR DESCRIPTION
The `_abort` library function gets proxied back to the main thread so
doesn't env up calling this function.  However direct calls to the
`abort` runtime function can occur in JS code.  More importantly
worker.js defines `assert` in terms of abort:

```
function assert(condition, text) {
  if (!condition) abort('Assertion failed: ' + text);
}
```

Without this fix `assert` calls from `worker.js` will end up in infinite
recursion.