### PR TITLE
Fix docs for --default-obj-ext

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -530,14 +530,11 @@ Options that are modified or new in *emcc* are listed below:
    using the "EM_CONFIG" environment variable.
 
 "--default-obj-ext <.ext>"
-   [compile+link] Specifies the file suffix to generate if the
-   location of a directory name is passed to the "-o" directive.
-
-   For example, consider the following command, which will by default
-   generate an output name **dir/a.o**. With "--default-obj-ext .ext"
-   the generated file has the custom suffix *dir/a.ext*.
-
-      emcc -c a.c -o dir/
+   [compile] Specifies the output suffix to use when compiling with
+   "-c" in the absence of "-o".  For example, when compiling multiple
+   sources files with "emcc -c *.c" the compiler will normally output
+   files with the ".o" extension, but "--default-obj-ext .obj" can be
+   used to instead generate files with the *.obj* extension.
 
 "--valid-abspath <path>"
    [compile+link] Note an allowed absolute path, which we should not

--- a/emcc.py
+++ b/emcc.py
@@ -149,6 +149,7 @@ UBSAN_SANITIZERS = {
 VALID_ENVIRONMENTS = ('web', 'webview', 'worker', 'node', 'shell')
 SIMD_INTEL_FEATURE_TOWER = ['-msse', '-msse2', '-msse3', '-mssse3', '-msse4.1', '-msse4.2', '-mavx']
 SIMD_NEON_FLAGS = ['-mfpu=neon']
+COMPILE_ONLY_FLAGS = set(['--default-obj-ext'])
 LINK_ONLY_FLAGS = set([
     '--bind', '--closure', '--cpuprofiler', '--embed-file',
     '--emit-symbol-map', '--emrun', '--exclude-file', '--extern-post-js',
@@ -1326,7 +1327,7 @@ def phase_setup(options, state, newargs, settings_map):
       if arg in LINK_ONLY_FLAGS:
         diagnostics.warning(
             'unused-command-line-argument',
-            "linker setting ignored during compilation: '%s'" % arg)
+            "linker flag ignored during compilation: '%s'" % arg)
     if state.has_dash_c:
       if '-emit-llvm' in newargs:
         options.default_object_extension = '.bc'
@@ -1340,6 +1341,12 @@ def phase_setup(options, state, newargs, settings_map):
 
     if options.output_file and len(input_files) > 1:
       exit_with_error('cannot specify -o with -c/-S/-E/-M and multiple source files')
+  else:
+    for arg in state.orig_args:
+      if any(arg.startswith(f) for f in COMPILE_ONLY_FLAGS):
+        diagnostics.warning(
+            'unused-command-line-argument',
+            "compiler flag ignored during linking: '%s'" % arg)
 
   if settings.MAIN_MODULE or settings.SIDE_MODULE:
     settings.RELOCATABLE = 1

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -463,15 +463,12 @@ Options that are modified or new in *emcc* are listed below:
   This can be overridden using the ``EM_CONFIG`` environment variable.
 
 ``--default-obj-ext <.ext>``
-  [compile+link]
-  Specifies the file suffix to generate if the location of a directory name is passed to the ``-o`` directive.
-
-  For example, consider the following command, which will by default generate an output name **dir/a.o**. With ``--default-obj-ext .ext`` the generated file has the custom suffix *dir/a.ext*.
-
-  ::
-
-    emcc -c a.c -o dir/
-
+  [compile]
+  Specifies the output suffix to use when compiling with ``-c`` in the absence
+  of ``-o``.  For example, when compiling multiple sources files with ``emcc -c
+  *.c`` the compiler will normally output files with the ``.o`` extension, but
+  ``--default-obj-ext .obj`` can be used to instead generate files with the
+  `.obj` extension.
 
 ``--valid-abspath <path>``
   [compile+link]

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10850,7 +10850,11 @@ kill -9 $$
 
   def test_link_only_flag_warning(self):
     err = self.run_process([EMCC, '--embed-file', 'file', '-c', test_file('hello_world.c')], stderr=PIPE).stderr
-    self.assertContained("warning: linker setting ignored during compilation: '--embed-file' [-Wunused-command-line-argument]", err)
+    self.assertContained("warning: linker flag ignored during compilation: '--embed-file' [-Wunused-command-line-argument]", err)
+
+  def test_compile_only_flag_warning(self):
+    err = self.run_process([EMCC, '--default-obj-ext', 'foo', test_file('hello_world.c')], stderr=PIPE).stderr
+    self.assertContained("warning: compiler flag ignored during linking: '--default-obj-ext' [-Wunused-command-line-argument]", err)
 
   def test_no_deprecated(self):
     # Test that -Wno-deprecated is passed on to clang driver


### PR DESCRIPTION
I believe that emscripten used to have the behaviour of allowing `-o <dir>`, but this
was removed a long time ago.

Also, warn when compile-only flags like this are passed
at link time.

Fixes: #15312