### PR TITLE
Make shared structs for EH/SjLj thread-local

### DIFF
--- a/system/lib/compiler-rt/emscripten_setjmp.c
+++ b/system/lib/compiler-rt/emscripten_setjmp.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <setjmp.h>
+#include <threads.h>
 
 // 0 - Nothing thrown
 // 1 - Exception thrown
@@ -74,8 +75,7 @@ struct __WasmLongjmpArgs {
   int val;
 };
 
-// FIXME Make this thread local?
-struct __WasmLongjmpArgs __wasm_longjmp_args;
+thread_local struct __WasmLongjmpArgs __wasm_longjmp_args;
 
 // Wasm EH allows us to throw and catch multiple values, but that requires
 // multivalue support in the toolchain, whch is not reliable at the time.

--- a/system/lib/libunwind/src/Unwind-wasm.c
+++ b/system/lib/libunwind/src/Unwind-wasm.c
@@ -1,6 +1,7 @@
 #include "config.h"
 #include "unwind.h"
 #include <stdbool.h>
+#include <threads.h>
 
 #ifdef __USING_WASM_EXCEPTIONS__
 
@@ -20,7 +21,7 @@ struct _Unwind_LandingPadContext {
 
 // Communication channel between compiler-generated user code and personality
 // function
-struct _Unwind_LandingPadContext __wasm_lpad_context;
+thread_local struct _Unwind_LandingPadContext __wasm_lpad_context;
 
 /// Calls to this function is in landing pads in compiler-generated user code.
 /// In other EH schemes, stack unwinding is done by libunwind library, which


### PR DESCRIPTION
These global variables are used as a medium to communicate between the
compiler-generated code and the libraries, so they should be
thread-local to support threads.