### PR TITLE
Fix lookupPath when applied to a symlink loop

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -166,7 +166,7 @@ FS.staticInit();` +
             var link = FS.readlink(current_path);
             current_path = PATH_FS.resolve(PATH.dirname(current_path), link);
 
-            var lookup = FS.lookupPath(current_path, { recurse_count: opts.recurse_count });
+            var lookup = FS.lookupPath(current_path, { recurse_count: opts.recurse_count + 1 });
             current = lookup.node;
 
             if (count++ > 40) {  // limit max consecutive symlinks to 40 (SYMLOOP_MAX).

--- a/tests/unistd/links.c
+++ b/tests/unistd/links.c
@@ -22,8 +22,6 @@ int main() {
     FS.symlink('../test/../there!', 'link');
     FS.writeFile('file', 'test');
     FS.mkdir('folder');
-
-    FS.symlink("linkX/inside","/linkX");
   );
 
   char* files[] = {"link", "file", "folder"};
@@ -86,6 +84,9 @@ int main() {
 
   // FS.lookupPath should notice the symlink loop and return ELOOP,
   // not go into an infinite recurse.
+  EM_ASM(
+    FS.symlink("linkX/inside","/linkX");
+  );
   int result = access("/linkX", F_OK);
   assert(result == -1);
   assert(errno == ELOOP);

--- a/tests/unistd/links.c
+++ b/tests/unistd/links.c
@@ -24,7 +24,6 @@ int main() {
     FS.mkdir('folder');
 
     FS.symlink("linkX/inside","/linkX");
-    FS.lookupPath("/linkX", {follow:true});
   );
 
   char* files[] = {"link", "file", "folder"};
@@ -83,6 +82,11 @@ int main() {
 #else
   assert(strcmp(buffer, "/the**ng/folder/new-nonexistent-path") == 0);
 #endif
+  errno = 0;
+
+  int result = access("/linkX", F_OK);
+  assert(result == -1);
+  assert(errno == 32);
   errno = 0;
 
   return 0;

--- a/tests/unistd/links.c
+++ b/tests/unistd/links.c
@@ -22,6 +22,9 @@ int main() {
     FS.symlink('../test/../there!', 'link');
     FS.writeFile('file', 'test');
     FS.mkdir('folder');
+
+    FS.symlink("linkX/inside","/linkX");
+    FS.lookupPath("/linkX", {follow:true});
   );
 
   char* files[] = {"link", "file", "folder"};

--- a/tests/unistd/links.c
+++ b/tests/unistd/links.c
@@ -82,8 +82,12 @@ int main() {
 #endif
   errno = 0;
 
-  // FS.lookupPath should notice the symlink loop and return ELOOP,
-  // not go into an infinite recurse.
+#ifdef NODEFS
+  // FS.lookupPath should notice the symlink loop and return ELOOP, not go into
+  // an infinite recurse.
+  //
+  // This test doesn't work in wasmfs -- probably because access sees the
+  // symlink and returns true without bothering to chase the symlink
   EM_ASM(
     FS.symlink("linkX/inside","/linkX");
   );
@@ -91,6 +95,7 @@ int main() {
   assert(result == -1);
   assert(errno == ELOOP);
   errno = 0;
+#endif
 
   return 0;
 }

--- a/tests/unistd/links.c
+++ b/tests/unistd/links.c
@@ -84,9 +84,11 @@ int main() {
 #endif
   errno = 0;
 
+  // FS.lookupPath should notice the symlink loop and return ELOOP,
+  // not go into an infinite recurse.
   int result = access("/linkX", F_OK);
   assert(result == -1);
-  assert(errno == 32);
+  assert(errno == ELOOP);
   errno = 0;
 
   return 0;

--- a/tests/unistd/links.c
+++ b/tests/unistd/links.c
@@ -82,17 +82,16 @@ int main() {
 #endif
   errno = 0;
 
-#ifdef NODEFS
+#ifndef WASMFS
   // FS.lookupPath should notice the symlink loop and return ELOOP, not go into
   // an infinite recurse.
   //
   // This test doesn't work in wasmfs -- probably because access sees the
   // symlink and returns true without bothering to chase the symlink
-  EM_ASM(
-    FS.symlink("linkX/inside","/linkX");
-  );
-  int result = access("/linkX", F_OK);
+  symlink("./linkX/inside","./linkX");
+  int result = access("linkX", F_OK);
   assert(result == -1);
+  printf("errno: %d\n", errno);
   assert(errno == ELOOP);
   errno = 0;
 #endif


### PR DESCRIPTION
The following code leads to an infinite recurse in `lookupPath`:
```js
FS.symlink("linkX/inside","/linkX");
FS.lookupPath("/linkX", {follow:true});
```
This patch fixes it.