### PR TITLE
workers: Use addEventListener instead of onmessage

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -242,7 +242,7 @@ var LibraryPThread = {
     //                    the workers have been initialized and are
     //                    ready to host pthreads.
     loadWasmModuleToWorker: function(worker, onFinishedLoading) {
-      worker.onmessage = (e) => {
+      worker.addEventListener('message', (e) => {
         var d = e['data'];
         var cmd = d['cmd'];
         // Sometimes we need to backproxy events to the calling thread (e.g.
@@ -303,7 +303,7 @@ var LibraryPThread = {
           err("worker sent an unknown command " + cmd);
         }
         PThread.currentProxiedOperationCallerThread = undefined;
-      };
+      });
 
       worker.onerror = (e) => {
         var message = 'worker sent an error!';

--- a/src/worker.js
+++ b/src/worker.js
@@ -105,7 +105,7 @@ Module['instantiateWasm'] = (info, receiveInstance) => {
 }
 #endif
 
-self.onmessage = (e) => {
+self.addEventListener('message', (e) => {
   try {
     if (e.data.cmd === 'load') { // Preload command that is called once per worker to parse and load the Emscripten code.
 #if PTHREADS_DEBUG
@@ -305,4 +305,4 @@ self.onmessage = (e) => {
     }
     throw ex;
   }
-};
+});


### PR DESCRIPTION
As a followup to discussions in #16239, use `addEventListener` instead of `onmessage` to receive messages in workers