### PR TITLE
Improve tests for pthreads+dylink. NFC

### DIFF
--- a/tests/core/pthread/test_pthread_dlopen.c
+++ b/tests/core/pthread/test_pthread_dlopen.c
@@ -15,18 +15,16 @@ static sidey_func_type p_side_func_address;
 static int* expected_data_addr;
 static func_t expected_func_addr;
 
-static pthread_cond_t ready_cond = PTHREAD_COND_INITIALIZER;
-static pthread_mutex_t ready_mutex = PTHREAD_MUTEX_INITIALIZER;
+static atomic_bool started = false;
 static atomic_bool ready = false;
 
 static void* thread_main() {
-  while (!ready) {
-    pthread_mutex_lock(&ready_mutex);
-    pthread_cond_wait(&ready_cond, &ready_mutex);
-    pthread_mutex_unlock(&ready_mutex);
-  }
-
   printf("in thread_main\n");
+  started = true;
+  // Spin until the main thread has loaded the side module
+  while (!ready) {}
+
+  // Without this explict sync we get "invalid index into function table" below
   _emscripten_thread_sync_code();
 
   printf("calling p_side_data_address=%p\n", p_side_data_address);
@@ -50,8 +48,10 @@ int main() {
   int rc = pthread_create(&t, NULL, thread_main, NULL);
   assert(rc == 0);
 
-  printf("loading dylib\n");
+  // Spin until the thread has started
+  while (!started) {}
 
+  printf("loading dylib\n");
   void* handle = dlopen("liblib.so", RTLD_NOW|RTLD_GLOBAL);
   if (!handle) {
     printf("dlerror: %s\n", dlerror());
@@ -71,10 +71,7 @@ int main() {
   printf("p_side_func_address -> %p\n", expected_func_addr);
   assert(expected_func_addr() == 43);
 
-  pthread_mutex_lock(&ready_mutex);
   ready = true;
-  pthread_cond_signal(&ready_cond);
-  pthread_mutex_unlock(&ready_mutex);
 
   printf("joining\n");
   rc = pthread_join(t, NULL);

--- a/tests/core/pthread/test_pthread_dlsym.c
+++ b/tests/core/pthread/test_pthread_dlsym.c
@@ -2,7 +2,6 @@
 #include <dlfcn.h>
 #include <pthread.h>
 #include <stdio.h>
-#include <emscripten/threading.h>
 
 typedef int (*func_t)();
 
@@ -53,7 +52,6 @@ static void test_order2() {
 
 static void* thread_main() {
   printf("in thread_main\n");
-  _emscripten_thread_sync_code();
   test_order2();
   printf("thread_main done\n");
   return 0;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8860,7 +8860,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
     self.prep_dlfcn_main()
     self.set_setting('EXIT_RUNTIME')
-    self.set_setting('PTHREAD_POOL_SIZE', 2)
     self.set_setting('PROXY_TO_PTHREAD')
     self.do_runf(test_file('core/pthread/test_pthread_dlopen.c'))
 
@@ -8873,7 +8872,6 @@ NODEFS is no longer included by default; build with -lnodefs.js
 
     self.prep_dlfcn_main()
     self.set_setting('EXIT_RUNTIME')
-    self.set_setting('PTHREAD_POOL_SIZE', 2)
     self.set_setting('PROXY_TO_PTHREAD')
     self.do_runf(test_file('core/pthread/test_pthread_dlsym.c'))
 


### PR DESCRIPTION
test_pthread_dlsym.c: Explicit syncing of code is not necessary in this
test. The libraries should be loaded in the same order on every thread
regardless.

test_pthread_dlsym.c: Be a little more hostile by avoiding pthread
constructs and just spinning.  This mean the explicit code sync is more
likely to actaully be needed, even in the face of syncronization happing
if futex_wait (which I'm porposing to add as followup).