### PR TITLE
[WASMFS] Switch to using `out` and `err`

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3494,6 +3494,22 @@ LibraryManager.library = {
 #endif
   },
 
+  emscripten_out__sig: 'vi',
+  emscripten_out: function(str) {
+#if ASSERTIONS
+    assert(typeof str === 'number');
+#endif
+    out(UTF8ToString(str));
+  },
+
+  emscripten_err__sig: 'vi',
+  emscripten_err: function(str) {
+#if ASSERTIONS
+    assert(typeof str === 'number');
+#endif
+    err(UTF8ToString(str));
+  },
+
   emscripten_console_log__sig: 'vi',
   emscripten_console_log: function(str) {
 #if ASSERTIONS

--- a/src/library.js
+++ b/src/library.js
@@ -3494,16 +3494,16 @@ LibraryManager.library = {
 #endif
   },
 
-  emscripten_out__sig: 'vi',
-  emscripten_out: function(str) {
+  _emscripten_out__sig: 'vi',
+  _emscripten_out: function(str) {
 #if ASSERTIONS
     assert(typeof str === 'number');
 #endif
     out(UTF8ToString(str));
   },
 
-  emscripten_err__sig: 'vi',
-  emscripten_err: function(str) {
+  _emscripten_err__sig: 'vi',
+  _emscripten_err: function(str) {
 #if ASSERTIONS
     assert(typeof str === 'number');
 #endif

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -15,18 +15,22 @@ void emscripten_console_log(const char *utf8String);
 void emscripten_console_warn(const char *utf8String);
 void emscripten_console_error(const char *utf8String);
 
+// Write to the out() and err() hooks directly (defined in shell.js).
+// These have different behavior compared to console.log/err.
+// Under node, they write to stdout and stderr which is a more direct way to
+// write output especially in worker threads.
+// The default behavior of these functions can be overridden by print and
+// printErr, if provided on the Module object.
+// See https://github.com/emscripten-core/emscripten/issues/14804
+void emscripten_out(const char *utf8String);
+void emscripten_err(const char *utf8String);
+
 // Similar to the above functions but operate with printf-like semantics.
 void emscripten_console_logf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 void emscripten_console_warnf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 void emscripten_console_errorf(const char *utf8String, ...)__attribute__((__format__(printf, 1, 2)));
-
-// Write to the out() and err() hooks directly (defined in shell.js).
-// These have different behaviour compared to console.log/err.
-// Under node, they write to stdout and stderr which is a more direct way to
-// write output especially in worker threads.
-// See https://github.com/emscripten-core/emscripten/issues/14804
-void emscripten_out(const char *utf8String);
-void emscripten_err(const char *utf8String);
+void emscripten_outf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_errf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -21,16 +21,17 @@ void emscripten_console_error(const char *utf8String);
 // write output especially in worker threads.
 // The default behavior of these functions can be overridden by print and
 // printErr, if provided on the Module object.
+// These functions are mainly intended for internal use.
 // See https://github.com/emscripten-core/emscripten/issues/14804
-void emscripten_out(const char *utf8String);
-void emscripten_err(const char *utf8String);
+void _emscripten_out(const char *utf8String);
+void _emscripten_err(const char *utf8String);
 
 // Similar to the above functions but operate with printf-like semantics.
 void emscripten_console_logf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 void emscripten_console_warnf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 void emscripten_console_errorf(const char *utf8String, ...)__attribute__((__format__(printf, 1, 2)));
-void emscripten_outf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
-void emscripten_errf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
+void _emscripten_outf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
+void _emscripten_errf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -20,6 +20,12 @@ void emscripten_console_logf(const char *utf8String, ...) __attribute__((__forma
 void emscripten_console_warnf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 void emscripten_console_errorf(const char *utf8String, ...)__attribute__((__format__(printf, 1, 2)));
 
+// Write to the out() and err() hooks directly.
+// out() and err() are defined in shell.js.
+// See https://github.com/emscripten-core/emscripten/issues/14804
+void emscripten_out(const char *utf8String);
+void emscripten_err(const char *utf8String);
+
 #ifdef __cplusplus
 }
 #endif

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -20,8 +20,10 @@ void emscripten_console_logf(const char *utf8String, ...) __attribute__((__forma
 void emscripten_console_warnf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 void emscripten_console_errorf(const char *utf8String, ...)__attribute__((__format__(printf, 1, 2)));
 
-// Write to the out() and err() hooks directly.
-// out() and err() are defined in shell.js.
+// Write to the out() and err() hooks directly (defined in shell.js).
+// These have different behaviour compared to console.log/err.
+// Under node, they write to stdout and stderr which is a more direct way to
+// write output especially in worker threads.
 // See https://github.com/emscripten-core/emscripten/issues/14804
 void emscripten_out(const char *utf8String);
 void emscripten_err(const char *utf8String);

--- a/system/lib/libc/emscripten_console.c
+++ b/system/lib/libc/emscripten_console.c
@@ -41,16 +41,16 @@ void emscripten_console_warnf(const char* fmt, ...) {
   va_end(ap);
 }
 
-void emscripten_outf(const char* fmt, ...) {
+void _emscripten_outf(const char* fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  vlogf(fmt, ap, &emscripten_out);
+  vlogf(fmt, ap, &_emscripten_out);
   va_end(ap);
 }
 
-void emscripten_errf(const char* fmt, ...) {
+void _emscripten_errf(const char* fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
-  vlogf(fmt, ap, &emscripten_err);
+  vlogf(fmt, ap, &_emscripten_err);
   va_end(ap);
 }

--- a/system/lib/libc/emscripten_console.c
+++ b/system/lib/libc/emscripten_console.c
@@ -40,3 +40,17 @@ void emscripten_console_warnf(const char* fmt, ...) {
   vlogf(fmt, ap, &emscripten_console_warn);
   va_end(ap);
 }
+
+void emscripten_outf(const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vlogf(fmt, ap, &emscripten_out);
+  va_end(ap);
+}
+
+void emscripten_errf(const char* fmt, ...) {
+  va_list ap;
+  va_start(ap, fmt);
+  vlogf(fmt, ap, &emscripten_err);
+  va_end(ap);
+}

--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -37,7 +37,7 @@ __wasi_errno_t StdoutFile::write(const uint8_t* buf, size_t len, off_t offset) {
   // Due to this issue with node and worker threads:
   // https://github.com/emscripten-core/emscripten/issues/14804. This function
   // will write to out(), which will write directly to stdout in node.
-  return writeStdBuffer(buf, len, &emscripten_out, writeBuffer);
+  return writeStdBuffer(buf, len, &_emscripten_out, writeBuffer);
 }
 
 std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
@@ -48,7 +48,7 @@ std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
 
 __wasi_errno_t StderrFile::write(const uint8_t* buf, size_t len, off_t offset) {
   // Similar issue with node and worker threads as emscripten_out.
-  return writeStdBuffer(buf, len, &emscripten_err, writeBuffer);
+  return writeStdBuffer(buf, len, &_emscripten_err, writeBuffer);
 }
 
 std::shared_ptr<StderrFile> StderrFile::getSingleton() {

--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -34,7 +34,7 @@ std::shared_ptr<StdinFile> StdinFile::getSingleton() {
 }
 
 __wasi_errno_t StdoutFile::write(const uint8_t* buf, size_t len, off_t offset) {
-  return writeStdBuffer(buf, len, &emscripten_console_log, writeBuffer);
+  return writeStdBuffer(buf, len, &emscripten_out, writeBuffer);
 }
 
 std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
@@ -44,7 +44,7 @@ std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
 }
 
 __wasi_errno_t StderrFile::write(const uint8_t* buf, size_t len, off_t offset) {
-  return writeStdBuffer(buf, len, &emscripten_console_error, writeBuffer);
+  return writeStdBuffer(buf, len, &emscripten_err, writeBuffer);
 }
 
 std::shared_ptr<StderrFile> StderrFile::getSingleton() {

--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -34,6 +34,9 @@ std::shared_ptr<StdinFile> StdinFile::getSingleton() {
 }
 
 __wasi_errno_t StdoutFile::write(const uint8_t* buf, size_t len, off_t offset) {
+  // Due to this issue with node and worker threads:
+  // https://github.com/emscripten-core/emscripten/issues/14804. This function
+  // will write to out(), which will write directly to stdout in node.
   return writeStdBuffer(buf, len, &emscripten_out, writeBuffer);
 }
 
@@ -44,6 +47,7 @@ std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
 }
 
 __wasi_errno_t StderrFile::write(const uint8_t* buf, size_t len, off_t offset) {
+  // Similar issue with node and worker threads as emscripten_out.
   return writeStdBuffer(buf, len, &emscripten_err, writeBuffer);
 }
 


### PR DESCRIPTION
- Propose using `out` and `err` instead of `emscripten_console_log` and `emscripten_console_error`

Similar issue to #14805, where pthreads + node led to inconsistent output with `emscripten_console_log`.

Add `emscripten_out` and `emscripten_err` along with `f` versions.
Replaced `emscripten_console_log`/`error` with those two functions respectively in `streams.cpp`.