### PR TITLE
Centralize internal pthread exports. NFC

### DIFF
--- a/emcc.py
+++ b/emcc.py
@@ -1536,9 +1536,10 @@ def setup_pthreads(target):
 
   include_and_export('establishStackSpace')
   include_and_export('invokeEntryPoint')
+  include_and_export('PThread')
   if not settings.MINIMAL_RUNTIME:
     # keepRuntimeAlive does not apply to MINIMAL_RUNTIME.
-    settings.EXPORTED_RUNTIME_METHODS += ['keepRuntimeAlive']
+    settings.EXPORTED_RUNTIME_METHODS += ['keepRuntimeAlive', 'ExitStatus', 'wasmMemory']
 
   if settings.MODULARIZE:
     if not settings.EXPORT_ES6 and settings.EXPORT_NAME == 'Module':

--- a/src/modules.js
+++ b/src/modules.js
@@ -432,6 +432,7 @@ function exportRuntime() {
     'callMain',
     'abort',
     'keepRuntimeAlive',
+    'wasmMemory',
   ];
 
   if (USE_PTHREADS && ALLOW_MEMORY_GROWTH) {
@@ -479,27 +480,13 @@ function exportRuntime() {
       'lengthBytesUTF32',
       'allocateUTF8',
       'allocateUTF8OnStack',
+      'ExitStatus',
     ]);
   }
 
   if (STACK_OVERFLOW_CHECK) {
     runtimeElements.push('writeStackCookie');
     runtimeElements.push('checkStackCookie');
-  }
-
-  if (USE_PTHREADS) {
-    // In pthreads mode, the following functions always need to be exported to
-    // Module for closure compiler, and also for MODULARIZE (so worker.js can
-    // access them).
-    const threadExports = ['PThread', 'wasmMemory'];
-    if (!MINIMAL_RUNTIME) {
-      threadExports.push('ExitStatus');
-    }
-
-    threadExports.forEach((x) => {
-      EXPORTED_RUNTIME_METHODS_SET.add(x);
-      runtimeElements.push(x);
-    });
   }
 
   if (SUPPORT_BASE64_EMBEDDING) {


### PR DESCRIPTION
The change moves from special case handling in `src/modules.js` to
`emcc.py` where other similar symbols are handled already.