### PR TITLE
Use callUserCallback for sigalrm calllback

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2620,10 +2620,12 @@ LibraryManager.library = {
   },
 
   // http://pubs.opengroup.org/onlinepubs/000095399/functions/alarm.html
-  alarm__deps: ['raise'],
+  alarm__deps: ['raise', '$callUserCallback'],
   alarm: function(seconds) {
     setTimeout(function() {
-      _raise({{{ cDefine('SIGALRM') }}});
+      callUserCallback(function() {
+        _raise({{{ cDefine('SIGALRM') }}});
+      });
     }, seconds*1000);
   },
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5318,6 +5318,8 @@ Module['onRuntimeInitialized'] = function() {
 
   def test_sigalrm(self):
     self.do_runf(test_file('test_sigalrm.c'), 'Received alarm!')
+    self.set_setting('EXIT_RUNTIME')
+    self.do_runf(test_file('test_sigalrm.c'), 'Received alarm!')
 
   def test_signals(self):
     self.do_core_test(test_file('test_signals.c'))

--- a/tests/test_sigalrm.c
+++ b/tests/test_sigalrm.c
@@ -8,16 +8,21 @@
 #include <signal.h>
 #include <unistd.h>
 #include <pthread.h>
+#include <emscripten/emscripten.h>
 
 void alarm_handler(int dummy) {
   printf("Received alarm!\n");
-  exit(0);
+  emscripten_force_exit(0);
 }
 
 int main() {
   if (signal(SIGALRM, alarm_handler) == SIG_ERR) {
     printf("Error in signal()!\n");
-    exit(1);
+    return 1;
   }
   alarm(1);
+  // Make sure that we keep the runtime alive long enough
+  // to receive the alarm.
+  emscripten_exit_with_live_runtime();
+  __builtin_unreachable();
 }


### PR DESCRIPTION
This allows for `unwind`ing and `exit`ing to work correctly from with the
callback.