### PR TITLE
Move initWorker call to library_pthread.js. NFC

### DIFF
--- a/src/postamble.js
+++ b/src/postamble.js
@@ -484,20 +484,6 @@ if (Module['noInitialRun']) shouldRunNow = false;
 
 #endif // HAS_MAIN
 
-#if USE_PTHREADS
-if (ENVIRONMENT_IS_PTHREAD) {
-  // The default behaviour for pthreads is always to exit once they return
-  // from their entry point (or call pthread_exit).  If we set noExitRuntime
-  // to true here on pthreads they would never complete and attempt to
-  // pthread_join to them would block forever.
-  // pthreads can still choose to set `noExitRuntime` explicitly, or
-  // call emscripten_unwind_to_js_event_loop to extend their lifetime beyond
-  // their main function.  See comment in src/worker.js for more.
-  noExitRuntime = false;
-  PThread.initWorker();
-}
-#endif
-
 run();
 
 #if BUILD_AS_WORKER

--- a/src/postamble_minimal.js
+++ b/src/postamble_minimal.js
@@ -60,13 +60,11 @@ function initRuntime(asm) {
 #endif
 
 #if USE_PTHREADS
-  // Export needed variables that worker.js needs to Module.
-  Module['HEAPU32'] = HEAPU32;
-  Module['__emscripten_thread_init'] = __emscripten_thread_init;
-  Module['_pthread_self'] = _pthread_self;
-
   if (ENVIRONMENT_IS_PTHREAD) {
-    PThread.initWorker();
+    // Export needed variables that worker.js needs to Module.
+    Module['HEAPU32'] = HEAPU32;
+    Module['__emscripten_thread_init'] = __emscripten_thread_init;
+    Module['_pthread_self'] = _pthread_self;
     return;
   }
 #endif


### PR DESCRIPTION
It seems cleaner to keep the callsite near to the definition
and it also increases consistency with initMainThread.