### PR TITLE
Fix inability to load WASM files when a slash is in the JS query/hash

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -583,3 +583,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * on-keyday <rokenboo47803@gmail.com>
 * Matthew Balch <matt5sean3@gmail.com>
 * James Price <jrprice@google.com> (copyright owned by Google, Inc.)
+* Nathan Rugg <nmrugg@gmail.com> (copyright owned by Chess.com, LLC)

--- a/src/shell.js
+++ b/src/shell.js
@@ -347,8 +347,10 @@ if (ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) {
   // otherwise, slice off the final part of the url to find the script directory.
   // if scriptDirectory does not contain a slash, lastIndexOf will return -1,
   // and scriptDirectory will correctly be replaced with an empty string.
+  // If scriptDirectory contains a query (starting with ?) or a fragment (starting with #),
+  // they are removed because they could contain a slash.
   if (scriptDirectory.indexOf('blob:') !== 0) {
-    scriptDirectory = scriptDirectory.substr(0, scriptDirectory.lastIndexOf('/')+1);
+    scriptDirectory = scriptDirectory.substr(0, scriptDirectory.replace(/[?#].*/, "").lastIndexOf('/')+1);
   } else {
     scriptDirectory = '';
   }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5121,6 +5121,20 @@ window.close = function() {
     self.emcc_args += ['-O2', '-s', 'ALLOW_MEMORY_GROWTH', '-s', 'MAXIMUM_MEMORY=4GB', '-s', 'ABORTING_MALLOC=0']
     self.do_run_in_out_file_test('browser', 'test_4GB_fail.cpp')
 
+  # Tests that Emscripten-compiled applications can be run when a slash in the URL query or fragment of the js file
+  def test_browser_run_with_slash_in_query_and_hash(self):
+    self.compile_btest([test_file('browser_test_hello_world.c'), '-o', 'test.html', '-O0'])
+    src = open('test.html').read()
+    # Slash in query
+    create_file('test-query.html', src.replace('test.js', 'test.js?type=pass/fail'))
+    self.run_browser('test-query.html', None, '/report_result?0')
+    # Slash in fragment
+    create_file('test-hash.html', src.replace('test.js', 'test.js#pass/fail'))
+    self.run_browser('test-hash.html', None, '/report_result?0')
+    # Slash in query and fragment
+    create_file('test-query-hash.html', src.replace('test.js', 'test.js?type=pass/fail#pass/fail'))
+    self.run_browser('test-query-hash.html', None, '/report_result?0')
+
   @disabled("only run this manually, to test for race conditions")
   @parameterized({
     'normal': ([],),


### PR DESCRIPTION
`scriptDirectory` is not always correctly set when the URL of the JS file contains a <a href=https://developer.mozilla.org/en-US/docs/Web/API/Location/search>querystring</a> (preceded by a `?`) or a <a href=https://developer.mozilla.org/en-US/docs/Web/API/Location/hash>fragment identifier hash</a> (preceded by a `#`) because these can contain a slash (`/`), which is getting mistaken for part of the path.

Severing JS files with a querystring or hash can be useful for a variety of reasons, including cache busting. (Even base64 encoded strings may contain a slash.)

This PR removes any querystring or fragment hash from `scriptDirectory`.