### PR TITLE
Cleanup JavaScript assertion info when message is undefined

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -69,7 +69,14 @@ var EXITSTATUS;
 /** @type {function(*, string=)} */
 function assert(condition, text) {
   if (!condition) {
-    abort('Assertion failed: ' + text);
+#if ASSERTIONS
+    abort('Assertion failed' + (text ? ': ' + text : ''));
+#else
+    // This build was created without ASSERTIONS defined.  `assert()` should not
+    // ever be called in this configuration but in case there are callers in
+    // the wild leave this simple abort() implemenation here for now.
+    abort(text);
+#endif
   }
 }
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -39,7 +39,7 @@ function dump(item) {
 
 function assert(a, msg) {
   if (!a) {
-    msg = 'Assertion failed: ' + msg;
+    msg = 'Assertion failed' + (msg ? ': ' + msg : '');
     print(msg);
     printErr('Stack: ' + new Error().stack);
     throw msg;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7132,6 +7132,8 @@ someweirdtext
     # Export things on "TheModule". This matches the typical use pattern of the bound library
     # being used as Box2D.* or Ammo.*, and we cannot rely on "Module" being always present (closure may remove it).
     self.emcc_args += ['-s', 'EXPORTED_FUNCTIONS=_malloc,_free', '--post-js=glue.js', '--extern-post-js=extern-post.js']
+    if mode == 'ALL':
+      self.emcc_args += ['-sASSERTIONS']
     if allow_memory_growth:
       self.set_setting('ALLOW_MEMORY_GROWTH')
 

--- a/tests/webidl/output_ALL.txt
+++ b/tests/webidl/output_ALL.txt
@@ -109,5 +109,3 @@ Aborted(Assertion failed: [CHECK FAILED] Parent::Parent(val:val): Expecting <int
 Parent:42
 Aborted(Assertion failed: [CHECK FAILED] Parent::voidStar(something:something): Expecting <pointer>)
 Aborted(Assertion failed: [CHECK FAILED] StringUser::Print(anotherString:anotherString): Expecting <string>)
-
-done.


### PR DESCRIPTION
When JS libray code calles `assert` without a message we were aborting
with `Aborted(Assertion failed: undefined)` which can be confusing
because it sounds like the assert was related to something being
undefined at runtime whereas the `undefined` is referring to the fact
that the assert had no explanatory text.