### PR TITLE
Be consistent about how we add the emscripten root to `sys.path`. NFC

### DIFF
--- a/tools/ctor_evaller.py
+++ b/tools/ctor_evaller.py
@@ -15,7 +15,9 @@ import os
 import subprocess
 import sys
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 from tools import utils
 

--- a/tools/emdwp.py
+++ b/tools/emdwp.py
@@ -9,7 +9,11 @@
 
 import sys
 import os
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
+
 from tools import shared
 
 cmd = [shared.LLVM_DWP] + sys.argv[1:]

--- a/tools/emnm.py
+++ b/tools/emnm.py
@@ -9,7 +9,11 @@
 
 import os
 import sys
-sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
+
 from tools import shared
 
 cmd = [shared.LLVM_NM] + sys.argv[1:]

--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -65,7 +65,9 @@ import random
 import uuid
 import ctypes
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 import posixpath
 from tools import shared, utils

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -85,7 +85,9 @@ import argparse
 import tempfile
 import subprocess
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 from tools import shared
 from tools import system_libs

--- a/tools/hacky_postprocess_around_closure_limitations.py
+++ b/tools/hacky_postprocess_around_closure_limitations.py
@@ -3,7 +3,9 @@ import os
 import re
 import sys
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 from tools import building
 from tools.utils import read_file, write_file

--- a/tools/js_optimizer.py
+++ b/tools/js_optimizer.py
@@ -11,18 +11,16 @@ import re
 import json
 import shutil
 
-__rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-sys.path.insert(1, __rootpath__)
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 from tools.toolchain_profiler import ToolchainProfiler
+from tools.utils import path_from_root
 from tools import building, config, shared, utils
 
 configuration = shared.configuration
 temp_files = configuration.get_temp_files()
-
-
-def path_from_root(*pathelems):
-  return os.path.join(__rootpath__, *pathelems)
 
 
 ACORN_OPTIMIZER = path_from_root('tools/acorn-optimizer.js')

--- a/tools/maybe_wasm2js.py
+++ b/tools/maybe_wasm2js.py
@@ -29,7 +29,9 @@ import os
 import subprocess
 import sys
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 from tools import shared, building
 

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -3,7 +3,9 @@ import sys
 import os
 import logging
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 from tools import shared
 from tools import line_endings

--- a/tools/simde_update.py
+++ b/tools/simde_update.py
@@ -15,7 +15,10 @@ import sys
 
 from os import path
 
-sys.path.insert(1, path.dirname(path.dirname(path.abspath(__file__))))
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
+
 from tools.shared import get_emscripten_temp_dir
 
 tmpdir = get_emscripten_temp_dir()

--- a/tools/toolchain_profiler.py
+++ b/tools/toolchain_profiler.py
@@ -12,10 +12,9 @@ import tempfile
 import time
 from contextlib import ContextDecorator
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 logger = logging.getLogger('profiler')
 
-from tools import response_file
+from . import response_file
 
 EMPROFILE = int(os.getenv('EMPROFILE', '0'))
 

--- a/tools/wasm-sourcemap.py
+++ b/tools/wasm-sourcemap.py
@@ -21,8 +21,9 @@ from subprocess import Popen, PIPE
 from pathlib import Path
 import sys
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 logger = logging.getLogger('wasm-sourcemap')
 

--- a/tools/webidl_binder.py
+++ b/tools/webidl_binder.py
@@ -11,7 +11,9 @@ https://emscripten.org/docs/porting/connecting_cpp_and_javascript/WebIDL-Binder.
 import os
 import sys
 
-sys.path.insert(1, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+__scriptdir__ = os.path.dirname(os.path.abspath(__file__))
+__rootdir__ = os.path.dirname(__scriptdir__)
+sys.path.append(__rootdir__)
 
 from tools import shared, utils
 


### PR DESCRIPTION
Turns out it can be a little tricky to get this right so always use this
consistent pattern.

`toolchain_profiler.py` don't not need to do any sys.path manipulation
since it is not an entry point and should always be imported via the top
level import (i.e. `tools.toolchain_profiler`).