### PR TITLE
Fix flakiness in test_pthread_c11_threads

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1261,7 +1261,7 @@ var LibraryPThread = {
 
   // This function is call by a pthread to signal that exit() was called and
   // that the entire process should exit.
-  // This function is always called form a pthread, but is executaed on the
+  // This function is always called from a pthread, but is executed on the
   // main thread due the __proxy attribute.
   $exitOnMainThread__deps: ['exit',
 #if !MINIMAL_RUNTIME

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1259,6 +1259,10 @@ var LibraryPThread = {
 #endif
   },
 
+  // This function is call by a pthread to signal that exit() was called and
+  // that the entire process should exit.
+  // This function is always called form a pthread, but is executaed on the
+  // main thread due the __proxy attribute.
   $exitOnMainThread__deps: ['exit',
 #if !MINIMAL_RUNTIME
     '$handleException',
@@ -1266,7 +1270,6 @@ var LibraryPThread = {
   ],
   $exitOnMainThread__proxy: 'async',
   $exitOnMainThread: function(returnCode) {
-    // A pthread has requested to exit the whole application process (runtime).
 #if PTHREADS_DEBUG
     err('exitOnMainThread');
 #endif

--- a/tests/pthread/test_pthread_c11_threads.c
+++ b/tests/pthread/test_pthread_c11_threads.c
@@ -18,14 +18,13 @@ void do_once(void) {
 }
 
 int thread_main(void* arg) {
-  printf("in thread_main %p\n", thrd_current());
-  tss_set(key, thrd_current());
+  printf("in thread_main %p\n", (void*)thrd_current());
+  tss_set(key, (void*)thrd_current());
   call_once(&flag, do_once);
   mtx_lock(&mutex);
   thread_counter--;
   cnd_signal(&cond);
   mtx_unlock(&mutex);
-  printf("done thread_main\n");
   return 42;
 }
 
@@ -35,14 +34,14 @@ int run_with_exit(void* arg) {
 }
 
 void destructor(void* val) {
-  printf("destructor: %p\n", thrd_current());
-  assert(val == thrd_current());
+  printf("destructor: %p\n", (void*)thrd_current());
+  assert(val == (void*)thrd_current());
   destructor_counter++;
 }
 
 int main(int argc, char* argv[]) {
   int result = 0;
-  printf("thrd_current: %p\n", thrd_current());
+  printf("thrd_current: %p\n", (void*)thrd_current());
 
   assert(tss_create(&key, destructor) == thrd_success);
 
@@ -89,7 +88,18 @@ int main(int argc, char* argv[]) {
   // Test thrd_detach
   thrd_t t6;
   assert(thrd_create(&t6, thread_main, NULL) == thrd_success);
+  thread_counter++;
   assert(thrd_detach(t6) == thrd_success);
+
+  // Wait for the thread to at least be done printing before exiting
+  // the process.
+  // We shouldn't need to do this but there is a bug in emscripten
+  // where a deadlock can occur between main thread calling fflush()
+  // during exitRuntime and the detached thread calling print (and
+  // therefore holding the stdout lock).
+  // See https://github.com/emscripten-core/emscripten/issues/14579.
+  while (thread_counter)
+    assert(cnd_wait(&cond, &mutex) == thrd_success);
 
   printf("done!\n");
   return 0;


### PR DESCRIPTION
I tracked down this issue to a deadlock between the detached thread
calling `printf()` (calling proxied write call while hold the stdout
lock) and the main thread trying to shut down the runtime by (calling
`fflush(0`)).

The problem could be addressed if we allowed nested calls to
`emscripten_current_thread_process_queued_calls`.

Fixes: #14579