### PR TITLE
Run core/test_safe_stack.c under pthreads + node. NFC

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8227,13 +8227,25 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.set_setting('TOTAL_STACK', 65536)
     self.do_runf(test_file('core/test_safe_stack.c'),
-                 expected_output=['abort(stack overflow)', '__handle_stack_overflow'], assert_returncode=NON_ZERO)
+                 expected_output=['abort(stack overflow)', '__handle_stack_overflow'],
+                 assert_returncode=NON_ZERO, assert_all=True)
+
+  @node_pthreads
+  def test_safe_stack_pthread(self):
+    self.set_setting('STACK_OVERFLOW_CHECK', 2)
+    self.set_setting('TOTAL_STACK', 65536)
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('USE_PTHREADS')
+    self.do_runf(test_file('core/test_safe_stack.c'),
+                 expected_output=['abort(stack overflow)', '__handle_stack_overflow'],
+                 assert_returncode=NON_ZERO, assert_all=True)
 
   def test_safe_stack_alloca(self):
     self.set_setting('STACK_OVERFLOW_CHECK', 2)
     self.set_setting('TOTAL_STACK', 65536)
     self.do_runf(test_file('core/test_safe_stack_alloca.c'),
-                 expected_output=['abort(stack overflow)', '__handle_stack_overflow'], assert_returncode=NON_ZERO)
+                 expected_output=['abort(stack overflow)', '__handle_stack_overflow'],
+                 assert_returncode=NON_ZERO, assert_all=True)
 
   @needs_dylink
   def test_safe_stack_dylink(self):


### PR DESCRIPTION
We already run this test with pthreads in test_browser.py but its useful
to run in this mode under node as well where the threading model is not
identical.

Also, add `assert_all=True` when running these tests as we want to match
all of the patterns, not just one.