### PR TITLE
WebGPU: Remove `None` from WGPUErrorFilter enum

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -356,7 +356,6 @@ var LibraryWebGPU = {
       'back',
     ],
     ErrorFilter: [
-      'none',
       'validation',
       'out-of-memory',
     ],

--- a/system/include/webgpu/webgpu.h
+++ b/system/include/webgpu/webgpu.h
@@ -199,9 +199,8 @@ typedef enum WGPUDeviceLostReason {
 } WGPUDeviceLostReason;
 
 typedef enum WGPUErrorFilter {
-    WGPUErrorFilter_None = 0x00000000,
-    WGPUErrorFilter_Validation = 0x00000001,
-    WGPUErrorFilter_OutOfMemory = 0x00000002,
+    WGPUErrorFilter_Validation = 0x00000000,
+    WGPUErrorFilter_OutOfMemory = 0x00000001,
     WGPUErrorFilter_Force32 = 0x7FFFFFFF
 } WGPUErrorFilter;
 

--- a/system/include/webgpu/webgpu_cpp.h
+++ b/system/include/webgpu/webgpu_cpp.h
@@ -236,9 +236,8 @@ namespace wgpu {
     };
 
     enum class ErrorFilter : uint32_t {
-        None = 0x00000000,
-        Validation = 0x00000001,
-        OutOfMemory = 0x00000002,
+        Validation = 0x00000000,
+        OutOfMemory = 0x00000001,
     };
 
     enum class ErrorType : uint32_t {

--- a/system/lib/webgpu/webgpu_cpp.cpp
+++ b/system/lib/webgpu/webgpu_cpp.cpp
@@ -144,7 +144,6 @@ namespace wgpu {
     static_assert(sizeof(ErrorFilter) == sizeof(WGPUErrorFilter), "sizeof mismatch for ErrorFilter");
     static_assert(alignof(ErrorFilter) == alignof(WGPUErrorFilter), "alignof mismatch for ErrorFilter");
 
-    static_assert(static_cast<uint32_t>(ErrorFilter::None) == WGPUErrorFilter_None, "value mismatch for ErrorFilter::None");
     static_assert(static_cast<uint32_t>(ErrorFilter::Validation) == WGPUErrorFilter_Validation, "value mismatch for ErrorFilter::Validation");
     static_assert(static_cast<uint32_t>(ErrorFilter::OutOfMemory) == WGPUErrorFilter_OutOfMemory, "value mismatch for ErrorFilter::OutOfMemory");
 


### PR DESCRIPTION
This was removed from the WebGPU spec, and has also now been removed
from webgpu-native/webgpu-headers and from Dawn.