### PR TITLE
Fix wasm2s (SAFE_HEAP) test suite

### DIFF
--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -6,7 +6,7 @@
 
 #include "runtime_safe_heap.js"
 
-#if ASSERTIONS
+#if ASSERTIONS || SAFE_HEAP
 /** @type {function(*, string=)} */
 function assert(condition, text) {
   if (!condition) throw text;

--- a/src/runtime_safe_heap.js
+++ b/src/runtime_safe_heap.js
@@ -110,7 +110,7 @@ function SAFE_HEAP_STORE(dest, value, bytes, isFloat) {
 #else
   if (dest % bytes !== 0) warnOnce('alignment error in a memory store operation, alignment was a multiple of ' + (((dest ^ (dest-1)) >> 1) + 1) + ', but was was expected to be aligned to a multiple of ' + bytes);
 #endif
-  if (runtimeInitialized) {
+  if (runtimeInitialized && !runtimeExited) {
     var brk = _sbrk() >>> 0;
     if (dest + bytes > brk) abort('segmentation fault, exceeded the top of the available dynamic heap when storing ' + bytes + ' bytes to address ' + dest + '. DYNAMICTOP=' + brk);
     assert(brk >= _emscripten_stack_get_base()); // sbrk-managed memory must be above the stack
@@ -134,7 +134,7 @@ function SAFE_HEAP_LOAD(dest, bytes, unsigned, isFloat) {
 #else
   if (dest % bytes !== 0) warnOnce('alignment error in a memory load operation, alignment was a multiple of ' + (((dest ^ (dest-1)) >> 1) + 1) + ', but was was expected to be aligned to a multiple of ' + bytes);
 #endif
-  if (runtimeInitialized) {
+  if (runtimeInitialized && !runtimeExited) {
     var brk = _sbrk() >>> 0;
     if (dest + bytes > brk) abort('segmentation fault, exceeded the top of the available dynamic heap when loading ' + bytes + ' bytes from address ' + dest + '. DYNAMICTOP=' + brk);
     assert(brk >= _emscripten_stack_get_base()); // sbrk-managed memory must be above the stack

--- a/src/shell.js
+++ b/src/shell.js
@@ -450,7 +450,9 @@ assert(typeof Module['TOTAL_MEMORY'] === 'undefined', 'Module.TOTAL_MEMORY has b
 {{{ makeRemovedFSAssert('IDBFS') }}}
 {{{ makeRemovedFSAssert('PROXYFS') }}}
 {{{ makeRemovedFSAssert('WORKERFS') }}}
+#if !NODERAWFS
 {{{ makeRemovedFSAssert('NODEFS') }}}
+#endif
 {{{ makeRemovedRuntimeFunction('alignMemory') }}}
 
 #if USE_PTHREADS

--- a/tests/core/test_functionpointer_libfunc_varargs.c
+++ b/tests/core/test_functionpointer_libfunc_varargs.c
@@ -11,8 +11,8 @@ typedef int (*fp_t)(int, int, ...);
 int main(int argc, char **argv) {
   fp_t fp = &fcntl;
   if (argc == 1337) fp = (fp_t) & main;
-  (*fp)(0, 10);
-  (*fp)(0, 10, 5);
+  (*fp)(0, F_GETFL);
+  (*fp)(0, F_SETSIG, 5);
   printf("waka\n");
   return 0;
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7881,13 +7881,11 @@ Module['onRuntimeInitialized'] = function() {
     # This test checks for the global variables required to run the memory
     # profiler.  It would fail if these variables were made no longer global
     # or if their identifiers were changed.
-    create_file('main.cpp', '''
-      extern "C" {
-        void check_memprof_requirements();
-      }
+    create_file('main.c', '''
+      int check_memprof_requirements();
+
       int main() {
-        check_memprof_requirements();
-        return 0;
+        return check_memprof_requirements();
       }
     ''')
     create_file('lib.js', '''
@@ -7898,14 +7896,16 @@ Module['onRuntimeInitialized'] = function() {
               typeof _emscripten_stack_get_current === 'function' &&
               typeof Module['___heap_base'] === 'number') {
              out('able to run memprof');
+             return 0;
            } else {
              out('missing the required variables to run memprof');
+             return 1;
            }
         }
       });
     ''')
     self.emcc_args += ['--memoryprofiler', '--js-library', 'lib.js']
-    self.do_runf('main.cpp', 'able to run memprof')
+    self.do_runf('main.c', 'able to run memprof')
 
   def test_fs_dict(self):
     self.set_setting('FORCE_FILESYSTEM')


### PR DESCRIPTION
This change fixes all but 1 failing tests in the wasm2s suite.  The final fix is in #15945.

My goal here is to enable this test suite on the emscripten-releases waterfall:
https://chromium-review.googlesource.com/c/emscripten-releases/+/3378856