### PR TITLE
Set __progname on libc init

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3479,11 +3479,13 @@ LibraryManager.library = {
   // programs. This function is for implementing them.
   _emscripten_get_progname__sig: 'vii',
   _emscripten_get_progname: function(str, len) {
+  #if !MINIMAL_RUNTIME
   #if ASSERTIONS
     assert(typeof str === 'number');
     assert(typeof len === 'number');
   #endif
     stringToUTF8(thisProgram, str, len);
+  #endif
   },
 
   emscripten_console_log__sig: 'vi',

--- a/src/library.js
+++ b/src/library.js
@@ -3475,6 +3475,17 @@ LibraryManager.library = {
     err(UTF8ToString(str));
   },
 
+  // Use program_invocation_short_name and program_invocation_name in compiled
+  // programs. This function is for implementing them.
+  _emscripten_get_progname__sig: 'vii',
+  _emscripten_get_progname: function(str, len) {
+  #if ASSERTIONS
+    assert(typeof str === 'number');
+    assert(typeof len === 'number');
+  #endif
+    stringToUTF8(thisProgram, str, len);
+  },
+
   emscripten_console_log__sig: 'vi',
   emscripten_console_log: function(str) {
 #if ASSERTIONS

--- a/system/lib/libc/musl/src/internal/libc.c
+++ b/system/lib/libc/musl/src/internal/libc.c
@@ -1,38 +1,11 @@
-#ifdef __EMSCRIPTEN__
-#include <limits.h>
-#include <string.h>
-#endif
-
 #include "libc.h"
 
 struct __libc __libc;
 
 size_t __hwcap;
+#ifndef __EMSCRIPTEN__
 char *__progname=0, *__progname_full=0;
 
 weak_alias(__progname, program_invocation_short_name);
 weak_alias(__progname_full, program_invocation_name);
-
-#ifdef __EMSCRIPTEN__
-/* See src/library.js for the implementation. */
-void _emscripten_get_progname(char*, int);
-
-__attribute__((constructor))
-static void __progname_ctor(void)
-{
-	static char full_path[PATH_MAX];
-	char *basename;
-
-	_emscripten_get_progname(full_path, sizeof(full_path));
-
-	basename = strrchr(full_path, '/');
-	if (basename == NULL) {
-		basename = full_path;
-	} else {
-		basename++;
-	}
-
-	__progname_full = full_path;
-	__progname = basename;
-}
 #endif

--- a/system/lib/libc/musl/src/internal/libc.c
+++ b/system/lib/libc/musl/src/internal/libc.c
@@ -1,3 +1,8 @@
+#ifdef __EMSCRIPTEN__
+#include <limits.h>
+#include <string.h>
+#endif
+
 #include "libc.h"
 
 struct __libc __libc;
@@ -7,3 +12,27 @@ char *__progname=0, *__progname_full=0;
 
 weak_alias(__progname, program_invocation_short_name);
 weak_alias(__progname_full, program_invocation_name);
+
+#ifdef __EMSCRIPTEN__
+/* See src/library.js for the implementation. */
+void _emscripten_get_progname(char*, int);
+
+__attribute__((constructor))
+static void __progname_ctor(void)
+{
+	static char full_path[PATH_MAX];
+	char *basename;
+
+	_emscripten_get_progname(full_path, sizeof(full_path));
+
+	basename = strrchr(full_path, '/');
+	if (basename == NULL) {
+		basename = full_path;
+	} else {
+		basename++;
+	}
+
+	__progname_full = full_path;
+	__progname = basename;
+}
+#endif

--- a/system/lib/libc/musl/src/internal/progname.c
+++ b/system/lib/libc/musl/src/internal/progname.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#ifdef __EMSCRIPTEN__
+#include <limits.h>
+#include <string.h>
+
+char *__progname=0, *__progname_full=0;
+
+weak_alias(__progname, program_invocation_short_name);
+weak_alias(__progname_full, program_invocation_name);
+
+/* See src/library.js for the implementation. */
+extern void _emscripten_get_progname(char*, int);
+
+__attribute__((constructor))
+static void __progname_ctor(void)
+{
+		static char full_path[PATH_MAX];
+		char *basename;
+
+		_emscripten_get_progname(full_path, sizeof(full_path));
+
+		basename = strrchr(full_path, '/');
+		if (basename == NULL) {
+			basename = full_path;
+		} else {
+			basename++;
+		}
+
+		__progname_full = full_path;
+		__progname = basename;
+}
+#endif

--- a/system/lib/libc/musl/src/internal/progname.c
+++ b/system/lib/libc/musl/src/internal/progname.c
@@ -20,19 +20,19 @@ extern void _emscripten_get_progname(char*, int);
 __attribute__((constructor))
 static void __progname_ctor(void)
 {
-		static char full_path[PATH_MAX];
-		char *basename;
+	static char full_path[PATH_MAX];
+	char *basename;
 
-		_emscripten_get_progname(full_path, sizeof(full_path));
+	_emscripten_get_progname(full_path, sizeof(full_path));
 
-		basename = strrchr(full_path, '/');
-		if (basename == NULL) {
-			basename = full_path;
-		} else {
-			basename++;
-		}
+	basename = strrchr(full_path, '/');
+	if (basename == NULL) {
+		basename = full_path;
+	} else {
+		basename++;
+	}
 
-		__progname_full = full_path;
-		__progname = basename;
+	__progname_full = full_path;
+	__progname = basename;
 }
 #endif

--- a/tests/other/test_err.out
+++ b/tests/other/test_err.out
@@ -1,1 +1,1 @@
-(null): hello warning 42
+test_err.js: hello warning 42

--- a/tests/other/test_libc_progname.c
+++ b/tests/other/test_libc_progname.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2022 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <string.h>
+
+extern const char *__progname;
+extern const char *__progname_full;
+
+int main(void) {
+  printf("__progname: %s\n", __progname);
+
+  /* Ensure the pointers aren't NULL. */
+  assert(__progname && __progname_full);
+
+  /* Ensure the basename is contained in the full path. */
+  assert(strstr(__progname_full, __progname));
+
+  /* Ensure the basename contains no path separator. */
+  assert(!strchr(__progname, '/'));
+
+  /* Ensure the full path starts with the root directory. */
+  assert(*__progname_full == '/');
+
+  /* Ensure the full path is a file and not a directory. */
+  assert(__progname_full[strlen(__progname_full)-1] != '/');
+
+  return 0;
+}

--- a/tests/other/test_libc_progname.out
+++ b/tests/other/test_libc_progname.out
@@ -1,0 +1,1 @@
+__progname: test_libc_progname.js

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -461,6 +461,9 @@ There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR P
   def test_tsearch(self):
     self.do_other_test('test_tsearch.c')
 
+  def test_libc_progname(self):
+    self.do_other_test('test_libc_progname.c')
+
   def test_combining_object_files(self):
     # Compiling two files with -c will generate separate object files
     self.run_process([EMCC, test_file('twopart_main.cpp'), test_file('twopart_side.c'), '-c'])


### PR DESCRIPTION
Implementing this required changing a musl compilation flag from
-std=c99 to -std=gnu99 because EM_ASM doesn't work in -std=c* modes.

This fixes #16037. I'm leaving it a draft to claim the issue and because it's incomplete.

Currently building the libc with this change works but when I try [this test program](https://github.com/guijan/emscripten-bug/) I get a build failure which I believe is unrelated:
```
cache:INFO: generating system library: sysroot/lib/wasm32-emscripten/libdlmalloc.a... (this will be cached in "/home/jan/Work/emscripten/cache/sysroot/lib/wasm32-emscripten/libdlmalloc.a" for subsequent builds)
/home/jan/Work/emscripten/system/lib/dlmalloc.c:35:1: error: static_assert failed due to requirement '(__alignof(max_align_t)) == 8' "max_align_t must be 8"
_Static_assert(MALLOC_ALIGNMENT == 8, "max_align_t must be 8");
^              ~~~~~~~~~~~~~~~~~~~~~
1 error generated.
emcc: error: '/usr/bin/clang -target wasm32-unknown-emscripten -DEMSCRIPTEN -fignore-exceptions -fvisibility=default -mllvm -combiner-global-alias-analysis=false -mllvm -enable-emscripten-sjlj -mllvm -disable-lsr -D__EMSCRIPTEN_major__=3 -D__EMSCRIPTEN_minor__=1 -D__EMSCRIPTEN_tiny__=2 -D_LIBCPP_ABI_VERSION=2 -Werror=implicit-function-declaration -Xclang -iwithsysroot/include/SDL --sysroot=/home/jan/Work/emscripten/cache/sysroot -Xclang -iwithsysroot/include/compat -O2 -Werror -fno-unroll-loops -fno-builtin -g -DNDEBUG -c /home/jan/Work/emscripten/system/lib/dlmalloc.c -o /home/jan/Work/emscripten/cache/build/libdlmalloc/dlmalloc.o' failed (returned 1)
```
That's on Alpine Linux BTW.