### PR TITLE
Support -msse4 as an alias for -msse4.2

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -151,7 +151,7 @@ EXTRA_INCOMING_JS_API = [
 ]
 
 VALID_ENVIRONMENTS = ('web', 'webview', 'worker', 'node', 'shell')
-SIMD_INTEL_FEATURE_TOWER = ['-msse', '-msse2', '-msse3', '-mssse3', '-msse4.1', '-msse4.2', '-mavx']
+SIMD_INTEL_FEATURE_TOWER = ['-msse', '-msse2', '-msse3', '-mssse3', '-msse4.1', '-msse4.2', '-msse4', '-mavx']
 SIMD_NEON_FLAGS = ['-mfpu=neon']
 COMPILE_ONLY_FLAGS = {'--default-obj-ext'}
 LINK_ONLY_FLAGS = {
@@ -794,10 +794,11 @@ def emsdk_cflags(user_args):
   if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[4:]):
     cflags += ['-D__SSE4_1__=1']
 
+  # Handle both -msse4.2 and its alias -msse4.
   if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[5:]):
     cflags += ['-D__SSE4_2__=1']
 
-  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[6:]):
+  if array_contains_any_of(user_args, SIMD_INTEL_FEATURE_TOWER[7:]):
     cflags += ['-D__AVX__=1']
 
   if array_contains_any_of(user_args, SIMD_NEON_FLAGS):

--- a/tests/common.py
+++ b/tests/common.py
@@ -160,6 +160,7 @@ def no_windows(note=''):
 def requires_native_clang(func):
   assert callable(func)
 
+  @wraps(func)
   def decorated(self, *args, **kwargs):
     if EMTEST_LACKS_NATIVE_CLANG:
       return self.skipTest('native clang tests are disabled')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -37,7 +37,7 @@ logger = logging.getLogger("test_core")
 
 def wasm_simd(f):
   @wraps(f)
-  def decorated(self, *args):
+  def decorated(self, *args, **kwargs):
     self.require_v8()
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')
@@ -46,7 +46,7 @@ def wasm_simd(f):
     self.emcc_args.append('-msimd128')
     self.emcc_args.append('-fno-lax-vector-conversions')
     self.v8_args.append('--experimental-wasm-simd')
-    f(self, *args)
+    f(self, *args, **kwargs)
   return decorated
 
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -36,7 +36,8 @@ logger = logging.getLogger("test_core")
 
 
 def wasm_simd(f):
-  def decorated(self):
+  @wraps(f)
+  def decorated(self, *args):
     self.require_v8()
     if not self.is_wasm():
       self.skipTest('wasm2js only supports MVP for now')
@@ -45,7 +46,7 @@ def wasm_simd(f):
     self.emcc_args.append('-msimd128')
     self.emcc_args.append('-fno-lax-vector-conversions')
     self.v8_args.append('--experimental-wasm-simd')
-    f(self)
+    f(self, *args)
   return decorated
 
 
@@ -6378,12 +6379,17 @@ void* operator new(size_t size) {
   # Tests invoking the SIMD API via x86 SSE4.2 nmmintrin.h header (_mm_x() functions)
   @wasm_simd
   @requires_native_clang
-  def test_sse4_2(self):
+  @parameterized({
+      '': (False,),
+      '2': (True,)
+  })
+  def test_sse4(self, use_4_2):
+    msse4 = '-msse4.2' if use_4_2 else '-msse4'
     src = test_file('sse/test_sse4_2.cpp')
-    self.run_process([shared.CLANG_CXX, src, '-msse4.2', '-Wno-argument-outside-range', '-o', 'test_sse4_2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
+    self.run_process([shared.CLANG_CXX, src, msse4, '-Wno-argument-outside-range', '-o', 'test_sse4_2', '-D_CRT_SECURE_NO_WARNINGS=1'] + clang_native.get_clang_native_args(), stdout=PIPE)
     native_result = self.run_process('./test_sse4_2', stdout=PIPE).stdout
 
-    self.emcc_args += ['-I' + test_file('sse'), '-msse4.2', '-Wno-argument-outside-range']
+    self.emcc_args += ['-I' + test_file('sse'), msse4, '-Wno-argument-outside-range']
     self.maybe_closure()
     self.do_runf(src, native_result)
 


### PR DESCRIPTION
Also update some of the test decorators to support parameterized tests so that
test_sse4 can be parameterized to use either -msse4 or -msse4.2.

Fixes #12746.