### PR TITLE
Unify importing of node fs and path modules

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -6,7 +6,7 @@
 
 mergeInto(LibraryManager.library, {
   $NODEFS__deps: ['$FS', '$PATH', '$ERRNO_CODES', '$mmapAlloc'],
-  $NODEFS__postset: 'if (ENVIRONMENT_IS_NODE) { var fs = require("fs"); var NODEJS_PATH = require("path"); NODEFS.staticInit(); }',
+  $NODEFS__postset: 'if (ENVIRONMENT_IS_NODE) { requireNodeFS(); NODEFS.staticInit(); }',
   $NODEFS: {
     isWindows: false,
     staticInit: function() {
@@ -227,7 +227,7 @@ mergeInto(LibraryManager.library, {
         var path = NODEFS.realPath(node);
         try {
           path = fs.readlinkSync(path);
-          path = NODEJS_PATH.relative(NODEJS_PATH.resolve(node.mount.opts.root), path);
+          path = nodePath.relative(nodePath.resolve(node.mount.opts.root), path);
           return path;
         } catch (e) {
           if (!e.code) throw e;

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -19,7 +19,7 @@ mergeInto(LibraryManager.library, {
     lookupPath: function(path, opts) {
       opts = opts || {};
       if (opts.parent) {
-        path = NODEJS_PATH.dirname(path);
+        path = nodePath.dirname(path);
       }
       var st = fs.lstatSync(path);
       var mode = NODEFS.getMode(path);

--- a/src/library_tty.js
+++ b/src/library_tty.js
@@ -112,7 +112,7 @@ mergeInto(LibraryManager.library, {
             var bytesRead = 0;
 
             try {
-              bytesRead = nodeFS.readSync(process.stdin.fd, buf, 0, BUFSIZE, null);
+              bytesRead = fs.readSync(process.stdin.fd, buf, 0, BUFSIZE, null);
             } catch(e) {
               // Cross-platform differences: on Windows, reading EOF throws an exception, but on other OSes,
               // reading EOF returns 0. Uniformize behavior by treating the EOF exception to return 0.

--- a/src/node_shell_read.js
+++ b/src/node_shell_read.js
@@ -4,6 +4,15 @@
  * SPDX-License-Identifier: MIT
  */
 
+requireNodeFS = function() {
+  // We always initialize both of these together, so we can use
+  // either one as the indicator for them not being initialized.
+  if (!fs) {
+    fs = require('fs');
+    nodePath = require('path');
+  }
+}
+
 read_ = function shell_read(filename, binary) {
 #if SUPPORT_BASE64_EMBEDDING
   var ret = tryParseAsDataURI(filename);
@@ -11,10 +20,9 @@ read_ = function shell_read(filename, binary) {
     return binary ? ret : ret.toString();
   }
 #endif
-  if (!nodeFS) nodeFS = require('fs');
-  if (!nodePath) nodePath = require('path');
+  requireNodeFS();
   filename = nodePath['normalize'](filename);
-  return nodeFS['readFileSync'](filename, binary ? null : 'utf8');
+  return fs.readFileSync(filename, binary ? null : 'utf8');
 };
 
 readBinary = function readBinary(filename) {
@@ -35,10 +43,9 @@ readAsync = function readAsync(filename, onload, onerror) {
     onload(ret);
   }
 #endif
-  if (!nodeFS) nodeFS = require('fs');
-  if (!nodePath) nodePath = require('path');
+  requireNodeFS();
   filename = nodePath['normalize'](filename);
-  nodeFS['readFile'](filename, function(err, data) {
+  fs.readFile(filename, function(err, data) {
     if (err) onerror(err);
     else onload(data.buffer);
   });

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -927,14 +927,14 @@ function instantiateSync(file, info) {
       // to load ok, but we do actually recompile the binary every time).
       var cachedCodeFile = '{{{ WASM_BINARY_FILE }}}.' + v8.cachedDataVersionTag() + '.cached';
       cachedCodeFile = locateFile(cachedCodeFile);
-      if (!nodeFS) nodeFS = require('fs');
-      var hasCached = nodeFS.existsSync(cachedCodeFile);
+      requireNodeFS();
+      var hasCached = fs.existsSync(cachedCodeFile);
       if (hasCached) {
 #if RUNTIME_LOGGING
         err('NODE_CODE_CACHING: loading module');
 #endif
         try {
-          module = v8.deserialize(nodeFS.readFileSync(cachedCodeFile));
+          module = v8.deserialize(fs.readFileSync(cachedCodeFile));
         } catch (e) {
           err('NODE_CODE_CACHING: failed to deserialize, bad cache file? (' + cachedCodeFile + ')');
           // Save the new compiled code when we have it.
@@ -949,7 +949,7 @@ function instantiateSync(file, info) {
 #if RUNTIME_LOGGING
       err('NODE_CODE_CACHING: saving module');
 #endif
-      nodeFS.writeFileSync(cachedCodeFile, v8.serialize(module));
+      fs.writeFileSync(cachedCodeFile, v8.serialize(module));
     }
 #else // NODE_CODE_CACHING
     module = new WebAssembly.Module(binary);

--- a/src/shell.js
+++ b/src/shell.js
@@ -174,8 +174,9 @@ function logExceptionOnExit(e) {
 #endif
 
 #if ENVIRONMENT_MAY_BE_NODE
-var nodeFS;
+var fs;
 var nodePath;
+var requireNodeFS;
 
 if (ENVIRONMENT_IS_NODE) {
 #if ENVIRONMENT
@@ -248,7 +249,7 @@ if (ENVIRONMENT_IS_NODE) {
 #if WASM == 2
   // If target shell does not support Wasm, load the JS version of the code.
   if (typeof WebAssembly === 'undefined') {
-    var fs = require('fs');
+    requireNodeFS();
     eval(fs.readFileSync(locateFile('{{{ TARGET_BASENAME }}}.wasm.js'))+'');
   }
 #endif
@@ -403,7 +404,7 @@ if (ENVIRONMENT_IS_NODE) {
 var defaultPrint = console.log.bind(console);
 var defaultPrintErr = console.warn.bind(console);
 if (ENVIRONMENT_IS_NODE) {
-  var fs = require('fs');
+  requireNodeFS();
   defaultPrint = function(str) { fs.writeSync(1, str + '\n'); };
   defaultPrintErr = function(str) { fs.writeSync(2, str + '\n'); };
 }

--- a/tests/other/test_split_module.post.js
+++ b/tests/other/test_split_module.post.js
@@ -5,7 +5,7 @@ function saveProfileData() {
     var offset = _malloc(len);
     var actualLen = __write_profile(offset, len);
     var profile_data = new Uint8Array(buffer, offset, len);
-    nodeFS.writeFileSync('profile.data', profile_data);
+    fs.writeFileSync('profile.data', profile_data);
     console.log('profile size is', actualLen, 'bytes (allocated', len, 'bytes)');
     console.log('wrote profile data')
     _free(offset);


### PR DESCRIPTION
We were importing these modules in different places and
under different names.  I went with `fs` for the name
of the `fs` import since that is what `library_nodefs.js`
and it is by far the heaviest user of this module.