### PR TITLE
Add variadic versions of emscripten_console functions

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3442,6 +3442,7 @@ LibraryManager.library = {
 #endif
   },
 
+  emscripten_console_log__sig: 'vi',
   emscripten_console_log: function(str) {
 #if ASSERTIONS
     assert(typeof str === 'number');
@@ -3449,6 +3450,7 @@ LibraryManager.library = {
     out(UTF8ToString(str));
   },
 
+  emscripten_console_warn__sig: 'vi',
   emscripten_console_warn: function(str) {
 #if ASSERTIONS
     assert(typeof str === 'number');
@@ -3456,6 +3458,7 @@ LibraryManager.library = {
     console.warn(UTF8ToString(str));
   },
 
+  emscripten_console_error__sig: 'vi',
   emscripten_console_error: function(str) {
 #if ASSERTIONS
     assert(typeof str === 'number');

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -9,9 +9,16 @@
 extern "C" {
 #endif
 
+// Write directly JavaScript console.  This can be useful for debugging since it
+// bypasses the stdio and filesystem sub-systems.
 void emscripten_console_log(const char *utf8String);
 void emscripten_console_warn(const char *utf8String);
 void emscripten_console_error(const char *utf8String);
+
+// Similar to the above functions but operate with printf-like semantics.
+void emscripten_console_logf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_console_warnf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_console_errorf(const char *utf8String, ...)__attribute__((__format__(printf, 1, 2)));
 
 #ifdef __cplusplus
 }

--- a/system/lib/al.c
+++ b/system/lib/al.c
@@ -10,6 +10,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <emscripten.h>
+#include <emscripten/console.h>
 
 #include <AL/alc.h>
 #include <AL/al.h>
@@ -61,9 +62,7 @@ void* alcGetProcAddress(ALCdevice *device, const ALCchar *name) {
   else if (!strcmp(name, "alcGetStringiSOFT")) { return emscripten_alcGetStringiSOFT; }
   else if (!strcmp(name, "alcResetDeviceSOFT")) { return emscripten_alcResetDeviceSOFT; }
 
-  EM_ASM({
-    err("bad name in alcGetProcAddress: " + UTF8ToString($0));
-  }, name);
+  emscripten_console_errorf("bad name in alcGetProcAddress: %s", name);
   return 0;
 }
 
@@ -160,8 +159,6 @@ void* alGetProcAddress(const ALchar *name) {
 
   // Extensions
 
-  EM_ASM({
-    err("bad name in alGetProcAddress: " + UTF8ToString($0));
-  }, name);
+  emscripten_console_errorf("bad name in alGetProcAddress: %s", name);
   return 0;
 }

--- a/system/lib/gl/webgl1.c
+++ b/system/lib/gl/webgl1.c
@@ -1,5 +1,5 @@
 #include <emscripten/threading.h>
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <string.h>
 #include <stdlib.h>
 #include <sys/types.h>
@@ -34,7 +34,7 @@ EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *targ
   GL_FUNCTION_TRACE(__func__);
   if (!attributes)
   {
-    EM_ASM(console.error('emscripten_webgl_create_context: attributes pointer is null!'));
+    emscripten_console_error("emscripten_webgl_create_context: attributes pointer is null!");
     return 0;
   }
   pthread_once(&tlsInit, InitWebGLTls);

--- a/system/lib/libc/emscripten_console.c
+++ b/system/lib/libc/emscripten_console.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+#include <alloca.h>
+#include <stdarg.h>
+#include <stdio.h>
+
+#include <emscripten/console.h>
+
+static void vlogf(const char* fmt, va_list ap, void (*callback)(const char*)) {
+  va_list ap2;
+  va_copy(ap2, ap);
+  size_t len = vsnprintf(0, 0, fmt, ap2);
+  va_end(ap2);
+  char* buf = alloca(len + 1);
+  vsnprintf(buf, len + 1, fmt, ap);
+  callback(buf);
+}
+
+void emscripten_console_logf(const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vlogf(fmt, ap, &emscripten_console_log);
+  va_end(ap);
+}
+
+void emscripten_console_errorf(const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vlogf(fmt, ap, &emscripten_console_error);
+  va_end(ap);
+}
+
+void emscripten_console_warnf(const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vlogf(fmt, ap, &emscripten_console_warn);
+  va_end(ap);
+}

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -858,6 +858,7 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
           'sigaction.c',
           'sigtimedwait.c',
           'pthread_sigmask.c',
+          'emscripten_console.c',
         ])
 
     libc_files += files_in_path(


### PR DESCRIPTION
This is useful to logging directly to the console, bypassing
the stdio subsystem.  I found these functions useful when
debugging libc and in particular the deadlock in the stdio
subsystem: #15186