### PR TITLE
[WebGPU] Rename RenderPipeline2 and RenderPipelineDescriptor2

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -575,3 +575,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * José Cadete <crudelios@gmail.com>
 * Cynthia K. Rey <cynthia@cynthia.dev>
 * Andrew Shaitorov <andrew.shaitorov@gmail.com>
+* James Price <jrprice@google.com> (copyright owned by Google, Inc.)

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -941,7 +941,7 @@ var LibraryWebGPU = {
     abort('unimplemented (TODO)');
   },
 
-  wgpuDeviceCreateRenderPipeline2: function(deviceId, descriptor) {
+  wgpuDeviceCreateRenderPipeline: function(deviceId, descriptor) {
     {{{ gpu.makeCheckDescriptor('descriptor') }}}
 
     function makePrimitiveState(rsPtr) {
@@ -1114,19 +1114,19 @@ var LibraryWebGPU = {
     var desc = {
       "label": undefined,
       "layout": WebGPU.mgrPipelineLayout.get(
-        {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPipelineDescriptor2.layout, '*') }}}),
+        {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPipelineDescriptor.layout, '*') }}}),
       "vertex": makeVertexState(
-        descriptor + {{{ C_STRUCTS.WGPURenderPipelineDescriptor2.vertex }}}),
+        descriptor + {{{ C_STRUCTS.WGPURenderPipelineDescriptor.vertex }}}),
       "primitive": makePrimitiveState(
-        descriptor + {{{ C_STRUCTS.WGPURenderPipelineDescriptor2.primitive }}}),
+        descriptor + {{{ C_STRUCTS.WGPURenderPipelineDescriptor.primitive }}}),
       "depthStencil": makeDepthStencilState(
-        {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPipelineDescriptor2.depthStencil, '*') }}}),
+        {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPipelineDescriptor.depthStencil, '*') }}}),
       "multisample": makeMultisampleState(
-        descriptor + {{{ C_STRUCTS.WGPURenderPipelineDescriptor2.multisample }}}),
+        descriptor + {{{ C_STRUCTS.WGPURenderPipelineDescriptor.multisample }}}),
       "fragment": makeFragmentState(
-        {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPipelineDescriptor2.fragment, '*') }}}),
+        {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPipelineDescriptor.fragment, '*') }}}),
     };
-    var labelPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPipelineDescriptor2.label, '*') }}};
+    var labelPtr = {{{ makeGetValue('descriptor', C_STRUCTS.WGPURenderPipelineDescriptor.label, '*') }}};
     if (labelPtr) desc["label"] = UTF8ToString(labelPtr);
 
     var device = WebGPU["mgrDevice"].get(deviceId);

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1709,7 +1709,7 @@
                 "targetCount",
                 "targets"
             ],
-            "WGPURenderPipelineDescriptor2": [
+            "WGPURenderPipelineDescriptor": [
                 "nextInChain",
                 "label",
                 "layout",

--- a/system/include/webgpu/webgpu.h
+++ b/system/include/webgpu/webgpu.h
@@ -924,7 +924,7 @@ typedef struct WGPUFragmentState {
     WGPUColorTargetState const * targets;
 } WGPUFragmentState;
 
-typedef struct WGPURenderPipelineDescriptor2 {
+typedef struct WGPURenderPipelineDescriptor {
     WGPUChainedStruct const * nextInChain;
     char const * label;
     WGPUPipelineLayout layout;
@@ -933,7 +933,7 @@ typedef struct WGPURenderPipelineDescriptor2 {
     WGPUDepthStencilState const * depthStencil;
     WGPUMultisampleState multisample;
     WGPUFragmentState const * fragment;
-} WGPURenderPipelineDescriptor2;
+} WGPURenderPipelineDescriptor;
 
 #ifdef __cplusplus
 extern "C" {
@@ -1024,8 +1024,8 @@ typedef void (*WGPUProcDeviceCreateComputePipelineAsync)(WGPUDevice device, WGPU
 typedef WGPUPipelineLayout (*WGPUProcDeviceCreatePipelineLayout)(WGPUDevice device, WGPUPipelineLayoutDescriptor const * descriptor);
 typedef WGPUQuerySet (*WGPUProcDeviceCreateQuerySet)(WGPUDevice device, WGPUQuerySetDescriptor const * descriptor);
 typedef WGPURenderBundleEncoder (*WGPUProcDeviceCreateRenderBundleEncoder)(WGPUDevice device, WGPURenderBundleEncoderDescriptor const * descriptor);
-typedef WGPURenderPipeline (*WGPUProcDeviceCreateRenderPipeline2)(WGPUDevice device, WGPURenderPipelineDescriptor2 const * descriptor);
-typedef void (*WGPUProcDeviceCreateRenderPipelineAsync)(WGPUDevice device, WGPURenderPipelineDescriptor2 const * descriptor, WGPUCreateRenderPipelineAsyncCallback callback, void * userdata);
+typedef WGPURenderPipeline (*WGPUProcDeviceCreateRenderPipeline)(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor);
+typedef void (*WGPUProcDeviceCreateRenderPipelineAsync)(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncCallback callback, void * userdata);
 typedef WGPUSampler (*WGPUProcDeviceCreateSampler)(WGPUDevice device, WGPUSamplerDescriptor const * descriptor);
 typedef WGPUShaderModule (*WGPUProcDeviceCreateShaderModule)(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor);
 typedef WGPUSwapChain (*WGPUProcDeviceCreateSwapChain)(WGPUDevice device, WGPUSurface surface, WGPUSwapChainDescriptor const * descriptor);
@@ -1217,8 +1217,8 @@ WGPU_EXPORT void wgpuDeviceCreateComputePipelineAsync(WGPUDevice device, WGPUCom
 WGPU_EXPORT WGPUPipelineLayout wgpuDeviceCreatePipelineLayout(WGPUDevice device, WGPUPipelineLayoutDescriptor const * descriptor);
 WGPU_EXPORT WGPUQuerySet wgpuDeviceCreateQuerySet(WGPUDevice device, WGPUQuerySetDescriptor const * descriptor);
 WGPU_EXPORT WGPURenderBundleEncoder wgpuDeviceCreateRenderBundleEncoder(WGPUDevice device, WGPURenderBundleEncoderDescriptor const * descriptor);
-WGPU_EXPORT WGPURenderPipeline wgpuDeviceCreateRenderPipeline2(WGPUDevice device, WGPURenderPipelineDescriptor2 const * descriptor);
-WGPU_EXPORT void wgpuDeviceCreateRenderPipelineAsync(WGPUDevice device, WGPURenderPipelineDescriptor2 const * descriptor, WGPUCreateRenderPipelineAsyncCallback callback, void * userdata);
+WGPU_EXPORT WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor);
+WGPU_EXPORT void wgpuDeviceCreateRenderPipelineAsync(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncCallback callback, void * userdata);
 WGPU_EXPORT WGPUSampler wgpuDeviceCreateSampler(WGPUDevice device, WGPUSamplerDescriptor const * descriptor);
 WGPU_EXPORT WGPUShaderModule wgpuDeviceCreateShaderModule(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor);
 WGPU_EXPORT WGPUSwapChain wgpuDeviceCreateSwapChain(WGPUDevice device, WGPUSurface surface, WGPUSwapChainDescriptor const * descriptor);

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -624,7 +624,7 @@ namespace wgpu {
     struct RenderPassDescriptor;
     struct VertexState;
     struct FragmentState;
-    struct RenderPipelineDescriptor2;
+    struct RenderPipelineDescriptor;
 
     template<typename Derived, typename CType>
     class ObjectBase {
@@ -828,8 +828,8 @@ namespace wgpu {
         PipelineLayout CreatePipelineLayout(PipelineLayoutDescriptor const * descriptor) const;
         QuerySet CreateQuerySet(QuerySetDescriptor const * descriptor) const;
         RenderBundleEncoder CreateRenderBundleEncoder(RenderBundleEncoderDescriptor const * descriptor) const;
-        RenderPipeline CreateRenderPipeline2(RenderPipelineDescriptor2 const * descriptor) const;
-        void CreateRenderPipelineAsync(RenderPipelineDescriptor2 const * descriptor, CreateRenderPipelineAsyncCallback callback, void * userdata) const;
+        RenderPipeline CreateRenderPipeline(RenderPipelineDescriptor const * descriptor) const;
+        void CreateRenderPipelineAsync(RenderPipelineDescriptor const * descriptor, CreateRenderPipelineAsyncCallback callback, void * userdata) const;
         Sampler CreateSampler(SamplerDescriptor const * descriptor = nullptr) const;
         ShaderModule CreateShaderModule(ShaderModuleDescriptor const * descriptor) const;
         SwapChain CreateSwapChain(Surface const& surface, SwapChainDescriptor const * descriptor) const;
@@ -1470,7 +1470,7 @@ namespace wgpu {
         ColorTargetState const * targets;
     };
 
-    struct RenderPipelineDescriptor2 {
+    struct RenderPipelineDescriptor {
         ChainedStruct const * nextInChain = nullptr;
         char const * label = nullptr;
         PipelineLayout layout = nullptr;

--- a/system/lib/webgpu/webgpu_cpp.cpp
+++ b/system/lib/webgpu/webgpu_cpp.cpp
@@ -1272,27 +1272,27 @@ namespace wgpu {
     static_assert(offsetof(FragmentState, targets) == offsetof(WGPUFragmentState, targets),
             "offsetof mismatch for FragmentState::targets");
 
-    // RenderPipelineDescriptor2
+    // RenderPipelineDescriptor
 
-    static_assert(sizeof(RenderPipelineDescriptor2) == sizeof(WGPURenderPipelineDescriptor2), "sizeof mismatch for RenderPipelineDescriptor2");
-    static_assert(alignof(RenderPipelineDescriptor2) == alignof(WGPURenderPipelineDescriptor2), "alignof mismatch for RenderPipelineDescriptor2");
+    static_assert(sizeof(RenderPipelineDescriptor) == sizeof(WGPURenderPipelineDescriptor), "sizeof mismatch for RenderPipelineDescriptor");
+    static_assert(alignof(RenderPipelineDescriptor) == alignof(WGPURenderPipelineDescriptor), "alignof mismatch for RenderPipelineDescriptor");
 
-    static_assert(offsetof(RenderPipelineDescriptor2, nextInChain) == offsetof(WGPURenderPipelineDescriptor2, nextInChain),
-            "offsetof mismatch for RenderPipelineDescriptor2::nextInChain");
-    static_assert(offsetof(RenderPipelineDescriptor2, label) == offsetof(WGPURenderPipelineDescriptor2, label),
-            "offsetof mismatch for RenderPipelineDescriptor2::label");
-    static_assert(offsetof(RenderPipelineDescriptor2, layout) == offsetof(WGPURenderPipelineDescriptor2, layout),
-            "offsetof mismatch for RenderPipelineDescriptor2::layout");
-    static_assert(offsetof(RenderPipelineDescriptor2, vertex) == offsetof(WGPURenderPipelineDescriptor2, vertex),
-            "offsetof mismatch for RenderPipelineDescriptor2::vertex");
-    static_assert(offsetof(RenderPipelineDescriptor2, primitive) == offsetof(WGPURenderPipelineDescriptor2, primitive),
-            "offsetof mismatch for RenderPipelineDescriptor2::primitive");
-    static_assert(offsetof(RenderPipelineDescriptor2, depthStencil) == offsetof(WGPURenderPipelineDescriptor2, depthStencil),
-            "offsetof mismatch for RenderPipelineDescriptor2::depthStencil");
-    static_assert(offsetof(RenderPipelineDescriptor2, multisample) == offsetof(WGPURenderPipelineDescriptor2, multisample),
-            "offsetof mismatch for RenderPipelineDescriptor2::multisample");
-    static_assert(offsetof(RenderPipelineDescriptor2, fragment) == offsetof(WGPURenderPipelineDescriptor2, fragment),
-            "offsetof mismatch for RenderPipelineDescriptor2::fragment");
+    static_assert(offsetof(RenderPipelineDescriptor, nextInChain) == offsetof(WGPURenderPipelineDescriptor, nextInChain),
+            "offsetof mismatch for RenderPipelineDescriptor::nextInChain");
+    static_assert(offsetof(RenderPipelineDescriptor, label) == offsetof(WGPURenderPipelineDescriptor, label),
+            "offsetof mismatch for RenderPipelineDescriptor::label");
+    static_assert(offsetof(RenderPipelineDescriptor, layout) == offsetof(WGPURenderPipelineDescriptor, layout),
+            "offsetof mismatch for RenderPipelineDescriptor::layout");
+    static_assert(offsetof(RenderPipelineDescriptor, vertex) == offsetof(WGPURenderPipelineDescriptor, vertex),
+            "offsetof mismatch for RenderPipelineDescriptor::vertex");
+    static_assert(offsetof(RenderPipelineDescriptor, primitive) == offsetof(WGPURenderPipelineDescriptor, primitive),
+            "offsetof mismatch for RenderPipelineDescriptor::primitive");
+    static_assert(offsetof(RenderPipelineDescriptor, depthStencil) == offsetof(WGPURenderPipelineDescriptor, depthStencil),
+            "offsetof mismatch for RenderPipelineDescriptor::depthStencil");
+    static_assert(offsetof(RenderPipelineDescriptor, multisample) == offsetof(WGPURenderPipelineDescriptor, multisample),
+            "offsetof mismatch for RenderPipelineDescriptor::multisample");
+    static_assert(offsetof(RenderPipelineDescriptor, fragment) == offsetof(WGPURenderPipelineDescriptor, fragment),
+            "offsetof mismatch for RenderPipelineDescriptor::fragment");
 
     // BindGroup
 
@@ -1533,12 +1533,12 @@ namespace wgpu {
         auto result = wgpuDeviceCreateRenderBundleEncoder(Get(), reinterpret_cast<WGPURenderBundleEncoderDescriptor const * >(descriptor));
         return RenderBundleEncoder::Acquire(result);
     }
-    RenderPipeline Device::CreateRenderPipeline2(RenderPipelineDescriptor2 const * descriptor) const {
-        auto result = wgpuDeviceCreateRenderPipeline2(Get(), reinterpret_cast<WGPURenderPipelineDescriptor2 const * >(descriptor));
+    RenderPipeline Device::CreateRenderPipeline(RenderPipelineDescriptor const * descriptor) const {
+        auto result = wgpuDeviceCreateRenderPipeline(Get(), reinterpret_cast<WGPURenderPipelineDescriptor const * >(descriptor));
         return RenderPipeline::Acquire(result);
     }
-    void Device::CreateRenderPipelineAsync(RenderPipelineDescriptor2 const * descriptor, CreateRenderPipelineAsyncCallback callback, void * userdata) const {
-        wgpuDeviceCreateRenderPipelineAsync(Get(), reinterpret_cast<WGPURenderPipelineDescriptor2 const * >(descriptor), callback, reinterpret_cast<void * >(userdata));
+    void Device::CreateRenderPipelineAsync(RenderPipelineDescriptor const * descriptor, CreateRenderPipelineAsyncCallback callback, void * userdata) const {
+        wgpuDeviceCreateRenderPipelineAsync(Get(), reinterpret_cast<WGPURenderPipelineDescriptor const * >(descriptor), callback, reinterpret_cast<void * >(userdata));
     }
     Sampler Device::CreateSampler(SamplerDescriptor const * descriptor) const {
         auto result = wgpuDeviceCreateSampler(Get(), reinterpret_cast<WGPUSamplerDescriptor const * >(descriptor));

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -1086,7 +1086,7 @@
             "nextInChain": 0,
             "occlusionQuerySet": 20
         },
-        "WGPURenderPipelineDescriptor2": {
+        "WGPURenderPipelineDescriptor": {
             "__size__": 76,
             "depthStencil": 52,
             "fragment": 72,


### PR DESCRIPTION
Dawn has now removed the '2' suffixed APIs.

PTAL @austinEng