### PR TITLE
Module attribute to customize fetch() settings

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -851,7 +851,7 @@ function getBinaryPromise() {
       && !isFileURI(wasmBinaryFile)
 #endif
     ) {
-      return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function(response) {
+      return fetch(wasmBinaryFile, Module['fetchSettings'] || { credentials: 'same-origin' }).then(function(response) {
         if (!response['ok']) {
           throw "failed to load wasm binary file at '" + wasmBinaryFile + "'";
         }
@@ -1201,7 +1201,7 @@ function createWasm() {
         !isFileURI(wasmBinaryFile) &&
 #endif
         typeof fetch === 'function') {
-      return fetch(wasmBinaryFile, { credentials: 'same-origin' }).then(function (response) {
+      return fetch(wasmBinaryFile, Module['fetchSettings'] || { credentials: 'same-origin' }).then(function (response) {
         var result = WebAssembly.instantiateStreaming(response, info);
 
 #if USE_OFFSET_CONVERTER


### PR DESCRIPTION
A wasm binary is typically loaded by the emscripten preamble using the JS fetch API. There currently exists the [locateFile](https://emscripten.org/docs/api_reference/module.html#Module.locateFile) Module property, to provide a function that can derive a URL out of the file name and path.

But the two calls to fetch hardcode a specific set of options (`credentials: same-origin`). It would be useful to be able to customize this.

With this proposal, the fetch calls would use the customized settings if provided, or fall back to the default otherwise. You could set any field available in the `init` argument ([docs](https://developer.mozilla.org/en-US/docs/Web/API/fetch)).

You could then have code like:
```
Module['fetchSettings'] = {
  credentials: 'omit',
  cache: 'no-store',
  headers: {
    some-custom-header: 'foo'
  }
}
```

This provides a lot more flexibility in how wasm modules are hosted, beyond just the url, in terms of things like cache control, cors settings, cookies, header-based auth, header-based request IDs, etc.

Thoughts @sbc100? I imagine there's some more work involved, but wanted to put the idea out first. Some guesses on what else is needed:
- Documentation in general
- We'd probably want the same support for [source maps](https://github.com/emscripten-core/emscripten/blob/4d864df0a57024d667e8db171aab2c3385d04c30/src/source_map_support.js#L113) right? Module is guaranteed to be defined there because it's pasted in early on in preamble.js?
- We could wrap this logic in a function and use the `expectToReceiveOnModule` macro to make it easy to strip code, but I imagine if the change is this small, maybe it's not worth it?
- We'd want this in the global [list](https://github.com/emscripten-core/emscripten/blob/9ecfa19d6790bcbfdf6ec23b56a4c361ba73d398/src/settings.js#L843) of incoming properties maybe?