### PR TITLE
Use btest_exit in tests/test_sockets.py. NFC

### DIFF
--- a/tests/sdl2_net_client.c
+++ b/tests/sdl2_net_client.c
@@ -46,11 +46,9 @@ void finish(int result) {
     SDLNet_Quit();
   }
 #ifdef __EMSCRIPTEN__
-  REPORT_RESULT(result);
-  emscripten_force_exit(result);
-#else
-  exit(result);
+  emscripten_cancel_main_loop();
 #endif
+  exit(result);
 }
 
 char *msgs[] = {

--- a/tests/sockets/test_enet_client.c
+++ b/tests/sockets/test_enet_client.c
@@ -5,6 +5,7 @@
  * found in the LICENSE file.
  */
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 #include <enet/enet.h>
@@ -40,12 +41,8 @@ void main_loop() {
               (char*)event.peer -> data,
               event.channelID);
 
-      int result = strcmp("packetfoo", (char*)event.packet->data);
-#ifdef __EMSCRIPTEN__
-      REPORT_RESULT(result);
-#else
+      assert(strcmp("packetfoo", (char*)event.packet->data) == 0);
       exit(EXIT_SUCCESS);
-#endif
 
       /* Clean up the packet now that we're done using it. */
       enet_packet_destroy (event.packet);

--- a/tests/sockets/test_sockets_echo_client.c
+++ b/tests/sockets/test_sockets_echo_client.c
@@ -45,18 +45,19 @@ int echo_read;
 int echo_wrote;
 
 void finish(int result) {
+  printf("finish: %d\n", result);
   if (server.fd) {
     close(server.fd);
     server.fd = 0;
   }
 #ifdef __EMSCRIPTEN__
-#ifdef REPORT_RESULT
-  REPORT_RESULT(result);
-#endif
+#if TEST_ASYNC
   emscripten_force_exit(result);
 #else
-  exit(result);
+  emscripten_cancel_main_loop();
 #endif
+#endif
+  exit(result);
 }
 
 void main_loop() {

--- a/tests/sockets/test_sockets_select_server_down_client.c
+++ b/tests/sockets/test_sockets_select_server_down_client.c
@@ -28,11 +28,9 @@ int sockfd = -1;
 void finish(int result) {
   close(sockfd);
 #ifdef __EMSCRIPTEN__
-  REPORT_RESULT(result);
-  emscripten_force_exit(result);
-#else
-  exit(result);
+  emscripten_cancel_main_loop();
 #endif
+  exit(result);
 }
 
 void iter() {
@@ -61,7 +59,7 @@ void iter() {
       finish(EXIT_FAILURE);
     } else if (!n) {
       perror("Connection to websocket server failed as expected.");
-      finish(266);
+      finish(0);
     }
   }
 }

--- a/tests/websocket/tcp_echo_client.cpp
+++ b/tests/websocket/tcp_echo_client.cpp
@@ -79,7 +79,7 @@ int main(int argc , char *argv[])
   if (sock == -1)
   {
     printf("Could not create socket");
-    exit(1);
+    return 1;
   }
   printf("Socket created: %d\n", sock);
 
@@ -116,8 +116,5 @@ int main(int argc , char *argv[])
   }
 
   close(sock);
-#ifdef REPORT_RESULT
-  REPORT_RESULT(101);
-#endif
   return 0;
 }

--- a/tests/websocket/test_websocket_send.c
+++ b/tests/websocket/test_websocket_send.c
@@ -35,10 +35,7 @@ EM_BOOL WebSocketMessage(int eventType, const EmscriptenWebSocketMessageEvent *e
 	if (e->isText)
 	{
 		printf("text data: \"%s\"\n", e->data);
-#ifdef REPORT_RESULT
-		if (!!strcmp((const char*)e->data, "hello on the other side")) REPORT_RESULT(-1);
-		passed += 1;
-#endif
+		assert(strcmp((const char*)e->data, "hello on the other side") == 0);
 	}
 	else
 	{
@@ -46,19 +43,13 @@ EM_BOOL WebSocketMessage(int eventType, const EmscriptenWebSocketMessageEvent *e
 		for(int i = 0; i < e->numBytes; ++i)
 		{
 			printf(" %02X", e->data[i]);
-#ifdef REPORT_RESULT
-			if (e->data[i] != i) REPORT_RESULT(-2);
-#endif
+			assert(e->data[i] == i);
 		}
 		printf("\n");
-		passed += 100;
 
 		emscripten_websocket_close(e->socket, 0, 0);
 		emscripten_websocket_delete(e->socket);
-#ifdef REPORT_RESULT
-		printf("%d\n", passed);
-		REPORT_RESULT(passed);
-#endif
+		emscripten_force_exit(0);
 	}
 	return 0;
 }
@@ -123,4 +114,6 @@ int main()
 	emscripten_websocket_set_onclose_callback(socket, (void*)43, WebSocketClose);
 	emscripten_websocket_set_onerror_callback(socket, (void*)44, WebSocketError);
 	emscripten_websocket_set_onmessage_callback(socket, (void*)45, WebSocketMessage);
+	emscripten_exit_with_live_runtime();
+	return 0;
 }


### PR DESCRIPTION
I saw this optimization/cleanup oportunity while working on #16443.         
                                                                                                                        
We were registering a handler both in `src/preamble.js` and in           
`tests/browser_reporting.js`, but we only need one.                      
                                                                         
All the `Module['pageThrewException']` handling is in                    
browser_reporting.js so there is no need for preamble to be involved        
here.  