### PR TITLE
Avoid using assert except when ASSERTIONS is defined

### DIFF
--- a/src/node_shell_read.js
+++ b/src/node_shell_read.js
@@ -22,7 +22,9 @@ readBinary = function readBinary(filename) {
   if (!ret.buffer) {
     ret = new Uint8Array(ret);
   }
+#if ASSERTIONS
   assert(ret.buffer);
+#endif
   return ret;
 };
 

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -76,7 +76,9 @@ function assert(condition, text) {
 // Returns the C function with a specified identifier (for C++, you need to do manual name mangling)
 function getCFunc(ident) {
   var func = Module['_' + ident]; // closure exported function
+#if ASSERTIONS
   assert(func, 'Cannot call unknown function ' + ident + ', make sure it is exported');
+#endif
   return func;
 }
 


### PR DESCRIPTION
assert() is really designed to be used in ASSERTIONS mode
and should not be used in release.  This change updates all
the places in the codebase where we were doing this.

I'm not sure about that value of throwing `new Error` vs
just thrown raw strings in library_dylink.js but there is
already one place where new Error is used, and we can
switch them over later as needed.