### PR TITLE
Remove stripping of individual command line arguments in emcc.py.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2918,9 +2918,6 @@ def parse_args(newargs):
       skip = False
       continue
 
-    # On Windows Vista (and possibly others), excessive spaces in the command line
-    # leak into the items in this array, so trim e.g. 'foo.cpp ' -> 'foo.cpp'
-    newargs[i] = newargs[i].strip()
     arg = newargs[i]
     arg_value = None
 


### PR DESCRIPTION
This was originally introduced 10 years ago to work around a bug that
occurred on windows vista (See
4ab1c8acec8efbdb73a4363581abf7d4f4c0aa53).  Its not clear if the bug was
in cmake or in windows itself, or in the version of python.

Windows Vista has been unsupported for a very long time now so I think
even attempted to verify this bug still exists would be very tricky.

What is more, the underlying tools such as clang don't support this
behavior so any user who suffered from this bug likely wouldn't be
able ot use clang outside of emscripten.  For example:

```
clang ' --version'
clang: error: no such file or directory: ' --version'; did you mean '--version'?
clang: error: no input files
```

I don't know of any tools that don't work like that above, so I don't
see why we should be any different.

The motivation for removing this now is that it came up in discussion
when working on code nearby (#16087) and it seems to pointless at best
and incomaptiable at worst (since it prevents the use of
filenames that start or end in space).