### PR TITLE
WebGPU deprecated path remove and depth stencil loadOp/StoreOp validation update

### DIFF
--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1535,24 +1535,36 @@ var LibraryWebGPU = {
       if (dsaPtr === 0) return undefined;
 
       var depthLoadOpInt = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthLoadOp) }}};
+      var depthStoreOpInt = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthStoreOp) }}};
       var depthClearValue = {{{ makeGetValue('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthClearValue, 'float') }}};
+      
       var stencilLoadOpInt = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilLoadOp) }}};
+      var stencilStoreOpInt = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilStoreOp) }}};
       var stencilClearValue = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilClearValue) }}};
 
-      return {
+      var desc = {
         "view": WebGPU.mgrTextureView.get(
           {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.view) }}}),
         "depthClearValue": depthClearValue,
-        "depthLoadOp": WebGPU.LoadOp[depthLoadOpInt],
-        "depthStoreOp": WebGPU.StoreOp[
-          {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthStoreOp) }}}],
         "depthReadOnly": {{{ gpu.makeGetBool('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthReadOnly) }}},
         "stencilClearValue": stencilClearValue,
-        "stencilLoadOp": WebGPU.LoadOp[stencilLoadOpInt],
-        "stencilStoreOp": WebGPU.StoreOp[
-          {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilStoreOp) }}}],
         "stencilReadOnly": {{{ gpu.makeGetBool('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilReadOnly) }}},
       };
+
+      if (depthLoadOpInt !== {{{ gpu.LoadOp.Undefined }}}) {
+        desc["depthLoadOp"] = WebGPU.LoadOp[depthLoadOpInt];
+      }
+      if (depthLoadOpInt !== {{{ gpu.StoreOp.Undefined }}}) {
+        desc["depthStoreOp"] = WebGPU.StoreOp[depthStoreOpInt];
+      }
+      if (stencilLoadOpInt !== {{{ gpu.LoadOp.Undefined }}}) {
+        desc["stencilLoadOp"] = WebGPU.LoadOp[stencilLoadOpInt];
+      }
+      if (stencilStoreOpInt !== {{{ gpu.StoreOp.Undefined }}}) {
+        desc["stencilStoreOp"] = WebGPU.StoreOp[stencilStoreOpInt];
+      }
+
+      return desc;
     }
 
     function makeRenderPassDescriptor(descriptor) {

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1554,9 +1554,6 @@ var LibraryWebGPU = {
         "stencilStoreOp": WebGPU.StoreOp[
           {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilStoreOp) }}}],
         "stencilReadOnly": {{{ gpu.makeGetBool('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilReadOnly) }}},
-        // TODO(shrekshao): remove deprecated path once browser (chrome) API update comes to stable (M101)
-        "depthLoadValue": depthLoadOpInt === {{{ gpu.LoadOp.Load }}} ? 'load' : depthClearValue,
-        "stencilLoadValue": stencilLoadOpInt === {{{ gpu.LoadOp.Load }}} ? 'load' : stencilClearValue,
       };
     }
 

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1520,8 +1520,6 @@ var LibraryWebGPU = {
         "clearValue": clearValue,
         "loadOp":  WebGPU.LoadOp[loadOpInt],
         "storeOp": WebGPU.StoreOp[storeOpInt],
-        // TODO(shrekshao): remove deprecated path once browser (chrome) API update comes to stable (M101)
-        "loadValue": loadOpInt === {{{ gpu.LoadOp.Load }}} ? 'load' : clearValue,
       };
     }
 
@@ -1901,12 +1899,7 @@ var LibraryWebGPU = {
 
   wgpuComputePassEncoderEnd: function(passId) {
     var pass = WebGPU.mgrComputePassEncoder.get(passId);
-    // TODO(shrekshao): remove once this API change moves to stable (e.g. in Chrome)
-    if (pass["end"]) {
-      pass["end"]();
-    } else {
-      pass["endPass"]();
-    }
+    pass["end"]();
   },
 
   // wgpuRenderPass
@@ -2040,12 +2033,7 @@ var LibraryWebGPU = {
 
   wgpuRenderPassEncoderEnd: function(passId) {
     var pass = WebGPU.mgrRenderPassEncoder.get(passId);
-    // TODO(shrekshao): remove once this API change moves to stable (e.g. in Chrome)
-    if (pass["end"]) {
-      pass["end"]();
-    } else {
-      pass["endPass"]();
-    }
+    pass["end"]();
   },
 
   // Render bundle encoder

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -1534,37 +1534,22 @@ var LibraryWebGPU = {
     function makeDepthStencilAttachment(dsaPtr) {
       if (dsaPtr === 0) return undefined;
 
-      var depthLoadOpInt = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthLoadOp) }}};
-      var depthStoreOpInt = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthStoreOp) }}};
-      var depthClearValue = {{{ makeGetValue('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthClearValue, 'float') }}};
-      
-      var stencilLoadOpInt = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilLoadOp) }}};
-      var stencilStoreOpInt = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilStoreOp) }}};
-      var stencilClearValue = {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilClearValue) }}};
-
-      var desc = {
+      return {
         "view": WebGPU.mgrTextureView.get(
           {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.view) }}}),
-        "depthClearValue": depthClearValue,
+        "depthClearValue": {{{ makeGetValue('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthClearValue, 'float') }}},
+        "depthLoadOp": WebGPU.LoadOp[
+          {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthLoadOp) }}}],
+        "depthStoreOp": WebGPU.StoreOp[
+          {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthStoreOp) }}}],
         "depthReadOnly": {{{ gpu.makeGetBool('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.depthReadOnly) }}},
-        "stencilClearValue": stencilClearValue,
+        "stencilClearValue": {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilClearValue) }}},
+        "stencilLoadOp": WebGPU.LoadOp[
+          {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilLoadOp) }}}],
+        "stencilStoreOp": WebGPU.StoreOp[
+          {{{ gpu.makeGetU32('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilStoreOp) }}}],
         "stencilReadOnly": {{{ gpu.makeGetBool('dsaPtr', C_STRUCTS.WGPURenderPassDepthStencilAttachment.stencilReadOnly) }}},
       };
-
-      if (depthLoadOpInt !== {{{ gpu.LoadOp.Undefined }}}) {
-        desc["depthLoadOp"] = WebGPU.LoadOp[depthLoadOpInt];
-      }
-      if (depthLoadOpInt !== {{{ gpu.StoreOp.Undefined }}}) {
-        desc["depthStoreOp"] = WebGPU.StoreOp[depthStoreOpInt];
-      }
-      if (stencilLoadOpInt !== {{{ gpu.LoadOp.Undefined }}}) {
-        desc["stencilLoadOp"] = WebGPU.LoadOp[stencilLoadOpInt];
-      }
-      if (stencilStoreOpInt !== {{{ gpu.StoreOp.Undefined }}}) {
-        desc["stencilStoreOp"] = WebGPU.StoreOp[stencilStoreOpInt];
-      }
-
-      return desc;
     }
 
     function makeRenderPassDescriptor(descriptor) {

--- a/tests/webgpu_basic_rendering.cpp
+++ b/tests/webgpu_basic_rendering.cpp
@@ -45,15 +45,15 @@ void GetDevice(void (*callback)(wgpu::Device)) {
 }
 
 static const char shaderCode[] = R"(
-    [[stage(vertex)]]
-    fn main_v([[builtin(vertex_index)]] idx: u32) -> [[builtin(position)]] vec4<f32> {
+    @stage(vertex)
+    fn main_v(@builtin(vertex_index) idx: u32) -> @builtin(position) vec4<f32> {
         var pos = array<vec2<f32>, 3>(
             vec2<f32>(0.0, 0.5), vec2<f32>(-0.5, -0.5), vec2<f32>(0.5, -0.5));
         return vec4<f32>(pos[idx], 0.0, 1.0);
     }
 
-    [[stage(fragment)]]
-    fn main_f() -> [[location(0)]] vec4<f32> {
+    @stage(fragment)
+    fn main_f() -> @location(0) vec4<f32> {
         return vec4<f32>(0.0, 0.502, 1.0, 1.0); // 0x80/0xff ~= 0.502
     }
 )";

--- a/tests/webgpu_basic_rendering.cpp
+++ b/tests/webgpu_basic_rendering.cpp
@@ -106,17 +106,24 @@ void init() {
         fragmentState.targetCount = 1;
         fragmentState.targets = &colorTargetState;
 
+        wgpu::DepthStencilState depthStencilState{};
+        depthStencilState.format = wgpu::TextureFormat::Depth32Float;
+
         wgpu::RenderPipelineDescriptor descriptor{};
         descriptor.layout = device.CreatePipelineLayout(&pl);
         descriptor.vertex.module = shaderModule;
         descriptor.vertex.entryPoint = "main_v";
         descriptor.fragment = &fragmentState;
         descriptor.primitive.topology = wgpu::PrimitiveTopology::TriangleList;
+        descriptor.depthStencil = &depthStencilState;
         pipeline = device.CreateRenderPipeline(&descriptor);
     }
 }
 
-void render(wgpu::TextureView view) {
+// The depth stencil attachment isn't really needed to draw the triangle
+// and doesn't really affect the render result.
+// But having one should give us a slightly better test coverage for the compile of the depth stencil descriptor.
+void render(wgpu::TextureView view, wgpu::TextureView depthStencilView) {
     wgpu::RenderPassColorAttachment attachment{};
     attachment.view = view;
     attachment.loadOp = wgpu::LoadOp::Clear;
@@ -126,6 +133,14 @@ void render(wgpu::TextureView view) {
     wgpu::RenderPassDescriptor renderpass{};
     renderpass.colorAttachmentCount = 1;
     renderpass.colorAttachments = &attachment;
+
+    wgpu::RenderPassDepthStencilAttachment depthStencilAttachment = {};
+    depthStencilAttachment.view = depthStencilView;
+    depthStencilAttachment.depthClearValue = 0;
+    depthStencilAttachment.depthLoadOp = wgpu::LoadOp::Clear;
+    depthStencilAttachment.depthStoreOp = wgpu::StoreOp::Store;
+
+    renderpass.depthStencilAttachment = &depthStencilAttachment;
 
     wgpu::CommandBuffer commands;
     {
@@ -284,7 +299,15 @@ void doRenderTest() {
         descriptor.format = wgpu::TextureFormat::BGRA8Unorm;
         readbackTexture = device.CreateTexture(&descriptor);
     }
-    render(readbackTexture.CreateView());
+    wgpu::Texture depthTexture;
+    {
+        wgpu::TextureDescriptor descriptor{};
+        descriptor.usage = wgpu::TextureUsage::RenderAttachment;
+        descriptor.size = {1, 1, 1};
+        descriptor.format = wgpu::TextureFormat::Depth32Float;
+        depthTexture = device.CreateTexture(&descriptor);
+    }
+    render(readbackTexture.CreateView(), depthTexture.CreateView());
 
     {
         wgpu::BufferDescriptor descriptor{};
@@ -315,10 +338,13 @@ void doRenderTest() {
 }
 
 wgpu::SwapChain swapChain;
+wgpu::TextureView canvasDepthStencilView;
+const uint32_t kWidth = 300;
+const uint32_t kHeight = 150;
 
 void frame() {
     wgpu::TextureView backbuffer = swapChain.GetCurrentTextureView();
-    render(backbuffer);
+    render(backbuffer, canvasDepthStencilView);
 
     // TODO: Read back from the canvas with drawImage() (or something) and
     // check the result.
@@ -350,10 +376,18 @@ void run() {
         wgpu::SwapChainDescriptor scDesc{};
         scDesc.usage = wgpu::TextureUsage::RenderAttachment;
         scDesc.format = wgpu::TextureFormat::BGRA8Unorm;
-        scDesc.width = 300;
-        scDesc.height = 150;
+        scDesc.width = kWidth;
+        scDesc.height = kHeight;
         scDesc.presentMode = wgpu::PresentMode::Fifo;
         swapChain = device.CreateSwapChain(surface, &scDesc);
+
+        {
+            wgpu::TextureDescriptor descriptor{};
+            descriptor.usage = wgpu::TextureUsage::RenderAttachment;
+            descriptor.size = {kWidth, kHeight, 1};
+            descriptor.format = wgpu::TextureFormat::Depth32Float;
+            canvasDepthStencilView = device.CreateTexture(&descriptor).CreateView();
+        }
     }
     emscripten_set_main_loop(frame, 0, false);
 }


### PR DESCRIPTION
Chrome M101 which deprecates these API will release on April 26 2022. It's good time to remove the deprecated API paths now.

Also there's a new validation which can fail the current implementation (mentioned at https://github.com/emscripten-core/emscripten/issues/16471#issuecomment-1104231582). Fix by only provide depth stencil loadOp/storeOp when the value is set (!= Undefined)

Create a depth stencil attachment in webgpu_basic_rendering test to provide a slightly better test coverage for compiling hopefully, before we have a better test sutie.