### PR TITLE
Update USE_OFFSET_CONVERTER test. NFC

### DIFF
--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -4,6 +4,9 @@
  * SPDX-License-Identifier: MIT
  */
 
+/**
+ * @constructor
+ */
 function WasmSourceMap(sourceMap) {
   this.version = sourceMap.version;
   this.sources = sourceMap.sources;
@@ -13,9 +16,7 @@ function WasmSourceMap(sourceMap) {
   this.offsets = [];
 
   var vlqMap = {};
-  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='.split('').forEach(function (c, i) {
-    vlqMap[c] = i;
-  });
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/='.split('').forEach((c, i) => vlqMap[c] = i);
 
   // based on https://github.com/Rich-Harris/vlq/blob/master/src/vlq.ts
   function decodeVLQ(string) {
@@ -57,7 +58,7 @@ function WasmSourceMap(sourceMap) {
     this.mapping[offset] = info;
     this.offsets.push(offset);
   }, this);
-  this.offsets.sort(function (a, b) { return a - b; });
+  this.offsets.sort((a, b) => a - b);
 }
 
 WasmSourceMap.prototype.lookup = function (offset) {
@@ -110,11 +111,9 @@ function getSourceMap() {
 
 function getSourceMapPromise() {
   if ((ENVIRONMENT_IS_WEB || ENVIRONMENT_IS_WORKER) && typeof fetch == 'function') {
-    return fetch(wasmSourceMapFile, {{{ makeModuleReceiveExpr('fetchSettings', "{ credentials: 'same-origin' }") }}}).then(function(response) {
-      return response['json']();
-    }).catch(function () {
-      return getSourceMap();
-    });
+    return fetch(wasmSourceMapFile, {{{ makeModuleReceiveExpr('fetchSettings', "{ credentials: 'same-origin' }") }}})
+      .then((response) => response['json']())
+      .catch(() => getSourceMap());
   }
   return new Promise(function(resolve, reject) {
     resolve(getSourceMap());

--- a/tests/other/test_offset_converter.c
+++ b/tests/other/test_offset_converter.c
@@ -1,7 +1,9 @@
 #include <stdio.h>
 #include <emscripten.h>
 
-void *get_pc(void) { return __builtin_return_address(0); }
+void *get_pc(void) {
+  return __builtin_return_address(0);
+}
 
 void magic_test_function(void) {
   EM_ASM({
@@ -11,4 +13,7 @@ void magic_test_function(void) {
   puts("ok");
 }
 
-int main(void) { magic_test_function(); }
+int main(void) {
+  magic_test_function();
+  return 0;
+}

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9661,12 +9661,12 @@ int main(void) {
                             '--profiling-funcs'])
 
   @parameterized({
-    'async': ['-sWASM_ASYNC_COMPILATION'],
+    '': [],
     'sync': ['-sWASM_ASYNC_COMPILATION=0'],
   })
   def test_offset_converter(self, *args):
     self.do_runf(test_file('other/test_offset_converter.c'), 'ok',
-                 emcc_args=['-sUSE_OFFSET_CONVERTER', '-gsource-map'] + list(args))
+                 emcc_args=['-sUSE_OFFSET_CONVERTER', '--profiling-funcs'] + list(args))
 
   @no_windows('ptys and select are not available on windows')
   def test_build_error_color(self):


### PR DESCRIPTION
Offset convert doesn't itself use source maps, only name section
so it only needs `--profiling-funcs`.

Also rely on WASM_ASYNC_COMPILATION being the default.

As a followup, I plan to add some testing with LOAD_SOURCE_MAP which
is not currently used or exposed outside of sanitizers.

Also some drive by cleanups of src/source_map_support.js.

Working towards #16552.