### PR TITLE
[memory64] Unify handling of high/low argument pairs in syscalls

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
-          test_targets: "wasm64.test_hello_world wasm64l.test_hello_world"
+          test_targets: "wasm64.test_hello_world wasm64l.test_hello_world wasm64l.test_unistd_truncate"
   test-other:
     executor: bionic
     steps:

--- a/src/library_syscall.js
+++ b/src/library_syscall.js
@@ -205,16 +205,6 @@ var SyscallsLibrary = {
       return stream;
     },
 #endif // SYSCALLS_REQUIRE_FILESYSTEM
-    get64: function(low, high) {
-#if ASSERTIONS
-      if (low >= 0) assert(high === 0);
-      else assert(high === -1);
-#endif
-#if SYSCALL_DEBUG
-      err('    (i64: "' + low + '")');
-#endif
-      return low;
-    }
   },
 
   _mmap_js__deps: ['$SYSCALLS',
@@ -718,14 +708,14 @@ var SyscallsLibrary = {
     stringToUTF8(cwd, buf, size);
     return cwdLengthInBytes;
   },
-  __syscall_truncate64: function(path, low, high) {
+  __syscall_truncate64: function(path, {{{ defineI64Param('length') }}}) {
+    {{{ receiveI64ParamAsDouble('length') }}}
     path = SYSCALLS.getStr(path);
-    var length = SYSCALLS.get64(low, high);
     FS.truncate(path, length);
     return 0;
   },
-  __syscall_ftruncate64: function(fd, low, high) {
-    var length = SYSCALLS.get64(low, high);
+  __syscall_ftruncate64: function(fd, {{{ defineI64Param('length') }}}) {
+    {{{ receiveI64ParamAsDouble('length') }}}
     FS.ftruncate(fd, length);
     return 0;
   },
@@ -878,9 +868,9 @@ var SyscallsLibrary = {
     var stream = SYSCALLS.getStreamFromFD(fd);
     return ___syscall_statfs64(0, size, buf);
   },
-  __syscall_fadvise64_64__nothrow: true,
-  __syscall_fadvise64_64__proxy: false,
-  __syscall_fadvise64_64: function(fd, offset, len, advice) {
+  __syscall_fadvise64__nothrow: true,
+  __syscall_fadvise64__proxy: false,
+  __syscall_fadvise64: function(fd, offset, len, advice) {
     return 0; // your advice is important to us (but we can't use it)
   },
   __syscall_openat: function(dirfd, path, flags, varargs) {
@@ -1009,10 +999,10 @@ var SyscallsLibrary = {
     FS.utime(path, atime, mtime);
     return 0;
   },
-  __syscall_fallocate: function(fd, mode, off_low, off_high, len_low, len_high) {
+  __syscall_fallocate: function(fd, mode, {{{ defineI64Param('offset') }}}, {{{ defineI64Param('len') }}}) {
+    {{{ receiveI64ParamAsDouble('offset') }}}
+    {{{ receiveI64ParamAsDouble('len') }}}
     var stream = SYSCALLS.getStreamFromFD(fd)
-    var offset = SYSCALLS.get64(off_low, off_high);
-    var len = SYSCALLS.get64(len_low, len_high);
 #if ASSERTIONS
     assert(mode === 0);
 #endif

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -1117,12 +1117,12 @@ function receiveI64ParamAsI32s(name) {
 function receiveI64ParamAsDouble(name) {
   if (WASM_BIGINT) {
     // Just convert the bigint into a double.
-    return `${name} = Number(${name});`;
+    return `var ${name} = Number(${name}_bigint);`;
   }
 
   // Combine the i32 params. Use an unsigned operator on low and shift high by
   // 32 bits.
-  return `${name} = ${name}_high * 0x100000000 + (${name}_low >>> 0);`;
+  return `var ${name} = ${name}_high * 0x100000000 + (${name}_low >>> 0);`;
 }
 
 function sendI64Argument(low, high) {

--- a/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
+++ b/system/lib/compiler-rt/lib/sanitizer_common/sanitizer_linux.cpp
@@ -272,16 +272,8 @@ uptr internal_write(fd_t fd, const void *buf, uptr count) {
 
 uptr internal_ftruncate(fd_t fd, uptr size) {
   sptr res;
-#if SANITIZER_EMSCRIPTEN
-  // The __SYSCALL_LL_O macros that musl uses to split 64-bit arguments
-  // doesn't work in C++ code so we have to do it manually.
-  union { long long ll; long l[2]; } split{ .ll = size };
-  HANDLE_EINTR(res, (sptr)internal_syscall(SYSCALL(ftruncate), fd,
-               split.l[0], split.l[1]));
-#else
   HANDLE_EINTR(res, (sptr)internal_syscall(SYSCALL(ftruncate), fd,
                (OFF_T)size));
-#endif
   return res;
 }
 

--- a/system/lib/libc/musl/arch/emscripten/bits/syscall.h
+++ b/system/lib/libc/musl/arch/emscripten/bits/syscall.h
@@ -62,7 +62,7 @@
 #define SYS_fcntl64		__syscall_fcntl64
 #define SYS_statfs64		__syscall_statfs64
 #define SYS_fstatfs64		__syscall_fstatfs64
-#define SYS_fadvise64_64	__syscall_fadvise64_64
+#define SYS_fadvise64		__syscall_fadvise64
 #define SYS_openat		__syscall_openat
 #define SYS_mkdirat		__syscall_mkdirat
 #define SYS_mknodat		__syscall_mknodat

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -2,10 +2,11 @@
 #include <wasi/wasi-helpers.h>
 #include <emscripten/em_macros.h>
 
-#define __SYSCALL_LL_E(x) \
-((union { long long ll; long l[2]; }){ .ll = x }).l[0], \
-((union { long long ll; long l[2]; }){ .ll = x }).l[1]
-#define __SYSCALL_LL_O(x) __SYSCALL_LL_E((x))
+// Compile as if we can pass uint64 values directly to the
+// host.  Binaryen will take care of splitting any i64 params
+// into a pair of i32 values if needed.
+#define __SYSCALL_LL_E(x) (x)
+#define __SYSCALL_LL_O(x) (x)
 
 #ifdef __cplusplus
 extern "C" {
@@ -59,8 +60,8 @@ int __syscall_poll(long fds, long nfds, long timeout);
 int __syscall_getcwd(long buf, long size);
 int __syscall_ugetrlimit(long resource, long rlim);
 int __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long off);
-int __syscall_truncate64(long path, long low, long high);
-int __syscall_ftruncate64(long fd, long low, long high);
+int __syscall_truncate64(long path, uint64_t length);
+int __syscall_ftruncate64(long fd, uint64_t length);
 int __syscall_stat64(long path, long buf);
 int __syscall_lstat64(long path, long buf);
 int __syscall_fstat64(long fd, long buf);
@@ -84,7 +85,7 @@ int __syscall_getdents64(long fd, long dirp, long count);
 int __syscall_fcntl64(long fd, long cmd, ...);
 int __syscall_statfs64(long path, long size, long buf);
 int __syscall_fstatfs64(long fd, long size, long buf);
-int __syscall_fadvise64_64(long fd, long low, long high, long low2, long high2, long advice);
+int __syscall_fadvise64(long fd, uint64_t base, uint64_t len, long advice);
 int __syscall_openat(long dirfd, long path, long flags, ...); // mode is optional
 int __syscall_mkdirat(long dirfd, long path, long mode);
 int __syscall_mknodat(long dirfd, long path, long mode, long dev);
@@ -99,7 +100,7 @@ int __syscall_fchmodat(long dirfd, long path, long mode, ...);
 int __syscall_faccessat(long dirfd, long path, long amode, long flags);
 int __syscall_pselect6(long nfds, long readfds, long writefds, long exceptfds, long timeout, long sigmaks);
 int __syscall_utimensat(long dirfd, long path, long times, long flags);
-int __syscall_fallocate(long fd, long mode, long off_low, long off_high, long len_low, long len_high);
+int __syscall_fallocate(long fd, long mode, uint64_t off, uint64_t len);
 int __syscall_dup3(long fd, long suggestfd, long flags);
 int __syscall_pipe2(long fds, long flags);
 int __syscall_recvmmsg(long sockfd, long msgvec, long vlen, long flags, ...);

--- a/system/lib/libc/musl/src/internal/syscall.h
+++ b/system/lib/libc/musl/src/internal/syscall.h
@@ -19,7 +19,14 @@
 #endif
 
 #ifndef __scc
+#ifdef __EMSCRIPTEN__
+// With emscripten we allow the passing of longer-than-word-sized
+// argument (such as off_t on wasm32) and let binaryen handle splitting
+// them into a pair of i32 arguments.
+#define __scc(X) ((long long) (X))
+#else
 #define __scc(X) ((long) (X))
+#endif
 typedef long syscall_arg_t;
 #endif
 


### PR DESCRIPTION
Other 64-bit platforms in musl basically do this same thing
(i.e. define __SYSCALL_LL_0 to the identity).

The rename of `fadvise64_64` -> `fadvise64` is just a driveby
cleanup.  I noticed that musl will define one to the other if its
found but otherwise treat them identically.

Note that this change only effects a very few syscalls that
pass `off_t` things which are 64-bit on all platforms.  It is
independent of (and doesn't try to address) the wider problem
how we handle pointers and `size_t` things.