### PR TITLE
Add scripts for copying changes out into upstream llvm and musl

### DIFF
--- a/system/lib/push_llvm_changes.py
+++ b/system/lib/push_llvm_changes.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+# Copyright 2021 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+# Copy local llvm library changes into the upstream llvm tree.
+# This is the logical inverse of update_compiler_rt.py, update_libcxx.py
+# and update_libcxxabi.py which copy changes form the upstream llvm 
+# into emscripten.
+
+import glob
+import os
+import sys
+import shutil
+
+script_dir = os.path.abspath(os.path.dirname(__file__))
+emscripten_root = os.path.dirname(os.path.dirname(script_dir))
+default_llvm_dir = os.path.join(os.path.dirname(emscripten_root), 'llvm-project')
+copy_dirs = [
+  'compiler-rt',
+  'libcxx',
+  'libcxxabi',
+]
+
+
+def main():
+  if len(sys.argv) > 1:
+    upstream_root = os.path.join(os.path.abspath(sys.argv[1]))
+  else:
+    upstream_root = default_llvm_dir
+  if not os.path.exists(upstream_root):
+    print(f'llvm tree not found: {upstream_root}')
+    return 1
+
+  for dir in copy_dirs:
+    assert os.path.exists(os.path.join(upstream_root, dir))
+
+  for dir in copy_dirs:
+    local_dir = os.path.join(script_dir, dir)
+    upstream_dir = os.path.join(upstream_root, dir)
+    print(f'copying {local_dir} -> {upstream_dir}')
+    shutil.copytree(local_dir, upstream_dir, dirs_exist_ok=True)
+
+
+if __name__ == '__main__':
+  main()

--- a/system/lib/push_musl_changes.py
+++ b/system/lib/push_musl_changes.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+# Copyright 2021 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+# Copy local emscripten changes into the upstream musl tree.
+# This is the logical inverse of update_musl.py which copies changes
+# form the upstream musl tree into emscripten.
+
+import glob
+import os
+import sys
+import shutil
+
+script_dir = os.path.abspath(os.path.dirname(__file__))
+local_dir = os.path.join(script_dir, 'libc', 'musl')
+emscripten_root = os.path.dirname(os.path.dirname(script_dir))
+default_musl_dir = os.path.join(os.path.dirname(emscripten_root), 'musl')
+
+
+def main():
+  if len(sys.argv) > 1:
+    upstream_root = os.path.join(os.path.abspath(sys.argv[1]))
+  else:
+    upstream_root = default_musl_dir
+  if not os.path.exists(upstream_root):
+    print(f'musl tree not found: {upstream_root}')
+    return 1
+
+  print(f'copying {local_dir} -> {upstream_root}')
+  shutil.copytree(local_dir, upstream_root, dirs_exist_ok=True)
+
+
+if __name__ == '__main__':
+  main()

--- a/system/lib/update_compiler_rt.py
+++ b/system/lib/update_compiler_rt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2020 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/system/lib/update_libcxx.py
+++ b/system/lib/update_libcxx.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2019 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be

--- a/system/lib/update_libcxxabi.py
+++ b/system/lib/update_libcxxabi.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # Copyright 2019 The Emscripten Authors.  All rights reserved.
 # Emscripten is available under two separate licenses, the MIT license and the
 # University of Illinois/NCSA Open Source License.  Both these licenses can be


### PR DESCRIPTION
We are now maintaining our llvm and musl patches in external
repositories so that it is easier to update from upstream
and rebase onto new releases.

I already created scripts for copying changes in one direction
(i.e. into emscripten).  This change adds push_llvm_changes.py
and push_musl_changes.py which can be used to push changes
in the other direction.

See #15396 