### PR TITLE
Fix `_memset is not defined` errors in asan builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ jobs:
     steps:
       - run-tests:
           # also add a few asan tests and a single test of EMTEST_BROWSER=node
-          test_targets: "wasm2 asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
+          test_targets: "wasm2 asan.test_stat asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
   test-wasm3:
     executor: bionic
     steps:

--- a/emcc.py
+++ b/emcc.py
@@ -2192,8 +2192,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
     if not settings.UBSAN_RUNTIME:
       settings.UBSAN_RUNTIME = 2
 
-    settings.EXPORTED_FUNCTIONS.append('_emscripten_builtin_memset')
-
     # helper functions for JS to call into C to do memory operations. these
     # let us sanitize memory access from the JS side, by calling into C where
     # it has been instrumented.

--- a/src/library.js
+++ b/src/library.js
@@ -3068,9 +3068,6 @@ LibraryManager.library = {
   // When lsan or asan is enabled withBuiltinMalloc temporarily replaces calls
   // to malloc, free, and memalign.
   $withBuiltinMalloc__deps: ['emscripten_builtin_malloc', 'emscripten_builtin_free', 'emscripten_builtin_memalign'
-#if USE_ASAN
-                             , 'emscripten_builtin_memset'
-#endif
                             ],
   $withBuiltinMalloc__docs: '/** @suppress{checkTypes} */',
   $withBuiltinMalloc: function (func) {
@@ -3080,19 +3077,12 @@ LibraryManager.library = {
     _malloc = _emscripten_builtin_malloc;
     _memalign = _emscripten_builtin_memalign;
     _free = _emscripten_builtin_free;
-#if USE_ASAN
-    var prev_memset = typeof _memset !== 'undefined' ? _memset : undefined
-    _memset = _emscripten_builtin_memset;
-#endif
     try {
       return func();
     } finally {
       _malloc = prev_malloc;
       _memalign = prev_memalign;
       _free = prev_free;
-#if USE_ASAN
-      _memset = prev_memset;
-#endif
     }
   },
 #endif


### PR DESCRIPTION
I recently landed #15617 which inadvertently broke asan builds because,
under asan, there was a real dependency on `_memset` in the
`withBuiltinMalloc` wrapper.   However this dependency is no longer
needed since the use of `_memset` was removed from the JS library code
in #14441.