### PR TITLE
Avoid sending stack information in pthread create postMessage. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -597,8 +597,6 @@ var LibraryPThread = {
         'start_routine': threadParams.startRoutine,
         'arg': threadParams.arg,
         'threadInfoStruct': threadParams.pthread_ptr,
-        'stackBase': threadParams.stackBase,
-        'stackSize': threadParams.stackSize
     };
 #if OFFSCREENCANVAS_SUPPORT
     // Note that we do not need to quote these names because they are only used
@@ -1260,7 +1258,17 @@ var LibraryPThread = {
     return func.apply(null, _emscripten_receive_on_main_thread_js_callArgs);
   },
 
-  $establishStackSpace: function(stackTop, stackMax) {
+  $establishStackSpace__internal: true,
+  $establishStackSpace: function() {
+    var pthread_ptr = _pthread_self();
+    var stackTop = {{{ makeGetValue('pthread_ptr', C_STRUCTS.pthread.stack, 'i32') }}};
+    var stackSize = {{{ makeGetValue('pthread_ptr', C_STRUCTS.pthread.stack_size, 'i32') }}};
+    var stackMax = stackTop - stackSize;
+#if ASSERTIONS
+    assert(stackTop != 0);
+    assert(stackMax != 0);
+    assert(stackTop > stackMax);
+#endif
     // Set stack limits used by `emscripten/stack.h` function.  These limits are
     // cached in wasm-side globals to make checks as fast as possible.
     _emscripten_stack_set_limits(stackTop, stackMax);

--- a/src/worker.js
+++ b/src/worker.js
@@ -190,18 +190,11 @@ self.onmessage = function(e) {
       // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
       Module['__emscripten_thread_init'](e.data.threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0);
 
-      // Establish the stack frame for this thread in global scope
-      // The stack grows downwards
-      var max = e.data.stackBase;
-      var top = e.data.stackBase + e.data.stackSize;
 #if ASSERTIONS
       assert(e.data.threadInfoStruct);
-      assert(top != 0);
-      assert(max != 0);
-      assert(top > max);
 #endif
       // Also call inside JS module to set up the stack frame for this pthread in JS module scope
-      Module['establishStackSpace'](top, max);
+      Module['establishStackSpace']();
       Module['PThread'].receiveObjectTransfer(e.data);
       Module['PThread'].threadInit();
 


### PR DESCRIPTION
This information is already stored in the native thread info
struct so no need to replicate it in the JS message.

This is the first part of a larger change to remove the stack
initialization completely from the JS side, but its a good
standalone change too.