### PR TITLE
webgl: Fix incorrect hooks

### DIFF
--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -570,6 +570,7 @@ var LibraryGL = {
         return ret;
       };
       glCtx['bufferData'] = function(a1, a2, a3, a4, a5) {
+          // WebGL1/2 versions have different parameters (not just extra ones)
           var ret = (a4 !== undefined) ? glCtx['real_bufferData'](a1, a2, a3, a4, a5) : glCtx['real_bufferData'](a1, a2, a3);
           return ret;
       };

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -573,6 +573,13 @@ var LibraryGL = {
           var ret = (a4 !== undefined) ? glCtx['real_bufferData'](a1, a2, a3, a4, a5) : glCtx['real_bufferData'](a1, a2, a3);
           return ret;
       };
+      const matrixFuncs = ['uniformMatrix2fv', 'uniformMatrix3fv', 'uniformMatrix4fv'];
+      for (const f of matrixFuncs) {
+          glCtx[f] = function(a1, a2, a3, a4, a5) {
+              // WebGL2 version has 2 extra optional parameters, ensure we forward them
+              return glCtx['real_' + f](a1, a2, a3, a4, a5);
+          }
+      }
     },
 #endif
     // Returns the context handle to the new context.

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -569,6 +569,10 @@ var LibraryGL = {
         var ret = (a9 !== undefined) ? glCtx['real_texSubImage3D'](a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11) : glCtx['real_texSubImage2D'](a1, a2, a3, a4, a5, a6, a7, a8);
         return ret;
       };
+      glCtx['bufferData'] = function(a1, a2, a3, a4, a5) {
+          var ret = (a4 !== undefined) ? glCtx['real_bufferData'](a1, a2, a3, a4, a5) : glCtx['real_bufferData'](a1, a2, a3);
+          return ret;
+      };
     },
 #endif
     // Returns the context handle to the new context.


### PR DESCRIPTION
This MR fixes a few hooks when enabling webgl calls tracing.

`bufferData` and `uniformMatrixXvf` take a different number of parameters depending on the webgl version being used. Without these patches the webgl1 flavor ends up being forced, which causes trouble since the parameters end up being shifted to different positions