### PR TITLE
Remove `Compiletime` from src/runtime.js. NFC

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -6,10 +6,6 @@
 
 //"use strict";
 
-var Compiletime = {
-  FLOAT_TYPES: set('float', 'double'),
-};
-
 // code used both at compile time and runtime is defined here, then put on
 // the Runtime object for compile time and support.js for the generated code
 


### PR DESCRIPTION
Since #15575 landed this object is basically empty and the remaining
FLOAT_TYPES can be moved to `parseTools.js` which is the only place it
gets used.