### PR TITLE
Threads that crash should not become joinable

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -271,7 +271,9 @@ self.onmessage = function(e) {
           else
 #endif // !MINIMAL_RUNTIME
           {
-            Module['__emscripten_thread_exit'](-2);
+            // The pthread "crashed".  Do not call `_emscripten_thread_exit` (which
+            // would make this thread joinable.  Instead, re-throw the exception
+            // and let the top level handler propagate it back to the main thread.
             throw ex;
           }
 #if ASSERTIONS

--- a/tests/common.py
+++ b/tests/common.py
@@ -1005,7 +1005,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     self._build_and_run(filename, expected_output, **kwargs)
 
   def do_runf(self, filename, expected_output=None, **kwargs):
-    self._build_and_run(filename, expected_output, **kwargs)
+    return self._build_and_run(filename, expected_output, **kwargs)
 
   ## Just like `do_run` but with filename of expected output
   def do_run_from_file(self, filename, expected_output_filename, **kwargs):
@@ -1078,6 +1078,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         except Exception:
           print('(test did not pass in JS engine: %s)' % engine)
           raise
+    return js_output
 
   def get_freetype_library(self):
     if '-Werror' in self.emcc_args:

--- a/tests/pthread/test_pthread_trap.c
+++ b/tests/pthread/test_pthread_trap.c
@@ -1,0 +1,19 @@
+#include <assert.h>
+#include <pthread.h>
+#include <stdio.h>
+
+void* thread_main() {
+  __builtin_trap();
+}
+
+int main() {
+  printf("in main\n");
+
+  pthread_t t;
+  int rc = pthread_create(&t, NULL, thread_main, NULL);
+  assert(rc == 0);
+
+  pthread_join(t, NULL);
+  printf("should never get here\n");
+  return 99;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4146,6 +4146,24 @@ window.close = function() {
     args += ['--pre-js', test_file('core/pthread/test_pthread_exit_runtime.pre.js')]
     self.btest(test_file('core/pthread/test_pthread_exit_runtime.c'), expected='onExit status: 42', args=args)
 
+  @requires_threads
+  def test_pthread_trap(self):
+    create_file('pre.js', '''
+    if (typeof window === 'object' && window) {
+      window.addEventListener('error', function(e) {
+        if (e.error && e.error.message.includes('unreachable'))
+          maybeReportResultToServer("expected exception caught");
+        else
+          maybeReportResultToServer("unexpected: " + e);
+      });
+    }''')
+    args = ['-s', 'USE_PTHREADS',
+            '-s', 'PROXY_TO_PTHREAD',
+            '-s', 'EXIT_RUNTIME',
+            '--profiling-funcs',
+            '--pre-js=pre.js']
+    self.btest(test_file('pthread/test_pthread_trap.c'), expected='expected exception caught', args=args)
+
   # Tests MAIN_THREAD_EM_ASM_INT() function call signatures.
   def test_main_thread_em_asm_signatures(self):
     self.btest_exit(test_file('core/test_em_asm_signatures.cpp'), assert_returncode=121, args=[])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11002,3 +11002,15 @@ void foo() {}
 
   def test_emscripten_set_immediate_loop(self):
     self.do_runf(test_file('emscripten_set_immediate_loop.c'))
+
+  @node_pthreads
+  def test_pthread_trap(self):
+    # TODO(https://github.com/emscripten-core/emscripten/issues/15161):
+    # Make this work without PROXY_TO_PTHREAD
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('USE_PTHREADS')
+    self.set_setting('EXIT_RUNTIME')
+    self.emcc_args += ['--profiling-funcs']
+    output = self.do_runf(test_file('pthread/test_pthread_trap.c'), assert_returncode=NON_ZERO)
+    self.assertContained("pthread sent an error!", output)
+    self.assertContained("at thread_main", output)


### PR DESCRIPTION
If we get a trap or exception form inside of a thread main function we
should not mark the thread as joinable but instead just re-throw so that
the exception is transmitted back to the main thread and the whole
application is brought down.

Sadly this doesn't currently work if the main thread is block in
`pthread_join` (because the posted exception will never get recieved) so
this test currently runs with `PROXY_TO_PTHREAD`.

Tested both under node and in the browser since they have slightly
different worker models.

I noticed this issue while debugging a mysterious pthread crash where
there was no error reported at all the main thread returned success!