### PR TITLE
Mark pthread create/free functions as `__noleakcheck`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,7 +369,7 @@ jobs:
     steps:
       - run-tests:
           # also add a few asan tests
-          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking"
+          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create"
   test-wasm3:
     executor: bionic
     steps:


### PR DESCRIPTION
We were trying to do this in `library_pthread.c` but this
file (and the whole of libc) is not compiled specifically for
lsan like it is for msan so in lsan builds that codepath was
not being compiled it.

Instead use JS-side mitigation which is to use `__noleakcheck`.