### PR TITLE
Add -Wno-unqualified-std-cast-call to libc++ build

### DIFF
--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1147,8 +1147,16 @@ class libcxxabi(NoExceptLibrary, MTLibrary):
 class libcxx(NoExceptLibrary, MTLibrary):
   name = 'libc++'
 
-  cflags = ['-DLIBCXX_BUILDING_LIBCXXABI=1', '-D_LIBCPP_BUILDING_LIBRARY', '-Oz',
-            '-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS']
+  cflags = [
+    '-Oz',
+    '-DLIBCXX_BUILDING_LIBCXXABI=1',
+    '-D_LIBCPP_BUILDING_LIBRARY',
+    '-D_LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS',
+    # TODO(sbc): clang recently introduced this new warning which is triggered
+    # by `filesystem/directory_iterator.cpp`: https://reviews.llvm.org/D119670
+    '-Wno-unqualified-std-cast-call',
+    '-Wno-unknown-warning-option',
+  ]
 
   src_dir = 'system/lib/libcxx/src'
   src_glob = '**/*.cpp'


### PR DESCRIPTION
A recent llvm change seem to have triggerd these errors in
directory_iterator.cpp: https://reviews.llvm.org/D119670
