### PR TITLE
Use `--export-dynamic` linker flag rather than `--export-all` when we want to export everything

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 2.0.34
 ------
+- Symbols marked as visibility hidden are no longer exported from C/C++
+  code when building with SIDE_MOUDLE, MAIN_MODULE or LINKABLE.  If you
+  need to export a hidden symbol you can still do so by adding it to
+  EXPORTED_FUNCTIONS.
 
 2.0.33 - 11/01/2021
 -------------------

--- a/emcc.py
+++ b/emcc.py
@@ -851,8 +851,14 @@ def get_cflags(user_args):
   if settings.INLINING_LIMIT:
     cflags.append('-fno-inline-functions')
 
-  if settings.RELOCATABLE:
+  if settings.RELOCATABLE and '-fPIC' not in user_args:
     cflags.append('-fPIC')
+
+  # We use default visiibilty=default in emscripten even though the upstream
+  # backend defaults visibility=hidden.  This matched the expectations of C/C++
+  # code in the wild which expects undecorated symbols to be exported to other
+  # DSO's by default.
+  if not any(a.startswith('-fvisibility') for a in user_args):
     cflags.append('-fvisibility=default')
 
   if settings.LTO:
@@ -1862,9 +1868,9 @@ def phase_linker_setup(options, state, newargs, settings_map):
   if settings.SIDE_MODULE:
     default_setting('ERROR_ON_UNDEFINED_SYMBOLS', 0)
     default_setting('WARN_ON_UNDEFINED_SYMBOLS', 0)
-  else:
-    settings.EXPORT_IF_DEFINED.append('__start_em_asm')
-    settings.EXPORT_IF_DEFINED.append('__stop_em_asm')
+
+  settings.EXPORT_IF_DEFINED.append('__start_em_asm')
+  settings.EXPORT_IF_DEFINED.append('__stop_em_asm')
 
   if options.use_preload_plugins or len(options.preload_files) or len(options.embed_files):
     if settings.NODERAWFS:

--- a/tests/core/test_dlfcn_self.exports
+++ b/tests/core/test_dlfcn_self.exports
@@ -4,12 +4,8 @@ __c_dot_utf8
 __c_dot_utf8_locale
 __c_locale
 __data_end
-__dso_handle
 __env_map
 __environ
-__fsmu8
-__hwcap
-__libc
 __optpos
 __optreset
 __pio2_hi
@@ -23,7 +19,6 @@ __signgam
 __stderr_used
 __stdin_used
 __stdout_used
-__sysinfo
 __threwValue
 _environ
 _ns_flagdata

--- a/tools/building.py
+++ b/tools/building.py
@@ -302,20 +302,20 @@ def lld_flags_for_executable(external_symbols):
     cmd.append('--strip-debug')
 
   if settings.LINKABLE:
-    cmd.append('--export-all')
+    cmd.append('--export-dynamic')
     cmd.append('--no-gc-sections')
-  else:
-    c_exports = [e for e in settings.EXPORTED_FUNCTIONS if is_c_symbol(e)]
-    # Strip the leading underscores
-    c_exports = [demangle_c_symbol_name(e) for e in c_exports]
-    if external_symbols:
-      # Filter out symbols external/JS symbols
-      c_exports = [e for e in c_exports if e not in external_symbols]
-    for export in c_exports:
-      cmd.append('--export-if-defined=' + export)
 
-    for export in settings.EXPORT_IF_DEFINED:
-      cmd.append('--export-if-defined=' + export)
+  c_exports = [e for e in settings.EXPORTED_FUNCTIONS if is_c_symbol(e)]
+  # Strip the leading underscores
+  c_exports = [demangle_c_symbol_name(e) for e in c_exports]
+  if external_symbols:
+    # Filter out symbols external/JS symbols
+    c_exports = [e for e in c_exports if e not in external_symbols]
+  for export in c_exports:
+    cmd.append('--export-if-defined=' + export)
+
+  for export in settings.EXPORT_IF_DEFINED:
+    cmd.append('--export-if-defined=' + export)
 
   if settings.RELOCATABLE:
     cmd.append('--experimental-pic')


### PR DESCRIPTION
This means hidden symbols no longer get exported by default.  The
only way to export a hidden symbol when building with MAIN_MODULE,
SIDE_MODULE or LINKABLE is to add it to the EXPORT_FUNCTIONS list.

This should be code side win for anyone building with MAIN_MODULE=1
or LINKABLE, and some folks building with SIDE_MODULE=1.

The primary motivator for this change is the musl upgrade where there
are new hidden symbols being introduced but we don't want them
exported when building with MAIN_MODULE=1.
