### PR TITLE
SDL2_mixer: add support for MID

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -1457,7 +1457,7 @@ var USE_MODPLUG = 0;
 // [link]
 var SDL2_IMAGE_FORMATS = [];
 
-// Formats to support in SDL2_mixer. Valid values: ogg, mp3
+// Formats to support in SDL2_mixer. Valid values: ogg, mp3, mod, mid
 // [link]
 var SDL2_MIXER_FORMATS = ["ogg"];
 

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -3275,6 +3275,8 @@ window.close = function() {
     'ogg': (['ogg'],    'MIX_INIT_OGG', 'alarmvictory_1.ogg'),
     'mp3': (['mp3'],    'MIX_INIT_MP3', 'pudinha.mp3'),
     'mod': (['mod'],    'MIX_INIT_MOD', 'bleep.xm'),
+    # TODO: need to source freepats.cfg and a midi file
+    # 'mod': (['mid'],    'MIX_INIT_MID', 'midi.mid'),
   })
   @requires_sound_hardware
   def test_sdl2_mixer_music(self, formats, flags, music_name):

--- a/tools/ports/sdl2_mixer.py
+++ b/tools/ports/sdl2_mixer.py
@@ -63,6 +63,11 @@ def get(ports, settings, shared):
         '-DMUSIC_MOD_MODPLUG',
       ]
 
+    if "mid" in settings.SDL2_MIXER_FORMATS:
+      flags += [
+        '-DMUSIC_MID_TIMIDITY',
+      ]
+
     ports.build_port(
       dest_path,
       final,
@@ -74,7 +79,6 @@ def get(ports, settings, shared):
       ],
       exclude_dirs=[
         'native_midi',
-        'timidity',
         'external',
       ]
     )


### PR DESCRIPTION
Upstreaming changes from a local fork to enable SDL2_mixer to use timidity to provide MIDI support.

To use, you must provide your own sound files. I sourced mine from [here](https://www.npmjs.com/package/freepats).

And mount them here:
```
--preload-file="../freepats@/etc/timidity"
```

(that's the default place timidity will look for configuration)

I didn't add any tests because I wasn't sure if you'd want something like all of freepats in the repo for one test. Although if that is OK, it might be nice to also just provide these sound files by default (and with an option to suppress/enable that)