### PR TITLE
When PTHREAD_DEBUG is enabled, always include thread and worker ID in err logs

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -9,6 +9,7 @@ var LibraryPThread = {
   $PThread__deps: ['_emscripten_thread_init',
                    '$killThread',
                    '$cancelThread', '$cleanupThread', '$zeroMemory',
+                   '$ptrToString',
                    '_emscripten_thread_free_data',
                    'exit',
 #if !MINIMAL_RUNTIME
@@ -25,7 +26,27 @@ var LibraryPThread = {
     // Contains all Workers that are currently hosting an active pthread.
     runningWorkers: [],
     tlsInitFunctions: [],
+#if PTHREADS_DEBUG
+    nextWorkerID: 1,
+    debugInit: function() {
+      function pthreadLogPrefix() {
+        var t = 0;
+        if (runtimeInitialized && !runtimeExited && typeof _pthread_self !== 'undefined') {
+          t = _pthread_self();
+        }
+        return 'w:' + (Module['workerID'] || 0) + ',t:' + ptrToString(t) + ': ';
+      }
+
+      // When PTHREAD_DEBUG is enabled, prefix all err() messages with the calling
+      // thread ID.
+      var origErr = err;
+      err = (message) => origErr(pthreadLogPrefix() + message);
+    },
+#endif
     init: function() {
+#if PTHREADS_DEBUG
+      PThread.debugInit();
+#endif
       if (ENVIRONMENT_IS_PTHREAD) {
         PThread.initWorker();
       } else {
@@ -186,7 +207,7 @@ var LibraryPThread = {
     // Called by worker.js each time a thread is started.
     threadInit: function() {
 #if PTHREADS_DEBUG
-      err('Pthread 0x' + _pthread_self().toString(16) + ' threadInit.');
+      err('threadInit.');
 #endif
       // Call thread init functions (these are the emscripten_tls_init for each
       // module loaded.
@@ -265,7 +286,7 @@ var LibraryPThread = {
         if (worker.pthread) {
           var pthread_ptr = worker.pthread.threadInfoStruct;
           if (pthread_ptr) {
-            message = 'Pthread 0x' + pthread_ptr.toString(16) + ' sent an error!';
+            message = 'Pthread ' + ptrToString(pthread_ptr) + ' sent an error!';
           }
         }
 #endif
@@ -323,6 +344,9 @@ var LibraryPThread = {
 #endif
 #if MAIN_MODULE
         'dynamicLibraries': Module['dynamicLibraries'],
+#endif
+#if PTHREADS_DEBUG
+        'workerID': PThread.nextWorkerID++,
 #endif
       });
     },
@@ -399,10 +423,14 @@ var LibraryPThread = {
     }
   },
 
+  $ptrToString: function(ptr) {
+    return '0x' + ptr.toString(16).padStart(8, '0');
+  },
+
   $killThread__deps: ['_emscripten_thread_free_data'],
   $killThread: function(pthread_ptr) {
 #if PTHREADS_DEBUG
-    err('killThread 0x' + pthread_ptr.toString(16));
+    err('killThread ' + ptrToString(pthread_ptr));
 #endif
 #if ASSERTIONS
     assert(!ENVIRONMENT_IS_PTHREAD, 'Internal Error! killThread() can only ever be called from main application thread!');
@@ -598,6 +626,9 @@ var LibraryPThread = {
       err('Current environment does not support SharedArrayBuffer, pthreads are not available!');
       return {{{ cDefine('EAGAIN') }}};
     }
+#if PTHREADS_DEBUG
+    err("createThread: " + ptrToString(pthread_ptr));
+#endif
 
     // List of JS objects that will transfer ownership to the Worker hosting the thread
     var transferList = [];
@@ -771,7 +802,7 @@ var LibraryPThread = {
     if (signal < 0 || signal >= 65/*_NSIG*/) return {{{ cDefine('EINVAL') }}};
     if (thread === _emscripten_main_browser_thread_id()) {
       if (signal == 0) return 0; // signal == 0 is a no-op.
-      err('Main thread (id=0x' + thread.toString(16) + ') cannot be killed with pthread_kill!');
+      err('Main thread (id=' + ptrToString(thread) + ') cannot be killed with pthread_kill!');
       return {{{ cDefine('ESRCH') }}};
     }
     if (!thread) {
@@ -780,7 +811,7 @@ var LibraryPThread = {
     }
     var self = {{{ makeGetValue('thread', C_STRUCTS.pthread.self, 'i32') }}};
     if (self !== thread) {
-      err('pthread_kill attempted on thread 0x' + thread.toString(16) + ', which does not point to a valid thread, or does not exist anymore!');
+      err('pthread_kill attempted on thread ' + ptrToString(thread) + ', which does not point to a valid thread, or does not exist anymore!');
       return {{{ cDefine('ESRCH') }}};
     }
     if (signal === {{{ cDefine('SIGCANCEL') }}}) { // Used by pthread_cancel in musl
@@ -800,14 +831,14 @@ var LibraryPThread = {
     if (!keepRuntimeAlive()) {
       // exitRuntime enabled, proxied main() finished in a pthread, shut down the process.
 #if PTHREADS_DEBUG
-      err('Proxied main thread 0x' + _pthread_self().toString(16) + ' finished with return code ' + returnCode + '. EXIT_RUNTIME=1 set, quitting process.');
+      err('Proxied main thread finished with return code ' + returnCode + '. EXIT_RUNTIME=1 set, quitting process.');
 #endif
       exitOnMainThread(returnCode);
     }
 #else
     // EXIT_RUNTIME==0 set on command line, keeping main thread alive.
 #if PTHREADS_DEBUG
-    err('Proxied main thread 0x' + _pthread_self().toString(16) + ' finished with return code ' + returnCode + '. EXIT_RUNTIME=0 set, so keeping main thread alive for asynchronous event operations.');
+    err('Proxied main thread finished with return code ' + returnCode + '. EXIT_RUNTIME=0 set, so keeping main thread alive for asynchronous event operations.');
 #endif
 #endif
   },
@@ -952,6 +983,9 @@ var LibraryPThread = {
   },
 
   $invokeEntryPoint: function(ptr, arg) {
+#if PTHREADS_DEBUG
+    err('invokeEntryPoint: ' + ptrToString(ptr));
+#endif
     return {{{ makeDynCall('ii', 'ptr') }}}(arg);
   },
 

--- a/src/worker.js
+++ b/src/worker.js
@@ -141,6 +141,10 @@ self.onmessage = (e) => {
 
       {{{ makeAsmImportsAccessInPthread('buffer') }}} = {{{ makeAsmImportsAccessInPthread('wasmMemory') }}}.buffer;
 
+#if PTHREADS_DEBUG
+      Module['workerID'] = e.data.workerID;
+#endif
+
 #if !MINIMAL_RUNTIME || MODULARIZE
       {{{ makeAsmImportsAccessInPthread('ENVIRONMENT_IS_PTHREAD') }}} = true;
 #endif


### PR DESCRIPTION
This avoids having to add rather cumbersome code at each logging call
site.

We do this only for stderr and not stdout to avoid messing with program
stdout.  Since we already inject stuff into stderr I think messaging
with stderr when `PTHREAD_DEBUG` is enabled is reasonable.

The output produced ends up looking like this:

```
$ node --experimental-wasm-threads --experimental-wasm-bulk-memory a.out.js
worker.js: loading module
w:0,t:0x00000dac: threadInit.
hello from main
ptr = 0x29
hello from side 0x28
w:0,t:0x00000dac: createThread: 0x005015a0
w:1,t:0x005015a0: threadInit.
w:1,t:0x005015a0: invokeEntryPoint: 0x00000028
```