### PR TITLE
[WASMFS] Generalize File Preloading

### DIFF
--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -12,6 +12,23 @@
 
 namespace wasmfs {
 //
+// DataFile
+//
+void DataFile::Handle::preloadFromJS(int index) {
+  // Create a buffer with the required file size.
+  std::vector<uint8_t> buffer(
+    EM_ASM_INT({return wasmFS$preloadedFiles[$0].fileData.length}, index));
+  // Ensure that files are preloaded from the main thread.
+  assert(emscripten_is_main_runtime_thread());
+  // TODO: Replace every EM_ASM with EM_JS.
+  // Load data into the in-memory buffer.
+  EM_ASM({ HEAPU8.set(wasmFS$preloadedFiles[$1].fileData, $0); },
+         buffer.data(),
+         index);
+
+  write((const uint8_t*)buffer.data(), buffer.size(), 0);
+}
+//
 // Directory
 //
 std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -159,6 +159,7 @@ public:
     }
 
     // This function loads preloaded files from JS Memory into this DataFile.
+    // TODO: Make this virtual so specific backends can specialize it for better performance.
     void preloadFromJS(int index);
   };
 

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -157,6 +157,9 @@ public:
     __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) {
       return getFile()->write(buf, len, offset);
     }
+
+    // This function loads preloaded files from JS Memory into this DataFile.
+    void preloadFromJS(int index);
   };
 
   Handle locked() { return Handle(shared_from_this()); }

--- a/system/lib/wasmfs/memory_file.cpp
+++ b/system/lib/wasmfs/memory_file.cpp
@@ -27,15 +27,4 @@ __wasi_errno_t MemoryFile::read(uint8_t* buf, size_t len, off_t offset) {
 
   return __WASI_ERRNO_SUCCESS;
 }
-
-void MemoryFile::Handle::preloadFromJS(int index) {
-  getFile()->buffer.resize(
-    EM_ASM_INT({return wasmFS$preloadedFiles[$0].fileData.length}, index));
-  // Ensure that files are preloaded from the main thread.
-  assert(emscripten_is_main_runtime_thread());
-  // TODO: Replace every EM_ASM with EM_JS.
-  EM_ASM({ HEAPU8.set(wasmFS$preloadedFiles[$1].fileData, $0); },
-         getFile()->buffer.data(),
-         index);
-}
 } // namespace wasmfs

--- a/system/lib/wasmfs/memory_file.h
+++ b/system/lib/wasmfs/memory_file.h
@@ -32,8 +32,6 @@ public:
 
   public:
     Handle(std::shared_ptr<File> dataFile) : DataFile::Handle(dataFile) {}
-    // This function copies preloaded files from JS Memory to Wasm Memory.
-    void preloadFromJS(int index);
   };
 
   Handle locked() { return Handle(shared_from_this()); }


### PR DESCRIPTION
Relevant Issue: #15041 

- Remove `preloadFromJS` from `MemoryFile`.
- Provide a general preloading function on all `DataFiles`.