### PR TITLE
Use `_emscripten_yield` to synchronize loaded code between threads

### DIFF
--- a/system/lib/pthread/emscripten_yield.c
+++ b/system/lib/pthread/emscripten_yield.c
@@ -11,6 +11,12 @@ void _emscripten_thread_crashed() {
   thread_crashed = true;
 }
 
+static void dummy()
+{
+}
+
+weak_alias(dummy, _emscripten_thread_sync_code);
+
 /*
  * Called whenever a thread performs a blocking action (or calls sched_yield).
  * This function takes care of running the event queue and other housekeeping
@@ -36,6 +42,5 @@ void _emscripten_yield() {
     emscripten_main_thread_process_queued_calls();
   }
 
-  // TODO(sbc): Do code synchronization between threads as part of yield
-  //_emscripten_thread_sync_code();
+  _emscripten_thread_sync_code();
 }

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -8861,9 +8861,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.emcc_args.append('-fexceptions')
     self.dylink_testf(test_file('core/pthread/test_pthread_dylink_exceptions.cpp'))
 
+  @parameterized({
+    '': (True,),
+    'no_yield': (False,)
+  })
   @needs_dylink
   @node_pthreads
-  def test_pthread_dlopen(self):
+  def test_pthread_dlopen(self, do_yield):
     self.set_setting('USE_PTHREADS')
     self.emcc_args.append('-Wno-experimental')
     self.build_dlfcn_lib(test_file('core/pthread/test_pthread_dlopen_side.c'))
@@ -8871,7 +8875,13 @@ NODEFS is no longer included by default; build with -lnodefs.js
     self.prep_dlfcn_main()
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('PROXY_TO_PTHREAD')
-    self.do_runf(test_file('core/pthread/test_pthread_dlopen.c'))
+    if do_yield:
+      self.emcc_args.append('-DYIELD')
+      self.do_runf(test_file('core/pthread/test_pthread_dlopen.c'), 'done join')
+    else:
+      self.do_runf(test_file('core/pthread/test_pthread_dlopen.c'),
+                   'invalid index into function table',
+                   assert_returncode=NON_ZERO)
 
   @needs_dylink
   @node_pthreads


### PR DESCRIPTION
This means that for most programs threads should synchronize without
requiring the explicit call to _emscripten_thread_sync_code.