### PR TITLE
Remove emscripten_sync_run_in_main_thread_xprintf_varargs

### DIFF
--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -18,7 +18,6 @@
 #include <stdatomic.h>
 #include <stdarg.h>
 #include <stdbool.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <sys/ioctl.h>
 #include <sys/mman.h>
@@ -487,29 +486,6 @@ void* emscripten_sync_run_in_main_thread_2(
   q.args[1].vp = arg2;
   q.returnValue.vp = 0;
   emscripten_sync_run_in_main_thread(&q);
-  return q.returnValue.vp;
-}
-
-void* emscripten_sync_run_in_main_thread_xprintf_varargs(
-  int function, int param0, const char* format, ...) {
-  va_list args;
-  va_start(args, format);
-  const int CAP = 128;
-  char str[CAP];
-  char* s = str;
-  int len = vsnprintf(s, CAP, format, args);
-  if (len >= CAP) {
-    s = (char*)malloc(len + 1);
-    va_start(args, format);
-    len = vsnprintf(s, len + 1, format, args);
-  }
-  em_queued_call q = {function};
-  q.args[0].vp = (void*)param0;
-  q.args[1].vp = s;
-  q.returnValue.vp = 0;
-  emscripten_sync_run_in_main_thread(&q);
-  if (s != str)
-    free(s);
   return q.returnValue.vp;
 }
 


### PR DESCRIPTION
I can't see where this function was ever used, and it not declared
in any header.

This function was first added in 3b99bb7bef220ad98760b117d14854098f86db9e
and at that point was used to implement fprintf and friends in
src/library.js, but then that code was completely removed in
d92efe09c6bc825539f9ce8f7e10ac2fcde0bdaf.