### PR TITLE
[WasmFS] Stub ioctl()/terminal support

### DIFF
--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -90,10 +90,12 @@ long __syscall_openat(int dirfd, const char* path, long flags, ...) {
   return -EPERM;
 }
 
+__attribute__((__weak__))
 int __syscall_ioctl(int fd, int op, ...) {
   return -ENOSYS;
 }
 
+__attribute__((__weak__))
 long __syscall_fcntl64(long fd, long cmd, ...) {
   return -ENOSYS;
 }

--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -90,13 +90,11 @@ long __syscall_openat(int dirfd, const char* path, long flags, ...) {
   return -EPERM;
 }
 
-__attribute__((__weak__))
-int __syscall_ioctl(int fd, int op, ...) {
+__attribute__((__weak__)) int __syscall_ioctl(int fd, int op, ...) {
   return -ENOSYS;
 }
 
-__attribute__((__weak__))
-long __syscall_fcntl64(long fd, long cmd, ...) {
+__attribute__((__weak__)) long __syscall_fcntl64(long fd, long cmd, ...) {
   return -ENOSYS;
 }
 

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1115,7 +1115,8 @@ int __syscall_ftruncate64(int fd, uint64_t size) {
 static bool isTTY(std::shared_ptr<File>& file) {
   // TODO: Full TTY support. For now, just see stdin/out/err as terminals and
   //       nothing else.
-  return file == Stdin::getSingleton() || file == Stdout::getSingleton() || file == Stderr::getSingleton();
+  return file == Stdin::getSingleton() || file == Stdout::getSingleton() ||
+         file == Stderr::getSingleton();
 }
 
 int __syscall_ioctl(int fd, int request, ...) {

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1115,7 +1115,7 @@ int __syscall_ftruncate64(int fd, uint64_t size) {
 static bool isTTY(int fd) {
   // TODO: Full TTY support. For now, just see stdin/out/err as terminals and
   //       nothing else.
-  return fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO; 
+  return fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO;
 }
 
 int __syscall_ioctl(int fd, int request, ...) {

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -27,6 +27,7 @@
 #include "file_table.h"
 #include "paths.h"
 #include "pipe_backend.h"
+#include "streams.h"
 #include "wasmfs.h"
 
 // File permission macros for wasmfs.
@@ -1115,8 +1116,9 @@ int __syscall_ftruncate64(int fd, uint64_t size) {
 static bool isTTY(std::shared_ptr<File>& file) {
   // TODO: Full TTY support. For now, just see stdin/out/err as terminals and
   //       nothing else.
-  return file == Stdin::getSingleton() || file == Stdout::getSingleton() ||
-         file == Stderr::getSingleton();
+  return file == StdinFile::getSingleton() ||
+         file == StdoutFile::getSingleton() ||
+         file == StderrFile::getSingleton();
 }
 
 int __syscall_ioctl(int fd, int request, ...) {
@@ -1124,7 +1126,7 @@ int __syscall_ioctl(int fd, int request, ...) {
   if (!openFile) {
     return -EBADF;
   }
-  if (!isTTY(openFile.locked().getFile())) {
+  if (!isTTY(openFile->locked().getFile())) {
     return -ENOTTY;
   }
   // TODO: Full TTY support. For now this is limited, and matches the old FS.

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1112,10 +1112,10 @@ int __syscall_ftruncate64(int fd, uint64_t size) {
   return ret;
 }
 
-static bool isTTY(int fd) {
+static bool isTTY(std::shared_ptr<File>& file) {
   // TODO: Full TTY support. For now, just see stdin/out/err as terminals and
   //       nothing else.
-  return fd == STDIN_FILENO || fd == STDOUT_FILENO || fd == STDERR_FILENO;
+  return file == Stdin::getSingleton() || file == Stdout::getSingleton() || file == Stderr::getSingleton();
 }
 
 int __syscall_ioctl(int fd, int request, ...) {
@@ -1123,7 +1123,7 @@ int __syscall_ioctl(int fd, int request, ...) {
   if (!openFile) {
     return -EBADF;
   }
-  if (!isTTY(fd)) {
+  if (!isTTY(openFile.locked().getFile())) {
     return -ENOTTY;
   }
   // TODO: Full TTY support. For now this is limited, and matches the old FS.

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -21,7 +21,6 @@
 #include <utility>
 #include <vector>
 #include <wasi/api.h>
-#include <syscall_arch.h>
 
 #include "backend.h"
 #include "file.h"

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -8163,6 +8163,7 @@ end
     out = self.run_process([EMCC, '--help'], stdout=PIPE).stdout
     assert re.search(expected, out)
 
+  @also_with_wasmfs
   def test_ioctl_window_size(self):
       self.do_other_test('test_ioctl_window_size.cpp')
 
@@ -10283,6 +10284,7 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
 ''')
     self.run_process([EMCC, 'errno_type.c'])
 
+  @also_with_wasmfs
   def test_standalone_syscalls(self):
     self.run_process([EMXX, test_file('other/test_standalone_syscalls.cpp'), '-o', 'test.wasm'])
     expected = read_file(test_file('other/test_standalone_syscalls.out'))


### PR DESCRIPTION
We don't have TTY support in emscripten anyhow, so most of this just
does nothing. We also do not yet have a concept of TTYs in wasmfs,
so just recognize stdin/out/err as such. This is enough for basic things,
gets some tests passing, and is almost at parity with the old FS (it had
the ability to create new terminals and mark them as such).