### PR TITLE
OpenAL: fixed invalid behavior and crashes in multi-source functions

### DIFF
--- a/src/library_openal.js
+++ b/src/library_openal.js
@@ -4294,7 +4294,8 @@ var LibraryOpenAL = {
     }
 
     for (var i = 0; i < count; ++i) {
-      AL.setSourceState({{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}, 0x1012 /* AL_PLAYING */);
+      var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
+      AL.setSourceState(AL.currentCtx.sources[srcId], 0x1012 /* AL_PLAYING */);
     }
   },
 
@@ -4344,7 +4345,8 @@ var LibraryOpenAL = {
     }
 
     for (var i = 0; i < count; ++i) {
-      AL.setSourceState({{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}, 0x1014 /* AL_STOPPED */);
+      var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
+      AL.setSourceState(AL.currentCtx.sources[srcId], 0x1014 /* AL_STOPPED */);
     }
   },
 
@@ -4397,7 +4399,8 @@ var LibraryOpenAL = {
     }
 
     for (var i = 0; i < count; ++i) {
-      AL.setSourceState({{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}, 0x1011 /* AL_INITIAL */);
+      var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
+      AL.setSourceState(AL.currentCtx.sources[srcId], 0x1011 /* AL_INITIAL */);
     }
   },
 
@@ -4447,7 +4450,8 @@ var LibraryOpenAL = {
     }
 
     for (var i = 0; i < count; ++i) {
-      AL.setSourceState({{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}}, 0x1013 /* AL_PAUSED */);
+      var srcId = {{{ makeGetValue('pSourceIds', 'i*4', 'i32') }}};
+      AL.setSourceState(AL.currentCtx.sources[srcId], 0x1013 /* AL_PAUSED */);
     }
   },
 

--- a/tests/openal_playback.cpp
+++ b/tests/openal_playback.cpp
@@ -45,14 +45,33 @@ void playSource(void* arg)
 
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_PLAYING);
-  alSourcePause(source);
+
+  alSourceRewind(source);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
-  assert(state == AL_PAUSED);
+  assert(state == AL_INITIAL);
   alSourcePlay(source);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_PLAYING);
+  alSourcePause(source);
+  alGetSourcei(source, AL_SOURCE_STATE, &state);
+  assert(state == AL_PAUSED);
 #ifndef TEST_LOOPED_PLAYBACK
   alSourceStop(source);
+  alGetSourcei(source, AL_SOURCE_STATE, &state);
+  assert(state == AL_STOPPED);
+#endif
+
+  alSourceRewindv(1, &source);
+  alGetSourcei(source, AL_SOURCE_STATE, &state);
+  assert(state == AL_INITIAL);
+  alSourcePlayv(1, &source);
+  alGetSourcei(source, AL_SOURCE_STATE, &state);
+  assert(state == AL_PLAYING);
+  alSourcePausev(1, &source);
+  alGetSourcei(source, AL_SOURCE_STATE, &state);
+  assert(state == AL_PAUSED);
+#ifndef TEST_LOOPED_PLAYBACK
+  alSourceStopv(1, &source);
   alGetSourcei(source, AL_SOURCE_STATE, &state);
   assert(state == AL_STOPPED);
   test_finished();


### PR DESCRIPTION
OpenAL multi-source functions (alSourcePlayv, alSourceStopv, alSourceRewindv, alSourcePausev) were not behaving as intended, e.g. alSourcePausev never paused any sound, and alSourceStopv even crashed with `Uncaught TypeError: src.bufQueue is undefined`.

It turned out that inside those functions setting the state of the provided list of sources was actually applied on the source-ids instead of the source objects.

This was not the case for the single-source functions.

This change should also fix [#13797](https://github.com/emscripten-core/emscripten/issues/13797).