### PR TITLE
Move test_support_errno.c to `other` and use a different JS library function. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1911,7 +1911,7 @@ LibraryManager.library = {
   },
 
   // note: lots of leaking here!
-  gethostbyaddr__deps: ['$DNS', '$getHostByName', '$inetNtop4'],
+  gethostbyaddr__deps: ['$DNS', '$getHostByName', '$inetNtop4', '$setErrNo'],
   gethostbyaddr__proxy: 'sync',
   gethostbyaddr__sig: 'iiii',
   gethostbyaddr: function (addr, addrlen, type) {

--- a/tests/core/test_support_errno.out
+++ b/tests/core/test_support_errno.out
@@ -1,3 +1,0 @@
-rtn     : -1
-errno   : 28
-strerror: Invalid argument

--- a/tests/other/test_support_errno.c
+++ b/tests/other/test_support_errno.c
@@ -9,11 +9,11 @@
 #include <errno.h>
 #include <string.h>
 #include <sys/types.h>
-#include <time.h>
+#include <netdb.h>
 
 int main() {
-  int rtn = clock_gettime(-1, NULL);
-  printf("rtn     : %d\n", rtn);
+  void* rtn = gethostbyaddr(NULL, 0, 0);
+  printf("rtn     : %p\n", rtn);
   printf("errno   : %d\n", errno);
   printf("strerror: %s\n", strerror(errno));
   return 0;

--- a/tests/other/test_support_errno.out
+++ b/tests/other/test_support_errno.out
@@ -1,0 +1,3 @@
+rtn     : 0
+errno   : 5
+strerror: Address family not supported by protocol

--- a/tests/other/test_support_errno_disabled.out
+++ b/tests/other/test_support_errno_disabled.out
@@ -1,3 +1,3 @@
-rtn     : -1
+rtn     : 0
 errno   : 0
 strerror: No error information

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -10447,8 +10447,8 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
   })
   def test_support_errno(self, args):
     self.emcc_args += args
-    src = test_file('core/test_support_errno.c')
-    output = test_file('core/test_support_errno.out')
+    src = test_file('other/test_support_errno.c')
+    output = test_file('other/test_support_errno.out')
 
     self.do_run_from_file(src, output)
     size_default = os.path.getsize('test_support_errno.js')
@@ -10456,7 +10456,7 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     # Run the same test again but with SUPPORT_ERRNO disabled.  This time we don't expect errno
     # to be set after the failing syscall.
     self.emcc_args += ['-sSUPPORT_ERRNO=0']
-    output = test_file('core/test_support_errno_disabled.out')
+    output = test_file('other/test_support_errno_disabled.out')
     self.do_run_from_file(src, output)
 
     # Verify the JS output was smaller


### PR DESCRIPTION
This test was under `core` instead of `other`.

Avoiding the use of `clock_gettime` since I'm about move that
to natice code with #16439.

Also, revealed a missed dependency we had in getpeername!