### PR TITLE
Skip all validation when 'no-validation' pass is specified

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7028,6 +7028,23 @@ int main() {
     # adding --metrics should not affect code size
     self.assertEqual(base_size, os.path.getsize('a.out.wasm'))
 
+  def test_binaryen_passes_no_validation(self):
+    def build(args=[]):
+      return self.run_process([EMXX, test_file('hello_world.cpp'), '-O3'] + args, stdout=PIPE).stdout
+
+    with env_modify({'BINARYEN_PASS_DEBUG': '1'}):
+      out = build()
+      self.assertContained('(validating)', out)
+      self.assertContained('(final validation)', out)
+      base_size = os.path.getsize('a.out.wasm')
+
+      out = build(['-s', 'BINARYEN_EXTRA_PASSES="--no-validation"'])
+      # (validating) and (final validation) should not appear
+      self.assertNotContained('(validating)', out)
+      self.assertNotContained('(final validation)', out)
+      # adding --no-validation should not affect code size
+      self.assertEqual(base_size, os.path.getsize('a.out.wasm'))
+
   def assertFileContents(self, filename, contents):
     contents = contents.replace('\r', '')
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -1443,6 +1443,13 @@ def run_binaryen_command(tool, infile, outfile=None, args=[], debug=False, stdou
   if settings.GENERATE_SOURCE_MAP and outfile:
     cmd += [f'--input-source-map={infile}.map']
     cmd += [f'--output-source-map={outfile}.map']
+  # we should skip all validation when 'no-validation' pass is specified
+  if settings.BINARYEN_EXTRA_PASSES:
+    # BINARYEN_EXTRA_PASSES is comma-separated
+    extras = settings.BINARYEN_EXTRA_PASSES.split(',')
+    # we support both '-'-prefixed and unprefixed pass names
+    if '--no-validation' in extras or 'no-validation' in extras:
+      cmd += ['--no-validation']
   ret = check_call(cmd, stdout=stdout).stdout
   if outfile:
     save_intermediate(outfile, '%s.wasm' % tool)


### PR DESCRIPTION
Discussion in https://github.com/WebAssembly/binaryen/issues/4167

Before:
> [PassRunner] running passes
[PassRunner]   running pass: generate-i64-dyncalls... 0.153705 seconds.
[PassRunner]   (validating)
[PassRunner]   running pass: legalize-js-interface... 0.0618519 seconds.
[PassRunner]   (validating)
[PassRunner]   running pass: strip-target-features... 0.022499 seconds.
[PassRunner]   (validating)
[PassRunner] passes took 0.238055 seconds.
[PassRunner] (final validation)

After:
> [PassRunner] running passes
[PassRunner]   running pass: generate-i64-dyncalls... 0.167555 seconds.
[PassRunner]   running pass: legalize-js-interface... 0.0663762 seconds.
[PassRunner]   running pass: strip-target-features... 0.0121898 seconds.
[PassRunner] passes took 0.246121 seconds.

Adds test `other.test_binaryen_passes_no_validation`