### PR TITLE
WebGPU: fix handling of WGPU_WHOLE_SIZE

### DIFF
--- a/src/library_int53.js
+++ b/src/library_int53.js
@@ -93,29 +93,34 @@ mergeInto(LibraryManager.library, {
     return HEAPU32[ptr>>2] + HEAPU32[ptr+4>>2] * 4294967296;
   },
 
-  // Converts the given 32-bit low-high pair to a signed 53-bit integer with
-  // the sign of the high word (and represented as a JavaScript Number).
+  // Converts the given 32-bit low-high pair to a signed JavaScript number value
+  // (with rounding beyond +/- 2^53).
+  // The result will have the sign of the high word.
   // The signedness of the low word doesn't matter; it will be bit-cast to u32.
   // TODO: Add $convertI32PairToI53Signaling() variant.
   $convertI32PairToI53: function(lo, hi) {
+#if ASSERTIONS
+    // This function should not be getting called with too large unsigned numbers
+    // in high part (if hi >= 0x7FFFFFFFF, one should have been calling
+    // convertU32PairToI53())
+    assert(hi === (hi|0));
+#endif
     var result = (lo >>> 0) + hi * 4294967296;
 #if ASSERTIONS
-    // Value should not have been rounded: lower word should be equal.
-    assert((result >>> 0) == (lo >>> 0));
+    if ((result >>> 0) != (lo >>> 0)) warnOnce('convertI32PairToI53() resulted in rounding lo=0x' + lo.toString(16) + ', hi=0x' + hi.toString(16) + ' to 0x' + result.toString(16));
 #endif
     return result;
   },
 
-  // Converts the given 32-bit low-high pair to an unsigned 53-bit integer with
-  // the sign of the high word (and represented as a JavaScript Number).
-  // The signedness of the low word doesn't matter; it will be bit-cast to u32.
+  // Converts the given 32-bit low-high pair to an unsigned JavaScript number value
+  // (with rounding beyond 2^53).
+  // The signedness of each word doesn't matter; they will be bit-cast to u32.
   // TODO: Add $convertU32PairToI53Signaling() variant.
   $convertU32PairToI53: function(lo, hi) {
     var result = (lo >>> 0) + (hi >>> 0) * 4294967296;
 #if ASSERTIONS
-    // Value should not have been rounded: lower word should be equal.
-    assert((result >>> 0) == (lo >>> 0));
+    if ((result >>> 0) != (lo >>> 0)) warnOnce('convertU32PairToI53() resulted in rounding (lo=0x' + lo + ', hi=0x' + hi + ') to 0x' + result.toString(16));
 #endif
     return result;
-  }
+  },
 });

--- a/src/library_int53.js
+++ b/src/library_int53.js
@@ -98,11 +98,12 @@ mergeInto(LibraryManager.library, {
   // The signedness of the low word doesn't matter; it will be bit-cast to u32.
   // TODO: Add $convertI32PairToI53Signaling() variant.
   $convertI32PairToI53: function(lo, hi) {
+    var result = (lo >>> 0) + hi * 4294967296;
 #if ASSERTIONS
-    // Value should not be outside the 53-bit integer range.
-    assert(hi >= -0x200000 && hi <= 0x200000);
+    // Value should not have been rounded: lower word should be equal.
+    assert((result >>> 0) == (lo >>> 0));
 #endif
-    return (lo >>> 0) + hi * 4294967296;
+    return result;
   },
 
   // Converts the given 32-bit low-high pair to an unsigned 53-bit integer with
@@ -110,10 +111,11 @@ mergeInto(LibraryManager.library, {
   // The signedness of the low word doesn't matter; it will be bit-cast to u32.
   // TODO: Add $convertU32PairToI53Signaling() variant.
   $convertU32PairToI53: function(lo, hi) {
+    var result = (lo >>> 0) + (hi >>> 0) * 4294967296;
 #if ASSERTIONS
-    // Value should not be outside the 53-bit integer range.
-    assert(hi >= 0 && hi <= 0x200000);
+    // Value should not have been rounded: lower word should be equal.
+    assert((result >>> 0) == (lo >>> 0));
 #endif
-    return (lo >>> 0) + (hi >>> 0) * 4294967296;
+    return result;
   }
 });

--- a/src/library_int53.js
+++ b/src/library_int53.js
@@ -83,14 +83,26 @@ mergeInto(LibraryManager.library, {
   // converts it to a JavaScript Number, which can represent 53 integer bits precisely.
   // TODO: Add $readI53FromI64Signaling() variant.
   $readI53FromI64: function(ptr) {
-    return HEAPU32[ptr>>2] + HEAP32[ptr+4>>2] * 4294967296;
+    var result = HEAPU32[ptr>>2] + HEAP32[ptr+4>>2] * 4294967296;
+#if ASSERTIONS
+    var lo = HEAPU32[ptr>>2];
+    var hi = HEAP32[ptr+4>>2];
+    if ((result >>> 0) != (lo >>> 0)) warnOnce('readI53FromI64() resulted in rounding lo=0x' + lo.toString(16) + ', hi=0x' + hi.toString(16) + ' to 0x' + result.toString(16));
+#endif
+    return result;
   },
 
   // Reads a 64-bit unsigned integer from the WebAssembly heap and
   // converts it to a JavaScript Number, which can represent 53 integer bits precisely.
   // TODO: Add $readI53FromU64Signaling() variant.
   $readI53FromU64: function(ptr) {
-    return HEAPU32[ptr>>2] + HEAPU32[ptr+4>>2] * 4294967296;
+    var result = HEAPU32[ptr>>2] + HEAPU32[ptr+4>>2] * 4294967296;
+#if ASSERTIONS
+    var lo = HEAPU32[ptr>>2];
+    var hi = HEAPU32[ptr+4>>2];
+    if ((result >>> 0) != (lo >>> 0)) warnOnce('readI53FromU64() resulted in rounding lo=0x' + lo.toString(16) + ', hi=0x' + hi.toString(16) + ' to 0x' + result.toString(16));
+#endif
+    return result;
   },
 
   // Converts the given 32-bit low-high pair to a signed JavaScript number value

--- a/src/library_int53.js
+++ b/src/library_int53.js
@@ -93,23 +93,27 @@ mergeInto(LibraryManager.library, {
     return HEAPU32[ptr>>2] + HEAPU32[ptr+4>>2] * 4294967296;
   },
 
-  // Converts the given signed 32-bit low-high pair to a JavaScript Number that can
-  // represent 53 bits of precision.
+  // Converts the given 32-bit low-high pair to a signed 53-bit integer with
+  // the sign of the high word (and represented as a JavaScript Number).
+  // The signedness of the low word doesn't matter; it will be bit-cast to u32.
   // TODO: Add $convertI32PairToI53Signaling() variant.
   $convertI32PairToI53: function(lo, hi) {
 #if ASSERTIONS
-    // This function should not be getting called with too large unsigned numbers
-    // in high part (if hi >= 0x7FFFFFFFF, one should have been calling
-    // convertU32PairToI53())
-    assert(hi === (hi|0));
+    // Value should not be outside the 53-bit integer range.
+    assert(hi >= -0x200000 && hi <= 0x200000);
 #endif
     return (lo >>> 0) + hi * 4294967296;
   },
 
-  // Converts the given unsigned 32-bit low-high pair to a JavaScript Number that can
-  // represent 53 bits of precision.
+  // Converts the given 32-bit low-high pair to an unsigned 53-bit integer with
+  // the sign of the high word (and represented as a JavaScript Number).
+  // The signedness of the low word doesn't matter; it will be bit-cast to u32.
   // TODO: Add $convertU32PairToI53Signaling() variant.
   $convertU32PairToI53: function(lo, hi) {
+#if ASSERTIONS
+    // Value should not be outside the 53-bit integer range.
+    assert(hi >= 0 && hi <= 0x200000);
+#endif
     return (lo >>> 0) + (hi >>> 0) * 4294967296;
   }
 });

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -923,8 +923,8 @@ var LibraryWebGPU = {
       var binding = {{{ gpu.makeGetU32('entryPtr', C_STRUCTS.WGPUBindGroupEntry.binding) }}};
 
       if (bufferId) {
-        var size_low = {{{ gpu.makeGetU32('entryPtr', C_STRUCTS.WGPUBindGroupEntry.size) }}};
-        var size_high = {{{ gpu.makeGetU32('entryPtr', C_STRUCTS.WGPUBindGroupEntry.size + 4) }}};
+        var size_low = {{{ makeGetValue('entryPtr', C_STRUCTS.WGPUBindGroupEntry.size, 'i32', false, false) }}};
+        var size_high = {{{ makeGetValue('entryPtr', C_STRUCTS.WGPUBindGroupEntry.size + 4, 'i32', false, false) }}};
         var size = (size_low == -1 && size_high == -1) ? undefined : convertU32PairToI53(size_low, size_high);
 
         return {

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -906,7 +906,7 @@ var LibraryWebGPU = {
     return WebGPU.mgrBindGroupLayout.create(device["createBindGroupLayout"](desc));
   },
 
-  wgpuDeviceCreateBindGroup__deps: ['$readI53FromU64'],
+  wgpuDeviceCreateBindGroup__deps: ['$convertU32PairToI53', '$readI53FromU64'],
   wgpuDeviceCreateBindGroup: function(deviceId, descriptor) {
     {{{ gpu.makeCheckDescriptor('descriptor') }}}
 
@@ -1820,7 +1820,7 @@ var LibraryWebGPU = {
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     pass["drawIndexed"](indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
   },
-  wgpuRenderPassEncoderDrawIndirect__deps: ['convertU32PairToI53'],
+  wgpuRenderPassEncoderDrawIndirect__deps: ['$convertU32PairToI53'],
   wgpuRenderPassEncoderDrawIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
     {{{ receiveI64ParamAsI32s('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);
@@ -1828,7 +1828,7 @@ var LibraryWebGPU = {
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
     pass["drawIndirect"](indirectBuffer, indirectOffset);
   },
-  wgpuRenderPassEncoderDrawIndexedIndirect__deps: ['convertU32PairToI53'],
+  wgpuRenderPassEncoderDrawIndexedIndirect__deps: ['$convertU32PairToI53'],
   wgpuRenderPassEncoderDrawIndexedIndirect: function(passId, indirectBufferId, {{{ defineI64Param('indirectOffset') }}}) {
     {{{ receiveI64ParamAsI32s('indirectOffset') }}}
     var indirectBuffer = WebGPU.mgrBuffer.get(indirectBufferId);

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -1035,9 +1035,9 @@ namespace wgpu {
         void PopDebugGroup() const;
         void PushDebugGroup(char const * groupLabel) const;
         void SetBindGroup(uint32_t groupIndex, BindGroup const& group, uint32_t dynamicOffsetCount = 0, uint32_t const * dynamicOffsets = nullptr) const;
-        void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = 0) const;
+        void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
         void SetPipeline(RenderPipeline const& pipeline) const;
-        void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = 0) const;
+        void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
 
       private:
         friend ObjectBase<RenderBundleEncoder, WGPURenderBundleEncoder>;
@@ -1065,11 +1065,11 @@ namespace wgpu {
         void PushDebugGroup(char const * groupLabel) const;
         void SetBindGroup(uint32_t groupIndex, BindGroup const& group, uint32_t dynamicOffsetCount = 0, uint32_t const * dynamicOffsets = nullptr) const;
         void SetBlendConstant(Color const * color) const;
-        void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = 0) const;
+        void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
         void SetPipeline(RenderPipeline const& pipeline) const;
         void SetScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height) const;
         void SetStencilReference(uint32_t reference) const;
-        void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = 0) const;
+        void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
         void SetViewport(float x, float y, float width, float height, float minDepth, float maxDepth) const;
         void WriteTimestamp(QuerySet const& querySet, uint32_t queryIndex) const;
 


### PR DESCRIPTION
WGPU_WHOLE_SIZE is 0xFFFF_FFFF_FFFF_FFFF, which gets passed in as (-1,-1), not as (0xFFFF_FFFF, 0xFFFF_FFFF) as previously thought.

While we're here, changed to use existing i53 functions instead of custom ones. Previously, these would happily go into unsafe integer territory (more than 2^53), but I don't think that is intended to actually "work", so added asserts to them.

Also incrementally updates SetIndexBuffer/SetVertexBuffer to default to WGPU_WHOLE_SIZE (instead of 0), in line with library_webgpu.js (and Dawn).

Fixes #15237