### PR TITLE
Move trivial unistd tests to other

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5349,12 +5349,6 @@ Module['onRuntimeInitialized'] = function() {
   def test_unistd_close(self):
     self.do_run_in_out_file_test('unistd/close.c')
 
-  def test_unistd_confstr(self):
-    self.do_run_in_out_file_test('unistd/confstr.c')
-
-  def test_unistd_ttyname(self):
-    self.do_runf(test_file('unistd/ttyname.c'), 'success')
-
   @also_with_noderawfs
   def test_unistd_pipe(self):
     self.do_runf(test_file('unistd/pipe.c'), 'success')
@@ -5362,13 +5356,6 @@ Module['onRuntimeInitialized'] = function() {
   @also_with_noderawfs
   def test_unistd_dup(self):
     self.do_run_in_out_file_test('unistd/dup.c')
-
-  def test_unistd_dup_write(self):
-    self.set_setting('WASMFS')
-    self.do_run_in_out_file_test('unistd/dup2.c')
-
-  def test_unistd_pathconf(self):
-    self.do_run_in_out_file_test('unistd/pathconf.c')
 
   def test_unistd_truncate(self):
     self.uses_es6 = True
@@ -5387,12 +5374,6 @@ Module['onRuntimeInitialized'] = function() {
     self.maybe_closure()
     self.do_run_in_out_file_test('unistd/truncate.c', js_engines=[config.NODE_JS])
 
-  def test_unistd_swab(self):
-    self.do_run_in_out_file_test('unistd/swab.c')
-
-  def test_unistd_isatty(self):
-    self.do_runf(test_file('unistd/isatty.c'), 'success')
-
   @also_with_standalone_wasm()
   def test_unistd_sysconf(self):
     self.do_run_in_out_file_test('unistd/sysconf.c')
@@ -5405,9 +5386,6 @@ Module['onRuntimeInitialized'] = function() {
     else:
       expected = 16 * 1024 * 1024 // webassembly.WASM_PAGE_SIZE
     self.do_runf(filename, str(expected) + ', errno: 0')
-
-  def test_unistd_login(self):
-    self.do_run_in_out_file_test('unistd/login.c')
 
   @no_windows('https://github.com/emscripten-core/emscripten/issues/8882')
   def test_unistd_unlink(self):
@@ -5456,9 +5434,6 @@ Module['onRuntimeInitialized'] = function() {
     self.emcc_args += ['-lnodefs.js']
     self.do_run_in_out_file_test('unistd/symlink_on_nodefs.c', js_engines=[config.NODE_JS])
 
-  def test_unistd_sleep(self):
-    self.do_run_in_out_file_test('unistd/sleep.c')
-
   @also_with_wasm_bigint
   def test_unistd_io(self):
     self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$ERRNO_CODES'])
@@ -5479,9 +5454,6 @@ Module['onRuntimeInitialized'] = function() {
       if fs == 'NODEFS':
         self.emcc_args += ['-lnodefs.js']
       self.do_run_in_out_file_test('unistd/misc.c', js_engines=[config.NODE_JS], interleaved_output=False)
-
-  def test_unistd_fstatfs(self):
-    self.do_run_in_out_file_test('unistd/fstatfs.c')
 
   # i64s in the API, which we'd need to legalize for JS, so in standalone mode
   # all we can test is wasm VMs

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11097,3 +11097,35 @@ void foo() {}
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
     self.do_other_test('test_pthread_out_err.c')
+
+  # unistd tests
+
+  def test_unistd_confstr(self):
+    self.do_run_in_out_file_test('unistd/confstr.c')
+
+  def test_unistd_ttyname(self):
+    self.do_runf(test_file('unistd/ttyname.c'), 'success')
+
+  def test_unistd_pathconf(self):
+    self.do_run_in_out_file_test('unistd/pathconf.c')
+
+  def test_unistd_swab(self):
+    self.do_run_in_out_file_test('unistd/swab.c')
+
+  def test_unistd_isatty(self):
+    self.do_runf(test_file('unistd/isatty.c'), 'success')
+
+  def test_unistd_login(self):
+    self.do_run_in_out_file_test('unistd/login.c')
+
+  def test_unistd_sleep(self):
+    self.do_run_in_out_file_test('unistd/sleep.c')
+
+  def test_unistd_fstatfs(self):
+    self.do_run_in_out_file_test('unistd/fstatfs.c')
+
+  # WASMFS tests
+
+  def test_wasmfs_unistd_dup_write(self):
+    self.set_setting('WASMFS')
+    self.do_run_in_out_file_test('unistd/dup2.c')


### PR DESCRIPTION
We don't need to run them in all opt modes. They do depend on JS, so
the opt mode can matter in theory, but to really test that we need to run
closure - which we have on a few strategic tests already. This just moves
the trivial tests that don't use closure or any interesting decorators etc.

(In general I think we should move more things out of `core` into `other`
in order to avoid wasted testing and speed up our CI, but we'll need to
consider each test on a case by case basis.)

This also renames the wasmfs test to have a `wasmfs_` prefix.

cc @ethanalee @tlively 