### PR TITLE
Disable the new browser.test_wasmfs_fetch_backend_main_thread in Firefox

### DIFF
--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5179,6 +5179,7 @@ window.close = function() {
     test(['-sMALLOC=emmalloc-memvalidate'])
     test(['-sMALLOC=emmalloc-memvalidate-verbose'])
 
+  @no_firefox('hangs on the main_thread version. TODO: browser bug?')
   @parameterized({
     # the fetch backend works even on the main thread: we proxy to a background
     # thread and busy-wait

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5179,7 +5179,6 @@ window.close = function() {
     test(['-sMALLOC=emmalloc-memvalidate'])
     test(['-sMALLOC=emmalloc-memvalidate-verbose'])
 
-  @no_firefox('hangs on the main_thread version. TODO: browser bug?')
   @parameterized({
     # the fetch backend works even on the main thread: we proxy to a background
     # thread and busy-wait
@@ -5189,6 +5188,8 @@ window.close = function() {
   })
   @requires_threads
   def test_wasmfs_fetch_backend(self, args):
+    if is_firefox() and '-sPROXY_TO_PTHREAD' not in args:
+      return self.skipTest('ff hangs on the main_thread version. browser bug?')
     create_file('data.dat', 'hello, fetch')
     self.btest_exit(test_file('wasmfs/wasmfs_fetch.c'),
                     args=['-sWASMFS', '-sUSE_PTHREADS'] + args)


### PR DESCRIPTION
By a sad coincidence, this was not tested before landing because of the
other Firefox issue with `sdl_alloctext` (which has since been worked
around), and so this landed without us noticing it worked on Chrome but
not on Firefox. After some time attempting to debug it, my best guess is
a browser bug, but it's hard to tell. In any case, the entire WasmFS fetch
backend is WIP and we may want to remove these tests eventually; for
now just unbreak CI by disabling it.