### PR TITLE
emscripten_log: use console.error() for EM_LOG_CONSOLE | EM_LOG_ERROR

### DIFF
--- a/site/source/docs/api_reference/emscripten.h.rst
+++ b/site/source/docs/api_reference/emscripten.h.rst
@@ -1006,7 +1006,7 @@ Defines
 
 .. c:macro:: EM_LOG_WARN
 
-  If specified, prints a warning message.
+  If specified, prints a warning message (combined with :c:data:`EM_LOG_CONSOLE`).
 
 .. c:macro:: EM_LOG_INFO
 
@@ -1018,7 +1018,7 @@ Defines
 
 .. c:macro:: EM_LOG_ERROR
 
-  If specified, prints an error message. If neither :c:data:`EM_LOG_WARN`, :c:data:`EM_LOG_ERROR`, :c:data:`EM_LOG_INFO` nor :c:data:`EM_LOG_DEBUG` is specified, an info message is printed. :c:data:`EM_LOG_WARN`, :c:data:`EM_LOG_INFO`, :c:data:`EM_LOG_DEBUG` and :c:data:`EM_LOG_ERROR` are mutually exclusive.
+  If specified, prints an error message (combined with :c:data:`EM_LOG_CONSOLE`). If neither :c:data:`EM_LOG_WARN`, :c:data:`EM_LOG_ERROR`, :c:data:`EM_LOG_INFO` nor :c:data:`EM_LOG_DEBUG` is specified, a log message is printed. :c:data:`EM_LOG_WARN`, :c:data:`EM_LOG_INFO`, :c:data:`EM_LOG_DEBUG` and :c:data:`EM_LOG_ERROR` are mutually exclusive. If :c:data:`EM_LOG_CONSOLE` is not specified then the message will be outputed via err() (for :c:data:`EM_LOG_ERROR` or :c:data:`EM_LOG_WARN`) or out() otherwise.
 
 .. c:macro:: EM_LOG_C_STACK
 

--- a/src/library.js
+++ b/src/library.js
@@ -2753,7 +2753,7 @@ LibraryManager.library = {
 
     if (flags & 1 /*EM_LOG_CONSOLE*/) {
       if (flags & 4 /*EM_LOG_ERROR*/) {
-        err(str);
+        console.error(str);
       } else if (flags & 2 /*EM_LOG_WARN*/) {
         console.warn(str);
       } else if (flags & 512 /*EM_LOG_INFO*/) {
@@ -2761,7 +2761,7 @@ LibraryManager.library = {
       } else if (flags & 256 /*EM_LOG_DEBUG*/) {
         console.debug(str);
       } else {
-        out(str);
+        console.log(str);
       }
     } else if (flags & 6 /*EM_LOG_ERROR|EM_LOG_WARN*/) {
       err(str);


### PR DESCRIPTION
Hi !

I was wondering if it was a deliberate choice to make emscripten_log behave differently for EM_LOG_ERROR? From what I understand, it should call console.error() so that we can correctly classify the console messages in DevTools.

I had some error messages which used to appear like warning messages before this patch. 

In the test file, there is also EM_LOG_NO_PATHS | EM_LOG_ERROR, which was supposed to print an error also, should it be added too (with the disabled test below)? 
https://github.com/emscripten-core/emscripten/blob/e325125379a98b0bc2988a6de8ad7f54191ade34/tests/emscripten_log/emscripten_log.cpp#L25

Thanks & Happy 2022!