### PR TITLE
Remove WASM_WORKERS_NO_TLS option

### DIFF
--- a/site/source/docs/api_reference/wasm_workers.rst
+++ b/site/source/docs/api_reference/wasm_workers.rst
@@ -33,9 +33,8 @@ which shares the same WebAssembly.Module and WebAssembly.Memory object. Then a
 ``postMessage()`` is passed to the Worker to ask it to execute the function
 ``run_in_worker()`` to print a string.
 
-For more complex threading scenarios, see the functions ``emscripten_create_wasm_worker_with_tls()``
-and ``emscripten_create_wasm_worker_no_tls()`` on how to manage the memory resources that
-the thread will use.
+To explicitly control the memory allocation placement when creating a worker, use the
+function ``emscripten_create_wasm_worker()``.
 
 Introduction
 ============

--- a/src/settings.js
+++ b/src/settings.js
@@ -1480,12 +1480,6 @@ var USE_PTHREADS = 0;
 // [compile+link] - affects user code at compile and system libraries at link.
 var WASM_WORKERS = 0;
 
-// Wasm Worker option: set to 1 to disable TLS for small code size gain when
-// not using TLS. This setting can be used to verify that there is no leftover
-// state stored in a Worker when manually implementing thread pooling in Workers.
-// [link]
-var WASM_WORKERS_NO_TLS = 0;
-
 // In web browsers, Workers cannot be created while the main browser thread
 // is executing JS/Wasm code, but the main thread must regularly yield back
 // to the browser event loop for Worker initialization to occur.

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -17,28 +17,16 @@ extern "C" {
                                   behaves, the dynamically allocated memory can never be freed, so use this function
                                   only in scenarios where the page does not need to deinitialize/tear itself down.
 
-   emscripten_create_wasm_worker_no_tls: Creates a Wasm Worker on the given placed stack address area, but no TLS.
-                                         Use this function on codebase that explicitly do not have any TLS state,
-                                         e.g. when the Worker is being reset to reinit execution at runtime, or to micro-
-                                         optimize code size when TLS is not needed. This function will assert() fail if
-                                         the compiled code does have any TLS uses in it. This function does not use any
-                                         dynamic memory allocation.
-
-   emscripten_create_wasm_worker_with_tls: Creates a Wasm Worker on given placed stack address and TLS area.
-                                           Use the Wasm built-in functions __builtin_wasm_tls_align() and
-                                           __builtin_wasm_tls_size() to obtain the needed memory size for the TLS area
-                                           (though note that __builtin_wasm_tls_align() can return zero when the TLS size
-                                           is zero, so be careful to avoid a divide by zero if/when rounding to this alignment)
-                                           Use this function to manually manage the memory that a Worker should use.
-                                           This function does not use any dynamic memory allocation.
+   emscripten_create_wasm_worker: Creates a Wasm Worker on given placed stack address.
+                                  Use this function to manually manage the memory that a Worker should use.
+                                  This function does not use any dynamic memory allocation.
 
    Returns an ID that represents the given Worker. If not building with Wasm workers enabled (-s WASM_WORKERS=0),
    these functions will return 0 to denote failure.
    Note that the Worker will be loaded up asynchronously, and initially will not be executing any code. Use
    emscripten_wasm_worker_post_function_*() set of functions to start executing code on the Worker. */
 emscripten_wasm_worker_t emscripten_malloc_wasm_worker(uint32_t stackSize);
-emscripten_wasm_worker_t emscripten_create_wasm_worker_no_tls(void *stackLowestAddress, uint32_t stackSize);
-emscripten_wasm_worker_t emscripten_create_wasm_worker_with_tls(void *stackLowestAddress, uint32_t stackSize, void *tlsAddress, uint32_t tlsSize);
+emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize);
 
 // Terminates the given Wasm Worker some time after it has finished executing its current, or possibly some subsequent
 // posted functions. Note that this function is not C++ RAII safe, but you must manually coordinate to release any

--- a/system/lib/compiler-rt/stack_limits.S
+++ b/system/lib/compiler-rt/stack_limits.S
@@ -82,11 +82,13 @@ emscripten_stack_get_free:
 # __stack_base and __stack_end globals from a separate file as externs in order for that to work.
 .globl emscripten_wasm_worker_initialize
 emscripten_wasm_worker_initialize:
-  .functype emscripten_wasm_worker_initialize (PTR, i32, PTR) -> ()
+  .functype emscripten_wasm_worker_initialize (PTR /*stackLowestAddress*/, i32 /*stackSize*/) -> ()
 
+  // __stack_end = stackLowestAddress;
   local.get 0
   global.set __stack_end
 
+  // __stack_base = stackLowestAddress + stackSize;
   local.get 0
   local.get 1
 #ifdef __wasm64__
@@ -96,13 +98,23 @@ emscripten_wasm_worker_initialize:
   local.tee 0
   global.set __stack_base
 
+  // __stack_pointer = __stack_base;
   local.get 0
   global.set __stack_pointer
 
-  local.get 2
-  .functype __wasm_init_tls (PTR) -> ()
-  call __wasm_init_tls
+  // __wasm_init_tls(__stack_end);
+  // __stack_end += __builtin_wasm_tls_size();
+  global.get __stack_end
+  global.get __stack_end
+  .functype wasm_worker_init_tls (PTR) -> (i32)
+  call wasm_worker_init_tls
+#ifdef __wasm64__
+  i64.extend_i32_u
+#endif
+  PTR.add
+  global.set __stack_end
 
+  i32.const 0
   end_function
 #endif
 

--- a/system/lib/compiler-rt/stack_limits.S
+++ b/system/lib/compiler-rt/stack_limits.S
@@ -84,8 +84,18 @@ emscripten_stack_get_free:
 emscripten_wasm_worker_initialize:
   .functype emscripten_wasm_worker_initialize (PTR /*stackLowestAddress*/, i32 /*stackSize*/) -> ()
 
-  // __stack_end = stackLowestAddress;
+  // __stack_end = stackLowestAddress + (__builtin_wasm_tls_size() + 15) & -16;
   local.get 0
+  .globaltype __tls_size, PTR, immutable
+  global.get __tls_size
+#ifdef __wasm64__
+  i64.extend_i32_u
+#endif
+  PTR.add
+  PTR.const 0xf
+  PTR.add
+  PTR.const -0x10
+  PTR.and
   global.set __stack_end
 
   // __stack_base = stackLowestAddress + stackSize;
@@ -95,26 +105,21 @@ emscripten_wasm_worker_initialize:
   i64.extend_i32_u
 #endif
   PTR.add
-  local.tee 0
   global.set __stack_base
 
-  // __stack_pointer = __stack_base;
+  // __wasm_init_tls(stackLowestAddress);
   local.get 0
+  .functype __wasm_init_tls (PTR) -> ()
+  call __wasm_init_tls
+
+  // N.b. The function __wasm_init_tls above does not need
+  // __stack_pointer initialized, and it destroys the value it was set to.
+  // So we must initialize __stack_pointer only *after* completing __wasm_init_tls:
+
+  // __stack_pointer = __stack_base;
+  global.get __stack_base
   global.set __stack_pointer
 
-  // __wasm_init_tls(__stack_end);
-  // __stack_end += __builtin_wasm_tls_size();
-  global.get __stack_end
-  global.get __stack_end
-  .functype wasm_worker_init_tls (PTR) -> (i32)
-  call wasm_worker_init_tls
-#ifdef __wasm64__
-  i64.extend_i32_u
-#endif
-  PTR.add
-  global.set __stack_end
-
-  i32.const 0
   end_function
 #endif
 

--- a/system/lib/wasm_worker/library_wasm_worker.c
+++ b/system/lib/wasm_worker/library_wasm_worker.c
@@ -2,6 +2,7 @@
 #include <emscripten/wasm_worker.h>
 #include <emscripten/threading.h>
 #include <emscripten/heap.h>
+#include <emscripten/stack.h>
 #include <malloc.h>
 
 #ifndef __EMSCRIPTEN_WASM_WORKERS__
@@ -9,61 +10,55 @@
 #endif
 
 // Options:
-// #define WASM_WORKER_NO_TLS 0/1 : set to 1 to disable TLS compilation support for a small code size gain
 // #define STACK_OVERFLOW_CHECK 0/1/2 : set to the current stack overflow check mode
 
 // Internal implementation function in JavaScript side that emscripten_create_wasm_worker() calls to
 // to perform the wasm worker creation.
-emscripten_wasm_worker_t _emscripten_create_wasm_worker_with_tls(void *stackLowestAddress, uint32_t stackSize, void *tlsAddress);
-emscripten_wasm_worker_t _emscripten_create_wasm_worker_no_tls(void *stackLowestAddress, uint32_t stackSize);
+emscripten_wasm_worker_t _emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize);
 
 void __wasm_init_tls(void *memory);
 
-#if !WASM_WORKER_NO_TLS
 __attribute__((constructor(48)))
 static void emscripten_wasm_worker_main_thread_initialize() {
 	uintptr_t* sbrk_ptr = emscripten_get_sbrk_ptr();
 	__wasm_init_tls((void*)*sbrk_ptr);
 	*sbrk_ptr += __builtin_wasm_tls_size();
 }
-#endif
 
-emscripten_wasm_worker_t emscripten_create_wasm_worker_with_tls(void *stackLowestAddress, uint32_t stackSize, void *tlsAddress, uint32_t tlsSize)
-{
-#if WASM_WORKER_NO_TLS
-	return emscripten_create_wasm_worker_no_tls(stackLowestAddress, stackSize);
-#else
-	assert((uintptr_t)stackLowestAddress % 16 == 0);
-	assert(stackSize % 16 == 0);
-	assert(__builtin_wasm_tls_align() != 0 || __builtin_wasm_tls_size() == 0); // Internal consistency check: Clang can report __builtin_wasm_tls_align to be zero if there is no TLS used - double check it never reports zero if it is used.
-	assert(__builtin_wasm_tls_align() == 0 || (uintptr_t)tlsAddress % __builtin_wasm_tls_align() == 0 && "TLS memory address not aligned in a call to emscripten_create_wasm_worker_with_tls()! Please allocate memory with alignment from __builtin_wasm_tls_align() when creating a Wasm Worker!");
-	assert(tlsSize != 0 || __builtin_wasm_tls_size() == 0 && "Program code contains TLS: please use function emscripten_create_wasm_worker_with_tls() to create a Wasm Worker!");
-	assert(tlsSize == __builtin_wasm_tls_size() && "TLS size mismatch! Please reserve exactly __builtin_wasm_tls_size() TLS memory in a call to emscripten_create_wasm_worker_with_tls()");
-	assert(tlsAddress != 0 || tlsSize == 0);
-	return _emscripten_create_wasm_worker_with_tls((void*)stackLowestAddress, stackSize, tlsAddress);
-#endif
+// TODO: If it is possible to directly access __builtin_wasm_tls_size() and __builtin_wasm_tls_align()
+// from system/lib/compiler-rt/stack_limits.S, then this function can be merged into there.
+uint32_t wasm_worker_init_tls(void *stackLowestAddress) {
+  size_t alignedTlsSize = (__builtin_wasm_tls_size() + 15) & -16;
+  assert(__builtin_wasm_tls_align() == 0 || (uintptr_t)stackLowestAddress % __builtin_wasm_tls_align() == 0);
+  __wasm_init_tls(stackLowestAddress);
+  return alignedTlsSize;
 }
 
-emscripten_wasm_worker_t emscripten_create_wasm_worker_no_tls(void *stackLowestAddress, uint32_t stackSize)
+emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize)
 {
-#if !WASM_WORKER_NO_TLS
-	return emscripten_create_wasm_worker_with_tls(stackLowestAddress, stackSize, 0, 0);
-#else
+	assert(stackLowestAddress != 0);
 	assert((uintptr_t)stackLowestAddress % 16 == 0);
+	assert(stackSize > 0);
 	assert(stackSize % 16 == 0);
-	assert(__builtin_wasm_tls_size() == 0 && "Cannot disable TLS with -sWASM_WORKERS_NO_TLS=1 when compiling code that does require TLS! Rebuild with -sWASM_WORKERS_NO_TLS=1 removed, or remove uses of TLS from the codebase.");
-	return _emscripten_create_wasm_worker_no_tls((void*)stackLowestAddress, stackSize);
-#endif
+
+	// Guard against a programming oopsie: The target Worker's stack cannot be part of the calling
+	// thread's stack.
+	assert(emscripten_stack_get_base() <= stackLowestAddress || emscripten_stack_get_end() >= stackLowestAddress + stackSize
+		&& "When creating a Wasm Worker, its stack should be located either in global data or on the heap, not on the calling thread's own stack!");
+
+	// The Worker's TLS area will be spliced off from the stack region.
+    // We expect TLS area to need to be at most 16 bytes aligned
+	assert(__builtin_wasm_tls_align() == 0 || 16 % __builtin_wasm_tls_align() == 0);
+
+	uint32_t tlsSize = (__builtin_wasm_tls_size() + 15) & -16;
+	assert(stackSize > tlsSize);
+
+	return _emscripten_create_wasm_worker(stackLowestAddress, stackSize);
 }
 
 emscripten_wasm_worker_t emscripten_malloc_wasm_worker(uint32_t stackSize)
 {
-#if WASM_WORKER_NO_TLS
-	return emscripten_create_wasm_worker_no_tls(memalign(16, stackSize), stackSize);
-#else
-	uint32_t tlsSize = __builtin_wasm_tls_size();
-	return emscripten_create_wasm_worker_with_tls(memalign(16, stackSize), stackSize, tlsSize ? memalign(__builtin_wasm_tls_align(), tlsSize) : 0, tlsSize);
-#endif
+	return emscripten_create_wasm_worker(memalign(16, stackSize), stackSize);
 }
 
 void emscripten_wasm_worker_sleep(int64_t nsecs)

--- a/system/lib/wasm_worker/library_wasm_worker_stub.c
+++ b/system/lib/wasm_worker/library_wasm_worker_stub.c
@@ -8,11 +8,7 @@
 #error __EMSCRIPTEN_WASM_WORKERS__ should not be defined when building this file!
 #endif
 
-emscripten_wasm_worker_t emscripten_create_wasm_worker_with_tls(void *stackLowestAddress, uint32_t stackSize, void *tlsAddress, uint32_t tlsSize) {
-  return 0;
-}
-
-emscripten_wasm_worker_t emscripten_create_wasm_worker_no_tls(void *stackLowestAddress, uint32_t stackSize) {
+emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize) {
   return 0;
 }
 

--- a/tests/code_size/hello_wasm_worker_wasm.js
+++ b/tests/code_size/hello_wasm_worker_wasm.js
@@ -30,7 +30,7 @@ var p, q;
 
 WebAssembly.instantiate(b.wasm, {
     a: {
-        b: function(a, d, t) {
+        b: function(a, d) {
             let r = h[k] = new Worker(b.$wb);
             r.postMessage({
                 $ww: k,
@@ -38,8 +38,7 @@ WebAssembly.instantiate(b.wasm, {
                 js: b.js,
                 mem: e,
                 sb: a,
-                sz: d,
-                tb: t
+                sz: d
             });
             r.addEventListener("message", n);
             return k++;
@@ -63,7 +62,7 @@ WebAssembly.instantiate(b.wasm, {
     p = a.g;
     q = a.i;
     f = a.h;
-    c ? (a = b, q(a.sb, a.sz, a.tb), removeEventListener("message", l), m = m.forEach(n), 
+    c ? (a = b, q(a.sb, a.sz), removeEventListener("message", l), m = m.forEach(n), 
     addEventListener("message", n)) : a.f();
     c || p();
 }));

--- a/tests/code_size/hello_wasm_worker_wasm.json
+++ b/tests/code_size/hello_wasm_worker_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 737,
   "a.html.gz": 433,
-  "a.js": 765,
-  "a.js.gz": 475,
-  "a.wasm": 1792,
-  "a.wasm.gz": 989,
-  "total": 3294,
-  "total_gz": 1897
+  "a.js": 753,
+  "a.js.gz": 468,
+  "a.wasm": 1800,
+  "a.wasm.gz": 994,
+  "total": 3290,
+  "total_gz": 1895
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 594,
-  "a.html.gz": 389,
+  "a.html": 567,
+  "a.html.gz": 379,
   "a.js": 20046,
   "a.js.gz": 8213,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 23811,
-  "total_gz": 11316
+  "total": 23784,
+  "total_gz": 11306
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 594,
-  "a.html.gz": 389,
+  "a.html": 567,
+  "a.html.gz": 379,
   "a.js": 19531,
   "a.js.gz": 8049,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 23296,
-  "total_gz": 11152
+  "total": 23269,
+  "total_gz": 11142
 }

--- a/tests/code_size/hello_world_wasm2js.json
+++ b/tests/code_size/hello_world_wasm2js.json
@@ -1,10 +1,10 @@
 {
-  "a.html": 705,
-  "a.html.gz": 441,
+  "a.html": 671,
+  "a.html.gz": 430,
   "a.js": 870,
   "a.js.gz": 510,
   "a.mem": 6,
   "a.mem.gz": 32,
-  "total": 1581,
-  "total_gz": 983
+  "total": 1547,
+  "total_gz": 972
 }

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5088,6 +5088,11 @@ window.close = function() {
   def test_wasm_worker_hello(self):
     self.btest(test_file('wasm_worker/hello_wasm_worker.c'), expected='0', args=['-sWASM_WORKERS'])
 
+  # Tests the hello_wasm_worker.c documentation example code.
+  @also_with_minimal_runtime
+  def test_wasm_worker_hello_wasm2js(self):
+    self.btest(test_file('wasm_worker/hello_wasm_worker.c'), expected='0', args=['-sWASM_WORKERS', '-sWASM=0'])
+
   # Tests the WASM_WORKERS=2 build mode, which embeds the Wasm Worker bootstrap JS script file to the main JS file.
   @also_with_minimal_runtime
   def test_wasm_worker_embedded(self):
@@ -5097,11 +5102,6 @@ window.close = function() {
   @also_with_minimal_runtime
   def test_wasm_worker_thread_stack(self):
     self.btest(test_file('wasm_worker/thread_stack.c'), expected='0', args=['-sWASM_WORKERS'])
-
-  # Tests Wasm Worker thread stack setup without TLS support active
-  @also_with_minimal_runtime
-  def test_wasm_worker_thread_stack_no_tls(self):
-    self.btest(test_file('wasm_worker/thread_stack.c'), expected='0', args=['-sWASM_WORKERS', '-sWASM_WORKERS_NO_TLS'])
 
   # Tests emscripten_malloc_wasm_worker() and emscripten_current_thread_is_wasm_worker() functions
   @also_with_minimal_runtime

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5088,7 +5088,7 @@ window.close = function() {
   def test_wasm_worker_hello(self):
     self.btest(test_file('wasm_worker/hello_wasm_worker.c'), expected='0', args=['-sWASM_WORKERS'])
 
-  # Tests the hello_wasm_worker.c documentation example code.
+  # Tests Wasm Workers build in Wasm2JS mode.
   @also_with_minimal_runtime
   def test_wasm_worker_hello_wasm2js(self):
     self.btest(test_file('wasm_worker/hello_wasm_worker.c'), expected='0', args=['-sWASM_WORKERS', '-sWASM=0'])

--- a/tests/wasm_worker/c11__Thread_local.c
+++ b/tests/wasm_worker/c11__Thread_local.c
@@ -25,13 +25,12 @@ void worker_main()
 }
 
 char stack[1024];
-char tlsBase[1024];
 
 int main()
 {
   EM_ASM(console.log($0), tls);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_with_tls(stack, sizeof(stack), tlsBase, __builtin_wasm_tls_size());
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/cpp11_thread_local.cpp
+++ b/tests/wasm_worker/cpp11_thread_local.cpp
@@ -24,13 +24,12 @@ void worker_main()
 }
 
 char stack[1024];
-char tlsBase[1024];
 
 int main()
 {
   EM_ASM(console.log($0), tls);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_with_tls(stack, sizeof(stack), tlsBase, __builtin_wasm_tls_size());
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/gcc___Thread.c
+++ b/tests/wasm_worker/gcc___Thread.c
@@ -25,13 +25,12 @@ void worker_main()
 }
 
 char stack[1024];
-char tlsBase[1024];
 
 int main()
 {
   EM_ASM(console.log($0), tls);
   assert(!emscripten_current_thread_is_wasm_worker());
   tls = 42;
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_with_tls(stack, sizeof(stack), tlsBase, __builtin_wasm_tls_size());
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/hardware_concurrency_is_lock_free.c
+++ b/tests/wasm_worker/hardware_concurrency_is_lock_free.c
@@ -30,6 +30,6 @@ char stack[1024];
 int main()
 {
   test();
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/lock_async_acquire.c
+++ b/tests/wasm_worker/lock_async_acquire.c
@@ -99,8 +99,7 @@ int main()
 #define NUM_THREADS 10
   for(int i = 0; i < NUM_THREADS; ++i)
   {
-    void *stack = memalign(16, 1024);
-    emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, 1024);
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
     emscripten_wasm_worker_post_function_vi(worker, (void (*)(int))schedule_work, 0);
   }
 

--- a/tests/wasm_worker/lock_busyspin_wait_acquire.c
+++ b/tests/wasm_worker/lock_busyspin_wait_acquire.c
@@ -45,6 +45,6 @@ int main()
 {
   test();
 
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/lock_busyspin_waitinf_acquire.c
+++ b/tests/wasm_worker/lock_busyspin_waitinf_acquire.c
@@ -35,7 +35,7 @@ int main()
 
   // Spawn a Worker to try to take the lock. It will succeed only after releaseLock()
   // gets called.
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 
   emscripten_set_timeout(releaseLock, 1000, 0);

--- a/tests/wasm_worker/lock_wait_acquire.c
+++ b/tests/wasm_worker/lock_wait_acquire.c
@@ -42,6 +42,6 @@ char stack[1024];
 
 int main()
 {
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/lock_wait_acquire2.c
+++ b/tests/wasm_worker/lock_wait_acquire2.c
@@ -50,8 +50,8 @@ char stack2[1024];
 
 int main()
 {
-  emscripten_wasm_worker_t worker1 = emscripten_create_wasm_worker_no_tls(stack1, sizeof(stack1));
-  emscripten_wasm_worker_t worker2 = emscripten_create_wasm_worker_no_tls(stack2, sizeof(stack2));
+  emscripten_wasm_worker_t worker1 = emscripten_create_wasm_worker(stack1, sizeof(stack1));
+  emscripten_wasm_worker_t worker2 = emscripten_create_wasm_worker(stack2, sizeof(stack2));
   emscripten_wasm_worker_post_function_v(worker1, worker1_main);
   emscripten_wasm_worker_post_function_v(worker2, worker2_main);
 }

--- a/tests/wasm_worker/lock_waitinf_acquire.c
+++ b/tests/wasm_worker/lock_waitinf_acquire.c
@@ -68,8 +68,7 @@ int main()
   numWorkersAlive = NUM_THREADS;
   for(int i = 0; i < NUM_THREADS; ++i)
   {
-    void *stack = memalign(16, 1024);
-    emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, 1024);
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
     emscripten_wasm_worker_post_function_v(worker, worker_main);
   }
 }

--- a/tests/wasm_worker/no_proxied_js_functions.c
+++ b/tests/wasm_worker/no_proxied_js_functions.c
@@ -47,6 +47,6 @@ char stack[1024];
 int main()
 {
   proxied_js_function();
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/post_function.c
+++ b/tests/wasm_worker/post_function.c
@@ -94,7 +94,7 @@ char stack[1024];
 int main()
 {
   assert(!emscripten_current_thread_is_wasm_worker());
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, v);
   emscripten_wasm_worker_post_function_vi(worker, vi, 1);
   emscripten_wasm_worker_post_function_vii(worker, vii, 2, 3);

--- a/tests/wasm_worker/post_function_to_main_thread.c
+++ b/tests/wasm_worker/post_function_to_main_thread.c
@@ -31,6 +31,6 @@ char stack[1024];
 
 int main()
 {
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/semaphore_waitinf_acquire.c
+++ b/tests/wasm_worker/semaphore_waitinf_acquire.c
@@ -77,15 +77,13 @@ int main()
 {
   emscripten_semaphore_init(&threadsWaiting, 0);
 
-  void *stack = memalign(16, 1024);
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, 1024);
+  emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
   emscripten_wasm_worker_post_function_v(worker, control_thread);
 
 #define NUM_THREADS 6
   for(int i = 0; i < NUM_THREADS; ++i)
   {
-    void *stack = memalign(16, 1024);
-    emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, 1024);
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
     emscripten_wasm_worker_post_function_v(worker, worker_main);
   }
 }

--- a/tests/wasm_worker/terminate_all_wasm_workers.c
+++ b/tests/wasm_worker/terminate_all_wasm_workers.c
@@ -75,8 +75,8 @@ void terminate_worker(void *userData)
 
 int main()
 {
-  worker[0] = emscripten_create_wasm_worker_no_tls(stack1, sizeof(stack1));
-  worker[1] = emscripten_create_wasm_worker_no_tls(stack2, sizeof(stack2));
+  worker[0] = emscripten_create_wasm_worker(stack1, sizeof(stack1));
+  worker[1] = emscripten_create_wasm_worker(stack2, sizeof(stack2));
   emscripten_wasm_worker_post_function_v(worker[0], worker_main);
   emscripten_wasm_worker_post_function_v(worker[1], worker_main);
 

--- a/tests/wasm_worker/terminate_wasm_worker.c
+++ b/tests/wasm_worker/terminate_wasm_worker.c
@@ -73,7 +73,7 @@ void terminate_worker(void *userData)
 
 int main()
 {
-  worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 
   // Terminate the worker after a small delay

--- a/tests/wasm_worker/thread_stack.c
+++ b/tests/wasm_worker/thread_stack.c
@@ -36,7 +36,7 @@ int main()
   for(int i = 0; i < NUM_THREADS; ++i)
   {
     thread_stack[i] = memalign(16, THREAD_STACK_SIZE);
-    emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(thread_stack[i], THREAD_STACK_SIZE);
+    emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(thread_stack[i], THREAD_STACK_SIZE);
     EM_ASM(console.log(`Created thread ${$0} with stack ptr=0x${$1.toString(16)}, size=0x${$2.toString(16)}`), i, thread_stack[i], THREAD_STACK_SIZE);
     emscripten_wasm_worker_post_function_vi(worker, test_stack, i);
   }

--- a/tests/wasm_worker/wait32_notify.c
+++ b/tests/wasm_worker/wait32_notify.c
@@ -67,7 +67,7 @@ EM_BOOL main_loop(double time, void *userData)
 int main()
 {
   console_log("main: creating worker");
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   console_log("main: posting function");
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 

--- a/tests/wasm_worker/wait64_notify.c
+++ b/tests/wasm_worker/wait64_notify.c
@@ -67,7 +67,7 @@ EM_BOOL main_loop(double time, void *userData)
 int main()
 {
   console_log("main: creating worker");
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   console_log("main: posting function");
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 

--- a/tests/wasm_worker/wait_async.c
+++ b/tests/wasm_worker/wait_async.c
@@ -59,7 +59,7 @@ void asyncWaitFinishedShouldBeOk(int32_t *ptr, uint32_t val, ATOMICS_WAIT_RESULT
 int main()
 {
   console_log("main: creating worker");
-  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+  emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
   console_log("main: posting function");
   emscripten_wasm_worker_post_function_v(worker, worker_main);
 

--- a/tests/wasm_worker/wasm_worker_self_id.c
+++ b/tests/wasm_worker/wasm_worker_self_id.c
@@ -45,8 +45,8 @@ char stack2[1024];
 int main()
 {
 	assert(emscripten_wasm_worker_self_id() == 0);
-	worker1 = emscripten_create_wasm_worker_no_tls(stack1, sizeof(stack1));
-	worker2 = emscripten_create_wasm_worker_no_tls(stack2, sizeof(stack2));
+	worker1 = emscripten_create_wasm_worker(stack1, sizeof(stack1));
+	worker2 = emscripten_create_wasm_worker(stack2, sizeof(stack2));
 	emscripten_wasm_worker_post_function_v(worker1, worker1_main);
 	emscripten_wasm_worker_post_function_v(worker2, worker2_main);
 }

--- a/tests/wasm_worker/wasm_worker_sleep.c
+++ b/tests/wasm_worker/wasm_worker_sleep.c
@@ -19,6 +19,6 @@ char stack[1024];
 
 int main()
 {
-	emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+	emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
 	emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tests/wasm_worker/wasm_worker_tls_wasm_assembly.c
+++ b/tests/wasm_worker/wasm_worker_tls_wasm_assembly.c
@@ -35,6 +35,6 @@ int main()
 	assert(globalData == 1);
 	globalData = 2;
 	set_tls_variable(42);
-	emscripten_wasm_worker_t worker = emscripten_create_wasm_worker_no_tls(stack, sizeof(stack));
+	emscripten_wasm_worker_t worker = emscripten_create_wasm_worker(stack, sizeof(stack));
 	emscripten_wasm_worker_post_function_v(worker, worker_main);
 }

--- a/tools/minimal_runtime_shell.py
+++ b/tools/minimal_runtime_shell.py
@@ -54,7 +54,7 @@ def generate_minimal_runtime_load_statement(target_basename):
     files_to_load += ["binary('%s')" % (target_basename + '.mem')]
 
   # Download .wasm file
-  if settings.WASM == 1 or not download_wasm:
+  if (settings.WASM == 1 and settings.WASM2JS == 0) or not download_wasm:
     if settings.MODULARIZE:
       modularize_imports += ['wasm: r[%d]' % len(files_to_load)]
     else:

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1031,7 +1031,6 @@ class libprintf_long_double(libc):
 
 class libwasm_workers(MTLibrary):
   def __init__(self, **kwargs):
-    self.tls = kwargs.pop('tls')
     self.stack_check = kwargs.pop('stack_check')
     self.debug = kwargs.pop('debug')
     super().__init__(**kwargs)
@@ -1041,8 +1040,7 @@ class libwasm_workers(MTLibrary):
   def get_cflags(self):
     cflags = ['-pthread',
               '-D_DEBUG' if self.debug else '-Oz',
-              '-DSTACK_OVERFLOW_CHECK=' + ('2' if self.stack_check else '0'),
-              '-DWASM_WORKER_NO_TLS=' + ('0' if self.tls else '1')]
+              '-DSTACK_OVERFLOW_CHECK=' + ('2' if self.stack_check else '0')]
     if not self.debug:
       cflags += ['-DNDEBUG']
     if self.is_ww or self.is_mt:
@@ -1055,8 +1053,6 @@ class libwasm_workers(MTLibrary):
     name = 'libwasm_workers'
     if not self.is_ww and not self.is_mt:
       name += '_stub'
-    if not self.tls:
-      name += '-notls'
     if self.debug:
       name += '-debug'
     if self.stack_check:
@@ -1065,11 +1061,11 @@ class libwasm_workers(MTLibrary):
 
   @classmethod
   def vary_on(cls):
-    return super().vary_on() + ['tls', 'debug', 'stack_check']
+    return super().vary_on() + ['debug', 'stack_check']
 
   @classmethod
   def get_default_variation(cls, **kwargs):
-    return super().get_default_variation(tls=not settings.WASM_WORKERS_NO_TLS, debug=settings.ASSERTIONS >= 1, stack_check=settings.STACK_OVERFLOW_CHECK == 2, **kwargs)
+    return super().get_default_variation(debug=settings.ASSERTIONS >= 1, stack_check=settings.STACK_OVERFLOW_CHECK == 2, **kwargs)
 
   def get_files(self):
     return files_in_path(


### PR DESCRIPTION
Remove WASM_WORKERS_NO_TLS option, and simplify Wasm Worker TLS creation by hiding it as an implementation detail - TLS block and stack will be initialized to the combined linear memory area passed for the Wasm Worker creation function.

This avoids the need to pass the TLS block size from main thread to Worker thread when creating the Wasm Worker.

Also fix MINIMAL_RUNTIME+WASM_WORKERS+WASM=0 build combination and add a test for that.