### PR TITLE
Unify `onerror` event handler used in test code. NFC

### DIFF
--- a/src/preamble.js
+++ b/src/preamble.js
@@ -300,17 +300,6 @@ assert(typeof Int32Array != 'undefined' && typeof Float64Array !== 'undefined' &
        'JS engine does not provide full typed array support');
 #endif
 
-#if IN_TEST_HARNESS
-// Test runs in browsers should always be free from uncaught exceptions. If an uncaught exception is thrown, we fail browser test execution in the REPORT_RESULT() macro to output an error value.
-if (ENVIRONMENT_IS_WEB) {
-  window.addEventListener('error', function(e) {
-    if (e.message.includes('unwind')) return;
-    console.error('Page threw an exception ' + e);
-    Module['pageThrewException'] = true;
-  });
-}
-#endif
-
 #if IMPORTED_MEMORY
 // In non-standalone/normal mode, we create the memory here.
 #include "runtime_init_memory.js"

--- a/tests/browser_reporting.js
+++ b/tests/browser_reporting.js
@@ -13,9 +13,6 @@ function reportResultToServer(result, sync, port) {
     out('RESULT: ' + result);
   } else {
     var xhr = new XMLHttpRequest();
-    if (hasModule && Module['pageThrewException']) {
-      result = 'pageThrewException';
-    }
     xhr.open('GET', 'http://localhost:' + port + '/report_result?' + result, !sync);
     xhr.send();
     if (typeof window === 'object' && window && hasModule && !Module['pageThrewException']) {
@@ -56,12 +53,13 @@ if (typeof window === 'object' && window) {
       console.error(status);
       maybeReportResultToServer('exit:' + status);
     } else {
+      if (hasModule) Module['pageThrewException'] = true;
       var xhr = new XMLHttpRequest();
-      xhr.open('GET', encodeURI('http://localhost:8888?exception=' + e.message + ' / ' + e.stack));
+      xhr.open('GET', encodeURI('http://localhost:8888?exception=' + message + ' / ' + e.stack));
       xhr.send();
     }
   }
-  window.addEventListener('error', report_error);
+  window.addEventListener('error', event => report_error(event));
   window.addEventListener('unhandledrejection', event => report_error(event.reason));
 }
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -4366,7 +4366,7 @@ window.close = function() {
     size = os.path.getsize('test.js')
     print('size:', size)
     # Note that this size includes test harness additions (for reporting the result, etc.).
-    self.assertLess(abs(size - 5787), 100)
+    self.assertLess(abs(size - 5609), 100)
 
   # Tests that it is possible to initialize and render WebGL content in a pthread by using OffscreenCanvas.
   # -DTEST_CHAINED_WEBGL_CONTEXT_PASSING: Tests that it is possible to transfer WebGL canvas in a chain from main thread -> thread 1 -> thread 2 and then init and render WebGL content there.


### PR DESCRIPTION
We were registering a handler both in `src/preamble.js` and in
`tests/browser_reporting.js`, but we only need one.

All the `Module['pageThrewException']` handlign is in
browser_reporting.js so there is no need for preamble to be involved
here.