### PR TITLE
Fix for MEMORY64 + -O3

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2507,6 +2507,7 @@ def phase_linker_setup(options, state, newargs, user_settings):
       exit_with_error('MEMORY64 is not compatible with WASM_BIGINT=0')
     settings.WASM_BIGINT = 1
     settings.MINIFY_WASM_IMPORTS_AND_EXPORTS = 0
+    settings.MINIFY_WASM_IMPORTED_MODULES = 0
 
   # check if we can address the 2GB mark and higher: either if we start at
   # 2GB, or if we allow growth to either any amount or to 2GB or more.

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11836,3 +11836,11 @@ void foo() {}
     self.assertTrue(re.search(r'\(data \(i32.add\s+\(global.get \$\S+\)\s+\(i32.const \d+\)', wat))
     # Test that extended-const expressions are used in at least one global initializer.
     self.assertTrue(re.search(r'\(global \$\S+ i32 \(i32.add\s+\(global.get \$\S+\)\s+\(i32.const \d+\)', wat))
+
+  # Smoketest for MEMORY64 setting.  Most of the testing of MEMORY64 is by way of the wasm64
+  # variant of the core test suite.
+  @require_v8
+  def test_memory64(self):
+    self.v8_args += ['--experimental-wasm-memory64']
+    for opt in ['-O0', '-O1', '-O2', '-O3']:
+      self.do_runf(test_file('hello_world.c'), 'hello, world', emcc_args=['-sMEMORY64', opt])


### PR DESCRIPTION
Right now disabling `MINIFY_WASM_IMPORTS_AND_EXPORTS` requires              
that `MINIFY_WASM_IMPORTED_MODULES` is also disabled.  This is           
because the call to `minify_wasm_imports_and_exports` which              
handles both of these processes is currently guarded by                  
`MINIFY_WASM_IMPORTS_AND_EXPORTS`.                                       
                                                                         
In the long run we need to address this and avoid disabling              
these but in the short term this fixes the broken logic.      

Fixes: https://github.com/WebAssembly/binaryen/issues/4532