### PR TITLE
Embind: test float argument conversion with and without assertions

### DIFF
--- a/src/embind/embind.js
+++ b/src/embind/embind.js
@@ -55,6 +55,9 @@ var LibraryEmbind = {
     // names. This lets the test suite know that.
     Module['DYNAMIC_EXECUTION'] = true;
 #endif
+#if ASSERTIONS
+    Module['ASSERTIONS'] = true;
+#endif
 #if EMBIND_STD_STRING_IS_UTF8
     Module['EMBIND_STD_STRING_IS_UTF8'] = true;
 #endif

--- a/tests/embind/embind.test.js
+++ b/tests/embind/embind.test.js
@@ -638,6 +638,24 @@ module({
             assert.equal(2, cm.const_ref_adder(true, true));
         });
 
+        assert.throws(TypeError, function() { cm.const_ref_adder(Symbol('0'), 1); });
+        assert.throws(TypeError, function() { cm.const_ref_adder(BigInt(0), 1); });
+
+        if (cm['ASSERTIONS']) {
+            test("can pass only number and boolean with assertions assertions", function() {
+                assert.throws(TypeError, function() { cm.const_ref_adder(1, undefined); });
+                assert.throws(TypeError, function() { cm.const_ref_adder(1, null); });
+                assert.throws(TypeError, function() { cm.const_ref_adder(1, '2'); });
+            });
+        } else {
+            test("can pass other types as floats without assertions", function() {
+                assert.equal(3, cm.const_ref_adder(1, '2'));
+                assert.equal(1, cm.const_ref_adder(1, null));  // null => 0
+                assert.true(isNaN(cm.const_ref_adder(1, 'cannot parse')));
+                assert.true(isNaN(cm.const_ref_adder(1, undefined)));  // undefined => NaN
+            });
+        }
+
         test("convert double to unsigned", function() {
             var rv = cm.emval_test_as_unsigned(1.5);
             assert.equal('number', typeof rv);

--- a/tests/embind/imvu_test_adapter.js
+++ b/tests/embind/imvu_test_adapter.js
@@ -203,6 +203,7 @@ function module(ignore, func) {
     }
 
     var formatTestValue = function(v) {
+        if (v === undefined) return 'undefined';
         return v.toString();
         /*
         var s = IMVU.repr(v, TEST_MAX_OUTPUT_SIZE + 1);


### PR DESCRIPTION
Adds an 'ASSERTIONS' property when assertions are enabled, so tests can detect the directive.

Adds tests for floating point argument toWireType behavior with and without assertions.

Adds a check for undefined when formatting arguments, as there is no toString on 'undefined'.