### PR TITLE
Remove unused `objectTransfer` command. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -309,8 +309,6 @@ var LibraryPThread = {
           }
         } else if (cmd === 'cancelDone') {
           PThread.returnWorkerToPool(worker);
-        } else if (cmd === 'objectTransfer') {
-          PThread.receiveObjectTransfer(e.data);
         } else if (e.data.target === 'setimmediate') {
           worker.postMessage(e.data); // Worker wants to postMessage() to itself to implement setImmediate() emulation.
         } else {

--- a/src/worker.js
+++ b/src/worker.js
@@ -162,8 +162,6 @@ self.onmessage = function(e) {
 #endif
 #endif
 #endif // MODULARIZE && EXPORT_ES6
-    } else if (e.data.cmd === 'objectTransfer') {
-      Module['PThread'].receiveObjectTransfer(e.data);
     } else if (e.data.cmd === 'run') {
       // This worker was idle, and now should start executing its pthread entry
       // point.


### PR DESCRIPTION
This command appears to be unused.  `receiveObjectTranster` is
done when the `run` command is received in the worker and nowhere
else.