### PR TITLE
Strip non-debug sections from separate-dwarf file

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8241,6 +8241,17 @@ int main() {
     self.assertNotIn(b'subdir/output.wasm.debug.wasm', wasm)
     self.assertNotIn(bytes(os.path.join('subdir', 'output.wasm.debug.wasm'), 'ascii'), wasm)
 
+    # Check that the dwarf file has only dwarf and name sections
+    debug_wasm = webassembly.Module('subdir/output.wasm.debug.wasm')
+    section_names = [sec.name for sec in debug_wasm.sections()]
+    if 'name' not in section_names:
+      self.fail('name section not found in separate dwarf file')
+    for sec in debug_wasm.sections():
+      if sec.type != webassembly.SecType.CUSTOM:
+        self.fail(f'non-custom section type {sec.type} found in separate dwarf file')
+      elif sec.name != 'name' and not sec.name.startswith('.debug'):
+        self.fail(f'non-debug section "{sec.name}" found in separate dwarf file')
+
   def test_separate_dwarf_with_filename(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-gseparate-dwarf=with_dwarf.wasm'])
     self.assertNotExists('a.out.wasm.debug.wasm')

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8243,8 +8243,7 @@ int main() {
 
     # Check that the dwarf file has only dwarf and name sections
     debug_wasm = webassembly.Module('subdir/output.wasm.debug.wasm')
-    section_names = [sec.name for sec in debug_wasm.sections()]
-    if 'name' not in section_names:
+    if not debug_wasm.has_name_section():
       self.fail('name section not found in separate dwarf file')
     for sec in debug_wasm.sections():
       if sec.type != webassembly.SecType.CUSTOM:

--- a/tools/building.py
+++ b/tools/building.py
@@ -1241,6 +1241,10 @@ def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   shutil.move(wasm_file, wasm_file_with_dwarf)
   strip(wasm_file_with_dwarf, wasm_file, debug=True)
 
+  # Strip the non-debug sections out of the DWARF file
+  check_call([LLVM_OBJCOPY, wasm_file_with_dwarf, '--only-keep-debug',
+              '--keep-section', 'name'])
+
   # embed a section in the main wasm to point to the file with external DWARF,
   # see https://yurydelendik.github.io/webassembly-dwarf/#external-DWARF
   section_name = b'\x13external_debug_info' # section name, including prefixed size


### PR DESCRIPTION
When using -gseparate-dwarf, emscripten strips the DWARF sections from the main
wasm output file, and writes a second file (foo.debug.wasm) with the DWARF
sections. Currently that file also contains a copy of all the other sections
as well, but this is unncessary and just wastes space.

Fixes #13084