### PR TITLE
Add support for TLS imports/exports to/from DSOs

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1623,7 +1623,15 @@ def phase_linker_setup(options, state, newargs, settings_map):
     settings.EXPORT_ALL = 1
 
   if settings.MAIN_MODULE:
-    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getDylinkMetadata', '$mergeLibSymbols']
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+        '$getDylinkMetadata',
+        '$mergeLibSymbols',
+    ]
+
+  if settings.USE_PTHREADS:
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+        '$registerTlsInit',
+    ]
 
   if settings.RELOCATABLE:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -970,13 +970,21 @@ function createWasm() {
     Module['asm'] = exports;
 
 #if MAIN_MODULE
-#if AUTOLOAD_DYLIBS
     var metadata = getDylinkMetadata(module);
+#if AUTOLOAD_DYLIBS
     if (metadata.neededDynlibs) {
       dynamicLibraries = metadata.neededDynlibs.concat(dynamicLibraries);
     }
 #endif
     mergeLibSymbols(exports, 'main')
+#endif
+
+#if USE_PTHREADS
+#if MAIN_MODULE
+    registerTlsInit(Module['asm']['emscripten_tls_init'], instance.exports, metadata);
+#else
+    registerTlsInit(Module['asm']['emscripten_tls_init']);
+#endif
 #endif
 
 #if !IMPORTED_MEMORY
@@ -1015,7 +1023,6 @@ function createWasm() {
     exportAsmFunctions(exports);
 #endif
 #if USE_PTHREADS
-    PThread.tlsInitFunctions.push(Module['asm']['emscripten_tls_init']);
     // We now have the Wasm module loaded up, keep a reference to the compiled module so we can post it to the workers.
     wasmModule = module;
     // Instantiation is synchronous in pthreads and we assert on run dependencies.

--- a/system/lib/pthread/emscripten_tls_init.c
+++ b/system/lib/pthread/emscripten_tls_init.c
@@ -28,15 +28,17 @@ static void free_tls(void* tls_block) {
   emscripten_builtin_free(tls_block);
 }
 
-void emscripten_tls_init(void) {
+void* emscripten_tls_init(void) {
   size_t tls_size = __builtin_wasm_tls_size();
   size_t tls_align = __builtin_wasm_tls_align();
-  if (tls_size) {
-    void *tls_block = emscripten_builtin_memalign(tls_align, tls_size);
-#ifdef DEBUG_TLS
-    printf("tls init: thread[%p] dso[%p] -> %p\n", pthread_self(), &__dso_handle, tls_block);
-#endif
-    __wasm_init_tls(tls_block);
-    __cxa_thread_atexit(free_tls, tls_block, &__dso_handle);
+  if (!tls_size) {
+    return NULL;
   }
+  void *tls_block = emscripten_builtin_memalign(tls_align, tls_size);
+#ifdef DEBUG_TLS
+  printf("tls init: thread[%p] dso[%p] -> %p\n", pthread_self(), &__dso_handle, tls_block);
+#endif
+  __wasm_init_tls(tls_block);
+  __cxa_thread_atexit(free_tls, tls_block, &__dso_handle);
+  return tls_block;
 }

--- a/tests/core/pthread/test_pthread_dylink_tls.c
+++ b/tests/core/pthread/test_pthread_dylink_tls.c
@@ -3,12 +3,21 @@
 #include <pthread.h>
 
 int get_side_tls();
+int get_side_tls2();
 int* get_side_tls_address();
+int* get_side_tls_address2();
 
-static __thread int main_tls = 10;
+__thread int main_tls = 10;
+__thread int main_tls2 = 11;
+extern __thread int side_tls;
+extern __thread int side_tls2;
 
 int get_main_tls() {
   return main_tls;
+}
+
+int get_main_tls2() {
+  return main_tls2;
 }
 
 int* get_main_tls_address() {
@@ -17,9 +26,13 @@ int* get_main_tls_address() {
 
 void report_tls() {
   //printf("side_tls address: %p\n", get_side_tls_address());
-  printf("side_tls value  : %d\n", get_side_tls());
+  printf("side_tls  value  : %d %d\n", get_side_tls(), get_side_tls2());
+  printf("side_tls direct  : %d %d\n", side_tls, side_tls2);
   //printf("main_tls address: %p\n", get_main_tls_address());
-  printf("main_tls value  : %d\n", get_main_tls());
+  printf("main_tls  value  : %d %d\n", get_main_tls(), get_main_tls2());
+  printf("main_tls direct  : %d %d\n", main_tls, main_tls2);
+  assert(get_side_tls() == side_tls);
+  assert(get_side_tls2() == side_tls2);
 }
 
 void test_tls(int inc) {

--- a/tests/core/pthread/test_pthread_dylink_tls.out
+++ b/tests/core/pthread/test_pthread_dylink_tls.out
@@ -1,15 +1,23 @@
 thread: 1
-side_tls value  : 42
-main_tls value  : 10
+side_tls  value  : 42 43
+side_tls direct  : 42 43
+main_tls  value  : 10 11
+main_tls direct  : 10 11
 increment done
-side_tls value  : 62
-main_tls value  : 30
+side_tls  value  : 62 43
+side_tls direct  : 62 43
+main_tls  value  : 30 11
+main_tls direct  : 30 11
 
 thread: 2
-side_tls value  : 42
-main_tls value  : 10
+side_tls  value  : 42 43
+side_tls direct  : 42 43
+main_tls  value  : 10 11
+main_tls direct  : 10 11
 increment done
-side_tls value  : 52
-main_tls value  : 20
+side_tls  value  : 52 43
+side_tls direct  : 52 43
+main_tls  value  : 20 11
+main_tls direct  : 20 11
 
 success

--- a/tests/core/pthread/test_pthread_dylink_tls_side.c
+++ b/tests/core/pthread/test_pthread_dylink_tls_side.c
@@ -1,9 +1,18 @@
-static __thread int mytls = 42;
+__thread int side_tls = 42;
+__thread int side_tls2 = 43;
 
 int get_side_tls() {
-  return mytls;
+  return side_tls;
+}
+
+int get_side_tls2() {
+  return side_tls2;
 }
 
 int* get_side_tls_address() {
-  return &mytls;
+  return &side_tls;
+}
+
+int* get_side_tls_address2() {
+  return &side_tls2;
 }

--- a/tests/core/test_dylink_tls_export.c
+++ b/tests/core/test_dylink_tls_export.c
@@ -1,0 +1,34 @@
+#include <threads.h>
+#include <stdio.h>
+
+thread_local int foo = 10;
+thread_local int bar = 11;
+extern thread_local int baz;
+extern thread_local int wiz;
+
+void sidey();
+
+int get_foo() {
+  return foo;
+}
+
+int get_bar() {
+  return bar;
+}
+
+int get_baz() {
+  return baz;
+}
+
+int get_wiz() {
+  return wiz;
+}
+
+int main(int argc, char const *argv[]) {
+  printf("main: foo=%d\n", get_foo());
+  printf("main: bar=%d\n", get_bar());
+  printf("main: baz=%d\n", get_baz());
+  printf("main: wiz=%d\n", get_wiz());
+  sidey();
+  return 0;
+}

--- a/tests/core/test_dylink_tls_export.out
+++ b/tests/core/test_dylink_tls_export.out
@@ -1,0 +1,8 @@
+main: foo=10
+main: bar=11
+main: baz=42
+main: wiz=43
+side: foo=10
+side: bar=11
+side: baz=42
+side: wiz=43

--- a/tests/core/test_dylink_tls_export_side.c
+++ b/tests/core/test_dylink_tls_export_side.c
@@ -1,0 +1,31 @@
+#include <threads.h>
+#include <stdio.h>
+#include <threads.h>
+
+thread_local int baz = 42;
+thread_local int wiz = 43;
+extern thread_local int foo;
+extern thread_local int bar;
+
+int get_foo() {
+  return foo;
+}
+
+int get_bar() {
+  return bar;
+}
+
+int get_baz() {
+  return baz;
+}
+
+int get_wiz() {
+  return wiz;
+}
+
+void sidey() {
+  printf("side: foo=%d\n", get_foo());
+  printf("side: bar=%d\n", get_bar());
+  printf("side: baz=%d\n", get_baz());
+  printf("side: wiz=%d\n", get_wiz());
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4588,14 +4588,15 @@ main main sees -524, -534, 72.
   @node_pthreads
   @needs_dylink
   def test_dylink_tls(self):
-    # We currently can't export TLS symbols from module since we don't have
-    # and ABI for signaling which exports are TLS and which are regular
-    # data exports.
-
-    # TODO(sbc): Add tests that depend on importing/exported TLS symbols
-    # once we figure out how to do that.
     self.emcc_args.append('-Wno-experimental')
     self.dylink_testf(test_file('core/test_dylink_tls.c'),
+                      need_reverse=False)
+
+  @node_pthreads
+  @needs_dylink
+  def test_dylink_tls_export(self):
+    self.emcc_args.append('-Wno-experimental')
+    self.dylink_testf(test_file('core/test_dylink_tls_export.c'),
                       need_reverse=False)
 
   def test_random(self):


### PR DESCRIPTION
This change is based on the recently added EXPORT_INFO metadata that tells
the dynamic linker which exports are TLS exports and which are normal data
exports: https://reviews.llvm.org/D108877
