### PR TITLE
In the Advanced APIs documentation (section "settings.js"), add a note with a link to https://emsettings.surma.technology

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ While Emscripten mostly focuses on compiling C and C++ using
 compilers (for example, Rust has Emscripten integration, with the
 `wasm32-unknown-emscripten` and `asmjs-unknown-emscripten` targets).
 
-License 
+License
 -------
 
 Emscripten is available under 2 licenses, the MIT license and the

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ While Emscripten mostly focuses on compiling C and C++ using
 compilers (for example, Rust has Emscripten integration, with the
 `wasm32-unknown-emscripten` and `asmjs-unknown-emscripten` targets).
 
-License
+License 
 -------
 
 Emscripten is available under 2 licenses, the MIT license and the

--- a/site/source/docs/api_reference/advanced-apis.rst
+++ b/site/source/docs/api_reference/advanced-apis.rst
@@ -39,7 +39,8 @@ other settings. For example, ``ASSERTIONS`` is enabled by default, but disabled
 in optimized builds (``-O1+``).
 
 .. note::
-  For more information on what options can be used to configure Emscripten, go to
+  For more information on what options can be used to configure Emscripten, read
+  ``src/settings.js`` or visit
   `the emsettings page <https://emsettings.surma.technology>`_.
 
 

--- a/site/source/docs/api_reference/advanced-apis.rst
+++ b/site/source/docs/api_reference/advanced-apis.rst
@@ -38,6 +38,11 @@ not be modified. Note also that the compiler changes some options depending on
 other settings. For example, ``ASSERTIONS`` is enabled by default, but disabled
 in optimized builds (``-O1+``).
 
+.. note::
+  For more information on what options can be used to configure Emscripten, go to
+  `the emsettings page <https://emsettings.surma.technology>`_.
+
+
 preamble.js
 ===========
 


### PR DESCRIPTION
Addressing #16563, this pull requests adds a note with this [link](https://emsettings.surma.technology/).

![New Image](https://user-images.githubusercontent.com/73802848/160174795-171aae94-b249-44a1-b1cb-7355942be25d.png)
In this image, the addition is the bottom note.