### PR TITLE
embuilder with thin lto support

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -127,7 +127,8 @@ def main():
   parser = argparse.ArgumentParser(description=__doc__,
                                    formatter_class=argparse.RawDescriptionHelpFormatter,
                                    epilog=get_help())
-  parser.add_argument('--lto', action='store_true', help='build bitcode object for LTO')
+  parser.add_argument('--lto', action='store', choices=['full', 'thin'],  const='full', default='full', nargs='?',
+                      help='build bitcode object for LTO')
   parser.add_argument('--pic', action='store_true',
                       help='build relocatable objects for suitable for dynamic linking')
   parser.add_argument('--force', action='store_true',
@@ -151,7 +152,7 @@ def main():
   shared.check_sanity()
 
   if args.lto:
-    settings.LTO = "full"
+    settings.LTO = args.lto
 
   if args.verbose:
     shared.PRINT_STAGES = True


### PR DESCRIPTION
fix #16172

this is the minimal implementation using argparse I could think of. This is not perfect:

```
.\embuilder --lto build sdl2
embuilder.py: error: argument --lto: invalid choice: 'build' (choose from 'full', 'thin')

.\embuilder build sdl2 --lto
embuilder:INFO: ...success. Took (4.40s)
```