### PR TITLE
Add a `failfast` command-line option to `runner.py`

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -272,7 +272,7 @@ def run_tests(options, suites):
   print('Test suites:')
   print([s[0] for s in suites])
   # Run the discovered tests
-  testRunner = unittest.TextTestRunner(verbosity=2)
+  testRunner = unittest.TextTestRunner(verbosity=2, failfast=options.failfast)
   for mod_name, suite in suites:
     print('Running %s: (%s tests)' % (mod_name, suite.countTestCases()))
     res = testRunner.run(suite)
@@ -310,6 +310,8 @@ def parse_args(args):
   parser.add_argument('--browser',
                       help='Command to launch web browser in which to run browser tests.')
   parser.add_argument('tests', nargs='*')
+  parser.add_argument('--failfast', dest='failfast', action='store_const',
+                      const=True, default=False)
   return parser.parse_args()
 
 


### PR DESCRIPTION
This is functionality already exposed by `TextTestRunner`.