### PR TITLE
[wasmfs] Make standalone's open syscall weak, to not conflict with WASMFS

### DIFF
--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -70,6 +70,9 @@ long __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long o
 // corner case error checking; everything else is not permitted.
 // TODO: full file support for WASI, or an option for it
 // open()
+// Mark this as weak so that wasmfs does not collide with it. That is, if wasmfs
+// is in use, we want to use that and not this.
+__attribute__((__weak__))
 long __syscall_open(const char* path, long flags, ...) {
   if (!strcmp(path, "/dev/stdin")) return STDIN_FILENO;
   if (!strcmp(path, "/dev/stdout")) return STDOUT_FILENO;


### PR DESCRIPTION
Both libwasmfs and libstandalonewasm implement the open syscall, as well as
others (only the first is in this PR). I think we should make them weak in
standalone wasm, that is, if wasmfs is present we always want to run that code.
The wasmfs syscall will then call lower-level things which we will need to implement
in standalone wasm (like we do in JS).