### PR TITLE
Fix asan.test_fs_trackingdelegate test failure

### DIFF
--- a/tests/fs/test_trackingdelegate.c
+++ b/tests/fs/test_trackingdelegate.c
@@ -123,6 +123,9 @@ int main() {
   read(fd, output, 100);
   printf("read returned %s\n", output);
   close(fd);
+  fflush(stdout);
+  fd = open("/renamed.txt", O_CREAT, 0666);
+  close(fd);
   fd = open("/renamed.txt", O_EXCL | O_WRONLY);
   close(fd);
   fd = open("/renamed.txt", O_TRUNC);

--- a/tests/fs/test_trackingdelegate.c
+++ b/tests/fs/test_trackingdelegate.c
@@ -123,7 +123,6 @@ int main() {
   read(fd, output, 100);
   printf("read returned %s\n", output);
   close(fd);
-  fflush(stdout);
   fd = open("/renamed.txt", O_CREAT, 0666);
   close(fd);
   fd = open("/renamed.txt", O_EXCL | O_WRONLY);

--- a/tests/fs/test_trackingdelegate.c
+++ b/tests/fs/test_trackingdelegate.c
@@ -123,8 +123,6 @@ int main() {
   read(fd, output, 100);
   printf("read returned %s\n", output);
   close(fd);
-  fd = open("/renamed.txt", O_CREAT);
-  close(fd);
   fd = open("/renamed.txt", O_EXCL | O_WRONLY);
   close(fd);
   fd = open("/renamed.txt", O_TRUNC);

--- a/tests/fs/test_trackingdelegate.out
+++ b/tests/fs/test_trackingdelegate.out
@@ -33,8 +33,6 @@ Wrote to file "/dev/tty" with 18 bytes written
 read returned test
 Wrote to file "/dev/tty" with 1 bytes written
 Closed /renamed.txt
-Opened "/renamed.txt" with flags O_CREAT O_RDONLY and file size 12
-Closed /renamed.txt
 Opened "/renamed.txt" with flags O_EXCL O_WRONLY and file size 12
 Closed /renamed.txt
 Opened "/renamed.txt" with flags O_TRUNC O_RDONLY and file size 0

--- a/tests/fs/test_trackingdelegate.out
+++ b/tests/fs/test_trackingdelegate.out
@@ -33,6 +33,8 @@ Wrote to file "/dev/tty" with 18 bytes written
 read returned test
 Wrote to file "/dev/tty" with 1 bytes written
 Closed /renamed.txt
+Opened "/renamed.txt" with flags O_CREAT O_RDONLY and file size 12
+Closed /renamed.txt
 Opened "/renamed.txt" with flags O_EXCL O_WRONLY and file size 12
 Closed /renamed.txt
 Opened "/renamed.txt" with flags O_TRUNC O_RDONLY and file size 0


### PR DESCRIPTION
Edited `test_trackingdelegate.c` to fix this test failure: https://github.com/emscripten-core/emscripten/pull/15005#issuecomment-916998082

Link to test: https://logs.chromium.org/logs/emscripten-releases/buildbucket/cr-buildbucket/8836509797771608017/+/steps/Emscripten_testsuite__AddressSanitizer_/0/stdout

Tested locally using `tests/runner asan.test_fs_trackingdelegate`