### PR TITLE
Close opened IndexedDBs at exit.

### DIFF
--- a/src/library_idbfs.js
+++ b/src/library_idbfs.js
@@ -6,6 +6,10 @@
 
 mergeInto(LibraryManager.library, {
   $IDBFS__deps: ['$FS', '$MEMFS', '$PATH'],
+  $IDBFS__postset: function() {
+    addAtExit('IDBFS.quit();');
+    return '';
+  },
   $IDBFS: {
     dbs: {},
     indexedDB: () => {
@@ -34,6 +38,10 @@ mergeInto(LibraryManager.library, {
           IDBFS.reconcile(src, dst, callback);
         });
       });
+    },
+    quit: () => {
+      Object.values(IDBFS.dbs).forEach((value) => value.close());
+      IDBFS.dbs = {};
     },
     getDB: (name, callback) => {
       // check the cache first

--- a/tests/fs/test_idbfs_fsync.c
+++ b/tests/fs/test_idbfs_fsync.c
@@ -74,6 +74,10 @@ int main() {
   // sync from memory state to persisted and then
   // run 'success'
   EM_ASM(
+    // Ensure IndexedDB is closed at exit.
+    Module['onExit'] = function() {
+      assert(Object.keys(IDBFS.dbs).length == 0);
+    };
     FS.syncfs(function (err) {
       assert(!err);
       ccall('success', 'v');

--- a/tests/fs/test_idbfs_sync.c
+++ b/tests/fs/test_idbfs_sync.c
@@ -155,6 +155,10 @@ void test() {
   // sync from memory state to persisted and then
   // run 'success'
   EM_ASM(
+    // Ensure IndexedDB is closed at exit.
+    Module['onExit'] = function() {
+      assert(Object.keys(IDBFS.dbs).length == 0);
+    };
     FS.syncfs(function (err) {
       assert(!err);
       ccall('success', 'v');


### PR DESCRIPTION
Fixes #12516 .
Also add a simple clean up check to IDBFS tests.
A more complex test could check that the `close` is successful and that it can be opened via JS, but I'm not familiar with the test system so it might take a bit longer. But let me know in case.

As an additional note, I think a more appropriate fix would be to implement `unmount` in IDBFS (which closes the DB), and have FS call that during all the `FS.unmount`s, and also doing proper `FS.unmount("/")` at exit (similar to what a unix system would do AFAIK).
But that require some design(?) changes to to `library_fs.js` (e.g. `/` cannot be unmounted right now), and I know there is work on a `WasmFS` rewrite (#15041), so I wonder if this is desired @sbc100 (I could work on that as an alternative to this PR).