### PR TITLE
Fix newly added variant of test_ubsan_full_null_ref.  NFC

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8195,6 +8195,8 @@ NODEFS is no longer included by default; build with -lnodefs.js
   })
   @no_wasm2js('TODO: sanitizers in wasm2js')
   def test_ubsan_full_null_ref(self, args):
+    if is_sanitizing(self.emcc_args):
+      self.skipTest('test is specific to null sanitizer')
     self.emcc_args += args
     self.do_runf(test_file('core/test_ubsan_full_null_ref.cpp'),
                  assert_all=True, expected_output=[


### PR DESCRIPTION
The dylink variant of this test was just added in #15779.  Because this
test is specifically testing certain sanitizers we don't want to be
running in the santizer condifuration is confusing (its also currently
broken since ASan is not compatible with dynamic linking today).