### PR TITLE
fix __rootpath__ handling to match what emsdk does

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 from . import diagnostics
 
-__rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
+__rootpath__ = os.path.abspath(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
 WINDOWS = sys.platform.startswith('win')
 MACOS = sys.platform == 'darwin'
 LINUX = sys.platform.startswith('linux')


### PR DESCRIPTION
`emsdk.py` passes the root path through  `os.path.realpath` to get the fully resolved path, but it also has the effect of normalizing case on Windows. For example `d:\SOmE\test.txt` becomes `D:\Some\test.txt` if that's what's stored on the file system. So running `emsdk_env` always sets up the correct case for the path.

Calling `emcc` directly without running emsdk_env first will make it find EM_CONFIG via `utils.py` which it will do without passing it through `os.path.realpath` so it won't normalize the case which will then cause the sanity check to fail and the cache will be cleared.

And these two will keep fighting and the emscripten cache will keep getting wiped out.

Doing the same `os.path.realpath` in `utils.py` fixes this.

My specific case was VS Code (normalizes drive letter to lower case) running CMake passing in the Emscripten toolchain and then Ninja which actually run a bunch of `emcc` in parallel. To make matters worse, only the first few compiles were executed with lowercase drive letter, the rest of the hundreds were all upper case so it managed to nuke itself basically :) 

Yeah, I know, **all file systems should be case sensitive** but we have what we have 😭 

_Putting this PR up to see if it tests succeed on all platforms_