### PR TITLE
Improve pthread error reporting. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -295,7 +295,16 @@ var LibraryPThread = {
       };
 
       worker.onerror = function(e) {
-        err('pthread sent an error! ' + e.filename + ':' + e.lineno + ': ' + e.message);
+        var message = 'worker sent an error!';
+#if ASSERTIONS
+        if (worker.pthread) {
+          var pthread_ptr = worker.pthread.threadInfoStruct;
+          if (pthread_ptr) {
+            message = 'Pthread 0x' + pthread_ptr.toString(16) + ' sent an error!';
+          }
+        }
+#endif
+        err(message + ' ' + e.filename + ':' + e.lineno + ': ' + e.message);
         throw e;
       };
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11193,8 +11193,8 @@ void foo() {}
     self.set_setting('EXIT_RUNTIME')
     self.emcc_args += ['--profiling-funcs']
     output = self.do_runf(test_file('pthread/test_pthread_trap.c'), assert_returncode=NON_ZERO)
-    self.assertContained("pthread sent an error!", output)
-    self.assertContained("at thread_main", output)
+    self.assertContained('sent an error!', output)
+    self.assertContained('at thread_main', output)
 
   @node_pthreads
   def test_emscripten_set_interval(self):


### PR DESCRIPTION
When an error occurs on a pthread, attempt to report the thread ID