### PR TITLE
Add comments when passing extra args to makeGet/SetValue. NFC

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1674,7 +1674,7 @@ LibraryManager.library = {
   $readSockaddr: function (sa, salen) {
     // family / port offsets are common to both sockaddr_in and sockaddr_in6
     var family = {{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_family, 'i16') }}};
-    var port = _ntohs({{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_port, 'i16', undefined, true) }}});
+    var port = _ntohs({{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_port, 'i16', undefined, /*unsigned=*/true) }}});
     var addr;
 
     switch (family) {

--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -82,18 +82,18 @@ mergeInto(LibraryManager.library, {
       var ret;
       argIndex = prepVararg(argIndex, type);
       if (type === 'double') {
-        ret = {{{ makeGetValue('argIndex', 0, 'double', undefined, undefined, true) }}};
+        ret = {{{ makeGetValue('argIndex', 0, 'double', undefined, undefined, /*ignore=*/true) }}};
         argIndex += 8;
       } else if (type == 'i64') {
-        ret = [{{{ makeGetValue('argIndex', 0, 'i32', undefined, undefined, true, 4) }}},
-               {{{ makeGetValue('argIndex', 4, 'i32', undefined, undefined, true, 4) }}}];
+        ret = [{{{ makeGetValue('argIndex', 0, 'i32', undefined, undefined, /*ignore=*/true, /*align=*/4) }}},
+               {{{ makeGetValue('argIndex', 4, 'i32', undefined, undefined, /*ignore=*/true, /*align=*/4) }}}];
         argIndex += 8;
       } else {
 #if ASSERTIONS
         assert((argIndex & 3) === 0);
 #endif
         type = 'i32'; // varargs are always i32, i64, or double
-        ret = {{{ makeGetValue('argIndex', 0, 'i32', undefined, undefined, true) }}};
+        ret = {{{ makeGetValue('argIndex', 0, 'i32', undefined, undefined, /*ignore=*/true) }}};
         argIndex += 4;
       }
       return ret;

--- a/src/runtime_safe_heap.js
+++ b/src/runtime_safe_heap.js
@@ -5,25 +5,27 @@
  */
 
 #if SAFE_HEAP || !MINIMAL_RUNTIME
-// In MINIMAL_RUNTIME, setValue() and getValue() are only available when building with safe heap enabled, for heap safety checking.
-// In traditional runtime, setValue() and getValue() are always available (although their use is highly discouraged due to perf penalties)
+// In MINIMAL_RUNTIME, setValue() and getValue() are only available when
+// building with safe heap enabled, for heap safety checking.
+// In traditional runtime, setValue() and getValue() are always available
+// (although their use is highly discouraged due to perf penalties)
 
 /** @param {number} ptr
     @param {number} value
     @param {string} type
     @param {number|boolean=} noSafe */
 function setValue(ptr, value, type = 'i8', noSafe) {
-  if (type.charAt(type.length-1) === '*') type = '{{{ POINTER_TYPE }}}';
+  if (type.endsWith('*')) type = '{{{ POINTER_TYPE }}}';
 #if SAFE_HEAP
   if (noSafe) {
     switch (type) {
-      case 'i1': {{{ makeSetValue('ptr', '0', 'value', 'i1', undefined, undefined, undefined, '1') }}}; break;
-      case 'i8': {{{ makeSetValue('ptr', '0', 'value', 'i8', undefined, undefined, undefined, '1') }}}; break;
-      case 'i16': {{{ makeSetValue('ptr', '0', 'value', 'i16', undefined, undefined, undefined, '1') }}}; break;
-      case 'i32': {{{ makeSetValue('ptr', '0', 'value', 'i32', undefined, undefined, undefined, '1') }}}; break;
-      case 'i64': {{{ makeSetValue('ptr', '0', 'value', 'i64', undefined, undefined, undefined, '1') }}}; break;
-      case 'float': {{{ makeSetValue('ptr', '0', 'value', 'float', undefined, undefined, undefined, '1') }}}; break;
-      case 'double': {{{ makeSetValue('ptr', '0', 'value', 'double', undefined, undefined, undefined, '1') }}}; break;
+      case 'i1': {{{ makeSetValue('ptr', '0', 'value', 'i1', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
+      case 'i8': {{{ makeSetValue('ptr', '0', 'value', 'i8', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
+      case 'i16': {{{ makeSetValue('ptr', '0', 'value', 'i16', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
+      case 'i32': {{{ makeSetValue('ptr', '0', 'value', 'i32', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
+      case 'i64': {{{ makeSetValue('ptr', '0', 'value', 'i64', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
+      case 'float': {{{ makeSetValue('ptr', '0', 'value', 'float', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
+      case 'double': {{{ makeSetValue('ptr', '0', 'value', 'double', undefined, undefined, undefined, /*noSafe=*/true) }}}; break;
       default: abort('invalid type for setValue: ' + type);
     }
   } else {
@@ -47,17 +49,17 @@ function setValue(ptr, value, type = 'i8', noSafe) {
     @param {string} type
     @param {number|boolean=} noSafe */
 function getValue(ptr, type = 'i8', noSafe) {
-  if (type.charAt(type.length-1) === '*') type = '{{{ POINTER_TYPE }}}';
+  if (type.endsWith('*')) type = '{{{ POINTER_TYPE }}}';
 #if SAFE_HEAP
   if (noSafe) {
     switch (type) {
-      case 'i1': return {{{ makeGetValue('ptr', '0', 'i1', undefined, undefined, undefined, undefined, '1') }}};
-      case 'i8': return {{{ makeGetValue('ptr', '0', 'i8', undefined, undefined, undefined, undefined, '1') }}};
-      case 'i16': return {{{ makeGetValue('ptr', '0', 'i16', undefined, undefined, undefined, undefined, '1') }}};
-      case 'i32': return {{{ makeGetValue('ptr', '0', 'i32', undefined, undefined, undefined, undefined, '1') }}};
-      case 'i64': return {{{ makeGetValue('ptr', '0', 'i64', undefined, undefined, undefined, undefined, '1') }}};
-      case 'float': return {{{ makeGetValue('ptr', '0', 'float', undefined, undefined, undefined, undefined, '1') }}};
-      case 'double': return {{{ makeGetValue('ptr', '0', 'double', undefined, undefined, undefined, undefined, '1') }}};
+      case 'i1': return {{{ makeGetValue('ptr', '0', 'i1', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
+      case 'i8': return {{{ makeGetValue('ptr', '0', 'i8', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
+      case 'i16': return {{{ makeGetValue('ptr', '0', 'i16', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
+      case 'i32': return {{{ makeGetValue('ptr', '0', 'i32', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
+      case 'i64': return {{{ makeGetValue('ptr', '0', 'i64', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
+      case 'float': return {{{ makeGetValue('ptr', '0', 'float', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
+      case 'double': return {{{ makeGetValue('ptr', '0', 'double', undefined, undefined, undefined, undefined, /*noSafe=*/true) }}};
       default: abort('invalid type for getValue: ' + type);
     }
   } else {


### PR DESCRIPTION
I'm trying unify/remove these arguments where possible to simplify the
code and documenting the current usage seems like a good start.

For some reason runtime_safe_heap.js was passing the string "1" for the
noSafe argument rather than just `true`.  This argument is only ever
check for truthiness.