### PR TITLE
Avoid sharing the parent process's stdin handle to python on Windows + other Windows bat script fixes

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,6 +43,13 @@ See docs/process.md for more on how version tagging works.
 
 2.0.30 - 09/14/2021
 -------------------
+- Fixed launcher batch script issues on Windows, and added two env. vars
+  EM_WORKAROUND_PYTHON_BUG_34780 and EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG that
+  can be enabled to work around a Windows Python issue
+  https://bugs.python.org/issue34780 , and a Windows 7 exit code issue (#15146)
+
+2.0.30
+------
 - Bug fixes
 
 2.0.29 - 08/26/2021

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -36,6 +36,10 @@ See docs/process.md for more on how version tagging works.
   `__syscall22`) to name-based (e.g. `__syscall_open`).  This should not be
   a visible change except for folks trying to intercept/implement syscalls
   in native code (#15202).
+- Fixed launcher batch script issues on Windows, and added two env. vars
+  EM_WORKAROUND_PYTHON_BUG_34780 and EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG that
+  can be enabled to work around a Windows Python issue
+  https://bugs.python.org/issue34780 , and a Windows 7 exit code issue (#15146)
 
 2.0.31 - 10/01/2021
 -------------------
@@ -43,13 +47,6 @@ See docs/process.md for more on how version tagging works.
 
 2.0.30 - 09/14/2021
 -------------------
-- Fixed launcher batch script issues on Windows, and added two env. vars
-  EM_WORKAROUND_PYTHON_BUG_34780 and EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG that
-  can be enabled to work around a Windows Python issue
-  https://bugs.python.org/issue34780 , and a Windows 7 exit code issue (#15146)
-
-2.0.30
-------
 - Bug fixes
 
 2.0.29 - 08/26/2021

--- a/em++.bat
+++ b/em++.bat
@@ -55,7 +55,7 @@
 
 :NORMAL
 @%CMD% %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @%CMD% %*
@@ -63,10 +63,8 @@
 
 :MUTE_STDIN
 @%CMD% %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @%CMD% %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/em++.bat
+++ b/em++.bat
@@ -24,20 +24,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  %CMD% %*
-) else (
-  %CMD% %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    %CMD% %*
+  ) else (
+    %CMD% %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    %CMD% %* < NUL
+  ) else (
+    %CMD% %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/em++.bat
+++ b/em++.bat
@@ -53,10 +53,6 @@
   )
 )
 
-:NORMAL
-@%CMD% %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @%CMD% %*
 @exit %ERRORLEVEL%
@@ -68,3 +64,6 @@
 :MUTE_STDIN_EXIT
 @%CMD% %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@%CMD% %*

--- a/em++.bat
+++ b/em++.bat
@@ -36,18 +36,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    %CMD% %*
+    goto NORMAL
   ) else (
-    %CMD% %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    %CMD% %* < NUL
+    goto MUTE_STDIN
   ) else (
-    %CMD% %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@%CMD% %*
+@goto END
+
+:NORMAL_EXIT
+@%CMD% %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@%CMD% %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@%CMD% %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/em-config.bat
+++ b/em-config.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/em-config.bat
+++ b/em-config.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/em-config.bat
+++ b/em-config.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/em-config.bat
+++ b/em-config.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/em-config.bat
+++ b/em-config.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emar.bat
+++ b/emar.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emar.bat
+++ b/emar.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emar.bat
+++ b/emar.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emar.bat
+++ b/emar.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emar.bat
+++ b/emar.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/embuilder.bat
+++ b/embuilder.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emcc.bat
+++ b/emcc.bat
@@ -19,4 +19,8 @@
   set CMD=ccache "%~dp0\%~n0.bat"
 )
 
-@%CMD% %*
+:: Python Windows bug https://bugs.python.org/issue34780: If emcc.bat was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@%CMD% %* < NUL

--- a/emcc.bat
+++ b/emcc.bat
@@ -55,7 +55,7 @@
 
 :NORMAL
 @%CMD% %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @%CMD% %*
@@ -63,10 +63,8 @@
 
 :MUTE_STDIN
 @%CMD% %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @%CMD% %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emcc.bat
+++ b/emcc.bat
@@ -5,22 +5,40 @@
 :: To make modifications to this file, edit `tools/run_python_compiler.bat` and
 :: then run `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
+@setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
+:: If _EMCC_CCACHE is not set, do a regular invocation of the python compiler driver.
+:: Otherwise remove the ccache env. var, and then reinvoke this script with ccache enabled.
 @if "%_EMCC_CCACHE%"=="" (
-  :: Do regular invocation of the python compiler driver
   set CMD="%EM_PY%" "%~dp0\%~n0.py"
 ) else (
-  :: Remove the ccache env. var, invoke ccache and re-enter this script to take the above branch.
   set _EMCC_CCACHE=
   set CMD=ccache "%~dp0\%~n0.bat"
 )
 
-:: Python Windows bug https://bugs.python.org/issue34780: If emcc.bat was invoked via a
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
 :: a certain state, running python.exe might hang here. To work around this, invoke python
 :: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@%CMD% %* < NUL
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  %CMD% %*
+) else (
+  %CMD% %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+:: Note that when th
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emcc.bat
+++ b/emcc.bat
@@ -24,21 +24,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  %CMD% %*
-) else (
-  %CMD% %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-:: Note that when th
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    %CMD% %*
+  ) else (
+    %CMD% %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    %CMD% %* < NUL
+  ) else (
+    %CMD% %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emcc.bat
+++ b/emcc.bat
@@ -53,10 +53,6 @@
   )
 )
 
-:NORMAL
-@%CMD% %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @%CMD% %*
 @exit %ERRORLEVEL%
@@ -68,3 +64,6 @@
 :MUTE_STDIN_EXIT
 @%CMD% %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@%CMD% %*

--- a/emcc.bat
+++ b/emcc.bat
@@ -36,18 +36,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    %CMD% %*
+    goto NORMAL
   ) else (
-    %CMD% %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    %CMD% %* < NUL
+    goto MUTE_STDIN
   ) else (
-    %CMD% %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@%CMD% %*
+@goto END
+
+:NORMAL_EXIT
+@%CMD% %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@%CMD% %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@%CMD% %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emcmake.bat
+++ b/emcmake.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emconfigure.bat
+++ b/emconfigure.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emdump.bat
+++ b/emdump.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\tools\emdump.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\tools\emdump.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\tools\emdump.py" %*

--- a/emdump.bat
+++ b/emdump.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\tools\emdump.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\tools\emdump.py" %*
+) else (
+  "%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emdump.bat
+++ b/emdump.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\tools\emdump.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\tools\emdump.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emdump.bat
+++ b/emdump.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\tools\emdump.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\tools\emdump.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\tools\emdump.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\tools\emdump.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emdump.bat
+++ b/emdump.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\tools\emdump.py" %*
-) else (
-  "%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\tools\emdump.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\tools\emdump.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\tools\emdump.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\tools\emdwp.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\tools\emdwp.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\tools\emdwp.py" %*

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\tools\emdwp.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\tools\emdwp.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\tools\emdwp.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\tools\emdwp.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\tools\emdwp.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\tools\emdwp.py" %*
+) else (
+  "%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\tools\emdwp.py" %*
-) else (
-  "%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\tools\emdwp.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\tools\emdwp.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emdwp.bat
+++ b/emdwp.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\tools\emdwp.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\tools\emdwp.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\tools\emdwp.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emmake.bat
+++ b/emmake.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emmake.bat
+++ b/emmake.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emmake.bat
+++ b/emmake.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emmake.bat
+++ b/emmake.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emmake.bat
+++ b/emmake.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emnm.bat
+++ b/emnm.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\tools\emnm.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\tools\emnm.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\tools\emnm.py" %*

--- a/emnm.bat
+++ b/emnm.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\tools\emnm.py" %*
-) else (
-  "%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\tools\emnm.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\tools\emnm.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emnm.bat
+++ b/emnm.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\tools\emnm.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\tools\emnm.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emnm.bat
+++ b/emnm.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\tools\emnm.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\tools\emnm.py" %*
+) else (
+  "%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emnm.bat
+++ b/emnm.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\tools\emnm.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\tools\emnm.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\tools\emnm.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\tools\emnm.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\tools\emnm.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\tools\emprofile.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\tools\emprofile.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\tools\emprofile.py" %*

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\tools\emprofile.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\tools\emprofile.py" %*
+) else (
+  "%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\tools\emprofile.py" %*
-) else (
-  "%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\tools\emprofile.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\tools\emprofile.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\tools\emprofile.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\tools\emprofile.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emprofile.bat
+++ b/emprofile.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\tools\emprofile.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\tools\emprofile.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\tools\emprofile.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\tools\emprofile.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\tools\emprofile.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emranlib.bat
+++ b/emranlib.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emrun.bat
+++ b/emrun.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emrun.bat
+++ b/emrun.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emrun.bat
+++ b/emrun.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emrun.bat
+++ b/emrun.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emrun.bat
+++ b/emrun.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emscons.bat
+++ b/emscons.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emscons.bat
+++ b/emscons.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emscons.bat
+++ b/emscons.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emscons.bat
+++ b/emscons.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emscons.bat
+++ b/emscons.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/emsize.bat
+++ b/emsize.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/emsize.bat
+++ b/emsize.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/emsize.bat
+++ b/emsize.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/emsize.bat
+++ b/emsize.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/emsize.bat
+++ b/emsize.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/tests/runner.bat
+++ b/tests/runner.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/tests/runner.bat
+++ b/tests/runner.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/tests/runner.bat
+++ b/tests/runner.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/tests/runner.bat
+++ b/tests/runner.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/tests/runner.bat
+++ b/tests/runner.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7613,7 +7613,7 @@ int main() {
 
     for directory, headers in directories.items():
       print('dir: ' + directory)
-      for header in headers:
+        for header in headers:
         if not header.endswith('.h'):
           continue
         print('header: ' + header)
@@ -7636,7 +7636,7 @@ int main() {
           create_file('a.c', inc)
           create_file('b.c', inc)
           for std in [[], ['-std=c89']]:
-            self.run_process([EMCC] + std + ['-Werror', '-Wall', '-pedantic', 'a.c', 'b.c'])
+          self.run_process([EMCC] + std + ['-Werror', '-Wall', '-pedantic', 'a.c', 'b.c'])
 
   @is_slow_test
   def test_single_file(self):
@@ -11076,3 +11076,12 @@ void foo() {}
   @node_pthreads
   def test_emscripten_set_timeout_loop(self):
     self.do_runf(test_file('emscripten_set_timeout_loop.c'), args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD'])
+
+  # Verify that we are able to successfully compile a script when the Windows 7
+  # and Python workaround env. vars are enabled.
+  # See https://bugs.python.org/issue34780
+  @with_env_modify({'EM_WORKAROUND_PYTHON_BUG_34780': '1',
+                    'EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG': '1'})
+  def test_windows_batch_script_workaround(self):
+    self.run_process([EMCC, test_file('hello_world.c')])
+    self.assertExists('a.out.js')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7613,7 +7613,7 @@ int main() {
 
     for directory, headers in directories.items():
       print('dir: ' + directory)
-        for header in headers:
+      for header in headers:
         if not header.endswith('.h'):
           continue
         print('header: ' + header)
@@ -7636,7 +7636,7 @@ int main() {
           create_file('a.c', inc)
           create_file('b.c', inc)
           for std in [[], ['-std=c89']]:
-          self.run_process([EMCC] + std + ['-Werror', '-Wall', '-pedantic', 'a.c', 'b.c'])
+            self.run_process([EMCC] + std + ['-Werror', '-Wall', '-pedantic', 'a.c', 'b.c'])
 
   @is_slow_test
   def test_single_file(self):

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/tools/file_packager.bat
+++ b/tools/file_packager.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/tools/run_python.bat
+++ b/tools/run_python.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/tools/run_python.bat
+++ b/tools/run_python.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/tools/run_python.bat
+++ b/tools/run_python.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/tools/run_python.bat
+++ b/tools/run_python.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/tools/run_python.bat
+++ b/tools/run_python.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)

--- a/tools/run_python_compiler.bat
+++ b/tools/run_python_compiler.bat
@@ -55,7 +55,7 @@
 
 :NORMAL
 @%CMD% %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @%CMD% %*
@@ -63,10 +63,8 @@
 
 :MUTE_STDIN
 @%CMD% %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @%CMD% %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/tools/run_python_compiler.bat
+++ b/tools/run_python_compiler.bat
@@ -24,20 +24,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  %CMD% %*
-) else (
-  %CMD% %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    %CMD% %*
+  ) else (
+    %CMD% %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    %CMD% %* < NUL
+  ) else (
+    %CMD% %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/tools/run_python_compiler.bat
+++ b/tools/run_python_compiler.bat
@@ -53,10 +53,6 @@
   )
 )
 
-:NORMAL
-@%CMD% %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @%CMD% %*
 @exit %ERRORLEVEL%
@@ -68,3 +64,6 @@
 :MUTE_STDIN_EXIT
 @%CMD% %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@%CMD% %*

--- a/tools/run_python_compiler.bat
+++ b/tools/run_python_compiler.bat
@@ -36,18 +36,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    %CMD% %*
+    goto NORMAL
   ) else (
-    %CMD% %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    %CMD% %* < NUL
+    goto MUTE_STDIN
   ) else (
-    %CMD% %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@%CMD% %*
+@goto END
+
+:NORMAL_EXIT
+@%CMD% %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@%CMD% %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@%CMD% %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -44,10 +44,6 @@
   )
 )
 
-:NORMAL
-@"%EM_PY%" "%~dp0\%~n0.py" %*
-@exit /b %ERRORLEVEL%
-
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
 @exit %ERRORLEVEL%
@@ -59,3 +55,6 @@
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -46,7 +46,7 @@
 
 :NORMAL
 @"%EM_PY%" "%~dp0\%~n0.py" %*
-@goto END
+@exit /b %ERRORLEVEL%
 
 :NORMAL_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %*
@@ -54,10 +54,8 @@
 
 :MUTE_STDIN
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-@goto END
+@exit /b %ERRORLEVEL%
 
 :MUTE_STDIN_EXIT
 @"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
 @exit %ERRORLEVEL%
-
-:END

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -27,18 +27,37 @@
 :: workaround this issue, which is to explicitly quit the calling process with the previous
 :: errorlevel from the above command.
 
+:: Also must use goto to jump to the command dispatch, since we cannot invoke emcc from
+:: inside a if() block, because if a cmdline param would contain a char '(' or ')', that
+:: would throw off the parsing of the cmdline arg.
 @if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
+    goto NORMAL
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %*
-    exit %ERRORLEVEL%
+    goto NORMAL_EXIT
   )
 ) else (
   @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    goto MUTE_STDIN
   ) else (
-    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-    exit %ERRORLEVEL%
+    goto MUTE_STDIN_EXIT
   )
 )
+
+:NORMAL
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@goto END
+
+:NORMAL_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %*
+@exit %ERRORLEVEL%
+
+:MUTE_STDIN
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@goto END
+
+:MUTE_STDIN_EXIT
+@"%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+@exit %ERRORLEVEL%
+
+:END

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -15,20 +15,30 @@
 
 :: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
 :: shared stdin handle from the parent process, and that parent process stdin handle is in
-:: a certain state, running python.exe might hang here. To work around this, invoke python
-:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
-@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
-  "%EM_PY%" "%~dp0\%~n0.py" %*
-) else (
-  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
-)
+:: a certain state, running python.exe might hang here. To work around this, if
+:: EM_WORKAROUND_PYTHON_BUG_34780 is defined, invoke python with '< NUL' stdin to avoid
+:: sharing the parent's stdin handle to it, avoiding the hang.
 
 :: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
 :: even when the python executable above did succeed and quit with errorlevel 0 above.
 :: On Windows 8 and newer, this issue has not been observed. It is possible that this
 :: issue is related to the above python bug, but this has not been conclusively confirmed,
-:: so using a separate env. var to enable the known workaround this issue, which is to
-:: explicitly quit the calling process with the previous errorlevel from the above command.
-@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
-  exit %ERRORLEVEL%
+:: so using a separate env. var EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG to enable the known
+:: workaround this issue, which is to explicitly quit the calling process with the previous
+:: errorlevel from the above command.
+
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %*
+    exit %ERRORLEVEL%
+  )
+) else (
+  @if "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+  ) else (
+    "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+    exit %ERRORLEVEL%
+  )
 )

--- a/tools/webidl_binder.bat
+++ b/tools/webidl_binder.bat
@@ -5,10 +5,30 @@
 :: To make modifications to this file, edit `tools/run_python.bat` and then run
 :: `tools/create_entry_points.py`
 
+:: All env. vars specified in this file are to be local only to this script.
 @setlocal
+
 @set EM_PY=%EMSDK_PYTHON%
 @if "%EM_PY%"=="" (
   set EM_PY=python
 )
 
-@"%EM_PY%" "%~dp0\%~n0.py" %*
+:: Python Windows bug https://bugs.python.org/issue34780: If this script was invoked via a
+:: shared stdin handle from the parent process, and that parent process stdin handle is in
+:: a certain state, running python.exe might hang here. To work around this, invoke python
+:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
+@if "%EM_WORKAROUND_PYTHON_BUG_34780%"=="" (
+  "%EM_PY%" "%~dp0\%~n0.py" %*
+) else (
+  "%EM_PY%" "%~dp0\%~n0.py" %* < NUL
+)
+
+:: On Windows 7, the compiler batch scripts are observed to exit with a non-zero errorlevel,
+:: even when the python executable above did succeed and quit with errorlevel 0 above.
+:: On Windows 8 and newer, this issue has not been observed. It is possible that this
+:: issue is related to the above python bug, but this has not been conclusively confirmed,
+:: so using a separate env. var to enable the known workaround this issue, which is to
+:: explicitly quit the calling process with the previous errorlevel from the above command.
+@if not "%EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG%"=="" (
+  exit %ERRORLEVEL%
+)


### PR DESCRIPTION
This PR performs the following fixes:

1. Add an env. var `EM_WORKAROUND_PYTHON_BUG_34780` that enables avoiding sharing the parent process's stdin handle to python when invoking python via emcc.bat script, to prevent a rare python deadlock hang bug https://bugs.python.org/issue34780
2. Add an env. var `EM_WORKAROUND_WIN7_BAD_ERRORLEVEL_BUG` that enables explicitly exiting the batch script with python errorlevel code, to work around a Windows 7 bad batch script exit code issue. We have not found a description of this bug on the web, but the issue that occurs is that on Windows 7, the invoked batch scripts return with a nonzero exit code, even if the python subprocess call was clean with exit code zero and the `%ERRORLEVEL%` variable in the batch script itself was zero. This is possibly caused by the same python bug 34780 as above, but we have no confirmation about this. Therefore it is important to treat this separately because the "nuclear option" of `exit %ERRORLEVEL%` will exit the parent shell as well.
3. Fix batch scripts to not leak env. vars to parent shell by adding a `setlocal` directive.
4. Fix a peculiar Windows batch script parsing issue where if a `:: comment` line is placed inside a `if ()` block, it will be somehow parsed by the interpreter. E.g. if one would have a bat script

```bat
@if ""=="" (
:: If _EMCC_CCACHE is not defined below, do a regular invocation of em++.py compiler.
:: Python Windows bug https://bugs.python.org/issue34780: If emcc.bat was invoked via a
:: shared stdin handle from the parent process, and that parent process stdin handle is in
:: a certain state, running python.exe might hang here. To work around this, invoke python
:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
  echo hello
)
```
then running this bat script will print
```
C:\code>test.bat
The system cannot find the drive specified.
The system cannot find the drive specified.
hello
```
These two error prints come from Windows bat script interpreter somehow parsing the comment strings as path names.

However, the following bat script
```bat
:: If _EMCC_CCACHE is not defined below, do a regular invocation of em++.py compiler.
:: Python Windows bug https://bugs.python.org/issue34780: If emcc.bat was invoked via a
:: shared stdin handle from the parent process, and that parent process stdin handle is in
:: a certain state, running python.exe might hang here. To work around this, invoke python
:: with '< NUL' stdin to avoid sharing the parent's stdin handle to it, avoiding the hang.
@if ""=="" (
  echo hello
)
```
correctly prints out
```
C:\code>test.bat
hello
```
so Windows parses comments somehow differently inside `if ()` sections. <b>This means that we should avoid placing `:: comment`s inside `if ()` sections in these batch scripts.