### PR TITLE
Fix newly added test_fs_noderawfs_nofollow. NFC

### DIFF
--- a/tests/fs/test_noderawfs_nofollow.c
+++ b/tests/fs/test_noderawfs_nofollow.c
@@ -1,9 +1,20 @@
 #include <assert.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <errno.h>
 
 int main() {
-    assert(open("/dev/pts/0", O_NOFOLLOW) != -1);
-    printf("success\n");
-    return 0;
+  // Opening either the target or source should work
+  assert(open("filename", O_RDONLY) >= 0);
+  assert(open("linkname", O_RDONLY) >= 0);
+
+  // But adding O_NOFOLLOW should cause the opening on the link to
+  // fail with ELOOP
+  assert(open("linkname", O_NOFOLLOW | O_RDONLY) < 0);
+  assert(errno == ELOOP);
+
+  assert(open("filename", O_NOFOLLOW | O_RDONLY) >= 0);
+
+  printf("success\n");
+  return 0;
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5361,10 +5361,11 @@ main( int argv, char ** argc ) {
     self.emcc_args += ['-lnodefs.js']
     self.do_runf(test_file('fs/test_nodefs_nofollow.c'), 'success', js_engines=[config.NODE_JS])
 
-  @no_windows('https://github.com/emscripten-core/emscripten/issues/15786')
-  @no_mac('https://github.com/emscripten-core/emscripten/issues/15786')
+  @no_windows('no symlink support on windows')
   def test_fs_noderawfs_nofollow(self):
     self.set_setting('NODERAWFS')
+    create_file('filename', 'foo')
+    os.symlink('filename', 'linkname')
     self.emcc_args += ['-lnodefs.js']
     self.do_runf(test_file('fs/test_noderawfs_nofollow.c'), 'success', js_engines=[config.NODE_JS])
 


### PR DESCRIPTION
Fix the test recently introduced in #15786.  On my linux machine on the
emscripten-releases builders `/dev/pts/0` does not exist at all.

We can test this features in a platform-neutral way by creating a
symlink ourselves.  Also exten the test to verify the flag is working as
intended.