### PR TITLE
Set data package_uuid to sha256 hash of preloaded contents

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -33,6 +33,8 @@ See docs/process.md for more on how version tagging works.
   are now exposed to native code and can be used to keep the runtime alive
   without immediately unwinding the event loop (as
   `emscripten_exit_with_live_runtime()` does). (#17160)
+- The file packager option `--use-preload-cache` now only invalidates the
+  cache if the data contents has changed. (#16807)
 
 3.1.13 - 06/02/2022
 -------------------

--- a/tests/test_other.py
+++ b/tests/test_other.py
@@ -21,7 +21,6 @@ import sys
 import time
 import tempfile
 import unittest
-import uuid
 from pathlib import Path
 from subprocess import PIPE, STDOUT
 
@@ -2661,7 +2660,7 @@ int f() {
     # verify '--separate-metadata' option produces separate metadata file
     os.chdir('..')
 
-    self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'data1.txt', '--preload', 'subdir/data2.txt', '--js-output=immutable.js', '--separate-metadata'])
+    self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'data1.txt', '--preload', 'subdir/data2.txt', '--js-output=immutable.js', '--separate-metadata', '--use-preload-cache'])
     self.assertExists('immutable.js.metadata')
     # verify js output JS file is not touched when the metadata is separated
     orig_timestamp = os.path.getmtime('immutable.js')
@@ -2669,7 +2668,7 @@ int f() {
     # ensure some time passes before running the packager again so that if it does touch the
     # js file it will end up with the different timestamp.
     time.sleep(1.0)
-    self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'data1.txt', '--preload', 'subdir/data2.txt', '--js-output=immutable.js', '--separate-metadata'])
+    self.run_process([FILE_PACKAGER, 'test.data', '--preload', 'data1.txt', '--preload', 'subdir/data2.txt', '--js-output=immutable.js', '--separate-metadata', '--use-preload-cache'])
     # assert both file content and timestamp are the same as reference copy
     self.assertTextDataIdentical(orig_content, read_file('immutable.js'))
     self.assertEqual(orig_timestamp, os.path.getmtime('immutable.js'))
@@ -2680,8 +2679,7 @@ int f() {
     assert metadata['files'][1]['start'] == len('data1') and metadata['files'][1]['end'] == len('data1') + len('data2') and metadata['files'][1]['filename'] == '/subdir/data2.txt'
     assert metadata['remote_package_size'] == len('data1') + len('data2')
 
-    # can only assert the uuid format is correct, the uuid's value is expected to differ in between invocation
-    uuid.UUID(metadata['package_uuid'], version=4)
+    self.assertEqual(metadata['package_uuid'], 'sha256-53ddc03623f867c7d4a631ded19c2613f2cb61d47b6aa214f47ff3cc15445bcd')
 
   def test_file_packager_unicode(self):
     unicode_name = 'unicode…☃'


### PR DESCRIPTION
This PR sets `package_uuid` to be the sha256 hash of the contents of the preloaded data file, if applicable. This avoids unnecessary cache misses–currently a new is generated per build, which invalidates the cached value in idb even if nothing changed in the data file.

The hash is generated based on the contents of the preloaded datafile post-compression, if applicable.

In #11952 it was suggested to make this be configurable–however, I don't think there's any reason to want this id to be unstable. At least, I can't think of one.

It's a bit weird that `package_uuid` is only sometimes actually an uuid. Another approach would be to keep `package_uuid` the same in the `metadata`, introduce a new `content_hash` field, and use this for the idb cache key: `metadata['content_hash'] || metadata['package_uuid']` (`content_hash` only being set when the data is preloaded). Is it important to retain current behavior of the metadata's package_uuid property?

Fixes #11952
