### PR TITLE
Fix return bug of glGetInternalformativ

### DIFF
--- a/src/library_webgl2.js
+++ b/src/library_webgl2.js
@@ -78,7 +78,7 @@ var LibraryWebGL2 = {
     var ret = GLctx['getInternalformatParameter'](target, internalformat, pname);
     if (ret === null) return;
     for (var i = 0; i < ret.length && i < bufSize; ++i) {
-      {{{ makeSetValue('params', 'i', 'ret[i]', 'i32') }}};
+      {{{ makeSetValue('params', 'i*4', 'ret[i]', 'i32') }}};
     }
   },
 


### PR DESCRIPTION
C++ Code
```
#include <webgl/webgl2.h>
...

int32_t values[8] = {};
emscripten_glGetInternalformativ(GL_RENDERBUFFER, GL_RGBA8, GL_SAMPLES, 8, values);
for (int value : values) {
    printf("%d\n", value);
}
```

The result of `emscripten_glGetInternalformativ` in C++ is different from the JavaScript result

![image](https://user-images.githubusercontent.com/7509600/141301245-5871cc65-26e2-4598-8247-ffe808bcdab9.png)


Fixed result:

![image](https://user-images.githubusercontent.com/7509600/141304665-ebb97a2f-77cb-46ea-90ff-fcb732c3900d.png)
