### PR TITLE
file_package.js: Set `canOwn` when loading embedded files

### DIFF
--- a/tools/file_packager.py
+++ b/tools/file_packager.py
@@ -470,7 +470,8 @@ def main():
       # Embed
       data = base64_encode(utils.read_binary(file_['srcpath']))
       code += "      var fileData%d = '%s';\n" % (counter, data)
-      code += ("      Module['FS_createDataFile']('%s', '%s', decodeBase64(fileData%d), true, true, false);\n"
+      # canOwn this data in the filesystem (i.e. there is no need to create a copy in the FS layer).
+      code += ("      Module['FS_createDataFile']('%s', '%s', decodeBase64(fileData%d), true, true, true);\n"
                % (dirname, basename, counter))
     elif file_['mode'] == 'preload':
       # Preload


### PR DESCRIPTION
There is no need to force an extra copy here unnecessarily. I have
not idea why this wasn't always set to true.  Seem like an oversight.