### PR TITLE
Improve libc++ abort behavior

### DIFF
--- a/system/lib/libcxxabi/src/abort_message.cpp
+++ b/system/lib/libcxxabi/src/abort_message.cpp
@@ -39,7 +39,7 @@ void abort_message(const char* format, ...)
         // even minimal logging for them, as we'll have a proper call stack, which
         // will show a call into "abort_message", and can help debugging. (In a
         // debug build that won't be inlined.)
-        __builtin_trap();
+        abort();
 #else
         fprintf(stderr, "libc++abi: ");
         va_list list;


### PR DESCRIPTION
Use `abort()` rather than `__builtin_trap()` here so that the use will
see `Aborted(native code called abort())` rather than just
`RuntimeError: unreachable`.

We could also consider building a `-debug` flavor of libc++ but I think
this is still a worthwhile change.

See #15892