### PR TITLE
Remove TextDecoderWrapper

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1211,8 +1211,8 @@ function runtimeKeepalivePop() {
 // To avoid that, this function allows obtaining an unshared copy of an
 // ArrayBuffer.
 function getUnsharedTextDecoderView(heap, start, end) {
-  let shared = `${heap}.slice(${start}, ${end})`;
-  let unshared = `${heap}.subarray(${start}, ${end})`;
+  const shared = `${heap}.slice(${start}, ${end})`;
+  const unshared = `${heap}.subarray(${start}, ${end})`;
 
   // No need to worry about this in non-shared memory builds
   if (!SHARED_MEMORY) return unshared;

--- a/src/runtime_strings_extra.js
+++ b/src/runtime_strings_extra.js
@@ -32,9 +32,9 @@ function stringToAscii(str, outPtr) {
 // a copy of that string as a Javascript String object.
 
 #if TEXTDECODER == 2
-var UTF16Decoder = new TextDecoder{{{ SHARED_MEMORY ? 'Wrapper' : ''}}}('utf-16le');
+var UTF16Decoder = new TextDecoder('utf-16le');
 #elif TEXTDECODER == 1
-var UTF16Decoder = typeof TextDecoder != 'undefined' ? new TextDecoder{{{ SHARED_MEMORY ? 'Wrapper' : ''}}}('utf-16le') : undefined;
+var UTF16Decoder = typeof TextDecoder != 'undefined' ? new TextDecoder('utf-16le') : undefined;
 #endif
 
 function UTF16ToString(ptr, maxBytesToRead) {
@@ -55,7 +55,7 @@ function UTF16ToString(ptr, maxBytesToRead) {
 #if TEXTDECODER != 2
   if (endPtr - ptr > 32 && UTF16Decoder) {
 #endif // TEXTDECODER != 2
-    return UTF16Decoder.decode(HEAPU8.subarray(ptr, endPtr));
+    return UTF16Decoder.decode({{{ getUnsharedTextDecoderView('HEAPU8', 'ptr', 'endPtr') }}});
 #if TEXTDECODER != 2
   } else {
 #endif // TEXTDECODER != 2

--- a/tests/code_size/hello_wasm_worker_wasm.js
+++ b/tests/code_size/hello_wasm_worker_wasm.js
@@ -1,12 +1,6 @@
 var b = Module;
 
-var c = b.$ww;
-
-new function(a) {
-    new TextDecoder(a);
-}("utf8");
-
-var e, f;
+var c = b.$ww, e, f;
 
 e = b.mem || new WebAssembly.Memory({
     initial: 256,

--- a/tests/code_size/hello_wasm_worker_wasm.json
+++ b/tests/code_size/hello_wasm_worker_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 737,
   "a.html.gz": 433,
-  "a.js": 813,
-  "a.js.gz": 501,
+  "a.js": 765,
+  "a.js.gz": 475,
   "a.wasm": 1792,
   "a.wasm.gz": 989,
-  "total": 3342,
-  "total_gz": 1923
+  "total": 3294,
+  "total_gz": 1897
 }


### PR DESCRIPTION
Remove TextDecoderWrapper, and optimize performance of shared->unshared conversions via compile time analysis, and optimize generated code size.