### PR TITLE
Remove an assertion with touch events

### DIFF
--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2051,30 +2051,27 @@ var LibraryJSEvents = {
 #if ASSERTIONS
       assert(e);
 #endif
-      var touches = {};
-      var et = e.touches;
+      var t, touches = {}, et = e.touches;
+      // To ease marshalling different kinds of touches that browser reports (all touches are listed in e.touches, 
+      // only changed touches in e.changedTouches, and touches on target at a.targetTouches), mark a boolean in
+      // each Touch object so that we can later loop only once over all touches we see to marshall over to Wasm.
+
       for (var i = 0; i < et.length; ++i) {
-        var touch = et[i];
-#if ASSERTIONS
-        // Verify that browser does not recycle touch objects with old stale data, but reports new ones each time.
-        assert(!touch.isChanged);
-        assert(!touch.onTarget);
-#endif
-        touches[touch.identifier] = touch;
+        t = et[i];
+        // Browser might recycle the generated Touch objects between each frame (Firefox on Android), so reset any
+        // changed/target states we may have set from previous frame.
+        t.isChanged = t.onTarget = 0;
+        touches[t.identifier] = t;
       }
-      et = e.changedTouches;
-      for (var i = 0; i < et.length; ++i) {
-        var touch = et[i];
-#if ASSERTIONS
-        // Verify that browser does not recycle touch objects with old stale data, but reports new ones each time.
-        assert(!touch.onTarget);
-#endif
-        touch.isChanged = 1;
-        touches[touch.identifier] = touch;
+      // Mark which touches are part of the changedTouches list.
+      for (var i = 0; i < e.changedTouches.length; ++i) {
+        t = e.changedTouches[i];
+        t.isChanged = 1;
+        touches[t.identifier] = t;
       }
-      et = e.targetTouches;
-      for (var i = 0; i < et.length; ++i) {
-        touches[et[i].identifier].onTarget = 1;
+      // Mark which touches are part of the targetTouches list.
+      for (var i = 0; i < e.targetTouches.length; ++i) {
+        touches[e.targetTouches[i].identifier].onTarget = 1;
       }
 
 #if USE_PTHREADS


### PR DESCRIPTION
Remove the assertion with touch events that assumes that browser would create new Touch event objects for each generated touch event. This does not hold at least for Firefox for Android. Instead use a different changed/onTarget tracking method that does not assume .isChanged and .onTarget would go away on each event, but instead reset the fields in each event.
