### PR TITLE
Decouple dispatching from em_queued_call management

### DIFF
--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -255,43 +255,49 @@ EMSCRIPTEN_RESULT emscripten_wait_for_call_i(em_queued_call *call, double timeou
 
 void emscripten_async_waitable_close(em_queued_call *call);
 
-// Runs the given function on the specified thread. If we are currently on
-// that target thread then we just execute the call synchronously; otherwise it
-// is queued on that thread to execute asynchronously.
-// Returns 1 if it executed the code (i.e., it was on the target thread), and 0
-// otherwise.
+// Runs the given function on the specified thread. If we are currently on that
+// target thread then we just execute the call synchronously; otherwise it is
+// queued on that thread to execute asynchronously. Returns 1 if the function
+// was successfully run or dispatched and 0 otherwise.
+int emscripten_dispatch_to_thread_ptr(pthread_t target_thread,
+                                      void (*func)(void*),
+                                      void* arg);
 int emscripten_dispatch_to_thread_args(pthread_t target_thread,
                                        EM_FUNC_SIGNATURE sig,
-                                       void* func_ptr,
+                                       void* func,
                                        void* satellite,
                                        va_list args);
 int emscripten_dispatch_to_thread_(pthread_t target_thread,
                                    EM_FUNC_SIGNATURE sig,
-                                   void* func_ptr,
+                                   void* func,
                                    void* satellite,
                                    ...);
+// Convenience wrapper supplying the explicit void* cast required by C++.
 #define emscripten_dispatch_to_thread(                                         \
-  target_thread, sig, func_ptr, satellite, ...)                                \
+  target_thread, sig, func, satellite, ...)                                    \
   emscripten_dispatch_to_thread_(                                              \
-    (target_thread), (sig), (void*)(func_ptr), (satellite), ##__VA_ARGS__)
+    (target_thread), (sig), (void*)(func), (satellite), ##__VA_ARGS__)
 
 // Similar to emscripten_dispatch_to_thread, but always runs the
 // function asynchronously, even if on the same thread. This is less efficient
 // but may be simpler to reason about in some cases.
+int emscripten_dispatch_to_thread_async_ptr(pthread_t target_thread,
+                                            void (*func)(void*),
+                                            void* arg);
 int emscripten_dispatch_to_thread_async_args(pthread_t target_thread,
                                              EM_FUNC_SIGNATURE sig,
-                                             void* func_ptr,
+                                             void* func,
                                              void* satellite,
                                              va_list args);
 int emscripten_dispatch_to_thread_async_(pthread_t target_thread,
                                          EM_FUNC_SIGNATURE sig,
-                                         void* func_ptr,
+                                         void* func,
                                          void* satellite,
                                          ...);
 #define emscripten_dispatch_to_thread_async(                                   \
-  target_thread, sig, func_ptr, satellite, ...)                                \
+  target_thread, sig, func, satellite, ...)                                    \
   emscripten_dispatch_to_thread_async_(                                        \
-    (target_thread), (sig), (void*)(func_ptr), (satellite), ##__VA_ARGS__)
+    (target_thread), (sig), (void*)(func), (satellite), ##__VA_ARGS__)
 
 // Returns 1 if the current thread is the thread that hosts the Emscripten runtime.
 int emscripten_is_main_runtime_thread(void);

--- a/tests/pthread/test_pthread_dispatch_after_exit.c
+++ b/tests/pthread/test_pthread_dispatch_after_exit.c
@@ -28,7 +28,7 @@ void looper() {
   if (doneEntry) {
     puts("looper() : running Shutdown on thread");
     int rc = emscripten_dispatch_to_thread(mythread, EM_FUNC_SIG_V, Shutdown, NULL);
-    assert(rc == 0);
+    assert(rc == 1);
     doneEntry = 0;
   }
   if (doneShutdown) {


### PR DESCRIPTION
Introduce new `emscripten_dispatch_to_thread_{async_}ptr` functions that take
`void (*)(void*)` function pointers and `void*` arguments and do not use the
`em_queued_call` functionality. These functions are both useful to users, who
may want to dispatch work that does not fit cleanly into the `em_queued_call`
system, and also simplifies the implementation by separating the proxying logic
from the `em_queued_call` creation and dispatch logic.

Now that these two pieces have been decoupled, the dispatching logic needs to
report whether or not dispatching succeeded so that the `em_queued_call` logic
can clean up in the event of failure. Previously `emscripten_dispatch_to_thread`
returned 1 if the dispatched function was synchronously called and 0 otherwise,
so there was no way to differentiate an error from a successful dispatch to
another thread. To fix this wart and enable proper resource management, change
the return value to 1 when the dispatch is successful.