### PR TITLE
[WasmFS] fcntl()

### DIFF
--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -61,12 +61,8 @@ WebAssembly = {
     // the main JS
   },
 
-  // Note that Instance must not be minified by closure as it will be used by
-  // workers in the case of pthreads: workers get the Module and will create an
-  // Instance of it, so WebAssembly.Instance is the one API they must be able to
-  // call.
   /** @constructor */
-  'Instance': function(module, info) {
+  Instance: function(module, info) {
     // TODO: use the module and info somehow - right now the wasm2js output is embedded in
     // the main JS
     // This will be replaced by the actual wasm2js code.
@@ -81,7 +77,7 @@ WebAssembly = {
 #if SHARED_MEMORY
           'module': module,
 #endif
-          'instance': new WebAssembly['Instance'](module)
+          'instance': new WebAssembly.Instance(module)
         });
 #if ASSERTIONS || WASM == 2 // see postamble_minimal.js which uses .catch
         // Emulate a simple WebAssembly.instantiate(..).then(()=>{}).catch(()=>{}) syntax.

--- a/src/wasm2js.js
+++ b/src/wasm2js.js
@@ -61,8 +61,12 @@ WebAssembly = {
     // the main JS
   },
 
+  // Note that Instance must not be minified by closure as it will be used by
+  // workers in the case of pthreads: workers get the Module and will create an
+  // Instance of it, so WebAssembly.Instance is the one API they must be able to
+  // call.
   /** @constructor */
-  Instance: function(module, info) {
+  'Instance': function(module, info) {
     // TODO: use the module and info somehow - right now the wasm2js output is embedded in
     // the main JS
     // This will be replaced by the actual wasm2js code.
@@ -77,7 +81,7 @@ WebAssembly = {
 #if SHARED_MEMORY
           'module': module,
 #endif
-          'instance': new WebAssembly.Instance(module)
+          'instance': new WebAssembly['Instance'](module)
         });
 #if ASSERTIONS || WASM == 2 // see postamble_minimal.js which uses .catch
         // Emulate a simple WebAssembly.instantiate(..).then(()=>{}).catch(()=>{}) syntax.

--- a/system/lib/standalone/standalone.c
+++ b/system/lib/standalone/standalone.c
@@ -68,11 +68,18 @@ const unsigned char * __map_file(const char *pathname, size_t *size) {
   return NULL;
 }
 
-long _mmap_js(long addr, long length, long prot, long flags, long fd, long offset, int* allocated) {
+long _mmap_js(long addr,
+              long length,
+              long prot,
+              long flags,
+              long fd,
+              long offset,
+              int* allocated) {
   return -ENOSYS;
 }
 
-long _munmap_js(long addr, long length, long prot, long flags, long fd, long offset) {
+long _munmap_js(
+  long addr, long length, long prot, long flags, long fd, long offset) {
   return -ENOSYS;
 }
 
@@ -82,11 +89,17 @@ long _munmap_js(long addr, long length, long prot, long flags, long fd, long off
 // open()
 // Mark this as weak so that wasmfs does not collide with it. That is, if wasmfs
 // is in use, we want to use that and not this.
-__attribute__((__weak__))
-long __syscall_openat(int dirfd, const char* path, long flags, ...) {
-  if (!strcmp(path, "/dev/stdin")) return STDIN_FILENO;
-  if (!strcmp(path, "/dev/stdout")) return STDOUT_FILENO;
-  if (!strcmp(path, "/dev/stderr")) return STDERR_FILENO;
+__attribute__((__weak__)) long
+__syscall_openat(int dirfd, const char* path, long flags, ...) {
+  if (!strcmp(path, "/dev/stdin")) {
+    return STDIN_FILENO;
+  }
+  if (!strcmp(path, "/dev/stdout")) {
+    return STDOUT_FILENO;
+  }
+  if (!strcmp(path, "/dev/stderr")) {
+    return STDERR_FILENO;
+  }
   return -EPERM;
 }
 

--- a/system/lib/wasmfs/file_table.h
+++ b/system/lib/wasmfs/file_table.h
@@ -32,7 +32,7 @@ template<typename T> bool addWillOverFlow(T a, T b) {
 class OpenFileState : public std::enable_shared_from_this<OpenFileState> {
   std::shared_ptr<File> file;
   off_t position;
-  const oflags_t flags; // RD_ONLY, WR_ONLY, RDWR
+  oflags_t flags; // RD_ONLY, WR_ONLY, RDWR
   // An OpenFileState needs a mutex if there are concurrent accesses on one open
   // file descriptor. This could occur if there are multiple seeks on the same
   // open file descriptor.
@@ -62,15 +62,14 @@ public:
 
     std::shared_ptr<File>& getFile() { return openFileState->file; };
 
-    off_t getPosition() { return openFileState->position; };
+    off_t getPosition() const { return openFileState->position; };
     void setPosition(off_t pos) { openFileState->position = pos; };
+
+    oflags_t getFlags() const { return openFileState->flags; };
+    void setFlags(oflags_t flags) { openFileState->flags = flags; };
   };
 
   Handle locked() { return Handle(shared_from_this()); }
-
-  // Return the flags we were created with. This does not require a lock as the
-  // flags never change after creation.
-  oflags_t getFlags() const { return flags; }
 };
 
 class FileTable {

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1341,7 +1341,14 @@ int __syscall_fcntl64(int fd, int cmd, ...) {
       va_start(v1, cmd);
       flags = va_arg(v1, int);
       va_end(v1);
-      // TODO: check validity
+      // This syscall should ignore most flags.
+      flags = flags & ~(O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL | O_NOCTTY | O_TRUNC);
+      // On linux only a few flags can be modified, and we support only a subset
+      // of those. Error on anything else.
+      auto supportedFlags = flags & O_APPEND;
+      if (flags != suportedFlags) {
+        return -EINVAL;
+      }
       openFile->locked().setFlags(flags);
       return 0;
     }

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1344,10 +1344,13 @@ int __syscall_fcntl64(int fd, int cmd, ...) {
       // This syscall should ignore most flags.
       flags = flags & ~(O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL |
                         O_NOCTTY | O_TRUNC);
+      // Also ignore this flag which musl always adds constantly, but does not
+      // matter for us.
+      flags = flags & ~O_LARGEFILE;
       // On linux only a few flags can be modified, and we support only a subset
       // of those. Error on anything else.
       auto supportedFlags = flags & O_APPEND;
-      if (flags != suportedFlags) {
+      if (flags != supportedFlags) {
         return -EINVAL;
       }
       openFile->locked().setFlags(flags);

--- a/system/lib/wasmfs/syscalls.cpp
+++ b/system/lib/wasmfs/syscalls.cpp
@@ -1342,7 +1342,8 @@ int __syscall_fcntl64(int fd, int cmd, ...) {
       flags = va_arg(v1, int);
       va_end(v1);
       // This syscall should ignore most flags.
-      flags = flags & ~(O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL | O_NOCTTY | O_TRUNC);
+      flags = flags & ~(O_RDONLY | O_WRONLY | O_RDWR | O_CREAT | O_EXCL |
+                        O_NOCTTY | O_TRUNC);
       // On linux only a few flags can be modified, and we support only a subset
       // of those. Error on anything else.
       auto supportedFlags = flags & O_APPEND;

--- a/tests/fcntl/test_fcntl.c
+++ b/tests/fcntl/test_fcntl.c
@@ -62,15 +62,15 @@ int main() {
   printf("\n");
   errno = 0;
 
-  printf("F_SETLK: %d\n", fcntl(f, F_SETLK, &lk));
-  printf("errno: %d\n", errno);
-  printf("\n");
-  errno = 0;
+#ifndef WASMFS // TODO: wasmfs support for byte offset locking.
+  int err = fcntl(f, F_SETLK, &lk);
+  assert(err == 0);
+  assert(errno == 0);
 
-  printf("F_SETLKW: %d\n", fcntl(f, F_SETLK, &lk));
-  printf("errno: %d\n", errno);
-  printf("\n");
-  errno = 0;
+  err = fcntl(f, F_SETLK, &lk);
+  assert(err == 0);
+  assert(errno == 0);
+#endif
 
   printf("F_SETOWN: %d\n", fcntl(f, F_SETOWN, 123));
   printf("errno: %d\n", errno);

--- a/tests/fcntl/test_fcntl.out
+++ b/tests/fcntl/test_fcntl.out
@@ -26,12 +26,6 @@ F_GETLK: 0
 errno: 0
 lk.l_type == F_UNLCK: 1
 
-F_SETLK: 0
-errno: 0
-
-F_SETLKW: 0
-errno: 0
-
 F_SETOWN: -1
 errno: 28
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2576,6 +2576,11 @@ The current type of b is: 9
   def test_pthread_proxying(self):
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('PROXY_TO_PTHREAD')
+    if self.is_wasm2js():
+      # Add one test of wasm2js + closure in the default test suites that run on
+      # the bots (they only run wasm2js1 atm, and by default we don't run
+      # closure on -O1 builds).
+      self.emcc_args += ['--closure=1']
     self.set_setting('INITIAL_MEMORY=32mb')
     args = [f'-I{path_from_root("system/lib/pthread")}']
     self.do_run_in_out_file_test('pthread/test_pthread_proxying.c',

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5459,10 +5459,12 @@ main( int argv, char ** argc ) {
   def test_stat_mknod(self):
     self.do_runf(test_file('stat/test_mknod.c'), 'success')
 
+  @also_with_wasmfs
   def test_fcntl(self):
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
     self.do_run_in_out_file_test('fcntl/test_fcntl.c')
 
+  @also_with_wasmfs
   def test_fcntl_open(self):
     self.do_run_in_out_file_test('fcntl/test_fcntl_open.c')
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2576,11 +2576,6 @@ The current type of b is: 9
   def test_pthread_proxying(self):
     self.set_setting('EXIT_RUNTIME')
     self.set_setting('PROXY_TO_PTHREAD')
-    if self.is_wasm2js():
-      # Add one test of wasm2js + closure in the default test suites that run on
-      # the bots (they only run wasm2js1 atm, and by default we don't run
-      # closure on -O1 builds).
-      self.emcc_args += ['--closure=1']
     self.set_setting('INITIAL_MEMORY=32mb')
     args = [f'-I{path_from_root("system/lib/pthread")}']
     self.do_run_in_out_file_test('pthread/test_pthread_proxying.c',
@@ -5464,7 +5459,6 @@ main( int argv, char ** argc ) {
     self.add_pre_run("FS.createDataFile('/', 'test', 'abcdef', true, true, false);")
     self.do_run_in_out_file_test('fcntl/test_fcntl.c')
 
-  @also_with_wasmfs
   def test_fcntl_open(self):
     self.do_run_in_out_file_test('fcntl/test_fcntl_open.c')
 


### PR DESCRIPTION
Fixes #15970

Changes flags to be behind a lock on file table entries, as now they can
be modified.

This basically matches the JS FS state, except that it does not claim to
support byte-range locks. As wasmfs is meant to support multithreading
well it seems best to not lie about that and return an error for now, until
we implement that (do we plan to?)