### PR TITLE
Move main thread queue processing into `emscripten_futex_wait`. NFC

### DIFF
--- a/system/lib/libc/musl/src/thread/__timedwait.c
+++ b/system/lib/libc/musl/src/thread/__timedwait.c
@@ -78,9 +78,6 @@ int __timedwait_cp(volatile int *addr, int val,
 				// cancel execution.
 				return ECANCELED;
 			}
-			// Assist other threads by executing proxied operations that are effectively singlethreaded.
-			if (is_runtime_thread) emscripten_main_thread_process_queued_calls();
-
 			msecsToSleep = sleepUntilTime - emscripten_get_now();
 			if (msecsToSleep <= 0) {
 				r = ETIMEDOUT;

--- a/system/lib/libc/musl/src/thread/__wait.c
+++ b/system/lib/libc/musl/src/thread/__wait.c
@@ -28,8 +28,6 @@ void __wait(volatile int *addr, volatile int *waiters, int val, int priv)
 					if (waiters) a_dec(waiters);
 					return;
 				}
-				// Assist other threads by executing proxied operations that are effectively singlethreaded.
-				if (is_runtime_thread) emscripten_main_thread_process_queued_calls();
 				// Must wait in slices in case this thread is cancelled in between.
 				e = emscripten_futex_wait((void*)addr, val, max_ms_slice_to_sleep);
 			} while (e == -ETIMEDOUT);

--- a/system/lib/libc/musl/src/thread/pthread_barrier_wait.c
+++ b/system/lib/libc/musl/src/thread/pthread_barrier_wait.c
@@ -95,8 +95,6 @@ int pthread_barrier_wait(pthread_barrier_t *b)
 				do {
 					// Main runtime thread may need to run proxied calls, so sleep in very small slices to be responsive.
 					e = emscripten_futex_wait(&inst->finished, 1, 1);
-					// Assist other threads by executing proxied operations that are effectively singlethreaded.
-					emscripten_main_thread_process_queued_calls();
 				} while (e == -ETIMEDOUT);
 			} else {
 				// Can wait in one go.


### PR DESCRIPTION
There are three functions that call `emscripten_futex_wait` in a loop
while processing the queue (on the main runtime thread only).

We already have an 'is_runtime_thread' block at the top ofjust
`emscripten_futex_wait` so we can just use that to run
`emscripten_main_thread_process_queued_calls`.

This refactoring reduces duplication but also paves the way for some
future optimizations.