### PR TITLE
[asan] Use standard POSIX code for AsanTSD (thread-specific data) han…

### DIFF
--- a/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
@@ -35,22 +35,6 @@ void InitializeAsanInterceptors() {}
 
 void FlushUnneededASanShadowMemory(uptr p, uptr size) {}
 
-// We can use a plain thread_local variable for TSD.
-static thread_local void *per_thread;
-
-void *AsanTSDGet() { return per_thread; }
-
-void AsanTSDSet(void *tsd) { per_thread = tsd; }
-
-// There's no initialization needed, and the passed-in destructor
-// will never be called.  Instead, our own thread destruction hook
-// (below) will call AsanThread::TSDDtor directly.
-void AsanTSDInit(void (*destructor)(void *tsd)) {
-  DCHECK(destructor == &PlatformTSDDtor);
-}
-
-void PlatformTSDDtor(void *tsd) { UNREACHABLE(__func__); }
-
 extern "C" {
   void *emscripten_builtin_malloc(size_t size);
   void emscripten_builtin_free(void *memory);

--- a/system/lib/compiler-rt/lib/asan/asan_posix.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_posix.cpp
@@ -115,7 +115,7 @@ void PlatformTSDDtor(void *tsd) {
   atomic_signal_fence(memory_order_seq_cst);
   AsanThread::TSDDtor(tsd);
 }
-#elif !SANITIZER_EMSCRIPTEN
+#else
 static pthread_key_t tsd_key;
 static bool tsd_key_inited = false;
 void AsanTSDInit(void (*destructor)(void *tsd)) {


### PR DESCRIPTION
…dling

As well use being less code to maintain and more shared code this also
enables thread exit handling which means ASan now tracks thread exit
where it didn't before.  With the old/existing code noone was ever
calling the ASan thread destructor (passed as arg0 to AsanTSDInit).

I imagine this approach might not have been possible in the past since
there were some issues with using pthread_keys with destructors (e.g. #15086).

Testing by running entire `asan` test suite.