### PR TITLE
Remove DLMALLOC_DEBUG. NFC

### DIFF
--- a/system/lib/dlmalloc.c
+++ b/system/lib/dlmalloc.c
@@ -10,7 +10,7 @@
 #define UNSIGNED_MORECORE 1
 /* we can only grow the heap up anyhow, so don't try to trim */
 #define MORECORE_CANNOT_TRIM 1
-#ifndef DLMALLOC_DEBUG
+#ifndef DEBUG
 /* dlmalloc has many checks, calls to abort() increase code size,
    leave them only in debug builds */
 #define ABORT __builtin_unreachable()

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1737,7 +1737,8 @@ class libmalloc(MTLibrary):
     if self.verbose:
       cflags += ['-DEMMALLOC_VERBOSE']
     if self.is_debug:
-      cflags += ['-UNDEBUG', '-DDLMALLOC_DEBUG']
+      # dlmalloc debugging is enabled by defining DEBUG
+      cflags += ['-UNDEBUG', '-DDEBUG']
     else:
       cflags += ['-DNDEBUG']
     if self.is_tracing:


### PR DESCRIPTION
dlmalloc already has `DEBUG` macros that is used to enable debugging, so
just use that one for consistency.

See #15662 and #15628
