### PR TITLE
Unlike other syscalls, mmap needs to return a pointer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,7 +376,7 @@ jobs:
     executor: bionic
     steps:
       - run-tests-linux:
-          test_targets: "wasm64.test_hello_world wasm64l.test_hello_world wasm64l.test_unistd_truncate"
+          test_targets: "wasm64.test_hello_world wasm64l.test_hello_world wasm64l.test_unistd_truncate wasm64l.test_mmap"
   test-other:
     executor: bionic
     steps:

--- a/system/lib/libc/emscripten_mmap.c
+++ b/system/lib/libc/emscripten_mmap.c
@@ -34,9 +34,9 @@ static volatile int lock[1];
 static struct map* mappings;
 
 // JS library functions.  Used only when mapping files (not MAP_ANONYMOUS)
-long _mmap_js(long addr, long length, long prot, long flags, long fd, long offset, int* allocated);
-long _munmap_js(long addr, long length, long prot, long flags, long fd, long offset);
-long _msync_js(long addr, long length, long flags, long fd);
+intptr_t _mmap_js(long addr, long length, long prot, long flags, long fd, long offset, int* allocated);
+int _munmap_js(long addr, long length, long prot, long flags, long fd, long offset);
+int _msync_js(long addr, long length, long flags, long fd);
 
 static struct map* find_mapping(long addr, struct map** prev) {
   struct map* map = mappings;
@@ -108,7 +108,7 @@ int __syscall_msync(long addr, long len, long flags) {
   return _msync_js(addr, len, map->flags, map->fd);
 }
 
-int __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long off) {
+intptr_t __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long off) {
   // addr argument must be page aligned if MAP_FIXED flag is set.
   if (flags & MAP_FIXED && (addr % WASM_PAGE_SIZE) != 0) {
     return -EINVAL;

--- a/system/lib/libc/musl/arch/emscripten/syscall_arch.h
+++ b/system/lib/libc/musl/arch/emscripten/syscall_arch.h
@@ -59,7 +59,7 @@ int __syscall_mremap(long old_addr, long old_size, long new_size, long flags, lo
 int __syscall_poll(long fds, long nfds, long timeout);
 int __syscall_getcwd(long buf, long size);
 int __syscall_ugetrlimit(long resource, long rlim);
-int __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long off);
+intptr_t __syscall_mmap2(long addr, long len, long prot, long flags, long fd, long off);
 int __syscall_truncate64(long path, uint64_t length);
 int __syscall_ftruncate64(long fd, uint64_t length);
 int __syscall_stat64(long path, long buf);


### PR DESCRIPTION
This is a followup to #16583 which converted all the syscall return
values to `int`.   However, there is one exception that I overlooked
which is `mmap`.  This syscall does return a pointer so (at least for
wasm64) is can't be of type `int`.