### PR TITLE
library_pthread.js build flags checks

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2022,12 +2022,8 @@ def phase_linker_setup(options, state, newargs, user_settings):
     default_setting(user_settings, 'ABORTING_MALLOC', 0)
 
   if settings.USE_PTHREADS:
-    if settings.USE_PTHREADS == 2:
-      exit_with_error('USE_PTHREADS=2 is no longer supported')
     if settings.ALLOW_MEMORY_GROWTH:
       diagnostics.warning('pthreads-mem-growth', 'USE_PTHREADS + ALLOW_MEMORY_GROWTH may run non-wasm code slowly, see https://github.com/WebAssembly/design/issues/1271')
-    if settings.BUILD_AS_WORKER:
-      exit_with_error('USE_PTHREADS + BUILD_AS_WORKER require separate modes that don\'t work together, see https://github.com/emscripten-core/emscripten/issues/8854')
     settings.JS_LIBRARIES.append((0, 'library_pthread.js'))
     # Functions needs to be exported from the module since they are used in worker.js
     settings.REQUIRED_EXPORTS += [
@@ -2138,9 +2134,6 @@ def phase_linker_setup(options, state, newargs, user_settings):
         diagnostics.warning('experimental', '-s MAIN_MODULE + pthreads is experimental')
       elif settings.LINKABLE:
         diagnostics.warning('experimental', '-s LINKABLE + pthreads is experimental')
-
-    if settings.PROXY_TO_WORKER:
-      exit_with_error('--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.')
   elif settings.PROXY_TO_PTHREAD:
     exit_with_error('-s PROXY_TO_PTHREAD=1 requires -s USE_PTHREADS to work!')
 
@@ -2214,8 +2207,6 @@ def phase_linker_setup(options, state, newargs, user_settings):
     exit_with_error(f'Due to collision in variable name "Module", the shell file "{options.shell_path}" is not compatible with build options "-s MODULARIZE=1 -s EXPORT_NAME=Module". Either provide your own shell file, change the name of the export to something else to avoid the name collision. (see https://github.com/emscripten-core/emscripten/issues/7950 for details)')
 
   if settings.STANDALONE_WASM:
-    if settings.USE_PTHREADS:
-      exit_with_error('STANDALONE_WASM does not support pthreads yet')
     if settings.MINIMAL_RUNTIME:
       exit_with_error('MINIMAL_RUNTIME reduces JS size, and is incompatible with STANDALONE_WASM which focuses on ignoring JS anyhow and being 100% wasm')
     # the wasm must be runnable without the JS, so there cannot be anything that
@@ -2236,8 +2227,6 @@ def phase_linker_setup(options, state, newargs, user_settings):
     if settings.WASM2JS:
       # code size/memory and correctness issues TODO
       exit_with_error('EVAL_CTORS is not compatible with wasm2js yet')
-    elif settings.USE_PTHREADS:
-      exit_with_error('EVAL_CTORS is not compatible with pthreads yet (passive segments)')
     elif settings.RELOCATABLE:
       exit_with_error('EVAL_CTORS is not compatible with relocatable yet (movable segments)')
     elif settings.ASYNCIFY:

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -7,9 +7,9 @@
 #if !USE_PTHREADS
 #error Internal error! USE_PTHREADS should be enabled when including library_pthread.js.
 #endif
-#if !SHARED_MEMORY
-#error Internal error! SHARED_MEMORY should be enabled when including library_pthread.js.
-#endif
+//#if !SHARED_MEMORY
+//#error Internal error! SHARED_MEMORY should be enabled when including library_pthread.js.
+//#endif
 #if USE_PTHREADS == 2
 #error USE_PTHREADS=2 is no longer supported
 #endif

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -4,6 +4,13 @@
  * SPDX-License-Identifier: MIT
  */
 
+#if !USE_PTHREADS
+#error Internal error! USE_PTHREADS should be enabled when including library_pthread.js.
+#endif
+#if !SHARED_MEMORY
+#error Internal error! SHARED_MEMORY should be enabled when including library_pthread.js.
+#endif
+
 var LibraryPThread = {
   $PThread__postset: 'PThread.init();',
   $PThread__deps: ['_emscripten_thread_init',

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -5,25 +5,25 @@
  */
 
 #if !USE_PTHREADS
-#error Internal error! USE_PTHREADS should be enabled when including library_pthread.js.
+#error "Internal error! USE_PTHREADS should be enabled when including library_pthread.js."
 #endif
 //#if !SHARED_MEMORY
-//#error Internal error! SHARED_MEMORY should be enabled when including library_pthread.js.
+//#error "Internal error! SHARED_MEMORY should be enabled when including library_pthread.js.""
 //#endif
 #if USE_PTHREADS == 2
-#error USE_PTHREADS=2 is no longer supported
+#error "USE_PTHREADS=2 is no longer supported"
 #endif
 #if BUILD_AS_WORKER
-#error USE_PTHREADS + BUILD_AS_WORKER require separate modes that don\'t work together, see https://github.com/emscripten-core/emscripten/issues/8854
+#error "USE_PTHREADS + BUILD_AS_WORKER require separate modes that don't work together, see https://github.com/emscripten-core/emscripten/issues/8854"
 #endif
 #if PROXY_TO_WORKER
-#error --proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.
+#error "--proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker."
 #endif
 #if EVAL_CTORS
-#error EVAL_CTORS is not compatible with pthreads yet (passive segments)
+#error "EVAL_CTORS is not compatible with pthreads yet (passive segments)"
 #endif
 #if STANDALONE_WASM
-#error STANDALONE_WASM does not support shared memories yet
+#error "STANDALONE_WASM does not support shared memories yet"
 #endif
 
 var LibraryPThread = {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -22,6 +22,9 @@
 #if EVAL_CTORS
 #error EVAL_CTORS is not compatible with pthreads yet (passive segments)
 #endif
+#if STANDALONE_WASM
+#error STANDALONE_WASM does not support shared memories yet
+#endif
 
 var LibraryPThread = {
   $PThread__postset: 'PThread.init();',

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -10,6 +10,18 @@
 #if !SHARED_MEMORY
 #error Internal error! SHARED_MEMORY should be enabled when including library_pthread.js.
 #endif
+#if USE_PTHREADS == 2
+#error USE_PTHREADS=2 is no longer supported
+#endif
+#if BUILD_AS_WORKER
+#error USE_PTHREADS + BUILD_AS_WORKER require separate modes that don\'t work together, see https://github.com/emscripten-core/emscripten/issues/8854
+#endif
+#if PROXY_TO_WORKER
+#error --proxy-to-worker is not supported with -s USE_PTHREADS>0! Use the option -s PROXY_TO_PTHREAD=1 if you want to run the main thread of a multithreaded application in a web worker.
+#endif
+#if EVAL_CTORS
+#error EVAL_CTORS is not compatible with pthreads yet (passive segments)
+#endif
 
 var LibraryPThread = {
   $PThread__postset: 'PThread.init();',

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -7,6 +7,9 @@
 #if USE_PTHREADS
 #error Internal error! USE_PTHREADS should not be enabled when including library_pthread_stub.js.
 #endif
+#if STANDALONE_WASM && SHARED_MEMORY
+#error STANDALONE_WASM does not support shared memories yet
+#endif
 
 var LibraryPThreadStub = {
   // ===================================================================================

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -4,6 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
 
+#if USE_PTHREADS
+#error Internal error! USE_PTHREADS should not be enabled when including library_pthread_stub.js.
+#endif
+
 var LibraryPThreadStub = {
   // ===================================================================================
   // Stub implementation for pthread.h when not compiling with pthreads support enabled.

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -7,9 +7,9 @@
 #if USE_PTHREADS
 #error Internal error! USE_PTHREADS should not be enabled when including library_pthread_stub.js.
 #endif
-#if STANDALONE_WASM && SHARED_MEMORY
-#error STANDALONE_WASM does not support shared memories yet
-#endif
+//#if STANDALONE_WASM && SHARED_MEMORY
+//#error STANDALONE_WASM does not support shared memories yet
+//#endif
 
 var LibraryPThreadStub = {
   // ===================================================================================

--- a/src/library_pthread_stub.js
+++ b/src/library_pthread_stub.js
@@ -5,10 +5,10 @@
  */
 
 #if USE_PTHREADS
-#error Internal error! USE_PTHREADS should not be enabled when including library_pthread_stub.js.
+#error "Internal error! USE_PTHREADS should not be enabled when including library_pthread_stub.js."
 #endif
 //#if STANDALONE_WASM && SHARED_MEMORY
-//#error STANDALONE_WASM does not support shared memories yet
+//#error "STANDALONE_WASM does not support shared memories yet"
 //#endif
 
 var LibraryPThreadStub = {

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -2480,7 +2480,7 @@ void *getBindBuffer() {
   def test_worker_api_with_pthread_compilation_fails(self):
     self.run_process([EMCC, '-c', '-o', 'hello.o', test_file('hello_world.c')])
     stderr = self.expect_fail([EMCC, 'hello.o', '-o', 'a.js', '-g', '--closure=1', '-sUSE_PTHREADS', '-sBUILD_AS_WORKER=1'])
-    self.assertContained('error: USE_PTHREADS + BUILD_AS_WORKER require separate modes that don\'t work together, see https://github.com/emscripten-core/emscripten/issues/8854', stderr)
+    self.assertContained("USE_PTHREADS + BUILD_AS_WORKER require separate modes that don't work together, see https://github.com/emscripten-core/emscripten/issues/8854", stderr)
 
   def test_emscripten_async_wget2(self):
     self.btest_exit('test_emscripten_async_wget2.cpp')


### PR DESCRIPTION
Move pthreads build flag checks from emcc.py over to library_pthread.js.