### PR TITLE
[WasmFS] Fix return value of cwd syscall

### DIFF
--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -632,8 +632,9 @@ long __syscall_getcwd(long buf, long size) {
   // Return value is a null-terminated c string.
   strcpy((char*)buf, res);
 
-  return 0;
+  return buf;
 }
+
 __wasi_errno_t __wasi_fd_fdstat_get(__wasi_fd_t fd, __wasi_fdstat_t* stat) {
   // TODO: This is only partial implementation of __wasi_fd_fdstat_get. Enough
   // to get __wasi_fd_is_valid working.

--- a/tests/wasmfs/wasmfs_chdir.c
+++ b/tests/wasmfs/wasmfs_chdir.c
@@ -22,22 +22,27 @@ int main() {
 
   // Try to print the root directory.
   char cwd[100];
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  char* ret;
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir: %s\n", cwd);
 
   // Try to switch to /working.
   chdir("working");
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir: %s\n", cwd);
 
   // Try to switch back to the root directory.
   chdir("/");
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir: %s\n", cwd);
 
   // Try to switch to a subdirectory of working.
   chdir("/working/test");
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir: %s\n", cwd);
 
   // Try to switch to a non-existent relative path from subdirectory.
@@ -45,7 +50,8 @@ int main() {
   chdir("working");
   printf("Errno: %s\n", strerror(errno));
   assert(errno == ENOENT);
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir is still: %s\n", cwd);
 
   // Try to switch back to absolute path /working.
@@ -53,7 +59,8 @@ int main() {
   chdir("/working");
   printf("Errno: %s\n", strerror(errno));
   assert(errno == 0);
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir is now: %s\n", cwd);
 
   // Try to switch to a non-existent absolute path.
@@ -61,19 +68,22 @@ int main() {
   chdir("/foobar");
   printf("Errno: %s\n", strerror(errno));
   assert(errno == ENOENT);
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir is still: %s\n", cwd);
 
   // Try to switch to /dev.
   chdir("/dev");
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir: %s\n", cwd);
 
   // Try to change cwd to a file.
   chdir("/dev/stdout");
   printf("Errno: %s\n", strerror(errno));
   assert(errno == ENOTDIR);
-  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
+  ret = getcwd(cwd, sizeof(cwd));
+  assert(ret == cwd);
   printf("Current working dir is still: %s\n", cwd);
 
   // Try to pass a size of 0.

--- a/tests/wasmfs/wasmfs_chdir.c
+++ b/tests/wasmfs/wasmfs_chdir.c
@@ -22,22 +22,22 @@ int main() {
 
   // Try to print the root directory.
   char cwd[100];
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir: %s\n", cwd);
 
   // Try to switch to /working.
   chdir("working");
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir: %s\n", cwd);
 
   // Try to switch back to the root directory.
   chdir("/");
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir: %s\n", cwd);
 
   // Try to switch to a subdirectory of working.
   chdir("/working/test");
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir: %s\n", cwd);
 
   // Try to switch to a non-existent relative path from subdirectory.
@@ -45,7 +45,7 @@ int main() {
   chdir("working");
   printf("Errno: %s\n", strerror(errno));
   assert(errno == ENOENT);
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir is still: %s\n", cwd);
 
   // Try to switch back to absolute path /working.
@@ -53,7 +53,7 @@ int main() {
   chdir("/working");
   printf("Errno: %s\n", strerror(errno));
   assert(errno == 0);
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir is now: %s\n", cwd);
 
   // Try to switch to a non-existent absolute path.
@@ -61,19 +61,19 @@ int main() {
   chdir("/foobar");
   printf("Errno: %s\n", strerror(errno));
   assert(errno == ENOENT);
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir is still: %s\n", cwd);
 
   // Try to switch to /dev.
   chdir("/dev");
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir: %s\n", cwd);
 
   // Try to change cwd to a file.
   chdir("/dev/stdout");
   printf("Errno: %s\n", strerror(errno));
   assert(errno == ENOTDIR);
-  getcwd(cwd, sizeof(cwd));
+  printf("getcwd() result: %s\n", getcwd(cwd, sizeof(cwd)));
   printf("Current working dir is still: %s\n", cwd);
 
   // Try to pass a size of 0.

--- a/tests/wasmfs/wasmfs_chdir.out
+++ b/tests/wasmfs/wasmfs_chdir.out
@@ -1,14 +1,23 @@
+getcwd() result: /
 Current working dir: /
+getcwd() result: /working
 Current working dir: /working
+getcwd() result: /
 Current working dir: /
+getcwd() result: /working/test
 Current working dir: /working/test
 Errno: No such file or directory
+getcwd() result: /working/test
 Current working dir is still: /working/test
 Errno: No error information
+getcwd() result: /working
 Current working dir is now: /working
 Errno: No such file or directory
+getcwd() result: /working
 Current working dir is still: /working
+getcwd() result: /dev
 Current working dir: /dev
 Errno: Not a directory
+getcwd() result: /dev
 Current working dir is still: /dev
 Errno: Invalid argument

--- a/tests/wasmfs/wasmfs_chdir.out
+++ b/tests/wasmfs/wasmfs_chdir.out
@@ -1,23 +1,14 @@
-getcwd() result: /
 Current working dir: /
-getcwd() result: /working
 Current working dir: /working
-getcwd() result: /
 Current working dir: /
-getcwd() result: /working/test
 Current working dir: /working/test
 Errno: No such file or directory
-getcwd() result: /working/test
 Current working dir is still: /working/test
 Errno: No error information
-getcwd() result: /working
 Current working dir is now: /working
 Errno: No such file or directory
-getcwd() result: /working
 Current working dir is still: /working
-getcwd() result: /dev
 Current working dir: /dev
 Errno: Not a directory
-getcwd() result: /dev
 Current working dir is still: /dev
 Errno: Invalid argument


### PR DESCRIPTION
The syscall should return the buffer. This makes us behave the same as in
native builds and the old FS.