### PR TITLE
Undefine SYS_access so we only need __syscall_faccessat

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -324,10 +324,6 @@ var SyscallsLibrary = {
     FS.chmod(path, mode);
     return 0;
   },
-  __syscall_access: function(path, amode) {
-    path = SYSCALLS.getStr(path);
-    return SYSCALLS.doAccess(path, amode);
-  },
   __syscall_rename: function(old_path, new_path) {
     old_path = SYSCALLS.getStr(old_path);
     new_path = SYSCALLS.getStr(new_path);

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -6,7 +6,6 @@
 #define SYS_chmod		 __syscall_chmod
 #define SYS_getpid		 __syscall_getpid
 #define SYS_pause		 __syscall_pause
-#define SYS_access		 __syscall_access
 #define SYS_nice		 __syscall_nice
 #define SYS_sync		 __syscall_sync
 #define SYS_rename		 __syscall_rename

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -993,7 +993,7 @@ long __syscall_chmod(char* path, long mode) {
   return 0;
 }
 
-long __syscall_access(long path, long amode) {
+long __syscall_faccessat(long dirfd, long path, long amode, long flags) {
   // The input must be F_OK (check for existence) or a combination of [RWX]_OK
   // flags.
   if (amode != F_OK && (amode & ~(R_OK | W_OK | X_OK))) {
@@ -1002,7 +1002,7 @@ long __syscall_access(long path, long amode) {
 
   auto pathParts = splitPath((char*)path);
   long err;
-  auto parsedPath = getParsedPath(pathParts, err);
+  auto parsedPath = getParsedPath(pathParts, err, nullptr, dirfd);
   if (!parsedPath.parent) {
     return err;
   }


### PR DESCRIPTION
This way we just need to define one syscall instead of two. (Musl will
call the proper syscall based on what it sees is defined.)