### PR TITLE
Process queued calls from other threads during sched_yeild

### DIFF
--- a/system/lib/libc/musl/src/sched/sched_yield.c
+++ b/system/lib/libc/musl/src/sched/sched_yield.c
@@ -1,12 +1,17 @@
 #include <sched.h>
 #include "syscall.h"
 
+#if __EMSCRIPTEN__
+#include <emscripten/threading.h>
+#endif
+
 int sched_yield()
 {
 #if __EMSCRIPTEN__
-	// SharedArrayBuffer and wasm threads do not support explicit yielding,
-	// but in practice it should happen automatically well enough anyhow, so
-	// report success in order to not break apps.
+	// SharedArrayBuffer and wasm threads do not support explicit yielding.
+	// For now we at least process our event queue so that other threads who
+	// are waiting on this one to perform actions can make progesss.
+	emscripten_current_thread_process_queued_calls();
 	return 0;
 #else
 	return syscall(SYS_sched_yield);

--- a/tests/pthread/test_pthread_busy_wait.cpp
+++ b/tests/pthread/test_pthread_busy_wait.cpp
@@ -1,7 +1,6 @@
 #include <atomic>
 #include <thread>
 #include <cstdio>
-#include <emscripten/threading.h>
 
 int main() {
   std::atomic<bool> done(false);
@@ -12,9 +11,6 @@ int main() {
   });
 
   while (!done) {
-    // TODO(sbc): this call should not be needed.
-    // See: https://github.com/emscripten-core/emscripten/issues/15868
-    emscripten_main_thread_process_queued_calls();
     std::this_thread::yield();
   }
 


### PR DESCRIPTION
This is part of two fixes for #15896.  Ideally will followup
by also removing the proxying of atexit calls, but this alone
should fix this issue as written.