### PR TITLE
Use Object.assign where available. NFC

### DIFF
--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -1240,7 +1240,7 @@ var LibraryGLEmulation = {
         }
         this.computeKey1 = function() {
           var k = this.traverseKey;
-          key = k[this.colorOp[0]] * 4096;
+          var key = k[this.colorOp[0]] * 4096;
           key += k[this.colorOp[1]] * 1024;
           key += k[this.colorOp[2]] * 256;
           key += k[this.alphaOp[0]] * 16;

--- a/src/library_html5.js
+++ b/src/library_html5.js
@@ -2093,7 +2093,7 @@ var LibraryHTML5 = {
       var targetRect = getBoundingClientRect(target);
       var numTouches = 0;
       for (var i in touches) {
-        var t = touches[i];
+        t = touches[i];
         HEAP32[idx + {{{ C_STRUCTS.EmscriptenTouchPoint.identifier / 4}}}] = t.identifier;
         HEAP32[idx + {{{ C_STRUCTS.EmscriptenTouchPoint.screenX / 4}}}] = t.screenX;
         HEAP32[idx + {{{ C_STRUCTS.EmscriptenTouchPoint.screenY / 4}}}] = t.screenY;

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -987,12 +987,7 @@ function instantiateSync(file, info) {
 // This does not work with nested objects that has prototypes, but it suffices for WasmSourceMap and WasmOffsetConverter.
 function resetPrototype(constructor, attrs) {
   var object = Object.create(constructor.prototype);
-  for (var key in attrs) {
-    if (attrs.hasOwnProperty(key)) {
-      object[key] = attrs[key];
-    }
-  }
-  return object;
+  return objAssign(object, attrs);
 }
 #endif
 

--- a/src/shell.js
+++ b/src/shell.js
@@ -43,6 +43,20 @@ var Module = typeof {{{ EXPORT_NAME }}} !== 'undefined' ? {{{ EXPORT_NAME }}} : 
 #include "promise_polyfill.js"
 #endif
 
+// See https://caniuse.com/mdn-javascript_builtins_object_assign
+#if MIN_CHROME_VERSION < 45 || MIN_EDGE_VERSION < 12 || MIN_FIREFOX_VERSION < 34 || MIN_IE_VERSION != TARGET_NOT_SUPPORTED || MIN_SAFARI_VERSION < 90000
+function objAssign(target, source) {
+  for (key in source) {
+    if (source.hasOwnProperty(key)) {
+      target[key] = source[key];
+    }
+  }
+  return target;
+}
+#else
+var objAssign = Object.assign;
+#endif
+
 #if MODULARIZE
 // Set up the promise that indicates the Module is initialized
 var readyPromiseResolve, readyPromiseReject;
@@ -64,13 +78,7 @@ Module['ready'] = new Promise(function(resolve, reject) {
 // we collect those properties and reapply _after_ we configure
 // the current environment's defaults to avoid having to be so
 // defensive during initialization.
-var moduleOverrides = {};
-var key;
-for (key in Module) {
-  if (Module.hasOwnProperty(key)) {
-    moduleOverrides[key] = Module[key];
-  }
-}
+var moduleOverrides = objAssign({}, Module);
 
 var arguments_ = [];
 var thisProgram = './this.program';
@@ -416,11 +424,7 @@ if (ENVIRONMENT_IS_NODE) {
 #endif
 
 // Merge back in the overrides
-for (key in moduleOverrides) {
-  if (moduleOverrides.hasOwnProperty(key)) {
-    Module[key] = moduleOverrides[key];
-  }
-}
+objAssign(Module, moduleOverrides);
 // Free the object hierarchy contained in the overrides, this lets the GC
 // reclaim data used e.g. in memoryInitializerRequest, which is a large typed array.
 moduleOverrides = null;


### PR DESCRIPTION
The reason this doesn't show up in any code size tests is (I think)
because the of the two types of code size tests we have one only
measures with MINIMAL_RUNTIME (tests/code_size) and the other only looks
at the size of the wasm file (tests/metadce).  We might want to consider
increasing coverage so that this kind of win is picked up the tests?

Hopefully this won't be needed once we allow all of ES6:  #11984 