### PR TITLE
Make use of `pathlib.Path` when dealing with paths within emscripten. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -38,7 +38,7 @@ from urllib.parse import quote
 
 
 import emscripten
-from tools import shared, system_libs
+from tools import shared, system_libs, utils
 from tools import colored_logger, diagnostics, building
 from tools.shared import unsuffixed, unsuffixed_basename, WINDOWS, safe_copy
 from tools.shared import run_process, read_and_preprocess, exit_with_error, DEBUG
@@ -240,7 +240,7 @@ class EmccOptions:
     self.embed_files = []
     self.exclude_files = []
     self.ignore_dynamic_linking = False
-    self.shell_path = shared.path_from_root('src', 'shell.html')
+    self.shell_path = utils.path_from_root('src/shell.html')
     self.source_map_base = ''
     self.emrun = False
     self.cpu_profiler = False
@@ -979,7 +979,7 @@ def run(args):
     #    site/build/text/docs/tools_reference/emcc.txt
     # This then needs to be copied to its final home in docs/emcc.txt from where
     # we read it here.  We have CI rules that ensure its always up-to-date.
-    with open(shared.path_from_root('docs', 'emcc.txt'), 'r') as f:
+    with open(utils.path_from_root('docs/emcc.txt'), 'r') as f:
       print(f.read())
 
     print('''
@@ -1023,7 +1023,7 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
     args = [x for x in args if x != '--cflags']
     with misc_temp_files.get_file(suffix='.o') as temp_target:
       input_file = 'hello_world.c'
-      cmd = [shared.PYTHON, sys.argv[0], shared.path_from_root('tests', input_file), '-v', '-c', '-o', temp_target] + args
+      cmd = [shared.PYTHON, sys.argv[0], utils.path_from_root('tests', input_file), '-v', '-c', '-o', temp_target] + args
       proc = run_process(cmd, stderr=PIPE, check=False)
       if proc.returncode != 0:
         print(proc.stderr)
@@ -1367,19 +1367,19 @@ def phase_linker_setup(options, state, newargs, settings_map):
     add_link_flag(state, sys.maxsize, f)
 
   if options.emrun:
-    options.pre_js += read_file(shared.path_from_root('src', 'emrun_prejs.js')) + '\n'
-    options.post_js += read_file(shared.path_from_root('src', 'emrun_postjs.js')) + '\n'
+    options.pre_js += read_file(utils.path_from_root('src/emrun_prejs.js')) + '\n'
+    options.post_js += read_file(utils.path_from_root('src/emrun_postjs.js')) + '\n'
     # emrun mode waits on program exit
     settings.EXIT_RUNTIME = 1
 
   if options.cpu_profiler:
-    options.post_js += read_file(shared.path_from_root('src', 'cpuprofiler.js')) + '\n'
+    options.post_js += read_file(utils.path_from_root('src/cpuprofiler.js')) + '\n'
 
   if options.memory_profiler:
     settings.MEMORYPROFILER = 1
 
   if options.thread_profiler:
-    options.post_js += read_file(shared.path_from_root('src', 'threadprofiler.js')) + '\n'
+    options.post_js += read_file(utils.path_from_root('src/threadprofiler.js')) + '\n'
 
   if options.memory_init_file is None:
     options.memory_init_file = settings.OPT_LEVEL >= 2
@@ -2030,8 +2030,8 @@ def phase_linker_setup(options, state, newargs, settings_map):
 
   if settings.MINIMAL_RUNTIME:
     # Minimal runtime uses a different default shell file
-    if options.shell_path == shared.path_from_root('src', 'shell.html'):
-      options.shell_path = shared.path_from_root('src', 'shell_minimal_runtime.html')
+    if options.shell_path == utils.path_from_root('src/shell.html'):
+      options.shell_path = utils.path_from_root('src/shell_minimal_runtime.html')
 
     if settings.EXIT_RUNTIME:
       settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['proc_exit']
@@ -2045,7 +2045,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
 
   if settings.MODULARIZE and not (settings.EXPORT_ES6 and not settings.SINGLE_FILE) and \
      settings.EXPORT_NAME == 'Module' and options.oformat == OFormat.HTML and \
-     (options.shell_path == shared.path_from_root('src', 'shell.html') or options.shell_path == shared.path_from_root('src', 'shell_minimal.html')):
+     (options.shell_path == utils.path_from_root('src/shell.html') or options.shell_path == utils.path_from_root('src/shell_minimal.html')):
     exit_with_error(f'Due to collision in variable name "Module", the shell file "{options.shell_path}" is not compatible with build options "-s MODULARIZE=1 -s EXPORT_NAME=Module". Either provide your own shell file, change the name of the export to something else to avoid the name collision. (see https://github.com/emscripten-core/emscripten/issues/7950 for details)')
 
   if settings.STANDALONE_WASM:
@@ -2638,7 +2638,7 @@ def phase_final_emitting(options, state, target, wasm_target, memfile):
     target_dir = os.path.dirname(os.path.abspath(target))
     worker_output = os.path.join(target_dir, settings.PTHREAD_WORKER_FILE)
     with open(worker_output, 'w') as f:
-      f.write(shared.read_and_preprocess(shared.path_from_root('src', 'worker.js'), expand_macros=True))
+      f.write(shared.read_and_preprocess(utils.path_from_root('src/worker.js'), expand_macros=True))
 
     # Minify the worker.js file in optimized builds
     if (settings.OPT_LEVEL >= 1 or settings.SHRINK_LEVEL >= 1) and not settings.DEBUG_LEVEL:
@@ -2659,7 +2659,7 @@ def phase_final_emitting(options, state, target, wasm_target, memfile):
     # Process .js runtime file. Note that we need to handle the license text
     # here, so that it will not confuse the hacky script.
     shared.JS.handle_license(final_js)
-    shared.run_process([shared.PYTHON, shared.path_from_root('tools', 'hacky_postprocess_around_closure_limitations.py'), final_js])
+    shared.run_process([shared.PYTHON, utils.path_from_root('tools/hacky_postprocess_around_closure_limitations.py'), final_js])
 
   # Unmangle previously mangled `import.meta` references in both main code and libraries.
   # See also: `preprocess` in parseTools.js.
@@ -2717,13 +2717,13 @@ def version_string():
   # if the emscripten folder is not a git repo, don't run git show - that can
   # look up and find the revision in a parent directory that is a git repo
   revision_suffix = ''
-  if os.path.exists(shared.path_from_root('.git')):
+  if os.path.exists(utils.path_from_root('.git')):
     git_rev = run_process(
       ['git', 'rev-parse', 'HEAD'],
-      stdout=PIPE, stderr=PIPE, cwd=shared.path_from_root()).stdout.strip()
+      stdout=PIPE, stderr=PIPE, cwd=utils.path_from_root()).stdout.strip()
     revision_suffix = '-git (%s)' % git_rev
-  elif os.path.exists(shared.path_from_root('emscripten-revision.txt')):
-    with open(shared.path_from_root('emscripten-revision.txt')) as f:
+  elif os.path.exists(utils.path_from_root('emscripten-revision.txt')):
+    with open(utils.path_from_root('emscripten-revision.txt')) as f:
       git_rev = f.read().strip()
     revision_suffix = ' (%s)' % git_rev
   return f'emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) {shared.EMSCRIPTEN_VERSION}{revision_suffix}'
@@ -3163,7 +3163,7 @@ def phase_binaryen(target, options, wasm_target):
     building.asyncify_lazy_load_code(wasm_target, debug=intermediate_debug_info)
 
   def preprocess_wasm2js_script():
-    return read_and_preprocess(shared.path_from_root('src', 'wasm2js.js'), expand_macros=True)
+    return read_and_preprocess(utils.path_from_root('src/wasm2js.js'), expand_macros=True)
 
   def run_closure_compiler():
     global final_js
@@ -3441,7 +3441,7 @@ def generate_traditional_runtime_html(target, options, js_target, target_basenam
   # when script.inline isn't empty, add required helper functions such as tryParseAsDataURI
   if script.inline:
     for filename in ('arrayUtils.js', 'base64Utils.js', 'URIUtils.js'):
-      content = read_and_preprocess(shared.path_from_root('src', filename))
+      content = read_and_preprocess(utils.path_from_root('src', filename))
       script.inline = content + script.inline
 
     script.inline = 'var ASSERTIONS = %s;\n%s' % (settings.ASSERTIONS, script.inline)
@@ -3516,7 +3516,7 @@ def generate_html(target, options, js_target, target_basename,
 
   if settings.EXPORT_NAME != 'Module' and \
      not settings.MINIMAL_RUNTIME and \
-     options.shell_path == shared.path_from_root('src', 'shell.html'):
+     options.shell_path == utils.path_from_root('src/shell.html'):
     # the minimal runtime shell HTML is designed to support changing the export
     # name, but the normal one does not support that currently
     exit_with_error('Customizing EXPORT_NAME requires that the HTML be customized to use that name (see https://github.com/emscripten-core/emscripten/issues/10086)')
@@ -3547,9 +3547,9 @@ def generate_worker_js(target, js_target, target_basename):
 
 
 def worker_js_script(proxy_worker_filename):
-  web_gl_client_src = read_file(shared.path_from_root('src', 'webGLClient.js'))
-  idb_store_src = read_file(shared.path_from_root('src', 'IDBStore.js'))
-  proxy_client_src = read_file(shared.path_from_root('src', 'proxyClient.js'))
+  web_gl_client_src = read_file(utils.path_from_root('src/webGLClient.js'))
+  idb_store_src = read_file(utils.path_from_root('src/IDBStore.js'))
+  proxy_client_src = read_file(utils.path_from_root('src/proxyClient.js'))
   proxy_client_src = do_replace(proxy_client_src, '{{{ filename }}}', proxy_worker_filename)
   proxy_client_src = do_replace(proxy_client_src, '{{{ IDBStore.js }}}', idb_store_src)
   return web_gl_client_src + '\n' + proxy_client_src
@@ -3662,7 +3662,7 @@ class ScriptSource:
 
 def is_valid_abspath(options, path_name):
   # Any path that is underneath the emscripten repository root must be ok.
-  if shared.path_from_root().replace('\\', '/') in path_name.replace('\\', '/'):
+  if utils.path_from_root().replace('\\', '/') in path_name.replace('\\', '/'):
     return True
 
   def in_directory(root, child):

--- a/emcmake.py
+++ b/emcmake.py
@@ -33,7 +33,7 @@ variables so that emcc etc. are used. Typical usage:
 
   # Append the Emscripten toolchain file if the user didn't specify one.
   if not has_substr(args, '-DCMAKE_TOOLCHAIN_FILE'):
-    args.append('-DCMAKE_TOOLCHAIN_FILE=' + utils.path_from_root('cmake', 'Modules', 'Platform', 'Emscripten.cmake'))
+    args.append('-DCMAKE_TOOLCHAIN_FILE=' + utils.path_from_root('cmake/Modules/Platform/Emscripten.cmake'))
 
   if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
     node_js = config.NODE_JS[0]

--- a/emscons.py
+++ b/emscons.py
@@ -11,9 +11,9 @@ my_env = Environment(tools=['emscripten'], toolpath=[os.environ['EMSCRIPTEN_TOOL
 import os
 import subprocess
 import sys
-from tools import shared
+from tools import utils
 
-tool_path = os.path.join(shared.path_from_root('tools'), 'scons', 'site_scons', 'site_tools', 'emscripten')
+tool_path = utils.path_from_root('tools/scons/site_scons/site_tools/emscripten')
 
 env = os.environ.copy()
 env['EMSCRIPTEN_TOOL_PATH'] = tool_path

--- a/emscripten.py
+++ b/emscripten.py
@@ -174,7 +174,7 @@ def compile_settings():
     # Call js compiler
     env = os.environ.copy()
     env['EMCC_BUILD_DIR'] = os.getcwd()
-    out = shared.run_js_tool(path_from_root('src', 'compiler.js'),
+    out = shared.run_js_tool(path_from_root('src/compiler.js'),
                              [settings_file], stdout=subprocess.PIPE, stderr=stderr_file,
                              cwd=path_from_root('src'), env=env)
   assert '//FORWARDED_DATA:' in out, 'Did not receive forwarded data in pre output - process failed?'

--- a/tests/clang_native.py
+++ b/tests/clang_native.py
@@ -14,7 +14,7 @@ logger = logging.getLogger('clang_native')
 # These extra args need to be passed to Clang when targeting a native host system executable
 def get_clang_native_args():
   if MACOS:
-    return ['-isystem', path_from_root('system', 'include', 'libcxx')]
+    return ['-isystem', path_from_root('system/include/libcxx')]
   elif os.name == 'nt':
     # TODO: If Windows.h et al. are needed, will need to add something like '-isystemC:/Program
     # Files (x86)/Microsoft SDKs/Windows/v7.1A/Include'.

--- a/tests/fuzz/csmith_driver.py
+++ b/tests/fuzz/csmith_driver.py
@@ -21,6 +21,7 @@ sys.path.append(os.path.join(os.path.dirname(os.path.dirname(script_dir))))
 
 from tools import shared
 from tools import config
+from tools import utils
 
 # can add flags like --no-threads --ion-offthread-compile=off
 engine = eval('config.' + sys.argv[1]) if len(sys.argv) > 1 else config.JS_ENGINES[0]
@@ -84,7 +85,7 @@ while 1:
     continue
 
   shared.run_process([COMP, '-m32', opts, '-emit-llvm', '-c', fullname, '-o', filename + '.bc'] + CSMITH_CFLAGS + shared.get_cflags() + ['-w'])
-  shared.run_process([shared.path_from_root('tools', 'nativize_llvm.py'), filename + '.bc'], stderr=PIPE)
+  shared.run_process([utils.path_from_root('tools/nativize_llvm.py'), filename + '.bc'], stderr=PIPE)
   shutil.move(filename + '.bc.run', filename + '2')
   shared.run_process([COMP, fullname, '-o', filename + '3'] + CSMITH_CFLAGS + ['-w'])
   print('3) Run natively')

--- a/tests/jsrun.py
+++ b/tests/jsrun.py
@@ -9,7 +9,7 @@ import sys
 import common
 from subprocess import Popen, PIPE, CalledProcessError
 
-from tools import shared
+from tools import shared, utils
 
 WORKING_ENGINES = {} # Holds all configured engines and whether they work: maps path -> True/False
 
@@ -59,7 +59,7 @@ def check_engine(engine):
   if engine_path not in WORKING_ENGINES:
     logging.debug('Checking JS engine %s' % engine)
     try:
-      output = run_js(shared.path_from_root('tests/hello_world.js'), engine, skip_check=True)
+      output = run_js(utils.path_from_root('tests/hello_world.js'), engine, skip_check=True)
       if 'hello, world!' in output:
         WORKING_ENGINES[engine_path] = True
       else:

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -37,10 +37,10 @@ sys.path.append(__rootpath__)
 import jsrun
 import parallel_testsuite
 import common
-from tools import shared, config
+from tools import shared, config, utils
 
 
-sys.path.append(shared.path_from_root('third_party/websockify'))
+sys.path.append(utils.path_from_root('third_party/websockify'))
 
 logger = logging.getLogger("runner")
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -231,7 +231,7 @@ If manually bisecting:
 
   def test_emscripten_log(self):
     self.btest_exit(test_file('emscripten_log/emscripten_log.cpp'),
-                    args=['--pre-js', path_from_root('src', 'emscripten-source-map.min.js'), '-gsource-map'])
+                    args=['--pre-js', path_from_root('src/emscripten-source-map.min.js'), '-gsource-map'])
 
   def test_preload_file(self):
     create_file('somefile.txt', 'load me right before running the code please')
@@ -574,7 +574,7 @@ If manually bisecting:
     # change the file package base dir to look in a "cdn". note that normally
     # you would add this in your own custom html file etc., and not by
     # modifying the existing shell in this manner
-    default_shell = read_file(path_from_root('src', 'shell.html'))
+    default_shell = read_file(path_from_root('src/shell.html'))
     create_file('shell.html', default_shell.replace('var Module = {', '''
     var Module = {
       locateFile: function(path, prefix) {
@@ -668,7 +668,7 @@ If manually bisecting:
     test()
 
     # TODO: CORS, test using a full url for locateFile
-    # create_file('shell.html', read_file(path_from_root('src', 'shell.html')).replace('var Module = {', 'var Module = { locateFile: function (path) {return "http:/localhost:8888/cdn/" + path;}, '))
+    # create_file('shell.html', read_file(path_from_root('src/shell.html')).replace('var Module = {', 'var Module = { locateFile: function (path) {return "http:/localhost:8888/cdn/" + path;}, '))
     # test()
 
   def test_dev_random(self):
@@ -3683,7 +3683,7 @@ window.close = function() {
   # pthreads tests
 
   def prep_no_SAB(self):
-    create_file('html.html', read_file(path_from_root('src', 'shell_minimal.html')).replace('''<body>''', '''<body>
+    create_file('html.html', read_file(path_from_root('src/shell_minimal.html')).replace('''<body>''', '''<body>
       <script>
         SharedArrayBuffer = undefined;
         Atomics = undefined;
@@ -3992,7 +3992,7 @@ window.close = function() {
     ''')
 
     # Test that it is possible to define "Module.locateFile" string to locate where worker.js will be loaded from.
-    create_file('shell.html', read_file(path_from_root('src', 'shell.html')).replace('var Module = {', 'var Module = { locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "cdn/" + path;}}, '))
+    create_file('shell.html', read_file(path_from_root('src/shell.html')).replace('var Module = {', 'var Module = { locateFile: function (path, prefix) {if (path.endsWith(".wasm")) {return prefix + path;} else {return "cdn/" + path;}}, '))
     self.compile_btest(['main.cpp', '--shell-file', 'shell.html', '-s', 'WASM=0', '-s', 'IN_TEST_HARNESS', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE', '-o', 'test.html'], reporting=Reporting.JS_ONLY)
     shutil.move('test.worker.js', Path('cdn/test.worker.js'))
     if os.path.exists('test.html.mem'):
@@ -4000,7 +4000,7 @@ window.close = function() {
     self.run_browser('test.html', '', '/report_result?exit:0')
 
     # Test that it is possible to define "Module.locateFile(foo)" function to locate where worker.js will be loaded from.
-    create_file('shell2.html', read_file(path_from_root('src', 'shell.html')).replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.worker.js") return "cdn/test.worker.js"; else return filename; }, '))
+    create_file('shell2.html', read_file(path_from_root('src/shell.html')).replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.worker.js") return "cdn/test.worker.js"; else return filename; }, '))
     self.compile_btest(['main.cpp', '--shell-file', 'shell2.html', '-s', 'WASM=0', '-s', 'IN_TEST_HARNESS', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE', '-o', 'test2.html'], reporting=Reporting.JS_ONLY)
     try_delete('test.worker.js')
     self.run_browser('test2.html', '', '/report_result?exit:0')
@@ -4268,7 +4268,7 @@ window.close = function() {
   def test_wasm_locate_file(self):
     # Test that it is possible to define "Module.locateFile(foo)" function to locate where worker.js will be loaded from.
     ensure_dir('cdn')
-    create_file('shell2.html', read_file(path_from_root('src', 'shell.html')).replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.wasm") return "cdn/test.wasm"; else return filename; }, '))
+    create_file('shell2.html', read_file(path_from_root('src/shell.html')).replace('var Module = {', 'var Module = { locateFile: function(filename) { if (filename == "test.wasm") return "cdn/test.wasm"; else return filename; }, '))
     self.compile_btest([test_file('browser_test_hello_world.c'), '--shell-file', 'shell2.html', '-o', 'test.html'])
     shutil.move('test.wasm', Path('cdn/test.wasm'))
     self.run_browser('test.html', '', '/report_result?0')
@@ -4863,7 +4863,7 @@ window.close = function() {
         return 0;
       }
     ''')
-    create_file('shell.html', read_file(path_from_root('src', 'shell.html')).replace('Emscripten-Generated Code', 'Emscripten-Generated Emoji 😅'))
+    create_file('shell.html', read_file(path_from_root('src/shell.html')).replace('Emscripten-Generated Code', 'Emscripten-Generated Emoji 😅'))
     self.btest_exit('main.cpp', args=['--shell-file', 'shell.html'])
 
   # Tests the functionality of the emscripten_thread_sleep() function.

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -364,7 +364,7 @@ class sockets(BrowserCore):
   # Test that native POSIX sockets API can be used by proxying calls to an intermediate WebSockets -> POSIX sockets bridge server
   def test_posix_proxy_sockets(self):
     # Build the websocket bridge server
-    self.run_process(['cmake', path_from_root('tools', 'websocket_to_posix_proxy')])
+    self.run_process(['cmake', path_from_root('tools/websocket_to_posix_proxy')])
     self.run_process(['cmake', '--build', '.'])
     if os.name == 'nt': # This is not quite exact, instead of "isWindows()" this should be "If CMake defaults to building with Visual Studio", but there is no good check for that, so assume Windows==VS.
       proxy_server = os.path.join(self.get_dir(), 'Debug', 'websocket_to_posix_proxy.exe')

--- a/third_party/websockify/websockify.py
+++ b/third_party/websockify/websockify.py
@@ -1,1 +1,5 @@
-run
+#!/usr/bin/env python
+
+import websockify
+
+websockify.websocketproxy.websockify_init()

--- a/tools/building.py
+++ b/tools/building.py
@@ -682,7 +682,7 @@ def js_optimizer(filename, passes):
 
 # run JS optimizer on some JS, ignoring asm.js contents if any - just run on it all
 def acorn_optimizer(filename, passes, extra_info=None, return_output=False):
-  optimizer = path_from_root('tools', 'acorn-optimizer.js')
+  optimizer = path_from_root('tools/acorn-optimizer.js')
   original_filename = filename
   if extra_info is not None:
     temp_files = configuration.get_temp_files()
@@ -714,7 +714,7 @@ def eval_ctors(js_file, binary_file, debug_info=False): # noqa
   logger.debug('Ctor evalling in the wasm backend is disabled due to https://github.com/emscripten-core/emscripten/issues/9527')
   return
   # TODO re-enable
-  # cmd = [PYTHON, path_from_root('tools', 'ctor_evaller.py'), js_file, binary_file, str(settings.INITIAL_MEMORY), str(settings.TOTAL_STACK), str(settings.GLOBAL_BASE), binaryen_bin, str(int(debug_info))]
+  # cmd = [PYTHON, path_from_root('tools/ctor_evaller.py'), js_file, binary_file, str(settings.INITIAL_MEMORY), str(settings.TOTAL_STACK), str(settings.GLOBAL_BASE), binaryen_bin, str(int(debug_info))]
   # if binaryen_bin:
   #   cmd += get_binaryen_feature_flags()
   # check_call(cmd)
@@ -783,7 +783,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
 
   # Closure externs file contains known symbols to be extern to the minification, Closure
   # should not minify these symbol names.
-  CLOSURE_EXTERNS = [path_from_root('src', 'closure-externs', 'closure-externs.js')]
+  CLOSURE_EXTERNS = [path_from_root('src/closure-externs/closure-externs.js')]
 
   # Closure compiler needs to know about all exports that come from the wasm module, because to optimize for small code size,
   # the exported symbols are added to global scope via a foreach loop in a way that evades Closure's static analysis. With an explicit
@@ -799,21 +799,21 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
 
   # Node.js specific externs
   if shared.target_environment_may_be('node'):
-    NODE_EXTERNS_BASE = path_from_root('third_party', 'closure-compiler', 'node-externs')
+    NODE_EXTERNS_BASE = path_from_root('third_party/closure-compiler/node-externs')
     NODE_EXTERNS = os.listdir(NODE_EXTERNS_BASE)
     NODE_EXTERNS = [os.path.join(NODE_EXTERNS_BASE, name) for name in NODE_EXTERNS
                     if name.endswith('.js')]
-    CLOSURE_EXTERNS += [path_from_root('src', 'closure-externs', 'node-externs.js')] + NODE_EXTERNS
+    CLOSURE_EXTERNS += [path_from_root('src/closure-externs/node-externs.js')] + NODE_EXTERNS
 
   # V8/SpiderMonkey shell specific externs
   if shared.target_environment_may_be('shell'):
-    V8_EXTERNS = [path_from_root('src', 'closure-externs', 'v8-externs.js')]
-    SPIDERMONKEY_EXTERNS = [path_from_root('src', 'closure-externs', 'spidermonkey-externs.js')]
+    V8_EXTERNS = [path_from_root('src/closure-externs/v8-externs.js')]
+    SPIDERMONKEY_EXTERNS = [path_from_root('src/closure-externs/spidermonkey-externs.js')]
     CLOSURE_EXTERNS += V8_EXTERNS + SPIDERMONKEY_EXTERNS
 
   # Web environment specific externs
   if shared.target_environment_may_be('web') or shared.target_environment_may_be('worker'):
-    BROWSER_EXTERNS_BASE = path_from_root('src', 'closure-externs', 'browser-externs')
+    BROWSER_EXTERNS_BASE = path_from_root('src/closure-externs/browser-externs')
     if os.path.isdir(BROWSER_EXTERNS_BASE):
       BROWSER_EXTERNS = os.listdir(BROWSER_EXTERNS_BASE)
       BROWSER_EXTERNS = [os.path.join(BROWSER_EXTERNS_BASE, name) for name in BROWSER_EXTERNS
@@ -821,10 +821,10 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
       CLOSURE_EXTERNS += BROWSER_EXTERNS
 
   if settings.DYNCALLS:
-    CLOSURE_EXTERNS += [path_from_root('src', 'closure-externs', 'dyncall-externs.js')]
+    CLOSURE_EXTERNS += [path_from_root('src/closure-externs/dyncall-externs.js')]
 
   if settings.MINIMAL_RUNTIME and settings.USE_PTHREADS and not settings.MODULARIZE:
-    CLOSURE_EXTERNS += [path_from_root('src', 'minimal_runtime_worker_externs.js')]
+    CLOSURE_EXTERNS += [path_from_root('src/minimal_runtime_worker_externs.js')]
 
   args = ['--compilation_level', 'ADVANCED_OPTIMIZATIONS' if advanced else 'SIMPLE_OPTIMIZATIONS']
   # Keep in sync with ecmaVersion in tools/acorn-optimizer.js
@@ -1242,7 +1242,7 @@ def apply_wasm_memory_growth(js_file):
   ret = js_file + '.pgrow.js'
   with open(fixed, 'r') as fixed_f:
     with open(ret, 'w') as ret_f:
-      with open(path_from_root('src', 'growableHeap.js')) as support_code_f:
+      with open(path_from_root('src/growableHeap.js')) as support_code_f:
         ret_f.write(support_code_f.read() + '\n' + fixed_f.read())
   return ret
 
@@ -1407,7 +1407,7 @@ def emit_wasm_source_map(wasm_file, map_file, final_wasm):
   # source file paths must be relative to the location of the map (which is
   # emitted alongside the wasm)
   base_path = os.path.dirname(os.path.abspath(final_wasm))
-  sourcemap_cmd = [PYTHON, path_from_root('tools', 'wasm-sourcemap.py'),
+  sourcemap_cmd = [PYTHON, path_from_root('tools/wasm-sourcemap.py'),
                    wasm_file,
                    '--dwarfdump=' + LLVM_DWARFDUMP,
                    '-o',  map_file,

--- a/tools/clean_webconsole.py
+++ b/tools/clean_webconsole.py
@@ -23,9 +23,9 @@ def nice(x):
 
 
 repdata = (
-  Path(path_from_root('system', 'include', 'GL', 'gl.h')).read_text().splitline(keepends=True) +
+  Path(path_from_root('system/include/GL/gl.h')).read_text().splitline(keepends=True) +
   ['\n'] +
-  Path(path_from_root('system', 'include', 'GL', 'glext.h')).read_text().splitlines(keepends=True)
+  Path(path_from_root('system/include/GL/glext.h')).read_text().splitlines(keepends=True)
 )
 reps = {}
 for rep in repdata:

--- a/tools/config.py
+++ b/tools/config.py
@@ -174,7 +174,7 @@ def generate_config(path, first_time=False):
   # Note: repr is used to ensure the paths are escaped correctly on Windows.
   # The full string is replaced so that the template stays valid Python.
 
-  config_data = utils.read_file(path_from_root('tools', 'settings_template.py'))
+  config_data = utils.read_file(path_from_root('tools/settings_template.py'))
   config_data = config_data.splitlines()[3:] # remove the initial comment
   config_data = '\n'.join(config_data)
   # autodetect some default paths

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -511,8 +511,8 @@ def main():
       # LZ4FS usage
       temp = data_target + '.orig'
       shutil.move(data_target, temp)
-      meta = shared.run_js_tool(shared.path_from_root('tools', 'lz4-compress.js'),
-                                [shared.path_from_root('third_party', 'mini-lz4.js'),
+      meta = shared.run_js_tool(utils.path_from_root('tools/lz4-compress.js'),
+                                [utils.path_from_root('third_party/mini-lz4.js'),
                                 temp, data_target], stdout=PIPE)
       os.unlink(temp)
       use_data = '''

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -89,6 +89,7 @@ sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tools import shared
 from tools import system_libs
+from tools import utils
 from tools.settings import settings
 
 QUIET = (__name__ != '__main__')
@@ -379,9 +380,9 @@ def main(args):
   global QUIET
 
   default_json_files = [
-      shared.path_from_root('src', 'struct_info.json'),
-      shared.path_from_root('src', 'struct_info_internal.json'),
-      shared.path_from_root('src', 'struct_info_cxx.json'),
+      utils.path_from_root('src/struct_info.json'),
+      utils.path_from_root('src/struct_info_internal.json'),
+      utils.path_from_root('src/struct_info_cxx.json'),
   ]
   parser = argparse.ArgumentParser(description='Generate JSON infos for structs.')
   parser.add_argument('json', nargs='*',
@@ -415,11 +416,11 @@ def main(args):
     cflags.append('-U' + arg)
 
   internal_cflags = [
-    '-I' + shared.path_from_root('system', 'lib', 'libc', 'musl', 'src', 'internal'),
+    '-I' + utils.path_from_root('system/lib/libc/musl/src/internal'),
   ]
 
   cxxflags = [
-    '-I' + shared.path_from_root('system', 'lib', 'libcxxabi', 'src'),
+    '-I' + utils.path_from_root('system/lib/libcxxabi/src'),
     '-D__USING_EMSCRIPTEN_EXCEPTIONS__',
   ]
 

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -25,7 +25,7 @@ def path_from_root(*pathelems):
   return os.path.join(__rootpath__, *pathelems)
 
 
-ACORN_OPTIMIZER = path_from_root('tools', 'acorn-optimizer.js')
+ACORN_OPTIMIZER = path_from_root('tools/acorn-optimizer.js')
 
 NUM_CHUNKS_PER_CORE = 3
 MIN_CHUNK_SIZE = int(os.environ.get('EMCC_JSOPT_MIN_CHUNK_SIZE') or 512 * 1024) # configuring this is just for debugging purposes

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -96,14 +96,14 @@ class SettingsManager:
     self.allowed_settings.clear()
 
     # Load the JS defaults into python.
-    with open(path_from_root('src', 'settings.js')) as fh:
+    with open(path_from_root('src/settings.js')) as fh:
       settings = fh.read().replace('//', '#')
     settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
     # Variable TARGET_NOT_SUPPORTED is referenced by value settings.js (also beyond declaring it),
     # so must pass it there explicitly.
     exec(settings, {'attrs': self.attrs})
 
-    with open(path_from_root('src', 'settings_internal.js')) as fh:
+    with open(path_from_root('src/settings_internal.js')) as fh:
       settings = fh.read().replace('//', '#')
     settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
     internal_attrs = {}

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -251,9 +251,9 @@ def timeout_run(proc, timeout=None, full_output=False, check=True):
 
 def get_npm_cmd(name):
   if WINDOWS:
-    cmd = [path_from_root('node_modules', '.bin', name + '.cmd')]
+    cmd = [path_from_root('node_modules/.bin', name + '.cmd')]
   else:
-    cmd = config.NODE_JS + [path_from_root('node_modules', '.bin', name)]
+    cmd = config.NODE_JS + [path_from_root('node_modules/.bin', name)]
   if not os.path.exists(cmd[-1]):
     exit_with_error(f'{name} was not found! Please run "npm install" in Emscripten root directory to set up npm dependencies')
   return cmd
@@ -841,7 +841,7 @@ EMRANLIB = bat_suffix(path_from_root('emranlib'))
 EMCMAKE = bat_suffix(path_from_root('emcmake'))
 EMCONFIGURE = bat_suffix(path_from_root('emconfigure'))
 EM_NM = bat_suffix(path_from_root('emnm'))
-FILE_PACKAGER = bat_suffix(path_from_root('tools', 'file_packager'))
+FILE_PACKAGER = bat_suffix(path_from_root('tools/file_packager'))
 
 apply_configuration()
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -6,6 +6,7 @@
 import contextlib
 import os
 import sys
+from pathlib import Path
 
 from . import diagnostics
 
@@ -20,7 +21,7 @@ def exit_with_error(msg, *args):
 
 
 def path_from_root(*pathelems):
-  return os.path.join(__rootpath__, *pathelems)
+  return str(Path(__rootpath__, *pathelems))
 
 
 def safe_ensure_dirs(dirname):

--- a/tools/wasm2c.py
+++ b/tools/wasm2c.py
@@ -78,8 +78,8 @@ def get_func_types(code):
 
 def do_wasm2c(infile):
   assert settings.STANDALONE_WASM
-  WASM2C = config.NODE_JS + [path_from_root('node_modules', 'wasm2c', 'wasm2c.js')]
-  WASM2C_DIR = path_from_root('node_modules', 'wasm2c')
+  WASM2C = config.NODE_JS + [path_from_root('node_modules/wasm2c/wasm2c.js')]
+  WASM2C_DIR = path_from_root('node_modules/wasm2c')
   c_file = unsuffixed(infile) + '.wasm.c'
   h_file = unsuffixed(infile) + '.wasm.h'
   cmd = WASM2C + [infile, '-o', c_file]
@@ -132,7 +132,7 @@ def do_wasm2c(infile):
 extern void wasmbox_init(void);
 ''')
   for support_file in support_files:
-    total = bundle_file(total, path_from_root('tools', 'wasm2c', support_file + '.c'))
+    total = bundle_file(total, path_from_root('tools/wasm2c', support_file + '.c'))
   # remove #includes of the headers we bundled
   for header in headers:
     total = total.replace('#include "%s"\n' % header[1], '/* include of %s */\n' % header[1])

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -12,15 +12,14 @@ import logging
 import os
 import sys
 
-from . import shared
 from . import utils
 from .settings import settings
 
-sys.path.append(shared.path_from_root('third_party'))
+sys.path.append(utils.path_from_root('third_party'))
 
 import leb128
 
-logger = logging.getLogger('shared')
+logger = logging.getLogger('webassembly')
 
 
 # For the Emscripten-specific WASM metadata section, follows semver, changes

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -15,8 +15,8 @@ sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from tools import shared, utils
 
-sys.path.append(shared.path_from_root('third_party'))
-sys.path.append(shared.path_from_root('third_party', 'ply'))
+sys.path.append(utils.path_from_root('third_party'))
+sys.path.append(utils.path_from_root('third_party/ply'))
 
 import WebIDL
 


### PR DESCRIPTION
This change is very much like that large change I made to the test
suite. See #14191 and #14175.

It enables is to use unix style paths rather than arrays of path
components which has several advantages.  As well as beeing more
readable and writable it also allows for things like `git grep
"musl/src"` to work as expected.  For an example of how much more
readable it makes the code see `tools/system_libs.py`.

This change was made almost exclusively with a bunch of `sed`
commands.

Because there is likely some minor performance overhead I did
some measurements.

Running `./tests/runner wasm2 --skip-slow`:

before:
real    1m10.403s
user    49m40.135s
sys     6m14.466s
after:
real    1m10.397s
user    49m43.849s
sys     6m10.698s

Running `./embuilder build libc --force`:

before:
real    0m5.597s
user    3m2.721s
sys     0m50.843s
after:
real    0m5.609s
user    3m0.998s
sys     0m49.796s