### PR TITLE
FIX Undefined HEAP8 with ALLOW_MEMORY_GROWTH before instantiating WASM

### DIFF
--- a/src/library_memfs.js
+++ b/src/library_memfs.js
@@ -274,7 +274,7 @@ mergeInto(LibraryManager.library, {
         // memory can grow, we can't hold on to references of the
         // memory buffer, as they may get invalidated. That means we
         // need to do copy its contents.
-        if (buffer.buffer === HEAP8.buffer) {
+        if (HEAP8 && buffer.buffer === HEAP8.buffer) {
           canOwn = false;
         }
 #endif // ALLOW_MEMORY_GROWTH


### PR DESCRIPTION
**The problem**
If I try to load assets while loading the wasm and add them to de MEMFS with ALLOW_MEMORY_GROWTH=1 it doesn't work

**The cause**
if ALLOW_MEMORY_GROWTH is active, it is checking if the current buffer is the same as in HEAP8, but HEAP8 is undefined because the WASM is still loading.

**The solution**
As the check is only to avoid copying the buffer, we can say that if HEAP8 is undefined we need to copy it without any further problems.