### PR TITLE
Parameterize test_embind. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -223,11 +223,14 @@ def env_modify(updates):
 
 # Decorator version of env_modify
 def with_env_modify(updates):
+  assert not callable(updates)
+
   def decorated(f):
-    def modified(self):
+    def modified(self, *args, **kwargs):
       with env_modify(updates):
-        return f(self)
+        return f(self, *args, **kwargs)
     return modified
+
   return decorated
 
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -2427,20 +2427,20 @@ int f() {
     self.assertContained('10\nok\n', self.run_js('a.out.js'))
 
   @is_slow_test
+  @parameterized({
+    '': [[]],
+    'no_utf8': [['-sEMBIND_STD_STRING_IS_UTF8=0']],
+    'no_dynamic': [['-sDYNAMIC_EXECUTION=0']],
+  })
   @with_env_modify({'EMCC_CLOSURE_ARGS': '--externs ' + shlex.quote(test_file('embind/underscore-externs.js'))})
-  def test_embind(self):
+  def test_embind(self, extra_args):
     test_cases = [
-        (['-lembind']),
-        (['-lembind', '-O1']),
-        (['-lembind', '-O2']),
-        (['-lembind', '-O2', '-sALLOW_MEMORY_GROWTH', test_file('embind/isMemoryGrowthEnabled=true.cpp')]),
+      (['-lembind']),
+      (['-lembind', '-O1']),
+      (['-lembind', '-O2']),
+      (['-lembind', '-O2', '-sALLOW_MEMORY_GROWTH', test_file('embind/isMemoryGrowthEnabled=true.cpp')]),
     ]
-    without_utf8_args = ['-sEMBIND_STD_STRING_IS_UTF8=0']
-    test_cases_without_utf8 = []
-    for args in test_cases:
-        test_cases_without_utf8.append((args + without_utf8_args))
-    test_cases += test_cases_without_utf8
-    test_cases.extend([(args[:] + ['-sDYNAMIC_EXECUTION=0']) for args in test_cases])
+    test_cases = [t + extra_args for t in test_cases]
     # closure compiler doesn't work with DYNAMIC_EXECUTION=0
     test_cases.append((['-lembind', '-O2', '--closure=1']))
     for args in test_cases:


### PR DESCRIPTION
This makes the test easier to read and breaks it up into 3.  Each
of these 3 tests still take a long time.. but 1/3 less.