### PR TITLE
Ensure FreeType compiles with pthreads support when necessary.

### DIFF
--- a/tools/ports/freetype.py
+++ b/tools/ports/freetype.py
@@ -87,18 +87,21 @@ def get(ports, settings, shared):
     for src in srcs:
       o = os.path.join(ports.get_build_dir(), 'freetype', src + '.o')
       shared.safe_ensure_dirs(os.path.dirname(o))
-      commands.append([shared.EMCC, '-c', os.path.join(dest_path, src), '-o', o,
-                       '-DFT2_BUILD_LIBRARY', '-O2',
-                       '-I' + dest_path + '/include',
-                       '-I' + dest_path + '/truetype',
-                       '-I' + dest_path + '/sfnt',
-                       '-I' + dest_path + '/autofit',
-                       '-I' + dest_path + '/smooth',
-                       '-I' + dest_path + '/raster',
-                       '-I' + dest_path + '/psaux',
-                       '-I' + dest_path + '/psnames',
-                       '-I' + dest_path + '/truetype',
-                       '-w'])
+      command = [shared.EMCC, '-c', os.path.join(dest_path, src), '-o', o,
+                 '-DFT2_BUILD_LIBRARY', '-O2',
+                 '-I' + dest_path + '/include',
+                 '-I' + dest_path + '/truetype',
+                 '-I' + dest_path + '/sfnt',
+                 '-I' + dest_path + '/autofit',
+                 '-I' + dest_path + '/smooth',
+                 '-I' + dest_path + '/raster',
+                 '-I' + dest_path + '/psaux',
+                 '-I' + dest_path + '/psnames',
+                 '-I' + dest_path + '/truetype',
+                 '-w']
+      if settings.USE_PTHREADS:
+        command += ['-sUSE_PTHREADS']
+      commands.append(command)
       o_s.append(o)
 
     ports.run_commands(commands)


### PR DESCRIPTION
This solves an error similar to those discussed in #8503, in which a program which needed both pthreads and freetype was failing to compile with this error:

> `wasm-ld: error: 'atomics' feature is disallowed by sfnt.c.o, so --shared-memory must not be used`

Making this change locally solved the issue. Solved in the same style as #8960.