### PR TITLE
CMake Toolkit: Shared Library as Side Module

### DIFF
--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -18,7 +18,12 @@ set(CMAKE_SYSTEM_NAME Emscripten)
 set(CMAKE_SYSTEM_VERSION 1)
 
 set(CMAKE_CROSSCOMPILING TRUE)
-set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS FALSE)
+
+# shared library (side module) support
+set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
+set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")    # instead of -shared
+set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")  # instead of -shared
+set(CMAKE_STRIP FALSE)  # not supported
 
 # Advertise Emscripten as a 32-bit platform (as opposed to
 # CMAKE_SYSTEM_PROCESSOR=x86_64 for 64-bit platform), since some projects (e.g.

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -21,8 +21,8 @@ set(CMAKE_CROSSCOMPILING TRUE)
 
 # shared library (side module) support
 set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
-set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")    # instead of -shared
-set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")  # instead of -shared
+set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-sSIDE_MODULE")    # instead of -shared
+set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-sSIDE_MODULE")  # instead of -shared
 set(CMAKE_STRIP FALSE)  # not supported
 set(BUILD_SHARED_LIBS OFF)  # default to static libs, even if we allow shared ones
 

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -24,6 +24,7 @@ set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
 set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-s SIDE_MODULE=1")    # instead of -shared
 set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-s SIDE_MODULE=1")  # instead of -shared
 set(CMAKE_STRIP FALSE)  # not supported
+set(BUILD_SHARED_LIBS OFF)  # default to static libs, even if we allow shared ones
 
 # Advertise Emscripten as a 32-bit platform (as opposed to
 # CMAKE_SYSTEM_PROCESSOR=x86_64 for 64-bit platform), since some projects (e.g.

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -108,7 +108,8 @@ if ("${CMAKE_RANLIB}" STREQUAL "")
 endif()
 
 if ("${CMAKE_STRIP}" STREQUAL "")
-  set(CMAKE_STRIP "${EMSCRIPTEN_ROOT_PATH}/llvm-strip" CACHE FILEPATH "Emscripten compatible strip command")
+  # see https://github.com/emscripten-core/emscripten/issues/16430
+  set(CMAKE_STRIP "llvm-strip" CACHE FILEPATH "Emscripten compatible strip command")
 endif()
 
 if ("${CMAKE_C_COMPILER_AR}" STREQUAL "")

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -108,7 +108,7 @@ if ("${CMAKE_RANLIB}" STREQUAL "")
 endif()
 
 if ("${CMAKE_STRIP}" STREQUAL "")
-  set(CMAKE_STRIP "${EMSCRIPTEN_ROOT_PATH}/llvm-strip" CACHE FILEPATH "Emscripten compatible strip command"))
+  set(CMAKE_STRIP "${EMSCRIPTEN_ROOT_PATH}/llvm-strip" CACHE FILEPATH "Emscripten compatible strip command")
 endif()
 
 if ("${CMAKE_C_COMPILER_AR}" STREQUAL "")

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -23,7 +23,6 @@ set(CMAKE_CROSSCOMPILING TRUE)
 set_property(GLOBAL PROPERTY TARGET_SUPPORTS_SHARED_LIBS TRUE)
 set(CMAKE_SHARED_LIBRARY_CREATE_C_FLAGS "-sSIDE_MODULE")    # instead of -shared
 set(CMAKE_SHARED_LIBRARY_CREATE_CXX_FLAGS "-sSIDE_MODULE")  # instead of -shared
-set(CMAKE_STRIP FALSE)  # not supported
 set(BUILD_SHARED_LIBS OFF)  # default to static libs, even if we allow shared ones
 
 # Advertise Emscripten as a 32-bit platform (as opposed to
@@ -106,6 +105,10 @@ endif()
 
 if ("${CMAKE_RANLIB}" STREQUAL "")
   set(CMAKE_RANLIB "${EMSCRIPTEN_ROOT_PATH}/emranlib${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten ranlib")
+endif()
+
+if ("${CMAKE_STRIP}" STREQUAL "")
+  set(CMAKE_STRIP "${EMSCRIPTEN_ROOT_PATH}/llvm-strip" CACHE FILEPATH "Emscripten compatible strip command"))
 endif()
 
 if ("${CMAKE_C_COMPILER_AR}" STREQUAL "")

--- a/cmake/Modules/Platform/Emscripten.cmake
+++ b/cmake/Modules/Platform/Emscripten.cmake
@@ -108,8 +108,7 @@ if ("${CMAKE_RANLIB}" STREQUAL "")
 endif()
 
 if ("${CMAKE_STRIP}" STREQUAL "")
-  # see https://github.com/emscripten-core/emscripten/issues/16430
-  set(CMAKE_STRIP "llvm-strip" CACHE FILEPATH "Emscripten compatible strip command")
+  set(CMAKE_STRIP "${EMSCRIPTEN_ROOT_PATH}/emstrip${EMCC_SUFFIX}" CACHE FILEPATH "Emscripten strip")
 endif()
 
 if ("${CMAKE_C_COMPILER_AR}" STREQUAL "")

--- a/tests/cmake/cpp_lib/CMakeLists.txt
+++ b/tests/cmake/cpp_lib/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.0)
 
 project(cpp_library)
 
-set(CPP_LIBRARY_TYPE "SHARED" CACHE STRING "Library type to build")
+set(CPP_LIBRARY_TYPE "STATIC" CACHE STRING "Library type to build")
 set_property(CACHE CPP_LIBRARY_TYPE PROPERTY STRINGS STATIC SHARED)
 
 add_library(cpp_lib ${CPP_LIBRARY_TYPE} lib.cpp)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6644,7 +6644,7 @@ void* operator new(size_t size) {
                               Path('codec/CMakeFiles/j2k_to_image.dir/convert.c.o'),
                               Path('codec/CMakeFiles/j2k_to_image.dir/__/common/color.c.o'),
                               Path('bin/libopenjpeg.a')],
-                             configure=['cmake', '.'],
+                             configure=['cmake', '.', '-DBUILD_SHARED_LIBS=OFF'],
                              # configure_args=['--enable-tiff=no', '--enable-jp3d=no', '--enable-png=no'],
                              make_args=[]) # no -j 2, since parallel builds can fail
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -619,7 +619,7 @@ f.close()
     'js':          ('target_js',      'test_cmake.js',         ['-DCMAKE_BUILD_TYPE=Debug']),
     'html':        ('target_html',    'hello_world_gles.html', ['-DCMAKE_BUILD_TYPE=Release']),
     'library':     ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=MinSizeRel']),
-    'static_cpp':  ('target_library', 'libtest_cmake.a',       ['-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DCPP_LIBRARY_TYPE=STATIC']),
+    'shared_cpp':  ('target_library', 'libtest_cmake.so',      ['-DCMAKE_BUILD_TYPE=RelWithDebInfo', '-DBUILD_SHARED_LIBS=ON', '-DCPP_LIBRARY_TYPE=SHARED']),
     'stdproperty': ('stdproperty',    'helloworld.js',         []),
     'post_build':  ('post_build',     'hello.js',              []),
   })


### PR DESCRIPTION
Enable support to build shared libraries as side modules. This should simplify builds with CMake that currently have to reside to manual link steps.

X-ref:
- https://github.com/emscripten-core/emscripten/issues/15276#issuecomment-1039349267
- #16157
- #8362 cc @sbc100 @kripken 
- https://github.com/pyodide/pyodide/pull/2169