### PR TITLE
[WASMFS] Fix mode on file and dir creation

### DIFF
--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -29,7 +29,7 @@ static __wasi_errno_t writeStdBuffer(const uint8_t* buf,
 
 std::shared_ptr<StdinFile> StdinFile::getSingleton() {
   static const std::shared_ptr<StdinFile> stdinFile =
-    std::make_shared<StdinFile>(S_IALLUGO | S_IFREG);
+    std::make_shared<StdinFile>(S_IALLUGO);
   return stdinFile;
 }
 
@@ -39,7 +39,7 @@ __wasi_errno_t StdoutFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
   static const std::shared_ptr<StdoutFile> stdoutFile =
-    std::make_shared<StdoutFile>(S_IALLUGO | S_IFREG);
+    std::make_shared<StdoutFile>(S_IALLUGO);
   return stdoutFile;
 }
 
@@ -49,7 +49,7 @@ __wasi_errno_t StderrFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 std::shared_ptr<StderrFile> StderrFile::getSingleton() {
   static const std::shared_ptr<StderrFile> stderrFile =
-    std::make_shared<StderrFile>(S_IALLUGO | S_IFREG);
+    std::make_shared<StderrFile>(S_IALLUGO);
   return stderrFile;
 }
 

--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -29,7 +29,7 @@ static __wasi_errno_t writeStdBuffer(const uint8_t* buf,
 
 std::shared_ptr<StdinFile> StdinFile::getSingleton() {
   static const std::shared_ptr<StdinFile> stdinFile =
-    std::make_shared<StdinFile>(S_IRUGO);
+    std::make_shared<StdinFile>(S_IALLUGO | S_IFREG);
   return stdinFile;
 }
 
@@ -39,7 +39,7 @@ __wasi_errno_t StdoutFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
   static const std::shared_ptr<StdoutFile> stdoutFile =
-    std::make_shared<StdoutFile>(S_IWUGO);
+    std::make_shared<StdoutFile>(S_IALLUGO | S_IFREG);
   return stdoutFile;
 }
 
@@ -49,7 +49,7 @@ __wasi_errno_t StderrFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 std::shared_ptr<StderrFile> StderrFile::getSingleton() {
   static const std::shared_ptr<StderrFile> stderrFile =
-    std::make_shared<StderrFile>(S_IWUGO);
+    std::make_shared<StderrFile>(S_IALLUGO | S_IFREG);
   return stderrFile;
 }
 

--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -31,7 +31,7 @@ std::shared_ptr<StdinFile> StdinFile::getSingleton() {
   // Give all permissions to user, group and other in stdin, stdout and stderr.
   // This is a placeholder for now which matches the JS filesystem.
   static const std::shared_ptr<StdinFile> stdinFile =
-    std::make_shared<StdinFile>(S_IALLUGO);
+    std::make_shared<StdinFile>(S_IRUGO);
   return stdinFile;
 }
 
@@ -41,7 +41,7 @@ __wasi_errno_t StdoutFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
   static const std::shared_ptr<StdoutFile> stdoutFile =
-    std::make_shared<StdoutFile>(S_IALLUGO);
+    std::make_shared<StdoutFile>(S_IWUGO);
   return stdoutFile;
 }
 
@@ -51,7 +51,7 @@ __wasi_errno_t StderrFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 std::shared_ptr<StderrFile> StderrFile::getSingleton() {
   static const std::shared_ptr<StderrFile> stderrFile =
-    std::make_shared<StderrFile>(S_IALLUGO);
+    std::make_shared<StderrFile>(S_IWUGO);
   return stderrFile;
 }
 

--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -28,6 +28,8 @@ static __wasi_errno_t writeStdBuffer(const uint8_t* buf,
 }
 
 std::shared_ptr<StdinFile> StdinFile::getSingleton() {
+  // Give all permissions to user, group and other in stdin, stdout and stderr.
+  // This is a placeholder for now which matches the JS filesystem.
   static const std::shared_ptr<StdinFile> stdinFile =
     std::make_shared<StdinFile>(S_IALLUGO);
   return stdinFile;

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -335,9 +335,12 @@ __wasi_fd_t __syscall_open(long pathname, long flags, long mode) {
     // If O_DIRECTORY is also specified, still create a regular file:
     // https://man7.org/linux/man-pages/man2/open.2.html#BUGS
     if (flags & O_CREAT) {
+      // Give all permissions to user, group and other.
+      // This is a placeholder for now which matches the JS filesystem.
       mode &= S_IALLUGO;
+
       // Create an empty in-memory file.
-      auto created = std::make_shared<MemoryFile>(mode);
+      auto created = std::make_shared<MemoryFile>(S_IALLUGO);
 
       // TODO: When rename is implemented make sure that one can atomically
       // remove the file from the source directory and then set its parent to
@@ -395,6 +398,10 @@ long __syscall_mkdir(long path, long mode) {
   if (curr) {
     return -EEXIST;
   } else {
+    // Give rwx permissions to user, group and other.
+    // Sticky bit is also set:
+    // https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
+    // This is a placeholder for now which matches the JS filesystem.
     mode &= S_IRWXUGO | S_ISVTX;
     // Create an empty in-memory directory.
     auto created = std::make_shared<Directory>(mode);

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -329,6 +329,8 @@ __wasi_fd_t __syscall_open(long pathname, long flags, long mode) {
     // If O_DIRECTORY is also specified, still create a regular file:
     // https://man7.org/linux/man-pages/man2/open.2.html#BUGS
     if (flags & O_CREAT) {
+      mode &= S_IALLUGO;
+      mode |= S_IFREG;
       // Create an empty in-memory file.
       auto created = std::make_shared<MemoryFile>(mode);
 
@@ -388,6 +390,8 @@ long __syscall_mkdir(long path, long mode) {
   if (curr) {
     return -EEXIST;
   } else {
+    mode &= S_IRWXUGO | S_ISVTX;
+    mode |= S_IFDIR;
     // Create an empty in-memory directory.
     auto created = std::make_shared<Directory>(mode);
 

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -27,8 +27,10 @@ __attribute__((init_priority(100))) WasmFS wasmFS;
 # 28 "wasmfs.cpp"
 
 std::shared_ptr<Directory> WasmFS::initRootDirectory() {
-  auto rootDirectory = std::make_shared<Directory>(S_IRUGO | S_IXUGO);
-  auto devDirectory = std::make_shared<Directory>(S_IRUGO | S_IXUGO);
+  auto rootDirectory =
+    std::make_shared<Directory>(S_IRWXUGO | S_ISVTX | S_IFDIR);
+  auto devDirectory =
+    std::make_shared<Directory>(S_IRWXUGO | S_ISVTX | S_IFDIR);
   rootDirectory->locked().setEntry("dev", devDirectory);
 
   auto dir = devDirectory->locked();

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -27,6 +27,10 @@ __attribute__((init_priority(100))) WasmFS wasmFS;
 # 28 "wasmfs.cpp"
 
 std::shared_ptr<Directory> WasmFS::initRootDirectory() {
+  // Give rwx permissions to user, group and other.
+  // Sticky bit is also set:
+  // https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
+  // This is a placeholder for now which matches the JS filesystem.
   auto rootDirectory = std::make_shared<Directory>(S_IRWXUGO | S_ISVTX);
   auto devDirectory = std::make_shared<Directory>(S_IRWXUGO | S_ISVTX);
   rootDirectory->locked().setEntry("dev", devDirectory);

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -31,8 +31,8 @@ std::shared_ptr<Directory> WasmFS::initRootDirectory() {
   // Sticky bit is also set:
   // https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
   // This is a placeholder for now which matches the JS filesystem.
-  auto rootDirectory = std::make_shared<Directory>(S_IRWXUGO | S_ISVTX);
-  auto devDirectory = std::make_shared<Directory>(S_IRWXUGO | S_ISVTX);
+  auto rootDirectory = std::make_shared<Directory>(S_IRUGO | S_IXUGO);
+  auto devDirectory = std::make_shared<Directory>(S_IRUGO | S_IXUGO);
   rootDirectory->locked().setEntry("dev", devDirectory);
 
   auto dir = devDirectory->locked();

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -27,10 +27,8 @@ __attribute__((init_priority(100))) WasmFS wasmFS;
 # 28 "wasmfs.cpp"
 
 std::shared_ptr<Directory> WasmFS::initRootDirectory() {
-  auto rootDirectory =
-    std::make_shared<Directory>(S_IRWXUGO | S_ISVTX | S_IFDIR);
-  auto devDirectory =
-    std::make_shared<Directory>(S_IRWXUGO | S_ISVTX | S_IFDIR);
+  auto rootDirectory = std::make_shared<Directory>(S_IRWXUGO | S_ISVTX);
+  auto devDirectory = std::make_shared<Directory>(S_IRWXUGO | S_ISVTX);
   rootDirectory->locked().setEntry("dev", devDirectory);
 
   auto dir = devDirectory->locked();

--- a/tests/wasmfs/wasmfs_create.c
+++ b/tests/wasmfs/wasmfs_create.c
@@ -18,13 +18,15 @@
 int main() {
   // Test creating a new file and writing and reading from it.
   errno = 0;
-  int fd = open("/test", O_RDWR | O_CREAT);
+  int fd = open("/test", O_RDWR | O_CREAT, 0777);
 
   // Check that the file type is correct on mode.
   struct stat file;
   fstat(fd, &file);
 
   assert((file.st_mode & S_IFMT) == S_IFREG);
+  printf("mode %i\n", file.st_mode);
+  assert(file.st_mode == (S_IRWXUGO | S_IFREG));
 
   assert(errno == 0);
   const char* msg = "Test\n";

--- a/tests/wasmfs/wasmfs_create.c
+++ b/tests/wasmfs/wasmfs_create.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 // FIXME: Merge with other existing close and open tests.
@@ -18,6 +19,13 @@ int main() {
   // Test creating a new file and writing and reading from it.
   errno = 0;
   int fd = open("/test", O_RDWR | O_CREAT);
+
+  // Check that the file type is correct on mode.
+  struct stat file;
+  fstat(fd, &file);
+
+  assert((file.st_mode & S_IFMT) == S_IFREG);
+
   assert(errno == 0);
   const char* msg = "Test\n";
   errno = 0;

--- a/tests/wasmfs/wasmfs_create.c
+++ b/tests/wasmfs/wasmfs_create.c
@@ -25,8 +25,6 @@ int main() {
   fstat(fd, &file);
 
   assert((file.st_mode & S_IFMT) == S_IFREG);
-  file.st_mode &= S_IFMT;
-  assert((file.st_mode & S_IALLUGO) == 0);
 
   assert(errno == 0);
   const char* msg = "Test\n";

--- a/tests/wasmfs/wasmfs_create.c
+++ b/tests/wasmfs/wasmfs_create.c
@@ -25,6 +25,8 @@ int main() {
   fstat(fd, &file);
 
   assert((file.st_mode & S_IFMT) == S_IFREG);
+  file.st_mode &= S_IFMT;
+  assert((file.st_mode & S_IALLUGO) == 0);
 
   assert(errno == 0);
   const char* msg = "Test\n";

--- a/tests/wasmfs/wasmfs_mkdir.c
+++ b/tests/wasmfs/wasmfs_mkdir.c
@@ -30,6 +30,9 @@ int main() {
   fstat(fdStat, &directory);
 
   assert((directory.st_mode & S_IFMT) == S_IFDIR);
+  assert((directory.st_mode & S_ISVTX) == 0);
+  directory.st_mode &= S_ISVTX;
+  assert((directory.st_mode & S_IRWXUGO) == 0);
 
   close(fdStat);
 

--- a/tests/wasmfs/wasmfs_mkdir.c
+++ b/tests/wasmfs/wasmfs_mkdir.c
@@ -30,10 +30,6 @@ int main() {
   fstat(fdStat, &directory);
 
   assert((directory.st_mode & S_IFMT) == S_IFDIR);
-  assert((directory.st_mode & S_ISVTX) == 0);
-  directory.st_mode &= S_ISVTX;
-  assert((directory.st_mode & S_IRWXUGO) == 0);
-
   close(fdStat);
 
   // Try to create a file in the same directory.

--- a/tests/wasmfs/wasmfs_mkdir.c
+++ b/tests/wasmfs/wasmfs_mkdir.c
@@ -24,6 +24,15 @@ int main() {
   printf("Errno: %s\n", strerror(errno));
   assert(errno == 0);
 
+  // Check that the file type is correct on mode.
+  int fdStat = open("/working", O_RDONLY | O_DIRECTORY);
+  struct stat directory;
+  fstat(fdStat, &directory);
+
+  assert((directory.st_mode & S_IFMT) == S_IFDIR);
+
+  close(fdStat);
+
   // Try to create a file in the same directory.
   int fd = open("/working/test", O_RDWR | O_CREAT, 0777);
   printf("Errno: %s\n", strerror(errno));

--- a/tests/wasmfs/wasmfs_mkdir.c
+++ b/tests/wasmfs/wasmfs_mkdir.c
@@ -21,16 +21,24 @@ int main() {
   // Try to make a directory under the root directory.
   errno = 0;
   mkdir("/working", 0777);
+  mkdir("/foobar", 01777);
   printf("Errno: %s\n", strerror(errno));
   assert(errno == 0);
 
-  // Check that the file type is correct on mode.
+  // Check that the file type is correct on mode (0777 = S_IRWXUGO)
   int fdStat = open("/working", O_RDONLY | O_DIRECTORY);
   struct stat directory;
   fstat(fdStat, &directory);
-
   assert((directory.st_mode & S_IFMT) == S_IFDIR);
+  assert(directory.st_mode == (S_IRWXUGO | S_IFDIR));
   close(fdStat);
+
+  // Check that the file type is correct on mode (01777 = S_ISVTX | S_IRWXUGO)
+  int fdStat2 = open("/foobar", O_RDONLY | O_DIRECTORY);
+  struct stat directory2;
+  fstat(fdStat2, &directory2);
+  assert(directory2.st_mode == (S_IRWXUGO | S_ISVTX | S_IFDIR));
+  close(fdStat2);
 
   // Try to create a file in the same directory.
   int fd = open("/working/test", O_RDWR | O_CREAT, 0777);

--- a/tests/wasmfs/wasmfs_open.c
+++ b/tests/wasmfs/wasmfs_open.c
@@ -10,6 +10,7 @@
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 // FIXME: Merge with other existing close and open tests.
@@ -28,6 +29,12 @@ int main() {
 
   dprintf(fd2, "WORKING WITHOUT TRAILING BACKSLASH\n");
 
+  // Check that the file type is correct on mode.
+  struct stat file;
+  fstat(fd2, &file);
+
+  assert((file.st_mode & S_IFMT) == S_IFREG);
+
   // Close open file
   close(fd2);
 
@@ -38,7 +45,13 @@ int main() {
   printf("Errno: %s\n", strerror(errno));
 
   // Attempt to open and then read/write to a directory.
-  int fd3 = open("/dev", O_RDONLY);
+  int fd3 = open("/dev", O_RDONLY | O_DIRECTORY);
+
+  // Check that the file type is correct on mode.
+  struct stat dir;
+  fstat(fd3, &dir);
+
+  assert((dir.st_mode & S_IFMT) == S_IFDIR);
 
   const char* msg = "Test\n";
 

--- a/tests/wasmfs/wasmfs_open.c
+++ b/tests/wasmfs/wasmfs_open.c
@@ -34,6 +34,8 @@ int main() {
   fstat(fd2, &file);
 
   assert((file.st_mode & S_IFMT) == S_IFREG);
+  file.st_mode &= S_IFMT;
+  assert((file.st_mode & S_IALLUGO) == 0);
 
   // Close open file
   close(fd2);
@@ -52,6 +54,10 @@ int main() {
   fstat(fd3, &dir);
 
   assert((dir.st_mode & S_IFMT) == S_IFDIR);
+  dir.st_mode &= S_IFMT;
+  assert((dir.st_mode & S_ISVTX) == 0);
+  dir.st_mode &= S_ISVTX;
+  assert((dir.st_mode & S_IRWXUGO) == 0);
 
   const char* msg = "Test\n";
 

--- a/tests/wasmfs/wasmfs_open.c
+++ b/tests/wasmfs/wasmfs_open.c
@@ -34,8 +34,6 @@ int main() {
   fstat(fd2, &file);
 
   assert((file.st_mode & S_IFMT) == S_IFREG);
-  file.st_mode &= S_IFMT;
-  assert((file.st_mode & S_IALLUGO) == 0);
 
   // Close open file
   close(fd2);
@@ -54,10 +52,6 @@ int main() {
   fstat(fd3, &dir);
 
   assert((dir.st_mode & S_IFMT) == S_IFDIR);
-  dir.st_mode &= S_IFMT;
-  assert((dir.st_mode & S_ISVTX) == 0);
-  dir.st_mode &= S_ISVTX;
-  assert((dir.st_mode & S_IRWXUGO) == 0);
 
   const char* msg = "Test\n";
 

--- a/tests/wasmfs/wasmfs_open.c
+++ b/tests/wasmfs/wasmfs_open.c
@@ -34,6 +34,7 @@ int main() {
   fstat(fd2, &file);
 
   assert((file.st_mode & S_IFMT) == S_IFREG);
+  assert(file.st_mode == (S_IWUGO | S_IFREG));
 
   // Close open file
   close(fd2);
@@ -52,6 +53,7 @@ int main() {
   fstat(fd3, &dir);
 
   assert((dir.st_mode & S_IFMT) == S_IFDIR);
+  assert(dir.st_mode == (S_IRUGO | S_IXUGO | S_IFDIR));
 
   const char* msg = "Test\n";
 


### PR DESCRIPTION
Relevant Issue: #15041 

- Add relevant `S_IFREG`, `S_IFDIR`, etc. bits onto file mode.
- Update relevant tests to verify after file and directory creation.