### PR TITLE
fix: #15163 add emcmake support to recognize -GNinja like arguments

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -42,7 +42,7 @@ variables so that emcc etc. are used. Typical usage:
   # toolchain was specified, to keep CMake from pulling in a native Visual
   # Studio, or Unix Makefiles.
   # Reduce cases of the concatented args e.g. "-GNinja" or "-GMingW Makefiles" by splitting them, fallback to default if none toolchain was specified.
-  args = [replaced for item in args for replaced in ([item[0:2], item[2:]] if item[0:2] == "-G" else [item])]
+  args = [replaced for item in args for replaced in ([item[0:2], item[2:]] if (item[0:2] == "-G" and len(item) != 2) else [item])]
   if utils.WINDOWS and '-G' not in args:
     if utils.which('mingw32-make'):
       args += ['-G', 'MinGW Makefiles']

--- a/emcmake.py
+++ b/emcmake.py
@@ -41,6 +41,8 @@ variables so that emcc etc. are used. Typical usage:
   # On Windows specify MinGW Makefiles or ninja if we have them and no other
   # toolchain was specified, to keep CMake from pulling in a native Visual
   # Studio, or Unix Makefiles.
+  # Reduce cases of the concatented args e.g. "-GNinja" or "-GMingW Makefiles" by splitting them, fallback to default if none toolchain was specified.
+  args = [replaced for item in args for replaced in ([item[0:2], item[2:]] if item[0:2] == "-G" else [item])]
   if utils.WINDOWS and '-G' not in args:
     if utils.which('mingw32-make'):
       args += ['-G', 'MinGW Makefiles']


### PR DESCRIPTION
[File Modified] emscripten/emcmake.py
[Details] reduce possible cases by splitting argument beginning with "-G" in the [args] list, if there's no toolchain specified, it will still fallback to default cases. Tested the function over testcase:
```
Cases: tested '-G' to be ignored, tested short argument 'x' to be ignored, tested arbitrary specified toolchain '-GToolchain' to be split.
 
Input: args = ['-C', '-GToolchain', '-G', 'x', '--argument']

Output: args = ['-C', '-G', 'Toolchain', '-G', 'x', '--argument']

```