### PR TITLE
Move stub system calls to native code

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,15 @@ See docs/process.md for more on how version tagging works.
 
 2.0.32
 ------
+- Stub functions from `library_syscall.js` and `library.js` were replaced with
+  native code stubs (See `system/lib/libc/emscripten_syscall_stubs.c`).  This
+  should be better for wasm module portability as well as code size.  As part
+  of this change the return value of `popen` was fixed to return NULL rather
+  than -1 and the `getpwnam` family of functions were changed to return an
+  error rather than throw a JavaScript exception (this behaviour matches what
+  the other stub functions do).  As before, the `ALLOW_UNIMPLEMENTED_SYSCALLS`
+  setting controls whether of not these stubs get included at link time, and
+  `STRICT` disables this setting.
 - Emscripten will now warn when linker-only flags are specified in
   compile-only (`-c`) mode.  Just like with clang itself, this warning can be
   disabled using the flag: `-Wno-unused-command-line-argument`.

--- a/embuilder.py
+++ b/embuilder.py
@@ -52,6 +52,8 @@ MINIMAL_TASKS = [
     'libGL',
     'libhtml5',
     'libsockets',
+    'libstubs',
+    'libstubs-debug',
     'libc_rt_wasm',
     'libc_rt_wasm-optz',
     'struct_info',

--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -197,10 +197,6 @@ function ${name}(${args}) {
         }
       }
 
-      if (!ALLOW_UNIMPLEMENTED_SYSCALLS && LibraryManager.library[ident + '__unimplemented']) {
-        error(`attempt to link unsupport syscall: ${ident} (use -s ALLOW_UNIMPLEMENTED_SYSCALLS (the default) to allow linking with a stub version`);
-      }
-
       var original = LibraryManager.library[ident];
       var snippet = original;
       var redirectedIdent = null;

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -56,14 +56,3 @@ var Runtime = {
   POINTER_SIZE: 4,
   QUANTUM_SIZE: 4,
 };
-
-// Additional runtime elements, that need preprocessing
-
-// "Process info" for syscalls is static and cannot change, so define it using
-// some fixed values
-var PROCINFO = {
-  ppid: 1,
-  pid: 42,
-  sid: 42,
-  pgid: 42
-};

--- a/src/utility.js
+++ b/src/utility.js
@@ -121,7 +121,6 @@ function isJsLibraryConfigIdentifier(ident) {
     '__docs',
     '__import',
     '__nothrow',
-    '__unimplemented',
     '__noleakcheck',
   ];
   return suffixes.some((suffix) => ident.endsWith(suffix));

--- a/system/lib/libc/emscripten_libc_stubs.c
+++ b/system/lib/libc/emscripten_libc_stubs.c
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * Fake/stub implemenations of libc functions.
+ * See emscripten_syscall_stubs.c for fake/stub implemenations of syscalls.
+ */
+
+#include <errno.h>
+#include <grp.h>
+#include <pwd.h>
+#include <string.h>
+#include <time.h>
+#include <spawn.h>
+#include <stdio.h>
+#include <sys/times.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+// ==========================================================================
+// sys/wait.h
+// ==========================================================================
+
+int waitid(idtype_t idtype, id_t id, siginfo_t *infop, int options) {
+  errno = ECHILD;
+  return -1;
+}
+
+// ==========================================================================
+// sys/times.h
+// ==========================================================================
+
+clock_t times(struct tms *buf) {
+  // clock_t times(struct tms *buffer);
+  // http://pubs.opengroup.org/onlinepubs/009695399/functions/times.html
+  // NOTE: This is fake, since we can't calculate real CPU time usage in JS.
+  if (buf) {
+    memset(buf, 0, sizeof(*buf));
+  }
+  return 0;
+}
+
+struct tm *getdate(const char *string) {
+  // struct tm *getdate(const char *string);
+  // http://pubs.opengroup.org/onlinepubs/009695399/functions/getdate.html
+  // TODO: Implement.
+  return 0;
+}
+
+int stime(const time_t *t) {
+  errno = EPERM;
+  return -1;
+}
+
+int clock_getcpuclockid(pid_t pid, clockid_t *clockid) {
+  if (pid < 0) {
+    return ESRCH;
+  }
+  if (pid != 0 && pid != getpid()) {
+    return ENOSYS;
+  }
+  if (clockid) {
+    *clockid = CLOCK_PROCESS_CPUTIME_ID;
+  }
+  return 0;
+}
+
+
+// pwd.h
+
+struct passwd *getpwnam(const char *name) {
+  errno = ENOENT;
+  return 0;
+}
+
+struct passwd *getpwuid(uid_t uid) {
+  errno = ENOENT;
+  return 0;
+}
+
+int getpwnam_r(const char *name, struct passwd *pwd,
+               char *buf, size_t buflen, struct passwd **result) {
+  return ENOENT;
+}
+
+int getpwuid_r(uid_t uid, struct passwd *pwd,
+                      char *buf, size_t buflen, struct passwd **result) {
+  return ENOENT;
+}
+
+void setpwent(void) {
+}
+
+void endpwent(void) {
+}
+
+struct passwd *getpwent(void) {
+  errno = EIO;
+  return NULL;
+}
+
+// grp.h
+
+struct group *getgrnam(const char *name) {
+  errno = ENOENT;
+  return 0;
+}
+
+struct group *getgrgid(gid_t gid) {
+  errno = ENOENT;
+  return 0;
+}
+
+int getgrnam_r(const char *name, struct group *grp,
+               char *buf, size_t buflen, struct group **result) {
+  return ENOENT;
+}
+
+int getgrgid_r(gid_t gid, struct group *grp,
+               char *buf, size_t buflen, struct group **result) {
+  return ENOENT;
+}
+
+struct group *getgrent(void) {
+  errno = EIO;
+  return NULL;
+}
+
+void endgrent(void) {
+}
+
+void setgrent(void) {
+}
+
+// ==========================================================================
+// sys/file.h
+// ==========================================================================
+
+int flock(int fd, int operation) {
+  // int flock(int fd, int operation);
+  // Pretend to succeed
+  return 0;
+}
+
+int chroot(const char *path) {
+  // int chroot(const char *path);
+  // http://pubs.opengroup.org/onlinepubs/7908799/xsh/chroot.html
+  errno = EACCES;
+  return -1;
+}
+
+int execve(const char *pathname, char *const argv[],
+           char *const envp[]) {
+  // int execve(const char *pathname, char *const argv[],
+  //            char *const envp[]);
+  // http://pubs.opengroup.org/onlinepubs/009695399/functions/exec.html
+  // We don't support executing external code.
+  errno = ENOEXEC;
+  return -1;
+}
+
+pid_t fork(void) {
+  // pid_t fork(void);
+  // http://pubs.opengroup.org/onlinepubs/000095399/functions/fork.html
+  // We don't support multiple processes.
+  errno = ENOSYS;
+  return -1;
+}
+
+pid_t vfork(void) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int posix_spawn(pid_t *pid, const char *path,
+                       const posix_spawn_file_actions_t *file_actions,
+                       const posix_spawnattr_t *attrp,
+                       char *const argv[], char *const envp[]) {
+  errno = ENOSYS;
+  return -1;
+}
+
+FILE *popen(const char *command, const char *type) {
+  errno = ENOSYS;
+  return NULL;
+}
+
+int pclose(FILE *stream) {
+  errno = ENOSYS;
+  return -1;
+}
+
+int setgroups(size_t size, const gid_t *list) {
+  // int setgroups(int ngroups, const gid_t *gidset);
+  // https://developer.apple.com/library/mac/#documentation/Darwin/Reference/ManPages/man2/setgroups.2.html
+  if (size < 1 || size > sysconf(_SC_NGROUPS_MAX)) {
+    errno = EINVAL;
+    return -1;
+  }
+  // We have just one process/user/group, so it makes no sense to set groups.
+  errno = EPERM;
+  return -1;
+}

--- a/system/lib/libc/emscripten_syscall_stubs.c
+++ b/system/lib/libc/emscripten_syscall_stubs.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ *
+ * Unimplemented/dummy syscall implemenations. These fall into 3 catagories.
+ *
+ * 1. Fake it, use dummy/placeholder values and return success.
+ * 2. Fake it, as above but warn at runtime if called.
+ * 3. Return ENOSYS and warn at runtime if called.
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <syscall_arch.h>
+#include <string.h>
+#include <sys/resource.h>
+#include <sys/stat.h>
+#include <time.h>
+#include <sys/utsname.h>
+
+static int g_pid = 42;
+static int g_pgid = 42;
+static int g_ppid = 1;
+static int g_sid = 42;
+static mode_t g_umask = S_IRWXU | S_IRWXG | S_IRWXO;
+
+#ifdef NDEBUG
+#define REPORT(name)
+#else
+#define REPORT(name) \
+  fprintf(stderr, "warning: unsupported syscall: __syscall_" #name "\n");
+#endif
+
+#define UNIMPLEMENTED(name, args) \
+  long __syscall_##name args { \
+    REPORT(name); \
+    return -ENOSYS; \
+  }
+
+long __syscall_uname(long buf) {
+  if (!buf) {
+    return -EFAULT;
+  }
+  struct utsname *utsname = (struct utsname *)buf;
+
+  strcpy(utsname->sysname, "Emscripten");
+  strcpy(utsname->nodename, "emscripten");
+  strcpy(utsname->release, "1.0");
+  strcpy(utsname->version, "#1");
+#ifdef __wams64__
+  strcpy(utsname->machine, "wasm64");
+#else
+  strcpy(utsname->machine, "wasm32");
+#endif
+  return 0;
+}
+
+long __syscall_setpgid(long pid, long pgid) {
+  if (pid && pid != g_pid) {
+    return -ESRCH;
+  }
+  if (pgid && pgid != g_pgid) {
+    return -EPERM;
+  }
+  return 0;
+}
+
+long __syscall_sync() {
+  return 0;
+}
+
+long __syscall_getsid(long pid) {
+  if (pid && pid != g_pid) {
+    return -ESRCH;
+  }
+  return g_sid;
+}
+
+long __syscall_getpgid(long pid) {
+  if (pid && pid != g_pid) {
+    return -ESRCH;
+  }
+  return g_pgid;
+}
+
+long __syscall_getpid() {
+  return g_pid;
+}
+
+long __syscall_getppid() {
+  return g_ppid;
+}
+
+long __syscall_link(long oldpath, long newpath) {
+  return -EMLINK; // no hardlinks for us
+}
+
+long __syscall_nice(long inc) {
+  return -EPERM; // no meaning to nice for our single-process environment
+}
+
+long __syscall_getgroups32(long size, long list) {
+  if (size < 1) {
+    return -EINVAL;
+  }
+  ((gid_t*)list)[0] = 0;
+  return 1;
+}
+
+long __syscall_setsid() {
+  return 0; // no-op
+}
+
+long  __syscall_umask(long mask) {
+  long old = g_umask;
+  g_umask = mask;
+  return old;
+}
+
+long __syscall_setrlimit(long resource, long limit) {
+  return 0; // no-op
+}
+
+long __syscall_getrusage(long who, long usage) {
+  REPORT(getrusage);
+  struct rusage *u = (struct rusage *)usage;
+  memset(u, 0, sizeof(*u));
+  u->ru_utime.tv_sec = 1;
+  u->ru_utime.tv_usec = 2;
+  u->ru_stime.tv_sec = 3;
+  u->ru_stime.tv_usec = 4;
+  return 0;
+}
+
+long __syscall_getpriority(long which, long who) {
+  return 0;
+}
+
+long __syscall_setpriority(long which, long who, long prio) {
+  return -EPERM;
+}
+
+long __syscall_setdomainname(long name, long size) {
+  return -EPERM;
+}
+
+long __syscall_getresuid32(long ruid, long euid, long suid) {
+  *((uid_t *)ruid) = 0;
+  *((uid_t *)euid) = 0;
+  *((uid_t *)suid) = 0;
+  return 0;
+}
+
+long __syscall_getresgid32(long ruid, long euid, long suid) {
+  REPORT(getresgid32);
+  *((uid_t *)ruid) = 0;
+  *((uid_t *)euid) = 0;
+  *((uid_t *)suid) = 0;
+  return 0;
+}
+
+long __syscall_pause() {
+  REPORT(pause);
+  return -EINTR; // we can't pause
+}
+
+long __syscall_madvise(long addr, long length, long advice) {
+  REPORT(madvise);
+  // advice is welcome, but ignored
+  return 0;
+}
+
+long __syscall_mlock(long addr, long len) {
+  REPORT(mlock);
+  return 0;
+}
+
+long __syscall_munlock(long addr, long len) {
+  REPORT(munlock);
+  return 0;
+}
+
+long __syscall_mprotect(long addr, long len, long size) {
+  REPORT(mprotect);
+  return 0; // let's not and say we did
+}
+
+long __syscall_mremap(long old_addr, long old_size, long new_size, long flags, long new_addr) {
+  REPORT(mremap);
+  return -ENOMEM; // never succeed
+}
+
+long __syscall_mlockall(long flags) {
+  REPORT(mlockall);
+  return 0;
+}
+
+long __syscall_munlockall() {
+  REPORT(munlockall);
+  return 0;
+}
+
+long __syscall_prlimit64(long pid, long resource, long new_limit, long old_limit) {
+  REPORT(prlimit64);
+  struct rlimit *old = (struct rlimit *)old_limit;
+  if (old) { // just report no limits
+    old->rlim_cur = RLIM_INFINITY;
+    old->rlim_max = RLIM_INFINITY;
+  }
+  return 0;
+}
+
+long __syscall_ugetrlimit(long resource, long rlim) {
+  REPORT(ugetrlimit);
+  struct rlimit * limits = (struct rlimit *)rlim;
+  limits->rlim_cur = RLIM_INFINITY;
+  limits->rlim_max = RLIM_INFINITY;
+  return 0; // just report no limits
+}
+
+long __syscall_setsockopt(long sockfd, long level, long optname, long optval, long optlen, long dummy) {
+  REPORT(setsockopt);
+  return -ENOPROTOOPT; // The option is unknown at the level indicated.
+}
+
+long __syscall_rt_sigqueueinfo(long tgid, long pid, long uinfo) {
+  REPORT(rt_sigqueueinfo);
+  return 0;
+}
+
+UNIMPLEMENTED(acct, (long filename))
+UNIMPLEMENTED(mincore, (long addr, long length, long vec))
+UNIMPLEMENTED(pipe2, (long fds, long flags))
+UNIMPLEMENTED(pselect6, (long nfds, long readfds, long writefds, long exceptfds, long timeout, long sigmaks))
+UNIMPLEMENTED(recvmmsg, (long sockfd, long msgvec, long vlen, long flags, ...))
+UNIMPLEMENTED(sendmmsg, (long sockfd, long msgvec, long vlen, long flags, ...))
+UNIMPLEMENTED(setitimer, (long which, long new_value, long old_value))
+UNIMPLEMENTED(getitimer, (long which, long old_value))
+UNIMPLEMENTED(shutdown, (long sockfd, long level, long optname, long optval, long optlen, long dummy))
+UNIMPLEMENTED(socketpair, (long sockfd, long level, long optname, long optval, long optlen, long dummy))
+UNIMPLEMENTED(wait4,(long pid, long wstatus, long options, long rusage))

--- a/tests/core/test_support_errno.c
+++ b/tests/core/test_support_errno.c
@@ -9,10 +9,10 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
-#include <unistd.h>
+#include <time.h>
 
 int main() {
-  pid_t rtn =  fork();
+  int rtn = clock_gettime(-1, NULL);
   printf("rtn     : %d\n", rtn);
   printf("errno   : %d\n", errno);
   printf("strerror: %s\n", strerror(errno));

--- a/tests/core/test_support_errno.out
+++ b/tests/core/test_support_errno.out
@@ -1,3 +1,3 @@
 rtn     : -1
-errno   : 52
-strerror: Function not implemented
+errno   : 28
+strerror: Invalid argument

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5466,6 +5466,7 @@ Module['onRuntimeInitialized'] = function() {
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
   def test_unistd_misc(self):
+    self.set_setting('LLD_REPORT_UNDEFINED')
     orig_compiler_opts = self.emcc_args.copy()
     for fs in ['MEMFS', 'NODEFS']:
       self.emcc_args = orig_compiler_opts + ['-D' + fs]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10902,7 +10902,7 @@ void foo() {}
     cmd = [EMCC, 'main.c', '-sASSERTIONS'] + args
     if args:
       err = self.expect_fail(cmd)
-      self.assertContained('error: attempt to link unsupport syscall: __syscall_mincore (use -s ALLOW_UNIMPLEMENTED_SYSCALLS (the default) to allow linking with a stub version', err)
+      self.assertContained('error: undefined symbol: __syscall_mincore', err)
     else:
       self.run_process(cmd)
       err = self.run_js('a.out.js')

--- a/tests/unistd/misc.out
+++ b/tests/unistd/misc.out
@@ -27,7 +27,7 @@ fchown(good): 0, errno: 0
 fchown(bad): -1, errno: 8
 fork: -1, errno: 52
 vfork: -1, errno: 52
-popen: 0xffffffff, errno: 52
+popen: 0, errno: 52
 pclose: -1, errno: 52
 crypt: ba4TuD1iozTxw, errno: 0
 encrypt, errno: 0

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -188,7 +188,6 @@ _deps_info = {
   # dependency.
   'setjmp': ['malloc', 'free', 'saveSetjmp', 'setThrew'],
   'setprotoent': ['malloc'],
-  'setgroups': ['sysconf'],
   'syslog': ['malloc', 'ntohs'],
   'vsyslog': ['malloc', 'ntohs'],
   'timegm': ['_get_tzname', '_get_daylight', '_get_timezone', 'malloc'],

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1459,6 +1459,39 @@ class libjsmath(Library):
     return super(libjsmath, self).can_use() and settings.JS_MATH
 
 
+class libstubs(Library):
+  name = 'libstubs'
+  cflags = ['-O2']
+  src_dir = 'system/lib/libc'
+  src_files = ['emscripten_syscall_stubs.c', 'emscripten_libc_stubs.c']
+
+  def __init__(self, **kwargs):
+    self.is_debug = kwargs.pop('is_debug')
+    super().__init__(**kwargs)
+
+  def get_base_name(self):
+    name = super().get_base_name()
+    if self.is_debug:
+      name += '-debug'
+    return name
+
+  def get_cflags(self):
+    cflags = super().get_cflags()
+    if self.is_debug:
+      cflags += ['-UNDEBUG']
+    else:
+      cflags += ['-DNDEBUG']
+    return cflags
+
+  @classmethod
+  def vary_on(cls):
+    return super().vary_on() + ['is_debug']
+
+  @classmethod
+  def get_default_variation(cls, **kwargs):
+    return super().get_default_variation(is_debug=settings.ASSERTIONS, **kwargs)
+
+
 # If main() is not in EXPORTED_FUNCTIONS, it may be dce'd out. This can be
 # confusing, so issue a warning.
 def warn_on_unexported_main(symbolses):
@@ -1597,6 +1630,8 @@ def calculate(input_files, forced):
     if settings.PRINTF_LONG_DOUBLE:
       add_library('libprintf_long_double')
 
+    if settings.ALLOW_UNIMPLEMENTED_SYSCALLS:
+      add_library('libstubs')
     add_library('libc')
     add_library('libcompiler_rt')
     if settings.LINK_AS_CXX:


### PR DESCRIPTION
This change removes a lot of JS functions and a lot of wasm imports.  It
will allow these stubs to be inlined and eliminated by binaryen and will
make STANDALONE_WASM binaries a lot more compatible with other wasm
runtimes by eliminating a whole set of `env` imports.