### PR TITLE
Add deprecation warning for `EMMAKEN_CFLAGS`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,7 @@ See docs/process.md for more on how version tagging works.
 
 3.0.1
 -----
+- Deprecate `EMMAKEN_CFLAGS` is favor of `EMCC_CFLAGS`.
 
 3.0.0 - 11/22/2021
 ------------------

--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -606,9 +606,11 @@ Environment variables
 
 *emcc* is affected by several environment variables, as listed below:
 
-   * "EMMAKEN_CFLAGS" [compile+link]
+   * "EMMAKEN_CFLAGS" [compile+link] Deprecated. Use "EMCC_CFLAGS"
+     instead.
 
-   * "EMMAKEN_COMPILER" [compile+link] Deprecated. Avoid using.
+   * "EMMAKEN_COMPILER" [compile+link] Deprecated. Use "EM_LLVM_ROOT"
+     and/or "EM_COMPIELR_WRAPPER" instead.
 
    * "EMMAKEN_JUST_CONFIGURE" [other]
 

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -524,8 +524,8 @@ Environment variables
 =====================
 *emcc* is affected by several environment variables, as listed below:
 
-  - ``EMMAKEN_CFLAGS`` [compile+link]
-  - ``EMMAKEN_COMPILER`` [compile+link] Deprecated. Avoid using.
+  - ``EMMAKEN_CFLAGS`` [compile+link] Deprecated. Use ``EMCC_CFLAGS`` instead.
+  - ``EMMAKEN_COMPILER`` [compile+link] Deprecated. Use ``EM_LLVM_ROOT`` and/or ``EM_COMPIELR_WRAPPER`` instead.
   - ``EMMAKEN_JUST_CONFIGURE`` [other]
   - ``EMCC_AUTODEBUG`` [compile+link]
   - ``EMCC_CFLAGS`` [compile+link]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6394,7 +6394,7 @@ void* operator new(size_t size) {
       # In ASan mode we need a large initial memory (or else wasm-ld fails).
       # The OpenJPEG CMake will build several executables (which we need parts
       # of in our testing, see above), so we must enable the flag for them all.
-      with env_modify({'EMMAKEN_CFLAGS': '-sINITIAL_MEMORY=300MB'}):
+      with env_modify({'EMCC_CFLAGS': '-sINITIAL_MEMORY=300MB'}):
         do_test_openjpeg()
     else:
       do_test_openjpeg()

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10342,6 +10342,11 @@ int main () {
     stderr = self.run_process([EMCC, '-c', test_file('core/test_hello_world.c')], stderr=PIPE).stderr
     self.assertContained('warning: `EMMAKEN_COMPILER` is deprecated', stderr)
 
+  @with_env_modify({'EMMAKEN_CFLAGS': '-O2'})
+  def test_emmaken_cflags(self):
+    stderr = self.run_process([EMCC, '-c', test_file('core/test_hello_world.c')], stderr=PIPE).stderr
+    self.assertContained('warning: `EMMAKEN_CFLAGS` is deprecated', stderr)
+
   @no_windows('relies on a shell script')
   def test_compiler_wrapper(self):
     create_file('wrapper.sh', '''\
@@ -10618,10 +10623,10 @@ exec "$@"
     self.assertFileContents(test_file('reference_struct_info.json'), read_file('out.json'))
 
   def test_gen_struct_info_env(self):
-    # gen_struct_info.py builds C code in a very particlar way.  We don't want EMMAKEN_CFLAGS to
+    # gen_struct_info.py builds C code in a very particlar way.  We don't want EMCC_CFLAGS to
     # be injected which could cause it to fail.
     # For example -O2 causes printf -> iprintf which will fail with undefined symbol iprintf.
-    with env_modify({'EMMAKEN_CFLAGS': '-O2 BAD_ARG'}):
+    with env_modify({'EMCC_CFLAGS': '-O2 BAD_ARG'}):
       self.run_process([PYTHON, path_from_root('tools/gen_struct_info.py'), '-o', 'out.json'])
 
   def test_relocatable_limited_exports(self):


### PR DESCRIPTION
Also, move processing of `EMMAKEN_CFLAGS` up to the same place
where we process `EMCC_FLAGS` to its obvious they are equivalent.

See https://github.com/emscripten-core/emscripten/issues/15684