### PR TITLE
Close fd leak in opendir / O_DIRECTORY

### DIFF
--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -90,6 +90,7 @@ mergeInto(LibraryManager.library, {
       var nfd = fs.openSync(pathTruncated, NODEFS.flagsForNode(flags), mode);
       var st = fs.fstatSync(nfd);
       if (flags & {{{ cDefine('O_DIRECTORY') }}} && !st.isDirectory()) {
+        fs.closeSync(nfd);
         throw new FS.ErrnoError(ERRNO_CODES.ENOTDIR);
       }
       var newMode = NODEFS.getMode(pathTruncated);


### PR DESCRIPTION
nfd must be closed when open() O_DIRECTORY fails with ENOTDIR.

Fixes: #16452
Signed-off-by: Christian Heimes <christian@python.org>