### PR TITLE
Avoid compile error on test_aligned_alloc

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -581,7 +581,8 @@ class TestCoreBase(RunnerCore):
 
   @no_asan('asan errors on corner cases we check')
   def test_aligned_alloc(self):
-    self.do_runf(test_file('test_aligned_alloc.c'), '')
+    self.do_runf(test_file('test_aligned_alloc.c'), '',
+                 emcc_args=['-Wno-non-power-of-two-alignment'])
 
   def test_unsigned(self):
     src = '''


### PR DESCRIPTION
A recent commit taught clang that the first parameter to aligned_alloc should be
a power of two alignment, and since then clang emits a warning (which we upgrade
to an error) when that argument is a constant that is not a power of two. Since
the test actually wants to test the function behavior in that case, ignore the
error.