### PR TITLE
Move alignUp() inside emscripten_resize_heap()

### DIFF
--- a/site/source/docs/api_reference/preamble.js.rst
+++ b/site/source/docs/api_reference/preamble.js.rst
@@ -415,7 +415,6 @@ The :ref:`emscripten-memory-model` uses a typed array buffer (``ArrayBuffer``) t
   Module['ALLOC_STACK'] = ALLOC_STACK;
   Module['HEAP'] = HEAP;
   Module['IHEAP'] = IHEAP;
-  function alignUp(x, multiple)
   function demangle(func)
   function demangleAll(text)
   function parseJSFunc(jsfunc)

--- a/src/library.js
+++ b/src/library.js
@@ -209,6 +209,8 @@ LibraryManager.library = {
 #endif
     }
 
+    let alignUp = (x, multiple) => x + (multiple - x % multiple) % multiple;
+
     // Loop through potential heap size increases. If we attempt a too eager
     // reservation that fails, cut down on the attempted size and reserve a
     // smaller bump instead. (max 3 times, chosen somewhat arbitrarily)

--- a/src/preamble.js
+++ b/src/preamble.js
@@ -211,13 +211,6 @@ function _free() {
 
 // Memory management
 
-function alignUp(x, multiple) {
-  if (x % multiple > 0) {
-    x += multiple - (x % multiple);
-  }
-  return x;
-}
-
 var HEAP,
 /** @type {!ArrayBuffer} */
   buffer,

--- a/src/preamble_minimal.js
+++ b/src/preamble_minimal.js
@@ -32,13 +32,6 @@ var tempRet0 = 0;
 var setTempRet0 = (value) => { tempRet0 = value };
 var getTempRet0 = () => tempRet0;
 
-function alignUp(x, multiple) {
-  if (x % multiple > 0) {
-    x += multiple - (x % multiple);
-  }
-  return x;
-}
-
 #if WASM != 2 && MAYBE_WASM2JS
 #if !WASM2JS
 if (Module['doWasm2JS']) {


### PR DESCRIPTION
It has been marked internal in documentation, so moving should be safe. Only emscripten_resize_heap() uses this in the codebase.