### PR TITLE
For response file, guess the encoding that will strip the BOM

### DIFF
--- a/tools/response_file.py
+++ b/tools/response_file.py
@@ -87,7 +87,7 @@ def read_response_file(response_filename):
   if len(components) > 1 and (encoding_suffix.startswith('utf') or encoding_suffix.startswith('cp') or encoding_suffix.startswith('iso') or encoding_suffix in ['ascii', 'latin-1']):
     guessed_encoding = encoding_suffix
   else:
-    guessed_encoding = 'utf-8'
+    guessed_encoding = 'utf-8-sig'
 
   try:
     # First try with the guessed encoding


### PR DESCRIPTION
This PR fixes #15162 and is my first PR here so please correct anything I've missed or got wrong .  When guessing the encoding from a response `rsp`, file with an extension that is not recognized the current code falls back to `utf-8`.    Typically on Windows at least, the response file ends with `.rsp` so the encoding will go to UTF8

I'm not Python expert by any stretch.  But on StackOverflow I see

https://stackoverflow.com/questions/13590749/reading-unicode-file-data-with-bom-chars-in-python

which suggests that to read _and remove_ the BOM it should be `utf-8-sig`  Indeed that change made locally fixes the problem with cmake 3.22 and NMake.

Does this need a test somewhere.  Attached a .rsp file renamed to .txt that fails currently.

[objects1.txt](https://github.com/emscripten-core/emscripten/files/8111640/objects1.txt)
?