### PR TITLE
Always copy files as writable

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1731,7 +1731,7 @@ def copytree_exist_ok(src, dst):
     if entry.is_dir():
       copytree_exist_ok(srcname, dstname)
     else:
-      shared.safe_copy(srcname, dstname)
+      shared.copy_file(srcname, dstname)
 
 
 def install_system_headers(stamp):


### PR DESCRIPTION
Use stat to ensure that any copyied files are wriable.  I tried using
copy2 which avoids copying permissions altogther by we have some files
(e.g. sdl2-config) which are executable so we need to preserve at least
some permissions.

This can be importantant in `install_system_headers` which copies files
from the emscripten directory (which may be read only) in the cache
directory.  In this case we don't want the resulting files in the cache
to also be read only.

This change also removes the checks for `src == dst` and `dst ==
os.devnull`.  Neither of this should occur with any of the callers of
these functions.  If they do its bug, so assert instead.

Fixes: #15374