### PR TITLE
proposal for better timezone detection

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -1335,6 +1335,14 @@ FS.staticInit();` +
       // just create the tmp dirs that reside in it commonly
       FS.mkdir('/dev/shm');
       FS.mkdir('/dev/shm/tmp');
+      
+      // setup file system with time zone information
+      const zone = '/usr/share/zoneinfo/' + Intl.DateTimeFormat().resolvedOptions().timeZone;
+      FS.mkdirTree(PATH.dirname(zone));
+      FS.createFile(PATH.dirname(zone), PATH.basename(zone));
+      FS.mkdir('/etc');
+      FS.symlink(zone, '/etc/localtime')
+
     },
     createSpecialDirectories: () => {
       // create /proc/self/fd which allows /proc/self/fd/6 => readlink gives the

--- a/src/library_wasi.js
+++ b/src/library_wasi.js
@@ -33,6 +33,7 @@ var WasiLibrary = {
         'PWD': '/',
         'HOME': '/home/web_user',
         'LANG': lang,
+        'TZ': Intl.DateTimeFormat().resolvedOptions().timeZone,
         '_': getExecutableName()
       };
       // Apply the user-provided values, if any.


### PR DESCRIPTION
In order to facilitate timezone detection there are a few standard ways of doing that "TZ" environment variable and `etc/localtime`.

This will allow libraries like icu4c to properly detect the current system timezone, which look for IANA time zone names in a few locations

The TZ environment variable should work out of the box for [icu4c](https://github.com/unicode-org/icu/blob/89c5d03023d5e96945188bc365a3d15e53441c86/icu4c/source/common/putil.cpp#L1147)
The `etc/localtime` symlink  requires icu4c to be built with [CHECK_LOCALTIME_LINK](https://github.com/unicode-org/icu/blob/89c5d03023d5e96945188bc365a3d15e53441c86/icu4c/source/common/putil.cpp#L1166) which is defined if any of [these](https://github.com/unicode-org/icu/blob/43276e8c34b7073fae266d0ff821391c7607c47e/icu4c/source/common/putil.cpp#L690) are true 