### PR TITLE
Fix user --js-library include order issue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -21,6 +21,10 @@ See docs/process.md for more on how version tagging works.
 3.0.1
 -----
 - Deprecate `EMMAKEN_CFLAGS` is favor of `EMCC_CFLAGS`.
+- Fixed an issue where user provided --js-library directives would not be
+  processed as the last item after all system provided JS libraries have been
+  added to the build. This fix enables overriding WebGL 2 symbols from user JS
+  libraries.
 
 3.0.0 - 11/22/2021
 ------------------

--- a/src/modules.js
+++ b/src/modules.js
@@ -143,14 +143,14 @@ var LibraryManager = {
       }
     }
 
-    // Add any explicitly specified system JS libraries to link to, add those to link.
-    libraries = libraries.concat(JS_LIBRARIES)
-
     if (LZ4) {
       libraries.push('library_lz4.js');
     }
 
     if (MAX_WEBGL_VERSION >= 2) {
+      // library_webgl2.js must be included only after library_webgl.js, so if we are
+      // about to include library_webgl2.js, first squeeze in library_webgl.js.
+      libraries.push('library_webgl.js');
       libraries.push('library_webgl2.js');
     }
 
@@ -178,6 +178,12 @@ var LibraryManager = {
     if (SUPPORT_BIG_ENDIAN) {
       libraries.push('library_little_endian_heap.js');
     }
+
+    // Add all user specified --js-library files to the link.
+    // These must be added last after all Emscripten-provided system libraries
+    // above, so that users can override built-in JS library symbols in their
+    // own code.
+    libraries = libraries.concat(JS_LIBRARIES);
 
     // Deduplicate libraries to avoid processing any library file multiple times
     libraries = libraries.filter((item, pos) => libraries.indexOf(item) == pos);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11038,10 +11038,10 @@ void foo() {}
 
     # When WebGL is implicitly linked in, the implicit linking should happen before any user
     # --js-libraries, so that they can adjust the behavior afterwards.
-    self.do_run_in_out_file_test(test_file('test_override_system_js_lib_symbol.c'), emcc_args=['--js-library', test_file('test_override_system_js_lib_symbol.js')])
+    self.do_run_in_out_file_test(test_file('test_override_system_js_lib_symbol.c'), emcc_args=['--js-library', test_file('test_override_system_js_lib_symbol.js'), '-sMAX_WEBGL_VERSION=2'])
 
     # When WebGL is explicitly linked to in strict mode, the linking order on command line should enable overriding.
-    self.emcc_args += ['-sAUTO_JS_LIBRARIES=0', '-lwebgl.js', '--js-library', test_file('test_override_system_js_lib_symbol.js')]
+    self.emcc_args += ['-sAUTO_JS_LIBRARIES=0', '-sMAX_WEBGL_VERSION=2', '-lwebgl.js', '--js-library', test_file('test_override_system_js_lib_symbol.js')]
     self.do_run_in_out_file_test(test_file('test_override_system_js_lib_symbol.c'))
 
   @node_pthreads

--- a/tests/test_override_system_js_lib_symbol.c
+++ b/tests/test_override_system_js_lib_symbol.c
@@ -1,14 +1,19 @@
 #include <emscripten.h>
 #include <emscripten/html5.h>
 #include <assert.h>
-#include <GLES2/gl2.h>
+#include <GLES3/gl3.h>
 #include <stdio.h>
 
 GLuint what_got_created(void);
 
 int main() {
+  EmscriptenWebGLContextAttributes attrs;
+  emscripten_webgl_init_context_attributes(&attrs);
+  attrs.majorVersion = 2;
+  emscripten_webgl_make_context_current(emscripten_webgl_create_context("canvas", &attrs));
+
   GLuint createType = GL_UNSIGNED_BYTE;
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 1, 1, 0, GL_RGBA, createType, 0);
+  glTexImage3D(GL_TEXTURE_3D, 0, GL_RGBA, 1, 1, 1, 0, GL_RGBA, createType, 0);
   GLuint whatGotCreated = what_got_created();
   printf("Created texture of type 0x%x\n", whatGotCreated);
   assert(createType == whatGotCreated);

--- a/tests/test_override_system_js_lib_symbol.js
+++ b/tests/test_override_system_js_lib_symbol.js
@@ -1,27 +1,28 @@
-if (!LibraryManager.library.glTexImage2D) throw 'This file should be getting processed after library_webgl.js!';
+if (!LibraryManager.library.glTexImage3D) throw 'This file should be getting processed after library_webgl2.js!';
 
 mergeInto(LibraryManager.library, {
-	orig_glTexImage2D__deps: LibraryManager.library.glTexImage2D__deps,
-	orig_glTexImage2D: LibraryManager.library.glTexImage2D,
+	orig_glTexImage3D__deps: LibraryManager.library.glTexImage3D__deps,
+	orig_glTexImage3D: LibraryManager.library.glTexImage3D,
 
-	glTexImage2D__deps: ['orig_glTexImage2D'],
-	glTexImage2D: function(target, level, internalFormat, width, height, border, format, type, pixels) {
-		_glTexImage2D.createdType = type;
-		// Check that the orignal fuction exists
-		assert(_orig_glTexImage2D);
-		// Also try invoking glTexImage2D to verify that it is actually the
-		// underlying functions from library_webgl.js
-		var texImage2D_called = false;
+	glTexImage3D__deps: ['orig_glTexImage3D'],
+	glTexImage3D: function(target, level, internalFormat, width, height, depth, border, format, type, pixels) {
+		_glTexImage3D.createdType = type;
+		// Check that the original fuction exists
+		assert(_orig_glTexImage3D);
+		// Also try invoking glTexImage3D to verify that it is actually the
+		// underlying function from library_webgl2.js
+		var texImage3D_called = false;
+		// Mock GL context to be able to call from shell.
 		GLctx = {
-			texImage2D: function() {
-				texImage2D_called = true;
+			texImage3D: function() {
+				texImage3D_called = true;
 			},
 		};
-		_orig_glTexImage2D();
-		assert(texImage2D_called);
+		_orig_glTexImage3D();
+		assert(texImage3D_called);
 	},
 
 	what_got_created: function() {
-		return _glTexImage2D.createdType;
+		return _glTexImage3D.createdType;
 	}
 });


### PR DESCRIPTION
Fix user --js-library include order issue that prevented users from overriding WebGL 2 symbols from their own JS library files.

Also fix an issue that results with linking in WebGL 2 when AUTO_JS_LIBRARIES=0, by including WebGL 1 library first in.