### PR TITLE
Add support for user JS library code to be able to depend on C functions

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -35,6 +35,7 @@ import time
 from enum import Enum, unique, auto
 from subprocess import PIPE
 from urllib.parse import quote
+from tools.deps_info import append_wasm_deps_info
 
 
 import emscripten
@@ -3749,6 +3750,11 @@ def process_libraries(state, linker_inputs):
   # Sort the input list from (order, lib_name) pairs to a flat array in the right order.
   settings.JS_LIBRARIES.sort(key=lambda lib: lib[0])
   settings.JS_LIBRARIES = [lib[1] for lib in settings.JS_LIBRARIES]
+
+  for f in settings.JS_LIBRARIES:
+    wasm_deps = shared.run_js_tool(shared.path_from_root('src/read_wasm_deps.js'), [shared.path_from_root('src', f)], stdout=PIPE)
+    append_wasm_deps_info(json.loads(wasm_deps))
+
   state.link_flags = new_flags
 
 

--- a/src/read_wasm_deps.js
+++ b/src/read_wasm_deps.js
@@ -1,0 +1,76 @@
+var fs = require('fs');
+
+function readFile(filename) {
+  return fs.readFileSync(filename).toString();
+}
+
+function include(filename) {
+  eval.call(null, readFile(`${__dirname}/${filename}`));
+}
+
+include('utility.js');
+include('settings.js');
+include('settings_internal.js');
+include('parseTools.js');
+
+// Read all input JS library files into LibraryManager.
+var LibraryManager = { library: {} };
+for(let f of process.argv.slice(2)) {
+  eval(processMacros(preprocess(readFile(f), f)));
+}
+
+// Grab all JS -> JS deps and JS -> C deps from the input files
+const DEPS_SUFFIX = '__deps';
+const WASM_DEPS_SUFFIX = '__wasm_deps';
+
+let jsToJsDeps = {};
+let jsToWasmDeps = {};
+
+for(let s in LibraryManager.library) {
+  if (s.endsWith(DEPS_SUFFIX)) jsToJsDeps[s.substr(0, s.length - DEPS_SUFFIX.length)] = LibraryManager.library[s];
+  else if (s.endsWith(WASM_DEPS_SUFFIX)) jsToWasmDeps[s.substr(0, s.length - WASM_DEPS_SUFFIX.length)] = LibraryManager.library[s];
+}
+
+// Key jsToJsDeps backwards: given a JS function as key, lists all functions that depend on this function.
+let jsToJsBackDeps = {};
+
+for(let depender in jsToJsDeps) {
+  for(let dependee of jsToJsDeps[depender]) {
+    if (!jsToJsBackDeps[dependee]) jsToJsBackDeps[dependee] = [];
+    if (!jsToJsBackDeps[dependee].includes(depender)) jsToJsBackDeps[dependee].push(depender);
+  }
+}
+
+// Appends those elements from array src to array dst that did not yet exist in dst.
+// Operates in-place, returns true if any modifications to array dst were done.
+function appendToArrayIfNotExists(dst, src) {
+  let modified = false;
+  for(let element of src) {
+    if (!dst.includes(element)) {
+      dst.push(element);
+      modified = true;
+    }
+  }
+  return modified;
+}
+
+// Transitively propagate all jsToWasm deps backwards, i.e. if jsFunc1 depends on jsFunc2,
+// and jsFunc2 depends on wasmFunc1, also record jsFunc1 to depend on wasmFunc1.
+// Perform the propagation to a new dictionary to not disturb iteration over jsToWasmDeps.
+let transitiveJsToWasmDeps = {};
+for(let dep in jsToWasmDeps) {
+  const wasmDeps = jsToWasmDeps[dep];
+  let stack = [dep];
+  while(stack.length > 0) {
+    let f = stack.pop();
+    if (!transitiveJsToWasmDeps[f]) transitiveJsToWasmDeps[f] = [];
+    if (appendToArrayIfNotExists(transitiveJsToWasmDeps[f], wasmDeps)) {
+      // Keep going if this append produced some modifications (this check makes sure we don't infinite loop on cycles)
+      if (jsToJsBackDeps[f]) stack = stack.concat(jsToJsBackDeps[f]);
+    }
+  }
+}
+jsToWasmDeps = transitiveJsToWasmDeps;
+
+// Print final output
+console.log(JSON.stringify(transitiveJsToWasmDeps));

--- a/src/settings.js
+++ b/src/settings.js
@@ -1947,7 +1947,7 @@ var SPLIT_MODULE = 0;
 //         llvm-nm on all input) and use the map in deps_info.py to determine
 //         the set of additional dependencies.
 // 'all' : Include the full set of possible reverse dependencies.
-// 'none': No reverse dependences will be added by emscriopten. Any reverse
+// 'none': No reverse dependences will be added by emscripten. Any reverse
 //         dependencies will be assumed to be explicitly added to
 //         EXPORTED_FUNCTIONS and deps_info.py will be completely ignored.
 // While 'auto' will produce a minimal set (so is good for code size), 'all'

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -199,6 +199,11 @@ _deps_info = {
 }
 
 
+def append_wasm_deps_info(wasm_deps_info):
+  for key, value in wasm_deps_info.items():
+    _deps_info[key] = value
+
+
 def get_deps_info():
   if not settings.EXCEPTION_HANDLING and settings.LINK_AS_CXX:
     _deps_info['__cxa_begin_catch'] = ['__cxa_is_pointer_type']


### PR DESCRIPTION
There is a long standing issue that user JS libraries cannot depend back on C functions without a) either modifying their Emscripten installation's src/deps_info.py file, or b) manually annotating EXPORTED_FUNCTIONS with all such C functions that the JS code will call back to.

Neither of these methods is tenable, since they both make it hard to share code between developers. (This limitation could be considered outright a bug)

This PR aims to add support for user JS library code to be able to depend on C functions, via a custom
`'foo__wasm_deps: ['wasmFunc1', 'wasmFunc2', ...]` directive.

This way JS functions can declare which C/Wasm functions they depend on, and they only need to know whether the depended function resides in Wasm or JS land, and either use `foo__deps: ['jsFunc']` or `foo__wasm_deps: ['wasmFunc']` to declare the dependency.

This is a barebones (but working) implementation, wanted to open this up for comments at this point.

The way this works is that JS libraries are parsed an additional time in the beginning to find the JS->wasm deps from them.

This will slow down builds, but slower is better than broken. However I appreciate that might create contention, so if there is pushback from someone not wanting/needing this machinery, I would be open to making this an optional cmdline flag that users have to pass to activate it (e.g. a `-sSCAN_WASM_DEPS=1` or pile on a new mode on the existing `-sREVERSE_DEPS` flag?)

I think in the long term it would be better to move to an architecture like this in the system JS libraries, and nuke all the registrations from deps_info.py altogether. That way we can get closer to "user JS libraries" being at the same power level as  "system JS libraries" are.

Thoughts? @kripken ?