### PR TITLE
Fix typo in comment for INLINING_LIMIT

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -291,7 +291,7 @@ var IGNORE_CLOSURE_COMPILER_ERRORS = 0;
 // [link]
 var DECLARE_ASM_MODULE_EXPORTS = 1;
 
-// If 0, prevents inlining if set to 1. If 0, we will inline normally in LLVM.
+// If set to 1, prevents inlining. If 0, we will inline normally in LLVM.
 // This does not affect the inlining policy in Binaryen.
 // [compile]
 var INLINING_LIMIT = 0;


### PR DESCRIPTION
From a quick glance at the code, I think this is what it meant to say.

BTW, is there a good central page that lists all these options? I've been using @surma's https://emsettings.surma.technology/ but jw if there's some other page I've overlooked on the emscripten docs site

EDIT: ah, I had been looking for "empscripten flags" but these are called settings. when I searched for that I do end up https://emscripten.org/docs/api_reference/advanced-apis.html#settings-js which points to the source file, which is OK. Perhaps it'd be nice to also link to surma's page