### PR TITLE
docs: fix code section in embind classes section

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -184,6 +184,8 @@ shown below:
 In order to prevent the closure compiler from renaming the symbols in the
 above example code it needs to be rewritten as follows:
 
+.. code:: javascript
+
    var instance = new Module["MyClass"](10, "hello");
    instance["incrementX"]();
    instance["x"]; // 11


### PR DESCRIPTION
Declare `code` block for proper code formatting (see https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#classes for current broken documentation render)