### PR TITLE
Move `-D_LIBCPP_ABI_VERSION=2` into source code. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -878,10 +878,6 @@ def get_cflags(user_args):
     for a in building.llvm_backend_args():
       cflags += ['-mllvm', a]
 
-  # Set the LIBCPP ABI version to at least 2 so that we get nicely aligned string
-  # data and other nice fixes.
-  cflags += ['-D_LIBCPP_ABI_VERSION=2']
-
   # Changes to default clang behavior
 
   # Implicit functions can cause horribly confusing function pointer type errors, see #2175

--- a/system/lib/libcxx/include/__config_site
+++ b/system/lib/libcxx/include/__config_site
@@ -1,1 +1,3 @@
-// empty
+// Set the LIBCPP ABI version 2 under emscripten so that we get nicely aligned string
+// data and other nice fixes.
+#define _LIBCPP_ABI_VERSION 2


### PR DESCRIPTION
There is no reason that I can see to set this in emcc.py.