### PR TITLE
Fix a system library build issue, where .S files would not be built with the same cmdline args as the other files.

### DIFF
--- a/tests/report_result.h
+++ b/tests/report_result.h
@@ -10,6 +10,8 @@
 #ifndef REPORT_RESULT_H_
 #define REPORT_RESULT_H_
 
+#ifndef __ASSEMBLER__ // Emit this file only to C/C++ language headers and not when preprocessing .S files
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,6 +35,8 @@ void _MaybeReportResult(int result, int sync);
   #define REPORT_RESULT_SYNC(result) _ReportResult((result), 1)
   #define MAYBE_REPORT_RESULT(result) _MaybeReportResult((result), 0)
   #define MAYBE_REPORT_RESULT_SYNC(result) _MaybeReportResult((result), 1)
+#endif
+
 #endif
 
 #endif // REPORT_RESULT_H_

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -290,7 +290,6 @@ class Library:
     commands = []
     objects = []
     cflags = self.get_cflags()
-    base_flags = get_base_cflags()
     case_insensitive = is_case_insensitive(build_dir)
     for src in self.get_files():
       object_basename = shared.unsuffixed_basename(src)
@@ -310,13 +309,12 @@ class Library:
         cmd = [shared.EMCC]
       else:
         cmd = [shared.EMXX]
+
+      cmd += cflags
       if ext in ('.s', '.S'):
-        cmd += base_flags
         # TODO(sbc) There is an llvm bug that causes a crash when `-g` is used with
         # assembly files that define wasm globals.
-        cmd.remove('-g')
-      else:
-        cmd += cflags
+        cmd = list(filter(lambda arg: arg != '-g', cmd))
       cmd = self.customize_build_cmd(cmd, src)
       commands.append(cmd + ['-c', src, '-o', o])
       objects.append(o)

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -314,7 +314,7 @@ class Library:
       if ext in ('.s', '.S'):
         # TODO(sbc) There is an llvm bug that causes a crash when `-g` is used with
         # assembly files that define wasm globals.
-        cmd = list(filter(lambda arg: arg != '-g', cmd))
+        cmd = [arg for arg in cmd if arg != '-g']
       cmd = self.customize_build_cmd(cmd, src)
       commands.append(cmd + ['-c', src, '-o', o])
       objects.append(o)


### PR DESCRIPTION
In particular, this would cause the .S files to not get the same preprocessor defines as .c and .cpp files have, so customizing .S files on preprocessor conditions was not possible.