### PR TITLE
[wasmfs] Use JS library methods instead of EM_ASM in WASMFS

### DIFF
--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -163,7 +163,7 @@ var WasmfsLibrary = {
     wasmFS$JSMemoryFreeList.push(index);
   },
   _emscripten_get_preloaded_file_size: function(index) {
-    return wasmFS$preloadedFiles[index].fileData.length
+    return wasmFS$preloadedFiles[index].fileData.length;
   },
   _emscripten_copy_preloaded_file_data: function(index, buffer) {
     HEAPU8.set(wasmFS$preloadedFiles[index].fileData, buffer);

--- a/src/library_wasmfs.js
+++ b/src/library_wasmfs.js
@@ -161,7 +161,13 @@ var WasmfsLibrary = {
     wasmFS$JSMemoryFiles[index] = null;
     // Add the index to the free list.
     wasmFS$JSMemoryFreeList.push(index);
-  }
+  },
+  _emscripten_get_preloaded_file_size: function(index) {
+    return wasmFS$preloadedFiles[index].fileData.length
+  },
+  _emscripten_copy_preloaded_file_data: function(index, buffer) {
+    HEAPU8.set(wasmFS$preloadedFiles[index].fileData, buffer);
+  },
 }
 
 mergeInto(LibraryManager.library, WasmfsLibrary);

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -10,6 +10,11 @@
 #include "wasmfs.h"
 #include <emscripten/threading.h>
 
+extern "C" size_t _emscripten_get_preloaded_file_size(uint32_t index);
+
+extern "C" size_t _emscripten_copy_preloaded_file_data(uint32_t index,
+                                                       uint8_t* data);
+
 namespace wasmfs {
 //
 // DataFile
@@ -17,15 +22,13 @@ namespace wasmfs {
 void DataFile::Handle::preloadFromJS(int index) {
   // TODO: Each Datafile type could have its own impl of file preloading.
   // Create a buffer with the required file size.
-  std::vector<uint8_t> buffer(
-    EM_ASM_INT({return wasmFS$preloadedFiles[$0].fileData.length}, index));
+  std::vector<uint8_t> buffer(_emscripten_get_preloaded_file_size(index));
+
   // Ensure that files are preloaded from the main thread.
   assert(emscripten_is_main_runtime_thread());
-  // TODO: Replace every EM_ASM with EM_JS.
+
   // Load data into the in-memory buffer.
-  EM_ASM({ HEAPU8.set(wasmFS$preloadedFiles[$1].fileData, $0); },
-         buffer.data(),
-         index);
+  _emscripten_copy_preloaded_file_data(index, buffer.data());
 
   write((const uint8_t*)buffer.data(), buffer.size(), 0);
 }

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -10,10 +10,12 @@
 #include "wasmfs.h"
 #include <emscripten/threading.h>
 
-extern "C" size_t _emscripten_get_preloaded_file_size(uint32_t index);
+extern "C" {
+  size_t _emscripten_get_preloaded_file_size(uint32_t index);
 
-extern "C" size_t _emscripten_copy_preloaded_file_data(uint32_t index,
-                                                       uint8_t* data);
+  size_t _emscripten_copy_preloaded_file_data(uint32_t index,
+                                              uint8_t* data);
+}
 
 namespace wasmfs {
 //


### PR DESCRIPTION
This implements a TODO. The new way is more efficient and also easier to
debug when things go wrong (proper names for functions).