### PR TITLE
Clarify internal `setThreadStatus` method by removing first argument. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -56,7 +56,7 @@ var LibraryPThread = {
 #if PTHREADS_PROFILING
     createProfilerBlock: function(pthreadPtr) {
       var profilerBlock = _malloc({{{ C_STRUCTS.thread_profiler_block.__size__ }}});
-      Atomics.store(HEAPU32, (pthreadPtr + {{{ C_STRUCTS.pthread.profilerBlock }}} ) >> 2, profilerBlock);
+      {{{ makeSetValue('pthreadPtr', C_STRUCTS.pthread.profilerBlock, 'profilerBlock', POINTER_TYPE) }}};
 
       // Zero fill contents at startup.
       zeroMemory(profilerBlock, {{{ C_STRUCTS.thread_profiler_block.__size__ }}});
@@ -65,26 +65,26 @@ var LibraryPThread = {
 
     // Sets the current thread status, but only if it was in the given expected state before. This is used
     // to allow high-level control flow "override" the thread status before low-level (futex wait) operations set it.
-    setThreadStatusConditional: function(pthreadPtr, expectedStatus, newStatus) {
-      var profilerBlock = Atomics.load(HEAPU32, (pthreadPtr + {{{ C_STRUCTS.pthread.profilerBlock }}} ) >> 2);
+    setThreadStatusConditional: function(expectedStatus, newStatus) {
+      var pthreadPtr = _pthread_self();
+      var profilerBlock = {{{ makeGetValue('pthreadPtr', C_STRUCTS.pthread.profilerBlock, POINTER_TYPE) }}};
       if (!profilerBlock) return;
 
-      var prevStatus = Atomics.load(HEAPU32, (profilerBlock + {{{ C_STRUCTS.thread_profiler_block.threadStatus }}} ) >> 2);
-
+      var prevStatus = {{{ makeGetValue('profilerBlock', C_STRUCTS.thread_profiler_block.threadStatus, 'i32') }}};
       if (prevStatus != newStatus && (prevStatus == expectedStatus || expectedStatus == -1)) {
         var now = performance.now();
         var startState = HEAPF64[(profilerBlock + {{{ C_STRUCTS.thread_profiler_block.currentStatusStartTime }}} ) >> 3];
         var duration = now - startState;
 
         HEAPF64[((profilerBlock + {{{ C_STRUCTS.thread_profiler_block.timeSpentInStatus }}} ) >> 3) + prevStatus] += duration;
-        Atomics.store(HEAPU32, (profilerBlock + {{{ C_STRUCTS.thread_profiler_block.threadStatus }}} ) >> 2, newStatus);
+        {{{ makeSetValue('profilerBlock', C_STRUCTS.thread_profiler_block.threadStatus, 'newStatus', 'i32') }}};
         HEAPF64[(profilerBlock + {{{ C_STRUCTS.thread_profiler_block.currentStatusStartTime }}} ) >> 3] = now;
       }
     },
 
     // Unconditionally sets the thread status.
-    setThreadStatus: function(pthreadPtr, newStatus) {
-      PThread.setThreadStatusConditional(pthreadPtr, -1, newStatus);
+    setThreadStatus: function(newStatus) {
+      PThread.setThreadStatusConditional(-1, newStatus);
     },
 
     setThreadName: function(pthreadPtr, name) {
@@ -216,7 +216,7 @@ var LibraryPThread = {
       err('Pthread 0x' + _pthread_self().toString(16) + ' threadInit.');
 #endif
 #if PTHREADS_PROFILING
-      PThread.setThreadStatus(_pthread_self(), {{{ cDefine('EM_THREAD_STATUS_RUNNING') }}});
+      PThread.setThreadStatus({{{ cDefine('EM_THREAD_STATUS_RUNNING') }}});
 #endif
       // Call thread init functions (these are the emscripten_tls_init for each
       // module loaded.
@@ -1014,14 +1014,14 @@ var LibraryPThread = {
   emscripten_conditional_set_current_thread_status__sig: 'vii',
   emscripten_conditional_set_current_thread_status: function(expectedStatus, newStatus) {
 #if PTHREADS_PROFILING
-    PThread.setThreadStatusConditional(_pthread_self(), expectedStatus, newStatus);
+    PThread.setThreadStatusConditional(expectedStatus, newStatus);
 #endif
   },
 
   emscripten_set_current_thread_status__sig: 'vi',
   emscripten_set_current_thread_status: function(newStatus) {
 #if PTHREADS_PROFILING
-    PThread.setThreadStatus(_pthread_self(), newStatus);
+    PThread.setThreadStatus(newStatus);
 #endif
   },
 


### PR DESCRIPTION
This functions only ever operates on the current and completely removing
the first argument helps to clarify this.

The native versions already don't take a thread as an argument in assume
they are operating on the current thread.

This function was operating with mix of atomic and non-atomic
operattions which made it unsafe except for running against the current
thread block.