### PR TITLE
Rethrow caught exception in FS syscalls

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1180,7 +1180,7 @@ function wrapSyscallFunction(x, library, isWasi) {
     pre += 'try {\n';
     handler +=
     "} catch (e) {\n" +
-    "  if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) abort(e);\n";
+    "  if (typeof FS === 'undefined' || !(e instanceof FS.ErrnoError)) throw e;\n";
 #if SYSCALL_DEBUG
     handler +=
     "  err('error: syscall failed with ' + e.errno + ' (' + ERRNO_MESSAGES[e.errno] + ')');\n" +


### PR DESCRIPTION
In the case that we get an unexpected (non-FS) exceptions during one of
these syscalls we want to rethrow it, preserving all the information
about the original exception.

Calling `abort()` generates a new exception obscuring the original one.

See https://github.com/emscripten-core/emscripten/issues/15470
for an example of an unhelpful stack track of this kind:

```
RuntimeError: Aborted(RuntimeError: Aborted(Assertion failed: undefined))
    at abort (C:\b\s\w\ir\tmp\t\tmp3j_wc7cp\emscripten_test_other_86z_eylk\a.out.js:1515:11)
    at ___syscall_readlink (C:\b\s\w\ir\tmp\t\tmp3j_wc7cp\emscripten_test_other_86z_eylk\a.out.js:4471:69)
    at <anonymous>:wasm-function[41]:0xf7a
    at <anonymous>:wasm-function[12]:0x774
    at main (<anonymous>:wasm-function[10]:0x3d7)
```

The actual error `(Assertion failed: undefined)` happens somewhere deep
in the syscall but the `abort()` call causes the backtrace to show only
the location of the catch which is not helpful.