### PR TITLE
Add -Wno-deprecated-non-prototype flag to zlib builds

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -1203,7 +1203,8 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     return poppler + freetype
 
   def get_zlib_library(self):
-    self.emcc_args += ['-Wno-deprecated-non-prototype']
+    # TODO: remove -Wno-unknown-warning-option when clang rev 11da1b53 rolls into emscripten
+    self.emcc_args += ['-Wno-deprecated-non-prototype', '-Wno-unknown-warning-option']
     if WINDOWS:
       return self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'),
                               configure=['cmake', '.'],

--- a/tests/common.py
+++ b/tests/common.py
@@ -1203,6 +1203,7 @@ class RunnerCore(unittest.TestCase, metaclass=RunnerMeta):
     return poppler + freetype
 
   def get_zlib_library(self):
+    self.emcc_args += ['-Wno-deprecated-non-prototype']
     if WINDOWS:
       return self.get_library(os.path.join('third_party', 'zlib'), os.path.join('libz.a'),
                               configure=['cmake', '.'],

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4865,7 +4865,6 @@ side init sees 82, 72, -534.
 main main sees -524, -534, 72.
 '''])
 
-  @disabled('re-enable when clang rev 11da1b53 rolls into emscripten')
   @needs_make('mingw32-make')
   @needs_dylink
   def test_dylink_zlib(self):
@@ -6509,7 +6508,6 @@ void* operator new(size_t size) {
                 includes=[test_file('sqlite')],
                 force_c=True)
 
-  @disabled('re-enable when clang rev 11da1b53 rolls into emscripten')
   @needs_make('mingw32-make')
   @is_slow_test
   @parameterized({
@@ -6533,7 +6531,8 @@ void* operator new(size_t size) {
       make_args = ['libz.a']
       configure = ['sh', './configure']
 
-    self.emcc_args += ['-Wno-deprecated-non-prototype']
+    # TODO: remove Wno-unknown-warning-option when clang rev 11da1b53 rolls into emscripten
+    self.emcc_args += ['-Wno-deprecated-non-prototype', '-Wno-unknown-warning-option']
     self.do_run_from_file(
         test_file('third_party/zlib/example.c'),
         test_file('core/test_zlib.out'),

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4865,6 +4865,7 @@ side init sees 82, 72, -534.
 main main sees -524, -534, 72.
 '''])
 
+  @disabled('re-enable when clang rev 11da1b53 rolls into emscripten')
   @needs_make('mingw32-make')
   @needs_dylink
   def test_dylink_zlib(self):
@@ -6508,6 +6509,7 @@ void* operator new(size_t size) {
                 includes=[test_file('sqlite')],
                 force_c=True)
 
+  @disabled('re-enable when clang rev 11da1b53 rolls into emscripten')
   @needs_make('mingw32-make')
   @is_slow_test
   @parameterized({

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -6531,6 +6531,7 @@ void* operator new(size_t size) {
       make_args = ['libz.a']
       configure = ['sh', './configure']
 
+    self.emcc_args += ['-Wno-deprecated-non-prototype']
     self.do_run_from_file(
         test_file('third_party/zlib/example.c'),
         test_file('core/test_zlib.out'),

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9989,7 +9989,6 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     self.run_process([EMCC, 'foo.o', 'main.o'])
     self.assertContained('Hello, world!\nHello, world!\n', self.run_js('a.out.js'))
 
-  @disabled('re-enable when clang rev 11da1b53 rolls into emscripten')
   def test_em_asm_c89(self):
     create_file('src.c', '''
       #include <emscripten/em_asm.h>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9989,6 +9989,7 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
     self.run_process([EMCC, 'foo.o', 'main.o'])
     self.assertContained('Hello, world!\nHello, world!\n', self.run_js('a.out.js'))
 
+  @disabled('re-enable when clang rev 11da1b53 rolls into emscripten')
   def test_em_asm_c89(self):
     create_file('src.c', '''
       #include <emscripten/em_asm.h>

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -9992,7 +9992,7 @@ Aborted(Module.arguments has been replaced with plain arguments_ (the initial va
   def test_em_asm_c89(self):
     create_file('src.c', '''
       #include <emscripten/em_asm.h>
-      int main() {
+      int main(void) {
         EM_ASM({ console.log('hello'); });
       }\n''')
     self.run_process([EMCC, '-c', 'src.c',


### PR DESCRIPTION
This is a new warning in Clang which is causing build failures.