### PR TITLE
Warn if source tree is in include path.

### DIFF
--- a/system/include/emscripten/version.h
+++ b/system/include/emscripten/version.h
@@ -1,0 +1,8 @@
+/*
+ * If anyone ever ends up including this file it would be an error
+ * since this directory should never be in the include path.
+ * The real version of this file gets auto-generated inside the
+ * `sysroot/include` directory (which should be in the include path
+ * instead).
+ */
+#error "Including files directly from the emscripten source tree is not supported.  Please use the cache/sysroot/include directory".

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11880,3 +11880,10 @@ void foo() {}
   # works with -sPROXY_POSIX_SOCKETS.
   def test_dylink_proxy_posix_sockets(self):
     self.do_runf(test_file('hello_world.cpp'), emcc_args=['-lwebsocket.js', '-sMAIN_MODULE=1', '-sPROXY_POSIX_SOCKETS'])
+
+  def test_in_tree_header_usage(self):
+    # Using headers directly from where they live in the source tree does not work.
+    # Verify that we generate a useful warning when folks try to do this.
+    create_file('test.c', '#include <emscripten.h>')
+    err = self.expect_fail([EMCC, '-I' + path_from_root('system/include'), 'test.c'])
+    self.assertContained('#error "Including files directly from the emscripten source tree is not supported', err)


### PR DESCRIPTION
Previosuly users who add this directory to the include path
would see "file not found: version.h".

Fixes: #16371