### PR TITLE
Remove declarations of unused syscalls. NFC

### DIFF
--- a/system/lib/fetch/asmfs.cpp
+++ b/system/lib/fetch/asmfs.cpp
@@ -1827,17 +1827,6 @@ static long writev(int fd, const iovec *iov, int iovcnt) // syscall146
   return total_write_amount;
 }
 
-long __syscall_write(long fd, long buf, long count)
-{
-#ifdef ASMFS_DEBUG
-  EM_ASM(
-    err('write(fd=' + $0 + ', buf=0x' + ($1).toString(16) + ', count=' + $2 + ')'), fd, buf, count);
-#endif
-
-  iovec io = {(void*)buf, (size_t)count};
-  return writev(fd, &io, 1);
-}
-
 // WASI support: provide a shim between the wasi fd_write syscall and the
 // syscall146 that is implemented here in ASMFS.
 // TODO: Refactor ASMFS's syscall146 into a direct handler for fd_write.

--- a/system/lib/libc/emscripten_syscall_stubs.c
+++ b/system/lib/libc/emscripten_syscall_stubs.c
@@ -227,11 +227,6 @@ long __syscall_setsockopt(long sockfd, long level, long optname, long optval, lo
   return -ENOPROTOOPT; // The option is unknown at the level indicated.
 }
 
-long __syscall_rt_sigqueueinfo(long tgid, long pid, long uinfo) {
-  REPORT(rt_sigqueueinfo);
-  return 0;
-}
-
 UNIMPLEMENTED(acct, (long filename))
 UNIMPLEMENTED(mincore, (long addr, long length, long vec))
 UNIMPLEMENTED(pipe2, (long fds, long flags))

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -1,6 +1,3 @@
-#define SYS_exit		  __syscall_exit
-#define SYS_read		  __syscall_read
-#define SYS_write		  __syscall_write
 #define SYS_open		  __syscall_open
 #define SYS_link		  __syscall_link
 #define SYS_unlink		 __syscall_unlink
@@ -50,9 +47,6 @@
 #define SYS_munlockall		__syscall_munlockall
 #define SYS_mremap		__syscall_mremap
 #define SYS_poll		__syscall_poll
-#define SYS_rt_sigqueueinfo	__syscall_rt_sigqueueinfo
-#define SYS_pread64		__syscall_pread64
-#define SYS_pwrite64		__syscall_pwrite64
 #define SYS_getcwd		__syscall_getcwd
 #define SYS_ugetrlimit		__syscall_ugetrlimit
 #define SYS_mmap2		__syscall_mmap2
@@ -73,10 +67,8 @@
 #define SYS_chown32		__syscall_chown32
 #define SYS_mincore		__syscall_mincore
 #define SYS_madvise		__syscall_madvise
-#define SYS_madvise1		__syscall_madvise1
 #define SYS_getdents64		__syscall_getdents64
 #define SYS_fcntl64		__syscall_fcntl64
-#define SYS_exit_group		__syscall_exit_group
 #define SYS_statfs64		__syscall_statfs64
 #define SYS_fstatfs64		__syscall_fstatfs64
 #define SYS_fadvise64_64	__syscall_fadvise64_64
@@ -97,8 +89,6 @@
 #define SYS_fallocate		__syscall_fallocate
 #define SYS_dup3		__syscall_dup3
 #define SYS_pipe2		__syscall_pipe2
-#define SYS_preadv		__syscall_preadv
-#define SYS_pwritev		__syscall_pwritev
 #define SYS_recvmmsg		__syscall_recvmmsg
 #define SYS_prlimit64		__syscall_prlimit64
 #define SYS_sendmmsg		__syscall_sendmmsg

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -62,7 +62,6 @@ long __syscall_mlockall(long flags);
 long __syscall_munlockall(void);
 long __syscall_mremap(long old_addr, long old_size, long new_size, long flags, long new_addr);
 long __syscall_poll(long fds, long nfds, long timeout);
-long __syscall_rt_sigqueueinfo(long tgid, long sig, long uinfo);
 long __syscall_getcwd(long buf, long size);
 long __syscall_ugetrlimit(long resource, long rlim);
 long __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long off);


### PR DESCRIPTION
I found these programatically using:

```
$ cat system/lib/libc/musl/arch/emscripten/bits/syscall.h | awk '{print $3}' | sort | uniq > delcared.txt
$ llvm-nm cache/sysroot/lib/wasm32-emscripten/libc.a  cache/sysroot/lib/wasm32-emscripten/libsockets.a | grep "U __syscall_" | awk '{print $2}' | sort | uniq > used_syscalls.txt
$ diff -u used_syscalls.txt delcared.txt
```