### PR TITLE
Reinstate test_bad_lookup

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -4543,6 +4543,9 @@ int main() {
     ''')
     self.run_process([EMXX, 'src.cpp', '-O2', '-s', 'SAFE_HEAP'])
 
+  def test_bad_lookup(self):
+    self.do_runf(path_from_root('tests/filesystem/bad_lookup.cpp'), expected_output='ok')
+
   @parameterized({
     'none': [{'EMCC_FORCE_STDLIBS': None}, False],
     # forced libs is ok, they were there anyhow


### PR DESCRIPTION
It seems that this test was mistakenly removed as part of
a bad merge in 2014: 3ed23f192a3f86dce310d1c78ce0c11626814cb5.