### PR TITLE
Add check for JS dependencies in deps_info.py. NFC

### DIFF
--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -310,7 +310,6 @@ var LibraryHtml5WebGL = {
 
   emscripten_webgl_destroy_context__proxy: 'sync_on_webgl_context_handle_thread',
   emscripten_webgl_destroy_context__sig: 'vi',
-  emscripten_webgl_destroy_context__deps: ['emscripten_webgl_get_current_context', 'emscripten_webgl_make_context_current'],
   emscripten_webgl_destroy_context: function(contextHandle) {
     if (GL.currentContext == contextHandle) GL.currentContext = 0;
     GL.deleteContext(contextHandle);
@@ -318,6 +317,7 @@ var LibraryHtml5WebGL = {
 
   // Special function that will be invoked on the thread calling emscripten_webgl_destroy_context(), before routing
   // the call over to the target thread.
+  emscripten_webgl_destroy_context_before_on_calling_thread__deps: ['emscripten_webgl_get_current_context', 'emscripten_webgl_make_context_current'],
   emscripten_webgl_destroy_context_before_on_calling_thread: function(contextHandle) {
     if (_emscripten_webgl_get_current_context() == contextHandle) _emscripten_webgl_make_context_current(0);
   },

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10733,6 +10733,11 @@ exec "$@"
         if direct not in js and via_module not in js and assignment not in js:
           self.fail(f'use of declared dependency {dep} not found in JS output for {function}')
 
+        # Check that the dependency not a JS library function.  Dependencies on JS functions
+        # do not need entries in deps_info.py.
+        if f'function _{dep}(' in js:
+          self.fail(f'dependency {dep} in deps_info.py looks like a JS function (but should be native)')
+
   @require_v8
   def test_shell_Oz(self):
     # regression test for -Oz working on non-web, non-node environments that

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -141,7 +141,6 @@ _deps_info = {
   'emscripten_set_visibilitychange_callback_on_thread': ['malloc', 'free'],
   'emscripten_set_wheel_callback_on_thread': ['malloc', 'free'],
   'emscripten_webgl_create_context': ['malloc'],
-  'emscripten_webgl_destroy_context': ['emscripten_webgl_make_context_current', 'emscripten_webgl_get_current_context'],
   'emscripten_webgl_get_parameter_utf8': ['malloc'],
   'emscripten_webgl_get_program_info_log_utf8': ['malloc'],
   'emscripten_webgl_get_shader_info_log_utf8': ['malloc'],
@@ -215,6 +214,12 @@ def get_deps_info():
     _deps_info['__cxa_find_matching_catch_7'] = ['__cxa_can_catch']
     _deps_info['__cxa_find_matching_catch_8'] = ['__cxa_can_catch']
     _deps_info['__cxa_find_matching_catch_9'] = ['__cxa_can_catch']
+  if settings.USE_PTHREADS and settings.OFFSCREENCANVAS_SUPPORT:
+    # When OFFSCREENCANVAS_SUPPORT, emscripten_webgl_destroy_context depends on
+    # emscripten_webgl_destroy_context_before_on_calling_thread which then depends on
+    # emscripten_webgl_make_context_current and emscripten_webgl_get_current_contex native
+    # functions.
+    _deps_info['emscripten_webgl_destroy_context'] = ['emscripten_webgl_make_context_current', 'emscripten_webgl_get_current_context']
   if settings.USE_PTHREADS:
     _deps_info['emscripten_set_canvas_element_size_calling_thread'] = ['emscripten_dispatch_to_thread_']
     _deps_info['emscripten_set_offscreencanvas_size_on_target_thread'] = ['emscripten_dispatch_to_thread_', 'malloc', 'free']


### PR DESCRIPTION
Only dependencies on native symbols should be present in deps_info.py.
Dependecies on JS symbols are handled as normal forward dependencies in
the JS compiler.

Split out from #15716