### PR TITLE
Fix crash due to accessing GLFW.lastGamepadState.length when it is null

### DIFF
--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -637,13 +637,13 @@ var LibraryGLFW = {
     },
 
     joys: {}, // glfw joystick data
-    lastGamepadState: null,
+    lastGamepadState: [],
     lastGamepadStateFrame: null, // The integer value of Browser.mainLoop.currentFrameNumber of when the last gamepad state was produced.
 
     refreshJoysticks: function() {
       // Produce a new Gamepad API sample if we are ticking a new game frame, or if not using emscripten_set_main_loop() at all to drive animation.
       if (Browser.mainLoop.currentFrameNumber !== GLFW.lastGamepadStateFrame || !Browser.mainLoop.currentFrameNumber) {
-        GLFW.lastGamepadState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : null);
+        GLFW.lastGamepadState = navigator.getGamepads ? navigator.getGamepads() : (navigator.webkitGetGamepads ? navigator.webkitGetGamepads : []);
         GLFW.lastGamepadStateFrame = Browser.mainLoop.currentFrameNumber;
 
         for (var joy = 0; joy < GLFW.lastGamepadState.length; ++joy) {


### PR DESCRIPTION
The value of `GLFW.lastGamepadState` should default to an empty array (instead of `null`) when the Gamepad API is not available. Otherwise, the for loop below will crash due to accessing `GLFW.lastGamepadState.length`, i.e. `null.length`.