### PR TITLE
Remove unnecessary export of `emscripten_futex_wake`. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1951,7 +1951,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
       '__emscripten_thread_init',
       '__emscripten_thread_exit',
       '_emscripten_tls_init',
-      '_emscripten_futex_wake',
       '_emscripten_current_thread_process_queued_calls',
       '_pthread_self',
     ]

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -7,7 +7,7 @@
 var LibraryPThread = {
   $PThread__postset: 'if (!ENVIRONMENT_IS_PTHREAD) PThread.initMainThreadBlock();',
   $PThread__deps: ['_emscripten_thread_init',
-                   'emscripten_futex_wake', '$killThread',
+                   '$killThread',
                    '$cancelThread', '$cleanupThread', '$zeroMemory',
                    '_emscripten_thread_free_data',
                    'exit',

--- a/src/worker.js
+++ b/src/worker.js
@@ -237,16 +237,6 @@ self.onmessage = function(e) {
 #endif
       } catch(ex) {
         if (ex != 'unwind') {
-#if ASSERTIONS
-          // FIXME(sbc): Figure out if this is still needed or useful.  Its not
-          // clear to me how this check could ever fail.  In order to get into
-          // this try/catch block at all we have already called bunch of
-          // functions on `Module`.. why is this one special?
-          if (typeof(Module['_emscripten_futex_wake']) !== 'function') {
-            err("Thread Initialisation failed.");
-            throw ex;
-          }
-#endif
           // ExitStatus not present in MINIMAL_RUNTIME
 #if !MINIMAL_RUNTIME
           if (ex instanceof Module['ExitStatus']) {


### PR DESCRIPTION
This was being exported solely for the benefit of an assertions that I
don't think served any purpose.

Its not clear exactly what this assertion was trying to check for but I
think it was checking for case where the Module object was not
initialized on the thread. However before this try/catch is even
executed we have already run several native methods. For example, see
`Module['__emscripten_thread_init']` just above.

For this reason I think removing the asserting and the extra export is
the correct action.