### PR TITLE
Fix misues of `is_main_runtime_thread` over `is_main_browser_thread`

### DIFF
--- a/system/lib/libc/musl/src/thread/__timedwait.c
+++ b/system/lib/libc/musl/src/thread/__timedwait.c
@@ -64,7 +64,7 @@ int __timedwait_cp(volatile int *addr, int val,
 
 #ifdef __EMSCRIPTEN__
 	double msecsToSleep = top ? (top->tv_sec * 1000 + top->tv_nsec / 1000000.0) : INFINITY;
-	int is_main_thread = emscripten_is_main_browser_thread();
+	int is_main_thread = emscripten_is_main_runtime_thread();
 	// cp suffix in the function name means "cancellation point", so this wait can be cancelled
 	// by the users unless current threads cancelability is set to PTHREAD_CANCEL_DISABLE
 	// which may be either done by the user of __timedwait() function.

--- a/system/lib/libc/musl/src/thread/__timedwait.c
+++ b/system/lib/libc/musl/src/thread/__timedwait.c
@@ -64,11 +64,11 @@ int __timedwait_cp(volatile int *addr, int val,
 
 #ifdef __EMSCRIPTEN__
 	double msecsToSleep = top ? (top->tv_sec * 1000 + top->tv_nsec / 1000000.0) : INFINITY;
-	int is_main_thread = emscripten_is_main_runtime_thread();
+	int is_runtime_thread = emscripten_is_main_runtime_thread();
 	// cp suffix in the function name means "cancellation point", so this wait can be cancelled
 	// by the users unless current threads cancelability is set to PTHREAD_CANCEL_DISABLE
 	// which may be either done by the user of __timedwait() function.
-	if (is_main_thread ||
+	if (is_runtime_thread ||
 	    pthread_self()->canceldisable != PTHREAD_CANCEL_DISABLE ||
 	    pthread_self()->cancelasync == PTHREAD_CANCEL_ASYNCHRONOUS) {
 		double sleepUntilTime = emscripten_get_now() + msecsToSleep;
@@ -80,7 +80,7 @@ int __timedwait_cp(volatile int *addr, int val,
 				return ECANCELED;
 			}
 			// Assist other threads by executing proxied operations that are effectively singlethreaded.
-			if (is_main_thread) emscripten_main_thread_process_queued_calls();
+			if (is_runtime_thread) emscripten_main_thread_process_queued_calls();
 			// Must wait in slices in case this thread is cancelled in between.
 			double waitMsecs = sleepUntilTime - emscripten_get_now();
 			if (waitMsecs <= 0) {
@@ -88,7 +88,7 @@ int __timedwait_cp(volatile int *addr, int val,
 				break;
 			}
 			if (waitMsecs > 100) waitMsecs = 100; // non-main threads can sleep in longer slices.
-			if (is_main_thread && waitMsecs > 1) waitMsecs = 1; // main thread may need to run proxied calls, so sleep in very small slices to be responsive.
+			if (is_runtime_thread && waitMsecs > 1) waitMsecs = 1; // the runtime thread may need to run proxied calls, so sleep in very small slices to be responsive.
 			r = -emscripten_futex_wait((void*)addr, val, waitMsecs);
 		} while(r == ETIMEDOUT);
 	} else {

--- a/system/lib/libc/musl/src/thread/__wait.c
+++ b/system/lib/libc/musl/src/thread/__wait.c
@@ -19,9 +19,9 @@ void __wait(volatile int *addr, volatile int *waiters, int val, int priv)
 	}
 	if (waiters) a_inc(waiters);
 #ifdef __EMSCRIPTEN__
-	int is_main_thread = emscripten_is_main_runtime_thread();
+	int is_runtime_thread = emscripten_is_main_runtime_thread();
 	while (*addr==val) {
-		if (is_main_thread || pthread_self()->cancelasync == PTHREAD_CANCEL_ASYNCHRONOUS) {
+		if (is_runtime_thread || pthread_self()->cancelasync == PTHREAD_CANCEL_ASYNCHRONOUS) {
 			// Must wait in slices in case this thread is cancelled in between.
 			int e;
 			do {
@@ -30,10 +30,10 @@ void __wait(volatile int *addr, volatile int *waiters, int val, int priv)
 					return;
 				}
 				// Assist other threads by executing proxied operations that are effectively singlethreaded.
-				if (is_main_thread) emscripten_main_thread_process_queued_calls();
+				if (is_runtime_thread) emscripten_main_thread_process_queued_calls();
 				// Main thread waits in _very_ small slices so that it stays responsive to assist proxied
 				// pthread calls.
-				e = emscripten_futex_wait((void*)addr, val, is_main_thread ? 1 : 100);
+				e = emscripten_futex_wait((void*)addr, val, is_runtime_thread ? 1 : 100);
 			} while(e == -ETIMEDOUT);
 		} else {
 			// Can wait in one go.

--- a/system/lib/libc/musl/src/thread/pthread_barrier_wait.c
+++ b/system/lib/libc/musl/src/thread/pthread_barrier_wait.c
@@ -88,7 +88,7 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 			a_spin();
 		a_inc(&inst->finished);
 #ifdef __EMSCRIPTEN__
-		int is_main_thread = emscripten_is_main_browser_thread();
+		int is_main_thread = emscripten_is_main_runtime_thread();
 		while (inst->finished == 1) {
 			if (is_main_thread) {
 				int e;

--- a/system/lib/libc/musl/src/thread/pthread_barrier_wait.c
+++ b/system/lib/libc/musl/src/thread/pthread_barrier_wait.c
@@ -88,9 +88,9 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 			a_spin();
 		a_inc(&inst->finished);
 #ifdef __EMSCRIPTEN__
-		int is_main_thread = emscripten_is_main_runtime_thread();
+		int is_runtime_thread = emscripten_is_main_runtime_thread();
 		while (inst->finished == 1) {
-			if (is_main_thread) {
+			if (is_runtime_thread) {
 				int e;
 				do {
 					// Main thread waits in _very_ small slices so that it stays responsive to assist proxied

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -92,7 +92,7 @@ void emscripten_thread_sleep(double msecs) {
   const double minimumTimeSliceToSleep = 0.1;
 
   // main thread may need to run proxied calls, so sleep in very small slices to be responsive.
-  const double maxMsecsSliceToSleep = emscripten_is_main_browser_thread() ? 1 : 100;
+  const double maxMsecsSliceToSleep = emscripten_is_main_runtime_thread() ? 1 : 100;
 
   emscripten_conditional_set_current_thread_status(
     EM_THREAD_STATUS_RUNNING, EM_THREAD_STATUS_SLEEPING);

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -91,7 +91,7 @@ void emscripten_thread_sleep(double msecs) {
   // If we have less than this many msecs left to wait, busy spin that instead.
   const double minimumTimeSliceToSleep = 0.1;
 
-  // main thread may need to run proxied calls, so sleep in very small slices to be responsive.
+  // runtime thread may need to run proxied calls, so sleep in very small slices to be responsive.
   const double maxMsecsSliceToSleep = emscripten_is_main_runtime_thread() ? 1 : 100;
 
   emscripten_conditional_set_current_thread_status(

--- a/system/lib/pthread/pthread_join.c
+++ b/system/lib/pthread/pthread_join.c
@@ -30,7 +30,7 @@ static int __pthread_join_internal(pthread_t t, void **res) {
     // thread is attempting to join to itself.
     return EDEADLK;
   }
-  int is_main_thread = emscripten_is_main_runtime_thread();
+  int is_runtime_thread = emscripten_is_main_runtime_thread();
   while (1) {
     // The thread we are joining with must be either DT_JOINABLE or
     // DT_EXITING.  If its DT_EXITING then we move it to DT_EXITED and
@@ -49,8 +49,8 @@ static int __pthread_join_internal(pthread_t t, void **res) {
     // In main runtime thread (the thread that initialized the Emscripten C
     // runtime and launched main()), assist pthreads in performing operations
     // that they need to access the Emscripten main runtime for.
-    if (is_main_thread) emscripten_main_thread_process_queued_calls();
-    emscripten_futex_wait(&t->detach_state, old_state, is_main_thread ? 100 : 1);
+    if (is_runtime_thread) emscripten_main_thread_process_queued_calls();
+    emscripten_futex_wait(&t->detach_state, old_state, is_runtime_thread ? 100 : 1);
   }
 }
 

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -45,7 +45,7 @@ void MemoryFile::Handle::preloadFromJS(int index) {
   getFile()->buffer.resize(
     EM_ASM_INT({return wasmFS$preloadedFiles[$0].fileData.length}, index));
   // Ensure that files are preloaded from the main thread.
-  assert(emscripten_is_main_browser_thread());
+  assert(emscripten_is_main_runtime_thread());
   // TODO: Replace every EM_ASM with EM_JS.
   EM_ASM({ HEAPU8.set(wasmFS$preloadedFiles[$1].fileData, $0); },
          getFile()->buffer.data(),

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -53,7 +53,7 @@ void WasmFS::preloadFiles() {
 #endif
 
   // Ensure that files are preloaded from the main thread.
-  assert(emscripten_is_main_browser_thread());
+  assert(emscripten_is_main_runtime_thread());
 
   int numFiles = EM_ASM_INT({return wasmFS$preloadedFiles.length});
   int numDirs = EM_ASM_INT({return wasmFS$preloadedDirs.length});


### PR DESCRIPTION
In all these places the code is really attempting to figure out if it is
the main runtime thread.  i.e. the first place the program is loaded and
the place that runs the callback and async events send from secondary
threads.

The reason this mistake often goes unnoticed is that in almost all cases
the main runtime thread is also running on the main browser thread.

One easy way to see that `is_main_browser_thread` is the wrong question
to be asking in many of these cases is to remember that when emscripten
is started in a worker there is no main browser involved and so this
function will return false on *all* threads.

In the case of `__timedwait.c` and `pthread_barrier_wait.c` the desire
is to avoid blocking the main runtime thread so that calls from other
threads can be processed by `emscripten_main_thread_process_queued_calls`.
`emscripten_main_thread_process_queued_calls` is expected to always run
on the main *runtime* thread, and not necessarily on the main *browser*
thread.  Indeed its first line is:

 `assert(emscripten_is_main_runtime_thread());`