### PR TITLE
Keep runtime alive while async ccall is running

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -130,10 +130,14 @@ function ccall(ident, returnType, argTypes, args, opts) {
   }
   var ret = func.apply(null, cArgs);
   function onDone(ret) {
+#if ASYNCIFY
+    runtimeKeepalivePop();
+#endif
     if (stack !== 0) stackRestore(stack);
     return convertReturnValue(ret);
   }
 #if ASYNCIFY
+  runtimeKeepalivePush();
   var asyncMode = opts && opts.async;
   // Check if we started an async operation just now.
   if (Asyncify.currData) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7447,11 +7447,15 @@ Module['onRuntimeInitialized'] = function() {
     self.emcc_args += ['--pre-js', 'pre.js']
     self.do_runf('main.c', 'HelloWorld')
 
-  def test_async_ccall_promise(self):
-    print('check ccall promise')
+  @parameterized({
+    '': (False,),
+    'exit_runtime': (True,),
+  })
+  def test_async_ccall_promise(self, exit_runtime):
     self.set_setting('ASYNCIFY')
     self.set_setting('ASSERTIONS')
     self.set_setting('INVOKE_RUN', 0)
+    self.set_setting('EXIT_RUNTIME', exit_runtime)
     self.set_setting('EXPORTED_FUNCTIONS', ['_stringf', '_floatf'])
     create_file('main.c', r'''
 #include <stdio.h>


### PR DESCRIPTION
Without this, when EXIT_RUNTIME is set, the runtime will exit when when we return the event loop.