### PR TITLE
[WasmFS] Error in close syscall on invalid FD

### DIFF
--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -253,6 +253,10 @@ __wasi_errno_t __wasi_fd_pread(__wasi_fd_t fd,
 __wasi_errno_t __wasi_fd_close(__wasi_fd_t fd) {
   auto fileTable = wasmFS.getLockedFileTable();
 
+  if (!fileTable[fd]) {
+    return __WASI_ERRNO_BADF;
+  }
+
   // Remove openFileState entry from fileTable.
   fileTable[fd] = nullptr;
 

--- a/tests/unistd/close.c
+++ b/tests/unistd/close.c
@@ -40,7 +40,6 @@ int main() {
   printf("errno: %d\n", errno);
   assert(ret == -1);
   assert(errno == EBADF);
-  errno = 0;
 
   return 0;
 }

--- a/tests/wasmfs/wasmfs_dup.c
+++ b/tests/wasmfs/wasmfs_dup.c
@@ -124,6 +124,7 @@ int main() {
   printf("f2,f3: %d\n", f2 == f3);
   printf("close(f1): %d\n", close(f));
   printf("close(f2): %d\n", close(f2));
+  // f3 is identical to f2, so this will error.
   printf("close(f3): %d\n", close(f3));
   errno = 0;
 

--- a/tests/wasmfs/wasmfs_dup.out
+++ b/tests/wasmfs/wasmfs_dup.out
@@ -29,4 +29,4 @@ f: 1
 f2,f3: 1
 close(f1): 0
 close(f2): 0
-close(f3): 0
+close(f3): -1


### PR DESCRIPTION
This fixes the existing test to be correct and match linux.

This includes the non-controversial parts from #16328