### PR TITLE
Disable asan for sqrtl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,7 +373,7 @@ jobs:
     steps:
       - run-tests:
           # also add a few asan tests and a single test of EMTEST_BROWSER=node
-          test_targets: "wasm2 asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
+          test_targets: "wasm2 asan.test_float_builtins asan.test_embind* asan.test_abort_on_exceptions asan.test_ubsan_full_left_shift_fsanitize_integer asan.test_pthread* asan.test_dyncall_specific_minimal_runtime asan.test_async_hello lsan.test_stdio_locking lsan.test_pthread_create browser.test_pthread_join"
   test-wasm3:
     executor: bionic
     steps:

--- a/system/lib/libc/musl/src/math/sqrtl.c
+++ b/system/lib/libc/musl/src/math/sqrtl.c
@@ -176,6 +176,10 @@ static inline u128 mul128_tail(u128 a, u128 b)
 
 /* see sqrt.c for detailed comments.  */
 
+#ifdef __EMSCRIPTEN__
+// https://github.com/emscripten-core/emscripten/issues/15655
+__attribute__((no_sanitize("address")))
+#endif
 long double sqrtl(long double x)
 {
 	u128 ix, ml;


### PR DESCRIPTION
This fixes asan.test_float_builtins which is currently failing.

I don't know if this is a genuine failure but it seems unlikely.
It only occurs with `-Oz` so it could be come kind of miscompile?

Leaving the bug open so somebody can follow up.

See: #15655