### PR TITLE
Remove some macros that are now defined by clang. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -826,9 +826,6 @@ def get_cflags(options, user_args):
   if options.tracing:
     cflags.append('-D__EMSCRIPTEN_TRACING__=1')
 
-  if settings.USE_PTHREADS:
-    cflags.append('-D__EMSCRIPTEN_PTHREADS__=1')
-
   if not settings.STRICT:
     # The preprocessor define EMSCRIPTEN is deprecated. Don't pass it to code
     # in strict mode. Code should use the define __EMSCRIPTEN__ instead.
@@ -861,11 +858,6 @@ def get_cflags(options, user_args):
              '-D__EMSCRIPTEN_minor__=' + str(shared.EMSCRIPTEN_VERSION_MINOR),
              '-D__EMSCRIPTEN_tiny__=' + str(shared.EMSCRIPTEN_VERSION_TINY),
              '-D_LIBCPP_ABI_VERSION=2']
-
-  # For compatability with the fastcomp compiler that defined these
-  cflags += ['-Dunix',
-             '-D__unix',
-             '-D__unix__']
 
   # Changes to default clang behavior
 


### PR DESCRIPTION
`__EMSCRIPTEN_PTHREADS__ `was added a long time ago and the `__unix__`
family of macros are being added in https://reviews.llvm.org/D108735.