### PR TITLE
Fix bzip2 port: omit C files with main function

### DIFF
--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -29,9 +29,8 @@ def get(ports, settings, shared):
 
     # build
     srcs = [
-      'blocksort.c', 'compress.c', 'decompress.c',
-      'huffman.c', 'randtable.c', 'unzcrash.c', 'bzlib.c',
-      'crctable.c',
+      'blocksort.c', 'compress.c', 'decompress.c', 'huffman.c',
+      'randtable.c', 'bzlib.c', 'crctable.c',
     ]
     commands = []
     o_s = []

--- a/tools/ports/bzip2.py
+++ b/tools/ports/bzip2.py
@@ -29,9 +29,9 @@ def get(ports, settings, shared):
 
     # build
     srcs = [
-      'blocksort.c', 'bzip2recover.c', 'compress.c', 'decompress.c',
-      'huffman.c', 'randtable.c', 'unzcrash.c', 'bzip2.c', 'bzlib.c',
-      'crctable.c', 'dlltest.c', 'mk251.c', 'spewG.c',
+      'blocksort.c', 'compress.c', 'decompress.c',
+      'huffman.c', 'randtable.c', 'unzcrash.c', 'bzlib.c',
+      'crctable.c',
     ]
     commands = []
     o_s = []


### PR DESCRIPTION
The emscripten port of bzip2 builds ``libbz2.a`` with extra files that should not be included in the library archive file. This leads to ``duplicate symbol main`` issues when linking with ``libbz2``:

```
/emsdk/upstream/emscripten/emcc -o python.wasm Programs/python.o libpython3.11d.a -ldl  -lm Modules/_decimal/libmpdec/libmpdec.a -s USE_ZLIB -s USE_BZIP2 -s USE_ZLIB Modules/expat/libexpat.a
wasm-ld: error: duplicate symbol: main
>>> defined in Programs/python.o
>>> defined in /emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/libbz2.a(mk251.c.o)
```

* [bzip2.c](https://github.com/emscripten-ports/bzip2/blob/master/bzip2.c) is the bzip2 command line application
* [bzip2recover.c](https://github.com/emscripten-ports/bzip2/blob/master/bzip2recover.c) is the bzip2recover command line application
* [mk251.c](https://github.com/emscripten-ports/bzip2/blob/master/mk251.c) is a test helper that *Spew out a long sequence of the byte 251*
* [dlltest.c](https://github.com/emscripten-ports/bzip2/blob/master/dlltest.c) is a Windows DLL test helper
* [spewG.c](https://github.com/emscripten-ports/bzip2/blob/master/spewG.c) is another test helper that *spew out a thoroughly gigantic file designed*