### PR TITLE
Simplify `self.emcc()` test method. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -902,10 +902,10 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         self.fail(f'subprocess exited with non-zero return code({e.returncode}): `{shared.shlex_join(cmd)}`')
 
   def emcc(self, filename, args=[], output_filename=None, **kwargs):
-    if output_filename is None:
-      output_filename = filename + '.o'
-    try_delete(output_filename)
-    self.run_process([compiler_for(filename), filename] + args + ['-o', output_filename], **kwargs)
+    cmd = [compiler_for(filename), filename] + args
+    if output_filename:
+      cmd += ['-o', output_filename]
+    self.run_process(cmd, **kwargs)
 
   # Shared test code between main suite and others
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -853,10 +853,10 @@ class TestCoreBase(RunnerCore):
     self.emcc('b2.c', ['-c'])
     self.emcc('main.c', ['-c'])
 
-    building.emar('cr', 'liba.a', ['a1.c.o', 'a2.c.o'])
-    building.emar('cr', 'libb.a', ['b1.c.o', 'b2.c.o'])
+    building.emar('cr', 'liba.a', ['a1.o', 'a2.o'])
+    building.emar('cr', 'libb.a', ['b1.o', 'b2.o'])
 
-    building.link_to_object(['main.c.o', 'liba.a', 'libb.a'], 'all.o')
+    building.link_to_object(['main.o', 'liba.a', 'libb.a'], 'all.o')
 
     self.emcc('all.o', self.get_emcc_args(), 'all.js')
     self.do_run('all.js', 'result: 1', no_build=True)


### PR DESCRIPTION
This avoids adding a default `-o` and therefore falls back to emcc/clang
defaults or `foo.o` rather than `foo.c.o`.

I also simplified some of the tests that call this function to make them
(I think) more readable.