### PR TITLE
Fix performance issue with WebGL 2 glBufferData

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -1767,7 +1767,7 @@ var LibraryGL = {
 
 #if MAX_WEBGL_VERSION >= 2
     if ({{{ isCurrentContextWebGL2() }}}) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
-      if (data) {
+      if (data && size > 0) {
         GLctx.bufferData(target, HEAPU8, usage, data, size);
       } else {
         GLctx.bufferData(target, size, usage);
@@ -1785,7 +1785,7 @@ var LibraryGL = {
   glBufferSubData__sig: 'viiii',
   glBufferSubData: function(target, offset, size, data) {
 #if MAX_WEBGL_VERSION >= 2
-    if ({{{ isCurrentContextWebGL2() }}}) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
+    if ({{{ isCurrentContextWebGL2() }}} && size > 0) { // WebGL 2 provides new garbage-free entry points to call to WebGL. Use those always when possible.
       GLctx.bufferSubData(target, offset, HEAPU8, data, size);
       return;
     }


### PR DESCRIPTION
Turns out the spec is dumb and considers `size` = 0 as "the rest of the buffer", meaning it would try to copy the entire heap if `data` isn't null. This is easily solved by checking for this condition and using a null `data` if `size` is zero.

Unfortunately for bufferSubData, passing just (target, offset, size) doesn't work, so we need to fall back to the method that allocates (can be easily solved with a global size 0 arraybuffer, but I don't know the internals of the emscripten js libraries enough to do it myself quickly)