### PR TITLE
Avoid re-using thread IDs. NFC

### DIFF
--- a/src/struct_info_internal.json
+++ b/src/struct_info_internal.json
@@ -9,17 +9,11 @@
               "threadStatus",
               "profilerBlock",
               "self",
-              "tsd",
               "detached",
               "stack",
               "stack_size",
               "result",
-              "attr",
-              "robust_list",
-              "tid",
-              "canceldisable",
-              "cancelasync",
-              "locale"
+              "attr"
             ],
             "thread_profiler_block": [
                 "threadStatus",

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -860,9 +860,8 @@ void __emscripten_init_main_thread(void) {
   __main_pthread.self = &__main_pthread;
   // pthread struct robust_list head should point to itself.
   __main_pthread.robust_list.head = &__main_pthread.robust_list.head;
-
-  // Main thread ID.
-  __main_pthread.tid = (long)&__main_pthread;
-
+  // Main thread ID is always 1.  It can't be 0 because musl assumes
+  // tid is always non-zero.
+  __main_pthread.tid = 1;
   __main_pthread.locale = &libc.global_locale;
 }

--- a/system/lib/pthread/pthread_create.c
+++ b/system/lib/pthread/pthread_create.c
@@ -66,6 +66,9 @@ static void init_file_lock(FILE *f) {
   if (f && f->lock<0) f->lock = 0;
 }
 
+// The main thread is tid 1, and the first created thread gets tid 2.
+static pid_t next_tid = 2;
+
 int __pthread_create(pthread_t *restrict res, const pthread_attr_t *restrict attrp, void *(*entry)(void *), void *restrict arg) {
   // Note on LSAN: lsan intercepts/wraps calls to pthread_create so any
   // allocation we we do here should be considered leaks.
@@ -92,7 +95,7 @@ int __pthread_create(pthread_t *restrict res, const pthread_attr_t *restrict att
   // The pthread struct has a field that points to itself - this is used as a
   // magic ID to detect whether the pthread_t structure is 'alive'.
   new->self = new;
-  new->tid = (uintptr_t)new;
+  new->tid = next_tid++;
 
   // pthread struct robust_list head should point to itself.
   new->robust_list.head = &new->robust_list.head;

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -1488,19 +1488,13 @@
         "pthread": {
             "__size__": 224,
             "attr": 100,
-            "cancelasync": 56,
-            "canceldisable": 52,
             "detached": 60,
-            "locale": 168,
             "profilerBlock": 4,
             "result": 88,
-            "robust_list": 148,
             "self": 8,
             "stack": 72,
             "stack_size": 76,
-            "threadStatus": 0,
-            "tid": 36,
-            "tsd": 96
+            "threadStatus": 0
         },
         "rlimit": {
             "__size__": 16,


### PR DESCRIPTION
I'm not clear this fixes any known issues but it certainly makes
debugging pthread issues easier when each thread has a unique and
non-reusaable ID.

I believe its also safer then resuing the address of the pthread
structure here since that can (and often is) re-used for other
things or indeed other new threads (so it not unique for the
life of the program).

I also noticed that this field (and serveral others) are no longer
needed in `struct_info_internal.json`.