### PR TITLE
[WasmFS][NFC] Rename entry to child in Directory API

### DIFF
--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -32,44 +32,44 @@ __wasi_errno_t MemoryFile::read(uint8_t* buf, size_t len, off_t offset) {
 }
 
 std::vector<Directory::Entry>::iterator
-MemoryDirectory::findEntry(const std::string& name) {
-  return std::find_if(entries.begin(), entries.end(), [&](const auto& entry) {
+MemoryDirectory::findChild(const std::string& name) {
+  return std::find_if(children.begin(), children.end(), [&](const auto& entry) {
     return entry.name == name;
   });
 }
 
-std::shared_ptr<File> MemoryDirectory::getEntry(const std::string& name) {
-  if (auto entry = findEntry(name); entry != entries.end()) {
-    return entry->file;
+std::shared_ptr<File> MemoryDirectory::getChild(const std::string& name) {
+  if (auto child = findChild(name); child != children.end()) {
+    return child->file;
   }
   return nullptr;
 }
 
-bool MemoryDirectory::removeEntry(const std::string& name) {
-  auto entry = findEntry(name);
-  if (entry == entries.end()) {
+bool MemoryDirectory::removeChild(const std::string& name) {
+  auto child = findChild(name);
+  if (child == children.end()) {
     return false;
   }
-  entries.erase(entry);
+  children.erase(child);
   return true;
 }
 
-std::shared_ptr<File> MemoryDirectory::insertEntry(const std::string& name,
+std::shared_ptr<File> MemoryDirectory::insertChild(const std::string& name,
                                                    std::shared_ptr<File> file) {
-  if (auto entry = findEntry(name); entry != entries.end()) {
-    return entry->file;
+  if (auto child = findChild(name); child != children.end()) {
+    return child->file;
   }
-  entries.push_back({name, file});
+  children.push_back({name, file});
   return file;
 }
 
 std::string MemoryDirectory::getName(std::shared_ptr<File> file) {
-  auto entry =
-    std::find_if(entries.begin(), entries.end(), [&](const auto& entry) {
-      return entry.file == file;
+  auto child =
+    std::find_if(children.begin(), children.end(), [&](const auto& child) {
+      return child.file == file;
     });
-  if (entry != entries.end()) {
-    return entry->name;
+  if (child != children.end()) {
+    return child->name;
   }
   return {};
 }

--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -32,44 +32,44 @@ __wasi_errno_t MemoryFile::read(uint8_t* buf, size_t len, off_t offset) {
 }
 
 std::vector<Directory::Entry>::iterator
-MemoryDirectory::findChild(const std::string& name) {
-  return std::find_if(children.begin(), children.end(), [&](const auto& entry) {
+MemoryDirectory::findEntry(const std::string& name) {
+  return std::find_if(entries.begin(), entries.end(), [&](const auto& entry) {
     return entry.name == name;
   });
 }
 
 std::shared_ptr<File> MemoryDirectory::getChild(const std::string& name) {
-  if (auto child = findChild(name); child != children.end()) {
-    return child->file;
+  if (auto entry = findEntry(name); entry != entries.end()) {
+    return entry->file;
   }
   return nullptr;
 }
 
 bool MemoryDirectory::removeChild(const std::string& name) {
-  auto child = findChild(name);
-  if (child == children.end()) {
+  auto entry = findEntry(name);
+  if (entry == entries.end()) {
     return false;
   }
-  children.erase(child);
+  entries.erase(entry);
   return true;
 }
 
 std::shared_ptr<File> MemoryDirectory::insertChild(const std::string& name,
                                                    std::shared_ptr<File> file) {
-  if (auto child = findChild(name); child != children.end()) {
-    return child->file;
+  if (auto entry = findEntry(name); entry != entries.end()) {
+    return entry->file;
   }
-  children.push_back({name, file});
+  entries.push_back({name, file});
   return file;
 }
 
 std::string MemoryDirectory::getName(std::shared_ptr<File> file) {
-  auto child =
-    std::find_if(children.begin(), children.end(), [&](const auto& child) {
-      return child.file == file;
+  auto entry =
+    std::find_if(entries.begin(), entries.end(), [&](const auto& entry) {
+      return entry.file == file;
     });
-  if (child != children.end()) {
-    return child->name;
+  if (entry != entries.end()) {
+    return entry->name;
   }
   return {};
 }

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -40,28 +40,28 @@ void DataFile::Handle::preloadFromJS(int index) {
 // Directory
 //
 
-bool Directory::Handle::removeEntry(const std::string& name) {
-  auto entry = getEntry(name);
-  if (entry == nullptr) {
+bool Directory::Handle::removeChild(const std::string& name) {
+  auto child = getChild(name);
+  if (child == nullptr) {
     return true;
   }
-  // Atomically remove the entry and clear its parent.
-  auto lockedEntry = entry->locked();
-  if (!getDir()->removeEntry(name)) {
+  // Atomically remove the child and clear its parent.
+  auto lockedChild = child->locked();
+  if (!getDir()->removeChild(name)) {
     return false;
   }
-  assert(lockedEntry.getParent() == getDir());
-  lockedEntry.setParent(nullptr);
+  assert(lockedChild.getParent() == getDir());
+  lockedChild.setParent(nullptr);
   return true;
 }
 
 std::shared_ptr<File>
-Directory::Handle::insertEntry(const std::string& name,
+Directory::Handle::insertChild(const std::string& name,
                                std::shared_ptr<File> file) {
   // Atomically add the entry and set its parent.
   auto lockedFile = file->locked();
   assert(lockedFile.getParent() == nullptr);
-  auto entry = getDir()->insertEntry(name, file);
+  auto entry = getDir()->insertChild(name, file);
   if (file == entry) {
     // The insertion succeeded; set the parent.
     lockedFile.setParent(getDir());

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -127,15 +127,15 @@ public:
 
 private:
   // Return the file with the given name or null if there is none.
-  virtual std::shared_ptr<File> getEntry(const std::string& name) = 0;
+  virtual std::shared_ptr<File> getChild(const std::string& name) = 0;
   // Remove the file with the given name, returning `true` on success or if the
-  // entry has already been removed.
-  virtual bool removeEntry(const std::string& name) = 0;
+  // child has already been removed.
+  virtual bool removeChild(const std::string& name) = 0;
   // Insert the given file with the given name if there is not already an entry
   // with the same name. Returns the inserted file or the preexisting file or
   // null if the file could not be inserted and there was also no preexisting
   // file.
-  virtual std::shared_ptr<File> insertEntry(const std::string& name,
+  virtual std::shared_ptr<File> insertChild(const std::string& name,
                                             std::shared_ptr<File> file) = 0;
   // Return the name of the file if it is contained within this directory or an
   // empty string if it is not.
@@ -241,11 +241,11 @@ public:
   Handle(std::shared_ptr<File> directory, std::defer_lock_t)
     : File::Handle(directory, std::defer_lock) {}
 
-  std::shared_ptr<File> getEntry(const std::string& name) {
-    return getDir()->getEntry(name);
+  std::shared_ptr<File> getChild(const std::string& name) {
+    return getDir()->getChild(name);
   }
-  bool removeEntry(const std::string& name);
-  std::shared_ptr<File> insertEntry(const std::string& name,
+  bool removeChild(const std::string& name);
+  std::shared_ptr<File> insertChild(const std::string& name,
                                     std::shared_ptr<File> file);
   std::string getName(std::shared_ptr<File> file) {
     return getDir()->getName(file);

--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -73,7 +73,7 @@ long _wasmfs_write_file(char* pathname, char* data, size_t data_size) {
     return 0;
   }
 
-  auto child = parsedPath.parent->getEntry(pathParts.back());
+  auto child = parsedPath.parent->getChild(pathParts.back());
   auto dataFile = child->dynCast<DataFile>();
 
   auto result = dataFile->locked().write((uint8_t*)data, data_size, 0);

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -39,17 +39,17 @@ public:
 
 class MemoryDirectory : public Directory {
   // Use a vector instead of a map to save code size.
-  std::vector<Entry> children;
+  std::vector<Entry> entries;
 
-  std::vector<Entry>::iterator findChild(const std::string& name);
+  std::vector<Entry>::iterator findEntry(const std::string& name);
 
   std::shared_ptr<File> getChild(const std::string& name) override;
   bool removeChild(const std::string& name) override;
   std::shared_ptr<File> insertChild(const std::string& name,
                                     std::shared_ptr<File> file) override;
   std::string getName(std::shared_ptr<File> file) override;
-  size_t getNumEntries() override { return children.size(); }
-  std::vector<Directory::Entry> getEntries() override { return children; }
+  size_t getNumEntries() override { return entries.size(); }
+  std::vector<Directory::Entry> getEntries() override { return entries; }
 
 public:
   MemoryDirectory(mode_t mode, backend_t backend) : Directory(mode, backend) {}

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -39,17 +39,17 @@ public:
 
 class MemoryDirectory : public Directory {
   // Use a vector instead of a map to save code size.
-  std::vector<Entry> entries;
+  std::vector<Entry> children;
 
-  std::vector<Entry>::iterator findEntry(const std::string& name);
+  std::vector<Entry>::iterator findChild(const std::string& name);
 
-  std::shared_ptr<File> getEntry(const std::string& name) override;
-  bool removeEntry(const std::string& name) override;
-  std::shared_ptr<File> insertEntry(const std::string& name,
+  std::shared_ptr<File> getChild(const std::string& name) override;
+  bool removeChild(const std::string& name) override;
+  std::shared_ptr<File> insertChild(const std::string& name,
                                     std::shared_ptr<File> file) override;
   std::string getName(std::shared_ptr<File> file) override;
-  size_t getNumEntries() override { return entries.size(); }
-  std::vector<Directory::Entry> getEntries() override { return entries; }
+  size_t getNumEntries() override { return children.size(); }
+  std::vector<Directory::Entry> getEntries() override { return children; }
 
 public:
   MemoryDirectory(mode_t mode, backend_t backend) : Directory(mode, backend) {}

--- a/system/lib/wasmfs/wasmfs.cpp
+++ b/system/lib/wasmfs/wasmfs.cpp
@@ -59,13 +59,13 @@ std::shared_ptr<Directory> WasmFS::initRootDirectory() {
     std::make_shared<MemoryDirectory>(S_IRUGO | S_IXUGO | S_IWUGO, rootBackend);
   auto devDirectory =
     std::make_shared<MemoryDirectory>(S_IRUGO | S_IXUGO, rootBackend);
-  rootDirectory->locked().insertEntry("dev", devDirectory);
+  rootDirectory->locked().insertChild("dev", devDirectory);
 
   auto dir = devDirectory->locked();
 
-  dir.insertEntry("stdin", StdinFile::getSingleton());
-  dir.insertEntry("stdout", StdoutFile::getSingleton());
-  dir.insertEntry("stderr", StderrFile::getSingleton());
+  dir.insertChild("stdin", StdinFile::getSingleton());
+  dir.insertChild("stdout", StdoutFile::getSingleton());
+  dir.insertChild("stderr", StderrFile::getSingleton());
 
   return rootDirectory;
 }
@@ -120,7 +120,7 @@ void WasmFS::preloadFiles() {
 
     auto created = rootBackend->createDirectory(S_IRUGO | S_IXUGO);
 
-    auto inserted = parentDir->locked().insertEntry(childName, created);
+    auto inserted = parentDir->locked().insertChild(childName, created);
     assert(inserted && "TODO: handle preload insertion errors");
   }
 
@@ -144,7 +144,7 @@ void WasmFS::preloadFiles() {
       abort();
     }
 
-    auto inserted = parentDir->locked().insertEntry(base, created);
+    auto inserted = parentDir->locked().insertChild(base, created);
     assert(inserted && "TODO: handle preload insertion errors");
 
     created->locked().preloadFromJS(i);


### PR DESCRIPTION
Rename `entry` to `child` whenever the API is dealing with directory contents as
shared pointers to `File`. This is in preparation for a follow-on change that
will change `getEntries` (which maintains its original name in this commit) to
return only the data needed by getdents rather than a vector of full `File`
objects.