### PR TITLE
Fix wasm-emscripten-finalize crash with pthreads + dylink + em_js + bigint

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -456,9 +456,7 @@ def compare_metadata(metadata, pymetadata):
 
 def finalize_wasm(infile, outfile, memfile):
   building.save_intermediate(infile, 'base.wasm')
-  # tell binaryen to look at the features section, and if there isn't one, to use MVP
-  # (which matches what llvm+lld has given us)
-  args = ['--minimize-wasm-changes']
+  args = []
 
   # if we don't need to modify the wasm, don't tell finalize to emit a wasm file
   modify_wasm = False
@@ -466,6 +464,13 @@ def finalize_wasm(infile, outfile, memfile):
   if settings.WASM2JS:
     # wasm2js requires full legalization (and will do extra wasm binary
     # later processing later anyhow)
+    modify_wasm = True
+  if settings.USE_PTHREADS and settings.RELOCATABLE:
+    # HACK: When settings.USE_PTHREADS and settings.RELOCATABLE are set finalize needs to scan
+    # more than just the start function for memory.init instructions.  This means it can't run
+    # with setSkipFunctionBodies() enabled.  Currently the only way to force this is to set an
+    # output file.
+    # TODO(sbc): Find a better way to do this.
     modify_wasm = True
   if settings.GENERATE_SOURCE_MAP:
     building.emit_wasm_source_map(infile, infile + '.map', outfile)

--- a/tests/hello_world_em_asm.c
+++ b/tests/hello_world_em_asm.c
@@ -11,4 +11,3 @@ int main() {
   EM_ASM({ out("hello, world!\n"); });
   return 0;
 }
-

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1713,6 +1713,22 @@ int f() {
     err = self.expect_fail([EMCC, '-Werror', '-sMAIN_MODULE', '-sUSE_PTHREADS', test_file('hello_world.c')])
     self.assertContained('error: -s MAIN_MODULE + pthreads is experimental', err)
 
+  @node_pthreads
+  def test_dylink_pthread_bigint_em_asm(self):
+    self.set_setting('MAIN_MODULE', 2)
+    self.set_setting('USE_PTHREADS')
+    self.set_setting('WASM_BIGINT')
+    self.emcc_args += ['-Wno-experimental']
+    self.do_runf(test_file('hello_world_em_asm.c'), 'hello, world')
+
+  @node_pthreads
+  def test_dylink_pthread_bigint_em_js(self):
+    self.set_setting('MAIN_MODULE', 2)
+    self.set_setting('USE_PTHREADS')
+    self.set_setting('WASM_BIGINT')
+    self.emcc_args += ['-Wno-experimental']
+    self.do_runf(test_file('core/test_em_js.cpp'))
+
   def test_dylink_no_autoload(self):
     create_file('main.c', r'''
       #include <stdio.h>


### PR DESCRIPTION
More of a workaround than a fix.

Fixes: #16109