### PR TITLE
Run asan and lsan suites without `-O2`

### DIFF
--- a/tests/core/test_em_asm_2.cpp
+++ b/tests/core/test_em_asm_2.cpp
@@ -102,11 +102,11 @@ int main()
   i = EM_ASM_INT("{console.log('5. got int ' + $0); return 7.5;}", 42); printf("5. returned int %d\n", i);
 
   printf("\nEM_ASM_INT: Return an integer in a single brief statement.\n");
-  i = EM_ASM_INT(return HEAP8.length); printf("1. returned statement %d\n", i);
-  i = EM_ASM_INT("return HEAP8.length+1"); printf("2. returned statement %d\n", i);
-  i = EM_ASM_INT({"return HEAP8.length+2"}); printf("3. returned statement %d\n", i);
-  i = EM_ASM_INT({return HEAP8.length+3}); printf("4. returned statement %d\n", i);
-  i = EM_ASM_INT("return HEAP8.length+4"); printf("5. returned statement %d\n", i);
+  i = EM_ASM_INT(return 42); printf("1. returned statement %d\n", i);
+  i = EM_ASM_INT("return 42+1"); printf("2. returned statement %d\n", i);
+  i = EM_ASM_INT({"return 42+2"}); printf("3. returned statement %d\n", i);
+  i = EM_ASM_INT({return 42+3}); printf("4. returned statement %d\n", i);
+  i = EM_ASM_INT("return 42+4"); printf("5. returned statement %d\n", i);
 
   // Note that expressions do not evaluate to return values, but the "return" keyword is needed. That is, the following line would return undefined and store i <- 0.
   // i = EM_ASM_INT(HEAP8.length); printf("returned statement %d\n", i);

--- a/tests/core/test_em_asm_2.out
+++ b/tests/core/test_em_asm_2.out
@@ -113,11 +113,11 @@ EM_ASM_INT: Return an integer back.
 5. returned int 7
 
 EM_ASM_INT: Return an integer in a single brief statement.
-1. returned statement 16777216
-2. returned statement 16777217
-3. returned statement 16777218
-4. returned statement 16777219
-5. returned statement 16777220
+1. returned statement 42
+2. returned statement 43
+3. returned statement 44
+4. returned statement 45
+5. returned statement 46
 
 EM_ASM_DOUBLE: Pass no parameters, return a double.
 1. returning double

--- a/tests/core/test_emptyclass.cpp
+++ b/tests/core/test_emptyclass.cpp
@@ -12,7 +12,6 @@ struct Randomized {
 };
 
 int main(int argc, const char *argv[]) {
-  new Randomized(55);
-
+  Randomized(55);
   return 0;
 }


### PR DESCRIPTION
Running them in `-O2` means llvm does optimizations which can hide
memory leaks (e.g. In some cases it can completely elinate calls
allocations due to malloc/new when the resulting pointer don't escape).

This should also speed up running these test suites.

Also, fix test_em_asm_2 under asan.

This change contains some parts that were split out from #15099.