### PR TITLE
[Minor] Add Asan to libwasmfs

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1379,7 +1379,7 @@ class libasmfs(MTLibrary):
     return True
 
 
-class libwasmfs(MTLibrary, DebugLibrary):
+class libwasmfs(MTLibrary, DebugLibrary, AsanInstrumentedLibrary):
   name = 'libwasmfs'
 
   cflags = ['-fno-exceptions', '-std=c++17']


### PR DESCRIPTION
Relevant Issue: #15041 

- Add`AsanInstrumentedLibrary` to `libwasmfs` in `system_libs.py`.