### PR TITLE
Use musl's weak symbol trick to initialize main thread TSD block. NFC

### DIFF
--- a/system/lib/libc/musl/src/thread/pthread_getspecific.c
+++ b/system/lib/libc/musl/src/thread/pthread_getspecific.c
@@ -4,10 +4,6 @@
 static void *__pthread_getspecific(pthread_key_t k)
 {
 	struct pthread *self = __pthread_self();
-	// XXX EMSCRIPTEN: self->tsd can be NULL in the case of the
-	// main thread where pthread_key_create is not called.
-	// See __pthread_key_create for where it get assigned.
-	if (!self->tsd) return NULL;
 	return self->tsd[k];
 }
 

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -825,10 +825,14 @@ EMSCRIPTEN_KEEPALIVE void* _emscripten_main_thread_futex;
 
 void __emscripten_init_main_thread_js(void* tb);
 
+static void *dummy_tsd[1] = { 0 };
+weak_alias(dummy_tsd, __pthread_tsd_main);
+
 // See system/lib/README.md for static constructor ordering.
 __attribute__((constructor(48)))
 void __emscripten_init_main_thread(void) {
   __emscripten_init_main_thread_js(&__main_pthread);
+
   // The pthread struct has a field that points to itself - this is used as
   // a magic ID to detect whether the pthread_t structure is 'alive'.
   __main_pthread.self = &__main_pthread;
@@ -838,4 +842,5 @@ void __emscripten_init_main_thread(void) {
   // tid is always non-zero.
   __main_pthread.tid = getpid();
   __main_pthread.locale = &libc.global_locale;
+  __main_pthread.tsd = (void **)__pthread_tsd_main;
 }


### PR DESCRIPTION
TSD == Thread specific data.

Basically, if there are any calls to to `pthread_key_create` we get a
full sized `__pthread_tsd_main` otherwise we get dummy one.

Split out from #13006.