### PR TITLE
Explicitly reference filenames in test code. NFC

### DIFF
--- a/tests/hello_world_loop.c
+++ b/tests/hello_world_loop.c
@@ -7,15 +7,13 @@
 #include <string.h>
 #include <stdlib.h>
 
-extern "C" {
-  void dump(char *s) {
-    printf("%s\n", s);
-  }
+void dump(char *s) {
+  printf("%s\n", s);
 }
 
 int main() {
   char *original = (char*)"h e l l o ,   w o r l d ! ";
-  char *copy = (char*)malloc(strlen(original));
+  char copy[strlen(original)];
   for (int i = 0; i < strlen(original); i += 2) {
     copy[i/2] = original[i];
   }

--- a/tests/hello_world_loop_malloc.c
+++ b/tests/hello_world_loop_malloc.c
@@ -7,15 +7,13 @@
 #include <string.h>
 #include <stdlib.h>
 
-extern "C" {
-  void dump(char *s) {
-    printf("%s\n", s);
-  }
+void dump(char *s) {
+  printf("%s\n", s);
 }
 
 int main() {
   char *original = (char*)"h e l l o ,   w o r l d ! ";
-  char copy[strlen(original)];
+  char *copy = (char*)malloc(strlen(original));
   for (int i = 0; i < strlen(original); i += 2) {
     copy[i/2] = original[i];
   }

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -394,7 +394,11 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
       print(params, opt_level, link_params, closure, has_malloc)
       self.clear()
       keep_debug = '-g' in params
-      args = [compiler, test_file('hello_world_loop' + ('_malloc' if has_malloc else '') + '.cpp')] + params
+      if has_malloc:
+        filename = test_file('hello_world_loop_malloc.c')
+      else:
+        filename = test_file('hello_world_loop.c')
+      args = [compiler, filename] + params
       print('..', args)
       output = self.run_process(args, stdout=PIPE, stderr=PIPE)
       assert len(output.stdout) == 0, output.stdout


### PR DESCRIPTION
I think this makes code clearer and also means that my
naive `./tools/maint/check_for_unused_test_files.py` can
track the usage of these files.

Also rename them from `.cpp` to `.c` to keep things even
simpler.