### PR TITLE
Temporarily disable test_metadce_hello_main_module_2

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7248,7 +7248,8 @@ int main() {
     # we don't metadce with linkable code! other modules may want stuff
     # TODO(sbc): Investivate why the number of exports is order of magnitude
     # larger for wasm backend.
-    'main_module_2': (['-O3', '-sMAIN_MODULE=2'], [], []), # noqa
+    # Temporarily disabled while https://reviews.llvm.org/D117412 rolls in
+    # 'main_module_2': (['-O3', '-sMAIN_MODULE=2'], [], []), # noqa
   })
   def test_metadce_hello(self, *args):
     self.run_metadce_test('hello_world.cpp', *args)


### PR DESCRIPTION
There is an llvm change pending that changes some internal
init functions https://reviews.llvm.org/D117412.  Once
that rolls in we can rebase and re-enable.

The delta is:

```
--- tests/other/metadce/hello_world_O3_MAIN_MODULE_2.funcs
+++ tests/other/metadce/hello_world_O3_MAIN_MODULE_2.funcs.new
@@ -3,8 +3,9 @@
 $__fwritex
 $__stdio_write
 $__towrite
-$__wasm_apply_global_relocs
+$__wasm_apply_data_relocs
 $__wasm_call_ctors
+$__wasm_start
 $dlmalloc
 $legalstub$dynCall_jiji
 $main
```