### PR TITLE
assert that preRun is never called on a pthread. NFC

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -354,8 +354,8 @@ function keepRuntimeAlive() {
 }
 
 function preRun() {
-#if USE_PTHREADS
-  if (ENVIRONMENT_IS_PTHREAD) return; // PThreads reuse the runtime from the main thread.
+#if ASSERTIONS && USE_PTHREADS
+  assert(!ENVIRONMENT_IS_PTHREAD); // PThreads reuse the runtime from the main thread.
 #endif
 
 #if expectToReceiveOnModule('preRun')


### PR DESCRIPTION
This function is never called from a pthread so the extra
check in release mode was unnecessary.