### PR TITLE
Fix error reporting from pthread_join

### DIFF
--- a/tests/other/test_pthread_self_join_detach.c
+++ b/tests/other/test_pthread_self_join_detach.c
@@ -2,21 +2,41 @@
 #include <errno.h>
 #include <pthread.h>
 #include <stdio.h>
+#include <string.h>
 
 #include <emscripten/threading.h>
 
 int main() {
+  /*
+   * When running in PROXY_TO_PTHREAD mode the main thread
+   * is already detached
+   */
+  int is_detached = !emscripten_is_main_browser_thread();
   pthread_t self = pthread_self();
 
-  /* Join the calling thread. This should fail with EDEADLK. */
-  assert(pthread_join(self, NULL) == EDEADLK);
-
-  /* We should be able to detach the main thread,
-   * but not the proxied main thread (as that one
-   * is already detached).
+  /*
+   * Attempts to join the current thread will either generate
+   * EDEADLK or EINVAL depending on whether has already been
+   * detached
    */
-  int ret = emscripten_is_main_browser_thread() ? 0 : EINVAL;
-  assert(pthread_detach(self) == ret);
+  int ret = pthread_join(self, NULL);
+  if (is_detached) {
+    assert(ret == EINVAL);
+  } else {
+    assert(ret == EDEADLK);
+  }
+
+  /*
+   * Attempts to detach the main thread will either succeed
+   * or cause EINVAL if its already been detached.
+   */
+  ret = pthread_detach(self);
+  printf("pthread_detach(self) -> %s\n", strerror(ret));
+  if (is_detached) {
+    assert(ret == EINVAL);
+  } else {
+    assert(ret == 0);
+  }
 
   puts("passed");
 


### PR DESCRIPTION
pthread_join should check for thread validity and for detached state
before it checks for joining self (i.e. deadlock).

Needed for (split out from) #13006.