### PR TITLE
Runtime source map usage

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2787,10 +2787,7 @@ LibraryManager.library = {
     var source;
 #if LOAD_SOURCE_MAP
     if (wasmSourceMap) {
-      var info = wasmSourceMap.lookup(pc);
-      if (info) {
-        source = {file: info.source, line: info.line, column: info.column};
-      }
+      source = wasmSourceMap.lookup(pc);
     }
 #endif
 

--- a/src/settings.js
+++ b/src/settings.js
@@ -1844,6 +1844,10 @@ var ASAN_SHADOW_SIZE = -1
 // [link]
 var USE_OFFSET_CONVERTER = false;
 
+// Whether we should load the WASM source map at runtime.
+// This is enabled automatically when using -g4 with sanitizers.
+var LOAD_SOURCE_MAP = false;
+
 // If set to 1, the JS compiler is run before wasm-ld so that the linker can
 // report undefined symbols within the binary.  Without this option the linker
 // doesn't know which symbols might be defined in JS so reporting of undefined

--- a/src/settings_internal.js
+++ b/src/settings_internal.js
@@ -77,10 +77,6 @@ var USE_LSAN = false;
 // by -fsanitize=leak instead of used directly.
 var USE_ASAN = false;
 
-// Whether we should load the WASM source map at runtime.
-// This is enabled automatically when using -g4 with sanitizers.
-var LOAD_SOURCE_MAP = false;
-
 // Whether embind has been enabled.
 var EMBIND = false;
 

--- a/src/source_map_support.js
+++ b/src/source_map_support.js
@@ -73,7 +73,7 @@ WasmSourceMap.prototype.lookup = function (offset) {
     return null;
   }
   return {
-    source: this.sources[info.source],
+    file: this.sources[info.source],
     line: info.line,
     column: info.column,
     name: this.names[info.name],

--- a/tests/other/test_offset_converter.c
+++ b/tests/other/test_offset_converter.c
@@ -6,10 +6,26 @@ void *get_pc(void) {
 }
 
 void magic_test_function(void) {
+  void* pc = get_pc(); // This is line (9) and on which we fetch the PC (at column 14).
   EM_ASM({
-    var name = wasmOffsetConverter.getName($0);
+    var pc = $0;
+
+    var name = wasmOffsetConverter.getName(pc);
+    console.log('wasmOffsetConverter ' + ptrToString(pc) + ' -> ' + name);
     assert(name == 'magic_test_function', 'expected magic_test_function, got: ' + name);
-  }, get_pc());
+
+#ifdef USE_SOURCE_MAP
+    // In addtion to wasmOffsetConverter (which only uses the name section)
+    // we can also use the source map to get more accurate line info.
+    assert(typeof wasmSourceMap !== 'undefined');
+    source = wasmSourceMap.lookup(pc);
+    assert(source);
+    console.log(source);
+    assert(source.file.includes('test_offset_converter.c'));
+    assert(source.line == 9);
+    assert(source.column == 14);
+#endif
+  }, pc);
   puts("ok");
 }
 

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9698,8 +9698,21 @@ int main(void) {
     'sync': ['-sWASM_ASYNC_COMPILATION=0'],
   })
   def test_offset_converter(self, *args):
-    self.do_runf(test_file('other/test_offset_converter.c'), 'ok',
-                 emcc_args=['-sUSE_OFFSET_CONVERTER', '--profiling-funcs'] + list(args))
+    self.set_setting('USE_OFFSET_CONVERTER')
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$ptrToString'])
+    self.emcc_args += ['--profiling-funcs']
+    self.do_runf(test_file('other/test_offset_converter.c'), 'ok', emcc_args=list(args))
+
+  @parameterized({
+    '': [],
+    'sync': ['-sWASM_ASYNC_COMPILATION=0'],
+  })
+  def test_offset_converter_source_map(self, *args):
+    self.set_setting('USE_OFFSET_CONVERTER')
+    self.set_setting('LOAD_SOURCE_MAP')
+    self.set_setting('DEFAULT_LIBRARY_FUNCS_TO_INCLUDE', ['$ptrToString'])
+    self.emcc_args += ['-gsource-map', '-DUSE_SOURCE_MAP']
+    self.do_runf(test_file('other/test_offset_converter.c'), 'ok', emcc_args=list(args))
 
   @no_windows('ptys and select are not available on windows')
   def test_build_error_color(self):


### PR DESCRIPTION
This option is useful an time we want to get line information
at runtime.  For example, add debug info to stack traces.

See #16552, #16731.
