### PR TITLE
Micro-optimize performance and code size generated for longjmp

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1323,8 +1323,11 @@ LibraryManager.library = {
   // setjmp.h
   // ==========================================================================
 
+#if SUPPORT_LONGJMP == 'emscripten'
   _emscripten_throw_longjmp__sig: 'v',
-  _emscripten_throw_longjmp: function() { throw 'longjmp'; },
+  _emscripten_throw_longjmp: function() { throw Infinity; },
+#endif
+
 #if !SUPPORT_LONGJMP
 #if !INCLUDE_FULL_LIBRARY
   // These are in order to print helpful error messages when either longjmp of
@@ -1340,6 +1343,7 @@ LibraryManager.library = {
   // built with SUPPORT_LONGJMP=1, the object file contains references of not
   // longjmp but _emscripten_throw_longjmp, which is called from
   // emscripten_longjmp.
+  _emscripten_throw_longjmp: function() { error('longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)'); },
   get _emscripten_throw_longjmp__deps() {
     return this.longjmp__deps;
   },

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -242,7 +242,10 @@ var LibraryDylink = {
         return dynCall(sig, arguments[0], Array.prototype.slice.call(arguments, 1));
       } catch(e) {
         stackRestore(sp);
-        if (e !== e+0 && e !== 'longjmp') throw e;
+        // Exceptions thrown from C++ exception will be integer numbers.
+        // longjmp will throw the number Infinity. Re-throw other types of
+        // exceptions using a compact and fast check.
+        if (e !== e+0) throw e;
         _setThrew(1, 0);
       }
     }

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -683,7 +683,7 @@ function makeAbortWrapper(original) {
         ABORT // rethrow exception if abort() was called in the original function call above
         || abortWrapperDepth > 1 // rethrow exceptions not caught at the top level if exception catching is enabled; rethrow from exceptions from within callMain
 #if SUPPORT_LONGJMP == 'emscripten'
-        || e === 'longjmp' // rethrow longjmp if enabled
+        || e === Infinity // rethrow longjmp if enabled (In Emscripten EH format longjmp will throw Infinity)
 #endif
       ) {
         throw e;

--- a/system/lib/compiler-rt/emscripten_setjmp.c
+++ b/system/lib/compiler-rt/emscripten_setjmp.c
@@ -22,7 +22,6 @@ typedef struct TableEntry {
 
 extern void setTempRet0(uint32_t value);
 extern void setThrew(uintptr_t threw, int value);
-extern void _emscripten_throw_longjmp(); // defined in src/library.js
 
 TableEntry* saveSetjmp(uintptr_t* env, uint32_t label, TableEntry* table, uint32_t size) {
   // Not particularly fast: slow table lookup of setjmpId to label. But setjmp
@@ -63,10 +62,15 @@ uint32_t testSetjmp(uintptr_t id, TableEntry* table, uint32_t size) {
   return 0;
 }
 
+#ifndef __USING_WASM_SJLJ__
+
+extern void _emscripten_throw_longjmp(); // defined in src/library.js
+
 void emscripten_longjmp(uintptr_t env, int val) {
   setThrew(env, val);
   _emscripten_throw_longjmp();
 }
+#endif
 
 #ifdef __USING_WASM_SJLJ__
 


### PR DESCRIPTION
Micro-optimize performance and code size generated for longjmp in Emscripten invokes to avoid string comparisons.

Something that came to mind while reviewing #15788.