### PR TITLE
Map `printErr` to `console.warn` rather then `console.error` in default shell.html

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3507,7 +3507,7 @@ LibraryManager.library = {
 #if ASSERTIONS
     assert(typeof str === 'number');
 #endif
-    console.warn(UTF8ToString(str));
+    err(UTF8ToString(str));
   },
 
   emscripten_console_error__sig: 'vi',
@@ -3515,7 +3515,7 @@ LibraryManager.library = {
 #if ASSERTIONS
     assert(typeof str === 'number');
 #endif
-    err(UTF8ToString(str));
+    console.error(UTF8ToString(str));
   },
 
   emscripten_throw_number: function(number) {

--- a/src/shell.html
+++ b/src/shell.html
@@ -1243,7 +1243,7 @@
         })(),
         printErr: function(text) {
           if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-          console.error(text);
+          console.warn(text);
         },
         canvas: (function() {
           var canvas = document.getElementById('canvas');

--- a/src/shell_minimal.html
+++ b/src/shell_minimal.html
@@ -95,7 +95,7 @@
         })(),
         printErr: function(text) {
           if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-          console.error(text);
+          console.warn(text);
         },
         canvas: (function() {
           var canvas = document.getElementById('canvas');

--- a/tests/emscripten_console_log.c
+++ b/tests/emscripten_console_log.c
@@ -1,15 +1,12 @@
+#include <assert.h>
 #include <emscripten.h>
 #include <emscripten/html5.h>
 
 int main()
 {
-	emscripten_console_log("Hello!");
-	emscripten_console_warn("Hello!");
-	emscripten_console_error("Hello!");
-	if (EM_ASM_INT(return Module['testPassed']))
-	{
-#ifdef REPORT_RESULT
-		REPORT_RESULT(0);
-#endif
-	}
+	emscripten_console_log("Hello log!");
+	emscripten_console_warn("Hello warn!");
+	emscripten_console_error("Hello error!");
+	assert(EM_ASM_INT(return Module['testPassed']));
+	return 0;
 }

--- a/tests/emscripten_console_log.out
+++ b/tests/emscripten_console_log.out
@@ -1,0 +1,3 @@
+Hello log!
+Hello warn!
+Hello error!

--- a/tests/emscripten_console_log_pre.js
+++ b/tests/emscripten_console_log_pre.js
@@ -7,15 +7,15 @@ var warned = false;
 
 console.log = function(s) {
 	console.realLog(s);
-	if (s === 'Hello!') logged = true;
+	if (s === 'Hello log!') logged = true;
 }
 
 console.warn = function(s) {
 	console.realWarn(s);
-	if (s === 'Hello!' && logged) warned = true;
+	if (s === 'Hello warn!' && logged) warned = true;
 }
 
 console.error = function(s) {
 	console.realError(s);
-	if (s === 'Hello!' && logged && warned) Module['testPassed'] = true;
+	if (s === 'Hello error!' && logged && warned) Module['testPassed'] = true;
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5015,7 +5015,7 @@ window.close = function() {
 
   # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
   def test_emscripten_console_log(self):
-    self.btest(test_file('emscripten_console_log.c'), '0', args=['--pre-js', test_file('emscripten_console_log_pre.js')])
+    self.btest_exit(test_file('emscripten_console_log.c'), args=['--pre-js', test_file('emscripten_console_log_pre.js')])
 
   def test_emscripten_throw_number(self):
     self.btest(test_file('emscripten_throw_number.c'), '0', args=['--pre-js', test_file('emscripten_throw_number_pre.js')])

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11095,7 +11095,7 @@ void foo() {}
 
   # Test emscripten_console_log(), emscripten_console_warn() and emscripten_console_error()
   def test_emscripten_console_log(self):
-    self.do_runf(test_file('emscripten_console_log.c'), emcc_args=['--pre-js', test_file('emscripten_console_log_pre.js')])
+    self.do_run_in_out_file_test(test_file('emscripten_console_log.c'), emcc_args=['--pre-js', test_file('emscripten_console_log_pre.js')])
 
   # Tests emscripten_unwind_to_js_event_loop() behavior
   def test_emscripten_unwind_to_js_event_loop(self, *args):


### PR DESCRIPTION
This matches the default mapping of the `err` JS helper function.

This change allows us to correctly run test_emscripten_console_log.
This test was previously not running correctly but this was going
unnoticed because the test was return zero in all cases.

Alternatively, we could go the other direction and change `err` to map to
console.error, but I think it makes sense the defulat `err` and the
default `printErr` map to the same thing.