### PR TITLE
Test more edge cases in test_unlink

### DIFF
--- a/tests/other/test_unlink.cpp
+++ b/tests/other/test_unlink.cpp
@@ -3,8 +3,11 @@
 // University of Illinois/NCSA Open Source License.  Both these licenses can be
 // found in the LICENSE file.
 
+#include <dirent.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <stdio.h>
+#include <string.h>
 #include <sys/stat.h>
 #include <unistd.h>
 
@@ -13,11 +16,8 @@ int main() {
   const char *dirname = "test";
 
   // Create a file
-  FILE *f = fopen(filename, "wb");
+  FILE* f = fopen(filename, "w+");
   if (f == NULL) {
-    return 1;
-  }
-  if (fclose(f)) {
     return 1;
   }
   // Check it exists
@@ -32,9 +32,30 @@ int main() {
   if (access(filename, F_OK) != -1) {
     return 1;
   }
+  // Check that we can still write to it
+  if (fwrite("hello", 1, 5, f) != 5) {
+    return 1;
+  }
+  // And seek in it.
+  if (fseek(f, 0, SEEK_SET) != 0) {
+    return 1;
+  }
+  // And read from it.
+  char buf[6] = {0};
+  if (fread(buf, 1, 5, f) != 5 || strcmp("hello", buf) != 0) {
+    return 1;
+  }
+  if (fclose(f)) {
+    return 1;
+  }
 
   // Create a directory
-  if (mkdir(dirname, 0700)) {
+  if (mkdir(dirname, 0700) != 0) {
+    return 1;
+  }
+  // Open the directory
+  DIR* d = opendir(dirname);
+  if (d == NULL) {
     return 1;
   }
   // Delete the directory
@@ -45,6 +66,17 @@ int main() {
   if (access(dirname, F_OK) != -1) {
     return 1;
   }
+  // Check that we can still read the directory, but that it is empty.
+  errno = 0;
+  if (readdir(d) != NULL || errno != 0) {
+    return 1;
+  }
+  // Check that we *cannot* create a child
+  if (openat(dirfd(d), filename, O_CREAT | O_WRONLY, S_IRWXU) != -1) {
+    return 1;
+  }
+
+  closedir(d);
 
   printf("ok\n");
 


### PR DESCRIPTION
Test that open files can still be read or written after they are unlinked and
that open directories can still be read after they are unlinked but that they
cannot gain new children.

Somewhat surprisingly, the old filesystem implementation passes this test with
no modifications. WasmFS cannot run it because it does not have an
implementation of `unlinkat`, and even if it did, it still would not pass.