### PR TITLE
Better parsing of node version

### DIFF
--- a/tools/shared.py
+++ b/tools/shared.py
@@ -305,7 +305,8 @@ def env_with_node_in_path():
 def check_node_version():
   try:
     actual = run_process(config.NODE_JS + ['--version'], stdout=PIPE).stdout.strip()
-    version = actual.replace('v', '').replace('-pre', '').split('.')
+    version = actual.replace('v', '')
+    version = version.split('-')[0].split('.')
     version = tuple(int(v) for v in version)
   except Exception as e:
     diagnostics.warning('version-check', 'cannot check node version: %s', e)


### PR DESCRIPTION
I was experimenting with the canary version of node which reports
a version of `v18.0.0-v8-canary2022031068abd7e7cd`