### PR TITLE
Merge `addFunction` and `addFunctionWasm`. NFC

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -99,7 +99,7 @@ var LibraryDylink = {
       }
       if (replace || GOT[symName].value == 0) {
         if (typeof value === 'function') {
-          GOT[symName].value = addFunctionWasm(value);
+          GOT[symName].value = addFunction(value);
 #if DYLINK_DEBUG
           err("updateGOT: FUNC: " + symName + ' : ' + GOT[symName].value);
 #endif
@@ -170,7 +170,7 @@ var LibraryDylink = {
         err('assigning dynamic symbol from main module: ' + symName + ' -> ' + prettyPrint(value));
 #endif
         if (typeof value === 'function') {
-          GOT[symName].value = addFunctionWasm(value, value.sig);
+          GOT[symName].value = addFunction(value, value.sig);
 #if DYLINK_DEBUG
           err('assigning table entry for : ' + symName + ' -> ' + GOT[symName].value);
 #endif
@@ -913,7 +913,7 @@ var LibraryDylink = {
       // the second argument will not be needed.  If its a JS function we rely
       // on the `sig` attribute being set based on the `<func>__sig` specified
       // in library JS file.
-      return addFunctionWasm(result, result.sig);
+      return addFunction(result, result.sig);
     } else {
       return result;
     }

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -114,8 +114,14 @@ function getEmptyTableSlot() {
   return wasmTable.length - 1;
 }
 
-// Add a wasm function to the table.
-function addFunctionWasm(func, sig) {
+
+// Add a function to the table.
+// 'sig' parameter is required if the function being added is a JS function.
+function addFunction(func, sig) {
+#if ASSERTIONS
+  assert(typeof func !== 'undefined');
+#endif // ASSERTIONS
+
   // Check if the function is already in the table, to ensure each function
   // gets a unique index. First, create the map if this is the first use.
   if (!functionsInTableMap) {
@@ -170,17 +176,4 @@ function removeFunction(index) {
   freeTableIndexes.push(index);
 }
 
-// 'sig' parameter is required for the llvm backend but only when func is not
-// already a WebAssembly function.
-function addFunction(func, sig) {
-#if ASSERTIONS
-  assert(typeof func !== 'undefined');
-#if ASSERTIONS == 2
-  if (typeof sig === 'undefined') {
-    err('warning: addFunction(): You should provide a wasm function signature string as a second argument. This is not necessary for asm.js and asm2wasm, but can be required for the LLVM wasm backend, so it is recommended for full portability.');
-  }
-#endif // ASSERTIONS == 2
-#endif // ASSERTIONS
 
-  return addFunctionWasm(func, sig);
-}


### PR DESCRIPTION
In updating the assert text in `addFunction` I noticed that we don't
really need the internal `addFunctionWasm` anymore and we can just merge
them for simplicity.

`addFunctionWasm` was add as an internal function and never documents so
should be safe to remove.

The assertion from `addFunction` is more precisely handled the assert
in the exception handling block:

```
    assert(typeof sig !== 'undefined', 'Missing signature argument to addFunction: ' + func);
```

This handles that case where addFunction is given a JS function but no
signature.