### PR TITLE
Simplify `emscripten_futex_wait` on them main thread

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -797,6 +797,8 @@ var LibraryPThread = {
     return 0;
   },
 
+  // Fallback function used by emscripten_futex_wait for when Atomics.wait is not
+  // available (i.e. in the main browser thread).
   // Returns 0 on success, or one of the values -ETIMEDOUT, -EWOULDBLOCK or -EINVAL on error.
   _emscripten_futex_wait_non_blocking__deps: ['emscripten_main_thread_process_queued_calls'],
   _emscripten_futex_wait_non_blocking: function(addr, val, timeout) {
@@ -805,50 +807,30 @@ var LibraryPThread = {
     assert(ENVIRONMENT_IS_WEB);
 #endif
 
-    // Atomics.wait is not available in the main browser thread, so simulate it via busy spinning.
     var tNow = performance.now();
     var tEnd = tNow + timeout;
+
+    if (Atomics.load(HEAP32, addr >> 2) != val) {
+      return -{{{ cDefine('EWOULDBLOCK') }}};
+    }
 
     // Register globally which address the main thread is simulating to be
     // waiting on. When zero, the main thread is not waiting on anything, and on
     // nonzero, the contents of the address pointed by __emscripten_main_thread_futex
     // tell which address the main thread is simulating its wait on.
-    // We need to be careful of recursion here: If we wait on a futex, and
-    // then call _emscripten_main_thread_process_queued_calls() below, that
-    // will call code that takes the proxying mutex - which can once more
-    // reach this code in a nested call. To avoid interference between the
-    // two (there is just a single __emscripten_main_thread_futex at a time), unmark
-    // ourselves before calling the potentially-recursive call. See below for
-    // how we handle the case of our futex being notified during the time in
-    // between when we are not set as the value of __emscripten_main_thread_futex.
-#if ASSERTIONS
-    assert(__emscripten_main_thread_futex > 0);
-#endif
     var lastAddr = Atomics.exchange(HEAP32, __emscripten_main_thread_futex >> 2, addr);
 #if ASSERTIONS
-    // We must not have already been waiting.
     assert(lastAddr == 0);
 #endif
 
-    while (1) {
+    while (lastAddr) {
       // Check for a timeout.
       tNow = performance.now();
       if (tNow > tEnd) {
-        // We timed out, so stop marking ourselves as waiting.
-        lastAddr = Atomics.exchange(HEAP32, __emscripten_main_thread_futex >> 2, 0);
-#if ASSERTIONS
-        // The current value must have been our address which we set, or
-        // in a race it was set to 0 which means another thread just allowed
-        // us to run, but (tragically) that happened just a bit too late.
-        assert(lastAddr == addr || lastAddr == 0);
-#endif
+        // We timed out
         return -{{{ cDefine('ETIMEDOUT') }}};
       }
-      // We are performing a blocking loop here, so we must handle proxied
-      // events from pthreads, to avoid deadlocks.
-      // Note that we have to do so carefully, as we may take a lock while
-      // doing so, which can recurse into this function; stop marking
-      // ourselves as waiting while we do so.
+
       lastAddr = Atomics.exchange(HEAP32, __emscripten_main_thread_futex >> 2, 0);
 #if ASSERTIONS
       assert(lastAddr == addr || lastAddr == 0);
@@ -857,51 +839,6 @@ var LibraryPThread = {
         // We were told to stop waiting, so stop.
         break;
       }
-      _emscripten_main_thread_process_queued_calls();
-
-      // Check the value, as if we were starting the futex all over again.
-      // This handles the following case:
-      //
-      //  * wait on futex A
-      //  * recurse into emscripten_main_thread_process_queued_calls(),
-      //    which waits on futex B. that sets the __emscripten_main_thread_futex address to
-      //    futex B, and there is no longer any mention of futex A.
-      //  * a worker is done with futex A. it checks __emscripten_main_thread_futex but does
-      //    not see A, so it does nothing special for the main thread.
-      //  * a worker is done with futex B. it flips mainThreadMutex from B
-      //    to 0, ending the wait on futex B.
-      //  * we return to the wait on futex A. __emscripten_main_thread_futex is 0, but that
-      //    is because of futex B being done - we can't tell from
-      //    __emscripten_main_thread_futex whether A is done or not. therefore, check the
-      //    memory value of the futex.
-      //
-      // That case motivates the design here. Given that, checking the memory
-      // address is also necessary for other reasons: we unset and re-set our
-      // address in __emscripten_main_thread_futex around calls to
-      // emscripten_main_thread_process_queued_calls(), and a worker could
-      // attempt to wake us up right before/after such times.
-      //
-      // Note that checking the memory value of the futex is valid to do: we
-      // could easily have been delayed (relative to the worker holding on
-      // to futex A), which means we could be starting all of our work at the
-      // later time when there is no need to block. The only "odd" thing is
-      // that we may have caused side effects in that "delay" time. But the
-      // only side effects we can have are to call
-      // emscripten_main_thread_process_queued_calls(). That is always ok to
-      // do on the main thread (it's why it is ok for us to call it in the
-      // middle of this function, and elsewhere). So if we check the value
-      // here and return, it's the same is if what happened on the main thread
-      // was the same as calling emscripten_main_thread_process_queued_calls()
-      // a few times times before calling emscripten_futex_wait().
-      if (Atomics.load(HEAP32, addr >> 2) != val) {
-        return -{{{ cDefine('EWOULDBLOCK') }}};
-      }
-
-      // Mark us as waiting once more, and continue the loop.
-      lastAddr = Atomics.exchange(HEAP32, __emscripten_main_thread_futex >> 2, addr);
-#if ASSERTIONS
-      assert(lastAddr == 0);
-#endif
     }
     return 0;
   },


### PR DESCRIPTION
The `_emscripten_futex_wait_non_blocking` contains a busy loop that and
was calling out to `emscripten_main_thread_process_queued_calls` on each
iteration.   However, all the caller of `emscripten_futex_wait` already
do their own busy loop calling
 `emscripten_main_thread_process_queued_calls`.  See:

- __wait.c: __wait
- __timed_wait.c: __timedwait_cp
- pthread_barrier_wait.c: pthread_barrier_wait
- pthread_join.c: __pthread_join_internal
- library_pthread.c: emscripten_thread_sleep

In all these cases `emscripten_futex_wait` is limited to a max sleep of
1ms when running on the main thread.

There is only one of other user and in this case emscripten_fetch_wait
is only used when not running on the main thread:

- emscripten_fetch.c: emscripten_fetch_wait