### PR TITLE
tests: Update require_node to handle MEMORY64. NFC

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -390,6 +390,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
         self.skipTest('test requires node and EMTEST_SKIP_NODE is set')
       else:
         self.fail('node required to run this test.  Use EMTEST_SKIP_NODE to skip')
+    if self.get_setting('MEMORY64') == 1:
+      self.skipTest("MEMORY64=1 tests don't yet run under node")
     self.js_engines = [config.NODE_JS]
 
   def setup_node_pthreads(self):

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -87,6 +87,7 @@ misc_test_modes = [
   'minimal0',
   'wasmfs',
   'wasm64',
+  'wasm64l',
 ]
 
 


### PR DESCRIPTION
MEMORY64=1 buildes do not run under node.  This change
takes care of skipping `require_node` tests in that mode.

Also, increase the usage of require_node to make tests that
require it.