### PR TITLE
Fix wasm2js2.test_demangle_stacks_symbol_map: avoid binaryen inlining

### DIFF
--- a/tests/core/test_demangle_stacks.cpp
+++ b/tests/core/test_demangle_stacks.cpp
@@ -15,9 +15,13 @@ class Class {
   void Aborter(double x, char y, int *z) {
     volatile int w = 1;
     if (w) {
-      EM_ASM({
+      if (EM_ASM_INT({
         out(stackTrace());
-      });
+      }) == 999999) {
+        // Add a fake call (that never happens in practice) to avoid the
+        // binaryen optimizer from inlining this method.
+        Aborter(x, y, z);
+      }
       abort();
     }
   }


### PR DESCRIPTION
Fixes #15747

I believe this affects wasm2js more than normal wasm because the wasm2js
pipeline runs the optimizer an extra time, giving it more of a chance to end up
inlining that method.