### PR TITLE
Remove `ignore` flag from `makeGetValue` in strptime

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -1028,12 +1028,12 @@ LibraryManager.library = {
         return (typeof value != 'number' || isNaN(value)) ? min : (value>=min ? (value<=max ? value: max): min);
       };
       return {
-        year: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_year, 'i32', undefined, undefined, /*ignore=*/true) }}} + 1900 , 1970, 9999),
-        month: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_mon, 'i32', undefined, undefined, /*ignore=*/true) }}}, 0, 11),
-        day: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_mday, 'i32', undefined, undefined, /*ignore=*/true) }}}, 1, 31),
-        hour: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_hour, 'i32', undefined, undefined, /*ignore=*/true) }}}, 0, 23),
-        min: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_min, 'i32', undefined, undefined, /*ignore=*/true) }}}, 0, 59),
-        sec: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_sec, 'i32', undefined, undefined, /*ignore=*/true) }}}, 0, 59)
+        year: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_year, 'i32') }}} + 1900 , 1970, 9999),
+        month: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_mon, 'i32') }}}, 0, 11),
+        day: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_mday, 'i32') }}}, 1, 31),
+        hour: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_hour, 'i32') }}}, 0, 23),
+        min: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_min, 'i32') }}}, 0, 59),
+        sec: fixup({{{ makeGetValue('tm', C_STRUCTS.tm.tm_sec, 'i32') }}}, 0, 59)
       };
     };
 


### PR DESCRIPTION
The ignore flag mean that we don't do SAFE_HEAP checks on these
accesses.  However we don't use the ignore flag on other writes to `tm`
structures in other libc functions, and also this change doesn't causes
any of the wasm2s tests to fail, so I assert that this is no longer
needed and might be a fastcomp artifact.

This change is part of a larger effort to simplify
makeGetValue/makeSetValue by removing these extra/unused params/modes.