### PR TITLE
 Fix more closure compiler warnings

### DIFF
--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -71,8 +71,9 @@ var WebAssembly = {};
 /**
  * @constructor
  * @param {Object} globalDescriptor
+ * @param {*=} value
  */
-WebAssembly.Global = function(globalDescriptor) {};
+WebAssembly.Global = function(globalDescriptor, value) {};
 /**
  * @constructor
  * @param {Object} tagDescriptor

--- a/src/closure-externs/node-externs.js
+++ b/src/closure-externs/node-externs.js
@@ -80,13 +80,13 @@ var fs;
 var Buffer = function(var_args) {};
 
 /**
- * @param {ArrayBuffer|SharedArrayBuffer} arrayBuffer
- * @param {number=} byteOffset
+ * @param {ArrayBuffer|SharedArrayBuffer|string} arrayBufferOrString
+ * @param {number|string=} byteOffsetOrEncoding
  * @param {number=} length
  * @return {nodeBuffer.Buffer}
  * @nosideeffects
  */
-Buffer.from = function(arrayBuffer, byteOffset, length) {};
+Buffer.from = function(arrayBufferOrString, byteOffsetOrEncoding, length) {};
 
 /**
  * @param {number} size

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -252,7 +252,7 @@ var LibraryBrowser = {
           // loadWebAssemblyModule can not load modules out-of-order, so rather
           // than just running the promises in parallel, this makes a chain of
           // promises to run in series.
-          this['asyncWasmLoadPromise'] = this['asyncWasmLoadPromise'].then(
+          wasmPlugin['asyncWasmLoadPromise'] = wasmPlugin['asyncWasmLoadPromise'].then(
             function() {
               return loadWebAssemblyModule(byteArray, {loadAsync: true, nodelete: true});
             }).then(

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -132,6 +132,7 @@ var LibraryDylink = {
   // Applies relocations to exported things.
   $relocateExports__internal: true,
   $relocateExports__deps: ['$updateGOT'],
+  $relocateExports__docs: '/** @param {boolean=} replace */',
   $relocateExports: function(exports, memoryBase, replace) {
     var relocated = {};
 
@@ -174,6 +175,7 @@ var LibraryDylink = {
         err('assigning dynamic symbol from main module: ' + symName + ' -> ' + prettyPrint(value));
 #endif
         if (typeof value === 'function') {
+          /** @suppress {checkTypes} */
           GOT[symName].value = addFunction(value, value.sig);
 #if DYLINK_DEBUG
           err('assigning table entry for : ' + symName + ' -> ' + GOT[symName].value);
@@ -295,6 +297,7 @@ var LibraryDylink = {
       return UTF8ArrayToString(binary, offset - len, len);
     }
 
+    /** @param {string=} message */
     function failIf(condition, message) {
       if (condition) throw new Error(message);
     }
@@ -336,8 +339,8 @@ var LibraryDylink = {
       // WebAssembly.make_shared_library() for "dylink" section extension format)
       var neededDynlibsCount = getLEB();
       for (var i = 0; i < neededDynlibsCount; ++i) {
-        var name = getString();
-        customSection.neededDynlibs.push(name);
+        var libname = getString();
+        customSection.neededDynlibs.push(libname);
       }
     } else {
       failIf(name !== 'dylink.0');
@@ -356,16 +359,16 @@ var LibraryDylink = {
         } else if (subsectionType === WASM_DYLINK_NEEDED) {
           var neededDynlibsCount = getLEB();
           for (var i = 0; i < neededDynlibsCount; ++i) {
-            var name = getString();
-            customSection.neededDynlibs.push(name);
+            libname = getString();
+            customSection.neededDynlibs.push(libname);
           }
         } else if (subsectionType === WASM_DYLINK_EXPORT_INFO) {
           var count = getLEB();
           while (count--) {
-            var name = getString();
+            var symname = getString();
             var flags = getLEB();
             if (flags & WASM_SYMBOL_TLS) {
-              customSection.tlsExports[name] = 1;
+              customSection.tlsExports[symname] = 1;
             }
           }
         } else {
@@ -429,6 +432,7 @@ var LibraryDylink = {
 
   // Loads a side module from binary data or compiled Module. Returns the module's exports or a
   // promise that resolves to its exports if the loadAsync flag is set.
+  $loadWebAssemblyModule__docs: '/** @param {number=} handle */',
   $loadWebAssemblyModule__deps: [
     '$loadDynamicLibrary', '$createInvokeFunction', '$getMemory',
     '$relocateExports', '$resolveGlobalSymbol', '$GOTHandler',
@@ -528,7 +532,7 @@ var LibraryDylink = {
           if (!(prop in stubs)) {
             var resolved;
             stubs[prop] = function() {
-              if (!resolved) resolved = resolveSymbol(prop, true);
+              if (!resolved) resolved = resolveSymbol(prop);
               return resolved.apply(null, arguments);
             };
           }
@@ -646,6 +650,7 @@ var LibraryDylink = {
   // flags.global and flags.nodelete are handled every time a load request is made.
   // Once a library becomes "global" or "nodelete", it cannot be removed or unloaded.
   $loadDynamicLibrary__deps: ['$LDSO', '$loadWebAssemblyModule', '$asmjsMangle', '$isInternalSym', '$mergeLibSymbols'],
+  $loadDynamicLibrary__docs: '/** @param {number=} handle */',
   $loadDynamicLibrary: function(lib, flags, handle) {
 #if DYLINK_DEBUG
     err('loadDynamicLibrary: ' + lib + ' handle:' + handle);
@@ -881,6 +886,7 @@ var LibraryDylink = {
   ],
   _emscripten_dlopen_js__sig: 'viiiii',
   _emscripten_dlopen_js: function(handle, onsuccess, onerror) {
+    /** @param {Object=} e */
     function errorCallback(e) {
       var filename = UTF8ToString({{{ makeGetValue('handle', C_STRUCTS.dso.name, '*') }}});
       dlSetError('Could not load dynamic lib: ' + filename + '\n' + e);

--- a/src/library_html5_webgpu.js
+++ b/src/library_html5_webgpu.js
@@ -71,7 +71,6 @@ var LibraryHTML5WebGPU = {
 
 {{{ html5_gpu.makeImportExport('device', 'Device') }}}
 {{{ html5_gpu.makeImportExport('queue', 'Queue') }}}
-{{{ html5_gpu.makeImportExport('fence', 'Fence') }}}
 
 {{{ html5_gpu.makeImportExport('command_buffer', 'CommandBuffer') }}}
 {{{ html5_gpu.makeImportExport('command_encoder', 'CommandEncoder') }}}

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -26,7 +26,7 @@
   global.gpu = {
     makeInitManager: function(type) {
       var mgr = 'WebGPU.mgr' + type
-      return mgr + ' = ' + mgr + ' || makeManager();';
+      return mgr + ' = ' + mgr + ' || new Manager();';
     },
 
     makeReferenceRelease: function(type) {
@@ -147,40 +147,39 @@ var LibraryWebGPU = {
     initManagers: function() {
       if (WebGPU.mgrDevice) return;
 
-      function makeManager() {
-        return {
-          objects: {},
-          nextId: 1,
-          create: function(object, wrapper /* = {} */) {
-            wrapper = wrapper || {};
+      /** @constructor */
+      function Manager() {
+        this.objects = {};
+        this.nextId = 1;
+        this.create = function(object, wrapper /* = {} */) {
+          wrapper = wrapper || {};
 
-            var id = this.nextId++;
-            {{{ gpu.makeCheck("typeof this.objects[id] === 'undefined'") }}}
-            wrapper.refcount = 1;
-            wrapper.object = object;
-            this.objects[id] = wrapper;
-            return id;
-          },
-          get: function(id) {
-            if (!id) return undefined;
-            var o = this.objects[id];
-            {{{ gpu.makeCheckDefined('o') }}}
-            return o.object;
-          },
-          reference: function(id) {
-            var o = this.objects[id];
-            {{{ gpu.makeCheckDefined('o') }}}
-            o.refcount++;
-          },
-          release: function(id) {
-            var o = this.objects[id];
-            {{{ gpu.makeCheckDefined('o') }}}
-            {{{ gpu.makeCheck('o.refcount > 0') }}}
-            o.refcount--;
-            if (o.refcount <= 0) {
-              delete this.objects[id];
-            }
-          },
+          var id = this.nextId++;
+          {{{ gpu.makeCheck("typeof this.objects[id] === 'undefined'") }}}
+          wrapper.refcount = 1;
+          wrapper.object = object;
+          this.objects[id] = wrapper;
+          return id;
+        };
+        this.get = function(id) {
+          if (!id) return undefined;
+          var o = this.objects[id];
+          {{{ gpu.makeCheckDefined('o') }}}
+          return o.object;
+        };
+        this.reference = function(id) {
+          var o = this.objects[id];
+          {{{ gpu.makeCheckDefined('o') }}}
+          o.refcount++;
+        };
+        this.release = function(id) {
+          var o = this.objects[id];
+          {{{ gpu.makeCheckDefined('o') }}}
+          {{{ gpu.makeCheck('o.refcount > 0') }}}
+          o.refcount--;
+          if (o.refcount <= 0) {
+            delete this.objects[id];
+          }
         };
       }
 

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -124,8 +124,11 @@ function updateTableMap(offset, count) {
   }
 }
 
-// Add a function to the table.
-// 'sig' parameter is required if the function being added is a JS function.
+/**
+ * Add a function to the table.
+ * 'sig' parameter is required if the function being added is a JS function.
+ * @param {string=} sig
+ */
 function addFunction(func, sig) {
 #if ASSERTIONS
   assert(typeof func !== 'undefined');

--- a/src/shell.js
+++ b/src/shell.js
@@ -26,6 +26,7 @@
 var /** @type {{
   noImageDecoding: boolean,
   noAudioDecoding: boolean,
+  noWasmDecoding: boolean,
   canvas: HTMLCanvasElement,
   dataFileDownloads: Object,
   preloadResults: Object

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -7934,17 +7934,23 @@ end
     # We must ignore various types of errors that are expected in this situation, as we
     # are including a lot of JS without corresponding compiled code for it. This still
     # lets us catch all other errors.
-    self.run_process([EMCC, test_file('hello_world.c'), '-O1', '-g1',
-                      '--closure=1',
-                      '-sCLOSURE_WARNINGS=error',
-                      '-sINCLUDE_FULL_LIBRARY'])
+    self.build(test_file('hello_world.c'), emcc_args=[
+      '-O1', '-g1',
+      '--closure=1',
+      '-sCLOSURE_WARNINGS=error',
+      '-sINCLUDE_FULL_LIBRARY',
+      '-sMAIN_MODULE'
+    ])
 
   def test_closure_webgpu(self):
     # This test can be removed if USE_WEBGPU is later included in INCLUDE_FULL_LIBRARY.
-    self.run_process([EMCC, test_file('hello_world.c'), '-O1', '-g1',
-                      '--closure=1',
-                      '-sINCLUDE_FULL_LIBRARY',
-                      '-sUSE_WEBGPU'])
+    self.build(test_file('hello_world.c'), emcc_args=[
+      '-O1', '-g1',
+      '--closure=1',
+      '-sCLOSURE_WARNINGS=error',
+      '-sINCLUDE_FULL_LIBRARY',
+      '-sUSE_WEBGPU'
+    ])
 
   # Tests --closure-args command line flag
   def test_closure_externs(self):


### PR DESCRIPTION
This change adds `-sCLOSURE_WARNINGS=error` to our full library
tests and fixes all the resulting closure warnings.

See #12728