### PR TITLE
[WASMFS] In-memory file - create, read, write

### DIFF
--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -9,6 +9,9 @@
 #include "file.h"
 
 namespace wasmfs {
+//
+// Directory
+//
 std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
   auto it = getDir().entries.find(pathName);
   if (it == getDir().entries.end()) {
@@ -17,9 +20,10 @@ std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
     return it->second;
   }
 }
-
-__wasi_errno_t
-MemoryFile::write(const uint8_t* buf, __wasi_size_t len, size_t offset) {
+//
+// MemoryFile
+//
+__wasi_errno_t MemoryFile::write(const uint8_t* buf, size_t len, off_t offset) {
   if (offset + len >= buffer.size()) {
     buffer.resize(offset + len);
     this->size = buffer.size();
@@ -29,8 +33,7 @@ MemoryFile::write(const uint8_t* buf, __wasi_size_t len, size_t offset) {
   return __WASI_ERRNO_SUCCESS;
 }
 
-__wasi_errno_t
-MemoryFile::read(uint8_t* buf, __wasi_size_t len, size_t offset) {
+__wasi_errno_t MemoryFile::read(uint8_t* buf, size_t len, off_t offset) {
   std::memcpy(buf, &buffer[offset], len);
 
   return __WASI_ERRNO_SUCCESS;

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -20,7 +20,10 @@ std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
 
 __wasi_errno_t
 MemoryFile::write(const uint8_t* buf, __wasi_size_t len, size_t offset) {
-  buffer.resize(buffer.size() + len);
+  if (offset + len > buffer.size()) {
+    buffer.resize(buffer.size() + len);
+    this->size = buffer.size();
+  }
   memcpy(&buffer[offset], buf, len * sizeof(uint8_t));
 
   return __WASI_ERRNO_SUCCESS;

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -26,7 +26,7 @@ std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
 __wasi_errno_t MemoryFile::write(const uint8_t* buf, size_t len, off_t offset) {
   if (offset + len >= buffer.size()) {
     buffer.resize(offset + len);
-    this->size = buffer.size();
+    size = buffer.size();
   }
   memcpy(&buffer[offset], buf, len);
 

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -1,0 +1,54 @@
+// Copyright 2021 The Emscripten Authors.  All rights reserved.
+// Emscripten is available under two separate licenses, the MIT license and the
+// University of Illinois/NCSA Open Source License.  Both these licenses can be
+// found in the LICENSE file.
+// This file defines the file object of the new file system.
+// Current Status: Work in Progress.
+// See https://github.com/emscripten-core/emscripten/issues/15041.
+
+#include "file.h"
+
+namespace wasmfs {
+template<class T> bool File::is() const {
+  static_assert(std::is_base_of<File, T>::value,
+                "File is not a base of destination type T");
+  return int(kind) == int(T::expectedKind);
+}
+
+template<class T> T* File::dynCast() {
+  static_assert(std::is_base_of<File, T>::value,
+                "File is not a base of destination type T");
+  return int(kind) == int(T::expectedKind) ? (T*)this : nullptr;
+}
+
+template<class T> T* File::cast() {
+  static_assert(std::is_base_of<File, T>::value,
+                "File is not a base of destination type T");
+  assert(int(kind) == int(T::expectedKind));
+  return (T*)this;
+}
+
+std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
+  auto it = getDir().entries.find(pathName);
+  if (it == getDir().entries.end()) {
+    return nullptr;
+  } else {
+    return it->second;
+  }
+}
+
+__wasi_errno_t
+MemoryFile::write(const uint8_t* buf, __wasi_size_t len, size_t offset) {
+  buffer.resize(buffer.size() + len);
+  memcpy(&buffer[offset], buf, len * sizeof(uint8_t));
+
+  return __WASI_ERRNO_SUCCESS;
+}
+
+__wasi_errno_t
+MemoryFile::read(uint8_t* buf, __wasi_size_t len, size_t offset) override {
+  std::memcpy(buf, &buffer[offset], len);
+
+  return __WASI_ERRNO_SUCCESS;
+};
+} // namespace wasmfs

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -20,8 +20,8 @@ std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
 
 __wasi_errno_t
 MemoryFile::write(const uint8_t* buf, __wasi_size_t len, size_t offset) {
-  if (offset + len > buffer.size()) {
-    buffer.resize(buffer.size() + len);
+  if (offset + len >= buffer.size()) {
+    buffer.resize(offset + len);
     this->size = buffer.size();
   }
   memcpy(&buffer[offset], buf, len);

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -24,7 +24,7 @@ MemoryFile::write(const uint8_t* buf, __wasi_size_t len, size_t offset) {
     buffer.resize(buffer.size() + len);
     this->size = buffer.size();
   }
-  memcpy(&buffer[offset], buf, len * sizeof(uint8_t));
+  memcpy(&buffer[offset], buf, len);
 
   return __WASI_ERRNO_SUCCESS;
 }

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -9,25 +9,6 @@
 #include "file.h"
 
 namespace wasmfs {
-template<class T> bool File::is() const {
-  static_assert(std::is_base_of<File, T>::value,
-                "File is not a base of destination type T");
-  return int(kind) == int(T::expectedKind);
-}
-
-template<class T> T* File::dynCast() {
-  static_assert(std::is_base_of<File, T>::value,
-                "File is not a base of destination type T");
-  return int(kind) == int(T::expectedKind) ? (T*)this : nullptr;
-}
-
-template<class T> T* File::cast() {
-  static_assert(std::is_base_of<File, T>::value,
-                "File is not a base of destination type T");
-  assert(int(kind) == int(T::expectedKind));
-  return (T*)this;
-}
-
 std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
   auto it = getDir().entries.find(pathName);
   if (it == getDir().entries.end()) {
@@ -46,7 +27,7 @@ MemoryFile::write(const uint8_t* buf, __wasi_size_t len, size_t offset) {
 }
 
 __wasi_errno_t
-MemoryFile::read(uint8_t* buf, __wasi_size_t len, size_t offset) override {
+MemoryFile::read(uint8_t* buf, __wasi_size_t len, size_t offset) {
   std::memcpy(buf, &buffer[offset], len);
 
   return __WASI_ERRNO_SUCCESS;

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -64,18 +64,17 @@ public:
 
 protected:
   File(FileKind kind) : kind(kind) {}
-  File(FileKind kind, uint32_t mode)
-    : kind(kind), mode(mode), ctime(time(0)), mtime(time(0)), atime(time(0)) {}
+  File(FileKind kind, uint32_t mode) : kind(kind), mode(mode) {}
   // A mutex is needed for multiple accesses to the same file.
   std::mutex mutex;
 
   size_t size = 0;
 
-  uint32_t mode = 0; // r/w/x modes
+  uint32_t mode = 0; // User and group mode bits for access permission.
 
-  time_t ctime = 0; // Time when the file node was last modified
-  time_t mtime = 0; // Time when the file content was last modified
-  time_t atime = 0; // Time when the content was last accessed
+  time_t ctime = 0; // Time when the file node was last modified.
+  time_t mtime = 0; // Time when the file content was last modified.
+  time_t atime = 0; // Time when the content was last accessed.
 
   FileKind kind;
 };
@@ -145,7 +144,7 @@ public:
   Handle locked() { return Handle(shared_from_this()); }
 };
 
-// This class describes a file that lives in WASM Memory.
+// This class describes a file that lives in Wasm Memory.
 class MemoryFile : public DataFile {
   std::vector<uint8_t> buffer;
 

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -54,7 +54,7 @@ public:
   public:
     Handle(std::shared_ptr<File> file) : file(file), lock(file->mutex) {}
     size_t& size() { return file->size; }
-    uint32_t& mode() { return file->mode; }
+    mode_t& mode() { return file->mode; }
     time_t& ctime() { return file->ctime; }
     time_t& mtime() { return file->mtime; }
     time_t& atime() { return file->atime; }
@@ -64,13 +64,13 @@ public:
 
 protected:
   File(FileKind kind) : kind(kind) {}
-  File(FileKind kind, uint32_t mode) : kind(kind), mode(mode) {}
+  File(FileKind kind, mode_t mode) : kind(kind), mode(mode) {}
   // A mutex is needed for multiple accesses to the same file.
   std::mutex mutex;
 
   size_t size = 0;
 
-  uint32_t mode = 0; // User and group mode bits for access permission.
+  mode_t mode = 0; // User and group mode bits for access permission.
 
   time_t ctime = 0; // Time when the file node was last modified.
   time_t mtime = 0; // Time when the file content was last modified.
@@ -88,7 +88,7 @@ class DataFile : public File {
 public:
   static constexpr FileKind expectedKind = File::DataFileKind;
   DataFile() : File(File::DataFileKind) {}
-  DataFile(uint32_t mode) : File(File::DataFileKind, mode) {}
+  DataFile(mode_t mode) : File(File::DataFileKind, mode) {}
   virtual ~DataFile() = default;
 
   class Handle : public File::Handle {
@@ -153,7 +153,7 @@ class MemoryFile : public DataFile {
   __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override;
 
 public:
-  MemoryFile(uint32_t mode) : DataFile(mode) {}
+  MemoryFile(mode_t mode) : DataFile(mode) {}
 };
 
 } // namespace wasmfs

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -82,10 +82,9 @@ protected:
 
 class DataFile : public File {
 
+  virtual __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) = 0;
   virtual __wasi_errno_t
-  read(uint8_t* buf, __wasi_size_t len, size_t offset) = 0;
-  virtual __wasi_errno_t
-  write(const uint8_t* buf, __wasi_size_t len, size_t offset) = 0;
+  write(const uint8_t* buf, size_t len, off_t offset) = 0;
 
 public:
   static constexpr FileKind expectedKind = File::DataFileKind;
@@ -101,10 +100,10 @@ public:
     Handle(std::shared_ptr<File> dataFile) : File::Handle(dataFile) {}
     Handle(Handle&&) = default;
 
-    __wasi_errno_t read(uint8_t* buf, __wasi_size_t len, size_t offset) {
+    __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) {
       return getFile().read(buf, len, offset);
     }
-    __wasi_errno_t write(const uint8_t* buf, __wasi_size_t len, size_t offset) {
+    __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) {
       return getFile().write(buf, len, offset);
     }
   };
@@ -146,13 +145,13 @@ public:
   Handle locked() { return Handle(shared_from_this()); }
 };
 
+// This class describes a file that lives in WASM Memory.
 class MemoryFile : public DataFile {
   std::vector<uint8_t> buffer;
 
-  __wasi_errno_t
-  write(const uint8_t* buf, __wasi_size_t len, size_t offset) override;
+  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override;
 
-  __wasi_errno_t read(uint8_t* buf, __wasi_size_t len, size_t offset) override;
+  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override;
 
 public:
   MemoryFile(uint32_t mode) : DataFile(mode) {}

--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -31,11 +31,12 @@ static __wasi_errno_t writeStdBuffer(const uint8_t* buf,
 
 class StdinFile : public DataFile {
 
-  __wasi_errno_t write(const uint8_t* buf, __wasi_size_t len) override {
+  __wasi_errno_t
+  write(const uint8_t* buf, __wasi_size_t len, size_t offset) override {
     return __WASI_ERRNO_INVAL;
   }
 
-  __wasi_errno_t read(const uint8_t* buf, __wasi_size_t len) override {
+  __wasi_errno_t read(uint8_t* buf, __wasi_size_t len, size_t offset) override {
     return __WASI_ERRNO_INVAL;
   };
 
@@ -50,11 +51,12 @@ public:
 class StdoutFile : public DataFile {
   std::vector<char> writeBuffer;
 
-  __wasi_errno_t write(const uint8_t* buf, __wasi_size_t len) override {
+  __wasi_errno_t
+  write(const uint8_t* buf, __wasi_size_t len, size_t offset) override {
     return writeStdBuffer(buf, len, &emscripten_console_log, writeBuffer);
   }
 
-  __wasi_errno_t read(const uint8_t* buf, __wasi_size_t len) override {
+  __wasi_errno_t read(uint8_t* buf, __wasi_size_t len, size_t offset) override {
     return __WASI_ERRNO_INVAL;
   };
 
@@ -72,11 +74,12 @@ class StderrFile : public DataFile {
   // TODO: May not want to proxy stderr (fd == 2) to the main thread.
   // This will not show in HTML - a console.warn in a worker is sufficient.
   // This would be a change from the current FS.
-  __wasi_errno_t write(const uint8_t* buf, __wasi_size_t len) override {
+  __wasi_errno_t
+  write(const uint8_t* buf, __wasi_size_t len, size_t offset) override {
     return writeStdBuffer(buf, len, &emscripten_console_error, writeBuffer);
   }
 
-  __wasi_errno_t read(const uint8_t* buf, __wasi_size_t len) override {
+  __wasi_errno_t read(uint8_t* buf, __wasi_size_t len, size_t offset) override {
     return __WASI_ERRNO_INVAL;
   };
 
@@ -90,11 +93,11 @@ public:
 
 FileTable::FileTable() {
   entries.push_back(
-    std::make_shared<OpenFileState>(0, StdinFile::getSingleton()));
+    std::make_shared<OpenFileState>(0, O_RDWR, StdinFile::getSingleton()));
   entries.push_back(
-    std::make_shared<OpenFileState>(0, StdoutFile::getSingleton()));
+    std::make_shared<OpenFileState>(0, O_RDWR, StdoutFile::getSingleton()));
   entries.push_back(
-    std::make_shared<OpenFileState>(0, StderrFile::getSingleton()));
+    std::make_shared<OpenFileState>(0, O_RDWR, StderrFile::getSingleton()));
 }
 
 // Initialize default directories including dev/stdin, dev/stdout, dev/stderr.

--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -90,11 +90,11 @@ public:
 
 FileTable::FileTable() {
   entries.push_back(
-    std::make_shared<OpenFileState>(0, O_RDWR, StdinFile::getSingleton()));
+    std::make_shared<OpenFileState>(0, O_RDONLY, StdinFile::getSingleton()));
   entries.push_back(
-    std::make_shared<OpenFileState>(0, O_RDWR, StdoutFile::getSingleton()));
+    std::make_shared<OpenFileState>(0, O_WRONLY, StdoutFile::getSingleton()));
   entries.push_back(
-    std::make_shared<OpenFileState>(0, O_RDWR, StderrFile::getSingleton()));
+    std::make_shared<OpenFileState>(0, O_WRONLY, StderrFile::getSingleton()));
 }
 
 // Initialize default directories including dev/stdin, dev/stdout, dev/stderr.

--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -13,10 +13,10 @@ namespace wasmfs {
 std::vector<std::shared_ptr<OpenFileState>> FileTable::entries;
 
 static __wasi_errno_t writeStdBuffer(const uint8_t* buf,
-                                     __wasi_size_t len,
+                                     size_t len,
                                      void (*console_write)(const char*),
                                      std::vector<char>& fd_write_buffer) {
-  for (__wasi_size_t j = 0; j < len; j++) {
+  for (size_t j = 0; j < len; j++) {
     uint8_t current = buf[j];
     if (current == '\0' || current == '\n') {
       fd_write_buffer.push_back('\0'); // for null-terminated C strings
@@ -31,12 +31,11 @@ static __wasi_errno_t writeStdBuffer(const uint8_t* buf,
 
 class StdinFile : public DataFile {
 
-  __wasi_errno_t
-  write(const uint8_t* buf, __wasi_size_t len, size_t offset) override {
+  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
     return __WASI_ERRNO_INVAL;
   }
 
-  __wasi_errno_t read(uint8_t* buf, __wasi_size_t len, size_t offset) override {
+  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
     return __WASI_ERRNO_INVAL;
   };
 
@@ -51,12 +50,11 @@ public:
 class StdoutFile : public DataFile {
   std::vector<char> writeBuffer;
 
-  __wasi_errno_t
-  write(const uint8_t* buf, __wasi_size_t len, size_t offset) override {
+  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
     return writeStdBuffer(buf, len, &emscripten_console_log, writeBuffer);
   }
 
-  __wasi_errno_t read(uint8_t* buf, __wasi_size_t len, size_t offset) override {
+  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
     return __WASI_ERRNO_INVAL;
   };
 
@@ -74,12 +72,11 @@ class StderrFile : public DataFile {
   // TODO: May not want to proxy stderr (fd == 2) to the main thread.
   // This will not show in HTML - a console.warn in a worker is sufficient.
   // This would be a change from the current FS.
-  __wasi_errno_t
-  write(const uint8_t* buf, __wasi_size_t len, size_t offset) override {
+  __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override {
     return writeStdBuffer(buf, len, &emscripten_console_error, writeBuffer);
   }
 
-  __wasi_errno_t read(uint8_t* buf, __wasi_size_t len, size_t offset) override {
+  __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
     return __WASI_ERRNO_INVAL;
   };
 

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -15,10 +15,14 @@
 #include <vector>
 #include <wasi/api.h>
 
+namespace wasmfs {
+static_assert(std::is_same<size_t, __wasi_size_t>::value,
+              "size_t should be the same as __wasi_size_t");
+static_assert(std::is_same<off_t, __wasi_filedelta_t>::value,
+              "off_t should be the same as __wasi_filedelta_t");
+
 // Flags determining the method of how paths are resolved.
 using __wasmfs_oflags_t = uint32_t;
-
-namespace wasmfs {
 
 std::shared_ptr<Directory> getRootDirectory();
 

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -15,10 +15,8 @@
 #include <vector>
 #include <wasi/api.h>
 
-/**
- * Flags determining the method of how paths are resolved.
- */
-typedef uint32_t __wasmfs_oflags_t;
+// Flags determining the method of how paths are resolved.
+using __wasmfs_oflags_t = uint32_t;
 
 namespace wasmfs {
 

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -21,6 +21,7 @@ static_assert(std::is_same<size_t, __wasi_size_t>::value,
 static_assert(std::is_same<off_t, __wasi_filedelta_t>::value,
               "off_t should be the same as __wasi_filedelta_t");
 
+// Overflow and underflow behaviour are only defined for unsigned types.
 template<typename T> bool addWillOverFlow(T a, T b) {
   if (a > 0 && b > std::numeric_limits<T>::max() - a) {
     return true;
@@ -29,14 +30,14 @@ template<typename T> bool addWillOverFlow(T a, T b) {
 }
 
 // Flags determining the method of how paths are resolved.
-using __wasmfs_oflags_t = uint32_t;
+using wasmfs_oflags_t = uint32_t;
 
 std::shared_ptr<Directory> getRootDirectory();
 
 class OpenFileState : public std::enable_shared_from_this<OpenFileState> {
   std::shared_ptr<File> file;
   size_t position;
-  __wasmfs_oflags_t flags; // RD_ONLY, WR_ONLY, RDWR
+  wasmfs_oflags_t flags; // RD_ONLY, WR_ONLY, RDWR
   // An OpenFileState needs a mutex if there are concurrent accesses on one open
   // file descriptor. This could occur if there are multiple seeks on the same
   // open file descriptor.
@@ -44,7 +45,7 @@ class OpenFileState : public std::enable_shared_from_this<OpenFileState> {
 
 public:
   OpenFileState(size_t position,
-                __wasmfs_oflags_t flags,
+                wasmfs_oflags_t flags,
                 std::shared_ptr<File> file)
     : position(position), flags(flags), file(file) {}
 

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -21,6 +21,13 @@ static_assert(std::is_same<size_t, __wasi_size_t>::value,
 static_assert(std::is_same<off_t, __wasi_filedelta_t>::value,
               "off_t should be the same as __wasi_filedelta_t");
 
+template<typename T> bool addWillOverFlow(T a, T b) {
+  if (a > 0 && b > std::numeric_limits<T>::max() - a) {
+    return true;
+  }
+  return false;
+}
+
 // Flags determining the method of how paths are resolved.
 using __wasmfs_oflags_t = uint32_t;
 

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -29,7 +29,7 @@ template<typename T> bool addWillOverFlow(T a, T b) {
   return false;
 }
 
-// Flags determining the method of how paths are resolved.
+// Access mode, file creation and file status flags for open.
 using wasmfs_oflags_t = uint32_t;
 
 std::shared_ptr<Directory> getRootDirectory();

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -15,6 +15,11 @@
 #include <vector>
 #include <wasi/api.h>
 
+/**
+ * Flags determining the method of how paths are resolved.
+ */
+typedef uint32_t __wasmfs_oflags_t;
+
 namespace wasmfs {
 
 std::shared_ptr<Directory> getRootDirectory();
@@ -22,14 +27,16 @@ std::shared_ptr<Directory> getRootDirectory();
 class OpenFileState : public std::enable_shared_from_this<OpenFileState> {
   std::shared_ptr<File> file;
   size_t position;
-  uint32_t flags; // RD_ONLY, WR_ONLY, RDWR
+  __wasmfs_oflags_t flags; // RD_ONLY, WR_ONLY, RDWR
   // An OpenFileState needs a mutex if there are concurrent accesses on one open
   // file descriptor. This could occur if there are multiple seeks on the same
   // open file descriptor.
   std::mutex mutex;
 
 public:
-  OpenFileState(size_t position, uint32_t flags, std::shared_ptr<File> file)
+  OpenFileState(size_t position,
+                __wasmfs_oflags_t flags,
+                std::shared_ptr<File> file)
     : position(position), flags(flags), file(file) {}
 
   class Handle {

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -36,7 +36,7 @@ std::shared_ptr<Directory> getRootDirectory();
 
 class OpenFileState : public std::enable_shared_from_this<OpenFileState> {
   std::shared_ptr<File> file;
-  size_t position;
+  off_t position;
   wasmfs_oflags_t flags; // RD_ONLY, WR_ONLY, RDWR
   // An OpenFileState needs a mutex if there are concurrent accesses on one open
   // file descriptor. This could occur if there are multiple seeks on the same
@@ -59,7 +59,7 @@ public:
 
     std::shared_ptr<File>& getFile() { return openFileState->file; };
 
-    size_t& position() { return openFileState->position; };
+    off_t& position() { return openFileState->position; };
   };
 
   Handle get() { return Handle(shared_from_this()); }

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -98,6 +98,7 @@ __wasi_errno_t __wasi_fd_write(__wasi_fd_t fd,
   }
 
   *nwritten = offset - lockedOpenFile.position();
+  lockedOpenFile.position() = offset;
 
   return __WASI_ERRNO_SUCCESS;
 }

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -20,6 +20,7 @@
 extern "C" {
 
 using namespace wasmfs;
+using __wasmfs_offset_t = uint64_t;
 
 long __syscall_dup2(long oldfd, long newfd) {
   auto fileTable = FileTable::get();
@@ -82,8 +83,9 @@ __wasi_errno_t __wasi_fd_write(__wasi_fd_t fd,
     const uint8_t* buf = iovs[i].buf;
     size_t len = iovs[i].buf_len;
 
-    // Check if the sum of the buf_len values overflows an ssize_t value.
-    if (uint64_t(offset) + uint64_t(len) < uint64_t(offset)) {
+    // Check if the sum of the buf_len values overflows a uint64_t (file size).
+    if (__wasmfs_offset_t(offset) + __wasmfs_offset_t(len) <
+        __wasmfs_offset_t(offset)) {
       return __WASI_ERRNO_INVAL;
     }
 
@@ -224,8 +226,9 @@ __wasi_fd_t __syscall_open(long pathname, long flags, long mode) {
   }
 
   // TODO: remove assert when all functionality is complete.
-  // assert((flags & ~(O_CREAT | O_EXCL | O_DIRECTORY | O_TRUNC | O_APPEND |
-  //                   O_RDWR | O_WRONLY | O_RDONLY)) == 0);
+  assert(((unsigned long)(flags) &
+          ~(long)(O_CREAT | O_EXCL | O_DIRECTORY | O_TRUNC | O_APPEND | O_RDWR |
+                  O_WRONLY | O_RDONLY | O_LARGEFILE)) == 0);
 
   std::vector<std::string> pathParts;
 

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -77,10 +77,10 @@ __wasi_errno_t __wasi_fd_write(__wasi_fd_t fd,
 
   auto lockedFile = file->locked();
 
-  ssize_t offset = lockedOpenFile.position();
+  off_t offset = lockedOpenFile.position();
   for (size_t i = 0; i < iovs_len; i++) {
     const uint8_t* buf = iovs[i].buf;
-    __wasi_size_t len = iovs[i].buf_len;
+    size_t len = iovs[i].buf_len;
 
     // Check if the sum of the buf_len values overflows an ssize_t value.
     if (offset + len < offset) {
@@ -123,7 +123,7 @@ __wasi_errno_t __wasi_fd_read(__wasi_fd_t fd,
 
   auto lockedFile = file->locked();
 
-  size_t offset = lockedOpenFile.position();
+  off_t offset = lockedOpenFile.position();
   size_t size = lockedFile.size();
   for (size_t i = 0; i < iovs_len; i++) {
     // Check if offset has exceeded size of file data.
@@ -133,11 +133,6 @@ __wasi_errno_t __wasi_fd_read(__wasi_fd_t fd,
     }
 
     uint8_t* buf = iovs[i].buf;
-
-    // Check if the sum of the buf_len values overflows an ssize_t value.
-    if (offset + iovs[i].buf_len < offset) {
-      return __WASI_ERRNO_INVAL;
-    }
 
     // Check if buf_len specifies a positive length buffer but buf is a
     // null pointer

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -280,8 +280,8 @@ __wasi_fd_t __syscall_open(long pathname, long flags, long mode) {
 
     // Requested entry (file or directory)
     if (!curr) {
+      // Create last element in path if O_CREAT is specified.
       if (i == pathParts.size() - 1 && flags & O_CREAT) {
-        // If curr is the last element and the create flag is specified
         auto lockedDir = directory->locked();
 
         // Create an empty in-memory file.
@@ -307,7 +307,7 @@ __wasi_fd_t __syscall_open(long pathname, long flags, long mode) {
     return -(ENOTDIR);
   }
 
-  // If the file exists and O_EXCL and O_CREAT are true
+  // Return an error if the file exists and O_CREAT and O_EXCL are specified.
   if (flags & O_EXCL && flags & O_CREAT) {
     return -(EEXIST);
   }

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -20,7 +20,7 @@
 extern "C" {
 
 using namespace wasmfs;
-using __wasmfs_offset_t = uint64_t;
+using wasmfs_offset_t = uint64_t;
 
 long __syscall_dup2(long oldfd, long newfd) {
   auto fileTable = FileTable::get();
@@ -76,6 +76,7 @@ __wasi_errno_t __wasi_fd_write(__wasi_fd_t fd,
   auto* file = lockedOpenFile.getFile()->dynCast<DataFile>();
 
   // If file is nullptr, then the file was not a DataFile.
+  // TODO: change to add support for symlinks.
   if (!file) {
     return __WASI_ERRNO_ISDIR;
   }
@@ -88,8 +89,7 @@ __wasi_errno_t __wasi_fd_write(__wasi_fd_t fd,
     size_t len = iovs[i].buf_len;
 
     // Check if the sum of the buf_len values overflows a uint64_t (file size).
-    // Overflow and underflow behaviour are only defined for unsigned types.
-    if (addWillOverFlow(__wasmfs_offset_t(offset), __wasmfs_offset_t(len))) {
+    if (addWillOverFlow(wasmfs_offset_t(offset), wasmfs_offset_t(len))) {
       return __WASI_ERRNO_FBIG;
     }
 
@@ -127,6 +127,7 @@ __wasi_errno_t __wasi_fd_read(__wasi_fd_t fd,
   auto* file = lockedOpenFile.getFile()->dynCast<DataFile>();
 
   // If file is nullptr, then the file was not a DataFile.
+  // TODO: change to add support for symlinks.
   if (!file) {
     return __WASI_ERRNO_ISDIR;
   }

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -148,7 +148,7 @@ __wasi_errno_t __wasi_fd_read(__wasi_fd_t fd,
   }
   *nread = offset - lockedOpenFile.position();
   lockedOpenFile.position() = offset;
-  return __WASI_ERRNO_INVAL;
+  return __WASI_ERRNO_SUCCESS;
 }
 
 __wasi_errno_t __wasi_fd_seek(__wasi_fd_t fd,

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -87,7 +87,7 @@ __wasi_errno_t __wasi_fd_write(__wasi_fd_t fd,
       return __WASI_ERRNO_INVAL;
     }
 
-    // Check if iov_len specifies a positive length buffer but iov_base is a
+    // Check if buf_len specifies a positive length buffer but buf is a
     // null pointer
     if (!buf && len > 0) {
       return __WASI_ERRNO_INVAL;
@@ -96,11 +96,8 @@ __wasi_errno_t __wasi_fd_write(__wasi_fd_t fd,
     lockedFile.write(buf, len, offset);
     offset += len;
   }
-  // number of bytes written is new position - old position.
-  *nwritten = offset - lockedOpenFile.position();
 
-  // the size of the file is now old position + number of bytes written
-  lockedFile.size() = offset;
+  *nwritten = offset - lockedOpenFile.position();
 
   return __WASI_ERRNO_SUCCESS;
 }
@@ -135,6 +132,17 @@ __wasi_errno_t __wasi_fd_read(__wasi_fd_t fd,
     }
 
     uint8_t* buf = iovs[i].buf;
+
+    // Check if the sum of the buf_len values overflows an ssize_t value.
+    if (offset + iovs[i].buf_len < offset) {
+      return __WASI_ERRNO_INVAL;
+    }
+
+    // Check if buf_len specifies a positive length buffer but buf is a
+    // null pointer
+    if (!buf && iovs[i].buf_len > 0) {
+      return __WASI_ERRNO_INVAL;
+    }
 
     size_t bytesToRead =
       (size_t)dataLeft < iovs[i].buf_len ? dataLeft : iovs[i].buf_len;

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -263,7 +263,7 @@ __wasi_fd_t __syscall_open(long pathname, long flags, long mode) {
         auto dir = directory->locked();
 
         // create empty in memory file.
-        auto created = std::make_shared<InMemoryFile>(mode);
+        auto created = std::make_shared<MemoryFile>(mode);
 
         dir.setEntry(pathParts[i], created);
         auto openFile = std::make_shared<OpenFileState>(0, flags, created);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11171,7 +11171,7 @@ void foo() {}
   def test_wasmfs_unistd_fstat(self):
     self.set_setting('WASMFS')
     self.do_run_in_out_file_test('wasmfs/wasmfs_fstat.c')
-    
+
   def test_wasmfs_unistd_create(self):
     self.set_setting('WASMFS')
     self.do_run_in_out_file_test('wasmfs/wasmfs_create.c')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11171,3 +11171,7 @@ void foo() {}
   def test_wasmfs_unistd_fstat(self):
     self.set_setting('WASMFS')
     self.do_run_in_out_file_test('wasmfs/wasmfs_fstat.c')
+    
+  def test_wasmfs_unistd_create(self):
+    self.set_setting('WASMFS')
+    self.do_run_in_out_file_test('wasmfs/wasmfs_create.c')

--- a/tests/wasmfs/wasmfs_create.c
+++ b/tests/wasmfs/wasmfs_create.c
@@ -35,23 +35,49 @@ int main() {
   close(fd);
   close(test);
 
-  // Try to create an existing file with O_EXCL and O_CREAT
+  // Try to create an existing file with O_EXCL and O_CREAT.
   errno = 0;
   int fd2 = open("/dev/stdin", O_RDWR | O_CREAT | O_EXCL);
   printf("Errno: %s\n", strerror(errno));
   assert(errno == EEXIST);
 
-  // Try to open a file with O_DIRECTORY
+  // Try to open a file with O_DIRECTORY.
   errno = 0;
   int fd3 = open("/dev/stdin", O_RDWR | O_DIRECTORY);
   printf("Errno: %s\n", strerror(errno));
   assert(errno == ENOTDIR);
 
-  // Try to open a directory with O_DIRECTORY
+  // Try to open a directory with O_DIRECTORY.
   errno = 0;
   int fd4 = open("/dev", O_RDONLY | O_DIRECTORY);
   printf("Errno: %s\n", strerror(errno));
   assert(errno == 0);
+
+  // Test zero size reads and writes.
+  char buf2[100] = {};
+  int fd5 = open("/newFile", O_RDWR | O_CREAT);
+  errno = 0;
+  printf("Read %zi bytes\n", read(fd5, buf2, 0));
+  assert(errno == 0);
+  printf("Wrote %zi bytes\n", write(fd5, msg, 0));
+  assert(errno == 0);
+
+  // Test large size reads and writes multiple times.
+  char buf3[100] = {};
+  int fd6 = open("/testFile", O_RDWR | O_CREAT);
+  errno = 0;
+  printf("Wrote %zi bytes\n", write(fd6, msg, strlen(msg) + 20));
+  printf("Wrote %zi bytes\n", write(fd6, msg, strlen(msg)));
+  printf("Wrote %zi bytes\n", write(fd6, msg, strlen(msg) + 30));
+  printf("Read %zi bytes\n", read(fd6, buf, 10000));
+
+  int fd7 = open("/testFile", O_RDWR);
+  assert(errno == 0);
+  printf("Read %zi bytes\n", read(fd7, buf3, sizeof buf3));
+  printf("File contents: %s", buf3);
+  assert(errno == 0);
+
+  // TODO: use seek to test out of bounds read.
 
   return 0;
 }

--- a/tests/wasmfs/wasmfs_create.c
+++ b/tests/wasmfs/wasmfs_create.c
@@ -16,13 +16,24 @@
 
 int main() {
   // Test creating a new file and writing and reading from it.
+  errno = 0;
   int fd = open("/test", O_RDWR | O_CREAT);
+  assert(errno == 0);
   const char* msg = "Test\n";
+  errno = 0;
   write(fd, msg, strlen(msg));
-  char buf[100];
-  read(fd, buf, sizeof(buf));
+  assert(errno == 0);
+  // Attempt to open another FD to the file just created.
+  errno = 0;
+  int test = open("/test", O_RDWR);
+  assert(errno == 0);
+  char buf[100] = {};
+  errno = 0;
+  read(test, buf, sizeof(buf));
+  assert(errno == 0);
   printf("%s", buf);
   close(fd);
+  close(test);
 
   // Try to create an existing file with O_EXCL and O_CREAT
   errno = 0;

--- a/tests/wasmfs/wasmfs_create.c
+++ b/tests/wasmfs/wasmfs_create.c
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+// FIXME: Merge with other existing close and open tests.
+
+int main() {
+  // Test creating a new file and writing and reading from it.
+  int fd = open("/test", O_RDWR | O_CREAT);
+  const char* msg = "Test\n";
+  write(fd, msg, strlen(msg));
+  char buf[100];
+  read(fd, buf, sizeof(buf));
+  printf("%s", buf);
+  close(fd);
+
+  // Try to create an existing file with O_EXCL and O_CREAT
+  errno = 0;
+  int fd2 = open("/dev/stdin", O_RDWR | O_CREAT | O_EXCL);
+  printf("Errno: %s\n", strerror(errno));
+  assert(errno == EEXIST);
+
+  // Try to open a file with O_DIRECTORY
+  errno = 0;
+  int fd3 = open("/dev/stdin", O_RDWR | O_DIRECTORY);
+  printf("Errno: %s\n", strerror(errno));
+  assert(errno == ENOTDIR);
+
+  // Try to open a directory with O_DIRECTORY
+  errno = 0;
+  int fd4 = open("/dev", O_RDONLY | O_DIRECTORY);
+  printf("Errno: %s\n", strerror(errno));
+  assert(errno == 0);
+
+  return 0;
+}

--- a/tests/wasmfs/wasmfs_create.out
+++ b/tests/wasmfs/wasmfs_create.out
@@ -2,3 +2,11 @@ Test
 Errno: File exists
 Errno: Not a directory
 Errno: No error information
+Read 0 bytes
+Wrote 0 bytes
+Wrote 25 bytes
+Wrote 5 bytes
+Wrote 35 bytes
+Read 0 bytes
+Read 65 bytes
+File contents: Test

--- a/tests/wasmfs/wasmfs_create.out
+++ b/tests/wasmfs/wasmfs_create.out
@@ -1,0 +1,4 @@
+Test
+Errno: File exists
+Errno: Not a directory
+Errno: No error information

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1292,7 +1292,7 @@ class libwasmfs(MTLibrary):
   def get_files(self):
     return files_in_path(
         path='system/lib/wasmfs',
-        filenames=['wasmfs.cpp', 'file_table.cpp'])
+        filenames=['wasmfs.cpp', 'file_table.cpp', 'file.cpp'])
 
   def can_build(self):
     return settings.WASMFS


### PR DESCRIPTION
Relevent Issue: #15041 

- Implement new in memory file class
- Expand coverage of `open` syscall
- Expand functionality of `read` and `write` to handle file offsets.