### PR TITLE
[WASMFS] rename syscall

### DIFF
--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -85,10 +85,6 @@ std::shared_ptr<Directory> getDir(std::vector<std::string>::iterator begin,
 #endif
     curr = directory->locked().getEntry(*it);
 
-    // Special case for the rename syscall.
-    // If one detects that old_path is a forbidden ancestor in the path of
-    // new_path, the rename operation is invalid. Ex.
-    // rename("dir", "dir/somename").
     if (forbiddenAncestor) {
       if (curr == forbiddenAncestor) {
         err = -EINVAL;

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -54,9 +54,11 @@ void MemoryFile::Handle::preloadFromJS(int index) {
 //
 // Path Parsing utilities
 //
+
 std::shared_ptr<Directory> getDir(std::vector<std::string>::iterator begin,
                                   std::vector<std::string>::iterator end,
-                                  long& err) {
+                                  long& err,
+                                  std::shared_ptr<File> ancestor) {
 
   std::shared_ptr<File> curr;
   // Check if the first path element is '/', indicating an absolute path.
@@ -82,6 +84,15 @@ std::shared_ptr<Directory> getDir(std::vector<std::string>::iterator begin,
     directory->locked().printKeys();
 #endif
     curr = directory->locked().getEntry(*it);
+
+    // For the rename syscall one must check if the source dir is an ancestor of
+    // the destination dir.
+    if (ancestor) {
+      if (curr == ancestor) {
+        err = -EINVAL;
+        return nullptr;
+      }
+    }
 
     // Requested entry (file or directory)
     if (!curr) {

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -87,7 +87,7 @@ public:
     if (handle.trylock()) {
       return Handle(shared_from_this());
     } else {
-      return std::nullopt;
+      return {};
     }
   }
 
@@ -232,7 +232,7 @@ public:
     if (handle.trylock()) {
       return Handle(shared_from_this());
     } else {
-      return std::nullopt;
+      return {};
     }
   }
 };
@@ -264,10 +264,12 @@ public:
 
 // Obtains parent directory of a given pathname.
 // Will return a nullptr if the parent is not a directory.
-std::shared_ptr<Directory> getDir(std::vector<std::string>::iterator begin,
-                                  std::vector<std::string>::iterator end,
-                                  long& err,
-                                  std::shared_ptr<File> ancestor = nullptr);
+// Will exit if the forbiddenAncestor shared_ptr is encountered while parsing.
+std::shared_ptr<Directory>
+getDir(std::vector<std::string>::iterator begin,
+       std::vector<std::string>::iterator end,
+       long& err,
+       std::shared_ptr<File> forbiddenAncestor = nullptr);
 
 // Return a vector of the '/'-delimited components of a path. The first element
 // will be "/" iff the path is an absolute path.

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -720,6 +720,7 @@ long __syscall_getdents64(long fd, long dirp, long count) {
   return bytesRead;
 }
 
+// TODO: Revisit this syscall after refactoring file system locking strategy.
 long __syscall_rename(long old_path, long new_path) {
   // The rename syscall must be atomic to prevent other file system operations
   // from concurrently changing the directories. If it were not atomic, then the

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -722,14 +722,14 @@ long __syscall_getdents64(long fd, long dirp, long count) {
 
 long __syscall_rename(long old_path, long new_path) {
   // The rename syscall must be atomic to prevent other file system operations
-  // from changing it. If it were not atomic, then another thread could unlink
-  // the destination directory after we have moved our source child. This would
-  // leave the file system in an undefined state as the source child is now
-  // orphaned. Protecting the destination and source parent directories ensures
-  // that no resources that we depend on are altered. Trylocking on the new_path
-  // parent is needed in the case where two renames are operating on opposing
-  // sources and destinations. This could cause them to lock the directories in
-  // reverse order and cause deadlock.
+  // from changing its state. If it were not atomic, then other threads could
+  // unlink the destination directory after we have moved our source child. This
+  // would leave the file system in an undefined state as the source child is
+  // now orphaned. Protecting the destination and source parent directories
+  // ensures that no resources that we depend on are altered. Trylocking on the
+  // new_path parent is needed in the case where two renames are operating on
+  // opposing sources and destinations. This could cause them to lock the
+  // directories in reverse order and cause deadlock.
 
   // Edge case: rename("dir", "dir/somename") - in this scenario it should not
   // be possible to rename the destination if the source is an ancestor.

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -768,8 +768,7 @@ long __syscall_rename(long old_path, long new_path) {
   // For this operation to be atomic we must lock the source parent directory.
   auto lockedOldParentDir = oldParentDir->locked();
 
-  auto oldPath = lockedOldParentDir.getEntry(oldBase),
-       forbiddenAncestor = oldPath;
+  auto oldPath = lockedOldParentDir.getEntry(oldBase);
 
   if (!oldPath) {
     return -ENOENT;
@@ -790,8 +789,9 @@ long __syscall_rename(long old_path, long new_path) {
 
   auto newBase = newPathParts.back();
 
-  auto newParentDir = getDir(
-    newPathParts.begin(), newPathParts.end() - 1, err, forbiddenAncestor);
+  // oldPath is the forbidden ancestor.
+  auto newParentDir =
+    getDir(newPathParts.begin(), newPathParts.end() - 1, err, oldPath);
 
   // If the destination parent directory doesn't exist, the source file cannot
   // be moved.

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -27,7 +27,7 @@ __attribute__((init_priority(100))) WasmFS wasmFS;
 # 28 "wasmfs.cpp"
 
 std::shared_ptr<Directory> WasmFS::initRootDirectory() {
-  auto rootDirectory = std::make_shared<Directory>(S_IRUGO | S_IXUGO);
+  auto rootDirectory = std::make_shared<Directory>(S_IRUGO | S_IXUGO | S_IWUGO);
   auto devDirectory = std::make_shared<Directory>(S_IRUGO | S_IXUGO);
   rootDirectory->locked().setEntry("dev", devDirectory);
 

--- a/tests/stdio/test_rename.c
+++ b/tests/stdio/test_rename.c
@@ -137,7 +137,7 @@ void test() {
   err = rename("dir/file2", "dir/file2");
   assert(!err);
 
-  // In Linux, renaming the root directory should return EBUSY.
+  // In Linux and WasmFS, renaming the root directory should return EBUSY.
   // In the JS file system it reports EINVAL.
   err = rename("/", "dir/file2");
   assert(err == -1);
@@ -150,32 +150,6 @@ void test() {
   err = rename("dir/file2", "/");
   assert(err == -1);
   assert(errno == ENOTEMPTY);
-
-  // Test renaming the current working directory while still root.
-  char buffer[100];
-  getcwd(buffer, sizeof(buffer));
-  err = rename(buffer, "dir/file");
-  assert(err == -1);
-#ifdef WASMFS
-  assert(errno == EBUSY);
-#else
-  assert(errno == EINVAL);
-#endif
-
-  // Test renaming the current working directory.
-  // In Linux, it is possible to rename the current working dir.
-  // The JS file system reports EBUSY.
-  chdir("new-dir");
-  getcwd(buffer, sizeof(buffer));
-  printf("buffer: %s\n", buffer);
-  err = rename(buffer, "/dir/new-dir");
-#ifdef WASMFS
-  assert(!err);
-#else
-  assert(errno == EBUSY);
-#endif
-  // Switch back to the root directory for cleanup.
-  chdir("/");
 
   puts("success");
 }

--- a/tests/stdio/test_rename.c
+++ b/tests/stdio/test_rename.c
@@ -33,6 +33,16 @@ void setup() {
   mkdir("dir/subdir", 0777);
   mkdir("dir/subdir/subsubdir", 0777);
   mkdir("dir-readonly", 0555);
+  // TODO: Remove when chmod is implemented in WasmFS.
+#ifdef WASMFS
+  mkdir("dir-readonly2", 0555);
+#else
+  mkdir("dir-readonly2", 0777);
+#endif
+  mkdir("dir-readonly2/somename", 0777);
+#ifndef WASMFS
+  chmod("dir-readonly2", 0555);
+#endif
   mkdir("dir-nonempty", 0777);
   mkdir("dir/subdir3", 0777);
   mkdir("dir/subdir3/subdir3_1", 0777);
@@ -62,6 +72,11 @@ void cleanup() {
   rmdir("dir/b/c");
   rmdir("dir/b");
   rmdir("dir");
+#ifndef WASMFS
+  chmod("dir-readonly2", 0777);
+#endif
+  rmdir("dir-readonly2/somename");
+  rmdir("dir-readonly2");
   rmdir("new-dir");
   rmdir("dir-readonly");
   unlink("dir-nonempty/file");
@@ -93,6 +108,11 @@ void test() {
 
   // can't create anything in a read-only directory
   err = rename("dir", "dir-readonly/dir");
+  assert(err == -1);
+  assert(errno == EACCES);
+  
+  // Can't move from a read-only directory.
+  err = rename("dir-readonly2/somename", "dir");
   assert(err == -1);
   assert(errno == EACCES);
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -180,6 +180,7 @@ def also_with_wasmfs(func):
     if self.get_setting('STANDALONE_WASM'):
       self.skipTest("test currently cannot run both with WASMFS and STANDALONE_WASM")
     self.set_setting('WASMFS')
+    self.emcc_args = self.emcc_args.copy() + ['-DWASMFS']
     func(self)
   return decorated
 
@@ -1606,6 +1607,7 @@ int main() {
   def test_alloca(self):
     self.do_core_test('test_alloca.c')
 
+  @also_with_wasmfs
   def test_rename(self):
     self.do_run_in_out_file_test('stdio/test_rename.c')
 


### PR DESCRIPTION
Relevant Issue: #15041 
- Implement rename
- Add to existing `test_rename.c`
- Gave write permissions to root directory.
- Introduce `recursive_mutex` and try locking mechanism.
- TODO: Need to refactor path parsing, clean up comments.