### PR TITLE
Avoid Module.printErr in shell.html

### DIFF
--- a/src/shell.html
+++ b/src/shell.html
@@ -1285,7 +1285,7 @@
         Module.setStatus('Exception thrown, see JavaScript console');
         spinnerElement.style.display = 'none';
         Module.setStatus = function(text) {
-          if (text) Module.printErr('[post-exception status] ' + text);
+          if (text) console.error('[post-exception status] ' + text);
         };
       };
     </script>

--- a/src/shell_minimal.html
+++ b/src/shell_minimal.html
@@ -136,7 +136,7 @@
         Module.setStatus('Exception thrown, see JavaScript console');
         spinnerElement.style.display = 'none';
         Module.setStatus = function(text) {
-          if (text) Module.printErr('[post-exception status] ' + text);
+          if (text) console.error('[post-exception status] ' + text);
         };
       };
     </script>


### PR DESCRIPTION
This function won't exist unless its part of EXPORTED_RUNTIME_METHODS
which it is not by default.

This code used to work prior to #15555 but has been broken since
that landed and result is an error when printErr is called here.