### PR TITLE
Add JS-side cache of wasm table entries. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1623,6 +1623,10 @@ def phase_linker_setup(options, state, newargs, settings_map):
   if settings.DYNCALLS and not settings.MINIMAL_RUNTIME:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$dynCall']
 
+  if not settings.BOOTSTRAPPING_STRUCT_INFO:
+    # Include the internal library function since they are used by runtime functions.
+    settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getWasmTableEntry', '$setWasmTableEntry']
+
   if settings.MAIN_MODULE:
     assert not settings.SIDE_MODULE
     if settings.MAIN_MODULE == 1:

--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -1159,7 +1159,7 @@ var LibraryEmbind = {
         return getDynCaller(signature, rawFunction);
       }
 #endif
-      return wasmTable.get(rawFunction);
+      return getWasmTableEntry(rawFunction);
 #endif
     }
 

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1064,7 +1064,7 @@ Please update to new syntax.`);
     if (DYNCALLS) {
       return `(function(cb, ${args}) { ${returnExpr} getDynCaller("${sig}", cb)(${args}) })`;
     } else {
-      return `(function(cb, ${args}) { ${returnExpr} wasmTable.get(cb)(${args}) })`;
+      return `(function(cb, ${args}) { ${returnExpr} getWasmTableEntry(cb)(${args}) })`;
     }
   }
 
@@ -1076,7 +1076,7 @@ Please update to new syntax.`);
       return `(function() { ${returnExpr} ${dyncall}.call(null, ${funcPtr}); })`;
     }
   } else {
-    return `wasmTable.get(${funcPtr})`;
+    return `getWasmTableEntry(${funcPtr})`;
   }
 }
 

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -121,7 +121,7 @@ function addFunctionWasm(func, sig) {
   if (!functionsInTableMap) {
     functionsInTableMap = new WeakMap();
     for (var i = 0; i < wasmTable.length; i++) {
-      var item = wasmTable.get(i);
+      var item = getWasmTableEntry(i);
       // Ignore null values.
       if (item) {
         functionsInTableMap.set(item, i);
@@ -139,7 +139,7 @@ function addFunctionWasm(func, sig) {
   // function is not actually in the wasm Table despite not being tracked in
   // functionsInTableMap.
   for (var i = 0; i < wasmTable.length; i++) {
-    assert(wasmTable.get(i) != func, 'function in Table but not functionsInTableMap');
+    assert(getWasmTableEntry(i) != func, 'function in Table but not functionsInTableMap');
   }
 #endif
 
@@ -148,7 +148,7 @@ function addFunctionWasm(func, sig) {
   // Set the new value.
   try {
     // Attempting to call this with JS function will cause of table.set() to fail
-    wasmTable.set(ret, func);
+    setWasmTableEntry(ret, func);
   } catch (err) {
     if (!(err instanceof TypeError)) {
       throw err;
@@ -157,7 +157,7 @@ function addFunctionWasm(func, sig) {
     assert(typeof sig !== 'undefined', 'Missing signature argument to addFunction: ' + func);
 #endif
     var wrapped = convertJsFunctionToWasm(func, sig);
-    wasmTable.set(ret, wrapped);
+    setWasmTableEntry(ret, wrapped);
   }
 
   functionsInTableMap.set(func, ret);
@@ -166,7 +166,7 @@ function addFunctionWasm(func, sig) {
 }
 
 function removeFunction(index) {
-  functionsInTableMap.delete(wasmTable.get(index));
+  functionsInTableMap.delete(getWasmTableEntry(index));
   freeTableIndexes.push(index);
 }
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -677,7 +677,7 @@ class JS:
       else:
         return 'Module["dynCall_%s"](%s)' % (sig, args)
     else:
-      return 'wasmTable.get(%s)(%s)' % (args[0], ','.join(args[1:]))
+      return 'getWasmTableEntry(%s)(%s)' % (args[0], ','.join(args[1:]))
 
   @staticmethod
   def make_invoke(sig, named=True):


### PR DESCRIPTION
Split out from #13844, this is an internal optimization
that avoids repeated calls to table.get.