### PR TITLE
Remove unused `nice` syscall. NFC

### DIFF
--- a/system/lib/libc/emscripten_syscall_stubs.c
+++ b/system/lib/libc/emscripten_syscall_stubs.c
@@ -100,10 +100,6 @@ int __syscall_link(long oldpath, long newpath) {
   return -EMLINK; // no hardlinks for us
 }
 
-int __syscall_nice(long inc) {
-  return -EPERM; // no meaning to nice for our single-process environment
-}
-
 int __syscall_getgroups32(long size, long list) {
   if (size < 1) {
     return -EINVAL;

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -4,7 +4,6 @@
 #define SYS_chmod		 __syscall_chmod
 #define SYS_getpid		 __syscall_getpid
 #define SYS_pause		 __syscall_pause
-#define SYS_nice		 __syscall_nice
 #define SYS_sync		 __syscall_sync
 #define SYS_mkdir		 __syscall_mkdir
 #define SYS_rmdir		 __syscall_rmdir

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -18,7 +18,6 @@ int __syscall_chmod(long path, long mode);
 int __syscall_getpid(void);
 int __syscall_pause(void);
 int __syscall_access(long path, long amode);
-int __syscall_nice(long inc);
 int __syscall_sync(void);
 int __syscall_mkdir(long path, long mode);
 int __syscall_rmdir(long path);


### PR DESCRIPTION
musl's nice.c uses setpriority which in turn calls __sys_setpriority,
so this syscall is never used.