### PR TITLE
[WasmFS] Dynamic linking fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ jobs:
       - run-tests-linux:
           # also add a little select testing for wasm2js in -O3
           # also add a little select wasmfs testing
-          test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink wasmfs.test_utime wasmfs.test_unistd_unlink wasmfs.test_unistd_access wasmfs.test_unistd_close wasmfs.test_unistd_truncate wasmfs.test_readdir wasmfs.test_unistd_pipe wasmfs.test_dlfcn_self"
+          test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink wasmfs.test_utime wasmfs.test_unistd_unlink wasmfs.test_unistd_access wasmfs.test_unistd_close wasmfs.test_unistd_truncate wasmfs.test_readdir wasmfs.test_unistd_pipe wasmfs.test_dlfcn_self wasmfs.test_dlfcn_unique_sig wasmfs.test_dylink_basics"
   test-wasm2js1:
     executor: bionic
     steps:

--- a/src/modules.js
+++ b/src/modules.js
@@ -326,11 +326,16 @@ function isFSPrefixed(name) {
 
 // forcing the filesystem exports a few things by default
 function isExportedByForceFilesystem(name) {
+  if (!WASMFS) {
+    // The old FS has some functionality that WasmFS lacks.
+    if (name === 'FS_createLazyFile' ||
+        name === 'FS_createDevice') {
+      return true;
+    }
+  }
   return name === 'FS_createPath' ||
          name === 'FS_createDataFile' ||
          name === 'FS_createPreloadedFile' ||
-         name === 'FS_createLazyFile' ||
-         name === 'FS_createDevice' ||
          name === 'FS_unlink' ||
          name === 'addRunDependency' ||
          name === 'removeRunDependency';


### PR DESCRIPTION
* Main module already forced full JS API support, but the code was ordered
  wrong so it did not take effect in all cases.
* The old FS has support for lazy files and for devices. I'm not sure if we'll
  support those in WasmFS eventually, but for now do not attempt to export
  things that do not exist.

This gets quite a lot of dynamic linking tests passing in wasmfs, but not all.