### PR TITLE
[Minor] Change can_build to can_use in system_libs.py

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1363,7 +1363,7 @@ class libwasmfs(MTLibrary):
         path='system/lib/wasmfs',
         filenames=['syscalls.cpp', 'file_table.cpp', 'file.cpp', 'wasmfs.cpp', 'streams.cpp', 'memory_file.cpp', 'memory_file_backend.cpp', 'js_file_backend.cpp'])
 
-  def can_build(self):
+  def can_use(self):
     return settings.WASMFS
 
 


### PR DESCRIPTION
- Minor change to fix CI tests. `embuilder build ALL` now works and builds everything including `libwasmfs`.