### PR TITLE
Update WebGPU vertex/index buffer binding methods

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -585,3 +585,4 @@ a license to everyone to use it as detailed in LICENSE.)
 * James Price <jrprice@google.com> (copyright owned by Google, Inc.)
 * Nathan Rugg <nmrugg@gmail.com> (copyright owned by Chess.com, LLC)
 * Alexander O'Mara <me@alexomara.com>
+* Kamaron Peterson <kamaron.peterson@gmail.com>

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -50,7 +50,7 @@
     },
 
     makeU64ToNumberWithSentinelAsUndefined: function(lowName, highName) {
-      var ret = `((${highName} === 0xFFFFFFFF && ${lowName} === 0xFFFFFFFF) ? undefined : \
+      var ret = `((${highName} === -1 && ${lowName} === -1) ? undefined : \
           ${this.makeU64ToNumber(lowName, highName)})`;
       return ret;
     },

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -1035,9 +1035,9 @@ namespace wgpu {
         void PopDebugGroup() const;
         void PushDebugGroup(char const * groupLabel) const;
         void SetBindGroup(uint32_t groupIndex, BindGroup const& group, uint32_t dynamicOffsetCount = 0, uint32_t const * dynamicOffsets = nullptr) const;
-        void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = 0) const;
+        void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
         void SetPipeline(RenderPipeline const& pipeline) const;
-        void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = 0) const;
+        void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
 
       private:
         friend ObjectBase<RenderBundleEncoder, WGPURenderBundleEncoder>;
@@ -1065,11 +1065,11 @@ namespace wgpu {
         void PushDebugGroup(char const * groupLabel) const;
         void SetBindGroup(uint32_t groupIndex, BindGroup const& group, uint32_t dynamicOffsetCount = 0, uint32_t const * dynamicOffsets = nullptr) const;
         void SetBlendConstant(Color const * color) const;
-        void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = 0) const;
+        void SetIndexBuffer(Buffer const& buffer, IndexFormat format, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
         void SetPipeline(RenderPipeline const& pipeline) const;
         void SetScissorRect(uint32_t x, uint32_t y, uint32_t width, uint32_t height) const;
         void SetStencilReference(uint32_t reference) const;
-        void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = 0) const;
+        void SetVertexBuffer(uint32_t slot, Buffer const& buffer, uint64_t offset = 0, uint64_t size = WGPU_WHOLE_SIZE) const;
         void SetViewport(float x, float y, float width, float height, float minDepth, float maxDepth) const;
         void WriteTimestamp(QuerySet const& querySet, uint32_t queryIndex) const;
 

--- a/tests/webgpu_basic_rendering.cpp
+++ b/tests/webgpu_basic_rendering.cpp
@@ -133,7 +133,7 @@ void render(wgpu::TextureView view) {
         {
             wgpu::RenderPassEncoder pass = encoder.BeginRenderPass(&renderpass);
             pass.SetPipeline(pipeline);
-            pass.Draw(3, 1, 0, 0);
+            pass.Draw(3);
             pass.EndPass();
         }
         commands = encoder.Finish();


### PR DESCRIPTION
I've also been running into #15237 - I'm using this fix on my development branch, and would like to merge it upstream.

I have a couple concerns, since this is my first contribution to Emscripten's code base and I want to make sure everything is in order:

I only included [this commit](https://dawn.googlesource.com/dawn/+/2be4b8483c745794971fad323f956d5c0392c878) from Dawn - there's probably a lot others that I didn't include, I didn't bother to check the rest (I'm not confident I would have been able to update all of them appropriately).

Thee bug in `makeU64ToNumberWithSentinelAsUndefined` is that `0xFFFFFFFF` in JavaScript is evaluated as a Number (not as an Int32) to 2^32-1, but `lowName` and `highName` were evaluated from that same bitset as `Int32`s. I could also compare as `((${highName} === (0xFFFFFFFF | 0)))` to force evaluation of `0xFFFFFFFF` as an `Int32` as well (compare apples to apples), but `=== -1` is a bit less crypitc IMO.

Thanks!