### PR TITLE
Avoid the need for library_stack_trace.js when BOOTSTRAPPING_STRUCT_INFO. NFC

### DIFF
--- a/src/modules.js
+++ b/src/modules.js
@@ -170,7 +170,6 @@ var LibraryManager = {
       libraries = [
         'library_bootstrap.js',
         'library_formatString.js',
-        'library_stack_trace.js',
         'library_int53.js',
       ];
     }


### PR DESCRIPTION
This is needed for #15262 