### PR TITLE
Fix for MAIN_MODULE + ubsan

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2158,8 +2158,6 @@ def phase_linker_setup(options, state, newargs, settings_map):
         'emscripten_builtin_memalign',
         'emscripten_builtin_malloc',
         'emscripten_builtin_free',
-        '__heap_base',
-        '__global_base'
     ]
 
   if settings.USE_OFFSET_CONVERTER and settings.WASM2JS:

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cpp
@@ -60,14 +60,7 @@ void ListOfModules::init() {
 
 void ListOfModules::fallbackInit() { clear(); }
 
-SANITIZER_WEAK_ATTRIBUTE int
-real_sigaction(int signum, const void *act, void *oldact);
-
 int internal_sigaction(int signum, const void *act, void *oldact) {
-#if !SANITIZER_GO
-  if (&real_sigaction)
-    return real_sigaction(signum, act, oldact);
-#endif
   return sigaction(signum, (const struct sigaction *)act,
                    (struct sigaction *)oldact);
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8184,6 +8184,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @parameterized({
     'fsanitize_undefined': (['-fsanitize=undefined'],),
     'fsanitize_null': (['-fsanitize=null'],),
+    'dylink': (['-fsanitize=null', '-sMAIN_MODULE=2'],),
   })
   @no_wasm2js('TODO: sanitizers in wasm2js')
   def test_ubsan_full_null_ref(self, args):


### PR DESCRIPTION
We didn't have any testing for UBSan + dynamic linking previously.
The export of `__heap_base` and `__global_base` doesn't make sense with
dynamic linking since those are defined in JS in that case.   This bug went
unnoticed because with don't support dynamic linking at all with ASan or
LSan.

Furthermore the export of `__heap_base` and `__global_base` does not
appear to be necessary at all for any of the santizers.

The weak import `real_sigaction` was cargo-culted from
`sanitizer_linux_libcdep.cpp` and was never needed (we never defined
such a thing).  For static build its harmless but for dynamic linking builds it
generates a weak import which currently causes and undefined symbol
warning/error at link time.

Fixes: #15773