### PR TITLE
Don't proxy entire abort function back to the main thread

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -445,9 +445,6 @@ LibraryManager.library = {
   // TODO: There are currently two abort() functions that get imported to asm module scope: the built-in runtime function abort(),
   // and this function _abort(). Remove one of these, importing two functions for the same purpose is wasteful.
   abort__sig: 'v',
-  // Proxy synchronously, which will have the effect of halting the program
-  // and killing all threads, including this one.
-  abort__proxy: 'sync',
   abort: function() {
 #if MINIMAL_RUNTIME
     // In MINIMAL_RUNTIME the module object does not exist, so its behavior to abort is to throw directly.

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -311,6 +311,10 @@ var LibraryPThread = {
           PThread.returnWorkerToPool(worker);
         } else if (e.data.target === 'setimmediate') {
           worker.postMessage(e.data); // Worker wants to postMessage() to itself to implement setImmediate() emulation.
+        } else if (cmd === 'onAbort') {
+          if (Module['onAbort']) {
+            Module['onAbort'](d['arg']);
+          }
         } else {
           err("worker sent an unknown command " + cmd);
         }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2356,6 +2356,9 @@ The current type of b is: 9
   @node_pthreads
   def test_pthread_abort(self):
     self.set_setting('PROXY_TO_PTHREAD')
+    # Add the onAbort handler at runtime during preRun.  This means that onAbort
+    # handler will only be present in the main thread (much like it would if it
+    # was passed in by pre-populating the module object on prior to loading).
     self.add_pre_run("Module.onAbort = function() { console.log('onAbort called'); }")
     self.do_run_in_out_file_test('pthread/test_pthread_abort.c', assert_returncode=NON_ZERO)
 


### PR DESCRIPTION
It turns out proxying abort has several issues:

1. If we do stuff like proxing during the call to abort
   it can allocate stack and heap space which might not
   be possible by the time abort is called.
2. All the other calls to abort that don't go via the library
   function (calls to abort directly from JS) are not proxied
   meaning we get inconsistent proxying.

Instead I use postMessage to send just the onAbort and do                   
the rest of the abort in the local thread.                                  
                                                                            
The exception will end up triggering the worker.onerror so                  
go entire application will still get torn down.   