### PR TITLE
Prefer `INT_MAX` over `0x7fffffff` in calls to `futex_wake`. NFC

### DIFF
--- a/system/lib/libc/musl/src/thread/pthread_cond_timedwait.c
+++ b/system/lib/libc/musl/src/thread/pthread_cond_timedwait.c
@@ -55,7 +55,7 @@ static inline void unlock_requeue(volatile int *l, volatile int *r, int w)
 	// primitive is strictly not needed, since it is more like an optimization to avoid spuriously waking
 	// all waiters, just to make them wait on another location immediately afterwards. Here we do exactly
 	// that: wake every waiter.
-	emscripten_futex_wake(l, 0x7FFFFFFF);
+	emscripten_futex_wake(l, INT_MAX);
 #else
 	if (w) __wake(l, 1, 1);
 	else __syscall(SYS_futex, l, FUTEX_REQUEUE|FUTEX_PRIVATE, 0, 1, r) != -ENOSYS

--- a/system/lib/pthread/library_pthread.c
+++ b/system/lib/pthread/library_pthread.c
@@ -640,7 +640,7 @@ void emscripten_current_thread_process_queued_calls() {
   pthread_mutex_unlock(&call_queue_lock);
 
   // If the queue was full and we had waiters pending to get to put data to queue, wake them up.
-  emscripten_futex_wake((void*)&q->call_queue_head, 0x7FFFFFFF);
+  emscripten_futex_wake((void*)&q->call_queue_head, INT_MAX);
 
   thread_is_processing_queued_calls = false;
 }

--- a/system/lib/websocket/websocket_to_posix_socket.cpp
+++ b/system/lib/websocket/websocket_to_posix_socket.cpp
@@ -1,3 +1,4 @@
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -201,7 +202,7 @@ static EM_BOOL bridge_socket_on_message(int eventType, const EmscriptenWebSocket
   }
 
   b->operationCompleted = 1;
-  emscripten_futex_wake(&b->operationCompleted, 0x7FFFFFFF);
+  emscripten_futex_wake(&b->operationCompleted, INT_MAX);
 
   return EM_TRUE;
 }


### PR DESCRIPTION
The documentation for this function says using INT_MAX is the way to go.