### PR TITLE
Rebaseline code size tests

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4973,
   "a.js.gz": 2417,
-  "a.wasm": 10440,
+  "a.wasm": 10442,
   "a.wasm.gz": 6664,
-  "total": 15982,
+  "total": 15984,
   "total_gz": 9460
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 594,
   "a.html.gz": 389,
-  "a.js": 20089,
-  "a.js.gz": 8208,
+  "a.js": 20028,
+  "a.js.gz": 8200,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 23854,
-  "total_gz": 11311
+  "total": 23793,
+  "total_gz": 11303
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4479,
   "a.js.gz": 2250,
-  "a.wasm": 10440,
+  "a.wasm": 10442,
   "a.wasm.gz": 6664,
-  "total": 15488,
+  "total": 15490,
   "total_gz": 9293
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 594,
   "a.html.gz": 389,
-  "a.js": 19574,
-  "a.js.gz": 8045,
+  "a.js": 19513,
+  "a.js.gz": 8038,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 23339,
-  "total_gz": 11148
+  "total": 23278,
+  "total_gz": 11141
 }

--- a/tests/code_size/math_wasm.json
+++ b/tests/code_size/math_wasm.json
@@ -4,7 +4,7 @@
   "a.js": 137,
   "a.js.gz": 141,
   "a.wasm": 2721,
-  "a.wasm.gz": 1634,
+  "a.wasm.gz": 1635,
   "total": 3531,
-  "total_gz": 2206
+  "total_gz": 2207
 }

--- a/tests/code_size/random_printf_wasm.json
+++ b/tests/code_size/random_printf_wasm.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 12945,
-  "a.html.gz": 6994,
-  "total": 12945,
-  "total_gz": 6994
+  "a.html": 12953,
+  "a.html.gz": 6998,
+  "total": 12953,
+  "total_gz": 6998
 }

--- a/tests/code_size/random_printf_wasm2js.json
+++ b/tests/code_size/random_printf_wasm2js.json
@@ -1,6 +1,6 @@
 {
-  "a.html": 17779,
-  "a.html.gz": 7588,
-  "total": 17779,
-  "total_gz": 7588
+  "a.html": 17788,
+  "a.html.gz": 7587,
+  "total": 17788,
+  "total_gz": 7587
 }


### PR DESCRIPTION
`main` started to fail on some improvements there, which must be from
the LLVM side since nothing changed in Binaryen or Emscripten.