### PR TITLE
Fix breakage from #16064

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -444,7 +444,7 @@ jobs:
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
       - run-tests:
-          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple core2.test_sse1 core2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file core2.test_utf16 other.test_special_chars_in_arguments other.test_toolchain_profiler other.test_realpath_nodefs other.test_response_file_encoding"
+          test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple core2.test_sse1 core2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file core2.test_utf16 other.test_special_chars_in_arguments other.test_toolchain_profiler other.test_realpath_nodefs other.test_response_file_encoding other.test_libc_progname"
   test-mac:
     executor: mac
     environment:

--- a/tests/other/test_libc_progname.c
+++ b/tests/other/test_libc_progname.c
@@ -6,6 +6,7 @@
  */
 
 #include <assert.h>
+#include <emscripten.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -23,6 +24,11 @@ int main(void) {
 
   /* Ensure the basename contains no path separator. */
   assert(!strchr(__progname, '/'));
+
+  if (EM_ASM_INT({ return process.platform.startsWith("win") })) {
+    // The rest of the test here assumes unix-style pathnames.
+    return 0;
+  }
 
   /* Ensure the full path starts with the root directory. */
   assert(*__progname_full == '/');


### PR DESCRIPTION
Skip the part of the test that assumes unix-style pathnames. See

https://github.com/emscripten-core/emscripten/pull/16064#issuecomment-1018649625