### PR TITLE
Temp: Use pass['endPass'] when pass['end'] is not available

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1890,7 +1890,12 @@ var LibraryWebGPU = {
 
   wgpuComputePassEncoderEnd: function(passId) {
     var pass = WebGPU.mgrComputePassEncoder.get(passId);
-    pass["end"]();
+    // TODO(shrekshao): remove once this API change moves to stable (e.g. in Chrome)
+    if (pass["end"]) {
+      pass["end"]();
+    } else {
+      pass["endPass"]();
+    }
   },
 
   // wgpuRenderPass
@@ -2024,7 +2029,12 @@ var LibraryWebGPU = {
 
   wgpuRenderPassEncoderEnd: function(passId) {
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
-    pass["end"]();
+    // TODO(shrekshao): remove once this API change moves to stable (e.g. in Chrome)
+    if (pass["end"]) {
+      pass["end"]();
+    } else {
+      pass["endPass"]();
+    }
   },
 
   // Render bundle encoder


### PR DESCRIPTION
Addressing #16465 
Intended reviewer: @kainino0x 