### PR TITLE
Remove shared.timeout_run

### DIFF
--- a/tests/fuzz/creduce_tester.py
+++ b/tests/fuzz/creduce_tester.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # Copyright 2013 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be
@@ -9,7 +9,8 @@
 
 import os
 import sys
-from subprocess import Popen, PIPE
+import subprocess
+from subprocess import PIPE
 
 sys.path += [os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), 'tools')]
 import shared
@@ -28,7 +29,7 @@ try:
   print('2) Compile natively')
   shared.run_process([shared.CLANG_CC, '-O2', filename, '-o', obj_filename] + CSMITH_CFLAGS)
   print('3) Run natively')
-  correct = shared.timeout_run(Popen([obj_filename], stdout=PIPE, stderr=PIPE), 3)
+  correct = subprocess.run([obj_filename], stdout=PIPE, stderr=PIPE, timeout=3).stdout
 except Exception as e:
   print('Failed or infinite looping in native, skipping', e)
   sys.exit(1) # boring

--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -17,7 +17,7 @@ import sys
 
 sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from tools import shared, utils
+from tools import utils
 
 
 js_file = sys.argv[1]
@@ -68,16 +68,11 @@ def eval_ctors(js, wasm_file, num):
   if debug_info:
     cmd += ['-g']
   logger.debug('wasm ctor cmd: ' + str(cmd))
-  proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
   try:
-    err = shared.timeout_run(proc, timeout=10, full_output=True, check=False)
-  except Exception as e:
-    if 'Timed out' not in str(e):
-      raise
+    err = subprocess.run(cmd, stderr=subprocess.PIPE, timeout=10).stdout
+  except subprocess.TimeoutExpired:
     logger.debug('ctors timed out\n')
     return 0, js
-  if proc.returncode != 0:
-    shared.exit_with_error('unexpected error while trying to eval ctors:\n' + err)
   num_successful = err.count('success on')
   logger.debug(err)
   if len(ctors) == num_successful:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -15,7 +15,6 @@ import os
 import re
 import shutil
 import subprocess
-import time
 import signal
 import sys
 import tempfile
@@ -232,25 +231,6 @@ def run_js_tool(filename, jsargs=[], *args, **kw):
   """
   command = config.NODE_JS + [filename] + jsargs
   return check_call(command, *args, **kw).stdout
-
-
-# Only used by tests and by ctor_evaller.py.   Once fastcomp is removed
-# this can most likely be moved into the tests/jsrun.py.
-def timeout_run(proc, timeout=None, full_output=False, check=True):
-  start = time.time()
-  if timeout is not None:
-    while time.time() - start < timeout and proc.poll() is None:
-      time.sleep(0.1)
-    if proc.poll() is None:
-      proc.kill() # XXX bug: killing emscripten.py does not kill it's child process!
-      raise Exception("Timed out")
-  stdout, stderr = proc.communicate()
-  out = ['' if o is None else o for o in (stdout, stderr)]
-  if check and proc.returncode != 0:
-    raise subprocess.CalledProcessError(proc.returncode, '', stdout, stderr)
-  if TRACK_PROCESS_SPAWNS:
-    logging.info(f'Process {proc.pid} finished after {time.time() - start} seconds. Exit code: {proc.returncode}')
-  return '\n'.join(out) if full_output else out[0]
 
 
 def get_npm_cmd(name):


### PR DESCRIPTION
This function is not longer needed since python's builtin
`subprocess.run` takes a `timeout` argument.

Did my best to keep csmith_driver.py running, and it now at
least does run successfully (prior to this change it had
bitrotted).
