### PR TITLE
Check for too many arguments to convertJsFunctionToWasm signature

### DIFF
--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -30,6 +30,9 @@ function convertJsFunctionToWasm(func, sig) {
     }
     return new WebAssembly.Function(type, func);
   }
+  if (sig.length > 123) {
+    throw new Error(`Too many arguments! Can handle at most 122 but was given ${sig.length - 1}.`);
+  }
 
   // The module is static, with the exception of the type section, which is
   // generated based on the signature passed in.


### PR DESCRIPTION
Research shows that giving `convertJsFunctionToWasm` a signature of length > 122 triggers a compiler error like
```js
CompileError: WebAssembly.Module(): unknown type form: 123 @+13
```
this puts in a more intelligible error message in this case.