### PR TITLE
Fix quoting for readValueFromPointer and argPackAdvance

### DIFF
--- a/src/embind/emval.js
+++ b/src/embind/emval.js
@@ -148,11 +148,11 @@ var LibraryEmVal = {
     /*This function returns a new function that looks like this:
     function emval_allocator_3(constructor, argTypes, args) {
         var argType0 = requireRegisteredType(HEAP32[(argTypes >> 2)], "parameter 0");
-        var arg0 = argType0.readValueFromPointer(args);
+        var arg0 = argType0['readValueFromPointer'](args);
         var argType1 = requireRegisteredType(HEAP32[(argTypes >> 2) + 1], "parameter 1");
-        var arg1 = argType1.readValueFromPointer(args + 8);
+        var arg1 = argType1['readValueFromPointer'](args + 8);
         var argType2 = requireRegisteredType(HEAP32[(argTypes >> 2) + 2], "parameter 2");
-        var arg2 = argType2.readValueFromPointer(args + 16);
+        var arg2 = argType2['readValueFromPointer'](args + 16);
         var obj = new constructor(arg0, arg1, arg2);
         return Emval.toHandle(obj);
     } */
@@ -162,8 +162,8 @@ var LibraryEmVal = {
       argsList[0] = constructor;
       for (var i = 0; i < argCount; ++i) {
         var argType = requireRegisteredType(HEAP32[(argTypes >> 2) + i], 'parameter ' + i);
-        argsList[i + 1] = argType.readValueFromPointer(args);
-        args += argType.argPackAdvance;
+        argsList[i + 1] = argType['readValueFromPointer'](args);
+        args += argType['argPackAdvance'];
       }
       var obj = new (constructor.bind.apply(constructor, argsList));
       return Emval.toHandle(obj);
@@ -400,8 +400,8 @@ var LibraryEmVal = {
     var invokerFunction = (handle, name, destructors, args) => {
       var offset = 0;
       for (var i = 0; i < argCount - 1; ++i) {
-        argN[i] = types[i + 1].readValueFromPointer(args + offset);
-        offset += types[i + 1].argPackAdvance;
+        argN[i] = types[i + 1]['readValueFromPointer'](args + offset);
+        offset += types[i + 1]['argPackAdvance'];
       }
       var rv = handle[name].apply(handle, argN);
       for (var i = 0; i < argCount - 1; ++i) {

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -15,7 +15,7 @@ see
 http://kripken.github.io/emscripten-site/docs/getting_started/test-suite.html
 """
 
-# Use EMTEST_ALL_ENGINES=1 in the environment or pass --all-engined to test all engines!
+# Use EMTEST_ALL_ENGINES=1 in the environment or pass --all-engines to test all engines!
 
 import argparse
 import atexit

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2365,6 +2365,7 @@ int f() {
       int foo(int x) { return x; }
       void bar() {
         emscripten::val(123).call<std::string>("toString");
+        emscripten::val jarray = emscripten::val::global("Float32Array").new_(10);
         emscripten_console_log("ok");
       }
       EMSCRIPTEN_BINDINGS(baz) {


### PR DESCRIPTION
Both of these were incorrectly minified by closure when DYNAMIC_EXECUTION is 0.

The added test fails without the fix and passes with it.