### PR TITLE
Fix initial currentStatusStartTime in PTHREADS_PROFILING

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -8,7 +8,7 @@ var LibraryPThread = {
   $PThread__postset: 'if (!ENVIRONMENT_IS_PTHREAD) PThread.initMainThreadBlock();',
   $PThread__deps: ['_emscripten_thread_init',
                    'emscripten_futex_wake', '$killThread',
-                   '$cancelThread', '$cleanupThread',
+                   '$cancelThread', '$cleanupThread', '$zeroMemory',
                    '_emscripten_thread_free_data',
                    'exit',
 #if !MINIMAL_RUNTIME
@@ -59,8 +59,8 @@ var LibraryPThread = {
       Atomics.store(HEAPU32, (pthreadPtr + {{{ C_STRUCTS.pthread.profilerBlock }}} ) >> 2, profilerBlock);
 
       // Zero fill contents at startup.
-      for (var i = 0; i < {{{ C_STRUCTS.thread_profiler_block.__size__ }}}; i += 4) Atomics.store(HEAPU32, (profilerBlock + i) >> 2, 0);
-      Atomics.store(HEAPU32, (profilerBlock + {{{ C_STRUCTS.thread_profiler_block.currentStatusStartTime }}} ) >> 2, performance.now());
+      zeroMemory(profilerBlock, {{{ C_STRUCTS.thread_profiler_block.__size__ }}});
+      HEAPF64[(profilerBlock + {{{ C_STRUCTS.thread_profiler_block.currentStatusStartTime }}} ) >> 3] = performance.now();
     },
 
     // Sets the current thread status, but only if it was in the given expected state before. This is used


### PR DESCRIPTION
`currentStatusStartTime` is a double not a u32 so needs to be set via
`HEAPF64`.  See below in `setThreadStatusConditional` where we update
this value (correctly) using `HEAPF64`.

Also, use zeroMemory rather than a loop.