### PR TITLE
CI: pip install using EMSDK_PYTHON on windows. NFC

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,16 +423,11 @@ jobs:
       - build
       # note we do *not* build all libraries and freeze the cache; as we run
       # only limited tests here, it's more efficient to build on demand
+      - pip-install:
+          python: "$EMSDK_PYTHON"
       - run-tests:
           test_targets: "other.test_emcc_cflags other.test_stdin other.test_bad_triple core2.test_sse1 core2.test_ccall other.test_closure_externs other.test_binaryen_debug other.test_js_optimizer_parse_error other.test_output_to_nowhere other.test_emcc_dev_null other.test_cmake* other.test_system_include_paths other.test_emar_response_file core2.test_utf16 other.test_special_chars_in_arguments other.test_toolchain_profiler other.test_realpath_nodefs other.test_response_file_encoding other.test_libc_progname other.test_realpath other.test_embed_file_dup"
       # Run a single websockify-based test to ensure it works on windows.
-      # We need to do this using the system python since the emsdk version
-      # does not have `pip` or come preloaded with `websockify`.
-      - run:
-          name: Set system python
-          command: echo "export EMSDK_PYTHON=/c/Python38/python.exe" >> $BASH_ENV
-      - pip-install:
-          python: "$EMSDK_PYTHON"
       - run-tests:
           test_targets: "sockets.test_nodejs_sockets_echo"
   test-mac:


### PR DESCRIPTION
Previously we could not use the emsdk version of python to
run pip install, but this was fixed in
https://github.com/emscripten-core/emsdk/pull/1001.