### PR TITLE
tests: Remove `do_smart_test` helper. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -15,6 +15,7 @@ import hashlib
 import logging
 import multiprocessing
 import os
+import re
 import shlex
 import shutil
 import stat
@@ -1064,6 +1065,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
                      assert_returncode=0, assert_identical=False, assert_all=False,
                      check_for_error=True, force_c=False, emcc_args=[],
                      interleaved_output=True,
+                     regex=False,
                      output_basename=None):
     logger.debug(f'_build_and_run: {filename}')
 
@@ -1106,11 +1108,18 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         try:
           if assert_identical:
             self.assertIdentical(expected_output, js_output)
-          elif assert_all:
+          elif assert_all or len(expected_output) == 1:
             for o in expected_output:
-              self.assertContained(o, js_output)
+              if regex:
+                self.assertTrue(re.search(o, js_output), 'Expected regex "%s" to match on:\n%s' % (regex, js_output))
+              else:
+                self.assertContained(o, js_output)
           else:
-            self.assertContained(expected_output, js_output)
+            if regex:
+              match_any = any(re.search(o, js_output) for o in expected_output)
+              self.assertTrue(match_any, 'Expected at least one of "%s" to match on:\n%s' % (expected_output, js_output))
+            else:
+              self.assertContained(expected_output, js_output)
             if assert_returncode == 0 and check_for_error:
               self.assertNotContained('ERROR', js_output)
         except Exception:


### PR DESCRIPTION
Add regex support to the existing `do_runf` to make this
helper redundant.

I had a need to using regexs in another PR and decided this
was a good way to make them universally available in tests.

Depends on #16181