### PR TITLE
Fix deadlock after failed partial `munmap`

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,9 @@ See docs/process.md for more on how version tagging works.
 - Remove unmaintained ASMFS filesystem backend and associated `-sASMFS`
   settings.  The new wasmfs filesystem is far enough along that it seems clear
   that ASMFS will not need to be revived.
+- Fix deadlock in `munmap` that was introduced in 3.1.5.  The deadlock would
+  occur in multi-threaded programs when a partial unmap was requested (which
+  emscripten does not support). (#16413)
 
 3.1.6 - 02/24/2022
 ------------------

--- a/system/lib/libc/emscripten_mmap.c
+++ b/system/lib/libc/emscripten_mmap.c
@@ -63,6 +63,7 @@ long __syscall_munmap(long addr, long length) {
 
   // We don't support partial munmapping.
   if (map->length != length) {
+    UNLOCK(lock);
     return -EINVAL;
   }
 

--- a/tests/core/test_mmap.c
+++ b/tests/core/test_mmap.c
@@ -6,6 +6,7 @@
  */
 
 #include <stdio.h>
+#include <errno.h>
 #include <sys/mman.h>
 #include <assert.h>
 #include <unistd.h>
@@ -37,15 +38,18 @@ int main(int argc, char* argv[]) {
                         MAP_SHARED | MAP_ANON, -1, 0);
   assert(map != MAP_FAILED);
 
-  int i;
-
-  for (i = 0; i < NUM_INTS; i++) {
+  for (int i = 0; i < NUM_INTS; i++) {
     map[i] = i;
   }
 
-  for (i = 0; i < NUM_INTS; i++) {
+  for (int i = 0; i < NUM_INTS; i++) {
     assert(map[i] == i);
   }
+
+  // Emscripten does not support partial unmapping
+  int rtn = munmap(map, 65536);
+  assert(rtn == -1);
+  assert(errno == EINVAL);
 
   assert(munmap(map, NUM_BYTES) == 0);
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6189,6 +6189,15 @@ void* operator new(size_t size) {
 
     self.do_core_test('test_mmap.c')
 
+  @node_pthreads
+  def test_mmap_pthreads(self):
+    # Same test with threading enabled so give is some basic sanity
+    # checks of the locking on the internal data structures.
+    self.set_setting('PROXY_TO_PTHREAD')
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('INITIAL_MEMORY', '64mb')
+    self.do_core_test('test_mmap.c')
+
   def test_mmap_file(self):
     for extra_args in [[]]:
       self.emcc_args += ['--embed-file', 'data.dat'] + extra_args


### PR DESCRIPTION
This deadlock was introduced recently in #16304.

Fixes: #16406