### PR TITLE
[WasmFS] Fix flushing of standard streams

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ jobs:
       - run-tests-linux:
           # also add a little select testing for wasm2js in -O3
           # also add a little select wasmfs testing
-          test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink wasmfs.test_utime wasmfs.test_unistd_unlink wasmfs.test_unistd_access wasmfs.test_unistd_close wasmfs.test_unistd_truncate wasmfs.test_readdir wasmfs.test_unistd_pipe wasmfs.test_dlfcn_self wasmfs.test_dlfcn_unique_sig wasmfs.test_dylink_basics"
+          test_targets: "core3 wasm2js3.test_memorygrowth_2 wasmfs.test_hello_world wasmfs.test_hello_world_standalone wasmfs.test_unistd_links* wasmfs.test_atexit_standalone wasmfs.test_emscripten_get_now wasmfs.test_dyncall_specific_minimal_runtime core2ss.test_pthread_dylink wasmfs.test_utime wasmfs.test_unistd_unlink wasmfs.test_unistd_access wasmfs.test_unistd_close wasmfs.test_unistd_truncate wasmfs.test_readdir wasmfs.test_unistd_pipe wasmfs.test_dlfcn_self wasmfs.test_dlfcn_unique_sig wasmfs.test_dylink_basics wasmfs.test_exit_status"
   test-wasm2js1:
     executor: bionic
     steps:

--- a/system/lib/wasmfs/streams.cpp
+++ b/system/lib/wasmfs/streams.cpp
@@ -46,9 +46,11 @@ __wasi_errno_t StdoutFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 void StdoutFile::flush() {
   // Write a null to flush the output (see comment above on "Flush on either a
-  // null or a newline").
-  const uint8_t nothing = '\0';
-  write(&nothing, 1, 0);
+  // null or a newline"), if we have content.
+  if (!writeBuffer.empty()) {
+    const uint8_t nothing = '\0';
+    write(&nothing, 1, 0);
+  }
 }
 
 std::shared_ptr<StdoutFile> StdoutFile::getSingleton() {
@@ -68,8 +70,10 @@ __wasi_errno_t StderrFile::write(const uint8_t* buf, size_t len, off_t offset) {
 
 void StderrFile::flush() {
   // Similar to StdoutFile.
-  const uint8_t nothing = '\0';
-  write(&nothing, 1, 0);
+  if (!writeBuffer.empty()) {
+    const uint8_t nothing = '\0';
+    write(&nothing, 1, 0);
+  }
 }
 
 std::shared_ptr<StderrFile> StderrFile::getSingleton() {


### PR DESCRIPTION
If there is nothing to flush, do nothing. This fixes a test that cared about
having extra newlines in the output during shutdown.