### PR TITLE
Fix dylink on Big Endian

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -312,11 +312,11 @@ var LibraryDylink = {
     } else {
       var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
 #if SUPPORT_BIG_ENDIAN
-      var magicNumber = 0x0061736d;
+      var magicNumberFound = int32View[0] == 0x6d736100 || int32View[0] == 0x0061736d;
 #else
-      var magicNumber = 0x6d736100;
+      var magicNumberFound = int32View[0] == 0x6d736100;
 #endif
-      failIf(int32View[0] != magicNumber, 'need to see wasm magic number'); // \0asm
+      failIf(!magicNumberFound, 'need to see wasm magic number'); // \0asm
       // we should see the dylink custom section right after the magic number and wasm version
       failIf(binary[8] !== 0, 'need the dylink section to be first')
       offset = 9;

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -311,7 +311,12 @@ var LibraryDylink = {
       end = binary.length
     } else {
       var int32View = new Uint32Array(new Uint8Array(binary.subarray(0, 24)).buffer);
-      failIf(int32View[0] != 0x6d736100, 'need to see wasm magic number'); // \0asm
+#if SUPPORT_BIG_ENDIAN
+      var magicNumber = 0x0061736d;
+#else
+      var magicNumber = 0x6d736100;
+#endif
+      failIf(int32View[0] != magicNumber, 'need to see wasm magic number'); // \0asm
       // we should see the dylink custom section right after the magic number and wasm version
       failIf(binary[8] !== 0, 'need the dylink section to be first')
       offset = 9;


### PR DESCRIPTION
Js Typed Arrays are loaded according to the platform byte order and as a result may need to be
reversed to match a Little Endian output.

A number of `wasm0` tests are currently failing on BE platforms as the loaded magic number value 
is not in LE order, which this PR is trying to fix.

Big Endian Support was previously added to emscripten in this PR: https://github.com/emscripten-core/emscripten/pull/13413