### PR TITLE
Draft: Add support for read/seek on files in the native file system

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3021,7 +3021,14 @@ LibraryManager.library = {
 #if RELOCATABLE
     code -= {{{ GLOBAL_BASE }}};
 #endif
-    var args = readAsmConstArgs(sigPtr, argbuf);
+#if EMSCRIPTEN_NATIVE_FS
+    if ( code === - 1 ) {
+        var args = 0;
+    }
+    else {
+        var args = readAsmConstArgs(sigPtr, argbuf);
+    }
+#endif
 #if USE_PTHREADS
     if (ENVIRONMENT_IS_PTHREAD) {
       // EM_ASM functions are variadic, receiving the actual arguments as a buffer

--- a/src/library_nativefs.js
+++ b/src/library_nativefs.js
@@ -1,0 +1,368 @@
+var LibraryNATIVEFS = {
+    /*
+      Documentation of functions is in include/emscripten/nativefs.h
+    */
+    $NATIVEFS: {
+        /*
+          nativefs_worker: a worker spawned by the runtime, that will 
+          allow synchronous reads on files selected by the user.
+
+          spawned in preamble.js, then the runtime will wait for
+          the init_nativefs message to remove the runtimeDependency.
+         */
+        worker: 0,
+        /*
+          Allocated memory region mapped like this :
+          {
+            fs_lock: int,
+            dispatch_index: int,
+            dispatch_param1: int,
+            dispatch_param2: int,
+            dispatch_param3: int,
+            // struct per file:
+            {
+              fileIndex: int, // Starts at one
+              fileLock: int, // protects from concurrent read/seek (same file)
+              readSize: int, // new read size 
+              seekOffset: int // new offset size
+            }
+          }
+        */
+        handle: 0,
+        /*
+          Keep track of files in the fs
+          nativefs_init will push to this array each time a file is selected.
+          { fd: , fileName: , fileSize: }
+        */
+        files: [],
+        /* 
+           dispatcher:
+           using shared memory to set the index of the function that will be called
+
+           Negative codes are for EM_ASM, and positive codes are
+           for proxiedFunctionTable indexes. If the code is 0, the 
+           function will be null and we will be able to handle this special
+           case. (in src/library_pthread.js).
+           sigPtr and arg are ignored.
+        */        
+        MAIN_THREAD_CONSTS: [
+            /* dispatcher */
+            function () {
+                var view = new Int32Array(Module.wasmMemory.buffer, NATIVEFS.handle, 5);
+                // get dispatcher index
+                var index = Atomics.load(view, 1);
+                // TODO: catch invalid indexes
+                // when this function fails, it is rarely
+                // with a nice 0 index (value is garbage)
+                if (index == 0) {
+                    console.error("nativefs error: could not dispatch functionindex is : " + index );
+		            return;
+                }
+                NATIVEFS.MAIN_THREAD_CONSTS[index]();
+            },
+            function () {
+                var view = new Int32Array(Module.wasmMemory.buffer, NATIVEFS.handle, 5);
+                // FIXME: reassign or remove?
+            },
+            /* nativefs_read */
+            function () {
+                var view = new Int32Array(Module.wasmMemory.buffer, NATIVEFS.handle, 5);
+                NATIVEFS.worker.postMessage({
+                    ops: "read",
+                    addr: Atomics.load(view, 2),
+                    handle: Atomics.load(view, 3),
+                    size: Atomics.load(view, 4)
+                });
+            },
+            /* nativefs_seek */
+            function () {
+                var view = new Int32Array(Module.wasmMemory.buffer, NATIVEFS.handle, 5);
+                NATIVEFS.worker.postMessage({
+                    ops: "seek",
+                    handle: Atomics.load(view, 2),
+                    offset: Atomics.load(view, 3),
+                    whence: Atomics.load(view, 4)
+                });
+            },
+            /* get file size */
+            function() {
+                var view = new Int32Array(Module.wasmMemory.buffer, NATIVEFS.handle, 5);
+                var handle = Atomics.load(view, 2);
+                Atomics.store(view, 3, NATIVEFS.files[handle - 3].fileSize);
+            },
+            /* close file */
+            function() {
+                var view = new Int32Array(Module.wasmMemory.buffer, NATIVEFS.handle, 5);
+                var fd = Atomics.load(view, 2);
+                // remove file from files entry
+                NATIVEFS.files[fd - 3] = {};
+                // remove from files in the worker
+                NATIVEFS.worker.postMessage({ ops: "close_file", fd: fd });
+                Atomics.store(view, 3, 1);
+            }
+        ],
+    },
+    /*
+      If we want to break free from the emscripten demo page, we will need
+      to attach the event listener that connects the file with NATIVEFS to a
+      specific element.      
+    */
+    nativefs_init__deps: ['$findEventTarget'],
+    nativefs_init: function(element) {
+        if (ENVIRONMENT_IS_PTHREAD) {
+            err("nativefs: cannot init nativefs in a pthread!");
+            return -1;
+        }
+        let fileHandle;
+        let fileCount = 0;
+        element = document.getElementById("NATIVEFS_button");
+        if (!element) {
+            element = findEventTarget(element);
+            // FIXME: what happens if findEventTarget does not work?
+        }
+        element.addEventListener('click', async function() {
+            element.innerHTML = "Selecting File";
+            // TODO: handle compat mode for firefox
+            // showOpenFilePicker() is a chrome/safari only api for now
+            [fileHandle] = await window.showOpenFilePicker();
+            fileHandle.getFile().then((blob) => {
+                // Send the file to the nativefs_worker
+                NATIVEFS.worker.postMessage( {
+                    ops: "push_file",
+                    file: blob,
+                });
+                // keep the record in the main thread
+                // (the same will be done in the worker)
+                NATIVEFS.files.push({
+                    fileName: blob.name,
+                    fileSize: blob.size
+                });
+                fileCount += 1;
+                element.innerHTML = "Opened "+ fileCount + " files";
+            });
+        });
+        return 0;
+    },
+    /*
+      FIXME: helper function to get a value from the main thread,
+      via shared memory
+    */
+    nativefs_get_prop_from_main_thread__deps: ['$mainThreadEM_ASM'],
+    nativefs_get_prop_from_main_thread: function() {
+        //FIXME: not implemented, not sure I need it anymore
+        if (!ENVIRONMENT_IS_PTHREAD) {
+            err("nativefs: operation not available in the main thread!");
+            return -1;
+        }
+        var nativefs_handle = Module.PThread.nativeFSHandle;
+        var view = new Int32Array(Module.wasmMemory.buffer, nativefs_handle, 5);
+        Atomics.store(view,1, 1);
+        mainThreadEM_ASM(-1, 0, 0, 1);
+    },
+    nativefs_read__deps: ['$mainThreadEM_ASM'],
+    nativefs_read: function(fd, buffer, size) {
+        if (!ENVIRONMENT_IS_PTHREAD) {
+            err("nativefs: operation not available in the main thread!");
+            return -1;
+        }
+        if ((fd == -1) || (buffer == 0) || (fd > {{{ NATIVEFS_MAX_FD }}}))
+            return -1;
+        if (size == 0)
+            return 0;
+
+        var nativefs_handle = Module.PThread.nativeFSHandle;
+        var view = new Int32Array(Module.wasmMemory.buffer, nativefs_handle, 5);
+        Atomics.store(view, 1, 4);
+        Atomics.store(view, 2, fd);
+        mainThreadEM_ASM(-1, 0, 0, 1);
+        var fileSize = Atomics.load(view, 3);
+
+        if (size > fileSize)
+            size = fileSize;
+        
+        var index = fd - 2;
+        var file_state = new Int32Array(Module.wasmMemory.buffer, Module.PThread.nativeFSHandle + (5*4) + (index*16), 4);
+        // check if the file was pushed                             
+        Atomics.wait(file_state, 0, 0);
+        
+        // Init read size: (don't touch read_size if the lock is still acquired)
+        Atomics.wait(file_state, 1, 1);
+        Atomics.store(file_state, 2, -1);
+        
+        // Acquire lock: (unblock atomic.wait() in read())
+        Atomics.store(file_state, 1, 1);
+        Atomics.notify(file_state, 1);
+
+        // setup read call in mainThread
+        Atomics.store(view, 1, 2);
+        // set read ops parameters
+        Atomics.store(view, 2, buffer);
+        Atomics.store(view, 3, fd);
+        Atomics.store(view, 4, size);
+
+        mainThreadEM_ASM(-1, 0, 0, 1);
+
+        // Wait for the size notification
+        Atomics.wait(file_state, 2, -1);
+        // release the lock:
+        Atomics.wait(file_state, 1, 1);
+
+        // return number of bytes read
+        return Atomics.load(file_state, 2);
+    },
+    nativefs_seek: function(fd, offset, whence) {
+        if (!ENVIRONMENT_IS_PTHREAD) {
+            err("nativefs: operation not available in the main thread!");
+            return -1;
+        }
+        if ((fd < 3) || (fd > {{{ NATIVEFS_MAX_FD }}}))
+            return -1;
+        var nativefs_handle = Module.PThread.nativeFSHandle;
+        var view = new Int32Array(Module.wasmMemory.buffer, nativefs_handle, 5);
+        var index = fd - 2;
+        var file_state = new Int32Array(Module.wasmMemory.buffer, Module.PThread.nativeFSHandle + (5*4) + (index*16), 4);
+
+        /*
+          Setup get_filesize call in mainThread
+          it will set the fileSize in the sharedMemory
+          to allow us to read it in Atomics.load() call below
+        */
+        Atomics.store(view, 1, 4);
+        Atomics.store(view, 2, fd);
+        mainThreadEM_ASM(-1, 0, 0, 1);
+
+        var fileSize = Atomics.load(view, 3);
+        
+        var currentOffset = Atomics.load(file_state, 3);
+        if ( whence === {{{ cDefine('NATIVEFS_SEEK_SET') }}} ) {
+            if ((offset < 0) || (offset > fileSize)) {
+                return -1;
+            }
+        }
+        else if ( whence === {{{ cDefine('NATIVEFS_SEEK_CUR') }}} ) {
+            if ((currentOffset + offset < 0) || (currentOffset + offset > fileSize)) {
+                return -1;
+            }
+        }
+        else if ( whence === {{{ cDefine('NATIVEFS_SEEK_END') }}} ) {            
+            if ((fileSize + offset < 0) || (fileSize + offset > fileSize)) {
+                return -1;
+            }
+        }
+        else {
+            return -1;
+        }            
+
+        // check if the file was pushed
+        Atomics.wait(file_state, 0, 0);
+
+        // Acquire lock: (unblock atomic.wait() in seek())
+        Atomics.store(file_state, 1, 1);
+        Atomics.notify(file_state, 1);
+
+        // setup seek call in mainThread
+        Atomics.store(view, 1, 3);
+        // set seek ops parameters
+        Atomics.store(view,2, fd);
+        Atomics.store(view,3, offset);
+        Atomics.store(view,4, whence);
+
+        mainThreadEM_ASM(-1, 0, 0, 1);
+
+        // release the lock here
+        Atomics.wait(file_state, 1, 1);
+        if (file_state[1] == -1) {
+            // the call failed
+            return -1;
+        }
+        // return the new file offset
+        return file_state[3];
+    },
+    nativefs_get_fd_from_filename: function(encodedName) {
+        if (ENVIRONMENT_IS_PTHREAD) {
+            err("nativefs: operation not available in the pthread!");
+            return -1;
+        }
+        if (!encodedName)
+            return -1;
+        var textdecoder = new TextDecoder();
+        var filename_view = textdecoder.decode(encodedName);
+        var flag = 0;
+        var j = 0;
+        for (file in NATIVEFS.files) {
+            var i = 0;
+            for (let c of filename_view.entries()) {
+                // item is [index, value]
+                if (item[1] !== file.fileName[i++]) {
+                    flag = 1;
+                    break;
+                }
+            }
+            // reached here without setting the flag to 1
+            if (flag === 0)
+                return (j + 3);
+            j++;
+        }
+        // reached end without setting the flag to 1
+        return -1;
+    },
+    /*
+      helper function to mark the specified files item for gc.
+    */
+    nativefs_close_file: function(fd) {
+        if (!ENVIRONMENT_IS_PTHREAD) {
+            err("nativefs: operation not available in the main thread!");
+            return -1;
+        }
+        if ((fd < 3) || (fd > {{{ NATIVEFS_MAX_FD }}}))
+            return -1;        
+        var nativefs_handle = Module.PThread.nativeFSHandle;
+        var view = new Int32Array(Module.wasmMemory.buffer, nativefs_handle, 5);
+        /* Setup close_file call in the main Thread */
+        Atomics.store(view, 1, 5);
+        Atomics.store(view, 2, fd);
+        mainThreadEM_ASM(-1, 0, 0, 1);
+
+        // reset file state to 0
+        var index = fd - 2;
+        var file_state = new Int32Array(Module.wasmMemory.buffer, Module.PThread.nativeFSHandle + (5*4) + (index*16), 4);
+        Atomics.store(file_state, 0, 0);
+        Atomics.store(file_state, 1, 0);
+        Atomics.store(file_state, 2, -1);
+        Atomics.store(file_state, 3, -1);
+
+        // return success/error
+        var ret = Atomics.load(view, 3);
+        if (ret == 1)
+            return 0;
+        else            
+            return -1;
+    },
+    /*
+      This function should be called when EXIT_RUNTIME is marked in effect.
+      It will invalidate the nativefs handle in the pthreads.
+      No function can be called after that.
+    */
+    nativefs_cleanup: function() {
+        if (ENVIRONMENT_IS_PTHREAD) {
+            err("nativefs: operation not available in a pthread!");
+            return -1;
+        }
+        if ((!NATIVEFS.handle) || (!NATIVEFS.worker)) {
+            return -1;
+        }
+        if (NATIVEFS.handle) {
+            Module._free(NATIVEFS.handle);
+            delete NATIVEFS.files;
+            delete NATIVEFS.worker;
+            delete NATIVEFS.handle;
+        }
+        return 0;
+    },
+}
+
+autoAddDeps(LibraryNATIVEFS, '$JSEvents');
+mergeInto(LibraryManager.library, LibraryNATIVEFS);
+if (EMSCRIPTEN_NATIVE_FS) {
+    DEFAULT_LIBRARY_FUNCS_TO_INCLUDE.push('$NATIVEFS');
+}

--- a/src/modules.js
+++ b/src/modules.js
@@ -131,6 +131,10 @@ global.LibraryManager = {
       libraries.push('library_lz4.js');
     }
 
+    if (EMSCRIPTEN_NATIVE_FS) {
+      libraries.push('library_nativefs.js')
+    }
+      
     if (MAX_WEBGL_VERSION >= 2) {
       // library_webgl2.js must be included only after library_webgl.js, so if we are
       // about to include library_webgl2.js, first squeeze in library_webgl.js.

--- a/src/nativefs_worker.js
+++ b/src/nativefs_worker.js
@@ -1,0 +1,146 @@
+var files = [];
+var fd = 2;
+var sharedMemory;
+var fs_lock = -1;
+var nativefs_handle;
+
+this.onmessage = function (msg) {
+    if (msg.data.ops === "push_file") {
+        if (msg.data.file === undefined) {
+            console.error("invalid operation: called push_file operation with invalid" +
+                          " file: " + msg.data.file + " } !");
+            return ;
+        }
+        fd += 1;
+        files.push({
+            handle: fd,
+            offset: 0,
+            file: msg.data.file
+        });
+
+        var index = fd - 2;
+        var file_state = new Int32Array(sharedMemory, nativefs_handle + (5*4) + (index*16), 4);
+
+        Atomics.store(file_state, 1, 0);
+        Atomics.notify(file_state, 1);
+        Atomics.store(file_state, 0, fd);
+        Atomics.notify(file_state, 0);
+    }
+    else if (msg.data.ops === "close_file") {
+        if (msg.data.fd === undefined) {
+            console.error("invalid operation: called close_file operation with invalid" +
+                          " fd: " + msg.data.fd + " } !");
+            return ;
+        }
+        
+    }
+    else if (msg.data.ops === "close_file") {
+        if (msg.data.fs === undefined) {
+            console.error("invalid operation: called close_file operation with invalid" +
+                          " fd : " + msg.data.fd + " } !");
+            return ;
+        }
+        files[fd - 3].handle = 0;
+        files[fd - 3].offset = 0;
+        files[fd - 3].file = 0;
+    }
+    /* not implemented, only for debug */
+    else if (msg.data.ops === "cleanup_nativefs") {
+        for (let file of files)
+            console.log(file);
+        files = [];
+    }
+    else if (msg.data.ops === "init_nativefs") {
+        /*
+          worker is ready to receive the runtime
+        */
+        this.postMessage( { ops: "init_nativefs" } );
+    }
+    else if (msg.data.ops === "init_nativefs_runtime") {
+        if (msg.data.moduleWasmMemory === undefined) {
+            console.error("invalid operation: called init_nativefs_runtime operation with invalid" +
+                          " { moduleWasmMemory: " +
+                          msg.data.moduleWasmMemory +
+                          " nativefs_handle: " +
+                          msg.data.handle + " } !");
+            return ;
+        }
+        sharedMemory = msg.data.moduleWasmMemory;
+        nativefs_handle = msg.data.handle;
+        this.postMessage( { ops: "init_fs_lock" } );
+    }
+    else if (msg.data.ops === "read") {
+        if (msg.data.addr === undefined
+            || msg.data.handle === undefined
+            || msg.data.size === undefined) {
+            console.error("invalid operation: called read operation with invalid { addr: " +
+                          msg.data.addr + " handle: " + msg.data.handle +
+                          " size: " + msg.data.size + " } !");
+            return ;
+        }
+        let p_buffer = msg.data.addr;
+        let index = msg.data.handle - 3;
+        let size = msg.data.size;
+        let offset = files[index].offset;
+        let file = files[index].file;
+        let handle_index = msg.data.handle - 2;
+
+        var file_state = new Int32Array(sharedMemory, nativefs_handle + (5*4) + (handle_index*16), 4);
+
+        // wait for read() call to acquire lock
+        Atomics.wait(file_state, 1, 0);
+        let blob = new Blob(
+            [file.slice(offset, offset + size)],
+            { type: 'application/octet-stream' });
+        let reader = new FileReaderSync();
+        let result = reader.readAsArrayBuffer(blob);
+        let dataView = new Uint8Array(result);
+        let wasmMemoryView = new Uint8Array(sharedMemory, p_buffer, dataView.length);
+        let wasmMemoryItems = wasmMemoryView.entries();
+        for ( let item of dataView.entries() ) {
+            //item is [index, value]
+            let ind = wasmMemoryItems.next().value[0];
+            wasmMemoryView[ind] = item[1];
+        }
+        files[index].offset += dataView.length;
+        Atomics.store(file_state, 3, files[index].offset);
+        // finished reading:
+        // 1. udpate size
+        Atomics.store(file_state, 2, dataView.length);
+        Atomics.notify(file_state, 2);
+        // 2. notify read()
+        Atomics.store(file_state, 1, 0);
+        Atomics.notify(file_state, 1);
+    }
+    else if (msg.data.ops === "seek") {
+        if (msg.data.offset === undefined
+            || msg.data.whence === undefined
+            || msg.data.handle === undefined) {
+            console.error("invalid operation: called seek operation with invalid { offset: " + msg.data.offset
+                          + " whence: " + msg.data.whence
+                          + " handle: " + msg.data.handle
+                          + " } !");
+            return ;
+        }
+        let handle_index = msg.data.handle - 2;
+        var file_state = new Int32Array(sharedMemory, nativefs_handle + (5*4) + (handle_index*16), 4);
+        let index = msg.data.handle - 3;
+        
+        // wait for seek() call to acquire lock
+        Atomics.wait(file_state, 1, 0);
+        let new_offset = msg.data.offset;
+        if (msg.data.whence === {{{ cDefine('NATIVEFS_SEEK_CUR') }}} ) {
+            new_offset = files[index].offset + msg.data.offset; 
+        }
+        else if (msg.data.whence === {{{ cDefine('NATIVEFS_SEEK_END') }}} ) {
+            new_offset = files[index].file.size + msg.data.offset;
+        }
+        files[index].offset = new_offset;
+
+        // notify seek()
+        Atomics.store(file_state, 1, 0);
+        Atomics.notify(file_state, 1);
+        Atomics.store(file_state, 3, new_offset);
+        Atomics.notify(file_state, 3);
+    }
+}

--- a/src/postamble.js
+++ b/src/postamble.js
@@ -190,6 +190,9 @@ function callMain(args) {
     assert(ret == 0, '_emscripten_proxy_main failed to start proxy thread: ' + ret);
 #endif
 #else
+#if EMSCRIPTEN_NATIVE_FS
+    _nativefs_cleanup();
+#endif
     // if we're not running an evented main loop, it's time to exit
     exit(ret, /* implicit = */ true);
     return ret;

--- a/src/settings.js
+++ b/src/settings.js
@@ -1994,6 +1994,16 @@ var OFFSCREEN_FRAMEBUFFER_FORBID_VAO_PATH = 0;
 // [link]
 var TEST_MEMORY_GROWTH_FAILS = 0;
 
+// This option will enable exposing the native file system throught
+// the native filesystem api (web.dev/file-system-access).
+// It is desabled by default.
+var EMSCRIPTEN_NATIVE_FS = 0;
+
+// This option depends on the previous one, it controls the size of allocated
+// nativefs structure that contains state information on the files currently open.
+// default value is 1024, maximum number of file descriptors allowed. 
+var NATIVEFS_MAX_FD=1024
+
 // For renamed settings the format is:
 // [OLD_NAME, NEW_NAME]
 // For removed settings (which now effectively have a fixed value and can no

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -129,6 +129,9 @@ var WASM_BINARY_FILE = '';
 // name of the file containing the pthread *.worker.js, if relevant
 var PTHREAD_WORKER_FILE = '';
 
+// name of the file containing the filesystem runtime worker
+var NATIVE_FS_WORKER_FILE = '';
+
 // Base URL the source mapfile, if relevant
 var SOURCE_MAP_BASE = '';
 

--- a/src/shell.html
+++ b/src/shell.html
@@ -1215,7 +1215,7 @@
       <canvas class="emscripten" id="canvas" oncontextmenu="event.preventDefault()" tabindex=-1></canvas>
     </div>
     <textarea id="output" rows="8"></textarea>
-
+    <button id="NATIVEFS_button">Select Files</button>
     <script type='text/javascript'>
       var statusElement = document.getElementById('status');
       var progressElement = document.getElementById('progress');

--- a/src/struct_info.json
+++ b/src/struct_info.json
@@ -1543,5 +1543,13 @@
                 "fragment"
             ]
         }
+    },
+    {
+        "file": "emscripten/nativefs.h",
+        "defines": [
+            "NATIVEFS_SEEK_SET",
+            "NATIVEFS_SEEK_CUR",
+            "NATIVEFS_SEEK_END"
+        ]
     }
 ]

--- a/src/worker.js
+++ b/src/worker.js
@@ -209,6 +209,9 @@ self.onmessage = (e) => {
       // Also call inside JS module to set up the stack frame for this pthread in JS module scope
       Module['establishStackSpace']();
       Module['PThread'].receiveObjectTransfer(e.data);
+#if EMSCRIPTEN_NATIVE_FS
+      Module['PThread'].nativeFSHandle = Module['PThread'].initNativeFSHandle();
+#endif
       Module['PThread'].threadInit();
 
 #if EMBIND
@@ -219,7 +222,6 @@ self.onmessage = (e) => {
         initializedJS = true;
       }
 #endif // EMBIND
-
       try {
         // pthread entry points are always of signature 'void *ThreadMain(void *arg)'
         // Native codebases sometimes spawn threads with other thread entry point signatures,

--- a/system/include/emscripten/nativefs.h
+++ b/system/include/emscripten/nativefs.h
@@ -1,0 +1,101 @@
+#ifndef NATIVEFS_H
+#define NATIVEFS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdlib.h>
+#include <stdbool.h>
+
+#define NATIVEFS_SEEK_SET 0
+#define NATIVEFS_SEEK_CUR 1
+#define NATIVEFS_SEEK_END 2
+
+/*
+  [main thread]
+  @function nativefs_init
+
+  @param element - The html element that will hold the
+  event handler that will select the file(s).
+
+  @discussion This function will set click handler callback on element. 
+  If called with NULL, it will default to "NATIVEFS_button", else, we
+  need to provide an element id prefixed with "#"
+  defined in src/shell.html
+
+  @result 0 if no issue is detected, (does not mean the push_file message 
+  was received). -1 if it was called from a pthread.
+*/
+int nativefs_init(const char *element);
+
+/*
+  [main thread]
+  @function nativefs_get_fd_from_filename
+
+  @param name - The name of the file (encoded in utf8)
+  @discussion Lookup the files array in the main thread until we find
+  a match for the name of the file we want. This function will of course fail
+  if we call it before the user selected a file.
+
+  @result valid file descriptor, -1 if the file was not found
+*/
+int nativefs_get_fd_from_filename(const char *name);
+
+/*
+  [pthread]
+  @function nativefs_read
+
+  @param fd - File descriptor of a file previously selected in the file picker
+  @param buffer - allocated destination in linear memory to write the file content to
+  @param size - size of the buffer to read
+
+  @discussion Synchronous function that will read size bytes into buffer for the file (represented by fd)
+
+  @result -1 if there was an error, or the number of bytes read
+*/
+ssize_t nativefs_read(int fd, void *buffer, size_t size);
+
+/*
+  [pthread]
+  @function nativefs_seek
+
+  @param fd - File descriptor of a file previously selected in the file picker
+  @param offset - new value of the offset
+  @param whence - specifies how to apply the offset (NATIVEFS_SEEK_SET, NATIVEFS_SEEK_CUR, NATIVEFS_SEEK_END)
+
+  @discussion Synchronous function that will set the file offset.
+  NATIVEFS_SEEK_SET: absolute
+  NATIVEFS_SEEK_CUR: relative to current offset
+  NATIVEFS_SEEK_END: relative to the end of the file
+
+  @result -1 if there was an error, or the new offset of the file.
+*/
+ssize_t nativefs_seek(int fd, size_t offset, int whence);
+
+/*
+  [pthread]
+  @function nativefs_close_file
+
+  @param fd - File descriptor of a file previously selected in the file picker
+  @discussion This function will lookup the file and mark it for gc.
+  @result -1 if the fd is invalid, or a valid file descriptor.
+*/
+int nativefs_close_file(int fd);
+
+/*
+  [main_thread]
+  @function nativefs_cleanup
+
+  @discussion This function is called by default if emscripten is set to exit the runtime, it is exposed
+  in case the user would want to do it without exiting the runtime.
+
+  @result 0 if it succeeded, -1 if there was an error.
+*/
+int nativefs_cleanup(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif NATIVEFS_H

--- a/tests/browser/nativefs/nativefs_read.c
+++ b/tests/browser/nativefs/nativefs_read.c
@@ -1,0 +1,165 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <emscripten.h>
+#include <emscripten/nativefs.h>
+#include <assert.h> 
+
+int flag = 1;
+
+void generate_test_files() {
+    /*
+      Test routine to allow testing files without ui
+     */
+    MAIN_THREAD_EM_ASM({
+            var blob = new File(["The quick brown fox jumps over the lazy dog"], "test.txt", {
+                    type: "text/plain",
+                });
+            NATIVEFS.worker.postMessage( {
+                ops: "push_file",
+                file: blob
+                });
+            // keep the record in the pthread
+            NATIVEFS.files.push({
+                fd: 3, // 0-1-2 are reserved
+                fileName: blob.name,
+                fileSize: blob.size
+                // file: blob (for debug?)
+                });            
+        });
+    MAIN_THREAD_EM_ASM({
+            var blob = new File(["The quick brown fox jumps over the lazy dog"], "test2.txt", {
+                type: "text/plain",
+                });
+            NATIVEFS.worker.postMessage( {
+                ops: "push_file",
+                file: blob
+                });
+            // keep the record in the pthread
+            NATIVEFS.files.push({
+                fd: 4, // 0-1-2 are reserved
+                fileName: blob.name,
+                fileSize: blob.size
+                // file: blob (for debug?)
+                });            
+        });
+    MAIN_THREAD_EM_ASM({
+            var blob = new File(["The quick brown fox jumps over the lazy dog"], "test3.txt", {
+                    type: "text/plain",
+                });
+            NATIVEFS.worker.postMessage( {
+                ops: "push_file",
+                file: blob
+                });
+            // keep the record in the pthread
+            NATIVEFS.files.push({
+                fd: 5, // 0-1-2 are reserved
+                fileName: blob.name,
+                fileSize: blob.size
+                // file: blob (for debug?)
+                });            
+        });
+    MAIN_THREAD_EM_ASM({
+            var blob = new File(["The quick brown fox jumps over the lazy dog"], "test4.txt", {
+                    type: "text/plain",
+                });
+            NATIVEFS.worker.postMessage( {
+                ops: "push_file",
+                file: blob
+                });
+            // keep the record in the pthread
+            NATIVEFS.files.push({
+                fd: 6, // 0-1-2 are reserved
+                fileName: blob.name,
+                fileSize: blob.size
+                // file: blob (for debug?)
+                });            
+        });
+
+}
+
+void *run(void *args) {
+    /* 
+       doing this here, because before pthread is initialized, nativefs
+       may not be ready
+    */
+    generate_test_files();
+    char buffer[44];
+    ssize_t ret = 0;
+    memset(buffer, 0, 44);
+    printf("Starting nativefs_read tests...\n");
+
+    ret = nativefs_read(3, NULL, 44);
+    assert(ret == -1);
+    printf("test_null_buffer: read returned:%zd bytes and read:%s\n", ret, buffer);
+
+    ret = nativefs_read(-1, buffer, 44);
+    assert(ret == -1);
+    printf("test_bad_fd: read returned:%zd bytes and read:%s\n", ret, buffer);
+
+    ret = nativefs_read(4242, buffer, 44);
+    assert(ret == -1);
+    printf("test_invalid_fd: read returned:%zd bytes and read:%s\n", ret, buffer);
+
+    ret = nativefs_read(3, buffer, 0);
+    assert(ret == 0);
+    printf("test_zero_size: read returned:%zd bytes and read:%s\n", ret, buffer);
+    memset(buffer, 0, 44);
+
+    ret = nativefs_read(3, buffer, 99);
+    assert(ret == 43);
+    assert(strcmp(buffer, "The quick brown fox jumps over the lazy dog") == 0);
+    printf("test_bigger_size: read returned:%zd bytes and read:%s\n", ret, buffer);
+    memset(buffer, 0, 44);
+
+    /*
+      not sure what this test should do?
+      char another_buffer[20];
+      memset(another_buffer, 0, 20);
+      ret = nativefs_read(4, another_buffer, 44);
+      printf("test_smaller_buffer_size: read %zd bytes: %s\n", ret, another_buffer);
+    */
+    int i = 0;
+    do {
+        ret = nativefs_read(5, buffer + i, 1);
+        i++;
+    } while (ret);
+    assert(strcmp(buffer, "The quick brown fox jumps over the lazy dog") == 0);
+    printf("test_multiple_reads: buffer is :%s\n", buffer);
+    memset(buffer, 0, 44);
+
+    ret = nativefs_read(6, buffer, 44);
+    assert(ret == 43);
+    assert(strcmp(buffer, "The quick brown fox jumps over the lazy dog") == 0);
+    printf("test_valid_read: read returned:%zd bytes and read:%s\n", ret, buffer);
+    memset(buffer, 0, 44);
+
+    ret = nativefs_read(6, buffer, 44);
+    assert(ret == 0);
+    printf("test_read_after_finish: read returned:%zd bytes and read:%s\n", ret, buffer);
+
+    ret = nativefs_read(6, buffer, 44);
+    assert(ret == 0);
+    printf("test_read_another_after_finish: read returned:%zd bytes and read:%s\n", ret, buffer);
+
+    flag = 0;
+    printf("nativefs_read tests succeeded!\n");
+    return NULL;
+}
+
+void iter(void) {
+    if (flag == 0) {
+        flag = 1;
+        emscripten_cancel_main_loop();
+        emscripten_force_exit(0);
+    }
+}
+
+int main() {
+    pthread_t tid;
+    nativefs_init(NULL);
+    pthread_create(&tid, NULL, run, NULL);
+    // avoid early return (that will beat the purpose of the test)
+    emscripten_set_main_loop(iter, 0, 1);
+    return 0;
+}

--- a/tests/browser/nativefs/nativefs_seek.c
+++ b/tests/browser/nativefs/nativefs_seek.c
@@ -1,0 +1,134 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <string.h>
+#include <emscripten.h>
+#include <emscripten/nativefs.h>
+#include <assert.h> 
+
+int flag = 1;
+
+void generate_test_files() {
+    /*
+      Test routine to allow testing files without ui
+     */
+    MAIN_THREAD_EM_ASM({
+            var blob = new File(["The lazy brown dog jumps over the quick fox"], "test.txt", {
+                    type: "text/plain",
+                });
+            NATIVEFS.worker.postMessage( {
+                ops: "push_file",
+                file: blob
+                });
+            // keep the record in the pthread
+            NATIVEFS.files.push({
+                fd: 3, // 0-1-2 are reserved
+                fileName: blob.name,
+                fileSize: blob.size
+                // file: blob (for debug?)
+                });            
+        });
+}
+
+void *run(void *args) {
+    /* 
+       doing this here, because before pthread is initialized, nativefs
+       may not be ready
+    */
+    generate_test_files();
+    char buffer[44];
+    ssize_t ret = 0;
+    memset(buffer, 0, 44);
+    printf("Starting nativefs_seek tests...\n");
+
+    ret = nativefs_seek(-1, 42, NATIVEFS_SEEK_SET);
+    assert(ret == -1);
+    printf("test_bad_fd: seek returned %zd\n", ret);
+
+    ret = nativefs_seek(4242, 42, NATIVEFS_SEEK_SET);
+    assert(ret == -1);
+    printf("test_invalid_fd: seek returned %zd\n", ret);
+
+    ret = nativefs_seek(3, 44, NATIVEFS_SEEK_SET);
+    assert(ret == -1);
+    printf("test_invalid_offset_cur_high: seek returned %zd\n", ret);
+
+    ret = nativefs_seek(3, -1, NATIVEFS_SEEK_SET);
+    assert(ret == -1);
+    printf("test_invalid_offset_cur_low: seek returned %zd\n", ret);
+
+    ret = nativefs_seek(3, 44, NATIVEFS_SEEK_CUR);
+    assert(ret == -1);
+    printf("test_invalid_offset_begin_high: seek returned %zd\n", ret);
+    ret = nativefs_seek(3, -44, NATIVEFS_SEEK_CUR);
+    assert(ret == -1);
+    printf("test_invalid_offset_begin_low: seek returned %zd\n", ret);
+
+    ret = nativefs_seek(3, -44, NATIVEFS_SEEK_END);
+    assert(ret == -1);
+    printf("test_invalid_offset_end_high: seek returned %zd\n", ret);
+
+    ret = nativefs_seek(3, 1, NATIVEFS_SEEK_END);
+    assert(ret == -1);
+    printf("test_invalid_offset_end_low: seek returned %zd\n", ret);
+    
+    ret = nativefs_seek(3, 42, 42);
+    assert(ret == -1);
+    printf("test_invalid_whence: seek returned %zd\n", ret);
+    
+    ssize_t read_ret = 0;
+    read_ret = nativefs_read(3, buffer, 4);
+    ret = nativefs_seek(3, -9, NATIVEFS_SEEK_END);
+    assert(ret == 34);
+    read_ret += nativefs_read(3, buffer + read_ret, 5);
+    ret = nativefs_seek(3, 8, NATIVEFS_SEEK_SET);
+    assert(ret == 8);
+    read_ret += nativefs_read(3, buffer + read_ret, 7);
+    ret = nativefs_seek(3, -3, NATIVEFS_SEEK_END);
+    assert(ret == 40);
+    read_ret += nativefs_read(3, buffer + read_ret, 6);
+    ret = nativefs_seek(3, 0, NATIVEFS_SEEK_SET);
+    assert(ret == 0);
+    ret = nativefs_seek(3, 18, NATIVEFS_SEEK_CUR);
+    assert(ret == 18);
+    read_ret += nativefs_read(3, buffer + read_ret, 15);
+    ret = nativefs_seek(3, -30, NATIVEFS_SEEK_CUR);
+    assert(ret == 3);
+    read_ret += nativefs_read(3, buffer + read_ret, 5);
+    ret = nativefs_seek(3, 14, NATIVEFS_SEEK_SET);
+    assert(ret == 14);
+    read_ret += nativefs_read(3, buffer + read_ret, 4);
+    printf("test_valid_multiple_seek: %s\n", buffer);
+    assert (strcmp(buffer, "The quick brown fox jumps over the lazy dog") == 0);
+
+    char another_buffer[5];
+    memset(another_buffer, 0, 5);
+    ret = nativefs_seek(3, 43, NATIVEFS_SEEK_SET);
+    assert(ret == 43);
+    ret = nativefs_read(3, another_buffer, 4);
+    assert(ret == 0);
+    ret = nativefs_read(3, another_buffer, 4);
+    assert(ret == 0);
+    printf("test_read_after_seek_to_end: second read returned %zd\n", ret);
+    
+    flag = 0;
+
+    printf("nativefs_read seek succeeded!\n");
+    return NULL;
+}
+
+void iter(void) {
+    if (flag == 0) {
+        flag = 1;
+        emscripten_cancel_main_loop();
+        emscripten_force_exit(0);
+    }
+}
+
+int main() {
+    pthread_t tid;
+    nativefs_init(NULL);
+    pthread_create(&tid, NULL, run, NULL);
+    // avoid early return (that will beat the purpose of the test)
+    emscripten_set_main_loop(iter, 0, 1);
+    return 0;
+}

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -753,6 +753,14 @@ If manually bisecting:
       '--preload-file', 'screenshot.jpeg', '-DSCREENSHOT_DIRNAME="/"', '-DSCREENSHOT_BASENAME="screenshot.jpeg"', '--use-preload-plugins'
     ])
 
+  def test_nativefs_read(self):
+    src = test_file('browser/nativefs/nativefs_read.c')
+    self.btest_exit(src, args=['-s', 'USE_PTHREADS', '-s', 'EMSCRIPTEN_NATIVE_FS', '-s', 'PTHREAD_POOL_SIZE'])
+
+  def test_nativefs_seek(self):
+    src = test_file('browser/nativefs/nativefs_seek.c')
+    self.btest_exit(src, args=['-s', 'USE_PTHREADS', '-s', 'EMSCRIPTEN_NATIVE_FS', '-s', 'PTHREAD_POOL_SIZE'])
+    
   def test_sdl_image_prepare(self):
     # load an image file, get pixel data.
     shutil.copyfile(test_file('screenshot.jpg'), 'screenshot.not')


### PR DESCRIPTION
Hi, 

This is a set of changes to try to solve the issue described in #14094.

This PR will add :
- EMSCRIPTEN_NATIVE_FS option: to spawn the nativefs_worker and setup pthreads so that they can read/seek selected files from sharedMemory
- NATIVEFS_MAX_FD option: to set the maximum number of files the user can select
- nativefs_* functions that can be called from c/c++
- a button in the demo page to allow file selection
- unit tests and one functional test for nativefs_read and nativefs_seek

I had an issue when I wanted to pass parameters from pthreads to the main thread, directly from a javascript library. I patched mainThreadEM_ASM to be able to make the calls, without having to define functions in C only to add Macros to inline javascript code.