### PR TITLE
Remove unused `ftfault` function from safe heap code.

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -55,7 +55,6 @@ LibraryManager.library = {
   // to native code.
   segfault: function() { segfault(); },
   alignfault: function() { alignfault(); },
-  ftfault: function() { ftfault(); },
 #endif
 
   // ==========================================================================

--- a/src/runtime_safe_heap.js
+++ b/src/runtime_safe_heap.js
@@ -160,9 +160,6 @@ function segfault() {
 function alignfault() {
   abort('alignment fault');
 }
-function ftfault() {
-  abort('Function table mask error');
-}
 #endif
 
 #if USE_ASAN


### PR DESCRIPTION
This may have been used in the past, perhaps under fastcomp but I could
find no usage to by llvm, binaryen, or emscripten itself.