### PR TITLE
Remove commented out usage of -fno-threadsafe-statics. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -873,8 +873,7 @@ def get_cflags(user_args):
 
   # Set the LIBCPP ABI version to at least 2 so that we get nicely aligned string
   # data and other nice fixes.
-  cflags += [# '-fno-threadsafe-statics', # disabled due to issue 1289
-             '-D__EMSCRIPTEN_major__=' + str(shared.EMSCRIPTEN_VERSION_MAJOR),
+  cflags += ['-D__EMSCRIPTEN_major__=' + str(shared.EMSCRIPTEN_VERSION_MAJOR),
              '-D__EMSCRIPTEN_minor__=' + str(shared.EMSCRIPTEN_VERSION_MINOR),
              '-D__EMSCRIPTEN_tiny__=' + str(shared.EMSCRIPTEN_VERSION_TINY),
              '-D_LIBCPP_ABI_VERSION=2']


### PR DESCRIPTION
I don't think we want to go back to setting this by default.

This is part of a sequence of changes to make emcc more like
vanilla clang (See: #15703).

See: #1289
See: caf93e9b5602bb8bec0e3822df8a6f0210acc4f2