### PR TITLE
Remove unneeded warning supressions when building libc. NFC

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -743,8 +743,6 @@ class libc(AsanInstrumentedLibrary, MuslInternalLibrary, MTLibrary):
 
   # Disable certain warnings for code patterns that are contained in upstream musl
   cflags += ['-Wno-ignored-attributes',
-             '-Wno-dangling-else',
-             '-Wno-unknown-pragmas',
              '-Wno-shift-op-parentheses',
              '-Wno-string-plus-int',
              '-Wno-pointer-sign']


### PR DESCRIPTION
I guess these were needed for a previous version of musl.