### PR TITLE
Remove usage of syscall macros that we don't support

### DIFF
--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -66,17 +66,11 @@
 #define SYS_getgid32		200
 #define SYS_geteuid32		201
 #define SYS_getegid32		202
-#define SYS_setreuid32		203
-#define SYS_setregid32		204
 #define SYS_getgroups32	205
 #define SYS_fchown32		207
-#define SYS_setresuid32	208
 #define SYS_getresuid32	209
-#define SYS_setresgid32	210
 #define SYS_getresgid32	211
 #define SYS_chown32		212
-#define SYS_setuid32		213
-#define SYS_setgid32		214
 #define SYS_mincore		218
 #define SYS_madvise		219
 #define SYS_madvise1		219

--- a/system/lib/libc/musl/src/internal/libc.h
+++ b/system/lib/libc/musl/src/internal/libc.h
@@ -55,7 +55,12 @@ void __unlockfile(FILE *) ATTR_LIBC_VISIBILITY;
 #define UNLOCK(x) __unlock(x)
 
 void __synccall(void (*)(void *), void *);
+#ifdef __EMSCRIPTEN__
+int __setxid_emscripten();
+#define __setxid(a, b, c, d) __setxid_emscripten()
+#else
 int __setxid(int, int, int, int);
+#endif
 
 extern char **__environ;
 


### PR DESCRIPTION
Followup to #15193.  With #15193 I removed the unused implementations,
this change also removes the syscall macros.

This change removes the only place in the codebase where `SYS_xxx`
macros are assumed to be numbers.  This change is part of a bigger
change to switch to using meaningful string names for `SYS_xxx` macros
rather than numbers.