### PR TITLE
import mutable globals used in Asyncify pass

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1914,7 +1914,7 @@ def phase_linker_setup(options, state, newargs, user_settings):
         '__asyncify_state',
         '__asyncify_data'
       ]
-    
+
     # Unconditional dependency in library_dylink.js
     settings.REQUIRED_EXPORTS += ['setThrew']
 

--- a/emcc.py
+++ b/emcc.py
@@ -1914,7 +1914,7 @@ def phase_linker_setup(options, state, newargs, user_settings):
         '__asyncify_state',
         '__asyncify_data'
       ]
-
+    
     # Unconditional dependency in library_dylink.js
     settings.REQUIRED_EXPORTS += ['setThrew']
 

--- a/emcc.py
+++ b/emcc.py
@@ -567,6 +567,8 @@ def get_binaryen_passes():
     passes += ['--fpcast-emu']
   if settings.ASYNCIFY == 1:
     passes += ['--asyncify']
+    if settings.MAIN_MODULE or settings.SIDE_MODULE:
+      passes += ['--pass-arg=asyncify-side-module']
     if settings.ASSERTIONS:
       passes += ['--pass-arg=asyncify-asserts']
     if settings.ASYNCIFY_ADVISE:
@@ -1906,6 +1908,13 @@ def phase_linker_setup(options, state, newargs, user_settings):
         '__heap_base',
         '__stack_pointer',
     ]
+
+    if settings.ASYNCIFY:
+      settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
+        '__asyncify_state',
+        '__asyncify_data'
+      ]
+    
     # Unconditional dependency in library_dylink.js
     settings.REQUIRED_EXPORTS += ['setThrew']
 

--- a/emcc.py
+++ b/emcc.py
@@ -568,7 +568,7 @@ def get_binaryen_passes():
   if settings.ASYNCIFY == 1:
     passes += ['--asyncify']
     if settings.MAIN_MODULE or settings.SIDE_MODULE:
-      passes += ['--pass-arg=asyncify-side-module']
+      passes += ['--pass-arg=asyncify-relocatable']
     if settings.ASSERTIONS:
       passes += ['--pass-arg=asyncify-asserts']
     if settings.ASYNCIFY_ADVISE:

--- a/emscripten.py
+++ b/emscripten.py
@@ -378,7 +378,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
 
   exports = metadata['exports']
 
-  if settings.ASYNCIFY:
+  if settings.ASYNCIFY and settings.RELOCATABLE:
     exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
     metadata['globalImports'] += ['__asyncify_state', '__asyncify_data']
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -380,6 +380,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
 
   if settings.ASYNCIFY:
     exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
+    metadata['globalImports'] += ['__asyncify_state', '__asyncify_data']
 
   report_missing_symbols(forwarded_json['librarySymbols'])
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -350,6 +350,9 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
     if settings.INITIAL_TABLE == -1:
       settings.INITIAL_TABLE = dylink_sec.table_size + 1
 
+    if settings.ASYNCIFY:
+      metadata['globalImports'] += ['__asyncify_state', '__asyncify_data']
+
   invoke_funcs = metadata['invokeFuncs']
   if invoke_funcs:
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += ['$getWasmTableEntry']
@@ -377,7 +380,6 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
 
   if settings.ASYNCIFY:
     exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
-    metadata['globalImports'] += ['__asyncify_state', '__asyncify_data']
 
   report_missing_symbols(forwarded_json['librarySymbols'])
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -377,6 +377,7 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
 
   if settings.ASYNCIFY:
     exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
+    metadata['globalImports'] += ['__asyncify_state', '__asyncify_data']
 
   report_missing_symbols(forwarded_json['librarySymbols'])
 

--- a/emscripten.py
+++ b/emscripten.py
@@ -378,9 +378,8 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile):
 
   exports = metadata['exports']
 
-  if settings.ASYNCIFY and settings.RELOCATABLE:
+  if settings.ASYNCIFY:
     exports += ['asyncify_start_unwind', 'asyncify_stop_unwind', 'asyncify_start_rewind', 'asyncify_stop_rewind']
-    metadata['globalImports'] += ['__asyncify_state', '__asyncify_data']
 
   report_missing_symbols(forwarded_json['librarySymbols'])
 

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -214,7 +214,8 @@ Asyncify with Dynamic Linking
 #############################
 
 If you want to use Asyncify in dynamic libraries, those methods which are imported
-from other linked modules should be listed in ``ASYNCIFY_IMPORTS``.
+from other linked modules (and that will be on the stack in an async operation)
+should be listed in ``ASYNCIFY_IMPORTS``.
 
 .. code-block:: cpp
 
@@ -225,7 +226,7 @@ from other linked modules should be listed in ``ASYNCIFY_IMPORTS``.
       emscripten_sleep(100);
     }
 
-In the side module, you can compile sleep.cpp in ordinal emscripten's dynamic
+In the side module, you can compile sleep.cpp in the ordinal emscripten dynamic
 linking manner:
 
 ::

--- a/site/source/docs/porting/asyncify.rst
+++ b/site/source/docs/porting/asyncify.rst
@@ -210,6 +210,48 @@ the list of imports to the wasm module that the Asyncify instrumentation must be
 aware of. Giving it that list tells it that all other JS calls will **not** do
 an async operation, which lets it not add overhead where it isn't needed.
 
+Asyncify with Dynamic Linking
+#############################
+
+If you want to use Asyncify in dynamic libraries, those methods which are imported
+from other linked modules should be listed in ``ASYNCIFY_IMPORTS``.
+
+.. code-block:: cpp
+
+    // sleep.cpp
+    #include <emscripten.h>
+
+    extern "C" void sleep_for_seconds() {
+      emscripten_sleep(100);
+    }
+
+In the side module, you can compile sleep.cpp in ordinal emscripten's dynamic
+linking manner:
+
+::
+
+    emcc sleep.cpp -O3 -o libsleep.wasm -sASYNCIFY -sSIDE_MODULE
+
+.. code-block:: cpp
+
+    // main.cpp
+    #include <emscripten.h>
+
+    extern "C" void sleep_for_seconds();
+
+    int main() {
+      sleep_for_seconds();
+      return 0;
+    }
+
+In the main module, the compiler doesn’t statically know that ``sleep_for_seconds`` is
+asynchronous. Therefore, you must add ``sleep_for_seconds`` to the ``ASYNCIFY_IMPORTS``
+list.
+
+::
+
+    emcc main.cpp libsleep.wasm -O3 -sASYNCIFY -sASYNCIFY_IMPORTS=sleep_for_seconds -sMAIN_MODULE
+
 Usage with Embind
 #################
 

--- a/src/library.js
+++ b/src/library.js
@@ -3626,6 +3626,12 @@ mergeInto(LibraryManager.library, {
   __c_longjmp: "new WebAssembly.Tag({'parameters': ['{{{ POINTER_WASM_TYPE }}}']})",
   __c_longjmp_import: true,
 #endif
+#if ASYNCIFY
+  __asyncify_state: "new WebAssembly.Global({'value': 'i32', 'mutable': true}, 0)",
+  __asyncify_state__import: true,
+  __asyncify_data: "new WebAssembly.Global({'value': 'i32', 'mutable': true}, 0)",
+  __asyncify_data__import: true,
+#endif
 #endif
 
   _emscripten_fs_load_embedded_files__deps: ['$FS', '$PATH'],

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -269,14 +269,16 @@ mergeInto(LibraryManager.library, {
       var func = Module['asm'][name];
 #if RELOCATABLE
       // Exported functions in side modules are not listed in `Module["asm"]`,
-      // but are added as a form of `Module["(asmjs mangled name)"]`.
-      // So we should find a rewind function from `Module["asm"]` and `Module["(asmjs mangled name)"]`.
+      // So we should use `resolveGlobalSymbol` helper function, which is defined in `library_dylink.js`.
       if (!func) {
-        func = Module[asmjsMangle(name)];
+        func = resolveGlobalSymbol(name);
       }
 #endif
       return func;
     },
+#if RELOCATABLE
+    getDataRewindFunc__deps: [ '$resolveGlobalSymbol' ],
+#endif
 
     doRewind: function(ptr) {
 #if ASYNCIFY == 2

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -271,7 +271,7 @@ mergeInto(LibraryManager.library, {
       // Exported functions in side modules are not listed in `Module["asm"]`,
       // So we should use `resolveGlobalSymbol` helper function, which is defined in `library_dylink.js`.
       if (!func) {
-        func = resolveGlobalSymbol(name);
+        func = resolveGlobalSymbol(name, false);
       }
 #endif
       return func;

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -263,6 +263,9 @@ mergeInto(LibraryManager.library, {
       {{{ makeSetValue('ptr', C_STRUCTS.asyncify_data_s.rewind_id, 'rewindId', 'i32') }}};
     },
 
+#if RELOCATABLE
+    getDataRewindFunc__deps: [ '$resolveGlobalSymbol' ],
+#endif
     getDataRewindFunc: function(ptr) {
       var id = {{{ makeGetValue('ptr', C_STRUCTS.asyncify_data_s.rewind_id, 'i32') }}};
       var name = Asyncify.callStackIdToName[id];
@@ -276,9 +279,6 @@ mergeInto(LibraryManager.library, {
 #endif
       return func;
     },
-#if RELOCATABLE
-    getDataRewindFunc__deps: [ '$resolveGlobalSymbol' ],
-#endif
 
     doRewind: function(ptr) {
 #if ASYNCIFY == 2

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -265,6 +265,9 @@ mergeInto(LibraryManager.library, {
       var name = Asyncify.callStackIdToName[id];
       var func = Module['asm'][name];
 #if RELOCATABLE
+      // Exported functions in side modules are not listed in `Module["asm"]`,
+      // but are added as a form of `Module["(asmjs mangled name)"]`.
+      // So we should find a rewind function from `Module["asm"]` and `Module["(asmjs mangled name)"]`.
       if (!func) {
         func = Module[asmjsMangle(name)];
       }

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -187,6 +187,9 @@ mergeInto(LibraryManager.library, {
                 }
               }
             };
+#if MAIN_MODULE
+            ret[x].orig = original;
+#endif
           } else {
             ret[x] = original;
           }

--- a/src/library_async.js
+++ b/src/library_async.js
@@ -264,6 +264,11 @@ mergeInto(LibraryManager.library, {
       var id = {{{ makeGetValue('ptr', C_STRUCTS.asyncify_data_s.rewind_id, 'i32') }}};
       var name = Asyncify.callStackIdToName[id];
       var func = Module['asm'][name];
+#if RELOCATABLE
+      if (!func) {
+        func = Module[asmjsMangle(name)];
+      }
+#endif
       return func;
     },
 

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -1025,8 +1025,8 @@ var LibraryDylink = {
 #endif
 
 #if ASYNCIFY
-      if (symbol in GOT && GOT[symbol].value != 0) {
-        return GOT[symbol].value;
+      if ('orig' in result) {
+        result = result.orig;
       }
 #endif
       // Insert the function into the wasm table.  If its a direct wasm function

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -1023,6 +1023,12 @@ var LibraryDylink = {
 #if DYLINK_DEBUG
       err('dlsym: ' + symbol + ' getting table slot for: ' + result);
 #endif
+
+#if ASYNCIFY
+      if(symbol in GOT && GOT[symbol].value != 0) {
+        return GOT[symbol].value 
+      }
+#endif
       // Insert the function into the wasm table.  If its a direct wasm function
       // the second argument will not be needed.  If its a JS function we rely
       // on the `sig` attribute being set based on the `<func>__sig` specified

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -1025,8 +1025,8 @@ var LibraryDylink = {
 #endif
 
 #if ASYNCIFY
-      if(symbol in GOT && GOT[symbol].value != 0) {
-        return GOT[symbol].value 
+      if (symbol in GOT && GOT[symbol].value != 0) {
+        return GOT[symbol].value;
       }
 #endif
       // Insert the function into the wasm table.  If its a direct wasm function

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -1025,6 +1025,7 @@ var LibraryDylink = {
 #endif
 
 #if ASYNCIFY
+      // Asyncify wraps exports, and we need to look through those wrappers.
       if ('orig' in result) {
         result = result.orig;
       }

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -624,6 +624,9 @@ var LibraryDylink = {
         // add new entries to functionsInTableMap
         updateTableMap(tableBase, metadata.tableSize);
         moduleExports = relocateExports(instance.exports, memoryBase);
+#if ASYNCIFY
+        moduleExports = Asyncify.instrumentWasmExports(moduleExports);
+#endif
         if (!flags.allowUndefined) {
           reportUndefinedSymbols();
         }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3982,28 +3982,26 @@ ok
     self.set_setting('EXIT_RUNTIME', 1)
 
     create_file('liblib.c', r'''
-        #include <stdio.h>
-        #include <emscripten/emscripten.h>
+      #include <stdio.h>
+      #include <emscripten/emscripten.h>
 
-        int side_module_run()
-        {
-          printf("before sleep\n");
-          emscripten_sleep(1000);
-          printf("after sleep\n");
-          return 42;
-        }
+      int side_module_run() {
+        printf("before sleep\n");
+        emscripten_sleep(1000);
+        printf("after sleep\n");
+        return 42;
+      }
       ''')
     self.build_dlfcn_lib('liblib.c')
 
     self.prep_dlfcn_main()
     src = r'''
-      #include <iostream>
+      #include <stdio.h>
       #include <dlfcn.h>
 
       typedef int (*func_t)();
 
-      int main(int argc, char **argv)
-      {
+      int main(int argc, char **argv) {
         void *_dlHandle = dlopen("liblib.so", RTLD_NOW | RTLD_LOCAL);
         func_t my_func = (func_t)dlsym(_dlHandle, "side_module_run");
         printf("%d\n", my_func());
@@ -8143,7 +8141,7 @@ Module['onRuntimeInitialized'] = function() {
   def test_asyncify_side_module(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('EXIT_RUNTIME', 1)
-    self.emcc_args += ['-sASYNCIFY_IMPORTS=["my_sleep"]']
+    self.set_setting('ASYNCIFY_IMPORTS', ['my_sleep'])
     self.dylink_test(r'''
       #include <stdio.h>
       #include "header.h"
@@ -8155,8 +8153,8 @@ Module['onRuntimeInitialized'] = function() {
         return 0;
       }
     ''', r'''
-      #include <emscripten.h>
       #include <stdio.h>
+      #include <emscripten.h>
       #include "header.h"
 
       void my_sleep(int milli_seconds) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3985,7 +3985,7 @@ ok
     create_file('liblib.c', r'''
         #include <stdio.h>
         #include <emscripten/emscripten.h>
- 
+
         int side_module_run()
         {
           printf("before sleep\n");

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8144,7 +8144,7 @@ Module['onRuntimeInitialized'] = function() {
   def test_asyncify_side_module(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('EXIT_RUNTIME', 1)
-    self.emcc_args += ['-sASYNCIFY_IMPORTS=["_Z8my_sleepi"]']
+    self.emcc_args += ['-sASYNCIFY_IMPORTS=["my_sleep"]']
     self.dylink_test(r'''
       #include <stdio.h>
       #include "header.h"
@@ -8168,7 +8168,7 @@ Module['onRuntimeInitialized'] = function() {
         // variable on stack in side module function should be restored.
         printf("%d\n", value);
       }
-    ''', 'before sleep\n42\n42\nafter sleep\n', header='void my_sleep(int);')
+    ''', 'before sleep\n42\n42\nafter sleep\n', header='void my_sleep(int);', force_c=True)
 
   @no_asan('asyncify stack operations confuse asan')
   @no_wasm64('TODO: asyncify for wasm64')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3979,7 +3979,6 @@ ok
   @no_wasm64('TODO: asyncify for wasm64')
   def test_dlfcn_asyncify(self):
     self.set_setting('ASYNCIFY')
-    self.set_setting('EXIT_RUNTIME', 1)
 
     create_file('liblib.c', r'''
       #include <stdio.h>
@@ -8140,7 +8139,6 @@ Module['onRuntimeInitialized'] = function() {
   @no_wasm64('TODO: asyncify for wasm64')
   def test_asyncify_side_module(self):
     self.set_setting('ASYNCIFY')
-    self.set_setting('EXIT_RUNTIME', 1)
     self.set_setting('ASYNCIFY_IMPORTS', ['my_sleep'])
     self.dylink_test(r'''
       #include <stdio.h>

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8112,7 +8112,9 @@ Module['onRuntimeInitialized'] = function() {
       #include "header.h"
 
       int main() {
+        printf("before sleep\n");
         my_sleep(1);
+        printf("after sleep\n");
         return 0;
       }
     ''', r'''
@@ -8123,12 +8125,12 @@ Module['onRuntimeInitialized'] = function() {
       void my_sleep(int milli_seconds) {
         // put variable onto stack
         volatile int value = 42;
-        printf("%d ", value);
+        printf("%d\n", value);
         emscripten_sleep(milli_seconds);
         // variable on stack in side module function should be restored.
         printf("%d\n", value);
       }
-    ''', '42 42', header='void my_sleep(int);')
+    ''', 'before sleep\n42\n42\nafter sleep\n', header='void my_sleep(int);')
 
   @needs_dylink
   @no_memory64('TODO: asyncify for wasm64')
@@ -8157,11 +8159,13 @@ Module['onRuntimeInitialized'] = function() {
       {
         int side_module_run()
         {
+          printf("before sleep\n");
           emscripten_sleep(1000);
+          printf("after sleep\n");
           return 42;
         }
       }
-    ''', '42', need_reverse=False)
+    ''', 'before sleep\nafter sleep\n42', need_reverse=False)
 
   @no_asan('asyncify stack operations confuse asan')
   @no_wasm64('TODO: asyncify for wasm64')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8105,13 +8105,14 @@ Module['onRuntimeInitialized'] = function() {
   @no_memory64('TODO: asyncify for wasm64')
   def test_asyncify_side_module(self):
     self.set_setting('ASYNCIFY')
+    self.set_setting('EXIT_RUNTIME', 1)
     self.emcc_args += ['-sASYNCIFY_IMPORTS=["_Z8my_sleepi"]']
     self.dylink_test(r'''
       #include <stdio.h>
       #include "header.h"
 
       int main() {
-        my_sleep(1);     
+        my_sleep(1);
         return 0;
       }
     ''', r'''

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3976,11 +3976,10 @@ ok
     self.do_run(src, 'float: 42.\n')
 
   @needs_dylink
-  @no_memory64('TODO: asyncify for wasm64')
+  @no_wasm64('TODO: asyncify for wasm64')
   def test_dlfcn_asyncify(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('EXIT_RUNTIME', 1)
-    self.emcc_args += ['-sASYNCIFY_IGNORE_INDIRECT=0']
 
     create_file('liblib.c', r'''
         #include <stdio.h>
@@ -8140,7 +8139,7 @@ Module['onRuntimeInitialized'] = function() {
         raise
 
   @needs_dylink
-  @no_memory64('TODO: asyncify for wasm64')
+  @no_wasm64('TODO: asyncify for wasm64')
   def test_asyncify_side_module(self):
     self.set_setting('ASYNCIFY')
     self.set_setting('EXIT_RUNTIME', 1)


### PR DESCRIPTION
This PR will be a solution to #15594

emscripten Asyncify won't work properly in side modules, because the globals, __asyncify_state and __asyncify_data, are not synchronized between main-module and side-modules.

With <https://github.com/WebAssembly/binaryen/pull/4427>, `__asyncify_state` and `__asyncify_data` will be imported global in the instrumented wasm.

