### PR TITLE
Add experimental implementation of metadata extraction in python. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -363,6 +363,10 @@ jobs:
           test_targets: "posixtest"
   test-core0:
     executor: bionic
+    # Temporarily set EMCC_READ_METADATA to compare to ensure that the python
+    # can marches precisely the output wasm-emscripten-finalize.
+    environment:
+      EMCC_READ_METADATA: "compare"
     steps:
       - run-tests:
           test_targets: "core0"

--- a/tools/extract_metadata.py
+++ b/tools/extract_metadata.py
@@ -1,0 +1,218 @@
+# Copyright 2022 The Emscripten Authors.  All rights reserved.
+# Emscripten is available under two separate licenses, the MIT license and the
+# University of Illinois/NCSA Open Source License.  Both these licenses can be
+# found in the LICENSE file.
+
+from . import webassembly
+from .shared import exit_with_error
+from .settings import settings
+
+
+def is_wrapper_function(module, function):
+  module.seek(function.offset)
+  num_local_decls = module.readULEB()
+  while num_local_decls:
+    local_count = module.readULEB()  # noqa
+    local_type = module.read_type()  # noqa
+    num_local_decls -= 1
+  end = function.offset + function.size
+  while module.tell() != end:
+    opcode = module.readByte()
+    try:
+      opcode = webassembly.OpCode(opcode)
+    except ValueError as e:
+      print(e)
+      return False
+    if opcode == webassembly.OpCode.CALL:
+      callee = module.readULEB()  # noqa
+    elif opcode == webassembly.OpCode.END:
+      break
+    else:
+      return False
+  assert opcode == webassembly.OpCode.END
+  return True
+
+
+def get_const_expr_value(expr):
+  assert len(expr) == 2
+  assert expr[1][0] == webassembly.OpCode.END
+  opcode, immediates = expr[0]
+  if opcode in (webassembly.OpCode.I32_CONST, webassembly.OpCode.I64_CONST):
+    assert len(immediates) == 1
+    return immediates[0]
+  elif opcode in (webassembly.OpCode.GLOBAL_GET,):
+    return 0
+  else:
+    exit_with_error('unexpected opcode in const expr: ' + str(opcode))
+
+
+def get_global_value(globl):
+  return get_const_expr_value(globl.init)
+
+
+def find_segment_with_address(module, address, size=0):
+  segments = module.get_segments()
+  active = [s for s in segments if s.init]
+
+  for seg in active:
+    offset = get_const_expr_value(seg.init)
+    if offset is None:
+      continue
+    if offset == address:
+      return (seg, 0)
+    if address > offset and address < offset + seg.size:
+      return (seg, address - offset)
+
+  passive = [s for s in segments if not s.init]
+  for seg in passive:
+    if seg.size == size:
+      return (seg, 0)
+
+
+def data_to_string(data):
+  data = data.decode('utf8')
+  # We have at least one test (tests/utf8.cpp) that uses a double
+  # backslash in the C++ source code, in order to represent a single backslash.
+  # This is because these strings historically were written and read back via
+  # JSON and a single slash is interpreted as an escape char there.
+  # Technically this escaping is no longer needed and could be removed
+  # but in order to maintain compatibility we strip out the double
+  # slashes here.
+  data = data.replace('\\\\', '\\')
+  return data
+
+
+def get_asm_strings(module, globls, export_map, imported_globals):
+  if '__start_em_asm' not in export_map or '__stop_em_asm' not in export_map:
+    return {}
+
+  start = export_map['__start_em_asm']
+  end = export_map['__stop_em_asm']
+  start_global = globls[start.index - imported_globals]
+  end_global = globls[end.index - imported_globals]
+  start_addr = get_global_value(start_global)
+  end_addr = get_global_value(end_global)
+
+  seg = find_segment_with_address(module, start_addr, end_addr - start_addr)
+  if not seg:
+    exit_with_error('unable to find segment starting at __start_em_asm: %s' % start_addr)
+  seg, seg_offset = seg
+
+  asm_strings = {}
+  str_start = seg_offset
+  data = module.readAt(seg.offset, seg.size)
+  size = end_addr - start_addr
+  end = seg_offset + size
+  while str_start < end:
+    str_end = data.find(b'\0', str_start)
+    asm_strings[str(start_addr - seg_offset + str_start)] = data_to_string(data[str_start:str_end])
+    str_start = str_end + 1
+  return asm_strings
+
+
+def get_main_reads_params(module, export_map, imported_funcs):
+  if settings.STANDALONE_WASM:
+    return 1
+
+  main = export_map.get('main')
+  if not main or main.kind != webassembly.ExternType.FUNC:
+    return 0
+
+  functions = module.get_functions()
+  main_func = functions[main.index - imported_funcs]
+  if is_wrapper_function(module, main_func):
+    return 0
+  else:
+    return 1
+
+
+def get_names_globals(globls, exports, imported_globals):
+  named_globals = {}
+  for export in exports:
+    if export.kind == webassembly.ExternType.GLOBAL:
+      if export.name in ('__start_em_asm', '__stop_em_asm') or export.name.startswith('__em_js__'):
+        continue
+      g = globls[export.index - imported_globals]
+      named_globals[export.name] = str(get_global_value(g))
+  return named_globals
+
+
+def update_metadata(filename, metadata):
+  declares = []
+  invoke_funcs = []
+  em_js_funcs = set(metadata['emJsFuncs'])
+  module = webassembly.Module(filename)
+  for i in module.get_imports():
+    if i.kind == webassembly.ExternType.FUNC:
+      if i.field.startswith('invoke_'):
+        invoke_funcs.append(i.field)
+      elif i.field not in em_js_funcs:
+        declares.append(i.field)
+
+  exports = [e.name for e in module.get_exports() if e.kind == webassembly.ExternType.FUNC]
+  metadata['declares'] = declares
+  metadata['exports'] = exports
+  metadata['invokeFuncs'] = invoke_funcs
+
+
+def get_string_at(module, address):
+  seg, offset = find_segment_with_address(module, address)
+  data = module.readAt(seg.offset, seg.size)
+  str_end = data.find(b'\0', offset)
+  return data_to_string(data[offset:str_end])
+
+
+def extract_metadata(filename):
+  module = webassembly.Module(filename)
+  export_names = []
+  declares = []
+  invoke_funcs = []
+  imported_funcs = 0
+  imported_globals = 0
+  global_imports = []
+  em_js_funcs = {}
+  exports = module.get_exports()
+  imports = module.get_imports()
+  globls = module.get_globals()
+
+  for i in imports:
+    if i.kind == webassembly.ExternType.FUNC:
+      if i.field.startswith('invoke_'):
+        invoke_funcs.append(i.field)
+      elif i.field not in em_js_funcs:
+        declares.append(i.field)
+      imported_funcs += 1
+    elif i.kind == webassembly.ExternType.GLOBAL:
+      imported_globals += 1
+      global_imports.append(i.field)
+
+  export_map = {e.name: e for e in exports}
+  for e in exports:
+    if e.kind == webassembly.ExternType.GLOBAL and e.name.startswith('__em_js__'):
+      name = e.name[len('__em_js__'):]
+      globl = globls[e.index - imported_globals]
+      string_address = get_global_value(globl)
+      em_js_funcs[name] = get_string_at(module, string_address)
+
+  export_names = [e.name for e in exports if e.kind == webassembly.ExternType.FUNC]
+
+  features = module.parse_features_section()
+  features = ['--enable-' + f[1] for f in features if f[0] == '+']
+  features = [f.replace('--enable-atomics', '--enable-threads') for f in features]
+  features = [f.replace('--enable-simd128', '--enable-simd') for f in features]
+  features = [f.replace('--enable-nontrapping-fptoint', '--enable-nontrapping-float-to-int') for f in features]
+
+  # If main does not read its parameters, it will just be a stub that
+  # calls __original_main (which has no parameters).
+  metadata = {}
+  metadata['asmConsts'] = get_asm_strings(module, globls, export_map, imported_globals)
+  metadata['declares'] = declares
+  metadata['emJsFuncs'] = em_js_funcs
+  metadata['exports'] = export_names
+  metadata['features'] = features
+  metadata['globalImports'] = global_imports
+  metadata['invokeFuncs'] = invoke_funcs
+  metadata['mainReadsParams'] = get_main_reads_params(module, export_map, imported_funcs)
+  metadata['namedGlobals'] = get_names_globals(globls, exports, imported_globals)
+  # print("Metadata parsed: " + pprint.pformat(metadata))
+  return metadata

--- a/tools/webassembly.py
+++ b/tools/webassembly.py
@@ -30,6 +30,12 @@ HEADER_SIZE = 8
 
 LIMITS_HAS_MAX = 0x1
 
+SEG_PASSIVE = 0x1
+
+PREFIX_MATH = 0xfc
+PREFIX_THREADS = 0xfe
+PREFIX_SIMD = 0xfd
+
 
 def toLEB(num):
   return leb128.u.encode(num)
@@ -41,6 +47,33 @@ def readULEB(iobuf):
 
 def readSLEB(iobuf):
   return leb128.i.decode_reader(iobuf)[0]
+
+
+class Type(IntEnum):
+  I32 = 0x7f # -0x1
+  I64 = 0x7e # -0x2
+  F32 = 0x7d # -0x3
+  F64 = 0x7c # -0x4
+  V128 = 0x7b # -0x5
+  FUNCREF = 0x70 # -0x10
+  EXTERNREF = 0x6f # -0x11
+
+
+class OpCode(IntEnum):
+  NOP = 0x01
+  BLOCK = 0x02
+  CALL = 0x10
+  END = 0x0b
+  LOCAL_GET = 0x20
+  LOCAL_SET = 0x21
+  GLOBAL_GET = 0x23
+  GLOBAL_SET = 0x24
+  RETURN = 0x0f
+  I32_CONST = 0x41
+  I64_CONST = 0x42
+  F32_CONST = 0x43
+  F64_CONST = 0x44
+  REF_NULL = 0xd0
 
 
 class SecType(IntEnum):
@@ -75,11 +108,15 @@ class DylinkType(IntEnum):
   IMPORT_INFO = 4
 
 
-Section = namedtuple('Section', ['type', 'size', 'offset'])
+Section = namedtuple('Section', ['type', 'size', 'offset', 'name'])
 Limits = namedtuple('Limits', ['flags', 'initial', 'maximum'])
 Import = namedtuple('Import', ['kind', 'module', 'field'])
 Export = namedtuple('Export', ['name', 'kind', 'index'])
+Global = namedtuple('Global', ['type', 'mutable', 'init'])
 Dylink = namedtuple('Dylink', ['mem_size', 'mem_align', 'table_size', 'table_align', 'needed', 'export_info', 'import_info'])
+Table = namedtuple('Table', ['elem_type', 'limits'])
+FunctionBody = namedtuple('FunctionBody', ['offset', 'size'])
+DataSegment = namedtuple('DataSegment', ['flags', 'init', 'offset', 'size'])
 
 
 class Module:
@@ -96,6 +133,10 @@ class Module:
   def __del__(self):
     self.buf.close()
 
+  def readAt(self, offset, count):
+    self.buf.seek(offset)
+    return self.buf.read(count)
+
   def readByte(self):
     return self.buf.read(1)[0]
 
@@ -109,13 +150,34 @@ class Module:
     size = self.readULEB()
     return self.buf.read(size).decode('utf-8')
 
-  def readLimits(self):
+  def read_limits(self):
     flags = self.readByte()
     initial = self.readULEB()
     maximum = 0
     if flags & LIMITS_HAS_MAX:
       maximum = self.readULEB()
     return Limits(flags, initial, maximum)
+
+  def read_type(self):
+    return Type(self.readULEB())
+
+  def read_init(self):
+    code = []
+    while 1:
+      opcode = OpCode(self.readByte())
+      args = []
+      if opcode in (OpCode.GLOBAL_GET, OpCode.I32_CONST, OpCode.I64_CONST):
+        args.append(self.readULEB())
+      elif opcode in (OpCode.REF_NULL,):
+        args.append(self.read_type())
+      elif opcode in (OpCode.END,):
+        pass
+      else:
+        raise Exception('unexpected opcode %s' % opcode)
+      code.append((opcode, args))
+      if opcode == OpCode.END:
+        break
+    return code
 
   def seek(self, offset):
     return self.buf.seek(offset)
@@ -134,20 +196,37 @@ class Module:
       section_type = SecType(self.readByte())
       section_size = self.readULEB()
       section_offset = self.buf.tell()
-      yield Section(section_type, section_size, section_offset)
+      name = None
+      if section_type == SecType.CUSTOM:
+        name = self.readString()
+      yield Section(section_type, section_size, section_offset, name)
       offset = section_offset + section_size
+
+  def parse_features_section(self):
+    features = []
+    for sec in self.sections():
+      if sec.type == SecType.CUSTOM and sec.name == 'target_features':
+        self.seek(sec.offset)
+        self.readString()  # name
+        feature_count = self.readULEB()
+        while feature_count:
+          prefix = self.readByte()
+          features.append((chr(prefix), self.readString()))
+          feature_count -= 1
+        break
+    return features
 
   def parse_dylink_section(self):
     dylink_section = next(self.sections())
     assert dylink_section.type == SecType.CUSTOM
     self.seek(dylink_section.offset)
     # section name
-    section_name = self.readString()
     needed = []
     export_info = {}
     import_info = {}
+    self.readString()  # name
 
-    if section_name == 'dylink':
+    if dylink_section.name == 'dylink':
       mem_size = self.readULEB()
       mem_align = self.readULEB()
       table_size = self.readULEB()
@@ -158,7 +237,7 @@ class Module:
         libname = self.readString()
         needed.append(libname)
         needed_count -= 1
-    elif section_name == 'dylink.0':
+    elif dylink_section.name == 'dylink.0':
       section_end = dylink_section.offset + dylink_section.size
       while self.tell() < section_end:
         subsection_type = self.readULEB()
@@ -236,10 +315,10 @@ class Module:
         self.readSLEB()  # global type
         self.readByte()  # mutable
       elif kind == ExternType.MEMORY:
-        self.readLimits()  # limits
+        self.read_limits()  # limits
       elif kind == ExternType.TABLE:
         self.readSLEB()  # table type
-        self.readLimits()  # limits
+        self.read_limits()  # limits
       elif kind == ExternType.TAG:
         self.readByte()  # attribute
         self.readULEB()  # sig
@@ -247,6 +326,66 @@ class Module:
         assert False
 
     return imports
+
+  def get_globals(self):
+    global_section = next((s for s in self.sections() if s.type == SecType.GLOBAL), None)
+    if not global_section:
+      return []
+    globls = []
+    self.seek(global_section.offset)
+    num_globals = self.readULEB()
+    for i in range(num_globals):
+      global_type = self.read_type()
+      mutable = self.readByte()
+      init = self.read_init()
+      globls.append(Global(global_type, mutable, init))
+    return globls
+
+  def get_functions(self):
+    code_section = next((s for s in self.sections() if s.type == SecType.CODE), None)
+    if not code_section:
+      return []
+    functions = []
+    self.seek(code_section.offset)
+    num_functions = self.readULEB()
+    for i in range(num_functions):
+      body_size = self.readULEB()
+      start = self.tell()
+      functions.append(FunctionBody(start, body_size))
+      self.seek(start + body_size)
+    return functions
+
+  def get_segments(self):
+    segments = []
+    data_section = next((s for s in self.sections() if s.type == SecType.DATA), None)
+    self.seek(data_section.offset)
+    num_segments = self.readULEB()
+    for i in range(num_segments):
+      flags = self.readULEB()
+      if (flags & SEG_PASSIVE):
+        init = None
+      else:
+        init = self.read_init()
+      size = self.readULEB()
+      offset = self.tell()
+      segments.append(DataSegment(flags, init, offset, size))
+      self.seek(offset + size)
+    return segments
+
+  def get_tables(self):
+    table_section = next((s for s in self.sections() if s.type == SecType.TABLE), None)
+    if not table_section:
+      return []
+
+    self.seek(table_section.offset)
+    num_tables = self.readULEB()
+    tables = []
+    for i in range(num_tables):
+      elem_type = self.read_type()
+      limits = self.read_limits()
+      tables.append(Table(elem_type, limits))
+
+    return tables
 
 
 def parse_dylink_section(wasm_file):


### PR DESCRIPTION
This change is NFC because the default extraction method is still 'binaryen'

Fixes: #15250