### PR TITLE
Fix WebGPU build with closure

### DIFF
--- a/src/library_html5_webgpu.js
+++ b/src/library_html5_webgpu.js
@@ -6,13 +6,13 @@
       s += 'LibraryHTML5WebGPU.emscripten_webgpu_import_' + snake_case + '__sig = "ii";';
       s += 'LibraryHTML5WebGPU.emscripten_webgpu_import_' + snake_case + '__deps = ["$WebGPU", "$JsValStore"];';
       s += 'LibraryHTML5WebGPU.emscripten_webgpu_import_' + snake_case + ' = function(handle) { '
-      s += 'return WebGPU["mgr' + CamelCase + '"].create(JsValStore.get(handle));'
+      s += 'return WebGPU.mgr' + CamelCase + '.create(JsValStore.get(handle));'
       s += '};';
 
       s += 'LibraryHTML5WebGPU.emscripten_webgpu_export_' + snake_case + '__sig = "ii";';
       s += 'LibraryHTML5WebGPU.emscripten_webgpu_export_' + snake_case + '__deps = ["$WebGPU", "$JsValStore"];';
       s += 'LibraryHTML5WebGPU.emscripten_webgpu_export_' + snake_case + ' = function(handle) { '
-      s += 'return JsValStore.add(WebGPU["mgr' + CamelCase + '"].get(handle));'
+      s += 'return JsValStore.add(WebGPU.mgr' + CamelCase + '.get(handle));'
       s += '};';
       return s;
     },
@@ -62,7 +62,7 @@ var LibraryHTML5WebGPU = {
 #endif
     var device = Module['preinitializedWebGPUDevice'];
     var deviceWrapper = { queueId: WebGPU.mgrQueue.create(device["queue"]) };
-    return WebGPU["mgrDevice"].create(device, deviceWrapper);
+    return WebGPU.mgrDevice.create(device, deviceWrapper);
   },
 };
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -25,7 +25,7 @@
   // Helper functions for code generation
   global.gpu = {
     makeInitManager: function(type) {
-      var mgr = 'this.mgr' + type
+      var mgr = 'WebGPU.mgr' + type
       return mgr + ' = ' + mgr + ' || makeManager();';
     },
 
@@ -145,7 +145,7 @@ var LibraryWebGPU = {
   $WebGPU__postset: 'WebGPU.initManagers();',
   $WebGPU: {
     initManagers: function() {
-      if (this.mgrDevice) return;
+      if (WebGPU.mgrDevice) return;
 
       function makeManager() {
         return {
@@ -242,7 +242,7 @@ var LibraryWebGPU = {
     makeImageCopyTexture: function(ptr) {
       {{{ gpu.makeCheckDescriptor('ptr') }}}
       return {
-        "texture": this.mgrTexture.get(
+        "texture": WebGPU.mgrTexture.get(
           {{{ makeGetValue('ptr', C_STRUCTS.WGPUImageCopyTexture.texture, '*') }}}),
         "mipLevel": {{{ gpu.makeGetU32('ptr', C_STRUCTS.WGPUImageCopyTexture.mipLevel) }}},
         "origin": WebGPU.makeOrigin3D(ptr + {{{ C_STRUCTS.WGPUImageCopyTexture.origin }}}),
@@ -264,8 +264,8 @@ var LibraryWebGPU = {
     makeImageCopyBuffer: function(ptr) {
       {{{ gpu.makeCheckDescriptor('ptr') }}}
       var layoutPtr = ptr + {{{ C_STRUCTS.WGPUImageCopyBuffer.layout }}};
-      var bufferCopyView = this.makeTextureDataLayout(layoutPtr);
-      bufferCopyView["buffer"] = this.mgrBuffer.get(
+      var bufferCopyView = WebGPU.makeTextureDataLayout(layoutPtr);
+      bufferCopyView["buffer"] = WebGPU.mgrBuffer.get(
         {{{ makeGetValue('ptr', C_STRUCTS.WGPUImageCopyBuffer.buffer, '*') }}});
       return bufferCopyView;
     },

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4480,7 +4480,7 @@ window.close = function() {
 
   @requires_graphics_hardware
   def test_webgpu_basic_rendering(self):
-    for args in [[], ['-s', 'ASSERTIONS'], ['-s', 'MAIN_MODULE=1']]:
+    for args in [[], ['-s', 'ASSERTIONS'], ['-s', 'ASSERTIONS', '--closure=1'], ['-s', 'MAIN_MODULE=1']]:
       self.btest_exit('webgpu_basic_rendering.cpp', args=['-s', 'USE_WEBGPU', '-s', 'EXPORTED_RUNTIME_METHODS=["ccall"]'] + args)
 
   # Tests the feature that shell html page can preallocate the typed array and place it

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4483,6 +4483,10 @@ window.close = function() {
     for args in [[], ['-s', 'ASSERTIONS', '--closure=1'], ['-s', 'MAIN_MODULE=1']]:
       self.btest_exit('webgpu_basic_rendering.cpp', args=['-s', 'USE_WEBGPU', '-s', 'EXPORTED_RUNTIME_METHODS=["ccall"]'] + args)
 
+  def test_webgpu_get_device(self):
+    for args in [['-s', 'ASSERTIONS', '--closure=1']]:
+      self.btest_exit('webgpu_get_device.cpp', args=['-s', 'USE_WEBGPU', '-s', 'EXPORTED_RUNTIME_METHODS=["ccall"]'] + args)
+
   # Tests the feature that shell html page can preallocate the typed array and place it
   # to Module.buffer before loading the script page.
   # In this build mode, the -s INITIAL_MEMORY=xxx option will be ignored.

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4480,7 +4480,7 @@ window.close = function() {
 
   @requires_graphics_hardware
   def test_webgpu_basic_rendering(self):
-    for args in [[], ['-s', 'ASSERTIONS'], ['-s', 'ASSERTIONS', '--closure=1'], ['-s', 'MAIN_MODULE=1']]:
+    for args in [[], ['-s', 'ASSERTIONS', '--closure=1'], ['-s', 'MAIN_MODULE=1']]:
       self.btest_exit('webgpu_basic_rendering.cpp', args=['-s', 'USE_WEBGPU', '-s', 'EXPORTED_RUNTIME_METHODS=["ccall"]'] + args)
 
   # Tests the feature that shell html page can preallocate the typed array and place it

--- a/tests/webgpu_get_device.cpp
+++ b/tests/webgpu_get_device.cpp
@@ -1,0 +1,9 @@
+#include <emscripten.h>
+#include <emscripten/html5_webgpu.h>
+
+int main() {
+  EM_ASM({
+    Module['preinitializedWebGPUDevice'] = { this_is: 'a_dummy_object' };
+  });
+  emscripten_webgpu_get_device();
+}


### PR DESCRIPTION
Hypothesis:
> Closure doesn't understand that functions that use `this.` are methods
rather than constructors, and freely moves them around and inlines them.
To work around it, replace `this.`  with `WebGPU.` (which is consistent
with how most of the file works already).

Fixes #15172