### PR TITLE
Minor path handling cleanups. NFC.

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1048,8 +1048,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
       engines += self.wasm_engines
       if self.get_setting('WASM2C') and not EMTEST_LACKS_NATIVE_CLANG:
         # compile the c file to a native executable.
-        c = shared.unsuffixed(js_file) + '.wasm.c'
-        executable = shared.unsuffixed(js_file) + '.exe'
+        c = shared.replace_suffix(js_file, '.wasm.c')
+        executable = shared.replace_suffix(js_file, '.exe')
         cmd = [shared.CLANG_CC, c, '-o', executable] + clang_native.get_clang_native_args()
         self.run_process(cmd, env=clang_native.get_clang_native_env())
         # we can now run the executable directly, without an engine, which

--- a/tests/jsrun.py
+++ b/tests/jsrun.py
@@ -18,7 +18,7 @@ def make_command(filename, engine, args=[]):
   # if no engine is needed, indicated by None, then there is a native executable
   # provided which we can just run
   if engine[0] is None:
-    executable = shared.unsuffixed(os.path.abspath(filename)) + '.exe'
+    executable = shared.replace_suffix(os.path.abspath(filename), '.exe')
     return [executable] + args
   if type(engine) is not list:
     engine = [engine]
@@ -44,7 +44,7 @@ def make_command(filename, engine, args=[]):
     command_flags += ['run']
   if is_wasmer or is_wasmtime:
     # in a wasm runtime, run the wasm, not the js
-    filename = shared.unsuffixed(filename) + '.wasm'
+    filename = shared.replace_suffix(filename, '.wasm')
   # Separates engine flags from script flags
   flag_separator = ['--'] if is_d8 or is_jsc else []
   return engine + command_flags + [filename] + shell_option_flags + flag_separator + args

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1735,7 +1735,7 @@ int main() {
 
   def test_emscripten_get_compiler_setting(self):
     src = test_file('core/emscripten_get_compiler_setting.c')
-    output = shared.unsuffixed(src) + '.out'
+    output = shared.replace_suffix(src, '.out')
     # with assertions, a nice message is shown
     self.set_setting('ASSERTIONS')
     self.do_runf(src, 'You must build with -s RETAIN_COMPILER_SETTINGS=1', assert_returncode=NON_ZERO)
@@ -3532,7 +3532,7 @@ ok
     # Same as dylink_test but takes source code as filenames on disc.
     old_args = self.emcc_args.copy()
     if not expected:
-      outfile = shared.unsuffixed(main) + '.out'
+      outfile = shared.replace_suffix(main, '.out')
       expected = read_file(outfile)
     if not side:
       side, ext = os.path.splitext(main)

--- a/tools/building.py
+++ b/tools/building.py
@@ -530,7 +530,7 @@ def link_bitcode(args, target, force_archive_contents=False):
 def get_command_with_possible_response_file(cmd):
   # 8k is a bit of an arbitrary limit, but a reasonable one
   # for max command line size before we use a response file
-  if len(' '.join(cmd)) <= 8192:
+  if len(shared.shlex_join(cmd)) <= 8192:
     return cmd
 
   logger.debug('using response file for %s' % cmd[0])
@@ -813,7 +813,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   # Specify input file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
   args += ['--js', move_to_safe_7bit_ascii_filename(filename)]
   cmd = closure_cmd + args + user_args
-  logger.debug('closure compiler: ' + ' '.join(cmd))
+  logger.debug(f'closure compiler: {shared.shlex_join(cmd)}')
 
   # Closure compiler does not work if any of the input files contain characters outside the
   # 7-bit ASCII range. Therefore make sure the command line we pass does not contain any such
@@ -847,7 +847,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
     logger.error(proc.stderr) # print list of errors (possibly long wall of text if input was minified)
 
     # Exit and print final hint to get clearer output
-    msg = 'closure compiler failed (rc: %d): %s' % (proc.returncode, shared.shlex_join(cmd))
+    msg = f'closure compiler failed (rc: {proc.returncode}): {shared.shlex_join(cmd)}'
     if not pretty:
       msg += ' the error message may be clearer with -g1 and EMCC_DEBUG=2 set'
     exit_with_error(msg)


### PR DESCRIPTION
Use shared utilities where possible.  This makes this code more explicit
and also paves the way for more use of `pathlib` over raw strings in the
future.