### PR TITLE
Fix readdir result for `..` entry

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -119,9 +119,8 @@ var SyscallsLibrary = {
         // need a valid mode
         return -{{{ cDefine('EINVAL') }}};
       }
-      var node;
       var lookup = FS.lookupPath(path, { follow: true });
-      node = lookup.node;
+      var node = lookup.node;
       if (!node) {
         return -{{{ cDefine('ENOENT') }}};
       }
@@ -863,7 +862,8 @@ var SyscallsLibrary = {
         type = 4; // DT_DIR
       }
       else if (name === '..') {
-        id = FS.lookupPath(stream.path, { parent: true }).id;
+        var lookup = FS.lookupPath(stream.path, { parent: true });
+        id = lookup.node.id;
         type = 4; // DT_DIR
       }
       else {

--- a/tests/dirent/test_readdir_empty.c
+++ b/tests/dirent/test_readdir_empty.c
@@ -15,24 +15,24 @@
 int main(int argc, char** argv) {
   if (mkdir("/tmp", S_IRWXG) != 0 && errno != EEXIST) {
     printf("Unable to create dir '/tmp'\n");
-    return -1;
+    return 1;
   }
 
-  if (mkdir("/tmp/1", S_IRWXG) != 0 && errno != EEXIST) {
-    printf("Unable to create dir '/tmp/1'\n");
-    return -1;
+  if (mkdir("/tmp/foo", S_IRWXG) != 0 && errno != EEXIST) {
+    printf("Unable to create dir '/tmp/foo'\n");
+    return 1;
   }
 
-  if (mkdir("/tmp/1/", S_IRWXG) != 0 && errno != EEXIST) {
-    printf("Unable to create dir '/tmp/1/'\n");
-    return -1;
+  if (mkdir("/tmp/foo/", S_IRWXG) != 0 && errno != EEXIST) {
+    printf("Unable to create dir '/tmp/foo/'\n");
+    return 1;
   }
 
   DIR *dir = opendir("/tmp");
 
   if (!dir) {
     printf("Unable to open dir '/tmp'\n");
-    return -2;
+    return 2;
   }
 
   struct dirent *dirent;
@@ -42,13 +42,13 @@ int main(int argc, char** argv) {
 
     if (strlen(dirent->d_name) == 0) {
       printf("Found empty path!\n");
-      return -3;
+      return 3;
     }
   }
 
   closedir(dir);
 
-  printf("success\n"); 
+  printf("success\n");
 
   return 0;
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5183,6 +5183,7 @@ main( int argv, char ** argc ) {
   def test_readdir(self):
     self.do_run_in_out_file_test('dirent/test_readdir.c')
 
+  @also_with_wasm_bigint
   def test_readdir_empty(self):
     self.do_run_in_out_file_test('dirent/test_readdir_empty.c')
 


### PR DESCRIPTION
This result of `FS.lookupPath` was not being correctly interpreted
esulting in `id` being undefined which was incorrect but can go
unnoticed except with WASM_BIGINT when it will cause makeSetValue to
fail.

Fixes: #15333