### PR TITLE
Remove unnecessary getPointerSize function. NFC

### DIFF
--- a/src/runtime.js
+++ b/src/runtime.js
@@ -13,9 +13,7 @@ var Compiletime = {
 // code used both at compile time and runtime is defined here, then put on
 // the Runtime object for compile time and support.js for the generated code
 
-function getPointerSize() {
-  return MEMORY64 ? 8 : 4;
-}
+const POINTER_SIZE = MEMORY64 ? 8 : 4;
 
 function getNativeTypeSize(type) {
   switch (type) {
@@ -27,7 +25,7 @@ function getNativeTypeSize(type) {
     case 'double': return 8;
     default: {
       if (type[type.length-1] === '*') {
-        return getPointerSize();
+        return POINTER_SIZE;
       } else if (type[0] === 'i') {
         var bits = Number(type.substr(1));
         assert(bits % 8 === 0, 'getNativeTypeSize invalid bits ' + bits + ', type ' + type);
@@ -49,6 +47,6 @@ var Runtime = {
     return Math.max(getNativeTypeSize(type), Runtime.QUANTUM_SIZE);
   },
 
-  POINTER_SIZE: getPointerSize(),
-  QUANTUM_SIZE: getPointerSize(),
+  POINTER_SIZE: POINTER_SIZE,
+  QUANTUM_SIZE: POINTER_SIZE,
 };

--- a/src/support.js
+++ b/src/support.js
@@ -5,10 +5,7 @@
  */
 
 var STACK_ALIGN = {{{ STACK_ALIGN }}};
-
-function getPointerSize() {
-  return {{{ MEMORY64 ? 8 : 4 }}};
-}
+var POINTER_SIZE = {{{ MEMORY64 ? 8 : 4 }}};
 
 {{{ getNativeTypeSize }}}
 


### PR DESCRIPTION
This can just be a constant.  Since this was only added recently in
PR #15579 its unlikely external library authors will be using it yet.