### PR TITLE
[SjLj] Reenable test_openjpeg for LTO

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6294,9 +6294,6 @@ void* operator new(size_t size) {
   @needs_make('make')
   @is_slow_test
   def test_openjpeg(self):
-    if '-flto' in self.emcc_args:
-      self.skipTest('https://github.com/emscripten-core/emscripten/issues/15679')
-
     def do_test_openjpeg():
       def line_splitter(data):
         out = ''


### PR DESCRIPTION
Now that #15679 has been fixed, this reenables LTO tests for
`test_openjpeg`.