### PR TITLE
Fix malloc() to work with -sWASM_WORKERS

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -2136,6 +2136,10 @@ def phase_linker_setup(options, state, newargs, user_settings):
       settings.WASM_WORKER_FILE = unsuffixed(os.path.basename(target)) + '.ww.js'
     settings.JS_LIBRARIES.append((0, shared.path_from_root('src', 'library_wasm_worker.js')))
 
+    if 'MALLOC' in user_settings and 'dlmalloc' in user_settings['MALLOC']:
+      exit_with_error('dlmalloc does not work with Wasm Workers! Please remove -sMALLOC=dlmalloc')
+    default_setting(user_settings, 'MALLOC', 'emmalloc')
+
   if settings.FORCE_FILESYSTEM and not settings.MINIMAL_RUNTIME:
     # when the filesystem is forced, we export by default methods that filesystem usage
     # may need, including filesystem usage from standalone file packager output (i.e.

--- a/src/library_wasm_worker.js
+++ b/src/library_wasm_worker.js
@@ -367,7 +367,7 @@ mergeInto(LibraryManager.library, {
                                           val - num /* Acquire 'num' of them */);
         if (ret == val) return dispatch(ret/*index of resource acquired*/, 0/*'ok'*/);
         val = ret;
-        let wait = Atomics['waitAsync'](HEAPU32, sem >> 2, ret, maxWaitMilliseconds);
+        var wait = Atomics['waitAsync'](HEAPU32, sem >> 2, ret, maxWaitMilliseconds);
       } while(wait.value === 'not-equal');
 #if ASSERTIONS
       assert(wait.async || wait.value === 'timed-out');

--- a/system/lib/emmalloc.c
+++ b/system/lib/emmalloc.c
@@ -97,7 +97,7 @@ typedef struct Region
   uint32_t _at_the_end_of_this_struct_size; // do not dereference, this is present for convenient struct sizeof() computation only
 } Region;
 
-#if defined(__EMSCRIPTEN_PTHREADS__)
+#if defined(__EMSCRIPTEN_PTHREADS__) || defined(__EMSCRIPTEN_WASM_WORKERS__)
 // In multithreaded builds, use a simple global spinlock strategy to acquire/release access to the memory allocator.
 static volatile uint8_t multithreadingLock = 0;
 #define MALLOC_ACQUIRE() while(__sync_lock_test_and_set(&multithreadingLock, 1)) { while(multithreadingLock) { /*nop*/ } }

--- a/system/lib/wasm_worker/library_wasm_worker.c
+++ b/system/lib/wasm_worker/library_wasm_worker.c
@@ -22,7 +22,8 @@ __attribute__((constructor(48)))
 static void emscripten_wasm_worker_main_thread_initialize() {
 	uintptr_t* sbrk_ptr = emscripten_get_sbrk_ptr();
 	__wasm_init_tls((void*)*sbrk_ptr);
-	*sbrk_ptr += __builtin_wasm_tls_size();
+	assert(*sbrk_ptr % 4 == 0); // sbrk value must always be a multiple of four bytes.
+	*sbrk_ptr += (__builtin_wasm_tls_size() + 3) & -4; // round TLS up to next 4 bytes to retain correct sbrk rounding.
 }
 
 emscripten_wasm_worker_t emscripten_create_wasm_worker(void *stackLowestAddress, uint32_t stackSize)

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -5288,6 +5288,11 @@ Stack dump:
   def test_wasm_worker_semaphore_try_acquire(self):
     self.btest(test_file('wasm_worker/semaphore_try_acquire.c'), expected='0', args=['-sWASM_WORKERS'])
 
+  # Tests that operating malloc from Wasm Workers is thread-safe.
+  @also_with_minimal_runtime
+  def test_wasm_worker_thread_safe_malloc(self):
+    self.btest(test_file('wasm_worker/thread_safe_malloc.cpp'), expected='0', args=['-sWASM_WORKERS', '-DEMMALLOC'])
+
   @no_firefox('no 4GB support yet')
   @require_v8
   def test_zzz_zzz_4gb(self):

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11847,6 +11847,15 @@ void foo() {}
   def test_wasm_worker_preprocessor_flags(self):
     self.run_process([EMCC, '-c', test_file('wasm_worker/wasm_worker_preprocessor_flags.c'), '-sWASM_WORKERS'])
 
+  # Tests that Wasm Workers are properly detected not to (at least for now) work with dlmalloc
+  @also_with_minimal_runtime
+  def test_wasm_worker_dlmalloc_not_supported(self):
+    # Using dlmalloc should produce a build error
+    stderr = self.run_process([EMCC, test_file('hello_world.c'), '-sWASM_WORKERS', '-sMALLOC=dlmalloc'], stderr=PIPE, check=False).stderr
+    self.assertContained('dlmalloc does not work with Wasm Workers! Please remove -sMALLOC=dlmalloc', stderr)
+    # Using emmalloc should compile ok
+    self.run_process([EMCC, test_file('hello_world.c'), '-sWASM_WORKERS', '-sMALLOC=emmalloc'])
+
   def test_debug_opt_warning(self):
     err = self.expect_fail([EMCC, test_file('hello_world.c'), '-O2', '-g', '-Werror'])
     self.assertContained('error: running limited binaryen optimizations because DWARF info requested (or indirectly required) [-Wlimited-postlink-optimizations]', err)

--- a/tests/wasm_worker/thread_safe_malloc.cpp
+++ b/tests/wasm_worker/thread_safe_malloc.cpp
@@ -1,0 +1,45 @@
+#include <emscripten.h>
+#include <emscripten/wasm_worker.h>
+#include <emscripten/threading.h>
+#include <emscripten/emmalloc.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+
+// Tests that operating malloc from Wasm Workers is thread-safe.
+
+emscripten_semaphore_t workDone = EMSCRIPTEN_SEMAPHORE_T_STATIC_INITIALIZER(0);
+
+void work()
+{
+  for(int i = 0; i < 100000; ++i)
+  {
+    void *ptr = malloc(emscripten_random() * 10000);
+    assert(ptr);
+    free(ptr);
+  }
+  emscripten_semaphore_release(&workDone, 1);
+}
+
+void allThreadsDone(volatile void *address, uint32_t idx, ATOMICS_WAIT_RESULT_T result, void *userData)
+{
+#ifdef EMMALLOC
+  assert(emmalloc_validate_memory_regions() == 0);
+#endif
+  printf("Test passed!\n");
+#ifdef REPORT_RESULT
+  REPORT_RESULT(0);
+#endif
+}
+
+int main()
+{
+#define NUM_THREADS 10
+  for(int i = 0; i < NUM_THREADS; ++i)
+  {
+    emscripten_wasm_worker_t worker = emscripten_malloc_wasm_worker(1024);
+    emscripten_wasm_worker_post_function_v(worker, work);
+  }
+
+  emscripten_semaphore_async_acquire(&workDone, NUM_THREADS, allThreadsDone, 0, EMSCRIPTEN_WAIT_ASYNC_INFINITY);
+}


### PR DESCRIPTION
Fix malloc() to work with -sWASM_WORKERS. Currently only emmalloc will work with Wasm Workers, but dlmalloc does not yet work. Fix emscripten_semaphore_async_acquire(). Add a test.