### PR TITLE
Remove undocumented and unused getFuncWrapper()

### DIFF
--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -779,36 +779,6 @@ var LibraryBrowser = {
     },
   },
 
-  $funcWrappers: {},
-
-  $getFuncWrapper__deps: ['$funcWrappers', '$dynCall'],
-  $getFuncWrapper: function(func, sig) {
-    if (!func) return; // on null pointer, return undefined
-    assert(sig);
-    if (!funcWrappers[sig]) {
-      funcWrappers[sig] = {};
-    }
-    var sigCache = funcWrappers[sig];
-    if (!sigCache[func]) {
-      // optimize away arguments usage in common cases
-      if (sig.length === 1) {
-        sigCache[func] = function dynCall_wrapper() {
-          return dynCall(sig, func);
-        };
-      } else if (sig.length === 2) {
-        sigCache[func] = function dynCall_wrapper(arg) {
-          return dynCall(sig, func, [arg]);
-        };
-      } else {
-        // general case
-        sigCache[func] = function dynCall_wrapper() {
-          return dynCall(sig, func, Array.prototype.slice.call(arguments));
-        };
-      }
-    }
-    return sigCache[func];
-  },
-
   emscripten_run_preload_plugins__deps: ['$PATH',
 #if !MINIMAL_RUNTIME
     '$runtimeKeepalivePush', '$runtimeKeepalivePop',

--- a/src/modules.js
+++ b/src/modules.js
@@ -417,7 +417,6 @@ function exportRuntime() {
     'registerFunctions',
     'addFunction',
     'removeFunction',
-    'getFuncWrapper',
     'prettyPrint',
     'dynCall',
     'getCompilerSetting',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6981,29 +6981,6 @@ void* operator new(size_t size) {
     self.set_setting('ASSERTIONS', 2)
     self.do_run_in_out_file_test('interop/test_add_function.cpp', interleaved_output=False)
 
-  def test_getFuncWrapper_sig_alias(self):
-    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$getFuncWrapper'])
-    src = r'''
-    #include <stdio.h>
-    #include <emscripten.h>
-
-    void func1(int a) {
-      printf("func1\n");
-    }
-    void func2(int a, int b) {
-      printf("func2\n");
-    }
-
-    int main() {
-      EM_ASM({
-        getFuncWrapper($0, 'vi')(0);
-        getFuncWrapper($1, 'vii')(0, 0);
-      }, func1, func2);
-      return 0;
-    }
-    '''
-    self.do_run(src, 'func1\nfunc2\n')
-
   def test_emulate_function_pointer_casts(self):
     # Forcibly disable EXIT_RUNTIME due to:
     # https://github.com/emscripten-core/emscripten/issues/15081


### PR DESCRIPTION
There may be users of this in theory, but as it has no documentation I
think it's safe to remove.