### PR TITLE
Trusted Types compatibility for Emscripten threads

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -414,12 +414,9 @@ var LibraryPThread = {
             }
           );
           PThread.unusedWorkers.push(new Worker(p.createScriptURL('ignored')));
-        } else {
-          PThread.unusedWorkers.push(new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)));
-        }
- #else
-        PThread.unusedWorkers.push(new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)));
+        } else
  #endif
+        PThread.unusedWorkers.push(new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)));
         return;
       }
 #endif
@@ -436,12 +433,9 @@ var LibraryPThread = {
       if (typeof trustedTypes !== 'undefined' && trustedTypes.createPolicy) {
         var p = trustedTypes.createPolicy('emscripten#workerPolicy2', { createScriptURL: function(ignored) { return pthreadMainJs } });
         PThread.unusedWorkers.push(new Worker(p.createScriptURL('ignored')));
-      } else {
-        PThread.unusedWorkers.push(new Worker(pthreadMainJs));
-      }
-#else
-      PThread.unusedWorkers.push(new Worker(pthreadMainJs));
+      } else
 #endif
+      PThread.unusedWorkers.push(new Worker(pthreadMainJs));
     },
 
     getNewWorker: function() {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -402,6 +402,7 @@ var LibraryPThread = {
 #if PTHREADS_DEBUG
         out('Allocating a new web worker from ' + new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url));
 #endif
+#if TRUSTED_TYPES
         // Use Trusted Types compatible wrappers.
         if (typeof trustedTypes !== 'undefined' && trustedTypes.createPolicy) {
           var p = trustedTypes.createPolicy('emscripten#workerPolicy1', { createScriptURL: function(ignored) { return new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)} });
@@ -410,6 +411,9 @@ var LibraryPThread = {
         } else {
           PThread.unusedWorkers.push(new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)));
         }
+ #else
+        PThread.unusedWorkers.push(new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)));
+ #endif
         return;
       }
 #endif
@@ -421,6 +425,7 @@ var LibraryPThread = {
 #if PTHREADS_DEBUG
       out('Allocating a new web worker from ' + pthreadMainJs);
 #endif
+#if TRUSTED_TYPES
       // Use Trusted Types compatible wrappers.
       if (typeof trustedTypes !== 'undefined' && trustedTypes.createPolicy) {
         var p = trustedTypes.createPolicy('emscripten#workerPolicy2', { createScriptURL: function(ignored) { return pthreadMainJs } });
@@ -428,6 +433,9 @@ var LibraryPThread = {
       } else {
         PThread.unusedWorkers.push(new Worker(pthreadMainJs));
       }
+#else
+      PThread.unusedWorkers.push(new Worker(pthreadMainJs));
+#endif
     },
 
     getNewWorker: function() {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -402,8 +402,14 @@ var LibraryPThread = {
 #if PTHREADS_DEBUG
         out('Allocating a new web worker from ' + new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url));
 #endif
-        // Use bundler-friendly `new Worker(new URL(..., import.meta.url))` pattern; works in browsers too.
-        PThread.unusedWorkers.push(new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)));
+        // Use Trusted Types compatible wrappers.
+        if (typeof trustedTypes !== 'undefined' && trustedTypes.createPolicy) {
+          var p = trustedTypes.createPolicy('emscripten#workerPolicy1', { createScriptURL: function(ignored) { return new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)} });
+          // Use bundler-friendly `new Worker(new URL(..., import.meta.url))` pattern; works in browsers too.
+          PThread.unusedWorkers.push(new Worker(p.createScriptURL('ignored')));
+        } else {
+          PThread.unusedWorkers.push(new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)));
+        }
         return;
       }
 #endif
@@ -415,7 +421,14 @@ var LibraryPThread = {
 #if PTHREADS_DEBUG
       out('Allocating a new web worker from ' + pthreadMainJs);
 #endif
-      PThread.unusedWorkers.push(new Worker(pthreadMainJs));
+      // Use Trusted Types compatible wrappers.
+      if (typeof trustedTypes !== 'undefined' && trustedTypes.createPolicy) {
+        var p = trustedTypes.createPolicy('emscripten#workerPolicy2', { createScriptURL: function(ignored) { return pthreadMainJs } });
+        // Use bundler-friendly `new Worker(new URL(..., import.meta.url))` pattern; works in browsers too.
+        PThread.unusedWorkers.push(new Worker(p.createScriptURL('ignored')));
+      } else {
+        PThread.unusedWorkers.push(new Worker(pthreadMainJs));
+      }
     },
 
     getNewWorker: function() {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -424,7 +424,6 @@ var LibraryPThread = {
       // Use Trusted Types compatible wrappers.
       if (typeof trustedTypes !== 'undefined' && trustedTypes.createPolicy) {
         var p = trustedTypes.createPolicy('emscripten#workerPolicy2', { createScriptURL: function(ignored) { return pthreadMainJs } });
-        // Use bundler-friendly `new Worker(new URL(..., import.meta.url))` pattern; works in browsers too.
         PThread.unusedWorkers.push(new Worker(p.createScriptURL('ignored')));
       } else {
         PThread.unusedWorkers.push(new Worker(pthreadMainJs));

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -413,7 +413,6 @@ var LibraryPThread = {
               }
             }
           );
-          // Use bundler-friendly `new Worker(new URL(..., import.meta.url))` pattern; works in browsers too.
           PThread.unusedWorkers.push(new Worker(p.createScriptURL('ignored')));
         } else {
           PThread.unusedWorkers.push(new Worker(new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)));

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -405,7 +405,14 @@ var LibraryPThread = {
 #if TRUSTED_TYPES
         // Use Trusted Types compatible wrappers.
         if (typeof trustedTypes !== 'undefined' && trustedTypes.createPolicy) {
-          var p = trustedTypes.createPolicy('emscripten#workerPolicy1', { createScriptURL: function(ignored) { return new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url)} });
+          var p = trustedTypes.createPolicy(
+            'emscripten#workerPolicy1',
+            {
+              createScriptURL: function(ignored) {
+                return new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url);
+              }
+            }
+          );
           // Use bundler-friendly `new Worker(new URL(..., import.meta.url))` pattern; works in browsers too.
           PThread.unusedWorkers.push(new Worker(p.createScriptURL('ignored')));
         } else {

--- a/src/settings.js
+++ b/src/settings.js
@@ -1951,6 +1951,12 @@ var AUTOLOAD_DYLIBS = 1;
 // though these syscalls will fail (or do nothing) at runtime.
 var ALLOW_UNIMPLEMENTED_SYSCALLS = 1;
 
+// Allow calls to Worker(...) and importScripts(...) to be Trusted Types compatible.
+// Trusted Types is a Web Platform feature designed to mitigate DOM XSS by restricting
+// the usage of DOM sink APIs. See https://w3c.github.io/webappsec-trusted-types/.
+// [link]
+var TRUSTED_TYPES = 0;
+
 //===========================================
 // Internal, used for testing only, from here
 //===========================================

--- a/src/worker.js
+++ b/src/worker.js
@@ -144,20 +144,28 @@ self.onmessage = function(e) {
       });
 #else
       if (typeof e.data.urlOrBlob === 'string') {
+#if TRUSTED_TYPES
         if (typeof self.trustedTypes !== 'undefined' && self.trustedTypes.createPolicy) {
           var p = self.trustedTypes.createPolicy('emscripten#workerPolicy3', { createScriptURL: function(ignored) { return e.data.urlOrBlob } });
           importScripts(p.createScriptURL('ignored'));
         } else {
           importScripts(e.data.urlOrBlob);
         }
+#else
+        importScripts(e.data.urlOrBlob);
+#endif
       } else {
         var objectUrl = URL.createObjectURL(e.data.urlOrBlob);
+#if TRUSTED_TYPES
         if (typeof self.trustedTypes !== 'undefined' && self.trustedTypes.createPolicy) {
           var p = self.trustedTypes.createPolicy('emscripten#workerPolicy3', { createScriptURL: function(ignored) { return objectUrl } });
           importScripts(p.createScriptURL('ignored'));
         } else {
           importScripts(objectUrl);
         }
+#else
+        importScripts(objectUrl);
+#endif
         URL.revokeObjectURL(objectUrl);
       }
 #if MODULARIZE

--- a/src/worker.js
+++ b/src/worker.js
@@ -144,10 +144,20 @@ self.onmessage = function(e) {
       });
 #else
       if (typeof e.data.urlOrBlob === 'string') {
-        importScripts(e.data.urlOrBlob);
+        if (typeof self.trustedTypes !== 'undefined' && self.trustedTypes.createPolicy) {
+          var p = self.trustedTypes.createPolicy('emscripten#workerPolicy3', { createScriptURL: function(ignored) { return e.data.urlOrBlob } });
+          importScripts(p.createScriptURL('ignored'));
+        } else {
+          importScripts(e.data.urlOrBlob);
+        }
       } else {
         var objectUrl = URL.createObjectURL(e.data.urlOrBlob);
-        importScripts(objectUrl);
+        if (typeof self.trustedTypes !== 'undefined' && self.trustedTypes.createPolicy) {
+          var p = self.trustedTypes.createPolicy('emscripten#workerPolicy3', { createScriptURL: function(ignored) { return objectUrl } });
+          importScripts(p.createScriptURL('ignored'));
+        } else {
+          importScripts(objectUrl);
+        }
         URL.revokeObjectURL(objectUrl);
       }
 #if MODULARIZE

--- a/src/worker.js
+++ b/src/worker.js
@@ -148,24 +148,18 @@ self.onmessage = function(e) {
         if (typeof self.trustedTypes !== 'undefined' && self.trustedTypes.createPolicy) {
           var p = self.trustedTypes.createPolicy('emscripten#workerPolicy3', { createScriptURL: function(ignored) { return e.data.urlOrBlob } });
           importScripts(p.createScriptURL('ignored'));
-        } else {
-          importScripts(e.data.urlOrBlob);
-        }
-#else
-        importScripts(e.data.urlOrBlob);
+        } else
 #endif
+        importScripts(e.data.urlOrBlob);
       } else {
         var objectUrl = URL.createObjectURL(e.data.urlOrBlob);
 #if TRUSTED_TYPES
         if (typeof self.trustedTypes !== 'undefined' && self.trustedTypes.createPolicy) {
           var p = self.trustedTypes.createPolicy('emscripten#workerPolicy3', { createScriptURL: function(ignored) { return objectUrl } });
           importScripts(p.createScriptURL('ignored'));
-        } else {
-          importScripts(objectUrl);
-        }
-#else
-        importScripts(objectUrl);
+        } else
 #endif
+        importScripts(objectUrl);
         URL.revokeObjectURL(objectUrl);
       }
 #if MODULARIZE


### PR DESCRIPTION
We noticed that worker-loading code in Emscripten will not work on a page with [Trusted Types](https://w3c.github.io/webappsec-trusted-types/dist/spec/) enabled. Given that this incompatibility will prevent Trusted Types enforcement (which has significant security benefits mitigating DOM XSS) for sites that rely on Emscripten, we wish to make the worker creation callsites compatible with [browsers that support Trusted Types](https://caniuse.com/trusted-types).

This change will be a no-op for browsers that do not support Trusted Types, but will allow worker creation for browsers that enforce it.

Please do not hesitate to reach out with any questions, and thank you for your consideration!