### PR TITLE
Fix utime() syscall

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -1046,13 +1046,18 @@ var SyscallsLibrary = {
     assert(flags === 0);
 #endif
     path = SYSCALLS.calculateAt(dirfd, path, true);
-    var seconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_sec, 'i32') }}};
-    var nanoseconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_nsec, 'i32') }}};
-    var atime = (seconds*1000) + (nanoseconds/(1000*1000));
-    times += {{{ C_STRUCTS.timespec.__size__ }}};
-    seconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_sec, 'i32') }}};
-    nanoseconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_nsec, 'i32') }}};
-    var mtime = (seconds*1000) + (nanoseconds/(1000*1000));
+    if (times === 0) {
+      var atime = Date.now() / 1000;
+      var mtime = atime;
+    } else {
+      var seconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_sec, 'i32') }}};
+      var nanoseconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_nsec, 'i32') }}};
+      var atime = seconds + (nanoseconds/(1000*1000*1000));
+      times += {{{ C_STRUCTS.timespec.__size__ }}};
+      seconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_sec, 'i32') }}};
+      nanoseconds = {{{ makeGetValue('times', C_STRUCTS.timespec.tv_nsec, 'i32') }}};
+      var mtime = seconds + (nanoseconds/(1000*1000*1000));
+    }
     FS.utime(path, atime, mtime);
     return 0;
   },


### PR DESCRIPTION
Fix off by factor 1000: ``FS.utime()`` expects mtime and atime in seconds.

``times == NULL`` is now correctly handled. ``utimes(path, NULL)``
updates atime and mtime to current time.

https://nodejs.org/api/fs.html#fsutimespath-atime-mtime-callback

Fixes: #16458
Signed-off-by: Christian Heimes <christian@python.org>