### PR TITLE
[Minor] Add wasmfs constructor to readme

### DIFF
--- a/system/lib/README.md
+++ b/system/lib/README.md
@@ -19,6 +19,7 @@ These current set of static constructors in system libraries and their prioritie
 - 47: `initialize_emmalloc_heap` (emmalloc.c)
 - 48: `__emscripten_init_main_thread` (pthread/library_pthread.c)
 - 50: asan init (??)
+- 100: `WasmFS wasmFS` (wasmfs/wasmfs.cpp)
 
 Priorities 0 - 100 are reserved for system libraries and user-level
 constructors should all run at 101 and above (for example libc++ initializes


### PR DESCRIPTION
Relevant Issue: #15041 
- Updated list of static constructors in `system/lib/README.md`.