### PR TITLE
Avoid flakes in other.test_wasmfs_jsfile_proxying_backend

### DIFF
--- a/tests/wasmfs/wasmfs_jsfile.c
+++ b/tests/wasmfs/wasmfs_jsfile.c
@@ -17,7 +17,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-void write_and_read(const char* msg, int fd) {
+void write_and_read(const char* msg, int fd, const char* expected) {
   char buf[200] = {};
   errno = 0;
   write(fd, msg, strlen(msg));
@@ -27,7 +27,7 @@ void write_and_read(const char* msg, int fd) {
   assert(errno == 0);
   read(fd, buf, sizeof(buf));
   assert(errno == 0);
-  printf("%s\n", buf);
+  assert(strcmp(buf, expected) == 0);
 }
 
 static backend_t make_js_file_backend(void* arg) {
@@ -52,7 +52,7 @@ int main() {
 
   // Try writing to and reading from the file.
   const char* msg = "Test with a new backend file\n";
-  write_and_read(msg, fd);
+  write_and_read(msg, fd, msg);
 
   // Verify that the size of the backend File is the same as the written buffer.
   assert(fstat(fd, &file) != -1);
@@ -60,10 +60,10 @@ int main() {
 
   // Try seeking to the beginning of the file and overwriting its contents.
   assert(lseek(fd, 0, SEEK_SET) != -1);
-  write_and_read(msg, fd);
+  write_and_read(msg, fd, msg);
 
   // Try appending to the end of the backend File.
-  write_and_read(msg, fd);
+  write_and_read(msg, fd, "Test with a new backend file\nTest with a new backend file\n");
 
   // Verify that the size of the backend File has increased.
   assert(fstat(fd, &file) != -1);
@@ -83,7 +83,7 @@ int main() {
   const char* msg2 =
     "Test with a backend file created under a backend directory\n";
 
-  write_and_read(msg2, fd2);
+  write_and_read(msg2, fd2, msg2);
 
   // Check that the backend file has the correct backend type.
   assert(wasmfs_get_backend_by_fd(fd2) == backend);
@@ -95,7 +95,7 @@ int main() {
 
   const char* msg3 =
     "Test with an in-memory file created under a backend directory\n";
-  write_and_read(msg3, fd3);
+  write_and_read(msg3, fd3, msg3);
 
   // Create a new backend file under root.
   int fd4 = wasmfs_create_file("/testfile2", 0777, backend);

--- a/tests/wasmfs/wasmfs_jsfile.c
+++ b/tests/wasmfs/wasmfs_jsfile.c
@@ -63,7 +63,8 @@ int main() {
   write_and_read(msg, fd, msg);
 
   // Try appending to the end of the backend File.
-  write_and_read(msg, fd, "Test with a new backend file\nTest with a new backend file\n");
+  write_and_read(
+    msg, fd, "Test with a new backend file\nTest with a new backend file\n");
 
   // Verify that the size of the backend File has increased.
   assert(fstat(fd, &file) != -1);

--- a/tests/wasmfs/wasmfs_jsfile.c
+++ b/tests/wasmfs/wasmfs_jsfile.c
@@ -27,6 +27,7 @@ void write_and_read(const char* msg, int fd, const char* expected) {
   assert(errno == 0);
   read(fd, buf, sizeof(buf));
   assert(errno == 0);
+  printf("%s\n", buf);
   assert(strcmp(buf, expected) == 0);
 }
 

--- a/tests/wasmfs/wasmfs_jsfile.out
+++ b/tests/wasmfs/wasmfs_jsfile.out
@@ -1,12 +1,1 @@
-Test with a new backend file
-
-Test with a new backend file
-
-Test with a new backend file
-Test with a new backend file
-
-Test with a backend file created under a backend directory
-
-Test with an in-memory file created under a backend directory
-
 \0\0\0\0\0\0\0\0\0\0Test with a backend file created under root


### PR DESCRIPTION
Occasionally the worker thread would terminate while the main thread was still
running and print an unexpected line into the test output, causing the test to
fail. Avoid this flake by explicitly asserting that the file contents are
correct rather than depending on printing.