### PR TITLE
Ensure system libraries maintains insertion order

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1650,6 +1650,7 @@ def calculate(input_files, forced):
 
   handle_reverse_deps(input_files)
 
+  force_include = []
   libs_to_link = []
   already_included = set()
   system_libs_map = Library.get_usable_variations()
@@ -1660,9 +1661,10 @@ def calculate(input_files, forced):
   # You can provide 1 to include everything, or a comma-separated list with the
   # ones you want
   force = os.environ.get('EMCC_FORCE_STDLIBS')
-  if force == '1':
-    force = ','.join(name for name, lib in system_libs_map.items() if not lib.never_force)
-  force_include = set((force.split(',') if force else []) + forced)
+  if force is not None:
+    force_include = [name for name, lib in system_libs_map.items() if
+                     not lib.never_force] if force == '1' else force.split(',')
+  force_include += forced
   if force_include:
     logger.debug(f'forcing stdlibs: {force_include}')
 
@@ -1731,11 +1733,11 @@ def calculate(input_files, forced):
     add_library('libc_rt')
 
     if settings.USE_LSAN:
-      force_include.add('liblsan_rt')
+      force_include.append('liblsan_rt')
       add_library('liblsan_rt')
 
     if settings.USE_ASAN:
-      force_include.add('libasan_rt')
+      force_include.append('libasan_rt')
       add_library('libasan_rt')
       add_library('libasan_js')
 

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1661,9 +1661,10 @@ def calculate(input_files, forced):
   # You can provide 1 to include everything, or a comma-separated list with the
   # ones you want
   force = os.environ.get('EMCC_FORCE_STDLIBS')
-  if force is not None:
-    force_include = [name for name, lib in system_libs_map.items() if
-                     not lib.never_force] if force == '1' else force.split(',')
+  if force == '1':
+    force_include = [name for name, lib in system_libs_map.items() if not lib.never_force]
+  elif force is not None:
+    force_include = force.split(',')
   force_include += forced
   if force_include:
     logger.debug(f'forcing stdlibs: {force_include}')


### PR DESCRIPTION
Linking multiple system libraries could produce a different result,
because sets in Python doesn't preserve insertion order.

<details>
  <summary>Details</summary>

```diff
--- a/18c4c7a71f217a4a24e6c9d6fa03dfca2f7b57cf9facbc5ab91dbf129727ffac.out
+++ b/b7110b179c4fb62b1548e139cdb44ffeae654cacac8e4875af9273814fc552e8.out
@@ -82,10 +82,10 @@ system_libs:DEBUG: adding dependency on _get_tzname due to deps-info on timegm
 system_libs:DEBUG: adding dependency on _get_daylight due to deps-info on timegm
 system_libs:DEBUG: adding dependency on _get_timezone due to deps-info on timegm
 system_libs:DEBUG: adding dependency on malloc due to deps-info on timegm
-system_libs:DEBUG: forcing stdlibs: {'libwasmfs', 'libembind'}
+system_libs:DEBUG: forcing stdlibs: {'libembind', 'libwasmfs'}
 system_libs:DEBUG: including crtbegin (crtbegin.o)
-system_libs:DEBUG: including libwasmfs (libwasmfs-mt.a)
 system_libs:DEBUG: including libembind (libembind-rtti.a)
+system_libs:DEBUG: including libwasmfs (libwasmfs-mt.a)
 system_libs:DEBUG: including libGL (libGL-mt.a)
 system_libs:DEBUG: including libal (libal.a)
 system_libs:DEBUG: including libhtml5 (libhtml5.a)
@@ -98,8 +98,8 @@ system_libs:DEBUG: including libmalloc (libdlmalloc-mt.a)
 system_libs:DEBUG: including libc_rt (libc_rt-mt.a)
 system_libs:DEBUG: including libsockets (libsockets-mt.a)
 profiler:DEBUG: block "calculate system libraries" took 0.09 seconds
-emcc:DEBUG: linking: ['vips.a', '-L/home/kleisauke/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten', '/home/kleisauke/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/crtbegin.o', '--whole-archive', '-lwasmfs-mt', '-lembind-rtti', '--no-whole-archive', '-lGL-mt', '-lal', '-lhtml5', '-lstubs', '-lc-mt', '-lcompiler_rt-mt', '-lc++-mt-noexcept', '-lc++abi-mt-noexcept', '-ldlmalloc-mt', '-lc_rt-mt', '-lsockets-mt']
-shared:DEBUG: successfully executed /home/kleisauke/emsdk/upstream/bin/wasm-ld -o vips.wasm vips.a -L/home/kleisauke/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten /home/kleisauke/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/crtbegin.o --whole-archive -lwasmfs-mt -lembind-rtti --no-whole-archive -lGL-mt -lal -lhtml5 -lstubs -lc-mt -lcompiler_rt-mt -lc++-mt-noexcept -lc++abi-mt-noexcept -ldlmalloc-mt -lc_rt-mt -lsockets-mt -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr --import-undefined --import-memory --shared-memory --strip-debug --export-if-defined=main --export-if-defined=_emscripten_thread_init --export-if-defined=_emscripten_thread_exit --export-if-defined=emscripten_tls_init --export-if-defined=emscripten_current_thread_process_queued_calls --export-if-defined=pthread_self --export-if-defined=__start_em_asm --export-if-defined=__stop_em_asm --export=emscripten_wasmfs_read_file --export=stackSave --export=stackRestore --export=stackAlloc --export=__wasm_call_ctors --export=__errno_location --export=emscripten_dispatch_to_thread_ --export=_emscripten_main_thread_futex --export=_emscripten_thread_free_data --export=_emscripten_allow_main_runtime_queued_calls --export=emscripten_main_browser_thread_id --export=emscripten_main_thread_process_queued_calls --export=emscripten_run_in_main_runtime_thread_js --export=emscripten_stack_set_limits --export=emscripten_sync_run_in_main_thread_2 --export=emscripten_sync_run_in_main_thread_4 --export=memalign --export=malloc --export=free --export=ntohs --export=htons --export=_get_tzname --export=_get_daylight --export=_get_timezone --export=saveSetjmp --export=setThrew --export=htonl --export-table -z stack-size=5242880 --initial-memory=16777216 --no-entry --max-memory=16777216 --global-base=1024
+emcc:DEBUG: linking: ['vips.a', '-L/home/kleisauke/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten', '/home/kleisauke/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/crtbegin.o', '--whole-archive', '-lembind-rtti', '-lwasmfs-mt', '--no-whole-archive', '-lGL-mt', '-lal', '-lhtml5', '-lstubs', '-lc-mt', '-lcompiler_rt-mt', '-lc++-mt-noexcept', '-lc++abi-mt-noexcept', '-ldlmalloc-mt', '-lc_rt-mt', '-lsockets-mt']
+shared:DEBUG: successfully executed /home/kleisauke/emsdk/upstream/bin/wasm-ld -o vips.wasm vips.a -L/home/kleisauke/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten /home/kleisauke/emsdk/upstream/emscripten/cache/sysroot/lib/wasm32-emscripten/crtbegin.o --whole-archive -lembind-rtti -lwasmfs-mt --no-whole-archive -lGL-mt -lal -lhtml5 -lstubs -lc-mt -lcompiler_rt-mt -lc++-mt-noexcept -lc++abi-mt-noexcept -ldlmalloc-mt -lc_rt-mt -lsockets-mt -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr --import-undefined --import-memory --shared-memory --strip-debug --export-if-defined=main --export-if-defined=_emscripten_thread_init --export-if-defined=_emscripten_thread_exit --export-if-defined=emscripten_tls_init --export-if-defined=emscripten_current_thread_process_queued_calls --export-if-defined=pthread_self --export-if-defined=__start_em_asm --export-if-defined=__stop_em_asm --export=emscripten_wasmfs_read_file --export=stackSave --export=stackRestore --export=stackAlloc --export=__wasm_call_ctors --export=__errno_location --export=emscripten_dispatch_to_thread_ --export=_emscripten_main_thread_futex --export=_emscripten_thread_free_data --export=_emscripten_allow_main_runtime_queued_calls --export=emscripten_main_browser_thread_id --export=emscripten_main_thread_process_queued_calls --export=emscripten_run_in_main_runtime_thread_js --export=emscripten_stack_set_limits --export=emscripten_sync_run_in_main_thread_2 --export=emscripten_sync_run_in_main_thread_4 --export=memalign --export=malloc --export=free --export=ntohs --export=htons --export=_get_tzname --export=_get_daylight --export=_get_timezone --export=saveSetjmp --export=setThrew --export=htonl --export-table -z stack-size=5242880 --initial-memory=16777216 --no-entry --max-memory=16777216 --global-base=1024
 profiler:DEBUG: block "link" took 0.07 seconds
 emcc:DEBUG: emscript
 building:DEBUG: saving debug copy /tmp/emscripten_temp/emcc-0-base.wasm
@@ -110,7 +110,15 @@ building:DEBUG: saving debug copy /tmp/emscripten_temp/emcc-2-post_finalize.wasm
 emscripten:DEBUG: Metadata parsed: {'asmConsts': {'1485032': '{return wasmFS$preloadedFiles[$0].fileData.length}',
                '1485083': '{ HEAPU8.set(wasmFS$preloadedFiles[$1].fileData, '
                           '$0); }'},
- 'declares': ['emscripten_asm_const_int',
+ 'declares': ['_embind_register_void',
+              '_embind_register_bool',
+              '_embind_register_integer',
+              '_embind_register_float',
+              '_embind_register_std_string',
+              '_embind_register_std_wstring',
+              '_embind_register_emval',
+              '_embind_register_memory_view',
+              'emscripten_asm_const_int',
               'abort',
               '__cxa_atexit',
               '_emscripten_out',
@@ -122,14 +130,6 @@ emscripten:DEBUG: Metadata parsed: {'asmConsts': {'1485032': '{return wasmFS$pre
               '_emscripten_get_preloaded_child_path',
               '_emscripten_get_preloaded_path_name',
               '_emscripten_get_preloaded_file_mode',
-              '_embind_register_void',
-              '_embind_register_bool',
-              '_embind_register_integer',
-              '_embind_register_float',
-              '_embind_register_std_string',
-              '_embind_register_std_wstring',
-              '_embind_register_emval',
-              '_embind_register_memory_view',
               '_emscripten_default_pthread_stack_size',
               '__pthread_create_js',
               'emscripten_get_now',
@@ -475,10 +475,10 @@ emscripten:DEBUG: Metadata parsed: {'asmConsts': {'1485032': '{return wasmFS$pre
  'exports': ['__wasm_call_ctors',
              'main',
              'emscripten_tls_init',
-             'emscripten_wasmfs_read_file',
-             'malloc',
              '__getTypeName',
              '__embind_register_native_and_builtin_types',
+             'emscripten_wasmfs_read_file',
+             'malloc',
              '__errno_location',
              '_emscripten_thread_init',
              '_get_tzname',
```
</details>

This change fixes this non-determinism behavior by removing the set
in favor of a list, which is guaranteed to keep the elements in order
in which they were inserted.

See: #15706.