### PR TITLE
Update pthread stub signatures

### DIFF
--- a/system/lib/pthread/library_pthread_stub.c
+++ b/system/lib/pthread/library_pthread_stub.c
@@ -285,11 +285,11 @@ int pthread_attr_destroy(pthread_attr_t *attr) {
   return 0;
 }
 
-int pthread_setcancelstate() {
+int pthread_setcancelstate(int state, int* oldstate) {
   return 0;
 }
 
-int pthread_setcanceltype() {
+int pthread_setcanceltype(int type, int* oldtype) {
   return 0;
 }
 

--- a/system/lib/pthread/pthread_create.c
+++ b/system/lib/pthread/pthread_create.c
@@ -66,7 +66,7 @@ static void init_file_lock(FILE *f) {
 static pid_t next_tid = 0;
 
 // In case the stub syscall is not linked it
-static int dummy_getpid() {
+static int dummy_getpid(void) {
   return 42;
 }
 weak_alias(dummy_getpid, __syscall_getpid);


### PR DESCRIPTION
pthread_setcancelstate and pthread_setcanceltype previously did not have any
arguments in library_pthread_stub.c. Fix them to take the proper arguments.