### PR TITLE
Fix asan.test_fs_trackingdelegate by fixing open() call

### DIFF
--- a/tests/fs/test_trackingdelegate.c
+++ b/tests/fs/test_trackingdelegate.c
@@ -123,7 +123,7 @@ int main() {
   read(fd, output, 100);
   printf("read returned %s\n", output);
   close(fd);
-  fd = open("/renamed.txt", O_CREAT);
+  fd = open("/renamed.txt", O_CREAT, 0666);
   close(fd);
   fd = open("/renamed.txt", O_EXCL | O_WRONLY);
   close(fd);


### PR DESCRIPTION
It turns out that when `O_CREAT` is given to `open()`, one must
also provide the flags with which to create the file. Not providing
that varargs param is apparently undefined behavior, and the
musl `open()` method will end up reading a vararg that does not
exist, which leads to a null deref.