### PR TITLE
Use abort function in MINIMAL_RUNTIME

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -449,12 +449,7 @@ LibraryManager.library = {
   // and killing all threads, including this one.
   abort__proxy: 'sync',
   abort: function() {
-#if MINIMAL_RUNTIME
-    // In MINIMAL_RUNTIME the module object does not exist, so its behavior to abort is to throw directly.
-    throw 'abort';
-#else
     abort();
-#endif
   },
 
   // This object can be modified by the user during startup, which affects


### PR DESCRIPTION
The abort runtime function exists in preamble_minimal.js as well as
preable.js so there is no reason not to use it (should be a code size
saving due to reduced duplication).

This code was originally added back in #8026 when the comment made
more sense since the alternate path uses `Module['abort']`.