### PR TITLE
[WASMFS] Use vector instead of map. NFC

### DIFF
--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -32,11 +32,15 @@ void DataFile::Handle::preloadFromJS(int index) {
 // Directory
 //
 std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
-  for (const auto& entry : getDir()->entries) {
-    if (entry.name == pathName) {
-      return entry.file;
-    }
+  auto found =
+    std::find_if(getDir()->entries.begin(),
+                 getDir()->entries.end(),
+                 [&](const auto& entry) { return entry.name == pathName; });
+
+  if (found != getDir()->entries.end()) {
+    return found->file;
   }
+
   return nullptr;
 }
 
@@ -67,20 +71,21 @@ void Directory::Handle::unlinkEntry(std::string pathName) {
   auto unlinked = getEntry(pathName)->locked();
   unlinked.setParent({});
 
-  for (auto it = getDir()->entries.begin(); it != getDir()->entries.end();
-       it++) {
-    if (it->name == pathName) {
-      getDir()->entries.erase(it);
-      return;
-    }
-  }
+  getDir()->entries.erase(
+    std::remove_if(getDir()->entries.begin(),
+                   getDir()->entries.end(),
+                   [&](const auto& entry) { return entry.name == pathName; }),
+    getDir()->entries.end());
 }
 
 std::string Directory::Handle::getName(std::shared_ptr<File> target) {
-  for (const auto& entry : getDir()->entries) {
-    if (entry.file == target) {
-      return entry.name;
-    }
+  auto found =
+    std::find_if(getDir()->entries.begin(),
+                 getDir()->entries.end(),
+                 [&](const auto& entry) { return entry.file == target; });
+
+  if (found != getDir()->entries.end()) {
+    return found->name;
   }
 
   return "";

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -32,12 +32,58 @@ void DataFile::Handle::preloadFromJS(int index) {
 // Directory
 //
 std::shared_ptr<File> Directory::Handle::getEntry(std::string pathName) {
-  auto it = getDir()->entries.find(pathName);
-  if (it == getDir()->entries.end()) {
-    return nullptr;
-  } else {
-    return it->second;
+  for (const auto& entry : getDir()->entries) {
+    if (entry.name == pathName) {
+      return entry.file;
+    }
   }
+  return nullptr;
+}
+
+void Directory::Handle::setEntry(std::string pathName,
+                                 std::shared_ptr<File> inserted) {
+  // Hold the lock over both functions to cover the case in which two
+  // directories attempt to add the file.
+  auto lockedInserted = inserted->locked();
+  // Simultaneously, set the parent of the inserted node to be this Dir.
+  // inserted must be locked because we have to go through Handle.
+  // TODO: When rename is implemented, ensure that the source directory has
+  // been removed as a parent.
+  // https://github.com/emscripten-core/emscripten/pull/15410#discussion_r742171264
+  assert(!lockedInserted.getParent());
+  lockedInserted.setParent(file);
+
+  // During testing, this will check that an existing file associated with
+  // pathName does not exist. For rename, the existing file must be unlinked
+  // first.
+  assert(!getEntry(pathName));
+  getDir()->entries.push_back({pathName, inserted});
+}
+
+void Directory::Handle::unlinkEntry(std::string pathName) {
+  // The file lock must be held for both operations. Removing the child file
+  // from the parent's entries and removing the parent pointer from the
+  // child should be atomic. The state should not be mutated in between.
+  auto unlinked = getEntry(pathName)->locked();
+  unlinked.setParent({});
+
+  for (auto it = getDir()->entries.begin(); it != getDir()->entries.end();
+       it++) {
+    if (it->name == pathName) {
+      getDir()->entries.erase(it);
+      return;
+    }
+  }
+}
+
+std::string Directory::Handle::getName(std::shared_ptr<File> target) {
+  for (const auto& entry : getDir()->entries) {
+    if (entry.file == target) {
+      return entry.name;
+    }
+  }
+
+  return "";
 }
 //
 // Path Parsing utilities

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -11,8 +11,8 @@
 
 #include <assert.h>
 #include <emscripten/html5.h>
-#include <map>
 #include <mutex>
+#include <optional>
 #include <sys/stat.h>
 #include <vector>
 #include <wasi/api.h>
@@ -172,13 +172,6 @@ public:
 };
 
 class Directory : public File {
-protected:
-  // TODO: maybe change to vector?
-  std::map<std::string, std::shared_ptr<File>> entries;
-  // 4096 bytes is the size of a block in ext4.
-  // This value was also copied from the existing file system.
-  size_t getSize() override { return 4096; }
-
 public:
   static constexpr FileKind expectedKind = File::DirectoryKind;
   Directory(mode_t mode, backend_t backend)
@@ -199,55 +192,21 @@ public:
 
     std::shared_ptr<File> getEntry(std::string pathName);
 
-    void setEntry(std::string pathName, std::shared_ptr<File> inserted) {
-      // Hold the lock over both functions to cover the case in which two
-      // directories attempt to add the file.
-      auto lockedInserted = inserted->locked();
-      getDir()->entries[pathName] = inserted;
-      // Simultaneously, set the parent of the inserted node to be this Dir.
-      // inserted must be locked because we have to go through Handle.
-      // TODO: When rename is implemented, ensure that the source directory has
-      // been removed as a parent.
-      // https://github.com/emscripten-core/emscripten/pull/15410#discussion_r742171264
-      assert(!lockedInserted.getParent());
-      lockedInserted.setParent(file);
-    }
+    void setEntry(std::string pathName, std::shared_ptr<File> inserted);
 
-    void unlinkEntry(std::string pathName) {
-      // The file lock must be held for both operations. Removing the child file
-      // from the parent's entries and removing the parent pointer from the
-      // child should be atomic. The state should not be mutated in between.
-      auto unlinked = getDir()->entries[pathName]->locked();
-      unlinked.setParent({});
-      getDir()->entries.erase(pathName);
-    }
+    void unlinkEntry(std::string pathName);
 
-    // Used to obtain name of child File in the directory entries vector.
-    std::string getName(std::shared_ptr<File> target) {
-      for (const auto& [key, value] : getDir()->entries) {
-        if (value == target) {
-          return key;
-        }
-      }
-
-      return "";
-    }
+    // Used to obtain the name of a child File in the directory entries vector.
+    std::string getName(std::shared_ptr<File> target);
 
     int getNumEntries() { return getDir()->entries.size(); }
 
-    // Return a vector of the key-value pairs in entries.
-    std::vector<Directory::Entry> getEntries() {
-      std::vector<Directory::Entry> entries;
-      for (const auto& [key, value] : getDir()->entries) {
-        entries.push_back({key, value});
-      }
-      return entries;
-    }
+    std::vector<Directory::Entry> getEntries() { return getDir()->entries; };
 
 #ifdef WASMFS_DEBUG
     void printKeys() {
-      for (auto keyPair : getDir()->entries) {
-        emscripten_console_log(keyPair.first.c_str());
+      for (const auto& entry : getDir()->entries) {
+        emscripten_console_log(entry.name.c_str());
       }
     }
 #endif
@@ -263,6 +222,12 @@ public:
       return {};
     }
   }
+
+protected:
+  std::vector<Entry> entries;
+  // 4096 bytes is the size of a block in ext4.
+  // This value was also copied from the JS file system.
+  size_t getSize() override { return 4096; }
 };
 
 struct ParsedPath {

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -224,6 +224,8 @@ public:
   }
 
 protected:
+  // A vector (instead of a map) saves on code size, but will lead to linear
+  // search time in certain operations, ex. getEntry().
   std::vector<Entry> entries;
   // 4096 bytes is the size of a block in ext4.
   // This value was also copied from the JS file system.

--- a/system/lib/wasmfs/wasmfs.h
+++ b/system/lib/wasmfs/wasmfs.h
@@ -13,7 +13,6 @@
 #include "file_table.h"
 #include <assert.h>
 #include <emscripten/html5.h>
-#include <map>
 #include <mutex>
 #include <sys/stat.h>
 #include <vector>

--- a/tests/wasmfs/wasmfs_getdents.out
+++ b/tests/wasmfs/wasmfs_getdents.out
@@ -50,17 +50,17 @@ d.d_off = 280
 d.d_reclen = 280
 d.d_type = directory
 
-d.d_name = stderr
-d.d_off = 280
-d.d_reclen = 280
-d.d_type = regular
-
 d.d_name = stdin
 d.d_off = 280
 d.d_reclen = 280
 d.d_type = regular
 
 d.d_name = stdout
+d.d_off = 280
+d.d_reclen = 280
+d.d_type = regular
+
+d.d_name = stderr
 d.d_off = 280
 d.d_reclen = 280
 d.d_type = regular
@@ -89,15 +89,15 @@ d.d_off = 280
 d.d_reclen = 280
 d.d_type = directory
 
-d.d_name = foobar
-d.d_off = 280
-d.d_reclen = 280
-d.d_type = regular
-
 d.d_name = test
 d.d_off = 280
 d.d_reclen = 280
 d.d_type = directory
+
+d.d_name = foobar
+d.d_off = 280
+d.d_reclen = 280
+d.d_type = regular
 
 pDirent->d_name: .
 pDirent->d_off: 280
@@ -109,17 +109,17 @@ pDirent->d_off: 560
 pDirent->d_reclen: 280
 pDirent->d_type: 4
 
-pDirent->d_name: stderr
+pDirent->d_name: stdin
 pDirent->d_off: 840
 pDirent->d_reclen: 280
 pDirent->d_type: 8
 
-pDirent->d_name: stdin
+pDirent->d_name: stdout
 pDirent->d_off: 1120
 pDirent->d_reclen: 280
 pDirent->d_type: 8
 
-pDirent->d_name: stdout
+pDirent->d_name: stderr
 pDirent->d_off: 1400
 pDirent->d_reclen: 280
 pDirent->d_type: 8


### PR DESCRIPTION
Relevant Issue: #15041 

To reduce code size, remove `std::map` from `WasmFS`.