### PR TITLE
Set emscripten_is_main_browser_thread based on ENVIRONMENT_IS_WEB

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,9 @@ See docs/process.md for more on how version tagging works.
 
 3.0.1
 -----
+- The return value of `emscripten_is_main_browser_thread` was fixed such that
+  it no longer returns true when the application is started outside of the
+  main browser thread (.e.g. in a worker, or under node). (#15630)
 
 3.0.0 - 11/22/2021
 ------------------

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -598,7 +598,7 @@ var LibraryPThread = {
     // Pass the thread address to the native code where they stored in wasm
     // globals which act as a form of TLS. Global constructors trying
     // to access this value will read the wrong value, but that is UB anyway.
-    __emscripten_thread_init(tb, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1);
+    __emscripten_thread_init(tb, /*isMainBrowserThread=*/ENVIRONMENT_IS_WEB, /*isMainRuntimeThread=*/1);
 #if ASSERTIONS
     PThread.mainRuntimeThread = true;
 #endif

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -13,7 +13,7 @@ var LibraryPThreadStub = {
 #if MINIMAL_RUNTIME
     return typeof importScripts === 'undefined';
 #else
-    return !ENVIRONMENT_IS_WORKER;
+    return ENVIRONMENT_IS_WEB;
 #endif
   },
 };

--- a/system/lib/fetch/emscripten_fetch.cpp
+++ b/system/lib/fetch/emscripten_fetch.cpp
@@ -75,8 +75,7 @@ emscripten_fetch_t* emscripten_fetch(emscripten_fetch_attr_t* fetch_attr, const 
   const bool writeToIndexedDB = (fetch_attr->attributes & EMSCRIPTEN_FETCH_PERSIST_FILE) != 0 ||
                                 !strncmp(fetch_attr->requestMethod, "EM_IDB_", strlen("EM_IDB_"));
   const bool performXhr = (fetch_attr->attributes & EMSCRIPTEN_FETCH_NO_DOWNLOAD) == 0;
-  const bool isMainBrowserThread = emscripten_is_main_browser_thread() != 0;
-  if (isMainBrowserThread && synchronous && (performXhr || readFromIndexedDB || writeToIndexedDB)) {
+  if (emscripten_is_main_browser_thread() && synchronous && (performXhr || readFromIndexedDB || writeToIndexedDB)) {
 #ifdef FETCH_DEBUG
     emscripten_console_errorf("emscripten_fetch('%s') failed! Synchronous blocking XHRs and IndexedDB operations are not supported on the main browser thread. Try dropping the EMSCRIPTEN_FETCH_SYNCHRONOUS flag, or run with the linker flag --proxy-to-worker to decouple main C runtime thread from the main browser thread.", url);
 #endif

--- a/system/lib/pthread/emscripten_thread_state.S
+++ b/system/lib/pthread/emscripten_thread_state.S
@@ -47,7 +47,7 @@ emscripten_is_main_runtime_thread:
   global.get is_runtime_thread
   end_function
 
-# Semantically the same as testing "!ENVIRONMENT_IS_WORKER" in JS
+# Semantically the same as testing "ENVIRONMENT_IS_WEB" in JS
 .globl emscripten_is_main_browser_thread
 emscripten_is_main_browser_thread:
   .functype emscripten_is_main_browser_thread () -> (i32)

--- a/tests/other/test_pthread_self_join_detach.c
+++ b/tests/other/test_pthread_self_join_detach.c
@@ -9,12 +9,14 @@
 #endif
 
 int main() {
+#ifdef __EMSCRIPTEN__
   /*
    * When running in PROXY_TO_PTHREAD mode the main thread
-   * is already detached
+   * is already detached.  We detect PROXY_TO_PTHREAD mode
+   * by noticing that the main() function is not running
+   * in the main runtime thread.
    */
-#ifdef __EMSCRIPTEN__
-  int is_detached = !emscripten_is_main_browser_thread();
+  int is_detached = !emscripten_is_main_runtime_thread();
 #else
   int is_detached = 0;
 #endif


### PR DESCRIPTION
The this is more accurate that !ENVIRONMENT_IS_WORKER, and holds
true, for example, under node where there is no main browser thread,
only a main runtime thread.