### PR TITLE
emar: only use a response file if needed. NFC

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -36,7 +36,7 @@ from common import RunnerCore, path_from_root, is_slow_test, ensure_dir, disable
 from common import env_modify, no_mac, no_windows, requires_native_clang, with_env_modify
 from common import create_file, parameterized, NON_ZERO, node_pthreads, TEST_ROOT, test_file
 from common import compiler_for, read_file, read_binary, EMBUILDER, require_v8, require_node
-from tools import shared, building, utils, deps_info
+from tools import shared, building, utils, deps_info, response_file
 import common
 import jsrun
 import clang_native
@@ -7770,7 +7770,8 @@ end
     create_file("file'2", ' ')
     create_file("hyvää päivää", ' ')
     create_file("snowman freezes covid ☃ 🦠", ' ')
-    building.emar('cr', 'libfoo.a', ("file'1", "file'2", "hyvää päivää", "snowman freezes covid ☃ 🦠"))
+    rsp = response_file.create_response_file(("file'1", "file'2", "hyvää päivää", "snowman freezes covid ☃ 🦠"), shared.TEMP_DIR)
+    building.emar('cr', 'libfoo.a', ['@' + rsp])
 
   def test_archive_empty(self):
     # This test added because we had an issue with the AUTO_ARCHIVE_INDEXES failing on empty

--- a/tools/building.py
+++ b/tools/building.py
@@ -586,12 +586,9 @@ def parse_llvm_nm_symbols(output):
 
 def emar(action, output_filename, filenames, stdout=None, stderr=None, env=None):
   try_delete(output_filename)
-  response_filename = response_file.create_response_file(filenames, TEMP_DIR)
-  cmd = [EMAR, action, output_filename] + ['@' + response_filename]
-  try:
-    run_process(cmd, stdout=stdout, stderr=stderr, env=env)
-  finally:
-    try_delete(response_filename)
+  cmd = [EMAR, action, output_filename] + filenames
+  cmd = get_command_with_possible_response_file(cmd)
+  run_process(cmd, stdout=stdout, stderr=stderr, env=env)
 
   if 'c' in action:
     assert os.path.exists(output_filename), 'emar could not create output file: ' + output_filename


### PR DESCRIPTION
All the other command runners in `tools/building.py` use this
pattern already.

`test_emar_response_file` was updated to explictly use a
response file.
