### PR TITLE
Remove welcome message bot

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,4 +1,0 @@
-# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
-newPRWelcomeComment: >
-  Thank you for submitting a pull request!
-  Someone will be along to review it shortly.


### PR DESCRIPTION
The bot used to be very important while we required people to add
themselves to AUTHORS - it was a useful reminder for that. But we've
removed that requirement. Now the bot just says a friendly message,
but we've gotten negative feedback on that,

https://github.com/emscripten-core/emscripten/pull/15071#issuecomment-922603298

I think I agree that a content-less message like that kind of sends an
unclear signal, as the normal expectation is to get someone to review it.
That is, the bot message sounds defensive. Let's just remove it.