### PR TITLE
[SjLj] Make Wasm SjLj work with LTO

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -867,6 +867,14 @@ def get_cflags(user_args):
   if settings.LTO:
     if not any(a.startswith('-flto') for a in user_args):
       cflags.append('-flto=' + settings.LTO)
+    # setjmp/longjmp handling using Wasm EH
+    # For non-LTO, '-mllvm -wasm-enable-eh' added in
+    # building.llvm_backend_args() sets this feature in clang. But in LTO, the
+    # argument is added to wasm-ld instead, so clang needs to know that EH is
+    # enabled so that it can be added to the attributes in LLVM IR.
+    if settings.SUPPORT_LONGJMP == 'wasm':
+      cflags.append('-mexception-handling')
+
   else:
     # In LTO mode these args get passed instead at link time when the backend runs.
     for a in building.llvm_backend_args():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -139,8 +139,6 @@ def with_both_sjlj_handling(f):
       if not self.is_wasm():
         self.skipTest('wasm2js does not support Wasm SjLj')
       self.require_v8()
-      if '-flto' in self.emcc_args:
-        self.skipTest('https://github.com/emscripten-core/emscripten/issues/15665')
       self.set_setting('SUPPORT_LONGJMP', 'wasm')
       # These are for Emscripten EH/SjLj
       self.set_setting('DISABLE_EXCEPTION_THROWING')


### PR DESCRIPTION
This makes LTO work with Wasm SjLj.

For exceptions, we have `-fwasm-exceptions` option, which was created to
match [other kinds of exceptions](https://github.com/llvm/llvm-project/blob/7f410251e8d483e57ad54340ad968e4b498461da/clang/include/clang/Driver/Options.td#L1455-L1462) (DWARF, SjLj, and SEH). Clang driver
checks if `-fwasm-exceptions` is given, and if so does these things:
- [Adds](https://github.com/llvm/llvm-project/blob/7f410251e8d483e57ad54340ad968e4b498461da/clang/lib/Driver/ToolChains/WebAssembly.cpp#L295-L297) `target-features=+exception-handling` attribute to LLVM IR
- [Adds](https://github.com/llvm/llvm-project/blob/7f410251e8d483e57ad54340ad968e4b498461da/clang/lib/Driver/ToolChains/WebAssembly.cpp#L298-L300) `-mllvm -wasm-enable-eh` to the backend options.

For SjLj, we couldn't create such option like `-fwasm-exceptions`,
because other platforms all enable it by default and doesn't have a
dedicated Clang option for that. So we are passing
`-mllvm -wasm-enable-sjlj` in emcc to Clang as an workaround. Clang
driver checks if `-mllvm -wasm-enable-sjlj` is given, and if so [adds](https://github.com/llvm/llvm-project/blob/7f410251e8d483e57ad54340ad968e4b498461da/clang/lib/Driver/ToolChains/WebAssembly.cpp#L357-L359)
`target-features=+exception-handling` attribute to LLVM IR too. (Unlike
EH, it doesn't need to add `-mllvm -wasm-enable-sjlj` again because we
are already using that option)

The problem is, `-mllvm` options are not Clang options but LLVM options,
and we [process](https://github.com/emscripten-core/emscripten/blob/ffe4d081ea03104493d260646d459fdc9addaed6/tools/building.py#L252-L253) them in `llvm_backend_args`. In non-LTO mode, these
options are added to Clang, but in LTO mode, these are added to wasm-ld.
But as mentioned above, we are using `-mllvm -wasm-enable-eh` as a kind
of Clang option due to lack of a dedicated Clang option like
`-fwasm-exceptions`. This adds `target-features=+exception-handling`
attribute to LLVM IR, which should be done in Clang and cannot be done
in wasm-ld.

We cannot just add `-mllvm -wasm-enable-eh` to `get_cflags`, because
then it will not be added to wasm-ld. The options is necessary in the
backend processing as well. We cannot add it to both `get_cflags` and
`llvm_backend_args` either because it will error out saying the same
option is given twice in non-LTO mode.

So this PR ads `-mexception-handling`, which enables EH feature, to
Clang, in case we use Wasm SjLj. (Wasm EH doesn't need this because
`-fwasm-exceptions` enables it in Clang.) This works for both LTO and
non-LTO modes.

Fixes #15665.