### PR TITLE
Fix prototypes for _dlinit() and dylink tests

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -220,7 +220,7 @@ var LibraryDylink = {
   _dlsym_js: function(handle, symbol) {
     abort(dlopenMissingError);
   },
-  _dlinit: function() {},
+  _dlinit: function(main_dso_handle) {},
 #else // MAIN_MODULE != 0
   // dynamic linker/loader (a-la ld.so on ELF systems)
   $LDSO: {

--- a/system/lib/libc/dynlink.c
+++ b/system/lib/libc/dynlink.c
@@ -22,7 +22,7 @@
 
 //#define DYLINK_DEBUG
 
-void _dlinit();
+void _dlinit(struct dso* main_dso_handle);
 void* _dlopen_js(struct dso* handle);
 void* _dlsym_js(struct dso* handle, const char* symbol);
 void _emscripten_dlopen_js(struct dso* handle,

--- a/tests/core/pthread/test_pthread_dylink_longjmp.c
+++ b/tests/core/pthread/test_pthread_dylink_longjmp.c
@@ -4,7 +4,7 @@
 #include <stdio.h>
 #include <pthread.h>
 
-void longjmp_side();
+void longjmp_side(jmp_buf* buf);
 
 static void* thread_main(void *arg) {
   jmp_buf buf;

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3466,11 +3466,11 @@ Var: 42
       #include <stdio.h>
       #include <string.h>
 
-      typedef void (*voidfunc)();
+      typedef void (*voidfunc)(void);
       typedef void (*intfunc)(int);
 
       void callvoid(voidfunc f) { f(); }
-      void callint(voidfunc f, int x) { f(x); }
+      void callint(intfunc f, int x) { f(x); }
 
       void void_0() { printf("void 0\n"); }
       void void_1() { printf("void 1\n"); }


### PR DESCRIPTION
As of LLVM revision
https://github.com/llvm/llvm-project/commit/33d3fc4466479285121cbb1a62db249454da0bda
Clang will warn when using a function with no prototye and passing it arguments.
Note that `void _dlinit()` is not a prototype, but `void _dlinit(void)` is.
However in this case the function actually does have an argument.

Also fix the discrepancy in the arguments  on the JS side, and fix 
prototypes in test_dylink_longjmp and test_dlfcn_funcs.