### PR TITLE
Add missing Closure extern for ftruncateSync

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5382,6 +5382,7 @@ Module['onRuntimeInitialized'] = function() {
   def test_unistd_truncate_noderawfs(self):
     self.uses_es6 = True
     self.set_setting('NODERAWFS')
+    self.maybe_closure()
     self.do_run_in_out_file_test('unistd/truncate.c', js_engines=[config.NODE_JS])
 
   def test_unistd_swab(self):

--- a/third_party/closure-compiler/node-externs/fs.js
+++ b/third_party/closure-compiler/node-externs/fs.js
@@ -57,6 +57,12 @@ fs.truncate = function(fd, len, callback) {};
 fs.truncateSync = function(fd, len) {};
 
 /**
+ * @param {*} fd
+ * @param {number} len
+ */
+fs.ftruncateSync = function(fd, len) {};
+
+/**
  * @param {string} path
  * @param {number} uid
  * @param {number} gid


### PR DESCRIPTION
Otherwise, the Closure Compiler might rename `fs.ftruncateSync`
during compilation when the `NODERAWFS` filesystem backend
is used.

<details>
  <summary>Details</summary>

```
======================================================================
FAIL: test_unistd_truncate_noderawfs (test_core.wasm2)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/kleisauke/emscripten/tests/test_core.py", line 5386, in test_unistd_truncate_noderawfs
    self.do_run_in_out_file_test('unistd/truncate.c', js_engines=[config.NODE_JS])
  File "/home/kleisauke/emscripten/tests/common.py", line 1017, in do_run_in_out_file_test
    self._build_and_run(srcfile, expected, **kwargs)
  File "/home/kleisauke/emscripten/tests/common.py", line 1058, in _build_and_run
    js_output = self.run_js(js_file, engine, args,
  File "/home/kleisauke/emscripten/tests/common.py", line 678, in run_js
    self.fail('JS subprocess failed (%s): %s.  Output:\n%s' % (error.cmd, error.returncode, ret))
AssertionError: JS subprocess failed (/home/kleisauke/emsdk/node/14.15.5_64bit/bin/node --stack-trace-limit=50 --unhandled-rejections=throw /tmp/emscripten_test_wasm2_gx1x9iox/truncate.js): 7.  Output:
f2: 18
st_size: 6

TypeError: Cannot read property 'apply' of undefined
    at Object.Wa (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:38:456)
    at Object.Wa (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:86:69)
    at __sys_ftruncate64 (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:87:189)
    at <anonymous>:wasm-function[22]:0x93c
    at main (<anonymous>:wasm-function[11]:0x2c6)
    at c._main (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:92:343)
    at a (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:94:196)
    at fb (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:95:266)
    at eb (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:93:398)
    at ya (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:10:141)
    at a (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:90:379)
    at b (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:90:398)
exception thrown: RuntimeError: abort(TypeError: Cannot read property 'apply' of undefined). Build with -s ASSERTIONS=1 for more info.,RuntimeError: abort(TypeError: Cannot read property 'apply' of undefined). Build with -s ASSERTIONS=1 for more info.
    at F (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:10:245)
    at __sys_ftruncate64 (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:87:256)
    at <anonymous>:wasm-function[22]:0x93c
    at main (<anonymous>:wasm-function[11]:0x2c6)
    at c._main (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:92:343)
    at a (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:94:196)
    at fb (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:95:266)
    at eb (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:93:398)
    at ya (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:10:141)
    at a (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:90:379)
    at b (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:90:398)
RuntimeError: abort(TypeError: Cannot read property 'apply' of undefined). Build with -s ASSERTIONS=1 for more info.
    at F (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:10:245)
    at __sys_ftruncate64 (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:87:256)
    at <anonymous>:wasm-function[22]:0x93c
    at main (<anonymous>:wasm-function[11]:0x2c6)
    at c._main (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:92:343)
    at a (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:94:196)
    at fb (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:95:266)
    at eb (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:93:398)
    at ya (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:10:141)
    at a (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:90:379)
    at b (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:90:398)
/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:4
typeof module&&(module.exports=c),process.on("uncaughtException",function(a){if(!(a instanceof da))throw a;}),process.on("unhandledRejection",F),aa=function(a,b){if(noExitRuntime||0<ea)throw process.exitCode=a,b;process.exit(a)},c.inspect=function(){return"[Emscripten Module object]"};else if(ba||p)p?w=self.location.href:"undefined"!==typeof document&&document.currentScript&&(w=document.currentScript.src),w=0!==w.indexOf("blob:")?w.substr(0,w.lastIndexOf("/")+1):"",x=function(a){var b=new XMLHttpRequest;
                                                                                                   ^

RuntimeError: abort(RuntimeError: abort(TypeError: Cannot read property 'apply' of undefined). Build with -s ASSERTIONS=1 for more info.). Build with -s ASSERTIONS=1 for more info.
    at process.F (/tmp/emscripten_test_wasm2_gx1x9iox/truncate.js:10:245)
    at process.emit (events.js:315:20)
    at processPromiseRejections (internal/process/promises.js:228:33)
    at processTicksAndRejections (internal/process/task_queues.js:94:32)


----------------------------------------------------------------------
Ran 1 test in 2.171s

FAILED (failures=1)
```
</details>

