### PR TITLE
Fix fd leak in NODERAWFS introduced by #14808

### DIFF
--- a/src/library_noderawfs.js
+++ b/src/library_noderawfs.js
@@ -45,9 +45,9 @@ mergeInto(LibraryManager.library, {
       return { path: path, node: { id: st.ino, mode: mode, node_ops: NODERAWFS, path: path }};
     },
     createStandardStreams: function() {
-      FS.streams[0] = FS.createStream({ fd: 0, nfd: 0, position: 0, path: '', flags: 0, tty: true, seekable: false });
+      FS.streams[0] = FS.createStream({ nfd: 0, position: 0, path: '', flags: 0, tty: true, seekable: false }, 0, 0);
       for (var i = 1; i < 3; i++) {
-        FS.streams[i] = FS.createStream({ fd: i, nfd: i, position: 0, path: '', flags: 577, tty: true, seekable: false });
+        FS.streams[i] = FS.createStream({ nfd: i, position: 0, path: '', flags: 577, tty: true, seekable: false }, i, i);
       }
     },
     // generic function for all node creation
@@ -103,19 +103,19 @@ mergeInto(LibraryManager.library, {
     createStream: function(stream, fd_start, fd_end){
       // Call the original FS.createStream
       var rtn = VFS.createStream(stream, fd_start, fd_end);
-      if (typeof rtn.shared.refcnt == "undefined") {
-        rtn.shared.refcnf = 0;
+      if (typeof rtn.shared.refcnt == 'undefined') {
+        rtn.shared.refcnt = 1;
       } else {
-        rtn.shared.refcnf++;
+        rtn.shared.refcnt++;
       }
       return rtn;
-   },
-   closeStream: function(fd) {
-    if (FS.streams[fd]) {
-      FS.streams[fd].shared.refcnt--;
-    }
-     VFS.closeStream(fd);
-   },
+    },
+    closeStream: function(fd) {
+      if (FS.streams[fd]) {
+        FS.streams[fd].shared.refcnt--;
+      }
+      VFS.closeStream(fd);
+    },
     close: function(stream) {
       FS.closeStream(stream.fd);
       if (!stream.stream_ops && stream.shared.refcnt === 0) {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5841,28 +5841,6 @@ Module['onRuntimeInitialized'] = function() {
     self.maybe_closure()
     self.do_run_in_out_file_test('unistd/truncate.c')
 
-  @no_windows("test is Linux-specific")
-  @no_mac("test is Linux-specific")
-  @require_node
-  def test_unistd_close_leak_noderawfs(self):
-    self.set_setting('NODERAWFS')
-    create_file('pre.js', '''
-const { execSync } = require('child_process');
-const process = require('process');
-
-let openFilesPre;
-
-Module['preRun'] = function() {
-  openFilesPre = execSync('ls -l /proc/' + process.pid + '/fd | wc -l').toString();
-}
-Module['postRun'] = function() {
-  const openFilesPost = execSync('ls -l /proc/' + process.pid + '/fd | wc -l').toString();
-  assert(openFilesPre == openFilesPost, 'File descriptors should not leak');
-}
-''')
-    self.emcc_args += ['--pre-js', 'pre.js']
-    self.do_run_in_out_file_test('unistd/close.c', js_engines=[config.NODE_JS])
-
   @also_with_standalone_wasm()
   def test_unistd_sysconf(self):
     self.do_run_in_out_file_test('unistd/sysconf.c')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5841,6 +5841,28 @@ Module['onRuntimeInitialized'] = function() {
     self.maybe_closure()
     self.do_run_in_out_file_test('unistd/truncate.c')
 
+  @no_windows("test is Linux-specific")
+  @no_mac("test is Linux-specific")
+  @require_node
+  def test_unistd_close_leak_noderawfs(self):
+    self.set_setting('NODERAWFS')
+    create_file('pre.js', '''
+const { execSync } = require('child_process');
+const process = require('process'); 
+
+let openFilesPre;
+
+Module['preRun'] = function() {
+  openFilesPre = execSync('ls -l /proc/' + process.pid + '/fd | wc -l').toString();
+}
+Module['postRun'] = function() {
+  const openFilesPost = execSync('ls -l /proc/' + process.pid + '/fd | wc -l').toString();
+  assert(openFilesPre == openFilesPost, 'File descriptor was leaked');
+}
+''')
+    self.emcc_args += ['--pre-js', 'pre.js']
+    self.do_run_in_out_file_test('unistd/close.c', js_engines=[config.NODE_JS])
+
   @also_with_standalone_wasm()
   def test_unistd_sysconf(self):
     self.do_run_in_out_file_test('unistd/sysconf.c')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5848,7 +5848,7 @@ Module['onRuntimeInitialized'] = function() {
     self.set_setting('NODERAWFS')
     create_file('pre.js', '''
 const { execSync } = require('child_process');
-const process = require('process'); 
+const process = require('process');
 
 let openFilesPre;
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -5857,7 +5857,7 @@ Module['preRun'] = function() {
 }
 Module['postRun'] = function() {
   const openFilesPost = execSync('ls -l /proc/' + process.pid + '/fd | wc -l').toString();
-  assert(openFilesPre == openFilesPost, 'File descriptor was leaked');
+  assert(openFilesPre == openFilesPost, 'File descriptors should not leak');
 }
 ''')
     self.emcc_args += ['--pre-js', 'pre.js']

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -11624,6 +11624,28 @@ void foo() {}
   def test_unistd_fstatfs(self):
     self.do_run_in_out_file_test('unistd/fstatfs.c')
 
+  @no_windows("test is Linux-specific")
+  @no_mac("test is Linux-specific")
+  @require_node
+  def test_unistd_close_noderawfs(self):
+    self.set_setting('NODERAWFS')
+    create_file('pre.js', '''
+const { execSync } = require('child_process');
+const process = require('process');
+
+let openFilesPre;
+
+Module['preRun'] = function() {
+  openFilesPre = execSync('ls -l /proc/' + process.pid + '/fd | wc -l').toString();
+}
+Module['postRun'] = function() {
+  const openFilesPost = execSync('ls -l /proc/' + process.pid + '/fd | wc -l').toString();
+  assert(openFilesPre == openFilesPost, 'File descriptors should not leak');
+}
+''')
+    self.emcc_args += ['--pre-js', 'pre.js']
+    self.do_run_in_out_file_test('unistd/close.c', js_engines=[config.NODE_JS])
+
   # WASMFS tests
 
   # TODO: This test will only work with the new file system.


### PR DESCRIPTION
`refcnt` (and not `refcnf`) needs to be initialized by 1 when
creating the filestream.

Also, apply #16661 to the other `FS.createStream` invocations
as well.

(This was noticed on the wasm-vips testsuite were it ran out of
file descriptors. It was probably reaching the limit of 
[`FS.MAX_OPEN_FDS`](https://github.com/emscripten-core/emscripten/blob/67ac24a66337c1c8babd664c601983313ea5e487/src/library_fs.js#L388))

/cc @hoodmane