### PR TITLE
Enable LLD_REPORT_UNDEFINED by default

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,11 @@ See docs/process.md for more on how version tagging works.
 
 3.1.28 (in development)
 -----------------------
+- `LLD_REPORT_UNDEFINED` is now enabled by default.  This makes undefined symbol
+  errors more precise by including the name of the object that references the
+  undefined symbol. The old behaviour (of allowing all undefined symbols at
+  wasm-ld time and reporting them later when processing JS library files) is
+  still available using `-sLLD_REPORT_UNDEFINED=0`. (#16003)
 - musl libc updated from v1.2.2 to v1.2.3. (#18270)
 - The default emscripten config file no longer contains `EMSCRIPTEN_ROOT`.  This
   setting has long been completely ignored by emscripten itself. For

--- a/emcc.py
+++ b/emcc.py
@@ -553,9 +553,8 @@ def get_all_js_syms():
     library_syms = read_file(filename).splitlines()
 
     # Limit of the overall size of the cache to 100 files.
-    # This code will get test coverage once we make LLD_REPORT_UNDEFINED the default
-    # since under those circumstances a full test run of `other` or `core` generates
-    # ~1000 unique symbol lists.
+    # This code will get test coverage since a full test run of `other` or `core`
+    # generates ~1000 unique symbol lists.
     cache_limit = 100
     root = cache.get_path('symbol_lists')
     if len(os.listdir(root)) > cache_limit:
@@ -1898,10 +1897,7 @@ def phase_linker_setup(options, state, newargs):
     if not settings.PURE_WASI and '-nostdlib' not in newargs and '-nodefaultlibs' not in newargs:
       default_setting('STACK_OVERFLOW_CHECK', max(settings.ASSERTIONS, settings.STACK_OVERFLOW_CHECK))
 
-  if settings.LLD_REPORT_UNDEFINED or settings.STANDALONE_WASM:
-    # Reporting undefined symbols at wasm-ld time requires us to know if we have a `main` function
-    # or not, as does standalone wasm mode.
-    # TODO(sbc): Remove this once this becomes the default
+  if settings.STANDALONE_WASM:
     settings.IGNORE_MISSING_MAIN = 0
 
   # For users that opt out of WARN_ON_UNDEFINED_SYMBOLS we assume they also

--- a/src/settings.js
+++ b/src/settings.js
@@ -1917,12 +1917,13 @@ var USE_OFFSET_CONVERTER = false;
 // This is enabled automatically when using -g4 with sanitizers.
 var LOAD_SOURCE_MAP = false;
 
-// If set to 1, the JS compiler is run before wasm-ld so that the linker can
-// report undefined symbols within the binary.  Without this option the linker
-// doesn't know which symbols might be defined in JS so reporting of undefined
-// symbols is delayed until the JS compiler is run.
+// If set to 0, delay undefined symbol report until after wasm-ld runs.  This
+// avoids running the the JS compiler prior to wasm-ld, but reduces the amount
+// of information in the undefined symbol message (Since JS compiler cannot
+// report the name of the object file that contains the reference to the
+// undefined symbol).
 // [link]
-var LLD_REPORT_UNDEFINED = false;
+var LLD_REPORT_UNDEFINED = true;
 
 // Default to c++ mode even when run as `emcc` rather then `emc++`.
 // When this is disabled `em++` is required when compiling and linking C++

--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -269,7 +269,6 @@ def inspect_headers(headers, cflags):
                                '-nostdlib',
                                compiler_rt,
                                '-sBOOTSTRAPPING_STRUCT_INFO',
-                               '-sLLD_REPORT_UNDEFINED',
                                '-sSTRICT',
                                '-sASSERTIONS=0',
                                # Use SINGLE_FILE so there is only a single


### PR DESCRIPTION
This makes undefined symbol errors more precise by including the name of the
object that references the undefined symbol.

Its also paves the way (in my mind anyway) for finally fixing reverse dependencies
in a salable way.  See #15982.  That PR uses an alternative script for the pre-processing
of dependencies but also fundamentally relies on processing JS libraries both before
and after linking.

The cost is about 300ms per link operation due to double processing of
the JS libraries, but results are cached so in practice this only
happens the first time a given link command is run (see #18326).
