### PR TITLE
emscripten.py: Remove redundant DEBUG param. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -28,7 +28,7 @@ from tools import utils
 from tools import gen_struct_info
 from tools import webassembly
 from tools.utils import exit_with_error, path_from_root
-from tools.shared import WINDOWS, asmjs_mangle
+from tools.shared import DEBUG, WINDOWS, asmjs_mangle
 from tools.shared import treat_as_user_function, strip_prefix
 from tools.settings import settings
 
@@ -63,7 +63,7 @@ def write_output_file(outfile, module):
     outfile.write(module[i])
 
 
-def optimize_syscalls(declares, DEBUG):
+def optimize_syscalls(declares):
   """Disables filesystem if only a limited subset of syscalls is used.
 
   Our syscalls are static, and so if we see a very limited set of them - in particular,
@@ -112,8 +112,8 @@ def to_nice_ident(ident): # limited version of the JS function toNiceIdent
   return ident.replace('%', '$').replace('@', '_').replace('.', '_')
 
 
-def update_settings_glue(metadata, DEBUG):
-  optimize_syscalls(metadata['declares'], DEBUG)
+def update_settings_glue(metadata):
+  optimize_syscalls(metadata['declares'])
 
   # Integrate info from backend
   if settings.SIDE_MODULE:
@@ -282,7 +282,7 @@ def create_named_globals(metadata):
   return '\n'.join(named_globals)
 
 
-def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
+def emscript(in_wasm, out_wasm, outfile_js, memfile):
   # Overview:
   #   * Run wasm-emscripten-finalize to extract metadata and modify the binary
   #     to use emscripten's wasm<->JS ABI
@@ -295,9 +295,9 @@ def emscript(in_wasm, out_wasm, outfile_js, memfile, DEBUG):
     # set file locations, so that JS glue can find what it needs
     settings.WASM_BINARY_FILE = js_manipulation.escape_for_js_string(os.path.basename(out_wasm))
 
-  metadata = finalize_wasm(in_wasm, out_wasm, memfile, DEBUG)
+  metadata = finalize_wasm(in_wasm, out_wasm, memfile)
 
-  update_settings_glue(metadata, DEBUG)
+  update_settings_glue(metadata)
 
   if settings.SIDE_MODULE:
     if metadata['asmConsts']:
@@ -390,7 +390,7 @@ def remove_trailing_zeros(memfile):
   utils.write_binary(memfile, mem_data[:end])
 
 
-def finalize_wasm(infile, outfile, memfile, DEBUG):
+def finalize_wasm(infile, outfile, memfile):
   building.save_intermediate(infile, 'base.wasm')
   # tell binaryen to look at the features section, and if there isn't one, to use MVP
   # (which matches what llvm+lld has given us)
@@ -464,7 +464,7 @@ def finalize_wasm(infile, outfile, memfile, DEBUG):
     # the dynamic linking case, our loader zeros it out)
     remove_trailing_zeros(memfile)
 
-  return load_metadata_wasm(stdout, DEBUG)
+  return load_metadata_wasm(stdout)
 
 
 def create_asm_consts(metadata):
@@ -762,7 +762,7 @@ def create_module(sending, receiving, invoke_funcs, metadata):
   return module
 
 
-def load_metadata_wasm(metadata_raw, DEBUG):
+def load_metadata_wasm(metadata_raw):
   try:
     metadata_json = json.loads(metadata_raw)
   except Exception:
@@ -853,4 +853,4 @@ def generate_struct_info():
 def run(in_wasm, out_wasm, outfile_js, memfile):
   generate_struct_info()
 
-  emscript(in_wasm, out_wasm, outfile_js, memfile, shared.DEBUG)
+  emscript(in_wasm, out_wasm, outfile_js, memfile)


### PR DESCRIPTION
I believe this is relic of the past when emscripten.py
wes run as an external process to emcc.py.