### PR TITLE
html5_webgl.js: Expose the actual canvas instead of a wrapper object

### DIFF
--- a/src/library_html5_webgl.js
+++ b/src/library_html5_webgl.js
@@ -178,7 +178,7 @@ var LibraryHtml5WebGL = {
 #endif
           return 0;
         }
-        canvas = GL.offscreenCanvases[canvas.id];
+        canvas = GL.offscreenCanvases[canvas.id].canvas;
       }
     }
 #else // !OFFSCREENCANVAS_SUPPORT


### PR DESCRIPTION
When creating a context from an offscreen canvas, `canvas` is expected
to represent an actual canvas object while it was representing a wrapper
object