### PR TITLE
WebGPU: fixes for SetVertexBuffer/SetIndexBuffer, WriteTexture

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -43,18 +43,15 @@
     makeU64ToNumber: function(lowName, highName) {
       var ret = '(';
       if (ASSERTIONS) {
-        ret += 'assert(' + highName + ' < 0x200000), ';
+        ret += `assert(${highName} < 0x200000), `;
       }
-      ret += highName + ' * 0x100000000 + ' + lowName + ')\n'
+      ret += `${highName} * 0x100000000 + ${lowName})\n`;
       return ret;
     },
 
     makeU64ToNumberWithSentinelAsUndefined: function(lowName, highName) {
-      var ret = '((' + highName + ' === 0xFFFFFFFF && ' + lowName + ' === 0xFFFFFFFF) ? undefined : (';
-      if (ASSERTIONS) {
-        ret += 'assert(' + highName + ' < 0x200000), ';
-      }
-      ret += highName + ' * 0x100000000 + ' + lowName + '))\n'
+      var ret = `((${highName} === 0xFFFFFFFF && ${lowName} === 0xFFFFFFFF) ? undefined : \
+          ${this.makeU64ToNumber(lowName, highName)})`;
       return ret;
     },
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1365,16 +1365,16 @@ var LibraryWebGPU = {
   },
 
   wgpuQueueWriteTexture: function(queueId,
-      destinationPtr, data, _dataSize, dataLayoutPtr, writeSizePtr) {
+      destinationPtr, data, dataSize, dataLayoutPtr, writeSizePtr) {
     var queue = WebGPU.mgrQueue.get(queueId);
 
     var destination = WebGPU.makeImageCopyTexture(destinationPtr);
     var dataLayout = WebGPU.makeTextureDataLayout(dataLayoutPtr);
-    // TODO(crbug.com/1134457): pass a subarray to work around Chrome bug? (complicated because this
-    // requires computing requiredBytesInCopy which needs the block/byte sizes of every texture format)
-    dataLayout["offset"] += data;
     var writeSize = WebGPU.makeExtent3D(writeSizePtr);
-    queue["writeTexture"](destination, HEAPU8, dataLayout, writeSize);
+    // This subarray isn't strictly necessary, but helps work around an issue
+    // where Chromium makes a copy of the entire heap. crbug.com/1134457
+    var subarray = HEAPU8.subarray(data, data + dataSize);
+    queue["writeTexture"](destination, subarray, dataLayout, writeSize);
   },
 
   // wgpuCommandEncoder

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1949,12 +1949,14 @@ var LibraryWebGPU = {
     pass["drawIndexed"](indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
   },
   wgpuRenderBundleEncoderDrawIndirect: function(bundleId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
+    {{{ receiveI64ParamAsI32s('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
     var indirectOffset = {{{ gpu.makeU64ToNumber('indirectOffset_low', 'indirectOffset_high') }}};
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);
     pass["drawIndirect"](indirectBuffer, indirectOffset);
   },
   wgpuRenderBundleEncoderDrawIndexedIndirect: function(bundleId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
+    {{{ receiveI64ParamAsI32s('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
     var indirectOffset = {{{ gpu.makeU64ToNumber('indirectOffset_low', 'indirectOffset_high') }}};
     var pass = WebGPU.mgrRenderBundleEncoder.get(bundleId);

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -50,7 +50,7 @@
     },
 
     makeU64ToNumberWithSentinelAsUndefined: function(lowName, highName) {
-      var ret = '((' highName + ' === 0xFFFFFFFF && ' + lowName ' === 0xFFFFFFFF) ? undefined : (';
+      var ret = '((' + highName + ' === 0xFFFFFFFF && ' + lowName + ' === 0xFFFFFFFF) ? undefined : (';
       if (ASSERTIONS) {
         ret += 'assert(' + highName + ' < 0x200000), ';
       }


### PR DESCRIPTION
- Create a subarray in WriteTexture to work around Chromium bug.
- SetVertexBuffer/SetIndexBuffer should accept WGPU_WHOLE_SIZE for the size, but we need to translate it to undefined.
- Fix numerous bugs in the 64-bit arguments to SetIndexBuffer/SetVertexBuffer (and DrawIndirect/DrawIndexedIndirect).