### PR TITLE
Simplify `run_js_tool`

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -223,14 +223,14 @@ def check_call(cmd, *args, **kw):
     exit_with_error("'%s' failed: %s", shlex_join(cmd), str(e))
 
 
-def run_js_tool(filename, jsargs=[], *args, **kw):
+def run_js_tool(filename, jsargs=[], **kw):
   """Execute a javascript tool.
 
   This is used by emcc to run parts of the build process that are written
   implemented in javascript.
   """
   command = config.NODE_JS + [filename] + jsargs
-  return check_call(command, *args, **kw).stdout
+  return check_call(command, **kw).stdout
 
 
 def get_npm_cmd(name):
@@ -768,7 +768,7 @@ def read_and_preprocess(filename, expand_macros=False):
   if expand_macros:
     args += ['--expandMacros']
 
-  run_js_tool(path_from_root('tools/preprocessor.js'), args, True, stdout=open(stdout, 'w'), cwd=dirname)
+  run_js_tool(path_from_root('tools/preprocessor.js'), args, stdout=open(stdout, 'w'), cwd=dirname)
   out = utils.read_file(stdout)
 
   return out


### PR DESCRIPTION
All the places except for one, where we want to through arguments to the
underlying `run_process` call we were doing so via keyword arguments
already

In the one place were we passing the positional `True` argument it was
to signal `check=True` which is already the default.

See #15342