### PR TITLE
Fix initialization of nodePath variable

### DIFF
--- a/src/node_shell_read.js
+++ b/src/node_shell_read.js
@@ -5,9 +5,10 @@
  */
 
 requireNodeFS = function() {
-  // We always initialize both of these together, so we can use
-  // either one as the indicator for them not being initialized.
-  if (!fs) {
+  // Use nodePath as the indicator for these not being initialized,
+  // since in some environments a global fs may have already been
+  // created.
+  if (!nodePath) {
     fs = require('fs');
     nodePath = require('path');
   }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8408,6 +8408,12 @@ test_module().then((test_module_instance) => {
     ret = self.run_process(config.NODE_JS + ['a.js'], stdout=PIPE).stdout
     self.assertContained('OK', ret)
 
+  def test_node_eval(self):
+    self.run_process([EMCC, '-sENVIRONMENT=node', test_file('hello_world.c'), '-o', 'a.js', '-O3'])
+    js = open('a.js').read()
+    ret = self.run_process(config.NODE_JS + ['-e', js], stdout=PIPE).stdout
+    self.assertContained('hello, world!', ret)
+
   def test_is_bitcode(self):
     fname = 'tmp.o'
 


### PR DESCRIPTION
When running Emscripten-generated scripts via `node -e "<script>"`,
the `fs` variable is already defined and so `nodePath` was never being
initialized.

This fixes a breakage caused by #15587.