### PR TITLE
Update library_glfw.js - use delta from getMouseWheelDelta(event)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -24,6 +24,8 @@ See docs/process.md for more on how version tagging works.
   binaryen optimizations are limited due to DWARF information being requested.
   Several binaryen passed are not compatible with the preservation of DWARF
   information. (#16428)
+- Use normalized mouse wheel delta for GLFW 3 in `library_glfw.js`. This changes 
+  the vertical scroll amount for GLFW 3. (#16480)
 
 3.1.7 - 03/07/2022
 -------------------

--- a/src/library_glfw.js
+++ b/src/library_glfw.js
@@ -529,13 +529,11 @@ var LibraryGLFW = {
 
 #if USE_GLFW == 3
       var sx = 0;
-      var sy = 0;
+      var sy = delta;
       if (event.type == 'mousewheel') {
         sx = event.wheelDeltaX;
-        sy = event.wheelDeltaY;
       } else {
         sx = event.deltaX;
-        sy = event.deltaY;
       }
 
       {{{ makeDynCall('vidd', 'GLFW.active.scrollFunc') }}}(GLFW.active.id, sx, sy);


### PR DESCRIPTION
Use delta from `getMouseWheelDelta(event)` when using GLFW 3. The adjustments made in https://github.com/emscripten-core/emscripten/pull/7968 (scaling mouse wheel delta) do not apply when using GLFW 3. This fixes that.