### PR TITLE
Fix wasm2js1.test_asyncify_lists_removelist_c. NFC

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7545,7 +7545,7 @@ Module['onRuntimeInitialized'] = function() {
     if should_pass:
       self.do_core_test('test_asyncify_lists.cpp', assert_identical=True)
     else:
-       self.do_runf(test_file('core/test_asyncify_lists.cpp'), 'RuntimeError', assert_returncode=NON_ZERO)
+       self.do_runf(test_file('core/test_asyncify_lists.cpp'), ('RuntimeError', 'Thrown at'), assert_returncode=NON_ZERO)
 
     # use of ASYNCIFY_* options may require intermediate debug info. that should
     # not end up emitted in the final binary


### PR DESCRIPTION
I updated the expectations for this failure in #15166 but it turns out
wasm2js generates a different type of error.  For now just check for
both types.  I wonder if we should try to have wasm2js be consistent
here?