### PR TITLE
Fix glGetInternalformativ() to return correct return value on arrays > 1 elements in size.

### DIFF
--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -78,7 +78,7 @@ var LibraryWebGL2 = {
     var ret = GLctx['getInternalformatParameter'](target, internalformat, pname);
     if (ret === null) return;
     for (var i = 0; i < ret.length && i < bufSize; ++i) {
-      {{{ makeSetValue('params', 'i', 'ret[i]', 'i32') }}};
+      {{{ makeSetValue('params', 'i*4', 'ret[i]', 'i32') }}};
     }
   },
 


### PR DESCRIPTION
Looking at git blame, this function has been broken all the way since 2015 when I first added it. A test would be good, but I don't unfortunately have time to work one now.