### PR TITLE
Remove redundant call to pthread_testcancel. NFC.

### DIFF
--- a/system/lib/libc/musl/src/thread/pthread_cond_timedwait.c
+++ b/system/lib/libc/musl/src/thread/pthread_cond_timedwait.c
@@ -187,10 +187,6 @@ done:
 		__pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, 0);
 	}
 
-#ifdef __EMSCRIPTEN__
-	pthread_testcancel();
-#endif
-
 	return e;
 }
 


### PR DESCRIPTION
This was introduced in commit d2bb705 (which was based on musl
1.0.5), but when musl was updated to 1.1.15 (commit 31cf2bb),
it ends up calling `pthread_testcancel` twice.

Split from PR #15603.