### PR TITLE
Fix bug where ASan shadow region was overlapping static data

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -187,6 +187,11 @@ def base64_encode(b):
   return b64.decode('ascii')
 
 
+def align_to_wasm_page_boudary(address):
+  page_size = webassembly.WASM_PAGE_SIZE
+  return ((address + (page_size - 1)) // page_size) * page_size
+
+
 @unique
 class OFormat(Enum):
   # Output a relocatable object file.  We use this
@@ -2179,6 +2184,17 @@ def phase_linker_setup(options, state, newargs, settings_map):
         'emscripten_builtin_free',
     ]
 
+  if ('leak' in sanitize or 'address' in sanitize) and not settings.ALLOW_MEMORY_GROWTH:
+    # Increase the minimum memory requirements to account for extra memory
+    # that the sanitizers might need (in addition to the shadow memory
+    # requirements handled below).
+    # These values are designed be over-estimate the actual requirements and
+    # based on experimentation with different tests/programs under asan and
+    # lsan.
+    settings.INITIAL_MEMORY += 50 * 1024 * 1024
+    if settings.USE_PTHREADS:
+      settings.INITIAL_MEMORY += 50 * 1024 * 1024
+
   if settings.USE_OFFSET_CONVERTER and settings.WASM2JS:
     exit_with_error('wasm2js is not compatible with USE_OFFSET_CONVERTER (see #14630)')
 
@@ -2235,27 +2251,31 @@ def phase_linker_setup(options, state, newargs, settings_map):
     if settings.GLOBAL_BASE != -1:
       exit_with_error("ASan does not support custom GLOBAL_BASE")
 
-    max_mem = settings.INITIAL_MEMORY
+    user_mem = settings.INITIAL_MEMORY
     if settings.ALLOW_MEMORY_GROWTH:
-      max_mem = settings.MAXIMUM_MEMORY
+      user_mem = settings.MAXIMUM_MEMORY
 
-    shadow_size = max_mem // 8
-    settings.GLOBAL_BASE = shadow_size
+    # The total memory is 1/8th shadow and 7/8th user/usable memory.
+    # Given the know value of user memory size we can work backwards
+    # to find the total memory and the shadow size based on the fact
+    # that the user memory is 7/8ths of the total memory.
+    # (i.e. user_mem == total_mem * 7 / 8
+    total_mem = user_mem * 8 / 7
 
-    sanitizer_mem = (shadow_size + webassembly.WASM_PAGE_SIZE) & ~webassembly.WASM_PAGE_SIZE
-    # sanitizers do at least 9 page allocs of a single page during startup.
-    sanitizer_mem += webassembly.WASM_PAGE_SIZE * 9
-    # we also allocate at least 11 "regions". Each region is kRegionSize (2 << 20) but
-    # MmapAlignedOrDieOnFatalError adds another 2 << 20 for alignment.
-    sanitizer_mem += (1 << 21) * 11
-    # When running in the threaded mode asan needs to allocate an array of kMaxNumberOfThreads
-    # (1 << 22) pointers.  See compiler-rt/lib/asan/asan_thread.cpp.
-    if settings.USE_PTHREADS:
-      sanitizer_mem += (1 << 22) * 4
+    # But we might need to re-align to wasm page size
+    total_mem = int(align_to_wasm_page_boudary(total_mem))
 
-    # Increase the size of the initial memory according to how much memory
-    # we think the sanitizers will use.
-    settings.INITIAL_MEMORY += sanitizer_mem
+    # The shadow size is 1/8th the resulting rounded up size
+    shadow_size = total_mem // 8
+
+    # We start our global data after the shadow memory.
+    # We don't need to worry about alignment here.  wasm-ld will take care of that.
+    settings.GLOBAL_BASE = shadow_size + 1
+
+    if not settings.ALLOW_MEMORY_GROWTH:
+      settings.INITIAL_MEMORY = total_mem
+    else:
+      settings.INITIAL_MEMORY += align_to_wasm_page_boudary(shadow_size)
 
     if settings.SAFE_HEAP:
       # SAFE_HEAP instruments ASan's shadow memory accesses.

--- a/emcc.py
+++ b/emcc.py
@@ -187,7 +187,7 @@ def base64_encode(b):
   return b64.decode('ascii')
 
 
-def align_to_wasm_page_boudary(address):
+def align_to_wasm_page_boundary(address):
   page_size = webassembly.WASM_PAGE_SIZE
   return ((address + (page_size - 1)) // page_size) * page_size
 
@@ -2270,7 +2270,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
     total_mem = user_mem * 8 / 7
 
     # But we might need to re-align to wasm page size
-    total_mem = int(align_to_wasm_page_boudary(total_mem))
+    total_mem = int(align_to_wasm_page_boundary(total_mem))
 
     # The shadow size is 1/8th the resulting rounded up size
     shadow_size = total_mem // 8
@@ -2282,7 +2282,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
     if not settings.ALLOW_MEMORY_GROWTH:
       settings.INITIAL_MEMORY = total_mem
     else:
-      settings.INITIAL_MEMORY += align_to_wasm_page_boudary(shadow_size)
+      settings.INITIAL_MEMORY += align_to_wasm_page_boundary(shadow_size)
 
     if settings.SAFE_HEAP:
       # SAFE_HEAP instruments ASan's shadow memory accesses.

--- a/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
@@ -24,7 +24,8 @@ void InitializeShadowMemory() {
   // Assert that the shadow region is large enough.  We don't want to start
   // running into the static data region which starts right after the shadow
   // region.
-  uptr max_address = __builtin_wasm_memory_size(0) * WASM_PAGE_SIZE;
+  uptr max_address =
+    (__builtin_wasm_memory_size(0) * uint64_t(WASM_PAGE_SIZE)) - 1;
   uptr max_shadow_address = MEM_TO_SHADOW(max_address);
   // TODO(sbc): In the growable memory case we should really be checking this
   // every time we grow.

--- a/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/asan/asan_emscripten.cpp
@@ -8,6 +8,8 @@
 
 #if SANITIZER_EMSCRIPTEN
 #include <emscripten.h>
+#include <emscripten/heap.h>
+#include <cassert>
 #include <cstddef>
 #include <pthread.h>
 #define __ATTRP_C11_THREAD ((void*)(uptr)-1)
@@ -18,6 +20,15 @@ void InitializeShadowMemory() {
   // Poison the shadow memory of the shadow area at the start of the address
   // space. This helps catching null pointer dereference.
   FastPoisonShadow(kLowShadowBeg, kLowShadowEnd - kLowShadowBeg, 0xff);
+
+  // Assert that the shadow region is large enough.  We don't want to start
+  // running into the static data region which starts right after the shadow
+  // region.
+  uptr max_address = __builtin_wasm_memory_size(0) * WASM_PAGE_SIZE;
+  uptr max_shadow_address = MEM_TO_SHADOW(max_address);
+  // TODO(sbc): In the growable memory case we should really be checking this
+  // every time we grow.
+  assert(max_shadow_address <= kLowShadowEnd && "shadow region is too small");
 }
 
 void AsanCheckDynamicRTPrereqs() {}


### PR DESCRIPTION
This bug was caused by miscalculating the adjustments made to TOTAL_MEMORY
and GLOBAL_BASE when using ASan.  The bug was introduced in #14631 and
was causing ASan to write poison values over static data in some cases.

This bug was really only effecting builds without ALLOW_MEMORY_GROWTH
since when ALLOW_MEMORY_GROWTH is enabled that shadow region is very
large and unless users were use a lot of memory it was unlikely ASan
would write to the end of it (and clobber static data).

As well as fixing the calculations, this change also adds a runtime
assert to ensure these regions never overlap (at least not at startup).
This should catch regressions in these calculations.

In order to test this case I removed ALLOW_MEMORY_GROWTH form several
asan and lsan tests.  It should not longer be necessary to set
`ALLOW_MEMORY_GROWTH` or adjust `TOTAL_MEMORY` when using sanitizers
these days.  The `asan` suite in the core tests still uses
`ALLOW_MEMORY_GROWTH`.  As a followup we might want to look into
removing that too.

Fixes: #15762