### PR TITLE
Avoid using EM_ASM in sbrk.c

### DIFF
--- a/src/library_memoryprofiler.js
+++ b/src/library_memoryprofiler.js
@@ -1,0 +1,9 @@
+var memoryProfiler = {
+  emscripten_memprof_sbrk_grow: function(old_brk, new_brk) {
+#if MEMORYPROFILER
+    emscriptenMemoryProfiler.onSbrkGrow(old_brk, new_brk);
+#endif
+  },
+};
+
+mergeInto(LibraryManager.library, memoryProfiler);

--- a/src/modules.js
+++ b/src/modules.js
@@ -72,6 +72,10 @@ global.LibraryManager = {
       libraries.push('library_html5_webgl.js');
     }
 
+    if (EMSCRIPTEN_TRACING) {
+      libraries.push('library_memoryprofiler.js');
+    }
+
     if (FILESYSTEM) {
       // Core filesystem libraries (always linked against, unless -s FILESYSTEM=0 is specified)
       libraries = libraries.concat([

--- a/system/lib/sbrk.c
+++ b/system/lib/sbrk.c
@@ -18,7 +18,7 @@
 #endif
 
 #ifdef __EMSCRIPTEN_TRACING__
-#include <emscripten/em_asm.h>
+void emscripten_memprof_sbrk_grow(intptr_t old, intptr_t new);
 #endif
 
 #include <emscripten/heap.h>
@@ -96,7 +96,7 @@ void *sbrk(intptr_t increment_) {
 #endif // __EMSCRIPTEN_PTHREADS__
 
 #ifdef __EMSCRIPTEN_TRACING__
-    EM_ASM({if (typeof emscriptenMemoryProfiler !== 'undefined') emscriptenMemoryProfiler.onSbrkGrow($0, $1)}, old_brk, old_brk + increment );
+    emscripten_memprof_sbrk_grow(old_brk, new_brk);
 #endif
     return (void*)old_brk;
 


### PR DESCRIPTION
I ran into some issues with the use of EM_ASM here related to SAFE_HEAP.
Its probably not a great idea to use EM_ASM in such a low level context.