### PR TITLE
Improve command line output for `toolchain_profiler.py`

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -3916,6 +3916,7 @@ def is_int(s):
     return False
 
 
+@ToolchainProfiler.profile_block('main')
 def main(args):
   start_time = time.time()
   ret = run(args)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7935,6 +7935,12 @@ end
     self.run_process([emprofile, '--graph'])
     self.assertTrue(glob.glob('toolchain_profiler.results*.html'))
 
+  @with_env_modify({'EMPROFILE': '2'})
+  def test_toolchain_profiler_stderr(self):
+    stderr = self.run_process([EMCC, test_file('hello_world.c')], stderr=PIPE).stderr
+    self.assertContained('start block "main"', stderr)
+    self.assertContained('block "main" took', stderr)
+
   def test_noderawfs(self):
     fopen_write = read_file(test_file('asmfs/fopen_write.cpp'))
     create_file('main.cpp', fopen_write)


### PR DESCRIPTION
This change adds a `EMPROFILE=2` mode that just output times
for the various blocks to stdout, while keeping track of nesting.

Example output:

```
$ EMPROFILE=2 ./emcc ~/test//hello.c -O2
profiler:INFO: start block "main"
profiler:INFO:   start block "sanity"
profiler:INFO:   block "sanity" took 0.05 seconds
profiler:INFO:   start block "parse arguments"
profiler:INFO:   block "parse arguments" took 0.00 seconds
profiler:INFO:   start block "setup"
profiler:INFO:   block "setup" took 0.00 seconds
profiler:INFO:   start block "compile inputs"
profiler:INFO:     start block "ensure_sysroot"
profiler:INFO:     block "ensure_sysroot" took 0.00 seconds
profiler:INFO:   block "compile inputs" took 0.06 seconds
profiler:INFO:   start block "linker_setup"
profiler:INFO:   block "linker_setup" took 0.00 seconds
profiler:INFO:   start block "calculate linker inputs"
profiler:INFO:   block "calculate linker inputs" took 0.00 seconds
profiler:INFO:   start block "calculate system libraries"
profiler:INFO:     start block "llvm_nm_multiple"
profiler:INFO:     block "llvm_nm_multiple" took 0.01 seconds
profiler:INFO:   block "calculate system libraries" took 0.02 seconds
profiler:INFO:   start block "link"
profiler:INFO:   block "link" took 0.03 seconds
profiler:INFO:   start block "post_link"
profiler:INFO:     start block "emscript"
profiler:INFO:     block "emscript" took 0.28 seconds
profiler:INFO:     start block "source transforms"
profiler:INFO:     block "source transforms" took 0.00 seconds
profiler:INFO:     start block "binaryen"
profiler:INFO:     block "binaryen" took 0.26 seconds
profiler:INFO:     start block "final emitting"
profiler:INFO:     block "final emitting" took 0.00 seconds
profiler:INFO:   block "post_link" took 0.54 seconds
profiler:INFO: block "main" took 0.71 seconds
```