### PR TITLE
Move most of the pthread_join to native. NFC

### DIFF
--- a/system/lib/pthread/pthread_join.c
+++ b/system/lib/pthread/pthread_join.c
@@ -5,12 +5,14 @@
  * found in the LICENSE file.
  */
 
+#include "assert.h"
 #include "pthread_impl.h"
 #include <pthread.h>
 
 extern int __pthread_join_js(pthread_t t, void **res, int tryjoin);
+extern int __emscripten_thread_cleanup(pthread_t t);
 
-static int __pthread_join_internal(pthread_t t, void **res, int tryjoin) {
+static int __pthread_join_internal(pthread_t t, void **res) {
   if (t->self != t) {
     // attempt to join a thread which does not point to a valid thread, or does
     // not exist anymore.
@@ -28,17 +30,39 @@ static int __pthread_join_internal(pthread_t t, void **res, int tryjoin) {
     // thread is attempting to join to itself.
     return EDEADLK;
   }
-  return __pthread_join_js(t, res, tryjoin);
+  int is_main_thread = emscripten_is_main_runtime_thread();
+  while (1) {
+    // The thread we are joining with must be either DT_JOINABLE or
+    // DT_EXITING.  If its DT_EXITING then we move it to DT_EXITED and
+    // we are done.   If its DT_JOINABLE we keep waiting.
+    int old_state = a_cas(&t->detach_state, DT_EXITING, DT_EXITED);
+    if (old_state == DT_EXITING) {
+      // We successfully marked the tread as DT_EXITED
+      if (res) *res = t->result;
+      __emscripten_thread_cleanup(t);
+      return 0;
+    }
+    assert(old_state == DT_JOINABLE);
+    if (old_state != DT_JOINABLE) return EINVAL;
+
+    __pthread_testcancel();
+    // In main runtime thread (the thread that initialized the Emscripten C
+    // runtime and launched main()), assist pthreads in performing operations
+    // that they need to access the Emscripten main runtime for.
+    if (is_main_thread) emscripten_main_thread_process_queued_calls();
+    emscripten_futex_wait(&t->detach_state, old_state, is_main_thread ? 100 : 1);
+  }
 }
 
 int __pthread_join(pthread_t t, void **res) {
-  return __pthread_join_internal(t, res, 0);
+  emscripten_check_blocking_allowed();
+  return __pthread_join_internal(t, res);
 }
 
 // Taken directly from system/lib/libc/musl/src/thread/pthread_join.c
 int __pthread_tryjoin_np(pthread_t t, void **res)
 {
-  return t->detach_state==DT_JOINABLE ? EBUSY : __pthread_join_internal(t, res, 1);
+  return t->detach_state==DT_JOINABLE ? EBUSY : __pthread_join_internal(t, res);
 }
 
 weak_alias(__pthread_join, emscripten_builtin_pthread_join);


### PR DESCRIPTION
The only part of `pthread_join` that needs to remain in JS
is the code for calling `cleanupThread`.