### PR TITLE
Fix test_proxy_to_pthread_stack test

### DIFF
--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -28,7 +28,7 @@ function checkStackCookie() {
   var cookie1 = {{{ makeGetValue('max + 4', '0', 'i32', 0, true) }}};
   var cookie2 = {{{ makeGetValue('max + 8', '0', 'i32', 0, true) }}};
   if (cookie1 != 0x2135467 || cookie2 != 0x89BACDFE) {
-    abort('Stack overflow! Stack cookie has been overwritten, expected hex dwords 0x89BACDFE and 0x2135467, but received 0x' + cookie2.toString(16) + ' ' + cookie1.toString(16));
+    abort('Stack overflow! Stack cookie has been overwritten, expected hex dwords 0x89BACDFE and 0x2135467, but received 0x' + cookie2.toString(16) + ' 0x' + cookie1.toString(16));
   }
 #if !USE_ASAN && !SAFE_HEAP // ASan and SAFE_HEAP check address 0 themselves
   // Also test the global address 0 for integrity.

--- a/system/lib/README.md
+++ b/system/lib/README.md
@@ -16,6 +16,7 @@ document.
 These current set of static constructors in system libraries and their priorities
 (lowest run first) are:
 
+- 1: `emscripten_stack_init` (stack_limits.S)
 - 47: `initialize_emmalloc_heap` (emmalloc.c)
 - 48: `__emscripten_init_main_thread` (pthread/library_pthread.c)
 - 50: asan init (??)

--- a/tests/other/test_proxy_to_pthread_stack.c
+++ b/tests/other/test_proxy_to_pthread_stack.c
@@ -3,7 +3,9 @@
 #include <assert.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <string.h>
 #include <pthread.h>
+#include <emscripten.h>
 
 int main(void) {
   pthread_attr_t attr;
@@ -12,13 +14,17 @@ int main(void) {
   pthread_attr_getstacksize(&attr, &stacksize);
   printf("stack size %zd\n", stacksize);
 
-  // Run with TOTAL_STACK=128k.
+  // This test is run with TOTAL_STACK=128k so we always expect that to be
+  // the ammount of stack we have in main()
   assert(stacksize == 128*1024);
 
-  // Run with DEFAULT_PTHREAD_STACK_SIZE=64k.
-  // This would fail if we were actually running with only the default pthread stack size.
-  int32_t data[64*1024];
+  // This test is run with DEFAULT_PTHREAD_STACK_SIZE=64k.  This would fail if
+  // this thread were run with only 64k of stack.
+  int8_t data[65*1024];
+  memset(data, 0xa0, sizeof(data));
+  EM_ASM(checkStackCookie());
   printf("data address %p\n", data);
+
   printf("success\n");
-  exit(0);
+  return 0;
 }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9335,7 +9335,10 @@ int main(void) {
     # DEFAULT_PTHREAD_STACK_SIZE.
     self.do_smart_test(test_file('other/test_proxy_to_pthread_stack.c'),
                        ['success'],
-                       emcc_args=['-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '-s', 'DEFAULT_PTHREAD_STACK_SIZE=64kb', '-s', 'TOTAL_STACK=128kb', '-s', 'EXIT_RUNTIME'])
+                       emcc_args=['-sUSE_PTHREADS', '-sPROXY_TO_PTHREAD',
+                                  '-sDEFAULT_PTHREAD_STACK_SIZE=64kb',
+                                  '-sTOTAL_STACK=128kb', '-sEXIT_RUNTIME',
+                                  '--profiling-funcs'])
 
   @parameterized({
     'async': ['-s', 'WASM_ASYNC_COMPILATION'],


### PR DESCRIPTION
The type of the local used in this test was 4-bytes wide rather
than 1-byte wide.

Also, actually write to allocated region. 

Also, embed the stack check directly in the code otherwise the
stack corruption can causes the program to fail to return correctly.