### PR TITLE
Add use of Clang  __attribute__((nonnull)) in Emscripten system headers.

### DIFF
--- a/system/include/emscripten/atomic.h
+++ b/system/include/emscripten/atomic.h
@@ -19,63 +19,63 @@ extern "C" {
 
 // Atomically stores the given value to the memory location, and returns the
 // value that was there prior to the store.
-uint8_t emscripten_atomic_exchange_u8(void/*uint8_t*/ *addr, uint8_t newVal);
-uint16_t emscripten_atomic_exchange_u16(void/*uint16_t*/ *addr, uint16_t newVal);
-uint32_t emscripten_atomic_exchange_u32(void/*uint32_t*/ *addr, uint32_t newVal);
-uint64_t emscripten_atomic_exchange_u64(void/*uint64_t*/ *addr, uint64_t newVal);
+uint8_t emscripten_atomic_exchange_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t newVal);
+uint16_t emscripten_atomic_exchange_u16(void/*uint16_t*/ *addr __attribute__((nonnull)), uint16_t newVal);
+uint32_t emscripten_atomic_exchange_u32(void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t newVal);
+uint64_t emscripten_atomic_exchange_u64(void/*uint64_t*/ *addr __attribute__((nonnull)), uint64_t newVal);
 
 // CAS returns the *old* value that was in the memory location before the
 // operation took place.
 // That is, if the return value when calling this function equals to 'oldVal',
 // then the operation succeeded, otherwise it was ignored.
-uint8_t emscripten_atomic_cas_u8(void/*uint8_t*/ *addr, uint8_t oldVal, uint8_t newVal);
-uint16_t emscripten_atomic_cas_u16(void/*uint16_t*/ *addr, uint16_t oldVal, uint16_t newVal);
-uint32_t emscripten_atomic_cas_u32(void/*uint32_t*/ *addr, uint32_t oldVal, uint32_t newVal);
-uint64_t emscripten_atomic_cas_u64(void/*uint64_t*/ *addr, uint64_t oldVal, uint64_t newVal);
+uint8_t emscripten_atomic_cas_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t oldVal, uint8_t newVal);
+uint16_t emscripten_atomic_cas_u16(void/*uint16_t*/ *addr __attribute__((nonnull)), uint16_t oldVal, uint16_t newVal);
+uint32_t emscripten_atomic_cas_u32(void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t oldVal, uint32_t newVal);
+uint64_t emscripten_atomic_cas_u64(void/*uint64_t*/ *addr __attribute__((nonnull)), uint64_t oldVal, uint64_t newVal);
 
-uint8_t emscripten_atomic_load_u8(const void/*uint8_t*/ *addr);
-uint16_t emscripten_atomic_load_u16(const void/*uint16_t*/ *addr);
-uint32_t emscripten_atomic_load_u32(const void/*uint32_t*/ *addr);
-float emscripten_atomic_load_f32(const void/*float*/ *addr);
+uint8_t emscripten_atomic_load_u8(const void/*uint8_t*/ *addr __attribute__((nonnull)));
+uint16_t emscripten_atomic_load_u16(const void/*uint16_t*/ *addr __attribute__((nonnull)));
+uint32_t emscripten_atomic_load_u32(const void/*uint32_t*/ *addr __attribute__((nonnull)));
+float emscripten_atomic_load_f32(const void/*float*/ *addr __attribute__((nonnull)));
 uint64_t emscripten_atomic_load_u64(const void/*uint64_t*/ *addr);
-double emscripten_atomic_load_f64(const void/*double*/ *addr);
+double emscripten_atomic_load_f64(const void/*double*/ *addr __attribute__((nonnull))) __attribute__((nonnull));
 
 // Returns the value that was stored (i.e. 'val')
-uint8_t emscripten_atomic_store_u8(void/*uint8_t*/ *addr, uint8_t val);
-uint16_t emscripten_atomic_store_u16(void/*uint16_t*/ *addr, uint16_t val);
-uint32_t emscripten_atomic_store_u32(void/*uint32_t*/ *addr, uint32_t val);
-float emscripten_atomic_store_f32(void/*float*/ *addr, float val);
-uint64_t emscripten_atomic_store_u64(void/*uint64_t*/ *addr, uint64_t val);
-double emscripten_atomic_store_f64(void/*double*/ *addr, double val);
+uint8_t emscripten_atomic_store_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t val);
+uint16_t emscripten_atomic_store_u16(void/*uint16_t*/ *addr __attribute__((nonnull)), uint16_t val);
+uint32_t emscripten_atomic_store_u32(void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t val);
+float emscripten_atomic_store_f32(void/*float*/ *addr __attribute__((nonnull)), float val);
+uint64_t emscripten_atomic_store_u64(void/*uint64_t*/ *addr __attribute__((nonnull)), uint64_t val);
+double emscripten_atomic_store_f64(void/*double*/ *addr __attribute__((nonnull)), double val);
 
 void emscripten_atomic_fence(void);
 
 // Each of the functions below (add, sub, and, or, xor) return the value that
 // was in the memory location before the operation occurred.
-uint8_t emscripten_atomic_add_u8(void/*uint8_t*/ *addr, uint8_t val);
-uint16_t emscripten_atomic_add_u16(void/*uint16_t*/ *addr, uint16_t val);
-uint32_t emscripten_atomic_add_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_add_u64(void/*uint64_t*/ *addr, uint64_t val);
+uint8_t emscripten_atomic_add_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t val);
+uint16_t emscripten_atomic_add_u16(void/*uint16_t*/ *addr __attribute__((nonnull)), uint16_t val);
+uint32_t emscripten_atomic_add_u32(void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t val);
+uint64_t emscripten_atomic_add_u64(void/*uint64_t*/ *addr __attribute__((nonnull)), uint64_t val);
 
-uint8_t emscripten_atomic_sub_u8(void/*uint8_t*/ *addr, uint8_t val);
-uint16_t emscripten_atomic_sub_u16(void/*uint16_t*/ *addr, uint16_t val);
-uint32_t emscripten_atomic_sub_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_sub_u64(void/*uint64_t*/ *addr, uint64_t val);
+uint8_t emscripten_atomic_sub_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t val);
+uint16_t emscripten_atomic_sub_u16(void/*uint16_t*/ *addr __attribute__((nonnull)), uint16_t val);
+uint32_t emscripten_atomic_sub_u32(void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t val);
+uint64_t emscripten_atomic_sub_u64(void/*uint64_t*/ *addr __attribute__((nonnull)), uint64_t val);
 
-uint8_t emscripten_atomic_and_u8(void/*uint8_t*/ *addr, uint8_t val);
-uint16_t emscripten_atomic_and_u16(void/*uint16_t*/ *addr, uint16_t val);
-uint32_t emscripten_atomic_and_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_and_u64(void/*uint64_t*/ *addr, uint64_t val);
+uint8_t emscripten_atomic_and_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t val);
+uint16_t emscripten_atomic_and_u16(void/*uint16_t*/ *addr __attribute__((nonnull)), uint16_t val);
+uint32_t emscripten_atomic_and_u32(void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t val);
+uint64_t emscripten_atomic_and_u64(void/*uint64_t*/ *addr __attribute__((nonnull)), uint64_t val);
 
-uint8_t emscripten_atomic_or_u8(void/*uint8_t*/ *addr, uint8_t val);
-uint16_t emscripten_atomic_or_u16(void/*uint16_t*/ *addr, uint16_t val);
-uint32_t emscripten_atomic_or_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_or_u64(void/*uint64_t*/ *addr, uint64_t val);
+uint8_t emscripten_atomic_or_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t val);
+uint16_t emscripten_atomic_or_u16(void/*uint16_t*/ *addr __attribute__((nonnull)), uint16_t val);
+uint32_t emscripten_atomic_or_u32(void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t val);
+uint64_t emscripten_atomic_or_u64(void/*uint64_t*/ *addr __attribute__((nonnull)), uint64_t val);
 
-uint8_t emscripten_atomic_xor_u8(void/*uint8_t*/ *addr, uint8_t val);
-uint16_t emscripten_atomic_xor_u16(void/*uint16_t*/ *addr, uint16_t val);
-uint32_t emscripten_atomic_xor_u32(void/*uint32_t*/ *addr, uint32_t val);
-uint64_t emscripten_atomic_xor_u64(void/*uint64_t*/ *addr, uint64_t val);
+uint8_t emscripten_atomic_xor_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t val);
+uint16_t emscripten_atomic_xor_u16(void/*uint16_t*/ *addr __attribute__((nonnull)), uint16_t val);
+uint32_t emscripten_atomic_xor_u32(void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t val);
+uint64_t emscripten_atomic_xor_u64(void/*uint64_t*/ *addr __attribute__((nonnull)), uint64_t val);
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/atomic.h
+++ b/system/include/emscripten/atomic.h
@@ -37,8 +37,8 @@ uint8_t emscripten_atomic_load_u8(const void/*uint8_t*/ *addr __attribute__((non
 uint16_t emscripten_atomic_load_u16(const void/*uint16_t*/ *addr __attribute__((nonnull)));
 uint32_t emscripten_atomic_load_u32(const void/*uint32_t*/ *addr __attribute__((nonnull)));
 float emscripten_atomic_load_f32(const void/*float*/ *addr __attribute__((nonnull)));
-uint64_t emscripten_atomic_load_u64(const void/*uint64_t*/ *addr);
-double emscripten_atomic_load_f64(const void/*double*/ *addr __attribute__((nonnull))) __attribute__((nonnull));
+uint64_t emscripten_atomic_load_u64(const void/*uint64_t*/ *addr __attribute__((nonnull)));
+double emscripten_atomic_load_f64(const void/*double*/ *addr __attribute__((nonnull)));
 
 // Returns the value that was stored (i.e. 'val')
 uint8_t emscripten_atomic_store_u8(void/*uint8_t*/ *addr __attribute__((nonnull)), uint8_t val);

--- a/system/include/emscripten/console.h
+++ b/system/include/emscripten/console.h
@@ -11,9 +11,9 @@ extern "C" {
 
 // Write directly JavaScript console.  This can be useful for debugging since it
 // bypasses the stdio and filesystem sub-systems.
-void emscripten_console_log(const char *utf8String);
-void emscripten_console_warn(const char *utf8String);
-void emscripten_console_error(const char *utf8String);
+void emscripten_console_log(const char *utf8String __attribute__((nonnull)));
+void emscripten_console_warn(const char *utf8String __attribute__((nonnull)));
+void emscripten_console_error(const char *utf8String __attribute__((nonnull)));
 
 // Write to the out() and err() hooks directly (defined in shell.js).
 // These have different behavior compared to console.log/err.
@@ -23,16 +23,16 @@ void emscripten_console_error(const char *utf8String);
 // printErr, if provided on the Module object.
 // These functions are mainly intended for internal use.
 // See https://github.com/emscripten-core/emscripten/issues/14804
-void _emscripten_out(const char *utf8String);
-void _emscripten_err(const char *utf8String);
+void _emscripten_out(const char *utf8String __attribute__((nonnull)));
+void _emscripten_err(const char *utf8String __attribute__((nonnull)));
 void _emscripten_dbg(const char *utf8String);
 
 // Similar to the above functions but operate with printf-like semantics.
-void emscripten_console_logf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
-void emscripten_console_warnf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
-void emscripten_console_errorf(const char *utf8String, ...)__attribute__((__format__(printf, 1, 2)));
-void _emscripten_outf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
-void _emscripten_errf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_console_logf(const char *utf8String __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_console_warnf(const char *utf8String __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
+void emscripten_console_errorf(const char *utf8String __attribute__((nonnull)), ...)__attribute__((__format__(printf, 1, 2)));
+void _emscripten_outf(const char *utf8String __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
+void _emscripten_errf(const char *utf8String __attribute__((nonnull)), ...) __attribute__((__format__(printf, 1, 2)));
 void _emscripten_dbgf(const char *utf8String, ...) __attribute__((__format__(printf, 1, 2)));
 
 #ifdef __cplusplus

--- a/system/include/emscripten/emmalloc.h
+++ b/system/include/emscripten/emmalloc.h
@@ -13,18 +13,22 @@ extern "C" {
 // *extremely slow*, use for debugging allocation test cases.
 void emmalloc_dump_memory_regions(void);
 
-// Allocates size bytes with the given pow-2 alignment.
+// Allocates size bytes with the given pow-2 alignment. If the WebAssembly memory runs out of
+// free bytes, this function will abort execution, or if building with -sABORTING_MALLOC=0,
+// return a null pointer.
 void *memalign(size_t alignment, size_t size);
 void *emmalloc_memalign(size_t alignment, size_t size);
 void *aligned_alloc(size_t alignment, size_t size);
 
-// Allocates size bytes with default alignment (8 bytes)
+// Allocates size bytes with default alignment (8 bytes). Like above, either aborts or returns
+// null on OOM.
 void *malloc(size_t size);
 void *emmalloc_malloc(size_t size);
 
 // Returns the number of bytes that are actually allocated to the given pointer ptr.
 // E.g. due to alignment or size requirements, the actual size of the allocation can be
-// larger than what was requested.
+// larger than what was requested. It is ok to pass a null pointer to these functions, in which
+// case 0 will be returned.
 size_t malloc_usable_size(void *ptr);
 size_t emmalloc_usable_size(void *ptr);
 
@@ -32,6 +36,7 @@ size_t emmalloc_usable_size(void *ptr);
 // in this file, e.g.
 // (emmalloc_)memalign, (emmalloc_)malloc, (emmalloc_)calloc, aligned_alloc,
 // (emmalloc_)realloc, emmalloc_realloc_try, emmalloc_realloc_uninitialized, (emmalloc_)aligned_realloc
+// It is ok to pass null in ptr, which will be a no-op.
 void free(void *ptr);
 void emmalloc_free(void *ptr);
 
@@ -39,8 +44,8 @@ void emmalloc_free(void *ptr);
 // pointed by ptr cannot be resized in place, a new memory region will be allocated, old
 // memory copied over, and the old memory area freed. The pointer ptr must have been
 // allocated with one of the emmalloc memory allocation functions (malloc, memalign, ...).
-// If called with size == 0, the pointer ptr is freed, and a null pointer is returned. If
-// called with null ptr, a new pointer is allocated.
+// If called with size == 0, the pointer ptr is freed, and a null pointer is returned.
+// If called with null ptr, a new pointer is allocated.
 // If there is not enough memory, the old memory block is not freed and null pointer is
 // returned.
 void *realloc(void *ptr, size_t size);

--- a/system/include/emscripten/emscripten.h
+++ b/system/include/emscripten/emscripten.h
@@ -32,11 +32,11 @@
 extern "C" {
 #endif
 
-void emscripten_run_script(const char *script);
-int emscripten_run_script_int(const char *script);
-char *emscripten_run_script_string(const char *script);
-void emscripten_async_run_script(const char *script, int millis);
-void emscripten_async_load_script(const char *script, em_callback_func onload, em_callback_func onerror);
+void emscripten_run_script(const char *script __attribute__((nonnull)));
+int emscripten_run_script_int(const char *script __attribute__((nonnull)));
+char *emscripten_run_script_string(const char *script __attribute__((nonnull)));
+void emscripten_async_run_script(const char *script __attribute__((nonnull)), int millis);
+void emscripten_async_load_script(const char *script __attribute__((nonnull)), em_callback_func onload, em_callback_func onerror);
 
 void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infinite_loop);
 
@@ -45,7 +45,7 @@ void emscripten_set_main_loop(em_callback_func func, int fps, int simulate_infin
 #define EM_TIMING_SETIMMEDIATE 2
 
 int emscripten_set_main_loop_timing(int mode, int value);
-void emscripten_get_main_loop_timing(int *mode, int *value);
+void emscripten_get_main_loop_timing(int *mode, int *value); // Pass a null pointer to skip receiving that particular value
 void emscripten_set_main_loop_arg(em_arg_callback_func func, void *arg, int fps, int simulate_infinite_loop);
 void emscripten_pause_main_loop(void);
 void emscripten_resume_main_loop(void);
@@ -79,10 +79,10 @@ double emscripten_get_device_pixel_ratio(void);
 
 char *emscripten_get_window_title();
 void emscripten_set_window_title(const char *);
-void emscripten_get_screen_size(int *width, int *height);
+void emscripten_get_screen_size(int *width __attribute__((nonnull)), int *height __attribute__((nonnull)));
 void emscripten_hide_mouse(void);
 void emscripten_set_canvas_size(int width, int height) __attribute__((deprecated("This variant does not allow specifying the target canvas", "Use emscripten_set_canvas_element_size() instead")));
-void emscripten_get_canvas_size(int *width, int *height, int *isFullscreen) __attribute__((deprecated("This variant does not allow specifying the target canvas", "Use emscripten_get_canvas_element_size() and emscripten_get_fullscreen_status() instead")));
+void emscripten_get_canvas_size(int *width __attribute__((nonnull)), int *height __attribute__((nonnull)), int *isFullscreen __attribute__((nonnull))) __attribute__((deprecated("This variant does not allow specifying the target canvas", "Use emscripten_get_canvas_element_size() and emscripten_get_fullscreen_status() instead")));
 
 double emscripten_get_now(void);
 float emscripten_random(void);
@@ -90,11 +90,11 @@ float emscripten_random(void);
 // IDB
 
 typedef void (*em_idb_onload_func)(void*, void*, int);
-void emscripten_idb_async_load(const char *db_name, const char *file_id, void* arg, em_idb_onload_func onload, em_arg_callback_func onerror);
-void emscripten_idb_async_store(const char *db_name, const char *file_id, void* ptr, int num, void* arg, em_arg_callback_func onstore, em_arg_callback_func onerror);
-void emscripten_idb_async_delete(const char *db_name, const char *file_id, void* arg, em_arg_callback_func ondelete, em_arg_callback_func onerror);
+void emscripten_idb_async_load(const char *db_name __attribute__((nonnull)), const char *file_id __attribute__((nonnull)), void* arg, em_idb_onload_func onload, em_arg_callback_func onerror);
+void emscripten_idb_async_store(const char *db_name __attribute__((nonnull)), const char *file_id __attribute__((nonnull)), void* ptr, int num, void* arg, em_arg_callback_func onstore, em_arg_callback_func onerror);
+void emscripten_idb_async_delete(const char *db_name __attribute__((nonnull)), const char *file_id __attribute__((nonnull)), void* arg, em_arg_callback_func ondelete, em_arg_callback_func onerror);
 typedef void (*em_idb_exists_func)(void*, int);
-void emscripten_idb_async_exists(const char *db_name, const char *file_id, void* arg, em_idb_exists_func oncheck, em_arg_callback_func onerror);
+void emscripten_idb_async_exists(const char *db_name __attribute__((nonnull)), const char *file_id __attribute__((nonnull)), void* arg, em_idb_exists_func oncheck, em_arg_callback_func onerror);
 
 // IDB "sync"
 

--- a/system/include/emscripten/eventloop.h
+++ b/system/include/emscripten/eventloop.h
@@ -15,15 +15,15 @@ extern "C" {
 
 void emscripten_unwind_to_js_event_loop(void) __attribute__((__noreturn__));
 
-int emscripten_set_timeout(void (*cb)(void *user_data), double msecs, void *user_data);
+int emscripten_set_timeout(void (*cb)(void *user_data) __attribute__((nonnull)), double msecs, void *user_data);
 void emscripten_clear_timeout(int id);
-void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *user_data), double interval_ms, void *user_data);
+void emscripten_set_timeout_loop(EM_BOOL (*cb)(double time, void *user_data) __attribute__((nonnull)), double interval_ms, void *user_data);
 
-int emscripten_set_immediate(void (*cb)(void *user_data), void *user_data);
+int emscripten_set_immediate(void (*cb)(void *user_data) __attribute__((nonnull)), void *user_data);
 void emscripten_clear_immediate(int id);
 void emscripten_set_immediate_loop(EM_BOOL (*cb)(void *user_data), void *user_data);
 
-int emscripten_set_interval(void (*cb)(void *user_data), double interval_ms, void *user_data);
+int emscripten_set_interval(void (*cb)(void *user_data) __attribute__((nonnull)), double interval_ms, void *user_data);
 void emscripten_clear_interval(int id);
 
 void emscripten_runtime_keepalive_push();

--- a/system/include/emscripten/exports.h
+++ b/system/include/emscripten/exports.h
@@ -16,7 +16,7 @@ extern "C" {
 
 // Returns a function pointer to the given exported function by name. Cast the returned pointer
 // to its proper signature before calling the function.
-void *emscripten_get_exported_function(const char *fname);
+void *emscripten_get_exported_function(const char *fname __attribute__((nonnull)));
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -202,7 +202,7 @@ void emscripten_fetch_attr_init(emscripten_fetch_attr_t *fetch_attr __attribute_
 
 // Initiates a new Emscripten fetch operation, which downloads data from the
 // given URL or from IndexedDB database.
-emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr __attribute__((nonnull)), const char *url);
+emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const char *url);
 
 // Synchronously blocks to wait for the given fetch operation to complete. This
 // operation is not allowed in the main browser thread, in which case it will
@@ -216,17 +216,17 @@ EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch __attribute__(
 // Closes a finished or an executing fetch operation and frees up all memory. If
 // the fetch operation was still executing, the onerror() handler will be called
 // in the calling thread before this function returns.
-EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch __attribute__((nonnull)));
+EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch);
 
 // Gets the size (in bytes) of the response headers as plain text.
 // This must be called on the same thread as the fetch originated on.
 // Note that this will return 0 if readyState < HEADERS_RECEIVED.
-size_t emscripten_fetch_get_response_headers_length(emscripten_fetch_t *fetch __attribute__((nonnull)));
+size_t emscripten_fetch_get_response_headers_length(emscripten_fetch_t *fetch);
 
 // Gets the response headers as plain text. dstSizeBytes should be
 // headers_length + 1 (for the null terminator).
 // This must be called on the same thread as the fetch originated on.
-size_t emscripten_fetch_get_response_headers(emscripten_fetch_t *fetch __attribute__((nonnull)), char *dst, size_t dstSizeBytes);
+size_t emscripten_fetch_get_response_headers(emscripten_fetch_t *fetch, char *dst, size_t dstSizeBytes);
 
 // Converts the plain text headers into an array of strings. This array takes
 // the form {"key1", "value1", "key2", "value2", "key3", "value3", ..., 0 };

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -198,11 +198,11 @@ typedef struct emscripten_fetch_t {
 
 // Clears the fields of an emscripten_fetch_attr_t structure to their default
 // values in a future-compatible manner.
-void emscripten_fetch_attr_init(emscripten_fetch_attr_t *fetch_attr);
+void emscripten_fetch_attr_init(emscripten_fetch_attr_t *fetch_attr __attribute__((nonnull)));
 
 // Initiates a new Emscripten fetch operation, which downloads data from the
 // given URL or from IndexedDB database.
-emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const char *url);
+emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr __attribute__((nonnull)), const char *url);
 
 // Synchronously blocks to wait for the given fetch operation to complete. This
 // operation is not allowed in the main browser thread, in which case it will
@@ -211,27 +211,27 @@ emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const 
 // EMSCRIPTEN_RESULT_TIMED_OUT.
 // The onsuccess()/onerror()/onprogress() handlers will be called in the calling
 // thread from within this function before this function returns.
-EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeoutMSecs);
+EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch __attribute__((nonnull)), double timeoutMSecs);
 
 // Closes a finished or an executing fetch operation and frees up all memory. If
 // the fetch operation was still executing, the onerror() handler will be called
 // in the calling thread before this function returns.
-EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch);
+EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch __attribute__((nonnull)));
 
 // Gets the size (in bytes) of the response headers as plain text.
 // This must be called on the same thread as the fetch originated on.
 // Note that this will return 0 if readyState < HEADERS_RECEIVED.
-size_t emscripten_fetch_get_response_headers_length(emscripten_fetch_t *fetch);
+size_t emscripten_fetch_get_response_headers_length(emscripten_fetch_t *fetch __attribute__((nonnull)));
 
 // Gets the response headers as plain text. dstSizeBytes should be
 // headers_length + 1 (for the null terminator).
 // This must be called on the same thread as the fetch originated on.
-size_t emscripten_fetch_get_response_headers(emscripten_fetch_t *fetch, char *dst, size_t dstSizeBytes);
+size_t emscripten_fetch_get_response_headers(emscripten_fetch_t *fetch __attribute__((nonnull)), char *dst, size_t dstSizeBytes);
 
 // Converts the plain text headers into an array of strings. This array takes
 // the form {"key1", "value1", "key2", "value2", "key3", "value3", ..., 0 };
 // Note especially that the array is terminated with a null pointer.
-char **emscripten_fetch_unpack_response_headers(const char *headersString);
+char **emscripten_fetch_unpack_response_headers(const char *headersString __attribute__((nonnull)));
 
 // This frees the memory used by the array of headers. Call this when finished
 // with the data returned by emscripten_fetch_unpack_response_headers.

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -198,11 +198,11 @@ typedef struct emscripten_fetch_t {
 
 // Clears the fields of an emscripten_fetch_attr_t structure to their default
 // values in a future-compatible manner.
-void emscripten_fetch_attr_init(emscripten_fetch_attr_t *fetch_attr __attribute__((nonnull)));
+void emscripten_fetch_attr_init(emscripten_fetch_attr_t * _Nonnull fetch_attr);
 
 // Initiates a new Emscripten fetch operation, which downloads data from the
 // given URL or from IndexedDB database.
-emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const char *url);
+emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t * _Nonnull fetch_attr, const char * _Nonnull url);
 
 // Synchronously blocks to wait for the given fetch operation to complete. This
 // operation is not allowed in the main browser thread, in which case it will
@@ -211,27 +211,27 @@ emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const 
 // EMSCRIPTEN_RESULT_TIMED_OUT.
 // The onsuccess()/onerror()/onprogress() handlers will be called in the calling
 // thread from within this function before this function returns.
-EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeoutMSecs);
+EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t * _Nonnull fetch, double timeoutMSecs);
 
 // Closes a finished or an executing fetch operation and frees up all memory. If
 // the fetch operation was still executing, the onerror() handler will be called
 // in the calling thread before this function returns.
-EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t *fetch);
+EMSCRIPTEN_RESULT emscripten_fetch_close(emscripten_fetch_t * _Nonnull fetch);
 
 // Gets the size (in bytes) of the response headers as plain text.
 // This must be called on the same thread as the fetch originated on.
 // Note that this will return 0 if readyState < HEADERS_RECEIVED.
-size_t emscripten_fetch_get_response_headers_length(emscripten_fetch_t *fetch);
+size_t emscripten_fetch_get_response_headers_length(emscripten_fetch_t * _Nonnull fetch);
 
 // Gets the response headers as plain text. dstSizeBytes should be
 // headers_length + 1 (for the null terminator).
 // This must be called on the same thread as the fetch originated on.
-size_t emscripten_fetch_get_response_headers(emscripten_fetch_t *fetch, char *dst, size_t dstSizeBytes);
+size_t emscripten_fetch_get_response_headers(emscripten_fetch_t * _Nonnull fetch, char * _Nonnull dst, size_t dstSizeBytes);
 
 // Converts the plain text headers into an array of strings. This array takes
 // the form {"key1", "value1", "key2", "value2", "key3", "value3", ..., 0 };
 // Note especially that the array is terminated with a null pointer.
-char **emscripten_fetch_unpack_response_headers(const char *headersString __attribute__((nonnull)));
+char **emscripten_fetch_unpack_response_headers(const char * _Nonnull headersString);
 
 // This frees the memory used by the array of headers. Call this when finished
 // with the data returned by emscripten_fetch_unpack_response_headers.

--- a/system/include/emscripten/fetch.h
+++ b/system/include/emscripten/fetch.h
@@ -211,7 +211,7 @@ emscripten_fetch_t *emscripten_fetch(emscripten_fetch_attr_t *fetch_attr, const 
 // EMSCRIPTEN_RESULT_TIMED_OUT.
 // The onsuccess()/onerror()/onprogress() handlers will be called in the calling
 // thread from within this function before this function returns.
-EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch __attribute__((nonnull)), double timeoutMSecs);
+EMSCRIPTEN_RESULT emscripten_fetch_wait(emscripten_fetch_t *fetch, double timeoutMSecs);
 
 // Closes a finished or an executing fetch operation and frees up all memory. If
 // the fetch operation was still executing, the onerror() handler will be called

--- a/system/include/emscripten/fiber.h
+++ b/system/include/emscripten/fiber.h
@@ -32,24 +32,24 @@ typedef struct emscripten_fiber_s {
 } emscripten_fiber_t;
 
 void emscripten_fiber_init(
-  emscripten_fiber_t *fiber,
+  emscripten_fiber_t *fiber __attribute__((nonnull)),
   em_arg_callback_func entry_func,
   void *entry_func_arg,
-  void *c_stack,
+  void *c_stack __attribute__((nonnull)),
   size_t c_stack_size,
-  void *asyncify_stack,
+  void *asyncify_stack __attribute__((nonnull)),
   size_t asyncify_stack_size
 );
 
 void emscripten_fiber_init_from_current_context(
-  emscripten_fiber_t *fiber,
-  void *asyncify_stack,
+  emscripten_fiber_t *fiber __attribute__((nonnull)),
+  void *asyncify_stack __attribute__((nonnull)),
   size_t asyncify_stack_size
 );
 
 void emscripten_fiber_swap(
-  emscripten_fiber_t *old_fiber,
-  emscripten_fiber_t *new_fiber
+  emscripten_fiber_t *old_fiber __attribute__((nonnull)),
+  emscripten_fiber_t *new_fiber __attribute__((nonnull))
 );
 
 #ifdef __cplusplus

--- a/system/include/emscripten/html5.h
+++ b/system/include/emscripten/html5.h
@@ -118,10 +118,10 @@ typedef struct EmscriptenKeyboardEvent {
 } EmscriptenKeyboardEvent;
 
 
-typedef EM_BOOL (*em_key_callback_func)(int eventType, const EmscriptenKeyboardEvent *keyEvent, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_keypress_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_keydown_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_keyup_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
+typedef EM_BOOL (*em_key_callback_func)(int eventType, const EmscriptenKeyboardEvent *keyEvent __attribute__((nonnull)), void *userData);
+EMSCRIPTEN_RESULT emscripten_set_keypress_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_keydown_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_keyup_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_key_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenMouseEvent {
   double timestamp;
@@ -146,18 +146,18 @@ typedef struct EmscriptenMouseEvent {
 } EmscriptenMouseEvent;
 
 
-typedef EM_BOOL (*em_mouse_callback_func)(int eventType, const EmscriptenMouseEvent *mouseEvent, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_click_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mousedown_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseup_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_dblclick_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mousemove_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseenter_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseleave_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseover_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_mouseout_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+typedef EM_BOOL (*em_mouse_callback_func)(int eventType, const EmscriptenMouseEvent *mouseEvent __attribute__((nonnull)), void *userData);
+EMSCRIPTEN_RESULT emscripten_set_click_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mousedown_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseup_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_dblclick_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mousemove_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseenter_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseleave_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseover_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_mouseout_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_mouse_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_mouse_status(EmscriptenMouseEvent *mouseState);
+EMSCRIPTEN_RESULT emscripten_get_mouse_status(EmscriptenMouseEvent *mouseState __attribute__((nonnull)));
 
 #define DOM_DELTA_PIXEL 0x00
 #define DOM_DELTA_LINE  0x01
@@ -172,8 +172,8 @@ typedef struct EmscriptenWheelEvent {
 } EmscriptenWheelEvent;
 
 
-typedef EM_BOOL (*em_wheel_callback_func)(int eventType, const EmscriptenWheelEvent *wheelEvent, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_wheel_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_wheel_callback_func callback, pthread_t targetThread);
+typedef EM_BOOL (*em_wheel_callback_func)(int eventType, const EmscriptenWheelEvent *wheelEvent __attribute__((nonnull)), void *userData);
+EMSCRIPTEN_RESULT emscripten_set_wheel_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_wheel_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenUiEvent {
   long detail;
@@ -188,20 +188,20 @@ typedef struct EmscriptenUiEvent {
 } EmscriptenUiEvent;
 
 
-typedef EM_BOOL (*em_ui_callback_func)(int eventType, const EmscriptenUiEvent *uiEvent, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_resize_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_ui_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_scroll_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_ui_callback_func callback, pthread_t targetThread);
+typedef EM_BOOL (*em_ui_callback_func)(int eventType, const EmscriptenUiEvent *uiEvent __attribute__((nonnull)), void *userData);
+EMSCRIPTEN_RESULT emscripten_set_resize_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_ui_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_scroll_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_ui_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenFocusEvent {
   EM_UTF8 nodeName[EM_HTML5_LONG_STRING_LEN_BYTES];
   EM_UTF8 id[EM_HTML5_LONG_STRING_LEN_BYTES];
 } EmscriptenFocusEvent;
 
-typedef EM_BOOL (*em_focus_callback_func)(int eventType, const EmscriptenFocusEvent *focusEvent, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_blur_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_focus_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_focusin_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_focusout_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
+typedef EM_BOOL (*em_focus_callback_func)(int eventType, const EmscriptenFocusEvent *focusEvent __attribute__((nonnull)), void *userData);
+EMSCRIPTEN_RESULT emscripten_set_blur_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focus_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focusin_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_focusout_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_focus_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenDeviceOrientationEvent {
   double alpha;
@@ -211,10 +211,10 @@ typedef struct EmscriptenDeviceOrientationEvent {
 } EmscriptenDeviceOrientationEvent;
 
 
-typedef EM_BOOL (*em_deviceorientation_callback_func)(int eventType, const EmscriptenDeviceOrientationEvent *deviceOrientationEvent, void *userData);
+typedef EM_BOOL (*em_deviceorientation_callback_func)(int eventType, const EmscriptenDeviceOrientationEvent *deviceOrientationEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_set_deviceorientation_callback_on_thread(void *userData, EM_BOOL useCapture, em_deviceorientation_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_deviceorientation_status(EmscriptenDeviceOrientationEvent *orientationState);
+EMSCRIPTEN_RESULT emscripten_get_deviceorientation_status(EmscriptenDeviceOrientationEvent *orientationState __attribute__((nonnull)));
 
 #define EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION                   0x01
 #define EMSCRIPTEN_DEVICE_MOTION_EVENT_SUPPORTS_ACCELERATION_INCLUDING_GRAVITY 0x02
@@ -234,10 +234,10 @@ typedef struct EmscriptenDeviceMotionEvent {
 } EmscriptenDeviceMotionEvent;
 
 
-typedef EM_BOOL (*em_devicemotion_callback_func)(int eventType, const EmscriptenDeviceMotionEvent *deviceMotionEvent, void *userData);
+typedef EM_BOOL (*em_devicemotion_callback_func)(int eventType, const EmscriptenDeviceMotionEvent *deviceMotionEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_set_devicemotion_callback_on_thread(void *userData, EM_BOOL useCapture, em_devicemotion_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_devicemotion_status(EmscriptenDeviceMotionEvent *motionState);
+EMSCRIPTEN_RESULT emscripten_get_devicemotion_status(EmscriptenDeviceMotionEvent *motionState __attribute__((nonnull)));
 
 #define EMSCRIPTEN_ORIENTATION_PORTRAIT_PRIMARY    1
 #define EMSCRIPTEN_ORIENTATION_PORTRAIT_SECONDARY  2
@@ -250,10 +250,10 @@ typedef struct EmscriptenOrientationChangeEvent {
 } EmscriptenOrientationChangeEvent;
 
 
-typedef EM_BOOL (*em_orientationchange_callback_func)(int eventType, const EmscriptenOrientationChangeEvent *orientationChangeEvent, void *userData);
+typedef EM_BOOL (*em_orientationchange_callback_func)(int eventType, const EmscriptenOrientationChangeEvent *orientationChangeEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_set_orientationchange_callback_on_thread(void *userData, EM_BOOL useCapture, em_orientationchange_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_orientation_status(EmscriptenOrientationChangeEvent *orientationStatus);
+EMSCRIPTEN_RESULT emscripten_get_orientation_status(EmscriptenOrientationChangeEvent *orientationStatus __attribute__((nonnull)));
 EMSCRIPTEN_RESULT emscripten_lock_orientation(int allowedOrientations);
 EMSCRIPTEN_RESULT emscripten_unlock_orientation(void);
 
@@ -269,10 +269,10 @@ typedef struct EmscriptenFullscreenChangeEvent {
 } EmscriptenFullscreenChangeEvent;
 
 
-typedef EM_BOOL (*em_fullscreenchange_callback_func)(int eventType, const EmscriptenFullscreenChangeEvent *fullscreenChangeEvent, void *userData);
+typedef EM_BOOL (*em_fullscreenchange_callback_func)(int eventType, const EmscriptenFullscreenChangeEvent *fullscreenChangeEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_set_fullscreenchange_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_fullscreenchange_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_fullscreen_status(EmscriptenFullscreenChangeEvent *fullscreenStatus);
+EMSCRIPTEN_RESULT emscripten_get_fullscreen_status(EmscriptenFullscreenChangeEvent *fullscreenStatus __attribute__((nonnull)));
 
 #define EMSCRIPTEN_FULLSCREEN_SCALE int
 #define EMSCRIPTEN_FULLSCREEN_SCALE_DEFAULT 0
@@ -301,12 +301,12 @@ typedef struct EmscriptenFullscreenStrategy {
   pthread_t canvasResizedCallbackTargetThread;
 } EmscriptenFullscreenStrategy;
 
-EMSCRIPTEN_RESULT emscripten_request_fullscreen(const char *target, EM_BOOL deferUntilInEventHandler);
-EMSCRIPTEN_RESULT emscripten_request_fullscreen_strategy(const char *target, EM_BOOL deferUntilInEventHandler, const EmscriptenFullscreenStrategy *fullscreenStrategy);
+EMSCRIPTEN_RESULT emscripten_request_fullscreen(const char *target __attribute__((nonnull)), EM_BOOL deferUntilInEventHandler);
+EMSCRIPTEN_RESULT emscripten_request_fullscreen_strategy(const char *target __attribute__((nonnull)), EM_BOOL deferUntilInEventHandler, const EmscriptenFullscreenStrategy *fullscreenStrategy __attribute__((nonnull)));
 
 EMSCRIPTEN_RESULT emscripten_exit_fullscreen(void);
 
-EMSCRIPTEN_RESULT emscripten_enter_soft_fullscreen(const char *target, const EmscriptenFullscreenStrategy *fullscreenStrategy);
+EMSCRIPTEN_RESULT emscripten_enter_soft_fullscreen(const char *target __attribute__((nonnull)), const EmscriptenFullscreenStrategy *fullscreenStrategy __attribute__((nonnull)));
 
 EMSCRIPTEN_RESULT emscripten_exit_soft_fullscreen(void);
 
@@ -317,15 +317,15 @@ typedef struct EmscriptenPointerlockChangeEvent {
 } EmscriptenPointerlockChangeEvent;
 
 
-typedef EM_BOOL (*em_pointerlockchange_callback_func)(int eventType, const EmscriptenPointerlockChangeEvent *pointerlockChangeEvent, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_pointerlockchange_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_pointerlockchange_callback_func callback, pthread_t targetThread);
+typedef EM_BOOL (*em_pointerlockchange_callback_func)(int eventType, const EmscriptenPointerlockChangeEvent *pointerlockChangeEvent __attribute__((nonnull)), void *userData);
+EMSCRIPTEN_RESULT emscripten_set_pointerlockchange_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_pointerlockchange_callback_func callback, pthread_t targetThread);
 
 typedef EM_BOOL (*em_pointerlockerror_callback_func)(int eventType, const void *reserved, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_pointerlockerror_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_pointerlockerror_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_pointerlockerror_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_pointerlockerror_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_pointerlock_status(EmscriptenPointerlockChangeEvent *pointerlockStatus);
+EMSCRIPTEN_RESULT emscripten_get_pointerlock_status(EmscriptenPointerlockChangeEvent *pointerlockStatus __attribute__((nonnull)));
 
-EMSCRIPTEN_RESULT emscripten_request_pointerlock(const char *target, EM_BOOL deferUntilInEventHandler);
+EMSCRIPTEN_RESULT emscripten_request_pointerlock(const char *target __attribute__((nonnull)), EM_BOOL deferUntilInEventHandler);
 
 EMSCRIPTEN_RESULT emscripten_exit_pointerlock(void);
 
@@ -339,10 +339,10 @@ typedef struct EmscriptenVisibilityChangeEvent {
   int visibilityState;
 } EmscriptenVisibilityChangeEvent;
 
-typedef EM_BOOL (*em_visibilitychange_callback_func)(int eventType, const EmscriptenVisibilityChangeEvent *visibilityChangeEvent, void *userData);
+typedef EM_BOOL (*em_visibilitychange_callback_func)(int eventType, const EmscriptenVisibilityChangeEvent *visibilityChangeEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_set_visibilitychange_callback_on_thread(void *userData, EM_BOOL useCapture, em_visibilitychange_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_visibility_status(EmscriptenVisibilityChangeEvent *visibilityStatus);
+EMSCRIPTEN_RESULT emscripten_get_visibility_status(EmscriptenVisibilityChangeEvent *visibilityStatus __attribute__((nonnull)));
 
 
 typedef struct EmscriptenTouchPoint
@@ -374,11 +374,11 @@ typedef struct EmscriptenTouchEvent {
 } EmscriptenTouchEvent;
 
 
-typedef EM_BOOL (*em_touch_callback_func)(int eventType, const EmscriptenTouchEvent *touchEvent, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_touchstart_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_touchend_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_touchmove_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_touchcancel_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
+typedef EM_BOOL (*em_touch_callback_func)(int eventType, const EmscriptenTouchEvent *touchEvent __attribute__((nonnull)), void *userData);
+EMSCRIPTEN_RESULT emscripten_set_touchstart_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchend_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchmove_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_touchcancel_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_touch_callback_func callback, pthread_t targetThread);
 
 
 typedef struct EmscriptenGamepadEvent {
@@ -395,13 +395,13 @@ typedef struct EmscriptenGamepadEvent {
 } EmscriptenGamepadEvent;
 
 
-typedef EM_BOOL (*em_gamepad_callback_func)(int eventType, const EmscriptenGamepadEvent *gamepadEvent, void *userData);
+typedef EM_BOOL (*em_gamepad_callback_func)(int eventType, const EmscriptenGamepadEvent *gamepadEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_set_gamepadconnected_callback_on_thread(void *userData, EM_BOOL useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
 EMSCRIPTEN_RESULT emscripten_set_gamepaddisconnected_callback_on_thread(void *userData, EM_BOOL useCapture, em_gamepad_callback_func callback, pthread_t targetThread);
 
 EMSCRIPTEN_RESULT emscripten_sample_gamepad_data(void);
 int emscripten_get_num_gamepads(void);
-EMSCRIPTEN_RESULT emscripten_get_gamepad_status(int index, EmscriptenGamepadEvent *gamepadState);
+EMSCRIPTEN_RESULT emscripten_get_gamepad_status(int index, EmscriptenGamepadEvent *gamepadState __attribute__((nonnull)));
 
 typedef struct EmscriptenBatteryEvent {
   double chargingTime;
@@ -410,27 +410,27 @@ typedef struct EmscriptenBatteryEvent {
   EM_BOOL charging;
 } EmscriptenBatteryEvent;
 
-typedef EM_BOOL (*em_battery_callback_func)(int eventType, const EmscriptenBatteryEvent *batteryEvent, void *userData);
+typedef EM_BOOL (*em_battery_callback_func)(int eventType, const EmscriptenBatteryEvent *batteryEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_set_batterychargingchange_callback_on_thread(void *userData, em_battery_callback_func callback, pthread_t targetThread);
 EMSCRIPTEN_RESULT emscripten_set_batterylevelchange_callback_on_thread(void *userData, em_battery_callback_func callback, pthread_t targetThread);
 
-EMSCRIPTEN_RESULT emscripten_get_battery_status(EmscriptenBatteryEvent *batteryState);
+EMSCRIPTEN_RESULT emscripten_get_battery_status(EmscriptenBatteryEvent *batteryState __attribute__((nonnull)));
 
 
 EMSCRIPTEN_RESULT emscripten_vibrate(int msecs);
-EMSCRIPTEN_RESULT emscripten_vibrate_pattern(int *msecsArray, int numEntries);
+EMSCRIPTEN_RESULT emscripten_vibrate_pattern(int *msecsArray __attribute__((nonnull)), int numEntries);
 
 typedef const char *(*em_beforeunload_callback)(int eventType, const void *reserved, void *userData);
 EMSCRIPTEN_RESULT emscripten_set_beforeunload_callback_on_thread(void *userData, em_beforeunload_callback callback, pthread_t targetThread);
 
 // Sets the canvas.width & canvas.height properties.
-EMSCRIPTEN_RESULT emscripten_set_canvas_element_size(const char *target, int width, int height);
+EMSCRIPTEN_RESULT emscripten_set_canvas_element_size(const char *target __attribute__((nonnull)), int width, int height);
 
 // Returns the canvas.width & canvas.height properties.
-EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char *target, int *width, int *height);
+EMSCRIPTEN_RESULT emscripten_get_canvas_element_size(const char *target __attribute__((nonnull)), int *width, int *height);
 
-EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target, double width, double height);
-EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target, double *width, double *height);
+EMSCRIPTEN_RESULT emscripten_set_element_css_size(const char *target __attribute__((nonnull)), double width, double height);
+EMSCRIPTEN_RESULT emscripten_get_element_css_size(const char *target __attribute__((nonnull)), double *width, double *height);
 
 void emscripten_html5_remove_all_event_listeners(void);
 

--- a/system/include/emscripten/html5_webgl.h
+++ b/system/include/emscripten/html5_webgl.h
@@ -46,7 +46,7 @@ typedef struct EmscriptenWebGLContextAttributes {
 
 void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttributes *attributes __attribute__((nonnull)));
 
-EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target __attribute__((nonnull)), const EmscriptenWebGLContextAttributes *attributes);
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target __attribute__((nonnull)), const EmscriptenWebGLContextAttributes * _Nonnull attributes);
 
 EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 

--- a/system/include/emscripten/html5_webgl.h
+++ b/system/include/emscripten/html5_webgl.h
@@ -44,21 +44,21 @@ typedef struct EmscriptenWebGLContextAttributes {
   EM_BOOL renderViaOffscreenBackBuffer;
 } EmscriptenWebGLContextAttributes;
 
-void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttributes *attributes);
+void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttributes *attributes __attribute__((nonnull)));
 
-EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target, const EmscriptenWebGLContextAttributes *attributes);
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target __attribute__((nonnull)), const EmscriptenWebGLContextAttributes *attributes __attribute__((nonnull)));
 
 EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
 EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_get_current_context(void);
 
-EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width, int *height);
+EMSCRIPTEN_RESULT emscripten_webgl_get_drawing_buffer_size(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, int *width __attribute__((nonnull)), int *height __attribute__((nonnull)));
 
-EMSCRIPTEN_RESULT emscripten_webgl_get_context_attributes(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, EmscriptenWebGLContextAttributes *outAttributes);
+EMSCRIPTEN_RESULT emscripten_webgl_get_context_attributes(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, EmscriptenWebGLContextAttributes *outAttributes __attribute__((nonnull)));
 
 EMSCRIPTEN_RESULT emscripten_webgl_destroy_context(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
-EM_BOOL emscripten_webgl_enable_extension(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, const char *extension);
+EM_BOOL emscripten_webgl_enable_extension(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context, const char *extension __attribute__((nonnull)));
 
 EM_BOOL emscripten_webgl_enable_ANGLE_instanced_arrays(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
@@ -73,8 +73,8 @@ EM_BOOL emscripten_webgl_enable_WEBGL_multi_draw(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE
 EM_BOOL emscripten_webgl_enable_WEBGL_multi_draw_instanced_base_vertex_base_instance(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
 typedef EM_BOOL (*em_webgl_context_callback)(int eventType, const void *reserved, void *userData);
-EMSCRIPTEN_RESULT emscripten_set_webglcontextlost_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
-EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback_on_thread(const char *target, void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_webglcontextlost_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
+EMSCRIPTEN_RESULT emscripten_set_webglcontextrestored_callback_on_thread(const char *target __attribute__((nonnull)), void *userData, EM_BOOL useCapture, em_webgl_context_callback callback, pthread_t targetThread);
 
 EM_BOOL emscripten_is_webgl_context_lost(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 
@@ -85,15 +85,15 @@ EM_BOOL emscripten_supports_offscreencanvas(void);
 // Returns function pointers to WebGL 1 functions. Please avoid using this function ever - all WebGL1/GLES2 functions, even those for WebGL1 extensions, are available to user code via static linking. Calling GL functions
 // via function pointers obtained here is slow, and using this function can greatly increase resulting compiled program size. This functionality is available only for easier program code porting purposes, but be aware
 // that calling this is causing a noticeable performance and compiled code size hit.
-void *emscripten_webgl1_get_proc_address(const char *name);
+void *emscripten_webgl1_get_proc_address(const char *name __attribute__((nonnull)));
 
 // Returns function pointers to WebGL 2 functions. Please avoid using this function ever - all WebGL2/GLES3 functions, even those for WebGL2 extensions, are available to user code via static linking. Calling GL functions
 // via function pointers obtained here is slow, and using this function can greatly increase resulting compiled program size. This functionality is available only for easier program code porting purposes, but be aware
 // that calling this is causing a noticeable performance and compiled code size hit.
-void *emscripten_webgl2_get_proc_address(const char *name);
+void *emscripten_webgl2_get_proc_address(const char *name __attribute__((nonnull)));
 
 // Combines emscripten_webgl1_get_proc_address() and emscripten_webgl2_get_proc_address() to return function pointers to both WebGL1 and WebGL2 functions. Same drawbacks apply.
-void *emscripten_webgl_get_proc_address(const char *name);
+void *emscripten_webgl_get_proc_address(const char *name __attribute__((nonnull)));
 
 #define emscripten_set_webglcontextlost_callback(target, userData, useCapture, callback)      emscripten_set_webglcontextlost_callback_on_thread(     (target), (userData), (useCapture), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
 #define emscripten_set_webglcontextrestored_callback(target, userData, useCapture, callback)  emscripten_set_webglcontextrestored_callback_on_thread( (target), (userData), (useCapture), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
@@ -148,7 +148,7 @@ GLint emscripten_webgl_get_vertex_attrib_o(int index, GLenum param);
 // Use dstType to specify whether to read an array of ints or floats.
 // The function writes at most dstLength array elements to array dst.
 // The actual length of the state array is returned (not the number of elements written)
-int emscripten_webgl_get_vertex_attrib_v(int index, GLenum param, void *dst, int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
+int emscripten_webgl_get_vertex_attrib_v(int index, GLenum param, void *dst __attribute__((nonnull)), int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
 
 // Calls GLctx.getUniform():
 // Returns the value of a uniform set in a program in the given location.
@@ -161,7 +161,7 @@ double emscripten_webgl_get_uniform_d(GLint program, int location);
 // Use dstType to specify whether to read in ints or floats.
 // The function writes at most dstLength array elements to array dst.
 // The actual length of the state array is returned (not the number of elements written)
-int emscripten_webgl_get_uniform_v(GLint program, int location, void *dst, int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
+int emscripten_webgl_get_uniform_v(GLint program, int location, void *dst __attribute__((nonnull)), int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
 
 // Calls GLctx.getParameter():
 // Gets an array of state set to the active WebGL context.
@@ -169,7 +169,7 @@ int emscripten_webgl_get_uniform_v(GLint program, int location, void *dst, int d
 // Use dstType to specify whether to read in ints or floats.
 // The function writes at most dstLength array elements to array dst.
 // The actual length of the state array is returned (not the number of elements written)
-int emscripten_webgl_get_parameter_v(GLenum param, void *dst, int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
+int emscripten_webgl_get_parameter_v(GLenum param, void *dst __attribute__((nonnull)), int dstLength, EMSCRIPTEN_WEBGL_PARAM_TYPE dstType);
 
 // Calls GLctx.getParameter():
 // Returns the given WebGL context state as double.
@@ -190,7 +190,7 @@ char *emscripten_webgl_get_parameter_utf8(GLenum param);
 // Calls GLctx.getParameter():
 // Returns the given WebGL context state as long long, written to the given heap location.
 // Call this function only for values of 'param' that return a WebGL Number type.
-void emscripten_webgl_get_parameter_i64v(GLenum param, long long *dst);
+void emscripten_webgl_get_parameter_i64v(GLenum param, long long *dst __attribute__((nonnull)));
 
 #undef GLint
 #undef GLenum

--- a/system/include/emscripten/html5_webgl.h
+++ b/system/include/emscripten/html5_webgl.h
@@ -46,7 +46,7 @@ typedef struct EmscriptenWebGLContextAttributes {
 
 void emscripten_webgl_init_context_attributes(EmscriptenWebGLContextAttributes *attributes __attribute__((nonnull)));
 
-EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target __attribute__((nonnull)), const EmscriptenWebGLContextAttributes *attributes __attribute__((nonnull)));
+EMSCRIPTEN_WEBGL_CONTEXT_HANDLE emscripten_webgl_create_context(const char *target __attribute__((nonnull)), const EmscriptenWebGLContextAttributes *attributes);
 
 EMSCRIPTEN_RESULT emscripten_webgl_make_context_current(EMSCRIPTEN_WEBGL_CONTEXT_HANDLE context);
 

--- a/system/include/emscripten/posix_socket.h
+++ b/system/include/emscripten/posix_socket.h
@@ -6,7 +6,7 @@
 extern "C" {
 #endif
 
-EMSCRIPTEN_RESULT emscripten_init_websocket_to_posix_socket_bridge(const char *bridgeUrl);
+EMSCRIPTEN_RESULT emscripten_init_websocket_to_posix_socket_bridge(const char *bridgeUrl __attribute__((nonnull)));
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/stack.h
+++ b/system/include/emscripten/stack.h
@@ -35,7 +35,7 @@ void emscripten_stack_init(void);
 // Sets the internal values reported by emscripten_stack_get_base() and
 // emscripten_stack_get_end().  This should be only used by low level libraries
 // such as asyncify fibers.
-void emscripten_stack_set_limits(void* base, void* end);
+void emscripten_stack_set_limits(void* base __attribute__((nonnull)), void* end __attribute__((nonnull)));
 
 // Returns the current stack pointer.
 uintptr_t emscripten_stack_get_current(void);

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -40,7 +40,8 @@ int emscripten_futex_wait(volatile void/*uint32_t*/ *addr __attribute__((nonnull
 
 // Wakes the given number of threads waiting on a location. Pass count ==
 // INT_MAX to wake all waiters on that location.
-int emscripten_futex_wake(volatile void/*uint32_t*/ *addr __attribute__((nonnull)), int count);
+// Returns -EINVAL if addr is null.
+int emscripten_futex_wake(volatile void/*uint32_t*/ *addr, int count);
 
 typedef struct em_queued_call em_queued_call;
 

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -36,11 +36,11 @@ void emscripten_force_num_logical_cores(int cores);
 
 // If the given memory address contains value val, puts the calling thread to
 // sleep waiting for that address to be notified.
-int emscripten_futex_wait(volatile void/*uint32_t*/ *addr, uint32_t val, double maxWaitMilliseconds);
+int emscripten_futex_wait(volatile void/*uint32_t*/ *addr __attribute__((nonnull)), uint32_t val, double maxWaitMilliseconds);
 
 // Wakes the given number of threads waiting on a location. Pass count ==
 // INT_MAX to wake all waiters on that location.
-int emscripten_futex_wake(volatile void/*uint32_t*/ *addr, int count);
+int emscripten_futex_wake(volatile void/*uint32_t*/ *addr __attribute__((nonnull)), int count);
 
 typedef struct em_queued_call em_queued_call;
 
@@ -148,7 +148,7 @@ typedef struct em_queued_call em_queued_call;
 //  - Calling emscripten_sync_* functions requires that the application was
 //    compiled with pthreads support enabled (-sUSE_PTHREADS=1/2) and that the
 //    browser supports SharedArrayBuffer specification.
-int emscripten_sync_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr, ...);
+int emscripten_sync_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr __attribute__((nonnull)), ...);
 
 // The 'async' variant of the run_in_main_thread functions are otherwise the
 // same as the synchronous ones, except that the operation is performed in a
@@ -158,7 +158,7 @@ int emscripten_sync_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *fun
 //  - Note that multiple asynchronous commands from a single pthread/Worker are
 //    guaranteed to be executed on the main thread in the program order they
 //    were called in.
-void emscripten_async_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr, ...);
+void emscripten_async_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr __attribute__((nonnull)), ...);
 
 // The 'async_waitable' variant of the run_in_main_runtime_thread functions run
 // like the 'async' variants, except that while the operation starts off
@@ -167,7 +167,7 @@ void emscripten_async_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *f
 //  - The object returned by this function call is dynamically allocated, and
 //    should be freed up via a call to emscripten_async_waitable_close() after
 //    the wait has been performed.
-em_queued_call *emscripten_async_waitable_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr, ...);
+em_queued_call *emscripten_async_waitable_run_in_main_runtime_thread_(EM_FUNC_SIGNATURE sig, void *func_ptr __attribute__((nonnull)), ...);
 
 // Since we can't validate the function pointer type, allow implicit casting of
 // functions to void* without complaining.
@@ -175,10 +175,10 @@ em_queued_call *emscripten_async_waitable_run_in_main_runtime_thread_(EM_FUNC_SI
 #define emscripten_async_run_in_main_runtime_thread(sig, func_ptr, ...) emscripten_async_run_in_main_runtime_thread_((sig), (void*)(func_ptr),##__VA_ARGS__)
 #define emscripten_async_waitable_run_in_main_runtime_thread(sig, func_ptr, ...) emscripten_async_waitable_run_in_main_runtime_thread_((sig), (void*)(func_ptr),##__VA_ARGS__)
 
-EMSCRIPTEN_RESULT emscripten_wait_for_call_v(em_queued_call *call, double timeoutMSecs);
-EMSCRIPTEN_RESULT emscripten_wait_for_call_i(em_queued_call *call, double timeoutMSecs, int *outResult);
+EMSCRIPTEN_RESULT emscripten_wait_for_call_v(em_queued_call *call __attribute__((nonnull)), double timeoutMSecs);
+EMSCRIPTEN_RESULT emscripten_wait_for_call_i(em_queued_call *call __attribute__((nonnull)), double timeoutMSecs, int *outResult);
 
-void emscripten_async_waitable_close(em_queued_call *call);
+void emscripten_async_waitable_close(em_queued_call *call __attribute__((nonnull)));
 
 // Runs the given function on the specified thread. If we are currently on
 // that target thread then we just execute the call synchronously; otherwise it
@@ -187,12 +187,12 @@ void emscripten_async_waitable_close(em_queued_call *call);
 // otherwise.
 int emscripten_dispatch_to_thread_args(pthread_t target_thread,
                                        EM_FUNC_SIGNATURE sig,
-                                       void* func_ptr,
+                                       void* func_ptr __attribute__((nonnull)),
                                        void* satellite,
                                        va_list args);
 int emscripten_dispatch_to_thread_(pthread_t target_thread,
                                    EM_FUNC_SIGNATURE sig,
-                                   void* func_ptr,
+                                   void* func_ptr __attribute__((nonnull)),
                                    void* satellite,
                                    ...);
 #define emscripten_dispatch_to_thread(                                         \
@@ -205,12 +205,12 @@ int emscripten_dispatch_to_thread_(pthread_t target_thread,
 // but may be simpler to reason about in some cases.
 int emscripten_dispatch_to_thread_async_args(pthread_t target_thread,
                                              EM_FUNC_SIGNATURE sig,
-                                             void* func_ptr,
+                                             void* func_ptr __attribute__((nonnull)),
                                              void* satellite,
                                              va_list args);
 int emscripten_dispatch_to_thread_async_(pthread_t target_thread,
                                          EM_FUNC_SIGNATURE sig,
-                                         void* func_ptr,
+                                         void* func_ptr __attribute__((nonnull)),
                                          void* satellite,
                                          ...);
 #define emscripten_dispatch_to_thread_async(                                   \
@@ -264,11 +264,11 @@ void emscripten_thread_sleep(double msecs);
 // The name parameter is a UTF-8 encoded string which is truncated to 32 bytes.
 // When thread profiler is not enabled (not building with --threadprofiler),
 // this is a no-op.
-void emscripten_set_thread_name(pthread_t threadId, const char *name);
+void emscripten_set_thread_name(pthread_t threadId, const char *name __attribute__((nonnull)));
 
 // Gets the stored pointer to a string representing the canvases to transfer to
 // the created thread.
-int emscripten_pthread_attr_gettransferredcanvases(const pthread_attr_t *a, const char **str);
+int emscripten_pthread_attr_gettransferredcanvases(const pthread_attr_t *a __attribute__((nonnull)), const char **str __attribute__((nonnull)));
 
 // Specifies a comma-delimited list of canvas DOM element IDs to transfer to the
 // thread to be created.
@@ -276,7 +276,7 @@ int emscripten_pthread_attr_gettransferredcanvases(const pthread_attr_t *a, cons
 // so must be held alive until pthread_create() has been called. If 0 or "", no
 // canvases are transferred.
 // The special value "#canvas" denotes the element stored in Module.canvas.
-int emscripten_pthread_attr_settransferredcanvases(pthread_attr_t *a, const char *str);
+int emscripten_pthread_attr_settransferredcanvases(pthread_attr_t *a __attribute__((nonnull)), const char *str __attribute__((nonnull)));
 
 // Called when blocking on the main thread. This will error if main thread
 // blocking is not enabled, see ALLOW_BLOCKING_ON_MAIN_THREAD.

--- a/system/include/emscripten/threading.h
+++ b/system/include/emscripten/threading.h
@@ -41,7 +41,7 @@ int emscripten_futex_wait(volatile void/*uint32_t*/ *addr __attribute__((nonnull
 // Wakes the given number of threads waiting on a location. Pass count ==
 // INT_MAX to wake all waiters on that location.
 // Returns -EINVAL if addr is null.
-int emscripten_futex_wake(volatile void/*uint32_t*/ *addr, int count);
+int emscripten_futex_wake(volatile void/*uint32_t*/ * _Nonnull addr, int count);
 
 typedef struct em_queued_call em_queued_call;
 

--- a/system/include/emscripten/wasm_worker.h
+++ b/system/include/emscripten/wasm_worker.h
@@ -26,7 +26,7 @@ extern "C" {
    Note that the Worker will be loaded up asynchronously, and initially will not be executing any code. Use
    emscripten_wasm_worker_post_function_*() set of functions to start executing code on the Worker. */
 emscripten_wasm_worker_t emscripten_malloc_wasm_worker(uint32_t stackSize);
-emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize);
+emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress __attribute__((nonnull)), uint32_t stackSize);
 
 // Terminates the given Wasm Worker some time after it has finished executing its current, or possibly some subsequent
 // posted functions. Note that this function is not C++ RAII safe, but you must manually coordinate to release any
@@ -60,14 +60,14 @@ uint32_t emscripten_wasm_worker_self_id(void);
    latency cost compared to direct coordination using atomics and synchronization primitives like mutexes
    and synchronization primitives. Additionally these functions will generate garbage on the JS heap.
    Therefore avoid using these functions where performance is critical. */
-void emscripten_wasm_worker_post_function_v(emscripten_wasm_worker_t id, void (*funcPtr)(void));
-void emscripten_wasm_worker_post_function_vi(emscripten_wasm_worker_t id, void (*funcPtr)(int), int arg0);
-void emscripten_wasm_worker_post_function_vii(emscripten_wasm_worker_t id, void (*funcPtr)(int, int), int arg0, int arg1);
-void emscripten_wasm_worker_post_function_viii(emscripten_wasm_worker_t id, void (*funcPtr)(int, int, int), int arg0, int arg1, int arg2);
-void emscripten_wasm_worker_post_function_vd(emscripten_wasm_worker_t id, void (*funcPtr)(double), double arg0);
-void emscripten_wasm_worker_post_function_vdd(emscripten_wasm_worker_t id, void (*funcPtr)(double, double), double arg0, double arg1);
-void emscripten_wasm_worker_post_function_vddd(emscripten_wasm_worker_t id, void (*funcPtr)(double, double, double), double arg0, double arg1, double arg2);
-void emscripten_wasm_worker_post_function_sig(emscripten_wasm_worker_t id, void *funcPtr, const char *sig, ...);
+void emscripten_wasm_worker_post_function_v(emscripten_wasm_worker_t id, void (*funcPtr)(void) __attribute__((nonnull)));
+void emscripten_wasm_worker_post_function_vi(emscripten_wasm_worker_t id, void (*funcPtr)(int) __attribute__((nonnull)), int arg0);
+void emscripten_wasm_worker_post_function_vii(emscripten_wasm_worker_t id, void (*funcPtr)(int, int) __attribute__((nonnull)), int arg0, int arg1);
+void emscripten_wasm_worker_post_function_viii(emscripten_wasm_worker_t id, void (*funcPtr)(int, int, int) __attribute__((nonnull)), int arg0, int arg1, int arg2);
+void emscripten_wasm_worker_post_function_vd(emscripten_wasm_worker_t id, void (*funcPtr)(double) __attribute__((nonnull)), double arg0);
+void emscripten_wasm_worker_post_function_vdd(emscripten_wasm_worker_t id, void (*funcPtr)(double, double) __attribute__((nonnull)), double arg0, double arg1);
+void emscripten_wasm_worker_post_function_vddd(emscripten_wasm_worker_t id, void (*funcPtr)(double, double, double) __attribute__((nonnull)), double arg0, double arg1, double arg2);
+void emscripten_wasm_worker_post_function_sig(emscripten_wasm_worker_t id, void *funcPtr __attribute__((nonnull)), const char *sig __attribute__((nonnull)), ...);
 
 #define ATOMICS_WAIT_RESULT_T int
 
@@ -82,7 +82,7 @@ void emscripten_wasm_worker_post_function_sig(emscripten_wasm_worker_t id, void 
 // If the given memory address contains value 'expectedValue', puts the calling thread to sleep to wait for that address to be notified.
 // Returns one of the ATOMICS_WAIT_* return codes.
 // NOTE: This function takes in the wait value in int64_t nanosecond units. Pass in maxWaitNanoseconds = -1 (or ATOMICS_WAIT_DURATION_INFINITE) to wait infinitely long.
-static __attribute__((always_inline)) ATOMICS_WAIT_RESULT_T emscripten_wasm_wait_i32(int32_t *address, int expectedValue, int64_t maxWaitNanoseconds)
+static __attribute__((always_inline)) ATOMICS_WAIT_RESULT_T emscripten_wasm_wait_i32(int32_t *address __attribute__((nonnull)), int expectedValue, int64_t maxWaitNanoseconds)
 {
 	return __builtin_wasm_memory_atomic_wait32(address, expectedValue, maxWaitNanoseconds);
 }
@@ -91,7 +91,7 @@ static __attribute__((always_inline)) ATOMICS_WAIT_RESULT_T emscripten_wasm_wait
 // If the given memory address contains value 'expectedValue', puts the calling thread to sleep to wait for that address to be notified.
 // Returns one of the ATOMICS_WAIT_* return codes.
 // NOTE: This function takes in the wait value in int64_t nanosecond units. Pass in maxWaitNanoseconds = -1 (or ATOMICS_WAIT_DURATION_INFINITE) to wait infinitely long.
-static __attribute__((always_inline)) ATOMICS_WAIT_RESULT_T emscripten_wasm_wait_i64(int64_t *address, int64_t expectedValue, int64_t maxWaitNanoseconds)
+static __attribute__((always_inline)) ATOMICS_WAIT_RESULT_T emscripten_wasm_wait_i64(int64_t *address __attribute__((nonnull)), int64_t expectedValue, int64_t maxWaitNanoseconds)
 {
 	return __builtin_wasm_memory_atomic_wait64(address, expectedValue, maxWaitNanoseconds);
 }
@@ -103,7 +103,7 @@ static __attribute__((always_inline)) ATOMICS_WAIT_RESULT_T emscripten_wasm_wait
 // Pass count == EMSCRIPTEN_NOTIFY_ALL_WAITERS to notify all waiters on the given location.
 // Returns the number of threads that were woken up.
 // Note: this function is used to notify both waiters waiting on an i32 and i64 addresses.
-static __attribute__((always_inline)) int64_t emscripten_wasm_notify(int32_t *address, int64_t count)
+static __attribute__((always_inline)) int64_t emscripten_wasm_notify(int32_t *address __attribute__((nonnull)), int64_t count)
 {
 	return __builtin_wasm_memory_atomic_notify(address, count);
 }
@@ -130,9 +130,9 @@ static __attribute__((always_inline)) int64_t emscripten_wasm_notify(int32_t *ad
 //  - Any other value: denotes a 'wait token' that can be passed to function emscripten_atomic_cancel_wait_async()
 //    to unregister an asynchronous wait. You can use the macro EMSCRIPTEN_IS_VALID_WAIT_TOKEN(retval) to check
 //    if this function returned a valid wait token.
-ATOMICS_WAIT_TOKEN_T emscripten_atomic_wait_async(int32_t *address,
+ATOMICS_WAIT_TOKEN_T emscripten_atomic_wait_async(int32_t *address __attribute__((nonnull)),
                                                   uint32_t value,
-                                                  void (*asyncWaitFinished)(int32_t *address, uint32_t value, ATOMICS_WAIT_RESULT_T waitResult, void *userData),
+                                                  void (*asyncWaitFinished)(int32_t *address, uint32_t value, ATOMICS_WAIT_RESULT_T waitResult, void *userData) __attribute__((nonnull)),
                                                   void *userData,
                                                   double maxWaitMilliseconds);
 
@@ -158,7 +158,7 @@ int emscripten_atomic_cancel_all_wait_asyncs(void);
 
 // Cancels all pending async waits in the calling thread to the given memory address.
 // Returns the number of async waits canceled.
-int emscripten_atomic_cancel_all_wait_asyncs_at_address(int32_t *address);
+int emscripten_atomic_cancel_all_wait_asyncs_at_address(int32_t *address __attribute__((nonnull)));
 
 // Sleeps the calling wasm worker for the given nanoseconds. Calling this function on the main thread
 // either results in a TypeError exception (Firefox), or a silent return without waiting (Chrome),
@@ -183,7 +183,7 @@ int emscripten_atomics_is_lock_free(int byteWidth);
 // Use with syntax "emscripten_lock_t l = EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER;"
 #define EMSCRIPTEN_LOCK_T_STATIC_INITIALIZER 0
 
-void emscripten_lock_init(emscripten_lock_t *lock);
+void emscripten_lock_init(emscripten_lock_t *lock __attribute__((nonnull)));
 
 // Attempts to acquire the specified lock. If the lock is free, then this function acquires
 // the lock and immediately returns EM_TRUE. If the lock is not free at the time of the call,
@@ -193,7 +193,7 @@ void emscripten_lock_init(emscripten_lock_t *lock);
 // times out and EM_FALSE is returned.
 // NOTE: This function can be only called in a Worker, and not on the main browser thread,
 //       because the main browser thread cannot synchronously sleep to wait for locks.
-EM_BOOL emscripten_lock_wait_acquire(emscripten_lock_t *lock, int64_t maxWaitNanoseconds);
+EM_BOOL emscripten_lock_wait_acquire(emscripten_lock_t *lock __attribute__((nonnull)), int64_t maxWaitNanoseconds);
 
 // Similar to emscripten_lock_wait_acquire(), but instead of waiting for at most a specified
 // timeout value, the thread will wait indefinitely long until the lock can be acquired.
@@ -201,7 +201,7 @@ EM_BOOL emscripten_lock_wait_acquire(emscripten_lock_t *lock, int64_t maxWaitNan
 //       Worker.
 // NOTE: This function can be only called in a Worker, and not on the main browser thread,
 //       because the main browser thread cannot synchronously sleep to wait for locks.
-void emscripten_lock_waitinf_acquire(emscripten_lock_t *lock);
+void emscripten_lock_waitinf_acquire(emscripten_lock_t *lock __attribute__((nonnull)));
 
 // Similar to emscripten_lock_wait_acquire(), but instead of placing the calling thread to
 // sleep until the lock can be acquired, this function will burn CPU cycles attempting to
@@ -212,7 +212,7 @@ void emscripten_lock_waitinf_acquire(emscripten_lock_t *lock);
 // NOTE: If this function is called on the main thread, be sure to use a reasonable max wait
 //       value, or otherwise a "slow script dialog" notification can pop up, and can cause the
 //       browser to stop executing the page.
-EM_BOOL emscripten_lock_busyspin_wait_acquire(emscripten_lock_t *lock, double maxWaitMilliseconds);
+EM_BOOL emscripten_lock_busyspin_wait_acquire(emscripten_lock_t *lock __attribute__((nonnull)), double maxWaitMilliseconds);
 
 // Similar to emscripten_lock_wait_acquire(), but instead of placing the calling thread to
 // sleep until the lock can be acquired, this function will burn CPU cycles indefinitely until
@@ -224,7 +224,7 @@ EM_BOOL emscripten_lock_busyspin_wait_acquire(emscripten_lock_t *lock, double ma
 //       a "slow script dialog", and/or cause the browser to stop the page. If you call this
 //       function on the main browser thread, be extra careful to analyze that the given lock will
 //       be extremely fast to acquire without contention from other threads.
-void emscripten_lock_busyspin_waitinf_acquire(emscripten_lock_t *lock);
+void emscripten_lock_busyspin_waitinf_acquire(emscripten_lock_t *lock __attribute__((nonnull)));
 
 // Registers an *asynchronous* lock acquire operation. The calling thread will asynchronously
 // try to obtain the given lock after the calling thread yields back to the event loop. If the
@@ -236,8 +236,8 @@ void emscripten_lock_busyspin_waitinf_acquire(emscripten_lock_t *lock);
 // as double millisecond units. See https://github.com/WebAssembly/threads/issues/175 for more information.
 // NOTE: This function can be called in both main thread and in Workers. If you use this API in Worker,
 //       you cannot utilise an infinite loop programming model.
-void emscripten_lock_async_acquire(emscripten_lock_t *lock,
-                                   void (*asyncWaitFinished)(volatile void *address, uint32_t value, ATOMICS_WAIT_RESULT_T waitResult, void *userData),
+void emscripten_lock_async_acquire(emscripten_lock_t *lock __attribute__((nonnull)),
+                                   void (*asyncWaitFinished)(volatile void *address, uint32_t value, ATOMICS_WAIT_RESULT_T waitResult, void *userData) __attribute__((nonnull)),
                                    void *userData,
                                    double maxWaitMilliseconds);
 
@@ -245,38 +245,38 @@ void emscripten_lock_async_acquire(emscripten_lock_t *lock,
 // this function will not sleep to wait until the lock is released, but immediately returns
 // EM_FALSE.
 // This function can be called on both main thread and in Workers.
-EM_BOOL emscripten_lock_try_acquire(emscripten_lock_t *lock);
+EM_BOOL emscripten_lock_try_acquire(emscripten_lock_t *lock __attribute__((nonnull)));
 
 // Unlocks the specified lock for another thread to access. Note that locks are extermely
 // lightweight, there is no "lock owner" tracking: this function does not actually check
 // whether the calling thread owns the specified lock, but any thread can call this function
 // to release a lock on behalf of whichever thread owns it.
 // This function can be called on both main thread and in Workers.
-void emscripten_lock_release(emscripten_lock_t *lock);
+void emscripten_lock_release(emscripten_lock_t *lock __attribute__((nonnull)));
 
 #define emscripten_semaphore_t volatile uint32_t
 
 // Use with syntax emscripten_semaphore_t s = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(num);
 #define EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(num) ((int)(num))
 
-void emscripten_semaphore_init(emscripten_semaphore_t *sem, int num);
+void emscripten_semaphore_init(emscripten_semaphore_t *sem __attribute__((nonnull)), int num);
 
 // main thread, try acquire num instances, but do not sleep to wait if not available.
 // Returns idx that was acquired or -1 if acquire failed.
-int emscripten_semaphore_try_acquire(emscripten_semaphore_t *sem, int num);
+int emscripten_semaphore_try_acquire(emscripten_semaphore_t *sem __attribute__((nonnull)), int num);
 
 // main thread, poll to try acquire num instances. Returns idx that was acquired. If you use this API in Worker, you cannot run an infinite loop.
-void emscripten_semaphore_async_acquire(emscripten_semaphore_t *sem,
+void emscripten_semaphore_async_acquire(emscripten_semaphore_t *sem __attribute__((nonnull)),
                                         int num,
-                                        void (*asyncWaitFinished)(volatile void *address, uint32_t idx, ATOMICS_WAIT_RESULT_T result, void *userData),
+                                        void (*asyncWaitFinished)(volatile void *address, uint32_t idx, ATOMICS_WAIT_RESULT_T result, void *userData) __attribute__((nonnull)),
                                         void *userData,
                                         double maxWaitMilliseconds);
 
 // worker, sleep to acquire num instances. Returns idx that was acquired, or -1 if timed out unable to acquire.
-int emscripten_semaphore_wait_acquire(emscripten_semaphore_t *sem, int num, int64_t maxWaitNanoseconds);
+int emscripten_semaphore_wait_acquire(emscripten_semaphore_t *sem __attribute__((nonnull)), int num, int64_t maxWaitNanoseconds);
 
 // worker, sleep infinitely long to acquire num instances. Returns idx that was acquired.
-int emscripten_semaphore_waitinf_acquire(emscripten_semaphore_t *sem, int num);
+int emscripten_semaphore_waitinf_acquire(emscripten_semaphore_t *sem __attribute__((nonnull)), int num);
 
 // Releases the given number of resources back to the semaphore. Note
 // that the ownership of resources is completely conceptual - there is
@@ -287,7 +287,7 @@ int emscripten_semaphore_waitinf_acquire(emscripten_semaphore_t *sem, int num);
 // new resources were released back to the semaphore. (i.e. the index where
 // the resource was put back to)
 // [main thread or worker]
-uint32_t emscripten_semaphore_release(emscripten_semaphore_t *sem, int num);
+uint32_t emscripten_semaphore_release(emscripten_semaphore_t *sem __attribute__((nonnull)), int num);
 
 // Condition variable is an object that can be waited on, and another thread can signal, while coordinating an access to a related mutex.
 #define emscripten_condvar_t volatile uint32_t
@@ -296,30 +296,30 @@ uint32_t emscripten_semaphore_release(emscripten_semaphore_t *sem, int num);
 #define EMSCRIPTEN_CONDVAR_T_STATIC_INITIALIZER ((int)(0))
 
 // Creates a new condition variable to the given memory location.
-void emscripten_condvar_init(emscripten_condvar_t *condvar);
+void emscripten_condvar_init(emscripten_condvar_t *condvar __attribute__((nonnull)));
 
 // Atomically performs the following:
 // 1. releases the given lock. The lock should (but does not strictly need to) be held by the calling thread prior to this call.
 // 2. sleep the calling thread to wait for the specified condition variable to be signaled.
 // 3. once the sleep has finished (another thread has signaled the condition variable), the calling thread wakes up
 //    and reacquires the lock prior to returning from this function.
-void emscripten_condvar_waitinf(emscripten_condvar_t *condvar, emscripten_lock_t *lock);
+void emscripten_condvar_waitinf(emscripten_condvar_t *condvar __attribute__((nonnull)), emscripten_lock_t *lock __attribute__((nonnull)));
 
 // Same as the above, except that an attempt to wait for the condition variable to become true is only performed for a maximum duration.
 // On success (no timeout), this function will return EM_TRUE. If the wait times out, this function will return EM_FALSE. In this case,
 // the calling thread will not try to reacquire the lock.
-EM_BOOL emscripten_condvar_wait(emscripten_condvar_t *condvar, emscripten_lock_t *lock, int64_t maxWaitNanoseconds);
+EM_BOOL emscripten_condvar_wait(emscripten_condvar_t *condvar __attribute__((nonnull)), emscripten_lock_t *lock __attribute__((nonnull)), int64_t maxWaitNanoseconds);
 
 // Asynchronously wait for the given condition variable to signal.
-ATOMICS_WAIT_TOKEN_T emscripten_condvar_wait_async(emscripten_condvar_t *condvar,
-                                                  emscripten_lock_t *lock,
-                                                  void (*asyncWaitFinished)(int32_t *address, uint32_t value, ATOMICS_WAIT_RESULT_T waitResult, void *userData),
+ATOMICS_WAIT_TOKEN_T emscripten_condvar_wait_async(emscripten_condvar_t *condvar __attribute__((nonnull)),
+                                                  emscripten_lock_t *lock __attribute__((nonnull)),
+                                                  void (*asyncWaitFinished)(int32_t *address, uint32_t value, ATOMICS_WAIT_RESULT_T waitResult, void *userData) __attribute__((nonnull)),
                                                   void *userData,
                                                   double maxWaitMilliseconds);
 
 // Signals the given number of waiters on the specified condition variable.
 // Pass numWaitersToSignal == EMSCRIPTEN_NOTIFY_ALL_WAITERS to wake all waiters ("broadcast" operation).
-void emscripten_condvar_signal(emscripten_condvar_t *condvar, int64_t numWaitersToSignal);
+void emscripten_condvar_signal(emscripten_condvar_t *condvar __attribute__((nonnull)), int64_t numWaitersToSignal);
 
 #ifdef __cplusplus
 }

--- a/system/include/emscripten/wasmfs.h
+++ b/system/include/emscripten/wasmfs.h
@@ -17,7 +17,7 @@ extern "C" {
 typedef struct Backend* backend_t;
 
 // Obtains the backend_t of a specified path.
-backend_t wasmfs_get_backend_by_path(char* path);
+backend_t wasmfs_get_backend_by_path(char* path __attribute__((nonnull)));
 
 // Obtains the backend_t of a specified fd.
 backend_t wasmfs_get_backend_by_fd(int fd);
@@ -26,11 +26,11 @@ backend_t wasmfs_get_backend_by_fd(int fd);
 // Returns the file descriptor for the new file like `open`. Returns a negative
 // value on error. TODO: It might be worth returning a more specialized type
 // like __wasi_fd_t here.
-int wasmfs_create_file(const char* pathname, mode_t mode, backend_t backend);
+int wasmfs_create_file(const char* pathname __attribute__((nonnull)), mode_t mode, backend_t backend);
 
 // Creates a new directory in the new file system under a specific backend.
 // Returns 0 on success like `mkdir`, or a negative value on error.
-int wasmfs_create_directory(const char* path, mode_t mode, backend_t backend);
+int wasmfs_create_directory(const char* path __attribute__((nonnull)), mode_t mode, backend_t backend);
 
 // Backend creation
 
@@ -51,9 +51,9 @@ backend_t wasmfs_create_memory_backend(void);
 //
 // TODO: Add an async version of this function that will work on the main
 // thread.
-backend_t wasmfs_create_fetch_backend(const char* base_url);
+backend_t wasmfs_create_fetch_backend(const char* base_url __attribute__((nonnull)));
 
-backend_t wasmfs_create_node_backend(const char* root);
+backend_t wasmfs_create_node_backend(const char* root __attribute__((nonnull)));
 
 // Note: this cannot be called on the browser main thread because it might
 // deadlock while waiting for the OPFS dedicated worker thread to be spawned.

--- a/system/include/emscripten/websocket.h
+++ b/system/include/emscripten/websocket.h
@@ -20,32 +20,32 @@ extern "C" {
 #define EMSCRIPTEN_WEBSOCKET_T int
 
 // Returns the WebSocket.readyState field into readyState. readyState must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_ready_state(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short *readyState);
+EMSCRIPTEN_RESULT emscripten_websocket_get_ready_state(EMSCRIPTEN_WEBSOCKET_T socket, unsigned short *readyState __attribute__((nonnull)));
 
 // Returns the WebSocket.bufferedAmount field into bufferedAmount. bufferedAmount must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, unsigned long long *bufferedAmount);
+EMSCRIPTEN_RESULT emscripten_websocket_get_buffered_amount(EMSCRIPTEN_WEBSOCKET_T socket, unsigned long long *bufferedAmount __attribute__((nonnull)));
 
 // Writes the WebSocket.url field as a UTF-8 string to the memory area pointed by url. The memory area must contain at least urlLength bytes of free space. If this memory area cannot
 // fit the url string, it will be truncated. Call emscripten_websocket_get_url_length() to determine how large memory area will be required to store the url.
 // url must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_url(EMSCRIPTEN_WEBSOCKET_T socket, char *url, int urlLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_url(EMSCRIPTEN_WEBSOCKET_T socket, char *url __attribute__((nonnull)), int urlLength);
 // Returns the byte length needed to store WebSocket.url string in Wasm heap. This length can be passed to emscripten_websocket_get_url as it includes the null byte in the count.
 // urlLength must not be a null pointer.
-EMSCRIPTEN_RESULT emscripten_websocket_get_url_length(EMSCRIPTEN_WEBSOCKET_T socket, int *urlLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_url_length(EMSCRIPTEN_WEBSOCKET_T socket, int *urlLength __attribute__((nonnull)));
 
 // Similar to emscripten_websocket_get_url(), but returns WebSocket.extensions field instead.
-EMSCRIPTEN_RESULT emscripten_websocket_get_extensions(EMSCRIPTEN_WEBSOCKET_T socket, char *extensions, int extensionsLength);
-EMSCRIPTEN_RESULT emscripten_websocket_get_extensions_length(EMSCRIPTEN_WEBSOCKET_T socket, int *extensionsLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_extensions(EMSCRIPTEN_WEBSOCKET_T socket, char *extensions __attribute__((nonnull)), int extensionsLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_extensions_length(EMSCRIPTEN_WEBSOCKET_T socket, int *extensionsLength __attribute__((nonnull)));
 
 // Similar to emscripten_websocket_get_url(), but returns WebSocket.protocol field instead.
-EMSCRIPTEN_RESULT emscripten_websocket_get_protocol(EMSCRIPTEN_WEBSOCKET_T socket, char *protocol, int protocolLength);
-EMSCRIPTEN_RESULT emscripten_websocket_get_protocol_length(EMSCRIPTEN_WEBSOCKET_T socket, int *protocolLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_protocol(EMSCRIPTEN_WEBSOCKET_T socket, char *protocol __attribute__((nonnull)), int protocolLength);
+EMSCRIPTEN_RESULT emscripten_websocket_get_protocol_length(EMSCRIPTEN_WEBSOCKET_T socket, int *protocolLength __attribute__((nonnull)));
 
 typedef struct EmscriptenWebSocketOpenEvent {
   EMSCRIPTEN_WEBSOCKET_T socket;
 } EmscriptenWebSocketOpenEvent;
 
-typedef EM_BOOL (*em_websocket_open_callback_func)(int eventType, const EmscriptenWebSocketOpenEvent *websocketEvent, void *userData);
+typedef EM_BOOL (*em_websocket_open_callback_func)(int eventType, const EmscriptenWebSocketOpenEvent *websocketEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_websocket_set_onopen_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_open_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketMessageEvent {
@@ -55,14 +55,14 @@ typedef struct EmscriptenWebSocketMessageEvent {
   EM_BOOL isText;
 } EmscriptenWebSocketMessageEvent;
 
-typedef EM_BOOL (*em_websocket_message_callback_func)(int eventType, const EmscriptenWebSocketMessageEvent *websocketEvent, void *userData);
+typedef EM_BOOL (*em_websocket_message_callback_func)(int eventType, const EmscriptenWebSocketMessageEvent *websocketEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_websocket_set_onmessage_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_message_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketErrorEvent {
   EMSCRIPTEN_WEBSOCKET_T socket;
 } EmscriptenWebSocketErrorEvent;
 
-typedef EM_BOOL (*em_websocket_error_callback_func)(int eventType, const EmscriptenWebSocketErrorEvent *websocketEvent, void *userData);
+typedef EM_BOOL (*em_websocket_error_callback_func)(int eventType, const EmscriptenWebSocketErrorEvent *websocketEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_websocket_set_onerror_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_error_callback_func callback, pthread_t targetThread);
 
 typedef struct EmscriptenWebSocketCloseEvent {
@@ -72,7 +72,7 @@ typedef struct EmscriptenWebSocketCloseEvent {
   char reason[512]; // WebSockets spec enforces this can be max 123 characters, so as UTF-8 at most 123*4 bytes < 512.
 } EmscriptenWebSocketCloseEvent;
 
-typedef EM_BOOL (*em_websocket_close_callback_func)(int eventType, const EmscriptenWebSocketCloseEvent *websocketEvent, void *userData);
+typedef EM_BOOL (*em_websocket_close_callback_func)(int eventType, const EmscriptenWebSocketCloseEvent *websocketEvent __attribute__((nonnull)), void *userData);
 EMSCRIPTEN_RESULT emscripten_websocket_set_onclose_callback_on_thread(EMSCRIPTEN_WEBSOCKET_T socket, void *userData, em_websocket_close_callback_func callback, pthread_t targetThread);
 
 #define emscripten_websocket_set_onopen_callback(socket, userData, callback)    emscripten_websocket_set_onopen_callback_on_thread(   (socket), (userData), (callback), EM_CALLBACK_THREAD_CONTEXT_CALLING_THREAD)
@@ -106,13 +106,13 @@ EM_BOOL emscripten_websocket_is_supported(void);
 // If the return value of this function is > 0, the function has succeeded and the return value represents a handle to the WebSocket object.
 // If the return value of this function is < 0, then the function has failed, and the return value can be interpreted as a EMSCRIPTEN_RESULT code
 // representing the cause of the failure. If the function returns 0, then the call has failed with an unknown reason (build with -sWEBSOCKET_DEBUG for more information)
-EMSCRIPTEN_WEBSOCKET_T emscripten_websocket_new(EmscriptenWebSocketCreateAttributes *createAttributes);
+EMSCRIPTEN_WEBSOCKET_T emscripten_websocket_new(EmscriptenWebSocketCreateAttributes *createAttributes __attribute__((nonnull)));
 
 // Sends the given string of null-delimited UTF8 encoded text data to the connected server.
-EMSCRIPTEN_RESULT emscripten_websocket_send_utf8_text(EMSCRIPTEN_WEBSOCKET_T socket, const char *textData);
+EMSCRIPTEN_RESULT emscripten_websocket_send_utf8_text(EMSCRIPTEN_WEBSOCKET_T socket, const char *textData __attribute__((nonnull)));
 
 // Sends the given block of raw memory data out to the connected server.
-EMSCRIPTEN_RESULT emscripten_websocket_send_binary(EMSCRIPTEN_WEBSOCKET_T socket, void *binaryData, uint32_t dataLength);
+EMSCRIPTEN_RESULT emscripten_websocket_send_binary(EMSCRIPTEN_WEBSOCKET_T socket, void *binaryData __attribute__((nonnull)), uint32_t dataLength);
 
 // Closes the specified WebSocket. N.B.: the meaning of "closing" a WebSocket means "eager read/lazy write"-closing the socket. That is, all still
 // pending untransferred outbound bytes will continue to transfer out, but after calling close on the socket, any pending bytes still in the process
@@ -130,7 +130,7 @@ EMSCRIPTEN_RESULT emscripten_websocket_delete(EMSCRIPTEN_WEBSOCKET_T socket);
 // even after the pthread quits, although be warned that if the target thread that was registered to handle events for a given WebSocket quits, then those
 // events will stop from being delivered altogether.
 void emscripten_websocket_deinitialize(void);
-  
+
 #ifdef __cplusplus
 } // ~extern "C"
 #endif

--- a/system/include/webgl/webgl1_ext.h
+++ b/system/include/webgl/webgl1_ext.h
@@ -33,12 +33,12 @@ WEBGL_APICALL EMSCRIPTEN_RESULT GL_APIENTRY emscripten_webgl_restoreContext(EMSC
 #define EMSCRIPTEN_GL_OES_vertex_array_object 1
 #define GL_VERTEX_ARRAY_BINDING_OES 0x85B5
 WEBGL_APICALL void GL_APIENTRY emscripten_glBindVertexArrayOES(GLuint array);
-WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays);
-WEBGL_APICALL void GL_APIENTRY emscripten_glGenVertexArraysOES(GLsizei n, GLuint *arrays);
+WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glGenVertexArraysOES(GLsizei n, GLuint *arrays __attribute__((nonnull)));
 WEBGL_APICALL GLboolean GL_APIENTRY emscripten_glIsVertexArrayOES(GLuint array);
 WEBGL_APICALL void GL_APIENTRY glBindVertexArrayOES(GLuint array);
-WEBGL_APICALL void GL_APIENTRY glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays);
-WEBGL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint *arrays);
+WEBGL_APICALL void GL_APIENTRY glDeleteVertexArraysOES(GLsizei n, const GLuint *arrays __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glGenVertexArraysOES(GLsizei n, GLuint *arrays __attribute__((nonnull)));
 WEBGL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES(GLuint array);
 #endif /* EMSCRIPTEN_GL_OES_vertex_array_object */
 
@@ -52,7 +52,7 @@ WEBGL_APICALL GLboolean GL_APIENTRY glIsVertexArrayOES(GLuint array);
 // 7. https://www.khronos.org/registry/webgl/extensions/WEBGL_debug_shaders/
 #ifndef EMSCRIPTEN_GL_WEBGL_debug_shaders
 #define EMSCRIPTEN_GL_WEBGL_debug_shaders 1
-WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint shader, GLsizei bufSize, GLsizei *length, GLchar *source);
+WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getTranslatedShaderSource(GLuint shader, GLsizei bufSize, GLsizei *length __attribute__((nonnull)), GLchar *source __attribute__((nonnull)));
 #endif /* EMSCRIPTEN_GL_WEBGL_debug_shaders */
 
 // 8. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_s3tc/
@@ -220,28 +220,28 @@ WEBGL_APICALL void GL_APIENTRY glVertexAttribDivisorANGLE(GLuint index, GLuint d
 #define GL_TIME_ELAPSED_EXT 0x88BF
 #define GL_TIMESTAMP_EXT 0x8E28
 #define GL_GPU_DISJOINT_EXT 0x8FBB
-WEBGL_APICALL void GL_APIENTRY emscripten_glGenQueriesEXT(GLsizei n, GLuint *ids);
-WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteQueriesEXT(GLsizei n, const GLuint *ids);
+WEBGL_APICALL void GL_APIENTRY emscripten_glGenQueriesEXT(GLsizei n, GLuint *ids __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glDeleteQueriesEXT(GLsizei n, const GLuint *ids __attribute__((nonnull)));
 WEBGL_APICALL GLboolean GL_APIENTRY emscripten_glIsQueryEXT(GLuint id);
 WEBGL_APICALL void GL_APIENTRY emscripten_glBeginQueryEXT(GLenum target, GLuint id);
 WEBGL_APICALL void GL_APIENTRY emscripten_glEndQueryEXT(GLenum target);
 WEBGL_APICALL void GL_APIENTRY emscripten_glQueryCounterEXT(GLuint id, GLenum target);
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryivEXT(GLenum target, GLenum pname, GLint *params);
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectivEXT(GLuint id, GLenum pname, GLint *params);
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint *params);
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params);
-WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params);
-WEBGL_APICALL void GL_APIENTRY glGenQueriesEXT(GLsizei n, GLuint *ids);
-WEBGL_APICALL void GL_APIENTRY glDeleteQueriesEXT(GLsizei n, const GLuint *ids);
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryivEXT(GLenum target, GLenum pname, GLint *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectivEXT(GLuint id, GLenum pname, GLint *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY emscripten_glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glGenQueriesEXT(GLsizei n, GLuint *ids __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glDeleteQueriesEXT(GLsizei n, const GLuint *ids __attribute__((nonnull)));
 WEBGL_APICALL GLboolean GL_APIENTRY glIsQueryEXT(GLuint id);
 WEBGL_APICALL void GL_APIENTRY glBeginQueryEXT(GLenum target, GLuint id);
 WEBGL_APICALL void GL_APIENTRY glEndQueryEXT(GLenum target);
 WEBGL_APICALL void GL_APIENTRY glQueryCounterEXT(GLuint id, GLenum target);
-WEBGL_APICALL void GL_APIENTRY glGetQueryivEXT(GLenum target, GLenum pname, GLint *params);
-WEBGL_APICALL void GL_APIENTRY glGetQueryObjectivEXT(GLuint id, GLenum pname, GLint *params);
-WEBGL_APICALL void GL_APIENTRY glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint *params);
-WEBGL_APICALL void GL_APIENTRY glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params);
-WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params);
+WEBGL_APICALL void GL_APIENTRY glGetQueryivEXT(GLenum target, GLenum pname, GLint *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glGetQueryObjectivEXT(GLuint id, GLenum pname, GLint *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glGetQueryObjectuivEXT(GLuint id, GLenum pname, GLuint *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glGetQueryObjecti64vEXT(GLuint id, GLenum pname, GLint64 *params __attribute__((nonnull)));
+WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params __attribute__((nonnull)));
 #endif /* EMSCRIPTEN_GL_EXT_disjoint_timer_query */
 
 // 29. https://www.khronos.org/registry/webgl/extensions/WEBGL_compressed_texture_etc/
@@ -290,7 +290,7 @@ WEBGL_APICALL void GL_APIENTRY glGetQueryObjectui64vEXT(GLuint id, GLenum pname,
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_10x10_KHR 0x93DB
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x10_KHR 0x93DC
 #define GL_COMPRESSED_SRGB8_ALPHA8_ASTC_12x12_KHR 0x93DD
-WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getSupportedAstcProfiles(GLsizei bufSize, GLsizei *length, GLchar *buf);
+WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getSupportedAstcProfiles(GLsizei bufSize, GLsizei *length __attribute__((nonnull)), GLchar *buf __attribute__((nonnull)));
 #endif /* EMSCRIPTEN_GL_WEBGL_compressed_texture_astc */
 
 // 31. https://www.khronos.org/registry/webgl/extensions/EXT_color_buffer_float/
@@ -317,14 +317,46 @@ WEBGL_APICALL void GL_APIENTRY emscripten_webgl_getSupportedAstcProfiles(GLsizei
 // 40. https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw/
 #ifndef EMSCRIPTEN_GL_WEBGL_multi_draw
 #define EMSCRIPTEN_GL_WEBGL_multi_draw 1
-WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, GLsizei drawcount);
-WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, GLsizei drawcount);
-WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, GLsizei drawcount);
-WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, GLsizei drawcount);
-WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, GLsizei drawcount);
-WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, GLsizei drawcount);
-WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, GLsizei drawcount);
-WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, GLsizei drawcount);
+WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysWEBGL(GLenum mode,
+                                                                 const GLint* firsts __attribute__((nonnull)),
+                                                                 const GLsizei* counts __attribute__((nonnull)),
+                                                                 GLsizei drawcount);
+WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedWEBGL(GLenum mode,
+                                                                          const GLint* firsts __attribute__((nonnull)),
+                                                                          const GLsizei* counts __attribute__((nonnull)),
+                                                                          const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                          GLsizei drawcount);
+WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsWEBGL(GLenum mode,
+                                                                   const GLsizei* counts __attribute__((nonnull)),
+                                                                   GLenum type,
+                                                                   const GLvoid* const* offsets __attribute__((nonnull)),
+                                                                   GLsizei drawcount);
+WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedWEBGL(GLenum mode,
+                                                                            const GLsizei* counts __attribute__((nonnull)),
+                                                                            GLenum type,
+                                                                            const GLvoid* const* offsets __attribute__((nonnull)),
+                                                                            const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                            GLsizei drawcount);
+WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysWEBGL(GLenum mode,
+                                                      const GLint* firsts __attribute__((nonnull)),
+                                                      const GLsizei* counts __attribute__((nonnull)),
+                                                      GLsizei drawcount);
+WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedWEBGL(GLenum mode,
+                                                               const GLint* firsts __attribute__((nonnull)),
+                                                               const GLsizei* counts __attribute__((nonnull)),
+                                                               const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                               GLsizei drawcount);
+WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsWEBGL(GLenum mode,
+                                                        const GLsizei* counts __attribute__((nonnull)),
+                                                        GLenum type,
+                                                        const GLvoid* const* offsets __attribute__((nonnull)),
+                                                        GLsizei drawcount);
+WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedWEBGL(GLenum mode,
+                                                                 const GLsizei* counts __attribute__((nonnull)),
+                                                                 GLenum type,
+                                                                 const GLvoid* const* offsets __attribute__((nonnull)),
+                                                                 const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                 GLsizei drawcount);
 #endif /* EMSCRIPTEN_GL_WEBGL_multi_draw */
 
 // 44. https://www.khronos.org/registry/webgl/extensions/EXT_texture_norm16/

--- a/system/include/webgl/webgl2.h
+++ b/system/include/webgl/webgl2.h
@@ -111,7 +111,7 @@ WEBGL_APICALL void GL_APIENTRY emscripten_glGetInternalformativ (GLenum target, 
 WEBGL_APICALL void GL_APIENTRY emscripten_glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, void *data);
 
 // WebGL 2 functions that do not exist in GLES3.0:
-WEBGL_APICALL void GL_APIENTRY glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, void *data);
+WEBGL_APICALL void GL_APIENTRY glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, void *data __attribute__((nonnull)));
 
 // Extensions:
 WEBGL_APICALL void GL_APIENTRY emscripten_glVertexAttribDivisorNV(GLuint index, GLuint divisor);

--- a/system/include/webgl/webgl2_ext.h
+++ b/system/include/webgl/webgl2_ext.h
@@ -15,41 +15,59 @@ WEBGL_APICALL void GL_APIENTRY emscripten_webgl2_queryCounterEXT(GLuint query, G
 // 46. https://www.khronos.org/registry/webgl/extensions/WEBGL_draw_instanced_base_vertex_base_instance/
 #ifndef EMSCRIPTEN_GL_WEBGL_draw_instanced_base_vertex_base_instance
 #define EMSCRIPTEN_GL_WEBGL_draw_instanced_base_vertex_base_instance 1
-WEBGL_APICALL void GL_APIENTRY emscripten_glDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
-WEBGL_APICALL void GL_APIENTRY emscripten_glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
-WEBGL_APICALL void GL_APIENTRY glDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
-WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
+
+WEBGL_APICALL void GL_APIENTRY emscripten_glDrawArraysInstancedBaseInstanceWEBGL(
+  GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
+
+WEBGL_APICALL void GL_APIENTRY emscripten_glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
+
+WEBGL_APICALL void GL_APIENTRY glDrawArraysInstancedBaseInstanceWEBGL(
+  GLenum mode, GLint first, GLsizei count, GLsizei instanceCount, GLuint baseInstance);
+
+WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  GLenum mode, GLsizei count, GLenum type, const void *offset, GLsizei instanceCount, GLint baseVertex, GLuint baseInstance);
+
 #endif /* EMSCRIPTEN_GL_WEBGL_draw_instanced_base_vertex_base_instance */
 
 // 47. https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/
 #ifndef EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance
 #define EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance 1
-WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode,
-                                                                                      const GLint* firsts __attribute__((nonnull)),
-                                                                                      const GLsizei* counts __attribute__((nonnull)),
-                                                                                      const GLsizei* instanceCounts __attribute__((nonnull)),
-                                                                                      const GLuint* baseInstances __attribute__((nonnull)),
-                                                                                      GLsizei drawCount);
-WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode,
-                                                                                                  const GLsizei* counts __attribute__((nonnull)),
-                                                                                                  GLenum type,
-                                                                                                  const GLvoid* const* offsets __attribute__((nonnull)),
-                                                                                                  const GLsizei* instanceCounts __attribute__((nonnull)),
-                                                                                                  const GLint* baseVertices __attribute__((nonnull)),
-                                                                                                  const GLuint* baseInstances __attribute__((nonnull)),
-                                                                                                  GLsizei drawCount);
-WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode,
-                                                                           const GLint* firsts __attribute__((nonnull)),
-                                                                           const GLsizei* counts __attribute__((nonnull)),
-                                                                           const GLsizei* instanceCounts __attribute__((nonnull)),
-                                                                           const GLuint* baseInstances __attribute__((nonnull)),
-                                                                           GLsizei drawCount);
-WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode,
-                                                                                       const GLsizei* counts __attribute__((nonnull)),
-                                                                                       GLenum type,
-                                                                                       const GLvoid* const* offsets __attribute__((nonnull)),
-                                                                                       const GLsizei* instanceCounts __attribute__((nonnull)),
-                                                                                       const GLint* baseVertices __attribute__((nonnull)),
-                                                                                       const GLuint* baseinstances __attribute__((nonnull)),
-                                                                                       GLsizei drawCount);
+
+WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedBaseInstanceWEBGL(
+  GLenum mode,
+  const GLint* firsts __attribute__((nonnull)),
+  const GLsizei* counts __attribute__((nonnull)),
+  const GLsizei* instanceCounts __attribute__((nonnull)),
+  const GLuint* baseInstances __attribute__((nonnull)),
+  GLsizei drawCount);
+
+WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  GLenum mode,
+  const GLsizei* counts __attribute__((nonnull)),
+  GLenum type,
+  const GLvoid* const* offsets __attribute__((nonnull)),
+  const GLsizei* instanceCounts __attribute__((nonnull)),
+  const GLint* baseVertices __attribute__((nonnull)),
+  const GLuint* baseInstances __attribute__((nonnull)),
+  GLsizei drawCount);
+
+WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedBaseInstanceWEBGL(
+  GLenum mode,
+ const GLint* firsts __attribute__((nonnull)),
+ const GLsizei* counts __attribute__((nonnull)),
+ const GLsizei* instanceCounts __attribute__((nonnull)),
+ const GLuint* baseInstances __attribute__((nonnull)),
+ GLsizei drawCount);
+
+WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(
+  GLenum mode,
+  const GLsizei* counts __attribute__((nonnull)),
+  GLenum type,
+  const GLvoid* const* offsets __attribute__((nonnull)),
+  const GLsizei* instanceCounts __attribute__((nonnull)),
+  const GLint* baseVertices __attribute__((nonnull)),
+  const GLuint* baseinstances __attribute__((nonnull)),
+  GLsizei drawCount);
+
 #endif /* EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance */

--- a/system/include/webgl/webgl2_ext.h
+++ b/system/include/webgl/webgl2_ext.h
@@ -24,8 +24,32 @@ WEBGL_APICALL void GL_APIENTRY glDrawElementsInstancedBaseVertexBaseInstanceWEBG
 // 47. https://www.khronos.org/registry/webgl/extensions/WEBGL_multi_draw_instanced_base_vertex_base_instance/
 #ifndef EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance
 #define EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance 1
-WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, const GLuint* baseInstances, GLsizei drawCount);
-WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, const GLint* baseVertices, const GLuint* baseInstances, GLsizei drawCount);
-WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode, const GLint* firsts, const GLsizei* counts, const GLsizei* instanceCounts, const GLuint* baseInstances, GLsizei drawCount);
-WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode, const GLsizei* counts, GLenum type, const GLvoid* const* offsets, const GLsizei* instanceCounts, const GLint* baseVertices, const GLuint* baseinstances, GLsizei drawCount);
+WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode,
+                                                                                      const GLint* firsts __attribute__((nonnull)),
+                                                                                      const GLsizei* counts __attribute__((nonnull)),
+                                                                                      const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                                      const GLuint* baseInstances __attribute__((nonnull)),
+                                                                                      GLsizei drawCount);
+WEBGL_APICALL void GL_APIENTRY emscripten_glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode,
+                                                                                                  const GLsizei* counts __attribute__((nonnull)),
+                                                                                                  GLenum type,
+                                                                                                  const GLvoid* const* offsets __attribute__((nonnull)),
+                                                                                                  const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                                                  const GLint* baseVertices __attribute__((nonnull)),
+                                                                                                  const GLuint* baseInstances __attribute__((nonnull)),
+                                                                                                  GLsizei drawCount);
+WEBGL_APICALL void GL_APIENTRY glMultiDrawArraysInstancedBaseInstanceWEBGL(GLenum mode,
+                                                                           const GLint* firsts __attribute__((nonnull)),
+                                                                           const GLsizei* counts __attribute__((nonnull)),
+                                                                           const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                           const GLuint* baseInstances __attribute__((nonnull)),
+                                                                           GLsizei drawCount);
+WEBGL_APICALL void GL_APIENTRY glMultiDrawElementsInstancedBaseVertexBaseInstanceWEBGL(GLenum mode,
+                                                                                       const GLsizei* counts __attribute__((nonnull)),
+                                                                                       GLenum type,
+                                                                                       const GLvoid* const* offsets __attribute__((nonnull)),
+                                                                                       const GLsizei* instanceCounts __attribute__((nonnull)),
+                                                                                       const GLint* baseVertices __attribute__((nonnull)),
+                                                                                       const GLuint* baseinstances __attribute__((nonnull)),
+                                                                                       GLsizei drawCount);
 #endif /* EMSCRIPTEN_GL_WEBGL_multi_draw_instanced_base_vertex_base_instance */

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -9361,6 +9361,7 @@ NODEFS is no longer included by default; build with -lnodefs.js
   @node_pthreads
   def test_emscripten_futexes(self):
     self.set_setting('USE_PTHREADS')
+    self.emcc_args += ['-Wno-nonnull']
     self.do_run_in_out_file_test('core/pthread/emscripten_futexes.c')
 
   @node_pthreads

--- a/test/test_html5_core.c
+++ b/test/test_html5_core.c
@@ -72,7 +72,7 @@ EM_BOOL key_callback(int eventType, const EmscriptenKeyboardEvent *e, void *user
     TEST_RESULT(emscripten_get_pointerlock_status);
     if (!plce.isActive) {
       printf("Requesting pointer lock..\n");
-      ret = emscripten_request_pointerlock(0, 1);
+      ret = emscripten_request_pointerlock("#canvas", 1);
       TEST_RESULT(emscripten_request_pointerlock);
     } else {
       printf("Exiting pointer lock..\n");


### PR DESCRIPTION
This allows users to get a compile time warning if they try to pass a statically null pointer value to a system header that is not intended to accept such a value.