### PR TITLE
Remove SYS_dup2 syscall. NFC

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -418,11 +418,6 @@ var SyscallsLibrary = {
     }
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
   },
-  __syscall_dup2: function(oldfd, suggestFD) {
-    var old = SYSCALLS.getStreamFromFD(oldfd);
-    if (old.fd === suggestFD) return suggestFD;
-    return SYSCALLS.doDup(old.path, old.flags, suggestFD);
-  },
   __syscall_symlink: function(target, linkpath) {
     target = SYSCALLS.getStr(target);
     linkpath = SYSCALLS.getStr(linkpath);
@@ -1120,9 +1115,6 @@ var SyscallsLibrary = {
     return 0;
   },
   __syscall_dup3: function(fd, suggestFD, flags) {
-#if SYSCALL_DEBUG
-    err('warning: untested syscall: dup3');
-#endif
     var old = SYSCALLS.getStreamFromFD(fd);
 #if ASSERTIONS
     assert(!flags);

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -422,7 +422,7 @@ uptr internal_dup(int oldfd) {
 }
 
 uptr internal_dup2(int oldfd, int newfd) {
-#if SANITIZER_USES_CANONICAL_LINUX_SYSCALLS
+#if SANITIZER_USES_CANONICAL_LINUX_SYSCALLS || SANITIZER_EMSCRIPTEN
   return internal_syscall(SYSCALL(dup3), oldfd, newfd, 0);
 #else
   return internal_syscall(SYSCALL(dup2), oldfd, newfd);

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -18,7 +18,6 @@
 #define SYS_ioctl		 __syscall_ioctl
 #define SYS_setpgid		 __syscall_setpgid
 #define SYS_umask		 __syscall_umask
-#define SYS_dup2		 __syscall_dup2
 #define SYS_getppid		 __syscall_getppid
 #define SYS_setsid		 __syscall_setsid
 #define SYS_setrlimit		 __syscall_setrlimit

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -31,7 +31,6 @@ long __syscall_acct(long filename);
 long __syscall_ioctl(long fd, long request, ...);
 long __syscall_setpgid(long pid, long gpid);
 long __syscall_umask(long mask);
-long __syscall_dup2(long oldfd, long newfd);
 long __syscall_getppid(void);
 long __syscall_getpgrp(void);
 long __syscall_setsid(void);

--- a/system/lib/libc/musl/src/unistd/dup2.c
+++ b/system/lib/libc/musl/src/unistd/dup2.c
@@ -14,7 +14,7 @@ int dup2(int old, int new)
 #else
 	if (old==new) {
 #ifdef __EMSCRIPTEN__
-		r = __wasi_fd_is_valid(old) ? 0 : -1;
+		r = __wasi_fd_is_valid(old) ? 0 : -EBADF;
 #else
 		r = __syscall(SYS_fcntl, old, F_GETFD);
 #endif

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -23,7 +23,7 @@ extern "C" {
 
 using namespace wasmfs;
 
-long __syscall_dup2(long oldfd, long newfd) {
+long __syscall_dup3(long oldfd, long newfd, long flags) {
   auto fileTable = wasmFS.getLockedFileTable();
 
   auto oldOpenFile = fileTable[oldfd];
@@ -38,7 +38,7 @@ long __syscall_dup2(long oldfd, long newfd) {
   }
 
   if (oldfd == newfd) {
-    return oldfd;
+    return -EINVAL;
   }
 
   // If the file descriptor newfd was previously open, it will just be
@@ -424,6 +424,24 @@ __wasi_errno_t __wasi_fd_seek(__wasi_fd_t fd,
     *newoffset = position;
   }
 
+  return __WASI_ERRNO_SUCCESS;
+}
+
+__wasi_errno_t __wasi_fd_fdstat_get(__wasi_fd_t fd, __wasi_fdstat_t* stat) {
+  // TODO: This is only partial implementation of __wasi_fd_fdstat_get.  Enough
+  // to get __wasi_fd_is_valid working.
+  // There are other fields in the stat structure that we should really
+  // be filling in here.
+  auto openFile = wasmFS.getLockedFileTable()[fd];
+  if (!openFile) {
+    return __WASI_ERRNO_BADF;
+  }
+
+  if (openFile.locked().getFile()->is<Directory>()) {
+    stat->fs_filetype = __WASI_FILETYPE_DIRECTORY;
+  } else {
+    stat->fs_filetype = __WASI_FILETYPE_REGULAR_FILE;
+  }
   return __WASI_ERRNO_SUCCESS;
 }
 }


### PR DESCRIPTION
The musl implemenation of dup2 works fine without this syscall as it can
be implemented in terms of dup3.

As part of this change I was forced to implement __wasi_fd_fdstat_get
for wasmfs since dup2 not depends on this wasi syscall.

Split out from #15411