### PR TITLE
Use stderr directly to write errors in worker.js under node. NFC

### DIFF
--- a/src/worker.js
+++ b/src/worker.js
@@ -63,6 +63,13 @@ function assert(condition, text) {
 
 function threadPrintErr() {
   var text = Array.prototype.slice.call(arguments).join(' ');
+#if ENVIRONMENT_MAY_BE_NODE
+  // See https://github.com/emscripten-core/emscripten/issues/14804
+  if (ENVIRONMENT_IS_NODE) {
+    fs.writeSync(2, text + '\n');
+    return;
+  }
+#endif
   console.error(text);
 }
 function threadAlert() {


### PR DESCRIPTION
Writing directly to stderr works even when the main thread is currently
blocked (not returning to its message loop), for example in
pthread_join.  We already do this in shell.sh when defining `err` in the
primary module code.

This issue was causing error messages from the worker to be lost in the
repro case posted in #16021.