### PR TITLE
Document --closure-args in emcc reference.

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -253,6 +253,16 @@ Options that are modified or new in *emcc* are listed below:
      * Closure is only run if JavaScript opts are being done ("-O2" or
        above).
 
+"--closure-args=<args>"
+   [link] Pass arguments to the *Closure compiler*. This is an
+   alternative to "EMCC_CLOSURE_ARGS".
+   
+   For example, one might want to pass an externs file to avoid
+   minifying JS functions defined in "--pre-js" or "--post-js" files.
+   To pass to Closure the "externs.js" file containing those public
+   APIs that should not be minified, one would add the flag:
+   "--closure-args=--externs=path/to/externs.js"
+
 "--pre-js <file>"
    [link] Specify a file whose contents are added before the emitted
    code and optimized together with it. Note that this might not

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -256,12 +256,12 @@ Options that are modified or new in *emcc* are listed below:
 "--closure-args=<args>"
    [link] Pass arguments to the *Closure compiler*. This is an
    alternative to "EMCC_CLOSURE_ARGS".
-   
+
    For example, one might want to pass an externs file to avoid
    minifying JS functions defined in "--pre-js" or "--post-js" files.
    To pass to Closure the "externs.js" file containing those public
-   APIs that should not be minified, one would add the flag:
-   "--closure-args=--externs=path/to/externs.js"
+   APIs that should not be minified, one would add the flag: "--
+   closure-args=--externs=path/to/externs.js"
 
 "--pre-js <file>"
    [link] Specify a file whose contents are added before the emitted

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -232,6 +232,13 @@ Options that are modified or new in *emcc* are listed below:
     - If closure compiler hits an out-of-memory, try adjusting ``JAVA_HEAP_SIZE`` in the environment (for example, to 4096m for 4GB).
     - Closure is only run if JavaScript opts are being done (``-O2`` or above).
 
+``--closure-args=<args>``
+   [link]
+   Pass arguments to the :term:`Closure compiler`. This is an alternative to ``EMCC_CLOSURE_ARGS``.
+
+   For example, one might want to pass an externs file to avoid minifying JS functions defined in ``--pre-js`` or ``--post-js`` files.
+   To pass to Closure the ``externs.js`` file containing those public APIs that should not be minified, one would add the flag:
+   ``--closure-args=--externs=path/to/externs.js``
 
 .. _emcc-pre-js:
 


### PR DESCRIPTION
The environment variable EMCC_CLOSURE_ARGS does not work well in all places (e.g. Bazel), so it would be good document the ability to use flags to impact Closure.