### PR TITLE
Allow unsigned types (u8/u16/u32) in makeGetValue. NFC

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -51,6 +51,7 @@ ignorePatterns:
 rules:
   #max-len: ["error", 100]
   max-len: "off"
+  no-multi-spaces: "off"
   require-jsdoc: "off"
   no-unused-vars: "off"
   arrow-body-style: ["error", "as-needed"]

--- a/src/library.js
+++ b/src/library.js
@@ -1674,7 +1674,7 @@ LibraryManager.library = {
   $readSockaddr: function (sa, salen) {
     // family / port offsets are common to both sockaddr_in and sockaddr_in6
     var family = {{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_family, 'i16') }}};
-    var port = _ntohs({{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_port, 'i16', undefined, /*unsigned=*/true) }}});
+    var port = _ntohs({{{ makeGetValue('sa', C_STRUCTS.sockaddr_in.sin_port, 'u16') }}});
     var addr;
 
     switch (family) {

--- a/src/library_browser.js
+++ b/src/library_browser.js
@@ -713,7 +713,7 @@ var LibraryBrowser = {
     setFullscreenCanvasSize: function() {
       // check if SDL is available
       if (typeof SDL != "undefined") {
-        var flags = {{{ makeGetValue('SDL.screen', '0', 'i32', 0, 1) }}};
+        var flags = {{{ makeGetValue('SDL.screen', '0', 'u32') }}};
         flags = flags | 0x00800000; // set SDL_FULLSCREEN flag
         {{{ makeSetValue('SDL.screen', '0', 'flags', 'i32') }}};
       }
@@ -724,7 +724,7 @@ var LibraryBrowser = {
     setWindowedCanvasSize: function() {
       // check if SDL is available
       if (typeof SDL != "undefined") {
-        var flags = {{{ makeGetValue('SDL.screen', '0', 'i32', 0, 1) }}};
+        var flags = {{{ makeGetValue('SDL.screen', '0', 'u32') }}};
         flags = flags & ~0x00800000; // clear SDL_FULLSCREEN flag
         {{{ makeSetValue('SDL.screen', '0', 'flags', 'i32') }}};
       }

--- a/src/library_formatString.js
+++ b/src/library_formatString.js
@@ -418,7 +418,7 @@ mergeInto(LibraryManager.library, {
             }
             if (arg) {
               for (var i = 0; i < argLength; i++) {
-                ret.push({{{ makeGetValue('arg++', 0, 'i8', null, true) }}});
+                ret.push({{{ makeGetValue('arg++', 0, 'u8') }}});
               }
             } else {
               ret = ret.concat(intArrayFromString('(null)'.substr(0, argLength), true));

--- a/src/library_glemu.js
+++ b/src/library_glemu.js
@@ -3065,7 +3065,7 @@ var LibraryGLEmulation = {
           assert(!GLctx.currentElementArrayBufferBinding);
 #endif
           for (var i = 0; i < numProvidedIndexes; i++) {
-            var currIndex = {{{ makeGetValue('ptr', 'i*2', 'i16', null, 1) }}};
+            var currIndex = {{{ makeGetValue('ptr', 'i*2', 'u16') }}};
             GLImmediate.firstVertex = Math.min(GLImmediate.firstVertex, currIndex);
             GLImmediate.lastVertex = Math.max(GLImmediate.lastVertex, currIndex+1);
           }

--- a/src/library_sdl.js
+++ b/src/library_sdl.js
@@ -467,7 +467,7 @@ var LibrarySDL = {
       for (var y = startY; y < endY; ++y) {
         var base = y * fullWidth;
         for (var x = startX; x < endX; ++x) {
-          data32[base + x] = colors32[{{{ makeGetValue('buffer + base + x', '0', 'i8', null, true) }}}];
+          data32[base + x] = colors32[{{{ makeGetValue('buffer + base + x', '0', 'u8') }}}];
         }
       }
     },
@@ -1201,16 +1201,16 @@ var LibrarySDL = {
         }
         if (audio.format == {{{ cDefine('AUDIO_S16LSB') }}}) {
           for (var j = 0; j < sizeSamplesPerChannel; ++j) {
-            channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*2', 'i16', 0, 0) }}}) / 0x8000;
+            channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*2', 'i16') }}}) / 0x8000;
           }
         } else if (audio.format == {{{ cDefine('AUDIO_U8') }}}) {
           for (var j = 0; j < sizeSamplesPerChannel; ++j) {
-            var v = ({{{ makeGetValue('heapPtr', 'j*numChannels + c', 'i8', 0, 0) }}});
+            var v = ({{{ makeGetValue('heapPtr', 'j*numChannels + c', 'i8') }}});
             channelData[j] = ((v >= 0) ? v-128 : v+128) /128;
           }
         } else if (audio.format == {{{ cDefine('AUDIO_F32') }}}) {
           for (var j = 0; j < sizeSamplesPerChannel; ++j) {
-            channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*4', 'float', 0, 0) }}});
+            channelData[j] = ({{{ makeGetValue('heapPtr', '(j*numChannels + c)*4', 'float') }}});
           }
         } else {
           throw 'Invalid SDL audio format ' + audio.format + '!';
@@ -1708,7 +1708,7 @@ var LibrarySDL = {
         var base = y*width*4;
         for (var x = 0; x < width; x++) {
           // See comment above about signs
-          var val = {{{ makeGetValue('s++', '0', 'i8', null, true) }}} * 4;
+          var val = {{{ makeGetValue('s++', '0', 'u8') }}} * 4;
           var start = base + x*4;
           data[start]   = colors[val];
           data[start+1] = colors[val+1];
@@ -1887,7 +1887,7 @@ var LibrarySDL = {
       var baseOfDst = row * pitchOfDst;
 
       for (var col = 0; col < width * 4; ++col) {
-        image.data[baseOfDst + col] = {{{ makeGetValue('pixels', 'baseOfDst + col', 'i8', null, true) }}};
+        image.data[baseOfDst + col] = {{{ makeGetValue('pixels', 'baseOfDst + col', 'u8') }}};
       }
     }
 
@@ -2148,9 +2148,9 @@ var LibrarySDL = {
 
     for (var i = 0; i < nColors; ++i) {
       var index = (firstColor + i) * 4;
-      surfData.colors[index] = {{{ makeGetValue('colors', 'i*4', 'i8', null, true) }}};
-      surfData.colors[index + 1] = {{{ makeGetValue('colors', 'i*4 + 1', 'i8', null, true) }}};
-      surfData.colors[index + 2] = {{{ makeGetValue('colors', 'i*4 + 2', 'i8', null, true) }}};
+      surfData.colors[index] = {{{ makeGetValue('colors', 'i*4', 'u8') }}};
+      surfData.colors[index + 1] = {{{ makeGetValue('colors', 'i*4 + 1', 'u8') }}};
+      surfData.colors[index + 2] = {{{ makeGetValue('colors', 'i*4 + 2', 'u8') }}};
       surfData.colors[index + 3] = 255; // opaque
     }
 
@@ -2347,9 +2347,9 @@ var LibrarySDL = {
           var sourcePtr = raw.data;
           var destPtr = 0;
           for (var i = 0; i < pixels; i++) {
-            data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'i8', null, 1) }}};
-            data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'i8', null, 1) }}};
-            data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'i8', null, 1) }}};
+            data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
+            data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
+            data[destPtr++] = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
             data[destPtr++] = 255;
           }
         } else if (raw.bpp == 2) {
@@ -2359,8 +2359,8 @@ var LibrarySDL = {
           var sourcePtr = raw.data;
           var destPtr = 0;
           for (var i = 0; i < pixels; i++) {
-            var gray = {{{ makeGetValue('sourcePtr++', 0, 'i8', null, 1) }}};
-            var alpha = {{{ makeGetValue('sourcePtr++', 0, 'i8', null, 1) }}};
+            var gray = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
+            var alpha = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
             data[destPtr++] = gray;
             data[destPtr++] = gray;
             data[destPtr++] = gray;
@@ -2373,7 +2373,7 @@ var LibrarySDL = {
           var sourcePtr = raw.data;
           var destPtr = 0;
           for (var i = 0; i < pixels; i++) {
-            var value = {{{ makeGetValue('sourcePtr++', 0, 'i8', null, 1) }}};
+            var value = {{{ makeGetValue('sourcePtr++', 0, 'u8') }}};
             data[destPtr++] = value;
             data[destPtr++] = value;
             data[destPtr++] = value;
@@ -2425,12 +2425,12 @@ var LibrarySDL = {
   SDL_OpenAudio: function(desired, obtained) {
     try {
       SDL.audio = {
-        freq: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.freq, 'i32', 0, 1) }}},
-        format: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.format, 'i16', 0, 1) }}},
-        channels: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.channels, 'i8', 0, 1) }}},
-        samples: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.samples, 'i16', 0, 1) }}}, // Samples in the CB buffer per single sound channel.
-        callback: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.callback, 'void*', 0, 1) }}},
-        userdata: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.userdata, 'void*', 0, 1) }}},
+        freq: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.freq, 'u32') }}},
+        format: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.format, 'u16') }}},
+        channels: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.channels, 'u8') }}},
+        samples: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.samples, 'u16') }}}, // Samples in the CB buffer per single sound channel.
+        callback: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.callback, 'void*') }}},
+        userdata: {{{ makeGetValue('desired', C_STRUCTS.SDL_AudioSpec.userdata, 'void*') }}},
         paused: true,
         timer: null
       };
@@ -2897,7 +2897,7 @@ var LibrarySDL = {
     var numSamples = len >> 1; // len is the length in bytes, and the array contains 16-bit PCM values
     var buffer = new Float32Array(numSamples);
     for (var i = 0; i < numSamples; ++i) {
-      buffer[i] = ({{{ makeGetValue('mem', 'i*2', 'i16', 0, 0) }}}) / 0x8000; // hardcoded 16-bit audio, signed (TODO: reSign if not ta2?)
+      buffer[i] = ({{{ makeGetValue('mem', 'i*2', 'i16') }}}) / 0x8000; // hardcoded 16-bit audio, signed (TODO: reSign if not ta2?)
     }
 
     if (SDL.webAudioAvailable()) {

--- a/src/library_uuid.js
+++ b/src/library_uuid.js
@@ -115,8 +115,8 @@ mergeInto(LibraryManager.library, {
     // void uuid_unparse(const uuid_t uu, char *out);
     var i = 0;
     var uuid = 'xxxx-xx-xx-xx-xxxxxx'.replace(/[x]/g, function(c) {
-      var r = upper ? ({{{ makeGetValue('uu', 'i', 'i8', 0, 1) }}}).toString(16).toUpperCase() :
-                      ({{{ makeGetValue('uu', 'i', 'i8', 0, 1) }}}).toString(16);
+      var r = upper ? ({{{ makeGetValue('uu', 'i', 'u8') }}}).toString(16).toUpperCase() :
+                      ({{{ makeGetValue('uu', 'i', 'u8') }}}).toString(16);
       r = (r.length === 1) ? '0' + r : r; // Zero pad single digit hex values
       i++;
       return r;

--- a/src/library_webgpu.js
+++ b/src/library_webgpu.js
@@ -61,11 +61,11 @@
       return '(' + makeGetValue(struct, offset, 'i8') + ' !== 0)';
     },
     makeGetU32: function(struct, offset) {
-      return makeGetValue(struct, offset, 'i32', false, true);
+      return makeGetValue(struct, offset, 'u32');
     },
     makeGetU64: function(struct, offset) {
-      var l = makeGetValue(struct, offset, 'i32', false, true);
-      var h = makeGetValue('(' + struct + ' + 4)', offset, 'i32', false, true)
+      var l = makeGetValue(struct, offset, 'u32');
+      var h = makeGetValue('(' + struct + ' + 4)', offset, 'u32')
       return h + ' * 0x100000000 + ' + l
     },
     makeCheck: function(str) {

--- a/src/runtime.js
+++ b/src/runtime.js
@@ -14,10 +14,10 @@ global.STACK_ALIGN = 16;
 
 function getNativeTypeSize(type) {
   switch (type) {
-    case 'i1': case 'i8': return 1;
-    case 'i16': return 2;
-    case 'i32': return 4;
-    case 'i64': return 8;
+    case 'i1': case 'i8': case 'u8': return 1;
+    case 'i16': case 'u16': return 2;
+    case 'i32': case 'u32': return 4;
+    case 'i64': case 'u64': return 8;
     case 'float': return 4;
     case 'double': return 8;
     default: {

--- a/src/runtime_stack_check.js
+++ b/src/runtime_stack_check.js
@@ -18,7 +18,7 @@ function writeStackCookie() {
   {{{ makeSetValue('max', 4, '0x89BACDFE', 'i32' ) }}};
 #if !USE_ASAN && !SAFE_HEAP // ASan and SAFE_HEAP check address 0 themselves
   // Also test the global address 0 for integrity.
-  HEAP32[0] = 0x63736d65; /* 'emsc' */
+  HEAPU32[0] = 0x63736d65; /* 'emsc' */
 #endif
 }
 
@@ -27,14 +27,14 @@ function checkStackCookie() {
   if (ABORT) return;
 #endif
   var max = _emscripten_stack_get_end();
-  var cookie1 = {{{ makeGetValue('max', 0, 'i32', 0, true) }}};
-  var cookie2 = {{{ makeGetValue('max', 4, 'i32', 0, true) }}};
+  var cookie1 = {{{ makeGetValue('max', 0, 'u32') }}};
+  var cookie2 = {{{ makeGetValue('max', 4, 'u32') }}};
   if (cookie1 != 0x2135467 || cookie2 != 0x89BACDFE) {
     abort('Stack overflow! Stack cookie has been overwritten, expected hex dwords 0x89BACDFE and 0x2135467, but received 0x' + cookie2.toString(16) + ' 0x' + cookie1.toString(16));
   }
 #if !USE_ASAN && !SAFE_HEAP // ASan and SAFE_HEAP check address 0 themselves
   // Also test the global address 0 for integrity.
-  if (HEAP32[0] !== 0x63736d65 /* 'emsc' */) abort('Runtime error: The application has corrupted its heap memory area (address zero)!');
+  if (HEAPU32[0] !== 0x63736d65 /* 'emsc' */) abort('Runtime error: The application has corrupted its heap memory area (address zero)!');
 #endif
 }
 #endif

--- a/src/runtime_strings_extra.js
+++ b/src/runtime_strings_extra.js
@@ -15,7 +15,7 @@ function AsciiToString(ptr) {
 #endif
   var str = '';
   while (1) {
-    var ch = {{{ makeGetValue('ptr++', 0, 'i8', null, true) }}};
+    var ch = {{{ makeGetValue('ptr++', 0, 'u8') }}};
     if (!ch) return str;
     str += String.fromCharCode(ch);
   }

--- a/tests/other/test_parseTools.js
+++ b/tests/other/test_parseTools.js
@@ -9,9 +9,14 @@ mergeInto(LibraryManager.library, {
     out('i32: ' + val.toString(16))
     assert(val == -0x12345678);
 
-    // unsigned i32
-    val = {{{ makeGetValue('ptr', '0', 'i32', undefined, /*unsigned=*/true) }}};
+    // u32
+    val = {{{ makeGetValue('ptr', '0', 'u32') }}};
     out('u32: ' + val.toString(16))
+    assert(val == 0xedcba988);
+
+    // unsigned i32 (legacy)
+    val = {{{ makeGetValue('ptr', '0', 'i32', undefined, /*unsigned=*/true) }}};
+    out('u32 legacy: ' + val.toString(16))
     assert(val == 0xedcba988);
 
     // i16
@@ -19,9 +24,14 @@ mergeInto(LibraryManager.library, {
     out('i16: ' + val.toString(16))
     assert(val == -0x5678);
 
-    // unsigned i16
-    val = {{{ makeGetValue('ptr', '0', 'i16', undefined, /*unsigned=*/true) }}};
+    // u16
+    val = {{{ makeGetValue('ptr', '0', 'u16') }}};
     out('u16: ' + val.toString(16))
+    assert(val == 43400);
+
+    // unsigned i16 (legacy)
+    val = {{{ makeGetValue('ptr', '0', 'i16', undefined, /*unsigned=*/true) }}};
+    out('u16 legacy: ' + val.toString(16))
     assert(val == 43400);
 
     // i8
@@ -29,9 +39,14 @@ mergeInto(LibraryManager.library, {
     out('i8: ' + val.toString(16))
     assert(val == -0x78);
 
-    // unsigned i8
-    val = {{{ makeGetValue('ptr', '0', 'i8', undefined, /*unsigned=*/true) }}};
+    // u8
+    val = {{{ makeGetValue('ptr', '0', 'u8') }}};
     out('u8: ' + val.toString(16))
+    assert(val == 0x88);
+
+    // unsigned i8 (legacy)
+    val = {{{ makeGetValue('ptr', '0', 'i8', undefined, /*unsigned=*/true) }}};
+    out('u8 legacy: ' + val.toString(16))
     assert(val == 0x88);
 
     // pointer

--- a/tests/other/test_parseTools.out
+++ b/tests/other/test_parseTools.out
@@ -1,9 +1,12 @@
 i32: -12345678
 u32: edcba988
+u32 legacy: edcba988
 i16: -5678
 u16: a988
+u16 legacy: a988
 i8: -78
 u8: 88
+u8 legacy: 88
 ptr: -12345678
 ptr: -12345678
 done


### PR DESCRIPTION
This is more readable and removes and removes the need for extra
arguments at the callsite that don't have obvious meaning.

This change is part of an ongoing effor to simplify the makeGet/SetValue
APIs.