### PR TITLE
Avoid using __cxa_thread_atexit for pthread_cleanup_push.

### DIFF
--- a/system/lib/pthread/emscripten_tls_init.c
+++ b/system/lib/pthread/emscripten_tls_init.c
@@ -19,8 +19,6 @@
 // linker-generated symbol that loads static TLS data at the given location.
 extern void __wasm_init_tls(void *memory);
 
-extern int __cxa_thread_atexit(void (*)(void *), void *, void *);
-
 extern int __dso_handle;
 
 void* emscripten_tls_init(void) {


### PR DESCRIPTION
These is no need to use `__cxa_thread_atexit` here, we can just call
these functions during thread exit (which is what musl does).

This also avoids references `__cxa_thread_atexit` which is normally a
libc++abi symbol from C programs.

Needed by (split out from) #14489.