### PR TITLE
Compile and test faccessat musl function

### DIFF
--- a/system/lib/libc/musl/src/unistd/faccessat.c
+++ b/system/lib/libc/musl/src/unistd/faccessat.c
@@ -5,6 +5,7 @@
 #include "syscall.h"
 #include "pthread_impl.h"
 
+#ifndef __EMSCRIPTEN__
 struct ctx {
 	int fd;
 	const char *filename;
@@ -30,9 +31,13 @@ static int checker(void *p)
 	for (i=0; i < sizeof errors/sizeof *errors - 1 && ret!=errors[i]; i++);
 	return i;
 }
+#endif
 
 int faccessat(int fd, const char *filename, int amode, int flag)
 {
+#ifdef __EMSCRIPTEN__
+	return syscall(SYS_faccessat, fd, filename, amode, flag);
+#else
 	if (!flag || (flag==AT_EACCESS && getuid()==geteuid() && getgid()==getegid()))
 		return syscall(SYS_faccessat, fd, filename, amode, flag);
 
@@ -60,4 +65,5 @@ int faccessat(int fd, const char *filename, int amode, int flag)
 	__restore_sigs(&set);
 
 	return __syscall_ret(ret);
+#endif
 }

--- a/tests/unistd/access.c
+++ b/tests/unistd/access.c
@@ -63,6 +63,14 @@ int main() {
   printf("F_OK(%s): %d\n", "renamedfile", access("renamedfile", F_OK));
   printf("errno: %d\n", errno);
 
+  // Same againt with faccessat
+  errno = 0;
+  printf("F_OK(%s): %d\n", "filetorename", faccessat(AT_FDCWD, "filetorename", F_OK, 0));
+  printf("errno: %d\n", errno);
+  errno = 0;
+  printf("F_OK(%s): %d\n", "renamedfile", faccessat(AT_FDCWD, "renamedfile", F_OK, 0));
+  printf("errno: %d\n", errno);
+
 #ifndef __EMSCRIPTEN_ASMFS__
   // Restore full permissions on all created files so that python test runner rmtree
   // won't have problems on deleting the files. On Windows, calling shutil.rmtree()

--- a/tests/unistd/access.out
+++ b/tests/unistd/access.out
@@ -56,3 +56,7 @@ F_OK(filetorename): -1
 errno: 44
 F_OK(renamedfile): 0
 errno: 0
+F_OK(filetorename): -1
+errno: 44
+F_OK(renamedfile): 0
+errno: 0

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -743,7 +743,6 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
         'gethostbyname2_r.c', 'gethostbyname_r.c', 'gethostbyname2.c',
         'alarm.c', 'syscall.c', 'popen.c', 'pclose.c',
         'getgrouplist.c', 'initgroups.c', 'wordexp.c', 'timer_create.c',
-        'faccessat.c',
         # 'process' exclusion
         'fork.c', 'vfork.c', 'posix_spawn.c', 'posix_spawnp.c', 'execve.c', 'waitid.c', 'system.c'
     ]


### PR DESCRIPTION
We already implemented `__syscall_faccessat` but we were not
using or testing it.