### PR TITLE
[NFC] Give proxying task_queues their own mutexes

### DIFF
--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -70,7 +70,10 @@ typedef struct task {
 // A task queue for a particular thread. Organized into a linked list of
 // task_queues for different threads.
 typedef struct task_queue {
-  // The target thread for this task_queue.
+  // Protects all modifications to mutable `task_queue` state.
+  pthread_mutex_t mutex;
+  // The target thread for this task_queue. Immutable and accessible without
+  // acquiring the mutex.
   pthread_t thread;
   // Recursion guard. TODO: We disallow recursive processing because that's what
   // the old proxying API does, so it is safer to start with the same behavior.
@@ -95,7 +98,8 @@ static task_queue* task_queue_create(pthread_t thread) {
     free(queue);
     return NULL;
   }
-  *queue = (task_queue){.thread = thread,
+  *queue = (task_queue){.mutex = PTHREAD_MUTEX_INITIALIZER,
+                        .thread = thread,
                         .processing = 0,
                         .tasks = tasks,
                         .capacity = TASK_QUEUE_INITIAL_CAPACITY,
@@ -105,6 +109,7 @@ static task_queue* task_queue_create(pthread_t thread) {
 }
 
 static void task_queue_destroy(task_queue* queue) {
+  pthread_mutex_destroy(&queue->mutex);
   free(queue->tasks);
   free(queue);
 }
@@ -119,7 +124,7 @@ static int task_queue_full(task_queue* queue) {
   return queue->head == (queue->tail + 1) % queue->capacity;
 }
 
-// // Not thread safe. Returns 1 on success and 0 on failure.
+// Not thread safe. Returns 1 on success and 0 on failure.
 static int task_queue_grow(task_queue* queue) {
   // Allocate a larger task queue.
   int new_capacity = queue->capacity * 2;
@@ -199,7 +204,7 @@ em_proxying_queue* emscripten_proxy_get_system_queue(void) {
 }
 
 // The head of the zombie list. Its mutex protects access to the list and its
-// other fields are not used..
+// other fields are not used.
 static em_proxying_queue zombie_list_head = {.zombie_prev = &zombie_list_head,
                                              .zombie_next = &zombie_list_head,
                                              .mutex =
@@ -330,24 +335,26 @@ void emscripten_proxy_execute_queue(em_proxying_queue* q) {
 
   pthread_mutex_lock(&q->mutex);
   task_queue* tasks = get_tasks_for_thread(q, pthread_self());
-  if (tasks == NULL || tasks->processing) {
-    // No tasks for this thread or they are already being processed.
-    goto end;
-  }
-  // Found the task queue; process the tasks.
-  tasks->processing = 1;
-  while (!task_queue_is_empty(tasks)) {
-    task t = task_queue_dequeue(tasks);
-    // Unlock while the task is running to allow more work to be queued in
-    // parallel.
-    pthread_mutex_unlock(&q->mutex);
-    t.func(t.arg);
-    pthread_mutex_lock(&q->mutex);
-  }
-  tasks->processing = 0;
-
-end:
   pthread_mutex_unlock(&q->mutex);
+
+  if (tasks != NULL) {
+    pthread_mutex_lock(&tasks->mutex);
+    if (!tasks->processing) {
+      // Found the task queue; process the tasks.
+      tasks->processing = 1;
+      while (!task_queue_is_empty(tasks)) {
+        task t = task_queue_dequeue(tasks);
+        // Unlock while the task is running to allow more work to be queued in
+        // parallel.
+        pthread_mutex_unlock(&tasks->mutex);
+        t.func(t.arg);
+        pthread_mutex_lock(&tasks->mutex);
+      }
+      tasks->processing = 0;
+    }
+    pthread_mutex_unlock(&tasks->mutex);
+  }
+
   if (is_system_queue) {
     executing_system_queue = 0;
   }
@@ -360,14 +367,17 @@ int emscripten_proxy_async(em_proxying_queue* q,
   assert(q != NULL);
   pthread_mutex_lock(&q->mutex);
   task_queue* tasks = get_or_add_tasks_for_thread(q, target_thread);
-  if (tasks == NULL) {
-    goto failed;
-  }
-  int empty = task_queue_is_empty(tasks);
-  if (!task_queue_enqueue(tasks, (task){func, arg})) {
-    goto failed;
-  }
   pthread_mutex_unlock(&q->mutex);
+  if (tasks == NULL) {
+    return 0;
+  }
+  pthread_mutex_lock(&tasks->mutex);
+  int empty = task_queue_is_empty(tasks);
+  int enqueued = task_queue_enqueue(tasks, (task){func, arg});
+  pthread_mutex_unlock(&tasks->mutex);
+  if (!enqueued) {
+    return 0;
+  }
   // If the queue was previously empty, notify the target thread to process it.
   // Otherwise, the target thread was already notified when the existing work
   // was enqueued so we don't need to notify it again.
@@ -377,10 +387,6 @@ int emscripten_proxy_async(em_proxying_queue* q,
       target_thread, pthread_self(), emscripten_main_browser_thread_id(), q);
   }
   return 1;
-
-failed:
-  pthread_mutex_unlock(&q->mutex);
-  return 0;
 }
 
 struct em_proxying_ctx {

--- a/system/lib/pthread/proxying.c
+++ b/system/lib/pthread/proxying.c
@@ -340,7 +340,7 @@ void emscripten_proxy_execute_queue(em_proxying_queue* q) {
   if (tasks != NULL) {
     pthread_mutex_lock(&tasks->mutex);
     if (!tasks->processing) {
-      // Found the task queue; process the tasks.
+      // Found the task queue and it is not already being processed; process it.
       tasks->processing = 1;
       while (!task_queue_is_empty(tasks)) {
         task t = task_queue_dequeue(tasks);

--- a/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
+++ b/tests/other/metadce/minimal_main_Oz_USE_PTHREADS_PROXY_TO_PTHREAD.funcs
@@ -43,7 +43,7 @@ $emscripten_proxy_main
 $emscripten_run_in_main_runtime_thread_js
 $emscripten_stack_set_limits
 $emscripten_tls_init
-$get_tasks_index_for_thread
+$get_tasks_for_thread
 $init_file_lock
 $init_mparams
 $main


### PR DESCRIPTION
A future PR will change how postMessage notifications are generated for proxying
queues and will require adding pointers to individual task_queues to postMessage
payloads. Currently each task_queue is protected by its parent
em_proxying_queue's mutex, so the postMessage payload would need to contain the
parent em_proxying_queue as well so that the proper lock can be acquired before
executing the received task_queue. To avoid the need for the postMessage payload
to contain both queue pointers and to increase scalability, give each task_queue
its own mutex instead. To prevent deadlocks, ensure that a thread never holds
both em_proxying_queue and task_queue mutexes at the same time.