### PR TITLE
Rename wasmX tests suites to just coreX

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,25 +361,25 @@ jobs:
     steps:
       - run-tests:
           test_targets: "posixtest"
-  test-wasm0:
+  test-core0:
     executor: bionic
     steps:
       - run-tests:
-          test_targets: "wasm0"
-  test-wasm2:
+          test_targets: "core0"
+  test-core2:
     executor: bionic
     environment:
       EMTEST_BROWSER: "node"
     steps:
       - run-tests:
           # also add a few asan tests and a single test of EMTEST_BROWSER=node
-          test_targets: "wasm2 asan.test_stat asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
-  test-wasm3:
+          test_targets: "core2 asan.test_stat asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
+  test-core3:
     executor: bionic
     steps:
       - run-tests:
           # also add a little select testing for wasm2js in -O3
-          test_targets: "wasm3 wasm2js3.test_memorygrowth_2"
+          test_targets: "core3 wasm2js3.test_memorygrowth_2"
   test-wasm2js1:
     executor: bionic
     steps:
@@ -439,7 +439,7 @@ jobs:
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - run-tests:
-          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple wasm2.test_sse1 wasm2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file wasm2.test_utf16 other.test_special_chars_in_arguments other.test_toolchain_profiler other.test_realpath_nodefs other.test_response_file_encoding"
+          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple core2.test_sse1 core2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file core2.test_utf16 other.test_special_chars_in_arguments other.test_toolchain_profiler other.test_realpath_nodefs other.test_response_file_encoding"
   test-mac:
     executor: mac
     environment:
@@ -457,7 +457,7 @@ jobs:
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - run-tests-mac:
-          test_targets: "other wasm0.test_lua wasm0.test_longjmp_standalone wasm2.test_sse1 skip:other.test_native_link_error_message"
+          test_targets: "other core0.test_lua core0.test_longjmp_standalone core2.test_sse1 skip:other.test_native_link_error_message"
 
 workflows:
   build-test:
@@ -472,13 +472,13 @@ workflows:
       - test-posixtest:
           requires:
             - build-linux
-      - test-wasm0:
+      - test-core0:
           requires:
             - build-linux
-      - test-wasm2:
+      - test-core2:
           requires:
             - build-linux
-      - test-wasm3:
+      - test-core3:
           requires:
             - build-linux
       - test-wasm64:

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.1.2
 -----
+- `wasmX` test suites that are defined in `test_core.py` have been renamed to
+  `coreX` to better reflect where they are defined.  The old suite names such
+  as `wasm2` will continue to work for now as aliases.
 
 3.1.1 - 08/01/2022
 ------------------

--- a/site/source/docs/getting_started/test-suite.rst
+++ b/site/source/docs/getting_started/test-suite.rst
@@ -31,17 +31,11 @@ The tests are divided into *modes*. You can run either an entire mode or an indi
   # run one test (in the default mode)
   tests/runner test_loop
 
-  # run one test in a specific mode (here, asm.js -O2)
-  tests/runner asm2.test_loop
+  # run a bunch of tests in one mode (here, all i64 tests in -O3)
+  tests/runner core3.test_*i64*
 
-  # run a test in a bunch of modes (here, all asm.js modes)
-  tests/runner asm*.test_loop
-
-  # run a bunch of tests in one mode (here, all i64 tests in wasm -O3)
-  tests/runner wasm3.test_*i64*
-
-  # run all tests in a specific mode (here, asm.js -O1)
-  tests/runner asm1
+  # run all tests in a specific mode (here, wasm2gs -O1)
+  tests/runner wasm2js1
 
 The *core* test modes (defined at the bottom of `tests/test_core.py <https://github.com/emscripten-core/emscripten/blob/main/tests/test_core.py>`_) let you run a specific test in either asm.js or wasm, and with different optimization flags. There are also non-core test modes, that run tests in more special manner (in particular, in those tests it is not possible to say "run the test with a different optimization flag" - that is what the core tests are for). The non-core test modes include
 

--- a/system/lib/libc/musl/include/inttypes.h
+++ b/system/lib/libc/musl/include/inttypes.h
@@ -27,7 +27,7 @@ uintmax_t wcstoumax(const wchar_t *__restrict, wchar_t **__restrict, int);
 #define __PRIPTR "l"
 #elif defined(__EMSCRIPTEN__)
 // Under emscripten __PTRDIFF_TYPE__ and therefor intptr_t are defined to
-// be `long int` even on wasm2.
+// be `long int` even on wasm32.
 #define __PRI64  "ll"
 #define __PRIPTR "l"
 #else

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -47,12 +47,12 @@ logger = logging.getLogger("runner")
 
 # The core test modes
 core_test_modes = [
-  'wasm0',
-  'wasm1',
-  'wasm2',
-  'wasm3',
-  'wasms',
-  'wasmz',
+  'core0',
+  'core1',
+  'core2',
+  'core3',
+  'cores',
+  'corez',
   'strict',
   'wasm2js0',
   'wasm2js1',
@@ -64,7 +64,7 @@ core_test_modes = [
 ]
 
 # The default core test mode, used when none is specified
-default_core_test_mode = 'wasm0'
+default_core_test_mode = 'core0'
 
 # The non-core test modes
 non_core_test_modes = [
@@ -225,8 +225,21 @@ def print_random_test_statistics(num_tests):
   atexit.register(show)
 
 
+def replace_legacy_suite_names(args):
+  newargs = []
+
+  for a in args:
+    if a.startswith('wasm') and not a.startswith('wasm2js'):
+      print('warning: test suites in test_core.py have been renamed from `wasm` to `core`. Please use the new names')
+      a = a.replace('wasm', 'core', 1)
+    newargs.append(a)
+
+  return newargs
+
+
 def load_test_suites(args, modules):
   loader = unittest.TestLoader()
+  args = replace_legacy_suite_names(args)
   unmatched_test_names = set(args)
   suites = []
   for m in modules:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8898,15 +8898,15 @@ def make_run(name, emcc_args, settings=None, env=None, node_args=None):
 
 
 # Main wasm test modes
-wasm0 = make_run('wasm0', emcc_args=['-O0'])
-wasm0g = make_run('wasm0g', emcc_args=['-O0', '-g'])
-wasm1 = make_run('wasm1', emcc_args=['-O1'])
-wasm2 = make_run('wasm2', emcc_args=['-O2'])
-wasm2g = make_run('wasm2g', emcc_args=['-O2', '-g'])
-wasm3 = make_run('wasm3', emcc_args=['-O3'])
-wasms = make_run('wasms', emcc_args=['-Os'])
-wasmz = make_run('wasmz', emcc_args=['-Oz'])
-wasm64 = make_run('wasm64', emcc_args=['-O0', '-g3'],
+core0 = make_run('core0', emcc_args=['-O0'])
+core0g = make_run('core0g', emcc_args=['-O0', '-g'])
+core1 = make_run('core1', emcc_args=['-O1'])
+core2 = make_run('core2', emcc_args=['-O2'])
+core2g = make_run('core2g', emcc_args=['-O2', '-g'])
+core3 = make_run('core3', emcc_args=['-O3'])
+cores = make_run('cores', emcc_args=['-Os'])
+corez = make_run('corez', emcc_args=['-Oz'])
+core64 = make_run('core64', emcc_args=['-O0', '-g3'],
                   settings={'MEMORY64': 2}, env=None, node_args='--experimental-wasm-bigint')
 
 lto0 = make_run('lto0', emcc_args=['-flto', '-O0'])
@@ -8930,9 +8930,10 @@ wasm2jsz = make_run('wasm2jsz', emcc_args=['-Oz'], settings={'WASM': 0})
 simd2 = make_run('simd2', emcc_args=['-O2', '-msimd128'])
 bulkmem2 = make_run('bulkmem2', emcc_args=['-O2', '-mbulk-memory'])
 
-# wasm
-wasm2s = make_run('wasm2s', emcc_args=['-O2'], settings={'SAFE_HEAP': 1})
-wasm2ss = make_run('wasm2ss', emcc_args=['-O2'], settings={'STACK_OVERFLOW_CHECK': 2})
+# SAFE_HEAP/STACK_OVERFLOW_CHECK
+core2s = make_run('wasm2s', emcc_args=['-O2'], settings={'SAFE_HEAP': 1})
+core2ss = make_run('wasm2ss', emcc_args=['-O2'], settings={'STACK_OVERFLOW_CHECK': 2})
+
 # Add DEFAULT_TO_CXX=0
 strict = make_run('strict', emcc_args=[], settings={'STRICT': 1})
 

--- a/tools/emcoverage.py
+++ b/tools/emcoverage.py
@@ -17,7 +17,7 @@ Special commands:
   - xml:    generate XML coverage report in ./coverage.xml
 
 Otherwise, you can run any python script or Emscripten command, for example:
-  - emcoverage.py ./tests/runner.py wasm0
+  - emcoverage.py ./tests/runner.py core0
   - emcoverage.py emcc file1.c file2.c
 
 Running a command under emcoverage.py will collect the code coverage


### PR DESCRIPTION
Since these are the default modes and we no longer have asmjs
anymore it seems logically to just call these after the test
suite itself