### PR TITLE
Fix for lookupPath and lookup under NODERAWFS

### DIFF
--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -14,12 +14,16 @@ mergeInto(LibraryManager.library, {
     'else { throw new Error("NODERAWFS is currently only supported on Node.js environment.") }',
   $NODERAWFS: {
     lookup: function(parent, name) {
-      return FS.lookupPath(parent.path + '/' + name);
+      return FS.lookupPath(parent.path + '/' + name).node;
     },
-    lookupPath: function(path) {
+    lookupPath: function(path, opts) {
+      opts = opts || {};
+      if (opts.parent) {
+        path = NODEJS_PATH.dirname(path);
+      }
       var st = fs.lstatSync(path);
       var mode = NODEFS.getMode(path);
-      return { path: path, id: st.ino, mode: mode, node: { mode: mode } };
+      return { path: path, node: { id: st.ino, mode: mode }};
     },
     createStandardStreams: function() {
       FS.streams[0] = { fd: 0, nfd: 0, position: 0, path: '', flags: 0, tty: true, seekable: false };

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -874,6 +874,9 @@ var SyscallsLibrary = {
                FS.isLink(child.mode) ? 10 :   // DT_LNK, symbolic link.
                8;                             // DT_REG, regular file.
       }
+#if ASSERTIONS
+      assert(id);
+#endif
       {{{ makeSetValue('dirp + pos', C_STRUCTS.dirent.d_ino, 'id', 'i64') }}};
       {{{ makeSetValue('dirp + pos', C_STRUCTS.dirent.d_off, '(idx + 1) * struct_size', 'i64') }}};
       {{{ makeSetValue('dirp + pos', C_STRUCTS.dirent.d_reclen, C_STRUCTS.dirent.__size__, 'i16') }}};

--- a/tests/dirent/test_readdir.c
+++ b/tests/dirent/test_readdir.c
@@ -119,32 +119,36 @@ void test() {
   // test rewinddir
   rewinddir(dir);
   ent = readdir(dir);
+  assert(ent && ent->d_ino);
   assert(!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..") || !strcmp(ent->d_name, "file.txt"));
 
   // test seek / tell
   rewinddir(dir);
   ent = readdir(dir);
+  assert(ent && ent->d_ino);
   assert(!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..") || !strcmp(ent->d_name, "file.txt"));
   loc = telldir(dir);
   assert(loc >= 0);
   //printf("loc=%d\n", loc);
   loc2 = ent->d_off;
   ent = readdir(dir);
+  assert(ent && ent->d_ino);
   char name_at_loc[1024];
   strcpy(name_at_loc, ent->d_name);
   //printf("name_at_loc: %s\n", name_at_loc);
   assert(!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..") || !strcmp(ent->d_name, "file.txt"));
   ent = readdir(dir);
+  assert(ent && ent->d_ino);
   assert(!strcmp(ent->d_name, ".") || !strcmp(ent->d_name, "..") || !strcmp(ent->d_name, "file.txt"));
   seekdir(dir, loc);
   ent = readdir(dir);
-  assert(ent);
+  assert(ent && ent->d_ino);
   //printf("check: %s / %s\n", ent->d_name, name_at_loc);
   assert(!strcmp(ent->d_name, name_at_loc));
 
   seekdir(dir, loc2);
   ent = readdir(dir);
-  assert(ent);
+  assert(ent && ent->d_ino);
   //printf("check: %s / %s\n", ent->d_name, name_at_loc);
   assert(!strcmp(ent->d_name, name_at_loc));
 


### PR DESCRIPTION
This `FS.lookupPath` to correct return an object with
exaclyt two keys (path, node), and `lookup` to return
the a node.

Without this FS.lookupPath was returning a object with
partially formed node which was causing __syscall_getdents64
to set all inodes to 0/undefined.

See: #15578