### PR TITLE
[WasmFS] Fix breakage from #16344

### DIFF
--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -252,21 +252,21 @@ __wasi_errno_t __wasi_fd_pread(__wasi_fd_t fd,
 __wasi_errno_t __wasi_fd_close(__wasi_fd_t fd) {
   auto fileTable = wasmFS.getFileTable().locked();
   if (!fileTable.getEntry(fd)) {
-    return -EBADF;
+    return __WASI_ERRNO_BADF;
   }
   fileTable.setEntry(fd, nullptr);
   return __WASI_ERRNO_SUCCESS;
 }
 
 __wasi_errno_t __wasi_fd_sync(__wasi_fd_t fd) {
-  auto openFile = wasmFS.getLockedFileTable()[fd];
+  auto openFile = wasmFS.getFileTable().locked().getEntry(fd);
   if (!openFile) {
     return __WASI_ERRNO_BADF;
   }
 
   // Nothing to flush for anything but a data file, but also not an error either
   // way. TODO: in the future we may want syncing of directories.
-  auto dataFile = openFile.locked().getFile()->dynCast<DataFile>();
+  auto dataFile = openFile->locked().getFile()->dynCast<DataFile>();
   if (dataFile) {
     dataFile->locked().flush();
   }


### PR DESCRIPTION
1. Some compile errors due to a racing landing.
2. That PR seems to have by mistake turned a return code from WASI to POSIX.