### PR TITLE
Update version of wasmtime used in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,8 +331,8 @@ jobs:
           name: get wasmtime
           command: |
             # use a pinned version due to https://github.com/bytecodealliance/wasmtime/issues/714
-            export VERSION=v0.8.0
-            wget https://github.com/bytecodealliance/wasmtime/releases/download/v0.8.0/wasmtime-$VERSION-x86_64-linux.tar.xz
+            export VERSION=v0.33.0
+            wget https://github.com/bytecodealliance/wasmtime/releases/download/$VERSION/wasmtime-$VERSION-x86_64-linux.tar.xz
             tar -xf wasmtime-$VERSION-x86_64-linux.tar.xz
             cp wasmtime-$VERSION-x86_64-linux/wasmtime ~/vms
       - run:

--- a/system/lib/libc/musl/src/time/clock_gettime.c
+++ b/system/lib/libc/musl/src/time/clock_gettime.c
@@ -59,10 +59,15 @@ _Static_assert(CLOCK_MONOTONIC == __WASI_CLOCKID_MONOTONIC, "monotonic clock mus
 
 int __clock_gettime(clockid_t clk, struct timespec *ts) {
 	__wasi_timestamp_t timestamp;
+	// See https://github.com/bytecodealliance/wasmtime/issues/3714
+	if (clk > __WASI_CLOCKID_THREAD_CPUTIME_ID || clk < 0) {
+		errno = EINVAL;
+		return -1;
+  }
 	if (__wasi_syscall_ret(__wasi_clock_time_get(clk, 1, &timestamp))) {
 		return -1;
 	}
-  *ts = __wasi_timestamp_to_timespec(timestamp);
+	*ts = __wasi_timestamp_to_timespec(timestamp);
 	return 0;
 }
 #else // __EMSCRIPTEN__

--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -42,6 +42,11 @@ struct timespec __wasi_timestamp_to_timespec(__wasi_timestamp_t timestamp) {
 }
 
 int clock_getres(clockid_t clk_id, struct timespec *tp) {
+  // See https://github.com/bytecodealliance/wasmtime/issues/3714
+  if (clk_id > __WASI_CLOCKID_THREAD_CPUTIME_ID || clk_id < 0) {
+    errno = EINVAL;
+    return -1;
+  }
   __wasi_timestamp_t res;
   __wasi_errno_t error = __wasi_clock_res_get(clk_id, &res);
   if (error != __WASI_ERRNO_SUCCESS) {


### PR DESCRIPTION
Includes added couple of extra checks when calling `__wasi_clock`
functions. These only apply to standlone builds as the non-standalone
builds implement these functions directly in JS.

See #16076