### PR TITLE
Simplify/correct localtime_r.c patch from #10536. NFC

### DIFF
--- a/system/lib/libc/musl/src/time/localtime_r.c
+++ b/system/lib/libc/musl/src/time/localtime_r.c
@@ -4,13 +4,18 @@
 
 struct tm *__localtime_r(const time_t *restrict t, struct tm *restrict tm)
 {
+	/* Unlike other musl targets emscripten uses `int` for time_t rather than
+	 * `int64`, so these checks don't apply (they rightly trigger
+	 * `autological-constant-out-of-range-compare` warnings).
+	 * TODO(sbc): Remove this if/when we switch to using int64 too. */
+#ifndef __EMSCRIPTEN__
 	/* Reject time_t values whose year would overflow int because
 	 * __secs_to_zone cannot safely handle them. */
-	// XXX EMSCRIPTEN: add casts to (long long) to avoid a new clang warning
-	if (((long long)*t) < INT_MIN * 31622400LL || ((long long)*t) > INT_MAX * 31622400LL) {
+	if (*t < INT_MIN * 31622400LL || *t > INT_MAX * 31622400LL) {
 		errno = EOVERFLOW;
 		return 0;
 	}
+#endif
 	__secs_to_zone(*t, 0, &tm->tm_isdst, &tm->__tm_gmtoff, 0, &tm->__tm_zone);
 	if (__secs_to_tm((long long)*t + tm->__tm_gmtoff, tm) < 0) {
 		errno = EOVERFLOW;


### PR DESCRIPTION
I'm hoping we can remove this patch completely if we switch to 64bit
time like the reset other targets (I think we we would only do this if
we can avoid code size bloat and introducing for 64-bit calls at the
wasm->JS boudary).