### PR TITLE
Fix check_type_size for Cmake when building with pthreads enabled

### DIFF
--- a/emcmake.py
+++ b/emcmake.py
@@ -35,9 +35,10 @@ variables so that emcc etc. are used. Typical usage:
 
   if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
     node_js = config.NODE_JS[0]
-    # In order to allow cmake to run code built with pthreads we need to pass extra flags to node.
+    # In order to allow cmake to run code built with pthreads we need to pass some extra flags to node.
+    # Note that we also need --experimental-wasm-bulk-memory which is true by default and hence not added here
     # See https://github.com/emscripten-core/emscripten/issues/15522
-    args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js};--experimental-wasm-threads;--experimental-wasm-bulk-memory')
+    args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js};--experimental-wasm-threads')
 
   # On Windows specify MinGW Makefiles or ninja if we have them and no other
   # toolchain was specified, to keep CMake from pulling in a native Visual

--- a/emcmake.py
+++ b/emcmake.py
@@ -35,7 +35,8 @@ variables so that emcc etc. are used. Typical usage:
 
   if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
     node_js = config.NODE_JS[0]
-    # See https://github.com/emscripten-core/emscripten/issues/15522 for why we enable additional flags
+    # In order to allow cmake to run code built with pthreads we need to pass extra flags to node.
+    # See https://github.com/emscripten-core/emscripten/issues/15522
     args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js};--experimental-wasm-threads;--experimental-wasm-bulk-memory')
 
   # On Windows specify MinGW Makefiles or ninja if we have them and no other

--- a/emcmake.py
+++ b/emcmake.py
@@ -35,7 +35,8 @@ variables so that emcc etc. are used. Typical usage:
 
   if not has_substr(args, '-DCMAKE_CROSSCOMPILING_EMULATOR'):
     node_js = config.NODE_JS[0]
-    args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js}')
+    # See https://github.com/emscripten-core/emscripten/issues/15522 for why we enable additional flags
+    args.append(f'-DCMAKE_CROSSCOMPILING_EMULATOR={node_js};--experimental-wasm-threads;--experimental-wasm-bulk-memory')
 
   # On Windows specify MinGW Makefiles or ninja if we have them and no other
   # toolchain was specified, to keep CMake from pulling in a native Visual

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -592,7 +592,7 @@ f.close()
     # would take 10 minutes+ to finish (CMake feature detection is slow), so
     # combine multiple features into one to try to cover as much as possible
     # while still keeping this test in sensible time limit.
-    'js':          ('target_js',      'test_cmake.js',         ['-DCMAKE_BUILD_TYPE=Debug']),
+    'js':          ('target_js',      'test_cmake.js',         ['-DCMAKE_BUILD_TYPE=Debug', '-DCMAKE_C_FLAGS_INIT=-pthread']),
     'html':        ('target_html',    'hello_world_gles.html', ['-DCMAKE_BUILD_TYPE=Release']),
     'library':     ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=MinSizeRel']),
     'static_cpp':  ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DCPP_LIBRARY_TYPE=STATIC']),

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -592,7 +592,7 @@ f.close()
     # would take 10 minutes+ to finish (CMake feature detection is slow), so
     # combine multiple features into one to try to cover as much as possible
     # while still keeping this test in sensible time limit.
-    'js':          ('target_js',      'test_cmake.js',         ['-DCMAKE_BUILD_TYPE=Debug', '-DCMAKE_C_FLAGS_INIT=-pthread']),
+    'js':          ('target_js',      'test_cmake.js',         ['-DCMAKE_BUILD_TYPE=Debug']),
     'html':        ('target_html',    'hello_world_gles.html', ['-DCMAKE_BUILD_TYPE=Release']),
     'library':     ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=MinSizeRel']),
     'static_cpp':  ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DCPP_LIBRARY_TYPE=STATIC']),
@@ -709,6 +709,11 @@ f.close()
       self.assertTrue(building.is_ar('myprefix_static_lib.somecustomsuffix'))
     else:
       self.assertTrue(building.is_ar('libstatic_lib.a'))
+
+  # Tests that cmake functions which require evaluation via the node runtime run properly with pthreads
+  def test_cmake_pthreads(self):
+    self.run_process([EMCMAKE, 'cmake', '-DCMAKE_C_FLAGS_INIT=-pthread', test_file('cmake/target_js')])
+    self.run_process(['cmake', '--build', '.'])
 
   # Tests that the CMake variable EMSCRIPTEN_VERSION is properly provided to user CMake scripts
   def test_cmake_emscripten_version(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -712,7 +712,7 @@ f.close()
 
   # Tests that cmake functions which require evaluation via the node runtime run properly with pthreads
   def test_cmake_pthreads(self):
-    self.run_process([EMCMAKE, 'cmake', '-DCMAKE_C_FLAGS_INIT=-pthread', test_file('cmake/target_js')])
+    self.run_process([EMCMAKE, 'cmake', '-DCMAKE_C_FLAGS=-pthread', test_file('cmake/target_js')])
 
   # Tests that the CMake variable EMSCRIPTEN_VERSION is properly provided to user CMake scripts
   def test_cmake_emscripten_version(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -713,7 +713,6 @@ f.close()
   # Tests that cmake functions which require evaluation via the node runtime run properly with pthreads
   def test_cmake_pthreads(self):
     self.run_process([EMCMAKE, 'cmake', '-DCMAKE_C_FLAGS_INIT=-pthread', test_file('cmake/target_js')])
-    self.run_process(['cmake', '--build', '.'])
 
   # Tests that the CMake variable EMSCRIPTEN_VERSION is properly provided to user CMake scripts
   def test_cmake_emscripten_version(self):


### PR DESCRIPTION
Addresses the cmake part of https://github.com/emscripten-core/emscripten/issues/15522