### PR TITLE
Rebaseline minimal runtime codesize test. NFC

### DIFF
--- a/tests/code_size/hello_webgl2_wasm.json
+++ b/tests/code_size/hello_webgl2_wasm.json
@@ -1,10 +1,10 @@
 {
   "a.html": 569,
   "a.html.gz": 379,
-  "a.js": 4962,
-  "a.js.gz": 2422,
-  "a.wasm": 10443,
-  "a.wasm.gz": 6670,
-  "total": 15974,
-  "total_gz": 9471
+  "a.js": 4968,
+  "a.js.gz": 2427,
+  "a.wasm": 10414,
+  "a.wasm.gz": 6667,
+  "total": 15951,
+  "total_gz": 9473
 }

--- a/tests/code_size/hello_webgl2_wasm2js.json
+++ b/tests/code_size/hello_webgl2_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 18172,
-  "a.js.gz": 8008,
+  "a.js": 18084,
+  "a.js.gz": 7991,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 21910,
-  "total_gz": 11101
+  "total": 21822,
+  "total_gz": 11084
 }

--- a/tests/code_size/hello_webgl_wasm.json
+++ b/tests/code_size/hello_webgl_wasm.json
@@ -3,8 +3,8 @@
   "a.html.gz": 379,
   "a.js": 4447,
   "a.js.gz": 2247,
-  "a.wasm": 10443,
-  "a.wasm.gz": 6670,
-  "total": 15459,
-  "total_gz": 9296
+  "a.wasm": 10414,
+  "a.wasm.gz": 6667,
+  "total": 15430,
+  "total_gz": 9293
 }

--- a/tests/code_size/hello_webgl_wasm2js.json
+++ b/tests/code_size/hello_webgl_wasm2js.json
@@ -1,10 +1,10 @@
 {
   "a.html": 567,
   "a.html.gz": 379,
-  "a.js": 17650,
-  "a.js.gz": 7848,
+  "a.js": 17556,
+  "a.js.gz": 7828,
   "a.mem": 3171,
   "a.mem.gz": 2714,
-  "total": 21388,
-  "total_gz": 10941
+  "total": 21294,
+  "total_gz": 10921
 }


### PR DESCRIPTION
This is needed to unblock the llvm roller.