### PR TITLE
[EH/SjLj] Support Wasm EH + Wasm SjLj

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1413,8 +1413,6 @@ def phase_setup(options, state, newargs, settings_map):
       exit_with_error('SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_CATCHING=0')
     if not settings.DISABLE_EXCEPTION_THROWING:
       exit_with_error('SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_THROWING=0')
-    if settings.EXCEPTION_HANDLING:
-      exit_with_error('Wasm SjLj is not supported with Wasm exceptions yet')
 
   return (newargs, input_files)
 

--- a/tests/core/test_exceptions_longjmp4.cpp
+++ b/tests/core/test_exceptions_longjmp4.cpp
@@ -10,6 +10,8 @@ void foo() {
 int main() {
   int jmpval = setjmp(buf);
   if (jmpval != 0) {
+    // This is not reached, because foo() doesn't longjmp. This test checks
+    // compilation of a setjmp call with a nested try.
     printf("setjmp returned for the second time\n");
     return 0;
   }

--- a/tests/core/test_exceptions_longjmp4.cpp
+++ b/tests/core/test_exceptions_longjmp4.cpp
@@ -1,0 +1,27 @@
+#include <stdio.h>
+#include <setjmp.h>
+
+static jmp_buf buf;
+
+void foo() {
+  throw 3;
+}
+
+int main() {
+  int jmpval = setjmp(buf);
+  if (jmpval != 0) {
+    printf("setjmp returned for the second time\n");
+    return 0;
+  }
+  try {
+    foo();
+    try {
+      foo();
+    } catch (int n) {
+      printf("inner catch: caught %d\n");
+    }
+  } catch (int n) {
+    printf("outer catch: caught %d\n");
+  }
+  return 0;
+}

--- a/tests/core/test_exceptions_longjmp4.cpp
+++ b/tests/core/test_exceptions_longjmp4.cpp
@@ -18,10 +18,10 @@ int main() {
     try {
       foo();
     } catch (int n) {
-      printf("inner catch: caught %d\n");
+      printf("inner catch: caught %d\n", n);
     }
   } catch (int n) {
-    printf("outer catch: caught %d\n");
+    printf("outer catch: caught %d\n", n);
   }
   return 0;
 }

--- a/tests/core/test_exceptions_longjmp4.out
+++ b/tests/core/test_exceptions_longjmp4.out
@@ -1,0 +1,1 @@
+outer catch: caught 3

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -125,6 +125,11 @@ def with_both_eh_sjlj(f):
     else:
       self.set_setting('DISABLE_EXCEPTION_CATCHING', 0)
       self.set_setting('SUPPORT_LONGJMP', 'emscripten')
+      # DISABLE_EXCEPTION_CATCHING=0 exports __cxa_can_catch and
+      # __cxa_is_pointer_type, so if we don't build in C++ mode, wasm-ld will
+      # error out because libc++abi is not included. See
+      # https://github.com/emscripten-core/emscripten/pull/14192 for details.
+      self.set_setting('DEFAULT_TO_CXX')
       f(self)
 
   metafunc._parameterize = {'': (False,),


### PR DESCRIPTION
Now that
https://github.com/llvm/llvm-project/commit/eb675e972d742476496fc5b3ee27e31e7516224d
has landed, we can use Wasm EH and Wasm SjLj together.

This PR
- enables Wasm EH + Wasm SjLj combination which was previously banned
- unifies `@with_both_exception_handling` and `@with_both_sjlj_handling`
  into `@with_both_eh_sjlj`. Given that we don't really have a
  plan to test Wasm EH + Emscripten SjLj combination going forward,
  which was meant to be only a temporary measure during the period we
  have only Wasm EH but not Wasm SjLj, I don't think it's worth the
  hassle of keeping three different decorators like
  `@with_both_exception_handling`, `@with_both_sjlj_handling`,
  `@with_both_eh_sjlj`.
- adds `@with_both_eh_sjlj` to several more tests that mix EH + SjLj
- adds one more test that mixes EH + SjLj
- duplicates `test_longjmp` into `test_longjmp_stadnalone`. I couldn't
  find a way to attach two decorators (`@with_both_eh_sjlj` and
  `@also_with_standalone_wasm`) to a single test.

Fixes #15404.