### PR TITLE
add bzip2

### DIFF
--- a/site/source/docs/getting_started/downloads.rst
+++ b/site/source/docs/getting_started/downloads.rst
@@ -121,8 +121,8 @@ Linux
 
   ::
 
-    # Install Python
-    sudo apt-get install python3
+    # Install Python and bzip2
+    sudo apt-get install python3 bzip2
 
     # Install CMake (optional, only needed for tests and building Binaryen or LLVM)
     sudo apt-get install cmake


### PR DESCRIPTION
I had:
```
tar (child): lbzip2: Cannot exec: No such file or directory
tar (child): Error is not recoverable: exiting now
```
I need to `sudo apt install bzip2`, so added to docs