### PR TITLE
Revert "Add support for specifying response file encoding (#15406)"

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -67,9 +67,6 @@ See docs/process.md for more on how version tagging works.
 - Added SAFE_HEAP=2 option which tests safe heap behavior for wasm-only builds
   (allowing unaligned memory accesses, which would not work in Wasm2JS but in
    wasm would be correct but potentially slow).
-- Added support for specifying the text encoding to be used in response filenames
-  by passing the encoding as a file suffix (e.g. "a.rsp.utf-8" or "a.rsp.cp1252").
-  If not specified, the encoding is autodetected. (#15406, #15292)
 
 2.0.31 - 10/01/2021
 -------------------

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10737,21 +10737,6 @@ exec "$@"
     self.run_process(building.get_command_with_possible_response_file([EMCC, 'main.c'] + files))
     self.assertContained(str(count * (count - 1) // 2), self.run_js('a.out.js'))
 
-  # Tests that the filename suffix of the response files can be used to detect which encoding the file is.
-  def test_response_file_encoding(self):
-    open('äö.c', 'w').write('int main(){}')
-
-    open('a.rsp', 'w', encoding='utf-8').write('äö.c') # Write a response file with unicode contents ...
-    self.run_process([EMCC, '@a.rsp']) # ... and test that in the absence of a file suffix, it is autodetected to utf-8.
-
-    open('a.rsp.cp437', 'w', encoding='cp437').write('äö.c') # Write a response file with Windows CP-437 encoding ...
-    self.run_process([EMCC, '@a.rsp.cp437']) # ... and test that with the explicit suffix present, it is properly decoded
-
-    if WINDOWS:
-      # This test assumes that the default system encoding is CP-1252.
-      open('a.rsp', 'w', encoding='cp1252').write('äö.c') # Write a response file with Windows CP-1252 encoding ...
-      self.run_process([EMCC, '@a.rsp']) # ... and test that it is properly autodetected.
-
   def test_output_name_collision(self):
     # Ensure that the seconday filenames never collide with the primary output filename
     # In this case we explcitly ask for JS to be ceated in a file with the `.wasm` suffix.


### PR DESCRIPTION
This reverts commit d65442e0378d10cd128e8530aea0e09acca44b2e.

This commit broke the windows emscripten-releases builder, and I think
it was auto-commited by mistake anyway.