### PR TITLE
Support --preload-file in the shell environment and d8

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -43,6 +43,10 @@ var Module = typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : 
 #include "promise_polyfill.js"
 #endif
 
+#if ENVIRONMENT_MAY_BE_SHELL
+#include "xhr_polyfill.js"
+#endif
+
 #if MODULARIZE
 // Set up the promise that indicates the Module is initialized
 var readyPromiseResolve, readyPromiseReject;

--- a/src/xhr_polyfill.js
+++ b/src/xhr_polyfill.js
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2012 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+// In d8 and other shells xhr might not exist. Polyfill it so that preload-file
+// works.
+// This is hackish and affects the global scope, but this file is only included
+// when using the shell environment, which is not on by default, and only takes
+// effect when XMLHttpRequest is not defined, which basically means when testing
+// in the shell locally.
+if (typeof XMLHttpRequest === 'undefined') {
+  // Polyfill XHR for d8, so that --preload-file
+  XMLHttpRequest = function() {
+    return {
+      open: function(mode, path, async) {
+        this.mode = mode;
+        this.path = path;
+        this.async = async;
+      },
+      send: function() {
+        if (!this.async) {
+          this.doSend();
+        } else {
+          var that = this;
+          setTimeout(function() {
+            that.doSend();
+            if (that.onload) that.onload();
+          }, 0);
+        }
+      },
+      doSend: function() {
+        if (this.responseType == 'arraybuffer') {
+          this.response = read(this.path, 'binary');
+        } else {
+          this.responseText = read(this.path);
+        }
+        this.status = 200;
+      },
+    };
+  };
+}
+

--- a/src/xhr_polyfill.js
+++ b/src/xhr_polyfill.js
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2012 The Emscripten Authors
+ * Copyright 2021 The Emscripten Authors
  * SPDX-License-Identifier: MIT
  */
 

--- a/src/xhr_polyfill.js
+++ b/src/xhr_polyfill.js
@@ -11,7 +11,6 @@
 // effect when XMLHttpRequest is not defined, which basically means when testing
 // in the shell locally.
 if (typeof XMLHttpRequest === 'undefined') {
-  // Polyfill XHR for d8, so that --preload-file
   XMLHttpRequest = function() {
     return {
       open: function(mode, path, async) {

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1448,10 +1448,13 @@ int f() {
       }
     ''')
 
-    self.run_process([EMXX, 'main.cpp'] + args)
-    # run in node.js to ensure we verify that file preloading works there
-    result = self.run_js('a.out.js', engine=config.NODE_JS)
-    self.assertContained('|hello from a file wi|', result)
+    self.run_process([EMXX, 'main.cpp', '-sENVIRONMENT=node,shell'] + args)
+    # run in all engines to ensure we verify that file preloading works in
+    # node and d8
+    for engine in config.JS_ENGINES:
+      print(engine)
+      result = self.run_js('a.out.js', engine=engine)
+      self.assertContained('|hello from a file wi|', result)
 
   def test_embed_file_dup(self):
     ensure_dir(self.in_dir('tst', 'test1'))


### PR DESCRIPTION
This does so using a polyfill for XHR. That has downsides, but the shell
environment is only really used for local testing, so that seems ok.

Other options to fix the general issue of embed-file being slow on huge
files is to optimize embed-file's output. However, testing of emitting the
base64-encoded data in chunks is inconclusive: faster to parse in our
JS optimizer but slower in closure.