### PR TITLE
Move dlopen flags from args to memory. NFC

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -420,7 +420,7 @@ var LibraryDylink = {
   // Loads a side module from binary data or compiled Module. Returns the module's exports or a
   // promise that resolves to its exports if the loadAsync flag is set.
   $loadWebAssemblyModule__deps: ['$loadDynamicLibrary', '$createInvokeFunction', '$getMemory', '$relocateExports', '$resolveGlobalSymbol', '$GOTHandler', '$getDylinkMetadata', '$alignMemory'],
-  $loadWebAssemblyModule: function(binary, flags) {
+  $loadWebAssemblyModule: function(binary, flags, handle) {
     var metadata = getDylinkMetadata(binary);
 #if ASSERTIONS
     var originalTable = wasmTable;
@@ -704,11 +704,11 @@ var LibraryDylink = {
       // module not preloaded - load lib data and create new module from it
       if (flags.loadAsync) {
         return loadLibData(lib).then(function(libData) {
-          return loadWebAssemblyModule(libData, flags);
+          return loadWebAssemblyModule(libData, flags, handle);
         });
       }
 
-      return loadWebAssemblyModule(loadLibData(lib), flags);
+      return loadWebAssemblyModule(loadLibData(lib), flags, handle);
     }
 
     // module for lib is loaded - update the dso & global namespace
@@ -768,11 +768,15 @@ var LibraryDylink = {
 
   // void* dlopen(const char* filename, int flags);
   $dlopenInternal__deps: ['$FS', '$ENV', '$dlSetError'],
-  $dlopenInternal: function(handle, flags, jsflags) {
+  $dlopenInternal: function(handle, jsflags) {
     // void *dlopen(const char *file, int mode);
     // http://pubs.opengroup.org/onlinepubs/009695399/functions/dlopen.html
-    var searchpaths = [];
     var filename = UTF8ToString(handle + {{{ C_STRUCTS.dso.name }}});
+    var flags = {{{ makeGetValue('handle', C_STRUCTS.dso.flags, 'i32') }}};
+#if DYLINK_DEBUG
+    err('dlopenInternal: ' + filename);
+#endif
+    var searchpaths = [];
 
     var isValidFile = function(filename) {
       var target = FS.findObject(filename);
@@ -792,10 +796,6 @@ var LibraryDylink = {
         }
       }
     }
-
-#if DYLINK_DEBUG
-    err('dlopenInternal: ' + filename);
-#endif
 
     // We don't care about RTLD_NOW and RTLD_LAZY.
     var combinedFlags = {
@@ -822,14 +822,14 @@ var LibraryDylink = {
 
   _dlopen_js__deps: ['$dlopenInternal'],
   _dlopen_js__sig: 'iiii',
-  _dlopen_js: function(handle, flags) {
+  _dlopen_js: function(handle) {
 #if ASYNCIFY
     return Asyncify.handleSleep(function(wakeUp) {
       var jsflags = {
         loadAsync: true,
         fs: FS, // load libraries from provided filesystem
       }
-      var promise = dlopenInternal(handle, flags, jsflags);
+      var promise = dlopenInternal(handle, jsflags);
       promise.then(wakeUp).catch(function() { wakeUp(0) });
     });
 #else
@@ -837,7 +837,7 @@ var LibraryDylink = {
       loadAsync: false,
       fs: FS, // load libraries from provided filesystem
     }
-    return dlopenInternal(handle, flags, jsflags);
+    return dlopenInternal(handle, jsflags);
 #endif
   },
 
@@ -849,7 +849,7 @@ var LibraryDylink = {
 #endif
   ],
   _emscripten_dlopen_js__sig: 'viiiii',
-  _emscripten_dlopen_js: function(handle, flags, onsuccess, onerror) {
+  _emscripten_dlopen_js: function(handle, onsuccess, onerror) {
     function errorCallback(e) {
       var filename = UTF8ToString({{{ makeGetValue('handle', C_STRUCTS.dso.name, '*') }}});
       dlSetError('Could not load dynamic lib: ' + filename + '\n' + e);
@@ -862,7 +862,7 @@ var LibraryDylink = {
     }
 
     {{{ runtimeKeepalivePush() }}}
-    var promise = dlopenInternal(handle, flags, { loadAsync: true });
+    var promise = dlopenInternal(handle, { loadAsync: true });
     if (promise) {
       promise.then(successCallback, errorCallback);
     } else {

--- a/src/struct_info_internal.json
+++ b/src/struct_info_internal.json
@@ -40,6 +40,7 @@
         "file": "dynlink.h",
         "structs": {
             "dso": [
+              "flags",
               "name"
             ]
         }

--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -20,9 +20,9 @@
 
 //#define DYLINK_DEBUG
 
-extern void* _dlopen_js(struct dso* handle, int mode);
+extern void* _dlopen_js(struct dso* handle);
 extern void* _dlsym_js(struct dso* handle, const char* symbol);
-extern void _emscripten_dlopen_js(struct dso* handle, int flags,
+extern void _emscripten_dlopen_js(struct dso* handle,
                                   em_arg_callback_func onsuccess,
                                   em_arg_callback_func onerror);
 
@@ -69,6 +69,7 @@ static struct dso* load_library_start(const char* name, int flags) {
   struct dso* p;
   size_t alloc_size = sizeof *p + strlen(name) + 1;
   p = calloc(1, alloc_size);
+  p->flags = flags;
   strcpy(p->name, name);
 
   return p;
@@ -77,7 +78,7 @@ static struct dso* load_library_start(const char* name, int flags) {
 static void dlopen_js_onsuccess(void* handle) {
   struct dso* p = (struct dso*)handle;
 #ifdef DYLINK_DEBUG
-  printf("dlopen_js_onsuccess: dso=%p\n", p);
+  fprintf(stderr, "%p: dlopen_js_onsuccess: dso=%p\n", pthread_self(), p);
 #endif
   load_library_done(p);
   pthread_rwlock_unlock(&lock);
@@ -87,7 +88,7 @@ static void dlopen_js_onsuccess(void* handle) {
 static void dlopen_js_onerror(void* handle) {
   struct dso* p = (struct dso*)handle;
 #ifdef DYLINK_DEBUG
-  printf("dlopen_js_onsuccess: dso=%p\n", p);
+  fprintf(stderr, "%p: dlopen_js_onerror: dso=%p\n", pthread_self(), handle);
 #endif
   pthread_rwlock_unlock(&lock);
   p->onerror(p->user_data);
@@ -99,10 +100,9 @@ static void init_dso_list() {
   pthread_rwlock_wrlock(&lock);
   if (!head) {
     // Flags are not important since the main module is already loaded.
-    int flags = RTLD_NOW|RTLD_GLOBAL;
-    struct dso* p = load_library_start("__main__", flags);
+    struct dso* p = load_library_start("__main__", RTLD_NOW|RTLD_GLOBAL);
     assert(p);
-    void* success = _dlopen_js(p, flags);
+    void* success = _dlopen_js(p);
     assert(success);
     load_library_done(p);
     assert(head);
@@ -118,7 +118,7 @@ void* dlopen(const char* file, int flags) {
     return head;
   }
 #ifdef DYLINK_DEBUG
-  printf("dlopen: %s [%d]\n", file, flags);
+  fprintf(stderr, "%p: dlopen: %s [%d]\n", pthread_self(), file, flags);
 #endif
 
   struct dso* p;
@@ -130,7 +130,7 @@ void* dlopen(const char* file, int flags) {
   for (p = head; p; p = p->next) {
     if (!strcmp(p->name, file)) {
 #ifdef DYLINK_DEBUG
-      printf("dlopen: already opened: %p\n", p);
+      fprintf(stderr, "%p: dlopen: already opened: %p\n", pthread_self(), p);
 #endif
       goto end;
     }
@@ -140,17 +140,17 @@ void* dlopen(const char* file, int flags) {
   if (!p) {
     goto end;
   }
-  void* success = _dlopen_js(p, flags);
+  void* success = _dlopen_js(p);
   if (!success) {
 #ifdef DYLINK_DEBUG
-    printf("dlopen_js: failed\n", p);
+    fprintf(stderr, "%p: dlopen_js: failed\n", pthread_self(), p);
 #endif
     free(p);
     p = NULL;
     goto end;
   }
 #ifdef DYLINK_DEBUG
-  printf("dlopen_js: success: %p\n", p);
+  fprintf(stderr, "%p: dlopen_js: success: %p\n", pthread_self(), p);
 #endif
   load_library_done(p);
 end:
@@ -179,15 +179,15 @@ void emscripten_dlopen(const char* filename, int flags, void* user_data,
   p->onsuccess = onsuccess;
   p->onerror = onerror;
 #ifdef DYLINK_DEBUG
-  printf("calling emscripten_dlopen_js %p\n", p);
+  fprintf(stderr, "%p: calling emscripten_dlopen_js %p\n", pthread_self(), p);
 #endif
   // Unlock happens in dlopen_js_onsuccess/dlopen_js_onerror
-  _emscripten_dlopen_js(p, flags, dlopen_js_onsuccess, dlopen_js_onerror);
+  _emscripten_dlopen_js(p, dlopen_js_onsuccess, dlopen_js_onerror);
 }
 
 void* __dlsym(void* restrict p, const char* restrict s, void* restrict ra) {
 #ifdef DYLINK_DEBUG
-  printf("__dlsym dso:%p sym:%s\n", p, s);
+  fprintf(stderr, "%p: __dlsym dso:%p sym:%s\n", pthread_self(), p, s);
 #endif
   if (p != RTLD_DEFAULT && p != RTLD_NEXT && __dl_invalid_handle(p)) {
     return 0;

--- a/system/lib/libc/musl/src/internal/dynlink.h
+++ b/system/lib/libc/musl/src/internal/dynlink.h
@@ -16,6 +16,10 @@ struct dso {
   em_arg_callback_func onerror;
   void* user_data;
 
+  // Flags used to open the library.  We need to cache these so that
+  // (in the future) other threads can mirror the open library state.
+  int flags;
+
   // Flexible array; must be final element of struct
   char name[];
 };

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -1366,8 +1366,9 @@
             "rem": 4
         },
         "dso": {
-            "__size__": 20,
-            "name": 20
+            "__size__": 24,
+            "flags": 20,
+            "name": 24
         },
         "emscripten_fetch_attr_t": {
             "__size__": 92,


### PR DESCRIPTION
This NFC change was split out from #15317.  These flags need to be
persisted and in shared memory so that each thread/worker can load with
the libraries with the same flags.