### PR TITLE
tests: Reduce usage of other.do_smart_test. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1111,7 +1111,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
               self.assertContained(o, js_output)
           else:
             self.assertContained(expected_output, js_output)
-            if check_for_error:
+            if assert_returncode == 0 and check_for_error:
               self.assertNotContained('ERROR', js_output)
         except Exception:
           print('(test did not pass in JS engine: %s)' % engine)


### PR DESCRIPTION
This change removes all the unnessary usage of this method.  It's only
need when regex's are used, otherwise it functions just like the
existing `do_runf`.

I'm hoping to remove this method completely as a followup since.  It now
only has two callsites.

I've also updated to_smart_test to honor the test-specific emcc
arguments (`self.emcc_args()`) for consistency with `do_runf` and all
its derivitives.