### PR TITLE
Fix incorrect ID mapping for GLFW_KEY_GRAVE_ACCENT

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -192,7 +192,7 @@ var LibraryGLFW = {
         case 0xDB:return 91; // DOM_VK_OPEN_BRACKET -> GLFW_KEY_LEFT_BRACKET
         case 0xDC:return 92; // DOM_VK_BACKSLASH -> GLFW_KEY_BACKSLASH
         case 0xDD:return 93; // DOM_VK_CLOSE_BRACKET -> GLFW_KEY_RIGHT_BRACKET
-        case 0xC0:return 94; // DOM_VK_BACK_QUOTE -> GLFW_KEY_GRAVE_ACCENT
+        case 0xC0:return 96; // DOM_VK_BACK_QUOTE -> GLFW_KEY_GRAVE_ACCENT
 
 #if USE_GLFW == 2
         //#define GLFW_KEY_SPECIAL      256


### PR DESCRIPTION
Incorrect identifier 94 instead of 96 is used for GLFW_KEY_GRAVE_ACCENT that is being mapped to DOM_VK_BACK_QUOTE.

[GLFW3](https://github.com/glfw/glfw/blob/8edbc4971d6c994d84f12f349afdeef41fae527f/include/GLFW/glfw3.h#L442) defines the following:
```
#define GLFW_KEY_GRAVE_ACCENT 96 /* ` */
```

This would also be an issue with [GLFW2](https://github.com/glfw/glfw-legacy/blob/0c9e8763f4ea3e2d5dd37f4f079a0a28b1f91aa4/include/GL/glfw.h#L201) which follows [ISO-8859-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1) that maps this character to 96 as well.
