### PR TITLE
Compile libpng with shared memory when using pthreads

### DIFF
--- a/embuilder.py
+++ b/embuilder.py
@@ -70,6 +70,7 @@ PORT_VARIANTS = {
     'sdl2_mixer_none': ('sdl2_mixer', {'SDL2_MIXER_FORMATS': []}),
     'sdl2_image_png': ('sdl2_image', {'SDL2_IMAGE_FORMATS': ["png"]}),
     'sdl2_image_jpg': ('sdl2_image', {'SDL2_IMAGE_FORMATS': ["jpg"]}),
+    'libpng-mt': ('libpng', {'USE_PTHREADS': 1}),
 }
 
 PORTS = sorted(list(ports.ports_by_name.keys()) + list(PORT_VARIANTS.keys()))

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -1818,6 +1818,13 @@ int f() {
     output = self.run_js('a.out.js')
     self.assertContained('libpng passes test', output)
 
+  @node_pthreads
+  def test_libpng_with_pthreads(self):
+    shutil.copyfile(test_file('third_party/libpng/pngtest.png'), 'pngtest.png')
+    self.emcc(test_file('third_party/libpng/pngtest.c'), ['--embed-file', 'pngtest.png', '-sUSE_LIBPNG', '-sUSE_PTHREADS'], output_filename='a.out.js')
+    output = self.run_js('a.out.js')
+    self.assertContained('libpng passes test', output)
+
   def test_giflib(self):
     shutil.copyfile(test_file('third_party/giflib/treescap.gif'), 'treescap.gif')
     self.emcc(test_file('third_party/giflib/giftext.c'), ['--embed-file', 'treescap.gif', '-sUSE_GIFLIB'], output_filename='a.out.js')

--- a/tools/ports/libpng.py
+++ b/tools/ports/libpng.py
@@ -18,6 +18,10 @@ def needed(settings):
   return settings.USE_LIBPNG
 
 
+def get_lib_name(settings):
+  return 'libpng' + ('-mt' if settings.USE_PTHREADS else '') + '.a'
+
+
 def get(ports, settings, shared):
   # This is an emscripten-hosted mirror of the libpng repo from Sourceforge.
   ports.fetch_project('libpng', 'https://storage.googleapis.com/webassembly/emscripten-ports/libpng-' + TAG + '.tar.gz', 'libpng-' + TAG, sha512hash=HASH)
@@ -34,13 +38,17 @@ def get(ports, settings, shared):
     Path(dest_path, 'pnglibconf.h').write_text(pnglibconf_h)
     ports.install_headers(dest_path)
 
-    ports.build_port(dest_path, final, flags=['-sUSE_ZLIB=1'], exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
+    flags = ['-sUSE_ZLIB=1']
+    if settings.USE_PTHREADS:
+      flags += ['-sUSE_PTHREADS=1']
 
-  return [shared.Cache.get_lib('libpng.a', create, what='port')]
+    ports.build_port(dest_path, final, flags=flags, exclude_files=['pngtest'], exclude_dirs=['scripts', 'contrib'])
+
+  return [shared.Cache.get_lib(get_lib_name(settings), create, what='port')]
 
 
 def clear(ports, settings, shared):
-  shared.Cache.erase_lib('libpng.a')
+  shared.Cache.erase_lib(get_lib_name(settings))
 
 
 def process_dependencies(settings):


### PR DESCRIPTION
Fixes #16681

Bisect [here](https://github.com/emscripten-core/emscripten/issues/16681#issuecomment-1095987697)

~This patch always builds libpng with `-pthread`. The alternative is to build a `-mt` variant, but the last time this issue happened @sbc100 [suggested](https://github.com/emscripten-core/emscripten/pull/16546#issuecomment-1075323826) this as the better approach.~

This patch builds a `-mt` variant with shared memory iff USE_PTHREAD is defined.