### PR TITLE
Exclude ldexp* math functions from LTO

### DIFF
--- a/tests/core/test_float_builtins.c
+++ b/tests/core/test_float_builtins.c
@@ -52,9 +52,11 @@ void test_long_double(long double x) {
   printf("ceil(x) = %Lf\n", ceill(x));
   printf("floor(x) = %Lf\n", floorl(x));
   printf("atan(x) = %Lf\n", atanl(x));
-  printf("atan2(x,1) = %Lf\n", atan2l(x,1));
+  printf("atan2(x,1) = %Lf\n", atan2l(x, 1));
   printf("asin(x) = %Lf\n", asinl(x));
   printf("acos(x) = %Lf\n", acosl(x));
+  printf("expl(x) = %Lf\n", expl(x));
+  printf("ldexpl(x) = %Lf\n", ldexpl(x, 7));
 }
 
 int main() {

--- a/tests/core/test_float_builtins.out
+++ b/tests/core/test_float_builtins.out
@@ -12,4 +12,6 @@ atan(x) = 1.508378
 atan2(x,1) = 1.508378
 asin(x) = nan
 acos(x) = nan
+expl(x) = 8886110.520508
+ldexpl(x) = 2048.000000
 ***end***

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -121,6 +121,7 @@ def get_libc_rt_files(is_optz=False, superset=False):
     'exp2.c',
     'exp2f.c', 'exp2f_data.c',
     'exp10.c', 'exp10f.c',
+    'ldexp.c', 'ldexpf.c', 'ldexpl.c',
     'scalbn.c', '__fpclassifyl.c',
     '__signbitl.c', '__signbitf.c', '__signbit.c',
     '__math_divzero.c', '__math_divzerof.c',


### PR DESCRIPTION
Apparently, like the math functions here these can be generated by the compiler
and therefore cannot themselves be part of LTO.

See #15506