### PR TITLE
Rebaseline a couple of wasm2js code size expectations. NFC

### DIFF
--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 594,
   "a.html.gz": 389,
-  "a.js": 20034,
-  "a.js.gz": 8200,
+  "a.js": 20090,
+  "a.js.gz": 8209,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 23799,
-  "total_gz": 11303
+  "total": 23855,
+  "total_gz": 11312
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 594,
   "a.html.gz": 389,
-  "a.js": 19519,
-  "a.js.gz": 8037,
+  "a.js": 19575,
+  "a.js.gz": 8046,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 23284,
-  "total_gz": 11140
+  "total": 23340,
+  "total_gz": 11149
 }


### PR DESCRIPTION
I bisecting this minor code size regression (which seems
to only effect wasm2js) to https://reviews.llvm.org/D105169.