### PR TITLE
[SjLj] Enable Wasm SjLj with -sSUPPORT_LONGJMP=wasm

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1445,9 +1445,9 @@ def phase_setup(options, state, newargs, settings_map):
     # Wasm SjLj cannot be used with Emscripten EH. We error out if
     # DISABLE_EXCEPTION_THROWING=0 is explicitly requested by the user;
     # otherwise we disable it here.
-    if 'DISABLE_EXCEPTION_THROWING' in settings_map and settings_map['DISABLE_EXCEPTION_THROWING'] == '0':
+    default_setting('DISABLE_EXCEPTION_THROWING', 1)
+    if not settings.DISABLE_EXCEPTION_THROWING:
       exit_with_error('SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_CATCHING=0')
-    settings.DISABLE_EXCEPTION_THROWING = 1
     # We error out for DISABLE_EXCEPTION_CATCHING=0, because it is 1 by default
     # and this can be 0 only if the user specifies so.
     if not settings.DISABLE_EXCEPTION_CATCHING:

--- a/emcc.py
+++ b/emcc.py
@@ -1441,10 +1441,13 @@ def phase_setup(options, state, newargs, settings_map):
 
   # Wasm SjLj cannot be used with Emscripten EH
   if settings.SUPPORT_LONGJMP == 'wasm':
+    # DISABLE_EXCEPTION_THROWING is 0 by default for Emscripten EH throwing, but
+    # Wasm SjLj cannot be used with Emscripten EH. So we disable it here.
+    DISABLE_EXCEPTION_THROWING = 1;
+    # We error out for DISABLE_EXCEPTION_CATCHING=0, because it is 1 by default
+    # and this can be 0 only if the user specifies so.
     if not settings.DISABLE_EXCEPTION_CATCHING:
       exit_with_error('SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_CATCHING=0')
-    if not settings.DISABLE_EXCEPTION_THROWING:
-      exit_with_error('SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_THROWING=0')
 
   return (newargs, input_files)
 

--- a/emcc.py
+++ b/emcc.py
@@ -1442,7 +1442,11 @@ def phase_setup(options, state, newargs, settings_map):
   # Wasm SjLj cannot be used with Emscripten EH
   if settings.SUPPORT_LONGJMP == 'wasm':
     # DISABLE_EXCEPTION_THROWING is 0 by default for Emscripten EH throwing, but
-    # Wasm SjLj cannot be used with Emscripten EH. So we disable it here.
+    # Wasm SjLj cannot be used with Emscripten EH. We error out if
+    # DISABLE_EXCEPTION_THROWING=0 is explicitly requested by the user;
+    # otherwise we disable it here.
+    if 'DISABLE_EXCEPTION_THROWING' in settings_map and settings_map['DISABLE_EXCEPTION_THROWING'] == '0':
+      exit_with_error('SUPPORT_LONGJMP=wasm cannot be used with DISABLE_EXCEPTION_CATCHING=0')
     settings.DISABLE_EXCEPTION_THROWING = 1
     # We error out for DISABLE_EXCEPTION_CATCHING=0, because it is 1 by default
     # and this can be 0 only if the user specifies so.

--- a/emcc.py
+++ b/emcc.py
@@ -1443,7 +1443,7 @@ def phase_setup(options, state, newargs, settings_map):
   if settings.SUPPORT_LONGJMP == 'wasm':
     # DISABLE_EXCEPTION_THROWING is 0 by default for Emscripten EH throwing, but
     # Wasm SjLj cannot be used with Emscripten EH. So we disable it here.
-    DISABLE_EXCEPTION_THROWING = 1;
+    settings.DISABLE_EXCEPTION_THROWING = 1
     # We error out for DISABLE_EXCEPTION_CATCHING=0, because it is 1 by default
     # and this can be 0 only if the user specifies so.
     if not settings.DISABLE_EXCEPTION_CATCHING:

--- a/src/settings.js
+++ b/src/settings.js
@@ -655,8 +655,10 @@ var ENVIRONMENT = 'web,webview,worker,node';
 var LZ4 = 0;
 
 // Emscripten exception handling options.
-// These options only pertain to Emscripten exception handling and do not
-// control the experimental native wasm exception handling option.
+// The three options below (DISABLE_EXCEPTION_CATCHING,
+// EXCEPTION_CATCHING_ALLOWED, and DISABLE_EXCEPTION_THROWING) only pertain to
+// Emscripten exception handling and do not control the experimental native wasm
+// exception handling option (EXCEPTION_HANDLING).
 
 // Disables generating code to actually catch exceptions. This disabling is on
 // by default as the overhead of exceptions is quite high in size and speed
@@ -682,6 +684,21 @@ var DISABLE_EXCEPTION_CATCHING = 1;
 //
 // [compile+link] - affects user code at compile and system libraries at link
 var EXCEPTION_CATCHING_ALLOWED = [];
+
+// Internal: Tracks whether Emscripten should link in exception throwing (C++
+// 'throw') support library. This does not need to be set directly, but pass
+// -fno-exceptions to the build disable exceptions support. (This is basically
+// -fno-exceptions, but checked at final link time instead of individual .cpp
+// file compile time) If the program *does* contain throwing code (some source
+// files were not compiled with `-fno-exceptions`), and this flag is set at link
+// time, then you will get errors on undefined symbols, as the exception
+// throwing code is not linked in. If so you should either unset the option (if
+// you do want exceptions) or fix the compilation of the source files so that
+// indeed no exceptions are used).
+// TODO(sbc): Move to settings_internal (current blocked due to use in test
+// code).
+// [link]
+var DISABLE_EXCEPTION_THROWING = 0;
 
 // By default we handle exit() in node, by catching the Exit exception. However,
 // this means we catch all process exceptions. If you disable this, then we no
@@ -1816,21 +1833,6 @@ var MAYBE_WASM2JS = 0;
 // future release.
 // [link]
 var ASAN_SHADOW_SIZE = -1
-
-// Internal: Tracks whether Emscripten should link in exception throwing (C++
-// 'throw') support library. This does not need to be set directly, but pass
-// -fno-exceptions to the build disable exceptions support. (This is basically
-// -fno-exceptions, but checked at final link time instead of individual .cpp
-// file compile time) If the program *does* contain throwing code (some source
-// files were not compiled with `-fno-exceptions`), and this flag is set at link
-// time, then you will get errors on undefined symbols, as the exception
-// throwing code is not linked in. If so you should either unset the option (if
-// you do want exceptions) or fix the compilation of the source files so that
-// indeed no exceptions are used).
-// TODO(sbc): Move to settings_internal (current blocked due to use in test
-// code).
-// [link]
-var DISABLE_EXCEPTION_THROWING = 0;
 
 // Whether we should use the offset converter.  This is needed for older
 // versions of v8 (<7.7) that does not give the hex module offset into wasm

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10471,6 +10471,12 @@ exec "$@"
     self.assertContained('error: longjmp support was disabled (SUPPORT_LONGJMP=0), but it is required by the code (either set SUPPORT_LONGJMP=1, or remove uses of it in the project)',
                          stderr)
 
+  def test_SUPPORT_LONGJMP_wasm(self):
+    # Tests if -sSUPPORT_LONGJMP=wasm alone is enough to use Wasm SjLj, i.e., it
+    # automatically sets DISABLE_EXCEPTION_THROWING to 1, which is 0 by default,
+    # because Emscripten EH and Wasm SjLj cannot be used at the same time.
+    self.run_process([EMCC, test_file('core/test_longjmp.c'), '-c', '-sSUPPORT_LONGJMP=wasm', '-o', 'a.o'])
+
   def test_pthread_MODULARIZE(self):
     stderr = self.run_process([EMCC, test_file('hello_world.c'), '-pthread', '-sMODULARIZE'], stderr=PIPE, check=False).stderr
     self.assertContained('pthreads + MODULARIZE currently require you to set -s EXPORT_NAME=Something (see settings.js) to Something != Module, so that the .worker.js file can work',


### PR DESCRIPTION
Because currently `DISABLE_EXCEPTION_THROWING` is 0 by default, which
enables Emscripten EH exception throwing, to use Wasm SjLj, you need to
specify both options, which is inconvenient and unintuitive:
```
emcc -sSUPPORT_LONGJMP=wasm -sDISABLE_EXCEPTION_THROWING=1 test.c
```

So far we've errored out when `SUPPORT_LONGJMP=wasm` was given with
either `DISABLE_EXCEPTION_CATCHING=0` or `DISABLE_EXCEPTION_THROWING=0`.
But unlike `DISABLE_EXCEPTION_CATCHING`, which is 1 by default and you
have to explicitly disable it to make it 0, `DISABLE_EXCEPTION_THROWING`
is 0 by default so you always have to turn it off when we use Wasm SjLj,
which is very inconvenient. This PR automatically sets
`DISABLE_EXCEPTION_THROWING` to 1 when `SUPPORT_LONGJMP` is `wasm`.