### PR TITLE
[NFC] Give proxying task_queues stable addresses

### DIFF
--- a/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -43,7 +43,7 @@ $emscripten_proxy_main
 $emscripten_run_in_main_runtime_thread_js
 $emscripten_stack_set_limits
 $emscripten_tls_init
-$get_tasks_index_for_thread
+$get_tasks_for_thread
 $init_file_lock
 $init_mparams
 $main


### PR DESCRIPTION
This is a prerequisite change for a future PR that will change how postMessage
notifications are generated. That future PR will send pointers to task_queues as
part of the postMessage payload and it will be important that those pointers
still point to the same task_queues when the postMessage notification are
received. task_queues are currently stored in flat arrays and when those arrays
are resized the task_queues are moved, which will not be correct after that
future change. To avoid the problem, ensure that each task_queue has a stable
address by changing the array elements to be pointers to task_queues allocated
with malloc.