### PR TITLE
Build WASMFS optionally as a debug library

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1379,7 +1379,7 @@ class libasmfs(MTLibrary):
     return True
 
 
-class libwasmfs(MTLibrary):
+class libwasmfs(MTLibrary, DebugLibrary):
   name = 'libwasmfs'
 
   cflags = ['-fno-exceptions', '-std=c++17']


### PR DESCRIPTION
With this we keep assertions in debug builds but not in shipping builds. WasmFS
does have a bunch of assertions so this can avoid unnecessary bloat.