### PR TITLE
Fix return code from __syscall_getcwd

### DIFF
--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -711,10 +711,10 @@ var SyscallsLibrary = {
   __syscall_getcwd: function(buf, size) {
     if (size === 0) return -{{{ cDefine('EINVAL') }}};
     var cwd = FS.cwd();
-    var cwdLengthInBytes = lengthBytesUTF8(cwd);
-    if (size < cwdLengthInBytes + 1) return -{{{ cDefine('ERANGE') }}};
+    var cwdLengthInBytes = lengthBytesUTF8(cwd) + 1;
+    if (size < cwdLengthInBytes) return -{{{ cDefine('ERANGE') }}};
     stringToUTF8(cwd, buf, size);
-    return buf;
+    return cwdLengthInBytes;
   },
   __syscall_truncate64: function(path, low, high) {
     path = SYSCALLS.getStr(path);

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -639,17 +639,18 @@ long __syscall_getcwd(long buf, long size) {
   }
 
   auto res = result.c_str();
+  int len = strlen(res) + 1;
 
   // Check if the size argument is less than the length of the absolute
   // pathname of the working directory, including null terminator.
-  if (strlen(res) >= size - 1) {
+  if (len >= size) {
     return -ENAMETOOLONG;
   }
 
   // Return value is a null-terminated c string.
   strcpy((char*)buf, res);
 
-  return buf;
+  return len;
 }
 
 __wasi_errno_t __wasi_fd_fdstat_get(__wasi_fd_t fd, __wasi_fdstat_t* stat) {


### PR DESCRIPTION
The return code from this syscall is the number of bytes written, not
the buffer pointer.

As it happens the libc function works just as well either way, but i've
been looking to change the return of all our syscalls from long to int
and I noticed this was the only system that had a pointer-sized return
value (thus requiring i64 on wasm64).  Turns out it doesn't require this
after all.

To show that this is that we expect the linux syscall to return here is
how glibc uses the return value:

https://github.com/lattera/glibc/blob/895ef79e04a953cac1493863bcae29ad85657ee1/sysdeps/unix/sysv/linux/getcwd.c#L78-L84