### PR TITLE
Fix ascii assertion. Fixes #15345

### DIFF
--- a/src/runtime_strings_extra.js
+++ b/src/runtime_strings_extra.js
@@ -256,7 +256,7 @@ function writeArrayToMemory(array, buffer) {
 function writeAsciiToMemory(str, buffer, dontAddNull) {
   for (var i = 0; i < str.length; ++i) {
 #if ASSERTIONS
-    assert(str.charCodeAt(i) === str.charCodeAt(i)&0xff);
+    assert(str.charCodeAt(i) === (str.charCodeAt(i) & 0xff));
 #endif
     {{{ makeSetValue('buffer++', 0, 'str.charCodeAt(i)', 'i8') }}};
   }


### PR DESCRIPTION
The priority of `===` vs `&` is confusing, and we were doing the
wrong thing here, writing `x == x & c` which actually does
`(x == x) & c` (which always returns 1!) versus the intended
`x == (x & c)`.