### PR TITLE
Fix freeaddrinfo(), which did not match allocation in JS.

### DIFF
--- a/system/lib/libc/musl/src/network/freeaddrinfo.c
+++ b/system/lib/libc/musl/src/network/freeaddrinfo.c
@@ -6,6 +6,13 @@
 
 void freeaddrinfo(struct addrinfo *p)
 {
+#if __EMSCRIPTEN__
+	// Emscripten's usage of this structure is very simple: we always allocate
+	// ai_addr, and do not use the linked list aspect at all. There is also no
+	// aliasing with aibuf.
+	free(p->ai_addr);
+	free(p);
+#else
 	size_t cnt;
 	for (cnt=1; p->ai_next; cnt++, p=p->ai_next);
 	struct aibuf *b = (void *)((char *)p - offsetof(struct aibuf, ai));
@@ -13,4 +20,5 @@ void freeaddrinfo(struct addrinfo *p)
 	LOCK(b->lock);
 	if (!(b->ref -= cnt)) free(b);
 	else UNLOCK(b->lock);
+#endif
 }


### PR DESCRIPTION
It is risky to allocate in JS and free in C, when given matching allocate/free
pairs like getaddrinfo/freeaddrinfo, and it looks like we had things wrong
here. That is, the existing musl code did not match how we use that
structure. The worst part is that musl appears to assume the struct is
identical/can alias some other struct, and that led to memory corruption.

Not sure if we can test this reliably as the issue is corruption.

Fixes #16081