### PR TITLE
Add `__noleakcheck` library attribute

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -121,7 +121,8 @@ function isJsLibraryConfigIdentifier(ident) {
     '__docs',
     '__import',
     '__nothrow',
-    '__unimplemented'
+    '__unimplemented',
+    '__noleakcheck',
   ];
   return suffixes.some((suffix) => ident.endsWith(suffix));
 }


### PR DESCRIPTION
This library function attribute signals that the function should be
wrapped in `withBuiltinMalloc` but is a no-op for non-sanitizer builds.

This is small win for code side when sanitizers are not enabled and
it enables entire functions to be easily wrapped without creating
extra lambdas/indentation in the code.

I was looking into wrapping `__pthread_create_js` and was wanting
something like this that would be minimally intrusive.