### PR TITLE
Add support for noexcept keyword in C++ class methods

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -636,22 +636,8 @@ struct GetterPolicy<GetterReturnType (GetterThisType::*)() const> {
 
 #ifdef __cpp_noexcept_function_type
 template<typename GetterReturnType, typename GetterThisType>
-struct GetterPolicy<GetterReturnType (GetterThisType::*)() const noexcept> {
-    typedef GetterReturnType ReturnType;
-    typedef GetterReturnType (GetterThisType::*Context)() const noexcept;
-
-    typedef internal::BindingType<ReturnType> Binding;
-    typedef typename Binding::WireType WireType;
-
-    template<typename ClassType>
-    static WireType get(const Context& context, const ClassType& ptr) {
-        return Binding::toWireType((ptr.*context)());
-    }
-
-    static void* getContext(Context context) {
-        return internal::getContext(context);
-    }
-};
+struct GetterPolicy<GetterReturnType (GetterThisType::*)() const noexcept>
+     : GetterPolicy<GetterReturnType (GetterThisType::*)() const> {};
 #endif
 
 template<typename GetterReturnType, typename GetterThisType>
@@ -731,22 +717,8 @@ struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType)> {
 
 #ifdef __cpp_noexcept_function_type
 template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
-struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType) noexcept> {
-    typedef SetterArgumentType ArgumentType;
-    typedef SetterReturnType (SetterThisType::*Context)(SetterArgumentType) noexcept;
-
-    typedef internal::BindingType<SetterArgumentType> Binding;
-    typedef typename Binding::WireType WireType;
-
-    template<typename ClassType>
-    static void set(const Context& context, ClassType& ptr, WireType wt) {
-        (ptr.*context)(Binding::fromWireType(wt));
-    }
-
-    static void* getContext(Context context) {
-        return internal::getContext(context);
-    }
-};
+struct SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType) noexcept>
+     : SetterPolicy<SetterReturnType (SetterThisType::*)(SetterArgumentType)> {};
 #endif
 
 template<typename SetterReturnType, typename SetterThisType, typename SetterArgumentType>
@@ -1388,46 +1360,12 @@ struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {
 
 #ifdef __cpp_noexcept_function_type
 template<typename ClassType, typename ReturnType, typename... Args>
-struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept> {
-
-    template <typename CT, typename... Policies>
-    static void invoke(const char* methodName,
-                        ReturnType (ClassType::*memberFunction)(Args...) noexcept)  {
-        auto invoker = &MethodInvoker<decltype(memberFunction), ReturnType, ClassType*, Args...>::invoke;
-
-        typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<ClassType>, Args...> args;
-        _embind_register_class_function(
-            TypeID<ClassType>::get(),
-            methodName,
-            args.getCount(),
-            args.getTypes(),
-            getSignature(invoker),
-            reinterpret_cast<GenericFunction>(invoker),
-            getContext(memberFunction),
-            isPureVirtual<Policies...>::value);
-    }
-};
+struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept>
+     : RegisterClassMethod<ReturnType (ClassType::*)(Args...)> {};
 
 template<typename ClassType, typename ReturnType, typename... Args>
-struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const noexcept> {
-
-    template <typename CT, typename... Policies>
-    static void invoke(const char* methodName,
-                        ReturnType (ClassType::*memberFunction)(Args...) const noexcept)  {
-        auto invoker = &MethodInvoker<decltype(memberFunction), ReturnType, const ClassType*, Args...>::invoke;
-
-        typename WithPolicies<Policies...>::template ArgTypeList<ReturnType, AllowedRawPointer<const ClassType>, Args...> args;
-        _embind_register_class_function(
-            TypeID<ClassType>::get(),
-            methodName,
-            args.getCount(),
-            args.getTypes(),
-            getSignature(invoker),
-            reinterpret_cast<GenericFunction>(invoker),
-            getContext(memberFunction),
-            isPureVirtual<Policies...>::value);
-    }
-};
+struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) const noexcept>
+     : RegisterClassMethod<ReturnType (ClassType::*)(Args...) const> {};
 #endif
 
 template<typename ReturnType, typename ThisType, typename... Args>


### PR DESCRIPTION
Closes #11871.

This PR is based off of the work done in #10613, except it also adds support for `noexcept` when using `class_::property()`. The conversation last spoke about merging the template specializations to reduce duplicate code. This is possible using deduction of the `noexcept` keyword like so:

```cpp
template<typename ClassType, typename ReturnType, typename... Args, bool IsNoexcept>
struct RegisterClassMethod<ReturnType (ClassType::*)(Args...) noexcept(IsNoexcept)> {
    template <typename CT, typename... Policies>
    static void invoke(const char* methodName, ReturnType (ClassType::*memberFunction)(Args...) noexcept(IsNoexcept)) {
        ...
    }
};
```

However, `noexcept` deduction is a non-standard extension of GCC and Clang introduced with C++17. I'm not sure this can be done without sacrificing support for some compilers and versions of C++ (see https://devblogs.microsoft.com/oldnewthing/20200714-00/?p=103981).
