### PR TITLE
Remove unnecessary export of memset. NFC

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1750,14 +1750,6 @@ def calculate(input_files, forced):
     if sanitize:
       add_library('libsanitizer_common_rt')
 
-    # the sanitizer runtimes may call mmap, which will need a few things. sadly
-    # the usual deps_info mechanism does not work since we scan only user files
-    # for things, and not libraries (to be able to scan libraries, we'd need to
-    # somehow figure out which of their object files will actually be linked in -
-    # but only lld knows that). so just directly handle that here.
-    if sanitize:
-      settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name('memset'))
-
     if settings.PROXY_POSIX_SOCKETS:
       add_library('libsockets_proxy')
     else:


### PR DESCRIPTION
This code is kind of in the wrong place.  If we wanted to keep
it we could move it to emcc.py:2164 where we export symbols needed
by the sanitizers:

```
  if sanitize:
    settings.USE_OFFSET_CONVERTER = 1
    settings.EXPORTED_FUNCTIONS += [
        '_memalign',
        '_emscripten_builtin_memalign',
        '_emscripten_builtin_malloc',
        '_emscripten_builtin_free',
        '___heap_base',
        '___global_base'
    ]
```

However, I don't think we do need it.  The comment set that `memset` is
needed for `mmap` but `mmap` uses the `zeroMemory` JS function which
does not depend on `memset` (perhaps it once did?)