### PR TITLE
Cleanup serialization of settings JSON file. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -166,10 +166,15 @@ def compile_settings():
     logger.info('logging stderr in js compiler phase into %s' % stderr_file)
     stderr_file = open(stderr_file, 'w')
 
+  # Only the names of the legacy settings are used by the JS compiler
+  # so we can reduce the size of serialized json by simplifying this
+  # otherwise complex value.
+  settings['LEGACY_SETTINGS'] = [l[0] for l in settings['LEGACY_SETTINGS']]
+
   # Save settings to a file to work around v8 issue 1579
-  with shared.configuration.get_temp_files().get_file('.txt') as settings_file:
+  with shared.configuration.get_temp_files().get_file('.json') as settings_file:
     with open(settings_file, 'w') as s:
-      json.dump(settings.dict(), s, sort_keys=True)
+      json.dump(settings.dict(), s, sort_keys=True, indent=2)
 
     # Call js compiler
     env = os.environ.copy()

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -890,8 +890,7 @@ function makeRetainedCompilerSettings() {
   const ignore = new Set(['STRUCT_INFO']);
   if (STRICT) {
     for (const setting of LEGACY_SETTINGS) {
-      const name = setting[0];
-      ignore.add(name);
+      ignore.add(setting);
     }
   }
 

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -96,18 +96,15 @@ class SettingsManager:
     self.allowed_settings.clear()
 
     # Load the JS defaults into python.
-    with open(path_from_root('src/settings.js')) as fh:
-      settings = fh.read().replace('//', '#')
-    settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
-    # Variable TARGET_NOT_SUPPORTED is referenced by value settings.js (also beyond declaring it),
-    # so must pass it there explicitly.
-    exec(settings, {'attrs': self.attrs})
+    def read_js_settings(filename, attrs):
+      with open(filename) as fh:
+        settings = fh.read().replace('//', '#')
+      settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
+      exec(settings, {'attrs': attrs})
 
-    with open(path_from_root('src/settings_internal.js')) as fh:
-      settings = fh.read().replace('//', '#')
-    settings = re.sub(r'var ([\w\d]+)', r'attrs["\1"]', settings)
     internal_attrs = {}
-    exec(settings, {'attrs': internal_attrs})
+    read_js_settings(path_from_root('src/settings.js'), self.attrs)
+    read_js_settings(path_from_root('src/settings_internal.js'), internal_attrs)
     self.attrs.update(internal_attrs)
 
     if 'EMCC_STRICT' in os.environ:


### PR DESCRIPTION
- Use .json extension
- Avoid seralizing entire LEGACY_SETTINGS
- Use indentation to make the file readable.
- Refactor JS settings file reading to avoid duplication.