### PR TITLE
Error in wasm-ld when essential symbols are missing. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -790,12 +790,15 @@ def load_metadata_wasm(metadata_raw, DEBUG):
   if DEBUG:
     logger.debug("Metadata parsed: " + pprint.pformat(metadata))
 
+  expected_exports = set(settings.EXPORTED_FUNCTIONS)
+  expected_exports.update(asmjs_mangle(s) for s in settings.REQUIRED_EXPORTS)
+
   # Calculate the subset of exports that were explicitly marked with llvm.used.
   # These are any exports that were not requested on the command line and are
   # not known auto-generated system functions.
   unexpected_exports = [e for e in metadata['exports'] if treat_as_user_function(e)]
   unexpected_exports = [asmjs_mangle(e) for e in unexpected_exports]
-  unexpected_exports = [e for e in unexpected_exports if e not in settings.EXPORTED_FUNCTIONS]
+  unexpected_exports = [e for e in unexpected_exports if e not in expected_exports]
   building.user_requested_exports.update(unexpected_exports)
   settings.EXPORTED_FUNCTIONS.extend(unexpected_exports)
 

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -30,7 +30,11 @@ var SIDE_MODULE_EXPORTS = [];
 var SIDE_MODULE_IMPORTS = [];
 
 // Like EXPORTED_FUNCTIONS, but will not error if symbol is missing
-var EXPORT_IF_DEFINED = [];
+var EXPORT_IF_DEFINED = ['__start_em_asm', '__stop_em_asm'];
+
+// Like EXPORTED_FUNCTIONS, but symbol is required to exist in native code.
+// This means wasm-ld will fail if these symbols are missing.
+var REQUIRED_EXPORTS = [];
 
 // stores the base name of the output file (-o TARGET_BASENAME.js)
 var TARGET_BASENAME = '';

--- a/tests/common.py
+++ b/tests/common.py
@@ -753,6 +753,9 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     return self.assertContained(text1, text2)
 
   def assertFileContents(self, filename, contents):
+    if EMTEST_VERBOSE:
+      print(f'Comparing results contents of file: {filename}')
+
     contents = contents.replace('\r', '')
 
     if EMTEST_REBASELINE:

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10081,8 +10081,9 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     # First ensure all the system libs are built
     self.run_process([EMCC, test_file('unistd/close.c')])
 
-    self.assertContained('undefined symbol:', self.expect_fail([EMCC, test_file('unistd/close.c'), '-nostdlib']))
-    self.assertContained('undefined symbol:', self.expect_fail([EMCC, test_file('unistd/close.c'), '-nodefaultlibs']))
+    err = 'symbol exported via --export not found: __errno_location'
+    self.assertContained(err, self.expect_fail([EMCC, test_file('unistd/close.c'), '-nostdlib']))
+    self.assertContained(err, self.expect_fail([EMCC, test_file('unistd/close.c'), '-nodefaultlibs']))
 
     # Build again but with explit system libraries
     libs = ['-lc', '-lcompiler_rt', '-lc_rt']
@@ -10457,6 +10458,7 @@ exec "$@"
 
   def test_wasm2js_no_dylink(self):
     for arg in ['-sMAIN_MODULE', '-sSIDE_MODULE', '-sRELOCATABLE']:
+      print(arg)
       err = self.expect_fail([EMCC, test_file('hello_world.c'), '-sWASM=0', arg])
       self.assertContained('WASM2JS is not compatible with relocatable output', err)
 

--- a/tools/building.py
+++ b/tools/building.py
@@ -308,14 +308,18 @@ def lld_flags_for_executable(external_symbols):
   c_exports = [e for e in settings.EXPORTED_FUNCTIONS if is_c_symbol(e)]
   # Strip the leading underscores
   c_exports = [demangle_c_symbol_name(e) for e in c_exports]
+  c_exports += settings.EXPORT_IF_DEFINED
   if external_symbols:
     # Filter out symbols external/JS symbols
     c_exports = [e for e in c_exports if e not in external_symbols]
   for export in c_exports:
     cmd.append('--export-if-defined=' + export)
 
-  for export in settings.EXPORT_IF_DEFINED:
-    cmd.append('--export-if-defined=' + export)
+  for export in settings.REQUIRED_EXPORTS:
+    if settings.ERROR_ON_UNDEFINED_SYMBOLS:
+      cmd.append('--export=' + export)
+    else:
+      cmd.append('--export-if-defined=' + export)
 
   if settings.RELOCATABLE:
     cmd.append('--experimental-pic')

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -214,11 +214,9 @@ def get_deps_info():
     _deps_info['__cxa_find_matching_catch_7'] = ['__cxa_can_catch']
     _deps_info['__cxa_find_matching_catch_8'] = ['__cxa_can_catch']
     _deps_info['__cxa_find_matching_catch_9'] = ['__cxa_can_catch']
-  if settings.USE_PTHREADS and settings.OFFSCREENCANVAS_SUPPORT:
-    # When OFFSCREENCANVAS_SUPPORT, emscripten_webgl_destroy_context depends on
-    # emscripten_webgl_destroy_context_before_on_calling_thread which then depends on
-    # emscripten_webgl_make_context_current and emscripten_webgl_get_current_contex native
-    # functions.
+  if settings.USE_PTHREADS and settings.OFFSCREEN_FRAMEBUFFER:
+    # When OFFSCREEN_FRAMEBUFFER is defined these functions are defined in native code,
+    # otherwise they are defined in src/library_html5_webgl.js.
     _deps_info['emscripten_webgl_destroy_context'] = ['emscripten_webgl_make_context_current', 'emscripten_webgl_get_current_context']
   if settings.USE_PTHREADS:
     _deps_info['emscripten_set_canvas_element_size_calling_thread'] = ['emscripten_dispatch_to_thread_']

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -15,7 +15,7 @@ from glob import iglob
 from . import shared, building, utils
 from . import deps_info, tempfiles
 from . import diagnostics
-from tools.shared import mangle_c_symbol_name, demangle_c_symbol_name
+from tools.shared import demangle_c_symbol_name
 from tools.settings import settings
 
 logger = logging.getLogger('system_libs')
@@ -1597,7 +1597,7 @@ def handle_reverse_deps(input_files):
     # than scanning the input files
     for symbols in deps_info.get_deps_info().values():
       for symbol in symbols:
-        settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(symbol))
+        settings.REQUIRED_EXPORTS.append(symbol)
     return
 
   if settings.REVERSE_DEPS != 'auto':
@@ -1614,7 +1614,7 @@ def handle_reverse_deps(input_files):
         for dep in deps:
           need['undefs'].add(dep)
           logger.debug('adding dependency on %s due to deps-info on %s' % (dep, ident))
-          settings.EXPORTED_FUNCTIONS.append(mangle_c_symbol_name(dep))
+          settings.REQUIRED_EXPORTS.append(dep)
     if more:
       add_reverse_deps(need) # recurse to get deps of deps
 

--- a/tools/toolchain_profiler.py
+++ b/tools/toolchain_profiler.py
@@ -26,10 +26,13 @@ class Logger(ContextDecorator):
   def __enter__(self):
     self.start = time.time()
 
-  def __exit__(self, type, value, traceback):
+  def __exit__(self, exc_type, value, traceback):
     # When a block ends debug log the total duration.
     now = time.time()
-    logger.debug('block "%s" took %.2f seconds', self.name, now - self.start)
+    if exc_type:
+      logger.debug('block "%s" raised an exception after %.2f seconds', self.name, now - self.start)
+    else:
+      logger.debug('block "%s" took %.2f seconds', self.name, now - self.start)
 
 
 if EMPROFILE:


### PR DESCRIPTION
Create new  `REQUIRED_SYMBOLS` internal setting.  Any symbols in
this list are exported with `--export` rather than `--export-if-defined`
which means if they are missing the link will fail during `wasm-ld`.

Like `EXPORT_IF_DEFINED` this list contains native symbol names without
any `_` prefixes.

These are internal settings so this change should not be user-visible.
This allows for a simpler/shorter `wasm-ld` commands and earlier failure
when one of these required symbols in missing.

This is useful for #15703.