### PR TITLE
Add option to clear single cached file in cache/sysroot/lib

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2949,6 +2949,11 @@ def parse_args(newargs):
       shared.Cache.erase()
       shared.check_sanity(force=True) # this is a good time for a sanity check
       should_exit = True
+    elif check_arg('--clear-cache-file'):
+      logger.info('clearing cache file as requested by --clear-cache-file: `%s`', shared.Cache.dirname)
+      shared.Cache.erase(consume_arg())
+      shared.check_sanity(force=True)
+      should_exit = True
     elif check_flag('--clear-ports'):
       logger.info('clearing ports and cache as requested by --clear-ports')
       system_libs.Ports.erase()

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -80,11 +80,15 @@ class Cache:
   def ensure(self):
     utils.safe_ensure_dirs(self.dirname)
 
-  def erase(self):
+  def erase(self, file=None):
     with self.lock():
       if os.path.exists(self.dirname):
-        for f in os.listdir(self.dirname):
-          tempfiles.try_delete(os.path.join(self.dirname, f))
+        if file == None:
+          for f in os.listdir(self.dirname):
+            tempfiles.try_delete(os.path.join(self.dirname, f))
+        else:
+          print('Attempted to clear ' + os.path.join(self.get_lib_dir(True), file))
+          tempfiles.try_delete(os.path.join(self.get_lib_dir(True), file))
 
   def get_path(self, name):
     return os.path.join(self.dirname, name)

--- a/tools/cache.py
+++ b/tools/cache.py
@@ -83,7 +83,7 @@ class Cache:
   def erase(self, file=None):
     with self.lock():
       if os.path.exists(self.dirname):
-        if file == None:
+        if file is None:
           for f in os.listdir(self.dirname):
             tempfiles.try_delete(os.path.join(self.dirname, f))
         else:


### PR DESCRIPTION
### Summary:
Suggestion to add an option to clear a single file in `cache/sysroot/lib/wasm32-emscripten/` or `cache/sysroot/lib/wasm64-emscripten/`
### Input: 
`emcc --clear-cache-file libwasmfs.a`
### Output:
```
emcc:INFO: clearing cache file as requested by --clear-cache-file: `/emscripten/cache`
Attempted to clear /emscripten/cache/sysroot/lib/wasm32-emscripten/libwasmfs.a
shared:INFO: (Emscripten: Running sanity checks)
```

Let me know if this might be a useful addition. I sometimes want to delete just one file in the cache to avoid rebuilding everything.