### PR TITLE
Attempt to work around Firefox CI issue. See #16242

### DIFF
--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -3191,11 +3191,23 @@ var LibrarySDL = {
     try {
       var offscreenCanvas = new OffscreenCanvas(0, 0);
       SDL.ttfContext = offscreenCanvas.getContext('2d');
+      // Firefox support for OffscreenCanvas is still experimental, and it seems
+      // like CI might be creating a context here but one that is not entirely
+      // valid. Check that explicitly and fall back to a plain Canvas if we need
+      // to. See https://github.com/emscripten-core/emscripten/issues/16242
+      if (typeof SDL.ttfContext.measureText !== 'function') {
+        throw 'bad context';
+      }
     } catch (ex) {
       var canvas = document.createElement('canvas');
       SDL.ttfContext = canvas.getContext('2d');
     }
-
+#if ASSERTIONS
+    // Check the final context looks valid. See
+    // https://github.com/emscripten-core/emscripten/issues/16242
+    assert(typeof SDL.ttfContext.measureText === 'function',
+           'context ' + SDL.ttfContext + 'must provide valid methods');
+#endif
     return 0;
   },
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2205,7 +2205,7 @@ void *getBindBuffer() {
     self.btest('sdl_ttf_render_text_solid.c', reference='sdl_ttf_render_text_solid.png', args=['-O2', '-sINITIAL_MEMORY=16MB', '-lSDL', '-lGL'])
 
   def test_sdl_alloctext(self):
-    self.btest('sdl_alloctext.c', expected='1', args=['-O2', '-sINITIAL_MEMORY=16MB', '-lSDL', '-lGL'])
+    self.btest('sdl_alloctext.c', expected='1', args=['-sINITIAL_MEMORY=16MB', '-lSDL', '-lGL'])
 
   def test_sdl_surface_refcount(self):
     self.btest('sdl_surface_refcount.c', args=['-lSDL'], expected='1')


### PR DESCRIPTION
I can't reproduce the issue locally, but this change got the test to pass on CI,
so I suspect the theory in #16242 is right: Firefox Dev now creates invalid
OffscreenCanvas elements in some cases. That happens on our CI, but not
locally even with the same flags, so it might be dependent on the OS or the
graphics backend or otherwise affect how Firefox creates the context. The
effect is that an OffscreenCanvas is created, but it lacks methods on the
object. To work around it, check for a valid method appearing on the object,
and if it's not there, use a normal (non-offscreen) Canvas.

Also add an assertion, which is mostly not needed assuming the workaround
is valid, but may help in the future.

Also remove `-O2` in the test, which was not necessary for any reason (and it
happens to disable assertions).