### PR TITLE
parallel_testsuite: Apply `skip:` arguments when starting child processes

### DIFF
--- a/tests/runner.py
+++ b/tests/runner.py
@@ -144,23 +144,26 @@ def tests_with_expanded_wildcards(args, all_tests):
   return new_args
 
 
+def skip_test(tests_to_skip, modules):
+  suite_name, test_name = tests_to_skip.split('.')
+  skipped = False
+  for m in modules:
+    suite = getattr(m, suite_name, None)
+    if suite:
+      setattr(suite, test_name, lambda s: s.skipTest("requested to be skipped"))
+      skipped = True
+      break
+  assert skipped, "Not able to skip test " + tests_to_skip
+
+
 def skip_requested_tests(args, modules):
+  os.environ['EMTEST_SKIP'] = ''
   for i, arg in enumerate(args):
     if arg.startswith('skip:'):
-      which = [arg.split('skip:')[1]]
-
-      print(','.join(which), file=sys.stderr)
-      skipped = False
-      for test in which:
-        print('will skip "%s"' % test, file=sys.stderr)
-        suite_name, test_name = test.split('.')
-        for m in modules:
-          suite = getattr(m, suite_name, None)
-          if suite:
-            setattr(suite, test_name, lambda s: s.skipTest("requested to be skipped"))
-            skipped = True
-            break
-      assert skipped, "Not able to skip test " + test
+      which = arg.split('skip:')[1]
+      os.environ['EMTEST_SKIP'] = os.environ['EMTEST_SKIP'] + ' ' + which
+      print('will skip "%s"' % which, file=sys.stderr)
+      skip_test(which, modules)
       args[i] = None
   return [a for a in args if a is not None]
 
@@ -435,3 +438,14 @@ if __name__ == '__main__':
   except KeyboardInterrupt:
     logger.warning('KeyboardInterrupt')
     sys.exit(1)
+else:
+  # We are not the main process, and most likely a child process of
+  # the multiprocess pool.  In this mode the modifications made to the
+  # test class by `skip_test` need to be re-applied in each child
+  # subprocess (sad but true).  This is needed in particular on macOS
+  # and Windows where the default mode for multiprocessing is `spawn`
+  # rather than `fork`
+  if 'EMTEST_SKIP' in os.environ:
+    modules = get_and_import_modules()
+    for skip in os.environ['EMTEST_SKIP'].split():
+      skip_test(skip, modules)


### PR DESCRIPTION

This is only really needed in Mac and Windows where the child processes
are lauched using spawn rather than fork.  Sad by true.