### PR TITLE
Avoid parsing settings.js files in src/compiler.js.

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -41,29 +41,12 @@ function load(f) {
 // Basic utilities
 load('utility.js');
 
-// Load settings, can be overridden by commandline
-load('./settings.js');
-load('./settings_internal.js');
-
+// Load settings from JSON passed on the command line
 const settingsFile = process['argv'][2];
+assert(settingsFile);
 
-if (settingsFile) {
-  const settings = JSON.parse(read(settingsFile));
-  for (const key in settings) {
-    if (Object.prototype.hasOwnProperty.call(settings, key)) {
-      let value = settings[key];
-      if (value[0] == '@') {
-        // response file type thing, workaround for large inputs: value is @path-to-file
-        try {
-          value = JSON.parse(read(value.substr(1)));
-        } catch (e) {
-          // continue normally; assume it is not a response file
-        }
-      }
-      global[key] = eval(JSON.stringify(value));
-    }
-  }
-}
+const settings = JSON.parse(read(settingsFile));
+Object.assign(global, settings);
 
 EXPORTED_FUNCTIONS = new Set(EXPORTED_FUNCTIONS);
 WASM_EXPORTS = new Set(WASM_EXPORTS);


### PR DESCRIPTION
We always pass the settings via a json file which is created by the
python code.   Additionally parsing the settings as JS here serves no
purpose that I can tell.

It might have been useful at some point in the past for debugging, but
I've certainly never used this feature.  It should be prefectly possible
to create a json file on demand in one needs one.

The motivation for doing this is that (a) it simplifies the code, (b)
it allows us to switch settings.js to python and (c) it moves us closer
to modernizing `src/compiler.js` by avoiding depending quite so much
on the legacy behaviour of `eval`.