### PR TITLE
[Minor] update open comment

### DIFF
--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -333,6 +333,8 @@ __wasi_fd_t __syscall_open(long pathname, long flags, long mode) {
     // Requested entry (file or directory)
     if (!curr) {
       // Create last element in path if O_CREAT is specified.
+      // If O_DIRECTORY is also specified, still create a regular file:
+      // https://man7.org/linux/man-pages/man2/open.2.html#BUGS
       if (i == pathParts.size() - 1 && flags & O_CREAT) {
         auto lockedDir = directory->locked();
 


### PR DESCRIPTION
Relevant Issue: #15041 

According to the manpage:
```
When both O_CREAT and O_DIRECTORY are specified in flags and the
       file specified by pathname does not exist, open() will create a
       regular file (i.e., O_DIRECTORY is ignored).
```
https://man7.org/linux/man-pages/man2/open.2.html#BUGS