### PR TITLE
Avoid overriding printErr in example shell html

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 3.0.0
 ------
+- The example `shell.html` and `shell_minimal.html` templaces no longer override
+  `printErr` on the module object.  This means error message from emscripten and
+  stderr from the application will go to the default location of `console.warn`
+  rather than `console.error`.  This only effects application that use the
+  example shell html files.
 - The version of musl libc used by emscripten was upgraded from v1.1.15 to
   v1.2.2.  There could be some minor size regressions (or gains) due to changes
   in upstream musl code but we don't expect anything major.  Since this is a

--- a/src/shell.html
+++ b/src/shell.html
@@ -1241,10 +1241,6 @@
             }
           };
         })(),
-        printErr: function(text) {
-          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-          console.error(text);
-        },
         canvas: (function() {
           var canvas = document.getElementById('canvas');
 

--- a/src/shell_minimal.html
+++ b/src/shell_minimal.html
@@ -93,10 +93,6 @@
             }
           };
         })(),
-        printErr: function(text) {
-          if (arguments.length > 1) text = Array.prototype.slice.call(arguments).join(' ');
-          console.error(text);
-        },
         canvas: (function() {
           var canvas = document.getElementById('canvas');
 


### PR DESCRIPTION
The default version of `printErr` already writes to the console so the
override is not actually doing anything useful.

However because the override is writing to console.error rather than
console.warn which is the default in `shell.js` this override can actually
cause some confusion.  Specifcally the `test_emscripten_console_log` test
expects `err` to be going to a certain place and this override was
meaning the place it was going was different when building with the html
shell vs the default.

As an alternative we should leave these overrides in as an example but
use `console.warn` instead.  I'm inclined not to do that though since is
add complexity to these shell files.