### PR TITLE
Fix utime(s) with FILESYSTEM=0

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -87,9 +87,12 @@ LibraryManager.library = {
     }
   },
 #else
+  $setFileTime__deps: ['$setErrNo'],
   $setFileTime: function(path, time) {
-    // No filesystem support; no-op.
-    return 0;
+    // No filesystem support; return an error as if the file does not exist
+    // (which it almost certainly does not, except for standard streams).
+    setErrNo({{{ cDefine('ENOENT') }}});
+    return -1;
   },
 #endif
 

--- a/src/library.js
+++ b/src/library.js
@@ -73,7 +73,8 @@ LibraryManager.library = {
   // utime.h
   // ==========================================================================
 
-  $setFileTime__deps: ['$setErrNo'],
+#if FILESYSTEM
+  $setFileTime__deps: ['$FS', '$setErrNo'],
   $setFileTime: function(path, time) {
     path = UTF8ToString(path);
     try {
@@ -85,8 +86,14 @@ LibraryManager.library = {
       return -1;
     }
   },
+#else
+  $setFileTime: function(path, time) {
+    // No filesystem support; no-op.
+    return 0;
+  },
+#endif
 
-  utime__deps: ['$FS', '$setFileTime'],
+  utime__deps: ['$setFileTime'],
   utime__proxy: 'sync',
   utime__sig: 'iii',
   utime: function(path, times) {
@@ -103,7 +110,7 @@ LibraryManager.library = {
     return setFileTime(path, time);
   },
 
-  utimes__deps: ['$FS', '$setFileTime'],
+  utimes__deps: ['$setFileTime'],
   utimes__proxy: 'sync',
   utimes__sig: 'iii',
   utimes: function(path, times) {


### PR DESCRIPTION
This fixes compilation of Sqlite in the benchmark suite. Not sure why this
became an issue at some point when it wasn't in the past - might have been
the musl upgrade perhaps?