### PR TITLE
Unix entry points: correctly detect the availability of a python binary

### DIFF
--- a/em++
+++ b/em++
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/em-config
+++ b/em-config
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emar
+++ b/emar
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/embuilder
+++ b/embuilder
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emcc
+++ b/emcc
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emcmake
+++ b/emcmake
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emconfigure
+++ b/emconfigure
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emdump
+++ b/emdump
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emdwp
+++ b/emdwp
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emmake
+++ b/emmake
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emnm
+++ b/emnm
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emprofile
+++ b/emprofile
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emranlib
+++ b/emranlib
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emrun
+++ b/emrun
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emscons
+++ b/emscons
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/emsize
+++ b/emsize
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/tests/runner
+++ b/tests/runner
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/tools/file_packager
+++ b/tools/file_packager
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/tools/run_python.sh
+++ b/tools/run_python.sh
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/tools/run_python_compiler.sh
+++ b/tools/run_python_compiler.sh
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then

--- a/tools/webidl_binder
+++ b/tools/webidl_binder
@@ -16,11 +16,11 @@ if [ -z "$PYTHON" ]; then
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python3 2> /dev/null)
+  PYTHON=$(command -v python3 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then
-  PYTHON=$(which python 2> /dev/null)
+  PYTHON=$(command -v python 2> /dev/null)
 fi
 
 if [ -z "$PYTHON" ]; then


### PR DESCRIPTION
The "which" program is not suitable for determining the existence or location of a python binary, because it is a non-standard program that is often not installed. It is often possible to manually install it as a third-party addon anyway, but this is a very bad thing to rely on in order to get good out of the box behavior.

If and when it is installed, it may display various incorrect behaviors, including unparseable output on stdout instead of stderr, outputting the contents of ~/.cshrc aliases, and more.

For more details on why never to use "which", see:

https://mywiki.wooledge.org/BashFAQ/081
https://unix.stackexchange.com/questions/85249/why-not-use-which-what-to-use-then/85250#85250

Instead, use the POSIX 2008 mandated builtin "command -v" implemented by all valid /bin/sh implementations, including ash, bash, busybox sh, dash, ksh, mksh, and zsh.

"command -v" has an actual standards body guaranteeing the format of the output, and that it is usable as a filesystem path to an executable, for all shells produced in the last 13 years. It is thus unlikely to break in the same way "which" does.