### PR TITLE
Don't call emscripten_tls_init from static constructor. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1864,7 +1864,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
       exit_with_error('USE_PTHREADS + BUILD_AS_WORKER require separate modes that don\'t work together, see https://github.com/emscripten-core/emscripten/issues/8854')
     settings.JS_LIBRARIES.append((0, 'library_pthread.js'))
     settings.EXPORTED_FUNCTIONS += [
-      '___emscripten_pthread_data_constructor',
+      '___emscripten_init_main_thread',
       '__emscripten_call_on_thread',
       '__emscripten_main_thread_futex',
       '__emscripten_thread_init',

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -483,17 +483,20 @@ var LibraryDylink = {
 
         // initialize the module
 #if USE_PTHREADS
-        // The main thread does a full __wasm_call_ctors (which includes a call
-        // to emscripten_tls_init), but secondary threads should not call static
-        // constructors in general - emscripten_tls_init is the exception.
-        if (ENVIRONMENT_IS_PTHREAD) {
-          var init = moduleExports['emscripten_tls_init'];
-          assert(init);
-#if DYLINK_DEBUG
-          out("adding to tlsInitFunctions: " + init);
+        // Only one thread (currently The main thread) should call
+        // __wasm_call_ctors, but all threads need to call emscripten_tls_init
+        var initTLS = moduleExports['emscripten_tls_init'];
+#if ASSERTIONS
+        assert(initTLS);
 #endif
-          PThread.tlsInitFunctions.push(init);
-        } else {
+#if DYLINK_DEBUG
+        out("adding to tlsInitFunctions: " + initTLS);
+#endif
+        PThread.tlsInitFunctions.push(initTLS);
+        if (runtimeInitialized) {
+          initTLS();
+        }
+        if (!ENVIRONMENT_IS_PTHREAD) {
 #endif
           var init = moduleExports['__wasm_call_ctors'];
           // TODO(sbc): Remove this once extra check once the binaryen

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -58,7 +58,6 @@ function initRuntime(asm) {
 
 #if USE_PTHREADS
   // Export needed variables that worker.js needs to Module.
-  Module['_emscripten_tls_init'] = _emscripten_tls_init;
   Module['HEAPU32'] = HEAPU32;
   Module['__emscripten_thread_init'] = __emscripten_thread_init;
   Module['_pthread_self'] = _pthread_self;
@@ -75,6 +74,10 @@ function initRuntime(asm) {
 #if STACK_OVERFLOW_CHECK >= 2
   ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
 #endif
+#endif
+
+#if USE_PTHREADS
+  PThread.tlsInitFunctions.push(asm['emscripten_tls_init']);
 #endif
 
 #if hasExportedFunction('___wasm_call_ctors')

--- a/system/lib/README.md
+++ b/system/lib/README.md
@@ -17,8 +17,7 @@ These current set of static constructors in system libraries and their prioritie
 (lowest run first) are:
 
 - 47: `initialize_emmalloc_heap` (emmalloc.c)
-- 48: `__emscripten_pthread_data_constructor` (pthread/emscripten_tls_init.c)
-- 49: `emscripten_tls_init` (pthread/library_pthread.c)
+- 48: `__emscripten_pthread_data_constructor` (pthread/library_pthread.c)
 - 50: asan init (??)
 
 Priorities 0 - 100 are reserved for system libraries and user-level

--- a/system/lib/pthread/emscripten_tls_init.c
+++ b/system/lib/pthread/emscripten_tls_init.c
@@ -28,8 +28,6 @@ static void free_tls(void* tls_block) {
   emscripten_builtin_free(tls_block);
 }
 
-//See system/lib/README.md for static constructor ordering.
-__attribute__((constructor(49)))
 void emscripten_tls_init(void) {
   size_t tls_size = __builtin_wasm_tls_size();
   size_t tls_align = __builtin_wasm_tls_align();

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -869,14 +869,12 @@ int _emscripten_call_on_thread(int forceAsync, pthread_t targetThread, EM_FUNC_S
 // the main thread is waiting, we wake it up before waking up any workers.
 EMSCRIPTEN_KEEPALIVE void* _emscripten_main_thread_futex;
 
-EM_JS(void, initPthreadsJS, (void* tb), {
-  PThread.initRuntime(tb);
-})
+void __emscripten_init_main_thread_js(void* tb);
 
 // See system/lib/README.md for static constructor ordering.
 __attribute__((constructor(48)))
-void __emscripten_pthread_data_constructor(void) {
-  initPthreadsJS(&__main_pthread);
+void __emscripten_init_main_thread(void) {
+  __emscripten_init_main_thread_js(&__main_pthread);
   // The pthread struct has a field that points to itself - this is used as
   // a magic ID to detect whether the pthread_t structure is 'alive'.
   __main_pthread.self = &__main_pthread;

--- a/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -1,5 +1,5 @@
 $GetQueue
-$__emscripten_pthread_data_constructor
+$__emscripten_init_main_thread
 $__errno_location
 $__pthread_mutex_lock
 $__pthread_mutex_trylock


### PR DESCRIPTION
This change makes handling of `emscripten_tls_init` the
same on all threads, including the main thread and/or library
loading thread.

This is precursor to a change that makes use of the return
value of `emscripten_tls_init` to do TLS relocations so making
the call explicit is required.