### PR TITLE
nodefs: Fix O_NOFOLLOW

### DIFF
--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -25,7 +25,8 @@ mergeInto(LibraryManager.library, {
         "{{{ cDefine('O_RDWR') }}}": flags["O_RDWR"],
         "{{{ cDefine('O_DSYNC') }}}": flags["O_SYNC"],
         "{{{ cDefine('O_TRUNC') }}}": flags["O_TRUNC"],
-        "{{{ cDefine('O_WRONLY') }}}": flags["O_WRONLY"]
+        "{{{ cDefine('O_WRONLY') }}}": flags["O_WRONLY"],
+        "{{{ cDefine('O_NOFOLLOW') }}}": flags["O_NOFOLLOW"]
       };
 #if ASSERTIONS
       // The 0 define must match on both sides, as otherwise we would not

--- a/src/library_nodefs.js
+++ b/src/library_nodefs.js
@@ -26,7 +26,7 @@ mergeInto(LibraryManager.library, {
         "{{{ cDefine('O_DSYNC') }}}": flags["O_SYNC"],
         "{{{ cDefine('O_TRUNC') }}}": flags["O_TRUNC"],
         "{{{ cDefine('O_WRONLY') }}}": flags["O_WRONLY"],
-        "{{{ cDefine('O_NOFOLLOW') }}}": flags["O_NOFOLLOW"]
+        "{{{ cDefine('O_NOFOLLOW') }}}": flags["O_NOFOLLOW"],
       };
 #if ASSERTIONS
       // The 0 define must match on both sides, as otherwise we would not

--- a/tests/fs/test_noderawfs_nofollow.c
+++ b/tests/fs/test_noderawfs_nofollow.c
@@ -1,0 +1,9 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <stdio.h>
+
+int main() {
+    assert(open("/dev/pts/0", O_NOFOLLOW) != -1);
+    printf("success\n");
+    return 0;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5361,6 +5361,13 @@ main( int argv, char ** argc ) {
     self.emcc_args += ['-lnodefs.js']
     self.do_runf(test_file('fs/test_nodefs_nofollow.c'), 'success', js_engines=[config.NODE_JS])
 
+  @no_windows('https://github.com/emscripten-core/emscripten/issues/15786')
+  @no_mac('https://github.com/emscripten-core/emscripten/issues/15786')
+  def test_fs_noderawfs_nofollow(self):
+    self.set_setting('NODERAWFS')
+    self.emcc_args += ['-lnodefs.js']
+    self.do_runf(test_file('fs/test_noderawfs_nofollow.c'), 'success', js_engines=[config.NODE_JS])
+
   def test_fs_trackingdelegate(self):
     self.set_setting('FS_DEBUG')
     self.do_run_in_out_file_test('fs/test_trackingdelegate.c')


### PR DESCRIPTION
Fixes #15786.

Adds O_NOFOLLOW to NODEFS.flagsForNodeMap and adds a simple test case.