### PR TITLE
Fix typo in wasm64l test suite name. NFC

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9178,7 +9178,7 @@ corez = make_run('corez', emcc_args=['-Oz'])
 wasm64 = make_run('wasm64', emcc_args=[], settings={'MEMORY64': 1},
                   require_v8=True, v8_args=['--experimental-wasm-memory64'])
 # MEMORY64=2, or "lowered"
-wasm64l = make_run('wasm64', emcc_args=[], settings={'MEMORY64': 2},
+wasm64l = make_run('wasm64l', emcc_args=[], settings={'MEMORY64': 2},
                    node_args=['--experimental-wasm-bigint'])
 
 lto0 = make_run('lto0', emcc_args=['-flto', '-O0'])


### PR DESCRIPTION
This mismatch can cause very odd crashes in the parallel test runner