### PR TITLE
Pass `--trace-uncuaght` to node when running test. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -403,7 +403,15 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     super().setUp()
     self.settings_mods = {}
     self.emcc_args = ['-Werror']
-    self.node_args = ['--stack-trace-limit=50', '--unhandled-rejections=throw']
+    self.node_args = [
+      # Increate stack trace limit to maximise usefulness of test failure reports
+      '--stack-trace-limit=50',
+      # Opt in to node v15 default behaviour:
+      # https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
+      '--unhandled-rejections=throw',
+      # Include backtrace for all uncuaght exceptions (not just Error).
+      '--trace-uncaught',
+    ]
     self.v8_args = []
     self.env = {}
     self.temp_files_before_run = []


### PR DESCRIPTION
This means we get backtrace information for all uncaught exceptions, not
just Error.

Also document why we pass each flag.