### PR TITLE
Move `emscripten_console_log` and other non-html library functions out of html5.h and html5.js

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3600,6 +3600,38 @@ LibraryManager.library = {
 #endif
   },
 
+  emscripten_console_log: function(str) {
+#if ASSERTIONS
+    assert(typeof str === 'number');
+#endif
+    out(UTF8ToString(str));
+  },
+
+  emscripten_console_warn: function(str) {
+#if ASSERTIONS
+    assert(typeof str === 'number');
+#endif
+    console.warn(UTF8ToString(str));
+  },
+
+  emscripten_console_error: function(str) {
+#if ASSERTIONS
+    assert(typeof str === 'number');
+#endif
+    err(UTF8ToString(str));
+  },
+
+  emscripten_throw_number: function(number) {
+    throw number;
+  },
+
+  emscripten_throw_string: function(str) {
+#if ASSERTIONS
+    assert(typeof str === 'number');
+#endif
+    throw UTF8ToString(str);
+  },
+
 #if !MINIMAL_RUNTIME
   $handleException: function(e) {
     // Certain exception types we do not treat as errors since they are used for

--- a/src/library_eventloop.js
+++ b/src/library_eventloop.js
@@ -1,0 +1,183 @@
+/**
+ * @license
+ * Copyright 2010 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+// Implementation of functions from emscripten/eventloop.h.
+
+LibraryJSEventLoop = {
+  emscripten_unwind_to_js_event_loop: function() {
+    throw 'unwind';
+  },
+
+  // Just like setImmediate but returns an i32 that can be passed back
+  // to wasm rather than a JS object.
+  $setImmediateWrapped: function(func) {
+    if (!setImmediateWrapped.mapping) setImmediateWrapped.mapping = [];
+    var id = setImmediateWrapped.mapping.length;
+    setImmediateWrapped.mapping[id] = setImmediate(function() {
+      setImmediateWrapped.mapping[id] = undefined;
+      func();
+    });
+    return id;
+  },
+
+  // Just like clearImmediate but takes an i32 rather than an object.
+  $clearImmediateWrapped: function(id) {
+#if ASSERTIONS
+    assert(id);
+    assert(setImmediateWrapped.mapping[id]);
+#endif
+    clearImmediate(setImmediateWrapped.mapping[id]);
+    setImmediateWrapped.mapping[id] = undefined;
+  },
+
+  $polyfillSetImmediate__deps: ['$setImmediateWrapped', '$clearImmediateWrapped'],
+  $polyfillSetImmediate__postset:
+    'var emSetImmediate;\n' +
+    'var emClearImmediate;\n' +
+    'if (typeof setImmediate !== "undefined") {\n' +
+      'emSetImmediate = setImmediateWrapped;\n' +
+      'emClearImmediate = clearImmediateWrapped;\n' +
+    '} else if (typeof addEventListener === "function") {\n' +
+      'var __setImmediate_id_counter = 0;\n' +
+      'var __setImmediate_queue = [];\n' +
+      'var __setImmediate_message_id = "_si";\n' +
+      'function __setImmediate_cb(e) {\n' +
+        'if (e.data === __setImmediate_message_id) {\n' +
+          'e.stopPropagation();\n' +
+          '__setImmediate_queue.shift()();\n' +
+          '++__setImmediate_id_counter;\n' +
+        '}\n' +
+      '}\n' +
+      'addEventListener("message", __setImmediate_cb, true);\n' +
+      'emSetImmediate = function(func) {\n' +
+        'postMessage(__setImmediate_message_id, "*");\n' +
+        'return __setImmediate_id_counter + __setImmediate_queue.push(func) - 1;\n' +
+      '}\n' +
+      'emClearImmediate = /**@type{function(number=)}*/(function(id) {\n' +
+        'var index = id - __setImmediate_id_counter;\n' +
+        'if (index >= 0 && index < __setImmediate_queue.length) __setImmediate_queue[index] = function() {};\n' + // must preserve the order and count of elements in the queue, so replace the pending callback with an empty function
+      '})\n' +
+    '}',
+
+  $polyfillSetImmediate: function() {
+    // nop, used for its postset to ensure setImmediate() polyfill is
+    // not duplicated between emscripten_set_immediate() and
+    // emscripten_set_immediate_loop() if application links to both of them.
+  },
+
+  emscripten_set_immediate__deps: ['$polyfillSetImmediate', '$callUserCallback',
+#if !MINIMAL_RUNTIME
+    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
+#endif
+  ],
+  emscripten_set_immediate: function(cb, userData) {
+    polyfillSetImmediate();
+    {{{ runtimeKeepalivePush(); }}}
+    return emSetImmediate(function() {
+      {{{ runtimeKeepalivePop(); }}}
+      callUserCallback(function() {
+        {{{ makeDynCall('vi', 'cb') }}}(userData);
+      });
+    });
+  },
+
+  emscripten_clear_immediate__deps: ['$polyfillSetImmediate',
+#if !MINIMAL_RUNTIME
+    '$runtimeKeepalivePop',
+#endif
+  ],
+  emscripten_clear_immediate: function(id) {
+    {{{ runtimeKeepalivePop(); }}}
+    emClearImmediate(id);
+  },
+
+  emscripten_set_immediate_loop__deps: ['$polyfillSetImmediate', '$callUserCallback',
+#if !MINIMAL_RUNTIME
+    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
+#endif
+  ],
+  emscripten_set_immediate_loop: function(cb, userData) {
+    polyfillSetImmediate();
+    function tick() {
+      {{{ runtimeKeepalivePop(); }}}
+      callUserCallback(function() {
+        if ({{{ makeDynCall('ii', 'cb') }}}(userData)) {
+          {{{ runtimeKeepalivePush(); }}}
+          emSetImmediate(tick);
+        }
+      });
+    }
+    {{{ runtimeKeepalivePush(); }}}
+    return emSetImmediate(tick);
+  },
+
+  emscripten_set_timeout__deps: ['$callUserCallback',
+#if !MINIMAL_RUNTIME
+    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
+#endif
+  ],
+  emscripten_set_timeout: function(cb, msecs, userData) {
+    {{{ runtimeKeepalivePush() }}}
+    return setTimeout(function() {
+      {{{ runtimeKeepalivePop() }}}
+      callUserCallback(function() {
+        {{{ makeDynCall('vi', 'cb') }}}(userData);
+      });
+    }, msecs);
+  },
+
+  emscripten_clear_timeout: function(id) {
+    clearTimeout(id);
+  },
+
+  emscripten_set_timeout_loop__deps: ['$callUserCallback',
+#if !MINIMAL_RUNTIME
+    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
+#endif
+  ],
+  emscripten_set_timeout_loop: function(cb, msecs, userData) {
+    function tick() {
+      var t = performance.now();
+      var n = t + msecs;
+      {{{ runtimeKeepalivePop() }}}
+      callUserCallback(function() {
+        if ({{{ makeDynCall('idi', 'cb') }}}(t, userData)) {
+          // Save a little bit of code space: modern browsers should treat
+          // negative setTimeout as timeout of 0
+          // (https://stackoverflow.com/questions/8430966/is-calling-settimeout-with-a-negative-delay-ok)
+          {{{ runtimeKeepalivePush() }}}
+          setTimeout(tick, n - performance.now());
+        }
+      });
+    }
+    {{{ runtimeKeepalivePush() }}}
+    return setTimeout(tick, 0);
+  },
+
+  emscripten_set_interval__deps: ['$callUserCallback',
+#if !MINIMAL_RUNTIME
+    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
+#endif
+  ],
+  emscripten_set_interval: function(cb, msecs, userData) {
+    {{{ runtimeKeepalivePush() }}}
+    return setInterval(function() {
+      callUserCallback(function() {
+        {{{ makeDynCall('vi', 'cb') }}}(userData)
+      });
+    }, msecs);
+  },
+
+#if !MINIMAL_RUNTIME
+  emscripten_clear_interval__deps: ['$runtimeKeepalivePop'],
+#endif
+  emscripten_clear_interval: function(id) {
+    {{{ runtimeKeepalivePop() }}}
+    clearInterval(id);
+  },
+};
+
+mergeInto(LibraryManager.library, LibraryJSEventLoop);

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-var LibraryJSEvents = {
+var LibraryHTML5 = {
   $JSEvents: {
 
 /* We do not depend on the exact initial values of falsey member fields - these fields can be populated on-demand
@@ -2673,216 +2673,12 @@ var LibraryJSEvents = {
     return requestAnimationFrame(tick);
   },
 
-  // Just like setImmediate but returns an i32 that can be passed back
-  // to wasm rather than a JS object.
-  $setImmediateWrapped: function(func) {
-    if (!setImmediateWrapped.mapping) setImmediateWrapped.mapping = [];
-    var id = setImmediateWrapped.mapping.length;
-    setImmediateWrapped.mapping[id] = setImmediate(function() {
-      setImmediateWrapped.mapping[id] = undefined;
-      func();
-    });
-    return id;
-  },
-
-  // Just like clearImmediate but takes an i32 rather than an object.
-  $clearImmediateWrapped: function(id) {
-#if ASSERTIONS
-    assert(id);
-    assert(setImmediateWrapped.mapping[id]);
-#endif
-    clearImmediate(setImmediateWrapped.mapping[id]);
-    setImmediateWrapped.mapping[id] = undefined;
-  },
-
-  $polyfillSetImmediate__deps: ['$setImmediateWrapped', '$clearImmediateWrapped'],
-  $polyfillSetImmediate__postset:
-    'var emSetImmediate;\n' +
-    'var emClearImmediate;\n' +
-    'if (typeof setImmediate !== "undefined") {\n' +
-      'emSetImmediate = setImmediateWrapped;\n' +
-      'emClearImmediate = clearImmediateWrapped;\n' +
-    '} else if (typeof addEventListener === "function") {\n' +
-      'var __setImmediate_id_counter = 0;\n' +
-      'var __setImmediate_queue = [];\n' +
-      'var __setImmediate_message_id = "_si";\n' +
-      'function __setImmediate_cb(e) {\n' +
-        'if (e.data === __setImmediate_message_id) {\n' +
-          'e.stopPropagation();\n' +
-          '__setImmediate_queue.shift()();\n' +
-          '++__setImmediate_id_counter;\n' +
-        '}\n' +
-      '}\n' +
-      'addEventListener("message", __setImmediate_cb, true);\n' +
-      'emSetImmediate = function(func) {\n' +
-        'postMessage(__setImmediate_message_id, "*");\n' +
-        'return __setImmediate_id_counter + __setImmediate_queue.push(func) - 1;\n' +
-      '}\n' +
-      'emClearImmediate = /**@type{function(number=)}*/(function(id) {\n' +
-        'var index = id - __setImmediate_id_counter;\n' +
-        'if (index >= 0 && index < __setImmediate_queue.length) __setImmediate_queue[index] = function() {};\n' + // must preserve the order and count of elements in the queue, so replace the pending callback with an empty function
-      '})\n' +
-    '}',
-
-  $polyfillSetImmediate: function() {
-    // nop, used for its postset to ensure setImmediate() polyfill is
-    // not duplicated between emscripten_set_immediate() and
-    // emscripten_set_immediate_loop() if application links to both of them.
-  },
-
-  emscripten_set_immediate__deps: ['$polyfillSetImmediate', '$callUserCallback',
-#if !MINIMAL_RUNTIME
-    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
-#endif
-  ],
-  emscripten_set_immediate: function(cb, userData) {
-    polyfillSetImmediate();
-    {{{ runtimeKeepalivePush(); }}}
-    return emSetImmediate(function() {
-      {{{ runtimeKeepalivePop(); }}}
-      callUserCallback(function() {
-        {{{ makeDynCall('vi', 'cb') }}}(userData);
-      });
-    });
-  },
-
-  emscripten_clear_immediate__deps: ['$polyfillSetImmediate',
-#if !MINIMAL_RUNTIME
-    '$runtimeKeepalivePop',
-#endif
-  ],
-  emscripten_clear_immediate: function(id) {
-    {{{ runtimeKeepalivePop(); }}}
-    emClearImmediate(id);
-  },
-
-  emscripten_set_immediate_loop__deps: ['$polyfillSetImmediate', '$callUserCallback',
-#if !MINIMAL_RUNTIME
-    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
-#endif
-  ],
-  emscripten_set_immediate_loop: function(cb, userData) {
-    polyfillSetImmediate();
-    function tick() {
-      {{{ runtimeKeepalivePop(); }}}
-      callUserCallback(function() {
-        if ({{{ makeDynCall('ii', 'cb') }}}(userData)) {
-          {{{ runtimeKeepalivePush(); }}}
-          emSetImmediate(tick);
-        }
-      });
-    }
-    {{{ runtimeKeepalivePush(); }}}
-    return emSetImmediate(tick);
-  },
-
-  emscripten_set_timeout__deps: ['$callUserCallback',
-#if !MINIMAL_RUNTIME
-    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
-#endif
-  ],
-  emscripten_set_timeout: function(cb, msecs, userData) {
-    {{{ runtimeKeepalivePush() }}}
-    return setTimeout(function() {
-      {{{ runtimeKeepalivePop() }}}
-      callUserCallback(function() {
-        {{{ makeDynCall('vi', 'cb') }}}(userData);
-      });
-    }, msecs);
-  },
-
-  emscripten_clear_timeout: function(id) {
-    clearTimeout(id);
-  },
-
-  emscripten_set_timeout_loop__deps: ['$callUserCallback',
-#if !MINIMAL_RUNTIME
-    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
-#endif
-  ],
-  emscripten_set_timeout_loop: function(cb, msecs, userData) {
-    function tick() {
-      var t = performance.now();
-      var n = t + msecs;
-      {{{ runtimeKeepalivePop() }}}
-      callUserCallback(function() {
-        if ({{{ makeDynCall('idi', 'cb') }}}(t, userData)) {
-          // Save a little bit of code space: modern browsers should treat
-          // negative setTimeout as timeout of 0
-          // (https://stackoverflow.com/questions/8430966/is-calling-settimeout-with-a-negative-delay-ok)
-          {{{ runtimeKeepalivePush() }}}
-          setTimeout(tick, n - performance.now());
-        }
-      });
-    }
-    {{{ runtimeKeepalivePush() }}}
-    return setTimeout(tick, 0);
-  },
-
-  emscripten_set_interval__deps: ['$callUserCallback',
-#if !MINIMAL_RUNTIME
-    '$runtimeKeepalivePush', '$runtimeKeepalivePop',
-#endif
-  ],
-  emscripten_set_interval: function(cb, msecs, userData) {
-    {{{ runtimeKeepalivePush() }}}
-    return setInterval(function() {
-      callUserCallback(function() {
-        {{{ makeDynCall('vi', 'cb') }}}(userData)
-      });
-    }, msecs);
-  },
-
-#if !MINIMAL_RUNTIME
-  emscripten_clear_interval__deps: ['$runtimeKeepalivePop'],
-#endif
-  emscripten_clear_interval: function(id) {
-    {{{ runtimeKeepalivePop() }}}
-    clearInterval(id);
-  },
-
   emscripten_date_now: function() {
     return Date.now();
   },
 
   emscripten_performance_now: function() {
     return performance.now();
-  },
-
-  emscripten_console_log: function(str) {
-#if ASSERTIONS
-    assert(typeof str === 'number');
-#endif
-    out(UTF8ToString(str));
-  },
-
-  emscripten_console_warn: function(str) {
-#if ASSERTIONS
-    assert(typeof str === 'number');
-#endif
-    console.warn(UTF8ToString(str));
-  },
-
-  emscripten_console_error: function(str) {
-#if ASSERTIONS
-    assert(typeof str === 'number');
-#endif
-    err(UTF8ToString(str));
-  },
-
-  emscripten_throw_number: function(number) {
-    throw number;
-  },
-
-  emscripten_throw_string: function(str) {
-#if ASSERTIONS
-    assert(typeof str === 'number');
-#endif
-    throw UTF8ToString(str);
-  },
-
-  emscripten_unwind_to_js_event_loop: function() {
-    throw 'unwind';
   },
 
   emscripten_get_device_pixel_ratio__proxy: 'sync',
@@ -2900,4 +2696,4 @@ var LibraryJSEvents = {
   }
 };
 
-mergeInto(LibraryManager.library, LibraryJSEvents);
+mergeInto(LibraryManager.library, LibraryHTML5);

--- a/src/modules.js
+++ b/src/modules.js
@@ -66,7 +66,8 @@ var LibraryManager = {
       'library_stack_trace.js',
       'library_wasi.js',
       'library_int53.js',
-      'library_dylink.js'
+      'library_dylink.js',
+      'library_eventloop.js',
     ];
 
     if (LINK_AS_CXX && !EXCEPTION_HANDLING) {

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void emscripten_console_log(const char *utf8String);
+void emscripten_console_warn(const char *utf8String);
+void emscripten_console_error(const char *utf8String);
+
+#ifdef __cplusplus
+}
+#endif

--- a/system/include/emscripten/em_types.h
+++ b/system/include/emscripten/em_types.h
@@ -28,3 +28,8 @@ typedef double __attribute__((aligned(1))) emscripten_align1_double;
 typedef void (*em_callback_func)(void);
 typedef void (*em_arg_callback_func)(void*);
 typedef void (*em_str_callback_func)(const char *);
+
+#define EM_BOOL int
+#define EM_TRUE 1
+#define EM_FALSE 0
+#define EM_UTF8 char

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -173,6 +173,9 @@ void emscripten_scan_stack(em_scan_func func);
 typedef void (*em_dlopen_callback)(void* handle, void* user_data);
 void emscripten_dlopen(const char *filename, int flags, void* user_data, em_dlopen_callback onsuccess, em_arg_callback_func onerror);
 
+void emscripten_throw_number(double number);
+void emscripten_throw_string(const char *utf8String);
+
 /* ===================================== */
 /* Internal APIs. Be careful with these. */
 /* ===================================== */

--- a/system/include/emscripten/eventloop.h
+++ b/system/include/emscripten/eventloop.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#pragma once
+
+#include "em_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void emscripten_unwind_to_js_event_loop(void) __attribute__((noreturn));
+
+long emscripten_set_timeout(void (*cb)(void *userData), double msecs, void *userData);
+void emscripten_clear_timeout(long setTimeoutId);
+void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *userData), double intervalMsecs, void *userData);
+
+long emscripten_set_immediate(void (*cb)(void *userData), void *userData);
+void emscripten_clear_immediate(long setImmediateId);
+void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *userData), void *userData);
+
+long emscripten_set_interval(void (*cb)(void *userData), double intervalMsecs, void *userData);
+void emscripten_clear_interval(long setIntervalId);
+
+#ifdef __cplusplus
+}
+#endif

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -8,13 +8,22 @@
 #pragma once
 
 #include <pthread.h>
+#include <emscripten/em_types.h>
+
+#include <emscripten/emscripten.h>
+
+// Include eventloop.h and console.h for compat with older version of this
+// header that used to define these functions.
+#include <emscripten/eventloop.h>
+#include <emscripten/console.h>
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* This file defines Emscripten low-level glue bindings for interfacing with HTML5 APIs
- * 
+/*
+ * This file defines Emscripten low-level glue bindings for interfacing with HTML5 APIs
+ *
  * Documentation for the public APIs defined in this file must be updated in: 
  *    site/source/docs/api_reference/html5.h.rst
  * A prebuilt local version of the documentation is available at: 
@@ -80,11 +89,6 @@ extern "C" {
 #define EMSCRIPTEN_EVENT_TARGET_DOCUMENT       ((const char*)1)
 #define EMSCRIPTEN_EVENT_TARGET_WINDOW         ((const char*)2)
 #define EMSCRIPTEN_EVENT_TARGET_SCREEN         ((const char*)3)
-
-#define EM_BOOL int
-#define EM_TRUE 1
-#define EM_FALSE 0
-#define EM_UTF8 char
 
 #define DOM_KEY_LOCATION int
 #define DOM_KEY_LOCATION_STANDARD 0x00
@@ -469,32 +473,12 @@ void emscripten_html5_remove_all_event_listeners(void);
 #define emscripten_set_batterylevelchange_callback(userData, callback)                        emscripten_set_batterylevelchange_callback_on_thread(             (userData),               (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 #define emscripten_set_beforeunload_callback(userData, callback)                              emscripten_set_beforeunload_callback_on_thread(                   (userData),               (callback), EM_CALLBACK_THREAD_CONTEXT_MAIN_BROWSER_THREAD)
 
-long emscripten_set_timeout(void (*cb)(void *userData), double msecs, void *userData);
-void emscripten_clear_timeout(long setTimeoutId);
-void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *userData), double intervalMsecs, void *userData);
-
 long emscripten_request_animation_frame(EM_BOOL (*cb)(double time, void *userData), void *userData);
 void emscripten_cancel_animation_frame(long requestAnimationFrameId);
 void emscripten_request_animation_frame_loop(EM_BOOL (*cb)(double time, void *userData), void *userData);
 
-long emscripten_set_immediate(void (*cb)(void *userData), void *userData);
-void emscripten_clear_immediate(long setImmediateId);
-void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *userData), void *userData);
-
-long emscripten_set_interval(void (*cb)(void *userData), double intervalMsecs, void *userData);
-void emscripten_clear_interval(long setIntervalId);
-
 double emscripten_date_now(void);
 double emscripten_performance_now(void);
-
-void emscripten_console_log(const char *utf8String);
-void emscripten_console_warn(const char *utf8String);
-void emscripten_console_error(const char *utf8String);
-
-void emscripten_throw_number(double number);
-void emscripten_throw_string(const char *utf8String);
-
-void emscripten_unwind_to_js_event_loop(void) __attribute__((noreturn));
 
 #ifdef __cplusplus
 } // ~extern "C"

--- a/tests/emscripten_set_immediate.c
+++ b/tests/emscripten_set_immediate.c
@@ -1,6 +1,7 @@
 #include <emscripten/html5.h>
 #include <stdlib.h>
 #include <assert.h>
+#include <stdio.h>
 
 int func1Executed = 0;
 int func2Executed = 0;
@@ -8,6 +9,7 @@ int func2Executed = 0;
 void func1(void *userData);
 
 void func2(void *userData) {
+  printf("func2: %p\n", userData);
   assert((long)userData == 2);
   ++func2Executed;
 
@@ -25,6 +27,7 @@ void func2(void *userData) {
 }
 
 void func1(void *userData) {
+  printf("func1: %p\n", userData);
   assert((long)userData == 1);
   ++func1Executed;
   assert(func1Executed == 1);

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5035,7 +5035,7 @@ window.close = function() {
 
   # Tests emscripten_unwind_to_js_event_loop() behavior
   def test_emscripten_unwind_to_js_event_loop(self, *args):
-    self.btest_exit(test_file('browser/test_emscripten_unwind_to_js_event_loop.c'))
+    self.btest_exit(test_file('test_emscripten_unwind_to_js_event_loop.c'))
 
   def test_wasm2js_fallback(self):
     self.set_setting('EXIT_RUNTIME')

--- a/tests/test_emscripten_unwind_to_js_event_loop.c
+++ b/tests/test_emscripten_unwind_to_js_event_loop.c
@@ -9,7 +9,7 @@ void timeout(void *userData) {
 }
 
 int main() {
-  emscripten_set_timeout(timeout, 2000, 0);
+  emscripten_set_timeout(timeout, 50, 0);
   emscripten_unwind_to_js_event_loop();
   // emscripten_unwind_to_js_event_loop should never return
   __builtin_trap();

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11014,3 +11014,23 @@ void foo() {}
     output = self.do_runf(test_file('pthread/test_pthread_trap.c'), assert_returncode=NON_ZERO)
     self.assertContained("pthread sent an error!", output)
     self.assertContained("at thread_main", output)
+
+  @node_pthreads
+  def test_emscripten_set_interval(self):
+    self.do_runf(test_file('emscripten_set_interval.c'), args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+
+  # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
+  def test_emscripten_console_log(self):
+    self.do_runf(test_file('emscripten_console_log.c'), emcc_args=['--pre-js', test_file('emscripten_console_log_pre.js')])
+
+  # Tests emscripten_unwind_to_js_event_loop() behavior
+  def test_emscripten_unwind_to_js_event_loop(self, *args):
+    self.do_runf(test_file('test_emscripten_unwind_to_js_event_loop.c'))
+
+  @node_pthreads
+  def test_emscripten_set_timeout(self):
+    self.do_runf(test_file('emscripten_set_timeout.c'), args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+
+  @node_pthreads
+  def test_emscripten_set_timeout_loop(self):
+    self.do_runf(test_file('emscripten_set_timeout_loop.c'), args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])


### PR DESCRIPTION
Split non-html5 functionality out of `html5.h` and `library_html5.js`.   The creates 
`eventloop.h` and `console.h` to hold the declarations and and new JS library called
`library_eventloop.js` for event-loop related JS functions.

The remaining two function `emscripten_throw_number` and `emscripten_throw_string` are small
and enough that it seems reasonable to add them to `emscripten.h` and `library.js`.

Where trivial also run the tests for these function in test_other.py
and not just in test_brower.py.