### PR TITLE
Fix convertJsFunctionToWasm when the signature has more than 122 arguments

### DIFF
--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -6,7 +6,7 @@
 
 // This gives correct answers for everything less than 2^{14} = 16384
 // I hope nobody is contemplating functions with 16384 arguments...
-function uleb128Encode(n){
+function uleb128Encode(n) {
 #if ASSERTIONS
   assert(n < 16384);
 #endif

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -7,10 +7,13 @@
 // This gives correct answers for everything less than 2^{14} = 16384
 // I hope nobody is contemplating functions with 16384 arguments...
 function uleb128Encode(n){
-  if(n < 128) {
+#ASSERTIONS
+  assert(n < 16384);
+#endif
+  if (n < 128) {
       return [n];
   }
-  return [(n % 128) + 128, n >> 7];
+  return [(n % 128) | 128, n >> 7];
 }
 
 

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -4,6 +4,16 @@
  * SPDX-License-Identifier: MIT
  */
 
+// This gives correct answers for everything less than 2^{14} = 16384
+// I hope nobody is contemplating functions with 16384 arguments...
+function uleb128Encode(n){
+  if(n < 128) {
+      return [n];
+  }
+  return [(n % 128) + 128, n >> 7];
+}
+
+
 // Wraps a JS function as a wasm function with a given signature.
 function convertJsFunctionToWasm(func, sig) {
 #if WASM2JS
@@ -34,8 +44,6 @@ function convertJsFunctionToWasm(func, sig) {
   // The module is static, with the exception of the type section, which is
   // generated based on the signature passed in.
   var typeSection = [
-    0x01, // id: section,
-    0x00, // length: 0 (placeholder)
     0x01, // count: 1
     0x60, // form: func
   ];
@@ -49,7 +57,7 @@ function convertJsFunctionToWasm(func, sig) {
   };
 
   // Parameters, length + signatures
-  typeSection.push(sigParam.length);
+  typeSection = typeSection.concat(uleb128Encode(sigParam.length));
   for (var i = 0; i < sigParam.length; ++i) {
     typeSection.push(typeCodes[sigParam[i]]);
   }
@@ -62,9 +70,12 @@ function convertJsFunctionToWasm(func, sig) {
     typeSection = typeSection.concat([0x01, typeCodes[sigRet]]);
   }
 
-  // Write the overall length of the type section back into the section header
-  // (excepting the 2 bytes for the section id and length)
-  typeSection[1] = typeSection.length - 2;
+  // Write the section code and overall length of the type section into the
+  // section header
+  typeSection = [0x01 /* Type section code */].concat(
+    uleb128Encode(typeSection.length),
+    typeSection
+  );
 
   // Rest of the module is static
   var bytes = new Uint8Array([

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -11,7 +11,7 @@ function uleb128Encode(n) {
   assert(n < 16384);
 #endif
   if (n < 128) {
-      return [n];
+    return [n];
   }
   return [(n % 128) | 128, n >> 7];
 }

--- a/src/runtime_functions.js
+++ b/src/runtime_functions.js
@@ -7,7 +7,7 @@
 // This gives correct answers for everything less than 2^{14} = 16384
 // I hope nobody is contemplating functions with 16384 arguments...
 function uleb128Encode(n){
-#ASSERTIONS
+#if ASSERTIONS
   assert(n < 16384);
 #endif
   if (n < 128) {


### PR DESCRIPTION
With this patch, `convertJsFunctionToWasm` works correctly with up to 1000 arguments. Called with 1001 arguments, Chrome, Firefox, and Node all agree that `WebAssembly.Module(): param count of 1001 exceeds internal limit of 1000`