### PR TITLE
[WASMFS] Build with fno-exceptions

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1278,6 +1278,8 @@ class libasmfs(MTLibrary):
 class libwasmfs(MTLibrary):
   name = 'libwasmfs'
 
+  cflags = ['-fno-exceptions']
+
   def get_files(self):
     return files_in_path(
         path='system/lib/wasmfs',


### PR DESCRIPTION
- Introduce `fno-exceptions` to `system_libs.py`

Smaller code size.