### PR TITLE
[WasmFS] Refactor the backend Directory API

### DIFF
--- a/system/lib/wasmfs/backend.h
+++ b/system/lib/wasmfs/backend.h
@@ -11,7 +11,6 @@
 #pragma once
 
 #include "file.h"
-#include "memory_backend.h"
 
 namespace wasmfs {
 // A backend (or modular backend) provides a base for the new file system to
@@ -22,28 +21,11 @@ class Backend {
 
 public:
   virtual std::shared_ptr<DataFile> createFile(mode_t mode) = 0;
-
-  // By default all backends create normal Directory instances for directories.
-  // That is, the default behavior is to keep directory structure in-memory.
-  virtual std::shared_ptr<Directory> createDirectory(mode_t mode) {
-    return std::make_shared<MemoryDirectory>(mode, this);
-  }
-
-  // By default all backends create normal Symlink instances for symlinks.
-  // That is, the default behavior is to implement symlinks in the trivial
-  // manner and in-memory.
-  virtual std::shared_ptr<Symlink> createSymlink(std::string target) {
-    return std::make_shared<Symlink>(target, this);
-  }
+  virtual std::shared_ptr<Directory> createDirectory(mode_t mode) = 0;
+  virtual std::shared_ptr<Symlink> createSymlink(std::string target) = 0;
 
   virtual ~Backend() = default;
 };
-
-// This will return an instance of a MemoryFileBackend.
-// Note: Backends will be defined in cpp files, but functions to instantiate
-// them will be defined in a header file. This is so that any unused backends
-// are not linked in if they are not called.
-backend_t createMemoryFileBackend();
 
 typedef backend_t (*backend_constructor_t)(void*);
 } // namespace wasmfs

--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -66,6 +66,7 @@ bool MemoryDirectory::insertMove(const std::string& name,
       break;
     }
   }
+  removeChild(name);
   insertChild(name, file);
   return true;
 }

--- a/system/lib/wasmfs/backends/memory_backend.cpp
+++ b/system/lib/wasmfs/backends/memory_backend.cpp
@@ -76,6 +76,12 @@ public:
   std::shared_ptr<DataFile> createFile(mode_t mode) override {
     return std::make_shared<MemoryFile>(mode, this);
   }
+  std::shared_ptr<Directory> createDirectory(mode_t mode) override {
+    return std::make_shared<MemoryDirectory>(mode, this);
+  }
+  std::shared_ptr<Symlink> createSymlink(std::string target) override {
+    return std::make_shared<MemorySymlink>(target, this);
+  }
 };
 
 backend_t createMemoryFileBackend() {

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -56,36 +56,74 @@ int _wasmfs_node_write(
 class NodeState {
   // Map all separate WasmFS opens of a file to a single underlying fd.
   size_t openCount = 0;
-  int fd = 0;
+  oflags_t openFlags = 0;
+  int fd = -1;
 
 public:
   std::string path;
+
   NodeState(std::string path) : path(path) {}
+
   int getFD() {
     assert(openCount > 0);
     return fd;
   }
+
   bool isOpen() { return openCount > 0; }
-  void open(oflags_t flags) {
-    if (openCount++ == 0) {
+
+  // Attempt to open the file with the given flags, returning 0 on success or an
+  // error code.
+  int open(oflags_t flags) {
+    int result = 0;
+    if (openCount == 0) {
+      // No existing fd, so open a fresh one.
       switch (flags) {
         case O_RDONLY:
-          fd = _wasmfs_node_open(path.c_str(), "r");
+          result = _wasmfs_node_open(path.c_str(), "r");
           break;
         case O_WRONLY:
-          fd = _wasmfs_node_open(path.c_str(), "w");
+          result = _wasmfs_node_open(path.c_str(), "w");
           break;
         case O_RDWR:
-          fd = _wasmfs_node_open(path.c_str(), "r+");
+          result = _wasmfs_node_open(path.c_str(), "r+");
           break;
         default:
           WASMFS_UNREACHABLE("Unexpected open access mode");
       }
+      if (result < 0) {
+        return result;
+      }
+      // Fall through to update our state with the new result.
+    } else if ((openFlags == O_RDONLY &&
+                (flags == O_WRONLY || flags == O_RDWR)) ||
+               (openFlags == O_WRONLY &&
+                (flags == O_RDONLY || flags == O_RDWR))) {
+      // We already have a file descriptor, but we need to replace it with a new
+      // fd with more access.
+      result = _wasmfs_node_open(path.c_str(), "r+");
+      if (result < 0) {
+        return result;
+      }
+      // Success! Close the old fd before updating it.
+      _wasmfs_node_close(fd);
+      // Fall through to update our state with the new result.
+    } else {
+      // Reuse the existing file descriptor.
+      ++openCount;
+      return 0;
     }
+    // Update our state for the new fd.
+    fd = result;
+    openFlags = flags;
+    ++openCount;
+    return 0;
   }
+
   void close() {
     if (--openCount == 0) {
       _wasmfs_node_close(fd);
+      fd = -1;
+      openFlags = 0;
     }
   }
 };
@@ -119,7 +157,11 @@ private:
     WASMFS_UNREACHABLE("TODO: implement NodeFile::setSize");
   }
 
-  void open(oflags_t flags) override { state.open(flags); }
+  void open(oflags_t flags) override {
+    // TODO: Properly report errors.
+    state.open(flags);
+  }
+
   void close() override { state.close(); }
 
   __wasi_errno_t read(uint8_t* buf, size_t len, off_t offset) override {
@@ -168,19 +210,17 @@ private:
     if (_wasmfs_node_get_mode(childPath.c_str(), &mode)) {
       return nullptr;
     }
-    std::shared_ptr<File> child;
     if (S_ISREG(mode)) {
-      child = std::make_shared<NodeFile>(mode, getBackend(), childPath);
+      return std::make_shared<NodeFile>(mode, getBackend(), childPath);
     } else if (S_ISDIR(mode)) {
-      child = std::make_shared<NodeDirectory>(mode, getBackend(), childPath);
+      return std::make_shared<NodeDirectory>(mode, getBackend(), childPath);
     } else if (S_ISLNK(mode)) {
       // return std::make_shared<NodeSymlink>(mode, getBackend(), childPath);
+      return nullptr;
     } else {
       // Unrecognized file kind not made visible to WasmFS.
       return nullptr;
     }
-    child->locked().setParent(shared_from_this()->cast<Directory>());
-    return child;
   }
 
   bool removeChild(const std::string& name) override {
@@ -198,36 +238,34 @@ private:
     return true;
   }
 
-  std::shared_ptr<File> insertChild(const std::string& name,
-                                    std::shared_ptr<File> file) override {
+  std::shared_ptr<DataFile> insertDataFile(const std::string& name,
+                                           mode_t mode) override {
     auto childPath = getChildPath(name);
-    auto mode = file->locked().getMode();
-    if (file->is<DataFile>()) {
-      if (_wasmfs_node_insert_file(childPath.c_str(), mode)) {
-        return nullptr;
-      }
-      std::static_pointer_cast<NodeFile>(file)->state.path = childPath;
-      return file;
-    } else if (file->is<Directory>()) {
-      if (_wasmfs_node_insert_directory(childPath.c_str(), mode)) {
-        return nullptr;
-      }
-      std::static_pointer_cast<NodeDirectory>(file)->state.path = childPath;
-      return file;
-    } else if (file->is<Symlink>()) {
-      // fs.linkSync(target, name)
-      assert(false && "Symlinks not implemented");
-      return nullptr;
-    } else {
-      assert(false && "Unimplemented file kind");
+    if (_wasmfs_node_insert_file(childPath.c_str(), mode)) {
       return nullptr;
     }
-    return nullptr;
+    return std::make_shared<NodeFile>(mode, getBackend(), childPath);
   }
 
-  std::string getName(std::shared_ptr<File> file) override {
-    WASMFS_UNREACHABLE("TODO: implement NodeDirectory::getName");
-    return "";
+  std::shared_ptr<Directory> insertDirectory(const std::string& name,
+                                             mode_t mode) override {
+    auto childPath = getChildPath(name);
+    if (_wasmfs_node_insert_directory(childPath.c_str(), mode)) {
+      return nullptr;
+    }
+    return std::make_shared<NodeDirectory>(mode, getBackend(), childPath);
+  }
+
+  std::shared_ptr<Symlink> insertSymlink(const std::string& name,
+                                         const std::string& target) override {
+    // TODO
+    abort();
+  }
+
+  bool insertMove(const std::string& name,
+                  std::shared_ptr<File> file) override {
+    // TODO
+    abort();
   }
 
   size_t getNumEntries() override {

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -122,8 +122,7 @@ public:
   void close() {
     if (--openCount == 0) {
       _wasmfs_node_close(fd);
-      fd = -1;
-      openFlags = 0;
+      *this = NodeState(path);
     }
   }
 };

--- a/system/lib/wasmfs/backends/node_backend.cpp
+++ b/system/lib/wasmfs/backends/node_backend.cpp
@@ -300,6 +300,11 @@ public:
   std::shared_ptr<Directory> createDirectory(mode_t mode) override {
     return std::make_shared<NodeDirectory>(mode, this, mountPath);
   }
+
+  std::shared_ptr<Symlink> createSymlink(std::string target) override {
+    // TODO
+    abort();
+  }
 };
 
 // TODO: symlink

--- a/system/lib/wasmfs/backends/proxied_file_backend.cpp
+++ b/system/lib/wasmfs/backends/proxied_file_backend.cpp
@@ -9,6 +9,7 @@
 
 #include "backend.h"
 #include "file.h"
+#include "memory_backend.h"
 #include "support.h"
 #include "thread_utils.h"
 #include "wasmfs.h"
@@ -76,6 +77,7 @@ public:
     proxy([&]() { baseFile = nullptr; });
   }
 };
+
 class ProxiedBackend : public Backend {
   backend_t backend;
   // ProxiedBackend uses the proxy member to create files on a thread.
@@ -91,6 +93,17 @@ public:
   std::shared_ptr<DataFile> createFile(mode_t mode) override {
     // This creates a file on a thread specified by the proxy member.
     return std::make_shared<ProxiedFile>(mode, this, backend, proxy);
+  }
+
+  std::shared_ptr<Directory> createDirectory(mode_t mode) override {
+    // TODO: This is not generally correct, but happens to work for the JS
+    // backend.
+    return std::make_shared<MemoryDirectory>(mode, this);
+  }
+
+  std::shared_ptr<Symlink> createSymlink(std::string target) override {
+    // TODO.
+    abort();
   }
 };
 

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -40,33 +40,180 @@ void DataFile::Handle::preloadFromJS(int index) {
 // Directory
 //
 
-bool Directory::Handle::removeChild(const std::string& name) {
-  auto child = getChild(name);
-  if (child == nullptr) {
-    return true;
+void Directory::Handle::finishInsertingChild(const std::string& name,
+                                             std::shared_ptr<File> child) {
+  // Update the dcache and set the child's parent.
+  auto& dcache = getDir()->dcache;
+  auto [_, inserted] = dcache.insert({name, {DCacheKind::Normal, child}});
+  assert(inserted && "inserted child already existed!");
+  assert(child->locked().getParent() == nullptr);
+  child->locked().setParent(getDir());
+}
+
+std::shared_ptr<File> Directory::Handle::getChild(const std::string& name) {
+  // Unlinked directories must be empty, without even "." or ".."
+  if (!getParent()) {
+    return nullptr;
   }
-  // Atomically remove the child and clear its parent.
-  auto lockedChild = child->locked();
-  if (!getDir()->removeChild(name)) {
+  if (name == ".") {
+    return file;
+  }
+  if (name == "..") {
+    return getParent();
+  }
+  // Check whether the cache already contains this child.
+  auto& dcache = getDir()->dcache;
+  if (auto it = dcache.find(name); it != dcache.end()) {
+    return it->second.file;
+  }
+  // Otherwise check whether the backend knows about the child.
+  auto child = getDir()->getChild(name);
+  if (!child) {
+    return nullptr;
+  }
+  finishInsertingChild(name, child);
+  return child;
+}
+
+bool Directory::Handle::mountChild(const std::string& name,
+                                   std::shared_ptr<File> child) {
+  assert(child);
+  // Cannot insert into an unlinked directory.
+  if (!getParent()) {
     return false;
   }
-  assert(lockedChild.getParent() == getDir());
-  lockedChild.setParent(nullptr);
+  // Insert the entry into the cache and set its parent.
+  auto [_, inserted] =
+    getDir()->dcache.insert({name, {DCacheKind::Mount, child}});
+  assert(inserted && "mountChild called when file already existed!");
+  assert(child->locked().getParent() == nullptr);
+  child->locked().setParent(getDir());
   return true;
 }
 
-std::shared_ptr<File>
-Directory::Handle::insertChild(const std::string& name,
-                               std::shared_ptr<File> file) {
-  // Atomically add the entry and set its parent.
-  auto lockedFile = file->locked();
-  assert(lockedFile.getParent() == nullptr);
-  auto entry = getDir()->insertChild(name, file);
-  if (file == entry) {
-    // The insertion succeeded; set the parent.
-    lockedFile.setParent(getDir());
+std::shared_ptr<DataFile>
+Directory::Handle::insertDataFile(const std::string& name, mode_t mode) {
+  // Cannot insert into an unlinked directory.
+  if (!getParent()) {
+    return nullptr;
   }
-  return entry;
+  auto child = getDir()->insertDataFile(name, mode);
+  if (!child) {
+    return nullptr;
+  }
+  finishInsertingChild(name, child);
+  return child;
+}
+
+std::shared_ptr<Directory>
+Directory::Handle::insertDirectory(const std::string& name, mode_t mode) {
+  // Cannot insert into an unlinked directory.
+  if (!getParent()) {
+    return nullptr;
+  }
+  auto child = getDir()->insertDirectory(name, mode);
+  if (!child) {
+    return nullptr;
+  }
+  finishInsertingChild(name, child);
+  return child;
+}
+
+std::shared_ptr<Symlink>
+Directory::Handle::insertSymlink(const std::string& name,
+                                 const std::string& target) {
+  // Cannot insert into an unlinked directory.
+  if (!getParent()) {
+    return nullptr;
+  }
+  auto child = getDir()->insertSymlink(name, target);
+  if (!child) {
+    return nullptr;
+  }
+  finishInsertingChild(name, child);
+  return child;
+}
+
+bool Directory::Handle::insertMove(const std::string& name,
+                                   std::shared_ptr<File> file) {
+  // Cannot insert into an unlinked directory.
+  if (!getParent()) {
+    return false;
+  }
+  // Look up the file in its old parent's cache.
+  auto& oldCache = file->locked().getParent()->dcache;
+  auto oldIt = std::find_if(oldCache.begin(), oldCache.end(), [&](auto& kv) {
+    return kv.second.file == file;
+  });
+  assert(oldIt != oldCache.end());
+  auto [oldName, entry] = *oldIt;
+  assert(oldName.size());
+  // Attempt the move.
+  if (!getDir()->insertMove(name, file)) {
+    return false;
+  }
+  // Update parent pointers and caches to reflect the successful move.
+  oldCache.erase(oldIt);
+  auto& newCache = getDir()->dcache;
+  auto [it, inserted] = newCache.insert({name, entry});
+  if (!inserted) {
+    // Update and overwrite the overwritten file.
+    it->second.file->locked().setParent(nullptr);
+    it->second = entry;
+  }
+  file->locked().setParent(getDir());
+  return true;
+}
+
+bool Directory::Handle::removeChild(const std::string& name) {
+  auto& dcache = getDir()->dcache;
+  auto entry = dcache.find(name);
+  // If this is a mount, we don't need to call into the backend.
+  if (entry != dcache.end() && entry->second.kind == DCacheKind::Mount) {
+    dcache.erase(entry);
+    return true;
+  }
+  if (!getDir()->removeChild(name)) {
+    return false;
+  }
+  if (entry != dcache.end()) {
+    entry->second.file->locked().setParent(nullptr);
+    dcache.erase(entry);
+  }
+  return true;
+}
+
+std::string Directory::Handle::getName(std::shared_ptr<File> file) {
+  auto& dcache = getDir()->dcache;
+  for (auto it = dcache.begin(); it != dcache.end(); ++it) {
+    if (it->second.file == file) {
+      return it->first;
+    }
+  }
+  return "";
+}
+
+size_t Directory::Handle::getNumEntries() {
+  size_t mounts = 0;
+  auto& dcache = getDir()->dcache;
+  for (auto it = dcache.begin(); it != dcache.end(); ++it) {
+    if (it->second.kind == DCacheKind::Mount) {
+      ++mounts;
+    }
+  }
+  return getDir()->getNumEntries() + mounts;
+}
+
+std::vector<Directory::Entry> Directory::Handle::getEntries() {
+  auto entries = getDir()->getEntries();
+  auto& dcache = getDir()->dcache;
+  for (auto it = dcache.begin(); it != dcache.end(); ++it) {
+    auto& [name, entry] = *it;
+    if (entry.kind == DCacheKind::Mount) {
+      entries.push_back({name, entry.file->kind, entry.file->getIno()});
+    }
+  }
+  return entries;
 }
 
 //

--- a/system/lib/wasmfs/file.cpp
+++ b/system/lib/wasmfs/file.cpp
@@ -216,12 +216,4 @@ std::vector<Directory::Entry> Directory::Handle::getEntries() {
   return entries;
 }
 
-//
-// Symlink
-//
-
-size_t Symlink::getSize() {
-  return target.size();
-}
-
 } // namespace wasmfs

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -212,24 +212,19 @@ protected:
 };
 
 class Symlink : public File {
-protected:
-  // The target file that this symlink points to. This is constant as symlinks
-  // cannot be modified to point to different things.
-  const std::string target;
-
-  size_t getSize() override;
-
 public:
   static constexpr FileKind expectedKind = File::SymlinkKind;
   // Note that symlinks provide a mode of 0 to File. The mode of a symlink does
   // not matter, so that value will never be read (what matters is the mode of
   // the target).
-  Symlink(std::string target, backend_t backend)
-    : File(File::SymlinkKind, 0, backend), target(target) {}
+  Symlink(backend_t backend) : File(File::SymlinkKind, 0, backend) {}
   virtual ~Symlink() = default;
 
   // Constant, and therefore thread-safe, and can be done without locking.
-  const std::string& getTarget() { return target; }
+  virtual std::string getTarget() const = 0;
+
+protected:
+  size_t getSize() override { return getTarget().size(); }
 };
 
 class File::Handle {

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -296,14 +296,17 @@ public:
 
 class Directory::Handle : public File::Handle {
   std::shared_ptr<Directory> getDir() { return file->cast<Directory>(); }
-  void finishInsertingChild(const std::string& name,
-                            std::shared_ptr<File> child);
+  void cacheChild(const std::string& name,
+                  std::shared_ptr<File> child,
+                  DCacheKind kind);
 
 public:
   Handle(std::shared_ptr<File> directory) : File::Handle(directory) {}
   Handle(std::shared_ptr<File> directory, std::defer_lock_t)
     : File::Handle(directory, std::defer_lock) {}
 
+  // Retrieve the child if it is in the dcache and otherwise forward the request
+  // to the backend, caching any `File` object it returns.
   std::shared_ptr<File> getChild(const std::string& name);
 
   // Add a child to this directory's entry cache without actually inserting it

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -152,6 +152,10 @@ public:
   };
 
 private:
+  // The directory cache, or `dcache`, stores `File` objects for the children of
+  // each directory so that subsequent lookups do not need to query the backend.
+  // It also supports cross-backend mount point children that are stored
+  // exclusively in the cache and not reflected in any backend.
   enum class DCacheKind { Normal, Mount };
   struct DCacheEntry {
     DCacheKind kind;

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -328,7 +328,8 @@ public:
   // directory with the new `name`, possibly overwriting another file that
   // already exists with that name. The old directory may be the same as this
   // directory. On success, return `true`. Otherwise return `false` without
-  // changing any underlying state.
+  // changing any underlying state. This should only be called from renameat
+  // with the locks on the old and new parents already held.
   bool insertMove(const std::string& name, std::shared_ptr<File> file);
 
   // Remove the file with the given name, returning `true` on success or if the

--- a/system/lib/wasmfs/file.h
+++ b/system/lib/wasmfs/file.h
@@ -35,6 +35,13 @@ const backend_t NullBackend = nullptr;
 // Access mode, file creation and file status flags for open.
 using oflags_t = uint32_t;
 
+// An abstract representation of an underlying file. All `File` objects
+// correspond to underlying (real or conceptual) files in a file system managed
+// by some backend, but not all underlying files have a corresponding `File`
+// object. For example, a persistent backend may contain some files that have
+// not yet been discovered by WasmFS and that therefore do not yet have
+// corresponding `File` objects. Backends override the `File` family of classes
+// to implement the mapping from `File` objects to their underlying files.
 class File : public std::enable_shared_from_this<File> {
 public:
   enum FileKind { UnknownKind, DataFileKind, DirectoryKind, SymlinkKind };
@@ -164,10 +171,11 @@ private:
   // TODO: Use a cache data structure with smaller code size.
   std::map<std::string, DCacheEntry> dcache;
 
-  // Return the file with the given name or null if there is none.
+  // Return the `File` object corresponding to the file with the given name or
+  // null if there is none.
   virtual std::shared_ptr<File> getChild(const std::string& name) = 0;
 
-  // Inserts a file with the given name, kind, and mode. Returns a `File`
+  // Inserts a file with the given name, kind, and mode. Returns a `File` object
   // corresponding to the newly created file or nullptr if the new file could
   // not be created. Assumes a child with this name does not already exist.
   virtual std::shared_ptr<DataFile> insertDataFile(const std::string& name,

--- a/system/lib/wasmfs/js_api.cpp
+++ b/system/lib/wasmfs/js_api.cpp
@@ -70,8 +70,7 @@ int _wasmfs_write_file(char* pathname, char* data, size_t data_size) {
     child = lockedParent.getChild(childName);
     if (!child) {
       // Lookup failed; try creating the file.
-      child = parent->getBackend()->createFile(0777);
-      child = lockedParent.insertChild(childName, child);
+      child = lockedParent.insertDataFile(childName, 0777);
       if (!child) {
         // File creation failed; nothing else to do.
         return 0;

--- a/system/lib/wasmfs/js_impl_backend.h
+++ b/system/lib/wasmfs/js_impl_backend.h
@@ -10,6 +10,7 @@
 #pragma once
 
 #include "backend.h"
+#include "memory_backend.h"
 #include "support.h"
 #include "wasmfs.h"
 
@@ -114,6 +115,12 @@ class JSImplBackend : public Backend {
 public:
   std::shared_ptr<DataFile> createFile(mode_t mode) override {
     return std::make_shared<JSImplFile>(mode, this);
+  }
+  std::shared_ptr<Directory> createDirectory(mode_t mode) override {
+    return std::make_shared<MemoryDirectory>(mode, this);
+  }
+  std::shared_ptr<Symlink> createSymlink(std::string target) override {
+    return std::make_shared<MemorySymlink>(target, this);
   }
 };
 

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -10,6 +10,7 @@
 
 #pragma once
 
+#include "backend.h"
 #include "file.h"
 #include <emscripten/threading.h>
 
@@ -51,34 +52,36 @@ class MemoryDirectory : public Directory {
 
   std::vector<ChildEntry>::iterator findEntry(const std::string& name);
 
-  std::shared_ptr<File> getChild(const std::string& name) override {
-    return nullptr;
-  }
-  bool removeChild(const std::string& name) override;
-
   void insertChild(const std::string& name, std::shared_ptr<File> child) {
     assert(findEntry(name) == entries.end());
     entries.push_back({name, child});
   }
 
+  std::shared_ptr<File> getChild(const std::string& name) override {
+    return nullptr;
+  }
+
+  bool removeChild(const std::string& name) override;
+
   std::shared_ptr<DataFile> insertDataFile(const std::string& name,
                                            mode_t mode) override {
-    auto child = std::make_shared<MemoryFile>(mode, getBackend());
+    auto child = getBackend()->createFile(mode);
     insertChild(name, child);
     return child;
   }
 
   std::shared_ptr<Directory> insertDirectory(const std::string& name,
                                              mode_t mode) override {
-    auto child = std::make_shared<MemoryDirectory>(mode, getBackend());
+    auto child = getBackend()->createDirectory(mode);
     insertChild(name, child);
     return child;
   }
 
   std::shared_ptr<Symlink> insertSymlink(const std::string& name,
                                          const std::string& target) override {
-    // TODO
-    abort();
+    auto child = getBackend()->createSymlink(target);
+    insertChild(name, child);
+    return child;
   }
 
   bool insertMove(const std::string& name, std::shared_ptr<File> file) override;
@@ -89,5 +92,17 @@ class MemoryDirectory : public Directory {
 public:
   MemoryDirectory(mode_t mode, backend_t backend) : Directory(mode, backend) {}
 };
+
+class MemorySymlink : public Symlink {
+  std::string target;
+
+  std::string getTarget() const override { return target; }
+
+public:
+  MemorySymlink(const std::string& target, backend_t backend)
+    : Symlink(backend), target(target) {}
+};
+
+backend_t createMemoryFileBackend();
 
 } // namespace wasmfs

--- a/system/lib/wasmfs/memory_backend.h
+++ b/system/lib/wasmfs/memory_backend.h
@@ -51,11 +51,38 @@ class MemoryDirectory : public Directory {
 
   std::vector<ChildEntry>::iterator findEntry(const std::string& name);
 
-  std::shared_ptr<File> getChild(const std::string& name) override;
+  std::shared_ptr<File> getChild(const std::string& name) override {
+    return nullptr;
+  }
   bool removeChild(const std::string& name) override;
-  std::shared_ptr<File> insertChild(const std::string& name,
-                                    std::shared_ptr<File> file) override;
-  std::string getName(std::shared_ptr<File> file) override;
+
+  void insertChild(const std::string& name, std::shared_ptr<File> child) {
+    assert(findEntry(name) == entries.end());
+    entries.push_back({name, child});
+  }
+
+  std::shared_ptr<DataFile> insertDataFile(const std::string& name,
+                                           mode_t mode) override {
+    auto child = std::make_shared<MemoryFile>(mode, getBackend());
+    insertChild(name, child);
+    return child;
+  }
+
+  std::shared_ptr<Directory> insertDirectory(const std::string& name,
+                                             mode_t mode) override {
+    auto child = std::make_shared<MemoryDirectory>(mode, getBackend());
+    insertChild(name, child);
+    return child;
+  }
+
+  std::shared_ptr<Symlink> insertSymlink(const std::string& name,
+                                         const std::string& target) override {
+    // TODO
+    abort();
+  }
+
+  bool insertMove(const std::string& name, std::shared_ptr<File> file) override;
+
   size_t getNumEntries() override { return entries.size(); }
   std::vector<Directory::Entry> getEntries() override;
 

--- a/system/lib/wasmfs/proxied_async_js_impl_backend.h
+++ b/system/lib/wasmfs/proxied_async_js_impl_backend.h
@@ -11,6 +11,7 @@
 
 #include "async_callback.h"
 #include "backend.h"
+#include "memory_backend.h"
 #include "support.h"
 #include "thread_utils.h"
 #include "wasmfs.h"
@@ -213,6 +214,14 @@ public:
 
   std::shared_ptr<DataFile> createFile(mode_t mode) override {
     return std::make_shared<ProxiedAsyncJSImplFile>(mode, this, proxy);
+  }
+
+  std::shared_ptr<Directory> createDirectory(mode_t mode) override {
+    return std::make_shared<MemoryDirectory>(mode, this);
+  }
+
+  std::shared_ptr<Symlink> createSymlink(std::string target) override {
+    return std::make_shared<MemorySymlink>(target, this);
   }
 };
 


### PR DESCRIPTION
Previously new entries were inserted into the file system by calling
`Backend::createDirectory` or `Backend::createFile`, etc. then passing the
result to `Directory::insertChild`. This was suboptimal because it forced `File`
objects to be created with no context and separately from the creation of the
underlying files. Backends would have to create some reasonable default `File`
and then later overwrite its state in the implementation of `insertChild`.

To avoid this spooky action at a distance, simplify the control flow, and reduce
statefulness in the API, replace `insertChild` with separate `insertDataFile`,
`insertDirectory`, and `insertSymlink` methods that both create the underlying
files and allocate and return the corresponding `File` objects.

But removing `insertChild` from the backend API makes it no longer possible for
a backend to contain a reference to a file on a different backend, a capability
we need at least for the root in-memory backend. To fix this (and also to
improve performance and also to fix an entire class of bugs stemming from having
multiple `File` objects corresponding to the same underlying file), add a
directory entry cache inspired by the dcache in Linux's [virtual file
system](https://github.com/torvalds/linux/blob/master/Documentation/filesystems/vfs.rst).

This directory entry cache lives in the base `Directory` class and is
manipulated solely by the `Directory::Handle` layer sitting between the syscall
implementations and the backends. A new method, `Directory::Handle::mountChild`,
can insert `File` objects into this cache without inserting them into the
underlying backend, allowing directories to contain children in different
backends without backends having to worry about how to represent such children.

Finally, add another method, `Directory::insertMove`, that implements an atomic
rename to replace the combination of `removeChild` followed by `insertChild`
that was previously used to implement rename. Although the previous call
sequence worked fine for the in-memory backend, it would have been extremely
awkward to support in any persistent backend and was in general not capable of
gracefully handling rename errors without data loss.

After all these updates to the directory API, there was one additional fix
necessary to keep the tests passing. Now that there is a unique `File`
corresponding to each underlying file in the Node backend, multiple `open`s of a
file will share an underlying file descriptor. But if a file is originally
opened for reading only, for example, and later opened for writing, writes will
fail because the underlying Node file descriptor was only opened for reading.

One possible solution would have been to always have the Node backend open files
for both reading and writing, but that would introduce spurious failures when
the user only has permissions for one or the other on the underlying file.
Instead, detect when the permission on the current underlying file descriptor
are insufficient and dynamically try to increase permissions on demand.

Resolves #16630.