### PR TITLE
Remove assembly vesion of emscripten_is_main_browser_thread

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -589,6 +589,10 @@ var LibraryPThread = {
     return navigator['hardwareConcurrency'];
   },
 
+  emscripten_is_main_browser_thread() {
+    return !ENVIRONMENT_IS_WORKER;
+  },
+
   __emscripten_init_main_thread_js: function(tb) {
 #if PTHREADS_PROFILING
     PThread.createProfilerBlock(tb);
@@ -598,7 +602,7 @@ var LibraryPThread = {
     // Pass the thread address to the native code where they stored in wasm
     // globals which act as a form of TLS. Global constructors trying
     // to access this value will read the wrong value, but that is UB anyway.
-    __emscripten_thread_init(tb, /*isMainBrowserThread=*/!ENVIRONMENT_IS_WORKER, /*isMainRuntimeThread=*/1, /*canBlock=*/!ENVIRONMENT_IS_WEB);
+    __emscripten_thread_init(tb, /*isMainRuntimeThread=*/1, /*canBlock=*/!ENVIRONMENT_IS_WEB);
 #if ASSERTIONS
     PThread.mainRuntimeThread = true;
     // Verify that this native symbol used by futex_wait/wake is exported correctly.

--- a/src/worker.js
+++ b/src/worker.js
@@ -188,7 +188,7 @@ self.onmessage = function(e) {
       Module['__performance_now_clock_drift'] = performance.now() - e.data.time;
 
       // Pass the thread address inside the asm.js scope to store it for fast access that avoids the need for a FFI out.
-      Module['__emscripten_thread_init'](e.data.threadInfoStruct, /*isMainBrowserThread=*/0, /*isMainRuntimeThread=*/0, /*canBlock=*/1);
+      Module['__emscripten_thread_init'](e.data.threadInfoStruct, /*isMainRuntimeThread=*/0, /*canBlock=*/1);
 
 #if ASSERTIONS
       assert(e.data.threadInfoStruct);

--- a/system/lib/pthread/emscripten_thread_state.S
+++ b/system/lib/pthread/emscripten_thread_state.S
@@ -9,9 +9,6 @@
 .globaltype thread_ptr, PTR
 thread_ptr:
 
-.globaltype is_main_thread, i32
-is_main_thread:
-
 .globaltype is_runtime_thread, i32
 is_runtime_thread:
 
@@ -26,14 +23,12 @@ __get_tp:
 
 .globl _emscripten_thread_init
 _emscripten_thread_init:
-  .functype _emscripten_thread_init (PTR, i32, i32, i32) -> ()
+  .functype _emscripten_thread_init (PTR, i32, i32) -> ()
   local.get 0
   global.set thread_ptr
   local.get 1
-  global.set is_main_thread
-  local.get 2
   global.set is_runtime_thread
-  local.get 3
+  local.get 2
   global.set supports_wait
   end_function
 
@@ -50,13 +45,6 @@ _emscripten_tls_base:
 emscripten_is_main_runtime_thread:
   .functype emscripten_is_main_runtime_thread () -> (i32)
   global.get is_runtime_thread
-  end_function
-
-# Semantically the same as testing "!ENVIRONMENT_IS_WORKER" in JS
-.globl emscripten_is_main_browser_thread
-emscripten_is_main_browser_thread:
-  .functype emscripten_is_main_browser_thread () -> (i32)
-  global.get is_main_thread
   end_function
 
 # Semantically the same as testing "!ENVIRONMENT_IS_WEB" in JS

--- a/system/lib/pthread/pthread_create.c
+++ b/system/lib/pthread/pthread_create.c
@@ -23,7 +23,7 @@
 // See musl's pthread_create.c
 
 extern int __pthread_create_js(struct pthread *thread, const pthread_attr_t *attr, void *(*start_routine) (void *), void *arg);
-extern void _emscripten_thread_init(int, int, int, int);
+extern void _emscripten_thread_init(int thread_ptr, int is_runtime_thread, int can_block);
 extern int _emscripten_default_pthread_stack_size();
 extern void __pthread_detached_exit();
 extern void* _emscripten_tls_base();
@@ -225,7 +225,7 @@ void _emscripten_thread_exit(void* result) {
   self->tsd = NULL;
 
   // Not hosting a pthread anymore in this worker set __pthread_self to NULL
-  _emscripten_thread_init(0, 0, 0, 1);
+  _emscripten_thread_init(0, 0, 1);
 
   /* This atomic potentially competes with a concurrent pthread_detach
    * call; the loser is responsible for freeing thread resources. */


### PR DESCRIPTION
This function was originally implemented as global.get because like
`emscripten_is_main_runtime_thread` because it was called frequently
from native threading primitives.  However, recent changes have all but
removed this function from the codebase so there is no need to cache
this in a wasm global anymore.

The only two remaining users of this function are:
system/lib/fetch/asmfs.cpp
system/lib/fetch/emscripten_fetch.cpp

The former is deprecated and later is not performance critical.