### PR TITLE
Make sure warnings are disabled for -Wno-error= values

### DIFF
--- a/tools/diagnostics.py
+++ b/tools/diagnostics.py
@@ -195,6 +195,8 @@ class WarningManager:
           self.warnings[warning_name]['error'] = enabled
           if enabled:
             self.warnings[warning_name]['enabled'] = True
+          else:
+            self.warnings[warning_name]['enabled'] = False
           cmd_args[i] = ''
           continue
 


### PR DESCRIPTION
Originally, when trying to disable warnings for pthreads-mem-growth via -Wno-error=pthreads-mem-growth, it was discovered that the warnings were not skipped.

This change makes sure to set 'enabled' to false when the -Wno-error value is found.