### PR TITLE
Remove EmccOptions.tracing and thread_profiler.

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1935,7 +1935,6 @@ int main(int argc, char **argv) {
     # Tracing of memory growths should work
     # (SAFE_HEAP would instrument the tracing code itself, leading to recursion)
     if not self.get_setting('SAFE_HEAP'):
-      self.set_setting('EMSCRIPTEN_TRACING')
       self.emcc_args += ['--tracing']
       self.do_runf(src, '*pre: hello,4.955*\n*hello,4.955*\n*hello,4.955*')
 


### PR DESCRIPTION
These options have the same effect as the equivalent settings.  Having
them exist as both options and settings can lead to bugs where the
option object is checked but not the setting.

For example this change fixes a bug where `-D__EMSCRIPTEN_TRACING__` was
passed the compiler when `--tracing` was set but not when
`-sEMSCRIPTEN_TRACING` is passed on the command line.