### PR TITLE
Declare `fs` with `let` instead of `var`

### DIFF
--- a/src/shell.js
+++ b/src/shell.js
@@ -182,7 +182,7 @@ function logExceptionOnExit(e) {
 #endif
 
 #if ENVIRONMENT_MAY_BE_NODE
-var fs;
+let fs;
 var nodePath;
 var requireNodeFS;
 


### PR DESCRIPTION
When running Emscripten-generated scripts via `node -e "<script>"`, the `fs` variable is already defined and so `if (!fs)` checks never fail. Using `let` forces the variable to be recreated with an `undefined` value.

This fixes a breakage caused by #15587. An alternative solution would be to rename the variable.