### PR TITLE
Avoid extra alignment/safe-heap args when calling makeGetValue

### DIFF
--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -82,18 +82,18 @@ mergeInto(LibraryManager.library, {
       var ret;
       argIndex = prepVararg(argIndex, type);
       if (type === 'double') {
-        ret = {{{ makeGetValue('argIndex', 0, 'double', undefined, undefined, /*ignore=*/true) }}};
+        ret = {{{ makeGetValue('argIndex', 0, 'double') }}};
         argIndex += 8;
       } else if (type == 'i64') {
-        ret = [{{{ makeGetValue('argIndex', 0, 'i32', undefined, undefined, /*ignore=*/true, /*align=*/4) }}},
-               {{{ makeGetValue('argIndex', 4, 'i32', undefined, undefined, /*ignore=*/true, /*align=*/4) }}}];
+        ret = [{{{ makeGetValue('argIndex', 0, 'i32') }}},
+               {{{ makeGetValue('argIndex', 4, 'i32') }}}];
         argIndex += 8;
       } else {
 #if ASSERTIONS
         assert((argIndex & 3) === 0);
 #endif
         type = 'i32'; // varargs are always i32, i64, or double
-        ret = {{{ makeGetValue('argIndex', 0, 'i32', undefined, undefined, /*ignore=*/true) }}};
+        ret = {{{ makeGetValue('argIndex', 0, 'i32') }}};
         argIndex += 4;
       }
       return ret;


### PR DESCRIPTION
These don't seem to be needed anymore, at least if they are we
are lacking test coverage of that case.