### PR TITLE
Fix auto-generation of struct_info with `-sMEMORY64=1`

### DIFF
--- a/tools/gen_struct_info.py
+++ b/tools/gen_struct_info.py
@@ -268,7 +268,6 @@ def inspect_headers(headers, cflags):
                                '-Wno-format',
                                '-nostdlib',
                                compiler_rt,
-                               '-sMEMORY64=' + str(settings.MEMORY64),
                                '-sBOOTSTRAPPING_STRUCT_INFO=1',
                                '-sLLD_REPORT_UNDEFINED=1',
                                '-sSTRICT',
@@ -285,6 +284,11 @@ def inspect_headers(headers, cflags):
 
   if settings.LTO:
     cmd += ['-flto=' + settings.LTO]
+
+  if settings.MEMORY64:
+    # Always use =2 here so that we don't generate binar that actually requires
+    # memeory64 to run.  All we care about is that the output is correct.
+    cmd += ['-sMEMORY64=2']
 
   show(shared.shlex_join(cmd))
   try:


### PR DESCRIPTION
We always want to use =2 internally when building the struct_info json
file.  The results will be the same either way but this removes the need
to run the output in a VM with memory64 enabled.