### PR TITLE
Allow test to override name of output JS file. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -547,7 +547,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       self.fail('es-check failed to verify ES5 output compliance')
 
   # Build JavaScript code from source code
-  def build(self, filename, libraries=[], includes=[], force_c=False, js_outfile=True, emcc_args=[]):
+  def build(self, filename, libraries=[], includes=[], force_c=False, js_outfile=True, emcc_args=[], output_basename=None):
     suffix = '.js' if js_outfile else '.wasm'
     compiler = [compiler_for(filename, force_c)]
     if compiler[0] == EMCC:
@@ -559,8 +559,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if force_c:
       compiler.append('-xc')
 
-    dirname, basename = os.path.split(filename)
-    output = shared.unsuffixed(basename) + suffix
+    if output_basename:
+      output = output_basename + suffix
+    else:
+      basename = os.path.basename(filename)
+      output = shared.unsuffixed(basename) + suffix
     cmd = compiler + [filename, '-o', output] + self.get_emcc_args(main_file=True) + emcc_args + libraries
     if shared.suffix(filename) not in ('.i', '.ii'):
       # Add the location of the test file to include path.
@@ -1023,14 +1026,16 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
                      includes=[],
                      assert_returncode=0, assert_identical=False, assert_all=False,
                      check_for_error=True, force_c=False, emcc_args=[],
-                     interleaved_output=True):
+                     interleaved_output=True,
+                     output_basename=None):
     logger.debug(f'_build_and_run: {filename}')
 
     if no_build:
       js_file = filename
     else:
       js_file = self.build(filename, libraries=libraries, includes=includes,
-                           force_c=force_c, emcc_args=emcc_args)
+                           force_c=force_c, emcc_args=emcc_args,
+                           output_basename=output_basename)
     self.assertExists(js_file)
 
     engines = self.filtered_js_engines(js_engines)

--- a/tests/test_posixtest.py
+++ b/tests/test_posixtest.py
@@ -158,7 +158,7 @@ def make_test(name, testfile, browser):
     if browser:
       self.btest_exit(testfile, args=args)
     else:
-      self.do_runf(testfile, emcc_args=args)
+      self.do_runf(testfile, emcc_args=args, output_basename=name)
 
   if name in expect_fail:
     f = unittest.expectedFailure(f)


### PR DESCRIPTION
This is useful in the posixtest suite where the source
filenames are things like `pthread_key_create/1-2.c` resulting
in a default output name of `1-2.js` which is not very useful
when looking at `ps` output of running tests.

With this change the JS files can match the test name
(e.g. test_pthread_testcancel_1_1.js).