### PR TITLE
Restore mistaken lsan change from upstream. NFC.

### DIFF
--- a/system/lib/compiler-rt/lib/lsan/lsan_interceptors.cpp
+++ b/system/lib/compiler-rt/lib/lsan/lsan_interceptors.cpp
@@ -532,7 +532,8 @@ namespace __lsan {
 
 void InitializeInterceptors() {
   // Fuchsia doesn't use interceptors that require any setup.
-#if !SANITIZER_FUCHSIA && !SANITIZER_EMSCRIPTEN
+#if !SANITIZER_FUCHSIA
+#if !SANITIZER_EMSCRIPTEN
   InitializeSignalInterceptors();
 
   INTERCEPT_FUNCTION(malloc);
@@ -562,7 +563,7 @@ void InitializeInterceptors() {
   LSAN_MAYBE_INTERCEPT_PTHREAD_ATFORK;
 
   LSAN_MAYBE_INTERCEPT_STRERROR;
-#endif  // !SANITIZER_FUCHSIA && !SANITIZER_EMSCRIPTEN
+#endif  // !SANITIZER_EMSCRIPTEN
 
 #if !SANITIZER_NETBSD && !SANITIZER_FREEBSD
   if (pthread_key_create(&g_thread_finalize_key, &thread_finalize)) {
@@ -570,6 +571,8 @@ void InitializeInterceptors() {
     Die();
   }
 #endif
+
+#endif  // !SANITIZER_FUCHSIA
 }
 
 } // namespace __lsan


### PR DESCRIPTION
In #15086 the intent was to enable `g_thread_finalize_key` under
emscripten but I unwittingly modified the ifdef region used by
fuchsia is well.