### PR TITLE
Support Sanitizers + Asyncify

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -367,7 +367,7 @@ jobs:
     steps:
       - run-tests:
           # also add a few asan tests
-          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime"
+          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello"
   test-wasm3:
     executor: bionic
     steps:

--- a/emcc.py
+++ b/emcc.py
@@ -2143,7 +2143,12 @@ def phase_linker_setup(options, state, newargs, settings_map):
       # we do not want asyncify to instrument these helpers - they just access
       # memory as small getters/setters, so they cannot pause anyhow, and also
       # we access them in the runtime as we prepare to rewind, which would hit
-      # an asyncify assertion.
+      # an asyncify assertion, if asyncify instrumented them.
+      #
+      # note that if ASYNCIFY_ONLY was set by the user then we do not need to
+      # do anything (as the user's list won't contain these functions), and if
+      # we did add them, the pass would assert on incompatible lists, hence the
+      # condition in the above if.
       settings.ASYNCIFY_REMOVE += ASAN_C_HELPERS
 
     if settings.ASAN_SHADOW_SIZE != -1:

--- a/emcc.py
+++ b/emcc.py
@@ -2139,7 +2139,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
 
     settings.EXPORTED_FUNCTIONS += ['_' + x for x in ASAN_C_HELPERS]
 
-    if settings.ASYNCIFY:
+    if settings.ASYNCIFY and not settings.ASYNCIFY_ONLY:
       # we do not want asyncify to instrument these helpers - they just access
       # memory as small getters/setters, so they cannot pause anyhow, and also
       # we access them in the runtime as we prepare to rewind, which would hit

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7503,11 +7503,13 @@ Module['onRuntimeInitialized'] = function() {
     'onlylist_a': (['-s', 'ASYNCIFY_ONLY=["main","__original_main","foo(int, double)","baz()","c_baz","Structy::funcy()","bar()"]'], True),
     'onlylist_b': (['-s', 'ASYNCIFY_ONLY=["main","__original_main","foo(int, double)","baz()","c_baz","Structy::funcy()"]'], True),
     'onlylist_c': (['-s', 'ASYNCIFY_ONLY=["main","__original_main","foo(int, double)","baz()","c_baz"]'], False),
-    'onlylist_d': (['-s', 'ASYNCIFY_ONLY=["foo(int, double)","baz()","c_baz","Structy::funcy()"]'], False),
+    'onlylist_d': (['-s', 'ASYNCIFY_ONLY=["foo(int, double)","baz()","c_baz","Structy::funcy()"]'], False, None, True),
     'onlylist_b_response': ([], True,  '["main","__original_main","foo(int, double)","baz()","c_baz","Structy::funcy()"]'),
     'onlylist_c_response': ([], False, '["main","__original_main","foo(int, double)","baz()","c_baz"]'),
   })
-  def test_asyncify_lists(self, args, should_pass, response=None):
+  def test_asyncify_lists(self, args, should_pass, response=None, no_san=False):
+    if no_san and is_sanitizing(self.emcc_args):
+      self.skipTest('remaining asyncify+sanitizer TODO')
     if response is not None:
       create_file('response.file', response)
       self.set_setting('ASYNCIFY_ONLY', '@response.file')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -250,6 +250,10 @@ no_minimal_runtime = make_no_decorator_for_setting('MINIMAL_RUNTIME')
 no_safe_heap = make_no_decorator_for_setting('SAFE_HEAP')
 
 
+def is_sanitizing(args):
+  return '-fsanitize=' in str(args)
+
+
 class TestCoreBase(RunnerCore):
   def is_wasm2js(self):
     return self.get_setting('WASM') == 0
@@ -7517,7 +7521,7 @@ Module['onRuntimeInitialized'] = function() {
 
     # use of ASYNCIFY_* options may require intermediate debug info. that should
     # not end up emitted in the final binary
-    if self.is_wasm():
+    if self.is_wasm() and not is_sanitizing(self.emcc_args):
       binary = read_binary('test_asyncify_lists.wasm')
       # there should be no name section
       self.assertFalse(b'name' in binary)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7523,6 +7523,8 @@ Module['onRuntimeInitialized'] = function() {
 
     # use of ASYNCIFY_* options may require intermediate debug info. that should
     # not end up emitted in the final binary
+    # (note that we can't check this if sanitizers run, as they include a lot of
+    # static strings that would match the search)
     if self.is_wasm() and not is_sanitizing(self.emcc_args):
       binary = read_binary('test_asyncify_lists.wasm')
       # there should be no name section

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7369,7 +7369,6 @@ someweirdtext
 
   # needs setTimeout which only node has
   @require_node
-  @no_asan('asan is not compatible with asyncify stack operations; may also need to not instrument asan_c_load_4, TODO')
   def test_async_hello(self):
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME')
@@ -7395,7 +7394,6 @@ int main() {
     self.do_runf('main.c', 'HelloWorld!99')
 
   @require_node
-  @no_asan('asyncify stack operations confuse asan')
   def test_async_ccall_bad(self):
     # check bad ccall use
     # needs to flush stdio streams
@@ -7427,7 +7425,6 @@ Module['onRuntimeInitialized'] = function() {
     self.do_runf('main.c', 'The call to main is running asynchronously.')
 
   @require_node
-  @no_asan('asyncify stack operations confuse asan')
   def test_async_ccall_good(self):
     # check reasonable ccall use
     # needs to flush stdio streams
@@ -7452,7 +7449,6 @@ Module['onRuntimeInitialized'] = function() {
     self.emcc_args += ['--pre-js', 'pre.js']
     self.do_runf('main.c', 'HelloWorld')
 
-  @no_asan('asyncify stack operations confuse asan')
   def test_async_ccall_promise(self):
     print('check ccall promise')
     self.set_setting('ASYNCIFY')
@@ -7485,7 +7481,6 @@ Module['onRuntimeInitialized'] = function() {
     self.emcc_args += ['--pre-js', 'pre.js']
     self.do_runf('main.c', 'first\nsecond\n6.4')
 
-  @no_asan('asyncify stack operations confuse asan')
   def test_fibers_asyncify(self):
     self.set_setting('ASYNCIFY')
     self.maybe_closure()
@@ -7508,7 +7503,6 @@ Module['onRuntimeInitialized'] = function() {
     'onlylist_b_response': ([], True,  '["main","__original_main","foo(int, double)","baz()","c_baz","Structy::funcy()"]'),
     'onlylist_c_response': ([], False, '["main","__original_main","foo(int, double)","baz()","c_baz"]'),
   })
-  @no_asan('asan is not compatible with asyncify stack operations; may also need to not instrument asan_c_load_4, TODO')
   def test_asyncify_lists(self, args, should_pass, response=None):
     if response is not None:
       create_file('response.file', response)
@@ -7537,7 +7531,6 @@ Module['onRuntimeInitialized'] = function() {
     'ignoreindirect': (['-s', 'ASYNCIFY_IGNORE_INDIRECT'], False),
     'add': (['-s', 'ASYNCIFY_IGNORE_INDIRECT', '-s', 'ASYNCIFY_ADD=["__original_main","main","virt()"]'], True),
   })
-  @no_asan('asan is not compatible with asyncify stack operations; may also need to not instrument asan_c_load_4, TODO')
   def test_asyncify_indirect_lists(self, args, should_pass):
     self.set_setting('ASYNCIFY')
     self.emcc_args += args
@@ -7550,7 +7543,6 @@ Module['onRuntimeInitialized'] = function() {
       if should_pass:
         raise
 
-  @no_asan('asyncify stack operations confuse asan')
   def test_emscripten_scan_registers(self):
     self.set_setting('ASYNCIFY')
     self.do_core_test('test_emscripten_scan_registers.cpp')


### PR DESCRIPTION
The problem here was that the `asan_c_load_4` etc. methods, that are tiny
functions in C that we let ASan instrument, and then JS calls into, were getting
processed by Asyncify. And we end up calling those `asan_c_*` methods
during critical Asyncify times like as we begin to rewind - times when it is
not valid to call into instrumented code, or we assert. To fix that, simply
ignore those specific methods in Asyncify - we don't need to process them
anyhow, as they cannot pause.

One test remains broken, `test_asyncify_lists_onlylist_d`, which I left as
a TODO. That test does something invalid, and it is expected to fail, but
it fails in a different way somehow. The details get complicated due to how
ASan modifies things. Let's leave #14807 open for that.