### PR TITLE
Fix for passing non-absolute paths as closure --externs

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7885,7 +7885,13 @@ end
 
   # Tests --closure-args command line flag
   def test_closure_externs(self):
-    self.run_process([EMCC, test_file('hello_world.c'), '--closure=1', '--pre-js', test_file('test_closure_externs_pre_js.js'), '--closure-args', '--externs "' + test_file('test_closure_externs.js') + '"'])
+    # Test with relocate path to the externs file to ensure that incoming relative paths
+    # are translated correctly (Since closure runs with a different CWD)
+    shutil.copyfile(test_file('test_closure_externs.js'), 'local_externs.js')
+    self.run_process([EMCC, test_file('hello_world.c'),
+                      '--closure=1',
+                      '--pre-js', test_file('test_closure_externs_pre_js.js'),
+                      '--closure-args', '--externs "local_externs.js"'])
 
   # Tests that it is possible to enable the Closure compiler via --closure=1 even if any of the input files reside in a path with unicode characters.
   def test_closure_cmdline_utf8_chars(self):

--- a/tools/building.py
+++ b/tools/building.py
@@ -794,7 +794,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
 
   def move_to_safe_7bit_ascii_filename(filename):
     if isascii(filename):
-      return filename
+      return os.path.abspath(filename)
     safe_filename = tempfiles.get('.js').name  # Safe 7-bit filename
     shutil.copyfile(filename, safe_filename)
     return os.path.relpath(safe_filename, tempfiles.tmpdir)


### PR DESCRIPTION
See https://github.com/emscripten-core/emsdk/pull/941