### PR TITLE
Add executable install test to test_cmake_install

### DIFF
--- a/tests/cmake/find_package/CMakeLists.txt
+++ b/tests/cmake/find_package/CMakeLists.txt
@@ -7,3 +7,10 @@ find_package(Foo REQUIRED)
 add_executable(Bar bar.c)
 
 target_link_libraries(Bar Foo)
+
+install(TARGETS Bar EXPORT BarTargets
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -753,6 +753,7 @@ f.close()
     self.run_process([EMCMAKE, 'cmake', test_file('cmake/find_package')], cwd='build2')
     self.run_process(['cmake', '--build', 'build2'])
     self.assertContained('foo: 42\n', self.run_js('build2/Bar.js'))
+    self.run_process(['cmake', '--build', 'build2', '--target', 'install'])
 
   def test_cmake_find_sdl2(self):
     os.mkdir('build')


### PR DESCRIPTION
Currently only the JS seems to get installed, but including
the test here so it can be built upon.