### PR TITLE
Error on linking with `-fsanitize=cfi`

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -267,7 +267,6 @@ class EmccOptions:
     self.use_preload_plugins = False
     self.default_object_extension = '.o'
     self.valid_abspaths = []
-    self.cfi = False
     # Specifies the line ending format to use for all generated text files.
     # Defaults to using the native EOL on each platform (\r\n on Windows, \n on
     # Linux & MacOS)
@@ -3209,8 +3208,8 @@ def parse_args(newargs):
       options.default_object_extension = consume_arg()
       if not options.default_object_extension.startswith('.'):
         options.default_object_extension = '.' + options.default_object_extension
-    elif arg == '-fsanitize=cfi':
-      options.cfi = True
+    elif arg.startswith('-fsanitize=cfi'):
+      exit_with_error('emscripten does not currently support -fsanitize=cfi')
     elif check_arg('--output_eol'):
       style = consume_arg()
       if style.lower() == 'windows':

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11924,3 +11924,7 @@ void foo() {}
     self.assertIn(b'.debug', read_binary('hello_world.o'))
     self.run_process([EMCC, test_file('hello_world.c'), '-c', '-g', '-g0'])
     self.assertNotIn(b'.debug', read_binary('hello_world.o'))
+
+  def test_no_cfi(self):
+    err = self.expect_fail([EMCC, '-fsanitize=cfi', '-flto', test_file('hello_world.c')])
+    self.assertContained('emcc: error: emscripten does not currently support -fsanitize=cfi', err)


### PR DESCRIPTION
At least until we get it working on the llvm side.

See: https://github.com/llvm/llvm-project/issues/53544