### PR TITLE
Fix return value of emscripten_builtin_mmap/munmap

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2961,16 +2961,26 @@ LibraryManager.library = {
   },
 #endif
 
-  emscripten_builtin_mmap2__deps: ['$syscallMmap2'],
+  emscripten_builtin_mmap2__deps: ['$syscallMmap2', '$setErrNo'],
   emscripten_builtin_mmap2__noleakcheck: true,
   emscripten_builtin_mmap2: function (addr, len, prot, flags, fd, off) {
-    return syscallMmap2(addr, len, prot, flags, fd, off);
+    var rtn = syscallMmap2(addr, len, prot, flags, fd, off);
+    if (rtn < 0) {
+      setErrNo(-rtn);
+      return -1;
+    }
+    return rtn;
   },
 
-  emscripten_builtin_munmap__deps: ['$syscallMunmap'],
+  emscripten_builtin_munmap__deps: ['$syscallMunmap', '$setErrNo'],
   emscripten_builtin_munmap__noleakcheck: true,
   emscripten_builtin_munmap: function (addr, len) {
-    return syscallMunmap(addr, len);
+    var rtn = syscallMunmap(addr, len);
+    if (rtn < 0) {
+      setErrNo(-rtn);
+      return -1;
+    }
+    return rtn;
   },
 
   $readAsmConstArgsArray: '=[]',

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_posix.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_posix.cpp
@@ -92,11 +92,17 @@ void *MmapAlignedOrDieOnFatalError(uptr size, uptr alignment,
   uptr res = map_res;
   if (!IsAligned(res, alignment)) {
     res = (map_res + alignment - 1) & ~(alignment - 1);
+#ifndef SANITIZER_EMSCRIPTEN
+    // Emscripten's fake mmap doesn't support partial unmapping
     UnmapOrDie((void*)map_res, res - map_res);
+#endif
   }
+#ifndef SANITIZER_EMSCRIPTEN
+  // Emscripten's fake mmap doesn't support partial unmapping
   uptr end = res + size;
   if (end != map_end)
     UnmapOrDie((void*)end, map_end - end);
+#endif
   return (void*)res;
 }
 


### PR DESCRIPTION
Errors (specifcally errors from emscripten_builtin_munmap) were being
obscured by the fact that we were returning -errno rather than -1 on
failure.  The santizer's internal_iserror function only for -1 so it
munmap was failing but this was not being detected/reported.

I noticed this while trying to land #16284.