### PR TITLE
Avoid unnecessary padding in syscall arguments. NFC

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -942,13 +942,13 @@ var SyscallsLibrary = {
   __syscall_mmap2: function(addr, len, prot, flags, fd, off) {
     return syscallMmap2(addr, len, prot, flags, fd, off);
   },
-  __syscall_truncate64: function(path, zero, low, high) {
+  __syscall_truncate64: function(path, low, high) {
     path = SYSCALLS.getStr(path);
     var length = SYSCALLS.get64(low, high);
     FS.truncate(path, length);
     return 0;
   },
-  __syscall_ftruncate64: function(fd, zero, low, high) {
+  __syscall_ftruncate64: function(fd, low, high) {
     var length = SYSCALLS.get64(low, high);
     FS.ftruncate(fd, length);
     return 0;

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -261,8 +261,11 @@ uptr internal_write(fd_t fd, const void *buf, uptr count) {
 uptr internal_ftruncate(fd_t fd, uptr size) {
   sptr res;
 #if SANITIZER_EMSCRIPTEN
+  // The __SYSCALL_LL_O macros that musl uses to split 64-bit arguments
+  // doesn't work in C++ code so we have to do it manually.
+  union { long long ll; long l[2]; } split{ .ll = size };
   HANDLE_EINTR(res, (sptr)internal_syscall(SYSCALL(ftruncate), fd,
-               0, size, 0));
+               split.l[0], split.l[1]));
 #else
   HANDLE_EINTR(res, (sptr)internal_syscall(SYSCALL(ftruncate), fd,
                (OFF_T)size));

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -5,7 +5,7 @@
 #define __SYSCALL_LL_E(x) \
 ((union { long long ll; long l[2]; }){ .ll = x }).l[0], \
 ((union { long long ll; long l[2]; }){ .ll = x }).l[1]
-#define __SYSCALL_LL_O(x) 0, __SYSCALL_LL_E((x))
+#define __SYSCALL_LL_O(x) __SYSCALL_LL_E((x))
 
 #ifdef __cplusplus
 extern "C" {
@@ -66,8 +66,8 @@ long __syscall_rt_sigqueueinfo(long tgid, long sig, long uinfo);
 long __syscall_getcwd(long buf, long size);
 long __syscall_ugetrlimit(long resource, long rlim);
 long __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long off);
-long __syscall_truncate64(long path, long zero, long low, long high);
-long __syscall_ftruncate64(long fd, long zero, long low, long high);
+long __syscall_truncate64(long path, long low, long high);
+long __syscall_ftruncate64(long fd, long low, long high);
 long __syscall_stat64(long path, long buf);
 long __syscall_lstat64(long path, long buf);
 long __syscall_fstat64(long fd, long buf);
@@ -93,7 +93,7 @@ long __syscall_getdents64(long fd, long dirp, long count);
 long __syscall_fcntl64(long fd, long cmd, ...);
 long __syscall_statfs64(long path, long size, long buf);
 long __syscall_fstatfs64(long fd, long size, long buf);
-long __syscall_fadvise64_64(long fd, long zero, long low, long high, long low2, long high2, long advice);
+long __syscall_fadvise64_64(long fd, long low, long high, long low2, long high2, long advice);
 long __syscall_openat(long dirfd, long path, long flags, ...);
 long __syscall_mkdirat(long dirfd, long path, long mode);
 long __syscall_mknodat(long dirfd, long path, long mode, long dev);


### PR DESCRIPTION
The musl syscall ABI defines __SYSCALL_LL_E and __SYSCALL_LL_0
for splitting `long long` arguments into a pair of `long` and
also adding zero paddings.

Emscripten needs the splitting part but doesn't need the extra
zero argument for padding.

This also happens to reduce (from 7 to 6) the max number of argument
needed for any given syscall which will allow the backporting of this
change from musl:

https://github.com/emscripten-core/musl/commit/788d5e24ca19c6291cebd8d1ad5b5ed6abf42665