### PR TITLE
Remove ignore argument from makeSetValue

### DIFF
--- a/src/library.js
+++ b/src/library.js
@@ -2735,7 +2735,7 @@ LibraryManager.library = {
     }
 
     for (var i = 0; i < count && stack[i+offset]; ++i) {
-      {{{ makeSetValue('buffer', 'i*4', 'convertFrameToPC(stack[i + offset])', 'i32', undefined, /*ignore=*/true) }}};
+      {{{ makeSetValue('buffer', 'i*4', 'convertFrameToPC(stack[i + offset])', 'i32') }}};
     }
     return i;
   },


### PR DESCRIPTION
Followup to #16831.  The `ignore` flag here tells us to skip the
SAFE_HEAP checks, but I can't see why we would want to do that here
since the incoming buffer needs to point to valid memory.