### PR TITLE
Use non-symlinked version of google-closure-compiler

### DIFF
--- a/tools/building.py
+++ b/tools/building.py
@@ -702,12 +702,15 @@ def eval_ctors(js_file, wasm_file, debug_info=False): # noqa
 
 
 def get_closure_compiler():
-  # First check if the user configured a specific CLOSURE_COMPILER in thier settings
+  # First check if the user configured a specific CLOSURE_COMPILER in their settings
   if config.CLOSURE_COMPILER:
     return config.CLOSURE_COMPILER
 
-  # Otherwise use the one installed vai npm
-  cmd = shared.get_npm_cmd('google-closure-compiler')
+  # Otherwise use the one installed via npm. We do not want to get the one
+  # in node_modules/.bin because that's a symlink, which may not work correctly in
+  # all environments (e.g. Bazel remote execution). Instead, we go to what that
+  # symlink would be pointing to directly.
+  cmd = shared.get_npm_cmd(os.path.join('google-closure-compiler', 'cli.js'), base='node_modules')
   if not WINDOWS:
     # Work around an issue that Closure compiler can take up a lot of memory and crash in an error
     # "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap

--- a/tools/building.py
+++ b/tools/building.py
@@ -706,12 +706,15 @@ def get_closure_compiler():
   if config.CLOSURE_COMPILER:
     return config.CLOSURE_COMPILER
 
-  # Otherwise use the one installed via npm. We do not want to get the one
-  # in node_modules/.bin because that's a symlink, which may not work correctly in
-  # all environments (e.g. Bazel remote execution). Instead, we go to what that
-  # symlink would be pointing to directly.
-  cmd = shared.get_npm_cmd(os.path.join('google-closure-compiler', 'cli.js'), base='node_modules')
-  if not WINDOWS:
+  # Otherwise use the one installed via npm.
+  if WINDOWS:
+    cmd = shared.get_npm_cmd('google-closure-compiler')
+  else:
+    #  We do not want to get the one in node_modules/.bin because that's a symlink, which
+    # may not work correctly in all environments (e.g. Bazel remote execution). Instead,
+    # we go to what that symlink would be pointing to directly.
+    cmd = shared.get_npm_cmd(os.path.join('node_modules', 'google-closure-compiler', 'cli.js'),
+                             direct=True)
     # Work around an issue that Closure compiler can take up a lot of memory and crash in an error
     # "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap
     # out of memory"

--- a/tools/building.py
+++ b/tools/building.py
@@ -714,7 +714,7 @@ def get_closure_compiler():
     # may not work correctly in all environments (e.g. Bazel remote execution). Instead,
     # we go to what that symlink would be pointing to directly.
     cmd = shared.get_npm_cmd(os.path.join('node_modules', 'google-closure-compiler', 'cli.js'),
-                             direct=True)
+                             relative_to_node_bin=False)
     # Work around an issue that Closure compiler can take up a lot of memory and crash in an error
     # "FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap
     # out of memory"

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -236,11 +236,20 @@ def run_js_tool(filename, jsargs=[], node_args=[], **kw):
   return check_call(command, **kw).stdout
 
 
-def get_npm_cmd(name):
+def get_npm_cmd(name, base='node_modules/.bin'):
+  """Returns a command list that executes the given npm executable.
+
+  If the file does not exist, this is because npm install was not run, so
+  we display that error to the user.
+
+  These executables are typically stored in node_modules/.bin and we
+  return a platform-specific list of a command and args that will invoke it.
+  """
   if WINDOWS:
-    cmd = [path_from_root('node_modules/.bin', name + '.cmd')]
+    cmd = [path_from_root(base, name + '.cmd')]
   else:
-    cmd = config.NODE_JS + [path_from_root('node_modules/.bin', name)]
+    # We want to invoke the script with the configured node binary.
+    cmd = config.NODE_JS + [path_from_root(base, name)]
   if not os.path.exists(cmd[-1]):
     exit_with_error(f'{name} was not found! Please run "npm install" in Emscripten root directory to set up npm dependencies')
   return cmd

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -236,7 +236,7 @@ def run_js_tool(filename, jsargs=[], node_args=[], **kw):
   return check_call(command, **kw).stdout
 
 
-def get_npm_cmd(name, base='node_modules/.bin'):
+def get_npm_cmd(name_or_path, direct=False):
   """Returns a command list that executes the given npm executable.
 
   If the file does not exist, this is because npm install was not run, so
@@ -244,14 +244,24 @@ def get_npm_cmd(name, base='node_modules/.bin'):
 
   These executables are typically stored in node_modules/.bin and we
   return a platform-specific list of a command and args that will invoke it.
+
+  If direct is False, the first argument will be treated as the name of a
+  node executable in node_modules/.bin. If direct is True, the first
+  argument will be used as a path relative to the root directory which is
+  pointing to the node executable.
   """
+  cmd_path = name_or_path
   if WINDOWS:
-    cmd = [path_from_root(base, name + '.cmd')]
+    if not direct:
+      cmd_path = os.path.join('node_modules/.bin', name_or_path + '.cmd')
+    cmd = [path_from_root(cmd_path)]
   else:
+    if not direct:
+      cmd_path = os.path.join('node_modules/.bin', name_or_path)
     # We want to invoke the script with the configured node binary.
-    cmd = config.NODE_JS + [path_from_root(base, name)]
+    cmd = config.NODE_JS + [path_from_root(cmd_path)]
   if not os.path.exists(cmd[-1]):
-    exit_with_error(f'{name} was not found! Please run "npm install" in Emscripten root directory to set up npm dependencies')
+    exit_with_error(f'{name_or_path} was not found! Please run "npm install" in Emscripten root directory to set up npm dependencies')
   return cmd
 
 

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -247,8 +247,7 @@ def get_npm_cmd(name_or_path, relative_to_node_bin=True):
 
   If relative_to_node_bin is True, the first argument will be treated as
   the name of a node executable in node_modules/.bin. If it is False, the first
-  argument will be used as a path relative to the root directory which is
-  pointing to the node executable.
+  argument will be used as a path relative to the emscripten root.
   """
   cmd_path = name_or_path
   if WINDOWS:

--- a/tools/shared.py
+++ b/tools/shared.py
@@ -236,7 +236,7 @@ def run_js_tool(filename, jsargs=[], node_args=[], **kw):
   return check_call(command, **kw).stdout
 
 
-def get_npm_cmd(name_or_path, direct=False):
+def get_npm_cmd(name_or_path, relative_to_node_bin=True):
   """Returns a command list that executes the given npm executable.
 
   If the file does not exist, this is because npm install was not run, so
@@ -245,18 +245,18 @@ def get_npm_cmd(name_or_path, direct=False):
   These executables are typically stored in node_modules/.bin and we
   return a platform-specific list of a command and args that will invoke it.
 
-  If direct is False, the first argument will be treated as the name of a
-  node executable in node_modules/.bin. If direct is True, the first
+  If relative_to_node_bin is True, the first argument will be treated as
+  the name of a node executable in node_modules/.bin. If it is False, the first
   argument will be used as a path relative to the root directory which is
   pointing to the node executable.
   """
   cmd_path = name_or_path
   if WINDOWS:
-    if not direct:
+    if relative_to_node_bin:
       cmd_path = os.path.join('node_modules/.bin', name_or_path + '.cmd')
     cmd = [path_from_root(cmd_path)]
   else:
-    if not direct:
+    if relative_to_node_bin:
       cmd_path = os.path.join('node_modules/.bin', name_or_path)
     # We want to invoke the script with the configured node binary.
     cmd = config.NODE_JS + [path_from_root(cmd_path)]


### PR DESCRIPTION
When trying to compile using emscripten/emsdk on [Bazel's remote executors](https://bazel.build/docs/remote-execution), I ran into an error like:

```
Linking ... failed: (Exit 1): emcc_link.sh failed: error executing command external/emsdk/emscripten_toolchain/emcc_link.sh @bazel-out/wasm-opt-ST-d9bb9c985c3e/bin/...-2.params
node:internal/modules/cjs/loader:936
  throw err;
  ^

Error: Cannot find module './lib/utils'
Require stack:
- /b/f/w/external/emscripten_bin_linux/emscripten/node_modules/.bin/google-closure-compiler
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:933:15)
    at Function.Module._load (node:internal/modules/cjs/loader:778:27)
    at Module.require (node:internal/modules/cjs/loader:1005:19)
    at require (node:internal/modules/cjs/helpers:94:18)
    at Object.<anonymous> (/b/f/w/external/emscripten_bin_linux/emscripten/node_modules/.bin/google-closure-compiler:20:57)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:79:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/b/f/w/external/emscripten_bin_linux/emscripten/node_modules/.bin/google-closure-compiler'
  ]
}
node:internal/modules/cjs/loader:936
  throw err;
  ^
```

By looking at the remote execution logs (e.g. appending `--execution_log_json_file=/tmp/execlog.json` to my Bazel command), I was able to figure out that Bazel was [not preserving symlinks](https://bazel.build/docs/remote-execution-rules#manage-workspace-rules) that were created by npm install, but rather uploading the linked file in place of the symlink.

Instead of uploading
```
.../node_modules/.bin/google-closure-compiler # symlink to ../google-closure-compiler/cli.js
.../node_modules/google-closure-compiler/cli.js
.../node_modules/google-closure-compiler/lib/utils.js
```
it was uploading
```
.../node_modules/.bin/google-closure-compiler # copy of ../google-closure-compiler/cli.js
.../node_modules/google-closure-compiler/cli.js
.../node_modules/google-closure-compiler/lib/utils.js
```

Then, when executing `node_modules/.bin/google-closure-compiler`, it would try to load `node_modules/.bin/lib/utils.js` and not be able to find it.

To work around this issue, we can bypass the symlink and run the google-closure-compiler/cli.js ourselves, which is successfully able to load the lib/utils.js and all other dependent files. This shouldn't impact non-Bazel clients.

https://github.com/emscripten-core/emsdk/issues/883 is possibly a related issue
