### PR TITLE
Update --closure-args docs with absolute paths

### DIFF
--- a/docs/emcc.txt
+++ b/docs/emcc.txt
@@ -261,7 +261,7 @@ Options that are modified or new in *emcc* are listed below:
    minifying JS functions defined in "--pre-js" or "--post-js" files.
    To pass to Closure the "externs.js" file containing those public
    APIs that should not be minified, one would add the flag: "--
-   closure-args=--externs=path/to/externs.js"
+   closure-args=--externs=/abs/path/to/externs.js"
 
 "--pre-js <file>"
    [link] Specify a file whose contents are added before the emitted

--- a/site/source/docs/tools_reference/emcc.rst
+++ b/site/source/docs/tools_reference/emcc.rst
@@ -238,7 +238,7 @@ Options that are modified or new in *emcc* are listed below:
 
    For example, one might want to pass an externs file to avoid minifying JS functions defined in ``--pre-js`` or ``--post-js`` files.
    To pass to Closure the ``externs.js`` file containing those public APIs that should not be minified, one would add the flag:
-   ``--closure-args=--externs=path/to/externs.js``
+   ``--closure-args=--externs=/abs/path/to/externs.js``
 
 .. _emcc-pre-js:
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -816,7 +816,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   # Specify input file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
   args += ['--js', move_to_safe_7bit_ascii_filename(filename)]
   cmd = closure_cmd + args + user_args
-  logger.debug(f'closure compiler: {shared.shlex_join(cmd)}')
+  logger.debug(f'closure compiler: {shared.shlex_join(cmd)} in directory {tempfiles.tmpdir}')
 
   # Closure compiler does not work if any of the input files contain characters outside the
   # 7-bit ASCII range. Therefore make sure the command line we pass does not contain any such


### PR DESCRIPTION
As discovered in [emscripten-core/emsdk#941](https://github.com/emscripten-core/emsdk/pull/941#issuecomment-984641606) the closure command is run in a temporary directory, so any externs files must be referenced by absolute path, otherwise they will not be found.

This also adds the temporary directory to the logs so future issues like this are easier to debug.