### PR TITLE
parseTools.js: Remove a lot of dead code. NFC

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,16 @@ See docs/process.md for more on how version tagging works.
 
 3.0.0
 ------
+- A set of internally-unused functions were removed from `parseTools.js`.  While
+  emscripten no longer needs any of these functions, there is slim chance that
+  some external JS library is depending on them.  Please file issues if any such
+  library code is found.  The removed/unused functions are:
+   `removePointing`, `pointingLevels`, `removeAllPointing`, `isVoidType`,
+   `isStructPointerType`, `isArrayType`, `isStructType`, `isVectorType`,
+   `isStructuralType` `getStructuralTypeParts`, `getStructuralTypePartBits`,
+   `isFunctionDef`, `isPossiblyFunctionType`, `isFunctionType`, `getReturnType`,
+   `splitTokenList`, `_IntToHex`, `IEEEUnHex`, `Compiletime.isPointerType`,
+   `Compiletime.isStructType`, `Compiletime.INT_TYPES`, `isType`.
 - The example `shell.html` and `shell_minimal.html` templaces no longer override
   `printErr` on the module object.  This means error message from emscripten and
   stderr from the application will go to the default location of `console.warn`

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -7,14 +7,6 @@
 //"use strict";
 
 var Compiletime = {
-  isPointerType: isPointerType,
-  isStructType: isStructType,
-
-  isNumberType: function(type) {
-    return type in Compiletime.INT_TYPES || type in Compiletime.FLOAT_TYPES;
-  },
-
-  INT_TYPES: set('i1', 'i8', 'i16', 'i32', 'i64'),
   FLOAT_TYPES: set('float', 'double'),
 };
 


### PR DESCRIPTION
There are no internal users of these functions.

Although these functions are potentially exposed to library
code outside of emscripten, I believe they all date back
to the factcomp era and don't make sense to use today. 
It also doesn't seem practical to keep around all this untests
and unmaintained code.