### PR TITLE
Add some new musl math files to libc-rt library

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -108,10 +108,20 @@ def get_wasm_libc_rt_files():
       'fmin.c', 'fminf.c', 'fminl.c',
       'fmax.c', 'fmaxf.c', 'fmaxl.c',
       'fmod.c', 'fmodf.c', 'fmodl.c',
-      'log2.c', 'log2f.c', 'log10.c', 'log10f.c',
-      'exp2.c', 'exp2f.c', 'exp10.c', 'exp10f.c',
+      'log.c', 'log_data.c',
+      'logf.c', 'logf_data.c',
+      'log2.c', 'log2_data.c',
+      'log2f.c', 'log2f_data.c',
+      'log10.c', 'log10f.c',
+      'exp.c', 'exp_data.c',
+      'exp2.c',
+      'exp2f.c', 'exp2f_data.c',
+      'exp10.c', 'exp10f.c',
       'scalbn.c', '__fpclassifyl.c',
-      '__signbitl.c', '__signbitf.c', '__signbit.c'
+      '__signbitl.c', '__signbitf.c', '__signbit.c',
+      '__math_divzero.c', '__math_divzerof.c',
+      '__math_oflow.c', '__math_oflowf.c',
+      '__math_uflow.c', '__math_uflowf.c',
     ])
   other_files = files_in_path(
     path='system/lib/libc',


### PR DESCRIPTION
We had some reports of missing symbols in LTO builds after
the musl upgrade (#13006):
https://groups.google.com/g/emscripten-discuss/c/g_vkRRSCPUI/m/aT6fnUAtCQAJ?utm_medium=email&utm_source=footer

This change moves some of the new math-related source files
into the libc-mt library which is excluded from LTO (see comments
in in system_libs.py for background on this).

Verified that `lto2.test_float_builtinsTest` now passes with this
change but fails without (after musl upgrade).

This change fixes `asan.test_float_builtins` that is currently
failing.  See #15498.