### PR TITLE
Fix checks for nodejs and/or the require function

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -158,12 +158,12 @@ var nodeFS;
 var nodePath;
 
 if (ENVIRONMENT_IS_NODE) {
-#if ENVIRONMENT
-#if ASSERTIONS
-  if (!(typeof process === 'object' && typeof require === 'function')) throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-#endif
-#endif
   if (ENVIRONMENT_IS_WORKER) {
+#if ASSERTIONS
+    if ((!typeof process === 'object' && typeof require === 'function')) {
+      throw new Error("node's require function not found, but is needed in this configuration");
+    }
+#endif
     scriptDirectory = require('path').dirname(scriptDirectory) + '/';
   } else {
     scriptDirectory = __dirname + '/';
@@ -232,10 +232,14 @@ if (ENVIRONMENT_IS_NODE) {
 #if ENVIRONMENT_MAY_BE_SHELL || ASSERTIONS
 if (ENVIRONMENT_IS_SHELL) {
 
-#if ENVIRONMENT
-#if ASSERTIONS
-  if ((typeof process === 'object' && typeof require === 'function') || typeof window === 'object' || typeof importScripts === 'function') throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
-#endif
+#if ENVIRONMENT && ASSERTIONS
+  if ((typeof process === 'object'
+       && typeof process.versions === 'object'
+       && typeof process.versions.node === 'string') /* NODE */
+    || typeof window === 'object' /* WEB */
+    || typeof importScripts === 'function' /* WORKER */) {
+    throw new Error('not compiled for this environment (did you build to HTML and try to run it not on the web, or set ENVIRONMENT to something - like node - and run it someplace else - like on the web?)');
+  }
 #endif
 
   if (typeof read != 'undefined') {


### PR DESCRIPTION
The check for `require` was being applied even in the case that it
wasn't needed.

The check for node, when running under the shell environment was out of
date with the node check that we use to define ENVIRONMENT_IS_NODE and
should not have been checking for require (which is not always present
under node these days).

Fixes: #15022