### PR TITLE
Fix test_asan_use_after_return

### DIFF
--- a/tests/core/test_asan_use_after_return.c
+++ b/tests/core/test_asan_use_after_return.c
@@ -2,7 +2,7 @@ const char *__asan_default_options() {
   return "detect_stack_use_after_return=1";
 }
 
-__attribute__((noinline)) int *f() {
+__attribute__((noinline)) volatile int* f() {
   int val;
   return &val;
 }


### PR DESCRIPTION
An improvement to DSE in clang caused the compiler to optimize out the UB in
this test case, so there was no bug for ASan to find at runtime. Add `volatile`
to force the UB to take place.