### PR TITLE
Fix name of __sys_ioctl when detecting needs for FS support

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -79,13 +79,13 @@ def optimize_syscalls(declares, DEBUG):
     # without filesystem support, it doesn't matter what syscalls need
     settings.SYSCALLS_REQUIRE_FILESYSTEM = 0
   else:
-    syscall_prefixes = ('__sys', 'fd_')
+    syscall_prefixes = ('__syscall_', 'fd_')
     syscalls = [d for d in declares if d.startswith(syscall_prefixes)]
     # check if the only filesystem syscalls are in: close, ioctl, llseek, write
     # (without open, etc.. nothing substantial can be done, so we can disable
     # extra filesystem support in that case)
     if set(syscalls).issubset(set([
-      '__sys_ioctl',
+      '__syscall_ioctl',
       'fd_seek',
       'fd_write',
       'fd_close',


### PR DESCRIPTION
Syscalls were renamed in #15202 but this was overlooked.