### PR TITLE
Avoid duplication on abort()/exception

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -443,11 +443,17 @@ LibraryManager.library = {
   __cxa_atexit: 'atexit',
 #endif
 
-  // TODO: There are currently two abort() functions that get imported to asm module scope: the built-in runtime function abort(),
-  // and this function _abort(). Remove one of these, importing two functions for the same purpose is wasteful.
+  // TODO: There are currently two abort() functions that get imported to asm
+  // module scope: the built-in runtime function abort(), and this library
+  // function _abort(). Remove one of these, importing two functions for the
+  // same purpose is wasteful.
   abort__sig: 'v',
   abort: function() {
-    abort();
+#if ASSERTIONS
+    abort('native code called abort()');
+#else
+    abort('');
+#endif
   },
 
   // This object can be modified by the user during startup, which affects
@@ -3604,14 +3610,6 @@ LibraryManager.library = {
     if (e instanceof ExitStatus || e == 'unwind') {
       return EXITSTATUS;
     }
-    // Anything else is an unexpected exception and we treat it as hard error.
-    var toLog = e;
-#if ASSERTIONS
-    if (e && typeof e === 'object' && e.stack) {
-      toLog = [e, e.stack];
-    }
-#endif
-    err('exception thrown: ' + toLog);
 #if MINIMAL_RUNTIME
     throw e;
 #else

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -593,17 +593,16 @@ function abort(what) {
   }
 #endif
 
-  what += '';
+  what = 'Aborted(' + what + ')';
+  // TODO(sbc): Should we remove printing and leave it up to whoever
+  // catches the exception?
   err(what);
 
   ABORT = true;
   EXITSTATUS = 1;
 
 #if ASSERTIONS == 0
-  what = 'abort(' + what + '). Build with -s ASSERTIONS=1 for more info.';
-#else
-  var output = 'abort(' + what + ') at ' + stackTrace();
-  what = output;
+  what += '. Build with -s ASSERTIONS=1 for more info.';
 #endif // ASSERTIONS
 
   // Use a wasm runtime error, because a JS error might be seen as a foreign

--- a/tests/browser_reporting.js
+++ b/tests/browser_reporting.js
@@ -15,7 +15,10 @@ function reportResultToServer(result, sync, port) {
   }
   xhr.open('GET', 'http://localhost:' + port + '/report_result?' + result, !sync);
   xhr.send();
-  if (typeof window === 'object' && window && hasModule && !Module['pageThrewException'] /* for easy debugging, don't close window on failure */) setTimeout(function() { window.close() }, 1000);
+  if (typeof window === 'object' && window && hasModule && !Module['pageThrewException']) {
+    /* for easy debugging, don't close window on failure */
+    setTimeout(function() { window.close() }, 1000);
+  }
 }
 
 /** @param {boolean=} sync

--- a/tests/core/FS_exports_assert.out
+++ b/tests/core/FS_exports_assert.out
@@ -1,1 +1,1 @@
-You can force-include filesystem support with  -s FORCE_FILESYSTEM=1
+Aborted(Filesystem support (FS) was not included. The problem is that you are using files from JS, but files were not used from C/C++, so filesystem support was not auto-included. You can force-include filesystem support with  -s FORCE_FILESYSTEM=1)

--- a/tests/core/FS_exports_assert_2.out
+++ b/tests/core/FS_exports_assert_2.out
@@ -1,1 +1,1 @@
-was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ). Alternatively, forcing filesystem support (-s FORCE_FILESYSTEM=1) can export this for you
+Aborted('FS_createDataFile' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ). Alternatively, forcing filesystem support (-s FORCE_FILESYSTEM=1) can export this for you)

--- a/tests/core/embind_lib_with_asyncify.test.js
+++ b/tests/core/embind_lib_with_asyncify.test.js
@@ -39,7 +39,7 @@ Module.onRuntimeInitialized = async () => {
       } catch (e) {
         err = e.message;
       }
-      assert(err.startsWith('abort(Assertion failed: Cannot have multiple async operations in flight at once)'), `"${err}" doesn't contain the assertion error`);
+      assert(err.includes('Assertion failed: Cannot have multiple async operations in flight at once)'), `"${err}" doesn't contain the assertion error`);
     }
 
     console.log('ok');

--- a/tests/core/getValue_setValue_assert.out
+++ b/tests/core/getValue_setValue_assert.out
@@ -1,1 +1,1 @@
-'setValue' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ)
+Aborted('setValue' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ))

--- a/tests/core/legacy_exported_runtime_numbers_assert.out
+++ b/tests/core/legacy_exported_runtime_numbers_assert.out
@@ -1,1 +1,1 @@
-'ALLOC_STACK' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ)
+Aborted('ALLOC_STACK' was not exported. add it to EXPORTED_RUNTIME_METHODS (see the FAQ))

--- a/tests/core/test_aborting_new.cpp
+++ b/tests/core/test_aborting_new.cpp
@@ -16,7 +16,7 @@ int main() {
       _allocate_too_much();
       out("no abort happened");
     } catch (e) {
-      assert(("" + e).indexOf("abort") >= 0, "expect an abort from new");
+      assert(("" + e).indexOf("Aborted") >= 0, "expect an abort from new");
       out("new aborted as expected");
     }
   });

--- a/tests/core/test_asyncify_assertions.out
+++ b/tests/core/test_asyncify_assertions.out
@@ -1,1 +1,1 @@
-Assertion failed: Waking up (starting to rewind) must be done from JS, without compiled code on the stack.
+Aborted(Assertion failed: Waking up (starting to rewind) must be done from JS, without compiled code on the stack.)

--- a/tests/core/test_asyncify_during_exit.out
+++ b/tests/core/test_asyncify_during_exit.out
@@ -1,2 +1,2 @@
 during_exit 1
-Assertion failed: Asyncify cannot be done during or after the runtime exits
+Aborted(Assertion failed: Asyncify cannot be done during or after the runtime exits)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2348,8 +2348,8 @@ void *getBindBuffer() {
         doCcall(1);
         ok = true; // should fail and not reach here, runtime is not ready yet so ccall will abort
       } catch(e) {
-        out('expected fail 1');
-        assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
+        out('expected fail 1: ' + e.toString());
+        assert(e.toString().indexOf('Assertion failed') >= 0); // assertion, not something else
         ABORT = false; // hackish
       }
       assert(ok === expected_ok);
@@ -2359,8 +2359,8 @@ void *getBindBuffer() {
         doCwrapCall(2);
         ok = true; // should fail and not reach here, runtime is not ready yet so cwrap call will abort
       } catch(e) {
-        out('expected fail 2');
-        assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
+        out('expected fail 2: ' + e.toString());
+        assert(e.toString().indexOf('Assertion failed') >= 0); // assertion, not something else
         ABORT = false; // hackish
       }
       assert(ok === expected_ok);
@@ -2370,8 +2370,8 @@ void *getBindBuffer() {
         doDirectCall(3);
         ok = true; // should fail and not reach here, runtime is not ready yet so any code execution
       } catch(e) {
-        out('expected fail 3');
-        assert(e.toString().indexOf('assert') >= 0); // assertion, not something else
+        out('expected fail 3:' + e.toString());
+        assert(e.toString().indexOf('Assertion failed') >= 0); // assertion, not something else
         ABORT = false; // hackish
       }
       assert(ok === expected_ok);
@@ -3400,13 +3400,13 @@ window.close = function() {
             reportResultToServer("Module creation succeeded when it should have failed");
           })
           .catch(err => {
-            reportResultToServer(err.message.slice(0, 54));
+            reportResultToServer(err.message);
           });
       </script>
     ''')
     print('Deleting a.out.wasm to cause a download error')
     os.remove('a.out.wasm')
-    self.run_browser('a.html', '...', '/report_result?abort(both async and sync fetching of the wasm failed)')
+    self.run_browser('a.html', '...', '/report_result?Aborted(both async and sync fetching of the wasm failed)')
 
   def test_modularize_init_error(self):
     test_cpp_path = test_file('browser/test_modularize_init_error.cpp')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -5439,7 +5439,7 @@ int main() {
               self.assertContained('managed another malloc!\n', output)
           else:
             # we should see an abort
-            self.assertContained('abort(Cannot enlarge memory arrays', output)
+            self.assertContained('Aborted(Cannot enlarge memory arrays', output)
             if growth:
               # when growth is enabled, the default is to not abort, so just explain that
               self.assertContained('If you want malloc to return NULL (0) instead of this abort, do not link with -s ABORTING_MALLOC=1', output)
@@ -9532,9 +9532,9 @@ int main(void) {
     ''')
     self.run_process([EMXX, 'src.cpp', '-s', 'ASSERTIONS'])
     self.assertContained('''
-Module.read has been replaced with plain read_ (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)
-Module.wasmBinary has been replaced with plain wasmBinary (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)
-Module.arguments has been replaced with plain arguments_ (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name)
+Aborted(Module.read has been replaced with plain read_ (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name))
+Aborted(Module.wasmBinary has been replaced with plain wasmBinary (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name))
+Aborted(Module.arguments has been replaced with plain arguments_ (the initial value can be provided on Module, but after startup the value is only looked for on a local variable of that name))
 ''', self.run_js('a.out.js'))
 
   def test_assertions_on_ready_promise(self):

--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -105,9 +105,9 @@ struct_ptr_array[0]->attr2 == 101
 4 : 0.25
 9 : 0.01
 10 : -20.42
-Assertion failed: [CHECK FAILED] Parent::Parent(val:val): Expecting <integer>
+Aborted(Assertion failed: [CHECK FAILED] Parent::Parent(val:val): Expecting <integer>)
 Parent:42
-Assertion failed: [CHECK FAILED] Parent::voidStar(something:something): Expecting <pointer>
-Assertion failed: [CHECK FAILED] StringUser::Print(anotherString:anotherString): Expecting <string>
+Aborted(Assertion failed: [CHECK FAILED] Parent::voidStar(something:something): Expecting <pointer>)
+Aborted(Assertion failed: [CHECK FAILED] StringUser::Print(anotherString:anotherString): Expecting <string>)
 
 done.


### PR DESCRIPTION
This change improves reporting for of to abort() and exceptions in
general. See #13647.  For this simple test programs the result of
this changes is shown below for both the browser and node.  

```
int main() {
  abort();
}
```

There is still some duplication, for example, I'm not sure we really need to
be outputing the abort message as well as throwing it, but I'll leave
that for a followup.


Node before:

```
exception thrown: RuntimeError: abort(undefined) at Error
    at jsStackTrace (/home/sbc/dev/wasm/emscripten/test.js:1789:19)
    at stackTrace (/home/sbc/dev/wasm/emscripten/test.js:1806:16)
    at abort (/home/sbc/dev/wasm/emscripten/test.js:1483:44)
    at _abort (/home/sbc/dev/wasm/emscripten/test.js:1812:7)
    at __original_main (<anonymous>:wasm-function[2]:0x19d)
    at main (<anonymous>:wasm-function[3]:0x1a5)
    at /home/sbc/dev/wasm/emscripten/test.js:1553:22
    at callMain (/home/sbc/dev/wasm/emscripten/test.js:2156:15)
    at doRun (/home/sbc/dev/wasm/emscripten/test.js:2213:23)
    at run (/home/sbc/dev/wasm/emscripten/test.js:2228:5),RuntimeError: abort(undefined) at Error
    at jsStackTrace (/home/sbc/dev/wasm/emscripten/test.js:1789:19)
    at stackTrace (/home/sbc/dev/wasm/emscripten/test.js:1806:16)
    at abort (/home/sbc/dev/wasm/emscripten/test.js:1483:44)
    at _abort (/home/sbc/dev/wasm/emscripten/test.js:1812:7)
    at __original_main (<anonymous>:wasm-function[2]:0x19d)
    at main (<anonymous>:wasm-function[3]:0x1a5)
    at /home/sbc/dev/wasm/emscripten/test.js:1553:22
    at callMain (/home/sbc/dev/wasm/emscripten/test.js:2156:15)
    at doRun (/home/sbc/dev/wasm/emscripten/test.js:2213:23)
    at run (/home/sbc/dev/wasm/emscripten/test.js:2228:5)
    at abort (/home/sbc/dev/wasm/emscripten/test.js:1489:11)
    at _abort (/home/sbc/dev/wasm/emscripten/test.js:1812:7)
    at __original_main (<anonymous>:wasm-function[2]:0x19d)
    at main (<anonymous>:wasm-function[3]:0x1a5)
    at /home/sbc/dev/wasm/emscripten/test.js:1553:22
    at callMain (/home/sbc/dev/wasm/emscripten/test.js:2156:15)
    at doRun (/home/sbc/dev/wasm/emscripten/test.js:2213:23)
    at run (/home/sbc/dev/wasm/emscripten/test.js:2228:5)
    at runCaller (/home/sbc/dev/wasm/emscripten/test.js:2134:19)
    at removeRunDependency (/home/sbc/dev/wasm/emscripten/test.js:1461:7)
/home/sbc/dev/wasm/emscripten/test.js:125
      throw ex;
      ^

RuntimeError: abort(undefined) at Error
    at jsStackTrace (/home/sbc/dev/wasm/emscripten/test.js:1789:19)
    at stackTrace (/home/sbc/dev/wasm/emscripten/test.js:1806:16)
    at abort (/home/sbc/dev/wasm/emscripten/test.js:1483:44)
    at _abort (/home/sbc/dev/wasm/emscripten/test.js:1812:7)
    at __original_main (<anonymous>:wasm-function[2]:0x19d)
    at main (<anonymous>:wasm-function[3]:0x1a5)
    at /home/sbc/dev/wasm/emscripten/test.js:1553:22
    at callMain (/home/sbc/dev/wasm/emscripten/test.js:2156:15)
    at doRun (/home/sbc/dev/wasm/emscripten/test.js:2213:23)
    at run (/home/sbc/dev/wasm/emscripten/test.js:2228:5)
    at abort (/home/sbc/dev/wasm/emscripten/test.js:1489:11)
    at _abort (/home/sbc/dev/wasm/emscripten/test.js:1812:7)
    at __original_main (<anonymous>:wasm-function[2]:0x19d)
    at main (<anonymous>:wasm-function[3]:0x1a5)
    at /home/sbc/dev/wasm/emscripten/test.js:1553:22
    at callMain (/home/sbc/dev/wasm/emscripten/test.js:2156:15)
    at doRun (/home/sbc/dev/wasm/emscripten/test.js:2213:23)
    at run (/home/sbc/dev/wasm/emscripten/test.js:2228:5)
    at runCaller (/home/sbc/dev/wasm/emscripten/test.js:2134:19)
    at removeRunDependency (/home/sbc/dev/wasm/emscripten/test.js:1461:7)
```

Node after:

```
Aborted(native code called abort())
/home/sbc/dev/wasm/emscripten/test.js:141
      throw ex;
      ^

RuntimeError: Aborted(native code called abort())
    at abort (/home/sbc/dev/wasm/emscripten/test.js:1509:11)
    at _abort (/home/sbc/dev/wasm/emscripten/test.js:1826:7)
    at __original_main (<anonymous>:wasm-function[2]:0x19d)
    at main (<anonymous>:wasm-function[3]:0x1a5)
    at /home/sbc/dev/wasm/emscripten/test.js:1573:22
    at callMain (/home/sbc/dev/wasm/emscripten/test.js:2170:15)
    at doRun (/home/sbc/dev/wasm/emscripten/test.js:2227:23)
    at run (/home/sbc/dev/wasm/emscripten/test.js:2242:5)
    at runCaller (/home/sbc/dev/wasm/emscripten/test.js:2148:19)
    at removeRunDependency (/home/sbc/dev/wasm/emscripten/test.js:1479:7)
```

Browser before:

```
test.html:1246 undefined
test.html:1246 exception thrown: RuntimeError: abort(undefined) at Error
    at jsStackTrace (http://localhost:6931/test.js:1789:19)
    at stackTrace (http://localhost:6931/test.js:1806:16)
    at abort (http://localhost:6931/test.js:1483:44)
    at _abort (http://localhost:6931/test.js:1812:7)
    at __original_main (http://localhost:6931/test.wasm:wasm-function[2]:0x19d)
    at main (http://localhost:6931/test.wasm:wasm-function[3]:0x1a5)
    at http://localhost:6931/test.js:1553:22
    at callMain (http://localhost:6931/test.js:2156:15)
    at doRun (http://localhost:6931/test.js:2213:23)
    at http://localhost:6931/test.js:2224:7,RuntimeError: abort(undefined) at Error
    at jsStackTrace (http://localhost:6931/test.js:1789:19)
    at stackTrace (http://localhost:6931/test.js:1806:16)
    at abort (http://localhost:6931/test.js:1483:44)
    at _abort (http://localhost:6931/test.js:1812:7)
    at __original_main (http://localhost:6931/test.wasm:wasm-function[2]:0x19d)
    at main (http://localhost:6931/test.wasm:wasm-function[3]:0x1a5)
    at http://localhost:6931/test.js:1553:22
    at callMain (http://localhost:6931/test.js:2156:15)
    at doRun (http://localhost:6931/test.js:2213:23)
    at http://localhost:6931/test.js:2224:7
    at abort (http://localhost:6931/test.js:1489:11)
    at _abort (http://localhost:6931/test.js:1812:7)
    at __original_main (http://localhost:6931/test.wasm:wasm-function[2]:0x19d)
    at main (http://localhost:6931/test.wasm:wasm-function[3]:0x1a5)
    at http://localhost:6931/test.js:1553:22
    at callMain (http://localhost:6931/test.js:2156:15)
    at doRun (http://localhost:6931/test.js:2213:23)
    at http://localhost:6931/test.js:2224:7
test.js:38 Uncaught RuntimeError: abort(undefined) at Error
    at jsStackTrace (test.js:1789)
    at stackTrace (test.js:1806)
    at abort (test.js:1483)
    at _abort (test.js:1812)
    at __original_main (test.wasm:0x19d)
    at main (test.wasm:0x1a5)
    at test.js:1553
    at callMain (test.js:2156)
    at doRun (test.js:2213)
    at test.js:2224
    at abort (test.js:1489)
    at _abort (test.js:1812)
    at __original_main (test.wasm:0x19d)
    at main (test.wasm:0x1a5)
    at test.js:1553
    at callMain (test.js:2156)
    at doRun (test.js:2213)
    at test.js:2224
```

Browser after:

```
test.html:1246 Aborted(native code called abort())
test.js:38 Uncaught RuntimeError: Aborted(native code called abort())
    at abort (test.js:1509)
    at _abort (test.js:1826)
    at __original_main (test.wasm:0x19d)
    at main (test.wasm:0x1a5)
    at test.js:1573
    at callMain (test.js:2170)
    at doRun (test.js:2227)
    at test.js:2238
```

Fixes: #13647