### PR TITLE
Remove __atomic_is_lock_free. NFC

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -892,10 +892,6 @@ var LibraryPThread = {
     return 0;
   },
 
-  __atomic_is_lock_free: function(size, ptr) {
-    return size <= 4 && (size & (size-1)) == 0 && (ptr&(size-1)) == 0;
-  },
-
   __call_main__deps: ['exit', '$exitOnMainThread'],
   __call_main: function(argc, argv) {
     var returnCode = {{{ exportedAsmFunc('_main') }}}(argc, argv);


### PR DESCRIPTION
I believe all the other functions in this family were already
removed back in 2a57fd9b2d9d1ecbcf671c0e6439b93e0192d74e.