### PR TITLE
[docs] embind.rst: Fix code indentation

### DIFF
--- a/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
+++ b/site/source/docs/porting/connecting_cpp_and_javascript/embind.rst
@@ -299,10 +299,10 @@ Consider the example below:
         int age;
     };
 
-	// Array fields are treated as if they were std::array<type,size>
-	struct ArrayInStruct {
-		int field[2];
-	};
+    // Array fields are treated as if they were std::array<type,size>
+    struct ArrayInStruct {
+        int field[2];
+    };
 
     PersonRecord findPersonAtLocation(Point2f);
 
@@ -317,15 +317,15 @@ Consider the example below:
             .field("age", &PersonRecord::age)
             ;
 
-		value_object<ArrayInStruct>("ArrayInStruct")
-			.field("field", &ArrayInStruct::field) // Need to register the array type
-			;
+	value_object<ArrayInStruct>("ArrayInStruct")
+            .field("field", &ArrayInStruct::field) // Need to register the array type
+            ;
 
-		// Register std::array<int, 2> because ArrayInStruct::field is interpreted as such
-		value_array<std::array<int, 2>>("array_int_2")
-			.element(index<0>())
-			.element(index<1>())
-			;
+	// Register std::array<int, 2> because ArrayInStruct::field is interpreted as such
+	value_array<std::array<int, 2>>("array_int_2")
+            .element(index<0>())
+            .element(index<1>())
+            ;
 
         function("findPersonAtLocation", &findPersonAtLocation);
     }


### PR DESCRIPTION
Probably should've noticed this earlier and included it into https://github.com/emscripten-core/emscripten/pull/16194

Current rendered section: https://emscripten.org/docs/porting/connecting_cpp_and_javascript/embind.html#value-types