### PR TITLE
Update expectations for other.test_metadce_minimal_pthreads after #15604

### DIFF
--- a/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -10,6 +10,7 @@ $__pthread_setcancelstate
 $__set_thread_state
 $__stdio_write
 $__timedwait
+$__wake
 $__wasi_syscall_ret
 $__wasm_call_ctors
 $__wasm_init_memory


### PR DESCRIPTION
This broke the emscripten-releases roller as well as recent test
runs on emscripten CI.

I have no idea how it actually passed in #15604.  That is rather
worrying.