### PR TITLE
Fix for getdents (readdir) under NODEFS.

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1061,13 +1061,10 @@ FS.staticInit();` +
       var stream = FS.createStream({
         node: node,
         path: FS.getPath(node),  // we want the absolute path to the node
-        id: node.id,
         flags: flags,
-        mode: node.mode,
         seekable: true,
         position: 0,
         stream_ops: node.stream_ops,
-        node_ops: node.node_ops,
         // used by the file family libc calls (fopen, fwrite, ferror, etc.)
         ungotten: [],
         error: false

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -29,6 +29,10 @@ mergeInto(LibraryManager.library, {
     }`,
   $NODERAWFS: {
     lookup: function(parent, name) {
+#if ASSERTIONS
+      assert(parent)
+      assert(parent.path)
+#endif
       return FS.lookupPath(parent.path + '/' + name).node;
     },
     lookupPath: function(path, opts) {
@@ -38,7 +42,7 @@ mergeInto(LibraryManager.library, {
       }
       var st = fs.lstatSync(path);
       var mode = NODEFS.getMode(path);
-      return { path: path, node: { id: st.ino, mode: mode }};
+      return { path: path, node: { id: st.ino, mode: mode, node_ops: NODERAWFS, path: path }};
     },
     createStandardStreams: function() {
       FS.streams[0] = { fd: 0, nfd: 0, position: 0, path: '', flags: 0, tty: true, seekable: false };
@@ -90,7 +94,8 @@ mergeInto(LibraryManager.library, {
       }
       var newMode = NODEFS.getMode(pathTruncated);
       var fd = suggestFD != null ? suggestFD : FS.nextfd(nfd);
-      var stream = { fd: fd, nfd: nfd, position: 0, path: path, id: st.ino, flags: flags, mode: newMode, node_ops: NODERAWFS, seekable: true };
+      var node = { id: st.ino, mode: newMode, node_ops: NODERAWFS, path: path }
+      var stream = { fd: fd, nfd: nfd, position: 0, path: path, flags: flags, node: node, seekable: true };
       FS.streams[fd] = stream;
       return stream;
     },

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -858,7 +858,7 @@ var SyscallsLibrary = {
       var type;
       var name = stream.getdents[idx];
       if (name === '.') {
-        id = stream.id;
+        id = stream.node.id;
         type = 4; // DT_DIR
       }
       else if (name === '..') {
@@ -867,7 +867,7 @@ var SyscallsLibrary = {
         type = 4; // DT_DIR
       }
       else {
-        var child = FS.lookupNode(stream, name);
+        var child = FS.lookupNode(stream.node, name);
         id = child.id;
         type = FS.isChrdev(child.mode) ? 2 :  // DT_CHR, character device.
                FS.isDir(child.mode) ? 4 :     // DT_DIR, directory.

--- a/tests/dirent/test_readdir.c
+++ b/tests/dirent/test_readdir.c
@@ -93,9 +93,12 @@ void test() {
   for (i = 0; i < 3; i++) {
     errno = 0;
     ent = readdir(dir);
-    //printf("ent, errno: %p, %d\n", ent, errno);
-    assert(ent);
-    //printf("%d file: %s (%d : %d)\n", i, ent->d_name, ent->d_reclen, sizeof(*ent));
+    if (ent) {
+      fprintf(stderr, "%d file: %s (%d : %lu)\n", i, ent->d_name, ent->d_reclen, sizeof(*ent));
+    } else {
+      fprintf(stderr, "ent: %p, errno: %d\n", ent, errno);
+      assert(ent);
+    }
     assert(ent->d_reclen == sizeof(*ent));
     if (!seen[0] && !strcmp(ent->d_name, ".")) {
       assert(ent->d_type & DT_DIR);

--- a/tests/fs/test_nodefs_readdir.c
+++ b/tests/fs/test_nodefs_readdir.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+#include <dirent.h>
+#include <emscripten.h>
+#include <stdio.h>
+
+void list_dir(const char *path) {
+  printf("listing contents of dir=%s\n", path);
+  struct dirent* entry;
+  DIR* dir = opendir(path);
+  assert(dir);
+  int n = 0;
+  while ((entry = readdir(dir)) != NULL) {
+    printf("%s\n", entry->d_name);
+    ++n;
+  }
+  assert(n);
+  closedir(dir);
+}
+
+int main(int argc, char * argv[]) {
+  list_dir("/");
+
+  // mount the current folder as a NODEFS instance
+  // inside of emscripten and create folders nodefs/a
+  // in mounted directory
+  EM_ASM(
+    FS.mkdir('/working');
+    FS.mount(NODEFS, { root: '.' }, '/working');
+  );
+
+  list_dir("/working");
+  puts("success");
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5433,6 +5433,12 @@ main( int argv, char ** argc ) {
     self.emcc_args += ['-lnodefs.js']
     self.do_runf(test_file('fs/test_nodefs_nofollow.c'), 'success', js_engines=[config.NODE_JS])
 
+  def test_fs_nodefs_readdir(self):
+    # externally setup an existing folder structure: existing/a
+    os.makedirs(os.path.join(self.working_dir, 'existing', 'a'))
+    self.emcc_args += ['-lnodefs.js']
+    self.do_runf(test_file('fs/test_nodefs_readdir.c'), 'success')
+
   @no_windows('no symlink support on windows')
   def test_fs_noderawfs_nofollow(self):
     self.set_setting('NODERAWFS')


### PR DESCRIPTION
The test case here was taken from #15308.

The main bugfix here is to use `stream.node` rather than just `stream`
when attempting to get node properties from a stream.  There were some
extra properties added to the streams back in #15167, but this change
reverts that and instread fixes up the streams returned by NODERAWFS
such that they have the correct/expected fields.