### PR TITLE
Fix side module exception handling

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -34,7 +34,7 @@ var LibraryDylink = {
     }
 
 #if !DISABLE_EXCEPTION_CATCHING
-    if(!sym && symName.startsWith("__cxa_find_matching_catch")){
+    if (!sym && symName.startsWith("__cxa_find_matching_catch")) {
       sym = Module["___cxa_find_matching_catch"];
     }
 #endif

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -33,9 +33,11 @@ var LibraryDylink = {
       sym = createInvokeFunction(symName.split('_')[1]);
     }
 
+#if !DISABLE_EXCEPTION_CATCHING
     if(!sym && symName.startsWith("__cxa_find_matching_catch")){
-      sym = Module.___cxa_find_matching_catch;
+      sym = Module["___cxa_find_matching_catch"];
     }
+#endif
     return sym;
   },
 

--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -33,6 +33,9 @@ var LibraryDylink = {
       sym = createInvokeFunction(symName.split('_')[1]);
     }
 
+    if(!sym && symName.startsWith("__cxa_find_matching_catch")){
+      sym = Module.___cxa_find_matching_catch;
+    }
     return sym;
   },
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4557,13 +4557,13 @@ res64 - external 64\n''', header='''
         try {
           throw 3;
         } catch (int x){
-          printf("side: caught int %d\n", x); 
+          printf("side: caught int %d\n", x);
         } catch (float x){
-          printf("side: caught float %f\n", x); 
+          printf("side: caught float %f\n", x);
         }
       }
       '''
-      
+
     create_file('liblib.cpp', side)
     create_file('main.cpp', main)
     self.maybe_closure()

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4542,7 +4542,7 @@ res64 - external 64\n''', header='''
   @with_both_eh_sjlj
   @needs_dylink
   def test_dylink_exceptions_try_catch_3(self):
-    main =r'''
+    main = r'''
       #include <dlfcn.h>
       int main() {
         void* handle = dlopen("liblib.so", RTLD_LAZY);
@@ -4551,7 +4551,7 @@ res64 - external 64\n''', header='''
         return 0;
       }
     '''
-    side=r'''
+    side = r'''
       #include <stdio.h>
       extern "C" void side() {
         try {


### PR DESCRIPTION
Resolves #16302. I am happy to add tests if you want, but would appreciate some guidelines for how to make them.

Exception handling for C++ code calls a bunch of functions with names like
`__cxa_find_matching_catch_##`. In Emscripten all of these functions are defined
to be the same function. Emscripten statically defines the set of these that are used
by C++ code in the main module, but it is possible that a side module will need extra
ones. This fixes the problem by updating `resolveGlobalSymbol` so that in a side module
every `__cxa_find_matching_catch_##` will resolve to `__cxa_find_matching_catch`.
