### PR TITLE
Improve test_dylink_tls. NFC

### DIFF
--- a/tests/core/test_dylink_tls.c
+++ b/tests/core/test_dylink_tls.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <threads.h>
+
+static thread_local int foo = 10;
+static thread_local int bar = 11;
+
+void sidey();
+
+int get_foo() {
+  return foo;
+}
+
+int get_bar() {
+  return bar;
+}
+
+int main(int argc, char const *argv[]) {
+  printf("main TLS: %d %d\n", get_foo(), get_bar());
+  sidey();
+  return 0;
+}

--- a/tests/core/test_dylink_tls.out
+++ b/tests/core/test_dylink_tls.out
@@ -1,0 +1,2 @@
+main TLS: 10 11
+side TLS: 42 43

--- a/tests/core/test_dylink_tls_side.c
+++ b/tests/core/test_dylink_tls_side.c
@@ -1,0 +1,17 @@
+#include <stdio.h>
+#include <threads.h>
+
+static thread_local int baz = 42;
+static thread_local int wiz = 43;
+
+int get_baz() {
+  return baz;
+}
+
+int get_wiz() {
+  return wiz;
+}
+
+void sidey() {
+  printf("side TLS: %d %d\n", get_baz(), get_wiz());
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4592,31 +4592,8 @@ main main sees -524, -534, 72.
 
     # TODO(sbc): Add tests that depend on importing/exported TLS symbols
     # once we figure out how to do that.
-    create_file('main.c', r'''
-      #include <stdio.h>
-
-      _Thread_local int foo = 10;
-
-      void sidey();
-
-      int main(int argc, char const *argv[]) {
-        printf("main TLS: %d\n", foo);
-        sidey();
-        return 0;
-      }
-    ''')
-    create_file('side.c', r'''
-      #include <stdio.h>
-
-      _Thread_local int bar = 11;
-
-      void sidey() {
-        printf("side TLS: %d\n", bar);
-      }
-    ''')
     self.emcc_args.append('-Wno-experimental')
-    self.dylink_testf('main.c', 'side.c',
-                      expected='main TLS: 10\nside TLS: 11\n',
+    self.dylink_testf(test_file('core/test_dylink_tls.c'), test_file('core/test_dylink_tls_side.c'),
                       need_reverse=False)
 
   def test_random(self):


### PR DESCRIPTION
Make TLS variables static which fixes a linker failure when
building with `-g` (for example this test currently fails under wasm2g
and wasm0g congigurations).

Also, add two different TLS variables in each of the modules which
helps with debugging since only one of them will be at TLS offset 0.