### PR TITLE
Free thread data in native code. NFC

### DIFF
--- a/src/struct_info_internal.json
+++ b/src/struct_info_internal.json
@@ -12,6 +12,7 @@
               "detach_state",
               "stack",
               "stack_size",
+              "stack_owned",
               "result",
               "robust_list",
               "tid",

--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -91,6 +91,7 @@ struct pthread {
 	// If --threadprofiler is enabled, this pointer is allocated to contain
 	// internal information about the thread state for profiling purposes.
 	thread_profiler_block * _Atomic profilerBlock;
+	int stack_owned;
 #endif
 };
 

--- a/system/lib/pthread/pthread_join.c
+++ b/system/lib/pthread/pthread_join.c
@@ -10,7 +10,7 @@
 #include <pthread.h>
 
 extern int __pthread_join_js(pthread_t t, void **res, int tryjoin);
-extern int __emscripten_thread_cleanup(pthread_t t);
+extern void __pthread_free_thread_data(pthread_t t);
 
 static int __pthread_join_internal(pthread_t t, void **res) {
   if (t->self != t) {
@@ -39,7 +39,7 @@ static int __pthread_join_internal(pthread_t t, void **res) {
     if (old_state == DT_EXITING) {
       // We successfully marked the tread as DT_EXITED
       if (res) *res = t->result;
-      __emscripten_thread_cleanup(t);
+      __pthread_free_thread_data(t);
       return 0;
     }
     assert(old_state == DT_JOINABLE);

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -1327,7 +1327,7 @@
             "p_proto": 8
         },
         "pthread": {
-            "__size__": 108,
+            "__size__": 112,
             "cancel": 28,
             "cancelasync": 33,
             "canceldisable": 32,
@@ -1338,6 +1338,7 @@
             "robust_list": 68,
             "self": 0,
             "stack": 44,
+            "stack_owned": 108,
             "stack_size": 48,
             "tid": 16,
             "tsd": 64


### PR DESCRIPTION
We free the thread data either when the thread exits (in the case it is
detached) or when it is joined (in the case it is not detached).

In either case we can re-cycle the worker (return it to the worker pool)
right away since the thread is no longer running.

Since `freeThreadData` is no longer called during `returnWorkerToPool`
it means that pthread data accocated with threads that were terminated
with worker.terminate will not be memory leaks.  However terminating a
thread in this was otherwise racey and dangerous and we should try to
avoid `worker.terminate` if at all possible.  Also, pthread data is
already excluded from lsan so this won't show up in leak reports.