### PR TITLE
Add -wasm-enable-eh flag when using wasm exceptions with LTO

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -457,7 +457,7 @@ def link_lld(args, target, external_symbols=None):
   # Wasm exception handling. This is a CodeGen option for the LLVM backend, so
   # wasm-ld needs to take this for the LTO mode.
   if settings.EXCEPTION_HANDLING:
-    cmd += ['-mllvm', '-exception-model=wasm']
+    cmd += ['-mllvm', '-exception-model=wasm', '-mllvm', '-wasm-enable-eh']
 
   # For relocatable output (generating an object file) we don't pass any of the
   # normal linker flags that are used when building and exectuable


### PR DESCRIPTION
Needed after https://github.com/llvm/llvm-project/commit/77b921b870aacfd531ff449166937e0de6a377bc

Fixes #14947 