### PR TITLE
Ensure STACK_OVERFLOW_CHECK boundaries are set correctly with threading + dynamic linking

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,7 +384,7 @@ jobs:
       - run-tests:
           # also add a little select testing for wasm2js in -O3
           # also add a little select wasmfs testing
-          test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime"
+          test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink"
   test-wasm2js1:
     executor: bionic
     steps:

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -555,7 +555,7 @@ var LibraryDylink = {
           reportUndefinedSymbols();
         }
 #if STACK_OVERFLOW_CHECK >= 2
-        moduleExports['__set_stack_limits']({{{ STACK_BASE }}} , {{{ STACK_MAX }}});
+        moduleExports['__set_stack_limits'](_emscripten_stack_get_base(), _emscripten_stack_get_end())
 #endif
 
         // initialize the module
@@ -611,6 +611,18 @@ var LibraryDylink = {
     });
     return loadModule();
   },
+
+#if STACK_OVERFLOW_CHECK >= 2
+  $setDylinkStackLimits: function(stackTop, stackMax) {
+    for (var name in LDSO.loadedLibsByName) {
+#if DYLINK_DEBUG
+      err('setDylinkStackLimits[' + name + ']');
+#endif
+      var lib = LDSO.loadedLibsByName[name];
+      lib.module['__set_stack_limits'](stackTop, stackMax);
+    }
+  },
+#endif
 
   // loadDynamicLibrary loads dynamic library @ lib URL / path and returns
   // handle for loaded DSO.


### PR DESCRIPTION
The way STACK_OVERFLOW_CHECK works is that each wasm modules has two
extra binaryen-generated internal globals that need to set before running
any code in the module.  For pthreads, this means that each module has
to have its limits set each time we start a thread.