### PR TITLE
tests: Avoid passing True/False strings as `-s` settings

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -515,6 +515,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
   def set_setting(self, key, value=1):
     if value is None:
       self.clear_setting(key)
+    if type(value) == bool:
+      value = int(value)
     self.settings_mods[key] = value
 
   def has_changed_setting(self, key):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7806,6 +7806,7 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('INVOKE_RUN', 0)
     self.set_setting('EXIT_RUNTIME', exit_runtime)
     self.set_setting('EXPORTED_FUNCTIONS', ['_stringf', '_floatf'])
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$maybeExit'])
     create_file('main.c', r'''
 #include <stdio.h>
 #include <emscripten.h>


### PR DESCRIPTION
I notived this bug while adding type checking to `-s` settings.  Luckly
it only seems to effect one test.

See #16440