### PR TITLE
[WasmFS] Flush streams on exit to fix EXIT_RUNTIME behavior

### DIFF
--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -139,6 +139,9 @@ class DataFile : public File {
   virtual __wasi_errno_t
   write(const uint8_t* buf, size_t len, off_t offset) = 0;
 
+  // TODO: Design a proper API for flushing files.
+  virtual void flush() = 0;
+
 public:
   static constexpr FileKind expectedKind = File::DataFileKind;
   DataFile(mode_t mode, backend_t backend)
@@ -160,6 +163,11 @@ public:
     }
     __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) {
       return getFile()->write(buf, len, offset);
+    }
+
+    // TODO: Design a proper API for flushing files.
+    void flush() {
+      getFile()->flush();
     }
 
     // This function loads preloaded files from JS Memory into this DataFile.

--- a/system/lib/wasmfs/js_file_backend.cpp
+++ b/system/lib/wasmfs/js_file_backend.cpp
@@ -46,6 +46,8 @@ class JSFile : public DataFile {
     return _wasmfs_read_js_file(index, buf, len, offset);
   }
 
+  void flush() override {}
+
   // The size of the JSFile is defined as the length of the backing JS array.
   size_t getSize() override { return _wasmfs_get_js_file_size(index); }
 

--- a/system/lib/wasmfs/memory_file.h
+++ b/system/lib/wasmfs/memory_file.h
@@ -21,6 +21,8 @@ class MemoryFile : public DataFile {
 
   __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override;
 
+  void flush() override {}
+
   size_t getSize() override { return buffer.size(); }
 
 public:

--- a/system/lib/wasmfs/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/proxied_file_backend.cpp
@@ -39,6 +39,8 @@ class ProxiedFile : public DataFile {
     return result;
   }
 
+  void flush() override {}
+
   // Querying the size of the Proxied File returns the size of the underlying
   // file given by the proxying mechanism.
   size_t getSize() override {

--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -45,18 +45,22 @@ __wasi_errno_t StdoutFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
   static const std::shared_ptr<StdoutFile> stdoutFile =
-    std::make_shared<StdoutFile>(S_IWUGO);
+    std::make_shared<StdoutFile>();
   return stdoutFile;
 }
 
 __wasi_errno_t StderrFile::write(const uint8_t* buf, size_t len, off_t offset) {
   // Similar issue with Node and worker threads as emscripten_out.
+  // TODO: May not want to proxy stderr (fd == 2) to the main thread, as
+  //       emscripten_err does.
+  //       This will not show in HTML - a console.warn in a worker is
+  //       sufficient. This would be a change from the current FS.
   return writeStdBuffer(buf, len, &_emscripten_err, writeBuffer);
 }
 
 std::shared_ptr<StderrFile> StderrFile::getSingleton() {
   static const std::shared_ptr<StderrFile> stderrFile =
-    std::make_shared<StderrFile>(S_IWUGO);
+    std::make_shared<StderrFile>();
   return stderrFile;
 }
 

--- a/system/lib/wasmfs/streams.h
+++ b/system/lib/wasmfs/streams.h
@@ -56,14 +56,7 @@ public:
 
   static std::shared_ptr<StdoutFile> getSingleton();
 
-  void flush() {
-    // Flush the musl libc buffers.
-    fflush(stdout);
-
-    // Write a null to flush the output.
-    const uint8_t nothing = 0;
-    write(&nothing, 1, 0);
-  }
+  void flush();
 };
 
 class StderrFile : public WritingStdFile {
@@ -74,14 +67,7 @@ public:
 
   static std::shared_ptr<StderrFile> getSingleton();
 
-  void flush() {
-    // Flush the musl libc buffers.
-    fflush(stderr);
-
-    // Write a null to flush the output.
-    const uint8_t nothing = 0;
-    write(&nothing, 1, 0);
-  }
+  void flush();
 };
 
 } // namespace wasmfs

--- a/system/lib/wasmfs/streams.h
+++ b/system/lib/wasmfs/streams.h
@@ -25,6 +25,8 @@ class StdinFile : public DataFile {
     return __WASI_ERRNO_INVAL;
   };
 
+  void flush() override {}
+
   size_t getSize() override { return 0; }
 
 public:
@@ -50,24 +52,22 @@ public:
 
 class StdoutFile : public WritingStdFile {
   __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override;
+  void flush() override;
 
 public:
   StdoutFile() {}
 
   static std::shared_ptr<StdoutFile> getSingleton();
-
-  void flush();
 };
 
 class StderrFile : public WritingStdFile {
   __wasi_errno_t write(const uint8_t* buf, size_t len, off_t offset) override;
+  void flush() override;
 
 public:
   StderrFile() {}
 
   static std::shared_ptr<StderrFile> getSingleton();
-
-  void flush();
 };
 
 } // namespace wasmfs

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -46,8 +46,8 @@ WasmFS::~WasmFS() {
   // Note that we lock here, although strictly speaking it is unnecessary given
   // that we are in the destructor of WasmFS: nothing can possibly be running
   // on files at this time.
-  DataFile::Handle(StdoutFile::getSingleton()).flush();
-  DataFile::Handle(StderrFile::getSingleton()).flush();
+  StdoutFile::getSingleton()->locked().flush();
+  StderrFile::getSingleton()->locked().flush();
 }
 
 std::shared_ptr<Directory> WasmFS::initRootDirectory() {

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -36,6 +36,7 @@ void _wasmfs_get_preloaded_path_name(int index, char* fileName);
 void _wasmfs_get_preloaded_child_path(int index, char* childName);
 }
 
+// TODO: destructor priority? We want this to happen last.
 WasmFS::~WasmFS() {
   // Flush musl libc streams.
   // TODO: Integrate musl exit() which would call this for us.

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -37,6 +37,11 @@ void _wasmfs_get_preloaded_child_path(int index, char* childName);
 }
 
 WasmFS::~WasmFS() {
+  // Flush musl libc streams.
+  // TODO: Integrate musl exit() which would call this for us.
+  fflush(0);
+
+  // Flush our own streams. TODO: flush all possible streams.
   StdoutFile::getSingleton()->flush();
   StderrFile::getSingleton()->flush();
 }

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -36,6 +36,11 @@ void _wasmfs_get_preloaded_path_name(int index, char* fileName);
 void _wasmfs_get_preloaded_child_path(int index, char* childName);
 }
 
+WasmFS::~WasmFS() {
+  StdoutFile::getSingleton()->flush();
+  StderrFile::getSingleton()->flush();
+}
+
 std::shared_ptr<Directory> WasmFS::initRootDirectory() {
   auto rootBackend = createMemoryFileBackend();
   auto rootDirectory =

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -36,15 +36,18 @@ void _wasmfs_get_preloaded_path_name(int index, char* fileName);
 void _wasmfs_get_preloaded_child_path(int index, char* childName);
 }
 
-// TODO: destructor priority? We want this to happen last.
 WasmFS::~WasmFS() {
   // Flush musl libc streams.
-  // TODO: Integrate musl exit() which would call this for us.
+  // TODO: Integrate musl exit() which would call this for us. That might also
+  //       help with destructor priority - we need to happen last.
   fflush(0);
 
   // Flush our own streams. TODO: flush all possible streams.
-  StdoutFile::getSingleton()->flush();
-  StderrFile::getSingleton()->flush();
+  // Note that we lock here, although strictly speaking it is unnecessary given
+  // that we are in the destructor of WasmFS: nothing can possibly be running
+  // on files at this time.
+  DataFile::Handle(StdoutFile::getSingleton()).flush();
+  DataFile::Handle(StderrFile::getSingleton()).flush();
 }
 
 std::shared_ptr<Directory> WasmFS::initRootDirectory() {

--- a/system/lib/wasmfs/wasmfs.h
+++ b/system/lib/wasmfs/wasmfs.h
@@ -44,6 +44,8 @@ public:
     preloadFiles();
   }
 
+  ~WasmFS();
+
   // This get method returns a locked file table.
   // There is only ever one FileTable in the system.
   FileTable::Handle getLockedFileTable() {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5319,6 +5319,7 @@ main( int argv, char ** argc ) {
     self.do_core_test('test_write_stdout_fileno.c')
     self.do_core_test('test_write_stdout_fileno.c', args=['-s', 'FILESYSTEM=0'])
 
+  @also_with_wasmfs # tests EXIT_RUNTIME flushing
   def test_direct_string_constant_usage(self):
     # needs to flush stdio streams
     self.set_setting('EXIT_RUNTIME')


### PR DESCRIPTION
Without this, `printf("hello world")` without a newline at the end will print
nothing. In `EXIT_RUNTIME` mode the streams should be flushed.

The old FS calls fflush from JS. This adds a destructor to WasmFS which
flushes the standard streams. (This does *not* yet support the JS ability to
warn on unflushed output without `EXIT_RUNTIME` mode; we may want
to find a way to support that later.)

Also remove some trivial and unnecessary duplicated code by adding a
new `WritingStdFile` class, which I noticed while editing that file, and other
tiny cleanups there.