### PR TITLE
Simplify `EMSCRIPTEN_BINDINGS` macro. NFC

### DIFF
--- a/system/include/emscripten/bind.h
+++ b/system/include/emscripten/bind.h
@@ -1884,10 +1884,9 @@ void constant(const char* name, const ConstantType& v) {
         static_cast<double>(asGenericValue(BT::toWireType(v))));
 }
 
-} // end namespace emscripten
+// EMSCRIPTEN_BINDINGS simple creates a static constructor function which
+// will get included in the program if the translation unit in which it is
+// define gets linked into the program.
+#define EMSCRIPTEN_BINDINGS(name) __attribute__((constructor)) static void __embind_init_##name(void)
 
-#define EMSCRIPTEN_BINDINGS(name)                                       \
-    static struct EmscriptenBindingInitializer_##name {                 \
-        EmscriptenBindingInitializer_##name();                          \
-    } EmscriptenBindingInitializer_##name##_instance;                   \
-    EmscriptenBindingInitializer_##name::EmscriptenBindingInitializer_##name()
+} // end namespace emscripten

--- a/system/lib/embind/bind.cpp
+++ b/system/lib/embind/bind.cpp
@@ -100,7 +100,12 @@ template <typename T> static void register_memory_view(const char* name) {
 } // namespace
 
 extern "C" {
-void EMSCRIPTEN_KEEPALIVE __embind_register_native_and_builtin_types() {
+
+// Normal initialization, executed through a global constructor. This
+// happens on the main thread; pthreads will call it manually, so make
+// sure we also export it (via EMSCRIPTEN_KEEPALIVE).
+EMSCRIPTEN_KEEPALIVE __attribute__((constructor))
+void __embind_register_native_and_builtin_types() {
   using namespace emscripten::internal;
 
   _embind_register_void(TypeID<void>::get(), "void");
@@ -161,10 +166,5 @@ void EMSCRIPTEN_KEEPALIVE __embind_register_native_and_builtin_types() {
   register_memory_view<long double>("emscripten::memory_view<long double>");
 #endif
 }
-}
 
-EMSCRIPTEN_BINDINGS(native_and_builtin_types) {
-  // Normal initialization, executed through a global constructor. This
-  // happens on the main thread; pthreads will call it manually.
-  __embind_register_native_and_builtin_types();
-}
+} // extern "C"


### PR DESCRIPTION
At least for me its easier to see the intent this way.  Its also
slightly more effecient as this function ends up directly getting called
from `__wasm_call_ctors` rather can getting includes in another
per-object file dispatch function for C++ statics.

Also, avoid the use the macro in bind.cpp where is didn't seem to
convey its intent.