### PR TITLE
Add a `bigint` test suite variant to test_core.py. NFC

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -64,6 +64,7 @@ passing_core_test_modes = [
   'wasm2jsz',
   'asan',
   'lsan',
+  'ubsan',
 ]
 
 # The default core test mode, used when none is specified
@@ -88,6 +89,7 @@ misc_test_modes = [
   'wasmfs',
   'wasm64',
   'wasm64l',
+  'bigint',
 ]
 
 


### PR DESCRIPTION
I don't think its worth running this config during CI but its useful
when working on the i64 stuff at the JS/wasm boundary.