### PR TITLE
Refactor mmap/munmap to store allocations in shared memory.

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2096,7 +2096,7 @@ def phase_linker_setup(options, state, newargs, settings_map):
 
   if settings.USE_PTHREADS:
     # memalign is used to ensure allocated thread stacks are aligned.
-    settings.REQUIRED_EXPORTS += ['memalign']
+    settings.REQUIRED_EXPORTS += ['emscripten_builtin_memalign']
 
     if settings.MINIMAL_RUNTIME:
       building.user_requested_exports.add('exit')

--- a/src/library.js
+++ b/src/library.js
@@ -2961,18 +2961,6 @@ LibraryManager.library = {
   },
 #endif
 
-  emscripten_builtin_mmap2__deps: ['$syscallMmap2'],
-  emscripten_builtin_mmap2__noleakcheck: true,
-  emscripten_builtin_mmap2: function (addr, len, prot, flags, fd, off) {
-    return syscallMmap2(addr, len, prot, flags, fd, off);
-  },
-
-  emscripten_builtin_munmap__deps: ['$syscallMunmap'],
-  emscripten_builtin_munmap__noleakcheck: true,
-  emscripten_builtin_munmap: function (addr, len) {
-    return syscallMunmap(addr, len);
-  },
-
   $readAsmConstArgsArray: '=[]',
   $readAsmConstArgs__deps: ['$readAsmConstArgsArray'],
   $readAsmConstArgs: function(sigPtr, buf) {
@@ -3580,14 +3568,14 @@ LibraryManager.library = {
   // page-aligned size, and clears the allocated space.
   $mmapAlloc__deps: ['$zeroMemory', '$alignMemory'],
   $mmapAlloc: function(size) {
-#if hasExportedFunction('_memalign')
+#if hasExportedFunction('_emscripten_builtin_memalign')
     size = alignMemory(size, {{{ WASM_PAGE_SIZE }}});
-    var ptr = _memalign({{{ WASM_PAGE_SIZE }}}, size);
+    var ptr = _emscripten_builtin_memalign({{{ WASM_PAGE_SIZE }}}, size);
     if (!ptr) return 0;
     zeroMemory(ptr, size);
     return ptr;
 #elif ASSERTIONS
-    abort('internal error: mmapAlloc called but `memalign` native symbol not exported');
+    abort('internal error: mmapAlloc called but `emscripten_builtin_memalign` native symbol not exported');
 #else
     abort();
 #endif

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -622,7 +622,7 @@ var LibraryPThread = {
   // allocations from __pthread_create_js we could also remove this.
   __pthread_create_js__noleakcheck: true,
   __pthread_create_js__sig: 'iiiii',
-  __pthread_create_js__deps: ['$spawnThread', 'pthread_self', 'memalign', 'emscripten_sync_run_in_main_thread_4'],
+  __pthread_create_js__deps: ['$spawnThread', 'pthread_self', 'emscripten_sync_run_in_main_thread_4'],
   __pthread_create_js: function(pthread_ptr, attr, start_routine, arg) {
     if (typeof SharedArrayBuffer == 'undefined') {
       err('Current environment does not support SharedArrayBuffer, pthreads are not available!');

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -15,8 +15,6 @@ var SyscallsLibrary = {
 #endif
   ],
   $SYSCALLS: {
-    mappings: {},
-
 #if SYSCALLS_REQUIRE_FILESYSTEM
     // global constants
     DEFAULT_POLLMASK: {{{ cDefine('POLLIN') }}} | {{{ cDefine('POLLOUT') }}},
@@ -222,81 +220,45 @@ var SyscallsLibrary = {
     }
   },
 
-  $syscallMmap2__deps: ['$SYSCALLS', '$zeroMemory', '$mmapAlloc',
+  _mmap_js__deps: ['$SYSCALLS',
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
     '$FS',
 #endif
   ],
-  $syscallMmap2: function(addr, len, prot, flags, fd, off) {
-    off <<= 12; // undo pgoffset
-    var ptr;
-    var allocated = false;
-
-    // addr argument must be page aligned if MAP_FIXED flag is set.
-    if ((flags & {{{ cDefine('MAP_FIXED') }}}) !== 0 && (addr % {{{ WASM_PAGE_SIZE }}}) !== 0) {
-      return -{{{ cDefine('EINVAL') }}};
-    }
-
-    // MAP_ANONYMOUS (aka MAP_ANON) isn't actually defined by POSIX spec,
-    // but it is widely used way to allocate memory pages on Linux, BSD and Mac.
-    // In this case fd argument is ignored.
-    if ((flags & {{{ cDefine('MAP_ANONYMOUS') }}}) !== 0) {
-      ptr = mmapAlloc(len);
-      if (!ptr) return -{{{ cDefine('ENOMEM') }}};
-      allocated = true;
-    } else {
+  _mmap_js: function(addr, len, prot, flags, fd, off, allocated, builtin) {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
-      var info = FS.getStream(fd);
-      if (!info) return -{{{ cDefine('EBADF') }}};
-      var res = FS.mmap(info, addr, len, off, prot, flags);
-      ptr = res.ptr;
-      allocated = res.allocated;
-#else // no filesystem support; report lack of support
-      return -{{{ cDefine('ENOSYS') }}};
-#endif
-    }
+    var info = FS.getStream(fd);
+    if (!info) return -{{{ cDefine('EBADF') }}};
+    var res = FS.mmap(info, addr, len, off, prot, flags);
+    var ptr = res.ptr;
+    {{{ makeSetValue('allocated', 0, 'res.allocated', 'i32') }}};
 #if CAN_ADDRESS_2GB
     ptr >>>= 0;
 #endif
-    SYSCALLS.mappings[ptr] = { malloc: ptr, len: len, allocated: allocated, fd: fd, prot: prot, flags: flags, offset: off };
     return ptr;
+#else // no filesystem support; report lack of support
+    return -{{{ cDefine('ENOSYS') }}};
+#endif
   },
 
-  $syscallMunmap__deps: ['$SYSCALLS',
+  _munmap_js__deps: ['$SYSCALLS',
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
     '$FS',
 #endif
   ],
-  $syscallMunmap: function(addr, len) {
+  _munmap_js: function(addr, len, prot, flags, fd, offset) {
 #if CAN_ADDRESS_2GB
     addr >>>= 0;
 #endif
-    // TODO: support unmmap'ing parts of allocations
-    var info = SYSCALLS.mappings[addr];
-    if (len === 0 || !info) {
-      return -{{{ cDefine('EINVAL') }}};
-    }
-    if (len === info.len) {
 #if FILESYSTEM && SYSCALLS_REQUIRE_FILESYSTEM
-      var stream = FS.getStream(info.fd);
-      if (stream) {
-        if (info.prot & {{{ cDefine('PROT_WRITE') }}}) {
-          SYSCALLS.doMsync(addr, stream, len, info.flags, info.offset);
-        }
-        FS.munmap(stream);
+    var stream = FS.getStream(fd);
+    if (stream) {
+      if (prot & {{{ cDefine('PROT_WRITE') }}}) {
+        SYSCALLS.doMsync(addr, stream, len, flags, offset);
       }
-#else
-#if ASSERTIONS
-      // Without FS support, only anonymous mappings are supported.
-      assert(SYSCALLS.mappings[addr].flags & {{{ cDefine('MAP_ANONYMOUS') }}});
-#endif
-#endif
-      SYSCALLS.mappings[addr] = null;
-      if (info.allocated) {
-        _free(info.malloc);
-      }
+      FS.munmap(stream);
     }
-    return 0;
+#endif
   },
 
   __syscall_open: function(path, flags, varargs) {
@@ -422,10 +384,6 @@ var SyscallsLibrary = {
   __syscall_readlink: function(path, buf, bufsize) {
     path = SYSCALLS.getStr(path);
     return SYSCALLS.doReadlink(path, buf, bufsize);
-  },
-  __syscall_munmap__deps: ['$syscallMunmap'],
-  __syscall_munmap: function(addr, len) {
-    return syscallMunmap(addr, len);
   },
   __syscall_fchmod: function(fd, mode) {
     FS.fchmod(fd, mode);
@@ -736,16 +694,14 @@ var SyscallsLibrary = {
       {{{ makeSetValue('exceptfds', '0', 'dstExceptLow', 'i32') }}};
       {{{ makeSetValue('exceptfds', '4', 'dstExceptHigh', 'i32') }}};
     }
-    
+
     return total;
   },
-  __syscall_msync: function(addr, len, flags) {
+  _msync_js: function(addr, len, flags, fd) {
 #if CAN_ADDRESS_2GB
     addr >>>= 0;
 #endif
-    var info = SYSCALLS.mappings[addr];
-    if (!info) return 0;
-    SYSCALLS.doMsync(addr, FS.getStream(info.fd), len, info.flags, 0);
+    SYSCALLS.doMsync(addr, FS.getStream(fd), len, flags, 0);
     return 0;
   },
   __syscall_fdatasync: function(fd) {
@@ -779,10 +735,6 @@ var SyscallsLibrary = {
     if (size < cwdLengthInBytes + 1) return -{{{ cDefine('ERANGE') }}};
     stringToUTF8(cwd, buf, size);
     return buf;
-  },
-  __syscall_mmap2__deps: ['$syscallMmap2'],
-  __syscall_mmap2: function(addr, len, prot, flags, fd, off) {
-    return syscallMmap2(addr, len, prot, flags, fd, off);
   },
   __syscall_truncate64: function(path, low, high) {
     path = SYSCALLS.getStr(path);

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_emscripten.cpp
@@ -23,11 +23,15 @@
 
 #include <emscripten.h>
 #include <emscripten/stack.h>
+#include <sys/types.h>
 
 namespace __sanitizer {
 
 extern "C" {
-  uptr emscripten_get_module_name(char *buf, uptr length);
+char* emscripten_get_module_name(char *buf, size_t length);
+void* emscripten_builtin_mmap(void *addr, size_t length, int prot, int flags,
+                             int fd, off_t offset);
+int emscripten_builtin_munmap(void *addr, size_t length);
 }
 
 void ListOfModules::init() {
@@ -65,16 +69,10 @@ int internal_sigaction(int signum, const void *act, void *oldact) {
                    (struct sigaction *)oldact);
 }
 
-extern "C" {
-  uptr emscripten_builtin_mmap2(void *addr, uptr length, int prot, int flags,
-                               int fd, unsigned offset);
-  uptr emscripten_builtin_munmap(void *addr, uptr length);
-}
-
 uptr internal_mmap(void *addr, uptr length, int prot, int flags, int fd,
                    u64 offset) {
   CHECK(IsAligned(offset, 4096));
-  return emscripten_builtin_mmap2(addr, length, prot, flags, fd, offset / 4096);
+  return (uptr)emscripten_builtin_mmap(addr, length, prot, flags, fd, offset / 4096);
 }
 
 uptr internal_munmap(void *addr, uptr length) {

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_posix.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_posix.cpp
@@ -92,11 +92,17 @@ void *MmapAlignedOrDieOnFatalError(uptr size, uptr alignment,
   uptr res = map_res;
   if (!IsAligned(res, alignment)) {
     res = (map_res + alignment - 1) & ~(alignment - 1);
+#ifndef SANITIZER_EMSCRIPTEN
+    // Emscripten's fake mmap doesn't support partial unmapping
     UnmapOrDie((void*)map_res, res - map_res);
+#endif
   }
+#ifndef SANITIZER_EMSCRIPTEN
+  // Emscripten's fake mmap doesn't support partial unmapping
   uptr end = res + size;
   if (end != map_end)
     UnmapOrDie((void*)end, map_end - end);
+#endif
   return (void*)res;
 }
 

--- a/system/lib/libc/emscripten_mmap.c
+++ b/system/lib/libc/emscripten_mmap.c
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2022 The Emscripten Authors.  All rights reserved.
+ * Emscripten is available under two separate licenses, the MIT license and the
+ * University of Illinois/NCSA Open Source License.  Both these licenses can be
+ * found in the LICENSE file.
+ */
+#include <assert.h>
+#include <errno.h>
+#include <malloc.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+
+#include <emscripten/heap.h>
+#include <emscripten/emmalloc.h>
+
+#include "lock.h"
+#include "syscall.h"
+
+struct map {
+  void* addr;
+  long length;
+  int allocated;
+  int fd;
+  int flags;
+  off_t offset;
+  int prot;
+  struct map* next;
+} __attribute__((aligned (1)));
+
+// Linked list of all mapping, guarded by a musl-style lock (LOCK/UNLOCK)
+static volatile int lock[1];
+static struct map* mappings;
+
+// JS library functions.  Used only when mapping files (not MAP_ANONYMOUS)
+long _mmap_js(long addr, long length, long prot, long flags, long fd, long offset, int* allocated);
+long _munmap_js(long addr, long length, long prot, long flags, long fd, long offset);
+long _msync_js(long addr, long length, long flags, long fd);
+
+static struct map* find_mapping(long addr, struct map** prev) {
+  struct map* map = mappings;
+  while (map) {
+    if (map->addr == (void*)addr) {
+      return map;
+    }
+    if (prev) {
+      *prev = map;
+    }
+    map = map->next;
+  }
+  return map;
+}
+
+long __syscall_munmap(long addr, long length) {
+  LOCK(lock);
+  struct map* prev = NULL;
+  struct map* map = find_mapping(addr, &prev);
+  if (!map || !length) {
+    UNLOCK(lock);
+    return -EINVAL;
+  }
+
+  // We don't support partial munmapping.
+  if (map->length != length) {
+    return -EINVAL;
+  }
+
+  // Remove map from linked list
+  if (prev) {
+    prev->next = map->next;
+  } else {
+    mappings = map->next;
+  }
+  UNLOCK(lock);
+
+  if (!(map->flags & MAP_ANONYMOUS)) {
+    int rtn = _munmap_js(addr, length, map->prot, map->flags, map->fd, map->offset);
+    if (rtn) {
+      return rtn;
+    }
+  }
+
+  // Release the memory.
+  if (map->allocated) {
+    emscripten_builtin_free(map->addr);
+  }
+
+  if (!(map->flags & MAP_ANONYMOUS)) {
+    emscripten_builtin_free(map);
+  }
+
+  // Success!
+  return 0;
+}
+
+long __syscall_msync(long addr, long len, long flags) {
+  LOCK(lock);
+  struct map* map = find_mapping(addr, NULL);
+  UNLOCK(lock);
+  if (!map) {
+    return -EINVAL;
+  }
+  if (map->flags & MAP_ANONYMOUS) {
+    return 0;
+  }
+  return _msync_js(addr, len, map->flags, map->fd);
+}
+
+long __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long off) {
+  // addr argument must be page aligned if MAP_FIXED flag is set.
+  if (flags & MAP_FIXED && (addr % WASM_PAGE_SIZE) != 0) {
+    return -EINVAL;
+  }
+
+  off *= SYSCALL_MMAP2_UNIT;
+  struct map* new_map;
+
+  // MAP_ANONYMOUS (aka MAP_ANON) isn't actually defined by POSIX spec,
+  // but it is widely used way to allocate memory pages on Linux, BSD and Mac.
+  // In this case fd argument is ignored.
+  if (flags & MAP_ANONYMOUS) {
+    // For anonymous maps, allocate that mapping at the end of the region.
+    void* ptr = emscripten_builtin_memalign(WASM_PAGE_SIZE, len + sizeof(struct map));
+    if (!ptr) {
+      return -ENOMEM;
+    }
+    memset(ptr, 0, len);
+    new_map = (struct map*)((char*)ptr + len);
+    new_map->addr = ptr;
+    new_map->fd = -1;
+    new_map->allocated = true;
+  } else {
+    new_map = emscripten_builtin_malloc(sizeof(struct map));
+    long rtn = _mmap_js(addr, len, prot, flags, fd, off, &new_map->allocated);
+    if (rtn < 0) {
+      emscripten_builtin_free(new_map);
+      return rtn;
+    }
+    new_map->addr = (void*)rtn;
+    new_map->fd = fd;
+  }
+
+  new_map->length = len;
+  new_map->flags = flags;
+  new_map->offset = off;
+  new_map->prot = prot;
+
+  LOCK(lock);
+  new_map->next = mappings;
+  mappings = new_map;
+  UNLOCK(lock);
+
+  return (long)new_map->addr;
+}

--- a/system/lib/libc/musl/src/mman/mmap.c
+++ b/system/lib/libc/musl/src/mman/mmap.c
@@ -37,5 +37,6 @@ void *__mmap(void *start, size_t len, int prot, int flags, int fd, off_t off)
 }
 
 weak_alias(__mmap, mmap);
+weak_alias(__mmap, emscripten_builtin_mmap);
 
 weak_alias(mmap, mmap64);

--- a/system/lib/libc/musl/src/mman/munmap.c
+++ b/system/lib/libc/musl/src/mman/munmap.c
@@ -11,3 +11,4 @@ int __munmap(void *start, size_t len)
 }
 
 weak_alias(__munmap, munmap);
+weak_alias(__munmap, emscripten_builtin_munmap);

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10992,6 +10992,8 @@ exec "$@"
         cmd.append('-fexceptions')
       if function.startswith('glfwGetMonitors'):
         cmd.append('-sUSE_GLFW=3')
+      if 'mmap' in function:
+        cmd.append('-sFORCE_FILESYSTEM')
       # In WebAssemblyLowerEmscriptenEHSjLj pass in the LLVM backend, function
       # calls that exist in the same function with setjmp are converted to some
       # code sequence that includes emscripten_longjmp. emscripten_longjmp is

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -170,8 +170,6 @@ _deps_info = {
   'localtime': ['malloc'],
   'localtime_r': ['malloc'],
   'mktime': ['malloc'],
-  'mmap': ['memalign'],
-  'munmap': ['free'],
   'pthread_create': ['malloc', 'free', 'emscripten_main_thread_process_queued_calls'],
   'recv': ['htons'],
   'recvmsg': ['htons'],
@@ -212,6 +210,8 @@ def get_deps_info():
     _deps_info['__cxa_find_matching_catch_7'] = ['__cxa_can_catch']
     _deps_info['__cxa_find_matching_catch_8'] = ['__cxa_can_catch']
     _deps_info['__cxa_find_matching_catch_9'] = ['__cxa_can_catch']
+  if settings.FILESYSTEM and settings.SYSCALLS_REQUIRE_FILESYSTEM:
+    _deps_info['mmap'] = ['emscripten_builtin_memalign']
   if settings.USE_PTHREADS and settings.OFFSCREEN_FRAMEBUFFER:
     # When OFFSCREEN_FRAMEBUFFER is defined these functions are defined in native code,
     # otherwise they are defined in src/library_html5_webgl.js.

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -977,9 +977,12 @@ class libc(MuslInternalLibrary,
 
     libc_files += files_in_path(
       path='system/lib/libc',
-      filenames=['emscripten_memcpy.c', 'emscripten_memset.c',
+      filenames=['emscripten_memcpy.c',
+                 'emscripten_memset.c',
                  'emscripten_scan_stack.c',
-                 'emscripten_memmove.c'])
+                 'emscripten_memmove.c',
+                 'emscripten_mmap.c'
+                 ])
 
     libc_files += glob_in_path('system/lib/libc/compat', '*.c')
 


### PR DESCRIPTION
Previously we were storing allocation in a JS mapping which doesn't work
across threads.

With this change the implemenation of mmap/munmap is primarily in native
code, calling out of JS only for if the filesystem is needed.

This change also removes the duplicate implementation of MAP_ANON between
JS and standalone.c.

Replaces both #16297 and #16284.