### PR TITLE
Move `allocate()` js runtime function to runtime_legacy.js.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -20,6 +20,10 @@ See docs/process.md for more on how version tagging works.
 
 3.1.4
 -----
+- Emscripten no longer uses the `allocate()` runtime function.  For backwards
+  compatabiliy with external JS code we still include this function by default
+  but it will no longer be included in `-sSTRICT` mode.  Usages of this function
+  are generally best replaced with `_malloc`, `stackAlloc` or `allocateUTF8`.
 - Due to an llvm change (https://reviews.llvm.org/D118573) some clang flags
   that did not previously have any effect are now honored (e.g.
   `-fnew-alignment` and `-fshort-wchar`).

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -203,38 +203,9 @@ function _free() {
 #endif // free
 #endif // ASSERTIONS
 
-var ALLOC_NORMAL = 0; // Tries to use _malloc()
-var ALLOC_STACK = 1; // Lives for the duration of the current function call
-
-/**
- * allocate(): This function is no longer used by emscripten but is kept around to avoid
- *             breaking external users.
- *             You should normally not use allocate(), and instead allocate
- *             memory using _malloc()/stackAlloc(), initialize it with
- *             setValue(), and so forth.
- * @param {(Uint8Array|Array<number>)} slab: An array of data.
- * @param {number=} allocator : How to allocate memory, see ALLOC_*
- */
-function allocate(slab, allocator) {
-  var ret;
-#if ASSERTIONS
-  assert(typeof allocator === 'number', 'allocate no longer takes a type argument')
-  assert(typeof slab !== 'number', 'allocate no longer takes a number as arg0')
+#if !STRICT
+#include "runtime_legacy.js"
 #endif
-
-  if (allocator == ALLOC_STACK) {
-    ret = stackAlloc(slab.length);
-  } else {
-    ret = {{{ makeMalloc('allocate', 'slab.length') }}};
-  }
-
-  if (!slab.subarray && !slab.slice) {
-    slab = new Uint8Array(slab);
-  }
-  HEAPU8.set(slab, ret);
-  return ret;
-}
-
 #include "runtime_strings.js"
 #include "runtime_strings_extra.js"
 

--- a/src/runtime_legacy.js
+++ b/src/runtime_legacy.js
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2010 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+var ALLOC_NORMAL = 0; // Tries to use _malloc()
+var ALLOC_STACK = 1; // Lives for the duration of the current function call
+
+/**
+ * allocate(): This function is no longer used by emscripten but is kept around to avoid
+ *             breaking external users.
+ *             You should normally not use allocate(), and instead allocate
+ *             memory using _malloc()/stackAlloc(), initialize it with
+ *             setValue(), and so forth.
+ * @param {(Uint8Array|Array<number>)} slab: An array of data.
+ * @param {number=} allocator : How to allocate memory, see ALLOC_*
+ */
+function allocate(slab, allocator) {
+  var ret;
+#if ASSERTIONS
+  assert(typeof allocator === 'number', 'allocate no longer takes a type argument')
+  assert(typeof slab !== 'number', 'allocate no longer takes a number as arg0')
+#endif
+
+  if (allocator == ALLOC_STACK) {
+    ret = stackAlloc(slab.length);
+  } else {
+    ret = {{{ makeMalloc('allocate', 'slab.length') }}};
+  }
+
+  if (!slab.subarray && !slab.slice) {
+    slab = new Uint8Array(slab);
+  }
+  HEAPU8.set(slab, ret);
+  return ret;
+}

--- a/tests/other/test_legacy_runtime.c
+++ b/tests/other/test_legacy_runtime.c
@@ -1,0 +1,10 @@
+#include <stdio.h>
+#include <emscripten/em_asm.h>
+
+int main () {
+  intptr_t addr = EM_ASM_INT({
+     return allocate(intArrayFromString("hello from js"), ALLOC_NORMAL);
+  });
+  printf("%s\n", (char*)addr);
+  return 0;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11629,3 +11629,9 @@ void foo() {}
 
   def test_stdint_limits(self):
     self.do_other_test('test_stdint_limits.c')
+
+  def test_legacy_runtime(self):
+    self.set_setting('EXPORTED_FUNCTIONS', ['_malloc', '_main'])
+    self.do_runf(test_file('other/test_legacy_runtime.c'), 'hello from js')
+    self.set_setting('STRICT')
+    self.do_runf(test_file('other/test_legacy_runtime.c'), 'ReferenceError: allocate is not defined', assert_returncode=NON_ZERO)


### PR DESCRIPTION
We no longer use this function internally.