### PR TITLE
Second attempt at fixing test_pthread_c11_threads

### DIFF
--- a/tests/pthread/test_pthread_c11_threads.c
+++ b/tests/pthread/test_pthread_c11_threads.c
@@ -17,6 +17,21 @@ void do_once(void) {
   printf("in do_once\n");
 }
 
+// Because this thread is detached it can still be running
+// when the main thread exits.  And becasue of an emscripten
+// bug (https://github.com/emscripten-core/emscripten/issues/15186).
+// this means we can't write to stdout after the main thread
+// exits.  This means we can't use `thread_main` below because
+// the destructor to the `tss_t key` writes to stdout.
+int thread_main_detached(void* arg) {
+  printf("in thread_main_detached %p\n", (void*)thrd_current());
+  mtx_lock(&mutex);
+  thread_counter--;
+  cnd_signal(&cond);
+  mtx_unlock(&mutex);
+  return 0;
+}
+
 int thread_main(void* arg) {
   printf("in thread_main %p\n", (void*)thrd_current());
   tss_set(key, (void*)thrd_current());
@@ -87,8 +102,7 @@ int main(int argc, char* argv[]) {
 
   // Test thrd_detach
   thrd_t t6;
-  assert(thrd_create(&t6, thread_main, NULL) == thrd_success);
-  thread_counter++;
+  assert(thrd_create(&t6, thread_main_detached, NULL) == thrd_success);
   assert(thrd_detach(t6) == thrd_success);
 
   // Wait for the thread to at least be done printing before exiting
@@ -97,9 +111,8 @@ int main(int argc, char* argv[]) {
   // where a deadlock can occur between main thread calling fflush()
   // during exitRuntime and the detached thread calling print (and
   // therefore holding the stdout lock).
-  // See https://github.com/emscripten-core/emscripten/issues/14579.
-  while (thread_counter)
-    assert(cnd_wait(&cond, &mutex) == thrd_success);
+  // See https://github.com/emscripten-core/emscripten/issues/15186.
+  assert(cnd_wait(&cond, &mutex) == thrd_success);
 
   printf("done!\n");
   return 0;


### PR DESCRIPTION
This time I'm pretty sure the deadlock no longer
occurs.  The issue was the pthread key destcrutor
was calling printf.

Again this doesn't fix the actual issues but avoids
hitting it this test.

Fixes: #14579
See: #15186