### PR TITLE
Improve support for FILESYSTEM=0. NFC

### DIFF
--- a/emscripten.py
+++ b/emscripten.py
@@ -89,6 +89,7 @@ def optimize_syscalls(declares):
       'fd_seek',
       'fd_write',
       'fd_close',
+      'fd_fdstat_get',
     }):
       if DEBUG:
         logger.debug('very limited syscalls (%s) so disabling full filesystem support', ', '.join(str(s) for s in syscalls))


### PR DESCRIPTION
Some of these syscalls were not respsecting this flag.

Also, add `fd_fdstat_get` to the list of syscalls which
can be referenced without cuasing filesystem code to be
included (printf uses this indirectrly via isatty).