### PR TITLE
Handle empty listen sockets gracefully.

### DIFF
--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -563,6 +563,9 @@ mergeInto(LibraryManager.library, {
           throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
         }
         var newsock = listensock.pending.shift();
+        if (!newsock) {
+          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
+        }
         newsock.stream.flags = listensock.stream.flags;
         return newsock;
       },

--- a/src/library_sockfs.js
+++ b/src/library_sockfs.js
@@ -559,13 +559,10 @@ mergeInto(LibraryManager.library, {
 #endif // ENVIRONMENT_MAY_BE_NODE
       },
       accept: function(listensock) {
-        if (!listensock.server) {
+        if (!listensock.server || !listensock.pending.length) {
           throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
         }
         var newsock = listensock.pending.shift();
-        if (!newsock) {
-          throw new FS.ErrnoError({{{ cDefine('EINVAL') }}});
-        }
         newsock.stream.flags = listensock.stream.flags;
         return newsock;
       },


### PR DESCRIPTION
``accept()`` syscall no longer crashes with error message
``TypeError: Cannot read property 'stream' of undefined`` when sockfs
has no pending listen socket. The syscall now returns ``EINVAL`` on
error.

See: #16047
Signed-off-by: Christian Heimes <christian@python.org>