### PR TITLE
Remove unused syscall: _getpgrp. NFC

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -468,11 +468,6 @@ var SyscallsLibrary = {
   __sys_getppid: function() {
     return {{{ PROCINFO.ppid }}};
   },
-  __sys_getpgrp__nothrow: true,
-  __sys_getpgrp__proxy: false,
-  __sys_getpgrp: function() {
-    return {{{ PROCINFO.pgid }}};
-  },
   __sys_setsid__nothrow: true,
   __sys_setsid__proxy: false,
   __sys_setsid: function() {

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -27,7 +27,6 @@
 #define __NR_umask		 60
 #define __NR_dup2		 63
 #define __NR_getppid		 64
-#define __NR_getpgrp		 65
 #define __NR_setsid		 66
 #define __NR_setrlimit		 75
 #define __NR_getrusage		 77
@@ -153,7 +152,6 @@
 #define SYS_umask		 60
 #define SYS_dup2		 63
 #define SYS_getppid		 64
-#define SYS_getpgrp		 65
 #define SYS_setsid		 66
 #define SYS_setrlimit		 75
 #define SYS_getrusage		 77

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h.in
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h.in
@@ -27,7 +27,6 @@
 #define __NR_umask		 60
 #define __NR_dup2		 63
 #define __NR_getppid		 64
-#define __NR_getpgrp		 65
 #define __NR_setsid		 66
 #define __NR_setrlimit		 75
 #define __NR_getrusage		 77

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -36,7 +36,6 @@ long SYS_IMPORT(setpgid) __syscall57(long pid, long gpid);
 long SYS_IMPORT(umask) __syscall60(long mask);
 long SYS_IMPORT(dup2) __syscall63(long oldfd, long newfd);
 long SYS_IMPORT(getppid) __syscall64(void);
-long SYS_IMPORT(getpgrp) __syscall65(void);
 long SYS_IMPORT(setsid) __syscall66(void);
 long SYS_IMPORT(setrlimit) __syscall75(long resource, long limit);
 long SYS_IMPORT(getrusage) __syscall77(long who, long usage);


### PR DESCRIPTION
The implementation of `getpgrp` in musl doesn't use this
syscall but instead uses `getpgid`.  So this syscall is
completely used.