### PR TITLE
Don't strip all non-debug sections from separate-dwarf file

### DIFF
--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8320,9 +8320,9 @@ int main() {
       # https://github.com/emscripten-core/emscripten/issues/13084)
       if sec.name and sec.name != 'name' and not sec.name.startswith('.debug'):
         self.fail(f'non-debug section "{sec.name}" found in separate dwarf file')
-    shared.PRINT_STAGES = True
+
     # Check that dwarfdump can dump the debug info
-    dwdump = shared.check_call(
+    dwdump = self.run_process(
         [LLVM_DWARFDUMP, 'subdir/output.wasm.debug.wasm', '-name', 'main'],
         stdout=PIPE).stdout
     # Basic check that the debug info is more than a skeleton. If so it will

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8330,7 +8330,6 @@ int main() {
     self.assertIn('DW_TAG_subprogram', dwdump)
     self.assertIn('DW_AT_name\t("main")', dwdump)
 
-
   def test_split_dwarf_dwp(self):
     self.run_process([EMCC, test_file('hello_world.c'), '-g', '-gsplit-dwarf'])
     self.assertExists('a.out.wasm')

--- a/tools/building.py
+++ b/tools/building.py
@@ -1248,10 +1248,6 @@ def emit_debug_on_side(wasm_file, wasm_file_with_dwarf):
   shutil.move(wasm_file, wasm_file_with_dwarf)
   strip(wasm_file_with_dwarf, wasm_file, debug=True)
 
-  # Strip the non-debug sections out of the DWARF file
-  check_call([LLVM_OBJCOPY, wasm_file_with_dwarf, '--only-keep-debug',
-              '--keep-section', 'name'])
-
   # embed a section in the main wasm to point to the file with external DWARF,
   # see https://yurydelendik.github.io/webassembly-dwarf/#external-DWARF
   section_name = b'\x13external_debug_info' # section name, including prefixed size


### PR DESCRIPTION
When LLVM tools such as llvm-dwp and llvm-dwarfdump parse debug info,
they use information from the wasm known sections (such as function
indices) to parse and verify the debug info. This means that #16110
broke use of these tools on separate-dwarf files.

This is basically a revert of #16110 except that it adds tests of
dwp and dwarfdump running on separate-dwarf and split-dwarf files.
We should actually solve #13084 again by stripping out just the code
section (instead of all known sections) but llvm-objdump currently doesn't
know how to do that (it only handles named custom sections currently).
So this PR reopens #13084