### PR TITLE
Remove use of makeStructuralReturn. NFC

### DIFF
--- a/src/compiler.js
+++ b/src/compiler.js
@@ -68,6 +68,9 @@ if (VERBOSE) {
 
 load('modules.js');
 load('parseTools.js');
+if (!STRICT) {
+  load('parseTools_legacy.js');
+}
 load('jsifier.js');
 load('runtime.js');
 

--- a/src/library_exceptions.js
+++ b/src/library_exceptions.js
@@ -335,14 +335,16 @@ var LibraryExceptions = {
     var thrown = exceptionLast;
     if (!thrown) {
       // just pass through the null ptr
-      {{{ makeStructuralReturn([0, 0]) }}};
+      setTempRet0(0);
+      return 0;
     }
     var info = new ExceptionInfo(thrown);
     info.set_adjusted_ptr(thrown);
     var thrownType = info.get_type();
     if (!thrownType) {
       // just pass through the thrown ptr
-      {{{ makeStructuralReturn(['thrown', 0]) }}};
+      setTempRet0(0);
+      return thrown;
     }
     var typeArray = Array.prototype.slice.call(arguments);
 
@@ -365,10 +367,12 @@ var LibraryExceptions = {
 #if EXCEPTION_DEBUG
         err("  __cxa_find_matching_catch found " + [ptrToString(info.get_adjusted_ptr()), caughtType]);
 #endif
-        {{{ makeStructuralReturn(['thrown', 'caughtType']) }}};
+        setTempRet0(caughtType);
+        return thrown;
       }
     }
-    {{{ makeStructuralReturn(['thrown', 'thrownType']) }}};
+    setTempRet0(thrownType);
+    return thrown;
   },
 
   __resumeException__deps: ['$exceptionLast'],

--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -671,14 +671,6 @@ function getHeapForType(type, unsigned) {
   assert(false, 'bad heap type: ' + type);
 }
 
-// Takes a pair of return values, stashes one in tempRet0 and returns the other.
-// Should probably be renamed to `makeReturn64` but keeping this old name in
-// case external JS library code uses this name.
-function makeStructuralReturn(values) {
-  assert(values.length == 2);
-  return 'setTempRet0(' + values[1] + '); return ' + asmCoercion(values[0], 'i32');
-}
-
 function makeThrow(what) {
   if (ASSERTIONS && DISABLE_EXCEPTION_CATCHING) {
     what += ' + " - Exception catching is disabled, this exception cannot be caught. Compile with -sNO_DISABLE_EXCEPTION_CATCHING or -sEXCEPTION_CATCHING_ALLOWED=[..] to catch."';

--- a/src/parseTools_legacy.js
+++ b/src/parseTools_legacy.js
@@ -1,0 +1,13 @@
+/**
+ * @license
+ * Copyright 2010 The Emscripten Authors
+ * SPDX-License-Identifier: MIT
+ */
+
+// Takes a pair of return values, stashes one in tempRet0 and returns the other.
+// Should probably be renamed to `makeReturn64` but keeping this old name in
+// case external JS library code uses this name.
+function makeStructuralReturn(values) {
+  assert(values.length == 2);
+  return 'setTempRet0(' + values[1] + '); return ' + asmCoercion(values[0], 'i32');
+}


### PR DESCRIPTION
The only caller of this function was __cxa_find_matching_catch.  IIRC
this function was designed for returning 64bit values by splitting them
into two 32bit values and returning one in tempRet0.  Historically it
was used like this:

 {{{ makeStructuralReturn(['low', 'high']) }}};

See #12838 for an example of this kind of usage that no longer exists
in the codebase.

However, the final remaining caller (`__cxa_find_matching_catch`) is not
using it in this way.  `__cxa_find_matching_catch` return a single
pointer type and is expected to set tempRet0 (to an unrelated value).

This change makes this more explicit and removes the need to this
(misnamed IMHO) helper function.