### PR TITLE
Fix test_dylink_spaghetti

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4463,14 +4463,21 @@ res64 - external 64\n''', header='''
       int side_x = -534;
       int adjust2 = main_x + 10;
       int *ptr2 = &main_x;
-      struct Class {
-        Class() {
+      struct SideClass {
+        SideClass() {
           printf("side init sees %d, %d, %d.\n", adjust2, *ptr2, side_x);
         }
       };
-      Class cs;
-    ''', expected=['side init sees 82, 72, -534.\nmain init sees -524, -534, 72.\nmain main sees -524, -534, 72.',
-                   'main init sees -524, -534, 72.\nside init sees 82, 72, -534.\nmain main sees -524, -534, 72.'])
+      SideClass cs;
+    ''', expected=['''\
+side init sees 82, 72, -534.
+main init sees -524, -534, 72.
+main main sees -524, -534, 72.
+''', '''\
+main init sees -524, -534, 72.
+side init sees 82, 72, -534.
+main main sees -524, -534, 72.
+'''])
 
   @needs_make('mingw32-make')
   @needs_dylink


### PR DESCRIPTION
This test was inadvertently relying on an bug in llvm which was recently
fixed: https://github.com/emscripten-core/emscripten/issues/13773

In this test the class `Class` is defined in both the main and the side
module.  If you run this code as is on the desktop the version of
`Class` defined in `main.cpp` will always win the `side init` will never
get printed.

The fix is to give the class in the side module a different name (and
alternative would be to put it in an anonymous namespace).

This change should allow the llvm fix to roll in:
https://reviews.llvm.org/D108413