### PR TITLE
Add profile-memory as an internal symbol

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -58,7 +58,10 @@ var LibraryDylink = {
       '__cpp_exception',
       '__wasm_apply_data_relocs',
       '__dso_handle',
-      '__set_stack_limits'
+      '__set_stack_limits',
+#if SPLIT_MODULE
+      'profile-memory'
+#endif
     ].includes(symName)
 #if SPLIT_MODULE
         // Exports synthesized by wasm-split should be prefixed with '%'


### PR DESCRIPTION
`profile-memory` is the name of the newly exported memory added by wasm-split
instrumentation for modules that do not already export their memories since
https://github.com/WebAssembly/binaryen/pull/4121. Adding it as an internal
symbol prevents the dynamic linker from treating it as an undefined symbol and
will unblock the Binaryen roller.