### PR TITLE
Remove JAVA config setting

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,8 +20,12 @@ See docs/process.md for more on how version tagging works.
 
 2.0.31
 ------
-2.0.30
+- The `JAVA` config settings has been removed.  Today, java is not be needed
+  except in the rare case of using closure-compiler on a plaform where not native
+  version of closure-compiler is available.  In this case, simply having `java`
+  available in the `PATH` should be sufficient.
 
+2.0.30
 ------
 - Bug fixes
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -25,7 +25,6 @@ LLVM_ROOT = None
 LLVM_ADD_VERSION = None
 CLANG_ADD_VERSION = None
 CLOSURE_COMPILER = None
-JAVA = None
 JS_ENGINE = None
 JS_ENGINES = None
 WASMER = None
@@ -56,7 +55,7 @@ def root_is_writable():
 
 
 def normalize_config_settings():
-  global CACHE, PORTS, JAVA, LLVM_ADD_VERSION, CLANG_ADD_VERSION, CLOSURE_COMPILER
+  global CACHE, PORTS, LLVM_ADD_VERSION, CLANG_ADD_VERSION, CLOSURE_COMPILER
   global NODE_JS, V8_ENGINE, JS_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
 
   # EM_CONFIG stuff
@@ -91,10 +90,6 @@ def normalize_config_settings():
   if not PORTS:
     PORTS = os.path.join(CACHE, 'ports')
 
-  if JAVA is None:
-    logger.debug('JAVA not defined in ' + EM_CONFIG + ', using "java"')
-    JAVA = 'java'
-
   # Tools/paths
   if LLVM_ADD_VERSION is None:
     LLVM_ADD_VERSION = os.getenv('LLVM_ADD_VERSION')
@@ -124,7 +119,6 @@ def parse_config_file():
     'LLVM_ADD_VERSION',
     'CLANG_ADD_VERSION',
     'CLOSURE_COMPILER',
-    'JAVA',
     'JS_ENGINE',
     'JS_ENGINES',
     'WASMER',

--- a/tools/settings_template.py
+++ b/tools/settings_template.py
@@ -23,8 +23,6 @@ BINARYEN_ROOT = '' # directory
 # This engine must exist, or nothing can be compiled.
 NODE_JS = '{{{ NODE }}}' # executable
 
-JAVA = 'java' # executable
-
 ################################################################################
 #
 # Test suite options:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -72,6 +72,7 @@ diagnostics.add_warning('export-main')
 diagnostics.add_warning('map-unrecognized-libraries')
 diagnostics.add_warning('unused-command-line-argument', shared=True)
 diagnostics.add_warning('pthreads-mem-growth')
+diagnostics.add_warning('closure-compiler')
 
 
 # TODO(sbc): Investigate switching to shlex.quote


### PR DESCRIPTION
A couple of reasons for this simplification.

1. We don't use java for anything anymore in the normal run of things.
   For closure-compiler we run the native version and only fall back
   to the Java version when there is no native version that the current
   architecture (i.e. on non-x86 platforms).
2. In the case we do want to run the java version it makes sense to
   simply expect it to be installed in the PATH.