### PR TITLE
Fix wasmTableMirror to work with ABORT_ON_WASM_EXCEPTIONS=1 

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -3194,7 +3194,7 @@ LibraryManager.library = {
   $setWasmTableEntry__deps: ['$wasmTableMirror'],
   $setWasmTableEntry: function(idx, func) {
     wasmTable.set(idx, func);
-    wasmTableMirror[idx] = func;
+    wasmTableMirror[idx] = wasmTable.get(idx);
   },
 
   $getWasmTableEntry__internal: true,


### PR DESCRIPTION
When `ABORT_ON_WASM_EXCEPTIONS` is enabled `wasmTable.get` is overridden to inject abort handlers.
This causes the recently added `wasmTableMirror` optimization to start failing as the functions don't match. 
This fixes it by actually fetching them from the wasmTable which will make it see the overriden function correctly.