### PR TITLE
[emcmake] Insert toolchain/emulator arg after user args

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -15,7 +15,7 @@ from subprocess import CalledProcessError
 # Main run() function
 #
 def run():
-  if len(sys.argv) < 2 or sys.argv[1] in ('--version', '--help') or sys.argv[1] != 'cmake':
+  if len(sys.argv) < 2 or sys.argv[1] in ('--version', '--help'):
     print('''\
 emcmake is a helper for cmake, setting various environment
 variables so that emcc etc. are used. Typical usage:


### PR DESCRIPTION
This allows user specified command line arg to overwrite whatever is
specified in the toolchain file, can be useful to overwrite variables
like CMAKE_SYSTEM_PROCESSOR, which is used by projects to detect if
system is ARM. This way we can exercise both Emscripten's SSE headers
and NEON headers.