### PR TITLE
Fix for exception handling + WASM_BIGINT.

### DIFF
--- a/tests/core/test_i64_invoke_bigint.cpp
+++ b/tests/core/test_i64_invoke_bigint.cpp
@@ -1,4 +1,3 @@
-
 #include <emscripten.h>
 #include <stdio.h>
 #include <stdint.h>
@@ -15,15 +14,19 @@ int64_t foobar(int64_t x, int y) {
   }
   return x + y; // use the int parameter too, to show they are all handled
 }
-  
+
 int main() {
   int64_t x;
   try {
     puts("try");
     x = foobar(big, 1);
-  } catch(int) {
-    puts("caught");
+    printf("ok: 0x%llx.\n", x);
+    x = foobar(1337, 1);
+    printf("should not get here\n");
+    __builtin_trap();
+  } catch(int e) {
+    printf("caught: %d\n", e);
   }
-  printf("ok: 0x%llx.\n", x);
+  printf("done");
+  return 0;
 }
-

--- a/tests/core/test_i64_invoke_bigint.out
+++ b/tests/core/test_i64_invoke_bigint.out
@@ -1,2 +1,3 @@
 try
 ok: 0x12345678aabbccde.
+caught: 1

--- a/tools/js_manipulation.py
+++ b/tools/js_manipulation.py
@@ -115,6 +115,10 @@ def make_invoke(sig):
   legal_sig = legalize_sig(sig) # TODO: do this in extcall, jscall?
   args = ['index'] + ['a' + str(i) for i in range(1, len(legal_sig))]
   ret = 'return ' if sig[0] != 'v' else ''
+  # For function that needs to return a genuine i64 (i.e. if legal_sig[0] is 'j')
+  # we need to return an actual BigInt, even in the exceptional case because
+  # wasm won't implicitly convert undefined to 0 in this case.
+  exceptional_ret = '\n    return BigInt(0);' if legal_sig[0] == 'j' else ''
   body = '%s%s;' % (ret, make_dynCall(sig, args))
   # C++ exceptions are numbers, and longjmp is a string 'longjmp'
   if settings.SUPPORT_LONGJMP:
@@ -130,8 +134,8 @@ function invoke_%s(%s) {
   } catch(e) {
     stackRestore(sp);
     %s
-    _setThrew(1, 0);
+    _setThrew(1, 0);%s
   }
-}''' % (sig, ','.join(args), body, rethrow)
+}''' % (sig, ','.join(args), body, rethrow, exceptional_ret)
 
   return ret


### PR DESCRIPTION
When WASM_BIGINT is enabled and a function that returns a BigInt
throws an exception we need to generate a valid return value.  For
normal (non-BitInt) types simply not returning anything at all works
because undefined gets implicitly coerced to zero.

Fixes: #15974