### PR TITLE
Enable --threadprofiler under node

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10527,6 +10527,14 @@ exec "$@"
     # TODO: Enable '-s', 'CLOSURE_WARNINGS=error' in the following, but that has currently regressed.
     self.run_process([EMCC, test_file('hello_world.c'), '-O2', '-s', 'USE_PTHREADS', '--closure=1', '--threadprofiler'])
 
+  @node_pthreads
+  def test_threadprofiler(self):
+    self.run_process([EMCC, test_file('test_threadprofiler.cpp'), '-sUSE_PTHREADS', '-sPROXY_TO_PTHREAD', '-sEXIT_RUNTIME', '--threadprofiler'])
+    output = self.run_js('a.out.js')
+    self.assertRegex(output, r'Thread "Browser main thread" \(0x.*\) now: running.')
+    self.assertRegex(output, r'Thread "Application main thread" \(0x.*\) now: waiting for a futex.')
+    self.assertRegex(output, r'Thread "test worker" \(0x.*\) now: sleeping.')
+
   def test_syslog(self):
     self.do_other_test('test_syslog.c')
 

--- a/tests/test_threadprofiler.cpp
+++ b/tests/test_threadprofiler.cpp
@@ -1,0 +1,18 @@
+#include <pthread.h>
+#include <unistd.h>
+#include <emscripten/threading.h>
+
+void* worker_thread(void*) {
+  emscripten_set_thread_name(pthread_self(), "test worker");
+  for (int i = 0; i < 2; i++) {
+    usleep(1000*1000);
+  }
+  return NULL;
+}
+
+int main() {
+  pthread_t thread;
+  pthread_create(&thread, NULL, worker_thread, NULL);
+  pthread_join(thread, NULL);
+  return 0;
+}


### PR DESCRIPTION
This simple dumps the thread state every N milliseconds.  Mostly this is
intended as way to provide some basic test coverage for the thread
profiling code.