### PR TITLE
Limit usage of JAVA config setting. NFC

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -710,17 +710,6 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   if extra_closure_args:
     user_args += extra_closure_args
 
-  # Closure compiler expects JAVA_HOME to be set *and* java.exe to be in the PATH in order
-  # to enable use the java backend.  Without this it will only try the native and JavaScript
-  # versions of the compiler.
-  java_bin = os.path.dirname(config.JAVA)
-  if java_bin:
-    def add_to_path(dirname):
-      env['PATH'] = env['PATH'] + os.pathsep + dirname
-    add_to_path(java_bin)
-    java_home = os.path.dirname(java_bin)
-    env.setdefault('JAVA_HOME', java_home)
-
   closure_cmd = get_closure_compiler()
 
   native_closure_compiler_works = check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=True)
@@ -728,6 +717,18 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
     # Run with Java Closure compiler as a fallback if the native version does not work
     user_args.append('--platform=java')
     check_closure_compiler(closure_cmd, user_args, env, allowed_to_fail=False)
+
+  if config.JAVA and '--platform=java' in user_args:
+    # Closure compiler expects JAVA_HOME to be set *and* java.exe to be in the PATH in order
+    # to enable use the java backend.  Without this it will only try the native and JavaScript
+    # versions of the compiler.
+    java_bin = os.path.dirname(config.JAVA)
+    if java_bin:
+      def add_to_path(dirname):
+        env['PATH'] = env['PATH'] + os.pathsep + dirname
+      add_to_path(java_bin)
+      java_home = os.path.dirname(java_bin)
+      env.setdefault('JAVA_HOME', java_home)
 
   # Closure externs file contains known symbols to be extern to the minification, Closure
   # should not minify these symbol names.

--- a/tools/config.py
+++ b/tools/config.py
@@ -56,7 +56,7 @@ def root_is_writable():
 
 
 def normalize_config_settings():
-  global CACHE, PORTS, JAVA, LLVM_ADD_VERSION, CLANG_ADD_VERSION, CLOSURE_COMPILER
+  global CACHE, PORTS, LLVM_ADD_VERSION, CLANG_ADD_VERSION, CLOSURE_COMPILER
   global NODE_JS, V8_ENGINE, JS_ENGINE, JS_ENGINES, SPIDERMONKEY_ENGINE, WASM_ENGINES
 
   # EM_CONFIG stuff
@@ -90,10 +90,6 @@ def normalize_config_settings():
       CACHE = os.path.expanduser(os.path.join('~', '.emscripten_cache'))
   if not PORTS:
     PORTS = os.path.join(CACHE, 'ports')
-
-  if JAVA is None:
-    logger.debug('JAVA not defined in ' + EM_CONFIG + ', using "java"')
-    JAVA = 'java'
 
   # Tools/paths
   if LLVM_ADD_VERSION is None:


### PR DESCRIPTION
This config setting is only needed/used under very specific circumstance
(i.e. when the native version is not supported).