### PR TITLE
Read pointer values as unsigned

### DIFF
--- a/src/parseTools.js
+++ b/src/parseTools.js
@@ -660,7 +660,8 @@ function calcFastOffset(ptr, pos, noNeedFirst) {
 function getHeapForType(type) {
   assert(type);
   if (isPointerType(type)) {
-    type = POINTER_TYPE;
+    // TODO(sbc): Make POINTER_TYPE u32/u64 rather than i32/i64
+    type = 'u' + POINTER_TYPE.slice(1);
   }
   if (WASM_BIGINT) {
     switch (type) {

--- a/tests/other/test_parseTools.js
+++ b/tests/other/test_parseTools.js
@@ -52,9 +52,9 @@ mergeInto(LibraryManager.library, {
     // pointer
     val = {{{ makeGetValue('ptr', '0', 'void*') }}};
     out('ptr: ' + val.toString(16))
-    assert(val == -0x12345678);
+    assert(val == 0xedcba988);
     val = {{{ makeGetValue('ptr', '0', 'i32*') }}};
     out('ptr: ' + val.toString(16))
-    assert(val == -0x12345678);
+    assert(val == 0xedcba988);
   }
 });

--- a/tests/other/test_parseTools.out
+++ b/tests/other/test_parseTools.out
@@ -7,6 +7,6 @@ u16 legacy: a988
 i8: -78
 u8: 88
 u8 legacy: 88
-ptr: -12345678
-ptr: -12345678
+ptr: edcba988
+ptr: edcba988
 done


### PR DESCRIPTION
This is most likely NFC because the value will be the same once it flows
back into WebAssembly but it makes for better debugging of pointer
values if they are always unsigned.