### PR TITLE
Fix for try_delete

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -74,6 +74,8 @@ EMMAKE = shared.bat_suffix(path_from_root('emmake'))
 def delete_contents(pathname):
   for entry in os.listdir(pathname):
     try_delete(os.path.join(pathname, entry))
+    # TODO(sbc): Should we make try_delete have a stronger guarantee?
+    assert not os.path.exists(os.path.join(pathname, entry))
 
 
 def test_file(*path_components):

--- a/tests/dirent/test_readdir.c
+++ b/tests/dirent/test_readdir.c
@@ -16,9 +16,11 @@
 #include <unistd.h>
 #include <sys/stat.h>
 
+#define CHECK(cond) if (!(cond)) { printf("errno: %s\n", strerror(errno)); assert(cond); }
+
 static void create_file(const char *path, const char *buffer, int mode) {
   int fd = open(path, O_WRONLY | O_CREAT | O_EXCL, mode);
-  assert(fd >= 0);
+  CHECK(fd >= 0);
 
   int err = write(fd, buffer, sizeof(char) * strlen(buffer));
   assert(err ==  (sizeof(char) * strlen(buffer)));
@@ -29,12 +31,12 @@ static void create_file(const char *path, const char *buffer, int mode) {
 void setup() {
   int err;
   err = mkdir("testtmp", 0777);  // can't call it tmp, that already exists
-  assert(!err);
+  CHECK(!err);
   chdir("testtmp");
   err = mkdir("nocanread", 0111);
-  assert(!err);
+  CHECK(!err);
   err = mkdir("foobar", 0777);
-  assert(!err);
+  CHECK(!err);
   create_file("foobar/file.txt", "ride into the danger zone", 0666);
 }
 

--- a/tools/tempfiles.py
+++ b/tools/tempfiles.py
@@ -27,13 +27,14 @@ def try_delete(pathname):
   if not os.path.exists(pathname):
     return
 
-  write_bits = stat.S_IWRITE | stat.S_IWGRP | stat.S_IWOTH
+  # Ensure all files are readable and writable by the current user.
+  permission_bits = stat.S_IWRITE | stat.S_IREAD
 
   def is_writable(path):
-    return (os.stat(path).st_mode & write_bits) == write_bits
+    return (os.stat(path).st_mode & permission_bits) != permission_bits
 
   def make_writable(path):
-    os.chmod(path, os.stat(path).st_mode | write_bits)
+    os.chmod(path, os.stat(path).st_mode | permission_bits)
 
   # Some tests make files and subdirectories read-only, so rmtree/unlink will not delete
   # them. Force-make everything writable in the subdirectory to make it


### PR DESCRIPTION
The code was checking only for writability but we also
need readabiity when recursively removing directories.

Without this change `wasm0.test_readdir` fails when run
with `--save-dir`.  This is because in `--save-dir` mode
the test direcotory is cleared using `delete_contents`
rather than created from scratch.