### PR TITLE
Clarify pthread attr usage in JS. NFC

### DIFF
--- a/src/struct_info_internal.json
+++ b/src/struct_info_internal.json
@@ -15,6 +15,9 @@
               "result",
               "attr"
             ],
+            "pthread_attr_t#": [
+              "_a_transferredcanvases"
+            ],
             "thread_profiler_block": [
                 "threadStatus",
                 "currentStatusStartTime",

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -1334,6 +1334,10 @@
             "stack_size": 76,
             "threadStatus": 0
         },
+        "pthread_attr_t": {
+            "__size__": 44,
+            "_a_transferredcanvases": 40
+        },
         "sockaddr": {
             "__size__": 16,
             "sa_data": 2,

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -173,7 +173,7 @@ def parse_c_output(lines):
 
 def gen_inspect_code(path, struct, code):
   if path[0][-1] == '#':
-    path[0] = path[0][:-1]
+    path[0] = path[0].rstrip('#')
     prefix = ''
   else:
     prefix = 'struct '


### PR DESCRIPTION
In the case of _a_transferredcanvases we can use the actual
member name.  For the other cases we use comments.

Split out from #13006.