### PR TITLE
WIP: Add dynamic tracing system to JS library code

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2314,6 +2314,20 @@ def phase_linker_setup(options, state, newargs, settings_map):
   settings.PROFILING_FUNCS = options.profiling_funcs
   settings.SOURCE_MAP_BASE = options.source_map_base or ''
 
+  if (settings.EXCEPTION_DEBUG or
+      settings.LIBRARY_DEBUG or
+      settings.SYSCALL_DEBUG or
+      settings.SOCKET_DEBUG or
+      settings.DYLINK_DEBUG or
+      settings.FS_DEBUG or
+      settings.OPENAL_DEBUG or
+      settings.WEBSOCKET_DEBUG or
+      settings.GL_DEBUG or
+      settings.ASYNCIFY_DEBUG or
+      settings.PTHREADS_DEBUG or
+      settings.FETCH_DEBUG): # noqa
+    default_setting('TRACING', 1)
+
   return target, wasm_target
 
 

--- a/src/compiler.js
+++ b/src/compiler.js
@@ -70,8 +70,6 @@ WASM_EXPORTS = set(WASM_EXPORTS);
 SIDE_MODULE_EXPORTS = set(SIDE_MODULE_EXPORTS);
 INCOMING_MODULE_JS_API = set(INCOMING_MODULE_JS_API);
 
-RUNTIME_DEBUG = LIBRARY_DEBUG || GL_DEBUG;
-
 // Side modules are pure wasm and have no JS
 assert(!SIDE_MODULE, "JS compiler should not run on side modules");
 

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -104,10 +104,11 @@ function JSify(functionsOnly) {
       snippet = modifyFunction(snippet, (name, args, body) => {
         return `\
 function ${name}(${args}) {
-  var ret = (function() { if (runtimeDebug) err("[library call:${finalName}: " + Array.prototype.slice.call(arguments).map(prettyPrint) + "]");
-  ${body}
+  var ret = (function() {
+    trace('LIBRARY', "[library call:${finalName}: " + Array.prototype.slice.call(arguments).map(prettyPrint) + "]");
+    ${body}
   }).apply(this, arguments);
-  if (runtimeDebug && typeof ret !== "undefined") err("  [     return:" + prettyPrint(ret));
+  if (ret !== "undefined") trace('LIBRARY', "  [     return:" + prettyPrint(ret));
   return ret;
 }`
       });

--- a/src/library.js
+++ b/src/library.js
@@ -3623,8 +3623,8 @@ LibraryManager.library = {
   $runtimeKeepalivePush__sig: 'v',
   $runtimeKeepalivePush: function() {
     runtimeKeepaliveCounter += 1;
-#if RUNTIME_DEBUG
-    err('runtimeKeepalivePush -> counter=' + runtimeKeepaliveCounter);
+#if TRACING
+    trace('RUNTIME', 'runtimeKeepalivePush -> counter=' + runtimeKeepaliveCounter);
 #endif
   },
 
@@ -3634,8 +3634,8 @@ LibraryManager.library = {
     assert(runtimeKeepaliveCounter > 0);
 #endif
     runtimeKeepaliveCounter -= 1;
-#if RUNTIME_DEBUG
-    err('runtimeKeepalivePop -> counter=' + runtimeKeepaliveCounter);
+#if TRACING
+    trace('RUNTIME', 'runtimeKeepalivePop -> counter=' + runtimeKeepaliveCounter);
 #endif
   },
 
@@ -3682,12 +3682,12 @@ LibraryManager.library = {
 #endif
   ],
   $maybeExit: function() {
-#if RUNTIME_DEBUG
-    err('maybeExit: user callback done: runtimeKeepaliveCounter=' + runtimeKeepaliveCounter);
+#if TRACING
+    trace('RUNTIME', 'maybeExit: user callback done: runtimeKeepaliveCounter=' + runtimeKeepaliveCounter);
 #endif
     if (!keepRuntimeAlive()) {
-#if RUNTIME_DEBUG
-      err('maybeExit: calling exit() implicitly after user callback completed: ' + EXITSTATUS);
+#if TRACING
+      trace('RUNTIME', 'maybeExit: calling exit() implicitly after user callback completed: ' + EXITSTATUS);
 #endif
       try {
 #if USE_PTHREADS

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -996,8 +996,8 @@ var LibraryBrowser = {
 #endif
     function checkIsRunning() {
       if (thisMainLoopId < Browser.mainLoop.currentlyRunningMainloop) {
-#if RUNTIME_DEBUG
-        err('main loop exiting..');
+#if TRACING
+        trace('RUNTIME', 'main loop exiting..');
 #endif
         {{{ runtimeKeepalivePop() }}}
 #if !MINIMAL_RUNTIME

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -161,20 +161,20 @@ var LibraryExceptions = {
   },
 
   $exception_addRef: function (info) {
-#if EXCEPTION_DEBUG
-    err('addref ' + info.excPtr);
+#if TRACING
+    trace('EXCEPTION', 'addref ' + info.excPtr);
 #endif
     info.add_ref();
   },
 
   $exception_decRef__deps: ['__cxa_free_exception'
-#if EXCEPTION_DEBUG
+#if ASSERTIONS
     , '$exceptionLast', '$exceptionCaught'
 #endif
   ],
   $exception_decRef: function(info) {
-#if EXCEPTION_DEBUG
-    err('decref ' + info.excPtr);
+#if TRACING
+    trace('EXCEPTION', 'decref ' + info.excPtr);
 #endif
     // A rethrown exception can reach refcount 0; it must not be discarded
     // Its next handler will clear the rethrown flag and addRef it, prior to
@@ -186,8 +186,8 @@ var LibraryExceptions = {
         {{{ makeDynCall('ii', 'destructor') }}}(info.excPtr);
       }
       ___cxa_free_exception(info.excPtr);
-#if EXCEPTION_DEBUG
-      err('decref freeing exception ' + [info.excPtr, exceptionLast, 'stack', exceptionCaught]);
+#if TRACING
+      trace('EXCEPTION', 'decref freeing exception ' + [info.excPtr, exceptionLast, 'stack', exceptionCaught]);
 #endif
     }
   },
@@ -232,8 +232,8 @@ var LibraryExceptions = {
   __cxa_throw__sig: 'viii',
   __cxa_throw__deps: ['$ExceptionInfo', '$exceptionLast', '$uncaughtExceptionCount'],
   __cxa_throw: function(ptr, type, destructor) {
-#if EXCEPTION_DEBUG
-    err('Compiled code throwing an exception, ' + [ptr,type,destructor]);
+#if TRACING
+    trace('EXCEPTION', 'Compiled code throwing an exception, ' + [ptr,type,destructor]);
 #endif
     var info = new ExceptionInfo(ptr);
     // Initialize ExceptionInfo content after it was allocated in __cxa_allocate_exception.
@@ -264,8 +264,8 @@ var LibraryExceptions = {
     } else {
       catchInfo.free();
     }
-#if EXCEPTION_DEBUG
-    err('Compiled code RE-throwing an exception, popped ' +
+#if TRACING
+    trace('EXCEPTION', 'Compiled code RE-throwing an exception, popped ' +
       [ptr, exceptionLast, 'stack', exceptionCaught]);
 #endif
     exceptionLast = ptr;
@@ -287,8 +287,8 @@ var LibraryExceptions = {
     }
     info.set_rethrown(false);
     exceptionCaught.push(catchInfo);
-#if EXCEPTION_DEBUG
-    err('cxa_begin_catch ' + [ptr, 'stack', exceptionCaught]);
+#if TRACING
+    trace('EXCEPTION', 'cxa_begin_catch ' + [ptr, 'stack', exceptionCaught]);
 #endif
     exception_addRef(info);
     return catchInfo.get_exception_ptr();
@@ -310,8 +310,8 @@ var LibraryExceptions = {
     // Call destructor if one is registered then clear it.
     var catchInfo = exceptionCaught.pop();
 
-#if EXCEPTION_DEBUG
-    err('cxa_end_catch popped ' + [catchInfo, exceptionLast, 'stack', exceptionCaught]);
+#if TRACING
+    trace('EXCEPTION', 'cxa_end_catch popped ' + [catchInfo, exceptionLast, 'stack', exceptionCaught]);
 #endif
     exception_decRef(catchInfo.get_exception_info());
     catchInfo.free();
@@ -320,8 +320,8 @@ var LibraryExceptions = {
 
   __cxa_get_exception_ptr__deps: ['$CatchInfo'],
   __cxa_get_exception_ptr: function(ptr) {
-#if EXCEPTION_DEBUG
-    err('cxa_get_exception_ptr ' + ptr);
+#if TRACING
+    trace('EXCEPTION', 'cxa_get_exception_ptr ' + ptr);
 #endif
     return new CatchInfo(ptr).get_exception_ptr();
   },
@@ -388,8 +388,8 @@ var LibraryExceptions = {
     var typeArray = Array.prototype.slice.call(arguments);
 
     // can_catch receives a **, add indirection
-#if EXCEPTION_DEBUG
-    out("can_catch on " + [thrown]);
+#if TRACING
+    trace('EXCEPTION', "can_catch on " + [thrown]);
 #endif
     // The different catch blocks are denoted by different types.
     // Due to inheritance, those types may not precisely match the
@@ -402,8 +402,8 @@ var LibraryExceptions = {
         break;
       }
       if ({{{ exportedAsmFunc('___cxa_can_catch') }}}(caughtType, thrownType, catchInfo.get_adjusted_ptr_addr())) {
-#if EXCEPTION_DEBUG
-        out("  can_catch found " + [catchInfo.get_adjusted_ptr(), caughtType]);
+#if TRACING
+        trace('EXCEPTION', '  can_catch found ' + [catchInfo.get_adjusted_ptr(), caughtType]);
 #endif
         {{{ makeStructuralReturn(['catchInfo.ptr', 'caughtType']) }}};
       }
@@ -415,8 +415,8 @@ var LibraryExceptions = {
   __resumeException: function(catchInfoPtr) {
     var catchInfo = new CatchInfo(catchInfoPtr);
     var ptr = catchInfo.get_base_ptr();
-#if EXCEPTION_DEBUG
-    out("Resuming exception " + [ptr, exceptionLast]);
+#if TRACING
+    trace('EXCEPTION', 'Resuming exception ' + [ptr, exceptionLast]);
 #endif
     if (!exceptionLast) { exceptionLast = ptr; }
     catchInfo.free();

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1089,8 +1089,8 @@ FS.staticInit();` +
         if (!FS.readFiles) FS.readFiles = {};
         if (!(path in FS.readFiles)) {
           FS.readFiles[path] = 1;
-#if FS_DEBUG
-          err("FS.trackingDelegate error on read file: " + path);
+#if TRACING
+          trace('FS', 'FS.trackingDelegate error on read file: ' + path);
 #endif
         }
       }

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -428,7 +428,7 @@ var LibraryGLEmulation = {
       // tandem with the rest of the program, by itself it cannot suffice.
       // Note that we need to remember shader types for this rewriting, saving sources makes it easier to debug.
       GL.shaderInfos = {};
-#if GL_DEBUG
+#if TRACING
       GL.shaderSources = {};
       GL.shaderOriginalSources = {};
 #endif
@@ -453,7 +453,7 @@ var LibraryGLEmulation = {
       var glShaderSource = _glShaderSource;
       _glShaderSource = _emscripten_glShaderSource = function _glShaderSource(shader, count, string, length) {
         var source = GL.getSource(shader, count, string, length);
-#if GL_DEBUG
+#if TRACING
         out("glShaderSource: Input: \n" + source);
         GL.shaderOriginalSources[shader] = source;
 #endif
@@ -556,7 +556,7 @@ var LibraryGLEmulation = {
           }
           source = ensurePrecision(source);
         }
-#if GL_DEBUG
+#if TRACING
         GL.shaderSources[shader] = source;
         out("glShaderSource: Output: \n" + source);
 #endif
@@ -567,12 +567,12 @@ var LibraryGLEmulation = {
       var glCompileShader = _glCompileShader;
       _glCompileShader = _emscripten_glCompileShader = function _glCompileShader(shader) {
         GLctx.compileShader(GL.shaders[shader]);
-#if GL_DEBUG
+#if TRACING
         if (!GLctx.getShaderParameter(GL.shaders[shader], GLctx.COMPILE_STATUS)) {
-          err('Failed to compile shader: ' + GLctx.getShaderInfoLog(GL.shaders[shader]));
-          err('Info: ' + JSON.stringify(GL.shaderInfos[shader]));
-          err('Original source: ' + GL.shaderOriginalSources[shader]);
-          err('Source: ' + GL.shaderSources[shader]);
+          trace('GL', 'Failed to compile shader: ' + GLctx.getShaderInfoLog(GL.shaders[shader]));
+          trace('GL', 'Info: ' + JSON.stringify(GL.shaderInfos[shader]));
+          trace('GL', 'Original source: ' + GL.shaderOriginalSources[shader]);
+          trace('GL', 'Source: ' + GL.shaderSources[shader]);
           throw 'Shader compilation halt';
         }
 #endif
@@ -603,13 +603,13 @@ var LibraryGLEmulation = {
 
       var glUseProgram = _glUseProgram;
       _glUseProgram = _emscripten_glUseProgram = function _glUseProgram(program) {
-#if GL_DEBUG
-        if (GL.debug) {
-          err('[using program with shaders]');
+#if TRACING
+        if (trace_channel_enabled('GL')) {
+          trace('GL', '[using program with shaders]');
           if (program) {
             GL.programShaders[program].forEach(function(shader) {
-              err('  shader ' + shader + ', original source: ' + GL.shaderOriginalSources[shader]);
-              err('         Source: ' + GL.shaderSources[shader]);
+              trace('GL', '  shader ' + shader + ', original source: ' + GL.shaderOriginalSources[shader]);
+              trace('GL', '         Source: ' + GL.shaderSources[shader]);
             });
           }
         }
@@ -2159,8 +2159,8 @@ var LibraryGLEmulation = {
       // If we don't already have it, create it.
       var renderer = keyView.get();
       if (!renderer) {
-#if GL_DEBUG
-        err('generating renderer for ' + JSON.stringify(attributes));
+#if TRACING
+        trace('GL', 'generating renderer for ' + JSON.stringify(attributes));
 #endif
         renderer = GLImmediate.createRenderer();
         GLImmediate.currentRenderer = renderer;
@@ -3667,8 +3667,8 @@ var LibraryGLEmulation = {
   },
 
   glLoadMatrixf: function(matrix) {
-#if GL_DEBUG
-    if (GL.debug) err('glLoadMatrixf receiving: ' + Array.prototype.slice.call(HEAPF32.subarray(matrix >> 2, (matrix >> 2) + 16)));
+#if TRACING
+    if (trace_channel_enabled('GL')) trace('GL', 'glLoadMatrixf receiving: ' + Array.prototype.slice.call(HEAPF32.subarray(matrix >> 2, (matrix >> 2) + 16)));
 #endif
     GLImmediate.matricesModified = true;
     GLImmediate.matrixVersion[GLImmediate.currentMatrix] = (GLImmediate.matrixVersion[GLImmediate.currentMatrix] + 1)|0;

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2430,16 +2430,16 @@ var LibraryJSEvents = {
         var prevViewport = canvas.GLctxObject.GLctx.getParameter(0xBA2 /* GL_VIEWPORT */);
         // TODO: Perhaps autoResizeViewport should only be true if FBO 0 is currently active?
         autoResizeViewport = (prevViewport[0] === 0 && prevViewport[1] === 0 && prevViewport[2] === canvas.width && prevViewport[3] === canvas.height);
-#if GL_DEBUG
-        err('Resizing canvas from ' + canvas.width + 'x' + canvas.height + ' to ' + width + 'x' + height + '. Previous GL viewport size was ' 
+#if TRACING
+        trace(GL, 'Resizing canvas from ' + canvas.width + 'x' + canvas.height + ' to ' + width + 'x' + height + '. Previous GL viewport size was ' 
           + prevViewport + ', so autoResizeViewport=' + autoResizeViewport);
 #endif
       }
       canvas.width = width;
       canvas.height = height;
       if (autoResizeViewport) {
-#if GL_DEBUG
-        err('Automatically resizing GL viewport to cover whole render target ' + width + 'x' + height);
+#if TRACING
+        trace(GL, 'Automatically resizing GL viewport to cover whole render target ' + width + 'x' + height);
 #endif
         // TODO: Add -s CANVAS_RESIZE_SETS_GL_VIEWPORT=0/1 option (default=1). This is commonly done and several graphics engines depend on this,
         // but this can be quite disruptive.
@@ -2450,8 +2450,8 @@ var LibraryJSEvents = {
       _emscripten_set_offscreencanvas_size_on_target_thread(targetThread, target, width, height);
       return {{{ cDefine('EMSCRIPTEN_RESULT_DEFERRED') }}}; // This will have to be done asynchronously
     } else {
-#if GL_DEBUG
-      err('canvas.controlTransferredOffscreen but we do not own the canvas, and do not know who has (no canvas.canvasSharedPtr present, an internal bug?)!\n');
+#if TRACING
+      trace(GL, 'canvas.controlTransferredOffscreen but we do not own the canvas, and do not know who has (no canvas.canvasSharedPtr present, an internal bug?)!\n');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
     }
@@ -2494,8 +2494,8 @@ var LibraryJSEvents = {
   emscripten_set_canvas_element_size__deps: ['$JSEvents', 'emscripten_set_canvas_element_size_calling_thread', 'emscripten_set_canvas_element_size_main_thread', '$findCanvasEventTarget'],
   emscripten_set_canvas_element_size__sig: 'iiii',
   emscripten_set_canvas_element_size: function(target, width, height) {
-#if GL_DEBUG
-    err('emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
+#if TRACING
+    trace(GL, 'emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
 #endif
     var canvas = findCanvasEventTarget(target);
     if (canvas) {
@@ -2508,8 +2508,8 @@ var LibraryJSEvents = {
   emscripten_set_canvas_element_size__deps: ['$JSEvents', '$findCanvasEventTarget'],
   emscripten_set_canvas_element_size__sig: 'iiii',
   emscripten_set_canvas_element_size: function(target, width, height) {
-#if GL_DEBUG
-    err('emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
+#if TRACING
+    trace(GL, 'emscripten_set_canvas_element_size(target='+target+',width='+width+',height='+height);
 #endif
     var canvas = findCanvasEventTarget(target);
     if (!canvas) return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
@@ -2524,8 +2524,8 @@ var LibraryJSEvents = {
 
   $setCanvasElementSize__deps: ['emscripten_set_canvas_element_size'],
   $setCanvasElementSize: function(target, width, height) {
-#if GL_DEBUG
-    err('setCanvasElementSize(target='+target+',width='+width+',height='+height);
+#if TRACING
+    trace(GL, 'setCanvasElementSize(target='+target+',width='+width+',height='+height);
 #endif
     if (!target.controlTransferredOffscreen) {
       target.width = width;
@@ -2562,8 +2562,8 @@ var LibraryJSEvents = {
       {{{ makeSetValue('width', 0, 'canvas.width', 'i32') }}};
       {{{ makeSetValue('height', 0, 'canvas.height', 'i32') }}};
     } else {
-#if GL_DEBUG
-      err('canvas.controlTransferredOffscreen but we do not own the canvas, and do not know who has (no canvas.canvasSharedPtr present, an internal bug?)!\n');
+#if TRACING
+      trace(GL, 'canvas.controlTransferredOffscreen but we do not own the canvas, and do not know who has (no canvas.canvasSharedPtr present, an internal bug?)!\n');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_UNKNOWN_TARGET') }}};
     }

--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -100,7 +100,7 @@ var LibraryHtml5WebGL = {
 
     var canvas = findCanvasEventTarget(target);
 
-#if GL_DEBUG
+#if TRACING
     var targetStr = UTF8ToString(target);
 #endif
 
@@ -112,10 +112,10 @@ var LibraryHtml5WebGL = {
         // When WebGL context is being proxied via the main thread, we must render using an offscreen FBO render target to avoid WebGL's
         // "implicit swap when callback exits" behavior. TODO: If OffscreenCanvas is supported, explicitSwapControl=true and still proxying,
         // then this can be avoided, since OffscreenCanvas enables explicit swap control.
-#if GL_DEBUG
-        if (contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS') }}}) err('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS enabled, proxying WebGL rendering from pthread to main thread.');
-        if (!canvas && contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK') }}}) err('Specified canvas target "' + targetStr + '" is not an OffscreenCanvas in the current pthread, but EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK is set. Proxying WebGL rendering from pthread to main thread.');
-        err('Performance warning: forcing renderViaOffscreenBackBuffer=true and preserveDrawingBuffer=true since proxying WebGL rendering.');
+#if TRACING
+        if (contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS') }}}) trace('GL', 'EMSCRIPTEN_WEBGL_CONTEXT_PROXY_ALWAYS enabled, proxying WebGL rendering from pthread to main thread.');
+        if (!canvas && contextAttributes.proxyContextToMainThread === {{{ cDefine('EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK') }}}) trace('GL', 'Specified canvas target "' + targetStr + '" is not an OffscreenCanvas in the current pthread, but EMSCRIPTEN_WEBGL_CONTEXT_PROXY_FALLBACK is set. Proxying WebGL rendering from pthread to main thread.');
+        trace('GL', 'Performance warning: forcing renderViaOffscreenBackBuffer=true and preserveDrawingBuffer=true since proxying WebGL rendering.');
 #endif
         // We will be proxying - if OffscreenCanvas is supported, we can proxy a bit more efficiently by avoiding having to create an Offscreen FBO.
         if (typeof OffscreenCanvas === 'undefined') {
@@ -128,8 +128,8 @@ var LibraryHtml5WebGL = {
 #endif
 
     if (!canvas) {
-#if GL_DEBUG
-      err('emscripten_webgl_create_context failed: Unknown canvas target "' + targetStr + '"!');
+#if TRACING
+      trace('GL', 'emscripten_webgl_create_context failed: Unknown canvas target "' + targetStr + '"!');
 #endif
       return 0;
     }
@@ -137,7 +137,7 @@ var LibraryHtml5WebGL = {
 #if OFFSCREENCANVAS_SUPPORT
     if (canvas.offscreenCanvas) canvas = canvas.offscreenCanvas;
 
-#if GL_DEBUG
+#if TRACING
     if (typeof OffscreenCanvas !== 'undefined' && canvas instanceof OffscreenCanvas) out('emscripten_webgl_create_context: Creating an OffscreenCanvas-based WebGL context on target "' + targetStr + '"');
     else if (typeof HTMLCanvasElement !== 'undefined' && canvas instanceof HTMLCanvasElement) out('emscripten_webgl_create_context: Creating an HTMLCanvasElement-based WebGL context on target "' + targetStr + '"');
 #endif
@@ -149,20 +149,20 @@ var LibraryHtml5WebGL = {
 #if OFFSCREEN_FRAMEBUFFER
         if (!contextAttributes.renderViaOffscreenBackBuffer) {
           contextAttributes.renderViaOffscreenBackBuffer = true;
-#if GL_DEBUG
-          err('emscripten_webgl_create_context: Performance warning, OffscreenCanvas is not supported but explicitSwapControl was requested, so force-enabling renderViaOffscreenBackBuffer=true to allow explicit swapping!');
+#if TRACING
+          trace('GL', 'emscripten_webgl_create_context: Performance warning, OffscreenCanvas is not supported but explicitSwapControl was requested, so force-enabling renderViaOffscreenBackBuffer=true to allow explicit swapping!');
 #endif
         }
 #else
-#if GL_DEBUG
-        err('emscripten_webgl_create_context failed: OffscreenCanvas is not supported but explicitSwapControl was requested!');
+#if TRACING
+        trace('GL', 'emscripten_webgl_create_context failed: OffscreenCanvas is not supported but explicitSwapControl was requested!');
 #endif
         return 0;
 #endif
       }
 
       if (canvas.transferControlToOffscreen) {
-#if GL_DEBUG
+#if TRACING
         out('explicitSwapControl requested: canvas.transferControlToOffscreen() on canvas "' + targetStr + '" to get .commit() function and not rely on implicit WebGL swap');
 #endif
         if (!canvas.controlTransferredOffscreen) {
@@ -173,8 +173,8 @@ var LibraryHtml5WebGL = {
           };
           canvas.controlTransferredOffscreen = true;
         } else if (!GL.offscreenCanvases[canvas.id]) {
-#if GL_DEBUG
-          err('OffscreenCanvas is supported, and canvas "' + canvas.id + '" has already before been transferred offscreen, but there is no known OffscreenCanvas with that name!');
+#if TRACING
+          trace('GL', 'OffscreenCanvas is supported, and canvas "' + canvas.id + '" has already before been transferred offscreen, but there is no known OffscreenCanvas with that name!');
 #endif
           return 0;
         }
@@ -185,14 +185,14 @@ var LibraryHtml5WebGL = {
 #if OFFSCREEN_FRAMEBUFFER
     if (contextAttributes.explicitSwapControl && !contextAttributes.renderViaOffscreenBackBuffer) {
       contextAttributes.renderViaOffscreenBackBuffer = true;
-#if GL_DEBUG
-      err('emscripten_webgl_create_context: Performance warning, not building with OffscreenCanvas support enabled but explicitSwapControl was requested, so force-enabling renderViaOffscreenBackBuffer=true to allow explicit swapping!');
+#if TRACING
+      trace('GL', 'emscripten_webgl_create_context: Performance warning, not building with OffscreenCanvas support enabled but explicitSwapControl was requested, so force-enabling renderViaOffscreenBackBuffer=true to allow explicit swapping!');
 #endif
     }
 #else
     if (contextAttributes.explicitSwapControl) {
-#if GL_DEBUG
-      err('emscripten_webgl_create_context failed: explicitSwapControl is not supported, please rebuild with -s OFFSCREENCANVAS_SUPPORT=1 to enable targeting the experimental OffscreenCanvas specification, or rebuild with -s OFFSCREEN_FRAMEBUFFER=1 to emulate explicitSwapControl in the absence of OffscreenCanvas support!');
+#if TRACING
+      trace('GL', 'emscripten_webgl_create_context failed: explicitSwapControl is not supported, please rebuild with -s OFFSCREENCANVAS_SUPPORT=1 to enable targeting the experimental OffscreenCanvas specification, or rebuild with -s OFFSCREEN_FRAMEBUFFER=1 to emulate explicitSwapControl in the absence of OffscreenCanvas support!');
 #endif
       return 0;
     }
@@ -250,8 +250,8 @@ var LibraryHtml5WebGL = {
     err('[Thread ' + threadId() + ', GL ctx: ' + GL.currentContext.handle + ']: emscripten_webgl_do_commit_frame()');
 #endif
     if (!GL.currentContext || !GL.currentContext.GLctx) {
-#if GL_DEBUG
-      err('emscripten_webgl_commit_frame() failed: no GL context set current via emscripten_webgl_make_context_current()!');
+#if TRACING
+      trace('GL', 'emscripten_webgl_commit_frame() failed: no GL context set current via emscripten_webgl_make_context_current()!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -259,15 +259,15 @@ var LibraryHtml5WebGL = {
 #if OFFSCREEN_FRAMEBUFFER
     if (GL.currentContext.defaultFbo) {
       GL.blitOffscreenFramebuffer(GL.currentContext);
-#if GL_DEBUG && OFFSCREENCANVAS_SUPPORT
-      if (GL.currentContext.GLctx.commit) err('emscripten_webgl_commit_frame(): Offscreen framebuffer should never have gotten created when canvas is in OffscreenCanvas mode, since it is redundant and not necessary');
+#if TRACING && OFFSCREENCANVAS_SUPPORT
+      if (GL.currentContext.GLctx.commit) trace('GL', 'emscripten_webgl_commit_frame(): Offscreen framebuffer should never have gotten created when canvas is in OffscreenCanvas mode, since it is redundant and not necessary');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_SUCCESS') }}};
     }
 #endif
     if (!GL.currentContext.attributes.explicitSwapControl) {
-#if GL_DEBUG
-      err('emscripten_webgl_commit_frame() cannot be called for canvases with implicit swap control mode!');
+#if TRACING
+      trace('GL', 'emscripten_webgl_commit_frame() cannot be called for canvases with implicit swap control mode!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }

--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -188,13 +188,13 @@ var LibraryOpenAL = {
           } else if (typeof(audioSrc.noteOn) !== 'undefined') {
             startTime = Math.max(startTime, src.context.audioCtx.currentTime);
             audioSrc.noteOn(startTime);
-#if OPENAL_DEBUG
+#if TRACING
             if (offset > 0.0) {
               warnOnce('The current browser does not support AudioBufferSourceNode.start(when, offset); method, so cannot play back audio with an offset '+startOffset+' secs! Audio glitches will occur!');
             }
 #endif
           }
-#if OPENAL_DEBUG
+#if TRACING
           else {
             warnOnce('Unable to start AudioBufferSourceNode playback! Not supported by the browser?');
           }
@@ -343,11 +343,11 @@ var LibraryOpenAL = {
         if (src.state === 0x1012 /* AL_PLAYING */ || src.state == 0x1014 /* AL_STOPPED */) {
           src.bufsProcessed = 0;
           src.bufOffset = 0.0;
-#if OPENAL_DEBUG
+#if TRACING
           out('setSourceState() resetting and playing source ' + src.id);
 #endif
         } else {
-#if OPENAL_DEBUG
+#if TRACING
           out('setSourceState() playing source ' + src.id + ' at ' + src.bufOffset);
 #endif
         }
@@ -364,7 +364,7 @@ var LibraryOpenAL = {
           AL.stopSourceAudio(src);
 
           src.state = 0x1013 /* AL_PAUSED */;
-#if OPENAL_DEBUG
+#if TRACING
           out('setSourceState() pausing source ' + src.id + ' at ' + src.bufOffset);
 #endif
         }
@@ -375,7 +375,7 @@ var LibraryOpenAL = {
           src.bufStartTime = Number.NEGATIVE_INFINITY;
           src.bufOffset = 0.0;
           AL.stopSourceAudio(src);
-#if OPENAL_DEBUG
+#if TRACING
           out('setSourceState() stopping source ' + src.id);
 #endif
         }
@@ -386,7 +386,7 @@ var LibraryOpenAL = {
           src.bufStartTime = Number.NEGATIVE_INFINITY;
           src.bufOffset = 0.0;
           AL.stopSourceAudio(src);
-#if OPENAL_DEBUG
+#if TRACING
           out('setSourceState() initializing source ' + src.id);
 #endif
         }
@@ -478,7 +478,7 @@ var LibraryOpenAL = {
         listener.positionY.value = ctx.listener.position[1];
         listener.positionZ.value = ctx.listener.position[2];
       } else {
-#if OPENAL_DEBUG
+#if TRACING
         warnOnce('Listener position attributes are not present, falling back to setPosition()');
 #endif
         listener.setPosition(ctx.listener.position[0], ctx.listener.position[1], ctx.listener.position[2]);
@@ -491,7 +491,7 @@ var LibraryOpenAL = {
         listener.upY.value = ctx.listener.up[1];
         listener.upZ.value = ctx.listener.up[2];
       } else {
-#if OPENAL_DEBUG
+#if TRACING
         warnOnce('Listener orientation attributes are not present, falling back to setOrientation()');
 #endif
         listener.setOrientation(
@@ -613,7 +613,7 @@ var LibraryOpenAL = {
         panner.positionY.value = posY;
         panner.positionZ.value = posZ;
       } else {
-#if OPENAL_DEBUG
+#if TRACING
         warnOnce('Panner position attributes are not present, falling back to setPosition()');
 #endif
         panner.setPosition(posX, posY, posZ);
@@ -623,7 +623,7 @@ var LibraryOpenAL = {
         panner.orientationY.value = dirY;
         panner.orientationZ.value = dirZ;
       } else {
-#if OPENAL_DEBUG
+#if TRACING
         warnOnce('Panner orientation attributes are not present, falling back to setOrientation()');
 #endif
         panner.setOrientation(dirX, dirY, dirZ);
@@ -740,8 +740,8 @@ var LibraryOpenAL = {
 
     getGlobalParam: function(funcname, param) {
       if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-        err(funcname + '() called without a valid context');
+#if TRACING
+        trace('OPENAL', funcname + '() called without a valid context');
 #endif
         return null;
       }
@@ -754,8 +754,8 @@ var LibraryOpenAL = {
       case 0xD000 /* AL_DISTANCE_MODEL */:
         return AL.currentCtx.distanceModel;
       default:
-#if OPENAL_DEBUG
-        err(funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
+#if TRACING
+        trace('OPENAL', funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return null;
@@ -764,8 +764,8 @@ var LibraryOpenAL = {
 
     setGlobalParam: function(funcname, param, value) {
       if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-        err(funcname + '() called without a valid context');
+#if TRACING
+        trace('OPENAL', funcname + '() called without a valid context');
 #endif
         return;
       }
@@ -773,8 +773,8 @@ var LibraryOpenAL = {
       switch (param) {
       case 0xC000 /* AL_DOPPLER_FACTOR */:
         if (!Number.isFinite(value) || value < 0.0) { // Strictly negative values are disallowed
-#if OPENAL_DEBUG
-          err(funcname + '() value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -785,8 +785,8 @@ var LibraryOpenAL = {
         break;
       case 0xC003 /* AL_SPEED_OF_SOUND */:
         if (!Number.isFinite(value) || value <= 0.0) { // Negative or zero values are disallowed
-#if OPENAL_DEBUG
-          err(funcname + '() value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -808,16 +808,16 @@ var LibraryOpenAL = {
           AL.updateContextGlobal(AL.currentCtx);
           break;
         default:
-#if OPENAL_DEBUG
-          err(funcname + '() value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
         }
         break;
       default:
-#if OPENAL_DEBUG
-        err(funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
+#if TRACING
+        trace('OPENAL', funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return;
@@ -826,8 +826,8 @@ var LibraryOpenAL = {
 
     getListenerParam: function(funcname, param) {
       if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-        err(funcname + '() called without a valid context');
+#if TRACING
+        trace('OPENAL', funcname + '() called without a valid context');
 #endif
         return null;
       }
@@ -842,8 +842,8 @@ var LibraryOpenAL = {
       case 0x100A /* AL_GAIN */:
         return AL.currentCtx.gain.gain.value;
       default:
-#if OPENAL_DEBUG
-        err(funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
+#if TRACING
+        trace('OPENAL', funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return null;
@@ -852,14 +852,14 @@ var LibraryOpenAL = {
 
     setListenerParam: function(funcname, param, value) {
       if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-        err(funcname + '() called without a valid context');
+#if TRACING
+        trace('OPENAL', funcname + '() called without a valid context');
 #endif
         return;
       }
       if (value === null) {
-#if OPENAL_DEBUG
-        err(funcname + '(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+        trace('OPENAL', funcname + '(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return;
@@ -869,8 +869,8 @@ var LibraryOpenAL = {
       switch (param) {
       case 0x1004 /* AL_POSITION */:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_POSITION value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_POSITION value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -883,8 +883,8 @@ var LibraryOpenAL = {
         break;
       case 0x1006 /* AL_VELOCITY */:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_VELOCITY value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_VELOCITY value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -897,8 +897,8 @@ var LibraryOpenAL = {
         break;
       case 0x100A /* AL_GAIN */:
         if (!Number.isFinite(value) || value < 0.0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_GAIN value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_GAIN value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -910,8 +910,8 @@ var LibraryOpenAL = {
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])
           || !Number.isFinite(value[3]) || !Number.isFinite(value[4]) || !Number.isFinite(value[5])
         ) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_ORIENTATION value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_ORIENTATION value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -926,8 +926,8 @@ var LibraryOpenAL = {
         AL.updateListenerSpace(AL.currentCtx);
         break;
       default:
-#if OPENAL_DEBUG
-        err(funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
+#if TRACING
+        trace('OPENAL', funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return;
@@ -936,15 +936,15 @@ var LibraryOpenAL = {
 
     getBufferParam: function(funcname, bufferId, param) {
       if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-        err(funcname + '() called without a valid context');
+#if TRACING
+        trace('OPENAL', funcname + '() called without a valid context');
 #endif
         return;
       }
       var buf = AL.buffers[bufferId];
       if (!buf || bufferId === 0) {
-#if OPENAL_DEBUG
-        err(funcname + '() called with an invalid buffer');
+#if TRACING
+        trace('OPENAL', funcname + '() called with an invalid buffer');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
@@ -969,8 +969,8 @@ var LibraryOpenAL = {
           ];
         }
       default:
-#if OPENAL_DEBUG
-        err(funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
+#if TRACING
+        trace('OPENAL', funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return null;
@@ -979,22 +979,22 @@ var LibraryOpenAL = {
 
     setBufferParam: function(funcname, bufferId, param, value) {
       if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-        err(funcname + '() called without a valid context');
+#if TRACING
+        trace('OPENAL', funcname + '() called without a valid context');
 #endif
         return;
       }
       var buf = AL.buffers[bufferId];
       if (!buf || bufferId === 0) {
-#if OPENAL_DEBUG
-        err(funcname + '() called with an invalid buffer');
+#if TRACING
+        trace('OPENAL', funcname + '() called with an invalid buffer');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
       }
       if (value === null) {
-#if OPENAL_DEBUG
-        err(funcname + '(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+        trace('OPENAL', funcname + '(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return;
@@ -1003,8 +1003,8 @@ var LibraryOpenAL = {
       switch (param) {
       case 0x2004 /* AL_SIZE */:
         if (value !== 0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_SIZE value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_SIZE value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1014,15 +1014,15 @@ var LibraryOpenAL = {
         break;
       case 0x2015 /* AL_LOOP_POINTS_SOFT */:
         if (value[0] < 0 || value[0] > buf.length || value[1] < 0 || value[1] > buf.Length || value[0] >= value[1]) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_LOOP_POINTS_SOFT value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_LOOP_POINTS_SOFT value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
         }
         if (buf.refCount > 0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_LOOP_POINTS_SOFT set on bound buffer');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_LOOP_POINTS_SOFT set on bound buffer');
 #endif
           AL.currentCtx.err = 0xA004 /* AL_INVALID_OPERATION */;
           return;
@@ -1034,8 +1034,8 @@ var LibraryOpenAL = {
         }
         break;
       default:
-#if OPENAL_DEBUG
-        err(funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
+#if TRACING
+        trace('OPENAL', funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return;
@@ -1044,15 +1044,15 @@ var LibraryOpenAL = {
 
     getSourceParam: function(funcname, sourceId, param) {
       if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-        err(funcname + '() called without a valid context');
+#if TRACING
+        trace('OPENAL', funcname + '() called without a valid context');
 #endif
         return null;
       }
       var src = AL.currentCtx.sources[sourceId];
       if (!src) {
-#if OPENAL_DEBUG
-        err(funcname + '() called with an invalid source');
+#if TRACING
+        trace('OPENAL', funcname + '() called with an invalid source');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return null;
@@ -1148,8 +1148,8 @@ var LibraryOpenAL = {
       case 0xD000 /* AL_DISTANCE_MODEL */:
         return src.distanceModel;
       default:
-#if OPENAL_DEBUG
-        err(funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
+#if TRACING
+        trace('OPENAL', funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return null;
@@ -1158,22 +1158,22 @@ var LibraryOpenAL = {
 
     setSourceParam: function(funcname, sourceId, param, value) {
       if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-        err(funcname + '() called without a valid context');
+#if TRACING
+        trace('OPENAL', funcname + '() called without a valid context');
 #endif
         return;
       }
       var src = AL.currentCtx.sources[sourceId];
       if (!src) {
-#if OPENAL_DEBUG
-        err('alSourcef() called with an invalid source');
+#if TRACING
+        trace('OPENAL', 'alSourcef() called with an invalid source');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
       }
       if (value === null) {
-#if OPENAL_DEBUG
-        err(funcname + '(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+        trace('OPENAL', funcname + '(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return;
@@ -1188,8 +1188,8 @@ var LibraryOpenAL = {
           src.relative = false;
           AL.updateSourceSpace(src);
         } else {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_SOURCE_RELATIVE value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_SOURCE_RELATIVE value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1197,8 +1197,8 @@ var LibraryOpenAL = {
         break;
       case 0x1001 /* AL_CONE_INNER_ANGLE */:
         if (!Number.isFinite(value)) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_CONE_INNER_ANGLE value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_CONE_INNER_ANGLE value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1211,8 +1211,8 @@ var LibraryOpenAL = {
         break;
       case 0x1002 /* AL_CONE_OUTER_ANGLE */:
         if (!Number.isFinite(value)) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_CONE_OUTER_ANGLE value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_CONE_OUTER_ANGLE value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1225,8 +1225,8 @@ var LibraryOpenAL = {
         break;
       case 0x1003 /* AL_PITCH */:
         if (!Number.isFinite(value) || value <= 0.0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_PITCH value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_PITCH value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1241,8 +1241,8 @@ var LibraryOpenAL = {
         break;
       case 0x1004 /* AL_POSITION */:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_POSITION value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_POSITION value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1255,8 +1255,8 @@ var LibraryOpenAL = {
         break;
       case 0x1005 /* AL_DIRECTION */:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_DIRECTION value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_DIRECTION value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1269,8 +1269,8 @@ var LibraryOpenAL = {
         break;
       case 0x1006 /* AL_VELOCITY */:
         if (!Number.isFinite(value[0]) || !Number.isFinite(value[1]) || !Number.isFinite(value[2])) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_VELOCITY value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_VELOCITY value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1300,8 +1300,8 @@ var LibraryOpenAL = {
             audioSrc._startTime = currentTime - src.bufOffset / src.playbackRate;
           }
         } else {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_LOOPING value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_LOOPING value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1309,8 +1309,8 @@ var LibraryOpenAL = {
         break;
       case 0x1009 /* AL_BUFFER */:
         if (src.state === 0x1012 /* AL_PLAYING */ || src.state === 0x1013 /* AL_PAUSED */) {
-#if OPENAL_DEBUG
-          err(funcname + '(AL_BUFFER) called while source is playing or paused');
+#if TRACING
+          trace('OPENAL', funcname + '(AL_BUFFER) called while source is playing or paused');
 #endif
           AL.currentCtx.err = 0xA004 /* AL_INVALID_OPERATION */;
           return;
@@ -1328,8 +1328,8 @@ var LibraryOpenAL = {
         } else {
           var buf = AL.buffers[value];
           if (!buf) {
-#if OPENAL_DEBUG
-            err('alSourcei(AL_BUFFER) called with an invalid buffer');
+#if TRACING
+            trace('OPENAL', 'alSourcei(AL_BUFFER) called with an invalid buffer');
 #endif
             AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
             return;
@@ -1351,8 +1351,8 @@ var LibraryOpenAL = {
         break;
       case 0x100A /* AL_GAIN */:
         if (!Number.isFinite(value) || value < 0.0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_GAIN value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_GAIN value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1361,34 +1361,34 @@ var LibraryOpenAL = {
         break;
       case 0x100D /* AL_MIN_GAIN */:
         if (!Number.isFinite(value) || value < 0.0 || value > Math.min(src.maxGain, 1.0)) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_MIN_GAIN value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_MIN_GAIN value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
         }
-#if OPENAL_DEBUG
+#if TRACING
         warnOnce('AL_MIN_GAIN is not currently supported');
 #endif
         src.minGain = value;
         break;
       case 0x100E /* AL_MAX_GAIN */:
         if (!Number.isFinite(value) || value < Math.max(0.0, src.minGain) || value > 1.0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_MAX_GAIN value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_MAX_GAIN value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
         }
-#if OPENAL_DEBUG
+#if TRACING
         warnOnce('AL_MAX_GAIN is not currently supported');
 #endif
         src.maxGain = value;
         break;
       case 0x1020 /* AL_REFERENCE_DISTANCE */:
         if (!Number.isFinite(value) || value < 0.0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_REFERENCE_DISTANCE value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_REFERENCE_DISTANCE value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1400,8 +1400,8 @@ var LibraryOpenAL = {
         break;
       case 0x1021 /* AL_ROLLOFF_FACTOR */:
         if (!Number.isFinite(value) || value < 0.0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_ROLLOFF_FACTOR value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_ROLLOFF_FACTOR value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1413,8 +1413,8 @@ var LibraryOpenAL = {
         break;
       case 0x1022 /* AL_CONE_OUTER_GAIN */:
         if (!Number.isFinite(value) || value < 0.0 || value > 1.0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_CORE_OUTER_GAIN value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_CORE_OUTER_GAIN value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1426,8 +1426,8 @@ var LibraryOpenAL = {
         break;
       case 0x1023 /* AL_MAX_DISTANCE */:
         if (!Number.isFinite(value) || value < 0.0) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_MAX_DISTANCE value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_MAX_DISTANCE value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1439,8 +1439,8 @@ var LibraryOpenAL = {
         break;
       case 0x1024 /* AL_SEC_OFFSET */:
         if (value < 0.0 || value > AL.sourceDuration(src)) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_SEC_OFFSET value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_SEC_OFFSET value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1461,8 +1461,8 @@ var LibraryOpenAL = {
           value /= frequency;
         }
         if (value < 0.0 || value > srcLen) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_SAMPLE_OFFSET value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_SAMPLE_OFFSET value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1484,8 +1484,8 @@ var LibraryOpenAL = {
           value /= bytesPerSec;
         }
         if (value < 0.0 || value > srcLen) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_BYTE_OFFSET value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_BYTE_OFFSET value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1495,8 +1495,8 @@ var LibraryOpenAL = {
         break;
       case 0x1214 /* AL_SOURCE_SPATIALIZE_SOFT */:
         if (value !== 0 /* AL_FALSE */ && value !== 1 /* AL_TRUE */ && value !== 2 /* AL_AUTO_SOFT */) {
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_SOURCE_SPATIALIZE_SOFT value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_SOURCE_SPATIALIZE_SOFT value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
@@ -1508,8 +1508,8 @@ var LibraryOpenAL = {
       case 0x2009 /* AL_BYTE_LENGTH_SOFT */: 
       case 0x200A /* AL_SAMPLE_LENGTH_SOFT */:
       case 0x200B /* AL_SEC_LENGTH_SOFT */:
-#if OPENAL_DEBUG
-        err(funcname + '() param AL_*_LENGTH_SOFT is read only');
+#if TRACING
+        trace('OPENAL', funcname + '() param AL_*_LENGTH_SOFT is read only');
 #endif
         AL.currentCtx.err = 0xA004 /* AL_INVALID_OPERATION */;
         break;
@@ -1528,16 +1528,16 @@ var LibraryOpenAL = {
           }
           break;
         default:
-#if OPENAL_DEBUG
-          err(funcname + '() param AL_DISTANCE_MODEL value ' + value + ' is out of range');
+#if TRACING
+          trace('OPENAL', funcname + '() param AL_DISTANCE_MODEL value ' + value + ' is out of range');
 #endif
           AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
           return;
         }
         break;
       default:
-#if OPENAL_DEBUG
-        err(funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
+#if TRACING
+        trace('OPENAL', funcname + '() param 0x' + param.toString(16) + ' is unknown or not implemented');
 #endif
         AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
         return;
@@ -1562,32 +1562,32 @@ var LibraryOpenAL = {
     // accept NULL as a 'use the default' device.
     requireValidCaptureDevice: function(deviceId, funcname) {
       if (deviceId === 0) {
-#if OPENAL_DEBUG
-        err(funcname+'() on a NULL device is an error');
+#if TRACING
+        trace('OPENAL', funcname+'() on a NULL device is an error');
 #endif
         AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
         return null;
       }
       var c = AL.captures[deviceId];
       if (!c) {
-#if OPENAL_DEBUG
-        err(funcname+'() on an invalid device');
+#if TRACING
+        trace('OPENAL', funcname+'() on an invalid device');
 #endif
         AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
         return null;
       }
       var err = c.mediaStreamError;
       if (err) {
-#if OPENAL_DEBUG
+#if TRACING
         switch (err.name) {
         case 'PermissionDeniedError':
-          err(funcname+'() but the user denied access to the device');
+          trace('OPENAL', funcname+'() but the user denied access to the device');
           break;
         case 'NotFoundError':
-          err(funcname+'() but no capture device was found');
+          trace('OPENAL', funcname+'() but no capture device was found');
           break;
         default:
-          err(funcname+'() but a MediaStreamError was encountered: ' + err);
+          trace('OPENAL', funcname+'() but a MediaStreamError was encountered: ' + err);
           break;
         }
 #endif
@@ -1620,8 +1620,8 @@ var LibraryOpenAL = {
     if (pDeviceName !== 0) {
       resolvedDeviceName = UTF8ToString(pDeviceName);
       if (resolvedDeviceName !== AL.CAPTURE_DEVICE_NAME) {
-#if OPENAL_DEBUG
-        err('alcCaptureOpenDevice() with invalid device name \''+resolvedDeviceName+'\'');
+#if TRACING
+        trace('OPENAL', 'alcCaptureOpenDevice() with invalid device name \''+resolvedDeviceName+'\'');
 #endif
         // ALC_OUT_OF_MEMORY
         // From the programmer's guide, ALC_OUT_OF_MEMORY's meaning is
@@ -1635,8 +1635,8 @@ var LibraryOpenAL = {
 
     // Otherwise it's probably okay (though useless) for bufferFrameCapacity to be zero.
     if (bufferFrameCapacity < 0) { // ALCsizei is signed int
-#if OPENAL_DEBUG
-      err('alcCaptureOpenDevice() with negative bufferSize');
+#if TRACING
+      trace('OPENAL', 'alcCaptureOpenDevice() with negative bufferSize');
 #endif
       AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
       return 0;
@@ -1651,8 +1651,8 @@ var LibraryOpenAL = {
       &&  navigator.mediaDevices.getUserMedia);
 
     if (!has_getUserMedia) {
-#if OPENAL_DEBUG
-      err('alcCaptureOpenDevice() cannot capture audio, because your browser lacks a `getUserMedia()` implementation');
+#if TRACING
+      trace('OPENAL', 'alcCaptureOpenDevice() cannot capture audio, because your browser lacks a `getUserMedia()` implementation');
 #endif
       // See previously mentioned rationale for ALC_OUT_OF_MEMORY
       AL.alcErr = 0xA005 /* ALC_OUT_OF_MEMORY */;
@@ -1665,8 +1665,8 @@ var LibraryOpenAL = {
       try {
         AL.sharedCaptureAudioCtx = new AudioContext();
       } catch(e) {
-#if OPENAL_DEBUG
-        err('alcCaptureOpenDevice() could not create the shared capture AudioContext: ' + e);
+#if TRACING
+        trace('OPENAL', 'alcCaptureOpenDevice() could not create the shared capture AudioContext: ' + e);
 #endif
         // See previously mentioned rationale for ALC_OUT_OF_MEMORY
         AL.alcErr = 0xA005 /* ALC_OUT_OF_MEMORY */;
@@ -1690,8 +1690,8 @@ var LibraryOpenAL = {
       outputChannelCount = 2;
       break;
     default:
-#if OPENAL_DEBUG
-      err('alcCaptureOpenDevice() with unsupported format ' + format);
+#if TRACING
+      trace('OPENAL', 'alcCaptureOpenDevice() with unsupported format ' + format);
 #endif
       AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
       return 0;
@@ -1728,8 +1728,8 @@ var LibraryOpenAL = {
         buffers[chan] = newSampleArray(bufferFrameCapacity);
       }
     } catch(e) {
-#if OPENAL_DEBUG
-      err('alcCaptureOpenDevice() failed to allocate internal buffers (is bufferSize low enough?): ' + e);
+#if TRACING
+      trace('OPENAL', 'alcCaptureOpenDevice() failed to allocate internal buffers (is bufferSize low enough?): ' + e);
 #endif
       AL.alcErr = 0xA005 /* ALC_OUT_OF_MEMORY */;
       return 0;
@@ -1766,8 +1766,8 @@ var LibraryOpenAL = {
 
     var onError = function(mediaStreamError) {
       newCapture.mediaStreamError = mediaStreamError;
-#if OPENAL_DEBUG
-      err('navigator.getUserMedia() errored with: ' + mediaStreamError);
+#if TRACING
+      trace('OPENAL', 'navigator.getUserMedia() errored with: ' + mediaStreamError);
 #endif
     };
     var onSuccess = function(mediaStream) {
@@ -1789,7 +1789,7 @@ var LibraryOpenAL = {
 
       newCapture.inputChannelCount = inputChannelCount;
 
-#if OPENAL_DEBUG
+#if TRACING
       if (inputChannelCount > 2 || outputChannelCount > 2) {
         console.warn('The number of input or output channels is too high, capture might not work as expected!');
       }
@@ -1942,7 +1942,7 @@ var LibraryOpenAL = {
     if (!c) return;
 
     if (c.isCapturing) {
-#if OPENAL_DEBUG
+#if TRACING
       console.warn('Redundant call to alcCaptureStart()');
 #endif
       // NOTE: Spec says (emphasis mine):
@@ -1962,7 +1962,7 @@ var LibraryOpenAL = {
     var c = AL.requireValidCaptureDevice(deviceId, 'alcCaptureStop');
     if (!c) return;
 
-#if OPENAL_DEBUG
+#if TRACING
     if (!c.isCapturing) {
       console.warn('Redundant call to alcCaptureStop()');
     }
@@ -1994,7 +1994,7 @@ var LibraryOpenAL = {
     if (requestedFrameCount < 0
     ||  requestedFrameCount > (c.capturedFrameCount / fratio)) 
     {
-  // if OPENAL_DEBUG
+  // if TRACING
       err('alcCaptureSamples() with invalid bufferSize');
   // endif
       AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
@@ -2018,8 +2018,8 @@ var LibraryOpenAL = {
     case 'i16': setSample = setI16Sample; break;
     case 'u8' : setSample = setU8Sample ; break;
     default: 
-#if OPENAL_DEBUG
-      err('Internal error: Unknown sample type \''+c.requestedSampleType+'\'');
+#if TRACING
+      trace('OPENAL', 'Internal error: Unknown sample type \''+c.requestedSampleType+'\'');
 #endif
       return;
     }
@@ -2099,7 +2099,7 @@ var LibraryOpenAL = {
   alcCreateContext__sig: 'iii',
   alcCreateContext: function(deviceId, pAttrList) {
     if (!(deviceId in AL.deviceRefCounts)) {
-#if OPENAL_DEBUG
+#if TRACING
       out('alcCreateContext() called with an invalid device');
 #endif
       AL.alcErr = 0xA001; /* ALC_INVALID_DEVICE */
@@ -2145,7 +2145,7 @@ var LibraryOpenAL = {
             case 2 /* ALC_DONT_CARE_SOFT */:
               break;
             default:
-#if OPENAL_DEBUG
+#if TRACING
               out('Unsupported ALC_HRTF_SOFT mode ' + val);
 #endif
               AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
@@ -2154,7 +2154,7 @@ var LibraryOpenAL = {
           break;
         case 0x1996 /* ALC_HRTF_ID_SOFT */:
           if (val !== 0) {
-#if OPENAL_DEBUG
+#if TRACING
             out('Invalid ALC_HRTF_ID_SOFT index ' + val);
 #endif
             AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
@@ -2162,7 +2162,7 @@ var LibraryOpenAL = {
           }
           break;
         default:
-#if OPENAL_DEBUG
+#if TRACING
           out('Unsupported context attribute 0x' + attr.toString(16));
 #endif
           AL.alcErr = 0xA004; /* ALC_INVALID_VALUE */
@@ -2182,7 +2182,7 @@ var LibraryOpenAL = {
       }
     } catch (e) {
       if (e.name === 'NotSupportedError') {
-#if OPENAL_DEBUG
+#if TRACING
         out('Invalid or unsupported options');
 #endif
         AL.alcErr = 0xA004; /* ALC_INVALID_VALUE */
@@ -2255,7 +2255,7 @@ var LibraryOpenAL = {
   alcDestroyContext: function(contextId) {
     var ctx = AL.contexts[contextId];
     if (AL.currentCtx === ctx) {
-#if OPENAL_DEBUG
+#if TRACING
       out('alcDestroyContext() called with an invalid context');
 #endif
       AL.alcErr = 0xA002 /* ALC_INVALID_CONTEXT */;
@@ -2336,8 +2336,8 @@ var LibraryOpenAL = {
     // Using a NULL handle is legal, but only the
     // tokens defined by the AL core are guaranteed.
     if (deviceId !== 0 && !(deviceId in AL.deviceRefCounts)) {
-#if OPENAL_DEBUG
-      err('alcGetEnumValue() called with an invalid device');
+#if TRACING
+      trace('OPENAL', 'alcGetEnumValue() called with an invalid device');
 #endif
       // ALC_INVALID_DEVICE is not listed as a possible error state for
       // this function, sadly.
@@ -2386,8 +2386,8 @@ var LibraryOpenAL = {
     case 'ALC_HRTF_UNSUPPORTED_FORMAT_SOFT': return 0x0005;
 
     default:
-#if OPENAL_DEBUG
-      err('No value for `' + pEnumName + '` is known by alcGetEnumValue()');
+#if TRACING
+      trace('OPENAL', 'No value for `' + pEnumName + '` is known by alcGetEnumValue()');
 #endif
       AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
       return 0 /* AL_NONE */;
@@ -2586,7 +2586,7 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '0', 'nsamples', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
+#if TRACING
       out('alcGetIntegerv() with param 0x' + param.toString(16) + ' not implemented yet');
 #endif
       AL.alcErr = 0xA003 /* ALC_INVALID_ENUM */;
@@ -2598,7 +2598,7 @@ var LibraryOpenAL = {
   emscripten_alcDevicePauseSOFT__sig: 'vi',
   emscripten_alcDevicePauseSOFT: function(deviceId) {
     if (!(deviceId in AL.deviceRefCounts)) {
-#if OPENAL_DEBUG
+#if TRACING
       out('alcDevicePauseSOFT() called with an invalid device');
 #endif
       AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
@@ -2626,7 +2626,7 @@ var LibraryOpenAL = {
   emscripten_alcDeviceResumeSOFT__sig: 'vi',
   emscripten_alcDeviceResumeSOFT: function(deviceId) {
     if (!(deviceId in AL.deviceRefCounts)) {
-#if OPENAL_DEBUG
+#if TRACING
       out('alcDeviceResumeSOFT() called with an invalid device');
 #endif
       AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
@@ -2654,7 +2654,7 @@ var LibraryOpenAL = {
   emscripten_alcGetStringiSOFT__deps: ['alcGetString'],
   emscripten_alcGetStringiSOFT: function(deviceId, param, index) {
     if (!(deviceId in AL.deviceRefCounts)) {
-#if OPENAL_DEBUG
+#if TRACING
       out('alcGetStringiSOFT() called with an invalid device');
 #endif
       AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
@@ -2671,7 +2671,7 @@ var LibraryOpenAL = {
       if (index === 0) {
         ret = 'Web Audio HRTF';
       } else {
-#if OPENAL_DEBUG
+#if TRACING
         out('alcGetStringiSOFT() with param ALC_HRTF_SPECIFIER_SOFT index ' + index + ' is out of range');
 #endif
         AL.alcErr = 0xA004 /* ALC_INVALID_VALUE */;
@@ -2682,7 +2682,7 @@ var LibraryOpenAL = {
       if (index === 0) {
         return _alcGetString(deviceId, param);
       } else {
-#if OPENAL_DEBUG
+#if TRACING
         out('alcGetStringiSOFT() with param 0x' + param.toString(16) + ' not implemented yet');
 #endif
         AL.alcErr = 0xA003 /* ALC_INVALID_ENUM */;
@@ -2699,7 +2699,7 @@ var LibraryOpenAL = {
   emscripten_alcResetDeviceSOFT__sig: 'iii',
   emscripten_alcResetDeviceSOFT: function(deviceId, pAttrList) {
     if (!(deviceId in AL.deviceRefCounts)) {
-#if OPENAL_DEBUG
+#if TRACING
       out('alcResetDeviceSOFT() called with an invalid device');
 #endif
       AL.alcErr = 0xA001 /* ALC_INVALID_DEVICE */;
@@ -2756,8 +2756,8 @@ var LibraryOpenAL = {
   alGenBuffers__sig: 'vii',
   alGenBuffers: function(count, pBufferIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alGenBuffers() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alGenBuffers() called without a valid context');
 #endif
       return;
     }
@@ -2783,8 +2783,8 @@ var LibraryOpenAL = {
   alDeleteBuffers__sig: 'vii',
   alDeleteBuffers: function(count, pBufferIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alDeleteBuffers() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alDeleteBuffers() called without a valid context');
 #endif
       return;
     }
@@ -2798,8 +2798,8 @@ var LibraryOpenAL = {
 
       // Make sure the buffer index is valid.
       if (!AL.buffers[bufId]) {
-#if OPENAL_DEBUG
-        err('alDeleteBuffers() called with an invalid buffer');
+#if TRACING
+        trace('OPENAL', 'alDeleteBuffers() called with an invalid buffer');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
@@ -2807,8 +2807,8 @@ var LibraryOpenAL = {
 
       // Make sure the buffer is no longer in use.
       if (AL.buffers[bufId].refCount) {
-#if OPENAL_DEBUG
-        err('alDeleteBuffers() called with a used buffer');
+#if TRACING
+        trace('OPENAL', 'alDeleteBuffers() called with a used buffer');
 #endif
         AL.currentCtx.err = 0xA004 /* AL_INVALID_OPERATION */;
         return;
@@ -2831,8 +2831,8 @@ var LibraryOpenAL = {
   alGenSources__sig: 'vii',
   alGenSources: function(count, pSourceIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alGenSources() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alGenSources() called without a valid context');
 #endif
       return;
     }
@@ -2883,8 +2883,8 @@ var LibraryOpenAL = {
   alDeleteSources__sig: 'vii',
   alDeleteSources: function(count, pSourceIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alDeleteSources() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alDeleteSources() called without a valid context');
 #endif
       return;
     }
@@ -2892,8 +2892,8 @@ var LibraryOpenAL = {
     for (var i = 0; i < count; ++i) {
       var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
       if (!AL.currentCtx.sources[srcId]) {
-#if OPENAL_DEBUG
-        err('alDeleteSources() called with an invalid source');
+#if TRACING
+        trace('OPENAL', 'alDeleteSources() called with an invalid source');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
@@ -2938,15 +2938,15 @@ var LibraryOpenAL = {
   alGetEnumValue__sig: 'ii',
   alGetEnumValue: function(pEnumName) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alGetEnumValue() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alGetEnumValue() called without a valid context');
 #endif
       return 0;
     }
 
     if (!pEnumName) {
-#if OPENAL_DEBUG
-      err('alGetEnumValue() called with null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetEnumValue() called with null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return 0 /* AL_NONE */;
@@ -3038,8 +3038,8 @@ var LibraryOpenAL = {
     case 'AL_FORMAT_STEREO_FLOAT32': return 0x10011;
 
     default:
-#if OPENAL_DEBUG
-      err('No value for `' + name + '` is known by alGetEnumValue()');
+#if TRACING
+      trace('OPENAL', 'No value for `' + name + '` is known by alGetEnumValue()');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return 0;
@@ -3050,8 +3050,8 @@ var LibraryOpenAL = {
   alGetString__sig: 'ii',
   alGetString: function(param) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alGetString() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alGetString() called without a valid context');
 #endif
       return 0;
     }
@@ -3111,8 +3111,8 @@ var LibraryOpenAL = {
   alEnable__sig: 'vi',
   alEnable: function(param) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alEnable() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alEnable() called without a valid context');
 #endif
       return;
     }
@@ -3122,8 +3122,8 @@ var LibraryOpenAL = {
       AL.updateContextGlobal(AL.currentCtx);
       break;
     default:
-#if OPENAL_DEBUG
-      err('alEnable() with param 0x' + param.toString(16) + ' not implemented yet');
+#if TRACING
+      trace('OPENAL', 'alEnable() with param 0x' + param.toString(16) + ' not implemented yet');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3134,8 +3134,8 @@ var LibraryOpenAL = {
   alDisable__sig: 'vi',
   alDisable: function(param) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alDisable() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alDisable() called without a valid context');
 #endif
       return;
     }
@@ -3145,8 +3145,8 @@ var LibraryOpenAL = {
       AL.updateContextGlobal(AL.currentCtx);
       break;
     default:
-#if OPENAL_DEBUG
-      err('alDisable() with param 0x' + param.toString(16) + ' not implemented yet');
+#if TRACING
+      trace('OPENAL', 'alDisable() with param 0x' + param.toString(16) + ' not implemented yet');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3157,8 +3157,8 @@ var LibraryOpenAL = {
   alIsEnabled__sig: 'ii',
   alIsEnabled: function(param) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alIsEnabled() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alIsEnabled() called without a valid context');
 #endif
       return 0;
     }
@@ -3166,8 +3166,8 @@ var LibraryOpenAL = {
     case 'AL_SOURCE_DISTANCE_MODEL':
       return AL.currentCtx.sourceDistanceModel ? 0 /* AL_FALSE */ : 1 /* AL_TRUE */;
     default:
-#if OPENAL_DEBUG
-      err('alIsEnabled() with param 0x' + param.toString(16) + ' not implemented yet');
+#if TRACING
+      trace('OPENAL', 'alIsEnabled() with param 0x' + param.toString(16) + ' not implemented yet');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return 0;
@@ -3188,8 +3188,8 @@ var LibraryOpenAL = {
     case 0xD000 /* AL_DISTANCE_MODEL */:
       return val;
     default:
-#if OPENAL_DEBUG
-      err('alGetDouble(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetDouble(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return 0.0;
@@ -3212,8 +3212,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '0', 'val', 'double') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetDoublev(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetDoublev(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3234,8 +3234,8 @@ var LibraryOpenAL = {
     case 0xD000 /* AL_DISTANCE_MODEL */:
       return val;
     default:
-#if OPENAL_DEBUG
-      err('alGetFloat(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetFloat(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       return 0.0;
     }
@@ -3257,8 +3257,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '0', 'val', 'float') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetFloatv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetFloatv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3279,8 +3279,8 @@ var LibraryOpenAL = {
     case 0xD000 /* AL_DISTANCE_MODEL */:
       return val;
     default:
-#if OPENAL_DEBUG
-      err('alGetInteger(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetInteger(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return 0;
@@ -3303,8 +3303,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '0', 'val', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetIntegerv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetIntegerv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3325,8 +3325,8 @@ var LibraryOpenAL = {
     case 0xD000 /* AL_DISTANCE_MODEL */:
       return val !== 0 ? 1 /* AL_TRUE */ : 0 /* AL_FALSE */;
     default:
-#if OPENAL_DEBUG
-      err('alGetBoolean(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetBoolean(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return 0 /* AL_FALSE */;
@@ -3349,8 +3349,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '0', 'val', 'i8') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetBooleanv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetBooleanv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3384,8 +3384,8 @@ var LibraryOpenAL = {
   alDopplerVelocity: function(value) {
     warnOnce('alDopplerVelocity() is deprecated, and only kept for compatibility with OpenAL 1.0. Use alSpeedOfSound() instead.');
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alDopplerVelocity() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alDopplerVelocity() called without a valid context');
 #endif
       return;
     }
@@ -3407,8 +3407,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue) {
-#if OPENAL_DEBUG
-      err('alGetListenerf() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetListenerf() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3419,8 +3419,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValue', '0', 'val', 'float') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetListenerf(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetListenerf(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3435,8 +3435,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue0 || !pValue1 || !pValue2) {
-#if OPENAL_DEBUG
-      err('alGetListener3f() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetListener3f() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3450,8 +3450,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValue2', '0', 'val[2]', 'float') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetListener3f(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetListener3f(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3466,8 +3466,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alGetListenerfv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetListenerfv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3489,8 +3489,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '20', 'val[5]', 'float') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetListenerfv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetListenerfv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3505,15 +3505,15 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue) {
-#if OPENAL_DEBUG
-      err('alGetListeneri() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetListeneri() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
 
-#if OPENAL_DEBUG
-    err('alGetListeneri(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+    trace('OPENAL', 'alGetListeneri(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
     AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
   },
@@ -3526,8 +3526,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue0 || !pValue1 || !pValue2) {
-#if OPENAL_DEBUG
-      err('alGetListener3i() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetListener3i() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3541,8 +3541,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValue2', '0', 'val[2]', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetListener3i(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetListener3i(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3557,8 +3557,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alGetListeneriv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetListeneriv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3580,8 +3580,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '20', 'val[5]', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetListeneriv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetListeneriv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3622,14 +3622,14 @@ var LibraryOpenAL = {
   alListenerfv__sig: 'vii',
   alListenerfv: function(param, pValues) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alListenerfv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alListenerfv() called without a valid context');
 #endif
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alListenerfv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alListenerfv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3685,14 +3685,14 @@ var LibraryOpenAL = {
   alListeneriv__sig: 'vii',
   alListeneriv: function(param, pValues) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alListeneriv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alListeneriv() called without a valid context');
 #endif
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alListeneriv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alListeneriv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3746,22 +3746,22 @@ var LibraryOpenAL = {
   alBufferData__sig: 'viiiii',
   alBufferData: function(bufferId, format, pData, size, freq) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alBufferData() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alBufferData() called without a valid context');
 #endif
       return;
     }
     var buf = AL.buffers[bufferId];
     if (!buf) {
-#if OPENAL_DEBUG
-      err('alBufferData() called with an invalid buffer');
+#if TRACING
+      trace('OPENAL', 'alBufferData() called with an invalid buffer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
     if (freq <= 0) {
-#if OPENAL_DEBUG
-      err('alBufferData() called with an invalid frequency');
+#if TRACING
+      trace('OPENAL', 'alBufferData() called with an invalid frequency');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3853,8 +3853,8 @@ var LibraryOpenAL = {
         buf.length = size >> 3;
         break;
       default:
-#if OPENAL_DEBUG
-        err('alBufferData() called with invalid format ' + format);
+#if TRACING
+        trace('OPENAL', 'alBufferData() called with invalid format ' + format);
 #endif
         AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
         return;
@@ -3862,8 +3862,8 @@ var LibraryOpenAL = {
       buf.frequency = freq;
       buf.audioBuf = audioBuf;
     } catch (e) {
-#if OPENAL_DEBUG
-      err('alBufferData() upload failed with an exception ' + e);
+#if TRACING
+      trace('OPENAL', 'alBufferData() upload failed with an exception ' + e);
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3878,15 +3878,15 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue) {
-#if OPENAL_DEBUG
-      err('alGetBufferf() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetBufferf() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
 
-#if OPENAL_DEBUG
-    err('alGetBufferf(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+    trace('OPENAL', 'alGetBufferf(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
     AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
   },
@@ -3899,15 +3899,15 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue0 || !pValue1 || !pValue2) {
-#if OPENAL_DEBUG
-      err('alGetBuffer3f() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetBuffer3f() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
 
-#if OPENAL_DEBUG
-    err('alGetBuffer3f(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+    trace('OPENAL', 'alGetBuffer3f(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
     AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
   },
@@ -3920,15 +3920,15 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alGetBufferfv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetBufferfv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
 
-#if OPENAL_DEBUG
-    err('alGetBufferfv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+    trace('OPENAL', 'alGetBufferfv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
     AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
   },
@@ -3941,8 +3941,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue) {
-#if OPENAL_DEBUG
-      err('alGetBufferi() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetBufferi() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -3956,8 +3956,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValue', '0', 'val', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetBufferi(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetBufferi(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -3972,15 +3972,15 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue0 || !pValue1 || !pValue2) {
-#if OPENAL_DEBUG
-      err('alGetBuffer3i() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetBuffer3i() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
     }
 
-#if OPENAL_DEBUG
-    err('alGetBuffer3i(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+    trace('OPENAL', 'alGetBuffer3i(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
     AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
   },
@@ -3993,8 +3993,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alGetBufferiv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetBufferiv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4012,8 +4012,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '4', 'val[1]', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetBufferiv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetBufferiv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -4040,14 +4040,14 @@ var LibraryOpenAL = {
   alBufferfv__sig: 'viii',
   alBufferfv: function(bufferId, param, pValues) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alBufferfv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alBufferfv() called without a valid context');
 #endif
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alBufferfv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alBufferfv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4072,14 +4072,14 @@ var LibraryOpenAL = {
   alBufferiv__sig: 'viii',
   alBufferiv: function(bufferId, param, pValues) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alBufferiv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alBufferiv() called without a valid context');
 #endif
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alBufferiv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alBufferiv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4119,22 +4119,22 @@ var LibraryOpenAL = {
   alSourceQueueBuffers__sig: 'viii',
   alSourceQueueBuffers: function(sourceId, count, pBufferIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourceQueueBuffers() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourceQueueBuffers() called without a valid context');
 #endif
       return;
     }
     var src = AL.currentCtx.sources[sourceId];
     if (!src) {
-#if OPENAL_DEBUG
-      err('alSourceQueueBuffers() called with an invalid source');
+#if TRACING
+      trace('OPENAL', 'alSourceQueueBuffers() called with an invalid source');
 #endif
       AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
       return;
     }
     if (src.type === 0x1028 /* AL_STATIC */) {
-#if OPENAL_DEBUG
-      err('alSourceQueueBuffers() called while a static buffer is bound');
+#if TRACING
+      trace('OPENAL', 'alSourceQueueBuffers() called while a static buffer is bound');
 #endif
       AL.currentCtx.err = 0xA004 /* AL_INVALID_OPERATION */;
       return;
@@ -4157,8 +4157,8 @@ var LibraryOpenAL = {
       var bufId = {{{ makeGetValue('pBufferIds', 'i*4', 'i32') }}};
       var buf = AL.buffers[bufId];
       if (!buf) {
-#if OPENAL_DEBUG
-        err('alSourceQueueBuffers() called with an invalid buffer');
+#if TRACING
+        trace('OPENAL', 'alSourceQueueBuffers() called with an invalid buffer');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
@@ -4170,8 +4170,8 @@ var LibraryOpenAL = {
         || buf.bytesPerSample !== templateBuf.bytesPerSample
         || buf.channels !== templateBuf.channels)
       ) {
-#if OPENAL_DEBUG
-        err('alSourceQueueBuffers() called with a buffer of different format');
+#if TRACING
+        trace('OPENAL', 'alSourceQueueBuffers() called with a buffer of different format');
 #endif
         AL.currentCtx.err = 0xA004 /* AL_INVALID_OPERATION */;
       }
@@ -4203,15 +4203,15 @@ var LibraryOpenAL = {
   alSourceUnqueueBuffers__sig: 'viii',
   alSourceUnqueueBuffers: function(sourceId, count, pBufferIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourceUnqueueBuffers() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourceUnqueueBuffers() called without a valid context');
 #endif
       return;
     }
     var src = AL.currentCtx.sources[sourceId];
     if (!src) {
-#if OPENAL_DEBUG
-      err('alSourceUnqueueBuffers() called with an invalid source');
+#if TRACING
+      trace('OPENAL', 'alSourceUnqueueBuffers() called with an invalid source');
 #endif
       AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
       return;
@@ -4246,15 +4246,15 @@ var LibraryOpenAL = {
   alSourcePlay__sig: 'vi',
   alSourcePlay: function(sourceId) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourcePlay() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourcePlay() called without a valid context');
 #endif
       return;
     }
     var src = AL.currentCtx.sources[sourceId];
     if (!src) {
-#if OPENAL_DEBUG
-      err('alSourcePlay() called with an invalid source');
+#if TRACING
+      trace('OPENAL', 'alSourcePlay() called with an invalid source');
 #endif
       AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
       return;
@@ -4266,21 +4266,21 @@ var LibraryOpenAL = {
   alSourcePlayv__sig: 'vii',
   alSourcePlayv: function(count, pSourceIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourcePlayv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourcePlayv() called without a valid context');
 #endif
       return;
     }
     if (!pSourceIds) {
-#if OPENAL_DEBUG
-      err('alSourcePlayv() called with null pointer');
+#if TRACING
+      trace('OPENAL', 'alSourcePlayv() called with null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
     }
     for (var i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
-#if OPENAL_DEBUG
-        err('alSourcePlayv() called with an invalid source');
+#if TRACING
+        trace('OPENAL', 'alSourcePlayv() called with an invalid source');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
@@ -4296,15 +4296,15 @@ var LibraryOpenAL = {
   alSourceStop__sig: 'vi',
   alSourceStop: function(sourceId) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourceStop() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourceStop() called without a valid context');
 #endif
       return;
     }
     var src = AL.currentCtx.sources[sourceId];
     if (!src) {
-#if OPENAL_DEBUG
-      err('alSourceStop() called with an invalid source');
+#if TRACING
+      trace('OPENAL', 'alSourceStop() called with an invalid source');
 #endif
       AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
       return;
@@ -4316,21 +4316,21 @@ var LibraryOpenAL = {
   alSourceStopv__sig: 'vii',
   alSourceStopv: function(count, pSourceIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourceStopv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourceStopv() called without a valid context');
 #endif
       return;
     }
     if (!pSourceIds) {
-#if OPENAL_DEBUG
-      err('alSourceStopv() called with null pointer');
+#if TRACING
+      trace('OPENAL', 'alSourceStopv() called with null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
     }
     for (var i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
-#if OPENAL_DEBUG
-        err('alSourceStopv() called with an invalid source');
+#if TRACING
+        trace('OPENAL', 'alSourceStopv() called with an invalid source');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
@@ -4346,15 +4346,15 @@ var LibraryOpenAL = {
   alSourceRewind__sig: 'vi',
   alSourceRewind: function(sourceId) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourceRewind() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourceRewind() called without a valid context');
 #endif
       return;
     }
     var src = AL.currentCtx.sources[sourceId];
     if (!src) {
-#if OPENAL_DEBUG
-      err('alSourceRewind() called with an invalid source');
+#if TRACING
+      trace('OPENAL', 'alSourceRewind() called with an invalid source');
 #endif
       AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
       return;
@@ -4369,21 +4369,21 @@ var LibraryOpenAL = {
   alSourceRewindv__sig: 'vii',
   alSourceRewindv: function(count, pSourceIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourceRewindv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourceRewindv() called without a valid context');
 #endif
       return;
     }
     if (!pSourceIds) {
-#if OPENAL_DEBUG
-      err('alSourceRewindv() called with null pointer');
+#if TRACING
+      trace('OPENAL', 'alSourceRewindv() called with null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
     }
     for (var i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
-#if OPENAL_DEBUG
-        err('alSourceRewindv() called with an invalid source');
+#if TRACING
+        trace('OPENAL', 'alSourceRewindv() called with an invalid source');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
@@ -4399,15 +4399,15 @@ var LibraryOpenAL = {
   alSourcePause__sig: 'vi',
   alSourcePause: function(sourceId) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourcePause() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourcePause() called without a valid context');
 #endif
       return;
     }
     var src = AL.currentCtx.sources[sourceId];
     if (!src) {
-#if OPENAL_DEBUG
-      err('alSourcePause() called with an invalid source');
+#if TRACING
+      trace('OPENAL', 'alSourcePause() called with an invalid source');
 #endif
       AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
       return;
@@ -4419,21 +4419,21 @@ var LibraryOpenAL = {
   alSourcePausev__sig: 'vii',
   alSourcePausev: function(count, pSourceIds) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourcePausev() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourcePausev() called without a valid context');
 #endif
       return;
     }
     if (!pSourceIds) {
-#if OPENAL_DEBUG
-      err('alSourcePausev() called with null pointer');
+#if TRACING
+      trace('OPENAL', 'alSourcePausev() called with null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
     }
     for (var i = 0; i < count; ++i) {
       if (!AL.currentCtx.sources[{{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}]) {
-#if OPENAL_DEBUG
-        err('alSourcePausev() called with an invalid source');
+#if TRACING
+        trace('OPENAL', 'alSourcePausev() called with an invalid source');
 #endif
         AL.currentCtx.err = 0xA001 /* AL_INVALID_NAME */;
         return;
@@ -4453,8 +4453,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue) {
-#if OPENAL_DEBUG
-      err('alGetSourcef() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetSourcef() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4478,8 +4478,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValue', '0', 'val', 'float') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetSourcef(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetSourcef(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -4494,8 +4494,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue0 || !pValue1 || !pValue2) {
-#if OPENAL_DEBUG
-      err('alGetSource3f() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetSource3f() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4510,8 +4510,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValue2', '0', 'val[2]', 'float') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetSource3f(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetSource3f(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -4526,8 +4526,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alGetSourcefv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetSourcefv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4558,8 +4558,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '8', 'val[2]', 'float') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetSourcefv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetSourcefv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -4574,8 +4574,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue) {
-#if OPENAL_DEBUG
-      err('alGetSourcei() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetSourcei() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4604,8 +4604,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValue', '0', 'val', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetSourcei(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetSourcei(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -4620,8 +4620,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValue0 || !pValue1 || !pValue2) {
-#if OPENAL_DEBUG
-      err('alGetSource3i() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetSource3i() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4636,8 +4636,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValue2', '0', 'val[2]', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetSource3i(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetSource3i(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -4652,8 +4652,8 @@ var LibraryOpenAL = {
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alGetSourceiv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alGetSourceiv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4689,8 +4689,8 @@ var LibraryOpenAL = {
       {{{ makeSetValue('pValues', '8', 'val[2]', 'i32') }}};
       break;
     default:
-#if OPENAL_DEBUG
-      err('alGetSourceiv(): param 0x' + param.toString(16) + ' has wrong signature');
+#if TRACING
+      trace('OPENAL', 'alGetSourceiv(): param 0x' + param.toString(16) + ' has wrong signature');
 #endif
       AL.currentCtx.err = 0xA002 /* AL_INVALID_ENUM */;
       return;
@@ -4745,14 +4745,14 @@ var LibraryOpenAL = {
   alSourcefv__sig: 'viii',
   alSourcefv: function(sourceId, param, pValues) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourcefv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourcefv() called without a valid context');
 #endif
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alSourcefv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alSourcefv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;
@@ -4839,14 +4839,14 @@ var LibraryOpenAL = {
   alSourceiv__sig: 'viii',
   alSourceiv: function(sourceId, param, pValues) {
     if (!AL.currentCtx) {
-#if OPENAL_DEBUG
-      err('alSourceiv() called without a valid context');
+#if TRACING
+      trace('OPENAL', 'alSourceiv() called without a valid context');
 #endif
       return;
     }
     if (!pValues) {
-#if OPENAL_DEBUG
-      err('alSourceiv() called with a null pointer');
+#if TRACING
+      trace('OPENAL', 'alSourceiv() called with a null pointer');
 #endif
       AL.currentCtx.err = 0xA003 /* AL_INVALID_VALUE */;
       return;

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -222,8 +222,8 @@ var LibraryPThread = {
     },
     // Called by worker.js each time a thread is started.
     threadInit: function() {
-#if PTHREADS_DEBUG
-      err('Pthread 0x' + _pthread_self().toString(16) + ' threadInit.');
+#if TRACING
+      trace('PTHREADS', 'Pthread 0x' + _pthread_self().toString(16) + ' threadInit.');
 #endif
 #if PTHREADS_PROFILING
       PThread.setThreadStatus(_pthread_self(), {{{ cDefine('EM_THREAD_STATUS_RUNNING') }}});
@@ -387,8 +387,8 @@ var LibraryPThread = {
 #if EXPORT_ES6 && USE_ES6_IMPORT_META
       // If we're using module output and there's no explicit override, use bundler-friendly pattern.
       if (!Module['locateFile']) {
-#if PTHREADS_DEBUG
-        err('Allocating a new web worker from ' + new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url));
+#if TRACING
+        trace('PTHREADS', 'Allocating a new web worker from ', new URL('{{{ PTHREAD_WORKER_FILE }}}', import.meta.url));
 #endif
 #if TRUSTED_TYPES
         // Use Trusted Types compatible wrappers.
@@ -413,8 +413,8 @@ var LibraryPThread = {
       // to the main html file is loaded.
       var pthreadMainJs = locateFile('{{{ PTHREAD_WORKER_FILE }}}');
 #endif
-#if PTHREADS_DEBUG
-      err('Allocating a new web worker from ' + pthreadMainJs);
+#if TRACING
+      trace('PTHREADS', 'Allocating a new web worker from ', pthreadMainJs);
 #endif
 #if TRUSTED_TYPES
       // Use Trusted Types compatible wrappers.
@@ -491,8 +491,8 @@ var LibraryPThread = {
   },
 
   $registerTlsInit: function(tlsInitFunc, moduleExports, metadata) {
-#if DYLINK_DEBUG
-    out("registerTlsInit: " + tlsInitFunc);
+#if TRACING
+    trace('DYLINK', 'registerTlsInit: ' + tlsInitFunc);
 #endif
 #if RELOCATABLE
     // In relocatable builds, we use the result of calling tlsInitFunc
@@ -500,8 +500,8 @@ var LibraryPThread = {
     // according to this new __tls_base.
     function tlsInitWrapper() {
       var __tls_base = tlsInitFunc();
-#if DYLINK_DEBUG
-      err('tlsInit -> ' + __tls_base);
+#if TRACING
+      trace('DYLINK', 'tlsInit -> ' + __tls_base);
 #endif
       for (var sym in metadata.tlsExports) {
         metadata.tlsExports[sym] = moduleExports[sym];
@@ -649,8 +649,8 @@ var LibraryPThread = {
 #endif
     if (transferredCanvasNames) transferredCanvasNames = UTF8ToString(transferredCanvasNames).trim();
     if (transferredCanvasNames) transferredCanvasNames = transferredCanvasNames.split(',');
-#if GL_DEBUG
-    out('pthread_create: transferredCanvasNames="' + transferredCanvasNames + '"');
+#if TRACING
+    trace('GL', 'pthread_create: transferredCanvasNames="' + transferredCanvasNames + '"');
 #endif
 
     var offscreenCanvases = {}; // Dictionary of OffscreenCanvas objects we'll transfer to the created thread to own
@@ -687,8 +687,8 @@ var LibraryPThread = {
             break;
           }
           if (canvas.transferControlToOffscreen) {
-#if GL_DEBUG
-            err('pthread_create: canvas.transferControlToOffscreen(), transferring canvas by name "' + name + '" (DOM id="' + canvas.id + '") from main thread to pthread');
+#if TRACING
+            trace('GL', 'pthread_create: canvas.transferControlToOffscreen(), transferring canvas by name "' + name + '" (DOM id="' + canvas.id + '") from main thread to pthread');
 #endif
             // Create a shared information block in heap so that we can control
             // the canvas size from any thread.
@@ -966,10 +966,10 @@ var LibraryPThread = {
     // the main thread, but if we ever fetched a rendering context for them that
     // would not be valid, so we don't try.
 
-#if PTHREADS_DEBUG
+#if TRACING
     var tb = _pthread_self();
     assert(tb);
-    err('Pthread 0x' + tb.toString(16) + ' exited.');
+    trace('PTHREADS', 'Pthread 0x' + tb.toString(16) + ' exited.');
 #endif
 
     while (PThread.threadExitHandlers.length > 0) {
@@ -1172,16 +1172,16 @@ var LibraryPThread = {
 #if EXIT_RUNTIME
     if (!keepRuntimeAlive()) {
       // exitRuntime enabled, proxied main() finished in a pthread, shut down the process.
-#if PTHREADS_DEBUG
-      err('Proxied main thread 0x' + _pthread_self().toString(16) + ' finished with return code ' + returnCode + '. EXIT_RUNTIME=1 set, quitting process.');
+#if TRACING
+      trace('PTHREADS', 'Proxied main thread 0x' + _pthread_self().toString(16) + ' finished with return code ' + returnCode + '. EXIT_RUNTIME=1 set, quitting process.');
 #endif
       postMessage({ 'cmd': 'exitProcess', 'returnCode': returnCode });
       return returnCode;
     }
 #else
     // EXIT_RUNTIME==0 set on command line, keeping main thread alive.
-#if PTHREADS_DEBUG
-    err('Proxied main thread 0x' + _pthread_self().toString(16) + ' finished with return code ' + returnCode + '. EXIT_RUNTIME=0 set, so keeping main thread alive for asynchronous event operations.');
+#if TRACING
+    trace('PTHREADS', 'Proxied main thread 0x' + _pthread_self().toString(16) + ' finished with return code ' + returnCode + '. EXIT_RUNTIME=0 set, so keeping main thread alive for asynchronous event operations.');
 #endif
 #endif
   },

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -10,7 +10,7 @@ var SyscallsLibrary = {
                    '$PATH',
                    '$FS',
 #endif
-#if SYSCALL_DEBUG
+#if TRACING
                    '$ERRNO_MESSAGES'
 #endif
   ],
@@ -192,15 +192,15 @@ var SyscallsLibrary = {
 #endif
       SYSCALLS.varargs += 4;
       var ret = {{{ makeGetValue('SYSCALLS.varargs', '-4', 'i32') }}};
-#if SYSCALL_DEBUG
-      err('    (raw: "' + ret + '")');
+#if TRACING
+      trace('SYSCALL', '    (raw: "' + ret + '")');
 #endif
       return ret;
     },
     getStr: function(ptr) {
       var ret = UTF8ToString(ptr);
-#if SYSCALL_DEBUG
-      err('    (str: "' + ret + '")');
+#if TRACING
+      trace('SYSCALL', '    (str: "' + ret + '")');
 #endif
       return ret;
     },
@@ -208,8 +208,8 @@ var SyscallsLibrary = {
     getStreamFromFD: function(fd) {
       var stream = FS.getStream(fd);
       if (!stream) throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
-#if SYSCALL_DEBUG
-      err('    (stream: "' + stream.path + '")');
+#if TRACING
+      trace('SYSCALL', '    (stream: "' + stream.path + '")');
 #endif
       return stream;
     },
@@ -219,8 +219,8 @@ var SyscallsLibrary = {
       if (low >= 0) assert(high === 0);
       else assert(high === -1);
 #endif
-#if SYSCALL_DEBUG
-      err('    (i64: "' + low + '")');
+#if TRACING
+      trace('SYSCALL', '    (i64: "' + low + '")');
 #endif
       return low;
     }
@@ -391,8 +391,8 @@ var SyscallsLibrary = {
   },
   __sys_ioctl: function(fd, op, varargs) {
 #if SYSCALLS_REQUIRE_FILESYSTEM == 0
-#if SYSCALL_DEBUG
-    err('no-op in ioctl syscall due to SYSCALLS_REQUIRE_FILESYSTEM=0');
+#if TRACING
+    trace('SYSCALL', 'no-op in ioctl syscall due to SYSCALLS_REQUIRE_FILESYSTEM=0');
 #endif
     return 0;
 #else
@@ -401,8 +401,8 @@ var SyscallsLibrary = {
       case {{{ cDefine('TCGETA') }}}:
       case {{{ cDefine('TCGETS') }}}: {
         if (!stream.tty) return -{{{ cDefine('ENOTTY') }}};
-#if SYSCALL_DEBUG
-        err('warning: not filling tio struct');
+#if TRACING
+        trace('SYSCALL', 'warning: not filling tio struct');
 #endif
         return 0;
       }
@@ -525,8 +525,8 @@ var SyscallsLibrary = {
   $getSocketFromFD: function(fd) {
     var socket = SOCKFS.getSocket(fd);
     if (!socket) throw new FS.ErrnoError({{{ cDefine('EBADF') }}});
-#if SYSCALL_DEBUG
-    err('    (socket: "' + socket.path + '")');
+#if TRACING
+    trace('SYSCALL', '    (socket: "' + socket.path + '")');
 #endif
     return socket;
   },
@@ -537,8 +537,8 @@ var SyscallsLibrary = {
     var info = readSockaddr(addrp, addrlen);
     if (info.errno) throw new FS.ErrnoError(info.errno);
     info.addr = DNS.lookup_addr(info.addr) || info.addr;
-#if SYSCALL_DEBUG
-    err('    (socketaddress: "' + [info.addr, info.port] + '")');
+#if TRACING
+    trace('SYSCALL', '    (socketaddress: "' + [info.addr, info.port] + '")');
 #endif
     return info;
   },
@@ -1095,8 +1095,8 @@ var SyscallsLibrary = {
   __sys_fcntl64__deps: ['$setErrNo'],
   __sys_fcntl64: function(fd, cmd, varargs) {
 #if SYSCALLS_REQUIRE_FILESYSTEM == 0
-#if SYSCALL_DEBUG
-    err('no-op in fcntl64 syscall due to SYSCALLS_REQUIRE_FILESYSTEM=0');
+#if TRACING
+    trace('SYSCALL', 'no-op in fcntl64 syscall due to SYSCALLS_REQUIRE_FILESYSTEM=0');
 #endif
     return 0;
 #else
@@ -1145,8 +1145,8 @@ var SyscallsLibrary = {
         setErrNo({{{ cDefine('EINVAL') }}});
         return -1;
       default: {
-#if SYSCALL_DEBUG
-        err('warning: fctl64 unrecognized command ' + cmd);
+#if TRACING
+        trace('SYSCALL', 'warning: fctl64 unrecognized command ' + cmd);
 #endif
         return -{{{ cDefine('EINVAL') }}};
       }
@@ -1184,8 +1184,8 @@ var SyscallsLibrary = {
     return 0; // your advice is important to us (but we can't use it)
   },
   __sys_openat: function(dirfd, path, flags, varargs) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
@@ -1193,24 +1193,24 @@ var SyscallsLibrary = {
     return FS.open(path, flags, mode).fd;
   },
   __sys_mkdirat: function(dirfd, path, mode) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     return SYSCALLS.doMkdir(path, mode);
   },
   __sys_mknodat: function(dirfd, path, mode, dev) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     return SYSCALLS.doMknod(path, mode, dev);
   },
   __sys_fchownat: function(dirfd, path, owner, group, flags) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     path = SYSCALLS.getStr(path);
 #if ASSERTIONS
@@ -1244,8 +1244,8 @@ var SyscallsLibrary = {
     return 0;
   },
   __sys_renameat: function(olddirfd, oldpath, newdirfd, newpath) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     oldpath = SYSCALLS.getStr(oldpath);
     newpath = SYSCALLS.getStr(newpath);
@@ -1260,24 +1260,24 @@ var SyscallsLibrary = {
     return -{{{ cDefine('EMLINK') }}}; // no hardlinks for us
   },
   __sys_symlinkat: function(target, newdirfd, linkpath) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     linkpath = SYSCALLS.calculateAt(newdirfd, linkpath);
     FS.symlink(target, linkpath);
     return 0;
   },
   __sys_readlinkat: function(dirfd, path, buf, bufsize) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     return SYSCALLS.doReadlink(path, buf, bufsize);
   },
   __sys_fchmodat: function(dirfd, path, mode, varargs) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
@@ -1285,8 +1285,8 @@ var SyscallsLibrary = {
     return 0;
   },
   __sys_faccessat: function(dirfd, path, amode, flags) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall');
 #endif
     path = SYSCALLS.getStr(path);
 #if ASSERTIONS
@@ -1322,8 +1322,8 @@ var SyscallsLibrary = {
     return 0;
   },
   __sys_dup3: function(fd, suggestFD, flags) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall: dup3');
+#if TRACING
+    trace('SYSCALL', 'warning: untested syscall: dup3');
 #endif
     var old = SYSCALLS.getStreamFromFD(fd);
 #if ASSERTIONS
@@ -1376,7 +1376,7 @@ function wrapSyscallFunction(x, library, isWasi) {
     pre += 'SYSCALLS.varargs = varargs;\n';
   }
 
-#if SYSCALL_DEBUG
+#if TRACING
   if (isVariadic) {
     if (canThrow) {
       post += 'finally { SYSCALLS.varargs = undefined; }\n';
@@ -1384,14 +1384,14 @@ function wrapSyscallFunction(x, library, isWasi) {
       post += 'SYSCALLS.varargs = undefined;\n';
     }
   }
-  pre += "err('syscall! " + x + ": [' + Array.prototype.slice.call(arguments) + ']');\n";
+  pre += "trace('SYSCALL', '" + x + ": [' + Array.prototype.slice.call(arguments) + ']');\n";
   pre += "var canWarn = true;\n";
   pre += "var ret = (function() {\n";
   post += "})();\n";
   post += "if (ret < 0 && canWarn) {\n";
-  post += "  err('error: syscall may have failed with ' + (-ret) + ' (' + ERRNO_MESSAGES[-ret] + ')');\n";
+  post += "  trace('SYSCALL', 'error: syscall may have failed with ' + (-ret) + ' (' + ERRNO_MESSAGES[-ret] + ')');\n";
   post += "}\n";
-  post += "err('syscall return: ' + ret);\n";
+  post += "trace('SYSCALL', 'syscall return: ' + ret);\n";
   post += "return ret;\n";
 #endif
   delete library[x + '__nothrow'];
@@ -1401,9 +1401,9 @@ function wrapSyscallFunction(x, library, isWasi) {
     handler +=
     "} catch (e) {\n" +
     "  if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) abort(e);\n";
-#if SYSCALL_DEBUG
+#if TRACING
     handler +=
-    "  err('error: syscall failed with ' + e.errno + ' (' + ERRNO_MESSAGES[e.errno] + ')');\n" +
+    "  trace('SYSCALL', 'error: syscall failed with ' + e.errno + ' (' + ERRNO_MESSAGES[e.errno] + ')');\n" +
     "  canWarn = false;\n";
 #endif
     // Musl syscalls are negated.

--- a/src/library_websocket.js
+++ b/src/library_websocket.js
@@ -16,8 +16,8 @@ var LibraryWebSocket = {
   emscripten_websocket_get_ready_state: function(socketId, readyState) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_get_ready_state(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_get_ready_state(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -32,8 +32,8 @@ var LibraryWebSocket = {
   emscripten_websocket_get_buffered_amount: function(socketId, bufferedAmount) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_get_buffered_amount(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_get_buffered_amount(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -48,8 +48,8 @@ var LibraryWebSocket = {
   emscripten_websocket_get_extensions: function(socketId, extensions, extensionsLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_get_extensions(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_get_extensions(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -64,8 +64,8 @@ var LibraryWebSocket = {
   emscripten_websocket_get_extensions_length: function(socketId, extensionsLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_get_extensions_length(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_get_extensions_length(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -80,8 +80,8 @@ var LibraryWebSocket = {
   emscripten_websocket_get_protocol: function(socketId, protocol, protocolLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_get_protocol(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_get_protocol(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -96,8 +96,8 @@ var LibraryWebSocket = {
   emscripten_websocket_get_protocol_length: function(socketId, protocolLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_get_protocol_length(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_get_protocol_length(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -112,8 +112,8 @@ var LibraryWebSocket = {
   emscripten_websocket_get_url: function(socketId, url, urlLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_get_url(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_get_url(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -128,8 +128,8 @@ var LibraryWebSocket = {
   emscripten_websocket_get_url_length: function(socketId, urlLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_get_url_length(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_get_url_length(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
@@ -150,18 +150,18 @@ var LibraryWebSocket = {
 
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_set_onopen_callback(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_set_onopen_callback(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_set_onopen_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_set_onopen_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
 #endif
     socket.onopen = function(e) {
-#if WEBSOCKET_DEBUG
-      err('websocket event "open": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#if TRACING
+      trace('WEBSOCKET', 'websocket event "open": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
 #endif
       HEAPU32[WS.socketEvent>>2] = socketId;
       {{{ makeDynCall('iiii', 'callbackFunc') }}}(0/*TODO*/, WS.socketEvent, userData);
@@ -177,18 +177,18 @@ var LibraryWebSocket = {
 
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_set_onerror_callback(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_set_onerror_callback(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_set_onerror_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_set_onerror_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
 #endif
     socket.onerror = function(e) {
-#if WEBSOCKET_DEBUG
-      err('websocket event "error": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#if TRACING
+      trace('WEBSOCKET', 'websocket event "error": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
 #endif
       HEAPU32[WS.socketEvent>>2] = socketId;
       {{{ makeDynCall('iiii', 'callbackFunc') }}}(0/*TODO*/, WS.socketEvent, userData);
@@ -204,18 +204,18 @@ var LibraryWebSocket = {
 
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_set_onclose_callback(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_set_onclose_callback(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_set_onclose_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_set_onclose_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
 #endif
     socket.onclose = function(e) {
-#if WEBSOCKET_DEBUG
-      err('websocket event "close": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#if TRACING
+      trace('WEBSOCKET', 'websocket event "close": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
 #endif
       HEAPU32[WS.socketEvent>>2] = socketId;
       HEAPU32[(WS.socketEvent+4)>>2] = e.wasClean;
@@ -234,34 +234,34 @@ var LibraryWebSocket = {
 
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_set_onmessage_callback(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_set_onmessage_callback(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_set_onmessage_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_set_onmessage_callback(socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
 #endif
     socket.onmessage = function(e) {
-#if WEBSOCKET_DEBUG == 2
-      err('websocket event "message": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
+#if TRACING == 2
+      trace('WEBSOCKET', 'websocket event "message": socketId='+socketId+',userData='+userData+',callbackFunc='+callbackFunc+')');
 #endif
       HEAPU32[WS.socketEvent>>2] = socketId;
       if (typeof e.data === 'string') {
         var len = lengthBytesUTF8(e.data)+1;
         var buf = _malloc(len);
         stringToUTF8(e.data, buf, len);
-#if WEBSOCKET_DEBUG
+#if TRACING
         var s = (e.data.length < 256) ? e.data : (e.data.substr(0, 256) + ' (' + (e.data.length-256) + ' more characters)');
-        err('WebSocket onmessage, received data: "' + e.data + '", ' + e.data.length + ' chars, ' + len + ' bytes encoded as UTF-8: "' + s + '"');
+        trace('WEBSOCKET', 'WebSocket onmessage, received data: "' + e.data + '", ' + e.data.length + ' chars, ' + len + ' bytes encoded as UTF-8: "' + s + '"');
 #endif
         HEAPU32[(WS.socketEvent+12)>>2] = 1; // text data
       } else {
         var len = e.data.byteLength;
         var buf = _malloc(len);
         HEAP8.set(new Uint8Array(e.data), buf);
-#if WEBSOCKET_DEBUG
+#if TRACING
         var s = 'WebSocket onmessage, received data: ' + len + ' bytes of binary:';
         for (var i = 0; i < Math.min(len, 256); ++i) s += ' ' + HEAPU8[buf+i].toString(16);
         s += ', "';
@@ -269,7 +269,7 @@ var LibraryWebSocket = {
         s += '"';
         if (len > 256) s + ' ... (' + (len - 256) + ' more bytes)';
 
-        err(s);
+        trace('WEBSOCKET', s);
 #endif
         HEAPU32[(WS.socketEvent+12)>>2] = 0; // binary data
       }
@@ -286,14 +286,14 @@ var LibraryWebSocket = {
   emscripten_websocket_new__sig: 'ii',
   emscripten_websocket_new: function(createAttributes) {
     if (typeof WebSocket === 'undefined') {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_new(): WebSocket API is not supported by current browser)');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_new(): WebSocket API is not supported by current browser)');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_NOT_SUPPORTED') }}};
     }
     if (!createAttributes) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_new(): Missing required "createAttributes" function parameter!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_new(): Missing required "createAttributes" function parameter!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_PARAM') }}};
     }
@@ -311,8 +311,8 @@ var LibraryWebSocket = {
     var socketId = WS.sockets.length;
     WS.sockets[socketId] = socket;
 
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_new(url='+url+', protocols=' + (protocols?UTF8ToString(protocols).split(','):'null') + '): created socket ID ' + socketId + ')');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_new(url='+url+', protocols=' + (protocols?UTF8ToString(protocols).split(','):'null') + '): created socket ID ' + socketId + ')');
 #endif
     return socketId;
   },
@@ -323,18 +323,18 @@ var LibraryWebSocket = {
   emscripten_websocket_send_utf8_text: function(socketId, textData) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_send_utf8_text(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_send_utf8_text(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
     var str = UTF8ToString(textData);
-#if WEBSOCKET_DEBUG == 2
-    err('emscripten_websocket_send_utf8_text(socketId='+socketId+',textData='+ str.length + ' chars, "' + str +'")');
+#if TRACING == 2
+    trace('WEBSOCKET', 'emscripten_websocket_send_utf8_text(socketId='+socketId+',textData='+ str.length + ' chars, "' + str +'")');
 #else
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_send_utf8_text(socketId='+socketId+',textData='+ str.length + ' chars, "' + ((str.length > 8) ? (str.substring(0,8) + '...') : str) + '")');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_send_utf8_text(socketId='+socketId+',textData='+ str.length + ' chars, "' + ((str.length > 8) ? (str.substring(0,8) + '...') : str) + '")');
 #endif
 #endif
     socket.send(str);
@@ -347,13 +347,13 @@ var LibraryWebSocket = {
   emscripten_websocket_send_binary: function(socketId, binaryData, dataLength) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_send_binary(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_send_binary(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
-#if WEBSOCKET_DEBUG
+#if TRACING
     var s = 'data: ' + dataLength + ' bytes of binary:';
     for (var i = 0; i < Math.min(dataLength, 256); ++i) s += ' '+ HEAPU8[binaryData+i].toString(16);
     s += ', "';
@@ -361,7 +361,7 @@ var LibraryWebSocket = {
     s += '"';
     if (dataLength > 256) s + ' ... (' + (dataLength - 256) + ' more bytes)';
 
-    err('emscripten_websocket_send_binary(socketId='+socketId+',binaryData='+binaryData+ ',dataLength='+dataLength+'), ' + s);
+    trace('WEBSOCKET', 'emscripten_websocket_send_binary(socketId='+socketId+',binaryData='+binaryData+ ',dataLength='+dataLength+'), ' + s);
 #endif
 #if USE_PTHREADS
     // TODO: This is temporary to cast a shared Uint8Array to a non-shared Uint8Array. This could be removed if WebSocket API is improved
@@ -379,15 +379,15 @@ var LibraryWebSocket = {
   emscripten_websocket_close: function(socketId, code, reason) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_close(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_close(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
     var reasonStr = reason ? UTF8ToString(reason) : undefined;
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_close(socketId='+socketId+',code='+code+',reason='+reasonStr+')');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_close(socketId='+socketId+',code='+code+',reason='+reasonStr+')');
 #endif
     // According to WebSocket specification, only close codes that are recognized have integer values
     // 1000-4999, with 3000-3999 and 4000-4999 denoting user-specified close codes:
@@ -406,14 +406,14 @@ var LibraryWebSocket = {
   emscripten_websocket_delete: function(socketId) {
     var socket = WS.sockets[socketId];
     if (!socket) {
-#if WEBSOCKET_DEBUG
-      err('emscripten_websocket_delete(): Invalid socket ID ' + socketId + ' specified!');
+#if TRACING
+      trace('WEBSOCKET', 'emscripten_websocket_delete(): Invalid socket ID ' + socketId + ' specified!');
 #endif
       return {{{ cDefine('EMSCRIPTEN_RESULT_INVALID_TARGET') }}};
     }
 
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_delete(socketId='+socketId+')');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_delete(socketId='+socketId+')');
 #endif
     socket.onopen = socket.onerror = socket.onclose = socket.onmessage = null;
     delete WS.sockets[socket];
@@ -431,8 +431,8 @@ var LibraryWebSocket = {
   emscripten_websocket_deinitialize__sig: 'v',
   emscripten_websocket_deinitialize__deps: ['emscripten_websocket_delete'],
   emscripten_websocket_deinitialize: function() {
-#if WEBSOCKET_DEBUG
-    err('emscripten_websocket_deinitialize()');
+#if TRACING
+    trace('WEBSOCKET', 'emscripten_websocket_deinitialize()');
 #endif
     for (var i in WS.sockets) {
       var socket = WS.sockets[i];

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -233,7 +233,7 @@ function run(args) {
 
   if (runDependencies > 0) {
 #if RUNTIME_LOGGING
-    err('run() called, but dependencies remain, so not running');
+    trace('RUNTIME', 'run() called, but dependencies remain, so not running');
 #endif
     return;
   }
@@ -256,7 +256,7 @@ function run(args) {
     // Loading dylibs can add run dependencies.
     if (runDependencies > 0) {
 #if RUNTIME_LOGGING
-      err('preloadDylibs added run() dependencies, not running yet');
+      trace('RUNTIME', 'preloadDylibs added run() dependencies, not running yet');
 #endif
       return;
     }
@@ -282,7 +282,7 @@ function run(args) {
   // a preRun added a dependency, run will be called later
   if (runDependencies > 0) {
 #if RUNTIME_LOGGING
-    err('run() called, but dependencies remain, so not running');
+    trace('RUNTIME', 'run() called, but dependencies remain, so not running');
 #endif
     return;
   }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -378,8 +378,8 @@ function initRuntime() {
 #endif
 
 #if STACK_OVERFLOW_CHECK >= 2
-#if RUNTIME_LOGGING
-  err('__set_stack_limits: ' + _emscripten_stack_get_base() + ', ' + _emscripten_stack_get_end());
+#if TRACING
+  trace('RUNTIME', '__set_stack_limits: ' + _emscripten_stack_get_base() + ', ' + _emscripten_stack_get_end());
 #endif
   ___set_stack_limits(_emscripten_stack_get_base(), _emscripten_stack_get_end());
 #endif
@@ -873,8 +873,8 @@ function instantiateSync(file, info) {
       if (!nodeFS) nodeFS = require('fs');
       var hasCached = nodeFS.existsSync(cachedCodeFile);
       if (hasCached) {
-#if RUNTIME_LOGGING
-        err('NODE_CODE_CACHING: loading module');
+#if TRACING
+        trace('RUNTIME', 'NODE_CODE_CACHING: loading module');
 #endif
         try {
           module = v8.deserialize(nodeFS.readFileSync(cachedCodeFile));
@@ -889,8 +889,8 @@ function instantiateSync(file, info) {
       module = new WebAssembly.Module(binary);
     }
     if (ENVIRONMENT_IS_NODE && !hasCached) {
-#if RUNTIME_LOGGING
-      err('NODE_CODE_CACHING: saving module');
+#if TRACING
+      trace('RUNTIME', 'NODE_CODE_CACHING: saving module');
 #endif
       nodeFS.writeFileSync(cachedCodeFile, v8.serialize(module));
     }
@@ -1223,8 +1223,8 @@ function createWasm() {
   }
 
 #if WASM_ASYNC_COMPILATION
-#if RUNTIME_LOGGING
-  err('asynchronously preparing wasm');
+#if TRACING
+  trace('RUNTIME', 'asynchronously preparing wasm');
 #endif
 #if MODULARIZE
   // If instantiation fails, reject the module ready promise.

--- a/src/runtime_debug.js
+++ b/src/runtime_debug.js
@@ -4,9 +4,103 @@
  * SPDX-License-Identifier: MIT
  */
 
-#if RUNTIME_DEBUG
-var runtimeDebug = true; // Switch to false at runtime to disable logging at the right times
+#if TRACING
+var trace_channels = {
+  'RUNTIME': 1,
+  'EXCEPTION': 1,
+  'LIBRARY': 1,
+  'SYSCALL': 1,
+  'SOCKET': 1,
+  'DYLINK': 1,
+  'FS': 1,
+  'OPENAL': 1,
+  'WEBSOCKET': 1,
+  'GL': 1,
+  'ASYNCIFY': 1,
+  'PTHREADS': 1,
+  'FETCH': 1,
+};
 
+var trace_channels_enabled = {
+  // The core RUNTIME channel is the only one that is
+  // enabled by default.
+  'RUNTIME': true,
+#if EXCEPTION_DEBUG
+  'EXCEPTION': true,
+#endif
+#if LIBRARY_DEBUG
+  'LIBRARY': true,
+#endif
+#if SYSCALL_DEBUG
+  'SYSCALL': true,
+#endif
+#if SOCKET_DEBUG
+  'SOCKET': true,
+#endif
+#if DYLINK_DEBUG
+  'DYLINK': true,
+#endif
+#if FS_DEBUG
+  'FS': true,
+#endif
+#if OPENAL_DEBUG
+  'OPENAL': true,
+#endif
+#if WEBSOCKET_DEBUG
+  'WEBSOCKET_DEBUG': true,
+#endif
+#if GL_DEBUG
+  'GL': true,
+#endif
+#if ASYNCIFY_DEBUG
+  'ASYNCIFY': true;
+#endif
+#if PTHREADS_DEBUG
+  'PTHREADS': true,
+#endif
+#if FETCH_DEBUG
+  'FETCH': true,
+#endif
+};
+
+function enable_trace_channel(channel) {
+#if ASSERTIONS
+  assert(channel in trace_channels, 'unknown trace channel: ' + channel);
+#endif
+  err('enabling trace channel: ' + channel);
+  trace_channels_enabled[channel] = true;
+}
+
+function trace_channel_enabled(channel) {
+  return trace_channels_enabled[channel] === true;
+}
+
+function trace(channel, msg) {
+#if ASSERTIONS
+  assert(channel in trace_channels, 'unknown trace channel: ' + channel);
+#endif
+  if (trace_channels_enabled[channel]) {
+    err(channel + ': ' + msg);
+  }
+}
+
+#if ENVIRONMENT_MAY_BE_NODE
+if (ENVIRONMENT_IS_NODE && process.env['EM_DEBUG']) {
+  if (process.env['EM_DEBUG'] == 'all') {
+    for (var channel in trace_channels) {
+      trace_channels_enabled[channel] = true;
+    }
+  } else {
+    var channels = process.env['EM_DEBUG'].split(',');
+    for (var i in channels) {
+      enable_trace_channel(channels[i].toUpperCase());
+    }
+  }
+}
+#endif
+#endif
+
+#if LIBRARY_DEBUG
 var printObjectList = [];
 
 function prettyPrint(arg) {

--- a/src/settings.js
+++ b/src/settings.js
@@ -65,6 +65,8 @@ var ASSERTIONS = 1;
 // [link]
 var RUNTIME_LOGGING = 0;
 
+var TRACING = 0;
+
 // Chooses what kind of stack smash checks to emit to generated code:
 // Building with ASSERTIONS=1 causes STACK_OVERFLOW_CHECK default to 1.
 // Since ASSERTIONS=1 is the default at -O0, which itself is the default

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10297,7 +10297,7 @@ exec "$@"
 
   def test_SYSCALL_DEBUG(self):
     self.set_setting('SYSCALL_DEBUG')
-    self.do_runf(test_file('hello_world.c'), 'syscall! fd_write: [1,')
+    self.do_runf(test_file('hello_world.c'), 'SYSCALL: fd_write: [1,')
 
   def test_LIBRARY_DEBUG(self):
     self.set_setting('LIBRARY_DEBUG')


### PR DESCRIPTION
This system is designed to replace all the existing compile time DEBUG   
settings (SYSCALL_DEBUG, GL_DEBUG, FS_DEBUG, etc) with a system where       
the channels can be enabled/disabled at runtime.                            
                                                                            
The old settings till work and enable the respective channel at startup. 
                                                                            
Under node channels can be enabled by running with EM_DEBUG set in the   
environment.  This is a comma separated list of channel names.     

Fixes: #15057