### PR TITLE
Enable testing for __sync_fetch_and_nand.  NFC

### DIFF
--- a/tests/pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.cpp
+++ b/tests/pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.cpp
@@ -16,23 +16,6 @@
 
 #define T uint64_t
 
-#if 0
-// TEMP to make this test pass:
-// Our Clang backend doesn't define this builtin function, so implement it ourselves.
-// The current Atomics spec doesn't have the nand atomic op either, so must use a cas loop.
-// TODO: Move this to Clang backend?
-T __sync_fetch_and_nand(T *ptr, T x)
-{
-	for(;;)
-	{
-		T old = emscripten_atomic_load_u32(ptr);
-		T newVal = ~(old & x);
-		T old2 = emscripten_atomic_cas_u32(ptr, old, newVal);
-		if (old2 == old) return old;
-	}
-}
-#endif
-
 void *thread_fetch_and_add(void *arg)
 {
 	for(int i = 0; i < 10000; ++i)
@@ -69,10 +52,7 @@ void *thread_fetch_and_xor(void *arg)
 		__sync_fetch_and_xor((T*)&fetch_and_xor_data, *(T*)arg);
 	pthread_exit(0);
 }
-#if 0
 
-// XXX NAND support does not exist in Atomics API.
-#if 0
 volatile long fetch_and_nand_data = 0;
 void *thread_fetch_and_nand(void *arg)
 {
@@ -80,8 +60,7 @@ void *thread_fetch_and_nand(void *arg)
 		__sync_fetch_and_nand((long*)&fetch_and_nand_data, (long)arg);
 	pthread_exit(0);
 }
-#endif
-#endif
+
 T threadArg[NUM_THREADS];
 pthread_t thread[NUM_THREADS];
 
@@ -178,8 +157,6 @@ int main()
 			}
 		}
 	}
-// XXX NAND support does not exist in Atomics API.
-#if 0
 	{
 		T x = 5;
 		T y = __sync_fetch_and_nand(&x, 9);
@@ -194,7 +171,6 @@ int main()
 			assert(fetch_and_nand_data == -1);
 		}
 	}
-#endif
 
 	return 0;
 }

--- a/tests/pthread/test_pthread_gcc_atomic_fetch_and_op.cpp
+++ b/tests/pthread/test_pthread_gcc_atomic_fetch_and_op.cpp
@@ -16,23 +16,6 @@
 
 #define T int
 
-#if 0
-// TEMP to make this test pass:
-// Our Clang backend doesn't define this builtin function, so implement it ourselves.
-// The current Atomics spec doesn't have the nand atomic op either, so must use a cas loop.
-// TODO: Move this to Clang backend?
-T __sync_fetch_and_nand(T *ptr, T x)
-{
-	for(;;)
-	{
-		T old = emscripten_atomic_load_u32(ptr);
-		T newVal = ~(old & x);
-		T old2 = emscripten_atomic_cas_u32(ptr, old, newVal);
-		if (old2 == old) return old;
-	}
-}
-#endif
-
 void *thread_fetch_and_add(void *arg)
 {
 	for(int i = 0; i < 10000; ++i)
@@ -72,7 +55,6 @@ void *thread_fetch_and_xor(void *arg)
 }
 
 // XXX NAND support does not exist in Atomics API.
-#if 0
 volatile long fetch_and_nand_data = 0;
 void *thread_fetch_and_nand(void *arg)
 {
@@ -80,7 +62,6 @@ void *thread_fetch_and_nand(void *arg)
 		__sync_fetch_and_nand(&fetch_and_nand_data, (long)arg);
 	pthread_exit(0);
 }
-#endif
 
 pthread_t thread[NUM_THREADS];
 
@@ -161,12 +142,6 @@ int main()
 		}
 	}
 
-	// Test that regex replacing also works on these.
-	emscripten_atomic_fence();
-	__sync_synchronize();
-
-// XXX NAND support does not exist in Atomics API.
-#if 0
 	{
 		T x = 5;
 		T y = __sync_fetch_and_nand(&x, 9);
@@ -181,7 +156,10 @@ int main()
 			assert(fetch_and_nand_data == -1);
 		}
 	}
-#endif
+
+	// Test that regex replacing also works on these.
+	emscripten_atomic_fence();
+	__sync_synchronize();
 
 	return 0;
 }

--- a/tests/pthread/test_pthread_gcc_atomic_op_and_fetch.cpp
+++ b/tests/pthread/test_pthread_gcc_atomic_op_and_fetch.cpp
@@ -16,23 +16,6 @@
 
 #define T int
 
-#if 0
-// TEMP to make this test pass:
-// Our Clang backend doesn't define this builtin function, so implement it ourselves.
-// The current Atomics spec doesn't have the nand atomic op either, so must use a cas loop.
-// TODO: Move this to Clang backend?
-T __sync_nand_and_fetch(T *ptr, T x)
-{
-	for(;;)
-	{
-		T old = emscripten_atomic_load_u32(ptr);
-		T newVal = ~(old & x);
-		T old2 = emscripten_atomic_cas_u32(ptr, old, newVal);
-		if (old2 == old) return newVal;
-	}
-}
-#endif
-
 void *thread_add_and_fetch(void *arg)
 {
 	for(int i = 0; i < 10000; ++i)
@@ -71,8 +54,6 @@ void *thread_xor_and_fetch(void *arg)
 	pthread_exit(0);
 }
 
-// XXX NAND support does not exist in Atomics API.
-#if 0
 volatile long nand_and_fetch_data = 0;
 void *thread_nand_and_fetch(void *arg)
 {
@@ -80,7 +61,6 @@ void *thread_nand_and_fetch(void *arg)
 		__sync_nand_and_fetch((long*)&nand_and_fetch_data, (long)arg);
 	pthread_exit(0);
 }
-#endif
 
 pthread_t thread[NUM_THREADS];
 
@@ -160,8 +140,6 @@ int main()
 			}
 		}
 	}
-// XXX NAND support does not exist in Atomics API.
-#if 0
 	{
 		T x = 5;
 		T y = __sync_nand_and_fetch(&x, 9);
@@ -176,7 +154,6 @@ int main()
 			assert(nand_and_fetch_data == -1);
 		}
 	}
-#endif
 
 	return 0;
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3802,6 +3802,7 @@ window.close = function() {
   # Test the old GCC atomic __sync_fetch_and_op builtin operations.
   @requires_threads
   def test_pthread_gcc_atomic_fetch_and_op(self):
+    self.emcc_args += ['-Wno-sync-fetch-and-nand-semantics-changed']
     for opt in [[], ['-O1'], ['-O2'], ['-O3'], ['-Os']]:
       for debug in [[], ['-g']]:
         args = opt + debug
@@ -3812,19 +3813,26 @@ window.close = function() {
   @also_with_wasm2js
   @requires_threads
   def test_pthread_gcc_64bit_atomic_fetch_and_op(self):
+    if not self.is_wasm():
+      self.skipTest('https://github.com/WebAssembly/binaryen/issues/4358')
+    self.emcc_args += ['-Wno-sync-fetch-and-nand-semantics-changed']
     self.btest_exit(test_file('pthread/test_pthread_gcc_64bit_atomic_fetch_and_op.cpp'), args=['-s', 'INITIAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE=8'])
 
   # Test the old GCC atomic __sync_op_and_fetch builtin operations.
   @also_with_wasm2js
   @requires_threads
   def test_pthread_gcc_atomic_op_and_fetch(self):
+    self.emcc_args += ['-Wno-sync-fetch-and-nand-semantics-changed']
     self.btest_exit(test_file('pthread/test_pthread_gcc_atomic_op_and_fetch.cpp'), args=['-s', 'INITIAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE=8'])
 
   # 64 bit version of the above test.
   @also_with_wasm2js
   @requires_threads
   def test_pthread_gcc_64bit_atomic_op_and_fetch(self):
-    self.btest_exit(test_file('pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.cpp'), args=['-s', 'INITIAL_MEMORY=64MB', '-O3', '-s', 'USE_PTHREADS', '-s', 'PTHREAD_POOL_SIZE=8'])
+    if not self.is_wasm():
+      self.skipTest('https://github.com/WebAssembly/binaryen/issues/4358')
+    self.emcc_args += ['-Wno-sync-fetch-and-nand-semantics-changed', '--profiling-funcs']
+    self.btest_exit(test_file('pthread/test_pthread_gcc_64bit_atomic_op_and_fetch.cpp'), args=['-s', 'INITIAL_MEMORY=64MB', '-s', 'USE_PTHREADS', '-O2', '-s', 'PTHREAD_POOL_SIZE=8'])
 
   # Tests the rest of the remaining GCC atomics after the two above tests.
   @also_with_wasm2js


### PR DESCRIPTION
Contrary to the comments there these atomics ops seem to work
fine these days.

The only exception is that __sync_fetch_and_nand doesn't work
under wasm2js due to a current binaryen limitation.

See https://github.com/WebAssembly/binaryen/issues/4358