### PR TITLE
[tests] Don't run es-check with --quiet. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -541,10 +541,14 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     es_check_env = os.environ.copy()
     es_check_env['PATH'] = os.path.dirname(config.NODE_JS[0]) + os.pathsep + es_check_env['PATH']
     try:
-      # Comment out --quiet if more detailed error logging is needed
-      shared.run_process(es_check + ['es5', os.path.abspath(filename), '--quiet'], stderr=PIPE, env=es_check_env)
+      # es-check prints the details of the errors to stdout, but it also prints
+      # stuff in the case there are no errors:
+      #  ES-Check: there were no ES version matching errors!
+      # pipe stdout and stderr so that we can choose if/when to print this
+      # output and avoid spamming stdout when tests are successful.
+      shared.run_process(es_check + ['es5', os.path.abspath(filename)], stdout=PIPE, stderr=STDOUT, env=es_check_env)
     except subprocess.CalledProcessError as e:
-      print(e.stderr)
+      print(e.stdout)
       self.fail('es-check failed to verify ES5 output compliance')
 
   # Build JavaScript code from source code


### PR DESCRIPTION
I added `--quiet` to try to stop es-check spamming stdout, but it turned
out that was also suppressing the error report (at least with recent
versions of es-check).

Fixes: #15252