### PR TITLE
Only install `unhandledRejection` handler if needed

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -195,7 +195,13 @@ if (ENVIRONMENT_IS_NODE) {
 #endif
 
 #if NODEJS_CATCH_REJECTION
-  process['on']('unhandledRejection', abort);
+  // The default behaviour for unhandled rejections changed from emitting
+  // a warning to thowing in node v15.  For older versions of node we
+  // don't want unhandled rejections to be ignored in this way.
+  // See https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
+  if (process['versions']['node'].split('.')[0] < 15) {
+    process['on']('unhandledRejection', abort);
+  }
 #endif
 
   quit_ = function(status, toThrow) {

--- a/tests/common.py
+++ b/tests/common.py
@@ -393,12 +393,17 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
 
   def setUp(self):
     super().setUp()
-    self.settings_mods = {}
-    self.emcc_args = ['-Werror']
+    # In the test environment to pass `--unhandled-rejections=throw` to
+    # get the node v15 behaviour.  This means can avoid setting
+    # `NODEJS_CATCH_REJECTION` which is enabled by default but can
+    # loose stack trace information because it catches and rethrows
+    # all uncaught promise rejections.
+    self.settings_mods = {'NODEJS_CATCH_REJECTION': 0}
+    self.emcc_args = ['-Werror', '-Wno-unused-command-line-argument']
     self.node_args = [
       # Increate stack trace limit to maximise usefulness of test failure reports
       '--stack-trace-limit=50',
-      # Opt in to node v15 default behaviour:
+      # Opt into node v15 default behaviour:
       # https://nodejs.org/api/cli.html#cli_unhandled_rejections_mode
       '--unhandled-rejections=throw',
       # Include backtrace for all uncuaght exceptions (not just Error).


### PR DESCRIPTION
We install this handler on node so that we can set the exit code
correctly.  However this is done by default on node 15 above and not
installing this handler makes reading error messages much clearer
because it preserves the stack traces.

Also add a test for the specific behaviour of this setting.