### PR TITLE
Add 'use strict' to all but one of our JS tools. NFC

### DIFF
--- a/tests/sourcemap2json.js
+++ b/tests/sourcemap2json.js
@@ -7,7 +7,7 @@
 // Quick utility script USED ONLY FOR TESTING.
 // Could be replaced if a good python source map library is found.
 
-"use strict";
+'use strict';
 
 var SourceMapConsumer = require('source-map').SourceMapConsumer;
 var fs = require('fs');

--- a/tools/acorn-optimizer.js
+++ b/tools/acorn-optimizer.js
@@ -1,4 +1,7 @@
 #!/usr/bin/env node
+
+'use strict';
+
 const acorn = require('acorn');
 const terser = require('../third_party/terser');
 const fs = require('fs');
@@ -1593,7 +1596,7 @@ function minifyLocals(ast) {
         if (newNames.has(name)) {
           node.name = newNames.get(name);
         } else if (isLocalName(name)) {
-          minified = getNextMinifiedName();
+          const minified = getNextMinifiedName();
           newNames.set(name, minified);
           node.name = minified;
         }
@@ -1806,27 +1809,27 @@ function reattachComments(ast, comments) {
 
 let suffix = '';
 
-const arguments = process['argv'].slice(2);
+const argv = process['argv'].slice(2);
 // If enabled, output retains parentheses and comments so that the
 // output can further be passed out to Closure.
-let closureFriendly = arguments.indexOf('--closureFriendly');
+let closureFriendly = argv.indexOf('--closureFriendly');
 if (closureFriendly > -1) {
-  arguments.splice(closureFriendly, 1);
+  argv.splice(closureFriendly, 1);
   closureFriendly = true;
 } else {
   closureFriendly = false;
 }
 
-let exportES6 = arguments.indexOf('--exportES6');
+let exportES6 = argv.indexOf('--exportES6');
 if (exportES6 > -1) {
-  arguments.splice(exportES6, 1);
+  argv.splice(exportES6, 1);
   exportES6 = true;
 } else {
   exportES6 = false;
 }
 
-const infile = arguments[0];
-const passes = arguments.slice(1);
+const infile = argv[0];
+const passes = argv.slice(1);
 
 const input = read(infile);
 const extraInfoStart = input.lastIndexOf('// EXTRA_INFO:');

--- a/tools/lz4-compress.js
+++ b/tools/lz4-compress.js
@@ -4,6 +4,8 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
+'use strict';
+
 const fs = require('fs');
 const path = require('path');
 
@@ -37,7 +39,7 @@ function load(f) {
   globalEval(read(f));
 }
 
-assert = function(x, message) {
+global.assert = function(x, message) {
   if (!x) throw new Errror(message);
 };
 

--- a/tools/preprocessor.js
+++ b/tools/preprocessor.js
@@ -12,6 +12,7 @@
 //                   file with modified settings and supply the filename here.
 //    shell file     This is the file that will be processed by the preprocessor
 
+'use strict';
 
 const fs = require('fs');
 const path = require('path');
@@ -19,10 +20,10 @@ const path = require('path');
 const arguments_ = process['argv'].slice(2);
 const debug = false;
 
-print = function(x) {
+global.print = function(x) {
   process['stdout'].write(x + '\n');
 };
-printErr = function(x) {
+global.printErr = function(x) {
   process['stderr'].write(x + '\n');
 };
 
@@ -37,12 +38,12 @@ function find(filename) {
   return filename;
 }
 
-read = function(filename) {
+global.read = function(filename) {
   const absolute = find(filename);
   return fs.readFileSync(absolute).toString();
 };
 
-load = function(f) {
+global.load = function(f) {
   eval.call(null, read(f));
 };
 


### PR DESCRIPTION
Sadly, the main tools `src/compiler.js` cannot function is strict mode
as it depends of the non-strict behaviour of JS `eval`.