### PR TITLE
Make use of filenames in tests more grep-able. NFC

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1737,13 +1737,14 @@ keydown(100);keyup(100); // trigger the end
 
   @requires_graphics_hardware
   def test_glgears_animation(self):
-    es2_suffix = ['', '_full', '_full_944']
-    for full_es2 in [0, 1, 2]:
-      print(full_es2)
-      self.compile_btest([test_file('hello_world_gles%s.c' % es2_suffix[full_es2]), '-o', 'something.html',
-                          '-DHAVE_BUILTIN_SINCOS', '-s', 'GL_TESTING', '-lGL', '-lglut',
-                          '--shell-file', test_file('hello_world_gles_shell.html')] +
-                         (['-s', 'FULL_ES2=1'] if full_es2 else []))
+    for filename in ['hello_world_gles.c', 'hello_world_gles_full.c', 'hello_world_gles_full_944.c']:
+      print(filename)
+      cmd = [test_file(filename), '-o', 'something.html',
+             '-DHAVE_BUILTIN_SINCOS', '-s', 'GL_TESTING', '-lGL', '-lglut',
+             '--shell-file', test_file('hello_world_gles_shell.html')]
+      if 'full' in filename:
+        cmd += ['-s', 'FULL_ES2=1']
+      self.compile_btest(cmd)
       self.run_browser('something.html', 'You should see animating gears.', '/report_gl_result?true')
 
   @requires_graphics_hardware

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8529,7 +8529,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   def test_stdio_locking(self):
     self.set_setting('PTHREAD_POOL_SIZE', '2')
     self.set_setting('EXIT_RUNTIME')
-    self.do_run_in_out_file_test('core', 'test_stdio_locking.c')
+    self.do_run_in_out_file_test('core/test_stdio_locking.c')
 
   @needs_dylink
   @node_pthreads

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10816,7 +10816,7 @@ kill -9 $$
       self.assertContained('failed (received SIGKILL (-9))', err)
 
   def test_concepts(self):
-    self.do_runf(test_file('other', 'test_concepts.cpp'), '', emcc_args=['-std=c++20'])
+    self.do_runf(test_file('other/test_concepts.cpp'), '', emcc_args=['-std=c++20'])
 
   def test_link_only_setting_warning(self):
     err = self.run_process([EMCC, '-sALLOW_MEMORY_GROWTH', '-c', test_file('hello_world.c')], stderr=PIPE).stderr
@@ -10995,7 +10995,7 @@ void foo() {}
     self.set_setting('USE_PTHREADS')
     self.set_setting('PROXY_TO_PTHREAD')
     self.set_setting('EXIT_RUNTIME')
-    self.build(test_file('other', 'test_pthread_js_exception.c'))
+    self.build(test_file('other/test_pthread_js_exception.c'))
     err = self.run_js('test_pthread_js_exception.js', assert_returncode=NON_ZERO)
     self.assertContained('missing is not defined', err)
 
@@ -11048,9 +11048,9 @@ void foo() {}
 
   @node_pthreads
   def test_default_pthread_stack_size(self):
-    self.do_runf(test_file('other', 'test_default_pthread_stack_size.c'))
+    self.do_runf(test_file('other/test_default_pthread_stack_size.c'))
     self.emcc_args.append('-sUSE_PTHREADS')
-    self.do_runf(test_file('other', 'test_default_pthread_stack_size.c'))
+    self.do_runf(test_file('other/test_default_pthread_stack_size.c'))
 
   def test_emscripten_set_immediate(self):
     self.do_runf(test_file('emscripten_set_immediate.c'))


### PR DESCRIPTION
Be consistent about how to specific files in tests so that
its easier to grep for filenames.

This makes life easier for `check_for_unused_test_files.py`.

See: #15511