### PR TITLE
Remove some (incorrect?) use of QUANTUM_SIZE

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -585,7 +585,7 @@ LibraryManager.library = {
     var dst = (summerOffset != winterOffset && date.getTimezoneOffset() == Math.min(winterOffset, summerOffset))|0;
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_isdst, 'dst', 'i32') }}};
 
-    var zonePtr = {{{ makeGetValue('__get_tzname()', 'dst ? ' + Runtime.QUANTUM_SIZE + ' : 0', 'i32') }}};
+    var zonePtr = {{{ makeGetValue('__get_tzname()', 'dst ? ' + Runtime.POINTER_SIZE + ' : 0', 'i32') }}};
     {{{ makeSetValue('tmPtr', C_STRUCTS.tm.tm_zone, 'zonePtr', 'i32') }}};
 
     return tmPtr;
@@ -685,10 +685,10 @@ LibraryManager.library = {
     if (summerOffset < winterOffset) {
       // Northern hemisphere
       {{{ makeSetValue('__get_tzname()', '0', 'winterNamePtr', 'i32') }}};
-      {{{ makeSetValue('__get_tzname()', Runtime.QUANTUM_SIZE, 'summerNamePtr', 'i32') }}};
+      {{{ makeSetValue('__get_tzname()', Runtime.POINTER_SIZE, 'summerNamePtr', 'i32') }}};
     } else {
       {{{ makeSetValue('__get_tzname()', '0', 'summerNamePtr', 'i32') }}};
-      {{{ makeSetValue('__get_tzname()', Runtime.QUANTUM_SIZE, 'winterNamePtr', 'i32') }}};
+      {{{ makeSetValue('__get_tzname()', Runtime.POINTER_SIZE, 'winterNamePtr', 'i32') }}};
     }
   },
 

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -2264,9 +2264,9 @@ var LibrarySDL = {
         }
       }
       var callStbImage = function(func, params) {
-        var x = Module['_malloc']({{{ Runtime.QUANTUM_SIZE }}});
-        var y = Module['_malloc']({{{ Runtime.QUANTUM_SIZE }}});
-        var comp = Module['_malloc']({{{ Runtime.QUANTUM_SIZE }}});
+        var x = Module['_malloc']({{{ getNativeTypeSize('i32') }}});
+        var y = Module['_malloc']({{{ getNativeTypeSize('i32') }}});
+        var comp = Module['_malloc']({{{ getNativeTypeSize('i32') }}});
         addCleanup(function() {
           Module['_free'](x);
           Module['_free'](y);


### PR DESCRIPTION
These are the last two remaining uses of QUANTUM_SIZE outside
runtime.js where is is defined.

For accessing the second element of _get_tzname() I believe
POINTER_SIZE is more approprate because _get_tzname() returns
the address of an array of 2 pointers.

For allocating the arguments to callStbImage I beleive sizeof
i32 is more approprate because the args are all of type `int*`:

`stbi_uc *stbi_load_from_memory(stbi_uc const *buffer, int len, int *x, int *y, int *comp, int req_comp)`