### PR TITLE
[WasmFS][NFC] Make Directory::Handle responsible for setting parents

### DIFF
--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -168,19 +168,17 @@ private:
     if (_wasmfs_node_get_mode(childPath.c_str(), &mode)) {
       return nullptr;
     }
-    std::shared_ptr<File> child;
     if (S_ISREG(mode)) {
-      child = std::make_shared<NodeFile>(mode, getBackend(), childPath);
+      return std::make_shared<NodeFile>(mode, getBackend(), childPath);
     } else if (S_ISDIR(mode)) {
-      child = std::make_shared<NodeDirectory>(mode, getBackend(), childPath);
+      return std::make_shared<NodeDirectory>(mode, getBackend(), childPath);
     } else if (S_ISLNK(mode)) {
       // return std::make_shared<NodeSymlink>(mode, getBackend(), childPath);
+      return nullptr;
     } else {
       // Unrecognized file kind not made visible to WasmFS.
       return nullptr;
     }
-    child->locked().setParent(shared_from_this()->cast<Directory>());
-    return child;
   }
 
   bool removeChild(const std::string& name) override {

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -283,7 +283,11 @@ public:
     if (name == "..") {
       return getParent();
     }
-    return getDir()->getChild(name);
+    auto child = getDir()->getChild(name);
+    if (child) {
+      child->locked().setParent(getDir());
+    }
+    return child;
   }
   bool removeChild(const std::string& name);
   std::shared_ptr<File> insertChild(const std::string& name,


### PR DESCRIPTION
Rather than having each backend have to remember to set the parent on newly
created `File` objects in `Directory::getChild`, move that responsibility to the
backend-independent logic.