### PR TITLE
Fix for windows node returning 'UNKNOWN' errors during readlink

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -36,7 +36,7 @@ mergeInto(LibraryManager.library, {
     convertNodeCode: function(e) {
       var code = e.code;
 #if ASSERTIONS
-      assert(code in ERRNO_CODES);
+      assert(code in ERRNO_CODES, 'unexpected node error code: ' + code + ' (' + e + ')');
 #endif
       return ERRNO_CODES[code];
     },
@@ -231,6 +231,9 @@ mergeInto(LibraryManager.library, {
           return path;
         } catch (e) {
           if (!e.code) throw e;
+          // node under windows can return code 'UNKNOWN' here:
+          // https://github.com/emscripten-core/emscripten/issues/15468
+          if (e.code === 'UNKNOWN') throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
           throw new FS.ErrnoError(NODEFS.convertNodeCode(e));
         }
       },

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6239,7 +6239,6 @@ int main(int argc, char **argv) {
     self.run_process([EMCC, 'src.c', '-s', 'SAFE_HEAP', '--embed-file', 'boot'])
     self.assertContained('Resolved: /boot/README.txt', self.run_js('a.out.js'))
 
-  @no_windows('https://github.com/emscripten-core/emscripten/issues/15468')
   def test_realpath_nodefs(self):
     create_file('src.c', r'''
 #include <stdlib.h>


### PR DESCRIPTION
Also re-enable the test that was failing under windows.
    
Fix: #15468