### PR TITLE
Fix size of __cxa_exception

### DIFF
--- a/system/lib/libcxxabi/src/cxa_exception.h
+++ b/system/lib/libcxxabi/src/cxa_exception.h
@@ -28,7 +28,13 @@ struct _LIBCXXABI_HIDDEN __cxa_exception {
   uint8_t caught;
   uint8_t rethrown;
   void *adjustedPtr;
+  // Add padding to ensure that the size of __cxa_exception is a multiple of
+  // the maximum useful alignment for the target machine.  This ensures that
+  // the thrown object that follows has that correct alignment.
+  void *padding;
 };
+
+static_assert(sizeof(__cxa_exception) % alignof(max_align_t) == 0, "__cxa_exception must have a size that is multipl of max alignment");
 
 #else
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -9228,6 +9228,7 @@ bulkmem2 = make_run('bulkmem2', emcc_args=['-O2', '-mbulk-memory'])
 wasmfs = make_run('wasmfs', emcc_args=['-O2', '-DWASMFS'], settings={'WASMFS': 1})
 
 # SAFE_HEAP/STACK_OVERFLOW_CHECK
+core0s = make_run('core2s', emcc_args=['-g'], settings={'SAFE_HEAP': 1})
 core2s = make_run('core2s', emcc_args=['-O2'], settings={'SAFE_HEAP': 1})
 core2ss = make_run('core2ss', emcc_args=['-O2'], settings={'STACK_OVERFLOW_CHECK': 2})
 


### PR DESCRIPTION
In #16611 a field was added to __cxa_exception which meant its size was
no longer a multiple of the max alignement.  This broke one of the
SAFE_HEAP tests: core2s.test_exceptions_multiple_inherit

This change adds some padding and fixes the test.