### PR TITLE
pthread+dylink: Ensure code is in sync on thread start

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2044,6 +2044,10 @@ def phase_linker_setup(options, state, newargs, settings_map):
       'emscripten_sync_run_in_main_thread_2',
       'emscripten_sync_run_in_main_thread_4',
     ]
+
+    if settings.MAIN_MODULE:
+      settings.REQUIRED_EXPORTS += ['_emscripten_thread_sync_code', '__dl_seterr']
+
     settings.DEFAULT_LIBRARY_FUNCS_TO_INCLUDE += [
       '$exitOnMainThread',
     ]

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -997,6 +997,12 @@ var LibraryPThread = {
 #if PTHREADS_DEBUG
     err('invokeEntryPoint: ' + ptrToString(ptr));
 #endif
+#if MAIN_MODULE
+    // Before we call the thread entry point, make sure any shared libraries
+    // have been loaded on this there.  Otherwise our table migth be not be
+    // in sync and might not contain the function pointer `ptr` at all.
+    __emscripten_thread_sync_code();
+#endif
     return {{{ makeDynCall('ii', 'ptr') }}}(arg);
   },
 

--- a/tests/core/pthread/test_pthread_dylink_entry_point.c
+++ b/tests/core/pthread/test_pthread_dylink_entry_point.c
@@ -1,0 +1,30 @@
+#include <stdio.h>
+#include <dlfcn.h>
+#include <pthread.h>
+
+typedef void* (*thread_main_t)(void*);
+
+int main() {
+  puts("hello from main");
+
+  void *lib_handle = dlopen("./liblib.so", RTLD_NOW);
+  if (!lib_handle) {
+    puts("cannot load side module");
+    puts(dlerror());
+    return 1;
+  }
+
+  thread_main_t tmain = (thread_main_t)dlsym(lib_handle, "side_module_thread_main");
+  if (!tmain) {
+    puts("cannot find side function");
+    return 1;
+  }
+
+  printf("starting thread with %p\n", tmain);
+  pthread_t t;
+  pthread_create(&t, NULL, tmain, (void*)"hello");
+  pthread_join(t, NULL);
+
+  printf("done\n");
+  return 0;
+}

--- a/tests/core/pthread/test_pthread_dylink_entry_point.out
+++ b/tests/core/pthread/test_pthread_dylink_entry_point.out
@@ -1,0 +1,1 @@
+call thread fn in side: hello

--- a/tests/core/pthread/test_pthread_dylink_entry_point_side.c
+++ b/tests/core/pthread/test_pthread_dylink_entry_point_side.c
@@ -1,0 +1,8 @@
+#include <stdio.h>
+#include <emscripten.h>
+#include <pthread.h>
+
+EMSCRIPTEN_KEEPALIVE void* side_module_thread_main(void* arg) {
+  printf("call thread fn in side: %s\n", (char*)arg);
+  return NULL;
+}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8681,6 +8681,20 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.dylink_testf(main, so_name=very_long_name,
                       need_reverse=False)
 
+  @parameterized({
+    '': (['-sNO_AUTOLOAD_DYLIBS'],),
+    'autoload': ([],)
+  })
+  @needs_dylink
+  @node_pthreads
+  def test_pthread_dylink_entry_point(self, args):
+    self.emcc_args.append('-Wno-experimental')
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('USE_PTHREADS')
+    self.set_setting('PTHREAD_POOL_SIZE', 1)
+    main = test_file('core/pthread/test_pthread_dylink_entry_point.c')
+    self.dylink_testf(main, need_reverse=False, emcc_args=args)
+
   @needs_dylink
   @node_pthreads
   def test_pthread_dlopen(self):


### PR DESCRIPTION
We still don't have a great way to keep threads in sync but this
at least means they will be correct at the moment the start.

Part of #3494.

Fixes: #16021