### PR TITLE
exception deleting empty path

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -306,8 +306,10 @@ var SyscallsLibrary = {
     return stream.fd;
   },
   __syscall_unlink: function(path) {
-    path = SYSCALLS.getStr(path);
-    FS.unlink(path);
+    if (path.length) {
+      path = SYSCALLS.getStr(path);
+      FS.unlink(path);
+    }
     return 0;
   },
   __syscall_chdir: function(path) {
@@ -591,7 +593,7 @@ var SyscallsLibrary = {
     for (var i = 0; i < num; i++) {
       var iovbase = {{{ makeGetValue('iov', '(' + C_STRUCTS.iovec.__size__ + ' * i) + ' + C_STRUCTS.iovec.iov_base, 'i8*') }}};
       var iovlen = {{{ makeGetValue('iov', '(' + C_STRUCTS.iovec.__size__ + ' * i) + ' + C_STRUCTS.iovec.iov_len, 'i32') }}};
-      for (var j = 0; j < iovlen; j++) {  
+      for (var j = 0; j < iovlen; j++) {
         view[offset++] = {{{ makeGetValue('iovbase', 'j', 'i8') }}};
       }
     }
@@ -672,7 +674,7 @@ var SyscallsLibrary = {
 #endif
 
     var total = 0;
-    
+
     var srcReadLow = (readfds ? {{{ makeGetValue('readfds', 0, 'i32') }}} : 0),
         srcReadHigh = (readfds ? {{{ makeGetValue('readfds', 4, 'i32') }}} : 0);
     var srcWriteLow = (writefds ? {{{ makeGetValue('writefds', 0, 'i32') }}} : 0),
@@ -739,7 +741,7 @@ var SyscallsLibrary = {
       {{{ makeSetValue('exceptfds', '0', 'dstExceptLow', 'i32') }}};
       {{{ makeSetValue('exceptfds', '4', 'dstExceptHigh', 'i32') }}};
     }
-    
+
     return total;
   },
   __syscall_msync: function(addr, len, flags) {

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -306,8 +306,8 @@ var SyscallsLibrary = {
     return stream.fd;
   },
   __syscall_unlink: function(path) {
+    path = SYSCALLS.getStr(path);
     if (path.length) {
-      path = SYSCALLS.getStr(path);
       FS.unlink(path);
     }
     return 0;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5445,6 +5445,22 @@ Module['onRuntimeInitialized'] = function() {
   def test_fs_64bit(self):
     self.do_runf(test_file('fs/test_64bit.c'), 'success')
 
+  def test_fs_delete_empty(self):
+    self.set_setting('FORCE_FILESYSTEM')
+    self.emcc_args += ['-std=c++17']
+    src = r'''
+        #include <iostream>
+        #include <filesystem>
+        int main()
+        {
+          std::string path("");
+          std::filesystem::remove(path);
+          std::cout << "hello" << std::endl;
+          return 0;
+        }
+      '''
+    self.do_run(src, 'hello\n')
+
   def test_sigalrm(self):
     self.do_runf(test_file('test_sigalrm.c'), 'Received alarm!')
     self.set_setting('EXIT_RUNTIME')


### PR DESCRIPTION
Exception in calling std filesystem delete with empty path.


https://app.circleci.com/pipelines/github/emscripten-core/emscripten/17250/workflows/de8bd146-7e49-4d9e-b38a-bf325a1fc2b9/jobs/478574?invite=true#step-106-1926
```
TypeError: Cannot read property 'mode' of null
    at Object.nodePermissions (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:2702:50)
    at Object.mayLookup (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:2707:26)
    at Object.lookupNode (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:2641:26)
    at Object.unlink (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:3129:23)
    at ___syscall_unlink (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:4266:10)
    at <anonymous>:wasm-function[1486]:0x1ff2a
    at <anonymous>:wasm-function[1496]:0x20078
    at <anonymous>:wasm-function[20]:0x1032
    at <anonymous>:wasm-function[17]:0xec5
    at main (<anonymous>:wasm-function[116]:0x38c8)
    at /tmp/emscripten_test_wasm0_s2qqjzfm/src.js:1549:22
    at callMain (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:5399:15)
    at doRun (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:5456:23)
    at run (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:5471:5)
    at runCaller (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:5377:19)
    at removeRunDependency (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:1478:7)
    at receiveInstance (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:1638:5)
    at receiveInstantiationResult (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:1655:5)
Thrown at:
    at nodePermissions (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:2702:50)
    at mayLookup (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:2707:26)
    at lookupNode (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:2641:26)
    at unlink (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:3129:23)
    at ___syscall_unlink (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:4266:10)
    at :1:130859
    at :1:131193
    at :1:4147
    at :1:3782
    at main (:1:14537)
    at /tmp/emscripten_test_wasm0_s2qqjzfm/src.js:1549:22
    at callMain (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:5399:15)
    at doRun (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:5456:23)
    at run (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:5471:5)
    at runCaller (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:5377:19)
    at removeRunDependency (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:1478:7)
    at receiveInstance (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:1638:5)
    at receiveInstantiationResult (/tmp/emscripten_test_wasm0_s2qqjzfm/src.js:1655:5)


----------------------------------------------------------------------
Ran 1 test in 3.858s

FAILED (failures=1)
```

