### PR TITLE
Refcount proxying queues to prevent use-after-frees

### DIFF
--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -1042,7 +1042,11 @@ var LibraryPThread = {
 
   _emscripten_notify_proxying_queue: function(targetThreadId, currThreadId, mainThreadId, queue) {
     if (targetThreadId == currThreadId) {
-      setTimeout(function() { _emscripten_proxy_execute_queue(queue); });
+      setTimeout(() => {
+        if (_pthread_self()) {
+          _emscripten_proxy_execute_queue(queue);
+        }
+      });
     } else if (ENVIRONMENT_IS_PTHREAD) {
       postMessage({'targetThread' : targetThreadId, 'cmd' : 'processProxyingQueue', 'queue' : queue});
     } else {

--- a/src/library_pthread.js
+++ b/src/library_pthread.js
@@ -265,7 +265,7 @@ var LibraryPThread = {
 
         if (cmd === 'processProxyingQueue') {
           // TODO: Must post message to main Emscripten thread in PROXY_TO_WORKER mode.
-          _emscripten_proxy_execute_queue(d['queue']);
+          __emscripten_execute_notified_proxying_queue(d['queue']);
         } else if (cmd === 'spawnThread') {
           spawnThread(d);
         } else if (cmd === 'cleanupThread') {
@@ -1042,11 +1042,7 @@ var LibraryPThread = {
 
   _emscripten_notify_proxying_queue: function(targetThreadId, currThreadId, mainThreadId, queue) {
     if (targetThreadId == currThreadId) {
-      setTimeout(() => {
-        if (_pthread_self()) {
-          _emscripten_proxy_execute_queue(queue);
-        }
-      });
+      setTimeout(() => __emscripten_execute_notified_proxying_queue(queue));
     } else if (ENVIRONMENT_IS_PTHREAD) {
       postMessage({'targetThread' : targetThreadId, 'cmd' : 'processProxyingQueue', 'queue' : queue});
     } else {

--- a/src/worker.js
+++ b/src/worker.js
@@ -286,9 +286,7 @@ self.onmessage = (e) => {
     } else if (e.data.target === 'setimmediate') {
       // no-op
     } else if (e.data.cmd === 'processProxyingQueue') {
-      if (Module['_pthread_self']()) { // If this thread is actually running?
-        Module['_emscripten_proxy_execute_queue'](e.data.queue);
-      }
+      Module['__emscripten_execute_notified_proxying_queue'](e.data.queue);
     } else {
       err('worker.js received unknown command ' + e.data.cmd);
       err(e.data);

--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -206,6 +206,7 @@ static task_queue* get_or_add_tasks_for_thread(em_proxying_queue* q,
 EMSCRIPTEN_KEEPALIVE
 void emscripten_proxy_execute_queue(em_proxying_queue* q) {
   assert(q != NULL);
+  assert(pthread_self());
 
   // Recursion guard to avoid infinite recursion when we arrive here from the
   // pthread_lock call below that executes the system queue. The per-task_queue

--- a/system/lib/pthread/proxying.h
+++ b/system/lib/pthread/proxying.h
@@ -18,6 +18,11 @@ extern "C" {
 // asynchronously or synchronously proxied from other threads. When work is
 // proxied to a queue on a particular thread, that thread is notified to start
 // processing work from that queue if it is not already doing so.
+//
+// Proxied work can only be completed on live thread runtimes, so users must
+// ensure either that all proxied work is completed before a thread exits or
+// that the thread exits with a live runtime, e.g. via
+// `emscripten_exit_with_live_runtime` to avoid dropped work.
 typedef struct em_proxying_queue em_proxying_queue;
 
 // Create and destroy proxying queues.

--- a/tests/pthread/test_pthread_proxying_dropped_work.c
+++ b/tests/pthread/test_pthread_proxying_dropped_work.c
@@ -1,0 +1,54 @@
+#include <assert.h>
+#include <pthread.h>
+#include <unistd.h>
+#include <emscripten/console.h>
+
+#include "proxying.h"
+
+em_proxying_queue* queue;
+
+_Atomic int exploded = 0;
+
+void explode(void* arg) {
+  exploded = 1;
+}
+
+void* proxy_to_self(void* arg) {
+  emscripten_proxy_async(queue, pthread_self(), explode, NULL);
+  return NULL;
+}
+
+void* do_nothing(void* arg) {
+  return NULL;
+}
+
+int main() {
+  emscripten_console_log("start");
+  queue = em_proxying_queue_create();
+  assert(queue);
+
+  // Check that proxying to a thread that exits without a live runtime causes
+  // the work to be dropped without other errors.
+  pthread_t worker;
+  pthread_create(&worker, NULL, do_nothing, NULL);
+  emscripten_proxy_async(queue, worker, explode, NULL);
+
+  // Check that a thread proxying to itself but exiting without a live runtime
+  // causes the work to be dropped without other errors.
+  pthread_t self_proxier;
+  pthread_create(&self_proxier, NULL, proxy_to_self, NULL);
+
+  pthread_join(worker, NULL);
+  pthread_join(self_proxier, NULL);
+
+  // Wait a bit (50 ms) to see if the `assert(pthread_self())` in
+  // emscripten_proxy_execute_queue fires or if we explode.
+  struct timespec time = {
+    .tv_sec = 0,
+    .tv_nsec = 50 * 1000 * 1000,
+  };
+  nanosleep(&time, NULL);
+
+  assert(!exploded);
+  emscripten_console_log("done");
+}

--- a/tests/pthread/test_pthread_proxying_dropped_work.out
+++ b/tests/pthread/test_pthread_proxying_dropped_work.out
@@ -1,0 +1,2 @@
+start
+done

--- a/tests/pthread/test_pthread_proxying_refcount.c
+++ b/tests/pthread/test_pthread_proxying_refcount.c
@@ -1,0 +1,65 @@
+#include <assert.h>
+#include <emscripten/console.h>
+#include <emscripten/emscripten.h>
+#include <pthread.h>
+#include <unistd.h>
+
+#include "proxying.h"
+
+em_proxying_queue* queue;
+
+_Atomic int should_execute = 0;
+_Atomic int executed = 0;
+pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
+pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
+
+void task(void* arg) {
+  executed = 1;
+  pthread_cond_signal(&cond);
+}
+
+void* execute_and_free_queue(void* arg) {
+  // Wait until we are signaled to execute the queue.
+  pthread_mutex_lock(&mutex);
+  while (!should_execute) {
+    pthread_cond_wait(&cond, &mutex);
+  }
+  pthread_mutex_unlock(&mutex);
+
+  // Execute the proxied work then free the empty queue.
+  emscripten_proxy_execute_queue(queue);
+  em_proxying_queue_destroy(queue);
+
+  // Exit with a live runtime so the queued work notification is received and we
+  // try to execute the queue again, even though it has been destroyed.
+  emscripten_exit_with_live_runtime();
+}
+
+int main() {
+  emscripten_console_log("start");
+  queue = em_proxying_queue_create();
+  assert(queue);
+
+  // Create the worker and send it a task.
+  pthread_t worker;
+  pthread_create(&worker, NULL, execute_and_free_queue, NULL);
+  emscripten_proxy_async(queue, worker, task, NULL);
+  should_execute = 1;
+  pthread_cond_signal(&cond);
+
+  // Wait for the task to be executed.
+  pthread_mutex_lock(&mutex);
+  while (!executed) {
+    pthread_cond_wait(&cond, &mutex);
+  }
+  pthread_mutex_unlock(&mutex);
+
+  // Wait a bit (50 ms) for the postmessage notification to be recieved and
+  // processed.
+  struct timespec time = {
+    .tv_sec = 0,
+    .tv_nsec = 50 * 1000 * 1000,
+  };
+  nanosleep(&time, NULL);
+  emscripten_console_log("done");
+}

--- a/tests/pthread/test_pthread_proxying_refcount.out
+++ b/tests/pthread/test_pthread_proxying_refcount.out
@@ -1,0 +1,2 @@
+start
+done

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2579,6 +2579,14 @@ The current type of b is: 9
                                  emcc_args=args, interleaved_output=False)
 
   @node_pthreads
+  def test_pthread_proxying_dropped_work(self):
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('PTHREAD_POOL_SIZE=2')
+    args = [f'-I{path_from_root("system/lib/pthread")}']
+    self.do_run_in_out_file_test('pthread/test_pthread_proxying_dropped_work.c',
+                                 emcc_args=args)
+
+  @node_pthreads
   def test_pthread_dispatch_after_exit(self):
     self.do_run_in_out_file_test('pthread/test_pthread_dispatch_after_exit.c', interleaved_output=False)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2587,6 +2587,15 @@ The current type of b is: 9
                                  emcc_args=args)
 
   @node_pthreads
+  def test_pthread_proxying_refcount(self):
+    self.set_setting('EXIT_RUNTIME')
+    self.set_setting('PTHREAD_POOL_SIZE=1')
+    self.set_setting('ASSERTIONS=0')
+    args = [f'-I{path_from_root("system/lib/pthread")}']
+    self.do_run_in_out_file_test('pthread/test_pthread_proxying_refcount.c',
+                                 emcc_args=args)
+
+  @node_pthreads
   def test_pthread_dispatch_after_exit(self):
     self.do_run_in_out_file_test('pthread/test_pthread_dispatch_after_exit.c', interleaved_output=False)
 


### PR DESCRIPTION
We want to support the eager execution of proxying queues so that they can be
used without having to return to the event queue. However, queues aren't aware
of whether they will be executed eagerly or after returning to the event queue,
so they have to unconditionally send notification messages containing references
to themselves when work is first enqueued. This can result in use-after-free
bugs when a thread returns to the event queue and processes the notification
after the queue has already been executed and destroyed.

To avoid these use-after-free bugs, add a reference count to each queue to
defer destroying queues until they have been explicitly destroyed by the user
and all outstanding notification messages have been processed as well.

Deferring queue destruction leads to spurious lsan reports because notified
queues are not actually freed until all target threads have returned to their
event queues, which might not happen before the main thread exits and the leak
checker is executed. To suppress these spurious reports, tell lsan to ignore
queues starting when the user calls their destructor.