### PR TITLE
Temporarily disable test_pthread_lsan under firefox

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4170,6 +4170,7 @@ window.close = function() {
     'no_leak': ['test_pthread_lsan_no_leak'],
   })
   @requires_threads
+  @no_firefox('https://github.com/emscripten-core/emscripten/issues/15978')
   def test_pthread_lsan(self, name, args=[]):
     self.btest(test_file('pthread', name + '.cpp'), expected='1', args=['-fsanitize=leak', '-s', 'INITIAL_MEMORY=256MB', '-s', 'USE_PTHREADS', '-s', 'PROXY_TO_PTHREAD', '--pre-js', test_file('pthread', name + '.js')] + args)
 


### PR DESCRIPTION
I'm struggling to figure out what changed to make this start
failing but I'm guessing it was always racey and something
in the timing changed.

See: #15978