### PR TITLE
Remove unnecessary CatchInfo JS class. NFC

### DIFF
--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -22,9 +22,11 @@ var LibraryExceptions = {
   //
   // excPtr - Thrown object pointer to wrap. Metadata pointer is calculated from it.
   $ExceptionInfo__docs: '/** @constructor */',
+  $ExceptionInfo__deps: ['__cxa_is_pointer_type',
 #if EXCEPTION_DEBUG
-  $ExceptionInfo__deps: ['$ptrToString'],
+    '$ptrToString',
 #endif
+  ],
   $ExceptionInfo: function(excPtr) {
     this.excPtr = excPtr;
     this.ptr = excPtr - {{{ C_STRUCTS.__cxa_exception.__size__ }}};
@@ -69,6 +71,10 @@ var LibraryExceptions = {
 
     // Initialize native structure fields. Should be called once after allocated.
     this.init = function(type, destructor) {
+#if EXCEPTION_DEBUG
+      err('ExceptionInfo init: ' + [type, destructor]);
+#endif
+      this.set_adjusted_ptr(0);
       this.set_type(type);
       this.set_destructor(destructor);
       this.set_refcount(0);
@@ -98,46 +104,13 @@ var LibraryExceptions = {
 #endif
       return prev === 1;
     };
-  },
-
-  $CatchInfo__docs: `
-  /**
-   * @constructor
-   * @param {number=} ptr
-   */`,
-  $CatchInfo__deps: ['$ExceptionInfo', '__cxa_is_pointer_type'],
-  // This native structure is returned from __cxa_find_matching_catch, and serves as catching
-  // context, i.e. stores information required to proceed with a specific selected catch. It stores
-  // base and adjusted pointers of a thrown object. It is allocated dynamically and should be freed
-  // when it is done with a specific catch (i.e. either in __cxa_end_catch when caught or in
-  // __resumeException when no catch clause matched). The class itself is just a native pointer
-  // wrapper, and contains all the necessary accessors for the fields in the native structure.
-  // ptr - Native structure pointer to wrap, the structure is allocated when not specified.
-  $CatchInfo: function(ptr) {
-
-    this.free = function() {
-      _free(this.ptr);
-      this.ptr = 0;
-    };
-
-    this.set_base_ptr = function(basePtr) {
-      {{{ makeSetValue('this.ptr', '0', 'basePtr', '*') }}};
-    };
-
-    this.get_base_ptr = function() {
-      return {{{ makeGetValue('this.ptr', '0', '*') }}};
-    };
 
     this.set_adjusted_ptr = function(adjustedPtr) {
-      {{{ makeSetValue('this.ptr', Runtime.POINTER_SIZE, 'adjustedPtr', '*') }}};
+      {{{ makeSetValue('this.ptr', C_STRUCTS.__cxa_exception.adjustedPtr, 'adjustedPtr', '*') }}};
     };
 
-    this.get_adjusted_ptr_addr = function() {
-      return this.ptr + {{{ Runtime.POINTER_SIZE }}};
-    }
-
     this.get_adjusted_ptr = function() {
-      return {{{ makeGetValue('this.ptr', Runtime.POINTER_SIZE, '*') }}};
+      return {{{ makeGetValue('this.ptr', C_STRUCTS.__cxa_exception.adjustedPtr, '*') }}};
     };
 
     // Get pointer which is expected to be received by catch clause in C++ code. It may be adjusted
@@ -147,26 +120,14 @@ var LibraryExceptions = {
     this.get_exception_ptr = function() {
       // Work around a fastcomp bug, this code is still included for some reason in a build without
       // exceptions support.
-      var isPointer = {{{ exportedAsmFunc('___cxa_is_pointer_type') }}}(
-        this.get_exception_info().get_type());
+      var isPointer = {{{ exportedAsmFunc('___cxa_is_pointer_type') }}}(this.get_type());
       if (isPointer) {
-        return {{{ makeGetValue('this.get_base_ptr()', '0', '*') }}};
+        return {{{ makeGetValue('this.excPtr', '0', '*') }}};
       }
       var adjusted = this.get_adjusted_ptr();
       if (adjusted !== 0) return adjusted;
-      return this.get_base_ptr();
+      return this.excPtr;
     };
-
-    this.get_exception_info = function() {
-      return new ExceptionInfo(this.get_base_ptr());
-    };
-
-    if (ptr === undefined) {
-      this.ptr = _malloc({{{ Runtime.POINTER_SIZE * 2 }}});
-      this.set_adjusted_ptr(0);
-    } else {
-      this.ptr = ptr;
-    }
   },
 
   $exception_addRef: function (info) {
@@ -258,20 +219,17 @@ var LibraryExceptions = {
   __cxa_rethrow__deps: ['$exceptionCaught', '$exceptionLast', '$uncaughtExceptionCount'],
   __cxa_rethrow__sig: 'v',
   __cxa_rethrow: function() {
-    var catchInfo = exceptionCaught.pop();
-    if (!catchInfo) {
+    var info = exceptionCaught.pop();
+    if (!info) {
       abort('no exception to throw');
     }
-    var info = catchInfo.get_exception_info();
-    var ptr = catchInfo.get_base_ptr();
+    var ptr = info.excPtr;
     if (!info.get_rethrown()) {
       // Only pop if the corresponding push was through rethrow_primary_exception
-      exceptionCaught.push(catchInfo);
+      exceptionCaught.push(info);
       info.set_rethrown(true);
       info.set_caught(false);
       uncaughtExceptionCount++;
-    } else {
-      catchInfo.free();
     }
 #if EXCEPTION_DEBUG
     err('__cxa_rethrow, popped ' +
@@ -285,30 +243,27 @@ var LibraryExceptions = {
     return type;
   },
 
-  __cxa_begin_catch__deps: ['$CatchInfo', '$exceptionCaught', '$exception_addRef',
-                            '$uncaughtExceptionCount'],
+  __cxa_begin_catch__deps: ['$exceptionCaught', '$exception_addRef', '$uncaughtExceptionCount'],
   __cxa_begin_catch: function(ptr) {
-    var catchInfo = new CatchInfo(ptr);
-    var info = catchInfo.get_exception_info();
+    var info = new ExceptionInfo(ptr);
     if (!info.get_caught()) {
       info.set_caught(true);
       uncaughtExceptionCount--;
     }
     info.set_rethrown(false);
-    exceptionCaught.push(catchInfo);
+    exceptionCaught.push(info);
 #if EXCEPTION_DEBUG
     err('__cxa_begin_catch ' + [ptrToString(ptr), 'stack', exceptionCaught]);
 #endif
     exception_addRef(info);
-    return catchInfo.get_exception_ptr();
+    return info.get_exception_ptr();
   },
 
   // We're done with a catch. Now, we can run the destructor if there is one
   // and free the exception. Note that if the dynCall on the destructor fails
   // due to calling apply on undefined, that means that the destructor is
   // an invalid index into the FUNCTION_TABLE, so something has gone wrong.
-  __cxa_end_catch__deps: ['$exceptionCaught', '$exceptionLast', '$exception_decRef',
-                          '$CatchInfo'],
+  __cxa_end_catch__deps: ['$exceptionCaught', '$exceptionLast', '$exception_decRef'],
   __cxa_end_catch__sig: 'v',
   __cxa_end_catch: function() {
     // Clear state flag.
@@ -317,22 +272,21 @@ var LibraryExceptions = {
     assert(exceptionCaught.length > 0);
 #endif
     // Call destructor if one is registered then clear it.
-    var catchInfo = exceptionCaught.pop();
+    var info = exceptionCaught.pop();
 
 #if EXCEPTION_DEBUG
-    err('__cxa_end_catch popped ' + [catchInfo, exceptionLast, 'stack', exceptionCaught]);
+    err('__cxa_end_catch popped ' + [info, exceptionLast, 'stack', exceptionCaught]);
 #endif
-    exception_decRef(catchInfo.get_exception_info());
-    catchInfo.free();
+    exception_decRef(info);
     exceptionLast = 0; // XXX in decRef?
   },
 
-  __cxa_get_exception_ptr__deps: ['$CatchInfo'],
+  __cxa_get_exception_ptr__deps: ['$ExceptionInfo'],
   __cxa_get_exception_ptr: function(ptr) {
 #if EXCEPTION_DEBUG
     err('__cxa_get_exception_ptr ' + ptrToString(ptr));
 #endif
-    return new CatchInfo(ptr).get_exception_ptr();
+    return new ExceptionInfo(ptr).get_exception_ptr();
   },
 
   __cxa_uncaught_exceptions__deps: ['$uncaughtExceptionCount'],
@@ -348,23 +302,21 @@ var LibraryExceptions = {
     throw exception;
   },
 
-  __cxa_current_primary_exception__deps: ['$exceptionCaught', '$exception_addRef', '$CatchInfo'],
+  __cxa_current_primary_exception__deps: ['$exceptionCaught', '$exception_addRef'],
   __cxa_current_primary_exception: function() {
     if (!exceptionCaught.length) {
       return 0;
     }
-    var catchInfo = exceptionCaught[exceptionCaught.length - 1];
-    exception_addRef(catchInfo.get_exception_info());
-    return catchInfo.get_base_ptr();
+    var info = exceptionCaught[exceptionCaught.length - 1];
+    exception_addRef(info);
+    return info.excPtr;
   },
 
-  __cxa_rethrow_primary_exception__deps: ['$CatchInfo', '$exceptionCaught', '__cxa_rethrow'],
+  __cxa_rethrow_primary_exception__deps: ['$ExceptionInfo', '$exceptionCaught', '__cxa_rethrow'],
   __cxa_rethrow_primary_exception: function(ptr) {
     if (!ptr) return;
-    var catchInfo = new CatchInfo();
-    catchInfo.set_base_ptr(ptr);
-    var info = catchInfo.get_exception_info();
-    exceptionCaught.push(catchInfo);
+    var info = new ExceptionInfo(ptr);
+    exceptionCaught.push(info);
     info.set_rethrown(true);
     ___cxa_rethrow();
   },
@@ -378,7 +330,7 @@ var LibraryExceptions = {
   // unwinding using 'if' blocks around each function, so the remaining
   // functionality boils down to picking a suitable 'catch' block.
   // We'll do that here, instead, to keep things simpler.
-  __cxa_find_matching_catch__deps: ['$exceptionLast', '$ExceptionInfo', '$CatchInfo', '__resumeException', '__cxa_can_catch'],
+  __cxa_find_matching_catch__deps: ['$exceptionLast', '$ExceptionInfo', '__resumeException', '__cxa_can_catch'],
   __cxa_find_matching_catch: function() {
     var thrown = exceptionLast;
     if (!thrown) {
@@ -386,13 +338,11 @@ var LibraryExceptions = {
       {{{ makeStructuralReturn([0, 0]) }}};
     }
     var info = new ExceptionInfo(thrown);
+    info.set_adjusted_ptr(thrown);
     var thrownType = info.get_type();
-    var catchInfo = new CatchInfo();
-    catchInfo.set_base_ptr(thrown);
-    catchInfo.set_adjusted_ptr(thrown);
     if (!thrownType) {
       // just pass through the thrown ptr
-      {{{ makeStructuralReturn(['catchInfo.ptr', 0]) }}};
+      {{{ makeStructuralReturn(['thrown', 0]) }}};
     }
     var typeArray = Array.prototype.slice.call(arguments);
 
@@ -410,25 +360,23 @@ var LibraryExceptions = {
         // Catch all clause matched or exactly the same type is caught
         break;
       }
-      if ({{{ exportedAsmFunc('___cxa_can_catch') }}}(caughtType, thrownType, catchInfo.get_adjusted_ptr_addr())) {
+      var adjusted_ptr_addr = info.ptr + {{{ C_STRUCTS.__cxa_exception.adjustedPtr }}};
+      if ({{{ exportedAsmFunc('___cxa_can_catch') }}}(caughtType, thrownType, adjusted_ptr_addr)) {
 #if EXCEPTION_DEBUG
-        err("  __cxa_find_matching_catch found " + [ptrToString(catchInfo.get_adjusted_ptr()), caughtType]);
+        err("  __cxa_find_matching_catch found " + [ptrToString(info.get_adjusted_ptr()), caughtType]);
 #endif
-        {{{ makeStructuralReturn(['catchInfo.ptr', 'caughtType']) }}};
+        {{{ makeStructuralReturn(['thrown', 'caughtType']) }}};
       }
     }
-    {{{ makeStructuralReturn(['catchInfo.ptr', 'thrownType']) }}};
+    {{{ makeStructuralReturn(['thrown', 'thrownType']) }}};
   },
 
-  __resumeException__deps: ['$exceptionLast', '$CatchInfo'],
-  __resumeException: function(catchInfoPtr) {
-    var catchInfo = new CatchInfo(catchInfoPtr);
-    var ptr = catchInfo.get_base_ptr();
+  __resumeException__deps: ['$exceptionLast'],
+  __resumeException: function(ptr) {
 #if EXCEPTION_DEBUG
-    err("Resuming exception " + [ptrToString(ptr), exceptionLast]);
+    err("__resumeException " + [ptrToString(ptr), exceptionLast]);
 #endif
     if (!exceptionLast) { exceptionLast = ptr; }
-    catchInfo.free();
     {{{ makeThrow('ptr') }}}
   },
 

--- a/src/struct_info_cxx.json
+++ b/src/struct_info_cxx.json
@@ -7,7 +7,8 @@
               "referenceCount",
               "exceptionType",
               "caught",
-              "rethrown"
+              "rethrown",
+              "adjustedPtr"
             ]
         }
     }

--- a/system/lib/libcxxabi/src/cxa_exception.h
+++ b/system/lib/libcxxabi/src/cxa_exception.h
@@ -27,6 +27,7 @@ struct _LIBCXXABI_HIDDEN __cxa_exception {
   void (*exceptionDestructor)(void *);
   uint8_t caught;
   uint8_t rethrown;
+  void *adjustedPtr;
 };
 
 #else

--- a/tests/reference_struct_info.json
+++ b/tests/reference_struct_info.json
@@ -1201,7 +1201,8 @@
             "nextInChain": 0
         },
         "__cxa_exception": {
-            "__size__": 16,
+            "__size__": 20,
+            "adjustedPtr": 16,
             "caught": 12,
             "exceptionDestructor": 8,
             "exceptionType": 4,

--- a/tools/deps_info.py
+++ b/tools/deps_info.py
@@ -196,6 +196,7 @@ _deps_info = {
 def get_deps_info():
   if not settings.EXCEPTION_HANDLING and settings.LINK_AS_CXX:
     _deps_info['__cxa_begin_catch'] = ['__cxa_is_pointer_type']
+    _deps_info['__cxa_throw'] = ['__cxa_is_pointer_type']
     _deps_info['__cxa_find_matching_catch'] = ['__cxa_can_catch']
     _deps_info['__cxa_find_matching_catch_1'] = ['__cxa_can_catch']
     _deps_info['__cxa_find_matching_catch_2'] = ['__cxa_can_catch']


### PR DESCRIPTION
This class was used to hold the "adjusted" exceptions pointer along with
the original one.  It was separately allocated from the exception itself
but AFAICT this is not necessary.

Instead this adjusted pointer can simply be part of the `__cpp_exception`
class, as it is on other platforms. This not only simplifies the code
but also removes memory fragmentation and JS dependencies on the
allocator (`malloc`/`free`).