### PR TITLE
Use internal version of `addOnExit` in emrun_postjs.js. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1590,10 +1590,8 @@ def phase_linker_setup(options, state, newargs, settings_map):
   if settings.MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and settings.MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION:
     exit_with_error('MINIMAL_RUNTIME_STREAMING_WASM_COMPILATION and MINIMAL_RUNTIME_STREAMING_WASM_INSTANTIATION are mutually exclusive!')
 
-  if options.emrun:
-    if settings.MINIMAL_RUNTIME:
-      exit_with_error('--emrun is not compatible with -s MINIMAL_RUNTIME=1')
-    settings.EXPORTED_RUNTIME_METHODS.append('addOnExit')
+  if options.emrun and settings.MINIMAL_RUNTIME:
+    exit_with_error('--emrun is not compatible with MINIMAL_RUNTIME')
 
   if options.use_closure_compiler:
     settings.USE_CLOSURE_COMPILER = options.use_closure_compiler

--- a/src/emrun_postjs.js
+++ b/src/emrun_postjs.js
@@ -40,7 +40,7 @@ if (typeof window === "object" && (typeof ENVIRONMENT_IS_PTHREAD === 'undefined'
       var emrun_http_sequence_number = 1;
       var prevPrint = out;
       var prevErr = err;
-      Module['addOnExit'](function() { if (emrun_num_post_messages_in_flight == 0) postExit('^exit^'+EXITSTATUS); else emrun_should_close_itself = true; });
+      addOnExit(function() { if (emrun_num_post_messages_in_flight == 0) postExit('^exit^'+EXITSTATUS); else emrun_should_close_itself = true; });
       out = function(text) { post('^out^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevPrint(text); };
       err = function(text) { post('^err^'+(emrun_http_sequence_number++)+'^'+encodeURIComponent(text)); prevErr(text); };
 


### PR DESCRIPTION
No need to export `addOnExit` here, we can just call the
internal version directly.