### PR TITLE
Fix create-stream breakage introduced by #14808

### DIFF
--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -429,11 +429,8 @@ FS.staticInit();` +
       }
       // clone it, so we can return an instance of FSStream
       stream = Object.assign(new FS.FSStream(), stream);
-      var fd = stream.fd;
-      if (fd === undefined) {
-        fd = FS.nextfd(fd_start, fd_end);
-        stream.fd = fd;
-      }
+      var fd = FS.nextfd(fd_start, fd_end);
+      stream.fd = fd;
       FS.streams[fd] = stream;
       return stream;
     },

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -429,8 +429,11 @@ FS.staticInit();` +
       }
       // clone it, so we can return an instance of FSStream
       stream = Object.assign(new FS.FSStream(), stream);
-      var fd = FS.nextfd(fd_start, fd_end);
-      stream.fd = fd;
+      var fd = stream.fd;
+      if(fd === undefined){
+        fd = FS.nextfd(fd_start, fd_end);
+        stream.fd = fd;
+      }
       FS.streams[fd] = stream;
       return stream;
     },

--- a/src/library_fs.js
+++ b/src/library_fs.js
@@ -430,7 +430,7 @@ FS.staticInit();` +
       // clone it, so we can return an instance of FSStream
       stream = Object.assign(new FS.FSStream(), stream);
       var fd = stream.fd;
-      if(fd === undefined){
+      if (fd === undefined) {
         fd = FS.nextfd(fd_start, fd_end);
         stream.fd = fd;
       }

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -96,7 +96,7 @@ mergeInto(LibraryManager.library, {
       var newMode = NODEFS.getMode(pathTruncated);
       var fd = suggestFD != null ? suggestFD : FS.nextfd(nfd);
       var node = { id: st.ino, mode: newMode, node_ops: NODERAWFS, path: path }
-      var stream = FS.createStream({ fd: fd, nfd: nfd, position: 0, path: path, flags: flags, node: node, seekable: true });
+      var stream = FS.createStream({ nfd: nfd, position: 0, path: path, flags: flags, node: node, seekable: true }, fd, fd + 1);
       FS.streams[fd] = stream;
       return stream;
     },

--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -96,7 +96,7 @@ mergeInto(LibraryManager.library, {
       var newMode = NODEFS.getMode(pathTruncated);
       var fd = suggestFD != null ? suggestFD : FS.nextfd(nfd);
       var node = { id: st.ino, mode: newMode, node_ops: NODERAWFS, path: path }
-      var stream = FS.createStream({ nfd: nfd, position: 0, path: path, flags: flags, node: node, seekable: true }, fd, fd + 1);
+      var stream = FS.createStream({ nfd: nfd, position: 0, path: path, flags: flags, node: node, seekable: true }, fd, fd);
       FS.streams[fd] = stream;
       return stream;
     },


### PR DESCRIPTION
If the stream argument to `fd.createStream` already has an `fd` attribute, we don't want to overwrite it. This was causing `test_unistd_truncate_noderawfs` to fail.