### PR TITLE
Fix missing `printErr` propoerty in PROXY_TO_WORKER

### DIFF
--- a/src/proxyClient.js
+++ b/src/proxyClient.js
@@ -9,16 +9,22 @@
 if (typeof Module == 'undefined') {
   console.warn('no Module object defined - cannot proxy canvas rendering and input events, etc.');
   Module = {
-    print: function(x) {
-      console.log(x);
-    },
-    printErr: function(x) {
-      console.log(x);
-    },
     canvas: {
       addEventListener: function() {},
       getBoundingClientRect: function() { return { bottom: 0, height: 0, left: 0, right: 0, top: 0, width: 0 } },
     },
+  };
+}
+
+if (!Object.hasOwnProperty(Module, 'print')) {
+  Module['print'] = function(x) {
+    console.log(x);
+  };
+}
+
+if (!Object.hasOwnProperty(Module, 'printErr')) {
+  Module['printErr'] = function(x) {
+    console.error(x);
   };
 }
 


### PR DESCRIPTION
This issues has been causing exception on the main JS thread when
running in PROXY_TO_WORKER mode when using the default `shell.html` from
which the `printErr` override was removing back in #15555.

Since not all folks will be providing `print`/`printErr` on the
incoming module, we have to provide a fallback method.