### PR TITLE
Add some missing deps for MINIMAL_RUNTIME in embind

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -765,7 +765,7 @@ var LibraryEmbind = {
     '$readLatin1String', '$registerType', '$simpleReadValueFromPointer',
 #if MINIMAL_RUNTIME
     '$UTF16ToString', '$stringToUTF16', '$lengthBytesUTF16',
-    '$UTF32ToString', '$stringToUTF32', '$lengthBytesUTF32'
+    '$UTF32ToString', '$stringToUTF32', '$lengthBytesUTF32',
 #endif
     ],
   _embind_register_std_wstring: function(rawType, charSize, name) {

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -762,9 +762,8 @@ var LibraryEmbind = {
   },
 
   _embind_register_std_wstring__deps: [
-    '$readLatin1String', '$registerType', '$simpleReadValueFromPointer'
+    '$readLatin1String', '$registerType', '$simpleReadValueFromPointer',
 #if MINIMAL_RUNTIME
-    ,
     '$UTF16ToString', '$stringToUTF16', '$lengthBytesUTF16',
     '$UTF32ToString', '$stringToUTF32', '$lengthBytesUTF32'
 #endif

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -762,8 +762,13 @@ var LibraryEmbind = {
   },
 
   _embind_register_std_wstring__deps: [
-    '$readLatin1String', '$registerType',
-    '$simpleReadValueFromPointer'],
+    '$readLatin1String', '$registerType', '$simpleReadValueFromPointer'
+#if MINIMAL_RUNTIME
+    ,
+    '$UTF16ToString', '$stringToUTF16', '$lengthBytesUTF16',
+    '$UTF32ToString', '$stringToUTF32', '$lengthBytesUTF32'
+#endif
+    ],
   _embind_register_std_wstring: function(rawType, charSize, name) {
     name = readLatin1String(name);
     var decodeString, encodeString, getHeap, lengthBytesUTF, shift;

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -78,6 +78,7 @@ non_core_test_modes = [
   'wasm2ss',
   'posixtest',
   'posixtest_browser',
+  'minimal0',
 ]
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8687,7 +8687,7 @@ asani = make_run('asani', emcc_args=['-fsanitize=address', '--profiling', '-O2',
 
 # Experimental modes (not tested by CI)
 lld = make_run('lld', emcc_args=[], settings={'LLD_REPORT_UNDEFINED': 1})
-minimal0 = make_run('minimal', emcc_args=['-g'], settings={'MINIMAL_RUNTIME': 1})
+minimal0 = make_run('minimal0', emcc_args=['-g'], settings={'MINIMAL_RUNTIME': 1})
 
 # TestCoreBase is just a shape for the specific subclasses, we don't test it itself
 del TestCoreBase # noqa


### PR DESCRIPTION
This is not enough to get the relevant tests passing. I'm not sure if that's
worth doing or not - do we have plans for embind and minimal runtime?