### PR TITLE
Parse settings on the command line passed in as hex

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3812,7 +3812,11 @@ def parse_value(text, expect_list):
       return parse_string_list(text)
 
   try:
-    return int(text)
+    if text.startswith('0x'):
+      base = 16
+    else:
+      base = 10
+    return int(text, base)
   except ValueError:
     return parse_string_value(text)
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -6556,6 +6556,11 @@ high = 1234
     err = self.expect_fail([EMXX, test_file('hello_world.cpp'), '-sEXPORTED_FUNCTIONS=foo'])
     self.assertContained('error: undefined exported symbol: "foo"', err)
 
+  def test_dash_s_hex(self):
+    self.run_process([EMCC, test_file('hello_world.c'), '-nostdlib', '-sERROR_ON_UNDEFINED_SYMBOLS=0'])
+    # Ensure that 0x0 is parsed as a zero and not as the string '0x0'.
+    self.run_process([EMCC, test_file('hello_world.c'), '-nostdlib', '-sERROR_ON_UNDEFINED_SYMBOLS=0x0'])
+
   def test_zeroinit(self):
     create_file('src.c', r'''
 #include <stdio.h>


### PR DESCRIPTION
I ran into this issue when working on #15763.  We have code interally
that converts `=-1` to `=0x7FFFFFFF` for the MIN_XX_VERSION settings.
However, this was then being interpreted interally as a string.  When
read from JS there is no differenence but from python code the value of
this setting would appear as the string "0x7FFFFFFF" and not the number
0x7FFFFFFF.