### PR TITLE
Rework SyncToAsync to avoid missed notifications 

### DIFF
--- a/system/lib/wasmfs/thread_utils.h
+++ b/system/lib/wasmfs/thread_utils.h
@@ -66,93 +66,158 @@ public:
 // End Public API
 
 private:
-  std::unique_ptr<std::thread> thread;
-  std::mutex mutex;
-  std::condition_variable condition;
-  std::function<void(Callback)> work;
-  bool readyToWork = false;
-  bool finishedWork;
-  bool quit = false;
-  std::unique_ptr<std::function<void()>> resume;
-  std::mutex invokeMutex;
+  // The dedicated worker thread.
+  std::thread thread;
 
-  // The child will be asynchronous, and therefore we cannot rely on RAII to
-  // unlock for us, we must do it manually.
-  std::unique_lock<std::mutex> childLock;
+  // Condition variable used for bidirectional communication between the worker
+  // thread and invoking threads. To avoid losing messages, the worker thread
+  // should always either hold `mutex`, preventing invokers from sending it new
+  // work, or be waiting on `condition` for invokers send it work and wake it.
+  // Similarly, invokers should either hold `mutex` or be waiting for their work
+  // to be done.
+  std::condition_variable condition;
+  std::mutex mutex;
+  std::unique_lock<std::mutex> workerLock;
+
+  // The current state of the worker thread. New work can only be submitted when
+  // in the `Waiting` state.
+  enum State {
+    Uninitialized,
+    Waiting,
+    WorkAvailable,
+    ShouldExit,
+  } state = Uninitialized;
+
+  // Increment the count every time work is finished. This will allow invokers
+  // to detect that their particular work has been completed even if some other
+  // invoker wins the race and submits new work before the original invoker can
+  // check for completion.
+  uint64_t workCount = 0;
+
+  // The work that the dedicated worker thread should perform and the callback
+  // that needs to be called when the work is finished.
+  std::function<void(Callback)> work;
+  std::function<void()> resume;
 
   static void* threadMain(void* arg) {
+    auto* parent = (SyncToAsync*)arg;
+
+    // The original thread should be waiting for us to start up. Acquire the
+    // lock to ensure the original thread has started waiting and to prevent it
+    // or any other thread from sending us work until we're ready.
+    parent->workerLock.lock();
+
+    // Now that we are safe from receiving work before we're ready, notify the
+    // original thread that it can continue. The original thread should be the
+    // only possible waiter because the SyncToAsync constructor has not returned
+    // yet.
+    parent->condition.notify_one();
+
+    // Schedule ourselves to start processing incoming work requests.
     emscripten_async_call(threadIter, arg, 0);
     return 0;
   }
 
+  // The main worker thread routine that waits for work, wakes up when work is
+  // available, executes the work, then schedules itself again.
   static void threadIter(void* arg) {
     auto* parent = (SyncToAsync*)arg;
-    if (parent->quit) {
+    assert(parent->workerLock.owns_lock());
+
+    // Wait until we get something to do.
+    parent->state = Waiting;
+    parent->condition.wait(parent->workerLock, [&]() {
+      return parent->state == WorkAvailable || parent->state == ShouldExit;
+    });
+
+    if (parent->state == ShouldExit) {
       pthread_exit(0);
     }
-    // Wait until we get something to do.
-    parent->childLock.lock();
-    parent->condition.wait(parent->childLock, [&]() {
-      return parent->readyToWork;
-    });
+
+    assert(parent->state == WorkAvailable);
     auto work = parent->work;
-    parent->readyToWork = false;
-    // Allocate a resume function, and stash it on the parent.
-    parent->resume = std::make_unique<std::function<void()>>([parent, arg]() {
-      // We are called, so the work was finished. Notify the caller.
-      parent->finishedWork = true;
-      parent->childLock.unlock();
-      parent->condition.notify_one();
+
+    // Allocate a resume function that will wake the invoker and schedule us to
+    // wait for more work.
+    parent->resume = [parent, arg]() {
+      assert(parent->workerLock.owns_lock());
+      // We are called, so the work was finished. Notify the invoker so it will
+      // wake up and continue once we resume waiting. There might be other
+      // invokers waiting to give us work, so `notify_all` to make sure our
+      // invoker wakes up.
+      parent->workCount++;
+      assert(parent->workCount && "workCount overflowed!");
+      parent->condition.notify_all();
+
       // Look for more work. Doing this asynchronously ensures that we continue
       // after the current call stack unwinds (avoiding constantly adding to the
       // stack, and also running any remaining code the caller had, like
       // destructors). TODO: add an option to do a synchronous call here in some
       // cases, which would avoid the time delay caused by a browser setTimeout.
       emscripten_async_call(threadIter, arg, 0);
-    });
+    };
+
     // Run the work function the user gave us. Give it a pointer to the resume
-    // function.
-    work(parent->resume.get());
+    // function, which it will be responsible for calling when it's done.
+    work(&parent->resume);
   }
 
 public:
-  SyncToAsync() : childLock(mutex) {
-    // The child lock is associated with the mutex, which takes the lock as we
-    // connect them, and so we must free it here so that the child can use it.
-    // Only the child will lock/unlock it from now on.
-    childLock.unlock();
-
-    // Create the thread after the lock is ready.
-    thread = std::make_unique<std::thread>(threadMain, this);
+  SyncToAsync() : workerLock(mutex, std::defer_lock) {
+    // Acquire the lock before spawning the worker thread so that we can wait
+    // for it to notify us that it has succefully started up. If we didn't lock
+    // before spawning it, we could miss that notification. If we didn't wait
+    // for it to start up at all, we could accidentally send it work before it
+    // is ready.
+    std::unique_lock<std::mutex> lock(mutex);
+    thread = std::thread(threadMain, this);
+    condition.wait(lock, [&]() { return state == Waiting; });
   }
 
   ~SyncToAsync() {
-    // Wake up the child to tell it to quit.
-    invoke([&](Callback func){
-      quit = true;
-      (*func)();
-    });
+    std::unique_lock<std::mutex> lock(mutex);
 
-    thread->join();
+    // We are destructing the SyncToAsync object, so we should not be racing
+    // with other threads trying to perform more `invoke`s. There should
+    // therefore not be any work available.
+    assert(state == Waiting);
+
+    // Wake the worker and tell it to quit. Be ready to join it when it does.
+    // There shouldn't be other invokers waiting to send work since we are
+    // destructing the SyncToAsync, so just use `notify_one`.
+    state = ShouldExit;
+    condition.notify_one();
+
+    // Unlock to allow the worker to wake up and exit.
+    lock.unlock();
+    thread.join();
   }
 };
 
 void SyncToAsync::invoke(std::function<void(Callback)> newWork) {
-  // Use the invokeMutex to prevent more than one invoke being in flight at a
-  // time, so that this is usable from multiple threads safely.
-  std::lock_guard<std::mutex> invokeLock(invokeMutex);
-
-  // Send the work over.
   std::unique_lock<std::mutex> lock(mutex);
-  work = newWork;
-  finishedWork = false;
-  readyToWork = true;
 
-  // Notify the thread and wait for it to complete.
-  condition.notify_one();
-  condition.wait(lock, [&]() {
-    return finishedWork;
-  });
+  // The worker might not be waiting for work if some other invoker just sent
+  // work and we won the race against the newly woken worker thread to acquire
+  // the lock. In that case, wait for the worker to be done with that work and
+  // ready for new work.
+  if (state != Waiting) {
+    condition.wait(lock, [&]() { return state == Waiting; });
+  }
+
+  // Now the worker is definitely waiting for our work. Send it over.
+  assert(state == Waiting);
+  uint64_t workID = workCount;
+  work = newWork;
+  state = WorkAvailable;
+
+  // Wake the worker and wait for it to finish the work. There might be other
+  // invokers waiting to send work as well, so `notify_all` to ensure the worker
+  // wakes up. Wait for `workCount` to increase rather than for the state to
+  // return to `Waiting` to make sure we wake up even if some other invoker wins
+  // the race and submits more work before we acquire the lock.
+  condition.notify_all();
+  condition.wait(lock, [&]() { return workCount > workID; });
 }
 
 } // namespace emscripten


### PR DESCRIPTION
 - Wait for the worker to start up in the constructor to avoid it missing
   messages sent before it starts.

 - Never release the lock in the worker except to wait for work. That prevents
   multiple invokers from trampling each other's work.

 - Wait in `invoke` for the worker thread to be ready to accept work to handle
   the case where multiple invokers race to submit work.

 - Maintain a count of finished work to avoid situations where an invoker whose
   work is finished is preempted by other invokers, so it wouldn't be able to
   tell that its work is finished.