### PR TITLE
Add debug build of libc++-abi

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -34,6 +34,8 @@ MINIMAL_TASKS = [
     'libc++abi',
     'libc++abi-except',
     'libc++abi-noexcept',
+    'libc++abi-debug-except',
+    'libc++abi-debug-noexcept',
     'libc++',
     'libc++-except',
     'libc++-noexcept',

--- a/tools/system_libs.py
+++ b/tools/system_libs.py
@@ -1140,7 +1140,7 @@ class crtbegin(Library):
     return super().can_use() and settings.SHARED_MEMORY
 
 
-class libcxxabi(NoExceptLibrary, MTLibrary):
+class libcxxabi(NoExceptLibrary, MTLibrary, DebugLibrary):
   name = 'libc++abi'
   cflags = [
       '-Oz',


### PR DESCRIPTION
There is code in libc++-abi that contains asserts so being able to build
it is debug mode has some value.