### PR TITLE
Use absolute path for --externs=foo.js arguments

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7957,15 +7957,6 @@ end
                        '--pre-js', test_file('test_closure_externs_pre_js.js')] +
                        args)
 
-  def test_closure_externs_one_arg(self):
-    # Test that if an externs file is specified with --externs=foo.js (e.g. when using Bazel),
-    # its absolute path is still used (otherwise the file will not be found).
-    shutil.copyfile(test_file('test_closure_externs.js'), 'local_externs.js')
-    self.run_process([EMCC, test_file('hello_world.c'),
-                      '--closure=1',
-                      '--pre-js', test_file('test_closure_externs_pre_js.js'),
-                      '--closure-args=--externs=local_externs.js'])
-
   # Tests that it is possible to enable the Closure compiler via --closure=1 even if any of the input files reside in a path with unicode characters.
   def test_closure_cmdline_utf8_chars(self):
     test = "☃ äö Ć € ' 🦠.c"

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7946,7 +7946,6 @@ end
     # Test with relocate path to the externs file to ensure that incoming relative paths
     # are translated correctly (Since closure runs with a different CWD)
     shutil.copyfile(test_file('test_closure_externs.js'), 'local_externs.js')
-    shutil.copyfile(test_file('test_closure_externs.js'), 'local_externs2.js')
     self.run_process([EMCC, test_file('hello_world.c'),
                       '--closure=1',
                       '--pre-js', test_file('test_closure_externs_pre_js.js'),

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7946,10 +7946,16 @@ end
     # Test with relocate path to the externs file to ensure that incoming relative paths
     # are translated correctly (Since closure runs with a different CWD)
     shutil.copyfile(test_file('test_closure_externs.js'), 'local_externs.js')
-    self.run_process([EMCC, test_file('hello_world.c'),
-                      '--closure=1',
-                      '--pre-js', test_file('test_closure_externs_pre_js.js'),
-                      '--closure-args', '--externs "local_externs.js"'])
+    test_cases = (
+      ['--closure-args', '--externs "local_externs.js"'],
+      ['--closure-args', '--externs=local_externs.js'],
+      ['--closure-args=--externs=local_externs.js'],
+    )
+    for args in test_cases:
+      self.run_process([EMCC, test_file('hello_world.c'),
+                       '--closure=1',
+                       '--pre-js', test_file('test_closure_externs_pre_js.js')] +
+                       args)
 
   def test_closure_externs_one_arg(self):
     # Test that if an externs file is specified with --externs=foo.js (e.g. when using Bazel),

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7953,9 +7953,9 @@ end
     )
     for args in test_cases:
       self.run_process([EMCC, test_file('hello_world.c'),
-                       '--closure=1',
-                       '--pre-js', test_file('test_closure_externs_pre_js.js')] +
-                       args)
+                        '--closure=1',
+                        '--pre-js', test_file('test_closure_externs_pre_js.js')] +
+                        args)
 
   # Tests that it is possible to enable the Closure compiler via --closure=1 even if any of the input files reside in a path with unicode characters.
   def test_closure_cmdline_utf8_chars(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7960,7 +7960,6 @@ end
                       '--pre-js', test_file('test_closure_externs_pre_js.js'),
                       '--closure-args=--externs=local_externs.js'])
 
-
   # Tests that it is possible to enable the Closure compiler via --closure=1 even if any of the input files reside in a path with unicode characters.
   def test_closure_cmdline_utf8_chars(self):
     test = "☃ äö Ć € ' 🦠.c"

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7946,10 +7946,21 @@ end
     # Test with relocate path to the externs file to ensure that incoming relative paths
     # are translated correctly (Since closure runs with a different CWD)
     shutil.copyfile(test_file('test_closure_externs.js'), 'local_externs.js')
+    shutil.copyfile(test_file('test_closure_externs.js'), 'local_externs2.js')
     self.run_process([EMCC, test_file('hello_world.c'),
                       '--closure=1',
                       '--pre-js', test_file('test_closure_externs_pre_js.js'),
                       '--closure-args', '--externs "local_externs.js"'])
+
+  def test_closure_externs_one_arg(self):
+    # Test that if an externs file is specified with --externs=foo.js (e.g. when using Bazel),
+    # its absolute path is still used (otherwise the file will not be found).
+    shutil.copyfile(test_file('test_closure_externs.js'), 'local_externs.js')
+    self.run_process([EMCC, test_file('hello_world.c'),
+                      '--closure=1',
+                      '--pre-js', test_file('test_closure_externs_pre_js.js'),
+                      '--closure-args=--externs=local_externs.js'])
+
 
   # Tests that it is possible to enable the Closure compiler via --closure=1 even if any of the input files reside in a path with unicode characters.
   def test_closure_cmdline_utf8_chars(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7955,7 +7955,7 @@ end
       self.run_process([EMCC, test_file('hello_world.c'),
                         '--closure=1',
                         '--pre-js', test_file('test_closure_externs_pre_js.js')] +
-                        args)
+                       args)
 
   # Tests that it is possible to enable the Closure compiler via --closure=1 even if any of the input files reside in a path with unicode characters.
   def test_closure_cmdline_utf8_chars(self):

--- a/tools/building.py
+++ b/tools/building.py
@@ -863,7 +863,19 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   # Specify input file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
   for e in CLOSURE_EXTERNS:
     args += ['--externs', e]
-  args += user_args
+  # Clients may specify extern files or js files like:
+  # --closure-args=--externs=user_externs.js
+  # We need to split this argument so the file stands alone as its own argument.
+  # This allows us to convert any relative path to an absolute path in run_closure_cmd.
+  for c in user_args:
+    if c.startswith('--externs='):
+      args.append('--externs')
+      args.append(c[len('--externs='):])
+    elif c.startswith('--js='):
+      args.append('--js')
+      args.append(c[len('--js='):])
+    else:
+      args.append(c)
 
   cmd = closure_cmd + args
   return run_closure_cmd(cmd, filename, env, pretty=pretty)

--- a/tools/building.py
+++ b/tools/building.py
@@ -863,19 +863,7 @@ def closure_compiler(filename, pretty, advanced=True, extra_closure_args=None):
   # Specify input file relative to the temp directory to avoid specifying non-7-bit-ASCII path names.
   for e in CLOSURE_EXTERNS:
     args += ['--externs', e]
-  # Clients may specify extern files or js files like:
-  # --closure-args=--externs=user_externs.js
-  # We need to split this argument so the file stands alone as its own argument.
-  # This allows us to convert any relative path to an absolute path in run_closure_cmd.
-  for c in user_args:
-    if c.startswith('--externs='):
-      args.append('--externs')
-      args.append(c[len('--externs='):])
-    elif c.startswith('--js='):
-      args.append('--js')
-      args.append(c[len('--js='):])
-    else:
-      args.append(c)
+  args += user_args
 
   cmd = closure_cmd + args
   return run_closure_cmd(cmd, filename, env, pretty=pretty)
@@ -896,8 +884,15 @@ def run_closure_cmd(cmd, filename, env, pretty):
     return os.path.relpath(safe_filename, tempfiles.tmpdir)
 
   for i in range(len(cmd)):
-    if cmd[i] == '--externs' or cmd[i] == '--js':
-      cmd[i + 1] = move_to_safe_7bit_ascii_filename(cmd[i + 1])
+    for prefix in ('--externs', '--js'):
+      # Handle the case where the the flag and the value are two separate arguments.
+      if cmd[i] == prefix:
+        cmd[i + 1] = move_to_safe_7bit_ascii_filename(cmd[i + 1])
+      # and the case where they are one argument, e.g. --externs=foo.js
+      elif cmd[i].startswith(prefix + '='):
+        # Replace the argument with a version that has a safe filename.
+        filename = cmd[i].split('=', 1)[1]
+        cmd[i] = '='.join([prefix, move_to_safe_7bit_ascii_filename(filename)])
 
   outfile = tempfiles.get('.cc.js').name  # Safe 7-bit filename
 


### PR DESCRIPTION
The equals sign is necessary when specifying arguments via Bazel, otherwise the externs file is treated as an input file.

This handles --js= also, for completeness.

See [#941](https://github.com/emscripten-core/emsdk/pull/941) for more.