### PR TITLE
Remove EMIT_EMSCRIPTEN_METADATA settings

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -48,7 +48,7 @@ See docs/process.md for more on how version tagging works.
   to override the default value of `CMAKE_SYSTEM_PROCESSOR` set by the
   toolchain file.
 - Remove support for the `EMIT_EMSCRIPTEN_METADATA` setting.  This setting has
-  been deprecated for some time now and we don't know of any remained reasons to
+  been deprecated for some time now and we don't know of any remaining reasons to
   keep it around.
 
 2.0.31 - 10/01/2021

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -47,6 +47,9 @@ See docs/process.md for more on how version tagging works.
 - Support a new CMake propert `EMSCRIPTEN_SYSTEM_PROCESSOR` which can be used
   to override the default value of `CMAKE_SYSTEM_PROCESSOR` set by the
   toolchain file.
+- Remove support for the `EMIT_EMSCRIPTEN_METADATA` setting.  This setting has
+  been deprecated for some time now and we don't know of any remained reasons to
+  keep it around.
 
 2.0.31 - 10/01/2021
 -------------------

--- a/emcc.py
+++ b/emcc.py
@@ -3175,10 +3175,6 @@ def phase_binaryen(target, options, wasm_target):
 
   # after generating the wasm, do some final operations
 
-  if settings.EMIT_EMSCRIPTEN_METADATA:
-    diagnostics.warning('deprecated', 'We hope to remove support for EMIT_EMSCRIPTEN_METADATA. See https://github.com/emscripten-core/emscripten/issues/12231')
-    webassembly.add_emscripten_metadata(wasm_target)
-
   if final_js:
     if settings.SUPPORT_BIG_ENDIAN:
       final_js = building.little_endian_heap(final_js)

--- a/src/settings.js
+++ b/src/settings.js
@@ -1321,12 +1321,6 @@ var WASM_BIGINT = 0;
 // [link]
 var EMIT_PRODUCERS_SECTION = 0;
 
-// If set then generated WASM files will contain a custom
-// "emscripten_metadata" section that contains information necessary
-// to execute the file without the accompanying JS file.
-// [link]
-var EMIT_EMSCRIPTEN_METADATA = 0;
-
 // Emits emscripten license info in the JS output.
 // [link]
 var EMIT_EMSCRIPTEN_LICENSE = 0;
@@ -2048,4 +2042,5 @@ var LEGACY_SETTINGS = [
   ['WORKAROUND_IOS_9_RIGHT_SHIFT_BUG', [0], 'Wasm2JS does not support iPhone 4s, iPad 2, iPad 3, iPad Mini 1, Pod Touch 5 (devices with end-of-life at iOS 9.3.5) and older'],
   ['RUNTIME_FUNCS_TO_IMPORT', [[]], 'No longer needed'],
   ['LIBRARY_DEPS_TO_AUTOEXPORT', [[]], 'No longer needed'],
+  ['EMIT_EMSCRIPTEN_METADATA', [0], 'No longer supported'],
 ];

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8800,23 +8800,6 @@ int main () {
       self.assertNotContained('invoke_ii', output)
       self.assertNotContained('invoke_v', output)
 
-  def test_emscripten_metadata(self):
-    self.run_process([EMCC, test_file('hello_world.c')])
-    self.assertNotIn(b'emscripten_metadata', read_binary('a.out.wasm'))
-
-    self.run_process([EMCC, test_file('hello_world.c'),
-                      '-s', 'EMIT_EMSCRIPTEN_METADATA'])
-    self.assertIn(b'emscripten_metadata', read_binary('a.out.wasm'))
-
-    # Test is standalone mode too.
-    self.run_process([EMCC, test_file('hello_world.c'), '-o', 'out.wasm',
-                      '-s', 'EMIT_EMSCRIPTEN_METADATA'])
-    self.assertIn(b'emscripten_metadata', read_binary('out.wasm'))
-
-    # make sure wasm executes correctly
-    ret = self.run_process(config.NODE_JS + ['a.out.js'], stdout=PIPE).stdout
-    self.assertContained('hello, world!\n', ret)
-
   @parameterized({
     'O0': (False, ['-O0']), # noqa
     'O0_emit': (True, ['-O0', '-s', 'EMIT_EMSCRIPTEN_LICENSE']), # noqa


### PR DESCRIPTION
We have been warning about the deprecation of this setting
for about a year now (since 2.0.9).

As explained in #12231, the major use cases for this metadata
are no longer valid since the embedder should on longer need to
know the memory layout of the module (since the memory and table
are both created and setup within the wasm module these days).

Fixes: #12231