### PR TITLE
Add additional functionality to trackingDelegate

### DIFF
--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -751,13 +751,13 @@ File system API
 
   .. code-block:: text
 
-    Opened "/test.txt" with flags 2
+    Opened "/test.txt" with flags O_CREAT O_TRUNC O_WRONLY and file size 0
     Wrote to file "/test.txt" with 11 bytes written
     Wrote to file "/test.txt" with 0 bytes written
     Closed /test.txt
     About to move "/test.txt" to "/renamed.txt"
     Moved "/test.txt" to "/renamed.txt"
-    Opened "/renamed.txt" with flags 1
+    Opened "/renamed.txt" with flags O_RDONLY and file size 11
     Read 0 bytes from "/renamed.txt"
     Read 11 bytes from "/renamed.txt"
     Read 0 bytes from "/renamed.txt"
@@ -765,11 +765,11 @@ File system API
     Wrote to file "/dev/tty" with 31 bytes written
     File read returned 'hello world'
     Wrote to file "/dev/tty" with 2 bytes written
-    About to delete "/renamed.txt"
     Closed /renamed.txt
+    About to delete "/renamed.txt"
     Deleted "/renamed.txt"
-    Created directory /home/test with mode 16893
-    Created symlink from /renamed.txt to /file.txt
+    Created directory "/home/test" with mode 16893
+    Created symlink from "/renamed.txt" to "/file.txt"
 
 
 

--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -684,10 +684,10 @@ File system API
   - ``onMovePath`` — Indicates path is moved.
   - ``willDeletePath`` — Indicates path is about to be deleted.
   - ``onDeletePath`` — Indicates path deleted.
-  - ``onOpenFile`` — Indicates file is opened and reports file size.
+  - ``onOpenFile`` — Indicates file is opened.
   - ``onWriteToFile`` — Indicates file is being written to and number of bytes written.
   - ``onReadFile`` — Indicates file is being read and number of bytes read.
-  - ``onSeekFile`` — Indicates seeking within a file and the position.
+  - ``onSeekFile`` — Indicates seeking within a file, position, and whence.
   - ``onCloseFile`` — Indicates a file being closed.
 
   :callback name: The name of the callback that indicates the filesystem event
@@ -709,8 +709,8 @@ File system API
       FS.trackingDelegate['onDeletePath'] = function(path) {
         out('Deleted "' + path + '"');
       };
-      FS.trackingDelegate['onOpenFile'] = function(path, flags, fileSize) {
-        out('Opened "' + path + '" with flags ' + flags + ' and size ' + fileSize);
+      FS.trackingDelegate['onOpenFile'] = function(path, flags) {
+        out('Opened "' + path + '" with flags ' + flags);
       };
       FS.trackingDelegate['onReadFile'] = function(path, bytesRead) {
         out('Read ' + bytesRead + ' bytes from "' + path + '"');
@@ -718,8 +718,8 @@ File system API
       FS.trackingDelegate['onWriteToFile'] = function(path, bytesWritten) {
         out('Wrote to file "' + path + '" with ' + bytesWritten + ' bytes written');
       };
-      FS.trackingDelegate['onSeekFile'] = function(path, position) {
-        out('Seek on "' + path + '" with position ' + position);
+      FS.trackingDelegate['onSeekFile'] = function(path, position, whence) {
+        out('Seek on "' + path + '" with position ' + position + ' and whence ' + whence);
       };
       FS.trackingDelegate['onCloseFile'] = function(path) {
         out('Closed ' + path);
@@ -751,13 +751,13 @@ File system API
 
   .. code-block:: text
 
-    Opened "/test.txt" with flags 2 and size 0
+    Opened "/test.txt" with flags 2
     Wrote to file "/test.txt" with 11 bytes written
     Wrote to file "/test.txt" with 0 bytes written
     Closed /test.txt
     About to move "/test.txt" to "/renamed.txt"
     Moved "/test.txt" to "/renamed.txt"
-    Opened "/renamed.txt" with flags 1 and size 11
+    Opened "/renamed.txt" with flags 1
     Read 0 bytes from "/renamed.txt"
     Read 11 bytes from "/renamed.txt"
     Read 0 bytes from "/renamed.txt"

--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -688,6 +688,7 @@ File system API
   - ``onWriteToFile`` — Indicates file is being written to and number of bytes written.
   - ``onReadFile`` — Indicates file is being read and number of bytes read.
   - ``onSeekFile`` — Indicates seeking within a file and the position.
+  - ``onCloseFile`` — Indicates a file being closed.
 
   :callback name: The name of the callback that indicates the filesystem event
 
@@ -720,6 +721,9 @@ File system API
       FS.trackingDelegate['onSeekFile'] = function(path, position) {
         out('Seek on "' + path + '" with position ' + position);
       };
+      FS.trackingDelegate['onCloseFile'] = function(path) {
+        out('Closed ' + path);
+      };
     );
 
     FILE *file;
@@ -742,6 +746,7 @@ File system API
     Opened "/test.txt" with flags 2 and size 0
     Wrote to file "/test.txt" with 11 bytes written
     Wrote to file "/test.txt" with 0 bytes written
+    Closed /test.txt
     About to move "/test.txt" to "/renamed.txt"
     Moved "/test.txt" to "/renamed.txt"
     Opened "/renamed.txt" with flags 1 and size 11
@@ -753,6 +758,7 @@ File system API
     File read returned 'hello world'
     Wrote to file "/dev/tty" with 2 bytes written
     About to delete "/renamed.txt"
+    Closed /renamed.txt
     Deleted "/renamed.txt"
 
 

--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -724,6 +724,12 @@ File system API
       FS.trackingDelegate['onCloseFile'] = function(path) {
         out('Closed ' + path);
       };
+      FS.trackingDelegate['onMakeDirectory'] = function(path, mode) {
+        out('Created directory ' + path + ' with mode ' + mode);
+      };
+      FS.trackingDelegate['onMakeSymlink'] = function(oldpath, newpath) {
+        out('Created symlink from ' + oldpath + ' to ' + newpath);
+      };
     );
 
     FILE *file;
@@ -737,6 +743,8 @@ File system API
     printf("File read returned '%s'\n", str);
     fclose(file);
     remove("/renamed.txt");
+    mkdir("/home/test", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+    symlink("/renamed.txt", "/file.txt");
 
 
   Example Output
@@ -760,6 +768,8 @@ File system API
     About to delete "/renamed.txt"
     Closed /renamed.txt
     Deleted "/renamed.txt"
+    Created directory /home/test with mode 16893
+    Created symlink from /renamed.txt to /file.txt
 
 
 

--- a/site/source/docs/api_reference/Filesystem-API.rst
+++ b/site/source/docs/api_reference/Filesystem-API.rst
@@ -684,8 +684,10 @@ File system API
   - ``onMovePath`` — Indicates path is moved.
   - ``willDeletePath`` — Indicates path is about to be deleted.
   - ``onDeletePath`` — Indicates path deleted.
-  - ``onOpenFile`` — Indicates file is opened.
-  - ``onWriteToFile`` — Indicates file is being written to.
+  - ``onOpenFile`` — Indicates file is opened and reports file size.
+  - ``onWriteToFile`` — Indicates file is being written to and number of bytes written.
+  - ``onReadFile`` — Indicates file is being read and number of bytes read.
+  - ``onSeekFile`` — Indicates seeking within a file and the position.
 
   :callback name: The name of the callback that indicates the filesystem event
 
@@ -695,22 +697,28 @@ File system API
 
     EM_ASM(
       FS.trackingDelegate['willMovePath'] = function(oldpath, newpath) {
-        Module.print('About to move "' + oldpath + '" to "' + newpath + '"');
+        out('About to move "' + oldpath + '" to "' + newpath + '"');
       };
       FS.trackingDelegate['onMovePath'] = function(oldpath, newpath) {
-        Module.print('Moved "' + oldpath + '" to "' + newpath + '"');
+        out('Moved "' + oldpath + '" to "' + newpath + '"');
       };
       FS.trackingDelegate['willDeletePath'] = function(path) {
-        Module.print('About to delete "' + path + '"');
+        out('About to delete "' + path + '"');
       };
       FS.trackingDelegate['onDeletePath'] = function(path) {
-        Module.print('Deleted "' + path + '"');
+        out('Deleted "' + path + '"');
       };
-      FS.trackingDelegate['onOpenFile'] = function(path, flags) {
-        Module.print('Opened "' + path + '" with flags ' + flags);
+      FS.trackingDelegate['onOpenFile'] = function(path, flags, fileSize) {
+        out('Opened "' + path + '" with flags ' + flags + ' and size ' + fileSize);
       };
-      FS.trackingDelegate['onWriteToFile'] = function(path) {
-        Module.print('Wrote to file "' + path + '"');
+      FS.trackingDelegate['onReadFile'] = function(path, bytesRead) {
+        out('Read ' + bytesRead + ' bytes from "' + path + '"');
+      };
+      FS.trackingDelegate['onWriteToFile'] = function(path, bytesWritten) {
+        out('Wrote to file "' + path + '" with ' + bytesWritten + ' bytes written');
+      };
+      FS.trackingDelegate['onSeekFile'] = function(path, position) {
+        out('Seek on "' + path + '" with position ' + position);
       };
     );
 
@@ -731,13 +739,19 @@ File system API
 
   .. code-block:: text
 
-    Opened "/test.txt" with flags 2
-    Wrote to file "/test.txt"
+    Opened "/test.txt" with flags 2 and size 0
+    Wrote to file "/test.txt" with 11 bytes written
+    Wrote to file "/test.txt" with 0 bytes written
     About to move "/test.txt" to "/renamed.txt"
     Moved "/test.txt" to "/renamed.txt"
-    Opened "/renamed.txt" with flags 1
+    Opened "/renamed.txt" with flags 1 and size 11
+    Read 0 bytes from "/renamed.txt"
+    Read 11 bytes from "/renamed.txt"
+    Read 0 bytes from "/renamed.txt"
+    Read 0 bytes from "/renamed.txt"
+    Wrote to file "/dev/tty" with 31 bytes written
     File read returned 'hello world'
-    Wrote to file "/dev/tty"
+    Wrote to file "/dev/tty" with 2 bytes written
     About to delete "/renamed.txt"
     Deleted "/renamed.txt"
 

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1178,7 +1178,6 @@ FS.staticInit();` +
       try {
         if (stream.path && FS.trackingDelegate['onReadFile']) {
           FS.trackingDelegate['onReadFile'](stream.path, bytesRead);
-
         }
       } catch(e) {
         err("FS.trackingDelegate['onReadFile']('"+stream.path+", bytesRead') threw an exception: " + e.message);

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -665,6 +665,15 @@ FS.staticInit();` +
       mode = mode !== undefined ? mode : 511 /* 0777 */;
       mode &= {{{ cDefine('S_IRWXUGO') }}} | {{{ cDefine('S_ISVTX') }}};
       mode |= {{{ cDefine('S_IFDIR') }}};
+      #if FS_DEBUG
+      try {
+        if (FS.trackingDelegate['onMakeDirectory']) {
+          FS.trackingDelegate['onMakeDirectory'](path, mode);
+        }
+      } catch(e) {
+        err("FS.trackingDelegate['onMakeDirectory']('"+path+"', " + mode + ") threw an exception: " + e.message);
+      }
+      #endif
       return FS.mknod(path, mode, 0);
     },
     // Creates a whole directory tree chain if it doesn't yet exist
@@ -706,6 +715,15 @@ FS.staticInit();` +
       if (!parent.node_ops.symlink) {
         throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
+      #if FS_DEBUG
+      try {
+        if (FS.trackingDelegate['onMakeSymlink']) {
+          FS.trackingDelegate['onMakeSymlink'](oldpath, newpath);
+        }
+      } catch(e) {
+        err("FS.trackingDelegate['onMakeSymlink']('"+oldpath+"', '" + newpath + "') threw an exception: " + e.message);
+      }
+      #endif
       return parent.node_ops.symlink(parent, newname, oldpath);
     },
     rename: function(old_path, new_path) {

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -104,9 +104,9 @@ FS.staticInit();` +
     // This is set to false during `preInit`, allowing you to modify the
     // filesystem freely up until that point (e.g. during `preRun`).
     ignorePermissions: true,
-    #if FS_DEBUG
+#if FS_DEBUG
     trackingDelegate: {},
-    #endif
+#endif
     ErrnoError: null, // set during init
     genericErrors: {},
     filesystems: null,
@@ -665,15 +665,15 @@ FS.staticInit();` +
       mode = mode !== undefined ? mode : 511 /* 0777 */;
       mode &= {{{ cDefine('S_IRWXUGO') }}} | {{{ cDefine('S_ISVTX') }}};
       mode |= {{{ cDefine('S_IFDIR') }}};
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['onMakeDirectory']) {
           FS.trackingDelegate['onMakeDirectory'](path, mode);
         }
       } catch(e) {
-        err("FS.trackingDelegate['onMakeDirectory']('"+path+"', " + mode + ") threw an exception: " + e.message);
+        err("FS.trackingDelegate['onMakeDirectory']('" + path + "', " + mode + ") threw an exception: " + e.message);
       }
-      #endif
+#endif
       return FS.mknod(path, mode, 0);
     },
     // Creates a whole directory tree chain if it doesn't yet exist
@@ -715,15 +715,15 @@ FS.staticInit();` +
       if (!parent.node_ops.symlink) {
         throw new FS.ErrnoError({{{ cDefine('EPERM') }}});
       }
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['onMakeSymlink']) {
           FS.trackingDelegate['onMakeSymlink'](oldpath, newpath);
         }
       } catch(e) {
-        err("FS.trackingDelegate['onMakeSymlink']('"+oldpath+"', '" + newpath + "') threw an exception: " + e.message);
+        err("FS.trackingDelegate['onMakeSymlink']('" + oldpath + "', '" + newpath + "') threw an exception: " + e.message);
       }
-      #endif
+#endif
       return parent.node_ops.symlink(parent, newname, oldpath);
     },
     rename: function(old_path, new_path) {
@@ -795,15 +795,15 @@ FS.staticInit();` +
           throw new FS.ErrnoError(errCode);
         }
       }
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['willMovePath']) {
           FS.trackingDelegate['willMovePath'](old_path, new_path);
         }
       } catch(e) {
-        err("FS.trackingDelegate['willMovePath']('"+old_path+"', '"+new_path+"') threw an exception: " + e.message);
+        err("FS.trackingDelegate['willMovePath']('" + old_path + "', '" + new_path + "') threw an exception: " + e.message);
       }
-      #endif
+#endif
       // remove the node from the lookup hash
       FS.hashRemoveNode(old_node);
       // do the underlying fs rename
@@ -816,13 +816,13 @@ FS.staticInit();` +
         // changed its name)
         FS.hashAddNode(old_node);
       }
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['onMovePath']) FS.trackingDelegate['onMovePath'](old_path, new_path);
       } catch(e) {
-        err("FS.trackingDelegate['onMovePath']('"+old_path+"', '"+new_path+"') threw an exception: " + e.message);
+        err("FS.trackingDelegate['onMovePath']('" + old_path + "', '" + new_path + "') threw an exception: " + e.message);
       }
-      #endif
+#endif
     },
     rmdir: function(path) {
       var lookup = FS.lookupPath(path, { parent: true });
@@ -839,24 +839,24 @@ FS.staticInit();` +
       if (FS.isMountpoint(node)) {
         throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
       }
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['willDeletePath']) {
           FS.trackingDelegate['willDeletePath'](path);
         }
       } catch(e) {
-        err("FS.trackingDelegate['willDeletePath']('"+path+"') threw an exception: " + e.message);
+        err("FS.trackingDelegate['willDeletePath']('" + path + "') threw an exception: " + e.message);
       }
-      #endif
+#endif
       parent.node_ops.rmdir(parent, name);
       FS.destroyNode(node);
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['onDeletePath']) FS.trackingDelegate['onDeletePath'](path);
       } catch(e) {
-        err("FS.trackingDelegate['onDeletePath']('"+path+"') threw an exception: " + e.message);
+        err("FS.trackingDelegate['onDeletePath']('" + path + "') threw an exception: " + e.message);
       }
-      #endif
+#endif
     },
     readdir: function(path) {
       var lookup = FS.lookupPath(path, { follow: true });
@@ -884,24 +884,24 @@ FS.staticInit();` +
       if (FS.isMountpoint(node)) {
         throw new FS.ErrnoError({{{ cDefine('EBUSY') }}});
       }
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['willDeletePath']) {
           FS.trackingDelegate['willDeletePath'](path);
         }
       } catch(e) {
-        err("FS.trackingDelegate['willDeletePath']('"+path+"') threw an exception: " + e.message);
+        err("FS.trackingDelegate['willDeletePath']('" + path + "') threw an exception: " + e.message);
       }
-      #endif
+#endif
       parent.node_ops.unlink(parent, name);
       FS.destroyNode(node);
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['onDeletePath']) FS.trackingDelegate['onDeletePath'](path);
       } catch(e) {
-        err("FS.trackingDelegate['onDeletePath']('"+path+"') threw an exception: " + e.message);
+        err("FS.trackingDelegate['onDeletePath']('" + path + "') threw an exception: " + e.message);
       }
-      #endif
+#endif
     },
     readlink: function(path) {
       var lookup = FS.lookupPath(path);
@@ -1089,9 +1089,9 @@ FS.staticInit();` +
       if ((flags & {{{ cDefine('O_TRUNC')}}})) {
         FS.truncate(node, 0);
       }
-      #if FS_DEBUG
+#if FS_DEBUG
       var trackingFlags = flags
-      #endif
+#endif
       // we've already handled these, don't pass down to the underlying vfs
       flags &= ~({{{ cDefine('O_EXCL') }}} | {{{ cDefine('O_TRUNC') }}} | {{{ cDefine('O_NOFOLLOW') }}});
 
@@ -1115,20 +1115,20 @@ FS.staticInit();` +
         if (!FS.readFiles) FS.readFiles = {};
         if (!(path in FS.readFiles)) {
           FS.readFiles[path] = 1;
-          #if FS_DEBUG
+#if FS_DEBUG
           err("FS.trackingDelegate error on read file: " + path);
-          #endif
+#endif
         }
       }
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (FS.trackingDelegate['onOpenFile']) {
           FS.trackingDelegate['onOpenFile'](path, trackingFlags);
         }
       } catch(e) {
-        err("FS.trackingDelegate['onOpenFile']('"+path+"', " + trackingFlags + ") threw an exception: " + e.message);
+        err("FS.trackingDelegate['onOpenFile']('" + path + "', " + trackingFlags + ") threw an exception: " + e.message);
       }
-      #endif
+#endif
       return stream;
     },
     close: function(stream) {
@@ -1146,15 +1146,15 @@ FS.staticInit();` +
         FS.closeStream(stream.fd);
       }
       stream.fd = null;
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (stream.path && FS.trackingDelegate['onCloseFile']) {
           FS.trackingDelegate['onCloseFile'](stream.path);
         }
       } catch(e) {
-        err("FS.trackingDelegate['onCloseFile']('"+stream.path+"') threw an exception: " + e.message);
+        err("FS.trackingDelegate['onCloseFile']('" + stream.path + "') threw an exception: " + e.message);
       }
-      #endif
+#endif
     },
     isClosed: function(stream) {
       return stream.fd === null;
@@ -1171,15 +1171,15 @@ FS.staticInit();` +
       }
       stream.position = stream.stream_ops.llseek(stream, offset, whence);
       stream.ungotten = [];
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (stream.path && FS.trackingDelegate['onSeekFile']) {
           FS.trackingDelegate['onSeekFile'](stream.path, stream.position, whence);
         }
       } catch(e) {
-        err("FS.trackingDelegate['onSeekFile']('"+stream.path+"', " + stream.position + ", " + whence + ") threw an exception: " + e.message);
+        err("FS.trackingDelegate['onSeekFile']('" + stream.path + "', " + stream.position + ", " + whence + ") threw an exception: " + e.message);
       }
-      #endif
+#endif
       return stream.position;
     },
     read: function(stream, buffer, offset, length, position) {
@@ -1209,15 +1209,15 @@ FS.staticInit();` +
       }
       var bytesRead = stream.stream_ops.read(stream, buffer, offset, length, position);
       if (!seeking) stream.position += bytesRead;
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (stream.path && FS.trackingDelegate['onReadFile']) {
           FS.trackingDelegate['onReadFile'](stream.path, bytesRead);
         }
       } catch(e) {
-        err("FS.trackingDelegate['onReadFile']('"+stream.path+"', " + bytesRead + ") threw an exception: " + e.message);
+        err("FS.trackingDelegate['onReadFile']('" + stream.path + "', " + bytesRead + ") threw an exception: " + e.message);
       }
-      #endif
+#endif
       return bytesRead;
     },
     write: function(stream, buffer, offset, length, position, canOwn) {
@@ -1251,16 +1251,16 @@ FS.staticInit();` +
       }
       var bytesWritten = stream.stream_ops.write(stream, buffer, offset, length, position, canOwn);
       if (!seeking) stream.position += bytesWritten;
-      #if FS_DEBUG
+#if FS_DEBUG
       try {
         if (stream.path && FS.trackingDelegate['onWriteToFile']) {
           FS.trackingDelegate['onWriteToFile'](stream.path, bytesWritten);
 
         }
       } catch(e) {
-        err("FS.trackingDelegate['onWriteToFile']('"+stream.path+"', " + bytesWritten + ") threw an exception: " + e.message);
+        err("FS.trackingDelegate['onWriteToFile']('" + stream.path + "', " + bytesWritten + ") threw an exception: " + e.message);
       }
-      #endif
+#endif
       return bytesWritten;
     },
     allocate: function(stream, offset, length) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -193,7 +193,7 @@ var MAXIMUM_MEMORY = 2147483648;
 
 // If false, we abort with an error if we try to allocate more memory than
 // we can (INITIAL_MEMORY). If true, we will grow the memory arrays at
-// runtime, seamlessly and dynamically. 
+// runtime, seamlessly and dynamically.
 // See https://code.google.com/p/v8/issues/detail?id=3907 regarding
 // memory growth performance in chrome.
 // Note that growing memory means we replace the JS typed array views, as
@@ -353,6 +353,10 @@ var SOCKET_DEBUG = 0;
 // Log dynamic linker information
 // [link]
 var DYLINK_DEBUG = 0;
+
+// Register file system callbacks using trackingDelegate in library_fs.js
+// [link]
+var FS_DEBUG = 0;
 
 // Select socket backend, either webrtc or websockets. XXX webrtc is not
 // currently tested, may be broken

--- a/tests/fs/test_trackingdelegate.c
+++ b/tests/fs/test_trackingdelegate.c
@@ -70,7 +70,7 @@ int main() {
       for (var i = 0; i < trackingFlags.length; i++) {
         output += trackingFlags[i] + ' ';
       }
-      output += 'and ' + fileSize;
+      output += 'and file size ' + fileSize;
       out(output)
     };
     FS.trackingDelegate['onReadFile'] = function(path, bytesRead) {

--- a/tests/fs/test_trackingdelegate.c
+++ b/tests/fs/test_trackingdelegate.c
@@ -24,17 +24,29 @@ int main() {
     FS.trackingDelegate['onDeletePath'] = function(path) {
       out('Deleted "' + path + '"');
     };
-    FS.trackingDelegate['onOpenFile'] = function(path, flags) { 
-      out('Opened "' + path + '" with flags ' + flags);
+    FS.trackingDelegate['onOpenFile'] = function(path, flags, fileSize) {
+      out('Opened "' + path + '" with flags ' + flags + ' and size ' + fileSize);
     };
-    FS.trackingDelegate['onWriteToFile'] = function(path) {
-      out('Wrote to file "' + path + '"');
+    FS.trackingDelegate['onReadFile'] = function(path, bytesRead) {
+      out('Read ' + bytesRead + ' bytes from "' + path + '"');
+    };
+    FS.trackingDelegate['onWriteToFile'] = function(path, bytesWritten) {
+      out('Wrote to file "' + path + '" with ' + bytesWritten + ' bytes written');
+    };
+    FS.trackingDelegate['onSeekFile'] = function(path, position) {
+      out('Seek on "' + path + '" with position ' + position);
     };
   );
 
   FILE *file;
-  file = fopen("/file.txt", "w");
-  fputs("hello!", file);
+  char buffer[100];
+
+  file = fopen("/file.txt", "w+");
+  fputs("hello", file);
+  fwrite(" world", 7, 1, file);
+  fseek(file, 0, SEEK_SET);
+  fread(buffer, 13, 1, file);
+  printf("%s\n", buffer);
   fclose(file);
   rename("/file.txt", "/renamed.txt");
   file = fopen("/renamed.txt", "r");

--- a/tests/fs/test_trackingdelegate.c
+++ b/tests/fs/test_trackingdelegate.c
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <emscripten.h>
+#include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
 
@@ -67,6 +68,12 @@ int main() {
     FS.trackingDelegate['onCloseFile'] = function(path) {
       out('Closed ' + path);
     };
+    FS.trackingDelegate['onMakeDirectory'] = function(path, mode) {
+      out('Created directory ' + path + ' with mode ' + mode);
+    };
+    FS.trackingDelegate['onMakeSymlink'] = function(oldpath, newpath) {
+      out('Created symlink from ' + oldpath + ' to ' + newpath);
+    };
   );
 
   FILE *file;
@@ -108,4 +115,6 @@ int main() {
   fd = open("/renamed.txt", O_APPEND);
   close(fd);
   remove("/renamed.txt");
+  mkdir("/home/test", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
+  symlink("/renamed.txt", "/file.txt");
 }

--- a/tests/fs/test_trackingdelegate.out
+++ b/tests/fs/test_trackingdelegate.out
@@ -1,4 +1,4 @@
-Opened "/file.txt" with flags 64 and file size 0
+Opened "/file.txt" with flags O_CREAT O_TRUNC O_RDWR and 0
 Wrote to file "/file.txt" with 12 bytes written
 Wrote to file "/file.txt" with 0 bytes written
 Seek on "/file.txt" with position 0 and whence 0
@@ -12,7 +12,7 @@ Wrote to file "/dev/tty" with 1 bytes written
 Closed /file.txt
 About to move "/file.txt" to "/renamed.txt"
 Moved "/file.txt" to "/renamed.txt"
-Opened "/renamed.txt" with flags 0 and file size 12
+Opened "/renamed.txt" with flags O_RDONLY and 12
 Read 0 bytes from "/renamed.txt"
 Read 12 bytes from "/renamed.txt"
 Read 0 bytes from "/renamed.txt"
@@ -21,11 +21,11 @@ Wrote to file "/dev/tty" with 31 bytes written
 File read returned 'hello world'
 Wrote to file "/dev/tty" with 2 bytes written
 Closed /renamed.txt
-Opened "/renamed.txt" with flags 0 and file size 12
+Opened "/renamed.txt" with flags O_RDONLY and 12
 Closed /renamed.txt
-Opened "/renamed.txt" with flags 1 and file size 12
+Opened "/renamed.txt" with flags O_WRONLY and 12
 Closed /renamed.txt
-Opened "/renamed.txt" with flags 2 and file size 12
+Opened "/renamed.txt" with flags O_RDWR and 12
 Wrote to file "/renamed.txt" with 10 bytes written
 Seek on "/renamed.txt" with position 0 and whence 0
 Read 12 bytes from "/renamed.txt"
@@ -33,15 +33,19 @@ Wrote to file "/dev/tty" with 18 bytes written
 read returned test
 Wrote to file "/dev/tty" with 1 bytes written
 Closed /renamed.txt
-Opened "/renamed.txt" with flags 64 and file size 12
+Opened "/renamed.txt" with flags O_CREAT O_RDONLY and 12
 Closed /renamed.txt
-Opened "/renamed.txt" with flags 128 and file size 12
+Opened "/renamed.txt" with flags O_EXCL O_WRONLY and 12
 Closed /renamed.txt
-Opened "/renamed.txt" with flags 512 and file size 0
+Opened "/renamed.txt" with flags O_TRUNC O_RDONLY and 0
 Closed /renamed.txt
-Opened "/renamed.txt" with flags 1024 and file size 0
+Opened "/renamed.txt" with flags O_TRUNC O_WRONLY and 0
+Closed /renamed.txt
+Opened "/renamed.txt" with flags O_TRUNC O_RDWR and 0
+Closed /renamed.txt
+Opened "/renamed.txt" with flags O_APPEND O_RDONLY and 0
 Closed /renamed.txt
 About to delete "/renamed.txt"
 Deleted "/renamed.txt"
-Created directory /home/test with mode 16893
-Created symlink from /renamed.txt to /file.txt
+Created directory "/home/test" with mode 16893
+Created symlink from "/renamed.txt" to "/file.txt"

--- a/tests/fs/test_trackingdelegate.out
+++ b/tests/fs/test_trackingdelegate.out
@@ -1,7 +1,7 @@
-Opened "/file.txt" with flags 3 and size 0
+Opened "/file.txt" with flags 64 and file size 0
 Wrote to file "/file.txt" with 12 bytes written
 Wrote to file "/file.txt" with 0 bytes written
-Seek on "/file.txt" with position 0
+Seek on "/file.txt" with position 0 and whence 0
 Read 12 bytes from "/file.txt"
 Read 0 bytes from "/file.txt"
 Read 0 bytes from "/file.txt"
@@ -9,9 +9,10 @@ Read 0 bytes from "/file.txt"
 Wrote to file "/dev/tty" with 11 bytes written
 hello world
 Wrote to file "/dev/tty" with 1 bytes written
+Closed /file.txt
 About to move "/file.txt" to "/renamed.txt"
 Moved "/file.txt" to "/renamed.txt"
-Opened "/renamed.txt" with flags 1 and size 12
+Opened "/renamed.txt" with flags 0 and file size 12
 Read 0 bytes from "/renamed.txt"
 Read 12 bytes from "/renamed.txt"
 Read 0 bytes from "/renamed.txt"
@@ -19,5 +20,26 @@ Read 0 bytes from "/renamed.txt"
 Wrote to file "/dev/tty" with 31 bytes written
 File read returned 'hello world'
 Wrote to file "/dev/tty" with 2 bytes written
+Closed /renamed.txt
+Opened "/renamed.txt" with flags 0 and file size 12
+Closed /renamed.txt
+Opened "/renamed.txt" with flags 1 and file size 12
+Closed /renamed.txt
+Opened "/renamed.txt" with flags 2 and file size 12
+Wrote to file "/renamed.txt" with 10 bytes written
+Seek on "/renamed.txt" with position 0 and whence 0
+Read 12 bytes from "/renamed.txt"
+Wrote to file "/dev/tty" with 18 bytes written
+read returned test
+Wrote to file "/dev/tty" with 1 bytes written
+Closed /renamed.txt
+Opened "/renamed.txt" with flags 64 and file size 12
+Closed /renamed.txt
+Opened "/renamed.txt" with flags 128 and file size 12
+Closed /renamed.txt
+Opened "/renamed.txt" with flags 512 and file size 0
+Closed /renamed.txt
+Opened "/renamed.txt" with flags 1024 and file size 0
+Closed /renamed.txt
 About to delete "/renamed.txt"
 Deleted "/renamed.txt"

--- a/tests/fs/test_trackingdelegate.out
+++ b/tests/fs/test_trackingdelegate.out
@@ -1,4 +1,4 @@
-Opened "/file.txt" with flags O_CREAT O_TRUNC O_RDWR and 0
+Opened "/file.txt" with flags O_CREAT O_TRUNC O_RDWR and file size 0
 Wrote to file "/file.txt" with 12 bytes written
 Wrote to file "/file.txt" with 0 bytes written
 Seek on "/file.txt" with position 0 and whence 0
@@ -12,7 +12,7 @@ Wrote to file "/dev/tty" with 1 bytes written
 Closed /file.txt
 About to move "/file.txt" to "/renamed.txt"
 Moved "/file.txt" to "/renamed.txt"
-Opened "/renamed.txt" with flags O_RDONLY and 12
+Opened "/renamed.txt" with flags O_RDONLY and file size 12
 Read 0 bytes from "/renamed.txt"
 Read 12 bytes from "/renamed.txt"
 Read 0 bytes from "/renamed.txt"
@@ -21,11 +21,11 @@ Wrote to file "/dev/tty" with 31 bytes written
 File read returned 'hello world'
 Wrote to file "/dev/tty" with 2 bytes written
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_RDONLY and 12
+Opened "/renamed.txt" with flags O_RDONLY and file size 12
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_WRONLY and 12
+Opened "/renamed.txt" with flags O_WRONLY and file size 12
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_RDWR and 12
+Opened "/renamed.txt" with flags O_RDWR and file size 12
 Wrote to file "/renamed.txt" with 10 bytes written
 Seek on "/renamed.txt" with position 0 and whence 0
 Read 12 bytes from "/renamed.txt"
@@ -33,17 +33,17 @@ Wrote to file "/dev/tty" with 18 bytes written
 read returned test
 Wrote to file "/dev/tty" with 1 bytes written
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_CREAT O_RDONLY and 12
+Opened "/renamed.txt" with flags O_CREAT O_RDONLY and file size 12
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_EXCL O_WRONLY and 12
+Opened "/renamed.txt" with flags O_EXCL O_WRONLY and file size 12
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_TRUNC O_RDONLY and 0
+Opened "/renamed.txt" with flags O_TRUNC O_RDONLY and file size 0
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_TRUNC O_WRONLY and 0
+Opened "/renamed.txt" with flags O_TRUNC O_WRONLY and file size 0
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_TRUNC O_RDWR and 0
+Opened "/renamed.txt" with flags O_TRUNC O_RDWR and file size 0
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_APPEND O_RDONLY and 0
+Opened "/renamed.txt" with flags O_APPEND O_RDONLY and file size 0
 Closed /renamed.txt
 About to delete "/renamed.txt"
 Deleted "/renamed.txt"

--- a/tests/fs/test_trackingdelegate.out
+++ b/tests/fs/test_trackingdelegate.out
@@ -1,11 +1,23 @@
-Opened "/file.txt" with flags 2
-Wrote to file "/file.txt"
-Wrote to file "/file.txt"
+Opened "/file.txt" with flags 3 and size 0
+Wrote to file "/file.txt" with 12 bytes written
+Wrote to file "/file.txt" with 0 bytes written
+Seek on "/file.txt" with position 0
+Read 12 bytes from "/file.txt"
+Read 0 bytes from "/file.txt"
+Read 0 bytes from "/file.txt"
+Read 0 bytes from "/file.txt"
+Wrote to file "/dev/tty" with 11 bytes written
+hello world
+Wrote to file "/dev/tty" with 1 bytes written
 About to move "/file.txt" to "/renamed.txt"
 Moved "/file.txt" to "/renamed.txt"
-Opened "/renamed.txt" with flags 1
-Wrote to file "/dev/tty"
-File read returned 'hello!'
-Wrote to file "/dev/tty"
+Opened "/renamed.txt" with flags 1 and size 12
+Read 0 bytes from "/renamed.txt"
+Read 12 bytes from "/renamed.txt"
+Read 0 bytes from "/renamed.txt"
+Read 0 bytes from "/renamed.txt"
+Wrote to file "/dev/tty" with 31 bytes written
+File read returned 'hello world'
+Wrote to file "/dev/tty" with 2 bytes written
 About to delete "/renamed.txt"
 Deleted "/renamed.txt"

--- a/tests/fs/test_trackingdelegate.out
+++ b/tests/fs/test_trackingdelegate.out
@@ -43,3 +43,5 @@ Opened "/renamed.txt" with flags 1024 and file size 0
 Closed /renamed.txt
 About to delete "/renamed.txt"
 Deleted "/renamed.txt"
+Created directory /home/test with mode 16893
+Created symlink from /renamed.txt to /file.txt

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5217,6 +5217,7 @@ main( int argv, char ** argc ) {
     self.do_runf(test_file('fs/test_nodefs_nofollow.c'), 'success', js_engines=[config.NODE_JS])
 
   def test_fs_trackingdelegate(self):
+    self.set_setting('FS_DEBUG')
     self.do_run_in_out_file_test('fs/test_trackingdelegate.c')
 
   @also_with_noderawfs


### PR DESCRIPTION
- Add file size to `onOpenFile`
- Add bytes written to `onWriteToFile` 
- Add `onReadFile`
- Add `onSeekFile`
- Add `onCloseFile`
- Add `onMakeDirectory`
- Add `onMakeSymlink`
- Add `FS_DEBUG` flag to allow users to selectively activate `trackingDelegate` functionality

Tests:
- Edited `tests/fs/test_trackingdelegate.c` to test `fread, fwrite, fseek` as well as outputting associated sizes of file operations.
- Updated tests to include `unistd.h` functions

Docs:
- Update docs to reflect changes