### PR TITLE
Delay setting of threadStatus on thread exit

### DIFF
--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -36,7 +36,7 @@ struct pthread {
 #ifdef __EMSCRIPTEN__
 	// Note: The specific order of these fields is important, since these are accessed
 	// by direct pointer arithmetic in worker.js.
-	int threadStatus; // 0: thread not exited, 1: exited.
+	_Atomic int threadStatus; // 0: thread not exited, 1: exited.
 	thread_profiler_block * _Atomic profilerBlock; // If --threadprofiler is enabled, this pointer is allocated to contain internal information about the thread state for profiling purposes.
 #endif
 


### PR DESCRIPTION
As soon as we set threadStatus then any waiting threads can join
with us, free out thread data, and recycle the workers.  For this
reason we want to delay setting this until as late as possible.