### PR TITLE
Fix wasmfs.test_wrap_malloc

### DIFF
--- a/tests/dlmalloc_test.c
+++ b/tests/dlmalloc_test.c
@@ -8,7 +8,7 @@
 // Emscripten tests
 
 #include <assert.h>
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <stdlib.h>
 
 int main(int ac, char **av)
@@ -45,5 +45,5 @@ int main(int ac, char **av)
     c1 += first == last;
     c2 += first == newer;
   }
-  emscripten_log(EM_LOG_CONSOLE, "*%d,%d*\n", c1, c2);
+  emscripten_console_logf("*%d,%d*\n", c1, c2);
 }

--- a/tests/wrap_malloc.cpp
+++ b/tests/wrap_malloc.cpp
@@ -4,7 +4,7 @@
 // found in the LICENSE file.
 
 #include <assert.h>
-#include <emscripten.h>
+#include <emscripten/console.h>
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -21,7 +21,7 @@ void * __attribute__((noinline)) malloc(size_t size)
 {
 	++totalAllocated;
 	void *ptr = emscripten_builtin_malloc(size);
-	emscripten_log(EM_LOG_CONSOLE, "Allocated %zu bytes, got %d. %d pointers allocated total.\n", size, ptr, totalAllocated);
+	emscripten_console_logf("Allocated %zu bytes, got %p. %d pointers allocated total.\n", size, ptr, totalAllocated);
 	return ptr;
 }
 
@@ -29,7 +29,7 @@ void __attribute__((noinline)) free(void *ptr)
 {
 	++totalFreed;
 	emscripten_builtin_free(ptr);
-	emscripten_log(EM_LOG_CONSOLE, "Freed ptr %p, %d pointers freed total.\n", ptr, totalFreed);
+	emscripten_console_logf("Freed ptr %p, %d pointers freed total.\n", ptr, totalFreed);
 }
 
 }
@@ -51,8 +51,8 @@ int main()
 		out = ptr;
 		free(ptr);
 	}
-	emscripten_log(EM_LOG_CONSOLE, "totalAllocated: %d\n", totalAllocated);
+	emscripten_console_logf("totalAllocated: %d\n", totalAllocated);
 	assert(totalAllocated == 20);
-	emscripten_log(EM_LOG_CONSOLE, "OK.\n");
+	emscripten_console_logf("OK.\n");
 	return 0;
 }


### PR DESCRIPTION
1. WasmFS does malloc/free during startup. Ignore allocations at that time.
2. Avoid printf for logging, as WasmFS's printf can allocate.

I wonder if we should perhaps consider malloc/free during startup a bug and work to fix it? It is difficult to see how, though, with preloading and embedding of files...