### PR TITLE
Fix warning in test code. NFC

### DIFF
--- a/tests/core/test_sscanf.c
+++ b/tests/core/test_sscanf.c
@@ -74,7 +74,7 @@ int main() {
   memset(buf4, 0, 100);
 
 
-  int numItems = sscanf("level=4:ref=3", "%255[^:=]=%255[^:]:%255[^=]=%c",
+  int numItems = sscanf("level=4:ref=3", "%99[^:=]=%99[^:]:%99[^=]=%c",
                         buf1, buf2, buf3, buf4);
   printf("%d, %s, %s, %s, %s\n", numItems, buf1, buf2, buf3, buf4);
 


### PR DESCRIPTION
This is current blocking the llvm roller which started reporting:

```
test_sscanf.c:78:25: error: 'sscanf' may overflow; destination buffer in argument 3 has size 100, but the corresponding specifier may require size 256 [-Werror,-Wfortify-source]
```