### PR TITLE
Warning on C++-only settings when linking as C

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -23,6 +23,8 @@ See docs/process.md for more on how version tagging works.
 - The `-sSHELL_FILE` setting, which (unlike the --shell-file command line
   options) we believe was never tested or externally used, has been removed.
   (#16589)
+- A warning is now issued when passing C++-only settings such
+  `-sEXCEPTION_CATCHING_ALLOWED` when not linking as C++. (#16609)
 
 3.1.8 - 03/24/2022
 ------------------

--- a/emcc.py
+++ b/emcc.py
@@ -2520,6 +2520,19 @@ def phase_linker_setup(options, state, newargs, user_settings):
   if settings.WASMFS:
     settings.LINK_AS_CXX = True
 
+  # Some settings make no sense when not linking as C++
+  if not settings.LINK_AS_CXX:
+    cxx_only_settings = [
+      'DEMANGLE_SUPPORT',
+      'EXCEPTION_DEBUG',
+      'DISABLE_EXCEPTION_CATCHING',
+      'EXCEPTION_CATCHING_ALLOWED',
+      'DISABLE_EXCEPTION_THROWING',
+    ]
+    for setting in cxx_only_settings:
+      if setting in user_settings:
+        diagnostics.warning('linkflags', 'setting `%s` is not meaningful unless linking as C++', setting)
+
   # Export tag objects which are likely needed by the native code, but which are
   # currently not reported in the metadata of wasm-emscripten-finalize
   if settings.RELOCATABLE:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5627,7 +5627,6 @@ main( int argv, char ** argc ) {
 
   @also_with_noderawfs
   def test_fs_writeFile(self):
-    self.set_setting('DISABLE_EXCEPTION_CATCHING') # see issue 2334
     self.do_run_in_out_file_test('fs/test_writeFile.cpp')
 
   def test_fs_write(self):
@@ -6470,7 +6469,6 @@ void* operator new(size_t size) {
   @no_asan('local count too large for VMs')
   @is_slow_test
   def test_sqlite(self):
-    self.set_setting('DISABLE_EXCEPTION_CATCHING')
     self.set_setting('EXPORTED_FUNCTIONS', ['_main', '_sqlite3_open', '_sqlite3_close', '_sqlite3_exec', '_sqlite3_free'])
     if '-g' in self.emcc_args:
       print("disabling inlining") # without registerize (which -g disables), we generate huge amounts of code


### PR DESCRIPTION
Certain settings such as `EXCEPTION_CATCHING_ALLOWED` do not
make sense unless linking as C++.