### PR TITLE
Use native version of `ctime_r`. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -615,14 +615,6 @@ LibraryManager.library = {
     return ret;
   },
 
-  ctime_r__deps: ['localtime_r', '__asctime_r', '$withStackSave'],
-  ctime_r__sig: 'iii',
-  ctime_r: function(time, buf) {
-    return withStackSave(function() {
-      return ___asctime_r(_localtime_r(time, stackAlloc({{{ C_STRUCTS.tm.__size__ }}})), buf);
-    });
-  },
-
   dysize: function(year) {
     var leap = ((year % 4 == 0) && ((year % 100 != 0) || (year % 400 == 0)));
     return leap ? 366 : 365;

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -910,6 +910,7 @@ class libc(MuslInternalLibrary,
           'localtime.c',
           'nanosleep.c',
           'clock_nanosleep.c',
+          'ctime_r.c',
         ])
     libc_files += files_in_path(
         path='system/lib/libc/musl/src/legacy',
@@ -1573,7 +1574,6 @@ class libstandalonewasm(MuslInternalLibrary):
                    '__year_to_secs.c',
                    'clock.c',
                    'clock_gettime.c',
-                   'ctime_r.c',
                    'difftime.c',
                    'gettimeofday.c',
                    'localtime_r.c',


### PR DESCRIPTION
The native code in musl is pretty much a transliteration
of the JS code here, but should be smaller and faster and
avoid the extra import (and work in standalone mode).

See https://github.com/emscripten-core/emscripten/blob/main/system/lib/libc/musl/src/time/ctime_r.c