### PR TITLE
Inform Acorn that the source type is a Module when EXPORT_ES6

### DIFF
--- a/tests/export_module.js
+++ b/tests/export_module.js
@@ -1,0 +1,5 @@
+function doNothing() {
+  return false;
+}
+
+export {doNothing};

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -235,6 +235,11 @@ class other(RunnerCore):
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-s', 'EXPORT_ES6=1', '-s', 'MODULARIZE=0'])
     self.assertContained('EXPORT_ES6 requires MODULARIZE to be set', err)
 
+  def test_export_es6_allows_export_in_post_js(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-s', 'EXPORT_ES6=1', '--post-js', test_file('export_module.js')])
+    src = read_file('a.out.js')
+    self.assertContained('export {doNothing};', src)
+  
   def test_emcc_out_file(self):
     # Verify that "-ofile" works in addition to "-o" "file"
     self.run_process([EMCC, '-c', '-ofoo.o', test_file('hello_world.c')])

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1812,6 +1812,14 @@ if (closureFriendly > -1) {
   closureFriendly = false;
 }
 
+var exportES6 = arguments.indexOf('--exportES6');
+if (exportES6 > -1) {
+  arguments.splice(exportES6, 1);
+  exportES6 = true;
+} else {
+  exportES6 = false;
+}
+
 var infile = arguments[0];
 var passes = arguments.slice(1);
 
@@ -1830,7 +1838,8 @@ try {
     // Keep in sync with --language_in that we pass to closure in building.py
     ecmaVersion: 2020,
     preserveParens: closureFriendly,
-    onComment: closureFriendly ? sourceComments : undefined
+    onComment: closureFriendly ? sourceComments : undefined,
+    sourceType: exportES6 ? "module" : "script"
   });
 } catch (err) {
   err.message += (function() {

--- a/tools/building.py
+++ b/tools/building.py
@@ -630,6 +630,8 @@ def acorn_optimizer(filename, passes, extra_info=None, return_output=False):
   # will be carried over to a later Closure run.
   if settings.USE_CLOSURE_COMPILER:
     cmd += ['--closureFriendly']
+  if settings.EXPORT_ES6:
+    cmd += ['--exportES6']
   if settings.VERBOSE:
     cmd += ['verbose']
   if not return_output:


### PR DESCRIPTION
Hi, I am a new contributor and this looked like an easy change to start with. This pull request fixes #13937 and adds a simple test case.