### PR TITLE
[WASMFS] Comprehensive dup test

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11155,7 +11155,7 @@ void foo() {}
 
   # TODO: This test will only work with the new file system.
   # Addresses this issue: https://github.com/emscripten-core/emscripten/issues/4017
-  # Also there are cases where an incorrect error is reported.
+  # The new file system also correctly identifies errors that the JS file system missed.
   def test_wasmfs_dup(self):
     self.set_setting('WASMFS')
     self.do_run_in_out_file_test('wasmfs/wasmfs_dup.c')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11156,8 +11156,7 @@ void foo() {}
   # TODO: This test will only work with the new file system.
   # Addresses this issue: https://github.com/emscripten-core/emscripten/issues/4017
   # Also there are cases where an incorrect error is reported.
-  @also_with_wasmfs
-  def test_unistd_dup(self):
+  def test_wasmfs_dup(self):
     self.set_setting('WASMFS')
     self.do_run_in_out_file_test('wasmfs/wasmfs_dup.c')
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11153,6 +11153,9 @@ void foo() {}
 
   # WASMFS tests
 
+  # TODO: This test will only work with the new file system.
+  # Addresses this issue: https://github.com/emscripten-core/emscripten/issues/4017
+  # Also there are cases where an incorrect error is reported.
   @also_with_wasmfs
   def test_unistd_dup(self):
     self.set_setting('WASMFS')

--- a/tests/wasmfs/wasmfs_dup.c
+++ b/tests/wasmfs/wasmfs_dup.c
@@ -9,6 +9,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 // FIXME: Merge this standalone test back into dup.c after new FS can support
@@ -56,13 +57,18 @@ int main() {
   errno = 0;
   f5 = dup2(f4, -1);
   assert(f5 == -1);
+// These errors are not reported in the JS file system.
+#ifdef WASMFS
   assert(errno == EBADF);
+#endif
 
   // Try calling dup2 with an invalid oldfd
   errno = 0;
   int f6 = dup2(-1, f5);
   assert(f6 == -1);
+#ifdef WASMFS
   assert(errno == EBADF);
+#endif
 
   // Try assigning a large fd
   int f7 = 4069;
@@ -72,8 +78,58 @@ int main() {
 
   errno = 0;
   int f9 = dup(-1);
+#ifdef WASMFS
   assert(f9 == -1);
   assert(errno == EBADF);
+#endif
+
+  off_t offset;
+
+  errno = 0;
+  printf("DUP\n");
+  mkdir("working", 0700);
+  f = open("working/file", O_RDWR | O_CREAT);
+  f2 = open("working/file", O_RDONLY);
+  f3 = dup(f);
+  printf("errno: %d\n", errno);
+  printf("f: %d\n", f != f2 && f != f3);
+  printf("f2,f3: %d\n", f2 != f3);
+
+  // dup()ed file descriptors should share all flags and even seek position
+  offset = lseek(f3, 0, SEEK_CUR);
+  printf("1. f3 offset was %d.    Should be 0\n", (int)offset);
+  offset = lseek(f, 1, SEEK_SET);
+  printf("2. f  offset set to %d. Should be 1\n", (int)offset);
+  offset = lseek(f2, 2, SEEK_SET);
+  printf("3. f2 offset set to %d. Should be 2\n", (int)offset);
+  offset = lseek(f, 0, SEEK_CUR);
+  printf("4. f  offset now is %d. Should be 1\n", (int)offset);
+  offset = lseek(f2, 0, SEEK_CUR);
+  printf("5. f2 offset now is %d. Should be 2\n", (int)offset);
+  offset = lseek(f3, 0, SEEK_CUR);
+  printf("6. f3 offset now is %d. Should be 1 (and not 0)\n", (int)offset);
+  offset = lseek(f3, 3, SEEK_SET);
+  printf("7. f3 offset set to %d. Should be 3\n", (int)offset);
+  offset = lseek(f, 0, SEEK_CUR);
+  printf("8. f  offset now is %d. Should be 3 (and not 1)\n", (int)offset);
+
+  printf("close(f1): %d\n", close(f));
+  printf("close(f2): %d\n", close(f2));
+  printf("close(f3): %d\n", close(f3));
+  printf("\n");
+  errno = 0;
+
+  printf("DUP2\n");
+  f = open("/", O_RDONLY);
+  f2 = open("/", O_RDONLY);
+  f3 = dup2(f, f2);
+  printf("errno: %d\n", errno);
+  printf("f: %d\n", f != f2 && f != f3);
+  printf("f2,f3: %d\n", f2 == f3);
+  printf("close(f1): %d\n", close(f));
+  printf("close(f2): %d\n", close(f2));
+  printf("close(f3): %d\n", close(f3));
+  errno = 0;
 
   return 0;
 }

--- a/tests/wasmfs/wasmfs_dup.c
+++ b/tests/wasmfs/wasmfs_dup.c
@@ -57,18 +57,15 @@ int main() {
   errno = 0;
   f5 = dup2(f4, -1);
   assert(f5 == -1);
-// These errors are not reported in the JS file system.
-#ifdef WASMFS
+  // This error is not reported in the JS filesystem.
   assert(errno == EBADF);
-#endif
 
   // Try calling dup2 with an invalid oldfd
   errno = 0;
   int f6 = dup2(-1, f5);
   assert(f6 == -1);
-#ifdef WASMFS
+  // This error is not reported in the JS filesystem.
   assert(errno == EBADF);
-#endif
 
   // Try assigning a large fd
   int f7 = 4069;
@@ -78,10 +75,9 @@ int main() {
 
   errno = 0;
   int f9 = dup(-1);
-#ifdef WASMFS
+  // This error is not reported in the JS filesystem.
   assert(f9 == -1);
   assert(errno == EBADF);
-#endif
 
   off_t offset;
 

--- a/tests/wasmfs/wasmfs_dup.out
+++ b/tests/wasmfs/wasmfs_dup.out
@@ -1,3 +1,4 @@
+DUP
 STDOUT
 CAN PRINT TO STDOUT WITH fd = 3
 DUP2
@@ -6,3 +7,26 @@ CAN PRINT TO STDOUT WITH fd = 5
 CAN PRINT TO STDOUT WITH fd = 5
 CAN PRINT TO STDOUT WITH fd = 5
 CAN PRINT TO STDOUT WITH f8 = 4069
+DUP
+errno: 0
+f: 1
+f2,f3: 1
+1. f3 offset was 0.    Should be 0
+2. f  offset set to 1. Should be 1
+3. f2 offset set to 2. Should be 2
+4. f  offset now is 1. Should be 1
+5. f2 offset now is 2. Should be 2
+6. f3 offset now is 1. Should be 1 (and not 0)
+7. f3 offset set to 3. Should be 3
+8. f  offset now is 3. Should be 3 (and not 1)
+close(f1): 0
+close(f2): 0
+close(f3): 0
+
+DUP2
+errno: 0
+f: 1
+f2,f3: 1
+close(f1): 0
+close(f2): 0
+close(f3): 0


### PR DESCRIPTION
Relevant Issue: #15041 

Verifies that this issue has been fixed with the dup syscall: https://github.com/emscripten-core/emscripten/issues/4017

`dup()ed file descriptors should share all flags (and also seek position). Opening same file twice is not the same thing`