### PR TITLE
Mention that adding oneself to AUTHORS is optional

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,4 +1,4 @@
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 newPRWelcomeComment: >
   Thank you for submitting a pull request!
-  If this is your first PR, make sure to add yourself to AUTHORS.
+  Someone will be along to review it shortly.

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,10 @@
-The following authors have all licensed their contributions to Emscripten
-under the licensing terms detailed in LICENSE.
+Contributors to Emscripten may optionally add themselves to this list of
+authors if they choose to do so. This is optional because the git history is
+good enough for that purpose, and in fact most projects do not maintain such a
+manual list.
+
+While the file is not necessary, to preserve the history of the project we are
+not removing it.
 
 (Authors keep copyright of their contributions, of course; they just grant
 a license to everyone to use it as detailed in LICENSE.)


### PR DESCRIPTION
I have received guidance that AUTHORS is not strictly needed. Like most
projects, we can just rely on git history if we ever need the list of
contributors.

However, since we have the file, we should keep it around for historical
purposes. Just mark it as optional.

We should also disable the bot that auto-suggests people add themselves.

fixes #14354