### PR TITLE
[WASMFS] Include file type in file mode

### DIFF
--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -140,7 +140,9 @@ class DataFile : public File {
 public:
   static constexpr FileKind expectedKind = File::DataFileKind;
   DataFile(mode_t mode, backend_t backend)
-    : File(File::DataFileKind, mode, backend) {}
+    : File(File::DataFileKind, mode | S_IFREG, backend) {}
+  DataFile(mode_t mode, backend_t backend, mode_t fileType)
+    : File(File::DataFileKind, mode | fileType, backend) {}
   virtual ~DataFile() = default;
 
   class Handle : public File::Handle {
@@ -173,7 +175,7 @@ protected:
 public:
   static constexpr FileKind expectedKind = File::DirectoryKind;
   Directory(mode_t mode, backend_t backend)
-    : File(File::DirectoryKind, mode, backend) {}
+    : File(File::DirectoryKind, mode | S_IFDIR, backend) {}
 
   struct Entry {
     std::string name;

--- a/system/lib/wasmfs/streams.h
+++ b/system/lib/wasmfs/streams.h
@@ -28,7 +28,7 @@ class StdinFile : public DataFile {
   size_t getSize() override { return 0; }
 
 public:
-  StdinFile(mode_t mode) : DataFile(mode, NullBackend) {}
+  StdinFile(mode_t mode) : DataFile(mode, NullBackend, S_IFCHR) {}
   static std::shared_ptr<StdinFile> getSingleton();
 };
 
@@ -45,7 +45,7 @@ class StdoutFile : public DataFile {
   size_t getSize() override { return 0; }
 
 public:
-  StdoutFile(mode_t mode) : DataFile(mode, NullBackend) {}
+  StdoutFile(mode_t mode) : DataFile(mode, NullBackend, S_IFCHR) {}
   static std::shared_ptr<StdoutFile> getSingleton();
 };
 
@@ -65,7 +65,7 @@ class StderrFile : public DataFile {
   size_t getSize() override { return 0; }
 
 public:
-  StderrFile(mode_t mode) : DataFile(mode, NullBackend) {}
+  StderrFile(mode_t mode) : DataFile(mode, NullBackend, S_IFCHR) {}
   static std::shared_ptr<StderrFile> getSingleton();
 };
 } // namespace wasmfs

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -436,7 +436,7 @@ static __wasi_fd_t doOpen(char* pathname,
   auto pathParts = splitPath(pathname);
 
   if (pathParts.empty()) {
-    return -EINVAL;
+    return -ENOENT;
   }
 
   auto base = pathParts.back();

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -352,12 +352,6 @@ static long doStat(std::shared_ptr<File> file, struct stat* buffer) {
     1; // ID of device containing file: Hardcode 1 for now, no meaning at the
   // moment for Emscripten.
   buffer->st_mode = lockedFile.mode();
-  // TODO: Add mode for symlinks.
-  if (file->is<Directory>()) {
-    buffer->st_mode |= S_IFDIR;
-  } else if (file->is<DataFile>()) {
-    buffer->st_mode |= S_IFREG;
-  }
   buffer->st_ino = file->getIno();
   // The number of hard links is 1 since they are unsupported.
   buffer->st_nlink = 1;

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11196,7 +11196,6 @@ void foo() {}
 
   @also_with_wasmfs
   def test_unistd_open(self):
-    self.set_setting('WASMFS')
     self.do_run_in_out_file_test('wasmfs/wasmfs_open.c')
 
   @also_with_wasmfs

--- a/tests/wasmfs/wasmfs_open.c
+++ b/tests/wasmfs/wasmfs_open.c
@@ -33,8 +33,13 @@ int main() {
   struct stat file;
   fstat(fd2, &file);
 
-  assert((file.st_mode & S_IFMT) == S_IFREG);
-  assert(file.st_mode == (S_IWUGO | S_IFREG));
+  assert((file.st_mode & S_IFMT) == S_IFCHR);
+  // The JS file system assigns S_IWUGO | S_IRUGO | S_IFCHR to devices.
+#ifdef WASMFS
+  assert(file.st_mode == (S_IWUGO | S_IFCHR));
+#else
+  assert(file.st_mode == (S_IWUGO | S_IRUGO | S_IFCHR));
+#endif
 
   // Close open file
   close(fd2);
@@ -53,14 +58,18 @@ int main() {
   fstat(fd3, &dir);
 
   assert((dir.st_mode & S_IFMT) == S_IFDIR);
+  // The JS file system assigns write access to /dev.
+#ifdef WASMFS
   assert(dir.st_mode == (S_IRUGO | S_IXUGO | S_IFDIR));
+#else
+  assert(dir.st_mode == (S_IWUGO | S_IRUGO | S_IXUGO | S_IFDIR));
+#endif
 
   const char* msg = "Test\n";
 
   errno = 0;
   write(fd3, msg, strlen(msg));
   // TODO: Change to assert(errno == EBADF) when access mode checking is added.
-  printf("Errno: %s\n", strerror(errno));
 
   char buf[100];
 
@@ -79,19 +88,29 @@ int main() {
   // Attempt to open a file path with a file intermediary.
   int fd5 = open("/dev/stdout/foo", O_RDWR);
   printf("Errno: %s\n", strerror(errno));
+  // Both errors are valid, but in WasmFS, ENOTDIR is returned first.
+#ifdef WASMFS
   assert(errno == ENOTDIR);
+#else
+  assert(errno == ENOENT);
+#endif
 
   errno = 0;
   // Attempt to open and write to the root directory.
   int fd6 = open("/", O_RDONLY);
   write(fd6, msg, strlen(msg));
   printf("Errno: %s\n", strerror(errno));
+  // In Linux and WasmFS one can obtain a fd to a directory.
+#ifdef WASMFS
   assert(errno == EISDIR);
+#else
+  assert(errno == EBADF);
+#endif
 
   errno = 0;
   // Attempt to open a blank path.
   int fd7 = open("", O_RDONLY);
-  assert(errno == EINVAL);
+  assert(errno == ENOENT);
 
   return 0;
 }

--- a/tests/wasmfs/wasmfs_open.out
+++ b/tests/wasmfs/wasmfs_open.out
@@ -2,7 +2,4 @@ WORKING WITH TRAILING BACKSLASH
 WORKING WITHOUT TRAILING BACKSLASH
 Errno: Bad file descriptor
 Errno: Is a directory
-Errno: Is a directory
 Errno: No such file or directory
-Errno: Not a directory
-Errno: Is a directory

--- a/tests/wasmfs/wasmfs_stat.c
+++ b/tests/wasmfs/wasmfs_stat.c
@@ -33,12 +33,7 @@ int main() {
   off_t fileInode = file.st_ino;
 
   assert(file.st_size == 0);
-  // TODO: In a follow up PR change /dev/stdout to have type S_IFCHR
-#ifdef WASMFS
-  assert((file.st_mode & S_IFMT) == S_IFREG);
-#else
   assert((file.st_mode & S_IFMT) == S_IFCHR);
-#endif
   assert(file.st_dev);
   assert(file.st_nlink);
   assert(file.st_uid == 0);
@@ -100,11 +95,7 @@ int main() {
   assert(stat("/dev/stdout/", &statFile) != -1);
 
   assert(statFile.st_size == 0);
-#ifdef WASMFS
-  assert((statFile.st_mode & S_IFMT) == S_IFREG);
-#else
   assert((statFile.st_mode & S_IFMT) == S_IFCHR);
-#endif
   assert(statFile.st_dev);
   assert(statFile.st_nlink);
   assert(statFile.st_uid == 0);
@@ -139,8 +130,9 @@ int main() {
   assert(lstat("/dev/stdout", &lstatFile) != -1);
 
   assert(lstatFile.st_dev);
+  // TODO: When symlinks are added, this WasmFS should return S_IFLNK.
 #ifdef WASMFS
-  assert((lstatFile.st_mode & S_IFMT) == S_IFREG);
+  assert((lstatFile.st_mode & S_IFMT) == S_IFCHR);
 #else
   assert((lstatFile.st_mode & S_IFMT) == S_IFLNK);
 #endif


### PR DESCRIPTION
Relevant Issue: #15041 

- Embed file type with file mode and simplify `doStat`.
- Remove the relevant #ifdefs from `wasmfs_stat.c`.

In the JS file system, the following permissions are given to devices:

https://github.com/emscripten-core/emscripten/blob/9297133fd75b9e91c66eea23bd6c27609eb4724d/src/library_fs.js#L689-L696