### PR TITLE
Limit output of test.assertNotContained. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -761,10 +761,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     if callable(string):
       string = string()
     if value in string:
-      self.fail("Expected to NOT find '%s' in '%s', diff:\n\n%s" % (
-        limit_size(value), limit_size(string),
-        limit_size(''.join([a.rstrip() + '\n' for a in difflib.unified_diff(value.split('\n'), string.split('\n'), fromfile='expected', tofile='actual')]))
-      ))
+      self.fail("Expected to NOT find '%s' in '%s'" % (limit_size(value), limit_size(string)))
 
   def assertContainedIf(self, value, string, condition):
     if condition:


### PR DESCRIPTION
This is normally used to verify that the file does not contain a certain
string.  Printing the entire file in this case is not normally helpful.
Nor is producing a diff of the file with the thing that it is supposed
to not contain.