### PR TITLE
[WASMFS] Fix entry handle

### DIFF
--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -24,28 +24,32 @@ FileTable::Handle::Entry&
 FileTable::Handle::Entry::operator=(std::shared_ptr<OpenFileState> ptr) {
   assert(fd >= 0);
 
-  if (fd >= fileTableHandle.fileTable.entries.size()) {
-    fileTableHandle.fileTable.entries.resize(fd + 1);
+  if (fd >= fileTable.entries.size()) {
+    fileTable.entries.resize(fd + 1);
   }
-  fileTableHandle.fileTable.entries[fd] = ptr;
+  fileTable.entries[fd] = ptr;
 
   return *this;
 }
 
 std::shared_ptr<OpenFileState> FileTable::Handle::Entry::unlocked() {
-  if (fd >= fileTableHandle.fileTable.entries.size() || fd < 0) {
+  if (fd >= fileTable.entries.size() || fd < 0) {
     return nullptr;
   }
 
-  return fileTableHandle.fileTable.entries[fd];
+  return fileTable.entries[fd];
 }
 
 FileTable::Handle::Entry::operator bool() const {
-  if (fd >= fileTableHandle.fileTable.entries.size() || fd < 0) {
+  if (fd >= fileTable.entries.size() || fd < 0) {
     return false;
   }
 
-  return fileTableHandle.fileTable.entries[fd] != nullptr;
+  return fileTable.entries[fd] != nullptr;
+}
+
+FileTable::Handle::Entry FileTable::Handle::operator[](__wasi_fd_t fd) {
+  return Entry(fileTable, fd);
 }
 
 __wasi_fd_t

--- a/system/lib/wasmfs/file_table.cpp
+++ b/system/lib/wasmfs/file_table.cpp
@@ -20,8 +20,8 @@ FileTable::FileTable() {
     std::make_shared<OpenFileState>(0, O_WRONLY, StderrFile::getSingleton()));
 }
 
-FileTable::Handle::Entry&
-FileTable::Handle::Entry::operator=(std::shared_ptr<OpenFileState> ptr) {
+FileTable::Entry&
+FileTable::Entry::operator=(std::shared_ptr<OpenFileState> ptr) {
   assert(fd >= 0);
 
   if (fd >= fileTable.entries.size()) {
@@ -32,7 +32,7 @@ FileTable::Handle::Entry::operator=(std::shared_ptr<OpenFileState> ptr) {
   return *this;
 }
 
-std::shared_ptr<OpenFileState> FileTable::Handle::Entry::unlocked() {
+std::shared_ptr<OpenFileState> FileTable::Entry::unlocked() {
   if (fd >= fileTable.entries.size() || fd < 0) {
     return nullptr;
   }
@@ -40,7 +40,7 @@ std::shared_ptr<OpenFileState> FileTable::Handle::Entry::unlocked() {
   return fileTable.entries[fd];
 }
 
-FileTable::Handle::Entry::operator bool() const {
+FileTable::Entry::operator bool() const {
   if (fd >= fileTable.entries.size() || fd < 0) {
     return false;
   }
@@ -48,7 +48,7 @@ FileTable::Handle::Entry::operator bool() const {
   return fileTable.entries[fd] != nullptr;
 }
 
-FileTable::Handle::Entry FileTable::Handle::operator[](__wasi_fd_t fd) {
+FileTable::Entry FileTable::Handle::operator[](__wasi_fd_t fd) {
   return Entry(fileTable, fd);
 }
 

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -57,8 +57,6 @@ public:
 
     off_t& position() { return openFileState->position; };
   };
-
-  Handle get() { return Handle(shared_from_this()); }
 };
 
 class FileTable {
@@ -72,13 +70,14 @@ class FileTable {
   FileTable();
 
 public:
+  class Entry;
+
   // Handle represents an RAII wrapper object. Access to the global FileTable
   // must go through a Handle. A Handle holds the single global FileTable's lock
   // for the duration of its lifetime. This is necessary because a FileTable may
   // have atomic operations where the lock must be held across multiple methods.
   // By providing access through the handle, callers of file table methods do
   // not need to remember to take a lock for every access.
-  class Entry;
   class Handle {
   protected:
     FileTable& fileTable;
@@ -88,21 +87,21 @@ public:
     Handle(FileTable& fileTable)
       : fileTable(fileTable), lock(fileTable.mutex) {}
 
-    // The Entry class abstracts over the list of entries, providing a simple
-    // and safe interface that looks much like accessing a std::map, in that
-    // table[x] = y will allocate a new entry if one is not already present
-    // there. One minor difference from std::map is that table[x] does not
-    // return a reference, and can be used to check for the lack of an item
-    // there without allocation (similar to how table[x] works on a JS object),
-    // which keeps syntax concise.
-
     Entry operator[](__wasi_fd_t fd);
 
     __wasi_fd_t add(std::shared_ptr<OpenFileState> openFileState);
   };
 };
 
+// The Entry class abstracts over the list of entries, providing a simple
+// and safe interface that looks much like accessing a std::map, in that
+// table[x] = y will allocate a new entry if one is not already present
+// there. One minor difference from std::map is that table[x] does not
+// return a reference, and can be used to check for the lack of an item
+// there without allocation (similar to how table[x] works on a JS object),
+// which keeps syntax concise.
 class FileTable::Entry : public FileTable::Handle {
+  // Handle must be a friend to access the private constructor of Entry.
   friend FileTable::Handle;
 
 public:
@@ -127,8 +126,6 @@ public:
   operator bool() const;
 
 private:
-  // Need to store a reference to the single global filetable, which is a
-  // local static variable.
   __wasi_fd_t fd;
 
   Entry(FileTable& fileTable, __wasi_fd_t fd)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1382,7 +1382,7 @@ class libasmfs(MTLibrary):
 class libwasmfs(MTLibrary, DebugLibrary):
   name = 'libwasmfs'
 
-  cflags = ['-fno-exceptions', '-std=c++17']
+  cflags = ['-O2', '-fno-exceptions', '-std=c++17']
 
   def get_files(self):
     return files_in_path(


### PR DESCRIPTION
Relevant Issue: #15041 

- Update the `Entry` class to be a special version of `FileTable::Handle`.

The following line: `auto openFile = wasmFS.getLockedFileTable()[fd];` demonstrates the problem. `getLockedFileTable()` returns a `Handle`, but this temporary value is destroyed since the `[]` operator will return an `Entry` object. The problem is that `Entry` has a reference to this parent `Handle`. However, after the end of the expression, temporaries are destructed and invalid access via this `fileTableHandle.fileTable` could occur.

TODO: Worthwhile to evaluate if this solution is optimal vs. implementing getter/setters without providing this simple `[]` interface to calling code.

This solves the bug found in: https://github.com/emscripten-core/emscripten/pull/15723