### PR TITLE
docs: Fix the markup of links on "Building to WebAssembly"

### DIFF
--- a/site/source/docs/compiling/WebAssembly.rst
+++ b/site/source/docs/compiling/WebAssembly.rst
@@ -6,10 +6,7 @@ Building to WebAssembly
 
 WebAssembly is a binary format for executing code on the web, allowing fast start times (smaller download and much faster parsing in browsers when compared to JS or asm.js). Emscripten compiles to WebAssembly by default, but you can also compile to JS for older browsers.
 
-For some historical background, see
-
-- `these slides <https://kripken.github.io/talks/wasm.html>`_ and
-- `this blogpost <https://hacks.mozilla.org/2015/12/compiling-to-webassembly-its-happening/>`_.
+For some historical background, see `these slides <https://kripken.github.io/talks/wasm.html>`_ and `this blogpost <https://hacks.mozilla.org/2015/12/compiling-to-webassembly-its-happening/>`_.
 
 Setup
 =====


### PR DESCRIPTION
Hello, this is a simple PR that fixes the markup to refine the layout of the link texts on ["Building to WebAssembly"](https://emscripten.org/docs/compiling/WebAssembly.html) page.

## Screenshots

Here are the difference of the change:

**Before**

<img width="1015" alt="Screen Shot 2021-10-25 at 17 31 53" src="https://user-images.githubusercontent.com/1425259/138662952-77b3b4b3-0036-46e2-9147-3ce935201d32.png">

**After**

<img width="1104" alt="Screen Shot 2021-10-25 at 17 33 07" src="https://user-images.githubusercontent.com/1425259/138662938-759833f6-1339-4bd9-9a04-5ab541e2fc19.png">
