### PR TITLE
Prefer to check against thread ID for musl's rwlock. NFC.

### DIFF
--- a/system/lib/libc/musl/src/internal/pthread_impl.h
+++ b/system/lib/libc/musl/src/internal/pthread_impl.h
@@ -131,7 +131,7 @@ enum {
 // XXX Emscripten: The spec allows detecting when multiple write locks would deadlock, so use an extra field
 // _rw_wr_owner to record which thread owns the write lock in order to avoid hangs.
 // Points to the pthread that currently has the write lock.
-#define _rw_wr_owner __u.__p[3]
+#define _rw_wr_owner __u.__vi[3]
 #endif
 #define _b_lock __u.__vi[0]
 #define _b_waiters __u.__vi[1]

--- a/system/lib/libc/musl/src/thread/pthread_rwlock_timedwrlock.c
+++ b/system/lib/libc/musl/src/thread/pthread_rwlock_timedwrlock.c
@@ -5,7 +5,7 @@ int __pthread_rwlock_timedwrlock(pthread_rwlock_t *restrict rw, const struct tim
 #ifdef __EMSCRIPTEN__
 	/// XXX Emscripten: The spec allows detecting when multiple write locks would deadlock, which we do here to avoid hangs.
 	/// If attempting to lock the write lock that we already own, error out.
-	if (rw->_rw_wr_owner == (void *)pthread_self()) return EDEADLK;
+	if (rw->_rw_wr_owner == __pthread_self()->tid) return EDEADLK;
 #endif
 	int r, t;
 
@@ -27,7 +27,7 @@ int __pthread_rwlock_timedwrlock(pthread_rwlock_t *restrict rw, const struct tim
 #ifdef __EMSCRIPTEN__
 	/// XXX Emscripten: The spec allows detecting when multiple write locks would deadlock, which we do here to avoid hangs.
 	/// Mark this thread as the owner of this write lock.
-	rw->_rw_wr_owner = (void *)pthread_self();
+	rw->_rw_wr_owner = __pthread_self()->tid;
 #endif
 	return r;
 }

--- a/system/lib/libc/musl/src/thread/pthread_rwlock_trywrlock.c
+++ b/system/lib/libc/musl/src/thread/pthread_rwlock_trywrlock.c
@@ -6,7 +6,7 @@ int __pthread_rwlock_trywrlock(pthread_rwlock_t *rw)
 #ifdef __EMSCRIPTEN__
 	/// XXX Emscripten: The spec allows detecting when multiple write locks would deadlock, which we do here to avoid hangs.
 	/// Mark this thread to own the write lock, to ignore multiple attempts to lock.
-	rw->_rw_wr_owner = (void *)pthread_self();
+	rw->_rw_wr_owner = __pthread_self()->tid;
 #endif
 	return 0;
 }

--- a/system/lib/libc/musl/src/thread/pthread_rwlock_unlock.c
+++ b/system/lib/libc/musl/src/thread/pthread_rwlock_unlock.c
@@ -7,7 +7,7 @@ int __pthread_rwlock_unlock(pthread_rwlock_t *rw)
 #ifdef __EMSCRIPTEN__
 	/// XXX Emscripten: The spec allows detecting when multiple write locks would deadlock, which we do here to avoid hangs.
 	/// Mark this thread to not own the write lock anymore.
-	if (rw->_rw_wr_owner == (void *)pthread_self()) rw->_rw_wr_owner = 0;
+	if (rw->_rw_wr_owner == __pthread_self()->tid) rw->_rw_wr_owner = 0;
 #endif
 
 	do {


### PR DESCRIPTION
Checking against thread IDs should be preferred instead of casting
`pthread_self` to a pointer. This should be safe to do after commit
b2cfa354366536963b8e935469b20bb5d0843c0d.

Split from PR #13007.