### PR TITLE
Update `cmake_minimum_required` used in tests. NFC

### DIFF
--- a/tests/cmake/cmake_with_emval/CMakeLists.txt
+++ b/tests/cmake/cmake_with_emval/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(cmake_with_emval)
 

--- a/tests/cmake/cpp_lib/CMakeLists.txt
+++ b/tests/cmake/cpp_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(cpp_library)
 

--- a/tests/cmake/find_stuff/CMakeLists.txt
+++ b/tests/cmake/find_stuff/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(find_stuff)
 

--- a/tests/cmake/post_build/CMakeLists.txt
+++ b/tests/cmake/post_build/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(post_build)
 

--- a/tests/cmake/static_lib/CMakeLists.txt
+++ b/tests/cmake/static_lib/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(static_library)
 

--- a/tests/cmake/stdproperty/CMakeLists.txt
+++ b/tests/cmake/stdproperty/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.0)
 project(helloworld)
 
 add_executable(helloworld main.cpp)

--- a/tests/cmake/target_html/CMakeLists.txt
+++ b/tests/cmake/target_html/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(hello_world_gles)
 

--- a/tests/cmake/target_js/CMakeLists.txt
+++ b/tests/cmake/target_js/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(test_cmake)
 

--- a/tests/cmake/target_library/CMakeLists.txt
+++ b/tests/cmake/target_library/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.0)
 
 project(test_cmake)
 


### PR DESCRIPTION
We don't actually test with older versions of cmake and these
old minimum version generate bunch of warning noise on stderr:

```
  Compatibility with CMake < 2.8.12 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.
```