### PR TITLE
Always emit a name section in unoptimized builds

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -25,6 +25,10 @@ See docs/process.md for more on how version tagging works.
   in upstream musl code but we don't expect anything major.  Since this is a
   fairly substantial change (at least internally) we are bumping the major
   version of Emscripten to 3. (#13006)
+- Unoptimzed (`-O0`) builds now include the WebAssembly name section by default.
+  This means that binaries will be larger but it means backtraces from engines
+  should include names for all functions.  This is the equivalent of enabling
+  `--profiling-funcs` by default in unoptimized builds.
 
 2.0.34 - 11/04/2021
 -------------------

--- a/emcc.py
+++ b/emcc.py
@@ -236,7 +236,6 @@ class EmccOptions:
     self.compiler_wrapper = None
     self.oformat = None
     self.requested_debug = ''
-    self.profiling_funcs = False
     self.emit_symbol_map = False
     self.use_closure_compiler = None
     self.closure_args = []
@@ -2372,8 +2371,9 @@ def phase_linker_setup(options, state, newargs, settings_map):
     settings.CAN_ADDRESS_2GB = 1
 
   settings.EMSCRIPTEN_VERSION = shared.EMSCRIPTEN_VERSION
-  settings.PROFILING_FUNCS = options.profiling_funcs
   settings.SOURCE_MAP_BASE = options.source_map_base or ''
+  if not settings.OPT_LEVEL:
+    settings.EMIT_NAME_SECTION = 1
 
   settings.LINK_AS_CXX = (run_via_emxx or settings.DEFAULT_TO_CXX) and '-nostdlib++' not in newargs
 
@@ -2959,7 +2959,7 @@ def parse_args(newargs):
     elif check_flag('-profiling') or check_flag('--profiling'):
       settings.DEBUG_LEVEL = max(settings.DEBUG_LEVEL, 2)
     elif check_flag('-profiling-funcs') or check_flag('--profiling-funcs'):
-      options.profiling_funcs = True
+      settings.EMIT_NAME_SECTION = 1
     elif newargs[i] == '--tracing' or newargs[i] == '--memoryprofiler':
       if newargs[i] == '--memoryprofiler':
         options.memory_profiler = True
@@ -3141,7 +3141,7 @@ def phase_binaryen(target, options, wasm_target):
   if settings.GENERATE_SOURCE_MAP and not settings.SOURCE_MAP_BASE:
     logger.warning("Wasm source map won't be usable in a browser without --source-map-base")
   # whether we need to emit -g (function name debug info) in the final wasm
-  debug_info = settings.DEBUG_LEVEL >= 2 or options.profiling_funcs
+  debug_info = settings.DEBUG_LEVEL >= 2 or settings.EMIT_NAME_SECTION
   # whether we need to emit -g in the intermediate binaryen invocations (but not
   # necessarily at the very end). this is necessary if we depend on debug info
   # during compilation, even if we do not emit it at the end.

--- a/emscripten.py
+++ b/emscripten.py
@@ -398,7 +398,7 @@ def finalize_wasm(infile, outfile, memfile, DEBUG):
     building.save_intermediate(infile + '.map', 'base_wasm.map')
     args += ['--output-source-map-url=' + settings.SOURCE_MAP_BASE + os.path.basename(outfile) + '.map']
     modify_wasm = True
-  if settings.DEBUG_LEVEL >= 2 or settings.ASYNCIFY_ADD or settings.ASYNCIFY_ADVISE or settings.ASYNCIFY_ONLY or settings.ASYNCIFY_REMOVE or settings.EMIT_SYMBOL_MAP or settings.PROFILING_FUNCS:
+  if settings.DEBUG_LEVEL >= 2 or settings.ASYNCIFY_ADD or settings.ASYNCIFY_ADVISE or settings.ASYNCIFY_ONLY or settings.ASYNCIFY_REMOVE or settings.EMIT_SYMBOL_MAP or settings.EMIT_NAME_SECTION:
     args.append('-g')
   if settings.WASM_BIGINT:
     args.append('--bigint')

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -101,20 +101,19 @@ var EMSCRIPTEN_VERSION = '';
 // Will be set to 0 if -fno-rtti is used on the command line.
 var USE_RTTI = 1;
 
-// This will contain the optimization level (-Ox). You should not modify this.
+// This will contain the optimization level (-Ox).
 var OPT_LEVEL = 0;
 
-// This will contain the debug level (-gx). You should not modify this.
+// This will contain the debug level (-gx).
 var DEBUG_LEVEL = 0;
 
 // This will contain the shrink level (1 or 2 for -Os or -Oz, or just 0).
-// You should not modify this.
 var SHRINK_LEVEL = 0;
 
-// Whether we are profiling functions. You should not modify this.
-var PROFILING_FUNCS = 0;
+// Whether or not to emit the name section in the final wasm binaryen.
+var EMIT_NAME_SECTION = 0;
 
-// Whether we are emitting a symbol map. You should not modify this.
+// Whether we are emitting a symbol map.
 var EMIT_SYMBOL_MAP = 0;
 
 // List of function explicitly exported by user on the command line.

--- a/tools/building.py
+++ b/tools/building.py
@@ -297,7 +297,7 @@ def lld_flags_for_executable(external_symbols):
   # section and DWARF, so we can only use it when we don't need any of
   # those things.
   if settings.DEBUG_LEVEL < 2 and (not settings.EMIT_SYMBOL_MAP and
-                                   not settings.PROFILING_FUNCS and
+                                   not settings.EMIT_NAME_SECTION and
                                    not settings.ASYNCIFY):
     cmd.append('--strip-debug')
 


### PR DESCRIPTION
Also rename the internal `PROFILING_FUNCS` settings to
`EMIT_NAME_SECTION` which is what it effectively is today.  The command
line options `--profiling-funcs` remains unchanged so as not to break
compat.

Fixes: #15470