### PR TITLE
Build libc and other core libraries for wasm64 in CI. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,10 @@ commands:
             ./embuilder build MINIMAL --lto
             ./tests/runner test_hello_world
       - run:
+          name: embuilder (WASM64)
+          command: |
+            ./embuilder build MINIMAL --wasm64
+      - run:
           name: embuilder (PIC)
           command: |
             ./embuilder build SYSTEM --pic

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1189,6 +1189,11 @@ class libmalloc(MTLibrary):
   def can_use(self):
     return super().can_use() and settings.MALLOC != 'none'
 
+  def can_build(self):
+    # emmalloc is not currently compatible with 64-bit pointers.  See
+    # the comment at the top of emmalloc.c.
+    return not self.malloc.startswith('emmalloc') or not settings.MEMORY64
+
   @classmethod
   def vary_on(cls):
     return super().vary_on() + ['is_debug', 'use_errno', 'is_tracing', 'memvalidate', 'verbose']


### PR DESCRIPTION
Even though we don't run any tests under wasm64 yet we want to avoid
regressions in the building the core libraries.

Mark emmalloc as not buildable under wasm64 but it currently assumes
32-bit pointer size.