### PR TITLE
Fix calling `pthread_exit()` from `main()`

### DIFF
--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -199,7 +199,7 @@ int pthread_cancel(pthread_t thread) {
 }
 
 _Noreturn void __pthread_exit(void* status) {
-   exit((int)status);
+   exit(0);
 }
 
 weak_alias(__pthread_exit, pthread_exit);

--- a/system/lib/pthread/pthread_create.c
+++ b/system/lib/pthread/pthread_create.c
@@ -137,9 +137,7 @@ void _emscripten_thread_exit(void* result) {
   __lock(self->exitlock);
 
   if (self == emscripten_main_browser_thread_id()) {
-    // FIXME(sbc): When pthread_exit causes the entire application to exit
-    // we should be returning zero (according to the man page for pthread_exit).
-    exit((intptr_t)result);
+    exit(0);
     return;
   }
 

--- a/tests/core/pthread/test_pthread_exit_main.c
+++ b/tests/core/pthread/test_pthread_exit_main.c
@@ -1,0 +1,12 @@
+// Tests calling pthread_exit() from main() which should cause
+// the program to exit with status 0.
+
+#include <pthread.h>
+#include <stdio.h>
+
+int main() {
+  printf("main\n");
+  pthread_exit((void*)42);
+  __builtin_trap();
+  return 99;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8403,6 +8403,15 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.do_run_in_out_file_test('core/pthread/test_pthread_exit_runtime.c', assert_returncode=42)
 
   @node_pthreads
+  def test_pthread_exit_main(self):
+    self.set_setting('EXIT_RUNTIME')
+    self.do_run_in_out_file_test('core/pthread/test_pthread_exit_main.c')
+
+  def test_pthread_exit_main_stub(self):
+    self.set_setting('EXIT_RUNTIME')
+    self.do_run_in_out_file_test('core/pthread/test_pthread_exit_main.c')
+
+  @node_pthreads
   @no_wasm2js('wasm2js does not support PROXY_TO_PTHREAD (custom section support)')
   def test_pthread_offset_converter(self):
     self.set_setting('PROXY_TO_PTHREAD')

--- a/tests/test_posixtest.py
+++ b/tests/test_posixtest.py
@@ -90,7 +90,6 @@ unsupported = {
   'test_pthread_cond_wait_2_2': 'lacking necessary mmap() support',
   'test_pthread_create_8_1': 'signals are not supported',
   'test_pthread_create_8_2': 'signals are not supported',
-  'test_pthread_create_10_1': 'signals are not supported',
   'test_pthread_create_11_1': '_POSIX_THREAD_CPUTIME not supported',
   'test_pthread_getcpuclockid_1_1': 'pthread_getcpuclockid not supported',
   'test_pthread_getschedparam_1_3': 'scheduling policy/parameters are not supported',


### PR DESCRIPTION
When `pthread_exit()` is called from main the return code of the
process should 0 and not the value passed to `pthread_exit` (that
value is only ever visible to the caller of `pthread_join`).