### PR TITLE
[Docs] Fix sample code in Fetch.rst

### DIFF
--- a/site/source/docs/api_reference/fetch.rst
+++ b/site/source/docs/api_reference/fetch.rst
@@ -389,7 +389,7 @@ be dealt with separately.
     strcpy(attr.requestMethod, "GET");
     attr.attributes = EMSCRIPTEN_FETCH_LOAD_TO_MEMORY;
     // Make a Range request to only fetch bytes 10 to 20
-    const char* headers[] = {"Range", "bytes=10-20"};
+    const char* headers[] = {"Range", "bytes=10-20", NULL};
     attr.requestHeaders = headers;
     attr.onsuccess = downloadSucceeded;
     attr.onerror = downloadFailed;


### PR DESCRIPTION
Was playing with the fetch library today and ran into issues while using the code from the sample. The fetch library counts the request headers in this fashion here: 
https://github.com/emscripten-core/emscripten/blob/df9c7d76905169b50c2466cf9f70d9b1554cc3e4/system/lib/fetch/emscripten_fetch.cpp#L116
Thus, a terminating null pointer needs to be present in the array