### PR TITLE
Rebasline test_minimal_runtime_code_size_random_printf_wasm2js after llvm change

### DIFF
--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17302,
-  "a.html.gz": 7429,
-  "total": 17302,
-  "total_gz": 7429
+  "a.html": 17333,
+  "a.html.gz": 7464,
+  "total": 17333,
+  "total_gz": 7464
 }


### PR DESCRIPTION
This llvm change causes a minor code size change for this test: https://reviews.llvm.org/D106450