### PR TITLE
Fix stack cookie location used by STACK_OVERFLOW_CHECK. NFC

### DIFF
--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -11,9 +11,11 @@ function writeStackCookie() {
 #if ASSERTIONS
   assert((max & 3) == 0);
 #endif
-  // The stack grows downwards
-  {{{ makeSetValue('max + 4', 0, '0x2135467', 'i32' ) }}};
-  {{{ makeSetValue('max + 8', 0, '0x89BACDFE', 'i32' ) }}};
+  // The stack grow downwards towards _emscripten_stack_get_end.
+  // We write cookies to the final two words in the stack and detect if they are
+  // ever overwritten.
+  {{{ makeSetValue('max', 0, '0x2135467', 'i32' ) }}};
+  {{{ makeSetValue('max', 4, '0x89BACDFE', 'i32' ) }}};
 #if !USE_ASAN && !SAFE_HEAP // ASan and SAFE_HEAP check address 0 themselves
   // Also test the global address 0 for integrity.
   HEAP32[0] = 0x63736d65; /* 'emsc' */
@@ -25,8 +27,8 @@ function checkStackCookie() {
   if (ABORT) return;
 #endif
   var max = _emscripten_stack_get_end();
-  var cookie1 = {{{ makeGetValue('max + 4', '0', 'i32', 0, true) }}};
-  var cookie2 = {{{ makeGetValue('max + 8', '0', 'i32', 0, true) }}};
+  var cookie1 = {{{ makeGetValue('max', 0, 'i32', 0, true) }}};
+  var cookie2 = {{{ makeGetValue('max', 4, 'i32', 0, true) }}};
   if (cookie1 != 0x2135467 || cookie2 != 0x89BACDFE) {
     abort('Stack overflow! Stack cookie has been overwritten, expected hex dwords 0x89BACDFE and 0x2135467, but received 0x' + cookie2.toString(16) + ' 0x' + cookie1.toString(16));
   }


### PR DESCRIPTION
I believe these values have always been written the wrong place (off by
one word) since they were adapted for the downward growing stack in #8811.

In the downward growing stack that last work in the stack lives a `max`
and not `max + 4`.