### PR TITLE
Refactor preload plugin usage code. NFC

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -310,6 +310,23 @@ var LibraryBrowser = {
       }
     },
 
+    // Tries to handle an input byteArray using preload plugins. Returns true if
+    // it was handled.
+    handledByPreloadPlugin: function(byteArray, fullname, finish, onerror) {
+      // Ensure plugins are ready.
+      Browser.init();
+
+      var handled = false;
+      Module['preloadPlugins'].forEach(function(plugin) {
+        if (handled) return;
+        if (plugin['canHandle'](fullname)) {
+          plugin['handle'](byteArray, fullname, finish, onerror);
+          handled = true;
+        }
+      });
+      return handled;
+    },
+
     createContext: function(canvas, useWebGL, setInModule, webGLContextAttributes) {
       if (useWebGL && Module.ctx && canvas == Module.canvas) return Module.ctx; // no need to recreate GL context if it's already been created for this canvas.
 

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1864,7 +1864,6 @@ FS.staticInit();` +
     // do preloading for the Image/Audio part, as if the typed array were the
     // result of an XHR that you did manually.
     createPreloadedFile: function(parent, name, url, canRead, canWrite, onload, onerror, dontCreateFile, canOwn, preFinish) {
-      Browser.init(); // XXX perhaps this method should move onto Browser?
       // TODO we should allow people to just pass in a complete filename instead
       // of parent and name being that we just join them anyways
       var fullname = name ? PATH_FS.resolve(PATH.join2(parent, name)) : parent;
@@ -1878,18 +1877,13 @@ FS.staticInit();` +
           if (onload) onload();
           removeRunDependency(dep);
         }
-        var handled = false;
-        Module['preloadPlugins'].forEach(function(plugin) {
-          if (handled) return;
-          if (plugin['canHandle'](fullname)) {
-            plugin['handle'](byteArray, fullname, finish, function() {
-              if (onerror) onerror();
-              removeRunDependency(dep);
-            });
-            handled = true;
-          }
-        });
-        if (!handled) finish(byteArray);
+        if (Browser.handledByPreloadPlugin(byteArray, fullname, finish, function() {
+          if (onerror) onerror();
+          removeRunDependency(dep);
+        })) {
+          return;
+        }
+        finish(byteArray);
       }
       addRunDependency(dep);
       if (typeof url == 'string') {


### PR DESCRIPTION
Just moves code from `library_fs` into `library_browser`. The code belongs in that
location anyhow - it would be good to move even more of it - and also this will
help WasmFS which needs the same code, and this will allow us to avoid
duplicating it.