### PR TITLE
Define SANITIZER_USES_CANONICAL_LINUX_SYSCALLS in compiler-rt

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -261,17 +261,6 @@ var SyscallsLibrary = {
 #endif
   },
 
-  __syscall_open: function(path, flags, varargs) {
-    var pathname = SYSCALLS.getStr(path);
-    var mode = varargs ? SYSCALLS.get() : 0;
-    var stream = FS.open(pathname, flags, mode);
-    return stream.fd;
-  },
-  __syscall_unlink: function(path) {
-    path = SYSCALLS.getStr(path);
-    FS.unlink(path);
-    return 0;
-  },
   __syscall_chdir: function(path) {
     path = SYSCALLS.getStr(path);
     FS.chdir(path);
@@ -380,10 +369,6 @@ var SyscallsLibrary = {
     linkpath = SYSCALLS.getStr(linkpath);
     FS.symlink(target, linkpath);
     return 0;
-  },
-  __syscall_readlink: function(path, buf, bufsize) {
-    path = SYSCALLS.getStr(path);
-    return SYSCALLS.doReadlink(path, buf, bufsize);
   },
   __syscall_fchmod: function(fd, mode) {
     FS.fchmod(fd, mode);
@@ -929,9 +914,6 @@ var SyscallsLibrary = {
     return 0; // your advice is important to us (but we can't use it)
   },
   __syscall_openat: function(dirfd, path, flags, varargs) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
-#endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     var mode = varargs ? SYSCALLS.get() : 0;
@@ -965,7 +947,7 @@ var SyscallsLibrary = {
     FS.chown(path, owner, group);
     return 0;
   },
-  __syscall_fstatat64: function(dirfd, path, buf, flags) {
+  __syscall_newfstatat: function(dirfd, path, buf, flags) {
     path = SYSCALLS.getStr(path);
     var nofollow = flags & {{{ cDefine('AT_SYMLINK_NOFOLLOW') }}};
     var allowEmpty = flags & {{{ cDefine('AT_EMPTY_PATH') }}};
@@ -989,9 +971,6 @@ var SyscallsLibrary = {
     return 0;
   },
   __syscall_renameat: function(olddirfd, oldpath, newdirfd, newpath) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
-#endif
     oldpath = SYSCALLS.getStr(oldpath);
     newpath = SYSCALLS.getStr(newpath);
     oldpath = SYSCALLS.calculateAt(olddirfd, oldpath);
@@ -1013,9 +992,6 @@ var SyscallsLibrary = {
     return 0;
   },
   __syscall_readlinkat: function(dirfd, path, buf, bufsize) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall');
-#endif
     path = SYSCALLS.getStr(path);
     path = SYSCALLS.calculateAt(dirfd, path);
     return SYSCALLS.doReadlink(path, buf, bufsize);

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_platform.h
@@ -283,6 +283,11 @@
 #define SANITIZER_SIGN_EXTENDED_ADDRESSES 0
 #endif
 
+// Emscripten emulates the canonical linux syscall set.
+#if !defined SANITIZER_USES_CANONICAL_LINUX_SYSCALLS && SANITIZER_EMSCRIPTEN
+# define SANITIZER_USES_CANONICAL_LINUX_SYSCALLS 1
+#endif
+
 // The AArch64 and RISC-V linux ports use the canonical syscall set as
 // mandated by the upstream linux community for all new ports. Other ports
 // may still use legacy syscalls.

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -1,6 +1,4 @@
-#define SYS_open		  __syscall_open
 #define SYS_link		  __syscall_link
-#define SYS_unlink		 __syscall_unlink
 #define SYS_chdir		 __syscall_chdir
 #define SYS_mknod		 __syscall_mknod
 #define SYS_chmod		 __syscall_chmod
@@ -8,7 +6,6 @@
 #define SYS_pause		 __syscall_pause
 #define SYS_nice		 __syscall_nice
 #define SYS_sync		 __syscall_sync
-#define SYS_rename		 __syscall_rename
 #define SYS_mkdir		 __syscall_mkdir
 #define SYS_rmdir		 __syscall_rmdir
 #define SYS_dup		 __syscall_dup
@@ -22,7 +19,6 @@
 #define SYS_setrlimit		 __syscall_setrlimit
 #define SYS_getrusage		 __syscall_getrusage
 #define SYS_symlink		 __syscall_symlink
-#define SYS_readlink		 __syscall_readlink
 #define SYS_munmap		 __syscall_munmap
 #define SYS_fchmod		 __syscall_fchmod
 #define SYS_getpriority	 __syscall_getpriority
@@ -74,7 +70,7 @@
 #define SYS_mkdirat		__syscall_mkdirat
 #define SYS_mknodat		__syscall_mknodat
 #define SYS_fchownat		__syscall_fchownat
-#define SYS_fstatat64		__syscall_fstatat64
+#define SYS_newfstatat		__syscall_newfstatat
 #define SYS_unlinkat		__syscall_unlinkat
 #define SYS_renameat		__syscall_renameat
 #define SYS_linkat		__syscall_linkat

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -11,9 +11,7 @@
 extern "C" {
 #endif
 
-long __syscall_open(long path, long flags, ...); // mode is optional
 long __syscall_link(long oldpath, long newpath);
-long __syscall_unlink(long path);
 long __syscall_chdir(long path);
 long __syscall_mknod(long path, long mode, long dev);
 long __syscall_chmod(long path, long mode);
@@ -22,7 +20,6 @@ long __syscall_pause(void);
 long __syscall_access(long path, long amode);
 long __syscall_nice(long inc);
 long __syscall_sync(void);
-long __syscall_rename(long old_path, long new_path);
 long __syscall_mkdir(long path, long mode);
 long __syscall_rmdir(long path);
 long __syscall_dup(long fd);
@@ -37,7 +34,6 @@ long __syscall_setsid(void);
 long __syscall_setrlimit(long resource, long limit);
 long __syscall_getrusage(long who, long usage);
 long __syscall_symlink(long target, long linkpath);
-long __syscall_readlink(long path, long buf, long bufsize);
 long __syscall_munmap(long addr, long len);
 long __syscall_fchmod(long fd, long mode);
 long __syscall_getpriority(long which, long who);
@@ -92,11 +88,11 @@ long __syscall_fcntl64(long fd, long cmd, ...);
 long __syscall_statfs64(long path, long size, long buf);
 long __syscall_fstatfs64(long fd, long size, long buf);
 long __syscall_fadvise64_64(long fd, long low, long high, long low2, long high2, long advice);
-long __syscall_openat(long dirfd, long path, long flags, ...);
+long __syscall_openat(long dirfd, long path, long flags, ...); // mode is optional
 long __syscall_mkdirat(long dirfd, long path, long mode);
 long __syscall_mknodat(long dirfd, long path, long mode, long dev);
 long __syscall_fchownat(long dirfd, long path, long owner, long group, long flags);
-long __syscall_fstatat64(long dirfd, long path, long buf, long flags);
+long __syscall_newfstatat(long dirfd, long path, long buf, long flags);
 long __syscall_unlinkat(long dirfd, long path, long flags);
 long __syscall_renameat(long olddirfd, long oldpath, long newdirfd, long newpath);
 long __syscall_linkat(long olddirfd, long oldpath, long newdirfd, long newpath, long flags);

--- a/system/lib/libc/musl/src/internal/syscall.h
+++ b/system/lib/libc/musl/src/internal/syscall.h
@@ -417,10 +417,10 @@ static inline long __alt_socketcall(int sys, int sock, int cp, long a, long b, l
 #define __sys_open_cp3(x,pn,fl,mo) __syscall_cp4(SYS_openat, AT_FDCWD, pn, (fl)|O_LARGEFILE, mo)
 #endif
 #else // __EMSCRIPTEN__
-#define __sys_open2(x,pn,fl) __syscall_open(__scc(pn), __scc((fl)|O_LARGEFILE))
-#define __sys_open3(x,pn,fl,mo) __syscall_open(__scc(pn), __scc((fl)|O_LARGEFILE), __scc(mo))
-#define __sys_open_cp2(x,pn,fl) __syscall_open(__scc(pn), __scc((fl)|O_LARGEFILE))
-#define __sys_open_cp3(x,pn,fl,mo) __syscall_open(__scc(pn), __scc((fl)|O_LARGEFILE), __scc(mo))
+#define __sys_open2(x,pn,fl) __syscall_openat(__scc(AT_FDCWD), __scc(pn), __scc((fl)|O_LARGEFILE))
+#define __sys_open3(x,pn,fl,mo) __syscall_openat(__scc(AT_FDCWD), __scc(pn), __scc((fl)|O_LARGEFILE), __scc(mo))
+#define __sys_open_cp2(x,pn,fl) __syscall_openat(__scc(AT_FDCWD), __scc(pn), __scc((fl)|O_LARGEFILE))
+#define __sys_open_cp3(x,pn,fl,mo) __syscall_openat(__scc(AT_FDCWD), __scc(pn), __scc((fl)|O_LARGEFILE), __scc(mo))
 #endif
 
 #define __sys_open(...) __SYSCALL_DISP(__sys_open,,__VA_ARGS__)

--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -83,7 +83,7 @@ long _munmap_js(long addr, long length, long prot, long flags, long fd, long off
 // Mark this as weak so that wasmfs does not collide with it. That is, if wasmfs
 // is in use, we want to use that and not this.
 __attribute__((__weak__))
-long __syscall_open(const char* path, long flags, ...) {
+long __syscall_openat(int dirfd, const char* path, long flags, ...) {
   if (!strcmp(path, "/dev/stdin")) return STDIN_FILENO;
   if (!strcmp(path, "/dev/stdout")) return STDOUT_FILENO;
   if (!strcmp(path, "/dev/stderr")) return STDERR_FILENO;

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -464,16 +464,6 @@ int wasmfs_create_file(char* pathname, mode_t mode, backend_t backend) {
   return doOpen(path::parseParent((char*)pathname), O_CREAT, mode, backend);
 }
 
-long __syscall_open(long path, long flags, ...) {
-  mode_t mode = 0;
-  va_list v1;
-  va_start(v1, flags);
-  mode = va_arg(v1, int);
-  va_end(v1);
-
-  return doOpen(path::parseParent((char*)path), flags, mode);
-}
-
 // TODO: Test this with non-AT_FDCWD values.
 long __syscall_openat(long dirfd, long path, long flags, ...) {
   mode_t mode = 0;
@@ -747,10 +737,6 @@ long __syscall_rmdir(long path) {
   return __syscall_unlinkat(AT_FDCWD, path, AT_REMOVEDIR);
 }
 
-long __syscall_unlink(long path) {
-  return __syscall_unlinkat(AT_FDCWD, path, 0);
-}
-
 long __syscall_getdents64(long fd, long dirp, long count) {
   dirent* result = (dirent*)dirp;
 
@@ -982,10 +968,6 @@ long __syscall_readlinkat(long dirfd, long path, long buf, long bufsize) {
   auto bytes = std::min((size_t)bufsize, target.size());
   memcpy((char*)buf, target.c_str(), bytes);
   return bytes;
-}
-
-long __syscall_readlink(long path, long buf, size_t bufSize) {
-  return __syscall_readlinkat(AT_FDCWD, path, buf, bufSize);
 }
 
 // TODO: Test this with non-AT_FDCWD values.


### PR DESCRIPTION
In defining this I noticed that musl will also choose to use
these canonical syscalls when the alternative is not defined.

This allows us to remove a bunch of duplicate syscalls and
their implementation.