### PR TITLE
Move wasm64 out of core test modes, so it's not run randomly

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -60,7 +60,6 @@ core_test_modes = [
   'wasm2js3',
   'wasm2jss',
   'wasm2jsz',
-  'wasm64'
 ]
 
 # The default core test mode, used when none is specified
@@ -81,6 +80,7 @@ non_core_test_modes = [
   'posixtest_browser',
   'minimal0',
   'wasmfs',
+  'wasm64',
 ]
 
 


### PR DESCRIPTION
In core, it gets run in random test choices (`./tests/runner.py random100` etc.)
and many of those tests still fail.