### PR TITLE
Better browser error reporting in test code. NFC

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -301,11 +301,13 @@ assert(typeof Int32Array != 'undefined' && typeof Float64Array !== 'undefined' &
 #endif
 
 #if IN_TEST_HARNESS
-// Test runs in browsers should always be free from uncaught exceptions. If an uncaught exception is thrown, we fail browser test execution in the REPORT_RESULT() macro to output an error value.
+// Test runs in browsers should always be free from uncaught exceptions. If an
+// uncaught exception is thrown, we fail browser test execution in the
+// REPORT_RESULT() macro to output an error value.
 if (ENVIRONMENT_IS_WEB) {
   window.addEventListener('error', function(e) {
     if (e.message.includes('unwind')) return;
-    console.error('Page threw an exception ' + e);
+    console.error('Page threw an error: ' + e.error.message);
     Module['pageThrewException'] = true;
   });
 }

--- a/tests/browser_reporting.js
+++ b/tests/browser_reporting.js
@@ -61,7 +61,7 @@ if (typeof window === 'object' && window) {
       xhr.send();
     }
   }
-  window.addEventListener('error', report_error);
+  window.addEventListener('error', event => report_error(event.error));
   window.addEventListener('unhandledrejection', event => report_error(event.reason));
 }
 


### PR DESCRIPTION
Rather than reporting `ErrorEvent` or `Object`, print a more useful error
message.  For `window.addEventListener` we know that the argument will
be an ErrorEvent which contains an `Error` object which itself contains
a `message` string.