### PR TITLE
Never try to run proxied work without a live runtime

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1042,7 +1042,11 @@ var LibraryPThread = {
 
   _emscripten_notify_proxying_queue: function(targetThreadId, currThreadId, mainThreadId, queue) {
     if (targetThreadId == currThreadId) {
-      setTimeout(function() { _emscripten_proxy_execute_queue(queue); });
+      setTimeout(() => {
+        if (_pthread_self()) {
+          _emscripten_proxy_execute_queue(queue);
+        }
+      });
     } else if (ENVIRONMENT_IS_PTHREAD) {
       postMessage({'targetThread' : targetThreadId, 'cmd' : 'processProxyingQueue', 'queue' : queue});
     } else {

--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -206,6 +206,7 @@ static task_queue* get_or_add_tasks_for_thread(em_proxying_queue* q,
 EMSCRIPTEN_KEEPALIVE
 void emscripten_proxy_execute_queue(em_proxying_queue* q) {
   assert(q != NULL);
+  assert(pthread_self());
 
   // Recursion guard to avoid infinite recursion when we arrive here from the
   // pthread_lock call below that executes the system queue. The per-task_queue

--- a/system/lib/pthread/proxying.h
+++ b/system/lib/pthread/proxying.h
@@ -18,6 +18,11 @@ extern "C" {
 // asynchronously or synchronously proxied from other threads. When work is
 // proxied to a queue on a particular thread, that thread is notified to start
 // processing work from that queue if it is not already doing so.
+//
+// Proxied work can only be completed on live thread runtimes, so users must
+// ensure either that all proxied work is completed before a thread exits or
+// that the thread exits with a live runtime, e.g. via
+// `emscripten_exit_with_live_runtime` to avoid dropped work.
 typedef struct em_proxying_queue em_proxying_queue;
 
 // Create and destroy proxying queues.

--- a/tests/pthread/test_pthread_proxying_dropped_work.c
+++ b/tests/pthread/test_pthread_proxying_dropped_work.c
@@ -1,7 +1,8 @@
 #include <assert.h>
-#include <pthread.h>
-#include <unistd.h>
 #include <emscripten/console.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <unistd.h>
 
 #include "proxying.h"
 
@@ -11,6 +12,7 @@ _Atomic int exploded = 0;
 
 void explode(void* arg) {
   exploded = 1;
+  assert(false);
 }
 
 void* proxy_to_self(void* arg) {

--- a/tests/pthread/test_pthread_proxying_dropped_work.c
+++ b/tests/pthread/test_pthread_proxying_dropped_work.c
@@ -1,0 +1,54 @@
+#include <assert.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <emscripten/console.h>
+
+#include "proxying.h"
+
+em_proxying_queue* queue;
+
+_Atomic int exploded = 0;
+
+void explode(void* arg) {
+  exploded = 1;
+}
+
+void* proxy_to_self(void* arg) {
+  emscripten_proxy_async(queue, pthread_self(), explode, NULL);
+  return NULL;
+}
+
+void* do_nothing(void* arg) {
+  return NULL;
+}
+
+int main() {
+  emscripten_console_log("start");
+  queue = em_proxying_queue_create();
+  assert(queue);
+
+  // Check that proxying to a thread that exits without a live runtime causes
+  // the work to be dropped without other errors.
+  pthread_t worker;
+  pthread_create(&worker, NULL, do_nothing, NULL);
+  emscripten_proxy_async(queue, worker, explode, NULL);
+
+  // Check that a thread proxying to itself but exiting without a live runtime
+  // causes the work to be dropped without other errors.
+  pthread_t self_proxier;
+  pthread_create(&self_proxier, NULL, proxy_to_self, NULL);
+
+  pthread_join(worker, NULL);
+  pthread_join(self_proxier, NULL);
+
+  // Wait a bit (50 ms) to see if the `assert(pthread_self())` in
+  // emscripten_proxy_execute_queue fires or if we explode.
+  struct timespec time = {
+    .tv_sec = 0,
+    .tv_nsec = 50 * 1000 * 1000,
+  };
+  nanosleep(&time, NULL);
+
+  assert(!exploded);
+  emscripten_console_log("done");
+}

--- a/tests/pthread/test_pthread_proxying_dropped_work.out
+++ b/tests/pthread/test_pthread_proxying_dropped_work.out
@@ -1,0 +1,2 @@
+start
+done

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2579,6 +2579,14 @@ The current type of b is: 9
                                  emcc_args=args, interleaved_output=False)
 
   @node_pthreads
+  def test_pthread_proxying_dropped_work(self):
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('PTHREAD_POOL_SIZE=2')
+    args = [f'-I{path_from_root("system/lib/pthread")}']
+    self.do_run_in_out_file_test('pthread/test_pthread_proxying_dropped_work.c',
+                                 emcc_args=args)
+
+  @node_pthreads
   def test_pthread_dispatch_after_exit(self):
     self.do_run_in_out_file_test('pthread/test_pthread_dispatch_after_exit.c', interleaved_output=False)
 


### PR DESCRIPTION
We were previously running `emscripten_proxy_execute_queue` from a JS callback
whenever a thread proxied to itself, even if the thread runtime had died by the
time the callback was received. In practice this never resulted in any work
running because the queue was not able to find the task queue for the thread
without the old `pthread_self` value, but it was still inconsistent with the
behavior when proxying to separate threads, which does not result in a call to
`emscripten_proxy_execute_queue`. Making the behavior more consistent lets us
insert a new assertion that `pthread_self()` is meaningful and is more robust to
future changes to the proxying mechanism.

Also improve the documentation to point out that work will be dropped if the
target thread dies with the work unfinished.