### PR TITLE
Fix pthread_attr_t having 9 elems instead of 10

### DIFF
--- a/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/alltypes.h
@@ -91,9 +91,9 @@ typedef long suseconds_t;
 #if defined(__NEED_pthread_attr_t) && !defined(__DEFINED_pthread_attr_t)
 typedef struct {
     union {
-        int __i[9];
-        volatile int __vi[9];
-        unsigned __s[9];
+        int __i[10];
+        volatile int __vi[10];
+        unsigned __s[10];
     } __u;
 #ifdef __EMSCRIPTEN__
     // For canvas transfer implementation in Emscripten, use an extra control field

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -1343,8 +1343,8 @@
             "tsd": 64
         },
         "pthread_attr_t": {
-            "__size__": 40,
-            "_a_transferredcanvases": 36
+            "__size__": 44,
+            "_a_transferredcanvases": 40
         },
         "sockaddr": {
             "__size__": 16,


### PR DESCRIPTION
Regression introduced here: https://github.com/emscripten-core/emscripten/pull/13006
We are relying on them having 10 elems thru the `_a_prio` field (in wasm64) and also offsets in library_pthread.js