### PR TITLE
Remove the workaround added for CMake where it was not able to stand sh.exe residing in PATH

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -29,6 +29,13 @@ See docs/process.md for more on how version tagging works.
   sigaction, sigpending, etc).  We still don't have a way to deliver signals from
   the outside but these at least now work for sending signals to the current
   thread (JS context) (#14883).
+- Remove the workaround used in emcmake and emmake that removed directories
+  with sh.exe from PATH on Windows when MinGW Makefiles generator was used.
+  This was needed with CMake versions older than 3.17.0. If you get an error
+  "sh.exe was found in your PATH" on Windows, please update to CMake 3.17.0
+  or newer (released on March 2020). See
+  https://github.com/Kitware/CMake/commit/82ddcf0db1d220564145122c3cce25d25ee0e254
+  for more information. (#14930)
 
 2.0.27 - 08/12/2021
 -------------------

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -32,8 +32,8 @@ See docs/process.md for more on how version tagging works.
 - Remove the workaround used in emcmake and emmake that removed directories
   with sh.exe from PATH on Windows when MinGW Makefiles generator was used.
   This was needed with CMake versions older than 3.17.0. If you get an error
-  "sh.exe was found in your PATH" on Windows, please update to CMake 3.17.0
-  or newer (released on March 2020). See
+  "sh.exe was found in your PATH" on Windows, you can either update to CMake
+  3.17.0 or newer, or remove the offending directory from your PATH. See
   https://github.com/Kitware/CMake/commit/82ddcf0db1d220564145122c3cce25d25ee0e254
   for more information. (#14930)
 

--- a/emcmake.py
+++ b/emcmake.py
@@ -5,8 +5,6 @@
 # found in the LICENSE file.
 
 import sys
-import os
-from tools import building
 from tools import shared
 from tools import config
 from tools import utils
@@ -51,18 +49,9 @@ variables so that emcc etc. are used. Typical usage:
       print('emcmake: no compatible cmake generator found; Please install ninja or mingw32-make, or specify a generator explicitly using -G', file=sys.stderr)
       return 1
 
-  # CMake has a requirement that it wants sh.exe off PATH if MinGW Makefiles
-  # is being used. This happens quite often, so do this automatically on
-  # behalf of the user. See
-  # http://www.cmake.org/Wiki/CMake_MinGW_Compiler_Issues
-  if utils.WINDOWS and 'MinGW Makefiles' in args:
-    env = building.remove_sh_exe_from_path(os.environ)
-  else:
-    env = None
-
   print('configure: ' + shared.shlex_join(args), file=sys.stderr)
   try:
-    shared.check_call(args, env=env)
+    shared.check_call(args)
     return 0
   except CalledProcessError as e:
     return e.returncode

--- a/emmake.py
+++ b/emmake.py
@@ -52,9 +52,6 @@ variables so that emcc etc. are used. Typical usage:
       if mingw32_make:
         args[0] = mingw32_make
 
-    if 'mingw32-make' in args[0]:
-      env = building.remove_sh_exe_from_path(env)
-
   # On Windows, run the execution through shell to get PATH expansion and
   # executable extension lookup, e.g. 'sdl2-config' will match with
   # 'sdl2-config.bat' in PATH.

--- a/tools/building.py
+++ b/tools/building.py
@@ -168,19 +168,6 @@ def get_building_env():
   return env
 
 
-# Returns a clone of the given environment with all directories that contain
-# sh.exe removed from the PATH.  Used to work around CMake limitation with
-# MinGW Makefiles, where sh.exe is not allowed to be present.
-def remove_sh_exe_from_path(env):
-  # Should only ever be called on WINDOWS
-  assert WINDOWS
-  env = env.copy()
-  path = env['PATH'].split(';')
-  path = [p for p in path if not os.path.exists(os.path.join(p, 'sh.exe'))]
-  env['PATH'] = ';'.join(path)
-  return env
-
-
 def make_paths_absolute(f):
   if f.startswith('-'):  # skip flags
     return f


### PR DESCRIPTION
Remove the workaround added for CMake where it was not able to stand sh.exe residing in PATH when MinGW Makefiles generator was used on CMake < 3.17.0. See https://github.com/Kitware/CMake/commit/82ddcf0db1d220564145122c3cce25d25ee0e254 for details.