### PR TITLE
[WASMFS] New Path Parsing

### DIFF
--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -68,7 +68,7 @@ ParsedPath getParsedPath(std::vector<std::string> pathParts,
   for (auto pathPart = begin; pathPart != pathParts.end() - 1; ++pathPart) {
     // Find the next entry in the current directory entry
 #ifdef WASMFS_DEBUG
-    directory->locked().printKeys();
+    curr->locked().printKeys();
 #endif
     auto entry = curr->locked().getEntry(*pathPart);
 
@@ -79,7 +79,7 @@ ParsedPath getParsedPath(std::vector<std::string> pathParts,
       }
     }
 
-    // Requested entry (file or directory)
+    // An entry is defined in the current directory's entries vector.
     if (!entry) {
       err = -ENOENT;
       return ParsedPath{{}, nullptr};

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -42,6 +42,68 @@ std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
 //
 // Path Parsing utilities
 //
+ParsedPath getParsedPath(std::vector<std::string> pathParts,
+                         long& err,
+                         std::shared_ptr<File> forbiddenAncestor) {
+  std::shared_ptr<Directory> curr;
+  auto begin = pathParts.begin();
+
+  if (pathParts.empty()) {
+    err = -ENOENT;
+    return ParsedPath{{}, nullptr};
+  }
+
+  // Check if the first path element is '/', indicating an absolute path.
+  if (pathParts[0] == "/") {
+    curr = wasmFS.getRootDirectory();
+    begin++;
+    // If the pathname is the root directory, return the root as the child.
+    if (pathParts.size() == 1) {
+      return ParsedPath{curr->locked(), curr};
+    }
+  } else {
+    curr = wasmFS.getCWD();
+  }
+
+  for (auto pathPart = begin; pathPart != pathParts.end() - 1; ++pathPart) {
+    // Find the next entry in the current directory entry
+#ifdef WASMFS_DEBUG
+    directory->locked().printKeys();
+#endif
+    auto entry = curr->locked().getEntry(*pathPart);
+
+    if (forbiddenAncestor) {
+      if (entry == forbiddenAncestor) {
+        err = -EINVAL;
+        return ParsedPath{{}, nullptr};
+      }
+    }
+
+    // Requested entry (file or directory)
+    if (!entry) {
+      err = -ENOENT;
+      return ParsedPath{{}, nullptr};
+    }
+
+    curr = entry->dynCast<Directory>();
+
+    // If file is nullptr, then the file was not a Directory.
+    // TODO: Change this to accommodate symlinks
+    if (!curr) {
+      err = -ENOTDIR;
+      return ParsedPath{{}, nullptr};
+    }
+
+#ifdef WASMFS_DEBUG
+    emscripten_console_log(*pathPart->c_str());
+#endif
+  }
+
+  // auto parent = curr->dynCast<Directory>();
+
+  auto child = curr->locked().getEntry(*(pathParts.end() - 1));
+  return ParsedPath{curr->locked(), child};
+}
 
 std::shared_ptr<Directory> getDir(std::vector<std::string>::iterator begin,
                                   std::vector<std::string>::iterator end,

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -99,10 +99,10 @@ ParsedPath getParsedPath(std::vector<std::string> pathParts,
 #endif
   }
 
-  // auto parent = curr->dynCast<Directory>();
-
-  auto child = curr->locked().getEntry(*(pathParts.end() - 1));
-  return ParsedPath{curr->locked(), child};
+  // Lock the parent once.
+  auto lockedCurr = curr->locked();
+  auto child = lockedCurr.getEntry(*(pathParts.end() - 1));
+  return ParsedPath{std::move(lockedCurr), child};
 }
 
 std::shared_ptr<Directory> getDir(std::vector<std::string>::iterator begin,

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -269,9 +269,9 @@ struct ParsedPath {
   std::shared_ptr<File> child;
 };
 
-// TODO: Should this return a locked parent handle or a pointer to the parent?
-// Given a pathname, this function will return a locked parent directory and a
-// pointer to the specified file.
+// TODO: When locking the directory structure is refactored, parent should be
+// returned as a pointer, similar to child. Given a pathname, this function will
+// return a locked parent directory and a pointer to the specified file.
 ParsedPath getParsedPath(std::vector<std::string> pathParts,
                          long& err,
                          std::shared_ptr<File> forbiddenAncestor = nullptr);

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -269,18 +269,25 @@ struct ParsedPath {
   std::shared_ptr<File> child;
 };
 
+// Call getParsedPath if one needs a locked handle to a parent dir and a
+// shared_ptr to its child file, given a file path.
 // TODO: When locking the directory structure is refactored, parent should be
 // returned as a pointer, similar to child. Given a pathname, this function will
 // return a locked parent directory and a pointer to the specified file.
-ParsedPath getParsedPath(std::vector<std::string> pathParts,
-                         long& err,
-                         std::shared_ptr<File> forbiddenAncestor = nullptr);
-
-// Obtains parent directory of a given pathname.
 // Will return a nullptr if the parent is not a directory.
 // Will error if the forbiddenAncestor is encountered while processing.
 // If the forbiddenAncestor is encountered, err will be set to EINVAL and
 // nullptr will be returned.
+ParsedPath getParsedPath(std::vector<std::string> pathParts,
+                         long& err,
+                         std::shared_ptr<File> forbiddenAncestor = nullptr);
+
+// Call getDir if one needs a parent directory of a file path.
+// TODO: Remove this when directory structure locking is refactored and use
+// getParsedPath instead. Obtains parent directory of a given pathname.
+// Will return a nullptr if the parent is not a directory. Will error if the
+// forbiddenAncestor is encountered while processing. If the forbiddenAncestor
+// is encountered, err will be set to EINVAL and nullptr will be returned.
 std::shared_ptr<Directory>
 getDir(std::vector<std::string>::iterator begin,
        std::vector<std::string>::iterator end,

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -91,6 +91,8 @@ public:
     // specified by the parent weak_ptr.
     std::shared_ptr<File> getParent() { return file->parent.lock(); }
     void setParent(std::shared_ptr<File> parent) { file->parent = parent; }
+
+    std::shared_ptr<File> unlocked() { return file; }
   };
 
   Handle locked() { return Handle(shared_from_this()); }
@@ -261,6 +263,19 @@ public:
     }
   }
 };
+
+struct ParsedPath {
+  std::optional<Directory::Handle> parent;
+  std::shared_ptr<File> child;
+};
+
+// TODO: Should this return a locked parent handle or a pointer to the parent?
+// Given a pathname, this function will return a locked parent directory and a
+// pointer to the specified file.
+ParsedPath getParsedPath(std::vector<std::string> pathParts,
+                         long& err,
+                         std::shared_ptr<File> forbiddenAncestor = nullptr);
+
 // Obtains parent directory of a given pathname.
 // Will return a nullptr if the parent is not a directory.
 // Will error if the forbiddenAncestor is encountered while processing.

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -163,7 +163,8 @@ public:
     }
 
     // This function loads preloaded files from JS Memory into this DataFile.
-    // TODO: Make this virtual so specific backends can specialize it for better performance.
+    // TODO: Make this virtual so specific backends can specialize it for better
+    // performance.
     void preloadFromJS(int index);
   };
 
@@ -272,12 +273,11 @@ struct ParsedPath {
 // Call getParsedPath if one needs a locked handle to a parent dir and a
 // shared_ptr to its child file, given a file path.
 // TODO: When locking the directory structure is refactored, parent should be
-// returned as a pointer, similar to child. Given a pathname, this function will
-// return a locked parent directory and a pointer to the specified file.
-// Will return a nullptr if the parent is not a directory.
+// returned as a pointer, similar to child.
+// Will return an empty handle if the parent is not a directory.
 // Will error if the forbiddenAncestor is encountered while processing.
 // If the forbiddenAncestor is encountered, err will be set to EINVAL and
-// nullptr will be returned.
+// an empty parent handle will be returned.
 ParsedPath getParsedPath(std::vector<std::string> pathParts,
                          long& err,
                          std::shared_ptr<File> forbiddenAncestor = nullptr);

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -412,6 +412,10 @@ static __wasi_fd_t doOpen(char* pathname,
     return err;
   }
 
+  if (pathParts.back().size() > WASMFS_NAME_MAX) {
+    return -ENAMETOOLONG;
+  }
+
   // The requested node was not found.
   if (!parsedPath.child) {
     // If curr is the last element and the create flag is specified
@@ -483,6 +487,10 @@ static long doMkdir(char* path, long mode, backend_t backend = NullBackend) {
   // Parent node doesn't exist.
   if (!parsedPath.parent) {
     return err;
+  }
+
+  if (pathParts.back().size() > WASMFS_NAME_MAX) {
+    return -ENAMETOOLONG;
   }
 
   // Check if the requested directory already exists.
@@ -811,6 +819,10 @@ long __syscall_rename(long old_path, long new_path) {
 
   if (!oldParsedPath.parent) {
     return err;
+  }
+
+  if (oldPathParts.back().size() > WASMFS_NAME_MAX) {
+    return -ENAMETOOLONG;
   }
 
   if (!oldParsedPath.child) {

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -309,38 +309,15 @@ backend_t wasmfs_get_backend_by_fd(int fd) {
 backend_t wasmfs_get_backend_by_path(char* path) {
   auto pathParts = splitPath(path);
 
-  if (pathParts.empty()) {
-    return NullBackend;
-  }
-
-  // TODO: Remove this when path parsing has been re-factored.
-  if (pathParts.size() == 1 && pathParts[0] == "/") {
-    return wasmFS.getRootDirectory()->getBackend();
-  }
-
-  auto base = pathParts.back();
-
   long err;
-  auto parentDir = getDir(pathParts.begin(), pathParts.end() - 1, err);
+  auto parsedPath = getParsedPath(pathParts, err);
 
   // Parent node doesn't exist.
-  if (!parentDir) {
+  if (!parsedPath.parent) {
     return NullBackend;
   }
 
-  auto lockedParentDir = parentDir->locked();
-
-  // TODO: In a future PR, edit function to just return the requested file
-  // instead of having to first obtain the parent dir.
-  auto curr = lockedParentDir.getEntry(base);
-
-  if (curr) {
-    auto dir = curr->dynCast<Directory>();
-
-    return dir ? dir->getBackend() : NullBackend;
-  }
-
-  return NullBackend;
+  return parsedPath.child ? parsedPath.child->getBackend() : NullBackend;
 }
 
 static long doStat(std::shared_ptr<File> file, struct stat* buffer) {
@@ -377,28 +354,17 @@ static long doStat(std::shared_ptr<File> file, struct stat* buffer) {
 long __syscall_stat64(long path, long buf) {
   auto pathParts = splitPath((char*)path);
 
-  if (pathParts.empty()) {
-    return -ENOENT;
-  }
-
-  auto base = pathParts.back();
-
   long err;
-  auto parentDir = getDir(pathParts.begin(), pathParts.end() - 1, err);
+  auto parsedPath = getParsedPath(pathParts, err);
 
   // Parent node doesn't exist.
-  if (!parentDir) {
+  if (!parsedPath.parent) {
     return err;
   }
 
-  auto lockedParentDir = parentDir->locked();
-
-  // TODO: In future PR, edit function to just return the requested file instead
-  // of having to first obtain the parent dir.
-  auto curr = lockedParentDir.getEntry(base);
-  if (curr) {
+  if (parsedPath.child) {
     struct stat* buffer = (struct stat*)buf;
-    return doStat(curr, buffer);
+    return doStat(parsedPath.child, buffer);
   } else {
     return -ENOENT;
   }
@@ -438,36 +404,16 @@ static __wasi_fd_t doOpen(char* pathname,
 
   auto pathParts = splitPath(pathname);
 
-  if (pathParts.empty()) {
-    return -ENOENT;
-  }
-
-  auto base = pathParts.back();
-  if (base.size() > WASMFS_NAME_MAX) {
-    return -ENAMETOOLONG;
-  }
-
-  // Root directory
-  if (pathParts.size() == 1 && pathParts[0] == "/") {
-    auto openFile =
-      std::make_shared<OpenFileState>(0, flags, wasmFS.getRootDirectory());
-    return wasmFS.getLockedFileTable().add(openFile);
-  }
-
   long err;
-  auto parentDir = getDir(pathParts.begin(), pathParts.end() - 1, err);
+  auto parsedPath = getParsedPath(pathParts, err);
 
   // Parent node doesn't exist.
-  if (!parentDir) {
+  if (!parsedPath.parent) {
     return err;
   }
 
-  auto lockedParentDir = parentDir->locked();
-
-  auto curr = lockedParentDir.getEntry(base);
-
   // The requested node was not found.
-  if (!curr) {
+  if (!parsedPath.child) {
     // If curr is the last element and the create flag is specified
     // If O_DIRECTORY is also specified, still create a regular file:
     // https://man7.org/linux/man-pages/man2/open.2.html#BUGS
@@ -480,14 +426,14 @@ static __wasi_fd_t doOpen(char* pathname,
       // parent directory. However, if a backend is passed as a parameter, then
       // that backend is used.
       if (!backend) {
-        backend = parentDir->getBackend();
+        backend = (*parsedPath.parent).unlocked()->getBackend();
       }
       auto created = backend->createFile(mode);
 
       // TODO: When rename is implemented make sure that one can atomically
       // remove the file from the source directory and then set its parent to
       // the dest directory.
-      lockedParentDir.setEntry(base, created);
+      (*parsedPath.parent).setEntry(pathParts.back(), created);
       auto openFile = std::make_shared<OpenFileState>(0, flags, created);
 
       return wasmFS.getLockedFileTable().add(openFile);
@@ -497,7 +443,7 @@ static __wasi_fd_t doOpen(char* pathname,
   }
 
   // Fail if O_DIRECTORY is specified and pathname is not a directory
-  if (flags & O_DIRECTORY && !curr->is<Directory>()) {
+  if (flags & O_DIRECTORY && !parsedPath.child->is<Directory>()) {
     return -ENOTDIR;
   }
 
@@ -506,7 +452,7 @@ static __wasi_fd_t doOpen(char* pathname,
     return -EEXIST;
   }
 
-  auto openFile = std::make_shared<OpenFileState>(0, flags, curr);
+  auto openFile = std::make_shared<OpenFileState>(0, flags, parsedPath.child);
 
   return wasmFS.getLockedFileTable().add(openFile);
 }
@@ -531,50 +477,33 @@ __wasi_fd_t __syscall_open(long pathname, long flags, ...) {
 static long doMkdir(char* path, long mode, backend_t backend = NullBackend) {
   auto pathParts = splitPath(path);
 
-  if (pathParts.empty()) {
-    return -ENOENT;
-  }
-  // Root (/) directory.
-  if (pathParts.size() == 1 && pathParts[0] == "/") {
-    return -EEXIST;
-  }
-
-  auto base = pathParts.back();
-  if (base.size() > WASMFS_NAME_MAX) {
-    return -ENAMETOOLONG;
-  }
-
   long err;
-  auto parentDir = getDir(pathParts.begin(), pathParts.end() - 1, err);
+  auto parsedPath = getParsedPath(pathParts, err);
 
-  if (!parentDir) {
-    // parent node doesn't exist
+  // Parent node doesn't exist.
+  if (!parsedPath.parent) {
     return err;
   }
 
-  auto lockedParentDir = parentDir->locked();
-
-  auto curr = lockedParentDir.getEntry(base);
-
   // Check if the requested directory already exists.
-  if (curr) {
+  if (parsedPath.child) {
     return -EEXIST;
   } else {
     // Mask rwx permissions for user, group and others, and the sticky bit.
     // This prevents users from entering S_IFREG for example.
     // https://www.gnu.org/software/libc/manual/html_node/Permission-Bits.html
     mode &= S_IRWXUGO | S_ISVTX;
-    // Create an empty in-memory directory.
 
     // By default, the backend that the directory is created in is the same as
     // the parent directory. However, if a backend is passed as a parameter,
     // then that backend is used.
     if (!backend) {
-      backend = parentDir->getBackend();
+      backend = (*parsedPath.parent).unlocked()->getBackend();
     }
+    // Create an empty in-memory directory.
     auto created = backend->createDirectory(mode);
 
-    lockedParentDir.setEntry(base, created);
+    (*parsedPath.parent).setEntry(pathParts.back(), created);
     return 0;
   }
 }
@@ -628,19 +557,25 @@ __wasi_errno_t __wasi_fd_seek(__wasi_fd_t fd,
 long __syscall_chdir(long path) {
   auto pathParts = splitPath((char*)path);
 
-  if (pathParts.empty()) {
-    return -ENOENT;
-  }
-
   long err;
-  auto dir = getDir(pathParts.begin(), pathParts.end(), err);
+  auto parsedPath = getParsedPath(pathParts, err);
 
-  if (!dir) {
+  if (!parsedPath.parent) {
     return err;
   }
 
-  wasmFS.setCWD(dir);
-  return 0;
+  if (!parsedPath.child) {
+    return -ENOENT;
+  }
+
+  auto childDir = parsedPath.child->dynCast<Directory>();
+
+  if (childDir) {
+    wasmFS.setCWD(childDir);
+    return 0;
+  } else {
+    return -ENOTDIR;
+  }
 }
 
 long __syscall_getcwd(long buf, long size) {
@@ -716,39 +651,27 @@ static long doUnlink(char* path, UnlinkMode unlinkMode) {
   auto pathParts = splitPath(path);
 
   // TODO: Ensure that . and .. are invalid when path parsing is updated.
-  // TODO: Change to check root directory pointer instead of path.
   // This can be done when path parsing is refactored.
-  // Current state just matches JS file system behaviour.
-  if (pathParts.size() == 1 && pathParts[0] == "/") {
-    return -EBUSY;
-  }
-
-  if (pathParts.empty()) {
-    return -ENOENT;
-  }
-
-  auto base = pathParts.back();
 
   long err;
-  auto parentDir = getDir(pathParts.begin(), pathParts.end() - 1, err);
+  auto parsedPath = getParsedPath(pathParts, err);
 
   // Parent node doesn't exist.
-  if (!parentDir) {
+  if (!parsedPath.parent) {
     return err;
   }
 
-  // Hold the locked directory to prevent the state from being changed during
-  // the operation.
-  auto lockedParentDir = parentDir->locked();
-
-  auto curr = lockedParentDir.getEntry(base);
-
-  if (!curr) {
+  if (!parsedPath.child) {
     return -ENOENT;
   }
 
+  // Current state just matches JS file system behaviour.
+  if (parsedPath.child == wasmFS.getRootDirectory()) {
+    return -EBUSY;
+  }
+
   // rmdir checks if the target is a directory and if the directory is empty.
-  auto targetDir = curr->dynCast<Directory>();
+  auto targetDir = parsedPath.child->dynCast<Directory>();
   if (unlinkMode == UnlinkMode::Rmdir) {
 
     if (!targetDir) {
@@ -767,12 +690,12 @@ static long doUnlink(char* path, UnlinkMode unlinkMode) {
   }
 
   // Cannot unlink/rmdir if the parent dir doesn't have write permissions.
-  if (!(lockedParentDir.mode() & WASMFS_PERM_WRITE)) {
+  if (!((*parsedPath.parent).mode() & WASMFS_PERM_WRITE)) {
     return -EACCES;
   }
 
   // Input is valid, perform the unlink.
-  lockedParentDir.unlinkEntry(base);
+  (*parsedPath.parent).unlinkEntry(pathParts.back());
   return 0;
 }
 
@@ -881,33 +804,22 @@ long __syscall_rename(long old_path, long new_path) {
 
   auto oldPathParts = splitPath((char*)old_path);
 
-  if (oldPathParts.empty()) {
-    return -ENOENT;
-  }
-
-  // In Linux, renaming the root directory returns EBUSY.
-  // TODO: Fix this when path parsing is refactored.
-  std::vector<std::string> root = {"/"};
-  if (oldPathParts == root) {
-    return -EBUSY;
-  }
-
-  auto oldBase = oldPathParts.back();
-
+  // For this operation to be atomic we must lock the source parent directory.
+  // getParsedPath() will return a locked parent directory.
   long err;
-  auto oldParentDir = getDir(oldPathParts.begin(), oldPathParts.end() - 1, err);
+  auto oldParsedPath = getParsedPath(oldPathParts, err);
 
-  if (!oldParentDir) {
+  if (!oldParsedPath.parent) {
     return err;
   }
 
-  // For this operation to be atomic we must lock the source parent directory.
-  auto lockedOldParentDir = oldParentDir->locked();
-
-  auto oldPath = lockedOldParentDir.getEntry(oldBase);
-
-  if (!oldPath) {
+  if (!oldParsedPath.child) {
     return -ENOENT;
+  }
+
+  // This matches JS file system behavior.
+  if (oldParsedPath.child == wasmFS.getRootDirectory()) {
+    return -EBUSY;
   }
 
   // Obtain the destination parent directory to see if it exists.
@@ -919,6 +831,7 @@ long __syscall_rename(long old_path, long new_path) {
 
   // In Linux, renaming a directory to the root directory returns ENOTEMPTY.
   // TODO: Fix this when path parsing is refactored.
+  std::vector<std::string> root = {"/"};
   if (newPathParts == root) {
     return -ENOTEMPTY;
   }
@@ -928,9 +841,9 @@ long __syscall_rename(long old_path, long new_path) {
     return -ENAMETOOLONG;
   }
 
-  // oldPath is the forbidden ancestor.
-  auto newParentDir =
-    getDir(newPathParts.begin(), newPathParts.end() - 1, err, oldPath);
+  // oldParsedPath.child is the forbidden ancestor.
+  auto newParentDir = getDir(
+    newPathParts.begin(), newPathParts.end() - 1, err, oldParsedPath.child);
 
   // If the destination parent directory doesn't exist, the source file cannot
   // be moved.
@@ -941,6 +854,8 @@ long __syscall_rename(long old_path, long new_path) {
   // Edge case: a/b -> a/c share the same parent. Trylocking the same parent
   // with a recursive mutex should work, so we don't need to treat that case
   // specially here.
+  // TODO: Should getParsedPath return a locked handle already or a shared
+  // pointer and rely on the caller to lock the directory?
   auto maybeLockedNewParentDir = newParentDir->maybeLocked();
   if (!maybeLockedNewParentDir) {
     return -EBUSY;
@@ -950,12 +865,12 @@ long __syscall_rename(long old_path, long new_path) {
   auto newPath = lockedNewParentDir.getEntry(newBase);
 
   // If old_path and new_path are the same, do nothing.
-  if (newPath == oldPath) {
+  if (newPath == oldParsedPath.child) {
     return 0;
   }
 
   // Cannot move from source directory without write permissions.
-  if (!(lockedOldParentDir.mode() & WASMFS_PERM_WRITE)) {
+  if (!((*oldParsedPath.parent).mode() & WASMFS_PERM_WRITE)) {
     return -EACCES;
   }
 
@@ -966,12 +881,12 @@ long __syscall_rename(long old_path, long new_path) {
 
   // new path must be removed if it exists.
   if (newPath) {
-    if (oldPath->is<DataFile>()) {
+    if (oldParsedPath.child->is<DataFile>()) {
       // Cannot overwrite a file with a directory.
       if (newPath->is<Directory>()) {
         return -EISDIR;
       }
-    } else if (oldPath->is<Directory>()) {
+    } else if (oldParsedPath.child->is<Directory>()) {
       auto newPathDirectory = newPath->dynCast<Directory>();
 
       // Cannot overwrite a directory with a file.
@@ -992,8 +907,8 @@ long __syscall_rename(long old_path, long new_path) {
   }
 
   // Unlink the oldpath and add the oldpath to the new parent dir.
-  lockedOldParentDir.unlinkEntry(oldBase);
-  lockedNewParentDir.setEntry(newBase, oldPath);
+  (*oldParsedPath.parent).unlinkEntry(oldPathParts.back());
+  lockedNewParentDir.setEntry(newBase, oldParsedPath.child);
 
   return 0;
 }

--- a/system/lib/wasmfs/wasmfs.h
+++ b/system/lib/wasmfs/wasmfs.h
@@ -26,7 +26,7 @@ class WasmFS {
   std::vector<std::unique_ptr<Backend>> backendTable;
   FileTable fileTable;
   std::shared_ptr<Directory> rootDirectory;
-  std::shared_ptr<File> cwd;
+  std::shared_ptr<Directory> cwd;
   std::mutex mutex;
 
   // Private method to initialize root directory once.
@@ -56,12 +56,12 @@ public:
 
   // For getting and setting cwd, a lock must be acquired. There is a chance
   // that two threads could be mutating the cwd simultaneously.
-  std::shared_ptr<File> getCWD() {
+  std::shared_ptr<Directory> getCWD() {
     const std::lock_guard<std::mutex> lock(mutex);
     return cwd;
   };
 
-  void setCWD(std::shared_ptr<File> directory) {
+  void setCWD(std::shared_ptr<Directory> directory) {
     const std::lock_guard<std::mutex> lock(mutex);
     cwd = directory;
   };

--- a/tests/wasmfs/wasmfs_mkdir.c
+++ b/tests/wasmfs/wasmfs_mkdir.c
@@ -61,6 +61,8 @@ int main() {
   // In Linux and WasmFS, an empty pathname returns ENOENT.
   errno = 0;
   mkdir("", 0777);
+  // in Linux and WasmFS, an empty pathname should return ENOENT.
+  // In the JS File system this returns EINVAL.
 #ifdef WASMFS
   assert(errno == ENOENT);
 #else

--- a/tests/wasmfs/wasmfs_stat.c
+++ b/tests/wasmfs/wasmfs_stat.c
@@ -124,8 +124,14 @@ int main() {
 #endif
   assert(statDirectory.st_blksize == 4096);
 
-  // Test calling stat with an empty pathname.
-  assert(stat("", &statFile) == -1);
+  // Test calling stat with an empty path.
+  errno = 0;
+  assert(stat("", &invalid));
+  assert(errno == ENOENT);
+
+  // Test calling stat with a non-existent path.
+  errno = 0;
+  assert(stat("/non-existent", &invalid));
   assert(errno == ENOENT);
 
   // Test calling lstat without opening a file.


### PR DESCRIPTION
Relevant Issue: #15041 

Propose new path parsing function `getParsedPath`.
TODO: Decide whether to return a locked parent handle or a pointer instead. Seems that rename is the only syscall in which we have to use a `trylock`, which affects the ability of `getParsedPath` to return a locked parent.
TODO: Integrate with any locking for the file system and potentially remove `getDir`.