### PR TITLE
Refactor __wasi_fd_write in wasmfs.cpp

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1779,7 +1779,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
     state.forced_stdlibs.append('libwasmfs')
     settings.FILESYSTEM = 0
     settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
-    settings.JS_LIBRARIES.append((0, 'library_wasmfs.js'))
+    # settings.JS_LIBRARIES.append((0, 'library_wasmfs.js')) TODO: populate with library_wasmfs.js later
 
   # Explicitly drop linking in a malloc implementation if program is not using any dynamic allocation calls.
   if not settings.USES_DYNAMIC_ALLOC:

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -1,17 +1,3 @@
-var WasmfsLibrary = {
-  $wasmfsBuffers: [null, [], []],
-  emscripten_wasmfs_printbuffer__deps: ['$wasmfsBuffers'],
-  emscripten_wasmfs_printbuffer: function(stream, ptr, len) {
-    for (var j = 0; j < len; j++) {
-      if (HEAPU8[ptr+j] === 0 || HEAPU8[ptr+j] === 10) {
-        (stream === 1 ? out : err)(UTF8ArrayToString(wasmfsBuffers[stream], 0));
-        wasmfsBuffers[stream].length = 0;
-      } else {
-        wasmfsBuffers[stream].push(HEAPU8[ptr+j]);
-      }
-    }
-    
-  }
-}
+var WasmfsLibrary = {}
 
 mergeInto(LibraryManager.library, WasmfsLibrary);

--- a/src/modules.js
+++ b/src/modules.js
@@ -110,9 +110,10 @@ var LibraryManager = {
         }
         libraries.push('library_noderawfs.js');
       }
-    } else {
-      libraries.push('library_wasmfs.js');
     }
+    //  else {
+    //   libraries.push('library_wasmfs.js');
+    // } TODO: populate with library_wasmfs.js later
 
     // Additional JS libraries (without AUTO_JS_LIBRARIES, link to these explicitly via -lxxx.js)
     if (AUTO_JS_LIBRARIES) {

--- a/src/modules.js
+++ b/src/modules.js
@@ -110,10 +110,8 @@ var LibraryManager = {
         }
         libraries.push('library_noderawfs.js');
       }
-    }
-    //  else {
-    //   libraries.push('library_wasmfs.js');
-    // } TODO: populate with library_wasmfs.js later
+    } 
+    // TODO: populate with libraries.push('library_wasmfs.js') later
 
     // Additional JS libraries (without AUTO_JS_LIBRARIES, link to these explicitly via -lxxx.js)
     if (AUTO_JS_LIBRARIES) {

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -14,7 +14,7 @@
 
 extern "C" {
 
-std::vector<char> buffer;
+static std::vector<char> fd_write_stdstream_buffer;
 
 __wasi_errno_t __wasi_fd_write(
   __wasi_fd_t fd, const __wasi_ciovec_t* iovs, size_t iovs_len, __wasi_size_t* nwritten) {
@@ -31,11 +31,15 @@ __wasi_errno_t __wasi_fd_write(
       for (__wasi_size_t j = 0; j < len; j++) {
         uint8_t current = buf[j];
         if (current == 0 || current == 10) {
-          buffer.push_back('\0'); // for null-terminated C strings
-          emscripten_console_log(&buffer[0]);
-          buffer.clear();
+          fd_write_stdstream_buffer.push_back('\0'); // for null-terminated C strings
+          if (fd == 1) {
+            emscripten_console_log(&fd_write_stdstream_buffer[0]);
+          } else if (fd == 2) {
+            emscripten_console_error(&fd_write_stdstream_buffer[0]);
+          }
+          fd_write_stdstream_buffer.clear();
         } else {
-          buffer.push_back(current);
+          fd_write_stdstream_buffer.push_back(current);
         }
       }
       num += len;

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -31,7 +31,7 @@ __wasi_errno_t __wasi_fd_write(
       for (__wasi_size_t j = 0; j < len; j++) {
         uint8_t current = buf[j];
         if (current == 0 || current == 10) {
-          buffer.push_back('\0');
+          buffer.push_back('\0'); // for null-terminated C strings
           emscripten_console_log(&buffer[0]);
           buffer.clear();
         } else {

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -14,8 +14,6 @@
 
 extern "C" {
 
-int emscripten_wasmfs_printbuffer(__wasi_fd_t fd, const uint8_t* ptr, __wasi_size_t len);
-
 std::string buffer;
 
 __wasi_errno_t __wasi_fd_write(
@@ -34,8 +32,9 @@ __wasi_errno_t __wasi_fd_write(
         char current = *(ptr + j);
         if (current == 0 || current == 10) {
           emscripten_console_log(buffer.c_str());
+          buffer.clear();
         } else {
-          buffer += current;
+          buffer.push_back(current);
         }
       }
       num += len;

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -26,10 +26,10 @@ __wasi_errno_t __wasi_fd_write(
   if (fd == 1 || fd == 2) {
     __wasi_size_t num = 0;
     for (size_t i = 0; i < iovs_len; i++) {
-      const uint8_t* ptr = iovs[i].buf;
+      const uint8_t* buf = iovs[i].buf;
       __wasi_size_t len = iovs[i].buf_len;
       for (__wasi_size_t j = 0; j < len; j++) {
-        char current = *(ptr + j);
+        uint8_t current = buf[j];
         if (current == 0 || current == 10) {
           buffer.push_back('\0');
           emscripten_console_log(&buffer[0]);

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -9,12 +9,12 @@
 #include <emscripten/emscripten.h>
 #include <emscripten/html5.h>
 #include <stdlib.h>
-#include <string>
+#include <vector>
 #include <wasi/api.h>
 
 extern "C" {
 
-std::string buffer;
+std::vector<char> buffer;
 
 __wasi_errno_t __wasi_fd_write(
   __wasi_fd_t fd, const __wasi_ciovec_t* iovs, size_t iovs_len, __wasi_size_t* nwritten) {
@@ -31,7 +31,8 @@ __wasi_errno_t __wasi_fd_write(
       for (__wasi_size_t j = 0; j < len; j++) {
         char current = *(ptr + j);
         if (current == 0 || current == 10) {
-          emscripten_console_log(buffer.c_str());
+          buffer.push_back('\0');
+          emscripten_console_log(&buffer[0]);
           buffer.clear();
         } else {
           buffer.push_back(current);

--- a/tests/common.py
+++ b/tests/common.py
@@ -552,6 +552,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     suffix = '.js' if js_outfile else '.wasm'
     compiler = [compiler_for(filename, force_c)]
     if compiler[0] == EMCC and not self.get_setting('WASMFS'):
+      # TODO change test behaviour in the future when WASMFS becomes default file system
+      # WASMFS is excluded here since it currently requires stdlib++ functions
       # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
       # We link with C++ stdlibs, even when linking with emcc for historical reasons.  We can remove
       # this if this issues is fixed.

--- a/tests/common.py
+++ b/tests/common.py
@@ -551,11 +551,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def build(self, filename, libraries=[], includes=[], force_c=False, js_outfile=True, emcc_args=[], output_basename=None):
     suffix = '.js' if js_outfile else '.wasm'
     compiler = [compiler_for(filename, force_c)]
-    if compiler[0] == EMCC:
-      # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
-      # We link with C++ stdlibs, even when linking with emcc for historical reasons.  We can remove
-      # this if this issues is fixed.
-      compiler.append('-nostdlib++')
+    # if compiler[0] == EMCC:
+    #   # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
+    #   # We link with C++ stdlibs, even when linking with emcc for historical reasons.  We can remove
+    #   # this if this issues is fixed.
+    #   compiler.append('-nostdlib++')
 
     if force_c:
       compiler.append('-xc')

--- a/tests/common.py
+++ b/tests/common.py
@@ -552,9 +552,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     suffix = '.js' if js_outfile else '.wasm'
     compiler = [compiler_for(filename, force_c)]
     if compiler[0] == EMCC and not self.get_setting('WASMFS'):
-    # #   # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
-    # #   # We link with C++ stdlibs, even when linking with emcc for historical reasons.  We can remove
-    # #   # this if this issues is fixed.
+      # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
+      # We link with C++ stdlibs, even when linking with emcc for historical reasons.  We can remove
+      # this if this issues is fixed.
       compiler.append('-nostdlib++')
 
     if force_c:

--- a/tests/common.py
+++ b/tests/common.py
@@ -551,11 +551,11 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def build(self, filename, libraries=[], includes=[], force_c=False, js_outfile=True, emcc_args=[], output_basename=None):
     suffix = '.js' if js_outfile else '.wasm'
     compiler = [compiler_for(filename, force_c)]
-    # if compiler[0] == EMCC:
-    #   # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
-    #   # We link with C++ stdlibs, even when linking with emcc for historical reasons.  We can remove
-    #   # this if this issues is fixed.
-    #   compiler.append('-nostdlib++')
+    if compiler[0] == EMCC and not self.get_setting('WASMFS'):
+    # #   # TODO(https://github.com/emscripten-core/emscripten/issues/11121)
+    # #   # We link with C++ stdlibs, even when linking with emcc for historical reasons.  We can remove
+    # #   # this if this issues is fixed.
+      compiler.append('-nostdlib++')
 
     if force_c:
       compiler.append('-xc')


### PR DESCRIPTION
- Refactor `__wasi_fd_write ` to only use C++
- Utilizes `emscripten_console_log` instead of calling out to JS

Addresses Jukka's comment in #15104