### PR TITLE
Rename internal JS helper functions and mark them as internal. NFC

### DIFF
--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_stacktrace_emscripten.cpp
@@ -22,7 +22,6 @@ namespace __sanitizer {
 
 extern "C" {
   uptr emscripten_stack_snapshot();
-  uptr emscripten_return_address(int level);
   u32 emscripten_stack_unwind_buffer(uptr pc, uptr *buffer, u32 depth);
 }
 


### PR DESCRIPTION
These functions take or return JS objects as arguments so are never callable
from native code.