### PR TITLE
Error at link time if dlfcn functions are used without MAIN_MODULE

### DIFF
--- a/src/jsifier.js
+++ b/src/jsifier.js
@@ -325,7 +325,9 @@ function ${name}(${args}) {
         //   foo: '=[value]'
         //  emits
         //   'var foo = [value];'
-        if (typeof snippet == 'string' && snippet[0] == '=') snippet = snippet.substr(1);
+        if (typeof snippet == 'string' && snippet[0] == '=') {
+          snippet = snippet.substr(1);
+        }
         contentText = `var ${finalName} = ${snippet};`;
       }
       const sig = LibraryManager.library[ident + '__sig'];

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -3,6 +3,8 @@
 //
 // ==========================================================================
 
+var dlopenMissingError = "'To use dlopen, you need enable dynamic linking, see https://github.com/emscripten-core/emscripten/wiki/Linking'"
+
 var LibraryDylink = {
 #if RELOCATABLE
   $resolveGlobalSymbol__internal: true,
@@ -199,14 +201,24 @@ var LibraryDylink = {
 #endif
 
 #if !MAIN_MODULE
+#if !ALLOW_UNIMPLEMENTED_SYSCALLS
+  _dlopen_js__deps: [function() { error(dlopenMissingError); }],
+  _emscripten_dlopen_js__deps: [function() { error(dlopenMissingError); }],
+  _dlsym_js__deps: [function() { error(dlopenMissingError); }],
+#else
+  $dlopenMissingError: `= ${dlopenMissingError}`,
+  _dlopen_js__deps: ['$dlopenMissingError'],
+  _emscripten_dlopen_js__deps: ['$dlopenMissingError'],
+  _dlsym_js__deps: ['$dlopenMissingError'],
+#endif
   _dlopen_js: function(filename, flag) {
-    abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/emscripten-core/emscripten/wiki/Linking");
+    abort(dlopenMissingError);
   },
   _emscripten_dlopen_js: function(filename, flags, user_data, onsuccess, onerror) {
-    abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/emscripten-core/emscripten/wiki/Linking");
+    abort(dlopenMissingError);
   },
   _dlsym_js: function(handle, symbol) {
-    abort("To use dlopen, you need to use Emscripten's linking support, see https://github.com/emscripten-core/emscripten/wiki/Linking");
+    abort(dlopenMissingError);
   },
   _dlinit: function() {},
 #else // MAIN_MODULE != 0

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11351,6 +11351,18 @@ void foo() {}
       err = self.run_js('a.out.js')
       self.assertNotContained('warning: unsupported syscall', err)
 
+  def test_unimplemented_syscalls_dlopen(self):
+    cmd = [EMCC, test_file('other/test_dlopen_blocking.c'), '-sASSERTIONS']
+    self.run_process(cmd)
+    err = self.run_js('a.out.js', assert_returncode=NON_ZERO)
+    self.assertContained('Aborted(To use dlopen, you need enable dynamic linking, see https://github.com/emscripten-core/emscripten/wiki/Linking)', err)
+
+    # If we build the same thing with ALLOW_UNIMPLEMENTED_SYSCALLS=0 we
+    # expect a link-time failure rather than a runtime one.
+    cmd += ['-sALLOW_UNIMPLEMENTED_SYSCALLS=0']
+    err = self.expect_fail(cmd)
+    self.assertContained('To use dlopen, you need enable dynamic linking, see https://github.com/emscripten-core/emscripten/wiki/Linking', err)
+
   @require_v8
   def test_missing_shell_support(self):
     # By default shell support is not included


### PR DESCRIPTION
Only if ALLOW_UNIMPLEMENTED_SYSCALLS (which is also set by STRICT)
is used.

This was previously only ever a runtime error.

Should help with https://github.com/emscripten-core/emscripten/issues/15276#issuecomment-943162542