### PR TITLE
Replace uses of for..of loops in generated code

### DIFF
--- a/src/library_wasmfs_node.js
+++ b/src/library_wasmfs_node.js
@@ -60,7 +60,7 @@ mergeInto(LibraryManager.library, {
       if (!e.code) throw e;
       return wasmfsNodeConvertNodeCode(e);
     }
-    for (let entry of entries) {
+    entries.forEach((entry) => {
       withStackSave(() => {
         let name = allocateUTF8OnStack(entry.name);
         let type;
@@ -76,7 +76,7 @@ mergeInto(LibraryManager.library, {
         }
         __wasmfs_node_record_dirent(vec, name, type);
       });
-    }
+    });
     // implicitly return 0
   },
 

--- a/src/library_webgl.js
+++ b/src/library_webgl.js
@@ -575,12 +575,12 @@ var LibraryGL = {
           return ret;
       };
       const matrixFuncs = ['uniformMatrix2fv', 'uniformMatrix3fv', 'uniformMatrix4fv'];
-      for (const f of matrixFuncs) {
+      matrixFuncs.forEach(f => {
           glCtx[f] = function(a1, a2, a3, a4, a5) {
               // WebGL2 version has 2 extra optional parameters, ensure we forward them
               return glCtx['real_' + f](a1, a2, a3, a4, a5);
           }
-      }
+      });
     },
 #endif
     // Returns the context handle to the new context.

--- a/src/worker.js
+++ b/src/worker.js
@@ -224,9 +224,9 @@ self.onmessage = (e) => {
         // initialized. Only do this once because it is only possible for
         // proxying notifications to arrive before thread initialization on
         // fresh workers.
-        for (const queue of pendingNotifiedProxyingQueues) {
+        pendingNotifiedProxyingQueues.forEach(queue => {
           executeNotifiedProxyingQueue(queue);
-        }
+        });
         pendingNotifiedProxyingQueues = [];
         initializedJS = true;
       }


### PR DESCRIPTION
These uses had unintentionally slipped in. We have meant to avoid for..of loops
so far because very old browsers do not support them.