### PR TITLE
Fix flakiness in test_pthread_nested_work_queue. NFC

### DIFF
--- a/tests/pthread/test_pthread_nested_work_queue.c
+++ b/tests/pthread/test_pthread_nested_work_queue.c
@@ -1,6 +1,10 @@
 #include <stdio.h>
+#include <stdbool.h>
+#include <stdatomic.h>
 #include <emscripten/threading.h>
 #include <emscripten/emscripten.h>
+
+atomic_bool work_done = false;
 
 void work() {
   // This `work` item is called from within
@@ -9,12 +13,15 @@ void work() {
   // `emscripten_current_thread_process_queued_calls`.
   printf("Begin work\n");
   emscripten_thread_sleep(1);
+  work_done = true;
   printf("End work\n");
 }
 
 void* thread_func(void* _param) {
   printf("Start thread\n");
-  emscripten_thread_sleep(1);
+  while (!work_done) {
+    emscripten_thread_sleep(1);
+  }
   printf("End thread\n");
   return NULL;
 };


### PR DESCRIPTION
Given the right timing the thread could start and finish all before the
work item was scheduled.  We have seen this test flake in this way a few
times recently.