### PR TITLE
Fix bad closure version check error print

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -684,7 +684,7 @@ def check_closure_compiler(cmd, args, env, allowed_to_fail):
     if isinstance(e, subprocess.CalledProcessError):
       sys.stderr.write(e.stdout)
     sys.stderr.write(str(e) + '\n')
-    exit_with_error('closure compiler ("%s --version") did not execute properly!' % str(cmd))
+    exit_with_error('closure compiler (%s) did not execute properly!' % str(cmd))
 
   if 'Version:' not in output:
     if allowed_to_fail:


### PR DESCRIPTION
Closure check failure would print out

```
emcc: error: closure compiler ("['E:\\code\\emsdk\\emscripten\\main\\node_modules\\.bin\\google-closure-compiler.cmd', '--platform=java', '--version'] --version") did not execute properly!
```
now prints
```
emcc: error: closure compiler (['E:\\code\\emsdk\\emscripten\\main\\node_modules\\.bin\\google-closure-compiler.cmd', '--platform=java', '--version']) did not execute properly!
```
